### PR TITLE
[test] ServiceFactory::getVeniceMultiClusterWrapper cleanup

### DIFF
--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/DaVinciClusterAgnosticTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/DaVinciClusterAgnosticTest.java
@@ -26,6 +26,7 @@ import com.linkedin.venice.controllerapi.VersionCreationResponse;
 import com.linkedin.venice.integration.utils.D2TestUtils;
 import com.linkedin.venice.integration.utils.ServiceFactory;
 import com.linkedin.venice.integration.utils.VeniceControllerWrapper;
+import com.linkedin.venice.integration.utils.VeniceMultiClusterCreateOptions;
 import com.linkedin.venice.integration.utils.VeniceMultiClusterWrapper;
 import com.linkedin.venice.integration.utils.VeniceServerWrapper;
 import com.linkedin.venice.integration.utils.ZkServerWrapper;
@@ -90,19 +91,15 @@ public class DaVinciClusterAgnosticTest {
         ClientConfig.defaultGenericClientConfig("")
             .setD2ServiceName(D2TestUtils.DEFAULT_TEST_SERVICE_NAME)
             .setD2Client(d2Client));
-    multiClusterVenice = ServiceFactory.getVeniceMultiClusterWrapper(
-        "",
-        2,
-        1,
-        3,
-        1,
-        3,
-        true,
-        false,
-        true,
-        Optional.of(testProperties),
-        Optional.of(new VeniceProperties(testProperties)),
-        false);
+    VeniceMultiClusterCreateOptions options = new VeniceMultiClusterCreateOptions.Builder(2).numberOfControllers(1)
+        .numberOfServers(3)
+        .numberOfRouters(1)
+        .replicationFactor(3)
+        .multiD2(true)
+        .childControllerProperties(testProperties)
+        .veniceProperties(new VeniceProperties(testProperties))
+        .build();
+    multiClusterVenice = ServiceFactory.getVeniceMultiClusterWrapper(options);
     clusterNames = multiClusterVenice.getClusterNames();
     Collection<VeniceControllerWrapper> childControllers = multiClusterVenice.getControllers().values();
     parentController = ServiceFactory.getVeniceParentController(

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestWritePathComputation.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestWritePathComputation.java
@@ -6,6 +6,7 @@ import com.linkedin.venice.controllerapi.ControllerResponse;
 import com.linkedin.venice.controllerapi.UpdateStoreQueryParams;
 import com.linkedin.venice.integration.utils.ServiceFactory;
 import com.linkedin.venice.integration.utils.VeniceControllerWrapper;
+import com.linkedin.venice.integration.utils.VeniceMultiClusterCreateOptions;
 import com.linkedin.venice.integration.utils.VeniceMultiClusterWrapper;
 import com.linkedin.venice.integration.utils.VeniceTwoLayerMultiColoMultiClusterWrapper;
 import com.linkedin.venice.utils.TestUtils;
@@ -20,7 +21,11 @@ public class TestWritePathComputation {
 
   @Test(timeOut = 60 * Time.MS_PER_SECOND)
   public void testFeatureFlagSingleDC() {
-    try (VeniceMultiClusterWrapper multiClusterWrapper = ServiceFactory.getVeniceMultiClusterWrapper(1, 1, 1, 0)) {
+    VeniceMultiClusterCreateOptions options = new VeniceMultiClusterCreateOptions.Builder(1).numberOfControllers(1)
+        .numberOfServers(1)
+        .numberOfRouters(0)
+        .build();
+    try (VeniceMultiClusterWrapper multiClusterWrapper = ServiceFactory.getVeniceMultiClusterWrapper(options)) {
       String clusterName = multiClusterWrapper.getClusterNames()[0];
       String storeName = "test-store0";
 

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/multicluster/TestMetadataOperationInMultiCluster.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/multicluster/TestMetadataOperationInMultiCluster.java
@@ -13,6 +13,7 @@ import com.linkedin.venice.controllerapi.VersionCreationResponse;
 import com.linkedin.venice.hadoop.VenicePushJob;
 import com.linkedin.venice.integration.utils.ServiceFactory;
 import com.linkedin.venice.integration.utils.VeniceControllerWrapper;
+import com.linkedin.venice.integration.utils.VeniceMultiClusterCreateOptions;
 import com.linkedin.venice.integration.utils.VeniceMultiClusterWrapper;
 import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.Version;
@@ -37,14 +38,19 @@ public class TestMetadataOperationInMultiCluster {
 
   @Test(timeOut = 60 * Time.MS_PER_SECOND)
   public void testCreateStoreAndVersionForMultiCluster() {
-    int numberOfController = 3;
-    int numberOfCluster = 2;
     String keySchema = "\"string\"";
     String valSchema = "\"string\"";
-    try (VeniceMultiClusterWrapper multiClusterWrapper =
-        ServiceFactory.getVeniceMultiClusterWrapper(numberOfCluster, numberOfController, 1, 1)) {
+
+    VeniceMultiClusterCreateOptions options = new VeniceMultiClusterCreateOptions.Builder(2).numberOfControllers(3)
+        .numberOfServers(1)
+        .numberOfRouters(1)
+        .build();
+    try (VeniceMultiClusterWrapper multiClusterWrapper = ServiceFactory.getVeniceMultiClusterWrapper(options)) {
       String[] clusterNames = multiClusterWrapper.getClusterNames();
-      Assert.assertEquals(clusterNames.length, numberOfCluster, "Should created " + numberOfCluster + " clusters.");
+      Assert.assertEquals(
+          clusterNames.length,
+          options.getNumberOfClusters(),
+          "Should created " + options.getNumberOfClusters() + " clusters.");
 
       String clusterName = clusterNames[0];
       String secondCluster = clusterNames[1];
@@ -125,10 +131,11 @@ public class TestMetadataOperationInMultiCluster {
 
   @Test
   public void testRunH2VInMultiCluster() throws Exception {
-    int numberOfController = 3;
-    int numberOfCluster = 2;
-    try (VeniceMultiClusterWrapper multiClusterWrapper =
-        ServiceFactory.getVeniceMultiClusterWrapper(numberOfCluster, numberOfController, 1, 1)) {
+    VeniceMultiClusterCreateOptions options = new VeniceMultiClusterCreateOptions.Builder(2).numberOfControllers(3)
+        .numberOfServers(1)
+        .numberOfRouters(1)
+        .build();
+    try (VeniceMultiClusterWrapper multiClusterWrapper = ServiceFactory.getVeniceMultiClusterWrapper(options)) {
       String[] clusterNames = multiClusterWrapper.getClusterNames();
       String storeNameSuffix = "-testStore";
       File inputDir = getTempDataDirectory();

--- a/internal/venice-test-common/src/main/java/com/linkedin/venice/integration/utils/ServiceFactory.java
+++ b/internal/venice-test-common/src/main/java/com/linkedin/venice/integration/utils/ServiceFactory.java
@@ -10,7 +10,6 @@ import static com.linkedin.venice.integration.utils.VeniceClusterWrapperConstant
 import static com.linkedin.venice.integration.utils.VeniceClusterWrapperConstants.DEFAULT_MAX_ATTEMPT;
 import static com.linkedin.venice.integration.utils.VeniceClusterWrapperConstants.DEFAULT_PARTITION_SIZE_BYTES;
 import static com.linkedin.venice.integration.utils.VeniceClusterWrapperConstants.DEFAULT_REPLICATION_FACTOR;
-import static com.linkedin.venice.integration.utils.VeniceClusterWrapperConstants.DEFAULT_SSL_TO_STORAGE_NODES;
 import static com.linkedin.venice.integration.utils.VeniceClusterWrapperConstants.DEFAULT_WAIT_TIME_FOR_CLUSTER_START_S;
 import static com.linkedin.venice.integration.utils.VeniceControllerWrapper.DEFAULT_PARENT_DATA_CENTER_REGION_NAME;
 
@@ -57,7 +56,7 @@ import org.apache.logging.log4j.Logger;
  * used in integration tests.
  */
 public class ServiceFactory {
-  private static final Logger LOGGER = LogManager.getLogger(ZkServerWrapper.class);
+  private static final Logger LOGGER = LogManager.getLogger(ServiceFactory.class);
   private static final VeniceProperties EMPTY_VENICE_PROPS = new VeniceProperties();
   private static final String ULIMIT;
   private static final String VM_ARGS;
@@ -318,38 +317,12 @@ public class ServiceFactory {
         authorizerService);
   }
 
-  /**
-   * Get a running admin spark server with a passed-in {@link Admin}, good for tests that want to provide a mock admin
-   * @param admin
-   * @return
-   */
-  public static AdminSparkServer getMockAdminSparkServer(Admin admin, String cluster) {
-    return getService("MockAdminSparkServer", (serviceName) -> {
-      Set<String> clusters = new HashSet<String>();
-      clusters.add(cluster);
-      AdminSparkServer server = new AdminSparkServer(
-          Utils.getFreePort(),
-          admin,
-          new MetricsRepository(),
-          clusters,
-          false,
-          Optional.empty(),
-          false,
-          Optional.empty(),
-          Collections.emptyList(),
-          null,
-          false);
-      server.start();
-      return server;
-    });
-  }
-
   public static AdminSparkServer getMockAdminSparkServer(
       Admin admin,
       String cluster,
       List<ControllerRoute> bannedRoutes) {
     return getService("MockAdminSparkServer", (serviceName) -> {
-      Set<String> clusters = new HashSet<String>();
+      Set<String> clusters = new HashSet<>();
       clusters.add(cluster);
       AdminSparkServer server = new AdminSparkServer(
           Utils.getFreePort(),
@@ -581,119 +554,8 @@ public class ServiceFactory {
     return getVeniceCluster(options);
   }
 
-  public static VeniceMultiClusterWrapper getVeniceMultiClusterWrapper(
-      int numberOfClusters,
-      int numberOfControllers,
-      int numberOfServers,
-      int numberOfRouters) {
-    return getService(
-        VeniceMultiClusterWrapper.SERVICE_NAME,
-        VeniceMultiClusterWrapper.generateService(
-            "",
-            numberOfClusters,
-            numberOfControllers,
-            numberOfServers,
-            numberOfRouters,
-            DEFAULT_REPLICATION_FACTOR,
-            DEFAULT_PARTITION_SIZE_BYTES,
-            false,
-            false,
-            DEFAULT_DELAYED_TO_REBALANCE_MS,
-            DEFAULT_REPLICATION_FACTOR - 1,
-            DEFAULT_SSL_TO_STORAGE_NODES,
-            true,
-            false,
-            Optional.empty(),
-            Optional.empty(),
-            Optional.empty(),
-            Optional.empty(),
-            false,
-            false,
-            Collections.emptyMap()));
-  }
-
-  public static VeniceMultiClusterWrapper getVeniceMultiClusterWrapper(
-      String coloName,
-      KafkaBrokerWrapper kafkaBrokerWrapper,
-      ZkServerWrapper zkServerWrapper,
-      int numberOfClusters,
-      int numberOfControllers,
-      int numberOfServers,
-      int numberOfRouters,
-      int replicationFactor,
-      boolean randomizeClusterName,
-      boolean multiColoSetup,
-      boolean multiD2,
-      Optional<Properties> childControllerProperties,
-      Optional<VeniceProperties> veniceProperties,
-      boolean forkServer,
-      Map<String, Map<String, String>> kafkaClusterMap) {
-    return getService(
-        VeniceMultiClusterWrapper.SERVICE_NAME,
-        VeniceMultiClusterWrapper.generateService(
-            coloName,
-            numberOfClusters,
-            numberOfControllers,
-            numberOfServers,
-            numberOfRouters,
-            replicationFactor,
-            DEFAULT_PARTITION_SIZE_BYTES,
-            false,
-            false,
-            DEFAULT_DELAYED_TO_REBALANCE_MS,
-            replicationFactor - 1,
-            DEFAULT_SSL_TO_STORAGE_NODES,
-            randomizeClusterName,
-            multiColoSetup,
-            Optional.of(zkServerWrapper),
-            Optional.of(kafkaBrokerWrapper),
-            childControllerProperties,
-            veniceProperties,
-            multiD2,
-            forkServer,
-            kafkaClusterMap));
-  }
-
-  /**
-   * Predictable cluster name
-   */
-  public static VeniceMultiClusterWrapper getVeniceMultiClusterWrapper(
-      String coloName,
-      int numberOfClusters,
-      int numberOfControllers,
-      int numberOfServers,
-      int numberOfRouters,
-      int replicationFactor,
-      boolean randomizeClusterName,
-      boolean multiColoSetup,
-      boolean multiD2,
-      Optional<Properties> childControllerProperties,
-      Optional<VeniceProperties> veniceProperties,
-      boolean forkServer) {
-    return getService(
-        VeniceMultiClusterWrapper.SERVICE_NAME,
-        VeniceMultiClusterWrapper.generateService(
-            coloName,
-            numberOfClusters,
-            numberOfControllers,
-            numberOfServers,
-            numberOfRouters,
-            replicationFactor,
-            DEFAULT_PARTITION_SIZE_BYTES,
-            false,
-            false,
-            DEFAULT_DELAYED_TO_REBALANCE_MS,
-            replicationFactor - 1,
-            DEFAULT_SSL_TO_STORAGE_NODES,
-            randomizeClusterName,
-            multiColoSetup,
-            Optional.empty(),
-            Optional.empty(),
-            childControllerProperties,
-            veniceProperties,
-            multiD2,
-            forkServer,
-            Collections.emptyMap()));
+  public static VeniceMultiClusterWrapper getVeniceMultiClusterWrapper(VeniceMultiClusterCreateOptions options) {
+    return getService(VeniceMultiClusterWrapper.SERVICE_NAME, VeniceMultiClusterWrapper.generateService(options));
   }
 
   public static VeniceTwoLayerMultiColoMultiClusterWrapper getVeniceTwoLayerMultiColoMultiClusterWrapper(

--- a/internal/venice-test-common/src/main/java/com/linkedin/venice/integration/utils/VeniceMultiClusterCreateOptions.java
+++ b/internal/venice-test-common/src/main/java/com/linkedin/venice/integration/utils/VeniceMultiClusterCreateOptions.java
@@ -6,19 +6,17 @@ import static com.linkedin.venice.integration.utils.VeniceClusterWrapperConstant
 import static com.linkedin.venice.integration.utils.VeniceClusterWrapperConstants.DEFAULT_NUMBER_OF_SERVERS;
 import static com.linkedin.venice.integration.utils.VeniceClusterWrapperConstants.DEFAULT_PARTITION_SIZE_BYTES;
 import static com.linkedin.venice.integration.utils.VeniceClusterWrapperConstants.DEFAULT_REPLICATION_FACTOR;
-import static com.linkedin.venice.integration.utils.VeniceClusterWrapperConstants.DEFAULT_SSL_TO_KAFKA;
 import static com.linkedin.venice.integration.utils.VeniceClusterWrapperConstants.DEFAULT_SSL_TO_STORAGE_NODES;
 
-import com.linkedin.venice.utils.Utils;
+import com.linkedin.venice.utils.VeniceProperties;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Properties;
 
 
-public class VeniceClusterCreateOptions {
-  private final String clusterName;
+public class VeniceMultiClusterCreateOptions {
   private final String coloName;
-  private final String clusterToD2;
+  private final int numberOfClusters;
   private final int numberOfControllers;
   private final int numberOfServers;
   private final int numberOfRouters;
@@ -26,52 +24,25 @@ public class VeniceClusterCreateOptions {
   private final int partitionSize;
   private final int minActiveReplica;
   private final long rebalanceDelayMs;
-  private final boolean standalone;
   private final boolean enableAllowlist;
   private final boolean enableAutoJoinAllowlist;
   private final boolean sslToStorageNodes;
-  private final boolean sslToKafka;
-  private final boolean isKafkaOpenSSLEnabled;
+  private final boolean randomizeClusterName;
+  private final boolean multiColoSetup;
+  private final boolean multiD2;
   private final boolean forkServer;
-  private final Properties extraProperties;
   private final Map<String, Map<String, String>> kafkaClusterMap;
   private final ZkServerWrapper zkServerWrapper;
   private final KafkaBrokerWrapper kafkaBrokerWrapper;
-
-  private VeniceClusterCreateOptions(Builder builder) {
-    this.clusterName = builder.clusterName;
-    this.coloName = builder.coloName;
-    this.clusterToD2 = builder.clusterToD2;
-    this.numberOfControllers = builder.numberOfControllers;
-    this.numberOfServers = builder.numberOfServers;
-    this.numberOfRouters = builder.numberOfRouters;
-    this.replicationFactor = builder.replicationFactor;
-    this.partitionSize = builder.partitionSize;
-    this.minActiveReplica = builder.minActiveReplica;
-    this.rebalanceDelayMs = builder.rebalanceDelayMs;
-    this.standalone = builder.standalone;
-    this.enableAllowlist = builder.enableAllowlist;
-    this.enableAutoJoinAllowlist = builder.enableAutoJoinAllowlist;
-    this.sslToStorageNodes = builder.sslToStorageNodes;
-    this.sslToKafka = builder.sslToKafka;
-    this.isKafkaOpenSSLEnabled = builder.isKafkaOpenSSLEnabled;
-    this.forkServer = builder.forkServer;
-    this.extraProperties = builder.extraProperties;
-    this.kafkaClusterMap = builder.kafkaClusterMap;
-    this.zkServerWrapper = builder.zkServerWrapper;
-    this.kafkaBrokerWrapper = builder.kafkaBrokerWrapper;
-  }
-
-  public String getClusterName() {
-    return clusterName;
-  }
+  private final Properties childControllerProperties;
+  private final VeniceProperties veniceProperties;
 
   public String getColoName() {
     return coloName;
   }
 
-  public String getClusterToD2() {
-    return clusterToD2;
+  public int getNumberOfClusters() {
+    return numberOfClusters;
   }
 
   public int getNumberOfControllers() {
@@ -102,10 +73,6 @@ public class VeniceClusterCreateOptions {
     return rebalanceDelayMs;
   }
 
-  public boolean isStandalone() {
-    return standalone;
-  }
-
   public boolean isEnableAllowlist() {
     return enableAllowlist;
   }
@@ -118,20 +85,20 @@ public class VeniceClusterCreateOptions {
     return sslToStorageNodes;
   }
 
-  public boolean isSslToKafka() {
-    return sslToKafka;
+  public boolean isRandomizeClusterName() {
+    return randomizeClusterName;
   }
 
-  public boolean isKafkaOpenSSLEnabled() {
-    return isKafkaOpenSSLEnabled;
+  public boolean isMultiColoSetup() {
+    return multiColoSetup;
+  }
+
+  public boolean isMultiD2() {
+    return multiD2;
   }
 
   public boolean isForkServer() {
     return forkServer;
-  }
-
-  public Properties getExtraProperties() {
-    return extraProperties;
   }
 
   public Map<String, Map<String, String>> getKafkaClusterMap() {
@@ -146,17 +113,22 @@ public class VeniceClusterCreateOptions {
     return kafkaBrokerWrapper;
   }
 
+  public Properties getChildControllerProperties() {
+    return childControllerProperties;
+  }
+
+  public VeniceProperties getVeniceProperties() {
+    return veniceProperties;
+  }
+
   @Override
   public String toString() {
-    return new StringBuilder().append("VeniceClusterCreateOptions - ")
-        .append("cluster:")
-        .append(clusterName)
-        .append(", ")
-        .append("standalone:")
-        .append(standalone)
-        .append(", ")
+    return new StringBuilder().append("VeniceMultiClusterCreateOptions - ")
         .append("coloName:")
         .append(coloName)
+        .append(", ")
+        .append("clusters:")
+        .append(numberOfClusters)
         .append(", ")
         .append("controllers:")
         .append(numberOfControllers)
@@ -188,20 +160,23 @@ public class VeniceClusterCreateOptions {
         .append("sslToStorageNodes:")
         .append(sslToStorageNodes)
         .append(", ")
-        .append("sslToKafka:")
-        .append(sslToKafka)
-        .append(", ")
-        .append("isKafkaOpenSSLEnabled:")
-        .append(isKafkaOpenSSLEnabled)
-        .append(", ")
         .append("forkServer:")
         .append(forkServer)
         .append(", ")
-        .append("extraProperties:")
-        .append(extraProperties)
+        .append("multiColoSetup:")
+        .append(multiColoSetup)
         .append(", ")
-        .append("clusterToD2:")
-        .append(clusterToD2)
+        .append("randomizeClusterName:")
+        .append(randomizeClusterName)
+        .append(", ")
+        .append("childControllerProperties:")
+        .append(childControllerProperties)
+        .append(", ")
+        .append("veniceProperties:")
+        .append(veniceProperties)
+        .append(", ")
+        .append("multiD2:")
+        .append(multiD2)
         .append(", ")
         .append("zk:")
         .append(zkServerWrapper == null ? "null" : zkServerWrapper.getAddress())
@@ -214,10 +189,33 @@ public class VeniceClusterCreateOptions {
         .toString();
   }
 
+  public VeniceMultiClusterCreateOptions(Builder builder) {
+    coloName = builder.coloName;
+    numberOfClusters = builder.numberOfClusters;
+    numberOfControllers = builder.numberOfControllers;
+    numberOfServers = builder.numberOfServers;
+    numberOfRouters = builder.numberOfRouters;
+    replicationFactor = builder.replicationFactor;
+    partitionSize = builder.partitionSize;
+    enableAllowlist = builder.enableAllowlist;
+    enableAutoJoinAllowlist = builder.enableAutoJoinAllowlist;
+    rebalanceDelayMs = builder.rebalanceDelayMs;
+    minActiveReplica = builder.minActiveReplica;
+    sslToStorageNodes = builder.sslToStorageNodes;
+    randomizeClusterName = builder.randomizeClusterName;
+    multiColoSetup = builder.multiColoSetup;
+    zkServerWrapper = builder.zkServerWrapper;
+    kafkaBrokerWrapper = builder.kafkaBrokerWrapper;
+    childControllerProperties = builder.childControllerProperties;
+    veniceProperties = builder.veniceProperties;
+    multiD2 = builder.multiD2;
+    forkServer = builder.forkServer;
+    kafkaClusterMap = builder.kafkaClusterMap;
+  }
+
   public static class Builder {
-    private String clusterName;
-    private String coloName;
-    private String clusterToD2 = null;
+    private String coloName = "";
+    private final int numberOfClusters;
     private int numberOfControllers = DEFAULT_NUMBER_OF_CONTROLLERS;
     private int numberOfServers = DEFAULT_NUMBER_OF_SERVERS;
     private int numberOfRouters = DEFAULT_NUMBER_OF_ROUTERS;
@@ -225,31 +223,26 @@ public class VeniceClusterCreateOptions {
     private int partitionSize = DEFAULT_PARTITION_SIZE_BYTES;
     private int minActiveReplica;
     private long rebalanceDelayMs = DEFAULT_DELAYED_TO_REBALANCE_MS;
-    private boolean standalone = true; // set to false for multi-cluster
-    private boolean enableAllowlist;
-    private boolean enableAutoJoinAllowlist;
+    private boolean enableAllowlist = false;
+    private boolean enableAutoJoinAllowlist = false;
     private boolean sslToStorageNodes = DEFAULT_SSL_TO_STORAGE_NODES;
-    private boolean sslToKafka = DEFAULT_SSL_TO_KAFKA;
-    private boolean isKafkaOpenSSLEnabled = false;
-    private boolean forkServer;
+    private boolean randomizeClusterName = true;
+    private boolean multiColoSetup = false;
+    private boolean multiD2 = false;
+    private boolean forkServer = false;
     private boolean isMinActiveReplicaSet = false;
-    private Properties extraProperties;
     private Map<String, Map<String, String>> kafkaClusterMap;
     private ZkServerWrapper zkServerWrapper;
     private KafkaBrokerWrapper kafkaBrokerWrapper;
+    private Properties childControllerProperties;
+    private VeniceProperties veniceProperties;
 
-    public Builder clusterName(String clusterName) {
-      this.clusterName = clusterName;
-      return this;
+    public Builder(int numberOfClusters) {
+      this.numberOfClusters = numberOfClusters;
     }
 
     public Builder coloName(String coloName) {
       this.coloName = coloName;
-      return this;
-    }
-
-    public Builder clusterToD2(String clusterToD2) {
-      this.clusterToD2 = clusterToD2;
       return this;
     }
 
@@ -289,11 +282,6 @@ public class VeniceClusterCreateOptions {
       return this;
     }
 
-    public Builder standalone(boolean standalone) {
-      this.standalone = standalone;
-      return this;
-    }
-
     public Builder enableAllowlist(boolean enableAllowlist) {
       this.enableAllowlist = enableAllowlist;
       return this;
@@ -309,23 +297,23 @@ public class VeniceClusterCreateOptions {
       return this;
     }
 
-    public Builder sslToKafka(boolean sslToKafka) {
-      this.sslToKafka = sslToKafka;
+    public Builder randomizeClusterName(boolean randomizeClusterName) {
+      this.randomizeClusterName = randomizeClusterName;
       return this;
     }
 
-    public Builder isKafkaOpenSSLEnabled(boolean isKafkaOpenSSLEnabled) {
-      this.isKafkaOpenSSLEnabled = isKafkaOpenSSLEnabled;
+    public Builder multiColoSetup(boolean multiColoSetup) {
+      this.multiColoSetup = multiColoSetup;
+      return this;
+    }
+
+    public Builder multiD2(boolean multiD2) {
+      this.multiD2 = multiD2;
       return this;
     }
 
     public Builder forkServer(boolean forkServer) {
       this.forkServer = forkServer;
-      return this;
-    }
-
-    public Builder extraProperties(Properties extraProperties) {
-      this.extraProperties = extraProperties;
       return this;
     }
 
@@ -344,27 +332,34 @@ public class VeniceClusterCreateOptions {
       return this;
     }
 
-    private void verifyAndAddDefaults() {
-      if (clusterName == null) {
-        clusterName = Utils.getUniqueString("venice-cluster");
-      }
-      if (standalone && coloName == null) {
-        coloName = "";
-      }
+    public Builder childControllerProperties(Properties childControllerProperties) {
+      this.childControllerProperties = childControllerProperties;
+      return this;
+    }
+
+    public Builder veniceProperties(VeniceProperties veniceProperties) {
+      this.veniceProperties = veniceProperties;
+      return this;
+    }
+
+    private void addDefaults() {
       if (!isMinActiveReplicaSet) {
         minActiveReplica = replicationFactor - 1;
       }
-      if (extraProperties == null) {
-        extraProperties = new Properties();
+      if (childControllerProperties == null) {
+        childControllerProperties = new Properties();
+      }
+      if (veniceProperties == null) {
+        veniceProperties = new VeniceProperties();
       }
       if (kafkaClusterMap == null) {
         kafkaClusterMap = Collections.emptyMap();
       }
     }
 
-    public VeniceClusterCreateOptions build() {
-      verifyAndAddDefaults();
-      return new VeniceClusterCreateOptions(this);
+    public VeniceMultiClusterCreateOptions build() {
+      addDefaults();
+      return new VeniceMultiClusterCreateOptions(this);
     }
   }
 }


### PR DESCRIPTION
   <!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci], [server], [controller],
[router], [samza], [vpj], [fast-client], [thin-client], [alpini],
[admin-tool], [test], [build], [doc], [script]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Summary, imperative, start upper case, don't end with a period
Remove overloaded versions of ServiceFactory::getVeniceMultiClusterWrapper.
Add a new method to create a multi-cluster wrapper that takes just one argument,
VeniceMultiClusterCreateOptions, which is constructed using a builder design
pattern.

<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Resolves #5 

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
UT & IT via CI

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.