### PR TITLE
[controller] Update version status on parent

### DIFF
--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -2054,6 +2054,8 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
           }
 
           topicToCreationTime.computeIfAbsent(version.kafkaTopicName(), topic -> System.currentTimeMillis());
+          // TODO: Once concurrent batch pushes handling no longer relies on topics on parent Kafka cluster, stop
+          // creating empty version topic on parent Kafka to indicate ongoing push.
           createBatchTopics(
               version,
               pushType,


### PR DESCRIPTION
Previously version status on parent is always STARTED; this PR enabled parent controller to update version status properly when job polling function returns a terminal status for a batch push.

## How was this PR tested?
Internal CI

## Does this PR introduce any user-facing changes?
Yes, Nuage reads version status from Venice parent controller.
This PR will not be merged until the release with new version status is running stably for parent controllers and Nuage in production; otherwise, once we start writing the new status on ZK, we cannot rollback parent controller and Nuage anymore.
Is there any other application that reads version from parent controller?