### PR TITLE
[server] End to end RMD chunking support for A/A store ingestion (First part)

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveProducerCallback.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveProducerCallback.java
@@ -62,8 +62,7 @@ public class ActiveActiveProducerCallback extends LeaderProducerCallback {
     if (chunkedRmdManifest == null) {
       manifestPut.replicationMetadataPayload = leaderProducedRecordContextPut.replicationMetadataPayload;
     } else {
-      ByteBuffer rmdManifest = ByteBuffer
-          .wrap(CHUNKED_VALUE_MANIFEST_SERIALIZER.serialize(ingestionTask.getVersionTopic(), chunkedRmdManifest));
+      ByteBuffer rmdManifest = CHUNKED_VALUE_MANIFEST_SERIALIZER.serialize(chunkedRmdManifest);
       rmdManifest.position(ValueRecord.SCHEMA_HEADER_LENGTH);
       manifestPut.replicationMetadataPayload = rmdManifest;
     }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveProducerCallback.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveProducerCallback.java
@@ -1,9 +1,11 @@
 package com.linkedin.davinci.kafka.consumer;
 
+import com.linkedin.davinci.store.record.ValueRecord;
 import com.linkedin.venice.kafka.protocol.KafkaMessageEnvelope;
 import com.linkedin.venice.kafka.protocol.Put;
 import com.linkedin.venice.message.KafkaKey;
 import com.linkedin.venice.writer.VeniceWriter;
+import java.nio.ByteBuffer;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.producer.RecordMetadata;
 
@@ -37,9 +39,17 @@ public class ActiveActiveProducerCallback extends LeaderProducerCallback {
   }
 
   @Override
-  protected Put instantiateChunkPut() {
+  protected Put instantiateValueChunkPut() {
     Put chunkPut = new Put();
     chunkPut.replicationMetadataPayload = EMPTY_BYTE_BUFFER;
+    chunkPut.replicationMetadataVersionId = VeniceWriter.VENICE_DEFAULT_TIMESTAMP_METADATA_VERSION_ID;
+    return chunkPut;
+  }
+
+  @Override
+  protected Put instantiateRmdChunkPut() {
+    Put chunkPut = new Put();
+    chunkPut.putValue = EMPTY_BYTE_BUFFER;
     chunkPut.replicationMetadataVersionId = VeniceWriter.VENICE_DEFAULT_TIMESTAMP_METADATA_VERSION_ID;
     return chunkPut;
   }
@@ -49,7 +59,15 @@ public class ActiveActiveProducerCallback extends LeaderProducerCallback {
     Put manifestPut = new Put();
     Put leaderProducedRecordContextPut = (Put) leaderProducedRecordContext.getValueUnion();
     manifestPut.replicationMetadataVersionId = leaderProducedRecordContextPut.replicationMetadataVersionId;
-    manifestPut.replicationMetadataPayload = leaderProducedRecordContextPut.replicationMetadataPayload;
+    if (chunkedRmdManifest == null) {
+      manifestPut.replicationMetadataPayload = leaderProducedRecordContextPut.replicationMetadataPayload;
+    } else {
+      ByteBuffer rmdManifest = ByteBuffer
+          .wrap(CHUNKED_VALUE_MANIFEST_SERIALIZER.serialize(ingestionTask.getVersionTopic(), chunkedRmdManifest));
+      rmdManifest.position(ValueRecord.SCHEMA_HEADER_LENGTH);
+      manifestPut.replicationMetadataPayload = rmdManifest;
+    }
+
     return manifestPut;
   }
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveProducerCallback.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveProducerCallback.java
@@ -50,6 +50,7 @@ public class ActiveActiveProducerCallback extends LeaderProducerCallback {
   protected Put instantiateRmdChunkPut() {
     Put chunkPut = new Put();
     chunkPut.putValue = EMPTY_BYTE_BUFFER;
+    // This field is not used in the RMD chunk. The correct RMD version id will be stored in the RMD manifest.
     chunkPut.replicationMetadataVersionId = VeniceWriter.VENICE_DEFAULT_TIMESTAMP_METADATA_VERSION_ID;
     return chunkPut;
   }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
@@ -507,8 +507,7 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
           serverConfig.isComputeFastAvroEnabled(),
           schemaRepository,
           storeName,
-          compressor.get(),
-          false);
+          compressor.get());
       hostLevelIngestionStats.recordIngestionValueBytesLookUpLatency(LatencyUtils.getLatencyInMS(lookupStartTimeInNS));
     } else {
       hostLevelIngestionStats.recordIngestionValueBytesCacheHitCount();

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
@@ -2,6 +2,7 @@ package com.linkedin.davinci.kafka.consumer;
 
 import static com.linkedin.davinci.kafka.consumer.LeaderFollowerStateType.LEADER;
 import static com.linkedin.davinci.kafka.consumer.LeaderFollowerStateType.STANDBY;
+import static com.linkedin.davinci.store.record.ValueRecord.*;
 import static com.linkedin.venice.VeniceConstants.REWIND_TIME_DECIDED_BY_SERVER;
 
 import com.linkedin.davinci.config.VeniceStoreVersionConfig;
@@ -13,7 +14,9 @@ import com.linkedin.davinci.replication.merge.RmdSerDe;
 import com.linkedin.davinci.stats.AggVersionedIngestionStats;
 import com.linkedin.davinci.storage.chunking.ChunkingUtils;
 import com.linkedin.davinci.storage.chunking.RawBytesChunkingAdapter;
+import com.linkedin.davinci.storage.chunking.SingleGetChunkingAdapter;
 import com.linkedin.davinci.store.cache.backend.ObjectCacheBackend;
+import com.linkedin.davinci.store.record.ValueRecord;
 import com.linkedin.davinci.utils.ByteArrayKey;
 import com.linkedin.venice.exceptions.PersistenceFailureException;
 import com.linkedin.venice.exceptions.VeniceException;
@@ -163,14 +166,18 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
   protected void putInStorageEngine(int partition, byte[] keyBytes, Put put) {
     try {
       // TODO: Honor BatchConflictResolutionPolicy and maybe persist RMD for batch push records.
-      switch (getStorageOperationType(partition, put.putValue, put.replicationMetadataPayload)) {
+      StorageOperationType storageOperationType =
+          getStorageOperationType(partition, put.putValue, put.replicationMetadataPayload);
+      switch (storageOperationType) {
         case VALUE_AND_RMD:
           byte[] metadataBytesWithValueSchemaId =
               prependReplicationMetadataBytesWithValueSchemaId(put.replicationMetadataPayload, put.schemaId);
           storageEngine.putWithReplicationMetadata(partition, keyBytes, put.putValue, metadataBytesWithValueSchemaId);
           break;
-        case RMD:
-          storageEngine.putReplicationMetadata(partition, keyBytes, put.replicationMetadataPayload.array());
+        case RMD_CHUNK:
+          metadataBytesWithValueSchemaId =
+              prependReplicationMetadataBytesWithValueSchemaId(put.replicationMetadataPayload, put.schemaId);
+          storageEngine.putReplicationMetadata(partition, keyBytes, metadataBytesWithValueSchemaId);
           break;
         case VALUE:
           storageEngine.put(partition, keyBytes, put.putValue);
@@ -207,19 +214,23 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
       logStorageOperationWhileUnsubscribed(partition);
       return StorageOperationType.NONE;
     }
-    if (valuePayload != null && valuePayload.remaining() == 0 && rmdPayload.remaining() != 0) {
-      return StorageOperationType.RMD;
+    if (isDaVinciClient) {
+      return StorageOperationType.VALUE;
     }
-    if ((pcs.isEndOfPushReceived() || rmdPayload.remaining() != 0) && !isDaVinciClient) {
-      return StorageOperationType.VALUE_AND_RMD;
+    if (pcs.isEndOfPushReceived() || rmdPayload.remaining() > 0) {
+      if (valuePayload == null || valuePayload.remaining() > 0) {
+        return StorageOperationType.VALUE_AND_RMD;
+      }
+      return StorageOperationType.RMD_CHUNK;
+    } else {
+      return StorageOperationType.VALUE;
     }
-    return StorageOperationType.VALUE;
   }
 
   private enum StorageOperationType {
     VALUE_AND_RMD, // Operate on value associated with RMD
     VALUE, // Operate on full or chunked value
-    RMD, // Operate on chunked RMD
+    RMD_CHUNK, // Operate on chunked RMD
     NONE
   }
 
@@ -242,34 +253,43 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
    * @param subPartition The partition to fetch the replication metadata from storage engine
    * @return The object containing RMD and value schema id. If nothing is found, return {@code Optional.empty()}
    */
-  private Optional<RmdWithValueSchemaId> getReplicationMetadataAndSchemaId(
+  Optional<RmdWithValueSchemaId> getReplicationMetadataAndSchemaId(
       PartitionConsumptionState partitionConsumptionState,
       byte[] key,
       int subPartition) {
     PartitionConsumptionState.TransientRecord cachedRecord = partitionConsumptionState.getTransientRecord(key);
     if (cachedRecord != null) {
-      hostLevelIngestionStats.recordIngestionReplicationMetadataCacheHitCount();
+      getHostLevelIngestionStats().recordIngestionReplicationMetadataCacheHitCount();
       return Optional.of(
           new RmdWithValueSchemaId(
               cachedRecord.getValueSchemaId(),
-              rmdProtocolVersionID,
+              getRmdProtocolVersionID(),
               cachedRecord.getReplicationMetadataRecord()));
     }
 
     final long lookupStartTimeInNS = System.nanoTime();
-    byte[] updatedKey;
-    if (isChunked) {
-      updatedKey = ChunkingUtils.KEY_WITH_CHUNKING_SUFFIX_SERIALIZER.serializeNonChunkedKey(key);
-    } else {
-      updatedKey = key;
-    }
-    byte[] replicationMetadataWithValueSchemaBytes = storageEngine.getReplicationMetadata(subPartition, updatedKey);
-    hostLevelIngestionStats
+
+    ByteBuffer rmdWithValueSchemaByteBuffer = getRmdWithValueSchemaByteBufferFromStorage(subPartition, key);
+    byte[] replicationMetadataWithValueSchemaBytes =
+        rmdWithValueSchemaByteBuffer == null ? null : rmdWithValueSchemaByteBuffer.array();
+
+    getHostLevelIngestionStats()
         .recordIngestionReplicationMetadataLookUpLatency(LatencyUtils.getLatencyInMS(lookupStartTimeInNS));
-    if (replicationMetadataWithValueSchemaBytes == null) {
+    if (rmdWithValueSchemaByteBuffer == null) {
       return Optional.empty(); // No RMD for this key
     }
-    return Optional.of(rmdSerDe.deserializeValueSchemaIdPrependedRmdBytes(replicationMetadataWithValueSchemaBytes));
+    return Optional
+        .of(getRmdSerDe().deserializeValueSchemaIdPrependedRmdBytes(replicationMetadataWithValueSchemaBytes));
+  }
+
+  ByteBuffer getRmdWithValueSchemaByteBufferFromStorage(int subPartition, byte[] key) {
+    ValueRecord result =
+        SingleGetChunkingAdapter.getReplicationMetadata(getStorageEngine(), subPartition, key, isChunked(), null);
+    if (result == null) {
+      return null;
+    }
+    return ByteBuffer
+        .wrap(result.getDataBytesPrependedWithWriterSchemaId(), SCHEMA_HEADER_LENGTH, result.getDataSize());
   }
 
   // This function may modify the original record in KME and it is unsafe to use the payload from KME directly after
@@ -461,8 +481,8 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
    * is that the {@link PartitionConsumptionState.TransientRecord} only contains the full value.
    * @param partitionConsumptionState The {@link PartitionConsumptionState} of the current partition
    * @param key The key bytes of the incoming record.
-   * @param topic The topic from which the incomign record was consumed
-   * @param partition The Kafka partition from which the incomign record was consumed
+   * @param topic The topic from which the incoming record was consumed
+   * @param partition The Kafka partition from which the incoming record was consumed
    * @return
    */
   private ByteBuffer getValueBytesForKey(
@@ -545,7 +565,6 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
       deletePayload.schemaId = valueSchemaId;
       deletePayload.replicationMetadataVersionId = rmdProtocolVersionID;
       deletePayload.replicationMetadataPayload = updatedRmdBytes;
-
       ProduceToTopic produceToTopicFunction = (callback, sourceTopicOffset) -> veniceWriter.get()
           .delete(
               key,
@@ -1294,5 +1313,9 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
         subPartition,
         kafkaUrl,
         beforeProcessingRecordTimestamp);
+  }
+
+  protected RmdSerDe getRmdSerDe() {
+    return rmdSerDe;
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
@@ -222,8 +222,8 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
     if (rmdPayload == null) {
       throw new IllegalArgumentException("Replication metadata payload not found.");
     }
-
     if (pcs.isEndOfPushReceived() || rmdPayload.remaining() > 0) {
+      // value payload == null means it is a DELETE request, while value payload size > 0 means it is a PUT request.
       if (valuePayload == null || valuePayload.remaining() > 0) {
         return StorageOperationType.VALUE_AND_RMD;
       }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -1367,7 +1367,7 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
         switch (MessageType.valueOf(envelope)) {
           case PUT:
             // Issue an read to get the current value of the key
-            byte[] actualValue = storageEngine.get(consumerRecord.partition(), key.getKey(), false);
+            byte[] actualValue = storageEngine.get(consumerRecord.partition(), key.getKey());
             if (actualValue != null) {
               int actualSchemaId = ByteUtils.readInt(actualValue, 0);
               Put put = (Put) envelope.payloadUnion;
@@ -1390,7 +1390,7 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
             /**
              * Lossy if the key/value pair is added back to the storage engine after the first DELETE message.
              */
-            actualValue = storageEngine.get(consumerRecord.partition(), key.getKey(), false);
+            actualValue = storageEngine.get(consumerRecord.partition(), key.getKey());
             if (actualValue == null) {
               lossy = false;
               logMsg += Utils.NEW_LINE_CHAR;
@@ -2824,8 +2824,7 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
             serverConfig.isComputeFastAvroEnabled(),
             schemaRepository,
             storeName,
-            compressor.get(),
-            false);
+            compressor.get());
         hostLevelIngestionStats.recordWriteComputeLookUpLatency(LatencyUtils.getLatencyInMS(lookupStartTimeInNS));
       } catch (Exception e) {
         writeComputeFailureCode = StatsErrorCode.WRITE_COMPUTE_DESERIALIZATION_FAILURE.code;

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -53,6 +53,7 @@ import com.linkedin.venice.utils.lazy.Lazy;
 import com.linkedin.venice.writer.LeaderMetadataWrapper;
 import com.linkedin.venice.writer.VeniceWriter;
 import com.linkedin.venice.writer.VeniceWriterFactory;
+import com.linkedin.venice.writer.VeniceWriterOptions;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import it.unimi.dsi.fastutil.ints.IntList;
 import java.io.IOException;
@@ -217,24 +218,23 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
         getVersionTopic());
 
     this.veniceWriterFactory = builder.getVeniceWriterFactory();
-    this.veniceWriter = Lazy.of(
-        () -> veniceWriterFactory.createBasicVeniceWriter(
-            kafkaVersionTopic,
-            /**
-             * In general, a partition in version topic follows this pattern:
-             * {Start_of_Segment, Start_of_Push, End_of_Segment, Start_of_Segment, data..., End_of_Segment, Start_of_Segment, End_of_Push, End_of_Segment}
-             * Therefore, in native replication where leader needs to producer all messages it consumes from remote, the first
-             * message that leader consumes is not SOP, in this case, leader doesn't know whether chunking is enabled.
-             *
-             * Notice that the pattern is different in stream reprocessing which contains a lot more segments and is also
-             * different in some test cases which reuse the same VeniceWriter.
-             */
-            isChunked,
-            venicePartitioner,
-            storeVersionPartitionCount * amplificationFactor));
-
+    /**
+     * In general, a partition in version topic follows this pattern:
+     * {Start_of_Segment, Start_of_Push, End_of_Segment, Start_of_Segment, data..., End_of_Segment, Start_of_Segment, End_of_Push, End_of_Segment}
+     * Therefore, in native replication where leader needs to producer all messages it consumes from remote, the first
+     * message that leader consumes is not SOP, in this case, leader doesn't know whether chunking is enabled.
+     *
+     * Notice that the pattern is different in stream reprocessing which contains a lot more segments and is also
+     * different in some test cases which reuse the same VeniceWriter.
+     */
+    VeniceWriterOptions writerOptions =
+        new VeniceWriterOptions.Builder(getVersionTopic()).setPartitioner(venicePartitioner)
+            .setChunkingEnabled(isChunked)
+            .setRmdChunkingEnabled(version.isRmdChunkingEnabled())
+            .setPartitionCount(Optional.of(storeVersionPartitionCount * amplificationFactor))
+            .build();
+    this.veniceWriter = Lazy.of(() -> veniceWriterFactory.createVeniceWriter(writerOptions));
     this.kafkaClusterIdToUrlMap = serverConfig.getKafkaClusterIdToUrlMap();
-
     this.kafkaDataIntegrityValidatorForLeaders = new KafkaDataIntegrityValidator(kafkaVersionTopic);
   }
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderProducerCallback.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderProducerCallback.java
@@ -251,13 +251,12 @@ class LeaderProducerCallback implements ChunkAwareCallback {
       Put chunkPut;
       if (isRmdChunks) {
         chunkPut = instantiateRmdChunkPut();
-        chunkPut.schemaId = AvroProtocolDefinition.CHUNK.getCurrentProtocolVersion();
         chunkPut.replicationMetadataPayload = chunkValue;
       } else {
         chunkPut = instantiateValueChunkPut();
         chunkPut.putValue = chunkValue;
-        chunkPut.schemaId = AvroProtocolDefinition.CHUNK.getCurrentProtocolVersion();
       }
+      chunkPut.schemaId = AvroProtocolDefinition.CHUNK.getCurrentProtocolVersion();
       LeaderProducedRecordContext producedRecordForChunk =
           LeaderProducedRecordContext.newChunkPutRecord(ByteUtils.extractByteArray(chunkKey), chunkPut);
       producedRecordForChunk.setProducedOffset(-1);

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -2951,18 +2951,20 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
    */
   private void prependHeaderAndWriteToStorageEngine(int partition, byte[] keyBytes, Put put) {
     ByteBuffer putValue = put.putValue;
-    /*
-     * Since {@link com.linkedin.venice.serialization.avro.OptimizedKafkaValueSerializer} reuses the original byte
-     * array, which is big enough to pre-append schema id, so we just reuse it to avoid unnecessary byte array allocation.
-     * This value encoding scheme is used in {@link PartitionConsumptionState#maybeUpdateExpectedChecksum(byte[], Put)} to
-     * calculate checksum for all the kafka PUT messages seen so far. Any change here needs to be reflected in that function.
-     */
+
     if ((put.putValue.remaining() == 0) && (put.replicationMetadataPayload.remaining() > 0)) {
+      // For RMD chunk, it is already prepended with the schema ID, so we will just put to storage engine.
       writeToStorageEngine(partition, keyBytes, put);
     } else if (putValue.position() < ValueRecord.SCHEMA_HEADER_LENGTH) {
       throw new VeniceException(
           "Start position of 'putValue' ByteBuffer shouldn't be less than " + ValueRecord.SCHEMA_HEADER_LENGTH);
     } else {
+      /*
+       * Since {@link com.linkedin.venice.serialization.avro.OptimizedKafkaValueSerializer} reuses the original byte
+       * array, which is big enough to pre-append schema id, so we just reuse it to avoid unnecessary byte array allocation.
+       * This value encoding scheme is used in {@link PartitionConsumptionState#maybeUpdateExpectedChecksum(byte[], Put)} to
+       * calculate checksum for all the kafka PUT messages seen so far. Any change here needs to be reflected in that function.
+       */
       // Back up the original 4 bytes
       putValue.position(putValue.position() - ValueRecord.SCHEMA_HEADER_LENGTH);
       int backupBytes = putValue.getInt();

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -2952,7 +2952,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
   private void prependHeaderAndWriteToStorageEngine(int partition, byte[] keyBytes, Put put) {
     ByteBuffer putValue = put.putValue;
 
-    if ((put.putValue.remaining() == 0) && (put.replicationMetadataPayload.remaining() > 0)) {
+    if ((putValue.remaining() == 0) && (put.replicationMetadataPayload.remaining() > 0)) {
       // For RMD chunk, it is already prepended with the schema ID, so we will just put to storage engine.
       writeToStorageEngine(partition, keyBytes, put);
     } else if (putValue.position() < ValueRecord.SCHEMA_HEADER_LENGTH) {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -2957,7 +2957,9 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
      * This value encoding scheme is used in {@link PartitionConsumptionState#maybeUpdateExpectedChecksum(byte[], Put)} to
      * calculate checksum for all the kafka PUT messages seen so far. Any change here needs to be reflected in that function.
      */
-    if (putValue.position() < ValueRecord.SCHEMA_HEADER_LENGTH) {
+    if ((put.putValue.remaining() == 0) && (put.replicationMetadataPayload.remaining() > 0)) {
+      writeToStorageEngine(partition, keyBytes, put);
+    } else if (putValue.position() < ValueRecord.SCHEMA_HEADER_LENGTH) {
       throw new VeniceException(
           "Start position of 'putValue' ByteBuffer shouldn't be less than " + ValueRecord.SCHEMA_HEADER_LENGTH);
     } else {
@@ -2966,7 +2968,6 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
       int backupBytes = putValue.getInt();
       putValue.position(putValue.position() - ValueRecord.SCHEMA_HEADER_LENGTH);
       ByteUtils.writeInt(putValue.array(), put.schemaId, putValue.position());
-
       writeToStorageEngine(partition, keyBytes, put);
 
       /* We still want to recover the original position to make this function idempotent. */
@@ -3127,7 +3128,6 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
         }
         valueLen = put.putValue.remaining();
         keyLen = keyBytes.length;
-
         // update checksum for this PUT message if needed.
         partitionConsumptionState.maybeUpdateExpectedChecksum(keyBytes, put);
         prependHeaderAndWriteToStorageEngine(
@@ -3154,7 +3154,6 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
           delete = ((Delete) leaderProducedRecordContext.getValueUnion());
         }
         keyLen = keyBytes.length;
-
         long deleteStartTimeNs = System.nanoTime();
 
         removeFromStorageEngine(producedPartition, keyBytes, delete);
@@ -3761,6 +3760,22 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
 
   protected AggVersionedIngestionStats getVersionIngestionStats() {
     return versionedIngestionStats;
+  }
+
+  protected CompressionStrategy getCompressionStrategy() {
+    return compressionStrategy;
+  }
+
+  protected Lazy<VeniceCompressor> getCompressor() {
+    return compressor;
+  }
+
+  protected boolean isChunked() {
+    return isChunked;
+  }
+
+  protected ReadOnlySchemaRepository getSchemaRepo() {
+    return schemaRepository;
   }
 
   protected HostLevelIngestionStats getHostLevelIngestionStats() {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/storage/chunking/AbstractAvroChunkingAdapter.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/storage/chunking/AbstractAvroChunkingAdapter.java
@@ -269,40 +269,6 @@ public abstract class AbstractAvroChunkingAdapter<T> implements ChunkingAdapter<
         compressor);
   }
 
-  public T getReplicationMetadata(
-      AbstractStorageEngine storageEngine,
-      String storeName,
-      int subPartition,
-      byte[] key,
-      boolean isChunked,
-      boolean fastAvroEnabled,
-      CompressionStrategy compressionStrategy,
-      VeniceCompressor compressor,
-      ReadOnlySchemaRepository schemaRepo) {
-    ByteBuffer keyBuffer;
-    if (isChunked) {
-      keyBuffer = ByteBuffer.wrap(ChunkingUtils.KEY_WITH_CHUNKING_SUFFIX_SERIALIZER.serializeNonChunkedKey(key));
-    } else {
-      keyBuffer = ByteBuffer.wrap(key);
-    }
-    return ChunkingUtils.getFromStorage(
-        this,
-        storageEngine,
-        -1,
-        subPartition,
-        keyBuffer,
-        null,
-        null,
-        null,
-        compressionStrategy,
-        fastAvroEnabled,
-        schemaRepo,
-        storeName,
-        compressor,
-        false,
-        true);
-  }
-
   public void getByPartialKey(
       String storeName,
       AbstractStorageEngine store,

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/storage/chunking/AbstractAvroChunkingAdapter.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/storage/chunking/AbstractAvroChunkingAdapter.java
@@ -143,8 +143,7 @@ public abstract class AbstractAvroChunkingAdapter<T> implements ChunkingAdapter<
       boolean fastAvroEnabled,
       ReadOnlySchemaRepository schemaRepo,
       String storeName,
-      VeniceCompressor compressor,
-      boolean skipCache) {
+      VeniceCompressor compressor) {
     return get(
         store,
         schemaRepo.getSupersetOrLatestValueSchema(storeName).getId(),
@@ -158,8 +157,7 @@ public abstract class AbstractAvroChunkingAdapter<T> implements ChunkingAdapter<
         fastAvroEnabled,
         schemaRepo,
         storeName,
-        compressor,
-        skipCache);
+        compressor);
   }
 
   public T get(
@@ -175,8 +173,7 @@ public abstract class AbstractAvroChunkingAdapter<T> implements ChunkingAdapter<
       boolean fastAvroEnabled,
       ReadOnlySchemaRepository schemaRepo,
       String storeName,
-      VeniceCompressor compressor,
-      boolean skipCache) {
+      VeniceCompressor compressor) {
     if (isChunked) {
       key = ByteBuffer.wrap(ChunkingUtils.KEY_WITH_CHUNKING_SUFFIX_SERIALIZER.serializeNonChunkedKey(key));
     }
@@ -194,7 +191,6 @@ public abstract class AbstractAvroChunkingAdapter<T> implements ChunkingAdapter<
         schemaRepo,
         storeName,
         compressor,
-        skipCache,
         false);
   }
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/storage/chunking/AbstractAvroChunkingAdapter.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/storage/chunking/AbstractAvroChunkingAdapter.java
@@ -194,7 +194,8 @@ public abstract class AbstractAvroChunkingAdapter<T> implements ChunkingAdapter<
         schemaRepo,
         storeName,
         compressor,
-        skipCache);
+        skipCache,
+        false);
   }
 
   public T get(
@@ -266,6 +267,40 @@ public abstract class AbstractAvroChunkingAdapter<T> implements ChunkingAdapter<
         schemaRepo,
         response,
         compressor);
+  }
+
+  public T getReplicationMetadata(
+      AbstractStorageEngine storageEngine,
+      String storeName,
+      int subPartition,
+      byte[] key,
+      boolean isChunked,
+      boolean fastAvroEnabled,
+      CompressionStrategy compressionStrategy,
+      VeniceCompressor compressor,
+      ReadOnlySchemaRepository schemaRepo) {
+    ByteBuffer keyBuffer;
+    if (isChunked) {
+      keyBuffer = ByteBuffer.wrap(ChunkingUtils.KEY_WITH_CHUNKING_SUFFIX_SERIALIZER.serializeNonChunkedKey(key));
+    } else {
+      keyBuffer = ByteBuffer.wrap(key);
+    }
+    return ChunkingUtils.getFromStorage(
+        this,
+        storageEngine,
+        -1,
+        subPartition,
+        keyBuffer,
+        null,
+        null,
+        null,
+        compressionStrategy,
+        fastAvroEnabled,
+        schemaRepo,
+        storeName,
+        compressor,
+        false,
+        true);
   }
 
   public void getByPartialKey(

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/storage/chunking/ChunkingUtils.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/storage/chunking/ChunkingUtils.java
@@ -116,40 +116,6 @@ public class ChunkingUtils {
         true);
   }
 
-  /**
-   * TODO: ADD API DOC + CHECK EACH ARG
-   * @param adapter
-   * @param store
-   * @param partition
-   * @param keyBuffer
-   * @param response
-   * @return
-   * @param <VALUE>
-   * @param <ASSEMBLED_VALUE_CONTAINER>
-   */
-  static <VALUE, ASSEMBLED_VALUE_CONTAINER> VALUE getReplicationMetadataFromStorage(
-      ChunkingAdapter<ASSEMBLED_VALUE_CONTAINER, VALUE> adapter,
-      AbstractStorageEngine store,
-      int partition,
-      ByteBuffer keyBuffer) {
-    return getFromStorage(
-        adapter,
-        store,
-        -1,
-        partition,
-        keyBuffer,
-        null,
-        null,
-        null,
-        CompressionStrategy.NO_OP,
-        false,
-        null,
-        null,
-        null,
-        false,
-        true);
-  }
-
   static <VALUE, CHUNKS_CONTAINER> VALUE getFromStorage(
       ChunkingAdapter<CHUNKS_CONTAINER, VALUE> adapter,
       AbstractStorageEngine store,

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/storage/chunking/ChunkingUtils.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/storage/chunking/ChunkingUtils.java
@@ -88,7 +88,6 @@ public class ChunkingUtils {
         null,
         null,
         null,
-        false,
         false);
   }
 
@@ -112,7 +111,6 @@ public class ChunkingUtils {
         null,
         null,
         null,
-        false,
         true);
   }
 
@@ -131,7 +129,7 @@ public class ChunkingUtils {
       String storeName,
       VeniceCompressor compressor) {
     long databaseLookupStartTimeInNS = (response != null) ? System.nanoTime() : 0;
-    reusedRawValue = store.get(partition, keyBuffer, reusedRawValue, false);
+    reusedRawValue = store.get(partition, keyBuffer, reusedRawValue);
     if (reusedRawValue == null) {
       return null;
     }
@@ -151,7 +149,6 @@ public class ChunkingUtils {
         schemaRepo,
         storeName,
         compressor,
-        false,
         false);
   }
 
@@ -251,12 +248,10 @@ public class ChunkingUtils {
       ReadOnlySchemaRepository schemaRepo,
       String storeName,
       VeniceCompressor compressor,
-      boolean skipCache,
       boolean isRmdValue) {
     long databaseLookupStartTimeInNS = (response != null) ? System.nanoTime() : 0;
-    byte[] value = isRmdValue
-        ? store.getReplicationMetadata(partition, keyBuffer.array())
-        : store.get(partition, keyBuffer, skipCache);
+    byte[] value =
+        isRmdValue ? store.getReplicationMetadata(partition, keyBuffer.array()) : store.get(partition, keyBuffer);
 
     return getFromStorage(
         value,
@@ -274,7 +269,6 @@ public class ChunkingUtils {
         schemaRepo,
         storeName,
         compressor,
-        skipCache,
         isRmdValue);
   }
 
@@ -307,7 +301,6 @@ public class ChunkingUtils {
       ReadOnlySchemaRepository schemaRepo,
       String storeName,
       VeniceCompressor compressor,
-      boolean skipCache,
       boolean isRmdValue) {
 
     if (value == null) {
@@ -352,7 +345,7 @@ public class ChunkingUtils {
       // premature optimization, we are not addressing it right now.
       byte[] chunkKey = chunkedValueManifest.keysWithChunkIdSuffix.get(chunkIndex).array();
       byte[] valueChunk =
-          isRmdValue ? store.getReplicationMetadata(partition, chunkKey) : store.get(partition, chunkKey, skipCache);
+          isRmdValue ? store.getReplicationMetadata(partition, chunkKey) : store.get(partition, chunkKey);
 
       if (valueChunk == null) {
         throw new VeniceException("Chunk not found in " + getExceptionMessageDetails(store, partition, chunkIndex));

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/storage/chunking/ChunkingUtils.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/storage/chunking/ChunkingUtils.java
@@ -288,13 +288,6 @@ public class ChunkingUtils {
       boolean skipCache,
       boolean isRmdValue) {
     long databaseLookupStartTimeInNS = (response != null) ? System.nanoTime() : 0;
-    /*
-    LogManager.getLogger().info("DEBUGGING is RMD? " + isRmdValue);
-    if (isRmdValue) {
-      LogManager.getLogger().info("DEBUGGING RMD STACK: " + Arrays.toString(Thread.currentThread().getStackTrace()));
-    }
-    
-     */
     byte[] value = isRmdValue
         ? store.getReplicationMetadata(partition, keyBuffer.array())
         : store.get(partition, keyBuffer, skipCache);
@@ -362,11 +355,6 @@ public class ChunkingUtils {
       if (response != null) {
         response.addDatabaseLookupLatency(LatencyUtils.getLatencyInMS(databaseLookupStartTimeInNS));
       }
-      /*
-      LogManager.getLogger()
-          .info("DEBUGGING: NOT CHUNKED BYTES isRmdValue: " + isRmdValue + " " + value.length + " " + writerSchemaId);
-      
-       */
       return adapter.constructValue(
           writerSchemaId,
           readerSchemaId,
@@ -387,12 +375,6 @@ public class ChunkingUtils {
     // End of initial sanity checks. We have a chunked value, so we need to fetch all chunks
 
     ChunkedValueManifest chunkedValueManifest = CHUNKED_VALUE_MANIFEST_SERIALIZER.deserialize(value, writerSchemaId);
-    /*
-    LogManager.getLogger()
-        .info(
-            "DEBUGGING: CHUNK MANIFEST RMD CHUNK? " + isRmdValue + " " + chunkedValueManifest.size + " "
-                + writerSchemaId + " " + chunkedValueManifest.keysWithChunkIdSuffix.size());
-    */
     CHUNKS_CONTAINER assembledValueContainer = adapter.constructChunksContainer(chunkedValueManifest);
     int actualSize = 0;
 
@@ -416,12 +398,6 @@ public class ChunkingUtils {
       }
 
       actualSize += valueChunk.length - ValueRecord.SCHEMA_HEADER_LENGTH;
-      /*
-      LogManager.getLogger()
-          .info(
-              "DEBUGGING GETTING CHUNK: " + chunkIndex + " " + actualSize + " " + chunkKey.length + " "
-                  + valueChunk.length);
-       */
       adapter.addChunkIntoContainer(assembledValueContainer, chunkIndex, valueChunk);
     }
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/storage/chunking/SingleGetChunkingAdapter.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/storage/chunking/SingleGetChunkingAdapter.java
@@ -7,6 +7,8 @@ import com.linkedin.venice.storage.protocol.ChunkedValueManifest;
 import io.netty.buffer.CompositeByteBuf;
 import io.netty.buffer.Unpooled;
 import java.nio.ByteBuffer;
+import java.util.Arrays;
+import org.apache.logging.log4j.LogManager;
 
 
 /**
@@ -52,5 +54,25 @@ public class SingleGetChunkingAdapter implements ChunkingAdapter<CompositeByteBu
       keyBuffer = ByteBuffer.wrap(key);
     }
     return ChunkingUtils.getFromStorage(SINGLE_GET_CHUNKING_ADAPTER, store, partition, keyBuffer, response);
+  }
+
+  public static ValueRecord getReplicationMetadata(
+      AbstractStorageEngine store,
+      int partition,
+      byte[] key,
+      boolean isChunked,
+      ReadResponse response) {
+    ByteBuffer keyBuffer = null;
+    if (isChunked) {
+      keyBuffer = ByteBuffer.wrap(ChunkingUtils.KEY_WITH_CHUNKING_SUFFIX_SERIALIZER.serializeNonChunkedKey(key));
+      LogManager.getLogger()
+          .info(
+              "GETTING CHUNKED KEY: " + keyBuffer + " "
+                  + Arrays.toString(ChunkingUtils.KEY_WITH_CHUNKING_SUFFIX_SERIALIZER.serializeNonChunkedKey(key)));
+    } else {
+      keyBuffer = ByteBuffer.wrap(key);
+    }
+    return ChunkingUtils
+        .getReplicationMetadataFromStorage(SINGLE_GET_CHUNKING_ADAPTER, store, partition, keyBuffer, response);
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/storage/chunking/SingleGetChunkingAdapter.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/storage/chunking/SingleGetChunkingAdapter.java
@@ -7,8 +7,6 @@ import com.linkedin.venice.storage.protocol.ChunkedValueManifest;
 import io.netty.buffer.CompositeByteBuf;
 import io.netty.buffer.Unpooled;
 import java.nio.ByteBuffer;
-import java.util.Arrays;
-import org.apache.logging.log4j.LogManager;
 
 
 /**
@@ -65,10 +63,6 @@ public class SingleGetChunkingAdapter implements ChunkingAdapter<CompositeByteBu
     ByteBuffer keyBuffer = null;
     if (isChunked) {
       keyBuffer = ByteBuffer.wrap(ChunkingUtils.KEY_WITH_CHUNKING_SUFFIX_SERIALIZER.serializeNonChunkedKey(key));
-      LogManager.getLogger()
-          .info(
-              "GETTING CHUNKED KEY: " + keyBuffer + " "
-                  + Arrays.toString(ChunkingUtils.KEY_WITH_CHUNKING_SUFFIX_SERIALIZER.serializeNonChunkedKey(key)));
     } else {
       keyBuffer = ByteBuffer.wrap(key);
     }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/AbstractStorageEngine.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/AbstractStorageEngine.java
@@ -415,20 +415,19 @@ public abstract class AbstractStorageEngine<Partition extends AbstractStoragePar
     partition.put(key, value);
   }
 
-  public byte[] get(int partitionId, byte[] key, boolean skipCache) throws VeniceException {
+  public byte[] get(int partitionId, byte[] key) throws VeniceException {
     AbstractStoragePartition partition = getPartitionOrThrow(partitionId);
-    return partition.get(key, skipCache);
+    return partition.get(key);
   }
 
-  public ByteBuffer get(int partitionId, byte[] key, ByteBuffer valueToBePopulated, boolean skipCache)
-      throws VeniceException {
+  public ByteBuffer get(int partitionId, byte[] key, ByteBuffer valueToBePopulated) throws VeniceException {
     AbstractStoragePartition partition = getPartitionOrThrow(partitionId);
-    return partition.get(key, valueToBePopulated, skipCache);
+    return partition.get(key, valueToBePopulated);
   }
 
-  public byte[] get(int partitionId, ByteBuffer keyBuffer, boolean skipCache) throws VeniceException {
+  public byte[] get(int partitionId, ByteBuffer keyBuffer) throws VeniceException {
     AbstractStoragePartition partition = getPartitionOrThrow(partitionId);
-    return partition.get(keyBuffer, skipCache);
+    return partition.get(keyBuffer);
   }
 
   public void getByKeyPrefix(int partitionId, byte[] partialKey, BytesStreamingCallback bytesStreamingCallback) {
@@ -481,7 +480,7 @@ public abstract class AbstractStorageEngine<Partition extends AbstractStoragePar
     if (partitionId < 0) {
       throw new IllegalArgumentException("Invalid partition id argument in getPartitionOffset");
     }
-    byte[] value = metadataPartition.get(getPartitionMetadataKey(partitionId), false);
+    byte[] value = metadataPartition.get(getPartitionMetadataKey(partitionId));
     if (value == null) {
       return Optional.empty();
     }
@@ -536,7 +535,7 @@ public abstract class AbstractStorageEngine<Partition extends AbstractStoragePar
       if (metadataPartition == null) {
         return null;
       }
-      byte[] value = metadataPartition.get(VERSION_METADATA_KEY, false);
+      byte[] value = metadataPartition.get(VERSION_METADATA_KEY);
       if (value == null) {
         return null;
       }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/AbstractStoragePartition.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/AbstractStoragePartition.java
@@ -44,14 +44,13 @@ public abstract class AbstractStoragePartition {
   /**
    * Get a value from the partition database
    * @param key key to be retrieved
-   * @param skipCache
    * @return null if the key does not exist, byte[] value if it exists.
    */
-  public abstract byte[] get(byte[] key, boolean skipCache);
+  public abstract byte[] get(byte[] key);
 
-  public ByteBuffer get(byte[] key, ByteBuffer valueToBePopulated, boolean skipCache) {
+  public ByteBuffer get(byte[] key, ByteBuffer valueToBePopulated) {
     // Naive default impl is not optimized... only storage engines that support the optimization implement it.
-    return ByteBuffer.wrap(get(key, skipCache));
+    return ByteBuffer.wrap(get(key));
   }
 
   /**
@@ -59,12 +58,11 @@ public abstract class AbstractStoragePartition {
    * @param <K> the type for Key
    * @param <V> the type for the return value
    * @param key key to be retrieved
-   * @param skipCache
    * @return null if the key does not exist, V value if it exists
    */
-  public abstract <K, V> V get(K key, boolean skipCache);
+  public abstract <K, V> V get(K key);
 
-  public abstract byte[] get(ByteBuffer key, boolean skipCache);
+  public abstract byte[] get(ByteBuffer key);
 
   /**
    * Populate provided callback with key-value pairs from the partition database where the keys have provided prefix.

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/blackhole/BlackHoleStorageEnginePartition.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/blackhole/BlackHoleStorageEnginePartition.java
@@ -29,19 +29,19 @@ public class BlackHoleStorageEnginePartition extends AbstractStoragePartition {
   }
 
   @Override
-  public byte[] get(byte[] key, boolean skipCache) {
+  public byte[] get(byte[] key) {
     // I think this is what you're looking for...
     return null;
   }
 
   @Override
-  public <K, V> V get(K key, boolean skipCache) {
+  public <K, V> V get(K key) {
     // this is fun
     return null;
   }
 
   @Override
-  public byte[] get(ByteBuffer key, boolean skipCache) {
+  public byte[] get(ByteBuffer key) {
     return null;
   }
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/cache/VeniceStoreCacheStoragePartition.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/cache/VeniceStoreCacheStoragePartition.java
@@ -75,17 +75,17 @@ public class VeniceStoreCacheStoragePartition extends AbstractStoragePartition {
   }
 
   @Override
-  public byte[] get(byte[] key, boolean skipCache) {
-    return this.get(ByteBuffer.wrap(key), skipCache);
+  public byte[] get(byte[] key) {
+    return this.get(ByteBuffer.wrap(key));
   }
 
   @Override
-  public <K, V> V get(K key, boolean skipCache) {
+  public <K, V> V get(K key) {
     throw new UnsupportedOperationException("Reading via a key synchronously is unsupported by this implementation!!");
   }
 
   @Override
-  public byte[] get(ByteBuffer key, boolean skipCache) {
+  public byte[] get(ByteBuffer key) {
     throw new UnsupportedOperationException(
         "Reading via a serialized key for a serialized record unsupported by this implementation!!");
   }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/memory/InMemoryStoragePartition.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/memory/InMemoryStoragePartition.java
@@ -54,7 +54,7 @@ public class InMemoryStoragePartition extends AbstractStoragePartition {
     throw new UnsupportedOperationException("Method not implemented!!");
   }
 
-  public byte[] get(byte[] key, boolean skipCache) throws PersistenceFailureException {
+  public byte[] get(byte[] key) throws PersistenceFailureException {
     ByteArray k = new ByteArray(key);
     if (partitionDb.containsKey(k)) {
       return partitionDb.get(k).get();
@@ -63,12 +63,12 @@ public class InMemoryStoragePartition extends AbstractStoragePartition {
   }
 
   @Override
-  public <K, V> V get(K key, boolean skipCache) {
+  public <K, V> V get(K key) {
     throw new UnsupportedOperationException("Method not implemented!!");
   }
 
   @Override
-  public byte[] get(ByteBuffer key, boolean skipCache) {
+  public byte[] get(ByteBuffer key) {
     throw new UnsupportedOperationException("Method not implemented!!");
   }
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/record/ValueRecord.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/record/ValueRecord.java
@@ -5,6 +5,7 @@ import com.linkedin.venice.utils.ByteUtils;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import java.nio.ByteBuffer;
+import org.apache.logging.log4j.LogManager;
 
 
 /**
@@ -39,6 +40,7 @@ public class ValueRecord {
     this.schemaId = schemaId;
     this.data = data;
     this.dataSize = data.readableBytes();
+    LogManager.getLogger().info("DEBUGGING VALUE RECORD: " + schemaId + "" + this.dataSize);
   }
 
   private ValueRecord(byte[] combinedData) {
@@ -112,5 +114,13 @@ public class ValueRecord {
     System.arraycopy(dataArr, 0, serializedArr, SCHEMA_HEADER_LENGTH, dataArr.length);
 
     return serializedArr;
+  }
+
+  public byte[] getDataBytesPrependedWithWriterSchemaId() {
+    byte[] result = new byte[SCHEMA_HEADER_LENGTH + dataSize];
+    ByteUtils.writeInt(result, schemaId, 0);
+    LogManager.getLogger().info("DEBUGGING RUN: " + data.readerIndex() + " " + data.readableBytes());
+    data.getBytes(data.readerIndex(), result, SCHEMA_HEADER_LENGTH, data.readableBytes());
+    return result;
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/record/ValueRecord.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/record/ValueRecord.java
@@ -5,7 +5,6 @@ import com.linkedin.venice.utils.ByteUtils;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import java.nio.ByteBuffer;
-import org.apache.logging.log4j.LogManager;
 
 
 /**
@@ -40,7 +39,6 @@ public class ValueRecord {
     this.schemaId = schemaId;
     this.data = data;
     this.dataSize = data.readableBytes();
-    LogManager.getLogger().info("DEBUGGING VALUE RECORD: " + schemaId + "" + this.dataSize);
   }
 
   private ValueRecord(byte[] combinedData) {
@@ -119,7 +117,6 @@ public class ValueRecord {
   public byte[] getDataBytesPrependedWithWriterSchemaId() {
     byte[] result = new byte[SCHEMA_HEADER_LENGTH + dataSize];
     ByteUtils.writeInt(result, schemaId, 0);
-    LogManager.getLogger().info("DEBUGGING RUN: " + data.readerIndex() + " " + data.readableBytes());
     data.getBytes(data.readerIndex(), result, SCHEMA_HEADER_LENGTH, data.readableBytes());
     return result;
   }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/record/ValueRecord.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/record/ValueRecord.java
@@ -105,19 +105,9 @@ public class ValueRecord {
     if (serializedArr != null) {
       return serializedArr;
     }
-    byte[] dataArr = data.array();
-
-    serializedArr = new byte[SCHEMA_HEADER_LENGTH + dataArr.length];
+    serializedArr = new byte[SCHEMA_HEADER_LENGTH + dataSize];
     ByteUtils.writeInt(serializedArr, schemaId, 0);
-    System.arraycopy(dataArr, 0, serializedArr, SCHEMA_HEADER_LENGTH, dataArr.length);
-
+    data.getBytes(data.readerIndex(), serializedArr, SCHEMA_HEADER_LENGTH, data.readableBytes());
     return serializedArr;
-  }
-
-  public byte[] getDataBytesPrependedWithWriterSchemaId() {
-    byte[] result = new byte[SCHEMA_HEADER_LENGTH + dataSize];
-    ByteUtils.writeInt(result, schemaId, 0);
-    data.getBytes(data.readerIndex(), result, SCHEMA_HEADER_LENGTH, data.readableBytes());
-    return result;
   }
 }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTaskTest.java
@@ -262,9 +262,9 @@ public class ActiveActiveStoreIngestionTaskTest {
     when(ingestionTask.getHostLevelIngestionStats()).thenReturn(mock(HostLevelIngestionStats.class));
 
     when(storageEngine.getReplicationMetadata(subPartition, topLevelKey1)).thenReturn(expectedNonChunkedValue);
-    ByteBuffer result = ingestionTask.getRmdWithValueSchemaByteBufferFromStorage(subPartition, key1);
+    byte[] result = ingestionTask.getRmdWithValueSchemaByteBufferFromStorage(subPartition, key1);
     Assert.assertNotNull(result);
-    Assert.assertEquals(result.array(), expectedNonChunkedValue);
+    Assert.assertEquals(result, expectedNonChunkedValue);
 
     /**
      * The 2nd key contains 1 chunks with 8 bytes.
@@ -296,9 +296,9 @@ public class ActiveActiveStoreIngestionTaskTest {
 
     when(storageEngine.getReplicationMetadata(subPartition, topLevelKey2)).thenReturn(chunkedManifestWithSchemaBytes);
     when(storageEngine.getReplicationMetadata(subPartition, chunkedKey1InKey2)).thenReturn(chunkedValue1);
-    ByteBuffer result2 = ingestionTask.getRmdWithValueSchemaByteBufferFromStorage(subPartition, key2);
+    byte[] result2 = ingestionTask.getRmdWithValueSchemaByteBufferFromStorage(subPartition, key2);
     Assert.assertNotNull(result2);
-    Assert.assertEquals(result2.array(), expectedChunkedValue1);
+    Assert.assertEquals(result2, expectedChunkedValue1);
 
     /**
      * The 3rd key contains 2 chunks, each contains 8 bytes and 12 bytes respectively.
@@ -337,8 +337,8 @@ public class ActiveActiveStoreIngestionTaskTest {
     when(storageEngine.getReplicationMetadata(subPartition, topLevelKey3)).thenReturn(chunkedManifestWithSchemaBytes);
     when(storageEngine.getReplicationMetadata(subPartition, chunkedKey1InKey3)).thenReturn(chunkedValue1);
     when(storageEngine.getReplicationMetadata(subPartition, chunkedKey2InKey3)).thenReturn(chunkedValue2);
-    ByteBuffer result3 = ingestionTask.getRmdWithValueSchemaByteBufferFromStorage(subPartition, key3);
+    byte[] result3 = ingestionTask.getRmdWithValueSchemaByteBufferFromStorage(subPartition, key3);
     Assert.assertNotNull(result3);
-    Assert.assertEquals(result3.array(), expectedChunkedValue2);
+    Assert.assertEquals(result3, expectedChunkedValue2);
   }
 }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTaskTest.java
@@ -259,6 +259,7 @@ public class ActiveActiveStoreIngestionTaskTest {
     when(ingestionTask.getServerConfig()).thenReturn(serverConfig);
     when(ingestionTask.getRmdWithValueSchemaByteBufferFromStorage(anyInt(), any())).thenCallRealMethod();
     when(ingestionTask.isChunked()).thenReturn(true);
+    when(ingestionTask.getHostLevelIngestionStats()).thenReturn(mock(HostLevelIngestionStats.class));
 
     when(storageEngine.getReplicationMetadata(subPartition, topLevelKey1)).thenReturn(expectedNonChunkedValue);
     ByteBuffer result = ingestionTask.getRmdWithValueSchemaByteBufferFromStorage(subPartition, key1);

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTaskTest.java
@@ -1,5 +1,6 @@
 package com.linkedin.davinci.kafka.consumer;
 
+import static com.linkedin.venice.utils.ByteUtils.SIZE_OF_INT;
 import static com.linkedin.venice.writer.VeniceWriter.ENABLE_CHUNKING;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
@@ -13,15 +14,30 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.linkedin.davinci.config.VeniceServerConfig;
 import com.linkedin.davinci.stats.AggVersionedDIVStats;
 import com.linkedin.davinci.stats.AggVersionedIngestionStats;
 import com.linkedin.davinci.stats.HostLevelIngestionStats;
 import com.linkedin.davinci.storage.chunking.ChunkingUtils;
+import com.linkedin.davinci.store.AbstractStorageEngine;
+import com.linkedin.venice.compression.CompressionStrategy;
+import com.linkedin.venice.compression.NoopCompressor;
+import com.linkedin.venice.compression.VeniceCompressor;
+import com.linkedin.venice.kafka.protocol.GUID;
 import com.linkedin.venice.kafka.protocol.KafkaMessageEnvelope;
+import com.linkedin.venice.kafka.protocol.ProducerMetadata;
 import com.linkedin.venice.kafka.protocol.Put;
 import com.linkedin.venice.kafka.protocol.enums.MessageType;
 import com.linkedin.venice.message.KafkaKey;
+import com.linkedin.venice.meta.ReadOnlySchemaRepository;
 import com.linkedin.venice.partitioner.DefaultVenicePartitioner;
+import com.linkedin.venice.schema.SchemaEntry;
+import com.linkedin.venice.serialization.KeyWithChunkingSuffixSerializer;
+import com.linkedin.venice.serialization.avro.AvroProtocolDefinition;
+import com.linkedin.venice.serialization.avro.ChunkedValueManifestSerializer;
+import com.linkedin.venice.storage.protocol.ChunkId;
+import com.linkedin.venice.storage.protocol.ChunkedKeySuffix;
+import com.linkedin.venice.storage.protocol.ChunkedValueManifest;
 import com.linkedin.venice.utils.ByteUtils;
 import com.linkedin.venice.utils.SystemTime;
 import com.linkedin.venice.utils.VeniceProperties;
@@ -30,6 +46,7 @@ import com.linkedin.venice.writer.KafkaProducerWrapper;
 import com.linkedin.venice.writer.VeniceWriter;
 import com.linkedin.venice.writer.VeniceWriterOptions;
 import java.nio.ByteBuffer;
+import java.util.ArrayList;
 import java.util.Properties;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
@@ -179,5 +196,148 @@ public class ActiveActiveStoreIngestionTaskTest {
     Assert.assertEquals(
         leaderProducedRecordContextArgumentCaptor.getAllValues().get(2).getKeyBytes(),
         kafkaKeyArgumentCaptor.getAllValues().get(3).getKey());
+  }
+
+  @Test
+  public void testReadingChunkedRmdFromStorage() {
+    String storeName = "testStore";
+    String topicName = "testStore_v1";
+    int subPartition = 1;
+    int valueSchema = 2;
+    KeyWithChunkingSuffixSerializer keyWithChunkingSuffixSerializer = new KeyWithChunkingSuffixSerializer();
+    ChunkedValueManifestSerializer chunkedValueManifestSerializer = new ChunkedValueManifestSerializer(true);
+
+    byte[] key1 = "foo".getBytes();
+    byte[] key2 = "bar".getBytes();
+    byte[] key3 = "ljl".getBytes();
+
+    byte[] topLevelKey1 = keyWithChunkingSuffixSerializer.serializeNonChunkedKey(key1);
+    byte[] expectedNonChunkedValue = new byte[8];
+    ByteUtils.writeInt(expectedNonChunkedValue, valueSchema, 0);
+    ByteUtils.writeInt(expectedNonChunkedValue, 666, 4);
+
+    byte[] expectedChunkedValue1 = new byte[12];
+    ByteUtils.writeInt(expectedChunkedValue1, valueSchema, 0);
+    ByteUtils.writeInt(expectedChunkedValue1, 666, 4);
+    ByteUtils.writeInt(expectedChunkedValue1, 777, 8);
+    byte[] expectedChunkedValue2 = new byte[24];
+    ByteUtils.writeInt(expectedChunkedValue2, valueSchema, 0);
+    ByteUtils.writeInt(expectedChunkedValue2, 666, 4);
+    ByteUtils.writeInt(expectedChunkedValue2, 777, 8);
+    ByteUtils.writeInt(expectedChunkedValue2, 111, 12);
+    ByteUtils.writeInt(expectedChunkedValue2, 222, 16);
+    ByteUtils.writeInt(expectedChunkedValue2, 333, 20);
+    byte[] chunkedValue1 = new byte[12];
+    ByteUtils.writeInt(chunkedValue1, AvroProtocolDefinition.CHUNK.getCurrentProtocolVersion(), 0);
+    ByteUtils.writeInt(chunkedValue1, 666, 4);
+    ByteUtils.writeInt(chunkedValue1, 777, 8);
+
+    byte[] chunkedValue2 = new byte[16];
+    ByteUtils.writeInt(chunkedValue2, AvroProtocolDefinition.CHUNK.getCurrentProtocolVersion(), 0);
+    ByteUtils.writeInt(chunkedValue2, 111, 4);
+    ByteUtils.writeInt(chunkedValue2, 222, 8);
+    ByteUtils.writeInt(chunkedValue2, 333, 12);
+
+    /**
+     * The 1st key does not have any chunk but only has a top level key.
+     */
+    AbstractStorageEngine storageEngine = mock(AbstractStorageEngine.class);
+    ReadOnlySchemaRepository schemaRepository = mock(ReadOnlySchemaRepository.class);
+    String stringSchema = "\"string\"";
+    when(schemaRepository.getSupersetOrLatestValueSchema(storeName))
+        .thenReturn(new SchemaEntry(valueSchema, stringSchema));
+    VeniceServerConfig serverConfig = mock(VeniceServerConfig.class);
+    when(serverConfig.isComputeFastAvroEnabled()).thenReturn(false);
+    ActiveActiveStoreIngestionTask ingestionTask = mock(ActiveActiveStoreIngestionTask.class);
+    when(ingestionTask.getRmdProtocolVersionID()).thenReturn(1);
+    Lazy<VeniceCompressor> compressor = Lazy.of(NoopCompressor::new);
+    when(ingestionTask.getCompressor()).thenReturn(compressor);
+    when(ingestionTask.getCompressionStrategy()).thenReturn(CompressionStrategy.NO_OP);
+    when(ingestionTask.getStoreName()).thenReturn(storeName);
+    when(ingestionTask.getStorageEngine()).thenReturn(storageEngine);
+    when(ingestionTask.getSchemaRepo()).thenReturn(schemaRepository);
+    when(ingestionTask.getServerConfig()).thenReturn(serverConfig);
+    when(ingestionTask.getRmdWithValueSchemaByteBufferFromStorage(anyInt(), any())).thenCallRealMethod();
+    when(ingestionTask.isChunked()).thenReturn(true);
+
+    when(storageEngine.getReplicationMetadata(subPartition, topLevelKey1)).thenReturn(expectedNonChunkedValue);
+    ByteBuffer result = ingestionTask.getRmdWithValueSchemaByteBufferFromStorage(subPartition, key1);
+    Assert.assertNotNull(result);
+    Assert.assertEquals(result.array(), expectedNonChunkedValue);
+
+    /**
+     * The 2nd key contains 1 chunks with 8 bytes.
+     */
+    ChunkedKeySuffix chunkedKeySuffix = new ChunkedKeySuffix();
+    chunkedKeySuffix.isChunk = true;
+    chunkedKeySuffix.chunkId = new ChunkId();
+    ProducerMetadata metadata = new ProducerMetadata(new GUID(), 1, 2, 100L, 200L);
+    chunkedKeySuffix.chunkId.producerGUID = metadata.producerGUID;
+    chunkedKeySuffix.chunkId.segmentNumber = metadata.segmentNumber;
+    chunkedKeySuffix.chunkId.messageSequenceNumber = metadata.messageSequenceNumber;
+    chunkedKeySuffix.chunkId.chunkIndex = 0;
+    ByteBuffer chunkedKeyWithSuffix1 =
+        ByteBuffer.wrap(keyWithChunkingSuffixSerializer.serializeChunkedKey(key2, chunkedKeySuffix));
+    ChunkedValueManifest chunkedValueManifest = new ChunkedValueManifest();
+    chunkedValueManifest.schemaId = valueSchema;
+    chunkedValueManifest.keysWithChunkIdSuffix = new ArrayList<>(1);
+    chunkedValueManifest.size = 8;
+    chunkedValueManifest.keysWithChunkIdSuffix.add(chunkedKeyWithSuffix1);
+    byte[] chunkedManifestBytes = chunkedValueManifestSerializer.serialize(topicName, chunkedValueManifest);
+    byte[] chunkedManifestWithSchemaBytes = new byte[SIZE_OF_INT + chunkedManifestBytes.length];
+    System.arraycopy(chunkedManifestBytes, 0, chunkedManifestWithSchemaBytes, 4, chunkedManifestBytes.length);
+    ByteUtils.writeInt(
+        chunkedManifestWithSchemaBytes,
+        AvroProtocolDefinition.CHUNKED_VALUE_MANIFEST.getCurrentProtocolVersion(),
+        0);
+    byte[] topLevelKey2 = keyWithChunkingSuffixSerializer.serializeNonChunkedKey(key2);
+    byte[] chunkedKey1InKey2 = chunkedKeyWithSuffix1.array();
+
+    when(storageEngine.getReplicationMetadata(subPartition, topLevelKey2)).thenReturn(chunkedManifestWithSchemaBytes);
+    when(storageEngine.getReplicationMetadata(subPartition, chunkedKey1InKey2)).thenReturn(chunkedValue1);
+    ByteBuffer result2 = ingestionTask.getRmdWithValueSchemaByteBufferFromStorage(subPartition, key2);
+    Assert.assertNotNull(result2);
+    Assert.assertEquals(result2.array(), expectedChunkedValue1);
+
+    /**
+     * The 3rd key contains 2 chunks, each contains 8 bytes and 12 bytes respectively.
+     */
+    chunkedKeySuffix = new ChunkedKeySuffix();
+    chunkedKeySuffix.isChunk = true;
+    chunkedKeySuffix.chunkId = new ChunkId();
+    chunkedKeySuffix.chunkId.producerGUID = metadata.producerGUID;
+    chunkedKeySuffix.chunkId.segmentNumber = metadata.segmentNumber;
+    chunkedKeySuffix.chunkId.messageSequenceNumber = metadata.messageSequenceNumber;
+    chunkedKeySuffix.chunkId.chunkIndex = 0;
+    chunkedKeyWithSuffix1 =
+        ByteBuffer.wrap(keyWithChunkingSuffixSerializer.serializeChunkedKey(key3, chunkedKeySuffix));
+
+    chunkedKeySuffix.chunkId.chunkIndex = 1;
+    ByteBuffer chunkedKeyWithSuffix2 =
+        ByteBuffer.wrap(keyWithChunkingSuffixSerializer.serializeChunkedKey(key3, chunkedKeySuffix));
+
+    chunkedValueManifest = new ChunkedValueManifest();
+    chunkedValueManifest.schemaId = valueSchema;
+    chunkedValueManifest.keysWithChunkIdSuffix = new ArrayList<>(2);
+    chunkedValueManifest.size = 8 + 12;
+    chunkedValueManifest.keysWithChunkIdSuffix.add(chunkedKeyWithSuffix1);
+    chunkedValueManifest.keysWithChunkIdSuffix.add(chunkedKeyWithSuffix2);
+    chunkedManifestBytes = chunkedValueManifestSerializer.serialize(topicName, chunkedValueManifest);
+    chunkedManifestWithSchemaBytes = new byte[SIZE_OF_INT + chunkedManifestBytes.length];
+    System.arraycopy(chunkedManifestBytes, 0, chunkedManifestWithSchemaBytes, SIZE_OF_INT, chunkedManifestBytes.length);
+    ByteUtils.writeInt(
+        chunkedManifestWithSchemaBytes,
+        AvroProtocolDefinition.CHUNKED_VALUE_MANIFEST.getCurrentProtocolVersion(),
+        0);
+    byte[] topLevelKey3 = keyWithChunkingSuffixSerializer.serializeNonChunkedKey(key3);
+    byte[] chunkedKey1InKey3 = chunkedKeyWithSuffix1.array();
+    byte[] chunkedKey2InKey3 = chunkedKeyWithSuffix2.array();
+
+    when(storageEngine.getReplicationMetadata(subPartition, topLevelKey3)).thenReturn(chunkedManifestWithSchemaBytes);
+    when(storageEngine.getReplicationMetadata(subPartition, chunkedKey1InKey3)).thenReturn(chunkedValue1);
+    when(storageEngine.getReplicationMetadata(subPartition, chunkedKey2InKey3)).thenReturn(chunkedValue2);
+    ByteBuffer result3 = ingestionTask.getRmdWithValueSchemaByteBufferFromStorage(subPartition, key3);
+    Assert.assertNotNull(result3);
+    Assert.assertEquals(result3.array(), expectedChunkedValue2);
   }
 }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
@@ -1037,8 +1037,7 @@ public abstract class StoreIngestionTaskTest {
     AbstractStoragePartition metadataPartition = mock(AbstractStoragePartition.class);
     InternalAvroSpecificSerializer<StoreVersionState> storeVersionStateSerializer =
         AvroProtocolDefinition.STORE_VERSION_STATE.getSerializer();
-    doReturn(storeVersionStateSerializer.serialize(null, svs)).when(metadataPartition)
-        .get(any(byte[].class), anyBoolean());
+    doReturn(storeVersionStateSerializer.serialize(null, svs)).when(metadataPartition).get(any(byte[].class));
     mockAbstractStorageEngine = mock(AbstractStorageEngine.class);
     doReturn(metadataPartition).when(mockAbstractStorageEngine).createStoragePartition(any());
     doReturn(svs).when(mockAbstractStorageEngine).getStoreVersionState();

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
@@ -791,6 +791,7 @@ public abstract class StoreIngestionTaskTest {
 
     mockWriterFactory = mock(VeniceWriterFactory.class);
     doReturn(null).when(mockWriterFactory).createBasicVeniceWriter(any());
+    doReturn(null).when(mockWriterFactory).createVeniceWriter(any());
     StorageMetadataService offsetManager;
     LOGGER.info("mockStorageMetadataService: {}", mockStorageMetadataService.getClass().getName());
     final InternalAvroSpecificSerializer<PartitionState> partitionStateSerializer =
@@ -1136,6 +1137,7 @@ public abstract class StoreIngestionTaskTest {
       vtWriter.broadcastEndOfPush(new HashMap<>());
       doReturn(vtWriter).when(mockWriterFactory)
           .createBasicVeniceWriter(anyString(), anyBoolean(), any(VenicePartitioner.class), anyInt());
+      doReturn(vtWriter).when(mockWriterFactory).createVeniceWriter(any());
       verify(mockLogNotifier, never()).completed(anyString(), anyInt(), anyLong());
       vtWriter.broadcastTopicSwitch(
           Collections.singletonList(inMemoryLocalKafkaBroker.getKafkaBootstrapServer()),

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/storage/chunking/ChunkingTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/storage/chunking/ChunkingTest.java
@@ -1,6 +1,5 @@
 package com.linkedin.davinci.storage.chunking;
 
-import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
@@ -205,9 +204,9 @@ public class ChunkingTest {
     System.arraycopy(serializedCVM, 0, serializedCVMwithHeader, ValueRecord.SCHEMA_HEADER_LENGTH, serializedCVM.length);
 
     doReturn(serializedCVMwithHeader).when(storageEngine)
-        .get(eq(partition), eq(ByteBuffer.wrap(serializeNonChunkedKey)), anyBoolean());
-    doReturn(chunk1Bytes).when(storageEngine).get(eq(partition), eq(firstKey), anyBoolean());
-    doReturn(chunk2Bytes).when(storageEngine).get(eq(partition), eq(secondKey), anyBoolean());
+        .get(eq(partition), eq(ByteBuffer.wrap(serializeNonChunkedKey)));
+    doReturn(chunk1Bytes).when(storageEngine).get(eq(partition), eq(firstKey));
+    doReturn(chunk2Bytes).when(storageEngine).get(eq(partition), eq(secondKey));
 
     try (StorageEngineBackedCompressorFactory compressorFactory =
         new StorageEngineBackedCompressorFactory(mock(StorageMetadataService.class))) {
@@ -226,8 +225,7 @@ public class ChunkingTest {
               true,
               schemaRepository,
               storeName,
-              compressor,
-              false));
+              compressor));
     }
   }
 

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/store/AbstractStorageEngineTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/store/AbstractStorageEngineTest.java
@@ -170,7 +170,7 @@ public abstract class AbstractStorageEngineTest extends AbstractStoreTest {
 
     byte[] found = null;
     try {
-      found = testStoreEngine.get(partitionId, key, false);
+      found = testStoreEngine.get(partitionId, key);
     } catch (PersistenceFailureException e) {
       // This is expected
     }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/store/AbstractStoreTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/store/AbstractStoreTest.java
@@ -35,7 +35,7 @@ public abstract class AbstractStoreTest {
 
   protected byte[] doGet(int partitionId, byte[] key) throws VeniceException {
     byte[] result;
-    result = testStore.get(partitionId, key, false);
+    result = testStore.get(partitionId, key);
     return result;
   }
 

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/store/rocksdb/ReplicationMetadataRocksDBStoragePartitionTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/store/rocksdb/ReplicationMetadataRocksDBStoragePartitionTest.java
@@ -199,7 +199,7 @@ public class ReplicationMetadataRocksDBStoragePartitionTest extends AbstractStor
 
     for (Map.Entry<String, Pair<String, String>> entry: inputRecords.entrySet()) {
       byte[] key = entry.getKey().getBytes();
-      byte[] value = storagePartition.get(key, false);
+      byte[] value = storagePartition.get(key);
       Assert.assertEquals(value, entry.getValue().getFirst().getBytes());
       byte[] metadata = storagePartition.getReplicationMetadata(key);
       ByteBuffer replicationMetadataWithValueSchema = ByteBuffer.wrap(metadata);
@@ -218,7 +218,7 @@ public class ReplicationMetadataRocksDBStoragePartitionTest extends AbstractStor
 
       storagePartition.deleteWithReplicationMetadata(key, updatedReplicationMetadataWitValueSchemaIdBytes);
 
-      byte[] value = storagePartition.get(key, false);
+      byte[] value = storagePartition.get(key);
       Assert.assertNull(value);
 
       byte[] metadata = storagePartition.getReplicationMetadata(key);
@@ -245,7 +245,7 @@ public class ReplicationMetadataRocksDBStoragePartitionTest extends AbstractStor
 
     for (Map.Entry<String, Pair<String, String>> entry: inputRecordsBatch.entrySet()) {
       byte[] key = entry.getKey().getBytes();
-      byte[] value = storagePartition.get(key, false);
+      byte[] value = storagePartition.get(key);
       Assert.assertEquals(value, entry.getValue().getFirst().getBytes());
       Assert.assertNull(storagePartition.getReplicationMetadata(key));
     }
@@ -259,7 +259,7 @@ public class ReplicationMetadataRocksDBStoragePartitionTest extends AbstractStor
 
       storagePartition.deleteWithReplicationMetadata(key, updatedReplicationMetadataWitValueSchemaIdBytes);
 
-      byte[] value = storagePartition.get(key, false);
+      byte[] value = storagePartition.get(key);
       Assert.assertNull(value);
 
       byte[] metadata = storagePartition.getReplicationMetadata(key);
@@ -419,7 +419,7 @@ public class ReplicationMetadataRocksDBStoragePartitionTest extends AbstractStor
     // Verify all the key/value pairs
     for (Map.Entry<String, Pair<String, String>> entry: inputRecords.entrySet()) {
       byte[] bytes = entry.getValue().getFirst() == null ? null : entry.getValue().getFirst().getBytes();
-      Assert.assertEquals(storagePartition.get(entry.getKey().getBytes(), false), bytes);
+      Assert.assertEquals(storagePartition.get(entry.getKey().getBytes()), bytes);
       if (sorted) {
         Assert.assertEquals(
             storagePartition.getReplicationMetadata(entry.getKey().getBytes()),
@@ -443,9 +443,9 @@ public class ReplicationMetadataRocksDBStoragePartitionTest extends AbstractStor
         rocksDBServerConfig);
     // Test deletion
     String toBeDeletedKey = KEY_PREFIX + 10;
-    Assert.assertNotNull(storagePartition.get(toBeDeletedKey.getBytes(), false));
+    Assert.assertNotNull(storagePartition.get(toBeDeletedKey.getBytes()));
     storagePartition.delete(toBeDeletedKey.getBytes());
-    Assert.assertNull(storagePartition.get(toBeDeletedKey.getBytes(), false));
+    Assert.assertNull(storagePartition.get(toBeDeletedKey.getBytes()));
 
     Options storeOptions = storagePartition.getOptions();
     Assert.assertEquals(storeOptions.level0FileNumCompactionTrigger(), 40);

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/store/rocksdb/RocksDBStoragePartitionTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/store/rocksdb/RocksDBStoragePartitionTest.java
@@ -213,7 +213,7 @@ public class RocksDBStoragePartitionTest {
 
     // Verify all the key/value pairs
     for (Map.Entry<String, String> entry: inputRecords.entrySet()) {
-      Assert.assertEquals(storagePartition.get(entry.getKey().getBytes(), false), entry.getValue().getBytes());
+      Assert.assertEquals(storagePartition.get(entry.getKey().getBytes()), entry.getValue().getBytes());
     }
 
     // Verify current ingestion mode is in deferred-write mode
@@ -233,9 +233,9 @@ public class RocksDBStoragePartitionTest {
 
     // Test deletion
     String toBeDeletedKey = KEY_PREFIX + 10;
-    Assert.assertNotNull(storagePartition.get(toBeDeletedKey.getBytes(), false));
+    Assert.assertNotNull(storagePartition.get(toBeDeletedKey.getBytes()));
     storagePartition.delete(toBeDeletedKey.getBytes());
-    Assert.assertNull(storagePartition.get(toBeDeletedKey.getBytes(), false));
+    Assert.assertNull(storagePartition.get(toBeDeletedKey.getBytes()));
 
     Options storeOptions = storagePartition.getOptions();
     Assert.assertEquals(storeOptions.level0FileNumCompactionTrigger(), 40);
@@ -342,7 +342,7 @@ public class RocksDBStoragePartitionTest {
 
     // Verify all the key/value pairs
     for (Map.Entry<String, String> entry: inputRecords.entrySet()) {
-      Assert.assertEquals(storagePartition.get(entry.getKey().getBytes(), false), entry.getValue().getBytes());
+      Assert.assertEquals(storagePartition.get(entry.getKey().getBytes()), entry.getValue().getBytes());
     }
 
     // Verify current ingestion mode is in deferred-write mode
@@ -367,14 +367,14 @@ public class RocksDBStoragePartitionTest {
 
     // Verify all the key/value pairs can be read using the new format
     for (Map.Entry<String, String> entry: inputRecords.entrySet()) {
-      Assert.assertEquals(storagePartition.get(entry.getKey().getBytes(), false), entry.getValue().getBytes());
+      Assert.assertEquals(storagePartition.get(entry.getKey().getBytes()), entry.getValue().getBytes());
     }
 
     // Test deletion
     String toBeDeletedKey = KEY_PREFIX + 10;
-    Assert.assertNotNull(storagePartition.get(toBeDeletedKey.getBytes(), false));
+    Assert.assertNotNull(storagePartition.get(toBeDeletedKey.getBytes()));
     storagePartition.delete(toBeDeletedKey.getBytes());
-    Assert.assertNull(storagePartition.get(toBeDeletedKey.getBytes(), false));
+    Assert.assertNull(storagePartition.get(toBeDeletedKey.getBytes()));
 
     Options storeOptions = storagePartition.getOptions();
     Assert.assertEquals(storeOptions.level0FileNumCompactionTrigger(), 40);
@@ -499,7 +499,7 @@ public class RocksDBStoragePartitionTest {
 
     // Verify all the key/value pairs
     for (Map.Entry<String, String> entry: inputRecords.entrySet()) {
-      Assert.assertEquals(storagePartition.get(entry.getKey().getBytes(), false), entry.getValue().getBytes());
+      Assert.assertEquals(storagePartition.get(entry.getKey().getBytes()), entry.getValue().getBytes());
     }
 
     // Verify current ingestion mode is in deferred-write mode
@@ -518,9 +518,9 @@ public class RocksDBStoragePartitionTest {
         rocksDBServerConfig);
     // Test deletion
     String toBeDeletedKey = KEY_PREFIX + 10;
-    Assert.assertNotNull(storagePartition.get(toBeDeletedKey.getBytes(), false));
+    Assert.assertNotNull(storagePartition.get(toBeDeletedKey.getBytes()));
     storagePartition.delete(toBeDeletedKey.getBytes());
-    Assert.assertNull(storagePartition.get(toBeDeletedKey.getBytes(), false));
+    Assert.assertNull(storagePartition.get(toBeDeletedKey.getBytes()));
 
     Options storeOptions = storagePartition.getOptions();
     Assert.assertEquals(storeOptions.level0FileNumCompactionTrigger(), 40);
@@ -585,7 +585,7 @@ public class RocksDBStoragePartitionTest {
 
     storagePartition.close();
     try {
-      storagePartition.get((KEY_PREFIX + "10").getBytes(), false);
+      storagePartition.get((KEY_PREFIX + "10").getBytes());
       Assert.fail("VeniceException is expected when looking up an already closed DB");
     } catch (VeniceException e) {
       Assert.assertTrue(e.getMessage().contains("RocksDB has been closed for store"));

--- a/clients/venice-samza/src/main/java/com/linkedin/venice/samza/VeniceSystemProducer.java
+++ b/clients/venice-samza/src/main/java/com/linkedin/venice/samza/VeniceSystemProducer.java
@@ -46,7 +46,6 @@ import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -584,7 +583,6 @@ public class VeniceSystemProducer implements SystemProducer, Closeable {
     }
 
     byte[] key = serializeObject(topicName, keyObject);
-    LogManager.getLogger().info("DEBUGGING SENDING PRODUCE KEY: " + keyObject + " " + Arrays.toString(key));
     final CompletableFuture<Void> completableFuture = new CompletableFuture<>();
     final Callback callback = new CompletableFutureCallback(completableFuture);
 

--- a/clients/venice-samza/src/main/java/com/linkedin/venice/samza/VeniceSystemProducer.java
+++ b/clients/venice-samza/src/main/java/com/linkedin/venice/samza/VeniceSystemProducer.java
@@ -46,6 +46,7 @@ import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -583,6 +584,7 @@ public class VeniceSystemProducer implements SystemProducer, Closeable {
     }
 
     byte[] key = serializeObject(topicName, keyObject);
+    LogManager.getLogger().info("DEBUGGING SENDING PRODUCE KEY: " + keyObject + " " + Arrays.toString(key));
     final CompletableFuture<Void> completableFuture = new CompletableFuture<>();
     final Callback callback = new CompletableFutureCallback(completableFuture);
 

--- a/internal/venice-common/src/main/java/com/linkedin/venice/kafka/validation/ProducerTracker.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/kafka/validation/ProducerTracker.java
@@ -409,6 +409,10 @@ public class ProducerTracker {
         segment.setLastRecordProducerTimestamp(consumerRecord.value().producerMetadata.messageTimestamp);
         return;
       }
+      LogManager.getLogger()
+          .info(
+              "DEBUGGING DIV GET DUPLICATE MESSAGE: " + incomingSequenceNumber + " " + previousSequenceNumber + " "
+                  + consumerRecord.value().producerMetadata.segmentNumber + " " + segment.getSegmentNumber());
       // This is a duplicate message, which we can safely ignore.
 
       // Although data duplication is a benign fault, we need to bubble up for two reasons:

--- a/internal/venice-common/src/main/java/com/linkedin/venice/kafka/validation/ProducerTracker.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/kafka/validation/ProducerTracker.java
@@ -409,10 +409,6 @@ public class ProducerTracker {
         segment.setLastRecordProducerTimestamp(consumerRecord.value().producerMetadata.messageTimestamp);
         return;
       }
-      LogManager.getLogger()
-          .info(
-              "DEBUGGING DIV GET DUPLICATE MESSAGE: " + incomingSequenceNumber + " " + previousSequenceNumber + " "
-                  + consumerRecord.value().producerMetadata.segmentNumber + " " + segment.getSegmentNumber());
       // This is a duplicate message, which we can safely ignore.
 
       // Although data duplication is a benign fault, we need to bubble up for two reasons:

--- a/internal/venice-common/src/main/java/com/linkedin/venice/writer/VeniceWriter.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/writer/VeniceWriter.java
@@ -85,6 +85,8 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
   public static final String CLOSE_TIMEOUT_MS = VENICE_WRITER_CONFIG_PREFIX + "close.timeout.ms";
   public static final String CHECK_SUM_TYPE = VENICE_WRITER_CONFIG_PREFIX + "checksum.type";
   public static final String ENABLE_CHUNKING = VENICE_WRITER_CONFIG_PREFIX + "chunking.enabled";
+  public static final String ENABLE_RMD_CHUNKING =
+      VENICE_WRITER_CONFIG_PREFIX + "replication.metadata.chunking.enabled";
   public static final String MAX_ATTEMPTS_WHEN_TOPIC_MISSING =
       VENICE_WRITER_CONFIG_PREFIX + "max.attemps.when.topic.missing";
   public static final String SLEEP_TIME_MS_WHEN_TOPIC_MISSING =
@@ -239,7 +241,7 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
   private volatile boolean isChunkingSet;
   private volatile boolean isChunkingFlagInvoked;
 
-  private boolean isRmdChunkingEnabled;
+  private final boolean isRmdChunkingEnabled;
 
   public VeniceWriter(
       VeniceWriterOptions params,
@@ -255,6 +257,7 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
     this.checkSumType = CheckSumType.valueOf(props.getString(CHECK_SUM_TYPE, DEFAULT_CHECK_SUM_TYPE));
     this.isChunkingEnabled = props.getBoolean(ENABLE_CHUNKING, false);
     this.isChunkingSet = props.containsKey(ENABLE_CHUNKING);
+    this.isRmdChunkingEnabled = props.getBoolean(ENABLE_RMD_CHUNKING, false);
     this.maxSizeForUserPayloadPerMessageInBytes = props
         .getInt(MAX_SIZE_FOR_USER_PAYLOAD_PER_MESSAGE_IN_BYTES, DEFAULT_MAX_SIZE_FOR_USER_PAYLOAD_PER_MESSAGE_IN_BYTES);
     if (maxSizeForUserPayloadPerMessageInBytes > DEFAULT_MAX_SIZE_FOR_USER_PAYLOAD_PER_MESSAGE_IN_BYTES) {
@@ -278,8 +281,6 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
         props.getLong(MAX_ELAPSED_TIME_FOR_SEGMENT_IN_MS, DEFAULT_MAX_ELAPSED_TIME_FOR_SEGMENT_IN_MS);
     this.elapsedTimeForClosingSegmentEnabled = maxElapsedTimeForSegmentInMs > 0;
     this.defaultDebugInfo = Utils.getDebugInfo();
-    // Hardcoded to false for now until we finished the implementation.
-    this.isRmdChunkingEnabled = false;
 
     // if INSTANCE_ID is not set, we'd use "hostname:port" as the default writer id
     if (props.containsKey(INSTANCE_ID)) {

--- a/internal/venice-common/src/main/java/com/linkedin/venice/writer/VeniceWriterFactory.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/writer/VeniceWriterFactory.java
@@ -55,6 +55,7 @@ public class VeniceWriterFactory {
       writerProperties.put(ConfigKeys.KAFKA_BOOTSTRAP_SERVERS, localKafkaBootstrapServers);
     }
     writerProperties.put(VeniceWriter.ENABLE_CHUNKING, options.isChunkingEnabled());
+    writerProperties.put(VeniceWriter.ENABLE_RMD_CHUNKING, options.isRmdChunkingEnabled());
     VeniceProperties props = new VeniceProperties(writerProperties);
     return new VeniceWriter<>(options, props, () -> {
       if (sharedKafkaProducerService.isPresent()) {

--- a/internal/venice-common/src/main/java/com/linkedin/venice/writer/VeniceWriterOptions.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/writer/VeniceWriterOptions.java
@@ -23,8 +23,9 @@ public class VeniceWriterOptions {
   private final VenicePartitioner partitioner;
   private final Time time;
   private final Optional<Integer> partitionCount;
-  private boolean chunkingEnabled;
-  private String kafkaBootstrapServers;
+  private final boolean chunkingEnabled;
+  private final boolean rmdChunkingEnabled;
+  private final String kafkaBootstrapServers;
 
   public String getKafkaBootstrapServers() {
     return kafkaBootstrapServers;
@@ -62,6 +63,10 @@ public class VeniceWriterOptions {
     return chunkingEnabled;
   }
 
+  public boolean isRmdChunkingEnabled() {
+    return rmdChunkingEnabled;
+  }
+
   private VeniceWriterOptions(Builder builder) {
     topicName = builder.topicName;
     keySerializer = builder.keySerializer;
@@ -71,6 +76,7 @@ public class VeniceWriterOptions {
     time = builder.time;
     partitionCount = builder.partitionCount;
     chunkingEnabled = builder.chunkingEnabled;
+    rmdChunkingEnabled = builder.rmdChunkingEnabled;
     kafkaBootstrapServers = builder.kafkaBootstrapServers;
   }
 
@@ -100,6 +106,7 @@ public class VeniceWriterOptions {
     private Time time = null;
     private Optional<Integer> partitionCount = Optional.empty();
     private boolean chunkingEnabled;
+    private boolean rmdChunkingEnabled;
     private boolean useKafkaKeySerializer = false;
     private String kafkaBootstrapServers = null;
 
@@ -153,6 +160,15 @@ public class VeniceWriterOptions {
 
     public Builder setChunkingEnabled(boolean chunkingEnabled) {
       this.chunkingEnabled = chunkingEnabled;
+      return this;
+    }
+
+    public boolean isRmdChunkingEnabled() {
+      return rmdChunkingEnabled;
+    }
+
+    public Builder setRmdChunkingEnabled(boolean rmdChunkingEnabled) {
+      this.rmdChunkingEnabled = rmdChunkingEnabled;
       return this;
     }
 

--- a/internal/venice-common/src/main/java/com/linkedin/venice/writer/WriterChunkingHelper.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/writer/WriterChunkingHelper.java
@@ -16,6 +16,7 @@ import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.function.BiConsumer;
 import java.util.function.Supplier;
+import org.apache.logging.log4j.LogManager;
 
 
 /**
@@ -49,6 +50,8 @@ public class WriterChunkingHelper {
     int sizeAvailablePerMessage = maxSizeForUserPayloadPerMessageInBytes - serializedKey.length;
     validateAvailableSizePerMessage(maxSizeForUserPayloadPerMessageInBytes, sizeAvailablePerMessage, sizeReport);
     int numberOfChunks = (int) Math.ceil((double) payload.length / (double) sizeAvailablePerMessage);
+    LogManager.getLogger()
+        .info("DEBUGGING CHUNKING PAYLOAD: " + isValuePayload + " " + payload.length + " " + numberOfChunks);
     final ChunkedValueManifest chunkedValueManifest = new ChunkedValueManifest();
     chunkedValueManifest.schemaId = schemaId;
     chunkedValueManifest.keysWithChunkIdSuffix = new ArrayList<>(numberOfChunks);
@@ -111,7 +114,6 @@ public class WriterChunkingHelper {
         putPayload.putValue = EMPTY_BYTE_BUFFER;
         putPayload.replicationMetadataPayload = chunk;
       }
-
       chunkedKeySuffix.chunkId.chunkIndex = chunkIndex;
       keyProvider = chunkIndex == 0 ? firstKeyProvider : subsequentKeyProvider;
 

--- a/internal/venice-common/src/main/java/com/linkedin/venice/writer/WriterChunkingHelper.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/writer/WriterChunkingHelper.java
@@ -16,7 +16,6 @@ import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.function.BiConsumer;
 import java.util.function.Supplier;
-import org.apache.logging.log4j.LogManager;
 
 
 /**
@@ -50,8 +49,6 @@ public class WriterChunkingHelper {
     int sizeAvailablePerMessage = maxSizeForUserPayloadPerMessageInBytes - serializedKey.length;
     validateAvailableSizePerMessage(maxSizeForUserPayloadPerMessageInBytes, sizeAvailablePerMessage, sizeReport);
     int numberOfChunks = (int) Math.ceil((double) payload.length / (double) sizeAvailablePerMessage);
-    LogManager.getLogger()
-        .info("DEBUGGING CHUNKING PAYLOAD: " + isValuePayload + " " + payload.length + " " + numberOfChunks);
     final ChunkedValueManifest chunkedValueManifest = new ChunkedValueManifest();
     chunkedValueManifest.schemaId = schemaId;
     chunkedValueManifest.keysWithChunkIdSuffix = new ArrayList<>(numberOfChunks);

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestActiveActiveIngestion.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestActiveActiveIngestion.java
@@ -263,6 +263,7 @@ public class TestActiveActiveIngestion {
         // not matter the DELETE is TTLed or not, the value should always be null
         Assert.assertNull(client.get(Integer.toString(i)).get());
       }
+
       // test old data - should be empty due to empty push
       for (int i = 40; i < 100; i++) {
         Assert.assertNull(client.get(Integer.toString(i)).get());

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestActiveActiveIngestion.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestActiveActiveIngestion.java
@@ -263,7 +263,6 @@ public class TestActiveActiveIngestion {
         // not matter the DELETE is TTLed or not, the value should always be null
         Assert.assertNull(client.get(Integer.toString(i)).get());
       }
-
       // test old data - should be empty due to empty push
       for (int i = 40; i < 100; i++) {
         Assert.assertNull(client.get(Integer.toString(i)).get());

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/writer/VeniceWriterTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/writer/VeniceWriterTest.java
@@ -1,5 +1,6 @@
 package com.linkedin.venice.writer;
 
+import static com.linkedin.venice.writer.VeniceWriter.*;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyInt;
 import static org.mockito.Mockito.anyString;
@@ -24,9 +25,15 @@ import com.linkedin.venice.kafka.protocol.Put;
 import com.linkedin.venice.kafka.protocol.enums.MessageType;
 import com.linkedin.venice.message.KafkaKey;
 import com.linkedin.venice.partitioner.DefaultVenicePartitioner;
+import com.linkedin.venice.serialization.KeyWithChunkingSuffixSerializer;
 import com.linkedin.venice.serialization.VeniceKafkaSerializer;
+import com.linkedin.venice.serialization.avro.AvroProtocolDefinition;
+import com.linkedin.venice.serialization.avro.ChunkedValueManifestSerializer;
 import com.linkedin.venice.serialization.avro.VeniceAvroKafkaSerializer;
 import com.linkedin.venice.utils.IntegrationTestPushUtils;
+import com.linkedin.venice.storage.protocol.ChunkId;
+import com.linkedin.venice.storage.protocol.ChunkedKeySuffix;
+import com.linkedin.venice.storage.protocol.ChunkedValueManifest;
 import com.linkedin.venice.utils.SystemTime;
 import com.linkedin.venice.utils.TestUtils;
 import com.linkedin.venice.utils.Time;
@@ -34,6 +41,7 @@ import com.linkedin.venice.utils.Utils;
 import com.linkedin.venice.utils.VeniceProperties;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -277,6 +285,169 @@ public class VeniceWriterTest {
     KafkaMessageEnvelope value6 = kafkaMessageEnvelopeArgumentCaptor.getAllValues().get(6);
     Assert.assertEquals(value6.messageType, MessageType.PUT.getValue());
     Assert.assertEquals(value6.producerMetadata.logicalTimestamp, VeniceWriter.APP_DEFAULT_LOGICAL_TS);
+  }
+
+  @Test(timeOut = 10000)
+  public void testReplicationMetadataChunking() throws ExecutionException, InterruptedException, TimeoutException {
+    KafkaProducerWrapper mockedProducer = mock(KafkaProducerWrapper.class);
+    Future mockedFuture = mock(Future.class);
+    when(mockedProducer.getNumberOfPartitions(any())).thenReturn(1);
+    when(mockedProducer.getNumberOfPartitions(any(), anyInt(), any())).thenReturn(1);
+    when(mockedProducer.sendMessage(anyString(), any(), any(), anyInt(), any())).thenReturn(mockedFuture);
+    Properties writerProperties = new Properties();
+    writerProperties.put(ENABLE_CHUNKING, true);
+    writerProperties.put(ENABLE_RMD_CHUNKING, true);
+
+    String stringSchema = "\"string\"";
+    VeniceKafkaSerializer serializer = new VeniceAvroKafkaSerializer(stringSchema);
+    String testTopic = "test";
+    VeniceWriterOptions veniceWriterOptions = new VeniceWriterOptions.Builder(testTopic).setKeySerializer(serializer)
+        .setValueSerializer(serializer)
+        .setWriteComputeSerializer(serializer)
+        .setPartitioner(new DefaultVenicePartitioner())
+        .setTime(SystemTime.INSTANCE)
+        .build();
+    VeniceWriter<Object, Object, Object> writer =
+        new VeniceWriter(veniceWriterOptions, new VeniceProperties(writerProperties), () -> mockedProducer);
+
+    ByteBuffer replicationMetadata = ByteBuffer.wrap(new byte[] { 0xa, 0xb });
+    PutMetadata putMetadata = new PutMetadata(1, replicationMetadata);
+
+    StringBuilder stringBuilder = new StringBuilder();
+    for (int i = 0; i < 50000; i++) {
+      stringBuilder.append("abcdefghabcdefghabcdefghabcdefgh");
+    }
+    String valueString = stringBuilder.toString();
+
+    writer.put(
+        Integer.toString(1),
+        valueString,
+        1,
+        null,
+        VeniceWriter.DEFAULT_LEADER_METADATA_WRAPPER,
+        VeniceWriter.APP_DEFAULT_LOGICAL_TS,
+        putMetadata);
+    ArgumentCaptor<KafkaKey> kafkaKeyArgumentCaptor = ArgumentCaptor.forClass(KafkaKey.class);
+    ArgumentCaptor<KafkaMessageEnvelope> kafkaMessageEnvelopeArgumentCaptor =
+        ArgumentCaptor.forClass(KafkaMessageEnvelope.class);
+    verify(mockedProducer, atLeast(2)).sendMessage(
+        eq(testTopic),
+        kafkaKeyArgumentCaptor.capture(),
+        kafkaMessageEnvelopeArgumentCaptor.capture(),
+        anyInt(),
+        any());
+    KeyWithChunkingSuffixSerializer keyWithChunkingSuffixSerializer = new KeyWithChunkingSuffixSerializer();
+    byte[] serializedKey = serializer.serialize(testTopic, Integer.toString(1));
+    byte[] serializedValue = serializer.serialize(testTopic, valueString);
+    byte[] serializedRmd = replicationMetadata.array();
+    int availableMessageSize = DEFAULT_MAX_SIZE_FOR_USER_PAYLOAD_PER_MESSAGE_IN_BYTES - serializedKey.length;
+
+    // The order should be SOS, valueChunk1, valueChunk2, replicationMetadataChunk1, manifest for value and RMD.
+    Assert.assertEquals(kafkaMessageEnvelopeArgumentCaptor.getAllValues().size(), 5);
+
+    // Verify value of the 1st chunk.
+    KafkaMessageEnvelope actualValue1 = kafkaMessageEnvelopeArgumentCaptor.getAllValues().get(1);
+    Assert.assertEquals(actualValue1.messageType, MessageType.PUT.getValue());
+    Assert.assertEquals(((Put) actualValue1.payloadUnion).schemaId, -10);
+    Assert.assertEquals(((Put) actualValue1.payloadUnion).replicationMetadataVersionId, -1);
+    Assert.assertEquals(((Put) actualValue1.payloadUnion).replicationMetadataPayload, ByteBuffer.allocate(0));
+    Assert.assertEquals(((Put) actualValue1.payloadUnion).putValue.array().length, availableMessageSize + 4);
+    Assert.assertEquals(actualValue1.producerMetadata.logicalTimestamp, VENICE_DEFAULT_LOGICAL_TS);
+
+    // Verify value of the 2nd chunk.
+    KafkaMessageEnvelope actualValue2 = kafkaMessageEnvelopeArgumentCaptor.getAllValues().get(2);
+    Assert.assertEquals(actualValue2.messageType, MessageType.PUT.getValue());
+    Assert.assertEquals(((Put) actualValue2.payloadUnion).schemaId, -10);
+    Assert.assertEquals(((Put) actualValue2.payloadUnion).replicationMetadataVersionId, -1);
+    Assert.assertEquals(((Put) actualValue2.payloadUnion).replicationMetadataPayload, ByteBuffer.allocate(0));
+    Assert.assertEquals(
+        ((Put) actualValue2.payloadUnion).putValue.array().length,
+        (serializedValue.length - availableMessageSize) + 4);
+    Assert.assertEquals(actualValue2.producerMetadata.logicalTimestamp, VENICE_DEFAULT_LOGICAL_TS);
+
+    ChunkedValueManifestSerializer chunkedValueManifestSerializer = new ChunkedValueManifestSerializer(true);
+
+    final ChunkedValueManifest chunkedValueManifest = new ChunkedValueManifest();
+    chunkedValueManifest.schemaId = 1;
+    chunkedValueManifest.keysWithChunkIdSuffix = new ArrayList<>(2);
+    chunkedValueManifest.size = serializedValue.length;
+
+    // Verify key of the 1st value chunk.
+    ChunkedKeySuffix chunkedKeySuffix = new ChunkedKeySuffix();
+    chunkedKeySuffix.isChunk = true;
+    chunkedKeySuffix.chunkId = new ChunkId();
+    ProducerMetadata producerMetadata = actualValue1.producerMetadata;
+    chunkedKeySuffix.chunkId.producerGUID = producerMetadata.producerGUID;
+    chunkedKeySuffix.chunkId.segmentNumber = producerMetadata.segmentNumber;
+    chunkedKeySuffix.chunkId.messageSequenceNumber = producerMetadata.messageSequenceNumber;
+
+    ByteBuffer keyWithSuffix =
+        ByteBuffer.wrap(keyWithChunkingSuffixSerializer.serializeChunkedKey(serializedKey, chunkedKeySuffix));
+    chunkedValueManifest.keysWithChunkIdSuffix.add(keyWithSuffix);
+    KafkaKey expectedKey1 = new KafkaKey(MessageType.PUT, keyWithSuffix.array());
+    KafkaKey actualKey1 = kafkaKeyArgumentCaptor.getAllValues().get(1);
+    Assert.assertEquals(actualKey1.getKey(), expectedKey1.getKey());
+
+    // Verify key of the 2nd value chunk.
+    chunkedKeySuffix.chunkId.chunkIndex = 1;
+    keyWithSuffix =
+        ByteBuffer.wrap(keyWithChunkingSuffixSerializer.serializeChunkedKey(serializedKey, chunkedKeySuffix));
+    chunkedValueManifest.keysWithChunkIdSuffix.add(keyWithSuffix);
+    KafkaKey expectedKey2 = new KafkaKey(MessageType.PUT, keyWithSuffix.array());
+    KafkaKey actualKey2 = kafkaKeyArgumentCaptor.getAllValues().get(2);
+    Assert.assertEquals(actualKey2.getKey(), expectedKey2.getKey());
+
+    // Check value of the 1st RMD chunk.
+    KafkaMessageEnvelope actualValue3 = kafkaMessageEnvelopeArgumentCaptor.getAllValues().get(3);
+    Assert.assertEquals(actualValue3.messageType, MessageType.PUT.getValue());
+    Assert.assertEquals(((Put) actualValue3.payloadUnion).schemaId, -10);
+    Assert.assertEquals(((Put) actualValue3.payloadUnion).replicationMetadataVersionId, -1);
+    Assert.assertEquals(((Put) actualValue3.payloadUnion).putValue, ByteBuffer.allocate(0));
+    Assert.assertEquals(
+        ((Put) actualValue3.payloadUnion).replicationMetadataPayload.array().length,
+        serializedRmd.length + 4);
+    Assert.assertEquals(actualValue3.producerMetadata.logicalTimestamp, VENICE_DEFAULT_LOGICAL_TS);
+
+    // Check key of the 1st RMD chunk.
+    ChunkedValueManifest chunkedRmdManifest = new ChunkedValueManifest();
+    chunkedRmdManifest.schemaId = 1;
+    chunkedRmdManifest.keysWithChunkIdSuffix = new ArrayList<>(1);
+    chunkedRmdManifest.size = serializedRmd.length;
+    chunkedKeySuffix = new ChunkedKeySuffix();
+    chunkedKeySuffix.isChunk = true;
+    chunkedKeySuffix.chunkId = new ChunkId();
+    producerMetadata = actualValue3.producerMetadata;
+    chunkedKeySuffix.chunkId.producerGUID = producerMetadata.producerGUID;
+    chunkedKeySuffix.chunkId.segmentNumber = producerMetadata.segmentNumber;
+    chunkedKeySuffix.chunkId.messageSequenceNumber = producerMetadata.messageSequenceNumber;
+    keyWithSuffix =
+        ByteBuffer.wrap(keyWithChunkingSuffixSerializer.serializeChunkedKey(serializedKey, chunkedKeySuffix));
+    chunkedRmdManifest.keysWithChunkIdSuffix.add(keyWithSuffix);
+    KafkaKey expectedKey3 = new KafkaKey(MessageType.PUT, keyWithSuffix.array());
+    KafkaKey actualKey3 = kafkaKeyArgumentCaptor.getAllValues().get(3);
+    Assert.assertEquals(actualKey3.getKey(), expectedKey3.getKey());
+
+    // Check key of the manifest.
+    byte[] topLevelKey = keyWithChunkingSuffixSerializer.serializeNonChunkedKey(serializedKey);
+    KafkaKey expectedKey4 = new KafkaKey(MessageType.PUT, topLevelKey);
+    KafkaKey actualKey4 = kafkaKeyArgumentCaptor.getAllValues().get(4);
+    Assert.assertEquals(actualKey4.getKey(), expectedKey4.getKey());
+
+    // Check manifest for both value and rmd.
+    KafkaMessageEnvelope actualValue4 = kafkaMessageEnvelopeArgumentCaptor.getAllValues().get(4);
+    Assert.assertEquals(actualValue4.messageType, MessageType.PUT.getValue());
+    Assert.assertEquals(
+        ((Put) actualValue4.payloadUnion).schemaId,
+        AvroProtocolDefinition.CHUNKED_VALUE_MANIFEST.getCurrentProtocolVersion());
+    Assert.assertEquals(((Put) actualValue4.payloadUnion).replicationMetadataVersionId, putMetadata.getRmdVersionId());
+    Assert.assertEquals(
+        ((Put) actualValue4.payloadUnion).replicationMetadataPayload,
+        ByteBuffer.wrap(chunkedValueManifestSerializer.serialize(testTopic, chunkedRmdManifest)));
+    Assert.assertEquals(
+        ((Put) actualValue4.payloadUnion).putValue,
+        ByteBuffer.wrap(chunkedValueManifestSerializer.serialize(testTopic, chunkedValueManifest)));
+    Assert.assertEquals(actualValue4.producerMetadata.logicalTimestamp, APP_DEFAULT_LOGICAL_TS);
+
   }
 
   @Test(timeOut = 30000)

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/writer/VeniceWriterTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/writer/VeniceWriterTest.java
@@ -1,6 +1,10 @@
 package com.linkedin.venice.writer;
 
-import static com.linkedin.venice.writer.VeniceWriter.*;
+import static com.linkedin.venice.writer.VeniceWriter.APP_DEFAULT_LOGICAL_TS;
+import static com.linkedin.venice.writer.VeniceWriter.DEFAULT_MAX_SIZE_FOR_USER_PAYLOAD_PER_MESSAGE_IN_BYTES;
+import static com.linkedin.venice.writer.VeniceWriter.ENABLE_CHUNKING;
+import static com.linkedin.venice.writer.VeniceWriter.ENABLE_RMD_CHUNKING;
+import static com.linkedin.venice.writer.VeniceWriter.VENICE_DEFAULT_LOGICAL_TS;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyInt;
 import static org.mockito.Mockito.anyString;
@@ -30,10 +34,10 @@ import com.linkedin.venice.serialization.VeniceKafkaSerializer;
 import com.linkedin.venice.serialization.avro.AvroProtocolDefinition;
 import com.linkedin.venice.serialization.avro.ChunkedValueManifestSerializer;
 import com.linkedin.venice.serialization.avro.VeniceAvroKafkaSerializer;
-import com.linkedin.venice.utils.IntegrationTestPushUtils;
 import com.linkedin.venice.storage.protocol.ChunkId;
 import com.linkedin.venice.storage.protocol.ChunkedKeySuffix;
 import com.linkedin.venice.storage.protocol.ChunkedValueManifest;
+import com.linkedin.venice.utils.IntegrationTestPushUtils;
 import com.linkedin.venice.utils.SystemTime;
 import com.linkedin.venice.utils.TestUtils;
 import com.linkedin.venice.utils.Time;
@@ -228,7 +232,7 @@ public class VeniceWriterTest {
         1,
         null,
         VeniceWriter.DEFAULT_LEADER_METADATA_WRAPPER,
-        VeniceWriter.APP_DEFAULT_LOGICAL_TS,
+        APP_DEFAULT_LOGICAL_TS,
         putMetadata);
     writer.update(Integer.toString(3), Integer.toString(2), 1, 1, null, ctime);
     writer.delete(Integer.toString(4), null, VeniceWriter.DEFAULT_LEADER_METADATA_WRAPPER, ctime);
@@ -242,7 +246,7 @@ public class VeniceWriterTest {
 
     // first one will be control message SOS, there should not be any aa metadata.
     KafkaMessageEnvelope value0 = kafkaMessageEnvelopeArgumentCaptor.getAllValues().get(0);
-    Assert.assertEquals(value0.producerMetadata.logicalTimestamp, VeniceWriter.VENICE_DEFAULT_LOGICAL_TS);
+    Assert.assertEquals(value0.producerMetadata.logicalTimestamp, VENICE_DEFAULT_LOGICAL_TS);
 
     // verify timestamp is encoded correctly.
     KafkaMessageEnvelope value1 = kafkaMessageEnvelopeArgumentCaptor.getAllValues().get(1);
@@ -270,7 +274,7 @@ public class VeniceWriterTest {
     Assert.assertEquals(put.schemaId, 1);
     Assert.assertEquals(put.replicationMetadataVersionId, 1);
     Assert.assertEquals(put.replicationMetadataPayload, ByteBuffer.wrap(new byte[] { 0xa, 0xb }));
-    Assert.assertEquals(value2.producerMetadata.logicalTimestamp, VeniceWriter.APP_DEFAULT_LOGICAL_TS);
+    Assert.assertEquals(value2.producerMetadata.logicalTimestamp, APP_DEFAULT_LOGICAL_TS);
 
     // verify replicationMetadata is encoded correctly for Delete.
     KafkaMessageEnvelope value5 = kafkaMessageEnvelopeArgumentCaptor.getAllValues().get(5);
@@ -279,12 +283,12 @@ public class VeniceWriterTest {
     Assert.assertEquals(delete.schemaId, 1);
     Assert.assertEquals(delete.replicationMetadataVersionId, 1);
     Assert.assertEquals(delete.replicationMetadataPayload, ByteBuffer.wrap(new byte[] { 0xa, 0xb }));
-    Assert.assertEquals(value5.producerMetadata.logicalTimestamp, VeniceWriter.APP_DEFAULT_LOGICAL_TS);
+    Assert.assertEquals(value5.producerMetadata.logicalTimestamp, APP_DEFAULT_LOGICAL_TS);
 
     // verify default logical_ts is encoded correctly
     KafkaMessageEnvelope value6 = kafkaMessageEnvelopeArgumentCaptor.getAllValues().get(6);
     Assert.assertEquals(value6.messageType, MessageType.PUT.getValue());
-    Assert.assertEquals(value6.producerMetadata.logicalTimestamp, VeniceWriter.APP_DEFAULT_LOGICAL_TS);
+    Assert.assertEquals(value6.producerMetadata.logicalTimestamp, APP_DEFAULT_LOGICAL_TS);
   }
 
   @Test(timeOut = 10000)
@@ -325,7 +329,7 @@ public class VeniceWriterTest {
         1,
         null,
         VeniceWriter.DEFAULT_LEADER_METADATA_WRAPPER,
-        VeniceWriter.APP_DEFAULT_LOGICAL_TS,
+        APP_DEFAULT_LOGICAL_TS,
         putMetadata);
     ArgumentCaptor<KafkaKey> kafkaKeyArgumentCaptor = ArgumentCaptor.forClass(KafkaKey.class);
     ArgumentCaptor<KafkaMessageEnvelope> kafkaMessageEnvelopeArgumentCaptor =

--- a/internal/venice-test-common/src/integrationtest/resources/CollectionRecordV1.avsc
+++ b/internal/venice-test-common/src/integrationtest/resources/CollectionRecordV1.avsc
@@ -1,0 +1,27 @@
+{
+  "name": "SampleRecord",
+  "type": "record",
+  "fields": [
+    {
+      "name": "name",
+      "type": "string",
+      "default": "default_name"
+    },
+    {
+      "name": "intArray",
+      "type": {
+        "type": "array",
+        "items": "int"
+      },
+      "default": []
+    },
+    {
+      "name": "stringMap",
+      "type": {
+        "type": "map",
+        "values": "string"
+      },
+      "default": {}
+    }
+  ]
+}

--- a/internal/venice-test-common/src/jmh/java/com/linkedin/venice/benchmark/ReplicationConsumptionBenchmark.java
+++ b/internal/venice-test-common/src/jmh/java/com/linkedin/venice/benchmark/ReplicationConsumptionBenchmark.java
@@ -166,9 +166,8 @@ public class ReplicationConsumptionBenchmark {
         rocksDBServerConfig);
     // Test deletion
     String toBeDeletedKey = KEY_PREFIX + 10;
-    // Assert.assertNotNull(storagePartition.get(toBeDeletedKey.getBytes(), false));
     storagePartition.delete(toBeDeletedKey.getBytes());
-    Assert.assertNull(storagePartition.get(toBeDeletedKey.getBytes(), false));
+    Assert.assertNull(storagePartition.get(toBeDeletedKey.getBytes()));
   }
 
   private Map<String, Pair<String, String>> generateInputWithMetadata(int startIndex, int endIndex) {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
@@ -1359,7 +1359,6 @@ public class VeniceParentHelixAdmin implements Admin {
    * Test if the given certificate has the write-access permission for the given batch-job heartbeat store.
    * @param requesterCert X.509 certificate object.
    * @param batchJobHeartbeatStoreName name of the batch-job heartbeat store.
-   * @param identityParser a parser object to retrieve identity information from a certificate.
    * @return <code>true</code> if input certificate has write-access permission for the given store;
    *         <code>false</code> otherwise.
    * @throws AclException

--- a/services/venice-server/src/main/java/com/linkedin/venice/listener/StorageReadRequestsHandler.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/listener/StorageReadRequestsHandler.java
@@ -674,8 +674,7 @@ public class StorageReadRequestsHandler extends ChannelInboundHandlerAdapter {
             fastAvroEnabled,
             this.schemaRepo,
             storeName,
-            compressor,
-            false);
+            compressor);
         break;
       case SINGLE_GET_WITH_REUSE:
         reuseValueRecord = GenericRecordChunkingAdapter.INSTANCE.get(

--- a/services/venice-server/src/test/java/com/linkedin/venice/listener/StorageReadRequestsHandlerTest.java
+++ b/services/venice-server/src/test/java/com/linkedin/venice/listener/StorageReadRequestsHandlerTest.java
@@ -73,7 +73,7 @@ public class StorageReadRequestsHandlerTest {
     GetRouterRequest testRequest = GetRouterRequest.parseGetHttpRequest(httpRequest);
 
     AbstractStorageEngine testStore = mock(AbstractStorageEngine.class);
-    doReturn(valueBytes).when(testStore).get(partition, ByteBuffer.wrap(keyString.getBytes()), false);
+    doReturn(valueBytes).when(testStore).get(partition, ByteBuffer.wrap(keyString.getBytes()));
 
     StorageEngineRepository testRepository = mock(StorageEngineRepository.class);
     doReturn(testStore).when(testRepository).getLocalStorageEngine(topic);
@@ -211,7 +211,7 @@ public class StorageReadRequestsHandlerTest {
     GetRouterRequest testRequest = GetRouterRequest.parseGetHttpRequest(httpRequest);
 
     AbstractStorageEngine testStore = mock(AbstractStorageEngine.class);
-    doReturn(valueBytes).when(testStore).get(partition, ByteBuffer.wrap(keyString.getBytes()), false);
+    doReturn(valueBytes).when(testStore).get(partition, ByteBuffer.wrap(keyString.getBytes()));
 
     StorageEngineRepository testRepository = mock(StorageEngineRepository.class);
 


### PR DESCRIPTION
## [server] End to end RMD chunking support for A/A store ingestion (First part)
This PR implements end to end RMD chunking support for A/A store with some limitations. With the implementation, all PUT/UPDATE operations can be processed correctly when value chunking and RMD chunking is enabled. Value and RMD will be chunked accordingly and will be re-assembled during read. This PR also adds an integration test to verify this behavior.

Note: There are two know issues in this implementation and will be addressed in the following PR for easier review experience.
1. DELETE operation can also be too big when existing RMD record is too big. The support of DELETE chunking will be added in the next PR.
2. During the implementation, we found the repush does not carry RMD when A/A + Chunking is enabled. This is not the correct behavior. Also, in the above case, if the latest operation around a key is a DELETE, the current implementation does not send it to the new version topic. This issue will also be addressed in a separated PR.

## How was this PR tested?
Added new integration test. Internal CI

## Does this PR introduce any user-facing changes?
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.