### PR TITLE
[client] Use VeniceConcurrentHashMap in VsonAvroDatumWriter to make it thread safe

### DIFF
--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/schema/vson/VsonAvroDatumWriter.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/schema/vson/VsonAvroDatumWriter.java
@@ -2,8 +2,8 @@ package com.linkedin.venice.schema.vson;
 
 import static com.linkedin.venice.schema.vson.VsonAvroSchemaAdapter.stripFromUnion;
 
+import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.Map;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericDatumWriter;
@@ -16,7 +16,7 @@ public class VsonAvroDatumWriter<K> extends GenericDatumWriter<K> {
 
   public VsonAvroDatumWriter(Schema root) {
     super(root);
-    cachedStrippedSchema = new HashMap<>();
+    cachedStrippedSchema = new VeniceConcurrentHashMap<>();
   }
 
   @Override


### PR DESCRIPTION
## Use VeniceConcurrentHashMap in VsonAvroDatumWriter to make it thread safe

The old Hashmap was throwing java.util.ConcurrentModificationException. Use a ConcurrentHashMap should solve this.

## How was this PR tested?
Existing unit and integration tests

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.