### PR TITLE
[controller] Added API endpoint for updating value schemas.

### DIFF
--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/AdminTool.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/AdminTool.java
@@ -496,6 +496,8 @@ public class AdminTool {
         case CLEANUP_INSTANCE_CUSTOMIZED_STATES:
           cleanupInstanceCustomizedStates(cmd);
           break;
+        case UPDATE_VALUE_SCHEMA:
+          updateValueSchema(cmd);
         default:
           StringJoiner availableCommands = new StringJoiner(", ");
           for (Command c: Command.values()) {
@@ -2607,6 +2609,14 @@ public class AdminTool {
   private static void cleanupInstanceCustomizedStates(CommandLine cmd) {
     MultiStoreTopicsResponse multiStoreTopicsResponse = controllerClient.cleanupInstanceCustomizedStates();
     printObject(multiStoreTopicsResponse);
+  }
+
+  private static void updateValueSchema(CommandLine cmd) {
+    String store = getRequiredArgument(cmd, Arg.STORE);
+    String valueStr = getRequiredArgument(cmd, Arg.VALUE_SCHEMA);
+    int id = Integer.parseInt(getRequiredArgument(cmd, Arg.VALUE_SCHEMA_ID));
+
+    SchemaResponse schemaResponse = controllerClient.updateValueSchema(store, valueStr, id);
   }
 
   private static Map<String, ControllerClient> getAndCheckChildControllerClientMap(

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/Command.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/Command.java
@@ -436,6 +436,11 @@ public enum Command {
   CLEANUP_INSTANCE_CUSTOMIZED_STATES(
       "cleanup-instance-customized-states", "Cleanup any lingering instance level customized states",
       new Arg[] { URL, CLUSTER }
+  ),
+  UPDATE_VALUE_SCHEMA(
+      "update-value-schema",
+      "Updates the schema associated with the given schema id and store to the passed schema string.",
+      new Arg[] { STORE, VALUE_SCHEMA_ID, VALUE_SCHEMA }
   );
 
   private final String commandName;

--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerClient.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerClient.java
@@ -837,6 +837,14 @@ public class ControllerClient implements Closeable {
     return request(ControllerRoute.GET_VALUE_SCHEMA, params, SchemaResponse.class);
   }
 
+  public SchemaResponse updateValueSchema(String storeName, String valueSchema, int schemaId) {
+    QueryParams params = newParams().add(NAME, storeName)
+        .add(CLUSTER, clusterName)
+        .add(SCHEMA_ID, schemaId)
+        .add(VALUE_SCHEMA, valueSchema);
+    return request(ControllerRoute.UPDATE_VALUE_SCHEMA, params, SchemaResponse.class);
+  }
+
   public SchemaResponse getValueSchemaID(String storeName, String valueSchemaStr) {
     QueryParams params = newParams().add(NAME, storeName).add(VALUE_SCHEMA, valueSchemaStr);
     return request(ControllerRoute.GET_VALUE_SCHEMA_ID, params, SchemaResponse.class);

--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerClient.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerClient.java
@@ -838,10 +838,7 @@ public class ControllerClient implements Closeable {
   }
 
   public SchemaResponse updateValueSchema(String storeName, String valueSchema, int schemaId) {
-    QueryParams params = newParams().add(NAME, storeName)
-        .add(CLUSTER, clusterName)
-        .add(SCHEMA_ID, schemaId)
-        .add(VALUE_SCHEMA, valueSchema);
+    QueryParams params = newParams().add(NAME, storeName).add(SCHEMA_ID, schemaId).add(VALUE_SCHEMA, valueSchema);
     return request(ControllerRoute.UPDATE_VALUE_SCHEMA, params, SchemaResponse.class);
   }
 

--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerRoute.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerRoute.java
@@ -158,6 +158,7 @@ public enum ControllerRoute {
 
   GET_KEY_SCHEMA("/get_key_schema", HttpMethod.GET, Collections.singletonList(NAME)),
   ADD_VALUE_SCHEMA("/add_value_schema", HttpMethod.POST, Arrays.asList(NAME, VALUE_SCHEMA), SCHEMA_ID),
+  UPDATE_VALUE_SCHEMA("/update_value_schema", HttpMethod.POST, Arrays.asList(NAME, VALUE_SCHEMA)),
   ADD_DERIVED_SCHEMA(
       "/add_derived_schema", HttpMethod.POST, Arrays.asList(NAME, SCHEMA_ID, DERIVED_SCHEMA), DERIVED_SCHEMA_ID
   ), SET_OWNER("/set_owner", HttpMethod.POST, Arrays.asList(NAME, OWNER)),

--- a/internal/venice-common/src/main/java/com/linkedin/venice/helix/HelixReadWriteSchemaRepository.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/helix/HelixReadWriteSchemaRepository.java
@@ -356,7 +356,7 @@ public class HelixReadWriteSchemaRepository implements ReadWriteSchemaRepository
       throw new VeniceException("Rejecting attempt to update non-existing schema.");
     }
     if (ret == null) {
-      throw new VeniceException("Returned NULL rip");
+      throw new VeniceException("Error obtaining value schema.");
     }
     return ret;
   }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/helix/HelixReadWriteSchemaRepository.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/helix/HelixReadWriteSchemaRepository.java
@@ -346,6 +346,21 @@ public class HelixReadWriteSchemaRepository implements ReadWriteSchemaRepository
     return newValueSchemaEntry;
   }
 
+  @Override
+  public synchronized SchemaEntry updateValueSchema(String storeName, String schemaStr, int schemaId) {
+    SchemaEntry ret = null;
+    if (accessor.existsValueSchema(storeName, Integer.toString(schemaId))) {
+      SchemaEntry newSchemaEntry = new SchemaEntry(schemaId, schemaStr);
+      ret = accessor.updateValueSchema(storeName, newSchemaEntry, Integer.toString(schemaId));
+    } else {
+      throw new VeniceException("Rejecting attempt to update non-existing schema.");
+    }
+    if (ret == null) {
+      throw new VeniceException("Returned NULL rip");
+    }
+    return ret;
+  }
+
   /**
    * Check if the incoming schema is a valid schema and return the next available schema ID.
    *

--- a/internal/venice-common/src/main/java/com/linkedin/venice/helix/HelixReadWriteSchemaRepositoryAdapter.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/helix/HelixReadWriteSchemaRepositoryAdapter.java
@@ -88,6 +88,15 @@ public class HelixReadWriteSchemaRepositoryAdapter implements ReadWriteSchemaRep
         errorMsgForUnsupportedOperationsAgainstSystemStore(storeName, systemStoreType, "addDerivedSchema"));
   }
 
+  public SchemaEntry updateValueSchema(String storeName, String schemaStr, int id) {
+    VeniceSystemStoreType systemStoreType = VeniceSystemStoreType.getSystemStoreType(storeName);
+    if (HelixReadOnlyStoreRepositoryAdapter.forwardToRegularRepository(systemStoreType)) {
+      return readWriteRegularStoreSchemaRepository.updateValueSchema(storeName, schemaStr, id);
+    }
+    throw new VeniceException(
+        errorMsgForUnsupportedOperationsAgainstSystemStore(storeName, systemStoreType, "updateValueSchema"));
+  }
+
   @Override
   public DerivedSchemaEntry addDerivedSchema(
       String storeName,

--- a/internal/venice-common/src/main/java/com/linkedin/venice/helix/HelixSchemaAccessor.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/helix/HelixSchemaAccessor.java
@@ -95,6 +95,19 @@ public class HelixSchemaAccessor {
     return schemaAccessor.get(getValueSchemaPath(storeName, id), null, AccessOption.PERSISTENT);
   }
 
+  public SchemaEntry updateValueSchema(String storeName, SchemaEntry newEntry, String id) {
+    SchemaEntry ret = null;
+    if (existsValueSchema(storeName, id)) {
+      schemaAccessor.set(getValueSchemaPath(storeName, id), newEntry, AccessOption.PERSISTENT);
+      ret = getValueSchema(storeName, id);
+    }
+    return ret;
+  }
+
+  public boolean existsValueSchema(String storeName, String id) {
+    return schemaAccessor.exists(getValueSchemaPath(storeName, id), AccessOption.PERSISTENT);
+  }
+
   public List<SchemaEntry> getAllValueSchemas(String storeName) {
     return HelixUtils.getChildren(
         schemaAccessor,

--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/ReadWriteSchemaRepository.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/ReadWriteSchemaRepository.java
@@ -28,6 +28,12 @@ public interface ReadWriteSchemaRepository extends ReadOnlySchemaRepository {
       DirectionalSchemaCompatibilityType expectedCompatibilityType);
 
   /**
+   * Update the given store's value schema, specifying schema id to update.
+   */
+
+  SchemaEntry updateValueSchema(String storeName, String schemaStr, int id);
+
+  /**
    * Add a new value schema for the given store by specifying schema id.
    * This API is mostly intended to be used in cross-colo mode. When there
    * are multiple colos, we'd like to have consistent value id across colos,

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/Admin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/Admin.java
@@ -286,6 +286,8 @@ public interface Admin extends AutoCloseable, Closeable {
 
   SchemaEntry getValueSchema(String clusterName, String storeName, int id);
 
+  SchemaEntry updateValueSchema(String clusterName, String storeName, int schemaId, String newSchemaString);
+
   SchemaEntry addValueSchema(
       String clusterName,
       String storeName,

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -77,6 +77,7 @@ import com.linkedin.venice.helix.HelixReadOnlyStoreConfigRepository;
 import com.linkedin.venice.helix.HelixReadOnlyZKSharedSchemaRepository;
 import com.linkedin.venice.helix.HelixReadOnlyZKSharedSystemStoreRepository;
 import com.linkedin.venice.helix.HelixReadWriteLiveClusterConfigRepository;
+import com.linkedin.venice.helix.HelixReadWriteSchemaRepositoryAdapter;
 import com.linkedin.venice.helix.HelixState;
 import com.linkedin.venice.helix.HelixStoreGraveyard;
 import com.linkedin.venice.helix.Replica;
@@ -4551,6 +4552,16 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
     ReadWriteSchemaRepository schemaRepository = getHelixVeniceClusterResources(clusterName).getSchemaRepository();
     schemaRepository.addValueSchema(storeName, valueSchemaStr, expectedCompatibilityType);
     return new SchemaEntry(schemaRepository.getValueSchemaId(storeName, valueSchemaStr), valueSchemaStr);
+  }
+
+  @Override
+  public SchemaEntry updateValueSchema(String clusterName, String storeName, int schemaId, String newSchemaString) {
+    checkControllerLeadershipFor(clusterName);
+    HelixReadWriteSchemaRepositoryAdapter schemaRepository =
+        (HelixReadWriteSchemaRepositoryAdapter) getHelixVeniceClusterResources(clusterName).getSchemaRepository();
+    schemaRepository.updateValueSchema(storeName, newSchemaString, schemaId);
+    SchemaEntry ret = schemaRepository.getValueSchema(storeName, schemaId);
+    return ret;
   }
 
   /**

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
@@ -2836,6 +2836,19 @@ public class VeniceParentHelixAdmin implements Admin {
     }
   }
 
+  @Override
+  public SchemaEntry updateValueSchema(String clusterName, String storeName, int id, String valueSchemaStr) {
+    acquireAdminMessageLock(clusterName, storeName);
+    SchemaEntry ret = null;
+    try {
+      LOGGER.info("Updating value schema: {} in store: {}, cluster: {}", id, storeName, clusterName);
+      ret = getVeniceHelixAdmin().updateValueSchema(clusterName, storeName, id, valueSchemaStr);
+    } finally {
+      releaseAdminMessageLock(clusterName, storeName);
+    }
+    return ret;
+  }
+
   private SchemaEntry addValueAndSupersetSchemaEntries(
       String clusterName,
       String storeName,

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/AdminSparkServer.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/AdminSparkServer.java
@@ -97,6 +97,7 @@ import static com.linkedin.venice.controllerapi.ControllerRoute.UPDATE_KAFKA_TOP
 import static com.linkedin.venice.controllerapi.ControllerRoute.UPDATE_KAFKA_TOPIC_RETENTION;
 import static com.linkedin.venice.controllerapi.ControllerRoute.UPDATE_STORAGE_PERSONA;
 import static com.linkedin.venice.controllerapi.ControllerRoute.UPDATE_STORE;
+import static com.linkedin.venice.controllerapi.ControllerRoute.UPDATE_VALUE_SCHEMA;
 import static com.linkedin.venice.controllerapi.ControllerRoute.UPLOAD_PUSH_JOB_STATUS;
 import static com.linkedin.venice.controllerapi.ControllerRoute.WIPE_CLUSTER;
 
@@ -351,6 +352,7 @@ public class AdminSparkServer extends AbstractVeniceService {
     httpService.post(ADD_VALUE_SCHEMA.getPath(), schemaRoutes.addValueSchema(admin));
     httpService.post(ADD_DERIVED_SCHEMA.getPath(), schemaRoutes.addDerivedSchema(admin));
     httpService.get(GET_VALUE_SCHEMA.getPath(), schemaRoutes.getValueSchema(admin));
+    httpService.post(UPDATE_VALUE_SCHEMA.getPath(), schemaRoutes.updateValueSchema(admin));
     httpService.post(GET_VALUE_SCHEMA_ID.getPath(), schemaRoutes.getValueSchemaID(admin));
     httpService.post(GET_VALUE_OR_DERIVED_SCHEMA_ID.getPath(), schemaRoutes.getDerivedSchemaID(admin));
     httpService.get(GET_ALL_VALUE_SCHEMA.getPath(), schemaRoutes.getAllValueSchema(admin));

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/SchemaRoutes.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/SchemaRoutes.java
@@ -174,6 +174,13 @@ public class SchemaRoutes extends AbstractRoute {
       SchemaResponse responseObject = new SchemaResponse();
       response.type(HttpConstants.JSON);
       try {
+        // Only allow allowlist users to run this command
+        if (!isAllowListUser(request)) {
+          response.status(HttpStatus.SC_FORBIDDEN);
+          responseObject.setError("Only admin users are allowed to run " + request.url());
+          responseObject.setErrorType(ErrorType.BAD_REQUEST);
+          return AdminSparkServer.OBJECT_MAPPER.writeValueAsString(responseObject);
+        }
         AdminSparkServer.validateParams(request, UPDATE_VALUE_SCHEMA.getParams(), admin);
         responseObject.setCluster(request.queryParams(CLUSTER));
         responseObject.setName(request.queryParams(NAME));


### PR DESCRIPTION
## Summary
- Added a new endpoint to update a store's value schema in-place via id.
- Added functionality in HelixReadWriteSchemaRepository to allow for in-place updates.
- Added test cases.
Build scan: JDK11 7513

## How was this PR tested?
wc-test passed new test cases for the new endpoint.

## Does this PR introduce any user-facing changes?
- [x] No.
- [ ] Yes.