### PR TITLE
[controller][common] Support version rollback in parent controller

### DIFF
--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerClient.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerClient.java
@@ -545,6 +545,11 @@ public class ControllerClient implements Closeable {
     return request(ControllerRoute.SET_VERSION, params, VersionResponse.class);
   }
 
+  public ControllerResponse rollbackToBackupVersion(String storeName) {
+    QueryParams params = newParams().add(NAME, storeName);
+    return request(ControllerRoute.ROLLBACK_TO_BACKUP_VERSION, params, ControllerResponse.class);
+  }
+
   public ControllerResponse killOfflinePushJob(String kafkaTopic) {
     String store = Version.parseStoreFromKafkaTopicName(kafkaTopic);
     int versionNumber = Version.parseVersionFromKafkaTopicName(kafkaTopic);

--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerClient.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerClient.java
@@ -226,6 +226,11 @@ public class ControllerClient implements Closeable {
     return request(ControllerRoute.STORE, params, StoreResponse.class);
   }
 
+  public StoreResponse getStore(String storeName, int timeoutMs) {
+    QueryParams params = newParams().add(NAME, storeName);
+    return request(ControllerRoute.STORE, params, StoreResponse.class, timeoutMs, 1, null);
+  }
+
   public RepushInfoResponse getRepushInfo(String storeName, Optional<String> fabircName) {
     QueryParams params = newParams().add(NAME, storeName);
     fabircName.ifPresent(s -> params.add(FABRIC, s));

--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerRoute.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerRoute.java
@@ -125,6 +125,7 @@ public enum ControllerRoute {
       REGULAR_VERSION_ETL_ENABLED, FUTURE_VERSION_ETL_ENABLED, ETLED_PROXY_USER_ACCOUNT, DISABLE_META_STORE,
       DISABLE_DAVINCI_PUSH_STATUS_STORE, PERSONA_NAME
   ), SET_VERSION("/set_version", HttpMethod.POST, Arrays.asList(NAME, VERSION)),
+  ROLLBACK_TO_BACKUP_VERSION("/rollback_to_backup_version", HttpMethod.POST, Collections.singletonList(NAME)),
   ENABLE_STORE("/enable_store", HttpMethod.POST, Arrays.asList(NAME, OPERATION, STATUS)), // status "true" or "false",
                                                                                           // operation "read" or "write"
                                                                                           // or "readwrite".

--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/StoreInfo.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/StoreInfo.java
@@ -1,12 +1,10 @@
 package com.linkedin.venice.meta;
 
 import static com.linkedin.venice.meta.Store.BOOTSTRAP_TO_ONLINE_TIMEOUT_IN_HOURS;
-import static com.linkedin.venice.meta.Store.NON_EXISTING_VERSION;
 import static com.linkedin.venice.meta.Store.NUM_VERSION_PRESERVE_NOT_SET;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.linkedin.venice.compression.CompressionStrategy;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -416,20 +414,6 @@ public class StoreInfo {
       }
     }
     return Optional.empty();
-  }
-
-  /**
-   * Get backup version number, the largest online version number that is less than the current version number
-   */
-  public int getBackupVersionNumber() {
-    int currentVersion = getCurrentVersion();
-    getVersions().sort(Comparator.comparingInt(Version::getNumber).reversed());
-    for (Version v: getVersions()) {
-      if (v.getNumber() < currentVersion && VersionStatus.ONLINE.equals(v.getStatus())) {
-        return v.getNumber();
-      }
-    }
-    return NON_EXISTING_VERSION;
   }
 
   public void setVersions(List<Version> versions) {

--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/StoreInfo.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/StoreInfo.java
@@ -1,10 +1,12 @@
 package com.linkedin.venice.meta;
 
 import static com.linkedin.venice.meta.Store.BOOTSTRAP_TO_ONLINE_TIMEOUT_IN_HOURS;
+import static com.linkedin.venice.meta.Store.NON_EXISTING_VERSION;
 import static com.linkedin.venice.meta.Store.NUM_VERSION_PRESERVE_NOT_SET;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.linkedin.venice.compression.CompressionStrategy;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -414,6 +416,20 @@ public class StoreInfo {
       }
     }
     return Optional.empty();
+  }
+
+  /**
+   * Get backup version number, the largest online version number that is less than the current version number
+   */
+  public int getBackupVersionNumber() {
+    int currentVersion = getCurrentVersion();
+    getVersions().sort(Comparator.comparingInt(Version::getNumber).reversed());
+    for (Version v: getVersions()) {
+      if (v.getNumber() < currentVersion && VersionStatus.ONLINE.equals(v.getStatus())) {
+        return v.getNumber();
+      }
+    }
+    return NON_EXISTING_VERSION;
   }
 
   public void setVersions(List<Version> versions) {

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/controller/TestParentControllerWithMultiDataCenter.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/controller/TestParentControllerWithMultiDataCenter.java
@@ -446,6 +446,5 @@ public class TestParentControllerWithMultiDataCenter {
         Assert.assertEquals(storeInfo.getCurrentVersion(), expectedVersion);
       });
     }
