### PR TITLE
[server] Add back emission of avg/max of consumed record e2e processing latency metric

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/IngestionStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/IngestionStats.java
@@ -299,6 +299,14 @@ public class IngestionStats {
     stalePartitionsWithoutIngestionTaskSensor.record();
   }
 
+  public double getConsumedRecordEndToEndProcessingLatencyAvg() {
+    return consumedRecordEndToEndProcessingLatencySensor.getAvg();
+  }
+
+  public double getConsumedRecordEndToEndProcessingLatencyMax() {
+    return consumedRecordEndToEndProcessingLatencySensor.getMax();
+  }
+
   public void recordConsumedRecordEndToEndProcessingLatency(double value) {
     consumedRecordEndToEndProcessingLatencySensor.record(value);
   }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/IngestionStatsReporter.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/IngestionStatsReporter.java
@@ -1,6 +1,33 @@
 package com.linkedin.davinci.stats;
 
-import static com.linkedin.davinci.stats.IngestionStats.*;
+import static com.linkedin.davinci.stats.IngestionStats.BATCH_FOLLOWER_OFFSET_LAG;
+import static com.linkedin.davinci.stats.IngestionStats.BATCH_LEADER_OFFSET_LAG;
+import static com.linkedin.davinci.stats.IngestionStats.BATCH_REPLICATION_LAG;
+import static com.linkedin.davinci.stats.IngestionStats.BYTES_CONSUMED_METRIC_NAME;
+import static com.linkedin.davinci.stats.IngestionStats.CONSUMED_RECORD_END_TO_END_PROCESSING_LATENCY;
+import static com.linkedin.davinci.stats.IngestionStats.FOLLOWER_BYTES_CONSUMED_METRIC_NAME;
+import static com.linkedin.davinci.stats.IngestionStats.FOLLOWER_OFFSET_LAG;
+import static com.linkedin.davinci.stats.IngestionStats.FOLLOWER_RECORDS_CONSUMED_METRIC_NAME;
+import static com.linkedin.davinci.stats.IngestionStats.HYBRID_FOLLOWER_OFFSET_LAG;
+import static com.linkedin.davinci.stats.IngestionStats.HYBRID_LEADER_OFFSET_LAG;
+import static com.linkedin.davinci.stats.IngestionStats.INGESTION_TASK_ERROR_GAUGE;
+import static com.linkedin.davinci.stats.IngestionStats.INGESTION_TASK_PUSH_TIMEOUT_GAUGE;
+import static com.linkedin.davinci.stats.IngestionStats.LEADER_BYTES_CONSUMED_METRIC_NAME;
+import static com.linkedin.davinci.stats.IngestionStats.LEADER_BYTES_PRODUCED_METRIC_NAME;
+import static com.linkedin.davinci.stats.IngestionStats.LEADER_OFFSET_LAG;
+import static com.linkedin.davinci.stats.IngestionStats.LEADER_RECORDS_CONSUMED_METRIC_NAME;
+import static com.linkedin.davinci.stats.IngestionStats.LEADER_RECORDS_PRODUCED_METRIC_NAME;
+import static com.linkedin.davinci.stats.IngestionStats.LEADER_STALLED_HYBRID_INGESTION_METRIC_NAME;
+import static com.linkedin.davinci.stats.IngestionStats.OFFSET_REGRESSION_DCR_ERROR;
+import static com.linkedin.davinci.stats.IngestionStats.READY_TO_SERVE_WITH_RT_LAG_METRIC_NAME;
+import static com.linkedin.davinci.stats.IngestionStats.RECORDS_CONSUMED_METRIC_NAME;
+import static com.linkedin.davinci.stats.IngestionStats.STALE_PARTITIONS_WITHOUT_INGESTION_TASK_METRIC_NAME;
+import static com.linkedin.davinci.stats.IngestionStats.SUBSCRIBE_ACTION_PREP_LATENCY;
+import static com.linkedin.davinci.stats.IngestionStats.TIMESTAMP_REGRESSION_DCR_ERROR;
+import static com.linkedin.davinci.stats.IngestionStats.TOMBSTONE_CREATION_DCR;
+import static com.linkedin.davinci.stats.IngestionStats.TOTAL_DCR;
+import static com.linkedin.davinci.stats.IngestionStats.UPDATE_IGNORED_DCR;
+import static com.linkedin.davinci.stats.IngestionStats.WRITE_COMPUTE_OPERATION_FAILURE;
 import static com.linkedin.venice.stats.StatsErrorCode.NULL_INGESTION_STATS;
 
 import com.linkedin.venice.common.VeniceSystemStoreUtils;

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/IngestionStatsReporter.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/IngestionStatsReporter.java
@@ -1,32 +1,6 @@
 package com.linkedin.davinci.stats;
 
