### PR TITLE
[common][controller] Separate kafka RF and minIsr config for VT, RT and admin topics

### DIFF
--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -90,16 +90,32 @@ public class ConfigKeys {
   public static final String KAFKA_MIN_LOG_COMPACTION_LAG_MS = "kafka.min.log.compaction.lag.ms";
 
   /**
-   * The min.isr property to be set at topic creation time. Will not modify already-existing topics.
+   * The min. in sync replicas property to be set at topic creation time. Will not modify already-existing topics. This
+   * config only applies to store version topics.
    *
    * If unset, will use the Kafka cluster's default.
    */
   public static final String KAFKA_MIN_ISR = "kafka.min.isr";
 
   /**
-   * The replication factor to set for real-time buffer topics and store-version topics, at topic creation time.
+   * Same as KAFKA_MIN_ISR except it applies to real-time buffer topics.
+   */
+  public static final String KAFKA_MIN_ISR_RT_TOPICS = "kafka.min.isr.rt.topics";
+
+  /**
+   * Same as KAFKA_MIN_ISR except it applies to admin topics.
+   */
+  public static final String KAFKA_MIN_ISR_ADMIN_TOPICS = "kafka.min.isr.admin.topics";
+
+  /**
+   * The replication factor to set for store-version topics only, at topic creation time.
    */
   public static final String KAFKA_REPLICATION_FACTOR = "kafka.replication.factor";
+
+  /**
+   * Same as KAFKA_REPLICATION_FACTOR except it applies to real-time buffer topics.
+   */
+  public static final String KAFKA_REPLICATION_FACTOR_RT_TOPICS = "kafka.replication.factor.rt.topics";
 
   /**
    * TODO: the following 3 configs will be deprecated after the native replication migration is changed to a two-step
@@ -1240,7 +1256,7 @@ public class ConfigKeys {
   public static final String HELIX_REBALANCE_ALG = "helix.rebalance.alg";
 
   /**
-   * What replication factor should the admin topics have, upon creation.
+   * Same as KAFKA_REPLICATION_FACTOR except it applies to admin topics.
    */
   public static final String ADMIN_TOPIC_REPLICATION_FACTOR = "admin.topic.replication.factor";
 

--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -90,30 +90,33 @@ public class ConfigKeys {
   public static final String KAFKA_MIN_LOG_COMPACTION_LAG_MS = "kafka.min.log.compaction.lag.ms";
 
   /**
-   * The min. in sync replicas property to be set at topic creation time. Will not modify already-existing topics. This
-   * config only applies to store version topics.
+   * The minimum number of in sync replicas to set for store version topics.
    *
-   * If unset, will use the Kafka cluster's default.
+   * Will use the Kafka cluster's default if not set.
    */
-  public static final String KAFKA_MIN_ISR = "kafka.min.isr";
+  public static final String KAFKA_MIN_IN_SYNC_REPLICAS = "kafka.min.in.sync.replicas";
 
   /**
-   * Same as KAFKA_MIN_ISR except it applies to real-time buffer topics.
+   * The minimum number of in sync replicas to set for real-time buffer topics.
+   *
+   * Will use the Kafka cluster's default if not set.
    */
-  public static final String KAFKA_MIN_ISR_RT_TOPICS = "kafka.min.isr.rt.topics";
+  public static final String KAFKA_MIN_IN_SYNC_REPLICAS_RT_TOPICS = "kafka.min.in.sync.replicas.rt.topics";
 
   /**
-   * Same as KAFKA_MIN_ISR except it applies to admin topics.
+   * The minimum number of in sync replicas to set for admin topics.
+   *
+   * Will use the Kafka cluster's default if not set.
    */
-  public static final String KAFKA_MIN_ISR_ADMIN_TOPICS = "kafka.min.isr.admin.topics";
+  public static final String KAFKA_MIN_IN_SYNC_REPLICAS_ADMIN_TOPICS = "kafka.min.in.sync.replicas.admin.topics";
 
   /**
-   * The replication factor to set for store-version topics only, at topic creation time.
+   * The replication factor to set for store-version topics.
    */
   public static final String KAFKA_REPLICATION_FACTOR = "kafka.replication.factor";
 
   /**
-   * Same as KAFKA_REPLICATION_FACTOR except it applies to real-time buffer topics.
+   * The replication factor to set for real-time buffer topics.
    */
   public static final String KAFKA_REPLICATION_FACTOR_RT_TOPICS = "kafka.replication.factor.rt.topics";
 
@@ -1256,7 +1259,7 @@ public class ConfigKeys {
   public static final String HELIX_REBALANCE_ALG = "helix.rebalance.alg";
 
   /**
-   * Same as KAFKA_REPLICATION_FACTOR except it applies to admin topics.
+   * The replication factor to set for admin topics.
    */
   public static final String ADMIN_TOPIC_REPLICATION_FACTOR = "admin.topic.replication.factor";
 

--- a/internal/venice-common/src/main/java/com/linkedin/venice/kafka/TopicManager.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/kafka/TopicManager.java
@@ -178,17 +178,6 @@ public class TopicManager implements Closeable {
    * Create a topic, and block until the topic is created, with a default timeout of
    * {@value #DEFAULT_KAFKA_OPERATION_TIMEOUT_MS}, after which this function will throw a VeniceException.
    *
-   * @see {@link #createTopic(String, int, int, boolean)}
-   */
-  @Deprecated
-  public void createTopic(String topicName, int numPartitions, int replication) {
-    createTopic(topicName, numPartitions, replication, true);
-  }
-
-  /**
-   * Create a topic, and block until the topic is created, with a default timeout of
-   * {@value #DEFAULT_KAFKA_OPERATION_TIMEOUT_MS}, after which this function will throw a VeniceException.
-   *
    * @see {@link #createTopic(String, int, int, boolean, boolean, Optional)}
    */
   public void createTopic(String topicName, int numPartitions, int replication, boolean eternal) {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerClusterConfig.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerClusterConfig.java
@@ -1,68 +1,7 @@
 package com.linkedin.venice.controller;
 
 import static com.linkedin.venice.CommonConfigKeys.SSL_FACTORY_CLASS_NAME;
-import static com.linkedin.venice.ConfigKeys.ADMIN_TOPIC_REPLICATION_FACTOR;
-import static com.linkedin.venice.ConfigKeys.CLUSTER_NAME;
-import static com.linkedin.venice.ConfigKeys.CLUSTER_TO_D2;
-import static com.linkedin.venice.ConfigKeys.CONTROLLER_DEFAULT_READ_QUOTA_PER_ROUTER;
-import static com.linkedin.venice.ConfigKeys.CONTROLLER_DISABLE_PARENT_REQUEST_TOPIC_FOR_STREAM_PUSHES;
-import static com.linkedin.venice.ConfigKeys.CONTROLLER_JETTY_CONFIG_OVERRIDE_PREFIX;
-import static com.linkedin.venice.ConfigKeys.CONTROLLER_NAME;
-import static com.linkedin.venice.ConfigKeys.CONTROLLER_SCHEMA_VALIDATION_ENABLED;
-import static com.linkedin.venice.ConfigKeys.CONTROLLER_SSL_ENABLED;
-import static com.linkedin.venice.ConfigKeys.DEFAULT_MAX_NUMBER_OF_PARTITIONS;
-import static com.linkedin.venice.ConfigKeys.DEFAULT_NUMBER_OF_PARTITION;
-import static com.linkedin.venice.ConfigKeys.DEFAULT_OFFLINE_PUSH_STRATEGY;
-import static com.linkedin.venice.ConfigKeys.DEFAULT_PARTITION_SIZE;
-import static com.linkedin.venice.ConfigKeys.DEFAULT_READ_STRATEGY;
-import static com.linkedin.venice.ConfigKeys.DEFAULT_REPLICA_FACTOR;
-import static com.linkedin.venice.ConfigKeys.DEFAULT_ROUTING_STRATEGY;
-import static com.linkedin.venice.ConfigKeys.DELAY_TO_REBALANCE_MS;
-import static com.linkedin.venice.ConfigKeys.ENABLE_ACTIVE_ACTIVE_REPLICATION_AS_DEFAULT_FOR_BATCH_ONLY_STORE;
-import static com.linkedin.venice.ConfigKeys.ENABLE_ACTIVE_ACTIVE_REPLICATION_AS_DEFAULT_FOR_HYBRID_STORE;
-import static com.linkedin.venice.ConfigKeys.ENABLE_ACTIVE_ACTIVE_REPLICATION_AS_DEFAULT_FOR_INCREMENTAL_PUSH_STORE;
-import static com.linkedin.venice.ConfigKeys.ENABLE_HYBRID_PUSH_SSL_ALLOWLIST;
-import static com.linkedin.venice.ConfigKeys.ENABLE_HYBRID_PUSH_SSL_WHITELIST;
-import static com.linkedin.venice.ConfigKeys.ENABLE_LEADER_FOLLOWER_AS_DEFAULT_FOR_ALL_STORES;
-import static com.linkedin.venice.ConfigKeys.ENABLE_LEADER_FOLLOWER_AS_DEFAULT_FOR_BATCH_ONLY_STORES;
-import static com.linkedin.venice.ConfigKeys.ENABLE_LEADER_FOLLOWER_AS_DEFAULT_FOR_HYBRID_STORES;
-import static com.linkedin.venice.ConfigKeys.ENABLE_LEADER_FOLLOWER_AS_DEFAULT_FOR_INCREMENTAL_PUSH_STORES;
-import static com.linkedin.venice.ConfigKeys.ENABLE_NATIVE_REPLICATION_AS_DEFAULT_FOR_BATCH_ONLY;
-import static com.linkedin.venice.ConfigKeys.ENABLE_NATIVE_REPLICATION_AS_DEFAULT_FOR_HYBRID;
-import static com.linkedin.venice.ConfigKeys.ENABLE_NATIVE_REPLICATION_AS_DEFAULT_FOR_INCREMENTAL_PUSH;
-import static com.linkedin.venice.ConfigKeys.ENABLE_NATIVE_REPLICATION_FOR_BATCH_ONLY;
-import static com.linkedin.venice.ConfigKeys.ENABLE_NATIVE_REPLICATION_FOR_HYBRID;
-import static com.linkedin.venice.ConfigKeys.ENABLE_NATIVE_REPLICATION_FOR_INCREMENTAL_PUSH;
-import static com.linkedin.venice.ConfigKeys.ENABLE_OFFLINE_PUSH_SSL_ALLOWLIST;
-import static com.linkedin.venice.ConfigKeys.ENABLE_OFFLINE_PUSH_SSL_WHITELIST;
-import static com.linkedin.venice.ConfigKeys.HELIX_REBALANCE_ALG;
-import static com.linkedin.venice.ConfigKeys.HELIX_SEND_MESSAGE_TIMEOUT_MS;
-import static com.linkedin.venice.ConfigKeys.KAFKA_BOOTSTRAP_SERVERS;
-import static com.linkedin.venice.ConfigKeys.KAFKA_LOG_COMPACTION_FOR_HYBRID_STORES;
-import static com.linkedin.venice.ConfigKeys.KAFKA_LOG_COMPACTION_FOR_INCREMENTAL_PUSH_STORES;
-import static com.linkedin.venice.ConfigKeys.KAFKA_MIN_ISR;
-import static com.linkedin.venice.ConfigKeys.KAFKA_MIN_LOG_COMPACTION_LAG_MS;
-import static com.linkedin.venice.ConfigKeys.KAFKA_REPLICATION_FACTOR;
-import static com.linkedin.venice.ConfigKeys.KAFKA_REPLICATION_FACTOR_LEGACY_SPELLING;
-import static com.linkedin.venice.ConfigKeys.KAFKA_SECURITY_PROTOCOL;
-import static com.linkedin.venice.ConfigKeys.KAFKA_ZK_ADDRESS;
-import static com.linkedin.venice.ConfigKeys.LEAKED_PUSH_STATUS_CLEAN_UP_SERVICE_SLEEP_INTERVAL_MS;
-import static com.linkedin.venice.ConfigKeys.LF_MODEL_DEPENDENCY_CHECK_DISABLED;
-import static com.linkedin.venice.ConfigKeys.MIN_ACTIVE_REPLICA;
-import static com.linkedin.venice.ConfigKeys.NATIVE_REPLICATION_SOURCE_FABRIC_AS_DEFAULT_FOR_BATCH_ONLY_STORES;
-import static com.linkedin.venice.ConfigKeys.NATIVE_REPLICATION_SOURCE_FABRIC_AS_DEFAULT_FOR_HYBRID_STORES;
-import static com.linkedin.venice.ConfigKeys.NATIVE_REPLICATION_SOURCE_FABRIC_AS_DEFAULT_FOR_INCREMENTAL_PUSH_STORES;
-import static com.linkedin.venice.ConfigKeys.OFFLINE_JOB_START_TIMEOUT_MS;
-import static com.linkedin.venice.ConfigKeys.PERSISTENCE_TYPE;
-import static com.linkedin.venice.ConfigKeys.PUSH_MONITOR_TYPE;
-import static com.linkedin.venice.ConfigKeys.PUSH_SSL_ALLOWLIST;
-import static com.linkedin.venice.ConfigKeys.PUSH_SSL_WHITELIST;
-import static com.linkedin.venice.ConfigKeys.REFRESH_ATTEMPTS_FOR_ZK_RECONNECT;
-import static com.linkedin.venice.ConfigKeys.REFRESH_INTERVAL_FOR_ZK_RECONNECT_MS;
-import static com.linkedin.venice.ConfigKeys.REPLICATION_METADATA_VERSION_ID;
-import static com.linkedin.venice.ConfigKeys.SSL_KAFKA_BOOTSTRAP_SERVERS;
-import static com.linkedin.venice.ConfigKeys.SSL_TO_KAFKA;
-import static com.linkedin.venice.ConfigKeys.ZOOKEEPER_ADDRESS;
+import static com.linkedin.venice.ConfigKeys.*;
 import static com.linkedin.venice.SSLConfig.DEFAULT_CONTROLLER_SSL_ENABLED;
 import static com.linkedin.venice.VeniceConstants.DEFAULT_PER_ROUTER_READ_QUOTA;
 import static com.linkedin.venice.VeniceConstants.DEFAULT_SSL_FACTORY_CLASS_NAME;
@@ -244,7 +183,10 @@ public class VeniceControllerClusterConfig {
    * defined by {@value com.linkedin.venice.ConfigKeys#DEFAULT_REPLICA_FACTOR}.
    */
   private int kafkaReplicationFactor;
+  private int kafkaReplicationFactorRTTopics;
   private Optional<Integer> minIsr;
+  private Optional<Integer> minIsrRTTopics;
+  private Optional<Integer> minIsrAdminTopics;
   private boolean kafkaLogCompactionForHybridStores;
   private boolean kafkaLogCompactionForIncrementalPushStores;
   private long kafkaMinLogCompactionLagInMs;
@@ -301,7 +243,10 @@ public class VeniceControllerClusterConfig {
     } catch (UndefinedPropertyException e) {
       kafkaReplicationFactor = props.getInt(KAFKA_REPLICATION_FACTOR_LEGACY_SPELLING);
     }
+    kafkaReplicationFactorRTTopics = props.getInt(KAFKA_REPLICATION_FACTOR_RT_TOPICS, kafkaReplicationFactor);
     minIsr = props.getOptionalInt(KAFKA_MIN_ISR);
+    minIsrRTTopics = props.getOptionalInt(KAFKA_MIN_ISR_RT_TOPICS);
+    minIsrAdminTopics = props.getOptionalInt(KAFKA_MIN_ISR_ADMIN_TOPICS);
     kafkaLogCompactionForHybridStores = props.getBoolean(KAFKA_LOG_COMPACTION_FOR_HYBRID_STORES, true);
     kafkaLogCompactionForIncrementalPushStores =
         props.getBoolean(KAFKA_LOG_COMPACTION_FOR_INCREMENTAL_PUSH_STORES, true);
@@ -505,6 +450,10 @@ public class VeniceControllerClusterConfig {
     return kafkaReplicationFactor;
   }
 
+  public int getKafkaReplicationFactorRTTopics() {
+    return kafkaReplicationFactorRTTopics;
+  }
+
   public long getPartitionSize() {
     return partitionSize;
   }
@@ -599,6 +548,14 @@ public class VeniceControllerClusterConfig {
 
   public Optional<Integer> getMinIsr() {
     return minIsr;
+  }
+
+  public Optional<Integer> getMinIsrRTTopics() {
+    return minIsrRTTopics;
+  }
+
+  public Optional<Integer> getMinIsrAdminTopics() {
+    return minIsrAdminTopics;
   }
 
   public boolean isKafkaLogCompactionForHybridStoresEnabled() {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerClusterConfig.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerClusterConfig.java
@@ -1,7 +1,71 @@
 package com.linkedin.venice.controller;
 
 import static com.linkedin.venice.CommonConfigKeys.SSL_FACTORY_CLASS_NAME;
-import static com.linkedin.venice.ConfigKeys.*;
+import static com.linkedin.venice.ConfigKeys.ADMIN_TOPIC_REPLICATION_FACTOR;
+import static com.linkedin.venice.ConfigKeys.CLUSTER_NAME;
+import static com.linkedin.venice.ConfigKeys.CLUSTER_TO_D2;
+import static com.linkedin.venice.ConfigKeys.CONTROLLER_DEFAULT_READ_QUOTA_PER_ROUTER;
+import static com.linkedin.venice.ConfigKeys.CONTROLLER_DISABLE_PARENT_REQUEST_TOPIC_FOR_STREAM_PUSHES;
+import static com.linkedin.venice.ConfigKeys.CONTROLLER_JETTY_CONFIG_OVERRIDE_PREFIX;
+import static com.linkedin.venice.ConfigKeys.CONTROLLER_NAME;
+import static com.linkedin.venice.ConfigKeys.CONTROLLER_SCHEMA_VALIDATION_ENABLED;
+import static com.linkedin.venice.ConfigKeys.CONTROLLER_SSL_ENABLED;
+import static com.linkedin.venice.ConfigKeys.DEFAULT_MAX_NUMBER_OF_PARTITIONS;
+import static com.linkedin.venice.ConfigKeys.DEFAULT_NUMBER_OF_PARTITION;
+import static com.linkedin.venice.ConfigKeys.DEFAULT_OFFLINE_PUSH_STRATEGY;
+import static com.linkedin.venice.ConfigKeys.DEFAULT_PARTITION_SIZE;
+import static com.linkedin.venice.ConfigKeys.DEFAULT_READ_STRATEGY;
+import static com.linkedin.venice.ConfigKeys.DEFAULT_REPLICA_FACTOR;
+import static com.linkedin.venice.ConfigKeys.DEFAULT_ROUTING_STRATEGY;
+import static com.linkedin.venice.ConfigKeys.DELAY_TO_REBALANCE_MS;
+import static com.linkedin.venice.ConfigKeys.ENABLE_ACTIVE_ACTIVE_REPLICATION_AS_DEFAULT_FOR_BATCH_ONLY_STORE;
+import static com.linkedin.venice.ConfigKeys.ENABLE_ACTIVE_ACTIVE_REPLICATION_AS_DEFAULT_FOR_HYBRID_STORE;
+import static com.linkedin.venice.ConfigKeys.ENABLE_ACTIVE_ACTIVE_REPLICATION_AS_DEFAULT_FOR_INCREMENTAL_PUSH_STORE;
+import static com.linkedin.venice.ConfigKeys.ENABLE_HYBRID_PUSH_SSL_ALLOWLIST;
+import static com.linkedin.venice.ConfigKeys.ENABLE_HYBRID_PUSH_SSL_WHITELIST;
+import static com.linkedin.venice.ConfigKeys.ENABLE_LEADER_FOLLOWER_AS_DEFAULT_FOR_ALL_STORES;
+import static com.linkedin.venice.ConfigKeys.ENABLE_LEADER_FOLLOWER_AS_DEFAULT_FOR_BATCH_ONLY_STORES;
+import static com.linkedin.venice.ConfigKeys.ENABLE_LEADER_FOLLOWER_AS_DEFAULT_FOR_HYBRID_STORES;
+import static com.linkedin.venice.ConfigKeys.ENABLE_LEADER_FOLLOWER_AS_DEFAULT_FOR_INCREMENTAL_PUSH_STORES;
+import static com.linkedin.venice.ConfigKeys.ENABLE_NATIVE_REPLICATION_AS_DEFAULT_FOR_BATCH_ONLY;
+import static com.linkedin.venice.ConfigKeys.ENABLE_NATIVE_REPLICATION_AS_DEFAULT_FOR_HYBRID;
+import static com.linkedin.venice.ConfigKeys.ENABLE_NATIVE_REPLICATION_AS_DEFAULT_FOR_INCREMENTAL_PUSH;
+import static com.linkedin.venice.ConfigKeys.ENABLE_NATIVE_REPLICATION_FOR_BATCH_ONLY;
+import static com.linkedin.venice.ConfigKeys.ENABLE_NATIVE_REPLICATION_FOR_HYBRID;
+import static com.linkedin.venice.ConfigKeys.ENABLE_NATIVE_REPLICATION_FOR_INCREMENTAL_PUSH;
+import static com.linkedin.venice.ConfigKeys.ENABLE_OFFLINE_PUSH_SSL_ALLOWLIST;
+import static com.linkedin.venice.ConfigKeys.ENABLE_OFFLINE_PUSH_SSL_WHITELIST;
+import static com.linkedin.venice.ConfigKeys.HELIX_REBALANCE_ALG;
+import static com.linkedin.venice.ConfigKeys.HELIX_SEND_MESSAGE_TIMEOUT_MS;
+import static com.linkedin.venice.ConfigKeys.KAFKA_BOOTSTRAP_SERVERS;
+import static com.linkedin.venice.ConfigKeys.KAFKA_LOG_COMPACTION_FOR_HYBRID_STORES;
+import static com.linkedin.venice.ConfigKeys.KAFKA_LOG_COMPACTION_FOR_INCREMENTAL_PUSH_STORES;
+import static com.linkedin.venice.ConfigKeys.KAFKA_MIN_IN_SYNC_REPLICAS;
+import static com.linkedin.venice.ConfigKeys.KAFKA_MIN_IN_SYNC_REPLICAS_ADMIN_TOPICS;
+import static com.linkedin.venice.ConfigKeys.KAFKA_MIN_IN_SYNC_REPLICAS_RT_TOPICS;
+import static com.linkedin.venice.ConfigKeys.KAFKA_MIN_LOG_COMPACTION_LAG_MS;
+import static com.linkedin.venice.ConfigKeys.KAFKA_REPLICATION_FACTOR;
+import static com.linkedin.venice.ConfigKeys.KAFKA_REPLICATION_FACTOR_LEGACY_SPELLING;
+import static com.linkedin.venice.ConfigKeys.KAFKA_REPLICATION_FACTOR_RT_TOPICS;
+import static com.linkedin.venice.ConfigKeys.KAFKA_SECURITY_PROTOCOL;
+import static com.linkedin.venice.ConfigKeys.KAFKA_ZK_ADDRESS;
+import static com.linkedin.venice.ConfigKeys.LEAKED_PUSH_STATUS_CLEAN_UP_SERVICE_SLEEP_INTERVAL_MS;
+import static com.linkedin.venice.ConfigKeys.LF_MODEL_DEPENDENCY_CHECK_DISABLED;
+import static com.linkedin.venice.ConfigKeys.MIN_ACTIVE_REPLICA;
+import static com.linkedin.venice.ConfigKeys.NATIVE_REPLICATION_SOURCE_FABRIC_AS_DEFAULT_FOR_BATCH_ONLY_STORES;
+import static com.linkedin.venice.ConfigKeys.NATIVE_REPLICATION_SOURCE_FABRIC_AS_DEFAULT_FOR_HYBRID_STORES;
+import static com.linkedin.venice.ConfigKeys.NATIVE_REPLICATION_SOURCE_FABRIC_AS_DEFAULT_FOR_INCREMENTAL_PUSH_STORES;
+import static com.linkedin.venice.ConfigKeys.OFFLINE_JOB_START_TIMEOUT_MS;
+import static com.linkedin.venice.ConfigKeys.PERSISTENCE_TYPE;
+import static com.linkedin.venice.ConfigKeys.PUSH_MONITOR_TYPE;
+import static com.linkedin.venice.ConfigKeys.PUSH_SSL_ALLOWLIST;
+import static com.linkedin.venice.ConfigKeys.PUSH_SSL_WHITELIST;
+import static com.linkedin.venice.ConfigKeys.REFRESH_ATTEMPTS_FOR_ZK_RECONNECT;
+import static com.linkedin.venice.ConfigKeys.REFRESH_INTERVAL_FOR_ZK_RECONNECT_MS;
+import static com.linkedin.venice.ConfigKeys.REPLICATION_METADATA_VERSION_ID;
+import static com.linkedin.venice.ConfigKeys.SSL_KAFKA_BOOTSTRAP_SERVERS;
+import static com.linkedin.venice.ConfigKeys.SSL_TO_KAFKA;
+import static com.linkedin.venice.ConfigKeys.ZOOKEEPER_ADDRESS;
 import static com.linkedin.venice.SSLConfig.DEFAULT_CONTROLLER_SSL_ENABLED;
 import static com.linkedin.venice.VeniceConstants.DEFAULT_PER_ROUTER_READ_QUOTA;
 import static com.linkedin.venice.VeniceConstants.DEFAULT_SSL_FACTORY_CLASS_NAME;
@@ -184,9 +248,9 @@ public class VeniceControllerClusterConfig {
    */
   private int kafkaReplicationFactor;
   private int kafkaReplicationFactorRTTopics;
-  private Optional<Integer> minIsr;
-  private Optional<Integer> minIsrRTTopics;
-  private Optional<Integer> minIsrAdminTopics;
+  private Optional<Integer> minInSyncReplicas;
+  private Optional<Integer> minInSyncReplicasRealTimeTopics;
+  private Optional<Integer> minInSyncReplicasAdminTopics;
   private boolean kafkaLogCompactionForHybridStores;
   private boolean kafkaLogCompactionForIncrementalPushStores;
   private long kafkaMinLogCompactionLagInMs;
@@ -244,9 +308,9 @@ public class VeniceControllerClusterConfig {
       kafkaReplicationFactor = props.getInt(KAFKA_REPLICATION_FACTOR_LEGACY_SPELLING);
     }
     kafkaReplicationFactorRTTopics = props.getInt(KAFKA_REPLICATION_FACTOR_RT_TOPICS, kafkaReplicationFactor);
-    minIsr = props.getOptionalInt(KAFKA_MIN_ISR);
-    minIsrRTTopics = props.getOptionalInt(KAFKA_MIN_ISR_RT_TOPICS);
-    minIsrAdminTopics = props.getOptionalInt(KAFKA_MIN_ISR_ADMIN_TOPICS);
+    minInSyncReplicas = props.getOptionalInt(KAFKA_MIN_IN_SYNC_REPLICAS);
+    minInSyncReplicasRealTimeTopics = props.getOptionalInt(KAFKA_MIN_IN_SYNC_REPLICAS_RT_TOPICS);
+    minInSyncReplicasAdminTopics = props.getOptionalInt(KAFKA_MIN_IN_SYNC_REPLICAS_ADMIN_TOPICS);
     kafkaLogCompactionForHybridStores = props.getBoolean(KAFKA_LOG_COMPACTION_FOR_HYBRID_STORES, true);
     kafkaLogCompactionForIncrementalPushStores =
         props.getBoolean(KAFKA_LOG_COMPACTION_FOR_INCREMENTAL_PUSH_STORES, true);
@@ -546,16 +610,16 @@ public class VeniceControllerClusterConfig {
     return pushMonitorType;
   }
 
-  public Optional<Integer> getMinIsr() {
-    return minIsr;
+  public Optional<Integer> getMinInSyncReplicas() {
+    return minInSyncReplicas;
   }
 
-  public Optional<Integer> getMinIsrRTTopics() {
-    return minIsrRTTopics;
+  public Optional<Integer> getMinInSyncReplicasRealTimeTopics() {
+    return minInSyncReplicasRealTimeTopics;
   }
 
-  public Optional<Integer> getMinIsrAdminTopics() {
-    return minIsrAdminTopics;
+  public Optional<Integer> getMinInSyncReplicasAdminTopics() {
+    return minInSyncReplicasAdminTopics;
   }
 
   public boolean isKafkaLogCompactionForHybridStoresEnabled() {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerMultiClusterConfig.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerMultiClusterConfig.java
@@ -145,10 +145,6 @@ public class VeniceControllerMultiClusterConfig {
     return getCommonConfig().getBatchJobHeartbeatInitialBufferTime();
   }
 
-  public int getKafkaReplicaFactor() {
-    return getCommonConfig().getKafkaReplicationFactor();
-  }
-
   public long getTopicCreationThrottlingTimeWindowMs() {
     return getCommonConfig().getTopicCreationThrottlingTimeWindowMs();
   }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -2149,10 +2149,10 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
                 getTopicManager().createTopic(
                     realTimeTopic,
                     numberOfPartitions,
-                    clusterConfig.getKafkaReplicationFactor(),
+                    clusterConfig.getKafkaReplicationFactorRTTopics(),
                     TopicManager.getExpectedRetentionTimeInMs(store, store.getHybridStoreConfig()),
                     false, // Note: do not enable RT compaction! Might make jobs in Online/Offline model stuck
-                    clusterConfig.getMinIsr(),
+                    clusterConfig.getMinIsrRTTopics(),
                     false);
               } else {
                 // If real-time topic already exists, check whether its retention time is correct.
@@ -2512,10 +2512,10 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
         getTopicManager().createTopic(
             realTimeTopic,
             partitionCount,
-            clusterConfig.getKafkaReplicationFactor(),
+            clusterConfig.getKafkaReplicationFactorRTTopics(),
             store.getRetentionTime(),
             false, // Note: do not enable RT compaction! Might make jobs in Online/Offline model stuck
-            clusterConfig.getMinIsr(),
+            clusterConfig.getMinIsrRTTopics(),
             false);
         // TODO: if there is an online version from a batch push before this store was hybrid then we won't start
         // replicating to it. A new version must be created.

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -1959,7 +1959,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
             clusterConfig.getKafkaReplicationFactor(),
             true,
             false,
-            clusterConfig.getMinIsr(),
+            clusterConfig.getMinInSyncReplicas(),
             useFastKafkaOperationTimeout));
   }
 
@@ -2152,7 +2152,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
                     clusterConfig.getKafkaReplicationFactorRTTopics(),
                     TopicManager.getExpectedRetentionTimeInMs(store, store.getHybridStoreConfig()),
                     false, // Note: do not enable RT compaction! Might make jobs in Online/Offline model stuck
-                    clusterConfig.getMinIsrRTTopics(),
+                    clusterConfig.getMinInSyncReplicasRealTimeTopics(),
                     false);
               } else {
                 // If real-time topic already exists, check whether its retention time is correct.
@@ -2515,7 +2515,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
             clusterConfig.getKafkaReplicationFactorRTTopics(),
             store.getRetentionTime(),
             false, // Note: do not enable RT compaction! Might make jobs in Online/Offline model stuck
-            clusterConfig.getMinIsrRTTopics(),
+            clusterConfig.getMinInSyncReplicasRealTimeTopics(),
             false);
         // TODO: if there is an online version from a batch push before this store was hybrid then we won't start
         // replicating to it. A new version must be created.

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
@@ -475,7 +475,10 @@ public class VeniceParentHelixAdmin implements Admin {
       topicManager.createTopic(
           topicName,
           AdminTopicUtils.PARTITION_NUM_FOR_ADMIN_TOPIC,
-          getMultiClusterConfigs().getKafkaReplicaFactor());
+          getMultiClusterConfigs().getControllerConfig(clusterName).getAdminTopicReplicationFactor(),
+          true,
+          false,
+          getMultiClusterConfigs().getControllerConfig(clusterName).getMinIsrAdminTopics());
       LOGGER.info("Created admin topic: {} for cluster: {}", topicName, clusterName);
     }
 

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
@@ -478,7 +478,7 @@ public class VeniceParentHelixAdmin implements Admin {
           getMultiClusterConfigs().getControllerConfig(clusterName).getAdminTopicReplicationFactor(),
           true,
           false,
-          getMultiClusterConfigs().getControllerConfig(clusterName).getMinIsrAdminTopics());
+          getMultiClusterConfigs().getControllerConfig(clusterName).getMinInSyncReplicasAdminTopics());
       LOGGER.info("Created admin topic: {} for cluster: {}", topicName, clusterName);
     }
 

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/kafka/consumer/AdminConsumerService.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/kafka/consumer/AdminConsumerService.java
@@ -112,6 +112,7 @@ public class AdminConsumerService extends AbstractVeniceService {
         config.isParent(),
         new AdminConsumptionStats(metricsRepository, clusterName + "-admin_consumption_task"),
         config.getAdminTopicReplicationFactor(),
+        config.getMinIsrAdminTopics(),
         config.getAdminConsumptionCycleTimeoutMs(),
         config.getAdminConsumptionMaxWorkerThreadPoolSize());
   }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/kafka/consumer/AdminConsumerService.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/kafka/consumer/AdminConsumerService.java
@@ -112,7 +112,7 @@ public class AdminConsumerService extends AbstractVeniceService {
         config.isParent(),
         new AdminConsumptionStats(metricsRepository, clusterName + "-admin_consumption_task"),
         config.getAdminTopicReplicationFactor(),
-        config.getMinIsrAdminTopics(),
+        config.getMinInSyncReplicasAdminTopics(),
         config.getAdminConsumptionCycleTimeoutMs(),
         config.getAdminConsumptionMaxWorkerThreadPoolSize());
   }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/kafka/consumer/AdminConsumptionTask.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/kafka/consumer/AdminConsumptionTask.java
@@ -131,6 +131,7 @@ public class AdminConsumptionTask implements Runnable, Closeable {
   private final AdminOperationSerializer deserializer;
   private final AdminConsumptionStats stats;
   private final int adminTopicReplicationFactor;
+  private final Optional<Integer> minIsr;
   private final boolean remoteConsumptionEnabled;
 
   private boolean isSubscribed;
@@ -237,6 +238,7 @@ public class AdminConsumptionTask implements Runnable, Closeable {
       boolean isParentController,
       AdminConsumptionStats stats,
       int adminTopicReplicationFactor,
+      Optional<Integer> minIsr,
       long processingCycleTimeoutInMs,
       int maxWorkerThreadPoolSize) {
     this.clusterName = clusterName;
@@ -251,6 +253,7 @@ public class AdminConsumptionTask implements Runnable, Closeable {
     this.topicExists = false;
     this.stats = stats;
     this.adminTopicReplicationFactor = adminTopicReplicationFactor;
+    this.minIsr = minIsr;
     this.consumer = consumer;
     this.remoteConsumptionEnabled = remoteConsumptionEnabled;
     this.adminTopicMetadataAccessor = adminTopicMetadataAccessor;
@@ -314,14 +317,7 @@ public class AdminConsumptionTask implements Runnable, Closeable {
               continue;
             }
             LOGGER.info(logMessageFormat, topic, "Since this is the parent controller, it will be created now.");
-            admin.getTopicManager()
-                .createTopic(
-                    topic,
-                    1,
-                    adminTopicReplicationFactor,
-                    true,
-                    false,
-                    Optional.of(adminTopicReplicationFactor - 1));
+            admin.getTopicManager().createTopic(topic, 1, adminTopicReplicationFactor, true, false, minIsr);
             LOGGER.info("Admin topic {} is created.", topic);
           }
           subscribe();

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/kafka/consumer/AdminConsumptionTask.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/kafka/consumer/AdminConsumptionTask.java
@@ -131,7 +131,7 @@ public class AdminConsumptionTask implements Runnable, Closeable {
   private final AdminOperationSerializer deserializer;
   private final AdminConsumptionStats stats;
   private final int adminTopicReplicationFactor;
-  private final Optional<Integer> minIsr;
+  private final Optional<Integer> minInSyncReplicas;
   private final boolean remoteConsumptionEnabled;
 
   private boolean isSubscribed;
@@ -238,7 +238,7 @@ public class AdminConsumptionTask implements Runnable, Closeable {
       boolean isParentController,
       AdminConsumptionStats stats,
       int adminTopicReplicationFactor,
-      Optional<Integer> minIsr,
+      Optional<Integer> minInSyncReplicas,
       long processingCycleTimeoutInMs,
       int maxWorkerThreadPoolSize) {
     this.clusterName = clusterName;
@@ -253,7 +253,7 @@ public class AdminConsumptionTask implements Runnable, Closeable {
     this.topicExists = false;
     this.stats = stats;
     this.adminTopicReplicationFactor = adminTopicReplicationFactor;
-    this.minIsr = minIsr;
+    this.minInSyncReplicas = minInSyncReplicas;
     this.consumer = consumer;
     this.remoteConsumptionEnabled = remoteConsumptionEnabled;
     this.adminTopicMetadataAccessor = adminTopicMetadataAccessor;
@@ -317,7 +317,7 @@ public class AdminConsumptionTask implements Runnable, Closeable {
               continue;
             }
             LOGGER.info(logMessageFormat, topic, "Since this is the parent controller, it will be created now.");
-            admin.getTopicManager().createTopic(topic, 1, adminTopicReplicationFactor, true, false, minIsr);
+            admin.getTopicManager().createTopic(topic, 1, adminTopicReplicationFactor, true, false, minInSyncReplicas);
             LOGGER.info("Admin topic {} is created.", topic);
           }
           subscribe();

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/AbstractTestVeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/AbstractTestVeniceParentHelixAdmin.java
@@ -176,6 +176,7 @@ public class AbstractTestVeniceParentHelixAdmin {
     VeniceControllerConfig config = mock(VeniceControllerConfig.class);
     doReturn(clusterName).when(config).getClusterName();
     doReturn(KAFKA_REPLICA_FACTOR).when(config).getKafkaReplicationFactor();
+    doReturn(KAFKA_REPLICA_FACTOR).when(config).getAdminTopicReplicationFactor();
     doReturn(10000).when(config).getParentControllerWaitingTimeForConsumptionMs();
     doReturn("fake_kafka_bootstrap_servers").when(config).getKafkaBootstrapServers();
     // PushJobStatusStore and participant message store are disabled in this unit test by default because many

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceParentHelixAdmin.java
@@ -115,8 +115,13 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
   public void testStartWithTopicExists() {
     parentAdmin.initStorageCluster(clusterName);
     verify(internalAdmin).getTopicManager();
-    verify(topicManager, never())
-        .createTopic(topicName, AdminTopicUtils.PARTITION_NUM_FOR_ADMIN_TOPIC, KAFKA_REPLICA_FACTOR);
+    verify(topicManager, never()).createTopic(
+        topicName,
+        AdminTopicUtils.PARTITION_NUM_FOR_ADMIN_TOPIC,
+        KAFKA_REPLICA_FACTOR,
+        true,
+        false,
+        Optional.empty());
   }
 
   @Test
@@ -124,7 +129,13 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
     doReturn(false).when(topicManager).containsTopicAndAllPartitionsAreOnline(topicName);
     parentAdmin.initStorageCluster(clusterName);
     verify(internalAdmin).getTopicManager();
-    verify(topicManager).createTopic(topicName, AdminTopicUtils.PARTITION_NUM_FOR_ADMIN_TOPIC, KAFKA_REPLICA_FACTOR);
+    verify(topicManager).createTopic(
+        topicName,
+        AdminTopicUtils.PARTITION_NUM_FOR_ADMIN_TOPIC,
+        KAFKA_REPLICA_FACTOR,
+        true,
+        false,
+        Optional.empty());
   }
 
   /**

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/kafka/consumer/TestAdminConsumptionTask.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/kafka/consumer/TestAdminConsumptionTask.java
@@ -236,6 +236,7 @@ public class TestAdminConsumptionTask {
         isParent,
         stats,
         1,
+        Optional.empty(),
         adminConsumptionCycleTimeoutMs,
         1);
   }

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/kafka/consumer/TestAdminConsumptionTask.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/kafka/consumer/TestAdminConsumptionTask.java
@@ -298,7 +298,7 @@ public class TestAdminConsumptionTask {
     verify(admin, timeout(TIMEOUT).atLeastOnce()).isLeaderControllerFor(clusterName);
     if (isParent) {
       verify(topicManager, timeout(TIMEOUT))
-          .createTopic(AdminTopicUtils.getTopicNameFromClusterName(clusterName), 1, 1, true, false, Optional.of(0));
+          .createTopic(AdminTopicUtils.getTopicNameFromClusterName(clusterName), 1, 1, true, false, Optional.empty());
       verify(mockKafkaConsumer, timeout(TIMEOUT)).subscribe(any(), anyInt(), anyLong());
     } else {
       verify(topicManager, never()).createTopic(anyString(), anyInt(), anyInt(), anyBoolean(), anyBoolean(), any());


### PR DESCRIPTION
## Separate kafka RF and minIsr config for VT, RT and admin topics

Kafka replication factor can now be configured with:

- "kafka.replication.factor" for version topics
- "kafka.replication.factor.rt.topics" for RT topics
- "admin.topic.replication.factor" for admin topics

Kafka minimum in sync replicas can now be configured with:

- "kafka.min.isr" for version topics
- "kafka.min.isr.rt.topics" for RT topics
- "kafka.min.isr.admin.topics" for admin topics

## How was this PR tested?
Existing unit and integration tests

## Does this PR introduce any user-facing changes?
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.