### PR TITLE
[router][server][tc][fc][dvc] Compression optimizations

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -2555,7 +2555,7 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
     if (shouldCompressData(partitionConsumptionState)) {
       try {
         // We need to expand the front of the returned bytebuffer to make room for schema header insertion
-        return ByteUtils.enlargeByteBufferForIntHeader(ByteUtils.compressByteBuffer(data, compressor.get()));
+        return compressor.get().compress(data, ByteUtils.SIZE_OF_INT);
       } catch (IOException e) {
         // throw a loud exception if something goes wrong here
         throw new RuntimeException(

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -3216,9 +3216,11 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
         try {
           deserializeValue(put.schemaId, put.putValue, record);
         } catch (Exception e) {
+          PartitionConsumptionState pcs = partitionConsumptionStateMap.get(record.partition());
+          LeaderFollowerStateType state = pcs == null ? null : pcs.getLeaderFollowerState();
           throw new VeniceException(
               "Failed to deserialize PUT for topic: " + record.topic() + ", partition: " + record.partition()
-                  + ", offset: " + record.offset() + ", schema id: " + put.schemaId,
+                  + ", offset: " + record.offset() + ", schema id: " + put.schemaId + ", LF state: " + state,
               e);
         }
         break;

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/storage/chunking/AbstractAvroChunkingAdapter.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/storage/chunking/AbstractAvroChunkingAdapter.java
@@ -13,7 +13,6 @@ import com.linkedin.venice.partitioner.VenicePartitioner;
 import com.linkedin.venice.serializer.RecordDeserializer;
 import com.linkedin.venice.storage.protocol.ChunkedValueManifest;
 import com.linkedin.venice.utils.LatencyUtils;
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
@@ -345,19 +344,14 @@ public abstract class AbstractAvroChunkingAdapter<T> implements ChunkingAdapter<
 
   private final DecoderWrapper<byte[], T> decompressingByteArrayDecoder =
       (reusedDecoder, bytes, inputBytesLength, reusedValue, deserializer, readResponse, compressor) -> {
-        try (InputStream inputStream = new ByteArrayInputStream(
-            bytes,
-            ValueRecord.SCHEMA_HEADER_LENGTH,
-            inputBytesLength - ValueRecord.SCHEMA_HEADER_LENGTH)) {
-
-          return decompressingInputStreamDecoder.decode(
-              reusedDecoder,
-              inputStream,
-              inputBytesLength,
+        try {
+          return deserializer.deserialize(
               reusedValue,
-              deserializer,
-              readResponse,
-              compressor);
+              compressor.decompress(
+                  bytes,
+                  ValueRecord.SCHEMA_HEADER_LENGTH,
+                  inputBytesLength - ValueRecord.SCHEMA_HEADER_LENGTH),
+              reusedDecoder);
         } catch (IOException e) {
           throw new VeniceException(
               "Failed to decompress, compressionStrategy: " + compressor.getCompressionStrategy().name(),
@@ -369,10 +363,10 @@ public abstract class AbstractAvroChunkingAdapter<T> implements ChunkingAdapter<
       new InstrumentedDecoderWrapper<>(byteArrayDecoder);
 
   private final DecoderWrapper<byte[], T> instrumentedDecompressingByteArrayDecoder =
-      new InstrumentedDecoderWrapper(decompressingByteArrayDecoder);
+      new InstrumentedDecoderWrapper<>(decompressingByteArrayDecoder);
 
   private final DecoderWrapper<InputStream, T> instrumentedDecompressingInputStreamDecoder =
-      new InstrumentedDecoderWrapper(decompressingInputStreamDecoder);
+      new InstrumentedDecoderWrapper<>(decompressingInputStreamDecoder);
 
   private DecoderWrapper<byte[], T> getByteArrayDecoder(
       CompressionStrategy compressionStrategy,

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/compression/GzipCompressor.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/compression/GzipCompressor.java
@@ -28,18 +28,26 @@ public class GzipCompressor extends VeniceCompressor {
 
   @Override
   public ByteBuffer compress(ByteBuffer data, int startPositionOfOutput) throws IOException {
-    ByteArrayOutputStream bos = new ByteArrayOutputStream();
+    /**
+     * N.B.: We initialize the size of buffer in this output stream at the size of the deflated payload, which is not
+     * ideal, but not necessarily bad either. The assumption is that GZIP usually doesn't compress our payloads that
+     * much, maybe shaving off only 10-20%, and so the excess capacity in the buffer will only be this much. In return
+     * for the cost of this excess capacity, we maximize the chance that there will be no resizing/copy of the buffer.
+     * We say "maximize" and not "eliminate" because in certain cases GZIP can actually bloat the payload, and in those
+     * cases there would still be at least one copy.
+     */
+    ByteArrayOutputStream outputStream = new ZeroCopyByteArrayOutputStream(data.remaining());
     for (int i = 0; i < startPositionOfOutput; i++) {
-      bos.write(0);
+      outputStream.write(0);
     }
-    try (GZIPOutputStream gos = new GZIPOutputStream(bos)) {
+    try (GZIPOutputStream gos = new GZIPOutputStream(outputStream)) {
       if (data.hasArray()) {
         gos.write(data.array(), data.position(), data.remaining());
       } else {
         gos.write(ByteUtils.extractByteArray(data));
       }
       gos.finish();
-      ByteBuffer output = ByteBuffer.wrap(bos.toByteArray());
+      ByteBuffer output = ByteBuffer.wrap(outputStream.toByteArray(), 0, outputStream.size());
       output.position(startPositionOfOutput);
       return output;
     }
@@ -47,7 +55,17 @@ public class GzipCompressor extends VeniceCompressor {
 
   @Override
   public ByteBuffer decompress(ByteBuffer data) throws IOException {
-    return data.hasRemaining() ? decompress(data.array(), data.position(), data.remaining()) : data;
+    if (data.hasRemaining()) {
+      if (data.hasArray()) {
+        return decompress(data.array(), data.position(), data.remaining());
+      } else if (data.isDirect()) {
+        return decompress(ByteUtils.extractByteArray(data), 0, data.remaining());
+      } else {
+        throw new IllegalArgumentException("The passed in ByteBuffer must be either direct or be backed by an array!");
+      }
+    } else {
+      return data;
+    }
   }
 
   @Override
@@ -60,5 +78,16 @@ public class GzipCompressor extends VeniceCompressor {
   @Override
   public InputStream decompress(InputStream inputStream) throws IOException {
     return new GZIPInputStream(inputStream);
+  }
+
+  private static class ZeroCopyByteArrayOutputStream extends ByteArrayOutputStream {
+    public ZeroCopyByteArrayOutputStream(int size) {
+      super(size);
+    }
+
+    @Override
+    public synchronized byte[] toByteArray() {
+      return buf;
+    }
   }
 }

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/compression/NoopCompressor.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/compression/NoopCompressor.java
@@ -17,6 +17,9 @@ public class NoopCompressor extends VeniceCompressor {
 
   @Override
   public ByteBuffer compress(ByteBuffer data, int startPositionOfOutput) throws IOException {
+    if (startPositionOfOutput != 0) {
+      throw new UnsupportedOperationException("Compression with front padding is not supported for NO_OP.");
+    }
     return data;
   }
 

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/compression/NoopCompressor.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/compression/NoopCompressor.java
@@ -16,7 +16,7 @@ public class NoopCompressor extends VeniceCompressor {
   }
 
   @Override
-  public ByteBuffer compress(ByteBuffer data) throws IOException {
+  public ByteBuffer compress(ByteBuffer data, int startPositionOfOutput) throws IOException {
     return data;
   }
 

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/compression/VeniceCompressor.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/compression/VeniceCompressor.java
@@ -15,7 +15,7 @@ public abstract class VeniceCompressor implements Closeable {
 
   public abstract byte[] compress(byte[] data) throws IOException;
 
-  public abstract ByteBuffer compress(ByteBuffer data) throws IOException;
+  public abstract ByteBuffer compress(ByteBuffer src, int startPositionOfOutput) throws IOException;
 
   public abstract ByteBuffer decompress(ByteBuffer data) throws IOException;
 

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/compression/ZstdWithDictCompressor.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/compression/ZstdWithDictCompressor.java
@@ -3,14 +3,18 @@ package com.linkedin.venice.compression;
 import static com.linkedin.venice.utils.ByteUtils.BYTES_PER_KB;
 import static com.linkedin.venice.utils.ByteUtils.BYTES_PER_MB;
 
+import com.github.luben.zstd.Zstd;
 import com.github.luben.zstd.ZstdCompressCtx;
+import com.github.luben.zstd.ZstdDecompressCtx;
+import com.github.luben.zstd.ZstdDictCompress;
+import com.github.luben.zstd.ZstdDictDecompress;
 import com.github.luben.zstd.ZstdDictTrainer;
+import com.github.luben.zstd.ZstdException;
 import com.github.luben.zstd.ZstdInputStream;
 import com.linkedin.venice.compression.protocol.FakeCompressingSchema;
 import com.linkedin.venice.serializer.AvroSerializer;
-import com.linkedin.venice.utils.ByteUtils;
 import com.linkedin.venice.utils.concurrent.CloseableThreadLocal;
-import java.io.ByteArrayInputStream;
+import com.linkedin.venice.utils.lazy.Lazy;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
@@ -18,17 +22,21 @@ import java.util.ArrayList;
 import java.util.List;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
-import org.apache.commons.io.IOUtils;
 
 
 public class ZstdWithDictCompressor extends VeniceCompressor {
-  private CloseableThreadLocal<ZstdCompressCtx> compressor;
-  private byte[] dictionary;
+  private final CloseableThreadLocal<ZstdCompressCtx> compressor;
+  private final CloseableThreadLocal<ZstdDecompressCtx> decompressor;
+  private final Lazy<ZstdDictCompress> zstdDictCompress;
+  private final Lazy<ZstdDictDecompress> zstdDictDecompress;
 
   public ZstdWithDictCompressor(final byte[] dictionary, int level) {
     super(CompressionStrategy.ZSTD_WITH_DICT);
-    this.dictionary = dictionary;
-    compressor = new CloseableThreadLocal(() -> new ZstdCompressCtx().loadDict(dictionary).setLevel(level));
+    this.zstdDictCompress = Lazy.of(() -> new ZstdDictCompress(dictionary, level));
+    this.zstdDictDecompress = Lazy.of(() -> new ZstdDictDecompress(dictionary));
+    this.compressor =
+        new CloseableThreadLocal<>(() -> new ZstdCompressCtx().loadDict(zstdDictCompress.get()).setLevel(level));
+    this.decompressor = new CloseableThreadLocal<>(() -> new ZstdDecompressCtx().loadDict(zstdDictDecompress.get()));
   }
 
   @Override
@@ -37,38 +45,100 @@ public class ZstdWithDictCompressor extends VeniceCompressor {
   }
 
   @Override
-  public ByteBuffer compress(ByteBuffer data) {
+  public ByteBuffer compress(ByteBuffer data, int startPositionOfOutput) throws IOException {
+    long maxDstSize = Zstd.compressBound(data.remaining());
+    if (maxDstSize > Integer.MAX_VALUE) {
+      throw new ZstdException(Zstd.errGeneric(), "Max output size is greater than Integer.MAX_VALUE");
+    }
+    int sizeOfOutput = (int) maxDstSize + startPositionOfOutput;
     if (data.isDirect()) {
       // TODO: It might be a decent refactor to add a pool of direct memory buffers so as to always leverage the this
       // interface and copy the results of the compression back into the passed in ByteBuffer. That would avoid
       // some of the data copy going on here.
-      return compressor.get().compress(data);
+      ByteBuffer output = ByteBuffer.allocateDirect(sizeOfOutput);
+      output.position(startPositionOfOutput);
+      data.mark();
+      int size = compressor.get().compress(output, data);
+      output.position(startPositionOfOutput);
+      output.limit(startPositionOfOutput + size);
+      data.reset();
+      return output;
     } else {
-      return ByteBuffer.wrap(compressor.get().compress(ByteUtils.extractByteArray(data)));
+      byte[] dst = new byte[sizeOfOutput];
+      int size = compressor.get()
+          .compressByteArray(
+              dst,
+              startPositionOfOutput,
+              (int) maxDstSize,
+              data.array(),
+              data.position(),
+              data.remaining());
+      return ByteBuffer.wrap(dst, startPositionOfOutput, size);
     }
   }
 
   @Override
   public ByteBuffer decompress(ByteBuffer data) throws IOException {
-    return data.hasRemaining() ? decompress(data.array(), data.position(), data.remaining()) : data;
-  }
-
-  @Override
-  public ByteBuffer decompress(byte[] data, int offset, int length) throws IOException {
-    // TODO: Investigate using ZstdDirectBufferDecompressingStream instead of copying data.
-    try (InputStream zis = decompress(new ByteArrayInputStream(data, offset, length))) {
-      return ByteBuffer.wrap(IOUtils.toByteArray(zis));
+    if (data.hasRemaining()) {
+      if (data.isDirect()) {
+        int expectedSize = validateExpectedDecompressedSize(Zstd.decompressedSize(data));
+        ByteBuffer output = ByteBuffer.allocateDirect(expectedSize);
+        int actualSize = decompressor.get().decompress(output, data);
+        output.position(0);
+        validateActualDecompressedSize(actualSize, expectedSize);
+        return output;
+      } else {
+        return decompress(data.array(), data.position(), data.remaining());
+      }
+    } else {
+      return data;
     }
   }
 
   @Override
+  public ByteBuffer decompress(byte[] data, int offset, int length) throws IOException {
+    int expectedSize = validateExpectedDecompressedSize(Zstd.decompressedSize(data, offset, length));
+    ByteBuffer returnedData = ByteBuffer.allocate(expectedSize);
+    int actualSize = decompressor.get()
+        .decompressByteArray(
+            returnedData.array(),
+            returnedData.position(),
+            returnedData.remaining(),
+            data,
+            offset,
+            length);
+    validateActualDecompressedSize(actualSize, expectedSize);
+    returnedData.position(0);
+    return returnedData;
+  }
+
+  @Override
   public InputStream decompress(InputStream inputStream) throws IOException {
-    return new ZstdInputStream(inputStream).setDict(this.dictionary);
+    return new ZstdInputStream(inputStream).setDict(this.zstdDictDecompress.get());
   }
 
   @Override
   public void close() throws IOException {
-    compressor.close();
+    this.zstdDictCompress.ifPresent(ZstdDictCompress::close);
+    this.zstdDictDecompress.ifPresent(ZstdDictDecompress::close);
+    this.compressor.close();
+    this.decompressor.close();
+  }
+
+  private int validateExpectedDecompressedSize(long expectedSize) {
+    if (expectedSize == 0) {
+      throw new IllegalStateException("The size of the compressed payload cannot be known.");
+    } else if (expectedSize > Integer.MAX_VALUE) {
+      throw new IllegalStateException("The size of the compressed payload is > " + Integer.MAX_VALUE);
+    }
+    return (int) expectedSize;
+  }
+
+  private void validateActualDecompressedSize(int actual, int expected) {
+    if (actual != expected) {
+      throw new IllegalStateException(
+          "The decompressed payload size (" + actual + ") is not as expected (" + expected + ").");
+    }
   }
 
   /**
@@ -78,7 +148,7 @@ public class ZstdWithDictCompressor extends VeniceCompressor {
    * @return a zstd compression dictionary trained on small amount of avro data
    */
   public static byte[] buildDictionaryOnSyntheticAvroData() {
-    AvroSerializer serializer = new AvroSerializer<Object>(FakeCompressingSchema.getClassSchema());
+    AvroSerializer<Object> serializer = new AvroSerializer<>(FakeCompressingSchema.getClassSchema());
     // Insert fake records. We need to generate at least some data for the
     // dictionary as failing to do so will result in the library throwing
     // an exception (it's only able to generate a dictionary with a minimum threshold of test data).

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/utils/ByteUtils.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/utils/ByteUtils.java
@@ -1,8 +1,6 @@
 package com.linkedin.venice.utils;
 
-import com.linkedin.venice.compression.VeniceCompressor;
 import com.linkedin.venice.exceptions.VeniceException;
-import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.text.CharacterIterator;
 import java.text.StringCharacterIterator;
@@ -25,8 +23,6 @@ public class ByteUtils {
 
   public static final int SIZE_OF_BOOLEAN = 1;
 
-  private static final int MAX_LENGTH_TO_LOG = 50;
-
   /**
    * Translate the given byte array into a hexadecimal string
    *
@@ -44,25 +40,6 @@ public class ByteUtils {
     byte[] newBytes = new byte[len];
     System.arraycopy(bytes, start, newBytes, 0, len);
     return Hex.encodeHexString(newBytes);
-  }
-
-  /**
-   * Translate the given byte array to a String so that it can be used in logging.
-   * This function handles truncation of the String to prevent log from overflowing.
-   *
-   * @param bytes
-   * @return String
-   */
-  public static String toLogString(byte[] bytes) {
-    if (bytes == null) {
-      return "null";
-    }
-
-    String str = toHexString(bytes);
-    if (str.length() > MAX_LENGTH_TO_LOG) {
-      return str.substring(0, MAX_LENGTH_TO_LOG) + "...truncated";
-    }
-    return str;
   }
 
   /**
@@ -282,22 +259,6 @@ public class ByteUtils {
     enlargedByteBuffer.position(ByteUtils.SIZE_OF_INT);
     byteBuffer.position(originalPosition);
     return enlargedByteBuffer;
-  }
-
-  public static ByteBuffer compressByteBuffer(ByteBuffer originalBuffer, VeniceCompressor compressor)
-      throws IOException {
-
-    // TODO: ByteUtils.extractByteArray does an extra copy in some of the compressor compress implementations.
-    // We 'might' be able to avoid this in the future but unfortunately ZSTD compression requires direct memory buffers
-    // if you want to leverage the byte buffer interface to compress. A good refactor in the future might be to keep a
-    // pool of direct memory buffers and use them as a means to hold temporary copys of data like this for compression
-    // and avoid heap GC additionally, we're not always sure that the resulting compressed data is always smaller then
-    // the data we're compressing. This means we can't always rely on the original bytebuffer array to hold the
-    // resulting
-    // compressed data. To accommodate this, we'd have to make a copy of the compressed data in another byte array,
-    // check it's size, and then store or resize the buffer in the originalBuffer, which would negate any savings that
-    // might be had trying to squeeze the result back into the original array.
-    return compressor.compress(originalBuffer);
   }
 
   /**

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/compression/TestVeniceCompressor.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/compression/TestVeniceCompressor.java
@@ -24,96 +24,111 @@ public class TestVeniceCompressor {
   private static final Logger LOGGER = LogManager.getLogger(TestVeniceCompressor.class);
   private static final long TEST_TIMEOUT = 5 * Time.MS_PER_SECOND;
 
-  @DataProvider(name = "Stateless-Compressor")
-  public static Object[][] statelessCompressorProvider() {
-    return new Object[][] { { CompressionStrategy.NO_OP }, { CompressionStrategy.GZIP } };
+  @DataProvider(name = "Params")
+  public static Object[][] paramsProvider() {
+    return new Object[][] { { CompressionStrategy.NO_OP, SourceDataType.DIRECT_BYTE_BUFFER, 0 },
+        { CompressionStrategy.NO_OP, SourceDataType.NON_DIRECT_BYTE_BUFFER, 0 },
+        { CompressionStrategy.NO_OP, SourceDataType.BYTE_ARRAY, 0 },
+        { CompressionStrategy.GZIP, SourceDataType.DIRECT_BYTE_BUFFER, 0 },
+        { CompressionStrategy.GZIP, SourceDataType.NON_DIRECT_BYTE_BUFFER, 0 },
+        { CompressionStrategy.GZIP, SourceDataType.BYTE_ARRAY, 0 },
+        { CompressionStrategy.GZIP, SourceDataType.DIRECT_BYTE_BUFFER, ByteUtils.SIZE_OF_INT },
+        { CompressionStrategy.GZIP, SourceDataType.NON_DIRECT_BYTE_BUFFER, ByteUtils.SIZE_OF_INT },
+        { CompressionStrategy.GZIP, SourceDataType.BYTE_ARRAY, ByteUtils.SIZE_OF_INT },
+        { CompressionStrategy.ZSTD_WITH_DICT, SourceDataType.DIRECT_BYTE_BUFFER, 0 },
+        { CompressionStrategy.ZSTD_WITH_DICT, SourceDataType.NON_DIRECT_BYTE_BUFFER, 0 },
+        { CompressionStrategy.ZSTD_WITH_DICT, SourceDataType.BYTE_ARRAY, 0 },
+        { CompressionStrategy.ZSTD_WITH_DICT, SourceDataType.DIRECT_BYTE_BUFFER, ByteUtils.SIZE_OF_INT },
+        { CompressionStrategy.ZSTD_WITH_DICT, SourceDataType.NON_DIRECT_BYTE_BUFFER, ByteUtils.SIZE_OF_INT },
+        { CompressionStrategy.ZSTD_WITH_DICT, SourceDataType.BYTE_ARRAY, ByteUtils.SIZE_OF_INT } };
   }
 
-  @Test(timeOut = TEST_TIMEOUT)
-  public void testMultiThreadZstdCompression() throws IOException {
-    byte[] dictionary = ZstdWithDictCompressor.buildDictionaryOnSyntheticAvroData();
-    try (VeniceCompressor compressor =
-        new CompressorFactory().createCompressorWithDictionary(dictionary, Zstd.maxCompressionLevel())) {
-      runTests(compressor);
+  private VeniceCompressor getCompressor(CompressionStrategy strategy) {
+    switch (strategy) {
+      case ZSTD_WITH_DICT:
+        byte[] dictionary = ZstdWithDictCompressor.buildDictionaryOnSyntheticAvroData();
+        return new CompressorFactory().createCompressorWithDictionary(dictionary, Zstd.maxCompressionLevel());
+      default:
+        return new CompressorFactory().getCompressor(strategy);
     }
   }
 
-  @Test(dataProvider = "Stateless-Compressor", timeOut = TEST_TIMEOUT)
-  public void testMultiThreadCompression(CompressionStrategy compressionStrategy) throws IOException {
-    try (VeniceCompressor compressor = new CompressorFactory().getCompressor(compressionStrategy)) {
-      runTests(compressor);
-    }
-  }
-
-  private void runTests(VeniceCompressor compressor) {
-    runTestInternal(compressor, SourceDataType.DIRECT_BYTE_BUFFER);
-    runTestInternal(compressor, SourceDataType.NON_DIRECT_BYTE_BUFFER);
-    runTestInternal(compressor, SourceDataType.BYTE_ARRAY);
-  }
-
-  private void runTestInternal(VeniceCompressor compressor, SourceDataType type) {
-    int threadPoolSize = 1;
-    int numRunnables = 1000;
-    ExecutorService executorService = Executors.newFixedThreadPool(threadPoolSize);
-    List<Future> compressionFutures = new ArrayList<>(numRunnables);
-    try {
-      for (int i = 0; i < numRunnables; i++) {
-        Random rd = new Random();
-        byte[] data = new byte[50];
-        Runnable runnable = () -> {
-          rd.nextBytes(data);
-          try {
-            ByteBuffer dataBuffer;
-            ByteBuffer deflatedData;
-            ByteBuffer reinflatedData;
-            switch (type) {
-              case DIRECT_BYTE_BUFFER:
-                dataBuffer = ByteBuffer.allocateDirect(data.length);
-                dataBuffer.put(data);
-                dataBuffer.position(0);
-                deflatedData = compressor.compress(dataBuffer, ByteUtils.SIZE_OF_INT);
-                reinflatedData = compressor.decompress(deflatedData);
-                Assert.assertEquals(reinflatedData, dataBuffer);
-                break;
-              case NON_DIRECT_BYTE_BUFFER:
-                dataBuffer = ByteBuffer.wrap(data);
-                deflatedData = compressor.compress(dataBuffer, ByteUtils.SIZE_OF_INT);
-                reinflatedData = compressor.decompress(deflatedData);
-                Assert.assertEquals(reinflatedData, dataBuffer);
-                break;
-              case BYTE_ARRAY:
-                byte[] deflated = compressor.compress(data);
-                reinflatedData = compressor.decompress(deflated, 0, deflated.length);
-                Assert.assertEquals(reinflatedData.array(), data);
-                break;
-              default: // Defensive code
-                break;
-            }
-          } catch (Exception e) {
-            LOGGER.error(e);
-            throw new RuntimeException(e);
-          }
-        };
-        compressionFutures.add(executorService.submit(runnable));
-      }
-    } finally {
-      executorService.shutdown();
-    }
-
-    TestUtils.waitForNonDeterministicAssertion(10, TimeUnit.SECONDS, false, true, () -> {
+  @Test(dataProvider = "Params", timeOut = TEST_TIMEOUT)
+  private void runTestInternal(CompressionStrategy strategy, SourceDataType type, int frontPadding) throws IOException {
+    try (VeniceCompressor compressor = getCompressor(strategy)) {
+      int threadPoolSize = 16;
+      int numRunnables = 1024;
+      ExecutorService executorService = Executors.newFixedThreadPool(threadPoolSize);
+      List<Future> compressionFutures = new ArrayList<>(numRunnables);
       try {
-        executorService.awaitTermination(1, TimeUnit.SECONDS);
-      } catch (InterruptedException e) {
-        Assert.fail();
-      }
-    });
+        for (int i = 0; i < numRunnables; i++) {
+          Random rd = new Random();
+          Runnable runnable = () -> {
+            byte[] data = new byte[50];
+            rd.nextBytes(data);
+            try {
+              ByteBuffer dataBuffer;
+              ByteBuffer deflatedData;
+              ByteBuffer reinflatedData;
+              switch (type) {
+                case DIRECT_BYTE_BUFFER:
+                  dataBuffer = ByteBuffer.allocateDirect(data.length);
+                  dataBuffer.put(data);
+                  dataBuffer.position(0);
+                  deflatedData = compressor.compress(dataBuffer, frontPadding);
+                  reinflatedData = compressor.decompress(deflatedData);
+                  Assert.assertEquals(reinflatedData, dataBuffer);
 
-    try {
-      for (Future compressionFuture: compressionFutures) {
-        compressionFuture.get();
+                  if (!deflatedData.isDirect()) {
+                    // Decompressor implementations are allowed to return a non-direct BB, but we still want to test
+                    // that
+                    ByteBuffer directDeflatedData = ByteBuffer.allocateDirect(deflatedData.remaining());
+                    directDeflatedData.put(deflatedData);
+                    directDeflatedData.position(0);
+                    reinflatedData = compressor.decompress(directDeflatedData);
+                    Assert.assertEquals(reinflatedData, dataBuffer);
+                  }
+                  break;
+                case NON_DIRECT_BYTE_BUFFER:
+                  dataBuffer = ByteBuffer.wrap(data);
+                  deflatedData = compressor.compress(dataBuffer, frontPadding);
+                  reinflatedData = compressor.decompress(deflatedData);
+                  Assert.assertEquals(reinflatedData, dataBuffer);
+                  break;
+                case BYTE_ARRAY:
+                  byte[] deflated = compressor.compress(data);
+                  reinflatedData = compressor.decompress(deflated, 0, deflated.length);
+                  Assert.assertEquals(reinflatedData.array(), data);
+                  break;
+                default: // Defensive code
+                  break;
+              }
+            } catch (Exception e) {
+              LOGGER.error(e);
+              throw new RuntimeException(e);
+            }
+          };
+          compressionFutures.add(executorService.submit(runnable));
+        }
+      } finally {
+        executorService.shutdown();
       }
-    } catch (Throwable t) {
-      Assert.fail("Compression must succeed", t);
+
+      TestUtils.waitForNonDeterministicAssertion(10, TimeUnit.SECONDS, false, true, () -> {
+        try {
+          executorService.awaitTermination(1, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+          Assert.fail();
+        }
+      });
+
+      try {
+        for (Future compressionFuture: compressionFutures) {
+          compressionFuture.get();
+        }
+      } catch (Throwable t) {
+        Assert.fail("Compression must succeed", t);
+      }
     }
   }
 

--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -750,7 +750,6 @@ public class ConfigKeys {
   // TODO the config names are same as the names in application.src, some of them should be changed to keep consistent
   // TODO with controller and server.
   public static final String LISTENER_SSL_PORT = "listener.ssl.port";
-  public static final String CLIENT_TIMEOUT = "client.timeout";
   public static final String HEARTBEAT_TIMEOUT = "heartbeat.timeout";
   public static final String HEARTBEAT_CYCLE = "heartbeat.cycle";
   public static final String MAX_READ_CAPACITY = "max.read.capacity";
@@ -1754,16 +1753,6 @@ public class ConfigKeys {
    * Prefix of configs to configure Jetty server in Controller.
    */
   public static final String CONTROLLER_JETTY_CONFIG_OVERRIDE_PREFIX = "controller.jetty.";
-
-  /**
-   * The number of threads that will be used to decompress multi-get records in routers.
-   */
-  public static final String ROUTER_MULTI_KEY_DECOMPRESSION_THREADS = "router.multi.key.decompression.threads";
-
-  /**
-   * The number of records per batch of records that will be decompressed in a multi-get request in routers.
-   */
-  public static final String ROUTER_MULTI_KEY_DECOMPRESSION_BATCH_SIZE = "router.multi.key.decompression.batch.size";
 
   /**
    * The number of records

--- a/internal/venice-test-common/build.gradle
+++ b/internal/venice-test-common/build.gradle
@@ -74,6 +74,10 @@ dependencies {
 
 task jmh(type: JavaExec, dependsOn: jmhClasses) {
   main = 'org.openjdk.jmh.Main'
+
+  // In order to run just one test from the command line, specify it here, and run ./gradlew internal:venice-test-common:jmh
+  // main = 'com.linkedin.venice.benchmark.RouterDecompressionBenchmark'
+
   classpath = sourceSets.jmh.runtimeClasspath
 }
 

--- a/internal/venice-test-common/build.gradle
+++ b/internal/venice-test-common/build.gradle
@@ -76,7 +76,7 @@ task jmh(type: JavaExec, dependsOn: jmhClasses) {
   main = 'org.openjdk.jmh.Main'
 
   // In order to run just one test from the command line, specify it here, and run ./gradlew internal:venice-test-common:jmh
-  // main = 'com.linkedin.venice.benchmark.RouterDecompressionBenchmark'
+  // main = 'com.linkedin.venice.benchmark.ZstdDecompressionBenchmark'
 
   classpath = sourceSets.jmh.runtimeClasspath
 }

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/PartialUpdateTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/PartialUpdateTest.java
@@ -311,7 +311,7 @@ public class PartialUpdateTest {
         sendStreamingRecord(veniceProducer, storeName, key, value);
 
         // Verify the streaming record
-        TestUtils.waitForNonDeterministicAssertion(60, TimeUnit.SECONDS, () -> {
+        TestUtils.waitForNonDeterministicAssertion(60, TimeUnit.SECONDS, true, () -> {
           try {
             GenericRecord retrievedValue = readValue(storeReader, key);
             assertNotNull(retrievedValue, "Key " + key + " should not be missing!");
@@ -333,7 +333,7 @@ public class PartialUpdateTest {
 
         sendStreamingRecord(veniceProducer, storeName, key, partialUpdateRecord);
         // Verify the update
-        TestUtils.waitForNonDeterministicAssertion(60, TimeUnit.SECONDS, () -> {
+        TestUtils.waitForNonDeterministicAssertion(60, TimeUnit.SECONDS, true, () -> {
           try {
             GenericRecord retrievedValue = readValue(storeReader, key);
             assertNotNull(retrievedValue, "Key " + key + " should not be missing!");
@@ -368,7 +368,7 @@ public class PartialUpdateTest {
         // Delete the record
         sendStreamingRecord(veniceProducer, storeName, key, null);
         // Verify the delete
-        TestUtils.waitForNonDeterministicAssertion(60, TimeUnit.SECONDS, () -> {
+        TestUtils.waitForNonDeterministicAssertion(60, TimeUnit.SECONDS, true, () -> {
           try {
             GenericRecord retrievedValue = readValue(storeReader, key);
             assertNull(retrievedValue, "Key " + key + " should be missing!");
@@ -391,7 +391,7 @@ public class PartialUpdateTest {
 
         sendStreamingRecord(veniceProducer, storeName, key, partialUpdateRecord2);
         // Verify the update
-        TestUtils.waitForNonDeterministicAssertion(60, TimeUnit.SECONDS, () -> {
+        TestUtils.waitForNonDeterministicAssertion(60, TimeUnit.SECONDS, true, () -> {
           try {
             GenericRecord retrievedValue = readValue(storeReader, key);
             assertNotNull(retrievedValue, "Key " + key + " should not be missing!");
@@ -412,7 +412,7 @@ public class PartialUpdateTest {
         GenericRecord partialUpdateRecord3 = updateBuilder.build();
         sendStreamingRecord(veniceProducer, storeName, key, partialUpdateRecord3);
         // Verify the update
-        TestUtils.waitForNonDeterministicAssertion(60, TimeUnit.SECONDS, () -> {
+        TestUtils.waitForNonDeterministicAssertion(60, TimeUnit.SECONDS, true, () -> {
           try {
             GenericRecord retrievedValue = readValue(storeReader, key);
             assertNotNull(retrievedValue, "Key " + key + " should not be missing!");

--- a/internal/venice-test-common/src/jmh/java/com/linkedin/venice/benchmark/RouterDecompressionBenchmark.java
+++ b/internal/venice-test-common/src/jmh/java/com/linkedin/venice/benchmark/RouterDecompressionBenchmark.java
@@ -1,0 +1,92 @@
+package com.linkedin.venice.benchmark;
+
+import com.github.luben.zstd.Zstd;
+import com.github.luben.zstd.ZstdInputStream;
+import com.linkedin.venice.compression.CompressorFactory;
+import com.linkedin.venice.compression.VeniceCompressor;
+import com.linkedin.venice.compression.ZstdWithDictCompressor;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import org.apache.commons.io.IOUtils;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OperationsPerInvocation;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.profile.GCProfiler;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+
+@Fork(value = 2, jvmArgs = { "-Xms4G", "-Xmx4G" })
+@Warmup(iterations = 2)
+@Measurement(iterations = 5)
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+public class RouterDecompressionBenchmark {
+  private static final int NUMBER_OF_PAYLOADS = 10_000;
+  VeniceCompressor compressor;
+  ByteBuffer[] compressedPayloads;
+  byte[] dictionary;
+
+  @Setup
+  public void setUp() throws Exception {
+    this.dictionary = ZstdWithDictCompressor.buildDictionaryOnSyntheticAvroData();
+    this.compressor = new CompressorFactory().createCompressorWithDictionary(dictionary, Zstd.maxCompressionLevel());
+    this.compressedPayloads = new ByteBuffer[NUMBER_OF_PAYLOADS];
+    Random rd = new Random();
+    for (int i = 0; i < NUMBER_OF_PAYLOADS; i++) {
+      byte[] data = new byte[64 * 1024];
+      rd.nextBytes(data);
+      this.compressedPayloads[i] = compressor.compress(ByteBuffer.wrap(data), 0);
+    }
+  }
+
+  @Benchmark
+  @OperationsPerInvocation(NUMBER_OF_PAYLOADS)
+  public void measureDecompression(org.openjdk.jmh.infra.Blackhole bh) throws IOException {
+    ByteBuffer decompressed;
+    ByteBuffer compressed;
+    for (int i = 0; i < NUMBER_OF_PAYLOADS; i++) {
+      compressed = compressedPayloads[i];
+      decompressed = compressor.decompress(compressed);
+      bh.consume(decompressed);
+    }
+  }
+
+  @Benchmark
+  @OperationsPerInvocation(NUMBER_OF_PAYLOADS)
+  public void measureDecompressionWithDictionaryReload(org.openjdk.jmh.infra.Blackhole bh) throws IOException {
+    ByteBuffer decompressed;
+    ByteBuffer compressed;
+    for (int i = 0; i < NUMBER_OF_PAYLOADS; i++) {
+      compressed = compressedPayloads[i];
+      try (
+          InputStream bais =
+              new ByteArrayInputStream(compressed.array(), compressed.position(), compressed.remaining());
+          InputStream zis = new ZstdInputStream(bais).setDict(this.dictionary)) {
+        decompressed = ByteBuffer.wrap(IOUtils.toByteArray(zis));
+        bh.consume(decompressed);
+      }
+    }
+  }
+
+  public static void main(String[] args) throws Exception {
+    Options opt = new OptionsBuilder().include(RouterDecompressionBenchmark.class.getSimpleName())
+        .addProfiler(GCProfiler.class)
+        .build();
+    new Runner(opt).run();
+  }
+}

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/api/VenicePathParser.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/api/VenicePathParser.java
@@ -30,13 +30,10 @@ import com.linkedin.venice.router.stats.RouterStats;
 import com.linkedin.venice.router.streaming.VeniceChunkedWriteHandler;
 import com.linkedin.venice.router.utils.VeniceRouterUtils;
 import com.linkedin.venice.streaming.StreamingUtils;
-import com.linkedin.venice.utils.NamedThreadFactory;
 import io.netty.channel.ChannelHandlerContext;
 import java.util.Collection;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.apache.commons.lang.StringUtils;
@@ -92,8 +89,6 @@ public class VenicePathParser<HTTP_REQUEST extends BasicHttpRequest>
   private final ReadOnlyStoreRepository storeRepository;
   private final VeniceRouterConfig routerConfig;
   private final CompressorFactory compressorFactory;
-  private final ExecutorService decompressionExecutor;
-  private final int multiGetDecompressionBatchSize;
 
   public VenicePathParser(
       VeniceVersionFinder versionFinder,
@@ -108,10 +103,6 @@ public class VenicePathParser<HTTP_REQUEST extends BasicHttpRequest>
     this.storeRepository = storeRepository;
     this.routerConfig = routerConfig;
     this.compressorFactory = compressorFactory;
-    this.decompressionExecutor = Executors.newFixedThreadPool(
-        routerConfig.getRouterMultiGetDecompressionThreads(),
-        new NamedThreadFactory("multi-get-decompressor"));
-    this.multiGetDecompressionBatchSize = routerConfig.getRouterMultiGetDecompressionBatchSize();
   };
 
   @Override
@@ -237,9 +228,7 @@ public class VenicePathParser<HTTP_REQUEST extends BasicHttpRequest>
           fullHttpRequest,
           storeName,
           version,
-          compressorFactory,
-          decompressionExecutor,
-          multiGetDecompressionBatchSize);
+          compressorFactory);
       path.setResponseDecompressor(responseDecompressor);
 
       AggRouterHttpRequestStats stats = routerStats.getStatsByType(requestType);

--- a/services/venice-router/src/test/java/com/linkedin/venice/router/api/TestVeniceDispatcher.java
+++ b/services/venice-router/src/test/java/com/linkedin/venice/router/api/TestVeniceDispatcher.java
@@ -58,7 +58,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.Executor;
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 import org.apache.http.client.methods.HttpGet;
 import org.testng.Assert;
@@ -428,17 +427,9 @@ public class TestVeniceDispatcher {
       return modifyingCompressor;
     })).when(compressorFactory).getCompressor(any());
 
-    ExecutorService decompressionExecutor = mock(ExecutorService.class);
-    doReturn(
-        new VeniceResponseDecompressor(
-            true,
-            routerStats,
-            mockRequest,
-            "test_store",
-            1,
-            compressorFactory,
-            decompressionExecutor,
-            10)).when(mockPath).getResponseDecompressor();
+    doReturn(new VeniceResponseDecompressor(true, routerStats, mockRequest, "test_store", 1, compressorFactory))
+        .when(mockPath)
+        .getResponseDecompressor();
 
     AsyncPromise mockHostSelected = mock(AsyncPromise.class);
     AsyncPromise mockTimeoutFuture = mock(AsyncPromise.class);

--- a/services/venice-router/src/test/java/com/linkedin/venice/router/api/TestVenicePathParser.java
+++ b/services/venice-router/src/test/java/com/linkedin/venice/router/api/TestVenicePathParser.java
@@ -92,7 +92,6 @@ public class TestVenicePathParser {
                 requestType,
                 mock(ReadOnlyStoreRepository.class),
                 true)));
-    doReturn(10).when(MOCK_ROUTER_CONFIG).getRouterMultiGetDecompressionThreads();
   }
 
   @AfterClass

--- a/services/venice-router/src/test/java/com/linkedin/venice/router/api/TestVeniceResponseAggregator.java
+++ b/services/venice-router/src/test/java/com/linkedin/venice/router/api/TestVeniceResponseAggregator.java
@@ -47,7 +47,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 import org.apache.avro.Schema;
 import org.testng.Assert;
@@ -62,22 +61,13 @@ public class TestVeniceResponseAggregator {
       RequestType requestType,
       RouterStats routerStats,
       BasicFullHttpRequest request,
-      CompressorFactory compressorFactory,
-      ExecutorService decompressionExecutor) {
+      CompressorFactory compressorFactory) {
     VenicePath path = mock(VenicePath.class);
     doReturn(requestType).when(path).getRequestType();
     doReturn(storeName).when(path).getStoreName();
     doReturn(Optional.empty()).when(path).getChunkedResponse();
-    doReturn(
-        new VeniceResponseDecompressor(
-            false,
-            routerStats,
-            request,
-            storeName,
-            1,
-            compressorFactory,
-            decompressionExecutor,
-            10)).when(path).getResponseDecompressor();
+    doReturn(new VeniceResponseDecompressor(false, routerStats, request, storeName, 1, compressorFactory)).when(path)
+        .getResponseDecompressor();
     return path;
   }
 
@@ -102,11 +92,9 @@ public class TestVeniceResponseAggregator {
     when(mockRouterStat.getStatsByType(RequestType.COMPUTE)).thenReturn(mockStatsForCompute);
 
     CompressorFactory compressorFactory = mock(CompressorFactory.class);
-    ExecutorService decompressionExecutor = mock(ExecutorService.class);
 
     Metrics metrics = new Metrics();
-    metrics.setPath(
-        getPath(storeName, RequestType.SINGLE_GET, mockRouterStat, request, compressorFactory, decompressionExecutor));
+    metrics.setPath(getPath(storeName, RequestType.SINGLE_GET, mockRouterStat, request, compressorFactory));
 
     VeniceResponseAggregator responseAggregator = new VeniceResponseAggregator(mockRouterStat, Optional.empty());
     FullHttpResponse finalResponse = responseAggregator.buildResponse(request, metrics, gatheredResponses);
@@ -170,11 +158,9 @@ public class TestVeniceResponseAggregator {
     when(mockRouterStat.getStatsByType(RequestType.COMPUTE)).thenReturn(mockStatsForCompute);
 
     CompressorFactory compressorFactory = mock(CompressorFactory.class);
-    ExecutorService decompressionExecutor = mock(ExecutorService.class);
 
     Metrics metrics = new Metrics();
-    metrics.setPath(
-        getPath(storeName, RequestType.MULTI_GET, mockRouterStat, request, compressorFactory, decompressionExecutor));
+    metrics.setPath(getPath(storeName, RequestType.MULTI_GET, mockRouterStat, request, compressorFactory));
 
     VeniceResponseAggregator responseAggregator = new VeniceResponseAggregator(mockRouterStat, Optional.empty());
     FullHttpResponse finalResponse = responseAggregator.buildResponse(request, metrics, gatheredResponses);

--- a/services/venice-router/src/test/java/com/linkedin/venice/router/api/TestVeniceResponseDecompressor.java
+++ b/services/venice-router/src/test/java/com/linkedin/venice/router/api/TestVeniceResponseDecompressor.java
@@ -14,7 +14,6 @@ import io.netty.buffer.CompositeByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpVersion;
-import java.util.concurrent.ExecutorService;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -35,16 +34,8 @@ public class TestVeniceResponseDecompressor {
     request.headers().add(VENICE_SUPPORTED_COMPRESSION_STRATEGY, CompressionStrategy.GZIP.getValue());
 
     CompressorFactory compressorFactory = mock(CompressorFactory.class);
-    ExecutorService decompressionExecutor = mock(ExecutorService.class);
-    VeniceResponseDecompressor responseDecompressor = new VeniceResponseDecompressor(
-        true,
-        null,
-        request,
-        "test-store",
-        1,
-        compressorFactory,
-        decompressionExecutor,
-        10);
+    VeniceResponseDecompressor responseDecompressor =
+        new VeniceResponseDecompressor(true, null, request, "test-store", 1, compressorFactory);
 
     CompositeByteBuf content = Unpooled.compositeBuffer();
 
@@ -75,23 +66,14 @@ public class TestVeniceResponseDecompressor {
 
     RouterExceptionAndTrackingUtils.setRouterStats(routerStats);
 
-    ExecutorService decompressionExecutor = mock(ExecutorService.class);
-
     try (CompressorFactory compressorFactory = new CompressorFactory()) {
       compressorFactory.createVersionSpecificCompressorIfNotExist(
           CompressionStrategy.ZSTD_WITH_DICT,
           "test-store_v1",
           new byte[] {});
 
-      VeniceResponseDecompressor responseDecompressor = new VeniceResponseDecompressor(
-          true,
-          routerStats,
-          request,
-          "test-store",
-          1,
-          compressorFactory,
-          decompressionExecutor,
-          10);
+      VeniceResponseDecompressor responseDecompressor =
+          new VeniceResponseDecompressor(true, routerStats, request, "test-store", 1, compressorFactory);
 
       CompositeByteBuf content = Unpooled.compositeBuffer();
 
@@ -124,23 +106,14 @@ public class TestVeniceResponseDecompressor {
 
     RouterExceptionAndTrackingUtils.setRouterStats(routerStats);
 
-    ExecutorService decompressionExecutor = mock(ExecutorService.class);
-
     try (CompressorFactory compressorFactory = new CompressorFactory()) {
       compressorFactory.createVersionSpecificCompressorIfNotExist(
           CompressionStrategy.ZSTD_WITH_DICT,
           "test-store_v1",
           new byte[] {});
 
-      VeniceResponseDecompressor responseDecompressor = new VeniceResponseDecompressor(
-          true,
-          routerStats,
-          request,
-          "test-store",
-          1,
-          compressorFactory,
-          decompressionExecutor,
-          10);
+      VeniceResponseDecompressor responseDecompressor =
+          new VeniceResponseDecompressor(true, routerStats, request, "test-store", 1, compressorFactory);
       CompositeByteBuf content1 = Unpooled.compositeBuffer();
       ContentDecompressResult result =
           responseDecompressor.decompressMultiGetContent(CompressionStrategy.ZSTD_WITH_DICT, content1);


### PR DESCRIPTION
1. Zstd decompression used to reload the dictionary on every payload. This is now done upfront, via ZstdDictDecompress and via the use of a thread-local. A new JMH benchmark is added for this, which reveals the following results:
   - At 64 KB of decompressed payload: 
     - the decompression latency drops from 73 micros to 10 micros,
     - garbage generated from 329 KB to 65 KB.
   - At 500 B of decompressed payload:
     - the decompression latency drops from 31 micros to 387 nanos,
     - garbage generated from 141 KB to 568 B.

2. Zstd decompression also used to rely on an InputStream in all cases, which would result in the allocation and copy of many byte[] instances. Now, it instead directly instantiates the byte[] of the correct size and populates it (except in the case of chunked value decompression, which still relies on a stream). Hot paths affected by this change include decompression in the router, FC and server (RC and WC).

3. When leaders compress data to be written to the VT, each message now does 1 fewer ByteBuffer allocation and 2 fewer byte[] copies. This is achieved by tweaking the VeniceCompressor::compress API to take in the amount of front padding as an additional param, as well as eliminating one of the copies happening in the Zstd lib itself. Since leader compression was the only usage of this API, it seems appropriate to specialize it such that the complexity is pushed down behind the abstraction.

4. The AbstractAvroChunkingAdapter no longer needs to instantiate a ByteArrayInputStream per item to decompress/deserialize.

5. In the router, removed parallel decompression of batch gets. This eliminates many collection instantiation and copies. Also pulled the code to get the compressor out of the loop, thus reducing map lookups involved in Zstd decompression from 1 per record to 1 per query. Sequential decompression should be fast enough, given the optimizations 1 and 2 above. This eliminates a thread pool (of default size 10) in each router, as well as 2 configs:
   - router.multi.key.decompression.threads
   - router.multi.key.decompression.batch.size

6. In VeniceResponseDecompressor::decompressMultiGetContent, avoid instantiating a CompositeByteBuf in cases where it's unnecessary, and use an empty buffer or non-composite buffer otherwise.

Miscellaneous:

1. Improved GzipCompressor resource handling via try-with-resources.

2. Added the LF state to the debugging details when an exception is caught while compression is validated in LFSIT.

3. Zstd decompression now supports direct buffers as well.

4. Added testing for decompression in TestVeniceCompressor.

5. Eliminated unused config key: client.timeout

<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci], [server], [controller],
[router], [samza], [vpj], [fast-client], [thin-client], [alpini],
[admin-tool], [test], [build], [doc], [script]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Summary, imperative, start upper case, don't end with a period
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Resolves #XXX

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.