### PR TITLE
[Test][da-vinci] Fixed a flakiness of StoreIngestionTaskTest

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/SharedKafkaConsumer.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/SharedKafkaConsumer.java
@@ -250,19 +250,6 @@ class SharedKafkaConsumer implements KafkaConsumerWrapper {
     return !this.currentAssignment.isEmpty();
   }
 
-  /**
-   * This function will return true as long as any topic in the passed {@param topics} has been subscribed.
-   */
-  @Override
-  public boolean hasSubscribedAnyTopic(Set<String> topics) {
-    for (TopicPartition subscribedTopicPartition: currentAssignment) {
-      if (topics.contains(subscribedTopicPartition.topic())) {
-        return true;
-      }
-    }
-    return false;
-  }
-
   @Override
   public boolean hasSubscription(String topic, int partition) {
     return currentAssignment.contains(new TopicPartition(topic, partition));

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StorageUtilizationManager.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StorageUtilizationManager.java
@@ -211,7 +211,7 @@ public class StorageUtilizationManager implements StoreDataChangedListener {
   /**
    * Enforce partition level quota for the map.
    * This function could be invoked by multiple threads when shared consumer is being used.
-   * Check {@link StoreIngestionTask#produceToStoreBufferServiceOrKafka} and {@link StoreIngestionTask#processMessages}
+   * Check {@link StoreIngestionTask#produceToStoreBufferServiceOrKafka} and {@link StoreIngestionTask#checkIngestionProgress}
    * to find more details.
    */
   public void checkAllPartitionsQuota() {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -1318,7 +1318,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
     }
   }
 
-  protected void processMessages(Store store) throws InterruptedException {
+  protected void checkIngestionProgress(Store store) throws InterruptedException {
     Exception ingestionTaskException = lastStoreIngestionException.get();
     if (ingestionTaskException != null) {
       throw new VeniceException(
@@ -1436,7 +1436,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
         processConsumerActions(store);
         checkLongRunningTaskState();
         checkLongRunningDBCompaction();
-        processMessages(store);
+        checkIngestionProgress(store);
       }
 
       // If the ingestion task is stopped gracefully (server stops), persist processed offset to disk

--- a/internal/venice-common/src/main/java/com/linkedin/venice/kafka/consumer/ApacheKafkaConsumer.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/kafka/consumer/ApacheKafkaConsumer.java
@@ -179,16 +179,6 @@ public class ApacheKafkaConsumer implements KafkaConsumerWrapper {
   }
 
   @Override
-  public boolean hasSubscribedAnyTopic(Set<String> topics) {
-    for (TopicPartition subscribedTopicPartition: kafkaConsumer.assignment()) {
-      if (topics.contains(subscribedTopicPartition.topic())) {
-        return true;
-      }
-    }
-    return false;
-  }
-
-  @Override
   public boolean hasSubscription(String topic, int partition) {
     TopicPartition tp = new TopicPartition(topic, partition);
     return kafkaConsumer.assignment().contains(tp);

--- a/internal/venice-common/src/main/java/com/linkedin/venice/kafka/consumer/KafkaConsumerWrapper.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/kafka/consumer/KafkaConsumerWrapper.java
@@ -27,11 +27,6 @@ public interface KafkaConsumerWrapper extends AutoCloseable, Closeable {
    */
   boolean hasAnySubscription();
 
-  /**
-   * @return True if this consumer has subscribed any topic in the given topic set {@param topics} and false otherwise.
-   */
-  boolean hasSubscribedAnyTopic(Set<String> topics);
-
   boolean hasSubscription(String topic, int partition);
 
   void pause(String topic, int partition);

--- a/internal/venice-test-common/src/main/java/com/linkedin/venice/unit/kafka/consumer/MockInMemoryConsumer.java
+++ b/internal/venice-test-common/src/main/java/com/linkedin/venice/unit/kafka/consumer/MockInMemoryConsumer.java
@@ -118,16 +118,6 @@ public class MockInMemoryConsumer implements KafkaConsumerWrapper {
   }
 
   @Override
-  public boolean hasSubscribedAnyTopic(Set<String> topics) {
-    for (TopicPartition subscribedTopicPartition: offsets.keySet()) {
-      if (topics.contains(subscribedTopicPartition.topic())) {
-        return true;
-      }
-    }
-    return false;
-  }
-
-  @Override
   public boolean hasSubscription(String topic, int partition) {
     return offsets.containsKey(new TopicPartition(topic, partition));
   }


### PR DESCRIPTION
This is a test only issue and there is no data loss issue discovered. And this code change also leverages `KafkaConsumerWrapper#batchUnsubscribe` in `KafkaConsumerService`.


## How was this PR tested?
Internal CI passed

## Does this PR introduce any user-facing changes?
`No`