-    parentControllerClient.deleteKafkaTopic(Version.composeKafkaTopic(storeName, expectedVersion));
   }
 }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/Admin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/Admin.java
@@ -354,6 +354,8 @@ public interface Admin extends AutoCloseable, Closeable {
 
   void setStoreCurrentVersion(String clusterName, String storeName, int versionNumber);
 
+  void rollbackToBackupVersion(String clusterName, String storeName);
+
   void setStoreLargestUsedVersion(String clusterName, String storeName, int versionNumber);
 
   void setStoreOwner(String clusterName, String storeName, String owner);

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/StoreBackupVersionCleanupService.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/StoreBackupVersionCleanupService.java
@@ -125,7 +125,8 @@ public class StoreBackupVersionCleanupService extends AbstractVeniceService {
           storeName,
           clusterName);
       try {
-        admin.deleteOneStoreVersion(clusterName, storeName, versionNum);
+        // deleteOldVersionInStore will run additional check to avoid deleting current version
+        admin.deleteOldVersionInStore(clusterName, storeName, versionNum);
       } catch (Exception e) {
         LOGGER.error(
             "Encountered exception while trying to delete version: {}, store: {}, in cluster: {}",

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -3228,6 +3228,14 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
   }
 
   /**
+   * Unsupported operation in the child controller.
+   */
+  @Override
+  public void rollbackToBackupVersion(String clusterName, String storeName) {
+    throw new VeniceUnsupportedOperationException("rollbackToBackupVersion is not supported in child controller!");
+  }
+
+  /**
    * Update the largest used version number of a specified store.
    */
   @Override

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -6,6 +6,7 @@ import static com.linkedin.venice.controller.UserSystemStoreLifeCycleHelper.DEFA
 import static com.linkedin.venice.meta.HybridStoreConfigImpl.DEFAULT_HYBRID_OFFSET_LAG_THRESHOLD;
 import static com.linkedin.venice.meta.HybridStoreConfigImpl.DEFAULT_HYBRID_TIME_LAG_THRESHOLD;
 import static com.linkedin.venice.meta.HybridStoreConfigImpl.DEFAULT_REWIND_TIME_IN_SECONDS;
+import static com.linkedin.venice.meta.Store.NON_EXISTING_VERSION;
 import static com.linkedin.venice.meta.Version.PushType;
 import static com.linkedin.venice.meta.VersionStatus.ERROR;
 import static com.linkedin.venice.meta.VersionStatus.NOT_CREATED;
@@ -3228,11 +3229,35 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
   }
 
   /**
-   * Unsupported operation in the child controller.
+   * Set backup version as current version in a child region.
    */
   @Override
   public void rollbackToBackupVersion(String clusterName, String storeName) {
-    throw new VeniceUnsupportedOperationException("rollbackToBackupVersion is not supported in child controller!");
+    storeMetadataUpdate(clusterName, storeName, store -> {
+      if (!store.isEnableWrites()) {
+        throw new VeniceException(
+            "Unable to update store:" + storeName + " current version since store does not enable write");
+      }
+      int backupVersion = getBackupVersionNumber(store.getVersions(), store.getCurrentVersion());
+      if (backupVersion == Store.NON_EXISTING_VERSION) {
+        throw new VeniceException("Backup version does not exist for store:" + storeName);
+      }
+      store.setCurrentVersion(backupVersion);
+      return store;
+    });
+  }
+
+  /**
+   * Get backup version number, the largest online version number that is less than the current version number
+   */
+  int getBackupVersionNumber(List<Version> versions, int currentVersion) {
+    versions.sort(Comparator.comparingInt(Version::getNumber).reversed());
+    for (Version v: versions) {
+      if (v.getNumber() < currentVersion && VersionStatus.ONLINE.equals(v.getStatus())) {
+        return v.getNumber();
+      }
+    }
+    return NON_EXISTING_VERSION;
   }
 
   /**

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/AdminSparkServer.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/AdminSparkServer.java
@@ -79,6 +79,7 @@ import static com.linkedin.venice.controllerapi.ControllerRoute.REMOVE_NODE;
 import static com.linkedin.venice.controllerapi.ControllerRoute.REMOVE_STORE_FROM_GRAVEYARD;
 import static com.linkedin.venice.controllerapi.ControllerRoute.REPLICATE_META_DATA;
 import static com.linkedin.venice.controllerapi.ControllerRoute.REQUEST_TOPIC;
+import static com.linkedin.venice.controllerapi.ControllerRoute.ROLLBACK_TO_BACKUP_VERSION;
 import static com.linkedin.venice.controllerapi.ControllerRoute.SEND_PUSH_JOB_DETAILS;
 import static com.linkedin.venice.controllerapi.ControllerRoute.SET_MIGRATION_PUSH_STRATEGY;
 import static com.linkedin.venice.controllerapi.ControllerRoute.SET_OWNER;
@@ -333,6 +334,7 @@ public class AdminSparkServer extends AbstractVeniceService {
     httpService.post(DELETE_ALL_VERSIONS.getPath(), storesRoutes.deleteAllVersions(admin));
     httpService.post(DELETE_OLD_VERSION.getPath(), storesRoutes.deleteOldVersions(admin));
     httpService.post(SET_VERSION.getPath(), storesRoutes.setCurrentVersion(admin));
+    httpService.post(ROLLBACK_TO_BACKUP_VERSION.getPath(), storesRoutes.rollbackToBackupVersion(admin));
 
     httpService.get(ClUSTER_HEALTH_INSTANCES.getPath(), nodesAndReplicas.listAllNodesStatus(admin));
     httpService.get(LIST_NODES.getPath(), nodesAndReplicas.listAllNodes(admin));

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/StoresRoutes.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/StoresRoutes.java
@@ -44,6 +44,7 @@ import static com.linkedin.venice.controllerapi.ControllerRoute.LIST_STORES;
 import static com.linkedin.venice.controllerapi.ControllerRoute.LIST_STORE_PUSH_INFO;
 import static com.linkedin.venice.controllerapi.ControllerRoute.MIGRATE_STORE;
 import static com.linkedin.venice.controllerapi.ControllerRoute.REMOVE_STORE_FROM_GRAVEYARD;
+import static com.linkedin.venice.controllerapi.ControllerRoute.ROLLBACK_TO_BACKUP_VERSION;
 import static com.linkedin.venice.controllerapi.ControllerRoute.SET_OWNER;
 import static com.linkedin.venice.controllerapi.ControllerRoute.SET_TOPIC_COMPACTION;
 import static com.linkedin.venice.controllerapi.ControllerRoute.SET_VERSION;
@@ -558,6 +559,28 @@ public class StoresRoutes extends AbstractRoute {
         veniceResponse.setCluster(clusterName);
         veniceResponse.setName(storeName);
         veniceResponse.setVersion(version);
+      }
+    };
+  }
+
+  /**
+   * Set backup version as current version in all child regions.
+   */
+  public Route rollbackToBackupVersion(Admin admin) {
+    return new VeniceRouteHandler<ControllerResponse>(ControllerResponse.class) {
+      @Override
+      public void internalHandle(Request request, ControllerResponse veniceResponse) {
+        // Only allow allowlist users to run this command
+        if (!checkIsAllowListUser(request, veniceResponse, () -> isAllowListUser(request))) {
+          return;
+        }
+        AdminSparkServer.validateParams(request, ROLLBACK_TO_BACKUP_VERSION.getParams(), admin);
+        String clusterName = request.queryParams(CLUSTER);
+        String storeName = request.queryParams(NAME);
+        admin.rollbackToBackupVersion(clusterName, storeName);
+
+        veniceResponse.setCluster(clusterName);
+        veniceResponse.setName(storeName);
       }
     };
   }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/StoresRoutes.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/StoresRoutes.java
@@ -564,7 +564,7 @@ public class StoresRoutes extends AbstractRoute {
   }
 
   /**
-   * Set backup version as current version in all child regions.
+   * Set backup version as current version.
    */
   public Route rollbackToBackupVersion(Admin admin) {
     return new VeniceRouteHandler<ControllerResponse>(ControllerResponse.class) {

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestStoreBackupVersionCleanupService.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestStoreBackupVersionCleanupService.java
@@ -144,7 +144,7 @@ public class TestStoreBackupVersionCleanupService {
     versions.put(2, VersionStatus.ONLINE);
     Store storeWithTwoVersions = mockStore(-1, System.currentTimeMillis() - defaultRetentionMs * 2, versions, 2);
     Assert.assertTrue(service.cleanupBackupVersion(storeWithTwoVersions, clusterName));
-    verify(admin).deleteOneStoreVersion(clusterName, storeWithTwoVersions.getName(), 1);
+    verify(admin).deleteOldVersionInStore(clusterName, storeWithTwoVersions.getName(), 1);
 
     // Store is qualified, but rollback was executed
     versions.clear();
@@ -186,7 +186,7 @@ public class TestStoreBackupVersionCleanupService {
     TestUtils.waitForNonDeterministicAssertion(
         1,
         TimeUnit.SECONDS,
-        () -> verify(admin, atLeast(1)).deleteOneStoreVersion(clusterName, storeWithTwoVersions.getName(), 1));
+        () -> verify(admin, atLeast(1)).deleteOldVersionInStore(clusterName, storeWithTwoVersions.getName(), 1));
   }
 
 }


### PR DESCRIPTION
To make version rollback a self-service, we need to support it in parent controller.
Add a new controller API rollbackToBackupVersion. Callers do not need to specify
any version number. Parent controller will find the backup version to roll back by
calling child controllers. If backup version is consistent across child regions,
current version in all child regions will be rolled back to backup version.
Otherwise, current version won't be changed.

<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci], [server], [controller],
[router], [samza], [vpj], [fast-client], [thin-client], [alpini],
[admin-tool], [test], [build], [doc], [script]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
Integration test testStoreRollbackToBackupVersion
Internal CI

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.