### PR TITLE
[server] Add chunking aware support for A/A producer callback

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
@@ -1316,4 +1316,31 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
               Optional.of(new PutMetadata(getRmdProtocolVersionID(), updatedRmdBytes)));
     };
   }
+
+  protected LeaderProducerCallback createLeaderProducerCallback(
+      ConsumerRecord<KafkaKey, KafkaMessageEnvelope> consumerRecord,
+      PartitionConsumptionState partitionConsumptionState,
+      LeaderProducedRecordContext leaderProducedRecordContext,
+      int subPartition,
+      String kafkaUrl,
+      long beforeProcessingRecordTimestamp) {
+    int partition = consumerRecord.partition();
+    String leaderTopic = consumerRecord.topic();
+    return new LeaderProducerCallback(
+        this,
+        consumerRecord,
+        partitionConsumptionState,
+        leaderProducedRecordContext,
+        leaderTopic,
+        getKafkaVersionTopic(),
+        partition,
+        subPartition,
+        kafkaUrl,
+        getVersionedDIVStats(),
+        getVersionIngestionStats(),
+        getHostLevelIngestionStats(),
+        System.nanoTime(),
+        beforeProcessingRecordTimestamp,
+        true);
+  }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
@@ -603,7 +603,7 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
                 newCallback,
                 sourceTopicOffset,
                 VeniceWriter.APP_DEFAULT_LOGICAL_TS,
-                Optional.ofNullable(new PutMetadata(rmdProtocolVersionID, updatedRmdBytes)));
+                Optional.of(new PutMetadata(rmdProtocolVersionID, updatedRmdBytes)));
       };
 
       produceToLocalKafka(

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
@@ -33,10 +33,12 @@ import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.offsets.OffsetRecord;
 import com.linkedin.venice.schema.rmd.RmdUtils;
+import com.linkedin.venice.storage.protocol.ChunkedValueManifest;
 import com.linkedin.venice.utils.ByteUtils;
 import com.linkedin.venice.utils.LatencyUtils;
 import com.linkedin.venice.utils.Time;
 import com.linkedin.venice.utils.lazy.Lazy;
+import com.linkedin.venice.writer.ChunkAwareCallback;
 import com.linkedin.venice.writer.DeleteMetadata;
 import com.linkedin.venice.writer.PutMetadata;
 import com.linkedin.venice.writer.VeniceWriter;
@@ -55,7 +57,7 @@ import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.BooleanSupplier;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
-import org.apache.kafka.clients.producer.Callback;
+import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -583,29 +585,12 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
         // used to persist on disk after producing to Kafka.
         updatedKeyBytes = ChunkingUtils.KEY_WITH_CHUNKING_SUFFIX_SERIALIZER.serializeNonChunkedKey(key);
       }
-      ProduceToTopic produceToTopicFunction = (callback, sourceTopicOffset) -> {
-        final Callback newCallback = (recordMetadata, exception) -> {
-          if (mergeConflictResult.doesResultReuseInput()) {
-            // Restore the original header so this function is eventually idempotent as the original KME ByteBuffer
-            // will be recovered after producing the message to Kafka or if the production failing.
-            ByteUtils.prependIntHeaderToByteBuffer(
-                updatedValueBytes,
-                ByteUtils.getIntHeaderFromByteBuffer(updatedValueBytes),
-                true);
-          }
-          callback.onCompletion(recordMetadata, exception);
-        };
-        return veniceWriter.get()
-            .put(
-                key,
-                ByteUtils.extractByteArray(updatedValueBytes),
-                valueSchemaId,
-                newCallback,
-                sourceTopicOffset,
-                VeniceWriter.APP_DEFAULT_LOGICAL_TS,
-                Optional.of(new PutMetadata(rmdProtocolVersionID, updatedRmdBytes)));
-      };
-
+      ProduceToTopic produceToTopicFunction = getProduceToTopicFunction(
+          key,
+          updatedValueBytes,
+          updatedRmdBytes,
+          valueSchemaId,
+          mergeConflictResult.doesResultReuseInput());
       produceToLocalKafka(
           consumerRecord,
           partitionConsumptionState,
@@ -1281,6 +1266,54 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
           newSourceTopicName,
           sourceTopicPartition,
           upstreamOffset);
