### PR TITLE
[test] Fix testParentControllerAutoMaterializeDaVinciPushStatusSystem…

### DIFF
--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/PushStatusStoreMultiColoTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/PushStatusStoreMultiColoTest.java
@@ -1,5 +1,7 @@
 package com.linkedin.venice.endToEnd;
 
+import static com.linkedin.venice.ConfigKeys.CONTROLLER_AUTO_MATERIALIZE_DAVINCI_PUSH_STATUS_SYSTEM_STORE;
+import static com.linkedin.venice.ConfigKeys.CONTROLLER_AUTO_MATERIALIZE_META_SYSTEM_STORE;
 import static com.linkedin.venice.ConfigKeys.SERVER_PROMOTION_TO_LEADER_REPLICA_DELAY_SECONDS;
 import static com.linkedin.venice.ConfigKeys.USE_PUSH_STATUS_STORE_FOR_INCREMENTAL_PUSH;
 import static com.linkedin.venice.integration.utils.VeniceClusterWrapper.DEFAULT_KEY_SCHEMA;
@@ -70,6 +72,10 @@ public class PushStatusStoreMultiColoTest {
     // all tests in this class will be reading incremental push status from push status store.
     extraProperties.setProperty(USE_PUSH_STATUS_STORE_FOR_INCREMENTAL_PUSH, String.valueOf(true));
 
+    // Enable auto materialize for meta and da-vinci push status system stores.
+    extraProperties.setProperty(CONTROLLER_AUTO_MATERIALIZE_META_SYSTEM_STORE, String.valueOf(true));
+    extraProperties.setProperty(CONTROLLER_AUTO_MATERIALIZE_DAVINCI_PUSH_STATUS_SYSTEM_STORE, String.valueOf(true));
+
     multiColoMultiClusterWrapper = ServiceFactory.getVeniceTwoLayerMultiColoMultiClusterWrapper(
         NUMBER_OF_CHILD_DATACENTERS,
         NUMBER_OF_CLUSTERS,
@@ -79,7 +85,7 @@ public class PushStatusStoreMultiColoTest {
         NUMBER_OF_ROUTERS,
         REPLICATION_FACTOR,
         Optional.of(new VeniceProperties(extraProperties)),
-        Optional.empty(),
+        Optional.of(extraProperties),
         Optional.empty(),
         false);
     childDatacenters = multiColoMultiClusterWrapper.getClusters();

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/PushStatusStoreMultiColoTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/PushStatusStoreMultiColoTest.java
@@ -1,0 +1,216 @@
+package com.linkedin.venice.endToEnd;
+
+import static com.linkedin.venice.ConfigKeys.SERVER_PROMOTION_TO_LEADER_REPLICA_DELAY_SECONDS;
+import static com.linkedin.venice.ConfigKeys.USE_PUSH_STATUS_STORE_FOR_INCREMENTAL_PUSH;
+import static com.linkedin.venice.integration.utils.VeniceClusterWrapper.DEFAULT_KEY_SCHEMA;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
+import com.linkedin.d2.balancer.D2Client;
+import com.linkedin.venice.D2.D2ClientUtils;
+import com.linkedin.venice.common.VeniceSystemStoreType;
+import com.linkedin.venice.controller.init.ClusterLeaderInitializationRoutine;
+import com.linkedin.venice.controllerapi.ControllerClient;
+import com.linkedin.venice.controllerapi.NewStoreResponse;
+import com.linkedin.venice.controllerapi.UpdateStoreQueryParams;
+import com.linkedin.venice.controllerapi.VersionCreationResponse;
+import com.linkedin.venice.integration.utils.D2TestUtils;
+import com.linkedin.venice.integration.utils.ServiceFactory;
+import com.linkedin.venice.integration.utils.VeniceClusterWrapper;
+import com.linkedin.venice.integration.utils.VeniceControllerWrapper;
+import com.linkedin.venice.integration.utils.VeniceMultiClusterWrapper;
+import com.linkedin.venice.integration.utils.VeniceRouterWrapper;
+import com.linkedin.venice.integration.utils.VeniceTwoLayerMultiColoMultiClusterWrapper;
+import com.linkedin.venice.meta.Store;
+import com.linkedin.venice.meta.Version;
+import com.linkedin.venice.pushstatushelper.PushStatusStoreReader;
+import com.linkedin.venice.serialization.avro.AvroProtocolDefinition;
+import com.linkedin.venice.utils.TestUtils;
+import com.linkedin.venice.utils.Utils;
+import com.linkedin.venice.utils.VeniceProperties;
+import java.util.List;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+
+public class PushStatusStoreMultiColoTest {
+  private static final int TEST_TIMEOUT_MS = 60_000;
+  private static final int NUMBER_OF_SERVERS = 2;
+  private static final int PARTITION_COUNT = 2;
+  private static final int REPLICATION_FACTOR = 2;
+  private VeniceClusterWrapper cluster;
+  private ControllerClient parentControllerClient;
+  private D2Client d2Client;
+  private PushStatusStoreReader reader;
+  private String storeName;
+  private VeniceControllerWrapper parentController;
+
+  private static final int NUMBER_OF_CHILD_DATACENTERS = 1;
+  private static final int NUMBER_OF_CLUSTERS = 1;
+  private static final int NUMBER_OF_PARENT_CONTROLLERS = 1;
+  private static final int NUMBER_OF_CHILD_CONTROLLERS = 1;
+  private static final int NUMBER_OF_ROUTERS = 1;
+  private List<VeniceMultiClusterWrapper> childDatacenters;
+  private List<VeniceControllerWrapper> parentControllers;
+
+  private VeniceTwoLayerMultiColoMultiClusterWrapper multiColoMultiClusterWrapper;
+
+  @BeforeClass
+  public void setUp() {
+    Utils.thisIsLocalhost();
+    Properties extraProperties = new Properties();
+    extraProperties.setProperty(SERVER_PROMOTION_TO_LEADER_REPLICA_DELAY_SECONDS, Long.toString(1L));
+    // all tests in this class will be reading incremental push status from push status store.
+    extraProperties.setProperty(USE_PUSH_STATUS_STORE_FOR_INCREMENTAL_PUSH, String.valueOf(true));
+
+    multiColoMultiClusterWrapper = ServiceFactory.getVeniceTwoLayerMultiColoMultiClusterWrapper(
+        NUMBER_OF_CHILD_DATACENTERS,
+        NUMBER_OF_CLUSTERS,
+        NUMBER_OF_PARENT_CONTROLLERS,
+        NUMBER_OF_CHILD_CONTROLLERS,
+        NUMBER_OF_SERVERS,
+        NUMBER_OF_ROUTERS,
+        REPLICATION_FACTOR,
+        Optional.of(new VeniceProperties(extraProperties)),
+        Optional.empty(),
+        Optional.empty(),
+        false);
+    childDatacenters = multiColoMultiClusterWrapper.getClusters();
+    parentControllers = multiColoMultiClusterWrapper.getParentControllers();
+
+    String[] clusterNames = childDatacenters.get(0).getClusterNames();
+    cluster = childDatacenters.get(0).getClusters().get(clusterNames[0]);
+    parentController = parentControllers.get(0);
+
+    parentControllerClient = new ControllerClient(cluster.getClusterName(), parentController.getControllerUrl());
+    d2Client = D2TestUtils.getAndStartD2Client(cluster.getZk().getAddress());
+    reader = new PushStatusStoreReader(
+        d2Client,
+        VeniceRouterWrapper.CLUSTER_DISCOVERY_D2_SERVICE_NAME,
+        TimeUnit.MINUTES.toSeconds(10));
+  }
+
+  @AfterClass
+  public void cleanUp() {
+    Utils.closeQuietlyWithErrorLogged(reader);
+    D2ClientUtils.shutdownClient(d2Client);
+    Utils.closeQuietlyWithErrorLogged(parentControllerClient);
+    Utils.closeQuietlyWithErrorLogged(multiColoMultiClusterWrapper);
+  }
+
+  public void setUpStore() {
+    storeName = Utils.getUniqueString("store");
+    String owner = "test";
+    // set up push status store.
+    TestUtils.assertCommand(parentControllerClient.createNewStore(storeName, owner, DEFAULT_KEY_SCHEMA, "\"string\""));
+    TestUtils.assertCommand(
+        parentControllerClient.updateStore(
+            storeName,
+            new UpdateStoreQueryParams().setStorageQuotaInByte(Store.UNLIMITED_STORAGE_QUOTA)
+                .setLeaderFollowerModel(true)
+                .setPartitionCount(PARTITION_COUNT)
+                .setAmplificationFactor(1)
+                .setIncrementalPushEnabled(true)));
+    String daVinciPushStatusSystemStoreName =
+        VeniceSystemStoreType.DAVINCI_PUSH_STATUS_STORE.getSystemStoreName(storeName);
+    VersionCreationResponse versionCreationResponseForDaVinciPushStatusSystemStore = parentControllerClient
+        .emptyPush(daVinciPushStatusSystemStoreName, "test_da_vinci_push_status_system_store_push_1", 10000);
+    assertFalse(
+        versionCreationResponseForDaVinciPushStatusSystemStore.isError(),
+        "New version creation for Da Vinci push status system store: " + daVinciPushStatusSystemStoreName
+            + " should success, but got error: " + versionCreationResponseForDaVinciPushStatusSystemStore.getError());
+    TestUtils.waitForNonDeterministicPushCompletion(
+        versionCreationResponseForDaVinciPushStatusSystemStore.getKafkaTopic(),
+        parentControllerClient,
+        30,
+        TimeUnit.SECONDS);
+  }
+
+  @Test(timeOut = TEST_TIMEOUT_MS)
+  public void testParentControllerAutoMaterializeDaVinciPushStatusSystemStore() {
+    setUpStore();
+    String zkSharedDaVinciPushStatusSchemaStoreName =
+        AvroProtocolDefinition.PUSH_STATUS_SYSTEM_SCHEMA_STORE.getSystemStoreName();
+    TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, true, () -> {
+      Store readOnlyStore = parentController.getVeniceAdmin()
+          .getReadOnlyZKSharedSystemStoreRepository()
+          .getStore(zkSharedDaVinciPushStatusSchemaStoreName);
+      assertNotNull(
+          readOnlyStore,
+          "Store: " + zkSharedDaVinciPushStatusSchemaStoreName + " should be initialized by "
+              + ClusterLeaderInitializationRoutine.class.getSimpleName());
+      assertTrue(
+          readOnlyStore.isHybrid(),
+          "Store: " + zkSharedDaVinciPushStatusSchemaStoreName + " should be configured to hybrid");
+    });
+    String userStoreName = Utils.getUniqueString("new-user-store");
+    NewStoreResponse newStoreResponse =
+        parentControllerClient.createNewStore(userStoreName, "venice-test", DEFAULT_KEY_SCHEMA, "\"string\"");
+    assertFalse(newStoreResponse.isError(), "Unexpected new store creation failure");
+    String daVinciPushStatusSystemStoreName =
+        VeniceSystemStoreType.DAVINCI_PUSH_STATUS_STORE.getSystemStoreName(userStoreName);
+    TestUtils.waitForNonDeterministicPushCompletion(
+        Version.composeKafkaTopic(daVinciPushStatusSystemStoreName, 1),
+        parentControllerClient,
+        30,
+        TimeUnit.SECONDS);
+    Store daVinciPushStatusSystemStore =
+        parentController.getVeniceAdmin().getStore(cluster.getClusterName(), daVinciPushStatusSystemStoreName);
+    assertEquals(daVinciPushStatusSystemStore.getLargestUsedVersionNumber(), 1);
+
+    // Do empty pushes to increase the system store's version
+    final int emptyPushAttempt = 2;
+    for (int i = 0; i < emptyPushAttempt; i++) {
+      final int newVersion = parentController.getVeniceAdmin()
+          .incrementVersionIdempotent(
+              cluster.getClusterName(),
+              daVinciPushStatusSystemStoreName,
+              "push job ID placeholder " + i,
+              1,
+              1)
+          .getNumber();
+      parentController.getVeniceAdmin()
+          .writeEndOfPush(cluster.getClusterName(), daVinciPushStatusSystemStoreName, newVersion, true);
+      TestUtils.waitForNonDeterministicPushCompletion(
+          Version.composeKafkaTopic(daVinciPushStatusSystemStoreName, newVersion),
+          parentControllerClient,
+          30,
+          TimeUnit.SECONDS);
+    }
+    daVinciPushStatusSystemStore =
+        parentController.getVeniceAdmin().getStore(cluster.getClusterName(), daVinciPushStatusSystemStoreName);
+    final int systemStoreCurrVersionBeforeBeingDeleted = daVinciPushStatusSystemStore.getLargestUsedVersionNumber();
+    assertEquals(systemStoreCurrVersionBeforeBeingDeleted, 1 + emptyPushAttempt);
+
+    TestUtils.assertCommand(parentControllerClient.disableAndDeleteStore(userStoreName));
+    // Both the system store and user store should be gone at this point
+    assertNull(parentController.getVeniceAdmin().getStore(cluster.getClusterName(), userStoreName));
+    assertNull(parentController.getVeniceAdmin().getStore(cluster.getClusterName(), daVinciPushStatusSystemStoreName));
+
+    // Create the same regular store again
+    TestUtils.assertCommand(
+        parentControllerClient.createNewStore(userStoreName, "venice-test", DEFAULT_KEY_SCHEMA, "\"string\""),
+        "Unexpected new store creation failure");
+
+    // The re-created/materialized per-user store system store should contain a continued version from its last life
+    daVinciPushStatusSystemStore =
+        parentController.getVeniceAdmin().getStore(cluster.getClusterName(), daVinciPushStatusSystemStoreName);
+    // TODO: Fix non-deterministic bug where (very rarely) the below assertion fails with "expected [4] but found [1]"
+    assertEquals(
+        daVinciPushStatusSystemStore.getLargestUsedVersionNumber(),
+        systemStoreCurrVersionBeforeBeingDeleted + 1);
+
+    TestUtils.waitForNonDeterministicPushCompletion(
+        Version.composeKafkaTopic(daVinciPushStatusSystemStoreName, systemStoreCurrVersionBeforeBeingDeleted + 1),
+        parentControllerClient,
+        30,
+        TimeUnit.SECONDS);
+  }
+}

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/PushStatusStoreTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/PushStatusStoreTest.java
@@ -2,7 +2,6 @@ package com.linkedin.venice.endToEnd;
 
 import static com.linkedin.venice.ConfigKeys.CLIENT_SYSTEM_STORE_REPOSITORY_REFRESH_INTERVAL_SECONDS;
 import static com.linkedin.venice.ConfigKeys.CLIENT_USE_SYSTEM_STORE_REPOSITORY;
-import static com.linkedin.venice.ConfigKeys.CONTROLLER_AUTO_MATERIALIZE_DAVINCI_PUSH_STATUS_SYSTEM_STORE;
 import static com.linkedin.venice.ConfigKeys.PUSH_STATUS_STORE_ENABLED;
 import static com.linkedin.venice.ConfigKeys.SERVER_PROMOTION_TO_LEADER_REPLICA_DELAY_SECONDS;
 import static com.linkedin.venice.ConfigKeys.USE_PUSH_STATUS_STORE_FOR_INCREMENTAL_PUSH;
@@ -89,7 +88,6 @@ public class PushStatusStoreTest {
         d2Client,
         VeniceRouterWrapper.CLUSTER_DISCOVERY_D2_SERVICE_NAME,
         TimeUnit.MINUTES.toSeconds(10));
-    extraProperties.setProperty(CONTROLLER_AUTO_MATERIALIZE_DAVINCI_PUSH_STATUS_SYSTEM_STORE, String.valueOf(true));
   }
 
   @AfterClass

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/PushStatusStoreTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/PushStatusStoreTest.java
@@ -3,7 +3,6 @@ package com.linkedin.venice.endToEnd;
 import static com.linkedin.venice.ConfigKeys.CLIENT_SYSTEM_STORE_REPOSITORY_REFRESH_INTERVAL_SECONDS;
 import static com.linkedin.venice.ConfigKeys.CLIENT_USE_SYSTEM_STORE_REPOSITORY;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_AUTO_MATERIALIZE_DAVINCI_PUSH_STATUS_SYSTEM_STORE;
