### PR TITLE
[controller] Update system store read/write check to follow the ZK shared store

### DIFF
--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/SystemStore.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/SystemStore.java
@@ -217,35 +217,31 @@ public class SystemStore extends AbstractStore {
   }
 
   /**
-   * This function is used to check the precondition for store deletion.
-   * Since the system store should deleted together with the corresponding regular Venice store, so
-   * this function will delegate the call to the regular Venice store.
-   * @return
+   * System stores are the internal stores, and even the corresponding user store is not writable, and the
+   * internal system stores could be writable, which is controlled by the {@link #zkSharedStore}.
    */
   @Override
   public boolean isEnableWrites() {
-    return veniceStore.isEnableWrites();
+    return zkSharedStore.isEnableWrites();
   }
 
   @Override
   public void setEnableWrites(boolean enableWrites) {
-    // do nothing since it will follow the regular Venice store.
+    // do nothing since it will follow the ZK shared Venice store.
   }
 
   /**
-   * This function is used to check the precondition for store deletion.
-   * Since the system store should deleted together with the corresponding regular Venice store, so
-   * this function will delegate the call to the regular Venice store.
-   * @return
+   * System stores are the internal stores, and even the corresponding user store is not readable, and the
+   * internal system stores could be readable, which is controlled by the {@link #zkSharedStore}.
    */
   @Override
   public boolean isEnableReads() {
-    return veniceStore.isEnableReads();
+    return zkSharedStore.isEnableReads();
   }
 
   @Override
   public void setEnableReads(boolean enableReads) {
-    // Do nothing since it will follow the regular Venice store
+    // Do nothing since it will follow the ZK shared Venice store
   }
 
   @Override

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -1564,6 +1564,13 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
     if (store == null) {
       throwStoreDoesNotExist(clusterName, storeName);
     }
+    if (VeniceSystemStoreUtils.isUserSystemStore(storeName)) {
+      /**
+       * For system stores, such as meta system store/DaVinci push status system store, they
+       * can be managed separately from the corresponding user stores.
+       */
+      return;
+    }
     if (store.isEnableReads() || store.isEnableWrites()) {
       String errorMsg = "Unable to delete the entire store or versions for store: " + storeName
           + ". Store has not been disabled. Both read and write need to be disabled before deleting.";


### PR DESCRIPTION
## Summary
The system stores can be updated even the user's store is disabled. For example, meta system store needs to be updated whenever there is a store config change or replica rebalance, and DaVinci push status system store still needs to take write from DaVinci or incremental push jobs.
System stores are for internal use and it won't affect the user store behavior.

<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci], [server], [controller],
[router], [samza], [vpj], [fast-client], [thin-client], [alpini],
[admin-tool], [test], [build], [doc], [script]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->


<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->


## How was this PR tested?
Internal CI passed.
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.