### PR TITLE
[controller][compat] Add back deprecated StartOfBufferReplay and KME compatibility test.

### DIFF
--- a/internal/venice-common/src/main/resources/avro/KafkaMessageEnvelope/v11/KafkaMessageEnvelope.avsc
+++ b/internal/venice-common/src/main/resources/avro/KafkaMessageEnvelope/v11/KafkaMessageEnvelope.avsc
@@ -119,7 +119,7 @@
           "fields": [
             {
               "name": "controlMessageType",
-              "doc": "Using int because Avro Enums are not evolvable. Readers should always handle the 'unknown' value edge case, to account for future evolutions of this protocol. The mapping is the following: 0 => StartOfPush, 1 => EndOfPush, 2 => StartOfSegment, 3 => EndOfSegment, 5 => StartOfIncrementalPush, 6 => EndOfIncrementalPush, 7 => TopicSwitch, 8 => VersionSwap",
+              "doc": "Using int because Avro Enums are not evolvable. Readers should always handle the 'unknown' value edge case, to account for future evolutions of this protocol. The mapping is the following: 0 => StartOfPush, 1 => EndOfPush, 2 => StartOfSegment, 3 => EndOfSegment, 4 => StartOfBufferReplay (Deprecated), 5 => StartOfIncrementalPush, 6 => EndOfIncrementalPush, 7 => TopicSwitch, 8 => VersionSwap",
               "type": "int"
             }, {
               "name": "debugInfo",
@@ -207,6 +207,28 @@
                       "name": "finalSegment",
                       "doc": "This field is set to true when the producer knows that there is no more data coming from its data source after this EndOfSegment. This happens at the time the producer is closed.",
                       "type": "boolean"
+                    }
+                  ]
+                }, {
+                  "name": "StartOfBufferReplay",
+                  "doc": "[Deprecated] This ControlMessage is sent by the Controller, once per partition, after the EndOfPush ControlMessage, in Hybrid Stores that ingest from both offline and nearline sources. It contains information about the the offsets from which the Buffer Replay Service started replaying data from the real-time buffer topic onto the store-version topic. This can be used as a synchronization marker between the real-time buffer topic and the store-version topic, akin to how a clapperboard is used to synchronize sound and image in filmmaking. This synchronization marker can in turn be used by the consumer to compute an offset lag.",
+                  "type": "record",
+                  "fields": [
+                    {
+                      "name": "sourceOffsets",
+                      "doc": "Array of offsets from the real-time buffer topic at which the Buffer Replay Service started replaying data. The index position of the array corresponds to the partition number in the real-time buffer.",
+                      "type": {
+                        "type": "array",
+                        "items": "long"
+                      }
+                    }, {
+                      "name": "sourceKafkaCluster",
+                      "doc": "Kafka bootstrap servers URL of the cluster where the source buffer exists.",
+                      "type": "string"
+                    }, {
+                      "name": "sourceTopicName",
+                      "doc": "Name of the source buffer topic.",
+                      "type": "string"
                     }
                   ]
                 }, {

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/kafka/protocol/ProtocolCompatibilityTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/kafka/protocol/ProtocolCompatibilityTest.java
@@ -1,0 +1,79 @@
+package com.linkedin.venice.controller.kafka.protocol;
+
+import com.linkedin.avro.fastserde.FastSerdeCache;
+import com.linkedin.venice.schema.avro.SchemaCompatibility;
+import com.linkedin.venice.utils.TestUtils;
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.apache.avro.Schema;
+import org.apache.avro.SchemaValidationException;
+import org.apache.avro.SchemaValidator;
+import org.apache.avro.SchemaValidatorBuilder;
+import org.testng.Assert;
+
+
+public abstract class ProtocolCompatibilityTest {
+  protected void testProtocolCompatibility(Map<Integer, Schema> schemaMap, int latestSchemaId)
+      throws InterruptedException {
+    Assert.assertNotNull(schemaMap.containsKey(latestSchemaId), "The latest schema should exist!");
+
+    SchemaValidatorBuilder schemaValidatorBuilder = new SchemaValidatorBuilder();
+    SchemaValidator schemaValidator = schemaValidatorBuilder.canReadStrategy().validateAll();
+
+    /**
+     * Also checked the schema evolution is acceptable for fast avro.
+     */
+    ExecutorService executor = Executors.newSingleThreadExecutor();
+    try {
+      FastSerdeCache fastSerdeCache = new FastSerdeCache(executor);
+
+      Schema latestSchema = schemaMap.get(latestSchemaId);
+      schemaMap.forEach((schemaId, schema) -> {
+        if (schemaId == latestSchemaId) {
+          return;
+        }
+        SchemaCompatibility.SchemaPairCompatibility backwardCompatibility =
+            SchemaCompatibility.checkReaderWriterCompatibility(latestSchema, schema);
+        String failMessage = "Older protocol with schema id: " + schemaId + ", schema: " + schema.toString(true)
+            + " is not compatible with the latest admin operation protocol with schema id: " + latestSchemaId
+            + ", schema: " + latestSchema.toString(true);
+        Assert.assertEquals(
+            backwardCompatibility.getType(),
+            SchemaCompatibility.SchemaCompatibilityType.COMPATIBLE,
+            failMessage);
+
+        /**
+         * Validate the compatibility between the latest schema and each historical schema by {@link SchemaValidator} since
+         * it could tell whether the schema is a valid schema or not.
+         * For example, if we specify a wrong default value: "-1" (string type) to a field with "Long" type, the above
+         * compatibility check will still pass with a warning message, but the {@link SchemaValidator} will fail when encountering
+         * such kind of invalid schema
+         */
+        try {
+          schemaValidator.validate(latestSchema, Collections.singletonList(schema));
+        } catch (SchemaValidationException e) {
+          Assert.fail(failMessage);
+        } catch (Exception e) {
+          Assert.fail(
+              "Received schema validation exception, and please check the content of schema with ids: " + latestSchemaId
+                  + " or " + schemaId,
+              e);
+        }
+
+        /**
+         * Validate that fast avro can build a deserializer with an old protocol schema as writer schema and the latest
+         * protocol schema as reader schema.
+         */
+        try {
+          fastSerdeCache.buildFastGenericDeserializer(schema, latestSchema);
+        } catch (Exception e) {
+          Assert.fail("Failed fast avro", e);
+        }
+      });
+    } finally {
+      TestUtils.shutdownExecutor(executor);
+    }
+  }
+}

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/kafka/protocol/admin/AdminOperationProtocolCompatibilityTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/kafka/protocol/admin/AdminOperationProtocolCompatibilityTest.java
@@ -1,84 +1,17 @@
 package com.linkedin.venice.controller.kafka.protocol.admin;
 
-import com.linkedin.avro.fastserde.FastSerdeCache;
+import com.linkedin.venice.controller.kafka.protocol.ProtocolCompatibilityTest;
 import com.linkedin.venice.controller.kafka.protocol.serializer.AdminOperationSerializer;
-import com.linkedin.venice.schema.avro.SchemaCompatibility;
-import com.linkedin.venice.utils.TestUtils;
-import java.util.Collections;
 import java.util.Map;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import org.apache.avro.Schema;
-import org.apache.avro.SchemaValidationException;
-import org.apache.avro.SchemaValidator;
-import org.apache.avro.SchemaValidatorBuilder;
-import org.testng.Assert;
 import org.testng.annotations.Test;
 
 
-public class AdminOperationProtocolCompatibilityTest {
+public class AdminOperationProtocolCompatibilityTest extends ProtocolCompatibilityTest {
   @Test
   public void testAdminOperationProtocolCompatibility() throws InterruptedException {
     Map<Integer, Schema> schemaMap = AdminOperationSerializer.initProtocolMap();
     int latestSchemaId = AdminOperationSerializer.LATEST_SCHEMA_ID_FOR_ADMIN_OPERATION;
-
-    Assert.assertNotNull(schemaMap.containsKey(latestSchemaId), "The latest schema should exist!");
-
-    SchemaValidatorBuilder schemaValidatorBuilder = new SchemaValidatorBuilder();
-    SchemaValidator schemaValidator = schemaValidatorBuilder.canReadStrategy().validateAll();
-
-    /**
-     * Also checked the the schema evolution is acceptable for fast avro.
-     */
-    ExecutorService executor = Executors.newSingleThreadExecutor();
-    try {
-      FastSerdeCache fastSerdeCache = new FastSerdeCache(executor);
-
-      Schema latestSchema = schemaMap.get(latestSchemaId);
-      schemaMap.forEach((schemaId, schema) -> {
-        if (schemaId == latestSchemaId) {
-          return;
-        }
-        SchemaCompatibility.SchemaPairCompatibility backwardCompatibility =
-            SchemaCompatibility.checkReaderWriterCompatibility(latestSchema, schema);
-        String failMessage = "Older admin operation protocol with schema id: " + schemaId + ", schema: "
-            + schema.toString(true) + " is not compatible with the latest admin operation protocol with schema id: "
-            + latestSchemaId + ", schema: " + latestSchema.toString(true);
-        Assert.assertEquals(
-            backwardCompatibility.getType(),
-            SchemaCompatibility.SchemaCompatibilityType.COMPATIBLE,
-            failMessage);
-
-        /**
-         * Validate the compatibility between the latest schema and each historical schema by {@link SchemaValidator} since
-         * it could tell whether the schema is a valid schema or not.
-         * For example, if we specify a wrong default value: "-1" (string type) to a field with "Long" type, the above
-         * compatibility check will still pass with a warning message, but the {@link SchemaValidator} will fail when encountering
-         * such kind of invalid schema
-         */
-        try {
-          schemaValidator.validate(latestSchema, Collections.singletonList(schema));
-        } catch (SchemaValidationException e) {
-          Assert.fail(failMessage);
-        } catch (Exception e) {
-          Assert.fail(
-              "Received schema validation exception, and please check the content of schema with ids: " + latestSchemaId
-                  + " or " + schemaId,
-              e);
-        }
-
-        /**
-         * Validate that fast avro can build a deserializer with an old protocol schema as writer schema and the latest
-         * protocol schema as reader schema.
-         */
-        try {
-          fastSerdeCache.buildFastGenericDeserializer(schema, latestSchema);
-        } catch (Exception e) {
-          Assert.fail("Failed fast avro", e);
-        }
-      });
-    } finally {
-      TestUtils.shutdownExecutor(executor);
-    }
+    testProtocolCompatibility(schemaMap, latestSchemaId);
   }
 }

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/kafka/protocol/kme/KMEProtocolCompatibilityTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/kafka/protocol/kme/KMEProtocolCompatibilityTest.java
@@ -1,0 +1,35 @@
+package com.linkedin.venice.controller.kafka.protocol.kme;
+
+import com.linkedin.venice.controller.kafka.protocol.ProtocolCompatibilityTest;
+import com.linkedin.venice.exceptions.VeniceMessageException;
+import com.linkedin.venice.serialization.avro.KafkaValueSerializer;
+import com.linkedin.venice.utils.Utils;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.avro.Schema;
+import org.testng.annotations.Test;
+
+
+public class KMEProtocolCompatibilityTest extends ProtocolCompatibilityTest {
+  private Map<Integer, Schema> initKMEProtocolMap() {
+    try {
+      Map<Integer, Schema> protocolSchemaMap = new HashMap<>();
+      int knownKMEProtocolsNum = new KafkaValueSerializer().knownProtocols().size();
+      for (int i = 1; i <= knownKMEProtocolsNum; i++) {
+        protocolSchemaMap
+            .put(i, Utils.getSchemaFromResource("avro/KafkaMessageEnvelope/v" + i + "/KafkaMessageEnvelope.avsc"));
+      }
+      return protocolSchemaMap;
+    } catch (IOException e) {
+      throw new VeniceMessageException("Could not initialize " + KafkaValueSerializer.class.getSimpleName(), e);
+    }
+  }
+
+  @Test
+  public void testKMEProtocolCompatibility() throws InterruptedException {
+    Map<Integer, Schema> schemaMap = initKMEProtocolMap();
+    int latestSchemaId = schemaMap.size();
+    testProtocolCompatibility(schemaMap, latestSchemaId);
+  }
+}

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/kafka/protocol/kme/KMEProtocolCompatibilityTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/kafka/protocol/kme/KMEProtocolCompatibilityTest.java
@@ -12,6 +12,13 @@ import org.testng.annotations.Test;
 
 
 public class KMEProtocolCompatibilityTest extends ProtocolCompatibilityTest {
+  @Test
+  public void testKMEProtocolCompatibility() throws InterruptedException {
+    Map<Integer, Schema> schemaMap = initKMEProtocolMap();
+    int latestSchemaId = schemaMap.size();
+    testProtocolCompatibility(schemaMap, latestSchemaId);
+  }
+
   private Map<Integer, Schema> initKMEProtocolMap() {
     try {
       Map<Integer, Schema> protocolSchemaMap = new HashMap<>();
@@ -24,12 +31,5 @@ public class KMEProtocolCompatibilityTest extends ProtocolCompatibilityTest {
     } catch (IOException e) {
       throw new VeniceMessageException("Could not initialize " + KafkaValueSerializer.class.getSimpleName(), e);
     }
-  }
-
-  @Test
-  public void testKMEProtocolCompatibility() throws InterruptedException {
-    Map<Integer, Schema> schemaMap = initKMEProtocolMap();
-    int latestSchemaId = schemaMap.size();
-    testProtocolCompatibility(schemaMap, latestSchemaId);
   }
 }


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci], [server], [controller],
[router], [samza], [vpj], [fast-client], [thin-client], [alpini],
[admin-tool], [test], [build], [doc], [script]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Summary, imperative, start upper case, don't end with a period
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

This PR fixes the incompatible v11 KME with the deletion of the deprecated `StartOfBufferReplay` control message. We plan to keep this control message in case some old topics still have this messages causing ingestion error. Besides, add a unit test to test the compatibility of newest KME protocol. 

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
Internal CI
## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.