### PR TITLE
[client] Return original value schema along with the read compute result

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/client/AvroGenericDaVinciClient.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/client/AvroGenericDaVinciClient.java
@@ -355,7 +355,7 @@ public class AvroGenericDaVinciClient<K, V> implements DaVinciClient<K, V>, Avro
       Optional<ClientStats> stats,
       Optional<ClientStats> streamingStats,
       final long preRequestTimeInNS) {
-    return new AvroComputeRequestBuilderV4<>(getLatestValueSchema(), this, stats, streamingStats);
+    return new AvroComputeRequestBuilderV4<K>(this, getLatestValueSchema()).setStats(stats, streamingStats);
   }
 
   private Schema getComputeResultSchema(ComputeRequestWrapper computeRequestWrapper) {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/client/AvroGenericDaVinciClient.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/client/AvroGenericDaVinciClient.java
@@ -34,6 +34,7 @@ import com.linkedin.venice.client.stats.ClientStats;
 import com.linkedin.venice.client.store.AvroComputeRequestBuilderV4;
 import com.linkedin.venice.client.store.AvroGenericReadComputeStoreClient;
 import com.linkedin.venice.client.store.ClientConfig;
+import com.linkedin.venice.client.store.ComputeGenericRecord;
 import com.linkedin.venice.client.store.ComputeRequestBuilder;
 import com.linkedin.venice.client.store.D2ServiceDiscovery;
 import com.linkedin.venice.client.store.streaming.StreamingCallback;
@@ -379,7 +380,7 @@ public class AvroGenericDaVinciClient<K, V> implements DaVinciClient<K, V>, Avro
       ComputeRequestWrapper computeRequestWrapper,
       Set<K> keys,
       Schema resultSchema,
-      StreamingCallback<K, GenericRecord> callback,
+      StreamingCallback<K, ComputeGenericRecord> callback,
       long preRequestTimeInNS) throws VeniceClientException {
     compute(computeRequestWrapper, keys, resultSchema, callback, preRequestTimeInNS, null, null);
   }
@@ -389,7 +390,7 @@ public class AvroGenericDaVinciClient<K, V> implements DaVinciClient<K, V>, Avro
       ComputeRequestWrapper computeRequestWrapper,
       Set<K> keys,
       Schema resultSchema,
-      StreamingCallback<K, GenericRecord> callback,
+      StreamingCallback<K, ComputeGenericRecord> callback,
       long preRequestTimeInNS,
       BinaryEncoder reusedEncoder,
       ByteArrayOutputStream reusedOutputStream) throws VeniceClientException {
@@ -446,7 +447,13 @@ public class AvroGenericDaVinciClient<K, V> implements DaVinciClient<K, V>, Avro
               computeRequestWrapper,
               computeResultSchema);
 
-          callback.onRecordReceived(key, computeResultValue);
+          if (computeResultValue != null) {
+            callback.onRecordReceived(
+                key,
+                new ComputeGenericRecord(computeResultValue, computeRequestWrapper.getValueSchema()));
+          } else {
+            callback.onRecordReceived(key, null);
+          }
         } else if (isVeniceQueryAllowed()) {
           missingKeys.add(key);
         } else if (!isPartitionSubscribed(versionBackend, partition)) {

--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/AbstractAvroComputeRequestBuilder.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/AbstractAvroComputeRequestBuilder.java
@@ -267,6 +267,11 @@ public abstract class AbstractAvroComputeRequestBuilder<K> implements ComputeReq
           .createSchemaField(hadamardProduct.resultFieldName.toString(), HADAMARD_PRODUCT_RESULT_SCHEMA, "", null);
       resultSchemaFields.add(hadamardProductField);
     });
