### PR TITLE
[venice-fast-client] Added vson support to fast-client

### DIFF
--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/ClientConfig.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/ClientConfig.java
@@ -59,6 +59,7 @@ public class ClientConfig<K, V, T extends SpecificRecord> {
   private final int longTailRetryThresholdForSingletGetInMicroSeconds;
   private final int longTailRetryThresholdForBatchGetInMicroSeconds;
   private final ClusterStats clusterStats;
+  private final boolean isVsonStore;
 
   private ClientConfig(
       String storeName,
@@ -83,7 +84,8 @@ public class ClientConfig<K, V, T extends SpecificRecord> {
       boolean longTailRetryEnabledForSingleGet,
       int longTailRetryThresholdForSingletGetInMicroSeconds,
       boolean longTailRetryEnabledForBatchGet,
-      int longTailRetryThresholdForBatchGetInMicroSeconds) {
+      int longTailRetryThresholdForBatchGetInMicroSeconds,
+      boolean isVsonStore) {
     if (storeName == null || storeName.isEmpty()) {
       throw new VeniceClientException("storeName param shouldn't be empty");
     }
@@ -161,6 +163,8 @@ public class ClientConfig<K, V, T extends SpecificRecord> {
       throw new VeniceClientException(
           "Speculative query feature can't be enabled together with long-tail retry for single-get");
     }
+
+    this.isVsonStore = isVsonStore;
   }
 
   public String getStoreName() {
@@ -247,6 +251,11 @@ public class ClientConfig<K, V, T extends SpecificRecord> {
     return longTailRetryThresholdForBatchGetInMicroSeconds;
   }
 
+  @Deprecated
+  public boolean isVsonStore() {
+    return isVsonStore;
+  }
+
   public ClientRoutingStrategy getClientRoutingStrategy() {
     return clientRoutingStrategy;
   }
@@ -285,6 +294,8 @@ public class ClientConfig<K, V, T extends SpecificRecord> {
 
     private boolean longTailRetryEnabledForBatchGet = false;
     private int longTailRetryThresholdForBatchtGetInMicroSeconds = 10000; // 10ms.
+
+    private boolean isVsonStore = false;
 
     public ClientConfigBuilder<K, V, T> setStoreName(String storeName) {
       this.storeName = storeName;
@@ -409,6 +420,12 @@ public class ClientConfig<K, V, T extends SpecificRecord> {
       return this;
     }
 
+    @Deprecated
+    public ClientConfigBuilder<K, V, T> setVsonStore(boolean vsonStore) {
+      isVsonStore = vsonStore;
+      return this;
+    }
+
     public ClientConfigBuilder<K, V, T> clone() {
       return new ClientConfigBuilder().setStoreName(storeName)
           .setR2Client(r2Client)
@@ -432,7 +449,8 @@ public class ClientConfig<K, V, T extends SpecificRecord> {
           .setLongTailRetryEnabledForSingleGet(longTailRetryEnabledForSingleGet)
           .setLongTailRetryThresholdForSingletGetInMicroSeconds(longTailRetryThresholdForSingletGetInMicroSeconds)
           .setLongTailRetryEnabledForBatchGet(longTailRetryEnabledForBatchGet)
-          .setLongTailRetryThresholdForBatchGetInMicroSeconds(longTailRetryThresholdForBatchtGetInMicroSeconds);
+          .setLongTailRetryThresholdForBatchGetInMicroSeconds(longTailRetryThresholdForBatchtGetInMicroSeconds)
+          .setVsonStore(isVsonStore);
     }
 
     public ClientConfig<K, V, T> build() {
@@ -459,7 +477,8 @@ public class ClientConfig<K, V, T extends SpecificRecord> {
           longTailRetryEnabledForSingleGet,
           longTailRetryThresholdForSingletGetInMicroSeconds,
           longTailRetryEnabledForBatchGet,
-          longTailRetryThresholdForBatchtGetInMicroSeconds);
+          longTailRetryThresholdForBatchtGetInMicroSeconds,
+          isVsonStore);
     }
   }
 }

--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/DispatchingAvroGenericStoreClient.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/DispatchingAvroGenericStoreClient.java
@@ -499,6 +499,10 @@ public class DispatchingAvroGenericStoreClient<K, V> extends InternalAvroStoreCl
       throw new VeniceClientException(
           "Failed to get writer schema with id: " + schemaId + " from store: " + metadata.getStoreName());
     }
+    return getValueDeserializer(writerSchema, readerSchema);
+  }
+
+  protected RecordDeserializer<V> getValueDeserializer(Schema writerSchema, Schema readerSchema) {
     return FastSerializerDeserializerFactory.getFastAvroGenericDeserializer(writerSchema, readerSchema);
   }
 
@@ -542,7 +546,6 @@ public class DispatchingAvroGenericStoreClient<K, V> extends InternalAvroStoreCl
   /* Short utility methods */
 
   private byte[] serializeMultiGetRequest(List<BatchGetRequestContext.KeyInfo<K>> keyList) {
-
     List<MultiGetRouterRequestKeyV1> routerRequestKeys = new ArrayList<>(keyList.size());
     AvroSerializer.ReusableObjects reusableObjects = AvroSerializer.REUSE.get();
     BatchGetRequestContext.KeyInfo<K> keyInfo;
@@ -567,9 +570,13 @@ public class DispatchingAvroGenericStoreClient<K, V> extends InternalAvroStoreCl
   public void start() throws VeniceClientException {
     metadata.start();
     // Initialize key serializer after metadata.start().
-    this.keySerializer = FastSerializerDeserializerFactory.getAvroGenericSerializer(getKeySchema());
+    this.keySerializer = getKeySerializer(getKeySchema());
     this.multiGetSerializer =
         FastSerializerDeserializerFactory.getAvroGenericSerializer(MultiGetRouterRequestKeyV1.SCHEMA$);
+  }
+
+  protected RecordSerializer getKeySerializer(Schema keySchema) {
+    return FastSerializerDeserializerFactory.getAvroGenericSerializer(keySchema);
   }
 
   @Override

--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/DispatchingVsonStoreClient.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/DispatchingVsonStoreClient.java
@@ -1,0 +1,28 @@
+package com.linkedin.venice.fastclient;
+
+import com.linkedin.venice.fastclient.meta.StoreMetadata;
+import com.linkedin.venice.serializer.RecordDeserializer;
+import com.linkedin.venice.serializer.RecordSerializer;
+import com.linkedin.venice.serializer.SerializerDeserializerFactory;
+import org.apache.avro.Schema;
+
+
+/**
+ * This class is used to support a legacy format from Voldemort.
+ */
+@Deprecated
+public class DispatchingVsonStoreClient<K, V> extends DispatchingAvroGenericStoreClient<K, V> {
+  public DispatchingVsonStoreClient(StoreMetadata metadata, ClientConfig config) {
+    super(metadata, config);
+  }
+
+  @Override
+  protected RecordSerializer getKeySerializer(Schema keySchema) {
+    return SerializerDeserializerFactory.getVsonSerializer(keySchema);
+  }
+
+  @Override
+  protected RecordDeserializer<V> getValueDeserializer(Schema writerSchema, Schema readerSchema) {
+    return SerializerDeserializerFactory.getVsonDeserializer(writerSchema, readerSchema);
+  }
+}

--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/factory/ClientFactory.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/factory/ClientFactory.java
@@ -6,6 +6,7 @@ import com.linkedin.venice.client.store.AvroSpecificStoreClient;
 import com.linkedin.venice.fastclient.ClientConfig;
 import com.linkedin.venice.fastclient.DispatchingAvroGenericStoreClient;
 import com.linkedin.venice.fastclient.DispatchingAvroSpecificStoreClient;
+import com.linkedin.venice.fastclient.DispatchingVsonStoreClient;
 import com.linkedin.venice.fastclient.DualReadAvroGenericStoreClient;
 import com.linkedin.venice.fastclient.DualReadAvroSpecificStoreClient;
 import com.linkedin.venice.fastclient.RetriableAvroGenericStoreClient;
@@ -47,8 +48,9 @@ public class ClientFactory {
   public static <K, V> AvroGenericStoreClient<K, V> getAndStartGenericStoreClient(
       StoreMetadata storeMetadata,
       ClientConfig clientConfig) {
-    final DispatchingAvroGenericStoreClient<K, V> dispatchingStoreClient =
-        new DispatchingAvroGenericStoreClient<>(storeMetadata, clientConfig);
+    final DispatchingAvroGenericStoreClient<K, V> dispatchingStoreClient = clientConfig.isVsonStore()
+        ? new DispatchingVsonStoreClient<>(storeMetadata, clientConfig)
+        : new DispatchingAvroGenericStoreClient<>(storeMetadata, clientConfig);
     StatsAvroGenericStoreClient<K, V> statsStoreClient;
     if (clientConfig.isLongTailRetryEnabledForSingleGet() || clientConfig.isLongTailRetryEnabledForBatchGet()) {
       statsStoreClient = new StatsAvroGenericStoreClient<>(

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
@@ -284,6 +284,7 @@ public class VenicePushJob implements AutoCloseable {
 
   public static final String STORAGE_QUOTA_PROP = "storage.quota";
   public static final String STORAGE_ENGINE_OVERHEAD_RATIO = "storage_engine_overhead_ratio";
+  @Deprecated
   public static final String VSON_PUSH = "vson.push";
   public static final String KAFKA_SECURITY_PROTOCOL = "SSL";
   public static final String COMPRESSION_STRATEGY = "compression.strategy";

--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/ClientConfig.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/ClientConfig.java
@@ -59,6 +59,7 @@ public class ClientConfig<T extends SpecificRecord> {
     return new ClientConfig(storeName);
   }
 
+  @Deprecated
   public static ClientConfig defaultVsonGenericClientConfig(String storeName) {
     return new ClientConfig(storeName).setVsonClient(true);
   }
@@ -268,10 +269,12 @@ public class ClientConfig<T extends SpecificRecord> {
     return this;
   }
 
+  @Deprecated
   public boolean isVsonClient() {
     return isVsonClient;
   }
 
+  @Deprecated
   public ClientConfig<T> setVsonClient(boolean isVonClient) {
     this.isVsonClient = isVonClient;
     return this;

--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/VsonGenericStoreClientImpl.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/VsonGenericStoreClientImpl.java
@@ -8,6 +8,7 @@ import com.linkedin.venice.serializer.SerializerDeserializerFactory;
 import org.apache.avro.Schema;
 
 
+@Deprecated
 public class VsonGenericStoreClientImpl<K, V> extends AvroGenericStoreClientImpl<K, V> {
   public VsonGenericStoreClientImpl(TransportClient transportClient, ClientConfig clientConfig) {
     this(transportClient, true, clientConfig);

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/schema/vson/AbstractVsonSchemaAdapter.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/schema/vson/AbstractVsonSchemaAdapter.java
@@ -10,7 +10,7 @@ import java.util.Map;
  * an abstraction of backend parser. It reads intermediate Object and parses it to schema.
  * It also contains a VsonReader reference so it could read from string straightly.
  */
-
+@Deprecated
 public abstract class AbstractVsonSchemaAdapter<T> {
   private Object schemaObject;
 

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/schema/vson/VsonAvroDatumReader.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/schema/vson/VsonAvroDatumReader.java
@@ -18,6 +18,7 @@ import org.apache.avro.io.Decoder;
 import org.apache.avro.io.ResolvingDecoder;
 
 
+@Deprecated
 public class VsonAvroDatumReader<D> extends GenericDatumReader<D> {
   public VsonAvroDatumReader(Schema schema) {
     super(schema, schema);

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/schema/vson/VsonAvroDatumWriter.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/schema/vson/VsonAvroDatumWriter.java
@@ -10,6 +10,7 @@ import org.apache.avro.generic.GenericDatumWriter;
 import org.apache.avro.io.Encoder;
 
 
+@Deprecated
 public class VsonAvroDatumWriter<K> extends GenericDatumWriter<K> {
   private Map<Schema, Schema> cachedStrippedSchema;
 

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/schema/vson/VsonAvroSchemaAdapter.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/schema/vson/VsonAvroSchemaAdapter.java
@@ -12,7 +12,7 @@ import org.apache.avro.Schema;
 /**
  * generate Avro schema. It will be invoked when creating new stores as Venice needs to convert Vson schema strings to Avro schemas.
  */
-
+@Deprecated
 public class VsonAvroSchemaAdapter extends AbstractVsonSchemaAdapter<Schema> {
   private static final String DEFAULT_RECORD_NAME = "record";
   public static final String DEFAULT_DOC = null;

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/schema/vson/VsonAvroSerializer.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/schema/vson/VsonAvroSerializer.java
@@ -27,6 +27,7 @@ import org.apache.avro.util.Utf8;
  * This class was inspired and referred from Voldemort.
  * https://github.com/voldemort/voldemort/blob/master/src/java/voldemort/serialization/json/JsonTypeSerializer.java
  */
+@Deprecated
 public class VsonAvroSerializer {
   private static final int MAX_SEQ_LENGTH = 0x3FFFFFFF;
 

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/schema/vson/VsonReader.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/schema/vson/VsonReader.java
@@ -15,7 +15,7 @@ import java.util.Map;
  * The intermediate objects then could be converted to either Avro or Vson Schema.
  * It throws exceptions if syntax errors incur.
  */
-
+@Deprecated
 public class VsonReader {
 
   // The java.io.Reader to use to get characters

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/schema/vson/VsonSchema.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/schema/vson/VsonSchema.java
@@ -10,6 +10,7 @@ import java.util.List;
 import java.util.Map;
 
 
+@Deprecated
 public final class VsonSchema implements Serializable {
   private static final long serialVersionUID = 1;
 

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/schema/vson/VsonSchemaAdapter.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/schema/vson/VsonSchemaAdapter.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.Map;
 
 
+@Deprecated
 public class VsonSchemaAdapter extends AbstractVsonSchemaAdapter<Object> {
   public static Object parse(String vsonSchemaStr) {
     VsonSchemaAdapter adapter = new VsonSchemaAdapter(vsonSchemaStr);

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/schema/vson/VsonTypes.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/schema/vson/VsonTypes.java
@@ -3,6 +3,7 @@ package com.linkedin.venice.schema.vson;
 import com.linkedin.venice.serializer.VsonSerializationException;
 
 
+@Deprecated
 public enum VsonTypes {
   BOOLEAN("boolean"), STRING("string"), INT8("int8"), INT16("int16"), INT32("int32"), INT64("int64"),
   FLOAT32("float32"), FLOAT64("float64"), BYTES("bytes"), DATE("date");


### PR DESCRIPTION
## Summary
Vson was a legacy format from Voldemort, and to smooth the migration from thin-client to fast-client, we need to add vson support to fast-client, and this format is currently supported by thin-client today.

This code change also added `@Deprecate` to all the vson related classes.

## How was this PR tested?
Internal CI passed: wc-test#6663

## Does this PR introduce any user-facing changes?
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.