### PR TITLE
[build] Split integration tests into 18 buckets

### DIFF
--- a/.github/rawWorkflows/gh-ci-parameterized-flow.txt
+++ b/.github/rawWorkflows/gh-ci-parameterized-flow.txt
@@ -1,0 +1,28 @@
+  $FlowName:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        jdk: [11]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: $TimeOut
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          java-version: ${{ matrix.jdk }}
+          distribution: 'microsoft'
+      - shell: bash
+        run: |
+          git remote set-head origin --auto
+          git remote add upstream https://github.com/linkedin/venice
+          git fetch upstream
+      - name: Validate Gradle wrapper
+        uses: gradle/wrapper-validation-action@e6e38bacfdf1a337459f332974bb2327a31aaf4b
+      - name: Build with Gradle
+        uses: gradle/gradle-build-action@67421db6bd0bf253fb4bd25b31ebb98943c375e1
+        with:
+          arguments: "$GradleArguments"

--- a/.github/workflows/gh-ci.yml
+++ b/.github/workflows/gh-ci.yml
@@ -1,10 +1,25 @@
+# Auto-generated file. Do not edit manually!
+#
+# To alter these flows, edit:
+#
+#     internal/venice-test-common/build.gradle
+#
+# To regenerate, run:
+#
+#     ./gradlew generateGHCI
+
 name: VeniceCI
 
 on: [push, pull_request]
 
 jobs:
-  Check:
-    runs-on: ubuntu-latest
+  StaticAnalysis:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        jdk: [11]
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v3
@@ -13,28 +28,28 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v3
         with:
-          java-version: '11'
+          java-version: ${{ matrix.jdk }}
           distribution: 'microsoft'
       - shell: bash
         run: |
-            git remote set-head origin --auto
-            git remote add upstream https://github.com/linkedin/venice
-            git fetch upstream
+          git remote set-head origin --auto
+          git remote add upstream https://github.com/linkedin/venice
+          git fetch upstream
       - name: Validate Gradle wrapper
         uses: gradle/wrapper-validation-action@e6e38bacfdf1a337459f332974bb2327a31aaf4b
       - name: Build with Gradle
         uses: gradle/gradle-build-action@67421db6bd0bf253fb4bd25b31ebb98943c375e1
         with:
-          arguments: "clean check -x spotlessCheck --continue --no-daemon -Pspotallbugs -Pspotbugs.xml -Pspotbugs.ignoreFailures -x test -x integrationTestA -x integrationTestB"
+          arguments: "--continue --no-daemon -Pspotallbugs -Pspotbugs.xml -Pspotbugs.ignoreFailures clean check -x spotlessCheck -x test -x integrationTest"
 
-  unit-tests-and-code-coverage-check:
+  UnitTestsAndCodeCoverage:
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
         jdk: [11]
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 90
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v3
         with:
@@ -51,18 +66,19 @@ jobs:
           git fetch upstream
       - name: Validate Gradle wrapper
         uses: gradle/wrapper-validation-action@e6e38bacfdf1a337459f332974bb2327a31aaf4b
-      - name: Run unit tests and verify the code coverage
+      - name: Build with Gradle
         uses: gradle/gradle-build-action@67421db6bd0bf253fb4bd25b31ebb98943c375e1
         with:
           arguments: "jacocoTestCoverageVerification"
-  E2ETestsA:
+
+  IntegrationTestsA:
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
         jdk: [11]
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 240
+    timeout-minutes: 120
     steps:
       - uses: actions/checkout@v3
         with:
@@ -82,17 +98,16 @@ jobs:
       - name: Build with Gradle
         uses: gradle/gradle-build-action@67421db6bd0bf253fb4bd25b31ebb98943c375e1
         with:
