### PR TITLE
[build] Fix upstream remote check. Add explicit upstream in GithubActions

### DIFF
--- a/.github/workflows/build-and-upload-archives-on-demand.yml
+++ b/.github/workflows/build-and-upload-archives-on-demand.yml
@@ -14,10 +14,12 @@ jobs:
       # Checks out a copy of your repository on the ubuntu-latest machine
       - name: Checkout code
         uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          # bring in all history because the gradle versions plugin needs to "walk back" to the closest ancestor tag
-          fetch-depth: 0
+
+      - name: Add upstream remote
+        run: git remote add upstream https://github.com/linkedin/venice
+
+      - name: Fetch upstream refs
+        run: git fetch upstream
 
       - name: Set up JDK 11
         uses: actions/setup-java@v3

--- a/.github/workflows/build-and-upload-archives-upon-creating-tags.yml
+++ b/.github/workflows/build-and-upload-archives-upon-creating-tags.yml
@@ -17,10 +17,12 @@ jobs:
       # Checks out a copy of your repository on the ubuntu-latest machine
       - name: Checkout code
         uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          # bring in all history because the gradle versions plugin needs to "walk back" to the closest ancestor tag
-          fetch-depth: 0
+
+      - name: Add upstream remote
+        run: git remote add upstream https://github.com/linkedin/venice
+
+      - name: Fetch upstream refs
+        run: git fetch upstream
 
       - name: Set up JDK 11
         uses: actions/setup-java@v3

--- a/gradle/helper/git.gradle
+++ b/gradle/helper/git.gradle
@@ -2,7 +2,7 @@ ext.git = [
   getUpstreamRemote: {
     def remotes = 'git remote -v'.execute().text.trim()
     for (line in remotes.split('\n')) {
-      if (line.contains('git@github.com:linkedin/venice.git') || line.contains('https://github.com/linkedin/venice.git')) {
+      if (line.contains('git@github.com:linkedin/venice') || line.contains('github.com/linkedin/venice')) {
         def remote = line.split('\t')[0]  // origin ssh://git@github.com... (fetch)
         ext._upstreamRemote = remote
         return remote

--- a/gradle/helper/git.gradle
+++ b/gradle/helper/git.gradle
@@ -2,7 +2,7 @@ ext.git = [
   getUpstreamRemote: {
     def remotes = 'git remote -v'.execute().text.trim()
     for (line in remotes.split('\n')) {
-      if (line.contains('git@github.com:linkedin/venice') || line.contains('github.com/linkedin/venice')) {
+      if (line.contains('git@github.com:linkedin/venice') || line.contains('https://github.com/linkedin/venice')) {
         def remote = line.split('\t')[0]  // origin ssh://git@github.com... (fetch)
         ext._upstreamRemote = remote
         return remote

--- a/make_tag.py
+++ b/make_tag.py
@@ -106,7 +106,7 @@ def get_remote():
     remote_text = check_output(['git', 'remote', '-v'])
     lines = [l.decode('UTF-8') for l in remote_text.splitlines()]
     for line in lines:
-        if 'git@github.com:linkedin/venice.git' in line or 'https://github.com/linkedin/venice.git' in line:
+        if 'git@github.com:linkedin/venice' in line or 'https://github.com/linkedin/venice' in line:
             remote = str(line).split('\t')[0]  # origin ssh://git@github.com... (fetch)
             print('Using remote: ' + remote)
             return remote


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci], [server], [controller],
[router], [samza], [vpj], [fast-client], [thin-client], [alpini],
[admin-tool], [test], [build], [doc], [script]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->
Previously, this action failed: https://github.com/linkedin/venice/actions/runs/3192717384
In the failed action, I found that github adds the repo without `.git`. Then I tested https and ssh ones and found that it works without `.git` for both

## Fix upstream remote check. Add explicit upstream in GithubActions
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
Tested here: https://github.com/nisargthakkar/venice/actions/runs/3193114715

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.