### PR TITLE
[thin-client] Changed the retry strategy of store init

### DIFF
--- a/clients/venice-thin-client/src/test/java/com/linkedin/venice/client/store/AvroGenericStoreClientImplTest.java
+++ b/clients/venice-thin-client/src/test/java/com/linkedin/venice/client/store/AvroGenericStoreClientImplTest.java
@@ -306,13 +306,6 @@ public class AvroGenericStoreClientImplTest {
 
   @Test
   public void getByStoreKeyTestWithNoSchemaAvailable() throws Throwable {
-    /**
-     * Bump up to 20K iterations to reliably trigger a {@link com.linkedin.r2.RemoteInvocationException}
-     *
-     * This only seems to happen with the D2 client. The HTTP client is stable.
-     *
-     * TODO: Fix flaky D2 client.
-     */
     final int TEST_ITERATIONS = 100;
 
     String keyStr = "test_key";


### PR DESCRIPTION
In thin-client, if the store init isn't done in the start method because of the delay start of d2 client, each request could trigger the store init procedure at runtime, and this has introduced some issue in the past especailly when the store isn't in a good state, such as store was deleted/disabled and the 10-time retry triggered by each request will put the application thread pool in a stuck state, and application's fallback logic can't kick in since the Venice call will be blocked by the internal store init procedure.

This code change introduces a change of the retry strategy: If d2 client isn't ready during the start invocation, the store init with retry triggered by the online request will only be executed once, and if the store init fails, all the subsequent requests will receive an exception immediately.

Here are the reasons:
1. Increase the store init success rate at the startup time especially in test env.
2. Don't stuck the application threads when the store isn't in a good state, so that application fallback logic could kick in.

This code change also fixed a flaky test in AvroGenericStoreClientImplTest.


## How was this PR tested?
Internal CI test passed
