### PR TITLE
[controller][test] Fix the error in getting largest used version numb…

### DIFF
--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/PushStatusStoreMultiColoTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/PushStatusStoreMultiColoTest.java
@@ -14,6 +14,7 @@ import static org.testng.Assert.assertTrue;
 import com.linkedin.d2.balancer.D2Client;
 import com.linkedin.venice.D2.D2ClientUtils;
 import com.linkedin.venice.common.VeniceSystemStoreType;
+import com.linkedin.venice.controller.Admin;
 import com.linkedin.venice.controller.init.ClusterLeaderInitializationRoutine;
 import com.linkedin.venice.controllerapi.ControllerClient;
 import com.linkedin.venice.controllerapi.NewStoreResponse;
@@ -43,7 +44,7 @@ import org.testng.annotations.Test;
 
 
 public class PushStatusStoreMultiColoTest {
-  private static final int TEST_TIMEOUT_MS = 60_000;
+  private static final int TEST_TIMEOUT_MS = 90_000;
   private static final int NUMBER_OF_SERVERS = 2;
   private static final int PARTITION_COUNT = 2;
   private static final int REPLICATION_FACTOR = 2;
@@ -199,6 +200,14 @@ public class PushStatusStoreMultiColoTest {
     // Both the system store and user store should be gone at this point
     assertNull(parentController.getVeniceAdmin().getStore(cluster.getClusterName(), userStoreName));
     assertNull(parentController.getVeniceAdmin().getStore(cluster.getClusterName(), daVinciPushStatusSystemStoreName));
+
+    Admin parentAdmin = parentControllers.get(0).getVeniceAdmin();
+    TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, true, () -> {
+      assertEquals(
+          parentAdmin
+              .getLargestUsedVersionFromStoreGraveyard(cluster.getClusterName(), daVinciPushStatusSystemStoreName),
+          systemStoreCurrVersionBeforeBeingDeleted);
+    });
 
     // Create the same regular store again
     TestUtils.assertCommand(

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/Admin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/Admin.java
@@ -825,7 +825,10 @@ public interface Admin extends AutoCloseable, Closeable {
 
   Map<String, StoreDataAudit> getClusterStaleStores(String clusterName);
 
-  int getStoreLargestUsedVersion(String clusterName, String storeName);
+  /**
+   * @return the largest used version number for the given store from store graveyard.
+   */
+  int getLargestUsedVersionFromStoreGraveyard(String clusterName, String storeName);
 
   Map<String, RegionPushDetails> listStorePushInfo(String clusterName, String storeName);
 

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/UserSystemStoreLifeCycleHelper.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/UserSystemStoreLifeCycleHelper.java
@@ -78,7 +78,7 @@ public class UserSystemStoreLifeCycleHelper {
       String systemStoreName = systemStoreType.getSystemStoreName(userStoreName);
       String pushJobId = AUTO_META_SYSTEM_STORE_PUSH_ID_PREFIX + System.currentTimeMillis();
       final int systemStoreLargestUsedVersionNumber =
-          parentAdmin.getStoreLargestUsedVersion(clusterName, systemStoreName);
+          parentAdmin.getLargestUsedVersionFromStoreGraveyard(clusterName, systemStoreName);
 
       int partitionCount =
           parentAdmin.calculateNumberOfPartitions(clusterName, systemStoreName, DEFAULT_META_SYSTEM_STORE_SIZE);

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -7294,15 +7294,11 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
   }
 
   /**
-   * @return the largest used version number by the given store.
+   * @return the largest used version number for the given store from store graveyard.
    */
   @Override
-  public int getStoreLargestUsedVersion(String clusterName, String storeName) {
-    if (hasStore(clusterName, storeName)) {
-      return getStore(clusterName, storeName).getLargestUsedVersionNumber();
-    } else {
-      return getStoreGraveyard().getLargestUsedVersionNumber(storeName);
-    }
+  public int getLargestUsedVersionFromStoreGraveyard(String clusterName, String storeName) {
+    return getStoreGraveyard().getLargestUsedVersionNumber(storeName);
   }
 
   /**

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
@@ -4441,18 +4441,13 @@ public class VeniceParentHelixAdmin implements Admin {
   }
 
   /**
-   * @return the largest used version number by the given store.
+   * @return the largest used version number for the given store from the store graveyard.
    */
   @Override
-  public int getStoreLargestUsedVersion(String clusterName, String storeName) {
+  public int getLargestUsedVersionFromStoreGraveyard(String clusterName, String storeName) {
     Map<String, ControllerClient> childControllers = getVeniceHelixAdmin().getControllerClientMap(clusterName);
-    int aggregatedLargestUsedVersionNumber;
-    if (hasStore(clusterName, storeName)) {
-      aggregatedLargestUsedVersionNumber = getStore(clusterName, storeName).getLargestUsedVersionNumber();
-    } else {
-      aggregatedLargestUsedVersionNumber =
-          getVeniceHelixAdmin().getStoreGraveyard().getLargestUsedVersionNumber(storeName);
-    }
+    int aggregatedLargestUsedVersionNumber =
+        getVeniceHelixAdmin().getStoreGraveyard().getLargestUsedVersionNumber(storeName);
     for (Map.Entry<String, ControllerClient> controller: childControllers.entrySet()) {
       VersionResponse response = controller.getValue().getStoreLargestUsedVersion(clusterName, storeName);
       if (response.getVersion() > aggregatedLargestUsedVersionNumber) {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/StoresRoutes.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/StoresRoutes.java
@@ -974,7 +974,7 @@ public class StoresRoutes extends AbstractRoute {
   }
 
   /**
-   * @see Admin#getStoreLargestUsedVersion(String, String)
+   * @see Admin#getLargestUsedVersionFromStoreGraveyard(String, String)
    */
   public Route getStoreLargestUsedVersion(Admin admin) {
     return new VeniceRouteHandler<VersionResponse>(VersionResponse.class) {
@@ -983,7 +983,7 @@ public class StoresRoutes extends AbstractRoute {
         AdminSparkServer.validateParams(request, GET_STORES_IN_CLUSTER.getParams(), admin);
         String cluster = request.queryParams(CLUSTER);
         String storeName = request.queryParams(NAME);
-        veniceResponse.setVersion(admin.getStoreLargestUsedVersion(cluster, storeName));
+        veniceResponse.setVersion(admin.getLargestUsedVersionFromStoreGraveyard(cluster, storeName));
       }
     };
   }


### PR DESCRIPTION
…er when recreating a per-user system store

When a store is deleted, put into the graveyard, and then recreated through a createStore API, it is expected to assign a version number to the system stores that is 1 more than the value retrieved from the graveyard. Today, for system stores, in function getStoreLargestUsedVersion, it checks if the regular store of such system stores has been created and only query store graveyard when it hasn't. This might have an issue because in the createStore workflow, regular store creation could happen before the query (or after it) if Admin execution task responds quickly (or slowly) and when the regular store is created, it doesn't ask store graveyard and wrong version number is returned.

This rb fixes the above issue by always querying the store graveyard for the largest used version number during createStore workflow. It also adds condition waitings in the related tests to make it more stable.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

Internal CI tests.

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.