### PR TITLE
[controller] Enforce minimal hybrid store partition count and allow hybrid store partition count backfill

### DIFF
--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -226,6 +226,7 @@ public class ConfigKeys {
   public static final String DEFAULT_ROUTING_STRATEGY = "default.routing.strategy";
   public static final String DEFAULT_REPLICA_FACTOR = "default.replica.factor";
   public static final String DEFAULT_NUMBER_OF_PARTITION = "default.partition.count";
+  public static final String DEFAULT_NUMBER_OF_PARTITION_FOR_HYBRID = "default.partition.count.for.hybrid";
   public static final String DEFAULT_MAX_NUMBER_OF_PARTITIONS = "default.partition.max.count";
   public static final String DEFAULT_PARTITION_SIZE = "default.partition.size";
   public static final String OFFLINE_JOB_START_TIMEOUT_MS = "offline.job.start.timeout.ms";

--- a/internal/venice-common/src/main/java/com/linkedin/venice/utils/Utils.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/utils/Utils.java
@@ -460,7 +460,7 @@ public class Utils {
   }
 
   public static List<String> parseCommaSeparatedStringToList(String rawString) {
-    String[] strArray = rawString.split(",");
+    String[] strArray = rawString.split(",\\s*");
     if (strArray.length < 1) {
       throw new VeniceException("Invalid input: " + rawString);
     }

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/controller/TestParentControllerWithMultiDataCenter.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/controller/TestParentControllerWithMultiDataCenter.java
@@ -130,6 +130,7 @@ public class TestParentControllerWithMultiDataCenter {
           Assert.assertEquals(storeInfo.getPartitionerConfig().getAmplificationFactor(), 2);
           Assert.assertTrue(storeInfo.isChunkingEnabled());
           Assert.assertTrue(storeInfo.isRmdChunkingEnabled());
+          Assert.assertEquals(storeInfo.getPartitionCount(), 1);
         }
       });
 

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerClusterConfig.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerClusterConfig.java
@@ -2,6 +2,7 @@ package com.linkedin.venice.controller;
 
 import static com.linkedin.venice.CommonConfigKeys.SSL_FACTORY_CLASS_NAME;
 import static com.linkedin.venice.ConfigKeys.ADMIN_TOPIC_REPLICATION_FACTOR;
+import static com.linkedin.venice.ConfigKeys.CHILD_CLUSTER_ALLOWLIST;
 import static com.linkedin.venice.ConfigKeys.CLUSTER_NAME;
 import static com.linkedin.venice.ConfigKeys.CLUSTER_TO_D2;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_DEFAULT_READ_QUOTA_PER_ROUTER;
@@ -12,6 +13,7 @@ import static com.linkedin.venice.ConfigKeys.CONTROLLER_SCHEMA_VALIDATION_ENABLE
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_SSL_ENABLED;
 import static com.linkedin.venice.ConfigKeys.DEFAULT_MAX_NUMBER_OF_PARTITIONS;
 import static com.linkedin.venice.ConfigKeys.DEFAULT_NUMBER_OF_PARTITION;
+import static com.linkedin.venice.ConfigKeys.DEFAULT_NUMBER_OF_PARTITION_FOR_HYBRID;
 import static com.linkedin.venice.ConfigKeys.DEFAULT_OFFLINE_PUSH_STRATEGY;
 import static com.linkedin.venice.ConfigKeys.DEFAULT_PARTITION_SIZE;
 import static com.linkedin.venice.ConfigKeys.DEFAULT_READ_STRATEGY;
