### PR TITLE
[server] A/A merge delete with field-level TS result should not reuse input

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/replication/merge/MergeConflictResolver.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/replication/merge/MergeConflictResolver.java
@@ -509,7 +509,7 @@ public class MergeConflictResolver {
     } else {
       mergedValueBytes = Optional.of(serializeMergedValueRecord(oldValueSchema, mergedValueAndRmd.getValue()));
     }
-    return new MergeConflictResult(mergedValueBytes, oldValueSchemaID, true, mergedValueAndRmd.getRmd());
+    return new MergeConflictResult(mergedValueBytes, oldValueSchemaID, false, mergedValueAndRmd.getRmd());
   }
 
   public MergeConflictResult update(

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/PartialUpdateTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/PartialUpdateTest.java
@@ -188,7 +188,7 @@ public class PartialUpdateTest {
         }
         updateBuilder.setEntriesToAddToMapField(mapFieldName, newEntries);
         GenericRecord partialUpdateRecord = updateBuilder.build();
-        sendStreamingRecord(veniceProducer, storeName, key, partialUpdateRecord, (long) (i * 10 + 1));
+        sendStreamingRecord(veniceProducer, storeName, key, partialUpdateRecord, i * 10L + 1);
       }
 
       // Verify the value record has been partially updated.
@@ -216,7 +216,7 @@ public class PartialUpdateTest {
       });
 
       // Send DELETE record that partially removes data.
-      sendStreamingDeleteRecord(veniceProducer, storeName, key, (long) ((updateCount - 1) * 10));
+      sendStreamingDeleteRecord(veniceProducer, storeName, key, (updateCount - 1) * 10L);
 
       TestUtils.waitForNonDeterministicAssertion(TEST_TIMEOUT_MS, TimeUnit.MILLISECONDS, true, () -> {
         GenericRecord valueRecord = readValue(storeReader, key);

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/PartialUpdateTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/PartialUpdateTest.java
@@ -239,7 +239,7 @@ public class PartialUpdateTest {
       });
 
       // Send DELETE record that fully removes data.
-      sendStreamingDeleteRecord(veniceProducer, storeName, key, (long) (updateCount * 10));
+      sendStreamingDeleteRecord(veniceProducer, storeName, key, updateCount * 10L);
       TestUtils.waitForNonDeterministicAssertion(TEST_TIMEOUT_MS, TimeUnit.MILLISECONDS, true, () -> {
         GenericRecord valueRecord = readValue(storeReader, key);
         boolean nullRecord = (valueRecord == null);


### PR DESCRIPTION
## [server] A/A merge delete with field-level TS result should not reuse input
MergeConflictResult.mergeDeleteWithFieldLevelTimestamp() should not result input as its data was not prepend with int header buffer. Integration test with DELETE op reveals that it can lead to ingestion task failure.
## How was this PR tested?
Add new integration test logic to cover the case. Test both DELETE that partially removes some data and also fully removes data.

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.