### PR TITLE
[Build] Add build/upload archive workflow for tag

### DIFF
--- a/.github/workflows/build-and-upload-archives-upon-creating-tags.yml
+++ b/.github/workflows/build-and-upload-archives-upon-creating-tags.yml
@@ -1,9 +1,8 @@
-name: Build and Upload Archives upon Creating Tags
+name: Build and Upload Archives Upon Creating Tags
 
 # Run this workflow every time a tag is created
 on:
   create:
-    tags:
 
 jobs:
   build:
@@ -12,21 +11,13 @@ jobs:
     # Set the type of machine to run on
     runs-on: ubuntu-latest
     # Only run for tag creation
-    if: github.event.ref_type == 'tag'
+    if: github.event.ref_type == 'tag' && github.repository == 'linkedin/venice'
     steps:
       # Checks out a copy of your repository on the ubuntu-latest machine
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 0 # all history for all branches and tags
-
-      - name: Add upstream remote
-        if: github.repository != 'linkedin/venice'
-        run: git remote add upstream https://github.com/linkedin/venice
-
-      - name: Fetch upstream refs
-        if: github.repository != 'linkedin/venice'
-        run: git fetch upstream
 
       - name: Set up JDK 11
         uses: actions/setup-java@v3
@@ -41,4 +32,4 @@ jobs:
         uses: gradle/gradle-build-action@67421db6bd0bf253fb4bd25b31ebb98943c375e1
         with:
           arguments: |
-            -Pversion=${{  github.ref_name }}" publishAllPublicationsToLinkedInJFrogRepository
+            "-Pversion=${{  github.ref_name }}" publishAllPublicationsToLinkedInJFrogRepository

--- a/.github/workflows/build-and-upload-archives-upon-pushing-tags.yml
+++ b/.github/workflows/build-and-upload-archives-upon-pushing-tags.yml
@@ -1,9 +1,10 @@
 name: Build and Upload Archives upon Creating Tags
 
-# Run this workflow every time a tag is created
+# Run this workflow every time a tag is created/pushed
 on:
-  create:
+  push:
     tags:
+      - '*'
 
 jobs:
   build:
@@ -11,8 +12,7 @@ jobs:
     name: Build tagged commit and upload an archive
     # Set the type of machine to run on
     runs-on: ubuntu-latest
-    # Only run for tag creation
-    if: github.event.ref_type == 'tag'
+    # timeout-minutes: 120
     steps:
       # Checks out a copy of your repository on the ubuntu-latest machine
       - name: Checkout code

--- a/.github/workflows/build-and-upload-archives-upon-pushing-tags.yml
+++ b/.github/workflows/build-and-upload-archives-upon-pushing-tags.yml
@@ -1,6 +1,6 @@
-name: Build and Upload Archives upon Creating Tags
+name: Build and Upload Archives Upon Pushing Tags
 
-# Run this workflow every time a tag is created/pushed
+# Run this workflow every time a tag is pushed
 on:
   push:
     tags:
@@ -12,21 +12,13 @@ jobs:
     name: Build tagged commit and upload an archive
     # Set the type of machine to run on
     runs-on: ubuntu-latest
-    # timeout-minutes: 120
+    if: github.repository == 'linkedin/venice'
     steps:
       # Checks out a copy of your repository on the ubuntu-latest machine
       - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 0 # all history for all branches and tags
-
-      - name: Add upstream remote
-        if: github.repository != 'linkedin/venice'
-        run: git remote add upstream https://github.com/linkedin/venice
-
-      - name: Fetch upstream refs
-        if: github.repository != 'linkedin/venice'
-        run: git fetch upstream
 
       - name: Set up JDK 11
         uses: actions/setup-java@v3
@@ -41,4 +33,4 @@ jobs:
         uses: gradle/gradle-build-action@67421db6bd0bf253fb4bd25b31ebb98943c375e1
         with:
           arguments: |
-            -Pversion=${{  github.ref_name }}" publishAllPublicationsToLinkedInJFrogRepository
+            "-Pversion=${{  github.ref_name }}" publishAllPublicationsToLinkedInJFrogRepository


### PR DESCRIPTION

 Since we are using git API to create tags in the actions workflow, it does not trigger the `push` tag workflow. Creating this workflow action to get triggered on tag creation event.




