### PR TITLE
[server] Bump ingestion isolation metric request timeout to 60 seconds

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/IsolatedIngestionBackend.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/IsolatedIngestionBackend.java
@@ -1,6 +1,5 @@
 package com.linkedin.davinci.ingestion;
 
-import static com.linkedin.venice.ConfigKeys.SERVER_INGESTION_ISOLATION_REQUEST_TIMEOUT_SECONDS;
 import static com.linkedin.venice.ingestion.protocol.enums.IngestionCommandType.DEMOTE_TO_STANDBY;
 import static com.linkedin.venice.ingestion.protocol.enums.IngestionCommandType.PROMOTE_TO_LEADER;
 import static com.linkedin.venice.ingestion.protocol.enums.IngestionCommandType.REMOVE_PARTITION;
@@ -69,10 +68,8 @@ public class IsolatedIngestionBackend extends DefaultIngestionBackend
     int listenerPort = configLoader.getVeniceServerConfig().getIngestionApplicationPort();
     this.configLoader = configLoader;
     Optional<SSLFactory> sslFactory = IsolatedIngestionUtils.getSSLFactory(configLoader);
-    int requestTimeoutInSeconds =
-        configLoader.getCombinedProperties().getInt(SERVER_INGESTION_ISOLATION_REQUEST_TIMEOUT_SECONDS, 60);
     // Create the ingestion request client.
-    mainIngestionRequestClient = new MainIngestionRequestClient(sslFactory, servicePort, requestTimeoutInSeconds);
+    mainIngestionRequestClient = new MainIngestionRequestClient(configLoader);
     // Create the forked isolated ingestion process.
     isolatedIngestionServiceProcess = mainIngestionRequestClient.startForkedIngestionProcess(configLoader);
     // Create and start the ingestion report listener.

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/isolated/IsolatedIngestionRequestClient.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/isolated/IsolatedIngestionRequestClient.java
@@ -1,6 +1,10 @@
 package com.linkedin.davinci.ingestion.isolated;
 
+import static com.linkedin.venice.ConfigKeys.SERVER_INGESTION_ISOLATION_REQUEST_TIMEOUT_SECONDS;
+
+import com.linkedin.davinci.config.VeniceConfigLoader;
 import com.linkedin.davinci.ingestion.HttpClientTransport;
+import com.linkedin.davinci.ingestion.utils.IsolatedIngestionUtils;
 import com.linkedin.venice.ingestion.protocol.IngestionTaskReport;
 import com.linkedin.venice.ingestion.protocol.enums.IngestionAction;
 import com.linkedin.venice.ingestion.protocol.enums.IngestionReportType;
