### PR TITLE
[da-vinci][test] Add a new metric to capture offset rewind in Kafka f…

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -1882,7 +1882,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
           startConsumingAsLeader(newPartitionConsumptionState);
         } else {
           updateLeaderTopicOnFollower(newPartitionConsumptionState);
-          reportUserStoreOffsetRewindMetrics(newPartitionConsumptionState);
+          reportStoreVersionTopicOffsetRewindMetrics(newPartitionConsumptionState);
 
           // Subscribe to local version topic.
           consumerSubscribe(
@@ -2004,11 +2004,11 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
   }
 
   /**
-   * This function checks, for a user store, if its persisted offset is greater than the end offset of its
+   * This function checks, for a store, if its persisted offset is greater than the end offset of its
    * corresponding Kafka topic (indicating an offset rewind event, thus a potential data loss in Kafka) and increases
    * related sensor counter values.
    */
-  private void reportUserStoreOffsetRewindMetrics(PartitionConsumptionState pcs) {
+  private void reportStoreVersionTopicOffsetRewindMetrics(PartitionConsumptionState pcs) {
     long offset = pcs.getLatestProcessedLocalVersionTopicOffset();
     if (offset == OffsetRecord.LOWEST_OFFSET) {
       return;
@@ -2023,7 +2023,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
           pcs.getPartition(),
           offset,
           endOffset);
-      versionedIngestionStats.recordIngestionOffsetRewind(storeName, versionNumber);
+      versionedIngestionStats.recordVerstionTopicIngestionOffsetRewind(storeName, versionNumber);
     }
   }
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -2023,7 +2023,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
           pcs.getPartition(),
           offset,
           endOffset);
