### PR TITLE
[build] Revert the git diff change

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -581,9 +581,10 @@ ext.createDiffFile = { ->
   def file = Files.createTempFile(URLEncoder.encode(project.name, 'UTF-8'), '.diff').toFile()
   def diffBase = "${git.getUpstreamRemote()}/main"
   def command = [
-      'git', 'diff', diffBase, '--no-color', '--minimal', '--', '.'
+      'git', 'diff', diffBase, '--no-color', '--minimal'
   ]
-  command.addAll(exclusionFilter)
+  // the git diff exclude requires git version 1.9 or above. Comment this out for now
+  // command.addAll(exclusionFilter)
   file.withOutputStream { out ->
     exec {
       commandLine command


### PR DESCRIPTION
Planned to use native git diff exclude syntax to exclude files we don't need for `diffCoverage` but it requires git version >= 1.9 and our internal CI has lower version.

Comment it out for now and will try to work on an alternative fix

### Test

jdk11 7584
jdk8 1180
