### PR TITLE
[h2v] Repush optimization for chunked topics

### DIFF
--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/input/kafka/chunk/ChunkAssembler.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/input/kafka/chunk/ChunkAssembler.java
@@ -3,21 +3,20 @@ package com.linkedin.venice.hadoop.input.kafka.chunk;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.hadoop.input.kafka.avro.KafkaInputMapperValue;
 import com.linkedin.venice.hadoop.input.kafka.avro.MapperValueType;
-import com.linkedin.venice.serialization.KeyWithChunkingSuffixSerializer;
 import com.linkedin.venice.serialization.avro.AvroProtocolDefinition;
 import com.linkedin.venice.serialization.avro.ChunkedValueManifestSerializer;
 import com.linkedin.venice.serializer.AvroSpecificDeserializer;
+import com.linkedin.venice.serializer.FastSerializerDeserializerFactory;
+import com.linkedin.venice.serializer.RecordDeserializer;
 import com.linkedin.venice.storage.protocol.ChunkedKeySuffix;
 import com.linkedin.venice.storage.protocol.ChunkedValueManifest;
 import com.linkedin.venice.utils.ByteUtils;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
-import java.util.Optional;
 import org.apache.avro.specific.SpecificDatumReader;
+import org.apache.hadoop.io.BytesWritable;
 
 
 /**
@@ -25,121 +24,121 @@ import org.apache.avro.specific.SpecificDatumReader;
  * message.
  */
 public class ChunkAssembler {
-  private final Map<ByteBuffer, ByteBuffer> chunksByCompositeKey;
+  private static final RecordDeserializer<KafkaInputMapperValue> KAFKA_INPUT_MAPPER_VALUE_AVRO_SPECIFIC_DESERIALIZER =
+      FastSerializerDeserializerFactory
+          .getFastAvroSpecificDeserializer(KafkaInputMapperValue.SCHEMA$, KafkaInputMapperValue.class);
   private final AvroSpecificDeserializer<ChunkedKeySuffix> chunkedKeySuffixDeserializer;
-  private final KeyWithChunkingSuffixSerializer keyWithChunkingSuffixSerializer;
   private final ChunkedValueManifestSerializer manifestSerializer;
 
   public ChunkAssembler() {
-    this.chunksByCompositeKey = new HashMap<>();
     SpecificDatumReader<ChunkedKeySuffix> specificDatumReader = new SpecificDatumReader<>(ChunkedKeySuffix.class);
     this.chunkedKeySuffixDeserializer = new AvroSpecificDeserializer<>(specificDatumReader);
-    this.keyWithChunkingSuffixSerializer = new KeyWithChunkingSuffixSerializer();
     this.manifestSerializer = new ChunkedValueManifestSerializer(true);
   }
 
-  public Optional<ValueBytesAndSchemaId> assembleAndGetValue(
-      final byte[] keyBytes,
-      final List<KafkaInputMapperValue> values) {
-    if (values.isEmpty()) {
+  public ValueBytesAndSchemaId assembleAndGetValue(final byte[] keyBytes, final Iterator<BytesWritable> valueIterator) {
+    if (!valueIterator.hasNext()) {
       throw new IllegalArgumentException("Expect values to be not empty.");
     }
-    try {
-      return doAssembleAndGetValue(keyBytes, values);
-    } finally {
-      reset();
-    }
-  }
+    // TODO: Getting rid of this large allocation would require leveraging MR secondary sorting
+    List<byte[]> chunkBytes = new ArrayList<>();
 
-  private Optional<ValueBytesAndSchemaId> doAssembleAndGetValue(
-      final byte[] keyBytes,
-      final List<KafkaInputMapperValue> values) {
-    values.sort(Comparator.comparingLong(value -> value.offset));
-
-    for (int i = values.size() - 1; i >= 0; i--) { // Start from the value with the highest offset
-      KafkaInputMapperValue mapperValue = values.get(i);
-      if (isRegularMessage(mapperValue)) {
-        return mapperValue.valueType == MapperValueType.DELETE
-            ? Optional.empty()
-            : Optional.of(new ValueBytesAndSchemaId(mapperValue.value, mapperValue.schemaId));
-
-      } else if (mapperValue.schemaId == AvroProtocolDefinition.CHUNKED_VALUE_MANIFEST.getCurrentProtocolVersion()) { // chunk
-                                                                                                                      // manifest
-        final ChunkedValueManifest chunkedValueManifest = manifestSerializer.deserialize(
-            ByteUtils.extractByteArray(mapperValue.value),
-            AvroProtocolDefinition.CHUNKED_VALUE_MANIFEST.getCurrentProtocolVersion());
-        if (chunksByCompositeKey.isEmpty()) {
-          buildChunksByCompositeKeyMapping(keyBytes, values);
-        }
-        return Optional.of(assembleLargeValue(chunkedValueManifest));
-
-      } else if (mapperValue.schemaId == AvroProtocolDefinition.CHUNK.getCurrentProtocolVersion()) { // chunk value
-        // No need to handle it here
-      } else {
-        throw new VeniceException(
-            String.format(
-                "Unhandled case with chunked key suffix %s and value schema ID %d",
-                deserializeChunkedKeySuffix(mapperValue.chunkedKeySuffix),
-                mapperValue.schemaId));
+    KafkaInputMapperValue mapperValue = null;
+    byte[] currentValueBytes;
+    byte[] largestValueBytes = null;
+    long largestOffset = Long.MIN_VALUE;
+    while (valueIterator.hasNext()) { // Start from the value with the highest offset
+      currentValueBytes = valueIterator.next().copyBytes();
+      mapperValue = KAFKA_INPUT_MAPPER_VALUE_AVRO_SPECIFIC_DESERIALIZER.deserialize(mapperValue, currentValueBytes);
+      if (mapperValue.schemaId == AvroProtocolDefinition.CHUNK.getCurrentProtocolVersion()) {
+        chunkBytes.add(currentValueBytes);
+      } else if (mapperValue.offset > largestOffset) {
+        largestOffset = mapperValue.offset;
+        largestValueBytes = currentValueBytes;
       }
     }
-    throw new VeniceException("No regular value nor chunk manifest for key: " + ByteUtils.toHexString(keyBytes));
+    if (largestValueBytes == null) {
+      throw new VeniceException("No regular value nor chunk manifest for key: " + ByteUtils.toHexString(keyBytes));
+    }
+    mapperValue = KAFKA_INPUT_MAPPER_VALUE_AVRO_SPECIFIC_DESERIALIZER.deserialize(mapperValue, largestValueBytes);
+
+    if (mapperValue.valueType == MapperValueType.DELETE) {
+      return null;
+    } else if (mapperValue.schemaId > 0) {
+      return new ValueBytesAndSchemaId(mapperValue.value, mapperValue.schemaId);
+    } else if (mapperValue.schemaId == AvroProtocolDefinition.CHUNKED_VALUE_MANIFEST.getCurrentProtocolVersion()) {
+      final ChunkedValueManifest chunkedValueManifest = manifestSerializer.deserialize(
+          ByteUtils.extractByteArray(mapperValue.value),
+          AvroProtocolDefinition.CHUNKED_VALUE_MANIFEST.getCurrentProtocolVersion());
+
+      return assembleLargeValue(keyBytes, chunkedValueManifest, chunkBytes);
+    } else {
+      throw new VeniceException(
+          String.format(
+              "Unhandled case with chunked key suffix %s and value schema ID %d",
+              deserializeChunkedKeySuffix(mapperValue.chunkedKeySuffix),
+              mapperValue.schemaId));
+    }
   }
 
-  private ValueBytesAndSchemaId assembleLargeValue(final ChunkedValueManifest manifest) {
-    List<ByteBuffer> allChunkBytes = new ArrayList<>(manifest.keysWithChunkIdSuffix.size());
+  private ValueBytesAndSchemaId assembleLargeValue(
+      byte[] keyBytes,
+      final ChunkedValueManifest manifest,
+      List<byte[]> allChunkBytes) {
+    byte[][] valueChunks = new byte[manifest.keysWithChunkIdSuffix.size()][];
+    ByteBuffer[] chunkKeySuffixes = new ByteBuffer[manifest.keysWithChunkIdSuffix.size()];
+    int startPosition, suffixLength;
+    ByteBuffer byteBuffer;
+    for (int i = 0; i < manifest.keysWithChunkIdSuffix.size(); i++) {
+      byteBuffer = manifest.keysWithChunkIdSuffix.get(i);
+      startPosition = byteBuffer.position() + keyBytes.length;
+      suffixLength = byteBuffer.remaining() - keyBytes.length;
+      chunkKeySuffixes[i] = ByteBuffer.wrap(byteBuffer.array(), startPosition, suffixLength);
+    }
+
     int totalByteCount = 0;
-
-    for (int chunkIndex = 0; chunkIndex < manifest.keysWithChunkIdSuffix.size(); chunkIndex++) {
-      ByteBuffer compositeKey = manifest.keysWithChunkIdSuffix.get(chunkIndex);
-      ByteBuffer chunkBytes = this.chunksByCompositeKey.get(compositeKey);
-      if (chunkBytes == null) {
-        throw new VeniceException(
-            "Cannot assemble a large value. Missing a chunk with the composite key: "
-                + ByteUtils.toHexString(ByteUtils.extractByteArray(compositeKey)));
+    KafkaInputMapperValue chunk = null;
+    int chunksFound = 0;
+    for (byte[] chunkBytes: allChunkBytes) {
+      if (chunksFound == valueChunks.length) {
+        break;
       }
-      allChunkBytes.add(chunkBytes);
-      totalByteCount += chunkBytes.remaining();
+      chunk = KAFKA_INPUT_MAPPER_VALUE_AVRO_SPECIFIC_DESERIALIZER.deserialize(chunk, chunkBytes);
+      for (int i = 0; i < chunkKeySuffixes.length; i++) {
+        byteBuffer = chunkKeySuffixes[i];
+        if (byteBuffer.equals(chunk.chunkedKeySuffix)) {
+          byte[] valueChunk = new byte[chunk.value.remaining()];
+          totalByteCount += valueChunk.length;
+          chunk.value.get(valueChunk);
+          valueChunks[i] = valueChunk;
+          chunksFound++;
+          break;
+        }
+      }
     }
+
+    if (chunksFound != valueChunks.length) {
+      int missingChunks = valueChunks.length - chunksFound;
+      throw new VeniceException(
+          "Cannot assemble a large value. Missing " + missingChunks + " / " + valueChunks.length + " chunks.");
+    }
+
     if (totalByteCount != manifest.size) {
       throw new VeniceException(String.format("Expect %d byte(s) but got %d byte(s)", manifest.size, totalByteCount));
     }
-    return new ValueBytesAndSchemaId(concatenateAllChunks(allChunkBytes, totalByteCount), manifest.schemaId);
-  }
-
-  private void buildChunksByCompositeKeyMapping(final byte[] keyBytes, final List<KafkaInputMapperValue> values) {
-    values.forEach(mapperValue -> {
-      if (mapperValue.schemaId == AvroProtocolDefinition.CHUNK.getCurrentProtocolVersion()) {
-        ByteBuffer compositeKey =
-            createCompositeKey(keyBytes, ByteUtils.extractByteArray(mapperValue.chunkedKeySuffix));
-        chunksByCompositeKey.put(compositeKey, mapperValue.value);
-      }
-    });
-  }
-
-  private void reset() {
-    chunksByCompositeKey.clear();
+    return new ValueBytesAndSchemaId(concatenateAllChunks(valueChunks, totalByteCount), manifest.schemaId);
   }
 
   private ChunkedKeySuffix deserializeChunkedKeySuffix(ByteBuffer chunkedKeySuffixBytes) {
     return chunkedKeySuffixDeserializer.deserialize(chunkedKeySuffixBytes);
   }
 
-  private ByteBuffer createCompositeKey(final byte[] keyBytes, final byte[] chunkedKeySuffixBytes) {
-    return ByteBuffer.wrap(keyWithChunkingSuffixSerializer.serialize(keyBytes, chunkedKeySuffixBytes));
-  }
-
-  private boolean isRegularMessage(KafkaInputMapperValue mapperValue) {
-    return mapperValue.schemaId > 0 || mapperValue.valueType == MapperValueType.DELETE;
-  }
-
-  private byte[] concatenateAllChunks(final List<ByteBuffer> chunks, final int totalByteCount) {
+  private byte[] concatenateAllChunks(final byte[][] chunks, final int totalByteCount) {
     byte[] concatenatedChunk = new byte[totalByteCount];
     int currStartingIndexInDst = 0;
-    for (ByteBuffer chunk: chunks) {
-      final int chunkSizeInBytes = chunk.remaining();
-      System.arraycopy(chunk.array(), chunk.position(), concatenatedChunk, currStartingIndexInDst, chunkSizeInBytes);
-      currStartingIndexInDst += chunkSizeInBytes;
+    for (byte[] chunk: chunks) {
+      System.arraycopy(chunk, 0, concatenatedChunk, currStartingIndexInDst, chunk.length);
+      currStartingIndexInDst += chunk.length;
     }
     return concatenatedChunk;
   }

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/input/kafka/TestVeniceKafkaInputReducer.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/input/kafka/TestVeniceKafkaInputReducer.java
@@ -9,7 +9,6 @@ import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Optional;
 import org.apache.hadoop.io.BytesWritable;
 import org.apache.hadoop.mapred.Reporter;
 import org.mockito.Mockito;
@@ -57,10 +56,9 @@ public class TestVeniceKafkaInputReducer {
     List<BytesWritable> values =
         getValues(Arrays.asList(MapperValueType.PUT, MapperValueType.PUT, MapperValueType.PUT));
 
-    Optional<VeniceReducer.VeniceWriterMessage> messageOptional =
+    VeniceReducer.VeniceWriterMessage message =
         reducer.extract(keyWritable, values.iterator(), Mockito.mock(Reporter.class));
-    Assert.assertTrue(messageOptional.isPresent());
-    VeniceReducer.VeniceWriterMessage message = messageOptional.get();
+    Assert.assertNotNull(message);
     Assert.assertEquals(message.getKeyBytes(), keyBytes);
     Assert.assertEquals(message.getValueBytes(), (VALUE_PREFIX + 2).getBytes());
     Assert.assertEquals(message.getValueSchemaId(), -1);
@@ -70,17 +68,16 @@ public class TestVeniceKafkaInputReducer {
      */
     values = getValues(Arrays.asList(MapperValueType.PUT, MapperValueType.PUT, MapperValueType.DELETE));
 
-    messageOptional = reducer.extract(keyWritable, values.iterator(), Mockito.mock(Reporter.class));
-    Assert.assertTrue(messageOptional.isPresent());
+    message = reducer.extract(keyWritable, values.iterator(), Mockito.mock(Reporter.class));
+    Assert.assertNotNull(message);
 
     /**
      * Construct a list of values, which contains both 'PUT' and 'DELETE', but 'DELETE' is in the middle.
      */
     values = getValues(Arrays.asList(MapperValueType.PUT, MapperValueType.DELETE, MapperValueType.PUT));
 
-    messageOptional = reducer.extract(keyWritable, values.iterator(), Mockito.mock(Reporter.class));
-    Assert.assertTrue(messageOptional.isPresent());
-    message = messageOptional.get();
+    message = reducer.extract(keyWritable, values.iterator(), Mockito.mock(Reporter.class));
+    Assert.assertNotNull(message);
     Assert.assertEquals(message.getKeyBytes(), keyBytes);
     Assert.assertEquals(message.getValueBytes(), (VALUE_PREFIX + 2).getBytes());
     Assert.assertEquals(message.getValueSchemaId(), -1);

--- a/docs/ops_guide/ops_guide.md
+++ b/docs/ops_guide/ops_guide.md
@@ -1,0 +1,9 @@
+---
+layout: default
+title: Operator Guides
+has_children: true
+permalink: docs/ops_guide
+---
+# Operator Guide
+
+This folder includes guides for Venice operators. Users should refer to Venice User Guide on how-to and the concepts.

--- a/docs/ops_guide/repush.md
+++ b/docs/ops_guide/repush.md
@@ -54,7 +54,7 @@ others. Alternatively, it's possible that correlated hardware failures resulted 
 partitions. In these cases, as long as one of the DCs is healthy, it can be used as the source of a repush to repair the
 data in other DCs.
 
-## Repush Configuration
+## Usage
 The following Venice Push Job config is used to enable Repush functionality:
 ```
 source.kafka = true

--- a/docs/ops_guide/repush.md
+++ b/docs/ops_guide/repush.md
@@ -95,7 +95,7 @@ it defaults to false.
 kafka.input.combiner.enabled = true
 ```
 ## Future Work
-Repush will eventually support a more efficient way to perform [TTL](https://linkedin.github.io/venice/user_guide/ttl).
+Repush will eventually support a more efficient way to perform [TTL](https://linkedin.github.io/venice/docs/user_guide/ttl).
 
 Another potential enhancement would be to add support for changing the compression setting of a store, which currently
 requires a Full Push, and which Repush does not support yet.

--- a/docs/ops_guide/repush.md
+++ b/docs/ops_guide/repush.md
@@ -20,14 +20,21 @@ The various motivations for operator-driven Repushes are described in more detai
 
 ### Reconfiguration
 In Venice, some store configs can be changed live, while some others take effect when the next store-version is pushed.
-Configs which take effect on the next store-version push include:
+Configs which can be changed with a Repush (or a regular Full Push) include:
 
 1. Partition-related settings
    1. Partition count
    2. Amplification factor
    3. Custom partitioner implementation
-2. Compression algorithm
-3. Replication settings
+2. Replication settings
+3. Whether a store is hybrid
+
+Having some configs be immutable within the scope of a store-version makes the development and maintenance of the system
+easier to reason about. In the past, the Venice team has leveraged Repushes to execute large scale migrations as new
+modes were introduced (e.g., migrating from active-passive to active-active replication, or migrating from the 
+offline/bootstrap/online state model to the leader/follower state model). Repush enabled operators to roll out (and 
+occasionally roll back) these migrations in a way that was invisible to users of the platform. Although these migrations 
+are behind us, it is possible that future migrations may also be designed to be executed this way.
 
 ### Sorting
 When doing a Full Push (and also when Repushing), the data gets sorted inside the Map Reduce job, prior to pushing. The 
@@ -48,7 +55,7 @@ partitions. In these cases, as long as one of the DCs is healthy, it can be used
 data in other DCs.
 
 ## Repush Configuration
-The following Venice Push Job config ise used to enable Repush functionality:
+The following Venice Push Job config is used to enable Repush functionality:
 ```
 source.kafka = true
 ```

--- a/docs/ops_guide/repush.md
+++ b/docs/ops_guide/repush.md
@@ -1,0 +1,88 @@
+---
+layout: default
+title: Repush
+parent: Operator Guides
+---
+
+# Repush
+
+In Venice, there are many things which happen under the hood as part of Full Pushes. Besides serving to refresh data,
+Full Pushes also serve to make certain configs take effect, and also more generally keep the system tidy and healthy.
+
+Many Venice users choose to periodically do Full Pushes for the sake of refreshing their data, in which case the
+auxiliary goals of Full Pushes end up being fulfilled organically.
+
+In other cases, users do Full Pushes either infrequently, or not at all. In these cases, the operator may want to 
+manually trigger a Repush, without involving the user.
+
+## Repush Use Cases
+The various motivations for operator-driven Repushes are described in more details below.
+
+### Reconfiguration
+In Venice, some store configs can be changed live, while some others take effect when the next store-version is pushed.
+Configs which take effect on the next store-version push include:
+
+1. Partition-related settings
+   1. Partition count
+   2. Amplification factor
+   3. Custom partitioner implementation
+2. Compression algorithm
+3. Replication settings
+
+### Sorting
+When doing a Full Push (and also when Repushing), the data gets sorted inside the Map Reduce job, prior to pushing. The 
+Start of Push control message is annotated with the fact that the incoming data is sorted, which triggers an alternative 
+code path within servers (and Da Vinci clients) in order to generate the storage files more efficiently.
+
+When doing a Stream Reprocessing (SR), on the other hand, data does not get sorted. More generally, if the last Full 
+Push happened a while ago, and lots of nearline writes happened since then, there could be a large portion of the data 
+which is unsorted, and the operator may find that rebalance performance degrades as a result.
+
+While it is not considered necessary to perform a Repush after every SR just for the sake of sorting, it can sometimes 
+be useful if the last SR or Full Push happened quite a while ago.
+
+### Repair
+In some cases where a datacenter (DC) suffered an outage, it is possible that pushes succeeded in some DCs and failed in
+others. Alternatively, it's possible that correlated hardware failures resulted in some DC losing all replicas of some 
+partitions. In these cases, as long as one of the DCs is healthy, it can be used as the source of a repush to repair the
+data in other DCs.
+
+## Repush Configuration
+The following Venice Push Job config ise used to enable Repush functionality:
+```
+source.kafka = true
+```
+
+### Optional Configs
+The following Venice Push Job configs provide more control over the Repush functionality:
+
+To specify which Kafka topic (i.e. which store-version) to use as the source of the Repush. If unspecified, it will
+default to the highest available store-version.
+```
+kafka.input.topic = store-name_v7
+```
+
+To specify which datacenter to pull from. If unspecified, it will default to one of the DCs which contains the highest
+available store-version.
+```
+kafka.input.fabric = dc-name
+```
+
+To specify the address of the Kafka cluster to pull from. If unspecified, it will use the one returned by the controller
+of the datacenter chosen to pull from.
+```
+kafka.input.broker.url = kafka-url:port
+```
+
+To specify the size of the offset range each mapper task will be responsible for. Each Kafka partition is fetched in
+parallel by multiple mappers, each taking care of distinct ranges. If unspecified, the default is 5M.
+```
+kafka.input.max.records.per.mapper = 1000000
+```
+
+To specify whether to enable the Combiner of the Map Reduce job, in order to prune the shuffling traffic between mappers
+and reducers. This is an experimental functionality that has not been vetted for production usage yet. If unspecified,
+it defaults to false.
+```
+kafka.input.combiner.enabled = true
+```

--- a/docs/ops_guide/repush.md
+++ b/docs/ops_guide/repush.md
@@ -2,6 +2,7 @@
 layout: default
 title: Repush
 parent: Operator Guides
+permalink: docs/ops_guide/repush
 ---
 
 # Repush
@@ -15,7 +16,7 @@ auxiliary goals of Full Pushes end up being fulfilled organically.
 In other cases, users do Full Pushes either infrequently, or not at all. In these cases, the operator may want to 
 manually trigger a Repush, without involving the user.
 
-## Repush Use Cases
+## Use Cases
 The various motivations for operator-driven Repushes are described in more details below.
 
 ### Reconfiguration
@@ -94,7 +95,7 @@ it defaults to false.
 kafka.input.combiner.enabled = true
 ```
 ## Future Work
-Repush will eventually support a more efficient way to perform [TTL](../user_guide/ttl.md).
+Repush will eventually support a more efficient way to perform [TTL](https://linkedin.github.io/venice/user_guide/ttl).
 
 Another potential enhancement would be to add support for changing the compression setting of a store, which currently
 requires a Full Push, and which Repush does not support yet.

--- a/docs/ops_guide/repush.md
+++ b/docs/ops_guide/repush.md
@@ -93,3 +93,8 @@ it defaults to false.
 ```
 kafka.input.combiner.enabled = true
 ```
+## Future Work
+Repush will eventually support a more efficient way to perform [TTL](../user_guide/ttl.md).
+
+Another potential enhancement would be to add support for changing the compression setting of a store, which currently
+requires a Full Push, and which Repush does not support yet.

--- a/docs/user_guide/ttl.md
+++ b/docs/user_guide/ttl.md
@@ -1,0 +1,29 @@
+---
+layout: default
+title: Time to Live (TTL)
+parent: User Guides
+---
+
+# Time to Live (TTL)
+For Venice stores that receive nearline writes, it is possible to set up a periodic purge of records that are older than
+some threshold.
+
+The way this works is by leveraging the real-time buffer replay mechanism of hybrid stores. As part of pushing a new 
+store-version, after the push finishes, but before swapping the read traffic over to the new version, there is a buffer
+replay phase where the last N seconds of buffered real-time data is replayed. The replayed data gets overlaid on top of
+the data from the Full Push.
+
+This can be leveraged in order to achieve a TTL behavior. By scheduling periodic empty pushes and configuring how far 
+back to replay the real-time data (N), one can control the TTL parameters. The time to live is defined by N, which acts 
+as a "minimum TTL", while the "maximum TTL" is N + delay between each empty push. For example, if you schedule a daily 
+empty push, and N = 6 days, then the oldest data in your store will be at least 6 days old, and at most 7 days old.
+
+## How to Set it Up
+At the moment, there are two ways to perform empty pushes:
+1. Via the `empty-push` command in the admin tool.
+2. Via the Venice Push Job, executed from a Hadoop grid, but with an empty input directory.
+
+## Future Work
+A more efficient implementation of TTL is currently under development, which will leverage [Repush](../ops_guide/repush.md)
+in order to do an offline compaction and sorting of the data and thus minimize the impact on servers. This guide will be
+updated when the functionality is ready to try.

--- a/docs/user_guide/ttl.md
+++ b/docs/user_guide/ttl.md
@@ -2,6 +2,7 @@
 layout: default
 title: Time to Live (TTL)
 parent: User Guides
+permalink: docs/user_guide/ttl
 ---
 
 # Time to Live (TTL)
@@ -18,12 +19,22 @@ back to replay the real-time data (N), one can control the TTL parameters. The t
 as a "minimum TTL", while the "maximum TTL" is N + delay between each empty push. For example, if you schedule a daily 
 empty push, and N = 6 days, then the oldest data in your store will be at least 6 days old, and at most 7 days old.
 
+## Use Cases
+TTL can serve as a storage efficiency optimization for use cases where the data is transient in nature, and not useful
+beyond a certain age.
+
+TTL can also be useful in certain scenarios where the data should not be retained longer than prescribed for compliance
+reasons. Note that for these scenarios, it is important to understand (as explained above) that the rewind time is the 
+minimum, not maximum, TTL. It is also advisable to schedule the periodic purging such that there is a margin of safety 
+in case of infra delays or failures.
+
 ## Usage
 At the moment, there are two ways to perform empty pushes:
 1. Via the `empty-push` command in the admin tool.
-2. Via the Venice Push Job, executed from a Hadoop grid, but with an empty input directory.
+2. Via the Venice Push Job, executed from a Hadoop grid, but with an input directory that contains a file with no 
+   records in it.
 
 ## Future Work
-A more efficient implementation of TTL is currently under development, which will leverage [Repush](../ops_guide/repush.md)
+A more efficient implementation of TTL is currently under development, which will leverage [Repush](https://linkedin.github.io/venice/ops_guide/repush)
 in order to do an offline compaction and sorting of the data and thus minimize the impact on servers. This guide will be
 updated when the functionality is ready to try.

--- a/docs/user_guide/ttl.md
+++ b/docs/user_guide/ttl.md
@@ -35,6 +35,6 @@ At the moment, there are two ways to perform empty pushes:
    records in it.
 
 ## Future Work
-A more efficient implementation of TTL is currently under development, which will leverage [Repush](https://linkedin.github.io/venice/ops_guide/repush)
+A more efficient implementation of TTL is currently under development, which will leverage [Repush](https://linkedin.github.io/venice/docs/ops_guide/repush)
 in order to do an offline compaction and sorting of the data and thus minimize the impact on servers. This guide will be
 updated when the functionality is ready to try.

--- a/docs/user_guide/ttl.md
+++ b/docs/user_guide/ttl.md
@@ -18,7 +18,7 @@ back to replay the real-time data (N), one can control the TTL parameters. The t
 as a "minimum TTL", while the "maximum TTL" is N + delay between each empty push. For example, if you schedule a daily 
 empty push, and N = 6 days, then the oldest data in your store will be at least 6 days old, and at most 7 days old.
 
-## How to Set it Up
+## Usage
 At the moment, there are two ways to perform empty pushes:
 1. Via the `empty-push` command in the admin tool.
 2. Via the Venice Push Job, executed from a Hadoop grid, but with an empty input directory.

--- a/docs/user_guide/user_guide.md
+++ b/docs/user_guide/user_guide.md
@@ -1,0 +1,9 @@
+---
+layout: default
+title: User Guides
+has_children: true
+permalink: docs/user_guide
+---
+# User Guide
+
+This folder includes guides for Venice users.

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/utils/SslUtils.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/utils/SslUtils.java
@@ -111,6 +111,10 @@ public class SslUtils {
     File file = new File(tempDir.getAbsolutePath(), resource);
     if (!file.exists()) {
       try (InputStream is = (ClassLoader.getSystemResourceAsStream(resource))) {
+        if (is == null) {
+          throw new IllegalStateException(
+              "ClassLoader.getSystemResourceAsStream returned null resource for: " + resource);
+        }
         Files.copy(is, file.getAbsoluteFile().toPath());
       } catch (IOException e) {
         throw new RuntimeException("Failed to copy resource: " + resource + " to tmp dir", e);


### PR DESCRIPTION
Implemented object reuse for chunked topics. Because the logic is more complex, it is still not as efficient as non-chunked, but nonetheless better than before. The memory requirement is now to buffer the bytes of all shuffled chunks rather than the objects of all shuffled events.

Also removed an unnecessary optional for the reducer hot path for all implementations (including regular VPJ and repush).

## How was this PR tested?
Unit tests (updated to new code structure)
Internal CI (green!)

## Does this PR introduce any user-facing changes?
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.