### PR TITLE
[da-vinci] Add back functions that were breaking backward comp…

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/client/DaVinciConfig.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/client/DaVinciConfig.java
@@ -98,4 +98,21 @@ public class DaVinciConfig {
     this.cacheConfig = cacheConfig;
     return this;
   }
+
+  /**
+   * These functions are unused but are a part of the public API. They have been kept for backward compatibility.
+   * @return Zero (dummy value)
+   */
+  @Deprecated
+  public long getMemoryLimit() {
+    return 0;
+  }
+
+  /**
+   * These functions are unused but are a part of the public API. They have been kept for backward compatibility.
+   */
+  @Deprecated
+  public DaVinciConfig setMemoryLimit(long memoryLimit) {
+    return this;
+  }
 }


### PR DESCRIPTION
…atibility

<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci], [server], [controller],
[router], [samza], [vpj], [fast-client], [thin-client], [alpini],
[admin-tool], [test], [build], [doc], [script]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Restore DaVinciConfig Backward Compatibility
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

[This commit](https://github.com/linkedin/venice/commit/336d28d600ebee026a7dab0d21d4e8f8671d5f8b) removed two functions from DaVinciConfig's Public API and it breaks backward compatibility since they were being used by Da Vinci client users. This PR adds them back to restore the backward compatibility

## How was this PR tested?
Running unit and integration tests

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [x] Yes. Make sure to explain your proposed changes and call out the behavior change.

This PR adds back two functions to DaVinciConfig's public API