### PR TITLE
[build] Add a git fetch to get all the commits in make_tags

### DIFF
--- a/.github/workflows/build-and-upload-archives-on-schedule.yml
+++ b/.github/workflows/build-and-upload-archives-on-schedule.yml
@@ -14,6 +14,7 @@ jobs:
       - uses: actions/checkout@v3
       - with:
           fetch-depth: 0 # all history for all branches and tags
+          
       - name: Cut release tag to build and upload Venice Release archive
         run: |
           ./make_tag.py --no-verify --github-actor '${GITHUB_ACTOR}'

--- a/.github/workflows/build-and-upload-archives-on-schedule.yml
+++ b/.github/workflows/build-and-upload-archives-on-schedule.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the code
-      - uses: actions/checkout@v3
-      - with:
+        uses: actions/checkout@v3
+        with:
           fetch-depth: 0 # all history for all branches and tags
-          
+
       - name: Cut release tag to build and upload Venice Release archive
         run: |
           ./make_tag.py --no-verify --github-actor '${GITHUB_ACTOR}'

--- a/.github/workflows/build-and-upload-archives-on-schedule.yml
+++ b/.github/workflows/build-and-upload-archives-on-schedule.yml
@@ -10,7 +10,10 @@ jobs:
     if: github.repository == 'linkedin/venice'
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout the code
       - uses: actions/checkout@v3
+      - with:
+          fetch-depth: 0 # all history for all branches and tags
       - name: Cut release tag to build and upload Venice Release archive
         run: |
           ./make_tag.py --no-verify --github-actor '${GITHUB_ACTOR}'

--- a/make_tag.py
+++ b/make_tag.py
@@ -98,6 +98,7 @@ def make_tag(remote, bump_major, bump_minor, need_verification, github_actor):
 
 def get_tags(remote):
     call(['git', 'fetch', remote, 'main', '--tags'])
+    call(['git', 'fetch', remote, 'main'])
 
 
 def run(bump_major, bump_minor, need_verification, github_actor):


### PR DESCRIPTION
Add a git fetch to get all the commits in make_tags. Currently make_tags fails as it cannot find the sha of the latest commits.

[No tags can describe 'sha_code`](fatal: No tags can describe 'ebac2af4b831cd5294cea214c42da239fcf7fe5a'.)