### PR TITLE
[controller][common] Improve listStorePushInfo api to report partitio…

### DIFF
--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/AdminTool.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/AdminTool.java
@@ -2273,8 +2273,12 @@ public class AdminTool {
     String urlParam = getRequiredArgument(cmd, Arg.URL);
     String clusterParam = getRequiredArgument(cmd, Arg.CLUSTER);
     String storeParam = getRequiredArgument(cmd, Arg.STORE);
+    boolean isPartitionDetailEnabled = Optional.ofNullable(getOptionalArgument(cmd, Arg.PARTITION_DETAIL_ENABLED))
+        .map(Boolean::parseBoolean)
+        .orElse(false);
 
-    StoreHealthAuditResponse response = controllerClient.listStorePushInfo(clusterParam, urlParam, storeParam);
+    StoreHealthAuditResponse response =
+        controllerClient.listStorePushInfo(clusterParam, urlParam, storeParam, isPartitionDetailEnabled);
     printObject(response);
   }
 

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/AdminTool.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/AdminTool.java
@@ -2270,15 +2270,12 @@ public class AdminTool {
   }
 
   private static void listStorePushInfo(CommandLine cmd) {
-    String urlParam = getRequiredArgument(cmd, Arg.URL);
-    String clusterParam = getRequiredArgument(cmd, Arg.CLUSTER);
     String storeParam = getRequiredArgument(cmd, Arg.STORE);
     boolean isPartitionDetailEnabled = Optional.ofNullable(getOptionalArgument(cmd, Arg.PARTITION_DETAIL_ENABLED))
         .map(Boolean::parseBoolean)
         .orElse(false);
 
-    StoreHealthAuditResponse response =
-        controllerClient.listStorePushInfo(clusterParam, urlParam, storeParam, isPartitionDetailEnabled);
+    StoreHealthAuditResponse response = controllerClient.listStorePushInfo(storeParam, isPartitionDetailEnabled);
     printObject(response);
   }
 

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/Arg.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/Arg.java
@@ -229,6 +229,9 @@ public enum Arg {
       "storage-view-configs", "svc", true,
       "Config that describes views to be added for a store.  Input is a json map.  Example: {\"ExampleView\": {\"viewClassName\": \"com.linkedin.venice.views.ChangeCaptureView\",\"params\": {}}}"
   ),
+  PARTITION_DETAIL_ENABLED(
+      "partition-detail-enabled", "pde", true, "A flag to indicate whether to retrieve partition details"
+  ),
 
   START_DATE("start-date", "sd", true, "Start date in PST. Example: 2020-10-10 10:10:10"),
   END_DATE("end-date", "ed", true, "End date in PST. Example: 2020-10-10 10:10:10"),

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/Command.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/Command.java
@@ -62,6 +62,7 @@ import static com.linkedin.venice.Arg.OWNER;
 import static com.linkedin.venice.Arg.PARTITIONER_CLASS;
 import static com.linkedin.venice.Arg.PARTITIONER_PARAMS;
 import static com.linkedin.venice.Arg.PARTITION_COUNT;
+import static com.linkedin.venice.Arg.PARTITION_DETAIL_ENABLED;
 import static com.linkedin.venice.Arg.PRINCIPAL;
 import static com.linkedin.venice.Arg.PROGRESS_INTERVAL;
 import static com.linkedin.venice.Arg.PUSH_ID;
