### PR TITLE
[controller][common] Support store graveyard cleanup

### DIFF
--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/exceptions/ErrorType.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/exceptions/ErrorType.java
@@ -15,7 +15,7 @@ public enum ErrorType {
   SCHEMA_NOT_FOUND(ExceptionType.SCHEMA_NOT_FOUND), CONNECTION_ERROR(ExceptionType.CONNECTION_ERROR),
   @JsonEnumDefaultValue
   GENERAL_ERROR(ExceptionType.GENERAL_ERROR), BAD_REQUEST(ExceptionType.BAD_REQUEST),
-  CONCURRENT_BATCH_PUSH(ExceptionType.BAD_REQUEST), PRECONDITION_CHECK_FAILED(ExceptionType.BAD_REQUEST);
+  CONCURRENT_BATCH_PUSH(ExceptionType.BAD_REQUEST), RESOURCE_STILL_EXISTS(ExceptionType.BAD_REQUEST);
 
   private final ExceptionType exceptionType;
 

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/exceptions/ErrorType.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/exceptions/ErrorType.java
@@ -15,7 +15,7 @@ public enum ErrorType {
   SCHEMA_NOT_FOUND(ExceptionType.SCHEMA_NOT_FOUND), CONNECTION_ERROR(ExceptionType.CONNECTION_ERROR),
   @JsonEnumDefaultValue
   GENERAL_ERROR(ExceptionType.GENERAL_ERROR), BAD_REQUEST(ExceptionType.BAD_REQUEST),
-  CONCURRENT_BATCH_PUSH(ExceptionType.BAD_REQUEST);
+  CONCURRENT_BATCH_PUSH(ExceptionType.BAD_REQUEST), PRECONDITION_CHECK_FAILED(ExceptionType.BAD_REQUEST);
 
   private final ExceptionType exceptionType;
 

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/AbstractVeniceStats.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/AbstractVeniceStats.java
@@ -102,13 +102,6 @@ public class AbstractVeniceStats {
     });
   }
 
