### PR TITLE
[build] make Github CI all depend on a dummy task

### DIFF
--- a/.github/rawWorkflows/gh-ci-parameterized-flow.txt
+++ b/.github/rawWorkflows/gh-ci-parameterized-flow.txt
@@ -5,6 +5,7 @@
         os: [ubuntu-latest]
         jdk: [11]
     runs-on: ${{ matrix.os }}
+    needs: $Dependency
     timeout-minutes: $TimeOut
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/gh-ci.yml
+++ b/.github/workflows/gh-ci.yml
@@ -20,7 +20,6 @@ jobs:
         os: [ubuntu-latest]
         jdk: [11]
     runs-on: ${{ matrix.os }}
-    needs: 
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v3
@@ -50,7 +49,6 @@ jobs:
         os: [ubuntu-latest]
         jdk: [11]
     runs-on: ${{ matrix.os }}
-    needs: 
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v3
@@ -80,7 +78,6 @@ jobs:
         os: [ubuntu-latest]
         jdk: [11]
     runs-on: ${{ matrix.os }}
-    needs: 
     timeout-minutes: 120
     steps:
       - uses: actions/checkout@v3
@@ -110,7 +107,6 @@ jobs:
         os: [ubuntu-latest]
         jdk: [11]
     runs-on: ${{ matrix.os }}
-    needs: 
     timeout-minutes: 120
     steps:
       - uses: actions/checkout@v3
@@ -140,7 +136,6 @@ jobs:
         os: [ubuntu-latest]
         jdk: [11]
     runs-on: ${{ matrix.os }}
-    needs: 
     timeout-minutes: 120
     steps:
       - uses: actions/checkout@v3
@@ -170,7 +165,6 @@ jobs:
         os: [ubuntu-latest]
         jdk: [11]
     runs-on: ${{ matrix.os }}
-    needs: 
     timeout-minutes: 120
     steps:
       - uses: actions/checkout@v3
@@ -200,7 +194,6 @@ jobs:
         os: [ubuntu-latest]
         jdk: [11]
     runs-on: ${{ matrix.os }}
-    needs: 
     timeout-minutes: 120
     steps:
       - uses: actions/checkout@v3
@@ -230,7 +223,6 @@ jobs:
         os: [ubuntu-latest]
         jdk: [11]
     runs-on: ${{ matrix.os }}
-    needs: 
     timeout-minutes: 120
     steps:
       - uses: actions/checkout@v3
@@ -260,7 +252,6 @@ jobs:
         os: [ubuntu-latest]
         jdk: [11]
     runs-on: ${{ matrix.os }}
-    needs: 
     timeout-minutes: 120
     steps:
       - uses: actions/checkout@v3
@@ -290,7 +281,6 @@ jobs:
         os: [ubuntu-latest]
         jdk: [11]
     runs-on: ${{ matrix.os }}
-    needs: 
     timeout-minutes: 120
     steps:
       - uses: actions/checkout@v3
@@ -320,7 +310,6 @@ jobs:
         os: [ubuntu-latest]
         jdk: [11]
     runs-on: ${{ matrix.os }}
-    needs: 
     timeout-minutes: 120
     steps:
       - uses: actions/checkout@v3
@@ -350,7 +339,6 @@ jobs:
         os: [ubuntu-latest]
         jdk: [11]
     runs-on: ${{ matrix.os }}
-    needs: 
     timeout-minutes: 120
     steps:
       - uses: actions/checkout@v3
@@ -380,7 +368,6 @@ jobs:
         os: [ubuntu-latest]
         jdk: [11]
     runs-on: ${{ matrix.os }}
-    needs: 
     timeout-minutes: 120
     steps:
       - uses: actions/checkout@v3
@@ -410,7 +397,6 @@ jobs:
         os: [ubuntu-latest]
         jdk: [11]
     runs-on: ${{ matrix.os }}
-    needs: 
     timeout-minutes: 120
     steps:
       - uses: actions/checkout@v3
@@ -440,7 +426,6 @@ jobs:
         os: [ubuntu-latest]
         jdk: [11]
     runs-on: ${{ matrix.os }}
-    needs: 
     timeout-minutes: 120
     steps:
       - uses: actions/checkout@v3
