### PR TITLE
[build] Exclude auto-generated files by Avro from Jacoco code coverage verification

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -371,6 +371,10 @@ subprojects {
 
   jacocoTestReport {
     dependsOn test // tests are required to run before generating the report
+
+    afterEvaluate {
+      excludedClassFiles(classDirectories)
+    }
   }
 
   afterEvaluate {
@@ -388,6 +392,10 @@ subprojects {
             minimum = threshold
           }
         }
+      }
+
+      afterEvaluate {
+        excludedClassFiles(classDirectories)
       }
     }
   }
@@ -585,4 +593,28 @@ ext.createDiffFile = { ->
   }
 
   return file
+}
+
+private excludedClassFiles(classDirectories) {
+  // exclude classes generated from Avro
+  def generatedSources = [
+      '**/com/linkedin/venice/admin/protocol/response/*',
+      '**/com/linkedin/venice/compute/protocol/request/*',
+      '**/com/linkedin/venice/compute/protocol/response/*',
+      '**/com/linkedin/venice/compute/protocol/request/router/*',
+      '**/com/linkedin/venice/controller/kafka/protocol/admin/*',
+      '**/com/linkedin/venice/ingestion/protocol/*',
+      '**/com/linkedin/venice/kafka/protocol/*',
+      '**/com/linkedin/venice/storage/protocol/*',
+      '**/com/linkedin/venice/status/protocol/*',
+      '**/com/linkedin/venice/meta/systemstore/schemas/*',
+      '**/com/linkedin/venice/participant/protocol/*',
+      '**/com/linkedin/venice/pushstatus/*',
+      '**/com/linkedin/venice/hadoop/input/kafka/avro/*',
+      '**/com/linkedin/venice/read/protocol/response/*',
+      '**/com/linkedin/venice/read/protocol/request/*'
+  ]
+  classDirectories.setFrom(files(classDirectories.files.collect {
+    fileTree(dir: it, exclude: generatedSources)
+  }))
 }

--- a/build.gradle
+++ b/build.gradle
@@ -483,30 +483,6 @@ task spotbugs {
 }
 check.dependsOn(spotbugs)
 
-tasks.register("CodeCoverageAggregateReport", JacocoReport) {
-  subprojects { subproject ->
-    subproject.plugins.withType(JacocoPlugin).configureEach {
-      subproject.tasks.matching({ t -> t.extensions.findByType(JacocoTaskExtension) }).configureEach { testTask ->
-        sourceSets subproject.sourceSets.main
-        executionData(testTask)
-      }
-
-      // To automatically run `test` every time `./gradlew codeCoverageReport` is called,
-      // you may want to set up a task dependency between them as shown below.
-      // Note that this requires the `test` tasks to be resolved eagerly (see `forEach`) which
-      // may have a negative effect on the configuration time of your build.
-//      subproject.tasks.matching({ t -> t.extensions.findByType(JacocoTaskExtension) }).forEach {
-//        rootProject.tasks.codeCoverageReport.dependsOn(it)
-//      }
-    }
-  }
-
-  reports {
-    html.enabled true
-    html.destination file("${buildDir}/report/jacocoHtml")
-  }
-}
-
 test {
   mustRunAfter spotbugs
   dependsOn subprojects.test

--- a/build.gradle
+++ b/build.gradle
@@ -389,6 +389,10 @@ subprojects {
           }
         }
       }
+
+      afterEvaluate {
+        excludedClassFiles(classDirectories)
+      }
     }
 
     diffCoverageReport {
@@ -568,6 +572,30 @@ idea.project.ipr {
       }
     }
   }
+}
+
+private excludedClassFiles(classDirectories) {
+  // exclude classes generated from Avro
+  def generatedSources = [
+      '**/com/linkedin/venice/admin/protocol/response/*',
+      '**/com/linkedin/venice/compute/protocol/request/*',
+      '**/com/linkedin/venice/compute/protocol/response/*',
+      '**/com/linkedin/venice/compute/protocol/request/router/*',
+      '**/com/linkedin/venice/controller/kafka/protocol/admin/*',
+      '**/com/linkedin/venice/ingestion/protocol/*',
+      '**/com/linkedin/venice/kafka/protocol/*',
+      '**/com/linkedin/venice/storage/protocol/*',
+      '**/com/linkedin/venice/status/protocol/*',
+      '**/com/linkedin/venice/meta/systemstore/schemas/*',
+      '**/com/linkedin/venice/participant/protocol/*',
+      '**/com/linkedin/venice/pushstatus/*',
+      '**/com/linkedin/venice/hadoop/input/kafka/avro/*',
+      '**/com/linkedin/venice/read/protocol/response/*',
+      '**/com/linkedin/venice/read/protocol/request/*'
+  ]
+  classDirectories.setFrom(files(classDirectories.files.collect {
+    fileTree(dir: it, exclude: generatedSources)
+  }))
 }
 
 // Allow running diffCoverage against uncommitted files

