### PR TITLE
[test] Add TestMergeUpdateWithFieldLevelTimestamp

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/replication/merge/MergeConflictResolver.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/replication/merge/MergeConflictResolver.java
@@ -624,7 +624,7 @@ public class MergeConflictResolver {
     }
   }
 
-  private GenericRecord createPerFieldTimestampRecord(
+  protected GenericRecord createPerFieldTimestampRecord(
       Schema rmdSchema,
       long fieldTimestamp,
       GenericRecord oldValueRecord) {

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/replication/merge/TestMergeUpdateWithFieldLevelTimestamp.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/replication/merge/TestMergeUpdateWithFieldLevelTimestamp.java
@@ -1,21 +1,334 @@
 package com.linkedin.davinci.replication.merge;
 
+import static com.linkedin.venice.schema.rmd.v1.CollectionRmdTimestamp.ACTIVE_ELEM_TS_FIELD_NAME;
+import static com.linkedin.venice.schema.rmd.v1.CollectionRmdTimestamp.DELETED_ELEM_FIELD_NAME;
+import static com.linkedin.venice.schema.rmd.v1.CollectionRmdTimestamp.DELETED_ELEM_TS_FIELD_NAME;
+import static com.linkedin.venice.schema.rmd.v1.CollectionRmdTimestamp.PUT_ONLY_PART_LENGTH_FIELD_NAME;
+import static com.linkedin.venice.schema.rmd.v1.CollectionRmdTimestamp.TOP_LEVEL_COLO_ID_FIELD_NAME;
+import static com.linkedin.venice.schema.rmd.v1.CollectionRmdTimestamp.TOP_LEVEL_TS_FIELD_NAME;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+import com.linkedin.davinci.replication.RmdWithValueSchemaId;
+import com.linkedin.venice.meta.ReadOnlySchemaRepository;
+import com.linkedin.venice.schema.SchemaEntry;
+import com.linkedin.venice.schema.SchemaUtils;
+import com.linkedin.venice.schema.rmd.RmdConstants;
+import com.linkedin.venice.schema.writecompute.DerivedSchemaEntry;
+import com.linkedin.venice.schema.writecompute.WriteComputeSchemaConverter;
+import com.linkedin.venice.serializer.avro.MapOrderingPreservingSerDeFactory;
+import com.linkedin.venice.utils.lazy.Lazy;
+import com.linkedin.venice.writer.update.UpdateBuilder;
+import com.linkedin.venice.writer.update.UpdateBuilderImpl;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.util.Utf8;
+import org.testng.Assert;
 import org.testng.annotations.Test;
 
 
+/**
+ * TODO: Use schema that contains map field after Avro Map deserialization issue is resolved.
+ * TODO: Merge with {@link TestMergeUpdateWithValueLevelTimestamp}.
+ */
 public class TestMergeUpdateWithFieldLevelTimestamp extends TestMergeConflictResolver {
   @Test
-  public void testUpdateIgnored() {
-    // TODO
+  public void testUpdateIgnoredFieldUpdate() {
+    final int incomingValueSchemaId = 3;
+    final int incomingWriteComputeSchemaId = 3;
+    final int oldValueSchemaId = 3;
+    // Set up
+    Schema writeComputeSchema = WriteComputeSchemaConverter.getInstance().convertFromValueRecordSchema(personSchemaV2);
+    GenericRecord updateFieldWriteComputeRecord = SchemaUtils.createGenericRecord(writeComputeSchema);
+    updateFieldWriteComputeRecord.put("age", 66);
+    updateFieldWriteComputeRecord.put("name", "Venice");
+    ByteBuffer writeComputeBytes = ByteBuffer.wrap(
+        MapOrderingPreservingSerDeFactory.getSerializer(writeComputeSchema).serialize(updateFieldWriteComputeRecord));
+    final long valueLevelTimestamp = 10L;
+    Map<String, Long> fieldNameToTimestampMap = new HashMap<>();
+    fieldNameToTimestampMap.put("age", 10L);
+    fieldNameToTimestampMap.put("favoritePet", 10L);
+    fieldNameToTimestampMap.put("name", 10L);
+    fieldNameToTimestampMap.put("intArray", 10L);
+    fieldNameToTimestampMap.put("stringArray", 10L);
+
+    GenericRecord rmdRecord = createRmdWithFieldLevelTimestamp(personRmdSchemaV2, fieldNameToTimestampMap);
+    RmdWithValueSchemaId rmdWithValueSchemaId = new RmdWithValueSchemaId(oldValueSchemaId, RMD_VERSION_ID, rmdRecord);
+    ReadOnlySchemaRepository readOnlySchemaRepository = mock(ReadOnlySchemaRepository.class);
+    doReturn(new DerivedSchemaEntry(incomingValueSchemaId, 1, writeComputeSchema)).when(readOnlySchemaRepository)
+        .getDerivedSchema(storeName, incomingValueSchemaId, incomingWriteComputeSchemaId);
+    doReturn(new SchemaEntry(oldValueSchemaId, personSchemaV2)).when(readOnlySchemaRepository)
+        .getValueSchema(storeName, oldValueSchemaId);
+    doReturn(Optional.of(new SchemaEntry(oldValueSchemaId, personSchemaV2))).when(readOnlySchemaRepository)
+        .getSupersetSchema(storeName);
+
+    // Update happens below
+    MergeConflictResolver mergeConflictResolver = MergeConflictResolverFactory.getInstance()
+        .createMergeConflictResolver(
+            readOnlySchemaRepository,
+            new RmdSerDe(readOnlySchemaRepository, storeName, RMD_VERSION_ID),
+            storeName,
+            true);
+    MergeConflictResult mergeConflictResult = mergeConflictResolver.update(
+        Lazy.of(() -> null),
+        Optional.of(rmdWithValueSchemaId),
+        writeComputeBytes,
+        incomingValueSchemaId,
+        incomingWriteComputeSchemaId,
+        valueLevelTimestamp - 1, // Slightly lower than existing timestamp. Thus update should be ignored.
+        1,
+        1,
+        1);
+    Assert.assertEquals(mergeConflictResult, MergeConflictResult.getIgnoredResult());
+    Assert.assertTrue(
+        ((List<?>) rmdRecord.get(RmdConstants.REPLICATION_CHECKPOINT_VECTOR_FIELD)).isEmpty(),
+        "When the Update request is ignored, replication_checkpoint_vector should stay the same (empty).");
   }
 
   @Test
   public void testWholeFieldUpdate() {
-    // TODO
+    final int incomingValueSchemaId = 3;
+    final int incomingWriteComputeSchemaId = 3;
+    final int oldValueSchemaId = 3;
+
+    // Set up old/current value.
+    GenericRecord oldValueRecord = SchemaUtils.createGenericRecord(personSchemaV2);
+    oldValueRecord.put("age", 30);
+    oldValueRecord.put("name", "Kafka");
+    oldValueRecord.put("intArray", Arrays.asList(1, 2, 3));
+    ByteBuffer oldValueBytes =
+        ByteBuffer.wrap(MapOrderingPreservingSerDeFactory.getSerializer(personSchemaV2).serialize(oldValueRecord));
+
+    // Set up Write Compute request.
+    Schema writeComputeSchema = WriteComputeSchemaConverter.getInstance().convertFromValueRecordSchema(personSchemaV2);
+
+    // Set up current replication metadata.
+    final long valueLevelTimestamp = 10L;
+    Map<String, Long> fieldNameToTimestampMap = new HashMap<>();
+    fieldNameToTimestampMap.put("age", valueLevelTimestamp);
+    fieldNameToTimestampMap.put("favoritePet", valueLevelTimestamp);
+    fieldNameToTimestampMap.put("name", valueLevelTimestamp);
+    fieldNameToTimestampMap.put("intArray", valueLevelTimestamp);
+    fieldNameToTimestampMap.put("stringArray", valueLevelTimestamp);
+    GenericRecord rmdRecord = createRmdWithFieldLevelTimestamp(personRmdSchemaV2, fieldNameToTimestampMap);
+    RmdWithValueSchemaId rmdWithValueSchemaId = new RmdWithValueSchemaId(oldValueSchemaId, RMD_VERSION_ID, rmdRecord);
+    ReadOnlySchemaRepository readOnlySchemaRepository = mock(ReadOnlySchemaRepository.class);
+    doReturn(new DerivedSchemaEntry(incomingValueSchemaId, 1, writeComputeSchema)).when(readOnlySchemaRepository)
+        .getDerivedSchema(storeName, incomingValueSchemaId, incomingWriteComputeSchemaId);
+    doReturn(new SchemaEntry(oldValueSchemaId, personSchemaV2)).when(readOnlySchemaRepository)
+        .getValueSchema(storeName, oldValueSchemaId);
+    doReturn(Optional.of(new SchemaEntry(oldValueSchemaId, personSchemaV2))).when(readOnlySchemaRepository)
+        .getSupersetSchema(storeName);
+
+    // Update happens below
+    MergeConflictResolver mergeConflictResolver = MergeConflictResolverFactory.getInstance()
+        .createMergeConflictResolver(
+            readOnlySchemaRepository,
+            new RmdSerDe(readOnlySchemaRepository, storeName, RMD_VERSION_ID),
+            storeName,
+            true);
+
+    GenericRecord updateFieldPartialUpdateRecord1 = SchemaUtils.createGenericRecord(writeComputeSchema);
+    updateFieldPartialUpdateRecord1.put("age", 66);
+    updateFieldPartialUpdateRecord1.put("name", "Venice");
+    updateFieldPartialUpdateRecord1.put("intArray", Arrays.asList(6, 7, 8));
+    ByteBuffer writeComputeBytes1 = ByteBuffer.wrap(
+        MapOrderingPreservingSerDeFactory.getSerializer(writeComputeSchema).serialize(updateFieldPartialUpdateRecord1));
+    MergeConflictResult mergeConflictResult = mergeConflictResolver.update(
+        Lazy.of(() -> oldValueBytes),
+        Optional.of(rmdWithValueSchemaId),
+        writeComputeBytes1,
+        incomingValueSchemaId,
+        incomingWriteComputeSchemaId,
+        valueLevelTimestamp + 1,
+        1,
+        1,
+        1);
+
+    GenericRecord updateFieldPartialUpdateRecord2 = SchemaUtils.createGenericRecord(writeComputeSchema);
+    updateFieldPartialUpdateRecord2.put("intArray", Arrays.asList(10, 20, 30, 40));
+    ByteBuffer writeComputeBytes2 = ByteBuffer.wrap(
+        MapOrderingPreservingSerDeFactory.getSerializer(writeComputeSchema).serialize(updateFieldPartialUpdateRecord2));
+
+    ByteBuffer updatedValueBytes = mergeConflictResult.getNewValue().get();
+    mergeConflictResult = mergeConflictResolver.update(
+        Lazy.of(() -> updatedValueBytes),
+        Optional.of(rmdWithValueSchemaId),
+        writeComputeBytes2,
+        incomingValueSchemaId,
+        incomingWriteComputeSchemaId,
+        valueLevelTimestamp + 2,
+        2,
+        0,
+        0);
+
+    // Validate updated replication metadata.
+    Assert.assertFalse(mergeConflictResult.isUpdateIgnored());
+    GenericRecord updatedRmd = mergeConflictResult.getRmdRecord();
+    Assert.assertEquals(
+        (List<?>) updatedRmd.get(RmdConstants.REPLICATION_CHECKPOINT_VECTOR_FIELD),
+        Arrays.asList(2L, 1L));
+
+    GenericRecord rmdTimestamp = (GenericRecord) updatedRmd.get(RmdConstants.TIMESTAMP_FIELD_NAME);
+    Assert.assertEquals(rmdTimestamp.get("age"), 11L);
+    Assert.assertEquals(rmdTimestamp.get("name"), 11L);
+    GenericRecord collectionFieldTimestampRecord = (GenericRecord) rmdTimestamp.get("intArray");
+    Assert.assertEquals((long) collectionFieldTimestampRecord.get(TOP_LEVEL_TS_FIELD_NAME), 12L);
+    Assert.assertEquals((int) collectionFieldTimestampRecord.get(PUT_ONLY_PART_LENGTH_FIELD_NAME), 4);
+    Assert.assertEquals((int) collectionFieldTimestampRecord.get(TOP_LEVEL_COLO_ID_FIELD_NAME), 0);
+    Assert
+        .assertEquals((List<?>) collectionFieldTimestampRecord.get(ACTIVE_ELEM_TS_FIELD_NAME), Collections.emptyList());
+    Assert.assertEquals((List<?>) collectionFieldTimestampRecord.get(DELETED_ELEM_FIELD_NAME), Collections.emptyList());
+    Assert.assertEquals(
+        (List<?>) collectionFieldTimestampRecord.get(DELETED_ELEM_TS_FIELD_NAME),
+        Collections.emptyList());
+
+    Assert.assertFalse(mergeConflictResult.isUpdateIgnored());
+    Optional<ByteBuffer> newValueOptional = mergeConflictResult.getNewValue();
+    Assert.assertTrue(newValueOptional.isPresent());
+    GenericRecord newValueRecord = getDeserializer(personSchemaV2, personSchemaV2).deserialize(newValueOptional.get());
+    Assert.assertEquals(newValueRecord.get("age").toString(), "66");
+    Assert.assertEquals(newValueRecord.get("name").toString(), "Venice");
+    Assert.assertEquals(newValueRecord.get("intArray"), Arrays.asList(10, 20, 30, 40));
   }
 
   @Test
   public void testCollectionMerge() {
-    // TODO
+    final int incomingValueSchemaId = 3;
+    final int incomingWriteComputeSchemaId = 3;
+    final int oldValueSchemaId = 3;
+
+    // Set up old/current value.
+    GenericRecord oldValueRecord = SchemaUtils.createGenericRecord(personSchemaV1);
+    oldValueRecord.put("age", 30);
+    oldValueRecord.put("name", "Kafka");
+    oldValueRecord.put("intArray", Arrays.asList(1, 2, 3));
+    Map<String, String> stringMap = new LinkedHashMap<>();
+    stringMap.put("1", "one");
+    stringMap.put("2", "two");
+    oldValueRecord.put("stringMap", stringMap);
+    ByteBuffer oldValueBytes =
+        ByteBuffer.wrap(MapOrderingPreservingSerDeFactory.getSerializer(personSchemaV1).serialize(oldValueRecord));
+
+    // Set up Write Compute request.
+    Schema writeComputeSchema = WriteComputeSchemaConverter.getInstance().convertFromValueRecordSchema(personSchemaV1);
+    UpdateBuilder updateBuilder = new UpdateBuilderImpl(writeComputeSchema);
+    updateBuilder.setNewFieldValue("age", 99);
+    updateBuilder.setNewFieldValue("name", "Francisco");
+    // Try to merge/add 3 numbers to the intArray list field.
+    updateBuilder.setElementsToAddToListField("intArray", Arrays.asList(6, 7, 8));
+    GenericRecord updateFieldRecord = updateBuilder.build();
+
+    ByteBuffer writeComputeBytes = ByteBuffer
+        .wrap(MapOrderingPreservingSerDeFactory.getSerializer(writeComputeSchema).serialize(updateFieldRecord));
+
+    // Set up current replication metadata.
+    final long valueLevelTimestamp = 10L;
+    Map<String, Long> fieldNameToTimestampMap = new HashMap<>();
+    fieldNameToTimestampMap.put("age", valueLevelTimestamp);
+    fieldNameToTimestampMap.put("name", valueLevelTimestamp);
+    fieldNameToTimestampMap.put("intArray", valueLevelTimestamp);
+    fieldNameToTimestampMap.put("stringMap", valueLevelTimestamp);
+    Map<String, Integer> fieldNameToExistingPutPartLengthMap = new HashMap<>();
+    fieldNameToExistingPutPartLengthMap.put("intArray", 3);
+    fieldNameToExistingPutPartLengthMap.put("stringMap", 2);
+
+    GenericRecord rmdRecord = createRmdWithFieldLevelTimestamp(
+        personRmdSchemaV1,
+        fieldNameToTimestampMap,
+        fieldNameToExistingPutPartLengthMap);
+    RmdWithValueSchemaId rmdWithValueSchemaId = new RmdWithValueSchemaId(oldValueSchemaId, RMD_VERSION_ID, rmdRecord);
+    ReadOnlySchemaRepository readOnlySchemaRepository = mock(ReadOnlySchemaRepository.class);
+    doReturn(new DerivedSchemaEntry(incomingValueSchemaId, 1, writeComputeSchema)).when(readOnlySchemaRepository)
+        .getDerivedSchema(storeName, incomingValueSchemaId, incomingWriteComputeSchemaId);
+    doReturn(new SchemaEntry(oldValueSchemaId, personSchemaV1)).when(readOnlySchemaRepository)
+        .getValueSchema(storeName, oldValueSchemaId);
+
+    doReturn(Optional.of(new SchemaEntry(oldValueSchemaId, personSchemaV1))).when(readOnlySchemaRepository)
+        .getSupersetSchema(storeName);
+
+    // Update happens below
+    MergeConflictResolver mergeConflictResolver = MergeConflictResolverFactory.getInstance()
+        .createMergeConflictResolver(
+            readOnlySchemaRepository,
+            new RmdSerDe(readOnlySchemaRepository, storeName, RMD_VERSION_ID),
+            storeName,
+            true);
+
+    final int newColoID = 3;
+    MergeConflictResult mergeConflictResult = mergeConflictResolver.update(
+        Lazy.of(() -> oldValueBytes),
+        Optional.of(rmdWithValueSchemaId),
+        writeComputeBytes,
+        incomingValueSchemaId,
+        incomingWriteComputeSchemaId,
+        valueLevelTimestamp + 1, // Slightly higher than existing timestamp. Thus update is NOT ignored.
+        1,
+        1,
+        newColoID);
+
+    // Validate updated replication metadata.
+    Assert.assertNotEquals(mergeConflictResult, MergeConflictResult.getIgnoredResult());
+    GenericRecord updatedRmd = mergeConflictResult.getRmdRecord();
+    Assert.assertEquals(
+        (List<?>) updatedRmd.get(RmdConstants.REPLICATION_CHECKPOINT_VECTOR_FIELD),
+        Arrays.asList(0L, 1L));
+
+    GenericRecord rmdTimestamp = (GenericRecord) updatedRmd.get(RmdConstants.TIMESTAMP_FIELD_NAME);
+    Assert.assertEquals(rmdTimestamp.get("age"), 11L);
+    Assert.assertEquals(rmdTimestamp.get("name"), 11L);
+    GenericRecord collectionFieldTimestampRecord = (GenericRecord) rmdTimestamp.get("intArray");
+    Assert.assertEquals(
+        (long) collectionFieldTimestampRecord.get(TOP_LEVEL_TS_FIELD_NAME),
+        10L,
+        "Collection top-level timestamp does not change because collection merge does not affect top-level timestamp");
+    Assert.assertEquals((int) collectionFieldTimestampRecord.get(PUT_ONLY_PART_LENGTH_FIELD_NAME), 3);
+    Assert.assertEquals(
+        (int) collectionFieldTimestampRecord.get(TOP_LEVEL_COLO_ID_FIELD_NAME),
+        -1,
+        "Collection top-level should NOT be changed by collection merge");
+    Assert.assertEquals(
+        (List<?>) collectionFieldTimestampRecord.get(ACTIVE_ELEM_TS_FIELD_NAME),
+        Arrays.asList(11L, 11L, 11L));
+    Assert.assertEquals((List<?>) collectionFieldTimestampRecord.get(DELETED_ELEM_FIELD_NAME), Collections.emptyList());
+    Assert.assertEquals(
+        (List<?>) collectionFieldTimestampRecord.get(DELETED_ELEM_TS_FIELD_NAME),
+        Collections.emptyList());
+
+    collectionFieldTimestampRecord = (GenericRecord) rmdTimestamp.get("stringMap");
+    Assert.assertEquals((long) collectionFieldTimestampRecord.get(TOP_LEVEL_TS_FIELD_NAME), 10L);
+    Assert.assertEquals((int) collectionFieldTimestampRecord.get(PUT_ONLY_PART_LENGTH_FIELD_NAME), 2);
+    Assert.assertEquals((int) collectionFieldTimestampRecord.get(TOP_LEVEL_COLO_ID_FIELD_NAME), -1);
+    Assert
+        .assertEquals((List<?>) collectionFieldTimestampRecord.get(ACTIVE_ELEM_TS_FIELD_NAME), Collections.emptyList());
+    Assert.assertEquals((List<?>) collectionFieldTimestampRecord.get(DELETED_ELEM_FIELD_NAME), Collections.emptyList());
+    Assert.assertEquals(
+        (List<?>) collectionFieldTimestampRecord.get(DELETED_ELEM_TS_FIELD_NAME),
+        Collections.emptyList());
+
+    // Validate updated value.
+    Assert.assertTrue(mergeConflictResult.getNewValue().isPresent());
+    ByteBuffer updatedValueBytes = mergeConflictResult.getNewValue().get();
+    GenericRecord updatedValueRecord = MapOrderingPreservingSerDeFactory.getDeserializer(personSchemaV1, personSchemaV1)
+        .deserialize(updatedValueBytes.array());
+
+    Assert.assertEquals(updatedValueRecord.get("age"), 99);
+    Assert.assertEquals(updatedValueRecord.get("name").toString(), "Francisco");
+    Assert.assertEquals(
+        updatedValueRecord.get("intArray"),
+        Arrays.asList(1, 2, 3, 6, 7, 8),
+        "After applying collection (list) merge, the list field should contain all integers.");
+    Map<Utf8, Utf8> updatedMapField = (Map<Utf8, Utf8>) updatedValueRecord.get("stringMap");
+    Assert.assertEquals(updatedMapField.size(), 2);
+    Assert.assertEquals(updatedMapField.get(toUtf8("1")), toUtf8("one"));
+    Assert.assertEquals(updatedMapField.get(toUtf8("2")), toUtf8("two"));
   }
 }


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci], [server], [controller],
[router], [samza], [vpj], [fast-client], [thin-client], [alpini],
[admin-tool], [test], [build], [doc], [script]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Add unit tests in TestMergeUpdateWithFieldLevelTimestamp
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Add this unit test to make sure merge update can work with field level timestamp
This PR does not change any behavior, just add 3 unit tests. There is a potential to merge this class with TestMergeUpdateWithValueLevelTimestamp, as most of the operations have large overlaps. I plan to do this after Map DCR String / UTF-8 issue is resolved.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
Local Test

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.