### PR TITLE
[da-vinci][server] Move Rmd serialization util to common package

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreWriteComputeProcessor.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreWriteComputeProcessor.java
@@ -1,6 +1,5 @@
 package com.linkedin.davinci.kafka.consumer;
 
-import com.linkedin.davinci.serialization.avro.MapOrderingPreservingSerDeFactory;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.meta.ReadOnlySchemaRepository;
 import com.linkedin.venice.schema.merge.MergeRecordHelper;
@@ -8,6 +7,7 @@ import com.linkedin.venice.schema.writecompute.WriteComputeProcessor;
 import com.linkedin.venice.schema.writecompute.WriteComputeSchemaValidator;
 import com.linkedin.venice.serializer.AvroGenericDeserializer;
 import com.linkedin.venice.serializer.AvroSerializer;
+import com.linkedin.venice.serializer.avro.MapOrderingPreservingSerDeFactory;
 import com.linkedin.venice.utils.Pair;
 import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
 import java.nio.ByteBuffer;

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/replication/merge/MergeConflictResolver.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/replication/merge/MergeConflictResolver.java
@@ -7,7 +7,6 @@ import static com.linkedin.venice.schema.rmd.v1.CollectionRmdTimestamp.TOP_LEVEL
 import static com.linkedin.venice.schema.rmd.v1.CollectionRmdTimestamp.TOP_LEVEL_TS_FIELD_NAME;
 
 import com.linkedin.davinci.replication.RmdWithValueSchemaId;
-import com.linkedin.davinci.serialization.avro.MapOrderingPreservingSerDeFactory;
 import com.linkedin.venice.annotation.Threadsafe;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.exceptions.VeniceUnsupportedOperationException;
@@ -17,6 +16,7 @@ import com.linkedin.venice.schema.SchemaUtils;
 import com.linkedin.venice.schema.merge.ValueAndRmd;
 import com.linkedin.venice.schema.writecompute.WriteComputeOperation;
 import com.linkedin.venice.schema.writecompute.WriteComputeSchemaConverter;
+import com.linkedin.venice.serializer.avro.MapOrderingPreservingSerDeFactory;
 import com.linkedin.venice.utils.lazy.Lazy;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/replication/merge/RmdSerDe.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/replication/merge/RmdSerDe.java
@@ -1,7 +1,6 @@
 package com.linkedin.davinci.replication.merge;
 
 import com.linkedin.davinci.replication.RmdWithValueSchemaId;
-import com.linkedin.davinci.serialization.avro.MapOrderingPreservingSerDeFactory;
 import com.linkedin.venice.annotation.Threadsafe;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.meta.ReadOnlySchemaRepository;
@@ -9,6 +8,7 @@ import com.linkedin.venice.schema.rmd.RmdSchemaEntry;
 import com.linkedin.venice.serializer.AvroSerializer;
 import com.linkedin.venice.serializer.RecordDeserializer;
 import com.linkedin.venice.serializer.RecordSerializer;
+import com.linkedin.venice.serializer.avro.MapOrderingPreservingSerDeFactory;
 import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
 import java.nio.ByteBuffer;
 import java.util.Map;

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/replication/merge/TestMergeConflictResolver.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/replication/merge/TestMergeConflictResolver.java
@@ -10,7 +10,6 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 
-import com.linkedin.davinci.serialization.avro.MapOrderingPreservingSerDeFactory;
 import com.linkedin.venice.meta.ReadOnlySchemaRepository;
 import com.linkedin.venice.schema.AvroSchemaParseUtils;
 import com.linkedin.venice.schema.SchemaEntry;
@@ -20,6 +19,7 @@ import com.linkedin.venice.schema.rmd.RmdSchemaGenerator;
 import com.linkedin.venice.serializer.FastSerializerDeserializerFactory;
 import com.linkedin.venice.serializer.RecordDeserializer;
 import com.linkedin.venice.serializer.RecordSerializer;
