### PR TITLE
[vpj][server] Make Zstd compression threadsafe

### DIFF
--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/utils/HashCodeComparator.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/utils/HashCodeComparator.java
@@ -1,0 +1,24 @@
+package com.linkedin.venice.utils;
+
+import java.util.Comparator;
+
+
+public final class HashCodeComparator<T> implements Comparator<T> {
+  @Override
+  public int compare(T o1, T o2) {
+    int h1 = o1.hashCode();
+    int h2 = o2.hashCode();
+    if (h1 == h2) {
+      return 0;
+    } else if (h1 > h2) {
+      return 1;
+    } else {
+      return -1;
+    }
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    return obj.hashCode() == this.hashCode();
+  }
+}

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/utils/concurrent/CloseableThreadLocal.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/utils/concurrent/CloseableThreadLocal.java
@@ -51,6 +51,7 @@ public class CloseableThreadLocal<T extends AutoCloseable> implements AutoClosea
   @Override
   public void close() {
     valueSet.parallelStream().forEach(this::closeQuietly);
+    valueSet.clear();
   }
 
   private Supplier<T> wrap(Supplier<T> initialValue) {
@@ -67,7 +68,5 @@ public class CloseableThreadLocal<T extends AutoCloseable> implements AutoClosea
     } catch (Exception e) {
       LOGGER.error(e);
     }
