### PR TITLE
[controller][H2V]  Add a reusable Gzip compressor for Venice mapper

### DIFF
--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/compression/GzipCompressor.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/compression/GzipCompressor.java
@@ -12,14 +12,17 @@ import org.apache.commons.io.IOUtils;
 
 
 public class GzipCompressor extends VeniceCompressor {
+  GzipPool gzipPool;
+
   public GzipCompressor() {
     super(CompressionStrategy.GZIP);
+    this.gzipPool = new GzipPool();
   }
 
   @Override
   public byte[] compress(byte[] data) throws IOException {
     ByteArrayOutputStream bos = new ByteArrayOutputStream();
-    ReusableGzipOutputStream out = GzipPool.forStream(bos);
+    ReusableGzipOutputStream out = gzipPool.forStream(bos);
     try {
       out.writeHeader();
       out.write(data);
@@ -29,6 +32,14 @@ public class GzipCompressor extends VeniceCompressor {
     }
 
     return bos.toByteArray();
+  }
+
+  @Override
+  public void close() throws IOException {
+    try {
+      gzipPool.close();
+    } catch (Exception e) {
+    }
   }
 
   @Override

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/compression/GzipCompressor.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/compression/GzipCompressor.java
@@ -19,11 +19,12 @@ public class GzipCompressor extends VeniceCompressor {
   @Override
   public byte[] compress(byte[] data) throws IOException {
     ByteArrayOutputStream bos = new ByteArrayOutputStream();
-    try (GZIPOutputStream gos = new GZIPOutputStream(bos)) {
-      gos.write(data);
-      gos.finish();
-      return bos.toByteArray();
-    }
+    ReusableGzipOutputStream out = GzipPool.forStream(bos);
+    out.writeHeader();
+    out.write(data);
+    out.finish();
+    out.reset();
+    return bos.toByteArray();
   }
 
   @Override

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/compression/GzipCompressor.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/compression/GzipCompressor.java
@@ -12,7 +12,7 @@ import org.apache.commons.io.IOUtils;
 
 
 public class GzipCompressor extends VeniceCompressor {
-  GzipPool gzipPool;
+  private final GzipPool gzipPool;
 
   public GzipCompressor() {
     super(CompressionStrategy.GZIP);
@@ -21,17 +21,15 @@ public class GzipCompressor extends VeniceCompressor {
 
   @Override
   public byte[] compress(byte[] data) throws IOException {
-    ByteArrayOutputStream bos = new ByteArrayOutputStream();
-    ReusableGzipOutputStream out = gzipPool.forStream(bos);
+    ReusableGzipOutputStream out = gzipPool.getReusableGzipOutputStream();
     try {
       out.writeHeader();
       out.write(data);
       out.finish();
+      return out.toByteArray();
     } finally {
       out.reset();
     }
-
-    return bos.toByteArray();
   }
 
   @Override

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/compression/GzipCompressor.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/compression/GzipCompressor.java
@@ -20,10 +20,14 @@ public class GzipCompressor extends VeniceCompressor {
   public byte[] compress(byte[] data) throws IOException {
     ByteArrayOutputStream bos = new ByteArrayOutputStream();
     ReusableGzipOutputStream out = GzipPool.forStream(bos);
-    out.writeHeader();
-    out.write(data);
-    out.finish();
-    out.reset();
+    try {
+      out.writeHeader();
+      out.write(data);
+      out.finish();
+    } finally {
+      out.reset();
+    }
+
     return bos.toByteArray();
   }
 

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/compression/GzipPool.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/compression/GzipPool.java
@@ -1,7 +1,7 @@
 package com.linkedin.venice.compression;
 
 import com.linkedin.venice.utils.concurrent.CloseableThreadLocal;
-import java.io.IOException;
+import java.io.ByteArrayOutputStream;
 import java.io.OutputStream;
 
 
@@ -12,7 +12,7 @@ class GzipPool implements AutoCloseable {
   }
 
   private static class ReusableObjects implements AutoCloseable {
-    final SettableOutputStream stream = new SettableOutputStream();
+    final ByteArrayOutputStream stream = new ByteArrayOutputStream();
     final ReusableGzipOutputStream gzipOutputStream = new ReusableGzipOutputStream(stream);
 
     @Override
@@ -29,28 +29,8 @@ class GzipPool implements AutoCloseable {
    * Retrieves an {@link ReusableGzipOutputStream} for the given {@link OutputStream}. Instances are pooled per thread.
    *
    */
-  public ReusableGzipOutputStream forStream(OutputStream target) {
+  public ReusableGzipOutputStream getReusableGzipOutputStream() {
     ReusableObjects reusableObjects = reusableObjectsThreadLocal.get();
-    reusableObjects.stream.target = target;
     return reusableObjects.gzipOutputStream;
-  }
-
-  static class SettableOutputStream extends OutputStream {
-    private OutputStream target;
-
-    @Override
-    public void write(byte[] b, int off, int len) throws IOException {
-      target.write(b, off, len);
-    }
-
-    @Override
-    public void write(byte[] b) throws IOException {
-      target.write(b);
-    }
-
-    @Override
-    public void write(int b) throws IOException {
-      target.write((byte) b);
-    }
   }
 }

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/compression/GzipPool.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/compression/GzipPool.java
@@ -1,0 +1,43 @@
+package com.linkedin.venice.compression;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+
+abstract class GzipPool {
+  private static final ThreadLocal<SettableOutputStream> streams =
+      ThreadLocal.withInitial(() -> new SettableOutputStream());
+
+  private static final ThreadLocal<ReusableGzipOutputStream> zipStreams =
+      ThreadLocal.withInitial(() -> new ReusableGzipOutputStream(streams.get()));
+
+  /**
+   * Retrieves an {@link ReusableGzipOutputStream} for the given {@link OutputStream}. Instances are pooled per thread.
+   *
+   * @param target
+   * @return
+   */
+  public static ReusableGzipOutputStream forStream(OutputStream target) {
+    streams.get().target = target;
+    return zipStreams.get();
+  }
+
+  static class SettableOutputStream extends OutputStream {
+    private OutputStream target;
+
+    @Override
+    public void write(byte[] b, int off, int len) throws IOException {
+      target.write(b, off, len);
+    }
+
+    @Override
+    public void write(byte[] b) throws IOException {
+      target.write(b);
+    }
+
+    @Override
+    public void write(int b) throws IOException {
+      target.write((byte) b);
+    }
+  }
+}

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/compression/ReusableGzipOutputStream.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/compression/ReusableGzipOutputStream.java
@@ -1,0 +1,128 @@
+package com.linkedin.venice.compression;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.zip.CRC32;
+import java.util.zip.Deflater;
+import java.util.zip.DeflaterOutputStream;
+
+
+public class ReusableGzipOutputStream extends DeflaterOutputStream {
+  /**
+   * CRC-32 of uncompressed data.
+   */
+  private final CRC32 crc = new CRC32();
+
+  /*
+   * GZIP header magic number.
+   */
+  private final static int GZIP_MAGIC = 0x8b1f;
+
+  /*
+   * Trailer size in bytes.
+   *
+   */
+  private final static int TRAILER_SIZE = 8;
+
+  /**
+   * Creates a new output stream with the specified buffer size and flush mode.
+   *
+   * @param out the output stream
+   * @exception IllegalArgumentException if {@code size <= 0}
+   *
+   * @since 1.7
+   */
+  public ReusableGzipOutputStream(OutputStream out) {
+    super(out, new Deflater(Deflater.DEFAULT_COMPRESSION, true));
+    crc.reset();
+  }
+
+  /**
+   * Writes array of bytes to the compressed output stream. This method will block until all the bytes are written.
+   *
+   * @param buf the data to be written
+   * @param off the start offset of the data
+   * @param len the length of the data
+   * @exception IOException If an I/O error has occurred.
+   */
+  public synchronized void write(byte[] buf, int off, int len) throws IOException {
+    super.write(buf, off, len);
+    crc.update(buf, off, len);
+  }
+
+  /**
+   * Finishes writing compressed data to the output stream without closing the underlying stream. Use this method when
+   * applying multiple filters in succession to the same output stream.
+   *
+   * @exception IOException if an I/O error has occurred
+   */
+  public void finish() throws IOException {
+    if (!def.finished()) {
+      def.finish();
+      while (!def.finished()) {
+        int len = def.deflate(buf, 0, buf.length);
+        if (def.finished() && len <= buf.length - TRAILER_SIZE) {
+          // last deflater buffer. Fit trailer at the end
+          writeTrailer(buf, len);
+          len = len + TRAILER_SIZE;
+          out.write(buf, 0, len);
+          return;
+        }
+        if (len > 0)
+          out.write(buf, 0, len);
+      }
+      // if we can't fit the trailer at the end of the last
+      // deflater buffer, we write it separately
+      byte[] trailer = new byte[TRAILER_SIZE];
+      writeTrailer(trailer, 0);
+      out.write(trailer);
+    }
+  }
+
+  /*
+   * Writes GZIP member header.
+   */
+  public void writeHeader() throws IOException {
+    out.write(
+        new byte[] { (byte) GZIP_MAGIC, // Magic number (short)
+            (byte) (GZIP_MAGIC >> 8), // Magic number (short)
+            Deflater.DEFLATED, // Compression method (CM)
+            0, // Flags (FLG)
+            0, // Modification time MTIME (int)
+            0, // Modification time MTIME (int)
+            0, // Modification time MTIME (int)
+            0, // Modification time MTIME (int)
+            0, // Extra flags (XFLG)
+            0 // Operating system (OS)
+        });
+  }
+
+  /*
+   * Writes GZIP member trailer to a byte array, starting at a given offset.
+   */
+  private void writeTrailer(byte[] buf, int offset) throws IOException {
+    writeInt((int) crc.getValue(), buf, offset); // CRC-32 of uncompr. data
+    writeInt(def.getTotalIn(), buf, offset + 4); // Number of uncompr. bytes
+  }
+
+  /*
+   * Writes integer in Intel byte order to a byte array, starting at a given offset.
+   */
+  private void writeInt(int i, byte[] buf, int offset) throws IOException {
+    writeShort(i & 0xffff, buf, offset);
+    writeShort((i >> 16) & 0xffff, buf, offset + 2);
+  }
+
+  /*
+   * Writes short integer in Intel byte order to a byte array, starting at a given offset
+   */
+  private void writeShort(int s, byte[] buf, int offset) throws IOException {
+    buf[offset] = (byte) (s & 0xff);
+    buf[offset + 1] = (byte) ((s >> 8) & 0xff);
+  }
+
+  public void reset() {
+    crc.reset();
+    def.reset();
+  }
+}

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/compression/ReusableGzipOutputStream.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/compression/ReusableGzipOutputStream.java
@@ -1,7 +1,7 @@
 package com.linkedin.venice.compression;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.io.OutputStream;
 import java.util.zip.CRC32;
 import java.util.zip.Deflater;
 import java.util.zip.DeflaterOutputStream;
@@ -40,9 +40,17 @@ public class ReusableGzipOutputStream extends DeflaterOutputStream {
    *
    * @since 1.7
    */
-  public ReusableGzipOutputStream(OutputStream out) {
+  private final ByteArrayOutputStream bos;
+
+  public ReusableGzipOutputStream(ByteArrayOutputStream out) {
     super(out, new Deflater(Deflater.DEFAULT_COMPRESSION, true));
     crc.reset();
+    out.reset();
+    this.bos = out;
+  }
+
+  public byte[] toByteArray() {
+    return bos.toByteArray();
   }
 
   /**
@@ -132,5 +140,6 @@ public class ReusableGzipOutputStream extends DeflaterOutputStream {
   public void reset() {
     crc.reset();
     def.reset();
+    bos.reset();
   }
 }

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/compression/ReusableGzipOutputStream.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/compression/ReusableGzipOutputStream.java
@@ -7,6 +7,14 @@ import java.util.zip.Deflater;
 import java.util.zip.DeflaterOutputStream;
 
 
+/**
+ * This class implements a stream filter for writing compressed data in the GZIP file format. It's an adoption of
+ * {@link java.util.zip.GZIPOutputStream} but with a notable difference regarding re-usability:
+ * <ul>
+ * <li>Expose {@link #reset()} to reset CRC32 and the deflater</li>
+ * <li>Don't write the GZIP header upon construction but expose {@link #writeHeader()}</li>
+ * </ul>
+ */
 public class ReusableGzipOutputStream extends DeflaterOutputStream {
   /**
    * CRC-32 of uncompressed data.


### PR DESCRIPTION

## Summary
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Ported a reusable Gzip compression from https://github.com/mp911de/reusing-gzip-streams for use in Venice mapper phase. For Gzip enabled stores this should improve mapper memory usage.

A reusable GZIPOutputStream differs from the JDK-provided class in some points:

Do not write the GZIP header upon instance creation but expose a writeHeader() method
Expose a reset() method to reset the deflater state
Do not close the stream to keep it reusable


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

CI run

## Does this PR introduce any user-facing changes?

No