@@ -12,14 +16,18 @@ import org.apache.logging.log4j.Logger;
 
 
 /**
- * IsolatedIngestionRequestClient sends requests to monitor service in main process and retrieves responses.
+ * This class sends requests to monitor service in main process and retrieves responses.
  */
 public class IsolatedIngestionRequestClient implements Closeable {
   private static final Logger LOGGER = LogManager.getLogger(IsolatedIngestionRequestClient.class);
 
   private final HttpClientTransport httpClientTransport;
 
-  public IsolatedIngestionRequestClient(Optional<SSLFactory> sslFactory, int port, int requestTimeoutInSeconds) {
+  public IsolatedIngestionRequestClient(VeniceConfigLoader configLoader) {
+    Optional<SSLFactory> sslFactory = IsolatedIngestionUtils.getSSLFactory(configLoader);
+    int port = configLoader.getVeniceServerConfig().getIngestionApplicationPort();
+    int requestTimeoutInSeconds =
+        configLoader.getCombinedProperties().getInt(SERVER_INGESTION_ISOLATION_REQUEST_TIMEOUT_SECONDS, 120);
     httpClientTransport = new HttpClientTransport(sslFactory, port, requestTimeoutInSeconds);
   }
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/isolated/IsolatedIngestionServer.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/isolated/IsolatedIngestionServer.java
@@ -2,8 +2,7 @@ package com.linkedin.davinci.ingestion.isolated;
 
 import static com.linkedin.venice.ConfigKeys.CLUSTER_DISCOVERY_D2_SERVICE;
 import static com.linkedin.venice.ConfigKeys.D2_ZK_HOSTS_ADDRESS;
-import static com.linkedin.venice.ConfigKeys.SERVER_INGESTION_ISOLATION_HEARTBEAT_TIMEOUT_MS;
-import static com.linkedin.venice.ConfigKeys.SERVER_INGESTION_ISOLATION_REQUEST_TIMEOUT_SECONDS;
+import static com.linkedin.venice.ConfigKeys.SERVER_INGESTION_ISOLATION_CONNECTION_TIMEOUT_MS;
 import static com.linkedin.venice.ConfigKeys.SERVER_INGESTION_ISOLATION_STATS_CLASS_LIST;
 import static com.linkedin.venice.ConfigKeys.SERVER_REMOTE_INGESTION_REPAIR_SLEEP_INTERVAL_SECONDS;
 import static com.linkedin.venice.ConfigKeys.SERVER_STOP_CONSUMPTION_WAIT_RETRIES_NUM;
@@ -158,7 +157,7 @@ public class IsolatedIngestionServer extends AbstractVeniceService {
     this.configLoader = new VeniceConfigLoader(loadedVeniceProperties, loadedVeniceProperties, kafkaClusterMap);
     this.servicePort = configLoader.getVeniceServerConfig().getIngestionServicePort();
     this.heartbeatTimeoutMs = configLoader.getCombinedProperties()
-        .getLong(SERVER_INGESTION_ISOLATION_HEARTBEAT_TIMEOUT_MS, 180 * Time.MS_PER_SECOND);
+        .getLong(SERVER_INGESTION_ISOLATION_CONNECTION_TIMEOUT_MS, 180 * Time.MS_PER_SECOND);
     // Initialize Netty server.
     Class<? extends ServerChannel> serverSocketChannelClass = NioServerSocketChannel.class;
     bossGroup = new NioEventLoopGroup();
@@ -671,10 +670,7 @@ public class IsolatedIngestionServer extends AbstractVeniceService {
         "Starting report client with target application port: {}",
         configLoader.getVeniceServerConfig().getIngestionApplicationPort());
     // Create Netty client to report status back to application.
-    reportClient = new IsolatedIngestionRequestClient(
-        IsolatedIngestionUtils.getSSLFactory(configLoader),
-        configLoader.getVeniceServerConfig().getIngestionApplicationPort(),
-        configLoader.getCombinedProperties().getInt(SERVER_INGESTION_ISOLATION_REQUEST_TIMEOUT_SECONDS, 120));
+    reportClient = new IsolatedIngestionRequestClient(configLoader);
 
     // Mark the IsolatedIngestionServer as initiated.
     isInitiated = true;

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/main/MainIngestionMonitorService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/main/MainIngestionMonitorService.java
@@ -1,7 +1,6 @@
 package com.linkedin.davinci.ingestion.main;
 
-import static com.linkedin.venice.ConfigKeys.SERVER_INGESTION_ISOLATION_HEARTBEAT_TIMEOUT_MS;
-import static com.linkedin.venice.ConfigKeys.SERVER_INGESTION_ISOLATION_REQUEST_TIMEOUT_SECONDS;
+import static com.linkedin.venice.ConfigKeys.SERVER_INGESTION_ISOLATION_CONNECTION_TIMEOUT_MS;
 import static java.lang.Thread.currentThread;
 
 import com.linkedin.davinci.config.VeniceConfigLoader;
@@ -80,7 +79,6 @@ public class MainIngestionMonitorService extends AbstractVeniceService {
    */
   private long heartbeatTimeoutMs;
   private volatile long latestHeartbeatTimestamp = -1;
-  private final int requestTimeoutInSeconds;
 
   public MainIngestionMonitorService(
       IsolatedIngestionBackend ingestionBackend,
@@ -106,10 +104,8 @@ public class MainIngestionMonitorService extends AbstractVeniceService {
         .option(ChannelOption.SO_REUSEADDR, true)
         .childOption(ChannelOption.TCP_NODELAY, true);
 
-    this.requestTimeoutInSeconds =
-        configLoader.getCombinedProperties().getInt(SERVER_INGESTION_ISOLATION_REQUEST_TIMEOUT_SECONDS, 120);
-    heartbeatClient = new MainIngestionRequestClient(this.sslFactory, this.servicePort, requestTimeoutInSeconds);
-    metricsClient = new MainIngestionRequestClient(this.sslFactory, this.servicePort, requestTimeoutInSeconds);
+    heartbeatClient = new MainIngestionRequestClient(configLoader);
+    metricsClient = new MainIngestionRequestClient(configLoader);
 
   }
 
@@ -118,7 +114,7 @@ public class MainIngestionMonitorService extends AbstractVeniceService {
     serverFuture = bootstrap.bind(applicationPort).sync();
     LOGGER.info("Report listener service started on port: {}", applicationPort);
     heartbeatTimeoutMs = configLoader.getCombinedProperties()
-        .getLong(SERVER_INGESTION_ISOLATION_HEARTBEAT_TIMEOUT_MS, 180 * Time.MS_PER_SECOND);
+        .getLong(SERVER_INGESTION_ISOLATION_CONNECTION_TIMEOUT_MS, 180 * Time.MS_PER_SECOND);
     setupMetricsCollection();
 
     // There is no async process in this function, so we are completely finished with the start-up process.
@@ -258,8 +254,7 @@ public class MainIngestionMonitorService extends AbstractVeniceService {
         "Lost connection to forked ingestion process since timestamp {}, restarting forked process.",
         latestHeartbeatTimestamp);
     heartbeatStats.recordForkedProcessRestart();
-    try (MainIngestionRequestClient client =
-        new MainIngestionRequestClient(sslFactory, servicePort, requestTimeoutInSeconds)) {
+    try (MainIngestionRequestClient client = new MainIngestionRequestClient(configLoader)) {
       /**
        * We need to destroy the previous isolated ingestion process first.
        * The previous isolated ingestion process might have released the port binding, but it might still taking up all
@@ -279,8 +274,7 @@ public class MainIngestionMonitorService extends AbstractVeniceService {
   }
 
   private void resumeOngoingIngestionTasks() {
-    try (MainIngestionRequestClient client =
-        new MainIngestionRequestClient(sslFactory, servicePort, requestTimeoutInSeconds)) {
+    try (MainIngestionRequestClient client = new MainIngestionRequestClient(configLoader)) {
       LOGGER.info("Start to recover ongoing ingestion tasks: {}", topicIngestionStatusMap);
       // Re-open metadata partitions in child process for all previously subscribed topics.
       topicIngestionStatusMap.keySet().forEach(client::openStorageEngine);

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/main/MainIngestionMonitorService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/main/MainIngestionMonitorService.java
@@ -302,11 +302,14 @@ public class MainIngestionMonitorService extends AbstractVeniceService {
 
   private void collectIngestionServiceMetrics() {
     long requestTimestamp = System.currentTimeMillis();
-    if (!metricsClient.collectMetrics(isolatedIngestionProcessStats)) {
+    if (metricsClient.collectMetrics(isolatedIngestionProcessStats)) {
+      LOGGER.info(
+          "Metric request completed in {} seconds.",
+          TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis() - requestTimestamp));
+    } else {
       LOGGER.warn(
-          "Metric request to forked process issued at {}, failed at {}",
-          System.currentTimeMillis(),
-          requestTimestamp);
+          "Unable to collect metrics from ingestion service after {} s.",
+          TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis() - requestTimestamp));
     }
   }
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/main/MainIngestionRequestClient.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/main/MainIngestionRequestClient.java
@@ -3,7 +3,9 @@ package com.linkedin.davinci.ingestion.main;
 import static com.linkedin.davinci.ingestion.utils.IsolatedIngestionUtils.buildAndSaveConfigsForForkedIngestionProcess;
 import static com.linkedin.davinci.ingestion.utils.IsolatedIngestionUtils.getDummyCommand;
 import static com.linkedin.davinci.ingestion.utils.IsolatedIngestionUtils.saveForkedIngestionKafkaClusterMapConfig;
-import static com.linkedin.venice.ConfigKeys.*;
+import static com.linkedin.venice.ConfigKeys.SERVER_INGESTION_ISOLATION_HEARTBEAT_REQUEST_TIMEOUT_SECONDS;
+import static com.linkedin.venice.ConfigKeys.SERVER_INGESTION_ISOLATION_METRIC_REQUEST_TIMEOUT_SECONDS;
+import static com.linkedin.venice.ConfigKeys.SERVER_INGESTION_ISOLATION_REQUEST_TIMEOUT_SECONDS;
 import static com.linkedin.venice.ingestion.protocol.enums.IngestionCommandType.START_CONSUMPTION;
 
 import com.linkedin.davinci.config.VeniceConfigLoader;

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/main/MainIngestionRequestClient.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/main/MainIngestionRequestClient.java
@@ -3,6 +3,7 @@ package com.linkedin.davinci.ingestion.main;
 import static com.linkedin.davinci.ingestion.utils.IsolatedIngestionUtils.buildAndSaveConfigsForForkedIngestionProcess;
 import static com.linkedin.davinci.ingestion.utils.IsolatedIngestionUtils.getDummyCommand;
 import static com.linkedin.davinci.ingestion.utils.IsolatedIngestionUtils.saveForkedIngestionKafkaClusterMapConfig;
+import static com.linkedin.venice.ConfigKeys.*;
 import static com.linkedin.venice.ingestion.protocol.enums.IngestionCommandType.START_CONSUMPTION;
 
 import com.linkedin.davinci.config.VeniceConfigLoader;
@@ -43,11 +44,19 @@ public class MainIngestionRequestClient implements Closeable {
       RedundantExceptionFilter.getRedundantExceptionFilter();
 
   private static final int REQUEST_MAX_ATTEMPT = 10;
-  private static final int HEARTBEAT_REQUEST_TIMEOUT_SECONDS = 5;
-  private static final int METRIC_REQUEST_TIMEOUT_SECONDS = 60;
   private HttpClientTransport httpClientTransport;
+  private final int heartbeatRequestTimeoutSeconds;
+  private final int metricRequestTimeoutSeconds;
 
-  public MainIngestionRequestClient(Optional<SSLFactory> sslFactory, int port, int requestTimeoutInSeconds) {
+  public MainIngestionRequestClient(VeniceConfigLoader configLoader) {
+    heartbeatRequestTimeoutSeconds =
+        configLoader.getCombinedProperties().getInt(SERVER_INGESTION_ISOLATION_HEARTBEAT_REQUEST_TIMEOUT_SECONDS, 5);
+    metricRequestTimeoutSeconds =
+        configLoader.getCombinedProperties().getInt(SERVER_INGESTION_ISOLATION_METRIC_REQUEST_TIMEOUT_SECONDS, 60);
+    Optional<SSLFactory> sslFactory = IsolatedIngestionUtils.getSSLFactory(configLoader);
+    int port = configLoader.getVeniceServerConfig().getIngestionServicePort();
+    int requestTimeoutInSeconds =
+        configLoader.getCombinedProperties().getInt(SERVER_INGESTION_ISOLATION_REQUEST_TIMEOUT_SECONDS, 120);
     httpClientTransport = new HttpClientTransport(sslFactory, port, requestTimeoutInSeconds);
   }
 
@@ -229,7 +238,7 @@ public class MainIngestionRequestClient implements Closeable {
   public boolean collectMetrics(IsolatedIngestionProcessStats isolatedIngestionProcessStats) {
     try {
       IngestionMetricsReport metricsReport =
-          httpClientTransport.sendRequest(IngestionAction.METRIC, getDummyCommand(), METRIC_REQUEST_TIMEOUT_SECONDS);
+          httpClientTransport.sendRequest(IngestionAction.METRIC, getDummyCommand(), metricRequestTimeoutSeconds);
       isolatedIngestionProcessStats.updateMetricMap(metricsReport.aggregatedMetrics);
       return true;
     } catch (Exception e) {
@@ -243,7 +252,7 @@ public class MainIngestionRequestClient implements Closeable {
 
   public boolean sendHeartbeatRequest() {
     try {
-      httpClientTransport.sendRequest(IngestionAction.HEARTBEAT, getDummyCommand(), HEARTBEAT_REQUEST_TIMEOUT_SECONDS);
+      httpClientTransport.sendRequest(IngestionAction.HEARTBEAT, getDummyCommand(), heartbeatRequestTimeoutSeconds);
       return true;
     } catch (Exception e) {
       // Don't spam the server logging.

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/main/MainIngestionStorageMetadataService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/main/MainIngestionStorageMetadataService.java
@@ -1,7 +1,5 @@
 package com.linkedin.davinci.ingestion.main;
 
-import static com.linkedin.venice.ConfigKeys.SERVER_INGESTION_ISOLATION_REQUEST_TIMEOUT_SECONDS;
-
 import com.linkedin.davinci.config.VeniceConfigLoader;
 import com.linkedin.davinci.ingestion.IsolatedIngestionBackend;
 import com.linkedin.davinci.ingestion.utils.IsolatedIngestionUtils;
@@ -57,12 +55,7 @@ public class MainIngestionStorageMetadataService extends AbstractVeniceService i
       MetadataUpdateStats metadataUpdateStats,
       VeniceConfigLoader configLoader,
       BiConsumer<String, StoreVersionState> storeVersionStateSyncer) {
-    int requestTimeoutInSeconds =
-        configLoader.getCombinedProperties().getInt(SERVER_INGESTION_ISOLATION_REQUEST_TIMEOUT_SECONDS, 60);
-    this.client = new MainIngestionRequestClient(
-        IsolatedIngestionUtils.getSSLFactory(configLoader),
-        targetPort,
-        requestTimeoutInSeconds);
+    this.client = new MainIngestionRequestClient(configLoader);
     this.partitionStateSerializer = partitionStateSerializer;
     this.metadataUpdateStats = metadataUpdateStats;
     this.metadataUpdateWorker = new MetadataUpdateWorker();

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/ingestion/main/MainIngestionRequestClientTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/ingestion/main/MainIngestionRequestClientTest.java
@@ -2,12 +2,15 @@ package com.linkedin.davinci.ingestion.main;
 
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyInt;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import com.linkedin.davinci.config.VeniceConfigLoader;
+import com.linkedin.davinci.config.VeniceServerConfig;
 import com.linkedin.davinci.ingestion.HttpClientTransport;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.ingestion.protocol.IngestionTaskReport;
-import java.util.Optional;
+import com.linkedin.venice.utils.VeniceProperties;
 import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -18,7 +21,14 @@ public class MainIngestionRequestClientTest {
 
   @Test(timeOut = TIMEOUT_IN_MILLIS)
   public void testIngestionCommand() {
-    try (MainIngestionRequestClient client = new MainIngestionRequestClient(Optional.empty(), 12345, 120)) {
+
+    VeniceServerConfig serverConfig = mock(VeniceServerConfig.class);
+    when(serverConfig.getIngestionServicePort()).thenReturn(12345);
+    VeniceConfigLoader configLoader = mock(VeniceConfigLoader.class);
+    when(configLoader.getVeniceServerConfig()).thenReturn(serverConfig);
+    VeniceProperties combinedProperties = mock(VeniceProperties.class);
+    when(configLoader.getCombinedProperties()).thenReturn(combinedProperties);
+    try (MainIngestionRequestClient client = new MainIngestionRequestClient(configLoader)) {
       HttpClientTransport mockedClientTransport = Mockito.mock(HttpClientTransport.class);
       IngestionTaskReport taskReport = new IngestionTaskReport();
       taskReport.setMessage("TEST MSG");

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/ingestion/main/TestMainIngestionRequestClient.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/ingestion/main/TestMainIngestionRequestClient.java
@@ -2,11 +2,14 @@ package com.linkedin.davinci.ingestion.main;
 
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyInt;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import com.linkedin.davinci.config.VeniceConfigLoader;
+import com.linkedin.davinci.config.VeniceServerConfig;
 import com.linkedin.davinci.ingestion.HttpClientTransport;
 import com.linkedin.venice.ingestion.protocol.IngestionTaskReport;
-import java.util.Optional;
+import com.linkedin.venice.utils.VeniceProperties;
 import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -18,9 +21,13 @@ public class TestMainIngestionRequestClient {
     String topicName = "testTopic";
     int partitionId = 1;
 
-    try (
-        MainIngestionRequestClient ingestionRequestClient =
-            new MainIngestionRequestClient(Optional.empty(), 12345, 120);
+    VeniceServerConfig serverConfig = mock(VeniceServerConfig.class);
+    when(serverConfig.getIngestionServicePort()).thenReturn(12345);
+    VeniceConfigLoader configLoader = mock(VeniceConfigLoader.class);
+    when(configLoader.getVeniceServerConfig()).thenReturn(serverConfig);
+    VeniceProperties combinedProperties = mock(VeniceProperties.class);
+    when(configLoader.getCombinedProperties()).thenReturn(combinedProperties);
+    try (MainIngestionRequestClient ingestionRequestClient = new MainIngestionRequestClient(configLoader);
         HttpClientTransport mockTransport = Mockito.mock(HttpClientTransport.class)) {
       // Client should throw exception when connection is bad.
       Assert.assertThrows(() -> ingestionRequestClient.startConsumption(topicName, partitionId));

--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -657,17 +657,30 @@ public class ConfigKeys {
    */
   public static final String SERVER_FORKED_PROCESS_JVM_ARGUMENT_LIST = "server.forked.process.jvm.arg.list";
 
+  /**
+   * Timeout for connection between main process and forked ingestion process. If heartbeat is not refreshed within this
+   * timeout, both processes should act to reconstruct the state in order to restore connection and service.
+   */
   public static final String SERVER_INGESTION_ISOLATION_CONNECTION_TIMEOUT_MS =
-      "server.ingestion.isolation.connection.timout.ms";
+      "server.ingestion.isolation.connection.timeout.ms";
 
+  /**
+   * Timeout for single ingestion command request sent from main process to forked ingestion process.
+   */
   public static final String SERVER_INGESTION_ISOLATION_REQUEST_TIMEOUT_SECONDS =
-      "server.ingestion.isolation.request.timout.seconds";
+      "server.ingestion.isolation.request.timeout.seconds";
 
+  /**
+   * Timeout for single heartbeat request sent from main process to forked ingestion process.
+   */
   public static final String SERVER_INGESTION_ISOLATION_HEARTBEAT_REQUEST_TIMEOUT_SECONDS =
-      "server.ingestion.isolation.heartbeat.request.timout.seconds";
+      "server.ingestion.isolation.heartbeat.request.timeout.seconds";
 
+  /**
+   * Timeout for single metric request sent from main process to forked ingestion process.
+   */
   public static final String SERVER_INGESTION_ISOLATION_METRIC_REQUEST_TIMEOUT_SECONDS =
-      "server.ingestion.isolation.metric.request.timout.seconds";
+      "server.ingestion.isolation.metric.request.timeout.seconds";
 
   /**
    * whether to enable checksum verification in the ingestion path from kafka to database persistency. If enabled it will

--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -661,8 +661,8 @@ public class ConfigKeys {
    * Timeout for connection between main process and forked ingestion process. If heartbeat is not refreshed within this
    * timeout, both processes should act to reconstruct the state in order to restore connection and service.
    */
-  public static final String SERVER_INGESTION_ISOLATION_CONNECTION_TIMEOUT_MS =
-      "server.ingestion.isolation.connection.timeout.ms";
+  public static final String SERVER_INGESTION_ISOLATION_CONNECTION_TIMEOUT_SECONDS =
+      "server.ingestion.isolation.connection.timeout.seconds";
 
   /**
    * Timeout for single ingestion command request sent from main process to forked ingestion process.

--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -646,9 +646,6 @@ public class ConfigKeys {
   public static final String SERVER_INGESTION_ISOLATION_STATS_CLASS_LIST =
       "server.ingestion.isolation.stats.class.list";
 
-  public static final String SERVER_INGESTION_ISOLATION_HEARTBEAT_TIMEOUT_MS =
-      "server.ingestion.isolation.heartbeat.timout.ms";
-
   public static final String SERVER_INGESTION_ISOLATION_SSL_ENABLED = "server.ingestion.isolation.ssl.enabled";
 
   public static final String SERVER_INGESTION_ISOLATION_ACL_ENABLED = "server.ingestion.isolation.acl.enabled";
@@ -660,8 +657,17 @@ public class ConfigKeys {
    */
   public static final String SERVER_FORKED_PROCESS_JVM_ARGUMENT_LIST = "server.forked.process.jvm.arg.list";
 
+  public static final String SERVER_INGESTION_ISOLATION_CONNECTION_TIMEOUT_MS =
+      "server.ingestion.isolation.connection.timout.ms";
+
   public static final String SERVER_INGESTION_ISOLATION_REQUEST_TIMEOUT_SECONDS =
       "server.ingestion.isolation.request.timout.seconds";
+
+  public static final String SERVER_INGESTION_ISOLATION_HEARTBEAT_REQUEST_TIMEOUT_SECONDS =
+      "server.ingestion.isolation.heartbeat.request.timout.seconds";
+
+  public static final String SERVER_INGESTION_ISOLATION_METRIC_REQUEST_TIMEOUT_SECONDS =
+      "server.ingestion.isolation.metric.request.timout.seconds";
 
   /**
    * whether to enable checksum verification in the ingestion path from kafka to database persistency. If enabled it will

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/davinci/DaVinciUserApp.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/davinci/DaVinciUserApp.java
@@ -1,7 +1,7 @@
 package com.linkedin.davinci;
 
 import static com.linkedin.venice.ConfigKeys.DATA_BASE_PATH;
-import static com.linkedin.venice.ConfigKeys.SERVER_INGESTION_ISOLATION_CONNECTION_TIMEOUT_MS;
+import static com.linkedin.venice.ConfigKeys.SERVER_INGESTION_ISOLATION_CONNECTION_TIMEOUT_SECONDS;
 import static com.linkedin.venice.ConfigKeys.SERVER_INGESTION_MODE;
 import static com.linkedin.venice.meta.IngestionMode.ISOLATED;
 
@@ -44,8 +44,7 @@ public class DaVinciUserApp {
 
     Map<String, Object> extraBackendConfig = new HashMap<>();
     extraBackendConfig.put(SERVER_INGESTION_MODE, ISOLATED);
-    extraBackendConfig
-        .put(SERVER_INGESTION_ISOLATION_CONNECTION_TIMEOUT_MS, TimeUnit.SECONDS.toMillis(heartbeatTimeoutSeconds));
+    extraBackendConfig.put(SERVER_INGESTION_ISOLATION_CONNECTION_TIMEOUT_SECONDS, heartbeatTimeoutSeconds);
     extraBackendConfig.put(DATA_BASE_PATH, baseDataPath);
 
     DaVinciTestContext<Integer, Integer> daVinciTestContext =

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/davinci/DaVinciUserApp.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/davinci/DaVinciUserApp.java
@@ -1,7 +1,7 @@
 package com.linkedin.davinci;
 
 import static com.linkedin.venice.ConfigKeys.DATA_BASE_PATH;
-import static com.linkedin.venice.ConfigKeys.SERVER_INGESTION_ISOLATION_HEARTBEAT_TIMEOUT_MS;
+import static com.linkedin.venice.ConfigKeys.SERVER_INGESTION_ISOLATION_CONNECTION_TIMEOUT_MS;
 import static com.linkedin.venice.ConfigKeys.SERVER_INGESTION_MODE;
 import static com.linkedin.venice.meta.IngestionMode.ISOLATED;
 
@@ -45,7 +45,7 @@ public class DaVinciUserApp {
     Map<String, Object> extraBackendConfig = new HashMap<>();
     extraBackendConfig.put(SERVER_INGESTION_MODE, ISOLATED);
     extraBackendConfig
-        .put(SERVER_INGESTION_ISOLATION_HEARTBEAT_TIMEOUT_MS, TimeUnit.SECONDS.toMillis(heartbeatTimeoutSeconds));
+        .put(SERVER_INGESTION_ISOLATION_CONNECTION_TIMEOUT_MS, TimeUnit.SECONDS.toMillis(heartbeatTimeoutSeconds));
     extraBackendConfig.put(DATA_BASE_PATH, baseDataPath);
 
     DaVinciTestContext<Integer, Integer> daVinciTestContext =

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/davinci/ingestion/IsolatedIngestionServerTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/davinci/ingestion/IsolatedIngestionServerTest.java
@@ -7,7 +7,7 @@ import static com.linkedin.venice.ConfigKeys.CLUSTER_NAME;
 import static com.linkedin.venice.ConfigKeys.D2_ZK_HOSTS_ADDRESS;
 import static com.linkedin.venice.ConfigKeys.KAFKA_BOOTSTRAP_SERVERS;
 import static com.linkedin.venice.ConfigKeys.KAFKA_ZK_ADDRESS;
-import static com.linkedin.venice.ConfigKeys.SERVER_INGESTION_ISOLATION_CONNECTION_TIMEOUT_MS;
+import static com.linkedin.venice.ConfigKeys.SERVER_INGESTION_ISOLATION_CONNECTION_TIMEOUT_SECONDS;
 import static com.linkedin.venice.ConfigKeys.SERVER_INGESTION_ISOLATION_SERVICE_PORT;
 import static com.linkedin.venice.ConfigKeys.SERVER_PARTITION_GRACEFUL_DROP_DELAY_IN_SECONDS;
 import static com.linkedin.venice.ConfigKeys.ZOOKEEPER_ADDRESS;
@@ -128,7 +128,7 @@ public class IsolatedIngestionServerTest {
         .put(KAFKA_ZK_ADDRESS, Utils.getUniqueString())
         .put(D2_ZK_HOSTS_ADDRESS, zkServerWrapper.getAddress())
         .put(SERVER_PARTITION_GRACEFUL_DROP_DELAY_IN_SECONDS, 100)
-        .put(SERVER_INGESTION_ISOLATION_CONNECTION_TIMEOUT_MS, 10 * Time.MS_PER_SECOND)
+        .put(SERVER_INGESTION_ISOLATION_CONNECTION_TIMEOUT_SECONDS, 10)
         .put(INGESTION_ISOLATION_CONFIG_PREFIX + "." + SERVER_PARTITION_GRACEFUL_DROP_DELAY_IN_SECONDS, 10)
         .put(SERVER_INGESTION_ISOLATION_SERVICE_PORT, servicePort)
         .build();

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/davinci/ingestion/IsolatedIngestionServerTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/davinci/ingestion/IsolatedIngestionServerTest.java
@@ -7,7 +7,7 @@ import static com.linkedin.venice.ConfigKeys.CLUSTER_NAME;
 import static com.linkedin.venice.ConfigKeys.D2_ZK_HOSTS_ADDRESS;
 import static com.linkedin.venice.ConfigKeys.KAFKA_BOOTSTRAP_SERVERS;
 import static com.linkedin.venice.ConfigKeys.KAFKA_ZK_ADDRESS;
-import static com.linkedin.venice.ConfigKeys.SERVER_INGESTION_ISOLATION_HEARTBEAT_TIMEOUT_MS;
+import static com.linkedin.venice.ConfigKeys.SERVER_INGESTION_ISOLATION_CONNECTION_TIMEOUT_MS;
 import static com.linkedin.venice.ConfigKeys.SERVER_INGESTION_ISOLATION_SERVICE_PORT;
 import static com.linkedin.venice.ConfigKeys.SERVER_PARTITION_GRACEFUL_DROP_DELAY_IN_SECONDS;
 import static com.linkedin.venice.ConfigKeys.ZOOKEEPER_ADDRESS;
@@ -51,8 +51,7 @@ public class IsolatedIngestionServerTest {
   public void testShutdownAfterHeartbeatTimeout() {
     int servicePort = Utils.getFreePort();
     VeniceConfigLoader configLoader = getConfigLoader(servicePort);
-    try (MainIngestionRequestClient client =
-        new MainIngestionRequestClient(IsolatedIngestionUtils.getSSLFactory(configLoader), servicePort, 120)) {
+    try (MainIngestionRequestClient client = new MainIngestionRequestClient(configLoader)) {
       Process isolatedIngestionService = client.startForkedIngestionProcess(configLoader);
       TestUtils.waitForNonDeterministicAssertion(
           10,
@@ -71,8 +70,7 @@ public class IsolatedIngestionServerTest {
   public void testReleaseTargetPortBinding() {
     int servicePort = Utils.getFreePort();
     VeniceConfigLoader configLoader = getConfigLoader(servicePort);
-    try (MainIngestionRequestClient client =
-        new MainIngestionRequestClient(IsolatedIngestionUtils.getSSLFactory(configLoader), servicePort, 120)) {
+    try (MainIngestionRequestClient client = new MainIngestionRequestClient(configLoader)) {
       // Make sure the process is forked successfully.
       ForkedJavaProcess isolatedIngestionService = (ForkedJavaProcess) client.startForkedIngestionProcess(configLoader);
       Assert.assertTrue(isolatedIngestionService.isAlive());
@@ -130,7 +128,7 @@ public class IsolatedIngestionServerTest {
         .put(KAFKA_ZK_ADDRESS, Utils.getUniqueString())
         .put(D2_ZK_HOSTS_ADDRESS, zkServerWrapper.getAddress())
         .put(SERVER_PARTITION_GRACEFUL_DROP_DELAY_IN_SECONDS, 100)
-        .put(SERVER_INGESTION_ISOLATION_HEARTBEAT_TIMEOUT_MS, 10 * Time.MS_PER_SECOND)
+        .put(SERVER_INGESTION_ISOLATION_CONNECTION_TIMEOUT_MS, 10 * Time.MS_PER_SECOND)
         .put(INGESTION_ISOLATION_CONFIG_PREFIX + "." + SERVER_PARTITION_GRACEFUL_DROP_DELAY_IN_SECONDS, 10)
         .put(SERVER_INGESTION_ISOLATION_SERVICE_PORT, servicePort)
         .build();

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/DaVinciClientTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/DaVinciClientTest.java
@@ -6,7 +6,7 @@ import static com.linkedin.venice.ConfigKeys.D2_ZK_HOSTS_ADDRESS;
 import static com.linkedin.venice.ConfigKeys.DATA_BASE_PATH;
 import static com.linkedin.venice.ConfigKeys.PERSISTENCE_TYPE;
 import static com.linkedin.venice.ConfigKeys.SERVER_CONSUMER_POOL_SIZE_PER_KAFKA_CLUSTER;
-import static com.linkedin.venice.ConfigKeys.SERVER_INGESTION_ISOLATION_CONNECTION_TIMEOUT_MS;
+import static com.linkedin.venice.ConfigKeys.SERVER_INGESTION_ISOLATION_CONNECTION_TIMEOUT_SECONDS;
 import static com.linkedin.venice.ConfigKeys.SERVER_INGESTION_ISOLATION_SERVICE_PORT;
 import static com.linkedin.venice.ConfigKeys.SERVER_PROMOTION_TO_LEADER_REPLICA_DELAY_SECONDS;
 import static com.linkedin.venice.ConfigKeys.VENICE_PARTITIONERS;
@@ -71,7 +71,6 @@ import com.linkedin.venice.utils.Pair;
 import com.linkedin.venice.utils.PropertyBuilder;
 import com.linkedin.venice.utils.TestUtils;
 import com.linkedin.venice.utils.TestWriteUtils;
-import com.linkedin.venice.utils.Time;
 import com.linkedin.venice.utils.Utils;
 import com.linkedin.venice.utils.VeniceProperties;
 import com.linkedin.venice.writer.VeniceWriter;
@@ -363,7 +362,7 @@ public class DaVinciClientTest {
     VeniceKafkaSerializer valueSerializer = new VeniceAvroKafkaSerializer(DEFAULT_VALUE_SCHEMA);
 
     Map<String, Object> extraBackendConfigMap = TestUtils.getIngestionIsolationPropertyMap();
-    extraBackendConfigMap.put(SERVER_INGESTION_ISOLATION_CONNECTION_TIMEOUT_MS, 5 * Time.MS_PER_SECOND);
+    extraBackendConfigMap.put(SERVER_INGESTION_ISOLATION_CONNECTION_TIMEOUT_SECONDS, 5);
 
     DaVinciTestContext<Integer, Integer> daVinciTestContext =
         ServiceFactory.getGenericAvroDaVinciFactoryAndClientWithRetries(


### PR DESCRIPTION
## [server] Bump ingestion isolation metric request timeout to 60 seconds
We found that ingestion isolation metric request cannot completed within 5s timeout in recent releases debugging. After frankenWar experiment we found that it takes ~15s to complete in venice-1 EI environment. 

This PR adjusts the request timeout as a short term solution to make sure metrics will be collected successfully. In the long term, we should find a solution to collect the metrics efficiently with much less query time.
**Changes in this PR:**
1. Introduces 2 new configs to control heartbeat and metric request timeout:
SERVER_INGESTION_ISOLATION_HEARTBEAT_REQUEST_TIMEOUT_SECONDS (default = 5s)
SERVER_INGESTION_ISOLATION_METRIC_REQUEST_TIMEOUT_SECONDS (default = 60s)
We can continue to tweak it with config change PR in venice-backend.
2. Minor refactor to let request client class constructor take single config loader parameter for simplicity and readability.

## How was this PR tested?
Internal CI. Deployed onto a host in pre-production env.

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.