### PR TITLE
[router] unhealthy host metrics should initialize/reset to 0

### DIFF
--- a/services/venice-router/src/main/java/com/linkedin/venice/router/api/VeniceHostHealth.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/api/VeniceHostHealth.java
@@ -73,8 +73,8 @@ public class VeniceHostHealth implements HostHealthMonitor<Instance> {
     if (unhealthyHosts.contains(identifier)) {
       unhealthyHosts.remove(identifier);
       LOGGER.info("Marking {} back to healthy host", identifier);
-      aggHostHealthStats.recordUnhealthyHostCountCausedByRouterHeartBeat(unhealthyHosts.size());
     }
+    aggHostHealthStats.recordUnhealthyHostCountCausedByRouterHeartBeat(unhealthyHosts.size());
   }
 
   @Override
@@ -124,6 +124,7 @@ public class VeniceHostHealth implements HostHealthMonitor<Instance> {
         if (pendingRequestUnhealthyTimeMap.remove(nodeId) != null) {
           routeHttpRequestStats.recordUnhealthyQueueDuration(nodeId, duration);
           aggHostHealthStats.recordPendingRequestUnhealthyDuration(nodeId, duration);
+          aggHostHealthStats.recordUnhealthyHostCountCausedByPendingQueue(pendingRequestUnhealthyTimeMap.size());
         }
         return false;
       }


### PR DESCRIPTION
## Unhealthy host metrics should initialize/reset to 0

0 should be emitted instead of no emission when there are no unhealthy hosts.

- unhealthy_host_count_caused_by_router_heart_beat is not in the hot path so we can emit the current unhealthy host count every time when the heartbeat succeeds (regardless if the count changed).
- unhealthy_host_count_caused_by_pending_queue is in the hot path but we should still emit the updated unhealthy host count when a host is recovered from an unhealthy state.

## How was this PR tested?
Existing unit and integration tests.

## Does this PR introduce any user-facing changes?
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.