### PR TITLE
[controller] Dont index store::version  using largestVersionNumber 

### DIFF
--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
@@ -664,9 +664,7 @@ public class VeniceParentHelixAdmin implements Admin {
         StoreInfo storeInfo = storeResponse.getStore();
 
         if (storeInfo.getHybridStoreConfig() != null && !storeInfo.getVersions().isEmpty()
-            && storeInfo.getVersions()
-                .get(storeInfo.getLargestUsedVersionNumber())
-                .getPartitionCount() == partitionCount
+            && storeInfo.getVersion(storeInfo.getLargestUsedVersionNumber()).get().getPartitionCount() == partitionCount
             && getTopicManager().containsTopicAndAllPartitionsAreOnline(Version.composeRealTimeTopic(storeName))) {
           storeReady = true;
         }


### PR DESCRIPTION
[controller] Call  instead indexing it using largestVersionNumber
  
Fix ArrayIndexOutOfBoundsException in HB system store init routine.