### PR TITLE
[server] Main process should throw exception when isolated ingestion process throws exception during the ingestion

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/isolated/IsolatedIngestionServerHandler.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/isolated/IsolatedIngestionServerHandler.java
@@ -246,6 +246,7 @@ public class IsolatedIngestionServerHandler extends SimpleChannelInboundHandler<
     } catch (Exception e) {
       LOGGER.error("Encounter exception while handling ingestion command", e);
       report.isPositive = false;
+      report.exceptionThrown = true;
       report.message = e.getClass().getSimpleName() + "_"
           + ExceptionUtils.compactExceptionDescription(e, "handleIngestionTaskCommand");
     }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/main/MainIngestionRequestClient.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/main/MainIngestionRequestClient.java
@@ -274,6 +274,11 @@ public class MainIngestionRequestClient implements Closeable {
     } catch (Exception e) {
       throw new VeniceException("Caught exception when sending command: " + commandType + commandInfo, e);
     }
+    if (report != null && report.exceptionThrown) {
+      throw new VeniceException(
+          "Caught exception when executing command in isolated process: " + commandType + commandInfo + " "
+              + report.message);
+    }
     return report != null && report.isPositive;
   }
 

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/ingestion/main/TestMainIngestionRequestClient.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/ingestion/main/TestMainIngestionRequestClient.java
@@ -1,0 +1,41 @@
+package com.linkedin.davinci.ingestion.main;
+
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyInt;
+import static org.mockito.Mockito.when;
+
+import com.linkedin.davinci.ingestion.HttpClientTransport;
+import com.linkedin.venice.ingestion.protocol.IngestionTaskReport;
+import java.util.Optional;
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class TestMainIngestionRequestClient {
+  @Test
+  public void testMainIngestionRequestClientProcessIngestionResult() {
+    String topicName = "testTopic";
+    int partitionId = 1;
+
+    try (
+        MainIngestionRequestClient ingestionRequestClient =
+            new MainIngestionRequestClient(Optional.empty(), 12345, 120);
+        HttpClientTransport mockTransport = Mockito.mock(HttpClientTransport.class)) {
+      // Client should throw exception when connection is bad.
+      Assert.assertThrows(() -> ingestionRequestClient.startConsumption(topicName, partitionId));
+      // Client should throw exception when isolated process throws exception during execution.
+      IngestionTaskReport reportWithExceptionThrow = new IngestionTaskReport();
+      reportWithExceptionThrow.isPositive = false;
+      reportWithExceptionThrow.exceptionThrown = true;
+      when(mockTransport.sendRequestWithRetry(any(), any(), anyInt())).thenReturn(reportWithExceptionThrow);
+      ingestionRequestClient.setHttpClientTransport(mockTransport);
+      Assert.assertThrows(() -> ingestionRequestClient.startConsumption(topicName, partitionId));
+      // Client should return false when isolated process rejects command execution.
+      IngestionTaskReport reportWithNegativeResponse = new IngestionTaskReport();
+      reportWithNegativeResponse.isPositive = false;
+      when(mockTransport.sendRequestWithRetry(any(), any(), anyInt())).thenReturn(reportWithNegativeResponse);
+      Assert.assertFalse(ingestionRequestClient.startConsumption(topicName, partitionId));
+    }
+  }
+}

--- a/internal/venice-common/src/main/resources/avro/IngestionTaskReport/v1/IngestionTaskReport.avsc
+++ b/internal/venice-common/src/main/resources/avro/IngestionTaskReport/v1/IngestionTaskReport.avsc
@@ -22,6 +22,11 @@
       "default": true
     },
     {
+      "name": "exceptionThrown",
+      "type": "boolean",
+      "default": false
+    },
+    {
       "name": "reportType",
       "doc": "0 => Completed, 1=> Errored, 2 => Started, 3 => Restarted, 4 => Progress, 5 => EndOfPushReceived, 6 => StartOfBufferReplayReceived, 7 => StartOfIncrementalPushReceived, 8 => EndOfIncrementalPushReceived, 9 => TopicSwitchReceived",
       "type": "int"


### PR DESCRIPTION


## [server] Main process should throw exception when isolated ingestion process throws exception during the ingestion
During the rollout of isolated ingestion we found that IsolatedIngestionBackend swallows the exception thrown in isolated ingestion process during ingestion. This does not align with the non-II behavior and will let server stuck in infinitive retry when there is a zombie resource in Helix that does not exist in ZK. When zombie resources exists, start consumption should throw exception after timeout as it could not locate the store version in the store repo. 

This PR fixes it by adding a new state in ingestion task report to declare there is exception thrown during the action and main process should also throw it.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
Internel CI
Add new unit tests to cover the case.

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.