### PR TITLE
[da-vinci] Make sure Da Vinci client can emit metrics after application restart and before next version push

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/DaVinciBackend.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/DaVinciBackend.java
@@ -345,9 +345,9 @@ public class DaVinciBackend implements Closeable {
     storeNameToBootstrapVersionMap.forEach((storeName, version) -> {
       List<Integer> partitions = storeNameToPartitionListMap.get(storeName);
       String versionTopic = version.kafkaTopicName();
-      LOGGER.info("Bootstrapping partitions " + partitions + " for " + version.kafkaTopicName());
+      LOGGER.info("Bootstrapping partitions {} for {}", partitions, versionTopic);
       aggVersionedStorageEngineStats.setStorageEngine(versionTopic, storageService.getStorageEngine(versionTopic));
-      StoreBackend storeBackend = getStoreOrThrow(version.getStoreName());
+      StoreBackend storeBackend = getStoreOrThrow(storeName);
       storeBackend.subscribe(ComplementSet.newSet(partitions), Optional.of(version));
     });
   }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/repository/NativeMetadataRepository.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/repository/NativeMetadataRepository.java
@@ -494,11 +494,9 @@ public abstract class NativeMetadataRepository
     // Workaround to make old metadata compatible with new fields
     newStore.fixMissingFields();
     Store oldStore = subscribedStoreMap.put(newStore.getName(), newStore);
-    if (oldStore == null) {
-      totalStoreReadQuota.addAndGet(newStore.getReadQuotaInCU());
-      notifyStoreCreated(newStore);
-    } else if (!oldStore.equals(newStore)) {
-      totalStoreReadQuota.addAndGet(newStore.getReadQuotaInCU() - oldStore.getReadQuotaInCU());
+    if ((oldStore == null) || (!oldStore.equals(newStore))) {
+      long previousStoreReadQuota = oldStore == null ? 0 : oldStore.getReadQuotaInCU();
+      totalStoreReadQuota.addAndGet(newStore.getReadQuotaInCU() - previousStoreReadQuota);
       notifyStoreChanged(newStore);
     }
     return oldStore;


### PR DESCRIPTION


<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci], [server], [controller],
[router], [samza], [vpj], [fast-client], [thin-client], [alpini],
[admin-tool], [test], [build], [doc], [script]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Da Vinci Client will emit metrics correctly between application restart and next version push
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
This PR address the issue found during a GCN investigation. Da Vinci client was able to emit disk_usage_in_bytes metrics during/after version push, however once customer application restart it will emit -18 signal (indicating NULL_STORAGE_ENGINE_STATS error)
1. This is caused by a bug in NativeMetadataRepository. When application restart, during store metadata repository subscription, it will add a store object into the map slot which was previously null. In this case it should ask listener to handle store change event, instead of store creation event. This signal miss will let stats class failed to link up with the current version.
2. Also, due to how AggVersionedStorageEngineStats links storage engine with the correct store version is implemented and called, Da Vinci backend for now will not be able to link to storage engine correctly when bootstrapping local storage engines. For server it is fine, as it will first create storeRepository and fetch all stores from ZK once and when storage service is restoring local engines, it could link it successfully. Isolated Ingestion server does not perform storage engine restore upon start, so it is fine. For DaVinciBackend, since the store repository is subscription-based, it will be empty in the beginning. During StorageService restoration, it will try to look up the store repo and failed and skipped the stat - storage engine link up. This PR also address the issue by manually set storage engine for the stat class during the final step of the bootstrap.

### Note: 
This PR also moves delete unused store logic out of the bootstrap local storage engine scan logic. It is irrelevant to the topic, but I believe it is not correct and might lead to potential issue.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
Multiple CI has been submitted to test. Changed the DaVinciClient#testBootstrap() method logic to validate the disk usage metric value after bootstrap.

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.