### PR TITLE
[controller] Release cluster level lock while sleeping for next poll of resource assignment status

### DIFF
--- a/internal/venice-common/src/main/java/com/linkedin/venice/pushmonitor/OfflinePushStatus.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pushmonitor/OfflinePushStatus.java
@@ -48,7 +48,7 @@ public class OfflinePushStatus {
   /**
    * The initial status details will be overridden later, when the Helix resource is created.
    */
-  private Optional<String> statusDetails = Optional.of("Helix Resource not created.");
+  private Optional<String> statusDetails = Optional.of(HELIX_RESOURCE_NOT_CREATED);
   private List<StatusSnapshot> statusHistory;
   private String incrementalPushVersion = "";
   // Key is Partition Id (0 to n-1); value is the corresponding partition status.
@@ -57,6 +57,9 @@ public class OfflinePushStatus {
   private Map<String, String> pushProperties;
 
   private int successfulPushDurationInSecs = -1;
+
+  public static final String HELIX_RESOURCE_NOT_CREATED = "Helix Resource not created.";
+  public static final String HELIX_ASSIGNMENT_COMPLETED = "Helix assignment complete";
 
   public OfflinePushStatus(
       String kafkaTopic,

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/controller/TestVeniceHelixAdminWithSharedEnvironment.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/controller/TestVeniceHelixAdminWithSharedEnvironment.java
@@ -66,6 +66,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import org.apache.avro.Schema;
@@ -97,7 +100,11 @@ public class TestVeniceHelixAdminWithSharedEnvironment extends AbstractTestVenic
 
   @AfterClass(alwaysRun = true)
   public void cleanUp() {
-    cleanupCluster();
+    // Controller shutdown needs to complete within 5 minutes
+    ExecutorService ex = Executors.newSingleThreadExecutor();
+    Future clusterShutdownFuture = ex.submit(this::cleanupCluster);
+    TestUtils.waitForNonDeterministicCompletion(5, TimeUnit.MINUTES, () -> clusterShutdownFuture.isDone());
+    ex.shutdownNow();
   }
 
   @Test(timeOut = TOTAL_TIMEOUT_FOR_SHORT_TEST_MS)

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/DaVinciClusterAgnosticTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/DaVinciClusterAgnosticTest.java
@@ -76,7 +76,7 @@ public class DaVinciClusterAgnosticTest {
         1,
         2,
         1,
-        1,
+        2,
         4,
         1,
         3,

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/DaVinciClusterAgnosticTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/DaVinciClusterAgnosticTest.java
@@ -77,7 +77,7 @@ public class DaVinciClusterAgnosticTest {
         2,
         1,
         1,
-        3,
+        4,
         1,
         3,
         Optional.of(new VeniceProperties(Collections.singletonMap(OFFLINE_JOB_START_TIMEOUT_MS, "180000"))),

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/DaVinciClusterAgnosticTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/DaVinciClusterAgnosticTest.java
@@ -77,7 +77,7 @@ public class DaVinciClusterAgnosticTest {
         2,
         1,
         2,
-        4,
+        3,
         1,
         3,
         Optional.of(new VeniceProperties(Collections.singletonMap(OFFLINE_JOB_START_TIMEOUT_MS, "180000"))),
@@ -99,7 +99,7 @@ public class DaVinciClusterAgnosticTest {
         TestUtils.waitForNonDeterministicPushCompletion(
             Version.composeKafkaTopic(participantStoreName, 1),
             controllerClient,
-            1,
+            5,
             TimeUnit.MINUTES);
       }
     }

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/DaVinciClusterAgnosticTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/DaVinciClusterAgnosticTest.java
@@ -76,7 +76,7 @@ public class DaVinciClusterAgnosticTest {
         1,
         2,
         1,
-        2,
+        1,
         3,
         1,
         3,

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/helixrebalance/LeaderFollowerThreadPoolTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/helixrebalance/LeaderFollowerThreadPoolTest.java
@@ -68,7 +68,7 @@ public class LeaderFollowerThreadPoolTest {
    * It's better to destroy the testbed between each test runs.
    */
 
-  @Test(timeOut = 300 * Time.MS_PER_SECOND)
+  @Test(timeOut = 120 * Time.MS_PER_SECOND)
   public void testLeaderFollowerDualThreadPool() throws Exception {
     commonTestProcedures(true);
 
@@ -78,7 +78,7 @@ public class LeaderFollowerThreadPoolTest {
     // New version can complete successfully (it will not complete without having a separate thread pool for future
     // version)
     TestUtils.waitForNonDeterministicAssertion(
-        300,
+        60,
         TimeUnit.SECONDS,
         true,
         () -> Assert.assertEquals(

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/helixrebalance/LeaderFollowerThreadPoolTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/helixrebalance/LeaderFollowerThreadPoolTest.java
@@ -45,10 +45,8 @@ public class LeaderFollowerThreadPoolTest {
     int numOfController = 1;
     int numOfServers = 0;
     int numOfRouters = 1;
-    LOGGER.info("[DEBUGDEBUG] 111");
     cluster = ServiceFactory
         .getVeniceCluster(numOfController, numOfServers, numOfRouters, replicaFactor, partitionSize, false, false);
-    LOGGER.info("[DEBUGDEBUG] 222");
   }
 
   @AfterMethod
@@ -103,18 +101,14 @@ public class LeaderFollowerThreadPoolTest {
    */
   @Test(timeOut = 150 * Time.MS_PER_SECOND)
   public void testLeaderFollowerSingleThreadPool() throws Exception {
-    LOGGER.info("[DEBUGDEBUG] 333");
     commonTestProcedures(false);
-    LOGGER.info("[DEBUGDEBUG] 444");
 
     // Start a new version push and expect it to fail with exception.
     try {
       createVersionAndPushData(storeName);
       Assert.fail("new version creation should have failed.");
     } catch (AssertionError e) {
-      LOGGER.info("[DEBUGDEBUG] 999 Good, we got an exception.", e);
       Assert.assertTrue(e.getMessage().contains("does not have enough replicas"));
-      LOGGER.info("[DEBUGDEBUG] 101010 Good, test passed!!");
     }
   }
 
@@ -192,7 +186,6 @@ public class LeaderFollowerThreadPoolTest {
       veniceWriter.put("test", "test", 1);
       veniceWriter.broadcastEndOfPush(new HashMap<>());
     }
-    LOGGER.info("[DEBUGDEBUG] 777");
     return topicName;
   }
 

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/helixrebalance/LeaderFollowerThreadPoolTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/helixrebalance/LeaderFollowerThreadPoolTest.java
@@ -69,7 +69,7 @@ public class LeaderFollowerThreadPoolTest {
    * It's better to destroy the testbed between each test runs.
    */
 
-  @Test(timeOut = 120 * Time.MS_PER_SECOND)
+  @Test(timeOut = 300 * Time.MS_PER_SECOND)
   public void testLeaderFollowerDualThreadPool() throws Exception {
     commonTestProcedures(true);
 
@@ -79,7 +79,7 @@ public class LeaderFollowerThreadPoolTest {
     // New version can complete successfully (it will not complete without having a separate thread pool for future
     // version)
     TestUtils.waitForNonDeterministicAssertion(
-        60,
+        300,
         TimeUnit.SECONDS,
         true,
         () -> Assert.assertEquals(

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/helixrebalance/LeaderFollowerThreadPoolTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/helixrebalance/LeaderFollowerThreadPoolTest.java
@@ -45,9 +45,10 @@ public class LeaderFollowerThreadPoolTest {
     int numOfController = 1;
     int numOfServers = 0;
     int numOfRouters = 1;
-
+    LOGGER.info("[DEBUGDEBUG] 111");
     cluster = ServiceFactory
         .getVeniceCluster(numOfController, numOfServers, numOfRouters, replicaFactor, partitionSize, false, false);
+    LOGGER.info("[DEBUGDEBUG] 222");
   }
 
   @AfterMethod
@@ -100,16 +101,20 @@ public class LeaderFollowerThreadPoolTest {
    * 5.  Create another version and push data.
    * 6.  Assert that the second version cannot be completed and expect a Venice Error.
    */
-  @Test(timeOut = 120 * Time.MS_PER_SECOND)
+  @Test(timeOut = 150 * Time.MS_PER_SECOND)
   public void testLeaderFollowerSingleThreadPool() throws Exception {
+    LOGGER.info("[DEBUGDEBUG] 333");
     commonTestProcedures(false);
+    LOGGER.info("[DEBUGDEBUG] 444");
 
     // Start a new version push and expect it to fail with exception.
     try {
       createVersionAndPushData(storeName);
       Assert.fail("new version creation should have failed.");
     } catch (AssertionError e) {
+      LOGGER.info("[DEBUGDEBUG] 999 Good, we got an exception.", e);
       Assert.assertTrue(e.getMessage().contains("does not have enough replicas"));
+      LOGGER.info("[DEBUGDEBUG] 101010 Good, test passed!!");
     }
   }
 
@@ -187,6 +192,7 @@ public class LeaderFollowerThreadPoolTest {
       veniceWriter.put("test", "test", 1);
       veniceWriter.broadcastEndOfPush(new HashMap<>());
     }
+    LOGGER.info("[DEBUGDEBUG] 777");
     return topicName;
   }
 

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/integration/utils/VeniceControllerWrapper.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/integration/utils/VeniceControllerWrapper.java
@@ -188,7 +188,7 @@ public class VeniceControllerWrapper extends ProcessWrapper {
             .put(ENABLE_OFFLINE_PUSH_SSL_WHITELIST, false)
             .put(ENABLE_HYBRID_PUSH_SSL_WHITELIST, false)
             .put(KAFKA_BOOTSTRAP_SERVERS, options.getKafkaBroker().getAddress())
-            .put(OFFLINE_JOB_START_TIMEOUT_MS, 300_000)
+            .put(OFFLINE_JOB_START_TIMEOUT_MS, 120_000)
             // To speed up topic cleanup
             .put(TOPIC_CLEANUP_SLEEP_INTERVAL_BETWEEN_TOPIC_LIST_FETCH_MS, 100)
             .put(TOPIC_CLEANUP_DELAY_FACTOR, 2)

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/integration/utils/VeniceControllerWrapper.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/integration/utils/VeniceControllerWrapper.java
@@ -188,7 +188,7 @@ public class VeniceControllerWrapper extends ProcessWrapper {
             .put(ENABLE_OFFLINE_PUSH_SSL_WHITELIST, false)
             .put(ENABLE_HYBRID_PUSH_SSL_WHITELIST, false)
             .put(KAFKA_BOOTSTRAP_SERVERS, options.getKafkaBroker().getAddress())
-            .put(OFFLINE_JOB_START_TIMEOUT_MS, 60_000)
+            .put(OFFLINE_JOB_START_TIMEOUT_MS, 300_000)
             // To speed up topic cleanup
             .put(TOPIC_CLEANUP_SLEEP_INTERVAL_BETWEEN_TOPIC_LIST_FETCH_MS, 100)
             .put(TOPIC_CLEANUP_DELAY_FACTOR, 2)

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/HelixVeniceClusterResources.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/HelixVeniceClusterResources.java
@@ -164,7 +164,8 @@ public class HelixVeniceClusterResources implements VeniceResource {
         aggregateRealTimeSourceKafkaUrl,
         getActiveActiveRealTimeSourceKafkaURLs(config),
         helixAdminClient,
-        config.isErrorLeaderReplicaFailOverEnabled());
+        config.isErrorLeaderReplicaFailOverEnabled(),
+        config.getOffLineJobWaitTimeInMilliseconds());
 
     this.leakedPushStatusCleanUpService = new LeakedPushStatusCleanUpService(
         clusterName,

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -14,7 +14,7 @@ import static com.linkedin.venice.meta.VersionStatus.NOT_CREATED;
 import static com.linkedin.venice.meta.VersionStatus.ONLINE;
 import static com.linkedin.venice.meta.VersionStatus.PUSHED;
 import static com.linkedin.venice.meta.VersionStatus.STARTED;
-import static com.linkedin.venice.pushmonitor.OfflinePushStatus.*;
+import static com.linkedin.venice.pushmonitor.OfflinePushStatus.HELIX_ASSIGNMENT_COMPLETED;
 import static com.linkedin.venice.utils.AvroSchemaUtils.isValidAvroSchema;
 import static com.linkedin.venice.views.ViewUtils.ETERNAL_TOPIC_RETENTION_ENABLED;
 import static com.linkedin.venice.views.ViewUtils.LOG_COMPACTION_ENABLED;

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -14,6 +14,7 @@ import static com.linkedin.venice.meta.VersionStatus.NOT_CREATED;
 import static com.linkedin.venice.meta.VersionStatus.ONLINE;
 import static com.linkedin.venice.meta.VersionStatus.PUSHED;
 import static com.linkedin.venice.meta.VersionStatus.STARTED;
+import static com.linkedin.venice.pushmonitor.OfflinePushStatus.*;
 import static com.linkedin.venice.utils.AvroSchemaUtils.isValidAvroSchema;
 import static com.linkedin.venice.views.ViewUtils.ETERNAL_TOPIC_RETENTION_ENABLED;
 import static com.linkedin.venice.views.ViewUtils.LOG_COMPACTION_ENABLED;
@@ -4448,7 +4449,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
         if (!notReadyReason.isPresent()) {
           LOGGER.info("After waiting for {}ms, resource allocation is completed for: {}.", elapsedTime, topic);
           pushMonitor
-              .refreshAndUpdatePushStatus(topic, ExecutionStatus.STARTED, Optional.of("Helix assignment complete"));
+              .refreshAndUpdatePushStatus(topic, ExecutionStatus.STARTED, Optional.of(HELIX_ASSIGNMENT_COMPLETED));
           pushMonitor.recordPushPreparationDuration(topic, TimeUnit.MILLISECONDS.toSeconds(elapsedTime));
           return;
         }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/init/ClusterLeaderInitializationManager.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/init/ClusterLeaderInitializationManager.java
@@ -44,12 +44,10 @@ public class ClusterLeaderInitializationManager implements ClusterLeaderInitiali
         initializedClusters.computeIfAbsent(clusterToInit, k -> new VeniceConcurrentHashMap());
 
     if (concurrentInit) {
-      LOGGER.info("[DEBUGDEBUG] ConcurrentInit!!");
       initRoutines.forEach(
           routine -> CompletableFuture
               .runAsync(() -> initRoutine(clusterToInit, initializedRoutinesForCluster, routine)));
     } else {
-      LOGGER.info("[DEBUGDEBUG] Sequential init!!");
       CompletableFuture.runAsync(
           () -> initRoutines.forEach(routine -> initRoutine(clusterToInit, initializedRoutinesForCluster, routine)));
     }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/init/ClusterLeaderInitializationManager.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/init/ClusterLeaderInitializationManager.java
@@ -44,10 +44,12 @@ public class ClusterLeaderInitializationManager implements ClusterLeaderInitiali
         initializedClusters.computeIfAbsent(clusterToInit, k -> new VeniceConcurrentHashMap());
 
     if (concurrentInit) {
+      LOGGER.info("[DEBUGDEBUG] ConcurrentInit!!");
       initRoutines.forEach(
           routine -> CompletableFuture
               .runAsync(() -> initRoutine(clusterToInit, initializedRoutinesForCluster, routine)));
     } else {
+      LOGGER.info("[DEBUGDEBUG] Sequential init!!");
       CompletableFuture.runAsync(
           () -> initRoutines.forEach(routine -> initRoutine(clusterToInit, initializedRoutinesForCluster, routine)));
     }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/AbstractPushMonitor.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/AbstractPushMonitor.java
@@ -501,6 +501,13 @@ public abstract class AbstractPushMonitor
           handleErrorPush(pushStatus, errorMsg);
           return new Pair<>(ExecutionStatus.ERROR, errorMsg);
         }
+      } else {
+        // Update the status details if this is the first time finding out Helix assignment completes
+        Optional<String> statusDetails = pushStatus.getOptionalStatusDetails();
+        if (statusDetails.isPresent() && Objects.equals(statusDetails.get(), "Helix Resource not created.")) {
+          refreshAndUpdatePushStatus(topic, ExecutionStatus.STARTED, Optional.of("Helix assignment complete"));
+          recordPushPreparationDuration(topic, getDurationInSec(pushStatus));
+        }
       }
     }
     return new Pair<>(currentPushStatus, pushStatus.getStatusDetails());

--- a/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/AbstractPushMonitor.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/AbstractPushMonitor.java
@@ -10,6 +10,7 @@ import com.linkedin.venice.controller.HelixAdminClient;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.exceptions.VeniceNoStoreException;
 import com.linkedin.venice.helix.HelixCustomizedViewOfflinePushRepository;
+import com.linkedin.venice.helix.ResourceAssignment;
 import com.linkedin.venice.ingestion.control.RealTimeTopicSwitcher;
 import com.linkedin.venice.meta.Instance;
 import com.linkedin.venice.meta.OfflinePushStrategy;
@@ -39,6 +40,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -75,6 +77,7 @@ public abstract class AbstractPushMonitor
   private final HelixAdminClient helixAdminClient;
   private final EventThrottler helixClientThrottler;
   private final boolean disableErrorLeaderReplica;
+  private final long offlineJobResourceAssignmentWaitTimeInMilliseconds;
 
   public AbstractPushMonitor(
       String clusterName,
@@ -88,7 +91,8 @@ public abstract class AbstractPushMonitor
       String aggregateRealTimeSourceKafkaUrl,
       List<String> activeActiveRealTimeSourceKafkaURLs,
       HelixAdminClient helixAdminClient,
-      boolean disableErrorLeaderReplica) {
+      boolean disableErrorLeaderReplica,
+      long offlineJobResourceAssignmentWaitTimeInMilliseconds) {
     this.clusterName = clusterName;
     this.offlinePushAccessor = offlinePushAccessor;
     this.storeCleaner = storeCleaner;
@@ -103,6 +107,7 @@ public abstract class AbstractPushMonitor
     this.disableErrorLeaderReplica = disableErrorLeaderReplica;
     this.helixClientThrottler =
         new EventThrottler(10, "push_monitor_helix_client_throttler", false, EventThrottler.BLOCK_STRATEGY);
+    this.offlineJobResourceAssignmentWaitTimeInMilliseconds = offlineJobResourceAssignmentWaitTimeInMilliseconds;
   }
 
   @Override
@@ -468,7 +473,37 @@ public abstract class AbstractPushMonitor
     if (pushStatus == null) {
       return new Pair<>(ExecutionStatus.NOT_CREATED, "Offline job hasn't been created yet.");
     }
-    return new Pair<>(pushStatus.getCurrentStatus(), pushStatus.getStatusDetails());
+    ExecutionStatus currentPushStatus = pushStatus.getCurrentStatus();
+    if (currentPushStatus.equals(ExecutionStatus.NOT_STARTED) || currentPushStatus.equals(ExecutionStatus.STARTED)) {
+      // Check whether resource assignment has completed; if yes, continue; if no:
+      // 1. if the push duration hasn't passed the resource assignment wait timeout, log the current status
+      // 2. if the duration has passed the wait timeout, terminate the push
+      final ResourceAssignment resourceAssignment = routingDataRepository.getResourceAssignment();
+      final OfflinePushStrategy strategy = pushStatus.getStrategy();
+      final int replicationFactor = pushStatus.getReplicationFactor();
+      final PushStatusDecider statusDecider = PushStatusDecider.getDecider(strategy);
+      Optional<String> notReadyReason =
+          statusDecider.hasEnoughNodesToStartPush(topic, replicationFactor, resourceAssignment, Optional.empty());
+      if (notReadyReason.isPresent()) {
+        final long elapsedTimeInSec = getDurationInSec(pushStatus);
+        if (elapsedTimeInSec < TimeUnit.MILLISECONDS.toSeconds(offlineJobResourceAssignmentWaitTimeInMilliseconds)) {
+          LOGGER.info(
+              "After waiting for " + elapsedTimeInSec + " seconds, resource assignment for: " + topic
+                  + " is still not complete, strategy=" + strategy.toString() + ", replicationFactor="
+                  + replicationFactor + ", reason=" + notReadyReason.get());
+        } else {
+          // early termination
+          // Time out, after waiting maxWaitTimeMs, there are not enough nodes assigned.
+          recordPushPreparationDuration(topic, elapsedTimeInSec);
+          String errorMsg = "After waiting for " + elapsedTimeInSec + " seconds, resource assignment for: " + topic
+              + " timed out, strategy=" + strategy.toString() + ", replicationFactor=" + replicationFactor + ", reason="
+              + notReadyReason.get();
+          handleErrorPush(pushStatus, errorMsg);
+          return new Pair<>(ExecutionStatus.ERROR, errorMsg);
+        }
+      }
+    }
+    return new Pair<>(currentPushStatus, pushStatus.getStatusDetails());
   }
 
   @Override

--- a/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/AbstractPushMonitor.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/AbstractPushMonitor.java
@@ -5,6 +5,7 @@ import static com.linkedin.venice.pushmonitor.ExecutionStatus.END_OF_INCREMENTAL
 import static com.linkedin.venice.pushmonitor.ExecutionStatus.ERROR;
 import static com.linkedin.venice.pushmonitor.ExecutionStatus.NOT_CREATED;
 import static com.linkedin.venice.pushmonitor.ExecutionStatus.START_OF_INCREMENTAL_PUSH_RECEIVED;
+import static com.linkedin.venice.pushmonitor.OfflinePushStatus.*;
 
 import com.linkedin.venice.controller.HelixAdminClient;
 import com.linkedin.venice.exceptions.VeniceException;
@@ -504,8 +505,8 @@ public abstract class AbstractPushMonitor
       } else {
         // Update the status details if this is the first time finding out Helix assignment completes
         Optional<String> statusDetails = pushStatus.getOptionalStatusDetails();
-        if (statusDetails.isPresent() && Objects.equals(statusDetails.get(), "Helix Resource not created.")) {
-          refreshAndUpdatePushStatus(topic, ExecutionStatus.STARTED, Optional.of("Helix assignment complete"));
+        if (statusDetails.isPresent() && Objects.equals(statusDetails.get(), HELIX_RESOURCE_NOT_CREATED)) {
+          refreshAndUpdatePushStatus(topic, ExecutionStatus.STARTED, Optional.of(HELIX_ASSIGNMENT_COMPLETED));
           recordPushPreparationDuration(topic, getDurationInSec(pushStatus));
         }
       }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/AbstractPushMonitor.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/AbstractPushMonitor.java
@@ -5,7 +5,8 @@ import static com.linkedin.venice.pushmonitor.ExecutionStatus.END_OF_INCREMENTAL
 import static com.linkedin.venice.pushmonitor.ExecutionStatus.ERROR;
 import static com.linkedin.venice.pushmonitor.ExecutionStatus.NOT_CREATED;
 import static com.linkedin.venice.pushmonitor.ExecutionStatus.START_OF_INCREMENTAL_PUSH_RECEIVED;
-import static com.linkedin.venice.pushmonitor.OfflinePushStatus.*;
+import static com.linkedin.venice.pushmonitor.OfflinePushStatus.HELIX_ASSIGNMENT_COMPLETED;
+import static com.linkedin.venice.pushmonitor.OfflinePushStatus.HELIX_RESOURCE_NOT_CREATED;
 
 import com.linkedin.venice.controller.HelixAdminClient;
 import com.linkedin.venice.exceptions.VeniceException;

--- a/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/PartitionStatusBasedPushMonitor.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/PartitionStatusBasedPushMonitor.java
@@ -35,7 +35,8 @@ public class PartitionStatusBasedPushMonitor extends AbstractPushMonitor {
       String aggregateRealTimeSourceKafkaUrl,
       List<String> childDataCenterKafkaUrls,
       HelixAdminClient helixAdminClient,
-      boolean disableErrorLeaderReplica) {
+      boolean disableErrorLeaderReplica,
+      long offlineJobResourceAssignmentWaitTimeInMilliseconds) {
     super(
         clusterName,
         offlinePushAccessor,
@@ -48,7 +49,8 @@ public class PartitionStatusBasedPushMonitor extends AbstractPushMonitor {
         aggregateRealTimeSourceKafkaUrl,
         childDataCenterKafkaUrls,
         helixAdminClient,
-        disableErrorLeaderReplica);
+        disableErrorLeaderReplica,
+        offlineJobResourceAssignmentWaitTimeInMilliseconds);
   }
 
   @Override

--- a/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/PushMonitorDelegator.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/PushMonitorDelegator.java
@@ -55,7 +55,8 @@ public class PushMonitorDelegator implements PushMonitor {
       String aggregateRealTimeSourceKafkaUrl,
       List<String> activeActiveRealTimeSourceKafkaURLs,
       HelixAdminClient helixAdminClient,
-      boolean disableErrorLeaderReplica) {
+      boolean disableErrorLeaderReplica,
+      long offlineJobResourceAssignmentWaitTimeInMilliseconds) {
     this.clusterName = clusterName;
     this.metadataRepository = metadataRepository;
     this.offlinePushAccessor = offlinePushAccessor;
@@ -72,7 +73,8 @@ public class PushMonitorDelegator implements PushMonitor {
         aggregateRealTimeSourceKafkaUrl,
         activeActiveRealTimeSourceKafkaURLs,
         helixAdminClient,
-        disableErrorLeaderReplica);
+        disableErrorLeaderReplica,
+        offlineJobResourceAssignmentWaitTimeInMilliseconds);
     this.clusterLockManager = clusterLockManager;
 
     this.topicToPushMonitorMap = new VeniceConcurrentHashMap<>();

--- a/services/venice-controller/src/test/java/com/linkedin/venice/pushmonitor/AbstractPushMonitorTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/pushmonitor/AbstractPushMonitorTest.java
@@ -20,6 +20,7 @@ import static org.mockito.Mockito.when;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.helix.HelixCustomizedViewOfflinePushRepository;
 import com.linkedin.venice.helix.HelixState;
+import com.linkedin.venice.helix.ResourceAssignment;
 import com.linkedin.venice.ingestion.control.RealTimeTopicSwitcher;
 import com.linkedin.venice.meta.BufferReplayPolicy;
 import com.linkedin.venice.meta.DataReplicationPolicy;
@@ -110,6 +111,7 @@ public abstract class AbstractPushMonitorTest {
     verify(mockAccessor, atLeastOnce()).createOfflinePushStatusAndItsPartitionStatuses(pushStatus);
     verify(mockAccessor, atLeastOnce()).subscribePartitionStatusChange(pushStatus, monitor);
     verify(mockRoutingDataRepo, atLeastOnce()).subscribeRoutingDataChange(getTopic(), monitor);
+    doReturn(mock(ResourceAssignment.class)).when(mockRoutingDataRepo).getResourceAssignment();
     try {
       monitor.startMonitorOfflinePush(
           topic,

--- a/services/venice-controller/src/test/java/com/linkedin/venice/pushmonitor/PartitionStatusBasedPushMonitorTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/pushmonitor/PartitionStatusBasedPushMonitorTest.java
@@ -58,7 +58,8 @@ public class PartitionStatusBasedPushMonitorTest extends AbstractPushMonitorTest
         getAggregateRealTimeSourceKafkaUrl(),
         Collections.emptyList(),
         helixAdminClient,
-        true);
+        true,
+        120000);
   }
 
   @Override
@@ -75,7 +76,8 @@ public class PartitionStatusBasedPushMonitorTest extends AbstractPushMonitorTest
         getAggregateRealTimeSourceKafkaUrl(),
         Collections.emptyList(),
         mock(HelixAdminClient.class),
-        true);
+        true,
+        120000);
   }
 
   @Test


### PR DESCRIPTION
Other changes:
 - Backup version early deletion will happen befor resource assignment for new resource completes, which better matches the original intention of early backup version deletion.

## How was this PR tested?
Internal CI:
JDK11: 7317 (yellow)
JDK8: 1072, 1073 (red)

Also added a new test case to enforce controller shutdown needs to complete within 5 minutes.

## Does this PR introduce any user-facing changes?
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.