### PR TITLE
[server][vpj] Producing chunks is now async

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveProducerCallback.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveProducerCallback.java
@@ -1,0 +1,59 @@
+package com.linkedin.davinci.kafka.consumer;
+
+import com.linkedin.venice.kafka.protocol.KafkaMessageEnvelope;
+import com.linkedin.venice.kafka.protocol.Put;
+import com.linkedin.venice.message.KafkaKey;
+import com.linkedin.venice.writer.VeniceWriter;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.producer.RecordMetadata;
+
+
+public class ActiveActiveProducerCallback extends LeaderProducerCallback {
+  private static final Runnable NO_OP = () -> {};
+  private Runnable onCompletionFunction = NO_OP;
+
+  public ActiveActiveProducerCallback(
+      LeaderFollowerStoreIngestionTask ingestionTask,
+      ConsumerRecord<KafkaKey, KafkaMessageEnvelope> sourceConsumerRecord,
+      PartitionConsumptionState partitionConsumptionState,
+      LeaderProducedRecordContext leaderProducedRecordContext,
+      int subPartition,
+      String kafkaUrl,
+      long beforeProcessingRecordTimestamp) {
+    super(
+        ingestionTask,
+        sourceConsumerRecord,
+        partitionConsumptionState,
+        leaderProducedRecordContext,
+        subPartition,
+        kafkaUrl,
+        beforeProcessingRecordTimestamp);
+  }
+
+  @Override
+  public void onCompletion(RecordMetadata recordMetadata, Exception exception) {
+    this.onCompletionFunction.run();
+    super.onCompletion(recordMetadata, exception);
+  }
+
+  @Override
+  protected Put instantiateChunkPut() {
+    Put chunkPut = new Put();
+    chunkPut.replicationMetadataPayload = EMPTY_BYTE_BUFFER;
+    chunkPut.replicationMetadataVersionId = VeniceWriter.VENICE_DEFAULT_TIMESTAMP_METADATA_VERSION_ID;
+    return chunkPut;
+  }
+
+  @Override
+  protected Put instantiateManifestPut() {
+    Put manifestPut = new Put();
+    Put leaderProducedRecordContextPut = (Put) leaderProducedRecordContext.getValueUnion();
+    manifestPut.replicationMetadataVersionId = leaderProducedRecordContextPut.replicationMetadataVersionId;
+    manifestPut.replicationMetadataPayload = leaderProducedRecordContextPut.replicationMetadataPayload;
+    return manifestPut;
+  }
+
+  public void setOnCompletionFunction(Runnable onCompletionFunction) {
+    this.onCompletionFunction = onCompletionFunction;
+  }
+}

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
@@ -33,12 +33,10 @@ import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.offsets.OffsetRecord;
 import com.linkedin.venice.schema.rmd.RmdUtils;
-import com.linkedin.venice.storage.protocol.ChunkedValueManifest;
 import com.linkedin.venice.utils.ByteUtils;
 import com.linkedin.venice.utils.LatencyUtils;
 import com.linkedin.venice.utils.Time;
 import com.linkedin.venice.utils.lazy.Lazy;
-import com.linkedin.venice.writer.ChunkAwareCallback;
 import com.linkedin.venice.writer.DeleteMetadata;
 import com.linkedin.venice.writer.PutMetadata;
 import com.linkedin.venice.writer.VeniceWriter;
@@ -57,7 +55,6 @@ import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.BooleanSupplier;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
-import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -1279,68 +1276,42 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
       ByteBuffer updatedRmdBytes,
       int valueSchemaId,
       boolean resultReuseInput) {
-    return (callback, sourceTopicOffset) -> {
-      final ChunkAwareCallback newCallback = new ChunkAwareCallback() {
-        @Override
-        public void setChunkingInfo(
-            byte[] key,
-            ByteBuffer[] valueChunks,
-            ChunkedValueManifest chunkedValueManifest,
-            ByteBuffer[] rmdChunks,
-            ChunkedValueManifest chunkedRmdManifest) {
-          ((ChunkAwareCallback) callback)
-              .setChunkingInfo(key, valueChunks, chunkedValueManifest, rmdChunks, chunkedRmdManifest);
-        }
-
-        @Override
-        public void onCompletion(RecordMetadata recordMetadata, Exception exception) {
-          if (resultReuseInput) {
-            // Restore the original header so this function is eventually idempotent as the original KME ByteBuffer
-            // will be recovered after producing the message to Kafka or if the production failing.
-            ByteUtils.prependIntHeaderToByteBuffer(
+    return (callback, leaderMetadataWrapper) -> {
+      if (resultReuseInput) {
+        // Restore the original header so this function is eventually idempotent as the original KME ByteBuffer
+        // will be recovered after producing the message to Kafka or if the production failing.
+        ((ActiveActiveProducerCallback) callback).setOnCompletionFunction(
+            () -> ByteUtils.prependIntHeaderToByteBuffer(
                 updatedValueBytes,
                 ByteUtils.getIntHeaderFromByteBuffer(updatedValueBytes),
-                true);
-          }
-          callback.onCompletion(recordMetadata, exception);
-        }
-      };
+                true));
+      }
       return getVeniceWriter().get()
           .put(
               key,
               ByteUtils.extractByteArray(updatedValueBytes),
               valueSchemaId,
-              newCallback,
-              sourceTopicOffset,
+              callback,
+              leaderMetadataWrapper,
               VeniceWriter.APP_DEFAULT_LOGICAL_TS,
-              Optional.of(new PutMetadata(getRmdProtocolVersionID(), updatedRmdBytes)));
+              new PutMetadata(getRmdProtocolVersionID(), updatedRmdBytes));
     };
   }
 
