### PR TITLE
[test] Fix flakies in TestValidateSchemaAndBuildDictMapperOutputReader

### DIFF
--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/TestValidateSchemaAndBuildDictMapperOutputReader.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/TestValidateSchemaAndBuildDictMapperOutputReader.java
@@ -1,11 +1,10 @@
 package com.linkedin.venice.hadoop;
 
-import static com.linkedin.venice.utils.TestPushUtils.getTempDataDirectory;
-
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.hadoop.output.avro.ValidateSchemaAndBuildDictMapperOutput;
 import com.linkedin.venice.utils.TestPushUtils;
 import com.linkedin.venice.utils.Time;
+import com.linkedin.venice.utils.Utils;
 import java.io.File;
 import java.nio.ByteBuffer;
 import org.apache.avro.Schema;
@@ -16,7 +15,6 @@ import org.testng.annotations.Test;
 public class TestValidateSchemaAndBuildDictMapperOutputReader {
   private static final int TEST_TIMEOUT = 10 * Time.MS_PER_SECOND;
   private static final Schema fileSchema = ValidateSchemaAndBuildDictMapperOutput.getClassSchema();
-  private final File inputDir = getTempDataDirectory();
 
   @Test(timeOut = TEST_TIMEOUT, expectedExceptions = NullPointerException.class, expectedExceptionsMessageRegExp = ".* output directory should not be empty")
   public void testGetWithDirAsNull() throws Exception {
@@ -32,6 +30,7 @@ public class TestValidateSchemaAndBuildDictMapperOutputReader {
 
   @Test(timeOut = TEST_TIMEOUT, expectedExceptions = NullPointerException.class, expectedExceptionsMessageRegExp = ".* output fileName should not be empty")
   public void testGetWithFileAsNull() throws Exception {
+    File inputDir = Utils.getTempDataDirectory();
     ValidateSchemaAndBuildDictMapperOutputReader reader =
         new ValidateSchemaAndBuildDictMapperOutputReader(inputDir.getAbsolutePath(), null);
     reader.close();
@@ -39,6 +38,7 @@ public class TestValidateSchemaAndBuildDictMapperOutputReader {
 
   @Test(timeOut = TEST_TIMEOUT, expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = ".* output fileName should not be empty")
   public void testGetWithFileAsEmpty() throws Exception {
+    File inputDir = Utils.getTempDataDirectory();
     ValidateSchemaAndBuildDictMapperOutputReader reader =
         new ValidateSchemaAndBuildDictMapperOutputReader(inputDir.getAbsolutePath(), "");
     reader.close();
@@ -46,6 +46,7 @@ public class TestValidateSchemaAndBuildDictMapperOutputReader {
 
   @Test(timeOut = TEST_TIMEOUT, expectedExceptions = VeniceException.class, expectedExceptionsMessageRegExp = "Encountered exception reading Avro data from.*")
   public void testGetWithNoFile() throws Exception {
+    File inputDir = Utils.getTempDataDirectory();
     String avroOutputFile = "nofile.avro"; // This file is not present
     ValidateSchemaAndBuildDictMapperOutputReader reader =
         new ValidateSchemaAndBuildDictMapperOutputReader(inputDir.getAbsolutePath(), avroOutputFile);
@@ -58,6 +59,7 @@ public class TestValidateSchemaAndBuildDictMapperOutputReader {
    */
   @Test(timeOut = TEST_TIMEOUT, expectedExceptions = VeniceException.class, expectedExceptionsMessageRegExp = "File .* contains no records.*")
   public void testGetWithEmptyFile() throws Exception {
+    File inputDir = Utils.getTempDataDirectory();
     String avroOutputFile = "empty_file.avro";
     TestPushUtils.writeEmptyAvroFileWithUserSchema(inputDir, avroOutputFile, fileSchema.toString());
     ValidateSchemaAndBuildDictMapperOutputReader reader =
@@ -71,6 +73,7 @@ public class TestValidateSchemaAndBuildDictMapperOutputReader {
    */
   @Test(timeOut = TEST_TIMEOUT, expectedExceptions = VeniceException.class, expectedExceptionsMessageRegExp = "Encountered exception reading Avro data from.*")
   public void testGetWithInvalidAvroFile() throws Exception {
+    File inputDir = Utils.getTempDataDirectory();
     String avroOutputFile = "invalid_file.avro";
     TestPushUtils.writeInvalidAvroFile(inputDir, avroOutputFile);
     ValidateSchemaAndBuildDictMapperOutputReader reader =
@@ -84,6 +87,7 @@ public class TestValidateSchemaAndBuildDictMapperOutputReader {
    */
   @Test(timeOut = TEST_TIMEOUT, expectedExceptions = VeniceException.class, expectedExceptionsMessageRegExp = "Retrieved inputFileDataSize .* is not valid")
   public void testGetWithInvalidInputFileDataSize() throws Exception {
+    File inputDir = Utils.getTempDataDirectory();
     String avroOutputFile = "valid_file.avro";
     TestPushUtils.writeSimpleAvroFileForValidateSchemaAndBuildDictMapperOutput(
         inputDir,
@@ -98,6 +102,7 @@ public class TestValidateSchemaAndBuildDictMapperOutputReader {
 
   @Test(timeOut = TEST_TIMEOUT)
   public void testGetWithValidInputFileDataSize() throws Exception {
+    File inputDir = Utils.getTempDataDirectory();
     String avroOutputFile = "valid_file.avro";
     TestPushUtils.writeSimpleAvroFileForValidateSchemaAndBuildDictMapperOutput(
         inputDir,
@@ -121,6 +126,7 @@ public class TestValidateSchemaAndBuildDictMapperOutputReader {
    */
   @Test(timeOut = TEST_TIMEOUT)
   public void testGetWithNoZstdDictionary() throws Exception {
+    File inputDir = Utils.getTempDataDirectory();
     String avroOutputFile = "valid_file.avro";
     TestPushUtils.writeSimpleAvroFileForValidateSchemaAndBuildDictMapperOutput(
         inputDir,


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci], [server], [controller],
[router], [samza], [vpj], [fast-client], [thin-client], [alpini],
[admin-tool], [test], [build], [doc], [script]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Fix flakies in TestValidateSchemaAndBuildDictMapperOutputReader
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
Internal CI - Running

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.