@@ -388,7 +389,7 @@ public enum Command {
   ),
   LIST_STORE_PUSH_INFO(
       "list-store-push-info", "List information about current pushes and push history for a specific store.",
-      new Arg[] { URL, CLUSTER, STORE }
+      new Arg[] { URL, CLUSTER, STORE }, new Arg[] { PARTITION_DETAIL_ENABLED }
   ),
   UPDATE_KAFKA_TOPIC_LOG_COMPACTION(
       "update-kafka-topic-log-compaction", "Update log compaction config of a topic through controllers",

--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerApiConstants.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerApiConstants.java
@@ -137,6 +137,8 @@ public class ControllerApiConstants {
 
   public static final String REPLICATION_METADATA_VERSION_ID = "replication_metadata_version_id";
 
+  public static final String PARTITION_DETAIL_ENABLED = "partition_detail_enabled";
+
   /**
    * How many records that one server could consume from Kafka at most in one second from the specified regions.
    * If the consume rate reached this quota, the consumption thread will be blocked until there is the available quota.

--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerClient.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerClient.java
@@ -995,33 +995,14 @@ public class ControllerClient implements Closeable {
     return request(ControllerRoute.GET_STORE_LARGEST_USED_VERSION, params, VersionResponse.class);
   }
 
-  public RegionPushDetailsResponse getRegionPushDetails(
-      String storeName,
-      String clusterName,
-      boolean isPartitionDetailEnabled) {
-    QueryParams params = newParams().add(CLUSTER, clusterName)
-        .add(NAME, storeName)
-        .add(PARTITION_DETAIL_ENABLED, isPartitionDetailEnabled);
+  public RegionPushDetailsResponse getRegionPushDetails(String storeName, boolean isPartitionDetailEnabled) {
+    QueryParams params = newParams().add(NAME, storeName).add(PARTITION_DETAIL_ENABLED, isPartitionDetailEnabled);
     return request(ControllerRoute.GET_REGION_PUSH_DETAILS, params, RegionPushDetailsResponse.class);
   }
 
-  public StoreHealthAuditResponse listStorePushInfo(
-      String clusterName,
-      String parentControllerUrl,
-      String storeName,
-      boolean isPartitionDetailEnabled) {
-    QueryParams params = newParams().add(CLUSTER, clusterName)
-        .add(NAME, storeName)
-        .add(PARTITION_DETAIL_ENABLED, isPartitionDetailEnabled);
-    try (ControllerTransport transport = new ControllerTransport(sslFactory)) {
-      return transport
-          .request(parentControllerUrl, ControllerRoute.LIST_STORE_PUSH_INFO, params, StoreHealthAuditResponse.class);
-    } catch (Exception e) {
-      return makeErrorResponse(
-          "controllerapi:ControllerClient:listStorePushInfo - ",
-          e,
-          StoreHealthAuditResponse.class);
-    }
+  public StoreHealthAuditResponse listStorePushInfo(String storeName, boolean isPartitionDetailEnabled) {
+    QueryParams params = newParams().add(NAME, storeName).add(PARTITION_DETAIL_ENABLED, isPartitionDetailEnabled);
+    return request(ControllerRoute.LIST_STORE_PUSH_INFO, params, StoreHealthAuditResponse.class);
   }
 
   public static D2ServiceDiscoveryResponse discoverCluster(

--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerClient.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerClient.java
@@ -31,6 +31,7 @@ import static com.linkedin.venice.controllerapi.ControllerApiConstants.OPERATION
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.OWNER;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.PARTITIONERS;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.PARTITION_COUNT;
+import static com.linkedin.venice.controllerapi.ControllerApiConstants.PARTITION_DETAIL_ENABLED;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.PERSONA_NAME;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.PERSONA_OWNERS;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.PERSONA_QUOTA;
@@ -994,19 +995,30 @@ public class ControllerClient implements Closeable {
     return request(ControllerRoute.GET_STORE_LARGEST_USED_VERSION, params, VersionResponse.class);
   }
 
-  public RegionPushDetailsResponse getRegionPushDetails(String storeName, String clusterName) {
-    QueryParams params = newParams().add(CLUSTER, clusterName).add(NAME, storeName);
+  public RegionPushDetailsResponse getRegionPushDetails(
+      String storeName,
+      String clusterName,
+      boolean isPartitionDetailEnabled) {
+    QueryParams params = newParams().add(CLUSTER, clusterName)
+        .add(NAME, storeName)
+        .add(PARTITION_DETAIL_ENABLED, isPartitionDetailEnabled);
     return request(ControllerRoute.GET_REGION_PUSH_DETAILS, params, RegionPushDetailsResponse.class);
   }
 
-  public StoreHealthAuditResponse listStorePushInfo(String clusterName, String parentControllerUrl, String storeName) {
-    QueryParams params = newParams().add(CLUSTER, clusterName).add(NAME, storeName);
+  public StoreHealthAuditResponse listStorePushInfo(
+      String clusterName,
+      String parentControllerUrl,
+      String storeName,
+      boolean isPartitionDetailEnabled) {
+    QueryParams params = newParams().add(CLUSTER, clusterName)
+        .add(NAME, storeName)
+        .add(PARTITION_DETAIL_ENABLED, isPartitionDetailEnabled);
     try (ControllerTransport transport = new ControllerTransport(sslFactory)) {
       return transport
           .request(parentControllerUrl, ControllerRoute.LIST_STORE_PUSH_INFO, params, StoreHealthAuditResponse.class);
     } catch (Exception e) {
       return makeErrorResponse(
-          "controllerapi:ControllerClient:listStorePushInfo - " + e.toString(),
+          "controllerapi:ControllerClient:listStorePushInfo - ",
           e,
           StoreHealthAuditResponse.class);
     }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerRoute.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerRoute.java
@@ -49,6 +49,7 @@ import static com.linkedin.venice.controllerapi.ControllerApiConstants.OWNER;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.PARTITIONER_CLASS;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.PARTITIONER_PARAMS;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.PARTITION_COUNT;
+import static com.linkedin.venice.controllerapi.ControllerApiConstants.PARTITION_DETAIL_ENABLED;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.PERSONA_NAME;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.PERSONA_OWNERS;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.PERSONA_QUOTA;
@@ -253,8 +254,10 @@ public enum ControllerRoute {
   ), GET_STALE_STORES_IN_CLUSTER("/get_stale_stores_in_cluster", HttpMethod.GET, Collections.singletonList(CLUSTER)),
   GET_STORES_IN_CLUSTER("/get_stores_in_cluster", HttpMethod.GET, Collections.singletonList(CLUSTER)),
   GET_STORE_LARGEST_USED_VERSION("/get_store_largest_used_version", HttpMethod.GET, Arrays.asList(CLUSTER, NAME)),
-  LIST_STORE_PUSH_INFO("/list_store_push_info", HttpMethod.GET, Arrays.asList(CLUSTER, NAME)),
-  GET_REGION_PUSH_DETAILS("/get_region_push_details", HttpMethod.GET, Arrays.asList(CLUSTER, NAME)),
+  LIST_STORE_PUSH_INFO("/list_store_push_info", HttpMethod.GET, Arrays.asList(CLUSTER, NAME, PARTITION_DETAIL_ENABLED)),
+  GET_REGION_PUSH_DETAILS(
+      "/get_region_push_details", HttpMethod.GET, Arrays.asList(CLUSTER, NAME, PARTITION_DETAIL_ENABLED)
+  ),
   UPDATE_KAFKA_TOPIC_LOG_COMPACTION(
       "/update_kafka_topic_log_compaction", HttpMethod.GET, Arrays.asList(TOPIC, KAFKA_TOPIC_LOG_COMPACTION_ENABLED)
   ),

--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/StoreHealthAuditResponse.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/StoreHealthAuditResponse.java
@@ -52,4 +52,11 @@ public class StoreHealthAuditResponse extends ControllerResponse {
     versionToRegion.putIfAbsent(version, new ArrayList<>());
     versionToRegion.get(version).add(name);
   }
+
+  @Override
+  public String toString() {
+    return "StoreHealthAuditResponse{" + "regionsWithStaleData=" + regionsWithStaleData + ", regionToCurrentVersion="
+        + regionToCurrentVersion + ", regionPushDetails=" + regionPushDetails + ", versionToRegion=" + versionToRegion
+        + '}';
+  }
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/PartitionDetail.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/PartitionDetail.java
@@ -1,0 +1,101 @@
+package com.linkedin.venice.meta;
+
+import com.linkedin.venice.pushmonitor.PartitionStatus;
+import com.linkedin.venice.pushmonitor.ReplicaStatus;
+import com.linkedin.venice.pushmonitor.StatusSnapshot;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.apache.commons.lang.StringUtils;
+
+
+public class PartitionDetail {
+  private int partitionId;
+  private List<ReplicaDetail> replicaDetails = new ArrayList<>();
+
+  public PartitionDetail() {
+  }
+
+  public PartitionDetail(int partitionId) {
+    this.partitionId = partitionId;
+  }
+
+  public int getPartitionId() {
+    return partitionId;
+  }
+
+  public void setPartitionId(int partitionId) {
+    this.partitionId = partitionId;
+  }
+
+  public List<ReplicaDetail> getReplicaDetails() {
+    return replicaDetails;
+  }
+
+  public void setReplicaDetails(List<ReplicaDetail> replicaDetails) {
+    this.replicaDetails = replicaDetails;
+  }
+
+  void addReplicaDetails(final PartitionStatus pStatus) {
+    for (Map.Entry<String, ReplicaStatus> entry: pStatus.getReplicaStatusMap().entrySet()) {
+      String instanceId = entry.getKey();
+      StatusSnapshot startStatus = entry.getValue().findStartStatus();
+      StatusSnapshot completeStatus = entry.getValue().findCompleteStatus();
+      replicaDetails.add(
+          new ReplicaDetail(
+              instanceId,
+              startStatus != null ? startStatus.getTime() : StringUtils.EMPTY,
+              completeStatus != null ? completeStatus.getTime() : StringUtils.EMPTY));
+    }
+  }
+
+  @Override
+  public String toString() {
+    return "PartitionDetail{" + "partitionId=" + partitionId + ", replicaDetails=" + replicaDetails + '}';
+  }
+}
+
+class ReplicaDetail {
+  private String instanceId;
+  private String pushStartDateTime;
+  private String pushEndDateTime;
+
+  public ReplicaDetail() {
+  }
+
+  public ReplicaDetail(String instanceId, String pushStartDateTime, String pushEndDateTime) {
+    this.instanceId = instanceId;
+    this.pushStartDateTime = pushStartDateTime;
+    this.pushEndDateTime = pushEndDateTime;
+  }
+
+  public String getInstanceId() {
+    return instanceId;
+  }
+
+  public void setInstanceId(String instanceId) {
+    this.instanceId = instanceId;
+  }
+
+  public String getPushStartDateTime() {
+    return pushStartDateTime;
+  }
+
+  public void setPushStartDateTime(String pushStartDateTime) {
+    this.pushStartDateTime = pushStartDateTime;
+  }
+
+  public String getPushEndDateTime() {
+    return pushEndDateTime;
+  }
+
+  public void setPushEndDateTime(String pushEndDateTime) {
+    this.pushEndDateTime = pushEndDateTime;
+  }
+
+  @Override
+  public String toString() {
+    return "ReplicaDetail{" + "instanceId='" + instanceId + '\'' + ", pushStartDateTime='" + pushStartDateTime + '\''
+        + ", pushEndDateTime='" + pushEndDateTime + '\'' + '}';
+  }
+}

--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/PartitionDetail.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/PartitionDetail.java
@@ -3,6 +3,7 @@ package com.linkedin.venice.meta;
 import com.linkedin.venice.pushmonitor.PartitionStatus;
 import com.linkedin.venice.pushmonitor.ReplicaStatus;
 import com.linkedin.venice.pushmonitor.StatusSnapshot;
+import com.linkedin.venice.utils.Pair;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -39,63 +40,15 @@ public class PartitionDetail {
   void addReplicaDetails(final PartitionStatus pStatus) {
     for (Map.Entry<String, ReplicaStatus> entry: pStatus.getReplicaStatusMap().entrySet()) {
       String instanceId = entry.getKey();
-      StatusSnapshot startStatus = entry.getValue().findStartStatus();
-      StatusSnapshot completeStatus = entry.getValue().findCompleteStatus();
-      replicaDetails.add(
-          new ReplicaDetail(
-              instanceId,
-              startStatus != null ? startStatus.getTime() : StringUtils.EMPTY,
-              completeStatus != null ? completeStatus.getTime() : StringUtils.EMPTY));
+      Pair<StatusSnapshot, StatusSnapshot> status = entry.getValue().findStartedAndCompletedStatus();
+      String startedTime = (status == null) ? StringUtils.EMPTY : status.getFirst().getTime();
+      String completedTime = (status == null) ? StringUtils.EMPTY : status.getSecond().getTime();
+      replicaDetails.add(new ReplicaDetail(instanceId, startedTime, completedTime));
     }
   }
 
   @Override
   public String toString() {
     return "PartitionDetail{" + "partitionId=" + partitionId + ", replicaDetails=" + replicaDetails + '}';
-  }
-}
-
-class ReplicaDetail {
-  private String instanceId;
-  private String pushStartDateTime;
-  private String pushEndDateTime;
-
-  public ReplicaDetail() {
-  }
-
-  public ReplicaDetail(String instanceId, String pushStartDateTime, String pushEndDateTime) {
-    this.instanceId = instanceId;
-    this.pushStartDateTime = pushStartDateTime;
-    this.pushEndDateTime = pushEndDateTime;
-  }
-
-  public String getInstanceId() {
-    return instanceId;
-  }
-
-  public void setInstanceId(String instanceId) {
-    this.instanceId = instanceId;
-  }
-
-  public String getPushStartDateTime() {
-    return pushStartDateTime;
-  }
-
-  public void setPushStartDateTime(String pushStartDateTime) {
-    this.pushStartDateTime = pushStartDateTime;
-  }
-
-  public String getPushEndDateTime() {
-    return pushEndDateTime;
-  }
-
-  public void setPushEndDateTime(String pushEndDateTime) {
-    this.pushEndDateTime = pushEndDateTime;
-  }
-
-  @Override
-  public String toString() {
-    return "ReplicaDetail{" + "instanceId='" + instanceId + '\'' + ", pushStartDateTime='" + pushStartDateTime + '\''
-        + ", pushEndDateTime='" + pushEndDateTime + '\'' + '}';
   }
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/RegionPushDetails.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/RegionPushDetails.java
@@ -1,8 +1,11 @@
 package com.linkedin.venice.meta;
 
+import com.linkedin.venice.pushmonitor.OfflinePushStatus;
+import com.linkedin.venice.pushmonitor.PartitionStatus;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.List;
 
 
 public class RegionPushDetails {
@@ -14,6 +17,23 @@ public class RegionPushDetails {
   private String errorMessage = null;
   private ArrayList<Integer> versions = new ArrayList<>();
   private Integer currentVersion = -1;
+  private List<PartitionDetail> partitionDetails = new ArrayList<>();
+
+  public List<PartitionDetail> getPartitionDetails() {
+    return partitionDetails;
+  }
+
+  public void setPartitionDetails(List<PartitionDetail> partitionDetails) {
+    this.partitionDetails = partitionDetails;
+  }
+
+  public ArrayList<Integer> getVersions() {
+    return versions;
+  }
+
+  public void setVersions(ArrayList<Integer> versions) {
+    this.versions = versions;
+  }
 
   public Integer getCurrentVersion() {
     return currentVersion;
@@ -23,8 +43,8 @@ public class RegionPushDetails {
     this.currentVersion = currentVersion;
   }
 
-  public RegionPushDetails(String _regionName) {
-    setRegionName(_regionName);
+  public RegionPushDetails(String regionName) {
+    this.regionName = regionName;
   }
 
   public RegionPushDetails() {
@@ -89,12 +109,29 @@ public class RegionPushDetails {
     this.errorMessage = errorMessage;
   }
 
-  public ArrayList<Integer> getVersions() {
-    return versions;
+  public void addVersion(int version) {
+    versions.add(version);
   }
 
-  public void setVersions(ArrayList<Integer> versions) {
-    this.versions = (ArrayList<Integer>) versions.clone();
+  public void addPartitionDetails(final OfflinePushStatus status) {
+    int numOfPartition = status.getNumberOfPartition();
+    for (int pid = 0; pid < numOfPartition; pid++) {
+      PartitionStatus partition = status.getPartitionStatus(pid);
+      if (partition == null) {
+        continue;
+      }
+      PartitionDetail pDetail = new PartitionDetail(partition.getPartitionId());
+      pDetail.addReplicaDetails(partition);
+      partitionDetails.add(pDetail);
+    }
   }
 
+  @Override
+  public String toString() {
+    return "RegionPushDetails{" + "regionName='" + regionName + '\'' + ", pushStartLocalDateTime='"
+        + pushStartLocalDateTime + '\'' + ", pushEndLocalDateTime='" + pushEndLocalDateTime + '\'' + ", dataAge='"
+        + dataAge + '\'' + ", latestFailedPush='" + latestFailedPush + '\'' + ", errorMessage='" + errorMessage + '\''
+        + ", versions=" + versions + ", currentVersion=" + currentVersion + ", partitionDetails=" + partitionDetails
+        + '}';
+  }
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/ReplicaDetail.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/ReplicaDetail.java
@@ -1,0 +1,46 @@
+package com.linkedin.venice.meta;
+
+public class ReplicaDetail {
+  private String instanceId;
+  private String pushStartDateTime;
+  private String pushEndDateTime;
+
+  public ReplicaDetail() {
+  }
+
+  public ReplicaDetail(String instanceId, String pushStartDateTime, String pushEndDateTime) {
+    this.instanceId = instanceId;
+    this.pushStartDateTime = pushStartDateTime;
+    this.pushEndDateTime = pushEndDateTime;
+  }
+
+  public String getInstanceId() {
+    return instanceId;
+  }
+
+  public void setInstanceId(String instanceId) {
+    this.instanceId = instanceId;
+  }
+
+  public String getPushStartDateTime() {
+    return pushStartDateTime;
+  }
+
+  public void setPushStartDateTime(String pushStartDateTime) {
+    this.pushStartDateTime = pushStartDateTime;
+  }
+
+  public String getPushEndDateTime() {
+    return pushEndDateTime;
+  }
+
+  public void setPushEndDateTime(String pushEndDateTime) {
+    this.pushEndDateTime = pushEndDateTime;
+  }
+
+  @Override
+  public String toString() {
+    return "ReplicaDetail{" + "instanceId='" + instanceId + '\'' + ", pushStartDateTime='" + pushStartDateTime + '\''
+        + ", pushEndDateTime='" + pushEndDateTime + '\'' + '}';
+  }
+}

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pushmonitor/PartitionStatus.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pushmonitor/PartitionStatus.java
@@ -27,6 +27,10 @@ public class PartitionStatus implements Comparable<PartitionStatus> {
     return partitionId;
   }
 
+  public Map<String, ReplicaStatus> getReplicaStatusMap() {
+    return replicaStatusMap;
+  }
+
   public void updateReplicaStatus(String instanceId, ExecutionStatus newStatus) {
     updateReplicaStatus(instanceId, newStatus, "");
   }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pushmonitor/ReplicaStatus.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pushmonitor/ReplicaStatus.java
@@ -188,4 +188,32 @@ public class ReplicaStatus {
     String[] parts = replicaId.split(":");
     return parts[parts.length - 1];
   }
+
+  /**
+   * @return the start status snapshot from the status history.
+   */
+  public StatusSnapshot findStartStatus() {
+    StatusSnapshot result = null;
+    for (StatusSnapshot status: statusHistory) {
+      if (status.getStatus() == STARTED && (result == null
+          || LocalDateTime.parse(status.getTime()).isBefore(LocalDateTime.parse(result.getTime())))) {
+        result = status;
+      }
+    }
+    return result;
+  }
+
+  /**
+   * @return the completed status snapshot from the status history.
+   */
+  public StatusSnapshot findCompleteStatus() {
+    StatusSnapshot result = null;
+    for (StatusSnapshot status: statusHistory) {
+      if (status.getStatus() == COMPLETED
+          && (result == null || LocalDateTime.parse(status.getTime()).isAfter(LocalDateTime.parse(result.getTime())))) {
+        result = status;
+      }
+    }
+    return result;
+  }
 }

--- a/internal/venice-common/src/test/java/com/linkedin/venice/controllerapi/TestOneTouchDataRecovery.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/controllerapi/TestOneTouchDataRecovery.java
@@ -13,9 +13,9 @@ import org.testng.annotations.Test;
 
 
 public class TestOneTouchDataRecovery {
-  final int numOfPartition = 5;
-  final int replicationFactor = 3;
-  final String kafkaTopic = "test_v1";
+  static final int NUM_OF_PARTITION = 5;
+  static final int REPLICATION_FACTOR = 3;
+  static final String KAFKA_TOPIC = "test_v1";
 
   @Test
   public void testDataRecoveryDataStructure() {
@@ -30,14 +30,14 @@ public class TestOneTouchDataRecovery {
 
   private RegionPushDetails buildPushStatus(LocalDateTime timestamp, boolean isNormal) {
     OfflinePushStatus status = new OfflinePushStatus(
-        kafkaTopic,
-        numOfPartition,
-        replicationFactor,
+        KAFKA_TOPIC,
+        NUM_OF_PARTITION,
+        REPLICATION_FACTOR,
         OfflinePushStrategy.WAIT_N_MINUS_ONE_REPLCIA_PER_PARTITION);
 
-    for (int i = 0; i < numOfPartition; i++) {
+    for (int i = 0; i < NUM_OF_PARTITION; i++) {
       PartitionStatus partition = new PartitionStatus(i);
-      for (int j = 0; j < replicationFactor; j++) {
+      for (int j = 0; j < REPLICATION_FACTOR; j++) {
         if (isNormal) {
           partition.updateReplicaStatus("instanceId-" + j, ExecutionStatus.STARTED, StringUtils.EMPTY);
           partition.updateReplicaStatus("instanceId-" + j, ExecutionStatus.END_OF_PUSH_RECEIVED, StringUtils.EMPTY);
@@ -58,9 +58,9 @@ public class TestOneTouchDataRecovery {
   }
 
   private void verifyPushStatus(final RegionPushDetails result, LocalDateTime timestamp, boolean isNormal) {
-    Assert.assertEquals(result.getPartitionDetails().size(), numOfPartition);
-    for (int i = 0; i < numOfPartition; i++) {
-      Assert.assertEquals(result.getPartitionDetails().get(i).getReplicaDetails().size(), replicationFactor);
+    Assert.assertEquals(result.getPartitionDetails().size(), NUM_OF_PARTITION);
+    for (int i = 0; i < NUM_OF_PARTITION; i++) {
+      Assert.assertEquals(result.getPartitionDetails().get(i).getReplicaDetails().size(), REPLICATION_FACTOR);
       for (ReplicaDetail replica: result.getPartitionDetails().get(i).getReplicaDetails()) {
         Assert.assertNotEquals(replica.getInstanceId(), StringUtils.EMPTY);
         if (isNormal) {

--- a/internal/venice-common/src/test/java/com/linkedin/venice/controllerapi/TestOneTouchDataRecovery.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/controllerapi/TestOneTouchDataRecovery.java
@@ -1,0 +1,72 @@
+package com.linkedin.venice.controllerapi;
+
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+import com.linkedin.venice.controller.VeniceHelixAdmin;
+import com.linkedin.venice.meta.OfflinePushStrategy;
+import com.linkedin.venice.meta.RegionPushDetails;
+import com.linkedin.venice.meta.Store;
+import com.linkedin.venice.pushmonitor.ExecutionStatus;
+import com.linkedin.venice.pushmonitor.OfflinePushStatus;
+import com.linkedin.venice.pushmonitor.PartitionStatus;
+import com.linkedin.venice.pushmonitor.StatusSnapshot;
+import com.linkedin.venice.utils.TestUtils;
+import java.time.LocalDateTime;
+import org.apache.commons.lang.StringUtils;
+import org.testng.Assert;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+
+public class TestOneTouchDataRecovery {
+  private VeniceHelixAdmin internalAdmin;
+  static final String clusterName = "test-cluster";
+
+  @BeforeMethod
+  public void setupTestCase() {
+    internalAdmin = mock(VeniceHelixAdmin.class);
+  }
+
+  @Test
+  public void testDataRecoveryAPIs() {
+    final String storeName = "test";
+    final String owner = "test";
+    final int numOfPartition = 5;
+    final int replicationFactor = 3;
+    final String kafkaTopic = "test_v1";
+
+    OfflinePushStatus status = new OfflinePushStatus(
+        kafkaTopic,
+        numOfPartition,
+        replicationFactor,
+        OfflinePushStrategy.WAIT_N_MINUS_ONE_REPLCIA_PER_PARTITION);
+    LocalDateTime now = LocalDateTime.now();
+
+    for (int i = 0; i < numOfPartition; i++) {
+      PartitionStatus partition = new PartitionStatus(i);
+      for (int j = 0; j < replicationFactor; j++) {
+        partition.updateReplicaStatus("instanceId-" + j, ExecutionStatus.STARTED, StringUtils.EMPTY);
+        partition.updateReplicaStatus("instanceId-" + j, ExecutionStatus.COMPLETED, StringUtils.EMPTY);
+      }
+      status.setPartitionStatus(partition);
+    }
+
+    status.getStatusHistory().add(new StatusSnapshot(ExecutionStatus.STARTED, now.toString()));
+    status.getStatusHistory().add(new StatusSnapshot(ExecutionStatus.COMPLETED, now.plusHours(1).toString()));
+    doReturn(status).when(internalAdmin).retrievePushStatus(anyString(), anyString());
+
+    Store s = TestUtils.createTestStore(storeName, owner, System.currentTimeMillis());
+    when(internalAdmin.getRegionPushDetails(anyString(), anyString(), anyBoolean())).thenCallRealMethod();
+    doReturn(s).when(internalAdmin).getStore(anyString(), anyString());
+
+    RegionPushDetails details = internalAdmin.getRegionPushDetails(clusterName, storeName, true);
+    Assert.assertEquals(details.getPushEndTimestamp(), now.plusHours(1).toString());
+    Assert.assertEquals(details.getCurrentVersion().intValue(), Store.NON_EXISTING_VERSION);
+    Assert.assertEquals(details.getPartitionDetails().size(), numOfPartition);
+    for (int i = 0; i < numOfPartition; i++) {
+      Assert.assertEquals(details.getPartitionDetails().get(i).getReplicaDetails().size(), replicationFactor);
+    }
+  }
+}

--- a/internal/venice-common/src/test/java/com/linkedin/venice/controllerapi/TestOneTouchDataRecovery.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/controllerapi/TestOneTouchDataRecovery.java
@@ -1,13 +1,11 @@
 package com.linkedin.venice.controllerapi;
 
-import static org.mockito.Mockito.*;
-
 import com.linkedin.venice.meta.OfflinePushStrategy;
 import com.linkedin.venice.meta.RegionPushDetails;
+import com.linkedin.venice.meta.ReplicaDetail;
 import com.linkedin.venice.pushmonitor.ExecutionStatus;
 import com.linkedin.venice.pushmonitor.OfflinePushStatus;
 import com.linkedin.venice.pushmonitor.PartitionStatus;
-import com.linkedin.venice.pushmonitor.StatusSnapshot;
 import java.time.LocalDateTime;
 import org.apache.commons.lang.StringUtils;
 import org.testng.Assert;
@@ -15,39 +13,66 @@ import org.testng.annotations.Test;
 
 
 public class TestOneTouchDataRecovery {
+  final int numOfPartition = 5;
+  final int replicationFactor = 3;
+  final String kafkaTopic = "test_v1";
+
   @Test
   public void testDataRecoveryDataStructure() {
-    final String storeName = "test";
-    final String owner = "test";
-    final int numOfPartition = 5;
-    final int replicationFactor = 3;
-    final String kafkaTopic = "test_v1";
+    LocalDateTime now = LocalDateTime.now();
+    RegionPushDetails result = buildPushStatus(now, true);
+    verifyPushStatus(result, now, true);
 
+    now = LocalDateTime.now();
+    result = buildPushStatus(now, false);
+    verifyPushStatus(result, now, false);
+  }
+
+  private RegionPushDetails buildPushStatus(LocalDateTime timestamp, boolean isNormal) {
     OfflinePushStatus status = new OfflinePushStatus(
         kafkaTopic,
         numOfPartition,
         replicationFactor,
         OfflinePushStrategy.WAIT_N_MINUS_ONE_REPLCIA_PER_PARTITION);
-    LocalDateTime now = LocalDateTime.now();
 
     for (int i = 0; i < numOfPartition; i++) {
       PartitionStatus partition = new PartitionStatus(i);
       for (int j = 0; j < replicationFactor; j++) {
+        if (isNormal) {
+          partition.updateReplicaStatus("instanceId-" + j, ExecutionStatus.STARTED, StringUtils.EMPTY);
+          partition.updateReplicaStatus("instanceId-" + j, ExecutionStatus.END_OF_PUSH_RECEIVED, StringUtils.EMPTY);
+          partition.updateReplicaStatus("instanceId-" + j, ExecutionStatus.TOPIC_SWITCH_RECEIVED, StringUtils.EMPTY);
+        }
+        partition.updateReplicaStatus("instanceId-" + j, ExecutionStatus.COMPLETED, StringUtils.EMPTY);
         partition.updateReplicaStatus("instanceId-" + j, ExecutionStatus.STARTED, StringUtils.EMPTY);
         partition.updateReplicaStatus("instanceId-" + j, ExecutionStatus.COMPLETED, StringUtils.EMPTY);
       }
       status.setPartitionStatus(partition);
     }
 
-    status.getStatusHistory().add(new StatusSnapshot(ExecutionStatus.STARTED, now.toString()));
-    status.getStatusHistory().add(new StatusSnapshot(ExecutionStatus.COMPLETED, now.plusHours(1).toString()));
+    RegionPushDetails result = new RegionPushDetails();
+    result.addPartitionDetails(status);
+    result.setPushStartTimestamp(timestamp.toString());
+    result.setPushEndTimestamp(timestamp.plusHours(1).toString());
+    return result;
+  }
 
-    RegionPushDetails ret = new RegionPushDetails();
-    ret.addPartitionDetails(status);
-
-    Assert.assertEquals(ret.getPartitionDetails().size(), numOfPartition);
+  private void verifyPushStatus(final RegionPushDetails result, LocalDateTime timestamp, boolean isNormal) {
+    Assert.assertEquals(result.getPartitionDetails().size(), numOfPartition);
     for (int i = 0; i < numOfPartition; i++) {
-      Assert.assertEquals(ret.getPartitionDetails().get(i).getReplicaDetails().size(), replicationFactor);
+      Assert.assertEquals(result.getPartitionDetails().get(i).getReplicaDetails().size(), replicationFactor);
+      for (ReplicaDetail replica: result.getPartitionDetails().get(i).getReplicaDetails()) {
+        Assert.assertNotEquals(replica.getInstanceId(), StringUtils.EMPTY);
+        if (isNormal) {
+          Assert.assertNotEquals(replica.getPushStartDateTime(), StringUtils.EMPTY);
+          Assert.assertNotEquals(replica.getPushEndDateTime(), StringUtils.EMPTY);
+        } else {
+          Assert.assertEquals(replica.getPushStartDateTime(), StringUtils.EMPTY);
+          Assert.assertEquals(replica.getPushEndDateTime(), StringUtils.EMPTY);
+        }
+      }
     }
+    Assert.assertEquals(result.getPushStartTimestamp(), timestamp.toString());
+    Assert.assertEquals(result.getPushEndTimestamp(), timestamp.plusHours(1).toString());
   }
 }

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/OneTouchDataRecoveryTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/OneTouchDataRecoveryTest.java
@@ -134,8 +134,7 @@ public class OneTouchDataRecoveryTest {
           TimeUnit.SECONDS);
 
       // Call listStorePushInfo with isPartitionDetailEnabled set to true.
-      StoreHealthAuditResponse resp =
-          parentControllerCli.listStorePushInfo(CLUSTER_NAME, parentControllerUrls, storeName, true);
+      StoreHealthAuditResponse resp = parentControllerCli.listStorePushInfo(storeName, true);
       LOGGER.info("StoreHealthAuditResponse = {}", resp);
       Assert.assertFalse(resp.isError());
       Assert.assertFalse(resp.getRegionPushDetails().isEmpty());
@@ -147,7 +146,7 @@ public class OneTouchDataRecoveryTest {
       }
 
       // Call listStorePushInfo with isPartitionDetailEnabled set to false.
-      resp = parentControllerCli.listStorePushInfo(CLUSTER_NAME, parentControllerUrls, storeName, false);
+      resp = parentControllerCli.listStorePushInfo(storeName, false);
       LOGGER.info("StoreHealthAuditResponse = {}", resp);
       Assert.assertFalse(resp.isError());
       Assert.assertFalse(resp.getRegionPushDetails().isEmpty());

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/OneTouchDataRecoveryTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/OneTouchDataRecoveryTest.java
@@ -1,0 +1,159 @@
+package com.linkedin.venice.endToEnd;
+
+import static com.linkedin.venice.ConfigKeys.*;
+import static com.linkedin.venice.utils.TestWriteUtils.*;
+
+import com.linkedin.venice.controllerapi.ControllerClient;
+import com.linkedin.venice.controllerapi.StoreHealthAuditResponse;
+import com.linkedin.venice.controllerapi.UpdateStoreQueryParams;
+import com.linkedin.venice.controllerapi.VersionCreationResponse;
+import com.linkedin.venice.helix.HelixReadOnlySchemaRepository;
+import com.linkedin.venice.integration.utils.ServiceFactory;
+import com.linkedin.venice.integration.utils.VeniceControllerWrapper;
+import com.linkedin.venice.integration.utils.VeniceMultiClusterWrapper;
+import com.linkedin.venice.integration.utils.VeniceTwoLayerMultiColoMultiClusterWrapper;
+import com.linkedin.venice.meta.RegionPushDetails;
+import com.linkedin.venice.meta.Version;
+import com.linkedin.venice.utils.TestUtils;
+import com.linkedin.venice.utils.Utils;
+import com.linkedin.venice.utils.VeniceProperties;
+import java.util.AbstractMap;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+
+public class OneTouchDataRecoveryTest {
+  private static final Logger LOGGER = LogManager.getLogger(OneTouchDataRecoveryTest.class);
+  private static final long TEST_TIMEOUT = 120_000;
+  private static final int NUMBER_OF_CHILD_DATACENTERS = 2;
+  private static final int NUMBER_OF_CLUSTERS = 1;
+  private static final int NUMBER_OF_PARENT_CONTROLLERS = 1;
+  private static final int NUMBER_OF_CONTROLLERS = 1;
+  private static final int NUMBER_OF_SERVERS = 1;
+  private static final int NUMBER_OF_ROUTERS = 1;
+  private static final int REPLICATION_FACTOR = 1;
+  private static final String CLUSTER_NAME = "venice-cluster0";
+
+  private VeniceTwoLayerMultiColoMultiClusterWrapper multiColoMultiClusterWrapper;
+  private List<VeniceMultiClusterWrapper> childDatacenters;
+  private List<VeniceControllerWrapper> parentControllers;
+
+  @BeforeClass(alwaysRun = true)
+  public void setUp() {
+    Utils.thisIsLocalhost();
+    Properties serverProperties = new Properties();
+    serverProperties.put(SERVER_PROMOTION_TO_LEADER_REPLICA_DELAY_SECONDS, 1L);
+
+    multiColoMultiClusterWrapper = ServiceFactory.getVeniceTwoLayerMultiColoMultiClusterWrapper(
+        NUMBER_OF_CHILD_DATACENTERS,
+        NUMBER_OF_CLUSTERS,
+        NUMBER_OF_PARENT_CONTROLLERS,
+        NUMBER_OF_CONTROLLERS,
+        NUMBER_OF_SERVERS,
+        NUMBER_OF_ROUTERS,
+        REPLICATION_FACTOR,
+        Optional.empty(),
+        Optional.empty(),
+        Optional.of(new VeniceProperties(serverProperties)),
+        false);
+
+    childDatacenters = multiColoMultiClusterWrapper.getClusters();
+    parentControllers = multiColoMultiClusterWrapper.getParentControllers();
+  }
+
+  @AfterClass(alwaysRun = true)
+  public void cleanUp() {
+    Utils.closeQuietlyWithErrorLogged(multiColoMultiClusterWrapper);
+  }
+
+  /**
+   * testBatchOnlyDataRecoveryAPIs does the following steps:
+   *
+   * 1.  Create a new store and push data.
+   * 2.  Wait for the push job to be in completed state.
+   * 3.  Call 'listStorePushInfo' controller api, and it contains partition details as expected.
+   */
+  @Test(timeOut = TEST_TIMEOUT)
+  public void testBatchOnlyDataRecoveryAPIs() {
+    String storeName = Utils.getUniqueString("oneTouch-dataRecovery-store-batch");
+    String parentControllerUrls =
+        parentControllers.stream().map(VeniceControllerWrapper::getControllerUrl).collect(Collectors.joining(","));
+    try (ControllerClient parentControllerCli = new ControllerClient(CLUSTER_NAME, parentControllerUrls);
+        ControllerClient dc0Client =
+            new ControllerClient(CLUSTER_NAME, childDatacenters.get(0).getControllerConnectString());
+        ControllerClient dc1Client =
+            new ControllerClient(CLUSTER_NAME, childDatacenters.get(1).getControllerConnectString())) {
+      List<ControllerClient> dcControllerClientList = Arrays.asList(dc0Client, dc1Client);
+      TestUtils.createAndVerifyStoreInAllRegions(storeName, parentControllerCli, dcControllerClientList);
+      Assert.assertFalse(
+          parentControllerCli
+              .updateStore(
+                  storeName,
+                  new UpdateStoreQueryParams().setLeaderFollowerModel(true)
+                      .setNativeReplicationEnabled(true)
+                      .setPartitionCount(1))
+              .isError());
+      TestUtils.verifyDCConfigNativeAndActiveRepl(dc0Client, storeName, true, false);
+      TestUtils.verifyDCConfigNativeAndActiveRepl(dc1Client, storeName, true, false);
+      VersionCreationResponse versionCreationResponse = parentControllerCli.requestTopicForWrites(
+          storeName,
+          1024,
+          Version.PushType.BATCH,
+          Version.guidBasedDummyPushId(),
+          true,
+          false,
+          false,
+          Optional.empty(),
+          Optional.empty(),
+          Optional.empty(),
+          false,
+          -1);
+      Assert.assertFalse(versionCreationResponse.isError());
+      TestUtils.writeBatchData(
+          versionCreationResponse,
+          STRING_SCHEMA,
+          STRING_SCHEMA,
+          IntStream.range(0, 10).mapToObj(i -> new AbstractMap.SimpleEntry<>(String.valueOf(i), String.valueOf(i))),
+          HelixReadOnlySchemaRepository.VALUE_SCHEMA_STARTING_ID);
+      TestUtils.waitForNonDeterministicPushCompletion(
+          versionCreationResponse.getKafkaTopic(),
+          parentControllerCli,
+          60,
+          TimeUnit.SECONDS);
+
+      // Call listStorePushInfo with isPartitionDetailEnabled set to true.
+      StoreHealthAuditResponse resp =
+          parentControllerCli.listStorePushInfo(CLUSTER_NAME, parentControllerUrls, storeName, true);
+      LOGGER.info("StoreHealthAuditResponse = {}", resp);
+      Assert.assertFalse(resp.isError());
+      Assert.assertFalse(resp.getRegionPushDetails().isEmpty());
+      for (Map.Entry<String, RegionPushDetails> entry: resp.getRegionPushDetails().entrySet()) {
+        RegionPushDetails detail = entry.getValue();
+        Assert.assertEquals(entry.getKey(), detail.getRegionName());
+        Assert.assertFalse(detail.getPartitionDetails().isEmpty());
+        Assert.assertFalse(detail.getPartitionDetails().get(0).getReplicaDetails().isEmpty());
+      }
+
+      // Call listStorePushInfo with isPartitionDetailEnabled set to false.
+      resp = parentControllerCli.listStorePushInfo(CLUSTER_NAME, parentControllerUrls, storeName, false);
+      LOGGER.info("StoreHealthAuditResponse = {}", resp);
+      Assert.assertFalse(resp.isError());
+      Assert.assertFalse(resp.getRegionPushDetails().isEmpty());
+      for (Map.Entry<String, RegionPushDetails> entry: resp.getRegionPushDetails().entrySet()) {
+        Assert.assertTrue(entry.getValue().getPartitionDetails().isEmpty());
+      }
+    }
+  }
+}

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestStaleDataVisibility.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestStaleDataVisibility.java
@@ -150,8 +150,7 @@ public class TestStaleDataVisibility {
       Assert.assertEquals(response.getAuditMap().get(storeName).getHealthyRegions().size(), 1);
 
       // test store health check
-      StoreHealthAuditResponse healthResponse =
-          controllerClient.listStorePushInfo(clusterName, parentControllerUrls, storeName, true);
+      StoreHealthAuditResponse healthResponse = controllerClient.listStorePushInfo(storeName, true);
       Assert.assertTrue(response.getAuditMap().containsKey(healthResponse.getName()));
       Map<String, StoreInfo> auditMapEntry = response.getAuditMap().get(healthResponse.getName()).getStaleRegions();
       for (Map.Entry<String, StoreInfo> entry: auditMapEntry.entrySet()) {

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestStaleDataVisibility.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestStaleDataVisibility.java
@@ -151,15 +151,15 @@ public class TestStaleDataVisibility {
 
       // test store health check
       StoreHealthAuditResponse healthResponse =
-          controllerClient.listStorePushInfo(clusterName, parentControllerUrls, storeName);
+          controllerClient.listStorePushInfo(clusterName, parentControllerUrls, storeName, true);
       Assert.assertTrue(response.getAuditMap().containsKey(healthResponse.getName()));
       Map<String, StoreInfo> auditMapEntry = response.getAuditMap().get(healthResponse.getName()).getStaleRegions();
-      for (Map.Entry<String, StoreInfo> entry: auditMapEntry.entrySet())
-        if (Objects.equals(entry.getValue().getName(), storeName))
-          Assert.assertTrue(healthResponse.getRegionsWithStaleData().contains(entry.getKey())); // verify that the same
-                                                                                                // regions are stale
-                                                                                                // across both responses
-                                                                                                // for the same store
+      for (Map.Entry<String, StoreInfo> entry: auditMapEntry.entrySet()) {
+        if (Objects.equals(entry.getValue().getName(), storeName)) {
+          // verify that the same regions are stale across both responses for the same store.
+          Assert.assertTrue(healthResponse.getRegionsWithStaleData().contains(entry.getKey()));
+        }
+      }
     }
   }
 }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/Admin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/Admin.java
@@ -830,9 +830,12 @@ public interface Admin extends AutoCloseable, Closeable {
    */
   int getLargestUsedVersionFromStoreGraveyard(String clusterName, String storeName);
 
-  Map<String, RegionPushDetails> listStorePushInfo(String clusterName, String storeName);
+  Map<String, RegionPushDetails> listStorePushInfo(
+      String clusterName,
+      String storeName,
+      boolean isPartitionDetailEnabled);
 
-  RegionPushDetails getRegionPushDetails(String clusterName, String storeName);
+  RegionPushDetails getRegionPushDetails(String clusterName, String storeName, boolean isPartitionDetailEnabled);
 
   Map<String, Long> getAdminTopicMetadata(String clusterName, Optional<String> storeName);
 

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -6750,7 +6750,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
     return ret;
   }
 
-  OfflinePushStatus retrievePushStatus(String clusterName, String storeName) {
+  public OfflinePushStatus retrievePushStatus(String clusterName, String storeName) {
     StoreInfo store = StoreInfo.fromStore(getStore(clusterName, storeName));
 
     VeniceOfflinePushMonitorAccessor accessor =

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
@@ -4504,7 +4504,6 @@ public class VeniceParentHelixAdmin implements Admin {
       String storeName,
       boolean isPartitionDetailEnabled) {
     Map<String, RegionPushDetails> retMap = new HashMap<>();
-
     try {
       Map<String, ControllerClient> controllerClientMap = getVeniceHelixAdmin().getControllerClientMap(clusterName);
       for (Map.Entry<String, ControllerClient> entry: controllerClientMap.entrySet()) {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
@@ -4508,12 +4508,11 @@ public class VeniceParentHelixAdmin implements Admin {
       Map<String, ControllerClient> controllerClientMap = getVeniceHelixAdmin().getControllerClientMap(clusterName);
       for (Map.Entry<String, ControllerClient> entry: controllerClientMap.entrySet()) {
         RegionPushDetailsResponse detailsResp =
-            entry.getValue().getRegionPushDetails(storeName, clusterName, isPartitionDetailEnabled);
+            entry.getValue().getRegionPushDetails(storeName, isPartitionDetailEnabled);
         if (detailsResp != null && detailsResp.getRegionPushDetails() != null) {
           detailsResp.getRegionPushDetails().setRegionName(entry.getKey());
           retMap.put(entry.getKey(), detailsResp.getRegionPushDetails());
         }
-
       }
 
     } catch (Exception e) {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
@@ -4490,7 +4490,7 @@ public class VeniceParentHelixAdmin implements Admin {
    * Unsupported operation in the parent controller.
    */
   @Override
-  public RegionPushDetails getRegionPushDetails(String clusterName, String storeName) {
+  public RegionPushDetails getRegionPushDetails(String clusterName, String storeName, boolean isPartitionDetailAdded) {
     throw new UnsupportedOperationException("This function has no implementation.");
   }
 
@@ -4499,18 +4499,24 @@ public class VeniceParentHelixAdmin implements Admin {
    * push jobs for that store across all regions.
    */
   @Override
-  public Map<String, RegionPushDetails> listStorePushInfo(String clusterName, String storeName) {
+  public Map<String, RegionPushDetails> listStorePushInfo(
+      String clusterName,
+      String storeName,
+      boolean isPartitionDetailEnabled) {
     Map<String, RegionPushDetails> retMap = new HashMap<>();
 
     try {
       Map<String, ControllerClient> controllerClientMap = getVeniceHelixAdmin().getControllerClientMap(clusterName);
       for (Map.Entry<String, ControllerClient> entry: controllerClientMap.entrySet()) {
-        RegionPushDetailsResponse detailsResp = entry.getValue().getRegionPushDetails(storeName, clusterName);
+        RegionPushDetailsResponse detailsResp =
+            entry.getValue().getRegionPushDetails(storeName, clusterName, isPartitionDetailEnabled);
         if (detailsResp != null && detailsResp.getRegionPushDetails() != null) {
           detailsResp.getRegionPushDetails().setRegionName(entry.getKey());
           retMap.put(entry.getKey(), detailsResp.getRegionPushDetails());
         }
+
       }
+
     } catch (Exception e) {
       throw new VeniceException("Something went wrong trying to get store push info. ", e);
     }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/StoresRoutes.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/StoresRoutes.java
@@ -11,6 +11,7 @@ import static com.linkedin.venice.controllerapi.ControllerApiConstants.NAME;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.NATIVE_REPLICATION_SOURCE_FABRIC;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.OPERATION;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.OWNER;
+import static com.linkedin.venice.controllerapi.ControllerApiConstants.PARTITION_DETAIL_ENABLED;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.READ_OPERATION;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.READ_WRITE_OPERATION;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.REGIONS_FILTER;
@@ -989,7 +990,7 @@ public class StoresRoutes extends AbstractRoute {
   }
 
   /**
-   * @see Admin#listStorePushInfo(String, String)
+   * @see Admin#listStorePushInfo(String, String, boolean)
    */
   public Route listStorePushInfo(Admin admin) {
     return new VeniceRouteHandler<StoreHealthAuditResponse>(StoreHealthAuditResponse.class) {
@@ -998,7 +999,8 @@ public class StoresRoutes extends AbstractRoute {
         AdminSparkServer.validateParams(request, LIST_STORE_PUSH_INFO.getParams(), admin);
         String cluster = request.queryParams(CLUSTER);
         String store = request.queryParams(NAME);
-        Map<String, RegionPushDetails> details = admin.listStorePushInfo(cluster, store);
+        boolean isPartitionDetailEnabled = Boolean.valueOf(request.queryParams(PARTITION_DETAIL_ENABLED));
+        Map<String, RegionPushDetails> details = admin.listStorePushInfo(cluster, store, isPartitionDetailEnabled);
 
         veniceResponse.setName(store);
         veniceResponse.setCluster(cluster);
@@ -1008,7 +1010,7 @@ public class StoresRoutes extends AbstractRoute {
   }
 
   /**
-   * @see Admin#getRegionPushDetails(String, String)
+   * @see Admin#getRegionPushDetails(String, String, boolean)
    */
   public Route getRegionPushDetails(Admin admin) {
     return new VeniceRouteHandler<RegionPushDetailsResponse>(RegionPushDetailsResponse.class) {
@@ -1017,7 +1019,8 @@ public class StoresRoutes extends AbstractRoute {
         AdminSparkServer.validateParams(request, GET_REGION_PUSH_DETAILS.getParams(), admin);
         String store = request.queryParams(NAME);
         String cluster = request.queryParams(CLUSTER);
-        RegionPushDetails details = admin.getRegionPushDetails(cluster, store);
+        boolean isPartitionDetailEnabled = Boolean.valueOf(request.queryParams(PARTITION_DETAIL_ENABLED));
+        RegionPushDetails details = admin.getRegionPushDetails(cluster, store, isPartitionDetailEnabled);
         veniceResponse.setRegionPushDetails(details);
       }
     };

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceParentHelixAdmin.java
@@ -2530,12 +2530,15 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
     doReturn(status).when(internalAdmin).retrievePushStatus(anyString(), anyString());
 
     Store s = TestUtils.createTestStore(storeName, owner, System.currentTimeMillis());
+    s.addVersion(new VersionImpl(s.getName(), 1, "pushJobId"));
+    s.setCurrentVersion(1);
     when(internalAdmin.getRegionPushDetails(anyString(), anyString(), anyBoolean())).thenCallRealMethod();
     doReturn(s).when(internalAdmin).getStore(anyString(), anyString());
 
     RegionPushDetails details = internalAdmin.getRegionPushDetails(clusterName, storeName, true);
     Assert.assertEquals(details.getPushEndTimestamp(), now.plusHours(1).toString());
-    Assert.assertEquals(details.getCurrentVersion().intValue(), Store.NON_EXISTING_VERSION);
+    Assert.assertEquals(details.getVersions().size(), 1);
+    Assert.assertEquals(details.getCurrentVersion().intValue(), 1);
     Assert.assertEquals(details.getPartitionDetails().size(), numOfPartition);
     for (int i = 0; i < numOfPartition; i++) {
       Assert.assertEquals(details.getPartitionDetails().get(i).getReplicaDetails().size(), replicationFactor);

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceParentHelixAdmin.java
@@ -58,6 +58,7 @@ import com.linkedin.venice.meta.HybridStoreConfigImpl;
 import com.linkedin.venice.meta.OfflinePushStrategy;
 import com.linkedin.venice.meta.PersistenceType;
 import com.linkedin.venice.meta.ReadStrategy;
+import com.linkedin.venice.meta.RegionPushDetails;
 import com.linkedin.venice.meta.RoutingStrategy;
 import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.StoreInfo;
@@ -67,6 +68,9 @@ import com.linkedin.venice.meta.ZKStore;
 import com.linkedin.venice.offsets.OffsetRecord;
 import com.linkedin.venice.partitioner.InvalidKeySchemaPartitioner;
 import com.linkedin.venice.pushmonitor.ExecutionStatus;
+import com.linkedin.venice.pushmonitor.OfflinePushStatus;
+import com.linkedin.venice.pushmonitor.PartitionStatus;
+import com.linkedin.venice.pushmonitor.StatusSnapshot;
 import com.linkedin.venice.schema.avro.DirectionalSchemaCompatibilityType;
 import com.linkedin.venice.serialization.avro.AvroProtocolDefinition;
 import com.linkedin.venice.utils.DataProviderUtils;
@@ -78,6 +82,7 @@ import com.linkedin.venice.utils.Time;
 import com.linkedin.venice.utils.Utils;
 import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
 import com.linkedin.venice.writer.VeniceWriter;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -89,6 +94,7 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import org.apache.commons.lang.StringUtils;
 import org.apache.http.HttpStatus;
 import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.common.TopicPartition;
@@ -2493,5 +2499,46 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
     parentAdmin.createStore(clusterName, storeName, owner, keySchemaStr, valueSchemaStr);
     doReturn(clusterLockManager).when(resources).getClusterLockManager();
     verify(clusterLockManager).createClusterReadLock();
+  }
+
+  @Test
+  public void testDataRecoveryAPIs() {
+    final String storeName = "test";
+    final String owner = "test";
+    final int numOfPartition = 5;
+    final int replicationFactor = 3;
+    final String kafkaTopic = "test_v1";
+
+    OfflinePushStatus status = new OfflinePushStatus(
+        kafkaTopic,
+        numOfPartition,
+        replicationFactor,
+        OfflinePushStrategy.WAIT_N_MINUS_ONE_REPLCIA_PER_PARTITION);
+    LocalDateTime now = LocalDateTime.now();
+
+    for (int i = 0; i < numOfPartition; i++) {
+      PartitionStatus partition = new PartitionStatus(i);
+      for (int j = 0; j < replicationFactor; j++) {
+        partition.updateReplicaStatus("instanceId-" + j, ExecutionStatus.STARTED, StringUtils.EMPTY);
+        partition.updateReplicaStatus("instanceId-" + j, ExecutionStatus.COMPLETED, StringUtils.EMPTY);
+      }
+      status.setPartitionStatus(partition);
+    }
+
+    status.getStatusHistory().add(new StatusSnapshot(ExecutionStatus.STARTED, now.toString()));
+    status.getStatusHistory().add(new StatusSnapshot(ExecutionStatus.COMPLETED, now.plusHours(1).toString()));
+    doReturn(status).when(internalAdmin).retrievePushStatus(anyString(), anyString());
+
+    Store s = TestUtils.createTestStore(storeName, owner, System.currentTimeMillis());
+    when(internalAdmin.getRegionPushDetails(anyString(), anyString(), anyBoolean())).thenCallRealMethod();
+    doReturn(s).when(internalAdmin).getStore(anyString(), anyString());
+
+    RegionPushDetails details = internalAdmin.getRegionPushDetails(clusterName, storeName, true);
+    Assert.assertEquals(details.getPushEndTimestamp(), now.plusHours(1).toString());
+    Assert.assertEquals(details.getCurrentVersion().intValue(), Store.NON_EXISTING_VERSION);
+    Assert.assertEquals(details.getPartitionDetails().size(), numOfPartition);
+    for (int i = 0; i < numOfPartition; i++) {
+      Assert.assertEquals(details.getPartitionDetails().get(i).getReplicaDetails().size(), replicationFactor);
+    }
   }
 }


### PR DESCRIPTION
…n and replica details

Today, `listStorePushInfo` is an API of parent controller to describe the push job information of a store's current version in each colo e.g. push job start(end) time. However, it does not contain per partition/replica raw stats used for estimating the data recovery time.

This rb modifies the current `listStorePushInfo` API to have a new flag indicating if partition and replica details should be returned. If it is set to false, it remains today's behavior, however, if it is set to true, it returns replicas details for each composing partition of the store's current version. This rb also adds a new integration test to verify the new API's effectiveness.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

Internal CI passed.

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [x] Yes. Make sure to explain your proposed changes and call out the behavior change.