### PR TITLE
[server] Fix ingestion isolation heartbeat request timeout

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/isolated/IsolatedIngestionServer.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/isolated/IsolatedIngestionServer.java
@@ -154,7 +154,7 @@ public class IsolatedIngestionServer extends AbstractVeniceService {
     this.configLoader = new VeniceConfigLoader(loadedVeniceProperties, loadedVeniceProperties, kafkaClusterMap);
     this.servicePort = configLoader.getVeniceServerConfig().getIngestionServicePort();
     this.heartbeatTimeoutMs = configLoader.getCombinedProperties()
-        .getLong(SERVER_INGESTION_ISOLATION_HEARTBEAT_TIMEOUT_MS, 60 * Time.MS_PER_SECOND);
+        .getLong(SERVER_INGESTION_ISOLATION_HEARTBEAT_TIMEOUT_MS, 180 * Time.MS_PER_SECOND);
     // Initialize Netty server.
     Class<? extends ServerChannel> serverSocketChannelClass = NioServerSocketChannel.class;
     bossGroup = new NioEventLoopGroup();

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/isolated/IsolatedIngestionServer.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/isolated/IsolatedIngestionServer.java
@@ -124,6 +124,10 @@ public class IsolatedIngestionServer extends AbstractVeniceService {
   private final Map<String, Map<Integer, AtomicBoolean>> topicPartitionSubscriptionMap =
       new VeniceConcurrentHashMap<>();
   private final Map<String, Double> metricsMap = new VeniceConcurrentHashMap<>();
+  /**
+   * Heartbeat timeout acknowledge disconnection between main and forked processes. After this timeout, forked process
+   * should stop running gracefully.
+   */
   private final long heartbeatTimeoutMs;
 
   private ChannelFuture serverFuture;

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/main/MainIngestionMonitorService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/main/MainIngestionMonitorService.java
@@ -73,6 +73,11 @@ public class MainIngestionMonitorService extends AbstractVeniceService {
   private KafkaStoreIngestionService storeIngestionService;
   private ReadOnlyStoreRepository storeRepository;
   private final VeniceConfigLoader configLoader;
+  /**
+   * Heartbeat timeout acknowledge disconnection between main and forked processes. After this timeout, main process
+   * should (1) Try to kill lingering forked process to release port (2) Respawn new forked ingestion process to continue
+   * ingestion work.
+   */
   private long heartbeatTimeoutMs;
   private volatile long latestHeartbeatTimestamp = -1;
   private final int requestTimeoutInSeconds;


### PR DESCRIPTION
## [server] Fix ingestion isolation heartbeat request timeout
This PR fixes a bug: ingestion isolation heartbeat timeout uses wrong time unit so it won't timeout until 10000 seconds rather than 10 seconds. If request stuck for some reason, the forked process will exit first due to correct timeout detection. However, main process won't detect until 10000s and it will make following ingestion all failed.

This PR also makes following adjustments:
1. Adjust periodic requests(Heartbeat/Metric) timeout to 5 seconds, so it won't be blocking forever. It is expected to complete fast, unless soemthing wrong happened and we should be able to detect it in the short period.
2. Do not update heartbeat timestamp in metric request. Only update it in heartbeat request so it is easier for debugging.
3. Adjust logging to make it more clear.
4. Align default heartbeat request timeout to 180s, as it has been adopted in EI config long time ago.

## How was this PR tested?
Internal CI
## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.