### PR TITLE
[server] Enhance isolated ingestion request handling logic

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/HttpClientTransport.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/HttpClientTransport.java
@@ -116,13 +116,12 @@ public class HttpClientTransport implements AutoCloseable {
   }
 
   public <T extends SpecificRecordBase, S extends SpecificRecordBase> T sendRequest(IngestionAction action, S param) {
-    return sendRequestWithRetry(action, param, requestTimeoutInSeconds, DEFAULT_REQUEST_RETRY_COUNT);
+    return sendRequestWithRetry(action, param, DEFAULT_REQUEST_RETRY_COUNT);
   }
 
   public <T extends SpecificRecordBase, S extends SpecificRecordBase> T sendRequestWithRetry(
       IngestionAction action,
       S param,
-      int requestTimeoutInSeconds,
       int maxAttempt) {
     // Sanity check for maxAttempt argument.
     if (maxAttempt <= 0) {
@@ -154,12 +153,5 @@ public class HttpClientTransport implements AutoCloseable {
       }
     }
     return result;
-  }
-
-  public <T extends SpecificRecordBase, S extends SpecificRecordBase> T sendRequestWithRetry(
-      IngestionAction action,
-      S param,
-      int maxAttempt) {
-    return sendRequestWithRetry(action, param, requestTimeoutInSeconds, maxAttempt);
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/HttpClientTransport.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/HttpClientTransport.java
@@ -29,7 +29,6 @@ public class HttpClientTransport implements AutoCloseable {
   private static final Logger LOGGER = LogManager.getLogger(HttpClientTransport.class);
   private static final int DEFAULT_CONNECTION_TIMEOUT_MS = 30 * Time.MS_PER_SECOND;
   private static final int DEFAULT_SOCKET_TIMEOUT_MS = 30 * Time.MS_PER_SECOND;
-  private static final int DEFAULT_REQUEST_TIMEOUT_MS = 180 * Time.MS_PER_SECOND;
   private static final int DEFAULT_REQUEST_RETRY_WAIT_TIME_MS = 1 * Time.MS_PER_SECOND;
 
   private static final int DEFAULT_REQUEST_RETRY_COUNT = 10;
@@ -42,10 +41,12 @@ public class HttpClientTransport implements AutoCloseable {
 
   private final CloseableHttpAsyncClient httpClient;
   private final String forkedProcessRequestUrl;
+  private final int requestTimeoutInSeconds;
 
-  public HttpClientTransport(Optional<SSLFactory> sslFactory, int port) {
-    forkedProcessRequestUrl = (sslFactory.isPresent() ? HTTPS : HTTP) + "://" + Utils.getHostName() + ":" + port;
-    httpClient =
+  public HttpClientTransport(Optional<SSLFactory> sslFactory, int port, int requestTimeoutInSeconds) {
+    this.forkedProcessRequestUrl = (sslFactory.isPresent() ? HTTPS : HTTP) + "://" + Utils.getHostName() + ":" + port;
+    this.requestTimeoutInSeconds = requestTimeoutInSeconds;
+    this.httpClient =
         HttpClientUtils
             .getMinimalHttpClientWithConnManager(
                 DEFAULT_IO_THREAD_COUNT,
@@ -74,7 +75,7 @@ public class HttpClientTransport implements AutoCloseable {
   public <T extends SpecificRecordBase, S extends SpecificRecordBase> T sendRequest(
       IngestionAction action,
       S param,
-      int timeoutMs) {
+      int requestTimeoutInSeconds) {
     HttpPost request = new HttpPost(forkedProcessRequestUrl + "/" + action.toString());
     try {
       byte[] requestPayload = serializeIngestionActionRequest(action, param);
@@ -85,9 +86,11 @@ public class HttpClientTransport implements AutoCloseable {
 
     HttpResponse response;
     try {
-      response = this.httpClient.execute(request, null).get(timeoutMs, TimeUnit.MILLISECONDS);
+      response = this.httpClient.execute(request, null).get(requestTimeoutInSeconds, TimeUnit.SECONDS);
     } catch (TimeoutException e) {
-      throw new VeniceTimeoutException("Unable to finish isolated ingestion request in given " + timeoutMs + " ms.", e);
+      throw new VeniceTimeoutException(
+          "Unable to finish isolated ingestion request in given " + requestTimeoutInSeconds + " s.",
+          e);
     } catch (InterruptedException e) {
       // Keep the interruption flag.
       Thread.currentThread().interrupt();
@@ -113,13 +116,13 @@ public class HttpClientTransport implements AutoCloseable {
   }
 
   public <T extends SpecificRecordBase, S extends SpecificRecordBase> T sendRequest(IngestionAction action, S param) {
-    return sendRequestWithRetry(action, param, DEFAULT_REQUEST_TIMEOUT_MS, DEFAULT_REQUEST_RETRY_COUNT);
+    return sendRequestWithRetry(action, param, requestTimeoutInSeconds, DEFAULT_REQUEST_RETRY_COUNT);
   }
 
   public <T extends SpecificRecordBase, S extends SpecificRecordBase> T sendRequestWithRetry(
       IngestionAction action,
       S param,
-      int timeoutMs,
+      int requestTimeoutInSeconds,
       int maxAttempt) {
     // Sanity check for maxAttempt argument.
     if (maxAttempt <= 0) {
@@ -130,7 +133,7 @@ public class HttpClientTransport implements AutoCloseable {
     final long startTimeIsMs = System.currentTimeMillis();
     while (true) {
       try {
-        result = sendRequest(action, param, timeoutMs);
+        result = sendRequest(action, param, requestTimeoutInSeconds);
         break;
       } catch (VeniceException e) {
         retryCount++;
@@ -157,6 +160,6 @@ public class HttpClientTransport implements AutoCloseable {
       IngestionAction action,
       S param,
       int maxAttempt) {
-    return sendRequestWithRetry(action, param, DEFAULT_REQUEST_TIMEOUT_MS, maxAttempt);
+    return sendRequestWithRetry(action, param, requestTimeoutInSeconds, maxAttempt);
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/HttpClientTransport.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/HttpClientTransport.java
@@ -29,7 +29,7 @@ public class HttpClientTransport implements AutoCloseable {
   private static final Logger LOGGER = LogManager.getLogger(HttpClientTransport.class);
   private static final int DEFAULT_CONNECTION_TIMEOUT_MS = 30 * Time.MS_PER_SECOND;
   private static final int DEFAULT_SOCKET_TIMEOUT_MS = 30 * Time.MS_PER_SECOND;
-  private static final int DEFAULT_REQUEST_TIMEOUT_MS = 60 * Time.MS_PER_SECOND;
+  private static final int DEFAULT_REQUEST_TIMEOUT_MS = 180 * Time.MS_PER_SECOND;
   private static final int DEFAULT_REQUEST_RETRY_WAIT_TIME_MS = 1 * Time.MS_PER_SECOND;
 
   private static final int DEFAULT_REQUEST_RETRY_COUNT = 10;

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/IsolatedIngestionBackend.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/IsolatedIngestionBackend.java
@@ -1,5 +1,6 @@
 package com.linkedin.davinci.ingestion;
 
+import static com.linkedin.venice.ConfigKeys.SERVER_INGESTION_ISOLATION_REQUEST_TIMEOUT_SECONDS;
 import static com.linkedin.venice.ingestion.protocol.enums.IngestionCommandType.DEMOTE_TO_STANDBY;
 import static com.linkedin.venice.ingestion.protocol.enums.IngestionCommandType.PROMOTE_TO_LEADER;
 import static com.linkedin.venice.ingestion.protocol.enums.IngestionCommandType.REMOVE_PARTITION;
@@ -68,8 +69,10 @@ public class IsolatedIngestionBackend extends DefaultIngestionBackend
     int listenerPort = configLoader.getVeniceServerConfig().getIngestionApplicationPort();
     this.configLoader = configLoader;
     Optional<SSLFactory> sslFactory = IsolatedIngestionUtils.getSSLFactory(configLoader);
+    int requestTimeoutInSeconds =
+        configLoader.getCombinedProperties().getInt(SERVER_INGESTION_ISOLATION_REQUEST_TIMEOUT_SECONDS, 60);
     // Create the ingestion request client.
-    mainIngestionRequestClient = new MainIngestionRequestClient(sslFactory, servicePort);
+    mainIngestionRequestClient = new MainIngestionRequestClient(sslFactory, servicePort, requestTimeoutInSeconds);
     // Create the forked isolated ingestion process.
     isolatedIngestionServiceProcess = mainIngestionRequestClient.startForkedIngestionProcess(configLoader);
     // Create and start the ingestion report listener.

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/IsolatedIngestionBackend.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/IsolatedIngestionBackend.java
@@ -148,6 +148,7 @@ public class IsolatedIngestionBackend extends DefaultIngestionBackend
       int timeoutInSeconds,
       boolean removeEmptyStorageEngine) {
     String topicName = storeConfig.getStoreVersionName();
+    mainIngestionMonitorService.cleanupTopicPartitionState(topicName, partition);
     executeCommandWithRetry(
         topicName,
         partition,
@@ -158,7 +159,6 @@ public class IsolatedIngestionBackend extends DefaultIngestionBackend
           // Clean up the topic partition ingestion status.
           mainIngestionRequestClient.resetTopicPartition(topicName, partition);
         });
-    mainIngestionMonitorService.cleanupTopicPartitionState(topicName, partition);
     if (mainIngestionMonitorService.getTopicPartitionCount(topicName) == 0) {
       LOGGER.info("No serving partitions exist for topic: {}, dropping the topic storage.", topicName);
       mainIngestionRequestClient.removeStorageEngine(topicName);

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/isolated/IsolatedIngestionRequestClient.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/isolated/IsolatedIngestionRequestClient.java
@@ -19,8 +19,8 @@ public class IsolatedIngestionRequestClient implements Closeable {
 
   private final HttpClientTransport httpClientTransport;
 
-  public IsolatedIngestionRequestClient(Optional<SSLFactory> sslFactory, int port) {
-    httpClientTransport = new HttpClientTransport(sslFactory, port);
+  public IsolatedIngestionRequestClient(Optional<SSLFactory> sslFactory, int port, int requestTimeoutInSeconds) {
+    httpClientTransport = new HttpClientTransport(sslFactory, port, requestTimeoutInSeconds);
   }
 
   public void reportIngestionStatus(IngestionTaskReport report) {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/isolated/IsolatedIngestionServer.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/isolated/IsolatedIngestionServer.java
@@ -3,6 +3,7 @@ package com.linkedin.davinci.ingestion.isolated;
 import static com.linkedin.venice.ConfigKeys.CLUSTER_DISCOVERY_D2_SERVICE;
 import static com.linkedin.venice.ConfigKeys.D2_ZK_HOSTS_ADDRESS;
 import static com.linkedin.venice.ConfigKeys.SERVER_INGESTION_ISOLATION_HEARTBEAT_TIMEOUT_MS;
+import static com.linkedin.venice.ConfigKeys.SERVER_INGESTION_ISOLATION_REQUEST_TIMEOUT_SECONDS;
 import static com.linkedin.venice.ConfigKeys.SERVER_INGESTION_ISOLATION_STATS_CLASS_LIST;
 import static com.linkedin.venice.ConfigKeys.SERVER_REMOTE_INGESTION_REPAIR_SLEEP_INTERVAL_SECONDS;
 import static com.linkedin.venice.ConfigKeys.SERVER_STOP_CONSUMPTION_WAIT_RETRIES_NUM;
@@ -103,7 +104,7 @@ public class IsolatedIngestionServer extends AbstractVeniceService {
   private final ServerBootstrap bootstrap;
   private final EventLoopGroup bossGroup;
   private final EventLoopGroup workerGroup;
-  private final ExecutorService ingestionExecutor = Executors.newFixedThreadPool(50);
+  private final ExecutorService ingestionExecutor = Executors.newFixedThreadPool(10);
   private final ScheduledExecutorService heartbeatCheckScheduler = Executors.newScheduledThreadPool(1);
   private final AtomicBoolean isShuttingDown = new AtomicBoolean(false);
   private final int servicePort;
@@ -668,7 +669,8 @@ public class IsolatedIngestionServer extends AbstractVeniceService {
     // Create Netty client to report status back to application.
     reportClient = new IsolatedIngestionRequestClient(
         IsolatedIngestionUtils.getSSLFactory(configLoader),
-        configLoader.getVeniceServerConfig().getIngestionApplicationPort());
+        configLoader.getVeniceServerConfig().getIngestionApplicationPort(),
+        configLoader.getCombinedProperties().getInt(SERVER_INGESTION_ISOLATION_REQUEST_TIMEOUT_SECONDS, 60));
 
     // Mark the IsolatedIngestionServer as initiated.
     isInitiated = true;

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/isolated/IsolatedIngestionServer.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/isolated/IsolatedIngestionServer.java
@@ -670,7 +670,7 @@ public class IsolatedIngestionServer extends AbstractVeniceService {
     reportClient = new IsolatedIngestionRequestClient(
         IsolatedIngestionUtils.getSSLFactory(configLoader),
         configLoader.getVeniceServerConfig().getIngestionApplicationPort(),
-        configLoader.getCombinedProperties().getInt(SERVER_INGESTION_ISOLATION_REQUEST_TIMEOUT_SECONDS, 60));
+        configLoader.getCombinedProperties().getInt(SERVER_INGESTION_ISOLATION_REQUEST_TIMEOUT_SECONDS, 120));
 
     // Mark the IsolatedIngestionServer as initiated.
     isInitiated = true;

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/isolated/IsolatedIngestionServer.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/isolated/IsolatedIngestionServer.java
@@ -103,7 +103,7 @@ public class IsolatedIngestionServer extends AbstractVeniceService {
   private final ServerBootstrap bootstrap;
   private final EventLoopGroup bossGroup;
   private final EventLoopGroup workerGroup;
-  private final ExecutorService ingestionExecutor = Executors.newFixedThreadPool(10);
+  private final ExecutorService ingestionExecutor = Executors.newFixedThreadPool(50);
   private final ScheduledExecutorService heartbeatCheckScheduler = Executors.newScheduledThreadPool(1);
   private final AtomicBoolean isShuttingDown = new AtomicBoolean(false);
   private final int servicePort;

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/isolated/IsolatedIngestionServerHandler.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/isolated/IsolatedIngestionServerHandler.java
@@ -140,6 +140,12 @@ public class IsolatedIngestionServerHandler extends SimpleChannelInboundHandler<
 
     IngestionTaskReport report = createIngestionTaskReport(topicName, partitionId);
     IngestionCommandType ingestionCommandType = IngestionCommandType.valueOf(ingestionTaskCommand.commandType);
+    LOGGER.info(
+        "Received ingestion command {} for topic: {}, partition: {} in timestamp: {}",
+        ingestionCommandType,
+        topicName,
+        partitionId,
+        startTimeInMs);
     try {
       if (!isolatedIngestionServer.isInitiated()) {
         throw new VeniceException("IsolatedIngestionServer has not been initiated.");
@@ -245,7 +251,7 @@ public class IsolatedIngestionServerHandler extends SimpleChannelInboundHandler<
     }
     long executionTimeInMs = System.currentTimeMillis() - startTimeInMs;
     LOGGER.info(
-        "Completed ingestion command {} for topic: {}, partition: {} in ms: {}",
+        "Completed ingestion command {} for topic: {}, partition: {} in {} ms.",
         ingestionCommandType,
         topicName,
         partitionId,

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/main/MainIngestionMonitorService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/main/MainIngestionMonitorService.java
@@ -102,7 +102,7 @@ public class MainIngestionMonitorService extends AbstractVeniceService {
         .childOption(ChannelOption.TCP_NODELAY, true);
 
     this.requestTimeoutInSeconds =
-        configLoader.getCombinedProperties().getInt(SERVER_INGESTION_ISOLATION_REQUEST_TIMEOUT_SECONDS, 60);
+        configLoader.getCombinedProperties().getInt(SERVER_INGESTION_ISOLATION_REQUEST_TIMEOUT_SECONDS, 120);
     heartbeatClient = new MainIngestionRequestClient(this.sslFactory, this.servicePort, requestTimeoutInSeconds);
     metricsClient = new MainIngestionRequestClient(this.sslFactory, this.servicePort, requestTimeoutInSeconds);
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/main/MainIngestionMonitorService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/main/MainIngestionMonitorService.java
@@ -1,6 +1,7 @@
 package com.linkedin.davinci.ingestion.main;
 
 import static com.linkedin.venice.ConfigKeys.SERVER_INGESTION_ISOLATION_HEARTBEAT_TIMEOUT_MS;
+import static com.linkedin.venice.ConfigKeys.SERVER_INGESTION_ISOLATION_REQUEST_TIMEOUT_SECONDS;
 import static java.lang.Thread.currentThread;
 
 import com.linkedin.davinci.config.VeniceConfigLoader;
@@ -74,6 +75,7 @@ public class MainIngestionMonitorService extends AbstractVeniceService {
   private final VeniceConfigLoader configLoader;
   private long heartbeatTimeoutMs;
   private volatile long latestHeartbeatTimestamp = -1;
+  private final int requestTimeoutInSeconds;
 
   public MainIngestionMonitorService(
       IsolatedIngestionBackend ingestionBackend,
@@ -99,8 +101,10 @@ public class MainIngestionMonitorService extends AbstractVeniceService {
         .option(ChannelOption.SO_REUSEADDR, true)
         .childOption(ChannelOption.TCP_NODELAY, true);
 
-    heartbeatClient = new MainIngestionRequestClient(this.sslFactory, this.servicePort);
-    metricsClient = new MainIngestionRequestClient(this.sslFactory, this.servicePort);
+    this.requestTimeoutInSeconds =
+        configLoader.getCombinedProperties().getInt(SERVER_INGESTION_ISOLATION_REQUEST_TIMEOUT_SECONDS, 60);
+    heartbeatClient = new MainIngestionRequestClient(this.sslFactory, this.servicePort, requestTimeoutInSeconds);
+    metricsClient = new MainIngestionRequestClient(this.sslFactory, this.servicePort, requestTimeoutInSeconds);
 
   }
 
@@ -249,7 +253,8 @@ public class MainIngestionMonitorService extends AbstractVeniceService {
         "Lost connection to forked ingestion process since timestamp {}, restarting forked process.",
         latestHeartbeatTimestamp);
     heartbeatStats.recordForkedProcessRestart();
-    try (MainIngestionRequestClient client = new MainIngestionRequestClient(sslFactory, servicePort)) {
+    try (MainIngestionRequestClient client =
+        new MainIngestionRequestClient(sslFactory, servicePort, requestTimeoutInSeconds)) {
       /**
        * We need to destroy the previous isolated ingestion process first.
        * The previous isolated ingestion process might have released the port binding, but it might still taking up all
@@ -269,7 +274,8 @@ public class MainIngestionMonitorService extends AbstractVeniceService {
   }
 
   private void resumeOngoingIngestionTasks() {
-    try (MainIngestionRequestClient client = new MainIngestionRequestClient(sslFactory, servicePort)) {
+    try (MainIngestionRequestClient client =
+        new MainIngestionRequestClient(sslFactory, servicePort, requestTimeoutInSeconds)) {
       LOGGER.info("Start to recover ongoing ingestion tasks: {}", topicIngestionStatusMap);
       // Re-open metadata partitions in child process for all previously subscribed topics.
       topicIngestionStatusMap.keySet().forEach(client::openStorageEngine);

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/main/MainIngestionRequestClient.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/main/MainIngestionRequestClient.java
@@ -43,8 +43,8 @@ public class MainIngestionRequestClient implements Closeable {
   private static final int HEARTBEAT_REQUEST_TIMEOUT_MS = 10 * Time.MS_PER_SECOND;
   private HttpClientTransport httpClientTransport;
 
-  public MainIngestionRequestClient(Optional<SSLFactory> sslFactory, int port) {
-    httpClientTransport = new HttpClientTransport(sslFactory, port);
+  public MainIngestionRequestClient(Optional<SSLFactory> sslFactory, int port, int requestTimeoutInSeconds) {
+    httpClientTransport = new HttpClientTransport(sslFactory, port, requestTimeoutInSeconds);
   }
 
   public synchronized Process startForkedIngestionProcess(VeniceConfigLoader configLoader) {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/main/MainIngestionStorageMetadataService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/main/MainIngestionStorageMetadataService.java
@@ -1,5 +1,7 @@
 package com.linkedin.davinci.ingestion.main;
 
+import static com.linkedin.venice.ConfigKeys.SERVER_INGESTION_ISOLATION_REQUEST_TIMEOUT_SECONDS;
+
 import com.linkedin.davinci.config.VeniceConfigLoader;
 import com.linkedin.davinci.ingestion.IsolatedIngestionBackend;
 import com.linkedin.davinci.ingestion.utils.IsolatedIngestionUtils;
@@ -55,7 +57,12 @@ public class MainIngestionStorageMetadataService extends AbstractVeniceService i
       MetadataUpdateStats metadataUpdateStats,
       VeniceConfigLoader configLoader,
       BiConsumer<String, StoreVersionState> storeVersionStateSyncer) {
-    this.client = new MainIngestionRequestClient(IsolatedIngestionUtils.getSSLFactory(configLoader), targetPort);
+    int requestTimeoutInSeconds =
+        configLoader.getCombinedProperties().getInt(SERVER_INGESTION_ISOLATION_REQUEST_TIMEOUT_SECONDS, 60);
+    this.client = new MainIngestionRequestClient(
+        IsolatedIngestionUtils.getSSLFactory(configLoader),
+        targetPort,
+        requestTimeoutInSeconds);
     this.partitionStateSerializer = partitionStateSerializer;
     this.metadataUpdateStats = metadataUpdateStats;
     this.metadataUpdateWorker = new MetadataUpdateWorker();

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/utils/IsolatedIngestionUtils.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/utils/IsolatedIngestionUtils.java
@@ -537,27 +537,6 @@ public class IsolatedIngestionUtils {
   }
 
   /**
-   * Create SSLFactory for inter-process communication encryption purpose.
-   */
-  public static Optional<SSLFactory> getSSLFactoryForInterProcessCommunication(VeniceConfigLoader configLoader) {
-    if (isolatedIngestionServerSslEnabled(configLoader)) {
-      try {
-        // If SSL communication is enabled but SSL configs are missing, we should fail fast here.
-        if (!sslEnabled(configLoader)) {
-          throw new VeniceException(
-              "Ingestion isolation SSL is enabled for communication, but SSL configs are missing.");
-        }
-        LOGGER.info("SSL is enabled, will create SSLFactory");
-        return Optional.of(new DefaultSSLFactory(configLoader.getCombinedProperties().toProperties()));
-      } catch (Exception e) {
-        throw new VeniceException("Caught exception during SSLFactory creation", e);
-      }
-    } else {
-      return Optional.empty();
-    }
-  }
-
-  /**
    * Create SSLFactory for D2Client in ClientConfig, which will be used by different ingestion components.
    */
   public static Optional<SSLFactory> getSSLFactoryForIngestion(VeniceConfigLoader configLoader) {
@@ -591,7 +570,7 @@ public class IsolatedIngestionUtils {
       }
       LOGGER.info(
           "Isolated ingestion server request ACL validation is enabled. Creating ACL handler with allowed principal name: {}",
-              allowedPrincipalName);
+          allowedPrincipalName);
       return Optional.of(new IsolatedIngestionServerAclHandler(identityParser, allowedPrincipalName));
     } else {
       return Optional.empty();

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/ingestion/IsolatedIngestionServerTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/ingestion/IsolatedIngestionServerTest.java
@@ -52,7 +52,7 @@ public class IsolatedIngestionServerTest {
     int servicePort = Utils.getFreePort();
     VeniceConfigLoader configLoader = getConfigLoader(servicePort);
     try (MainIngestionRequestClient client =
-        new MainIngestionRequestClient(IsolatedIngestionUtils.getSSLFactory(configLoader), servicePort, 60)) {
+        new MainIngestionRequestClient(IsolatedIngestionUtils.getSSLFactory(configLoader), servicePort, 120)) {
       Process isolatedIngestionService = client.startForkedIngestionProcess(configLoader);
       TestUtils.waitForNonDeterministicAssertion(
           10,
@@ -72,7 +72,7 @@ public class IsolatedIngestionServerTest {
     int servicePort = Utils.getFreePort();
     VeniceConfigLoader configLoader = getConfigLoader(servicePort);
     try (MainIngestionRequestClient client =
-        new MainIngestionRequestClient(IsolatedIngestionUtils.getSSLFactory(configLoader), servicePort, 60)) {
+        new MainIngestionRequestClient(IsolatedIngestionUtils.getSSLFactory(configLoader), servicePort, 120)) {
       // Make sure the process is forked successfully.
       ForkedJavaProcess isolatedIngestionService = (ForkedJavaProcess) client.startForkedIngestionProcess(configLoader);
       Assert.assertTrue(isolatedIngestionService.isAlive());

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/ingestion/IsolatedIngestionServerTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/ingestion/IsolatedIngestionServerTest.java
@@ -52,7 +52,7 @@ public class IsolatedIngestionServerTest {
     int servicePort = Utils.getFreePort();
     VeniceConfigLoader configLoader = getConfigLoader(servicePort);
     try (MainIngestionRequestClient client =
-        new MainIngestionRequestClient(IsolatedIngestionUtils.getSSLFactory(configLoader), servicePort)) {
+        new MainIngestionRequestClient(IsolatedIngestionUtils.getSSLFactory(configLoader), servicePort, 60)) {
       Process isolatedIngestionService = client.startForkedIngestionProcess(configLoader);
       TestUtils.waitForNonDeterministicAssertion(
           10,
@@ -72,7 +72,7 @@ public class IsolatedIngestionServerTest {
     int servicePort = Utils.getFreePort();
     VeniceConfigLoader configLoader = getConfigLoader(servicePort);
     try (MainIngestionRequestClient client =
-        new MainIngestionRequestClient(IsolatedIngestionUtils.getSSLFactory(configLoader), servicePort)) {
+        new MainIngestionRequestClient(IsolatedIngestionUtils.getSSLFactory(configLoader), servicePort, 60)) {
       // Make sure the process is forked successfully.
       ForkedJavaProcess isolatedIngestionService = (ForkedJavaProcess) client.startForkedIngestionProcess(configLoader);
       Assert.assertTrue(isolatedIngestionService.isAlive());

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/ingestion/main/MainIngestionRequestClientTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/ingestion/main/MainIngestionRequestClientTest.java
@@ -18,7 +18,7 @@ public class MainIngestionRequestClientTest {
 
   @Test(timeOut = TIMEOUT_IN_MILLIS)
   public void testIngestionCommand() {
-    try (MainIngestionRequestClient client = new MainIngestionRequestClient(Optional.empty(), 12345)) {
+    try (MainIngestionRequestClient client = new MainIngestionRequestClient(Optional.empty(), 12345, 60)) {
       HttpClientTransport mockedClientTransport = Mockito.mock(HttpClientTransport.class);
       IngestionTaskReport taskReport = new IngestionTaskReport();
       taskReport.setMessage("TEST MSG");

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/ingestion/main/MainIngestionRequestClientTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/ingestion/main/MainIngestionRequestClientTest.java
@@ -18,7 +18,7 @@ public class MainIngestionRequestClientTest {
 
   @Test(timeOut = TIMEOUT_IN_MILLIS)
   public void testIngestionCommand() {
-    try (MainIngestionRequestClient client = new MainIngestionRequestClient(Optional.empty(), 12345, 60)) {
+    try (MainIngestionRequestClient client = new MainIngestionRequestClient(Optional.empty(), 12345, 120)) {
       HttpClientTransport mockedClientTransport = Mockito.mock(HttpClientTransport.class);
       IngestionTaskReport taskReport = new IngestionTaskReport();
       taskReport.setMessage("TEST MSG");

--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -660,6 +660,9 @@ public class ConfigKeys {
    */
   public static final String SERVER_FORKED_PROCESS_JVM_ARGUMENT_LIST = "server.forked.process.jvm.arg.list";
 
+  public static final String SERVER_INGESTION_ISOLATION_REQUEST_TIMEOUT_SECONDS =
+      "server.ingestion.isolation.request.timout.seconds";
+
   /**
    * whether to enable checksum verification in the ingestion path from kafka to database persistency. If enabled it will
    * keep a running checksum for all and only PUT kafka data message received in the ingestion task and periodically

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/DaVinciClientTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/DaVinciClientTest.java
@@ -406,7 +406,7 @@ public class DaVinciClientTest {
       dummyOffsetMetadata.payload =
           ByteBuffer.wrap(new OffsetRecord(AvroProtocolDefinition.PARTITION_STATE.getSerializer()).toBytes());
       MainIngestionRequestClient requestClient =
-          new MainIngestionRequestClient(Optional.empty(), isolatedIngestionServicePort);
+          new MainIngestionRequestClient(Optional.empty(), isolatedIngestionServicePort, 60);
       TestUtils.waitForNonDeterministicAssertion(TEST_TIMEOUT, TimeUnit.MILLISECONDS, () -> {
         assertTrue(requestClient.updateMetadata(dummyOffsetMetadata));
       });

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/DaVinciClientTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/DaVinciClientTest.java
@@ -406,7 +406,7 @@ public class DaVinciClientTest {
       dummyOffsetMetadata.payload =
           ByteBuffer.wrap(new OffsetRecord(AvroProtocolDefinition.PARTITION_STATE.getSerializer()).toBytes());
       MainIngestionRequestClient requestClient =
-          new MainIngestionRequestClient(Optional.empty(), isolatedIngestionServicePort, 60);
+          new MainIngestionRequestClient(Optional.empty(), isolatedIngestionServicePort, 120);
       TestUtils.waitForNonDeterministicAssertion(TEST_TIMEOUT, TimeUnit.MILLISECONDS, () -> {
         assertTrue(requestClient.updateMetadata(dummyOffsetMetadata));
       });


### PR DESCRIPTION

## [server] Enhance isolated ingestion request handling logic
During the rolling out of isolated ingestion in EI enviorment, an issue was detected: Each server handles large amount of requests from different stores and drop partition command can be time consuming (it needs to potentially stop consumption and drain records and then close RocksDB) and taking up available threads (currently 10) in the thread pool. New requests can be piling up and eventually time out for the default 60s timeout. The problem can be more severe when the request is actually processed (partition removed from II host and cleaned up the status from II server but does not reset it in main process due to the fact it thinks the request time out and still retrying). The next retry will get rejected as II thinks this topic partition resources does not being to II process. It will stuck in this retry loop and the helix OFFLINE->DROPPED transition will never be completed.

Based on the observation, this PR makes the following tweaks:  (1) Introduce a new config to control the timeout and  increase the default client request timeout from 60s to 120s (2) Move the main process resource status cleanup logic up to before sending out request to II process so main process should not get stuck in the loop forever.

## How was this PR tested?
Internal CI
Will deploy the fix to EI server to validate it.

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.