### PR TITLE
[test] ServiceFactory::getVeniceParentController cleanup

### DIFF
--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/controller/TestControllerEnforceSSL.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/controller/TestControllerEnforceSSL.java
@@ -9,6 +9,7 @@ import com.linkedin.venice.controllerapi.StoreResponse;
 import com.linkedin.venice.controllerapi.UpdateStoreQueryParams;
 import com.linkedin.venice.integration.utils.KafkaBrokerWrapper;
 import com.linkedin.venice.integration.utils.ServiceFactory;
+import com.linkedin.venice.integration.utils.VeniceControllerCreateOptions;
 import com.linkedin.venice.integration.utils.VeniceControllerWrapper;
 import com.linkedin.venice.integration.utils.ZkServerWrapper;
 import com.linkedin.venice.utils.SslUtils;
@@ -38,17 +39,14 @@ public class TestControllerEnforceSSL {
 
     try (ZkServerWrapper zkServer = ServiceFactory.getZkServer();
         KafkaBrokerWrapper kafkaBrokerWrapper = ServiceFactory.getKafkaBroker(zkServer);
-        VeniceControllerWrapper controllerWrapper = ServiceFactory.getVeniceChildController(
-            new String[] { CLUSTER_NAME },
-            kafkaBrokerWrapper,
-            1,
-            10,
-            0,
-            1,
-            null,
-            true,
-            false,
-            extraProperties);
+        VeniceControllerWrapper controllerWrapper = ServiceFactory.getVeniceController(
+            new VeniceControllerCreateOptions.Builder(CLUSTER_NAME, kafkaBrokerWrapper).replicationFactor(1)
+                .partitionSize(10)
+                .rebalanceDelayMs(0)
+                .minActiveReplica(1)
+                .sslToKafka(true)
+                .extraProperties(extraProperties)
+                .build());
         ControllerClient controllerClient =
             ControllerClient.constructClusterControllerClient(CLUSTER_NAME, controllerWrapper.getControllerUrl());
         ControllerClient secureControllerClient = ControllerClient.constructClusterControllerClient(

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/controller/TestD2ControllerClient.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/controller/TestD2ControllerClient.java
@@ -8,13 +8,13 @@ import com.linkedin.venice.controllerapi.StoreResponse;
 import com.linkedin.venice.integration.utils.D2TestUtils;
 import com.linkedin.venice.integration.utils.KafkaBrokerWrapper;
 import com.linkedin.venice.integration.utils.ServiceFactory;
+import com.linkedin.venice.integration.utils.VeniceControllerCreateOptions;
 import com.linkedin.venice.integration.utils.VeniceControllerWrapper;
 import com.linkedin.venice.integration.utils.ZkServerWrapper;
 import com.linkedin.venice.utils.Time;
 import com.linkedin.venice.utils.Utils;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.util.Properties;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -27,17 +27,14 @@ public class TestD2ControllerClient {
     D2Client d2Client = null;
     try (ZkServerWrapper zkServer = ServiceFactory.getZkServer();
         KafkaBrokerWrapper kafkaBrokerWrapper = ServiceFactory.getKafkaBroker(zkServer);
-        VeniceControllerWrapper controllerWrapper = ServiceFactory.getVeniceChildController(
-            new String[] { CLUSTER_NAME },
-            kafkaBrokerWrapper,
-            1,
-            10,
-            0,
-            1,
-            null,
-            true,
-            true,
-            new Properties())) {
+        VeniceControllerWrapper controllerWrapper = ServiceFactory.getVeniceController(
+            new VeniceControllerCreateOptions.Builder(CLUSTER_NAME, kafkaBrokerWrapper).replicationFactor(1)
+                .partitionSize(10)
+                .rebalanceDelayMs(0)
+                .minActiveReplica(1)
+                .sslToKafka(true)
+                .d2Enabled(true)
+                .build())) {
       String zkAddress = kafkaBrokerWrapper.getZkAddress();
       D2TestUtils.setupD2Config(
           zkAddress,

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/controller/VeniceParentHelixAdminTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/controller/VeniceParentHelixAdminTest.java
@@ -91,7 +91,6 @@ public class VeniceParentHelixAdminTest {
                 .childControllers(new VeniceControllerWrapper[] { venice.getLeaderVeniceController() })
                 .zkAddress(zkServerWrapper.getAddress())
                 .extraProperties(properties)
-                .parent(true)
                 .build());
         ControllerClient parentControllerClient =
             new ControllerClient(venice.getClusterName(), parentController.getControllerUrl())) {
@@ -122,7 +121,6 @@ public class VeniceParentHelixAdminTest {
                 .childControllers(new VeniceControllerWrapper[] { venice.getLeaderVeniceController() })
                 .zkAddress(zkServerWrapper.getAddress())
                 .extraProperties(properties)
-                .parent(true)
                 .build());
         ControllerClient parentControllerClient =
             new ControllerClient(venice.getClusterName(), parentControllerWrapper.getControllerUrl())) {
@@ -245,7 +243,6 @@ public class VeniceParentHelixAdminTest {
                 .childControllers(new VeniceControllerWrapper[] { venice.getLeaderVeniceController() })
                 .zkAddress(zkServerWrapper.getAddress())
                 .extraProperties(properties)
-                .parent(true)
                 .build());
         ControllerClient parentControllerClient =
             new ControllerClient(venice.getClusterName(), parentController.getControllerUrl())) {
@@ -305,7 +302,6 @@ public class VeniceParentHelixAdminTest {
     try (VeniceControllerWrapper parentControllerWrapper = ServiceFactory.getVeniceController(
         new VeniceControllerCreateOptions.Builder(venice.getClusterName(), venice.getKafka())
             .childControllers(new VeniceControllerWrapper[] { venice.getLeaderVeniceController() })
-            .parent(true)
             .zkAddress(zkServerWrapper.getAddress())
             .build())) {
       String controllerUrl = parentControllerWrapper.getControllerUrl();
@@ -411,7 +407,6 @@ public class VeniceParentHelixAdminTest {
                 .childControllers(new VeniceControllerWrapper[] { childControllerWrapper })
                 .zkAddress(parentZk.getAddress())
                 .extraProperties(properties)
-                .parent(true)
                 .sslToKafka(isControllerSslEnabled)
                 .build())) {
       String childControllerUrl = isControllerSslEnabled

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/DaVinciClusterAgnosticTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/DaVinciClusterAgnosticTest.java
@@ -105,7 +105,6 @@ public class DaVinciClusterAgnosticTest {
     VeniceControllerCreateOptions controllerCreateOptions =
         new VeniceControllerCreateOptions.Builder(clusterNames, multiClusterVenice.getKafkaBrokerWrapper())
             .zkAddress(zkServer.getAddress())
-            .parent(true)
             .replicationFactor(3)
             .childControllers(childControllers.toArray(new VeniceControllerWrapper[0]))
             .extraProperties(testProperties)

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/DaVinciClusterAgnosticTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/DaVinciClusterAgnosticTest.java
@@ -25,6 +25,7 @@ import com.linkedin.venice.controllerapi.ControllerClient;
 import com.linkedin.venice.controllerapi.VersionCreationResponse;
 import com.linkedin.venice.integration.utils.D2TestUtils;
 import com.linkedin.venice.integration.utils.ServiceFactory;
+import com.linkedin.venice.integration.utils.VeniceControllerCreateOptions;
 import com.linkedin.venice.integration.utils.VeniceControllerWrapper;
 import com.linkedin.venice.integration.utils.VeniceMultiClusterCreateOptions;
 import com.linkedin.venice.integration.utils.VeniceMultiClusterWrapper;
@@ -42,7 +43,6 @@ import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.Optional;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.IntStream;
@@ -102,16 +102,16 @@ public class DaVinciClusterAgnosticTest {
     multiClusterVenice = ServiceFactory.getVeniceMultiClusterWrapper(options);
     clusterNames = multiClusterVenice.getClusterNames();
     Collection<VeniceControllerWrapper> childControllers = multiClusterVenice.getControllers().values();
-    parentController = ServiceFactory.getVeniceParentController(
-        clusterNames,
-        zkServer.getAddress(),
-        multiClusterVenice.getKafkaBrokerWrapper(),
-        childControllers.toArray(new VeniceControllerWrapper[0]),
-        multiClusterVenice.getClusterToD2(),
-        false,
-        3,
-        new VeniceProperties(testProperties),
-        Optional.empty());
+    VeniceControllerCreateOptions controllerCreateOptions =
+        new VeniceControllerCreateOptions.Builder(clusterNames, multiClusterVenice.getKafkaBrokerWrapper())
+            .zkAddress(zkServer.getAddress())
+            .parent(true)
+            .replicationFactor(3)
+            .childControllers(childControllers.toArray(new VeniceControllerWrapper[0]))
+            .extraProperties(testProperties)
+            .clusterToD2(multiClusterVenice.getClusterToD2())
+            .build();
+    parentController = ServiceFactory.getVeniceController(controllerCreateOptions);
     for (String cluster: clusterNames) {
       try (ControllerClient controllerClient =
           new ControllerClient(cluster, multiClusterVenice.getLeaderController(cluster).getControllerUrl())) {

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/MetaSystemStoreTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/MetaSystemStoreTest.java
@@ -41,6 +41,7 @@ import com.linkedin.venice.exceptions.VeniceNoStoreException;
 import com.linkedin.venice.integration.utils.D2TestUtils;
 import com.linkedin.venice.integration.utils.ServiceFactory;
 import com.linkedin.venice.integration.utils.VeniceClusterWrapper;
+import com.linkedin.venice.integration.utils.VeniceControllerCreateOptions;
 import com.linkedin.venice.integration.utils.VeniceControllerWrapper;
 import com.linkedin.venice.integration.utils.ZkServerWrapper;
 import com.linkedin.venice.meta.PersistenceType;
@@ -105,13 +106,13 @@ public class MetaSystemStoreTest {
     venice = ServiceFactory.getVeniceCluster(1, 2, 1, 2, 1000000, false, false);
     controllerClient = venice.getControllerClient();
     parentZkServer = ServiceFactory.getZkServer();
-    parentController = ServiceFactory.getVeniceParentController(
-        venice.getClusterName(),
-        parentZkServer.getAddress(),
-        venice.getKafka(),
-        venice.getVeniceControllers().toArray(new VeniceControllerWrapper[0]),
-        new VeniceProperties(testProperties),
-        false);
+    parentController = ServiceFactory.getVeniceController(
+        new VeniceControllerCreateOptions.Builder(venice.getClusterName(), venice.getKafka())
+            .childControllers(venice.getVeniceControllers().toArray(new VeniceControllerWrapper[0]))
+            .parent(true)
+            .extraProperties(testProperties)
+            .zkAddress(parentZkServer.getAddress())
+            .build());
   }
 
   @AfterClass

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/MetaSystemStoreTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/MetaSystemStoreTest.java
@@ -109,7 +109,6 @@ public class MetaSystemStoreTest {
     parentController = ServiceFactory.getVeniceController(
         new VeniceControllerCreateOptions.Builder(venice.getClusterName(), venice.getKafka())
             .childControllers(venice.getVeniceControllers().toArray(new VeniceControllerWrapper[0]))
-            .parent(true)
             .extraProperties(testProperties)
             .zkAddress(parentZkServer.getAddress())
             .build());

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/ParticipantStoreTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/ParticipantStoreTest.java
@@ -91,7 +91,6 @@ public class ParticipantStoreTest {
             .childControllers(venice.getVeniceControllers().toArray(new VeniceControllerWrapper[0]))
             .zkAddress(parentZk.getAddress())
             .extraProperties(controllerConfig)
-            .parent(true)
             .build());
     participantMessageStoreName = VeniceSystemStoreUtils.getParticipantStoreNameForCluster(venice.getClusterName());
     controllerClient = venice.getControllerClient();

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/ParticipantStoreTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/ParticipantStoreTest.java
@@ -23,6 +23,7 @@ import com.linkedin.venice.controllerapi.VersionCreationResponse;
 import com.linkedin.venice.integration.utils.D2TestUtils;
 import com.linkedin.venice.integration.utils.ServiceFactory;
 import com.linkedin.venice.integration.utils.VeniceClusterWrapper;
+import com.linkedin.venice.integration.utils.VeniceControllerCreateOptions;
 import com.linkedin.venice.integration.utils.VeniceControllerWrapper;
 import com.linkedin.venice.integration.utils.VeniceRouterWrapper;
 import com.linkedin.venice.integration.utils.VeniceServerWrapper;
@@ -39,7 +40,6 @@ import com.linkedin.venice.pushmonitor.ExecutionStatus;
 import com.linkedin.venice.utils.TestUtils;
 import com.linkedin.venice.utils.Time;
 import com.linkedin.venice.utils.Utils;
-import com.linkedin.venice.utils.VeniceProperties;
 import io.tehuti.Metric;
 import java.util.Map;
 import java.util.Optional;
@@ -86,13 +86,13 @@ public class ParticipantStoreTest {
     serverProperties.setProperty(PARTICIPANT_MESSAGE_CONSUMPTION_DELAY_MS, Long.toString(100));
     veniceServerWrapper = venice.addVeniceServer(serverFeatureProperties, serverProperties);
     parentZk = ServiceFactory.getZkServer();
-    parentController = ServiceFactory.getVeniceParentController(
-        venice.getClusterName(),
-        parentZk.getAddress(),
-        venice.getKafka(),
-        venice.getVeniceControllers().toArray(new VeniceControllerWrapper[0]),
-        new VeniceProperties(controllerConfig),
-        false);
+    parentController = ServiceFactory.getVeniceController(
+        new VeniceControllerCreateOptions.Builder(venice.getClusterName(), venice.getKafka())
+            .childControllers(venice.getVeniceControllers().toArray(new VeniceControllerWrapper[0]))
+            .zkAddress(parentZk.getAddress())
+            .extraProperties(controllerConfig)
+            .parent(true)
+            .build());
     participantMessageStoreName = VeniceSystemStoreUtils.getParticipantStoreNameForCluster(venice.getClusterName());
     controllerClient = venice.getControllerClient();
     parentControllerClient = new ControllerClient(venice.getClusterName(), parentController.getControllerUrl());

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/PushJobDetailsTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/PushJobDetailsTest.java
@@ -43,6 +43,7 @@ import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.hadoop.VenicePushJob;
 import com.linkedin.venice.integration.utils.ServiceFactory;
 import com.linkedin.venice.integration.utils.VeniceClusterWrapper;
+import com.linkedin.venice.integration.utils.VeniceControllerCreateOptions;
 import com.linkedin.venice.integration.utils.VeniceControllerWrapper;
 import com.linkedin.venice.integration.utils.ZkServerWrapper;
 import com.linkedin.venice.meta.Version;
@@ -54,7 +55,6 @@ import com.linkedin.venice.status.protocol.PushJobStatusRecordKey;
 import com.linkedin.venice.utils.TestUtils;
 import com.linkedin.venice.utils.Time;
 import com.linkedin.venice.utils.Utils;
-import com.linkedin.venice.utils.VeniceProperties;
 import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
@@ -98,13 +98,13 @@ public class PushJobDetailsTest {
     controllerProperties.setProperty(ENABLE_LEADER_FOLLOWER_AS_DEFAULT_FOR_ALL_STORES, "true");
     controllerProperties.setProperty(ENABLE_ACTIVE_ACTIVE_REPLICATION_AS_DEFAULT_FOR_HYBRID_STORE, "true");
     controllerProperties.setProperty(ENABLE_ACTIVE_ACTIVE_REPLICATION_AS_DEFAULT_FOR_BATCH_ONLY_STORE, "true");
-    parentController = ServiceFactory.getVeniceParentController(
-        venice.getClusterName(),
-        zkWrapper.getAddress(),
-        venice.getKafka(),
-        new VeniceControllerWrapper[] { venice.getLeaderVeniceController() },
-        new VeniceProperties(controllerProperties),
-        false);
+    parentController = ServiceFactory.getVeniceController(
+        new VeniceControllerCreateOptions.Builder(venice.getClusterName(), venice.getKafka())
+            .childControllers(new VeniceControllerWrapper[] { venice.getLeaderVeniceController() })
+            .extraProperties(controllerProperties)
+            .parent(true)
+            .zkAddress(zkWrapper.getAddress())
+            .build());
     parentControllerClient = new ControllerClient(venice.getClusterName(), parentController.getControllerUrl());
     venice.useControllerClient(
         controllerClient -> TestUtils.waitForNonDeterministicPushCompletion(

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/PushJobDetailsTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/PushJobDetailsTest.java
@@ -102,7 +102,6 @@ public class PushJobDetailsTest {
         new VeniceControllerCreateOptions.Builder(venice.getClusterName(), venice.getKafka())
             .childControllers(new VeniceControllerWrapper[] { venice.getLeaderVeniceController() })
             .extraProperties(controllerProperties)
-            .parent(true)
             .zkAddress(zkWrapper.getAddress())
             .build());
     parentControllerClient = new ControllerClient(venice.getClusterName(), parentController.getControllerUrl());

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/PushStatusStoreTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/PushStatusStoreTest.java
@@ -104,7 +104,6 @@ public class PushStatusStoreTest {
             .childControllers(cluster.getVeniceControllers().toArray(new VeniceControllerWrapper[0]))
             .extraProperties(extraProperties)
             .zkAddress(parentZkServer.getAddress())
-            .parent(true)
             .build());
   }
 

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/PushStatusStoreTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/PushStatusStoreTest.java
@@ -39,6 +39,7 @@ import com.linkedin.venice.integration.utils.D2TestUtils;
 import com.linkedin.venice.integration.utils.DaVinciTestContext;
 import com.linkedin.venice.integration.utils.ServiceFactory;
 import com.linkedin.venice.integration.utils.VeniceClusterWrapper;
+import com.linkedin.venice.integration.utils.VeniceControllerCreateOptions;
 import com.linkedin.venice.integration.utils.VeniceControllerWrapper;
 import com.linkedin.venice.integration.utils.ZkServerWrapper;
 import com.linkedin.venice.meta.Store;
@@ -98,13 +99,13 @@ public class PushStatusStoreTest {
     reader = new PushStatusStoreReader(d2Client, TimeUnit.MINUTES.toSeconds(10));
     extraProperties.setProperty(CONTROLLER_AUTO_MATERIALIZE_DAVINCI_PUSH_STATUS_SYSTEM_STORE, String.valueOf(true));
     parentZkServer = ServiceFactory.getZkServer();
-    parentController = ServiceFactory.getVeniceParentController(
-        cluster.getClusterName(),
-        parentZkServer.getAddress(),
-        cluster.getKafka(),
-        cluster.getVeniceControllers().toArray(new VeniceControllerWrapper[0]),
-        new VeniceProperties(extraProperties),
-        false);
+    parentController = ServiceFactory.getVeniceController(
+        new VeniceControllerCreateOptions.Builder(cluster.getClusterName(), cluster.getKafka())
+            .childControllers(cluster.getVeniceControllers().toArray(new VeniceControllerWrapper[0]))
+            .extraProperties(extraProperties)
+            .zkAddress(parentZkServer.getAddress())
+            .parent(true)
+            .build());
   }
 
   @AfterClass

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/StoragePersonaTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/StoragePersonaTest.java
@@ -16,6 +16,7 @@ import com.linkedin.venice.controllerapi.UpdateStoreQueryParams;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.integration.utils.ServiceFactory;
 import com.linkedin.venice.integration.utils.VeniceClusterWrapper;
+import com.linkedin.venice.integration.utils.VeniceControllerCreateOptions;
 import com.linkedin.venice.integration.utils.VeniceControllerWrapper;
 import com.linkedin.venice.integration.utils.ZkServerWrapper;
 import com.linkedin.venice.meta.Store;
@@ -49,12 +50,12 @@ public class StoragePersonaTest {
     Properties extraProperties = new Properties();
     venice = ServiceFactory.getVeniceCluster(1, 1, 1, 2, 1000000, false, false, extraProperties);
     parentZk = ServiceFactory.getZkServer();
-    parentController = ServiceFactory.getVeniceParentController(
-        venice.getClusterName(),
-        parentZk.getAddress(),
-        venice.getKafka(),
-        new VeniceControllerWrapper[] { venice.getLeaderVeniceController() },
-        false);
+    parentController = ServiceFactory.getVeniceController(
+        new VeniceControllerCreateOptions.Builder(venice.getClusterName(), venice.getKafka())
+            .childControllers(new VeniceControllerWrapper[] { venice.getLeaderVeniceController() })
+            .parent(true)
+            .zkAddress(parentZk.getAddress())
+            .build());
     controllerClient = new ControllerClient(venice.getClusterName(), parentController.getControllerUrl());
   }
 

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/StoragePersonaTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/StoragePersonaTest.java
@@ -53,7 +53,6 @@ public class StoragePersonaTest {
     parentController = ServiceFactory.getVeniceController(
         new VeniceControllerCreateOptions.Builder(venice.getClusterName(), venice.getKafka())
             .childControllers(new VeniceControllerWrapper[] { venice.getLeaderVeniceController() })
-            .parent(true)
             .zkAddress(parentZk.getAddress())
             .build());
     controllerClient = new ControllerClient(venice.getClusterName(), parentController.getControllerUrl());

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestHybrid.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestHybrid.java
@@ -54,6 +54,7 @@ import com.linkedin.venice.hadoop.VenicePushJob;
 import com.linkedin.venice.helix.HelixBaseRoutingRepository;
 import com.linkedin.venice.integration.utils.ServiceFactory;
 import com.linkedin.venice.integration.utils.VeniceClusterWrapper;
+import com.linkedin.venice.integration.utils.VeniceControllerCreateOptions;
 import com.linkedin.venice.integration.utils.VeniceControllerWrapper;
 import com.linkedin.venice.integration.utils.VeniceServerWrapper;
 import com.linkedin.venice.integration.utils.ZkServerWrapper;
@@ -170,12 +171,12 @@ public class TestHybrid {
         VeniceClusterWrapper venice =
             ServiceFactory.getVeniceCluster(1, 2, 1, 1, 1000000, false, false, extraProperties);
         ZkServerWrapper parentZk = ServiceFactory.getZkServer();
-        VeniceControllerWrapper parentController = ServiceFactory.getVeniceParentController(
-            venice.getClusterName(),
-            parentZk.getAddress(),
-            venice.getKafka(),
-            new VeniceControllerWrapper[] { venice.getLeaderVeniceController() },
-            false);
+        VeniceControllerWrapper parentController = ServiceFactory.getVeniceController(
+            new VeniceControllerCreateOptions.Builder(venice.getClusterName(), venice.getKafka())
+                .childControllers(new VeniceControllerWrapper[] { venice.getLeaderVeniceController() })
+                .parent(true)
+                .zkAddress(parentZk.getAddress())
+                .build());
         ControllerClient controllerClient =
             new ControllerClient(venice.getClusterName(), parentController.getControllerUrl());
         TopicManager topicManager = new TopicManager(

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestHybrid.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestHybrid.java
@@ -174,7 +174,6 @@ public class TestHybrid {
         VeniceControllerWrapper parentController = ServiceFactory.getVeniceController(
             new VeniceControllerCreateOptions.Builder(venice.getClusterName(), venice.getKafka())
                 .childControllers(new VeniceControllerWrapper[] { venice.getLeaderVeniceController() })
-                .parent(true)
                 .zkAddress(parentZk.getAddress())
                 .build());
         ControllerClient controllerClient =

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestStoreUpdateStoragePersona.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestStoreUpdateStoragePersona.java
@@ -42,7 +42,6 @@ public class TestStoreUpdateStoragePersona {
         new VeniceControllerCreateOptions.Builder(venice.getClusterName(), venice.getKafka())
             .childControllers(new VeniceControllerWrapper[] { venice.getLeaderVeniceController() })
             .zkAddress(parentZk.getAddress())
-            .parent(true)
             .build());
     controllerClient = new ControllerClient(venice.getClusterName(), parentController.getControllerUrl());
   }

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestStoreUpdateStoragePersona.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestStoreUpdateStoragePersona.java
@@ -8,6 +8,7 @@ import com.linkedin.venice.controllerapi.UpdateStoreQueryParams;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.integration.utils.ServiceFactory;
 import com.linkedin.venice.integration.utils.VeniceClusterWrapper;
+import com.linkedin.venice.integration.utils.VeniceControllerCreateOptions;
 import com.linkedin.venice.integration.utils.VeniceControllerWrapper;
 import com.linkedin.venice.integration.utils.ZkServerWrapper;
 import com.linkedin.venice.meta.Store;
@@ -37,12 +38,12 @@ public class TestStoreUpdateStoragePersona {
     Properties extraProperties = new Properties();
     venice = ServiceFactory.getVeniceCluster(1, 1, 1, 2, 1000000, false, false, extraProperties);
     parentZk = ServiceFactory.getZkServer();
-    parentController = ServiceFactory.getVeniceParentController(
-        venice.getClusterName(),
-        parentZk.getAddress(),
-        venice.getKafka(),
-        new VeniceControllerWrapper[] { venice.getLeaderVeniceController() },
-        false);
+    parentController = ServiceFactory.getVeniceController(
+        new VeniceControllerCreateOptions.Builder(venice.getClusterName(), venice.getKafka())
+            .childControllers(new VeniceControllerWrapper[] { venice.getLeaderVeniceController() })
+            .zkAddress(parentZk.getAddress())
+            .parent(true)
+            .build());
     controllerClient = new ControllerClient(venice.getClusterName(), parentController.getControllerUrl());
   }
 

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/kafka/ssl/AdminChannelWithSSLTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/kafka/ssl/AdminChannelWithSSLTest.java
@@ -37,8 +37,7 @@ public class AdminChannelWithSSLTest {
         ZkServerWrapper parentZk = ServiceFactory.getZkServer();
 
         VeniceControllerWrapper controllerWrapper = ServiceFactory.getVeniceController(
-            new VeniceControllerCreateOptions.Builder(clusterName, kafkaBrokerWrapper).parent(true)
-                .zkAddress(parentZk.getAddress())
+            new VeniceControllerCreateOptions.Builder(clusterName, kafkaBrokerWrapper).zkAddress(parentZk.getAddress())
                 .childControllers(new VeniceControllerWrapper[] { childControllerWrapper })
                 .sslToKafka(true)
                 .build())) {

--- a/internal/venice-test-common/src/main/java/com/linkedin/venice/integration/utils/ServiceFactory.java
+++ b/internal/venice-test-common/src/main/java/com/linkedin/venice/integration/utils/ServiceFactory.java
@@ -125,8 +125,11 @@ public class ServiceFactory {
         KafkaBrokerWrapper.generateService(zkServerWrapper, mockTime));
   }
 
-  public static VeniceControllerWrapper getVeniceController(VeniceControllerCreateOptions options) {
-    return getStatefulService(VeniceControllerWrapper.SERVICE_NAME, VeniceControllerWrapper.generateService(options));
+  // to get parent controller, add child controllers to controllerCreateOptions
+  public static VeniceControllerWrapper getVeniceController(VeniceControllerCreateOptions controllerCreateOptions) {
+    return getStatefulService(
+        VeniceControllerWrapper.SERVICE_NAME,
+        VeniceControllerWrapper.generateService(controllerCreateOptions));
   }
 
   public static AdminSparkServer getMockAdminSparkServer(

--- a/internal/venice-test-common/src/main/java/com/linkedin/venice/integration/utils/VeniceClusterWrapper.java
+++ b/internal/venice-test-common/src/main/java/com/linkedin/venice/integration/utils/VeniceClusterWrapper.java
@@ -192,17 +192,17 @@ public class VeniceClusterWrapper extends ProcessWrapper {
               .setStoreName("dummy");
           options.getExtraProperties().put(CLIENT_CONFIG_FOR_CONSUMER, clientConfig);
         }
-        VeniceControllerWrapper veniceControllerWrapper = ServiceFactory.getVeniceChildController(
-            new String[] { options.getClusterName() },
-            kafkaBrokerWrapper,
-            options.getReplicationFactor(),
-            options.getPartitionSize(),
-            options.getRebalanceDelayMs(),
-            options.getMinActiveReplica(),
-            options.getClusterToD2(),
-            options.isSslToKafka(),
-            true,
-            options.getExtraProperties());
+        VeniceControllerWrapper veniceControllerWrapper = ServiceFactory.getVeniceController(
+            new VeniceControllerCreateOptions.Builder(options.getClusterName(), kafkaBrokerWrapper)
+                .replicationFactor(options.getReplicationFactor())
+                .partitionSize(options.getPartitionSize())
+                .rebalanceDelayMs(options.getRebalanceDelayMs())
+                .minActiveReplica(options.getMinActiveReplica())
+                .clusterToD2(options.getClusterToD2())
+                .sslToKafka(options.isSslToKafka())
+                .d2Enabled(true)
+                .extraProperties(options.getExtraProperties())
+                .build());
         veniceControllerWrappers.put(veniceControllerWrapper.getPort(), veniceControllerWrapper);
       }
 
@@ -474,17 +474,15 @@ public class VeniceClusterWrapper extends ProcessWrapper {
   }
 
   public VeniceControllerWrapper addVeniceController(Properties properties) {
-    VeniceControllerWrapper veniceControllerWrapper = ServiceFactory.getVeniceChildController(
-        new String[] { clusterName },
-        kafkaBrokerWrapper,
-        defaultReplicaFactor,
-        defaultPartitionSize,
-        defaultDelayToRebalanceMS,
-        defaultMinActiveReplica,
-        null,
-        sslToKafka,
-        false,
-        properties);
+    VeniceControllerWrapper veniceControllerWrapper = ServiceFactory.getVeniceController(
+        new VeniceControllerCreateOptions.Builder(clusterName, kafkaBrokerWrapper)
+            .replicationFactor(defaultReplicaFactor)
+            .partitionSize(defaultPartitionSize)
+            .rebalanceDelayMs(defaultDelayToRebalanceMS)
+            .minActiveReplica(defaultMinActiveReplica)
+            .sslToKafka(sslToKafka)
+            .extraProperties(properties)
+            .build());
     synchronized (this) {
       veniceControllerWrappers.put(veniceControllerWrapper.getPort(), veniceControllerWrapper);
       setExternalControllerDiscoveryURL(

--- a/internal/venice-test-common/src/main/java/com/linkedin/venice/integration/utils/VeniceControllerCreateOptions.java
+++ b/internal/venice-test-common/src/main/java/com/linkedin/venice/integration/utils/VeniceControllerCreateOptions.java
@@ -1,0 +1,291 @@
+package com.linkedin.venice.integration.utils;
+
+import static com.linkedin.venice.ConfigKeys.CONTROLLER_AUTO_MATERIALIZE_DAVINCI_PUSH_STATUS_SYSTEM_STORE;
+import static com.linkedin.venice.ConfigKeys.CONTROLLER_AUTO_MATERIALIZE_META_SYSTEM_STORE;
+import static com.linkedin.venice.ConfigKeys.LOCAL_REGION_NAME;
+import static com.linkedin.venice.integration.utils.VeniceClusterWrapperConstants.DEFAULT_DELAYED_TO_REBALANCE_MS;
+import static com.linkedin.venice.integration.utils.VeniceClusterWrapperConstants.DEFAULT_PARTITION_SIZE_BYTES;
+import static com.linkedin.venice.integration.utils.VeniceClusterWrapperConstants.DEFAULT_REPLICATION_FACTOR;
+import static com.linkedin.venice.integration.utils.VeniceControllerWrapper.*;
+
+import com.linkedin.venice.authorization.AuthorizerService;
+import java.util.Arrays;
+import java.util.Properties;
+import java.util.stream.Collectors;
+import org.apache.commons.lang.Validate;
+
+
+public class VeniceControllerCreateOptions {
+  private final boolean isParent;
+  private final boolean sslToKafka;
+  private final boolean d2Enabled;
+  private final int replicationFactor;
+  private final int partitionSize;
+  private final int minActiveReplica;
+  private final long rebalanceDelayMs;
+  private final String[] clusterNames;
+  private final String zkAddress;
+  private final String clusterToD2;
+  private final VeniceControllerWrapper[] childControllers;
+  private final KafkaBrokerWrapper kafkaBroker;
+  private final Properties extraProperties;
+  private final AuthorizerService authorizerService;
+
+  private VeniceControllerCreateOptions(Builder builder) {
+    isParent = builder.isParent;
+    sslToKafka = builder.sslToKafka;
+    d2Enabled = builder.d2Enabled;
+    replicationFactor = builder.replicationFactor;
+    partitionSize = builder.partitionSize;
+    minActiveReplica = builder.minActiveReplica;
+    rebalanceDelayMs = builder.rebalanceDelayMs;
+    clusterNames = builder.clusterNames;
+    zkAddress = builder.zkAddress;
+    clusterToD2 = builder.clusterToD2;
+    childControllers = builder.childControllers;
+    kafkaBroker = builder.kafkaBroker;
+    extraProperties = builder.extraProperties;
+    authorizerService = builder.authorizerService;
+  }
+
+  @Override
+  public String toString() {
+    return new StringBuilder().append("isParent:")
+        .append(isParent)
+        .append(", ")
+        .append("sslToKafka:")
+        .append(sslToKafka)
+        .append(", ")
+        .append("replicationFactor:")
+        .append(replicationFactor)
+        .append(", ")
+        .append("partitionSize:")
+        .append(partitionSize)
+        .append(", ")
+        .append("minActiveReplica:")
+        .append(minActiveReplica)
+        .append(", ")
+        .append("rebalanceDelayMs:")
+        .append(rebalanceDelayMs)
+        .append(", ")
+        .append("clusterNames:")
+        .append(Arrays.toString(clusterNames))
+        .append(", ")
+        .append("zkAddress:")
+        .append(zkAddress)
+        .append(", ")
+        .append("kafkaBroker:")
+        .append(kafkaBroker == null ? "null" : kafkaBroker.getAddress())
+        .append(", ")
+        .append("d2Enabled:")
+        .append(d2Enabled)
+        .append(", ")
+        .append("clusterToD2:")
+        .append(clusterToD2)
+        .append(", ")
+        .append("extraProperties:")
+        .append(extraProperties)
+        .append(", ")
+        .append("childControllers:")
+        .append(getAddressesOfChildControllers())
+        .toString();
+  }
+
+  private String getAddressesOfChildControllers() {
+    if (childControllers == null) {
+      return "null";
+    }
+    return Arrays.stream(childControllers)
+        .map(VeniceControllerWrapper::getControllerUrl)
+        .collect(Collectors.toList())
+        .toString();
+  }
+
+  public boolean isParent() {
+    return isParent;
+  }
+
+  public boolean isSslToKafka() {
+    return sslToKafka;
+  }
+
+  public boolean isD2Enabled() {
+    return d2Enabled;
+  }
+
+  public int getReplicationFactor() {
+    return replicationFactor;
+  }
+
+  public int getPartitionSize() {
+    return partitionSize;
+  }
+
+  public int getMinActiveReplica() {
+    return minActiveReplica;
+  }
+
+  public long getRebalanceDelayMs() {
+    return rebalanceDelayMs;
+  }
+
+  public String[] getClusterNames() {
+    return clusterNames;
+  }
+
+  public String getZkAddress() {
+    return zkAddress;
+  }
+
+  public String getClusterToD2() {
+    return clusterToD2;
+  }
+
+  public VeniceControllerWrapper[] getChildControllers() {
+    return childControllers;
+  }
+
+  public KafkaBrokerWrapper getKafkaBroker() {
+    return kafkaBroker;
+  }
+
+  public Properties getExtraProperties() {
+    return extraProperties;
+  }
+
+  public AuthorizerService getAuthorizerService() {
+    return authorizerService;
+  }
+
+  public static class Builder {
+    private final String[] clusterNames;
+    private final KafkaBrokerWrapper kafkaBroker;
+
+    private boolean isParent = false;
+    private boolean sslToKafka = false;
+    private boolean d2Enabled = false;
+    private boolean isMinActiveReplicaSet = false;
+    private int replicationFactor = DEFAULT_REPLICATION_FACTOR;
+    private int partitionSize = DEFAULT_PARTITION_SIZE_BYTES;
+    private int minActiveReplica;
+    private long rebalanceDelayMs = DEFAULT_DELAYED_TO_REBALANCE_MS;
+    private String zkAddress;
+    private String clusterToD2 = null;
+    private VeniceControllerWrapper[] childControllers = null;
+    private Properties extraProperties = new Properties();
+    private AuthorizerService authorizerService;
+
+    public Builder(String[] clusterNames, KafkaBrokerWrapper kafkaBroker) {
+      this.clusterNames = clusterNames;
+      this.kafkaBroker = kafkaBroker;
+    }
+
+    public Builder(String clusterName, KafkaBrokerWrapper kafkaBroker) {
+      this(new String[] { clusterName }, kafkaBroker);
+    }
+
+    public Builder parent(boolean parent) {
+      isParent = parent;
+      return this;
+    }
+
+    public Builder sslToKafka(boolean sslToKafka) {
+      this.sslToKafka = sslToKafka;
+      return this;
+    }
+
+    public Builder d2Enabled(boolean d2Enabled) {
+      this.d2Enabled = d2Enabled;
+      return this;
+    }
+
+    public Builder replicationFactor(int replicationFactor) {
+      this.replicationFactor = replicationFactor;
+      return this;
+    }
+
+    public Builder partitionSize(int partitionSize) {
+      this.partitionSize = partitionSize;
+      return this;
+    }
+
+    public Builder minActiveReplica(int minActiveReplica) {
+      this.minActiveReplica = minActiveReplica;
+      this.isMinActiveReplicaSet = true;
+      return this;
+    }
+
+    public Builder rebalanceDelayMs(long rebalanceDelayMs) {
+      this.rebalanceDelayMs = rebalanceDelayMs;
+      return this;
+    }
+
+    public Builder zkAddress(String zkAddress) {
+      this.zkAddress = zkAddress;
+      return this;
+    }
+
+    public Builder clusterToD2(String clusterToD2) {
+      this.clusterToD2 = clusterToD2;
+      return this;
+    }
+
+    public Builder childControllers(VeniceControllerWrapper[] childControllers) {
+      this.childControllers = childControllers;
+      return this;
+    }
+
+    public Builder extraProperties(Properties extraProperties) {
+      this.extraProperties = extraProperties;
+      return this;
+    }
+
+    public Builder authorizerService(AuthorizerService authorizerService) {
+      this.authorizerService = authorizerService;
+      return this;
+    }
+
+    private void verifyAndAddParentControllerSpecificDefaults() {
+      if (!isMinActiveReplicaSet) {
+        minActiveReplica = replicationFactor > 1 ? replicationFactor - 1 : replicationFactor;
+      }
+      extraProperties.setProperty(LOCAL_REGION_NAME, DEFAULT_PARENT_DATA_CENTER_REGION_NAME);
+      if (!extraProperties.containsKey(CONTROLLER_AUTO_MATERIALIZE_META_SYSTEM_STORE)) {
+        extraProperties.setProperty(CONTROLLER_AUTO_MATERIALIZE_META_SYSTEM_STORE, "true");
+      }
+      if (!extraProperties.containsKey(CONTROLLER_AUTO_MATERIALIZE_DAVINCI_PUSH_STATUS_SYSTEM_STORE)) {
+        extraProperties.setProperty(CONTROLLER_AUTO_MATERIALIZE_DAVINCI_PUSH_STATUS_SYSTEM_STORE, "true");
+      }
+      d2Enabled = clusterToD2 != null;
+      if (childControllers == null || childControllers.length == 0) {
+        throw new IllegalArgumentException("Child controller list cannot be null or empty for parent controller");
+      }
+    }
+
+    private void verifyAndAddChildControllerSpecificDefaults() {
+      if (!isMinActiveReplicaSet) {
+        minActiveReplica = replicationFactor;
+      }
+    }
+
+    private void addDefaults() {
+      Validate.notNull(kafkaBroker);
+      if (zkAddress == null) {
+        zkAddress = kafkaBroker.getZkAddress();
+      }
+      if (extraProperties == null) {
+        extraProperties = new Properties();
+      }
+      if (isParent) {
+        verifyAndAddParentControllerSpecificDefaults();
+      } else {
+        verifyAndAddChildControllerSpecificDefaults();
+      }
+    }
+
+    public VeniceControllerCreateOptions build() {
+      addDefaults();
+      return new VeniceControllerCreateOptions(this);
+    }
+  }
+}

--- a/internal/venice-test-common/src/main/java/com/linkedin/venice/integration/utils/VeniceControllerCreateOptions.java
+++ b/internal/venice-test-common/src/main/java/com/linkedin/venice/integration/utils/VeniceControllerCreateOptions.java
@@ -32,7 +32,6 @@ public class VeniceControllerCreateOptions {
   private final AuthorizerService authorizerService;
 
   private VeniceControllerCreateOptions(Builder builder) {
-    isParent = builder.isParent;
     sslToKafka = builder.sslToKafka;
     d2Enabled = builder.d2Enabled;
     replicationFactor = builder.replicationFactor;
@@ -46,6 +45,7 @@ public class VeniceControllerCreateOptions {
     kafkaBroker = builder.kafkaBroker;
     extraProperties = builder.extraProperties;
     authorizerService = builder.authorizerService;
+    isParent = builder.childControllers != null && builder.childControllers.length != 0;
   }
 
   @Override
@@ -160,8 +160,6 @@ public class VeniceControllerCreateOptions {
   public static class Builder {
     private final String[] clusterNames;
     private final KafkaBrokerWrapper kafkaBroker;
-
-    private boolean isParent = false;
     private boolean sslToKafka = false;
     private boolean d2Enabled = false;
     private boolean isMinActiveReplicaSet = false;
@@ -182,11 +180,6 @@ public class VeniceControllerCreateOptions {
 
     public Builder(String clusterName, KafkaBrokerWrapper kafkaBroker) {
       this(new String[] { clusterName }, kafkaBroker);
-    }
-
-    public Builder parent(boolean parent) {
-      isParent = parent;
-      return this;
     }
 
     public Builder sslToKafka(boolean sslToKafka) {
@@ -257,9 +250,6 @@ public class VeniceControllerCreateOptions {
         extraProperties.setProperty(CONTROLLER_AUTO_MATERIALIZE_DAVINCI_PUSH_STATUS_SYSTEM_STORE, "true");
       }
       d2Enabled = clusterToD2 != null;
-      if (childControllers == null || childControllers.length == 0) {
-        throw new IllegalArgumentException("Child controller list cannot be null or empty for parent controller");
-      }
     }
 
     private void verifyAndAddChildControllerSpecificDefaults() {
@@ -276,7 +266,7 @@ public class VeniceControllerCreateOptions {
       if (extraProperties == null) {
         extraProperties = new Properties();
       }
-      if (isParent) {
+      if (childControllers != null && childControllers.length != 0) {
         verifyAndAddParentControllerSpecificDefaults();
       } else {
         verifyAndAddChildControllerSpecificDefaults();

--- a/internal/venice-test-common/src/main/java/com/linkedin/venice/integration/utils/VeniceMultiClusterWrapper.java
+++ b/internal/venice-test-common/src/main/java/com/linkedin/venice/integration/utils/VeniceMultiClusterWrapper.java
@@ -99,18 +99,19 @@ public class VeniceMultiClusterWrapper extends ProcessWrapper {
           ClientConfig.defaultGenericClientConfig("")
               .setD2ServiceName(D2TestUtils.DEFAULT_TEST_SERVICE_NAME)
               .setD2Client(clientConfigD2Client));
+      VeniceControllerCreateOptions controllerCreateOptions =
+          new VeniceControllerCreateOptions.Builder(clusterNames, kafkaBrokerWrapper)
+              .replicationFactor(options.getReplicationFactor())
+              .partitionSize(options.getPartitionSize())
+              .rebalanceDelayMs(options.getRebalanceDelayMs())
+              .minActiveReplica(options.getMinActiveReplica())
+              .clusterToD2(clusterToD2)
+              .sslToKafka(false)
+              .d2Enabled(true)
+              .extraProperties(controllerProperties)
+              .build();
       for (int i = 0; i < options.getNumberOfControllers(); i++) {
-        VeniceControllerWrapper controllerWrapper = ServiceFactory.getVeniceChildController(
-            clusterNames,
-            kafkaBrokerWrapper,
-            options.getReplicationFactor(),
-            options.getPartitionSize(),
-            options.getRebalanceDelayMs(),
-            options.getMinActiveReplica(),
-            clusterToD2,
-            false,
-            true,
-            controllerProperties);
+        VeniceControllerWrapper controllerWrapper = ServiceFactory.getVeniceController(controllerCreateOptions);
         controllerMap.put(controllerWrapper.getPort(), controllerWrapper);
       }
       // Specify the system store cluster name

--- a/internal/venice-test-common/src/main/java/com/linkedin/venice/integration/utils/VeniceTwoLayerMultiColoMultiClusterWrapper.java
+++ b/internal/venice-test-common/src/main/java/com/linkedin/venice/integration/utils/VeniceTwoLayerMultiColoMultiClusterWrapper.java
@@ -253,7 +253,6 @@ public class VeniceTwoLayerMultiColoMultiClusterWrapper extends ProcessWrapper {
           false);
       VeniceControllerCreateOptions options =
           new VeniceControllerCreateOptions.Builder(clusterNames, parentKafka).zkAddress(parentKafka.getZkAddress())
-              .parent(true)
               .replicationFactor(replicationFactor)
               .childControllers(childControllers)
               .extraProperties(finalParentControllerProperties)

--- a/internal/venice-test-common/src/main/java/com/linkedin/venice/integration/utils/VeniceTwoLayerMultiColoMultiClusterWrapper.java
+++ b/internal/venice-test-common/src/main/java/com/linkedin/venice/integration/utils/VeniceTwoLayerMultiColoMultiClusterWrapper.java
@@ -251,19 +251,18 @@ public class VeniceTwoLayerMultiColoMultiClusterWrapper extends ProcessWrapper {
           D2TestUtils.CONTROLLER_CLUSTER_NAME,
           VeniceSystemFactory.VENICE_PARENT_D2_SERVICE,
           false);
+      VeniceControllerCreateOptions options =
+          new VeniceControllerCreateOptions.Builder(clusterNames, parentKafka).zkAddress(parentKafka.getZkAddress())
+              .parent(true)
+              .replicationFactor(replicationFactor)
+              .childControllers(childControllers)
+              .extraProperties(finalParentControllerProperties)
+              .clusterToD2(clusterToD2)
+              .build();
       // Create parentControllers for multi-cluster
       for (int i = 0; i < numberOfParentControllers; i++) {
         // random controller from each multi-cluster, in reality this should include all controllers, not just one
-        VeniceControllerWrapper parentController = ServiceFactory.getVeniceParentController(
-            clusterNames,
-            parentKafka.getZkAddress(),
-            parentKafka,
-            childControllers,
-            clusterToD2,
-            false,
-            replicationFactor,
-            new VeniceProperties(finalParentControllerProperties),
-            Optional.empty());
+        VeniceControllerWrapper parentController = ServiceFactory.getVeniceController(options);
         parentControllers.add(parentController);
       }
 

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/kafka/consumer/TestAdminConsumptionTask.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/kafka/consumer/TestAdminConsumptionTask.java
@@ -62,6 +62,7 @@ import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.guid.GuidUtils;
 import com.linkedin.venice.integration.utils.KafkaBrokerWrapper;
 import com.linkedin.venice.integration.utils.ServiceFactory;
+import com.linkedin.venice.integration.utils.VeniceControllerCreateOptions;
 import com.linkedin.venice.integration.utils.VeniceControllerWrapper;
 import com.linkedin.venice.integration.utils.ZkServerWrapper;
 import com.linkedin.venice.kafka.TopicManager;
@@ -469,7 +470,9 @@ public class TestAdminConsumptionTask {
       String adminTopic = AdminTopicUtils.getTopicNameFromClusterName(clusterName);
       topicManager.createTopic(adminTopic, 1, 1, true);
       String storeName = "test-store";
-      try (VeniceControllerWrapper controller = ServiceFactory.getVeniceChildController(clusterName, kafka);
+      try (
+          VeniceControllerWrapper controller =
+              ServiceFactory.getVeniceController(new VeniceControllerCreateOptions.Builder(clusterName, kafka).build());
           VeniceWriter<byte[], byte[], byte[]> writer =
               TestUtils.getVeniceWriterFactory(kafka.getAddress()).createBasicVeniceWriter(adminTopic)) {
         byte[] message = getStoreCreationMessage(clusterName, storeName, owner, "invalid_key_schema", valueSchema, 1); // This

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/AbstractTestAdminSparkServer.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/AbstractTestAdminSparkServer.java
@@ -43,7 +43,6 @@ public class AbstractTestAdminSparkServer {
     VeniceControllerCreateOptions options =
         new VeniceControllerCreateOptions.Builder(cluster.getClusterName(), cluster.getKafka())
             .zkAddress(parentZk.getAddress())
-            .parent(true)
             .replicationFactor(1)
             .childControllers(new VeniceControllerWrapper[] { cluster.getLeaderVeniceController() })
             .extraProperties(extraProperties)

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/AbstractTestAdminSparkServer.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/AbstractTestAdminSparkServer.java
@@ -7,12 +7,12 @@ import com.linkedin.venice.authorization.AuthorizerService;
 import com.linkedin.venice.controllerapi.ControllerClient;
 import com.linkedin.venice.integration.utils.ServiceFactory;
 import com.linkedin.venice.integration.utils.VeniceClusterWrapper;
+import com.linkedin.venice.integration.utils.VeniceControllerCreateOptions;
 import com.linkedin.venice.integration.utils.VeniceControllerWrapper;
 import com.linkedin.venice.integration.utils.ZkServerWrapper;
 import com.linkedin.venice.utils.TestUtils;
 import com.linkedin.venice.utils.Time;
 import com.linkedin.venice.utils.Utils;
-import com.linkedin.venice.utils.VeniceProperties;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
@@ -40,16 +40,16 @@ public class AbstractTestAdminSparkServer {
     // The cluster does not have router setup
     extraProperties.setProperty(CONTROLLER_AUTO_MATERIALIZE_META_SYSTEM_STORE, "false");
     extraProperties.setProperty(CONTROLLER_AUTO_MATERIALIZE_DAVINCI_PUSH_STATUS_SYSTEM_STORE, "false");
-    parentController = ServiceFactory.getVeniceParentController(
-        new String[] { cluster.getClusterName() },
-        parentZk.getAddress(),
-        cluster.getKafka(),
-        new VeniceControllerWrapper[] { cluster.getLeaderVeniceController() },
-        null,
-        false,
-        1,
-        new VeniceProperties(extraProperties),
-        authorizerService);
+    VeniceControllerCreateOptions options =
+        new VeniceControllerCreateOptions.Builder(cluster.getClusterName(), cluster.getKafka())
+            .zkAddress(parentZk.getAddress())
+            .parent(true)
+            .replicationFactor(1)
+            .childControllers(new VeniceControllerWrapper[] { cluster.getLeaderVeniceController() })
+            .extraProperties(extraProperties)
+            .authorizerService(authorizerService.orElse(null))
+            .build();
+    parentController = ServiceFactory.getVeniceController(options);
 
     if (!useParentRestEndpoint) {
       controllerClient =

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/TestAdminSparkServerGetLeader.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/TestAdminSparkServerGetLeader.java
@@ -8,6 +8,7 @@ import com.linkedin.venice.controllerapi.LeaderControllerResponse;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.integration.utils.KafkaBrokerWrapper;
 import com.linkedin.venice.integration.utils.ServiceFactory;
+import com.linkedin.venice.integration.utils.VeniceControllerCreateOptions;
 import com.linkedin.venice.integration.utils.VeniceControllerWrapper;
 import com.linkedin.venice.integration.utils.ZkServerWrapper;
 import com.linkedin.venice.utils.TestUtils;
@@ -45,7 +46,8 @@ public class TestAdminSparkServerGetLeader {
   public void setUp() {
     zkServer = ServiceFactory.getZkServer();
     kafkaBrokerWrapper = ServiceFactory.getKafkaBroker(zkServer);
-    veniceControllerWrapper = ServiceFactory.getVeniceChildController(cluster, kafkaBrokerWrapper);
+    veniceControllerWrapper = ServiceFactory
+        .getVeniceController(new VeniceControllerCreateOptions.Builder(cluster, kafkaBrokerWrapper).build());
   }
 
   @AfterMethod

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/TestBackupControllerResponse.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/TestBackupControllerResponse.java
@@ -11,6 +11,7 @@ import com.linkedin.venice.controllerapi.VersionCreationResponse;
 import com.linkedin.venice.exceptions.VeniceHttpException;
 import com.linkedin.venice.integration.utils.KafkaBrokerWrapper;
 import com.linkedin.venice.integration.utils.ServiceFactory;
+import com.linkedin.venice.integration.utils.VeniceControllerCreateOptions;
 import com.linkedin.venice.integration.utils.VeniceControllerWrapper;
 import com.linkedin.venice.integration.utils.ZkServerWrapper;
 import java.util.Optional;
@@ -27,8 +28,10 @@ public class TestBackupControllerResponse {
     try (ZkServerWrapper zkServer = ServiceFactory.getZkServer();
         KafkaBrokerWrapper kafka = ServiceFactory.getKafkaBroker(zkServer);
         ControllerTransport transport = new ControllerTransport(Optional.empty());
-        VeniceControllerWrapper controller1 = ServiceFactory.getVeniceChildController(clusterName, kafka);
-        VeniceControllerWrapper controller2 = ServiceFactory.getVeniceChildController(clusterName, kafka)) {
+        VeniceControllerWrapper controller1 =
+            ServiceFactory.getVeniceController(new VeniceControllerCreateOptions.Builder(clusterName, kafka).build());
+        VeniceControllerWrapper controller2 =
+            ServiceFactory.getVeniceController(new VeniceControllerCreateOptions.Builder(clusterName, kafka).build())) {
       // TODO: Eliminate sleep to make test reliable
       Thread.sleep(2000);
       VeniceControllerWrapper nonLeaderController =


### PR DESCRIPTION
## ServiceFactory::getVeniceParentController cleanup
Removed all existing variations of ServiceFactory::getVeniceController and ServiceFactory::getVeniceParentController. Added a new method that takes just one argument: ServiceFactory::getVeniceController(VeniceControllerCreateOptions). VeniceControllerCreateOptions uses builder to collect controller creation options. To get parent controller, set 'parent' to true while building VeniceControllerCreateOptions.

Resolves #12 

## How was this PR tested?
UT & IT via Li CI

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.