### PR TITLE
[server] Fix RMD retrieval bug when chunking is enabled

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
@@ -249,7 +249,13 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
     }
 
     final long lookupStartTimeInNS = System.nanoTime();
-    byte[] replicationMetadataWithValueSchemaBytes = storageEngine.getReplicationMetadata(subPartition, key);
+    byte[] updatedKey;
+    if (isChunked) {
+      updatedKey = ChunkingUtils.KEY_WITH_CHUNKING_SUFFIX_SERIALIZER.serializeNonChunkedKey(key);
+    } else {
+      updatedKey = key;
+    }
+    byte[] replicationMetadataWithValueSchemaBytes = storageEngine.getReplicationMetadata(subPartition, updatedKey);
     hostLevelIngestionStats
         .recordIngestionReplicationMetadataLookUpLatency(LatencyUtils.getLatencyInMS(lookupStartTimeInNS));
     if (replicationMetadataWithValueSchemaBytes == null) {

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/ActiveActiveReplicationForHybridTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/ActiveActiveReplicationForHybridTest.java
@@ -572,13 +572,18 @@ public class ActiveActiveReplicationForHybridTest {
     }
   }
 
-  @Test(timeOut = TEST_TIMEOUT, dataProvider = "True-and-False", dataProviderClass = DataProviderUtils.class)
-  public void testAAReplicationCanResolveConflicts(boolean useLogicalTimestamp) {
+  @Test(timeOut = TEST_TIMEOUT, dataProvider = "Two-True-and-False", dataProviderClass = DataProviderUtils.class)
+  public void testAAReplicationCanResolveConflicts(boolean useLogicalTimestamp, boolean chunkingEnabled) {
     String clusterName = CLUSTER_NAMES[0];
     String storeName = Utils.getUniqueString("test-store");
     try {
       assertCommand(parentControllerClient.createNewStore(storeName, "owner", STRING_SCHEMA, STRING_SCHEMA));
-      updateStoreToHybrid(storeName, parentControllerClient, Optional.of(true), Optional.of(true), Optional.of(false));
+      updateStoreToHybrid(
+          storeName,
+          parentControllerClient,
+          Optional.of(true),
+          Optional.of(true),
+          Optional.of(chunkingEnabled));
 
       // Empty push to create a version
       assertCommand(


### PR DESCRIPTION
## [server] Fix RMD retrieval bug when chunking is enabled
This hot fix commit fixes RMD retrieval bug when chunking is enabled in A/A mode.

Current implementation always use raw key bytes to retrive RMD from storage, however, when chunking is enabled, it should be adjusted with chunking specific suffix. Current code will miss old RMD from storage and will make incoming record always accepted by DCR, unless a cache hit from transient record.

This PR fixes it by checking the chunking flag and adjust the key accordingly. This PR also adjusts an existing integration test to make sure chunking+AA will work correctly.

## How was this PR tested?
Internal CI 3 times.
Adjust existing integration test to make sure A/A+Chunking combination is covered.

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.