### PR TITLE
[misc] Use upstream/main as a default baseline for wc-test

### DIFF
--- a/wc-test
+++ b/wc-test
@@ -25,7 +25,7 @@ def read_config(path):
 def run_command(command):
   status, output = subprocess.getstatusoutput(command)
   if status:
-    raise SystemExit(output)
+    raise SystemExit(command + '\n' + output)
   return output
 
 def get_queued_build(build_url, params):
@@ -63,7 +63,7 @@ if __name__ == "__main__":
   parser.add_argument("-m", "--message", help="optional description of the changes")
   parser.add_argument("patch", nargs='?', help="diff-formatted patch to submit for testing")
 
-  params = dict(job="Venice-WcTest", baseline="origin/master")
+  params = dict(job="Venice-WcTest", baseline="upstream/main")
   params.update(read_config(CI_CONFIG))
   parser.set_defaults(**params)
   params.update(vars(parser.parse_args()))
@@ -80,6 +80,7 @@ if __name__ == "__main__":
   if "patch" in params:
     response = run_command(command + shlex.quote(params["patch"]))
   else:
+    run_command("git fetch upstream")
     changes = run_command("git diff --find-renames --compact-summary " + params["baseline"])
     if not changes:
       raise SystemExit("No changes")


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci], [server], [controller],
[router], [samza], [vpj], [fast-client], [thin-client], [alpini],
[admin-tool], [test], [build], [doc], [script]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->
[script]

## Summary, imperative, start upper case, don't end with a period
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
Make sure wc-test uses upstream/main as a default baseline to compute local changes.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
Internal CI

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.