### PR TITLE
[da-vinci][server] Fixed excessive logging because of a race condition

### DIFF
--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
@@ -52,6 +52,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
@@ -2408,6 +2409,9 @@ public abstract class StoreIngestionTaskTest {
       verify(mockLogNotifier, timeout(TEST_TIMEOUT_MS)).stopped(eq(topic), eq(PARTITION_FOO), anyLong());
       verify(mockLogNotifier, never()).error(eq(topic), eq(PARTITION_BAR), anyString(), any());
       assertTrue(storeIngestionTaskUnderTest.isRunning(), "The StoreIngestionTask should still be running");
+      assertNull(
+          storeIngestionTaskUnderTest.getPartitionIngestionExceptionList().get(PARTITION_FOO),
+          "Exception for the errored partition should be cleared after unsubscription");
     }, isActiveActiveReplicationEnabled);
     for (int i = 0; i < 10000; ++i) {
       storeIngestionTaskUnderTest


### PR DESCRIPTION
There is a race condition between "STANDBY->OFFLINE" ST and "OFFLINE->DROP" ST since the former will be executed aysnchronously.
Previously, SIT only clears the exception at drop time, and when race condition happens, there will be some buffered messages in drainer queue, which will continue to throw exception and persist in SIT and no code will clear it up, which will result in excessive logging in SIT#processIngestionException.

The fix to prevent excessive logging even with the race condition:
1. Clear the exception list during un-subscribing.
2. Clear the exception list if there is no active subscription when executing SIT#processIngestionException.

<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci], [server], [controller],
[router], [samza], [vpj], [fast-client], [thin-client], [alpini],
[admin-tool], [test], [build], [doc], [script]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->



## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.