### PR TITLE
[controller] Use storage quota to calculate partition number when store level partition count is not configured

### DIFF
--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -200,6 +200,14 @@ public class ConfigKeys {
   public static final String DEFAULT_NUMBER_OF_PARTITION_FOR_HYBRID = "default.partition.count.for.hybrid";
   public static final String DEFAULT_MAX_NUMBER_OF_PARTITIONS = "default.partition.max.count";
   public static final String DEFAULT_PARTITION_SIZE = "default.partition.size";
+  /**
+   * Whether to round up the version-level partition count calculated by storage quota. Default is false.
+   */
+  public static final String ENABLE_PARTITION_COUNT_ROUND_UP = "enable.partition.count.round.up";
+  /**
+   * If {@value ENABLE_PARTITION_COUNT_ROUND_UP} is enabled, this config defines the round up size. Default is 1.
+   */
+  public static final String PARTITION_COUNT_ROUND_UP_SIZE = "partition.count.round.up.size";
   public static final String OFFLINE_JOB_START_TIMEOUT_MS = "offline.job.start.timeout.ms";
   public static final String DELAY_TO_REBALANCE_MS = "delay.to.rebalance.ms";
   public static final String MIN_ACTIVE_REPLICA = "min.active.replica";

--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerClient.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerClient.java
@@ -286,6 +286,7 @@ public class ControllerClient implements Closeable {
       long rewindTimeInSecondsOverride,
       boolean deferVersionSwap) {
     QueryParams params = newParams().add(NAME, storeName)
+        // TODO: Store size is not used anymore. Remove it after the next round of controller deployment.
         .add(STORE_SIZE, Long.toString(storeSize))
         .add(PUSH_JOB_ID, pushJobId)
         .add(PUSH_TYPE, pushType.toString())
@@ -434,6 +435,7 @@ public class ControllerClient implements Closeable {
   }
 
   public VersionCreationResponse emptyPush(String storeName, String pushJobId, long storeSize) {
+    // TODO: Store size is not used anymore. Remove it after the next round of controller deployment.
     QueryParams params =
         newParams().add(NAME, storeName).add(PUSH_JOB_ID, pushJobId).add(STORE_SIZE, Long.toString(storeSize));
     return request(ControllerRoute.EMPTY_PUSH, params, VersionCreationResponse.class);

--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerRoute.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerRoute.java
@@ -74,7 +74,6 @@ import static com.linkedin.venice.controllerapi.ControllerApiConstants.SOURCE_FA
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.STATUS;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.STORAGE_NODE_ID;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.STORAGE_QUOTA_IN_BYTE;
-import static com.linkedin.venice.controllerapi.ControllerApiConstants.STORE_SIZE;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.STORE_TYPE;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.TOPIC;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.TOPIC_COMPACTION_POLICY;
@@ -91,15 +90,14 @@ import java.util.List;
 
 
 public enum ControllerRoute {
-  REQUEST_TOPIC(
-      "/request_topic", HttpMethod.POST, Arrays.asList(NAME, STORE_SIZE, PUSH_TYPE, PUSH_JOB_ID), PUSH_IN_SORTED_ORDER
-  ), // topic that writer should produce to
-  EMPTY_PUSH("/empty_push", HttpMethod.POST, Arrays.asList(NAME, STORE_SIZE, PUSH_JOB_ID)), // do an empty push into a
-                                                                                            // new version for this
-                                                                                            // store
-  END_OF_PUSH("/end_of_push", HttpMethod.POST, Arrays.asList(NAME, VERSION)), // write an END OF PUSH message into the
-                                                                              // topic
-  STORE("/store", HttpMethod.GET, Collections.singletonList(NAME)), // get all information about that store
+  // Request a topic that writer should produce to
+  REQUEST_TOPIC("/request_topic", HttpMethod.POST, Arrays.asList(NAME, PUSH_TYPE, PUSH_JOB_ID), PUSH_IN_SORTED_ORDER),
+  // Do an empty push into a new version for this store
+  EMPTY_PUSH("/empty_push", HttpMethod.POST, Arrays.asList(NAME, PUSH_JOB_ID)),
+  // Write an END_OF_PUSH message into the topic
+  END_OF_PUSH("/end_of_push", HttpMethod.POST, Arrays.asList(NAME, VERSION)),
+  // Get all information about that store
+  STORE("/store", HttpMethod.GET, Collections.singletonList(NAME)),
   NEW_STORE(
       "/new_store", HttpMethod.POST, Arrays.asList(NAME, KEY_SCHEMA, VALUE_SCHEMA), OWNER, IS_SYSTEM_STORE,
       ACCESS_PERMISSION
@@ -127,9 +125,8 @@ public enum ControllerRoute {
       PERSONA_NAME
   ), SET_VERSION("/set_version", HttpMethod.POST, Arrays.asList(NAME, VERSION)),
   ROLLBACK_TO_BACKUP_VERSION("/rollback_to_backup_version", HttpMethod.POST, Collections.singletonList(NAME)),
-  ENABLE_STORE("/enable_store", HttpMethod.POST, Arrays.asList(NAME, OPERATION, STATUS)), // status "true" or "false",
-                                                                                          // operation "read" or "write"
-                                                                                          // or "readwrite".
+  // Enable/disable read write for this store. Status is "true" or "false". Operation "read" or "write" or "readwrite".
+  ENABLE_STORE("/enable_store", HttpMethod.POST, Arrays.asList(NAME, OPERATION, STATUS)),
   DELETE_ALL_VERSIONS("/delete_all_versions", HttpMethod.POST, Collections.singletonList(NAME)),
   DELETE_OLD_VERSION("/delete_old_version", HttpMethod.POST, Arrays.asList(NAME, VERSION)),
   UPDATE_CLUSTER_CONFIG(

--- a/internal/venice-common/src/main/java/com/linkedin/venice/utils/PartitionUtils.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/utils/PartitionUtils.java
@@ -34,13 +34,19 @@ public class PartitionUtils {
       int storePartitionCount,
       long partitionSize,
       int minPartitionCount,
-      int maxPartitionCount) {
+      int maxPartitionCount,
+      boolean isRoundUpEnabled,
+      int roundUpSize) {
     if (storageQuota <= 0 && storageQuota != Store.UNLIMITED_STORAGE_QUOTA) {
       throw new VeniceException("Storage quota: " + storageQuota + " is invalid.");
     }
     if (storePartitionCount == 0) {
       // Store level partition count is not configured, calculate partition count
       long partitionCount = storageQuota / partitionSize;
+      if (isRoundUpEnabled) {
+        // Round upwards to the next multiple of roundUpSize
+        partitionCount = (partitionCount + roundUpSize - 1) / roundUpSize * roundUpSize;
+      }
       if (partitionCount > maxPartitionCount) {
         partitionCount = maxPartitionCount;
       } else if (partitionCount < minPartitionCount) {

--- a/internal/venice-common/src/main/java/com/linkedin/venice/utils/PartitionUtils.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/utils/PartitionUtils.java
@@ -5,6 +5,7 @@ import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.meta.PartitionerConfig;
 import com.linkedin.venice.meta.PartitionerConfigImpl;
 import com.linkedin.venice.meta.ReadOnlyStoreRepository;
+import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.partitioner.DefaultVenicePartitioner;
 import com.linkedin.venice.partitioner.UserPartitionAwarePartitioner;
@@ -24,41 +25,40 @@ public class PartitionUtils {
   private static final Logger LOGGER = LogManager.getLogger(PartitionUtils.class);
 
   /**
-   * Calculate partition count for new version. If the version is the first one of the given store,
-   * calculate the number by given store size and partition size. Otherwise, use the number from the current active
-   * version.
+   * Calculate partition count for new version. If store level partition count is not configured (0),
+   * calculate the number by storage quota and partition size. Otherwise, use the store level partition count.
    */
   public static int calculatePartitionCount(
       String storeName,
-      long storeSizeBytes,
-      int previousPartitionCount,
+      long storageQuota,
+      int storePartitionCount,
       long partitionSize,
       int minPartitionCount,
       int maxPartitionCount) {
-    if (storeSizeBytes <= 0) {
-      throw new VeniceException("Store size: " + storeSizeBytes + " is invalid.");
+    if (storageQuota <= 0 && storageQuota != Store.UNLIMITED_STORAGE_QUOTA) {
+      throw new VeniceException("Storage quota: " + storageQuota + " is invalid.");
     }
-    if (previousPartitionCount == 0) {
-      // First Version, calculate partition count
-      long partitionCount = storeSizeBytes / partitionSize;
+    if (storePartitionCount == 0) {
+      // Store level partition count is not configured, calculate partition count
+      long partitionCount = storageQuota / partitionSize;
       if (partitionCount > maxPartitionCount) {
         partitionCount = maxPartitionCount;
       } else if (partitionCount < minPartitionCount) {
         partitionCount = minPartitionCount;
       }
       LOGGER.info(
-          "Assign partition count: {} by given size: {} for the first version of store: {}",
+          "Assign partition count: {} calculated by storage quota: {} to the new version of store: {}",
           partitionCount,
-          storeSizeBytes,
+          storageQuota,
           storeName);
       return (int) partitionCount;
     } else {
-      // Active version exists, use the partition count calculated before.
+      // Store level partition count is configured, use the number
       LOGGER.info(
-          "Assign partition count: {}, which come from previous version, for store: {}",
-          previousPartitionCount,
+          "Assign partition count: {} from store level config to the new version of store: {}",
+          storePartitionCount,
           storeName);
-      return previousPartitionCount;
+      return storePartitionCount;
     }
   }
 

--- a/internal/venice-common/src/test/java/com/linkedin/venice/utils/TestPartitionUtils.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/utils/TestPartitionUtils.java
@@ -1,0 +1,26 @@
+package com.linkedin.venice.utils;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class TestPartitionUtils {
+  @Test
+  public void testCalculatePartitionCount() {
+    long storageQuota = 10;
+    long partitionSize = 10;
+    int minPartitionCount = 1;
+    int maxPartitionCount = 16;
+    int roundUpSize = 10;
+    int partitionCount = PartitionUtils.calculatePartitionCount(
+        "store",
+        storageQuota,
+        0,
+        partitionSize,
+        minPartitionCount,
+        maxPartitionCount,
+        true,
+        roundUpSize);
+    Assert.assertEquals(partitionCount, 10, "Partition count should round up to 10");
+  }
+}

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/controller/TestDelayedRebalance.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/controller/TestDelayedRebalance.java
@@ -219,7 +219,9 @@ public class TestDelayedRebalance {
     int partitionCount = 1;
 
     cluster.getNewStore(storeName);
-    cluster.updateStore(storeName, new UpdateStoreQueryParams().setStorageQuotaInByte(partitionCount * partitionSize));
+    cluster.updateStore(
+        storeName,
+        new UpdateStoreQueryParams().setStorageQuotaInByte((long) partitionCount * partitionSize));
     VersionCreationResponse response = cluster.getNewVersion(storeName);
     Assert.assertFalse(response.isError());
     String topicName = response.getKafkaTopic();

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/controller/TestDelayedRebalance.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/controller/TestDelayedRebalance.java
@@ -1,5 +1,6 @@
 package com.linkedin.venice.controller;
 
+import com.linkedin.venice.controllerapi.UpdateStoreQueryParams;
 import com.linkedin.venice.controllerapi.VersionCreationResponse;
 import com.linkedin.venice.integration.utils.ServiceFactory;
 import com.linkedin.venice.integration.utils.VeniceClusterCreateOptions;
@@ -216,10 +217,10 @@ public class TestDelayedRebalance {
   private String createVersionAndPushData() {
     String storeName = Utils.getUniqueString("TestDelayedRebalance");
     int partitionCount = 1;
-    int dataSize = partitionCount * partitionSize;
 
     cluster.getNewStore(storeName);
-    VersionCreationResponse response = cluster.getNewVersion(storeName, dataSize);
+    cluster.updateStore(storeName, new UpdateStoreQueryParams().setStorageQuotaInByte(partitionCount * partitionSize));
+    VersionCreationResponse response = cluster.getNewVersion(storeName);
     Assert.assertFalse(response.isError());
     String topicName = response.getKafkaTopic();
 

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/controller/TestIncrementalPush.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/controller/TestIncrementalPush.java
@@ -48,13 +48,16 @@ public class TestIncrementalPush {
   public void testGetOfflineStatusIncrementalPush() {
     String storeName = Utils.getUniqueString("testIncPushStore");
     int partitionCount = 2;
-    int dataSize = partitionCount * partitionSize;
+    long storageQuota = (long) partitionCount * partitionSize;
     cluster.getNewStore(storeName);
     UpdateStoreQueryParams params = new UpdateStoreQueryParams();
-    params.setIncrementalPushEnabled(true).setHybridRewindSeconds(1).setHybridOffsetLagThreshold(1);
+    params.setIncrementalPushEnabled(true)
+        .setHybridRewindSeconds(1)
+        .setHybridOffsetLagThreshold(1)
+        .setStorageQuotaInByte(storageQuota);
     cluster.updateStore(storeName, params);
 
-    VersionCreationResponse response = cluster.getNewVersion(storeName, dataSize);
+    VersionCreationResponse response = cluster.getNewVersion(storeName);
     Assert.assertFalse(response.isError());
     String topicName = response.getKafkaTopic();
     // push version 1 to completion
@@ -71,7 +74,7 @@ public class TestIncrementalPush {
     // set up store for inc push to rt
 
     cluster.updateStore(storeName, params);
-    response = cluster.getNewVersion(storeName, dataSize);
+    response = cluster.getNewVersion(storeName);
     topicName = response.getKafkaTopic();
 
     // broadcast to VT

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/controller/TestInstanceRemovable.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/controller/TestInstanceRemovable.java
@@ -1,6 +1,7 @@
 package com.linkedin.venice.controller;
 
 import com.linkedin.venice.controllerapi.ControllerClient;
+import com.linkedin.venice.controllerapi.UpdateStoreQueryParams;
 import com.linkedin.venice.controllerapi.VersionCreationResponse;
 import com.linkedin.venice.integration.utils.ServiceFactory;
 import com.linkedin.venice.integration.utils.VeniceClusterWrapper;
@@ -49,13 +50,14 @@ public class TestInstanceRemovable {
 
   @Test(timeOut = 120 * Time.MS_PER_SECOND)
   public void testIsInstanceRemovableDuringPush() {
-    String storeName = Utils.getUniqueString("testLeaderControllerFailover");
+    String storeName = Utils.getUniqueString("testIsInstanceRemovableDuringPush");
     int partitionCount = 2;
-    int dataSize = partitionCount * partitionSize;
+    long storageQuota = (long) partitionCount * partitionSize;
 
     cluster.getNewStore(storeName);
+    cluster.updateStore(storeName, new UpdateStoreQueryParams().setStorageQuotaInByte(storageQuota));
 
-    VersionCreationResponse response = cluster.getNewVersion(storeName, dataSize);
+    VersionCreationResponse response = cluster.getNewVersion(storeName);
     Assert.assertFalse(response.isError());
     String topicName = response.getKafkaTopic();
 
@@ -138,13 +140,14 @@ public class TestInstanceRemovable {
 
   @Test(timeOut = 60 * Time.MS_PER_SECOND)
   public void testIsInstanceRemovableAfterPush() {
-    String storeName = Utils.getUniqueString("testLeaderControllerFailover");
+    String storeName = Utils.getUniqueString("testIsInstanceRemovableAfterPush");
     int partitionCount = 2;
-    int dataSize = partitionCount * partitionSize;
+    long storageQuota = (long) partitionCount * partitionSize;
 
     cluster.getNewStore(storeName);
+    cluster.updateStore(storeName, new UpdateStoreQueryParams().setStorageQuotaInByte(storageQuota));
 
-    VersionCreationResponse response = cluster.getNewVersion(storeName, dataSize);
+    VersionCreationResponse response = cluster.getNewVersion(storeName);
     Assert.assertFalse(response.isError());
     String topicName = response.getKafkaTopic();
 

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/controller/server/TestAdminSparkWithMocks.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/controller/server/TestAdminSparkWithMocks.java
@@ -1,7 +1,6 @@
 package com.linkedin.venice.controller.server;
 
 import static org.mockito.Mockito.anyBoolean;
-import static org.mockito.Mockito.anyLong;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.eq;
@@ -72,7 +71,7 @@ public class TestAdminSparkWithMocks {
     doReturn(mockStore).when(admin).getStore(anyString(), anyString());
     doReturn(true).when(admin).isLeaderControllerFor(anyString());
     doReturn(1).when(admin).getReplicationFactor(anyString(), anyString());
-    doReturn(1).when(admin).calculateNumberOfPartitions(anyString(), anyString(), anyLong());
+    doReturn(1).when(admin).calculateNumberOfPartitions(anyString(), anyString());
     doReturn("kafka-bootstrap").when(admin).getKafkaBootstrapServers(anyBoolean());
     doReturn("store_rt").when(admin).getRealTimeTopic(anyString(), anyString());
     // Add a banned route not relevant to the test just to make sure theres coverage for unbanned routes still be
@@ -131,7 +130,7 @@ public class TestAdminSparkWithMocks {
     doReturn(mockStore).when(admin).getStore(anyString(), anyString());
     doReturn(true).when(admin).isLeaderControllerFor(anyString());
     doReturn(1).when(admin).getReplicationFactor(anyString(), anyString());
-    doReturn(1).when(admin).calculateNumberOfPartitions(anyString(), anyString(), anyLong());
+    doReturn(1).when(admin).calculateNumberOfPartitions(anyString(), anyString());
     doReturn("kafka-bootstrap").when(admin).getKafkaBootstrapServers(anyBoolean());
     doReturn("store_rt").when(admin).getRealTimeTopic(anyString(), anyString());
     AdminSparkServer server =
@@ -203,7 +202,7 @@ public class TestAdminSparkWithMocks {
     doReturn(true).when(admin).isParent();
     doReturn(true).when(admin).isLeaderControllerFor(anyString());
     doReturn(1).when(admin).getReplicationFactor(anyString(), anyString());
-    doReturn(1).when(admin).calculateNumberOfPartitions(anyString(), anyString(), anyLong());
+    doReturn(1).when(admin).calculateNumberOfPartitions(anyString(), anyString());
     doReturn(corpRegionKafka).when(admin).getKafkaBootstrapServers(anyBoolean());
     doReturn(true).when(admin).whetherEnableBatchPushFromAdmin(anyString());
     doReturn(true).when(admin).isActiveActiveReplicationEnabledInAllRegion(clusterName, storeName, false);
@@ -319,7 +318,7 @@ public class TestAdminSparkWithMocks {
     doReturn(mockStore).when(admin).getStore(anyString(), anyString());
     doReturn(true).when(admin).isLeaderControllerFor(anyString());
     doReturn(1).when(admin).getReplicationFactor(anyString(), anyString());
-    doReturn(1).when(admin).calculateNumberOfPartitions(anyString(), anyString(), anyLong());
+    doReturn(1).when(admin).calculateNumberOfPartitions(anyString(), anyString());
     doReturn("kafka-bootstrap").when(admin).getKafkaBootstrapServers(anyBoolean());
     doReturn("store_rt").when(admin).getRealTimeTopic(anyString(), anyString());
     doReturn(samzaPolicy).when(admin).isParent();

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/ActiveActiveReplicationForHybridTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/ActiveActiveReplicationForHybridTest.java
@@ -3,7 +3,6 @@ package com.linkedin.venice.endToEnd;
 import static com.linkedin.davinci.store.rocksdb.RocksDBServerConfig.ROCKSDB_PLAIN_TABLE_FORMAT_ENABLED;
 import static com.linkedin.venice.CommonConfigKeys.SSL_ENABLED;
 import static com.linkedin.venice.ConfigKeys.DATA_BASE_PATH;
-import static com.linkedin.venice.ConfigKeys.DEFAULT_MAX_NUMBER_OF_PARTITIONS;
 import static com.linkedin.venice.ConfigKeys.NATIVE_REPLICATION_SOURCE_FABRIC;
 import static com.linkedin.venice.ConfigKeys.PARENT_KAFKA_CLUSTER_FABRIC_LIST;
 import static com.linkedin.venice.ConfigKeys.PERSISTENCE_TYPE;
@@ -145,7 +144,6 @@ public class ActiveActiveReplicationForHybridTest {
     serverProperties.put(SERVER_KAFKA_PRODUCER_POOL_SIZE_PER_KAFKA_CLUSTER, "2");
 
     Properties controllerProps = new Properties();
-    controllerProps.put(DEFAULT_MAX_NUMBER_OF_PARTITIONS, 1000);
     controllerProps.put(NATIVE_REPLICATION_SOURCE_FABRIC, "dc-0");
     controllerProps.put(PARENT_KAFKA_CLUSTER_FABRIC_LIST, DEFAULT_PARENT_DATA_CENTER_REGION_NAME);
     multiRegionMultiClusterWrapper = ServiceFactory.getVeniceTwoLayerMultiRegionMultiClusterWrapper(

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/DaVinciClientTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/DaVinciClientTest.java
@@ -355,7 +355,7 @@ public class DaVinciClientTest {
         throw new VeniceException(response.getError());
       }
     });
-    VersionCreationResponse newVersion = cluster.getNewVersion(storeName, 1024);
+    VersionCreationResponse newVersion = cluster.getNewVersion(storeName);
     final int pushVersion = newVersion.getVersion();
     String topic = newVersion.getKafkaTopic();
     VeniceWriterFactory vwFactory = TestUtils.getVeniceWriterFactory(cluster.getKafka().getAddress());
@@ -739,7 +739,7 @@ public class DaVinciClientTest {
       client.subscribeAll().get();
     }
 
-    VersionCreationResponse newVersion = cluster.getNewVersion(storeName, 1024);
+    VersionCreationResponse newVersion = cluster.getNewVersion(storeName);
     String topic = newVersion.getKafkaTopic();
     VeniceWriterFactory vwFactory = TestUtils.getVeniceWriterFactory(cluster.getKafka().getAddress());
     VeniceKafkaSerializer keySerializer = new VeniceAvroKafkaSerializer(DEFAULT_KEY_SCHEMA);

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/DaVinciComputeTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/DaVinciComputeTest.java
@@ -178,7 +178,7 @@ public class DaVinciComputeTest {
       TestUtils.createMetaSystemStore(client, storeName, Optional.of(LOGGER));
     });
 
-    VersionCreationResponse newVersion = cluster.getNewVersion(storeName, 1024);
+    VersionCreationResponse newVersion = cluster.getNewVersion(storeName);
     String topic = newVersion.getKafkaTopic();
     VeniceWriterFactory vwFactory = TestUtils.getVeniceWriterFactory(cluster.getKafka().getAddress());
 
@@ -284,7 +284,7 @@ public class DaVinciComputeTest {
       TestUtils.createMetaSystemStore(client, storeName, Optional.of(LOGGER));
     });
 
-    VersionCreationResponse newVersion = cluster.getNewVersion(storeName, 1024);
+    VersionCreationResponse newVersion = cluster.getNewVersion(storeName);
     String topic = newVersion.getKafkaTopic();
     VeniceWriterFactory vwFactory = TestUtils.getVeniceWriterFactory(cluster.getKafka().getAddress());
 
@@ -357,7 +357,7 @@ public class DaVinciComputeTest {
         clientMissingField -> TestUtils
             .assertCommand(clientMissingField.addValueSchema(storeName, VALUE_SCHEMA_FOR_COMPUTE_MISSING_FIELD)));
 
-    VersionCreationResponse newVersionMissingField = cluster.getNewVersion(storeName, 1024);
+    VersionCreationResponse newVersionMissingField = cluster.getNewVersion(storeName);
     String topicForMissingField = newVersionMissingField.getKafkaTopic();
 
     DaVinciTestContext<Integer, Integer> daVinciTestContext2 =
@@ -417,7 +417,7 @@ public class DaVinciComputeTest {
       TestUtils.createMetaSystemStore(client, storeName, Optional.of(LOGGER));
     });
 
-    VersionCreationResponse newVersion = cluster.getNewVersion(storeName, 1024);
+    VersionCreationResponse newVersion = cluster.getNewVersion(storeName);
     String topic = newVersion.getKafkaTopic();
     VeniceWriterFactory vwFactory = TestUtils.getVeniceWriterFactory(cluster.getKafka().getAddress());
 
@@ -478,7 +478,7 @@ public class DaVinciComputeTest {
         clientMissingField -> TestUtils
             .assertCommand(clientMissingField.addValueSchema(storeName, VALUE_SCHEMA_FOR_COMPUTE_MISSING_FIELD)));
 
-    VersionCreationResponse newVersionMissingField = cluster.getNewVersion(storeName, 1024);
+    VersionCreationResponse newVersionMissingField = cluster.getNewVersion(storeName);
     String topicForMissingField = newVersionMissingField.getKafkaTopic();
 
     DaVinciTestContext<Integer, Integer> daVinciTestContext2 =
@@ -530,7 +530,7 @@ public class DaVinciComputeTest {
       TestUtils.createMetaSystemStore(client, storeName, Optional.of(LOGGER));
     });
 
-    VersionCreationResponse newVersion = cluster.getNewVersion(storeName, 1024);
+    VersionCreationResponse newVersion = cluster.getNewVersion(storeName);
     String topic = newVersion.getKafkaTopic();
     VeniceWriterFactory vwFactory = TestUtils.getVeniceWriterFactory(cluster.getKafka().getAddress());
 
@@ -629,7 +629,7 @@ public class DaVinciComputeTest {
       TestUtils.createMetaSystemStore(client, storeName, Optional.of(LOGGER));
     });
 
-    VersionCreationResponse newVersion = cluster.getNewVersion(storeName, 1024);
+    VersionCreationResponse newVersion = cluster.getNewVersion(storeName);
     String topic = newVersion.getKafkaTopic();
     VeniceWriterFactory vwFactory = TestUtils.getVeniceWriterFactory(cluster.getKafka().getAddress());
 
@@ -730,7 +730,7 @@ public class DaVinciComputeTest {
       TestUtils.createMetaSystemStore(client, storeName, Optional.of(LOGGER));
     });
 
-    VersionCreationResponse newVersion = cluster.getNewVersion(storeName, 1024);
+    VersionCreationResponse newVersion = cluster.getNewVersion(storeName);
     String topic = newVersion.getKafkaTopic();
     VeniceWriterFactory vwFactory = TestUtils.getVeniceWriterFactory(cluster.getKafka().getAddress());
 

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/DaVinciLiveUpdateSuppressionTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/DaVinciLiveUpdateSuppressionTest.java
@@ -105,7 +105,7 @@ public class DaVinciLiveUpdateSuppressionTest {
           new UpdateStoreQueryParams().setHybridRewindSeconds(10).setHybridOffsetLagThreshold(10));
     });
 
-    VersionCreationResponse newVersion = cluster.getNewVersion(storeName, 1024);
+    VersionCreationResponse newVersion = cluster.getNewVersion(storeName);
     String topic = newVersion.getKafkaTopic();
     VeniceWriterFactory vwFactory = TestUtils.getVeniceWriterFactory(cluster.getKafka().getAddress());
     VeniceKafkaSerializer keySerializer = new VeniceAvroKafkaSerializer(DEFAULT_KEY_SCHEMA);

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/DataRecoveryTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/DataRecoveryTest.java
@@ -3,7 +3,6 @@ package com.linkedin.venice.endToEnd;
 import static com.linkedin.davinci.store.rocksdb.RocksDBServerConfig.ROCKSDB_PLAIN_TABLE_FORMAT_ENABLED;
 import static com.linkedin.venice.CommonConfigKeys.SSL_ENABLED;
 import static com.linkedin.venice.ConfigKeys.ALLOW_CLUSTER_WIPE;
-import static com.linkedin.venice.ConfigKeys.DEFAULT_MAX_NUMBER_OF_PARTITIONS;
 import static com.linkedin.venice.ConfigKeys.MIN_NUMBER_OF_UNUSED_KAFKA_TOPICS_TO_PRESERVE;
 import static com.linkedin.venice.ConfigKeys.NATIVE_REPLICATION_SOURCE_FABRIC;
 import static com.linkedin.venice.ConfigKeys.PARENT_KAFKA_CLUSTER_FABRIC_LIST;
@@ -89,7 +88,6 @@ public class DataRecoveryTest {
     serverProperties.put(SERVER_KAFKA_PRODUCER_POOL_SIZE_PER_KAFKA_CLUSTER, "2");
 
     Properties controllerProps = new Properties();
-    controllerProps.put(DEFAULT_MAX_NUMBER_OF_PARTITIONS, 1000);
     controllerProps.put(NATIVE_REPLICATION_SOURCE_FABRIC, DEFAULT_PARENT_DATA_CENTER_REGION_NAME);
     controllerProps.put(PARENT_KAFKA_CLUSTER_FABRIC_LIST, DEFAULT_PARENT_DATA_CENTER_REGION_NAME);
     controllerProps.put(ALLOW_CLUSTER_WIPE, "true");

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestActiveActiveReplicationForIncPush.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestActiveActiveReplicationForIncPush.java
@@ -2,7 +2,6 @@ package com.linkedin.venice.endToEnd;
 
 import static com.linkedin.davinci.store.rocksdb.RocksDBServerConfig.ROCKSDB_PLAIN_TABLE_FORMAT_ENABLED;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_AUTO_MATERIALIZE_DAVINCI_PUSH_STATUS_SYSTEM_STORE;
-import static com.linkedin.venice.ConfigKeys.DEFAULT_MAX_NUMBER_OF_PARTITIONS;
 import static com.linkedin.venice.ConfigKeys.SERVER_DATABASE_CHECKSUM_VERIFICATION_ENABLED;
 import static com.linkedin.venice.ConfigKeys.SERVER_DATABASE_SYNC_BYTES_INTERNAL_FOR_DEFERRED_WRITE_MODE;
 import static com.linkedin.venice.ConfigKeys.SERVER_KAFKA_PRODUCER_POOL_SIZE_PER_KAFKA_CLUSTER;
@@ -74,7 +73,6 @@ public class TestActiveActiveReplicationForIncPush {
     serverProperties.put(SERVER_KAFKA_PRODUCER_POOL_SIZE_PER_KAFKA_CLUSTER, "1");
 
     Properties controllerProps = new Properties();
-    controllerProps.put(DEFAULT_MAX_NUMBER_OF_PARTITIONS, 1000);
     controllerProps.put(CONTROLLER_AUTO_MATERIALIZE_DAVINCI_PUSH_STATUS_SYSTEM_STORE, "true");
 
     multiRegionMultiClusterWrapper = ServiceFactory.getVeniceTwoLayerMultiRegionMultiClusterWrapper(

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestActiveActiveReplicationWithDownRegion.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestActiveActiveReplicationWithDownRegion.java
@@ -1,7 +1,6 @@
 package com.linkedin.venice.endToEnd;
 
 import static com.linkedin.davinci.store.rocksdb.RocksDBServerConfig.ROCKSDB_PLAIN_TABLE_FORMAT_ENABLED;
-import static com.linkedin.venice.ConfigKeys.DEFAULT_MAX_NUMBER_OF_PARTITIONS;
 import static com.linkedin.venice.ConfigKeys.KAFKA_ADMIN_GET_TOPIC_CONFIG_MAX_RETRY_TIME_SEC;
 import static com.linkedin.venice.ConfigKeys.NATIVE_REPLICATION_SOURCE_FABRIC;
 import static com.linkedin.venice.ConfigKeys.PARENT_KAFKA_CLUSTER_FABRIC_LIST;
@@ -90,7 +89,6 @@ public class TestActiveActiveReplicationWithDownRegion {
 
     Properties controllerProps = new Properties();
     controllerProps.put(KAFKA_ADMIN_GET_TOPIC_CONFIG_MAX_RETRY_TIME_SEC, 10L);
-    controllerProps.put(DEFAULT_MAX_NUMBER_OF_PARTITIONS, 1000);
     controllerProps.put(NATIVE_REPLICATION_SOURCE_FABRIC, "dc-0");
     controllerProps.put(PARENT_KAFKA_CLUSTER_FABRIC_LIST, DEFAULT_PARENT_DATA_CENTER_REGION_NAME);
 

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestBatch.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestBatch.java
@@ -385,7 +385,7 @@ public abstract class TestBatch {
         },
         validator,
         storeName,
-        new UpdateStoreQueryParams().setCompressionStrategy(CompressionStrategy.ZSTD_WITH_DICT));
+        new UpdateStoreQueryParams().setCompressionStrategy(CompressionStrategy.ZSTD_WITH_DICT).setPartitionCount(3));
     // Collect the dict of the current version.
     String sourceTopic = Version.composeKafkaTopic(storeName, 2);
     Properties props = new Properties();

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestLeaderReplicaFailover.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestLeaderReplicaFailover.java
@@ -109,7 +109,12 @@ public class TestLeaderReplicaFailover {
         DEFAULT_OFFLINE_PUSH_STRATEGY,
         OfflinePushStrategy.WAIT_N_MINUS_ONE_REPLCIA_PER_PARTITION.toString());
     String keySchemaStr = recordSchema.getField(VenicePushJob.DEFAULT_KEY_FIELD_PROP).schema().toString();
-    createStoreForJob(clusterName, keySchemaStr, valueSchemaStr, props, new UpdateStoreQueryParams()).close();
+    createStoreForJob(
+        clusterName,
+        keySchemaStr,
+        valueSchemaStr,
+        props,
+        new UpdateStoreQueryParams().setPartitionCount(3)).close();
     // Create a new version
     VersionCreationResponse versionCreationResponse = TestUtils.assertCommand(
         parentControllerClient.requestTopicForWrites(

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestPushJobWithEmergencySourceRegionSelection.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestPushJobWithEmergencySourceRegionSelection.java
@@ -1,7 +1,6 @@
 package com.linkedin.venice.endToEnd;
 
 import static com.linkedin.davinci.store.rocksdb.RocksDBServerConfig.ROCKSDB_PLAIN_TABLE_FORMAT_ENABLED;
-import static com.linkedin.venice.ConfigKeys.DEFAULT_MAX_NUMBER_OF_PARTITIONS;
 import static com.linkedin.venice.ConfigKeys.EMERGENCY_SOURCE_REGION;
 import static com.linkedin.venice.ConfigKeys.NATIVE_REPLICATION_SOURCE_FABRIC;
 import static com.linkedin.venice.ConfigKeys.SERVER_DATABASE_CHECKSUM_VERIFICATION_ENABLED;
@@ -88,7 +87,6 @@ public class TestPushJobWithEmergencySourceRegionSelection {
     serverProperties.put(SERVER_KAFKA_PRODUCER_POOL_SIZE_PER_KAFKA_CLUSTER, "1");
 
     Properties controllerProps = new Properties();
-    controllerProps.put(DEFAULT_MAX_NUMBER_OF_PARTITIONS, 1000);
     controllerProps.put(NATIVE_REPLICATION_SOURCE_FABRIC, "dc-0");
     controllerProps.put(EMERGENCY_SOURCE_REGION, "dc-2");
 

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestPushJobWithNativeReplication.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestPushJobWithNativeReplication.java
@@ -63,6 +63,7 @@ import com.linkedin.venice.meta.DataReplicationPolicy;
 import com.linkedin.venice.meta.HybridStoreConfig;
 import com.linkedin.venice.meta.Instance;
 import com.linkedin.venice.meta.Store;
+import com.linkedin.venice.meta.StoreInfo;
 import com.linkedin.venice.meta.VeniceUserStoreType;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.offsets.OffsetRecord;
@@ -902,12 +903,12 @@ public class TestPushJobWithNativeReplication {
                   .useControllerClient(
                       dc1Client -> TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, true, () -> {
                         // verify the update store command has taken effect before starting the push job.
-                        Assert.assertEquals(
-                            dc0Client.getStore(storeName).getStore().getStorageQuotaInByte(),
-                            Store.UNLIMITED_STORAGE_QUOTA);
-                        Assert.assertEquals(
-                            dc1Client.getStore(storeName).getStore().getStorageQuotaInByte(),
-                            Store.UNLIMITED_STORAGE_QUOTA);
+                        StoreInfo store = dc0Client.getStore(storeName).getStore();
+                        Assert.assertNotNull(store);
+                        Assert.assertEquals(store.getStorageQuotaInByte(), Store.UNLIMITED_STORAGE_QUOTA);
+                        store = dc1Client.getStore(storeName).getStore();
+                        Assert.assertNotNull(store);
+                        Assert.assertEquals(store.getStorageQuotaInByte(), Store.UNLIMITED_STORAGE_QUOTA);
                       })));
 
       makeSureSystemStoreIsPushed(clusterName, storeName);

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestPushJobWithNativeReplicationSharedProducer.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestPushJobWithNativeReplicationSharedProducer.java
@@ -1,7 +1,6 @@
 package com.linkedin.venice.endToEnd;
 
 import static com.linkedin.davinci.store.rocksdb.RocksDBServerConfig.ROCKSDB_PLAIN_TABLE_FORMAT_ENABLED;
-import static com.linkedin.venice.ConfigKeys.DEFAULT_MAX_NUMBER_OF_PARTITIONS;
 import static com.linkedin.venice.ConfigKeys.SERVER_DATABASE_CHECKSUM_VERIFICATION_ENABLED;
 import static com.linkedin.venice.ConfigKeys.SERVER_DATABASE_SYNC_BYTES_INTERNAL_FOR_DEFERRED_WRITE_MODE;
 import static com.linkedin.venice.ConfigKeys.SERVER_KAFKA_PRODUCER_POOL_SIZE_PER_KAFKA_CLUSTER;
@@ -90,7 +89,6 @@ public class TestPushJobWithNativeReplicationSharedProducer {
     serverProperties.put(SHARED_KAFKA_PRODUCER_BATCH_SIZE, 32864);
 
     Properties controllerProps = new Properties();
-    controllerProps.put(DEFAULT_MAX_NUMBER_OF_PARTITIONS, 1000);
     multiRegionMultiClusterWrapper = ServiceFactory.getVeniceTwoLayerMultiRegionMultiClusterWrapper(
         NUMBER_OF_CHILD_DATACENTERS,
         NUMBER_OF_CLUSTERS,

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestPushJobWithSourceGridFabricSelection.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestPushJobWithSourceGridFabricSelection.java
@@ -1,7 +1,6 @@
 package com.linkedin.venice.endToEnd;
 
 import static com.linkedin.davinci.store.rocksdb.RocksDBServerConfig.ROCKSDB_PLAIN_TABLE_FORMAT_ENABLED;
-import static com.linkedin.venice.ConfigKeys.DEFAULT_MAX_NUMBER_OF_PARTITIONS;
 import static com.linkedin.venice.ConfigKeys.SERVER_DATABASE_CHECKSUM_VERIFICATION_ENABLED;
 import static com.linkedin.venice.ConfigKeys.SERVER_DATABASE_SYNC_BYTES_INTERNAL_FOR_DEFERRED_WRITE_MODE;
 import static com.linkedin.venice.ConfigKeys.SERVER_KAFKA_PRODUCER_POOL_SIZE_PER_KAFKA_CLUSTER;
@@ -73,8 +72,6 @@ public class TestPushJobWithSourceGridFabricSelection {
     serverProperties.put(SERVER_KAFKA_PRODUCER_POOL_SIZE_PER_KAFKA_CLUSTER, "1");
 
     Properties controllerProps = new Properties();
-    controllerProps.put(DEFAULT_MAX_NUMBER_OF_PARTITIONS, 1000);
-
     multiRegionMultiClusterWrapper = ServiceFactory.getVeniceTwoLayerMultiRegionMultiClusterWrapper(
         NUMBER_OF_CHILD_DATACENTERS,
         NUMBER_OF_CLUSTERS,

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/helixrebalance/TestRebalanceByDefaultStrategy.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/helixrebalance/TestRebalanceByDefaultStrategy.java
@@ -1,5 +1,6 @@
 package com.linkedin.venice.helixrebalance;
 
+import com.linkedin.venice.controllerapi.UpdateStoreQueryParams;
 import com.linkedin.venice.controllerapi.VersionCreationResponse;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.helix.HelixState;
@@ -55,8 +56,10 @@ public class TestRebalanceByDefaultStrategy {
         false,
         false);
     String storeName = Utils.getUniqueString("testRollingUpgrade");
+    long storageQuota = (long) partitionSize * partitionNumber;
     cluster.getNewStore(storeName);
-    VersionCreationResponse response = cluster.getNewVersion(storeName, partitionSize * partitionNumber);
+    cluster.updateStore(storeName, new UpdateStoreQueryParams().setStorageQuotaInByte(storageQuota));
+    VersionCreationResponse response = cluster.getNewVersion(storeName);
 
     topicName = response.getKafkaTopic();
 

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/integration/utils/VeniceClusterWrapper.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/integration/utils/VeniceClusterWrapper.java
@@ -851,16 +851,16 @@ public class VeniceClusterWrapper extends ProcessWrapper {
         controllerClient.get().createNewStore(storeName, getClass().getName(), keySchema, valueSchema));
   }
 
-  public VersionCreationResponse getNewVersion(String storeName, int dataSize) {
-    return getNewVersion(storeName, dataSize, true);
+  public VersionCreationResponse getNewVersion(String storeName) {
+    return getNewVersion(storeName, true);
   }
 
-  public VersionCreationResponse getNewVersion(String storeName, int dataSize, boolean sendStartOfPush) {
+  public VersionCreationResponse getNewVersion(String storeName, boolean sendStartOfPush) {
     return assertCommand(
         controllerClient.get()
             .requestTopicForWrites(
                 storeName,
-                dataSize,
+                1024, // TODO: Store size is not used anymore. Remove it after the next round of controller deployment.
                 Version.PushType.BATCH,
                 Version.guidBasedDummyPushId(),
                 sendStartOfPush,

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/kafka/ssl/TestProduceWithSSL.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/kafka/ssl/TestProduceWithSSL.java
@@ -68,7 +68,7 @@ public class TestProduceWithSSL {
   public void testVeniceWriterSupportSSL() throws ExecutionException, InterruptedException {
     String storeName = Utils.getUniqueString("testVeniceWriterSupportSSL");
     cluster.getNewStore(storeName);
-    VersionCreationResponse response = cluster.getNewVersion(storeName, 1000);
+    VersionCreationResponse response = cluster.getNewVersion(storeName);
     Assert.assertFalse(response.isError());
     int version = response.getVersion();
     String topic = response.getKafkaTopic();

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/restart/TestRestartController.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/restart/TestRestartController.java
@@ -46,10 +46,9 @@ public class TestRestartController {
   @Test(timeOut = 60 * Time.MS_PER_SECOND)
   public void testLeaderControllerFailover() {
     String storeName = Utils.getUniqueString("testLeaderControllerFailover");
-    int dataSize = 1000;
     cluster.getNewStore(storeName);
 
-    VersionCreationResponse response = cluster.getNewVersion(storeName, dataSize);
+    VersionCreationResponse response = cluster.getNewVersion(storeName);
     Assert.assertFalse(response.isError());
     String topicName = response.getKafkaTopic();
     int versionNum = response.getVersion();
@@ -76,7 +75,7 @@ public class TestRestartController {
         controllerClient,
         OPERATION_TIMEOUT_MS,
         TimeUnit.MILLISECONDS);
-    VersionCreationResponse responseV2 = createNewVersionWithRetry(storeName, dataSize);
+    VersionCreationResponse responseV2 = createNewVersionWithRetry(storeName);
     Assert.assertFalse(responseV2.isError());
     Assert.assertEquals(responseV2.getVersion(), versionNum + 1);
 
@@ -112,7 +111,7 @@ public class TestRestartController {
         TimeUnit.MILLISECONDS);
 
     // Check it one more time for good measure with a third and final push
-    VersionCreationResponse responseV3 = createNewVersionWithRetry(storeName, dataSize);
+    VersionCreationResponse responseV3 = createNewVersionWithRetry(storeName);
     Assert.assertFalse(responseV3.isError());
     Assert.assertEquals(responseV3.getVersion(), versionNum + 2);
 
@@ -138,9 +137,8 @@ public class TestRestartController {
   @Test(timeOut = 60 * Time.MS_PER_SECOND)
   public void testControllerRestartFetchesLastSuccessfulPushDuration() {
     String storeName = Utils.getUniqueString("testControllerRestartFetchesLastSuccessfulPushDuration");
-    int dataSize = 1000;
     cluster.getNewStore(storeName);
-    VersionCreationResponse response = cluster.getNewVersion(storeName, dataSize);
+    VersionCreationResponse response = cluster.getNewVersion(storeName);
     Assert.assertFalse(response.isError());
     String topicName = response.getKafkaTopic();
 
@@ -192,15 +190,15 @@ public class TestRestartController {
 
   }
 
-  private VersionCreationResponse createNewVersionWithRetry(String storeName, int dataSize) {
+  private VersionCreationResponse createNewVersionWithRetry(String storeName) {
     // After restart, regardless who is leader, there should be only one leader and could handle request correctly.
     VersionCreationResponse response = null;
     try {
-      response = cluster.getNewVersion(storeName, dataSize);
+      response = cluster.getNewVersion(storeName);
     } catch (VeniceException e) {
       // Some times, the leader controller would be changed after getting it from cluster. Just retry on the new leader.
       cluster.getLeaderVeniceController();
-      response = cluster.getNewVersion(storeName, dataSize);
+      response = cluster.getNewVersion(storeName);
     }
     return response;
   }

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/restart/TestRestartRouter.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/restart/TestRestartRouter.java
@@ -72,7 +72,7 @@ public class TestRestartRouter {
 
     // Choose another router to handle request. Cluster will help us to find another running router and send the request
     // to.
-    VersionCreationResponse response = cluster.getNewVersion(storeName, 100);
+    VersionCreationResponse response = cluster.getNewVersion(storeName);
     int versionNum = response.getVersion();
     Assert.assertEquals(versionNum, 1);
     // restart

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/router/TestStreaming.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/router/TestStreaming.java
@@ -120,7 +120,7 @@ public class TestStreaming {
 
     storeName = Utils.getUniqueString("venice-store");
     veniceCluster.getNewStore(storeName, KEY_SCHEMA, VALUE_SCHEMA);
-    VersionCreationResponse creationResponse = veniceCluster.getNewVersion(storeName, 1024, false);
+    VersionCreationResponse creationResponse = veniceCluster.getNewVersion(storeName, false);
 
     storeVersionName = creationResponse.getKafkaTopic();
     // enable compute

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/storagenode/ReadComputeValidationTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/storagenode/ReadComputeValidationTest.java
@@ -137,7 +137,7 @@ public class ReadComputeValidationTest {
     params.setChunkingEnabled(valueLargerThan1MB);
     veniceCluster.updateStore(storeName, params);
 
-    VersionCreationResponse newVersion = veniceCluster.getNewVersion(storeName, 1024);
+    VersionCreationResponse newVersion = veniceCluster.getNewVersion(storeName);
     final int pushVersion = newVersion.getVersion();
     String topic = newVersion.getKafkaTopic();
 
@@ -176,7 +176,7 @@ public class ReadComputeValidationTest {
       // Restart the server to get new schemas
       veniceCluster.stopAndRestartVeniceServer(veniceCluster.getVeniceServers().get(0).getPort());
 
-      VersionCreationResponse newVersion2 = veniceCluster.getNewVersion(storeName, 1024);
+      VersionCreationResponse newVersion2 = veniceCluster.getNewVersion(storeName);
       final int pushVersion2 = newVersion2.getVersion();
       String topic2 = newVersion2.getKafkaTopic();
       VeniceWriter<Object, byte[], byte[]> veniceWriter2 = vwFactory.createVeniceWriter(
@@ -221,7 +221,7 @@ public class ReadComputeValidationTest {
     params.setChunkingEnabled(false);
     veniceCluster.updateStore(storeName, params);
 
-    VersionCreationResponse newVersion = veniceCluster.getNewVersion(storeName, 1024);
+    VersionCreationResponse newVersion = veniceCluster.getNewVersion(storeName);
     final int pushVersion = newVersion.getVersion();
     String topic = newVersion.getKafkaTopic();
 
@@ -257,7 +257,7 @@ public class ReadComputeValidationTest {
       // Restart the server to get new schemas
       veniceCluster.stopAndRestartVeniceServer(veniceCluster.getVeniceServers().get(0).getPort());
 
-      VersionCreationResponse newVersion2 = veniceCluster.getNewVersion(storeName, 1024);
+      VersionCreationResponse newVersion2 = veniceCluster.getNewVersion(storeName);
       final int pushVersion2 = newVersion2.getVersion();
       String topic2 = newVersion2.getKafkaTopic();
       VeniceWriter<Object, byte[], byte[]> veniceWriter2 =

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/storagenode/StorageNodeComputeTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/storagenode/StorageNodeComputeTest.java
@@ -191,7 +191,7 @@ public class StorageNodeComputeTest {
     ControllerResponse controllerResponse = veniceCluster.updateStore(storeName, params);
     Assert.assertFalse(controllerResponse.isError(), "Error updating store settings: " + controllerResponse.getError());
 
-    VersionCreationResponse newVersion = veniceCluster.getNewVersion(storeName, 1024, false);
+    VersionCreationResponse newVersion = veniceCluster.getNewVersion(storeName, false);
     Assert.assertFalse(newVersion.isError(), "Error creation new version: " + newVersion.getError());
     final int pushVersion = newVersion.getVersion();
     String topic = newVersion.getKafkaTopic();
@@ -307,7 +307,7 @@ public class StorageNodeComputeTest {
     params.setReadComputationEnabled(true);
     veniceCluster.updateStore(storeName, params);
 
-    VersionCreationResponse newVersion = veniceCluster.getNewVersion(storeName, 1024);
+    VersionCreationResponse newVersion = veniceCluster.getNewVersion(storeName);
     final int pushVersion = newVersion.getVersion();
 
     try (

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/storagenode/TestEarlyTermination.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/storagenode/TestEarlyTermination.java
@@ -75,7 +75,7 @@ public class TestEarlyTermination {
     veniceCluster.addVeniceServer(serverFeaturePropertiesWithEarlyTermination, serverPropertiesWithEarlyTermination);
 
     // Create new version
-    VersionCreationResponse creationResponse = veniceCluster.getNewVersion(storeName, 100000000);
+    VersionCreationResponse creationResponse = veniceCluster.getNewVersion(storeName);
 
     storeVersionName = creationResponse.getKafkaTopic();
     valueSchemaId = HelixReadOnlySchemaRepository.VALUE_SCHEMA_STARTING_ID;

--- a/internal/venice-test-common/src/jmh/java/com/linkedin/venice/benchmark/MixedIngestionBenchmark.java
+++ b/internal/venice-test-common/src/jmh/java/com/linkedin/venice/benchmark/MixedIngestionBenchmark.java
@@ -3,6 +3,7 @@ package com.linkedin.venice.benchmark;
 import static com.linkedin.venice.ConfigKeys.SERVER_DEDICATED_DRAINER_FOR_SORTED_INPUT_ENABLED;
 
 import com.linkedin.venice.ConfigKeys;
+import com.linkedin.venice.controllerapi.UpdateStoreQueryParams;
 import com.linkedin.venice.controllerapi.VersionCreationResponse;
 import com.linkedin.venice.integration.utils.ServiceFactory;
 import com.linkedin.venice.integration.utils.VeniceClusterWrapper;
@@ -83,9 +84,10 @@ public class MixedIngestionBenchmark {
   @Benchmark
   public void ingestionBenchMark() throws Exception {
     String storeName = Utils.getUniqueString("new_store");
-    int dataSize = 1000000;
+    long storageQuota = 1000000;
     cluster.getNewStore(storeName);
-    VersionCreationResponse response = cluster.getNewVersion(storeName, dataSize);
+    cluster.updateStore(storeName, new UpdateStoreQueryParams().setStorageQuotaInByte(storageQuota));
+    VersionCreationResponse response = cluster.getNewVersion(storeName);
 
     String topicName = response.getKafkaTopic();
     Assert.assertEquals(response.getReplicas(), replicaFactor);

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/Admin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/Admin.java
@@ -450,9 +450,9 @@ public interface Admin extends AutoCloseable, Closeable {
   boolean isLeaderControllerFor(String clusterName);
 
   /**
-  * Calculate how many partitions are needed for the given store and size.
+  * Calculate how many partitions are needed for the given store.
   */
-  int calculateNumberOfPartitions(String clusterName, String storeName, long storeSize);
+  int calculateNumberOfPartitions(String clusterName, String storeName);
 
   int getReplicationFactor(String clusterName, String storeName);
 

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/UserSystemStoreLifeCycleHelper.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/UserSystemStoreLifeCycleHelper.java
@@ -32,7 +32,6 @@ import org.apache.logging.log4j.Logger;
  */
 public class UserSystemStoreLifeCycleHelper {
   static final String AUTO_META_SYSTEM_STORE_PUSH_ID_PREFIX = "Auto_meta_system_store_empty_push_";
-  static final long DEFAULT_META_SYSTEM_STORE_SIZE = 1024 * 1024 * 1024;
   private static final VeniceSystemStoreType[] aclRequiredSystemStores =
       new VeniceSystemStoreType[] { VeniceSystemStoreType.META_STORE, VeniceSystemStoreType.DAVINCI_PUSH_STATUS_STORE };
   private static final Set<VeniceSystemStoreType> aclRequiredSystemStoresSet =
@@ -80,8 +79,7 @@ public class UserSystemStoreLifeCycleHelper {
       final int systemStoreLargestUsedVersionNumber =
           parentAdmin.getLargestUsedVersionFromStoreGraveyard(clusterName, systemStoreName);
 
-      int partitionCount =
-          parentAdmin.calculateNumberOfPartitions(clusterName, systemStoreName, DEFAULT_META_SYSTEM_STORE_SIZE);
+      int partitionCount = parentAdmin.calculateNumberOfPartitions(clusterName, systemStoreName);
       int replicationFactor = parentAdmin.getReplicationFactor(clusterName, systemStoreName);
       Version version;
       if (systemStoreLargestUsedVersionNumber == Store.NON_EXISTING_VERSION) {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerClusterConfig.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerClusterConfig.java
@@ -34,6 +34,7 @@ import static com.linkedin.venice.ConfigKeys.ENABLE_NATIVE_REPLICATION_FOR_HYBRI
 import static com.linkedin.venice.ConfigKeys.ENABLE_NATIVE_REPLICATION_FOR_INCREMENTAL_PUSH;
 import static com.linkedin.venice.ConfigKeys.ENABLE_OFFLINE_PUSH_SSL_ALLOWLIST;
 import static com.linkedin.venice.ConfigKeys.ENABLE_OFFLINE_PUSH_SSL_WHITELIST;
+import static com.linkedin.venice.ConfigKeys.ENABLE_PARTITION_COUNT_ROUND_UP;
 import static com.linkedin.venice.ConfigKeys.FORCE_LEADER_ERROR_REPLICA_FAIL_OVER_ENABLED;
 import static com.linkedin.venice.ConfigKeys.HELIX_REBALANCE_ALG;
 import static com.linkedin.venice.ConfigKeys.HELIX_SEND_MESSAGE_TIMEOUT_MS;
@@ -53,6 +54,7 @@ import static com.linkedin.venice.ConfigKeys.NATIVE_REPLICATION_SOURCE_FABRIC_AS
 import static com.linkedin.venice.ConfigKeys.NATIVE_REPLICATION_SOURCE_FABRIC_AS_DEFAULT_FOR_HYBRID_STORES;
 import static com.linkedin.venice.ConfigKeys.NATIVE_REPLICATION_SOURCE_FABRIC_AS_DEFAULT_FOR_INCREMENTAL_PUSH_STORES;
 import static com.linkedin.venice.ConfigKeys.OFFLINE_JOB_START_TIMEOUT_MS;
+import static com.linkedin.venice.ConfigKeys.PARTITION_COUNT_ROUND_UP_SIZE;
 import static com.linkedin.venice.ConfigKeys.PERSISTENCE_TYPE;
 import static com.linkedin.venice.ConfigKeys.PUSH_MONITOR_TYPE;
 import static com.linkedin.venice.ConfigKeys.PUSH_SSL_ALLOWLIST;
@@ -111,6 +113,8 @@ public class VeniceControllerClusterConfig {
   private int numberOfPartitionForHybrid;
   private int maxNumberOfPartition;
   private long partitionSize;
+  private boolean partitionCountRoundUpEnabled;
+  private int partitionCountRoundUpSize;
   private long offLineJobWaitTimeInMilliseconds;
   private Map<String, String> clusterToD2Map;
   private Map<String, String> clusterToServerD2Map;
@@ -289,6 +293,8 @@ public class VeniceControllerClusterConfig {
     kafkaBootstrapServers = props.getString(KAFKA_BOOTSTRAP_SERVERS);
     partitionSize = props.getSizeInBytes(DEFAULT_PARTITION_SIZE);
     maxNumberOfPartition = props.getInt(DEFAULT_MAX_NUMBER_OF_PARTITIONS);
+    partitionCountRoundUpEnabled = props.getBoolean(ENABLE_PARTITION_COUNT_ROUND_UP, false);
+    partitionCountRoundUpSize = props.getInt(PARTITION_COUNT_ROUND_UP_SIZE, 1);
     // If the timeout is longer than 3min, we need to update controller client's timeout as well, otherwise creating
     // version would fail.
     offLineJobWaitTimeInMilliseconds = props.getLong(OFFLINE_JOB_START_TIMEOUT_MS, 120000);
@@ -471,6 +477,14 @@ public class VeniceControllerClusterConfig {
 
   public int getMaxNumberOfPartition() {
     return maxNumberOfPartition;
+  }
+
+  public boolean isPartitionCountRoundUpEnabled() {
+    return partitionCountRoundUpEnabled;
+  }
+
+  public int getPartitionCountRoundUpSize() {
+    return partitionCountRoundUpSize;
   }
 
   public long getOffLineJobWaitTimeInMilliseconds() {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -4,7 +4,6 @@ import static com.linkedin.venice.ConfigKeys.KAFKA_MIN_IN_SYNC_REPLICAS;
 import static com.linkedin.venice.ConfigKeys.KAFKA_REPLICATION_FACTOR;
 import static com.linkedin.venice.ConfigKeys.PUSH_STATUS_STORE_DERIVED_SCHEMA_ID;
 import static com.linkedin.venice.controller.UserSystemStoreLifeCycleHelper.AUTO_META_SYSTEM_STORE_PUSH_ID_PREFIX;
-import static com.linkedin.venice.controller.UserSystemStoreLifeCycleHelper.DEFAULT_META_SYSTEM_STORE_SIZE;
 import static com.linkedin.venice.meta.HybridStoreConfigImpl.DEFAULT_HYBRID_OFFSET_LAG_THRESHOLD;
 import static com.linkedin.venice.meta.HybridStoreConfigImpl.DEFAULT_HYBRID_TIME_LAG_THRESHOLD;
 import static com.linkedin.venice.meta.HybridStoreConfigImpl.DEFAULT_REWIND_TIME_IN_SECONDS;
@@ -4944,7 +4943,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
             clusterName,
             systemStoreName,
             pushJobId,
-            calculateNumberOfPartitions(clusterName, systemStoreName, DEFAULT_META_SYSTEM_STORE_SIZE),
+            calculateNumberOfPartitions(clusterName, systemStoreName),
             getReplicationFactor(clusterName, systemStoreName));
         int versionNumber = version.getNumber();
         writeEndOfPush(clusterName, systemStoreName, versionNumber, true);
@@ -5608,17 +5607,17 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
   }
 
   /**
-   * Calculate number of partition for given store by give size.
+   * Calculate number of partition for given store.
    */
   @Override
-  public int calculateNumberOfPartitions(String clusterName, String storeName, long storeSize) {
+  public int calculateNumberOfPartitions(String clusterName, String storeName) {
     checkControllerLeadershipFor(clusterName);
     HelixVeniceClusterResources resources = getHelixVeniceClusterResources(clusterName);
     Store store = resources.getStoreMetadataRepository().getStoreOrThrow(storeName);
     VeniceControllerClusterConfig config = resources.getConfig();
     return PartitionUtils.calculatePartitionCount(
         storeName,
-        storeSize,
+        store.getStorageQuotaInByte(),
         store.getPartitionCount(),
         config.getPartitionSize(),
         config.getNumberOfPartition(),

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -5621,7 +5621,9 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
         store.getPartitionCount(),
         config.getPartitionSize(),
         config.getNumberOfPartition(),
-        config.getMaxNumberOfPartition());
+        config.getMaxNumberOfPartition(),
+        config.isPartitionCountRoundUpEnabled(),
+        config.getPartitionCountRoundUpSize());
   }
 
   /**

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
@@ -3490,11 +3490,11 @@ public class VeniceParentHelixAdmin implements Admin {
   }
 
   /**
-   * @see VeniceHelixAdmin#calculateNumberOfPartitions(String, String, long)
+   * @see Admin#calculateNumberOfPartitions(String, String)
    */
   @Override
-  public int calculateNumberOfPartitions(String clusterName, String storeName, long storeSize) {
-    return getVeniceHelixAdmin().calculateNumberOfPartitions(clusterName, storeName, storeSize);
+  public int calculateNumberOfPartitions(String clusterName, String storeName) {
+    return getVeniceHelixAdmin().calculateNumberOfPartitions(clusterName, storeName);
   }
 
   /**

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/CreateVersion.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/CreateVersion.java
@@ -16,7 +16,6 @@ import static com.linkedin.venice.controllerapi.ControllerApiConstants.REPLICATI
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.REWIND_TIME_IN_SECONDS_OVERRIDE;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.SEND_START_OF_PUSH;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.SOURCE_GRID_FABRIC;
-import static com.linkedin.venice.controllerapi.ControllerApiConstants.STORE_SIZE;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.VERSION;
 import static com.linkedin.venice.controllerapi.ControllerRoute.ADD_VERSION;
 import static com.linkedin.venice.controllerapi.ControllerRoute.EMPTY_PUSH;
@@ -165,9 +164,8 @@ public class CreateVersion extends AbstractRoute {
           sendStartOfPush = Utils.parseBooleanFromString(request.queryParams(SEND_START_OF_PUSH), SEND_START_OF_PUSH);
         }
 
-        long storeSize = Utils.parseLongFromString(request.queryParams(STORE_SIZE), STORE_SIZE);
         int replicationFactor = admin.getReplicationFactor(clusterName, storeName);
-        int partitionCount = admin.calculateNumberOfPartitions(clusterName, storeName, storeSize);
+        int partitionCount = admin.calculateNumberOfPartitions(clusterName, storeName);
         responseObject.setReplicas(replicationFactor);
         responseObject.setPartitions(partitionCount);
 
@@ -645,9 +643,8 @@ public class CreateVersion extends AbstractRoute {
         }
 
         clusterName = request.queryParams(CLUSTER);
-        long storeSize = Utils.parseLongFromString(request.queryParams(STORE_SIZE), STORE_SIZE);
         String pushJobId = request.queryParams(PUSH_JOB_ID);
-        int partitionNum = admin.calculateNumberOfPartitions(clusterName, storeName, storeSize);
+        int partitionNum = admin.calculateNumberOfPartitions(clusterName, storeName);
         int replicationFactor = admin.getReplicationFactor(clusterName, storeName);
         version = admin.incrementVersionIdempotent(clusterName, storeName, pushJobId, partitionNum, replicationFactor);
         int versionNumber = version.getNumber();


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci], [server], [controller],
[router], [samza], [vpj], [fast-client], [thin-client], [alpini],
[admin-tool], [test], [build], [doc], [script]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Summary
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Before the commit: If store level partition count is not configured, use the data size passed from push job to calculate partition count for the new version. Otherwise, use store level partition count for the new version.

Issue: Sometimes the data size counted by push job is underestimated, causing less partiton counts than expected.

After the commit: If store level partition count is not configured, use store's disk quota to calculate partition count for the new version. Otherwise, use store level partition count for the new version.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
testGetNumberOfPartition
testGetNumberOfPartitionsFromStoreLevelConfig
Internal CI

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [x] Yes. Make sure to explain your proposed changes and call out the behavior change.