### PR TITLE
[build] Remove separate publishing for shadow jars

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -124,45 +124,6 @@ publishing {
   }
 }
 
-// This does not include modules that are published as shadow jars as they have their own publishing sections:
-// 1. venice-push-job
-// 2. venice-admin-tool
-Set<String> projectsToPublish = [
-  // Services
-  ':services:venice-controller',
-  ':services:venice-router',
-  ':services:venice-server',
-
-  // Clients
-  ':clients:da-vinci-client',
-  ':clients:venice-client',
-  ':clients:venice-samza',
-  ':clients:venice-thin-client',
-
-  // Internal
-  ':internal:venice-client-common',
-  ':internal:venice-common',
-  ':internal:venice-compatibility-test',
-  ':internal:venice-consumer',
-  ':internal:venice-test-common',
-
-  // Internal - Alpini
-  ':internal:alpini:common:alpini-common-base',
-  ':internal:alpini:common:alpini-common-cli',
-  ':internal:alpini:common:alpini-common-const',
-  ':internal:alpini:common:alpini-common-io',
-  ':internal:alpini:common:alpini-common-log',
-  ':internal:alpini:common:alpini-common-native',
-  ':internal:alpini:common:alpini-common-test',
-  ':internal:alpini:netty4:alpini-netty4-base',
-  ':internal:alpini:router:alpini-router-api',
-  ':internal:alpini:router:alpini-router-base',
-  ':internal:alpini:router:alpini-router-impl',
-
-  // Depend-all module
-  ':all-modules',
-]
-
 subprojects {
   //apply group and version to all submodules
   group = rootProject.group
@@ -406,14 +367,14 @@ subprojects {
     classifier = 'tests'
   }
 
-  if (project.path in projectsToPublish) {
-    // Do not add source jar for shadow jars as they need to have sources of all transitive dependencies too
-    task sourceJar(type: Jar) {
-      from sourceSets.main.allJava
-      classifier 'sources'
-    }
+  task sourceJar(type: Jar) {
+    from sourceSets.main.allJava
+    classifier 'sources'
+  }
 
-    publishing.configureRegularArtifactPublishing(project, sourceJar, testJar)
+  // Only publish artifacts for projects that are at the leaf level
+  if (project.childProjects.size() == 0) {
+    publishing.configureArtifactPublishing(project, sourceJar, testJar)
   }
 }
 

--- a/clients/venice-admin-tool/build.gradle
+++ b/clients/venice-admin-tool/build.gradle
@@ -19,10 +19,6 @@ dependencies {
 apply from: "$rootDir/gradle/helper/publishing.gradle"
 apply from: "$rootDir/gradle/helper/packaging.gradle"
 
-artifacts {
-  archives shadowJar
-}
-
 jar {
   manifest {
     attributes = ['Implementation-Title'  : 'Venice Admin Tool',

--- a/clients/venice-admin-tool/build.gradle
+++ b/clients/venice-admin-tool/build.gradle
@@ -30,12 +30,3 @@ jar {
                   'Main-Class'            : 'com.linkedin.venice.AdminTool']
   }
 }
-
-//"fat" sources jar
-task sourceJar(type: Jar, dependsOn: classes) {
-  duplicatesStrategy = DuplicatesStrategy.WARN
-  // we return here a closure to do this lazy, after all projects are configured by gradle
-  from { packaging.collectSourceSetsIncludingSubmodules(project) }
-}
-
-publishing.configureShadowArtifactPublishing(project, shadowJar, sourceJar, testJar)

--- a/clients/venice-push-job/build.gradle
+++ b/clients/venice-push-job/build.gradle
@@ -67,12 +67,3 @@ jar {
     attributes 'Main-Class': 'com.linkedin.venice.hadoop.VenicePushJob'
   }
 }
-
-//"fat" sources jar
-task sourceJar(type: Jar, dependsOn: classes) {
-  duplicatesStrategy = DuplicatesStrategy.WARN
-  // we return here a closure to do this lazy, after all projects are configured by gradle
-  from { packaging.collectSourceSetsIncludingSubmodules(project) }
-}
-
-publishing.configureShadowArtifactPublishing(project, shadowJar, sourceJar, testJar)

--- a/clients/venice-push-job/build.gradle
+++ b/clients/venice-push-job/build.gradle
@@ -53,15 +53,6 @@ artifacts {
   archives shadowJar
 }
 
-shadowJar {
-  include '**'
-  exclude '**/com/linkedin/hadoop**'
-  exclude '**/org.apache.hadoop*'
-  exclude '**/org/apache/commons/**'
-  exclude '**/org/apache/hadoop/**'
-  exclude '**/org/apache/xerces/**'
-}
-
 jar {
   manifest {
     attributes 'Main-Class': 'com.linkedin.venice.hadoop.VenicePushJob'

--- a/clients/venice-push-job/build.gradle
+++ b/clients/venice-push-job/build.gradle
@@ -49,10 +49,6 @@ dependencies {
 apply from: "$rootDir/gradle/helper/publishing.gradle"
 apply from: "$rootDir/gradle/helper/packaging.gradle"
 
-artifacts {
-  archives shadowJar
-}
-
 jar {
   manifest {
     attributes 'Main-Class': 'com.linkedin.venice.hadoop.VenicePushJob'

--- a/gradle/helper/publishing.gradle
+++ b/gradle/helper/publishing.gradle
@@ -1,5 +1,5 @@
 ext.publishing = [
-    configureRegularArtifactPublishing: { currentProject, sourceJar, testJar ->
+    configureArtifactPublishing: { currentProject, sourceJar, testJar ->
       if (currentProject.version != project.DEFAULT_VERSION) {
         println "Will publish ${currentProject.path} at ${currentProject.group}:${currentProject.name}:${currentProject.version}"
 
@@ -40,50 +40,5 @@ ext.publishing = [
           //repositories inherited from parent build.gradle
         }
       }
-    },
-
-    configureShadowArtifactPublishing: { currentProject, shadowJar, sourceJar, testJar ->
-      if (currentProject.version != project.DEFAULT_VERSION) {
-        def classifier = 'all'
-        println "Will publish ${currentProject.path} at ${currentProject.group}:${currentProject.name}-${classifier}:${currentProject.version}"
-
-        publishing {
-          publications {
-            "${currentProject.name}"(MavenPublication) {
-              groupId currentProject.group
-              artifactId currentProject.name
-              version currentProject.version
-
-              artifact source: shadowJar, classifier: "$classifier"
-              // TODO: Enable after we figure out getting the full source for shadow jars
-              // artifact sourceJar
-              // TODO: Enable after we have valid javadocs
-              // artifact javadocJar
-
-              //we strive to meet https://central.sonatype.org/pages/requirements.html
-              pom {
-                name = 'Venice'
-                description = 'Derived Data Platform for planet-scale workloads'
-                url = 'https://github.com/linkedin/venice'
-
-                licenses {
-                  license {
-                    name = 'BSD 2-Clause'
-                    url = 'https://raw.githubusercontent.com/linkedin/venice/main/LICENSE'
-                  }
-                }
-                scm {
-                  connection = 'scm:git:git://github.com:linkedin/venice.git'
-                  developerConnection = 'scm:git:ssh://github.com:linkedin/venice.git'
-                  url = 'https://github.com/linkedin/venice'
-                }
-              }
-            }
-          }
-
-          //repositories inherited from parent build.gradle
-        }
-      }
-
     }
 ]


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci], [server], [controller],
[router], [samza], [vpj], [fast-client], [thin-client], [alpini],
[admin-tool], [test], [build], [doc], [script]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Remove different publishing for shadow jars
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
Shadow plugin configures artifact publishing to publish shadow jars to maven ([venice-controller example](https://linkedin.jfrog.io/ui/repos/tree/General/venice/com/linkedin/venice/venice-controller/0.4.3)). If we don't publish regular jars, then the `all-modules` component cannot depend on any published artifacts for `venice-push-job` and `venice-admin-tool`.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
Published to maven local: https://gist.github.com/nisargthakkar/48977caca2dd59561c603e7d6a7f7a30

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.