### PR TITLE
[server] Do not open storage engines for invalid store versions

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/storage/StorageService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/storage/StorageService.java
@@ -172,6 +172,17 @@ public class StorageService extends AbstractVeniceService {
         AbstractStorageEngine storageEngine;
 
         try {
+          String store = Version.parseStoreFromVersionTopic(storeName);
+          int versionNum = Version.parseVersionFromKafkaTopicName(storeName);
+
+          Optional<Version> version = storeRepository.getStoreOrThrow(store).getVersion(versionNum);
+          if (!version.isPresent()) {
+            LOGGER.error(
+                "Could not find the version {} for the following store {}: skip opening it.",
+                storeName,
+                versionNum);
+            continue;
+          }
           storageEngine = openStore(storeConfig, () -> null);
         } catch (Exception e) {
           if (ExceptionUtils.recursiveClassEquals(e, RocksDBException.class)) {

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/fastclient/AvroStoreClientEndToEndTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/fastclient/AvroStoreClientEndToEndTest.java
@@ -264,7 +264,7 @@ public class AvroStoreClientEndToEndTest extends AbstractClientEndToEndSetup {
     runTest(clientConfigBuilder, useDaVinciClientBasedMetadata, true, 2);
   }
 
-  // TODO This test fails for the first time and then succeeds when the entire fastclient
+  // TODO This test fails for the first time and then succeeds when the entire fast-client
   // testsuite is run, but runs successfully when this test is run alone. Need to debug.
   @Test
   public void testFastClientSingleGetLongTailRetry() throws Exception {

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/server/VeniceServerTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/server/VeniceServerTest.java
@@ -66,10 +66,12 @@ public class VeniceServerTest {
 
       // Create a storage engine.
       String storeName = Utils.getUniqueString("testCheckBeforeJoinCluster");
+      cluster.getNewStore(storeName);
+      cluster.getNewVersion(storeName, 1000);
       server.getVeniceServer()
           .getStorageService()
           .openStoreForNewPartition(
-              server.getVeniceServer().getConfigLoader().getStoreConfig(storeName),
+              server.getVeniceServer().getConfigLoader().getStoreConfig(storeName + "_v1"),
               1,
               () -> null);
       Assert.assertEquals(


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci], [server], [controller],
[router], [samza], [vpj], [fast-client], [thin-client], [alpini],
[admin-tool], [test], [build], [doc], [script]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Summary, imperative, start upper case, don't end with a period
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Do not open storage engines for invalid store versions. Often times due to failed pushes/stuck ingestion tasks or some unknown reasons the server host rocksDB path would contain many old store version folders. During restart of the server currently we try to open each and every one of them, which is a waste of resources. This PR validate the store versions before opening them.



## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
CI build
## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.