### PR TITLE
[common] Catch TopicDoesNotExistException and return true for TopicManager#isTopicTruncated

### DIFF
--- a/internal/venice-common/src/main/java/com/linkedin/venice/kafka/TopicManager.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/kafka/TopicManager.java
@@ -441,8 +441,19 @@ public class TopicManager implements Closeable {
     return UNKNOWN_TOPIC_RETENTION;
   }
 
+  /**
+   * Check whether topic is absent or truncated
+   * @param topicName
+   * @param truncatedTopicMaxRetentionMs
+   * @return true if the topic does not exist or if it exists but its retention time is below truncated threshold
+   *         false if the topic exists and its retention time is above truncated threshold
+   */
   public boolean isTopicTruncated(String topicName, long truncatedTopicMaxRetentionMs) {
-    return isRetentionBelowTruncatedThreshold(getTopicRetention(topicName), truncatedTopicMaxRetentionMs);
+    try {
+      return isRetentionBelowTruncatedThreshold(getTopicRetention(topicName), truncatedTopicMaxRetentionMs);
+    } catch (TopicDoesNotExistException e) {
+      return true;
+    }
   }
 
   public boolean isRetentionBelowTruncatedThreshold(long retention, long truncatedTopicMaxRetentionMs) {

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/controller/TestParentControllerWithMultiDataCenter.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/controller/TestParentControllerWithMultiDataCenter.java
@@ -439,6 +439,7 @@ public class TestParentControllerWithMultiDataCenter {
       String storeName,
       int expectedVersion) {
     VersionCreationResponse vcr = parentControllerClient.emptyPush(storeName, Utils.getUniqueString("empty-push"), 1L);
+    Assert.assertFalse(vcr.isError());
     assertEquals(
         vcr.getVersion(),
         expectedVersion,

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -2932,7 +2932,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
   }
 
   /**
-   * Test if a kafka topic is truncated.
+   * Check if a kafka topic is absent or truncated.
    * @see ConfigKeys#DEPRECATED_TOPIC_MAX_RETENTION_MS
    */
   @Override


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci], [server], [controller],
[router], [samza], [vpj], [fast-client], [thin-client], [alpini],
[admin-tool], [test], [build], [doc], [script]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Summary
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Test testStoreRollbackToBackupVersion is flaky in JDK8. The second empty push sometimes fails as previous empty push
version topic is truncated during getOffLinePushStatus and sometimes the topic is deleted quickly. Then isTopicTruncated 
inside truncateTopicsBasedOnMaxErroredTopicNumToKeep throws topic does not exist exception and fails the second 
empty push job.

The commit catches TopicDoesNotExistException and returns true for TopicManager#isTopicTruncated.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
Internal WcTest8 1103 1104 1105: No testStoreRollbackToBackupVersion failure

FYI, previous failed test exception stack trace:
```
com.linkedin.venice.kafka.TopicDoesNotExistException: Topic: testStoreRollbackToBackupVersion_53201a239c474_b5510b98_v1 doesn't exist
        at com.linkedin.venice.kafka.admin.KafkaAdminClient.getTopicConfig(KafkaAdminClient.java:141) ~[venice-common.jar:?]
        at com.linkedin.venice.kafka.admin.InstrumentedKafkaAdmin.lambda$getTopicConfig$5(InstrumentedKafkaAdmin.java:103) ~[venice-common.jar:?]
        at com.linkedin.venice.kafka.admin.InstrumentedKafkaAdmin.instrument(InstrumentedKafkaAdmin.java:165) ~[venice-common.jar:?]
        at com.linkedin.venice.kafka.admin.InstrumentedKafkaAdmin.getTopicConfig(InstrumentedKafkaAdmin.java:103) ~[venice-common.jar:?]
        at com.linkedin.venice.kafka.TopicManager.getTopicConfig(TopicManager.java:456) ~[venice-common.jar:?]
        at com.linkedin.venice.kafka.TopicManager.getTopicRetention(TopicManager.java:430) ~[venice-common.jar:?]
        at com.linkedin.venice.kafka.TopicManager.isTopicTruncated(TopicManager.java:445) ~[venice-common.jar:?]
        at com.linkedin.venice.controller.VeniceHelixAdmin.isTopicTruncated(VeniceHelixAdmin.java:2940) ~[venice-controller.jar:?]
        at com.linkedin.venice.controller.VeniceParentHelixAdmin.isTopicTruncated(VeniceParentHelixAdmin.java:3956) ~[venice-controller.jar:?]
        at com.linkedin.venice.controller.VeniceParentHelixAdmin.lambda$truncateTopicsBasedOnMaxErroredTopicNumToKeep$8(VeniceParentHelixAdmin.java:1308) ~[venice-controller.jar:?]
        at java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:174) ~[?:1.8.0_282]
        at java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1384) ~[?:1.8.0_282]
        at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:482) ~[?:1.8.0_282]
        at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:472) ~[?:1.8.0_282]
        at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:708) ~[?:1.8.0_282]
        at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234) ~[?:1.8.0_282]
        at java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:566) ~[?:1.8.0_282]
        at com.linkedin.venice.controller.VeniceParentHelixAdmin.truncateTopicsBasedOnMaxErroredTopicNumToKeep(VeniceParentHelixAdmin.java:1312) ~[venice-controller.jar:?]
        at com.linkedin.venice.controller.VeniceParentHelixAdmin.getTopicForCurrentPushJob(VeniceParentHelixAdmin.java:1290) ~[venice-controller.jar:?]
        at com.linkedin.venice.controller.VeniceParentHelixAdmin.incrementVersionIdempotent(VeniceParentHelixAdmin.java:1481) ~[venice-controller.jar:?]
        at com.linkedin.venice.controller.Admin.incrementVersionIdempotent(Admin.java:185) ~[venice-controller.jar:?]
        at com.linkedin.venice.controller.server.CreateVersion.lambda$emptyPush$7(CreateVersion.java:638) ~[venice-controller.jar:?]
```

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.