@@ -470,7 +455,6 @@ jobs:
         os: [ubuntu-latest]
         jdk: [11]
     runs-on: ${{ matrix.os }}
-    needs: 
     timeout-minutes: 120
     steps:
       - uses: actions/checkout@v3
@@ -500,7 +484,6 @@ jobs:
         os: [ubuntu-latest]
         jdk: [11]
     runs-on: ${{ matrix.os }}
-    needs: 
     timeout-minutes: 120
     steps:
       - uses: actions/checkout@v3
@@ -530,7 +513,6 @@ jobs:
         os: [ubuntu-latest]
         jdk: [11]
     runs-on: ${{ matrix.os }}
-    needs: 
     timeout-minutes: 120
     steps:
       - uses: actions/checkout@v3
@@ -560,7 +542,6 @@ jobs:
         os: [ubuntu-latest]
         jdk: [11]
     runs-on: ${{ matrix.os }}
-    needs: 
     timeout-minutes: 120
     steps:
       - uses: actions/checkout@v3
@@ -590,7 +571,6 @@ jobs:
         os: [ubuntu-latest]
         jdk: [11]
     runs-on: ${{ matrix.os }}
-    needs: 
     timeout-minutes: 120
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/gh-ci.yml
+++ b/.github/workflows/gh-ci.yml
@@ -20,6 +20,7 @@ jobs:
         os: [ubuntu-latest]
         jdk: [11]
     runs-on: ${{ matrix.os }}
+    needs: 
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v3
@@ -49,6 +50,7 @@ jobs:
         os: [ubuntu-latest]
         jdk: [11]
     runs-on: ${{ matrix.os }}
+    needs: 
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v3
@@ -78,6 +80,7 @@ jobs:
         os: [ubuntu-latest]
         jdk: [11]
     runs-on: ${{ matrix.os }}
+    needs: 
     timeout-minutes: 120
     steps:
       - uses: actions/checkout@v3
@@ -107,6 +110,7 @@ jobs:
         os: [ubuntu-latest]
         jdk: [11]
     runs-on: ${{ matrix.os }}
+    needs: 
     timeout-minutes: 120
     steps:
       - uses: actions/checkout@v3
@@ -136,6 +140,7 @@ jobs:
         os: [ubuntu-latest]
         jdk: [11]
     runs-on: ${{ matrix.os }}
+    needs: 
     timeout-minutes: 120
     steps:
       - uses: actions/checkout@v3
@@ -165,6 +170,7 @@ jobs:
         os: [ubuntu-latest]
         jdk: [11]
     runs-on: ${{ matrix.os }}
+    needs: 
     timeout-minutes: 120
     steps:
       - uses: actions/checkout@v3
@@ -194,6 +200,7 @@ jobs:
         os: [ubuntu-latest]
         jdk: [11]
     runs-on: ${{ matrix.os }}
+    needs: 
     timeout-minutes: 120
     steps:
       - uses: actions/checkout@v3
@@ -223,6 +230,7 @@ jobs:
         os: [ubuntu-latest]
         jdk: [11]
     runs-on: ${{ matrix.os }}
+    needs: 
     timeout-minutes: 120
     steps:
       - uses: actions/checkout@v3
@@ -252,6 +260,7 @@ jobs:
         os: [ubuntu-latest]
         jdk: [11]
     runs-on: ${{ matrix.os }}
+    needs: 
     timeout-minutes: 120
     steps:
       - uses: actions/checkout@v3
@@ -281,6 +290,7 @@ jobs:
         os: [ubuntu-latest]
         jdk: [11]
     runs-on: ${{ matrix.os }}
+    needs: 
     timeout-minutes: 120
     steps:
       - uses: actions/checkout@v3
@@ -310,6 +320,7 @@ jobs:
         os: [ubuntu-latest]
         jdk: [11]
     runs-on: ${{ matrix.os }}
+    needs: 
     timeout-minutes: 120
     steps:
       - uses: actions/checkout@v3
@@ -339,6 +350,7 @@ jobs:
         os: [ubuntu-latest]
         jdk: [11]
     runs-on: ${{ matrix.os }}
+    needs: 
     timeout-minutes: 120
     steps:
       - uses: actions/checkout@v3
