### PR TITLE
[da-vinci][server] Got rid of bounded memory queue for ingestion exceptions

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -2196,13 +2196,13 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
       // fast short-circuit in normal cases.
       try {
         int partitionId = partitionConsumptionState.getPartition();
-        offerConsumerException(
+        setIngestionException(
+            partitionId,
             new VeniceException(
                 "Store version " + this.kafkaVersionTopic + " partition " + partitionId
                     + " is consuming from local version topic and producing back to local version topic"
                     + ", kafkaClusterId = " + kafkaClusterId + ", kafkaUrl = " + kafkaUrl + ", this.localKafkaServer = "
-                    + this.localKafkaServer),
-            partitionId);
+                    + this.localKafkaServer));
       } catch (VeniceException offerToQueueException) {
         setLastStoreIngestionException(offerToQueueException);
       }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderProducerCallback.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderProducerCallback.java
@@ -190,7 +190,7 @@ class LeaderProducerCallback implements ChunkAwareCallback {
         // If EOP is not received yet, set the ingestion task exception so that ingestion will fail eventually.
         if (!endOfPushReceived) {
           try {
-            ingestionTask.offerProducerException(oe, sourceConsumerRecord.partition());
+            ingestionTask.setIngestionException(sourceConsumerRecord.partition(), oe);
           } catch (VeniceException offerToQueueException) {
             ingestionTask.setLastStoreIngestionException(offerToQueueException);
           }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/PartitionExceptionInfo.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/PartitionExceptionInfo.java
@@ -1,16 +1,15 @@
 package com.linkedin.davinci.kafka.consumer;
 
-import com.linkedin.venice.common.Measurable;
-
-
 /** Measurable wrapper for exception, partition id pair */
-class PartitionExceptionInfo implements Measurable {
+class PartitionExceptionInfo {
   private final Exception e;
   private final int partitionId;
+  private final boolean replicaCompleted;
 
-  public PartitionExceptionInfo(Exception e, int partitionId) {
+  public PartitionExceptionInfo(Exception e, int partitionId, boolean replicaCompleted) {
     this.e = e;
     this.partitionId = partitionId;
+    this.replicaCompleted = replicaCompleted;
   }
 
   public Exception getException() {
@@ -21,12 +20,7 @@ class PartitionExceptionInfo implements Measurable {
     return partitionId;
   }
 
-  @Override
-  public int getSize() {
-    int size = 4;
-    if (e != null && e.getMessage() != null) {
-      size += e.getMessage().length();
-    }
-    return size;
+  public boolean isReplicaCompleted() {
+    return replicaCompleted;
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreBufferService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreBufferService.java
@@ -283,9 +283,9 @@ public class StoreBufferService extends AbstractStoreBufferService {
             Exception processConsumerRecordException = (Exception) e;
             if (ingestionTask != null) {
               try {
-                ingestionTask.offerDrainerException(processConsumerRecordException, consumerRecord.partition());
-              } catch (VeniceException offerToQueueException) {
-                ingestionTask.setLastStoreIngestionException(offerToQueueException);
+                ingestionTask.setIngestionException(consumerRecord.partition(), processConsumerRecordException);
+              } catch (VeniceException ingestionException) {
+                ingestionTask.setLastStoreIngestionException(ingestionException);
               }
               if (e instanceof VeniceChecksumException) {
                 ingestionTask.recordChecksumVerificationFailure();

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreBufferServiceTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreBufferServiceTest.java
@@ -63,7 +63,7 @@ public class StoreBufferServiceTest {
     bufferService.start();
     verify(mockTask, timeout(TIMEOUT_IN_MS)).processConsumerRecord(cr1, null, kafkaUrl, 0L);
     verify(mockTask, timeout(TIMEOUT_IN_MS)).processConsumerRecord(cr2, null, kafkaUrl, 0L);
-    verify(mockTask).offerDrainerException(e, partition1);
+    verify(mockTask).setIngestionException(partition1, e);
     bufferService.stop();
   }
 
@@ -179,7 +179,7 @@ public class StoreBufferServiceTest {
       // Verify map the cleared out
       Assert.assertTrue(bufferService.getTopicToTimeSpentMap(i).size() == 0);
     }
-    verify(mockTask).offerDrainerException(e, partition1);
+    verify(mockTask).setIngestionException(partition1, e);
     verify(mockTask).recordChecksumVerificationFailure();
     bufferService.stop();
   }

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestHybrid.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestHybrid.java
@@ -373,6 +373,8 @@ public class TestHybrid {
           }
         });
 
+        // Run one more VPJ
+        runVPJ(vpjProperties, 2, controllerClient);
         // verify the topic compaction policy
         String topicForStoreVersion2 = Version.composeKafkaTopic(storeName, 2);
         Assert.assertTrue(


### PR DESCRIPTION
Previously, StoreIngestionTask is using a memory-bounded queue to buffer
the ingestion exception, which is working fine for most of the scenarios,
but it could block StoreBufferService if the exception queue is full without
draining, and it happened when some StoreInestionTask is closed, but there
are still some pending messages in the drainer queue, which would throw a lot
of exceptions to stuck the SToreBufferService since the exception queue is full.
    
The fix is to use Map to store the last exception per partition, which would never block.
In the meantime, this code change also fixed a couple of flaky tests in StoreIngestionTaskTest.
Also this code change modified the way how to track the ingestion exception per partition:
1. Record the ingestion exception whenever there is an exception thrown.
2. Unsubscribe the errored partition to avoid the data gap issue or useless consumption.
3. Only cleanup the partition exception during rebalance.

<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci], [server], [controller],
[router], [samza], [vpj], [fast-client], [thin-client], [alpini],
[admin-tool], [test], [build], [doc], [script]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->



## How was this PR tested?
CI.
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.