### PR TITLE
[server] Async update CachedKafkaMetadataGetter to avoid metric fetch slowdown

### DIFF
--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/CachedKafkaMetadataGetterTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/CachedKafkaMetadataGetterTest.java
@@ -1,0 +1,60 @@
+package com.linkedin.davinci.kafka.consumer;
+
+import com.linkedin.venice.exceptions.VeniceException;
+import com.linkedin.venice.kafka.TopicDoesNotExistException;
+import com.linkedin.venice.utils.TestUtils;
+import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class CachedKafkaMetadataGetterTest {
+  @Test
+  public void testCacheWillResetStatusWhenExceptionIsThrown() {
+    CachedKafkaMetadataGetter cachedKafkaMetadataGetter = new CachedKafkaMetadataGetter(1000);
+    CachedKafkaMetadataGetter.KafkaMetadataCacheKey key =
+        new CachedKafkaMetadataGetter.KafkaMetadataCacheKey("server", "topic", 1);
+    Map<CachedKafkaMetadataGetter.KafkaMetadataCacheKey, CachedKafkaMetadataGetter.ValueAndExpiryTime<Long>> offsetCache =
+        new VeniceConcurrentHashMap<>();
+    CachedKafkaMetadataGetter.ValueAndExpiryTime<Long> valueCache =
+        new CachedKafkaMetadataGetter.ValueAndExpiryTime<>(1L, System.nanoTime());
+    offsetCache.put(key, valueCache);
+    // Successful call will update the value from 1 to 2.
+    TestUtils.waitForNonDeterministicAssertion(5, TimeUnit.SECONDS, () -> {
+      Long actualResult = cachedKafkaMetadataGetter.fetchMetadata(key, offsetCache, () -> 2L);
+      Long expectedResult = 2L;
+      Assert.assertEquals(actualResult, expectedResult);
+    });
+
+    // TopicDoesNotExistException is caught and thrown.
+    TestUtils.waitForNonDeterministicAssertion(5, TimeUnit.SECONDS, () -> {
+      Assert.assertThrows(
+          TopicDoesNotExistException.class,
+          () -> cachedKafkaMetadataGetter.fetchMetadata(key, offsetCache, () -> {
+            throw new TopicDoesNotExistException("dummy exception");
+          }));
+    });
+
+    // TopicDoesNotExistException flag is cleaned up and other types of exception won't be thrown.
+    long initialExpiredTime = offsetCache.get(key).getExpiryTimeNs();
+    TestUtils.waitForNonDeterministicAssertion(5, TimeUnit.SECONDS, () -> {
+      Long actualResult = cachedKafkaMetadataGetter.fetchMetadata(key, offsetCache, () -> {
+        throw new VeniceException("do not throw this exception!");
+      });
+      Long expectedResult = 2L;
+      Assert.assertEquals(expectedResult, actualResult);
+    });
+    // Value is not updated at all.
+    Assert.assertEquals(offsetCache.get(key).getExpiryTimeNs(), initialExpiredTime);
+
+    // Successful call will update the value from 2 to 3.
+    TestUtils.waitForNonDeterministicAssertion(5, TimeUnit.SECONDS, () -> {
+      Long actualResult = cachedKafkaMetadataGetter.fetchMetadata(key, offsetCache, () -> 3L);
+      Long expectedResult = 3L;
+      Assert.assertEquals(actualResult, expectedResult);
+    });
+
+  }
+}

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/CachedKafkaMetadataGetterTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/CachedKafkaMetadataGetterTest.java
@@ -1,7 +1,6 @@
 package com.linkedin.davinci.kafka.consumer;
 
 import com.linkedin.venice.exceptions.VeniceException;
-import com.linkedin.venice.kafka.TopicDoesNotExistException;
 import com.linkedin.venice.utils.TestUtils;
 import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
 import java.util.Map;
@@ -29,13 +28,11 @@ public class CachedKafkaMetadataGetterTest {
       Assert.assertEquals(actualResult, expectedResult);
     });
 
-    // TopicDoesNotExistException is caught and thrown.
+    // For persisting exception, it will be caught and thrown.
     TestUtils.waitForNonDeterministicAssertion(5, TimeUnit.SECONDS, () -> {
-      Assert.assertThrows(
-          TopicDoesNotExistException.class,
-          () -> cachedKafkaMetadataGetter.fetchMetadata(key, offsetCache, () -> {
-            throw new TopicDoesNotExistException("dummy exception");
-          }));
+      Assert.assertThrows(VeniceException.class, () -> cachedKafkaMetadataGetter.fetchMetadata(key, offsetCache, () -> {
+        throw new VeniceException("dummy exception");
+      }));
     });
 
     // Reset the cached value to 1.
@@ -54,7 +51,6 @@ public class CachedKafkaMetadataGetterTest {
       });
       Long expectedResult = 2L;
       Assert.assertEquals(actualResult, expectedResult);
-      Assert.assertNull(offsetCache.get(key).getException());
     });
   }
 }


### PR DESCRIPTION
## [server] Async update CachedKafkaMetadataGetter to avoid metric fetch slowdown
This PR makes CachedKafkaMetadataGetter value update logic async so metric call to fetch the offset won't be slowdown due to slowness in Kafka metadata fetching.
This PR will issue async call to update value when it found the cached value TTL has expired. All the call to fetch the value will return immediately except the very first call, when the cache is empty.

## How was this PR tested?
TEST NOT ADDED, will added after main logic acknowledged.

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.