### PR TITLE
[fast-client] Fix default value for routingUnavailableRequestCounterResetDelayMS

### DIFF
--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/ClientConfig.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/ClientConfig.java
@@ -129,7 +129,7 @@ public class ClientConfig<K, V, T extends SpecificRecord> {
         : TimeUnit.SECONDS.toMillis(10); // 10 seconds
     this.routingUnavailableRequestCounterResetDelayMS = routingUnavailableRequestCounterResetDelayMS > 0
         ? routingUnavailableRequestCounterResetDelayMS
-        : TimeUnit.MINUTES.toMicros(1); // 1 min
+        : TimeUnit.SECONDS.toMillis(10); // 10 seconds
     this.routingPendingRequestCounterInstanceBlockThreshold = routingPendingRequestCounterInstanceBlockThreshold > 0
         ? routingPendingRequestCounterInstanceBlockThreshold
         : 50;


### PR DESCRIPTION
## Fixed conversion bug resulting the default value for a config to be extremely high

- The default value for config routingUnavailableRequestCounterResetDelayMS was set to 1000 minutes or 16+ hours by mistake. This causes instances that encountered a one-off exception to be blocked for extended periods of time which reduces SN availability. 
- One-off exceptions should be rare, further reducing the default delay to 10s so instance can join back the healthy pool sooner rather than later.

## How was this PR tested?
Existing unit and integration tests.

## Does this PR introduce any user-facing changes?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.