-
-    valueSet.remove(value);
   }
 }

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/utils/concurrent/CloseableThreadLocal.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/utils/concurrent/CloseableThreadLocal.java
@@ -1,0 +1,95 @@
+package com.linkedin.venice.utils.concurrent;
+
+import java.util.Set;
+import java.util.function.Supplier;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+
+/**
+ * A wrapper of {@link ThreadLocal} for {@link AutoCloseable} objects.
+ * Java's {@link ThreadLocal} only dereferences the thread-local objects
+ * when the {@link Thread} exits which triggers their garbage collection.
+ * It does not {@code close} the {@link AutoCloseable} thread-local objects.
+ * @param <T> The {@link AutoCloseable} type whose objects will be held by an object of this class.
+ */
+public class CloseableThreadLocal<T extends AutoCloseable> implements AutoCloseable {
+  private static final Logger LOGGER = LogManager.getLogger(CloseableThreadLocal.class);
+  private final Set<T> itemSet = VeniceConcurrentHashMap.newKeySet();
+  private final ThreadLocal<T> threadLocal;
+
+  /**
+   * Creates a closeable thread local. The initial value of the
+   * variable is determined by invoking the {@code get} method
+   * on the {@code Supplier}.
+   * @param initialValue the supplier to be used to determine
+   *                     the initial value for each Thread
+   */
+  public CloseableThreadLocal(Supplier<T> initialValue) {
+    this.threadLocal = ThreadLocal.withInitial(initialValue);
+  }
+
+  /**
+   * Returns the value in the current thread's copy of this
+   * thread-local variable.  If the variable has no value for the
+   * current thread, it is first initialized to the value returned
+   * by an invocation of the {@code initialValue} method.
+   *
+   * @return the current thread's value of this thread-local
+   */
+  public T get() {
+    T item = threadLocal.get();
+    itemSet.add(item);
+    return item;
+  }
+
+  /**
+   * Removes the current thread's value for this thread-local
+   * variable. It also triggers {@code close} on the current
+   * thread's value. If this thread-local variable is subsequently
+   * {@linkplain #get read} by the current thread, its value will be
+   * reinitialized by invoking its {@code initialValue} method,
+   * unless its value is {@linkplain #set set} by the current thread
+   * in the interim. This may result in multiple invocations of the
+   * {@code initialValue} method in the current thread.
+   */
+  public void remove() {
+    closeQuietly(threadLocal.get());
+    threadLocal.remove();
+  }
+
+  /**
+   * Sets the current thread's copy of this thread-local variable
+   * to the specified value. Most subclasses will have no need to
+   * override this method, relying solely on the {@code initialValue}
+   * method to set the values of thread-locals.
+   *
+   * @param value the value to be stored in the current thread's copy of
+   *        this thread-local.
+   */
+  public void set(T value) {
+    threadLocal.set(value);
+    itemSet.add(value);
+  }
+
+  /**
+   * Clean up the resources held by this object. It triggers {@code close}
+   * on each thread's value. It is the responsibility of the caller to ensure
+   * that all threads have finished processing the thread-local objects.
+   */
+  @Override
+  public void close() {
+    itemSet.parallelStream().forEach(this::closeQuietly);
+  }
+
+  private void closeQuietly(T closeable) {
+    if (closeable != null) {
+      try {
+        closeable.close();
+      } catch (Exception e) {
+        LOGGER.error(e);
+      }
+      itemSet.remove(closeable);
+    }
+  }
+}

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/compression/TestVeniceCompressor.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/compression/TestVeniceCompressor.java
@@ -1,0 +1,74 @@
+package com.linkedin.venice.compression;
+
+import com.github.luben.zstd.Zstd;
+import com.linkedin.venice.utils.TestUtils;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Random;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+
+public class TestVeniceCompressor {
+  private static final Logger LOGGER = LogManager.getLogger(TestVeniceCompressor.class);
+
+  @DataProvider(name = "Stateless-Compressor")
+  public static Object[][] statelessCompressorProvider() {
+    return new Object[][] { { CompressionStrategy.NO_OP }, { CompressionStrategy.GZIP } };
+  }
+
+  @Test
+  public void testMultiThreadZstdCompression() throws IOException {
+    byte[] dictionary = ZstdWithDictCompressor.buildDictionaryOnSyntheticAvroData();
+    try (VeniceCompressor compressor =
+        new CompressorFactory().createCompressorWithDictionary(dictionary, Zstd.maxCompressionLevel())) {
+      runTest(compressor);
+    }
+  }
+
+  @Test(dataProvider = "Stateless-Compressor")
+  public void testMultiThreadCompression(CompressionStrategy compressionStrategy) throws IOException {
+    try (VeniceCompressor compressor = new CompressorFactory().getCompressor(compressionStrategy)) {
+      runTest(compressor);
+    }
+  }
+
+  private void runTest(VeniceCompressor compressor) {
+    int threadPoolSize = 100;
+    int numThreads = threadPoolSize * 10;
+    ExecutorService executorService = Executors.newFixedThreadPool(threadPoolSize);
+    try {
+      for (int i = 0; i < numThreads; i++) {
+        Runnable runnable = () -> {
+          Random rd = new Random();
+          byte[] data = new byte[50];
+          rd.nextBytes(data);
+          ByteBuffer dataBuffer = ByteBuffer.wrap(data);
+          try {
+            compressor.compress(dataBuffer);
+          } catch (Exception e) {
+            LOGGER.error(e);
+            throw new RuntimeException(e);
+          }
+        };
+        executorService.submit(runnable);
+      }
+    } finally {
+      executorService.shutdown();
+    }
+
+    TestUtils.waitForNonDeterministicAssertion(10, TimeUnit.SECONDS, false, true, () -> {
+      try {
+        executorService.awaitTermination(Long.MAX_VALUE, TimeUnit.NANOSECONDS);
+      } catch (InterruptedException e) {
+        Assert.fail();
+      }
+    });
+  }
+}

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/compression/TestVeniceCompressor.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/compression/TestVeniceCompressor.java
@@ -52,11 +52,11 @@ public class TestVeniceCompressor {
 
   private void runTestInternal(VeniceCompressor compressor, SourceDataType type) {
     int threadPoolSize = 1;
-    int numThreads = 1000;
+    int numRunnables = 1000;
     ExecutorService executorService = Executors.newFixedThreadPool(threadPoolSize);
-    List<Future> compressionFutures = new ArrayList<>(numThreads);
+    List<Future> compressionFutures = new ArrayList<>(numRunnables);
     try {
-      for (int i = 0; i < numThreads; i++) {
+      for (int i = 0; i < numRunnables; i++) {
         Random rd = new Random();
         byte[] data = new byte[50];
         Runnable runnable = () -> {
@@ -92,7 +92,7 @@ public class TestVeniceCompressor {
 
     TestUtils.waitForNonDeterministicAssertion(10, TimeUnit.SECONDS, false, true, () -> {
       try {
-        executorService.awaitTermination(Long.MAX_VALUE, TimeUnit.NANOSECONDS);
+        executorService.awaitTermination(1, TimeUnit.SECONDS);
       } catch (InterruptedException e) {
         Assert.fail();
       }

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/utils/concurrent/CloseableThreadLocalTest.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/utils/concurrent/CloseableThreadLocalTest.java
@@ -6,7 +6,6 @@ import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -30,49 +29,6 @@ public class CloseableThreadLocalTest {
   public void testGet() {
     try (CloseableThreadLocal<CloseableClass> numbers = new CloseableThreadLocal<>(() -> new CloseableClass(5))) {
       Assert.assertEquals(numbers.get().value, 5);
-    }
-  }
-
-  @Test
-  public void testRemove() {
-    CloseableClass initialValue;
-    try (CloseableThreadLocal<CloseableClass> numbers = new CloseableThreadLocal<>(() -> new CloseableClass(5))) {
-      initialValue = numbers.get();
-      Assert.assertEquals(initialValue.value, 5); // Initialize the value
-      numbers.remove();
-      Assert.assertTrue(initialValue.closed);
-      // Override closed to test if the object gets closed a second time
-      initialValue.closed = false;
-    }
-
-    // A previously removed object must not get closed a second time. If it does, it indicates a memory leak.
-    Assert.assertFalse(initialValue.closed);
-  }
-
-  @Test
-  public void testSet() {
-    AtomicBoolean initializerCalled = new AtomicBoolean(false);
-    try (CloseableThreadLocal<CloseableClass> numbers = new CloseableThreadLocal<>(() -> {
-      initializerCalled.set(true);
-      return new CloseableClass(5);
-    })) {
-      numbers.set(new CloseableClass(7));
-      CloseableClass initialValue = numbers.get();
-      Assert.assertEquals(initialValue.value, 7);
-    }
-
-    // The initializer must never be invoked
-    Assert.assertFalse(initializerCalled.get());
-  }
-
-  @Test
-  public void testSetClosesPreviousValue() {
-    try (CloseableThreadLocal<CloseableClass> numbers = new CloseableThreadLocal<>(() -> new CloseableClass(5))) {
-      numbers.set(new CloseableClass(7));
-      CloseableClass initialValue = numbers.get();
-      numbers.set(new CloseableClass(8));
-      Assert.assertTrue(initialValue.closed);
-      Assert.assertEquals(numbers.get().value, 8);
     }
   }
 

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/utils/concurrent/CloseableThreadLocalTest.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/utils/concurrent/CloseableThreadLocalTest.java
@@ -1,0 +1,119 @@
+package com.linkedin.venice.utils.concurrent;
+
+import com.linkedin.venice.utils.TestUtils;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class CloseableThreadLocalTest {
+  private static class CloseableClass implements AutoCloseable {
+    private boolean closed = false;
+    private int value;
+
+    public CloseableClass(int value) {
+      this.value = value;
+    }
+
+    @Override
+    public void close() throws Exception {
+      closed = true;
+    }
+  }
+
+  @Test
+  public void testGet() {
+    try (CloseableThreadLocal<CloseableClass> numbers = new CloseableThreadLocal<>(() -> new CloseableClass(5))) {
+      Assert.assertEquals(numbers.get().value, 5);
+    }
+  }
+
+  @Test
+  public void testRemove() {
+    CloseableClass initialValue;
+    try (CloseableThreadLocal<CloseableClass> numbers = new CloseableThreadLocal<>(() -> new CloseableClass(5))) {
+      initialValue = numbers.get();
+      Assert.assertEquals(initialValue.value, 5); // Initialize the value
+      numbers.remove();
+      Assert.assertTrue(initialValue.closed);
+      // Override closed to test if the object gets closed a second time
+      initialValue.closed = false;
+    }
+
+    // A previously removed object must not get closed a second time. If it does, it indicates a memory leak.
+    Assert.assertFalse(initialValue.closed);
+  }
+
+  @Test
+  public void testSet() {
+    AtomicBoolean initializerCalled = new AtomicBoolean(false);
+    try (CloseableThreadLocal<CloseableClass> numbers = new CloseableThreadLocal<>(() -> {
+      initializerCalled.set(true);
+      return new CloseableClass(5);
+    })) {
+      numbers.set(new CloseableClass(7));
+      CloseableClass initialValue = numbers.get();
+      Assert.assertEquals(initialValue.value, 7);
+    }
+
+    // The initializer must never be invoked
+    Assert.assertFalse(initializerCalled.get());
+  }
+
+  @Test
+  public void testSetClosesPreviousValue() {
+    try (CloseableThreadLocal<CloseableClass> numbers = new CloseableThreadLocal<>(() -> new CloseableClass(5))) {
+      numbers.set(new CloseableClass(7));
+      CloseableClass initialValue = numbers.get();
+      numbers.set(new CloseableClass(8));
+      Assert.assertTrue(initialValue.closed);
+      Assert.assertEquals(numbers.get().value, 8);
+    }
+  }
+
+  @Test
+  public void testClose() {
+    CloseableThreadLocal<CloseableClass> numbers = new CloseableThreadLocal<>(() -> new CloseableClass(5));
+    Set<CloseableClass> closeableObjects = new HashSet<>();
+    int threadPoolSize = 10;
+    int numRunnables = 1000;
+    ExecutorService executorService = Executors.newFixedThreadPool(threadPoolSize);
+    try {
+      for (int i = 0; i < numRunnables; i++) {
+        executorService.submit(() -> {
+          closeableObjects.add(numbers.get());
+        });
+      }
+    } finally {
+      executorService.shutdown();
+    }
+
+    TestUtils.waitForNonDeterministicAssertion(10, TimeUnit.SECONDS, false, true, () -> {
+      try {
+        executorService.awaitTermination(1, TimeUnit.SECONDS);
+      } catch (InterruptedException e) {
+        Assert.fail();
+      }
+    });
+
+    // Assert there are separate objects created for each thread
+    Assert.assertEquals(closeableObjects.size(), threadPoolSize);
+
+    // Verify that the objects have not been closed yet
+    for (CloseableClass object: closeableObjects) {
+      Assert.assertFalse(object.closed);
+    }
+
+    numbers.close();
+
+    // Verify that the objects have now been closed
+    for (CloseableClass object: closeableObjects) {
+      Assert.assertTrue(object.closed);
+    }
+  }
+}

--- a/internal/venice-client-common/src/test/resources/log4j.properties
+++ b/internal/venice-client-common/src/test/resources/log4j.properties
@@ -1,0 +1,9 @@
+# Define root logger
+log = /tmp/log4j
+log4j.rootLogger = INFO, stdout
+
+# Direct log messages to stdout
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.Target=System.out
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%d{ISO8601} %-5p %c{1}:%L - %m%n

--- a/internal/venice-client-common/src/test/resources/log4j2.properties
+++ b/internal/venice-client-common/src/test/resources/log4j2.properties
@@ -1,0 +1,18 @@
+status = error
+name = PropertiesConfig
+
+filters = threshold
+
+filter.threshold.type = ThresholdFilter
+filter.threshold.level = debug
+
+appenders = console
+
+appender.console.type = Console
+appender.console.name = STDOUT
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss} %p [%c{1}] [%t] %m%n
+
+rootLogger.level = info
+rootLogger.appenderRefs = stdout
+rootLogger.appenderRef.stdout.ref = STDOUT


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci], [server], [controller],
[router], [samza], [vpj], [fast-client], [thin-client], [alpini],
[admin-tool], [test], [build], [doc], [script]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->


## Make Zstd compression threadsafe
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
This commit uses a thread-local `ZstdCompressorCtx` objects since they are not thread-safe. To help with closing of these objects cleanly, a new `CloseableThreadLocal` class is also created

Resolves #88

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
Added new unit tests.
Internal CI - JDK11 #6647

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.