### PR TITLE
[server][da-vinci] Fix regression in recent ingestion isolation improvements.

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/IsolatedIngestionBackend.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/IsolatedIngestionBackend.java
@@ -1,6 +1,10 @@
 package com.linkedin.davinci.ingestion;
 
-import static com.linkedin.venice.ingestion.protocol.enums.IngestionCommandType.*;
+import static com.linkedin.venice.ingestion.protocol.enums.IngestionCommandType.DEMOTE_TO_STANDBY;
+import static com.linkedin.venice.ingestion.protocol.enums.IngestionCommandType.PROMOTE_TO_LEADER;
+import static com.linkedin.venice.ingestion.protocol.enums.IngestionCommandType.REMOVE_PARTITION;
+import static com.linkedin.venice.ingestion.protocol.enums.IngestionCommandType.START_CONSUMPTION;
+import static com.linkedin.venice.ingestion.protocol.enums.IngestionCommandType.STOP_CONSUMPTION;
 
 import com.linkedin.davinci.config.VeniceConfigLoader;
 import com.linkedin.davinci.config.VeniceStoreVersionConfig;
@@ -104,7 +108,7 @@ public class IsolatedIngestionBackend extends DefaultIngestionBackend
     executeCommandWithRetry(
         topicName,
         partition,
-        IngestionCommandType.STOP_CONSUMPTION,
+        STOP_CONSUMPTION,
         () -> mainIngestionRequestClient.stopConsumption(storeConfig.getStoreVersionName(), partition),
         () -> super.stopConsumption(storeConfig, partition));
   }
@@ -118,7 +122,7 @@ public class IsolatedIngestionBackend extends DefaultIngestionBackend
     executeCommandWithRetry(
         topicName,
         partition,
-        IngestionCommandType.PROMOTE_TO_LEADER,
+        PROMOTE_TO_LEADER,
         () -> mainIngestionRequestClient.promoteToLeader(topicName, partition),
         () -> super.promoteToLeader(storeConfig, partition, leaderSessionIdChecker));
   }
@@ -132,7 +136,7 @@ public class IsolatedIngestionBackend extends DefaultIngestionBackend
     executeCommandWithRetry(
         topicName,
         partition,
-        IngestionCommandType.DEMOTE_TO_STANDBY,
+        DEMOTE_TO_STANDBY,
         () -> mainIngestionRequestClient.demoteToStandby(topicName, partition),
         () -> super.demoteToStandby(storeConfig, partition, leaderSessionIdChecker));
   }
@@ -147,7 +151,7 @@ public class IsolatedIngestionBackend extends DefaultIngestionBackend
     executeCommandWithRetry(
         topicName,
         partition,
-        IngestionCommandType.REMOVE_PARTITION,
+        REMOVE_PARTITION,
         () -> mainIngestionRequestClient.unsubscribeTopicPartition(topicName, partition),
         () -> {
           super.dropStoragePartitionGracefully(storeConfig, partition, timeoutInSeconds, removeEmptyStorageEngine);

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/IsolatedIngestionBackend.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/IsolatedIngestionBackend.java
@@ -216,6 +216,10 @@ public class IsolatedIngestionBackend extends DefaultIngestionBackend
     return isolatedIngestionServiceProcess;
   }
 
+  public MainIngestionMonitorService getMainIngestionMonitorService() {
+    return mainIngestionMonitorService;
+  }
+
   public void close() {
     try {
       mainIngestionMonitorService.stopInner();
@@ -230,12 +234,12 @@ public class IsolatedIngestionBackend extends DefaultIngestionBackend
   }
 
   private boolean isTopicPartitionHostedInMainProcess(String topicName, int partition) {
-    return mainIngestionMonitorService.getTopicPartitionIngestionStatus(topicName, partition)
+    return getMainIngestionMonitorService().getTopicPartitionIngestionStatus(topicName, partition)
         .equals(MainPartitionIngestionStatus.MAIN);
   }
 
   private boolean isTopicPartitionIngesting(String topicName, int partition) {
-    return !mainIngestionMonitorService.getTopicPartitionIngestionStatus(topicName, partition)
+    return !getMainIngestionMonitorService().getTopicPartitionIngestionStatus(topicName, partition)
         .equals(MainPartitionIngestionStatus.NOT_EXIST);
   }
 
@@ -264,7 +268,7 @@ public class IsolatedIngestionBackend extends DefaultIngestionBackend
     };
   }
 
