### PR TITLE
[build] Revert fetch-depth to get all history

### DIFF
--- a/.github/workflows/build-and-upload-archives-on-demand.yml
+++ b/.github/workflows/build-and-upload-archives-on-demand.yml
@@ -14,11 +14,15 @@ jobs:
       # Checks out a copy of your repository on the ubuntu-latest machine
       - name: Checkout code
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0 # all history for all branches and tags
 
       - name: Add upstream remote
+        if: github.repository != 'linkedin/venice'
         run: git remote add upstream https://github.com/linkedin/venice
 
       - name: Fetch upstream refs
+        if: github.repository != 'linkedin/venice'
         run: git fetch upstream
 
       - name: Set up JDK 11

--- a/.github/workflows/build-and-upload-archives-upon-creating-tags.yml
+++ b/.github/workflows/build-and-upload-archives-upon-creating-tags.yml
@@ -17,11 +17,15 @@ jobs:
       # Checks out a copy of your repository on the ubuntu-latest machine
       - name: Checkout code
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0 # all history for all branches and tags
 
       - name: Add upstream remote
+        if: github.repository != 'linkedin/venice'
         run: git remote add upstream https://github.com/linkedin/venice
 
       - name: Fetch upstream refs
+        if: github.repository != 'linkedin/venice'
         run: git fetch upstream
 
       - name: Set up JDK 11


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci], [server], [controller],
[router], [samza], [vpj], [fast-client], [thin-client], [alpini],
[admin-tool], [test], [build], [doc], [script]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Summary, imperative, start upper case, don't end with a period
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Set fetch-depth to 0 to get all history instead of just the current tag. This was the previous behavior till I incorrectly changed in #36

For example: https://github.com/linkedin/venice/actions/runs/3185966029/jobs/5196103210 ran on the older code and fetched all tags. It wouldn't have run into the issue that https://github.com/linkedin/venice/actions/runs/3193427287/jobs/5211964867 did

(Checkout Code -> Checking out the ref)

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
Ran action: https://github.com/nisargthakkar/venice/actions/runs/3193477299

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.