### PR TITLE
[server] Forked process should catch and log exception when resuming ingestion tasks

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/IsolatedIngestionBackend.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/IsolatedIngestionBackend.java
@@ -13,7 +13,6 @@ import com.linkedin.davinci.ingestion.main.MainIngestionMonitorService;
 import com.linkedin.davinci.ingestion.main.MainIngestionRequestClient;
 import com.linkedin.davinci.ingestion.main.MainIngestionStorageMetadataService;
 import com.linkedin.davinci.ingestion.main.MainPartitionIngestionStatus;
-import com.linkedin.davinci.ingestion.utils.IsolatedIngestionUtils;
 import com.linkedin.davinci.kafka.consumer.KafkaStoreIngestionService;
 import com.linkedin.davinci.kafka.consumer.LeaderFollowerStateType;
 import com.linkedin.davinci.notifier.RelayNotifier;
@@ -24,7 +23,6 @@ import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.ingestion.protocol.enums.IngestionCommandType;
 import com.linkedin.venice.ingestion.protocol.enums.IngestionComponentType;
 import com.linkedin.venice.meta.ReadOnlyStoreRepository;
-import com.linkedin.venice.security.SSLFactory;
 import com.linkedin.venice.utils.Time;
 import com.linkedin.venice.utils.Utils;
 import io.tehuti.metrics.MetricsRepository;
@@ -67,14 +65,13 @@ public class IsolatedIngestionBackend extends DefaultIngestionBackend
     int servicePort = configLoader.getVeniceServerConfig().getIngestionServicePort();
     int listenerPort = configLoader.getVeniceServerConfig().getIngestionApplicationPort();
     this.configLoader = configLoader;
-    Optional<SSLFactory> sslFactory = IsolatedIngestionUtils.getSSLFactory(configLoader);
     // Create the ingestion request client.
     mainIngestionRequestClient = new MainIngestionRequestClient(configLoader);
     // Create the forked isolated ingestion process.
     isolatedIngestionServiceProcess = mainIngestionRequestClient.startForkedIngestionProcess(configLoader);
     // Create and start the ingestion report listener.
     try {
-      mainIngestionMonitorService = new MainIngestionMonitorService(this, configLoader, sslFactory);
+      mainIngestionMonitorService = new MainIngestionMonitorService(this, configLoader);
       mainIngestionMonitorService.setStoreRepository(storeRepository);
       mainIngestionMonitorService.setMetricsRepository(metricsRepository);
       mainIngestionMonitorService.setStoreIngestionService(storeIngestionService);

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/main/MainIngestionMonitorService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/main/MainIngestionMonitorService.java
@@ -280,7 +280,7 @@ public class MainIngestionMonitorService extends AbstractVeniceService {
                   .info("Recovered ingestion task in isolated process for topic: {}, partition: {}", topic, partition);
               count.addAndGet(1);
             } catch (Exception e) {
-              LOGGER.info("Recovery of ingestion failed for topic: {}, partition: {}", topic, partition, e);
+              LOGGER.warn("Recovery of ingestion failed for topic: {}, partition: {}", topic, partition, e);
             }
           }
         });

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/ingestion/main/MainIngestionMonitorServiceTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/ingestion/main/MainIngestionMonitorServiceTest.java
@@ -1,0 +1,40 @@
+package com.linkedin.davinci.ingestion.main;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.linkedin.venice.exceptions.VeniceException;
+import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
+import java.util.Map;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class MainIngestionMonitorServiceTest {
+  @Test
+  public void testRecoverOngoingIngestionTask() {
+    Map<String, MainTopicIngestionStatus> topicIngestionStatusMap = new VeniceConcurrentHashMap<>();
+    String topic = "topic1";
+    MainTopicIngestionStatus mainTopicIngestionStatus = new MainTopicIngestionStatus(topic);
+    mainTopicIngestionStatus.setPartitionIngestionStatusToLocalIngestion(0);
+    mainTopicIngestionStatus.setPartitionIngestionStatusToIsolatedIngestion(1);
+    mainTopicIngestionStatus.setPartitionIngestionStatusToIsolatedIngestion(2);
+    mainTopicIngestionStatus.setPartitionIngestionStatusToIsolatedIngestion(3);
+    topicIngestionStatusMap.put(topic, mainTopicIngestionStatus);
+
+    MainIngestionRequestClient client = mock(MainIngestionRequestClient.class);
+    when(client.startConsumption(topic, 0))
+        .thenThrow(new VeniceException("Not expected to start remote consumption on local resource"));
+    when(client.startConsumption(topic, 1))
+        .thenThrow(new VeniceException("Simulate zombie resource ingestion failure"));
+    when(client.startConsumption(topic, 2)).thenReturn(Boolean.TRUE);
+    when(client.startConsumption(topic, 3)).thenReturn(Boolean.TRUE);
+
+    MainIngestionMonitorService monitorService = mock(MainIngestionMonitorService.class);
+    when(monitorService.getTopicIngestionStatusMap()).thenReturn(topicIngestionStatusMap);
+    when(monitorService.createClient()).thenReturn(client);
+    when(monitorService.resumeOngoingIngestionTasks()).thenCallRealMethod();
+    Assert.assertEquals(monitorService.resumeOngoingIngestionTasks(), 2);
+
+  }
+}

--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -613,7 +613,7 @@ public class ConfigKeys {
 
   /**
    * A boolean config to specify if we are using Da Vinci client for ingestion. This config will be parsed by
-   * isDaVinciConfig variable in VeniceServerConfig. By default it is false (use Venice Server)
+   * isDaVinciConfig variable in VeniceServerConfig. By default, it is false (use Venice Server)
    */
   public static final String INGESTION_USE_DA_VINCI_CLIENT = "ingestion.use.da.vinci.client";
 
@@ -623,14 +623,12 @@ public class ConfigKeys {
   public static final String SERVER_STOP_CONSUMPTION_WAIT_RETRIES_NUM = "server.stop.consumption.wait.retries.num";
 
   /**
-   * Port number for ingestion listener. For Parent/Child mode, it will be used by child process. For SplitService mode,
-   * it will be used by IngestionService.
+   * Service listening port number for main ingestion service.
    */
   public static final String SERVER_INGESTION_ISOLATION_SERVICE_PORT = "server.ingestion.isolation.service.port";
 
   /**
-   * Port number for ingestion listener. For Parent/Child mode, it will be used by parent process. For SplitService mode,
-   * it will be used by venice server that are using the ingestion service.
+   * Service listening port number for forked ingestion process.
    */
   public static final String SERVER_INGESTION_ISOLATION_APPLICATION_PORT =
       "server.ingestion.isolation.application.port";


### PR DESCRIPTION
## [server] Forked process should catch and log exception when resuming ingestion tasks

client.startConsumption() could throw exception when there is zombie resource (resource removed from store repo but exists in Helix). Removing zombie resources is another effort, this PR improves isolated ingestion logic to handle such failure gracefully.
Also this PR removes some unused variables.

## How was this PR tested?
Added new unit test to cover logic changes.

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.