### PR TITLE
[server] Cache RT offset lag for lag metric

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
@@ -1220,7 +1220,7 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
         for (String sourceRealTimeTopicKafkaURL: sourceRealTimeTopicKafkaURLs) {
           try {
             // Return true if offset lag in any reachable region is larger than the threshold
-            if (measureRTOffsetLagForSingleRegion(sourceRealTimeTopicKafkaURL, pcs, false) > offsetLagThreshold) {
+            if (pcs.getRegionRTOffsetLagFromCache(sourceRealTimeTopicKafkaURL) > offsetLagThreshold) {
               return true;
             }
           } catch (Exception e) {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -3021,18 +3021,4 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
   protected Lazy<VeniceWriter<byte[], byte[], byte[]>> getVeniceWriter() {
     return veniceWriter;
   }
-
-  @Override
-  protected void maybeUpdateRegionRTOffsetLagCacheAfterReadyToServe(
-      PartitionConsumptionState partitionConsumptionState) {
-    long currTimestamp = System.currentTimeMillis();
-    if ((currTimestamp - partitionConsumptionState.getLatestRTOffsetLagCacheUpdateTimestamp()) > MINUTES.toMillis(1)) {
-      for (String sourceRealTimeTopicKafkaURL: getRealTimeDataSourceKafkaAddress(partitionConsumptionState)) {
-        partitionConsumptionState.updateRegionRTOffsetLagCache(
-            sourceRealTimeTopicKafkaURL,
-            measureRTOffsetLagForSingleRegion(sourceRealTimeTopicKafkaURL, partitionConsumptionState, false));
-      }
-      partitionConsumptionState.setLatestRTOffsetLagCacheUpdateTimestamp(currTimestamp);
-    }
-  }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/PartitionConsumptionState.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/PartitionConsumptionState.java
@@ -157,6 +157,10 @@ public class PartitionConsumptionState {
    */
   private Map<String, Long> latestProcessedUpstreamRTOffsetMap;
 
+  private Map<String, Long> rtRegionOffsetLagCacheMap;
+
+  private long latestRTOffsetLagCacheUpdateTimestamp = -1;
+
   public PartitionConsumptionState(int partition, int amplificationFactor, OffsetRecord offsetRecord, boolean hybrid) {
     this.partition = partition;
     this.amplificationFactor = amplificationFactor;
@@ -186,6 +190,7 @@ public class PartitionConsumptionState {
     // checkpoint upstream offset map
     consumedUpstreamRTOffsetMap = new VeniceConcurrentHashMap<>();
     latestProcessedUpstreamRTOffsetMap = new VeniceConcurrentHashMap<>();
+    rtRegionOffsetLagCacheMap = new VeniceConcurrentHashMap<>();
     if (offsetRecord.getLeaderTopic() != null && Version.isRealTimeTopic(offsetRecord.getLeaderTopic())) {
       offsetRecord.cloneUpstreamOffsetMap(consumedUpstreamRTOffsetMap);
       offsetRecord.cloneUpstreamOffsetMap(latestProcessedUpstreamRTOffsetMap);
@@ -557,6 +562,22 @@ public class PartitionConsumptionState {
     public int getValueSchemaId() {
       return valueSchemaId;
     }
+  }
+
+  public void setLatestRTOffsetLagCacheUpdateTimestamp(long updateTimestamp) {
+    latestRTOffsetLagCacheUpdateTimestamp = updateTimestamp;
+  }
+
+  public long getLatestRTOffsetLagCacheUpdateTimestamp() {
+    return latestRTOffsetLagCacheUpdateTimestamp;
+  }
+
+  public void updateRegionRTOffsetLagCache(String kafkaUrl, long lag) {
+    rtRegionOffsetLagCacheMap.put(kafkaUrl, lag);
+  }
+
+  public long getRegionRTOffsetLagFromCache(String kafkaUrl) {
+    return rtRegionOffsetLagCacheMap.getOrDefault(kafkaUrl, Long.MAX_VALUE);
   }
 
   public void updateLeaderConsumedUpstreamRTOffset(String kafkaUrl, long offset) {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -3569,6 +3569,9 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
         } else {
           statusReportAdapter.reportProgress(partitionConsumptionState);
         }
+      } else if (partitionConsumptionState.isComplete() && partitionConsumptionState.isHybrid()) {
+        // Periodically update RT offset lag cache so RT offset metrics can be kept updated after ready-to-serve state.
+        maybeUpdateRegionRTOffsetLagCacheAfterReadyToServe(partitionConsumptionState);
       }
     };
   }
@@ -3800,4 +3803,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
     KafkaMessageEnvelope kafkaValue = consumerRecord.value();
     return kafkaValue.leaderMetadataFooter != null && kafkaValue.leaderMetadataFooter.upstreamOffset >= 0;
   }
+
+  protected abstract void maybeUpdateRegionRTOffsetLagCacheAfterReadyToServe(
+      PartitionConsumptionState partitionConsumptionState);
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -3571,7 +3571,9 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
         }
       } else if (partitionConsumptionState.isComplete() && partitionConsumptionState.isHybrid()) {
         // Periodically update RT offset lag cache so RT offset metrics can be kept updated after ready-to-serve state.
-        maybeUpdateRegionRTOffsetLagCacheAfterReadyToServe(partitionConsumptionState);
+        partitionConsumptionState.maybeUpdateRegionRTOffsetLagCacheAfterReadyToServe(
+            getRealTimeDataSourceKafkaAddress(partitionConsumptionState),
+            kafkaUrl -> measureRTOffsetLagForSingleRegion(kafkaUrl, partitionConsumptionState, false));
       }
     };
   }
@@ -3804,6 +3806,8 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
     return kafkaValue.leaderMetadataFooter != null && kafkaValue.leaderMetadataFooter.upstreamOffset >= 0;
   }
 
-  protected abstract void maybeUpdateRegionRTOffsetLagCacheAfterReadyToServe(
-      PartitionConsumptionState partitionConsumptionState);
+  protected abstract long measureRTOffsetLagForSingleRegion(
+      String sourceRealTimeTopicKafkaURL,
+      PartitionConsumptionState partitionConsumptionState,
+      boolean shouldLogLag);
 }


### PR DESCRIPTION
## [server] Cache RT offset lag for lag metric
ready_to_serve_with_rt_lag metrics will try to evaluate RT offset lag between latest persisted offset and RT topic end offset. The call to fetch RT topic end offset is expensive and can lead to slow down of the overall metrics retrieval and results in metrics not displayed correctly on InGraph dashboard.

To solve this issue, this PR proposes to build a region level lag cache map in the PartitionConsumptionState for metrics computation so it won't be slow down.

Before ready to serve is announced, each RT message consumption will trigger lag measurement, so it will also update the cache. After ready to serve is announced, we will periodically meausre RT offset lag in all regions and update the cache so metrics will still be able to get the updated view.

There is an edge case to be solved here: If the RT does not has new messages to be consumed after a certain period, then the after ready-to-serve call path will not be triggered, and the lag might not become zero even if we consume the last batch of data from RT in the last 1 minute period.

## How was this PR tested?
Internal CI

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.