### PR TITLE
[doc] Use GitHub Pages for documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,7 @@ build/
 internal/venice-test-common/tmp/
 internal/venice-test-common/dump.complete.hprof
 internal/venice-test-common/src/jmh/generated
+.jekyll-cache/
+_site/
+Gemfile.lock
+.bundles_cache

--- a/docs/CODE_OF_CONDUCT.md
+++ b/docs/CODE_OF_CONDUCT.md
@@ -1,3 +1,9 @@
+---
+layout: default
+title: Code Of Conduct
+parent: Community Guides
+permalink: /code_of_conduct
+---
 
 # Contributor Covenant Code of Conduct
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,3 +1,10 @@
+---
+layout: default
+title: Contribution Agreement
+parent: Community Guides
+permalink: /community_guides/contribution_agreement
+---
+
 # Contribution Agreement
 
 As a contributor, you represent that the code you submit is your
@@ -9,7 +16,7 @@ license.
 
 # Responsible Disclosure of Security Vulnerabilities
 
-Please refer to our [Security Policy](./SECURITY.md) for our policy on
+Please refer to our [Security Policy](https://linkedin.github.io/venice/community_guides/security_vulnerability) for our policy on
 responsibly reporting security vulnerabilities.
 
 # Contribution Process
@@ -30,8 +37,8 @@ If you have any user feedback, please create a new GitHub issue and the communit
 
 ## For New Contributors
 
-Please follow [Venice Workspace Setup](./docs/dev_guide/workspace_setup.md) and
-[Venice Recommended Development Workflow](./docs/dev_guide/recommended_development_workflow.md)
+Please follow [Venice Workspace Setup](https://linkedin.github.io/venice/dev_guide/workspace_setup) and
+[Venice Recommended Development Workflow](https://linkedin.github.io/venice/dev_guide/recommended_development_workflow)
 
 ## Tips for Getting Your Pull Request Accepted
 
@@ -44,4 +51,4 @@ Please follow [Venice Workspace Setup](./docs/dev_guide/workspace_setup.md) and
 
 ## Code of Conduct
 
-This project and everyone who participates in it is governed by the [Venice Code of Conduct](CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code. Please report unacceptable behavior on [Slack](https://venicedb.slack.com/archives/C03SLQWRSLF).
+This project and everyone who participates in it is governed by the [Venice Code of Conduct](https://linkedin.github.io/venice/code_of_conduct). By participating, you are expected to uphold this code. Please report unacceptable behavior on [Slack](https://venicedb.slack.com/archives/C03SLQWRSLF).

--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -1,0 +1,5 @@
+source "https://rubygems.org"
+
+# do NOT include the jekyll gem !
+gem "github-pages", "~> 219", group: :jekyll_plugins
+gem "kramdown-parser-gfm"

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,20 @@
-Venice
-======
+<html>
+    <h1 align="center">
+      Venice
+    </h1>
+    <h3 align="center">
+      Derived Data Platform for planet-scale workloads
+    </h3>
+    <h3 align="center">
+      Important Links:
+      <a href="https://communityinviter.com/apps/venicedb/venice">Slack</a> &
+      <a href="https://github.com/linkedin/venice/discussions">Discussions</a>.   
+      <a href="https://linkedin.github.io/venice/">Docs</a>.
+    </h3>
+</html> 
+
+[![License](https://img.shields.io/badge/License-BSD_2--Clause-blue.svg)](https://github.com/linkedin/venice/blob/master/LICENSE)
+[![Docs Latest](https://img.shields.io/badge/docs-latest-blue.svg)](https://linkedin.github.io/venice/)
 
 Venice is a derived data storage platform, providing the following characteristics:
 
@@ -59,12 +74,10 @@ There are two main client modes for accessing Venice data:
 - **Classical Venice**: perform remote queries against Venice's distributed backend service. In this mode, read compute queries are pushed down to the backend and only the computation results are returned to the client. 
 - **Da Vinci**: eagerly load some or all partitions of the dataset and perform queries against the resulting local cache. Future updates to the data continue to be streamed in and applied to the local cache.
 
-Getting Started
-===============
-Refer to the [Venice quickstart](./quickstart/README.md) to create your own Venice cluster and play around with some features like creating a data store, batch push, incremental push, and single get.
+# Getting Started
+Refer to the [Venice quickstart](https://linkedin.github.io/venice/docs/quickstart) to create your own Venice cluster and play around with some features like creating a data store, batch push, incremental push, and single get.
 
-Previously Published Content
-============================
+# Previously Published Content
 
 The following blog posts have previously been published about Venice:
 
@@ -84,14 +97,11 @@ The following talks have been given about Venice:
 
 Keep in mind that older content reflects an earlier phase of the project and may not be entirely correct anymore.
 
-Community Resources
-===================
+# Community Resources
 
 Feel free to engage with the community using our:
 - [Slack workspace](https://communityinviter.com/apps/venicedb/venice)
 - [LinkedIn group](https://www.linkedin.com/groups/14129519/)
 - [Twitter handle](https://twitter.com/VeniceDataBase)
 - GitHub [issues](https://github.com/linkedin/venice/issues) and [discussions](https://github.com/linkedin/venice/discussions)
-- The [contributor's guide](./CONTRIBUTING.md).
-
-[//]: # (TODO: Add link to setup and execution guide)
+- The [contributor's guide](CONTRIBUTING.md).

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -1,5 +1,11 @@
-Responsible Disclosure of Security Vulnerabilities
-==================================================
+---
+layout: default
+title: Responsible Disclosure of Security Vulnerabilities
+parent: Community Guides
+permalink: /community_guides/security_vulnerability
+---
+
+# Responsible Disclosure of Security Vulnerabilities
 
 Please do not file reports on GitHub for security issues.  Please
 review the guidelines for reporting [Security Vulnerabilities](https://www.linkedin.com/help/linkedin/answer/62924/security-vulnerabilities?lang=en).

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,2 @@
+title: Venice
+remote_theme: just-the-docs/just-the-docs

--- a/docs/community_guidelines.md
+++ b/docs/community_guidelines.md
@@ -1,0 +1,9 @@
+---
+layout: default
+title: Community Guides
+has_children: true
+permalink: docs/community_guide
+---
+# Community Guides
+
+This folder includes guides for interacting with the Venice Community

--- a/docs/dev_guide/dev_guide.md
+++ b/docs/dev_guide/dev_guide.md
@@ -1,0 +1,9 @@
+---
+layout: default
+title: Developer Guides
+has_children: true
+permalink: docs/dev_guide
+---
+# Developer Guide
+
+This folder includes guides for Venice developers. Users should refer to Venice User Guide on how-to and the concepts

--- a/docs/dev_guide/doc_guide.md
+++ b/docs/dev_guide/doc_guide.md
@@ -1,0 +1,28 @@
+---
+layout: default
+title: Documentation Guideline
+parent: Developer Guides
+---
+
+# Documentation Guideline
+
+We prefer simplicity and currently use GitHub page to host Venice documentation. Those documentation will be built automatically by GitHub pipelines in the `master` branch.
+
+## Hierarchy
+
+In order for your docs to be rendered properly in the documentation hierarchy, Venice developers need to add a header
+section at the top of each documentation. The `title` section will be what the end user sees in the sidebar, and
+the `parent` section represents the parent page of the current page for linking purpose. An example of the header is
+below:
+
+```
+---
+layout: default
+title: Documentation Guideline
+parent: Developer Guides
+---
+```
+
+## Emojis
+
+Here's a link to all the emojis available in README files: [Emoji Cheat Sheet](https://github.com/ikatyang/emoji-cheat-sheet/blob/master/README.md). If you want to find a good emoji, you can use [this website](https://emojicombos.com/).

--- a/docs/dev_guide/recommended_development_workflow.md
+++ b/docs/dev_guide/recommended_development_workflow.md
@@ -18,7 +18,7 @@ The GitHub issue should contain the detailed problem statement.
 1. Fork the GitHub repository at http://github.com/linkedin/venice if you haven't already
 2. Clone your fork, create a new branch, push commits to the branch
 3. Consider whether documentation or tests need to be added or updated as part of the change, and add them as needed (doc changes should be submitted along with code change in the same PR)
-4. Run all tests as described in the project's [Workspace setup guide](./workspace_setup.md#run-the-test-suite).
+4. Run all tests as described in the project's [Workspace setup guide](https://linkedin.github.io/venice/dev_guide/workspace_setup#run-the-test-suite).
 5. Open a pull request against the `master` branch of `linkedin/venice`. (Only in special cases would the PR be opened against other branches.)
 6. The PR title should usually be of the form `[component1]...[componentN]: Concise commit message`.
    * Valid component tags are: `[da-vinci]`, `[server]`, `[controller]`,

--- a/docs/quickstart/quickstart.md
+++ b/docs/quickstart/quickstart.md
@@ -1,3 +1,9 @@
+---
+layout: default
+title: Quickstart
+permalink: docs/quickstart
+---
+
 ## Venice Quickstart
 
 Follow this guide to set up a simple venice cluster using docker images
@@ -14,7 +20,7 @@ wget https://raw.githubusercontent.com/linkedin/venice/master/quickstart/docker-
 ```
 
 #### Step 3: Run docker compose
-This will download and start containers for kafka, zookeeper, venice-controller, venice-router, 
+This will download and start containers for kafka, zookeeper, venice-controller, venice-router,
 venice-server, and venice-client.
 Once containers are up and running, it will create a test cluster, namely, `venice-cluster`.
 
@@ -24,8 +30,8 @@ docker compose up -d
 ```
 
 #### Step 4: Access `venice-client` container's bash shell
- From this container, we will create a store in `venice-cluster`, which was created in step 3, push 
- data to it and run queries against it.
+From this container, we will create a store in `venice-cluster`, which was created in step 3, push
+data to it and run queries against it.
 ```
 docker exec -it venice-client bash
 ```
@@ -55,7 +61,7 @@ bash create_store.sh
 ```
 
 #### Step 6: Push data to the store
-Venice supports multiple ways to write data to the store. For more details, please refer to [Write Path](https://github.com/linkedin/venice#write-path) section in [README](https://github.com/linkedin/venice#venice). 
+Venice supports multiple ways to write data to the store. For more details, please refer to [Write Path](https://linkedin.github.io/venice#write-path) section in [README](https://linkedin.github.io/venice).
 In this example, we will use batch push mode and push 100 records.
 ```
 key: 1 to 100
@@ -134,5 +140,5 @@ docker compose down
 
 ## Next steps
 Venice is a feature rich derived data store. It offers features such as write-compute, read-compute, streaming ingestion, multi data center active-active replication,
-deterministic conflict resolution, etc. To know more about such features please refer [README](https://github.com/linkedin/venice#venice) and reach out to 
-the [Venice team](https://github.com/linkedin/venice#community-resources).
+deterministic conflict resolution, etc. To know more about such features please refer [README](https://linkedin.github.io/venice/) and reach out to
+the [Venice team](https://linkedin.github.io/venice/#community-resources).


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci], [server], [controller],
[router], [samza], [vpj], [fast-client], [thin-client], [alpini],
[admin-tool], [test], [build], [doc], [script]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Setup Docs on GitHub Pages
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
This PR sets up docs on GitHub Pages using the [JustTheDocs](https://just-the-docs.github.io/just-the-docs/) template.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
Tested on my personal fork: https://nisargthakkar.github.io/venice/

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [x] Yes. Make sure to explain your proposed changes and call out the behavior change.
It adds a public facing documentation page that can be updated in-repo.