### PR TITLE
[build] Release format only contains version number. Add support to p…

### DIFF
--- a/.github/workflows/build-and-upload-archives-on-demand.yml
+++ b/.github/workflows/build-and-upload-archives-on-demand.yml
@@ -1,4 +1,4 @@
-name: Build with All Tests and Upload Archives On Demand
+name: Build and Upload Archives On Demand
 
 # Run this workflow when triggered manually
 on: workflow_dispatch

--- a/.github/workflows/build-and-upload-archives-upon-creating-tags.yml
+++ b/.github/workflows/build-and-upload-archives-upon-creating-tags.yml
@@ -28,18 +28,11 @@ jobs:
           distribution: 'microsoft'
           java-version: '11'
 
-      - name: Validate Gradle wrapper
-        uses: gradle/wrapper-validation-action@e6e38bacfdf1a337459f332974bb2327a31aaf4b
-
-      - name: Build with Gradle
+      - name: Upload archive
+        env:
+          JFROG_USERNAME: ${{ secrets.JFROG_USERNAME }}
+          JFROG_API_KEY: ${{ secrets.JFROG_API_KEY }}
         uses: gradle/gradle-build-action@67421db6bd0bf253fb4bd25b31ebb98943c375e1
         with:
-          arguments: clean assemble
-
-      - name: package artifacts
-        run: mkdir staging && find . -name "*.jar" -exec cp "{}" staging \;
-
-      - uses: actions/upload-artifact@v3
-        with:
-          name: Package
-          path: staging
+          arguments: |
+            -Pversion=${{  github.ref_name }}" publishAllPublicationsToLinkedInJFrogRepository

--- a/build.gradle
+++ b/build.gradle
@@ -4,12 +4,15 @@ import org.apache.tools.ant.taskdefs.condition.Os
 plugins {
   id 'idea'
   id 'java'
+  id 'maven-publish'
   id 'com.diffplug.spotless' version '6.9.1'
   id 'com.dorongold.task-tree' version '2.1.0'
   id 'com.github.johnrengelman.shadow' version '6.1.0' apply false
   id 'com.github.spotbugs' version '4.8.0' apply false
   id 'org.gradle.test-retry' version '1.4.0' apply false
 }
+
+apply from: "$rootDir/gradle/helper/publishing.gradle"
 
 /*
  * This snippet allows the Gradle environment to be overridden with custom
@@ -102,7 +105,49 @@ ext.libraries = [
     zstd: 'com.github.luben:zstd-jni:1.5.2-3'
 ]
 
+group = 'com.linkedin.venice'
+
+//does not include "hadoop-to-venice-bridge" as that module has its own publishing section (because shadow jar)
+//does not include "venice-admin-tool" as that module has its own publishing section (because shadow jar)
+//does not include "venice-test-common" as that is a test-only module
+Map<String, String> projectsToPublish = new HashMap<String, String>() {{
+  // Services
+  put(":services:venice-controller", "venice-controller")
+  put(":services:venice-router", "venice-router")
+  put(":services:venice-server", "venice-server")
+
+  // Clients
+  put(":clients:da-vinci-client", "da-vinci-client")
+  put(":clients:venice-client", "venice-client")
+  put(":clients:venice-samza", "venice-samza")
+  put(":clients:venice-thin-client", "venice-thin-client")
+
+  // Internal
+  put(":internal:venice-client-common", "venice-client-common")
+  put(":internal:venice-common", "venice-common")
+  put(":internal:venice-compatibility-test", "venice-compatibility-test")
+  put(":internal:venice-consumer", "venice-consumer")
+  put(":internal:venice-test-common", "venice-test-common")
+
+  // Internal - Alpini
+  put(":internal:alpini:common:common-base", "alpini-common-base")
+  put(":internal:alpini:common:common-cli", "alpini-common-cli")
+  put(":internal:alpini:common:common-const", "alpini-common-const")
+  put(":internal:alpini:common:common-io", "alpini-common-io")
+  put(":internal:alpini:common:common-log", "alpini-common-log")
+  put(":internal:alpini:common:common-native", "alpini-common-native")
+  put(":internal:alpini:common:common-test", "alpini-common-test")
+  put(":internal:alpini:netty4:netty4-base", "alpini-netty4-base")
+  put(":internal:alpini:router:router-api", "alpini-router-api")
+  put(":internal:alpini:router:router-base", "alpini-router-base")
+  put(":internal:alpini:router:router-impl", "alpini-router-impl")
+}}
+
 subprojects {
+  //apply group and version to all submodules
+  group = rootProject.group
+  version = rootProject.version
+
   apply {
     plugin 'idea'
     plugin 'jacoco'
@@ -328,6 +373,32 @@ subprojects {
     zip64 = true
     duplicatesStrategy = DuplicatesStrategy.FAIL
     exclude('**/*.xml')