-import static com.linkedin.venice.ConfigKeys.CONTROLLER_AUTO_MATERIALIZE_META_SYSTEM_STORE;
 import static com.linkedin.venice.ConfigKeys.PUSH_STATUS_STORE_ENABLED;
 import static com.linkedin.venice.ConfigKeys.SERVER_PROMOTION_TO_LEADER_REPLICA_DELAY_SECONDS;
 import static com.linkedin.venice.ConfigKeys.USE_PUSH_STATUS_STORE_FOR_INCREMENTAL_PUSH;
@@ -16,7 +15,6 @@ import static com.linkedin.venice.utils.TestPushUtils.writeSimpleAvroFileWithInt
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
-import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 
 import com.linkedin.d2.balancer.D2Client;
@@ -28,10 +26,8 @@ import com.linkedin.venice.client.store.ClientConfig;
 import com.linkedin.venice.client.store.ClientFactory;
 import com.linkedin.venice.common.VeniceSystemStoreType;
 import com.linkedin.venice.controller.Admin;
-import com.linkedin.venice.controller.init.ClusterLeaderInitializationRoutine;
 import com.linkedin.venice.controllerapi.ControllerClient;
 import com.linkedin.venice.controllerapi.JobStatusQueryResponse;
-import com.linkedin.venice.controllerapi.NewStoreResponse;
 import com.linkedin.venice.controllerapi.UpdateStoreQueryParams;
 import com.linkedin.venice.controllerapi.VersionCreationResponse;
 import com.linkedin.venice.hadoop.VenicePushJob;
