### PR TITLE
[da-vinci][venice] Added aggregated metrics for disk usage and rmd usage

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/AbstractStorageEngine.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/AbstractStorageEngine.java
@@ -101,7 +101,15 @@ public abstract class AbstractStorageEngine<Partition extends AbstractStoragePar
 
   public abstract long getStoreSizeInBytes();
 
+  public long getCachedStoreSizeInBytes() {
+    return 0;
+  }
+
   public long getRMDSizeInBytes() {
+    return 0;
+  }
+
+  public long getCachedRMDSizeInBytes() {
     return 0;
   }
 

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/AbstractVeniceStats.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/AbstractVeniceStats.java
@@ -19,6 +19,7 @@ public class AbstractVeniceStats {
   private final MetricsRepository metricsRepository;
   private final String name;
   private final Map<String, Sensor> sensors;
+  private final boolean isTotalStats;
 
   public AbstractVeniceStats(MetricsRepository metricsRepository, String name) {
     this.metricsRepository = metricsRepository;
@@ -26,10 +27,16 @@ public class AbstractVeniceStats {
     // name and attribute name, so they cause issues if we let them slip in...
     this.name = name.replace(':', '_').replace(".", "_");
     this.sensors = new VeniceConcurrentHashMap<>();
+    this.isTotalStats = name.equals(STORE_NAME_FOR_TOTAL_STAT);
+    ;
   }
 
   public MetricsRepository getMetricsRepository() {
     return metricsRepository;
+  }
+
+  protected boolean isTotalStats() {
+    return isTotalStats;
   }
 
   public String getName() {


### PR DESCRIPTION
The aggregated metrics are using the cached disk usage to reduce the overhead, and the cached value should be updated regularly since there are store-level metrics for them as well.


## How was this PR tested?
Internal CI test passed

## Does this PR introduce any user-facing changes?
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.