### PR TITLE
[venice-common] Upgrade KME with adding new change capture topic switch control message event and cleanups.

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -1211,12 +1211,9 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
       // DaVinci clients don't need to maintain leader production states
       if (!isDaVinciClient) {
         // also update the leader topic offset using the upstream offset in ProducerMetadata
-        if (kafkaValue.producerMetadata.upstreamOffset >= 0
-            || (kafkaValue.leaderMetadataFooter != null && kafkaValue.leaderMetadataFooter.upstreamOffset >= 0)) {
+        if (kafkaValue.leaderMetadataFooter != null && kafkaValue.leaderMetadataFooter.upstreamOffset >= 0) {
           final String sourceKafkaUrl = sourceKafkaUrlSupplier.get();
-          final long newUpstreamOffset = kafkaValue.leaderMetadataFooter == null
-              ? kafkaValue.producerMetadata.upstreamOffset
-              : kafkaValue.leaderMetadataFooter.upstreamOffset;
+          final long newUpstreamOffset = kafkaValue.leaderMetadataFooter.upstreamOffset;
           String upstreamTopicName =
               offsetRecord.getLeaderTopic() != null ? offsetRecord.getLeaderTopic() : kafkaVersionTopic;
           final long previousUpstreamOffset =

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -1211,12 +1211,9 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
       // DaVinci clients don't need to maintain leader production states
       if (!isDaVinciClient) {
         // also update the leader topic offset using the upstream offset in ProducerMetadata
-        if (kafkaValue.producerMetadata.upstreamOffset >= 0
-            || (kafkaValue.leaderMetadataFooter != null && kafkaValue.leaderMetadataFooter.upstreamOffset >= 0)) {
+        if (kafkaValue.leaderMetadataFooter != null && kafkaValue.leaderMetadataFooter.upstreamOffset >= 0) {
           final String sourceKafkaUrl = sourceKafkaUrlSupplier.get();
-          final long newUpstreamOffset = kafkaValue.leaderMetadataFooter == null
-              ? kafkaValue.producerMetadata.upstreamOffset
-              : kafkaValue.leaderMetadataFooter.upstreamOffset;
+          final long newUpstreamOffset = kafkaValue.leaderMetadataFooter.upstreamOffset;
           String upstreamTopicName =
               offsetRecord.getLeaderTopic() != null ? offsetRecord.getLeaderTopic() : kafkaVersionTopic;
           final long previousUpstreamOffset =
@@ -2018,11 +2015,6 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
               producedFinally = false;
             }
             break;
-          case START_OF_BUFFER_REPLAY:
-            // this msg coming here is not possible;
-            throw new VeniceMessageException(
-                consumerTaskId + " hasProducedToKafka: Received SOBR in L/F mode. Topic: " + consumerRecord.topic()
-                    + " Partition " + consumerRecord.partition() + " Offset " + consumerRecord.offset());
           case START_OF_INCREMENTAL_PUSH:
           case END_OF_INCREMENTAL_PUSH:
             // For inc push to RT policy, the control msg is written in RT topic, we will need to calculate the

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -1211,9 +1211,12 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
       // DaVinci clients don't need to maintain leader production states
       if (!isDaVinciClient) {
         // also update the leader topic offset using the upstream offset in ProducerMetadata
-        if (kafkaValue.leaderMetadataFooter != null && kafkaValue.leaderMetadataFooter.upstreamOffset >= 0) {
+        if (kafkaValue.producerMetadata.upstreamOffset >= 0
+            || (kafkaValue.leaderMetadataFooter != null && kafkaValue.leaderMetadataFooter.upstreamOffset >= 0)) {
           final String sourceKafkaUrl = sourceKafkaUrlSupplier.get();
-          final long newUpstreamOffset = kafkaValue.leaderMetadataFooter.upstreamOffset;
+          final long newUpstreamOffset = kafkaValue.leaderMetadataFooter == null
+              ? kafkaValue.producerMetadata.upstreamOffset
+              : kafkaValue.leaderMetadataFooter.upstreamOffset;
           String upstreamTopicName =
               offsetRecord.getLeaderTopic() != null ? offsetRecord.getLeaderTopic() : kafkaVersionTopic;
           final long previousUpstreamOffset =

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -2674,8 +2674,6 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
          * Nothing to do here as all of the processing is being done in {@link StoreIngestionTask#delegateConsumerRecord(ConsumerRecord, int, String)}.
          */
         break;
-      case START_OF_BUFFER_REPLAY:
-        throw new UnsupportedMessageTypeException(type + " is a legacy mechanism that should never happen anymore.");
       case START_OF_INCREMENTAL_PUSH:
         processStartOfIncrementalPush(controlMessage, partitionConsumptionState);
         break;

--- a/internal/venice-common/src/main/java/com/linkedin/venice/kafka/protocol/enums/ControlMessageType.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/kafka/protocol/enums/ControlMessageType.java
@@ -2,8 +2,6 @@ package com.linkedin.venice.kafka.protocol.enums;
 
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.exceptions.VeniceMessageException;
-import com.linkedin.venice.exceptions.validation.UnsupportedMessageTypeException;
-import com.linkedin.venice.kafka.protocol.ChangeCaptureTopicSwitch;
 import com.linkedin.venice.kafka.protocol.ControlMessage;
 import com.linkedin.venice.kafka.protocol.EndOfIncrementalPush;
 import com.linkedin.venice.kafka.protocol.EndOfPush;
@@ -13,6 +11,7 @@ import com.linkedin.venice.kafka.protocol.StartOfIncrementalPush;
 import com.linkedin.venice.kafka.protocol.StartOfPush;
 import com.linkedin.venice.kafka.protocol.StartOfSegment;
 import com.linkedin.venice.kafka.protocol.TopicSwitch;
+import com.linkedin.venice.kafka.protocol.VersionSwap;
 import com.linkedin.venice.utils.EnumUtils;
 import com.linkedin.venice.utils.VeniceEnumValue;
 
@@ -25,9 +24,8 @@ import com.linkedin.venice.utils.VeniceEnumValue;
  *       not support evolution (i.e.: adding values) properly.
  */
 public enum ControlMessageType implements VeniceEnumValue {
-  START_OF_PUSH(0), END_OF_PUSH(1), START_OF_SEGMENT(2), END_OF_SEGMENT(3), @Deprecated
-  START_OF_BUFFER_REPLAY(4), START_OF_INCREMENTAL_PUSH(5), END_OF_INCREMENTAL_PUSH(6), TOPIC_SWITCH(7),
-  CHANGE_CAPTURE_TOPIC_SWITCH(8);
+  START_OF_PUSH(0), END_OF_PUSH(1), START_OF_SEGMENT(2), END_OF_SEGMENT(3), START_OF_INCREMENTAL_PUSH(4),
+  END_OF_INCREMENTAL_PUSH(5), TOPIC_SWITCH(6), VERSION_SWAP(7);
 
   /** The value is the byte used on the wire format */
   private final int value;
@@ -53,7 +51,7 @@ public enum ControlMessageType implements VeniceEnumValue {
    *         - {@link StartOfIncrementalPush}
    *         - {@link EndOfIncrementalPush}
    *         - {@link TopicSwitch}
-   *         - {@link ChangeCaptureTopicSwitch}
+   *         - {@link VersionSwap}
    */
   public Object getNewInstance() {
     switch (valueOf(value)) {
@@ -65,16 +63,14 @@ public enum ControlMessageType implements VeniceEnumValue {
         return new StartOfSegment();
       case END_OF_SEGMENT:
         return new EndOfSegment();
-      case START_OF_BUFFER_REPLAY:
-        throw new UnsupportedMessageTypeException("SOBR is a legacy mechanism that should never be used anymore.");
       case START_OF_INCREMENTAL_PUSH:
         return new StartOfIncrementalPush();
       case END_OF_INCREMENTAL_PUSH:
         return new EndOfIncrementalPush();
       case TOPIC_SWITCH:
         return new TopicSwitch();
-      case CHANGE_CAPTURE_TOPIC_SWITCH:
-        return new ChangeCaptureTopicSwitch();
+      case VERSION_SWAP:
+        return new VersionSwap();
 
       default:
         throw new VeniceException("Unsupported " + getClass().getSimpleName() + " value: " + value);

--- a/internal/venice-common/src/main/java/com/linkedin/venice/kafka/protocol/enums/ControlMessageType.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/kafka/protocol/enums/ControlMessageType.java
@@ -3,6 +3,7 @@ package com.linkedin.venice.kafka.protocol.enums;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.exceptions.VeniceMessageException;
 import com.linkedin.venice.exceptions.validation.UnsupportedMessageTypeException;
+import com.linkedin.venice.kafka.protocol.ChangeCaptureTopicSwitch;
 import com.linkedin.venice.kafka.protocol.ControlMessage;
 import com.linkedin.venice.kafka.protocol.EndOfIncrementalPush;
 import com.linkedin.venice.kafka.protocol.EndOfPush;
@@ -25,7 +26,8 @@ import com.linkedin.venice.utils.VeniceEnumValue;
  */
 public enum ControlMessageType implements VeniceEnumValue {
   START_OF_PUSH(0), END_OF_PUSH(1), START_OF_SEGMENT(2), END_OF_SEGMENT(3), @Deprecated
-  START_OF_BUFFER_REPLAY(4), START_OF_INCREMENTAL_PUSH(5), END_OF_INCREMENTAL_PUSH(6), TOPIC_SWITCH(7);
+  START_OF_BUFFER_REPLAY(4), START_OF_INCREMENTAL_PUSH(5), END_OF_INCREMENTAL_PUSH(6), TOPIC_SWITCH(7),
+  CHANGE_CAPTURE_TOPIC_SWITCH(8);
 
   /** The value is the byte used on the wire format */
   private final int value;
@@ -51,6 +53,7 @@ public enum ControlMessageType implements VeniceEnumValue {
    *         - {@link StartOfIncrementalPush}
    *         - {@link EndOfIncrementalPush}
    *         - {@link TopicSwitch}
+   *         - {@link ChangeCaptureTopicSwitch}
    */
   public Object getNewInstance() {
     switch (valueOf(value)) {
@@ -70,6 +73,8 @@ public enum ControlMessageType implements VeniceEnumValue {
         return new EndOfIncrementalPush();
       case TOPIC_SWITCH:
         return new TopicSwitch();
+      case CHANGE_CAPTURE_TOPIC_SWITCH:
+        return new ChangeCaptureTopicSwitch();
 
       default:
         throw new VeniceException("Unsupported " + getClass().getSimpleName() + " value: " + value);

--- a/internal/venice-common/src/main/java/com/linkedin/venice/kafka/protocol/enums/ControlMessageType.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/kafka/protocol/enums/ControlMessageType.java
@@ -6,7 +6,6 @@ import com.linkedin.venice.kafka.protocol.ControlMessage;
 import com.linkedin.venice.kafka.protocol.EndOfIncrementalPush;
 import com.linkedin.venice.kafka.protocol.EndOfPush;
 import com.linkedin.venice.kafka.protocol.EndOfSegment;
-import com.linkedin.venice.kafka.protocol.StartOfBufferReplay;
 import com.linkedin.venice.kafka.protocol.StartOfIncrementalPush;
 import com.linkedin.venice.kafka.protocol.StartOfPush;
 import com.linkedin.venice.kafka.protocol.StartOfSegment;
@@ -24,8 +23,8 @@ import com.linkedin.venice.utils.VeniceEnumValue;
  *       not support evolution (i.e.: adding values) properly.
  */
 public enum ControlMessageType implements VeniceEnumValue {
-  START_OF_PUSH(0), END_OF_PUSH(1), START_OF_SEGMENT(2), END_OF_SEGMENT(3), START_OF_INCREMENTAL_PUSH(4),
-  END_OF_INCREMENTAL_PUSH(5), TOPIC_SWITCH(6), VERSION_SWAP(7);
+  START_OF_PUSH(0), END_OF_PUSH(1), START_OF_SEGMENT(2), END_OF_SEGMENT(3), @Deprecated
+  START_OF_BUFFER_REPLAY(4), START_OF_INCREMENTAL_PUSH(5), END_OF_INCREMENTAL_PUSH(6), TOPIC_SWITCH(7), VERSION_SWAP(8);
 
   /** The value is the byte used on the wire format */
   private final int value;
@@ -47,7 +46,6 @@ public enum ControlMessageType implements VeniceEnumValue {
    *         - {@link EndOfPush}
    *         - {@link StartOfSegment}
    *         - {@link EndOfSegment}
-   *         - {@link StartOfBufferReplay}
    *         - {@link StartOfIncrementalPush}
    *         - {@link EndOfIncrementalPush}
    *         - {@link TopicSwitch}

--- a/internal/venice-common/src/main/java/com/linkedin/venice/kafka/validation/ProducerTracker.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/kafka/validation/ProducerTracker.java
@@ -720,9 +720,6 @@ public class ProducerTracker {
           .append(
               "; producer timestamp: " + producerMetadata.messageTimestamp + " ("
                   + new Date(producerMetadata.messageTimestamp).toString() + ")");
-      if (producerMetadata.upstreamOffset != -1) {
-        sb.append("; producer metadata's upstream offset: " + producerMetadata.upstreamOffset);
-      }
       if (consumerRecord.value().leaderMetadataFooter != null) {
         sb.append("; leader metadata's upstream offset: " + consumerRecord.value().leaderMetadataFooter.upstreamOffset)
             .append("; leader metadata's host name: " + consumerRecord.value().leaderMetadataFooter.hostName);

--- a/internal/venice-common/src/main/java/com/linkedin/venice/kafka/validation/ProducerTracker.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/kafka/validation/ProducerTracker.java
@@ -720,6 +720,9 @@ public class ProducerTracker {
           .append(
               "; producer timestamp: " + producerMetadata.messageTimestamp + " ("
                   + new Date(producerMetadata.messageTimestamp).toString() + ")");
+      if (producerMetadata.upstreamOffset != -1) {
+        sb.append("; producer metadata's upstream offset: " + producerMetadata.upstreamOffset);
+      }
       if (consumerRecord.value().leaderMetadataFooter != null) {
         sb.append("; leader metadata's upstream offset: " + consumerRecord.value().leaderMetadataFooter.upstreamOffset)
             .append("; leader metadata's host name: " + consumerRecord.value().leaderMetadataFooter.hostName);

--- a/internal/venice-common/src/main/java/com/linkedin/venice/serialization/avro/AvroProtocolDefinition.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/serialization/avro/AvroProtocolDefinition.java
@@ -40,7 +40,7 @@ public enum AvroProtocolDefinition {
   /**
    * Used for the Kafka topics, including the main data topics as well as the admin topic.
    */
-  KAFKA_MESSAGE_ENVELOPE(23, 10, KafkaMessageEnvelope.class),
+  KAFKA_MESSAGE_ENVELOPE(23, 11, KafkaMessageEnvelope.class),
 
   /**
    * Used to persist the state of a partition in Storage Nodes, including offset,

--- a/internal/venice-common/src/main/java/com/linkedin/venice/writer/VeniceWriter.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/writer/VeniceWriter.java
@@ -733,7 +733,6 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
 
     return () -> {
       kafkaMessageEnvelope.leaderMetadataFooter = leaderMetadata;
-      kafkaMessageEnvelope.producerMetadata.upstreamOffset = -1; // This field has been deprecated
       return kafkaMessageEnvelope;
     };
   }
@@ -1481,7 +1480,6 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
       producerMetadata.messageSequenceNumber = currentSegment.getSequenceNumber();
     }
     producerMetadata.messageTimestamp = time.getMilliseconds();
-    producerMetadata.upstreamOffset = -1; // This field has been deprecated
     producerMetadata.logicalTimestamp = logicalTs.orElse(VENICE_DEFAULT_LOGICAL_TS);
     kafkaValue.producerMetadata = producerMetadata;
     kafkaValue.leaderMetadataFooter = new LeaderMetadata();

--- a/internal/venice-common/src/main/java/com/linkedin/venice/writer/VeniceWriter.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/writer/VeniceWriter.java
@@ -733,6 +733,7 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
 
     return () -> {
       kafkaMessageEnvelope.leaderMetadataFooter = leaderMetadata;
+      kafkaMessageEnvelope.producerMetadata.upstreamOffset = -1; // This field has been deprecated
       return kafkaMessageEnvelope;
     };
   }
@@ -1480,6 +1481,7 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
       producerMetadata.messageSequenceNumber = currentSegment.getSequenceNumber();
     }
     producerMetadata.messageTimestamp = time.getMilliseconds();
+    producerMetadata.upstreamOffset = -1; // This field has been deprecated
     producerMetadata.logicalTimestamp = logicalTs.orElse(VENICE_DEFAULT_LOGICAL_TS);
     kafkaValue.producerMetadata = producerMetadata;
     kafkaValue.leaderMetadataFooter = new LeaderMetadata();

--- a/internal/venice-common/src/main/resources/avro/KafkaMessageEnvelope/v11/KafkaMessageEnvelope.avsc
+++ b/internal/venice-common/src/main/resources/avro/KafkaMessageEnvelope/v11/KafkaMessageEnvelope.avsc
@@ -34,8 +34,12 @@
             "name": "messageTimestamp",
             "doc": "The time of the producer's local system clock, at the time the message was submitted for production. This is the number of milliseconds from the unix epoch, 1 January 1970 00:00:00.000 UTC.",
             "type": "long"
-          },
-          {
+          }, {
+            "name": "upstreamOffset",
+            "doc": "this field is deprecated and superseded by the field inside the LeaderMetadata. TODO: Remove this field in the future.",
+            "type": "long",
+            "default": -1
+          }, {
             "name": "logicalTimestamp",
             "doc": "This timestamp may be specified by the user. Sentinel value of -1 => apps are not using latest lib, -2 => apps have not specified the time. In case of negative values messageTimestamp field will be used for replication metadata.",
             "type": "long",
@@ -278,6 +282,16 @@
                         }
                       ],
                       "default": null
+                    }, {
+                      "name": "isRepush",
+                      "doc": "Flag to indicate this version swap is triggered by repush or not.",
+                      "type": "boolean",
+                      "default": false
+                    }, {
+                      "name": "isLastVersionSwapMessageFromRealTimeTopic",
+                      "doc": "Flag to indicate this version swap message in version topic is triggered by the last version swap in real time topic the leader server has received. With this flag, new leader will be able to recover the full state during leadership handover, when we rely on real-time topics for all regions to achieve version swap synchronization.",
+                      "type": "boolean",
+                      "default": false
                     }
                   ]
                 }

--- a/internal/venice-common/src/main/resources/avro/KafkaMessageEnvelope/v11/KafkaMessageEnvelope.avsc
+++ b/internal/venice-common/src/main/resources/avro/KafkaMessageEnvelope/v11/KafkaMessageEnvelope.avsc
@@ -256,7 +256,7 @@
                   ]
                 }, {
                   "name": "VersionSwap",
-                  "doc": "This controlMessage is written to the real-time topic by the controller and to the store-version topic by the leader server. It can be used by the consumer client to switch to another store-version topic and filter messages that have a lower watermark than the one dictated by the leader.",
+                  "doc": "This controlMessage is written to the real-time topic by the controller or to the store-version topic by the current version's leader server. It can be used to let current version and future version synchronize on a specific point for all regions' real-time topics, to guarantee there is only one store version producing to change capture topic all the time. It can also be used by the consumer client to switch to another store-version topic and filter messages that have a lower watermark than the one dictated by the leader.",
                   "type": "record",
                   "fields": [
                     {

--- a/internal/venice-common/src/main/resources/avro/KafkaMessageEnvelope/v11/KafkaMessageEnvelope.avsc
+++ b/internal/venice-common/src/main/resources/avro/KafkaMessageEnvelope/v11/KafkaMessageEnvelope.avsc
@@ -1,0 +1,347 @@
+{
+  "name": "KafkaMessageEnvelope",
+  "namespace": "com.linkedin.venice.kafka.protocol",
+  "type": "record",
+  "fields": [
+    {
+      "name": "messageType",
+      "doc": "Using int because Avro Enums are not evolvable. Readers should always handle the 'unknown' value edge case, to account for future evolutions of this protocol. The mapping is the following: 0 => Put, 1 => Delete, 2 => ControlMessage.",
+      "type": "int"
+    }, {
+      "name": "producerMetadata",
+      "doc": "ProducerMetadata contains information that the consumer can use to identify an upstream producer. This is common for all MessageType.",
+      "type": {
+        "name": "ProducerMetadata",
+        "type": "record",
+        "fields": [
+          {
+            "name": "producerGUID",
+            "doc": "A unique identifier for this producer.",
+            "type": {
+              "name": "GUID",
+              "type": "fixed",
+              "size": 16
+            }
+          }, {
+            "name": "segmentNumber",
+            "doc": "A number used to disambiguate between sequential segments sent into a given partition by a given producer. An incremented SegmentNumber should only be sent following an EndOfSegment control message. For finite streams (such as those bulk-loaded from Hadoop), it can be acceptable to have a single SegmentNumber per producer/partition combination, though that is not something that the downstream consumer should assume. For infinite streams, segments should be terminated and begun anew periodically. This number begins at 0.",
+            "type": "int"
+          }, {
+            "name": "messageSequenceNumber",
+            "doc": "A monotonically increasing number with no gaps used to distinguish unique messages produced in this segment (i.e.: by this producer into a given partition). This number begins at 0 (with a StartOfSegment ControlMessage) and subsequent messages (such as Put) will have a SequenceNumber of 1 and so forth.",
+            "type": "int"
+          }, {
+            "name": "messageTimestamp",
+            "doc": "The time of the producer's local system clock, at the time the message was submitted for production. This is the number of milliseconds from the unix epoch, 1 January 1970 00:00:00.000 UTC.",
+            "type": "long"
+          }, {
+            "name": "upstreamOffset",
+            "doc": "this field is deprecated and superseded by the field inside the LeaderMetadata. TODO: Remove this field in the future.",
+            "type": "long",
+            "default": -1
+          },
+          {
+            "name": "logicalTimestamp",
+            "doc": "This timestamp may be specified by the user. Sentinel value of -1 => apps are not using latest lib, -2 => apps have not specified the time. In case of negative values messageTimestamp field will be used for replication metadata.",
+            "type": "long",
+            "default": -1
+          }
+        ]
+      }
+    }, {
+      "name": "targetVersion",
+      "doc": "This field is used in incremental pushes only - the current version of the target store when the inc push starts.",
+      "type": "int",
+      "default": -1
+    }, {
+      "name": "payloadUnion",
+      "doc": "This contains the main payload of the message. Which branch of the union is present is based on the previously-defined MessageType field.",
+      "type": [
+        {
+          "name": "Put",
+          "doc": "Put payloads contain a record value, and information on how to deserialize it.",
+          "type": "record",
+          "fields": [
+            {
+              "name": "putValue",
+              "doc": "The record's value to be persisted in the storage engine.",
+              "type": "bytes"
+            }, {
+              "name": "schemaId",
+              "doc": "An identifier used to determine how the PutValue can be deserialized. Also used, in conjunction with the replicationMetadataVersionId, to deserialize the replicationMetadataPayload.",
+              "type": "int"
+            }, {
+              "name": "replicationMetadataVersionId",
+              "doc": "The A/A replication metadata schema version ID that will be used to deserialize replicationMetadataPayload.",
+              "type": "int",
+              "default": -1
+            }, {
+              "name": "replicationMetadataPayload",
+              "doc": "The serialized value of the replication metadata schema.",
+              "type": "bytes",
+              "default": ""
+            }
+          ]
+        }, {
+          "name": "Update",
+          "doc": "Partial update operation, which merges the update value with the existing value.",
+          "type": "record",
+          "fields": [
+            {
+              "name": "schemaId",
+              "doc": "The original schema ID.",
+              "type": "int"
+            }, {
+              "name": "updateSchemaId",
+              "doc": "The derived schema ID that will be used to deserialize updateValue.",
+              "type": "int"
+            }, {
+              "name": "updateValue",
+              "doc": "New value(s) for parts of the record that need to be updated.",
+              "type": "bytes"
+            }
+          ]
+        }, {
+          "name": "Delete",
+          "doc": "Delete payloads contain fields related to replication metadata of the record.",
+          "type": "record",
+          "fields": [
+            {
+              "name": "schemaId",
+              "doc": "An identifier used, in conjunction with the replicationMetadataVersionId, to deserialize the replicationMetadataPayload.",
+              "type": "int",
+              "default": -1
+            }, {
+              "name": "replicationMetadataVersionId",
+              "doc": "The A/A replication metadata schema version ID that will be used to deserialize replicationMetadataPayload.",
+              "type": "int",
+              "default": -1
+            }, {
+              "name": "replicationMetadataPayload",
+              "doc": "The serialized value of the replication metadata schema.",
+              "type": "bytes",
+              "default": ""
+            }
+          ]
+        }, {
+          "name": "ControlMessage",
+          "doc": "ControlMessage payloads contain metadata about the stream of data, for validation and debuggability purposes.",
+          "type": "record",
+          "fields": [
+            {
+              "name": "controlMessageType",
+              "doc": "Using int because Avro Enums are not evolvable. Readers should always handle the 'unknown' value edge case, to account for future evolutions of this protocol. The mapping is the following: 0 => StartOfPush, 1 => EndOfPush, 2 => StartOfSegment, 3 => EndOfSegment, 4 => StartOfBufferReplay, 5=> StartOfIncrementalPush, 6=> EndOfIncrementalPush",
+              "type": "int"
+            }, {
+              "name": "debugInfo",
+              "doc": "This metadata is for logging and traceability purposes. It can be used to propagate information about the producer, the environment it runs in, or the source of data being produced into Venice. There should be no assumptions that any of this data will be used (or even looked at) by the downstream consumer in any particular way.",
+              "type": {
+                "type": "map",
+                "values": "string"
+              }
+            }, {
+              "name": "controlMessageUnion",
+              "doc": "This contains the ControlMessage data which is specific to each type of ControlMessage. Which branch of the union is present is based on the previously-defined MessageType field.",
+              "type": [
+                {
+                  "name": "StartOfPush",
+                  "doc": "This ControlMessage is sent once per partition, at the beginning of a bulk load, before any of the data producers come online. This does not contain any data beyond the one which is common to all ControlMessageType.",
+                  "type": "record",
+                  "fields": [
+                    {
+                      "name": "sorted",
+                      "doc": "Whether the messages inside current topic partition between 'StartOfPush' control message and 'EndOfPush' control message is lexicographically sorted by key bytes",
+                      "type": "boolean",
+                      "default": false
+                    }, {
+                      "name": "chunked",
+                      "doc": "Whether the messages inside the current push are encoded with chunking support. If true, this means keys will be prefixed with ChunkId, and values may contain a ChunkedValueManifest (if schema is defined as -20).",
+                      "type": "boolean",
+                      "default": false
+                    }, {
+                      "name": "compressionStrategy",
+                      "doc": "What type of compression strategy the current push uses. Using int because Avro Enums are not evolvable. The mapping is the following: 0 => NO_OP, 1 => GZIP, 2 => ZSTD, 3 => ZSTD_WITH_DICT",
+                      "type": "int",
+                      "default": 0
+                    }, {
+                      "name": "compressionDictionary",
+                      "doc": "The raw bytes of dictionary used to compress/decompress records.",
+                      "type": ["null", "bytes"],
+                      "default": null
+                    }, {
+                      "name": "timestampPolicy",
+                      "doc": "The policy to determine timestamps of batch push records. 0 => no per record replication metadata is stored, hybrid writes always win over batch, 1 => no per record timestamp metadata is stored, Start-Of-Push Control message's logicalTimestamp is treated as last update timestamp for all batch record, and hybrid writes wins only when their own logicalTimestamp are higher, 2 => per record timestamp metadata is provided by the push job and stored for each key, enabling full conflict resolution granularity on a per field basis, just like when merging concurrent update operations.",
+                      "type": "int",
+                      "default": 0
+                    }
+                  ]
+                }, {
+                  "name": "EndOfPush",
+                  "doc": "This ControlMessage is sent once per partition, at the end of a bulk load, after all of the data producers come online. This does not contain any data beyond the one which is common to all ControlMessageType.",
+                  "type": "record",
+                  "fields": []
+                }, {
+                  "name": "StartOfSegment",
+                  "doc": "This ControlMessage is sent at least once per partition per producer. It may be sent more than once per partition/producer, but only after the producer has sent an EndOfSegment into that partition to terminate the previously started segment.",
+                  "type": "record",
+                  "fields": [
+                    {
+                      "name": "checksumType",
+                      "doc": "Using int because Avro Enums are not evolvable. Readers should always handle the 'unknown' value edge case, to account for future evolutions of this protocol. The downstream consumer is expected to compute this checksum and use it to validate the incoming stream of data. The current mapping is the following: 0 => None, 1 => MD5, 2 => Adler32, 3 => CRC32.",
+                      "type": "int"
+                    }, {
+                      "name": "upcomingAggregates",
+                      "doc": "An array of names of aggregate computation strategies for which there will be a value percolated in the corresponding EndOfSegment ControlMessage. The downstream consumer may choose to compute these aggregates on its own and use them as additional validation safeguards, or it may choose to merely log them, or even ignore them altogether.",
+                      "type": {
+                        "type": "array",
+                        "items": "string"
+                      }
+                    }
+                  ]
+                }, {
+                  "name": "EndOfSegment",
+                  "doc": "This ControlMessage is sent at least once per partition per producer. It may be sent more than once per partition/producer, but only after the producer has sent a StartOfSegment into that partition. There should be an equal number of StartOfSegment and EndOfSegment messages in each producer/partition pair.",
+                  "type": "record",
+                  "fields": [
+                    {
+                      "name": "checksumValue",
+                      "doc": "The value of the checksum computed since the last StartOfSegment ControlMessage.",
+                      "type": "bytes"
+                    }, {
+                      "name": "computedAggregates",
+                      "doc": "A map containing the results of the aggregate computation strategies that were promised in the previous StartOfSegment ControlMessage. The downstream consumer may choose to compare the value of these aggregates against those that it computed on its own ir oder to use them as additional validation safeguards, or it may choose to merely log them, or even ignore them altogether.",
+                      "type": {
+                        "type": "array",
+                        "items": "long"
+                      }
+                    }, {
+                      "name": "finalSegment",
+                      "doc": "This field is set to true when the producer knows that there is no more data coming from its data source after this EndOfSegment. This happens at the time the producer is closed.",
+                      "type": "boolean"
+                    }
+                  ]
+                }, {
+                  "name": "StartOfBufferReplay",
+                  "doc": "This ControlMessage is sent by the Controller, once per partition, after the EndOfPush ControlMessage, in Hybrid Stores that ingest from both offline and nearline sources. It contains information about the the offsets from which the Buffer Replay Service started replaying data from the real-time buffer topic onto the store-version topic. This can be used as a synchronization marker between the real-time buffer topic and the store-version topic, akin to how a clapperboard is used to synchronize sound and image in filmmaking. This synchronization marker can in turn be used by the consumer to compute an offset lag.",
+                  "type": "record",
+                  "fields": [
+                    {
+                      "name": "sourceOffsets",
+                      "doc": "Array of offsets from the real-time buffer topic at which the Buffer Replay Service started replaying data. The index position of the array corresponds to the partition number in the real-time buffer.",
+                      "type": {
+                        "type": "array",
+                        "items": "long"
+                      }
+                    }, {
+                      "name": "sourceKafkaCluster",
+                      "doc": "Kafka bootstrap servers URL of the cluster where the source buffer exists.",
+                      "type": "string"
+                    }, {
+                      "name": "sourceTopicName",
+                      "doc": "Name of the source buffer topic.",
+                      "type": "string"
+                    }
+                  ]
+                }, {
+                  "name": "StartOfIncrementalPush",
+                  "doc": "This ControlMessage is sent per partition by each offline incremental push job, once per partition, at the beginning of a incremental push.",
+                  "type": "record",
+                  "fields": [
+                    {
+                      "name": "version",
+                      "doc": "The version of current incremental push. Each incremental push is associated with a version. Both 'StartOfIncrementalPush' control message and 'EndOfIncrementalPush' contain version info so they can be paired to each other.",
+                      "type": "string"
+                    }
+                  ]
+                }, {
+                  "name": "EndOfIncrementalPush",
+                  "doc": "This ControlMessage is sent per partition by each offline incremental push job, once per partition, at the end of a incremental push",
+                  "type": "record",
+                  "fields": [
+                    {
+                      "name": "version",
+                      "doc": "The version of current incremental push. Each incremental push is associated with a version. Both 'StartOfIncrementalPush' control message and 'EndOfIncrementalPush' contain version info so they can be paired to each other.",
+                      "type": "string"
+                    }
+                  ]
+                }, {
+                  "name": "TopicSwitch",
+                  "doc": "This ControlMessage is sent by the Controller, once per partition; it will only be used in leader/follower state transition model; this control message will indicate the leader to switch to a new source topic and start consuming from offset with a specific timestamp.",
+                  "type": "record",
+                  "fields": [
+                    {
+                      "name": "sourceKafkaServers",
+                      "doc": "A list of Kafka bootstrap servers URLs where the new source topic exists; currently there will be only one URL in the list, but the list opens up the possibility for leader to consume from different fabrics in active-active replication mode.",
+                      "type": {
+                        "type": "array",
+                        "items": "string"
+                      }
+                    }, {
+                      "name": "sourceTopicName",
+                      "doc": "Name of new the source topic.",
+                      "type": "string"
+                    }, {
+                      "name": "rewindStartTimestamp",
+                      "doc": "The creation time of this control message in parent controller minus the rewind time of the corresponding store; leaders in different fabrics will get the offset of the source topic by the same start timestamp and start consuming from there; if timestamp is 0, leader will start consuming from the beginning of the source topic.",
+                      "type": "long"
+                    }
+                  ]
+                }, {
+                  "name": "ChangeCaptureTopicSwitch",
+                  "doc": "This ControlMessage is sent by the Controller and Venice Leader Server Node, once per partition; it will only be used in change capture; this control message will indicate change capture consumer client to switch to a new version topic and start consuming from offset higher than the local high watermark prepared by leader.",
+                  "type": "record",
+                  "fields": [
+                    {
+                      "name": "oldServingVersionTopic",
+                      "doc": "Name of the old source topic we are switching from.",
+                      "type": "string"
+                    }, {
+                      "name": "newServingVersionTopic",
+                      "doc": "Name of the new source topic we are switching to.",
+                      "type": "string"
+                    }, {
+                      "name": "localHighWatermarks",
+                      "doc": "The latest offsets of all real-time topic has been consumed up until now.",
+                      "type": {
+                        "type": "array",
+                        "items": "long"
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }, {
+      "name": "leaderMetadataFooter",
+      "doc": "A optional footer that leader SN can use to give extra L/F related mete data",
+      "type": [
+        "null",
+        {
+          "name": "LeaderMetadata",
+          "type": "record",
+          "fields": [
+            {
+              "name": "hostName",
+              "doc": "The identifier of the host which sends the message.This helps detect the 'split brain' scenario in leader SN. Notice that it is different from GUID. GUID represents the one who produces the message. In 'pass-through' mode, the relaying producer will reuse the same GUID from the upstream message.",
+              "type": "string"
+            }, {
+              "name": "upstreamOffset",
+              "doc": "Where this message is located in RT/GF/remote VT topic. This value will be determined and modified by leader SN at runtime.",
+              "type": "long",
+              "default": -1
+            }, {
+              "name": "upstreamKafkaClusterId",
+              "doc": "Kafka bootstrap server URL of the cluster where RT/GF/remote VT topic exists, represented by an integer to reduce the overhead. This value will be determined and modified by leader SN at runtime.",
+              "type": "int",
+              "default": -1
+            }
+          ]
+        }
+      ],
+      "default": null
+    }
+  ]
+}

--- a/internal/venice-common/src/main/resources/avro/KafkaMessageEnvelope/v11/KafkaMessageEnvelope.avsc
+++ b/internal/venice-common/src/main/resources/avro/KafkaMessageEnvelope/v11/KafkaMessageEnvelope.avsc
@@ -302,10 +302,14 @@
                     }, {
                       "name": "localHighWatermarks",
                       "doc": "The latest offsets of all real-time topic has been consumed up until now.",
-                      "type": {
-                        "type": "array",
-                        "items": "long"
-                      }
+                      "type": [
+                        "null",
+                        {
+                          "type": "array",
+                          "items": "long"
+                        }
+                      ],
+                      "default": null
                     }
                   ]
                 }

--- a/internal/venice-common/src/main/resources/avro/KafkaMessageEnvelope/v11/KafkaMessageEnvelope.avsc
+++ b/internal/venice-common/src/main/resources/avro/KafkaMessageEnvelope/v11/KafkaMessageEnvelope.avsc
@@ -35,11 +35,6 @@
             "doc": "The time of the producer's local system clock, at the time the message was submitted for production. This is the number of milliseconds from the unix epoch, 1 January 1970 00:00:00.000 UTC.",
             "type": "long"
           }, {
-            "name": "upstreamOffset",
-            "doc": "this field is deprecated and superseded by the field inside the LeaderMetadata. TODO: Remove this field in the future.",
-            "type": "long",
-            "default": -1
-          }, {
             "name": "logicalTimestamp",
             "doc": "This timestamp may be specified by the user. Sentinel value of -1 => apps are not using latest lib, -2 => apps have not specified the time. In case of negative values messageTimestamp field will be used for replication metadata.",
             "type": "long",

--- a/internal/venice-common/src/main/resources/avro/KafkaMessageEnvelope/v11/KafkaMessageEnvelope.avsc
+++ b/internal/venice-common/src/main/resources/avro/KafkaMessageEnvelope/v11/KafkaMessageEnvelope.avsc
@@ -5,7 +5,7 @@
   "fields": [
     {
       "name": "messageType",
-      "doc": "Using int because Avro Enums are not evolvable. Readers should always handle the 'unknown' value edge case, to account for future evolutions of this protocol. The mapping is the following: 0 => Put, 1 => Delete, 2 => ControlMessage.",
+      "doc": "Using int because Avro Enums are not evolvable. Readers should always handle the 'unknown' value edge case, to account for future evolutions of this protocol. The mapping is the following: 0 => Put, 1 => Delete, 2 => ControlMessage, 3 => Update.",
       "type": "int"
     }, {
       "name": "producerMetadata",
@@ -34,11 +34,6 @@
             "name": "messageTimestamp",
             "doc": "The time of the producer's local system clock, at the time the message was submitted for production. This is the number of milliseconds from the unix epoch, 1 January 1970 00:00:00.000 UTC.",
             "type": "long"
-          }, {
-            "name": "upstreamOffset",
-            "doc": "this field is deprecated and superseded by the field inside the LeaderMetadata. TODO: Remove this field in the future.",
-            "type": "long",
-            "default": -1
           },
           {
             "name": "logicalTimestamp",
@@ -48,11 +43,6 @@
           }
         ]
       }
-    }, {
-      "name": "targetVersion",
-      "doc": "This field is used in incremental pushes only - the current version of the target store when the inc push starts.",
-      "type": "int",
-      "default": -1
     }, {
       "name": "payloadUnion",
       "doc": "This contains the main payload of the message. Which branch of the union is present is based on the previously-defined MessageType field.",
@@ -130,7 +120,7 @@
           "fields": [
             {
               "name": "controlMessageType",
-              "doc": "Using int because Avro Enums are not evolvable. Readers should always handle the 'unknown' value edge case, to account for future evolutions of this protocol. The mapping is the following: 0 => StartOfPush, 1 => EndOfPush, 2 => StartOfSegment, 3 => EndOfSegment, 4 => StartOfBufferReplay, 5=> StartOfIncrementalPush, 6=> EndOfIncrementalPush",
+              "doc": "Using int because Avro Enums are not evolvable. Readers should always handle the 'unknown' value edge case, to account for future evolutions of this protocol. The mapping is the following: 0 => StartOfPush, 1 => EndOfPush, 2 => StartOfSegment, 3 => EndOfSegment, 4 => StartOfIncrementalPush, 5 => EndOfIncrementalPush, 6 => TopicSwitch, 7 => VersionSwap",
               "type": "int"
             }, {
               "name": "debugInfo",
@@ -221,28 +211,6 @@
                     }
                   ]
                 }, {
-                  "name": "StartOfBufferReplay",
-                  "doc": "This ControlMessage is sent by the Controller, once per partition, after the EndOfPush ControlMessage, in Hybrid Stores that ingest from both offline and nearline sources. It contains information about the the offsets from which the Buffer Replay Service started replaying data from the real-time buffer topic onto the store-version topic. This can be used as a synchronization marker between the real-time buffer topic and the store-version topic, akin to how a clapperboard is used to synchronize sound and image in filmmaking. This synchronization marker can in turn be used by the consumer to compute an offset lag.",
-                  "type": "record",
-                  "fields": [
-                    {
-                      "name": "sourceOffsets",
-                      "doc": "Array of offsets from the real-time buffer topic at which the Buffer Replay Service started replaying data. The index position of the array corresponds to the partition number in the real-time buffer.",
-                      "type": {
-                        "type": "array",
-                        "items": "long"
-                      }
-                    }, {
-                      "name": "sourceKafkaCluster",
-                      "doc": "Kafka bootstrap servers URL of the cluster where the source buffer exists.",
-                      "type": "string"
-                    }, {
-                      "name": "sourceTopicName",
-                      "doc": "Name of the source buffer topic.",
-                      "type": "string"
-                    }
-                  ]
-                }, {
                   "name": "StartOfIncrementalPush",
                   "doc": "This ControlMessage is sent per partition by each offline incremental push job, once per partition, at the beginning of a incremental push.",
                   "type": "record",
@@ -287,8 +255,8 @@
                     }
                   ]
                 }, {
-                  "name": "ChangeCaptureTopicSwitch",
-                  "doc": "This ControlMessage is sent by the Controller and Venice Leader Server Node, once per partition; it will only be used in change capture; this control message will indicate change capture consumer client to switch to a new version topic and start consuming from offset higher than the local high watermark prepared by leader.",
+                  "name": "VersionSwap",
+                  "doc": "This controlMessage is written to the real-time topic by the controller and to the store-version topic by the leader server. It can be used by the consumer client to switch to another store-version topic and filter messages that have a lower watermark than the one dictated by the leader.",
                   "type": "record",
                   "fields": [
                     {

--- a/internal/venice-common/src/main/resources/avro/KafkaMessageEnvelope/v11/KafkaMessageEnvelope.avsc
+++ b/internal/venice-common/src/main/resources/avro/KafkaMessageEnvelope/v11/KafkaMessageEnvelope.avsc
@@ -120,7 +120,7 @@
           "fields": [
             {
               "name": "controlMessageType",
-              "doc": "Using int because Avro Enums are not evolvable. Readers should always handle the 'unknown' value edge case, to account for future evolutions of this protocol. The mapping is the following: 0 => StartOfPush, 1 => EndOfPush, 2 => StartOfSegment, 3 => EndOfSegment, 4 => StartOfIncrementalPush, 5 => EndOfIncrementalPush, 6 => TopicSwitch, 7 => VersionSwap",
+              "doc": "Using int because Avro Enums are not evolvable. Readers should always handle the 'unknown' value edge case, to account for future evolutions of this protocol. The mapping is the following: 0 => StartOfPush, 1 => EndOfPush, 2 => StartOfSegment, 3 => EndOfSegment, 5 => StartOfIncrementalPush, 6 => EndOfIncrementalPush, 7 => TopicSwitch, 8 => VersionSwap",
               "type": "int"
             }, {
               "name": "debugInfo",

--- a/internal/venice-common/src/test/java/com/linkedin/venice/kafka/protocol/enums/ControlMessageTypeTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/kafka/protocol/enums/ControlMessageTypeTest.java
@@ -22,9 +22,9 @@ public class ControlMessageTypeTest {
     Assert.assertEquals(ControlMessageType.valueOf(1), END_OF_PUSH, assertionErrorMessage);
     Assert.assertEquals(ControlMessageType.valueOf(2), START_OF_SEGMENT, assertionErrorMessage);
     Assert.assertEquals(ControlMessageType.valueOf(3), END_OF_SEGMENT, assertionErrorMessage);
-    Assert.assertEquals(ControlMessageType.valueOf(4), START_OF_INCREMENTAL_PUSH, assertionErrorMessage);
-    Assert.assertEquals(ControlMessageType.valueOf(5), END_OF_INCREMENTAL_PUSH, assertionErrorMessage);
-    Assert.assertEquals(ControlMessageType.valueOf(6), TOPIC_SWITCH, assertionErrorMessage);
-    Assert.assertEquals(ControlMessageType.valueOf(7), VERSION_SWAP, assertionErrorMessage);
+    Assert.assertEquals(ControlMessageType.valueOf(5), START_OF_INCREMENTAL_PUSH, assertionErrorMessage);
+    Assert.assertEquals(ControlMessageType.valueOf(6), END_OF_INCREMENTAL_PUSH, assertionErrorMessage);
+    Assert.assertEquals(ControlMessageType.valueOf(7), TOPIC_SWITCH, assertionErrorMessage);
+    Assert.assertEquals(ControlMessageType.valueOf(8), VERSION_SWAP, assertionErrorMessage);
   }
 }

--- a/internal/venice-common/src/test/java/com/linkedin/venice/kafka/protocol/enums/ControlMessageTypeTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/kafka/protocol/enums/ControlMessageTypeTest.java
@@ -3,11 +3,11 @@ package com.linkedin.venice.kafka.protocol.enums;
 import static com.linkedin.venice.kafka.protocol.enums.ControlMessageType.END_OF_INCREMENTAL_PUSH;
 import static com.linkedin.venice.kafka.protocol.enums.ControlMessageType.END_OF_PUSH;
 import static com.linkedin.venice.kafka.protocol.enums.ControlMessageType.END_OF_SEGMENT;
-import static com.linkedin.venice.kafka.protocol.enums.ControlMessageType.START_OF_BUFFER_REPLAY;
 import static com.linkedin.venice.kafka.protocol.enums.ControlMessageType.START_OF_INCREMENTAL_PUSH;
 import static com.linkedin.venice.kafka.protocol.enums.ControlMessageType.START_OF_PUSH;
 import static com.linkedin.venice.kafka.protocol.enums.ControlMessageType.START_OF_SEGMENT;
 import static com.linkedin.venice.kafka.protocol.enums.ControlMessageType.TOPIC_SWITCH;
+import static com.linkedin.venice.kafka.protocol.enums.ControlMessageType.VERSION_SWAP;
 
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -22,9 +22,9 @@ public class ControlMessageTypeTest {
     Assert.assertEquals(ControlMessageType.valueOf(1), END_OF_PUSH, assertionErrorMessage);
     Assert.assertEquals(ControlMessageType.valueOf(2), START_OF_SEGMENT, assertionErrorMessage);
     Assert.assertEquals(ControlMessageType.valueOf(3), END_OF_SEGMENT, assertionErrorMessage);
-    Assert.assertEquals(ControlMessageType.valueOf(4), START_OF_BUFFER_REPLAY, assertionErrorMessage);
-    Assert.assertEquals(ControlMessageType.valueOf(5), START_OF_INCREMENTAL_PUSH, assertionErrorMessage);
-    Assert.assertEquals(ControlMessageType.valueOf(6), END_OF_INCREMENTAL_PUSH, assertionErrorMessage);
-    Assert.assertEquals(ControlMessageType.valueOf(7), TOPIC_SWITCH, assertionErrorMessage);
+    Assert.assertEquals(ControlMessageType.valueOf(4), START_OF_INCREMENTAL_PUSH, assertionErrorMessage);
+    Assert.assertEquals(ControlMessageType.valueOf(5), END_OF_INCREMENTAL_PUSH, assertionErrorMessage);
+    Assert.assertEquals(ControlMessageType.valueOf(6), TOPIC_SWITCH, assertionErrorMessage);
+    Assert.assertEquals(ControlMessageType.valueOf(7), VERSION_SWAP, assertionErrorMessage);
   }
 }

--- a/internal/venice-consumer/src/test/java/com/linkedin/venice/consumer/ConsumerTest.java
+++ b/internal/venice-consumer/src/test/java/com/linkedin/venice/consumer/ConsumerTest.java
@@ -108,7 +108,6 @@ public class ConsumerTest {
     producerMetadata.messageSequenceNumber = 0;
     messageFromNewProtocol.put(PRODUCER_METADATA_FIELD, producerMetadata);
     messageFromNewProtocol.put(MESSAGE_TYPE_FIELD, MessageType.PUT.getValue());
-    messageFromNewProtocol.put(TARGET_VERSION_FIELD, -1);
     Put put = new Put();
     put.schemaId = 1;
     put.putValue = ByteBuffer.allocate(1);

--- a/internal/venice-consumer/src/test/java/com/linkedin/venice/kafka/validation/KafkaDataIntegrityValidatorTest.java
+++ b/internal/venice-consumer/src/test/java/com/linkedin/venice/kafka/validation/KafkaDataIntegrityValidatorTest.java
@@ -140,6 +140,7 @@ public class KafkaDataIntegrityValidatorTest {
     producerMetadata.segmentNumber = currentSegment.getSegmentNumber();
     producerMetadata.messageSequenceNumber = currentSegment.getSequenceNumber();
     producerMetadata.messageTimestamp = brokerTimestamp;
+    producerMetadata.upstreamOffset = -1; // This field has been deprecated
     messageEnvelope.producerMetadata = producerMetadata;
     messageEnvelope.leaderMetadataFooter = new LeaderMetadata();
     messageEnvelope.leaderMetadataFooter.upstreamOffset = -1;

--- a/internal/venice-consumer/src/test/java/com/linkedin/venice/kafka/validation/KafkaDataIntegrityValidatorTest.java
+++ b/internal/venice-consumer/src/test/java/com/linkedin/venice/kafka/validation/KafkaDataIntegrityValidatorTest.java
@@ -140,7 +140,6 @@ public class KafkaDataIntegrityValidatorTest {
     producerMetadata.segmentNumber = currentSegment.getSegmentNumber();
     producerMetadata.messageSequenceNumber = currentSegment.getSequenceNumber();
     producerMetadata.messageTimestamp = brokerTimestamp;
-    producerMetadata.upstreamOffset = -1; // This field has been deprecated
     messageEnvelope.producerMetadata = producerMetadata;
     messageEnvelope.leaderMetadataFooter = new LeaderMetadata();
     messageEnvelope.leaderMetadataFooter.upstreamOffset = -1;

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestHybrid.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestHybrid.java
@@ -1735,7 +1735,6 @@ public class TestHybrid {
     producerMetadata.segmentNumber = segmentNumber;
     producerMetadata.messageSequenceNumber = sequenceNumber;
     producerMetadata.messageTimestamp = System.currentTimeMillis();
-    producerMetadata.upstreamOffset = -1; // This field has been deprecated
     kafkaValue.producerMetadata = producerMetadata;
     kafkaValue.leaderMetadataFooter = new LeaderMetadata();
     kafkaValue.leaderMetadataFooter.upstreamOffset = upstreamOffset;

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestHybrid.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestHybrid.java
@@ -1735,6 +1735,7 @@ public class TestHybrid {
     producerMetadata.segmentNumber = segmentNumber;
     producerMetadata.messageSequenceNumber = sequenceNumber;
     producerMetadata.messageTimestamp = System.currentTimeMillis();
+    producerMetadata.upstreamOffset = -1; // This field has been deprecated
     kafkaValue.producerMetadata = producerMetadata;
     kafkaValue.leaderMetadataFooter = new LeaderMetadata();
     kafkaValue.leaderMetadataFooter.upstreamOffset = upstreamOffset;


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci], [server], [controller],
[router], [samza], [vpj], [fast-client], [thin-client], [alpini],
[admin-tool], [test], [build], [doc], [script]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

This change add a new control message that will be consumed by the Venice consumer client and the Venice leader. 

It is initially emitted by the controller to a local RT and consumed by a venice leader. The message should contain BOTH the source version (the version we're switching FROM) and the destination version (the version we're switching TO). 
When a leader node sees this message on the RT, it produces the message to it's VT by adding its local real-time topic high watermark, indicating the latest offsets of all RT's that it's consumed up until now. We also add two flags into this control message: 
     1. Whether this version push is triggered by repush.
     2. Whether this version swap message in VT is triggered by the last RT's message the leader server has read. 

Besides, we bundled some cleanups for KME. 

<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- [x] Yes. Test with CI. 
## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.