### PR TITLE
[controller][test] Add 2 new version status without writing them in ZK yet

### DIFF
--- a/docs/dev_guide/recommended_development_workflow.md
+++ b/docs/dev_guide/recommended_development_workflow.md
@@ -24,7 +24,8 @@ The GitHub issue should contain the detailed problem statement.
 6. The PR title should usually be of the form `[component1]...[componentN]: Concise commit message`.
    * Valid component tags are: `[da-vinci]`, `[server]`, `[controller]`,
       `[router]`, `[samza]`, `[vpj]`, `[fast-client]`, `[thin-client]`, `[alpini]`,
-      `[admin-tool]`, `[test]`, `[build]`, `[doc]`, `[script]`
+      `[admin-tool]`, `[test]`, `[build]`, `[doc]`, `[script]`, `[compat]`
+   * `[compat]` tag means there are compatibility related changes in this PR, including upgrading protocol version, upgrading system store value schemas, etc. When there is a compatibility related change, it usually requires a specific deployment order, like upgrading controller before upgrading server. In this case, please explicitly call out the required deployment order in the commit message.
 7. If the pull request is still a work in progress, and so is not ready to be merged, but needs to be pushed to GitHub to facilitate review,
     then create the PR as a [draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests) PR
    * If the PR cannot be created as a [draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests) PR,

--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/AbstractStore.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/AbstractStore.java
@@ -230,20 +230,6 @@ public abstract class AbstractStore implements Store {
     throw new VeniceException("Version:" + versionNumber + " does not exist");
   }
 