@@ -368,6 +380,7 @@ jobs:
         os: [ubuntu-latest]
         jdk: [11]
     runs-on: ${{ matrix.os }}
+    needs: 
     timeout-minutes: 120
     steps:
       - uses: actions/checkout@v3
@@ -397,6 +410,7 @@ jobs:
         os: [ubuntu-latest]
         jdk: [11]
     runs-on: ${{ matrix.os }}
+    needs: 
     timeout-minutes: 120
     steps:
       - uses: actions/checkout@v3
@@ -426,6 +440,7 @@ jobs:
         os: [ubuntu-latest]
         jdk: [11]
     runs-on: ${{ matrix.os }}
+    needs: 
     timeout-minutes: 120
     steps:
       - uses: actions/checkout@v3
@@ -455,6 +470,7 @@ jobs:
         os: [ubuntu-latest]
         jdk: [11]
     runs-on: ${{ matrix.os }}
+    needs: 
     timeout-minutes: 120
     steps:
       - uses: actions/checkout@v3
@@ -484,6 +500,7 @@ jobs:
         os: [ubuntu-latest]
         jdk: [11]
     runs-on: ${{ matrix.os }}
+    needs: 
     timeout-minutes: 120
     steps:
       - uses: actions/checkout@v3
@@ -513,6 +530,7 @@ jobs:
         os: [ubuntu-latest]
         jdk: [11]
     runs-on: ${{ matrix.os }}
+    needs: 
     timeout-minutes: 120
     steps:
       - uses: actions/checkout@v3
@@ -542,6 +560,7 @@ jobs:
         os: [ubuntu-latest]
         jdk: [11]
     runs-on: ${{ matrix.os }}
+    needs: 
     timeout-minutes: 120
     steps:
       - uses: actions/checkout@v3
@@ -571,6 +590,7 @@ jobs:
         os: [ubuntu-latest]
         jdk: [11]
     runs-on: ${{ matrix.os }}
+    needs: 
     timeout-minutes: 120
     steps:
       - uses: actions/checkout@v3
@@ -592,4 +612,34 @@ jobs:
         uses: gradle/gradle-build-action@67421db6bd0bf253fb4bd25b31ebb98943c375e1
         with:
           arguments: "--continue --no-daemon -DforkEvery=1 -DmaxParallelForks=1 integrationTestZ"
+
+  DummyStep:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        jdk: [11]
+    runs-on: ${{ matrix.os }}
+    needs: [StaticAnalysis, UnitTestsAndCodeCoverage, IntegrationTestsA, IntegrationTestsB, IntegrationTestsC, IntegrationTestsD, IntegrationTestsE, IntegrationTestsF, IntegrationTestsG, IntegrationTestsH, IntegrationTestsI, IntegrationTestsJ, IntegrationTestsK, IntegrationTestsL, IntegrationTestsM, IntegrationTestsN, IntegrationTestsO, IntegrationTestsP, IntegrationTestsQ, IntegrationTestsZ]
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          java-version: ${{ matrix.jdk }}
+          distribution: 'microsoft'
+      - shell: bash
+        run: |
+          git remote set-head origin --auto
+          git remote add upstream https://github.com/linkedin/venice
+          git fetch upstream
+      - name: Validate Gradle wrapper
+        uses: gradle/wrapper-validation-action@e6e38bacfdf1a337459f332974bb2327a31aaf4b
+      - name: Build with Gradle
+        uses: gradle/gradle-build-action@67421db6bd0bf253fb4bd25b31ebb98943c375e1
+        with:
+          arguments: "clean"
 

