### PR TITLE
Add error messages to sys.exit to indidate failure

### DIFF
--- a/make_tag.py
+++ b/make_tag.py
@@ -39,7 +39,7 @@ def get_next_version(bump_major, bump_minor, remote):
     commits = check_output(['git', 'log', f'{tag_text}..HEAD', '--oneline'], text=True)
     if commits == "":
         print(f'Not pushing new tag as there is no new commit since the last tag {tag_text}')
-        sys.exit()
+        sys.exit("Tag not pushed as no new commit")
     version_numbers = tag_text.split('.')  # ['0','1','36']
     version_ints = [int(part) for part in version_numbers]  # [0,1,36]
 
@@ -73,14 +73,14 @@ def make_tag(remote, bump_major, bump_minor, need_verification, github_actor):
     if github_actor:
         set_user=call(['git', 'config', 'user.name', github_actor])
         if set_user != 0:
-            sys.exit()
+            sys.exit("Could not set user.name config")
         set_email=call(['git', 'config', 'user.email', f'{github_actor}@users.noreply.github.com'])
         if set_email != 0:
-            sys.exit()
+            sys.exit("Could not set user.email config")
 
     pull_success = call(['git', 'pull', '--rebase', remote, 'main'])
     if pull_success != 0:
-        sys.exit()
+        sys.exit("Could not rebase with remote")
     version = get_next_version(bump_major, bump_minor, remote)
     tag_message = 'tag for release ' + version
 
@@ -92,7 +92,7 @@ def make_tag(remote, bump_major, bump_minor, need_verification, github_actor):
 
     tag_success = call(['git', 'tag', '-a', '-m', tag_message, version])
     if tag_success != 0:
-        sys.exit()
+        sys.exit("Could not tag")
     call(['git', 'push', remote, version])
 
 


### PR DESCRIPTION
Adding error logs in sys.exit method in make_tags. 
Without any error log, it would indicate a successful run which would trigger the next part the workflow to publish artifact which would fail eventually.