### PR TITLE
[server] Add periodic refresh of quota usage metric

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -1389,6 +1389,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
     if (emitMetrics.get()) {
       long currentQuota = store.getStorageQuotaInByte();
       hostLevelIngestionStats.recordDiskQuotaAllowed(currentQuota);
+      hostLevelIngestionStats.recordStorageQuotaUsed(storageUtilizationManager.getDiskQuotaUsage());
     }
   }
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -1345,7 +1345,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
 
     idleCounter = 0;
     maybeUnsubscribeCompletedPartitions(store);
-    recordDiskQuotaAllowedForStore(store);
+    recordQuotaMetrics(store);
 
     /**
      * While using the shared consumer, we still need to check hybrid quota here since the actual disk usage could change
@@ -1385,7 +1385,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
     }
   }
 
-  private void recordDiskQuotaAllowedForStore(Store store) {
+  private void recordQuotaMetrics(Store store) {
     if (emitMetrics.get()) {
       long currentQuota = store.getStorageQuotaInByte();
       hostLevelIngestionStats.recordDiskQuotaAllowed(currentQuota);

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/integration/utils/VeniceClusterWrapper.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/integration/utils/VeniceClusterWrapper.java
@@ -859,7 +859,6 @@ public class VeniceClusterWrapper extends ProcessWrapper {
 
   // Pass the dictionary and the training samples as well
   public String createStoreWithZstdDictionary(int keyCount) {
-
     return createStore(
         DEFAULT_KEY_SCHEMA,
         "\"string\"",

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/integration/utils/VeniceClusterWrapperConstants.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/integration/utils/VeniceClusterWrapperConstants.java
@@ -4,19 +4,19 @@ import com.linkedin.venice.utils.VeniceProperties;
 
 
 public class VeniceClusterWrapperConstants {
-  protected static final int DEFAULT_MAX_ATTEMPT = 10;
-  protected static final int DEFAULT_REPLICATION_FACTOR = 1;
-  protected static final int DEFAULT_PARTITION_SIZE_BYTES = 100;
+  public static final int DEFAULT_MAX_ATTEMPT = 10;
+  public static final int DEFAULT_REPLICATION_FACTOR = 1;
+  public static final int DEFAULT_PARTITION_SIZE_BYTES = 100;
   // By default, disable the delayed rebalance for testing.
-  protected static final long DEFAULT_DELAYED_TO_REBALANCE_MS = 0;
-  protected static final boolean DEFAULT_SSL_TO_STORAGE_NODES = false;
-  protected static final boolean DEFAULT_SSL_TO_KAFKA = false;
-  protected static final int DEFAULT_NUMBER_OF_SERVERS = 1;
-  protected static final int DEFAULT_NUMBER_OF_ROUTERS = 1;
-  protected static final int DEFAULT_NUMBER_OF_CONTROLLERS = 1;
-  protected static final VeniceProperties EMPTY_VENICE_PROPS = new VeniceProperties();
+  public static final long DEFAULT_DELAYED_TO_REBALANCE_MS = 0;
+  public static final boolean DEFAULT_SSL_TO_STORAGE_NODES = false;
+  public static final boolean DEFAULT_SSL_TO_KAFKA = false;
+  public static final int DEFAULT_NUMBER_OF_SERVERS = 1;
+  public static final int DEFAULT_NUMBER_OF_ROUTERS = 1;
+  public static final int DEFAULT_NUMBER_OF_CONTROLLERS = 1;
+  public static final VeniceProperties EMPTY_VENICE_PROPS = new VeniceProperties();
   // Wait time to make sure all the cluster services have been started.
   // If this value is not large enough, i.e. some services have not been
   // started before clients start to interact, please increase it.
-  protected static final int DEFAULT_WAIT_TIME_FOR_CLUSTER_START_S = 90;
+  public static final int DEFAULT_WAIT_TIME_FOR_CLUSTER_START_S = 90;
 }


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci], [server], [controller],
[router], [samza], [vpj], [fast-client], [thin-client], [alpini],
[admin-tool], [test], [build], [doc], [script]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Summary, imperative, start upper case, don't end with a period
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
Periodically refresh quota usage metric to report up-to-date values. Previously the metric was refreshed only during consumption, which led to incorrect (stale) values reported for fully ingested stores or/and after server restart. Also the change helps to reflect quota changes in runtime rather than on a new push.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
Added additional checks to `TestRestartServer` to verify new

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.