### PR TITLE
[server] Log exception message when forked process metric fetching request failed

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/main/MainIngestionRequestClient.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/main/MainIngestionRequestClient.java
@@ -23,6 +23,7 @@ import com.linkedin.venice.ingestion.protocol.enums.IngestionComponentType;
 import com.linkedin.venice.meta.IngestionMetadataUpdateType;
 import com.linkedin.venice.security.SSLFactory;
 import com.linkedin.venice.utils.ForkedJavaProcess;
+import com.linkedin.venice.utils.RedundantExceptionFilter;
 import com.linkedin.venice.utils.Utils;
 import java.io.Closeable;
 import java.util.ArrayList;
@@ -38,6 +39,9 @@ import org.apache.logging.log4j.Logger;
  */
 public class MainIngestionRequestClient implements Closeable {
   private static final Logger LOGGER = LogManager.getLogger(MainIngestionRequestClient.class);
+  private static final RedundantExceptionFilter REDUNDANT_EXCEPTION_FILTER =
+      RedundantExceptionFilter.getRedundantExceptionFilter();
+
   private static final int REQUEST_MAX_ATTEMPT = 10;
   private static final int PERIODIC_REQUEST_TIMEOUT_SECONDS = 5;
   private HttpClientTransport httpClientTransport;
@@ -245,6 +249,9 @@ public class MainIngestionRequestClient implements Closeable {
     } catch (Exception e) {
       // Don't spam the server logging.
       LOGGER.warn("Unable to get heartbeat from ingestion service");
+      if (!REDUNDANT_EXCEPTION_FILTER.isRedundantException(e.getMessage())) {
+        LOGGER.info(e);
+      }
       return false;
     }
   }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/main/MainIngestionRequestClient.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/main/MainIngestionRequestClient.java
@@ -238,6 +238,9 @@ public class MainIngestionRequestClient implements Closeable {
     } catch (Exception e) {
       // Don't spam the server logging.
       LOGGER.warn("Unable to collect metrics from ingestion service");
+      if (!REDUNDANT_EXCEPTION_FILTER.isRedundantException(e.getMessage())) {
+        LOGGER.info(e);
+      }
       return false;
     }
   }
@@ -249,9 +252,6 @@ public class MainIngestionRequestClient implements Closeable {
     } catch (Exception e) {
       // Don't spam the server logging.
       LOGGER.warn("Unable to get heartbeat from ingestion service");
-      if (!REDUNDANT_EXCEPTION_FILTER.isRedundantException(e.getMessage())) {
-        LOGGER.info(e);
-      }
       return false;
     }
   }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/main/MainIngestionRequestClient.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/main/MainIngestionRequestClient.java
@@ -239,7 +239,7 @@ public class MainIngestionRequestClient implements Closeable {
       // Don't spam the server logging.
       LOGGER.warn("Unable to collect metrics from ingestion service");
       if (!REDUNDANT_EXCEPTION_FILTER.isRedundantException(e.getMessage())) {
-        LOGGER.info(e);
+        LOGGER.warn(e);
       }
       return false;
     }


### PR DESCRIPTION
## [server] Log exception message when forked process metric fetching request failed
**Context:**
After adding a few fixes and more logging messages to isolated ingestion implementation, current test environment baking seems fine for ingestion behaviors / server start & stop for the most active clusters. However, it also reveal that metrics fetching failed constantly with log saying: "Unable to collect metrics from ingestion service".
With metrics fetching working correctly since beginning for Da Vinci use case, I suspect it is too many metrics number causing either metrics fetching timeout or message delivery failure, but will need to see the exact exception message to determine.
**Change:**
This PR tries to log exception message when main process failed to retrieve metrics from isolated ingestion process.

## How was this PR tested?
Internal CI, will need to reveal the exception in EI and propose real fix.
## Does this PR introduce any user-facing changes?
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.