### PR TITLE
[server] Introduced mode to disable post leader logic buffering

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -101,7 +101,7 @@ ext.libraries = [
     snappy: 'org.iq80.snappy:snappy:0.4',
     spark: 'com.sparkjava:spark-core:2.9.4',
     spotbugs: 'com.github.spotbugs:spotbugs:4.5.2',
-    tehuti: 'io.tehuti:tehuti:0.9.1',
+    tehuti: 'io.tehuti:tehuti:0.9.2',
     testng: 'org.testng:testng:6.14.3',
     // Resolves java.lang.UnsupportedOperationException:  setXIncludeAware is not supported on this JAXP implementation or earlier: class org.apache.xerces.jaxp.DocumentBuilderFactoryImpl
     xalan: 'xalan:xalan:2.7.1',

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
@@ -90,6 +90,7 @@ import static com.linkedin.venice.ConfigKeys.SERVER_SYSTEM_STORE_PROMOTION_TO_LE
 import static com.linkedin.venice.ConfigKeys.SERVER_UNSUB_AFTER_BATCHPUSH;
 import static com.linkedin.venice.ConfigKeys.SEVER_CALCULATE_QUOTA_USAGE_BASED_ON_PARTITIONS_ASSIGNMENT_ENABLED;
 import static com.linkedin.venice.ConfigKeys.SORTED_INPUT_DRAINER_SIZE;
+import static com.linkedin.venice.ConfigKeys.STORE_WRITER_BUFFER_AFTER_LEADER_LOGIC_ENABLED;
 import static com.linkedin.venice.ConfigKeys.STORE_WRITER_BUFFER_MEMORY_CAPACITY;
 import static com.linkedin.venice.ConfigKeys.STORE_WRITER_BUFFER_NOTIFY_DELTA;
 import static com.linkedin.venice.ConfigKeys.STORE_WRITER_NUMBER;
@@ -165,6 +166,12 @@ public class VeniceServerConfig extends VeniceClusterConfig {
    * Thread pool size of unsorted ingestion drainer when dedicatedDrainerQueue is enabled.
    */
   private final int drainerPoolSizeUnsortedInput;
+
+  /**
+   * Whether to queue writes into the {@link com.linkedin.davinci.kafka.consumer.StoreBufferService} after the
+   * leader-specific logic (DCR, produce to Kafka) has been performed.
+   */
+  private final boolean storeWriterBufferAfterLeaderLogicEnabled;
 
   /**
    * Buffer capacity being used by each writer.
@@ -399,6 +406,8 @@ public class VeniceServerConfig extends VeniceClusterConfig {
     drainerPoolSizeSortedInput = serverProperties.getInt(SORTED_INPUT_DRAINER_SIZE, 8);
     drainerPoolSizeUnsortedInput = serverProperties.getInt(UNSORTED_INPUT_DRAINER_SIZE, 8);
 
+    storeWriterBufferAfterLeaderLogicEnabled =
+        serverProperties.getBoolean(STORE_WRITER_BUFFER_AFTER_LEADER_LOGIC_ENABLED, true);
     // To minimize the GC impact during heavy ingestion.
     storeWriterBufferMemoryCapacity =
         serverProperties.getSizeInBytes(STORE_WRITER_BUFFER_MEMORY_CAPACITY, 10 * 1024 * 1024);
@@ -628,6 +637,10 @@ public class VeniceServerConfig extends VeniceClusterConfig {
 
   public int getStoreWriterNumber() {
     return this.storeWriterNumber;
+  }
+
+  public boolean isStoreWriterBufferAfterLeaderLogicEnabled() {
+    return this.storeWriterBufferAfterLeaderLogicEnabled;
   }
 
   public long getStoreWriterBufferMemoryCapacity() {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionService.java
@@ -381,7 +381,8 @@ public class KafkaStoreIngestionService extends AbstractVeniceService implements
       this.storeBufferService = new StoreBufferService(
           serverConfig.getStoreWriterNumber(),
           serverConfig.getStoreWriterBufferMemoryCapacity(),
-          serverConfig.getStoreWriterBufferNotifyDelta());
+          serverConfig.getStoreWriterBufferNotifyDelta(),
+          serverConfig.isStoreWriterBufferAfterLeaderLogicEnabled());
     }
     this.kafkaMessageEnvelopeSchemaReader = kafkaMessageEnvelopeSchemaReader;
     /**

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderProducerCallback.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderProducerCallback.java
@@ -24,7 +24,7 @@ import org.apache.logging.log4j.Logger;
 class LeaderProducerCallback implements ChunkAwareCallback {
   private static final Logger LOGGER = LogManager.getLogger(LeaderFollowerStoreIngestionTask.class);
   private static final RedundantExceptionFilter REDUNDANT_LOGGING_FILTER =
-      RedundantExceptionFilter.getDailyRedundantExceptionFilter();
+      RedundantExceptionFilter.getRedundantExceptionFilter();
 
   protected static final ChunkedValueManifestSerializer CHUNKED_VALUE_MANIFEST_SERIALIZER =
       new ChunkedValueManifestSerializer(false);

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/SeparatedStoreBufferService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/SeparatedStoreBufferService.java
@@ -34,11 +34,13 @@ public class SeparatedStoreBufferService extends AbstractStoreBufferService {
         new StoreBufferService(
             serverConfig.getDrainerPoolSizeSortedInput(),
             serverConfig.getStoreWriterBufferMemoryCapacity(),
-            serverConfig.getStoreWriterBufferNotifyDelta()),
+            serverConfig.getStoreWriterBufferNotifyDelta(),
+            serverConfig.isStoreWriterBufferAfterLeaderLogicEnabled()),
         new StoreBufferService(
             serverConfig.getDrainerPoolSizeUnsortedInput(),
             serverConfig.getStoreWriterBufferMemoryCapacity(),
-            serverConfig.getStoreWriterBufferNotifyDelta()));
+            serverConfig.getStoreWriterBufferNotifyDelta(),
+            serverConfig.isStoreWriterBufferAfterLeaderLogicEnabled()));
     LOGGER.info(
         "Created separated store buffer service with {} sorted drainers and {} unsorted drainers queues with capacity of {}",
         sortedPoolSize,

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StorageUtilizationManager.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StorageUtilizationManager.java
@@ -383,7 +383,10 @@ public class StorageUtilizationManager implements StoreDataChangedListener {
       quota /= subPartitionCount;
     }
 
-    long usage = partitionConsumptionSizeMap.values().stream().mapToLong(StoragePartitionDiskUsage::getUsage).sum();
+    long usage = 0;
+    for (StoragePartitionDiskUsage diskUsage: partitionConsumptionSizeMap.values()) {
+      usage += diskUsage.getUsage();
+    }
     return (double) usage / quota;
   }
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreBufferService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreBufferService.java
@@ -357,10 +357,6 @@ public class StoreBufferService extends AbstractStoreBufferService {
     this.leaderRecordHandler = queueLeaderWrites ? this::queueLeaderRecord : StoreBufferService::processRecord;
   }
 
-  public StoreBufferService(int drainerNum, long bufferCapacityPerDrainer, long bufferNotifyDelta) {
-    this(drainerNum, bufferCapacityPerDrainer, bufferNotifyDelta, false);
-  }
-
   protected MemoryBoundBlockingQueue<QueueNode> getDrainerForConsumerRecord(
       PubSubMessage<KafkaKey, KafkaMessageEnvelope, Long> consumerRecord,
       int subPartition) {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -1864,9 +1864,9 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
   public void processConsumerRecord(
       PubSubMessage<KafkaKey, KafkaMessageEnvelope, Long> record,
       LeaderProducedRecordContext leaderProducedRecordContext,
+      int subPartition,
       String kafkaUrl,
       long beforeProcessingRecordTimestamp) throws InterruptedException {
-    int subPartition = PartitionUtils.getSubPartition(record.getTopicPartition(), amplificationFactor);
     // The partitionConsumptionStateMap can be modified by other threads during consumption (for example when
     // unsubscribing)
     // in order to maintain thread safety, we hold onto the reference to the partitionConsumptionState and pass that

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderProducerCallbackTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderProducerCallbackTest.java
@@ -17,6 +17,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.config.Configuration;
+import org.apache.logging.log4j.core.config.LoggerConfig;
 import org.testng.annotations.Test;
 
 
@@ -75,9 +76,12 @@ public class LeaderProducerCallbackTest {
       assertEquals(matchedLogs, 3L);
       assertEquals(reportedStatsCounter.get(), cbInvocations); // stats should be reported for all invocations
     } finally {
-      inMemoryLogAppender.stop();
-      config.getRootLogger().removeAppender(inMemoryLogAppender.getName());
+      LoggerConfig loggerConfig = config.getLoggerConfig(LeaderFollowerStoreIngestionTask.class.getName());
+      if (loggerConfig.getName().equals(LeaderFollowerStoreIngestionTask.class.getCanonicalName())) {
+        loggerConfig.removeAppender(inMemoryLogAppender.getName());
+      }
       ctx.updateLoggers();
+      inMemoryLogAppender.stop();
     }
   }
 }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/SITWithPWiseAndBufferAfterLeaderTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/SITWithPWiseAndBufferAfterLeaderTest.java
@@ -1,0 +1,11 @@
+package com.linkedin.davinci.kafka.consumer;
+
+public class SITWithPWiseAndBufferAfterLeaderTest extends StoreIngestionTaskTest {
+  protected KafkaConsumerService.ConsumerAssignmentStrategy getConsumerAssignmentStrategy() {
+    return KafkaConsumerService.ConsumerAssignmentStrategy.PARTITION_WISE_SHARED_CONSUMER_ASSIGNMENT_STRATEGY;
+  }
+
+  protected boolean isStoreWriterBufferAfterLeaderLogicEnabled() {
+    return true;
+  }
+}

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/SITWithPWiseWithoutBufferAfterLeaderTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/SITWithPWiseWithoutBufferAfterLeaderTest.java
@@ -1,7 +1,11 @@
 package com.linkedin.davinci.kafka.consumer;
 
-public class StoreIngestionTaskWithPartitionWiseTest extends StoreIngestionTaskTest {
+public class SITWithPWiseWithoutBufferAfterLeaderTest extends StoreIngestionTaskTest {
   protected KafkaConsumerService.ConsumerAssignmentStrategy getConsumerAssignmentStrategy() {
     return KafkaConsumerService.ConsumerAssignmentStrategy.PARTITION_WISE_SHARED_CONSUMER_ASSIGNMENT_STRATEGY;
+  }
+
+  protected boolean isStoreWriterBufferAfterLeaderLogicEnabled() {
+    return false;
   }
 }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/SITWithTWiseAndBufferAfterLeaderTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/SITWithTWiseAndBufferAfterLeaderTest.java
@@ -1,0 +1,11 @@
+package com.linkedin.davinci.kafka.consumer;
+
+public class SITWithTWiseAndBufferAfterLeaderTest extends StoreIngestionTaskTest {
+  protected KafkaConsumerService.ConsumerAssignmentStrategy getConsumerAssignmentStrategy() {
+    return KafkaConsumerService.ConsumerAssignmentStrategy.TOPIC_WISE_SHARED_CONSUMER_ASSIGNMENT_STRATEGY;
+  }
+
+  protected boolean isStoreWriterBufferAfterLeaderLogicEnabled() {
+    return true;
+  }
+}

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/SITWithTWiseWithoutBufferAfterLeaderTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/SITWithTWiseWithoutBufferAfterLeaderTest.java
@@ -1,7 +1,11 @@
 package com.linkedin.davinci.kafka.consumer;
 
-public class StoreIngestionTaskWithTopicWiseTest extends StoreIngestionTaskTest {
+public class SITWithTWiseWithoutBufferAfterLeaderTest extends StoreIngestionTaskTest {
   protected KafkaConsumerService.ConsumerAssignmentStrategy getConsumerAssignmentStrategy() {
     return KafkaConsumerService.ConsumerAssignmentStrategy.TOPIC_WISE_SHARED_CONSUMER_ASSIGNMENT_STRATEGY;
+  }
+
+  protected boolean isStoreWriterBufferAfterLeaderLogicEnabled() {
+    return false;
   }
 }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreBufferServiceTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreBufferServiceTest.java
@@ -59,8 +59,8 @@ public class StoreBufferServiceTest {
     bufferService.putConsumerRecord(cr2, mockTask, null, partition2, kafkaUrl, 0L);
 
     bufferService.start();
-    verify(mockTask, timeout(TIMEOUT_IN_MS)).processConsumerRecord(cr1, null, kafkaUrl, 0L);
-    verify(mockTask, timeout(TIMEOUT_IN_MS)).processConsumerRecord(cr2, null, kafkaUrl, 0L);
+    verify(mockTask, timeout(TIMEOUT_IN_MS)).processConsumerRecord(cr1, null, partition1, kafkaUrl, 0L);
+    verify(mockTask, timeout(TIMEOUT_IN_MS)).processConsumerRecord(cr2, null, partition2, kafkaUrl, 0L);
 
     bufferService.stop();
     Assert.assertThrows(
@@ -85,14 +85,14 @@ public class StoreBufferServiceTest {
         new ImmutablePubSubMessage<>(key, value, pubSubTopicPartition2, -1, 0, 0);
     Exception e = new VeniceException("test_exception");
 
-    doThrow(e).when(mockTask).processConsumerRecord(cr1, null, kafkaUrl, 0L);
+    doThrow(e).when(mockTask).processConsumerRecord(cr1, null, partition1, kafkaUrl, 0L);
 
     bufferService.putConsumerRecord(cr1, mockTask, null, partition1, kafkaUrl, 0L);
     bufferService.putConsumerRecord(cr2, mockTask, null, partition2, kafkaUrl, 0L);
 
     bufferService.start();
-    verify(mockTask, timeout(TIMEOUT_IN_MS)).processConsumerRecord(cr1, null, kafkaUrl, 0L);
-    verify(mockTask, timeout(TIMEOUT_IN_MS)).processConsumerRecord(cr2, null, kafkaUrl, 0L);
+    verify(mockTask, timeout(TIMEOUT_IN_MS)).processConsumerRecord(cr1, null, partition1, kafkaUrl, 0L);
+    verify(mockTask, timeout(TIMEOUT_IN_MS)).processConsumerRecord(cr2, null, partition2, kafkaUrl, 0L);
     verify(mockTask).setIngestionException(partition1, e);
     bufferService.stop();
   }
@@ -213,14 +213,14 @@ public class StoreBufferServiceTest {
     PubSubMessage<KafkaKey, KafkaMessageEnvelope, Long> cr2 =
         new ImmutablePubSubMessage<>(key, value, pubSubTopicPartition2, -1, 0, 0);
     Exception e = new VeniceChecksumException("test_exception");
-    doThrow(e).when(mockTask).processConsumerRecord(cr1, null, kafkaUrl, 0L);
+    doThrow(e).when(mockTask).processConsumerRecord(cr1, null, partition1, kafkaUrl, 0L);
 
     bufferService.putConsumerRecord(cr1, mockTask, null, partition1, kafkaUrl, 0L);
     bufferService.putConsumerRecord(cr2, mockTask, null, partition2, kafkaUrl, 0L);
 
     bufferService.start();
-    verify(mockTask, timeout(TIMEOUT_IN_MS)).processConsumerRecord(cr1, null, kafkaUrl, 0L);
-    verify(mockTask, timeout(TIMEOUT_IN_MS)).processConsumerRecord(cr2, null, kafkaUrl, 0L);
+    verify(mockTask, timeout(TIMEOUT_IN_MS)).processConsumerRecord(cr1, null, partition1, kafkaUrl, 0L);
+    verify(mockTask, timeout(TIMEOUT_IN_MS)).processConsumerRecord(cr2, null, partition2, kafkaUrl, 0L);
     bufferService.getMaxMemoryUsagePerDrainer();
     for (int i = 0; i < 1; ++i) {
       // Verify map the cleared out

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreBufferServiceTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreBufferServiceTest.java
@@ -23,6 +23,7 @@ import com.linkedin.venice.pubsub.PubSubTopicRepository;
 import com.linkedin.venice.pubsub.api.PubSubMessage;
 import com.linkedin.venice.pubsub.api.PubSubTopic;
 import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
+import com.linkedin.venice.utils.DataProviderUtils;
 import com.linkedin.venice.utils.Utils;
 import java.nio.ByteBuffer;
 import org.testng.Assert;
@@ -32,35 +33,47 @@ import org.testng.annotations.Test;
 public class StoreBufferServiceTest {
   private final PubSubTopicRepository pubSubTopicRepository = new PubSubTopicRepository();
   private final KafkaKey key = new KafkaKey(MessageType.PUT, null);
-  private final KafkaMessageEnvelope value = new KafkaMessageEnvelope(
-      MessageType.PUT.getValue(),
-      new ProducerMetadata(),
-      new Put(ByteBuffer.allocate(0), 0, 0, ByteBuffer.allocate(0)),
-      null);
+  private final Put put = new Put(ByteBuffer.allocate(0), 0, 0, ByteBuffer.allocate(0));
+  private final KafkaMessageEnvelope value =
+      new KafkaMessageEnvelope(MessageType.PUT.getValue(), new ProducerMetadata(), put, null);
+  private final LeaderProducedRecordContext leaderContext =
+      LeaderProducedRecordContext.newPutRecord(0, 0, key.getKey(), put);
   private static final int TIMEOUT_IN_MS = 1000;
 
-  @Test
-  public void testRun() throws Exception {
-    StoreBufferService bufferService = new StoreBufferService(1, 10000, 1000);
+  @Test(dataProviderClass = DataProviderUtils.class, dataProvider = "True-and-False")
+  public void testRun(boolean queueLeaderWrites) throws Exception {
+    StoreBufferService bufferService = new StoreBufferService(1, 10000, 1000, queueLeaderWrites);
     StoreIngestionTask mockTask = mock(StoreIngestionTask.class);
     String topic = Utils.getUniqueString("test_topic") + "_v1";
     int partition1 = 1;
     int partition2 = 2;
+    int partition3 = 3;
+    int partition4 = 4;
     PubSubTopic pubSubTopic = pubSubTopicRepository.getTopic(topic);
     PubSubTopicPartition pubSubTopicPartition1 = new PubSubTopicPartitionImpl(pubSubTopic, partition1);
     PubSubTopicPartition pubSubTopicPartition2 = new PubSubTopicPartitionImpl(pubSubTopic, partition2);
+    PubSubTopicPartition pubSubTopicPartition3 = new PubSubTopicPartitionImpl(pubSubTopic, partition3);
+    PubSubTopicPartition pubSubTopicPartition4 = new PubSubTopicPartitionImpl(pubSubTopic, partition4);
     String kafkaUrl = "blah";
     PubSubMessage<KafkaKey, KafkaMessageEnvelope, Long> cr1 =
         new ImmutablePubSubMessage<>(key, value, pubSubTopicPartition1, -1, 0, 0);
     PubSubMessage<KafkaKey, KafkaMessageEnvelope, Long> cr2 =
         new ImmutablePubSubMessage<>(key, value, pubSubTopicPartition2, -1, 0, 0);
+    PubSubMessage<KafkaKey, KafkaMessageEnvelope, Long> cr3 =
+        new ImmutablePubSubMessage<>(key, value, pubSubTopicPartition3, -1, 0, 0);
+    PubSubMessage<KafkaKey, KafkaMessageEnvelope, Long> cr4 =
+        new ImmutablePubSubMessage<>(key, value, pubSubTopicPartition4, -1, 0, 0);
 
     bufferService.putConsumerRecord(cr1, mockTask, null, partition1, kafkaUrl, 0L);
     bufferService.putConsumerRecord(cr2, mockTask, null, partition2, kafkaUrl, 0L);
+    bufferService.putConsumerRecord(cr3, mockTask, leaderContext, partition3, kafkaUrl, 0L);
+    bufferService.putConsumerRecord(cr4, mockTask, leaderContext, partition4, kafkaUrl, 0L);
 
     bufferService.start();
     verify(mockTask, timeout(TIMEOUT_IN_MS)).processConsumerRecord(cr1, null, partition1, kafkaUrl, 0L);
     verify(mockTask, timeout(TIMEOUT_IN_MS)).processConsumerRecord(cr2, null, partition2, kafkaUrl, 0L);
+    verify(mockTask, timeout(TIMEOUT_IN_MS)).processConsumerRecord(cr3, leaderContext, partition3, kafkaUrl, 0L);
+    verify(mockTask, timeout(TIMEOUT_IN_MS)).processConsumerRecord(cr4, leaderContext, partition4, kafkaUrl, 0L);
 
     bufferService.stop();
     Assert.assertThrows(
@@ -68,9 +81,9 @@ public class StoreBufferServiceTest {
         () -> bufferService.drainBufferedRecordsFromTopicPartition(pubSubTopicPartition1));
   }
 
-  @Test
-  public void testRunWhenThrowException() throws Exception {
-    StoreBufferService bufferService = new StoreBufferService(1, 10000, 1000);
+  @Test(dataProviderClass = DataProviderUtils.class, dataProvider = "True-and-False")
+  public void testRunWhenThrowException(boolean queueLeaderWrites) throws Exception {
+    StoreBufferService bufferService = new StoreBufferService(1, 10000, 1000, queueLeaderWrites);
     StoreIngestionTask mockTask = mock(StoreIngestionTask.class);
     String topic = Utils.getUniqueString("test_topic") + "_v1";
     int partition1 = 1;
@@ -97,9 +110,9 @@ public class StoreBufferServiceTest {
     bufferService.stop();
   }
 
-  @Test
-  public void testDrainBufferedRecordsWhenNotExists() throws Exception {
-    StoreBufferService bufferService = new StoreBufferService(1, 10000, 1000);
+  @Test(dataProviderClass = DataProviderUtils.class, dataProvider = "True-and-False")
+  public void testDrainBufferedRecordsWhenNotExists(boolean queueLeaderWrites) throws Exception {
+    StoreBufferService bufferService = new StoreBufferService(1, 10000, 1000, queueLeaderWrites);
     StoreIngestionTask mockTask = mock(StoreIngestionTask.class);
     String topic = Utils.getUniqueString("test_topic") + "_v1";
     int partition = 1;
@@ -118,9 +131,9 @@ public class StoreBufferServiceTest {
     bufferService.stop();
   }
 
-  @Test
-  public void testDrainBufferedRecordsWhenExists() throws Exception {
-    StoreBufferService bufferService = new StoreBufferService(1, 10000, 1000);
+  @Test(dataProviderClass = DataProviderUtils.class, dataProvider = "True-and-False")
+  public void testDrainBufferedRecordsWhenExists(boolean queueLeaderWrites) throws Exception {
+    StoreBufferService bufferService = new StoreBufferService(1, 10000, 1000, queueLeaderWrites);
     StoreIngestionTask mockTask = mock(StoreIngestionTask.class);
     String topic = Utils.getUniqueString("test_topic") + "_v1";
     int partition = 1;
@@ -135,8 +148,8 @@ public class StoreBufferServiceTest {
     bufferService.stop();
   }
 
-  @Test
-  public void testGetDrainerIndexForConsumerRecordSeparateDrainer() {
+  @Test(dataProviderClass = DataProviderUtils.class, dataProvider = "True-and-False")
+  public void testGetDrainerIndexForConsumerRecordSeparateDrainer(boolean queueLeaderWrites) {
     String topic = Utils.getUniqueString("test_topic") + "_v1";
     PubSubTopic pubSubTopic = pubSubTopicRepository.getTopic(topic);
     int partitionCount = 32;
@@ -150,6 +163,7 @@ public class StoreBufferServiceTest {
     doReturn(8).when(serverConfig).getDrainerPoolSizeUnsortedInput();
     doReturn(1000l).when(serverConfig).getStoreWriterBufferNotifyDelta();
     doReturn(10000l).when(serverConfig).getStoreWriterBufferMemoryCapacity();
+    doReturn(queueLeaderWrites).when(serverConfig).isStoreWriterBufferAfterLeaderLogicEnabled();
     SeparatedStoreBufferService bufferService = new SeparatedStoreBufferService(serverConfig);
     for (int partition = 0; partition < partitionCount; ++partition) {
       PubSubMessage<KafkaKey, KafkaMessageEnvelope, Long> cr =
@@ -174,8 +188,8 @@ public class StoreBufferServiceTest {
     }
   }
 
-  @Test
-  public void testGetDrainerIndexForConsumerRecord() {
+  @Test(dataProviderClass = DataProviderUtils.class, dataProvider = "True-and-False")
+  public void testGetDrainerIndexForConsumerRecord(boolean queueLeaderWrites) {
     String topic = Utils.getUniqueString("test_topic") + "_v1";
     PubSubTopic pubSubTopic = pubSubTopicRepository.getTopic(topic);
     int partitionCount = 64;
@@ -184,7 +198,7 @@ public class StoreBufferServiceTest {
     for (int i = 0; i < drainerNum; ++i) {
       drainerPartitionCount[i] = 0;
     }
-    StoreBufferService bufferService = new StoreBufferService(8, 10000, 1000);
+    StoreBufferService bufferService = new StoreBufferService(8, 10000, 1000, queueLeaderWrites);
     for (int partition = 0; partition < partitionCount; ++partition) {
       PubSubMessage<KafkaKey, KafkaMessageEnvelope, Long> cr =
           new ImmutablePubSubMessage<>(key, value, new PubSubTopicPartitionImpl(pubSubTopic, partition), 100, 0, 0);
@@ -197,9 +211,9 @@ public class StoreBufferServiceTest {
     }
   }
 
-  @Test
-  public void testRunWhenThrowVeniceCheckSumFailException() throws Exception {
-    StoreBufferService bufferService = new StoreBufferService(1, 10000, 1000);
+  @Test(dataProviderClass = DataProviderUtils.class, dataProvider = "True-and-False")
+  public void testRunWhenThrowVeniceCheckSumFailException(boolean queueLeaderWrites) throws Exception {
+    StoreBufferService bufferService = new StoreBufferService(1, 10000, 1000, queueLeaderWrites);
     StoreIngestionTask mockTask = mock(StoreIngestionTask.class);
     String topic = Utils.getUniqueString("test_topic") + "_v1";
     int partition1 = 1;
@@ -231,13 +245,14 @@ public class StoreBufferServiceTest {
     bufferService.stop();
   }
 
-  @Test
-  public void testPutConsumerRecord() throws InterruptedException {
+  @Test(dataProviderClass = DataProviderUtils.class, dataProvider = "True-and-False")
+  public void testPutConsumerRecord(boolean queueLeaderWrites) throws InterruptedException {
     VeniceServerConfig serverConfig = mock(VeniceServerConfig.class);
     doReturn(8).when(serverConfig).getDrainerPoolSizeSortedInput();
     doReturn(8).when(serverConfig).getDrainerPoolSizeUnsortedInput();
     doReturn(1000l).when(serverConfig).getStoreWriterBufferNotifyDelta();
     doReturn(10000l).when(serverConfig).getStoreWriterBufferMemoryCapacity();
+    doReturn(queueLeaderWrites).when(serverConfig).isStoreWriterBufferAfterLeaderLogicEnabled();
     StoreBufferService sortedSBS = mock(StoreBufferService.class);
     StoreBufferService unsortedSBS = mock(StoreBufferService.class);
     SeparatedStoreBufferService bufferService = new SeparatedStoreBufferService(8, 8, sortedSBS, unsortedSBS);

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
@@ -362,7 +362,7 @@ public abstract class StoreIngestionTaskTest {
   public void suiteSetUp() throws Exception {
     taskPollingService = Executors.newFixedThreadPool(1);
 
-    storeBufferService = new StoreBufferService(3, 10000, 1000);
+    storeBufferService = new StoreBufferService(3, 10000, 1000, isStoreWriterBufferAfterLeaderLogicEnabled());
     storeBufferService.start();
   }
 
@@ -906,6 +906,8 @@ public abstract class StoreIngestionTaskTest {
   }
 
   abstract KafkaConsumerService.ConsumerAssignmentStrategy getConsumerAssignmentStrategy();
+
+  abstract boolean isStoreWriterBufferAfterLeaderLogicEnabled();
 
   private void prepareAggKafkaConsumerServiceMock() {
     doAnswer(invocation -> {

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/utils/StoragePartitionDiskUsageTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/utils/StoragePartitionDiskUsageTest.java
@@ -24,12 +24,10 @@ public class StoragePartitionDiskUsageTest {
 
   @Test
   public void testAddAndGetPartitionUsage() {
-    boolean added = partitionDiskUsage.add(smallRecordSizeToBeAdded);
-    Assert.assertTrue(added);
+    partitionDiskUsage.add(smallRecordSizeToBeAdded);
     Assert.assertEquals(smallRecordSizeToBeAdded, partitionDiskUsage.getUsage());
     // negative record size shouldn't be appended to partition diskUsage
-    added = partitionDiskUsage.add(-smallRecordSizeToBeAdded);
-    Assert.assertFalse(added);
+    partitionDiskUsage.add(-smallRecordSizeToBeAdded);
     Assert.assertEquals(smallRecordSizeToBeAdded, partitionDiskUsage.getUsage());
   }
 }

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/utils/RedundantExceptionFilter.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/utils/RedundantExceptionFilter.java
@@ -34,11 +34,6 @@ public class RedundantExceptionFilter {
     return getRedundantExceptionFilter(DEFAULT_BITSET_SIZE, DEFAULT_NO_REDUNDANT_EXCEPTION_DURATION_MS);
   }
 
-  public synchronized static RedundantExceptionFilter getDailyRedundantExceptionFilter() {
-    // clean up the bitset every day for the use case do not need to clean up frequently.
-    return getRedundantExceptionFilter(DEFAULT_BITSET_SIZE, Time.MS_PER_DAY);
-  }
-
   public synchronized static RedundantExceptionFilter getRedundantExceptionFilter(
       int bitSetSize,
       long noRedundantExceptionDurationMs) {

--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -343,6 +343,8 @@ public class ConfigKeys {
   public static final String STORE_WRITER_NUMBER = "store.writer.number";
   public static final String SORTED_INPUT_DRAINER_SIZE = "sorted.input.drainer.size";
   public static final String UNSORTED_INPUT_DRAINER_SIZE = "unsorted.input.drainer.size";
+  public static final String STORE_WRITER_BUFFER_AFTER_LEADER_LOGIC_ENABLED =
+      "store.writer.buffer.after.leader.logic.enabled";
   public static final String STORE_WRITER_BUFFER_MEMORY_CAPACITY = "store.writer.buffer.memory.capacity";
   public static final String STORE_WRITER_BUFFER_NOTIFY_DELTA = "store.writer.buffer.notify.delta";
   public static final String SERVER_REST_SERVICE_STORAGE_THREAD_NUM = "server.rest.service.storage.thread.num";

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/ImmutablePubSubMessage.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/ImmutablePubSubMessage.java
@@ -2,6 +2,7 @@ package com.linkedin.venice.pubsub;
 
 import com.linkedin.venice.pubsub.api.PubSubMessage;
 import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
+import java.util.Objects;
 
 
 public class ImmutablePubSubMessage<K, V> implements PubSubMessage<K, V, Long> {
@@ -21,7 +22,7 @@ public class ImmutablePubSubMessage<K, V> implements PubSubMessage<K, V, Long> {
       int payloadSize) {
     this.key = key;
     this.value = value;
-    this.topicPartition = topicPartition;
+    this.topicPartition = Objects.requireNonNull(topicPartition);
     this.offset = offset;
     this.timestamp = timestamp;
     this.payloadSize = payloadSize;

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/DataRecoveryTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/DataRecoveryTest.java
@@ -139,8 +139,7 @@ public class DataRecoveryTest {
                       .setNativeReplicationEnabled(true)
                       .setPartitionCount(1))
               .isError());
-      TestUtils.verifyDCConfigNativeAndActiveRepl(dc0Client, storeName, true, false);
-      TestUtils.verifyDCConfigNativeAndActiveRepl(dc1Client, storeName, true, false);
+      TestUtils.verifyDCConfigNativeAndActiveRepl(storeName, true, false, dc0Client, dc1Client);
       Assert.assertFalse(
           parentControllerClient.emptyPush(storeName, "empty-push-" + System.currentTimeMillis(), 1000).isError());
       TestUtils.waitForNonDeterministicPushCompletion(
@@ -188,8 +187,7 @@ public class DataRecoveryTest {
                   storeName,
                   new UpdateStoreQueryParams().setNativeReplicationEnabled(true).setPartitionCount(1))
               .isError());
-      TestUtils.verifyDCConfigNativeAndActiveRepl(dc0Client, storeName, true, false);
-      TestUtils.verifyDCConfigNativeAndActiveRepl(dc1Client, storeName, true, false);
+      TestUtils.verifyDCConfigNativeAndActiveRepl(storeName, true, false, dc0Client, dc1Client);
       VersionCreationResponse versionCreationResponse = parentControllerClient.requestTopicForWrites(
           storeName,
           1024,
@@ -265,8 +263,7 @@ public class DataRecoveryTest {
                       .setActiveActiveReplicationEnabled(true)
                       .setPartitionCount(1))
               .isError());
-      TestUtils.verifyDCConfigNativeAndActiveRepl(dc0Client, storeName, true, true);
-      TestUtils.verifyDCConfigNativeAndActiveRepl(dc1Client, storeName, true, true);
+      TestUtils.verifyDCConfigNativeAndActiveRepl(storeName, true, true, dc0Client, dc1Client);
       Assert.assertFalse(
           parentControllerClient.emptyPush(storeName, "empty-push-" + System.currentTimeMillis(), 1000).isError());
       String versionTopic = Version.composeKafkaTopic(storeName, 1);

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/OneTouchDataRecoveryTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/OneTouchDataRecoveryTest.java
@@ -103,8 +103,7 @@ public class OneTouchDataRecoveryTest {
                   storeName,
                   new UpdateStoreQueryParams().setNativeReplicationEnabled(true).setPartitionCount(1))
               .isError());
-      TestUtils.verifyDCConfigNativeAndActiveRepl(dc0Client, storeName, true, false);
-      TestUtils.verifyDCConfigNativeAndActiveRepl(dc1Client, storeName, true, false);
+      TestUtils.verifyDCConfigNativeAndActiveRepl(storeName, true, false, dc0Client, dc1Client);
       VersionCreationResponse versionCreationResponse = parentControllerCli.requestTopicForWrites(
           storeName,
           1024,

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestActiveActiveReplicationForIncPush.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestActiveActiveReplicationForIncPush.java
@@ -170,10 +170,14 @@ public class TestActiveActiveReplicationForIncPush {
       TestWriteUtils.updateStore(storeName, parentControllerClient, enableAARepl);
 
       // verify store configs
-      TestUtils.verifyDCConfigNativeAndActiveRepl(parentControllerClient, storeName, true, true);
-      TestUtils.verifyDCConfigNativeAndActiveRepl(dc0ControllerClient, storeName, true, true);
-      TestUtils.verifyDCConfigNativeAndActiveRepl(dc1ControllerClient, storeName, true, true);
-      TestUtils.verifyDCConfigNativeAndActiveRepl(dc2ControllerClient, storeName, true, true);
+      TestUtils.verifyDCConfigNativeAndActiveRepl(
+          storeName,
+          true,
+          true,
+          parentControllerClient,
+          dc0ControllerClient,
+          dc1ControllerClient,
+          dc2ControllerClient);
 
       // Run a batch push first
       try (VenicePushJob job = new VenicePushJob("Test push job batch with NR + A/A all fabrics", propsBatch)) {

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestPushJobWithEmergencySourceRegionSelection.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestPushJobWithEmergencySourceRegionSelection.java
@@ -157,9 +157,7 @@ public class TestPushJobWithEmergencySourceRegionSelection {
        * Check the update store command in parent controller has been propagated into child controllers, before
        * sending any commands directly into child controllers, which can help avoid race conditions.
        */
-      TestUtils.verifyDCConfigNativeAndActiveRepl(dc0Client, storeName, true, true);
-      TestUtils.verifyDCConfigNativeAndActiveRepl(dc1Client, storeName, true, true);
-      TestUtils.verifyDCConfigNativeAndActiveRepl(dc2Client, storeName, true, true);
+      TestUtils.verifyDCConfigNativeAndActiveRepl(storeName, true, true, dc0Client, dc1Client, dc2Client);
     }
 
     try (VenicePushJob job = new VenicePushJob("Test push job", props)) {

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/helix/HelixLiveInstanceMonitorIntegrationTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/helix/HelixLiveInstanceMonitorIntegrationTest.java
@@ -13,7 +13,7 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 
-public class TestHelixLiveInstanceMonitor {
+public class HelixLiveInstanceMonitorIntegrationTest {
   private String zkAddress;
   private ZkClient zkClient;
   private String cluster = "test-metadata-cluster";

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/integration/utils/VeniceClusterWrapper.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/integration/utils/VeniceClusterWrapper.java
@@ -1,9 +1,6 @@
 package com.linkedin.venice.integration.utils;
 
-import static com.linkedin.venice.ConfigKeys.DEFAULT_MAX_NUMBER_OF_PARTITIONS;
-import static com.linkedin.venice.ConfigKeys.KAFKA_BOOTSTRAP_SERVERS;
-import static com.linkedin.venice.ConfigKeys.SERVER_ENABLE_KAFKA_OPENSSL;
-import static com.linkedin.venice.ConfigKeys.ZOOKEEPER_ADDRESS;
+import static com.linkedin.venice.ConfigKeys.*;
 import static com.linkedin.venice.integration.utils.VeniceServerWrapper.CLIENT_CONFIG_FOR_CONSUMER;
 import static com.linkedin.venice.integration.utils.VeniceServerWrapper.SERVER_ENABLE_SERVER_ALLOW_LIST;
 import static com.linkedin.venice.integration.utils.VeniceServerWrapper.SERVER_ENABLE_SSL;
@@ -252,6 +249,10 @@ public class VeniceClusterWrapper extends ProcessWrapper {
         featureProperties.setProperty(SERVER_IS_AUTO_JOIN, Boolean.toString(options.isEnableAutoJoinAllowlist()));
         featureProperties.setProperty(SERVER_ENABLE_SSL, Boolean.toString(options.isSslToStorageNodes()));
         featureProperties.setProperty(SERVER_SSL_TO_KAFKA, Boolean.toString(options.isSslToKafka()));
+
+        // Half of servers on each mode, with 1 server clusters aligning with the default (true)
+        featureProperties.setProperty(STORE_WRITER_BUFFER_AFTER_LEADER_LOGIC_ENABLED, Boolean.toString(i % 2 == 0));
+
         if (!veniceRouterWrappers.isEmpty()) {
           ClientConfig clientConfig = new ClientConfig().setVeniceURL(zkAddress)
               .setD2ServiceName(VeniceRouterWrapper.CLUSTER_DISCOVERY_D2_SERVICE_NAME)

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/pubsub/adapter/kafka/producer/ApacheKafkaProducerAdapterITest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/pubsub/adapter/kafka/producer/ApacheKafkaProducerAdapterITest.java
@@ -239,6 +239,7 @@ public class ApacheKafkaProducerAdapterITest {
         continue;
       }
 
+      assertNotNull(cb.getException());
       assertNotNull(cb.getException().getMessage());
       assertTrue(cb.getException().getMessage().contains("Producer is closed forcefully."));
       try {

--- a/internal/venice-test-common/src/main/java/com/linkedin/venice/utils/TestUtils.java
+++ b/internal/venice-test-common/src/main/java/com/linkedin/venice/utils/TestUtils.java
@@ -646,36 +646,23 @@ public class TestUtils {
     });
   }
 
-  public static void verifySystemStoreInAllRegions(
-      String regularStoreName,
-      VeniceSystemStoreType systemStoreType,
-      List<ControllerClient> controllerClientList) {
-    String systemStoreName = systemStoreType.getSystemStoreName(regularStoreName);
-    TestUtils.waitForNonDeterministicAssertion(60, TimeUnit.SECONDS, () -> {
-      for (ControllerClient client: controllerClientList) {
-        StoreResponse response = client.getStore(systemStoreName);
-        Assert.assertFalse(response.isError());
-        Assert.assertTrue(response.getStore().getCurrentVersion() > 0);
-      }
-    });
-  }
-
   public static void verifyDCConfigNativeAndActiveRepl(
-      ControllerClient controllerClient,
       String storeName,
       boolean enabledNR,
-      boolean enabledAA) {
-    TestUtils.waitForNonDeterministicAssertion(20, TimeUnit.SECONDS, true, () -> {
-      StoreResponse storeResponse = controllerClient.getStore(storeName);
-      Assert.assertFalse(storeResponse.isError());
-      Assert.assertEquals(
-          storeResponse.getStore().isNativeReplicationEnabled(),
-          enabledNR,
-          "The native replication config does not match.");
-      Assert.assertEquals(
-          storeResponse.getStore().isActiveActiveReplicationEnabled(),
-          enabledAA,
-          "The active active replication config does not match.");
+      boolean enabledAA,
+      ControllerClient... controllerClients) {
+    TestUtils.waitForNonDeterministicAssertion(60, TimeUnit.SECONDS, true, () -> {
+      for (ControllerClient controllerClient: controllerClients) {
+        StoreResponse storeResponse = assertCommand(controllerClient.getStore(storeName));
+        Assert.assertEquals(
+            storeResponse.getStore().isNativeReplicationEnabled(),
+            enabledNR,
+            "The native replication config does not match.");
+        Assert.assertEquals(
+            storeResponse.getStore().isActiveActiveReplicationEnabled(),
+            enabledAA,
+            "The active active replication config does not match.");
+      }
     });
   }
 

--- a/internal/venice-test-common/src/test/java/com/linkedin/venice/utils/TestUtilsTest.java
+++ b/internal/venice-test-common/src/test/java/com/linkedin/venice/utils/TestUtilsTest.java
@@ -1,0 +1,29 @@
+package com.linkedin.venice.utils;
+
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.linkedin.venice.controllerapi.ControllerClient;
+import com.linkedin.venice.controllerapi.StoreResponse;
+import com.linkedin.venice.meta.StoreInfo;
+import org.testng.annotations.Test;
+
+
+public class TestUtilsTest {
+  @Test
+  public void testVerifyDCConfigNativeAndActiveRepl() {
+    ControllerClient controllerClient = mock(ControllerClient.class);
+    StoreResponse storeResponse = mock(StoreResponse.class);
+    StoreInfo storeInfo = mock(StoreInfo.class);
+    when(storeInfo.isNativeReplicationEnabled()).thenReturn(true);
+    when(storeInfo.isActiveActiveReplicationEnabled()).thenReturn(true);
+    when(storeResponse.getStore()).thenReturn(storeInfo);
+    when(controllerClient.getStore(anyString())).thenReturn(storeResponse);
+    TestUtils.verifyDCConfigNativeAndActiveRepl("blah", true, true, controllerClient);
+    verify(controllerClient).getStore(anyString());
+    verify(storeInfo).isNativeReplicationEnabled();
+    verify(storeInfo).isActiveActiveReplicationEnabled();
+  }
+}


### PR DESCRIPTION
The new mode is controlled by:

store.writer.buffer.after.leader.logic.enabled (default = true)

The current behavior (which matches the default of the new config), is to have 3 threads involved in leader ingestion:

1. Consume from RT -> DCR logic -> produce to VT
2. Producer callback -> enqueue to SBS
3. SBS run loop -> dequeue from buffer -> persist to local storage

When the new mode is enabled, it skips SBS and uses only 2 threads:

1. Consume from RT -> DCR logic -> produce to VT
2. Producer callback -> persist to local storage

In the new mode, the pub sub producer’s callback acts as the only buffer, instead of chaining two buffers one right after the other. Unless the producer callback queue has some weakness in the way it handles buffering, then this should reduce the end-to-end overhead of ingestion, effectively reducing the size of garbage buffered inside SBS by 1/3rd in typical deployments (i.e. assuming RF=3).

Miscellaneous:

- Changed TestUtils::verifyDCConfigNativeAndActiveRepl so that it takes multiple controller clients and can therefore wait longer in case one of them needs it, without the total wait time being extremely long. This seems to be an area of recurring flakiness.

- Bumped the Tehuti dependency to 0.9.2, containing a hot path performance optimization in Sensor::record, which accounts for more than 7% of the CPU of a server profiling.

- Made StoragePartitionDiskUsage::getUsage unsynchronized, and reduced the overall complexity of the class. Also changed the StorageUtilizationManager::getDiskQuotaUsage to use a normal for loop instead of stream. The SUM::getDiskQuotaUsage function was shown to take 7% of the CPU of StorePartitionDataReceiver::write in a profiling on a server, in-between pushes (ingesting 14K msg per sec of RT writes), so these changes should make ingestion more efficient.

As discussed here: https://venicedb.slack.com/archives/C03SLQWRSLF/p1676218619454699

## How was this PR tested?
Test suite

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.