+    };
+  }
+
+  int getRmdProtocolVersionID() {
+    return rmdProtocolVersionID;
+  }
+
+  protected ProduceToTopic getProduceToTopicFunction(
+      byte[] key,
+      ByteBuffer updatedValueBytes,
+      ByteBuffer updatedRmdBytes,
+      int valueSchemaId,
+      boolean resultReuseInput) {
+    return (callback, sourceTopicOffset) -> {
+      final ChunkAwareCallback newCallback = new ChunkAwareCallback() {
+        @Override
+        public void setChunkingInfo(
+            byte[] key,
+            ByteBuffer[] valueChunks,
+            ChunkedValueManifest chunkedValueManifest,
+            ByteBuffer[] rmdChunks,
+            ChunkedValueManifest chunkedRmdManifest) {
+          ((ChunkAwareCallback) callback)
+              .setChunkingInfo(key, valueChunks, chunkedValueManifest, rmdChunks, chunkedRmdManifest);
+        }
+
+        @Override
+        public void onCompletion(RecordMetadata recordMetadata, Exception exception) {
+          if (resultReuseInput) {
+            // Restore the original header so this function is eventually idempotent as the original KME ByteBuffer
+            // will be recovered after producing the message to Kafka or if the production failing.
+            ByteUtils.prependIntHeaderToByteBuffer(
+                updatedValueBytes,
+                ByteUtils.getIntHeaderFromByteBuffer(updatedValueBytes),
+                true);
+          }
+          callback.onCompletion(recordMetadata, exception);
+        }
+      };
+      return getVeniceWriter().get()
+          .put(
+              key,
+              ByteUtils.extractByteArray(updatedValueBytes),
+              valueSchemaId,
+              newCallback,
+              sourceTopicOffset,
+              VeniceWriter.APP_DEFAULT_LOGICAL_TS,
+              Optional.of(new PutMetadata(getRmdProtocolVersionID(), updatedRmdBytes)));
     };
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -3044,7 +3044,8 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
         getVersionIngestionStats(),
         getHostLevelIngestionStats(),
         System.nanoTime(),
-        beforeProcessingRecordTimestamp);
+        beforeProcessingRecordTimestamp,
+        false);
   }
 
   protected Lazy<VeniceWriter<byte[], byte[], byte[]>> getVeniceWriter() {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -3034,16 +3034,20 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
         this,
         consumerRecord,
         partitionConsumptionState,
+        leaderProducedRecordContext,
         leaderTopic,
         getKafkaVersionTopic(),
         partition,
         subPartition,
         kafkaUrl,
         getVersionedDIVStats(),
-        leaderProducedRecordContext,
         getVersionIngestionStats(),
         getHostLevelIngestionStats(),
         System.nanoTime(),
         beforeProcessingRecordTimestamp);
