### PR TITLE
[h2v] Add repush ttl config and filter to the H2V.

### DIFF
--- a/clients/hadoop-to-venice-bridge/src/main/java/com/linkedin/venice/hadoop/AbstractVeniceFilter.java
+++ b/clients/hadoop-to-venice-bridge/src/main/java/com/linkedin/venice/hadoop/AbstractVeniceFilter.java
@@ -21,7 +21,7 @@ public abstract class AbstractVeniceFilter<INPUT_VALUE> {
    * @param value
    * @return true if the value should be filtered out, otherwise false.
    */
-  protected abstract boolean process(final INPUT_VALUE value);
+  protected abstract boolean filter(final INPUT_VALUE value);
 
   /**
    * This function passes the value through the filter chain to determine
@@ -29,11 +29,11 @@ public abstract class AbstractVeniceFilter<INPUT_VALUE> {
    * @param value
    * @return true if the value should be filtered out by this filter or its successor, otherwise false.
    */
-  public boolean processRecursively(final INPUT_VALUE value) {
-    if (process((value))) {
+  public boolean filterRecursively(final INPUT_VALUE value) {
+    if (filter((value))) {
       return true;
     } else {
-      return next != null && next.processRecursively(value);
+      return next != null && next.filterRecursively(value);
     }
   }
 

--- a/clients/hadoop-to-venice-bridge/src/main/java/com/linkedin/venice/hadoop/AbstractVeniceFilter.java
+++ b/clients/hadoop-to-venice-bridge/src/main/java/com/linkedin/venice/hadoop/AbstractVeniceFilter.java
@@ -21,7 +21,7 @@ public abstract class AbstractVeniceFilter<INPUT_VALUE> {
    * @param value
    * @return true if the value should be filtered out, otherwise false.
    */
-  protected abstract boolean filter(final INPUT_VALUE value);
+  protected abstract boolean apply(final INPUT_VALUE value);
 
   /**
    * This function passes the value through the filter chain to determine
@@ -29,11 +29,11 @@ public abstract class AbstractVeniceFilter<INPUT_VALUE> {
    * @param value
    * @return true if the value should be filtered out by this filter or its successor, otherwise false.
    */
-  public boolean filterRecursively(final INPUT_VALUE value) {
-    if (filter((value))) {
+  public boolean applyRecursively(final INPUT_VALUE value) {
+    if (apply((value))) {
       return true;
     } else {
-      return next != null && next.filterRecursively(value);
+      return next != null && next.applyRecursively(value);
     }
   }
 

--- a/clients/hadoop-to-venice-bridge/src/main/java/com/linkedin/venice/hadoop/AbstractVeniceFilter.java
+++ b/clients/hadoop-to-venice-bridge/src/main/java/com/linkedin/venice/hadoop/AbstractVeniceFilter.java
@@ -1,0 +1,61 @@
+package com.linkedin.venice.hadoop;
+
+import com.linkedin.venice.utils.VeniceProperties;
+
+
+/**
+ * An abstraction to filter data using Chain of Responsibility pattern.
+ * @param <INPUT_VALUE>
+ */
+public abstract class AbstractVeniceFilter<INPUT_VALUE> {
+  protected final VeniceProperties props;
+
+  public AbstractVeniceFilter(final VeniceProperties props) {
+    this.props = props;
+  }
+
+  private AbstractVeniceFilter<INPUT_VALUE> next;
+
+  /**
+   * This function implements how to parse the value and determine if filtering is needed.
+   * @param value
+   * @return true if the value should be filtered out, otherwise false.
+   */
+  protected abstract boolean process(final INPUT_VALUE value);
+
+  /**
+   * This function passes the value through the filter chain to determine
+   * if the value can be filtered out or not.
+   * @param value
+   * @return true if the value should be filtered out by this filter or its successor, otherwise false.
+   */
+  public boolean processRecursively(final INPUT_VALUE value) {
+    if (process((value))) {
+      return true;
+    } else {
+      return next != null && next.processRecursively(value);
+    }
+  }
+
+  /**
+   * Set the next filter for this chain.
+   * @param filter, a chainable filter to handle <INPUT_VALUE>.
+   */
+  public void setNext(final AbstractVeniceFilter<INPUT_VALUE> filter) {
+    this.next = filter;
+  }
+
+  /**
+   * @return the next filter in this chain.
+   */
+  public AbstractVeniceFilter<INPUT_VALUE> next() {
+    return this.next;
+  }
+
+  /**
+   * @return true if the chain has more filters.
+   */
+  public boolean hasNext() {
+    return this.next != null;
+  }
+}

--- a/clients/hadoop-to-venice-bridge/src/main/java/com/linkedin/venice/hadoop/AbstractVeniceMapper.java
+++ b/clients/hadoop-to-venice-bridge/src/main/java/com/linkedin/venice/hadoop/AbstractVeniceMapper.java
@@ -15,6 +15,7 @@ import com.linkedin.venice.utils.Utils;
 import com.linkedin.venice.utils.VeniceProperties;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.Optional;
 import org.apache.hadoop.io.BytesWritable;
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.mapred.Mapper;
@@ -43,6 +44,7 @@ public abstract class AbstractVeniceMapper<INPUT_KEY, INPUT_VALUE> extends Abstr
   BytesWritable keyBW = new BytesWritable(), valueBW = new BytesWritable();
 
   protected AbstractVeniceRecordReader<INPUT_KEY, INPUT_VALUE> veniceRecordReader;
+  protected Optional<AbstractVeniceFilter<INPUT_VALUE>> veniceFilter;
 
   @Override
   public void map(
@@ -122,6 +124,11 @@ public abstract class AbstractVeniceMapper<INPUT_KEY, INPUT_VALUE> extends Abstr
    * A method for child classes to setup {@link AbstractVeniceMapper#veniceRecordReader}.
    */
   abstract protected AbstractVeniceRecordReader<INPUT_KEY, INPUT_VALUE> getRecordReader(VeniceProperties props);
+
+  /**
+   * A method for child classes to setup {@link AbstractVeniceMapper#veniceFilter}.
+   */
+  abstract protected Optional<AbstractVeniceFilter<INPUT_VALUE>> getFilter(final VeniceProperties props);
 
   @Override
   protected void configureTask(VeniceProperties props, JobConf job) {

--- a/clients/hadoop-to-venice-bridge/src/main/java/com/linkedin/venice/hadoop/VeniceAvroMapper.java
+++ b/clients/hadoop-to-venice-bridge/src/main/java/com/linkedin/venice/hadoop/VeniceAvroMapper.java
@@ -1,6 +1,7 @@
 package com.linkedin.venice.hadoop;
 
 import com.linkedin.venice.utils.VeniceProperties;
+import java.util.Optional;
 import org.apache.avro.generic.IndexedRecord;
 import org.apache.avro.mapred.AvroWrapper;
 import org.apache.hadoop.io.NullWritable;
@@ -10,5 +11,10 @@ public class VeniceAvroMapper extends AbstractVeniceMapper<AvroWrapper<IndexedRe
   @Override
   public AbstractVeniceRecordReader<AvroWrapper<IndexedRecord>, NullWritable> getRecordReader(VeniceProperties props) {
     return new VeniceAvroRecordReader(props);
+  }
+
+  @Override
+  protected Optional<AbstractVeniceFilter<NullWritable>> getFilter(final VeniceProperties props) {
+    return Optional.empty();
   }
 }

--- a/clients/hadoop-to-venice-bridge/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
+++ b/clients/hadoop-to-venice-bridge/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
@@ -312,7 +312,7 @@ public class VenicePushJob implements AutoCloseable {
    * try to override it.
    */
   public static final long DEFAULT_RE_PUSH_REWIND_IN_SECONDS_OVERRIDE = Time.SECONDS_PER_DAY;
-  public static final String REPUSH_TTL_IN_HOURS_OVERRIDE = "repush.ttl.hours.override";
+  public static final String REPUSH_TTL_IN_HOURS = "repush.ttl.hours";
   public static final String REPUSH_TTL_POLICY = "repush.ttl.policy";
   private static final Logger LOGGER = LogManager.getLogger(VenicePushJob.class);
 
@@ -643,7 +643,7 @@ public class VenicePushJob implements AutoCloseable {
     pushJobSettingToReturn.kafkaInputCombinerEnabled = props.getBoolean(KAFKA_INPUT_COMBINER_ENABLED, false);
     pushJobSettingToReturn.suppressEndOfPushMessage = props.getBoolean(SUPPRESS_END_OF_PUSH_MESSAGE, false);
     pushJobSettingToReturn.deferVersionSwap = props.getBoolean(DEFER_VERSION_SWAP, false);
-    pushJobSettingToReturn.repushTtlInHours = props.getLong(REPUSH_TTL_IN_HOURS_OVERRIDE, -1);
+    pushJobSettingToReturn.repushTtlInHours = props.getLong(REPUSH_TTL_IN_HOURS, -1);
 
     if (pushJobSettingToReturn.repushTtlInHours != -1 && !pushJobSettingToReturn.isSourceKafka) {
       throw new VeniceException("Repush with TTL is only supported while using Kafka input");
@@ -2527,7 +2527,7 @@ public class VenicePushJob implements AutoCloseable {
        */
       conf.set(KAFKA_INPUT_TOPIC, pushJobSetting.kafkaInputTopic);
       conf.set(KAFKA_INPUT_BROKER_URL, pushJobSetting.kafkaInputBrokerUrl);
-      conf.setLong(REPUSH_TTL_IN_HOURS_OVERRIDE, pushJobSetting.repushTtlInHours);
+      conf.setLong(REPUSH_TTL_IN_HOURS, pushJobSetting.repushTtlInHours);
       conf.setInt(REPUSH_TTL_POLICY, 0); // only support one policy thus not allow any value passed in.
     } else {
       conf.setInt(VALUE_SCHEMA_ID_PROP, pushJobSchemaInfo.getValueSchemaId());

--- a/clients/hadoop-to-venice-bridge/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
+++ b/clients/hadoop-to-venice-bridge/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
@@ -319,7 +319,7 @@ public class VenicePushJob implements AutoCloseable {
   public static final String REPUSH_TTL_IN_HOURS = "repush.ttl.hours";
   public static final String REPUSH_TTL_POLICY = "repush.ttl.policy";
 
-  public static final int UNSET = -1;
+  public static final int NOT_SET = -1;
   private static final Logger LOGGER = LogManager.getLogger(VenicePushJob.class);
 
   /**
@@ -649,10 +649,10 @@ public class VenicePushJob implements AutoCloseable {
     pushJobSettingToReturn.kafkaInputCombinerEnabled = props.getBoolean(KAFKA_INPUT_COMBINER_ENABLED, false);
     pushJobSettingToReturn.suppressEndOfPushMessage = props.getBoolean(SUPPRESS_END_OF_PUSH_MESSAGE, false);
     pushJobSettingToReturn.deferVersionSwap = props.getBoolean(DEFER_VERSION_SWAP, false);
-    pushJobSettingToReturn.repushTtlInHours = props.getLong(REPUSH_TTL_IN_HOURS, UNSET);
+    pushJobSettingToReturn.repushTtlInHours = props.getLong(REPUSH_TTL_IN_HOURS, NOT_SET);
 
-    if (pushJobSettingToReturn.repushTtlInHours != UNSET && !pushJobSettingToReturn.isSourceKafka) {
-      throw new VeniceException("Repush with TTL is only supported while using Kafka input");
+    if (pushJobSettingToReturn.repushTtlInHours != NOT_SET && !pushJobSettingToReturn.isSourceKafka) {
+      throw new VeniceException("Repush with TTL is only supported while using Kafka Input Format");
     }
 
     if (pushJobSettingToReturn.isSourceKafka) {
@@ -663,13 +663,13 @@ public class VenicePushJob implements AutoCloseable {
       pushJobSettingToReturn.isDuplicateKeyAllowed = true;
 
       if (pushJobSettingToReturn.isIncrementalPush) {
-        throw new VeniceException("Incremental push is not supported while using Kafka Input");
+        throw new VeniceException("Incremental push is not supported while using Kafka Input Format");
       }
       if (pushJobSettingToReturn.isSourceETL) {
-        throw new VeniceException("Source ETL is not supported while using Kafka Input");
+        throw new VeniceException("Source ETL is not supported while using Kafka Input Format");
       }
       if (pushJobSettingToReturn.enablePBNJ) {
-        throw new VeniceException("PBNJ is not supported while using Kafka Input");
+        throw new VeniceException("PBNJ is not supported while using Kafka Input Format");
       }
       pushJobSettingToReturn.kafkaInputTopic =
           getSourceTopicNameForKafkaInput(props.getString(VENICE_STORE_NAME_PROP), props, pushJobSettingToReturn);
@@ -678,13 +678,13 @@ public class VenicePushJob implements AutoCloseable {
           : pushJobSettingToReturn.repushInfoResponse.getRepushInfo().getKafkaBrokerUrl();
     }
     pushJobSettingToReturn.storeName = props.getString(VENICE_STORE_NAME_PROP);
-    pushJobSettingToReturn.rewindTimeInSecondsOverride = props.getLong(REWIND_TIME_IN_SECONDS_OVERRIDE, UNSET);
+    pushJobSettingToReturn.rewindTimeInSecondsOverride = props.getLong(REWIND_TIME_IN_SECONDS_OVERRIDE, NOT_SET);
 
     // If we didn't specify a rewind time
-    if (pushJobSettingToReturn.rewindTimeInSecondsOverride == UNSET) {
+    if (pushJobSettingToReturn.rewindTimeInSecondsOverride == NOT_SET) {
       // But we did specify a rewind time epoch timestamp
-      long rewindTimestamp = props.getLong(REWIND_EPOCH_TIME_IN_SECONDS_OVERRIDE, UNSET);
-      if (rewindTimestamp > UNSET) {
+      long rewindTimestamp = props.getLong(REWIND_EPOCH_TIME_IN_SECONDS_OVERRIDE, NOT_SET);
+      if (rewindTimestamp != NOT_SET) {
         long nowInSeconds = System.currentTimeMillis() / 1000;
         // So long as that rewind time isn't in the future
         if (rewindTimestamp > nowInSeconds) {
@@ -912,7 +912,7 @@ public class VenicePushJob implements AutoCloseable {
       storeSetting = getSettingsFromController(controllerClient, pushJobSetting);
       inputStorageQuotaTracker = new InputStorageQuotaTracker(storeSetting.storeStorageQuota);
 
-      if (pushJobSetting.repushTtlInHours != UNSET && storeSetting.isChunkingEnabled) {
+      if (pushJobSetting.repushTtlInHours != NOT_SET && storeSetting.isChunkingEnabled) {
         throw new VeniceException("Repush TTL is not supported when the store has chunking enabled.");
       }
 
@@ -995,7 +995,7 @@ public class VenicePushJob implements AutoCloseable {
         if (pushJobSetting.isSourceKafka) {
           pushId = Version.generateRePushId(pushId);
           if (storeSetting.sourceKafkaInputVersionInfo.getHybridStoreConfig() != null
-              && pushJobSetting.rewindTimeInSecondsOverride == UNSET) {
+              && pushJobSetting.rewindTimeInSecondsOverride == NOT_SET) {
             pushJobSetting.rewindTimeInSecondsOverride = DEFAULT_RE_PUSH_REWIND_IN_SECONDS_OVERRIDE;
             LOGGER.info("Overriding re-push rewind time in seconds to: {}", DEFAULT_RE_PUSH_REWIND_IN_SECONDS_OVERRIDE);
           }
@@ -2775,7 +2775,7 @@ public class VenicePushJob implements AutoCloseable {
     propKeyValuePairs.add("Is duplicated key allowed: " + pushJobSetting.isDuplicateKeyAllowed);
     propKeyValuePairs.add("Is source ETL data: " + pushJobSetting.isSourceETL);
     propKeyValuePairs.add("ETL value schema transformation : " + pushJobSetting.etlValueSchemaTransformation);
-    propKeyValuePairs.add("Is Kafka Input: " + pushJobSetting.isSourceKafka);
+    propKeyValuePairs.add("Is Kafka Input Format: " + pushJobSetting.isSourceKafka);
     if (pushJobSetting.isSourceKafka) {
       propKeyValuePairs.add("Kafka Input broker urls: " + pushJobSetting.kafkaInputBrokerUrl);
       propKeyValuePairs.add("Kafka Input topic name: " + pushJobSetting.kafkaInputTopic);

--- a/clients/hadoop-to-venice-bridge/src/main/java/com/linkedin/venice/hadoop/VeniceVsonMapper.java
+++ b/clients/hadoop-to-venice-bridge/src/main/java/com/linkedin/venice/hadoop/VeniceVsonMapper.java
@@ -1,6 +1,7 @@
 package com.linkedin.venice.hadoop;
 
 import com.linkedin.venice.utils.VeniceProperties;
+import java.util.Optional;
 import org.apache.hadoop.io.BytesWritable;
 
 
@@ -11,5 +12,10 @@ public class VeniceVsonMapper extends AbstractVeniceMapper<BytesWritable, BytesW
   @Override
   public AbstractVeniceRecordReader<BytesWritable, BytesWritable> getRecordReader(VeniceProperties props) {
     return new VeniceVsonRecordReader(props);
+  }
+
+  @Override
+  protected Optional<AbstractVeniceFilter<BytesWritable>> getFilter(final VeniceProperties props) {
+    return Optional.empty();
   }
 }

--- a/clients/hadoop-to-venice-bridge/src/main/java/com/linkedin/venice/hadoop/input/kafka/VeniceKafkaInputMapper.java
+++ b/clients/hadoop-to-venice-bridge/src/main/java/com/linkedin/venice/hadoop/input/kafka/VeniceKafkaInputMapper.java
@@ -30,8 +30,8 @@ public class VeniceKafkaInputMapper extends AbstractVeniceMapper<BytesWritable, 
 
   @Override
   protected Optional<AbstractVeniceFilter<KafkaInputMapperValue>> getFilter(final VeniceProperties props) {
-    long ttlInHours = props.getLong(VenicePushJob.REPUSH_TTL_IN_HOURS, -1);
-    if (ttlInHours != -1) {
+    long ttlInHours = props.getLong(VenicePushJob.REPUSH_TTL_IN_HOURS, VenicePushJob.UNSET);
+    if (ttlInHours != VenicePushJob.UNSET) {
       VeniceKafkaInputTTLFilter filter = new VeniceKafkaInputTTLFilter(props);
       return Optional.of(filter);
     }

--- a/clients/hadoop-to-venice-bridge/src/main/java/com/linkedin/venice/hadoop/input/kafka/VeniceKafkaInputMapper.java
+++ b/clients/hadoop-to-venice-bridge/src/main/java/com/linkedin/venice/hadoop/input/kafka/VeniceKafkaInputMapper.java
@@ -30,7 +30,7 @@ public class VeniceKafkaInputMapper extends AbstractVeniceMapper<BytesWritable, 
 
   @Override
   protected Optional<AbstractVeniceFilter<KafkaInputMapperValue>> getFilter(final VeniceProperties props) {
-    long ttlInHours = props.getLong(VenicePushJob.REPUSH_TTL_IN_HOURS_OVERRIDE, -1);
+    long ttlInHours = props.getLong(VenicePushJob.REPUSH_TTL_IN_HOURS, -1);
     if (ttlInHours != -1) {
       VeniceKafkaInputTTLFilter filter = new VeniceKafkaInputTTLFilter(props);
       return Optional.of(filter);
@@ -54,7 +54,7 @@ public class VeniceKafkaInputMapper extends AbstractVeniceMapper<BytesWritable, 
       BytesWritable keyBW,
       BytesWritable valueBW,
       Reporter reporter) {
-    if (veniceFilter.isPresent() && veniceFilter.get().processRecursively(inputValue)) {
+    if (veniceFilter.isPresent() && veniceFilter.get().filterRecursively(inputValue)) {
       return false;
     }
     keyBW.set(inputKey);

--- a/clients/hadoop-to-venice-bridge/src/main/java/com/linkedin/venice/hadoop/input/kafka/VeniceKafkaInputMapper.java
+++ b/clients/hadoop-to-venice-bridge/src/main/java/com/linkedin/venice/hadoop/input/kafka/VeniceKafkaInputMapper.java
@@ -30,8 +30,8 @@ public class VeniceKafkaInputMapper extends AbstractVeniceMapper<BytesWritable, 
 
   @Override
   protected Optional<AbstractVeniceFilter<KafkaInputMapperValue>> getFilter(final VeniceProperties props) {
-    long ttlInHours = props.getLong(VenicePushJob.REPUSH_TTL_IN_HOURS, VenicePushJob.UNSET);
-    if (ttlInHours != VenicePushJob.UNSET) {
+    long ttlInHours = props.getLong(VenicePushJob.REPUSH_TTL_IN_HOURS, VenicePushJob.NOT_SET);
+    if (ttlInHours != VenicePushJob.NOT_SET) {
       VeniceKafkaInputTTLFilter filter = new VeniceKafkaInputTTLFilter(props);
       return Optional.of(filter);
     }

--- a/clients/hadoop-to-venice-bridge/src/main/java/com/linkedin/venice/hadoop/input/kafka/VeniceKafkaInputMapper.java
+++ b/clients/hadoop-to-venice-bridge/src/main/java/com/linkedin/venice/hadoop/input/kafka/VeniceKafkaInputMapper.java
@@ -54,7 +54,7 @@ public class VeniceKafkaInputMapper extends AbstractVeniceMapper<BytesWritable, 
       BytesWritable keyBW,
       BytesWritable valueBW,
       Reporter reporter) {
-    if (veniceFilter.isPresent() && veniceFilter.get().filterRecursively(inputValue)) {
+    if (veniceFilter.isPresent() && veniceFilter.get().applyRecursively(inputValue)) {
       return false;
     }
     keyBW.set(inputKey);

--- a/clients/hadoop-to-venice-bridge/src/main/java/com/linkedin/venice/hadoop/input/kafka/VeniceKafkaInputMapper.java
+++ b/clients/hadoop-to-venice-bridge/src/main/java/com/linkedin/venice/hadoop/input/kafka/VeniceKafkaInputMapper.java
@@ -1,12 +1,16 @@
 package com.linkedin.venice.hadoop.input.kafka;
 
+import com.linkedin.venice.hadoop.AbstractVeniceFilter;
 import com.linkedin.venice.hadoop.AbstractVeniceMapper;
 import com.linkedin.venice.hadoop.AbstractVeniceRecordReader;
+import com.linkedin.venice.hadoop.VenicePushJob;
 import com.linkedin.venice.hadoop.input.kafka.avro.KafkaInputMapperValue;
+import com.linkedin.venice.hadoop.input.kafka.ttl.VeniceKafkaInputTTLFilter;
 import com.linkedin.venice.serializer.AvroSerializer;
 import com.linkedin.venice.serializer.FastSerializerDeserializerFactory;
 import com.linkedin.venice.serializer.RecordSerializer;
 import com.linkedin.venice.utils.VeniceProperties;
+import java.util.Optional;
 import org.apache.hadoop.io.BytesWritable;
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.mapred.Reporter;
@@ -25,11 +29,22 @@ public class VeniceKafkaInputMapper extends AbstractVeniceMapper<BytesWritable, 
   }
 
   @Override
+  protected Optional<AbstractVeniceFilter<KafkaInputMapperValue>> getFilter(final VeniceProperties props) {
+    long ttlInHours = props.getLong(VenicePushJob.REPUSH_TTL_IN_HOURS_OVERRIDE, -1);
+    if (ttlInHours != -1) {
+      VeniceKafkaInputTTLFilter filter = new VeniceKafkaInputTTLFilter(props);
+      return Optional.of(filter);
+    }
+    return Optional.empty();
+  }
+
+  @Override
   protected void configureTask(VeniceProperties props, JobConf job) {
     /**
      * Do nothing for {@link KafkaInputFormat} for now, and if we need to support compression rebuild during re-push,
      * this function needs to be changed.
      */
+    this.veniceFilter = getFilter(props);
   }
 
   @Override
@@ -39,6 +54,9 @@ public class VeniceKafkaInputMapper extends AbstractVeniceMapper<BytesWritable, 
       BytesWritable keyBW,
       BytesWritable valueBW,
       Reporter reporter) {
+    if (veniceFilter.isPresent() && veniceFilter.get().processRecursively(inputValue)) {
+      return false;
+    }
     keyBW.set(inputKey);
     byte[] serializedValue = KAFKA_INPUT_MAPPER_VALUE_SERIALIZER.serialize(inputValue, AvroSerializer.REUSE.get());
     valueBW.set(serializedValue, 0, serializedValue.length);

--- a/clients/hadoop-to-venice-bridge/src/main/java/com/linkedin/venice/hadoop/input/kafka/ttl/TTLResolutionPolicy.java
+++ b/clients/hadoop-to-venice-bridge/src/main/java/com/linkedin/venice/hadoop/input/kafka/ttl/TTLResolutionPolicy.java
@@ -7,7 +7,7 @@ import java.util.Map;
 
 /**
  * The policy controls the TTL behavior regarding how batch writes are treated.
- * As of today (09/15/2022), only real-time write can be TTLed/supported.
+ * As of writing, only real-time write can be TTLed/supported.
  */
 public enum TTLResolutionPolicy {
   /**

--- a/clients/hadoop-to-venice-bridge/src/main/java/com/linkedin/venice/hadoop/input/kafka/ttl/TTLResolutionPolicy.java
+++ b/clients/hadoop-to-venice-bridge/src/main/java/com/linkedin/venice/hadoop/input/kafka/ttl/TTLResolutionPolicy.java
@@ -1,0 +1,60 @@
+package com.linkedin.venice.hadoop.input.kafka.ttl;
+
+import com.linkedin.venice.exceptions.VeniceException;
+import java.util.HashMap;
+import java.util.Map;
+
+
+/**
+ * The policy controls the TTL behavior regarding how batch writes are treated.
+ * As of today (09/15/2022), only real-time write can be TTLed/supported.
+ */
+public enum TTLResolutionPolicy {
+  /**
+   * Reject batch writes as they don't contain RMD to perform TTL logic, so only real-time write. can be TTLed
+   */
+  REJECT_BATCH_WRITE(0),
+
+  /**
+   * Bypass all the batch data and don't perform TTL on them.
+   * Note this policy is NOT supported yet.
+   * In order to support this, H2V job has to differentiate batch write and real-time write.
+   */
+  BYPASS_BATCH_WRITE(1),
+
+  /**
+   * Allow both batch writes and real-time writes be TTLed.
+   * Note this policy is NOT supported yet.
+   * In order to support this, a reliable timestamp has to be designed/identified for batch writes.
+   */
+  ACCEPT_BATCH_WRITE(2);
+
+  private final int value;
+
+  private static final Map<Integer, TTLResolutionPolicy> TTL_RESOLUTION_POLICIES = getTTLResolutionPolicies();
+
+  private static Map<Integer, TTLResolutionPolicy> getTTLResolutionPolicies() {
+    Map<Integer, TTLResolutionPolicy> policies = new HashMap<>();
+    for (TTLResolutionPolicy policy: TTLResolutionPolicy.values()) {
+      policies.put(policy.value, policy);
+    }
+    return policies;
+  }
+
+  TTLResolutionPolicy(int value) {
+    this.value = value;
+  }
+
+  public int getValue() {
+    return value;
+  }
+
+  public static TTLResolutionPolicy valueOf(int value) {
+    TTLResolutionPolicy policy = TTL_RESOLUTION_POLICIES.get(value);
+    if (policy == null) {
+      throw new VeniceException("Invalid TTL resolution policy type: " + value);
+    }
+    return policy;
+  }
+
+}

--- a/clients/hadoop-to-venice-bridge/src/main/java/com/linkedin/venice/hadoop/input/kafka/ttl/TTLResolutionPolicy.java
+++ b/clients/hadoop-to-venice-bridge/src/main/java/com/linkedin/venice/hadoop/input/kafka/ttl/TTLResolutionPolicy.java
@@ -11,9 +11,10 @@ import java.util.Map;
  */
 public enum TTLResolutionPolicy {
   /**
-   * Reject batch writes as they don't contain RMD to perform TTL logic, so only real-time write. can be TTLed
+   * Only real-time(RT) data, which can contain the RMD, will be TTLed. If the data doesn't contain RMD,
+   * it means the data comes from batch or the store is not AA-enabled, this policy will fail the H2V job.
    */
-  REJECT_BATCH_WRITE(0),
+  RT_WRITE_ONLY(0),
 
   /**
    * Bypass all the batch data and don't perform TTL on them.

--- a/clients/hadoop-to-venice-bridge/src/main/java/com/linkedin/venice/hadoop/input/kafka/ttl/VeniceKafkaInputTTLFilter.java
+++ b/clients/hadoop-to-venice-bridge/src/main/java/com/linkedin/venice/hadoop/input/kafka/ttl/VeniceKafkaInputTTLFilter.java
@@ -1,0 +1,29 @@
+package com.linkedin.venice.hadoop.input.kafka.ttl;
+
+import com.linkedin.venice.hadoop.AbstractVeniceFilter;
+import com.linkedin.venice.hadoop.VenicePushJob;
+import com.linkedin.venice.hadoop.input.kafka.avro.KafkaInputMapperValue;
+import com.linkedin.venice.utils.VeniceProperties;
+
+
+public class VeniceKafkaInputTTLFilter extends AbstractVeniceFilter<KafkaInputMapperValue> {
+  private final TTLResolutionPolicy ttlPolicy;
+
+  public VeniceKafkaInputTTLFilter(VeniceProperties props) {
+    super(props);
+    ttlPolicy = TTLResolutionPolicy.valueOf(props.getInt(VenicePushJob.REPUSH_TTL_POLICY));
+  }
+
+  @Override
+  protected boolean process(final KafkaInputMapperValue kafkaInputMapperValue) {
+    switch (ttlPolicy) {
+      case REJECT_BATCH_WRITE:
+        // TODO implementation to retrieve RMD and parse timestamp information. See VENG-9956
+        return false; // do not drop anything
+      case BYPASS_BATCH_WRITE:
+      case ACCEPT_BATCH_WRITE:
+      default:
+        throw new UnsupportedOperationException(ttlPolicy + " policy is not supported.");
+    }
+  }
+}

--- a/clients/hadoop-to-venice-bridge/src/main/java/com/linkedin/venice/hadoop/input/kafka/ttl/VeniceKafkaInputTTLFilter.java
+++ b/clients/hadoop-to-venice-bridge/src/main/java/com/linkedin/venice/hadoop/input/kafka/ttl/VeniceKafkaInputTTLFilter.java
@@ -15,7 +15,7 @@ public class VeniceKafkaInputTTLFilter extends AbstractVeniceFilter<KafkaInputMa
   }
 
   @Override
-  protected boolean filter(final KafkaInputMapperValue kafkaInputMapperValue) {
+  protected boolean apply(final KafkaInputMapperValue kafkaInputMapperValue) {
     switch (ttlPolicy) {
       case RT_WRITE_ONLY:
         // TODO implementation to retrieve RMD and parse timestamp information. See VENG-9956

--- a/clients/hadoop-to-venice-bridge/src/main/java/com/linkedin/venice/hadoop/input/kafka/ttl/VeniceKafkaInputTTLFilter.java
+++ b/clients/hadoop-to-venice-bridge/src/main/java/com/linkedin/venice/hadoop/input/kafka/ttl/VeniceKafkaInputTTLFilter.java
@@ -15,9 +15,9 @@ public class VeniceKafkaInputTTLFilter extends AbstractVeniceFilter<KafkaInputMa
   }
 
   @Override
-  protected boolean process(final KafkaInputMapperValue kafkaInputMapperValue) {
+  protected boolean filter(final KafkaInputMapperValue kafkaInputMapperValue) {
     switch (ttlPolicy) {
-      case REJECT_BATCH_WRITE:
+      case RT_WRITE_ONLY:
         // TODO implementation to retrieve RMD and parse timestamp information. See VENG-9956
         return false; // do not drop anything
       case BYPASS_BATCH_WRITE:

--- a/clients/hadoop-to-venice-bridge/src/test/java/com/linkedin/venice/hadoop/TestVeniceAvroMapper.java
+++ b/clients/hadoop-to-venice-bridge/src/test/java/com/linkedin/venice/hadoop/TestVeniceAvroMapper.java
@@ -14,6 +14,7 @@ import static org.mockito.Mockito.when;
 
 import com.linkedin.venice.exceptions.UndefinedPropertyException;
 import com.linkedin.venice.exceptions.VeniceException;
+import com.linkedin.venice.utils.VeniceProperties;
 import java.io.IOException;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
@@ -183,6 +184,13 @@ public class TestVeniceAvroMapper extends AbstractTestVeniceMapper<VeniceAvroMap
     // Expect the output collect to collect output due to no early termination
     verify(output, times(getNumberOfCollectorInvocationForFirstMapInvocation(numReducers, taskId)))
         .collect(any(), any());
+  }
+
+  @Test
+  public void testEmptyFilter() {
+    try (VeniceAvroMapper mapper = new VeniceAvroMapper()) {
+      Assert.assertFalse(mapper.getFilter(new VeniceProperties()).isPresent());
+    }
   }
 
   private AvroWrapper<IndexedRecord> getAvroWrapper(String keyFieldValue, String valueFieldValue) {

--- a/clients/hadoop-to-venice-bridge/src/test/java/com/linkedin/venice/hadoop/TestVenicePushJobConfig.java
+++ b/clients/hadoop-to-venice-bridge/src/test/java/com/linkedin/venice/hadoop/TestVenicePushJobConfig.java
@@ -1,0 +1,120 @@
+package com.linkedin.venice.hadoop;
+
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+
+import com.linkedin.venice.compression.CompressionStrategy;
+import com.linkedin.venice.controllerapi.ControllerClient;
+import com.linkedin.venice.controllerapi.D2ServiceDiscoveryResponse;
+import com.linkedin.venice.controllerapi.SchemaResponse;
+import com.linkedin.venice.controllerapi.StoreResponse;
+import com.linkedin.venice.exceptions.VeniceException;
+import com.linkedin.venice.meta.StoreInfo;
+import com.linkedin.venice.meta.Version;
+import com.linkedin.venice.meta.VersionImpl;
+import com.linkedin.venice.utils.TestPushUtils;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.function.Consumer;
+import org.testng.annotations.Test;
+
+
+/**
+ * Compared to {@link TestVenicePushJob} which is the integration test for PushJob,
+ * this unit test focus on configuration-related tests.
+ */
+public class TestVenicePushJobConfig {
+  private static final String TEST_PUSH = "test_push";
+  private static final String TEST_URL = "test_url";
+  private static final String TEST_PATH = "test_path";
+  private static final String TEST_STORE = "test_store";
+  private static final String TEST_CLUSTER = "test_cluster";
+  private static final String TEST_SERVICE = "test_venice";
+
+  @Test(expectedExceptions = VeniceException.class, expectedExceptionsMessageRegExp = ".*Repush with TTL is only supported while using Kafka input.*")
+  public void testRepushTTLJobWithNonKafkaInput() {
+    Properties repushProps = new Properties();
+    repushProps.put(VenicePushJob.REPUSH_TTL_IN_HOURS_OVERRIDE, 10L);
+    VenicePushJob pushJob = getSpyVenicePushJob(Optional.of(repushProps), Optional.empty());
+    pushJob.run();
+  }
+
+  @Test(expectedExceptions = VeniceException.class, expectedExceptionsMessageRegExp = ".*Chunking is not supported when using repush with ttl feature.*")
+  public void testRepushTTLJobWithChunking() {
+    Properties repushProps = new Properties();
+    repushProps.put(VenicePushJob.REPUSH_TTL_IN_HOURS_OVERRIDE, 10L);
+    repushProps.setProperty(VenicePushJob.SOURCE_KAFKA, "true");
+    repushProps.setProperty(VenicePushJob.KAFKA_INPUT_TOPIC, Version.composeKafkaTopic(TEST_STORE, 0));
+    repushProps.setProperty(VenicePushJob.KAFKA_INPUT_BROKER_URL, "localhost");
+    repushProps.setProperty(VenicePushJob.KAFKA_INPUT_MAX_RECORDS_PER_MAPPER, "5");
+
+    ControllerClient client = getClient(storeInfo -> {
+      Version version = new VersionImpl(TEST_STORE, 0, TEST_PUSH);
+      version.setChunkingEnabled(true);
+      storeInfo.setChunkingEnabled(true);
+      storeInfo.setVersions(Collections.singletonList(version));
+    });
+    VenicePushJob pushJob = getSpyVenicePushJob(Optional.of(repushProps), Optional.of(client));
+    pushJob.run();
+  }
+
+  private VenicePushJob getSpyVenicePushJob() {
+    return getSpyVenicePushJob(Optional.empty(), Optional.empty());
+  }
+
+  private VenicePushJob getSpyVenicePushJob(Optional<Properties> props, Optional<ControllerClient> client) {
+    Properties baseProps = TestPushUtils.defaultH2VProps(TEST_URL, TEST_PATH, TEST_STORE);
+    // for mocked tests, only attempt once.
+    baseProps.put(VenicePushJob.CONTROLLER_REQUEST_RETRY_ATTEMPTS, 1);
+    props.ifPresent(baseProps::putAll);
+    ControllerClient mockClient = client.orElseGet(this::getClient);
+    VenicePushJob pushJob = spy(new VenicePushJob(TEST_PUSH, baseProps, mockClient, mockClient));
+    pushJob.setSystemKMEStoreControllerClient(mockClient);
+    return pushJob;
+  }
+
+  private ControllerClient getClient() {
+    return getClient(storeInfo -> {});
+  }
+
+  private ControllerClient getClient(Consumer<StoreInfo> storeInfo) {
+    ControllerClient client = mock(ControllerClient.class);
+    // mock discover cluster
+    D2ServiceDiscoveryResponse clusterResponse = new D2ServiceDiscoveryResponse();
+    clusterResponse.setCluster(TEST_CLUSTER);
+    clusterResponse.setD2Service(TEST_SERVICE);
+    doReturn(clusterResponse).when(client).discoverCluster(TEST_STORE);
+
+    // mock value schema
+    SchemaResponse schemaResponse = new SchemaResponse();
+    doReturn(schemaResponse).when(client).getValueSchema(anyString(), anyInt());
+
+    // mock storeinfo response
+    StoreResponse storeResponse = new StoreResponse();
+    storeResponse.setStore(getStoreInfo(storeInfo));
+    doReturn(storeResponse).when(client).getStore(TEST_STORE);
+
+    return client;
+  }
+
+  private StoreInfo getStoreInfo(Consumer<StoreInfo> info) {
+    StoreInfo storeInfo = new StoreInfo();
+    storeInfo.setIncrementalPushEnabled(false);
+    storeInfo.setStorageQuotaInByte(1L);
+    storeInfo.setSchemaAutoRegisterFromPushJobEnabled(false);
+    storeInfo.setChunkingEnabled(false);
+    storeInfo.setCompressionStrategy(CompressionStrategy.NO_OP);
+    storeInfo.setWriteComputationEnabled(false);
+    storeInfo.setLeaderFollowerModelEnabled(false);
+    storeInfo.setIncrementalPushEnabled(false);
+
+    Version version = new VersionImpl(TEST_STORE, 0, TEST_PUSH);
+    storeInfo.setVersions(Collections.singletonList(version));
+    info.accept(storeInfo);
+    return storeInfo;
+  }
+}

--- a/clients/hadoop-to-venice-bridge/src/test/java/com/linkedin/venice/hadoop/TestVenicePushJobConfig.java
+++ b/clients/hadoop-to-venice-bridge/src/test/java/com/linkedin/venice/hadoop/TestVenicePushJobConfig.java
@@ -38,7 +38,7 @@ public class TestVenicePushJobConfig {
   @Test(expectedExceptions = VeniceException.class, expectedExceptionsMessageRegExp = ".*Repush with TTL is only supported while using Kafka input.*")
   public void testRepushTTLJobWithNonKafkaInput() {
     Properties repushProps = new Properties();
-    repushProps.put(VenicePushJob.REPUSH_TTL_IN_HOURS_OVERRIDE, 10L);
+    repushProps.put(VenicePushJob.REPUSH_TTL_IN_HOURS, 10L);
     VenicePushJob pushJob = getSpyVenicePushJob(Optional.of(repushProps), Optional.empty());
     pushJob.run();
   }
@@ -46,7 +46,7 @@ public class TestVenicePushJobConfig {
   @Test(expectedExceptions = VeniceException.class, expectedExceptionsMessageRegExp = ".*Chunking is not supported when using repush with ttl feature.*")
   public void testRepushTTLJobWithChunking() {
     Properties repushProps = new Properties();
-    repushProps.put(VenicePushJob.REPUSH_TTL_IN_HOURS_OVERRIDE, 10L);
+    repushProps.put(VenicePushJob.REPUSH_TTL_IN_HOURS, 10L);
     repushProps.setProperty(VenicePushJob.SOURCE_KAFKA, "true");
     repushProps.setProperty(VenicePushJob.KAFKA_INPUT_TOPIC, Version.composeKafkaTopic(TEST_STORE, 0));
     repushProps.setProperty(VenicePushJob.KAFKA_INPUT_BROKER_URL, "localhost");

--- a/clients/hadoop-to-venice-bridge/src/test/java/com/linkedin/venice/hadoop/TestVenicePushJobConfig.java
+++ b/clients/hadoop-to-venice-bridge/src/test/java/com/linkedin/venice/hadoop/TestVenicePushJobConfig.java
@@ -43,7 +43,7 @@ public class TestVenicePushJobConfig {
     pushJob.run();
   }
 
-  @Test(expectedExceptions = VeniceException.class, expectedExceptionsMessageRegExp = ".*Chunking is not supported when using repush with ttl feature.*")
+  @Test(expectedExceptions = VeniceException.class, expectedExceptionsMessageRegExp = ".*Repush TTL is not supported when the store has chunking enabled.*")
   public void testRepushTTLJobWithChunking() {
     Properties repushProps = new Properties();
     repushProps.put(VenicePushJob.REPUSH_TTL_IN_HOURS, 10L);

--- a/clients/hadoop-to-venice-bridge/src/test/java/com/linkedin/venice/hadoop/TestVenicePushJobConfig.java
+++ b/clients/hadoop-to-venice-bridge/src/test/java/com/linkedin/venice/hadoop/TestVenicePushJobConfig.java
@@ -35,7 +35,7 @@ public class TestVenicePushJobConfig {
   private static final String TEST_CLUSTER = "test_cluster";
   private static final String TEST_SERVICE = "test_venice";
 
-  @Test(expectedExceptions = VeniceException.class, expectedExceptionsMessageRegExp = ".*Repush with TTL is only supported while using Kafka input.*")
+  @Test(expectedExceptions = VeniceException.class, expectedExceptionsMessageRegExp = ".*Repush with TTL is only supported while using Kafka Input Format.*")
   public void testRepushTTLJobWithNonKafkaInput() {
     Properties repushProps = new Properties();
     repushProps.put(VenicePushJob.REPUSH_TTL_IN_HOURS, 10L);

--- a/clients/hadoop-to-venice-bridge/src/test/java/com/linkedin/venice/hadoop/TestVeniceVsonMapper.java
+++ b/clients/hadoop-to-venice-bridge/src/test/java/com/linkedin/venice/hadoop/TestVeniceVsonMapper.java
@@ -12,6 +12,7 @@ import com.linkedin.venice.schema.vson.VsonAvroSchemaAdapter;
 import com.linkedin.venice.schema.vson.VsonAvroSerializer;
 import com.linkedin.venice.serialization.avro.VeniceAvroKafkaSerializer;
 import com.linkedin.venice.utils.Pair;
+import com.linkedin.venice.utils.VeniceProperties;
 import java.io.IOException;
 import java.util.HashMap;
 import org.apache.avro.Schema;
@@ -109,6 +110,13 @@ public class TestVeniceVsonMapper extends AbstractTestVeniceMapper<VeniceVsonMap
     jobConf.set(FILE_VALUE_SCHEMA, fileValueSchemaStr);
 
     return jobConf;
+  }
+
+  @Test
+  public void testEmptyFilter() {
+    try (VeniceVsonMapper mapper = new VeniceVsonMapper()) {
+      Assert.assertFalse(mapper.getFilter(new VeniceProperties()).isPresent());
+    }
   }
 
   private Pair<BytesWritable, BytesWritable> generateRecord() {

--- a/clients/hadoop-to-venice-bridge/src/test/java/com/linkedin/venice/hadoop/input/kafka/TestVeniceKafkaInputMapper.java
+++ b/clients/hadoop-to-venice-bridge/src/test/java/com/linkedin/venice/hadoop/input/kafka/TestVeniceKafkaInputMapper.java
@@ -1,6 +1,6 @@
 package com.linkedin.venice.hadoop.input.kafka;
 
-import static com.linkedin.venice.hadoop.VenicePushJob.REPUSH_TTL_IN_HOURS_OVERRIDE;
+import static com.linkedin.venice.hadoop.VenicePushJob.REPUSH_TTL_IN_HOURS;
 import static com.linkedin.venice.hadoop.VenicePushJob.REPUSH_TTL_POLICY;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -59,7 +59,7 @@ public class TestVeniceKafkaInputMapper extends AbstractTestVeniceMapper<VeniceK
   @Test
   public void testValidFilterWhenTTLSpecified() {
     Properties props = new Properties();
-    props.put(REPUSH_TTL_IN_HOURS_OVERRIDE, 10L);
+    props.put(REPUSH_TTL_IN_HOURS, 10L);
     props.put(REPUSH_TTL_POLICY, 0);
     Assert.assertTrue(newMapper().getFilter(new VeniceProperties(props)).isPresent());
   }

--- a/clients/hadoop-to-venice-bridge/src/test/java/com/linkedin/venice/hadoop/input/kafka/TestVeniceKafkaInputMapper.java
+++ b/clients/hadoop-to-venice-bridge/src/test/java/com/linkedin/venice/hadoop/input/kafka/TestVeniceKafkaInputMapper.java
@@ -1,0 +1,107 @@
+package com.linkedin.venice.hadoop.input.kafka;
+
+import static com.linkedin.venice.hadoop.VenicePushJob.REPUSH_TTL_IN_HOURS_OVERRIDE;
+import static com.linkedin.venice.hadoop.VenicePushJob.REPUSH_TTL_POLICY;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.linkedin.venice.hadoop.AbstractTestVeniceMapper;
+import com.linkedin.venice.hadoop.input.kafka.avro.KafkaInputMapperValue;
+import com.linkedin.venice.hadoop.input.kafka.avro.MapperValueType;
+import com.linkedin.venice.utils.Pair;
+import com.linkedin.venice.utils.VeniceProperties;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Properties;
+import java.util.function.Consumer;
+import org.apache.hadoop.io.BytesWritable;
+import org.apache.hadoop.mapred.JobConf;
+import org.apache.hadoop.mapred.OutputCollector;
+import org.mockito.ArgumentCaptor;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class TestVeniceKafkaInputMapper extends AbstractTestVeniceMapper<VeniceKafkaInputMapper> {
+  private static final BytesWritable BYTES_WRITABLE = new BytesWritable(new byte[0]);
+  private static final String RMD = "rmd";
+
+  @Override
+  protected VeniceKafkaInputMapper newMapper() {
+    return new VeniceKafkaInputMapper();
+  }
+
+  @Test(dataProvider = MAPPER_PARAMS_DATA_PROVIDER)
+  public void testConfigure(int numReducers, int taskId) throws IOException {
+    JobConf job = setupJobConf(numReducers, taskId);
+    VeniceKafkaInputMapper mapper = getMapper(numReducers, taskId);
+    try {
+      mapper.configure(job);
+    } catch (Exception e) {
+      Assert.fail(
+          "VeniceKafkaInputMapper#configure should not throw any exception when all the required props are there");
+    }
+  }
+
+  @Test(expectedExceptions = UnsupportedOperationException.class)
+  public void testUnsupportedGetRecordReader() {
+    newMapper().getRecordReader(new VeniceProperties());
+  }
+
+  @Test
+  public void testEmptyFilterWhenTTLNotSpecified() {
+    try (VeniceKafkaInputMapper mapper = new VeniceKafkaInputMapper()) {
+      Assert.assertFalse(mapper.getFilter(new VeniceProperties()).isPresent());
+    }
+  }
+
+  @Test
+  public void testValidFilterWhenTTLSpecified() {
+    Properties props = new Properties();
+    props.put(REPUSH_TTL_IN_HOURS_OVERRIDE, 10L);
+    props.put(REPUSH_TTL_POLICY, 0);
+    Assert.assertTrue(newMapper().getFilter(new VeniceProperties(props)).isPresent());
+  }
+
+  @Test(dataProvider = MAPPER_PARAMS_DATA_PROVIDER)
+  public void testProcessWithoutFilter(int numReducers, int taskId) throws IOException {
+    VeniceKafkaInputMapper mapper = getMapper(numReducers, taskId);
+
+    ArgumentCaptor<BytesWritable> keyCaptor = ArgumentCaptor.forClass(BytesWritable.class);
+    ArgumentCaptor<BytesWritable> valueCaptor = ArgumentCaptor.forClass(BytesWritable.class);
+    OutputCollector<BytesWritable, BytesWritable> collector = mock(OutputCollector.class);
+
+    Pair<BytesWritable, KafkaInputMapperValue> record = generateRecord();
+    mapper.map(record.getFirst(), record.getSecond(), collector, null);
+
+    // Given there's no filter and all records are valid, collector should collect all key and value
+    verify(collector, times(getNumberOfCollectorInvocationForFirstMapInvocation(numReducers, taskId)))
+        .collect(keyCaptor.capture(), valueCaptor.capture());
+  }
+
+  @Test(dataProvider = MAPPER_PARAMS_DATA_PROVIDER)
+  public void testProcessWithFilterFilteringPartialRecords(int numReducers, int taskId) throws IOException {
+    // TODO implement this when VeniceKafkaInputTTLFilter is completed
+  }
+
+  @Test(dataProvider = MAPPER_PARAMS_DATA_PROVIDER)
+  public void testProcessWithFilterFilteringAllRecords(int numReducers, int taskId) throws IOException {
+    // TODO implement this when VeniceKafkaInputTTLFilter is completed
+  }
+
+  private Pair<BytesWritable, KafkaInputMapperValue> generateRecord() {
+    return generateRecord(value -> {});
+  }
+
+  private Pair<BytesWritable, KafkaInputMapperValue> generateRecord(Consumer<KafkaInputMapperValue> consumer) {
+    KafkaInputMapperValue value = new KafkaInputMapperValue();
+    value.offset = 0;
+    value.schemaId = -1;
+    value.valueType = MapperValueType.PUT;
+    value.replicationMetadataPayload = ByteBuffer.wrap(RMD.getBytes());
+    value.value = ByteBuffer.wrap(new byte[0]);
+    consumer.accept(value);
+    return new Pair<>(BYTES_WRITABLE, value);
+  }
+}

--- a/clients/hadoop-to-venice-bridge/src/test/java/com/linkedin/venice/hadoop/input/kafka/ttl/TestVeniceKafkaInputTTLFilter.java
+++ b/clients/hadoop-to-venice-bridge/src/test/java/com/linkedin/venice/hadoop/input/kafka/ttl/TestVeniceKafkaInputTTLFilter.java
@@ -41,13 +41,13 @@ public class TestVeniceKafkaInputTTLFilter {
   @Test(expectedExceptions = UnsupportedOperationException.class, expectedExceptionsMessageRegExp = ".*policy is not supported.*")
   public void testFilterWithUnsupportedPolicy() {
     KafkaInputMapperValue value = new KafkaInputMapperValue();
-    filterWithUnsupportedPolicy.filterRecursively(value);
+    filterWithUnsupportedPolicy.applyRecursively(value);
   }
 
   @Test
   public void testFilterWithRejectBatchWritePolicy() {
     KafkaInputMapperValue value = new KafkaInputMapperValue();
     // TODO change this once the implementation of REJECT_BATCH_WRITE is completed
-    Assert.assertFalse(filterWithSupportedPolicy.filterRecursively(value));
+    Assert.assertFalse(filterWithSupportedPolicy.applyRecursively(value));
   }
 }

--- a/clients/hadoop-to-venice-bridge/src/test/java/com/linkedin/venice/hadoop/input/kafka/ttl/TestVeniceKafkaInputTTLFilter.java
+++ b/clients/hadoop-to-venice-bridge/src/test/java/com/linkedin/venice/hadoop/input/kafka/ttl/TestVeniceKafkaInputTTLFilter.java
@@ -16,12 +16,12 @@ public class TestVeniceKafkaInputTTLFilter {
   @BeforeClass
   public void setUp() {
     Properties validProps = new Properties();
-    validProps.put(VenicePushJob.REPUSH_TTL_IN_HOURS_OVERRIDE, 10L);
+    validProps.put(VenicePushJob.REPUSH_TTL_IN_HOURS, 10L);
     validProps.put(VenicePushJob.REPUSH_TTL_POLICY, 0);
     VeniceProperties valid = new VeniceProperties(validProps);
 
     Properties invalidProps = new Properties();
-    invalidProps.put(VenicePushJob.REPUSH_TTL_IN_HOURS_OVERRIDE, 10L);
+    invalidProps.put(VenicePushJob.REPUSH_TTL_IN_HOURS, 10L);
     invalidProps.put(VenicePushJob.REPUSH_TTL_POLICY, 1);
     VeniceProperties invalid = new VeniceProperties(invalidProps);
 
@@ -41,13 +41,13 @@ public class TestVeniceKafkaInputTTLFilter {
   @Test(expectedExceptions = UnsupportedOperationException.class, expectedExceptionsMessageRegExp = ".*policy is not supported.*")
   public void testFilterWithUnsupportedPolicy() {
     KafkaInputMapperValue value = new KafkaInputMapperValue();
-    filterWithUnsupportedPolicy.processRecursively(value);
+    filterWithUnsupportedPolicy.filterRecursively(value);
   }
 
   @Test
   public void testFilterWithRejectBatchWritePolicy() {
     KafkaInputMapperValue value = new KafkaInputMapperValue();
     // TODO change this once the implementation of REJECT_BATCH_WRITE is completed
-    Assert.assertFalse(filterWithSupportedPolicy.processRecursively(value));
+    Assert.assertFalse(filterWithSupportedPolicy.filterRecursively(value));
   }
 }

--- a/clients/hadoop-to-venice-bridge/src/test/java/com/linkedin/venice/hadoop/input/kafka/ttl/TestVeniceKafkaInputTTLFilter.java
+++ b/clients/hadoop-to-venice-bridge/src/test/java/com/linkedin/venice/hadoop/input/kafka/ttl/TestVeniceKafkaInputTTLFilter.java
@@ -1,0 +1,53 @@
+package com.linkedin.venice.hadoop.input.kafka.ttl;
+
+import com.linkedin.venice.hadoop.VenicePushJob;
+import com.linkedin.venice.hadoop.input.kafka.avro.KafkaInputMapperValue;
+import com.linkedin.venice.utils.VeniceProperties;
+import java.util.Properties;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+
+public class TestVeniceKafkaInputTTLFilter {
+  VeniceKafkaInputTTLFilter filterWithSupportedPolicy;
+  VeniceKafkaInputTTLFilter filterWithUnsupportedPolicy;
+
+  @BeforeClass
+  public void setUp() {
+    Properties validProps = new Properties();
+    validProps.put(VenicePushJob.REPUSH_TTL_IN_HOURS_OVERRIDE, 10L);
+    validProps.put(VenicePushJob.REPUSH_TTL_POLICY, 0);
+    VeniceProperties valid = new VeniceProperties(validProps);
+
+    Properties invalidProps = new Properties();
+    invalidProps.put(VenicePushJob.REPUSH_TTL_IN_HOURS_OVERRIDE, 10L);
+    invalidProps.put(VenicePushJob.REPUSH_TTL_POLICY, 1);
+    VeniceProperties invalid = new VeniceProperties(invalidProps);
+
+    this.filterWithSupportedPolicy = new VeniceKafkaInputTTLFilter(valid);
+    this.filterWithUnsupportedPolicy = new VeniceKafkaInputTTLFilter(invalid);
+  }
+
+  @Test
+  public void testFilterChain() {
+    filterWithSupportedPolicy.setNext(filterWithUnsupportedPolicy);
+    Assert.assertTrue(filterWithSupportedPolicy.hasNext());
+    Assert.assertEquals(filterWithSupportedPolicy.next(), filterWithUnsupportedPolicy);
+    Assert.assertFalse(filterWithUnsupportedPolicy.hasNext());
+    filterWithSupportedPolicy.setNext(null);
+  }
+
+  @Test(expectedExceptions = UnsupportedOperationException.class, expectedExceptionsMessageRegExp = ".*policy is not supported.*")
+  public void testFilterWithUnsupportedPolicy() {
+    KafkaInputMapperValue value = new KafkaInputMapperValue();
+    filterWithUnsupportedPolicy.processRecursively(value);
+  }
+
+  @Test
+  public void testFilterWithRejectBatchWritePolicy() {
+    KafkaInputMapperValue value = new KafkaInputMapperValue();
+    // TODO change this once the implementation of REJECT_BATCH_WRITE is completed
+    Assert.assertFalse(filterWithSupportedPolicy.processRecursively(value));
+  }
+}


### PR DESCRIPTION
## Description
This commit introduces two new config REPUSH_TTL_IN_HOURS and REPUSH_TTL_POLICY. They are used in conjunction to apply corresponding TTL logic to records. Note that as for now, we only support one REPUSH_TTL_POLICY so its value is hardcoded.

The TTL filter uses the chain of responsibility pattern so we can introduce more filters to the Mapper stage. TTL filter also comes with 3 policies w.r.t batch writes. The core implementation will be added in a separate commit.

## How was this PR tested?
unit tests and integration tests

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [x] Yes. Make sure to explain your proposed changes and call out the behavior change.
Users now can specify the ttl time in hours in the repush job. When the config is specified, the filter will be present during H2V mapper stage. Currently, this filter doesn't do anything but allowing everything flow thru. Its implementation will be introduce in a different PR.