### PR TITLE
[server] Make sure LEADER drainer DIV logic does not skip value chunks and manifest messages

### DIFF
--- a/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -2543,7 +2543,13 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
        * 3. The DIV info checkpoint on disk must match the actual data persistence which is done inside drainer threads.
        */
       try {
-        validateMessage(this.kafkaDataIntegrityValidator, consumerRecord, endOfPushReceived, subPartition);
+        if ((leaderProducedRecordContext == null) || (leaderProducedRecordContext.getConsumedOffset() > -1)) {
+          /**
+           * N.B.: If the consumed offset is -1, it means we are processing a chunk, in which case the
+           * {@link consumerRecord} is going to be the same for every chunk, and we don't want to treat them as dupes.
+           */
+          validateMessage(this.kafkaDataIntegrityValidator, consumerRecord, endOfPushReceived, subPartition);
+        }
         versionedDIVStats.recordSuccessMsg(storeName, versionNumber);
       } catch (FatalDataValidationException fatalException) {
         if (!endOfPushReceived) {


### PR DESCRIPTION
## [server] Make sure LEADER drainer DIV logic does not skip value chunks and manifest messages

This is a hot fix PR on top of current server release version to make sure leader replica drainer won't skip chunks and manifest due to DIV logic.

## How was this PR tested?
Tested the fix on the main branch with full integration test.
## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.