### PR TITLE
[controller][server] avoid serializing PartitionStatus.replicaStatusMap into ZK node

### DIFF
--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/PartitionDetail.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/PartitionDetail.java
@@ -6,7 +6,6 @@ import com.linkedin.venice.pushmonitor.StatusSnapshot;
 import com.linkedin.venice.utils.Pair;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import org.apache.commons.lang.StringUtils;
 
 
@@ -38,9 +37,9 @@ public class PartitionDetail {
   }
 
   void addReplicaDetails(final PartitionStatus pStatus) {
-    for (Map.Entry<String, ReplicaStatus> entry: pStatus.getReplicaStatusMap().entrySet()) {
-      String instanceId = entry.getKey();
-      Pair<StatusSnapshot, StatusSnapshot> status = entry.getValue().findStartedAndCompletedStatus();
+    for (ReplicaStatus replicaStatus: pStatus.getReplicaStatuses()) {
+      String instanceId = replicaStatus.getInstanceId();
+      Pair<StatusSnapshot, StatusSnapshot> status = replicaStatus.findStartedAndCompletedStatus();
       String startedTime = (status == null) ? StringUtils.EMPTY : status.getFirst().getTime();
       String completedTime = (status == null) ? StringUtils.EMPTY : status.getSecond().getTime();
       replicaDetails.add(new ReplicaDetail(instanceId, startedTime, completedTime));

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pushmonitor/PartitionStatus.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pushmonitor/PartitionStatus.java
@@ -27,10 +27,6 @@ public class PartitionStatus implements Comparable<PartitionStatus> {
     return partitionId;
   }
 
-  public Map<String, ReplicaStatus> getReplicaStatusMap() {
-    return replicaStatusMap;
-  }
-
   public void updateReplicaStatus(String instanceId, ExecutionStatus newStatus) {
     updateReplicaStatus(instanceId, newStatus, "");
   }


### PR DESCRIPTION
Getter function PartitionStatus.getReplicaStatusMap() will cause duplicate info (replicaStatuses/replicaStatusMap) to be serialized into Znode, thus increase its contents. This commit fixes the issue by removing this getter function.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
Internal CI tests passed.
## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.