### PR TITLE
[server] Support RMD chunking on KIF repush

### DIFF
--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/AbstractMapReduceTask.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/AbstractMapReduceTask.java
@@ -27,6 +27,8 @@ public abstract class AbstractMapReduceTask {
   private int taskId = TASK_ID_NOT_SET;
   private boolean isChunkingEnabled;
 
+  private boolean isRmdChunkingEnabled;
+
   abstract protected void configureTask(VeniceProperties props, JobConf job);
 
   protected int getPartitionCount() {
@@ -45,6 +47,14 @@ public abstract class AbstractMapReduceTask {
     return isChunkingEnabled;
   }
 
+  protected void setRmdChunkingEnabled(boolean isRmdChunkingEnabled) {
+    this.isRmdChunkingEnabled = isRmdChunkingEnabled;
+  }
+
+  protected boolean isRmdChunkingEnabled() {
+    return isRmdChunkingEnabled;
+  }
+
   public final void configure(JobConf job) {
     Properties javaProps = HadoopUtils.getProps(job);
     String sslConfiguratorClassName = job.get(SSL_CONFIGURATOR_CLASS_CONFIG);
@@ -57,6 +67,7 @@ public abstract class AbstractMapReduceTask {
       }
     }
     VeniceProperties props = new VeniceProperties(javaProps);
+    setRmdChunkingEnabled(props.getBoolean(VeniceWriter.ENABLE_RMD_CHUNKING, false));
     setChunkingEnabled(props.getBoolean(VeniceWriter.ENABLE_CHUNKING));
     this.partitionCount = job.getNumReduceTasks();
     TaskAttemptID taskAttemptID = TaskAttemptID.forName(job.get(MAPRED_TASK_ID_PROP_NAME));

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VeniceReducer.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VeniceReducer.java
@@ -32,6 +32,7 @@ import com.linkedin.venice.writer.DeleteMetadata;
 import com.linkedin.venice.writer.PutMetadata;
 import com.linkedin.venice.writer.VeniceWriter;
 import com.linkedin.venice.writer.VeniceWriterFactory;
+import com.linkedin.venice.writer.VeniceWriterOptions;
 import java.io.ByteArrayOutputStream;
 import java.io.Closeable;
 import java.io.IOException;
@@ -388,18 +389,21 @@ public class VeniceReducer extends AbstractMapReduceTask
     }
     writerProps.put(ConfigKeys.PUSH_JOB_MAP_REDUCE_JOB_ID, mapReduceJobId.getId());
     VeniceWriterFactory veniceWriterFactoryFactory = new VeniceWriterFactory(writerProps);
-    boolean chunkingEnabled = props.getBoolean(VeniceWriter.ENABLE_CHUNKING);
+    boolean chunkingEnabled = props.getBoolean(VeniceWriter.ENABLE_CHUNKING, false);
+    boolean rmdChunkingEnabled = props.getBoolean(VeniceWriter.ENABLE_RMD_CHUNKING, false);
     VenicePartitioner partitioner = PartitionUtils.getVenicePartitioner(props);
-    return veniceWriterFactoryFactory.createVeniceWriter(
-        props.getString(TOPIC_PROP),
-        new DefaultSerializer(),
-        new DefaultSerializer(),
-        new DefaultSerializer(),
-        Optional.of(chunkingEnabled),
-        SystemTime.INSTANCE,
-        partitioner,
-        Optional.empty(),
-        Optional.empty());
+
+    VeniceWriterOptions options =
+        new VeniceWriterOptions.Builder(props.getString(TOPIC_PROP)).setKeySerializer(new DefaultSerializer())
+            .setValueSerializer(new DefaultSerializer())
+            .setWriteComputeSerializer(new DefaultSerializer())
+            .setChunkingEnabled(chunkingEnabled)
+            .setRmdChunkingEnabled(rmdChunkingEnabled)
+            .setTime(SystemTime.INSTANCE)
+            .setPartitioner(partitioner)
+            .setPartitionCount(Optional.empty())
+            .build();
+    return veniceWriterFactoryFactory.createVeniceWriter(options);
   }
 
   private void telemetry() {

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/input/kafka/VeniceKafkaInputReducer.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/input/kafka/VeniceKafkaInputReducer.java
@@ -76,7 +76,7 @@ public class VeniceKafkaInputReducer extends VeniceReducer {
     super.setChunkingEnabled(isChunkingEnabled);
     if (isChunkingEnabled) {
       this.extractor = this::extractChunkedMessage;
-      this.chunkAssembler = new ChunkAssembler();
+      this.chunkAssembler = new ChunkAssembler(isRmdChunkingEnabled());
     } else {
       this.extractor = this::extractNonChunkedMessage;
       this.chunkAssembler = null;

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/input/kafka/chunk/ChunkAssembler.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/input/kafka/chunk/ChunkAssembler.java
@@ -146,13 +146,12 @@ public class ChunkAssembler {
            */
           continue;
         }
-        // Collecting chunks
+        // Matching chunk information with value and RMD chunks.
         boolean isChunkMatched = false;
         if (isRmdChunkingEnabled && (rmdChunksFound != rmdChunkKeySuffixes.length)) {
           for (int i = 0; i < rmdChunkKeySuffixes.length; i++) {
             ByteBuffer byteBuffer = rmdChunkKeySuffixes[i];
-            if (byteBuffer.equals(reusedMapperValue.chunkedKeySuffix)
-                && (reusedMapperValue.replicationMetadataPayload.remaining() > 0)) {
+            if (byteBuffer.equals(reusedMapperValue.chunkedKeySuffix)) {
               byte[] rmdChunk = new byte[reusedMapperValue.replicationMetadataPayload.remaining()];
               totalRmdByteCount += rmdChunk.length;
               reusedMapperValue.replicationMetadataPayload.get(rmdChunk);
@@ -163,6 +162,7 @@ public class ChunkAssembler {
             }
           }
         }
+        // Bypass iterations on value chunk matching if it is matched with RMD chunk.
         if (!isChunkMatched) {
           for (int i = 0; i < valueChunkKeySuffixes.length; i++) {
             ByteBuffer byteBuffer = valueChunkKeySuffixes[i];
@@ -176,8 +176,7 @@ public class ChunkAssembler {
             }
           }
         }
-        if ((valueChunksFound == valueChunks.length)
-            && ((!isRmdChunkingEnabled) || (rmdChunksFound == rmdChunks.length))) {
+        if ((valueChunksFound == valueChunks.length) && (rmdChunksFound == rmdChunks.length)) {
           break;
         }
       } else {

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/input/kafka/chunk/ChunkAssembler.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/input/kafka/chunk/ChunkAssembler.java
@@ -147,26 +147,31 @@ public class ChunkAssembler {
           continue;
         }
         // Collecting chunks
-        for (int i = 0; i < valueChunkKeySuffixes.length; i++) {
-          ByteBuffer byteBuffer = valueChunkKeySuffixes[i];
-          if (byteBuffer.equals(reusedMapperValue.chunkedKeySuffix)) {
-            byte[] valueChunk = new byte[reusedMapperValue.value.remaining()];
-            totalValueByteCount += valueChunk.length;
-            reusedMapperValue.value.get(valueChunk);
-            valueChunks[i] = valueChunk;
-            valueChunksFound++;
-            break;
-          }
-        }
-        if (isRmdChunkingEnabled) {
+        boolean isChunkMatched = false;
+        if (isRmdChunkingEnabled && (rmdChunksFound != rmdChunkKeySuffixes.length)) {
           for (int i = 0; i < rmdChunkKeySuffixes.length; i++) {
             ByteBuffer byteBuffer = rmdChunkKeySuffixes[i];
-            if (byteBuffer.equals(reusedMapperValue.chunkedKeySuffix)) {
+            if (byteBuffer.equals(reusedMapperValue.chunkedKeySuffix)
+                && (reusedMapperValue.replicationMetadataPayload.remaining() > 0)) {
               byte[] rmdChunk = new byte[reusedMapperValue.replicationMetadataPayload.remaining()];
               totalRmdByteCount += rmdChunk.length;
               reusedMapperValue.replicationMetadataPayload.get(rmdChunk);
               rmdChunks[i] = rmdChunk;
               rmdChunksFound++;
+              isChunkMatched = true;
+              break;
+            }
+          }
+        }
+        if (!isChunkMatched) {
+          for (int i = 0; i < valueChunkKeySuffixes.length; i++) {
+            ByteBuffer byteBuffer = valueChunkKeySuffixes[i];
+            if (byteBuffer.equals(reusedMapperValue.chunkedKeySuffix)) {
+              byte[] valueChunk = new byte[reusedMapperValue.value.remaining()];
+              totalValueByteCount += valueChunk.length;
+              reusedMapperValue.value.get(valueChunk);
+              valueChunks[i] = valueChunk;
+              valueChunksFound++;
               break;
             }
           }

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/input/kafka/chunk/TestChunkAssembler.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/input/kafka/chunk/TestChunkAssembler.java
@@ -29,7 +29,7 @@ import org.testng.annotations.Test;
 public class TestChunkAssembler {
 
   // Since every invocation on this method should clear its internal state, all tests sharing one instance should work
-  private final ChunkAssembler chunkAssembler = new ChunkAssembler();
+  private final ChunkAssembler chunkAssembler = new ChunkAssembler(false);
 
   private static final int CHUNK_MANIFEST_SCHEMA_ID =
       AvroProtocolDefinition.CHUNKED_VALUE_MANIFEST.getCurrentProtocolVersion();

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/input/kafka/chunk/TestChunkAssembler.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/input/kafka/chunk/TestChunkAssembler.java
@@ -27,10 +27,8 @@ import org.testng.annotations.Test;
 
 
 public class TestChunkAssembler {
-
-  // Since every invocation on this method should clear its internal state, all tests sharing one instance should work
   private final ChunkAssembler chunkAssembler = new ChunkAssembler(false);
-
+  private final ChunkAssembler rmdChunkingEnabledChunkAssembler = new ChunkAssembler(true);
   private static final int CHUNK_MANIFEST_SCHEMA_ID =
       AvroProtocolDefinition.CHUNKED_VALUE_MANIFEST.getCurrentProtocolVersion();
   private static final int CHUNK_VALUE_SCHEMA_ID = AvroProtocolDefinition.CHUNK.getCurrentProtocolVersion();
@@ -52,16 +50,16 @@ public class TestChunkAssembler {
     final int eachCountSizeInBytes = 20;
     final int segmentNumber = 12;
     final int messageSequenceNumber = 34;
-    final int currStartingByteValue = 0;
     final ChunkedValueManifest chunkedValueManifest = new ChunkedValueManifest();
     chunkedValueManifest.keysWithChunkIdSuffix = new ArrayList<>(totalChunkCount);
-
     final byte[] serializedKey = createChunkBytes(0, 5);
+
+    ChunkInfo valueChunkInfo = new ChunkInfo(totalChunkCount, eachCountSizeInBytes);
+
     List<BytesWritable> values = createKafkaInputMapperValues(
         serializedKey,
-        totalChunkCount,
-        currStartingByteValue,
-        eachCountSizeInBytes,
+        valueChunkInfo,
+        null,
         segmentNumber,
         messageSequenceNumber,
         VALUE_SCHEMA_ID,
@@ -75,6 +73,33 @@ public class TestChunkAssembler {
     Assert.assertEquals(assembledValue.getReplicationMetadataVersionId(), 1);
   }
 
+  // E.g. value_chunk_0, value_chunk_1, ..., value_chunk_N, rmd_chunk_0, rmd_chunk1, ..., rmd_chunk_M, chunk_manifest
+  @Test
+  public void testAssembleOneCompleteLargeValueWithRmdChunking() {
+    final int segmentNumber = 12;
+    final int messageSequenceNumber = 34;
+    ChunkInfo valueChunkInfo = new ChunkInfo(10, 20);
+    ChunkInfo rmdChunkInfo = new ChunkInfo(20, 10);
+    final byte[] serializedKey = createChunkBytes(0, 5);
+    List<BytesWritable> values = createKafkaInputMapperValues(
+        serializedKey,
+        valueChunkInfo,
+        rmdChunkInfo,
+        segmentNumber,
+        messageSequenceNumber,
+        VALUE_SCHEMA_ID,
+        0);
+    ChunkAssembler.ValueBytesAndSchemaId assembledValue =
+        rmdChunkingEnabledChunkAssembler.assembleAndGetValue(serializedKey, values.iterator());
+
+    Assert.assertNotNull(assembledValue);
+    Assert.assertEquals(assembledValue.getSchemaID(), VALUE_SCHEMA_ID);
+    Assert.assertEquals(
+        assembledValue.getBytes(),
+        createChunkBytes(0, valueChunkInfo.totalChunkCount * valueChunkInfo.eachCountSizeInBytes));
+    Assert.assertEquals(assembledValue.getReplicationMetadataVersionId(), 1);
+  }
+
   // E.g. chunk_0, chunk_1, … chunk_N (no manifest)
   @Test
   public void testNoCompleteLargeValueWithMissingManifest() {
@@ -82,16 +107,15 @@ public class TestChunkAssembler {
     final int eachCountSizeInBytes = 20;
     final int segmentNumber = 12;
     final int messageSequenceNumber = 34;
-    final int currStartingByteValue = 0;
     final ChunkedValueManifest chunkedValueManifest = new ChunkedValueManifest();
     chunkedValueManifest.keysWithChunkIdSuffix = new ArrayList<>(totalChunkCount);
+    ChunkInfo valueChunkInfo = new ChunkInfo(totalChunkCount, eachCountSizeInBytes);
 
     final byte[] serializedKey = createChunkBytes(0, 5);
     List<BytesWritable> values = createKafkaInputMapperValues(
         serializedKey,
-        totalChunkCount,
-        currStartingByteValue,
-        eachCountSizeInBytes,
+        valueChunkInfo,
+        null,
         segmentNumber,
         messageSequenceNumber,
         VALUE_SCHEMA_ID,
@@ -110,14 +134,13 @@ public class TestChunkAssembler {
     final int eachCountSizeInBytes = 20;
     final int segmentNumber = 12;
     final int messageSequenceNumber = 34;
-    final int currStartingByteValue = 0;
+    ChunkInfo valueChunkInfo = new ChunkInfo(totalChunkCount, eachCountSizeInBytes);
 
     final byte[] serializedKey = createChunkBytes(0, 5);
     List<BytesWritable> values = createKafkaInputMapperValues(
         serializedKey,
-        totalChunkCount,
-        currStartingByteValue,
-        eachCountSizeInBytes,
+        valueChunkInfo,
+        null,
         segmentNumber,
         messageSequenceNumber,
         VALUE_SCHEMA_ID,
@@ -137,7 +160,6 @@ public class TestChunkAssembler {
     final int totalChunkCount2 = 20;
     final int eachCountSizeInBytes2 = 15;
 
-    final int currStartingByteValue = 0;
     final ChunkId chunkId1 = new ChunkId();
     chunkId1.segmentNumber = 12;
     chunkId1.messageSequenceNumber = 34;
@@ -145,23 +167,22 @@ public class TestChunkAssembler {
     final ChunkId chunkId2 = new ChunkId();
     chunkId2.segmentNumber = 22;
     chunkId2.messageSequenceNumber = 54;
+    ChunkInfo valueChunkInfo1 = new ChunkInfo(totalChunkCount1, eachCountSizeInBytes1);
 
     final byte[] serializedKey = createChunkBytes(0, 5);
     List<BytesWritable> values1 = createKafkaInputMapperValues(
         serializedKey,
-        totalChunkCount1,
-        currStartingByteValue,
-        eachCountSizeInBytes1,
+        valueChunkInfo1,
+        null,
         chunkId1.segmentNumber,
         chunkId1.messageSequenceNumber,
         VALUE_SCHEMA_ID,
         0);
-
+    ChunkInfo valueChunkInfo2 = new ChunkInfo(totalChunkCount2, eachCountSizeInBytes2);
     List<BytesWritable> values2 = createKafkaInputMapperValues(
         serializedKey,
-        totalChunkCount2,
-        currStartingByteValue,
-        eachCountSizeInBytes2,
+        valueChunkInfo2,
+        null,
         chunkId2.segmentNumber,
         chunkId2.messageSequenceNumber,
         VALUE_SCHEMA_ID_2,
@@ -192,7 +213,6 @@ public class TestChunkAssembler {
     final int totalChunkCount2 = 20;
     final int eachCountSizeInBytes2 = 15;
 
-    final int currStartingByteValue = 0;
     final ChunkId chunkId1 = new ChunkId();
     chunkId1.segmentNumber = 12;
     chunkId1.messageSequenceNumber = 34;
@@ -200,13 +220,14 @@ public class TestChunkAssembler {
     final ChunkId chunkId2 = new ChunkId();
     chunkId2.segmentNumber = 22;
     chunkId2.messageSequenceNumber = 54;
+    ChunkInfo valueChunkInfo1 = new ChunkInfo(totalChunkCount1, eachCountSizeInBytes1);
+    ChunkInfo valueChunkInfo2 = new ChunkInfo(totalChunkCount2, eachCountSizeInBytes2);
 
     final byte[] serializedKey = createChunkBytes(0, 5);
     List<BytesWritable> values1 = createKafkaInputMapperValues(
         serializedKey,
-        totalChunkCount1,
-        currStartingByteValue,
-        eachCountSizeInBytes1,
+        valueChunkInfo1,
+        null,
         chunkId1.segmentNumber,
         chunkId1.messageSequenceNumber,
         VALUE_SCHEMA_ID,
@@ -214,9 +235,8 @@ public class TestChunkAssembler {
 
     List<BytesWritable> values2 = createKafkaInputMapperValues(
         serializedKey,
-        totalChunkCount2,
-        currStartingByteValue,
-        eachCountSizeInBytes2,
+        valueChunkInfo2,
+        null,
         chunkId2.segmentNumber,
         chunkId2.messageSequenceNumber,
         VALUE_SCHEMA_ID_2,
@@ -240,7 +260,6 @@ public class TestChunkAssembler {
     final int totalChunkCount2 = 20;
     final int eachCountSizeInBytes2 = 15;
 
-    final int currStartingByteValue = 0;
     final ChunkId chunkId1 = new ChunkId();
     chunkId1.segmentNumber = 12;
     chunkId1.messageSequenceNumber = 34;
@@ -248,13 +267,14 @@ public class TestChunkAssembler {
     final ChunkId chunkId2 = new ChunkId();
     chunkId2.segmentNumber = 22;
     chunkId2.messageSequenceNumber = 54; // Fresher large value
+    ChunkInfo valueChunkInfo1 = new ChunkInfo(totalChunkCount1, eachCountSizeInBytes1);
+    ChunkInfo valueChunkInfo2 = new ChunkInfo(totalChunkCount2, eachCountSizeInBytes2);
 
     final byte[] serializedKey = createChunkBytes(0, 5);
     List<BytesWritable> values1 = createKafkaInputMapperValues(
         serializedKey,
-        totalChunkCount1,
-        currStartingByteValue,
-        eachCountSizeInBytes1,
+        valueChunkInfo1,
+        null,
         chunkId1.segmentNumber,
         chunkId1.messageSequenceNumber,
         VALUE_SCHEMA_ID,
@@ -262,9 +282,8 @@ public class TestChunkAssembler {
 
     List<BytesWritable> values2 = createKafkaInputMapperValues(
         serializedKey,
-        totalChunkCount2,
-        currStartingByteValue,
-        eachCountSizeInBytes2,
+        valueChunkInfo2,
+        null,
         chunkId2.segmentNumber,
         chunkId2.messageSequenceNumber,
         VALUE_SCHEMA_ID_2,
@@ -290,7 +309,6 @@ public class TestChunkAssembler {
     final int totalChunkCount2 = 20;
     final int eachCountSizeInBytes2 = 15;
 
-    final int currStartingByteValue = 0;
     final ChunkId chunkId1 = new ChunkId();
     chunkId1.segmentNumber = 12;
     chunkId1.messageSequenceNumber = 34;
@@ -298,13 +316,14 @@ public class TestChunkAssembler {
     final ChunkId chunkId2 = new ChunkId();
     chunkId2.segmentNumber = 22;
     chunkId2.messageSequenceNumber = 54; // Fresher large value
+    ChunkInfo valueChunkInfo1 = new ChunkInfo(totalChunkCount1, eachCountSizeInBytes1);
+    ChunkInfo valueChunkInfo2 = new ChunkInfo(totalChunkCount2, eachCountSizeInBytes2);
 
     final byte[] serializedKey = createChunkBytes(0, 5);
     List<BytesWritable> values1 = createKafkaInputMapperValues(
         serializedKey,
-        totalChunkCount1,
-        currStartingByteValue,
-        eachCountSizeInBytes1,
+        valueChunkInfo1,
+        null,
         chunkId1.segmentNumber,
         chunkId1.messageSequenceNumber,
         VALUE_SCHEMA_ID,
@@ -324,9 +343,8 @@ public class TestChunkAssembler {
 
     List<BytesWritable> values2 = createKafkaInputMapperValues(
         serializedKey,
-        totalChunkCount2,
-        currStartingByteValue,
-        eachCountSizeInBytes2,
+        valueChunkInfo2,
+        null,
         chunkId2.segmentNumber,
         chunkId2.messageSequenceNumber,
         VALUE_SCHEMA_ID_2,
@@ -353,7 +371,6 @@ public class TestChunkAssembler {
     final int totalChunkCount2 = 20;
     final int eachCountSizeInBytes2 = 15;
 
-    final int currStartingByteValue = 0;
     final ChunkId chunkId1 = new ChunkId();
     chunkId1.segmentNumber = 12;
     chunkId1.messageSequenceNumber = 34;
@@ -361,13 +378,14 @@ public class TestChunkAssembler {
     final ChunkId chunkId2 = new ChunkId();
     chunkId2.segmentNumber = 22;
     chunkId2.messageSequenceNumber = 54; // Fresher large value
+    ChunkInfo valueChunkInfo1 = new ChunkInfo(totalChunkCount1, eachCountSizeInBytes1);
+    ChunkInfo valueChunkInfo2 = new ChunkInfo(totalChunkCount2, eachCountSizeInBytes2);
 
     final byte[] serializedKey = createChunkBytes(0, 5);
     List<BytesWritable> values1 = createKafkaInputMapperValues(
         serializedKey,
-        totalChunkCount1,
-        currStartingByteValue,
-        eachCountSizeInBytes1,
+        valueChunkInfo1,
+        null,
         chunkId1.segmentNumber,
         chunkId1.messageSequenceNumber,
         VALUE_SCHEMA_ID,
@@ -386,9 +404,8 @@ public class TestChunkAssembler {
 
     List<BytesWritable> values2 = createKafkaInputMapperValues(
         serializedKey,
-        totalChunkCount2,
-        currStartingByteValue,
-        eachCountSizeInBytes2,
+        valueChunkInfo2,
+        null,
         chunkId2.segmentNumber,
         chunkId2.messageSequenceNumber,
         VALUE_SCHEMA_ID_2,
@@ -411,16 +428,15 @@ public class TestChunkAssembler {
     final int eachCountSizeInBytes = 20;
     final int segmentNumber = 12;
     final int messageSequenceNumber = 34;
-    final int currStartingByteValue = 0;
     final ChunkedValueManifest chunkedValueManifest = new ChunkedValueManifest();
     chunkedValueManifest.keysWithChunkIdSuffix = new ArrayList<>(totalChunkCount);
+    ChunkInfo valueChunkInfo = new ChunkInfo(totalChunkCount, eachCountSizeInBytes);
 
     final byte[] serializedKey = createChunkBytes(0, 5);
     List<BytesWritable> values = createKafkaInputMapperValues(
         serializedKey,
-        totalChunkCount,
-        currStartingByteValue,
-        eachCountSizeInBytes,
+        valueChunkInfo,
+        null,
         segmentNumber,
         messageSequenceNumber,
         VALUE_SCHEMA_ID,
@@ -441,16 +457,15 @@ public class TestChunkAssembler {
     final int eachCountSizeInBytes = 20;
     final int segmentNumber = 12;
     final int messageSequenceNumber = 34;
-    final int currStartingByteValue = 0;
     final ChunkedValueManifest chunkedValueManifest = new ChunkedValueManifest();
     chunkedValueManifest.keysWithChunkIdSuffix = new ArrayList<>(totalChunkCount);
+    ChunkInfo valueChunkInfo = new ChunkInfo(totalChunkCount, eachCountSizeInBytes);
 
     final byte[] serializedKey = createChunkBytes(0, 5);
     List<BytesWritable> values = createKafkaInputMapperValues(
         serializedKey,
-        totalChunkCount,
-        currStartingByteValue,
-        eachCountSizeInBytes,
+        valueChunkInfo,
+        null,
         segmentNumber,
         messageSequenceNumber,
         VALUE_SCHEMA_ID,
@@ -528,16 +543,15 @@ public class TestChunkAssembler {
     final int eachCountSizeInBytes = 20;
     final int segmentNumber = 12;
     final int messageSequenceNumber = 34;
-    final int currStartingByteValue = 0;
     final ChunkedValueManifest chunkedValueManifest = new ChunkedValueManifest();
     chunkedValueManifest.keysWithChunkIdSuffix = new ArrayList<>(totalChunkCount);
+    ChunkInfo valueChunkInfo = new ChunkInfo(totalChunkCount, eachCountSizeInBytes);
 
     final byte[] serializedKey = createChunkBytes(0, 5);
     List<BytesWritable> values = createKafkaInputMapperValues(
         serializedKey,
-        totalChunkCount,
-        currStartingByteValue,
-        eachCountSizeInBytes,
+        valueChunkInfo,
+        null,
         segmentNumber,
         messageSequenceNumber,
         VALUE_SCHEMA_ID,
@@ -555,16 +569,15 @@ public class TestChunkAssembler {
     final int eachCountSizeInBytes = 20;
     final int segmentNumber = 12;
     final int messageSequenceNumber = 34;
-    final int currStartingByteValue = 0;
     final ChunkedValueManifest chunkedValueManifest = new ChunkedValueManifest();
     chunkedValueManifest.keysWithChunkIdSuffix = new ArrayList<>(totalChunkCount);
+    ChunkInfo valueChunkInfo = new ChunkInfo(totalChunkCount, eachCountSizeInBytes);
 
     final byte[] serializedKey = createChunkBytes(0, 5);
     List<BytesWritable> values = createKafkaInputMapperValues(
         serializedKey,
-        totalChunkCount,
-        currStartingByteValue,
-        eachCountSizeInBytes,
+        valueChunkInfo,
+        null,
         segmentNumber,
         messageSequenceNumber,
         VALUE_SCHEMA_ID,
@@ -608,18 +621,17 @@ public class TestChunkAssembler {
     final int eachCountSizeInBytes = 20;
     final int segmentNumber = 12;
     final int messageSequenceNumber = 34;
-    final int currStartingByteValue = 0;
     final ChunkedValueManifest chunkedValueManifest = new ChunkedValueManifest();
     chunkedValueManifest.keysWithChunkIdSuffix = new ArrayList<>(totalChunkCount);
+    ChunkInfo valueChunkInfo = new ChunkInfo(totalChunkCount, eachCountSizeInBytes);
 
     final byte[] serializedKey = createChunkBytes(0, 5);
     List<BytesWritable> values = new ArrayList<>(1 + totalChunkCount + 1);
     values.addAll(
         createKafkaInputMapperValues(
             serializedKey,
-            totalChunkCount,
-            currStartingByteValue,
-            eachCountSizeInBytes,
+            valueChunkInfo,
+            null,
             segmentNumber,
             messageSequenceNumber,
             VALUE_SCHEMA_ID,
@@ -643,9 +655,9 @@ public class TestChunkAssembler {
     final int eachCountSizeInBytes = 20;
     final int segmentNumber = 12;
     final int messageSequenceNumber = 34;
-    final int currStartingByteValue = 0;
     final ChunkedValueManifest chunkedValueManifest = new ChunkedValueManifest();
     chunkedValueManifest.keysWithChunkIdSuffix = new ArrayList<>(totalChunkCount);
+    ChunkInfo valueChunkInfo = new ChunkInfo(totalChunkCount, eachCountSizeInBytes);
 
     final byte[] serializedKey = createChunkBytes(0, 5);
     List<BytesWritable> values = new ArrayList<>();
@@ -653,9 +665,8 @@ public class TestChunkAssembler {
     values.addAll(
         createKafkaInputMapperValues(
             serializedKey,
-            totalChunkCount,
-            currStartingByteValue,
-            eachCountSizeInBytes,
+            valueChunkInfo,
+            null,
             segmentNumber,
             messageSequenceNumber,
             VALUE_SCHEMA_ID,
@@ -676,9 +687,9 @@ public class TestChunkAssembler {
     final int eachCountSizeInBytes = 20;
     final int segmentNumber = 12;
     final int messageSequenceNumber = 34;
-    final int currStartingByteValue = 0;
     final ChunkedValueManifest chunkedValueManifest = new ChunkedValueManifest();
     chunkedValueManifest.keysWithChunkIdSuffix = new ArrayList<>(totalChunkCount);
+    ChunkInfo valueChunkInfo = new ChunkInfo(totalChunkCount, eachCountSizeInBytes);
 
     final byte[] serializedKey = createChunkBytes(0, 5);
     List<BytesWritable> values = new ArrayList<>();
@@ -686,9 +697,8 @@ public class TestChunkAssembler {
     values.addAll(
         createKafkaInputMapperValues(
             serializedKey,
-            totalChunkCount,
-            currStartingByteValue,
-            eachCountSizeInBytes,
+            valueChunkInfo,
+            null,
             segmentNumber,
             messageSequenceNumber,
             VALUE_SCHEMA_ID,
@@ -709,18 +719,17 @@ public class TestChunkAssembler {
     final int eachCountSizeInBytes = 20;
     final int segmentNumber = 12;
     final int messageSequenceNumber = 34;
-    final int currStartingByteValue = 0;
     final ChunkedValueManifest chunkedValueManifest = new ChunkedValueManifest();
     chunkedValueManifest.keysWithChunkIdSuffix = new ArrayList<>(totalChunkCount);
+    ChunkInfo valueChunkInfo = new ChunkInfo(totalChunkCount, eachCountSizeInBytes);
 
     final byte[] serializedKey = createChunkBytes(0, 5);
     List<BytesWritable> values = new ArrayList<>();
     values.addAll(
         createKafkaInputMapperValues(
             serializedKey,
-            totalChunkCount,
-            currStartingByteValue,
-            eachCountSizeInBytes,
+            valueChunkInfo,
+            null,
             segmentNumber,
             messageSequenceNumber,
             VALUE_SCHEMA_ID,
@@ -753,41 +762,72 @@ public class TestChunkAssembler {
    */
   private List<BytesWritable> createKafkaInputMapperValues(
       byte[] serializedKey,
-      int totalChunkCount,
-      int currStartingByteValue,
-      int eachCountSizeInBytes,
+      ChunkInfo valueChunkInfo,
+      ChunkInfo rmdChunkInfo,
       int segmentNumber,
-      int messageSequenceNumber,
+      int sequenceNumber,
       int valueSchemaID,
       int startOffset) {
-    List<BytesWritable> values = new ArrayList<>(totalChunkCount + 1);
+
+    List<BytesWritable> values = rmdChunkInfo == null
+        ? new ArrayList<>(valueChunkInfo.totalChunkCount + 1)
+        : new ArrayList<>(valueChunkInfo.totalChunkCount + rmdChunkInfo.totalChunkCount + 1);
     KeyWithChunkingSuffixSerializer keyWithChunkingSuffixSerializer = new KeyWithChunkingSuffixSerializer();
     final ChunkedValueManifest chunkedValueManifest = new ChunkedValueManifest();
-    chunkedValueManifest.keysWithChunkIdSuffix = new ArrayList<>(totalChunkCount);
+    chunkedValueManifest.keysWithChunkIdSuffix = new ArrayList<>(valueChunkInfo.totalChunkCount);
+    ChunkedValueManifest chunkedRmdManifest = null;
     int currOffset = startOffset;
-
-    for (int i = 0; i < totalChunkCount; i++) {
-      byte[] chunkBytes = createChunkBytes(currStartingByteValue, eachCountSizeInBytes);
+    int currStartingByteValue = 0;
+    for (int i = 0; i < valueChunkInfo.totalChunkCount; i++) {
+      byte[] chunkBytes = createChunkBytes(currStartingByteValue, valueChunkInfo.eachCountSizeInBytes);
       KafkaInputMapperValue mapperValue = new KafkaInputMapperValue();
       mapperValue.valueType = MapperValueType.PUT;
       mapperValue.offset = currOffset;
       currOffset++;
       mapperValue.schemaId = CHUNK_VALUE_SCHEMA_ID;
       mapperValue.value = ByteBuffer.wrap(chunkBytes);
-      ChunkedKeySuffix chunkedKeySuffix = createChunkedKeySuffix(segmentNumber, messageSequenceNumber, i);
+      ChunkedKeySuffix chunkedKeySuffix = createChunkedKeySuffix(segmentNumber, sequenceNumber, i);
       mapperValue.chunkedKeySuffix = ByteBuffer.wrap(CHUNKED_KEY_SUFFIX_SERIALIZER.serialize("", chunkedKeySuffix));
       mapperValue.replicationMetadataPayload = ByteBuffer.wrap(new byte[0]);
 
       values.add(serialize(mapperValue));
-      currStartingByteValue += eachCountSizeInBytes;
+      currStartingByteValue += valueChunkInfo.eachCountSizeInBytes;
 
       ByteBuffer keyWithSuffix = keyWithChunkingSuffixSerializer.serializeChunkedKey(serializedKey, chunkedKeySuffix);
       chunkedValueManifest.keysWithChunkIdSuffix.add(keyWithSuffix);
     }
 
+    if (rmdChunkInfo != null) {
+      chunkedRmdManifest = new ChunkedValueManifest();
+      chunkedRmdManifest.keysWithChunkIdSuffix = new ArrayList<>(rmdChunkInfo.totalChunkCount);
+      currStartingByteValue = 0;
+      for (int i = 0; i < rmdChunkInfo.totalChunkCount; i++) {
+        byte[] chunkBytes = createChunkBytes(currStartingByteValue, rmdChunkInfo.eachCountSizeInBytes);
+        KafkaInputMapperValue mapperValue = new KafkaInputMapperValue();
+        mapperValue.valueType = MapperValueType.PUT;
+        mapperValue.offset = currOffset;
+        currOffset++;
+        mapperValue.schemaId = CHUNK_VALUE_SCHEMA_ID;
+        mapperValue.value = ByteBuffer.wrap(new byte[0]);
+        ChunkedKeySuffix chunkedKeySuffix = createChunkedKeySuffix(segmentNumber, sequenceNumber, i);
+        mapperValue.chunkedKeySuffix = ByteBuffer.wrap(CHUNKED_KEY_SUFFIX_SERIALIZER.serialize("", chunkedKeySuffix));
+        mapperValue.replicationMetadataPayload = ByteBuffer.wrap(chunkBytes);
+
+        values.add(serialize(mapperValue));
+        currStartingByteValue += rmdChunkInfo.eachCountSizeInBytes;
+
+        ByteBuffer keyWithSuffix = keyWithChunkingSuffixSerializer.serializeChunkedKey(serializedKey, chunkedKeySuffix);
+        chunkedRmdManifest.keysWithChunkIdSuffix.add(keyWithSuffix);
+      }
+    }
+
     // Add the manifest
     chunkedValueManifest.schemaId = valueSchemaID;
-    chunkedValueManifest.size = totalChunkCount * eachCountSizeInBytes;
+    chunkedValueManifest.size = valueChunkInfo.totalChunkCount * valueChunkInfo.eachCountSizeInBytes;
+    if (rmdChunkInfo != null) {
+      chunkedRmdManifest.schemaId = valueSchemaID;
+      chunkedRmdManifest.size = rmdChunkInfo.totalChunkCount * rmdChunkInfo.eachCountSizeInBytes;
+    }
     KafkaInputMapperValue lastMapperValue = new KafkaInputMapperValue();
     lastMapperValue.valueType = MapperValueType.PUT;
     lastMapperValue.offset = currOffset;
@@ -795,11 +835,12 @@ public class TestChunkAssembler {
     lastMapperValue.value = ByteBuffer.wrap(CHUNKED_VALUE_MANIFEST_SERIALIZER.serialize("", chunkedValueManifest));
     lastMapperValue.chunkedKeySuffix = ByteBuffer
         .wrap(CHUNKED_KEY_SUFFIX_SERIALIZER.serialize("", KeyWithChunkingSuffixSerializer.NON_CHUNK_KEY_SUFFIX));
-    lastMapperValue.replicationMetadataPayload = ByteBuffer.wrap(new byte[0]);
+    lastMapperValue.replicationMetadataPayload = (rmdChunkInfo == null)
+        ? ByteBuffer.wrap(new byte[0])
+        : ByteBuffer.wrap(CHUNKED_VALUE_MANIFEST_SERIALIZER.serialize("", chunkedRmdManifest));
     lastMapperValue.replicationMetadataVersionId = 1;
 
     values.add(serialize(lastMapperValue));
-
     // The offset of the messages will be in descending order.
     Collections.reverse(values);
     return values;
@@ -811,5 +852,15 @@ public class TestChunkAssembler {
 
   private BytesWritable serialize(KafkaInputMapperValue value) {
     return new BytesWritable(KAFKA_INPUT_MAPPER_VALUE_AVRO_SPECIFIC_SERIALIZER.serialize(value));
+  }
+
+  static class ChunkInfo {
+    private final int totalChunkCount;
+    private final int eachCountSizeInBytes;
+
+    public ChunkInfo(int totalChunkCount, int eachCountSizeInBytes) {
+      this.totalChunkCount = totalChunkCount;
+      this.eachCountSizeInBytes = eachCountSizeInBytes;
+    }
   }
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/writer/VeniceWriter.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/writer/VeniceWriter.java
@@ -1179,17 +1179,20 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
         serializedValue,
         true,
         valueSchemaId,
+        0,
         callback instanceof ChunkAwareCallback,
         reportSizeGenerator,
         maxSizeForUserPayloadPerMessageInBytes,
         keyWithChunkingSuffixSerializer,
         sendMessageFunction);
+    int valueChunkCount = valueChunksAndManifest.getChunkedValueManifest().keysWithChunkIdSuffix.size();
     ChunkedPayloadAndManifest rmdChunksAndManifest = isRmdChunkingEnabled
         ? WriterChunkingHelper.chunkPayloadAndSend(
             serializedKey,
             putMetadata == null ? EMPTY_BYTE_ARRAY : ByteUtils.extractByteArray(putMetadata.getRmdPayload()),
             false,
             valueSchemaId,
+            valueChunkCount,
             callback instanceof ChunkAwareCallback,
             reportSizeGenerator,
             maxSizeForUserPayloadPerMessageInBytes,

--- a/internal/venice-common/src/main/java/com/linkedin/venice/writer/WriterChunkingHelper.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/writer/WriterChunkingHelper.java
@@ -41,6 +41,7 @@ public class WriterChunkingHelper {
       byte[] payload,
       boolean isValuePayload,
       int schemaId,
+      int chunkedKeySuffixStartingIndex,
       boolean isChunkAwareCallback,
       Supplier<String> sizeReport,
       int maxSizeForUserPayloadPerMessageInBytes,
@@ -110,7 +111,7 @@ public class WriterChunkingHelper {
         putPayload.putValue = EMPTY_BYTE_BUFFER;
         putPayload.replicationMetadataPayload = chunk;
       }
-      chunkedKeySuffix.chunkId.chunkIndex = chunkIndex;
+      chunkedKeySuffix.chunkId.chunkIndex = chunkIndex + chunkedKeySuffixStartingIndex;
       keyProvider = chunkIndex == 0 ? firstKeyProvider : subsequentKeyProvider;
 
       try {

--- a/internal/venice-common/src/test/java/com/linkedin/venice/writer/WriterChunkingHelperTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/writer/WriterChunkingHelperTest.java
@@ -16,6 +16,7 @@ public class WriterChunkingHelperTest {
         valueBytes,
         true,
         1,
+        0,
         true,
         () -> "",
         maxSizeForUserPayloadPerMessageInBytes,

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/PartialUpdateTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/PartialUpdateTest.java
@@ -2,6 +2,10 @@ package com.linkedin.venice.endToEnd;
 
 import static com.linkedin.venice.hadoop.VenicePushJob.DEFAULT_KEY_FIELD_PROP;
 import static com.linkedin.venice.hadoop.VenicePushJob.DEFAULT_VALUE_FIELD_PROP;
+import static com.linkedin.venice.hadoop.VenicePushJob.KAFKA_INPUT_BROKER_URL;
+import static com.linkedin.venice.hadoop.VenicePushJob.KAFKA_INPUT_MAX_RECORDS_PER_MAPPER;
+import static com.linkedin.venice.hadoop.VenicePushJob.REWIND_TIME_IN_SECONDS_OVERRIDE;
+import static com.linkedin.venice.hadoop.VenicePushJob.SOURCE_KAFKA;
 import static com.linkedin.venice.utils.IntegrationTestPushUtils.getSamzaProducer;
 import static com.linkedin.venice.utils.IntegrationTestPushUtils.sendStreamingDeleteRecord;
 import static com.linkedin.venice.utils.IntegrationTestPushUtils.sendStreamingRecord;
@@ -55,6 +59,7 @@ import com.linkedin.venice.schema.writecompute.WriteComputeSchemaConverter;
 import com.linkedin.venice.utils.DataProviderUtils;
 import com.linkedin.venice.utils.IntegrationTestPushUtils;
 import com.linkedin.venice.utils.TestUtils;
+import com.linkedin.venice.utils.TestWriteUtils;
 import com.linkedin.venice.utils.Time;
 import com.linkedin.venice.utils.Utils;
 import com.linkedin.venice.utils.VeniceProperties;
@@ -80,6 +85,7 @@ import org.apache.avro.io.BinaryEncoder;
 import org.apache.avro.io.DatumWriter;
 import org.apache.avro.util.Utf8;
 import org.apache.samza.system.SystemProducer;
+import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -173,6 +179,7 @@ public class PartialUpdateTest {
     String listFieldName = "intArray";
     String mapFieldName = "stringMap";
 
+    // Insert large amount of Map entries to trigger RMD chunking.
     int updateCount = 30;
     int singleUpdateEntryCount = 10000;
     try (AvroGenericStoreClient<Object, Object> storeReader = ClientFactory.getAndStartGenericAvroClient(
@@ -208,6 +215,47 @@ public class PartialUpdateTest {
       });
       // Validate RMD bytes after PUT requests.
       String kafkaTopic = Version.composeKafkaTopic(storeName, 1);
+      validateRmdData(rmdSerDe, kafkaTopic, key, rmdWithValueSchemaId -> {
+        GenericRecord timestampRecord = (GenericRecord) rmdWithValueSchemaId.getRmdRecord().get("timestamp");
+        GenericRecord stringMapTimestampRecord = (GenericRecord) timestampRecord.get("stringMap");
+        List<Long> activeElementsTimestamps = (List<Long>) stringMapTimestampRecord.get("activeElementsTimestamps");
+        assertEquals(activeElementsTimestamps.size(), updateCount * singleUpdateEntryCount);
+      });
+
+      Properties props =
+          IntegrationTestPushUtils.defaultVPJProps(multiColoMultiClusterWrapper, "dummyInputPath", storeName);
+      props.setProperty(SOURCE_KAFKA, "true");
+      props.setProperty(KAFKA_INPUT_BROKER_URL, veniceCluster.getKafka().getAddress());
+      props.setProperty(KAFKA_INPUT_MAX_RECORDS_PER_MAPPER, "5");
+      // intentionally stop re-consuming from RT so stale records don't affect the testing results
+      props.put(REWIND_TIME_IN_SECONDS_OVERRIDE, 0);
+      TestWriteUtils.runPushJob("Run repush job", props);
+
+      ControllerClient controllerClient =
+          new ControllerClient("venice-cluster0", childDatacenters.get(0).getControllerConnectString());
+      TestUtils.waitForNonDeterministicAssertion(
+          5,
+          TimeUnit.SECONDS,
+          () -> Assert.assertEquals(controllerClient.getStore(storeName).getStore().getCurrentVersion(), 2));
+      veniceCluster.refreshAllRouterMetaData();
+
+      TestUtils.waitForNonDeterministicAssertion(TEST_TIMEOUT_MS * 2, TimeUnit.MILLISECONDS, true, () -> {
+        try {
+          GenericRecord valueRecord = readValue(storeReader, key);
+          boolean nullRecord = (valueRecord == null);
+          assertFalse(nullRecord);
+          assertEquals(valueRecord.get(primitiveFieldName).toString(), "Tottenham"); // Updated field
+          Map<String, String> mapFieldResult = new HashMap<>();
+          ((Map<Utf8, Utf8>) valueRecord.get(mapFieldName))
+              .forEach((x, y) -> mapFieldResult.put(x.toString(), y.toString()));
+          assertEquals(mapFieldResult.size(), updateCount * singleUpdateEntryCount);
+        } catch (Exception e) {
+          throw new VeniceException(e);
+        }
+      });
+
+      // Validate RMD bytes after PUT requests.
+      kafkaTopic = Version.composeKafkaTopic(storeName, 2);
       validateRmdData(rmdSerDe, kafkaTopic, key, rmdWithValueSchemaId -> {
         GenericRecord timestampRecord = (GenericRecord) rmdWithValueSchemaId.getRmdRecord().get("timestamp");
         GenericRecord stringMapTimestampRecord = (GenericRecord) timestampRecord.get("stringMap");

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/writer/VeniceWriterTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/writer/VeniceWriterTest.java
@@ -413,6 +413,7 @@ public class VeniceWriterTest {
     chunkedKeySuffix.chunkId.producerGUID = producerMetadata.producerGUID;
     chunkedKeySuffix.chunkId.segmentNumber = producerMetadata.segmentNumber;
     chunkedKeySuffix.chunkId.messageSequenceNumber = producerMetadata.messageSequenceNumber;
+    chunkedKeySuffix.chunkId.chunkIndex = 2;
     keyWithSuffix = keyWithChunkingSuffixSerializer.serializeChunkedKey(serializedKey, chunkedKeySuffix);
     chunkedRmdManifest.keysWithChunkIdSuffix.add(keyWithSuffix);
     KafkaKey expectedKey3 = new KafkaKey(MessageType.PUT, keyWithSuffix.array());

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/writer/VeniceWriterTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/writer/VeniceWriterTest.java
@@ -371,6 +371,7 @@ public class VeniceWriterTest {
     ChunkedKeySuffix chunkedKeySuffix = new ChunkedKeySuffix();
     chunkedKeySuffix.isChunk = true;
     chunkedKeySuffix.chunkId = new ChunkId();
+    chunkedKeySuffix.chunkId.chunkIndex = 0;
     ProducerMetadata producerMetadata = actualValue1.producerMetadata;
     chunkedKeySuffix.chunkId.producerGUID = producerMetadata.producerGUID;
     chunkedKeySuffix.chunkId.segmentNumber = producerMetadata.segmentNumber;
@@ -413,6 +414,8 @@ public class VeniceWriterTest {
     chunkedKeySuffix.chunkId.producerGUID = producerMetadata.producerGUID;
     chunkedKeySuffix.chunkId.segmentNumber = producerMetadata.segmentNumber;
     chunkedKeySuffix.chunkId.messageSequenceNumber = producerMetadata.messageSequenceNumber;
+    // The chunkIndex of the first RMD should be the number of value chunks so that key space of value chunk and RMD
+    // chunk will not collide.
     chunkedKeySuffix.chunkId.chunkIndex = 2;
     keyWithSuffix = keyWithChunkingSuffixSerializer.serializeChunkedKey(serializedKey, chunkedKeySuffix);
     chunkedRmdManifest.keysWithChunkIdSuffix.add(keyWithSuffix);


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci], [server], [controller],
[router], [samza], [vpj], [fast-client], [thin-client], [alpini],
[admin-tool], [test], [build], [doc], [script]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## [server] Support RMD chunking on KIF repush
This PR adds RMD chunking supports in KIF repush.
KIF reducer now is aware of the rmd chunking flag and will use this to determine whether to collect RMD chunks as well when encountering manifest as the last message of a key.

## How was this PR tested?
Integration Test

Added unit test in TestChunkAssembler

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.