### PR TITLE
[DaVinci] Added an interface for the customized transformation support of Object Cache

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/client/CacheValueTransformer.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/client/CacheValueTransformer.java
@@ -1,0 +1,11 @@
+package com.linkedin.davinci.client;
+
+/**
+ * Customized transformation function for object cache.
+ *
+ * When the customized function is on with object cache feature is enabled,
+ * DaVinci will cache the transformed object instead of the raw value.
+ */
+public interface CacheValueTransformer<V, T> {
+  T transform(V value);
+}

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/client/DaVinciClient.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/client/DaVinciClient.java
@@ -1,6 +1,7 @@
 package com.linkedin.davinci.client;
 
 import com.linkedin.venice.client.store.AvroGenericStoreClient;
+import com.linkedin.venice.exceptions.VeniceUnsupportedOperationException;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
@@ -55,4 +56,8 @@ public interface DaVinciClient<K, V> extends AvroGenericStoreClient<K, V> {
    * @return partition count
    */
   int getPartitionCount();
+
+  default <T> TransformedCacheStoreClient<K, T> getTransformedCacheStoreClient() {
+    throw new VeniceUnsupportedOperationException("getTransformedCacheStoreClient");
+  }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/client/TransformedCacheStoreClient.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/client/TransformedCacheStoreClient.java
@@ -1,0 +1,55 @@
+package com.linkedin.davinci.client;
+
+import com.linkedin.venice.client.exceptions.VeniceClientException;
+import com.linkedin.venice.client.store.AvroGenericStoreClient;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import org.apache.avro.Schema;
+
+
+/**
+ * This class exposes a view of cache when customized transformation is enabled.
+ */
+public class TransformedCacheStoreClient<K, T> implements AvroGenericStoreClient<K, T> {
+  private final AvroGenericDaVinciClient daVinciClient;
+
+  public TransformedCacheStoreClient(AvroGenericDaVinciClient daVinciClient) {
+    this.daVinciClient = daVinciClient;
+  }
+
+  @Override
+  public CompletableFuture<T> get(K key) throws VeniceClientException {
+    return null;
+  }
+
+  @Override
+  public CompletableFuture<Map<K, T>> batchGet(Set<K> keys) throws VeniceClientException {
+    return null;
+  }
+
+  @Override
+  public void start() throws VeniceClientException {
+    // do nothing
+  }
+
+  @Override
+  public void close() {
+    // do nothing
+  }
+
+  @Override
+  public String getStoreName() {
+    return daVinciClient.getStoreName();
+  }
+
+  @Override
+  public Schema getKeySchema() {
+    return daVinciClient.getKeySchema();
+  }
+
+  @Override
+  public Schema getLatestValueSchema() {
+    return daVinciClient.getLatestValueSchema();
+  }
+}

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/cache/backend/ObjectCacheConfig.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/cache/backend/ObjectCacheConfig.java
@@ -1,11 +1,13 @@
 package com.linkedin.davinci.store.cache.backend;
 
+import com.linkedin.davinci.client.CacheValueTransformer;
 import java.util.Optional;
 
 
 public class ObjectCacheConfig {
   private Optional<Long> maxCacheSize = Optional.empty();
   private Optional<Long> ttlInMilliseconds = Optional.empty();
+  private Optional<CacheValueTransformer> valueTransformer = Optional.empty();
 
   public ObjectCacheConfig setMaxPerPartitionCacheSize(Long maxPerPartitionCacheSize) {
     this.maxCacheSize = Optional.of(maxPerPartitionCacheSize);
@@ -14,6 +16,11 @@ public class ObjectCacheConfig {
 
   public ObjectCacheConfig setTtlInMilliseconds(Long ttlInMilliseconds) {
     this.ttlInMilliseconds = Optional.of(ttlInMilliseconds);
+    return this;
+  }
+
+  public ObjectCacheConfig setValueTransformer(CacheValueTransformer transformer) {
+    this.valueTransformer = Optional.of(transformer);
     return this;
   }
 
@@ -27,24 +34,15 @@ public class ObjectCacheConfig {
 
   @Override
   public boolean equals(Object o) {
-    if (o == null) {
-      return false;
-    }
-
-    if (o == this) {
+    if (this == o) {
       return true;
     }
-    if (!(o instanceof ObjectCacheConfig)) {
+    if (o == null || getClass() != o.getClass()) {
       return false;
     }
-    ObjectCacheConfig c = (ObjectCacheConfig) o;
-    if (!this.getTtlInMilliseconds().orElse(-1L).equals(c.getTtlInMilliseconds().orElse(-1L))) {
-      return false;
-    }
-    if (!this.getMaxCacheSize().orElse(-1L).equals(c.getMaxCacheSize().orElse(-1L))) {
-      return false;
-    }
-    return true;
+    ObjectCacheConfig that = (ObjectCacheConfig) o;
+    return maxCacheSize.equals(that.maxCacheSize) && ttlInMilliseconds.equals(that.ttlInMilliseconds)
+        && valueTransformer.equals(that.valueTransformer);
   }
 
   @Override
@@ -52,6 +50,7 @@ public class ObjectCacheConfig {
     int result = 1;
     result = result * 31 + maxCacheSize.hashCode();
     result = result * 31 + ttlInMilliseconds.hashCode();
+    result = result * 31 + valueTransformer.hashCode();
     return result;
   }
 


### PR DESCRIPTION
## Summary, imperative, start upper case, don't end with a period
The initial interface for the customized object cache in DaVinci client.

## How was this PR tested?
N/A

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [x] Yes. Make sure to explain your proposed changes and call out the behavior change.
1. When customer wants to use customized object cache, they will need to specify a transformation function per store.
2. With this interface, the user will need to use a separate store client to retrieve the cached value besides the original DaVinciClient since the returned object will be with different type from the original value.
3. The assumption is that when customized object cache is enabled, DaVinci won't need to cache the raw value any more.
4. We will need to make the storage engine configurable in the future since when object cache is enabled, they don't need to use plaintable format for most of the scenarios.