-  protected LeaderProducerCallback createLeaderProducerCallback(
+  protected LeaderProducerCallback createProducerCallback(
       ConsumerRecord<KafkaKey, KafkaMessageEnvelope> consumerRecord,
       PartitionConsumptionState partitionConsumptionState,
       LeaderProducedRecordContext leaderProducedRecordContext,
       int subPartition,
       String kafkaUrl,
       long beforeProcessingRecordTimestamp) {
-    int partition = consumerRecord.partition();
-    String leaderTopic = consumerRecord.topic();
-    return new LeaderProducerCallback(
+    return new ActiveActiveProducerCallback(
         this,
         consumerRecord,
         partitionConsumptionState,
         leaderProducedRecordContext,
-        leaderTopic,
-        getKafkaVersionTopic(),
-        partition,
         subPartition,
         kafkaUrl,
-        getVersionedDIVStats(),
-        getVersionIngestionStats(),
-        getHostLevelIngestionStats(),
-        System.nanoTime(),
-        beforeProcessingRecordTimestamp,
-        true);
+        beforeProcessingRecordTimestamp);
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -1451,7 +1451,7 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
       String kafkaUrl,
       int kafkaClusterId,
       long beforeProcessingRecordTimestamp) {
-    LeaderProducerCallback callback = createLeaderProducerCallback(
+    LeaderProducerCallback callback = createProducerCallback(
         consumerRecord,
         partitionConsumptionState,
         leaderProducedRecordContext,
@@ -3013,31 +3013,21 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
     return lag;
   }
 
-  protected LeaderProducerCallback createLeaderProducerCallback(
+  protected LeaderProducerCallback createProducerCallback(
       ConsumerRecord<KafkaKey, KafkaMessageEnvelope> consumerRecord,
       PartitionConsumptionState partitionConsumptionState,
       LeaderProducedRecordContext leaderProducedRecordContext,
       int subPartition,
       String kafkaUrl,
       long beforeProcessingRecordTimestamp) {
-    int partition = consumerRecord.partition();
-    String leaderTopic = consumerRecord.topic();
     return new LeaderProducerCallback(
         this,
         consumerRecord,
         partitionConsumptionState,
         leaderProducedRecordContext,
-        leaderTopic,
-        getKafkaVersionTopic(),
-        partition,
         subPartition,
         kafkaUrl,
-        getVersionedDIVStats(),
-        getVersionIngestionStats(),
-        getHostLevelIngestionStats(),
-        System.nanoTime(),
-        beforeProcessingRecordTimestamp,
-        false);
+        beforeProcessingRecordTimestamp);
   }
 
   protected Lazy<VeniceWriter<byte[], byte[], byte[]>> getVeniceWriter() {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderProducerCallback.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderProducerCallback.java
@@ -154,7 +154,7 @@ class LeaderProducerCallback implements ChunkAwareCallback {
             chunkPut.schemaId = schemaId;
 
             LeaderProducedRecordContext producedRecordForChunk =
-                LeaderProducedRecordContext.newPutRecord(-1, -1, ByteUtils.extractByteArray(chunkKey), chunkPut);
+                LeaderProducedRecordContext.newChunkPutRecord(ByteUtils.extractByteArray(chunkKey), chunkPut);
             producedRecordForChunk.setProducedOffset(-1);
             ingestionTask.produceToStoreBufferService(
                 sourceConsumerRecord,

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderProducerCallback.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderProducerCallback.java
@@ -1,17 +1,12 @@
 package com.linkedin.davinci.kafka.consumer;
 
 import static com.linkedin.davinci.kafka.consumer.LeaderFollowerStateType.LEADER;
-import static com.linkedin.venice.writer.VeniceWriter.VENICE_DEFAULT_TIMESTAMP_METADATA_VERSION_ID;
 
-import com.linkedin.davinci.stats.AggVersionedDIVStats;
-import com.linkedin.davinci.stats.AggVersionedIngestionStats;
-import com.linkedin.davinci.stats.HostLevelIngestionStats;
 import com.linkedin.davinci.store.record.ValueRecord;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.kafka.protocol.KafkaMessageEnvelope;
 import com.linkedin.venice.kafka.protocol.Put;
 import com.linkedin.venice.message.KafkaKey;
-import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.serialization.avro.AvroProtocolDefinition;
 import com.linkedin.venice.serialization.avro.ChunkedValueManifestSerializer;
 import com.linkedin.venice.storage.protocol.ChunkedValueManifest;
@@ -30,28 +25,21 @@ class LeaderProducerCallback implements ChunkAwareCallback {
 
   protected static final ChunkedValueManifestSerializer CHUNKED_VALUE_MANIFEST_SERIALIZER =
       new ChunkedValueManifestSerializer(false);
-  private static final ByteBuffer EMPTY_BYTE_BUFFER = ByteBuffer.allocate(0);
+  protected static final ByteBuffer EMPTY_BYTE_BUFFER = ByteBuffer.allocate(0);
 
   private final LeaderFollowerStoreIngestionTask ingestionTask;
   private final ConsumerRecord<KafkaKey, KafkaMessageEnvelope> sourceConsumerRecord;
   private final PartitionConsumptionState partitionConsumptionState;
-  private final String leaderTopic;
-  private final String versionTopic;
-  private final int partition;
   private final int subPartition;
   private final String kafkaUrl;
-  private final AggVersionedDIVStats versionedDIVStats;
-  private final LeaderProducedRecordContext leaderProducedRecordContext;
-  private final AggVersionedIngestionStats versionedStorageIngestionStats;
-  private final HostLevelIngestionStats hostLevelIngestionStats;
+  protected final LeaderProducedRecordContext leaderProducedRecordContext;
   private final long produceTimeNs;
   private final long beforeProcessingRecordTimestamp;
-  private final boolean isActiveActiveReplication;
 
   /**
    * The mutable fields below are determined by the {@link com.linkedin.venice.writer.VeniceWriter},
-   * which populates them via {@link ChunkAwareCallback#setChunkingInfo(byte[], ByteBuffer[],
-   * ChunkedValueManifest, ByteBuffer[], ChunkedValueManifest)}.
+   * which populates them via:
+   * {@link ChunkAwareCallback#setChunkingInfo(byte[], ByteBuffer[], ChunkedValueManifest, ByteBuffer[], ChunkedValueManifest)}
    */
   private byte[] key = null;
   private ChunkedValueManifest chunkedValueManifest = null;
@@ -64,43 +52,29 @@ class LeaderProducerCallback implements ChunkAwareCallback {
       ConsumerRecord<KafkaKey, KafkaMessageEnvelope> sourceConsumerRecord,
       PartitionConsumptionState partitionConsumptionState,
       LeaderProducedRecordContext leaderProducedRecordContext,
-      String leaderTopic,
-      String versionTopic,
-      int partition,
       int subPartition,
       String kafkaUrl,
-      AggVersionedDIVStats versionedDIVStats,
-      AggVersionedIngestionStats versionedStorageIngestionStats,
-      HostLevelIngestionStats hostLevelIngestionStats,
-      long produceTimeNs,
-      long beforeProcessingRecordTimestamp,
-      boolean isActiveActiveReplication) {
+      long beforeProcessingRecordTimestamp) {
     this.ingestionTask = ingestionTask;
     this.sourceConsumerRecord = sourceConsumerRecord;
     this.partitionConsumptionState = partitionConsumptionState;
-    this.leaderTopic = leaderTopic;
-    this.versionTopic = versionTopic;
-    this.partition = partition;
     this.subPartition = subPartition;
     this.kafkaUrl = kafkaUrl;
-    this.versionedDIVStats = versionedDIVStats;
     this.leaderProducedRecordContext = leaderProducedRecordContext;
-    this.produceTimeNs = produceTimeNs;
-    this.versionedStorageIngestionStats = versionedStorageIngestionStats;
-    this.hostLevelIngestionStats = hostLevelIngestionStats;
+    this.produceTimeNs = System.nanoTime();
     this.beforeProcessingRecordTimestamp = beforeProcessingRecordTimestamp;
-    this.isActiveActiveReplication = isActiveActiveReplication;
   }
 
   @Override
   public void onCompletion(RecordMetadata recordMetadata, Exception e) {
     if (e != null) {
       LOGGER.error(
-          "Leader failed to send out message to version topic when consuming " + leaderTopic + " partition "
-              + partition,
+          "Leader failed to send out message to version topic when consuming {} partition {}",
+          sourceConsumerRecord.topic(),
+          sourceConsumerRecord.partition(),
           e);
-      int version = Version.parseVersionFromKafkaTopicName(versionTopic);
-      versionedDIVStats.recordLeaderProducerFailure(ingestionTask.getStoreName(), version);
+      ingestionTask.getVersionedDIVStats()
+          .recordLeaderProducerFailure(ingestionTask.getStoreName(), ingestionTask.versionNumber);
     } else {
       // recordMetadata.partition() represents the partition being written by VeniceWriter
       // partitionConsumptionState.getPartition() is leaderSubPartition
@@ -137,10 +111,11 @@ class LeaderProducerCallback implements ChunkAwareCallback {
       // queuing to drainer.
       // this indicates how much time kafka took to deliver the message to broker.
       if (!ingestionTask.isUserSystemStore()) {
-        versionedDIVStats.recordLeaderProducerCompletionTime(
-            ingestionTask.getStoreName(),
-            ingestionTask.versionNumber,
-            LatencyUtils.getLatencyInMS(produceTimeNs));
+        ingestionTask.getVersionedDIVStats()
+            .recordLeaderProducerCompletionTime(
+                ingestionTask.getStoreName(),
+                ingestionTask.versionNumber,
+                LatencyUtils.getLatencyInMS(produceTimeNs));
       }
 
       int producedRecordNum = 0;
@@ -174,13 +149,9 @@ class LeaderProducerCallback implements ChunkAwareCallback {
             ByteBuffer chunkKey = chunkedValueManifest.keysWithChunkIdSuffix.get(i);
             ByteBuffer chunkValue = valueChunks[i];
 
-            Put chunkPut = new Put();
+            Put chunkPut = instantiateChunkPut();
             chunkPut.putValue = chunkValue;
             chunkPut.schemaId = schemaId;
-            if (isActiveActiveReplication) {
-              chunkPut.replicationMetadataPayload = EMPTY_BYTE_BUFFER;
-              chunkPut.replicationMetadataVersionId = VENICE_DEFAULT_TIMESTAMP_METADATA_VERSION_ID;
-            }
 
             LeaderProducedRecordContext producedRecordForChunk =
                 LeaderProducedRecordContext.newPutRecord(-1, -1, ByteUtils.extractByteArray(chunkKey), chunkPut);
@@ -197,8 +168,7 @@ class LeaderProducerCallback implements ChunkAwareCallback {
 
           // produce the manifest inside the top-level key
           schemaId = AvroProtocolDefinition.CHUNKED_VALUE_MANIFEST.getCurrentProtocolVersion();
-          ByteBuffer manifest =
-              ByteBuffer.wrap(CHUNKED_VALUE_MANIFEST_SERIALIZER.serialize(versionTopic, chunkedValueManifest));
+          ByteBuffer manifest = CHUNKED_VALUE_MANIFEST_SERIALIZER.serialize(chunkedValueManifest);
           /**
            * The byte[] coming out of the {@link CHUNKED_VALUE_MANIFEST_SERIALIZER} is padded in front, so
            * that the put to the storage engine can avoid a copy, but we need to set the position to skip
@@ -206,15 +176,9 @@ class LeaderProducerCallback implements ChunkAwareCallback {
            */
           manifest.position(ValueRecord.SCHEMA_HEADER_LENGTH);
 
-          Put manifestPut = new Put();
+          Put manifestPut = instantiateManifestPut();
           manifestPut.putValue = manifest;
           manifestPut.schemaId = schemaId;
-          if (isActiveActiveReplication) {
-            manifestPut.replicationMetadataVersionId =
-                ((Put) leaderProducedRecordContext.getValueUnion()).replicationMetadataVersionId;
-            manifestPut.replicationMetadataPayload =
-                ((Put) leaderProducedRecordContext.getValueUnion()).replicationMetadataPayload;
-          }
 
           LeaderProducedRecordContext producedRecordForManifest = LeaderProducedRecordContext.newPutRecordWithFuture(
               leaderProducedRecordContext.getConsumedKafkaClusterId(),
@@ -244,7 +208,7 @@ class LeaderProducerCallback implements ChunkAwareCallback {
         // If EOP is not received yet, set the ingestion task exception so that ingestion will fail eventually.
         if (!endOfPushReceived) {
           try {
-            ingestionTask.offerProducerException(oe, partition);
+            ingestionTask.offerProducerException(oe, sourceConsumerRecord.partition());
           } catch (VeniceException offerToQueueException) {
             ingestionTask.setLastStoreIngestionException(offerToQueueException);
           }
@@ -272,12 +236,21 @@ class LeaderProducerCallback implements ChunkAwareCallback {
   }
 
   private void recordProducerStats(int producedRecordSize, int producedRecordNum) {
-    versionedStorageIngestionStats.recordLeaderProduced(
-        ingestionTask.getStoreName(),
-        ingestionTask.versionNumber,
-        producedRecordSize,
-        producedRecordNum);
-    hostLevelIngestionStats.recordTotalLeaderBytesProduced(producedRecordSize);
-    hostLevelIngestionStats.recordTotalLeaderRecordsProduced(producedRecordNum);
+    ingestionTask.getVersionIngestionStats()
+        .recordLeaderProduced(
+            ingestionTask.getStoreName(),
+            ingestionTask.versionNumber,
+            producedRecordSize,
+            producedRecordNum);
+    ingestionTask.getHostLevelIngestionStats().recordTotalLeaderBytesProduced(producedRecordSize);
+    ingestionTask.getHostLevelIngestionStats().recordTotalLeaderRecordsProduced(producedRecordNum);
+  }
+
+  protected Put instantiateChunkPut() {
+    return new Put();
+  }
+
+  protected Put instantiateManifestPut() {
+    return new Put();
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -2753,7 +2753,14 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
        * 3. The DIV info checkpoint on disk must match the actual data persistence which is done inside drainer threads.
        */
       try {
-        validateMessage(this.kafkaDataIntegrityValidator, consumerRecord, endOfPushReceived, subPartition);
+        if (leaderProducedRecordContext == null || leaderProducedRecordContext.hasCorrespondingUpstreamMessage()) {
+          /**
+           * N.B.: If a leader server is processing a chunk, then the {@link consumerRecord} is going to be the same for
+           * every chunk, and we don't want to treat them as dupes, hence we skip DIV. The DIV state will get updated on
+           * the last message of the sequence, which is not a chunk but rather the manifest.
+           */
+          validateMessage(this.kafkaDataIntegrityValidator, consumerRecord, endOfPushReceived, subPartition);
+        }
         versionedDIVStats.recordSuccessMsg(storeName, versionNumber);
       } catch (FatalDataValidationException fatalException) {
         if (!endOfPushReceived) {

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTaskTest.java
@@ -62,7 +62,7 @@ public class ActiveActiveStoreIngestionTaskTest {
     when(ingestionTask.getVersionIngestionStats()).thenReturn(mock(AggVersionedIngestionStats.class));
     when(ingestionTask.getVersionedDIVStats()).thenReturn(mock(AggVersionedDIVStats.class));
     when(ingestionTask.getKafkaVersionTopic()).thenReturn(testTopic);
-    when(ingestionTask.createLeaderProducerCallback(any(), any(), any(), anyInt(), anyString(), anyLong()))
+    when(ingestionTask.createProducerCallback(any(), any(), any(), anyInt(), anyString(), anyLong()))
         .thenCallRealMethod();
     when(ingestionTask.getProduceToTopicFunction(any(), any(), any(), anyInt(), anyBoolean())).thenCallRealMethod();
     when(ingestionTask.getRmdProtocolVersionID()).thenReturn(rmdProtocolVersionID);

--- a/internal/venice-common/src/main/java/com/linkedin/venice/serialization/avro/InternalAvroSpecificSerializer.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/serialization/avro/InternalAvroSpecificSerializer.java
@@ -9,6 +9,7 @@ import com.linkedin.venice.utils.ByteUtils;
 import com.linkedin.venice.utils.Utils;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
@@ -182,7 +183,7 @@ public class InternalAvroSpecificSerializer<SPECIFIC_RECORD extends SpecificReco
   /**
    * Construct an array of bytes from the given object
    *
-   * @param topic  Topic to which the object belongs.
+   * @param topic  Topic to which the object belongs (for API compatibility reason only, but unused)
    * @param object A {@link SPECIFIC_RECORD} instance to be serialized.
    * @return The Avro binary format bytes which represent the {@param object}
    */
@@ -221,6 +222,10 @@ public class InternalAvroSpecificSerializer<SPECIFIC_RECORD extends SpecificReco
           this.getClass().getSimpleName() + " failed to encode message: " + object.toString(),
           e);
     }
+  }
+
+  public ByteBuffer serialize(SPECIFIC_RECORD object) {
+    return ByteBuffer.wrap(serialize(null, object));
   }
 
   /**

--- a/internal/venice-common/src/main/java/com/linkedin/venice/writer/ChunkAwareCallback.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/writer/ChunkAwareCallback.java
@@ -7,8 +7,8 @@ import org.apache.kafka.clients.producer.Callback;
 
 /**
  *  The {@link VeniceWriter}, upon detecting an instance of this class being passed to it, will always call
- *  the {@link #setChunkingInfo(byte[], ByteBuffer[], ChunkedValueManifest)} API whenever processing a
- *  {@link com.linkedin.venice.kafka.protocol.enums.MessageType#PUT}, whether it is chunked or not.
+ *  {@link #setChunkingInfo(byte[], ByteBuffer[], ChunkedValueManifest, ByteBuffer[], ChunkedValueManifest)} whenever
+ *  processing a {@link com.linkedin.venice.kafka.protocol.enums.MessageType#PUT}, whether it is chunked or not.
  */
 public interface ChunkAwareCallback extends Callback {
   /**

--- a/internal/venice-common/src/main/java/com/linkedin/venice/writer/ErrorPropagationCallback.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/writer/ErrorPropagationCallback.java
@@ -1,0 +1,23 @@
+package com.linkedin.venice.writer;
+
+import org.apache.kafka.clients.producer.Callback;
+import org.apache.kafka.clients.producer.RecordMetadata;
+
+
+/**
+ * Wraps another {@link Callback} and propagates exceptions to it, but swallows successful completions.
+ */
+class ErrorPropagationCallback implements Callback {
+  private final Callback callback;
+
+  public ErrorPropagationCallback(Callback callback) {
+    this.callback = callback;
+  }
+
+  @Override
+  public void onCompletion(RecordMetadata metadata, Exception exception) {
+    if (exception != null) {
+      callback.onCompletion(null, exception);
+    } // else, no-op
+  }
+}

--- a/internal/venice-common/src/main/java/com/linkedin/venice/writer/PutMetadata.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/writer/PutMetadata.java
@@ -2,13 +2,12 @@ package com.linkedin.venice.writer;
 
 import com.linkedin.venice.utils.ByteUtils;
 import java.nio.ByteBuffer;
-import java.util.Optional;
 import org.apache.kafka.clients.producer.Callback;
 
 
 /**
  * This is a simple container class to hold replication metadata related fields together to be passed on to the Put api in VeniceWriter
- * {@link VeniceWriter#put(Object, Object, int, Callback, LeaderMetadataWrapper, long, Optional)}. Caller should construct an instance of this object by properly
+ * {@link VeniceWriter#put(Object, Object, int, Callback, LeaderMetadataWrapper, long, PutMetadata)}. Caller should construct an instance of this object by properly
  * filling up all the fields of this object.
  */
 public class PutMetadata {

--- a/internal/venice-common/src/main/java/com/linkedin/venice/writer/VeniceWriter.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/writer/VeniceWriter.java
@@ -38,6 +38,7 @@ import com.linkedin.venice.serialization.avro.AvroProtocolDefinition;
 import com.linkedin.venice.serialization.avro.ChunkedValueManifestSerializer;
 import com.linkedin.venice.storage.protocol.ChunkedKeySuffix;
 import com.linkedin.venice.storage.protocol.ChunkedValueManifest;
+import com.linkedin.venice.utils.ByteUtils;
 import com.linkedin.venice.utils.ExceptionUtils;
 import com.linkedin.venice.utils.LatencyUtils;
 import com.linkedin.venice.utils.Time;
@@ -54,6 +55,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.BiConsumer;
 import java.util.function.Supplier;
 import javax.annotation.Nonnull;
 import org.apache.avro.specific.FixedSize;
@@ -72,6 +74,8 @@ import org.apache.logging.log4j.Logger;
  */
 @Threadsafe
 public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
+  private static final ChunkedPayloadAndManifest EMPTY_CHUNKED_PAYLOAD_AND_MANIFEST =
+      new ChunkedPayloadAndManifest(null, null);
 
   // log4j logger
   private final Logger logger;
@@ -180,7 +184,9 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
    */
   public static final int VENICE_DEFAULT_VALUE_SCHEMA_ID = -1;
 
-  private static final ByteBuffer EMPTY_BYTE_BUFFER = ByteBuffer.allocate(0);
+  private static final byte[] EMPTY_BYTE_ARRAY = new byte[0];
+
+  private static final ByteBuffer EMPTY_BYTE_BUFFER = ByteBuffer.wrap(EMPTY_BYTE_ARRAY);
 
   public static final LeaderMetadataWrapper DEFAULT_LEADER_METADATA_WRAPPER =
       new LeaderMetadataWrapper(DEFAULT_UPSTREAM_OFFSET, DEFAULT_UPSTREAM_KAFKA_CLUSTER_ID);
@@ -384,7 +390,7 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
    * completes and then return the metadata for the record or throw any exception that occurred while sending the record.
    */
   public Future<RecordMetadata> delete(K key, Callback callback) {
-    return delete(key, callback, DEFAULT_LEADER_METADATA_WRAPPER, APP_DEFAULT_LOGICAL_TS, Optional.empty());
+    return delete(key, callback, DEFAULT_LEADER_METADATA_WRAPPER, APP_DEFAULT_LOGICAL_TS, null);
   }
 
   /**
@@ -398,7 +404,7 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
    * completes and then return the metadata for the record or throw any exception that occurred while sending the record.
    */
   public Future<RecordMetadata> delete(K key, long logicalTs, Callback callback) {
-    return delete(key, callback, DEFAULT_LEADER_METADATA_WRAPPER, logicalTs, Optional.empty());
+    return delete(key, callback, DEFAULT_LEADER_METADATA_WRAPPER, logicalTs, null);
   }
 
   /**
@@ -416,7 +422,7 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
    * completes and then return the metadata for the record or throw any exception that occurred while sending the record.
    */
   public Future<RecordMetadata> delete(K key, Callback callback, LeaderMetadataWrapper leaderMetadataWrapper) {
-    return delete(key, callback, leaderMetadataWrapper, APP_DEFAULT_LOGICAL_TS, Optional.empty());
+    return delete(key, callback, leaderMetadataWrapper, APP_DEFAULT_LOGICAL_TS, null);
   }
 
   /**
@@ -439,7 +445,7 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
       Callback callback,
       LeaderMetadataWrapper leaderMetadataWrapper,
       long logicalTs) {
-    return delete(key, callback, leaderMetadataWrapper, logicalTs, Optional.empty());
+    return delete(key, callback, leaderMetadataWrapper, logicalTs, null);
   }
 
   /**
@@ -462,17 +468,12 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
       Callback callback,
       LeaderMetadataWrapper leaderMetadataWrapper,
       DeleteMetadata deleteMetadata) {
-    return delete(key, callback, leaderMetadataWrapper, APP_DEFAULT_LOGICAL_TS, Optional.ofNullable(deleteMetadata));
+    return delete(key, callback, leaderMetadataWrapper, APP_DEFAULT_LOGICAL_TS, deleteMetadata);
   }
 
   @Override
   public Future<RecordMetadata> delete(K key, Callback callback, DeleteMetadata deleteMetadata) {
-    return delete(
-        key,
-        callback,
-        DEFAULT_LEADER_METADATA_WRAPPER,
-        APP_DEFAULT_LOGICAL_TS,
-        Optional.ofNullable(deleteMetadata));
+    return delete(key, callback, DEFAULT_LEADER_METADATA_WRAPPER, APP_DEFAULT_LOGICAL_TS, deleteMetadata);
   }
 
   /**
@@ -486,7 +487,7 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
    *                         >=0: Leader replica consumes a delete message from real-time topic, VeniceWriter in leader
    *                              is sending this message to version topic with extra info: offset in the real-time topic.
    * @param logicalTs - An timestamp field to indicate when this record was produced from apps point of view.
-   * @param deleteMetadata - an optional DeleteMetadata containing replication metadata related fields.
+   * @param deleteMetadata - a DeleteMetadata containing replication metadata related fields (can be null).
    * @return a java.util.concurrent.Future Future for the RecordMetadata that will be assigned to this
    * record. Invoking java.util.concurrent.Future's get() on this future will block until the associated request
    * completes and then return the metadata for the record or throw any exception that occurred while sending the record.
@@ -496,11 +497,11 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
       Callback callback,
       LeaderMetadataWrapper leaderMetadataWrapper,
       long logicalTs,
-      Optional<DeleteMetadata> deleteMetadata) {
+      DeleteMetadata deleteMetadata) {
     byte[] serializedKey = keySerializer.serialize(topicName, key);
     isChunkingFlagInvoked = true;
 
-    int rmdPayloadSize = deleteMetadata.map(DeleteMetadata::getSerializedSize).orElse(0);
+    int rmdPayloadSize = deleteMetadata == null ? 0 : deleteMetadata.getSerializedSize();
     if (serializedKey.length + rmdPayloadSize > maxSizeForUserPayloadPerMessageInBytes) {
       throw new RecordTooLargeException(
           "This record exceeds the maximum size. " + getSizeReport(serializedKey.length, 0, rmdPayloadSize));
@@ -519,14 +520,14 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
     int partition = getPartition(kafkaKey);
 
     Delete delete = new Delete();
-    if (deleteMetadata.isPresent()) {
-      delete.schemaId = deleteMetadata.get().getValueSchemaId();
-      delete.replicationMetadataVersionId = deleteMetadata.get().getRmdVersionId();
-      delete.replicationMetadataPayload = deleteMetadata.get().getRmdPayload();
-    } else {
+    if (deleteMetadata == null) {
       delete.schemaId = VENICE_DEFAULT_VALUE_SCHEMA_ID;
       delete.replicationMetadataVersionId = VENICE_DEFAULT_TIMESTAMP_METADATA_VERSION_ID;
       delete.replicationMetadataPayload = EMPTY_BYTE_BUFFER;
+    } else {
+      delete.schemaId = deleteMetadata.getValueSchemaId();
+      delete.replicationMetadataVersionId = deleteMetadata.getRmdVersionId();
+      delete.replicationMetadataPayload = deleteMetadata.getRmdPayload();
     }
 
     return sendMessage(
@@ -536,7 +537,7 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
         partition,
         callback,
         leaderMetadataWrapper,
-        Optional.of(logicalTs));
+        logicalTs);
   }
 
   /**
@@ -552,14 +553,7 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
    */
   @Override
   public Future<RecordMetadata> put(K key, V value, int valueSchemaId, Callback callback) {
-    return put(
-        key,
-        value,
-        valueSchemaId,
-        callback,
-        DEFAULT_LEADER_METADATA_WRAPPER,
-        APP_DEFAULT_LOGICAL_TS,
-        Optional.empty());
+    return put(key, value, valueSchemaId, callback, DEFAULT_LEADER_METADATA_WRAPPER, APP_DEFAULT_LOGICAL_TS, null);
   }
 
   @Override
@@ -571,7 +565,7 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
         callback,
         DEFAULT_LEADER_METADATA_WRAPPER,
         APP_DEFAULT_LOGICAL_TS,
-        Optional.ofNullable(putMetadata));
+        putMetadata);
   }
 
   /**
@@ -580,14 +574,14 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
    * @param key   - The key to put in storage.
    * @param value - The value to be associated with the given key
    * @param valueSchemaId - value schema id for the given value
-   * @param logicalTs - An optional timestamp field to indicate when this record was produced from apps view.
+   * @param logicalTs - A timestamp field to indicate when this record was produced from apps view.
    * @param callback - Callback function invoked by Kafka producer after sending the message
    * @return a java.util.concurrent.Future Future for the RecordMetadata that will be assigned to this
    * record. Invoking java.util.concurrent.Future's get() on this future will block until the associated request
    * completes and then return the metadata for the record or throw any exception that occurred while sending the record.
    */
   public Future<RecordMetadata> put(K key, V value, int valueSchemaId, long logicalTs, Callback callback) {
-    return put(key, value, valueSchemaId, callback, DEFAULT_LEADER_METADATA_WRAPPER, logicalTs, Optional.empty());
+    return put(key, value, valueSchemaId, callback, DEFAULT_LEADER_METADATA_WRAPPER, logicalTs, null);
   }
 
   /**
@@ -605,7 +599,7 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
       int valueSchemaId,
       Callback callback,
       LeaderMetadataWrapper leaderMetadataWrapper) {
-    return put(key, value, valueSchemaId, callback, leaderMetadataWrapper, APP_DEFAULT_LOGICAL_TS, Optional.empty());
+    return put(key, value, valueSchemaId, callback, leaderMetadataWrapper, APP_DEFAULT_LOGICAL_TS, null);
   }
 
   /**
@@ -623,7 +617,7 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
    *    >=0: Leader replica consumes a put message from real-time topic, VeniceWriter in leader
    *         is sending this message to version topic with extra info: offset in the real-time topic.
    * @param logicalTs - An timestamp field to indicate when this record was produced from apps view.
-   * @param putMetadata - an optional PutMetadata containing replication metadata related fields.
+   * @param putMetadata - a PutMetadata containing replication metadata related fields (can be null).
    * @return a java.util.concurrent.Future Future for the RecordMetadata that will be assigned to this
    * record. Invoking java.util.concurrent.Future's get() on this future will block until the associated request
    * completes and then return the metadata for the record or throw any exception that occurred while sending the record.
@@ -635,12 +629,12 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
       Callback callback,
       LeaderMetadataWrapper leaderMetadataWrapper,
       long logicalTs,
-      Optional<PutMetadata> putMetadata) {
+      PutMetadata putMetadata) {
     byte[] serializedKey = keySerializer.serialize(topicName, key);
     byte[] serializedValue = valueSerializer.serialize(topicName, value);
     int partition = getPartition(serializedKey);
 
-    int replicationMetadataPayloadSize = putMetadata.isPresent() ? putMetadata.get().getSerializedSize() : 0;
+    int replicationMetadataPayloadSize = putMetadata == null ? 0 : putMetadata.getSerializedSize();
     isChunkingFlagInvoked = true;
     if (serializedKey.length + serializedValue.length
         + replicationMetadataPayloadSize > maxSizeForUserPayloadPerMessageInBytes) {
@@ -676,12 +670,12 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
     putPayload.putValue = ByteBuffer.wrap(serializedValue);
     putPayload.schemaId = valueSchemaId;
 
-    if (putMetadata.isPresent()) {
-      putPayload.replicationMetadataVersionId = putMetadata.get().getRmdVersionId();
-      putPayload.replicationMetadataPayload = putMetadata.get().getRmdPayload();
-    } else {
+    if (putMetadata == null) {
       putPayload.replicationMetadataVersionId = VENICE_DEFAULT_TIMESTAMP_METADATA_VERSION_ID;
       putPayload.replicationMetadataPayload = EMPTY_BYTE_BUFFER;
+    } else {
+      putPayload.replicationMetadataVersionId = putMetadata.getRmdVersionId();
+      putPayload.replicationMetadataPayload = putMetadata.getRmdPayload();
     }
     return sendMessage(
         producerMetadata -> kafkaKey,
@@ -690,7 +684,7 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
         partition,
         callback,
         leaderMetadataWrapper,
-        Optional.of(logicalTs));
+        logicalTs);
   }
 
   /**
@@ -800,7 +794,7 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
         partition,
         callback,
         DEFAULT_LEADER_METADATA_WRAPPER,
-        Optional.of(logicalTs));
+        logicalTs);
   }
 
   /**
@@ -1003,7 +997,7 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
       int partition,
       Callback callback,
       LeaderMetadataWrapper leaderMetadataWrapper,
-      Optional<Long> logicalTs) {
+      long logicalTs) {
     return sendMessage(
         keyProvider,
         messageType,
@@ -1025,7 +1019,7 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
       Callback callback,
       boolean updateDIV,
       LeaderMetadataWrapper leaderMetadataWrapper,
-      Optional<Long> logicalTs) {
+      long logicalTs) {
     KafkaMessageEnvelopeProvider kafkaMessageEnvelopeProvider = () -> {
       KafkaMessageEnvelope kafkaValue =
           getKafkaMessageEnvelope(messageType, isEndOfSegment, partition, updateDIV, leaderMetadataWrapper, logicalTs);
@@ -1126,10 +1120,19 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
       int partition,
       LeaderMetadataWrapper leaderMetadataWrapper,
       long logicalTs,
-      Optional<PutMetadata> putMetadata) {
-    int replicationMetadataPayloadSize = putMetadata.map(PutMetadata::getSerializedSize).orElse(0);
+      PutMetadata putMetadata) {
+    int replicationMetadataPayloadSize = putMetadata == null ? 0 : putMetadata.getSerializedSize();
     final Supplier<String> reportSizeGenerator =
         () -> getSizeReport(serializedKey.length, serializedValue.length, replicationMetadataPayloadSize);
+    Callback chunkCallback = callback == null ? null : new ErrorPropagationCallback(callback);
+    BiConsumer<KeyProvider, Put> sendMessageFunction = (keyProvider, putPayload) -> sendMessage(
+        keyProvider,
+        MessageType.PUT,
+        putPayload,
+        partition,
+        chunkCallback,
+        DEFAULT_LEADER_METADATA_WRAPPER,
+        VENICE_DEFAULT_LOGICAL_TS);
     ChunkedPayloadAndManifest valueChunksAndManifest = WriterChunkingHelper.chunkPayloadAndSend(
         serializedKey,
         serializedValue,
@@ -1139,53 +1142,35 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
         reportSizeGenerator,
         maxSizeForUserPayloadPerMessageInBytes,
         keyWithChunkingSuffixSerializer,
-        (keyProvider, putPayload) -> sendMessage(
-            keyProvider,
-            MessageType.PUT,
-            putPayload,
-            partition,
-            null,
-            DEFAULT_LEADER_METADATA_WRAPPER,
-            Optional.empty()));
-    ChunkedPayloadAndManifest rmdChunksAndManifest = null;
-    if (isRmdChunkingEnabled) {
-      rmdChunksAndManifest = WriterChunkingHelper.chunkPayloadAndSend(
-          serializedKey,
-          (putMetadata.isPresent() ? putMetadata.get().getRmdPayload() : EMPTY_BYTE_BUFFER).array(),
-          false,
-          valueSchemaId,
-          callback instanceof ChunkAwareCallback,
-          reportSizeGenerator,
-          maxSizeForUserPayloadPerMessageInBytes,
-          keyWithChunkingSuffixSerializer,
-          (keyProvider, putPayload) -> sendMessage(
-              keyProvider,
-              MessageType.PUT,
-              putPayload,
-              partition,
-              null,
-              DEFAULT_LEADER_METADATA_WRAPPER,
-              Optional.empty()));
-    }
+        sendMessageFunction);
+    ChunkedPayloadAndManifest rmdChunksAndManifest = isRmdChunkingEnabled
+        ? WriterChunkingHelper.chunkPayloadAndSend(
+            serializedKey,
+            putMetadata == null ? EMPTY_BYTE_ARRAY : ByteUtils.extractByteArray(putMetadata.getRmdPayload()),
+            false,
+            valueSchemaId,
+            callback instanceof ChunkAwareCallback,
+            reportSizeGenerator,
+            maxSizeForUserPayloadPerMessageInBytes,
+            keyWithChunkingSuffixSerializer,
+            sendMessageFunction)
+        : EMPTY_CHUNKED_PAYLOAD_AND_MANIFEST;
     // Now that we've sent all the chunks, we can take care of the final value, the manifest.
     byte[] topLevelKey = keyWithChunkingSuffixSerializer.serializeNonChunkedKey(serializedKey);
     KeyProvider manifestKeyProvider = producerMetadata -> new KafkaKey(MessageType.PUT, topLevelKey);
 
     Put putManifestsPayload = new Put();
-    putManifestsPayload.putValue = ByteBuffer
-        .wrap(chunkedValueManifestSerializer.serialize(topicName, valueChunksAndManifest.getChunkedValueManifest()));
+    putManifestsPayload.putValue =
+        chunkedValueManifestSerializer.serialize(valueChunksAndManifest.getChunkedValueManifest());
     putManifestsPayload.schemaId = AvroProtocolDefinition.CHUNKED_VALUE_MANIFEST.getCurrentProtocolVersion();
-    if (putMetadata.isPresent()) {
-      putManifestsPayload.replicationMetadataVersionId = putMetadata.get().getRmdVersionId();
-      if (isRmdChunkingEnabled) {
-        putManifestsPayload.replicationMetadataPayload = ByteBuffer
-            .wrap(chunkedValueManifestSerializer.serialize(topicName, rmdChunksAndManifest.getChunkedValueManifest()));
-      } else {
-        putManifestsPayload.replicationMetadataPayload = putMetadata.get().getRmdPayload();
-      }
-    } else {
+    if (putMetadata == null) {
       putManifestsPayload.replicationMetadataVersionId = VENICE_DEFAULT_TIMESTAMP_METADATA_VERSION_ID;
       putManifestsPayload.replicationMetadataPayload = EMPTY_BYTE_BUFFER;
+    } else {
+      putManifestsPayload.replicationMetadataVersionId = putMetadata.getRmdVersionId();
+      putManifestsPayload.replicationMetadataPayload = isRmdChunkingEnabled
+          ? chunkedValueManifestSerializer.serialize(rmdChunksAndManifest.getChunkedValueManifest())
+          : putMetadata.getRmdPayload();
     }
     final int sizeAvailablePerMessage = maxSizeForUserPayloadPerMessageInBytes - serializedKey.length;
     if (putManifestsPayload.putValue.remaining()
@@ -1197,13 +1182,13 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
     }
 
     if (callback instanceof ChunkAwareCallback) {
-      /** We leave a handle to the key, chunks and manifest so that the {@link ChunkAwareCallback} can act on them */
+      /** We leave a handle to the key, chunks and manifests so that the {@link ChunkAwareCallback} can act on them */
       ((ChunkAwareCallback) callback).setChunkingInfo(
           topLevelKey,
           valueChunksAndManifest.getPayloadChunks(),
           valueChunksAndManifest.getChunkedValueManifest(),
-          rmdChunksAndManifest == null ? null : rmdChunksAndManifest.getPayloadChunks(),
-          rmdChunksAndManifest == null ? null : rmdChunksAndManifest.getChunkedValueManifest());
+          rmdChunksAndManifest.getPayloadChunks(),
+          rmdChunksAndManifest.getChunkedValueManifest());
     }
 
     // We only return the last future (the one for the manifest) and assume that once this one is finished,
@@ -1215,7 +1200,7 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
         partition,
         callback,
         leaderMetadataWrapper,
-        Optional.of(logicalTs));
+        logicalTs);
   }
 
   private String getSizeReport(int serializedKeySize, int serializedValueSize, int replicationMetadataPayloadSize) {
@@ -1320,7 +1305,7 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
    *
    * If the Kafka topic does not exist, this function will back off for {@link #sleepTimeMsWhenTopicMissing}
    * ms and try again for a total of {@link #maxAttemptsWhenTopicMissing} attempts. Note that this back off
-   * and retry behavior does not happen in {@link #sendMessage(KeyProvider, MessageType, Object, int, Callback, LeaderMetadataWrapper, Optional<Long>)}
+   * and retry behavior does not happen in {@link #sendMessage(KeyProvider, MessageType, Object, int, Callback, LeaderMetadataWrapper, long)}
    * because that function returns a {@link Future}, and it is {@link Future#get()} which throws the relevant
    * exception. In any case, the topic should be seeded with a {@link ControlMessageType#START_OF_SEGMENT}
    * at first, and therefore, there should be no cases where a topic has not been created yet and we attempt
@@ -1359,7 +1344,7 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
               callback,
               updateCheckSum,
               leaderMetadataWrapper,
-              Optional.empty()).get();
+              VENICE_DEFAULT_LOGICAL_TS).get();
           return;
         } catch (InterruptedException | ExecutionException e) {
           if (e.getMessage() != null && e.getMessage().contains(Errors.UNKNOWN_TOPIC_OR_PARTITION.message())) {
@@ -1416,7 +1401,7 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
           callback,
           updateCheckSum,
           leaderMetadataWrapper,
-          Optional.empty());
+          VENICE_DEFAULT_LOGICAL_TS);
     }
   }
 
@@ -1463,7 +1448,7 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
       int partition,
       boolean incrementSequenceNumber,
       LeaderMetadataWrapper leaderMetadataWrapper,
-      Optional<Long> logicalTs) {
+      long logicalTs) {
     // If single-threaded, the kafkaValue could be re-used (and clobbered). TODO: explore GC tuning later.
     KafkaMessageEnvelope kafkaValue = new KafkaMessageEnvelope();
     kafkaValue.messageType = messageType.getValue();
@@ -1479,7 +1464,7 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
       producerMetadata.messageSequenceNumber = currentSegment.getSequenceNumber();
     }
     producerMetadata.messageTimestamp = time.getMilliseconds();
-    producerMetadata.logicalTimestamp = logicalTs.orElse(VENICE_DEFAULT_LOGICAL_TS);
+    producerMetadata.logicalTimestamp = logicalTs;
     kafkaValue.producerMetadata = producerMetadata;
     kafkaValue.leaderMetadataFooter = new LeaderMetadata();
     kafkaValue.leaderMetadataFooter.hostName = writerId;

--- a/internal/venice-common/src/main/java/com/linkedin/venice/writer/WriterChunkingHelper.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/writer/WriterChunkingHelper.java
@@ -14,10 +14,8 @@ import com.linkedin.venice.storage.protocol.ChunkedValueManifest;
 import com.linkedin.venice.utils.ByteUtils;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
-import java.util.concurrent.Future;
-import java.util.function.BiFunction;
+import java.util.function.BiConsumer;
 import java.util.function.Supplier;
-import org.apache.kafka.clients.producer.RecordMetadata;
 
 
 /**
@@ -47,7 +45,7 @@ public class WriterChunkingHelper {
       Supplier<String> sizeReport,
       int maxSizeForUserPayloadPerMessageInBytes,
       KeyWithChunkingSuffixSerializer keyWithChunkingSuffixSerializer,
-      BiFunction<VeniceWriter.KeyProvider, Put, Future<RecordMetadata>> sendMessageFunction) {
+      BiConsumer<VeniceWriter.KeyProvider, Put> sendMessageFunction) {
     int sizeAvailablePerMessage = maxSizeForUserPayloadPerMessageInBytes - serializedKey.length;
     validateAvailableSizePerMessage(maxSizeForUserPayloadPerMessageInBytes, sizeAvailablePerMessage, sizeReport);
     int numberOfChunks = (int) Math.ceil((double) payload.length / (double) sizeAvailablePerMessage);
@@ -118,15 +116,8 @@ public class WriterChunkingHelper {
       keyProvider = chunkIndex == 0 ? firstKeyProvider : subsequentKeyProvider;
 
       try {
-        /**
-         * Here are the reasons to do a blocking call of 'sendMessage' with 'null' callback:
-         * 1. We don't want the upper layer know the chunking logic here. Right now, if we pass the callback parameter,
-         * it will cause the job failure because the message count of sent/completed in 'VeniceReducer' won't match;
-         * 2. Blocking call could guarantee correctness;
-         * 3. Infinite blocking means the following 'sendMessage' call will follow the config of the internal Kafka Producer,
-         * such as timeout, retries and so on;
-         */
-        sendMessageFunction.apply(keyProvider, putPayload).get();
+        /** Non-blocking */
+        sendMessageFunction.accept(keyProvider, putPayload);
       } catch (Exception e) {
         throw new VeniceException(
             "Caught an exception while attempting to produce a chunk of a large value into Kafka... "

--- a/internal/venice-common/src/test/java/com/linkedin/venice/writer/VeniceWriterTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/writer/VeniceWriterTest.java
@@ -36,7 +36,6 @@ import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 import java.util.Properties;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
@@ -213,7 +212,7 @@ public class VeniceWriterTest {
         null,
         VeniceWriter.DEFAULT_LEADER_METADATA_WRAPPER,
         ctime,
-        Optional.empty());
+        null);
     writer.put(
         Integer.toString(2),
         Integer.toString(2),
@@ -221,7 +220,7 @@ public class VeniceWriterTest {
         null,
         VeniceWriter.DEFAULT_LEADER_METADATA_WRAPPER,
         VeniceWriter.APP_DEFAULT_LOGICAL_TS,
-        Optional.ofNullable(putMetadata));
+        putMetadata);
     writer.update(Integer.toString(3), Integer.toString(2), 1, 1, null, ctime);
     writer.delete(Integer.toString(4), null, VeniceWriter.DEFAULT_LEADER_METADATA_WRAPPER, ctime);
     writer.delete(Integer.toString(5), null, VeniceWriter.DEFAULT_LEADER_METADATA_WRAPPER, deleteMetadata);

--- a/internal/venice-common/src/test/java/com/linkedin/venice/writer/WriterChunkingHelperTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/writer/WriterChunkingHelperTest.java
@@ -1,7 +1,6 @@
 package com.linkedin.venice.writer;
 
 import com.linkedin.venice.serialization.KeyWithChunkingSuffixSerializer;
-import java.util.concurrent.CompletableFuture;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -21,7 +20,7 @@ public class WriterChunkingHelperTest {
         () -> "",
         maxSizeForUserPayloadPerMessageInBytes,
         new KeyWithChunkingSuffixSerializer(),
-        (x, y) -> CompletableFuture.completedFuture(null));
+        (x, y) -> {});
     Assert.assertEquals(result.getPayloadChunks().length, 5);
   }
 }

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/consumer/ConsumerIntegrationTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/consumer/ConsumerIntegrationTest.java
@@ -38,7 +38,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
@@ -244,7 +243,7 @@ public class ConsumerIntegrationTest {
         int partition,
         boolean incrementSequenceNumber,
         LeaderMetadataWrapper leaderMetadataWrapper,
-        Optional<Long> logicalTs) {
+        long logicalTs) {
       KafkaMessageEnvelope normalKME =
           super.getKafkaMessageEnvelope(messageType, isEndOfSegment, partition, true, leaderMetadataWrapper, logicalTs);
 


### PR DESCRIPTION
The VeniceWriter::putLargeValue function used to block on every chunk, purportedly for reliability reasons, but this appears unnecessary. Furthermore, it imposes a significant throughput penalty on clusters containing stores that exercise both write compute and chunking.

In order to avoid silently swallowing producer errors, we introduce a new class called ErrorPropagationCallback, which forwards exceptions to another Kafka callback, but does nothing on successfully produced messages.

Miscellaneous clean ups:

1. Eliminated unnecessary Optionals from the VeniceWriter's hot path.

2. Eliminated many unnecessary properties from LeaderProducerCallback, greatly simplifying the constructor, and eliminating 4 object pointers (5 for non-A/A) and 2 primitives from each instance.

3. Introduced a ActiveActiveProducerCallback which extends LeaderProducerCallback and specializes some of its behavior for the needs of A/A, thus making the L/F and A/A code better separated, and with fewer branching.

4. Refactored the ActiveActiveStoreIngestionTask::getProduceToTopicFunction so that it does not use an anonymous class, and instantiates one fewer object in some cases.

5. Added a new serialize function to InternalAvroSpecificSerializer which takes out some boilerplate code from a few places.

<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci], [server], [controller],
[router], [samza], [vpj], [fast-client], [thin-client], [alpini],
[admin-tool], [test], [build], [doc], [script]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## How was this PR tested?
CI

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.