### PR TITLE
[all] Move VeniceWriter props out of exception msg

### DIFF
--- a/internal/venice-common/src/main/java/com/linkedin/venice/writer/VeniceWriter.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/writer/VeniceWriter.java
@@ -284,6 +284,9 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
         this.writerId += ":" + props.getInt(LISTENER_PORT);
       }
     }
+    this.producerGUID = GuidUtils.getGUID(props);
+    this.logger =
+        LogManager.getLogger(VeniceWriter.class.getSimpleName() + " [" + GuidUtils.getHexFromGuid(producerGUID) + "]");
 
     try {
       this.producer = producerWrapperSupplier.get();
@@ -304,14 +307,10 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
         partitionLocks[i] = new Object();
         segmentsCreationTimeArray[i] = -1L;
       }
-      this.producerGUID = GuidUtils.getGUID(props);
-      this.logger = LogManager
-          .getLogger(VeniceWriter.class.getSimpleName() + " [" + GuidUtils.getHexFromGuid(producerGUID) + "]");
       OPEN_VENICE_WRITER_COUNT.incrementAndGet();
     } catch (Exception e) {
-      throw new VeniceException(
-          "Error while constructing VeniceWriter for store name: " + topicName + ", props: " + props.toString(),
-          e);
+      logger.error("VeniceWriter cannot be constructed with the props: {}", props);
+      throw new VeniceException("Error while constructing VeniceWriter for store name: " + topicName, e);
     }
   }
 


### PR DESCRIPTION
## Description

During my testing, the push jobs failed due to not able to construct VeniceWriter but the exception contains very long props information that makes the debugging difficult as the real exception is **swallowed** due to the length limit.

For examples
```
com.linkedin.venice.exceptions.VeniceException: Error while constructing VeniceWriter for store name: testStore_EI_adchen_02_v5, props: {abstractfs.failover.overload.scheme.target.hdfs.impl: org.apache.hadoop.fs.Hdfs, adl.feature.ownerandgroup.enableupn: false, adl.http.timeout: -1, allow.duplicate.key: true, amplification.factor: 1 ..... } // this props has over 20000 characters. Azkaban and Hadoop couldn't display the full msg.
```

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

After deploying this change, the actual exception can be revealed.
```
Error: com.linkedin.venice.exceptions.VeniceException: Error while constructing VeniceWriter for store name: testStore_adchen_02_v6
....
Caused by: com.linkedin.venice.exceptions.VeniceException: ssl.keystore.location is required when Kafka SSL is enabled
```

However, the logger doesn't log the props in the VPJ logs. I suspect that's related to some log configuration but didn't have time to dive too deep now. Given few value this props provides, I think this change is acceptable.

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.