### PR TITLE
[server] Implement server side handling logic for RMD chunking

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/AbstractStorageEngine.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/AbstractStorageEngine.java
@@ -405,6 +405,11 @@ public abstract class AbstractStorageEngine<Partition extends AbstractStoragePar
     partition.putWithReplicationMetadata(key, value, replicationMetadata);
   }
 
+  public void putReplicationMetadata(int partitionId, byte[] key, byte[] replicationMetadata) throws VeniceException {
+    AbstractStoragePartition partition = getPartitionOrThrow(partitionId);
+    partition.putReplicationMetadata(key, replicationMetadata);
+  }
+
   public <K, V> void put(int partitionId, K key, V value) {
     AbstractStoragePartition partition = getPartitionOrThrow(partitionId);
     partition.put(key, value);

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/AbstractStoragePartition.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/AbstractStoragePartition.java
@@ -159,6 +159,10 @@ public abstract class AbstractStoragePartition {
     throw new VeniceUnsupportedOperationException("putWithReplicationMetadata");
   }
 
+  public void putReplicationMetadata(byte[] key, byte[] metadata) {
+    throw new VeniceUnsupportedOperationException("putReplicationMetadata");
+  }
+
   /**
    * This API retrieves replication metadata from replicationMetadataColumnFamily.
    * Only {@link ReplicationMetadataRocksDBStoragePartition} will execute this method,

--- a/internal/venice-common/src/main/java/com/linkedin/venice/writer/ChunkAwareCallback.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/writer/ChunkAwareCallback.java
@@ -17,8 +17,13 @@ public interface ChunkAwareCallback extends Callback {
    * is not chunked.
    *
    * @param key A byte[] corresponding to the top-level key written to Kafka, potentially including a chunking suffix
-   * @param chunks An array of {@link ByteBuffer} where the backing array has sufficient headroom to prepend Venice's header
+   * @param valueChunks An array of {@link ByteBuffer} where the backing array has sufficient headroom to prepend Venice's header
    * @param chunkedValueManifest The {@link ChunkedValueManifest} of the chunked value
    */
-  void setChunkingInfo(byte[] key, ByteBuffer[] chunks, ChunkedValueManifest chunkedValueManifest);
+  void setChunkingInfo(
+      byte[] key,
+      ByteBuffer[] valueChunks,
+      ChunkedValueManifest chunkedValueManifest,
+      ByteBuffer[] rmdChunks,
+      ChunkedValueManifest chunkedRmdManifest);
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/writer/ChunkedPayloadAndManifest.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/writer/ChunkedPayloadAndManifest.java
@@ -8,8 +8,8 @@ import java.nio.ByteBuffer;
  * This class contains both chunked results and manifest for a specific payload.
  */
 public class ChunkedPayloadAndManifest {
-  ByteBuffer[] payloadChunks;
-  ChunkedValueManifest chunkedValueManifest;
+  private final ByteBuffer[] payloadChunks;
+  private final ChunkedValueManifest chunkedValueManifest;
 
   public ChunkedPayloadAndManifest(ByteBuffer[] payloadChunks, ChunkedValueManifest chunkedValueManifest) {
     this.payloadChunks = payloadChunks;

--- a/internal/venice-common/src/main/java/com/linkedin/venice/writer/VeniceWriter.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/writer/VeniceWriter.java
@@ -511,7 +511,7 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
     }
 
     if (callback instanceof ChunkAwareCallback) {
-      ((ChunkAwareCallback) callback).setChunkingInfo(serializedKey, null, null);
+      ((ChunkAwareCallback) callback).setChunkingInfo(serializedKey, null, null, null, null);
     }
 
     KafkaKey kafkaKey = new KafkaKey(MessageType.DELETE, serializedKey);
@@ -666,7 +666,7 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
     }
 
     if (callback instanceof ChunkAwareCallback) {
-      ((ChunkAwareCallback) callback).setChunkingInfo(serializedKey, null, null);
+      ((ChunkAwareCallback) callback).setChunkingInfo(serializedKey, null, null, null, null);
     }
 
     KafkaKey kafkaKey = new KafkaKey(MessageType.PUT, serializedKey);
@@ -717,7 +717,7 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
         getKafkaMessageEnvelopeProvider(kafkaMessageEnvelope, leaderMetadataWrapper);
 
     if (callback instanceof ChunkAwareCallback) {
-      ((ChunkAwareCallback) callback).setChunkingInfo(serializedKey, null, null);
+      ((ChunkAwareCallback) callback).setChunkingInfo(serializedKey, null, null, null, null);
     }
 
     return sendMessage(producerMetadata -> kafkaKey, kafkaMessageEnvelopeProvider, upstreamPartition, callback, false);
@@ -755,7 +755,7 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
 
     if (callback instanceof ChunkAwareCallback) {
       byte[] serializedKey = kafkaKey.getKey();
-      ((ChunkAwareCallback) callback).setChunkingInfo(serializedKey, null, null);
+      ((ChunkAwareCallback) callback).setChunkingInfo(serializedKey, null, null, null, null);
     }
 
     return sendMessage(producerMetadata -> kafkaKey, kafkaMessageEnvelopeProvider, upstreamPartition, callback, false);
@@ -1108,9 +1108,10 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
     int replicationMetadataPayloadSize = putMetadata.map(PutMetadata::getSerializedSize).orElse(0);
     final Supplier<String> reportSizeGenerator =
         () -> getSizeReport(serializedKey.length, serializedValue.length, replicationMetadataPayloadSize);
-    ChunkedPayloadAndManifest valueChunksAndManifest = ChunkHelper.chunkPayloadAndSend(
+    ChunkedPayloadAndManifest valueChunksAndManifest = WriterChunkingHelper.chunkPayloadAndSend(
         serializedKey,
         serializedValue,
+        true,
         valueSchemaId,
         callback instanceof ChunkAwareCallback,
         reportSizeGenerator,
@@ -1126,9 +1127,10 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
             Optional.empty()));
     ChunkedPayloadAndManifest rmdChunksAndManifest = null;
     if (isRmdChunkingEnabled) {
-      rmdChunksAndManifest = ChunkHelper.chunkPayloadAndSend(
+      rmdChunksAndManifest = WriterChunkingHelper.chunkPayloadAndSend(
           serializedKey,
           (putMetadata.isPresent() ? putMetadata.get().getRmdPayload() : EMPTY_BYTE_BUFFER).array(),
+          false,
           valueSchemaId,
           callback instanceof ChunkAwareCallback,
           reportSizeGenerator,
@@ -1177,7 +1179,9 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
       ((ChunkAwareCallback) callback).setChunkingInfo(
           topLevelKey,
           valueChunksAndManifest.getPayloadChunks(),
-          valueChunksAndManifest.getChunkedValueManifest());
+          valueChunksAndManifest.getChunkedValueManifest(),
+          rmdChunksAndManifest == null ? null : rmdChunksAndManifest.getPayloadChunks(),
+          rmdChunksAndManifest == null ? null : rmdChunksAndManifest.getChunkedValueManifest());
     }
 
     // We only return the last future (the one for the manifest) and assume that once this one is finished,

--- a/internal/venice-common/src/test/java/com/linkedin/venice/writer/WriterChunkingHelperTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/writer/WriterChunkingHelperTest.java
@@ -6,21 +6,22 @@ import org.testng.Assert;
 import org.testng.annotations.Test;
 
 
-public class ChunkHelperTest {
+public class WriterChunkingHelperTest {
   @Test
   public void testChunkPayload() {
     byte[] keyBytes = new byte[10];
     byte[] valueBytes = new byte[100];
     int maxSizeForUserPayloadPerMessageInBytes = 30;
-    ChunkedPayloadAndManifest result = ChunkHelper.chunkPayloadAndSend(
+    ChunkedPayloadAndManifest result = WriterChunkingHelper.chunkPayloadAndSend(
         keyBytes,
         valueBytes,
+        true,
         1,
         true,
         () -> "",
         maxSizeForUserPayloadPerMessageInBytes,
         new KeyWithChunkingSuffixSerializer(),
         (x, y) -> CompletableFuture.completedFuture(null));
-    Assert.assertEquals(result.payloadChunks.length, 5);
+    Assert.assertEquals(result.getPayloadChunks().length, 5);
   }
 }


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci], [server], [controller],
[router], [samza], [vpj], [fast-client], [thin-client], [alpini],
[admin-tool], [test], [build], [doc], [script]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## [server] Implement server side handling logic for RMD chunking
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

This PR adds implementation for server side handling logic for RMD chunking. 
1. Added a new StorageOperationType RMD in AASIT which handles RMD chunks PUT operation. Changed NORMAL type to VALUE, changed RMD to VALUE_AND_RMD to reflect its purpose. 
2. Tweaks the getStorageOperationType logic to make it backward compatible.
3. Add logic the storage layer to put RMD only data into storage.
4. Some minor changes in LeaderProducerCallback/ChunkAwareCallback to support setting RMD chunking information.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
Internal CI
There is no integration test / unit test added as at this point there is no end to end path to validate the logic. 
Please feel free to comment if you think there is any logic should be unit tested.


## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.