-  private void executeCommandWithRetry(
+  void executeCommandWithRetry(
       String topicName,
       int partition,
       IngestionCommandType command,

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/IsolatedIngestionBackend.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/IsolatedIngestionBackend.java
@@ -1,5 +1,7 @@
 package com.linkedin.davinci.ingestion;
 
+import static com.linkedin.venice.ingestion.protocol.enums.IngestionCommandType.*;
+
 import com.linkedin.davinci.config.VeniceConfigLoader;
 import com.linkedin.davinci.config.VeniceStoreVersionConfig;
 import com.linkedin.davinci.helix.LeaderFollowerPartitionStateModel;
@@ -90,7 +92,7 @@ public class IsolatedIngestionBackend extends DefaultIngestionBackend
       int partition,
       Optional<LeaderFollowerStateType> leaderState) {
     String topicName = storeConfig.getStoreVersionName();
-    executeCommandWithRetry(topicName, partition, IngestionCommandType.START_CONSUMPTION, () -> {
+    executeCommandWithRetry(topicName, partition, START_CONSUMPTION, () -> {
       mainIngestionMonitorService.setVersionPartitionToIsolatedIngestion(storeConfig.getStoreVersionName(), partition);
       return mainIngestionRequestClient.startConsumption(storeConfig.getStoreVersionName(), partition);
     }, () -> super.startConsumption(storeConfig, partition, leaderState));
@@ -269,8 +271,8 @@ public class IsolatedIngestionBackend extends DefaultIngestionBackend
       Supplier<Boolean> remoteCommandSupplier,
       Runnable localCommandRunnable) {
     do {
-      if (isTopicPartitionHostedInMainProcess(topicName, partition) || (!isTopicPartitionIngesting(topicName, partition)
-          && (!command.equals(IngestionCommandType.START_CONSUMPTION)))) {
+      if (isTopicPartitionHostedInMainProcess(topicName, partition)
+          || (!isTopicPartitionIngesting(topicName, partition) && command != START_CONSUMPTION)) {
         LOGGER.info(
             "Executing command {} of topic: {}, partition: {} in main process process.",
             command,

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/isolated/IsolatedIngestionServer.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/isolated/IsolatedIngestionServer.java
@@ -400,7 +400,7 @@ public class IsolatedIngestionServer extends AbstractVeniceService {
             report.message);
       }
 
-      setPartitionToBeUnsubscribed(topicName, partitionId);
+      setResourceToBeUnsubscribed(topicName, partitionId);
 
       Future<?> executionFuture = submitStopConsumptionAndCloseStorageTask(report);
       statusReportingExecutor.execute(() -> {
@@ -436,27 +436,38 @@ public class IsolatedIngestionServer extends AbstractVeniceService {
   }
 
   // Set the topic partition state to be unsubscribed.
-  public void setPartitionToBeUnsubscribed(String topicName, int partition) {
+  public void setResourceToBeUnsubscribed(String topicName, int partition) {
     topicPartitionSubscriptionMap.putIfAbsent(topicName, new VeniceConcurrentHashMap<>());
     topicPartitionSubscriptionMap.get(topicName).putIfAbsent(partition, new AtomicBoolean(false));
     topicPartitionSubscriptionMap.get(topicName).get(partition).set(false);
   }
 
   // Set the topic partition state to be subscribed.
-  public void setPartitionToBeSubscribed(String topicName, int partition) {
+  public void setResourceToBeSubscribed(String topicName, int partition) {
     topicPartitionSubscriptionMap.putIfAbsent(topicName, new VeniceConcurrentHashMap<>());
     topicPartitionSubscriptionMap.get(topicName).putIfAbsent(partition, new AtomicBoolean(true));
     topicPartitionSubscriptionMap.get(topicName).get(partition).set(true);
   }
 
   // Check if topic partition is being subscribed.
-  public boolean isPartitionSubscribed(String topicName, int partition) {
+  public boolean isResourceSubscribed(String topicName, int partition) {
     AtomicBoolean subscription =
         getTopicPartitionSubscriptionMap().getOrDefault(topicName, Collections.emptyMap()).get(partition);
     if (subscription == null) {
       return false;
     }
     return subscription.get();
+  }
+
+  public void maybeSubscribeNewResource(String topicName, int partition) {
+    topicPartitionSubscriptionMap.putIfAbsent(topicName, new VeniceConcurrentHashMap<>());
+    topicPartitionSubscriptionMap.get(topicName).putIfAbsent(partition, new AtomicBoolean(true));
+  }
+
+  public boolean isNewResource(String topicName, int partition) {
+    AtomicBoolean subscription =
+        getTopicPartitionSubscriptionMap().getOrDefault(topicName, Collections.emptyMap()).get(partition);
+    return subscription == null;
   }
 
   Map<String, Map<Integer, AtomicBoolean>> getTopicPartitionSubscriptionMap() {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/isolated/IsolatedIngestionServer.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/isolated/IsolatedIngestionServer.java
@@ -437,16 +437,16 @@ public class IsolatedIngestionServer extends AbstractVeniceService {
 
   // Set the topic partition state to be unsubscribed.
   public void setResourceToBeUnsubscribed(String topicName, int partition) {
-    topicPartitionSubscriptionMap.putIfAbsent(topicName, new VeniceConcurrentHashMap<>());
-    topicPartitionSubscriptionMap.get(topicName).putIfAbsent(partition, new AtomicBoolean(false));
-    topicPartitionSubscriptionMap.get(topicName).get(partition).set(false);
+    topicPartitionSubscriptionMap.computeIfAbsent(topicName, s -> new VeniceConcurrentHashMap<>())
+        .computeIfAbsent(partition, p -> new AtomicBoolean(false))
+        .set(false);
   }
 
   // Set the topic partition state to be subscribed.
   public void setResourceToBeSubscribed(String topicName, int partition) {
-    topicPartitionSubscriptionMap.putIfAbsent(topicName, new VeniceConcurrentHashMap<>());
-    topicPartitionSubscriptionMap.get(topicName).putIfAbsent(partition, new AtomicBoolean(true));
-    topicPartitionSubscriptionMap.get(topicName).get(partition).set(true);
+    topicPartitionSubscriptionMap.computeIfAbsent(topicName, s -> new VeniceConcurrentHashMap<>())
+        .computeIfAbsent(partition, p -> new AtomicBoolean(true))
+        .set(true);
   }
 
   // Check if topic partition is being subscribed.
@@ -462,12 +462,6 @@ public class IsolatedIngestionServer extends AbstractVeniceService {
   public void maybeSubscribeNewResource(String topicName, int partition) {
     topicPartitionSubscriptionMap.putIfAbsent(topicName, new VeniceConcurrentHashMap<>());
     topicPartitionSubscriptionMap.get(topicName).putIfAbsent(partition, new AtomicBoolean(true));
-  }
-
-  public boolean isNewResource(String topicName, int partition) {
-    AtomicBoolean subscription =
-        getTopicPartitionSubscriptionMap().getOrDefault(topicName, Collections.emptyMap()).get(partition);
-    return subscription == null;
   }
 
   Map<String, Map<Integer, AtomicBoolean>> getTopicPartitionSubscriptionMap() {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/isolated/IsolatedIngestionServer.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/isolated/IsolatedIngestionServer.java
@@ -460,8 +460,8 @@ public class IsolatedIngestionServer extends AbstractVeniceService {
   }
 
   public void maybeSubscribeNewResource(String topicName, int partition) {
-    topicPartitionSubscriptionMap.putIfAbsent(topicName, new VeniceConcurrentHashMap<>());
-    topicPartitionSubscriptionMap.get(topicName).putIfAbsent(partition, new AtomicBoolean(true));
+    topicPartitionSubscriptionMap.computeIfAbsent(topicName, s -> new VeniceConcurrentHashMap<>())
+        .computeIfAbsent(partition, p -> new AtomicBoolean(true));
   }
 
   Map<String, Map<Integer, AtomicBoolean>> getTopicPartitionSubscriptionMap() {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/isolated/IsolatedIngestionServerHandler.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/isolated/IsolatedIngestionServerHandler.java
@@ -151,6 +151,7 @@ public class IsolatedIngestionServerHandler extends SimpleChannelInboundHandler<
       storeConfig.setRestoreDataPartitions(false);
       switch (ingestionCommandType) {
         case START_CONSUMPTION:
+          isolatedIngestionServer.maybeSubscribeNewResource(topicName, partitionId);
           validateAndExecuteCommand(ingestionCommandType, report, () -> {
             ReadOnlyStoreRepository storeRepository = isolatedIngestionServer.getStoreRepository();
             // For subscription based store repository, we will need to subscribe to the store explicitly.
@@ -163,7 +164,7 @@ public class IsolatedIngestionServerHandler extends SimpleChannelInboundHandler<
               }
             }
             LOGGER.info("Start ingesting partition: {} of topic: {}", partitionId, topicName);
-            isolatedIngestionServer.setPartitionToBeSubscribed(topicName, partitionId);
+            isolatedIngestionServer.setResourceToBeSubscribed(topicName, partitionId);
             isolatedIngestionServer.getIngestionBackend().startConsumption(storeConfig, partitionId);
           });
           break;
@@ -379,7 +380,7 @@ public class IsolatedIngestionServerHandler extends SimpleChannelInboundHandler<
       Runnable commandRunnable) {
     String topic = report.topicName.toString();
     int partition = report.partitionId;
-    if (isolatedIngestionServer.isPartitionSubscribed(topic, partition)) {
+    if (isolatedIngestionServer.isResourceSubscribed(topic, partition)) {
       commandRunnable.run();
     } else {
       /**

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/main/MainIngestionRequestClient.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/main/MainIngestionRequestClient.java
@@ -112,7 +112,7 @@ public class MainIngestionRequestClient implements Closeable {
         topicName,
         Optional.of(partitionId),
         REQUEST_MAX_ATTEMPT,
-        true);
+        false);
   }
 
   public boolean stopConsumption(String topicName, int partitionId) {
@@ -125,7 +125,7 @@ public class MainIngestionRequestClient implements Closeable {
         topicName,
         Optional.of(partitionId),
         REQUEST_MAX_ATTEMPT,
-        true);
+        false);
   }
 
   public void killConsumptionTask(String topicName) {
@@ -134,21 +134,21 @@ public class MainIngestionRequestClient implements Closeable {
     ingestionTaskCommand.topicName = topicName;
 
     // We do not need to retry here. Retry will slow down DaVinciBackend's shutdown speed severely.
-    sendIngestionCommandWithRetry(ingestionTaskCommand, topicName, Optional.empty(), 1, true);
+    sendIngestionCommandWithRetry(ingestionTaskCommand, topicName, Optional.empty(), 1, false);
   }
 
   public void removeStorageEngine(String topicName) {
     IngestionTaskCommand ingestionTaskCommand = new IngestionTaskCommand();
     ingestionTaskCommand.commandType = IngestionCommandType.REMOVE_STORAGE_ENGINE.getValue();
     ingestionTaskCommand.topicName = topicName;
-    sendIngestionCommandWithRetry(ingestionTaskCommand, topicName, Optional.empty(), REQUEST_MAX_ATTEMPT, true);
+    sendIngestionCommandWithRetry(ingestionTaskCommand, topicName, Optional.empty(), REQUEST_MAX_ATTEMPT, false);
   }
 
   public void openStorageEngine(String topicName) {
     IngestionTaskCommand ingestionTaskCommand = new IngestionTaskCommand();
     ingestionTaskCommand.commandType = IngestionCommandType.OPEN_STORAGE_ENGINE.getValue();
     ingestionTaskCommand.topicName = topicName;
-    sendIngestionCommandWithRetry(ingestionTaskCommand, topicName, Optional.empty(), REQUEST_MAX_ATTEMPT, true);
+    sendIngestionCommandWithRetry(ingestionTaskCommand, topicName, Optional.empty(), REQUEST_MAX_ATTEMPT, false);
   }
 
   public boolean unsubscribeTopicPartition(String topicName, int partitionId) {
@@ -156,7 +156,7 @@ public class MainIngestionRequestClient implements Closeable {
     ingestionTaskCommand.commandType = IngestionCommandType.REMOVE_PARTITION.getValue();
     ingestionTaskCommand.topicName = topicName;
     ingestionTaskCommand.partitionId = partitionId;
-    return sendIngestionCommandWithRetry(ingestionTaskCommand, topicName, Optional.empty(), REQUEST_MAX_ATTEMPT, true);
+    return sendIngestionCommandWithRetry(ingestionTaskCommand, topicName, Optional.empty(), REQUEST_MAX_ATTEMPT, false);
   }
 
   public boolean promoteToLeader(String topicName, int partitionId) {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/main/MainIngestionRequestClient.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/main/MainIngestionRequestClient.java
@@ -111,8 +111,7 @@ public class MainIngestionRequestClient implements Closeable {
         ingestionTaskCommand,
         topicName,
         Optional.of(partitionId),
-        REQUEST_MAX_ATTEMPT,
-        false);
+        REQUEST_MAX_ATTEMPT);
   }
 
   public boolean stopConsumption(String topicName, int partitionId) {
@@ -124,8 +123,7 @@ public class MainIngestionRequestClient implements Closeable {
         ingestionTaskCommand,
         topicName,
         Optional.of(partitionId),
-        REQUEST_MAX_ATTEMPT,
-        false);
+        REQUEST_MAX_ATTEMPT);
   }
 
   public void killConsumptionTask(String topicName) {
@@ -134,21 +132,21 @@ public class MainIngestionRequestClient implements Closeable {
     ingestionTaskCommand.topicName = topicName;
 
     // We do not need to retry here. Retry will slow down DaVinciBackend's shutdown speed severely.
-    sendIngestionCommandWithRetry(ingestionTaskCommand, topicName, Optional.empty(), 1, false);
+    sendIngestionCommandWithRetry(ingestionTaskCommand, topicName, Optional.empty(), 1);
   }
 
   public void removeStorageEngine(String topicName) {
     IngestionTaskCommand ingestionTaskCommand = new IngestionTaskCommand();
     ingestionTaskCommand.commandType = IngestionCommandType.REMOVE_STORAGE_ENGINE.getValue();
     ingestionTaskCommand.topicName = topicName;
-    sendIngestionCommandWithRetry(ingestionTaskCommand, topicName, Optional.empty(), REQUEST_MAX_ATTEMPT, false);
+    sendIngestionCommandWithRetry(ingestionTaskCommand, topicName, Optional.empty(), REQUEST_MAX_ATTEMPT);
   }
 
   public void openStorageEngine(String topicName) {
     IngestionTaskCommand ingestionTaskCommand = new IngestionTaskCommand();
     ingestionTaskCommand.commandType = IngestionCommandType.OPEN_STORAGE_ENGINE.getValue();
     ingestionTaskCommand.topicName = topicName;
-    sendIngestionCommandWithRetry(ingestionTaskCommand, topicName, Optional.empty(), REQUEST_MAX_ATTEMPT, false);
+    sendIngestionCommandWithRetry(ingestionTaskCommand, topicName, Optional.empty(), REQUEST_MAX_ATTEMPT);
   }
 
   public boolean unsubscribeTopicPartition(String topicName, int partitionId) {
@@ -156,7 +154,7 @@ public class MainIngestionRequestClient implements Closeable {
     ingestionTaskCommand.commandType = IngestionCommandType.REMOVE_PARTITION.getValue();
     ingestionTaskCommand.topicName = topicName;
     ingestionTaskCommand.partitionId = partitionId;
-    return sendIngestionCommandWithRetry(ingestionTaskCommand, topicName, Optional.empty(), REQUEST_MAX_ATTEMPT, false);
+    return sendIngestionCommandWithRetry(ingestionTaskCommand, topicName, Optional.empty(), REQUEST_MAX_ATTEMPT);
   }
 
   public boolean promoteToLeader(String topicName, int partitionId) {
@@ -168,8 +166,7 @@ public class MainIngestionRequestClient implements Closeable {
         ingestionTaskCommand,
         topicName,
         Optional.of(partitionId),
-        REQUEST_MAX_ATTEMPT,
-        false);
+        REQUEST_MAX_ATTEMPT);
   }
 
   public boolean demoteToStandby(String topicName, int partitionId) {
@@ -181,8 +178,7 @@ public class MainIngestionRequestClient implements Closeable {
         ingestionTaskCommand,
         topicName,
         Optional.of(partitionId),
-        REQUEST_MAX_ATTEMPT,
-        false);
+        REQUEST_MAX_ATTEMPT);
   }
 
   public void resetTopicPartition(String topicName, int partitionId) {
@@ -190,12 +186,7 @@ public class MainIngestionRequestClient implements Closeable {
     ingestionTaskCommand.commandType = IngestionCommandType.RESET_PARTITION.getValue();
     ingestionTaskCommand.topicName = topicName;
     ingestionTaskCommand.partitionId = partitionId;
-    sendIngestionCommandWithRetry(
-        ingestionTaskCommand,
-        topicName,
-        Optional.of(partitionId),
-        REQUEST_MAX_ATTEMPT,
-        false);
+    sendIngestionCommandWithRetry(ingestionTaskCommand, topicName, Optional.of(partitionId), REQUEST_MAX_ATTEMPT);
   }
 
   public boolean updateMetadata(IngestionStorageMetadata ingestionStorageMetadata) {
@@ -272,8 +263,7 @@ public class MainIngestionRequestClient implements Closeable {
       IngestionTaskCommand command,
       String topicName,
       Optional<Integer> partitionId,
-      int requestMaxAttempt,
-      boolean throwExceptionOnFailure) {
+      int requestMaxAttempt) {
     String commandType = IngestionCommandType.valueOf(command.commandType).toString();
     String commandInfo =
         " for topic: " + topicName + (partitionId.map(integer -> (", partition: " + integer)).orElse(""));
@@ -283,10 +273,6 @@ public class MainIngestionRequestClient implements Closeable {
       report = httpClientTransport.sendRequestWithRetry(IngestionAction.COMMAND, command, requestMaxAttempt);
     } catch (Exception e) {
       throw new VeniceException("Caught exception when sending command: " + commandType + commandInfo, e);
-    }
-    if (report != null && !report.isPositive && throwExceptionOnFailure) {
-      String errorMessage = (report.message != null) ? report.message.toString() : "";
-      throw new VeniceException("Caught exception in forked ingestion process: " + errorMessage);
     }
     return report != null && report.isPositive;
   }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/ingestion/IsolatedIngestionBackendTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/ingestion/IsolatedIngestionBackendTest.java
@@ -1,0 +1,65 @@
+package com.linkedin.davinci.ingestion;
+
+import static com.linkedin.davinci.ingestion.main.MainPartitionIngestionStatus.ISOLATED;
+import static com.linkedin.davinci.ingestion.main.MainPartitionIngestionStatus.MAIN;
+import static com.linkedin.davinci.ingestion.main.MainPartitionIngestionStatus.NOT_EXIST;
+import static com.linkedin.venice.ingestion.protocol.enums.IngestionCommandType.START_CONSUMPTION;
+import static com.linkedin.venice.ingestion.protocol.enums.IngestionCommandType.STOP_CONSUMPTION;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.linkedin.davinci.ingestion.main.MainIngestionMonitorService;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class IsolatedIngestionBackendTest {
+  @Test
+  public void testBackendCanDirectCommandCorrectly() {
+    try (MainIngestionMonitorService monitorService = mock(MainIngestionMonitorService.class);
+        IsolatedIngestionBackend backend = mock(IsolatedIngestionBackend.class)) {
+      when(backend.getMainIngestionMonitorService()).thenReturn(monitorService);
+      doCallRealMethod().when(backend).executeCommandWithRetry(anyString(), anyInt(), any(), any(), any());
+
+      String topic = "testTopic";
+      int partition = 0;
+      AtomicInteger executionFlag = new AtomicInteger();
+      Supplier<Boolean> remoteProcessSupplier = () -> {
+        executionFlag.set(1);
+        return true;
+      };
+      Runnable localCommandRunnable = () -> executionFlag.set(-1);
+
+      // Resource does not exist.
+      when(monitorService.getTopicPartitionIngestionStatus(topic, partition)).thenReturn(NOT_EXIST);
+      // Consumption request should be executed in remote.
+      executionFlag.set(0);
+      backend.executeCommandWithRetry(topic, partition, START_CONSUMPTION, remoteProcessSupplier, localCommandRunnable);
+      Assert.assertEquals(executionFlag.get(), 1);
+
+      // Other request should be executed in local.
+      executionFlag.set(0);
+      backend.executeCommandWithRetry(topic, partition, STOP_CONSUMPTION, remoteProcessSupplier, localCommandRunnable);
+      Assert.assertEquals(executionFlag.get(), -1);
+
+      // Resource exists in main process.
+      when(monitorService.getTopicPartitionIngestionStatus(topic, partition)).thenReturn(MAIN);
+      executionFlag.set(0);
+      backend.executeCommandWithRetry(topic, partition, START_CONSUMPTION, remoteProcessSupplier, localCommandRunnable);
+      Assert.assertEquals(executionFlag.get(), -1);
+
+      // Resource exists in isolated process.
+      when(monitorService.getTopicPartitionIngestionStatus(topic, partition)).thenReturn(ISOLATED);
+      executionFlag.set(0);
+      backend.executeCommandWithRetry(topic, partition, START_CONSUMPTION, remoteProcessSupplier, localCommandRunnable);
+      Assert.assertEquals(executionFlag.get(), 1);
+    }
+
+  }
+}

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/ingestion/isolated/IsolatedIngestionServerHandlerTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/ingestion/isolated/IsolatedIngestionServerHandlerTest.java
@@ -20,7 +20,7 @@ public class IsolatedIngestionServerHandlerTest {
 
     Map<String, Map<Integer, AtomicBoolean>> topicPartitionSubscriptionMap = new VeniceConcurrentHashMap<>();
     IsolatedIngestionServer mockedServer = Mockito.mock(IsolatedIngestionServer.class);
-    Mockito.when(mockedServer.isPartitionSubscribed(topic, partitionId)).thenCallRealMethod();
+    Mockito.when(mockedServer.isResourceSubscribed(topic, partitionId)).thenCallRealMethod();
     Mockito.when(mockedServer.getTopicPartitionSubscriptionMap()).thenReturn(topicPartitionSubscriptionMap);
     IsolatedIngestionServerHandler isolatedIngestionServerHandler = new IsolatedIngestionServerHandler(mockedServer);
     IngestionTaskReport ingestionTaskReport = IsolatedIngestionUtils.createIngestionTaskReport(topic, partitionId);

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestBatch.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestBatch.java
@@ -121,9 +121,7 @@ public abstract class TestBatch {
 
   @AfterClass(alwaysRun = true)
   public void cleanUp() {
-    if (veniceCluster != null) {
-      Utils.closeQuietlyWithErrorLogged(veniceCluster);
-    }
+    Utils.closeQuietlyWithErrorLogged(veniceCluster);
   }
 
   @Test(timeOut = TEST_TIMEOUT)

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestBatch.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestBatch.java
@@ -122,12 +122,12 @@ public abstract class TestBatch {
   @AfterClass(alwaysRun = true)
   public void cleanUp() {
     if (veniceCluster != null) {
-      veniceCluster.close();
+      Utils.closeQuietlyWithErrorLogged(veniceCluster);
     }
   }
 
   @Test(timeOut = TEST_TIMEOUT)
-  public void storeWithNoVersionThrows400() {
+  public void testStoreWithNoVersionThrows400() {
 
     // Create store
     File inputDir = getTempDataDirectory();
@@ -471,7 +471,7 @@ public abstract class TestBatch {
     }, storeName, null);
   }
 
-  @Test(timeOut = TEST_TIMEOUT)
+  @Test(timeOut = TEST_TIMEOUT, enabled = false)
   public void testIncrementalPushWritesToRealTimeTopicWithPolicy() throws Exception {
     /**
      * N.B. This test has some flaky issues where it occasionally times out... It seems to be specific to

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestBatch.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestBatch.java
@@ -471,7 +471,7 @@ public abstract class TestBatch {
     }, storeName, null);
   }
 
-  @Test(timeOut = TEST_TIMEOUT, enabled = false)
+  @Test(timeOut = TEST_TIMEOUT)
   public void testIncrementalPushWritesToRealTimeTopicWithPolicy() throws Exception {
     /**
      * N.B. This test has some flaky issues where it occasionally times out... It seems to be specific to


### PR DESCRIPTION


<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci], [server], [controller],
[router], [samza], [vpj], [fast-client], [thin-client], [alpini],
[admin-tool], [test], [build], [doc], [script]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## [server][da-vinci] Fix regression in recent ingestion isolation improvements
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
This PR fixes recent regression added to the ingestion isolation command request logics.
1. Do not throw exception when remote ingestion process reject command as it should be a transient state during unsubscription from II to main process. (improvement)
2. Try to initialize topic partition status to be subscribed in the forked process before START_CONSUMPTION command execution check. If the topic partition has not been touched in the forked process this action will initialize the state so ingestion command can go through (bug fix)
3. For any commands other than START_CONSUMPTION, if a topic partition is not hosted in a server, the default go-to process should be main process instead of forked process. (bug fix)

Local test fixes the TestBatchForIngestionIsolation test failures and hanging in the cleanup() method. Running CI to verify the fix.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
Submitted to multiple CI tests.
## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [x] Yes. Make sure to explain your proposed changes and call out the behavior change.