### PR TITLE
[admin-tool] Fixed the admin tool command to dump admin topic

### DIFF
--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/AdminTool.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/AdminTool.java
@@ -6,7 +6,6 @@ import static org.apache.kafka.clients.consumer.ConsumerConfig.BOOTSTRAP_SERVERS
 import static org.apache.kafka.clients.consumer.ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG;
 import static org.apache.kafka.clients.consumer.ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG;
 
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
@@ -120,7 +119,6 @@ import org.apache.kafka.clients.CommonClientConfigs;
 
 public class AdminTool {
   private static ObjectWriter jsonWriter = ObjectMapperFactory.getInstance().writerWithDefaultPrettyPrinter();
-  private static List<String> fieldsToDisplay = new ArrayList<>();
   private static final String STATUS = "status";
   private static final String ERROR = "error";
   private static final String SUCCESS = "success";
@@ -172,9 +170,6 @@ public class AdminTool {
 
       if (cmd.hasOption(Arg.FLAT_JSON.toString())) {
         jsonWriter = ObjectMapperFactory.getInstance().writer();
-      }
-      if (cmd.hasOption(Arg.FILTER_JSON.toString())) {
-        fieldsToDisplay = Arrays.asList(cmd.getOptionValue(Arg.FILTER_JSON.first()).split(","));
       }
 
       switch (foundCommand) {
@@ -2559,25 +2554,7 @@ public class AdminTool {
 
   protected static void printObject(Object response, Consumer<String> printFunction) {
     try {
-      ObjectMapper mapper = ObjectMapperFactory.getInstance();
-      ObjectWriter plainJsonWriter = mapper.writer();
-      String jsonString = plainJsonWriter.writeValueAsString(response);
-      Map<String, Object> printMap = mapper.readValue(jsonString, new TypeReference<Map<String, Object>>() {
-      });
-      Map<String, Object> filteredPrintMap = new HashMap<>();
-      if (fieldsToDisplay.size() > 0) {
-        printMap.entrySet().stream().filter(entry -> fieldsToDisplay.contains(entry.getKey())).forEach(entry -> {
-          filteredPrintMap.put(entry.getKey(), entry.getValue());
-        });
-      } else {
-        filteredPrintMap.putAll(printMap);
-      }
-      // Always filter out exceptionType if error is null.
-      if (filteredPrintMap.containsKey("error") && printMap.get("error") == null) {
-        filteredPrintMap.remove("error");
-        filteredPrintMap.remove("exceptionType");
-      }
-      printFunction.accept(jsonWriter.writeValueAsString(filteredPrintMap));
+      printFunction.accept(jsonWriter.writeValueAsString(response));
       printFunction.accept("\n");
     } catch (IOException e) {
       printFunction.accept("{\"" + ERROR + "\":\"" + e.getMessage() + "\"}");

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/Arg.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/Arg.java
@@ -150,10 +150,6 @@ public enum Arg {
       "Backup version retention time in day after a new version is promoted to the current version, if not specified, Venice will use the configured retention as the default policy"
   ), REPLICATION_FACTOR("replication-factor", "rf", true, "the number of replica each store version will have"),
 
-  FILTER_JSON(
-      "filter-json", "ftj", true,
-      "Comma-delimited list of fields to display from the json output.  Omit to display all fields"
-  ),
   FLAT_JSON("flat-json", "flj", false, "Display output as flat json, without pretty-print indentation and line breaks"),
   HELP("help", "h", false, "Show usage"), FORCE("force", "f", false, "Force execute this operation"),
   INCLUDE_SYSTEM_STORES("include-system-stores", "iss", true, "Include internal stores maintained by the system."),


### PR DESCRIPTION
There was a bug in AdminTool#printObject method, which can't handle a list of response because of the internal filtering logic. Since field filtering is not being used actively, this code change removes the field filtering option.
In the meantime, this code change also skips the Control Message when dumping admin topic to avoid confusion.


## How was this PR tested?
Manual test in test env.

## Does this PR introduce any user-facing changes?
- [ ] No. You can skip the rest of this section.
- [x] Yes. Make sure to explain your proposed changes and call out the behavior change.

The command option: `filter-json` is removed from admin tool