-      versionedIngestionStats.recordVerstionTopicIngestionOffsetRewind(storeName, versionNumber);
+      versionedIngestionStats.recordVersionTopicEndOffsetRewind(storeName, versionNumber);
     }
   }
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -2004,15 +2004,11 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
   }
 
   /**
-   * This function checks, for a regular user store, if its persisted offset is greater than the end offset of its
+   * This function checks, for a user store, if its persisted offset is greater than the end offset of its
    * corresponding Kafka topic (indicating an offset rewind event, thus a potential data loss in Kafka) and increases
    * related sensor counter values.
    */
   private void reportUserStoreOffsetRewindMetrics(PartitionConsumptionState pcs) {
-    if (!isUserSystemStore()) {
-      return;
-    }
-
     long offset = pcs.getLatestProcessedLocalVersionTopicOffset();
     if (offset == OffsetRecord.LOWEST_OFFSET) {
       return;
@@ -2022,8 +2018,9 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
     if (endOffset != StatsErrorCode.LAG_MEASUREMENT_FAILURE.code && offset > endOffset) {
       // report offset rewind.
       LOGGER.warn(
-          "Offset rewind for version topic: {}, persisted record offset: {}, Kafka topic partition end-offset: {}",
+          "Offset rewind for version topic: {}, partition: {}, persisted record offset: {}, Kafka topic partition end-offset: {}",
           kafkaVersionTopic,
+          pcs.getPartition(),
           offset,
           endOffset);
       versionedIngestionStats.recordIngestionOffsetRewind(storeName, versionNumber);

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/AggVersionedIngestionStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/AggVersionedIngestionStats.java
@@ -133,7 +133,7 @@ public class AggVersionedIngestionStats
     recordVersionedAndTotalStat(storeName, version, stat -> stat.recordConsumedRecordEndToEndProcessingLatency(value));
   }
 
-  public void recordVerstionTopicIngestionOffsetRewind(String storeName, int version) {
-    recordVersionedAndTotalStat(storeName, version, IngestionStats::recordVersionTopicIngestionOffsetRewind);
+  public void recordVersionTopicEndOffsetRewind(String storeName, int version) {
+    recordVersionedAndTotalStat(storeName, version, IngestionStats::recordVersionTopicEndOffsetRewind);
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/AggVersionedIngestionStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/AggVersionedIngestionStats.java
@@ -132,4 +132,8 @@ public class AggVersionedIngestionStats
   public void recordConsumedRecordEndToEndProcessingLatency(String storeName, int version, double value) {
     recordVersionedAndTotalStat(storeName, version, stat -> stat.recordConsumedRecordEndToEndProcessingLatency(value));
   }
+
+  public void recordIngestionOffsetRewind(String storeName, int version) {
+    recordVersionedAndTotalStat(storeName, version, IngestionStats::recordIngestionOffsetRewind);
+  }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/AggVersionedIngestionStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/AggVersionedIngestionStats.java
@@ -133,7 +133,7 @@ public class AggVersionedIngestionStats
     recordVersionedAndTotalStat(storeName, version, stat -> stat.recordConsumedRecordEndToEndProcessingLatency(value));
   }
 
-  public void recordIngestionOffsetRewind(String storeName, int version) {
-    recordVersionedAndTotalStat(storeName, version, IngestionStats::recordIngestionOffsetRewind);
+  public void recordVerstionTopicIngestionOffsetRewind(String storeName, int version) {
+    recordVersionedAndTotalStat(storeName, version, IngestionStats::recordVersionTopicIngestionOffsetRewind);
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/IngestionStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/IngestionStats.java
@@ -53,7 +53,7 @@ public class IngestionStats {
   protected static final String OFFSET_REGRESSION_DCR_ERROR = "offset_regression_dcr_error";
   protected static final String TOMBSTONE_CREATION_DCR = "tombstone_creation_dcr";
   protected static final String READY_TO_SERVE_WITH_RT_LAG_METRIC_NAME = "ready_to_serve_with_rt_lag";
-  public static final String VERSION_TOPIC_INGESTION_OFFSET_REWIND_COUNT = "vt_ingestion_task_offset_rewind_count";
+  public static final String VERSION_TOPIC_END_OFFSET_REWIND_COUNT = "version_topic_end_offset_rewind_count";
 
   private static final MetricConfig METRIC_CONFIG = new MetricConfig();
   private StoreIngestionTask ingestionTask;
@@ -85,8 +85,8 @@ public class IngestionStats {
   private final RateSensor tombstoneCreationDCRSensor;
 
   /** Record a version-level offset rewind events for VTs across all stores. */
-  private final Count vtIngestionOffsetRewindCount = new Count();
-  private final Sensor vtIngestionOffsetRewindSensor;
+  private final Count versionTopicEndOffsetRewindCount = new Count();
+  private final Sensor versionTopicEndOffsetRewindSensor;
 
   public IngestionStats(VeniceServerConfig serverConfig) {
 
@@ -153,8 +153,8 @@ public class IngestionStats {
             + stalePartitionsWithoutIngestionTaskCount.getClass().getSimpleName(),
         stalePartitionsWithoutIngestionTaskCount);
 
-    vtIngestionOffsetRewindSensor = localMetricRepository.sensor(VERSION_TOPIC_INGESTION_OFFSET_REWIND_COUNT);
-    vtIngestionOffsetRewindSensor.add(VERSION_TOPIC_INGESTION_OFFSET_REWIND_COUNT, vtIngestionOffsetRewindCount);
+    versionTopicEndOffsetRewindSensor = localMetricRepository.sensor(VERSION_TOPIC_END_OFFSET_REWIND_COUNT);
+    versionTopicEndOffsetRewindSensor.add(VERSION_TOPIC_END_OFFSET_REWIND_COUNT, versionTopicEndOffsetRewindCount);
 
     subscribePrepLatencySensor =
         new WritePathLatencySensor(localMetricRepository, METRIC_CONFIG, SUBSCRIBE_ACTION_PREP_LATENCY);
@@ -307,12 +307,12 @@ public class IngestionStats {
     stalePartitionsWithoutIngestionTaskSensor.record();
   }
 
-  public void recordVersionTopicIngestionOffsetRewind() {
-    vtIngestionOffsetRewindSensor.record();
+  public void recordVersionTopicEndOffsetRewind() {
+    versionTopicEndOffsetRewindSensor.record();
   }
 
-  public double getRecordIngestionOffsetRewindCount() {
-    return vtIngestionOffsetRewindCount.measure(METRIC_CONFIG, System.currentTimeMillis());
+  public double getVersionTopicEndOffsetRewindCount() {
+    return versionTopicEndOffsetRewindCount.measure(METRIC_CONFIG, System.currentTimeMillis());
   }
 
   public double getConsumedRecordEndToEndProcessingLatencyAvg() {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/IngestionStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/IngestionStats.java
@@ -53,7 +53,7 @@ public class IngestionStats {
   protected static final String OFFSET_REGRESSION_DCR_ERROR = "offset_regression_dcr_error";
   protected static final String TOMBSTONE_CREATION_DCR = "tombstone_creation_dcr";
   protected static final String READY_TO_SERVE_WITH_RT_LAG_METRIC_NAME = "ready_to_serve_with_rt_lag";
-  public static final String INGESTION_OFFSET_REWIND_COUNT = "ingestion_task_offset_rewind_count";
+  public static final String VERSION_TOPIC_INGESTION_OFFSET_REWIND_COUNT = "vt_ingestion_task_offset_rewind_count";
 
   private static final MetricConfig METRIC_CONFIG = new MetricConfig();
   private StoreIngestionTask ingestionTask;
@@ -83,8 +83,10 @@ public class IngestionStats {
   private final RateSensor timestampRegressionDCRErrorSensor;
   private final RateSensor offsetRegressionDCRErrorSensor;
   private final RateSensor tombstoneCreationDCRSensor;
-  private final Count ingestionOffsetRewindCount = new Count();
-  private final Sensor ingestionOffsetRewindSensor;
+
+  /** Record a version-level offset rewind events for VTs across all stores. */
+  private final Count vtIngestionOffsetRewindCount = new Count();
+  private final Sensor vtIngestionOffsetRewindSensor;
 
   public IngestionStats(VeniceServerConfig serverConfig) {
 
@@ -151,8 +153,8 @@ public class IngestionStats {
             + stalePartitionsWithoutIngestionTaskCount.getClass().getSimpleName(),
         stalePartitionsWithoutIngestionTaskCount);
 
-    ingestionOffsetRewindSensor = localMetricRepository.sensor(INGESTION_OFFSET_REWIND_COUNT);
-    ingestionOffsetRewindSensor.add(INGESTION_OFFSET_REWIND_COUNT, ingestionOffsetRewindCount);
+    vtIngestionOffsetRewindSensor = localMetricRepository.sensor(VERSION_TOPIC_INGESTION_OFFSET_REWIND_COUNT);
+    vtIngestionOffsetRewindSensor.add(VERSION_TOPIC_INGESTION_OFFSET_REWIND_COUNT, vtIngestionOffsetRewindCount);
 
     subscribePrepLatencySensor =
         new WritePathLatencySensor(localMetricRepository, METRIC_CONFIG, SUBSCRIBE_ACTION_PREP_LATENCY);
@@ -305,12 +307,12 @@ public class IngestionStats {
     stalePartitionsWithoutIngestionTaskSensor.record();
   }
 
-  public void recordIngestionOffsetRewind() {
-    ingestionOffsetRewindSensor.record();
+  public void recordVersionTopicIngestionOffsetRewind() {
+    vtIngestionOffsetRewindSensor.record();
   }
 
   public double getRecordIngestionOffsetRewindCount() {
-    return ingestionOffsetRewindCount.measure(METRIC_CONFIG, System.currentTimeMillis());
+    return vtIngestionOffsetRewindCount.measure(METRIC_CONFIG, System.currentTimeMillis());
   }
 
   public double getConsumedRecordEndToEndProcessingLatencyAvg() {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/IngestionStatsReporter.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/IngestionStatsReporter.java
@@ -10,6 +10,7 @@ import static com.linkedin.davinci.stats.IngestionStats.FOLLOWER_OFFSET_LAG;
 import static com.linkedin.davinci.stats.IngestionStats.FOLLOWER_RECORDS_CONSUMED_METRIC_NAME;
 import static com.linkedin.davinci.stats.IngestionStats.HYBRID_FOLLOWER_OFFSET_LAG;
 import static com.linkedin.davinci.stats.IngestionStats.HYBRID_LEADER_OFFSET_LAG;
+import static com.linkedin.davinci.stats.IngestionStats.INGESTION_OFFSET_REWIND_COUNT;
 import static com.linkedin.davinci.stats.IngestionStats.INGESTION_TASK_ERROR_GAUGE;
 import static com.linkedin.davinci.stats.IngestionStats.INGESTION_TASK_PUSH_TIMEOUT_GAUGE;
 import static com.linkedin.davinci.stats.IngestionStats.LEADER_BYTES_CONSUMED_METRIC_NAME;
@@ -86,6 +87,11 @@ public class IngestionStatsReporter extends AbstractVeniceStatsReporter<Ingestio
       registerSensor(
           BATCH_FOLLOWER_OFFSET_LAG,
           new IngestionStatsGauge(this, () -> (double) getStats().getBatchFollowerOffsetLag(), 0));
+
+      // Only report offset rewind count for regular user stores.
+      registerSensor(
+          INGESTION_OFFSET_REWIND_COUNT,
+          new IngestionStatsGauge(this, () -> getStats().getRecordIngestionOffsetRewindCount(), 0));
     }
 
     registerSensor(

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/IngestionStatsReporter.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/IngestionStatsReporter.java
@@ -27,7 +27,7 @@ import static com.linkedin.davinci.stats.IngestionStats.TIMESTAMP_REGRESSION_DCR
 import static com.linkedin.davinci.stats.IngestionStats.TOMBSTONE_CREATION_DCR;
 import static com.linkedin.davinci.stats.IngestionStats.TOTAL_DCR;
 import static com.linkedin.davinci.stats.IngestionStats.UPDATE_IGNORED_DCR;
-import static com.linkedin.davinci.stats.IngestionStats.VERSION_TOPIC_INGESTION_OFFSET_REWIND_COUNT;
+import static com.linkedin.davinci.stats.IngestionStats.VERSION_TOPIC_END_OFFSET_REWIND_COUNT;
 import static com.linkedin.davinci.stats.IngestionStats.WRITE_COMPUTE_OPERATION_FAILURE;
 import static com.linkedin.venice.stats.StatsErrorCode.NULL_INGESTION_STATS;
 
@@ -76,8 +76,8 @@ public class IngestionStatsReporter extends AbstractVeniceStatsReporter<Ingestio
         HYBRID_FOLLOWER_OFFSET_LAG,
         new IngestionStatsGauge(this, () -> (double) getStats().getHybridFollowerOffsetLag(), 0));
     registerSensor(
-        VERSION_TOPIC_INGESTION_OFFSET_REWIND_COUNT,
-        new IngestionStatsGauge(this, () -> getStats().getRecordIngestionOffsetRewindCount(), 0));
+        VERSION_TOPIC_END_OFFSET_REWIND_COUNT,
+        new IngestionStatsGauge(this, () -> getStats().getVersionTopicEndOffsetRewindCount(), 0));
 
     // System store mostly operates on hybrid partial updates so batch metrics are not useful.
     if (!VeniceSystemStoreUtils.isUserSystemStore(storeName)) {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/IngestionStatsReporter.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/IngestionStatsReporter.java
@@ -75,6 +75,9 @@ public class IngestionStatsReporter extends AbstractVeniceStatsReporter<Ingestio
     registerSensor(
         HYBRID_FOLLOWER_OFFSET_LAG,
         new IngestionStatsGauge(this, () -> (double) getStats().getHybridFollowerOffsetLag(), 0));
+    registerSensor(
+        INGESTION_OFFSET_REWIND_COUNT,
+        new IngestionStatsGauge(this, () -> getStats().getRecordIngestionOffsetRewindCount(), 0));
 
     // System store mostly operates on hybrid partial updates so batch metrics are not useful.
     if (!VeniceSystemStoreUtils.isUserSystemStore(storeName)) {
@@ -87,11 +90,6 @@ public class IngestionStatsReporter extends AbstractVeniceStatsReporter<Ingestio
       registerSensor(
           BATCH_FOLLOWER_OFFSET_LAG,
           new IngestionStatsGauge(this, () -> (double) getStats().getBatchFollowerOffsetLag(), 0));
-
-      // Only report offset rewind count for regular user stores.
-      registerSensor(
-          INGESTION_OFFSET_REWIND_COUNT,
-          new IngestionStatsGauge(this, () -> getStats().getRecordIngestionOffsetRewindCount(), 0));
     }
 
     registerSensor(

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/IngestionStatsReporter.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/IngestionStatsReporter.java
@@ -10,7 +10,6 @@ import static com.linkedin.davinci.stats.IngestionStats.FOLLOWER_OFFSET_LAG;
 import static com.linkedin.davinci.stats.IngestionStats.FOLLOWER_RECORDS_CONSUMED_METRIC_NAME;
 import static com.linkedin.davinci.stats.IngestionStats.HYBRID_FOLLOWER_OFFSET_LAG;
 import static com.linkedin.davinci.stats.IngestionStats.HYBRID_LEADER_OFFSET_LAG;
-import static com.linkedin.davinci.stats.IngestionStats.INGESTION_OFFSET_REWIND_COUNT;
 import static com.linkedin.davinci.stats.IngestionStats.INGESTION_TASK_ERROR_GAUGE;
 import static com.linkedin.davinci.stats.IngestionStats.INGESTION_TASK_PUSH_TIMEOUT_GAUGE;
 import static com.linkedin.davinci.stats.IngestionStats.LEADER_BYTES_CONSUMED_METRIC_NAME;
@@ -28,6 +27,7 @@ import static com.linkedin.davinci.stats.IngestionStats.TIMESTAMP_REGRESSION_DCR
 import static com.linkedin.davinci.stats.IngestionStats.TOMBSTONE_CREATION_DCR;
 import static com.linkedin.davinci.stats.IngestionStats.TOTAL_DCR;
 import static com.linkedin.davinci.stats.IngestionStats.UPDATE_IGNORED_DCR;
+import static com.linkedin.davinci.stats.IngestionStats.VERSION_TOPIC_INGESTION_OFFSET_REWIND_COUNT;
 import static com.linkedin.davinci.stats.IngestionStats.WRITE_COMPUTE_OPERATION_FAILURE;
 import static com.linkedin.venice.stats.StatsErrorCode.NULL_INGESTION_STATS;
 
@@ -76,7 +76,7 @@ public class IngestionStatsReporter extends AbstractVeniceStatsReporter<Ingestio
         HYBRID_FOLLOWER_OFFSET_LAG,
         new IngestionStatsGauge(this, () -> (double) getStats().getHybridFollowerOffsetLag(), 0));
     registerSensor(
-        INGESTION_OFFSET_REWIND_COUNT,
+        VERSION_TOPIC_INGESTION_OFFSET_REWIND_COUNT,
         new IngestionStatsGauge(this, () -> getStats().getRecordIngestionOffsetRewindCount(), 0));
 
     // System store mostly operates on hybrid partial updates so batch metrics are not useful.

--- a/services/venice-server/src/test/java/com/linkedin/venice/stats/AggVersionedIngestionStatsTest.java
+++ b/services/venice-server/src/test/java/com/linkedin/venice/stats/AggVersionedIngestionStatsTest.java
@@ -48,7 +48,7 @@ public class AggVersionedIngestionStatsTest {
   @BeforeTest
   public void setUp() {
     String prefix = "." + STORE_FOO;
-    String postfix = IngestionStats.VERSION_TOPIC_INGESTION_OFFSET_REWIND_COUNT + ".IngestionStatsGauge";
+    String postfix = IngestionStats.VERSION_TOPIC_END_OFFSET_REWIND_COUNT + ".IngestionStatsGauge";
     totalKey = prefix + "_total--" + postfix;
     backupKey = prefix + "_backup--" + postfix;
     currentKey = prefix + "_current--" + postfix;
@@ -100,17 +100,17 @@ public class AggVersionedIngestionStatsTest {
 
     int backupVerCnt = 2, curVerCnt = 3, futureVerCnt = 4;
     for (int i = 0; i < backupVerCnt; i++) {
-      aggIngestionStats.recordVerstionTopicIngestionOffsetRewind(STORE_FOO, backupVer.getNumber());
+      aggIngestionStats.recordVersionTopicEndOffsetRewind(STORE_FOO, backupVer.getNumber());
     }
     verifyCounters(backupVerCnt, backupVerCnt, 0, 0);
 
     for (int i = 0; i < curVerCnt; i++) {
-      aggIngestionStats.recordVerstionTopicIngestionOffsetRewind(STORE_FOO, currentVer.getNumber());
+      aggIngestionStats.recordVersionTopicEndOffsetRewind(STORE_FOO, currentVer.getNumber());
     }
     verifyCounters(backupVerCnt + curVerCnt, backupVerCnt, curVerCnt, 0);
 
     for (int i = 0; i < futureVerCnt; i++) {
-      aggIngestionStats.recordVerstionTopicIngestionOffsetRewind(STORE_FOO, futureVer.getNumber());
+      aggIngestionStats.recordVersionTopicEndOffsetRewind(STORE_FOO, futureVer.getNumber());
     }
     verifyCounters(backupVerCnt + curVerCnt + futureVerCnt, backupVerCnt, curVerCnt, futureVerCnt);
 

--- a/services/venice-server/src/test/java/com/linkedin/venice/stats/AggVersionedIngestionStatsTest.java
+++ b/services/venice-server/src/test/java/com/linkedin/venice/stats/AggVersionedIngestionStatsTest.java
@@ -1,0 +1,149 @@
+package com.linkedin.venice.stats;
+
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+import com.linkedin.davinci.config.VeniceServerConfig;
+import com.linkedin.davinci.stats.AggVersionedIngestionStats;
+import com.linkedin.davinci.stats.IngestionStats;
+import com.linkedin.venice.meta.OfflinePushStrategy;
+import com.linkedin.venice.meta.PersistenceType;
+import com.linkedin.venice.meta.ReadOnlyStoreRepository;
+import com.linkedin.venice.meta.ReadStrategy;
+import com.linkedin.venice.meta.RoutingStrategy;
+import com.linkedin.venice.meta.Store;
+import com.linkedin.venice.meta.Version;
+import com.linkedin.venice.meta.VersionImpl;
+import com.linkedin.venice.meta.VersionStatus;
+import com.linkedin.venice.meta.ZKStore;
+import com.linkedin.venice.tehuti.MockTehutiReporter;
+import com.linkedin.venice.utils.Utils;
+import io.tehuti.metrics.MetricsRepository;
+import it.unimi.dsi.fastutil.ints.Int2ObjectMaps;
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.annotations.AfterTest;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
+
+public class AggVersionedIngestionStatsTest {
+  private AggVersionedIngestionStats aggIngestionStats;
+  private final MetricsRepository metricsRepo = new MetricsRepository();
+  private final MockTehutiReporter reporter = new MockTehutiReporter();
+  private final VeniceServerConfig mockVeniceServerConfig = Mockito.mock(VeniceServerConfig.class);
+
+  private String totalKey;
+  private String backupKey;
+  private String currentKey;
+  private String futureKey;
+
+  private Version backupVer;
+  private Version currentVer;
+  private Version futureVer;
+
+  private static final String STORE_FOO = Utils.getUniqueString("store_foo");
+
+  @BeforeTest
+  public void setUp() {
+    String prefix = "." + STORE_FOO;
+    String postfix = IngestionStats.INGESTION_OFFSET_REWIND_COUNT + ".IngestionStatsGauge";
+    totalKey = prefix + "_total--" + postfix;
+    backupKey = prefix + "_backup--" + postfix;
+    currentKey = prefix + "_current--" + postfix;
+    futureKey = prefix + "_future--" + postfix;
+
+    metricsRepo.addReporter(reporter);
+    ReadOnlyStoreRepository mockMetaRepository = mock(ReadOnlyStoreRepository.class);
+    doReturn(Int2ObjectMaps.emptyMap()).when(mockVeniceServerConfig).getKafkaClusterIdToAliasMap();
+    doReturn(true).when(mockVeniceServerConfig).isUnregisterMetricForDeletedStoreEnabled();
+
+    aggIngestionStats = new AggVersionedIngestionStats(metricsRepo, mockMetaRepository, mockVeniceServerConfig);
+
+    Store mockStore = createStore();
+
+    backupVer = new VersionImpl(STORE_FOO, 1);
+    backupVer.setStatus(VersionStatus.ONLINE);
+    mockStore.addVersion(backupVer);
+
+    currentVer = new VersionImpl(STORE_FOO, 2);
+    currentVer.setStatus(VersionStatus.ONLINE);
+    mockStore.addVersion(currentVer);
+
+    futureVer = new VersionImpl(STORE_FOO, 3);
+    futureVer.setStatus(VersionStatus.PUSHED);
+    mockStore.addVersion(futureVer);
+    mockStore.setCurrentVersion(currentVer.getNumber());
+
+    Mockito.doReturn(mockStore).when(mockMetaRepository).getStoreOrThrow(any());
+  }
+
+  @AfterTest
+  public void cleanUp() {
+    metricsRepo.close();
+  }
+
+  /**
+   * testIngestionOffsetRewind does the following steps:
+   *
+   * 1. Create a store with 3 versions: backup, current, and future.
+   * 2. Verify that no metrics exist initially.
+   * 3. Increase the offset rewind counter for the store's backup, current, and future version.
+   * 4. Verify that metrics repository contains the right counter value.
+   * 5. Verify that no metrics after store is deleted, if UNREGISTER_METRIC_FOR_DELETED_STORE_ENABLED is enabled.
+   */
+  @Test
+  public void testIngestionOffsetRewind() {
+    // No metrics initially.
+    verifyNoMetrics();
+
+    int backupVerCnt = 2, curVerCnt = 3, futureVerCnt = 4;
+    for (int i = 0; i < backupVerCnt; i++) {
+      aggIngestionStats.recordIngestionOffsetRewind(STORE_FOO, backupVer.getNumber());
+    }
+    verifyCounters(backupVerCnt, backupVerCnt, 0, 0);
+
+    for (int i = 0; i < curVerCnt; i++) {
+      aggIngestionStats.recordIngestionOffsetRewind(STORE_FOO, currentVer.getNumber());
+    }
+    verifyCounters(backupVerCnt + curVerCnt, backupVerCnt, curVerCnt, 0);
+
+    for (int i = 0; i < futureVerCnt; i++) {
+      aggIngestionStats.recordIngestionOffsetRewind(STORE_FOO, futureVer.getNumber());
+    }
+    verifyCounters(backupVerCnt + curVerCnt + futureVerCnt, backupVerCnt, curVerCnt, futureVerCnt);
+
+    aggIngestionStats.handleStoreDeleted(STORE_FOO);
+    // Metrics are unregistered when UNREGISTER_METRIC_FOR_DELETED_STORE_ENABLED is enabled.
+    if (mockVeniceServerConfig.isUnregisterMetricForDeletedStoreEnabled()) {
+      verifyNoMetrics();
+    }
+  }
+
+  private Store createStore() {
+    return new ZKStore(
+        STORE_FOO,
+        "",
+        10,
+        PersistenceType.ROCKS_DB,
+        RoutingStrategy.CONSISTENT_HASH,
+        ReadStrategy.ANY_OF_ONLINE,
+        OfflinePushStrategy.WAIT_ALL_REPLICAS,
+        1);
+  }
+
+  private void verifyCounters(double total, double backup, double current, double future) {
+    Assert.assertEquals(reporter.query(totalKey).value(), total);
+    Assert.assertEquals(reporter.query(backupKey).value(), backup);
+    Assert.assertEquals(reporter.query(currentKey).value(), current);
+    Assert.assertEquals(reporter.query(futureKey).value(), future);
+  }
+
+  private void verifyNoMetrics() {
+    Assert.assertNull(metricsRepo.getMetric(totalKey));
+    Assert.assertNull(metricsRepo.getMetric(backupKey));
+    Assert.assertNull(metricsRepo.getMetric(currentKey));
+    Assert.assertNull(metricsRepo.getMetric(futureKey));
+  }
+}

--- a/services/venice-server/src/test/java/com/linkedin/venice/stats/AggVersionedIngestionStatsTest.java
+++ b/services/venice-server/src/test/java/com/linkedin/venice/stats/AggVersionedIngestionStatsTest.java
@@ -48,7 +48,7 @@ public class AggVersionedIngestionStatsTest {
   @BeforeTest
   public void setUp() {
     String prefix = "." + STORE_FOO;
-    String postfix = IngestionStats.INGESTION_OFFSET_REWIND_COUNT + ".IngestionStatsGauge";
+    String postfix = IngestionStats.VERSION_TOPIC_INGESTION_OFFSET_REWIND_COUNT + ".IngestionStatsGauge";
     totalKey = prefix + "_total--" + postfix;
     backupKey = prefix + "_backup--" + postfix;
     currentKey = prefix + "_current--" + postfix;
@@ -100,17 +100,17 @@ public class AggVersionedIngestionStatsTest {
 
     int backupVerCnt = 2, curVerCnt = 3, futureVerCnt = 4;
     for (int i = 0; i < backupVerCnt; i++) {
-      aggIngestionStats.recordIngestionOffsetRewind(STORE_FOO, backupVer.getNumber());
+      aggIngestionStats.recordVerstionTopicIngestionOffsetRewind(STORE_FOO, backupVer.getNumber());
     }
     verifyCounters(backupVerCnt, backupVerCnt, 0, 0);
 
     for (int i = 0; i < curVerCnt; i++) {
-      aggIngestionStats.recordIngestionOffsetRewind(STORE_FOO, currentVer.getNumber());
+      aggIngestionStats.recordVerstionTopicIngestionOffsetRewind(STORE_FOO, currentVer.getNumber());
     }
     verifyCounters(backupVerCnt + curVerCnt, backupVerCnt, curVerCnt, 0);
 
     for (int i = 0; i < futureVerCnt; i++) {
-      aggIngestionStats.recordIngestionOffsetRewind(STORE_FOO, futureVer.getNumber());
+      aggIngestionStats.recordVerstionTopicIngestionOffsetRewind(STORE_FOO, futureVer.getNumber());
     }
     verifyCounters(backupVerCnt + curVerCnt + futureVerCnt, backupVerCnt, curVerCnt, futureVerCnt);
 


### PR DESCRIPTION
…or user stores

In a Kafka problem hit previous, if durability related configs are not set correctly, Kafka could lose data and reset end-offset of the impacted partitions to smaller offsets; new writes on the impacted partitions will have old(small) offsets than the checkpoint offsets in Venice, and thus Venice drops and loses new writes. (Another side effect is that Venice servers could re-consume the entire partition from the beginning). We want to detect this end-offset drop/rewind event and report when it happens. One way to detect it from the Venice servers's point is to compare its local persisted offset for that partition with the end-offset in Kafka and report when the persisted one is greater. The comparison is only done at the time when server subscribes to that partition.

This rb also introduces a new version level metrics to report the offset rewind (backup, current, future, and total) for each user store and it records the occurrence number for the rewind events across all partitions for the store versions. A unit test is also added to verity the behaviour of the metrics is as expected.

Note that this rb only targets store's version topics and the realtime topic is handled by the existing logic e.g. LeaderFollowerStoreIngestionTask.checkAndHandleUpstreamOffsetRewind 

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

Internal CI test.
Added new unit tests.

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.