+  }
+
+  def publishRegularArtifacts = projectsToPublish.containsKey(project.path)
+
+  if (publishRegularArtifacts) {
+    task sourceJar(type: Jar) {
+      from sourceSets.main.allJava
+      classifier "sources"
+    }
+  }
+
+  // TODO: Enable after we have valid javadocs
+  // task javadocJar(type: Jar) {
+  //   from javadoc
+  //   classifier = 'javadoc'
+  // }
+
+  task testJar(type: Jar) {
+    from sourceSets.test.allJava
+    classifier = 'tests'
+  }
+
+  if (project.version != project.DEFAULT_VERSION) {
+    if (publishRegularArtifacts) {
+      publishing.configureRegularArtifactPublishing(project, projectsToPublish.get(project.path), sourceJar, testJar)
+    }
   }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -107,9 +107,9 @@ ext.libraries = [
 
 group = 'com.linkedin.venice'
 
-//does not include "hadoop-to-venice-bridge" as that module has its own publishing section (because shadow jar)
-//does not include "venice-admin-tool" as that module has its own publishing section (because shadow jar)
-//does not include "venice-test-common" as that is a test-only module
+// This does not include modules that are published as shadow jars as they have their own publishing sections:
+// 1. hadoop-to-venice-bridge
+// 2. venice-admin-tool
 Map<String, String> projectsToPublish = new HashMap<String, String>() {{
   // Services
   put(":services:venice-controller", "venice-controller")

--- a/clients/hadoop-to-venice-bridge/build.gradle
+++ b/clients/hadoop-to-venice-bridge/build.gradle
@@ -46,6 +46,9 @@ dependencies {
   runtimeOnly libraries.httpClient
 }
 
+apply from: "$rootDir/gradle/helper/publishing.gradle"
+apply from: "$rootDir/gradle/helper/packaging.gradle"
+
 artifacts {
   archives shadowJar
 }
@@ -64,3 +67,13 @@ jar {
     attributes 'Main-Class': 'com.linkedin.venice.hadoop.VenicePushJob'
   }
 }
+
+//"fat" sources jar
+task sourceJar(type: Jar, dependsOn: classes) {
+  duplicatesStrategy = DuplicatesStrategy.WARN
+  // we return here a closure to do this lazy, after all projects are configured by gradle
+  from { packaging.collectSourceSetsIncludingSubmodules(project) }
+}
+
+def artifactName = "hadoop-to-venice-bridge"
+publishing.configureShadowArtifactPublishing(project, artifactName, shadowJar, sourceJar, testJar)

--- a/clients/venice-admin-tool/build.gradle
+++ b/clients/venice-admin-tool/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 dependencies {
-  implementation (libraries.avro) {
+  implementation(libraries.avro) {
     exclude group: 'org.mortbay.jetty' // jetty 6 conflicts with spark-java used in controller api
   }
 
@@ -16,16 +16,27 @@ dependencies {
   implementation libraries.log4j2api
 }
 
+apply from: "$rootDir/gradle/helper/publishing.gradle"
+apply from: "$rootDir/gradle/helper/packaging.gradle"
+
 artifacts {
   archives shadowJar
 }
 
 jar {
   manifest {
-    attributes = [
-        'Implementation-Title': 'Venice Admin Tool',
-        'Implementation-Version': project.version,
-        'Main-Class': 'com.linkedin.venice.AdminTool'
-    ]
+    attributes = ['Implementation-Title'  : 'Venice Admin Tool',
+                  'Implementation-Version': project.version,
+                  'Main-Class'            : 'com.linkedin.venice.AdminTool']
   }
 }
+
+//"fat" sources jar
+task sourceJar(type: Jar, dependsOn: classes) {
+  duplicatesStrategy = DuplicatesStrategy.WARN
+  // we return here a closure to do this lazy, after all projects are configured by gradle
+  from { packaging.collectSourceSetsIncludingSubmodules(project) }
+}
+
+def artifactName = "venice-admin-tool"
+publishing.configureShadowArtifactPublishing(project, artifactName, shadowJar, sourceJar, testJar)

--- a/gradle/helper/packaging.gradle
+++ b/gradle/helper/packaging.gradle
@@ -1,0 +1,24 @@
+ext.packaging = [
+    collectSourceSetsIncludingSubmodules: { subproject ->
+      return collectSourceSetsIncludingSubmodules(subproject)
+    }
+]
+
+// workaround for missing gradle shadow plugin feature, see https://github.com/johnrengelman/shadow/issues/41
+private Set<SourceDirectorySet> collectSourceSetsIncludingSubmodules(Project project){
+  Set<SourceDirectorySet> result = [].toSet()
+  recursiveCollectSourceSets(project, [].toSet(), result)
+  return result
+}
+
+private void recursiveCollectSourceSets(Project visitingProject,
+    Set<Project> visitedProjects,
+    Set<SourceDirectorySet> collectedSourceSets) {
+  if (!visitedProjects.contains(visitingProject)) {
+    visitedProjects.add(visitingProject)
+    collectedSourceSets.add(visitingProject.sourceSets.main.allSource)
+    visitingProject.configurations.implementation.getAllDependencies().withType(ProjectDependency).each {
+      ProjectDependency pd -> recursiveCollectSourceSets(pd.getDependencyProject(), visitedProjects, collectedSourceSets)
+    }
+  }
+}

--- a/gradle/helper/publishing.gradle
+++ b/gradle/helper/publishing.gradle
@@ -1,0 +1,96 @@
+ext.publishing = [
+    configureRegularArtifactPublishing: { subproject, artifactName, sourceJar, testJar ->
+      println "Will publish ${subproject.path} at ${subproject.group}:${artifactName}:${subproject.version}"
+
+      publishing {
+        publications {
+          "$artifactName"(MavenPublication) {
+            groupId subproject.group
+            artifactId artifactName
+            version subproject.version
+
+            from components.java
+            artifact sourceJar
+            //  TODO: Enable after we have valid javadocs
+            // artifact javadocJar
+            artifact testJar
+
+            //we strive to meet https://central.sonatype.org/pages/requirements.html
+            pom {
+              name = 'Venice'
+              description = 'Derived Data Platform for planet-scale workloads'
+              url = 'https://github.com/linkedin/venice'
+
+              licenses {
+                license {
+                  name = 'BSD 2-Clause'
+                  url = 'https://raw.githubusercontent.com/linkedin/venice/master/LICENSE'
+                }
+              }
+              scm {
+                connection = 'scm:git:git://github.com:linkedin/venice.git'
+                developerConnection = 'scm:git:ssh://github.com:linkedin/venice.git'
+                url = 'https://github.com/linkedin/venice'
+              }
+            }
+          }
+        }
+
+        repositories {
+          mavenLocal()
+          maven {
+            name "LinkedInJFrog"
+            url "https://linkedin.jfrog.io/artifactory/venice"
+            credentials {
+              if (System.getenv('JFROG_USERNAME') != null && System.getenv('JFROG_API_KEY') != null) {
+                username System.getenv('JFROG_USERNAME')
+                password System.getenv('JFROG_API_KEY')
+              }
+            }
+          }
+        }
+      }
+    },
+
+    configureShadowArtifactPublishing: { subproject, artifactName, shadowJar, sourceJar, testJar ->
+      println "Will publish ${subproject.path} at ${subproject.group}:${artifactName}:${subproject.version}"
+
+      publishing {
+        publications {
+          "$artifactName"(MavenPublication) {
+            groupId subproject.group
+            artifactId "$artifactName"
+            version subproject.version
+
+            artifact source: shadowJar, classifier: 'all'
+            // TODO: Enable after we figure out getting the full source for shadow jars
+            // artifact sourceJar
+            // TODO: Enable after we have valid javadocs
+            // artifact javadocJar
+
+            //we strive to meet https://central.sonatype.org/pages/requirements.html
+            pom {
+              name = 'Venice'
+              description = 'Derived Data Platform for planet-scale workloads'
+              url = 'https://github.com/linkedin/venice'
+
+              licenses {
+                license {
+                  name = 'BSD 2-Clause'
+                  url = 'https://raw.githubusercontent.com/linkedin/venice/master/LICENSE'
+                }
+              }
+              scm {
+                connection = 'scm:git:git://github.com:linkedin/venice.git'
+                developerConnection = 'scm:git:ssh://github.com:linkedin/venice.git'
+                url = 'https://github.com/linkedin/venice'
+              }
+            }
+          }
+        }
+
+        //repositories inherited from parent build.gradle
+      }
+
+    }
+]


### PR DESCRIPTION
…ublish artifacts to LinkedIn JFrog

<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci], [server], [controller],
[router], [samza], [vpj], [fast-client], [thin-client], [alpini],
[admin-tool], [test], [build], [doc], [script]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Add support to publish artifacts to LinkedIn JFrog
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
To be able to share artifacts, we need to be able to upload them to a public registry. We cannot upload to Maven Central yet since we have other dependencies that are available only on LinkedIn JFrog Artifactory.

## How was this PR tested?
Tested locally using:
```
./gradlew clean -Pversion="0.0.1" publishAllPublicationsToMavenLocalRepository --no-daemon
```
Directory structure of the artifacts: https://gist.github.com/nisargthakkar/48977caca2dd59561c603e7d6a7f7a30

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [x] Yes. Make sure to explain your proposed changes and call out the behavior change.

1. Git tags are now just the version numbers
2. Artifacts are published to LinkedIn JFrog when tags are created