### PR TITLE
[server][dvc][fc][vpj][doc] Lots of tidying up, mainly in DVC & server

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -431,3 +431,70 @@ build {
     'services:venice-controller:installDist'
   )
 }
+
+idea.project.ipr {
+  withXml { provider ->
+    provider.node.component
+            .find { it.@name == 'VcsDirectoryMappings' }
+            .mapping.@vcs = 'Git'
+
+    def inspectionProjectProfileManager = provider.node.component
+        .find { it.@name == 'InspectionProjectProfileManager' }
+
+    def danglingJavaDocInspectionProperties = [
+      class: "DanglingJavadoc",
+      enabled: "false",
+      level: "WARNING",
+      enabled_by_default: "false"
+    ]
+
+    if (inspectionProjectProfileManager == null) {
+      inspectionProjectProfileManager = provider.node.appendNode(
+        "component",
+        [
+          name: "InspectionProjectProfileManager"
+        ]
+      )
+
+      def profile = inspectionProjectProfileManager.appendNode(
+        "profile",
+        [
+          version: "1.0"
+        ]
+      )
+
+      profile.appendNode(
+        "option",
+        [
+          name: "myName",
+          value: "Project Default"
+        ]
+      )
+
+      profile.appendNode(
+        "inspection_tool",
+        danglingJavaDocInspectionProperties
+      )
+
+      inspectionProjectProfileManager.appendNode(
+        "version",
+        [
+          value: "1.0"
+        ]
+      )
+    } else {
+      def danglingJavaDoc = inspectionProjectProfileManager.profile.inspection_tool
+          .find { it.@class == 'DanglingJavadoc' }
+      if (danglingJavaDoc == null) {
+        inspectionProjectProfileManager.profile.get(0).appendNode(
+          "inspection_tool",
+          danglingJavaDocInspectionProperties
+        )
+      } else {
+        danglingJavaDoc.@enabled = false
+        danglingJavaDoc.@level = "WARNING"
+        danglingJavaDoc.@enabled_by_default = false
+      }
+    }
+  }
+}

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/DaVinciBackend.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/DaVinciBackend.java
@@ -171,7 +171,8 @@ public class DaVinciBackend implements Closeable {
               backendConfig.getIngestionServicePort(),
               partitionStateSerializer,
               new MetadataUpdateStats(metricsRepository),
-              configLoader)
+              configLoader,
+              storageService.getStoreVersionStateSyncer())
           : new StorageEngineMetadataService(storageService.getStorageEngineRepository(), partitionStateSerializer);
       // Start storage metadata service
       ((AbstractVeniceService) storageMetadataService).start();
@@ -188,7 +189,6 @@ public class DaVinciBackend implements Closeable {
           schemaRepository,
           null,
           metricsRepository,
-          rocksDBMemoryStats,
           Optional.of(kafkaMessageEnvelopeSchemaReader),
           Optional.empty(),
           partitionStateSerializer,

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/compression/StorageEngineBackedCompressorFactory.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/compression/StorageEngineBackedCompressorFactory.java
@@ -19,11 +19,15 @@ public class StorageEngineBackedCompressorFactory extends CompressorFactory {
 
   public VeniceCompressor getCompressor(CompressionStrategy compressionStrategy, String kafkaTopic) {
     if (ZSTD_WITH_DICT.equals(compressionStrategy)) {
-      if (versionSpecificCompressorExists(kafkaTopic)) {
-        return getVersionSpecificCompressor(kafkaTopic);
+      VeniceCompressor compressor = getVersionSpecificCompressor(kafkaTopic);
+      if (compressor != null) {
+        return compressor;
       }
 
       ByteBuffer dictionary = metadataService.getStoreVersionCompressionDictionary(kafkaTopic);
+      if (dictionary == null) {
+        throw new IllegalStateException("Got a null dictionary for: " + kafkaTopic);
+      }
       return super.createVersionSpecificCompressorIfNotExist(
           compressionStrategy,
           kafkaTopic,

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/DefaultIngestionBackend.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/DefaultIngestionBackend.java
@@ -8,11 +8,13 @@ import com.linkedin.davinci.notifier.VeniceNotifier;
 import com.linkedin.davinci.storage.StorageMetadataService;
 import com.linkedin.davinci.storage.StorageService;
 import com.linkedin.davinci.store.AbstractStorageEngine;
+import com.linkedin.venice.kafka.protocol.state.StoreVersionState;
 import com.linkedin.venice.utils.Utils;
 import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -42,21 +44,24 @@ public class DefaultIngestionBackend implements DaVinciIngestionBackend, VeniceI
       VeniceStoreVersionConfig storeConfig,
       int partition,
       Optional<LeaderFollowerStateType> leaderState) {
-    LOGGER.info("Retrieving storage engine for store {} partition {}", storeConfig.getStoreVersionName(), partition);
-    Utils.waitStoreVersionOrThrow(storeConfig.getStoreVersionName(), getStoreIngestionService().getMetadataRepo());
-    AbstractStorageEngine storageEngine = getStorageService().openStoreForNewPartition(storeConfig, partition);
-    if (topicStorageEngineReferenceMap.containsKey(storeConfig.getStoreVersionName())) {
-      topicStorageEngineReferenceMap.get(storeConfig.getStoreVersionName()).set(storageEngine);
-    }
+    String storeVersion = storeConfig.getStoreVersionName();
+    LOGGER.info("Retrieving storage engine for store {} partition {}", storeVersion, partition);
+    Utils.waitStoreVersionOrThrow(storeVersion, getStoreIngestionService().getMetadataRepo());
+    Supplier<StoreVersionState> svsSupplier = () -> storageMetadataService.getStoreVersionState(storeVersion);
+    AbstractStorageEngine storageEngine = storageService.openStoreForNewPartition(storeConfig, partition, svsSupplier);
+    topicStorageEngineReferenceMap.compute(storeVersion, (key, storageEngineAtomicReference) -> {
+      if (storageEngineAtomicReference != null) {
+        storageEngineAtomicReference.set(storageEngine);
+      }
+      return storageEngineAtomicReference;
+    });
     LOGGER.info(
         "Retrieved storage engine for store {} partition {}. Starting consumption in ingestion service",
-        storeConfig.getStoreVersionName(),
+        storeVersion,
         partition);
     getStoreIngestionService().startConsumption(storeConfig, partition, leaderState);
-    LOGGER.info(
-        "Completed starting consumption in ingestion service for store {} partition {}",
-        storeConfig.getStoreVersionName(),
-        partition);
+    LOGGER
+        .info("Completed starting consumption in ingestion service for store {} partition {}", storeVersion, partition);
   }
 
   @Override
@@ -128,7 +133,11 @@ public class DefaultIngestionBackend implements DaVinciIngestionBackend, VeniceI
   public void setStorageEngineReference(
       String topicName,
       AtomicReference<AbstractStorageEngine> storageEngineReference) {
-    topicStorageEngineReferenceMap.put(topicName, storageEngineReference);
+    if (storageEngineReference == null) {
+      topicStorageEngineReferenceMap.remove(topicName);
+    } else {
+      topicStorageEngineReferenceMap.put(topicName, storageEngineReference);
+    }
   }
 
   @Override

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/isolated/IsolatedIngestionServer.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/isolated/IsolatedIngestionServer.java
@@ -383,10 +383,10 @@ public class IsolatedIngestionServer extends AbstractVeniceService {
         report.offsetRecordArray = getStoreIngestionService().getPartitionOffsetRecords(topicName, partitionId);
 
         // Set store version state in ingestion report.
-        Optional<StoreVersionState> storeVersionState = storageMetadataService.getStoreVersionState(topicName);
-        if (storeVersionState.isPresent()) {
+        StoreVersionState storeVersionState = storageMetadataService.getStoreVersionState(topicName);
+        if (storeVersionState != null) {
           report.storeVersionState =
-              ByteBuffer.wrap(IsolatedIngestionUtils.serializeStoreVersionState(topicName, storeVersionState.get()));
+              ByteBuffer.wrap(IsolatedIngestionUtils.serializeStoreVersionState(topicName, storeVersionState));
         } else {
           throw new VeniceException("StoreVersionState does not exist for topic: " + topicName);
         }
@@ -646,7 +646,6 @@ public class IsolatedIngestionServer extends AbstractVeniceService {
         schemaRepository,
         liveConfigRepository,
         metricsRepository,
-        rocksDBMemoryStats,
         Optional.of(kafkaMessageEnvelopeSchemaReader),
         isDaVinciClient ? Optional.empty() : Optional.of(clientConfig),
         partitionStateSerializer,

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/isolated/IsolatedIngestionServerHandler.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/isolated/IsolatedIngestionServerHandler.java
@@ -197,7 +197,7 @@ public class IsolatedIngestionServerHandler extends SimpleChannelInboundHandler<
           // Open metadata partition of the store engine.
           storeConfig.setRestoreDataPartitions(false);
           storeConfig.setRestoreMetadataPartition(true);
-          isolatedIngestionServer.getStorageService().openStore(storeConfig);
+          isolatedIngestionServer.getStorageService().openStore(storeConfig, () -> null);
           LOGGER.info("Metadata partition of topic: {} restored.", ingestionTaskCommand.topicName);
           break;
         case PROMOTE_TO_LEADER:
@@ -305,9 +305,9 @@ public class IsolatedIngestionServerHandler extends SimpleChannelInboundHandler<
           break;
         case PUT_STORE_VERSION_STATE:
           isolatedIngestionServer.getStorageMetadataService()
-              .put(
+              .computeStoreVersionState(
                   topicName,
-                  IsolatedIngestionUtils
+                  ignored -> IsolatedIngestionUtils
                       .deserializeStoreVersionState(topicName, ingestionStorageMetadata.payload.array()));
           break;
         case CLEAR_STORE_VERSION_STATE:

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionService.java
@@ -23,14 +23,12 @@ import com.linkedin.davinci.stats.AggLagStats;
 import com.linkedin.davinci.stats.AggVersionedDIVStats;
 import com.linkedin.davinci.stats.AggVersionedIngestionStats;
 import com.linkedin.davinci.stats.ParticipantStoreConsumptionStats;
-import com.linkedin.davinci.stats.RocksDBMemoryStats;
 import com.linkedin.davinci.stats.StoreBufferServiceStats;
 import com.linkedin.davinci.storage.StorageEngineRepository;
 import com.linkedin.davinci.storage.StorageMetadataService;
 import com.linkedin.davinci.store.cache.backend.ObjectCacheBackend;
 import com.linkedin.venice.client.store.ClientConfig;
 import com.linkedin.venice.common.VeniceSystemStoreType;
-import com.linkedin.venice.compression.CompressionStrategy;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.exceptions.VeniceNoStoreException;
 import com.linkedin.venice.helix.HelixReadOnlyZKSharedSchemaRepository;
@@ -184,7 +182,6 @@ public class KafkaStoreIngestionService extends AbstractVeniceService implements
       ReadOnlySchemaRepository schemaRepo,
       ReadOnlyLiveClusterConfigRepository liveClusterConfigRepository,
       MetricsRepository metricsRepository,
-      RocksDBMemoryStats rocksDBMemoryStats,
       Optional<SchemaReader> kafkaMessageEnvelopeSchemaReader,
       Optional<ClientConfig> clientConfig,
       InternalAvroSpecificSerializer<PartitionState> partitionStateSerializer,
@@ -480,6 +477,7 @@ public class KafkaStoreIngestionService extends AbstractVeniceService implements
         .setIsDaVinciClient(isDaVinciClient)
         .setRemoteIngestionRepairService(remoteIngestionRepairService)
         .setMetaStoreWriter(metaStoreWriter)
+        .setCompressorFactory(compressorFactory)
         .build();
   }
 
@@ -559,7 +557,6 @@ public class KafkaStoreIngestionService extends AbstractVeniceService implements
         veniceStoreVersionConfig,
         partitionId,
         isIsolatedIngestion,
-        compressorFactory,
         cacheBackend);
   }
 
@@ -1060,16 +1057,6 @@ public class KafkaStoreIngestionService extends AbstractVeniceService implements
      */
     kafkaConsumerProperties.setProperty(ConsumerConfig.CLIENT_ID_CONFIG, groupId);
     return kafkaConsumerProperties;
-  }
-
-  @Override
-  public boolean isStoreVersionChunked(String topicName) {
-    return storageMetadataService.isStoreVersionChunked(topicName);
-  }
-
-  @Override
-  public CompressionStrategy getStoreVersionCompressionStrategy(String topicName) {
-    return storageMetadataService.getStoreVersionCompressionStrategy(topicName);
   }
 
   @Override

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -203,16 +203,18 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
       if (isHybridMode()) {
         dataRecoveryCompletionTimeLagThresholdInMs = TopicManager.BUFFER_REPLAY_MINIMAL_SAFETY_MARGIN / 2;
         LOGGER.info(
-            "Data recovery info for topic: " + getVersionTopic() + ", source kafka url: "
-                + nativeReplicationSourceVersionTopicKafkaURL + ", time lag threshold for completion: "
-                + dataRecoveryCompletionTimeLagThresholdInMs);
+            "Data recovery info for topic: {}, source kafka url: {}, time lag threshold for completion: {}",
+            getVersionTopic(),
+            nativeReplicationSourceVersionTopicKafkaURL,
+            dataRecoveryCompletionTimeLagThresholdInMs);
       }
     }
     this.nativeReplicationSourceVersionTopicKafkaURLSingletonSet =
         Collections.singleton(nativeReplicationSourceVersionTopicKafkaURL);
     LOGGER.info(
-        "Native replication source version topic kafka url set to: " + nativeReplicationSourceVersionTopicKafkaURL
-            + " for topic: " + getVersionTopic());
+        "Native replication source version topic kafka url set to: {} for topic: {}",
+        nativeReplicationSourceVersionTopicKafkaURL,
+        getVersionTopic());
 
     this.veniceWriterFactory = builder.getVeniceWriterFactory();
     this.veniceWriter = Lazy.of(
@@ -436,8 +438,9 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
           if (!store.isMigrationDuplicateStore()) {
             partitionConsumptionState.setLeaderFollowerState(IN_TRANSITION_FROM_STANDBY_TO_LEADER);
             LOGGER.info(
-                consumerTaskId + " became in transition to leader for partition "
-                    + partitionConsumptionState.getPartition());
+                "{} became in transition to leader for partition {}",
+                consumerTaskId,
+                partitionConsumptionState.getPartition());
           }
           break;
 
@@ -451,8 +454,10 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
           long lastTimestamp = getLastConsumedMessageTimestamp(partition);
           if (LatencyUtils.getElapsedTimeInMs(lastTimestamp) > newLeaderInactiveTime) {
             LOGGER.info(
-                consumerTaskId + " start promoting to leader for partition " + partition
-                    + " unsubscribing from current topic: " + kafkaVersionTopic);
+                "{} start promoting to leader for partition {} unsubscribing from current topic: {}",
+                consumerTaskId,
+                partition,
+                kafkaVersionTopic);
             /**
              * There isn't any new message from the old leader for at least {@link newLeaderInactiveTime} minutes,
              * this replica can finally be promoted to leader.
@@ -461,8 +466,10 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
             consumerUnSubscribe(kafkaVersionTopic, partitionConsumptionState);
 
             LOGGER.info(
-                consumerTaskId + " start promoting to leader for partition " + partition
-                    + ", unsubscribed from current topic: " + kafkaVersionTopic);
+                "{} start promoting to leader for partition {}, unsubscribed from current topic: {}",
+                consumerTaskId,
+                partition,
+                kafkaVersionTopic);
             OffsetRecord offsetRecord = partitionConsumptionState.getOffsetRecord();
             if (offsetRecord.getLeaderTopic() == null) {
               /**
@@ -480,8 +487,7 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
 
             if (!amplificationFactorAdapter.isLeaderSubPartition(partition)
                 && partitionConsumptionState.isEndOfPushReceived()) {
-              LOGGER.info(
-                  "Stop promoting non-leaderSubPartition: " + partition + " of store: " + storeName + " to leader.");
+              LOGGER.info("Stop promoting non-leaderSubPartition: {} of store: {}} to leader.", partition, storeName);
               partitionConsumptionState.setLeaderFollowerState(STANDBY);
               consumerSubscribe(
                   kafkaVersionTopic,
@@ -532,8 +538,10 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
 
             partitionConsumptionState.setConsumeRemotely(false);
             LOGGER.info(
-                consumerTaskId + " disabled remote consumption from topic " + currentLeaderTopic + " partition "
-                    + partition);
+                "{} disabled remote consumption from topic {} partition {}",
+                consumerTaskId,
+                currentLeaderTopic,
+                partition);
             /**
              * The flag is turned on in {@link LeaderFollowerStoreIngestionTask#shouldProcessRecord} avoid consuming
              * unwanted messages after EOP in remote VT, such as SOBR. Now that the leader switches to consume locally,
@@ -635,8 +643,10 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
       if (shouldNewLeaderSwitchToRemoteConsumption(partitionConsumptionState)) {
         partitionConsumptionState.setConsumeRemotely(true);
         LOGGER.info(
-            consumerTaskId + " enabled remote consumption from topic " + offsetRecord.getLeaderTopic() + " partition "
-                + partition);
+            "{} enabled remote consumption from topic {} partition {}",
+            consumerTaskId,
+            offsetRecord.getLeaderTopic(),
+            partition);
       }
     }
 
@@ -654,16 +664,15 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
     // subscribe to the new upstream
     String leaderSourceKafkaURL = leaderSourceKafkaURLs.iterator().next();
     LOGGER.info(
-        String.format(
-            "%s is promoted to leader for partition %d and it is going to start consuming from "
-                + "topic %s partition %d at offset %d; source Kafka url: %s; remote consumption flag: %s",
-            consumerTaskId,
-            partition,
-            leaderTopic,
-            leaderTopicPartition,
-            leaderStartOffset,
-            leaderSourceKafkaURL,
-            partitionConsumptionState.consumeRemotely()));
+        "{} is promoted to leader for partition {} and it is going to start consuming from "
+            + "topic {} partition {} at offset {}; source Kafka url: {}; remote consumption flag: {}",
+        consumerTaskId,
+        partition,
+        leaderTopic,
+        leaderTopicPartition,
+        leaderStartOffset,
+        leaderSourceKafkaURL,
+        partitionConsumptionState.consumeRemotely());
     consumerSubscribe(
         leaderTopic,
         partitionConsumptionState.getSourceTopicPartition(leaderTopic),
@@ -675,12 +684,11 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
         Collections.singletonMap(leaderSourceKafkaURL, leaderStartOffset));
 
     LOGGER.info(
-        String.format(
-            "%s, as a leader, started consuming from topic %s partition %d at offset %d",
-            consumerTaskId,
-            offsetRecord.getLeaderTopic(),
-            leaderTopicPartition,
-            leaderStartOffset));
+        "{}, as a leader, started consuming from topic {} partition {} at offset {}",
+        consumerTaskId,
+        offsetRecord.getLeaderTopic(),
+        leaderTopicPartition,
+        leaderStartOffset);
   }
 
   private boolean switchAwayFromStreamReprocessingTopic(String currentLeaderTopic, TopicSwitch topicSwitch) {
@@ -734,8 +742,10 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
     if (isNativeReplicationEnabled && !newSourceKafkaServer.equals(localKafkaServer)) {
       partitionConsumptionState.setConsumeRemotely(true);
       LOGGER.info(
-          consumerTaskId + " enabled remote consumption from topic " + newSourceTopicName + " partition "
-              + partitionConsumptionState.getSourceTopicPartition(newSourceTopicName));
+          "{} enabled remote consumption from topic {} partition {}",
+          consumerTaskId,
+          newSourceTopicName,
+          partitionConsumptionState.getSourceTopicPartition(newSourceTopicName));
     }
     partitionConsumptionState.getOffsetRecord().setLeaderTopic(newSourceTopicName);
     partitionConsumptionState.getOffsetRecord()
@@ -757,8 +767,12 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
         Collections.singletonMap(sourceKafkaURL, upstreamStartOffset));
 
     LOGGER.info(
-        consumerTaskId + " leader successfully switch feed topic from " + currentLeaderTopic + " to "
-            + newSourceTopicName + " offset " + upstreamStartOffset + " partition " + partition);
+        "{} leader successfully switch feed topic from {} to {} offset {} partition {}",
+        consumerTaskId,
+        currentLeaderTopic,
+        newSourceTopicName,
+        upstreamStartOffset,
+        partition);
 
     // In case new topic is empty and leader can never become online
     defaultReadyToServeChecker.apply(partitionConsumptionState);
@@ -917,10 +931,12 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
       if (LatencyUtils
           .getElapsedTimeInMs(latestConsumedProducerTimestamp) < dataRecoveryCompletionTimeLagThresholdInMs) {
         LOGGER.info(
-            "Data recovery completed for topic: " + kafkaVersionTopic + " partition: "
-                + partitionConsumptionState.getPartition() + " upon consuming records with producer timestamp of "
-                + latestConsumedProducerTimestamp + " which is within the data recovery completion lag threshold of "
-                + dataRecoveryCompletionTimeLagThresholdInMs + " ms");
+            "Data recovery completed for topic: {} partition: {} upon consuming records with "
+                + "producer timestamp of {} which is within the data recovery completion lag threshold of {} ms",
+            kafkaVersionTopic,
+            partitionConsumptionState.getPartition(),
+            latestConsumedProducerTimestamp,
+            dataRecoveryCompletionTimeLagThresholdInMs);
         isDataRecoveryCompleted = true;
       }
     }
@@ -938,9 +954,10 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
       long lastTimestamp = getLastConsumedMessageTimestamp(partitionConsumptionState.getPartition());
       if (isAtEndOfSourceVT && LatencyUtils.getElapsedTimeInMs(lastTimestamp) > newLeaderInactiveTime) {
         LOGGER.info(
-            "Data recovery completed for topic: " + kafkaVersionTopic + " partition: "
-                + partitionConsumptionState.getPartition() + " upon exceeding leader inactive time of "
-                + newLeaderInactiveTime + " ms");
+            "Data recovery completed for topic: {} partition: {} upon exceeding leader inactive time of {} ms",
+            kafkaVersionTopic,
+            partitionConsumptionState.getPartition(),
+            newLeaderInactiveTime);
         isDataRecoveryCompleted = true;
       }
     }
@@ -982,7 +999,7 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
      * Hence, before processing TopicSwitch message, we need to force downgrade other subPartitions into FOLLOWER.
      */
     if (isLeader(partitionConsumptionState) && !amplificationFactorAdapter.isLeaderSubPartition(partition)) {
-      LOGGER.info("SubPartition: " + partitionConsumptionState.getPartition() + " is demoted from LEADER to STANDBY.");
+      LOGGER.info("SubPartition: {} is demoted from LEADER to STANDBY.", partitionConsumptionState.getPartition());
       String currentLeaderTopic = partitionConsumptionState.getOffsetRecord().getLeaderTopic();
       consumerUnSubscribe(currentLeaderTopic, partitionConsumptionState);
       waitForLastLeaderPersistFuture(
@@ -1074,18 +1091,24 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
       Map<String, Long> upstreamStartOffsetByKafkaURL) {
     storageMetadataService.computeStoreVersionState(kafkaVersionTopic, previousStoreVersionState -> {
       if (previousStoreVersionState != null) {
-        String newTopicSwitchLogging = "TopicSwitch message (new source topic:" + topicSwitch.sourceTopicName
-            + "; rewind start time:" + topicSwitch.rewindStartTimestamp
-            + "; upstream start offset by source Kafka URL: " + upstreamStartOffsetByKafkaURL + ")";
-
         if (previousStoreVersionState.topicSwitch == null) {
-          LOGGER.info("First time receiving a " + newTopicSwitchLogging);
+          LOGGER.info(
+              "First time receiving a TopicSwitch message (new source topic: {}; "
+                  + "rewind start time: {}; upstream start offset by source Kafka URL: {})",
+              topicSwitch.sourceTopicName,
+              topicSwitch.rewindStartTimestamp,
+              upstreamStartOffsetByKafkaURL);
         } else {
           LOGGER.info(
-              "Previous TopicSwitch message in metadata store (source topic:"
-                  + previousStoreVersionState.topicSwitch.sourceTopicName + "; rewind start time:"
-                  + previousStoreVersionState.topicSwitch.rewindStartTimestamp + "; source kafka servers "
-                  + topicSwitch.sourceKafkaServers + ") will be replaced" + " by the new " + newTopicSwitchLogging);
+              "Previous TopicSwitch message in metadata store (source topic: {}; rewind start time: {}; "
+                  + "source kafka servers {}) will be replaced by the new TopicSwitch message (new source topic: {}; "
+                  + "rewind start time: {}; upstream start offset by source Kafka URL: {})",
+              previousStoreVersionState.topicSwitch.sourceTopicName,
+              previousStoreVersionState.topicSwitch.rewindStartTimestamp,
+              topicSwitch.sourceKafkaServers,
+              topicSwitch.sourceTopicName,
+              topicSwitch.rewindStartTimestamp,
+              upstreamStartOffsetByKafkaURL);
         }
         previousStoreVersionState.topicSwitch = topicSwitch;
 
@@ -1352,7 +1375,7 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
             break;
         }
       } catch (Exception e) {
-        LOGGER.warn(consumerTaskId + " failed comparing the rewind message with the actual value in Venice", e);
+        LOGGER.warn("{} failed comparing the rewind message with the actual value in Venice", consumerTaskId, e);
       }
 
       if (lossy) {
@@ -1568,8 +1591,9 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
     PartitionConsumptionState partitionConsumptionState = partitionConsumptionStateMap.get(subPartition);
     if (partitionConsumptionState == null) {
       LOGGER.info(
-          "Skipping message as partition is no longer actively subscribed. Topic: " + kafkaVersionTopic
-              + " Partition Id: " + subPartition);
+          "Skipping message as partition is no longer actively subscribed. Topic: {} Partition Id: {}",
+          kafkaVersionTopic,
+          subPartition);
       return false;
     }
     switch (partitionConsumptionState.getLeaderFollowerState()) {
@@ -1622,7 +1646,7 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
                 errorMsg + ". Throwing exception as the node still subscribes to " + recordTopic);
           }
           if (!REDUNDANT_LOGGING_FILTER.isRedundantException(errorMsg)) {
-            LOGGER.error(errorMsg + ". Skipping the message as the node does not subscribe to " + recordTopic);
+            LOGGER.error("{}. Skipping the message as the node does not subscribe to {}", errorMsg, recordTopic);
           }
           return false;
         }
@@ -1632,7 +1656,7 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
           String message = consumerTaskId + " Current L/F state:" + partitionConsumptionState.getLeaderFollowerState()
               + "; The record was already processed partition " + subPartition;
           if (!REDUNDANT_LOGGING_FILTER.isRedundantException(message)) {
-            LOGGER.info(message + " LastKnown " + lastOffset + " Current " + record.offset());
+            LOGGER.info("{}; LastKnown {}; Current {}", message, lastOffset, record.offset());
           }
           return false;
         }
@@ -1844,9 +1868,7 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
          * messages to disk, and potentially rewind a k/v pair to an old value.
          */
         divErrorMetricCallback.execute(e);
-        if (LOGGER.isDebugEnabled()) {
-          LOGGER.debug(consumerTaskId + " : Skipping a duplicate record at offset: " + consumerRecord.offset());
-        }
+        LOGGER.debug("{} : Skipping a duplicate record at offset: {}", consumerTaskId, consumerRecord.offset());
         return DelegateConsumerRecordResult.DUPLICATE_MESSAGE;
       }
 