--- a/build.gradle
+++ b/build.gradle
@@ -371,10 +371,6 @@ subprojects {
 
   jacocoTestReport {
     dependsOn test // tests are required to run before generating the report
-
-    afterEvaluate {
-      excludedClassFiles(classDirectories)
-    }
   }
 
   afterEvaluate {
@@ -405,7 +401,7 @@ subprojects {
       diffSource.file = createDiffFile()
     }
 
-    // Report locates at <module_name>/build/reports/jacoco/diffCoverage/html/index.html
+    // Report locates at [clients|internal|services]/build/reports/jacoco/diffCoverage/html/index.html
     reports {
       html = true
     }
@@ -486,6 +482,30 @@ task spotbugs {
   dependsOn subprojects.tasks*.withType(SpotBugsTask)
 }
 check.dependsOn(spotbugs)
+
+tasks.register("CodeCoverageAggregateReport", JacocoReport) {
+  subprojects { subproject ->
+    subproject.plugins.withType(JacocoPlugin).configureEach {
+      subproject.tasks.matching({ t -> t.extensions.findByType(JacocoTaskExtension) }).configureEach { testTask ->
+        sourceSets subproject.sourceSets.main
+        executionData(testTask)
+      }
+
+      // To automatically run `test` every time `./gradlew codeCoverageReport` is called,
+      // you may want to set up a task dependency between them as shown below.
+      // Note that this requires the `test` tasks to be resolved eagerly (see `forEach`) which
+      // may have a negative effect on the configuration time of your build.
+//      subproject.tasks.matching({ t -> t.extensions.findByType(JacocoTaskExtension) }).forEach {
+//        rootProject.tasks.codeCoverageReport.dependsOn(it)
+//      }
+    }
+  }
+
+  reports {
+    html.enabled true
+    html.destination file("${buildDir}/report/jacocoHtml")
+  }
+}
 
 test {
   mustRunAfter spotbugs

--- a/clients/da-vinci-client/build.gradle
+++ b/clients/da-vinci-client/build.gradle
@@ -36,5 +36,5 @@ dependencies {
 }
 
 ext {
-  jacocoCoverageThreshold = 0.40
+  jacocoCoverageThreshold = 0.41
 }

--- a/clients/venice-push-job/build.gradle
+++ b/clients/venice-push-job/build.gradle
@@ -56,5 +56,5 @@ jar {
 }
 
 ext {
-  jacocoCoverageThreshold = 0.39
+  jacocoCoverageThreshold = 0.38
 }

--- a/docs/dev_guide/workspace_setup.md
+++ b/docs/dev_guide/workspace_setup.md
@@ -53,11 +53,19 @@ with various values and find ones that work for you.
 # Run jacoco code coverage check, which will also generate jacoco report
 ./gradlew jacocoTestCoverageVerification
  
+# Run jacoco code coverage check along with jacoco report and diff coverage check
+# Note that Jacoco task must be run before running diffCoverage otherwise the coverage data is 0
+# Also make sure the git origin is up-to-date with the git upstream otherwise the diff may show files not from the commit
+./gradlew jacocoTestCoverageVerification diffCoverage
+
 # Run enabled checks only for main code and in da-vinci-client subproject
 ./gradlew :clients:da-vinci-client:spotbugsMain
 
- # Run jacoco code coverage check for a specific module along with jacoco report
+# Run jacoco code coverage check for a specific module along with jacoco report
 ./gradlew :clients:da-vinci-client:jacocoTestCoverageVerification
+
+# Run jacoco code coverage check for a specific module along with jacoco report and diff coverage check
+./gradlew :clients:da-vinci-client:jacocoTestCoverageVerification diffCoverage
 
 # Run a specific test in any module
 $ ./gradlew :sub-module:testType --tests "fully.qualified.name.of.the.test"

--- a/internal/venice-client-common/build.gradle
+++ b/internal/venice-client-common/build.gradle
@@ -44,5 +44,5 @@ dependencies {
 }
 
 ext {
-  jacocoCoverageThreshold = 0.24
+  jacocoCoverageThreshold = 0.25
 }

--- a/internal/venice-common/build.gradle
+++ b/internal/venice-common/build.gradle
@@ -63,5 +63,5 @@ task generateSslCertificate(type: Exec) {
 sourceSets.main.resources.srcDir(generateSslCertificate)
 
 ext {
-  jacocoCoverageThreshold = 0.26
+  jacocoCoverageThreshold = 0.29
 }

--- a/services/venice-controller/build.gradle
+++ b/services/venice-controller/build.gradle
@@ -54,5 +54,5 @@ jar {
 }
 
 ext {
-  jacocoCoverageThreshold = 0.21
+  jacocoCoverageThreshold = 0.19
 }


### PR DESCRIPTION
### Summary
As titled.

I was hoping to exclude them from the report as well but `diffCoverage` complains configuration issue, which I suspect it can be related to the messy setup by misuse of `afterEvaluate`. However, my Gradle knowledge couldn't help me to find out how to resolve it so post the PR for review and see if people have some ideas.

### Test
JDK11: 7541
JDK8: 1171