### PR TITLE
[server] Fix regression in IsolatedIngestionServerHandler

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/isolated/IsolatedIngestionServerHandler.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/isolated/IsolatedIngestionServerHandler.java
@@ -151,21 +151,19 @@ public class IsolatedIngestionServerHandler extends SimpleChannelInboundHandler<
       storeConfig.setRestoreDataPartitions(false);
       switch (ingestionCommandType) {
         case START_CONSUMPTION:
-          validateAndExecuteCommand(ingestionCommandType, report, () -> {
-            ReadOnlyStoreRepository storeRepository = isolatedIngestionServer.getStoreRepository();
-            // For subscription based store repository, we will need to subscribe to the store explicitly.
-            if (storeRepository instanceof SubscriptionBasedReadOnlyStoreRepository) {
-              LOGGER.info("Ingestion Service subscribing to store: {}", storeName);
-              try {
-                ((SubscriptionBasedReadOnlyStoreRepository) storeRepository).subscribe(storeName);
-              } catch (InterruptedException e) {
-                LOGGER.warn("Subscription to store: {} is interrupted. ", storeName);
-              }
+          ReadOnlyStoreRepository storeRepository = isolatedIngestionServer.getStoreRepository();
+          // For subscription based store repository, we will need to subscribe to the store explicitly.
+          if (storeRepository instanceof SubscriptionBasedReadOnlyStoreRepository) {
+            LOGGER.info("Ingestion Service subscribing to store: {}", storeName);
+            try {
+              ((SubscriptionBasedReadOnlyStoreRepository) storeRepository).subscribe(storeName);
+            } catch (InterruptedException e) {
+              LOGGER.warn("Subscription to store: {} is interrupted. ", storeName);
             }
-            LOGGER.info("Start ingesting partition: {} of topic: {}", partitionId, topicName);
-            isolatedIngestionServer.setPartitionToBeSubscribed(topicName, partitionId);
-            isolatedIngestionServer.getIngestionBackend().startConsumption(storeConfig, partitionId);
-          });
+          }
+          LOGGER.info("Start ingesting partition: {} of topic: {}", partitionId, topicName);
+          isolatedIngestionServer.setPartitionToBeSubscribed(topicName, partitionId);
+          isolatedIngestionServer.getIngestionBackend().startConsumption(storeConfig, partitionId);
           break;
         case STOP_CONSUMPTION:
           validateAndExecuteCommand(
@@ -388,11 +386,12 @@ public class IsolatedIngestionServerHandler extends SimpleChannelInboundHandler<
        * it will be executed inside main process.
        */
       report.isPositive = false;
-      LOGGER.info(
+      report.message = String.format(
           "Topic: {}, partition {} is being unsubscribed, will reject command {}",
           topic,
           partition,
           command.name());
+      LOGGER.info(report.message);
     }
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/isolated/IsolatedIngestionServerHandler.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/isolated/IsolatedIngestionServerHandler.java
@@ -387,7 +387,7 @@ public class IsolatedIngestionServerHandler extends SimpleChannelInboundHandler<
        */
       report.isPositive = false;
       report.message = String.format(
-          "Topic: {}, partition {} is being unsubscribed, will reject command {}",
+          "Topic: %s, partition %d is being unsubscribed, will reject command %s",
           topic,
           partition,
           command.name());


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci], [server], [controller],
[router], [samza], [vpj], [fast-client], [thin-client], [alpini],
[admin-tool], [test], [build], [doc], [script]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Summary, imperative, start upper case, don't end with a period
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Resolves regression in IsolatedIngestionServerHandler that caused rejection of all START_CONSUMPTION requests.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
Ran TestBatchForIngestionIsolation locally. Internal CI (pending).

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.