### PR TITLE
[samza] Add a function to create a VeniceSystemProducer with a Config…

### DIFF
--- a/clients/venice-samza/src/main/java/com/linkedin/venice/samza/VeniceSystemFactory.java
+++ b/clients/venice-samza/src/main/java/com/linkedin/venice/samza/VeniceSystemFactory.java
@@ -197,6 +197,48 @@ public class VeniceSystemFactory implements SystemFactory, Serializable {
         samzaJobId,
         runningFabric,
         verifyLatestProtocolPresent,
+        config,
+        sslFactory,
+        partitioners);
+  }
+
+  /**
+   * Construct a new instance of {@link VeniceSystemProducer}
+   * @param veniceChildD2ZkHost D2 Zk Address where the components in the child colo are announcing themselves
+   * @param primaryControllerColoD2ZKHost D2 Zk Address of the colo where the primary controller resides
+   * @param primaryControllerD2ServiceName The service name that the primary controller uses to announce itself to D2
+   * @param storeName The store to write to
+   * @param pushType The {@link PushType} to use to write to the store
+   * @param samzaJobId A unique id used to identify jobs that can concurrently write to the same store
+   * @param runningFabric The colo where the job is running. It is used to find the best destination for the data to be written to
+   * @param verifyLatestProtocolPresent Config to check whether the protocol versions used at runtime are valid in Venice backend
+   * @param factory The {@link VeniceSystemFactory} object that was used to create this object
+   * @param config A Config object that may be used by the factory implementation to create an overridden SystemProducer instance
+   * @param sslFactory An optional {@link SSLFactory} that is used to communicate with other components using SSL
+   * @param partitioners A list of comma-separated partitioners class names that are supported.
+   */
+  @SuppressWarnings("unused")
+  protected SystemProducer createSystemProducer(
+      String veniceChildD2ZkHost,
+      String primaryControllerColoD2ZKHost,
+      String primaryControllerD2Service,
+      String storeName,
+      Version.PushType venicePushType,
+      String samzaJobId,
+      String runningFabric,
+      boolean verifyLatestProtocolPresent,
+      Config config,
+      Optional<SSLFactory> sslFactory,
+      Optional<String> partitioners) {
+    return createSystemProducer(
+        veniceChildD2ZkHost,
+        primaryControllerColoD2ZKHost,
+        primaryControllerD2Service,
+        storeName,
+        venicePushType,
+        samzaJobId,
+        runningFabric,
+        verifyLatestProtocolPresent,
         sslFactory,
         partitioners);
   }
@@ -354,6 +396,8 @@ public class VeniceSystemFactory implements SystemFactory, Serializable {
         samzaJobId,
         runningFabric,
         verifyLatestProtocolPresent,
+        config, // Although we don't use this config in our default implementation, overridden implementations might
+                // need this
         sslFactory,
         partitioners);
     this.systemProducerStatues.computeIfAbsent(systemProducer, k -> Pair.create(true, false));


### PR DESCRIPTION
… argument (#141)

Overridden implementations of VeniceSystemFactory might need the Config arg to create a custom VeniceSystemProducer instance. Added an overridden function to pass these as arguments.

<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci], [server], [controller],
[router], [samza], [vpj], [fast-client], [thin-client], [alpini],
[admin-tool], [test], [build], [doc], [script]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Summary, imperative, start upper case, don't end with a period
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Resolves #XXX

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.