### PR TITLE
[common] Adding chunking support for large RMD payload in Venice Writer

### DIFF
--- a/internal/venice-common/src/main/java/com/linkedin/venice/writer/ChunkHelper.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/writer/ChunkHelper.java
@@ -1,4 +1,149 @@
 package com.linkedin.venice.writer;
 
+import static com.linkedin.venice.writer.VeniceWriter.*;
+
+import com.linkedin.venice.exceptions.VeniceException;
+import com.linkedin.venice.kafka.protocol.Put;
+import com.linkedin.venice.kafka.protocol.enums.MessageType;
+import com.linkedin.venice.message.KafkaKey;
+import com.linkedin.venice.serialization.KeyWithChunkingSuffixSerializer;
+import com.linkedin.venice.serialization.avro.AvroProtocolDefinition;
+import com.linkedin.venice.storage.protocol.ChunkId;
+import com.linkedin.venice.storage.protocol.ChunkedKeySuffix;
+import com.linkedin.venice.storage.protocol.ChunkedValueManifest;
+import com.linkedin.venice.utils.ByteUtils;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.concurrent.Future;
+import java.util.function.BiFunction;
+import java.util.function.Supplier;
+import org.apache.kafka.clients.producer.Callback;
+import org.apache.kafka.clients.producer.RecordMetadata;
+
+
 public class ChunkHelper {
+  private static final ByteBuffer EMPTY_BYTE_BUFFER = ByteBuffer.allocate(0);
+
+  private static void validateAvailableSizePerMessage(
+      int maxSizeForUserPayloadPerMessageInBytes,
+      int sizeAvailablePerMessage,
+      Supplier<String> sizeReport) {
+    if (sizeAvailablePerMessage < maxSizeForUserPayloadPerMessageInBytes / 2) {
+      /**
+       * If the key size is more than half the available payload per message, then we cannot even encode a
+       * {@link ChunkedValueManifest} with two keys in it, hence we would fail anyway. Might as well fail fast.
+       *
+       * N.B.: The above may not be strictly true, since Kafka-level compression may squeeze us under the limit,
+       * but this is not likely to work deterministically, so it would be iffy to attempt it on a best-effort
+       * basis. That being said, allowing keys to be as large as half the available payload size is probably
+       * overly permissive anyway. Ideally, the key size should be much smaller than this.
+       *
+       * TODO: Implement a proper key size (and value size) quota mechanism.
+       */
+      throw new VeniceException("Chunking cannot support this use case. The key is too large. " + sizeReport.get());
+    }
+  }
+
+  public static ChunkedPayloadAndManifest chunksPayloadAndSend(
+      byte[] serializedKey,
+      byte[] payload,
+      int schemaId,
+      Callback callback,
+      Supplier<String> sizeReport,
+      int maxSizeForUserPayloadPerMessageInBytes,
+      KeyWithChunkingSuffixSerializer keyWithChunkingSuffixSerializer,
+      BiFunction<VeniceWriter.KeyProvider, Put, Future<RecordMetadata>> sendMessageFunction) {
+    int sizeAvailablePerMessage = maxSizeForUserPayloadPerMessageInBytes - serializedKey.length;
+    validateAvailableSizePerMessage(maxSizeForUserPayloadPerMessageInBytes, sizeAvailablePerMessage, sizeReport);
+    int numberOfChunks = (int) Math.ceil((double) payload.length / (double) sizeAvailablePerMessage);
+    final ChunkedValueManifest chunkedValueManifest = new ChunkedValueManifest();
+    chunkedValueManifest.schemaId = schemaId;
+    chunkedValueManifest.keysWithChunkIdSuffix = new ArrayList<>(numberOfChunks);
+    chunkedValueManifest.size = payload.length;
+
+    VeniceWriter.KeyProvider keyProvider, firstKeyProvider, subsequentKeyProvider;
+    boolean chunkAwareCallback = callback instanceof ChunkAwareCallback;
+    ByteBuffer[] chunks = null;
+    if (chunkAwareCallback) {
+      // We only carry this state if it's going to be used, else we don't even instantiate this
+      chunks = new ByteBuffer[numberOfChunks];
+    }
+
+    /**
+     * This {@link ChunkedKeySuffix} instance gets mutated along the way, first in the loop, where its
+     * chunk index is incremented at each iteration, and then also on the first iteration of the loop,
+     * the {@link firstKeyProvider} will extract {@link ProducerMetadata} information out of the first
+     * message sent, to be re-used across all chunk keys belonging to this value.
+     */
+    final ChunkedKeySuffix chunkedKeySuffix = new ChunkedKeySuffix();
+    chunkedKeySuffix.isChunk = true;
+    chunkedKeySuffix.chunkId = new ChunkId();
+
+    subsequentKeyProvider = producerMetadata -> {
+      ByteBuffer keyWithSuffix =
+          ByteBuffer.wrap(keyWithChunkingSuffixSerializer.serializeChunkedKey(serializedKey, chunkedKeySuffix));
+      chunkedValueManifest.keysWithChunkIdSuffix.add(keyWithSuffix);
+      return new KafkaKey(MessageType.PUT, keyWithSuffix.array());
+    };
+    firstKeyProvider = producerMetadata -> {
+      chunkedKeySuffix.chunkId.producerGUID = producerMetadata.producerGUID;
+      chunkedKeySuffix.chunkId.segmentNumber = producerMetadata.segmentNumber;
+      chunkedKeySuffix.chunkId.messageSequenceNumber = producerMetadata.messageSequenceNumber;
+      return subsequentKeyProvider.getKey(producerMetadata);
+    };
+    for (int chunkIndex = 0; chunkIndex < numberOfChunks; chunkIndex++) {
+      int chunkStartByteIndex = chunkIndex * sizeAvailablePerMessage;
+      int chunkEndByteIndex = Math.min((chunkIndex + 1) * sizeAvailablePerMessage, payload.length);
+
+      /**
+       * We leave 4 bytes of headroom at the beginning of the ByteBuffer so that the Venice Storage Node
+       * can use this room to write the value header, without allocating a new byte array nor copying.
+       */
+      final int chunkLength = chunkEndByteIndex - chunkStartByteIndex;
+      byte[] chunkValue = new byte[chunkLength + ByteUtils.SIZE_OF_INT];
+      System.arraycopy(payload, chunkStartByteIndex, chunkValue, ByteUtils.SIZE_OF_INT, chunkLength);
+      ByteBuffer chunk = ByteBuffer.wrap(chunkValue);
+      chunk.position(ByteUtils.SIZE_OF_INT);
+
+      if (chunks != null) {
+        chunks[chunkIndex] = chunk;
+      }
+
+      Put putPayload = new Put();
+      putPayload.putValue = chunk;
+      putPayload.schemaId = AvroProtocolDefinition.CHUNK.getCurrentProtocolVersion();
+      putPayload.replicationMetadataVersionId = VENICE_DEFAULT_TIMESTAMP_METADATA_VERSION_ID;
+      putPayload.replicationMetadataPayload = EMPTY_BYTE_BUFFER;
+
+      chunkedKeySuffix.chunkId.chunkIndex = chunkIndex;
+      keyProvider = chunkIndex == 0 ? firstKeyProvider : subsequentKeyProvider;
+
+      try {
+        /**
+         * Here are the reasons to do a blocking call of 'sendMessage' with 'null' callback:
+         * 1. We don't want the upper layer know the chunking logic here. Right now, if we pass the callback parameter,
+         * it will cause the job failure because the message count of sent/completed in 'VeniceReducer' won't match;
+         * 2. Blocking call could guarantee correctness;
+         * 3. Infinite blocking means the following 'sendMessage' call will follow the config of the internal Kafka Producer,
+         * such as timeout, retries and so on;
+         */
+        sendMessageFunction.apply(keyProvider, putPayload).get();
+      } catch (Exception e) {
+        throw new VeniceException(
+            "Caught an exception while attempting to produce a chunk of a large value into Kafka... "
+                + getDetailedSizeReport(chunkIndex, numberOfChunks, sizeAvailablePerMessage, sizeReport),
+            e);
+      }
+    }
+    return new ChunkedPayloadAndManifest(chunkedValueManifest, chunks);
+  }
+
+  private static String getDetailedSizeReport(
+      int chunkIndex,
+      int numberOfChunks,
+      int sizeAvailablePerMessage,
+      Supplier<String> sizeReport) {
+    return "Current chunk index: " + chunkIndex + ", " + "Number of chunks: " + numberOfChunks + ", "
+        + "Size available per message: " + sizeAvailablePerMessage + ", " + sizeReport.get();
+  }
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/writer/ChunkHelper.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/writer/ChunkHelper.java
@@ -1,0 +1,4 @@
+package com.linkedin.venice.writer;
+
+public class ChunkHelper {
+}

--- a/internal/venice-common/src/main/java/com/linkedin/venice/writer/ChunkHelper.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/writer/ChunkHelper.java
@@ -1,6 +1,6 @@
 package com.linkedin.venice.writer;
 
-import static com.linkedin.venice.writer.VeniceWriter.*;
+import static com.linkedin.venice.writer.VeniceWriter.VENICE_DEFAULT_TIMESTAMP_METADATA_VERSION_ID;
 
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.kafka.protocol.Put;
@@ -156,7 +156,11 @@ public class ChunkHelper {
       int numberOfChunks,
       int sizeAvailablePerMessage,
       Supplier<String> sizeReport) {
-    return "Current chunk index: " + chunkIndex + ", " + "Number of chunks: " + numberOfChunks + ", "
-        + "Size available per message: " + sizeAvailablePerMessage + ", " + sizeReport.get();
+    return String.format(
+        "Current chunk index: %d, Number of chunks: %d, Size available per message: %d, %s",
+        chunkIndex,
+        numberOfChunks,
+        sizeAvailablePerMessage,
+        sizeReport.get());
   }
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/writer/ChunkedPayloadAndManifest.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/writer/ChunkedPayloadAndManifest.java
@@ -1,0 +1,23 @@
+package com.linkedin.venice.writer;
+
+import com.linkedin.venice.storage.protocol.ChunkedValueManifest;
+import java.nio.ByteBuffer;
+
+
+public class ChunkedPayloadAndManifest {
+  ByteBuffer[] payloadChunks;
+  ChunkedValueManifest chunkedValueManifest;
+
+  public ChunkedPayloadAndManifest(ChunkedValueManifest chunkedValueManifest, ByteBuffer[] payloadChunks) {
+    this.payloadChunks = payloadChunks;
+    this.chunkedValueManifest = chunkedValueManifest;
+  }
+
+  public ByteBuffer[] getPayloadChunks() {
+    return payloadChunks;
+  }
+
+  public ChunkedValueManifest getChunkedValueManifest() {
+    return chunkedValueManifest;
+  }
+}

--- a/internal/venice-common/src/main/java/com/linkedin/venice/writer/ChunkedPayloadAndManifest.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/writer/ChunkedPayloadAndManifest.java
@@ -4,11 +4,14 @@ import com.linkedin.venice.storage.protocol.ChunkedValueManifest;
 import java.nio.ByteBuffer;
 
 
+/**
+ * This class contains both chunked results and manifest for a specific payload.
+ */
 public class ChunkedPayloadAndManifest {
   ByteBuffer[] payloadChunks;
   ChunkedValueManifest chunkedValueManifest;
 
-  public ChunkedPayloadAndManifest(ChunkedValueManifest chunkedValueManifest, ByteBuffer[] payloadChunks) {
+  public ChunkedPayloadAndManifest(ByteBuffer[] payloadChunks, ChunkedValueManifest chunkedValueManifest) {
     this.payloadChunks = payloadChunks;
     this.chunkedValueManifest = chunkedValueManifest;
   }

--- a/internal/venice-common/src/test/java/com/linkedin/venice/writer/ChunkHelperTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/writer/ChunkHelperTest.java
@@ -1,0 +1,26 @@
+package com.linkedin.venice.writer;
+
+import com.linkedin.venice.serialization.KeyWithChunkingSuffixSerializer;
+import java.util.concurrent.CompletableFuture;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class ChunkHelperTest {
+  @Test
+  public void testChunkPayload() {
+    byte[] keyBytes = new byte[10];
+    byte[] valueBytes = new byte[100];
+    int maxSizeForUserPayloadPerMessageInBytes = 30;
+    ChunkedPayloadAndManifest result = ChunkHelper.chunkPayloadAndSend(
+        keyBytes,
+        valueBytes,
+        1,
+        true,
+        () -> "",
+        maxSizeForUserPayloadPerMessageInBytes,
+        new KeyWithChunkingSuffixSerializer(),
+        (x, y) -> CompletableFuture.completedFuture(null));
+    Assert.assertEquals(result.payloadChunks.length, 5);
+  }
+}


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci], [server], [controller],
[router], [samza], [vpj], [fast-client], [thin-client], [alpini],
[admin-tool], [test], [build], [doc], [script]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Adds RMD chunking support in Venice Writer
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

This PR adds support of chunking RMD in Venice Writer only. It is controlled by a "isRmdChunkingEnabled" flag and for now we hardcode it to false as there is no downstream handling logic. Once downstream logic is ready it will be configurable.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
Internal CI

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.