### PR TITLE
[vpj] Added a secondary sorting for KIF repush to reduce the memory usage in reducer

### DIFF
--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VeniceMRPartitioner.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VeniceMRPartitioner.java
@@ -17,7 +17,7 @@ import org.apache.hadoop.mapred.Partitioner;
  * the same Kafka topic partition.
  */
 public class VeniceMRPartitioner implements Partitioner<BytesWritable, BytesWritable> {
-  private VenicePartitioner venicePartitioner;
+  protected VenicePartitioner venicePartitioner;
 
   public static final int EMPTY_KEY_LENGTH = 0;
 
@@ -27,6 +27,10 @@ public class VeniceMRPartitioner implements Partitioner<BytesWritable, BytesWrit
       // Special case, used only to ensure that all reducers are instantiated, even if starved of actual data.
       return ByteUtils.readInt(value.getBytes(), 0);
     }
+    return getPartition(key, numPartitions);
+  }
+
+  protected int getPartition(BytesWritable key, int numPartitions) {
     return venicePartitioner.getPartitionId(key.getBytes(), 0, key.getLength(), numPartitions);
   }
 

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/input/kafka/KafkaInputFormat.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/input/kafka/KafkaInputFormat.java
@@ -4,6 +4,7 @@ import static com.linkedin.venice.hadoop.VenicePushJob.KAFKA_INPUT_MAX_RECORDS_P
 import static com.linkedin.venice.hadoop.VenicePushJob.KAFKA_INPUT_TOPIC;
 import static com.linkedin.venice.hadoop.input.kafka.KafkaInputUtils.getConsumerFactory;
 
+import com.linkedin.venice.hadoop.input.kafka.avro.KafkaInputMapperKey;
 import com.linkedin.venice.hadoop.input.kafka.avro.KafkaInputMapperValue;
 import com.linkedin.venice.kafka.KafkaClientFactory;
 import com.linkedin.venice.kafka.TopicManager;
@@ -12,7 +13,6 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import org.apache.hadoop.io.BytesWritable;
 import org.apache.hadoop.mapred.InputFormat;
 import org.apache.hadoop.mapred.InputSplit;
 import org.apache.hadoop.mapred.JobConf;
@@ -27,7 +27,7 @@ import org.apache.kafka.common.TopicPartition;
  *
  * This {@link InputFormat} implementation is used to read data off a Kafka topic.
  */