+import com.linkedin.venice.serializer.avro.MapOrderingPreservingSerDeFactory;
 import com.linkedin.venice.utils.AvroSupersetSchemaUtils;
 import java.util.ArrayList;
 import java.util.Map;

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/replication/merge/TestMergeUpdateWithValueLevelTimestamp.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/replication/merge/TestMergeUpdateWithValueLevelTimestamp.java
@@ -10,7 +10,6 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 
 import com.linkedin.davinci.replication.RmdWithValueSchemaId;
-import com.linkedin.davinci.serialization.avro.MapOrderingPreservingSerDeFactory;
 import com.linkedin.venice.meta.ReadOnlySchemaRepository;
 import com.linkedin.venice.schema.SchemaEntry;
 import com.linkedin.venice.schema.SchemaUtils;
@@ -18,6 +17,7 @@ import com.linkedin.venice.schema.rmd.RmdConstants;
 import com.linkedin.venice.schema.rmd.RmdSchemaEntry;
 import com.linkedin.venice.schema.writecompute.DerivedSchemaEntry;
 import com.linkedin.venice.schema.writecompute.WriteComputeSchemaConverter;
+import com.linkedin.venice.serializer.avro.MapOrderingPreservingSerDeFactory;
 import com.linkedin.venice.utils.lazy.Lazy;
 import com.linkedin.venice.writer.update.UpdateBuilder;
 import com.linkedin.venice.writer.update.UpdateBuilderImpl;

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/serializer/avro/MapOrderPreservingDatumReader.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/serializer/avro/MapOrderPreservingDatumReader.java
@@ -1,4 +1,4 @@
-package com.linkedin.davinci.serialization.avro;
+package com.linkedin.venice.serializer.avro;
 
 import com.linkedin.venice.utils.IndexedHashMap;
 import com.linkedin.venice.utils.IndexedMap;

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/serializer/avro/MapOrderPreservingDeserializer.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/serializer/avro/MapOrderPreservingDeserializer.java
@@ -1,4 +1,4 @@
-package com.linkedin.davinci.serialization.avro;
+package com.linkedin.venice.serializer.avro;
 
 import com.linkedin.venice.serializer.AvroGenericDeserializer;
 import org.apache.avro.Schema;

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/serializer/avro/MapOrderPreservingGenericDatumWriter.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/serializer/avro/MapOrderPreservingGenericDatumWriter.java
@@ -1,4 +1,4 @@
-package com.linkedin.davinci.serialization.avro;
+package com.linkedin.venice.serializer.avro;
 
 import com.linkedin.venice.utils.IndexedHashMap;
 import java.io.IOException;

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/serializer/avro/MapOrderPreservingSerializer.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/serializer/avro/MapOrderPreservingSerializer.java
@@ -1,4 +1,4 @@
-package com.linkedin.davinci.serialization.avro;
+package com.linkedin.venice.serializer.avro;
 
 import com.linkedin.venice.serializer.AvroSerializer;
 import org.apache.avro.Schema;

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/serializer/avro/MapOrderPreservingSpecificDatumWriter.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/serializer/avro/MapOrderPreservingSpecificDatumWriter.java
@@ -1,4 +1,4 @@
-package com.linkedin.davinci.serialization.avro;
+package com.linkedin.venice.serializer.avro;
 
 import com.linkedin.venice.utils.IndexedHashMap;
 import java.io.IOException;

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/serializer/avro/MapOrderingPreservingSerDeFactory.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/serializer/avro/MapOrderingPreservingSerDeFactory.java
@@ -1,4 +1,4 @@
-package com.linkedin.davinci.serialization.avro;
+package com.linkedin.venice.serializer.avro;
 
 import com.linkedin.venice.serializer.SerializerDeserializerFactory;
 import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/serializer/avro/MapOrderPreservingSerDeTest.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/serializer/avro/MapOrderPreservingSerDeTest.java
@@ -1,4 +1,4 @@
-package com.linkedin.davinci.serialization.avro;
+package com.linkedin.venice.serializer.avro;
 
 import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
 import com.linkedin.venice.utils.IndexedHashMap;


### PR DESCRIPTION
## Description
Move Rmd serialization utils to common package such that other packages, e.g. h2v, can utilize them. Have to separate these changes into a single PR to reduce the change list.
## How was this PR tested?
internal CI