### PR TITLE
[vpj][controller][samza][test] Make VPJ use D2 controller client

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -128,8 +128,6 @@ publishing {
 }
 
 subprojects {
-  def thisProject = project
-
   //apply group and version to all submodules
   group = rootProject.group
   version = rootProject.version

--- a/build.gradle
+++ b/build.gradle
@@ -128,6 +128,8 @@ publishing {
 }
 
 subprojects {
+  def thisProject = project
+
   //apply group and version to all submodules
   group = rootProject.group
   version = rootProject.version
@@ -390,21 +392,19 @@ subprojects {
         }
       }
     }
-  }
 
-  diffCoverageReport {
-    afterEvaluate {
+    diffCoverageReport {
       diffSource.file = createDiffFile()
-    }
 
-    // Report locates at <module_name>/build/reports/jacoco/diffCoverage/html/index.html
-    reports {
-      html = true
-    }
+      // Report locates at <module_name>/build/reports/jacoco/diffCoverage/html/index.html
+      reports {
+        html = true
+      }
 
-    violationRules {
-      minBranches = 0.6
-      failOnViolation = true
+      violationRules {
+        minBranches = project.ext.has('diffCoverageThreshold') ? project.ext.diffCoverageThreshold : 0.6
+        failOnViolation = true
+      }
     }
   }
 

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/AdminTool.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/AdminTool.java
@@ -1141,7 +1141,7 @@ public class AdminTool {
   }
 
   private static void enableThrottling(boolean enable) {
-    ControllerResponse response = controllerClient.enableThrotting(enable);
+    ControllerResponse response = controllerClient.enableThrottling(enable);
     printSuccess(response);
   }
 

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
@@ -19,7 +19,7 @@ import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
 import com.linkedin.venice.compression.CompressionStrategy;
 import com.linkedin.venice.controllerapi.ControllerClient;
 import com.linkedin.venice.controllerapi.ControllerResponse;
-import com.linkedin.venice.controllerapi.D2ControllerClient;
+import com.linkedin.venice.controllerapi.D2ControllerClientFactory;
 import com.linkedin.venice.controllerapi.JobStatusQueryResponse;
 import com.linkedin.venice.controllerapi.MultiSchemaResponse;
 import com.linkedin.venice.controllerapi.RepushInfoResponse;
@@ -1590,7 +1590,7 @@ public class VenicePushJob implements AutoCloseable {
       Optional<SSLFactory> sslFactory,
       int retryAttempts) {
     if (useD2ControllerClient) {
-      return D2ControllerClient.discoverAndConstructControllerClient(
+      return D2ControllerClientFactory.discoverAndConstructControllerClient(
           storeName,
           controllerD2ServiceName,
           d2ZkHosts,

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
@@ -19,6 +19,7 @@ import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
 import com.linkedin.venice.compression.CompressionStrategy;
 import com.linkedin.venice.controllerapi.ControllerClient;
 import com.linkedin.venice.controllerapi.ControllerResponse;
+import com.linkedin.venice.controllerapi.D2ControllerClient;
 import com.linkedin.venice.controllerapi.JobStatusQueryResponse;
 import com.linkedin.venice.controllerapi.MultiSchemaResponse;
 import com.linkedin.venice.controllerapi.RepushInfoResponse;
@@ -227,8 +228,8 @@ public class VenicePushJob implements AutoCloseable {
   public static final String REWIND_TIME_IN_SECONDS_OVERRIDE = "rewind.time.in.seconds.override";
 
   /**
-   * A time stamp specified to rewind to before replaying data.  This config is ignored if rewind.time.in.seconds.override
-   * is provided.  This config at time of push will be leveraged to fill in the rewind.time.in.seconds.override by taking
+   * A time stamp specified to rewind to before replaying data. This config is ignored if rewind.time.in.seconds.override
+   * is provided. This config at time of push will be leveraged to fill in the rewind.time.in.seconds.override by taking
    * System.currentTime - rewind.epoch.time.in.seconds.override and storing the result in rewind.time.in.seconds.override.
    * With this in mind, a push policy of REWIND_FROM_SOP should be used in order to get a behavior that makes sense to a user.
    * A timestamp that is in the future is not valid and will result in an exception.
@@ -237,26 +238,48 @@ public class VenicePushJob implements AutoCloseable {
 
   /**
    * This config is a boolean which suppresses submitting the end of push message after data has been sent and does
-   * not poll for the status of the job to complete.  Using this flag means that a user must manually mark the job success
+   * not poll for the status of the job to complete. Using this flag means that a user must manually mark the job success
    * or failed.
    */
   public static final String SUPPRESS_END_OF_PUSH_MESSAGE = "suppress.end.of.push.message";
 
+  /**
+   * This config is a boolean which waits for an external signal to trigger version swap after buffer replay is complete.
+   */
   public static final String DEFER_VERSION_SWAP = "defer.version.swap";
 
   /**
-   * Relates to the above argument.  An overridable amount of buffer to be applied to the epoch (as the rewind isn't
-   * perfectly instantaneous).  Defaults to 1 minute.
+   * This config specifies the prefix for d2 zk hosts config. Configs of type {@literal <prefix>.<regionName>} are
+   * expected to be defined.
+   */
+  public static final String D2_ZK_HOSTS_PREFIX = "d2.zk.hosts.";
+
+  /**
+   * This config specifies the region identifier where parent controller is running
+   */
+  public static final String PARENT_CONTROLLER_REGION_NAME = "parent.controller.colo.name";
+
+  /**
+   * Relates to the above argument. An overridable amount of buffer to be applied to the epoch (as the rewind isn't
+   * perfectly instantaneous). Defaults to 1 minute.
    */
   public static final String REWIND_EPOCH_TIME_BUFFER_IN_SECONDS_OVERRIDE =
       "rewind.epoch.time.buffer.in.seconds.override";
 
   /**
-   * In single-colo mode, this can be either a controller or router.
-   * In multi-colo mode, it must be a parent controller.
+   * This config specifies if Venice is deployed in a multi-region mode
+   */
+  public static final String MULTI_REGION = "multi.region";
+
+  /**
+   * In single-region mode, this must be a comma-separated list of child controller URLs or {@literal d2://<d2ServiceNameForChildController>}
+   * In multi-region mode, it must be a comma-separated list of parent controller URLs or {@literal d2://<d2ServiceNameForParentController>}
    */
   public static final String VENICE_DISCOVER_URL_PROP = "venice.discover.urls";
 
+  /**
+   * An identifier of the data center which is used to determine the Kafka URL and child controllers that push jobs communicate with
+   */
   public static final String SOURCE_GRID_FABRIC = "source.grid.fabric";
 
   public static final String ENABLE_WRITE_COMPUTE = "venice.write.compute.enable";
@@ -356,7 +379,6 @@ public class VenicePushJob implements AutoCloseable {
   // Immutable state
   protected final VeniceProperties props;
   private final String jobId;
-  private final String clusterName;
 
   // Lazy state
   private final Lazy<Properties> sslProperties;
@@ -365,8 +387,7 @@ public class VenicePushJob implements AutoCloseable {
 
   // Mutable state
   private ControllerClient controllerClient;
-  private ControllerClient systemKMEStoreControllerClient;
-  private ControllerClient clusterDiscoveryControllerClient;
+  private ControllerClient kmeSchemaSystemStoreControllerClient;
   private ControllerClient livenessHeartbeatStoreControllerClient;
   private RunningJob runningJob;
   // Job config for schema validation and Compression dictionary creation (if needed)
@@ -396,6 +417,7 @@ public class VenicePushJob implements AutoCloseable {
     String veniceControllerUrl;
     String veniceRouterUrl;
     String storeName;
+    String clusterName;
     String sourceGridFabric;
     int batchNumBytes;
     boolean enablePBNJ;
@@ -434,6 +456,13 @@ public class VenicePushJob implements AutoCloseable {
     long repushTTLInSeconds;
     // HDFS directory to cache RMD schemas
     String rmdSchemaDir;
+    String controllerD2ServiceName;
+    String parentControllerRegionD2ZkHosts;
+    String childControllerRegionD2ZkHosts;
+    boolean livenessHeartbeatEnabled;
+    String livenessHeartbeatStoreName;
+    boolean multiRegion;
+    boolean d2Routing;
   }
 
   protected PushJobSetting pushJobSetting;
@@ -476,7 +505,6 @@ public class VenicePushJob implements AutoCloseable {
   protected StoreSetting storeSetting;
   private InputStorageQuotaTracker inputStorageQuotaTracker;
   private PushJobHeartbeatSenderFactory pushJobHeartbeatSenderFactory;
-  private final boolean jobLivenessHeartbeatEnabled;
   private boolean pushJobStatusUploadDisabledHasBeenLogged = false;
 
   /**
@@ -504,14 +532,11 @@ public class VenicePushJob implements AutoCloseable {
     }
   }
 
-  // Visible for testing
-  public VenicePushJob(
-      String jobId,
-      Properties vanillaProps,
-      ControllerClient controllerClient,
-      ControllerClient clusterDiscoveryControllerClient) {
-    this.controllerClient = controllerClient;
-    this.clusterDiscoveryControllerClient = clusterDiscoveryControllerClient;
+  /**
+   * @param jobId  id of the job
+   * @param vanillaProps  Property bag for the job
+   */
+  public VenicePushJob(String jobId, Properties vanillaProps) {
     this.jobId = jobId;
     this.props = getVenicePropsFromVanillaProps(vanillaProps);
     if (isSslEnabled()) {
@@ -525,72 +550,17 @@ public class VenicePushJob implements AutoCloseable {
       }
     });
     LOGGER.info("Constructing {}: {}", VenicePushJob.class.getSimpleName(), props.toString(true));
-    String veniceControllerUrl = props.getString(VENICE_DISCOVER_URL_PROP);
-    initControllerClient(
-        props.getString(VENICE_STORE_NAME_PROP),
-        props.getString(VENICE_DISCOVER_URL_PROP),
-        VPJSSLUtils.createSSLFactory(
-            isSslEnabled(),
-            props.getString(SSL_FACTORY_CLASS_NAME, DEFAULT_SSL_FACTORY_CLASS_NAME),
-            this.sslProperties),
-        props.getInt(CONTROLLER_REQUEST_RETRY_ATTEMPTS, 1));
-    this.pushJobSetting = getPushJobSetting(veniceControllerUrl, props);
-    LOGGER.info("Going to use controller URL: {}  to discover cluster.", veniceControllerUrl);
-    this.clusterName = discoverCluster(props.getString(VENICE_STORE_NAME_PROP));
-    LOGGER
-        .info("The store {} is discovered in Venice cluster {}", props.getString(VENICE_STORE_NAME_PROP), clusterName);
+    this.pushJobSetting = getPushJobSetting(props);
+    LOGGER.info("Going to use controller URL: {}  to discover cluster.", pushJobSetting.veniceControllerUrl);
     // Optional configs:
     this.pushJobDetails = new PushJobDetails();
-    boolean jobLivenessHeartbeatEnabled;
-    if (props.getBoolean(HEARTBEAT_ENABLED_CONFIG.getConfigName(), false)) {
+    if (pushJobSetting.livenessHeartbeatEnabled) {
       LOGGER.info("Push job heartbeat is enabled.");
-      try {
-        this.pushJobHeartbeatSenderFactory = new DefaultPushJobHeartbeatSenderFactory();
-        this.livenessHeartbeatStoreControllerClient = createLivenessHeartbeatControllerClient(props);
-        jobLivenessHeartbeatEnabled = true;
-
-      } catch (Exception e) {
-        LOGGER.warn(
-            "Initializing the liveness heartbeat sender or its controller client failed. Hence the feature is disabled.",
-            e);
-        this.pushJobDetails.sendLivenessHeartbeatFailureDetails = e.getMessage();
-        this.pushJobHeartbeatSenderFactory = new NoOpPushJobHeartbeatSenderFactory();
-        this.livenessHeartbeatStoreControllerClient = null;
-        jobLivenessHeartbeatEnabled = false;
-      }
+      this.pushJobHeartbeatSenderFactory = new DefaultPushJobHeartbeatSenderFactory();
     } else {
       LOGGER.info("Push job heartbeat is NOT enabled.");
       this.pushJobHeartbeatSenderFactory = new NoOpPushJobHeartbeatSenderFactory();
-      this.livenessHeartbeatStoreControllerClient = null;
-      jobLivenessHeartbeatEnabled = false;
     }
-    this.jobLivenessHeartbeatEnabled = jobLivenessHeartbeatEnabled;
-  }
-
-  private ControllerClient createLivenessHeartbeatControllerClient(VeniceProperties properties) {
-    String heartbeatStoreName = properties.getString(HEARTBEAT_STORE_NAME_CONFIG.getConfigName()); // Required config
-                                                                                                   // value
-    Optional<SSLFactory> sslFactory = VPJSSLUtils.createSSLFactory(
-        isSslEnabled(),
-        properties.getString(SSL_FACTORY_CLASS_NAME, DEFAULT_SSL_FACTORY_CLASS_NAME),
-        this.sslProperties);
-    String veniceControllerUrl = props.getString(VENICE_DISCOVER_URL_PROP);
-    String heartbeatStoreClusterName = discoverCluster(heartbeatStoreName);
-    ControllerClient heartbeatStoreControllerClient =
-        ControllerClient.constructClusterControllerClient(heartbeatStoreClusterName, veniceControllerUrl, sslFactory);
-    LOGGER.info(
-        "Created controller client for the liveness heartbeat store {} in {} cluster",
-        heartbeatStoreName,
-        heartbeatStoreClusterName);
-    return heartbeatStoreControllerClient;
-  }
-
-  /**
-   * @param jobId  id of the job
-   * @param vanillaProps  Property bag for the job
-   */
-  public VenicePushJob(String jobId, Properties vanillaProps) {
-    this(jobId, vanillaProps, null, null);
   }
 
   // Visible for testing
@@ -626,9 +596,9 @@ public class VenicePushJob implements AutoCloseable {
     return props.getBoolean(ENABLE_SSL, DEFAULT_SSL_ENABLED);
   }
 
-  private PushJobSetting getPushJobSetting(String veniceControllerUrl, VeniceProperties props) {
+  private PushJobSetting getPushJobSetting(VeniceProperties props) {
     PushJobSetting pushJobSettingToReturn = new PushJobSetting();
-    pushJobSettingToReturn.veniceControllerUrl = veniceControllerUrl;
+    pushJobSettingToReturn.veniceControllerUrl = props.getString(VENICE_DISCOVER_URL_PROP);
     pushJobSettingToReturn.enablePush = props.getBoolean(ENABLE_PUSH, true);
     if (props.containsKey(SOURCE_GRID_FABRIC)) {
       pushJobSettingToReturn.sourceGridFabric = props.getString(SOURCE_GRID_FABRIC);
@@ -663,6 +633,31 @@ public class VenicePushJob implements AutoCloseable {
       throw new VeniceException("Repush with TTL is only supported while using Kafka Input Format");
     }
 
+    final String D2_PREFIX = "d2://";
+    if (pushJobSettingToReturn.veniceControllerUrl.startsWith(D2_PREFIX)) {
+      pushJobSettingToReturn.d2Routing = true;
+      pushJobSettingToReturn.controllerD2ServiceName =
+          pushJobSettingToReturn.veniceControllerUrl.substring(D2_PREFIX.length());
+      pushJobSettingToReturn.multiRegion = props.getBoolean(MULTI_REGION);
+      if (pushJobSettingToReturn.multiRegion) {
+        String parentControllerRegionName = props.getString(PARENT_CONTROLLER_REGION_NAME);
+        pushJobSettingToReturn.parentControllerRegionD2ZkHosts =
+            props.getString(D2_ZK_HOSTS_PREFIX + parentControllerRegionName);
+      } else {
+        pushJobSettingToReturn.childControllerRegionD2ZkHosts =
+            props.getString(D2_ZK_HOSTS_PREFIX + pushJobSettingToReturn.sourceGridFabric);
+      }
+    } else {
+      pushJobSettingToReturn.d2Routing = false;
+      pushJobSettingToReturn.controllerD2ServiceName = null;
+      pushJobSettingToReturn.multiRegion = props.getBoolean(MULTI_REGION, false);
+      pushJobSettingToReturn.parentControllerRegionD2ZkHosts = null;
+      pushJobSettingToReturn.childControllerRegionD2ZkHosts = null;
+    }
+
+    pushJobSettingToReturn.livenessHeartbeatEnabled = props.getBoolean(HEARTBEAT_ENABLED_CONFIG.getConfigName(), false);
+    pushJobSettingToReturn.livenessHeartbeatStoreName =
+        props.getString(HEARTBEAT_STORE_NAME_CONFIG.getConfigName(), "");
     if (pushJobSettingToReturn.isSourceKafka) {
       /**
        * The topic could contain duplicate records since the topic could belong to a hybrid store
@@ -679,12 +674,8 @@ public class VenicePushJob implements AutoCloseable {
       if (pushJobSettingToReturn.enablePBNJ) {
         throw new VeniceException("PBNJ is not supported while using Kafka Input Format");
       }
-      pushJobSettingToReturn.kafkaInputTopic =
-          getSourceTopicNameForKafkaInput(props.getString(VENICE_STORE_NAME_PROP), props, pushJobSettingToReturn);
-      pushJobSettingToReturn.kafkaInputBrokerUrl = pushJobSettingToReturn.repushInfoResponse == null
-          ? props.getString(KAFKA_INPUT_BROKER_URL)
-          : pushJobSettingToReturn.repushInfoResponse.getRepushInfo().getKafkaBrokerUrl();
     }
+
     pushJobSettingToReturn.storeName = props.getString(VENICE_STORE_NAME_PROP);
     pushJobSettingToReturn.rewindTimeInSecondsOverride = props.getLong(REWIND_TIME_IN_SECONDS_OVERRIDE, NOT_SET);
 
@@ -758,18 +749,7 @@ public class VenicePushJob implements AutoCloseable {
    */
   private String getSourceTopicNameForKafkaInput(
       final String userProvidedStoreName,
-      final VeniceProperties properties,
-      final PushJobSetting pushJobSettingUnderConstruction) {
-    if (controllerClient == null) {
-      initControllerClient(
-          pushJobSettingUnderConstruction.storeName,
-          props.getString(VENICE_DISCOVER_URL_PROP),
-          VPJSSLUtils.createSSLFactory(
-              isSslEnabled(),
-              properties.getString(SSL_FACTORY_CLASS_NAME, DEFAULT_SSL_FACTORY_CLASS_NAME),
-              this.sslProperties),
-          pushJobSettingUnderConstruction.controllerRetries);
-    }
+      final VeniceProperties properties) {
     final Optional<String> userProvidedTopicNameOptional =
         Optional.ofNullable(properties.getString(KAFKA_INPUT_TOPIC, () -> null));
 
@@ -778,21 +758,21 @@ public class VenicePushJob implements AutoCloseable {
       return getUserProvidedTopicName(
           userProvidedStoreName,
           userProvidedTopicNameOptional.get(),
-          pushJobSettingUnderConstruction.controllerRetries);
+          pushJobSetting.controllerRetries);
     }
     // If VPJ has fabric name available use that to find the child colo version otherwise
     // use the largest version among the child colo to use as KIF input topic.
     final Optional<String> userProvidedFabricNameOptional =
         Optional.ofNullable(properties.getString(KAFKA_INPUT_FABRIC, () -> null));
 
-    pushJobSettingUnderConstruction.repushInfoResponse = ControllerClient.retryableRequest(
+    pushJobSetting.repushInfoResponse = ControllerClient.retryableRequest(
         controllerClient,
-        pushJobSettingUnderConstruction.controllerRetries,
+        pushJobSetting.controllerRetries,
         c -> c.getRepushInfo(userProvidedStoreName, userProvidedFabricNameOptional));
-    if (pushJobSettingUnderConstruction.repushInfoResponse.isError()) {
+    if (pushJobSetting.repushInfoResponse.isError()) {
       throw new VeniceException("Could not get repush info for store " + userProvidedStoreName);
     }
-    int version = pushJobSettingUnderConstruction.repushInfoResponse.getRepushInfo().getVersion().getNumber();
+    int version = pushJobSetting.repushInfoResponse.getRepushInfo().getVersion().getNumber();
     return Version.composeKafkaTopic(userProvidedStoreName, version);
   }
 
@@ -857,11 +837,6 @@ public class VenicePushJob implements AutoCloseable {
   }
 
   // Visible for testing
-  protected void setClusterDiscoveryControllerClient(ControllerClient clusterDiscoveryControllerClient) {
-    this.clusterDiscoveryControllerClient = clusterDiscoveryControllerClient;
-  }
-
-  // Visible for testing
   protected void setInputDataInfoProvider(InputDataInfoProvider inputDataInfoProvider) {
     this.inputDataInfoProvider = inputDataInfoProvider;
   }
@@ -887,23 +862,28 @@ public class VenicePushJob implements AutoCloseable {
   public void run() {
     PushJobHeartbeatSender pushJobHeartbeatSender = null;
     try {
+      Optional<SSLFactory> sslFactory = VPJSSLUtils.createSSLFactory(
+          isSslEnabled(),
+          props.getString(SSL_FACTORY_CLASS_NAME, DEFAULT_SSL_FACTORY_CLASS_NAME),
+          this.sslProperties);
+      initControllerClient(pushJobSetting.storeName, sslFactory);
+      pushJobSetting.clusterName = controllerClient.getClusterName();
+      LOGGER.info(
+          "The store {} is discovered in Venice cluster {}",
+          pushJobSetting.storeName,
+          pushJobSetting.clusterName);
+
+      if (pushJobSetting.isSourceKafka) {
+        initKIFRepushDetails();
+      }
+
       initPushJobDetails();
       jobStartTimeMs = System.currentTimeMillis();
       logGreeting();
-      final boolean sslEnabled = isSslEnabled();
-      Optional<SSLFactory> sslFactory = VPJSSLUtils.createSSLFactory(
-          sslEnabled,
-          props.getString(SSL_FACTORY_CLASS_NAME, DEFAULT_SSL_FACTORY_CLASS_NAME),
-          this.sslProperties);
-      initControllerClient(
-          pushJobSetting.storeName,
-          pushJobSetting.veniceControllerUrl,
-          sslFactory,
-          pushJobSetting.controllerRetries);
       sendPushJobDetailsToController();
       validateKafkaMessageEnvelopeSchema(pushJobSetting);
       validateRemoteHybridSettings(pushJobSetting);
-      pushJobHeartbeatSender = createPushJobHeartbeatSender(sslEnabled);
+      pushJobHeartbeatSender = createPushJobHeartbeatSender(isSslEnabled());
       inputDirectory = getInputURI(props);
       storeSetting = getSettingsFromController(controllerClient, pushJobSetting);
       inputStorageQuotaTracker = new InputStorageQuotaTracker(storeSetting.storeStorageQuota);
@@ -1030,13 +1010,7 @@ public class VenicePushJob implements AutoCloseable {
         pushJobHeartbeatSender.start(pushJobSetting.storeName, kafkaTopicInfo.version);
         sendPushJobDetailsToController();
         // Log Venice data push job related info
-        logPushJobProperties(
-            kafkaTopicInfo,
-            pushJobSetting,
-            pushJobSchemaInfo,
-            clusterName,
-            inputDirectory,
-            inputFileDataSize);
+        logPushJobProperties(kafkaTopicInfo, pushJobSetting, pushJobSchemaInfo, inputDirectory, inputFileDataSize);
 
         // Setup the hadoop job
         // If reducer phase is enabled, each reducer will sort all the messages inside one single
@@ -1489,8 +1463,8 @@ public class VenicePushJob implements AutoCloseable {
   }
 
   // Visible for testing
-  void setSystemKMEStoreControllerClient(ControllerClient controllerClient) {
-    this.systemKMEStoreControllerClient = controllerClient;
+  void setKmeSchemaSystemStoreControllerClient(ControllerClient controllerClient) {
+    this.kmeSchemaSystemStoreControllerClient = controllerClient;
   }
 
   private void verifyCountersWithZeroValues() throws IOException {
@@ -1553,25 +1527,81 @@ public class VenicePushJob implements AutoCloseable {
    * @param sslFactory
    * @param retryAttempts
    */
-  private void initControllerClient(
-      String storeName,
-      String veniceControllerUrl,
-      Optional<SSLFactory> sslFactory,
-      int retryAttempts) {
+  private void initControllerClient(String storeName, Optional<SSLFactory> sslFactory) {
+    final String controllerD2ZkHost;
+    if (pushJobSetting.multiRegion) {
+      // In multi region mode, push jobs will communicate with parent controller
+      controllerD2ZkHost = pushJobSetting.parentControllerRegionD2ZkHosts;
+    } else {
+      // In single region mode, push jobs will communicate with child controller
+      controllerD2ZkHost = pushJobSetting.childControllerRegionD2ZkHosts;
+    }
+
     if (controllerClient == null) {
-      controllerClient = ControllerClient
-          .discoverAndConstructControllerClient(storeName, veniceControllerUrl, sslFactory, retryAttempts);
+      controllerClient = getControllerClient(
+          storeName,
+          pushJobSetting.d2Routing,
+          pushJobSetting.controllerD2ServiceName,
+          controllerD2ZkHost,
+          sslFactory,
+          pushJobSetting.controllerRetries);
     } else {
       LOGGER.info("Controller client has already been initialized");
     }
-    if (systemKMEStoreControllerClient == null) {
-      systemKMEStoreControllerClient = ControllerClient.discoverAndConstructControllerClient(
+
+    if (kmeSchemaSystemStoreControllerClient == null) {
+      kmeSchemaSystemStoreControllerClient = getControllerClient(
           AvroProtocolDefinition.KAFKA_MESSAGE_ENVELOPE.getSystemStoreName(),
-          veniceControllerUrl,
+          pushJobSetting.d2Routing,
+          pushJobSetting.controllerD2ServiceName,
+          controllerD2ZkHost,
+          sslFactory,
+          pushJobSetting.controllerRetries);
+    } else {
+      LOGGER.info("System store controller client has already been initialized");
+    }
+
+    if (pushJobSetting.livenessHeartbeatEnabled) {
+      String heartbeatStoreName = pushJobSetting.livenessHeartbeatStoreName;
+      this.livenessHeartbeatStoreControllerClient = getControllerClient(
+          heartbeatStoreName,
+          pushJobSetting.d2Routing,
+          pushJobSetting.controllerD2ServiceName,
+          controllerD2ZkHost,
+          sslFactory,
+          pushJobSetting.controllerRetries);
+    } else {
+      this.livenessHeartbeatStoreControllerClient = null;
+    }
+  }
+
+  protected void initKIFRepushDetails() {
+    pushJobSetting.kafkaInputTopic = getSourceTopicNameForKafkaInput(pushJobSetting.storeName, props);
+    pushJobSetting.kafkaInputBrokerUrl = pushJobSetting.repushInfoResponse == null
+        ? props.getString(KAFKA_INPUT_BROKER_URL)
+        : pushJobSetting.repushInfoResponse.getRepushInfo().getKafkaBrokerUrl();
+  }
+
+  private ControllerClient getControllerClient(
+      String storeName,
+      boolean useD2ControllerClient,
+      String controllerD2ServiceName,
+      String d2ZkHosts,
+      Optional<SSLFactory> sslFactory,
+      int retryAttempts) {
+    if (useD2ControllerClient) {
+      return D2ControllerClient.discoverAndConstructControllerClient(
+          storeName,
+          controllerD2ServiceName,
+          d2ZkHosts,
           sslFactory,
           retryAttempts);
     } else {
-      LOGGER.info("System store controller client has already been initialized");
+      return ControllerClient.discoverAndConstructControllerClient(
+          storeName,
+          pushJobSetting.veniceControllerUrl,
+          sslFactory,
+          retryAttempts);
     }
   }
 
@@ -1633,7 +1663,7 @@ public class VenicePushJob implements AutoCloseable {
   }
 
   private void initPushJobDetails() {
-    pushJobDetails.clusterName = this.clusterName;
+    pushJobDetails.clusterName = pushJobSetting.clusterName;
     pushJobDetails.overallStatus = new ArrayList<>();
     pushJobDetails.overallStatus.add(getPushJobDetailsStatusTuple(PushJobDetailsStatus.STARTED.getValue()));
     pushJobDetails.pushId = "";
@@ -1647,8 +1677,9 @@ public class VenicePushJob implements AutoCloseable {
     pushJobDetails.totalCompressedValueBytes = -1;
     pushJobDetails.failureDetails = "";
     pushJobDetails.pushJobLatestCheckpoint = PushJobCheckpoints.INITIALIZE_PUSH_JOB.getValue();
-    pushJobDetails.pushJobConfigs =
-        Collections.singletonMap(HEARTBEAT_ENABLED_CONFIG.getConfigName(), String.valueOf(jobLivenessHeartbeatEnabled));
+    pushJobDetails.pushJobConfigs = Collections.singletonMap(
+        HEARTBEAT_ENABLED_CONFIG.getConfigName(),
+        String.valueOf(pushJobSetting.livenessHeartbeatEnabled));
   }
 
   private void updatePushJobDetailsWithCheckpoint(PushJobCheckpoints checkpoint) {
@@ -1686,7 +1717,8 @@ public class VenicePushJob implements AutoCloseable {
           pushJobConfigs.put(key, props.getString(key));
         }
         if (!pushJobConfigs.containsKey(HEARTBEAT_ENABLED_CONFIG.getConfigName())) {
-          pushJobConfigs.put(HEARTBEAT_ENABLED_CONFIG.getConfigName(), String.valueOf(jobLivenessHeartbeatEnabled));
+          pushJobConfigs
+              .put(HEARTBEAT_ENABLED_CONFIG.getConfigName(), String.valueOf(pushJobSetting.livenessHeartbeatEnabled));
         }
         pushJobDetails.pushJobConfigs = pushJobConfigs;
         // TODO find a way to get meaningful producer configs to populate the producerConfigs map here.
@@ -1859,7 +1891,7 @@ public class VenicePushJob implements AutoCloseable {
       PushJobSetting setting,
       PushJobSchemaInfo pushJobSchemaInfo) {
     Schema serverSchema = getKeySchemaFromController(controllerClient, setting.controllerRetries, setting.storeName);
-    Schema clientSchema = Schema.parse(pushJobSchemaInfo.getKeySchemaString());
+    Schema clientSchema = AvroCompatibilityHelper.parse(pushJobSchemaInfo.getKeySchemaString());
     String canonicalizedServerSchema = AvroCompatibilityHelper.toParsingForm(serverSchema);
     String canonicalizedClientSchema = AvroCompatibilityHelper.toParsingForm(clientSchema);
     if (!canonicalizedServerSchema.equals(canonicalizedClientSchema)) {
@@ -1890,7 +1922,7 @@ public class VenicePushJob implements AutoCloseable {
       if (!setting.validateRemoteReplayPolicy.equals(hybridStoreConfig.getBufferReplayPolicy())) {
         throw new VeniceException(
             String.format(
-                "Remote rewind policy is {} but push settings require a policy of {}.  "
+                "Remote rewind policy is {} but push settings require a policy of {}. "
                     + "Please adjust hybrid settings or push job configuration!",
                 hybridStoreConfig.getBufferReplayPolicy(),
                 setting.validateRemoteReplayPolicy));
@@ -1900,7 +1932,7 @@ public class VenicePushJob implements AutoCloseable {
 
   private void validateKafkaMessageEnvelopeSchema(PushJobSetting setting) {
     SchemaResponse response = ControllerClient.retryableRequest(
-        systemKMEStoreControllerClient,
+        kmeSchemaSystemStoreControllerClient,
         setting.controllerRetries,
         c -> c.getValueSchema(
             AvroProtocolDefinition.KAFKA_MESSAGE_ENVELOPE.getSystemStoreName(),
@@ -2148,7 +2180,7 @@ public class VenicePushJob implements AutoCloseable {
             Optional.of(partitioners),
             dictionary,
             Optional.ofNullable(setting.sourceGridFabric),
-            jobLivenessHeartbeatEnabled,
+            setting.livenessHeartbeatEnabled,
             setting.rewindTimeInSecondsOverride,
             setting.deferVersionSwap));
     if (versionCreationResponse.isError()) {
@@ -2303,7 +2335,7 @@ public class VenicePushJob implements AutoCloseable {
   }
 
   /**
-   * High level, we want to poll the consumption job status until it errors or is complete.  This is more complicated
+   * High level, we want to poll the consumption job status until it errors or is complete. This is more complicated
    * because we might be dealing with multiple destination clusters and we might not be able to reach all of them. We
    * are using a semantic of "poll until all accessible datacenters report success".
    *
@@ -2805,24 +2837,16 @@ public class VenicePushJob implements AutoCloseable {
       TopicInfo topicInfo,
       PushJobSetting pushJobSetting,
       PushJobSchemaInfo pushJobSchemaInfo,
-      String clusterName,
       String inputDirectory,
       long inputFileDataSize) {
     LOGGER.info(
-        pushJobPropertiesToString(
-            topicInfo,
-            pushJobSetting,
-            pushJobSchemaInfo,
-            clusterName,
-            inputDirectory,
-            inputFileDataSize));
+        pushJobPropertiesToString(topicInfo, pushJobSetting, pushJobSchemaInfo, inputDirectory, inputFileDataSize));
   }
 
   private String pushJobPropertiesToString(
       TopicInfo topicInfo,
       PushJobSetting pushJobSetting,
       PushJobSchemaInfo pushJobSchemaInfo,
-      String clusterName,
       String inputDirectory,
       final long inputFileDataSize) {
     List<String> propKeyValuePairs = new ArrayList<>();
@@ -2833,7 +2857,7 @@ public class VenicePushJob implements AutoCloseable {
     propKeyValuePairs.add("Kafka Queue Bytes: " + pushJobSetting.batchNumBytes);
     propKeyValuePairs.add("Input Directory: " + inputDirectory);
     propKeyValuePairs.add("Venice Store Name: " + pushJobSetting.storeName);
-    propKeyValuePairs.add("Venice Cluster Name: " + clusterName);
+    propKeyValuePairs.add("Venice Cluster Name: " + pushJobSetting.clusterName);
     propKeyValuePairs.add("Venice URL: " + pushJobSetting.veniceControllerUrl);
     if (pushJobSchemaInfo != null) {
       propKeyValuePairs.add("File Schema: " + pushJobSchemaInfo.getFileSchemaString());
@@ -2943,19 +2967,6 @@ public class VenicePushJob implements AutoCloseable {
     return new Path(resolvedPath);
   }
 
-  private String discoverCluster(String storeName) {
-    LOGGER.info("Discover cluster for store: {}", storeName);
-    ControllerResponse clusterDiscoveryResponse = ControllerClient.retryableRequest(
-        clusterDiscoveryControllerClient == null ? controllerClient : clusterDiscoveryControllerClient,
-        pushJobSetting.controllerRetries,
-        c -> c.discoverCluster(storeName));
-    if (clusterDiscoveryResponse.isError()) {
-      throw new VeniceException("Failed to discover cluster, error :" + clusterDiscoveryResponse.getError());
-    } else {
-      return clusterDiscoveryResponse.getCluster();
-    }
-  }
-
   public String getKafkaTopic() {
     return kafkaTopicInfo.topic;
   }
@@ -3010,14 +3021,9 @@ public class VenicePushJob implements AutoCloseable {
 
   @Override
   public void close() {
-    closeClients();
-  }
-
-  private void closeClients() {
     closeVeniceWriter();
     Utils.closeQuietlyWithErrorLogged(controllerClient);
-    Utils.closeQuietlyWithErrorLogged(systemKMEStoreControllerClient);
-    Utils.closeQuietlyWithErrorLogged(clusterDiscoveryControllerClient);
+    Utils.closeQuietlyWithErrorLogged(kmeSchemaSystemStoreControllerClient);
     Utils.closeQuietlyWithErrorLogged(livenessHeartbeatStoreControllerClient);
   }
 

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/TestVenicePushJobCheckpoints.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/TestVenicePushJobCheckpoints.java
@@ -1,6 +1,9 @@
 package com.linkedin.venice.hadoop;
 
 import static com.linkedin.venice.hadoop.VenicePushJob.COMPRESSION_METRIC_COLLECTION_ENABLED;
+import static com.linkedin.venice.hadoop.VenicePushJob.D2_ZK_HOSTS_PREFIX;
+import static com.linkedin.venice.hadoop.VenicePushJob.MULTI_REGION;
+import static com.linkedin.venice.hadoop.VenicePushJob.SOURCE_GRID_FABRIC;
 import static com.linkedin.venice.hadoop.VenicePushJob.USE_MAPPER_TO_BUILD_DICTIONARY;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyBoolean;
@@ -48,6 +51,7 @@ public class TestVenicePushJobCheckpoints {
   private static final int PARTITION_COUNT = 10;
   private static final int NUMBER_OF_FILES_TO_READ_AND_BUILD_DICT_COUNT = 1; // DUMMY Number of files for
                                                                              // ValidateSchemaAndBuildDictMapper
+  private static final String TEST_CLUSTER_NAME = "some-cluster";
   private static final String SCHEMA_STR = "{" + "  \"namespace\" : \"example.avro\",  " + "  \"type\": \"record\",   "
       + "  \"name\": \"User\",     " + "  \"fields\": [           "
       + "       { \"name\": \"id\", \"type\": \"string\" },  "
@@ -474,36 +478,44 @@ public class TestVenicePushJobCheckpoints {
     if (extraProps != null) {
       extraProps.accept(props);
     }
-    VenicePushJob venicePushJob =
-        new VenicePushJob("job-id", props, createControllerClientMock(), createClusterDiscoverControllerClient());
+    ControllerClient controllerClient = mock(ControllerClient.class);
+    configureControllerClientMock(controllerClient);
+    configureClusterDiscoverControllerClient(controllerClient);
+    try (VenicePushJob venicePushJob = new VenicePushJob("job-id", props)) {
+      venicePushJob.setControllerClient(controllerClient);
+      venicePushJob.setKmeSchemaSystemStoreControllerClient(controllerClient);
+      venicePushJob.setJobClientWrapper(jobClientWrapper);
+      venicePushJob.setInputDataInfoProvider(inputDataInfoProvider);
+      venicePushJob.setVeniceWriter(createVeniceWriterMock());
+      SentPushJobDetailsTrackerImpl pushJobDetailsTracker = new SentPushJobDetailsTrackerImpl();
+      venicePushJob.setSentPushJobDetailsTracker(pushJobDetailsTracker);
 
-    venicePushJob.setSystemKMEStoreControllerClient(createControllerClientMock());
-    venicePushJob.setJobClientWrapper(jobClientWrapper);
-    venicePushJob.setClusterDiscoveryControllerClient(createClusterDiscoveryControllerClientMock());
-    venicePushJob.setInputDataInfoProvider(inputDataInfoProvider);
-    venicePushJob.setVeniceWriter(createVeniceWriterMock());
-    SentPushJobDetailsTrackerImpl pushJobDetailsTracker = new SentPushJobDetailsTrackerImpl();
-    venicePushJob.setSentPushJobDetailsTracker(pushJobDetailsTracker);
+      try {
+        venicePushJob.run();
+      } finally {
+        List<Integer> actualReportedCheckpointValues =
+            new ArrayList<>(pushJobDetailsTracker.getRecordedPushJobDetails().size());
 
-    try {
-      venicePushJob.run();
-    } finally {
-      List<Integer> actualReportedCheckpointValues =
-          new ArrayList<>(pushJobDetailsTracker.getRecordedPushJobDetails().size());
+        for (PushJobDetails pushJobDetails: pushJobDetailsTracker.getRecordedPushJobDetails()) {
+          actualReportedCheckpointValues.add(pushJobDetails.pushJobLatestCheckpoint);
+        }
+        List<Integer> expectedCheckpointValues = expectedReportedCheckpoints.stream()
+            .map(VenicePushJob.PushJobCheckpoints::getValue)
+            .collect(Collectors.toList());
 
-      for (PushJobDetails pushJobDetails: pushJobDetailsTracker.getRecordedPushJobDetails()) {
-        actualReportedCheckpointValues.add(pushJobDetails.pushJobLatestCheckpoint);
+        Assert.assertEquals(actualReportedCheckpointValues, expectedCheckpointValues);
       }
-      List<Integer> expectedCheckpointValues = expectedReportedCheckpoints.stream()
-          .map(VenicePushJob.PushJobCheckpoints::getValue)
-          .collect(Collectors.toList());
-
-      Assert.assertEquals(actualReportedCheckpointValues, expectedCheckpointValues);
     }
   }
 
   private Properties getVPJProps() {
     Properties props = new Properties();
+    props.setProperty(MULTI_REGION, "false");
+
+    String childRegion = "child_region";
+    props.setProperty(SOURCE_GRID_FABRIC, childRegion);
+    props.setProperty(D2_ZK_HOSTS_PREFIX + childRegion, "child.zk.com:1234");
+
     props.put(VenicePushJob.VENICE_DISCOVER_URL_PROP, "venice-urls");
     props.put(VenicePushJob.VENICE_STORE_NAME_PROP, "store-name");
     props.put(VenicePushJob.INPUT_PATH_PROP, "input-path");
@@ -541,14 +553,6 @@ public class TestVenicePushJobCheckpoints {
     return inputDataInfoProvider;
   }
 
-  private ControllerClient createClusterDiscoveryControllerClientMock() {
-    ControllerClient controllerClient = mock(ControllerClient.class);
-    D2ServiceDiscoveryResponse controllerResponse = mock(D2ServiceDiscoveryResponse.class);
-    when(controllerResponse.getCluster()).thenReturn("mock-cluster-name");
-    when(controllerClient.discoverCluster(anyString())).thenReturn(controllerResponse);
-    return controllerClient;
-  }
-
   private JobStatusQueryResponse createJobStatusQueryResponseMock() {
     JobStatusQueryResponse jobStatusQueryResponse = mock(JobStatusQueryResponse.class);
     when(jobStatusQueryResponse.isError()).thenReturn(false);
@@ -559,11 +563,11 @@ public class TestVenicePushJobCheckpoints {
     return jobStatusQueryResponse;
   }
 
-  private ControllerClient createControllerClientMock() {
-    ControllerClient controllerClient = mock(ControllerClient.class);
+  private void configureControllerClientMock(ControllerClient controllerClient) {
     StoreResponse storeResponse = mock(StoreResponse.class);
-    StoreInfo storeInfo = mock(StoreInfo.class);
+    when(controllerClient.getClusterName()).thenReturn(TEST_CLUSTER_NAME);
 
+    StoreInfo storeInfo = mock(StoreInfo.class);
     when(controllerClient.getValueSchema(anyString(), anyInt())).thenReturn(mock(SchemaResponse.class));
 
     StorageEngineOverheadRatioResponse storageEngineOverheadRatioResponse =
@@ -610,16 +614,13 @@ public class TestVenicePushJobCheckpoints {
     ControllerResponse controllerResponse = mock(ControllerResponse.class);
     when(controllerResponse.isError()).thenReturn(false);
     when(controllerClient.sendPushJobDetails(anyString(), anyInt(), any(byte[].class))).thenReturn(controllerResponse);
-    return controllerClient;
   }
 
-  private ControllerClient createClusterDiscoverControllerClient() {
-    ControllerClient controllerClient = mock(ControllerClient.class);
+  private void configureClusterDiscoverControllerClient(ControllerClient controllerClient) {
     D2ServiceDiscoveryResponse clusterDiscoveryResponse = mock(D2ServiceDiscoveryResponse.class);
     when(clusterDiscoveryResponse.isError()).thenReturn(false);
-    when(clusterDiscoveryResponse.getCluster()).thenReturn("some-cluster");
+    when(clusterDiscoveryResponse.getCluster()).thenReturn(TEST_CLUSTER_NAME);
     when(controllerClient.discoverCluster(anyString())).thenReturn(clusterDiscoveryResponse);
-    return controllerClient;
   }
 
   private VersionCreationResponse createVersionCreationResponse() {

--- a/docs/user_guide/write_api/push_job.md
+++ b/docs/user_guide/write_api/push_job.md
@@ -54,6 +54,21 @@ The user may choose to specify the following configs:
   the `STRICT` mode in avro-util's [SchemaParseConfiguration](https://github.com/linkedin/avro-util/blob/master/helper/helper-common/src/main/java/com/linkedin/avroutil1/compatibility/SchemaParseConfiguration.java)). 
   If set to `false`, it becomes equivalent to avro-util's `LOOSE` mode. Default: `true`
 
+The push job also supports using D2 URLs for automated controller service discovery. To use this, the user or operator
+must specify the following configs:
+
+- `multi.region`: `true` if the Venice cluster is deployed in a multi-region mode; `false` otherwise
+- `venice.discover.urls`: The D2 URL of the Venice controller. It must be of the form `d2://<D2 service name of the controller>`
+- `d2.zk.hosts.<region name>`: The Zookeeper addresses where the components in the specified region are announcing themselves to D2
+- If `multi.region` is `true`:
+  - `venice.discover.urls` must use the D2 service name of the parent controller
+  - `parent.controller.region.name` must denote the name of the datacenter where the parent controller is deployed
+  - `d2.zk.hosts.<parent controller region>` is a mandatory config
+- If `multi.region` is `false`
+  - `venice.discover.urls` must use the D2 service name of the child controller
+  - `source.grid.fabric` must denote the name of the datacenter where Venice is deployed
+  - `d2.zk.hosts.<source grid fabric>` is a mandatory config
+
 The user or operator may want to specify the following security-related configs:
 
 - `venice.ssl.enable`. Default: `false`

--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerClient.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerClient.java
@@ -111,16 +111,6 @@ public class ControllerClient implements Closeable {
   private final VeniceJsonSerializer<Version> versionVeniceJsonSerializer = new VeniceJsonSerializer<>(Version.class);
   private String leaderControllerUrl;
   private final List<String> controllerDiscoveryUrls;
-  private boolean isShared = false; // Denote if the object is shared in multiple places and each can close it
-                                    // independently
-
-  protected void setShared(boolean isShared) {
-    this.isShared = isShared;
-  }
-
-  protected boolean getShared() {
-    return this.isShared;
-  }
 
   public ControllerClient(String clusterName, String discoveryUrls) {
     this(clusterName, discoveryUrls, Optional.empty());
@@ -165,9 +155,8 @@ public class ControllerClient implements Closeable {
 
   @Override
   public void close() {
-    if (getShared()) {
-      // Object is still in use at other places. Do not release resources right now.
-      ControllerClientFactory.release(this);
+    if (ControllerClientFactory.release(this)) {
+      // Object is no longer used in other places. Safe to clean up resources
     }
   }
 

--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerClient.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerClient.java
@@ -155,9 +155,13 @@ public class ControllerClient implements Closeable {
 
   @Override
   public void close() {
-    if (ControllerClientFactory.release(this)) {
-      // Object is no longer used in other places. Safe to clean up resources
-    }
+    // Currently, we do not have any resources to clean up. If there is something to clean-up, we must check the return
+    // value of "ControllerClientFactory.release(this)" and if that is true, only then is it safe to clean up resources.
+    // if (ControllerClientFactory.release(this)) {
+    // // Object is no longer used in other places. Safe to clean up resources
+    // ...
+    // }
+    ControllerClientFactory.release(this);
   }
 
   protected String discoverLeaderController() {

--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerClientFactory.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerClientFactory.java
@@ -1,0 +1,38 @@
+package com.linkedin.venice.controllerapi;
+
+import com.linkedin.venice.security.SSLFactory;
+import com.linkedin.venice.utils.SharedObjectFactory;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+
+public class ControllerClientFactory {
+  private static final SharedObjectFactory<ControllerClient> SHARED_OBJECT_FACTORY = new SharedObjectFactory<>();
+  private static final Map<ControllerClient, String> CONTROLLER_CLIENT_TO_IDENTIFIER_MAP = new HashMap<>();
+
+  public static ControllerClient getControllerClient(
+      String clusterName,
+      String discoveryUrls,
+      Optional<SSLFactory> sslFactory) {
+    final String clientIdentifier = clusterName + discoveryUrls;
+    return SHARED_OBJECT_FACTORY.getObject(clientIdentifier, () -> {
+      ControllerClient client = new ControllerClient(clusterName, discoveryUrls, sslFactory);
+      client.setShared(true);
+      CONTROLLER_CLIENT_TO_IDENTIFIER_MAP.put(client, clientIdentifier);
+      return client;
+    }, client -> {
+      CONTROLLER_CLIENT_TO_IDENTIFIER_MAP.remove(client, clientIdentifier);
+      client.setShared(false);
+      client.close(); // Doesn't run anything right now - but is useful to clean up if close method adds some cleanup
+      // functionality later
+    });
+  }
+
+  public static void release(ControllerClient client) {
+    String clientIdentifier = CONTROLLER_CLIENT_TO_IDENTIFIER_MAP.get(client);
+    if (clientIdentifier != null) {
+      SHARED_OBJECT_FACTORY.release(clientIdentifier);
+    }
+  }
+}

--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerClientFactory.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerClientFactory.java
@@ -16,23 +16,22 @@ public class ControllerClientFactory {
       String discoveryUrls,
       Optional<SSLFactory> sslFactory) {
     final String clientIdentifier = clusterName + discoveryUrls;
-    return SHARED_OBJECT_FACTORY.getObject(clientIdentifier, () -> {
+    return SHARED_OBJECT_FACTORY.get(clientIdentifier, () -> {
       ControllerClient client = new ControllerClient(clusterName, discoveryUrls, sslFactory);
-      client.setShared(true);
       CONTROLLER_CLIENT_TO_IDENTIFIER_MAP.put(client, clientIdentifier);
       return client;
     }, client -> {
       CONTROLLER_CLIENT_TO_IDENTIFIER_MAP.remove(client, clientIdentifier);
-      client.setShared(false);
       client.close(); // Doesn't run anything right now - but is useful to clean up if close method adds some cleanup
       // functionality later
     });
   }
 
-  public static void release(ControllerClient client) {
+  public static boolean release(ControllerClient client) {
     String clientIdentifier = CONTROLLER_CLIENT_TO_IDENTIFIER_MAP.get(client);
     if (clientIdentifier != null) {
-      SHARED_OBJECT_FACTORY.release(clientIdentifier);
+      return SHARED_OBJECT_FACTORY.release(clientIdentifier);
     }
+    return true;
   }
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/D2ControllerClient.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/D2ControllerClient.java
@@ -4,8 +4,10 @@ import com.linkedin.d2.balancer.D2Client;
 import com.linkedin.d2.balancer.D2ClientBuilder;
 import com.linkedin.r2.message.rest.RestResponse;
 import com.linkedin.venice.D2.D2ClientUtils;
+import com.linkedin.venice.d2.D2ClientFactory;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.security.SSLFactory;
+import com.linkedin.venice.utils.ReferenceCounted;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
@@ -21,9 +23,10 @@ public class D2ControllerClient extends ControllerClient {
   private static final String DUMMY_URL_WHEN_USING_D2_CLIENT = "http://fake.host";
 
   private final String d2ServiceName;
-  private final D2Client d2Client;
+  private final ReferenceCounted<D2Client> d2Client;
   private final boolean externalD2Client;
   private final Optional<SSLFactory> sslFactory;
+  private final String controllerClientCacheKey;
 
   public D2ControllerClient(
       String d2ServiceName,
@@ -32,14 +35,10 @@ public class D2ControllerClient extends ControllerClient {
       Optional<SSLFactory> sslFactory) {
     super(clusterName, DUMMY_URL_WHEN_USING_D2_CLIENT, sslFactory);
     this.d2ServiceName = d2ServiceName;
-    this.d2Client = new D2ClientBuilder().setZkHosts(d2ZKHost)
-        .setSSLContext(sslFactory.isPresent() ? sslFactory.get().getSSLContext() : null)
-        .setIsSSLEnabled(sslFactory.isPresent())
-        .setSSLParameters(sslFactory.isPresent() ? sslFactory.get().getSSLParameters() : null)
-        .build();
-    D2ClientUtils.startClient(d2Client);
+    this.d2Client = D2ClientFactory.getD2Client(d2ZKHost, sslFactory);
     this.externalD2Client = false;
     this.sslFactory = sslFactory;
+    this.controllerClientCacheKey = getControllerClientCacheKey(clusterName, d2ServiceName, d2ZKHost);
   }
 
   public D2ControllerClient(String d2ServiceName, String clusterName, D2Client d2Client) {
@@ -53,15 +52,16 @@ public class D2ControllerClient extends ControllerClient {
       Optional<SSLFactory> sslFactory) {
     super(clusterName, DUMMY_URL_WHEN_USING_D2_CLIENT, sslFactory);
     this.d2ServiceName = d2ServiceName;
-    this.d2Client = d2Client;
+    this.d2Client = new ReferenceCounted<>(d2Client, client -> {});
     this.externalD2Client = true;
     this.sslFactory = sslFactory;
+    this.controllerClientCacheKey = getControllerClientCacheKey(clusterName, d2ServiceName, d2Client);
   }
 
   @Override
   protected String discoverLeaderController() {
     LeaderControllerResponse controllerResponse = d2ClientGet(
-        this.d2Client,
+        this.d2Client.get(),
         this.d2ServiceName,
         ControllerRoute.LEADER_CONTROLLER.getPath(),
         newParams(),
@@ -80,9 +80,13 @@ public class D2ControllerClient extends ControllerClient {
      */
     if (sslFactory.isPresent()) {
       try {
+        if (controllerResponse.getSecureUrl() != null) {
+          return controllerResponse.getSecureUrl();
+        }
+
         URL responseUrl = new URL(controllerResponse.getUrl());
         if (responseUrl.getProtocol().equalsIgnoreCase("http")) {
-          URL secureControllerUrl = convertToSecureUrl(responseUrl, 1578);
+          URL secureControllerUrl = convertToSecureUrl(responseUrl);
           return secureControllerUrl.toString();
         }
       } catch (MalformedURLException e) {
@@ -117,23 +121,123 @@ public class D2ControllerClient extends ControllerClient {
         D2ServiceDiscoveryResponse.class);
   }
 
-  @Override
-  public D2ServiceDiscoveryResponse discoverCluster(String storeName) {
-    return discoverCluster(d2Client, d2ServiceName, storeName);
+  public static D2ServiceDiscoveryResponse discoverCluster(String d2ZkHost, String d2ServiceName, String storeName)
+      throws VeniceException {
+    return discoverCluster(d2ZkHost, d2ServiceName, storeName, 1);
   }
 
-  @Override
-  public void close() {
-    super.close();
-    if (!this.externalD2Client) {
+  public static D2ServiceDiscoveryResponse discoverCluster(
+      String d2ZkHost,
+      String d2ServiceName,
+      String storeName,
+      int retryAttempts) {
+    D2Client d2Client = new D2ClientBuilder().setZkHosts(d2ZkHost).build();
+    try {
+      D2ClientUtils.startClient(d2Client);
+      return discoverCluster(d2Client, d2ServiceName, storeName, retryAttempts);
+    } finally {
       D2ClientUtils.shutdownClient(d2Client);
     }
   }
 
   /**
-   * Convert a HTTP url to HTTPS url with specific port number;
-   * TODO: remove the below helper function after Controller ACL migration.
+   * Here, if discovery fails, we will throw a VeniceException.
    */
+  public static D2ServiceDiscoveryResponse discoverCluster(
+      D2Client d2Client,
+      String d2ServiceName,
+      String storeName,
+      int retryAttempts) {
+    try (D2ControllerClient client = new D2ControllerClient(d2ServiceName, "*", d2Client)) {
+      D2ServiceDiscoveryResponse discoResponse =
+          retryableRequest(client, retryAttempts, c -> discoverCluster(d2Client, d2ServiceName, storeName));
+      if (discoResponse.isError()) {
+        throw new VeniceException(discoResponse.getError());
+      }
+      return discoResponse;
+    }
+  }
+
+  @Override
+  protected String getControllerClientCacheKey() {
+    return controllerClientCacheKey;
+  }
+
+  private static String getControllerClientCacheKey(String clusterName, String d2ServiceName, String d2ZkHost) {
+    return clusterName + d2ServiceName + d2ZkHost;
+  }
+
+  private static String getControllerClientCacheKey(String clusterName, String d2ServiceName, D2Client d2Client) {
+    return clusterName + d2ServiceName + d2Client.hashCode();
+  }
+
+  public static D2ControllerClient discoverAndConstructControllerClient(
+      String storeName,
+      String d2ServiceName,
+      String d2ZkHost,
+      Optional<SSLFactory> sslFactory,
+      int retryAttempts) {
+    D2ServiceDiscoveryResponse discoResponse = discoverCluster(d2ZkHost, d2ServiceName, storeName, retryAttempts);
+    if (!clusterToClientMapContains(getControllerClientCacheKey(discoResponse.getCluster(), d2ServiceName, d2ZkHost))) {
+      addClusterToClientMapEntry(
+          new D2ControllerClient(d2ServiceName, discoResponse.getCluster(), d2ZkHost, sslFactory));
+    }
+    return constructClusterControllerClient(discoResponse.getCluster(), d2ServiceName, d2ZkHost, sslFactory);
+  }
+
+  public static D2ControllerClient constructClusterControllerClient(
+      String clusterName,
+      String d2ServiceName,
+      String d2ZkHost) {
+    return D2ControllerClient.constructClusterControllerClient(clusterName, d2ServiceName, d2ZkHost, Optional.empty());
+  }
+
+  private static D2ControllerClient constructClusterControllerClient(
+      String clusterName,
+      String d2ServiceName,
+      String d2ZkHost,
+      Optional<SSLFactory> sslFactory) {
+    String controllerClientCacheKey = getControllerClientCacheKey(clusterName, d2ServiceName, d2ZkHost);
+    if (!clusterToClientMapContains(controllerClientCacheKey)) {
+      D2ControllerClient controllerClient = new D2ControllerClient(d2ServiceName, clusterName, d2ZkHost, sslFactory);
+      addClusterToClientMapEntry(controllerClient);
+      return controllerClient;
+    } else {
+      ReferenceCounted<ControllerClient> controllerClientRef = getClusterToClientMapEntry(controllerClientCacheKey);
+      controllerClientRef.retain();
+      return (D2ControllerClient) controllerClientRef.get();
+    }
+  }
+
+  @Override
+  public D2ServiceDiscoveryResponse discoverCluster(String storeName) {
+    return discoverCluster(d2Client.get(), d2ServiceName, storeName, 1);
+  }
+
+  @Override
+  public void close() {
+    super.close();
+    if (this.externalD2Client) {
+      d2Client.release();
+    }
+  }
+
+  /**
+   * Convert a HTTP url to HTTPS url with 1578 port number;
+   * TODO: remove the below helper functions after Controller ACL migration.
+   * @deprecated
+   */
+  @Deprecated
+  public static URL convertToSecureUrl(URL url) throws MalformedURLException {
+    return convertToSecureUrl(url, 1578);
+  }
+
+  /**
+   * Convert a HTTP url to HTTPS url with specific port number;
+   * TODO: remove the below helper functions after Controller ACL migration.
+   * @deprecated
+   */
+  @Deprecated
   public static URL convertToSecureUrl(URL url, int port) throws MalformedURLException {
     return new URL("https", url.getHost(), port, url.getFile());
   }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/D2ControllerClient.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/D2ControllerClient.java
@@ -1,13 +1,11 @@
 package com.linkedin.venice.controllerapi;
 
 import com.linkedin.d2.balancer.D2Client;
-import com.linkedin.d2.balancer.D2ClientBuilder;
 import com.linkedin.r2.message.rest.RestResponse;
 import com.linkedin.venice.D2.D2ClientUtils;
 import com.linkedin.venice.d2.D2ClientFactory;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.security.SSLFactory;
-import com.linkedin.venice.utils.ReferenceCounted;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
@@ -23,10 +21,10 @@ public class D2ControllerClient extends ControllerClient {
   private static final String DUMMY_URL_WHEN_USING_D2_CLIENT = "http://fake.host";
 
   private final String d2ServiceName;
-  private final ReferenceCounted<D2Client> d2Client;
+  private final D2Client d2Client;
   private final boolean externalD2Client;
+  private final String d2ZkHost;
   private final Optional<SSLFactory> sslFactory;
-  private final String controllerClientCacheKey;
 
   public D2ControllerClient(
       String d2ServiceName,
@@ -37,8 +35,8 @@ public class D2ControllerClient extends ControllerClient {
     this.d2ServiceName = d2ServiceName;
     this.d2Client = D2ClientFactory.getD2Client(d2ZKHost, sslFactory);
     this.externalD2Client = false;
+    this.d2ZkHost = d2ZKHost;
     this.sslFactory = sslFactory;
-    this.controllerClientCacheKey = getControllerClientCacheKey(clusterName, d2ServiceName, d2ZKHost);
   }
 
   public D2ControllerClient(String d2ServiceName, String clusterName, D2Client d2Client) {
@@ -52,16 +50,16 @@ public class D2ControllerClient extends ControllerClient {
       Optional<SSLFactory> sslFactory) {
     super(clusterName, DUMMY_URL_WHEN_USING_D2_CLIENT, sslFactory);
     this.d2ServiceName = d2ServiceName;
-    this.d2Client = new ReferenceCounted<>(d2Client, client -> {});
+    this.d2Client = d2Client;
     this.externalD2Client = true;
+    this.d2ZkHost = null;
     this.sslFactory = sslFactory;
-    this.controllerClientCacheKey = getControllerClientCacheKey(clusterName, d2ServiceName, d2Client);
   }
 
   @Override
   protected String discoverLeaderController() {
     LeaderControllerResponse controllerResponse = d2ClientGet(
-        this.d2Client.get(),
+        this.d2Client,
         this.d2ServiceName,
         ControllerRoute.LEADER_CONTROLLER.getPath(),
         newParams(),
@@ -121,29 +119,24 @@ public class D2ControllerClient extends ControllerClient {
         D2ServiceDiscoveryResponse.class);
   }
 
-  public static D2ServiceDiscoveryResponse discoverCluster(String d2ZkHost, String d2ServiceName, String storeName)
-      throws VeniceException {
-    return discoverCluster(d2ZkHost, d2ServiceName, storeName, 1);
-  }
-
   public static D2ServiceDiscoveryResponse discoverCluster(
       String d2ZkHost,
       String d2ServiceName,
       String storeName,
       int retryAttempts) {
-    D2Client d2Client = new D2ClientBuilder().setZkHosts(d2ZkHost).build();
+    D2Client d2Client;
     try {
-      D2ClientUtils.startClient(d2Client);
+      d2Client = D2ClientFactory.getD2Client(d2ZkHost, Optional.empty());
       return discoverCluster(d2Client, d2ServiceName, storeName, retryAttempts);
     } finally {
-      D2ClientUtils.shutdownClient(d2Client);
+      D2ClientFactory.release(d2ZkHost);
     }
   }
 
   /**
    * Here, if discovery fails, we will throw a VeniceException.
    */
-  public static D2ServiceDiscoveryResponse discoverCluster(
+  private static D2ServiceDiscoveryResponse discoverCluster(
       D2Client d2Client,
       String d2ServiceName,
       String storeName,
@@ -159,66 +152,21 @@ public class D2ControllerClient extends ControllerClient {
   }
 
   @Override
-  protected String getControllerClientCacheKey() {
-    return controllerClientCacheKey;
-  }
-
-  private static String getControllerClientCacheKey(String clusterName, String d2ServiceName, String d2ZkHost) {
-    return clusterName + d2ServiceName + d2ZkHost;
-  }
-
-  private static String getControllerClientCacheKey(String clusterName, String d2ServiceName, D2Client d2Client) {
-    return clusterName + d2ServiceName + d2Client.hashCode();
-  }
-
-  public static D2ControllerClient discoverAndConstructControllerClient(
-      String storeName,
-      String d2ServiceName,
-      String d2ZkHost,
-      Optional<SSLFactory> sslFactory,
-      int retryAttempts) {
-    D2ServiceDiscoveryResponse discoResponse = discoverCluster(d2ZkHost, d2ServiceName, storeName, retryAttempts);
-    if (!clusterToClientMapContains(getControllerClientCacheKey(discoResponse.getCluster(), d2ServiceName, d2ZkHost))) {
-      addClusterToClientMapEntry(
-          new D2ControllerClient(d2ServiceName, discoResponse.getCluster(), d2ZkHost, sslFactory));
-    }
-    return constructClusterControllerClient(discoResponse.getCluster(), d2ServiceName, d2ZkHost, sslFactory);
-  }
-
-  public static D2ControllerClient constructClusterControllerClient(
-      String clusterName,
-      String d2ServiceName,
-      String d2ZkHost) {
-    return D2ControllerClient.constructClusterControllerClient(clusterName, d2ServiceName, d2ZkHost, Optional.empty());
-  }
-
-  private static D2ControllerClient constructClusterControllerClient(
-      String clusterName,
-      String d2ServiceName,
-      String d2ZkHost,
-      Optional<SSLFactory> sslFactory) {
-    String controllerClientCacheKey = getControllerClientCacheKey(clusterName, d2ServiceName, d2ZkHost);
-    if (!clusterToClientMapContains(controllerClientCacheKey)) {
-      D2ControllerClient controllerClient = new D2ControllerClient(d2ServiceName, clusterName, d2ZkHost, sslFactory);
-      addClusterToClientMapEntry(controllerClient);
-      return controllerClient;
-    } else {
-      ReferenceCounted<ControllerClient> controllerClientRef = getClusterToClientMapEntry(controllerClientCacheKey);
-      controllerClientRef.retain();
-      return (D2ControllerClient) controllerClientRef.get();
-    }
-  }
-
-  @Override
   public D2ServiceDiscoveryResponse discoverCluster(String storeName) {
-    return discoverCluster(d2Client.get(), d2ServiceName, storeName, 1);
+    return discoverCluster(d2Client, d2ServiceName, storeName, 1);
   }
 
   @Override
   public void close() {
     super.close();
-    if (this.externalD2Client) {
-      d2Client.release();
+    if (getShared()) {
+      // Object is still in use at other places. Do not release resources right now.
+      D2ControllerClientFactory.release(this);
+    } else {
+      // Object is no longer used in other places. Safe to clean up resources
+      if (!externalD2Client) {
+        D2ClientFactory.release(d2ZkHost);
+      }
     }
   }
 

--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/D2ControllerClient.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/D2ControllerClient.java
@@ -158,15 +158,14 @@ public class D2ControllerClient extends ControllerClient {
 
   @Override
   public void close() {
-    super.close();
-    if (getShared()) {
-      // Object is still in use at other places. Do not release resources right now.
-      D2ControllerClientFactory.release(this);
-    } else {
+    if (D2ControllerClientFactory.release(this)) {
       // Object is no longer used in other places. Safe to clean up resources
+      super.close();
       if (!externalD2Client) {
         D2ClientFactory.release(d2ZkHost);
       }
+    } else {
+      // Object is still in use at other places. Do not release resources right now.
     }
   }
 

--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/D2ControllerClientFactory.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/D2ControllerClientFactory.java
@@ -17,24 +17,23 @@ public class D2ControllerClientFactory {
       String d2ZkHost,
       Optional<SSLFactory> sslFactory) {
     final String clientIdentifier = clusterName + d2ServiceName + d2ZkHost;
-    return SHARED_OBJECT_FACTORY.getObject(clientIdentifier, () -> {
+    return SHARED_OBJECT_FACTORY.get(clientIdentifier, () -> {
       D2ControllerClient client = new D2ControllerClient(d2ServiceName, clusterName, d2ZkHost, sslFactory);
-      client.setShared(true);
       CONTROLLER_CLIENT_TO_IDENTIFIER_MAP.put(client, clientIdentifier);
       return client;
     }, client -> {
       CONTROLLER_CLIENT_TO_IDENTIFIER_MAP.remove(client, clientIdentifier);
-      client.setShared(false);
       client.close(); // Doesn't run anything right now - but is useful to clean up if close method adds some cleanup
       // functionality later
     });
   }
 
-  public static void release(D2ControllerClient client) {
+  public static boolean release(D2ControllerClient client) {
     String clientIdentifier = CONTROLLER_CLIENT_TO_IDENTIFIER_MAP.get(client);
     if (clientIdentifier != null) {
-      SHARED_OBJECT_FACTORY.release(clientIdentifier);
+      return SHARED_OBJECT_FACTORY.release(clientIdentifier);
     }
+    return true;
   }
 
   public static D2ControllerClient discoverAndConstructControllerClient(

--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/D2ControllerClientFactory.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/D2ControllerClientFactory.java
@@ -1,0 +1,51 @@
+package com.linkedin.venice.controllerapi;
+
+import com.linkedin.venice.security.SSLFactory;
+import com.linkedin.venice.utils.SharedObjectFactory;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+
+public class D2ControllerClientFactory {
+  private static final SharedObjectFactory<D2ControllerClient> SHARED_OBJECT_FACTORY = new SharedObjectFactory<>();
+  private static final Map<ControllerClient, String> CONTROLLER_CLIENT_TO_IDENTIFIER_MAP = new HashMap<>();
+
+  public static D2ControllerClient getControllerClient(
+      String d2ServiceName,
+      String clusterName,
+      String d2ZkHost,
+      Optional<SSLFactory> sslFactory) {
+    final String clientIdentifier = clusterName + d2ServiceName + d2ZkHost;
+    return SHARED_OBJECT_FACTORY.getObject(clientIdentifier, () -> {
+      D2ControllerClient client = new D2ControllerClient(d2ServiceName, clusterName, d2ZkHost, sslFactory);
+      client.setShared(true);
+      CONTROLLER_CLIENT_TO_IDENTIFIER_MAP.put(client, clientIdentifier);
+      return client;
+    }, client -> {
+      CONTROLLER_CLIENT_TO_IDENTIFIER_MAP.remove(client, clientIdentifier);
+      client.setShared(false);
+      client.close(); // Doesn't run anything right now - but is useful to clean up if close method adds some cleanup
+      // functionality later
+    });
+  }
+
+  public static void release(D2ControllerClient client) {
+    String clientIdentifier = CONTROLLER_CLIENT_TO_IDENTIFIER_MAP.get(client);
+    if (clientIdentifier != null) {
+      SHARED_OBJECT_FACTORY.release(clientIdentifier);
+    }
+  }
+
+  public static D2ControllerClient discoverAndConstructControllerClient(
+      String storeName,
+      String d2ServiceName,
+      String d2ZkHost,
+      Optional<SSLFactory> sslFactory,
+      int retryAttempts) {
+    D2ServiceDiscoveryResponse discoResponse =
+        D2ControllerClient.discoverCluster(d2ZkHost, d2ServiceName, storeName, retryAttempts);
+    String clusterName = discoResponse.getCluster();
+    return D2ControllerClientFactory.getControllerClient(d2ServiceName, clusterName, d2ZkHost, sslFactory);
+  }
+}

--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/LeaderControllerResponse.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/LeaderControllerResponse.java
@@ -4,6 +4,7 @@ public class LeaderControllerResponse
     extends ControllerResponse { /* Uses Json Reflective Serializer, get without set may break things */
   private String cluster;
   private String url;
+  private String secureUrl = null;
 
   public String getCluster() {
     return cluster;
@@ -19,5 +20,13 @@ public class LeaderControllerResponse
 
   public void setUrl(String url) {
     this.url = url;
+  }
+
+  public String getSecureUrl() {
+    return secureUrl;
+  }
+
+  public void setSecureUrl(String url) {
+    this.secureUrl = url;
   }
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/d2/D2ClientFactory.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/d2/D2ClientFactory.java
@@ -30,13 +30,13 @@ public class D2ClientFactory {
       throw new VeniceUnsupportedOperationException("setD2Client in non-unit-test-mode");
     }
 
-    SHARED_OBJECT_FACTORY.getObject(d2ZkHost, () -> d2Client, d2Client1 -> {});
+    SHARED_OBJECT_FACTORY.get(d2ZkHost, () -> d2Client, d2Client1 -> {});
   }
 
   // Visible for testing
   // In unit tests, we do not spin up a Zk Server, so we test without starting the client.
   public static D2Client getD2Client(String d2ZkHost, Optional<SSLFactory> sslFactoryOptional) {
-    return SHARED_OBJECT_FACTORY.getObject(d2ZkHost, () -> {
+    return SHARED_OBJECT_FACTORY.get(d2ZkHost, () -> {
       D2Client d2Client = new D2ClientBuilder().setZkHosts(d2ZkHost)
           .setSSLContext(sslFactoryOptional.map(SSLFactory::getSSLContext).orElse(null))
           .setIsSSLEnabled(sslFactoryOptional.isPresent())

--- a/internal/venice-common/src/main/java/com/linkedin/venice/d2/D2ClientFactory.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/d2/D2ClientFactory.java
@@ -1,0 +1,51 @@
+package com.linkedin.venice.d2;
+
+import com.linkedin.d2.balancer.D2Client;
+import com.linkedin.d2.balancer.D2ClientBuilder;
+import com.linkedin.venice.D2.D2ClientUtils;
+import com.linkedin.venice.security.SSLFactory;
+import com.linkedin.venice.utils.ReferenceCounted;
+import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
+import java.util.Map;
+import java.util.Optional;
+
+
+public class D2ClientFactory {
+  // Visible for testing
+  // Cache for reusing d2 clients for a zk cluster
+  protected static final Map<String, ReferenceCounted<D2Client>> D2_CLIENT_CACHE = new VeniceConcurrentHashMap<>();
+
+  public static ReferenceCounted<D2Client> getD2Client(String d2ZKHost, Optional<SSLFactory> sslFactoryOptional) {
+    return getD2Client(d2ZKHost, sslFactoryOptional, false);
+  }
+
+  // Visible for testing
+  // In unit tests, we do not spin up a Zk Server, so we test without starting the client.
+  protected static ReferenceCounted<D2Client> getD2Client(
+      String d2ZKHost,
+      Optional<SSLFactory> sslFactoryOptional,
+      boolean skipClientStart) {
+    ReferenceCounted<D2Client> d2ClientRef;
+    if (D2_CLIENT_CACHE.containsKey(d2ZKHost)) {
+      d2ClientRef = D2_CLIENT_CACHE.get(d2ZKHost);
+      d2ClientRef.retain();
+    } else {
+      D2Client d2Client = new D2ClientBuilder().setZkHosts(d2ZKHost)
+          .setSSLContext(sslFactoryOptional.map(SSLFactory::getSSLContext).orElse(null))
+          .setIsSSLEnabled(sslFactoryOptional.isPresent())
+          .setSSLParameters(sslFactoryOptional.map(SSLFactory::getSSLParameters).orElse(null))
+          .build();
+      if (!skipClientStart) {
+        D2ClientUtils.startClient(d2Client);
+      }
+      d2ClientRef = new ReferenceCounted<>(d2Client, client -> {
+        D2_CLIENT_CACHE.remove(d2ZKHost);
+        if (!skipClientStart) {
+          D2ClientUtils.shutdownClient(client);
+        }
+      });
+      D2_CLIENT_CACHE.put(d2ZKHost, d2ClientRef);
+    }
+    return d2ClientRef;
+  }
+}

--- a/internal/venice-common/src/main/java/com/linkedin/venice/d2/D2ClientFactory.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/d2/D2ClientFactory.java
@@ -3,49 +3,57 @@ package com.linkedin.venice.d2;
 import com.linkedin.d2.balancer.D2Client;
 import com.linkedin.d2.balancer.D2ClientBuilder;
 import com.linkedin.venice.D2.D2ClientUtils;
+import com.linkedin.venice.exceptions.VeniceUnsupportedOperationException;
 import com.linkedin.venice.security.SSLFactory;
-import com.linkedin.venice.utils.ReferenceCounted;
-import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
-import java.util.Map;
+import com.linkedin.venice.utils.SharedObjectFactory;
 import java.util.Optional;
 
 
 public class D2ClientFactory {
   // Visible for testing
+  // Flag to denote if the test is in unit test mode and hence, will not start the D2Client
+  private static boolean unitTestMode = false;
   // Cache for reusing d2 clients for a zk cluster
-  protected static final Map<String, ReferenceCounted<D2Client>> D2_CLIENT_CACHE = new VeniceConcurrentHashMap<>();
+  protected static final SharedObjectFactory<D2Client> SHARED_OBJECT_FACTORY = new SharedObjectFactory<>();
 
-  public static ReferenceCounted<D2Client> getD2Client(String d2ZKHost, Optional<SSLFactory> sslFactoryOptional) {
-    return getD2Client(d2ZKHost, sslFactoryOptional, false);
+  public static void setUnitTestMode() {
+    unitTestMode = true;
+  }
+
+  public static void resetUnitTestMode() {
+    unitTestMode = false;
+  }
+
+  // Allow for overriding with mock D2Client for unit tests. The caller must release the object to prevent side-effects
+  public static void setD2Client(String d2ZkHost, D2Client d2Client) {
+    if (!unitTestMode) {
+      throw new VeniceUnsupportedOperationException("setD2Client in non-unit-test-mode");
+    }
+
+    SHARED_OBJECT_FACTORY.getObject(d2ZkHost, () -> d2Client, d2Client1 -> {});
   }
 
   // Visible for testing
   // In unit tests, we do not spin up a Zk Server, so we test without starting the client.
-  protected static ReferenceCounted<D2Client> getD2Client(
-      String d2ZKHost,
-      Optional<SSLFactory> sslFactoryOptional,
-      boolean skipClientStart) {
-    ReferenceCounted<D2Client> d2ClientRef;
-    if (D2_CLIENT_CACHE.containsKey(d2ZKHost)) {
-      d2ClientRef = D2_CLIENT_CACHE.get(d2ZKHost);
-      d2ClientRef.retain();
-    } else {
-      D2Client d2Client = new D2ClientBuilder().setZkHosts(d2ZKHost)
+  public static D2Client getD2Client(String d2ZkHost, Optional<SSLFactory> sslFactoryOptional) {
+    return SHARED_OBJECT_FACTORY.getObject(d2ZkHost, () -> {
+      D2Client d2Client = new D2ClientBuilder().setZkHosts(d2ZkHost)
           .setSSLContext(sslFactoryOptional.map(SSLFactory::getSSLContext).orElse(null))
           .setIsSSLEnabled(sslFactoryOptional.isPresent())
           .setSSLParameters(sslFactoryOptional.map(SSLFactory::getSSLParameters).orElse(null))
           .build();
-      if (!skipClientStart) {
+      if (!unitTestMode) {
         D2ClientUtils.startClient(d2Client);
       }
-      d2ClientRef = new ReferenceCounted<>(d2Client, client -> {
-        D2_CLIENT_CACHE.remove(d2ZKHost);
-        if (!skipClientStart) {
-          D2ClientUtils.shutdownClient(client);
-        }
-      });
-      D2_CLIENT_CACHE.put(d2ZKHost, d2ClientRef);
-    }
-    return d2ClientRef;
+      return d2Client;
+    }, d2Client -> {
+      if (!unitTestMode) {
+        D2ClientUtils.shutdownClient(d2Client);
+      }
+    });
+  }
+
+  public static void release(String d2ZkHost) {
+    SHARED_OBJECT_FACTORY.release(d2ZkHost);
   }
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/Instance.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/Instance.java
@@ -87,6 +87,10 @@ public class Instance {
     return port;
   }
 
+  public int getSslPort() {
+    return sslPort;
+  }
+
   /***
    * Convenience method for getting a host and port based url.
    * Wraps IPv6 host strings in square brackets

--- a/internal/venice-common/src/main/java/com/linkedin/venice/utils/ReferenceCounted.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/utils/ReferenceCounted.java
@@ -44,4 +44,8 @@ public class ReferenceCounted<T> implements AutoCloseable {
       }
     }
   }
+
+  public int getReferenceCount() {
+    return refCount.get();
+  }
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/utils/SharedObjectFactory.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/utils/SharedObjectFactory.java
@@ -6,40 +6,73 @@ import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 
+/**
+ * A factory class to create shared objects that need to release resources cleanly. This class uses reference counting
+ * to ensure that resources are released safely.
+ * @param <T> Class whose objects need to release resources cleanly.
+ */
 public class SharedObjectFactory<T> {
   private final Map<String, ReferenceCounted<T>> objectMap = new VeniceConcurrentHashMap<>();
 
-  public T getObject(String objectIdentifier, Supplier<T> objectSupplier, Consumer<T> destroyer) {
-    if (!objectMap.containsKey(objectIdentifier)) {
-      T object = objectSupplier.get();
-      objectMap.put(objectIdentifier, new ReferenceCounted<>(object, obj -> {
+  /**
+   * Get a shared object that has the specified {@param identifier}. If an object with the {@param identifier} doesn't
+   * exist, a new one is created using the {@param constructor}. When this function is called, the reference count of
+   * the shared object is incremented by 1.
+   * @param identifier A string that uniquely identifies the object being shared
+   * @param constructor A {@link Supplier> to construct a new instance of the object
+   * @param destroyer A {@link Consumer} to clean-up any state when the object is no longer needed
+   * @return A shared object
+   */
+  public T get(String identifier, Supplier<T> constructor, Consumer<T> destroyer) {
+    if (!objectMap.containsKey(identifier)) {
+      T object = constructor.get();
+      objectMap.put(identifier, new ReferenceCounted<>(object, obj -> {
         destroyer.accept(obj);
-        objectMap.remove(objectIdentifier);
+        objectMap.remove(identifier);
       }));
       return object;
     } else {
-      ReferenceCounted<T> referenceCounted = objectMap.get(objectIdentifier);
+      ReferenceCounted<T> referenceCounted = objectMap.get(identifier);
       referenceCounted.retain();
       return referenceCounted.get();
     }
   }
 
-  public void release(String objectIdentifier) {
-    ReferenceCounted<T> referenceCounted = objectMap.get(objectIdentifier);
+  /**
+   * A method to notify to the factory that the user of the object no longer needs it. This method decreases the
+   * reference count of the shared object by 1. If the reference count becomes 0, the destroyer is invoked and the
+   * object is removed from the shared objects.
+   * @param identifier A string that uniquely identifies the object being shared
+   * @return {@code true} if the shared object is no longer being used; {@code false} otherwise
+   */
+  public boolean release(String identifier) {
+    ReferenceCounted<T> referenceCounted = objectMap.get(identifier);
     if (referenceCounted != null) {
-      referenceCounted.release();
+      referenceCounted.release(); // Also removes the object from the objectMap
+      return referenceCounted.getReferenceCount() == 0;
     }
+    return true;
   }
 
+  /**
+   * @return The number of shared objects that are being managed
+   */
   public int size() {
     return objectMap.size();
   }
 
-  public int getReferenceCount(String objectIdentifier) {
-    if (!objectMap.containsKey(objectIdentifier)) {
+  /**
+   * Return the current reference count of the object identified by the {@param identifier}. If the factory isn't
+   * managing an object with the identifier, returns 0
+   * @param identifier A string that uniquely identifies the object being shared
+   * @return the current reference count of the object identified by the {@param identifier}. If the factory isn't
+   * managing an object with the identifier, returns 0
+   */
+  public int getReferenceCount(String identifier) {
+    if (!objectMap.containsKey(identifier)) {
       return 0;
     } else {
-      return objectMap.get(objectIdentifier).getReferenceCount();
+      return objectMap.get(identifier).getReferenceCount();
     }
   }
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/utils/SharedObjectFactory.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/utils/SharedObjectFactory.java
@@ -1,0 +1,45 @@
+package com.linkedin.venice.utils;
+
+import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
+import java.util.Map;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+
+public class SharedObjectFactory<T> {
+  private final Map<String, ReferenceCounted<T>> objectMap = new VeniceConcurrentHashMap<>();
+
+  public T getObject(String objectIdentifier, Supplier<T> objectSupplier, Consumer<T> destroyer) {
+    if (!objectMap.containsKey(objectIdentifier)) {
+      T object = objectSupplier.get();
+      objectMap.put(objectIdentifier, new ReferenceCounted<>(object, obj -> {
+        destroyer.accept(obj);
+        objectMap.remove(objectIdentifier);
+      }));
+      return object;
+    } else {
+      ReferenceCounted<T> referenceCounted = objectMap.get(objectIdentifier);
+      referenceCounted.retain();
+      return referenceCounted.get();
+    }
+  }
+
+  public void release(String objectIdentifier) {
+    ReferenceCounted<T> referenceCounted = objectMap.get(objectIdentifier);
+    if (referenceCounted != null) {
+      referenceCounted.release();
+    }
+  }
+
+  public int size() {
+    return objectMap.size();
+  }
+
+  public int getReferenceCount(String objectIdentifier) {
+    if (!objectMap.containsKey(objectIdentifier)) {
+      return 0;
+    } else {
+      return objectMap.get(objectIdentifier).getReferenceCount();
+    }
+  }
+}

--- a/internal/venice-common/src/test/java/com/linkedin/venice/controllerapi/TestD2ControllerClient.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/controllerapi/TestD2ControllerClient.java
@@ -1,0 +1,227 @@
+package com.linkedin.venice.controllerapi;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.linkedin.d2.balancer.D2Client;
+import com.linkedin.data.ByteString;
+import com.linkedin.r2.message.rest.RestRequest;
+import com.linkedin.r2.message.rest.RestResponse;
+import com.linkedin.venice.d2.D2ClientFactory;
+import com.linkedin.venice.exceptions.VeniceException;
+import com.linkedin.venice.security.SSLFactory;
+import com.linkedin.venice.utils.ObjectMapperFactory;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+
+public class TestD2ControllerClient {
+  private static final String TEST_STORE = "test_store";
+  private static final String TEST_CLUSTER = "test_cluster";
+  private static final String TEST_ZK_ADDRESS = "localhost:2181";
+  private static final String TEST_CONTROLLER_D2_SERVICE = "ChildController";
+  private static final String TEST_ROUTER_D2_SERVICE = "VeniceRouter";
+
+  @BeforeClass(alwaysRun = true)
+  public void setUp() {
+    D2ClientFactory.setUnitTestMode();
+  }
+
+  @AfterClass(alwaysRun = true)
+  public void teardown() {
+    D2ClientFactory.resetUnitTestMode();
+  }
+
+  @Test
+  public void testConstructD2ControllerClient() {
+    try (D2ControllerClient controllerClient =
+        new D2ControllerClient(TEST_CONTROLLER_D2_SERVICE, TEST_CLUSTER, TEST_ZK_ADDRESS, Optional.empty())) {
+    }
+    ;
+  }
+
+  @Test
+  public void testDiscoverCluster() throws JsonProcessingException {
+    D2ServiceDiscoveryResponse serviceDiscoveryResponse = new D2ServiceDiscoveryResponse();
+    serviceDiscoveryResponse.setCluster(TEST_CLUSTER);
+    serviceDiscoveryResponse.setD2Service(TEST_ROUTER_D2_SERVICE);
+    serviceDiscoveryResponse.setName(TEST_STORE);
+
+    String discoverClusterResponse = ObjectMapperFactory.getInstance().writeValueAsString(serviceDiscoveryResponse);
+
+    RestResponse discoverClusterRestResponse = mock(RestResponse.class);
+    doReturn(ByteString.unsafeWrap(discoverClusterResponse.getBytes(StandardCharsets.UTF_8)))
+        .when(discoverClusterRestResponse)
+        .getEntity();
+
+    D2Client mockD2Client = Mockito.mock(D2Client.class);
+    doAnswer(invocation -> {
+      RestRequest request = invocation.getArgument(0, RestRequest.class);
+      URI uri = request.getURI();
+      if (uri.getPath().equals(ControllerRoute.CLUSTER_DISCOVERY.getPath())) {
+        return CompletableFuture.supplyAsync(() -> discoverClusterRestResponse);
+      }
+      return null;
+    }).when(mockD2Client).restRequest(any());
+
+    D2ClientFactory.setD2Client(TEST_ZK_ADDRESS, mockD2Client);
+
+    D2ServiceDiscoveryResponse response =
+        D2ControllerClient.discoverCluster(TEST_ZK_ADDRESS, TEST_CONTROLLER_D2_SERVICE, TEST_STORE, 1);
+    Assert.assertEquals(response.getCluster(), TEST_CLUSTER);
+
+    try (D2ControllerClient controllerClient =
+        new D2ControllerClient(TEST_CONTROLLER_D2_SERVICE, TEST_CLUSTER, TEST_ZK_ADDRESS, Optional.empty())) {
+      D2ServiceDiscoveryResponse response1 = controllerClient.discoverCluster(TEST_STORE);
+      Assert.assertEquals(response1.getCluster(), TEST_CLUSTER);
+    }
+    ;
+
+    D2ClientFactory.release(TEST_ZK_ADDRESS);
+  }
+
+  @Test
+  public void testDiscoverClusterFailure() throws JsonProcessingException {
+    D2ServiceDiscoveryResponse serviceDiscoveryResponse = new D2ServiceDiscoveryResponse();
+    serviceDiscoveryResponse.setError(new VeniceException("FAIL"));
+    serviceDiscoveryResponse.setName(TEST_STORE);
+
+    String discoverClusterResponse = ObjectMapperFactory.getInstance().writeValueAsString(serviceDiscoveryResponse);
+
+    RestResponse discoverClusterRestResponse = mock(RestResponse.class);
+    doReturn(ByteString.unsafeWrap(discoverClusterResponse.getBytes(StandardCharsets.UTF_8)))
+        .when(discoverClusterRestResponse)
+        .getEntity();
+
+    D2Client mockD2Client = Mockito.mock(D2Client.class);
+    doAnswer(invocation -> {
+      RestRequest request = invocation.getArgument(0, RestRequest.class);
+      URI uri = request.getURI();
+      if (uri.getPath().equals(ControllerRoute.CLUSTER_DISCOVERY.getPath())) {
+        return CompletableFuture.supplyAsync(() -> discoverClusterRestResponse);
+      }
+      return null;
+    }).when(mockD2Client).restRequest(any());
+
+    D2ClientFactory.setD2Client(TEST_ZK_ADDRESS, mockD2Client);
+    Assert.assertThrows(
+        VeniceException.class,
+        () -> D2ControllerClient.discoverCluster(TEST_ZK_ADDRESS, TEST_CONTROLLER_D2_SERVICE, TEST_STORE, 1));
+
+    try (D2ControllerClient controllerClient = D2ControllerClientFactory
+        .getControllerClient(TEST_CONTROLLER_D2_SERVICE, TEST_CLUSTER, TEST_ZK_ADDRESS, Optional.empty())) {
+      Assert.assertThrows(VeniceException.class, () -> controllerClient.discoverCluster(TEST_STORE));
+    }
+    ;
+
+    D2ClientFactory.release(TEST_ZK_ADDRESS);
+  }
+
+  @Test
+  public void testDiscoverLeaderController() throws JsonProcessingException {
+    LeaderControllerResponse leaderControllerResponse = new LeaderControllerResponse();
+    leaderControllerResponse.setCluster(TEST_CLUSTER);
+    leaderControllerResponse.setName(TEST_STORE);
+    leaderControllerResponse.setUrl("http://localhost:2000");
+    leaderControllerResponse.setSecureUrl("http://localhost:2001");
+
+    String leaderControllerResponseStr = ObjectMapperFactory.getInstance().writeValueAsString(leaderControllerResponse);
+
+    RestResponse leaderControllerRestResponse = mock(RestResponse.class);
+    doReturn(ByteString.unsafeWrap(leaderControllerResponseStr.getBytes(StandardCharsets.UTF_8)))
+        .when(leaderControllerRestResponse)
+        .getEntity();
+
+    D2Client mockD2Client = Mockito.mock(D2Client.class);
+    doAnswer(invocation -> {
+      RestRequest request = invocation.getArgument(0, RestRequest.class);
+      URI uri = request.getURI();
+      if (uri.getPath().equals(ControllerRoute.LEADER_CONTROLLER.getPath())) {
+        return CompletableFuture.supplyAsync(() -> leaderControllerRestResponse);
+      }
+      return null;
+    }).when(mockD2Client).restRequest(any());
+
+    D2ClientFactory.setD2Client(TEST_ZK_ADDRESS, mockD2Client);
+
+    try (D2ControllerClient controllerClient =
+        new D2ControllerClient(TEST_CONTROLLER_D2_SERVICE, TEST_CLUSTER, TEST_ZK_ADDRESS, Optional.empty())) {
+      String leaderController = controllerClient.discoverLeaderController();
+      Assert.assertEquals(leaderController, leaderControllerResponse.getUrl());
+    }
+    ;
+
+    try (D2ControllerClient controllerClient = new D2ControllerClient(
+        TEST_CONTROLLER_D2_SERVICE,
+        TEST_CLUSTER,
+        TEST_ZK_ADDRESS,
+        Optional.of(mock(SSLFactory.class)))) {
+      String leaderController = controllerClient.discoverLeaderController();
+      Assert.assertEquals(leaderController, leaderControllerResponse.getSecureUrl());
+    }
+    ;
+
+    D2ClientFactory.release(TEST_ZK_ADDRESS);
+  }
+
+  @Test
+  public void testDiscoverLeaderControllerWithLegacySslPort() throws JsonProcessingException, MalformedURLException {
+    LeaderControllerResponse leaderControllerResponse = new LeaderControllerResponse();
+    leaderControllerResponse.setCluster(TEST_CLUSTER);
+    leaderControllerResponse.setName(TEST_STORE);
+    leaderControllerResponse.setUrl("http://localhost:2000");
+
+    String leaderControllerResponseStr = ObjectMapperFactory.getInstance().writeValueAsString(leaderControllerResponse);
+
+    RestResponse leaderControllerRestResponse = mock(RestResponse.class);
+    doReturn(ByteString.unsafeWrap(leaderControllerResponseStr.getBytes(StandardCharsets.UTF_8)))
+        .when(leaderControllerRestResponse)
+        .getEntity();
+
+    D2Client mockD2Client = Mockito.mock(D2Client.class);
+    doAnswer(invocation -> {
+      RestRequest request = invocation.getArgument(0, RestRequest.class);
+      URI uri = request.getURI();
+      if (uri.getPath().equals(ControllerRoute.LEADER_CONTROLLER.getPath())) {
+        return CompletableFuture.supplyAsync(() -> leaderControllerRestResponse);
+      }
+      return null;
+    }).when(mockD2Client).restRequest(any());
+
+    D2ClientFactory.setD2Client(TEST_ZK_ADDRESS, mockD2Client);
+
+    try (D2ControllerClient controllerClient = new D2ControllerClient(
+        TEST_CONTROLLER_D2_SERVICE,
+        TEST_CLUSTER,
+        TEST_ZK_ADDRESS,
+        Optional.of(mock(SSLFactory.class)))) {
+      URL responseUrl = new URL(controllerClient.discoverLeaderController());
+      Assert.assertEquals(responseUrl.getPort(), 1578);
+    }
+    ;
+
+    D2ClientFactory.release(TEST_ZK_ADDRESS);
+  }
+
+  /**
+   * TODO: Remove the below unit test after controller ACL migration
+   */
+  @Test
+  public void testHelperFunctionToConvertUrl() throws MalformedURLException {
+    URL testUrl = new URL("http://localhost:1576");
+    Assert.assertEquals(D2ControllerClient.convertToSecureUrl(testUrl).toString(), "https://localhost:1578");
+    Assert.assertEquals(D2ControllerClient.convertToSecureUrl(testUrl, 2000).toString(), "https://localhost:2000");
+  }
+}

--- a/internal/venice-common/src/test/java/com/linkedin/venice/d2/TestD2ClientFactory.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/d2/TestD2ClientFactory.java
@@ -1,48 +1,53 @@
 package com.linkedin.venice.d2;
 
 import static org.testng.AssertJUnit.assertEquals;
-import static org.testng.AssertJUnit.assertFalse;
 import static org.testng.AssertJUnit.assertNotSame;
 import static org.testng.AssertJUnit.assertSame;
-import static org.testng.AssertJUnit.assertTrue;
 
 import com.linkedin.d2.balancer.D2Client;
-import com.linkedin.venice.utils.ReferenceCounted;
-import java.util.Map;
 import java.util.Optional;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 
 public class TestD2ClientFactory {
+  @BeforeClass(alwaysRun = true)
+  public void setUp() {
+    D2ClientFactory.setUnitTestMode();
+  }
+
+  @AfterClass(alwaysRun = true)
+  public void teardown() {
+    D2ClientFactory.resetUnitTestMode();
+  }
+
   @Test
-  public void getD2ClientFromFactory() throws NoSuchFieldException, IllegalAccessException {
+  public void getD2ClientFromFactory() {
     String d2ZkHost = "localhost:2181";
-    ReferenceCounted<D2Client> d2Client = D2ClientFactory.getD2Client(d2ZkHost, Optional.empty(), true);
-    Map<String, ReferenceCounted<D2Client>> d2ClientCache = D2ClientFactory.D2_CLIENT_CACHE;
-    assertEquals(d2ClientCache.size(), 1);
-    assertEquals(d2ClientCache.get(d2ZkHost).getReferenceCount(), 1);
+    D2Client d2Client = D2ClientFactory.getD2Client(d2ZkHost, Optional.empty());
+    assertEquals(D2ClientFactory.SHARED_OBJECT_FACTORY.size(), 1);
+    assertEquals(D2ClientFactory.SHARED_OBJECT_FACTORY.getReferenceCount(d2ZkHost), 1);
 
     // Close D2Client should clean up and remove the client from the cache
-    ReferenceCounted<D2Client> referenceCounted = d2ClientCache.get(d2ZkHost);
-    referenceCounted.release();
-    assertEquals(referenceCounted.getReferenceCount(), 0);
-    assertFalse(d2ClientCache.containsKey(d2ZkHost));
+    D2ClientFactory.release(d2ZkHost);
+    assertEquals(D2ClientFactory.SHARED_OBJECT_FACTORY.size(), 0);
+    assertEquals(D2ClientFactory.SHARED_OBJECT_FACTORY.getReferenceCount(d2ZkHost), 0);
 
-    ReferenceCounted<D2Client> d2Client2 = D2ClientFactory.getD2Client(d2ZkHost, Optional.empty(), true);
-    ReferenceCounted<D2Client> d2Client3 = D2ClientFactory.getD2Client(d2ZkHost, Optional.empty(), true);
+    D2Client d2Client2 = D2ClientFactory.getD2Client(d2ZkHost, Optional.empty());
+    D2Client d2Client3 = D2ClientFactory.getD2Client(d2ZkHost, Optional.empty());
     assertNotSame(d2Client, d2Client2);
     assertSame(d2Client2, d2Client3);
-    assertEquals(d2ClientCache.size(), 1);
-    assertEquals(d2ClientCache.get(d2ZkHost).getReferenceCount(), 2);
+    assertEquals(D2ClientFactory.SHARED_OBJECT_FACTORY.size(), 1);
+    assertEquals(D2ClientFactory.SHARED_OBJECT_FACTORY.getReferenceCount(d2ZkHost), 2);
 
     // Closing one D2Client should not clean up and remove the client from the cache
-    d2Client2.release();
-    assertEquals(d2Client2.getReferenceCount(), 1);
-    assertTrue(d2ClientCache.containsKey(d2ZkHost));
+    D2ClientFactory.release(d2ZkHost);
+    assertEquals(D2ClientFactory.SHARED_OBJECT_FACTORY.getReferenceCount(d2ZkHost), 1);
 
     // Closing the last shared D2Client should clean up and remove the client from the cache
-    d2Client3.release();
-    assertEquals(d2Client3.getReferenceCount(), 0);
-    assertFalse(d2ClientCache.containsKey(d2ZkHost));
+    D2ClientFactory.release(d2ZkHost);
+    assertEquals(D2ClientFactory.SHARED_OBJECT_FACTORY.size(), 0);
+    assertEquals(D2ClientFactory.SHARED_OBJECT_FACTORY.getReferenceCount(d2ZkHost), 0);
   }
 }

--- a/internal/venice-common/src/test/java/com/linkedin/venice/d2/TestD2ClientFactory.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/d2/TestD2ClientFactory.java
@@ -1,0 +1,48 @@
+package com.linkedin.venice.d2;
+
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertFalse;
+import static org.testng.AssertJUnit.assertNotSame;
+import static org.testng.AssertJUnit.assertSame;
+import static org.testng.AssertJUnit.assertTrue;
+
+import com.linkedin.d2.balancer.D2Client;
+import com.linkedin.venice.utils.ReferenceCounted;
+import java.util.Map;
+import java.util.Optional;
+import org.testng.annotations.Test;
+
+
+public class TestD2ClientFactory {
+  @Test
+  public void getD2ClientFromFactory() throws NoSuchFieldException, IllegalAccessException {
+    String d2ZkHost = "localhost:2181";
+    ReferenceCounted<D2Client> d2Client = D2ClientFactory.getD2Client(d2ZkHost, Optional.empty(), true);
+    Map<String, ReferenceCounted<D2Client>> d2ClientCache = D2ClientFactory.D2_CLIENT_CACHE;
+    assertEquals(d2ClientCache.size(), 1);
+    assertEquals(d2ClientCache.get(d2ZkHost).getReferenceCount(), 1);
+
+    // Close D2Client should clean up and remove the client from the cache
+    ReferenceCounted<D2Client> referenceCounted = d2ClientCache.get(d2ZkHost);
+    referenceCounted.release();
+    assertEquals(referenceCounted.getReferenceCount(), 0);
+    assertFalse(d2ClientCache.containsKey(d2ZkHost));
+
+    ReferenceCounted<D2Client> d2Client2 = D2ClientFactory.getD2Client(d2ZkHost, Optional.empty(), true);
+    ReferenceCounted<D2Client> d2Client3 = D2ClientFactory.getD2Client(d2ZkHost, Optional.empty(), true);
+    assertNotSame(d2Client, d2Client2);
+    assertSame(d2Client2, d2Client3);
+    assertEquals(d2ClientCache.size(), 1);
+    assertEquals(d2ClientCache.get(d2ZkHost).getReferenceCount(), 2);
+
+    // Closing one D2Client should not clean up and remove the client from the cache
+    d2Client2.release();
+    assertEquals(d2Client2.getReferenceCount(), 1);
+    assertTrue(d2ClientCache.containsKey(d2ZkHost));
+
+    // Closing the last shared D2Client should clean up and remove the client from the cache
+    d2Client3.release();
+    assertEquals(d2Client3.getReferenceCount(), 0);
+    assertFalse(d2ClientCache.containsKey(d2ZkHost));
+  }
+}

--- a/internal/venice-common/src/test/java/com/linkedin/venice/utils/SharedObjectFactoryTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/utils/SharedObjectFactoryTest.java
@@ -1,0 +1,72 @@
+package com.linkedin.venice.utils;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class SharedObjectFactoryTest {
+  private class TestSharedObject implements AutoCloseable {
+    String identifier;
+    boolean destructorInvoked;
+
+    TestSharedObject(String identifier) {
+      this.identifier = identifier;
+      destructorInvoked = false;
+    }
+
+    @Override
+    public void close() {
+      destructorInvoked = true;
+    }
+  }
+
+  @Test
+  public void testSharedObject() {
+    SharedObjectFactory<TestSharedObject> factory = new SharedObjectFactory<>();
+
+    String id1 = "id1";
+    // Create a new shared object
+    TestSharedObject obj1 = factory.get(id1, () -> new TestSharedObject(id1), TestSharedObject::close);
+    Assert.assertFalse(obj1.destructorInvoked);
+    Assert.assertEquals(factory.getReferenceCount(id1), 1);
+
+    // Get the same shared object from the factory
+    TestSharedObject obj2 = factory.get(id1, () -> new TestSharedObject(id1), TestSharedObject::close);
+    Assert.assertSame(obj1, obj2);
+    Assert.assertFalse(obj1.destructorInvoked);
+    Assert.assertEquals(factory.getReferenceCount(id1), 2);
+
+    Assert.assertEquals(factory.size(), 1);
+
+    String id2 = "id2";
+    // Create a new shared object with a different identifier
+    TestSharedObject obj3 = factory.get(id2, () -> new TestSharedObject(id1), TestSharedObject::close);
+    Assert.assertFalse(obj3.destructorInvoked);
+    Assert.assertEquals(factory.getReferenceCount(id2), 1);
+
+    Assert.assertEquals(factory.size(), 2);
+
+    // Release a shared object. The destructor will not be invoked since the object is shared
+    Assert.assertFalse(factory.release(id1));
+    Assert.assertFalse(obj2.destructorInvoked);
+    Assert.assertEquals(factory.getReferenceCount(id1), 1);
+    Assert.assertEquals(factory.size(), 2);
+
+    // Release the last reference of a shared object. The destructor will now be invoked
+    Assert.assertTrue(factory.release(id1));
+    Assert.assertTrue(obj2.destructorInvoked);
+    Assert.assertEquals(factory.getReferenceCount(id1), 0);
+    Assert.assertEquals(factory.size(), 1);
+
+    // Release the last reference of a shared object. The destructor will now be invoked
+    Assert.assertTrue(factory.release(id2));
+    Assert.assertTrue(obj2.destructorInvoked);
+    Assert.assertEquals(factory.getReferenceCount(id1), 0);
+    Assert.assertEquals(factory.size(), 0);
+
+    // Calling release on a non-managed object returns true
+    Assert.assertTrue(factory.release(id1));
+    String id3 = "id3";
+    Assert.assertTrue(factory.release(id3));
+  }
+}

--- a/internal/venice-common/src/test/java/com/linkedin/venice/utils/SharedObjectFactoryTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/utils/SharedObjectFactoryTest.java
@@ -6,11 +6,9 @@ import org.testng.annotations.Test;
 
 public class SharedObjectFactoryTest {
   private class TestSharedObject implements AutoCloseable {
-    String identifier;
     boolean destructorInvoked;
 
-    TestSharedObject(String identifier) {
-      this.identifier = identifier;
+    TestSharedObject() {
       destructorInvoked = false;
     }
 
@@ -26,12 +24,12 @@ public class SharedObjectFactoryTest {
 
     String id1 = "id1";
     // Create a new shared object
-    TestSharedObject obj1 = factory.get(id1, () -> new TestSharedObject(id1), TestSharedObject::close);
+    TestSharedObject obj1 = factory.get(id1, TestSharedObject::new, TestSharedObject::close);
     Assert.assertFalse(obj1.destructorInvoked);
     Assert.assertEquals(factory.getReferenceCount(id1), 1);
 
     // Get the same shared object from the factory
-    TestSharedObject obj2 = factory.get(id1, () -> new TestSharedObject(id1), TestSharedObject::close);
+    TestSharedObject obj2 = factory.get(id1, TestSharedObject::new, TestSharedObject::close);
     Assert.assertSame(obj1, obj2);
     Assert.assertFalse(obj1.destructorInvoked);
     Assert.assertEquals(factory.getReferenceCount(id1), 2);
@@ -40,7 +38,7 @@ public class SharedObjectFactoryTest {
 
     String id2 = "id2";
     // Create a new shared object with a different identifier
-    TestSharedObject obj3 = factory.get(id2, () -> new TestSharedObject(id1), TestSharedObject::close);
+    TestSharedObject obj3 = factory.get(id2, TestSharedObject::new, TestSharedObject::close);
     Assert.assertFalse(obj3.destructorInvoked);
     Assert.assertEquals(factory.getReferenceCount(id2), 1);
 

--- a/internal/venice-test-common/build.gradle
+++ b/internal/venice-test-common/build.gradle
@@ -276,3 +276,8 @@ task integrationTestJar(type: Jar, dependsOn: integrationTestClasses) {
 artifacts {
   integrationTestConf integrationTestJar
 }
+
+ext {
+  jacocoCoverageThreshold = 0.00
+  diffCoverageThreshold = 0.00
+}

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/controller/AdminToolBackfillTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/controller/AdminToolBackfillTest.java
@@ -60,7 +60,7 @@ public class AdminToolBackfillTest {
         Optional.empty(),
         Optional.empty(),
         false);
-    childDatacenters = multiColoMultiClusterWrapper.getChildColoList();
+    childDatacenters = multiColoMultiClusterWrapper.getChildRegionList();
     clusterNames = multiColoMultiClusterWrapper.getClusterNames();
   }
 

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/controller/AdminToolBackfillTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/controller/AdminToolBackfillTest.java
@@ -60,7 +60,7 @@ public class AdminToolBackfillTest {
         Optional.empty(),
         Optional.empty(),
         false);
-    childDatacenters = multiColoMultiClusterWrapper.getChildRegionList();
+    childDatacenters = multiColoMultiClusterWrapper.getChildRegions();
     clusterNames = multiColoMultiClusterWrapper.getClusterNames();
   }
 

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/controller/AdminToolBackfillTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/controller/AdminToolBackfillTest.java
@@ -13,7 +13,6 @@ import com.linkedin.venice.controllerapi.MultiStoreResponse;
 import com.linkedin.venice.controllerapi.NewStoreResponse;
 import com.linkedin.venice.controllerapi.StoreResponse;
 import com.linkedin.venice.integration.utils.ServiceFactory;
-import com.linkedin.venice.integration.utils.VeniceControllerWrapper;
 import com.linkedin.venice.integration.utils.VeniceMultiClusterWrapper;
 import com.linkedin.venice.integration.utils.VeniceTwoLayerMultiColoMultiClusterWrapper;
 import com.linkedin.venice.utils.TestUtils;
@@ -26,7 +25,6 @@ import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -38,8 +36,8 @@ public class AdminToolBackfillTest {
   private static final int NUMBER_OF_CHILD_DATACENTERS = 2; // DO NOT CHANGE
   private static final int NUMBER_OF_CLUSTERS = 1;
 
+  private String[] clusterNames;
   private List<VeniceMultiClusterWrapper> childDatacenters;
-  private List<VeniceControllerWrapper> parentControllers;
 
   private VeniceTwoLayerMultiColoMultiClusterWrapper multiColoMultiClusterWrapper;
 
@@ -62,8 +60,8 @@ public class AdminToolBackfillTest {
         Optional.empty(),
         Optional.empty(),
         false);
-    childDatacenters = multiColoMultiClusterWrapper.getClusters();
-    parentControllers = multiColoMultiClusterWrapper.getParentControllers();
+    childDatacenters = multiColoMultiClusterWrapper.getChildColoList();
+    clusterNames = multiColoMultiClusterWrapper.getClusterNames();
   }
 
   @AfterClass(alwaysRun = true)
@@ -73,11 +71,10 @@ public class AdminToolBackfillTest {
 
   @Test(timeOut = TEST_TIMEOUT)
   public void testMetaSystemStoreBackfill() throws Exception {
-    String clusterName = multiColoMultiClusterWrapper.getClusters().get(0).getClusterNames()[0];
+    String clusterName = clusterNames[0];
     String testStoreName = Utils.getUniqueString("test-store");
 
-    String parentControllerUrls =
-        parentControllers.stream().map(VeniceControllerWrapper::getControllerUrl).collect(Collectors.joining(","));
+    String parentControllerUrls = multiColoMultiClusterWrapper.getControllerConnectString();
     ControllerClient parentControllerClient =
         ControllerClient.constructClusterControllerClient(clusterName, parentControllerUrls);
     ControllerClient dc0Client = ControllerClient
@@ -143,11 +140,10 @@ public class AdminToolBackfillTest {
 
   @Test(timeOut = TEST_TIMEOUT)
   public void testPushStatusStoreBackfill() throws Exception {
-    String clusterName = multiColoMultiClusterWrapper.getClusters().get(0).getClusterNames()[0];
+    String clusterName = clusterNames[0];
     String testStoreName = Utils.getUniqueString("test-store");
 
-    String parentControllerUrls =
-        parentControllers.stream().map(VeniceControllerWrapper::getControllerUrl).collect(Collectors.joining(","));
+    String parentControllerUrls = multiColoMultiClusterWrapper.getControllerConnectString();
     ControllerClient parentControllerClient =
         ControllerClient.constructClusterControllerClient(clusterName, parentControllerUrls);
     ControllerClient dc0Client = ControllerClient

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/controller/TestD2ControllerClient.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/controller/TestD2ControllerClient.java
@@ -13,8 +13,6 @@ import com.linkedin.venice.integration.utils.VeniceControllerWrapper;
 import com.linkedin.venice.integration.utils.ZkServerWrapper;
 import com.linkedin.venice.utils.Time;
 import com.linkedin.venice.utils.Utils;
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.util.Collections;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -68,14 +66,5 @@ public class TestD2ControllerClient {
         D2ClientUtils.shutdownClient(d2Client);
       }
     }
-  }
-
-  /**
-   * TODO: Remove the below unit test after controller ACL migration
-   */
-  @Test(timeOut = 60 * Time.MS_PER_SECOND)
-  public void testHelperFunctionToConvertUrl() throws MalformedURLException {
-    URL testUrl = new URL("http://localhost:1576");
-    Assert.assertEquals(D2ControllerClient.convertToSecureUrl(testUrl, 1578).toString(), "https://localhost:1578");
   }
 }

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/controller/TestFabricBuildout.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/controller/TestFabricBuildout.java
@@ -28,8 +28,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -41,10 +39,8 @@ public class TestFabricBuildout {
 
   private static final int NUMBER_OF_CHILD_DATACENTERS = 2;
   private static final int NUMBER_OF_CLUSTERS = 1;
-  private static final String[] CLUSTER_NAMES =
-      IntStream.range(0, NUMBER_OF_CLUSTERS).mapToObj(i -> "venice-cluster" + i).toArray(String[]::new); // ["venice-cluster0",
-                                                                                                         // "venice-cluster1",
-                                                                                                         // ...];
+  private String[] clusterNames;
+  private String[] dcNames;
 
   private List<VeniceMultiClusterWrapper> childDatacenters;
   private List<VeniceControllerWrapper> parentControllers;
@@ -72,8 +68,11 @@ public class TestFabricBuildout {
         Optional.of(new VeniceProperties(serverProperties)),
         false);
 
-    childDatacenters = multiColoMultiClusterWrapper.getClusters();
+    childDatacenters = multiColoMultiClusterWrapper.getChildColoList();
     parentControllers = multiColoMultiClusterWrapper.getParentControllers();
+
+    clusterNames = multiColoMultiClusterWrapper.getClusterNames();
+    dcNames = multiColoMultiClusterWrapper.getChildColoNames().toArray(new String[0]);
   }
 
   @AfterClass(alwaysRun = true)
@@ -83,12 +82,11 @@ public class TestFabricBuildout {
 
   @Test(timeOut = TEST_TIMEOUT)
   public void testStoresMetadataCopyOver() {
-    String clusterName = CLUSTER_NAMES[0];
+    String clusterName = clusterNames[0];
     String storeName = Utils.getUniqueString("store");
 
     // Test the admin channel
-    String parentControllerUrls =
-        parentControllers.stream().map(VeniceControllerWrapper::getControllerUrl).collect(Collectors.joining(","));
+    String parentControllerUrls = multiColoMultiClusterWrapper.getControllerConnectString();
 
     try (
         ControllerClient parentControllerClient =
@@ -112,7 +110,7 @@ public class TestFabricBuildout {
           dc0Client.updateAdminTopicMetadata(2L, Optional.of(storeName), Optional.empty(), Optional.empty()).isError());
 
       // Call metadata copy over to copy dc0's store configs to dc1
-      parentControllerClient.copyOverStoreMetadata("dc-0", "dc-1", storeName);
+      parentControllerClient.copyOverStoreMetadata(dcNames[0], dcNames[1], storeName);
       ControllerClient dc1Client = ControllerClient
           .constructClusterControllerClient(clusterName, childDatacenters.get(1).getControllerConnectString());
       checkStoreConfig(dc1Client, storeName);
@@ -124,7 +122,7 @@ public class TestFabricBuildout {
 
   @Test(timeOut = TEST_TIMEOUT)
   public void testStartFabricBuildout() throws Exception {
-    String clusterName = CLUSTER_NAMES[0];
+    String clusterName = clusterNames[0];
     try (
         ControllerClient childControllerClient0 =
             new ControllerClient(clusterName, childDatacenters.get(0).getControllerConnectString());
@@ -154,7 +152,7 @@ public class TestFabricBuildout {
       checkStoreConfigAndCurrentVersion(childControllerClient1, testStoreName1, 1);
 
       String[] args = { "--start-fabric-buildout", "--url", parentControllers.get(0).getControllerUrl(), "--cluster",
-          clusterName, "--source-fabric", "dc-0", "--dest-fabric", "dc-1" };
+          clusterName, "--source-fabric", dcNames[0], "--dest-fabric", dcNames[1] };
       AdminTool.main(args);
 
       checkStoreConfigAndCurrentVersion(childControllerClient1, testStoreName1, 1);
@@ -164,9 +162,8 @@ public class TestFabricBuildout {
 
   @Test(timeOut = TEST_TIMEOUT)
   public void testCompareStore() {
-    String clusterName = CLUSTER_NAMES[0];
-    String parentControllerUrls =
-        parentControllers.stream().map(VeniceControllerWrapper::getControllerUrl).collect(Collectors.joining(","));
+    String clusterName = clusterNames[0];
+    String parentControllerUrls = multiColoMultiClusterWrapper.getControllerConnectString();
     try (ControllerClient parentControllerClient = new ControllerClient(clusterName, parentControllerUrls);
         ControllerClient childControllerClient0 =
             new ControllerClient(clusterName, childDatacenters.get(0).getControllerConnectString());
@@ -190,7 +187,7 @@ public class TestFabricBuildout {
           childControllerClient0.addValueSchema(testStoreName, TestWriteUtils.NESTED_SCHEMA_STRING_V2);
       Assert.assertFalse(schemaResponse.isError());
 
-      StoreComparisonResponse response = parentControllerClient.compareStore(testStoreName, "dc-0", "dc-1");
+      StoreComparisonResponse response = parentControllerClient.compareStore(testStoreName, dcNames[0], dcNames[1]);
       // Make sure the diffs are discovered.
       Assert.assertFalse(response.getPropertyDiff().isEmpty());
       Assert.assertFalse(response.getSchemaDiff().isEmpty());

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/controller/TestFabricBuildout.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/controller/TestFabricBuildout.java
@@ -68,11 +68,11 @@ public class TestFabricBuildout {
         Optional.of(new VeniceProperties(serverProperties)),
         false);
 
-    childDatacenters = multiColoMultiClusterWrapper.getChildColoList();
+    childDatacenters = multiColoMultiClusterWrapper.getChildRegionList();
     parentControllers = multiColoMultiClusterWrapper.getParentControllers();
 
     clusterNames = multiColoMultiClusterWrapper.getClusterNames();
-    dcNames = multiColoMultiClusterWrapper.getChildColoNames().toArray(new String[0]);
+    dcNames = multiColoMultiClusterWrapper.getChildRegionNames().toArray(new String[0]);
   }
 
   @AfterClass(alwaysRun = true)

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/controller/TestFabricBuildout.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/controller/TestFabricBuildout.java
@@ -68,7 +68,7 @@ public class TestFabricBuildout {
         Optional.of(new VeniceProperties(serverProperties)),
         false);
 
-    childDatacenters = multiColoMultiClusterWrapper.getChildRegionList();
+    childDatacenters = multiColoMultiClusterWrapper.getChildRegions();
     parentControllers = multiColoMultiClusterWrapper.getParentControllers();
 
     clusterNames = multiColoMultiClusterWrapper.getClusterNames();

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/controller/TestParentControllerWithMultiDataCenter.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/controller/TestParentControllerWithMultiDataCenter.java
@@ -70,7 +70,7 @@ public class TestParentControllerWithMultiDataCenter {
         Optional.of(controllerProps),
         Optional.empty());
 
-    childDatacenters = multiColoMultiClusterWrapper.getChildColoList();
+    childDatacenters = multiColoMultiClusterWrapper.getChildRegionList();
   }
 
   @AfterClass(alwaysRun = true)

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/controller/TestParentControllerWithMultiDataCenter.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/controller/TestParentControllerWithMultiDataCenter.java
@@ -70,7 +70,7 @@ public class TestParentControllerWithMultiDataCenter {
         Optional.of(controllerProps),
         Optional.empty());
 
-    childDatacenters = multiColoMultiClusterWrapper.getChildRegionList();
+    childDatacenters = multiColoMultiClusterWrapper.getChildRegions();
   }
 
   @AfterClass(alwaysRun = true)

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/controller/TestParentControllerWithMultiDataCenter.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/controller/TestParentControllerWithMultiDataCenter.java
@@ -11,7 +11,6 @@ import com.linkedin.venice.controllerapi.StoreResponse;
 import com.linkedin.venice.controllerapi.UpdateStoreQueryParams;
 import com.linkedin.venice.controllerapi.VersionCreationResponse;
 import com.linkedin.venice.integration.utils.ServiceFactory;
-import com.linkedin.venice.integration.utils.VeniceControllerWrapper;
 import com.linkedin.venice.integration.utils.VeniceMultiClusterWrapper;
 import com.linkedin.venice.integration.utils.VeniceTwoLayerMultiColoMultiClusterWrapper;
 import com.linkedin.venice.meta.BufferReplayPolicy;
@@ -31,7 +30,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.apache.avro.Schema;
 import org.testng.Assert;
@@ -50,7 +48,6 @@ public class TestParentControllerWithMultiDataCenter {
                                                                                                          // ...];
 
   private List<VeniceMultiClusterWrapper> childDatacenters;
-  private List<VeniceControllerWrapper> parentControllers;
   private VeniceTwoLayerMultiColoMultiClusterWrapper multiColoMultiClusterWrapper;
 
   private static final String BASIC_USER_SCHEMA_STRING_WITH_DEFAULT = "{" + "  \"namespace\" : \"example.avro\",  "
@@ -73,8 +70,7 @@ public class TestParentControllerWithMultiDataCenter {
         Optional.of(controllerProps),
         Optional.empty());
 
-    childDatacenters = multiColoMultiClusterWrapper.getClusters();
-    parentControllers = multiColoMultiClusterWrapper.getParentControllers();
+    childDatacenters = multiColoMultiClusterWrapper.getChildColoList();
   }
 
   @AfterClass(alwaysRun = true)
@@ -87,8 +83,7 @@ public class TestParentControllerWithMultiDataCenter {
     String clusterName = CLUSTER_NAMES[0];
     String storeName = Utils.getUniqueString("store");
 
-    String parentControllerURLs =
-        parentControllers.stream().map(VeniceControllerWrapper::getControllerUrl).collect(Collectors.joining(","));
+    String parentControllerURLs = multiColoMultiClusterWrapper.getControllerConnectString();
     try (ControllerClient parentControllerClient =
         ControllerClient.constructClusterControllerClient(clusterName, parentControllerURLs)) {
       /**
@@ -207,8 +202,7 @@ public class TestParentControllerWithMultiDataCenter {
     String clusterName = CLUSTER_NAMES[0];
     String storeName = Utils.getUniqueString("store");
 
-    String parentControllerURLs =
-        parentControllers.stream().map(VeniceControllerWrapper::getControllerUrl).collect(Collectors.joining(","));
+    String parentControllerURLs = multiColoMultiClusterWrapper.getControllerConnectString();
     try (ControllerClient parentControllerClient =
         ControllerClient.constructClusterControllerClient(clusterName, parentControllerURLs)) {
       /**
@@ -335,8 +329,7 @@ public class TestParentControllerWithMultiDataCenter {
     Schema rmdSchema2 = RmdSchemaGenerator.generateMetadataSchema(valueRecordSchemaStr2, 1);
     Schema rmdSchema3 = RmdSchemaGenerator.generateMetadataSchema(valueRecordSchemaStr3, 1);
 
-    String parentControllerURLs =
-        parentControllers.stream().map(VeniceControllerWrapper::getControllerUrl).collect(Collectors.joining(","));
+    String parentControllerURLs = multiColoMultiClusterWrapper.getControllerConnectString();
     try (ControllerClient parentControllerClient = new ControllerClient(clusterName, parentControllerURLs)) {
       /**
        * Create a test store
@@ -432,8 +425,7 @@ public class TestParentControllerWithMultiDataCenter {
   public void testStoreRollbackToBackupVersion() {
     String clusterName = CLUSTER_NAMES[0];
     String storeName = Utils.getUniqueString("testStoreRollbackToBackupVersion");
-    String parentControllerURLs =
-        parentControllers.stream().map(VeniceControllerWrapper::getControllerUrl).collect(Collectors.joining(","));
+    String parentControllerURLs = multiColoMultiClusterWrapper.getControllerConnectString();
     try (ControllerClient parentControllerClient = new ControllerClient(clusterName, parentControllerURLs);
         ControllerClient dc0Client =
             new ControllerClient(clusterName, childDatacenters.get(0).getControllerConnectString());

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/controller/server/TestAdminSparkServer.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/controller/server/TestAdminSparkServer.java
@@ -833,9 +833,9 @@ public class TestAdminSparkServer extends AbstractTestAdminSparkServer {
 
   @Test(timeOut = TEST_TIMEOUT)
   public void controllerClientCanEnableThrottling() {
-    controllerClient.enableThrotting(false);
+    controllerClient.enableThrottling(false);
     Assert.assertFalse(controllerClient.getRoutersClusterConfig().getConfig().isThrottlingEnabled());
-    controllerClient.enableThrotting(true);
+    controllerClient.enableThrottling(true);
     Assert.assertTrue(controllerClient.getRoutersClusterConfig().getConfig().isThrottlingEnabled());
 
   }

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/ActiveActiveReplicationForHybridTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/ActiveActiveReplicationForHybridTest.java
@@ -164,7 +164,7 @@ public class ActiveActiveReplicationForHybridTest {
         Optional.of(controllerProps),
         Optional.of(new VeniceProperties(serverProperties)),
         false);
-    childDatacenters = multiColoMultiClusterWrapper.getClusters();
+    childDatacenters = multiColoMultiClusterWrapper.getChildColoList();
     parentControllers = multiColoMultiClusterWrapper.getParentControllers();
 
     // Set up a d2 client for DC0 region
@@ -384,7 +384,7 @@ public class ActiveActiveReplicationForHybridTest {
       // disable the purging of transientRecord buffer using reflection.
       if (useTransientRecordCache) {
         String topicName = Version.composeKafkaTopic(storeName, versionNumber);
-        for (VeniceMultiClusterWrapper veniceColo: multiColoMultiClusterWrapper.getClusters()) {
+        for (VeniceMultiClusterWrapper veniceColo: multiColoMultiClusterWrapper.getChildColoList()) {
           VeniceClusterWrapper veniceCluster = veniceColo.getClusters().get(clusterName);
           for (VeniceServerWrapper veniceServerWrapper: veniceCluster.getVeniceServers()) {
             StoreIngestionTaskBackdoor.setPurgeTransientRecordBuffer(veniceServerWrapper, topicName, false);

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/ActiveActiveReplicationForHybridTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/ActiveActiveReplicationForHybridTest.java
@@ -164,7 +164,7 @@ public class ActiveActiveReplicationForHybridTest {
         Optional.of(controllerProps),
         Optional.of(new VeniceProperties(serverProperties)),
         false);
-    childDatacenters = multiColoMultiClusterWrapper.getChildRegionList();
+    childDatacenters = multiColoMultiClusterWrapper.getChildRegions();
     parentControllers = multiColoMultiClusterWrapper.getParentControllers();
 
     // Set up a d2 client for DC0 region
@@ -384,7 +384,7 @@ public class ActiveActiveReplicationForHybridTest {
       // disable the purging of transientRecord buffer using reflection.
       if (useTransientRecordCache) {
         String topicName = Version.composeKafkaTopic(storeName, versionNumber);
-        for (VeniceMultiClusterWrapper veniceColo: multiColoMultiClusterWrapper.getChildRegionList()) {
+        for (VeniceMultiClusterWrapper veniceColo: multiColoMultiClusterWrapper.getChildRegions()) {
           VeniceClusterWrapper veniceCluster = veniceColo.getClusters().get(clusterName);
           for (VeniceServerWrapper veniceServerWrapper: veniceCluster.getVeniceServers()) {
             StoreIngestionTaskBackdoor.setPurgeTransientRecordBuffer(veniceServerWrapper, topicName, false);

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/ActiveActiveReplicationForHybridTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/ActiveActiveReplicationForHybridTest.java
@@ -164,7 +164,7 @@ public class ActiveActiveReplicationForHybridTest {
         Optional.of(controllerProps),
         Optional.of(new VeniceProperties(serverProperties)),
         false);
-    childDatacenters = multiColoMultiClusterWrapper.getChildColoList();
+    childDatacenters = multiColoMultiClusterWrapper.getChildRegionList();
     parentControllers = multiColoMultiClusterWrapper.getParentControllers();
 
     // Set up a d2 client for DC0 region
@@ -384,7 +384,7 @@ public class ActiveActiveReplicationForHybridTest {
       // disable the purging of transientRecord buffer using reflection.
       if (useTransientRecordCache) {
         String topicName = Version.composeKafkaTopic(storeName, versionNumber);
-        for (VeniceMultiClusterWrapper veniceColo: multiColoMultiClusterWrapper.getChildColoList()) {
+        for (VeniceMultiClusterWrapper veniceColo: multiColoMultiClusterWrapper.getChildRegionList()) {
           VeniceClusterWrapper veniceCluster = veniceColo.getClusters().get(clusterName);
           for (VeniceServerWrapper veniceServerWrapper: veniceCluster.getVeniceServers()) {
             StoreIngestionTaskBackdoor.setPurgeTransientRecordBuffer(veniceServerWrapper, topicName, false);

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/DaVinciClusterAgnosticTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/DaVinciClusterAgnosticTest.java
@@ -82,7 +82,7 @@ public class DaVinciClusterAgnosticTest {
         Optional.empty(),
         Optional.empty(),
         false);
-    multiClusterVenice = multiColoMultiClusterWrapper.getChildColoList().get(0);
+    multiClusterVenice = multiColoMultiClusterWrapper.getChildRegionList().get(0);
     clusterNames = multiClusterVenice.getClusterNames();
     parentControllerURLs = multiColoMultiClusterWrapper.getParentControllers()
         .stream()

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/DaVinciClusterAgnosticTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/DaVinciClusterAgnosticTest.java
@@ -82,7 +82,7 @@ public class DaVinciClusterAgnosticTest {
         Optional.empty(),
         Optional.empty(),
         false);
-    multiClusterVenice = multiColoMultiClusterWrapper.getClusters().get(0);
+    multiClusterVenice = multiColoMultiClusterWrapper.getChildColoList().get(0);
     clusterNames = multiClusterVenice.getClusterNames();
     parentControllerURLs = multiColoMultiClusterWrapper.getParentControllers()
         .stream()

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/DaVinciClusterAgnosticTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/DaVinciClusterAgnosticTest.java
@@ -82,7 +82,7 @@ public class DaVinciClusterAgnosticTest {
         Optional.empty(),
         Optional.empty(),
         false);
-    multiClusterVenice = multiColoMultiClusterWrapper.getChildRegionList().get(0);
+    multiClusterVenice = multiColoMultiClusterWrapper.getChildRegions().get(0);
     clusterNames = multiClusterVenice.getClusterNames();
     parentControllerURLs = multiColoMultiClusterWrapper.getParentControllers()
         .stream()

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/DataRecoveryTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/DataRecoveryTest.java
@@ -110,7 +110,7 @@ public class DataRecoveryTest {
         Optional.of(controllerProps),
         Optional.of(new VeniceProperties(serverProperties)),
         false);
-    childDatacenters = multiColoMultiClusterWrapper.getChildRegionList();
+    childDatacenters = multiColoMultiClusterWrapper.getChildRegions();
     parentControllers = multiColoMultiClusterWrapper.getParentControllers();
     clusterName = CLUSTER_NAMES[0];
   }

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/DataRecoveryTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/DataRecoveryTest.java
@@ -57,7 +57,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.apache.samza.config.MapConfig;
 import org.apache.samza.system.SystemProducer;
@@ -111,7 +110,7 @@ public class DataRecoveryTest {
         Optional.of(controllerProps),
         Optional.of(new VeniceProperties(serverProperties)),
         false);
-    childDatacenters = multiColoMultiClusterWrapper.getClusters();
+    childDatacenters = multiColoMultiClusterWrapper.getChildColoList();
     parentControllers = multiColoMultiClusterWrapper.getParentControllers();
     clusterName = CLUSTER_NAMES[0];
   }
@@ -124,8 +123,7 @@ public class DataRecoveryTest {
   @Test(timeOut = TEST_TIMEOUT)
   public void testStartDataRecoveryAPIs() {
     String storeName = Utils.getUniqueString("dataRecovery-store");
-    String parentControllerURLs =
-        parentControllers.stream().map(VeniceControllerWrapper::getControllerUrl).collect(Collectors.joining(","));
+    String parentControllerURLs = multiColoMultiClusterWrapper.getControllerConnectString();
 
     try (ControllerClient parentControllerClient = new ControllerClient(clusterName, parentControllerURLs);
         ControllerClient dc0Client =
@@ -180,8 +178,7 @@ public class DataRecoveryTest {
   @Test(timeOut = TEST_TIMEOUT)
   public void testBatchOnlyDataRecovery() throws Exception {
     String storeName = Utils.getUniqueString("dataRecovery-store-batch");
-    String parentControllerURLs =
-        parentControllers.stream().map(VeniceControllerWrapper::getControllerUrl).collect(Collectors.joining(","));
+    String parentControllerURLs = multiColoMultiClusterWrapper.getControllerConnectString();
     try (ControllerClient parentControllerClient = new ControllerClient(clusterName, parentControllerURLs);
         ControllerClient dc0Client =
             new ControllerClient(clusterName, childDatacenters.get(0).getControllerConnectString());
@@ -255,8 +252,7 @@ public class DataRecoveryTest {
   @Test(timeOut = TEST_TIMEOUT * 2)
   public void testHybridAADataRecovery() throws Exception {
     String storeName = Utils.getUniqueString("dataRecovery-store-hybrid-AA");
-    String parentControllerURLs =
-        parentControllers.stream().map(VeniceControllerWrapper::getControllerUrl).collect(Collectors.joining(","));
+    String parentControllerURLs = multiColoMultiClusterWrapper.getControllerConnectString();
     try (ControllerClient parentControllerClient = new ControllerClient(clusterName, parentControllerURLs);
         ControllerClient dc0Client =
             new ControllerClient(clusterName, childDatacenters.get(0).getControllerConnectString());

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/DataRecoveryTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/DataRecoveryTest.java
@@ -110,7 +110,7 @@ public class DataRecoveryTest {
         Optional.of(controllerProps),
         Optional.of(new VeniceProperties(serverProperties)),
         false);
-    childDatacenters = multiColoMultiClusterWrapper.getChildColoList();
+    childDatacenters = multiColoMultiClusterWrapper.getChildRegionList();
     parentControllers = multiColoMultiClusterWrapper.getParentControllers();
     clusterName = CLUSTER_NAMES[0];
   }

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/OneTouchDataRecoveryTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/OneTouchDataRecoveryTest.java
@@ -69,7 +69,7 @@ public class OneTouchDataRecoveryTest {
         Optional.of(new VeniceProperties(serverProperties)),
         false);
 
-    childDatacenters = multiColoMultiClusterWrapper.getClusters();
+    childDatacenters = multiColoMultiClusterWrapper.getChildRegionList();
     parentControllers = multiColoMultiClusterWrapper.getParentControllers();
   }
 

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/OneTouchDataRecoveryTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/OneTouchDataRecoveryTest.java
@@ -69,7 +69,7 @@ public class OneTouchDataRecoveryTest {
         Optional.of(new VeniceProperties(serverProperties)),
         false);
 
-    childDatacenters = multiColoMultiClusterWrapper.getChildRegionList();
+    childDatacenters = multiColoMultiClusterWrapper.getChildRegions();
     parentControllers = multiColoMultiClusterWrapper.getParentControllers();
   }
 

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/PartialUpdateTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/PartialUpdateTest.java
@@ -41,8 +41,8 @@ import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.schema.writecompute.WriteComputeSchemaConverter;
 import com.linkedin.venice.utils.DataProviderUtils;
+import com.linkedin.venice.utils.IntegrationTestPushUtils;
 import com.linkedin.venice.utils.TestUtils;
-import com.linkedin.venice.utils.TestWriteUtils;
 import com.linkedin.venice.utils.Time;
 import com.linkedin.venice.utils.Utils;
 import com.linkedin.venice.utils.VeniceProperties;
@@ -104,7 +104,7 @@ public class PartialUpdateTest {
         Optional.of(new Properties(controllerProps)),
         Optional.of(new VeniceProperties(serverProperties)),
         false);
-    this.childDatacenters = multiColoMultiClusterWrapper.getClusters();
+    this.childDatacenters = multiColoMultiClusterWrapper.getChildColoList();
     List<VeniceControllerWrapper> parentControllers = multiColoMultiClusterWrapper.getParentControllers();
     if (parentControllers.size() != 1) {
       throw new IllegalStateException("Expect only one parent controller. Got: " + parentControllers.size());
@@ -199,7 +199,7 @@ public class PartialUpdateTest {
     ByteBuffer rmdKeyByteBuffer = ByteBuffer.wrap(
         ChunkingUtils.KEY_WITH_CHUNKING_SUFFIX_SERIALIZER.serializeNonChunkedKey(serializeStringKeyToByteArray(key)));
     String kafkaTopic = Version.composeKafkaTopic(storeName, 1);
-    for (VeniceServerWrapper serverWrapper: multiColoMultiClusterWrapper.getClusters()
+    for (VeniceServerWrapper serverWrapper: multiColoMultiClusterWrapper.getChildColoList()
         .get(0)
         .getClusters()
         .get("venice-cluster0")
@@ -338,7 +338,8 @@ public class PartialUpdateTest {
       // Records 1-100, id string to name record
       Schema recordSchema = writeSimpleAvroFileWithStringToRecordSchema(inputDir, true);
       VeniceClusterWrapper veniceClusterWrapper = childDatacenters.get(0).getClusters().get(CLUSTER_NAME);
-      Properties vpjProperties = TestWriteUtils.defaultVPJProps(parentControllerURL, inputDirPath, storeName);
+      Properties vpjProperties =
+          IntegrationTestPushUtils.defaultVPJProps(multiColoMultiClusterWrapper, inputDirPath, storeName);
       try (ControllerClient controllerClient = new ControllerClient(CLUSTER_NAME, parentControllerURL);
           AvroGenericStoreClient<Object, Object> storeReader = ClientFactory.getAndStartGenericAvroClient(
               ClientConfig.defaultGenericClientConfig(storeName)

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/PartialUpdateTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/PartialUpdateTest.java
@@ -104,7 +104,7 @@ public class PartialUpdateTest {
         Optional.of(new Properties(controllerProps)),
         Optional.of(new VeniceProperties(serverProperties)),
         false);
-    this.childDatacenters = multiColoMultiClusterWrapper.getChildColoList();
+    this.childDatacenters = multiColoMultiClusterWrapper.getChildRegionList();
     List<VeniceControllerWrapper> parentControllers = multiColoMultiClusterWrapper.getParentControllers();
     if (parentControllers.size() != 1) {
       throw new IllegalStateException("Expect only one parent controller. Got: " + parentControllers.size());
@@ -199,7 +199,7 @@ public class PartialUpdateTest {
     ByteBuffer rmdKeyByteBuffer = ByteBuffer.wrap(
         ChunkingUtils.KEY_WITH_CHUNKING_SUFFIX_SERIALIZER.serializeNonChunkedKey(serializeStringKeyToByteArray(key)));
     String kafkaTopic = Version.composeKafkaTopic(storeName, 1);
-    for (VeniceServerWrapper serverWrapper: multiColoMultiClusterWrapper.getChildColoList()
+    for (VeniceServerWrapper serverWrapper: multiColoMultiClusterWrapper.getChildRegionList()
         .get(0)
         .getClusters()
         .get("venice-cluster0")

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/PartialUpdateTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/PartialUpdateTest.java
@@ -104,7 +104,7 @@ public class PartialUpdateTest {
         Optional.of(new Properties(controllerProps)),
         Optional.of(new VeniceProperties(serverProperties)),
         false);
-    this.childDatacenters = multiColoMultiClusterWrapper.getChildRegionList();
+    this.childDatacenters = multiColoMultiClusterWrapper.getChildRegions();
     List<VeniceControllerWrapper> parentControllers = multiColoMultiClusterWrapper.getParentControllers();
     if (parentControllers.size() != 1) {
       throw new IllegalStateException("Expect only one parent controller. Got: " + parentControllers.size());
@@ -199,7 +199,7 @@ public class PartialUpdateTest {
     ByteBuffer rmdKeyByteBuffer = ByteBuffer.wrap(
         ChunkingUtils.KEY_WITH_CHUNKING_SUFFIX_SERIALIZER.serializeNonChunkedKey(serializeStringKeyToByteArray(key)));
     String kafkaTopic = Version.composeKafkaTopic(storeName, 1);
-    for (VeniceServerWrapper serverWrapper: multiColoMultiClusterWrapper.getChildRegionList()
+    for (VeniceServerWrapper serverWrapper: multiColoMultiClusterWrapper.getChildRegions()
         .get(0)
         .getClusters()
         .get("venice-cluster0")

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/PushJobDetailsTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/PushJobDetailsTest.java
@@ -114,7 +114,7 @@ public class PushJobDetailsTest {
         false);
     String clusterName = multiColoMultiClusterWrapper.getClusterNames()[0];
 
-    VeniceMultiClusterWrapper childColoMultiClusterWrapper = multiColoMultiClusterWrapper.getChildColoList().get(0);
+    VeniceMultiClusterWrapper childColoMultiClusterWrapper = multiColoMultiClusterWrapper.getChildRegionList().get(0);
     childColoClusterWrapper = childColoMultiClusterWrapper.getClusters().get(clusterName);
 
     controllerClient = new ControllerClient(clusterName, childColoMultiClusterWrapper.getControllerConnectString());

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/PushJobDetailsTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/PushJobDetailsTest.java
@@ -114,7 +114,7 @@ public class PushJobDetailsTest {
         false);
     String clusterName = multiColoMultiClusterWrapper.getClusterNames()[0];
 
-    VeniceMultiClusterWrapper childColoMultiClusterWrapper = multiColoMultiClusterWrapper.getChildRegionList().get(0);
+    VeniceMultiClusterWrapper childColoMultiClusterWrapper = multiColoMultiClusterWrapper.getChildRegions().get(0);
     childColoClusterWrapper = childColoMultiClusterWrapper.getClusters().get(clusterName);
 
     controllerClient = new ControllerClient(clusterName, childColoMultiClusterWrapper.getControllerConnectString());

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/PushStatusStoreMultiColoTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/PushStatusStoreMultiColoTest.java
@@ -89,7 +89,7 @@ public class PushStatusStoreMultiColoTest {
         Optional.of(extraProperties),
         Optional.empty(),
         false);
-    childDatacenters = multiColoMultiClusterWrapper.getChildColoList();
+    childDatacenters = multiColoMultiClusterWrapper.getChildRegionList();
     parentControllers = multiColoMultiClusterWrapper.getParentControllers();
 
     String[] clusterNames = childDatacenters.get(0).getClusterNames();

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/PushStatusStoreMultiColoTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/PushStatusStoreMultiColoTest.java
@@ -89,7 +89,7 @@ public class PushStatusStoreMultiColoTest {
         Optional.of(extraProperties),
         Optional.empty(),
         false);
-    childDatacenters = multiColoMultiClusterWrapper.getClusters();
+    childDatacenters = multiColoMultiClusterWrapper.getChildColoList();
     parentControllers = multiColoMultiClusterWrapper.getParentControllers();
 
     String[] clusterNames = childDatacenters.get(0).getClusterNames();

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/PushStatusStoreMultiColoTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/PushStatusStoreMultiColoTest.java
@@ -89,7 +89,7 @@ public class PushStatusStoreMultiColoTest {
         Optional.of(extraProperties),
         Optional.empty(),
         false);
-    childDatacenters = multiColoMultiClusterWrapper.getChildRegionList();
+    childDatacenters = multiColoMultiClusterWrapper.getChildRegions();
     parentControllers = multiColoMultiClusterWrapper.getParentControllers();
 
     String[] clusterNames = childDatacenters.get(0).getClusterNames();

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestActiveActiveIngestion.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestActiveActiveIngestion.java
@@ -123,7 +123,7 @@ public class TestActiveActiveIngestion {
         Optional.of(new VeniceProperties(serverProperties)),
         false);
 
-    childDatacenters = multiColoMultiClusterWrapper.getChildColoList();
+    childDatacenters = multiColoMultiClusterWrapper.getChildRegionList();
     parentControllers = multiColoMultiClusterWrapper.getParentControllers();
     clusterName = CLUSTER_NAMES[0];
     clusterWrapper = childDatacenters.get(0).getClusters().get(clusterName);

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestActiveActiveIngestion.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestActiveActiveIngestion.java
@@ -123,7 +123,7 @@ public class TestActiveActiveIngestion {
         Optional.of(new VeniceProperties(serverProperties)),
         false);
 
-    childDatacenters = multiColoMultiClusterWrapper.getChildRegionList();
+    childDatacenters = multiColoMultiClusterWrapper.getChildRegions();
     parentControllers = multiColoMultiClusterWrapper.getParentControllers();
     clusterName = CLUSTER_NAMES[0];
     clusterWrapper = childDatacenters.get(0).getClusters().get(clusterName);

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestActiveActiveIngestion.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestActiveActiveIngestion.java
@@ -52,6 +52,7 @@ import com.linkedin.venice.samza.VeniceSystemFactory;
 import com.linkedin.venice.samza.VeniceSystemProducer;
 import com.linkedin.venice.serializer.AvroSerializer;
 import com.linkedin.venice.utils.DataProviderUtils;
+import com.linkedin.venice.utils.IntegrationTestPushUtils;
 import com.linkedin.venice.utils.MockCircularTime;
 import com.linkedin.venice.utils.TestUtils;
 import com.linkedin.venice.utils.TestWriteUtils;
@@ -122,7 +123,7 @@ public class TestActiveActiveIngestion {
         Optional.of(new VeniceProperties(serverProperties)),
         false);
 
-    childDatacenters = multiColoMultiClusterWrapper.getClusters();
+    childDatacenters = multiColoMultiClusterWrapper.getChildColoList();
     parentControllers = multiColoMultiClusterWrapper.getParentControllers();
     clusterName = CLUSTER_NAMES[0];
     clusterWrapper = childDatacenters.get(0).getClusters().get(clusterName);
@@ -149,8 +150,7 @@ public class TestActiveActiveIngestion {
     Schema recordSchema = writeSimpleAvroFileWithUserSchema(inputDir);
     String inputDirPath = "file:" + inputDir.getAbsolutePath();
     String storeName = Utils.getUniqueString("store");
-    Properties props =
-        TestWriteUtils.defaultVPJProps(parentControllers.get(0).getControllerUrl(), inputDirPath, storeName);
+    Properties props = IntegrationTestPushUtils.defaultVPJProps(multiColoMultiClusterWrapper, inputDirPath, storeName);
     String keySchemaStr = recordSchema.getField(DEFAULT_KEY_FIELD_PROP).schema().toString();
     String valueSchemaStr = recordSchema.getField(DEFAULT_VALUE_FIELD_PROP).schema().toString();
     UpdateStoreQueryParams storeParms = new UpdateStoreQueryParams().setLeaderFollowerModel(true)
@@ -331,8 +331,7 @@ public class TestActiveActiveIngestion {
     Schema recordSchema = writeSimpleAvroFileWithUserSchema(inputDir);
     String inputDirPath = "file:" + inputDir.getAbsolutePath();
     String storeName = Utils.getUniqueString("store");
-    Properties props =
-        TestWriteUtils.defaultVPJProps(parentControllers.get(0).getControllerUrl(), inputDirPath, storeName);
+    Properties props = IntegrationTestPushUtils.defaultVPJProps(multiColoMultiClusterWrapper, inputDirPath, storeName);
     String keySchemaStr = recordSchema.getField(DEFAULT_KEY_FIELD_PROP).schema().toString();
     String valueSchemaStr = recordSchema.getField(DEFAULT_VALUE_FIELD_PROP).schema().toString();
     UpdateStoreQueryParams storeParms = new UpdateStoreQueryParams().setActiveActiveReplicationEnabled(true)

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestActiveActiveReplicationForIncPush.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestActiveActiveReplicationForIncPush.java
@@ -91,7 +91,7 @@ public class TestActiveActiveReplicationForIncPush {
         Optional.of(controllerProps),
         Optional.of(new VeniceProperties(serverProperties)),
         false);
-    childDatacenters = multiColoMultiClusterWrapper.getChildRegionList();
+    childDatacenters = multiColoMultiClusterWrapper.getChildRegions();
     clusterNames = multiColoMultiClusterWrapper.getClusterNames();
     parentColoName = multiColoMultiClusterWrapper.getParentRegionName();
     dcNames = multiColoMultiClusterWrapper.getChildRegionNames().toArray(new String[0]);

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestActiveActiveReplicationForIncPush.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestActiveActiveReplicationForIncPush.java
@@ -91,10 +91,10 @@ public class TestActiveActiveReplicationForIncPush {
         Optional.of(controllerProps),
         Optional.of(new VeniceProperties(serverProperties)),
         false);
-    childDatacenters = multiColoMultiClusterWrapper.getChildColoList();
+    childDatacenters = multiColoMultiClusterWrapper.getChildRegionList();
     clusterNames = multiColoMultiClusterWrapper.getClusterNames();
-    parentColoName = multiColoMultiClusterWrapper.getParentColoName();
-    dcNames = multiColoMultiClusterWrapper.getChildColoNames().toArray(new String[0]);
+    parentColoName = multiColoMultiClusterWrapper.getParentRegionName();
+    dcNames = multiColoMultiClusterWrapper.getChildRegionNames().toArray(new String[0]);
 
     veniceParentDefaultKafka = multiColoMultiClusterWrapper.getParentKafkaBrokerWrapper();
   }

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestActiveActiveReplicationWithDownColo.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestActiveActiveReplicationWithDownColo.java
@@ -108,7 +108,7 @@ public class TestActiveActiveReplicationWithDownColo {
         Optional.of(controllerProps),
         Optional.of(new VeniceProperties(serverProperties)),
         false);
-    childDatacenters = multiColoMultiClusterWrapper.getChildRegionList();
+    childDatacenters = multiColoMultiClusterWrapper.getChildRegions();
     parentControllers = multiColoMultiClusterWrapper.getParentControllers();
   }
 
@@ -133,8 +133,8 @@ public class TestActiveActiveReplicationWithDownColo {
     // These variable don't do anything other than to make it easy to find their values in the debugger so you can hook
     // up ZooInspector and figure which colo is assigned where
     int zkPort = multiColoMultiClusterWrapper.getZkServerWrapper().getPort();
-    int dc0Kafka = multiColoMultiClusterWrapper.getChildRegionList().get(0).getKafkaBrokerWrapper().getPort();
-    int dc1kafka = multiColoMultiClusterWrapper.getChildRegionList().get(1).getKafkaBrokerWrapper().getPort();
+    int dc0Kafka = multiColoMultiClusterWrapper.getChildRegions().get(0).getKafkaBrokerWrapper().getPort();
+    int dc1kafka = multiColoMultiClusterWrapper.getChildRegions().get(1).getKafkaBrokerWrapper().getPort();
 
     // Spotbug doesn't like unused variables. Given they are assigned for debugging purposes, print them out.
     LOGGER.info("zkPort: {}", zkPort);
@@ -261,10 +261,7 @@ public class TestActiveActiveReplicationWithDownColo {
     // should succeed in the OTHER colos and go live.
 
     // It's simple, we kill the kafka broker
-    multiColoMultiClusterWrapper.getChildRegionList()
-        .get(NUMBER_OF_CHILD_DATACENTERS - 1)
-        .getKafkaBrokerWrapper()
-        .close();
+    multiColoMultiClusterWrapper.getChildRegions().get(NUMBER_OF_CHILD_DATACENTERS - 1).getKafkaBrokerWrapper().close();
 
     // Execute a new push by writing some rows and sending an endOfPushMessage
     try (ControllerClient parentControllerClient = new ControllerClient(clusterName, parentControllerUrls)) {

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestActiveActiveReplicationWithDownColo.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestActiveActiveReplicationWithDownColo.java
@@ -108,7 +108,7 @@ public class TestActiveActiveReplicationWithDownColo {
         Optional.of(controllerProps),
         Optional.of(new VeniceProperties(serverProperties)),
         false);
-    childDatacenters = multiColoMultiClusterWrapper.getChildColoList();
+    childDatacenters = multiColoMultiClusterWrapper.getChildRegionList();
     parentControllers = multiColoMultiClusterWrapper.getParentControllers();
   }
 
@@ -133,8 +133,8 @@ public class TestActiveActiveReplicationWithDownColo {
     // These variable don't do anything other than to make it easy to find their values in the debugger so you can hook
     // up ZooInspector and figure which colo is assigned where
     int zkPort = multiColoMultiClusterWrapper.getZkServerWrapper().getPort();
-    int dc0Kafka = multiColoMultiClusterWrapper.getChildColoList().get(0).getKafkaBrokerWrapper().getPort();
-    int dc1kafka = multiColoMultiClusterWrapper.getChildColoList().get(1).getKafkaBrokerWrapper().getPort();
+    int dc0Kafka = multiColoMultiClusterWrapper.getChildRegionList().get(0).getKafkaBrokerWrapper().getPort();
+    int dc1kafka = multiColoMultiClusterWrapper.getChildRegionList().get(1).getKafkaBrokerWrapper().getPort();
 
     // Spotbug doesn't like unused variables. Given they are assigned for debugging purposes, print them out.
     LOGGER.info("zkPort: {}", zkPort);
@@ -261,7 +261,7 @@ public class TestActiveActiveReplicationWithDownColo {
     // should succeed in the OTHER colos and go live.
 
     // It's simple, we kill the kafka broker
-    multiColoMultiClusterWrapper.getChildColoList()
+    multiColoMultiClusterWrapper.getChildRegionList()
         .get(NUMBER_OF_CHILD_DATACENTERS - 1)
         .getKafkaBrokerWrapper()
         .close();

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestHybridQuota.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestHybridQuota.java
@@ -137,6 +137,8 @@ public class TestHybridQuota {
               .setChunkingEnabled(chunkingEnabled)
               .setHybridStoreDiskQuotaEnabled(true));
 
+      Assert.assertFalse(response.isError());
+
       HelixAdmin helixAdmin = null;
       try {
         helixAdmin = new ZKHelixAdmin(sharedVenice.getZk().getAddress());
@@ -146,7 +148,6 @@ public class TestHybridQuota {
           helixAdmin.close();
         }
       }
-      Assert.assertFalse(response.isError());
 
       readManager = new SafeHelixManager(
           HelixManagerFactory.getZKHelixManager(

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestMultiDataCenterAdminOperations.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestMultiDataCenterAdminOperations.java
@@ -73,7 +73,7 @@ public class TestMultiDataCenterAdminOperations {
         Optional.of(new VeniceProperties(serverProperties)),
         false);
 
-    childClusters = multiColoMultiClusterWrapper.getChildRegionList();
+    childClusters = multiColoMultiClusterWrapper.getChildRegions();
     childControllers = childClusters.stream()
         .map(veniceClusterWrapper -> new ArrayList<>(veniceClusterWrapper.getControllers().values()))
         .collect(Collectors.toList());

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestMultiDataCenterAdminOperations.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestMultiDataCenterAdminOperations.java
@@ -73,7 +73,7 @@ public class TestMultiDataCenterAdminOperations {
         Optional.of(new VeniceProperties(serverProperties)),
         false);
 
-    childClusters = multiColoMultiClusterWrapper.getClusters();
+    childClusters = multiColoMultiClusterWrapper.getChildColoList();
     childControllers = childClusters.stream()
         .map(veniceClusterWrapper -> new ArrayList<>(veniceClusterWrapper.getControllers().values()))
         .collect(Collectors.toList());
@@ -105,8 +105,7 @@ public class TestMultiDataCenterAdminOperations {
   public void testHybridConfigPartitionerConfigConflict() {
     String clusterName = CLUSTER_NAMES[0];
     String storeName = Utils.getUniqueString("store");
-    String parentControllerUrl =
-        parentControllers.stream().map(VeniceControllerWrapper::getControllerUrl).collect(Collectors.joining(","));
+    String parentControllerUrl = multiColoMultiClusterWrapper.getControllerConnectString();
 
     // Create store first
     ControllerClient controllerClient = new ControllerClient(clusterName, parentControllerUrl);

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestMultiDataCenterAdminOperations.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestMultiDataCenterAdminOperations.java
@@ -73,7 +73,7 @@ public class TestMultiDataCenterAdminOperations {
         Optional.of(new VeniceProperties(serverProperties)),
         false);
 
-    childClusters = multiColoMultiClusterWrapper.getChildColoList();
+    childClusters = multiColoMultiClusterWrapper.getChildRegionList();
     childControllers = childClusters.stream()
         .map(veniceClusterWrapper -> new ArrayList<>(veniceClusterWrapper.getControllers().values()))
         .collect(Collectors.toList());

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestPushJobVersionCleanup.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestPushJobVersionCleanup.java
@@ -65,7 +65,7 @@ public class TestPushJobVersionCleanup {
         Optional.of(controllerProps),
         Optional.of(new VeniceProperties(serverProperties)),
         false);
-    childDatacenters = multiColoMultiClusterWrapper.getChildColoList();
+    childDatacenters = multiColoMultiClusterWrapper.getChildRegionList();
   }
 
   @AfterClass(alwaysRun = true)

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestPushJobVersionCleanup.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestPushJobVersionCleanup.java
@@ -65,7 +65,7 @@ public class TestPushJobVersionCleanup {
         Optional.of(controllerProps),
         Optional.of(new VeniceProperties(serverProperties)),
         false);
-    childDatacenters = multiColoMultiClusterWrapper.getChildRegionList();
+    childDatacenters = multiColoMultiClusterWrapper.getChildRegions();
   }
 
   @AfterClass(alwaysRun = true)

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestPushJobWithEmergencySourceRegionSelection.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestPushJobWithEmergencySourceRegionSelection.java
@@ -106,7 +106,7 @@ public class TestPushJobWithEmergencySourceRegionSelection {
         Optional.of(controllerProps),
         Optional.of(new VeniceProperties(serverProperties)),
         false);
-    childDatacenters = multiColoMultiClusterWrapper.getChildColoList();
+    childDatacenters = multiColoMultiClusterWrapper.getChildRegionList();
     parentControllers = multiColoMultiClusterWrapper.getParentControllers();
   }
 

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestPushJobWithEmergencySourceRegionSelection.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestPushJobWithEmergencySourceRegionSelection.java
@@ -106,7 +106,7 @@ public class TestPushJobWithEmergencySourceRegionSelection {
         Optional.of(controllerProps),
         Optional.of(new VeniceProperties(serverProperties)),
         false);
-    childDatacenters = multiColoMultiClusterWrapper.getChildRegionList();
+    childDatacenters = multiColoMultiClusterWrapper.getChildRegions();
     parentControllers = multiColoMultiClusterWrapper.getParentControllers();
   }
 

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestPushJobWithEmergencySourceRegionSelection.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestPushJobWithEmergencySourceRegionSelection.java
@@ -27,6 +27,7 @@ import com.linkedin.venice.integration.utils.VeniceControllerWrapper;
 import com.linkedin.venice.integration.utils.VeniceMultiClusterWrapper;
 import com.linkedin.venice.integration.utils.VeniceTwoLayerMultiColoMultiClusterWrapper;
 import com.linkedin.venice.meta.Store;
+import com.linkedin.venice.utils.IntegrationTestPushUtils;
 import com.linkedin.venice.utils.TestUtils;
 import com.linkedin.venice.utils.TestWriteUtils;
 import com.linkedin.venice.utils.Utils;
@@ -36,7 +37,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.apache.avro.Schema;
 import org.apache.logging.log4j.LogManager;
@@ -106,7 +106,7 @@ public class TestPushJobWithEmergencySourceRegionSelection {
         Optional.of(controllerProps),
         Optional.of(new VeniceProperties(serverProperties)),
         false);
-    childDatacenters = multiColoMultiClusterWrapper.getClusters();
+    childDatacenters = multiColoMultiClusterWrapper.getChildColoList();
     parentControllers = multiColoMultiClusterWrapper.getParentControllers();
   }
 
@@ -126,9 +126,8 @@ public class TestPushJobWithEmergencySourceRegionSelection {
     Schema recordSchema = TestWriteUtils.writeSimpleAvroFileWithUserSchema(inputDir, true, recordCount);
     String inputDirPath = "file:" + inputDir.getAbsolutePath();
     String storeName = Utils.getUniqueString("store");
-    String parentControllerUrls =
-        parentControllers.stream().map(VeniceControllerWrapper::getControllerUrl).collect(Collectors.joining(","));
-    Properties props = TestWriteUtils.defaultVPJProps(parentControllerUrls, inputDirPath, storeName);
+    String parentControllerUrls = multiColoMultiClusterWrapper.getControllerConnectString();
+    Properties props = IntegrationTestPushUtils.defaultVPJProps(multiColoMultiClusterWrapper, inputDirPath, storeName);
     props.put(SEND_CONTROL_MESSAGES_DIRECTLY, true);
     String keySchemaStr = recordSchema.getField(DEFAULT_KEY_FIELD_PROP).schema().toString();
     String valueSchemaStr = recordSchema.getField(DEFAULT_VALUE_FIELD_PROP).schema().toString();

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestPushJobWithNativeReplication.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestPushJobWithNativeReplication.java
@@ -168,7 +168,7 @@ public class TestPushJobWithNativeReplication {
         Optional.of(controllerProps),
         Optional.of(new VeniceProperties(serverProperties)),
         false);
-    childDatacenters = multiColoMultiClusterWrapper.getChildColoList();
+    childDatacenters = multiColoMultiClusterWrapper.getChildRegionList();
     parentControllers = multiColoMultiClusterWrapper.getParentControllers();
   }
 

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestPushJobWithNativeReplication.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestPushJobWithNativeReplication.java
@@ -168,7 +168,7 @@ public class TestPushJobWithNativeReplication {
         Optional.of(controllerProps),
         Optional.of(new VeniceProperties(serverProperties)),
         false);
-    childDatacenters = multiColoMultiClusterWrapper.getChildRegionList();
+    childDatacenters = multiColoMultiClusterWrapper.getChildRegions();
     parentControllers = multiColoMultiClusterWrapper.getParentControllers();
   }
 

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestPushJobWithNativeReplicationSharedProducer.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestPushJobWithNativeReplicationSharedProducer.java
@@ -24,6 +24,7 @@ import com.linkedin.venice.integration.utils.VeniceControllerWrapper;
 import com.linkedin.venice.integration.utils.VeniceMultiClusterWrapper;
 import com.linkedin.venice.integration.utils.VeniceTwoLayerMultiColoMultiClusterWrapper;
 import com.linkedin.venice.meta.Store;
+import com.linkedin.venice.utils.IntegrationTestPushUtils;
 import com.linkedin.venice.utils.TestUtils;
 import com.linkedin.venice.utils.TestWriteUtils;
 import com.linkedin.venice.utils.Utils;
@@ -34,7 +35,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.apache.avro.Schema;
 import org.apache.commons.io.FileUtils;
@@ -106,7 +106,7 @@ public class TestPushJobWithNativeReplicationSharedProducer {
         Optional.of(controllerProps),
         Optional.of(new VeniceProperties(serverProperties)),
         false);
-    childDatacenters = multiColoMultiClusterWrapper.getClusters();
+    childDatacenters = multiColoMultiClusterWrapper.getChildColoList();
     parentControllers = multiColoMultiClusterWrapper.getParentControllers();
   }
 
@@ -125,15 +125,15 @@ public class TestPushJobWithNativeReplicationSharedProducer {
 
     String clusterName = CLUSTER_NAMES[0];
     File inputDir = getTempDataDirectory();
-    String parentControllerUrls =
-        parentControllers.stream().map(VeniceControllerWrapper::getControllerUrl).collect(Collectors.joining(","));
+    String parentControllerUrls = multiColoMultiClusterWrapper.getControllerConnectString();
     String inputDirPath = "file:" + inputDir.getAbsolutePath();
 
     try {
       for (int i = 0; i < storeCount; i++) {
         String storeName = Utils.getUniqueString("store");
         storeNames[i] = storeName;
-        Properties props = TestWriteUtils.defaultVPJProps(parentControllerUrls, inputDirPath, storeName);
+        Properties props =
+            IntegrationTestPushUtils.defaultVPJProps(multiColoMultiClusterWrapper, inputDirPath, storeName);
         storeProps[i] = props;
         props.put(SEND_CONTROL_MESSAGES_DIRECTLY, true);
 

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestPushJobWithNativeReplicationSharedProducer.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestPushJobWithNativeReplicationSharedProducer.java
@@ -106,7 +106,7 @@ public class TestPushJobWithNativeReplicationSharedProducer {
         Optional.of(controllerProps),
         Optional.of(new VeniceProperties(serverProperties)),
         false);
-    childDatacenters = multiColoMultiClusterWrapper.getChildRegionList();
+    childDatacenters = multiColoMultiClusterWrapper.getChildRegions();
     parentControllers = multiColoMultiClusterWrapper.getParentControllers();
   }
 

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestPushJobWithNativeReplicationSharedProducer.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestPushJobWithNativeReplicationSharedProducer.java
@@ -106,7 +106,7 @@ public class TestPushJobWithNativeReplicationSharedProducer {
         Optional.of(controllerProps),
         Optional.of(new VeniceProperties(serverProperties)),
         false);
-    childDatacenters = multiColoMultiClusterWrapper.getChildColoList();
+    childDatacenters = multiColoMultiClusterWrapper.getChildRegionList();
     parentControllers = multiColoMultiClusterWrapper.getParentControllers();
   }
 

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestPushJobWithSourceGridFabricSelection.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestPushJobWithSourceGridFabricSelection.java
@@ -89,7 +89,7 @@ public class TestPushJobWithSourceGridFabricSelection {
         Optional.of(controllerProps),
         Optional.of(new VeniceProperties(serverProperties)),
         false);
-    childDatacenters = multiColoMultiClusterWrapper.getChildRegionList();
+    childDatacenters = multiColoMultiClusterWrapper.getChildRegions();
     parentControllerRegionName = multiColoMultiClusterWrapper.getParentRegionName() + ".parent";
     clusterNames = multiColoMultiClusterWrapper.getClusterNames();
     dcNames = multiColoMultiClusterWrapper.getChildRegionNames().toArray(new String[0]);

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestPushJobWithSourceGridFabricSelection.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestPushJobWithSourceGridFabricSelection.java
@@ -22,13 +22,14 @@ import com.linkedin.venice.controllerapi.ControllerClient;
 import com.linkedin.venice.controllerapi.UpdateStoreQueryParams;
 import com.linkedin.venice.hadoop.VenicePushJob;
 import com.linkedin.venice.integration.utils.ServiceFactory;
-import com.linkedin.venice.integration.utils.VeniceControllerWrapper;
 import com.linkedin.venice.integration.utils.VeniceMultiClusterWrapper;
 import com.linkedin.venice.integration.utils.VeniceTwoLayerMultiColoMultiClusterWrapper;
 import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.VeniceUserStoreType;
+import com.linkedin.venice.utils.IntegrationTestPushUtils;
 import com.linkedin.venice.utils.TestUtils;
 import com.linkedin.venice.utils.TestWriteUtils;
+import com.linkedin.venice.utils.Time;
 import com.linkedin.venice.utils.Utils;
 import com.linkedin.venice.utils.VeniceProperties;
 import java.io.File;
@@ -36,8 +37,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 import org.apache.avro.Schema;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
@@ -47,17 +46,15 @@ import org.testng.annotations.Test;
 
 
 public class TestPushJobWithSourceGridFabricSelection {
-  private static final int TEST_TIMEOUT_MS = 90_000; // 90 seconds
+  private static final int TEST_TIMEOUT_MS = 90 * Time.MS_PER_SECOND;
 
   private static final int NUMBER_OF_CHILD_DATACENTERS = 2;
   private static final int NUMBER_OF_CLUSTERS = 1;
-  private static final String[] CLUSTER_NAMES =
-      IntStream.range(0, NUMBER_OF_CLUSTERS).mapToObj(i -> "venice-cluster" + i).toArray(String[]::new); // ["venice-cluster0",
-                                                                                                         // "venice-cluster1",
-                                                                                                         // ...];
+  private String[] clusterNames;
+  private String parentControllerRegionName;
+  private String[] dcNames;
 
   private List<VeniceMultiClusterWrapper> childDatacenters;
-  private List<VeniceControllerWrapper> parentControllers;
   private VeniceTwoLayerMultiColoMultiClusterWrapper multiColoMultiClusterWrapper;
 
   @DataProvider(name = "storeSize")
@@ -92,8 +89,10 @@ public class TestPushJobWithSourceGridFabricSelection {
         Optional.of(controllerProps),
         Optional.of(new VeniceProperties(serverProperties)),
         false);
-    childDatacenters = multiColoMultiClusterWrapper.getClusters();
-    parentControllers = multiColoMultiClusterWrapper.getParentControllers();
+    childDatacenters = multiColoMultiClusterWrapper.getChildColoList();
+    parentControllerRegionName = multiColoMultiClusterWrapper.getParentColoName() + ".parent";
+    clusterNames = multiColoMultiClusterWrapper.getClusterNames();
+    dcNames = multiColoMultiClusterWrapper.getChildColoNames().toArray(new String[0]);
   }
 
   @AfterClass(alwaysRun = true)
@@ -106,13 +105,12 @@ public class TestPushJobWithSourceGridFabricSelection {
    */
   @Test(timeOut = TEST_TIMEOUT_MS, dataProvider = "storeSize")
   public void testPushJobWithSourceGridFabricSelection(int recordCount, int partitionCount) throws Exception {
-    String clusterName = CLUSTER_NAMES[0];
+    String clusterName = clusterNames[0];
     File inputDir = getTempDataDirectory();
     Schema recordSchema = TestWriteUtils.writeSimpleAvroFileWithUserSchema(inputDir, true, recordCount);
     String inputDirPath = "file:" + inputDir.getAbsolutePath();
     String storeName = Utils.getUniqueString("store");
-    String parentControllerUrls =
-        parentControllers.stream().map(VeniceControllerWrapper::getControllerUrl).collect(Collectors.joining(","));
+    String parentControllerUrls = multiColoMultiClusterWrapper.getControllerConnectString();
 
     // Enable NR in all colos and A/A in parent colo and 1 child colo only. The NR source fabric cluster level config is
     // dc-0 by default.
@@ -123,20 +121,20 @@ public class TestPushJobWithSourceGridFabricSelection {
                   true,
                   VeniceUserStoreType.BATCH_ONLY.toString(),
                   Optional.empty(),
-                  Optional.of("dc-parent-0.parent,dc-0,dc-1"))
+                  Optional.of(String.join(",", parentControllerRegionName, dcNames[0], dcNames[1])))
               .isError());
       Assert.assertFalse(
           parentControllerClient
               .configureActiveActiveReplicationForCluster(
                   true,
                   VeniceUserStoreType.BATCH_ONLY.toString(),
-                  Optional.of("dc-parent-0.parent,dc-0"))
+                  Optional.of(String.join(",", parentControllerRegionName, dcNames[0])))
               .isError());
     }
 
-    Properties props = TestWriteUtils.defaultVPJProps(parentControllerUrls, inputDirPath, storeName);
+    Properties props = IntegrationTestPushUtils.defaultVPJProps(multiColoMultiClusterWrapper, inputDirPath, storeName);
     props.put(SEND_CONTROL_MESSAGES_DIRECTLY, true);
-    props.put(SOURCE_GRID_FABRIC, "dc-1");
+    props.put(SOURCE_GRID_FABRIC, dcNames[1]);
 
     String keySchemaStr = recordSchema.getField(DEFAULT_KEY_FIELD_PROP).schema().toString();
     String valueSchemaStr = recordSchema.getField(DEFAULT_VALUE_FIELD_PROP).schema().toString();
@@ -147,7 +145,7 @@ public class TestPushJobWithSourceGridFabricSelection {
             .setPartitionCount(partitionCount)
             .setLeaderFollowerModel(true)
             .setNativeReplicationEnabled(true)
-            .setNativeReplicationSourceFabric("dc-0");
+            .setNativeReplicationSourceFabric(dcNames[0]);
 
     createStoreForJob(clusterName, keySchemaStr, valueSchemaStr, props, updateStoreParams).close();
 
@@ -167,7 +165,7 @@ public class TestPushJobWithSourceGridFabricSelection {
               .configureActiveActiveReplicationForCluster(
                   true,
                   VeniceUserStoreType.BATCH_ONLY.toString(),
-                  Optional.of("dc-parent-0.parent,dc-0,dc-1"))
+                  Optional.of(String.join(",", parentControllerRegionName, dcNames[0], dcNames[1])))
               .isError());
     }
 

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestPushJobWithSourceGridFabricSelection.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestPushJobWithSourceGridFabricSelection.java
@@ -89,10 +89,10 @@ public class TestPushJobWithSourceGridFabricSelection {
         Optional.of(controllerProps),
         Optional.of(new VeniceProperties(serverProperties)),
         false);
-    childDatacenters = multiColoMultiClusterWrapper.getChildColoList();
-    parentControllerRegionName = multiColoMultiClusterWrapper.getParentColoName() + ".parent";
+    childDatacenters = multiColoMultiClusterWrapper.getChildRegionList();
+    parentControllerRegionName = multiColoMultiClusterWrapper.getParentRegionName() + ".parent";
     clusterNames = multiColoMultiClusterWrapper.getClusterNames();
-    dcNames = multiColoMultiClusterWrapper.getChildColoNames().toArray(new String[0]);
+    dcNames = multiColoMultiClusterWrapper.getChildRegionNames().toArray(new String[0]);
   }
 
   @AfterClass(alwaysRun = true)

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestStaleDataVisibility.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestStaleDataVisibility.java
@@ -72,7 +72,7 @@ public class TestStaleDataVisibility {
         Optional.of(new VeniceProperties(serverProperties)),
         false);
 
-    childClusters = multiColoMultiClusterWrapper.getChildColoList();
+    childClusters = multiColoMultiClusterWrapper.getChildRegionList();
     childControllers = childClusters.stream()
         .map(veniceClusterWrapper -> new ArrayList<>(veniceClusterWrapper.getControllers().values()))
         .collect(Collectors.toList());
@@ -136,7 +136,7 @@ public class TestStaleDataVisibility {
 
       // get single child controller, empty push to it
       Properties props2 = IntegrationTestPushUtils
-          .defaultVPJProps(multiColoMultiClusterWrapper.getChildColoList().get(0), inputDirPath, storeName);
+          .defaultVPJProps(multiColoMultiClusterWrapper.getChildRegionList().get(0), inputDirPath, storeName);
       try (VenicePushJob job = new VenicePushJob("Test push job", props2)) {
         job.run();
       }

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestStaleDataVisibility.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestStaleDataVisibility.java
@@ -72,7 +72,7 @@ public class TestStaleDataVisibility {
         Optional.of(new VeniceProperties(serverProperties)),
         false);
 
-    childClusters = multiColoMultiClusterWrapper.getChildRegionList();
+    childClusters = multiColoMultiClusterWrapper.getChildRegions();
     childControllers = childClusters.stream()
         .map(veniceClusterWrapper -> new ArrayList<>(veniceClusterWrapper.getControllers().values()))
         .collect(Collectors.toList());
@@ -136,7 +136,7 @@ public class TestStaleDataVisibility {
 
       // get single child controller, empty push to it
       Properties props2 = IntegrationTestPushUtils
-          .defaultVPJProps(multiColoMultiClusterWrapper.getChildRegionList().get(0), inputDirPath, storeName);
+          .defaultVPJProps(multiColoMultiClusterWrapper.getChildRegions().get(0), inputDirPath, storeName);
       try (VenicePushJob job = new VenicePushJob("Test push job", props2)) {
         job.run();
       }

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestStoreGraveyardCleanupService.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestStoreGraveyardCleanupService.java
@@ -63,7 +63,7 @@ public class TestStoreGraveyardCleanupService {
         Optional.of(new VeniceProperties(serverProperties)),
         false);
 
-    childDatacenters = multiColoMultiClusterWrapper.getChildRegionList();
+    childDatacenters = multiColoMultiClusterWrapper.getChildRegions();
     parentControllers = multiColoMultiClusterWrapper.getParentControllers();
   }
 

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestStoreGraveyardCleanupService.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestStoreGraveyardCleanupService.java
@@ -63,7 +63,7 @@ public class TestStoreGraveyardCleanupService {
         Optional.of(new VeniceProperties(serverProperties)),
         false);
 
-    childDatacenters = multiColoMultiClusterWrapper.getChildColoList();
+    childDatacenters = multiColoMultiClusterWrapper.getChildRegionList();
     parentControllers = multiColoMultiClusterWrapper.getParentControllers();
   }
 

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestStoreGraveyardCleanupService.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestStoreGraveyardCleanupService.java
@@ -63,7 +63,7 @@ public class TestStoreGraveyardCleanupService {
         Optional.of(new VeniceProperties(serverProperties)),
         false);
 
-    childDatacenters = multiColoMultiClusterWrapper.getClusters();
+    childDatacenters = multiColoMultiClusterWrapper.getChildColoList();
     parentControllers = multiColoMultiClusterWrapper.getParentControllers();
   }
 

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestStoreMigration.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestStoreMigration.java
@@ -137,7 +137,7 @@ public class TestStoreMigration {
         Optional.of(new VeniceProperties(serverProperties)),
         true);
 
-    multiClusterWrapper = twoLayerMultiColoMultiClusterWrapper.getChildColoList().get(0);
+    multiClusterWrapper = twoLayerMultiColoMultiClusterWrapper.getChildRegionList().get(0);
     String[] clusterNames = multiClusterWrapper.getClusterNames();
     Arrays.sort(clusterNames);
     srcClusterName = clusterNames[0]; // venice-cluster0

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestStoreMigration.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestStoreMigration.java
@@ -40,7 +40,6 @@ import com.linkedin.venice.hadoop.VenicePushJob;
 import com.linkedin.venice.integration.utils.D2TestUtils;
 import com.linkedin.venice.integration.utils.DaVinciTestContext;
 import com.linkedin.venice.integration.utils.ServiceFactory;
-import com.linkedin.venice.integration.utils.VeniceControllerWrapper;
 import com.linkedin.venice.integration.utils.VeniceMultiClusterWrapper;
 import com.linkedin.venice.integration.utils.VeniceRouterWrapper;
 import com.linkedin.venice.integration.utils.VeniceTwoLayerMultiColoMultiClusterWrapper;
@@ -64,7 +63,6 @@ import java.util.Optional;
 import java.util.Properties;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 import org.apache.avro.Schema;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -139,19 +137,16 @@ public class TestStoreMigration {
         Optional.of(new VeniceProperties(serverProperties)),
         true);
 
-    multiClusterWrapper = twoLayerMultiColoMultiClusterWrapper.getClusters().get(0);
+    multiClusterWrapper = twoLayerMultiColoMultiClusterWrapper.getChildColoList().get(0);
     String[] clusterNames = multiClusterWrapper.getClusterNames();
     Arrays.sort(clusterNames);
     srcClusterName = clusterNames[0]; // venice-cluster0
     destClusterName = clusterNames[1]; // venice-cluster1
-    parentControllerUrl = twoLayerMultiColoMultiClusterWrapper.getParentControllers()
-        .stream()
-        .map(VeniceControllerWrapper::getControllerUrl)
-        .collect(Collectors.joining(","));
+    parentControllerUrl = twoLayerMultiColoMultiClusterWrapper.getControllerConnectString();
     childControllerUrl0 = multiClusterWrapper.getControllerConnectString();
   }
 
-  @AfterClass
+  @AfterClass(alwaysRun = true)
   public void cleanUp() {
     twoLayerMultiColoMultiClusterWrapper.close();
   }
@@ -159,7 +154,7 @@ public class TestStoreMigration {
   @Test(timeOut = TEST_TIMEOUT)
   public void testStoreMigrationOnParentController() throws Exception {
     String storeName = Utils.getUniqueString("store");
-    createAndPushStore(parentControllerUrl, srcClusterName, storeName);
+    createAndPushStore(srcClusterName, storeName);
 
     String srcD2ServiceName = multiClusterWrapper.getClusterToD2().get(srcClusterName);
     String destD2ServiceName = multiClusterWrapper.getClusterToD2().get(destClusterName);
@@ -197,7 +192,7 @@ public class TestStoreMigration {
   @Test(timeOut = TEST_TIMEOUT)
   public void testStoreMigrationWithNewPushesAndUpdatesOnParentController() throws Exception {
     String storeName = Utils.getUniqueString("store");
-    Properties props = createAndPushStore(parentControllerUrl, srcClusterName, storeName);
+    Properties props = createAndPushStore(srcClusterName, storeName);
 
     try (ControllerClient srcParentControllerClient = new ControllerClient(srcClusterName, parentControllerUrl);
         ControllerClient destParentControllerClient = new ControllerClient(destClusterName, parentControllerUrl)) {
@@ -249,7 +244,7 @@ public class TestStoreMigration {
   @Test(timeOut = TEST_TIMEOUT)
   public void testStoreMigrationWithMetaSystemStoreOnParentController() throws Exception {
     String storeName = Utils.getUniqueString("store");
-    createAndPushStore(parentControllerUrl, srcClusterName, storeName);
+    createAndPushStore(srcClusterName, storeName);
 
     try (ControllerClient srcParentControllerClient = new ControllerClient(srcClusterName, parentControllerUrl)) {
       // Enable the meta system store
@@ -314,7 +309,7 @@ public class TestStoreMigration {
   @Test(timeOut = TEST_TIMEOUT)
   public void testStoreMigrationWithDaVinciPushStatusSystemStoreOnParentController() throws Exception {
     String storeName = Utils.getUniqueString("store");
-    createAndPushStore(parentControllerUrl, srcClusterName, storeName);
+    createAndPushStore(srcClusterName, storeName);
 
     try (ControllerClient srcParentControllerClient = new ControllerClient(srcClusterName, parentControllerUrl)) {
       // Enable the da vinci push status system store
@@ -388,18 +383,19 @@ public class TestStoreMigration {
   @Test(timeOut = TEST_TIMEOUT)
   public void testStoreMigrationOnChildController() throws Exception {
     String storeName = Utils.getUniqueString("store");
-    createAndPushStore(parentControllerUrl, srcClusterName, storeName);
+    createAndPushStore(srcClusterName, storeName);
 
     startMigration(childControllerUrl0, storeName);
     completeMigration(childControllerUrl0, storeName);
     endMigration(childControllerUrl0, storeName);
   }
 
-  private Properties createAndPushStore(String controllerUrl, String clusterName, String storeName) throws Exception {
+  private Properties createAndPushStore(String clusterName, String storeName) throws Exception {
     File inputDir = getTempDataDirectory();
     String inputDirPath = "file:" + inputDir.getAbsolutePath();
     Schema recordSchema = TestWriteUtils.writeSimpleAvroFileWithUserSchema(inputDir, true, RECORD_COUNT);
-    Properties props = TestWriteUtils.defaultVPJProps(controllerUrl, inputDirPath, storeName);
+    Properties props =
+        IntegrationTestPushUtils.defaultVPJProps(twoLayerMultiColoMultiClusterWrapper, inputDirPath, storeName);
     String keySchemaStr = recordSchema.getField(props.getProperty(VenicePushJob.KEY_FIELD_PROP)).schema().toString();
     String valueSchemaStr =
         recordSchema.getField(props.getProperty(VenicePushJob.VALUE_FIELD_PROP)).schema().toString();

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestStoreMigration.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestStoreMigration.java
@@ -137,7 +137,7 @@ public class TestStoreMigration {
         Optional.of(new VeniceProperties(serverProperties)),
         true);
 
-    multiClusterWrapper = twoLayerMultiColoMultiClusterWrapper.getChildRegionList().get(0);
+    multiClusterWrapper = twoLayerMultiColoMultiClusterWrapper.getChildRegions().get(0);
     String[] clusterNames = multiClusterWrapper.getClusterNames();
     Arrays.sort(clusterNames);
     srcClusterName = clusterNames[0]; // venice-cluster0

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestVsonStoreBatch.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestVsonStoreBatch.java
@@ -7,7 +7,7 @@ import static com.linkedin.venice.hadoop.VenicePushJob.KEY_FIELD_PROP;
 import static com.linkedin.venice.hadoop.VenicePushJob.SOURCE_KAFKA;
 import static com.linkedin.venice.hadoop.VenicePushJob.VALUE_FIELD_PROP;
 import static com.linkedin.venice.utils.IntegrationTestPushUtils.createStoreForJob;
-import static com.linkedin.venice.utils.IntegrationTestPushUtils.defaultVPJProps;
+import static com.linkedin.venice.utils.IntegrationTestPushUtils.defaultVPJPropsWithoutD2Routing;
 import static com.linkedin.venice.utils.TestWriteUtils.getTempDataDirectory;
 import static com.linkedin.venice.utils.TestWriteUtils.writeComplexVsonFile;
 import static com.linkedin.venice.utils.TestWriteUtils.writeMultiLevelVsonFile;
@@ -267,9 +267,6 @@ public class TestVsonStoreBatch {
       Schema selectedValueSchema = VsonAvroSchemaAdapter.stripFromUnion(schemas.getSecond()).getField("name").schema();
       return new KeyAndValueSchemas(schemas.getFirst(), selectedValueSchema);
     }, properties -> {
-      /**
-       * Here will use {@link VENICE_DISCOVER_URL_PROP} instead.
-       */
       properties.setProperty(VenicePushJob.KEY_FIELD_PROP, "");
       properties.setProperty(VenicePushJob.VALUE_FIELD_PROP, "name");
     },
@@ -307,7 +304,7 @@ public class TestVsonStoreBatch {
 
     try {
       String inputDirPath = "file://" + inputDir.getAbsolutePath();
-      Properties props = defaultVPJProps(veniceCluster, inputDirPath, storeName);
+      Properties props = defaultVPJPropsWithoutD2Routing(veniceCluster, inputDirPath, storeName);
       extraProps.accept(props);
 
       if (!storeNameOptional.isPresent()) {

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestWritePathComputation.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestWritePathComputation.java
@@ -55,7 +55,7 @@ public class TestWritePathComputation {
     try (VeniceTwoLayerMultiColoMultiClusterWrapper twoLayerMultiColoMultiClusterWrapper =
         ServiceFactory.getVeniceTwoLayerMultiColoMultiClusterWrapper(1, 1, 1, 1, 1, 0)) {
 
-      VeniceMultiClusterWrapper multiCluster = twoLayerMultiColoMultiClusterWrapper.getChildColoList().get(0);
+      VeniceMultiClusterWrapper multiCluster = twoLayerMultiColoMultiClusterWrapper.getChildRegionList().get(0);
       VeniceControllerWrapper parentController = twoLayerMultiColoMultiClusterWrapper.getParentControllers().get(0);
       String clusterName = multiCluster.getClusterNames()[0];
       String storeName = "test-store0";

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestWritePathComputation.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestWritePathComputation.java
@@ -55,7 +55,7 @@ public class TestWritePathComputation {
     try (VeniceTwoLayerMultiColoMultiClusterWrapper twoLayerMultiColoMultiClusterWrapper =
         ServiceFactory.getVeniceTwoLayerMultiColoMultiClusterWrapper(1, 1, 1, 1, 1, 0)) {
 
-      VeniceMultiClusterWrapper multiCluster = twoLayerMultiColoMultiClusterWrapper.getClusters().get(0);
+      VeniceMultiClusterWrapper multiCluster = twoLayerMultiColoMultiClusterWrapper.getChildColoList().get(0);
       VeniceControllerWrapper parentController = twoLayerMultiColoMultiClusterWrapper.getParentControllers().get(0);
       String clusterName = multiCluster.getClusterNames()[0];
       String storeName = "test-store0";

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestWritePathComputation.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestWritePathComputation.java
@@ -55,7 +55,7 @@ public class TestWritePathComputation {
     try (VeniceTwoLayerMultiColoMultiClusterWrapper twoLayerMultiColoMultiClusterWrapper =
         ServiceFactory.getVeniceTwoLayerMultiColoMultiClusterWrapper(1, 1, 1, 1, 1, 0)) {
 
-      VeniceMultiClusterWrapper multiCluster = twoLayerMultiColoMultiClusterWrapper.getChildRegionList().get(0);
+      VeniceMultiClusterWrapper multiCluster = twoLayerMultiColoMultiClusterWrapper.getChildRegions().get(0);
       VeniceControllerWrapper parentController = twoLayerMultiColoMultiClusterWrapper.getParentControllers().get(0);
       String clusterName = multiCluster.getClusterNames()[0];
       String storeName = "test-store0";

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/WriteComputeWithActiveActiveReplicationTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/WriteComputeWithActiveActiveReplicationTest.java
@@ -131,7 +131,7 @@ public class WriteComputeWithActiveActiveReplicationTest {
         false);
 
     parentControllers = multiColoMultiClusterWrapper.getParentControllers();
-    childDatacenters = multiColoMultiClusterWrapper.getChildColoList();
+    childDatacenters = multiColoMultiClusterWrapper.getChildRegionList();
 
     String clusterName = CLUSTER_NAMES[0];
     String parentControllerURLs =

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/WriteComputeWithActiveActiveReplicationTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/WriteComputeWithActiveActiveReplicationTest.java
@@ -131,7 +131,7 @@ public class WriteComputeWithActiveActiveReplicationTest {
         false);
 
     parentControllers = multiColoMultiClusterWrapper.getParentControllers();
-    childDatacenters = multiColoMultiClusterWrapper.getClusters();
+    childDatacenters = multiColoMultiClusterWrapper.getChildColoList();
 
     String clusterName = CLUSTER_NAMES[0];
     String parentControllerURLs =

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/WriteComputeWithActiveActiveReplicationTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/WriteComputeWithActiveActiveReplicationTest.java
@@ -131,7 +131,7 @@ public class WriteComputeWithActiveActiveReplicationTest {
         false);
 
     parentControllers = multiColoMultiClusterWrapper.getParentControllers();
-    childDatacenters = multiColoMultiClusterWrapper.getChildRegionList();
+    childDatacenters = multiColoMultiClusterWrapper.getChildRegions();
 
     String clusterName = CLUSTER_NAMES[0];
     String parentControllerURLs =

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/integration/utils/D2TestUtils.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/integration/utils/D2TestUtils.java
@@ -85,6 +85,7 @@ public class D2TestUtils {
           extraClusterServiceConfigurations,
           serviceVariants);
 
+      // populate zookeeper
       d2Config.configure();
     } catch (Exception e) {
       throw new VeniceException(e);

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/integration/utils/VeniceMultiClusterWrapper.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/integration/utils/VeniceMultiClusterWrapper.java
@@ -278,4 +278,8 @@ public class VeniceMultiClusterWrapper extends ProcessWrapper {
       controllers.remove(controllerWrapper.getPort());
     }
   }
+
+  public String getColoName() {
+    return coloName;
+  }
 }

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/integration/utils/VeniceMultiClusterWrapper.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/integration/utils/VeniceMultiClusterWrapper.java
@@ -279,7 +279,7 @@ public class VeniceMultiClusterWrapper extends ProcessWrapper {
     }
   }
 
-  public String getColoName() {
+  public String getRegionName() {
     return coloName;
   }
 }

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/integration/utils/VeniceTwoLayerMultiColoMultiClusterWrapper.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/integration/utils/VeniceTwoLayerMultiColoMultiClusterWrapper.java
@@ -49,8 +49,11 @@ import org.apache.logging.log4j.Logger;
 public class VeniceTwoLayerMultiColoMultiClusterWrapper extends ProcessWrapper {
   private static final Logger LOGGER = LogManager.getLogger(VeniceTwoLayerMultiColoMultiClusterWrapper.class);
   public static final String SERVICE_NAME = "VeniceTwoLayerMultiCluster";
-  private final List<VeniceMultiClusterWrapper> clusters;
+  private final String parentColoName;
+  private final List<String> childColoNames;
+  private final List<VeniceMultiClusterWrapper> childColoList;
   private final List<VeniceControllerWrapper> parentControllers;
+  private final String[] clusterNames;
   private final ZkServerWrapper zkServerWrapper;
   private final KafkaBrokerWrapper parentKafkaBrokerWrapper;
 
@@ -58,13 +61,18 @@ public class VeniceTwoLayerMultiColoMultiClusterWrapper extends ProcessWrapper {
       File dataDirectory,
       ZkServerWrapper zkServerWrapper,
       KafkaBrokerWrapper parentKafkaBrokerWrapper,
-      List<VeniceMultiClusterWrapper> clusters,
-      List<VeniceControllerWrapper> parentControllers) {
+      List<VeniceMultiClusterWrapper> childColoList,
+      List<VeniceControllerWrapper> parentControllers,
+      String parentColoName,
+      List<String> childColoNames) {
     super(SERVICE_NAME, dataDirectory);
     this.zkServerWrapper = zkServerWrapper;
     this.parentKafkaBrokerWrapper = parentKafkaBrokerWrapper;
     this.parentControllers = parentControllers;
-    this.clusters = clusters;
+    this.childColoList = childColoList;
+    this.parentColoName = parentColoName;
+    this.childColoNames = childColoNames;
+    this.clusterNames = childColoList.get(0).getClusterNames();
   }
 
   static ServiceProvider<VeniceTwoLayerMultiColoMultiClusterWrapper> generateService(
@@ -263,7 +271,9 @@ public class VeniceTwoLayerMultiColoMultiClusterWrapper extends ProcessWrapper {
           finalZkServer,
           finalParentKafka,
           multiClusters,
-          parentControllers);
+          parentControllers,
+          parentColoName,
+          childColoNames);
     } catch (Exception e) {
       parentControllers.forEach(IOUtils::closeQuietly);
       multiClusters.forEach(IOUtils::closeQuietly);
@@ -340,7 +350,7 @@ public class VeniceTwoLayerMultiColoMultiClusterWrapper extends ProcessWrapper {
   @Override
   protected void internalStop() throws Exception {
     parentControllers.forEach(IOUtils::closeQuietly);
-    clusters.forEach(IOUtils::closeQuietly);
+    childColoList.forEach(IOUtils::closeQuietly);
     IOUtils.closeQuietly(parentKafkaBrokerWrapper);
     IOUtils.closeQuietly(zkServerWrapper);
   }
@@ -350,8 +360,8 @@ public class VeniceTwoLayerMultiColoMultiClusterWrapper extends ProcessWrapper {
     throw new UnsupportedOperationException("Cluster does not support to create new process.");
   }
 
-  public List<VeniceMultiClusterWrapper> getClusters() {
-    return clusters;
+  public List<VeniceMultiClusterWrapper> getChildColoList() {
+    return childColoList;
   }
 
   public List<VeniceControllerWrapper> getParentControllers() {
@@ -381,5 +391,23 @@ public class VeniceTwoLayerMultiColoMultiClusterWrapper extends ProcessWrapper {
       Utils.sleep(Time.MS_PER_SECOND);
     }
     throw new VeniceException("Leader controller does not exist, cluster=" + clusterName);
+  }
+
+  public String getParentColoName() {
+    return parentColoName;
+  }
+
+  public List<String> getChildColoNames() {
+    return childColoNames;
+  }
+
+  public String[] getClusterNames() {
+    return clusterNames;
+  }
+
+  public String getControllerConnectString() {
+    return getParentControllers().stream()
+        .map(controller -> controller.getControllerUrl())
+        .collect(Collectors.joining(","));
   }
 }

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/integration/utils/VeniceTwoLayerMultiColoMultiClusterWrapper.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/integration/utils/VeniceTwoLayerMultiColoMultiClusterWrapper.java
@@ -51,7 +51,7 @@ public class VeniceTwoLayerMultiColoMultiClusterWrapper extends ProcessWrapper {
   public static final String SERVICE_NAME = "VeniceTwoLayerMultiCluster";
   private final String parentRegionName;
   private final List<String> childRegionNames;
-  private final List<VeniceMultiClusterWrapper> childRegionList;
+  private final List<VeniceMultiClusterWrapper> childRegions;
   private final List<VeniceControllerWrapper> parentControllers;
   private final String[] clusterNames;
   private final ZkServerWrapper zkServerWrapper;
@@ -61,7 +61,7 @@ public class VeniceTwoLayerMultiColoMultiClusterWrapper extends ProcessWrapper {
       File dataDirectory,
       ZkServerWrapper zkServerWrapper,
       KafkaBrokerWrapper parentKafkaBrokerWrapper,
-      List<VeniceMultiClusterWrapper> childRegionList,
+      List<VeniceMultiClusterWrapper> childRegions,
       List<VeniceControllerWrapper> parentControllers,
       String parentRegionName,
       List<String> childRegionNames) {
@@ -69,10 +69,10 @@ public class VeniceTwoLayerMultiColoMultiClusterWrapper extends ProcessWrapper {
     this.zkServerWrapper = zkServerWrapper;
     this.parentKafkaBrokerWrapper = parentKafkaBrokerWrapper;
     this.parentControllers = parentControllers;
-    this.childRegionList = childRegionList;
+    this.childRegions = childRegions;
     this.parentRegionName = parentRegionName;
     this.childRegionNames = childRegionNames;
-    this.clusterNames = childRegionList.get(0).getClusterNames();
+    this.clusterNames = childRegions.get(0).getClusterNames();
   }
 
   static ServiceProvider<VeniceTwoLayerMultiColoMultiClusterWrapper> generateService(
@@ -350,7 +350,7 @@ public class VeniceTwoLayerMultiColoMultiClusterWrapper extends ProcessWrapper {
   @Override
   protected void internalStop() throws Exception {
     parentControllers.forEach(IOUtils::closeQuietly);
-    childRegionList.forEach(IOUtils::closeQuietly);
+    childRegions.forEach(IOUtils::closeQuietly);
     IOUtils.closeQuietly(parentKafkaBrokerWrapper);
     IOUtils.closeQuietly(zkServerWrapper);
   }
@@ -360,8 +360,8 @@ public class VeniceTwoLayerMultiColoMultiClusterWrapper extends ProcessWrapper {
     throw new UnsupportedOperationException("Cluster does not support to create new process.");
   }
 
-  public List<VeniceMultiClusterWrapper> getChildRegionList() {
-    return childRegionList;
+  public List<VeniceMultiClusterWrapper> getChildRegions() {
+    return childRegions;
   }
 
   public List<VeniceControllerWrapper> getParentControllers() {

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/integration/utils/VeniceTwoLayerMultiColoMultiClusterWrapper.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/integration/utils/VeniceTwoLayerMultiColoMultiClusterWrapper.java
@@ -49,9 +49,9 @@ import org.apache.logging.log4j.Logger;
 public class VeniceTwoLayerMultiColoMultiClusterWrapper extends ProcessWrapper {
   private static final Logger LOGGER = LogManager.getLogger(VeniceTwoLayerMultiColoMultiClusterWrapper.class);
   public static final String SERVICE_NAME = "VeniceTwoLayerMultiCluster";
-  private final String parentColoName;
-  private final List<String> childColoNames;
-  private final List<VeniceMultiClusterWrapper> childColoList;
+  private final String parentRegionName;
+  private final List<String> childRegionNames;
+  private final List<VeniceMultiClusterWrapper> childRegionList;
   private final List<VeniceControllerWrapper> parentControllers;
   private final String[] clusterNames;
   private final ZkServerWrapper zkServerWrapper;
@@ -61,18 +61,18 @@ public class VeniceTwoLayerMultiColoMultiClusterWrapper extends ProcessWrapper {
       File dataDirectory,
       ZkServerWrapper zkServerWrapper,
       KafkaBrokerWrapper parentKafkaBrokerWrapper,
-      List<VeniceMultiClusterWrapper> childColoList,
+      List<VeniceMultiClusterWrapper> childRegionList,
       List<VeniceControllerWrapper> parentControllers,
-      String parentColoName,
-      List<String> childColoNames) {
+      String parentRegionName,
+      List<String> childRegionNames) {
     super(SERVICE_NAME, dataDirectory);
     this.zkServerWrapper = zkServerWrapper;
     this.parentKafkaBrokerWrapper = parentKafkaBrokerWrapper;
     this.parentControllers = parentControllers;
-    this.childColoList = childColoList;
-    this.parentColoName = parentColoName;
-    this.childColoNames = childColoNames;
-    this.clusterNames = childColoList.get(0).getClusterNames();
+    this.childRegionList = childRegionList;
+    this.parentRegionName = parentRegionName;
+    this.childRegionNames = childRegionNames;
+    this.clusterNames = childRegionList.get(0).getClusterNames();
   }
 
   static ServiceProvider<VeniceTwoLayerMultiColoMultiClusterWrapper> generateService(
@@ -350,7 +350,7 @@ public class VeniceTwoLayerMultiColoMultiClusterWrapper extends ProcessWrapper {
   @Override
   protected void internalStop() throws Exception {
     parentControllers.forEach(IOUtils::closeQuietly);
-    childColoList.forEach(IOUtils::closeQuietly);
+    childRegionList.forEach(IOUtils::closeQuietly);
     IOUtils.closeQuietly(parentKafkaBrokerWrapper);
     IOUtils.closeQuietly(zkServerWrapper);
   }
@@ -360,8 +360,8 @@ public class VeniceTwoLayerMultiColoMultiClusterWrapper extends ProcessWrapper {
     throw new UnsupportedOperationException("Cluster does not support to create new process.");
   }
 
-  public List<VeniceMultiClusterWrapper> getChildColoList() {
-    return childColoList;
+  public List<VeniceMultiClusterWrapper> getChildRegionList() {
+    return childRegionList;
   }
 
   public List<VeniceControllerWrapper> getParentControllers() {
@@ -393,12 +393,12 @@ public class VeniceTwoLayerMultiColoMultiClusterWrapper extends ProcessWrapper {
     throw new VeniceException("Leader controller does not exist, cluster=" + clusterName);
   }
 
-  public String getParentColoName() {
-    return parentColoName;
+  public String getParentRegionName() {
+    return parentRegionName;
   }
 
-  public List<String> getChildColoNames() {
-    return childColoNames;
+  public List<String> getChildRegionNames() {
+    return childRegionNames;
   }
 
   public String[] getClusterNames() {

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/kafka/ssl/TestProduceWithSSL.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/kafka/ssl/TestProduceWithSSL.java
@@ -53,6 +53,7 @@ public class TestProduceWithSSL {
 
   @BeforeClass
   public void setUp() {
+    Utils.thisIsLocalhost();
     VeniceClusterCreateOptions options =
         new VeniceClusterCreateOptions.Builder().sslToKafka(true).isKafkaOpenSSLEnabled(false).build();
     cluster = ServiceFactory.getVeniceCluster(options);

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/multicluster/TestMetadataOperationInMultiCluster.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/multicluster/TestMetadataOperationInMultiCluster.java
@@ -16,8 +16,8 @@ import com.linkedin.venice.integration.utils.VeniceMultiClusterCreateOptions;
 import com.linkedin.venice.integration.utils.VeniceMultiClusterWrapper;
 import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.Version;
+import com.linkedin.venice.utils.IntegrationTestPushUtils;
 import com.linkedin.venice.utils.TestUtils;
-import com.linkedin.venice.utils.TestWriteUtils;
 import com.linkedin.venice.utils.Time;
 import com.linkedin.venice.utils.Utils;
 import java.io.File;
@@ -58,7 +58,7 @@ public class TestMetadataOperationInMultiCluster {
       try (VeniceControllerWrapper controllerWrapper = multiClusterWrapper.getRandomController();
           ControllerClient secondControllerClient =
               ControllerClient.constructClusterControllerClient(secondCluster, controllerWrapper.getControllerUrl())) {
-        // controller client could talk to any controller and find the lead of the given cluster correclty.
+        // controller client could talk to any controller and find the leader of the given cluster correctly.
         ControllerClient controllerClient =
             ControllerClient.constructClusterControllerClient(clusterName, controllerWrapper.getControllerUrl());
 
@@ -67,8 +67,6 @@ public class TestMetadataOperationInMultiCluster {
         NewStoreResponse storeResponse = controllerClient.createNewStore(storeName, "test", keySchema, valSchema);
         Assert.assertFalse(storeResponse.isError(), "Should create a new store.");
 
-        // Pickup the second cluster
-        ;
         // Create store with the same name in this cluster
         storeResponse = controllerClient.createNewStore(storeName, "test", keySchema, valSchema);
         Assert.assertTrue(storeResponse.isError(), "Should not create the duplicated store even in another cluster.");
@@ -145,9 +143,9 @@ public class TestMetadataOperationInMultiCluster {
       Map<String, Properties> propertiesMap = new HashMap<>();
       for (String clusterName: clusterNames) {
         String storeName = clusterName + storeNameSuffix;
-        // Use th first cluster in config, and test could vpj find the correct cluster.
-        Properties vpjProperties = TestWriteUtils
-            .defaultVPJProps(multiClusterWrapper.getRandomController().getControllerUrl(), inputDirPath, storeName);
+        // Use th first cluster in config, and test could h2v find the correct cluster.
+        Properties vpjProperties =
+            IntegrationTestPushUtils.defaultVPJProps(multiClusterWrapper, inputDirPath, storeName);
         propertiesMap.put(clusterName, vpjProperties);
         Schema keySchema = recordSchema.getField(VenicePushJob.DEFAULT_KEY_FIELD_PROP).schema();
         Schema valueSchema = recordSchema.getField(VenicePushJob.DEFAULT_VALUE_FIELD_PROP).schema();
@@ -165,17 +163,16 @@ public class TestMetadataOperationInMultiCluster {
       }
 
       for (String clusterName: clusterNames) {
-        Properties properties = propertiesMap.get(clusterName);
-        properties.setProperty(VenicePushJob.PBNJ_ENABLE, "true");
-        properties.setProperty(
-            VenicePushJob.PBNJ_ROUTER_URL_PROP,
-            multiClusterWrapper.getClusters().get(clusterName).getRandomRouterURL());
-        runVPJ(
-            properties,
-            1,
-            ControllerClient.constructClusterControllerClient(
-                clusterName,
-                multiClusterWrapper.getRandomController().getControllerUrl()));
+        try (ControllerClient controllerClient = ControllerClient.constructClusterControllerClient(
+            clusterName,
+            multiClusterWrapper.getRandomController().getControllerUrl())) {
+          Properties properties = propertiesMap.get(clusterName);
+          properties.setProperty(VenicePushJob.PBNJ_ENABLE, "true");
+          properties.setProperty(
+              VenicePushJob.PBNJ_ROUTER_URL_PROP,
+              multiClusterWrapper.getClusters().get(clusterName).getRandomRouterURL());
+          runVPJ(properties, 1, controllerClient);
+        }
       }
     }
   }

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/restart/TestRestartServerDuringIngestion.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/restart/TestRestartServerDuringIngestion.java
@@ -90,6 +90,7 @@ public abstract class TestRestartServerDuringIngestion {
     Properties properties = new Properties();
     properties.put(VenicePushJob.VENICE_DISCOVER_URL_PROP, veniceUrl);
     properties.put(VenicePushJob.VENICE_STORE_NAME_PROP, storeName);
+    properties.put(VenicePushJob.MULTI_REGION, false);
     IntegrationTestPushUtils.createStoreForJob(cluster, stringSchemaStr, stringSchemaStr, properties).close();
     IntegrationTestPushUtils.makeStoreLF(cluster, storeName);
     IntegrationTestPushUtils.makeStoreHybrid(cluster, storeName, 3600, 10);
@@ -235,6 +236,7 @@ public abstract class TestRestartServerDuringIngestion {
     Properties properties = new Properties();
     properties.put(VenicePushJob.VENICE_DISCOVER_URL_PROP, veniceUrl);
     properties.put(VenicePushJob.VENICE_STORE_NAME_PROP, storeName);
+    properties.put(VenicePushJob.MULTI_REGION, false);
     IntegrationTestPushUtils.createStoreForJob(cluster, stringSchemaStr, stringSchemaStr, properties).close();
 
     IntegrationTestPushUtils.makeStoreHybrid(cluster, storeName, 3600, 10);

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/utils/IntegrationTestPushUtils.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/utils/IntegrationTestPushUtils.java
@@ -100,7 +100,7 @@ public class IntegrationTestPushUtils {
     String parentColoZkAddress = multiColoMultiClusterWrapper.getZkServerWrapper().getAddress();
     String parentColoName = multiColoMultiClusterWrapper.getParentRegionName();
 
-    Map<String, String> childColoNamesToZkAddress = multiColoMultiClusterWrapper.getChildRegionList()
+    Map<String, String> childColoNamesToZkAddress = multiColoMultiClusterWrapper.getChildRegions()
         .stream()
         .collect(
             Collectors.toMap(

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/utils/IntegrationTestPushUtils.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/utils/IntegrationTestPushUtils.java
@@ -25,7 +25,7 @@ import static com.linkedin.venice.samza.VeniceSystemFactory.VENICE_STORE;
 import com.linkedin.venice.compression.CompressionStrategy;
 import com.linkedin.venice.controllerapi.ControllerClient;
 import com.linkedin.venice.controllerapi.ControllerResponse;
-import com.linkedin.venice.controllerapi.D2ControllerClient;
+import com.linkedin.venice.controllerapi.D2ControllerClientFactory;
 import com.linkedin.venice.controllerapi.NewStoreResponse;
 import com.linkedin.venice.controllerapi.UpdateStoreQueryParams;
 import com.linkedin.venice.exceptions.VeniceException;
@@ -275,7 +275,8 @@ public class IntegrationTestPushUtils {
         String childControllerColoName = pushJobProps.getProperty(SOURCE_GRID_FABRIC);
         d2ZkHosts = pushJobProps.getProperty(D2_ZK_HOSTS_PREFIX + childControllerColoName);
       }
-      return D2ControllerClient.constructClusterControllerClient(veniceClusterName, d2ServiceName, d2ZkHosts);
+      return D2ControllerClientFactory
+          .getControllerClient(d2ServiceName, veniceClusterName, d2ZkHosts, Optional.empty());
     } else {
       return ControllerClient.constructClusterControllerClient(veniceClusterName, veniceUrl);
     }

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/utils/IntegrationTestPushUtils.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/utils/IntegrationTestPushUtils.java
@@ -82,7 +82,7 @@ public class IntegrationTestPushUtils {
       String inputDirPath,
       String storeName) {
     Map<String, String> childColoNamesToZkAddress = Collections
-        .singletonMap(veniceMultiCluster.getColoName(), veniceMultiCluster.getZkServerWrapper().getAddress());
+        .singletonMap(veniceMultiCluster.getRegionName(), veniceMultiCluster.getZkServerWrapper().getAddress());
     return TestWriteUtils.defaultVPJPropsWithD2Routing(
         null,
         null,
@@ -98,13 +98,13 @@ public class IntegrationTestPushUtils {
       String inputDirPath,
       String storeName) {
     String parentColoZkAddress = multiColoMultiClusterWrapper.getZkServerWrapper().getAddress();
-    String parentColoName = multiColoMultiClusterWrapper.getParentColoName();
+    String parentColoName = multiColoMultiClusterWrapper.getParentRegionName();
 
-    Map<String, String> childColoNamesToZkAddress = multiColoMultiClusterWrapper.getChildColoList()
+    Map<String, String> childColoNamesToZkAddress = multiColoMultiClusterWrapper.getChildRegionList()
         .stream()
         .collect(
             Collectors.toMap(
-                veniceColo -> veniceColo.getColoName(),
+                veniceColo -> veniceColo.getRegionName(),
                 veniceColo -> veniceColo.getZkServerWrapper().getAddress()));
     return TestWriteUtils.defaultVPJPropsWithD2Routing(
         parentColoName,

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/ControllerRoutes.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/ControllerRoutes.java
@@ -17,6 +17,7 @@ import com.linkedin.venice.controllerapi.ControllerResponse;
 import com.linkedin.venice.controllerapi.LeaderControllerResponse;
 import com.linkedin.venice.exceptions.ErrorType;
 import com.linkedin.venice.kafka.TopicManager;
+import com.linkedin.venice.meta.Instance;
 import com.linkedin.venice.utils.Utils;
 import java.util.Optional;
 import org.apache.http.HttpStatus;
@@ -40,7 +41,12 @@ public class ControllerRoutes extends AbstractRoute {
         AdminSparkServer.validateParams(request, LEADER_CONTROLLER.getParams(), admin);
         String cluster = request.queryParams(CLUSTER);
         responseObject.setCluster(cluster);
-        responseObject.setUrl(admin.getLeaderController(cluster).getUrl(isSslEnabled()));
+        Instance leaderController = admin.getLeaderController(cluster);
+        responseObject.setUrl(leaderController.getUrl(isSslEnabled()));
+        if (leaderController.getPort() != leaderController.getSslPort()) {
+          // Controller is SSL Enabled
+          responseObject.setSecureUrl(leaderController.getUrl(true));
+        }
       } catch (Throwable e) {
         responseObject.setError(e);
         AdminSparkServer.handleError(e, request, response);

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/ControllerRoutesTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/ControllerRoutesTest.java
@@ -1,0 +1,69 @@
+package com.linkedin.venice.controller.server;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+import com.linkedin.venice.controller.Admin;
+import com.linkedin.venice.controller.VeniceParentHelixAdmin;
+import com.linkedin.venice.controllerapi.ControllerApiConstants;
+import com.linkedin.venice.controllerapi.LeaderControllerResponse;
+import com.linkedin.venice.meta.Instance;
+import com.linkedin.venice.utils.ObjectMapperFactory;
+import java.util.Optional;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import spark.Request;
+import spark.Response;
+import spark.Route;
+
+
+public class ControllerRoutesTest {
+  private static final String TEST_CLUSTER = "test_cluster";
+  private static final String TEST_NODE_ID = "l2181";
+  private static final String TEST_HOST = "localhost";
+  private static final int TEST_PORT = 2181;
+  private static final int TEST_SSL_PORT = 2182;
+
+  @Test
+  public void testGetLeaderController() throws Exception {
+    Admin mockAdmin = mock(VeniceParentHelixAdmin.class);
+    doReturn(true).when(mockAdmin).isLeaderControllerFor(anyString());
+    Instance leaderController = new Instance(TEST_NODE_ID, TEST_HOST, TEST_PORT, TEST_SSL_PORT);
+    doReturn(leaderController).when(mockAdmin).getLeaderController(anyString());
+
+    Request request = mock(Request.class);
+    doReturn(TEST_CLUSTER).when(request).queryParams(eq(ControllerApiConstants.CLUSTER));
+
+    Route leaderControllerRoute = new ControllerRoutes(false, Optional.empty()).getLeaderController(mockAdmin);
+    LeaderControllerResponse leaderControllerResponse = ObjectMapperFactory.getInstance()
+        .readValue(
+            leaderControllerRoute.handle(request, mock(Response.class)).toString(),
+            LeaderControllerResponse.class);
+    Assert.assertEquals(leaderControllerResponse.getCluster(), TEST_CLUSTER);
+    Assert.assertEquals(leaderControllerResponse.getUrl(), "http://" + TEST_HOST + ":" + TEST_PORT);
+    Assert.assertEquals(leaderControllerResponse.getSecureUrl(), "https://" + TEST_HOST + ":" + TEST_SSL_PORT);
+
+    Route leaderControllerSslRoute = new ControllerRoutes(true, Optional.empty()).getLeaderController(mockAdmin);
+    LeaderControllerResponse leaderControllerResponseSsl = ObjectMapperFactory.getInstance()
+        .readValue(
+            leaderControllerSslRoute.handle(request, mock(Response.class)).toString(),
+            LeaderControllerResponse.class);
+    Assert.assertEquals(leaderControllerResponseSsl.getCluster(), TEST_CLUSTER);
+    Assert.assertEquals(leaderControllerResponseSsl.getUrl(), "https://" + TEST_HOST + ":" + TEST_SSL_PORT);
+    Assert.assertEquals(leaderControllerResponseSsl.getSecureUrl(), "https://" + TEST_HOST + ":" + TEST_SSL_PORT);
+
+    // Controller doesn't support SSL
+    Instance leaderNonSslController = new Instance(TEST_NODE_ID, TEST_HOST, TEST_PORT, TEST_PORT);
+    doReturn(leaderNonSslController).when(mockAdmin).getLeaderController(anyString());
+
+    LeaderControllerResponse leaderControllerNonSslResponse = ObjectMapperFactory.getInstance()
+        .readValue(
+            leaderControllerRoute.handle(request, mock(Response.class)).toString(),
+            LeaderControllerResponse.class);
+    Assert.assertEquals(leaderControllerNonSslResponse.getCluster(), TEST_CLUSTER);
+    Assert.assertEquals(leaderControllerNonSslResponse.getUrl(), "http://" + TEST_HOST + ":" + TEST_PORT);
+    Assert.assertEquals(leaderControllerNonSslResponse.getSecureUrl(), null);
+  }
+}


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci], [server], [controller],
[router], [samza], [vpj], [fast-client], [thin-client], [alpini],
[admin-tool], [test], [build], [doc], [script]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Make VPJ use D2 controller client
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
In addition to making VPJ use D2 controller client, this commit makes the following changes:
1. VPJ has a few config requirements to use D2 routing. When using D2 routing, "venice.discover.urls" should specify a D2 URL and the following additional configs are also required:
    * A new mandatory config called "multi.region" has been added to differentiate between D2 service names of parent controllers or child controllers
    * A new config called "parent.controller.region.name" has been added (mandatory in multi region mode)
    * "source.grid.fabric" has been converted to a mandatory config in single colo mode. It has been overloaded to refer to the colo whose child controller VPJ will communicate with
    * New configs of type `d2.zk.hosts.<regionName>` have been added to fetch region-specific d2 zk hosts
        * `d2.zk.hosts.<parentRegionName>` is mandatory in multi region mode
        * `d2.zk.hosts.<sourceGridFabric>` is mandatory in single region mode
2. VPJ has additional cleanups for reusing same controller client for cluster discovery (previously it was a special code path for tests)
3. ControllerClient has a static cache to reuse clients for the same cluster. This has been upgraded to use reference counting so that they can be closed cleanly
4. Added a new static cache in D2ControllerClient to reuse D2 clients for the same zk cluster. This uses reference counting so that they can be closed cleanly
5. Some test cases have been cleaned up to use existing cluster wrapper classes instead of creating a customized venice cluster
6. Unrelated changes
    * Corrected some grammatical errors in a few places

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
Internal CI: 7554, 7555, 7562

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.

## Recommended Review Order
1. ControllerClient
2. D2ControllerClient
3. D2ClientFactory
4. VenicePushJob
5. TestWriteUtils
6. IntegrationTestPushUtils
7. Everything else