### PR TITLE
[server][vpj] Calculate target partition before adding chunkedKeySuffix in VeniceWriter::delete

### DIFF
--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/KafkaTopicDumper.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/KafkaTopicDumper.java
@@ -230,7 +230,7 @@ public class KafkaTopicDumper implements AutoCloseable {
       LeaderMetadata leaderMetadata = kafkaMessageEnvelope.leaderMetadataFooter;
 
       LOGGER.info(
-          "{} {} Offset:{} ProducerMd=(guid:{},seg:{},msn:{},mts:{},lts:{}) LeaderMd=(host:{},uo:{},ukcId:{})",
+          "{} {} Offset:{} ProducerMd=(guid:{},seg:{},seq:{},mts:{},lts:{}) LeaderMd=(host:{},uo:{},ukcId:{})",
           kafkaKey.isControlMessage() ? CONTROL_REC : REGULAR_REC,
           msgType,
           record.offset(),

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/KafkaTopicDumper.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/KafkaTopicDumper.java
@@ -5,6 +5,7 @@ import com.linkedin.venice.controllerapi.ControllerClient;
 import com.linkedin.venice.controllerapi.MultiSchemaResponse;
 import com.linkedin.venice.etl.VeniceKafkaDecodedRecord;
 import com.linkedin.venice.exceptions.VeniceException;
+import com.linkedin.venice.guid.GuidUtils;
 import com.linkedin.venice.kafka.protocol.ControlMessage;
 import com.linkedin.venice.kafka.protocol.KafkaMessageEnvelope;
 import com.linkedin.venice.kafka.protocol.LeaderMetadata;
@@ -229,13 +230,13 @@ public class KafkaTopicDumper implements AutoCloseable {
       LeaderMetadata leaderMetadata = kafkaMessageEnvelope.leaderMetadataFooter;
 
       LOGGER.info(
-          "{} {} Offset:{} ProducerMd=(guid:{},seqNum:{},segNum:{},mts:{},lts:{}) LeaderMd=(host:{},uo:{},ukcId:{})",
+          "{} {} Offset:{} ProducerMd=(guid:{},seg:{},msn:{},mts:{},lts:{}) LeaderMd=(host:{},uo:{},ukcId:{})",
           kafkaKey.isControlMessage() ? CONTROL_REC : REGULAR_REC,
           msgType,
           record.offset(),
-          Arrays.toString(producerMetadata.producerGUID.bytes()),
-          producerMetadata.messageSequenceNumber,
+          GuidUtils.getHexFromGuid(producerMetadata.producerGUID),
           producerMetadata.segmentNumber,
+          producerMetadata.messageSequenceNumber,
           producerMetadata.messageTimestamp,
           producerMetadata.logicalTimestamp,
           leaderMetadata == null ? "-" : leaderMetadata.hostName,

--- a/internal/venice-common/src/main/java/com/linkedin/venice/writer/VeniceWriter.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/writer/VeniceWriter.java
@@ -1479,14 +1479,6 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
    * @param key the {@link KafkaKey} for which we want to get the partition.
    * @return the partition number that the provided key belongs to.
    */
-  private int getPartition(KafkaKey key) {
-    return getPartition(key.getKey());
-  }
-
-  /**
-   * @param key the {@link KafkaKey} for which we want to get the partition.
-   * @return the partition number that the provided key belongs to.
-   */
   private int getPartition(byte[] key) {
     return partitioner.getPartitionId(key, numberOfPartitions);
   }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/writer/VeniceWriter.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/writer/VeniceWriter.java
@@ -500,6 +500,8 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
       long logicalTs,
       DeleteMetadata deleteMetadata) {
     byte[] serializedKey = keySerializer.serialize(topicName, key);
+    int partition = getPartition(serializedKey);
+
     isChunkingFlagInvoked = true;
 
     int rmdPayloadSize = deleteMetadata == null ? 0 : deleteMetadata.getSerializedSize();
@@ -517,8 +519,6 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
     }
 
     KafkaKey kafkaKey = new KafkaKey(MessageType.DELETE, serializedKey);
-
-    int partition = getPartition(kafkaKey);
 
     Delete delete = new Delete();
     if (deleteMetadata == null) {

--- a/internal/venice-common/src/test/java/com/linkedin/venice/writer/VeniceWriterUnitTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/writer/VeniceWriterUnitTest.java
@@ -1,0 +1,69 @@
+package com.linkedin.venice.writer;
+
+import static com.linkedin.venice.writer.VeniceWriter.ENABLE_CHUNKING;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.linkedin.venice.partitioner.DefaultVenicePartitioner;
+import com.linkedin.venice.serialization.VeniceKafkaSerializer;
+import com.linkedin.venice.serialization.avro.VeniceAvroKafkaSerializer;
+import com.linkedin.venice.utils.DataProviderUtils;
+import com.linkedin.venice.utils.VeniceProperties;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.concurrent.Future;
+import org.mockito.ArgumentCaptor;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class VeniceWriterUnitTest {
+  @Test(dataProvider = "Chunking-And-Partition-Counts", dataProviderClass = DataProviderUtils.class)
+  public void testTargetPartitionIsSameForAllOperationsWithTheSameKey(boolean isChunkingEnabled, int partitionCount) {
+    KafkaProducerWrapper mockedProducer = mock(KafkaProducerWrapper.class);
+    Future mockedFuture = mock(Future.class);
+    when(mockedProducer.sendMessage(anyString(), any(), any(), anyInt(), any())).thenReturn(mockedFuture);
+    Properties writerProperties = new Properties();
+    writerProperties.put(ENABLE_CHUNKING, isChunkingEnabled);
+
+    String stringSchema = "\"string\"";
+    VeniceKafkaSerializer serializer = new VeniceAvroKafkaSerializer(stringSchema);
+    String testTopic = "test";
+    VeniceWriterOptions veniceWriterOptions = new VeniceWriterOptions.Builder(testTopic).setKeySerializer(serializer)
+        .setValueSerializer(serializer)
+        .setWriteComputeSerializer(serializer)
+        .setPartitioner(new DefaultVenicePartitioner())
+        .setPartitionCount(Optional.of(partitionCount))
+        .build();
+    VeniceWriter<Object, Object, Object> writer =
+        new VeniceWriter(veniceWriterOptions, new VeniceProperties(writerProperties), () -> mockedProducer);
+
+    String valueString = "value-string";
+    String key = "test-key";
+
+    ArgumentCaptor<Integer> putOpTargetPartitionCaptor = ArgumentCaptor.forClass(Integer.class);
+    writer.put(key, valueString, 1, null);
+    verify(mockedProducer, atLeast(2))
+        .sendMessage(eq(testTopic), any(), any(), putOpTargetPartitionCaptor.capture(), any());
+
+    ArgumentCaptor<Integer> deleteOpTargetPartitionCaptor = ArgumentCaptor.forClass(Integer.class);
+    writer.delete(key, null);
+    verify(mockedProducer, atLeast(2))
+        .sendMessage(eq(testTopic), any(), any(), deleteOpTargetPartitionCaptor.capture(), any());
+
+    Assert.assertEquals(putOpTargetPartitionCaptor.getValue(), deleteOpTargetPartitionCaptor.getValue());
+
+    ArgumentCaptor<Integer> updateOpTargetPartitionCaptor = ArgumentCaptor.forClass(Integer.class);
+    writer.delete(key, null);
+    verify(mockedProducer, atLeast(2))
+        .sendMessage(eq(testTopic), any(), any(), updateOpTargetPartitionCaptor.capture(), any());
+
+    Assert.assertEquals(putOpTargetPartitionCaptor.getValue(), updateOpTargetPartitionCaptor.getValue());
+  }
+}

--- a/internal/venice-test-common/src/main/java/com/linkedin/venice/utils/DataProviderUtils.java
+++ b/internal/venice-test-common/src/main/java/com/linkedin/venice/utils/DataProviderUtils.java
@@ -93,7 +93,7 @@ public class DataProviderUtils {
   }
 
   @DataProvider(name = "Chunking-And-Partition-Counts")
-  public static Object[][] numberOfPartitions() {
+  public static Object[][] chunkingAndPartitionCountsCombination() {
     return allPermutationGenerator(BOOLEAN, PARTITION_COUNTS);
   }
 

--- a/internal/venice-test-common/src/main/java/com/linkedin/venice/utils/DataProviderUtils.java
+++ b/internal/venice-test-common/src/main/java/com/linkedin/venice/utils/DataProviderUtils.java
@@ -24,6 +24,7 @@ public class DataProviderUtils {
   public static final Object[] BOOLEAN_TRUE = { true };
   public static final Object[] BOOLEAN = { false, true };
   public static final Object[] COMPRESSION_STRATEGIES = { NO_OP, GZIP, ZSTD_WITH_DICT };
+  public static final Object[] PARTITION_COUNTS = { 1, 2, 3, 4, 8, 10, 16, 19, 92, 128 };
 
   /**
    * To use these data providers, add (dataProvider = "<provider_name>", dataProviderClass = DataProviderUtils.class)
@@ -89,6 +90,11 @@ public class DataProviderUtils {
   @DataProvider(name = "Amplification-Factor")
   public static Object[][] amplificationFactor() {
     return new Object[][] { { 1 }, { 3 } };
+  }
+
+  @DataProvider(name = "Chunking-And-Partition-Counts")
+  public static Object[][] numberOfPartitions() {
+    return allPermutationGenerator(BOOLEAN, PARTITION_COUNTS);
   }
 
   @DataProvider(name = "Boolean-Compression")


### PR DESCRIPTION
Currently, when chunking is enabled, for DELETE op records we calculate the target partition after adding a chunkedKeySuffix. However, for PUT ops we calculate the target partition before adding any suffix to the key. The suffix added to the key changes the partition on which the record lands. This means that the records with the same key but different operations may end up on different partitions.

To send records to the proper partition we need to get the target partition without chunkedKeySuffix addition to the key.


## How was this PR tested?
Internal CI

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.