### PR TITLE
[controller] Enforce default partition count for new inc push store

### DIFF
--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
@@ -47,6 +47,9 @@ import static com.linkedin.venice.controllerapi.ControllerApiConstants.STORE_MIG
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.TIME_LAG_TO_GO_ONLINE;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.VERSION;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.WRITE_COMPUTATION_ENABLED;
+import static com.linkedin.venice.meta.HybridStoreConfigImpl.DEFAULT_HYBRID_OFFSET_LAG_THRESHOLD;
+import static com.linkedin.venice.meta.HybridStoreConfigImpl.DEFAULT_HYBRID_TIME_LAG_THRESHOLD;
+import static com.linkedin.venice.meta.HybridStoreConfigImpl.DEFAULT_REWIND_TIME_IN_SECONDS;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -2370,21 +2373,26 @@ public class VeniceParentHelixAdmin implements Admin {
         hybridStoreConfigRecord.dataReplicationPolicy = hybridStoreConfig.getDataReplicationPolicy().getValue();
         hybridStoreConfigRecord.bufferReplayPolicy = hybridStoreConfig.getBufferReplayPolicy().getValue();
         setStore.hybridStoreConfig = hybridStoreConfigRecord;
-        if (!currStore.isHybrid() && setStore.partitionNum == 0) {
-          // This is a new hybrid store. Update store partition count from 0 to default value.
-          setStore.partitionNum = getVeniceHelixAdmin().getHelixVeniceClusterResources(clusterName)
-              .getConfig()
-              .getNumberOfPartitionForHybrid();
-          updatedConfigsList.add(PARTITION_COUNT);
-        }
       }
 
       if (incrementalPushEnabled.orElse(currStore.isIncrementalPushEnabled())
           && !veniceHelixAdmin.isHybrid(currStore.getHybridStoreConfig())
           && !veniceHelixAdmin.isHybrid(hybridStoreConfig)) {
         LOGGER.info(
-            "Enabling incremental push for a batch store:{} will convert it to a hybrid store with default configs.",
+            "Enabling incremental push for a batch store:{}. Converting it to a hybrid store with default configs.",
             storeName);
+        HybridStoreConfigRecord hybridStoreConfigRecord = new HybridStoreConfigRecord();
+        hybridStoreConfigRecord.rewindTimeInSeconds = DEFAULT_REWIND_TIME_IN_SECONDS;
+        updatedConfigsList.add(REWIND_TIME_IN_SECONDS);
+        hybridStoreConfigRecord.offsetLagThresholdToGoOnline = DEFAULT_HYBRID_OFFSET_LAG_THRESHOLD;
+        updatedConfigsList.add(OFFSET_LAG_TO_GO_ONLINE);
+        hybridStoreConfigRecord.producerTimestampLagThresholdToGoOnlineInSeconds = DEFAULT_HYBRID_TIME_LAG_THRESHOLD;
+        updatedConfigsList.add(TIME_LAG_TO_GO_ONLINE);
+        hybridStoreConfigRecord.dataReplicationPolicy = DataReplicationPolicy.NONE.getValue();
+        updatedConfigsList.add(DATA_REPLICATION_POLICY);
+        hybridStoreConfigRecord.bufferReplayPolicy = BufferReplayPolicy.REWIND_FROM_EOP.getValue();
+        updatedConfigsList.add(BUFFER_REPLAY_POLICY);
+        setStore.hybridStoreConfig = hybridStoreConfigRecord;
       }
 
       /**
@@ -2392,7 +2400,6 @@ public class VeniceParentHelixAdmin implements Admin {
        * do append-only and compaction will happen later.
        * We expose actual disk usage to users, instead of multiplying/dividing the overhead ratio by situations.
        */
-
       setStore.storageQuotaInByte =
           storageQuotaInByte.map(addToUpdatedConfigList(updatedConfigsList, STORAGE_QUOTA_IN_BYTE))
               .orElseGet(currStore::getStorageQuotaInByte);
@@ -2540,6 +2547,19 @@ public class VeniceParentHelixAdmin implements Admin {
         // Dry-run generating Write Compute schemas before sending admin messages to enable Write Compute because Write
         // Compute schema generation may fail due to some reasons. If that happens, abort the store update process.
         addWriteComputeSchemaForStore(clusterName, storeName, true);
+      }
+
+      if (!veniceHelixAdmin.isHybrid(currStore.getHybridStoreConfig())
+          && veniceHelixAdmin.isHybrid(setStore.hybridStoreConfig) && setStore.partitionNum == 0) {
+        // This is a new hybrid store and partition count is not specified. Use default hybrid store partition count.
+        setStore.partitionNum = getVeniceHelixAdmin().getHelixVeniceClusterResources(clusterName)
+            .getConfig()
+            .getNumberOfPartitionForHybrid();
+        LOGGER.info(
+            "Enforcing default hybrid partition count:{} for a new hybrid store:{}.",
+            setStore.partitionNum,
+            storeName);
+        updatedConfigsList.add(PARTITION_COUNT);
       }
 
       AdminOperation message = new AdminOperation();


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci], [server], [controller],
[router], [samza], [vpj], [fast-client], [thin-client], [alpini],
[admin-tool], [test], [build], [doc], [script]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Summary
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Previous commit 4bb6c9115 enforces partition count when a store is converted to hybrid by providing hybrid configs. But it does not enforce partition count for another implicit hybrid conversion: when a store enables inc push, the store will be converted to hybrid.

The commit moves inc push store hybrid conversion logic to parent controller. It also moves partition count enforcement logic right before parent controller sending update_store admin message. As long as the store is converted to hybrid through parent controller update store and partition count is not specified, store partition count will be set to the value of default.partition.count.for.hybrid config.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
testUpdateStore
CI

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.