@@ -2015,17 +2037,14 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
             break;
         }
         if (!isSegmentControlMsg(controlMessageType)) {
-          if (producedFinally) {
-            LOGGER.info(
-                consumerTaskId + " hasProducedToKafka: YES. ControlMessage: " + controlMessageType.name()
-                    + ", received from  Topic: " + consumerRecord.topic() + " Partition: " + consumerRecord.partition()
-                    + " Offset: " + consumerRecord.offset());
-          } else {
-            LOGGER.info(
-                consumerTaskId + " hasProducedToKafka: NO. ControlMessage: " + controlMessageType.name()
-                    + ", received from  Topic: " + consumerRecord.topic() + " Partition: " + consumerRecord.partition()
-                    + " Offset: " + consumerRecord.offset());
-          }
+          LOGGER.info(
+              "{} hasProducedToKafka: {}; ControlMessage: {}; topic: {}; partition: {}; offset: {}",
+              consumerTaskId,
+              producedFinally,
+              controlMessageType.name(),
+              consumerRecord.topic(),
+              consumerRecord.partition(),
+              consumerRecord.offset());
         }
       } else if (kafkaValue == null) {
         throw new VeniceMessageException(
@@ -2085,14 +2104,18 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
         }
       } catch (InterruptedException e) {
         LOGGER.warn(
-            "Got interrupted while waiting for the last queued record to be persisted for topic: " + topic
-                + " partition: " + partition + ". Will throw the interrupt exception",
+            "Got interrupted while waiting for the last queued record to be persisted for topic: {}; partition: {}. "
+                + "Will throw the interrupt exception.",
+            topic,
+            partition,
             e);
         throw e;
       } catch (Exception e) {
         LOGGER.error(
-            "Got exception while waiting for the latest queued record future to be completed for topic: " + topic
-                + " partition: " + partition,
+            "Got exception while waiting for the last queued record to be persisted for topic: {}; partition: {}. "
+                + "Will swallow.",
+            topic,
+            partition,
             e);
       }
       Future<Void> lastFuture = null;