-import static com.linkedin.davinci.stats.IngestionStats.BATCH_FOLLOWER_OFFSET_LAG;
-import static com.linkedin.davinci.stats.IngestionStats.BATCH_LEADER_OFFSET_LAG;
-import static com.linkedin.davinci.stats.IngestionStats.BATCH_REPLICATION_LAG;
-import static com.linkedin.davinci.stats.IngestionStats.BYTES_CONSUMED_METRIC_NAME;
-import static com.linkedin.davinci.stats.IngestionStats.FOLLOWER_BYTES_CONSUMED_METRIC_NAME;
-import static com.linkedin.davinci.stats.IngestionStats.FOLLOWER_OFFSET_LAG;
-import static com.linkedin.davinci.stats.IngestionStats.FOLLOWER_RECORDS_CONSUMED_METRIC_NAME;
-import static com.linkedin.davinci.stats.IngestionStats.HYBRID_FOLLOWER_OFFSET_LAG;
-import static com.linkedin.davinci.stats.IngestionStats.HYBRID_LEADER_OFFSET_LAG;
-import static com.linkedin.davinci.stats.IngestionStats.INGESTION_TASK_ERROR_GAUGE;
-import static com.linkedin.davinci.stats.IngestionStats.INGESTION_TASK_PUSH_TIMEOUT_GAUGE;
-import static com.linkedin.davinci.stats.IngestionStats.LEADER_BYTES_CONSUMED_METRIC_NAME;
-import static com.linkedin.davinci.stats.IngestionStats.LEADER_BYTES_PRODUCED_METRIC_NAME;
-import static com.linkedin.davinci.stats.IngestionStats.LEADER_OFFSET_LAG;
-import static com.linkedin.davinci.stats.IngestionStats.LEADER_RECORDS_CONSUMED_METRIC_NAME;
-import static com.linkedin.davinci.stats.IngestionStats.LEADER_RECORDS_PRODUCED_METRIC_NAME;
-import static com.linkedin.davinci.stats.IngestionStats.LEADER_STALLED_HYBRID_INGESTION_METRIC_NAME;
-import static com.linkedin.davinci.stats.IngestionStats.OFFSET_REGRESSION_DCR_ERROR;
-import static com.linkedin.davinci.stats.IngestionStats.READY_TO_SERVE_WITH_RT_LAG_METRIC_NAME;
-import static com.linkedin.davinci.stats.IngestionStats.RECORDS_CONSUMED_METRIC_NAME;
-import static com.linkedin.davinci.stats.IngestionStats.STALE_PARTITIONS_WITHOUT_INGESTION_TASK_METRIC_NAME;
-import static com.linkedin.davinci.stats.IngestionStats.SUBSCRIBE_ACTION_PREP_LATENCY;
-import static com.linkedin.davinci.stats.IngestionStats.TIMESTAMP_REGRESSION_DCR_ERROR;
-import static com.linkedin.davinci.stats.IngestionStats.TOMBSTONE_CREATION_DCR;
-import static com.linkedin.davinci.stats.IngestionStats.TOTAL_DCR;
-import static com.linkedin.davinci.stats.IngestionStats.UPDATE_IGNORED_DCR;
-import static com.linkedin.davinci.stats.IngestionStats.WRITE_COMPUTE_OPERATION_FAILURE;
+import static com.linkedin.davinci.stats.IngestionStats.*;
 import static com.linkedin.venice.stats.StatsErrorCode.NULL_INGESTION_STATS;
 
 import com.linkedin.venice.common.VeniceSystemStoreUtils;
@@ -121,6 +95,12 @@ public class IngestionStatsReporter extends AbstractVeniceStatsReporter<Ingestio
       registerSensor(
           SUBSCRIBE_ACTION_PREP_LATENCY + "_max",
           new IngestionStatsGauge(this, () -> getStats().getSubscribePrepLatencyMax(), 0));
+      registerSensor(
+          CONSUMED_RECORD_END_TO_END_PROCESSING_LATENCY + "_avg",
+          new IngestionStatsGauge(this, () -> getStats().getConsumedRecordEndToEndProcessingLatencyAvg(), 0));
+      registerSensor(
+          CONSUMED_RECORD_END_TO_END_PROCESSING_LATENCY + "_max",
+          new IngestionStatsGauge(this, () -> getStats().getConsumedRecordEndToEndProcessingLatencyMax(), 0));
     }
   }
 


### PR DESCRIPTION


<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci], [server], [controller],
[router], [samza], [vpj], [fast-client], [thin-client], [alpini],
[admin-tool], [test], [build], [doc], [script]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Add back record consumption avg/max latency metric
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

This PR fixes a bug: Avg/Max metric of e2e record consumption latency is missing. The bug was introduced during previous refactor of metrics and the retrieval and registration of these two metrics were lost.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
Internal CI

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.