-  protected void unregisterSensor(String sensorName) {
-    Sensor sensor = sensors.remove(sensorName);
-    if (sensor != null) {
-      metricsRepository.removeSensor(sensorName);
-    }
-  }
-
   protected void unregisterAllSensors() {
     for (Sensor sensor: sensors.values()) {
       metricsRepository.removeSensor(sensor.name());

--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -321,6 +321,18 @@ public class ConfigKeys {
    */
   public static final String CONTROLLER_IN_AZURE_FABRIC = "controller.in.azure.fabric";
 
+  /**
+   * Whether to enable graveyard cleanup for batch-only store at cluster level. Default is false.
+   */
+  public static final String CONTROLLER_ENABLE_GRAVEYARD_CLEANUP_FOR_BATCH_ONLY_STORE =
+      "controller.enable.graveyard.cleanup.for.batch.only.store";
+
+  /**
+   * Sleep interval between each graveyard list fetch from ZK in StoreGraveyardCleanup service. Default is 15 min.
+   */
+  public static final String CONTROLLER_GRAVEYARD_CLEANUP_SLEEP_INTERVAL_BETWEEN_LIST_FETCH_MS =
+      "controller.graveyard.cleanup.sleep.interval.between.list.fetch.ms";
+
   // Server specific configs
   public static final String LISTENER_PORT = "listener.port";
   public static final String DATA_BASE_PATH = "data.base.path";

--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -324,14 +324,20 @@ public class ConfigKeys {
   /**
    * Whether to enable graveyard cleanup for batch-only store at cluster level. Default is false.
    */
-  public static final String CONTROLLER_ENABLE_GRAVEYARD_CLEANUP_FOR_BATCH_ONLY_STORE =
-      "controller.enable.graveyard.cleanup.for.batch.only.store";
+  public static final String CONTROLLER_STORE_GRAVEYARD_CLEANUP_ENABLED = "controller.store.graveyard.cleanup.enabled";
+
+  /**
+   * When store graveyard cleanup is enabled, delete the graveyard znode if it has not been changed for a specific time.
+   * Default is 0 min.
+   */
+  public static final String CONTROLLER_STORE_GRAVEYARD_CLEANUP_DELAY_MINUTES =
+      "controller.store.graveyard.cleanup.delay.minutes";
 
   /**
    * Sleep interval between each graveyard list fetch from ZK in StoreGraveyardCleanup service. Default is 15 min.
-   */
-  public static final String CONTROLLER_GRAVEYARD_CLEANUP_SLEEP_INTERVAL_BETWEEN_LIST_FETCH_MS =
-      "controller.graveyard.cleanup.sleep.interval.between.list.fetch.ms";
+   * */
+  public static final String CONTROLLER_STORE_GRAVEYARD_CLEANUP_SLEEP_INTERVAL_BETWEEN_LIST_FETCH_MINUTES =
+      "controller.store.graveyard.cleanup.sleep.interval.between.list.fetch.minutes";
 
   // Server specific configs
   public static final String LISTENER_PORT = "listener.port";

--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerRoute.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerRoute.java
@@ -279,7 +279,7 @@ public enum ControllerRoute {
 
   CLEANUP_INSTANCE_CUSTOMIZED_STATES(
       "/cleanup_instance_customized_states", HttpMethod.POST, Collections.singletonList(CLUSTER)
-  );
+  ), REMOVE_STORE_FROM_GRAVEYARD("/remove_store_from_graveyard", HttpMethod.POST, Collections.singletonList(NAME));
 
   private final String path;
   private final HttpMethod httpMethod;

--- a/internal/venice-common/src/main/java/com/linkedin/venice/exceptions/PreconditionCheckFailedException.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/exceptions/PreconditionCheckFailedException.java
@@ -1,0 +1,16 @@
+package com.linkedin.venice.exceptions;
+
+import org.apache.http.HttpStatus;
+
+
+public class PreconditionCheckFailedException extends VeniceException {
+  public PreconditionCheckFailedException(String message) {
+    super(message);
+    super.errorType = ErrorType.PRECONDITION_CHECK_FAILED;
+  }
+
+  @Override
+  public int getHttpStatusCode() {
+    return HttpStatus.SC_PRECONDITION_FAILED;
+  }
+}

--- a/internal/venice-common/src/main/java/com/linkedin/venice/exceptions/ResourceStillExistsException.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/exceptions/ResourceStillExistsException.java
@@ -3,10 +3,10 @@ package com.linkedin.venice.exceptions;
 import org.apache.http.HttpStatus;
 
 
-public class PreconditionCheckFailedException extends VeniceException {
-  public PreconditionCheckFailedException(String message) {
+public class ResourceStillExistsException extends VeniceException {
+  public ResourceStillExistsException(String message) {
     super(message);
-    super.errorType = ErrorType.PRECONDITION_CHECK_FAILED;
+    super.errorType = ErrorType.RESOURCE_STILL_EXISTS;
   }
 
   @Override

--- a/internal/venice-common/src/main/java/com/linkedin/venice/helix/HelixStoreGraveyard.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/helix/HelixStoreGraveyard.java
@@ -44,8 +44,7 @@ public class HelixStoreGraveyard implements StoreGraveyard {
       Collection<String> clusterNames,
       VeniceSerializer<Store> storeSerializer) {
     this.clusterNames = new HashSet<>(clusterNames);
-    adapterSerializer
-        .registerSerializer(getGeneralDeletedStorePath(PathResourceRegistry.WILDCARD_MATCH_ANY), storeSerializer);
+    adapterSerializer.registerSerializer(getGeneralStoreGraveyardPath(), storeSerializer);
     zkClient.setZkSerializer(adapterSerializer);
     dataAccessor = new ZkBaseDataAccessor<>(zkClient);
   }
@@ -81,37 +80,6 @@ public class HelixStoreGraveyard implements StoreGraveyard {
         "Found store: {} in the store graveyard. Will initialize the new store at version: {}.",
         storeName,
         largestUsedVersionNumber);
-    return largestUsedVersionNumber;
-  }
-
-  @Override
-  public int getPerUserStoreSystemStoreLargestUsedVersionNumber(
-      String userStoreName,
-      VeniceSystemStoreType systemStoreType) {
-    String systemStoreName = systemStoreType.getSystemStoreName(userStoreName);
-    List<Store> deletedStores = getStoreFromAllClusters(userStoreName);
-    if (deletedStores.isEmpty()) {
-      LOGGER.info(
-          "User store: {} does NOT exist in the store graveyard. Hence, no largest used version for "
-              + "its system store: {}.",
-          userStoreName,
-          systemStoreName);
-      return Store.NON_EXISTING_VERSION;
-    }
-    int largestUsedVersionNumber = Store.NON_EXISTING_VERSION;
-    for (Store deletedStore: deletedStores) {
-      Map<String, SystemStoreAttributes> systemStoreNamesToAttributes = deletedStore.getSystemStores();
-      SystemStoreAttributes systemStoreAttributes =
-          systemStoreNamesToAttributes.get(VeniceSystemStoreType.getSystemStoreType(systemStoreName).getPrefix());
-      if (systemStoreAttributes != null) {
-        largestUsedVersionNumber =
-            Math.max(largestUsedVersionNumber, systemStoreAttributes.getLargestUsedVersionNumber());
-      }
-    }
-
-    if (largestUsedVersionNumber == Store.NON_EXISTING_VERSION) {
-      LOGGER.info("Can not find largest used version number for {}.", systemStoreName);
-    }
     return largestUsedVersionNumber;
   }
 
@@ -160,20 +128,32 @@ public class HelixStoreGraveyard implements StoreGraveyard {
 
     // Store does not exist in graveyard OR store already exists but the re-created store is deleted again so we need to
     // update the ZNode.
-    HelixUtils.update(dataAccessor, getClusterDeletedStorePath(clusterName, store.getName()), store);
+    HelixUtils.update(dataAccessor, getStoreGraveyardPath(clusterName, store.getName()), store);
     LOGGER.info(
         "Put store: {} into graveyard with largestUsedVersionNumber {}.",
         store.getName(),
         largestUsedVersionNumber);
   }
 
+  @Override
+  public Store getStoreFromGraveyard(String clusterName, String storeName) {
+    String path = getStoreGraveyardPath(clusterName, storeName);
+    return dataAccessor.get(path, null, AccessOption.PERSISTENT);
+  }
+
+  @Override
   public void removeStoreFromGraveyard(String clusterName, String storeName) {
-    String path = getClusterDeletedStorePath(clusterName, storeName);
+    String path = getStoreGraveyardPath(clusterName, storeName);
     Store store = dataAccessor.get(path, null, AccessOption.PERSISTENT);
     if (store != null) {
       HelixUtils.remove(dataAccessor, path);
-      LOGGER.info("Removed store: {} from graveyard.", storeName);
+      LOGGER.info("Removed store: {} from graveyard in cluster: {}.", storeName, clusterName);
     }
+  }
+
+  @Override
+  public List<String> listStoreNamesFromGraveyard(String clusterName) {
+    return HelixUtils.listPathContents(dataAccessor, getStoreGraveyardParentPath(clusterName));
   }
 
   /**
@@ -185,7 +165,7 @@ public class HelixStoreGraveyard implements StoreGraveyard {
   private List<Store> getStoreFromAllClusters(String storeName) {
     List<Store> stores = new ArrayList<>();
     for (String clusterName: clusterNames) {
-      Store store = dataAccessor.get(getClusterDeletedStorePath(clusterName, storeName), null, AccessOption.PERSISTENT);
+      Store store = dataAccessor.get(getStoreGraveyardPath(clusterName, storeName), null, AccessOption.PERSISTENT);
       if (store != null) {
         stores.add(store);
       }
@@ -193,12 +173,44 @@ public class HelixStoreGraveyard implements StoreGraveyard {
     return stores;
   }
 
-  private String getGeneralDeletedStorePath(String storeName) {
-    return HelixUtils.getHelixClusterZkPath(PathResourceRegistry.WILDCARD_MATCH_ANY) + STORE_GRAVEYARD_PATH + "/"
-        + storeName;
+  private int getPerUserStoreSystemStoreLargestUsedVersionNumber(
+      String userStoreName,
+      VeniceSystemStoreType systemStoreType) {
+    String systemStoreName = systemStoreType.getSystemStoreName(userStoreName);
+    List<Store> deletedStores = getStoreFromAllClusters(userStoreName);
+    if (deletedStores.isEmpty()) {
+      LOGGER.info(
+          "User store: {} does NOT exist in the store graveyard. Hence, no largest used version for its system store: {}",
+          userStoreName,
+          systemStoreName);
+      return Store.NON_EXISTING_VERSION;
+    }
+    int largestUsedVersionNumber = Store.NON_EXISTING_VERSION;
+    for (Store deletedStore: deletedStores) {
+      Map<String, SystemStoreAttributes> systemStoreNamesToAttributes = deletedStore.getSystemStores();
+      SystemStoreAttributes systemStoreAttributes =
+          systemStoreNamesToAttributes.get(VeniceSystemStoreType.getSystemStoreType(systemStoreName).getPrefix());
+      if (systemStoreAttributes != null) {
+        largestUsedVersionNumber =
+            Math.max(largestUsedVersionNumber, systemStoreAttributes.getLargestUsedVersionNumber());
+      }
+    }
+
+    if (largestUsedVersionNumber == Store.NON_EXISTING_VERSION) {
+      LOGGER.info("Can not find largest used version number for {}.", systemStoreName);
+    }
+    return largestUsedVersionNumber;
   }
 
-  private String getClusterDeletedStorePath(String clusterName, String storeName) {
-    return HelixUtils.getHelixClusterZkPath(clusterName) + STORE_GRAVEYARD_PATH + "/" + storeName;
+  private String getGeneralStoreGraveyardPath() {
+    return getStoreGraveyardPath(PathResourceRegistry.WILDCARD_MATCH_ANY, PathResourceRegistry.WILDCARD_MATCH_ANY);
+  }
+
+  private String getStoreGraveyardPath(String clusterName, String storeName) {
+    return getStoreGraveyardParentPath(clusterName) + "/" + storeName;
+  }
+
+  private String getStoreGraveyardParentPath(String clusterName) {
+    return HelixUtils.getHelixClusterZkPath(clusterName) + STORE_GRAVEYARD_PATH;
   }
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/helix/HelixStoreGraveyard.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/helix/HelixStoreGraveyard.java
@@ -20,6 +20,7 @@ import org.apache.helix.manager.zk.ZkBaseDataAccessor;
 import org.apache.helix.zookeeper.impl.client.ZkClient;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.zookeeper.data.Stat;
 
 
 public class HelixStoreGraveyard implements StoreGraveyard {
@@ -136,9 +137,9 @@ public class HelixStoreGraveyard implements StoreGraveyard {
   }
 
   @Override
-  public Store getStoreFromGraveyard(String clusterName, String storeName) {
+  public Store getStoreFromGraveyard(String clusterName, String storeName, Stat stat) {
     String path = getStoreGraveyardPath(clusterName, storeName);
-    return dataAccessor.get(path, null, AccessOption.PERSISTENT);
+    return dataAccessor.get(path, stat, AccessOption.PERSISTENT);
   }
 
   @Override

--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/StoreGraveyard.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/StoreGraveyard.java
@@ -1,6 +1,7 @@
 package com.linkedin.venice.meta;
 
 import java.util.List;
+import org.apache.zookeeper.data.Stat;
 
 
 /**
@@ -25,7 +26,7 @@ public interface StoreGraveyard {
   /**
    * Get store from the graveyard in the specified cluster.
    */
-  Store getStoreFromGraveyard(String clusterName, String storeName);
+  Store getStoreFromGraveyard(String clusterName, String storeName, Stat stat);
 
   /**
    * Remove the given store from graveyard in the specified cluster.

--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/StoreGraveyard.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/StoreGraveyard.java
@@ -1,6 +1,6 @@
 package com.linkedin.venice.meta;
 
-import com.linkedin.venice.common.VeniceSystemStoreType;
+import java.util.List;
 
 
 /**
@@ -17,19 +17,23 @@ public interface StoreGraveyard {
   int getLargestUsedVersionNumber(String storeName);
 
   /**
-   * Retrieve the largest used version number for the system store of the user store from graveyard. Return 0 if the
-   * store dose not exist in the graveyard, which is the default value we used for the new store.
-   */
-  int getPerUserStoreSystemStoreLargestUsedVersionNumber(String userStoreName, VeniceSystemStoreType systemStoreType);
-
-  /**
-   * Put the given store into grave yard. If the store has already existed in the grave yard, update it by this given
+   * Put the given store into graveyard. If the store has already existed in the graveyard, update it by this given
    * store.
    */
   void putStoreIntoGraveyard(String clusterName, Store store);
 
   /**
-   * Remove the given store from grave yard if it exists.
+   * Get store from the graveyard in the specified cluster.
+   */
+  Store getStoreFromGraveyard(String clusterName, String storeName);
+
+  /**
+   * Remove the given store from graveyard in the specified cluster.
    */
   void removeStoreFromGraveyard(String clusterName, String storeName);
+
+  /**
+   * List store names from graveyard in the specified cluster.
+   */
+  List<String> listStoreNamesFromGraveyard(String clusterName);
 }

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestStoreGraveyardCleanupService.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestStoreGraveyardCleanupService.java
@@ -1,0 +1,114 @@
+package com.linkedin.venice.endToEnd;
+
+import static com.linkedin.venice.ConfigKeys.CONTROLLER_ENABLE_GRAVEYARD_CLEANUP_FOR_BATCH_ONLY_STORE;
+import static com.linkedin.venice.ConfigKeys.CONTROLLER_GRAVEYARD_CLEANUP_SLEEP_INTERVAL_BETWEEN_LIST_FETCH_MS;
+import static com.linkedin.venice.ConfigKeys.SERVER_PROMOTION_TO_LEADER_REPLICA_DELAY_SECONDS;
+
+import com.linkedin.venice.controllerapi.ControllerClient;
+import com.linkedin.venice.controllerapi.ControllerResponse;
+import com.linkedin.venice.controllerapi.NewStoreResponse;
+import com.linkedin.venice.controllerapi.TrackableControllerResponse;
+import com.linkedin.venice.controllerapi.UpdateStoreQueryParams;
+import com.linkedin.venice.integration.utils.ServiceFactory;
+import com.linkedin.venice.integration.utils.VeniceControllerWrapper;
+import com.linkedin.venice.integration.utils.VeniceMultiClusterWrapper;
+import com.linkedin.venice.integration.utils.VeniceTwoLayerMultiColoMultiClusterWrapper;
+import com.linkedin.venice.meta.StoreGraveyard;
+import com.linkedin.venice.utils.TestUtils;
+import com.linkedin.venice.utils.Utils;
+import com.linkedin.venice.utils.VeniceProperties;
+import java.util.List;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+
+public class TestStoreGraveyardCleanupService {
+  private static final int TEST_TIMEOUT = 60_000; // ms
+
+  private static final int NUMBER_OF_CHILD_DATACENTERS = 1;
+  private static final int NUMBER_OF_CLUSTERS = 1;
+  private static final String CLUSTER_NAME = "venice-cluster0";
+
+  private List<VeniceMultiClusterWrapper> childDatacenters;
+  private List<VeniceControllerWrapper> parentControllers;
+  private VeniceTwoLayerMultiColoMultiClusterWrapper multiColoMultiClusterWrapper;
+
+  @BeforeClass
+  public void setUp() {
+    Properties serverProperties = new Properties();
+    serverProperties.put(SERVER_PROMOTION_TO_LEADER_REPLICA_DELAY_SECONDS, 1L);
+
+    Properties parentControllerProperties = new Properties();
+    parentControllerProperties.put(CONTROLLER_ENABLE_GRAVEYARD_CLEANUP_FOR_BATCH_ONLY_STORE, "true");
+    parentControllerProperties.put(CONTROLLER_GRAVEYARD_CLEANUP_SLEEP_INTERVAL_BETWEEN_LIST_FETCH_MS, 1000L);
+
+    multiColoMultiClusterWrapper = ServiceFactory.getVeniceTwoLayerMultiColoMultiClusterWrapper(
+        NUMBER_OF_CHILD_DATACENTERS,
+        NUMBER_OF_CLUSTERS,
+        1,
+        1,
+        1,
+        1,
+        1,
+        Optional.of(new VeniceProperties(parentControllerProperties)),
+        Optional.empty(),
+        Optional.of(new VeniceProperties(serverProperties)),
+        false);
+
+    childDatacenters = multiColoMultiClusterWrapper.getClusters();
+    parentControllers = multiColoMultiClusterWrapper.getParentControllers();
+  }
+
+  @AfterClass(alwaysRun = true)
+  public void cleanUp() {
+    multiColoMultiClusterWrapper.close();
+  }
+
+  @Test(timeOut = TEST_TIMEOUT)
+  public void testCleanupStoreGraveyard() {
+    String parentControllerUrls =
+        parentControllers.stream().map(VeniceControllerWrapper::getControllerUrl).collect(Collectors.joining(","));
+    try (ControllerClient parentControllerClient = new ControllerClient(CLUSTER_NAME, parentControllerUrls)) {
+      String batchStoreName = Utils.getUniqueString("testStoreGraveyardCleanupBatch");
+      NewStoreResponse newStoreResponse =
+          parentControllerClient.createNewStore(batchStoreName, "test", "\"string\"", "\"string\"");
+      Assert.assertFalse(newStoreResponse.isError());
+      String hybridStoreName = Utils.getUniqueString("testStoreGraveyardCleanupHybrid");
+      newStoreResponse = parentControllerClient.createNewStore(hybridStoreName, "test", "\"string\"", "\"string\"");
+      Assert.assertFalse(newStoreResponse.isError());
+
+      ControllerResponse updateResponse = parentControllerClient
+          .updateStore(batchStoreName, new UpdateStoreQueryParams().setEnableReads(false).setEnableWrites(false));
+      Assert.assertFalse(updateResponse.isError());
+      updateResponse = parentControllerClient.updateStore(
+          hybridStoreName,
+          new UpdateStoreQueryParams().setHybridRewindSeconds(10)
+              .setHybridOffsetLagThreshold(2)
+              .setEnableReads(false)
+              .setEnableWrites(false));
+      Assert.assertFalse(updateResponse.isError());
+
+      TrackableControllerResponse response = parentControllerClient.deleteStore(batchStoreName);
+      Assert.assertFalse(response.isError());
+      response = parentControllerClient.deleteStore(hybridStoreName);
+      Assert.assertFalse(response.isError());
+
+      StoreGraveyard parentStoreGraveyard = parentControllers.get(0).getVeniceAdmin().getStoreGraveyard();
+      StoreGraveyard childStoreGraveyard =
+          childDatacenters.get(0).getLeaderController(CLUSTER_NAME).getVeniceAdmin().getStoreGraveyard();
+      // Only batch store graveyard is cleaned up
+      TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, false, true, () -> {
+        Assert.assertNull(parentStoreGraveyard.getStoreFromGraveyard(CLUSTER_NAME, batchStoreName));
+        Assert.assertNotNull(parentStoreGraveyard.getStoreFromGraveyard(CLUSTER_NAME, hybridStoreName));
+        Assert.assertNull(childStoreGraveyard.getStoreFromGraveyard(CLUSTER_NAME, batchStoreName));
+        Assert.assertNotNull(childStoreGraveyard.getStoreFromGraveyard(CLUSTER_NAME, hybridStoreName));
+      });
+    }
+  }
+}

--- a/internal/venice-test-common/src/main/java/com/linkedin/venice/integration/utils/VeniceControllerWrapper.java
+++ b/internal/venice-test-common/src/main/java/com/linkedin/venice/integration/utils/VeniceControllerWrapper.java
@@ -40,6 +40,7 @@ import static com.linkedin.venice.ConfigKeys.PUSH_STATUS_STORE_ENABLED;
 import static com.linkedin.venice.ConfigKeys.SSL_KAFKA_BOOTSTRAP_SERVERS;
 import static com.linkedin.venice.ConfigKeys.SSL_TO_KAFKA;
 import static com.linkedin.venice.ConfigKeys.STORAGE_ENGINE_OVERHEAD_RATIO;
+import static com.linkedin.venice.ConfigKeys.TOPIC_CLEANUP_DELAY_FACTOR;
 import static com.linkedin.venice.ConfigKeys.TOPIC_CLEANUP_SEND_CONCURRENT_DELETES_REQUESTS;
 import static com.linkedin.venice.ConfigKeys.TOPIC_CLEANUP_SLEEP_INTERVAL_BETWEEN_TOPIC_LIST_FETCH_MS;
 import static com.linkedin.venice.ConfigKeys.TOPIC_CREATION_THROTTLING_TIME_WINDOW_MS;
@@ -165,6 +166,7 @@ public class VeniceControllerWrapper extends ProcessWrapper {
             .put(OFFLINE_JOB_START_TIMEOUT_MS, 60_000)
             // To speed up topic cleanup
             .put(TOPIC_CLEANUP_SLEEP_INTERVAL_BETWEEN_TOPIC_LIST_FETCH_MS, 100)
+            .put(TOPIC_CLEANUP_DELAY_FACTOR, 2)
             .put(KAFKA_ADMIN_CLASS, KafkaAdminClient.class.getName())
             .put(PERSISTENCE_TYPE, PersistenceType.ROCKS_DB)
             // Moving from topic monitor to admin protocol for add version and starting ingestion

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/Admin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/Admin.java
@@ -20,6 +20,7 @@ import com.linkedin.venice.meta.RegionPushDetails;
 import com.linkedin.venice.meta.RoutersClusterConfig;
 import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.StoreDataAudit;
+import com.linkedin.venice.meta.StoreGraveyard;
 import com.linkedin.venice.meta.StoreInfo;
 import com.linkedin.venice.meta.VeniceUserStoreType;
 import com.linkedin.venice.meta.Version;
@@ -862,4 +863,8 @@ public interface Admin extends AutoCloseable, Closeable {
    * @return list of deleted ZNode paths.
    */
   List<String> cleanupInstanceCustomizedStates(String clusterName);
+
+  StoreGraveyard getStoreGraveyard();
+
+  void removeStoreFromGraveyard(String clusterName, String storeName);
 }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/StoreGraveyardCleanupService.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/StoreGraveyardCleanupService.java
@@ -1,6 +1,6 @@
 package com.linkedin.venice.controller;
 
-import com.linkedin.venice.exceptions.PreconditionCheckFailedException;
+import com.linkedin.venice.exceptions.ResourceStillExistsException;
 import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.service.AbstractVeniceService;
 import com.linkedin.venice.utils.SystemTime;
@@ -84,8 +84,8 @@ public class StoreGraveyardCleanupService extends AbstractVeniceService {
                   admin.removeStoreFromGraveyard(clusterName, storeName);
                   didCleanup = true;
                 }
-              } catch (PreconditionCheckFailedException preconditionCheckFailedException) {
-                // Ignore PreconditionCheckFailedException which indicates store graveyard is not ready for removal.
+              } catch (ResourceStillExistsException resourceStillExistsException) {
+                // Ignore ResourceStillExistsException which indicates store graveyard is not ready for removal.
               } catch (Exception exception) {
                 LOGGER.error(
                     "Encountered exception while handling store graveyard cleanup for store: {} in cluster: {}",

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/StoreGraveyardCleanupService.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/StoreGraveyardCleanupService.java
@@ -1,0 +1,109 @@
+package com.linkedin.venice.controller;
+
+import com.linkedin.venice.exceptions.PreconditionCheckFailedException;
+import com.linkedin.venice.meta.Store;
+import com.linkedin.venice.service.AbstractVeniceService;
+import com.linkedin.venice.utils.SystemTime;
+import com.linkedin.venice.utils.Time;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+
+/**
+ * This service is in charge of removing stores under /venice/<cluster>/StoreGraveyard zk path.
+ *
+ * A store is removable from graveyard when the following resources do not exist:
+ * 1. Kafka topics, including user store and its system stores version, streaming reprocessing and real-time topics.
+ * 2. Helix resources, including resources created by Helix for user store and its system stores versions.
+ * 3. Offline pushes, including OfflinePushes zk nodes created by Venice for user store and its system stores versions.
+ *
+ * The service runs in parent controller only. Parent controller find removable stores and calls child controllers.
+ * Each child controller checks if the store can be removed from graveyard in the child colo. If so, remove it and
+ * respond OK. Otherwise, respond with error. If all child controllers respond OK, parent controller will remove
+ * the store from graveyard in parent colo.
+ *
+ * The service only removes batch-only stores for now because hybrid ETL needs graveyard to guarantee version numbers
+ * are not reused in recreated stores before ETL off-boarding steps.
+ */
+public class StoreGraveyardCleanupService extends AbstractVeniceService {
+  private static final Logger LOGGER = LogManager.getLogger(StoreGraveyardCleanupService.class);
+
+  private final VeniceParentHelixAdmin admin;
+  private final VeniceControllerMultiClusterConfig multiClusterConfig;
+  private final Thread cleanupThread;
+  private final long sleepIntervalBetweenListFetchMs; // default is 15 min
+  private final long sleepIntervalBetweenStore = TimeUnit.MINUTES.toMillis(1);
+  private final Time time = new SystemTime();
+  private boolean stop = false;
+
+  public StoreGraveyardCleanupService(
+      VeniceParentHelixAdmin admin,
+      VeniceControllerMultiClusterConfig multiClusterConfig) {
+    this.admin = admin;
+    this.multiClusterConfig = multiClusterConfig;
+    this.sleepIntervalBetweenListFetchMs = multiClusterConfig.getGraveyardCleanupSleepIntervalBetweenListFetchMs();
+    this.cleanupThread = new Thread(new StoreGraveyardCleanupTask(), "StoreGraveyardCleanupTask");
+  }
+
+  @Override
+  public boolean startInner() throws Exception {
+    cleanupThread.start();
+    return true;
+  }
+
+  @Override
+  public void stopInner() throws Exception {
+    stop = true;
+    cleanupThread.interrupt();
+  }
+
+  private class StoreGraveyardCleanupTask implements Runnable {
+    @Override
+    public void run() {
+      LOGGER.info("Started running {}", getClass().getSimpleName());
+      while (!stop) {
+        try {
+          time.sleep(sleepIntervalBetweenListFetchMs);
+          // loop all clusters
+          for (String clusterName: multiClusterConfig.getClusters()) {
+            boolean cleanupForBatchOnlyStoreEnabled =
+                multiClusterConfig.getControllerConfig(clusterName).isGraveyardCleanupForBatchOnlyStoreEnabled();
+            if (!cleanupForBatchOnlyStoreEnabled || !admin.isLeaderControllerFor(clusterName)) {
+              // Only clean up when config is enabled and this is the leader controller for current cluster
+              continue;
+            }
+            // List all stores from graveyard for current cluster
+            List<String> storeNames = admin.getStoreGraveyard().listStoreNamesFromGraveyard(clusterName);
+            for (String storeName: storeNames) {
+              boolean didCleanup = false;
+              try {
+                Store store = admin.getStoreGraveyard().getStoreFromGraveyard(clusterName, storeName);
+                if (store != null && !store.isHybrid() && !store.isIncrementalPushEnabled()) {
+                  admin.removeStoreFromGraveyard(clusterName, storeName);
+                  didCleanup = true;
+                }
+              } catch (PreconditionCheckFailedException preconditionCheckFailedException) {
+                // Ignore PreconditionCheckFailedException which indicates store graveyard is not ready for removal.
+              } catch (Exception exception) {
+                LOGGER.error(
+                    "Encountered exception while handling store graveyard cleanup for store: {} in cluster: {}",
+                    storeName,
+                    clusterName,
+                    exception);
+              }
+              if (didCleanup) {
+                time.sleep(sleepIntervalBetweenStore);
+              }
+            }
+          }
+        } catch (InterruptedException e) {
+          LOGGER.error("Received InterruptedException during sleep in {} thread", getClass().getSimpleName());
+          break;
+        }
+      }
+      LOGGER.info("{} stopped", getClass().getSimpleName());
+    }
+  }
+}

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerConfig.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerConfig.java
@@ -33,7 +33,9 @@ import static com.linkedin.venice.ConfigKeys.CONTROLLER_DISABLED_ROUTES;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_DISABLE_PARENT_TOPIC_TRUNCATION_UPON_COMPLETION;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_EARLY_DELETE_BACKUP_ENABLED;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_ENABLE_BATCH_PUSH_FROM_ADMIN_IN_CHILD;
+import static com.linkedin.venice.ConfigKeys.CONTROLLER_ENABLE_GRAVEYARD_CLEANUP_FOR_BATCH_ONLY_STORE;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_ENFORCE_SSL;
+import static com.linkedin.venice.ConfigKeys.CONTROLLER_GRAVEYARD_CLEANUP_SLEEP_INTERVAL_BETWEEN_LIST_FETCH_MS;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_HAAS_SUPER_CLUSTER_NAME;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_IN_AZURE_FABRIC;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_SYSTEM_SCHEMA_CLUSTER_NAME;
@@ -236,6 +238,10 @@ public class VeniceControllerConfig extends VeniceControllerClusterConfig {
 
   private final String identityParserClassName;
 
+  private final boolean graveyardCleanupForBatchOnlyStoreEnabled;
+
+  private final long graveyardCleanupSleepIntervalBetweenListFetchMs;
+
   public VeniceControllerConfig(VeniceProperties props) {
     super(props);
     this.adminPort = props.getInt(ADMIN_PORT);
@@ -425,6 +431,10 @@ public class VeniceControllerConfig extends VeniceControllerClusterConfig {
     this.controllerInAzureFabric = props.getBoolean(CONTROLLER_IN_AZURE_FABRIC, false);
     this.unregisterMetricForDeletedStoreEnabled = props.getBoolean(UNREGISTER_METRIC_FOR_DELETED_STORE_ENABLED, false);
     this.identityParserClassName = props.getString(IDENTITY_PARSER_CLASS, DefaultIdentityParser.class.getName());
+    this.graveyardCleanupForBatchOnlyStoreEnabled =
+        props.getBoolean(CONTROLLER_ENABLE_GRAVEYARD_CLEANUP_FOR_BATCH_ONLY_STORE, false);
+    this.graveyardCleanupSleepIntervalBetweenListFetchMs =
+        props.getLong(CONTROLLER_GRAVEYARD_CLEANUP_SLEEP_INTERVAL_BETWEEN_LIST_FETCH_MS, TimeUnit.MINUTES.toMillis(15));
   }
 
   private void validateActiveActiveConfigs() {
@@ -783,6 +793,14 @@ public class VeniceControllerConfig extends VeniceControllerClusterConfig {
 
   public String getIdentityParserClassName() {
     return identityParserClassName;
+  }
+
+  public boolean isGraveyardCleanupForBatchOnlyStoreEnabled() {
+    return graveyardCleanupForBatchOnlyStoreEnabled;
+  }
+
+  public long getGraveyardCleanupSleepIntervalBetweenListFetchMs() {
+    return graveyardCleanupSleepIntervalBetweenListFetchMs;
   }
 
   /**

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerConfig.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerConfig.java
@@ -33,11 +33,12 @@ import static com.linkedin.venice.ConfigKeys.CONTROLLER_DISABLED_ROUTES;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_DISABLE_PARENT_TOPIC_TRUNCATION_UPON_COMPLETION;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_EARLY_DELETE_BACKUP_ENABLED;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_ENABLE_BATCH_PUSH_FROM_ADMIN_IN_CHILD;
-import static com.linkedin.venice.ConfigKeys.CONTROLLER_ENABLE_GRAVEYARD_CLEANUP_FOR_BATCH_ONLY_STORE;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_ENFORCE_SSL;
-import static com.linkedin.venice.ConfigKeys.CONTROLLER_GRAVEYARD_CLEANUP_SLEEP_INTERVAL_BETWEEN_LIST_FETCH_MS;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_HAAS_SUPER_CLUSTER_NAME;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_IN_AZURE_FABRIC;
+import static com.linkedin.venice.ConfigKeys.CONTROLLER_STORE_GRAVEYARD_CLEANUP_DELAY_MINUTES;
+import static com.linkedin.venice.ConfigKeys.CONTROLLER_STORE_GRAVEYARD_CLEANUP_ENABLED;
+import static com.linkedin.venice.ConfigKeys.CONTROLLER_STORE_GRAVEYARD_CLEANUP_SLEEP_INTERVAL_BETWEEN_LIST_FETCH_MINUTES;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_SYSTEM_SCHEMA_CLUSTER_NAME;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_SYSTEM_STORE_ACL_SYNCHRONIZATION_DELAY_MS;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_ZK_SHARED_DAVINCI_PUSH_STATUS_SYSTEM_SCHEMA_STORE_AUTO_CREATION_ENABLED;
@@ -238,9 +239,11 @@ public class VeniceControllerConfig extends VeniceControllerClusterConfig {
 
   private final String identityParserClassName;
 
-  private final boolean graveyardCleanupForBatchOnlyStoreEnabled;
+  private final boolean storeGraveyardCleanupEnabled;
 
-  private final long graveyardCleanupSleepIntervalBetweenListFetchMs;
+  private final int storeGraveyardCleanupDelayMinutes;
+
+  private final int storeGraveyardCleanupSleepIntervalBetweenListFetchMinutes;
 
   public VeniceControllerConfig(VeniceProperties props) {
     super(props);
@@ -431,10 +434,10 @@ public class VeniceControllerConfig extends VeniceControllerClusterConfig {
     this.controllerInAzureFabric = props.getBoolean(CONTROLLER_IN_AZURE_FABRIC, false);
     this.unregisterMetricForDeletedStoreEnabled = props.getBoolean(UNREGISTER_METRIC_FOR_DELETED_STORE_ENABLED, false);
     this.identityParserClassName = props.getString(IDENTITY_PARSER_CLASS, DefaultIdentityParser.class.getName());
-    this.graveyardCleanupForBatchOnlyStoreEnabled =
-        props.getBoolean(CONTROLLER_ENABLE_GRAVEYARD_CLEANUP_FOR_BATCH_ONLY_STORE, false);
-    this.graveyardCleanupSleepIntervalBetweenListFetchMs =
-        props.getLong(CONTROLLER_GRAVEYARD_CLEANUP_SLEEP_INTERVAL_BETWEEN_LIST_FETCH_MS, TimeUnit.MINUTES.toMillis(15));
+    this.storeGraveyardCleanupEnabled = props.getBoolean(CONTROLLER_STORE_GRAVEYARD_CLEANUP_ENABLED, false);
+    this.storeGraveyardCleanupDelayMinutes = props.getInt(CONTROLLER_STORE_GRAVEYARD_CLEANUP_DELAY_MINUTES, 0);
+    this.storeGraveyardCleanupSleepIntervalBetweenListFetchMinutes =
+        props.getInt(CONTROLLER_STORE_GRAVEYARD_CLEANUP_SLEEP_INTERVAL_BETWEEN_LIST_FETCH_MINUTES, 15);
   }
 
   private void validateActiveActiveConfigs() {
@@ -795,12 +798,16 @@ public class VeniceControllerConfig extends VeniceControllerClusterConfig {
     return identityParserClassName;
   }
 
-  public boolean isGraveyardCleanupForBatchOnlyStoreEnabled() {
-    return graveyardCleanupForBatchOnlyStoreEnabled;
+  public boolean isStoreGraveyardCleanupEnabled() {
+    return storeGraveyardCleanupEnabled;
   }
 
-  public long getGraveyardCleanupSleepIntervalBetweenListFetchMs() {
-    return graveyardCleanupSleepIntervalBetweenListFetchMs;
+  public int getStoreGraveyardCleanupDelayMinutes() {
+    return storeGraveyardCleanupDelayMinutes;
+  }
+
+  public int getStoreGraveyardCleanupSleepIntervalBetweenListFetchMinutes() {
+    return storeGraveyardCleanupSleepIntervalBetweenListFetchMinutes;
   }
 
   /**

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerMultiClusterConfig.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerMultiClusterConfig.java
@@ -257,7 +257,7 @@ public class VeniceControllerMultiClusterConfig {
     return getCommonConfig().getEmergencySourceRegion();
   }
 
-  public long getGraveyardCleanupSleepIntervalBetweenListFetchMs() {
-    return getCommonConfig().getGraveyardCleanupSleepIntervalBetweenListFetchMs();
+  public int getGraveyardCleanupSleepIntervalBetweenListFetchMinutes() {
+    return getCommonConfig().getStoreGraveyardCleanupSleepIntervalBetweenListFetchMinutes();
   }
 }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerMultiClusterConfig.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerMultiClusterConfig.java
@@ -256,4 +256,8 @@ public class VeniceControllerMultiClusterConfig {
   public String getEmergencySourceRegion() {
     return getCommonConfig().getEmergencySourceRegion();
   }
+
+  public long getGraveyardCleanupSleepIntervalBetweenListFetchMs() {
+    return getCommonConfig().getGraveyardCleanupSleepIntervalBetweenListFetchMs();
+  }
 }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -57,7 +57,7 @@ import com.linkedin.venice.controllerapi.UpdateStoreQueryParams;
 import com.linkedin.venice.controllerapi.VersionResponse;
 import com.linkedin.venice.exceptions.ConfigurationException;
 import com.linkedin.venice.exceptions.InvalidVeniceSchemaException;
-import com.linkedin.venice.exceptions.PreconditionCheckFailedException;
+import com.linkedin.venice.exceptions.ResourceStillExistsException;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.exceptions.VeniceHttpException;
 import com.linkedin.venice.exceptions.VeniceNoClusterException;
@@ -6751,7 +6751,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
         storeNameForTopic = Version.parseStoreFromKafkaTopicName(topic);
       }
       if (storeNameForTopic != null && allRelevantStores.contains(storeNameForTopic)) {
-        throw new PreconditionCheckFailedException(
+        throw new ResourceStillExistsException(
             "Topic: " + topic + " still exists for store: " + storeName + ", please make sure all "
                 + (checkVersionTopic ? "" : "real-time ") + "topics are removed.");
       }
@@ -6763,7 +6763,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
         if (Version.isVersionTopic(resource)) {
           String storeNameForResource = Version.parseStoreFromVersionTopic(resource);
           if (allRelevantStores.contains(storeNameForResource)) {
-            throw new PreconditionCheckFailedException(
+            throw new ResourceStillExistsException(
                 "Helix Resource: " + resource + " still exists for store: " + storeName
                     + ", please make sure all helix resources are removed.");
           }
@@ -6777,7 +6777,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
         if (Version.isVersionTopic(resource)) {
           String storeNameForResource = Version.parseStoreFromVersionTopic(resource);
           if (allRelevantStores.contains(storeNameForResource)) {
-            throw new PreconditionCheckFailedException(
+            throw new ResourceStillExistsException(
                 "Offline push: " + resource + " still exists for store: " + storeName
                     + ", please make sure all offline push nodes are removed.");
           }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -57,6 +57,7 @@ import com.linkedin.venice.controllerapi.UpdateStoreQueryParams;
 import com.linkedin.venice.controllerapi.VersionResponse;
 import com.linkedin.venice.exceptions.ConfigurationException;
 import com.linkedin.venice.exceptions.InvalidVeniceSchemaException;
+import com.linkedin.venice.exceptions.PreconditionCheckFailedException;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.exceptions.VeniceHttpException;
 import com.linkedin.venice.exceptions.VeniceNoClusterException;
@@ -6185,14 +6186,6 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
     multiClusterConfigs.addClusterConfig(config);
   }
 
-  private ZkAllowlistAccessor getAllowlistAccessor() {
-    return allowlistAccessor;
-  }
-
-  StoreGraveyard getStoreGraveyard() {
-    return storeGraveyard;
-  }
-
   String getControllerName() {
     return controllerName;
   }
@@ -6724,12 +6717,6 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
       throw new VeniceException("Store: " + storeName + " still exists in cluster: " + clusterName);
     }
 
-    Set<String> allRelevantStores = new HashSet<>();
-    Arrays.stream(VeniceSystemStoreType.values()).forEach(s -> allRelevantStores.add(s.getSystemStoreName(storeName)));
-    allRelevantStores.add(storeName);
-
-    // Check all the topics belonging to this store.
-    Set<String> topics = getTopicManager().listTopics();
     /**
      * All store version topics from before deletion will not be used since we will create a new version number
      * that has not been used previously. We let TopicCleanupService take care of the cleanups.
@@ -6737,29 +6724,62 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
      * The version check skip was introduced when Venice was running with Kafka MirrorMaker to avoid a KMM crash.
      * TODO: Evaluate if this code needs to change now that KMM logic has been deprecated.
      *
-     * So for topic check, we will ensure the RT topic for the Venice store will be deleted, and all other system
-     * store topics.
+     * So for topic check, we ensure RT topics for the Venice store and its system stores are deleted.
      */
+    checkKafkaTopicAndHelixResource(clusterName, storeName, false, checkHelixResource, false);
+  }
+
+  void checkKafkaTopicAndHelixResource(
+      String clusterName,
+      String storeName,
+      boolean checkVersionTopic,
+      boolean checkHelixResource,
+      boolean checkOfflinePush) {
+    Set<String> allRelevantStores = new HashSet<>();
+    Arrays.stream(VeniceSystemStoreType.values())
+        .filter(VeniceSystemStoreType::isStoreZkShared)
+        .forEach(s -> allRelevantStores.add(s.getSystemStoreName(storeName)));
+    allRelevantStores.add(storeName);
+
+    // Check Kafka topics belonging to this store.
+    Set<String> topics = getTopicManager().listTopics();
     topics.forEach(topic -> {
+      String storeNameForTopic = null;
       if (Version.isRealTimeTopic(topic)) {
-        String storeNameForTopic = Version.parseStoreFromRealTimeTopic(topic);
-        if (allRelevantStores.contains(storeNameForTopic)) {
-          throw new VeniceException(
-              "Topic: " + ": " + topic + " still exists for store: " + storeName
-                  + ", please make sure all the resources are removed before store re-creation");
-        }
+        storeNameForTopic = Version.parseStoreFromRealTimeTopic(topic);
+      } else if (checkVersionTopic) {
+        storeNameForTopic = Version.parseStoreFromKafkaTopicName(topic);
+      }
+      if (storeNameForTopic != null && allRelevantStores.contains(storeNameForTopic)) {
+        throw new PreconditionCheckFailedException(
+            "Topic: " + topic + " still exists for store: " + storeName + ", please make sure all "
+                + (checkVersionTopic ? "" : "real-time ") + "topics are removed.");
       }
     });
-    // Check all the helix resources.
+    // Check all helix resources.
     if (checkHelixResource) {
       List<String> helixAliveResources = getAllLiveHelixResources(clusterName);
       helixAliveResources.forEach(resource -> {
         if (Version.isVersionTopic(resource)) {
-          String storeNameForResource = Version.parseStoreFromKafkaTopicName(resource);
+          String storeNameForResource = Version.parseStoreFromVersionTopic(resource);
           if (allRelevantStores.contains(storeNameForResource)) {
-            throw new VeniceException(
-                "Helix Resource: " + ": " + resource + " still exists for store: " + storeName
-                    + ", please make sure all the resources are removed before store re-creation");
+            throw new PreconditionCheckFailedException(
+                "Helix Resource: " + resource + " still exists for store: " + storeName
+                    + ", please make sure all helix resources are removed.");
+          }
+        }
+      });
+    }
+    // Check all offline push zk nodes.
+    if (checkOfflinePush) {
+      List<String> offlinePushes = zkClient.getChildren("/" + clusterName + "/OfflinePushes");
+      offlinePushes.forEach(resource -> {
+        if (Version.isVersionTopic(resource)) {
+          String storeNameForResource = Version.parseStoreFromVersionTopic(resource);
+          if (allRelevantStores.contains(storeNameForResource)) {
+            throw new PreconditionCheckFailedException(
+                "Offline push: " + resource + " still exists for store: " + storeName
+                    + ", please make sure all offline push nodes are removed.");
           }
         }
       });
@@ -7343,5 +7363,17 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
       }
     }
     return deletedZNodes;
+  }
+
+  @Override
+  public StoreGraveyard getStoreGraveyard() {
+    return storeGraveyard;
+  }
+
+  @Override
+  public void removeStoreFromGraveyard(String clusterName, String storeName) {
+    checkControllerLeadershipFor(clusterName);
+    checkKafkaTopicAndHelixResource(clusterName, storeName, true, true, true);
+    storeGraveyard.removeStoreFromGraveyard(clusterName, storeName);
   }
 }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
@@ -130,7 +130,7 @@ import com.linkedin.venice.exceptions.ConcurrentBatchPushException;
 import com.linkedin.venice.exceptions.ConfigurationException;
 import com.linkedin.venice.exceptions.ErrorType;
 import com.linkedin.venice.exceptions.PartitionerSchemaMismatchException;
-import com.linkedin.venice.exceptions.PreconditionCheckFailedException;
+import com.linkedin.venice.exceptions.ResourceStillExistsException;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.exceptions.VeniceHttpException;
 import com.linkedin.venice.exceptions.VeniceNoStoreException;
@@ -4974,8 +4974,8 @@ public class VeniceParentHelixAdmin implements Admin {
     controllerClientMap.forEach((coloName, cc) -> {
       ControllerResponse response = cc.removeStoreFromGraveyard(storeName);
       if (response.isError()) {
-        if (ErrorType.PRECONDITION_CHECK_FAILED.equals(response.getErrorType())) {
-          throw new PreconditionCheckFailedException(
+        if (ErrorType.RESOURCE_STILL_EXISTS.equals(response.getErrorType())) {
+          throw new ResourceStillExistsException(
               "Store graveyard " + storeName + " is not ready for removal in colo: " + coloName);
         }
         throw new VeniceException(

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
@@ -130,6 +130,7 @@ import com.linkedin.venice.exceptions.ConcurrentBatchPushException;
 import com.linkedin.venice.exceptions.ConfigurationException;
 import com.linkedin.venice.exceptions.ErrorType;
 import com.linkedin.venice.exceptions.PartitionerSchemaMismatchException;
+import com.linkedin.venice.exceptions.PreconditionCheckFailedException;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.exceptions.VeniceHttpException;
 import com.linkedin.venice.exceptions.VeniceNoStoreException;
@@ -156,6 +157,7 @@ import com.linkedin.venice.meta.RoutersClusterConfig;
 import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.StoreConfig;
 import com.linkedin.venice.meta.StoreDataAudit;
+import com.linkedin.venice.meta.StoreGraveyard;
 import com.linkedin.venice.meta.StoreInfo;
 import com.linkedin.venice.meta.VeniceUserStoreType;
 import com.linkedin.venice.meta.Version;
@@ -4956,5 +4958,30 @@ public class VeniceParentHelixAdmin implements Admin {
   @Override
   public List<String> cleanupInstanceCustomizedStates(String clusterName) {
     throw new VeniceUnsupportedOperationException("cleanupInstanceCustomizedStates");
+  }
+
+  @Override
+  public StoreGraveyard getStoreGraveyard() {
+    return getVeniceHelixAdmin().getStoreGraveyard();
+  }
+
+  @Override
+  public void removeStoreFromGraveyard(String clusterName, String storeName) {
+    // Check parent data center to make sure store could be removed from graveyard.
+    getVeniceHelixAdmin().checkKafkaTopicAndHelixResource(clusterName, storeName, true, false, false);
+    // Check all child data centers to make sure store is removed from graveyard there.
+    Map<String, ControllerClient> controllerClientMap = getVeniceHelixAdmin().getControllerClientMap(clusterName);
+    controllerClientMap.forEach((coloName, cc) -> {
+      ControllerResponse response = cc.removeStoreFromGraveyard(storeName);
+      if (response.isError()) {
+        if (ErrorType.PRECONDITION_CHECK_FAILED.equals(response.getErrorType())) {
+          throw new PreconditionCheckFailedException(
+              "Store graveyard " + storeName + " is not ready for removal in colo: " + coloName);
+        }
+        throw new VeniceException(
+            "Error when removing store graveyard " + storeName + " in colo: " + coloName + ". " + response.getError());
+      }
+    });
+    getStoreGraveyard().removeStoreFromGraveyard(clusterName, storeName);
   }
 }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/AdminSparkServer.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/AdminSparkServer.java
@@ -76,6 +76,7 @@ import static com.linkedin.venice.controllerapi.ControllerRoute.OFFLINE_PUSH_INF
 import static com.linkedin.venice.controllerapi.ControllerRoute.PREPARE_DATA_RECOVERY;
 import static com.linkedin.venice.controllerapi.ControllerRoute.REMOVE_DERIVED_SCHEMA;
 import static com.linkedin.venice.controllerapi.ControllerRoute.REMOVE_NODE;
+import static com.linkedin.venice.controllerapi.ControllerRoute.REMOVE_STORE_FROM_GRAVEYARD;
 import static com.linkedin.venice.controllerapi.ControllerRoute.REPLICATE_META_DATA;
 import static com.linkedin.venice.controllerapi.ControllerRoute.REQUEST_TOPIC;
 import static com.linkedin.venice.controllerapi.ControllerRoute.SEND_PUSH_JOB_DETAILS;
@@ -152,7 +153,7 @@ public class AdminSparkServer extends AbstractVeniceService {
   final private SparkServerStats nonclusterSpecificStats;
 
   private static String REQUEST_START_TIME = "startTime";
-  private static String REQUEST_SUCCEED = "succeed";
+  protected static String REQUEST_SUCCEED = "succeed";
 
   // In order to build multiple controller in a single JVM, we create a new http service instance for each of
   // AdminSparkServer instance.
@@ -422,6 +423,7 @@ public class AdminSparkServer extends AbstractVeniceService {
     httpService.post(UPDATE_ADMIN_TOPIC_METADATA.getPath(), adminTopicMetadataRoutes.updateAdminTopicMetadata(admin));
 
     httpService.post(DELETE_KAFKA_TOPIC.getPath(), storesRoutes.deleteKafkaTopic(admin));
+    httpService.post(REMOVE_STORE_FROM_GRAVEYARD.getPath(), storesRoutes.removeStoreFromGraveyard(admin));
 
     httpService.post(CREATE_STORAGE_PERSONA.getPath(), storagePersonaRoutes.createStoragePersona(admin));
     httpService.get(GET_STORAGE_PERSONA.getPath(), storagePersonaRoutes.getStoragePersona(admin));

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/AdminSparkServer.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/AdminSparkServer.java
@@ -521,12 +521,18 @@ public class AdminSparkServer extends AbstractVeniceService {
   }
 
   protected static void handleError(Throwable e, Request request, Response response) {
-    StringBuilder sb = new StringBuilder("Request params were: ");
-    request.queryMap().toMap().forEach((k, v) -> { /* Map<String, String[]> */
-      sb.append(k).append("=").append(String.join(",", v)).append(" ");
-    });
-    String errMsg = sb.toString();
-    LOGGER.error(errMsg, e);
+    handleError(e, request, response, true);
+  }
+
+  protected static void handleError(Throwable e, Request request, Response response, boolean logErrorMessage) {
+    if (logErrorMessage) {
+      StringBuilder sb = new StringBuilder("Request params were: ");
+      request.queryMap().toMap().forEach((k, v) -> { /* Map<String, String[]> */
+        sb.append(k).append("=").append(String.join(",", v)).append(" ");
+      });
+      String errMsg = sb.toString();
+      LOGGER.error(errMsg, e);
+    }
     if (e instanceof Error) {
       throw (Error) e;
     }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/AdminSparkServer.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/AdminSparkServer.java
@@ -153,7 +153,7 @@ public class AdminSparkServer extends AbstractVeniceService {
   final private SparkServerStats nonclusterSpecificStats;
 
   private static String REQUEST_START_TIME = "startTime";
-  protected static String REQUEST_SUCCEED = "succeed";
+  private static String REQUEST_SUCCEED = "succeed";
 
   // In order to build multiple controller in a single JVM, we create a new http service instance for each of
   // AdminSparkServer instance.

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/StoresRoutes.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/StoresRoutes.java
@@ -1041,8 +1041,7 @@ public class StoresRoutes extends AbstractRoute {
         admin.removeStoreFromGraveyard(clusterName, storeName);
       } catch (ResourceStillExistsException exception) {
         responseObject.setError(exception);
-        response.status(exception.getHttpStatusCode());
-        request.attribute(AdminSparkServer.REQUEST_SUCCEED, false);
+        AdminSparkServer.handleError(exception, request, response, false);
       } catch (Throwable throwable) {
         responseObject.setError(throwable);
         AdminSparkServer.handleError(new VeniceException(throwable), request, response);

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/StoresRoutes.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/StoresRoutes.java
@@ -1,5 +1,6 @@
 package com.linkedin.venice.controller.server;
 
+import static com.linkedin.venice.controller.server.VeniceRouteHandler.ACL_CHECK_FAILURE_WARN_MESSAGE_PREFIX;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.CLUSTER;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.CLUSTER_DEST;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.FABRIC;
@@ -42,6 +43,7 @@ import static com.linkedin.venice.controllerapi.ControllerRoute.LIST_LF_STORES;
 import static com.linkedin.venice.controllerapi.ControllerRoute.LIST_STORES;
 import static com.linkedin.venice.controllerapi.ControllerRoute.LIST_STORE_PUSH_INFO;
 import static com.linkedin.venice.controllerapi.ControllerRoute.MIGRATE_STORE;
+import static com.linkedin.venice.controllerapi.ControllerRoute.REMOVE_STORE_FROM_GRAVEYARD;
 import static com.linkedin.venice.controllerapi.ControllerRoute.SET_OWNER;
 import static com.linkedin.venice.controllerapi.ControllerRoute.SET_TOPIC_COMPACTION;
 import static com.linkedin.venice.controllerapi.ControllerRoute.SET_VERSION;
@@ -49,6 +51,7 @@ import static com.linkedin.venice.controllerapi.ControllerRoute.STORAGE_ENGINE_O
 import static com.linkedin.venice.controllerapi.ControllerRoute.STORE;
 import static com.linkedin.venice.controllerapi.ControllerRoute.UPDATE_STORE;
 
+import com.linkedin.venice.HttpConstants;
 import com.linkedin.venice.acl.DynamicAccessController;
 import com.linkedin.venice.controller.Admin;
 import com.linkedin.venice.controller.AdminCommandExecutionTracker;
@@ -74,6 +77,8 @@ import com.linkedin.venice.controllerapi.StoreResponse;
 import com.linkedin.venice.controllerapi.TrackableControllerResponse;
 import com.linkedin.venice.controllerapi.UpdateStoreQueryParams;
 import com.linkedin.venice.controllerapi.VersionResponse;
+import com.linkedin.venice.exceptions.ErrorType;
+import com.linkedin.venice.exceptions.PreconditionCheckFailedException;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.exceptions.VeniceNoStoreException;
 import com.linkedin.venice.kafka.TopicDoesNotExistException;
@@ -94,6 +99,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import org.apache.avro.Schema;
+import org.apache.http.HttpStatus;
 import spark.Request;
 import spark.Route;
 
@@ -1013,6 +1019,35 @@ public class StoresRoutes extends AbstractRoute {
         admin.truncateKafkaTopic(topicName);
         veniceResponse.setCluster(cluster);
       }
+    };
+  }
+
+  public Route removeStoreFromGraveyard(Admin admin) {
+    return (request, response) -> {
+      ControllerResponse responseObject = new ControllerResponse();
+      response.type(HttpConstants.JSON);
+      try {
+        if (!isAllowListUser(request)) {
+          response.status(HttpStatus.SC_FORBIDDEN);
+          responseObject.setError(ACL_CHECK_FAILURE_WARN_MESSAGE_PREFIX + request.url());
+          responseObject.setErrorType(ErrorType.BAD_REQUEST);
+          return AdminSparkServer.OBJECT_MAPPER.writeValueAsString(responseObject);
+        }
+        AdminSparkServer.validateParams(request, REMOVE_STORE_FROM_GRAVEYARD.getParams(), admin);
+        String clusterName = request.queryParams(CLUSTER);
+        String storeName = request.queryParams(NAME);
+        responseObject.setCluster(clusterName);
+        responseObject.setName(storeName);
+        admin.removeStoreFromGraveyard(clusterName, storeName);
+      } catch (PreconditionCheckFailedException exception) {
+        responseObject.setError(exception);
+        response.status(exception.getHttpStatusCode());
+        request.attribute(AdminSparkServer.REQUEST_SUCCEED, false);
+      } catch (Throwable throwable) {
+        responseObject.setError(throwable);
+        AdminSparkServer.handleError(new VeniceException(throwable), request, response);
+      }
+      return AdminSparkServer.OBJECT_MAPPER.writeValueAsString(responseObject);
     };
   }
 }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/StoresRoutes.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/StoresRoutes.java
@@ -78,7 +78,7 @@ import com.linkedin.venice.controllerapi.TrackableControllerResponse;
 import com.linkedin.venice.controllerapi.UpdateStoreQueryParams;
 import com.linkedin.venice.controllerapi.VersionResponse;
 import com.linkedin.venice.exceptions.ErrorType;
-import com.linkedin.venice.exceptions.PreconditionCheckFailedException;
+import com.linkedin.venice.exceptions.ResourceStillExistsException;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.exceptions.VeniceNoStoreException;
 import com.linkedin.venice.kafka.TopicDoesNotExistException;
@@ -1039,7 +1039,7 @@ public class StoresRoutes extends AbstractRoute {
         responseObject.setCluster(clusterName);
         responseObject.setName(storeName);
         admin.removeStoreFromGraveyard(clusterName, storeName);
-      } catch (PreconditionCheckFailedException exception) {
+      } catch (ResourceStillExistsException exception) {
         responseObject.setError(exception);
         response.status(exception.getHttpStatusCode());
         request.attribute(AdminSparkServer.REQUEST_SUCCEED, false);

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceHelixAdminWithSharedEnvironment.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceHelixAdminWithSharedEnvironment.java
@@ -1127,6 +1127,31 @@ public class TestVeniceHelixAdminWithSharedEnvironment extends AbstractTestVenic
   }
 
   @Test
+  public void testRemoveStoreFromGraveyard() {
+    String storeName = Utils.getUniqueString("testRemoveStoreFromGraveyard");
+    veniceAdmin.createStore(clusterName, storeName, storeOwner, "\"string\"", "\"string\"");
+    Version version =
+        veniceAdmin.incrementVersionIdempotent(clusterName, storeName, Version.guidBasedDummyPushId(), 1, 1);
+    String versionTopic = Version.composeKafkaTopic(storeName, version.getNumber());
+    Assert.assertTrue(
+        veniceAdmin.getTopicManager().containsTopicAndAllPartitionsAreOnline(versionTopic),
+        "Kafka topic should be created.");
+
+    veniceAdmin.setStoreReadability(clusterName, storeName, false);
+    veniceAdmin.setStoreWriteability(clusterName, storeName, false);
+    veniceAdmin.deleteStore(clusterName, storeName, Store.IGNORE_VERSION, true);
+    // Topic has not been deleted. Store graveyard could not be removed.
+    Assert.assertThrows(VeniceException.class, () -> veniceAdmin.removeStoreFromGraveyard(clusterName, storeName));
+
+    TestUtils
+        .waitForNonDeterministicAssertion(TOTAL_TIMEOUT_FOR_LONG_TEST_MS, TimeUnit.MILLISECONDS, false, true, () -> {
+          veniceAdmin.getTopicManager().ensureTopicIsDeletedAndBlockWithRetry(versionTopic);
+          veniceAdmin.removeStoreFromGraveyard(clusterName, storeName);
+          Assert.assertNull(veniceAdmin.getStoreGraveyard().getStoreFromGraveyard(clusterName, storeName));
+        });
+  }
+
+  @Test
   public void testDeleteStoreWithLargestUsedVersionNumberOverwritten() {
     String storeName = Utils.getUniqueString("testDeleteStore");
     int largestUsedVersionNumber = 1000;

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceHelixAdminWithSharedEnvironment.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceHelixAdminWithSharedEnvironment.java
@@ -1147,7 +1147,7 @@ public class TestVeniceHelixAdminWithSharedEnvironment extends AbstractTestVenic
         .waitForNonDeterministicAssertion(TOTAL_TIMEOUT_FOR_LONG_TEST_MS, TimeUnit.MILLISECONDS, false, true, () -> {
           veniceAdmin.getTopicManager().ensureTopicIsDeletedAndBlockWithRetry(versionTopic);
           veniceAdmin.removeStoreFromGraveyard(clusterName, storeName);
-          Assert.assertNull(veniceAdmin.getStoreGraveyard().getStoreFromGraveyard(clusterName, storeName));
+          Assert.assertNull(veniceAdmin.getStoreGraveyard().getStoreFromGraveyard(clusterName, storeName, null));
         });
   }
 

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceHelixAdminWithoutCluster.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceHelixAdminWithoutCluster.java
@@ -279,6 +279,8 @@ public class TestVeniceHelixAdminWithoutCluster {
 
     doCallRealMethod().when(admin).checkResourceCleanupBeforeStoreCreation(anyString(), anyString());
     doCallRealMethod().when(admin).checkResourceCleanupBeforeStoreCreation(anyString(), anyString(), anyBoolean());
+    doCallRealMethod().when(admin)
+        .checkKafkaTopicAndHelixResource(anyString(), anyString(), anyBoolean(), anyBoolean(), anyBoolean());
 
     testExecution.accept(admin);
   }


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci], [server], [controller],
[router], [samza], [vpj], [fast-client], [thin-client], [alpini],
[admin-tool], [test], [build], [doc], [script]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## [controller][common] Support store graveyard cleanup
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Today when a store is deleted, it will be put into store graveyard to avoid the version overlapping between the deleted store and re-created store. But store graveyard zk nodes are never removed and will continue increasing with more stores being deleted.

This commit adds store graveyard cleanup service. When the controller cluster level config is enabled, the service running on parent controller will gather stale and removable store graveyards and calls child controllers. Each child controller checks if the store can be removed from graveyard in the child colo. If so, remove it and respond OK. Otherwise, respond with error. Once all child controllers respond OK, parent controller will remove the store graveyard in parent colo.

A store is removable from graveyard when the following resources do not exist:
1. Kafka topics, including user store and its system stores VT, SR and RT topics.
2. Helix resources, including resources created by Helix for user store and its system stores versions.
3. Offline pushes, including OfflinePushes zk nodes for user store and its system stores versions.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
TestVeniceHelixAdminWithSharedEnvironment#testRemoveStoreFromGraveyard
TestStoreGraveyardCleanupService#testCleanupStoreGraveyard

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.