@@ -2106,23 +2129,29 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
         }
       } catch (InterruptedException e) {
         LOGGER.warn(
-            "Got interrupted while waiting for the last leader producer future for topic: " + topic + " partition: "
-                + partition + ". No data loss. Will throw the interrupt exception",
+            "Got interrupted while waiting for the last leader producer future for topic: {}; partition: {}. "
+                + "No data loss. Will throw the interrupt exception.",
+            topic,
+            partition,
             e);
         versionedDIVStats.recordBenignLeaderProducerFailure(storeName, versionNumber);
         throw e;
       } catch (TimeoutException e) {
         LOGGER.error(
-            "Timeout on waiting for the last leader producer future for topic: " + topic + " partition: " + partition
-                + ". No data loss.",
+            "Timeout on waiting for the last leader producer future for topic: {}; partition: {}. No data loss."
+                + "Will swallow.",
+            topic,
+            partition,
             e);
         lastFuture.cancel(true);
         partitionConsumptionState.setLastLeaderPersistFuture(null);
         versionedDIVStats.recordBenignLeaderProducerFailure(storeName, versionNumber);
       } catch (Exception e) {
         LOGGER.error(
-            "Got exception while waiting for the latest producer future to be completed for topic: " + topic
-                + " partition: " + partition,
+            "Got exception while waiting for the latest producer future to be completed for topic: {}; partition: {}"
+                + "Will swallow.",
+            topic,
+            partition,
             e);
         partitionConsumptionState.setLastLeaderPersistFuture(null);
         // No need to fail the push job; just record the failure.

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ParticipantStoreConsumptionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ParticipantStoreConsumptionTask.java
@@ -20,6 +20,7 @@ import java.io.Closeable;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
+import org.apache.commons.lang3.Validate;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -49,10 +50,10 @@ public class ParticipantStoreConsumptionTask implements Runnable, Closeable {
       long participantMessageConsumptionDelayMs,
       ICProvider icProvider) {
 
-    this.stats = stats;
-    this.storeIngestionService = storeIngestionService;
-    this.clusterInfoProvider = clusterInfoProvider;
-    this.clientConfig = clientConfig;
+    this.stats = Validate.notNull(stats);
+    this.storeIngestionService = Validate.notNull(storeIngestionService);
+    this.clusterInfoProvider = Validate.notNull(clusterInfoProvider);
+    this.clientConfig = Validate.notNull(clientConfig);
     this.participantMessageConsumptionDelayMs = participantMessageConsumptionDelayMs;
     this.icProvider = icProvider;
   }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StorageUtilizationManager.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StorageUtilizationManager.java
@@ -392,6 +392,9 @@ public class StorageUtilizationManager implements StoreDataChangedListener {
 
   public void notifyFlushToDisk(PartitionConsumptionState pcs) {
     int partition = pcs.getPartition();
-    partitionConsumptionSizeMap.get(partition).syncWithDB();
+    StoragePartitionDiskUsage partitionConsumptionState = partitionConsumptionSizeMap.get(partition);
+    if (partitionConsumptionState != null) {
+      partitionConsumptionState.syncWithDB();
+    }
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -6,10 +6,10 @@ import static com.linkedin.davinci.kafka.consumer.ConsumerActionType.UNSUBSCRIBE
 import static java.util.concurrent.TimeUnit.HOURS;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.MINUTES;
-import static java.util.concurrent.TimeUnit.NANOSECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 import com.linkedin.avroutil1.compatibility.shaded.org.apache.commons.lang3.Validate;
+import com.linkedin.davinci.compression.StorageEngineBackedCompressorFactory;
 import com.linkedin.davinci.config.VeniceServerConfig;
 import com.linkedin.davinci.config.VeniceStoreVersionConfig;
 import com.linkedin.davinci.helix.LeaderFollowerPartitionStateModel;
@@ -28,6 +28,7 @@ import com.linkedin.davinci.store.record.ValueRecord;
 import com.linkedin.venice.common.VeniceSystemStoreType;
 import com.linkedin.venice.common.VeniceSystemStoreUtils;
 import com.linkedin.venice.compression.CompressionStrategy;
+import com.linkedin.venice.compression.VeniceCompressor;
 import com.linkedin.venice.exceptions.PersistenceFailureException;
 import com.linkedin.venice.exceptions.UnsubscribedTopicPartitionException;
 import com.linkedin.venice.exceptions.VeniceChecksumException;
@@ -83,9 +84,11 @@ import com.linkedin.venice.utils.DiskUsage;
 import com.linkedin.venice.utils.LatencyUtils;
 import com.linkedin.venice.utils.PartitionUtils;
 import com.linkedin.venice.utils.RedundantExceptionFilter;
+import com.linkedin.venice.utils.SparseConcurrentList;
 import com.linkedin.venice.utils.Timer;
 import com.linkedin.venice.utils.VeniceProperties;
 import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
+import com.linkedin.venice.utils.lazy.Lazy;
 import com.linkedin.venice.writer.LeaderMetadataWrapper;
 import it.unimi.dsi.fastutil.ints.IntList;
 import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
@@ -93,6 +96,7 @@ import it.unimi.dsi.fastutil.ints.IntSet;
 import it.unimi.dsi.fastutil.ints.IntSets;
 import it.unimi.dsi.fastutil.objects.Object2IntMap;
 import java.io.Closeable;
+import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.time.Duration;
 import java.time.Instant;
@@ -123,7 +127,6 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 import org.apache.avro.Schema;
-import org.apache.commons.codec.binary.Hex;
 import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.producer.Callback;
@@ -234,8 +237,8 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
   // use this checker to check whether ingestion completion can be reported for a partition
   protected final ReadyToServeCheck defaultReadyToServeChecker;
 
-  protected final IntSet availableSchemaIds;
-  protected final IntSet deserializedSchemaIds;
+  protected final SparseConcurrentList<Object> availableSchemaIds = new SparseConcurrentList<>();
+  protected final SparseConcurrentList<Object> deserializedSchemaIds = new SparseConcurrentList<>();
   protected int idleCounter = 0;
 
   // This indicates whether it polls nothing from Kafka
@@ -288,6 +291,8 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
    * entry for each key.
    */
   private final boolean disableAutoCompactionForSamzaReprocessingJob;
+  /** Constructor which only returns an instance if the related functionality is enabled, and null otherwise. */
+  private final Supplier<IntSet> intSetProviderForTrackingCompactingPartitions;
   /**
    * This map is used to track the manual compaction progress for each partition.
    * This map won't be cleaned up even the compaction is done since it is being used in {@link #produceToStoreBufferServiceOrKafka}
@@ -353,6 +358,9 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
   private final Object2IntMap<String> kafkaClusterUrlToIdMap;
   protected final boolean readOnlyForBatchOnlyStoreEnabled;
   protected final CompressionStrategy compressionStrategy;
+  protected final StorageEngineBackedCompressorFactory compressorFactory;
+  protected final Lazy<VeniceCompressor> compressor;
+  protected final boolean isChunked;
 
   public StoreIngestionTask(
       StoreIngestionTaskFactory.Builder builder,
@@ -384,8 +392,6 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
     this.isUserSystemStore = VeniceSystemStoreUtils.isUserSystemStore(storeName);
     this.realTimeTopic = Version.composeRealTimeTopic(storeName);
     this.versionNumber = Version.parseVersionFromKafkaTopicName(kafkaVersionTopic);
-    this.availableSchemaIds = new IntOpenHashSet();
-    this.deserializedSchemaIds = new IntOpenHashSet();
     this.consumerActionsQueue = new PriorityBlockingQueue<>(CONSUMER_ACTION_QUEUE_INIT_CAPACITY);
 
     // partitionConsumptionStateMap could be accessed by multiple threads: consumption thread and the thread handling
@@ -415,7 +421,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
 
     this.diskUsage = builder.getDiskUsage();
 
-    this.storageEngine = storageEngineRepository.getLocalStorageEngine(kafkaVersionTopic);
+    this.storageEngine = Validate.notNull(storageEngineRepository.getLocalStorageEngine(kafkaVersionTopic));
 
     this.serverConfig = builder.getServerConfig();
 
@@ -437,6 +443,8 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
      * The reason to use a different field name here is that the naming convention will be consistent with RocksDB.
      */
     this.disableAutoCompactionForSamzaReprocessingJob = !serverConfig.isEnableAutoCompactionForSamzaReprocessingJob();
+    this.intSetProviderForTrackingCompactingPartitions =
+        disableAutoCompactionForSamzaReprocessingJob ? IntOpenHashSet::new : () -> null;
 
     this.storeVersionPartitionCount = version.getPartitionCount();
 
@@ -470,7 +478,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
 
     this.cacheBackend = cacheBackend;
     this.localKafkaServer = this.kafkaProps.getProperty(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG);
-    this.localKafkaServerSingletonSet = Collections.unmodifiableSet(Collections.singleton(localKafkaServer));
+    this.localKafkaServerSingletonSet = Collections.singleton(localKafkaServer);
     this.isDaVinciClient = builder.isDaVinciClient();
     this.isActiveActiveReplicationEnabled = version.isActiveActiveReplicationEnabled();
     this.offsetLagDeltaRelaxEnabled = serverConfig.getOffsetLagDeltaRelaxFactorForFastOnlineTransitionInRestart() > 0;
@@ -494,6 +502,9 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
     this.kafkaClusterUrlToIdMap = serverConfig.getKafkaClusterUrlToIdMap();
     this.localKafkaClusterId = kafkaClusterUrlToIdMap.getOrDefault(localKafkaServer, Integer.MIN_VALUE);
     this.compressionStrategy = version.getCompressionStrategy();
+    this.compressorFactory = builder.getCompressorFactory();
+    this.compressor = Lazy.of(() -> compressorFactory.getCompressor(compressionStrategy, kafkaVersionTopic));
+    this.isChunked = version.isChunkingEnabled();
   }
 
   /** Package-private on purpose, only intended for tests. Do not use for production use cases. */
@@ -985,13 +996,32 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
      * Once the manual compaction is triggered, all the following messages belonging to the same partition
      * will be dropped.
      */
-    IntSet compactingPartitions = new IntOpenHashSet();
+    IntSet compactingPartitions = intSetProviderForTrackingCompactingPartitions.get();
     int subPartition =
         PartitionUtils.getSubPartition(topicPartition.topic(), topicPartition.partition(), amplificationFactor);
     for (ConsumerRecord<KafkaKey, KafkaMessageEnvelope> record: records) {
       long beforeProcessingRecordTimestamp = System.nanoTime();
       if (!shouldProcessRecord(record, subPartition)) {
         continue;
+      }
+
+      if (record.key().isControlMessage()) {
+        ControlMessage controlMessage = (ControlMessage) record.value().payloadUnion;
+        if (ControlMessageType.valueOf(controlMessage.controlMessageType) == ControlMessageType.START_OF_PUSH) {
+          /**
+           * N.B.: The rest of the {@link ControlMessage} types are handled by:
+           * {@link #processControlMessage(KafkaMessageEnvelope, ControlMessage, int, long, PartitionConsumptionState)}
+           *
+           * But for the SOP in particular, we want to process it here, at the start of the pipeline, to ensure that the
+           * {@link StoreVersionState} is properly primed, as other functions below this point, but prior to being
+           * enqueued into the {@link StoreBufferService} rely on this state to be there.
+           */
+          processStartOfPush(
+              record.value(),
+              controlMessage,
+              record.partition(),
+              partitionConsumptionStateMap.get(subPartition));
+        }
       }
 
       if (disableAutoCompactionForSamzaReprocessingJob) {
@@ -1027,9 +1057,8 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
           KafkaKey kafkaKey = record.key();
           if (kafkaKey.isControlMessage() && ControlMessageType
               .valueOf((ControlMessage) record.value().payloadUnion) == ControlMessageType.END_OF_PUSH) {
-            Optional<StoreVersionState> storeVersionState =
-                storageMetadataService.getStoreVersionState(kafkaVersionTopic);
-            if (!storeVersionState.isPresent()) {
+            StoreVersionState storeVersionState = storageEngine.getStoreVersionState();
+            if (storeVersionState == null) {
               /**
                * EOP is received, but {@link StoreVersionState} for current store is not available, which indicates that
                * this is a small push, but to be consistent, we will flush all the pending messages in the drainer queue, and wait
@@ -1050,15 +1079,15 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
                   record.topic(),
                   record.partition(),
                   partitionConsumptionState);
-              storeVersionState = storageMetadataService.getStoreVersionState(kafkaVersionTopic);
-              if (!storeVersionState.isPresent()) {
+              storeVersionState = storageEngine.getStoreVersionState();
+              if (storeVersionState == null) {
                 throw new VeniceException(
                     "Failed to get StoreVersionState after draining all the pending messages for topic: "
                         + kafkaVersionTopic + ", partition: " + consumingPartition);
               }
             }
 
-            if (storeVersionState.get().sorted) {
+            if (storeVersionState.sorted) {
               /**
                * The batch part is sorted, which indicates the push job is mostly from VPJ, so no delay compaction is required.
                * Nothing needs to be done here
@@ -1706,13 +1735,13 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
     // If this storage node has never consumed data from this topic, instead of sending "START" here, we send it
     // once START_OF_PUSH message has been read.
     if (offsetRecord.getLocalVersionTopicOffset() > 0) {
-      Optional<StoreVersionState> storeVersionState = storageMetadataService.getStoreVersionState(kafkaVersionTopic);
-      if (storeVersionState.isPresent()) {
-        boolean sorted = storeVersionState.get().sorted;
+      StoreVersionState storeVersionState = storageEngine.getStoreVersionState();
+      if (storeVersionState != null) {
+        boolean sorted = storeVersionState.sorted;
         /**
          * Put TopicSwitch message into in-memory state.
          */
-        TopicSwitch topicSwitch = resolveSourceKafkaServersWithinTopicSwitch(storeVersionState.get().topicSwitch);
+        TopicSwitch topicSwitch = resolveSourceKafkaServersWithinTopicSwitch(storeVersionState.topicSwitch);
         newPartitionConsumptionState.setTopicSwitch(topicSwitch);
 
         /**
@@ -1720,8 +1749,8 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
          */
         beginBatchWrite(partition, sorted, newPartitionConsumptionState);
 
-        newPartitionConsumptionState.setStartOfPushTimestamp(storeVersionState.get().startOfPushTimestamp);
-        newPartitionConsumptionState.setEndOfPushTimestamp(storeVersionState.get().endOfPushTimestamp);
+        newPartitionConsumptionState.setStartOfPushTimestamp(storeVersionState.startOfPushTimestamp);
+        newPartitionConsumptionState.setEndOfPushTimestamp(storeVersionState.endOfPushTimestamp);
 
         statusReportAdapter.reportRestarted(newPartitionConsumptionState);
       }
@@ -1973,8 +2002,8 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
     return localKafkaServerSingletonSet;
   }
 
-  public Optional<PartitionConsumptionState> getPartitionConsumptionState(int partitionId) {
-    return Optional.ofNullable(partitionConsumptionStateMap.get(partitionId));
+  public PartitionConsumptionState getPartitionConsumptionState(int partitionId) {
+    return partitionConsumptionStateMap.get(partitionId);
   }
 
   public boolean hasAnyPartitionConsumptionState(Predicate<PartitionConsumptionState> pcsPredicate) {
@@ -2388,18 +2417,19 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
   }
 
   private void syncEndOfPushTimestampToMetadataService(long endOfPushTimestamp) {
-    Optional<StoreVersionState> storeVersionState = storageMetadataService.getStoreVersionState(kafkaVersionTopic);
-    if (storeVersionState.isPresent()) {
-      storeVersionState.get().endOfPushTimestamp = endOfPushTimestamp;
+    storageMetadataService.computeStoreVersionState(kafkaVersionTopic, previousStoreVersionState -> {
+      if (previousStoreVersionState != null) {
+        previousStoreVersionState.endOfPushTimestamp = endOfPushTimestamp;
 
-      // Sync latest store version level metadata to disk
-      storageMetadataService.put(kafkaVersionTopic, storeVersionState.get());
-    } else {
-      throw new VeniceException(
-          "Unexpected: received some " + ControlMessageType.END_OF_PUSH.name()
-              + " control message in a topic where we have not yet received a "
-              + ControlMessageType.START_OF_PUSH.name() + " control message.");
-    }
+        // Sync latest store version level metadata to disk
+        return previousStoreVersionState;
+      } else {
+        throw new VeniceException(
+            "Unexpected: received some " + ControlMessageType.END_OF_PUSH.name()
+                + " control message in a topic where we have not yet received a "
+                + ControlMessageType.START_OF_PUSH.name() + " control message.");
+      }
+    });
   }
 
   private void processStartOfPush(
@@ -2415,33 +2445,37 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
     partitionConsumptionState.setStartOfPushTimestamp(startOfPushKME.producerMetadata.messageTimestamp);
 
     statusReportAdapter.reportStarted(partitionConsumptionState);
-    Optional<StoreVersionState> storeVersionState = storageMetadataService.getStoreVersionState(kafkaVersionTopic);
-    if (!storeVersionState.isPresent()) {
-      // No other partition of the same topic has started yet, let's initialize the StoreVersionState
-      StoreVersionState newStoreVersionState = new StoreVersionState();
-      newStoreVersionState.sorted = startOfPush.sorted;
-      newStoreVersionState.chunked = startOfPush.chunked;
-      newStoreVersionState.compressionStrategy = startOfPush.compressionStrategy;
-      newStoreVersionState.compressionDictionary = startOfPush.compressionDictionary;
-      newStoreVersionState.batchConflictResolutionPolicy = startOfPush.timestampPolicy;
-      newStoreVersionState.startOfPushTimestamp = startOfPushKME.producerMetadata.messageTimestamp;
+    storageMetadataService.computeStoreVersionState(kafkaVersionTopic, previousStoreVersionState -> {
+      if (previousStoreVersionState == null) {
+        // No other partition of the same topic has started yet, let's initialize the StoreVersionState
+        StoreVersionState newStoreVersionState = new StoreVersionState();
+        newStoreVersionState.sorted = startOfPush.sorted;
+        newStoreVersionState.chunked = startOfPush.chunked;
+        newStoreVersionState.compressionStrategy = startOfPush.compressionStrategy;
+        newStoreVersionState.compressionDictionary = startOfPush.compressionDictionary;
+        newStoreVersionState.batchConflictResolutionPolicy = startOfPush.timestampPolicy;
+        newStoreVersionState.startOfPushTimestamp = startOfPushKME.producerMetadata.messageTimestamp;
 
-      storageMetadataService.put(kafkaVersionTopic, newStoreVersionState);
-      LOGGER.info(
-          "Persisted {} for the first time following a SOP for topic {}.",
-          StoreVersionState.class.getSimpleName(),
-          kafkaVersionTopic);
-    } else if (storeVersionState.get().sorted != startOfPush.sorted) {
-      // Something very wrong is going on ): ...
-      throw new VeniceException(
-          "Unexpected: received multiple " + ControlMessageType.START_OF_PUSH.name()
-              + " control messages with inconsistent 'sorted' fields within the same topic!");
-    } else if (storeVersionState.get().chunked != startOfPush.chunked) {
-      // Something very wrong is going on ): ...
-      throw new VeniceException(
-          "Unexpected: received multiple " + ControlMessageType.START_OF_PUSH.name()
-              + " control messages with inconsistent 'chunked' fields within the same topic!");
-    } // else, no need to persist it once more.
+        LOGGER.info(
+            "Persisted {} for the first time following a SOP for topic {}.",
+            StoreVersionState.class.getSimpleName(),
+            kafkaVersionTopic);
+        return newStoreVersionState;
+      } else if (previousStoreVersionState.sorted != startOfPush.sorted) {
+        // Something very wrong is going on ): ...
+        throw new VeniceException(
+            "Unexpected: received multiple " + ControlMessageType.START_OF_PUSH.name()
+                + " control messages with inconsistent 'sorted' fields within the same topic!");
+      } else if (previousStoreVersionState.chunked != startOfPush.chunked) {
+        // Something very wrong is going on ): ...
+        throw new VeniceException(
+            "Unexpected: received multiple " + ControlMessageType.START_OF_PUSH.name()
+                + " control messages with inconsistent 'chunked' fields within the same topic!");
+      } else {
+        // No need to mutate it, so we return it as is
+        return previousStoreVersionState;
+      }
+    });
   }
 
   protected void processEndOfPush(
@@ -2562,7 +2596,10 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
     }
     switch (type) {
       case START_OF_PUSH:
-        processStartOfPush(kafkaMessageEnvelope, controlMessage, partition, partitionConsumptionState);
+        /**
+         * N.B.: The processing for SOP happens at the very beginning of the pipeline, in:
+         * {@link #produceToStoreBufferServiceOrKafka(Iterable, boolean, TopicPartition, String, int)}
+         */
         break;
       case END_OF_PUSH:
         processEndOfPush(kafkaMessageEnvelope, controlMessage, partition, offset, partitionConsumptionState);
@@ -3113,18 +3150,12 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
         Put put = (Put) kafkaValue.payloadUnion;
         waitReadyToProcessDataRecord(put.schemaId);
         try {
-          deserializeValue(put.schemaId, put.putValue);
+          deserializeValue(put.schemaId, put.putValue, record);
         } catch (Exception e) {
-          byte[] valueBytes = ByteUtils.extractByteArray(put.putValue);
-          LOGGER.error(
-              "Encounter the error while deserializing PUT message. topic: {}, partition: {}"
-                  + " offset: {}, schema id: {}, value bytes: {}",
-              record.topic(),
-              record.partition(),
-              record.offset(),
-              put.schemaId,
-              Hex.encodeHexString(valueBytes));
-          throw e;
+          throw new VeniceException(
+              "Failed to deserialize PUT for topic: " + record.topic() + ", partition: " + record.partition()
+                  + ", offset: " + record.offset() + ", schema id: " + put.schemaId,
+              e);
         }
         break;
       case UPDATE:
@@ -3169,18 +3200,20 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
   }
 
   protected StoreVersionState waitVersionStateAvailable(String kafkaTopic) throws InterruptedException {
-    long startTime = System.nanoTime();
+    long startTime = System.currentTimeMillis();
+    long elapsedTime;
+    StoreVersionState state;
     for (;;) {
-      Optional<StoreVersionState> state = storageMetadataService.getStoreVersionState(this.kafkaVersionTopic);
-      long elapsedTime = System.nanoTime() - startTime;
+      state = storageEngine.getStoreVersionState();
+      elapsedTime = System.currentTimeMillis() - startTime;
 
-      if (state.isPresent()) {
-        LOGGER.info("Version state is available for {} after {}", kafkaTopic, NANOSECONDS.toSeconds(elapsedTime));
-        return state.get();
+      if (state != null) {
+        LOGGER.info("Version state is available for {} after {} ms", kafkaTopic, elapsedTime);
+        return state;
       }
 
-      if (NANOSECONDS.toMillis(elapsedTime) > SCHEMA_POLLING_TIMEOUT_MS || !isRunning()) {
-        LOGGER.warn("Version state is not available for {} after {}", kafkaTopic, NANOSECONDS.toSeconds(elapsedTime));
+      if (elapsedTime > SCHEMA_POLLING_TIMEOUT_MS || !isRunning()) {
+        LOGGER.warn("Version state is not available for {} after {}", kafkaTopic, elapsedTime);
         throw new VeniceException("Store version state is not available for " + kafkaTopic);
       }
 
@@ -3190,11 +3223,13 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
 
   private void waitUntilValueSchemaAvailable(int schemaId) throws InterruptedException {
     // Considering value schema is immutable for an existing store, we can cache it locally
-    if (availableSchemaIds.contains(schemaId)) {
+    if (availableSchemaIds.get(schemaId) != null) {
       return;
     }
 
-    long startTime = System.nanoTime();
+    long startTime = System.currentTimeMillis();
+    long elapsedTime;
+    boolean schemaExists;
     for (;;) {
       // Since schema registration topic might be slower than data topic,
       // the consumer will be pending until the new schema arrives.
@@ -3204,15 +3239,11 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
       // such as throwing error after certain amount of time;
       // Or we might want to propagate our state to the Controller via the VeniceNotifier,
       // if we're stuck polling more than a certain threshold of time?
-      boolean schemaExists = schemaRepository.hasValueSchema(storeName, schemaId);
-      long elapsedTime = System.nanoTime() - startTime;
+      schemaExists = schemaRepository.hasValueSchema(storeName, schemaId);
+      elapsedTime = System.currentTimeMillis() - startTime;
       if (schemaExists) {
-        LOGGER.info(
-            "Found new value schema [{}] for {} after {}",
-            schemaId,
-            storeName,
-            NANOSECONDS.toSeconds(elapsedTime));
-        availableSchemaIds.add(schemaId);
+        LOGGER.info("Found new value schema [{}] for {} after {} ms", schemaId, storeName, elapsedTime);
+        availableSchemaIds.set(schemaId, new Object());
         // TODO: Query metastore for existence of value schema id before doing an update. During bounce of large
         // cluster these metastore writes could be spiky
         if (metaStoreWriter != null && !VeniceSystemStoreType.META_STORE.isSystemStore(storeName)) {
@@ -3225,12 +3256,8 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
         return;
       }
 
-      if (NANOSECONDS.toMillis(elapsedTime) > SCHEMA_POLLING_TIMEOUT_MS || !isRunning()) {
-        LOGGER.warn(
-            "Value schema [{}] is not available for {} after {}",
-            schemaId,
-            storeName,
-            NANOSECONDS.toSeconds(elapsedTime));
+      if (elapsedTime > SCHEMA_POLLING_TIMEOUT_MS || !isRunning()) {
+        LOGGER.warn("Value schema [{}] is not available for {} after {} ms", schemaId, storeName, elapsedTime);
         throw new VeniceException("Value schema [" + schemaId + "] is not available for " + storeName);
       }
 
@@ -3240,27 +3267,30 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
 
   /**
    * Deserialize a value using the schema that serializes it. Exception will be thrown and ingestion will fail if the
-   * value cannot be deserialized. Currently the deserialization dry-run won't happen in the following cases:
+   * value cannot be deserialized. Currently, the deserialization dry-run won't happen in the following cases:
    *
    * 1. Value is chunked. A single piece of value cannot be deserialized. In this case, the schema id is not added in
    *    availableSchemaIds by {@link StoreIngestionTask#waitUntilValueSchemaAvailable}.
-   * 2. Value is compressed, which cannot be deserialized without decompression.
-   * 3. Ingestion isolation is enabled, in which ingestion happens on forked process instead of this main process.
+   * 2. Ingestion isolation is enabled, in which case ingestion happens on forked process instead of this main process.
    */
-  private void deserializeValue(int schemaId, ByteBuffer value) {
-    if (!availableSchemaIds.contains(schemaId) || deserializedSchemaIds.contains(schemaId)) {
+  private void deserializeValue(int schemaId, ByteBuffer value, ConsumerRecord<KafkaKey, KafkaMessageEnvelope> record)
+      throws IOException {
+    if (schemaId < 0 || deserializedSchemaIds.get(schemaId) != null || availableSchemaIds.get(schemaId) == null) {
       return;
     }
-    Optional<StoreVersionState> state = storageMetadataService.getStoreVersionState(this.kafkaVersionTopic);
-    if (!state.isPresent() || state.get().compressionStrategy != CompressionStrategy.NO_OP.getValue()) {
-      return;
+    if (!Version.isRealTimeTopic(record.topic())) {
+      value = compressor.get().decompress(value);
     }
     SchemaEntry valueSchema = schemaRepository.getValueSchema(storeName, schemaId);
     if (valueSchema != null) {
       Schema schema = valueSchema.getSchema();
       new AvroGenericDeserializer<>(schema, schema).deserialize(value);
-      LOGGER.info("Value deserialization succeeded with schema [{}] for {}", schemaId, storeName);
-      deserializedSchemaIds.add(schemaId);
+      LOGGER.info(
+          "Value deserialization succeeded with schema id {} for topic: {}, partition: {}",
+          schemaId,
+          record.topic(),
+          record.partition());
+      deserializedSchemaIds.set(schemaId, new Object());
     }
   }
 
@@ -3544,8 +3574,10 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
    * Invoked by admin request to dump store version state metadata.
    */
   public void dumpStoreVersionState(AdminResponse response) {
-    Optional<StoreVersionState> storeVersionState = storageMetadataService.getStoreVersionState(kafkaVersionTopic);
-    storeVersionState.ifPresent(response::addStoreVersionState);
+    StoreVersionState storeVersionState = storageEngine.getStoreVersionState();
+    if (storeVersionState != null) {
+      response.addStoreVersionState(storeVersionState);
+    }
   }
 
   public VeniceServerConfig getServerConfig() {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskFactory.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskFactory.java
@@ -49,7 +49,6 @@ public class StoreIngestionTaskFactory {
       VeniceStoreVersionConfig storeConfig,
       int partitionId,
       boolean isIsolatedIngestion,
-      StorageEngineBackedCompressorFactory compressorFactory,
       Optional<ObjectCacheBackend> cacheBackend) {
     if (version.isActiveActiveReplicationEnabled()) {
       return new ActiveActiveStoreIngestionTask(
@@ -61,8 +60,7 @@ public class StoreIngestionTaskFactory {
           storeConfig,
           partitionId,
           isIsolatedIngestion,
-          cacheBackend,
-          compressorFactory);
+          cacheBackend);
     } else if (version.isLeaderFollowerModelEnabled()) {
       return new LeaderFollowerStoreIngestionTask(
           builder,
@@ -73,8 +71,7 @@ public class StoreIngestionTaskFactory {
           storeConfig,
           partitionId,
           isIsolatedIngestion,
-          cacheBackend,
-          compressorFactory);
+          cacheBackend);
     } else {
       throw new VeniceException("State transition model not defined.");
     }
@@ -120,6 +117,7 @@ public class StoreIngestionTaskFactory {
     private boolean isDaVinciClient;
     private RemoteIngestionRepairService remoteIngestionRepairService;
     private MetaStoreWriter metaStoreWriter;
+    private StorageEngineBackedCompressorFactory compressorFactory;
 
     private interface Setter {
       void apply();
@@ -345,6 +343,14 @@ public class StoreIngestionTaskFactory {
 
     public Builder setIsDaVinciClient(boolean isDaVinciClient) {
       return set(() -> this.isDaVinciClient = isDaVinciClient);
+    }
+
+    public StorageEngineBackedCompressorFactory getCompressorFactory() {
+      return compressorFactory;
+    }
+
+    public Builder setCompressorFactory(StorageEngineBackedCompressorFactory compressorFactory) {
+      return set(() -> this.compressorFactory = compressorFactory);
     }
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/repository/VeniceMetadataRepositoryBuilder.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/repository/VeniceMetadataRepositoryBuilder.java
@@ -180,5 +180,7 @@ public class VeniceMetadataRepositoryBuilder {
 
     liveClusterConfigRepo = new HelixReadOnlyLiveClusterConfigRepository(zkClient, adapter, clusterName);
     liveClusterConfigRepo.refresh();
+
+    clusterInfoProvider = new StaticClusterInfoProvider(Collections.singleton(clusterName));
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/storage/MetadataRetriever.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/storage/MetadataRetriever.java
@@ -1,16 +1,11 @@
 package com.linkedin.davinci.storage;
 
 import com.linkedin.davinci.listener.response.AdminResponse;
-import com.linkedin.venice.compression.CompressionStrategy;
 import com.linkedin.venice.utils.ComplementSet;
 import java.nio.ByteBuffer;
 
 
 public interface MetadataRetriever {
-  boolean isStoreVersionChunked(String topicName);
-
-  CompressionStrategy getStoreVersionCompressionStrategy(String topicName);
-
   ByteBuffer getStoreVersionCompressionDictionary(String topicName);
 
   AdminResponse getConsumptionSnapshots(String topicName, ComplementSet<Integer> partitions);

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/storage/StorageEngineRepository.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/storage/StorageEngineRepository.java
@@ -12,8 +12,6 @@ import org.apache.logging.log4j.Logger;
 
 /**
  *  A wrapper class that holds all the server's storage engines.
- *
- *  TODO 1. Later need to add stats and monitoring
  */
 public class StorageEngineRepository {
   private static final Logger LOGGER = LogManager.getLogger(StorageEngineRepository.class);
@@ -22,13 +20,6 @@ public class StorageEngineRepository {
    *   Local storage engine for this node. This is lowest level persistence abstraction, these StorageEngines provide an iterator over their values.
    */
   private final ConcurrentMap<String, AbstractStorageEngine> localStorageEngines = new ConcurrentHashMap<>();
-
-  /*
-  Usual CRUD operations on map of Local Storage Engines
-   */
-  public boolean hasLocalStorageEngine(String name) {
-    return localStorageEngines.containsKey(name);
-  }
 
   public AbstractStorageEngine getLocalStorageEngine(String storeName) {
     return localStorageEngines.get(storeName);

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/storage/StorageMetadataService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/storage/StorageMetadataService.java
@@ -1,25 +1,18 @@
 package com.linkedin.davinci.storage;
 
-import com.linkedin.venice.compression.CompressionStrategy;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.kafka.protocol.state.StoreVersionState;
 import com.linkedin.venice.offsets.OffsetManager;
 import java.nio.ByteBuffer;
-import java.util.Optional;
+import java.util.function.Function;
 
 
 /**
- * This is a superset of the the OffsetManager APIs, which also provide functions
- * for storing store-version level state.
+ * This is a superset of the OffsetManager APIs, which also provide functions for storing store-version level state.
  */
 public interface StorageMetadataService extends OffsetManager {
-  /**
-   * Persist a new {@link StoreVersionState} for the given {@param topicName}.
-   *
-   * @param topicName for which to retrieve the current {@link StoreVersionState}.
-   * @param record the {@link StoreVersionState} to persist
-   */
-  void put(String topicName, StoreVersionState record) throws VeniceException;
+  void computeStoreVersionState(String topicName, Function<StoreVersionState, StoreVersionState> mapFunction)
+      throws VeniceException;
 
   /**
    * This will clear all metadata, including store-version state and partition states, tied to {@param topicName}.
@@ -32,33 +25,15 @@ public interface StorageMetadataService extends OffsetManager {
    * Gets the currently-persisted {@link StoreVersionState} for this topic.
    *
    * @param topicName  kafka topic to which the consumer thread is registered to.
-   * @return an instance of {@link StoreVersionState} corresponding to this topic.
+   * @return an instance of {@link StoreVersionState} corresponding to this topic, or null if there isn't any.
    */
-  Optional<StoreVersionState> getStoreVersionState(String topicName) throws VeniceException;
-
-  /**
-   * Tailored function for retrieving chunking setting. Specific implementations can optionally
-   * implement a more optimized version of this API, since it is expected to be used at greater
-   * frequency than the others.
-   */
-  default boolean isStoreVersionChunked(String topicName) {
-    return getStoreVersionState(topicName).map(storeVersionState -> storeVersionState.chunked).orElse(false);
-  }
-
-  /**
-   * Tailored function for retrieving version's compression strategy setting.
-   */
-  default CompressionStrategy getStoreVersionCompressionStrategy(String topicName) {
-    return getStoreVersionState(topicName)
-        .map(storeVersionState -> CompressionStrategy.valueOf(storeVersionState.compressionStrategy))
-        .orElse(CompressionStrategy.NO_OP);
-  }
+  StoreVersionState getStoreVersionState(String topicName) throws VeniceException;
 
   /**
    * Tailored function for retrieving version's compression dictionary.
    */
   default ByteBuffer getStoreVersionCompressionDictionary(String topicName) {
-    return getStoreVersionState(topicName).map(storeVersionState -> storeVersionState.compressionDictionary)
-        .orElse(null);
+    StoreVersionState svs = getStoreVersionState(topicName);
+    return svs == null ? null : svs.compressionDictionary;
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/storage/chunking/ChunkingAdapter.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/storage/chunking/ChunkingAdapter.java
@@ -1,6 +1,5 @@
 package com.linkedin.davinci.storage.chunking;
 
-import com.linkedin.davinci.compression.StorageEngineBackedCompressorFactory;
 import com.linkedin.davinci.listener.response.ReadResponse;
 import com.linkedin.venice.compression.CompressionStrategy;
 import com.linkedin.venice.compression.VeniceCompressor;
@@ -27,7 +26,7 @@ public interface ChunkingAdapter<CHUNKS_CONTAINER, VALUE> {
    * @param fullBytes includes both the schema ID header and the payload
    *
    * The following parameters can be ignored, by implementing {@link #constructValue(int, byte[])}:
-   *@param bytesLength
+   * @param bytesLength
    * @param reusedValue a previous instance of {@type VALUE} to be re-used in order to minimize GC
    * @param reusedDecoder a previous instance of {@link BinaryDecoder} to be re-used in order to minimize GC
    * @param response the response returned by the query path, which carries certain metrics to be recorded at the end
@@ -50,8 +49,7 @@ public interface ChunkingAdapter<CHUNKS_CONTAINER, VALUE> {
       boolean fastAvroEnabled,
       ReadOnlySchemaRepository schemaRepo,
       String storeName,
-      StorageEngineBackedCompressorFactory compressorFactory,
-      String versionTopic) {
+      VeniceCompressor compressor) {
     return constructValue(writerSchemaId, fullBytes);
   }
 
@@ -71,8 +69,7 @@ public interface ChunkingAdapter<CHUNKS_CONTAINER, VALUE> {
   /**
    * This function can be implemented by the adapters which need fewer parameters.
    *
-   * @see #constructValue(int, int, byte[], int, Object, BinaryDecoder, ReadResponse, CompressionStrategy, boolean,
-   * ReadOnlySchemaRepository, String, StorageEngineBackedCompressorFactory, String)
+   * @see #constructValue(int, int, byte[], int, Object, BinaryDecoder, ReadResponse, CompressionStrategy, boolean, ReadOnlySchemaRepository, String, VeniceCompressor)
    */
   default VALUE constructValue(int schemaId, byte[] fullBytes) {
     throw new VeniceException("Not implemented.");
@@ -120,15 +117,14 @@ public interface ChunkingAdapter<CHUNKS_CONTAINER, VALUE> {
       boolean fastAvroEnabled,
       ReadOnlySchemaRepository schemaRepo,
       String storeName,
-      StorageEngineBackedCompressorFactory compressorFactory,
-      String versionTopic) {
+      VeniceCompressor compressor) {
     return constructValue(schemaId, chunksContainer);
   }
 
   /**
    * This function can be implemented by the adapters which need fewer parameters.
    *
-   * @see #constructValue(int, Object, Object, BinaryDecoder, ReadResponse, CompressionStrategy, boolean, ReadOnlySchemaRepository, String, StorageEngineBackedCompressorFactory, String)
+   * @see #constructValue(int, Object, Object, BinaryDecoder, ReadResponse, CompressionStrategy, boolean, ReadOnlySchemaRepository, String, VeniceCompressor)
    */
   default VALUE constructValue(int schemaId, CHUNKS_CONTAINER chunksContainer) {
     throw new VeniceException("Not implemented.");

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionServiceTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionServiceTest.java
@@ -2,7 +2,9 @@ package com.linkedin.davinci.kafka.consumer;
 
 import static com.linkedin.venice.ConfigKeys.KAFKA_BOOTSTRAP_SERVERS;
 import static com.linkedin.venice.ConfigKeys.KAFKA_ZK_ADDRESS;
-import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionServiceTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionServiceTest.java
@@ -2,8 +2,7 @@ package com.linkedin.davinci.kafka.consumer;
 
 import static com.linkedin.venice.ConfigKeys.KAFKA_BOOTSTRAP_SERVERS;
 import static com.linkedin.venice.ConfigKeys.KAFKA_ZK_ADDRESS;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -70,6 +69,7 @@ public abstract class KafkaStoreIngestionServiceTest {
   @BeforeClass
   public void setUp() {
     mockStorageEngineRepository = mock(StorageEngineRepository.class);
+    doReturn(mock(AbstractStorageEngine.class)).when(mockStorageEngineRepository).getLocalStorageEngine(anyString());
     storageMetadataService = mock(StorageMetadataService.class);
     mockClusterInfoProvider = mock(ClusterInfoProvider.class);
     mockMetadataRepo = mock(ReadOnlyStoreRepository.class);
@@ -130,7 +130,6 @@ public abstract class KafkaStoreIngestionServiceTest {
         mockSchemaRepo,
         mockLiveClusterConfigRepo,
         new MetricsRepository(),
-        null,
         Optional.empty(),
         Optional.empty(),
         AvroProtocolDefinition.PARTITION_STATE.getSerializer(),
@@ -211,7 +210,6 @@ public abstract class KafkaStoreIngestionServiceTest {
         mockSchemaRepo,
         mockLiveClusterConfigRepo,
         new MetricsRepository(),
-        null,
         Optional.empty(),
         Optional.empty(),
         AvroProtocolDefinition.PARTITION_STATE.getSerializer(),
@@ -296,7 +294,6 @@ public abstract class KafkaStoreIngestionServiceTest {
         mockSchemaRepo,
         mockLiveClusterConfigRepo,
         new MetricsRepository(),
-        null,
         Optional.empty(),
         Optional.empty(),
         AvroProtocolDefinition.PARTITION_STATE.getSerializer(),

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/PushTimeoutTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/PushTimeoutTest.java
@@ -5,7 +5,6 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 
-import com.linkedin.davinci.compression.StorageEngineBackedCompressorFactory;
 import com.linkedin.davinci.config.VeniceServerConfig;
 import com.linkedin.davinci.config.VeniceStoreVersionConfig;
 import com.linkedin.davinci.notifier.VeniceNotifier;
@@ -71,8 +70,7 @@ public class PushTimeoutTest {
         mockVeniceStoreVersionConfig,
         0,
         false,
-        Optional.empty(),
-        mock(StorageEngineBackedCompressorFactory.class));
+        Optional.empty());
 
     leaderFollowerStoreIngestionTask.subscribePartition(versionTopic, 0, Optional.empty());
     leaderFollowerStoreIngestionTask.run();
@@ -143,8 +141,7 @@ public class PushTimeoutTest {
         mockVeniceStoreVersionConfig,
         0,
         false,
-        Optional.empty(),
-        mock(StorageEngineBackedCompressorFactory.class));
+        Optional.empty());
 
     leaderFollowerStoreIngestionTask.subscribePartition(versionTopic, 0, Optional.empty());
     /**

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
@@ -26,6 +26,7 @@ import static com.linkedin.venice.utils.TestUtils.waitForNonDeterministicAsserti
 import static com.linkedin.venice.utils.TestUtils.waitForNonDeterministicCompletion;
 import static com.linkedin.venice.utils.Time.MS_PER_DAY;
 import static com.linkedin.venice.utils.Time.MS_PER_HOUR;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.after;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyDouble;
@@ -119,6 +120,7 @@ import com.linkedin.venice.schema.rmd.RmdSchemaGenerator;
 import com.linkedin.venice.serialization.DefaultSerializer;
 import com.linkedin.venice.serialization.avro.AvroProtocolDefinition;
 import com.linkedin.venice.serialization.avro.InternalAvroSpecificSerializer;
+import com.linkedin.venice.serialization.avro.VeniceAvroKafkaSerializer;
 import com.linkedin.venice.serializer.FastSerializerDeserializerFactory;
 import com.linkedin.venice.serializer.RecordSerializer;
 import com.linkedin.venice.throttle.EventThrottler;
@@ -278,7 +280,7 @@ public abstract class StoreIngestionTaskTest {
   }
   private static final int PARTITION_FOO = 1;
   private static final int PARTITION_BAR = 2;
-  private static final int SCHEMA_ID = -1;
+  private static final int SCHEMA_ID = 1;
   private static final int EXISTING_SCHEMA_ID = 1;
   private static final int NON_EXISTING_SCHEMA_ID = 2;
   private static final Schema STRING_SCHEMA = Schema.parse("\"string\"");
@@ -286,7 +288,7 @@ public abstract class StoreIngestionTaskTest {
   private static final byte[] putKeyFoo = getRandomKey(PARTITION_FOO);
   private static final byte[] putKeyFoo2 = getRandomKey(PARTITION_FOO);
   private static final byte[] putKeyBar = getRandomKey(PARTITION_BAR);
-  private static final byte[] putValue = "TestValuePut".getBytes(StandardCharsets.UTF_8);
+  private static final byte[] putValue = new VeniceAvroKafkaSerializer(STRING_SCHEMA).serialize(null, "TestValuePut");
   private static final byte[] putValueToCorrupt = "Please corrupt me!".getBytes(StandardCharsets.UTF_8);
   private static final byte[] deleteKeyFoo = getRandomKey(PARTITION_FOO);
 
@@ -311,7 +313,7 @@ public abstract class StoreIngestionTaskTest {
   private KafkaConsumerServiceStats kafkaConsumerServiceStats = mock(KafkaConsumerServiceStats.class);
   private KafkaClientFactory mockFactory = mock(KafkaClientFactory.class);
 
-  private Supplier<Optional<StoreVersionState>> storeVersionStateSupplier = (Optional::empty);
+  private Supplier<StoreVersionState> storeVersionStateSupplier = () -> new StoreVersionState();
 
   private static byte[] getRandomKey(Integer partition) {
     String randomString = Utils.getUniqueString("KeyForPartition" + partition);
@@ -403,7 +405,6 @@ public abstract class StoreIngestionTaskTest {
     mockPartitionStatusNotifier = mock(PartitionPushStatusNotifier.class);
     mockLeaderFollowerStateModelNotifier = mock(LeaderFollowerIngestionProgressNotifier.class);
 
-    mockAbstractStorageEngine = mock(AbstractStorageEngine.class);
     mockStorageMetadataService = mock(StorageMetadataService.class);
 
     mockBandwidthThrottler = mock(EventThrottler.class);
@@ -428,6 +429,7 @@ public abstract class StoreIngestionTaskTest {
 
     isCurrentVersion = () -> false;
     hybridStoreConfig = Optional.empty();
+
     databaseChecksumVerificationEnabled = false;
     rocksDBServerConfig = mock(RocksDBServerConfig.class);
 
@@ -438,7 +440,7 @@ public abstract class StoreIngestionTaskTest {
         .when(mockSchemaRepo)
         .getReplicationMetadataSchema(storeNameWithoutVersionInfo, EXISTING_SCHEMA_ID, REPLICATION_METADATA_VERSION_ID);
 
-    storeVersionStateSupplier = getStoreVersionStateSupplierDefault();
+    setDefaultStoreVersionStateSupplier();
   }
 
   private VeniceWriter getVeniceWriter(
@@ -577,7 +579,6 @@ public abstract class StoreIngestionTaskTest {
     StoreIngestionTaskFactory ingestionTaskFactory = getIngestionTaskFactoryBuilder(
         pollStrategy,
         partitions,
-        hybridStoreConfig,
         diskUsageForTest,
         amplificationFactor,
         extraServerProperties,
@@ -587,8 +588,6 @@ public abstract class StoreIngestionTaskTest {
     kafkaProps.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, inMemoryLocalKafkaBroker.getKafkaBootstrapServer());
 
     int leaderSubPartition = PartitionUtils.getLeaderSubPartition(PARTITION_FOO, amplificationFactor);
-    doReturn(new DeepCopyStorageEngine(mockAbstractStorageEngine)).when(mockStorageEngineRepository)
-        .getLocalStorageEngine(topic);
     storeIngestionTaskUnderTest = ingestionTaskFactory.getNewIngestionTask(
         mockStore,
         version,
@@ -597,7 +596,6 @@ public abstract class StoreIngestionTaskTest {
         storeConfig,
         leaderSubPartition,
         false,
-        new StorageEngineBackedCompressorFactory(mockStorageMetadataService),
         Optional.empty());
 
     Future testSubscribeTaskFuture = null;
@@ -692,11 +690,12 @@ public abstract class StoreIngestionTaskTest {
   private StoreIngestionTaskFactory.Builder getIngestionTaskFactoryBuilder(
       PollStrategy pollStrategy,
       Set<Integer> partitions,
-      Optional<HybridStoreConfig> hybridStoreConfig,
       Optional<DiskUsage> diskUsageForTest,
       int amplificationFactor,
       Map<String, Object> extraServerProperties,
       Boolean isLiveConfigEnabled) {
+    doReturn(new DeepCopyStorageEngine(mockAbstractStorageEngine)).when(mockStorageEngineRepository)
+        .getLocalStorageEngine(topic);
 
     inMemoryLocalKafkaConsumer =
         new MockInMemoryConsumer(inMemoryLocalKafkaBroker, pollStrategy, mockLocalKafkaConsumer);
@@ -722,11 +721,6 @@ public abstract class StoreIngestionTaskTest {
       for (int partition: PartitionUtils.getSubPartitions(partitions, amplificationFactor)) {
         doReturn(new OffsetRecord(partitionStateSerializer)).when(mockStorageMetadataService)
             .getLastOffset(topic, partition);
-        if (hybridStoreConfig.isPresent()) {
-          doReturn(Optional.of(new StoreVersionState())).when(mockStorageMetadataService).getStoreVersionState(topic);
-        } else {
-          doReturn(storeVersionStateSupplier.get()).when(mockStorageMetadataService).getStoreVersionState(topic);
-        }
       }
     }
     offsetManager = new DeepCopyStorageMetadataService(mockStorageMetadataService);
@@ -813,6 +807,7 @@ public abstract class StoreIngestionTaskTest {
         .setDiskUsage(diskUsage)
         .setAggKafkaConsumerService(aggKafkaConsumerService)
         .setCacheWarmingThreadPool(Executors.newFixedThreadPool(1))
+        .setCompressorFactory(new StorageEngineBackedCompressorFactory(mockStorageMetadataService))
         .setPartitionStateSerializer(partitionStateSerializer);
   }
 
@@ -936,15 +931,27 @@ public abstract class StoreIngestionTaskTest {
     }).when(aggKafkaConsumerService).resumeConsumerFor(anyString(), anyString(), anyInt());
   }
 
-  Supplier<Optional<StoreVersionState>> getStoreVersionStateSupplierDefault() {
-    StoreVersionState storeVersionState = new StoreVersionState();
-    return (() -> Optional.of(storeVersionState));
+  void setDefaultStoreVersionStateSupplier() {
+    setStoreVersionStateSupplier(new StoreVersionState());
   }
 
-  Supplier<Optional<StoreVersionState>> getStoreVersionStateSupplier(boolean sorted) {
+  void setStoreVersionStateSupplier(StoreVersionState svs) {
+    storeVersionStateSupplier = () -> svs;
+    AbstractStoragePartition metadataPartition = mock(AbstractStoragePartition.class);
+    InternalAvroSpecificSerializer<StoreVersionState> storeVersionStateSerializer =
+        AvroProtocolDefinition.STORE_VERSION_STATE.getSerializer();
+    doReturn(storeVersionStateSerializer.serialize(null, svs)).when(metadataPartition)
+        .get(any(byte[].class), anyBoolean());
+    mockAbstractStorageEngine = mock(AbstractStorageEngine.class);
+    doReturn(metadataPartition).when(mockAbstractStorageEngine).createStoragePartition(any());
+    doReturn(svs).when(mockAbstractStorageEngine).getStoreVersionState();
+    doReturn(svs).when(mockStorageMetadataService).getStoreVersionState(topic);
+  }
+
+  void setStoreVersionStateSupplier(boolean sorted) {
     StoreVersionState storeVersionState = new StoreVersionState();
     storeVersionState.sorted = sorted;
-    return (() -> Optional.of(storeVersionState));
+    setStoreVersionStateSupplier(storeVersionState);
   }
 
   private Pair<TopicPartition, Long> getTopicPartitionOffsetPair(RecordMetadata recordMetadata) {
@@ -1032,7 +1039,7 @@ public abstract class StoreIngestionTaskTest {
       vtWriter.broadcastStartOfPush(new HashMap<>());
       vtWriter.broadcastEndOfPush(new HashMap<>());
       doReturn(vtWriter).when(mockWriterFactory)
-          .createBasicVeniceWriter(anyString(), any(Optional.class), any(VenicePartitioner.class), anyInt());
+          .createBasicVeniceWriter(anyString(), anyBoolean(), any(VenicePartitioner.class), anyInt());
       verify(mockLogNotifier, never()).completed(anyString(), anyInt(), anyLong());
       vtWriter.broadcastTopicSwitch(
           Collections.singletonList(inMemoryLocalKafkaBroker.getKafkaBootstrapServer()),
@@ -1238,18 +1245,6 @@ public abstract class StoreIngestionTaskTest {
           .completed(topic, PARTITION_FOO, fooLastOffset + 1);
       verify(mockLeaderFollowerStateModelNotifier, timeout(TEST_TIMEOUT_MS).atLeastOnce())
           .completed(topic, PARTITION_BAR, barLastOffset + 1);
-
-      /**
-       * It seems Mockito will mess up the verification if there are two functions with the same name:
-       * {@link StorageMetadataService#put(String, StoreVersionState)}
-       * {@link StorageMetadataService#put(String, int, OffsetRecord)}
-       *
-       * So if the first function gets invoked, Mockito will try to match the second function this test wanted,
-       * which is specified by the following statements, which will cause 'argument mismatch error'.
-       * For now, to bypass this issue, this test will try to wait the async consumption to be done before
-       * any {@link StorageMetadataService#put} function verification by verifying {@link VeniceNotifier#completed(String, int, long)}
-       * first.
-       */
       verify(mockStorageMetadataService)
           .put(eq(topic), eq(PARTITION_FOO), eq(getOffsetRecord(fooLastOffset + 1, true)));
       verify(mockStorageMetadataService)
@@ -1826,7 +1821,7 @@ public abstract class StoreIngestionTaskTest {
     final int totalNumberOfMessages = 1000;
     final int totalNumberOfConsumptionRestarts = 10;
 
-    storeVersionStateSupplier = getStoreVersionStateSupplier(sortedInput);
+    setStoreVersionStateSupplier(sortedInput);
     localVeniceWriter.broadcastStartOfPush(sortedInput, new HashMap<>());
     for (int i = 0; i < totalNumberOfMessages; i++) {
       byte[] key = getNumberedKey(i);
@@ -1926,8 +1921,8 @@ public abstract class StoreIngestionTaskTest {
        * never be updated
        */
       relevantPartitions.stream().forEach(partition -> {
-        Assert.assertTrue(storeIngestionTaskUnderTest.getPartitionConsumptionState(partition).isPresent());
-        PartitionConsumptionState pcs = storeIngestionTaskUnderTest.getPartitionConsumptionState(partition).get();
+        Assert.assertNotNull(storeIngestionTaskUnderTest.getPartitionConsumptionState(partition));
+        PartitionConsumptionState pcs = storeIngestionTaskUnderTest.getPartitionConsumptionState(partition);
         Assert.assertTrue(pcs.getLatestProcessedUpstreamRTOffsetMap().isEmpty());
       });
     }, isActiveActiveReplicationEnabled);
@@ -2004,7 +1999,7 @@ public abstract class StoreIngestionTaskTest {
 
   @Test(dataProvider = "True-and-False", dataProviderClass = DataProviderUtils.class)
   public void testVeniceMessagesProcessingWithSortedInput(boolean isActiveActiveReplicationEnabled) throws Exception {
-    storeVersionStateSupplier = getStoreVersionStateSupplier(true);
+    setStoreVersionStateSupplier(true);
     localVeniceWriter.broadcastStartOfPush(true, new HashMap<>());
     RecordMetadata putMetadata = (RecordMetadata) localVeniceWriter.put(putKeyFoo, putValue, EXISTING_SCHEMA_ID).get();
     RecordMetadata deleteMetadata = (RecordMetadata) localVeniceWriter.delete(deleteKeyFoo, null).get();
@@ -2039,7 +2034,7 @@ public abstract class StoreIngestionTaskTest {
       throws Exception {
     databaseChecksumVerificationEnabled = true;
     doReturn(false).when(rocksDBServerConfig).isRocksDBPlainTableFormatEnabled();
-    storeVersionStateSupplier = getStoreVersionStateSupplier(true);
+    setStoreVersionStateSupplier(true);
     localVeniceWriter.broadcastStartOfPush(true, new HashMap<>());
     RecordMetadata putMetadata = (RecordMetadata) localVeniceWriter.put(putKeyFoo, putValue, SCHEMA_ID).get();
     // intentionally not sending the EOP so that expectedSSTFileChecksum calculation does not get reset.
@@ -2164,7 +2159,7 @@ public abstract class StoreIngestionTaskTest {
 
   @Test(dataProvider = "True-and-False", dataProviderClass = DataProviderUtils.class)
   public void testIncrementalPush(boolean isActiveActiveReplicationEnabled) throws Exception {
-    storeVersionStateSupplier = getStoreVersionStateSupplier(true);
+    setStoreVersionStateSupplier(true);
     localVeniceWriter.broadcastStartOfPush(true, new HashMap<>());
     long fooOffset = getOffset(localVeniceWriter.put(putKeyFoo, putValue, SCHEMA_ID));
     localVeniceWriter.broadcastEndOfPush(new HashMap<>());
@@ -2199,7 +2194,7 @@ public abstract class StoreIngestionTaskTest {
 
   @Test(dataProvider = "True-and-False", dataProviderClass = DataProviderUtils.class)
   public void testCacheWarming(boolean isActiveActiveReplicationEnabled) throws Exception {
-    storeVersionStateSupplier = getStoreVersionStateSupplier(true);
+    setStoreVersionStateSupplier(true);
     localVeniceWriter.broadcastStartOfPush(true, new HashMap<>());
     long fooOffset = getOffset(localVeniceWriter.put(putKeyFoo, putValue, SCHEMA_ID));
     localVeniceWriter.broadcastEndOfPush(new HashMap<>());
@@ -2239,7 +2234,7 @@ public abstract class StoreIngestionTaskTest {
 
   @Test(dataProvider = "True-and-False", dataProviderClass = DataProviderUtils.class)
   public void testSchemaCacheWarming(boolean isActiveActiveReplicationEnabled) throws Exception {
-    storeVersionStateSupplier = getStoreVersionStateSupplier(true);
+    setStoreVersionStateSupplier(true);
     localVeniceWriter.broadcastStartOfPush(true, new HashMap<>());
     long fooOffset = getOffset(localVeniceWriter.put(putKeyFoo, putValue, SCHEMA_ID));
     localVeniceWriter.broadcastEndOfPush(new HashMap<>());
@@ -2470,7 +2465,6 @@ public abstract class StoreIngestionTaskTest {
     StoreIngestionTaskFactory ingestionTaskFactory = getIngestionTaskFactoryBuilder(
         new RandomPollStrategy(),
         Utils.setOf(PARTITION_FOO),
-        Optional.of(hybridStoreConfig),
         Optional.empty(),
         1,
         extraServerProperties,
@@ -2488,7 +2482,6 @@ public abstract class StoreIngestionTaskTest {
         storeConfig,
         leaderSubPartition,
         false,
-        new StorageEngineBackedCompressorFactory(mockStorageMetadataService),
         Optional.empty());
 
     AtomicLong remoteKafkaQuota = new AtomicLong(10);
@@ -2603,7 +2596,6 @@ public abstract class StoreIngestionTaskTest {
     StoreIngestionTaskFactory ingestionTaskFactory = getIngestionTaskFactoryBuilder(
         new RandomPollStrategy(),
         Utils.setOf(PARTITION_FOO),
-        Optional.of(hybridStoreConfig),
         Optional.empty(),
         1,
         extraServerProperties,
@@ -2634,7 +2626,6 @@ public abstract class StoreIngestionTaskTest {
         storeConfig,
         leaderSubPartition,
         false,
-        new StorageEngineBackedCompressorFactory(mockStorageMetadataService),
         Optional.empty());
 
     String rtTopic = Version.composeRealTimeTopic(mockStore.getName());
@@ -2769,7 +2760,6 @@ public abstract class StoreIngestionTaskTest {
     StoreIngestionTaskFactory ingestionTaskFactory = getIngestionTaskFactoryBuilder(
         new RandomPollStrategy(),
         Utils.setOf(PARTITION_FOO),
-        Optional.of(hybridStoreConfig),
         Optional.empty(),
         1,
         new HashMap<>(),
@@ -2797,7 +2787,6 @@ public abstract class StoreIngestionTaskTest {
         storeConfig,
         leaderSubPartition,
         false,
-        new StorageEngineBackedCompressorFactory(mockStorageMetadataService),
         Optional.empty());
 
     String rtTopic = Version.composeRealTimeTopic(mockStore.getName());
@@ -2847,10 +2836,11 @@ public abstract class StoreIngestionTaskTest {
     Store mockStore = storeAndVersionConfigs.store;
     Version version = storeAndVersionConfigs.version;
     VeniceStoreVersionConfig storeConfig = storeAndVersionConfigs.storeVersionConfig;
+    doReturn(new DeepCopyStorageEngine(mockAbstractStorageEngine)).when(mockStorageEngineRepository)
+        .getLocalStorageEngine(topic);
     StoreIngestionTaskFactory ingestionTaskFactory = getIngestionTaskFactoryBuilder(
         new RandomPollStrategy(),
         Utils.setOf(PARTITION_FOO),
-        Optional.of(hybridStoreConfig),
         Optional.empty(),
         amplificationFactor,
         new HashMap<>(),
@@ -2869,7 +2859,6 @@ public abstract class StoreIngestionTaskTest {
         storeConfig,
         leaderSubPartition,
         false,
-        new StorageEngineBackedCompressorFactory(mockStorageMetadataService),
         Optional.empty());
 
     TopicManager mockTopicManagerRemoteKafka = mock(TopicManager.class);
@@ -2939,8 +2928,7 @@ public abstract class StoreIngestionTaskTest {
         mockVeniceStoreVersionConfig,
         0,
         false,
-        Optional.empty(),
-        mock(StorageEngineBackedCompressorFactory.class));
+        Optional.empty());
 
     TopicSwitch topicSwitch = new TopicSwitch();
     topicSwitch.sourceKafkaServers = Collections.singletonList("localhost");
@@ -2975,7 +2963,10 @@ public abstract class StoreIngestionTaskTest {
   @Test
   public void testLeaderShouldSubscribeToCorrectVTOffset() {
     StoreIngestionTaskFactory.Builder builder = mock(StoreIngestionTaskFactory.Builder.class);
-    doReturn(mock(StorageEngineRepository.class)).when(builder).getStorageEngineRepository();
+    StorageEngineRepository mockStorageEngineRepository = mock(StorageEngineRepository.class);
+    doReturn(new DeepCopyStorageEngine(mockAbstractStorageEngine)).when(mockStorageEngineRepository)
+        .getLocalStorageEngine(anyString());
+    doReturn(mockStorageEngineRepository).when(builder).getStorageEngineRepository();
     VeniceServerConfig veniceServerConfig = mock(VeniceServerConfig.class);
     doReturn(new VeniceProperties()).when(veniceServerConfig).getKafkaConsumerConfigsForLocalConsumption();
     doReturn(new VeniceProperties()).when(veniceServerConfig).getKafkaConsumerConfigsForRemoteConsumption();
@@ -3008,8 +2999,7 @@ public abstract class StoreIngestionTaskTest {
             storeConfig,
             -1,
             false,
-            Optional.empty(),
-            mock(StorageEngineBackedCompressorFactory.class)));
+            Optional.empty()));
 
     OffsetRecord offsetRecord = mock(OffsetRecord.class);
     doReturn("testStore_v1").when(offsetRecord).getLeaderTopic();

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
@@ -26,7 +26,7 @@ import static com.linkedin.venice.utils.TestUtils.waitForNonDeterministicAsserti
 import static com.linkedin.venice.utils.TestUtils.waitForNonDeterministicCompletion;
 import static com.linkedin.venice.utils.Time.MS_PER_DAY;
 import static com.linkedin.venice.utils.Time.MS_PER_HOUR;
-import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.after;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyDouble;

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/storage/chunking/ChunkingTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/storage/chunking/ChunkingTest.java
@@ -10,10 +10,10 @@ import com.linkedin.davinci.storage.StorageMetadataService;
 import com.linkedin.davinci.store.AbstractStorageEngine;
 import com.linkedin.davinci.store.record.ValueRecord;
 import com.linkedin.venice.compression.CompressionStrategy;
+import com.linkedin.venice.compression.VeniceCompressor;
 import com.linkedin.venice.helix.HelixReadOnlySchemaRepository;
 import com.linkedin.venice.schema.SchemaEntry;
 import com.linkedin.venice.serialization.avro.AvroProtocolDefinition;
-import com.linkedin.venice.serializer.RecordDeserializer;
 import com.linkedin.venice.serializer.SerializerDeserializerFactory;
 import com.linkedin.venice.storage.protocol.ChunkedValueManifest;
 import com.linkedin.venice.utils.ByteUtils;
@@ -209,10 +209,10 @@ public class ChunkingTest {
     doReturn(chunk1Bytes).when(storageEngine).get(eq(partition), eq(firstKey), anyBoolean());
     doReturn(chunk2Bytes).when(storageEngine).get(eq(partition), eq(secondKey), anyBoolean());
 
-    RecordDeserializer deserializer = chunkingAdapter.getDeserializer(storeName, 1, schemaRepository, true);
-
     try (StorageEngineBackedCompressorFactory compressorFactory =
         new StorageEngineBackedCompressorFactory(mock(StorageMetadataService.class))) {
+      VeniceCompressor compressor =
+          compressorFactory.getCompressor(CompressionStrategy.NO_OP, storageEngine.getStoreName());
       assertions.apply(
           chunkingAdapter.get(
               storageEngine,
@@ -226,7 +226,7 @@ public class ChunkingTest {
               true,
               schemaRepository,
               storeName,
-              compressorFactory,
+              compressor,
               false));
     }
   }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/store/memory/InMemoryStorageEngineTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/store/memory/InMemoryStorageEngineTest.java
@@ -51,7 +51,7 @@ public class InMemoryStorageEngineTest extends AbstractStorageEngineTest {
         mock(ReadOnlyStoreRepository.class));
     storeConfig = new VeniceStoreVersionConfig(STORE_NAME, serverProperties);
 
-    testStoreEngine = service.openStoreForNewPartition(storeConfig, PARTITION_ID);
+    testStoreEngine = service.openStoreForNewPartition(storeConfig, PARTITION_ID, () -> null);
     createStoreForTest();
   }
 

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/store/rocksdb/ReplicationMeadataRocksDBStoragePartitionCFTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/store/rocksdb/ReplicationMeadataRocksDBStoragePartitionCFTest.java
@@ -60,7 +60,7 @@ public class ReplicationMeadataRocksDBStoragePartitionCFTest extends Replication
         AvroProtocolDefinition.PARTITION_STATE.getSerializer(),
         mockReadOnlyStoreRepository);
     storeConfig = new VeniceStoreVersionConfig(topicName, serverProps, PersistenceType.ROCKS_DB);
-    testStoreEngine = storageService.openStoreForNewPartition(storeConfig, PARTITION_ID);
+    testStoreEngine = storageService.openStoreForNewPartition(storeConfig, PARTITION_ID, () -> null);
     createStoreForTest();
     String stringSchema = "\"string\"";
     Schema aaSchema = RmdSchemaGenerator.generateMetadataSchema(stringSchema, 1);

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/store/rocksdb/ReplicationMetadataRocksDBStoragePartitionTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/store/rocksdb/ReplicationMetadataRocksDBStoragePartitionTest.java
@@ -124,7 +124,7 @@ public class ReplicationMetadataRocksDBStoragePartitionTest extends AbstractStor
         AvroProtocolDefinition.PARTITION_STATE.getSerializer(),
         mockReadOnlyStoreRepository);
     storeConfig = new VeniceStoreVersionConfig(topicName, serverProps, PersistenceType.ROCKS_DB);
-    testStoreEngine = storageService.openStoreForNewPartition(storeConfig, PARTITION_ID);
+    testStoreEngine = storageService.openStoreForNewPartition(storeConfig, PARTITION_ID, () -> null);
     createStoreForTest();
     String stringSchema = "\"string\"";
     Schema aaSchema = RmdSchemaGenerator.generateMetadataSchema(stringSchema, 1);

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/store/rocksdb/RocksDBStorageEngineTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/store/rocksdb/RocksDBStorageEngineTest.java
@@ -52,7 +52,7 @@ public class RocksDBStorageEngineTest extends AbstractStorageEngineTest {
         AvroProtocolDefinition.PARTITION_STATE.getSerializer(),
         mockReadOnlyStoreRepository);
     storeConfig = new VeniceStoreVersionConfig(topicName, serverProps, PersistenceType.ROCKS_DB);
-    testStoreEngine = storageService.openStoreForNewPartition(storeConfig, PARTITION_ID);
+    testStoreEngine = storageService.openStoreForNewPartition(storeConfig, PARTITION_ID, () -> null);
     createStoreForTest();
   }
 
@@ -116,11 +116,11 @@ public class RocksDBStorageEngineTest extends AbstractStorageEngineTest {
     storeVersionStateRecord.sorted = true;
 
     rocksDBStorageEngine.putStoreVersionState(storeVersionStateRecord);
-    Assert.assertEquals(rocksDBStorageEngine.getStoreVersionState().get(), storeVersionStateRecord);
+    Assert.assertEquals(rocksDBStorageEngine.getStoreVersionState(), storeVersionStateRecord);
 
-    // If no store version state is present in this metadata partition, Optional.empty() should be returned.
+    // If no store version state is present in this metadata partition, null should be returned.
     rocksDBStorageEngine.clearStoreVersionState();
-    Assert.assertEquals(rocksDBStorageEngine.getStoreVersionState(), Optional.empty());
+    Assert.assertNull(rocksDBStorageEngine.getStoreVersionState());
   }
 
   @Test

--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/meta/DaVinciClientBasedMetadata.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/meta/DaVinciClientBasedMetadata.java
@@ -424,7 +424,8 @@ public class DaVinciClientBasedMetadata extends AbstractStoreMetadata {
   public VeniceCompressor getCompressor(CompressionStrategy compressionStrategy, int version) {
     if (compressionStrategy == CompressionStrategy.ZSTD_WITH_DICT) {
       String resourceName = getResourceName(version);
-      if (!compressorFactory.versionSpecificCompressorExists(resourceName)) {
+      VeniceCompressor compressor = compressorFactory.getVersionSpecificCompressor(resourceName);
+      if (compressor == null) {
         ByteBuffer dictionary = versionZstdDictionaryMap.get(version);
         if (dictionary == null) {
           throw new VeniceClientException(
@@ -433,11 +434,11 @@ public class DaVinciClientBasedMetadata extends AbstractStoreMetadata {
                   storeName,
                   version));
         } else {
-          compressorFactory
-              .createVersionSpecificCompressorIfNotExist(compressionStrategy, resourceName, dictionary.array(), 0);
+          compressor = compressorFactory
+              .createVersionSpecificCompressorIfNotExist(compressionStrategy, resourceName, dictionary.array());
         }
       }
-      return compressorFactory.getVersionSpecificCompressor(resourceName);
+      return compressor;
     } else {
       return compressorFactory.getCompressor(compressionStrategy);
     }

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/AbstractVeniceMapper.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/AbstractVeniceMapper.java
@@ -144,14 +144,12 @@ public abstract class AbstractVeniceMapper<INPUT_KEY, INPUT_VALUE> extends Abstr
       int compressionLevel = props.getInt(ZSTD_COMPRESSION_LEVEL, Zstd.maxCompressionLevel());
 
       if (compressionDictionary != null && compressionDictionary.limit() > 0) {
-        this.compressor = compressorFactory.createCompressorWithDictionary(
-            CompressionStrategy.ZSTD_WITH_DICT,
-            compressionDictionary.array(),
-            compressionLevel);
+        this.compressor =
+            compressorFactory.createCompressorWithDictionary(compressionDictionary.array(), compressionLevel);
       }
     } else {
       this.compressor =
-          compressorFactory.createCompressor(CompressionStrategy.valueOf(props.getString(COMPRESSION_STRATEGY)));
+          compressorFactory.getCompressor(CompressionStrategy.valueOf(props.getString(COMPRESSION_STRATEGY)));
     }
   }
 

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
@@ -466,6 +466,7 @@ public class VenicePushJob implements AutoCloseable {
   private InputStorageQuotaTracker inputStorageQuotaTracker;
   private PushJobHeartbeatSenderFactory pushJobHeartbeatSenderFactory;
   private final boolean jobLivenessHeartbeatEnabled;
+  private boolean pushJobStatusUploadDisabledHasBeenLogged = false;
 
   /**
    * Different successful checkpoints and known error scenarios of the VPJ flow.
@@ -1720,10 +1721,14 @@ public class VenicePushJob implements AutoCloseable {
   }
 
   private void sendPushJobDetailsToController() {
-    if (!pushJobSetting.enablePushJobStatusUpload || pushJobDetails == null) {
-      String detailMessage =
-          pushJobSetting.enablePushJobStatusUpload ? "The payload was not populated properly" : "Feature is disabled";
-      LOGGER.warn("Unable to send push job details for monitoring purpose. {}", detailMessage);
+    if (!pushJobSetting.enablePushJobStatusUpload) {
+      if (!pushJobStatusUploadDisabledHasBeenLogged) {
+        pushJobStatusUploadDisabledHasBeenLogged = true;
+        LOGGER.warn("Unable to send push job details for monitoring purpose. Feature is disabled");
+      }
+      return;
+    } else if (pushJobDetails == null) {
+      LOGGER.warn("Unable to send push job details for monitoring purpose. The payload was not populated properly");
       return;
     }
     try {
@@ -2345,12 +2350,10 @@ public class VenicePushJob implements AutoCloseable {
       String previousOverallDetails,
       Map<String, String> previousExtraDetails) {
     String newOverallDetails = previousOverallDetails;
-    String logMessage = "Specific status: ";
     Map<String, String> datacenterSpecificInfo = response.getExtraInfo();
     if (datacenterSpecificInfo != null && !datacenterSpecificInfo.isEmpty()) {
-      logMessage += datacenterSpecificInfo;
+      LOGGER.info("Specific status: {}", datacenterSpecificInfo);
     }
-    LOGGER.info(logMessage);
 
     Optional<String> details = response.getOptionalStatusDetails();
     if (details.isPresent() && detailsAreDifferent(previousOverallDetails, details.get())) {

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,21 +1,19 @@
-
 <html>
     <h1 align="center">
       Venice
     </h1>
     <h3 align="center">
-      Derived Data Platform for planet-scale workloads
+      Derived Data Platform for Planet-Scale Workloads<br/>
     </h3>
-    <h3 align="center">
-      Important Links:
-      <a href="https://communityinviter.com/apps/venicedb/venice">Slack</a> &
-      <a href="https://github.com/linkedin/venice/discussions">Discussions</a>.   
-      <a href="https://linkedin.github.io/venice/">Docs</a>.
-    </h3>
-</html> 
-
-[![License](https://img.shields.io/badge/License-BSD_2--Clause-blue.svg)](https://github.com/linkedin/venice/blob/main/LICENSE)
-[![Docs Latest](https://img.shields.io/badge/docs-latest-blue.svg)](https://linkedin.github.io/venice/)
+    <div align="center">
+        <a href="https://github.com/linkedin/venice/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-BSD_2--Clause-blue.svg" alt="License"></a>
+        <a href="https://linkedin.github.io/venice/"><img src="https://img.shields.io/badge/docs-latest-blue.svg" alt="Docs Latest"></a>
+        <a href="http://twitter.com/VeniceDataBase"><img src="https://img.shields.io/badge/Twitter-%231DA1F2.svg?logo=Twitter&logoColor=white" alt="Twitter"></a>
+        <a href="https://www.linkedin.com/groups/14129519/"><img src="https://img.shields.io/badge/linkedin-%230077B5.svg?logo=linkedin&logoColor=white" alt="LinkedIn"></a>
+        <a href="https://communityinviter.com/apps/venicedb/venice"><img src="https://img.shields.io/badge/Slack-4A154B?logo=slack&logoColor=white" alt="Slack"></a>
+        <a href="http://github.com/linkedin/venice"><img src="https://img.shields.io/badge/github-%23121011.svg?logo=github&logoColor=white" alt="GitHub"></a>
+    </div>
+</html>
 
 Venice is a derived data storage platform, providing the following characteristics:
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -96,6 +96,7 @@ The following talks have been given about Venice:
 - 2018: [Venice with Apache Kafka & Samza](https://www.youtube.com/watch?v=Usz8E4S-hZE)
 - 2019: [People You May Know: Fast Recommendations over Massive Data](https://www.infoq.com/presentations/recommendation-massive-data/)
 - 2019: [Enabling next generation models for PYMK Scale](https://www.youtube.com/watch?v=znd-Q6IvCqY)
+- 2022: [Open Sourcing Venice](https://www.youtube.com/watch?v=pJeg4V3JgYo)
 
 Keep in mind that older content reflects an earlier phase of the project and may not be entirely correct anymore.
 

--- a/docs/dev_guide/style_guide.md
+++ b/docs/dev_guide/style_guide.md
@@ -56,7 +56,8 @@ Use a single-line JavaDoc if it fits, e.g., `/** A very short description */`
 
 Note that we also use JavaDoc everywhere we feel like, not just at the top of functions and classes. This is atypical,
 but intentional. It allows us to use the `{@link ClassName}` syntax in order to make the code more easily navigable and
-refactorable. If your IDE complains that the JavaDoc is misplaced, disable that hint (:
+refactorable. If your IDE complains about dangling JavaDocs, that hint should be disabled. If using IntelliJ, this will
+be configured automatically when calling: `./gradlew cleanIdea idea`
 
 ### Logging
 
@@ -98,6 +99,13 @@ consider whether a class actually needs a handle of an instance of an entire oth
 call any of its functions), or whether it could make do with an instance of a more constrained interface, which the 
 other class implements, or perhaps even just a handle to a specific function of the other class (thus limiting the 
 surface area of their interaction).
+
+### Avoid Wildcard Imports
+
+We avoid wildcard imports since they may lead to bugs due to pulling in unintended classes or functions. If using 
+IntelliJ, the auto-conversion of imports into wildcards can be disabled by following these 
+[instructions](https://www.jetbrains.com/help/idea/creating-and-optimizing-imports.html#disable-wildcard-imports). This
+would be a good candidate for automation, perhaps via a new Spotbugs plugin; contributions welcome!
 
 ### Avoid Optionals
 

--- a/docs/dev_guide/style_guide.md
+++ b/docs/dev_guide/style_guide.md
@@ -25,10 +25,11 @@ judgment call, and needs to be balanced by concerns like managing the risk of un
 Regarding code style, we use the Eclipse Java Formatter variant of Spotless, which automatically reformats the code as
 part of git commit hooks. Make sure to run `./gradlew assemble` to get the git hooks set up.
 
-We also use spotbugs, with some of the rules resulting in build failures if violated. Over time, we intend to pick up
-more of these rules, fix the code to comply with them, and add them to the list. If you would like to contribute to this 
-effort, feel free to open an issue and suggest which rules you are interested in fixing. Note that there are a few rules 
-that we intend to ignore as they seem to be imprecise or not sufficiently useful.
+We also use Spotbugs, with [some of the rules](https://github.com/linkedin/venice/blob/main/gradle/spotbugs/include.xml) 
+resulting in build failures if violated. Over time, we intend to pick up more of these rules, fix the code to comply 
+with them, and add them to the list. If you would like to contribute to this effort, feel free to open an issue and 
+suggest which rules you are interested in fixing. Note that there are [a few rules that we intend to ignore](https://github.com/linkedin/venice/blob/main/gradle/spotbugs/exclude.xml) 
+as they seem to be imprecise or not sufficiently useful.
 
 In the future, we might add other forms of automation to increase code quality along other dimensions. Feel free to
 suggest ideas in this space.
@@ -94,15 +95,16 @@ private functions, in the correct order.
 
 Avoid passing `this` into classes as this may make the flow of the code difficult to understand. Also, more generally,
 consider whether a class actually needs a handle of an instance of an entire other class (and thus have the ability to 
-call any of its functions), or whether it could make do with just one or two handles to specific functions of the other
-class (thus limiting the surface area of their interaction).
+call any of its functions), or whether it could make do with an instance of a more constrained interface, which the 
+other class implements, or perhaps even just a handle to a specific function of the other class (thus limiting the 
+surface area of their interaction).
 
 ### Avoid Optionals
 
 We are aligned with the philosophy of the original creators of the Optional API, which is that it is a useful construct
 in the context of the Java 8 stream APIs, but should generally not be used beyond that. Null is a perfectly appropriate
-way to denote emptiness, and is not more or less likely to cause NullPointerExceptions. Sentinel values in primitive 
-types (e.g., -1 for a numeric value that is otherwise expected to be positive) are also perfectly appropriate ways to
+way to denote emptiness, and is not more or less likely to cause a `NullPointerException`. Sentinel values in primitive 
+types (e.g., `-1` for a numeric value that is otherwise expected to be positive) are also perfectly appropriate ways to
 denote emptiness. For more info, here are a good [video](https://www.youtube.com/watch?v=fBYhtvY19xA&t=2317s) and 
 [post](https://homes.cs.washington.edu/~mernst/advice/nothing-is-better-than-optional.html) on this subject.
 
@@ -141,7 +143,7 @@ efficient, but also easier to reason about, since it indicates the immutability 
 Another example is interrogating a map to see if it contains a key, and if true, then getting that key out of the map.
 This requires 2 lookups, whereas in fact only 1 lookup would suffice, as we can get a value from the map and then check
 whether it's null. Moreover, doing it in 1 lookup is actually cleaner, since it eliminates the race condition where the
-lookup may exist during the `containsKey` check but then get removed prior to the subsequent `get` call. Again, the 
+lookup may exist during the `containsKey` check but then be removed prior to the subsequent `get` call. Again, the 
 faster code is cleaner.
 
 Yet another example is using the optimal data structure for a given use case. A frequent use case within Venice is to

--- a/docs/dev_guide/style_guide.md
+++ b/docs/dev_guide/style_guide.md
@@ -1,0 +1,139 @@
+---
+layout: default
+title: Style Guide
+parent: Developer Guides
+permalink: /docs/dev_guide/style_guide
+---
+
+# Style Guide
+
+This page describes some stylistic concerns which the development team cares about. Some of them are enforced by 
+automation, while others are guidelines of a more informal, or even philosophical, nature. More generally, we believe in 
+acquiring a deep understanding of the principles behind these guidelines, and being thoughtful about which situation 
+they apply or don't apply to. We don't buy into mainstream ideas such as "all coupling is bad", "all optimizations are
+premature", etc. We take this common wisdom and incorporate it into our reflections, without blindly taking it at face
+value.
+
+We also want to acknowledge that our conclusions change over time, either due to hindsight or because of the evolving 
+context that the project needs to navigate. As such, this should be thought of as a living document, and it is therefore 
+natural that not all parts of the code base adhere to it perfectly. When such deviations are discovered, it is 
+encouraged to try to rectify them "in passing", even if the objective of the code change is unrelated. This, too, is a 
+judgment call, and needs to be balanced by concerns like managing the risk of unintended regressions.
+
+## Automation
+
+Regarding code style, we use the Eclipse Java Formatter variant of Spotless, which automatically reformats the code as
+part of git commit hooks. Make sure to run `./gradlew assemble` to get the git hooks set up.
+
+We also use spotbugs, with some of the rules resulting in build failures if violated. Over time, we intend to pick up
+more of these rules, fix the code to comply with them, and add them to the list. If you would like to contribute to this 
+effort, feel free to open an issue and suggest which rules you are interested in fixing. Note that there are a few rules 
+that we intend to ignore as they seem to be imprecise or not sufficiently useful.
+
+In the future, we might add other forms of automation to increase code quality along other dimensions. Feel free to
+suggest ideas in this space.
+
+## Guidelines
+
+Below are a set of guidelines to take into consideration when developing in the Venice project. They are not absolute
+rules and there may be good reasons to deviate from them occasionally. When deviating, it is useful to leave comments
+explaining why we deviated, whether it was intentional, or due to the need for expediency. This helps future maintainers 
+understand what is actually worth cleaning up and how careful they need to be when doing it.
+
+### JavaDoc
+
+Speaking of comments, we ideally want JavaDoc at the top of all classes. The top of class JavaDoc should indicate the
+set of responsibilities of the class. If the list of responsibilities grows long and/or lacks a common theme, it may be
+an indicator that the class ought to be split up.
+
+JavaDoc for functions is desired for public client APIs intended to be leveraged directly by end users. For internal
+functions, JavaDoc is desired only if there is something important to call out. Sometimes, a lengthy function JavaDoc
+may be an indication that the function's name is not sufficiently clear, or that the complex function should be split 
+into multiple simpler (and well-named!) functions.
+
+Use a single-line JavaDoc if it fits, e.g., `/** A very short description */`
+
+Note that we also use JavaDoc everywhere we feel like, not just at the top of functions and classes. This is atypical,
+but intentional. It allows us to use the `{@link ClassName}` syntax in order to make the code more easily navigable and
+refactorable. If your IDE complains that the JavaDoc is misplaced, disable that hint (:
+
+### Logging
+
+We use log4j and want to use interpolation, rather than manual string concatenation, everywhere, for efficiency reasons. 
+Note that Spotless may break up fragments of strings by concatenating over multiple lines, but that doesn't matter as it
+gets optimized away by the compiler. Only concatenations with variables end up carrying an overhead.
+
+Hot path logging should not be above debug level. Keep in mind that exception paths could occasionally turn into hot 
+paths. In those cases, we may want to use the `RedundantExceptionFilter`. More generally, hot path logging typically
+benefits from being converted into a metric instead.
+
+Do your best to make log messages meaningful. Avoid scary yet imprecise wording. If the situation is dire, let the log
+spell out precisely what happened, along with enough context to make debugging easier.
+
+If there is a known solution to remediate the issue, consider why isn't this solution reactively activated so the system 
+fixes itself, rather than just logging? If the solution exists but cannot be wired in reactively, then it may be 
+desirable for the log to indicate what that solution is, to give the user or operator a clue about what to do next 
+(i.e. the _Ghost in the Shell_ design pattern).
+
+### Encapsulation
+
+As much as possible, try to maintain tight encapsulation in all classes. Internal state should be exposed as little as
+feasible, and possibly not at all. Consider providing only getters, and not setters, if there is no need for the latter.
+Always be careful when returning objects (as opposed to primitives) as these may contain state that can then be mutated
+from outside the class they originated from. For example, instead of returning a map, it may be preferable to expose
+only a getter for retrieving entries from this map. Alternatively, the map could be placed in a read-only wrapper (but
+do consider this option carefully if it is going to happen on the hot path, in which case perhaps the read-only wrapper
+could be pre-allocated, especially if the wrapped map is final).
+
+If the API of a class is such that another class needs to call multiple functions in a row to achieve a desired outcome,
+then ask yourself whether the calling class is hand holding the internal state of the called class. Would the internal
+state of the called class be left in an inconsistent or incoherent state if the calling class stopped halfway through
+its sequence of function calls, or if it called those same functions in a different order? If the answer is yet, then
+perhaps the multiple functions should be presented as a single public function, which then internally delegates to many
+private functions, in the correct order.
+
+Avoid passing `this` into classes as this may make the flow of the code difficult to understand. Also, more generally,
+consider whether a class actually needs a handle of an instance of an entire other class (and thus have the ability to 
+call any of its functions), or whether it could make do with just one or two handles to specific functions of the other
+class (thus limiting the surface area of their interaction).
+
+### Avoid Optionals
+
+We are aligned with the philosophy of the original creators of the Optional API, which is that it is a useful construct
+in the context of the Java 8 stream APIs, but should generally not be used beyond that. Null is a perfectly appropriate
+way to denote emptiness, and is not more or less likely to cause NullPointerExceptions. Sentinel values in primitive 
+types (e.g., -1 for a numeric value that is otherwise expected to be positive) are also perfectly appropriate ways to
+denote emptiness. For more info, here are a good [video](https://www.youtube.com/watch?v=fBYhtvY19xA&t=2317s) and 
+[post](https://homes.cs.washington.edu/~mernst/advice/nothing-is-better-than-optional.html) on this subject.
+
+### Look for Ways to Mitigate Failures
+
+In a system with lots of moving parts, it should be expected that things fail all the time. We should look for design
+patterns that help us mitigate failures, wherever possible.
+
+An example of this is the way that dataset versions work in Venice. A dataset version has a unique name, based on the 
+dataset name concatenated with a monotonically increasing version number. A given dataset version name is immutable, in
+the sense that it will forever point to one and only dataset version, and cannot be reused. Even if a dataset is deleted
+and then re-created under the same name, we don't restart the version number sequence, so there cannot be a clash in
+the names of dataset versions coming from before and after the dataset re-creation. A dataset version is associated with
+various resources including a Kafka topic, a Helix resource, persistent state, and in-memory state. When purging an old
+dataset version, if any of the resources that constitute it fail to get cleaned up properly, it doesn't prevent future
+dataset versions from continuing to get created, since they should never clash. In this case, therefore, a failure to
+delete a resource results not in immediate and widespread systemic failure, but merely in a resource leak, which can be 
+monitored, alerted on, and remediated if it creeps beyond a certain threshold.
+
+### Be a Benevolent Tyrant
+
+The CPU will do whatever we tell it, day in day out, without complaints, but it does not mean we ought to abuse it.
+Although there is undoubtedly a kernel of truth in the saying that "premature optimization is the root of all evil",
+it is important to consider that the reverse is not equally true: non-optimized code is not the root of all clean code.
+
+For example, if a class contains some final string property, and the code in this class repeatedly performs a lookup
+by that property, then it implies that the result of this lookup may change over time. If that is true, then the code is
+fine, but if it is not true that the result of the lookup would change over time, then it is simply useless code. Doing
+the lookup just once, and hanging on to the result in another final property, makes the code not only faster and more 
+efficient, but also easier to reason about, since it indicates the immutability of this looked up property.
+
+Consider that the hot path in Venice may be invoked hundreds of thousands of times per second per server, and it is
+therefore important to minimize overhead in these paths. By being benevolent tyrants, our CPUs serve us better, and will
+hopefully care for us when AGI takes over the world.

--- a/docs/dev_guide/style_guide.md
+++ b/docs/dev_guide/style_guide.md
@@ -127,26 +127,33 @@ monitored, alerted on, and remediated if it creeps beyond a certain threshold.
 The CPU will do whatever we tell it, day in day out, without complaints, but it does not mean we ought to abuse it.
 Although there is undoubtedly a kernel of truth in the saying that "premature optimization is the root of all evil",
 it is important to consider that the reverse is not equally true. In other words, non-optimized code is not the root of 
-all clean code.
+all clean code. This picture from one of the talks by Java performance expert Aleksey Shipilëv describes the idea in an 
+easy to grasp manner:
+
+![Complexity vs Performance](https://user-images.githubusercontent.com/1248632/195111861-518f81c4-f226-4942-b88a-a34337da79e3.png)
 
 For example, if a class contains some final string property, and the code in this class repeatedly performs a lookup
 by that property, then it implies that the result of this lookup may change over time. If that is true, then the code is
 fine, but if it is not true that the result of the lookup would change over time, then it is simply useless code. Doing
-the lookup just once, and hanging on to the result in another final property, makes the code not only faster and more 
+the lookup just once, and caching the result in another final property, makes the code not only faster and more 
 efficient, but also easier to reason about, since it indicates the immutability of this looked up property.
 
 Another example is interrogating a map to see if it contains a key, and if true, then getting that key out of the map.
 This requires 2 lookups, whereas in fact only 1 lookup would suffice, as we can get a value from the map and then check
 whether it's null. Moreover, doing it in 1 lookup is actually cleaner, since it eliminates the race condition where the
-lookup may exist during the `containsKey` check but then get removed prior to the subsequent `get` call. Again, the fast
-code is cleaner.
+lookup may exist during the `containsKey` check but then get removed prior to the subsequent `get` call. Again, the 
+faster code is cleaner.
 
-Yet another example is using the optimal data structure for a given use case. If both a map and an array can do the job
-equally well, then let us use an array, as it is more efficient than a map. For collections of primitives, it is advised 
-to consider using fastutil. If using a more efficient data structure requires significant acrobatics, then we may still 
-prefer to opt for the less efficient one, for the sake of maintainability, but we should consider whether we can build a 
-new data structure which achieves both convenience and efficiency for a given use case. This kind of low-level work is 
-not considered off-limits within Venice, and we welcome it if there is a good rationale for it.
+Yet another example is using the optimal data structure for a given use case. A frequent use case within Venice is to
+look something up by partition number (which are in a tight range, between zero and some low number), and thus it is
+possible do the job with either an int-keyed map or an array. If both work equally well from a functional standpoint, 
+then let us use an array, as it is more efficient to perform an index lookup within an array than a map lookup. For 
+collections of primitives, it is advised to consider using [fastutil](https://fastutil.di.unimi.it/). If using a more 
+efficient data structure requires significant acrobatics, then we may still prefer to opt for the less efficient one, 
+for the sake of maintainability (e.g., if it falls within the red zone of the above diagram). That being said, we should 
+consider whether we can build a new data structure which achieves both convenience and efficiency for a given use case
+(e.g., yellow zone). This kind of low-level work is not considered off-limits within Venice, and we welcome it if there 
+is a good rationale for it.
 
 More generally, always keep in mind that the hot path in Venice may be invoked hundreds of thousands of times per second 
 per server, and it is therefore important to minimize overhead in these paths. By being benevolent tyrants, our CPUs 

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/utils/Pair.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/utils/Pair.java
@@ -8,7 +8,10 @@ import java.util.Objects;
  * Represents a pair of items
  * @param <F> The type of the first item
  * @param <S> The type of the second item
+ *
+ * @deprecated Instead of this, please create a dedicated class with well-named, non-generic (potentially primitive) properties and getters.
  */
+@Deprecated
 public class Pair<F, S> implements Serializable {
   private static final long serialVersionUID = 1L;
 

--- a/internal/venice-common/src/main/java/com/linkedin/venice/writer/VeniceWriterFactory.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/writer/VeniceWriterFactory.java
@@ -128,12 +128,12 @@ public class VeniceWriterFactory {
   @Deprecated
   public VeniceWriter<byte[], byte[], byte[]> createBasicVeniceWriter(
       String topicName,
-      Optional<Boolean> chunkingEnabled,
+      boolean chunkingEnabled,
       VenicePartitioner partitioner,
       int topicPartitionCount) {
     VeniceWriterOptions options = new VeniceWriterOptions.Builder(topicName).setPartitioner(partitioner)
         .setPartitionCount(Optional.of(topicPartitionCount))
-        .setChunkingEnabled(chunkingEnabled.orElse(false))
+        .setChunkingEnabled(chunkingEnabled)
         .build();
     return createVeniceWriter(options);
   }

--- a/internal/venice-test-common/build.gradle
+++ b/internal/venice-test-common/build.gradle
@@ -90,3 +90,11 @@ flakyTest {
   classpath += sourceSets.integrationTest.runtimeClasspath
   testClassesDirs += sourceSets.integrationTest.output.classesDirs
 }
+
+idea {
+  module {
+    testSourceDirs += project.sourceSets.integrationTest.java.srcDirs
+    testResourceDirs += project.sourceSets.integrationTest.resources.srcDirs
+    testSourceDirs += project.sourceSets.jmh.java.srcDirs
+  }
+}

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/controller/VeniceParentHelixAdminTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/controller/VeniceParentHelixAdminTest.java
@@ -10,7 +10,6 @@ import static com.linkedin.venice.controller.SchemaConstants.VALUE_SCHEMA_FOR_WR
 import static com.linkedin.venice.controller.SchemaConstants.VALUE_SCHEMA_FOR_WRITE_COMPUTE_V3;
 import static com.linkedin.venice.controller.SchemaConstants.VALUE_SCHEMA_FOR_WRITE_COMPUTE_V4;
 import static com.linkedin.venice.controller.SchemaConstants.VALUE_SCHEMA_FOR_WRITE_COMPUTE_V5;
-import static com.linkedin.venice.integration.utils.VeniceClusterWrapperConstants.*;
 import static com.linkedin.venice.utils.TestUtils.assertCommand;
 import static com.linkedin.venice.utils.TestUtils.waitForNonDeterministicAssertion;
 import static com.linkedin.venice.utils.TestUtils.waitForNonDeterministicPushCompletion;

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestBatch.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestBatch.java
@@ -246,7 +246,7 @@ public abstract class TestBatch {
     }
   }
 
-  @Test(timeOut = TEST_TIMEOUT, dataProvider = "Two-True-and-False", dataProviderClass = DataProviderUtils.class)
+  @Test(dataProvider = "Two-True-and-False", dataProviderClass = DataProviderUtils.class)
   public void testCompressingRecord(boolean compressionMetricCollectionEnabled, boolean useMapperToBuildDict)
       throws Exception {
     VPJValidator validator = (avroClient, vsonClient, metricsRepository) -> {

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestHybrid.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestHybrid.java
@@ -1159,7 +1159,7 @@ public class TestHybrid {
     }
   }
 
-  @Test(dataProvider = "Boolean-Compression", dataProviderClass = DataProviderUtils.class, timeOut = 180
+  @Test(dataProvider = "Boolean-Compression", dataProviderClass = DataProviderUtils.class, timeOut = 60
       * Time.MS_PER_SECOND)
   public void testDuplicatedMessagesWontBePersisted(
       boolean isIngestionIsolationEnabled,

--- a/internal/venice-test-common/src/main/java/com/linkedin/venice/integration/utils/VeniceControllerCreateOptions.java
+++ b/internal/venice-test-common/src/main/java/com/linkedin/venice/integration/utils/VeniceControllerCreateOptions.java
@@ -6,7 +6,6 @@ import static com.linkedin.venice.ConfigKeys.LOCAL_REGION_NAME;
 import static com.linkedin.venice.integration.utils.VeniceClusterWrapperConstants.DEFAULT_DELAYED_TO_REBALANCE_MS;
 import static com.linkedin.venice.integration.utils.VeniceClusterWrapperConstants.DEFAULT_PARTITION_SIZE_BYTES;
 import static com.linkedin.venice.integration.utils.VeniceClusterWrapperConstants.DEFAULT_REPLICATION_FACTOR;
-import static com.linkedin.venice.integration.utils.VeniceControllerWrapper.*;
 
 import com.linkedin.venice.authorization.AuthorizerService;
 import java.util.Arrays;
@@ -242,7 +241,7 @@ public class VeniceControllerCreateOptions {
       if (!isMinActiveReplicaSet) {
         minActiveReplica = replicationFactor > 1 ? replicationFactor - 1 : replicationFactor;
       }
-      extraProperties.setProperty(LOCAL_REGION_NAME, DEFAULT_PARENT_DATA_CENTER_REGION_NAME);
+      extraProperties.setProperty(LOCAL_REGION_NAME, VeniceControllerWrapper.DEFAULT_PARENT_DATA_CENTER_REGION_NAME);
       if (!extraProperties.containsKey(CONTROLLER_AUTO_MATERIALIZE_META_SYSTEM_STORE)) {
         extraProperties.setProperty(CONTROLLER_AUTO_MATERIALIZE_META_SYSTEM_STORE, "true");
       }

--- a/internal/venice-test-common/src/main/java/com/linkedin/venice/utils/TestUtils.java
+++ b/internal/venice-test-common/src/main/java/com/linkedin/venice/utils/TestUtils.java
@@ -6,7 +6,7 @@ import static com.linkedin.venice.ConfigKeys.PARTITIONER_CLASS;
 import static com.linkedin.venice.ConfigKeys.SERVER_FORKED_PROCESS_JVM_ARGUMENT_LIST;
 import static com.linkedin.venice.ConfigKeys.SERVER_INGESTION_MODE;
 import static com.linkedin.venice.utils.TestPushUtils.STRING_SCHEMA;
-import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyInt;
 import static org.mockito.Mockito.doReturn;

--- a/internal/venice-test-common/src/main/java/com/linkedin/venice/utils/TestUtils.java
+++ b/internal/venice-test-common/src/main/java/com/linkedin/venice/utils/TestUtils.java
@@ -6,6 +6,7 @@ import static com.linkedin.venice.ConfigKeys.PARTITIONER_CLASS;
 import static com.linkedin.venice.ConfigKeys.SERVER_FORKED_PROCESS_JVM_ARGUMENT_LIST;
 import static com.linkedin.venice.ConfigKeys.SERVER_INGESTION_MODE;
 import static com.linkedin.venice.utils.TestPushUtils.STRING_SCHEMA;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyInt;
 import static org.mockito.Mockito.doReturn;
@@ -24,6 +25,7 @@ import com.linkedin.davinci.stats.AggVersionedDIVStats;
 import com.linkedin.davinci.stats.AggVersionedIngestionStats;
 import com.linkedin.davinci.storage.StorageEngineRepository;
 import com.linkedin.davinci.storage.StorageMetadataService;
+import com.linkedin.davinci.store.AbstractStorageEngine;
 import com.linkedin.venice.ConfigKeys;
 import com.linkedin.venice.common.VeniceSystemStoreType;
 import com.linkedin.venice.compression.CompressionStrategy;
@@ -376,7 +378,7 @@ public class TestUtils {
       ByteBuffer compressionDictionary) {
     VeniceCompressor compressor = null;
     if (compressionStrategy == CompressionStrategy.ZSTD_WITH_DICT) {
-      compressor = new ZstdWithDictCompressor(compressionDictionary.array(), 0);
+      compressor = new ZstdWithDictCompressor(compressionDictionary.array(), Zstd.maxCompressionLevel());
     } else if (compressionStrategy == CompressionStrategy.GZIP) {
       compressor = new GzipCompressor();
     } else {
@@ -762,8 +764,7 @@ public class TestUtils {
       HttpGet getReq = new HttpGet(sb.toString());
       try (InputStream bodyStream = storageNodeClient.execute(getReq, null).get().getEntity().getContent()) {
         byte[] dictionary = IOUtils.toByteArray(bodyStream);
-        return compressorFactory
-            .createCompressorWithDictionary(compressionStrategy, dictionary, Zstd.maxCompressionLevel());
+        return compressorFactory.createCompressorWithDictionary(dictionary, Zstd.maxCompressionLevel());
       } catch (InterruptedException | ExecutionException e) {
         throw e;
       }
@@ -781,6 +782,9 @@ public class TestUtils {
     KafkaClientFactory mockKafkaClientFactory = mock(KafkaClientFactory.class);
     KafkaConsumerWrapper mockKafkaConsumerWrapper = mock(KafkaConsumerWrapper.class);
     doReturn(mockKafkaConsumerWrapper).when(mockKafkaClientFactory).getConsumer(any());
+
+    StorageEngineRepository mockStorageEngineRepository = mock(StorageEngineRepository.class);
+    doReturn(mock(AbstractStorageEngine.class)).when(mockStorageEngineRepository).getLocalStorageEngine(anyString());
 
     ReadOnlyStoreRepository mockReadOnlyStoreRepository = mock(ReadOnlyStoreRepository.class);
     Store mockStore = mock(Store.class);
@@ -834,7 +838,7 @@ public class TestUtils {
 
     return new StoreIngestionTaskFactory.Builder().setVeniceWriterFactory(mock(VeniceWriterFactory.class))
         .setKafkaClientFactory(mockKafkaClientFactory)
-        .setStorageEngineRepository(mock(StorageEngineRepository.class))
+        .setStorageEngineRepository(mockStorageEngineRepository)
         .setStorageMetadataService(mockStorageMetadataService)
         .setLeaderFollowerNotifiersQueue(new ArrayDeque<>())
         .setBandwidthThrottler(mock(EventThrottler.class))
@@ -912,8 +916,8 @@ public class TestUtils {
       String storeName,
       Optional<Logger> logger) {
     String metaSystemStoreName = VeniceSystemStoreType.META_STORE.getSystemStoreName(storeName);
-    VersionCreationResponse response = controllerClient.emptyPush(metaSystemStoreName, "testEmptyPush", 1234321);
-    Assert.assertFalse(response.isError());
+    VersionCreationResponse response =
+        assertCommand(controllerClient.emptyPush(metaSystemStoreName, "testEmptyPush", 1234321));
     TestUtils.waitForNonDeterministicPushCompletion(response.getKafkaTopic(), controllerClient, 1, TimeUnit.MINUTES);
     logger.ifPresent(value -> value.info("System store " + metaSystemStoreName + " is created."));
   }

--- a/services/venice-router/src/test/java/com/linkedin/venice/router/api/TestVeniceResponseDecompressor.java
+++ b/services/venice-router/src/test/java/com/linkedin/venice/router/api/TestVeniceResponseDecompressor.java
@@ -81,8 +81,7 @@ public class TestVeniceResponseDecompressor {
       compressorFactory.createVersionSpecificCompressorIfNotExist(
           CompressionStrategy.ZSTD_WITH_DICT,
           "test-store_v1",
-          new byte[] {},
-          22);
+          new byte[] {});
 
       VeniceResponseDecompressor responseDecompressor = new VeniceResponseDecompressor(
           true,
@@ -131,8 +130,7 @@ public class TestVeniceResponseDecompressor {
       compressorFactory.createVersionSpecificCompressorIfNotExist(
           CompressionStrategy.ZSTD_WITH_DICT,
           "test-store_v1",
-          new byte[] {},
-          22);
+          new byte[] {});
 
       VeniceResponseDecompressor responseDecompressor = new VeniceResponseDecompressor(
           true,

--- a/services/venice-server/src/main/java/com/linkedin/venice/listener/StorageReadRequestsHandler.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/listener/StorageReadRequestsHandler.java
@@ -17,6 +17,7 @@ import com.linkedin.davinci.store.rocksdb.RocksDBComputeAccessMode;
 import com.linkedin.venice.VeniceConstants;
 import com.linkedin.venice.cleaner.ResourceReadUsageTracker;
 import com.linkedin.venice.compression.CompressionStrategy;
+import com.linkedin.venice.compression.VeniceCompressor;
 import com.linkedin.venice.compute.ComputeOperationUtils;
 import com.linkedin.venice.compute.ComputeRequestWrapper;
 import com.linkedin.venice.compute.ReadComputeOperator;
@@ -39,6 +40,7 @@ import com.linkedin.venice.listener.response.HttpShortcutResponse;
 import com.linkedin.venice.listener.response.MultiGetResponseWrapper;
 import com.linkedin.venice.listener.response.StorageResponseObject;
 import com.linkedin.venice.meta.PartitionerConfig;
+import com.linkedin.venice.meta.PartitionerConfigImpl;
 import com.linkedin.venice.meta.ReadOnlySchemaRepository;
 import com.linkedin.venice.meta.ReadOnlyStoreRepository;
 import com.linkedin.venice.meta.Store;
@@ -362,6 +364,14 @@ public class StorageReadRequestsHandler extends ChannelInboundHandlerAdapter {
         Optional<Version> version = store.getVersion(versionNumber);
         if (version.isPresent()) {
           partitionerConfig = version.get().getPartitionerConfig();
+          if (partitionerConfig == null) {
+            /**
+             * If we did find the version in the metadata, and its partitioner config is null (common case) then we want
+             * to distinguish this by caching the default partitioner, otherwise we will end up re-executing this
+             * closure repeatedly and needlessly.
+             */
+            return new PartitionerConfigImpl();
+          }
         }
         return partitionerConfig;
       } catch (Exception e) {
@@ -372,16 +382,15 @@ public class StorageReadRequestsHandler extends ChannelInboundHandlerAdapter {
   }
 
   private ReadResponse handleSingleGetRequest(GetRouterRequest request) {
-    PartitionerConfig partitionerConfig = getPartitionerConfig(request.getResourceName());
-    int subPartition =
-        getSubPartitionId(request.getPartition(), request.getResourceName(), partitionerConfig, request.getKeyBytes());
     String topic = request.getResourceName();
+    PartitionerConfig partitionerConfig = getPartitionerConfig(topic);
+    int subPartition = getSubPartitionId(request.getPartition(), topic, partitionerConfig, request.getKeyBytes());
     byte[] key = request.getKeyBytes();
-    boolean isChunked = metadataRetriever.isStoreVersionChunked(topic);
 
     AbstractStorageEngine storageEngine = getStorageEngine(topic);
+    boolean isChunked = storageEngine.isChunked();
     StorageResponseObject response = new StorageResponseObject();
-    response.setCompressionStrategy(metadataRetriever.getStoreVersionCompressionStrategy(topic));
+    response.setCompressionStrategy(storageEngine.getCompressionStrategy());
     response.setDatabaseLookupLatency(0);
 
     ValueRecord valueRecord = SingleGetChunkingAdapter.get(storageEngine, subPartition, key, isChunked, response);
@@ -403,9 +412,9 @@ public class StorageReadRequestsHandler extends ChannelInboundHandlerAdapter {
     AbstractStorageEngine store = getStorageEngine(topic);
 
     MultiGetResponseWrapper responseWrapper = new MultiGetResponseWrapper(request.getKeyCount());
-    responseWrapper.setCompressionStrategy(metadataRetriever.getStoreVersionCompressionStrategy(topic));
+    responseWrapper.setCompressionStrategy(store.getCompressionStrategy());
     responseWrapper.setDatabaseLookupLatency(0);
-    boolean isChunked = metadataRetriever.isStoreVersionChunked(topic);
+    boolean isChunked = store.isChunked();
 
     ExecutorService executorService = getExecutor(RequestType.MULTI_GET);
     if (!(keys instanceof ArrayList)) {
@@ -435,8 +444,7 @@ public class StorageReadRequestsHandler extends ChannelInboundHandlerAdapter {
         for (int subChunkCur = startPos; subChunkCur < endPos; ++subChunkCur) {
           final MultiGetRouterRequestKeyV1 key = keyList.get(subChunkCur);
           optionalKeyList.ifPresent(list -> list.add(key.keyBytes.remaining()));
-          int subPartitionId =
-              getSubPartitionId(key.partitionId, request.getResourceName(), partitionerConfig, key.keyBytes.array());
+          int subPartitionId = getSubPartitionId(key.partitionId, topic, partitionerConfig, key.keyBytes.array());
           MultiGetResponseRecordV1 record =
               BatchGetChunkingAdapter.get(store, subPartitionId, key.keyBytes, isChunked, responseWrapper);
           if (record == null) {
@@ -488,12 +496,11 @@ public class StorageReadRequestsHandler extends ChannelInboundHandlerAdapter {
     AbstractStorageEngine store = getStorageEngine(topic);
 
     MultiGetResponseWrapper responseWrapper = new MultiGetResponseWrapper(request.getKeyCount());
-    responseWrapper.setCompressionStrategy(metadataRetriever.getStoreVersionCompressionStrategy(topic));
+    responseWrapper.setCompressionStrategy(store.getCompressionStrategy());
     responseWrapper.setDatabaseLookupLatency(0);
-    boolean isChunked = metadataRetriever.isStoreVersionChunked(topic);
+    boolean isChunked = store.isChunked();
     for (MultiGetRouterRequestKeyV1 key: keys) {
-      int subPartitionId =
-          getSubPartitionId(key.partitionId, request.getResourceName(), partitionerConfig, key.keyBytes.array());
+      int subPartitionId = getSubPartitionId(key.partitionId, topic, partitionerConfig, key.keyBytes.array());
       MultiGetResponseRecordV1 record =
           BatchGetChunkingAdapter.get(store, subPartitionId, key.keyBytes, isChunked, responseWrapper);
       if (record == null) {
@@ -549,8 +556,8 @@ public class StorageReadRequestsHandler extends ChannelInboundHandlerAdapter {
     }
 
     ComputeResponseWrapper responseWrapper = new ComputeResponseWrapper(request.getKeyCount());
-    CompressionStrategy compressionStrategy = metadataRetriever.getStoreVersionCompressionStrategy(topic);
-    boolean isChunked = metadataRetriever.isStoreVersionChunked(topic);
+    CompressionStrategy compressionStrategy = store.getCompressionStrategy();
+    boolean isChunked = store.isChunked();
 
     // The following metrics will get incremented for each record processed in computeResult()
     responseWrapper.setReadComputeDeserializationLatency(0.0);
@@ -582,10 +589,10 @@ public class StorageReadRequestsHandler extends ChannelInboundHandlerAdapter {
     }
 
     Map<String, Object> globalContext = new HashMap<>();
+    VeniceCompressor compressor = compressorFactory.getCompressor(compressionStrategy, topic);
     for (ComputeRouterRequestKeyV1 key: keys) {
       clearFieldsInReusedRecord(reuseResultRecord, computeResultSchema);
-      int subPartitionId =
-          getSubPartitionId(key.partitionId, request.getResourceName(), partitionerConfig, key.keyBytes.array());
+      int subPartitionId = getSubPartitionId(key.partitionId, topic, partitionerConfig, key.keyBytes.array());
       ComputeResponseRecordV1 record = computeResult(
           store,
           storeName,
@@ -604,7 +611,8 @@ public class StorageReadRequestsHandler extends ChannelInboundHandlerAdapter {
           request.isStreamingRequest(),
           responseWrapper,
           globalContext,
-          reusedRawValue);
+          reusedRawValue,
+          compressor);
       if (record != null) {
         // TODO: streaming support in storage node
         responseWrapper.addRecord(record);
@@ -645,7 +653,8 @@ public class StorageReadRequestsHandler extends ChannelInboundHandlerAdapter {
       boolean isStreaming,
       ComputeResponseWrapper response,
       Map<String, Object> globalContext,
-      ByteBuffer reuseRawValue) {
+      ByteBuffer reuseRawValue,
+      VeniceCompressor compressor) {
 
     switch (rocksDBComputeAccessMode) {
       case SINGLE_GET:
@@ -661,7 +670,7 @@ public class StorageReadRequestsHandler extends ChannelInboundHandlerAdapter {
             fastAvroEnabled,
             this.schemaRepo,
             storeName,
-            compressorFactory,
+            compressor,
             false);
         break;
       case SINGLE_GET_WITH_REUSE:
@@ -678,7 +687,7 @@ public class StorageReadRequestsHandler extends ChannelInboundHandlerAdapter {
             fastAvroEnabled,
             this.schemaRepo,
             response,
-            compressorFactory);
+            compressor);
         break;
       default:
         throw new VeniceException("Unknown rocksDB compute storage operation");

--- a/services/venice-server/src/main/java/com/linkedin/venice/server/VeniceServer.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/server/VeniceServer.java
@@ -277,7 +277,8 @@ public class VeniceServer {
           veniceConfigLoader.getVeniceServerConfig().getIngestionServicePort(),
           partitionStateSerializer,
           new MetadataUpdateStats(metricsRepository),
-          veniceConfigLoader);
+          veniceConfigLoader,
+          storageService.getStoreVersionStateSyncer());
       services.add(ingestionStorageMetadataService);
       storageMetadataService = ingestionStorageMetadataService;
     } else {
@@ -335,7 +336,6 @@ public class VeniceServer {
         schemaRepo,
         liveClusterConfigRepo,
         metricsRepository,
-        rocksDBMemoryStats,
         kafkaMessageEnvelopeSchemaReader,
         clientConfigForConsumer,
         partitionStateSerializer,

--- a/services/venice-server/src/test/java/com/linkedin/venice/server/VeniceServerTest.java
+++ b/services/venice-server/src/test/java/com/linkedin/venice/server/VeniceServerTest.java
@@ -68,7 +68,10 @@ public class VeniceServerTest {
       String storeName = Utils.getUniqueString("testCheckBeforeJoinCluster");
       server.getVeniceServer()
           .getStorageService()
-          .openStoreForNewPartition(server.getVeniceServer().getConfigLoader().getStoreConfig(storeName), 1);
+          .openStoreForNewPartition(
+              server.getVeniceServer().getConfigLoader().getStoreConfig(storeName),
+              1,
+              () -> null);
       Assert.assertEquals(
           repository.getAllLocalStorageEngines().size(),
           1,


### PR DESCRIPTION
Stability improvements:

1. The cached state in MainIngestionStorageMetadataService could get out of sync with the one in AbstractStoragePartition. To resolve this, the MainIngestionStorageMetadataService now takes in a storeVersionStateSyncer at construction-time, thus giving it a constrained API for mutating the internal state of the correct objects when necessary. In turn, this means we can retrieve the StoreVersionState either out of the StorageMetadataService (which requires an extra lookup) or out of AbstractStoragePartition and both are in-sync with one another.

2. Replaced the StorageMetadataService interface's put function with computeStoreVersionState, which provides first-class support for read-modify-write operations against the StoreVersionState, with a promise of proper synchronization. There are 3 code paths doing RMW operations against the StoreVersionState, so they now have proper synchronization. In practice, the race condition seems unlikely (perhaps impossible) between the current code paths, so this is defensive coding more than anything else.

3. Fixed a mem leak in the topicStorageEngineReferenceMap inside the DefaultIngestionBackend. It is now cleaned up from the close of VersionBackend.

4. Fixed a NPE in the ParticipantStoreConsumptionTask, and in the StorageUtilizationManager.

5. In SIT::produceToStoreBufferServiceOrKafka, processStartOfPush is now invoked as soon as we get a SOP, so that the StoreVersionState can be primed early, rather than later, in processControlMessage, which is called after passing through the StoreBufferService. This enables SIT::deserializeValue to perform its defensive check on compressed topics as well (which was previously unsupported). Also eliminated the logging of the value in case deserialization fails.

Object allocation reduction:

1. StoreVersionState, PartitionConsumptionState and the future inside StoreBufferService.QueueNode are not wrapped in Optionals anymore.

2. StoreBufferService.QueueNode is now specialized into 2 subclasses, each having different properties, resulting in 1 fewer null per ingested msg.

3. The compactingPartitions in SIT::produceToStoreBufferServiceOrKafka now only gets allocated if the related functionality is on.

Performance improvement:

1. ChunkingUtils and all related adapters now take in a specific compressor instance rather than a compressor factory, which means the responsibility of looking up the compressor is moved out of the adapters and into the calling code. This used to result in 1 map lookup for NO_OP and GZIP compression strategies, and 2 map lookups for ZSTD. The new structure amortizes the lookups better:
   - For ingestion, the SIT keeps a single compressor reference, eliminating map lookups per msg in WC.
   - For Da Vinci reads, it eliminates map loopups per key lookup.
   - For Read Compute, it changes the lookups from per key to per query.

2. StorageEngineBackedCompressorFactory::getCompressor now does 1 fewer map lookup, thus bringing ZSTD down to just 1, and the other strategies to 0. This is invoked once per query in all Classical Venice APIs (either on the client-side, router-side, or server-side for Read Compute, depending on the case).

3. The SIT now allocates a isChunked property at construction-time. This eliminates roughly 2 map lookups per ingested msg depending on which exact code path is triggered.

4. The SIT's availableSchemaIds and deserializedSchemaIds are now SparseConcurrentList rather than IntSet. This results in 3 fewer map lookups per ingested msg.

5. The MetadataRetriever interface lost isStoreVersionChunked and getStoreVersionCompressionStrategy, both of which were called on each read query by the StorageReadRequestsHandler. Instead, this info is now gotten from the AbstractStorageEngine that is also looked up, and which already carries this info from its cached StoreVersionState (which is where the MetadataRetriever ends up getting it also). This eliminates 2 map lookups per Classical Venice query.

6. In StoreBufferService::putConsumerRecord, there was a lookup of PartitionConsumptionState which used to be executed all the time but which only matters for followers. This eliminates 1 map lookup per ingested msg for leaders.

7. In FC, DaVinciClientBasedMetadata::getCompressor eliminates 1 map lookup. For batch gets, it gets called once per query rather than once per received value.

8. In StorageReadRequestsHandler::getPartitionerConfig, the cache will now maintain a vanilla PartitionerConfigImpl in the common case where there is no partition config override, thus eliminating calls to the computeIfAbsent closure (once per query).

Miscellaneous:

1. Marked the Pair class as deprecated.

2. Added a style guide.

3. Added logging interpolation everywhere in LFSIT.

4. Improved IntelliJ integration by doing some additional setup when running ./gradlew idea

5. Removed all wildcard imports.

## New image asset

![image](https://user-images.githubusercontent.com/1248632/195111861-518f81c4-f226-4942-b88a-a34337da79e3.png)

## How was this PR tested?
Lots of internal CI runs. Greens and yellows.

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.