### PR TITLE
[server] Fix A/A RMD missing during repush when chunking is enabled

### DIFF
--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VeniceReducer.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VeniceReducer.java
@@ -113,9 +113,6 @@ public class VeniceReducer extends AbstractMapReduceTask
       this.rmdVersionId = rmdVersionId;
       this.consumer = writer -> {
         if (rmdPayload != null) {
-          if (rmdPayload.remaining() == 0) {
-            throw new VeniceException("Found empty replication metadata");
-          }
           if (valueBytes == null) {
             DeleteMetadata deleteMetadata = new DeleteMetadata(valueSchemaId, rmdVersionId, rmdPayload);
             writer.delete(keyBytes, callback, deleteMetadata);

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VeniceReducer.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VeniceReducer.java
@@ -113,6 +113,9 @@ public class VeniceReducer extends AbstractMapReduceTask
       this.rmdVersionId = rmdVersionId;
       this.consumer = writer -> {
         if (rmdPayload != null) {
+          if (rmdPayload.remaining() == 0) {
+            throw new VeniceException("Found empty replication metadata");
+          }
           if (valueBytes == null) {
             DeleteMetadata deleteMetadata = new DeleteMetadata(valueSchemaId, rmdVersionId, rmdPayload);
             writer.delete(keyBytes, callback, deleteMetadata);

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/input/kafka/VeniceKafkaInputReducer.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/input/kafka/VeniceKafkaInputReducer.java
@@ -96,11 +96,12 @@ public class VeniceKafkaInputReducer extends VeniceReducer {
       MRJobCounterHelper.incrRepushTtlFilterCount(reporter, 1L);
       return null;
     } else {
-      // TODO: RMD Chunking is not supported, so don't include RMD info in VeniceWriterMessage yet.
       return new VeniceWriterMessage(
           keyBytes,
           value.getBytes(),
           value.getSchemaID(),
+          value.getReplicationMetadataVersionId(),
+          value.getReplicationMetadataPayload(),
           getCallback(),
           isEnableWriteCompute(),
           getDerivedValueSchemaId());

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/input/kafka/VeniceKafkaInputReducer.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/input/kafka/VeniceKafkaInputReducer.java
@@ -96,6 +96,15 @@ public class VeniceKafkaInputReducer extends VeniceReducer {
       MRJobCounterHelper.incrRepushTtlFilterCount(reporter, 1L);
       return null;
     } else {
+      if (value.getReplicationMetadataPayload().remaining() == 0) {
+        return new VeniceWriterMessage(
+            keyBytes,
+            value.getBytes(),
+            value.getSchemaID(),
+            getCallback(),
+            isEnableWriteCompute(),
+            getDerivedValueSchemaId());
+      }
       return new VeniceWriterMessage(
           keyBytes,
           value.getBytes(),

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/input/kafka/chunk/ChunkAssembler.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/input/kafka/chunk/ChunkAssembler.java
@@ -63,10 +63,17 @@ public class ChunkAssembler {
     mapperValue = KAFKA_INPUT_MAPPER_VALUE_AVRO_SPECIFIC_DESERIALIZER.deserialize(mapperValue, largestValueBytes);
 
     if (mapperValue.valueType == MapperValueType.DELETE) {
+      if (mapperValue.replicationMetadataPayload.remaining() != 0) {
+        return new ValueBytesAndSchemaId(
+            null,
+            mapperValue.schemaId,
+            mapperValue.replicationMetadataVersionId,
+            mapperValue.replicationMetadataPayload);
+      }
       return null;
     } else if (mapperValue.schemaId > 0) {
       return new ValueBytesAndSchemaId(
-          mapperValue.value,
+          ByteUtils.extractByteArray(mapperValue.value),
           mapperValue.schemaId,
           mapperValue.replicationMetadataVersionId,
           mapperValue.replicationMetadataPayload);
@@ -158,10 +165,6 @@ public class ChunkAssembler {
 
     private final int replicationMetadataVersionId;
     private final ByteBuffer replicationMetadataPayload;
-
-    ValueBytesAndSchemaId(ByteBuffer byteBuffer, int schemaID, int rmdId, ByteBuffer rmdPayload) {
-      this(ByteUtils.extractByteArray(byteBuffer), schemaID, rmdId, rmdPayload);
-    }
 
     ValueBytesAndSchemaId(byte[] bytes, int schemaID, int rmdId, ByteBuffer rmdPayload) {
       this.bytes = bytes;

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/input/kafka/TestVeniceKafkaInputReducer.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/input/kafka/TestVeniceKafkaInputReducer.java
@@ -68,8 +68,7 @@ public class TestVeniceKafkaInputReducer {
     Assert.assertEquals(message.getKeyBytes(), keyBytes);
     Assert.assertEquals(message.getValueBytes(), (VALUE_PREFIX + 2).getBytes());
     Assert.assertEquals(message.getValueSchemaId(), 1);
-    // TODO: RMD chunking is not supported so RMD info doesn't get wrote back and remains -1.
-    Assert.assertEquals(message.getRmdVersionId(), isChunkingEnabled ? -1 : 1);
+    Assert.assertEquals(message.getRmdVersionId(), 1);
 
     /**
      * Construct a list of values, which contains both 'PUT' and 'DELETE', but 'DELETE' is the last one.
@@ -77,11 +76,7 @@ public class TestVeniceKafkaInputReducer {
     values = getValues(Arrays.asList(MapperValueType.PUT, MapperValueType.PUT, MapperValueType.DELETE));
 
     message = reducer.extract(keyWritable, values.iterator(), Mockito.mock(Reporter.class));
-    if (isChunkingEnabled) {
-      Assert.assertNull(message);
-    } else {
-      Assert.assertNotNull(message);
-    }
+    Assert.assertNotNull(message);
 
     /**
      * Construct a list of values, which contains both 'PUT' and 'DELETE', but 'DELETE' is in the middle.
@@ -93,8 +88,7 @@ public class TestVeniceKafkaInputReducer {
     Assert.assertEquals(message.getKeyBytes(), keyBytes);
     Assert.assertEquals(message.getValueBytes(), (VALUE_PREFIX + 2).getBytes());
     Assert.assertEquals(message.getValueSchemaId(), 1);
-    // TODO: RMD chunking is not supported so RMD info doesn't get wrote back and remains -1.
-    Assert.assertEquals(message.getRmdVersionId(), isChunkingEnabled ? -1 : 1);
+    Assert.assertEquals(message.getRmdVersionId(), 1);
   }
 
   @Test(dataProvider = "True-and-False", dataProviderClass = DataProviderUtils.class)


### PR DESCRIPTION
## [server] Fix A/A RMD missing during repush when chunking is enabled
This PR adds:
1. Available RMD info during repush when chunking is enabled
2. In the KIF reducer when chunking is enabled, make sure DELETE message is included when RMD data is present.

## How was this PR tested?
Internal CI, adjusted integration tests and unit tests.
## Does this PR introduce any user-facing changes?
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.