### PR TITLE
[server] New leader metrics to count large and small values writes

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -1046,6 +1046,7 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
     return (!versionTopic.equals(leaderTopic) || partitionConsumptionState.consumeRemotely());
   }
 
+  @Override
   protected boolean isLeader(PartitionConsumptionState partitionConsumptionState) {
     return Objects.equals(partitionConsumptionState.getLeaderFollowerState(), LEADER);
   }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -2880,7 +2880,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
         if (isManifestPayload) {
           hostLevelIngestionStats.recordLeaderLargeValueWrites();
         } else if (isChunkedDataPayload) {
-          hostLevelIngestionStats.recordLeaderSmallValueWrites();
+          hostLevelIngestionStats.recordLeaderChunkDataWrites();
         } else {
           hostLevelIngestionStats.recordLeaderSmallValueWrites();
         }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -534,6 +534,8 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
       PubSubTopicPartition topicPartition,
       LeaderFollowerPartitionStateModel.LeaderSessionIdChecker checker);
 
+  protected abstract boolean isLeader(PartitionConsumptionState partitionConsumptionState);
+
   public void kill() {
     synchronized (this) {
       throwIfNotRunning();
@@ -2875,7 +2877,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
        */
       hostLevelIngestionStats.recordKeySize(keyLen);
       hostLevelIngestionStats.recordValueSize(valueLen);
-      if (leaderProducedRecordContext != null) {
+      if (isLeader(partitionConsumptionState)) {
         // metrics that are only emitted in leader replica
         if (isManifestPayload) {
           hostLevelIngestionStats.recordLeaderLargeValueWrites();

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/HostLevelIngestionStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/HostLevelIngestionStats.java
@@ -14,6 +14,7 @@ import io.tehuti.metrics.stats.Avg;
 import io.tehuti.metrics.stats.Count;
 import io.tehuti.metrics.stats.Max;
 import io.tehuti.metrics.stats.Min;
+import io.tehuti.metrics.stats.OccurrenceRate;
 import io.tehuti.metrics.stats.Rate;
 import io.tehuti.metrics.stats.Total;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
@@ -155,6 +156,10 @@ public class HostLevelIngestionStats extends AbstractVeniceStats {
   private final Sensor totalTombstoneCreationDCRSensor;
 
   private final Sensor totalLeaderDelegateRealTimeRecordLatencySensor;
+
+  private final Sensor leaderLargeValueWritesSensor;
+  private final Sensor leaderSmallValueWritesSensor;
+  private final Sensor leaderChunkDataWritesSensor;
 
   private Sensor registerPerStoreAndTotal(
       String sensorName,
@@ -477,6 +482,27 @@ public class HostLevelIngestionStats extends AbstractVeniceStats {
         totalStats,
         () -> totalStats.leaderIngestionReplicationMetadataLookUpLatencySensor,
         avgAndMax());
+
+    this.leaderLargeValueWritesSensor = registerPerStoreAndTotal(
+        "leader_large_value_writes",
+        totalStats,
+        () -> totalStats.leaderLargeValueWritesSensor,
+        new Count(),
+        new OccurrenceRate());
+
+    this.leaderSmallValueWritesSensor = registerPerStoreAndTotal(
+        "leader_small_value_writes",
+        totalStats,
+        () -> totalStats.leaderSmallValueWritesSensor,
+        new Count(),
+        new OccurrenceRate());
+
+    this.leaderChunkDataWritesSensor = registerPerStoreAndTotal(
+        "leader_chunk_data_writes",
+        totalStats,
+        () -> totalStats.leaderChunkDataWritesSensor,
+        new Count(),
+        new OccurrenceRate());
   }
 
   /** Record a host-level byte consumption rate across all store versions */
@@ -659,5 +685,17 @@ public class HostLevelIngestionStats extends AbstractVeniceStats {
 
   public void recordLeaderDelegateRealTimeRecordLatency(double latency) {
     totalLeaderDelegateRealTimeRecordLatencySensor.record(latency);
+  }
+
+  public void recordLeaderLargeValueWrites() {
+    leaderLargeValueWritesSensor.record();
+  }
+
+  public void recordLeaderSmallValueWrites() {
+    leaderSmallValueWritesSensor.record();
+  }
+
+  public void recordLeaderChunkDataWrites() {
+    leaderChunkDataWritesSensor.record();
   }
 }


### PR DESCRIPTION
3 new metrics in leader replicas:
leader_large_value_writes - numbers of large value writes (values are chunks manifest) (not unique keys) leader_small_value_writes - numbers of small value writes leader_chunk_data_writes - number of chunk data writes (data chunks for the large values)

Each of them has a Counter type metric and an Occurrence type metrics; the new metrics will only be emitted for the largest active version of a store.

## How was this PR tested?
Internal CI in progress; will update the result once it's done.

## Does this PR introduce any user-facing changes?
- [-] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.