+  }
+
+  protected Lazy<VeniceWriter<byte[], byte[], byte[]>> getVeniceWriter() {
+    return veniceWriter;
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderProducerCallback.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderProducerCallback.java
@@ -1,7 +1,7 @@
 package com.linkedin.davinci.kafka.consumer;
 
 import static com.linkedin.davinci.kafka.consumer.LeaderFollowerStateType.LEADER;
-import static com.linkedin.venice.writer.VeniceWriter.*;
+import static com.linkedin.venice.writer.VeniceWriter.VENICE_DEFAULT_TIMESTAMP_METADATA_VERSION_ID;
 
 import com.linkedin.davinci.stats.AggVersionedDIVStats;
 import com.linkedin.davinci.stats.AggVersionedIngestionStats;

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderProducerCallback.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderProducerCallback.java
@@ -1,6 +1,7 @@
 package com.linkedin.davinci.kafka.consumer;
 
 import static com.linkedin.davinci.kafka.consumer.LeaderFollowerStateType.LEADER;
+import static com.linkedin.venice.writer.VeniceWriter.*;
 
 import com.linkedin.davinci.stats.AggVersionedDIVStats;
 import com.linkedin.davinci.stats.AggVersionedIngestionStats;
@@ -29,6 +30,7 @@ class LeaderProducerCallback implements ChunkAwareCallback {
 
   protected static final ChunkedValueManifestSerializer CHUNKED_VALUE_MANIFEST_SERIALIZER =
       new ChunkedValueManifestSerializer(false);
+  private static final ByteBuffer EMPTY_BYTE_BUFFER = ByteBuffer.allocate(0);
 
   private final LeaderFollowerStoreIngestionTask ingestionTask;
   private final ConsumerRecord<KafkaKey, KafkaMessageEnvelope> sourceConsumerRecord;
@@ -175,8 +177,8 @@ class LeaderProducerCallback implements ChunkAwareCallback {
             chunkPut.putValue = chunkValue;
             chunkPut.schemaId = schemaId;
             if (hasReplicationMetadata) {
-              chunkPut.replicationMetadataPayload = ByteBuffer.allocate(0);
-              chunkPut.replicationMetadataVersionId = -1;
+              chunkPut.replicationMetadataPayload = EMPTY_BYTE_BUFFER;
+              chunkPut.replicationMetadataVersionId = VENICE_DEFAULT_TIMESTAMP_METADATA_VERSION_ID;
             }
 
             LeaderProducedRecordContext producedRecordForChunk =

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderProducerCallback.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderProducerCallback.java
@@ -46,7 +46,7 @@ class LeaderProducerCallback implements ChunkAwareCallback {
   private final HostLevelIngestionStats hostLevelIngestionStats;
   private final long produceTimeNs;
   private final long beforeProcessingRecordTimestamp;
-  private final boolean hasReplicationMetadata;
+  private final boolean isActiveActiveReplication;
 
   /**
    * The mutable fields below are determined by the {@link com.linkedin.venice.writer.VeniceWriter},
@@ -73,7 +73,8 @@ class LeaderProducerCallback implements ChunkAwareCallback {
       AggVersionedIngestionStats versionedStorageIngestionStats,
       HostLevelIngestionStats hostLevelIngestionStats,
       long produceTimeNs,
-      long beforeProcessingRecordTimestamp) {
+      long beforeProcessingRecordTimestamp,
+      boolean isActiveActiveReplication) {
     this.ingestionTask = ingestionTask;
     this.sourceConsumerRecord = sourceConsumerRecord;
     this.partitionConsumptionState = partitionConsumptionState;
@@ -88,7 +89,7 @@ class LeaderProducerCallback implements ChunkAwareCallback {
     this.versionedStorageIngestionStats = versionedStorageIngestionStats;
     this.hostLevelIngestionStats = hostLevelIngestionStats;
     this.beforeProcessingRecordTimestamp = beforeProcessingRecordTimestamp;
-    this.hasReplicationMetadata = ingestionTask instanceof ActiveActiveStoreIngestionTask;
+    this.isActiveActiveReplication = isActiveActiveReplication;
   }
 
   @Override
@@ -176,7 +177,7 @@ class LeaderProducerCallback implements ChunkAwareCallback {
             Put chunkPut = new Put();
             chunkPut.putValue = chunkValue;
             chunkPut.schemaId = schemaId;
-            if (hasReplicationMetadata) {
+            if (isActiveActiveReplication) {
               chunkPut.replicationMetadataPayload = EMPTY_BYTE_BUFFER;
               chunkPut.replicationMetadataVersionId = VENICE_DEFAULT_TIMESTAMP_METADATA_VERSION_ID;
             }
@@ -208,7 +209,7 @@ class LeaderProducerCallback implements ChunkAwareCallback {
           Put manifestPut = new Put();
           manifestPut.putValue = manifest;
           manifestPut.schemaId = schemaId;
-          if (hasReplicationMetadata) {
+          if (isActiveActiveReplication) {
             manifestPut.replicationMetadataVersionId =
                 ((Put) leaderProducedRecordContext.getValueUnion()).replicationMetadataVersionId;
             manifestPut.replicationMetadataPayload =

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -3735,4 +3735,20 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
   protected void setPartitionConsumptionState(int partition, PartitionConsumptionState pcs) {
     partitionConsumptionStateMap.put(partition, pcs);
   }
+
+  protected AggVersionedDIVStats getVersionedDIVStats() {
+    return versionedDIVStats;
+  }
+
+  protected AggVersionedIngestionStats getVersionIngestionStats() {
+    return versionedIngestionStats;
+  }
+
+  protected HostLevelIngestionStats getHostLevelIngestionStats() {
+    return hostLevelIngestionStats;
+  }
+
+  protected String getKafkaVersionTopic() {
+    return kafkaVersionTopic;
+  }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -91,6 +91,7 @@ import com.linkedin.venice.utils.Timer;
 import com.linkedin.venice.utils.VeniceProperties;
 import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
 import com.linkedin.venice.utils.lazy.Lazy;
+import com.linkedin.venice.writer.ChunkAwareCallback;
 import com.linkedin.venice.writer.LeaderMetadataWrapper;
 import it.unimi.dsi.fastutil.ints.IntList;
 import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
@@ -131,7 +132,6 @@ import java.util.function.Supplier;
 import org.apache.avro.Schema;
 import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
-import org.apache.kafka.clients.producer.Callback;
 import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.logging.log4j.LogManager;
@@ -3617,7 +3617,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
    */
   @FunctionalInterface
   interface ProduceToTopic {
-    Future<RecordMetadata> apply(Callback callback, LeaderMetadataWrapper leaderMetadataWrapper);
+    Future<RecordMetadata> apply(ChunkAwareCallback callback, LeaderMetadataWrapper leaderMetadataWrapper);
   }
 
   /**

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTaskTest.java
@@ -1,0 +1,187 @@
+package com.linkedin.davinci.kafka.consumer;
+
+import static com.linkedin.venice.writer.VeniceWriter.ENABLE_CHUNKING;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.atMost;
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.linkedin.davinci.stats.AggVersionedDIVStats;
+import com.linkedin.davinci.stats.AggVersionedIngestionStats;
+import com.linkedin.davinci.stats.HostLevelIngestionStats;
+import com.linkedin.davinci.storage.chunking.ChunkingUtils;
+import com.linkedin.venice.kafka.protocol.KafkaMessageEnvelope;
+import com.linkedin.venice.message.KafkaKey;
+import com.linkedin.venice.partitioner.DefaultVenicePartitioner;
+import com.linkedin.venice.serialization.VeniceKafkaSerializer;
+import com.linkedin.venice.serialization.avro.VeniceAvroKafkaSerializer;
+import com.linkedin.venice.utils.ByteUtils;
+import com.linkedin.venice.utils.SystemTime;
+import com.linkedin.venice.utils.VeniceProperties;
+import com.linkedin.venice.writer.KafkaProducerWrapper;
+import com.linkedin.venice.writer.PutMetadata;
+import com.linkedin.venice.writer.VeniceWriter;
+import com.linkedin.venice.writer.VeniceWriterOptions;
+import java.nio.ByteBuffer;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicLong;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.producer.Callback;
+import org.apache.kafka.clients.producer.RecordMetadata;
+import org.apache.logging.log4j.LogManager;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.testng.annotations.Test;
+
+
+public class ActiveActiveStoreIngestionTaskTest {
+  @Test
+  public void testLeaderCanSendValueChunksIntoDrainer()
+      throws ExecutionException, InterruptedException, TimeoutException {
+    String testTopic = "test";
+    ActiveActiveStoreIngestionTask ingestionTask = mock(ActiveActiveStoreIngestionTask.class);
+    when(ingestionTask.getHostLevelIngestionStats()).thenReturn(mock(HostLevelIngestionStats.class));
+    when(ingestionTask.getVersionIngestionStats()).thenReturn(mock(AggVersionedIngestionStats.class));
+    when(ingestionTask.getVersionedDIVStats()).thenReturn(mock(AggVersionedDIVStats.class));
+    when(ingestionTask.getKafkaVersionTopic()).thenReturn(testTopic);
+    LeaderProducerCallback mockLeaderProducerCallback = mock(LeaderProducerCallback.class);
+    when(ingestionTask.createLeaderProducerCallback(any(), any(), any(), anyInt(), anyString(), anyLong()))
+        .thenReturn(mockLeaderProducerCallback);
+    doCallRealMethod().when(ingestionTask)
+        .produceToLocalKafka(any(), any(), any(), any(), anyInt(), anyString(), anyInt(), anyLong());
+    byte[] key = "foo".getBytes();
+    byte[] updatedKeyBytes = ChunkingUtils.KEY_WITH_CHUNKING_SUFFIX_SERIALIZER.serializeNonChunkedKey(key);
+
+    KafkaProducerWrapper mockedProducer = mock(KafkaProducerWrapper.class);
+    Future mockedFuture = mock(Future.class);
+    when(mockedProducer.getNumberOfPartitions(any())).thenReturn(1);
+    when(mockedProducer.getNumberOfPartitions(any(), anyInt(), any())).thenReturn(1);
+    AtomicLong offset = new AtomicLong(0);
+    when(mockedProducer.sendMessage(anyString(), any(), any(), anyInt(), any())).thenAnswer(new Answer<Future>() {
+      @Override
+      public Future answer(InvocationOnMock invocation) throws Throwable {
+        KafkaKey kafkaKey = (KafkaKey) invocation.getArgument(1);
+        KafkaMessageEnvelope kafkaMessageEnvelope = (KafkaMessageEnvelope) invocation.getArgument(2);
+        Callback callback = (Callback) invocation.getArgument(4);
+        RecordMetadata recordMetadata = mock(RecordMetadata.class);
+        offset.addAndGet(1);
+        when(recordMetadata.offset()).thenReturn(offset.get());
+        when(recordMetadata.serializedKeySize()).thenReturn(kafkaKey.getKeyLength());
+        // when(recordMetadata.serializedValueSize()).thenReturn(((Put)(kafkaMessageEnvelope.payloadUnion)).putValue.remaining());
+        when(recordMetadata.serializedValueSize()).thenReturn(123);
+        LogManager.getLogger()
+            .info(
+                "DEBUGGING: GET CALLBACK: " + callback + " " + recordMetadata.offset() + " "
+                    + recordMetadata.serializedKeySize() + " " + recordMetadata.serializedValueSize());
+        callback.onCompletion(recordMetadata, null);
+        return mockedFuture;
+      }
+
+    });
+    Properties writerProperties = new Properties();
+    writerProperties.put(ENABLE_CHUNKING, true);
+
+    String stringSchema = "\"string\"";
+    VeniceKafkaSerializer serializer = new VeniceAvroKafkaSerializer(stringSchema);
+    VeniceWriterOptions veniceWriterOptions = new VeniceWriterOptions.Builder(testTopic)
+        // .setKeySerializer(serializer)
+        // .setValueSerializer(serializer)
+        // .setWriteComputeSerializer(serializer)
+        .setPartitioner(new DefaultVenicePartitioner())
+        .setTime(SystemTime.INSTANCE)
+        .build();
+    VeniceWriter<Object, Object, Object> writer =
+        new VeniceWriter(veniceWriterOptions, new VeniceProperties(writerProperties), () -> mockedProducer);
+
+    StringBuilder stringBuilder = new StringBuilder();
+    for (int i = 0; i < 50000; i++) {
+      stringBuilder.append("abcdefghabcdefghabcdefghabcdefgh");
+    }
+    int valueSchemaId = 1;
+    int rmdProtocolVersionID = 1;
+    boolean resultReuseInput = true;
+    String valueString = stringBuilder.toString();
+    byte[] valueBytes = valueString.getBytes();
+    byte[] schemaIdPrependedValueBytes = new byte[4 + valueBytes.length];
+    ByteUtils.writeInt(schemaIdPrependedValueBytes, 1, 0);
+    System.arraycopy(valueBytes, 0, schemaIdPrependedValueBytes, 4, valueBytes.length);
+    ByteBuffer updatedValueBytes = ByteBuffer.wrap(schemaIdPrependedValueBytes, 4, valueBytes.length);
+    ByteBuffer updatedRmdBytes = ByteBuffer.wrap(new byte[] { 0xa, 0xb });
+    PutMetadata putMetadata = new PutMetadata(1, updatedRmdBytes);
+
+    ConsumerRecord<KafkaKey, KafkaMessageEnvelope> consumerRecord = mock(ConsumerRecord.class);
+    PartitionConsumptionState partitionConsumptionState = mock(PartitionConsumptionState.class);
+    LeaderProducedRecordContext leaderProducedRecordContext = mock(LeaderProducedRecordContext.class);
+    StoreIngestionTask.ProduceToTopic produceFunction = getProduceFunction(
+        updatedKeyBytes,
+        updatedValueBytes,
+        updatedRmdBytes,
+        valueSchemaId,
+        rmdProtocolVersionID,
+        writer,
+        resultReuseInput);
+    int subPartition = 0;
+    String kafkaUrl = "kafkaUrl";
+    int kafkaClusterId = 0;
+    long beforeProcessingRecordTimestamp = 0;
+    ingestionTask.produceToLocalKafka(
+        consumerRecord,
+        partitionConsumptionState,
+        leaderProducedRecordContext,
+        produceFunction,
+        subPartition,
+        kafkaUrl,
+        kafkaClusterId,
+        beforeProcessingRecordTimestamp);
+
+    // Send 1 SOS, 2 Chunks, 1 Manifest.
+    verify(mockedProducer, atLeast(4)).sendMessage(eq(testTopic), any(), any(), anyInt(), any());
+    // Exactly once onCompletion call for manifest
+    verify(mockLeaderProducerCallback, atMost(1)).onCompletion(any(), any());
+    verify(mockLeaderProducerCallback, atLeast(1)).onCompletion(any(), any());
+    // No Chunking Manifest is set.
+    verify(mockLeaderProducerCallback, atMost(0)).setChunkingInfo(any(), any(), any(), any(), any());
+  }
+
+  public StoreIngestionTask.ProduceToTopic getProduceFunction(
+      byte[] updatedKeyBytes,
+      ByteBuffer updatedValueBytes,
+      ByteBuffer updatedRmdBytes,
+      int valueSchemaId,
+      int rmdProtocolVersionID,
+      VeniceWriter veniceWriter,
+      boolean resultReuseInput) {
+    return (callback, sourceTopicOffset) -> {
+      final Callback newCallback = (recordMetadata, exception) -> {
+        if (resultReuseInput) {
+          // Restore the original header so this function is eventually idempotent as the original KME ByteBuffer
+          // will be recovered after producing the message to Kafka or if the production failing.
+          ByteUtils.prependIntHeaderToByteBuffer(
+              updatedValueBytes,
+              ByteUtils.getIntHeaderFromByteBuffer(updatedValueBytes),
+              true);
+        }
+        callback.onCompletion(recordMetadata, exception);
+      };
+      return veniceWriter.put(
+          updatedKeyBytes,
+          ByteUtils.extractByteArray(updatedValueBytes),
+          valueSchemaId,
+          newCallback,
+          sourceTopicOffset,
+          VeniceWriter.APP_DEFAULT_LOGICAL_TS,
+          Optional.of(new PutMetadata(rmdProtocolVersionID, updatedRmdBytes)));
+    };
+  }
+}

--- a/internal/venice-common/src/main/java/com/linkedin/venice/writer/VeniceWriter.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/writer/VeniceWriter.java
@@ -682,7 +682,6 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
       putPayload.replicationMetadataVersionId = VENICE_DEFAULT_TIMESTAMP_METADATA_VERSION_ID;
       putPayload.replicationMetadataPayload = EMPTY_BYTE_BUFFER;
     }
-
     return sendMessage(
         producerMetadata -> kafkaKey,
         MessageType.PUT,
@@ -1052,7 +1051,6 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
         }
         segment.addToCheckSum(key, kafkaValue);
       }
-      LogManager.getLogger().info("DEBUGGING: INCOMING CALLBACK: " + callback);
       Callback messageCallback = callback;
       if (callback == null) {
         messageCallback = new KafkaMessageCallback(kafkaValue, logger);
@@ -1064,10 +1062,6 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
       }
 
       try {
-        LogManager.getLogger()
-            .info(
-                "DEBUGGING SENDING: " + producer + " " + topicName + " " + key + " " + partition + " "
-                    + messageCallback);
         return producer.sendMessage(topicName, key, kafkaValue, partition, messageCallback);
       } catch (Exception e) {
         if (ExceptionUtils.recursiveClassEquals(e, TopicAuthorizationException.class)) {
@@ -1112,10 +1106,6 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
     int replicationMetadataPayloadSize = putMetadata.map(PutMetadata::getSerializedSize).orElse(0);
     final Supplier<String> reportSizeGenerator =
         () -> getSizeReport(serializedKey.length, serializedValue.length, replicationMetadataPayloadSize);
-    LogManager.getLogger()
-        .info(
-            "DEBUGGING: PUT LARGE VALUE " + serializedKey.length + " " + serializedValue.length + " "
-                + replicationMetadataPayloadSize);
     ChunkedPayloadAndManifest valueChunksAndManifest = WriterChunkingHelper.chunkPayloadAndSend(
         serializedKey,
         serializedValue,

--- a/internal/venice-common/src/main/java/com/linkedin/venice/writer/VeniceWriter.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/writer/VeniceWriter.java
@@ -234,7 +234,7 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
 
   private boolean isRmdChunkingEnabled;
 
-  protected VeniceWriter(
+  public VeniceWriter(
       VeniceWriterOptions params,
       VeniceProperties props,
       Supplier<KafkaProducerWrapper> producerWrapperSupplier) {
@@ -1052,6 +1052,7 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
         }
         segment.addToCheckSum(key, kafkaValue);
       }
+      LogManager.getLogger().info("DEBUGGING: INCOMING CALLBACK: " + callback);
       Callback messageCallback = callback;
       if (callback == null) {
         messageCallback = new KafkaMessageCallback(kafkaValue, logger);
@@ -1063,6 +1064,10 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
       }
 
       try {
+        LogManager.getLogger()
+            .info(
+                "DEBUGGING SENDING: " + producer + " " + topicName + " " + key + " " + partition + " "
+                    + messageCallback);
         return producer.sendMessage(topicName, key, kafkaValue, partition, messageCallback);
       } catch (Exception e) {
         if (ExceptionUtils.recursiveClassEquals(e, TopicAuthorizationException.class)) {
@@ -1107,6 +1112,10 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
     int replicationMetadataPayloadSize = putMetadata.map(PutMetadata::getSerializedSize).orElse(0);
     final Supplier<String> reportSizeGenerator =
         () -> getSizeReport(serializedKey.length, serializedValue.length, replicationMetadataPayloadSize);
+    LogManager.getLogger()
+        .info(
+            "DEBUGGING: PUT LARGE VALUE " + serializedKey.length + " " + serializedValue.length + " "
+                + replicationMetadataPayloadSize);
     ChunkedPayloadAndManifest valueChunksAndManifest = WriterChunkingHelper.chunkPayloadAndSend(
         serializedKey,
         serializedValue,

--- a/internal/venice-common/src/main/java/com/linkedin/venice/writer/WriterChunkingHelper.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/writer/WriterChunkingHelper.java
@@ -18,6 +18,7 @@ import java.util.concurrent.Future;
 import java.util.function.BiFunction;
 import java.util.function.Supplier;
 import org.apache.kafka.clients.producer.RecordMetadata;
+import org.apache.logging.log4j.LogManager;
 
 
 /**
@@ -55,6 +56,7 @@ public class WriterChunkingHelper {
     chunkedValueManifest.schemaId = schemaId;
     chunkedValueManifest.keysWithChunkIdSuffix = new ArrayList<>(numberOfChunks);
     chunkedValueManifest.size = payload.length;
+    LogManager.getLogger().info("DEBUGGING: CHUNK COUNT: " + numberOfChunks);
 
     VeniceWriter.KeyProvider keyProvider, firstKeyProvider, subsequentKeyProvider;
     ByteBuffer[] chunks = null;

--- a/internal/venice-common/src/main/java/com/linkedin/venice/writer/WriterChunkingHelper.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/writer/WriterChunkingHelper.java
@@ -18,7 +18,6 @@ import java.util.concurrent.Future;
 import java.util.function.BiFunction;
 import java.util.function.Supplier;
 import org.apache.kafka.clients.producer.RecordMetadata;
-import org.apache.logging.log4j.LogManager;
 
 
 /**
@@ -56,7 +55,6 @@ public class WriterChunkingHelper {
     chunkedValueManifest.schemaId = schemaId;
     chunkedValueManifest.keysWithChunkIdSuffix = new ArrayList<>(numberOfChunks);
     chunkedValueManifest.size = payload.length;
-    LogManager.getLogger().info("DEBUGGING: CHUNK COUNT: " + numberOfChunks);
 
     VeniceWriter.KeyProvider keyProvider, firstKeyProvider, subsequentKeyProvider;
     ByteBuffer[] chunks = null;


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci], [server], [controller],
[router], [samza], [vpj], [fast-client], [thin-client], [alpini],
[admin-tool], [test], [build], [doc], [script]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## [server] Add chunking aware support for A/A producer callback
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

This PR fixes the issue that A/A producer callback does not implement ChunkAwareCallback interface. This results in all values will be stored in a single un-chunked value for leader node even if the value produced to VT and saved by follower is chunked. It makes RocksDB data not consistent between leader and follower.
This PR fixes the issue by letting the wrapper callback also implement the ChunkAwareCallback API and in the LeaderProducerCallback it also add support for RMD payload if A/A enabled.
Currently only one PROD store has this issue, we can re-push to create a new version with consistent state when this fix is deployed.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
Internal CI
Added a new unit test to capture the issue.

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.