### PR TITLE
[da-vinci][samza] Da Vinci Client will fail fast if they use a KME version that is not yet registered in Zk. Enable KME validation by default for samza jobs

### DIFF
--- a/clients/venice-samza/src/main/java/com/linkedin/venice/samza/VeniceSystemFactory.java
+++ b/clients/venice-samza/src/main/java/com/linkedin/venice/samza/VeniceSystemFactory.java
@@ -281,10 +281,19 @@ public class VeniceSystemFactory implements SystemFactory, Serializable {
       localVeniceZKHosts = legacyLocalVeniceZKHosts;
     }
 
-    String localControllerD2Service =
-        config.get(VENICE_CHILD_CONTROLLER_D2_SERVICE, LEGACY_VENICE_CHILD_CONTROLLER_D2_SERVICE);
-    String parentControllerD2Service =
-        config.get(VENICE_PARENT_CONTROLLER_D2_SERVICE, LEGACY_VENICE_PARENT_CONTROLLER_D2_SERVICE);
+    String localControllerD2Service = config.get(VENICE_CHILD_CONTROLLER_D2_SERVICE);
+    if (isEmpty(localControllerD2Service)) {
+      LOGGER.info(
+          VENICE_CHILD_CONTROLLER_D2_SERVICE + " is not defined. Using " + LEGACY_VENICE_CHILD_CONTROLLER_D2_SERVICE);
+      localControllerD2Service = LEGACY_VENICE_CHILD_CONTROLLER_D2_SERVICE;
+    }
+
+    String parentControllerD2Service = config.get(VENICE_PARENT_CONTROLLER_D2_SERVICE);
+    if (isEmpty(parentControllerD2Service)) {
+      LOGGER.info(
+          VENICE_PARENT_CONTROLLER_D2_SERVICE + " is not defined. Using " + LEGACY_VENICE_PARENT_CONTROLLER_D2_SERVICE);
+      parentControllerD2Service = LEGACY_VENICE_PARENT_CONTROLLER_D2_SERVICE;
+    }
 
     // Build Ssl Factory if Controller SSL is enabled
     Optional<SSLFactory> sslFactory = Optional.empty();

--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -1824,4 +1824,11 @@ public class ConfigKeys {
    * It contains a string of concatenated partitioner class names separated by comma.
    */
   public static final String VENICE_PARTITIONERS = "venice.partitioners";
+
+  /**
+   * Config to check whether the protocol versions used at runtime are valid in Venice backend; if not, fail fast.
+   * Used by Samza jobs and Da Vinci clients. Default value should be true.
+   * Turn off the config in where access to routers is not feasible.
+   */
+  public static final String VALIDATE_VENICE_INTERNAL_SCHEMA_VERSION = "validate.venice.internal.schema.version";
 }

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/ActiveActiveReplicationForHybridTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/ActiveActiveReplicationForHybridTest.java
@@ -621,6 +621,7 @@ public class ActiveActiveReplicationForHybridTest {
       VeniceMultiClusterWrapper childDataCenter = childDatacenters.get(0);
       try (VeniceSystemProducer producerInDC0 = new VeniceSystemProducer(
           childDataCenter.getZkServerWrapper().getAddress(),
+          childDataCenter.getZkServerWrapper().getAddress(),
           D2_SERVICE_NAME,
           storeName,
           Version.PushType.STREAM,
@@ -703,6 +704,7 @@ public class ActiveActiveReplicationForHybridTest {
       // Build the SystemProducer with the mock time
       VeniceMultiClusterWrapper childDataCenter1 = childDatacenters.get(1);
       try (VeniceSystemProducer producerInDC1 = new VeniceSystemProducer(
+          childDataCenter.getZkServerWrapper().getAddress(),
           childDataCenter1.getZkServerWrapper().getAddress(),
           D2_SERVICE_NAME,
           storeName,

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestPushJobWithNativeReplication.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestPushJobWithNativeReplication.java
@@ -361,7 +361,7 @@ public class TestPushJobWithNativeReplication {
           samzaConfig.put(configPrefix + VENICE_PUSH_TYPE, Version.PushType.STREAM.toString());
           samzaConfig.put(configPrefix + VENICE_STORE, storeName);
           samzaConfig.put(configPrefix + VENICE_AGGREGATE, "true");
-          samzaConfig.put(VENICE_CHILD_D2_ZK_HOSTS, "invalid_child_zk_address");
+          samzaConfig.put(VENICE_CHILD_D2_ZK_HOSTS, childDatacenters.get(0).getZkServerWrapper().getAddress());
           samzaConfig.put(VENICE_CHILD_CONTROLLER_D2_SERVICE, D2_SERVICE_NAME);
           samzaConfig.put(VENICE_PARENT_D2_ZK_HOSTS, multiColoMultiClusterWrapper.getZkServerWrapper().getAddress());
           samzaConfig.put(VENICE_PARENT_CONTROLLER_D2_SERVICE, PARENT_D2_SERVICE_NAME);

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestPushJobWithNativeReplication.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestPushJobWithNativeReplication.java
@@ -113,7 +113,7 @@ import org.testng.annotations.Test;
 
 public class TestPushJobWithNativeReplication {
   private static final Logger LOGGER = LogManager.getLogger(TestPushJobWithNativeReplication.class);
-  private static final int TEST_TIMEOUT = 120_000; // ms
+  private static final int TEST_TIMEOUT = 2 * Time.MS_PER_MINUTE;
 
   private static final int NUMBER_OF_CHILD_DATACENTERS = 2;
   private static final int NUMBER_OF_CLUSTERS = 1;
@@ -865,7 +865,7 @@ public class TestPushJobWithNativeReplication {
     }
   }
 
-  private interface NativeReplTest {
+  private interface NativeReplicationTest {
     void run(
         ControllerClient parentControllerClient,
         String clusterName,
@@ -877,7 +877,7 @@ public class TestPushJobWithNativeReplication {
   private void motherOfAllTests(
       Function<UpdateStoreQueryParams, UpdateStoreQueryParams> updateStoreParamsTransformer,
       int recordCount,
-      NativeReplTest test) throws Exception {
+      NativeReplicationTest test) throws Exception {
     String clusterName = CLUSTER_NAMES[0];
     File inputDir = getTempDataDirectory();
     String parentControllerUrls =


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci], [server], [controller],
[router], [samza], [vpj], [fast-client], [thin-client], [alpini],
[admin-tool], [test], [build], [doc], [script]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Da Vinci Client will fail fast if they use a KME version that is not yet registered in Zk. Enable KME validation by default for samza jobs
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

1. Make Da Vinci Client fail fast if they use a KME version that is not yet registered in Zookeeper.
2. Fix Router-dependent things in Samza jobs to use child colo D2 zk host
    1. `RouterBackedSchemaReader` for KME
    2. `RouterBasedPushMonitor`
    3. `RouterBasedHybridStoreQuotaMonitor`
3. Enable KME validation by default for samza jobs and da-vinci clients

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
Multiple Internal CI runs passed

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.