-          arguments: "build --continue --no-daemon -DforkEvery=1 -DmaxParallelForks=1 -x shadowDistTar -x shadowDistZip -x shadowJar -x startShadowScripts -x distTar -x distZip -x test -x integrationTestB"
+          arguments: "--continue --no-daemon -DforkEvery=1 -DmaxParallelForks=1 integrationTestA"
 
-
-  E2ETestsB:
+  IntegrationTestsB:
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
         jdk: [11]
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 240
+    timeout-minutes: 120
     steps:
       - uses: actions/checkout@v3
         with:
@@ -112,5 +127,469 @@ jobs:
       - name: Build with Gradle
         uses: gradle/gradle-build-action@67421db6bd0bf253fb4bd25b31ebb98943c375e1
         with:
-          arguments: "build --continue --no-daemon -DforkEvery=1 -DmaxParallelForks=1 -x shadowDistTar -x shadowDistZip -x shadowJar -x startShadowScripts -x distTar -x distZip -x test -x integrationTestA"
+          arguments: "--continue --no-daemon -DforkEvery=1 -DmaxParallelForks=1 integrationTestB"
+
+  IntegrationTestsC:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        jdk: [11]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          java-version: ${{ matrix.jdk }}
+          distribution: 'microsoft'
+      - shell: bash
+        run: |
+          git remote set-head origin --auto
+          git remote add upstream https://github.com/linkedin/venice
+          git fetch upstream
+      - name: Validate Gradle wrapper
+        uses: gradle/wrapper-validation-action@e6e38bacfdf1a337459f332974bb2327a31aaf4b
+      - name: Build with Gradle
+        uses: gradle/gradle-build-action@67421db6bd0bf253fb4bd25b31ebb98943c375e1
+        with:
+          arguments: "--continue --no-daemon -DforkEvery=1 -DmaxParallelForks=1 integrationTestC"
+
+  IntegrationTestsD:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        jdk: [11]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          java-version: ${{ matrix.jdk }}
+          distribution: 'microsoft'
+      - shell: bash
+        run: |
+          git remote set-head origin --auto
+          git remote add upstream https://github.com/linkedin/venice
+          git fetch upstream
+      - name: Validate Gradle wrapper
+        uses: gradle/wrapper-validation-action@e6e38bacfdf1a337459f332974bb2327a31aaf4b
+      - name: Build with Gradle
+        uses: gradle/gradle-build-action@67421db6bd0bf253fb4bd25b31ebb98943c375e1
+        with:
+          arguments: "--continue --no-daemon -DforkEvery=1 -DmaxParallelForks=1 integrationTestD"
+
+  IntegrationTestsE:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        jdk: [11]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          java-version: ${{ matrix.jdk }}
+          distribution: 'microsoft'
+      - shell: bash
+        run: |
+          git remote set-head origin --auto
+          git remote add upstream https://github.com/linkedin/venice
+          git fetch upstream
+      - name: Validate Gradle wrapper
+        uses: gradle/wrapper-validation-action@e6e38bacfdf1a337459f332974bb2327a31aaf4b
+      - name: Build with Gradle
+        uses: gradle/gradle-build-action@67421db6bd0bf253fb4bd25b31ebb98943c375e1
+        with:
+          arguments: "--continue --no-daemon -DforkEvery=1 -DmaxParallelForks=1 integrationTestE"
+
+  IntegrationTestsF:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        jdk: [11]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          java-version: ${{ matrix.jdk }}
+          distribution: 'microsoft'
+      - shell: bash
+        run: |
+          git remote set-head origin --auto
+          git remote add upstream https://github.com/linkedin/venice
+          git fetch upstream
+      - name: Validate Gradle wrapper
+        uses: gradle/wrapper-validation-action@e6e38bacfdf1a337459f332974bb2327a31aaf4b
+      - name: Build with Gradle
+        uses: gradle/gradle-build-action@67421db6bd0bf253fb4bd25b31ebb98943c375e1
+        with:
+          arguments: "--continue --no-daemon -DforkEvery=1 -DmaxParallelForks=1 integrationTestF"
+
+  IntegrationTestsG:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        jdk: [11]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          java-version: ${{ matrix.jdk }}
+          distribution: 'microsoft'
+      - shell: bash
+        run: |
+          git remote set-head origin --auto
+          git remote add upstream https://github.com/linkedin/venice
+          git fetch upstream
+      - name: Validate Gradle wrapper
+        uses: gradle/wrapper-validation-action@e6e38bacfdf1a337459f332974bb2327a31aaf4b
+      - name: Build with Gradle
+        uses: gradle/gradle-build-action@67421db6bd0bf253fb4bd25b31ebb98943c375e1
+        with:
+          arguments: "--continue --no-daemon -DforkEvery=1 -DmaxParallelForks=1 integrationTestG"
+
+  IntegrationTestsH:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        jdk: [11]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          java-version: ${{ matrix.jdk }}
+          distribution: 'microsoft'
+      - shell: bash
+        run: |
+          git remote set-head origin --auto
+          git remote add upstream https://github.com/linkedin/venice
+          git fetch upstream
+      - name: Validate Gradle wrapper
+        uses: gradle/wrapper-validation-action@e6e38bacfdf1a337459f332974bb2327a31aaf4b
+      - name: Build with Gradle
+        uses: gradle/gradle-build-action@67421db6bd0bf253fb4bd25b31ebb98943c375e1
+        with:
+          arguments: "--continue --no-daemon -DforkEvery=1 -DmaxParallelForks=1 integrationTestH"
+
+  IntegrationTestsI:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        jdk: [11]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          java-version: ${{ matrix.jdk }}
+          distribution: 'microsoft'
+      - shell: bash
+        run: |
+          git remote set-head origin --auto
+          git remote add upstream https://github.com/linkedin/venice
+          git fetch upstream
+      - name: Validate Gradle wrapper
+        uses: gradle/wrapper-validation-action@e6e38bacfdf1a337459f332974bb2327a31aaf4b
+      - name: Build with Gradle
+        uses: gradle/gradle-build-action@67421db6bd0bf253fb4bd25b31ebb98943c375e1
+        with:
+          arguments: "--continue --no-daemon -DforkEvery=1 -DmaxParallelForks=1 integrationTestI"
+
+  IntegrationTestsJ:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        jdk: [11]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          java-version: ${{ matrix.jdk }}
+          distribution: 'microsoft'
+      - shell: bash
+        run: |
+          git remote set-head origin --auto
+          git remote add upstream https://github.com/linkedin/venice
+          git fetch upstream
+      - name: Validate Gradle wrapper
+        uses: gradle/wrapper-validation-action@e6e38bacfdf1a337459f332974bb2327a31aaf4b
+      - name: Build with Gradle
+        uses: gradle/gradle-build-action@67421db6bd0bf253fb4bd25b31ebb98943c375e1
+        with:
+          arguments: "--continue --no-daemon -DforkEvery=1 -DmaxParallelForks=1 integrationTestJ"
+
+  IntegrationTestsK:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        jdk: [11]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          java-version: ${{ matrix.jdk }}
+          distribution: 'microsoft'
+      - shell: bash
+        run: |
+          git remote set-head origin --auto
+          git remote add upstream https://github.com/linkedin/venice
+          git fetch upstream
+      - name: Validate Gradle wrapper
+        uses: gradle/wrapper-validation-action@e6e38bacfdf1a337459f332974bb2327a31aaf4b
+      - name: Build with Gradle
+        uses: gradle/gradle-build-action@67421db6bd0bf253fb4bd25b31ebb98943c375e1
+        with:
+          arguments: "--continue --no-daemon -DforkEvery=1 -DmaxParallelForks=1 integrationTestK"
+
+  IntegrationTestsL:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        jdk: [11]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          java-version: ${{ matrix.jdk }}
+          distribution: 'microsoft'
+      - shell: bash
+        run: |
+          git remote set-head origin --auto
+          git remote add upstream https://github.com/linkedin/venice
+          git fetch upstream
+      - name: Validate Gradle wrapper
+        uses: gradle/wrapper-validation-action@e6e38bacfdf1a337459f332974bb2327a31aaf4b
+      - name: Build with Gradle
+        uses: gradle/gradle-build-action@67421db6bd0bf253fb4bd25b31ebb98943c375e1
+        with:
+          arguments: "--continue --no-daemon -DforkEvery=1 -DmaxParallelForks=1 integrationTestL"
+
+  IntegrationTestsM:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        jdk: [11]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          java-version: ${{ matrix.jdk }}
+          distribution: 'microsoft'
+      - shell: bash
+        run: |
+          git remote set-head origin --auto
+          git remote add upstream https://github.com/linkedin/venice
+          git fetch upstream
+      - name: Validate Gradle wrapper
+        uses: gradle/wrapper-validation-action@e6e38bacfdf1a337459f332974bb2327a31aaf4b
+      - name: Build with Gradle
+        uses: gradle/gradle-build-action@67421db6bd0bf253fb4bd25b31ebb98943c375e1
+        with:
+          arguments: "--continue --no-daemon -DforkEvery=1 -DmaxParallelForks=1 integrationTestM"
+
+  IntegrationTestsN:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        jdk: [11]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          java-version: ${{ matrix.jdk }}
+          distribution: 'microsoft'
+      - shell: bash
+        run: |
+          git remote set-head origin --auto
+          git remote add upstream https://github.com/linkedin/venice
+          git fetch upstream
+      - name: Validate Gradle wrapper
+        uses: gradle/wrapper-validation-action@e6e38bacfdf1a337459f332974bb2327a31aaf4b
+      - name: Build with Gradle
+        uses: gradle/gradle-build-action@67421db6bd0bf253fb4bd25b31ebb98943c375e1
+        with:
+          arguments: "--continue --no-daemon -DforkEvery=1 -DmaxParallelForks=1 integrationTestN"
+
+  IntegrationTestsO:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        jdk: [11]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          java-version: ${{ matrix.jdk }}
+          distribution: 'microsoft'
+      - shell: bash
+        run: |
+          git remote set-head origin --auto
+          git remote add upstream https://github.com/linkedin/venice
+          git fetch upstream
+      - name: Validate Gradle wrapper
+        uses: gradle/wrapper-validation-action@e6e38bacfdf1a337459f332974bb2327a31aaf4b
+      - name: Build with Gradle
+        uses: gradle/gradle-build-action@67421db6bd0bf253fb4bd25b31ebb98943c375e1
+        with:
+          arguments: "--continue --no-daemon -DforkEvery=1 -DmaxParallelForks=1 integrationTestO"
+
+  IntegrationTestsP:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        jdk: [11]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          java-version: ${{ matrix.jdk }}
+          distribution: 'microsoft'
+      - shell: bash
+        run: |
+          git remote set-head origin --auto
+          git remote add upstream https://github.com/linkedin/venice
+          git fetch upstream
+      - name: Validate Gradle wrapper
+        uses: gradle/wrapper-validation-action@e6e38bacfdf1a337459f332974bb2327a31aaf4b
+      - name: Build with Gradle
+        uses: gradle/gradle-build-action@67421db6bd0bf253fb4bd25b31ebb98943c375e1
+        with:
+          arguments: "--continue --no-daemon -DforkEvery=1 -DmaxParallelForks=1 integrationTestP"
+
+  IntegrationTestsQ:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        jdk: [11]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          java-version: ${{ matrix.jdk }}
+          distribution: 'microsoft'
+      - shell: bash
+        run: |
+          git remote set-head origin --auto
+          git remote add upstream https://github.com/linkedin/venice
+          git fetch upstream
+      - name: Validate Gradle wrapper
+        uses: gradle/wrapper-validation-action@e6e38bacfdf1a337459f332974bb2327a31aaf4b
+      - name: Build with Gradle
+        uses: gradle/gradle-build-action@67421db6bd0bf253fb4bd25b31ebb98943c375e1
+        with:
+          arguments: "--continue --no-daemon -DforkEvery=1 -DmaxParallelForks=1 integrationTestQ"
+
+  IntegrationTestsZ:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        jdk: [11]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          java-version: ${{ matrix.jdk }}
+          distribution: 'microsoft'
+      - shell: bash
+        run: |
+          git remote set-head origin --auto
+          git remote add upstream https://github.com/linkedin/venice
+          git fetch upstream
+      - name: Validate Gradle wrapper
+        uses: gradle/wrapper-validation-action@e6e38bacfdf1a337459f332974bb2327a31aaf4b
+      - name: Build with Gradle
+        uses: gradle/gradle-build-action@67421db6bd0bf253fb4bd25b31ebb98943c375e1
+        with:
+          arguments: "--continue --no-daemon -DforkEvery=1 -DmaxParallelForks=1 integrationTestZ"
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,7 @@
 import com.github.spotbugs.snom.SpotBugsTask
 import org.apache.tools.ant.taskdefs.condition.Os