@@ -110,6 +112,7 @@ public class VeniceControllerClusterConfig {
   private RoutingStrategy routingStrategy;
   private int replicationFactor;
   private int numberOfPartition;
+  private int numberOfPartitionForHybrid;
   private int maxNumberOfPartition;
   private long partitionSize;
   private long offLineJobWaitTimeInMilliseconds;
@@ -285,6 +288,8 @@ public class VeniceControllerClusterConfig {
   private int defaultReadQuotaPerRouter;
   private int replicationMetadataVersionId;
 
+  private String childDatacenters;
+
   public VeniceControllerClusterConfig(VeniceProperties props) {
     try {
       this.props = props;
@@ -318,6 +323,7 @@ public class VeniceControllerClusterConfig {
         props.getLong(KAFKA_MIN_LOG_COMPACTION_LAG_MS, DEFAULT_KAFKA_MIN_LOG_COMPACTION_LAG_MS);
     replicationFactor = props.getInt(DEFAULT_REPLICA_FACTOR);
     numberOfPartition = props.getInt(DEFAULT_NUMBER_OF_PARTITION);
+    numberOfPartitionForHybrid = props.getInt(DEFAULT_NUMBER_OF_PARTITION_FOR_HYBRID, numberOfPartition);
     kafkaBootstrapServers = props.getString(KAFKA_BOOTSTRAP_SERVERS);
     partitionSize = props.getSizeInBytes(DEFAULT_PARTITION_SIZE);
     maxNumberOfPartition = props.getInt(DEFAULT_MAX_NUMBER_OF_PARTITIONS);
@@ -453,6 +459,7 @@ public class VeniceControllerClusterConfig {
     this.defaultReadQuotaPerRouter =
         props.getInt(CONTROLLER_DEFAULT_READ_QUOTA_PER_ROUTER, DEFAULT_PER_ROUTER_READ_QUOTA);
     this.replicationMetadataVersionId = props.getInt(REPLICATION_METADATA_VERSION_ID, 1);
+    this.childDatacenters = props.getString(CHILD_CLUSTER_ALLOWLIST);
   }
 
   private boolean doesControllerNeedsSslConfig() {
@@ -508,6 +515,10 @@ public class VeniceControllerClusterConfig {
 
   public int getNumberOfPartition() {
     return numberOfPartition;
+  }
+
+  public int getNumberOfPartitionForHybrid() {
+    return numberOfPartitionForHybrid;
   }
 
   public int getKafkaReplicationFactor() {
@@ -716,5 +727,9 @@ public class VeniceControllerClusterConfig {
 
   public int getReplicationMetadataVersionId() {
     return replicationMetadataVersionId;
+  }
+
+  public String getChildDatacenters() {
+    return childDatacenters;
   }
 }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -3317,7 +3317,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
         TopicManager topicManager;
         if (isParent()) {
           // RT might not exist in parent colo. Get RT partition count from a child colo.
-          String childDatacenter = clusterConfig.getChildDatacenters().split(",\\s*")[0];
+          String childDatacenter = Utils.parseCommaSeparatedStringToList(clusterConfig.getChildDatacenters()).get(0);
           topicManager = getTopicManager(
               Pair.create(
                   multiClusterConfigs.getChildDataCenterKafkaUrlMap().get(childDatacenter),

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceHelixAdminWithSharedEnvironment.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceHelixAdminWithSharedEnvironment.java
@@ -17,7 +17,6 @@ import com.linkedin.venice.compression.CompressionStrategy;
 import com.linkedin.venice.controller.exception.HelixClusterMaintenanceModeException;
 import com.linkedin.venice.controllerapi.UpdateClusterConfigQueryParams;
 import com.linkedin.venice.controllerapi.UpdateStoreQueryParams;
-import com.linkedin.venice.exceptions.ConfigurationException;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.exceptions.VeniceNoStoreException;
 import com.linkedin.venice.exceptions.VeniceUnsupportedOperationException;
@@ -449,12 +448,8 @@ public class TestVeniceHelixAdminWithSharedEnvironment extends AbstractTestVenic
 
     veniceAdmin.setStorePartitionCount(clusterName, storeName, newPartitionCount);
     Assert.assertEquals(veniceAdmin.getStore(clusterName, storeName).getPartitionCount(), newPartitionCount);
-    Assert.assertThrows(
-        ConfigurationException.class,
-        () -> veniceAdmin.setStorePartitionCount(clusterName, storeName, MAX_NUMBER_OF_PARTITION + 1));
-    Assert.assertThrows(
-        ConfigurationException.class,
-        () -> veniceAdmin.setStorePartitionCount(clusterName, storeName, -1));
+    Assert.assertThrows(() -> veniceAdmin.setStorePartitionCount(clusterName, storeName, MAX_NUMBER_OF_PARTITION + 1));
+    Assert.assertThrows(() -> veniceAdmin.setStorePartitionCount(clusterName, storeName, -1));
 
     // test setting amplification factor
     Assert.assertEquals(


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci], [server], [controller],
[router], [samza], [vpj], [fast-client], [thin-client], [alpini],
[admin-tool], [test], [build], [doc], [script]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Summary
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Problem: Parent controller does not enforce minimal partition count for hybrid stores. When an existing store is converted to hybrid, if owners do not specify, store partition count remains as 0, and version partition count will be re-calculated for every new push. As a result, version topic and real-time topic partiton counts might mismatch.

Fix: Add a config default.partition.count.for.hybrid whose default value is the same with default.partition.count. Config value will be increased in production. Parent controller will uses this config to set new hybrid store partition count if it is not speified by store owners.

For existing stores with 0 partition count, this commit also allows updating it to a value that matches real-time topic partition count.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
CI

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.