### PR TITLE
[server] clean up read compute access mode config, enable object reuse in write path lookups.

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
@@ -36,7 +36,6 @@ import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.offsets.OffsetRecord;
 import com.linkedin.venice.schema.rmd.RmdUtils;
-import com.linkedin.venice.serializer.AvroSerializer;
 import com.linkedin.venice.utils.ByteUtils;
 import com.linkedin.venice.utils.LatencyUtils;
 import com.linkedin.venice.utils.Time;
@@ -78,7 +77,7 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
   private final AggVersionedIngestionStats aggVersionedIngestionStats;
   private final RemoteIngestionRepairService remoteIngestionRepairService;
 
-  private static class ReusableObjects extends AvroSerializer.AvroSerializerReusableObjects {
+  private static class ReusableObjects {
     // reuse buffer for rocksDB value object
     final ByteBuffer reusedByteBuffer = ByteBuffer.allocate(1024 * 1024);
     final BinaryDecoder binaryDecoder =

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
@@ -4,6 +4,7 @@ import static com.linkedin.davinci.kafka.consumer.LeaderFollowerStateType.LEADER
 import static com.linkedin.davinci.kafka.consumer.LeaderFollowerStateType.STANDBY;
 import static com.linkedin.venice.VeniceConstants.REWIND_TIME_DECIDED_BY_SERVER;
 
+import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
 import com.linkedin.davinci.config.VeniceStoreVersionConfig;
 import com.linkedin.davinci.replication.RmdWithValueSchemaId;
 import com.linkedin.davinci.replication.merge.MergeConflictResolver;
@@ -35,6 +36,7 @@ import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.offsets.OffsetRecord;
 import com.linkedin.venice.schema.rmd.RmdUtils;
+import com.linkedin.venice.serializer.AvroSerializer;
 import com.linkedin.venice.utils.ByteUtils;
 import com.linkedin.venice.utils.LatencyUtils;
 import com.linkedin.venice.utils.Time;
@@ -56,6 +58,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.BooleanSupplier;
 import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.io.BinaryDecoder;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -66,12 +69,23 @@ import org.apache.logging.log4j.Logger;
  */
 public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestionTask {
   private static final Logger LOGGER = LogManager.getLogger(ActiveActiveStoreIngestionTask.class);
+  private static final byte[] BINARY_DECODER_PARAM = new byte[16];
+
   private final int rmdProtocolVersionID;
   private final MergeConflictResolver mergeConflictResolver;
   private final RmdSerDe rmdSerDe;
   private final Lazy<KeyLevelLocksManager> keyLevelLocksManager;
   private final AggVersionedIngestionStats aggVersionedIngestionStats;
   private final RemoteIngestionRepairService remoteIngestionRepairService;
+
+  private static class ReusableObjects extends AvroSerializer.AvroSerializerReusableObjects {
+    // reuse buffer for rocksDB value object
+    final ByteBuffer reusedByteBuffer = ByteBuffer.allocate(1024 * 1024);
+    final BinaryDecoder binaryDecoder =
+        AvroCompatibilityHelper.newBinaryDecoder(BINARY_DECODER_PARAM, 0, BINARY_DECODER_PARAM.length, null);
+  }
+
+  private final ThreadLocal<ReusableObjects> threadLocalReusableObjects = ThreadLocal.withInitial(ReusableObjects::new);
 
   public ActiveActiveStoreIngestionTask(
       StoreIngestionTaskFactory.Builder builder,
@@ -501,13 +515,17 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
     PartitionConsumptionState.TransientRecord transientRecord = partitionConsumptionState.getTransientRecord(key);
     if (transientRecord == null) {
       long lookupStartTimeInNS = System.nanoTime();
+      ReusableObjects reusableObjects = threadLocalReusableObjects.get();
+      ByteBuffer reusedRawValue = reusableObjects.reusedByteBuffer;
+      BinaryDecoder binaryDecoder = reusableObjects.binaryDecoder;
+
       originalValue = RawBytesChunkingAdapter.INSTANCE.get(
           storageEngine,
           getSubPartitionId(key, topic, partition),
           ByteBuffer.wrap(key),
           isChunked,
-          null,
-          null,
+          reusedRawValue,
+          binaryDecoder,
           null,
           compressionStrategy,
           serverConfig.isComputeFastAvroEnabled(),

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/RocksDBServerConfig.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/RocksDBServerConfig.java
@@ -185,8 +185,6 @@ public class RocksDBServerConfig {
   public static final String ROCKSDB_LEVEL0_STOPS_WRITES_TRIGGER_WRITE_ONLY_VERSION =
       "rocksdb.level0.stops.writes.trigger.write.only.version";
 
-  public static final String ROCKSDB_COMPUTE_ACCESS_MODE = "rocksdb.compute.access.mode";
-
   public static final String ROCKSDB_PUT_REUSE_BYTE_BUFFER = "rocksdb.put.reuse.byte.buffer";
 
   /**
@@ -266,8 +264,6 @@ public class RocksDBServerConfig {
   private final boolean atomicFlushEnabled;
   private final boolean separateRMDCacheEnabled;
   private int blockBaseFormatVersion;
-
-  private final RocksDBComputeAccessMode serverStorageOperation;
 
   public RocksDBServerConfig(VeniceProperties props) {
     // Do not use Direct IO for reads by default
@@ -376,20 +372,6 @@ public class RocksDBServerConfig {
     this.separateRMDCacheEnabled = props.getBoolean(ROCKSDB_SEPARATE_RMD_CACHE_ENABLED, false);
 
     this.blockBaseFormatVersion = props.getInt(ROCKSDB_BLOCK_BASE_FORMAT_VERSION, 2);
-    String rocksDBOperationType =
-        props.getString(ROCKSDB_COMPUTE_ACCESS_MODE, RocksDBComputeAccessMode.SINGLE_GET.name());
-    try {
-      this.serverStorageOperation = RocksDBComputeAccessMode.valueOf(rocksDBOperationType);
-    } catch (IllegalArgumentException e) {
-      throw new VeniceException(
-          "Invalid operation type: " + rocksDBOperationType + ", available types: "
-              + Arrays.toString(RocksDBComputeAccessMode.values()));
-    }
-
-  }
-
-  public RocksDBComputeAccessMode getServerStorageOperation() {
-    return serverStorageOperation;
   }
 
   public int getLevel0FileNumCompactionTriggerWriteOnlyVersion() {

--- a/services/venice-server/src/main/java/com/linkedin/venice/listener/StorageReadRequestsHandler.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/listener/StorageReadRequestsHandler.java
@@ -13,7 +13,6 @@ import com.linkedin.davinci.storage.chunking.GenericRecordChunkingAdapter;
 import com.linkedin.davinci.storage.chunking.SingleGetChunkingAdapter;
 import com.linkedin.davinci.store.AbstractStorageEngine;
 import com.linkedin.davinci.store.record.ValueRecord;
-import com.linkedin.davinci.store.rocksdb.RocksDBComputeAccessMode;
 import com.linkedin.venice.VeniceConstants;
 import com.linkedin.venice.cleaner.ResourceReadUsageTracker;
 import com.linkedin.venice.compression.CompressionStrategy;
@@ -121,7 +120,6 @@ public class StorageReadRequestsHandler extends ChannelInboundHandlerAdapter {
   private final boolean parallelBatchGetEnabled;
   private final int parallelBatchGetChunkSize;
   private final boolean keyValueProfilingEnabled;
-  private final RocksDBComputeAccessMode rocksDBComputeAccessMode;
   private final VeniceServerConfig serverConfig;
   private final Map<String, VenicePartitioner> resourceToPartitionerMap = new VeniceConcurrentHashMap<>();
   private final Map<String, PartitionerConfig> resourceToPartitionConfigMap = new VeniceConcurrentHashMap<>();
@@ -180,7 +178,6 @@ public class StorageReadRequestsHandler extends ChannelInboundHandlerAdapter {
     this.parallelBatchGetEnabled = parallelBatchGetEnabled;
     this.parallelBatchGetChunkSize = parallelBatchGetChunkSize;
     this.keyValueProfilingEnabled = serverConfig.isKeyValueProfilingEnabled();
-    this.rocksDBComputeAccessMode = serverConfig.getRocksDBServerConfig().getServerStorageOperation();
     this.serverConfig = serverConfig;
     this.compressorFactory = compressorFactory;
     this.resourceReadUsageTracker = resourceReadUsageTracker;
@@ -580,12 +577,9 @@ public class StorageReadRequestsHandler extends ChannelInboundHandlerAdapter {
         .computeIfAbsent(computeResultSchema, k -> new GenericData.Record(finalComputeResultSchema1));
 
     // Reuse the same value record and result record instances for all values
-    ByteBuffer reusedRawValue = null;
-    if (rocksDBComputeAccessMode == RocksDBComputeAccessMode.SINGLE_GET_WITH_REUSE) {
-      reusedRawValue = reusableObjects.reusedByteBuffer;
-    }
-
+    ByteBuffer reusedRawValue = reusableObjects.reusedByteBuffer;
     RecordSerializer<GenericRecord> resultSerializer;
+
     if (fastAvroEnabled) {
       resultSerializer = FastSerializerDeserializerFactory.getFastAvroGenericSerializer(computeResultSchema);
     } else {
@@ -660,41 +654,20 @@ public class StorageReadRequestsHandler extends ChannelInboundHandlerAdapter {
       ByteBuffer reuseRawValue,
       VeniceCompressor compressor) {
 
-    switch (rocksDBComputeAccessMode) {
-      case SINGLE_GET:
-        reuseValueRecord = GenericRecordChunkingAdapter.INSTANCE.get(
-            store,
-            partition,
-            key,
-            isChunked,
-            reuseValueRecord,
-            reusableObjects.binaryDecoder,
-            response,
-            compressionStrategy,
-            fastAvroEnabled,
-            this.schemaRepo,
-            storeName,
-            compressor);
-        break;
-      case SINGLE_GET_WITH_REUSE:
-        reuseValueRecord = GenericRecordChunkingAdapter.INSTANCE.get(
-            storeName,
-            store,
-            partition,
-            ByteUtils.extractByteArray(key),
-            reuseRawValue,
-            reuseValueRecord,
-            reusableObjects.binaryDecoder,
-            isChunked,
-            compressionStrategy,
-            fastAvroEnabled,
-            this.schemaRepo,
-            response,
-            compressor);
-        break;
-      default:
-        throw new VeniceException("Unknown rocksDB compute storage operation");
-    }
+    reuseValueRecord = GenericRecordChunkingAdapter.INSTANCE.get(
+        storeName,
+        store,
+        partition,
+        ByteUtils.extractByteArray(key),
+        reuseRawValue,
+        reuseValueRecord,
+        reusableObjects.binaryDecoder,
+        isChunked,
+        compressionStrategy,
+        fastAvroEnabled,
+        this.schemaRepo,
+        response,
+        compressor);
 
     if (reuseValueRecord == null) {
       if (isStreaming) {

--- a/services/venice-server/src/main/java/com/linkedin/venice/listener/StorageReadRequestsHandler.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/listener/StorageReadRequestsHandler.java
@@ -653,7 +653,6 @@ public class StorageReadRequestsHandler extends ChannelInboundHandlerAdapter {
       Map<String, Object> globalContext,
       ByteBuffer reuseRawValue,
       VeniceCompressor compressor) {
-
     reuseValueRecord = GenericRecordChunkingAdapter.INSTANCE.get(
         storeName,
         store,


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci], [server], [controller],
[router], [samza], [vpj], [fast-client], [thin-client], [alpini],
[admin-tool], [test], [build], [doc], [script]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Summary, imperative, start upper case, don't end with a period
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Since its been enabled in venice-9 for very long time, removing this config "venice.rocksdb.compute.access.mode" along with code using it. Also added object reuse in A/A ingestion path object lookup


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

CI build
## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.