### PR TITLE
[server] Make sure LEADER drainer DIV logic does not skip value chunks and manifest messages

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -2753,7 +2753,13 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
        * 3. The DIV info checkpoint on disk must match the actual data persistence which is done inside drainer threads.
        */
       try {
-        validateMessage(this.kafkaDataIntegrityValidator, consumerRecord, endOfPushReceived, subPartition);
+        if ((leaderProducedRecordContext == null) || (leaderProducedRecordContext.getConsumedOffset() > -1)) {
+          /**
+           * N.B.: If the consumed offset is -1, it means we are processing a chunk, in which case the
+           * {@link consumerRecord} is going to be the same for every chunk, and we don't want to treat them as dupes.
+           */
+          validateMessage(this.kafkaDataIntegrityValidator, consumerRecord, endOfPushReceived, subPartition);
+        }
         versionedDIVStats.recordSuccessMsg(storeName, versionNumber);
       } catch (FatalDataValidationException fatalException) {
         if (!endOfPushReceived) {

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/PartialUpdateWithSingleReplicaTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/PartialUpdateWithSingleReplicaTest.java
@@ -1,0 +1,28 @@
+package com.linkedin.venice.endToEnd;
+
+import com.linkedin.venice.integration.utils.ServiceFactory;
+import com.linkedin.venice.integration.utils.VeniceTwoLayerMultiColoMultiClusterWrapper;
+import com.linkedin.venice.utils.VeniceProperties;
+import java.util.Optional;
+import java.util.Properties;
+
+
+public class PartialUpdateWithSingleReplicaTest extends PartialUpdateTest {
+  @Override
+  protected VeniceTwoLayerMultiColoMultiClusterWrapper getMultiColoMultiClusterWrapper(
+      Properties serverProperties,
+      Properties controllerProps) {
+    return ServiceFactory.getVeniceTwoLayerMultiColoMultiClusterWrapper(
+        NUMBER_OF_CHILD_DATACENTERS,
+        NUMBER_OF_CLUSTERS,
+        1,
+        1,
+        1,
+        1,
+        1,
+        Optional.of(new VeniceProperties(controllerProps)),
+        Optional.of(new Properties(controllerProps)),
+        Optional.of(new VeniceProperties(serverProperties)),
+        false);
+  }
+}

--- a/internal/venice-test-common/src/integrationtest/resources/CollectionRecordV1.avsc
+++ b/internal/venice-test-common/src/integrationtest/resources/CollectionRecordV1.avsc
@@ -1,0 +1,27 @@
+{
+  "name": "SampleRecord",
+  "type": "record",
+  "fields": [
+    {
+      "name": "name",
+      "type": "string",
+      "default": "default_name"
+    },
+    {
+      "name": "intArray",
+      "type": {
+        "type": "array",
+        "items": "int"
+      },
+      "default": []
+    },
+    {
+      "name": "stringMap",
+      "type": {
+        "type": "map",
+        "values": "string"
+      },
+      "default": {}
+    }
+  ]
+}


### PR DESCRIPTION
## [server] Make sure LEADER drainer DIV logic does not skip value chunks and manifest messages
This PR fixes the bug that leader drainer skips chunks starting from the 2nd chunk and its manifest in L/F model.
Added a new integration test to guarantee the regression won't happen.

## How was this PR tested?
Added new integration tests.
## Does this PR introduce any user-facing changes?
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.