--- a/internal/venice-test-common/build.gradle
+++ b/internal/venice-test-common/build.gradle
@@ -201,26 +201,41 @@ task generateGHCI() {
   append(targetFilePath, "on: [push, pull_request]\n\n")
   append(targetFilePath, "jobs:\n")
 
+  def jobs = []
+
   def common = "--continue --no-daemon "
   def staticAnalysisFlowGradleArgs = common + "-Pspotallbugs -Pspotbugs.xml -Pspotbugs.ignoreFailures clean check -x spotlessCheck -x test -x integrationTest"
-  appendToGHCI(paramFileContent, targetFilePath, "StaticAnalysis", 20, staticAnalysisFlowGradleArgs)
-  appendToGHCI(paramFileContent, targetFilePath, "UnitTestsAndCodeCoverage", 60, "jacocoTestCoverageVerification")
+
+  def staticAnalysis = "StaticAnalysis"
+  appendToGHCI(paramFileContent, targetFilePath, staticAnalysis, 20, staticAnalysisFlowGradleArgs)
+  jobs << staticAnalysis
+  def unitTestsAndCodeCoverage = "UnitTestsAndCodeCoverage"
+  appendToGHCI(paramFileContent, targetFilePath, unitTestsAndCodeCoverage, 60, "jacocoTestCoverageVerification")
+  jobs << unitTestsAndCodeCoverage
+
   def integTestGradleArgs = common + "-DforkEvery=1 -DmaxParallelForks=1 integrationTest"
   integrationTestBuckets.each { name, patterns ->
     def flowName = "IntegrationTests" + name
+    jobs << flowName
     appendToGHCI(paramFileContent, targetFilePath, flowName, 120, integTestGradleArgs + name)
   }
-  appendToGHCI(paramFileContent, targetFilePath, "IntegrationTestsZ", 120, integTestGradleArgs + "Z")
+  def otherTest = "IntegrationTestsZ"
+  appendToGHCI(paramFileContent, targetFilePath, otherTest, 120, integTestGradleArgs + "Z")
+  jobs << otherTest
+
+  // define a job that depends others but does nothing to manage the status check
+  appendToGHCI(paramFileContent, targetFilePath, "DummyStep", 120, "clean", jobs)
 
   def finalDestinationPath = Paths.get(rootDir.getPath() + "/.github/workflows/gh-ci.yml")
   Files.move(targetFilePath, finalDestinationPath, StandardCopyOption.REPLACE_EXISTING)
 }
 
-def appendToGHCI(String paramFileContent, Path targetFilePath, String flowName, int timeOut, String gradleArguments) {
+def appendToGHCI(String paramFileContent, Path targetFilePath, String flowName, int timeOut, String gradleArguments, ArrayList dependency=null) {
   String postProcessing = paramFileContent
       .replace("\$FlowName", flowName)
       .replace("\$TimeOut", Integer.toString(timeOut))
       .replace("\$GradleArguments", gradleArguments)
+      .replace("\$Dependency", dependency == null ? "" : dependency.toString())
 
   append(targetFilePath, postProcessing)
   append(targetFilePath, "\n")

--- a/internal/venice-test-common/build.gradle
+++ b/internal/venice-test-common/build.gradle
@@ -235,7 +235,12 @@ def appendToGHCI(String paramFileContent, Path targetFilePath, String flowName, 
       .replace("\$FlowName", flowName)
       .replace("\$TimeOut", Integer.toString(timeOut))
       .replace("\$GradleArguments", gradleArguments)
-      .replace("\$Dependency", dependency == null ? "" : dependency.toString())
+
+  if (dependency == null) {
+    postProcessing = postProcessing.replace("    needs: \$Dependency\n", "")
+  } else {
+    postProcessing = postProcessing.replace("\$Dependency", dependency.toString())
+  }
 
   append(targetFilePath, postProcessing)
   append(targetFilePath, "\n")

--- a/internal/venice-test-common/build.gradle
+++ b/internal/venice-test-common/build.gradle
@@ -223,7 +223,7 @@ task generateGHCI() {
   appendToGHCI(paramFileContent, targetFilePath, otherTest, 120, integTestGradleArgs + "Z")
   jobs << otherTest
 
-  // define a job that depends others but does nothing to manage the status check
+  // define a job that depends others to manage the status check
   appendToGHCI(paramFileContent, targetFilePath, "DummyStep", 120, "clean", jobs)
 
   def finalDestinationPath = Paths.get(rootDir.getPath() + "/.github/workflows/gh-ci.yml")


### PR DESCRIPTION
We want to make a dummy stage that all other tasks depend on, such that we can manage the status check on github easier.

### Test

Checked the dependency graph and confirmed that the dummy stage depends on every task.

https://github.com/adamxchen/venice/actions/runs/3952777862