+    /**
+     * Error map field can not be a static variable; after setting the error map field in a schema, the position of the
+     * field will be updated, so the next time when we set the field in a new schema, it would fail because
+     * {@link Schema#setFields(List)} check whether the position is -1.
+     */
     resultSchemaFields.add(
         AvroCompatibilityHelper.createSchemaField(
             VENICE_COMPUTATION_ERROR_MAP_FIELD_NAME,

--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/AbstractAvroComputeRequestBuilder.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/AbstractAvroComputeRequestBuilder.java
@@ -203,12 +203,6 @@ public abstract class AbstractAvroComputeRequestBuilder<K> implements ComputeReq
    * @return a set of existing operations result field name
    */
   protected Set<String> commonValidityCheck() {
-    // Projection
-    projectFields.forEach(projectField -> {
-      if (latestValueSchema.getField(projectField) == null) {
-        throw new VeniceClientException("Unknown project field: " + projectField);
-      }
-    });
     // DotProduct
     Set<String> computeResultFields = new HashSet<>();
     dotProducts.forEach(
@@ -255,7 +249,9 @@ public abstract class AbstractAvroComputeRequestBuilder<K> implements ComputeReq
        *    value in Java format, but the {@link Schema.Field#equals} will compare the underlying {@link com.fasterxml.jackson.databind.JsonNode}
        *    format of the default value.
        */
-      resultSchemaFields.add(AvroCompatibilityHelper.newField(existingField).setDoc("").build());
+      if (existingField != null) {
+        resultSchemaFields.add(AvroCompatibilityHelper.newField(existingField).setDoc("").build());
+      }
     });
     dotProducts.forEach(dotProduct -> {
       Schema.Field dotProductField = AvroCompatibilityHelper

--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/AbstractAvroComputeRequestBuilder.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/AbstractAvroComputeRequestBuilder.java
@@ -22,6 +22,7 @@ import com.linkedin.venice.compute.protocol.request.enums.ComputeOperationType;
 import com.linkedin.venice.utils.ComputeUtils;
 import com.linkedin.venice.utils.Pair;
 import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
+import io.tehuti.utils.SystemTime;
 import io.tehuti.utils.Time;
 import java.io.ByteArrayOutputStream;
 import java.util.Arrays;
@@ -48,66 +49,39 @@ import org.apache.avro.io.BinaryEncoder;
  * @param <K>
  */
 public abstract class AbstractAvroComputeRequestBuilder<K> implements ComputeRequestBuilder<K> {
-  /**
-   * Error map field can not be a static variable; after setting the error map field in a schema, the position of the
-   * field will be updated, so the next time when we set the field in a new schema, it would fail because
-   * {@link Schema#setFields(List)} check whether the position is -1.
-   */
-  protected final Schema.Field VENICE_COMPUTATION_ERROR_MAP_FIELD = AvroCompatibilityHelper.createSchemaField(
-      VENICE_COMPUTATION_ERROR_MAP_FIELD_NAME,
-      Schema.createMap(Schema.create(Schema.Type.STRING)),
-      "",
-      null);
-
   protected static final Map<Map<String, Object>, Pair<Schema, String>> RESULT_SCHEMA_CACHE =
       new VeniceConcurrentHashMap<>();
   protected static final String PROJECTION_SPEC = "projection_spec";
   protected static final String DOT_PRODUCT_SPEC = "dotProduct_spec";
   protected static final String COSINE_SIMILARITY_SPEC = "cosineSimilarity_spec";
-  private static final String HADAMARD_PRODUCT_SPEC = "hadamardProduct_spec";
+  protected static final String HADAMARD_PRODUCT_SPEC = "hadamardProduct_spec";
 
-  private static final Schema HADAMARD_PRODUCT_RESULT_SCHEMA = Schema.createUnion(
+  protected static final Schema HADAMARD_PRODUCT_RESULT_SCHEMA = Schema.createUnion(
       Arrays.asList(Schema.create(Schema.Type.NULL), Schema.createArray(Schema.create(Schema.Type.FLOAT))));
-
   protected static final Schema DOT_PRODUCT_RESULT_SCHEMA =
       Schema.createUnion(Arrays.asList(Schema.create(Schema.Type.NULL), Schema.create(Schema.Type.FLOAT)));
   protected static final Schema COSINE_SIMILARITY_RESULT_SCHEMA =
       Schema.createUnion(Arrays.asList(Schema.create(Schema.Type.NULL), Schema.create(Schema.Type.FLOAT)));
 
-  private final Time time;
-  protected final Schema latestValueSchema;
   protected final AvroGenericReadComputeStoreClient storeClient;
+  protected final Schema latestValueSchema;
   protected final String resultSchemaName;
-  private final Optional<ClientStats> stats;
-  private final Optional<ClientStats> streamingStats;
+
+  private boolean executed = false;
+  private Time time = new SystemTime();
+  private Optional<ClientStats> stats = Optional.empty();
+  private Optional<ClientStats> streamingStats = Optional.empty();
+
+  private boolean reuseObjects = false;
+  private BinaryEncoder reusedEncoder;
+  private ByteArrayOutputStream reusedOutputStream;
+  private boolean projectionFieldValidation = true;
+  private Set<String> projectFields = new HashSet<>();
+  private List<DotProduct> dotProducts = new LinkedList<>();
+  private List<CosineSimilarity> cosineSimilarities = new LinkedList<>();
   private List<HadamardProduct> hadamardProducts = new LinkedList<>();
 
-  private final boolean reuseObjects;
-  private final BinaryEncoder reusedEncoder;
-  private final ByteArrayOutputStream reusedOutputStream;
-
-  protected Set<String> projectFields = new HashSet<>();
-  protected List<DotProduct> dotProducts = new LinkedList<>();
-  protected List<CosineSimilarity> cosineSimilarities = new LinkedList<>();
-
-  public AbstractAvroComputeRequestBuilder(
-      Schema latestValueSchema,
-      AvroGenericReadComputeStoreClient storeClient,
-      Optional<ClientStats> stats,
-      Optional<ClientStats> streamingStats,
-      Time time) {
-    this(latestValueSchema, storeClient, stats, streamingStats, time, false, null, null);
-  }
-
-  public AbstractAvroComputeRequestBuilder(
-      Schema latestValueSchema,
-      AvroGenericReadComputeStoreClient storeClient,
-      Optional<ClientStats> stats,
-      Optional<ClientStats> streamingStats,
-      Time time,
-      boolean reuseObjects,
-      BinaryEncoder reusedEncoder,
-      ByteArrayOutputStream reusedOutputStream) {
+  public AbstractAvroComputeRequestBuilder(AvroGenericReadComputeStoreClient storeClient, Schema latestValueSchema) {
 
     if (latestValueSchema.getType() != Schema.Type.RECORD) {
       throw new VeniceClientException("Only value schema with 'RECORD' type is supported");
@@ -117,33 +91,50 @@ public abstract class AbstractAvroComputeRequestBuilder<K> implements ComputeReq
           "Field name: " + VENICE_COMPUTATION_ERROR_MAP_FIELD_NAME
               + " is reserved, please don't use it in value schema: " + latestValueSchema);
     }
-    this.time = time;
-    this.latestValueSchema = latestValueSchema;
+
     this.storeClient = storeClient;
-    this.stats = stats;
-    this.streamingStats = streamingStats;
+    this.latestValueSchema = latestValueSchema;
     this.resultSchemaName =
         ComputeUtils.removeAvroIllegalCharacter(storeClient.getStoreName()) + "_VeniceComputeResult";
-    this.reuseObjects = reuseObjects;
-    this.reusedEncoder = reusedEncoder;
-    this.reusedOutputStream = reusedOutputStream;
+
   }
 
-  @Override
-  public ComputeRequestBuilder<K> project(String... fieldNames) throws VeniceClientException {
-    for (String fieldName: fieldNames) {
-      projectFields.add(fieldName);
-    }
+  /** test-only*/
+  public AbstractAvroComputeRequestBuilder<K> setTime(Time time) {
+    this.time = time;
+    return this;
+  }
 
+  public AbstractAvroComputeRequestBuilder<K> setStats(
+      Optional<ClientStats> stats,
+      Optional<ClientStats> streamingStats) {
+    this.stats = stats;
+    this.streamingStats = streamingStats;
+    return this;
+  }
+
+  public AbstractAvroComputeRequestBuilder<K> setReuseObjects(
+      BinaryEncoder reusedEncoder,
+      ByteArrayOutputStream reusedOutputStream) {
+    this.reuseObjects = true;
+    this.reusedEncoder = reusedEncoder;
+    this.reusedOutputStream = reusedOutputStream;
+    return this;
+  }
+
+  public AbstractAvroComputeRequestBuilder<K> setValidateProjectionFields(boolean projectionFieldValidation) {
+    this.projectionFieldValidation = projectionFieldValidation;
     return this;
   }
 
   @Override
-  public ComputeRequestBuilder<K> project(Collection<String> fieldNames) throws VeniceClientException {
-    for (String fieldName: fieldNames) {
-      projectFields.add(fieldName);
-    }
+  public ComputeRequestBuilder<K> project(String... fieldNames) throws VeniceClientException {
+    return project(Arrays.asList(fieldNames));
+  }
 
+  @Override
+  public ComputeRequestBuilder<K> project(Collection<String> fieldNames) throws VeniceClientException {
+    projectFields.addAll(fieldNames);
     return this;
   }
 
@@ -203,6 +194,14 @@ public abstract class AbstractAvroComputeRequestBuilder<K> implements ComputeReq
    * @return a set of existing operations result field name
    */
   protected Set<String> commonValidityCheck() {
+    // Projection
+    if (projectionFieldValidation) {
+      projectFields.forEach(projectField -> {
+        if (latestValueSchema.getField(projectField) == null) {
+          throw new VeniceClientException("Unknown project field: " + projectField);
+        }
+      });
+    }
     // DotProduct
     Set<String> computeResultFields = new HashSet<>();
     dotProducts.forEach(
@@ -255,12 +254,12 @@ public abstract class AbstractAvroComputeRequestBuilder<K> implements ComputeReq
     });
     dotProducts.forEach(dotProduct -> {
       Schema.Field dotProductField = AvroCompatibilityHelper
-          .createSchemaField(dotProduct.resultFieldName.toString(), getDotProductResultSchema(), "", null);
+          .createSchemaField(dotProduct.resultFieldName.toString(), DOT_PRODUCT_RESULT_SCHEMA, "", null);
       resultSchemaFields.add(dotProductField);
     });
     cosineSimilarities.forEach(cosineSimilarity -> {
       Schema.Field cosineSimilarityField = AvroCompatibilityHelper
-          .createSchemaField(cosineSimilarity.resultFieldName.toString(), getCosineSimilarityResultSchema(), "", null);
+          .createSchemaField(cosineSimilarity.resultFieldName.toString(), COSINE_SIMILARITY_RESULT_SCHEMA, "", null);
       resultSchemaFields.add(cosineSimilarityField);
     });
     hadamardProducts.forEach(hadamardProduct -> {
@@ -268,7 +267,12 @@ public abstract class AbstractAvroComputeRequestBuilder<K> implements ComputeReq
           .createSchemaField(hadamardProduct.resultFieldName.toString(), HADAMARD_PRODUCT_RESULT_SCHEMA, "", null);
       resultSchemaFields.add(hadamardProductField);
     });
-    resultSchemaFields.add(VENICE_COMPUTATION_ERROR_MAP_FIELD);
+    resultSchemaFields.add(
+        AvroCompatibilityHelper.createSchemaField(
+            VENICE_COMPUTATION_ERROR_MAP_FIELD_NAME,
+            Schema.createMap(Schema.create(Schema.Type.STRING)),
+            "",
+            null));
     return resultSchemaFields;
   }
 
@@ -361,6 +365,11 @@ public abstract class AbstractAvroComputeRequestBuilder<K> implements ComputeReq
   @Override
   public void streamingExecute(Set<K> keys, StreamingCallback<K, ComputeGenericRecord> callback)
       throws VeniceClientException {
+    if (executed) {
+      throw new VeniceClientException(getClass().getName() + " reuse is not supported.");
+    }
+    executed = true;
+
     long preRequestTimeInNS = time.nanoseconds();
     Pair<Schema, String> resultSchema = getResultSchema();
     // Generate ComputeRequest object
@@ -489,12 +498,4 @@ public abstract class AbstractAvroComputeRequestBuilder<K> implements ComputeReq
   }
 
   protected abstract ComputeRequestWrapper generateComputeRequest(String resultSchemaStr);
-
-  protected Schema getDotProductResultSchema() {
-    return DOT_PRODUCT_RESULT_SCHEMA;
-  }
-
-  protected Schema getCosineSimilarityResultSchema() {
-    return COSINE_SIMILARITY_RESULT_SCHEMA;
-  }
 }

--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/AbstractAvroStoreClient.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/AbstractAvroStoreClient.java
@@ -669,7 +669,7 @@ public abstract class AbstractAvroStoreClient<K, V> extends InternalAvroStoreCli
       this.schemaReader = new RouterBackedSchemaReader(
           this::getStoreClientForSchemaReader,
           getReaderSchema(),
-          clientConfig.isSupersetSchemaEnabled());
+          clientConfig.getPreferredSchemaFilter());
     }
     warmUpVeniceClient();
   }

--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/AbstractAvroStoreClient.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/AbstractAvroStoreClient.java
@@ -627,19 +627,14 @@ public abstract class AbstractAvroStoreClient<K, V> extends InternalAvroStoreCli
       final Optional<ClientStats> streamingStats,
       final InternalAvroStoreClient computeStoreClient,
       final long preRequestTimeInNS) {
+    AbstractAvroComputeRequestBuilder<K> builder =
+        new AvroComputeRequestBuilderV3<K>(computeStoreClient, getLatestValueSchema()).setStats(stats, streamingStats)
+            .setValidateProjectionFields(clientConfig.isProjectionFieldValidationEnabled());
     if (reuseObjectsForSerialization) {
       AvroSerializer.ReusableObjects reusableObjects = AvroSerializer.REUSE.get();
-      return new AvroComputeRequestBuilderV3<>(
-          getLatestValueSchema(),
-          computeStoreClient,
-          stats,
-          streamingStats,
-          true,
-          reusableObjects.getBinaryEncoder(),
-          reusableObjects.getByteArrayOutputStream());
-    } else {
-      return new AvroComputeRequestBuilderV3<>(getLatestValueSchema(), computeStoreClient, stats, streamingStats);
+      builder.setReuseObjects(reusableObjects.getBinaryEncoder(), reusableObjects.getByteArrayOutputStream());
     }
+    return builder;
   }
 
   private byte[] serializeComputeRequest(List<K> keyList, byte[] serializedComputeRequest) {

--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/AbstractAvroStoreClient.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/AbstractAvroStoreClient.java
@@ -137,6 +137,7 @@ public abstract class AbstractAvroStoreClient<K, V> extends InternalAvroStoreCli
   private final CompletableFuture<Map<K, GenericRecord>> COMPLETABLE_FUTURE_FOR_EMPTY_KEY_IN_COMPUTE =
       CompletableFuture.completedFuture(new HashMap<>());
 
+  private final ClientConfig clientConfig;
   protected final boolean needSchemaReader;
   /** Used to communicate with Venice backend to retrieve necessary store schemas */
   private SchemaReader schemaReader;
@@ -161,7 +162,6 @@ public abstract class AbstractAvroStoreClient<K, V> extends InternalAvroStoreCli
   private final boolean reuseObjectsForSerialization;
 
   private final boolean forceClusterDiscoveryAtStartTime;
-
   private volatile boolean isServiceDiscovered;
 
   /**
@@ -204,6 +204,7 @@ public abstract class AbstractAvroStoreClient<K, V> extends InternalAvroStoreCli
       ClientConfig clientConfig) {
     this.transportClient = transportClient;
     this.storeName = clientConfig.getStoreName();
+    this.clientConfig = clientConfig;
     this.needSchemaReader = needSchemaReader;
     this.deserializationExecutor =
         Optional.ofNullable(clientConfig.getDeserializationExecutor()).orElse(getDefaultDeserializationExecutor());
@@ -670,7 +671,10 @@ public abstract class AbstractAvroStoreClient<K, V> extends InternalAvroStoreCli
   @Override
   public void start() throws VeniceClientException {
     if (needSchemaReader) {
-      this.schemaReader = new RouterBackedSchemaReader(this::getStoreClientForSchemaReader, this.getReaderSchema());
+      this.schemaReader = new RouterBackedSchemaReader(
+          this::getStoreClientForSchemaReader,
+          getReaderSchema(),
+          clientConfig.isSupersetSchemaEnabled());
     }
     warmUpVeniceClient();
   }
@@ -1073,7 +1077,7 @@ public abstract class AbstractAvroStoreClient<K, V> extends InternalAvroStoreCli
       ComputeRequestWrapper computeRequestWrapper,
       Set<K> keys,
       Schema resultSchema,
-      StreamingCallback<K, GenericRecord> callback,
+      StreamingCallback<K, ComputeGenericRecord> callback,
       long preRequestTimeInNS) throws VeniceClientException {
     compute(computeRequestWrapper, keys, resultSchema, callback, preRequestTimeInNS, null, null);
   }
@@ -1083,7 +1087,7 @@ public abstract class AbstractAvroStoreClient<K, V> extends InternalAvroStoreCli
       ComputeRequestWrapper computeRequestWrapper,
       Set<K> keys,
       Schema resultSchema,
-      StreamingCallback<K, GenericRecord> callback,
+      StreamingCallback<K, ComputeGenericRecord> callback,
       long preRequestTimeInNS,
       BinaryEncoder reusedEncoder,
       ByteArrayOutputStream reusedOutputStream) throws VeniceClientException {
@@ -1132,7 +1136,9 @@ public abstract class AbstractAvroStoreClient<K, V> extends InternalAvroStoreCli
                 // Safeguard to handle empty value, which indicates non-existing key.
                 return null;
               }
-              return ComputeGenericRecord.wrap(computeResultRecordDeserializer.deserialize(envelope.value));
+              return new ComputeGenericRecord(
+                  computeResultRecordDeserializer.deserialize(envelope.value),
+                  computeRequestWrapper.getValueSchema());
             },
             envelope -> envelope.keyIndex,
             envelope -> streamingFooterRecordDeserializer.deserialize(envelope.value)),

--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/AvroBlackHoleResponseStoreClientImpl.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/AvroBlackHoleResponseStoreClientImpl.java
@@ -17,7 +17,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import org.apache.avro.Schema;
-import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.io.BinaryEncoder;
 
 
@@ -37,7 +36,7 @@ public class AvroBlackHoleResponseStoreClientImpl<K, V> extends AvroGenericStore
       ComputeRequestWrapper computeRequestWrapper,
       Set<K> keys,
       Schema resultSchema,
-      StreamingCallback<K, GenericRecord> callback,
+      StreamingCallback<K, ComputeGenericRecord> callback,
       long preRequestTimeInNS) throws VeniceClientException {
     compute(computeRequestWrapper, keys, resultSchema, callback, preRequestTimeInNS, null, null);
   }
@@ -52,7 +51,7 @@ public class AvroBlackHoleResponseStoreClientImpl<K, V> extends AvroGenericStore
       ComputeRequestWrapper computeRequestWrapper,
       Set<K> keys,
       Schema resultSchema,
-      StreamingCallback<K, GenericRecord> callback,
+      StreamingCallback<K, ComputeGenericRecord> callback,
       long preRequestTimeInNS,
       BinaryEncoder reusedEncoder,
       ByteArrayOutputStream reusedOutputStream) throws VeniceClientException {

--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/AvroComputeRequestBuilderV3.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/AvroComputeRequestBuilderV3.java
@@ -4,7 +4,6 @@ import static com.linkedin.venice.VeniceConstants.COMPUTE_REQUEST_VERSION_V3;
 import static com.linkedin.venice.compute.protocol.request.enums.ComputeOperationType.COUNT;
 
 import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
-import com.linkedin.venice.client.stats.ClientStats;
 import com.linkedin.venice.client.store.predicate.Predicate;
 import com.linkedin.venice.client.store.streaming.StreamingCallback;
 import com.linkedin.venice.compute.ComputeRequestWrapper;
@@ -12,18 +11,13 @@ import com.linkedin.venice.compute.protocol.request.ComputeOperation;
 import com.linkedin.venice.compute.protocol.request.Count;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.utils.Pair;
-import io.tehuti.utils.SystemTime;
-import io.tehuti.utils.Time;
-import java.io.ByteArrayOutputStream;
 import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericRecord;
-import org.apache.avro.io.BinaryEncoder;
 
 
 /**
@@ -35,50 +29,14 @@ import org.apache.avro.io.BinaryEncoder;
  * @param <K>
  */
 public class AvroComputeRequestBuilderV3<K> extends AbstractAvroComputeRequestBuilder<K> {
+  private static final int COMPUTE_REQUEST_VERSION = COMPUTE_REQUEST_VERSION_V3;
+  private static final String COUNT_SPEC = "count_spec";
   private static final Schema COUNT_RESULT_SCHEMA =
       Schema.createUnion(Arrays.asList(Schema.create(Schema.Type.NULL), Schema.create(Schema.Type.INT)));
-  private static final String COUNT_SPEC = "count_spec";
-  private List<Count> countLists = new LinkedList<>();
+  private final List<Count> countOperations = new LinkedList<>();
 
-  private static final int COMPUTE_REQUEST_VERSION = COMPUTE_REQUEST_VERSION_V3;
-
-  public AvroComputeRequestBuilderV3(
-      Schema latestValueSchema,
-      AvroGenericReadComputeStoreClient storeClient,
-      Optional<ClientStats> stats,
-      Optional<ClientStats> streamingStats) {
-    this(latestValueSchema, storeClient, stats, streamingStats, new SystemTime(), false, null, null);
-  }
-
-  public AvroComputeRequestBuilderV3(
-      Schema latestValueSchema,
-      AvroGenericReadComputeStoreClient storeClient,
-      Optional<ClientStats> stats,
-      Optional<ClientStats> streamingStats,
-      boolean reuseObjects,
-      BinaryEncoder reusedEncoder,
-      ByteArrayOutputStream reusedOutputStream) {
-    this(
-        latestValueSchema,
-        storeClient,
-        stats,
-        streamingStats,
-        new SystemTime(),
-        reuseObjects,
-        reusedEncoder,
-        reusedOutputStream);
-  }
-
-  public AvroComputeRequestBuilderV3(
-      Schema latestValueSchema,
-      AvroGenericReadComputeStoreClient storeClient,
-      Optional<ClientStats> stats,
-      Optional<ClientStats> streamingStats,
-      Time time,
-      boolean reuseObjects,
-      BinaryEncoder reusedEncoder,
-      ByteArrayOutputStream reusedOutputStream) {
-    super(latestValueSchema, storeClient, stats, streamingStats, time, reuseObjects, reusedEncoder, reusedOutputStream);
+  public AvroComputeRequestBuilderV3(AvroGenericReadComputeStoreClient storeClient, Schema latestValueSchema) {
+    super(storeClient, latestValueSchema);
   }
 
   @Override
@@ -86,7 +44,7 @@ public class AvroComputeRequestBuilderV3<K> extends AbstractAvroComputeRequestBu
     Map<String, Object> computeSpec = getCommonComputeSpec();
 
     List<Pair<CharSequence, CharSequence>> countPairs = new LinkedList<>();
-    countLists.forEach(count -> {
+    countOperations.forEach(count -> {
       countPairs.add(Pair.create(count.field, count.resultFieldName));
     });
     computeSpec.put(COUNT_SPEC, countPairs);
@@ -99,7 +57,7 @@ public class AvroComputeRequestBuilderV3<K> extends AbstractAvroComputeRequestBu
       // Check the validity first
       Set<String> computeResultFields = commonValidityCheck();
 
-      countLists.forEach(
+      countOperations.forEach(
           count -> checkComputeFieldValidity(
               count.field.toString(),
               count.resultFieldName.toString(),
@@ -108,7 +66,7 @@ public class AvroComputeRequestBuilderV3<K> extends AbstractAvroComputeRequestBu
 
       // Generate result schema
       List<Schema.Field> resultSchemaFields = getCommonResultFields();
-      countLists.forEach(count -> {
+      countOperations.forEach(count -> {
         Schema.Field countField =
             AvroCompatibilityHelper.createSchemaField(count.resultFieldName.toString(), COUNT_RESULT_SCHEMA, "", null);
         resultSchemaFields.add(countField);
@@ -127,14 +85,13 @@ public class AvroComputeRequestBuilderV3<K> extends AbstractAvroComputeRequestBu
     computeRequestWrapper.setResultSchemaStr(resultSchemaStr);
     computeRequestWrapper.setOperations(getComputeRequestOperations());
     computeRequestWrapper.setValueSchema(latestValueSchema);
-
     return computeRequestWrapper;
   }
 
   protected List<ComputeOperation> getComputeRequestOperations() {
     List<ComputeOperation> operations = getCommonComputeOperations();
 
-    countLists.forEach(count -> {
+    countOperations.forEach(count -> {
       ComputeOperation computeOperation = new ComputeOperation();
       computeOperation.operationType = COUNT.getValue();
       computeOperation.operation = count;
@@ -148,8 +105,7 @@ public class AvroComputeRequestBuilderV3<K> extends AbstractAvroComputeRequestBu
     Count count = (Count) COUNT.getNewInstance();
     count.field = inputFieldName;
     count.resultFieldName = resultFieldName;
-    countLists.add(count);
-
+    countOperations.add(count);
     return this;
   }
 

--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/AvroComputeRequestBuilderV4.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/AvroComputeRequestBuilderV4.java
@@ -5,7 +5,6 @@ import static org.apache.avro.Schema.Type.RECORD;
 
 import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
 import com.linkedin.venice.client.exceptions.VeniceClientException;
-import com.linkedin.venice.client.stats.ClientStats;
 import com.linkedin.venice.client.store.predicate.AndPredicate;
 import com.linkedin.venice.client.store.predicate.EqualsRelationalOperator;
 import com.linkedin.venice.client.store.predicate.Predicate;
@@ -16,42 +15,21 @@ import com.linkedin.venice.serializer.AvroSerializer;
 import com.linkedin.venice.serializer.FastSerializerDeserializerFactory;
 import com.linkedin.venice.serializer.RecordSerializer;
 import com.linkedin.venice.utils.Pair;
-import io.tehuti.utils.SystemTime;
-import io.tehuti.utils.Time;
-import java.io.ByteArrayOutputStream;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
-import org.apache.avro.io.BinaryEncoder;
 
 
 public class AvroComputeRequestBuilderV4<K> extends AvroComputeRequestBuilderV3<K> {
   private static final int COMPUTE_REQUEST_VERSION = COMPUTE_REQUEST_VERSION_V4;
 
-  public AvroComputeRequestBuilderV4(
-      Schema latestValueSchema,
-      AvroGenericReadComputeStoreClient storeClient,
-      Optional<ClientStats> stats,
-      Optional<ClientStats> streamingStats) {
-    this(latestValueSchema, storeClient, stats, streamingStats, new SystemTime(), false, null, null);
-  }
-
-  public AvroComputeRequestBuilderV4(
-      Schema latestValueSchema,
-      AvroGenericReadComputeStoreClient storeClient,
-      Optional<ClientStats> stats,
-      Optional<ClientStats> streamingStats,
-      Time time,
-      boolean reuseObjects,
-      BinaryEncoder reusedEncoder,
-      ByteArrayOutputStream reusedOutputStream) {
-    super(latestValueSchema, storeClient, stats, streamingStats, time, reuseObjects, reusedEncoder, reusedOutputStream);
+  public AvroComputeRequestBuilderV4(AvroGenericReadComputeStoreClient storeClient, Schema latestValueSchema) {
+    super(storeClient, latestValueSchema);
   }
 
   @Override
@@ -61,7 +39,6 @@ public class AvroComputeRequestBuilderV4<K> extends AvroComputeRequestBuilderV3<
     computeRequestWrapper.setResultSchemaStr(resultSchemaStr);
     computeRequestWrapper.setOperations(getComputeRequestOperations());
     computeRequestWrapper.setValueSchema(latestValueSchema);
-
     return computeRequestWrapper;
   }
 
@@ -72,7 +49,6 @@ public class AvroComputeRequestBuilderV4<K> extends AvroComputeRequestBuilderV3<
     byte[] prefixBytes = extractKeyPrefixBytesFromPredicate(requiredPrefixFields, storeClient.getKeySchema());
     Pair<Schema, String> resultSchema = getResultSchema();
     ComputeRequestWrapper computeRequestWrapper = generateComputeRequest(resultSchema.getSecond());
-
     storeClient.computeWithKeyPrefixFilter(prefixBytes, computeRequestWrapper, callback);
   }
 

--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/AvroGenericReadComputeStoreClient.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/AvroGenericReadComputeStoreClient.java
@@ -27,14 +27,14 @@ public interface AvroGenericReadComputeStoreClient<K, V> extends AvroGenericStor
       ComputeRequestWrapper computeRequestWrapper,
       Set<K> keys,
       Schema resultSchema,
-      StreamingCallback<K, GenericRecord> callback,
+      StreamingCallback<K, ComputeGenericRecord> callback,
       final long preRequestTimeInNS) throws VeniceClientException;
 
   void compute(
       ComputeRequestWrapper computeRequestWrapper,
       Set<K> keys,
       Schema resultSchema,
-      StreamingCallback<K, GenericRecord> callback,
+      StreamingCallback<K, ComputeGenericRecord> callback,
       final long preRequestTimeInNS,
       BinaryEncoder reusedEncoder,
       ByteArrayOutputStream reusedOutputStream) throws VeniceClientException;

--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/ClientConfig.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/ClientConfig.java
@@ -48,6 +48,7 @@ public class ClientConfig<T extends SpecificRecord> {
   private boolean reuseObjectsForSerialization = false;
   private boolean forceClusterDiscoveryAtStartTime = false;
   private boolean supersetSchemaEnabled = true;
+  private boolean projectionFieldValidation = true;
 
   // Security settings
   private boolean isHttps = false;
@@ -392,6 +393,15 @@ public class ClientConfig<T extends SpecificRecord> {
 
   public ClientConfig<T> setSupersetSchemaEnabled(boolean supersetSchemaEnabled) {
     this.supersetSchemaEnabled = supersetSchemaEnabled;
+    return this;
+  }
+
+  public boolean isProjectionFieldValidationEnabled() {
+    return projectionFieldValidation;
+  }
+
+  public ClientConfig<T> setProjectionFieldValidationEnabled(boolean projectionFieldValidation) {
+    this.projectionFieldValidation = projectionFieldValidation;
     return this;
   }
 

--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/ClientConfig.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/ClientConfig.java
@@ -47,6 +47,7 @@ public class ClientConfig<T extends SpecificRecord> {
   private boolean useBlackHoleDeserializer = false;
   private boolean reuseObjectsForSerialization = false;
   private boolean forceClusterDiscoveryAtStartTime = false;
+  private boolean supersetSchemaEnabled = true;
 
   // Security settings
   private boolean isHttps = false;
@@ -382,6 +383,15 @@ public class ClientConfig<T extends SpecificRecord> {
 
   public ClientConfig<T> setReuseObjectsForSerialization(boolean reuseObjectsForSerialization) {
     this.reuseObjectsForSerialization = reuseObjectsForSerialization;
+    return this;
+  }
+
+  public boolean isSupersetSchemaEnabled() {
+    return supersetSchemaEnabled;
+  }
+
+  public ClientConfig<T> setSupersetSchemaEnabled(boolean supersetSchemaEnabled) {
+    this.supersetSchemaEnabled = supersetSchemaEnabled;
     return this;
   }
 

--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/ClientConfig.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/ClientConfig.java
@@ -8,7 +8,10 @@ import com.linkedin.venice.serializer.AvroGenericDeserializer;
 import io.tehuti.metrics.MetricsRepository;
 import io.tehuti.utils.SystemTime;
 import io.tehuti.utils.Time;
+import java.util.Optional;
 import java.util.concurrent.Executor;
+import java.util.function.Predicate;
+import org.apache.avro.Schema;
 import org.apache.avro.specific.SpecificRecord;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -17,6 +20,7 @@ import org.apache.logging.log4j.Logger;
 public class ClientConfig<T extends SpecificRecord> {
   private static final Logger LOGGER = LogManager.getLogger(ClientConfig.class);
   private static final String HTTPS = "https";
+
   public static final int DEFAULT_ZK_TIMEOUT_MS = 5000;
   public static final String DEFAULT_CLUSTER_DISCOVERY_D2_SERVICE_NAME = "venice-discovery";
   public static final String DEFAULT_D2_ZK_BASE_PATH = "/d2";
@@ -47,8 +51,9 @@ public class ClientConfig<T extends SpecificRecord> {
   private boolean useBlackHoleDeserializer = false;
   private boolean reuseObjectsForSerialization = false;
   private boolean forceClusterDiscoveryAtStartTime = false;
-  private boolean supersetSchemaEnabled = true;
   private boolean projectionFieldValidation = true;
+
+  private Optional<Predicate<Schema>> preferredSchemaFilter = Optional.empty();
 
   // Security settings
   private boolean isHttps = false;
@@ -387,21 +392,21 @@ public class ClientConfig<T extends SpecificRecord> {
     return this;
   }
 
-  public boolean isSupersetSchemaEnabled() {
-    return supersetSchemaEnabled;
-  }
-
-  public ClientConfig<T> setSupersetSchemaEnabled(boolean supersetSchemaEnabled) {
-    this.supersetSchemaEnabled = supersetSchemaEnabled;
-    return this;
-  }
-
   public boolean isProjectionFieldValidationEnabled() {
     return projectionFieldValidation;
   }
 
   public ClientConfig<T> setProjectionFieldValidationEnabled(boolean projectionFieldValidation) {
     this.projectionFieldValidation = projectionFieldValidation;
+    return this;
+  }
+
+  public Optional<Predicate<Schema>> getPreferredSchemaFilter() {
+    return preferredSchemaFilter;
+  }
+
+  public ClientConfig<T> setPreferredSchemaFilter(Predicate<Schema> preferredSchemaFilter) {
+    this.preferredSchemaFilter = Optional.ofNullable(preferredSchemaFilter);
     return this;
   }
 

--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/ClientFactory.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/ClientFactory.java
@@ -9,6 +9,7 @@ import com.linkedin.venice.client.store.transport.HttpTransportClient;
 import com.linkedin.venice.client.store.transport.HttpsTransportClient;
 import com.linkedin.venice.client.store.transport.TransportClient;
 import com.linkedin.venice.schema.SchemaReader;
+import java.util.Optional;
 import org.apache.avro.specific.SpecificRecord;
 
 
@@ -84,7 +85,8 @@ public class ClientFactory {
      */
     return new RouterBackedSchemaReader(
         () -> new AvroGenericStoreClientImpl<>(getTransportClient(clientConfig), false, clientConfig),
-        clientConfig.isSupersetSchemaEnabled());
+        Optional.empty(),
+        clientConfig.getPreferredSchemaFilter());
   }
 
   public static StoreSchemaFetcher createStoreSchemaFetcher(ClientConfig clientConfig) {

--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/ClientFactory.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/ClientFactory.java
@@ -83,7 +83,8 @@ public class ClientFactory {
      * Closing this {@link SchemaReader} instance will also close the underlying client.
      */
     return new RouterBackedSchemaReader(
-        () -> new AvroGenericStoreClientImpl<>(getTransportClient(clientConfig), false, clientConfig));
+        () -> new AvroGenericStoreClientImpl<>(getTransportClient(clientConfig), false, clientConfig),
+        clientConfig.isSupersetSchemaEnabled());
   }
 
   public static StoreSchemaFetcher createStoreSchemaFetcher(ClientConfig clientConfig) {

--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/ComputeGenericRecord.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/ComputeGenericRecord.java
@@ -16,9 +16,13 @@ import org.apache.avro.generic.GenericRecord;
 public class ComputeGenericRecord implements GenericRecord {
   private final GenericRecord innerRecord;
   private final Optional<Map<String, String>> computationErrorMap;
+  private final Schema valueSchema;
 
-  private ComputeGenericRecord(GenericRecord record) {
+  /** Schema of the original record that was used to compute the result */
+
+  public ComputeGenericRecord(GenericRecord record, Schema valueSchema) {
     this.innerRecord = record;
+    this.valueSchema = valueSchema;
     Object errorMap = record.get(VENICE_COMPUTATION_ERROR_MAP_FIELD_NAME);
     if (errorMap != null && errorMap instanceof Map && !((Map) errorMap).isEmpty()) {
       /**
@@ -33,10 +37,6 @@ public class ComputeGenericRecord implements GenericRecord {
     } else {
       computationErrorMap = Optional.empty();
     }
-  }
-
-  public static GenericRecord wrap(GenericRecord record) {
-    return new ComputeGenericRecord(record);
   }
 
   @Override
@@ -67,5 +67,9 @@ public class ComputeGenericRecord implements GenericRecord {
   @Override
   public Schema getSchema() {
     return innerRecord.getSchema();
+  }
+
+  public Schema getValueSchema() {
+    return valueSchema;
   }
 }

--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/ComputeRequestBuilder.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/ComputeRequestBuilder.java
@@ -75,7 +75,7 @@ public interface ComputeRequestBuilder<K> {
    * @return
    * @throws VeniceClientException
    */
-  CompletableFuture<Map<K, GenericRecord>> execute(Set<K> keys) throws VeniceClientException;
+  CompletableFuture<Map<K, ComputeGenericRecord>> execute(Set<K> keys) throws VeniceClientException;
 
   /**
    * Send compute request to Venice, and this should be the last step of the compute specification.
@@ -87,7 +87,8 @@ public interface ComputeRequestBuilder<K> {
    * @return
    * @throws VeniceClientException
    */
-  CompletableFuture<VeniceResponseMap<K, GenericRecord>> streamingExecute(Set<K> keys) throws VeniceClientException;
+  CompletableFuture<VeniceResponseMap<K, ComputeGenericRecord>> streamingExecute(Set<K> keys)
+      throws VeniceClientException;
 
   /**
    * Streaming interface for {@link #execute(Set)}, and you could find more info in {@link StreamingCallback}.
@@ -95,7 +96,7 @@ public interface ComputeRequestBuilder<K> {
    * @param callback
    * @throws VeniceClientException
    */
-  void streamingExecute(Set<K> keys, StreamingCallback<K, GenericRecord> callback) throws VeniceClientException;
+  void streamingExecute(Set<K> keys, StreamingCallback<K, ComputeGenericRecord> callback) throws VeniceClientException;
 
   /**
    * Streaming interface that sends compute request to Venice, which will be executed on values whose keys satisfy

--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/DelegatingStoreClient.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/DelegatingStoreClient.java
@@ -11,7 +11,6 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import org.apache.avro.Schema;
-import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.io.BinaryEncoder;
 
 
@@ -70,7 +69,7 @@ public class DelegatingStoreClient<K, V> extends InternalAvroStoreClient<K, V> {
       ComputeRequestWrapper computeRequestWrapper,
       Set<K> keys,
       Schema resultSchema,
-      StreamingCallback<K, GenericRecord> callback,
+      StreamingCallback<K, ComputeGenericRecord> callback,
       final long preRequestTimeInNS) throws VeniceClientException {
     innerStoreClient.compute(computeRequestWrapper, keys, resultSchema, callback, preRequestTimeInNS);
   }
@@ -80,7 +79,7 @@ public class DelegatingStoreClient<K, V> extends InternalAvroStoreClient<K, V> {
       ComputeRequestWrapper computeRequestWrapper,
       Set<K> keys,
       Schema resultSchema,
-      StreamingCallback<K, GenericRecord> callback,
+      StreamingCallback<K, ComputeGenericRecord> callback,
       final long preRequestTimeInNS,
       BinaryEncoder reusedEncoder,
       ByteArrayOutputStream reusedOutputStream) throws VeniceClientException {

--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/StatTrackingStoreClient.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/StatTrackingStoreClient.java
@@ -25,7 +25,6 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiFunction;
 import org.apache.avro.Schema;
-import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.io.BinaryEncoder;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -235,7 +234,7 @@ public class StatTrackingStoreClient<K, V> extends DelegatingStoreClient<K, V> {
       ComputeRequestWrapper computeRequestWrapper,
       Set<K> keys,
       Schema resultSchema,
-      StreamingCallback<K, GenericRecord> callback,
+      StreamingCallback<K, ComputeGenericRecord> callback,
       final long preRequestTimeInNS) throws VeniceClientException {
     computeStreamingStats.recordRequestKeyCount(keys.size());
     super.compute(
@@ -251,7 +250,7 @@ public class StatTrackingStoreClient<K, V> extends DelegatingStoreClient<K, V> {
       ComputeRequestWrapper computeRequestWrapper,
       Set<K> keys,
       Schema resultSchema,
-      StreamingCallback<K, GenericRecord> callback,
+      StreamingCallback<K, ComputeGenericRecord> callback,
       final long preRequestTimeInNS,
       BinaryEncoder reusedEncoder,
       ByteArrayOutputStream reusedOutputStream) throws VeniceClientException {

--- a/clients/venice-thin-client/src/test/java/com/linkedin/venice/client/schema/RouterBackedSchemaReaderTest.java
+++ b/clients/venice-thin-client/src/test/java/com/linkedin/venice/client/schema/RouterBackedSchemaReaderTest.java
@@ -9,6 +9,7 @@ import com.linkedin.venice.controllerapi.SchemaResponse;
 import com.linkedin.venice.schema.SchemaReader;
 import com.linkedin.venice.utils.ObjectMapperFactory;
 import java.io.IOException;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import org.apache.avro.Schema;
@@ -18,7 +19,7 @@ import org.testng.annotations.Test;
 
 
 public class RouterBackedSchemaReaderTest {
-  private static ObjectMapper mapper = ObjectMapperFactory.getInstance();
+  private static final ObjectMapper mapper = ObjectMapperFactory.getInstance();
   private final int TIMEOUT = 3;
 
   @Test
@@ -246,7 +247,10 @@ public class RouterBackedSchemaReaderTest {
         .when(clientMock)
         .getRaw("value_schema/" + storeName);
 
-    try (SchemaReader schemaReader = new RouterBackedSchemaReader(() -> clientMock, true)) {
+    try (SchemaReader schemaReader = new RouterBackedSchemaReader(
+        () -> clientMock,
+        Optional.empty(),
+        Optional.of(schema -> schema.toString().equals(valueSchemaStr1)))) {
       Assert.assertEquals(schemaReader.getValueSchema(valueSchemaId1).toString(), valueSchemaStr1);
       Assert.assertEquals(schemaReader.getValueSchema(valueSchemaId2).toString(), valueSchemaStr2);
       Assert.assertEquals(schemaReader.getLatestValueSchema().toString(), valueSchemaStr1);
@@ -254,7 +258,8 @@ public class RouterBackedSchemaReaderTest {
       Mockito.verify(clientMock, Mockito.timeout(TIMEOUT).times(1)).getRaw(Mockito.anyString());
     }
 
-    try (SchemaReader schemaReader = new RouterBackedSchemaReader(() -> clientMock, false)) {
+    try (SchemaReader schemaReader =
+        new RouterBackedSchemaReader(() -> clientMock, Optional.empty(), Optional.empty())) {
       Assert.assertEquals(schemaReader.getValueSchema(valueSchemaId1).toString(), valueSchemaStr1);
       Assert.assertEquals(schemaReader.getValueSchema(valueSchemaId2).toString(), valueSchemaStr2);
       Assert.assertEquals(schemaReader.getLatestValueSchema().toString(), valueSchemaStr2);

--- a/clients/venice-thin-client/src/test/java/com/linkedin/venice/client/store/AvroComputeRequestBuilderTest.java
+++ b/clients/venice-thin-client/src/test/java/com/linkedin/venice/client/store/AvroComputeRequestBuilderTest.java
@@ -256,7 +256,7 @@ public class AvroComputeRequestBuilderTest {
         new AvroComputeRequestBuilderV3(ARRAY_SCHEMA, mockClient, Optional.empty(), Optional.empty());
   }
 
-  @Test(expectedExceptions = VeniceClientException.class, expectedExceptionsMessageRegExp = "Unknown project field.*")
+  @Test
   public void testProjectUnknownField() {
     AbstractAvroStoreClient mockClient = getMockClient();
     AvroComputeRequestBuilderV3<String> computeRequestBuilder =

--- a/clients/venice-thin-client/src/test/java/com/linkedin/venice/client/store/AvroComputeRequestBuilderTest.java
+++ b/clients/venice-thin-client/src/test/java/com/linkedin/venice/client/store/AvroComputeRequestBuilderTest.java
@@ -119,6 +119,7 @@ public class AvroComputeRequestBuilderTest {
     Assert.assertEquals(preRequestTimeCaptor.getValue().longValue(), preRequestTimeInNS);
     ComputeRequestWrapper capturedComputeRequest = computeRequestCaptor.getValue();
     Assert.assertNotNull(capturedComputeRequest);
+    Assert.assertEquals(capturedComputeRequest.getValueSchema(), VALID_RECORD_SCHEMA);
     Assert.assertEquals(capturedComputeRequest.getResultSchemaStr().toString(), expectedSchema);
     Assert.assertEquals(capturedComputeRequest.getOperations().size(), 6);
     Assert.assertEquals(capturedComputeRequest.getComputeRequestVersion(), COMPUTE_REQUEST_VERSION_V3);
@@ -224,6 +225,7 @@ public class AvroComputeRequestBuilderTest {
     Assert.assertEquals(preRequestTimeCaptor.getValue().longValue(), preRequestTimeInNS);
     capturedComputeRequest = computeRequestCaptor.getValue();
     Assert.assertNotNull(capturedComputeRequest);
+    Assert.assertEquals(capturedComputeRequest.getValueSchema(), VALID_RECORD_SCHEMA);
     Assert.assertEquals(capturedComputeRequest.getResultSchemaStr().toString(), expectedSchema);
     Assert.assertEquals(capturedComputeRequest.getOperations().size(), 3);
     /**

--- a/clients/venice-thin-client/src/test/java/com/linkedin/venice/client/store/AvroComputeRequestBuilderTest.java
+++ b/clients/venice-thin-client/src/test/java/com/linkedin/venice/client/store/AvroComputeRequestBuilderTest.java
@@ -84,15 +84,10 @@ public class AvroComputeRequestBuilderTest {
     long preRequestTimeInNS = 1234;
     doReturn(preRequestTimeInNS).when(mockTime).nanoseconds();
 
-    AvroComputeRequestBuilderV3<String> computeRequestBuilder = new AvroComputeRequestBuilderV3(
-        VALID_RECORD_SCHEMA,
-        mockClient,
-        Optional.empty(),
-        Optional.empty(),
-        mockTime,
-        false,
-        null,
-        null);
+    AvroComputeRequestBuilderV3<String> computeRequestBuilder =
+        new AvroComputeRequestBuilderV3<>(mockClient, VALID_RECORD_SCHEMA);
+    computeRequestBuilder.setTime(mockTime);
+
     computeRequestBuilder.project("float_field", "record_field")
         .project("int_field")
         .dotProduct("float_array_field1", dotProductParam, "float_array_field1_dot_product_result")
@@ -193,17 +188,11 @@ public class AvroComputeRequestBuilderTest {
      */
     AbstractAvroStoreClient mockClient2 = getMockClient();
     doReturn("testStore").when(mockClient2).getStoreName();
-    AvroComputeRequestBuilderV3<String> computeRequestBuilder3 = new AvroComputeRequestBuilderV3(
-        VALID_RECORD_SCHEMA,
-        mockClient2,
-        Optional.empty(),
-        Optional.empty(),
-        mockTime,
-        false,
-        null,
-        null);
+    AvroComputeRequestBuilderV3<String> computeRequestBuilder2 =
+        new AvroComputeRequestBuilderV3<>(mockClient2, VALID_RECORD_SCHEMA);
+    computeRequestBuilder2.setTime(mockTime);
 
-    computeRequestBuilder3
+    computeRequestBuilder2
         .hadamardProduct("float_array_field1", hadamardProductParam, "float_array_field1_hadamard_product_result")
         .project("int_field")
         .dotProduct("float_array_field1", dotProductParam, "float_array_field1_dot_product_result")
@@ -253,23 +242,28 @@ public class AvroComputeRequestBuilderTest {
   public void testComputeAgainstNonRecordSchema() {
     AbstractAvroStoreClient mockClient = getMockClient();
     AvroComputeRequestBuilderV3<String> computeRequestBuilder =
-        new AvroComputeRequestBuilderV3(ARRAY_SCHEMA, mockClient, Optional.empty(), Optional.empty());
+        new AvroComputeRequestBuilderV3(mockClient, ARRAY_SCHEMA);
   }
 
   @Test
   public void testProjectUnknownField() {
     AbstractAvroStoreClient mockClient = getMockClient();
     AvroComputeRequestBuilderV3<String> computeRequestBuilder =
-        new AvroComputeRequestBuilderV3(VALID_RECORD_SCHEMA, mockClient, Optional.empty(), Optional.empty());
+        new AvroComputeRequestBuilderV3(mockClient, VALID_RECORD_SCHEMA);
     computeRequestBuilder.project("some_unknown_field");
-    computeRequestBuilder.execute(keys);
+    VeniceClientException e =
+        Assert.expectThrows(VeniceClientException.class, () -> computeRequestBuilder.execute(keys));
+    Assert.assertTrue(e.getMessage().startsWith("Unknown project field:"));
+    AvroComputeRequestBuilderV3<String> computeRequestBuilder2 =
+        new AvroComputeRequestBuilderV3(mockClient, VALID_RECORD_SCHEMA);
+    computeRequestBuilder2.setValidateProjectionFields(false).project("some_unknown_field");
   }
 
   @Test(expectedExceptions = VeniceClientException.class, expectedExceptionsMessageRegExp = "Unknown DOT_PRODUCT field.*")
   public void testDotProductAgainstUnknownField() {
     AbstractAvroStoreClient mockClient = getMockClient();
     AvroComputeRequestBuilderV3<String> computeRequestBuilder =
-        new AvroComputeRequestBuilderV3(VALID_RECORD_SCHEMA, mockClient, Optional.empty(), Optional.empty());
+        new AvroComputeRequestBuilderV3(mockClient, VALID_RECORD_SCHEMA);
     computeRequestBuilder.dotProduct("some_unknown_field", dotProductParam, "new_unknown_field");
     computeRequestBuilder.execute(keys);
   }
@@ -278,7 +272,7 @@ public class AvroComputeRequestBuilderTest {
   public void testCosineSimilarityAgainstUnknownField() {
     AbstractAvroStoreClient mockClient = getMockClient();
     AvroComputeRequestBuilderV3<String> computeRequestBuilder =
-        new AvroComputeRequestBuilderV3(VALID_RECORD_SCHEMA, mockClient, Optional.empty(), Optional.empty());
+        new AvroComputeRequestBuilderV3(mockClient, VALID_RECORD_SCHEMA);
     computeRequestBuilder.cosineSimilarity("some_unknown_field", cosineSimilarityParam, "new_unknown_field");
     computeRequestBuilder.execute(keys);
   }
@@ -287,7 +281,7 @@ public class AvroComputeRequestBuilderTest {
   public void testDotProductAgainstNonFloatArrayField1() {
     AbstractAvroStoreClient mockClient = getMockClient();
     AvroComputeRequestBuilderV3<String> computeRequestBuilder =
-        new AvroComputeRequestBuilderV3(VALID_RECORD_SCHEMA, mockClient, Optional.empty(), Optional.empty());
+        new AvroComputeRequestBuilderV3(mockClient, VALID_RECORD_SCHEMA);
     computeRequestBuilder.dotProduct("int_field", dotProductParam, "new_unknown_field");
     computeRequestBuilder.execute(keys);
   }
@@ -296,7 +290,7 @@ public class AvroComputeRequestBuilderTest {
   public void testCosineSimilarityAgainstNonFloatArrayField1() {
     AbstractAvroStoreClient mockClient = getMockClient();
     AvroComputeRequestBuilderV3<String> computeRequestBuilder =
-        new AvroComputeRequestBuilderV3(VALID_RECORD_SCHEMA, mockClient, Optional.empty(), Optional.empty());
+        new AvroComputeRequestBuilderV3(mockClient, VALID_RECORD_SCHEMA);
     computeRequestBuilder.cosineSimilarity("int_field", cosineSimilarityParam, "new_unknown_field");
     computeRequestBuilder.execute(keys);
   }
@@ -305,7 +299,7 @@ public class AvroComputeRequestBuilderTest {
   public void testDotProductAgainstNonFloatArrayField2() {
     AbstractAvroStoreClient mockClient = getMockClient();
     AvroComputeRequestBuilderV3<String> computeRequestBuilder =
-        new AvroComputeRequestBuilderV3(VALID_RECORD_SCHEMA, mockClient, Optional.empty(), Optional.empty());
+        new AvroComputeRequestBuilderV3(mockClient, VALID_RECORD_SCHEMA);
     computeRequestBuilder.dotProduct("int_array_field2", dotProductParam, "new_unknown_field");
     computeRequestBuilder.execute(keys);
   }
@@ -314,7 +308,7 @@ public class AvroComputeRequestBuilderTest {
   public void testCosineSimilarityAgainstNonFloatArrayField2() {
     AbstractAvroStoreClient mockClient = getMockClient();
     AvroComputeRequestBuilderV3<String> computeRequestBuilder =
-        new AvroComputeRequestBuilderV3(VALID_RECORD_SCHEMA, mockClient, Optional.empty(), Optional.empty());
+        new AvroComputeRequestBuilderV3(mockClient, VALID_RECORD_SCHEMA);
     computeRequestBuilder.cosineSimilarity("int_array_field2", cosineSimilarityParam, "new_unknown_field");
     computeRequestBuilder.execute(keys);
   }
@@ -325,14 +319,14 @@ public class AvroComputeRequestBuilderTest {
         + "\t\"fields\": [\n" + "\t\t{\"name\": \"int_field\", \"type\": \"int\", \"default\": 0},\n"
         + "\t\t{\"name\": \"" + VENICE_COMPUTATION_ERROR_MAP_FIELD_NAME + "\", \"type\": \"string\"}\n" + "\t]\n" + "}";
     AbstractAvroStoreClient mockClient = getMockClient();
-    new AvroComputeRequestBuilderV3(Schema.parse(invalidSchemaStr), mockClient, Optional.empty(), Optional.empty());
+    new AvroComputeRequestBuilderV3(mockClient, Schema.parse(invalidSchemaStr));
   }
 
   @Test(expectedExceptions = VeniceClientException.class, expectedExceptionsMessageRegExp = ".* __veniceComputationError__ is reserved.*")
   public void testDotProductWhileResultFieldUsingReservedFieldName() {
     AbstractAvroStoreClient mockClient = getMockClient();
     AvroComputeRequestBuilderV3<String> computeRequestBuilder =
-        new AvroComputeRequestBuilderV3(VALID_RECORD_SCHEMA, mockClient, Optional.empty(), Optional.empty());
+        new AvroComputeRequestBuilderV3(mockClient, VALID_RECORD_SCHEMA);
     computeRequestBuilder.dotProduct("float_array_field1", dotProductParam, VENICE_COMPUTATION_ERROR_MAP_FIELD_NAME);
     computeRequestBuilder.execute(keys);
   }
@@ -341,7 +335,7 @@ public class AvroComputeRequestBuilderTest {
   public void testCosineSimilarityWhileResultFieldUsingReservedFieldName() {
     AbstractAvroStoreClient mockClient = getMockClient();
     AvroComputeRequestBuilderV3<String> computeRequestBuilder =
-        new AvroComputeRequestBuilderV3(VALID_RECORD_SCHEMA, mockClient, Optional.empty(), Optional.empty());
+        new AvroComputeRequestBuilderV3(mockClient, VALID_RECORD_SCHEMA);
     computeRequestBuilder
         .cosineSimilarity("float_array_field1", cosineSimilarityParam, VENICE_COMPUTATION_ERROR_MAP_FIELD_NAME);
     computeRequestBuilder.execute(keys);
@@ -351,7 +345,7 @@ public class AvroComputeRequestBuilderTest {
   public void testDotProductWhileResultFieldUsingExistingFieldName() {
     AbstractAvroStoreClient mockClient = getMockClient();
     AvroComputeRequestBuilderV3<String> computeRequestBuilder =
-        new AvroComputeRequestBuilderV3(VALID_RECORD_SCHEMA, mockClient, Optional.empty(), Optional.empty());
+        new AvroComputeRequestBuilderV3(mockClient, VALID_RECORD_SCHEMA);
     computeRequestBuilder.dotProduct("float_array_field1", dotProductParam, "int_field");
     computeRequestBuilder.execute(keys);
   }
@@ -360,7 +354,7 @@ public class AvroComputeRequestBuilderTest {
   public void testCosineSimilarityWhileResultFieldUsingExistingFieldName() {
     AbstractAvroStoreClient mockClient = getMockClient();
     AvroComputeRequestBuilderV3<String> computeRequestBuilder =
-        new AvroComputeRequestBuilderV3(VALID_RECORD_SCHEMA, mockClient, Optional.empty(), Optional.empty());
+        new AvroComputeRequestBuilderV3(mockClient, VALID_RECORD_SCHEMA);
     computeRequestBuilder.cosineSimilarity("float_array_field1", cosineSimilarityParam, "int_field");
     computeRequestBuilder.execute(keys);
   }
@@ -369,7 +363,7 @@ public class AvroComputeRequestBuilderTest {
   public void testDotProductWhileResultFieldUsingSameFieldNameMultipleTimes() {
     AbstractAvroStoreClient mockClient = getMockClient();
     AvroComputeRequestBuilderV3<String> computeRequestBuilder =
-        new AvroComputeRequestBuilderV3(VALID_RECORD_SCHEMA, mockClient, Optional.empty(), Optional.empty());
+        new AvroComputeRequestBuilderV3(mockClient, VALID_RECORD_SCHEMA);
     computeRequestBuilder.dotProduct("float_array_field1", dotProductParam, "same_field_name");
     computeRequestBuilder.dotProduct("float_array_field2", dotProductParam, "same_field_name");
     computeRequestBuilder.execute(keys);
@@ -379,7 +373,7 @@ public class AvroComputeRequestBuilderTest {
   public void testCosineSimilarityWhileResultFieldUsingSameFieldNameMultipleTimes() {
     AbstractAvroStoreClient mockClient = getMockClient();
     AvroComputeRequestBuilderV3<String> computeRequestBuilder =
-        new AvroComputeRequestBuilderV3(VALID_RECORD_SCHEMA, mockClient, Optional.empty(), Optional.empty());
+        new AvroComputeRequestBuilderV3(mockClient, VALID_RECORD_SCHEMA);
     computeRequestBuilder.cosineSimilarity("float_array_field1", cosineSimilarityParam, "same_field_name");
     computeRequestBuilder.cosineSimilarity("float_array_field2", cosineSimilarityParam, "same_field_name");
     computeRequestBuilder.execute(keys);
@@ -389,7 +383,7 @@ public class AvroComputeRequestBuilderTest {
   public void testDifferentOperationsWhileResultFieldUsingSameFieldNameMultipleTimes() {
     AbstractAvroStoreClient mockClient = getMockClient();
     AvroComputeRequestBuilderV3<String> computeRequestBuilder =
-        new AvroComputeRequestBuilderV3(VALID_RECORD_SCHEMA, mockClient, Optional.empty(), Optional.empty());
+        new AvroComputeRequestBuilderV3(mockClient, VALID_RECORD_SCHEMA);
     computeRequestBuilder.dotProduct("float_array_field1", dotProductParam, "same_field_name");
     computeRequestBuilder.cosineSimilarity("float_array_field2", cosineSimilarityParam, "same_field_name");
     computeRequestBuilder.execute(keys);
@@ -404,15 +398,8 @@ public class AvroComputeRequestBuilderTest {
     ArgumentCaptor<byte[]> prefixByteCaptor = ArgumentCaptor.forClass(byte[].class);
     ArgumentCaptor<StreamingCallback> streamingCallbackCaptor = ArgumentCaptor.forClass(StreamingCallback.class);
 
-    AvroComputeRequestBuilderV4<GenericRecord> computeRequestBuilder = new AvroComputeRequestBuilderV4(
-        VALID_RECORD_SCHEMA,
-        mockClient,
-        Optional.empty(),
-        Optional.empty(),
-        null,
-        false,
-        null,
-        null);
+    AvroComputeRequestBuilderV4<GenericRecord> computeRequestBuilder =
+        new AvroComputeRequestBuilderV4(mockClient, VALID_RECORD_SCHEMA);
 
     Predicate requiredKeyFields = and(equalTo("companyId", "5678"), equalTo("id", "1234"));
 
@@ -460,15 +447,8 @@ public class AvroComputeRequestBuilderTest {
     AbstractAvroStoreClient mockClient = getMockClient();
     doReturn(KEY_SCHEMA).when(mockClient).getKeySchema();
 
-    AvroComputeRequestBuilderV4<GenericRecord> computeRequestBuilder = new AvroComputeRequestBuilderV4(
-        VALID_RECORD_SCHEMA,
-        mockClient,
-        Optional.empty(),
-        Optional.empty(),
-        null,
-        false,
-        null,
-        null);
+    AvroComputeRequestBuilderV4<GenericRecord> computeRequestBuilder =
+        new AvroComputeRequestBuilderV4(mockClient, VALID_RECORD_SCHEMA);
 
     Predicate requiredKeyFields = and(equalTo("int_field", 1234), equalTo("id", "1234"));
 
@@ -490,15 +470,8 @@ public class AvroComputeRequestBuilderTest {
     AbstractAvroStoreClient mockClient = getMockClient();
     doReturn(KEY_SCHEMA).when(mockClient).getKeySchema();
 
-    AvroComputeRequestBuilderV4<GenericRecord> computeRequestBuilder = new AvroComputeRequestBuilderV4(
-        VALID_RECORD_SCHEMA,
-        mockClient,
-        Optional.empty(),
-        Optional.empty(),
-        null,
-        false,
-        null,
-        null);
+    AvroComputeRequestBuilderV4<GenericRecord> computeRequestBuilder =
+        new AvroComputeRequestBuilderV4(mockClient, VALID_RECORD_SCHEMA);
 
     Predicate requiredKeyFields = and(equalTo("fake_field1", 1234), equalTo("fake_field2", "1234"));
 

--- a/clients/venice-thin-client/src/test/java/com/linkedin/venice/client/store/StatTrackingStoreClientTest.java
+++ b/clients/venice-thin-client/src/test/java/com/linkedin/venice/client/store/StatTrackingStoreClientTest.java
@@ -426,11 +426,11 @@ public class StatTrackingStoreClientTest {
         storeClient,
         ClientConfig.defaultGenericClientConfig(storeName).setMetricsRepository(repository));
 
-    CompletableFuture<Map<String, GenericRecord>> computeFuture = statTrackingStoreClient.compute()
+    CompletableFuture<Map<String, ComputeGenericRecord>> computeFuture = statTrackingStoreClient.compute()
         .project("int_field")
         .dotProduct("float_array_field1", dotProductParam, "dot_product_for_float_array_field1")
         .execute(keys);
-    Map<String, GenericRecord> computeResult = computeFuture.get();
+    Map<String, ComputeGenericRecord> computeResult = computeFuture.get();
     Assert.assertEquals(computeResult.size(), 2);
     Assert.assertNotNull(computeResult.get("key1"));
     GenericRecord resultForKey1 = computeResult.get("key1");
@@ -642,13 +642,13 @@ public class StatTrackingStoreClientTest {
           ComputeRequestWrapper computeRequestWrapper,
           Set<K> keys,
           Schema resultSchema,
-          StreamingCallback<K, GenericRecord> callback,
+          StreamingCallback<K, ComputeGenericRecord> callback,
           long preRequestTimeInNS,
           BinaryEncoder reusedEncoder,
           ByteArrayOutputStream reusedOutputStream) {
         Thread callbackThread = new Thread(() -> {
           for (int i = 0; i < 10; i += 2) {
-            callback.onRecordReceived((K) ("key_" + i), mock(GenericRecord.class));
+            callback.onRecordReceived((K) ("key_" + i), mock(ComputeGenericRecord.class));
             callback.onRecordReceived((K) ("key_" + (i + 1)), null);
           }
           if (callback instanceof TrackingStreamingCallback) {
@@ -678,7 +678,7 @@ public class StatTrackingStoreClientTest {
     for (int i = 0; i < 10; ++i) {
       keys.add("key_" + i);
     }
-    CompletableFuture<VeniceResponseMap<String, GenericRecord>> resultFuture =
+    CompletableFuture<VeniceResponseMap<String, ComputeGenericRecord>> resultFuture =
         statTrackingStoreClient.compute().project("int_field").streamingExecute(keys);
     // Make the behavior deterministic
     resultLatch.await();

--- a/clients/venice-thin-client/src/test/java/com/linkedin/venice/client/store/StoreClientPerfTest.java
+++ b/clients/venice-thin-client/src/test/java/com/linkedin/venice/client/store/StoreClientPerfTest.java
@@ -34,6 +34,7 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericRecord;
@@ -320,11 +321,11 @@ public class StoreClientPerfTest {
 
       ComputeRequestBuilder<String> computeRequestBuilder = client.compute().project(fieldNames);
       for (int call = 1; call <= numberOfCalls; call++) {
-        CompletableFuture<Map<String, GenericRecord>> future;
+        CompletableFuture<Map<String, ? extends GenericRecord>> future;
         if (compute) {
-          future = computeRequestBuilder.execute(keys);
+          future = computeRequestBuilder.execute(keys).thenApply(Function.identity());
         } else {
-          future = client.batchGet(keys);
+          future = client.batchGet(keys).thenApply(Function.identity());
         }
         futures[call % numberOfConcurrentCallsPerBatch] = future.handle((o, throwable) -> {
           if (throwable != null) {

--- a/internal/venice-avro-compatibility-test/src/test/java/com/linkedin/venice/VeniceClientCompatibilityTest.java
+++ b/internal/venice-avro-compatibility-test/src/test/java/com/linkedin/venice/VeniceClientCompatibilityTest.java
@@ -10,6 +10,7 @@ import com.linkedin.davinci.client.DaVinciClient;
 import com.linkedin.venice.client.store.AvroGenericStoreClient;
 import com.linkedin.venice.client.store.ClientConfig;
 import com.linkedin.venice.client.store.ClientFactory;
+import com.linkedin.venice.client.store.ComputeGenericRecord;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.integration.utils.ServiceFactory;
 import com.linkedin.venice.utils.ClassPathSupplierForVeniceCluster;
@@ -174,7 +175,7 @@ public class VeniceClientCompatibilityTest {
     List<Float> p = Arrays.asList(100.0f, 0.1f);
     List<Float> cosP = Arrays.asList(123.4f, 5.6f);
     List<Float> hadamardP = Arrays.asList(135.7f, 246.8f);
-    Map<String, GenericRecord> computeResult = client.compute()
+    Map<String, ComputeGenericRecord> computeResult = client.compute()
         .project("id", "boolean_field", "int_field", "float_field", "member_feature")
         .dotProduct("member_feature", p, "member_score")
         .cosineSimilarity("member_feature", cosP, "cosine_similarity_result")
@@ -188,7 +189,7 @@ public class VeniceClientCompatibilityTest {
         .get(2, TimeUnit.SECONDS);
     Assert.assertEquals(computeResult.size(), keyCount);
 
-    for (Map.Entry<String, GenericRecord> entry: computeResult.entrySet()) {
+    for (Map.Entry<String, ComputeGenericRecord> entry: computeResult.entrySet()) {
       int keyIdx = getKeyIndex(entry.getKey(), KEY_PREFIX);
       // check projection result
       Assert.assertEquals(entry.getValue().get("id"), new Utf8(ID_FIELD_PREFIX + keyIdx));

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/controllerapi/MultiSchemaResponse.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/controllerapi/MultiSchemaResponse.java
@@ -1,6 +1,7 @@
 package com.linkedin.venice.controllerapi;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.linkedin.venice.schema.SchemaData;
 
 
 public class MultiSchemaResponse
@@ -8,7 +9,7 @@ public class MultiSchemaResponse
   /**
    * If this is set it should be used to replace latestValueSchema to deserialize during read.
    */
-  private int superSetSchemaId = -1;
+  private int superSetSchemaId = SchemaData.INVALID_VALUE_SCHEMA_ID;
 
   public void setSuperSetSchemaId(int id) {
     superSetSchemaId = id;
@@ -24,9 +25,9 @@ public class MultiSchemaResponse
      * An uninitialized primitive defaults to 0, which could cause the Venice Samza System producer starts sending
      * Venice UPDATE messages instead of PUT messages.
      */
-    private int derivedSchemaId = -1;
+    private int derivedSchemaId = SchemaData.INVALID_VALUE_SCHEMA_ID;
 
-    private int rmdValueSchemaId = -1;
+    private int rmdValueSchemaId = SchemaData.INVALID_VALUE_SCHEMA_ID;
     private String schemaStr;
 
     public int getId() {
@@ -43,7 +44,7 @@ public class MultiSchemaResponse
 
     @JsonIgnore
     public boolean isDerivedSchema() {
-      return derivedSchemaId != -1;
+      return derivedSchemaId != SchemaData.INVALID_VALUE_SCHEMA_ID;
     }
 
     public void setDerivedSchemaId(int derivedSchemaId) {

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/DaVinciComputeTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/DaVinciComputeTest.java
@@ -21,6 +21,7 @@ import com.linkedin.davinci.client.NonLocalAccessPolicy;
 import com.linkedin.davinci.client.StorageClass;
 import com.linkedin.davinci.client.factory.CachingDaVinciClientFactory;
 import com.linkedin.venice.D2.D2ClientUtils;
+import com.linkedin.venice.client.store.ComputeGenericRecord;
 import com.linkedin.venice.client.store.ComputeRequestBuilder;
 import com.linkedin.venice.client.store.predicate.Predicate;
 import com.linkedin.venice.client.store.streaming.StreamingCallback;
@@ -184,7 +185,7 @@ public class DaVinciComputeTest {
     VeniceKafkaSerializer keySerializer = new VeniceAvroKafkaSerializer(DEFAULT_KEY_SCHEMA);
     VeniceKafkaSerializer valueSerializer = new VeniceAvroKafkaSerializer(VALUE_SCHEMA_FOR_COMPUTE_NULLABLE_LIST_FIELD);
 
-    Map<Integer, GenericRecord> computeResult;
+    Map<Integer, ComputeGenericRecord> computeResult;
     final int key1 = 1;
     final int key2 = 2;
     Set<Integer> keySetForCompute = new HashSet<Integer>() {
@@ -227,7 +228,7 @@ public class DaVinciComputeTest {
       pushRecordsToStore(valuesByKey, veniceWriter, 1);
       client.subscribeAll().get();
 
-      final Consumer<Map<Integer, GenericRecord>> assertComputeResults = (readComputeResult) -> {
+      final Consumer<Map<Integer, ComputeGenericRecord>> assertComputeResults = (readComputeResult) -> {
         // Expect no error
         readComputeResult.forEach(
             (key, value) -> Assert.assertEquals(
@@ -291,7 +292,7 @@ public class DaVinciComputeTest {
         new VeniceAvroKafkaSerializer(VALUE_SCHEMA_FOR_COMPUTE_MISSING_FIELD);
 
     int numRecords = 100;
-    Map<Integer, GenericRecord> computeResult;
+    Map<Integer, ComputeGenericRecord> computeResult;
     Set<Integer> keySetForCompute = new HashSet<Integer>() {
       {
         add(1);
@@ -419,7 +420,7 @@ public class DaVinciComputeTest {
     VeniceKafkaSerializer valueSerializerSwapped = new VeniceAvroKafkaSerializer(VALUE_SCHEMA_FOR_COMPUTE_SWAPPED);
 
     int numRecords = 100;
-    Map<Integer, GenericRecord> computeResult;
+    Map<Integer, ComputeGenericRecord> computeResult;
     Set<Integer> keySetForCompute = new HashSet<Integer>() {
       {
         add(1);
@@ -566,13 +567,13 @@ public class DaVinciComputeTest {
 
       // Test compute with streaming execute using custom provided callback
       AtomicInteger computeResultCnt = new AtomicInteger(0);
-      Map<String, GenericRecord> finalComputeResultMap = new VeniceConcurrentHashMap<>();
+      Map<String, ComputeGenericRecord> finalComputeResultMap = new VeniceConcurrentHashMap<>();
       CountDownLatch computeLatch = new CountDownLatch(1);
 
       ComputeRequestBuilder<String> computeRequestBuilder = client.compute().project("int_field");
-      computeRequestBuilder.streamingExecute(keySet, new StreamingCallback<String, GenericRecord>() {
+      computeRequestBuilder.streamingExecute(keySet, new StreamingCallback<String, ComputeGenericRecord>() {
         @Override
-        public void onRecordReceived(String key, GenericRecord value) {
+        public void onRecordReceived(String key, ComputeGenericRecord value) {
           computeResultCnt.incrementAndGet();
           if (value != null) {
             finalComputeResultMap.put(key, value);
@@ -593,9 +594,9 @@ public class DaVinciComputeTest {
       verifyStreamingComputeResult(finalComputeResultMap);
 
       // Test compute with streaming execute using default callback
-      CompletableFuture<VeniceResponseMap<String, GenericRecord>> computeFuture =
+      CompletableFuture<VeniceResponseMap<String, ComputeGenericRecord>> computeFuture =
           computeRequestBuilder.streamingExecute(keySet);
-      Map<String, GenericRecord> computeResultMap = computeFuture.get();
+      Map<String, ComputeGenericRecord> computeResultMap = computeFuture.get();
       Assert.assertEquals(computeResultMap.size(), MAX_KEY_LIMIT - NON_EXISTING_KEY_NUM);
       verifyStreamingComputeResult(computeResultMap);
 
@@ -850,7 +851,7 @@ public class DaVinciComputeTest {
     writer.broadcastEndOfPush(Collections.emptyMap());
   }
 
-  private void verifyStreamingComputeResult(Map<String, GenericRecord> resultMap) {
+  private void verifyStreamingComputeResult(Map<String, ComputeGenericRecord> resultMap) {
     for (int i = 0; i < MAX_KEY_LIMIT - NON_EXISTING_KEY_NUM; ++i) {
       String key = KEY_PREFIX + i;
       GenericRecord record = resultMap.get(key);

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/router/TestRead.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/router/TestRead.java
@@ -260,6 +260,7 @@ public abstract class TestRead {
 
   @Test // (timeOut = 50 * Time.MS_PER_SECOND)
   public void testRead() throws Exception {
+    final String UNKNOWN_FIELD_NAME = "unknown_field";
     if (!isTestEnabled()) {
       return;
     }
@@ -287,7 +288,7 @@ public abstract class TestRead {
         Map<String, GenericRecord> result = storeClient.batchGet(keySet).get();
         Assert.assertEquals(result.size(), MAX_KEY_LIMIT - 1);
         Map<String, ComputeGenericRecord> computeResult =
-            storeClient.compute().project(VALUE_FIELD_NAME).execute(keySet).get();
+            storeClient.compute().project(VALUE_FIELD_NAME, UNKNOWN_FIELD_NAME).execute(keySet).get();
         Assert.assertEquals(computeResult.size(), MAX_KEY_LIMIT - 1);
 
         for (int i = 0; i < MAX_KEY_LIMIT - 1; ++i) {
@@ -295,6 +296,7 @@ public abstract class TestRead {
           record.put(VALUE_FIELD_NAME, i);
           Assert.assertEquals(result.get(KEY_PREFIX + i), record);
           Assert.assertEquals(computeResult.get(KEY_PREFIX + i).get(VALUE_FIELD_NAME), i);
+          Assert.assertNull(computeResult.get(KEY_PREFIX + i).get(UNKNOWN_FIELD_NAME));
         }
 
         /**

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/router/TestRead.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/router/TestRead.java
@@ -274,7 +274,8 @@ public abstract class TestRead {
     try (AvroGenericStoreClient<String, GenericRecord> storeClient = ClientFactory.getAndStartGenericAvroClient(
         ClientConfig.defaultGenericClientConfig(storeName)
             .setD2Client(d2Client)
-            .setD2ServiceName(VeniceRouterWrapper.CLUSTER_DISCOVERY_D2_SERVICE_NAME))) {
+            .setD2ServiceName(VeniceRouterWrapper.CLUSTER_DISCOVERY_D2_SERVICE_NAME)
+            .setProjectionFieldValidationEnabled(false))) {
 
       // Run multiple rounds
       int rounds = 100;

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/router/TestRead.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/router/TestRead.java
@@ -16,6 +16,7 @@ import com.linkedin.venice.client.exceptions.VeniceClientHttpException;
 import com.linkedin.venice.client.store.AvroGenericStoreClient;
 import com.linkedin.venice.client.store.ClientConfig;
 import com.linkedin.venice.client.store.ClientFactory;
+import com.linkedin.venice.client.store.ComputeGenericRecord;
 import com.linkedin.venice.controllerapi.ControllerClient;
 import com.linkedin.venice.controllerapi.ControllerResponse;
 import com.linkedin.venice.controllerapi.D2ServiceDiscoveryResponse;
@@ -285,7 +286,7 @@ public abstract class TestRead {
         keySet.add("unknown_key");
         Map<String, GenericRecord> result = storeClient.batchGet(keySet).get();
         Assert.assertEquals(result.size(), MAX_KEY_LIMIT - 1);
-        Map<String, GenericRecord> computeResult =
+        Map<String, ComputeGenericRecord> computeResult =
             storeClient.compute().project(VALUE_FIELD_NAME).execute(keySet).get();
         Assert.assertEquals(computeResult.size(), MAX_KEY_LIMIT - 1);
 

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/router/TestRouterRetry.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/router/TestRouterRetry.java
@@ -5,6 +5,7 @@ import com.linkedin.venice.client.exceptions.VeniceClientException;
 import com.linkedin.venice.client.store.AvroGenericStoreClient;
 import com.linkedin.venice.client.store.ClientConfig;
 import com.linkedin.venice.client.store.ClientFactory;
+import com.linkedin.venice.client.store.ComputeGenericRecord;
 import com.linkedin.venice.controllerapi.ControllerClient;
 import com.linkedin.venice.controllerapi.UpdateStoreQueryParams;
 import com.linkedin.venice.controllerapi.VersionCreationResponse;
@@ -144,7 +145,7 @@ public class TestRouterRetry {
         keySet.add("unknown_key");
         Map<String, GenericRecord> result = storeClient.batchGet(keySet).get();
         Assert.assertEquals(result.size(), MAX_KEY_LIMIT - 1);
-        Map<String, GenericRecord> computeResult =
+        Map<String, ComputeGenericRecord> computeResult =
             storeClient.compute().project(VALUE_FIELD_NAME).execute(keySet).get();
         Assert.assertEquals(computeResult.size(), MAX_KEY_LIMIT - 1);
 

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/router/TestStreaming.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/router/TestStreaming.java
@@ -14,6 +14,7 @@ import com.linkedin.venice.client.exceptions.VeniceClientException;
 import com.linkedin.venice.client.store.AvroGenericStoreClient;
 import com.linkedin.venice.client.store.ClientConfig;
 import com.linkedin.venice.client.store.ClientFactory;
+import com.linkedin.venice.client.store.ComputeGenericRecord;
 import com.linkedin.venice.client.store.ComputeRequestBuilder;
 import com.linkedin.venice.client.store.StatTrackingStoreClient;
 import com.linkedin.venice.client.store.streaming.StreamingCallback;
@@ -279,13 +280,13 @@ public class TestStreaming {
         verifyMultiGetResult(multiGetResultMap);
         // Test compute streaming
         AtomicInteger computeResultCnt = new AtomicInteger(0);
-        Map<String, GenericRecord> finalComputeResultMap = new VeniceConcurrentHashMap<>();
+        Map<String, ComputeGenericRecord> finalComputeResultMap = new VeniceConcurrentHashMap<>();
         CountDownLatch computeLatch = new CountDownLatch(1);
         ComputeRequestBuilder<String> computeRequestBuilder =
             trackingStoreClient.compute().project("int_field", "nullable_string_field");
-        computeRequestBuilder.streamingExecute(keySet, new StreamingCallback<String, GenericRecord>() {
+        computeRequestBuilder.streamingExecute(keySet, new StreamingCallback<String, ComputeGenericRecord>() {
           @Override
-          public void onRecordReceived(String key, GenericRecord value) {
+          public void onRecordReceived(String key, ComputeGenericRecord value) {
             computeResultCnt.incrementAndGet();
             if (value != null) {
               finalComputeResultMap.put(key, value);
@@ -307,9 +308,9 @@ public class TestStreaming {
                                                                                                  // key
         verifyComputeResult(finalComputeResultMap);
         // Test compute with streaming implementation
-        CompletableFuture<VeniceResponseMap<String, GenericRecord>> computeFuture =
+        CompletableFuture<VeniceResponseMap<String, ComputeGenericRecord>> computeFuture =
             computeRequestBuilder.streamingExecute(keySet);
-        Map<String, GenericRecord> computeResultMap = computeFuture.get();
+        Map<String, ComputeGenericRecord> computeResultMap = computeFuture.get();
         Assert.assertEquals(computeResultMap.size(), MAX_KEY_LIMIT - NON_EXISTING_KEY_NUM);
         verifyComputeResult(computeResultMap);
       }
@@ -368,7 +369,7 @@ public class TestStreaming {
     }
   }
 
-  private void verifyComputeResult(Map<String, GenericRecord> resultMap) {
+  private void verifyComputeResult(Map<String, ComputeGenericRecord> resultMap) {
     for (int i = 0; i < MAX_KEY_LIMIT - NON_EXISTING_KEY_NUM; ++i) {
       String key = KEY_PREFIX + i;
       GenericRecord record = resultMap.get(key);

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/storagenode/ReadComputeValidationTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/storagenode/ReadComputeValidationTest.java
@@ -7,6 +7,7 @@ import com.linkedin.venice.client.exceptions.VeniceClientException;
 import com.linkedin.venice.client.store.AvroGenericStoreClient;
 import com.linkedin.venice.client.store.ClientConfig;
 import com.linkedin.venice.client.store.ClientFactory;
+import com.linkedin.venice.client.store.ComputeGenericRecord;
 import com.linkedin.venice.compression.CompressionStrategy;
 import com.linkedin.venice.compression.CompressorFactory;
 import com.linkedin.venice.compute.ComputeOperationUtils;
@@ -190,7 +191,7 @@ public class ReadComputeValidationTest {
       veniceCluster.stopAndRestartVeniceServer(veniceCluster.getVeniceServers().get(0).getPort());
 
       TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, true, true, () -> {
-        Map<Integer, GenericRecord> computeResult = storeClient.compute()
+        Map<Integer, ComputeGenericRecord> computeResult = storeClient.compute()
             .cosineSimilarity("companiesEmbedding", PYMK_COSINE_SIMILARITY_EMBEDDING, "companiesEmbedding_score")
             .cosineSimilarity("member_feature", PYMK_COSINE_SIMILARITY_EMBEDDING, "member_feature_score")
             .execute(keySet)
@@ -267,7 +268,8 @@ public class ReadComputeValidationTest {
       // Restart the server to get new schemas
       veniceCluster.stopAndRestartVeniceServer(veniceCluster.getVeniceServers().get(0).getPort());
 
-      Map<Integer, GenericRecord> computeResult = storeClient.compute().project("member_feature").execute(keySet).get();
+      Map<Integer, ComputeGenericRecord> computeResult =
+          storeClient.compute().project("member_feature").execute(keySet).get();
 
       computeResult.forEach(
           (key, value) -> Assert
@@ -343,7 +345,7 @@ public class ReadComputeValidationTest {
       Set<Integer> keySet = Utils.setOf(key1, key2);
 
       TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, false, true, () -> {
-        Map<Integer, GenericRecord> computeResult = storeClient.compute()
+        Map<Integer, ComputeGenericRecord> computeResult = storeClient.compute()
             .dotProduct("member_feature", memberFeatureEmbedding, "dot_product_result")
             .hadamardProduct("member_feature", memberFeatureEmbedding, "hadamard_product_result")
             .cosineSimilarity("member_feature", memberFeatureEmbedding, "cosine_similarity_result")

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/storagenode/StorageNodeComputeTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/storagenode/StorageNodeComputeTest.java
@@ -9,6 +9,7 @@ import com.linkedin.venice.client.exceptions.VeniceClientException;
 import com.linkedin.venice.client.store.AvroGenericStoreClient;
 import com.linkedin.venice.client.store.ClientConfig;
 import com.linkedin.venice.client.store.ClientFactory;
+import com.linkedin.venice.client.store.ComputeGenericRecord;
 import com.linkedin.venice.compression.CompressionStrategy;
 import com.linkedin.venice.compression.CompressorFactory;
 import com.linkedin.venice.compression.VeniceCompressor;
@@ -235,7 +236,7 @@ public class StorageNodeComputeTest {
       List<Float> hadamardP = Arrays.asList(135.7f, 246.8f);
 
       TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, false, true, () -> {
-        Map<String, GenericRecord> computeResult = storeClient.compute()
+        Map<String, ComputeGenericRecord> computeResult = storeClient.compute()
             .project("id")
             .dotProduct("member_feature", p, "member_score")
             .cosineSimilarity("member_feature", cosP, "cosine_similarity_result")
@@ -347,7 +348,7 @@ public class StorageNodeComputeTest {
           p.add((float) (i * 0.1));
         }
 
-        Map<String, GenericRecord> computeResult = storeClient.compute()
+        Map<String, ComputeGenericRecord> computeResult = storeClient.compute()
             .dotProduct("member_feature", p, "member_score")
             .execute(keySet)
             /**

--- a/internal/venice-test-common/src/jmh/java/com/linkedin/venice/benchmark/DaVinciPartialKeyLookupBenchmark.java
+++ b/internal/venice-test-common/src/jmh/java/com/linkedin/venice/benchmark/DaVinciPartialKeyLookupBenchmark.java
@@ -7,6 +7,7 @@ import static com.linkedin.venice.integration.utils.ServiceFactory.getVeniceClus
 import com.linkedin.davinci.client.DaVinciClient;
 import com.linkedin.davinci.client.DaVinciConfig;
 import com.linkedin.davinci.client.StorageClass;
+import com.linkedin.venice.client.store.ComputeGenericRecord;
 import com.linkedin.venice.client.store.predicate.Predicate;
 import com.linkedin.venice.client.store.streaming.StreamingCallback;
 import com.linkedin.venice.integration.utils.VeniceClusterWrapper;
@@ -150,18 +151,20 @@ public class DaVinciPartialKeyLookupBenchmark {
       keys.add(key);
     }
 
-    client.compute().project("value").streamingExecute(keys, new StreamingCallback<GenericRecord, GenericRecord>() {
-      @Override
-      public void onRecordReceived(GenericRecord key, GenericRecord value) {
-        blackhole.consume(key);
-        blackhole.consume(value);
-      }
+    client.compute()
+        .project("value")
+        .streamingExecute(keys, new StreamingCallback<GenericRecord, ComputeGenericRecord>() {
+          @Override
+          public void onRecordReceived(GenericRecord key, ComputeGenericRecord value) {
+            blackhole.consume(key);
+            blackhole.consume(value);
+          }
 
-      @Override
-      public void onCompletion(Optional<Exception> exception) {
-        exception.ifPresent(Throwable::printStackTrace);
-      }
-    });
+          @Override
+          public void onCompletion(Optional<Exception> exception) {
+            exception.ifPresent(Throwable::printStackTrace);
+          }
+        });
   }
 
   protected String buildVectorStore(VeniceClusterWrapper cluster) throws Exception {

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/MetaDataHandler.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/MetaDataHandler.java
@@ -46,6 +46,7 @@ import com.linkedin.venice.routerapi.HybridStoreQuotaStatusResponse;
 import com.linkedin.venice.routerapi.PushStatusResponse;
 import com.linkedin.venice.routerapi.ReplicaState;
 import com.linkedin.venice.routerapi.ResourceStateResponse;
+import com.linkedin.venice.schema.SchemaData;
 import com.linkedin.venice.schema.SchemaEntry;
 import com.linkedin.venice.schema.writecompute.DerivedSchemaEntry;
 import com.linkedin.venice.utils.ExceptionUtils;
@@ -215,7 +216,7 @@ public class MetaDataHandler extends SimpleChannelInboundHandler<HttpRequest> {
       responseObject.setCluster(clusterName);
       responseObject.setName(storeName);
       int superSetSchemaId = storeRepository.getStore(storeName).getLatestSuperSetValueSchemaId();
-      if (superSetSchemaId != -1) {
+      if (superSetSchemaId != SchemaData.INVALID_VALUE_SCHEMA_ID) {
         responseObject.setSuperSetSchemaId(superSetSchemaId);
       }
       Collection<SchemaEntry> valueSchemaEntries = schemaRepo.getValueSchemas(storeName);


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci], [server], [controller],
[router], [samza], [vpj], [fast-client], [thin-client], [alpini],
[admin-tool], [test], [build], [doc], [script]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->
[thin-client] [da-vinci] Return original value schema along with the read compute result

## Summary, imperative, start upper case, don't end with a period
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
Original value schema may contain metadata fields that aren't carried over to computed result schema. PR changes Read-Compute API to return `ComputeGenericRecord` wrapper instead of `GenericRecord` so that additional information can be passed along. Also added synchronized section to `RouterBackedSchemaReader::refreshAllValueSchema` to avoid data race in `latestValueSchemaEntry` handling.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- Added new test `RouterBackedSchemaReaderTest.testGetLatestValueSchemaWithSupersetSchema` to verify `preferredSchemaFilter` behavior.
- Updated `AbstractAvroStoreClientTest.testCompute` to verify that compute results contains original value schema.
- Updated `AvroComputeRequestBuilderTest.testComputeRequestBuilder` to verify that `ComputeRequestWrapper` contains value schema.

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [x] Yes. Make sure to explain your proposed changes and call out the behavior change.
Projection on fields missing in the latest value schema won't fail, but such fields won't be present in the result record either (i.e equivalent to `null`)
Minimal interface changes in `AvroGenericReadComputeStoreClient` and `ComputeRequestBuilder`
`ComputeRequestBuilder` reuse after request execution is not allowed anymore