### PR TITLE
[da-vinci][server] fixed an ingestion race condition

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/cache/VeniceStoreCacheStorageEngine.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/cache/VeniceStoreCacheStorageEngine.java
@@ -8,12 +8,19 @@ import com.linkedin.davinci.store.cache.backend.ObjectCacheConfig;
 import com.linkedin.venice.meta.PersistenceType;
 import com.linkedin.venice.serialization.avro.AvroProtocolDefinition;
 import java.util.Set;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 import org.apache.avro.Schema;
 
 
 public class VeniceStoreCacheStorageEngine extends AbstractStorageEngine<VeniceStoreCacheStoragePartition> {
   private final ObjectCacheConfig cacheConfig;
   private final VeniceStoreCacheStoragePartition omniPartition;
+  /**
+   * Since there is only one storage partition per storage engine, we need to create a global lock here since
+   * all the requests will be direct to partition 0.
+   */
+  private final ReadWriteLock globalRWlock = new ReentrantReadWriteLock();
 
   public VeniceStoreCacheStorageEngine(
       String storeName,
@@ -62,6 +69,11 @@ public class VeniceStoreCacheStorageEngine extends AbstractStorageEngine<VeniceS
   @Override
   public synchronized AbstractStoragePartition getPartitionOrThrow(int partitionId) {
     return omniPartition;
+  }
+
+  @Override
+  public ReadWriteLock getRWLockForPartitionOrThrow(int partitionId) {
+    return globalRWlock;
   }
 
   public <K, V> void putDeserializedValue(K key, V value) {

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/DeepCopyStorageEngine.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/DeepCopyStorageEngine.java
@@ -13,6 +13,7 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.locks.ReadWriteLock;
 import java.util.function.Supplier;
 
 
@@ -174,6 +175,11 @@ public class DeepCopyStorageEngine extends AbstractStorageEngine<AbstractStorage
   @Override
   public AbstractStoragePartition getPartitionOrThrow(int partitionId) {
     return this.delegate.getPartitionOrThrow(partitionId);
+  }
+
+  @Override
+  public ReadWriteLock getRWLockForPartitionOrThrow(int partitionId) {
+    return this.delegate.getRWLockForPartitionOrThrow(partitionId);
   }
 
   @Override

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
@@ -184,6 +184,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.BooleanSupplier;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
@@ -1109,6 +1110,7 @@ public abstract class StoreIngestionTaskTest {
 
     AbstractStoragePartition mockStoragePartition = mock(AbstractStoragePartition.class);
     doReturn(mockStoragePartition).when(mockAbstractStorageEngine).getPartitionOrThrow(anyInt());
+    doReturn(new ReentrantReadWriteLock()).when(mockAbstractStorageEngine).getRWLockForPartitionOrThrow(anyInt());
 
     doReturn(putKeyFooReplicationMetadataWithValueSchemaIdBytesDefault).when(mockStoragePartition)
         .getReplicationMetadata(putKeyFoo);

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/store/AbstractStorageEngineTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/store/AbstractStorageEngineTest.java
@@ -11,7 +11,6 @@ import static com.linkedin.venice.ConfigKeys.ZOOKEEPER_ADDRESS;
 
 import com.linkedin.davinci.callback.BytesStreamingCallback;
 import com.linkedin.davinci.config.VeniceConfigLoader;
-import com.linkedin.venice.exceptions.PersistenceFailureException;
 import com.linkedin.venice.exceptions.StorageInitializationException;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.meta.PersistenceType;
@@ -164,14 +163,14 @@ public abstract class AbstractStorageEngineTest extends AbstractStoreTest {
     // test put
     try {
       testStoreEngine.put(partitionId, key, value);
-    } catch (PersistenceFailureException e) {
+    } catch (VeniceException e) {
       // This is expected.
     }
 
     byte[] found = null;
     try {
       found = testStoreEngine.get(partitionId, key);
-    } catch (PersistenceFailureException e) {
+    } catch (VeniceException e) {
       // This is expected
     }
 
@@ -181,7 +180,7 @@ public abstract class AbstractStorageEngineTest extends AbstractStoreTest {
         "PUT and GET on key: " + Hex.encodeHexString(key) + " in invalid partition: " + partitionId + " succeeded");
 
     Assert.assertThrows(
-        PersistenceFailureException.class,
+        VeniceException.class,
         () -> testStoreEngine.getByKeyPrefix(partitionId, key, new BytesStreamingCallback() {
           @Override
           public void onRecordReceived(byte[] key, byte[] value) {
@@ -201,7 +200,7 @@ public abstract class AbstractStorageEngineTest extends AbstractStoreTest {
     // test delete
     try {
       testStoreEngine.delete(partitionId, key);
-    } catch (PersistenceFailureException e) {
+    } catch (VeniceException e) {
       // This is expected
       return;
     }


### PR DESCRIPTION
When active/active or write-compute is enabled, the consumer thread could read the local database, while the drainer threads could be adjusting the storage partition when receiving some special Control Messages/signals, such as StartOfPush or ReadyToServe signal.
Previously, we coded a fix to make sure the partition id list is always valid for the above race condition, but that fix couldn't make sure the partition will be accessible in consumer thread when the same partition is being adjusted, such as close and reopen.

This fix introduces an additonal safeguard to make sure the partition being accessed will be always valid and it also updates the locking granularity to be partition-level.


## How was this PR tested?
Internal CI
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.