### PR TITLE
[doc] Expose router port in docker-compose example in order to allow clients to connect

### DIFF
--- a/quickstart/docker-compose.yaml
+++ b/quickstart/docker-compose.yaml
@@ -67,6 +67,8 @@ services:
         interval: 5s
         timeout: 20s
         retries: 5
+    ports:
+       - "7777:7777"
 
   venice-client:
     image: venicedb/venice-client:latest


### PR DESCRIPTION
## Summary, imperative, start upper case, don't end with a period

Expose port 7777 on the venice-router service in order to let clients connect from outside the docker network


## How was this PR tested?

I have tested it manually

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.