### PR TITLE
[server] Fix hanging isolated ingestion server issue caused by race condition in status reporting

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/HttpClientTransport.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/HttpClientTransport.java
@@ -30,7 +30,9 @@ public class HttpClientTransport implements AutoCloseable {
   private static final int DEFAULT_CONNECTION_TIMEOUT_MS = 30 * Time.MS_PER_SECOND;
   private static final int DEFAULT_SOCKET_TIMEOUT_MS = 30 * Time.MS_PER_SECOND;
   private static final int DEFAULT_REQUEST_TIMEOUT_MS = 60 * Time.MS_PER_SECOND;
-  private static final int DEFAULT_REQUEST_RETRY_WAIT_TIME_MS = 30 * Time.MS_PER_SECOND;
+  private static final int DEFAULT_REQUEST_RETRY_WAIT_TIME_MS = 1 * Time.MS_PER_SECOND;
+
+  private static final int DEFAULT_REQUEST_RETRY_COUNT = 10;
   private static final int DEFAULT_MAX_CONNECTION_PER_ROUTE = 2;
   private static final int DEFAULT_MAX_CONNECTION_TOTAL = 10;
   private static final int DEFAULT_IDLE_CONNECTION_CLEANUP_THRESHOLD_IN_MINUTES = 3 * Time.MINUTES_PER_HOUR;
@@ -111,7 +113,7 @@ public class HttpClientTransport implements AutoCloseable {
   }
 
   public <T extends SpecificRecordBase, S extends SpecificRecordBase> T sendRequest(IngestionAction action, S param) {
-    return sendRequestWithRetry(action, param, DEFAULT_REQUEST_TIMEOUT_MS, 1);
+    return sendRequestWithRetry(action, param, DEFAULT_REQUEST_TIMEOUT_MS, DEFAULT_REQUEST_RETRY_COUNT);
   }
 
   public <T extends SpecificRecordBase, S extends SpecificRecordBase> T sendRequestWithRetry(

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/isolated/IsolatedIngestionServer.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/isolated/IsolatedIngestionServer.java
@@ -369,7 +369,7 @@ public class IsolatedIngestionServer extends AbstractVeniceService {
       int partitionId = report.partitionId;
       long offset = report.offset;
 
-      // Collect offsetRecord array and store version state after consumption stops.
+      // Collect the latest OffsetRecord ByteBuffer array and store version state before consumption stops.
       if (ingestionReportType.equals(IngestionReportType.COMPLETED)) {
         // Set offset record in ingestion report.
         report.offsetRecordArray = getStoreIngestionService().getPartitionOffsetRecords(topicName, partitionId);

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionService.java
@@ -1112,10 +1112,11 @@ public class KafkaStoreIngestionService extends AbstractVeniceService implements
    */
   public List<ByteBuffer> getPartitionOffsetRecords(String topicName, int partition) {
     List<ByteBuffer> offsetRecordArray = new ArrayList<>();
-    int amplificationFactor = getStoreIngestionTask(topicName).getAmplificationFactor();
+    StoreIngestionTask storeIngestionTask = getStoreIngestionTask(topicName);
+    int amplificationFactor = storeIngestionTask.getAmplificationFactor();
     for (int i = 0; i < amplificationFactor; i++) {
       int subPartitionId = amplificationFactor * partition + i;
-      PartitionConsumptionState pcs = getStoreIngestionTask(topicName).getPartitionConsumptionState(subPartitionId);
+      PartitionConsumptionState pcs = storeIngestionTask.getPartitionConsumptionState(subPartitionId);
       offsetRecordArray.add(ByteBuffer.wrap(pcs.getOffsetRecord().toBytes()));
     }
     return offsetRecordArray;

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StatusReportAdapter.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StatusReportAdapter.java
@@ -14,14 +14,11 @@ import static com.linkedin.venice.pushmonitor.SubPartitionStatus.TOPIC_SWITCH_RE
 import com.linkedin.venice.exceptions.VeniceIngestionTaskKilledException;
 import com.linkedin.venice.pushmonitor.SubPartitionStatus;
 import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
-import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.logging.log4j.LogManager;
@@ -52,14 +49,6 @@ public class StatusReportAdapter {
    */
   public void initializePartitionReportStatus(int userPartition) {
     partitionReportStatus.put(userPartition, new PartitionReportStatus(userPartition));
-  }
-
-  /**
-   * This method retrieves a list of ByteBuffer serialized from OffsetRecord. These OffsetRecords contain the latest
-   * ingestion progress of all subPartitions inside the specified user partition.
-   */
-  public List<ByteBuffer> getOffsetRecordArray(int userPartition) {
-    return partitionReportStatus.get(userPartition).getOffsetRecordArray();
   }
 
   // This method is called when PartitionConsumptionState are not initialized
@@ -158,24 +147,12 @@ public class StatusReportAdapter {
    */
   class PartitionReportStatus {
     private final Map<String, AtomicInteger> statusRecordCounter = new VeniceConcurrentHashMap<>();
-    private final Map<String, Set<Integer>> statusRecordMap = new VeniceConcurrentHashMap<>();
+    private final Map<String, List<AtomicBoolean>> statusRecordMap = new VeniceConcurrentHashMap<>();
     private final Map<String, AtomicBoolean> statusReportMap = new VeniceConcurrentHashMap<>();
-    private final Map<Integer, ByteBuffer> partitionStateMap = new VeniceConcurrentHashMap<>();
     private final int userPartition;
 
     public PartitionReportStatus(int userPartition) {
       this.userPartition = userPartition;
-    }
-
-    /**
-     * Return the OffsetRecord array for all subPartitions.
-     */
-    public List<ByteBuffer> getOffsetRecordArray() {
-      List<ByteBuffer> offsetRecordArray = new ArrayList<>();
-      for (int i = 0; i < amplificationFactorAdapter.getAmplificationFactor(); i++) {
-        offsetRecordArray.add(partitionStateMap.get(i));
-      }
-      return offsetRecordArray;
     }
 
     /**
@@ -196,7 +173,13 @@ public class StatusReportAdapter {
       String versionAwareStatus = status.name() + (version.map(s -> "-" + s).orElse(""));
       statusRecordCounter.putIfAbsent(versionAwareStatus, new AtomicInteger(0));
       statusReportMap.putIfAbsent(versionAwareStatus, new AtomicBoolean(false));
-      statusRecordMap.putIfAbsent(versionAwareStatus, new HashSet<>());
+      statusRecordMap.computeIfAbsent(versionAwareStatus, v -> {
+        List<AtomicBoolean> list = new ArrayList<>();
+        for (int i = 0; i < amplificationFactor; i++) {
+          list.add(new AtomicBoolean(false));
+        }
+        return list;
+      });
 
       AtomicInteger counter = statusRecordCounter.get(versionAwareStatus);
       int updatedCount;
@@ -211,18 +194,12 @@ public class StatusReportAdapter {
         updatedCount = counter.addAndGet(amplificationFactor);
       } else {
         /**
-         * Once completed is reported, each subPartition should serialize its own {@link com.linkedin.venice.offsets.OffsetRecord}
-         * for main process to catch up the progress. This cannot be done by the thread that is reporting COMPLETED as
-         * other subpartitions might still be consuming records and updating offsets, thus the serialization call might
-         * lead to {@link java.util.ConcurrentModificationException} when ingestion isolation is enabled.
-         * Here it will let each subPartition to perform checkpoint and serialization on its own, so there won't be any
-         * conflict.
+         * Both the drainer thread and SIT thread can hit this path via ready-to-serve check. Adding this additional
+         * safeguard to avoid race condition.
          */
-        if (status.equals(COMPLETED)) {
-          ByteBuffer bb = ByteBuffer.wrap(partitionConsumptionState.getOffsetRecord().toBytes());
-          partitionStateMap.put(subPartitionIndex, bb);
-        }
-        if (!statusRecordMap.get(versionAwareStatus).contains(subPartitionIndex)) {
+        boolean updateResult =
+            statusRecordMap.get(versionAwareStatus).get(subPartitionIndex).compareAndSet(false, true);
+        if (updateResult) {
           if (logStatus) {
             LOGGER.info(
                 "{} reported from subPartition: {}, status report details: {}.",
@@ -231,32 +208,28 @@ public class StatusReportAdapter {
                 statusRecordMap.get(versionAwareStatus));
           }
           partitionConsumptionState.recordSubPartitionStatus(versionAwareStatus);
-          statusRecordMap.get(versionAwareStatus).add(subPartitionIndex);
-          updatedCount = counter.incrementAndGet();
-        } else {
-          updatedCount = counter.get();
         }
+        updatedCount = updateResult ? counter.incrementAndGet() : counter.get();
       }
-      maybeReportStatus(status, versionAwareStatus, updatedCount, report, logStatus);
+      if (updatedCount == amplificationFactor) {
+        maybeReportStatus(status, versionAwareStatus, report, logStatus);
+      }
     }
 
     private void maybeReportStatus(
         SubPartitionStatus status,
         String versionAwareStatus,
-        int updatedCount,
         Runnable report,
         boolean logStatus) {
-      if (updatedCount == amplificationFactorAdapter.getAmplificationFactor()) {
-        // This is a safeguard to make sure we only report exactly once for each status.
-        if (statusReportMap.get(versionAwareStatus).compareAndSet(false, true)) {
-          if (logStatus) {
-            LOGGER.info("Reporting status {} for user partition: {}.", versionAwareStatus, userPartition);
-          }
-          report.run();
-          if (status.equals(COMPLETED)) {
-            amplificationFactorAdapter
-                .executePartitionConsumptionState(userPartition, PartitionConsumptionState::completionReported);
-          }
+      // This is a safeguard to make sure we only report exactly once for each status.
+      if (statusReportMap.get(versionAwareStatus).compareAndSet(false, true)) {
+        if (logStatus) {
+          LOGGER.info("Reporting status {} for user partition: {}.", versionAwareStatus, userPartition);
+        }
+        report.run();
+        if (status.equals(COMPLETED)) {
+          amplificationFactorAdapter
+              .executePartitionConsumptionState(userPartition, PartitionConsumptionState::completionReported);
         }
       }
     }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/offsets/OffsetRecord.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/offsets/OffsetRecord.java
@@ -58,11 +58,11 @@ public class OffsetRecord {
     PartitionState emptyPartitionState = new PartitionState();
     emptyPartitionState.offset = LOWEST_OFFSET;
     emptyPartitionState.offsetLag = LOWEST_OFFSET_LAG;
-    emptyPartitionState.producerStates = new HashMap<>();
+    emptyPartitionState.producerStates = new VeniceConcurrentHashMap<>();
     emptyPartitionState.endOfPush = false;
     emptyPartitionState.lastUpdate = 0;
-    emptyPartitionState.databaseInfo = new HashMap<>();
-    emptyPartitionState.previousStatuses = new HashMap<>();
+    emptyPartitionState.databaseInfo = new VeniceConcurrentHashMap<>();
+    emptyPartitionState.previousStatuses = new VeniceConcurrentHashMap<>();
     emptyPartitionState.leaderOffset = DEFAULT_UPSTREAM_OFFSET;
     emptyPartitionState.upstreamOffsetMap = new VeniceConcurrentHashMap<>();
     emptyPartitionState.upstreamVersionTopicOffset = DEFAULT_UPSTREAM_OFFSET;

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestBatch.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestBatch.java
@@ -471,13 +471,6 @@ public abstract class TestBatch {
 
   @Test(timeOut = TEST_TIMEOUT)
   public void testIncrementalPushWritesToRealTimeTopicWithPolicy() throws Exception {
-    /**
-     * N.B. This test has some flaky issues where it occasionally times out... It seems to be specific to
-     *      the {@link TestBatchForIngestionIsolation} subclass, and manifests in the form of one of the
-     *      three push jobs below timing out. Adding some logs just to try to weed out the relevant
-     *      start/end boundaries in build logs since the CI seems to jumble them up sometimes, especially
-     *      when flaky retries are involved...
-     */
     double randomNumber = Math.random();
     String classAndFunctionName = getClass().getSimpleName() + ".testIncrementalPushWritesToRealTimeTopicWithPolicy()";
     String uniqueTestId = "attempt [" + randomNumber + "] of " + classAndFunctionName;


### PR DESCRIPTION
## [server] Fix hanging isolated ingestion server issue caused by race condition in status reporting

This PR fixes the CI build hanging issue in TestBatchForIngestionIsolation#cleanup() method.

The issue is caused by IsolatedIngestionServer failed to serialize COMPLETE report from forked process to main process and cause ingestion task to fail and test time out. (Most likely happening in testIncrementalPushWritesToRealTimeTopicWithPolicy() as it sets AMP=2 and increase the likelyhood). The root cause of the serailization failure is: ready-to-serve check and COMPLETE report of a same subPartition can actually be invoked from (1) Drainer thread who is processing the records of this subPartition (2) SIT thread checking long running task state (this was introduced long before to avoid the edge case that no data in RT topic and (1) will never be invoked to complete the ingestion). The race condition in StatusReportAdapter counter will lead to one OffsetRecord in user partition being null during serailization and failed.

This PR fixes the issue by introducing a AtomicBoolean state for each subPartition for each status. The status recording counter will only be incremented when the state is flipped from False -> True. Also, this PR fixes another hidden ConcurrentModificationException issue caused by serailization of the OffsetRecord by initialzing PartitionState with VeniceConcurrentHashMap for map field. This fix also simplies the OffsetRecord serailization logic during COMPLETE reporting.

This PR also make two minor adjustments for isolated ingestion progress reporting:
1. It adds default report retry count from 1 to 10 to make it resilient to any unforeseen transient error happening during IPC.
2. Lower down report retry interval from 30s to 1s as 30s is too long especially in test setup.

## How was this PR tested?
Internal CI running.
Run the specific test 100 times on Azure VM with JDK 8 setup and invoke setup() and cleanup() before/after each test.
1 run failed due to known Router resource unavailable issue and this failure won't block shutdown.

## Does this PR introduce any user-facing changes?
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.