### PR TITLE
[vpj] Change config name from parent.controller.colo.name to parent.controller.region.name

### DIFF
--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
@@ -259,7 +259,7 @@ public class VenicePushJob implements AutoCloseable {
   /**
    * This config specifies the region identifier where parent controller is running
    */
-  public static final String PARENT_CONTROLLER_REGION_NAME = "parent.controller.colo.name";
+  public static final String PARENT_CONTROLLER_REGION_NAME = "parent.controller.region.name";
 
   /**
    * Relates to the above argument. An overridable amount of buffer to be applied to the epoch (as the rewind isn't


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci], [server], [controller],
[router], [samza], [vpj], [fast-client], [thin-client], [alpini],
[admin-tool], [test], [build], [doc], [script]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Change config name from `parent.controller.colo.name` to `parent.controller.region.name`
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

In PR #195, we started with `colo` to denote data centers. Felix suggested that `colo` was not an industry term and we decided to change it to `region`. I changed it in most places, but now realize that I missed one config name. Since this change is pretty new, changing the config to align with the industry.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
Github CI will run for this

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.