### PR TITLE
[build] Simplified make_tags to work with new format. Inherit secrets…

### DIFF
--- a/.github/workflows/build-and-upload-archives-on-schedule.yml
+++ b/.github/workflows/build-and-upload-archives-on-schedule.yml
@@ -18,3 +18,4 @@ jobs:
   build-and-publish:
     needs: make-tag
     uses: ./.github/workflows/build-and-upload-archives.yml
+    secrets: inherit

--- a/.github/workflows/build-and-upload-archives.yml
+++ b/.github/workflows/build-and-upload-archives.yml
@@ -10,6 +10,7 @@ jobs:
     name: Build tagged commit and upload an archive
     # Set the type of machine to run on
     runs-on: ubuntu-latest
+    secrets: inherit
     # Only run for upstream main
     if: github.repository == 'linkedin/venice'
     steps:

--- a/.github/workflows/build-and-upload-archives.yml
+++ b/.github/workflows/build-and-upload-archives.yml
@@ -10,7 +10,6 @@ jobs:
     name: Build tagged commit and upload an archive
     # Set the type of machine to run on
     runs-on: ubuntu-latest
-    secrets: inherit
     # Only run for upstream main
     if: github.repository == 'linkedin/venice'
     steps:

--- a/make_tag.py
+++ b/make_tag.py
@@ -33,8 +33,8 @@ def format_version(major, minor, build):
     return f'{major}.{minor}.{build}'
 
 
-def get_next_version(bump_major, bump_minor):
-    tag_text = check_output(['git', 'describe', '--tags', '--abbrev=0', 'main'], text=True)
+def get_next_version(bump_major, bump_minor, remote):
+    tag_text = check_output(['git', 'describe', '--tags', '--abbrev=0', f'{remote}/main'], text=True)
     tag_text = tag_text.rstrip()
     commits = check_output(['git', 'log', f'{tag_text}..HEAD', '--oneline'], text=True)
     if commits == "":
@@ -46,10 +46,12 @@ def get_next_version(bump_major, bump_minor):
     major = version_ints[0]
     if bump_major:
         major += 1
+        return format_version(major, 0, 0)
 
     minor = version_ints[1]
     if bump_minor:
         minor += 1
+        return format_version(major, minor, 0)
 
     build = version_ints[2]
 
@@ -76,10 +78,10 @@ def make_tag(remote, bump_major, bump_minor, need_verification, github_actor):
         if set_email != 0:
             sys.exit()
 
-   # pull_success = call(['git', 'pull', '--rebase', remote, 'main'])
-    #if pull_success != 0:
-     #   sys.exit()
-    version = get_next_version(bump_major, bump_minor)
+    pull_success = call(['git', 'pull', '--rebase', remote, 'main'])
+    if pull_success != 0:
+        sys.exit()
+    version = get_next_version(bump_major, bump_minor, remote)
     tag_message = 'tag for release ' + version
 
     if need_verification:


### PR DESCRIPTION
Now make_tags will work with new format (v1.v2.v3) only and skip pushing tags if there is no new commits since the last tag push.  Also added a step to inherit secrets in reusable workflow.