-  /**
-   * Use the form of this method that accepts a pushJobId
-   */
-  @Deprecated
-  @Override
-  public Version increaseVersion() {
-    return increaseVersion(Version.guidBasedDummyPushId(), true);
-  }
-
-  @Override
-  public Version increaseVersion(String pushJobId) {
-    return increaseVersion(pushJobId, true);
-  }
-
   @Override
   public Version peekNextVersion() {
     return increaseVersion(Version.guidBasedDummyPushId(), false);
@@ -265,7 +251,7 @@ public abstract class AbstractStore implements Store {
   public VersionStatus getVersionStatus(int versionNumber) {
     Optional<Version> version = getVersion(versionNumber);
     if (!version.isPresent()) {
-      return VersionStatus.ERROR.NOT_CREATED;
+      return VersionStatus.NOT_CREATED;
     }
 
     return version.get().getStatus();

--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/ReadOnlyStore.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/ReadOnlyStore.java
@@ -1214,16 +1214,6 @@ public class ReadOnlyStore implements Store {
   }
 
   @Override
-  public Version increaseVersion() {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
-  public Version increaseVersion(String pushJobId) {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
   public Version peekNextVersion() {
     return this.delegate.peekNextVersion();
   }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/Store.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/Store.java
@@ -348,14 +348,6 @@ public interface Store {
 
   void updateVersionStatus(int versionNumber, VersionStatus status);
 
-  /**
-   * Use the form of this method that accepts a pushJobId
-   */
-  @Deprecated
-  Version increaseVersion();
-
-  Version increaseVersion(String pushJobId);
-
   Version peekNextVersion();
 
   Optional<Version> getVersion(int versionNumber);

--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/VersionStatus.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/VersionStatus.java
@@ -15,7 +15,12 @@ public enum VersionStatus {
   // serve read request because the writes to this store is disabled.
   PUSHED(2),
   // Version has been pushed to venice and is ready to serve read request.
-  ONLINE(3), ERROR(4);
+  ONLINE(3), ERROR(4),
+  // Version is created and persisted inside ZK, but controller hasn't finished preparation works yet.
+  CREATED(5),
+  // Version has been pushed to Venice and is ready to serve in some regions, but failed in other regions.
+  // This version status only exists in parent.
+  PARTIALLY_ONLINE(6);
 
   private final int value;
 

--- a/internal/venice-common/src/test/java/com/linkedin/venice/helix/TestHelixReadOnlyStorageEngineRepository.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/helix/TestHelixReadOnlyStorageEngineRepository.java
@@ -7,6 +7,7 @@ import com.linkedin.venice.integration.utils.ServiceFactory;
 import com.linkedin.venice.integration.utils.ZkServerWrapper;
 import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.StoreDataChangedListener;
+import com.linkedin.venice.meta.VersionImpl;
 import com.linkedin.venice.utils.TestUtils;
 import com.linkedin.venice.utils.Utils;
 import com.linkedin.venice.utils.locks.ClusterLockManager;
@@ -70,7 +71,7 @@ public class TestHelixReadOnlyStorageEngineRepository {
   public void testGetStore() throws InterruptedException {
     // Add and get notificaiton
     Store s1 = TestUtils.createTestStore("s1", "owner", System.currentTimeMillis());
-    s1.increaseVersion();
+    s1.addVersion(new VersionImpl("s1", 1, "pushJobId"));
     s1.setReadQuotaInCU(100);
     writeRepo.addStore(s1);
     Thread.sleep(1000L);
@@ -86,7 +87,7 @@ public class TestHelixReadOnlyStorageEngineRepository {
 
     // Update and get notification
     Store s2 = writeRepo.getStore(s1.getName());
-    s2.increaseVersion();
+    s2.addVersion(new VersionImpl(s2.getName(), s2.getLargestUsedVersionNumber() + 1, "pushJobId2"));
     writeRepo.updateStore(s2);
     Thread.sleep(1000L);
     Assert.assertEquals(
@@ -106,7 +107,7 @@ public class TestHelixReadOnlyStorageEngineRepository {
     Store[] stores = new Store[count];
     for (int i = 0; i < count; i++) {
       Store s = TestUtils.createTestStore("s" + i, "owner", System.currentTimeMillis());
-      s.increaseVersion();
+      s.addVersion(new VersionImpl(s.getName(), s.getLargestUsedVersionNumber() + 1, "pushJobId"));
       s.setReadQuotaInCU(i + 1);
       writeRepo.addStore(s);
       stores[i] = s;

--- a/internal/venice-common/src/test/java/com/linkedin/venice/helix/TestHelixReadOnlyStoreRepositoryAdapter.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/helix/TestHelixReadOnlyStoreRepositoryAdapter.java
@@ -17,6 +17,7 @@ import com.linkedin.venice.meta.BackupStrategy;
 import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.StoreDataChangedListener;
 import com.linkedin.venice.meta.SystemStore;
+import com.linkedin.venice.meta.VersionImpl;
 import com.linkedin.venice.utils.TestUtils;
 import com.linkedin.venice.utils.Utils;
 import com.linkedin.venice.utils.locks.ClusterLockManager;
@@ -87,7 +88,8 @@ public class TestHelixReadOnlyStoreRepositoryAdapter {
     // Create one regular store
     regularStoreName = Utils.getUniqueString("test_store");
     Store s1 = TestUtils.createTestStore(regularStoreName, "owner", System.currentTimeMillis());
-    s1.increaseVersion();
+    s1.addVersion(new VersionImpl(s1.getName(), s1.getLargestUsedVersionNumber() + 1, "pushJobId"));
+    s1.setReadQuotaInCU(100);
     s1.setReadQuotaInCU(100);
     s1.setBatchGetLimit(100);
     s1.setReadComputationEnabled(true);
@@ -96,7 +98,7 @@ public class TestHelixReadOnlyStoreRepositoryAdapter {
     regularStoreNameWithMetaSystemStoreEnabled = Utils.getUniqueString("test_store_with_meta_system_store_enabled");
     Store s2 =
         TestUtils.createTestStore(regularStoreNameWithMetaSystemStoreEnabled, "owner", System.currentTimeMillis());
-    s2.increaseVersion();
+    s2.addVersion(new VersionImpl(s2.getName(), s2.getLargestUsedVersionNumber() + 1, "pushJobId"));
     s2.setReadQuotaInCU(100);
     s2.setBatchGetLimit(100);
     s2.setReadComputationEnabled(true);

--- a/internal/venice-common/src/test/java/com/linkedin/venice/helix/TestHelixReadOnlyZKSharedSystemStoreRepository.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/helix/TestHelixReadOnlyZKSharedSystemStoreRepository.java
@@ -14,6 +14,7 @@ import com.linkedin.venice.meta.BufferReplayPolicy;
 import com.linkedin.venice.meta.DataReplicationPolicy;
 import com.linkedin.venice.meta.HybridStoreConfigImpl;
 import com.linkedin.venice.meta.Store;
+import com.linkedin.venice.meta.VersionImpl;
 import com.linkedin.venice.utils.TestUtils;
 import com.linkedin.venice.utils.Utils;
 import com.linkedin.venice.utils.locks.ClusterLockManager;
@@ -71,7 +72,7 @@ public class TestHelixReadOnlyZKSharedSystemStoreRepository {
     // Create one regular store
     regularStoreName = Utils.getUniqueString("test_store");
     Store s1 = TestUtils.createTestStore(regularStoreName, "owner", System.currentTimeMillis());
-    s1.increaseVersion();
+    s1.addVersion(new VersionImpl(s1.getName(), s1.getLargestUsedVersionNumber() + 1, "pushJobId"));
     s1.setReadQuotaInCU(100);
     writeRepo.addStore(s1);
   }

--- a/internal/venice-common/src/test/java/com/linkedin/venice/helix/TestHelixReadWriteStorageEngineRepository.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/helix/TestHelixReadWriteStorageEngineRepository.java
@@ -60,7 +60,7 @@ public class TestHelixReadWriteStorageEngineRepository {
   public void testAddAndReadStore() {
     repo.refresh();
     Store s1 = TestUtils.createTestStore("s1", "owner", System.currentTimeMillis());
-    s1.increaseVersion();
+    s1.addVersion(new VersionImpl(s1.getName(), s1.getLargestUsedVersionNumber() + 1, "pushJobId"));
     repo.addStore(s1);
     Store s2 = repo.getStore("s1");
     Assert.assertEquals(s2, s1, "Store was not added successfully");
@@ -77,10 +77,10 @@ public class TestHelixReadWriteStorageEngineRepository {
   @Test
   public void testUpdateAndReadStore() {
     Store s1 = TestUtils.createTestStore("s1", "owner", System.currentTimeMillis());
-    s1.increaseVersion();
+    s1.addVersion(new VersionImpl(s1.getName(), s1.getLargestUsedVersionNumber() + 1, "pushJobId"));
     repo.addStore(s1);
     Store s2 = repo.getStore(s1.getName());
-    s2.increaseVersion();
+    s2.addVersion(new VersionImpl(s2.getName(), s2.getLargestUsedVersionNumber() + 1, "pushJobId2"));
     repo.updateStore(s2);
     Store s3 = repo.getStore(s2.getName());
     Assert.assertEquals(s3, s2, "Store was not updated successfully.");
@@ -90,7 +90,7 @@ public class TestHelixReadWriteStorageEngineRepository {
   public void testLoadFromZK() {
     repo.refresh();
     Store s1 = TestUtils.createTestStore("s1", "owner", System.currentTimeMillis());
-    s1.increaseVersion();
+    s1.addVersion(new VersionImpl(s1.getName(), s1.getLargestUsedVersionNumber() + 1, "pushJobId"));
     s1.setReadQuotaInCU(100);
     repo.addStore(s1);
     Store s2 = TestUtils.createTestStore("s2", "owner", System.currentTimeMillis());

--- a/internal/venice-common/src/test/java/com/linkedin/venice/helix/TestHelixReadWriteStoreRepositoryAdapter.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/helix/TestHelixReadWriteStoreRepositoryAdapter.java
@@ -74,7 +74,7 @@ public class TestHelixReadWriteStoreRepositoryAdapter {
     // Create one regular store
     regularStoreName = Utils.getUniqueString("test_store");
     Store s1 = TestUtils.createTestStore(regularStoreName, "owner", System.currentTimeMillis());
-    s1.increaseVersion();
+    s1.addVersion(new VersionImpl(s1.getName(), s1.getLargestUsedVersionNumber() + 1, "pushJobId"));
     s1.setReadQuotaInCU(100);
     s1.setBatchGetLimit(100);
     s1.setReadComputationEnabled(true);

--- a/internal/venice-common/src/test/java/com/linkedin/venice/helix/TestStoreJsonSerializer.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/helix/TestStoreJsonSerializer.java
@@ -27,7 +27,7 @@ public class TestStoreJsonSerializer {
   @Test
   public void testSerializeAndDeserializeStore() throws IOException {
     Store store = TestUtils.createTestStore("s1", "owner", 1l);
-    store.increaseVersion();
+    store.addVersion(new VersionImpl(store.getName(), store.getLargestUsedVersionNumber() + 1, "pushJobId"));
     HybridStoreConfig hybridStoreConfig = new HybridStoreConfigImpl(
         1000,
         1000,
@@ -90,7 +90,7 @@ public class TestStoreJsonSerializer {
   @Test
   public void testDeserializeStoreWithUnknownField() throws IOException {
     Store store = TestUtils.createTestStore("s1", "owner", 1l);
-    store.increaseVersion();
+    store.addVersion(new VersionImpl(store.getName(), store.getLargestUsedVersionNumber() + 1, "pushJobId"));
     store.setReadQuotaInCU(100);
     StoreJSONSerializer serializer = new StoreJSONSerializer();
     byte[] data = serializer.serialize(store, "");
@@ -104,7 +104,7 @@ public class TestStoreJsonSerializer {
   @Test
   public void testDeserializeDisabledStore() throws IOException {
     Store store = TestUtils.createTestStore("s1", "owner", 1l);
-    store.increaseVersion();
+    store.addVersion(new VersionImpl(store.getName(), store.getLargestUsedVersionNumber() + 1, "pushJobId"));
     store.setEnableReads(false);
     store.setEnableWrites(false);
     store.setReadQuotaInCU(100);

--- a/internal/venice-common/src/test/java/com/linkedin/venice/meta/TestZKStore.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/meta/TestZKStore.java
@@ -71,7 +71,7 @@ public class TestZKStore {
     Assert.assertEquals(s.peekNextVersion().getNumber(), 1, "clone should peek at biggest used version plus 1");
 
     Store s2 = TestUtils.createTestStore("s2", "owner", System.currentTimeMillis());
-    s2.increaseVersion();
+    s2.addVersion(new VersionImpl(s2.getName(), s2.getLargestUsedVersionNumber() + 1, "pushJobId"));
     Store s2clone = s2.cloneStore();
     Assert.assertEquals(s2, s2clone);
     s2clone.setEnableWrites(false);
@@ -193,7 +193,7 @@ public class TestZKStore {
     }
     // increase version number for disabled store.
     try {
-      store.increaseVersion();
+      store.addVersion(new VersionImpl(store.getName(), store.getLargestUsedVersionNumber() + 1, "pushJobId"));
       Assert.fail("Store is disabled to write, can not add new store to it.");
     } catch (StoreDisabledException e) {
     }
@@ -214,7 +214,7 @@ public class TestZKStore {
     // After store is enabled to write, add/increase/reserve version for this store as normal
     store.addVersion(new VersionImpl(storeName, 1));
     Assert.assertEquals(store.getVersions().get(0).getNumber(), 1);
-    store.increaseVersion();
+    store.addVersion(new VersionImpl(store.getName(), store.getLargestUsedVersionNumber() + 1, "pushJobId"));
     Assert.assertEquals(store.getVersions().get(1).getNumber(), 2);
     Assert.assertEquals(store.peekNextVersion().getNumber(), 3);
     store.setCurrentVersion(1);
@@ -262,7 +262,8 @@ public class TestZKStore {
   public void testDisableAndEnableStoreRead() {
     String storeName = "testDisableStoreRead";
     Store store = TestUtils.createTestStore(storeName, "owner", System.currentTimeMillis());
-    Version version = store.increaseVersion();
+    Version version = new VersionImpl(store.getName(), store.getLargestUsedVersionNumber() + 1, "pushJobId");
+    store.addVersion(version);
     store.updateVersionStatus(version.getNumber(), VersionStatus.ONLINE);
     store.setCurrentVersion(version.getNumber());
     Assert.assertEquals(
@@ -273,7 +274,8 @@ public class TestZKStore {
     store.setEnableReads(false);
     Assert.assertFalse(store.isEnableReads(), "Store has been disabled to read");
     // Only disable read, store could continue to increase version and update version status.
-    version = store.increaseVersion();
+    version = new VersionImpl(store.getName(), store.getLargestUsedVersionNumber() + 1, "pushJobId2");
+    store.addVersion(version);
     store.updateVersionStatus(version.getNumber(), VersionStatus.ONLINE);
     store.setCurrentVersion(version.getNumber());
     store.setEnableReads(true);
@@ -287,11 +289,12 @@ public class TestZKStore {
   public void testUseTheDeletedVersionNumber() {
     String storeName = Utils.getUniqueString("store");
     Store store = TestUtils.createTestStore(storeName, "owner", System.currentTimeMillis());
-    store.increaseVersion();
-    store.increaseVersion();
+    store.addVersion(new VersionImpl(store.getName(), store.getLargestUsedVersionNumber() + 1, "pushJobId"));
+    store.addVersion(new VersionImpl(store.getName(), store.getLargestUsedVersionNumber() + 1, "pushJobId2"));
     // largest version number is 2
     store.deleteVersion(2);
-    Version version = store.increaseVersion();
+    Version version = new VersionImpl(store.getName(), store.getLargestUsedVersionNumber() + 1, "pushJobId3");
+    store.addVersion(version);
     Assert.assertEquals(version.getNumber(), 3);
     Assert.assertEquals(store.peekNextVersion().getNumber(), 4);
   }
@@ -308,7 +311,8 @@ public class TestZKStore {
     Assert.assertEquals(store.getVersions().size(), 2);
     // largest used version is still 5
     Assert.assertEquals(store.peekNextVersion().getNumber(), 6);
-    Version version = store.increaseVersion();
+    Version version = new VersionImpl(store.getName(), store.getLargestUsedVersionNumber() + 1, "pushJobId");
+    store.addVersion(version);
     Assert.assertEquals(version.getNumber(), 6);
   }
 

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/InstanceStatusDecider.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/InstanceStatusDecider.java
@@ -5,11 +5,8 @@ import com.linkedin.venice.helix.Replica;
 import com.linkedin.venice.helix.ResourceAssignment;
 import com.linkedin.venice.meta.Partition;
 import com.linkedin.venice.meta.PartitionAssignment;
-import com.linkedin.venice.meta.ReadWriteStoreRepository;
 import com.linkedin.venice.meta.RoutingDataRepository;
-import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.Version;
-import com.linkedin.venice.meta.VersionStatus;
 import com.linkedin.venice.pushmonitor.PushMonitor;
 import com.linkedin.venice.utils.HelixUtils;
 import com.linkedin.venice.utils.LatencyUtils;
@@ -221,20 +218,4 @@ public class InstanceStatusDecider {
     return getPartitionAssignmentAfterRemoving(instanceId, partitionAssignment, resourceName, isInstanceView);
   }
 
-  private static VersionStatus getVersionStatus(ReadWriteStoreRepository storeRepository, String resourceName) {
-    Store store = storeRepository.getStore(Version.parseStoreFromKafkaTopicName(resourceName));
-    if (store == null) {
-      LOGGER.info("Can not find store for the resource: {}", resourceName);
-      return VersionStatus.NOT_CREATED;
-    }
-    if (!store.isEnableReads()) {
-      // Ignore store replicas that have read disabled.
-      LOGGER.info(
-          "Ignoring node removal checks for resource: {} because the store: {} has reads disabled",
-          resourceName,
-          store.getName());
-      return VersionStatus.NOT_CREATED;
-    }
-    return store.getVersionStatus(Version.parseVersionFromKafkaTopicName(resourceName));
-  }
 }

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceHelixAdminWithSharedEnvironment.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceHelixAdminWithSharedEnvironment.java
@@ -1003,7 +1003,8 @@ public class TestVeniceHelixAdminWithSharedEnvironment extends AbstractTestVenic
   public void testDeleteAllVersionsInStoreWithoutJobAndResource() {
     String storeName = "testDeleteVersionInWithoutJobAndResource";
     Store store = TestUtils.createTestStore(storeName, storeOwner, System.currentTimeMillis());
-    Version version = store.increaseVersion();
+    Version version = new VersionImpl(store.getName(), store.getLargestUsedVersionNumber() + 1, "pushJobId");
+    store.addVersion(version);
     store.updateVersionStatus(version.getNumber(), VersionStatus.ONLINE);
     store.setCurrentVersion(version.getNumber());
     veniceAdmin.getHelixVeniceClusterResources(clusterName).getStoreMetadataRepository().addStore(store);

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceHelixAdminWithoutCluster.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceHelixAdminWithoutCluster.java
@@ -14,16 +14,10 @@ import com.linkedin.venice.meta.BufferReplayPolicy;
 import com.linkedin.venice.meta.DataReplicationPolicy;
 import com.linkedin.venice.meta.HybridStoreConfig;
 import com.linkedin.venice.meta.HybridStoreConfigImpl;
-import com.linkedin.venice.meta.OfflinePushStrategy;
-import com.linkedin.venice.meta.PersistenceType;
-import com.linkedin.venice.meta.ReadStrategy;
 import com.linkedin.venice.meta.ReadWriteStoreRepository;
-import com.linkedin.venice.meta.RoutingStrategy;
 import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.StoreConfig;
 import com.linkedin.venice.meta.Version;
-import com.linkedin.venice.meta.VersionStatus;
-import com.linkedin.venice.meta.ZKStore;
 import com.linkedin.venice.utils.TestUtils;
 import com.linkedin.venice.utils.Utils;
 import java.util.Collections;
@@ -38,49 +32,6 @@ import org.testng.annotations.Test;
 
 
 public class TestVeniceHelixAdminWithoutCluster {
-  @Test
-  public void canFindStartedVersionInStore() {
-    String storeName = Utils.getUniqueString("store");
-    Store store = new ZKStore(
-        storeName,
-        "owner",
-        System.currentTimeMillis(),
-        PersistenceType.IN_MEMORY,
-        RoutingStrategy.CONSISTENT_HASH,
-        ReadStrategy.ANY_OF_ONLINE,
-        OfflinePushStrategy.WAIT_N_MINUS_ONE_REPLCIA_PER_PARTITION,
-        1);
-    store.increaseVersion("123");
-    Version version = store.getVersions().get(0);
-    Optional<Version> returnedVersion = VeniceHelixAdmin.getStartedVersion(store);
-    Assert.assertEquals(returnedVersion.get(), version);
-  }
-
-  /**
-   * This test should fail and be removed when we revert to using push ID to guarantee idempotence.
-   */
-  @Test
-  public void findStartedVersionIgnoresPushId() {
-    String pushId = Utils.getUniqueString("pushid");
-    String storeName = Utils.getUniqueString("store");
-    Store store = new ZKStore(
-        storeName,
-        "owner",
-        System.currentTimeMillis(),
-        PersistenceType.IN_MEMORY,
-        RoutingStrategy.CONSISTENT_HASH,
-        ReadStrategy.ANY_OF_ONLINE,
-        OfflinePushStrategy.WAIT_N_MINUS_ONE_REPLCIA_PER_PARTITION,
-        1);
-    store.increaseVersion(pushId);
-    Version version = store.getVersions().get(0);
-    store.updateVersionStatus(version.getNumber(), VersionStatus.ONLINE);
-    store.increaseVersion(pushId);
-    Version startedVersion = store.getVersions().get(1);
-    Optional<Version> returnedVersion = VeniceHelixAdmin.getStartedVersion(store);
-    Assert.assertEquals(returnedVersion.get(), startedVersion);
-  }
-
   @Test
   public void canMergeNewHybridConfigValuesToOldStore() {
     String storeName = Utils.getUniqueString("storeName");

--- a/services/venice-router/src/test/java/com/linkedin/venice/router/api/TestVenicePartitionFinder.java
+++ b/services/venice-router/src/test/java/com/linkedin/venice/router/api/TestVenicePartitionFinder.java
@@ -11,6 +11,7 @@ import com.linkedin.venice.meta.ReadStrategy;
 import com.linkedin.venice.meta.RoutingDataRepository;
 import com.linkedin.venice.meta.RoutingStrategy;
 import com.linkedin.venice.meta.Store;
+import com.linkedin.venice.meta.VersionImpl;
 import com.linkedin.venice.meta.ZKStore;
 import com.linkedin.venice.partitioner.DefaultVenicePartitioner;
 import com.linkedin.venice.partitioner.VenicePartitioner;
@@ -41,8 +42,8 @@ public class TestVenicePartitionFinder {
         ReadStrategy.ANY_OF_ONLINE,
         OfflinePushStrategy.WAIT_N_MINUS_ONE_REPLCIA_PER_PARTITION,
         1);
-    for (int i = 0; i < NUM_VERSIONS; i++) {
-      store.increaseVersion(String.valueOf(i));
+    for (int i = 1; i <= NUM_VERSIONS; i++) {
+      store.addVersion(new VersionImpl(storeName, i, String.valueOf(i), NUM_PARTITIONS));
     }
     VenicePartitioner partitioner = new DefaultVenicePartitioner();
     doReturn(store).when(mockMetadataRepo).getStore(storeName);


### PR DESCRIPTION
2 new version status:
CREATED - Version is created and persisted inside ZK, but controller hasn't finished preparation works yet. PARTIALLY_ONLINE - Version has been pushed to Venice and is ready to serve in some regions, but failed in other regions.

These new version status are prerequisite for two future works:
1. Make AddVersion command processing idempotent
2. Stop using empty topic in parent Kafka cluster to indicate ongoing pushes, instead, leverage versin status.

Introduce new version statuses in the code base, deploy them first, so that rollback is allowed in future when there is a need to rollback the codes but new version statuses are already persisted on ZK.

Other changes:
Clean up deprecated API Store#increaseVersion which is only used in test cases.