@@ -39,16 +35,12 @@ import com.linkedin.venice.integration.utils.D2TestUtils;
 import com.linkedin.venice.integration.utils.DaVinciTestContext;
 import com.linkedin.venice.integration.utils.ServiceFactory;
 import com.linkedin.venice.integration.utils.VeniceClusterWrapper;
-import com.linkedin.venice.integration.utils.VeniceControllerCreateOptions;
-import com.linkedin.venice.integration.utils.VeniceControllerWrapper;
 import com.linkedin.venice.integration.utils.VeniceRouterWrapper;
-import com.linkedin.venice.integration.utils.ZkServerWrapper;
 import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.pushmonitor.ExecutionStatus;
 import com.linkedin.venice.pushstatushelper.PushStatusStoreReader;
 import com.linkedin.venice.pushstatushelper.PushStatusStoreRecordDeleter;
-import com.linkedin.venice.serialization.avro.AvroProtocolDefinition;
 import com.linkedin.venice.utils.DataProviderUtils;
 import com.linkedin.venice.utils.PropertyBuilder;
 import com.linkedin.venice.utils.TestUtils;
@@ -80,8 +72,6 @@ public class PushStatusStoreTest {
   private D2Client d2Client;
   private PushStatusStoreReader reader;
   private String storeName;
-  private VeniceControllerWrapper parentController;
-  private ZkServerWrapper parentZkServer;
 
   @BeforeClass
   public void setUp() {
@@ -90,8 +80,6 @@ public class PushStatusStoreTest {
     // all tests in this class will be reading incremental push status from push status store
     extraProperties.setProperty(USE_PUSH_STATUS_STORE_FOR_INCREMENTAL_PUSH, String.valueOf(true));
 
-    // Need to set this up as test testParentControllerAutoMaterializeDaVinciPushStatusSystemStore will get stuck.
-    extraProperties.setProperty(CONTROLLER_AUTO_MATERIALIZE_META_SYSTEM_STORE, String.valueOf(false));
     Utils.thisIsLocalhost();
     cluster = ServiceFactory
         .getVeniceCluster(1, NUMBER_OF_SERVERS, 1, REPLICATION_FACTOR, 10000, false, false, extraProperties);
@@ -102,13 +90,6 @@ public class PushStatusStoreTest {
         VeniceRouterWrapper.CLUSTER_DISCOVERY_D2_SERVICE_NAME,
         TimeUnit.MINUTES.toSeconds(10));
     extraProperties.setProperty(CONTROLLER_AUTO_MATERIALIZE_DAVINCI_PUSH_STATUS_SYSTEM_STORE, String.valueOf(true));
-    parentZkServer = ServiceFactory.getZkServer();
-    parentController = ServiceFactory.getVeniceController(
-        new VeniceControllerCreateOptions.Builder(cluster.getClusterName(), cluster.getKafka())
-            .childControllers(cluster.getVeniceControllers().toArray(new VeniceControllerWrapper[0]))
-            .extraProperties(extraProperties)
-            .zkAddress(parentZkServer.getAddress())
-            .build());
   }
 
   @AfterClass
@@ -116,9 +97,7 @@ public class PushStatusStoreTest {
     Utils.closeQuietlyWithErrorLogged(reader);
     D2ClientUtils.shutdownClient(d2Client);
     Utils.closeQuietlyWithErrorLogged(controllerClient);
-    Utils.closeQuietlyWithErrorLogged(parentController);
     Utils.closeQuietlyWithErrorLogged(cluster);
-    Utils.closeQuietlyWithErrorLogged(parentZkServer);
   }
 
   @BeforeMethod
@@ -322,90 +301,6 @@ public class PushStatusStoreTest {
       TestUtils.waitForNonDeterministicAssertion(TEST_TIMEOUT_MS, TimeUnit.MILLISECONDS, () -> {
         assertEquals(reader.getPartitionStatus(storeName, 1, 0, Optional.empty()).size(), 0);
       });
-    }
-  }
-
-  @Test(timeOut = TEST_TIMEOUT_MS)
-  public void testParentControllerAutoMaterializeDaVinciPushStatusSystemStore() {
-    try (ControllerClient parentControllerClient =
-        new ControllerClient(cluster.getClusterName(), parentController.getControllerUrl())) {
-      String zkSharedDaVinciPushStatusSchemaStoreName =
-          AvroProtocolDefinition.PUSH_STATUS_SYSTEM_SCHEMA_STORE.getSystemStoreName();
-      TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, true, () -> {
-        Store readOnlyStore = parentController.getVeniceAdmin()
-            .getReadOnlyZKSharedSystemStoreRepository()
-            .getStore(zkSharedDaVinciPushStatusSchemaStoreName);
-        assertNotNull(
-            readOnlyStore,
-            "Store: " + zkSharedDaVinciPushStatusSchemaStoreName + " should be initialized by "
-                + ClusterLeaderInitializationRoutine.class.getSimpleName());
-        assertTrue(
-            readOnlyStore.isHybrid(),
-            "Store: " + zkSharedDaVinciPushStatusSchemaStoreName + " should be configured to hybrid");
-      });
-      String userStoreName = Utils.getUniqueString("new-user-store");
-      NewStoreResponse newStoreResponse =
-          parentControllerClient.createNewStore(userStoreName, "venice-test", DEFAULT_KEY_SCHEMA, "\"string\"");
-      assertFalse(newStoreResponse.isError(), "Unexpected new store creation failure");
-      String daVinciPushStatusSystemStoreName =
-          VeniceSystemStoreType.DAVINCI_PUSH_STATUS_STORE.getSystemStoreName(userStoreName);
-      TestUtils.waitForNonDeterministicPushCompletion(
-          Version.composeKafkaTopic(daVinciPushStatusSystemStoreName, 1),
-          parentControllerClient,
-          30,
-          TimeUnit.SECONDS);
-      Store daVinciPushStatusSystemStore =
-          parentController.getVeniceAdmin().getStore(cluster.getClusterName(), daVinciPushStatusSystemStoreName);
-      assertEquals(daVinciPushStatusSystemStore.getLargestUsedVersionNumber(), 1);
-
-      // Do empty pushes to increase the system store's version
-      final int emptyPushAttempt = 2;
-      for (int i = 0; i < emptyPushAttempt; i++) {
-        final int newVersion = parentController.getVeniceAdmin()
-            .incrementVersionIdempotent(
-                cluster.getClusterName(),
-                daVinciPushStatusSystemStoreName,
-                "push job ID placeholder " + i,
-                1,
-                1)
-            .getNumber();
-        parentController.getVeniceAdmin()
-            .writeEndOfPush(cluster.getClusterName(), daVinciPushStatusSystemStoreName, newVersion, true);
-        TestUtils.waitForNonDeterministicPushCompletion(
-            Version.composeKafkaTopic(daVinciPushStatusSystemStoreName, newVersion),
-            parentControllerClient,
-            30,
-            TimeUnit.SECONDS);
-      }
-      daVinciPushStatusSystemStore =
-          parentController.getVeniceAdmin().getStore(cluster.getClusterName(), daVinciPushStatusSystemStoreName);
-      final int systemStoreCurrVersionBeforeBeingDeleted = daVinciPushStatusSystemStore.getLargestUsedVersionNumber();
-      assertEquals(systemStoreCurrVersionBeforeBeingDeleted, 1 + emptyPushAttempt);
-
-      TestUtils.assertCommand(parentControllerClient.disableAndDeleteStore(userStoreName));
-      // Both the system store and user store should be gone at this point
-      assertNull(parentController.getVeniceAdmin().getStore(cluster.getClusterName(), userStoreName));
-      assertNull(
-          parentController.getVeniceAdmin().getStore(cluster.getClusterName(), daVinciPushStatusSystemStoreName));
-
-      // Create the same regular store again
-      TestUtils.assertCommand(
-          parentControllerClient.createNewStore(userStoreName, "venice-test", DEFAULT_KEY_SCHEMA, "\"string\""),
-          "Unexpected new store creation failure");
-
-      // The re-created/materialized per-user store system store should contain a continued version from its last life
-      daVinciPushStatusSystemStore =
-          parentController.getVeniceAdmin().getStore(cluster.getClusterName(), daVinciPushStatusSystemStoreName);
-      // TODO: Fix non-deterministic bug where (very rarely) the below assertion fails with "expected [4] but found [1]"
-      assertEquals(
-          daVinciPushStatusSystemStore.getLargestUsedVersionNumber(),
-          systemStoreCurrVersionBeforeBeingDeleted + 1);
-
-      TestUtils.waitForNonDeterministicPushCompletion(
-          Version.composeKafkaTopic(daVinciPushStatusSystemStoreName, systemStoreCurrVersionBeforeBeingDeleted + 1),
-          parentControllerClient,
-          30,
-          TimeUnit.SECONDS);
     }
   }
 


### PR DESCRIPTION
…Storetest

This test requires a multi colo setup (both parent and child controller with their own Kafka cluster). However, its current setup shares the same Kafka brokers between both parent and child. The consequence of such setup would be that during a store deletion, both parent and child need to first delete store's all version topics, update new store info in its meta_store_rt topic and then remove the meta_store_rt topic from their own Kafka cluster. Due to the shared Kafka cluster, when both parent and child perform the above operations in parallel, there has issues. When meta_store_rt topic is removed by one controller (parent or child), the second controller's Kafka producer have to wait infinitely to flush any date, while still holding a store level lock. Thus, it would block other operations to the same store and fails the test if enables CONTROLLER_AUTO_MATERIALIZE_META_SYSTEM_STORE.

To fix the issue, the test should instead use a multi colo setup where parent and child have their own individual Kafka cluster. This rb moves the test to an separate test file with a multi colo setup and removes the unnecessary disabling of CONTROLLER_AUTO_MATERIALIZE_META_SYSTEM_STORE.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
Internal CI test.

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.