+import org.gradle.internal.logging.text.StyledTextOutputFactory
+import org.gradle.internal.logging.text.StyledTextOutput.Style
 
 plugins {
   id 'idea'
@@ -346,9 +348,21 @@ subprojects {
     }
 
     testLogging {
-      events 'started', 'passed', 'failed', 'skipped'
+      events 'started', 'failed', 'skipped' // N.B. we override how 'passed' tests are formatted in afterTest
       showStandardStreams = false // to mute the DDS Router's noisy behavior...
       exceptionFormat = 'full'
+    }
+
+    afterTest { descriptor, result ->
+      if (result.resultType == TestResult.ResultType.SUCCESS) {
+        def totalTime = result.endTime - result.startTime
+        def prettyTime = totalTime < 1000 ? "$totalTime ms" : "${totalTime / 1000} s"
+
+        def out = services.get(StyledTextOutputFactory).create("an-ouput")
+        out.style(Style.Normal).text("Gradle suite > Gradle test > $descriptor.className > $descriptor.displayName ")
+            .style(Style.Identifier).text("PASSED ")
+            .style(Style.Normal).println("($prettyTime)")
+      }
     }
   }
 
@@ -452,6 +466,10 @@ check.dependsOn(spotbugs)
 test {
   mustRunAfter spotbugs
   dependsOn subprojects.test
+  afterTest { descriptor, result ->
+    def totalTime = result.endTime - result.startTime
+    println "Total time of $descriptor.name was $totalTime"
+  }
 }
 
 assemble {

--- a/internal/venice-test-common/build.gradle
+++ b/internal/venice-test-common/build.gradle
@@ -1,3 +1,10 @@
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+import java.nio.file.StandardCopyOption
+import java.nio.file.StandardOpenOption
+
+
 configurations {
   all {
     resolutionStrategy {
@@ -86,10 +93,7 @@ task jmh(type: JavaExec, dependsOn: jmhClasses) {
   classpath = sourceSets.jmh.runtimeClasspath
 }
 
-task integrationTestA(type: Test) {
-  filter {
-    excludeTestsMatching "com.linkedin.venice.endToEnd.*"
-  }
+def integrationTestConfigs = {
   mustRunAfter test
   classpath = sourceSets.integrationTest.runtimeClasspath
   testClassesDirs = sourceSets.integrationTest.output.classesDirs
@@ -97,18 +101,135 @@ task integrationTestA(type: Test) {
   maxParallelForks = Integer.parseInt(project.properties.get('integrationTest.maxParallelForks', "$maxParallelForks"))
 }
 
-task integrationTestB(type: Test) {
-  filter {
-    includeTestsMatching "com.linkedin.venice.endToEnd.*"
+def integrationTestBuckets = [
+  "A": [
+      "com.linkedin.davinci.*",
+      "com.linkedin.venice.endToEnd.DaVinciClient*"],
+  "B": [
+      "com.linkedin.venice.endToEnd.DaVinciCluster*",
+      "com.linkedin.venice.endToEnd.DaVinciCompute*",
+      "com.linkedin.venice.endToEnd.DaVinciLive*"],
+  "C": [
+      "com.linkedin.venice.endToEnd.ActiveActive*"],
+  "D": [
+      "com.linkedin.venice.endToEnd.TestActiveActive*"],
+  "E": [
+      "com.linkedin.venice.helix.*",
+      "com.linkedin.venice.helixrebalance.*"],
+  "F": [
+      "com.linkedin.venice.server.*",
+      "com.linkedin.venice.storagenode.*",
+      "com.linkedin.venice.restart.*"],
+  "G": [
+      "com.linkedin.venice.router.*"],
+  "H": [
+      "com.linkedin.venice.fastclient.BatchGet*",
+      "com.linkedin.venice.fastclient.schema.*",
+      "com.linkedin.venice.fastclient.meta.*"],
+  "I": [
+      "com.linkedin.venice.fastclient.AvroStore*"],
+  "J": [
+      "com.linkedin.venice.hadoop.*",
+      "com.linkedin.venice.endToEnd.TestVson*",
+      "com.linkedin.venice.endToEnd.Push*"],
+  "K": [
+      "com.linkedin.venice.endToEnd.TestPushJob*"],
+  "L": [
+      "com.linkedin.venice.endToEnd.TestBatch*"],
+  "M": [
+      "com.linkedin.venice.kafka.*",
+      "com.linkedin.venice.samza.*",
+      "com.linkedin.venice.writer.*",
+      "com.linkedin.venice.endToEnd.PartialUpdateTest",
+      "com.linkedin.venice.endToEnd.TestWritePathComputation",
+      "com.linkedin.venice.endToEnd.WriteComputeWithActiveActiveReplicationTest"],
+  "N": [
+      "com.linkedin.venice.endToEnd.StoragePersona*",
+      "com.linkedin.venice.endToEnd.TestStoreUpdateStoragePersona",
+      "com.linkedin.venice.persona.*"],
+  "O": [
+      "com.linkedin.venice.endToEnd.TestHybrid*"],
+  "P": [
+      "com.linkedin.venice.controller.server.*",
+      "com.linkedin.venice.controller.kafka.consumer.*",
+      "com.linkedin.venice.controller.migration.*",
+      "com.linkedin.venice.controller.AdminTool*",
+      "com.linkedin.venice.controller.VeniceParentHelixAdminTest"],
+  "Q": [
+      "com.linkedin.venice.controller.Test*"]
+]
+
+integrationTestBuckets.each { name, patterns ->
+  task "integrationTest${name}" (type: Test) {
+    filter {
+      patterns.each { pattern ->
+        includeTestsMatching pattern
+      }
+    }
+    configure integrationTestConfigs
   }
-  mustRunAfter test
-  classpath = sourceSets.integrationTest.runtimeClasspath
-  testClassesDirs = sourceSets.integrationTest.output.classesDirs
-  forkEvery = Integer.parseInt(project.properties.get('integrationTest.forkEvery', "$forkEvery"))
-  maxParallelForks = Integer.parseInt(project.properties.get('integrationTest.maxParallelForks', "$maxParallelForks"))
 }
-check.dependsOn(integrationTestA)
-check.dependsOn(integrationTestB)
+
+task integrationTestZ(type: Test) {
+  filter {
+    integrationTestBuckets.each { name, patterns ->
+      patterns.each { pattern ->
+        excludeTestsMatching pattern
+      }
+    }
+  }
+  configure integrationTestConfigs
+}
+
+task generateGHCI() {
+  def targetDir = rootDir.getPath() + "/.github/rawWorkflows/"
+  def targetFile = new File(targetDir, "gh-ci.yml")
+  def targetFilePath = Paths.get(targetFile.getPath())
+
+  def paramFile = new File(targetDir, "gh-ci-parameterized-flow.txt")
+  def paramFilePath = Paths.get(paramFile.getPath())
+  def paramFileContent = new String(Files.readAllBytes(paramFilePath));
+
+  targetFile.delete()
+  targetFile.createNewFile()
+
+  Files.writeString(targetFilePath, "# Auto-generated file. Do not edit manually!\n#\n", StandardOpenOption.APPEND)
+  Files.writeString(targetFilePath, "# To alter these flows, edit:\n#\n#     internal/venice-test-common/build.gradle\n#\n", StandardOpenOption.APPEND)
+  Files.writeString(targetFilePath, "# To regenerate, run:\n#\n#     ./gradlew generateGHCI\n\n", StandardOpenOption.APPEND)
+
+  Files.writeString(targetFilePath, "name: VeniceCI\n\n", StandardOpenOption.APPEND)
+  Files.writeString(targetFilePath, "on: [push, pull_request]\n\n", StandardOpenOption.APPEND)
+  Files.writeString(targetFilePath, "jobs:\n", StandardOpenOption.APPEND)
+
+  def common = "--continue --no-daemon "
+  def staticAnalysisFlowGradleArgs = common + "-Pspotallbugs -Pspotbugs.xml -Pspotbugs.ignoreFailures clean check -x spotlessCheck -x test -x integrationTest"
+  appendToGHCI(paramFileContent, targetFilePath, "StaticAnalysis", 20, staticAnalysisFlowGradleArgs)
+  appendToGHCI(paramFileContent, targetFilePath, "UnitTestsAndCodeCoverage", 60, "jacocoTestCoverageVerification")
+  def integTestGradleArgs = common + "-DforkEvery=1 -DmaxParallelForks=1 integrationTest"
+  integrationTestBuckets.each { name, patterns ->
+    def flowName = "IntegrationTests" + name
+    appendToGHCI(paramFileContent, targetFilePath, flowName, 120, integTestGradleArgs + name)
+  }
+  appendToGHCI(paramFileContent, targetFilePath, "IntegrationTestsZ", 120, integTestGradleArgs + "Z")
+
+  def finalDestinationPath = Paths.get(rootDir.getPath() + "/.github/workflows/gh-ci.yml")
+  Files.move(targetFilePath, finalDestinationPath, StandardCopyOption.REPLACE_EXISTING)
+}
+
+def appendToGHCI(String paramFileContent, Path targetFilePath, String flowName, int timeOut, String gradleArguments) {
+  String postProcessing = paramFileContent
+      .replace("\$FlowName", flowName)
+      .replace("\$TimeOut", Integer.toString(timeOut))
+      .replace("\$GradleArguments", gradleArguments)
+
+  Files.writeString(targetFilePath, postProcessing, StandardOpenOption.APPEND)
+  Files.writeString(targetFilePath, "\n", StandardOpenOption.APPEND)
+}
+
+task integrationTest(type: Test) {
+  configure integrationTestConfigs
+}
+check.dependsOn(integrationTest)
 
 flakyTest {
   classpath += sourceSets.integrationTest.runtimeClasspath


### PR DESCRIPTION
The buckets are controlled by a map defined in:

internal/venice-test-common/build.gradle

The build can now also dynamically generate the GitHub CI workflow file according to the content of the build, by running:

./gradlew generateGHCI

This reduces the wall-clock time of the build to roughly half an hour.

## How was this PR tested?
Example run: https://github.com/FelixGV/venice/actions/runs/3877390120/usage

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.