-public class KafkaInputFormat implements InputFormat<BytesWritable, KafkaInputMapperValue> {
+public class KafkaInputFormat implements InputFormat<KafkaInputMapperKey, KafkaInputMapperValue> {
   /**
    * The default max records per mapper, and if there are more records in one topic partition, it will be
    * consumed by multiple mappers in parallel.
@@ -82,7 +82,7 @@ public class KafkaInputFormat implements InputFormat<BytesWritable, KafkaInputMa
   }
 
   @Override
-  public RecordReader<BytesWritable, KafkaInputMapperValue> getRecordReader(
+  public RecordReader<KafkaInputMapperKey, KafkaInputMapperValue> getRecordReader(
       InputSplit split,
       JobConf job,
       Reporter reporter) {

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/input/kafka/KafkaInputKeyComparator.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/input/kafka/KafkaInputKeyComparator.java
@@ -1,0 +1,87 @@
+package com.linkedin.venice.hadoop.input.kafka;
+
+import com.linkedin.venice.hadoop.input.kafka.avro.KafkaInputMapperKey;
+import com.linkedin.venice.serializer.FastSerializerDeserializerFactory;
+import com.linkedin.venice.serializer.RecordDeserializer;
+import java.io.IOException;
+import java.io.Serializable;
+import org.apache.avro.io.OptimizedBinaryDecoderFactory;
+import org.apache.hadoop.io.BytesWritable;
+import org.apache.hadoop.io.DataInputBuffer;
+import org.apache.hadoop.io.RawComparator;
+import org.apache.hadoop.io.WritableComparator;
+
+
+/**
+ * This class is used to support secondary sorting for KafkaInput Repush.
+ * The key is composed by the raw key + offset, and this class will compare key part first to make it in ascending order
+ * and then compare the offset part when keys are equal to maintain an offset-descending order for the same key.
+ */
+public class KafkaInputKeyComparator implements RawComparator<BytesWritable>, Serializable {
+  private static final long serialVersionUID = 1L;
+
+  private static final OptimizedBinaryDecoderFactory OPTIMIZED_BINARY_DECODER_FACTORY =
+      OptimizedBinaryDecoderFactory.defaultFactory();
+  private static final RecordDeserializer<KafkaInputMapperKey> KAFKA_INPUT_MAPPER_KEY_AVRO_SPECIFIC_DESERIALIZER =
+      FastSerializerDeserializerFactory
+          .getFastAvroSpecificDeserializer(KafkaInputMapperKey.SCHEMA$, KafkaInputMapperKey.class);
+
+  @Override
+  public int compare(byte[] b1, int s1, int l1, byte[] b2, int s2, int l2) {
+    DataInputBuffer inputBuffer = new DataInputBuffer();
+    inputBuffer.reset(b1, s1, l1);
+
+    BytesWritable bw1 = new BytesWritable();
+    try {
+      bw1.readFields(inputBuffer);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+    inputBuffer.reset(b2, s2, l2);
+    BytesWritable bw2 = new BytesWritable();
+
+    try {
+      bw2.readFields(inputBuffer);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+
+    return compare(bw1, bw2);
+  }
+
+  @Override
+  public int compare(BytesWritable o1, BytesWritable o2) {
+    if (o1.getLength() == 0) {
+      return -1;
+    }
+    if (o2.getLength() == 0) {
+      return 1;
+    }
+    KafkaInputMapperKey k1 = KAFKA_INPUT_MAPPER_KEY_AVRO_SPECIFIC_DESERIALIZER
+        .deserialize(OPTIMIZED_BINARY_DECODER_FACTORY.createOptimizedBinaryDecoder(o1.getBytes(), 0, o1.getLength()));
+    KafkaInputMapperKey k2 = KAFKA_INPUT_MAPPER_KEY_AVRO_SPECIFIC_DESERIALIZER
+        .deserialize(OPTIMIZED_BINARY_DECODER_FACTORY.createOptimizedBinaryDecoder(o2.getBytes(), 0, o2.getLength()));
+
+    return compare(k1, k2);
+  }
+
+  protected int compare(KafkaInputMapperKey k1, KafkaInputMapperKey k2) {
+    int compareResult = WritableComparator.compareBytes(
+        k1.key.array(),
+        k1.key.position(),
+        k1.key.remaining(),
+        k2.key.array(),
+        k2.key.position(),
+        k2.key.remaining());
+
+    if (compareResult != 0) {
+      return compareResult;
+    }
+    if (k1.offset < k2.offset) {
+      return 1;
+    } else if (k1.offset > k2.offset) {
+      return -1;
+    }
+    return 0;
+  }
+}

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/input/kafka/KafkaInputMRPartitioner.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/input/kafka/KafkaInputMRPartitioner.java
@@ -1,0 +1,29 @@
+package com.linkedin.venice.hadoop.input.kafka;
+
+import com.linkedin.venice.hadoop.VeniceMRPartitioner;
+import com.linkedin.venice.hadoop.input.kafka.avro.KafkaInputMapperKey;
+import com.linkedin.venice.serializer.FastSerializerDeserializerFactory;
+import com.linkedin.venice.serializer.RecordDeserializer;
+import org.apache.avro.io.OptimizedBinaryDecoderFactory;
+import org.apache.hadoop.io.BytesWritable;
+
+
+/**
+ * This class is used for KafkaInput Repush, and it only considers the key part of the composed key (ignoring the offset).
+ */
+public class KafkaInputMRPartitioner extends VeniceMRPartitioner {
+  private static final OptimizedBinaryDecoderFactory OPTIMIZED_BINARY_DECODER_FACTORY =
+      OptimizedBinaryDecoderFactory.defaultFactory();
+  private static final RecordDeserializer<KafkaInputMapperKey> KAFKA_INPUT_MAPPER_KEY_AVRO_SPECIFIC_DESERIALIZER =
+      FastSerializerDeserializerFactory
+          .getFastAvroSpecificDeserializer(KafkaInputMapperKey.SCHEMA$, KafkaInputMapperKey.class);
+
+  @Override
+  protected int getPartition(BytesWritable key, int numPartitions) {
+    KafkaInputMapperKey mapperKey = KAFKA_INPUT_MAPPER_KEY_AVRO_SPECIFIC_DESERIALIZER
+        .deserialize(OPTIMIZED_BINARY_DECODER_FACTORY.createOptimizedBinaryDecoder(key.getBytes(), 0, key.getLength()));
+    return venicePartitioner
+        .getPartitionId(mapperKey.key.array(), mapperKey.key.position(), mapperKey.key.remaining(), numPartitions);
+  }
+
+}

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/input/kafka/KafkaInputValueGroupingComparator.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/input/kafka/KafkaInputValueGroupingComparator.java
@@ -1,0 +1,24 @@
+package com.linkedin.venice.hadoop.input.kafka;
+
+import com.linkedin.venice.hadoop.input.kafka.avro.KafkaInputMapperKey;
+import org.apache.hadoop.io.WritableComparator;
+
+
+/**
+ * This class together with {@link KafkaInputKeyComparator} supports secondary sorting of KafkaInput Repush.
+ * This class is used to group the entries with same key by ignoring the offset part.
+ */
+public class KafkaInputValueGroupingComparator extends KafkaInputKeyComparator {
+  private static final long serialVersionUID = 1L;
+
+  @Override
+  protected int compare(KafkaInputMapperKey k1, KafkaInputMapperKey k2) {
+    return WritableComparator.compareBytes(
+        k1.key.array(),
+        k1.key.position(),
+        k1.key.remaining(),
+        k2.key.array(),
+        k2.key.position(),
+        k2.key.remaining());
+  }
+}

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/input/kafka/chunk/ChunkAssembler.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/input/kafka/chunk/ChunkAssembler.java
@@ -5,17 +5,13 @@ import com.linkedin.venice.hadoop.input.kafka.avro.KafkaInputMapperValue;
 import com.linkedin.venice.hadoop.input.kafka.avro.MapperValueType;
 import com.linkedin.venice.serialization.avro.AvroProtocolDefinition;
 import com.linkedin.venice.serialization.avro.ChunkedValueManifestSerializer;
-import com.linkedin.venice.serializer.AvroSpecificDeserializer;
 import com.linkedin.venice.serializer.FastSerializerDeserializerFactory;
 import com.linkedin.venice.serializer.RecordDeserializer;
-import com.linkedin.venice.storage.protocol.ChunkedKeySuffix;
 import com.linkedin.venice.storage.protocol.ChunkedValueManifest;
 import com.linkedin.venice.utils.ByteUtils;
 import java.nio.ByteBuffer;
-import java.util.ArrayList;
 import java.util.Iterator;
-import java.util.List;
-import org.apache.avro.specific.SpecificDatumReader;
+import org.apache.avro.io.OptimizedBinaryDecoderFactory;
 import org.apache.hadoop.io.BytesWritable;
 
 
@@ -24,129 +20,156 @@ import org.apache.hadoop.io.BytesWritable;
  * message.
  */
 public class ChunkAssembler {
+  private static final OptimizedBinaryDecoderFactory OPTIMIZED_BINARY_DECODER_FACTORY =
+      OptimizedBinaryDecoderFactory.defaultFactory();
   private static final RecordDeserializer<KafkaInputMapperValue> KAFKA_INPUT_MAPPER_VALUE_AVRO_SPECIFIC_DESERIALIZER =
       FastSerializerDeserializerFactory
           .getFastAvroSpecificDeserializer(KafkaInputMapperValue.SCHEMA$, KafkaInputMapperValue.class);
-  private final AvroSpecificDeserializer<ChunkedKeySuffix> chunkedKeySuffixDeserializer;
   private final ChunkedValueManifestSerializer manifestSerializer;
 
   public ChunkAssembler() {
-    SpecificDatumReader<ChunkedKeySuffix> specificDatumReader = new SpecificDatumReader<>(ChunkedKeySuffix.class);
-    this.chunkedKeySuffixDeserializer = new AvroSpecificDeserializer<>(specificDatumReader);
     this.manifestSerializer = new ChunkedValueManifestSerializer(true);
   }
 
+  /**
+   * The `valueIterator` of this function is supposed to be in descending order by offset.
+   *
+   * Here is the high-level algo:
+   * 1. If the latest event is a `DELETE`, return;
+   * 2. If the latest event is a regular 'PUT`, return;
+   * 3. If the latest event is a manifest, capture all the chunk info from the latest one and ignore the older ones.
+   * 4. For chunks:
+   *    a. If there is no manifest captured yet, ignore.
+   *    b. If there is a manifest captured previously, check whether the current chunk belongs to it or not.
+   */
   public ValueBytesAndSchemaId assembleAndGetValue(final byte[] keyBytes, final Iterator<BytesWritable> valueIterator) {
     if (!valueIterator.hasNext()) {
       throw new IllegalArgumentException("Expect values to be not empty.");
     }
-    // TODO: Getting rid of this large allocation would require leveraging MR secondary sorting
-    List<byte[]> chunkBytes = new ArrayList<>();
 
-    KafkaInputMapperValue mapperValue = null;
-    byte[] currentValueBytes;
-    byte[] largestValueBytes = null;
-    long largestOffset = Long.MIN_VALUE;
-    while (valueIterator.hasNext()) { // Start from the value with the highest offset
-      currentValueBytes = valueIterator.next().copyBytes();
-      mapperValue = KAFKA_INPUT_MAPPER_VALUE_AVRO_SPECIFIC_DESERIALIZER.deserialize(mapperValue, currentValueBytes);
-      if (mapperValue.schemaId == AvroProtocolDefinition.CHUNK.getCurrentProtocolVersion()) {
-        chunkBytes.add(currentValueBytes);
-      } else if (mapperValue.offset > largestOffset) {
-        largestOffset = mapperValue.offset;
-        largestValueBytes = currentValueBytes;
-      }
-    }
-    if (largestValueBytes == null) {
-      throw new VeniceException("No regular value nor chunk manifest for key: " + ByteUtils.toHexString(keyBytes));
-    }
-    mapperValue = KAFKA_INPUT_MAPPER_VALUE_AVRO_SPECIFIC_DESERIALIZER.deserialize(mapperValue, largestValueBytes);
+    KafkaInputMapperValue reusedMapperValue = null;
 
-    if (mapperValue.valueType == MapperValueType.DELETE) {
-      if (mapperValue.replicationMetadataPayload.remaining() != 0) {
-        return new ValueBytesAndSchemaId(
-            null,
-            mapperValue.schemaId,
-            mapperValue.replicationMetadataVersionId,
-            mapperValue.replicationMetadataPayload);
-      }
-      return null;
-    } else if (mapperValue.schemaId > 0) {
-      return new ValueBytesAndSchemaId(
-          ByteUtils.extractByteArray(mapperValue.value),
-          mapperValue.schemaId,
-          mapperValue.replicationMetadataVersionId,
-          mapperValue.replicationMetadataPayload);
-    } else if (mapperValue.schemaId == AvroProtocolDefinition.CHUNKED_VALUE_MANIFEST.getCurrentProtocolVersion()) {
-      final ChunkedValueManifest chunkedValueManifest = manifestSerializer.deserialize(
-          ByteUtils.extractByteArray(mapperValue.value),
-          AvroProtocolDefinition.CHUNKED_VALUE_MANIFEST.getCurrentProtocolVersion());
-
-      return assembleLargeValue(keyBytes, chunkedValueManifest, chunkBytes, mapperValue);
-    } else {
-      throw new VeniceException(
-          String.format(
-              "Unhandled case with chunked key suffix %s and value schema ID %d",
-              deserializeChunkedKeySuffix(mapperValue.chunkedKeySuffix),
-              mapperValue.schemaId));
-    }
-  }
-
-  private ValueBytesAndSchemaId assembleLargeValue(
-      byte[] keyBytes,
-      final ChunkedValueManifest manifest,
-      List<byte[]> allChunkBytes,
-      KafkaInputMapperValue manifestMapperValue) {
-    byte[][] valueChunks = new byte[manifest.keysWithChunkIdSuffix.size()][];
-    ByteBuffer[] chunkKeySuffixes = new ByteBuffer[manifest.keysWithChunkIdSuffix.size()];
-    int startPosition, suffixLength;
-    ByteBuffer byteBuffer;
-    for (int i = 0; i < manifest.keysWithChunkIdSuffix.size(); i++) {
-      byteBuffer = manifest.keysWithChunkIdSuffix.get(i);
-      startPosition = byteBuffer.position() + keyBytes.length;
-      suffixLength = byteBuffer.remaining() - keyBytes.length;
-      chunkKeySuffixes[i] = ByteBuffer.wrap(byteBuffer.array(), startPosition, suffixLength);
-    }
-
-    int totalByteCount = 0;
-    KafkaInputMapperValue chunk = null;
+    ChunkedValueManifest latestChunkedValueManifest = null;
+    int latestChunkedValueManifestRMDVersionId = -1;
+    ByteBuffer latestChunkedValueManifestRMDPayload = null;
+    byte[][] valueChunks = new byte[0][0];
+    ByteBuffer[] chunkKeySuffixes = new ByteBuffer[0];
     int chunksFound = 0;
-    for (byte[] chunkBytes: allChunkBytes) {
-      if (chunksFound == valueChunks.length) {
-        break;
+    int totalByteCount = 0;
+    long lastOffset = Long.MAX_VALUE;
+
+    while (valueIterator.hasNext()) { // Start from the value with the highest offset
+      BytesWritable currentValue = valueIterator.next();
+      reusedMapperValue = KAFKA_INPUT_MAPPER_VALUE_AVRO_SPECIFIC_DESERIALIZER.deserialize(
+          reusedMapperValue,
+          OPTIMIZED_BINARY_DECODER_FACTORY
+              .createOptimizedBinaryDecoder(currentValue.getBytes(), 0, currentValue.getLength()));
+      if (reusedMapperValue.offset > lastOffset) {
+        throw new VeniceException(
+            "Unexpected, the input is supposed to be in descending order by offset, previous offset: " + lastOffset
+                + ", current offset: " + reusedMapperValue.offset);
       }
-      chunk = KAFKA_INPUT_MAPPER_VALUE_AVRO_SPECIFIC_DESERIALIZER.deserialize(chunk, chunkBytes);
-      for (int i = 0; i < chunkKeySuffixes.length; i++) {
-        byteBuffer = chunkKeySuffixes[i];
-        if (byteBuffer.equals(chunk.chunkedKeySuffix)) {
-          byte[] valueChunk = new byte[chunk.value.remaining()];
-          totalByteCount += valueChunk.length;
-          chunk.value.get(valueChunk);
-          valueChunks[i] = valueChunk;
-          chunksFound++;
+      lastOffset = reusedMapperValue.offset;
+
+      if (reusedMapperValue.valueType.equals(MapperValueType.DELETE)) {
+        if (latestChunkedValueManifest != null) {
+          // Ignore older entries since a more recent manifest is discovered.
+          continue;
+        }
+        /**
+         * The latest event is a delete event.
+         */
+        if (reusedMapperValue.replicationMetadataPayload.remaining() != 0) {
+          return new ValueBytesAndSchemaId(
+              null,
+              reusedMapperValue.schemaId,
+              reusedMapperValue.replicationMetadataVersionId,
+              reusedMapperValue.replicationMetadataPayload);
+        }
+        return null;
+      }
+
+      if (reusedMapperValue.schemaId > 0) {
+        if (latestChunkedValueManifest != null) {
+          // Ignore older entries since a more recent manifest is discovered.
+          continue;
+        }
+        /**
+         * The latest event is a put event.
+         */
+        return new ValueBytesAndSchemaId(
+            ByteUtils.extractByteArray(reusedMapperValue.value),
+            reusedMapperValue.schemaId,
+            reusedMapperValue.replicationMetadataVersionId,
+            reusedMapperValue.replicationMetadataPayload);
+      }
+
+      if (reusedMapperValue.schemaId == AvroProtocolDefinition.CHUNKED_VALUE_MANIFEST.getCurrentProtocolVersion()) {
+        // Only capture the latest manifest
+        if (latestChunkedValueManifest == null) {
+          latestChunkedValueManifestRMDVersionId = reusedMapperValue.replicationMetadataVersionId;
+          latestChunkedValueManifestRMDPayload =
+              ByteBuffer.wrap(ByteUtils.copyByteArray(reusedMapperValue.replicationMetadataPayload));
+          latestChunkedValueManifest = manifestSerializer.deserialize(
+              ByteUtils.extractByteArray(reusedMapperValue.value),
+              AvroProtocolDefinition.CHUNKED_VALUE_MANIFEST.getCurrentProtocolVersion());
+          int chunkCount = latestChunkedValueManifest.keysWithChunkIdSuffix.size();
+          valueChunks = new byte[chunkCount][];
+          chunkKeySuffixes = new ByteBuffer[chunkCount];
+
+          for (int i = 0; i < latestChunkedValueManifest.keysWithChunkIdSuffix.size(); i++) {
+            ByteBuffer byteBuffer = latestChunkedValueManifest.keysWithChunkIdSuffix.get(i);
+            int startPosition = byteBuffer.position() + keyBytes.length;
+            int suffixLength = byteBuffer.remaining() - keyBytes.length;
+            chunkKeySuffixes[i] = ByteBuffer.wrap(byteBuffer.array(), startPosition, suffixLength);
+          }
+        }
+      } else if (reusedMapperValue.schemaId == AvroProtocolDefinition.CHUNK.getCurrentProtocolVersion()) {
+        if (latestChunkedValueManifest == null) {
+          /**
+           * It is possible that KafkaInputFormat could only read the partial chunks for a large message, which means
+           * there are chunks without the corresponding manifest.
+           */
+          continue;
+        }
+        // Collecting chunks
+        for (int i = 0; i < chunkKeySuffixes.length; i++) {
+          ByteBuffer byteBuffer = chunkKeySuffixes[i];
+          if (byteBuffer.equals(reusedMapperValue.chunkedKeySuffix)) {
+            byte[] valueChunk = new byte[reusedMapperValue.value.remaining()];
+            totalByteCount += valueChunk.length;
+            reusedMapperValue.value.get(valueChunk);
+            valueChunks[i] = valueChunk;
+            chunksFound++;
+            break;
+          }
+        }
+        if (chunksFound == valueChunks.length) {
           break;
         }
+      } else {
+        throw new IllegalArgumentException("Unexpected schema id: " + reusedMapperValue.schemaId);
       }
     }
-
-    if (chunksFound != valueChunks.length) {
-      int missingChunks = valueChunks.length - chunksFound;
-      throw new VeniceException(
-          "Cannot assemble a large value. Missing " + missingChunks + " / " + valueChunks.length + " chunks.");
+    if (latestChunkedValueManifest == null) {
+      // No valid data.
+      return null;
+    } else {
+      if (chunksFound != valueChunks.length) {
+        int missingChunks = valueChunks.length - chunksFound;
+        throw new VeniceException(
+            "Cannot assemble a large value. Missing " + missingChunks + " / " + valueChunks.length + " chunks.");
+      }
+      if (totalByteCount != latestChunkedValueManifest.size) {
+        throw new VeniceException(
+            String.format("Expect %d byte(s) but got %d byte(s)", latestChunkedValueManifest.size, totalByteCount));
+      }
+      return new ValueBytesAndSchemaId(
+          concatenateAllChunks(valueChunks, totalByteCount),
+          latestChunkedValueManifest.schemaId,
+          latestChunkedValueManifestRMDVersionId,
+          latestChunkedValueManifestRMDPayload);
     }
-
-    if (totalByteCount != manifest.size) {
-      throw new VeniceException(String.format("Expect %d byte(s) but got %d byte(s)", manifest.size, totalByteCount));
-    }
-    return new ValueBytesAndSchemaId(
-        concatenateAllChunks(valueChunks, totalByteCount),
-        manifest.schemaId,
-        manifestMapperValue.replicationMetadataVersionId,
-        manifestMapperValue.replicationMetadataPayload);
-  }
-
-  private ChunkedKeySuffix deserializeChunkedKeySuffix(ByteBuffer chunkedKeySuffixBytes) {
-    return chunkedKeySuffixDeserializer.deserialize(chunkedKeySuffixBytes);
   }
 
   private byte[] concatenateAllChunks(final byte[][] chunks, final int totalByteCount) {

--- a/clients/venice-push-job/src/main/resources/avro/KafkaInputMapperKey.avsc
+++ b/clients/venice-push-job/src/main/resources/avro/KafkaInputMapperKey.avsc
@@ -1,0 +1,18 @@
+{
+  "name": "KafkaInputMapperKey",
+  "namespace": "com.linkedin.venice.hadoop.input.kafka.avro",
+  "type": "record",
+  "doc": "The protocol between Mapper and Reducer with KafkaInputFormat for key field",
+  "fields": [
+    {
+      "name": "key",
+      "doc": "The raw key bytes excluding any chunking suffix",
+      "type": "bytes"
+    },
+    {
+      "name": "offset",
+      "doc": "The offset of the record in the original Kafka topic partition",
+      "type": "long"
+    }
+  ]
+}

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/input/kafka/TestKafkaInputKeyComparator.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/input/kafka/TestKafkaInputKeyComparator.java
@@ -1,0 +1,148 @@
+package com.linkedin.venice.hadoop.input.kafka;
+
+import static org.testng.Assert.*;
+
+import com.linkedin.venice.hadoop.input.kafka.avro.KafkaInputMapperKey;
+import com.linkedin.venice.serializer.FastSerializerDeserializerFactory;
+import com.linkedin.venice.serializer.RecordSerializer;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import org.apache.hadoop.io.BytesWritable;
+import org.apache.hadoop.io.DataOutputBuffer;
+import org.testng.annotations.Test;
+
+
+public class TestKafkaInputKeyComparator {
+  private static RecordSerializer<KafkaInputMapperKey> KAFKA_INPUT_MAPPER_KEY_SERIALIZER =
+      FastSerializerDeserializerFactory.getAvroGenericSerializer(KafkaInputMapperKey.SCHEMA$);
+  private static KafkaInputKeyComparator KAFKA_INPUT_KEY_COMPARATOR = new KafkaInputKeyComparator();
+
+  private static final ByteBuffer SERIALIZED_EMPTY_BYTES_WRITABLE;
+
+  static {
+    try {
+      SERIALIZED_EMPTY_BYTES_WRITABLE = getSerializedEmptyBytesWritable();
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private static final BytesWritable EMPTY_BYTES_WRITABLE = new BytesWritable();
+
+  public static BytesWritable getBytesWritable(byte[] key, long offset) {
+    KafkaInputMapperKey mapperKey = new KafkaInputMapperKey();
+    mapperKey.key = ByteBuffer.wrap(key);
+    mapperKey.offset = offset;
+
+    byte[] serializedKey = KAFKA_INPUT_MAPPER_KEY_SERIALIZER.serialize(mapperKey);
+    BytesWritable bytesWritable = new BytesWritable();
+    bytesWritable.set(serializedKey, 0, serializedKey.length);
+
+    return bytesWritable;
+  }
+
+  public static ByteBuffer getSerializedBytesWritable(byte[] key, long offset) throws IOException {
+    BytesWritable bytesWritable = getBytesWritable(key, offset);
+    DataOutputBuffer outputBuffer = new DataOutputBuffer();
+    bytesWritable.write(outputBuffer);
+    return ByteBuffer.wrap(outputBuffer.getData(), 0, outputBuffer.getLength());
+  }
+
+  private static ByteBuffer getSerializedEmptyBytesWritable() throws IOException {
+    BytesWritable bytesWritable = new BytesWritable();
+    DataOutputBuffer outputBuffer = new DataOutputBuffer();
+    bytesWritable.write(outputBuffer);
+    return ByteBuffer.wrap(outputBuffer.getData(), 0, outputBuffer.getLength());
+  }
+
+  @Test
+  public void testCompareWithDifferentKey() throws IOException {
+    byte[] key1 = "123".getBytes();
+    byte[] key2 = "223".getBytes();
+    long offsetForKey1 = 1;
+    long offsetForKey2 = 2;
+    BytesWritable bwForKey1 = getBytesWritable(key1, offsetForKey1);
+    BytesWritable bwForKey2 = getBytesWritable(key2, offsetForKey2);
+    ByteBuffer bbForKey1 = getSerializedBytesWritable(key1, offsetForKey1);
+    ByteBuffer bbForKey2 = getSerializedBytesWritable(key2, offsetForKey2);
+
+    assertTrue(KAFKA_INPUT_KEY_COMPARATOR.compare(bwForKey1, bwForKey2) < 0);
+    assertTrue(KAFKA_INPUT_KEY_COMPARATOR.compare(bwForKey2, bwForKey1) > 0);
+
+    assertTrue(
+        KAFKA_INPUT_KEY_COMPARATOR.compare(
+            bbForKey1.array(),
+            bbForKey1.position(),
+            bbForKey1.remaining(),
+            bbForKey2.array(),
+            bbForKey2.position(),
+            bbForKey2.remaining()) < 0);
+    assertTrue(
+        KAFKA_INPUT_KEY_COMPARATOR.compare(
+            bbForKey2.array(),
+            bbForKey2.position(),
+            bbForKey2.remaining(),
+            bbForKey1.array(),
+            bbForKey1.position(),
+            bbForKey1.remaining()) > 0);
+  }
+
+  @Test
+  public void testCompareWithSameKeyWithDifferentOffset() throws IOException {
+    byte[] key = "123".getBytes();
+    long keyOffset1 = 1;
+    long keyOffset2 = 2;
+    BytesWritable bwForKey1 = getBytesWritable(key, keyOffset1);
+    BytesWritable bwForKey2 = getBytesWritable(key, keyOffset2);
+    ByteBuffer bbForKey1 = getSerializedBytesWritable(key, keyOffset1);
+    ByteBuffer bbForKey2 = getSerializedBytesWritable(key, keyOffset2);
+
+    assertTrue(KAFKA_INPUT_KEY_COMPARATOR.compare(bwForKey1, bwForKey2) > 0);
+    assertTrue(KAFKA_INPUT_KEY_COMPARATOR.compare(bwForKey2, bwForKey1) < 0);
+
+    assertTrue(
+        KAFKA_INPUT_KEY_COMPARATOR.compare(
+            bbForKey1.array(),
+            bbForKey1.position(),
+            bbForKey1.remaining(),
+            bbForKey2.array(),
+            bbForKey2.position(),
+            bbForKey2.remaining()) > 0);
+    assertTrue(
+        KAFKA_INPUT_KEY_COMPARATOR.compare(
+            bbForKey2.array(),
+            bbForKey2.position(),
+            bbForKey2.remaining(),
+            bbForKey1.array(),
+            bbForKey1.position(),
+            bbForKey1.remaining()) < 0);
+  }
+
+  @Test
+  public void testSprayKeySorting() throws IOException {
+    byte[] key = "123".getBytes();
+    long keyOffset1 = 1;
+    BytesWritable bwForKey1 = getBytesWritable(key, keyOffset1);
+    ByteBuffer bbForKey1 = getSerializedBytesWritable(key, keyOffset1);
+
+    assertTrue(KAFKA_INPUT_KEY_COMPARATOR.compare(EMPTY_BYTES_WRITABLE, bwForKey1) < 0);
+    assertTrue(KAFKA_INPUT_KEY_COMPARATOR.compare(bwForKey1, EMPTY_BYTES_WRITABLE) > 0);
+
+    assertTrue(
+        KAFKA_INPUT_KEY_COMPARATOR.compare(
+            bbForKey1.array(),
+            bbForKey1.position(),
+            bbForKey1.remaining(),
+            SERIALIZED_EMPTY_BYTES_WRITABLE.array(),
+            SERIALIZED_EMPTY_BYTES_WRITABLE.position(),
+            SERIALIZED_EMPTY_BYTES_WRITABLE.remaining()) > 0);
+    assertTrue(
+        KAFKA_INPUT_KEY_COMPARATOR.compare(
+            SERIALIZED_EMPTY_BYTES_WRITABLE.array(),
+            SERIALIZED_EMPTY_BYTES_WRITABLE.position(),
+            SERIALIZED_EMPTY_BYTES_WRITABLE.remaining(),
+            bbForKey1.array(),
+            bbForKey1.position(),
+            bbForKey1.remaining()) < 0);
+  }
+}

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/input/kafka/TestKafkaInputMRPartitioner.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/input/kafka/TestKafkaInputMRPartitioner.java
@@ -1,0 +1,36 @@
+package com.linkedin.venice.hadoop.input.kafka;
+
+import static org.testng.Assert.*;
+
+import org.apache.hadoop.io.BytesWritable;
+import org.apache.hadoop.mapred.JobConf;
+import org.testng.annotations.Test;
+
+
+public class TestKafkaInputMRPartitioner {
+  private static final KafkaInputMRPartitioner MR_PARTITIONER = new KafkaInputMRPartitioner();
+  static {
+    MR_PARTITIONER.configure(new JobConf());
+  }
+  private static final int PARTITION_COUNT = 10000;
+
+  @Test
+  public void testWithDifferentKeys() {
+    BytesWritable bwForKey1 = TestKafkaInputKeyComparator.getBytesWritable("123".getBytes(), 1);
+    BytesWritable bwForKey2 = TestKafkaInputKeyComparator.getBytesWritable("223".getBytes(), 2);
+
+    assertNotEquals(
+        MR_PARTITIONER.getPartition(bwForKey1, PARTITION_COUNT),
+        MR_PARTITIONER.getPartition(bwForKey2, PARTITION_COUNT));
+  }
+
+  @Test
+  public void testWithSameKeyWithDifferentOffsets() {
+    BytesWritable bwForKey1 = TestKafkaInputKeyComparator.getBytesWritable("123".getBytes(), 1);
+    BytesWritable bwForKey2 = TestKafkaInputKeyComparator.getBytesWritable("123".getBytes(), 2);
+
+    assertEquals(
+        MR_PARTITIONER.getPartition(bwForKey1, PARTITION_COUNT),
+        MR_PARTITIONER.getPartition(bwForKey2, PARTITION_COUNT));
+  }
+}

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/input/kafka/TestKafkaInputValueGroupingComparator.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/input/kafka/TestKafkaInputValueGroupingComparator.java
@@ -1,0 +1,27 @@
+package com.linkedin.venice.hadoop.input.kafka;
+
+import static org.testng.Assert.*;
+
+import org.apache.hadoop.io.BytesWritable;
+import org.testng.annotations.Test;
+
+
+public class TestKafkaInputValueGroupingComparator {
+  private static final KafkaInputValueGroupingComparator GROUPING_COMPARATOR = new KafkaInputValueGroupingComparator();
+
+  @Test
+  public void testDifferentKeys() {
+    BytesWritable bwForKey1 = TestKafkaInputKeyComparator.getBytesWritable("123".getBytes(), 1);
+    BytesWritable bwForKey2 = TestKafkaInputKeyComparator.getBytesWritable("223".getBytes(), 2);
+
+    assertTrue(GROUPING_COMPARATOR.compare(bwForKey1, bwForKey2) < 0);
+  }
+
+  @Test
+  public void testWithSameKeyWithDifferentOffsets() {
+    BytesWritable bwForKey1 = TestKafkaInputKeyComparator.getBytesWritable("123".getBytes(), 1);
+    BytesWritable bwForKey2 = TestKafkaInputKeyComparator.getBytesWritable("123".getBytes(), 2);
+
+    assertTrue(GROUPING_COMPARATOR.compare(bwForKey1, bwForKey2) == 0);
+  }
+}

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/input/kafka/TestVeniceKafkaInputMapper.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/input/kafka/TestVeniceKafkaInputMapper.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.verify;
 import com.linkedin.venice.hadoop.AbstractTestVeniceMapper;
 import com.linkedin.venice.hadoop.AbstractVeniceFilter;
 import com.linkedin.venice.hadoop.FilterChain;
+import com.linkedin.venice.hadoop.input.kafka.avro.KafkaInputMapperKey;
 import com.linkedin.venice.hadoop.input.kafka.avro.KafkaInputMapperValue;
 import com.linkedin.venice.hadoop.input.kafka.avro.MapperValueType;
 import com.linkedin.venice.utils.VeniceProperties;
@@ -30,6 +31,12 @@ import org.testng.annotations.Test;
 
 public class TestVeniceKafkaInputMapper extends AbstractTestVeniceMapper<VeniceKafkaInputMapper> {
   private static final BytesWritable BYTES_WRITABLE = new BytesWritable(new byte[0]);
+  private static final KafkaInputMapperKey EMPTY_KEY = new KafkaInputMapperKey();
+  static {
+    EMPTY_KEY.key = ByteBuffer.wrap("test_key".getBytes());
+    EMPTY_KEY.offset = 1;
+  }
+
   private static final String RMD = "rmd";
 
   @Override
@@ -82,7 +89,7 @@ public class TestVeniceKafkaInputMapper extends AbstractTestVeniceMapper<VeniceK
     ArgumentCaptor<BytesWritable> valueCaptor = ArgumentCaptor.forClass(BytesWritable.class);
     OutputCollector<BytesWritable, BytesWritable> collector = mock(OutputCollector.class);
 
-    mapper.map(BYTES_WRITABLE, generateKIFRecord(), collector, null);
+    mapper.map(EMPTY_KEY, generateKIFRecord(), collector, null);
 
     // Given there's no filter and all records are valid, collector should collect all key and value
     verify(collector, times(getNumberOfCollectorInvocationForFirstMapInvocation(numReducers, taskId)))
@@ -100,7 +107,7 @@ public class TestVeniceKafkaInputMapper extends AbstractTestVeniceMapper<VeniceK
     mapper.configureTask(any(), any());
     int validCount = 0, filteredCount = 0;
     for (int i = 0; i < 5; i++) {
-      if (mapper.process(BYTES_WRITABLE, generateKIFRecord(), BYTES_WRITABLE, BYTES_WRITABLE, null)) {
+      if (mapper.process(EMPTY_KEY, generateKIFRecord(), BYTES_WRITABLE, BYTES_WRITABLE, null)) {
         validCount++;
       } else {
         filteredCount++;

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/input/kafka/chunk/TestChunkAssembler.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/input/kafka/chunk/TestChunkAssembler.java
@@ -66,7 +66,6 @@ public class TestChunkAssembler {
         messageSequenceNumber,
         VALUE_SCHEMA_ID,
         0);
-    Collections.shuffle(values);
     ChunkAssembler.ValueBytesAndSchemaId assembledValue =
         chunkAssembler.assembleAndGetValue(serializedKey, values.iterator());
 
@@ -77,7 +76,7 @@ public class TestChunkAssembler {
   }
 
   // E.g. chunk_0, chunk_1, … chunk_N (no manifest)
-  @Test(expectedExceptions = VeniceException.class, expectedExceptionsMessageRegExp = ".*No regular value nor chunk manifest.*")
+  @Test
   public void testNoCompleteLargeValueWithMissingManifest() {
     final int totalChunkCount = 10;
     final int eachCountSizeInBytes = 20;
@@ -97,8 +96,7 @@ public class TestChunkAssembler {
         messageSequenceNumber,
         VALUE_SCHEMA_ID,
         0);
-    values.remove(values.size() - 1); // Remove the last value which should be a manifest
-    Collections.shuffle(values);
+    values.remove(0); // Remove the first value which should be a manifest
 
     ChunkAssembler.ValueBytesAndSchemaId assembledValue =
         chunkAssembler.assembleAndGetValue(serializedKey, values.iterator());
@@ -124,9 +122,8 @@ public class TestChunkAssembler {
         messageSequenceNumber,
         VALUE_SCHEMA_ID,
         0);
-    int indexOfMissingChunk = ThreadLocalRandom.current().nextInt(values.size() - 1);
+    int indexOfMissingChunk = ThreadLocalRandom.current().nextInt(values.size() - 2) + 1;
     values.remove(indexOfMissingChunk); // Remove a chunk
-    Collections.shuffle(values);
     chunkAssembler.assembleAndGetValue(serializedKey, values.iterator());
   }
 
@@ -170,11 +167,10 @@ public class TestChunkAssembler {
         VALUE_SCHEMA_ID_2,
         totalChunkCount1 + 1);
 
-    values2.remove(values2.size() - 1); // Remove the manifest from the second sequence
+    values2.remove(0); // Remove the manifest from the second sequence
     List<BytesWritable> allValues = new ArrayList<>();
-    allValues.addAll(values1);
     allValues.addAll(values2);
-    Collections.shuffle(allValues);
+    allValues.addAll(values1);
 
     ChunkAssembler.ValueBytesAndSchemaId assembledValue =
         chunkAssembler.assembleAndGetValue(serializedKey, allValues.iterator());
@@ -226,11 +222,11 @@ public class TestChunkAssembler {
         VALUE_SCHEMA_ID_2,
         totalChunkCount1);
 
-    int indexOfMissingChunk = ThreadLocalRandom.current().nextInt(values2.size() - 1);
+    int indexOfMissingChunk = ThreadLocalRandom.current().nextInt(values2.size() - 2) + 1;
     values2.remove(indexOfMissingChunk); // Remove a chunk from the second sequence
     List<BytesWritable> allValues = new ArrayList<>();
-    allValues.addAll(values1);
     allValues.addAll(values2);
+    allValues.addAll(values1);
     chunkAssembler.assembleAndGetValue(serializedKey, allValues.iterator());
   }
 
@@ -274,9 +270,8 @@ public class TestChunkAssembler {
         VALUE_SCHEMA_ID_2,
         totalChunkCount1);
     List<BytesWritable> allValues = new ArrayList<>();
-    allValues.addAll(values1);
     allValues.addAll(values2);
-    Collections.shuffle(allValues);
+    allValues.addAll(values1);
 
     ChunkAssembler.ValueBytesAndSchemaId assembledValue =
         chunkAssembler.assembleAndGetValue(serializedKey, allValues.iterator());
@@ -337,9 +332,8 @@ public class TestChunkAssembler {
         VALUE_SCHEMA_ID_2,
         totalChunkCount1 + 1);
     List<BytesWritable> allValues = new ArrayList<>();
-    allValues.addAll(values1);
     allValues.addAll(values2);
-    Collections.shuffle(allValues);
+    allValues.addAll(values1);
 
     ChunkAssembler.ValueBytesAndSchemaId assembledValue =
         chunkAssembler.assembleAndGetValue(serializedKey, allValues.iterator());
@@ -400,9 +394,8 @@ public class TestChunkAssembler {
         VALUE_SCHEMA_ID_2,
         totalChunkCount1 + 1);
     List<BytesWritable> allValues = new ArrayList<>();
-    allValues.addAll(values1);
     allValues.addAll(values2);
-    Collections.shuffle(allValues);
+    allValues.addAll(values1);
 
     ChunkAssembler.ValueBytesAndSchemaId assembledValue =
         chunkAssembler.assembleAndGetValue(serializedKey, allValues.iterator());
@@ -433,8 +426,7 @@ public class TestChunkAssembler {
         VALUE_SCHEMA_ID,
         0);
     byte[] regularValueBytes = createChunkBytes(100, 23);
-    values.add(createRegularValue(regularValueBytes, VALUE_SCHEMA_ID_2, totalChunkCount + 1, MapperValueType.PUT));
-    Collections.shuffle(values);
+    values.add(0, createRegularValue(regularValueBytes, VALUE_SCHEMA_ID_2, totalChunkCount + 1, MapperValueType.PUT));
     ChunkAssembler.ValueBytesAndSchemaId assembledValue =
         chunkAssembler.assembleAndGetValue(serializedKey, values.iterator());
 
@@ -464,11 +456,10 @@ public class TestChunkAssembler {
         VALUE_SCHEMA_ID,
         0);
     // Randomly remove a value to simulate the incomplete large value
-    values.remove(ThreadLocalRandom.current().nextInt(values.size()));
+    values.remove(ThreadLocalRandom.current().nextInt(values.size() - 2) + 1);
 
     byte[] regularValueBytes = createChunkBytes(100, 23);
-    values.add(createRegularValue(regularValueBytes, VALUE_SCHEMA_ID_2, totalChunkCount + 1, MapperValueType.PUT));
-    Collections.shuffle(values);
+    values.add(0, createRegularValue(regularValueBytes, VALUE_SCHEMA_ID_2, totalChunkCount + 1, MapperValueType.PUT));
     ChunkAssembler.ValueBytesAndSchemaId assembledValue =
         chunkAssembler.assembleAndGetValue(serializedKey, values.iterator());
 
@@ -492,8 +483,8 @@ public class TestChunkAssembler {
     values.add(createRegularValue(value1Bytes, VALUE_SCHEMA_ID_2, value1Offset, MapperValueType.PUT));
     values.add(createRegularValue(value2Bytes, VALUE_SCHEMA_ID_2, value2Offset, MapperValueType.PUT));
     values.add(createRegularValue(value3Bytes, VALUE_SCHEMA_ID_2, value3Offset, MapperValueType.PUT)); // The third
-                                                                                                       // value wins
-    Collections.shuffle(values);
+
+    Collections.reverse(values); // value wins
 
     final byte[] serializedKey = createChunkBytes(0, 5);
     ChunkAssembler.ValueBytesAndSchemaId assembledValue =
@@ -518,8 +509,9 @@ public class TestChunkAssembler {
     values.add(createRegularValue(value1Bytes, VALUE_SCHEMA_ID_2, value1Offset, MapperValueType.PUT));
     values.add(createRegularValue(new byte[0], -1, value2Offset, MapperValueType.DELETE));
     values.add(createRegularValue(value3Bytes, VALUE_SCHEMA_ID_2, value3Offset, MapperValueType.PUT)); // The third
-                                                                                                       // value wins
-    Collections.shuffle(values);
+
+    // value wins
+    Collections.reverse(values);
 
     final byte[] serializedKey = createChunkBytes(0, 5);
     ChunkAssembler.ValueBytesAndSchemaId assembledValue =
@@ -551,8 +543,7 @@ public class TestChunkAssembler {
         VALUE_SCHEMA_ID,
         0);
     // "Delete value" at the end
-    values.add(createRegularValue(new byte[0], -1, totalChunkCount + 1, MapperValueType.DELETE));
-    Collections.shuffle(values);
+    values.add(0, createRegularValue(new byte[0], -1, totalChunkCount + 1, MapperValueType.DELETE));
     ChunkAssembler.ValueBytesAndSchemaId assembledValue =
         chunkAssembler.assembleAndGetValue(serializedKey, values.iterator());
     Assert.assertNull(assembledValue);
@@ -579,11 +570,10 @@ public class TestChunkAssembler {
         VALUE_SCHEMA_ID,
         0);
     // Randomly remove a value to simulate the incomplete large value
-    values.remove(ThreadLocalRandom.current().nextInt(values.size()));
+    values.remove(ThreadLocalRandom.current().nextInt(values.size() - 2) + 1);
 
     // "Delete value" at the end
-    values.add(createRegularValue(new byte[0], -1, totalChunkCount + 1, MapperValueType.DELETE));
-    Collections.shuffle(values);
+    values.add(0, createRegularValue(new byte[0], -1, totalChunkCount + 1, MapperValueType.DELETE));
     ChunkAssembler.ValueBytesAndSchemaId assembledValue =
         chunkAssembler.assembleAndGetValue(serializedKey, values.iterator());
 
@@ -603,7 +593,7 @@ public class TestChunkAssembler {
     values.add(createRegularValue(value1Bytes, VALUE_SCHEMA_ID_2, value1Offset, MapperValueType.PUT));
     values.add(createRegularValue(value2Bytes, VALUE_SCHEMA_ID_2, value2Offset, MapperValueType.PUT));
     values.add(createRegularValue(new byte[0], -1, value3Offset, MapperValueType.DELETE)); // The third value wins
-    Collections.shuffle(values);
+    Collections.reverse(values);
 
     final byte[] serializedKey = createChunkBytes(0, 5);
     ChunkAssembler.ValueBytesAndSchemaId assembledValue =
@@ -624,8 +614,6 @@ public class TestChunkAssembler {
 
     final byte[] serializedKey = createChunkBytes(0, 5);
     List<BytesWritable> values = new ArrayList<>(1 + totalChunkCount + 1);
-    byte[] regularValueBytes = createChunkBytes(100, 23);
-    values.add(createRegularValue(regularValueBytes, VALUE_SCHEMA_ID_2, 0, MapperValueType.PUT));
     values.addAll(
         createKafkaInputMapperValues(
             serializedKey,
@@ -638,8 +626,9 @@ public class TestChunkAssembler {
             1));
     // Randomly remove a value chunk to simulate the incomplete large value
     values.remove(ThreadLocalRandom.current().nextInt(values.size() - 2) + 1);
+    byte[] regularValueBytes = createChunkBytes(100, 23);
+    values.add(createRegularValue(regularValueBytes, VALUE_SCHEMA_ID_2, 0, MapperValueType.PUT));
 
-    Collections.shuffle(values);
     ChunkAssembler.ValueBytesAndSchemaId assembledValue =
         chunkAssembler.assembleAndGetValue(serializedKey, values.iterator());
 
@@ -660,8 +649,7 @@ public class TestChunkAssembler {
 
     final byte[] serializedKey = createChunkBytes(0, 5);
     List<BytesWritable> values = new ArrayList<>();
-    byte[] regularValueBytes = createChunkBytes(100, 23);
-    values.add(createRegularValue(regularValueBytes, VALUE_SCHEMA_ID_2, 0, MapperValueType.PUT));
+
     values.addAll(
         createKafkaInputMapperValues(
             serializedKey,
@@ -672,7 +660,8 @@ public class TestChunkAssembler {
             messageSequenceNumber,
             VALUE_SCHEMA_ID,
             1));
-    Collections.shuffle(values);
+    byte[] regularValueBytes = createChunkBytes(100, 23);
+    values.add(createRegularValue(regularValueBytes, VALUE_SCHEMA_ID_2, 0, MapperValueType.PUT));
     ChunkAssembler.ValueBytesAndSchemaId assembledValue =
         chunkAssembler.assembleAndGetValue(serializedKey, values.iterator());
 
@@ -693,7 +682,6 @@ public class TestChunkAssembler {
 
     final byte[] serializedKey = createChunkBytes(0, 5);
     List<BytesWritable> values = new ArrayList<>();
-    values.add(createRegularValue(new byte[0], -1, 0, MapperValueType.DELETE));
 
     values.addAll(
         createKafkaInputMapperValues(
@@ -705,7 +693,8 @@ public class TestChunkAssembler {
             messageSequenceNumber,
             VALUE_SCHEMA_ID,
             1));
-    Collections.shuffle(values);
+    values.add(createRegularValue(new byte[0], -1, 0, MapperValueType.DELETE));
+
     ChunkAssembler.ValueBytesAndSchemaId assembledValue =
         chunkAssembler.assembleAndGetValue(serializedKey, values.iterator());
 
@@ -726,7 +715,6 @@ public class TestChunkAssembler {
 
     final byte[] serializedKey = createChunkBytes(0, 5);
     List<BytesWritable> values = new ArrayList<>();
-    values.add(createRegularValue(new byte[0], -1, 0, MapperValueType.DELETE));
     values.addAll(
         createKafkaInputMapperValues(
             serializedKey,
@@ -739,8 +727,8 @@ public class TestChunkAssembler {
             1));
     // Randomly remove a chunk value to simulate the incomplete large value
     values.remove(ThreadLocalRandom.current().nextInt(values.size() - 2) + 1);
+    values.add(createRegularValue(new byte[0], -1, 0, MapperValueType.DELETE));
 
-    Collections.shuffle(values);
     ChunkAssembler.ValueBytesAndSchemaId assembledValue =
         chunkAssembler.assembleAndGetValue(serializedKey, values.iterator());
 
@@ -812,6 +800,9 @@ public class TestChunkAssembler {
     lastMapperValue.replicationMetadataVersionId = 1;
 
     values.add(serialize(lastMapperValue));
+
+    // The offset of the messages will be in descending order.
+    Collections.reverse(values);
     return values;
   }
 

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/utils/ByteUtils.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/utils/ByteUtils.java
@@ -207,6 +207,16 @@ public class ByteUtils {
     }
   }
 
+  public static byte[] copyByteArray(ByteBuffer byteBuffer) {
+    if (!byteBuffer.hasRemaining()) {
+      return new byte[0];
+    }
+    int size = byteBuffer.remaining();
+    byte[] ret = new byte[size];
+    System.arraycopy(byteBuffer.array(), byteBuffer.position(), ret, 0, size);
+    return ret;
+  }
+
   /**
    * Extract the data in the ByteBuffer into the destination array by copying "length" bytes from the source
    * buffer into the given array, starting at the current position of the source buffer and at the given offset in the

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/utils/ByteUtilsTest.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/utils/ByteUtilsTest.java
@@ -1,5 +1,7 @@
 package com.linkedin.venice.utils;
 
+import java.nio.ByteBuffer;
+import java.util.Arrays;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -35,5 +37,16 @@ public class ByteUtilsTest {
     Assert.assertEquals(ByteUtils.generateHumanReadableByteCountString((long) Math.pow(1024, 6)), "1.0 EiB");
     Assert.assertEquals(ByteUtils.generateHumanReadableByteCountString(Long.MAX_VALUE), "8.0 EiB");
     Assert.assertEquals(ByteUtils.generateHumanReadableByteCountString(Long.MIN_VALUE), "-8.0 EiB");
+  }
+
+  @Test
+  public void testCopyByteArray() {
+    ByteBuffer EMPTY_BYTE_BUFFER = ByteBuffer.wrap(new byte[0]);
+
+    Assert.assertEquals(ByteUtils.copyByteArray(EMPTY_BYTE_BUFFER).length, 0);
+
+    byte[] data = "111222333".getBytes();
+    ByteBuffer nonEmptyByteBuffer = ByteBuffer.wrap(data, 3, 3);
+    Assert.assertTrue(Arrays.equals(ByteUtils.copyByteArray(nonEmptyByteBuffer), "222".getBytes()));
   }
 }

--- a/internal/venice-common/src/main/java/org/apache/avro/io/OptimizedBinaryDecoderFactory.java
+++ b/internal/venice-common/src/main/java/org/apache/avro/io/OptimizedBinaryDecoderFactory.java
@@ -1,6 +1,7 @@
 package org.apache.avro.io;
 
 import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
+import java.nio.ByteBuffer;
 
 
 public class OptimizedBinaryDecoderFactory {
@@ -16,8 +17,12 @@ public class OptimizedBinaryDecoderFactory {
     return DEFAULT_FACTORY;
   }
 
+  public OptimizedBinaryDecoder createOptimizedBinaryDecoder(ByteBuffer bb) {
+    return createOptimizedBinaryDecoder(bb.array(), bb.position(), bb.remaining());
+  }
+
   /**
-   * This function will create a optimized binary decoder.
+   * This function will create an optimized binary decoder.
    */
   public OptimizedBinaryDecoder createOptimizedBinaryDecoder(byte[] data, int offset, int length) {
     OptimizedBinaryDecoder threadLocalDecoder = localBinaryDecoder.get();

--- a/internal/venice-common/src/test/java/org/apache/avro/io/OptimizedBinaryDecoderTest.java
+++ b/internal/venice-common/src/test/java/org/apache/avro/io/OptimizedBinaryDecoderTest.java
@@ -16,11 +16,15 @@ public class OptimizedBinaryDecoderTest {
 
   @Test(dataProvider = "True-and-False", dataProviderClass = DataProviderUtils.class)
   public void testHappyPath(boolean buffered) throws IOException {
-    BinaryEncoder encoder = testHappyPath(null, buffered);
-    testHappyPath(encoder, buffered);
+    BinaryEncoder encoder = testHappyPath(null, buffered, false);
+    testHappyPath(encoder, buffered, false);
+    testHappyPath(encoder, buffered, true);
   }
 
-  private BinaryEncoder testHappyPath(BinaryEncoder reusedEncoder, boolean bufferedEncoder) throws IOException {
+  private BinaryEncoder testHappyPath(
+      BinaryEncoder reusedEncoder,
+      boolean bufferedEncoder,
+      boolean useByteBufferConstructor) throws IOException {
     int wholeArraySize = 100;
     int byteBufferSize = 50;
     byte[] bytes = new byte[byteBufferSize];
@@ -40,7 +44,12 @@ public class OptimizedBinaryDecoderTest {
     encoder.flush();
     byte[] wholeArray = byteArrayOutputStream.toByteArray();
 
-    BinaryDecoder decoder = FACTORY.createOptimizedBinaryDecoder(wholeArray, 0, wholeArray.length);
+    BinaryDecoder decoder;
+    if (useByteBufferConstructor) {
+      decoder = FACTORY.createOptimizedBinaryDecoder(ByteBuffer.wrap(wholeArray));
+    } else {
+      decoder = FACTORY.createOptimizedBinaryDecoder(wholeArray, 0, wholeArray.length);
+    }
     float deserializedFloat1 = decoder.readFloat();
     ByteBuffer deserializedByteBuffer = decoder.readBytes(null);
     float deserializedFloat2 = decoder.readFloat();

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/hadoop/input/kafka/TestKafkaInputRecordReader.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/hadoop/input/kafka/TestKafkaInputRecordReader.java
@@ -5,6 +5,7 @@ import static com.linkedin.venice.hadoop.VenicePushJob.KAFKA_INPUT_TOPIC;
 import static com.linkedin.venice.kafka.TopicManager.DEFAULT_KAFKA_OPERATION_TIMEOUT_MS;
 
 import com.linkedin.venice.hadoop.VenicePushJob;
+import com.linkedin.venice.hadoop.input.kafka.avro.KafkaInputMapperKey;
 import com.linkedin.venice.hadoop.input.kafka.avro.KafkaInputMapperValue;
 import com.linkedin.venice.hadoop.input.kafka.avro.MapperValueType;
 import com.linkedin.venice.integration.utils.KafkaBrokerWrapper;
@@ -21,7 +22,6 @@ import com.linkedin.venice.utils.Utils;
 import com.linkedin.venice.writer.VeniceWriter;
 import com.linkedin.venice.writer.VeniceWriterFactory;
 import java.io.IOException;
-import org.apache.hadoop.io.BytesWritable;
 import org.apache.hadoop.mapred.JobConf;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
@@ -86,10 +86,10 @@ public class TestKafkaInputRecordReader {
 
     KafkaInputRecordReader reader = new KafkaInputRecordReader(new KafkaInputSplit(topic, 0, 0, 102), conf, null);
     for (int i = 0; i < 100; ++i) {
-      BytesWritable key = new BytesWritable();
+      KafkaInputMapperKey key = new KafkaInputMapperKey();
       KafkaInputMapperValue value = new KafkaInputMapperValue();
       reader.next(key, value);
-      Assert.assertEquals(key.copyBytes(), (KAFKA_MESSAGE_KEY_PREFIX + i).getBytes());
+      Assert.assertEquals(key.key.array(), (KAFKA_MESSAGE_KEY_PREFIX + i).getBytes());
       Assert.assertEquals(value.offset, i + 1);
       Assert.assertEquals(value.schemaId, -1);
       Assert.assertEquals(value.valueType, MapperValueType.PUT);
@@ -106,10 +106,10 @@ public class TestKafkaInputRecordReader {
     conf.set(VenicePushJob.KAFKA_SOURCE_KEY_SCHEMA_STRING_PROP, ChunkedKeySuffix.SCHEMA$.toString());
     KafkaInputRecordReader reader = new KafkaInputRecordReader(new KafkaInputSplit(topic, 0, 0, 102), conf, null);
     for (int i = 0; i < 100; ++i) {
-      BytesWritable key = new BytesWritable();
+      KafkaInputMapperKey key = new KafkaInputMapperKey();
       KafkaInputMapperValue value = new KafkaInputMapperValue();
       reader.next(key, value);
-      Assert.assertEquals(key.copyBytes(), (KAFKA_MESSAGE_KEY_PREFIX + i).getBytes());
+      Assert.assertEquals(key.key.array(), (KAFKA_MESSAGE_KEY_PREFIX + i).getBytes());
       Assert.assertEquals(value.offset, i + 1);
       Assert.assertEquals(value.schemaId, -1);
       if (i <= 10) {
@@ -132,7 +132,7 @@ public class TestKafkaInputRecordReader {
     conf.set(VenicePushJob.KAFKA_SOURCE_KEY_SCHEMA_STRING_PROP, ChunkedKeySuffix.SCHEMA$.toString());
     KafkaInputRecordReader reader = new KafkaInputRecordReader(new KafkaInputSplit(topic, 0, 0, 102), conf, null);
     for (int i = 0; i < 100; ++i) {
-      BytesWritable key = new BytesWritable();
+      KafkaInputMapperKey key = new KafkaInputMapperKey();
       KafkaInputMapperValue value = new KafkaInputMapperValue();
       if (i == 21) {
         try {
@@ -145,7 +145,7 @@ public class TestKafkaInputRecordReader {
       } else {
         reader.next(key, value);
       }
-      Assert.assertEquals(key.copyBytes(), (KAFKA_MESSAGE_KEY_PREFIX + i).getBytes());
+      Assert.assertEquals(key.key.array(), (KAFKA_MESSAGE_KEY_PREFIX + i).getBytes());
       Assert.assertEquals(value.offset, i + 1);
       Assert.assertEquals(value.schemaId, -1);
       if (i <= 10) {


### PR DESCRIPTION
Without MR secondary sorting, the KIF reducer needs to cache all the messages belonging to the same key, which includes regular put/delete and chunks and manifest to figure out the latest value, which is not sustainable for some hot keys, which have been updated many times, and another known issue to make it worse is that Venice doesn't cleanup the previous chunks when there is a new update, since the backend will just replace the chunk manifest entry, but leave alone the previous chunks.
With secondary sort, the assembly of chunked messages is much simpler and cost efficient since manifest is always with a higher offset than the corresponding chunks, and there is no need to cache all the decoded messages any more.

<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci], [server], [controller],
[router], [samza], [vpj], [fast-client], [thin-client], [alpini],
[admin-tool], [test], [build], [doc], [script]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->


## How was this PR tested?
Internal CI
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.