### PR TITLE
[server] Add resiliency to isolated ingestion remote requests

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/IsolatedIngestionBackend.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/IsolatedIngestionBackend.java
@@ -313,7 +313,7 @@ public class IsolatedIngestionBackend extends DefaultIngestionBackend
        * process and thus keeps failing. If the check indicates that resource is managed locally, it will execute the
        * command locally and break the loop, thus the request won't be stuck forever.
        */
-      if (getStoreIngestionService().isPartitionConsuming(topicName, partition)) {
+      if (command.equals(STOP_CONSUMPTION) && getStoreIngestionService().isPartitionConsuming(topicName, partition)) {
         LOGGER.warn(
             "Expect topic: {}, partition: {} in forked process but found in main process, will execute command {} locally.",
             topicName,

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/IsolatedIngestionBackend.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/IsolatedIngestionBackend.java
@@ -290,6 +290,23 @@ public class IsolatedIngestionBackend extends DefaultIngestionBackend
       if (remoteCommandSupplier.get()) {
         return;
       }
+      /**
+       * The idea of this check below is to add resiliency to isolated ingestion metadata management.
+       * Although in most of the case the resource ingestion status managed by main / forked process should be in sync,
+       * but in event of regression or unexpected error metadata could be out of sync.
+       * This extra check covers the case where resource is maintained locally but main process think it is in forked
+       * process and thus keeps failing. If the check indicates that resource is managed locally, it will execute the
+       * command locally and break the loop, thus the request won't be stuck forever.
+       */
+      if (getStoreIngestionService().isPartitionConsuming(topicName, partition)) {
+        LOGGER.warn(
+            "Expect topic: {}, partition: {} in forked process but found in main process, will execute command {} locally.",
+            topicName,
+            partition,
+            command);
+        localCommandRunnable.run();
+        return;
+      }
       LOGGER.info(
           "Command {} rejected by remote ingestion process, will retry in {} ms.",
           command,

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/IsolatedIngestionBackend.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/IsolatedIngestionBackend.java
@@ -291,6 +291,7 @@ public class IsolatedIngestionBackend extends DefaultIngestionBackend
       LOGGER.info("Sending command {} of topic: {}, partition: {} to fork process.", command, topicName, partition);
       try {
         if (command.equals(START_CONSUMPTION)) {
+          // Start consumption should set up resource ingestion status for tracking purpose.
           getMainIngestionMonitorService().setVersionPartitionToIsolatedIngestion(topicName, partition);
         }
         if (remoteCommandSupplier.get()) {
@@ -298,6 +299,7 @@ public class IsolatedIngestionBackend extends DefaultIngestionBackend
         }
       } catch (Exception e) {
         if (command.equals(START_CONSUMPTION)) {
+          // Failure in start consumption request should reset the resource ingestion status.
           LOGGER.warn("Clean up ingestion status for topic: {}, partition: {}.", topicName, partition);
           getMainIngestionMonitorService().cleanupTopicPartitionState(topicName, partition);
         }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/isolated/IsolatedIngestionServerHandler.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/isolated/IsolatedIngestionServerHandler.java
@@ -182,7 +182,7 @@ public class IsolatedIngestionServerHandler extends SimpleChannelInboundHandler<
           isolatedIngestionServer.cleanupTopicState(topicName);
           break;
         case IS_PARTITION_CONSUMING:
-          report.isPositive = storeIngestionService.isPartitionConsuming(storeConfig, partitionId);
+          report.isPositive = storeIngestionService.isPartitionConsuming(topicName, partitionId);
           break;
         case REMOVE_STORAGE_ENGINE:
           isolatedIngestionServer.getIngestionBackend().removeStorageEngine(topicName);

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/main/MainIngestionMonitorService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/main/MainIngestionMonitorService.java
@@ -176,7 +176,7 @@ public class MainIngestionMonitorService extends AbstractVeniceService {
   }
 
   public MainPartitionIngestionStatus getTopicPartitionIngestionStatus(String topicName, int partitionId) {
-    MainTopicIngestionStatus topicIngestionStatus = topicIngestionStatusMap.get(topicName);
+    MainTopicIngestionStatus topicIngestionStatus = getTopicIngestionStatusMap().get(topicName);
     if (topicIngestionStatus != null) {
       return topicIngestionStatus.getPartitionIngestionStatus(partitionId);
     }
@@ -184,28 +184,28 @@ public class MainIngestionMonitorService extends AbstractVeniceService {
   }
 
   public void setVersionPartitionToLocalIngestion(String topicName, int partitionId) {
-    topicIngestionStatusMap.computeIfAbsent(topicName, x -> new MainTopicIngestionStatus(topicName))
+    getTopicIngestionStatusMap().computeIfAbsent(topicName, x -> new MainTopicIngestionStatus(topicName))
         .setPartitionIngestionStatusToLocalIngestion(partitionId);
   }
 
   public void setVersionPartitionToIsolatedIngestion(String topicName, int partitionId) {
-    topicIngestionStatusMap.computeIfAbsent(topicName, x -> new MainTopicIngestionStatus(topicName))
+    getTopicIngestionStatusMap().computeIfAbsent(topicName, x -> new MainTopicIngestionStatus(topicName))
         .setPartitionIngestionStatusToIsolatedIngestion(partitionId);
   }
 
   public void cleanupTopicPartitionState(String topicName, int partitionId) {
-    MainTopicIngestionStatus topicIngestionStatus = topicIngestionStatusMap.get(topicName);
+    MainTopicIngestionStatus topicIngestionStatus = getTopicIngestionStatusMap().get(topicName);
     if (topicIngestionStatus != null) {
       topicIngestionStatus.removePartitionIngestionStatus(partitionId);
     }
   }
 
   public void cleanupTopicState(String topicName) {
-    topicIngestionStatusMap.remove(topicName);
+    getTopicIngestionStatusMap().remove(topicName);
   }
 
   public long getTopicPartitionCount(String topicName) {
-    MainTopicIngestionStatus topicIngestionStatus = topicIngestionStatusMap.get(topicName);
+    MainTopicIngestionStatus topicIngestionStatus = getTopicIngestionStatusMap().get(topicName);
     if (topicIngestionStatus != null) {
       return topicIngestionStatus.getIngestingPartitionCount();
     }
@@ -326,7 +326,7 @@ public class MainIngestionMonitorService extends AbstractVeniceService {
     return new MainIngestionRequestClient(configLoader);
   }
 
-  Map<String, MainTopicIngestionStatus> getTopicIngestionStatusMap() {
+  public Map<String, MainTopicIngestionStatus> getTopicIngestionStatusMap() {
     return topicIngestionStatusMap;
   }
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionService.java
@@ -851,14 +851,14 @@ public class KafkaStoreIngestionService extends AbstractVeniceService implements
       int sleepSeconds,
       int numRetries) {
     String topicName = veniceStore.getStoreVersionName();
-    if (isPartitionConsuming(veniceStore, partitionId)) {
+    if (isPartitionConsuming(topicName, partitionId)) {
       stopConsumption(veniceStore, partitionId);
       try {
         long startTimeInMs = System.currentTimeMillis();
         for (int i = 0; i < numRetries; i++) {
-          if (!isPartitionConsuming(veniceStore, partitionId)) {
+          if (!isPartitionConsuming(topicName, partitionId)) {
             LOGGER.info(
-                "Partition: {} of topic: {} has stopped consumption in {}ms.",
+                "Partition: {} of topic: {} has stopped consumption in {} ms.",
                 partitionId,
                 topicName,
                 LatencyUtils.getElapsedTimeInMs(startTimeInMs));
@@ -963,8 +963,7 @@ public class KafkaStoreIngestionService extends AbstractVeniceService implements
   }
 
   @Override
-  public boolean isPartitionConsuming(VeniceStoreVersionConfig veniceStore, int partitionId) {
-    final String topic = veniceStore.getStoreVersionName();
+  public boolean isPartitionConsuming(String topic, int partitionId) {
     try (AutoCloseableLock ignore = topicLockManager.getLockForResource(topic)) {
       StoreIngestionTask ingestionTask = topicNameToIngestionTaskMap.get(topic);
       return ingestionTask != null && ingestionTask.isRunning() && ingestionTask.isPartitionConsuming(partitionId);

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionService.java
@@ -91,7 +91,7 @@ public interface StoreIngestionService extends MetadataRetriever {
   /**
    * Check whether the specified partition is still being consumed
    */
-  boolean isPartitionConsuming(VeniceStoreVersionConfig veniceStore, int partitionId);
+  boolean isPartitionConsuming(String topic, int partitionId);
 
   /**
    * Get topic names that are currently maintained by the ingestion service with corresponding version status not in an

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/ingestion/IsolatedIngestionBackendTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/ingestion/IsolatedIngestionBackendTest.java
@@ -13,7 +13,11 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.linkedin.davinci.ingestion.main.MainIngestionMonitorService;
+import com.linkedin.davinci.ingestion.main.MainTopicIngestionStatus;
 import com.linkedin.davinci.kafka.consumer.KafkaStoreIngestionService;
+import com.linkedin.venice.exceptions.VeniceException;
+import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 import org.testng.Assert;
@@ -42,35 +46,93 @@ public class IsolatedIngestionBackendTest {
       };
       Runnable localCommandRunnable = () -> executionFlag.set(-1);
 
-      // Resource does not exist.
-      when(monitorService.getTopicPartitionIngestionStatus(topic, partition)).thenReturn(NOT_EXIST);
-      // Consumption request should be executed in remote.
+      Map<String, MainTopicIngestionStatus> topicIngestionStatusMap = new VeniceConcurrentHashMap<>();
+      doCallRealMethod().when(monitorService).cleanupTopicPartitionState(topic, partition);
+      doCallRealMethod().when(monitorService).setVersionPartitionToLocalIngestion(topic, partition);
+      doCallRealMethod().when(monitorService).setVersionPartitionToIsolatedIngestion(topic, partition);
+      when(monitorService.getTopicPartitionIngestionStatus(topic, partition)).thenCallRealMethod();
+
+      when(monitorService.getTopicIngestionStatusMap()).thenReturn(topicIngestionStatusMap);
+
+      // Resource does not exist. Consumption request should be executed in remote.
       executionFlag.set(0);
+      Assert.assertEquals(monitorService.getTopicPartitionIngestionStatus(topic, partition), NOT_EXIST);
       backend.executeCommandWithRetry(topic, partition, START_CONSUMPTION, remoteProcessSupplier, localCommandRunnable);
+      Assert.assertEquals(monitorService.getTopicPartitionIngestionStatus(topic, partition), ISOLATED);
       Assert.assertEquals(executionFlag.get(), 1);
 
       // Other request should be executed in local.
       executionFlag.set(0);
+      monitorService.cleanupTopicPartitionState(topic, partition);
       backend.executeCommandWithRetry(topic, partition, STOP_CONSUMPTION, remoteProcessSupplier, localCommandRunnable);
+      Assert.assertEquals(monitorService.getTopicPartitionIngestionStatus(topic, partition), NOT_EXIST);
       Assert.assertEquals(executionFlag.get(), -1);
 
       // Resource exists in main process.
-      when(monitorService.getTopicPartitionIngestionStatus(topic, partition)).thenReturn(MAIN);
       executionFlag.set(0);
+      monitorService.setVersionPartitionToLocalIngestion(topic, partition);
       backend.executeCommandWithRetry(topic, partition, START_CONSUMPTION, remoteProcessSupplier, localCommandRunnable);
+      Assert.assertEquals(monitorService.getTopicPartitionIngestionStatus(topic, partition), MAIN);
       Assert.assertEquals(executionFlag.get(), -1);
 
       // Resource exists in isolated process.
-      when(monitorService.getTopicPartitionIngestionStatus(topic, partition)).thenReturn(ISOLATED);
+      monitorService.setVersionPartitionToIsolatedIngestion(topic, partition);
       executionFlag.set(0);
       backend.executeCommandWithRetry(topic, partition, START_CONSUMPTION, remoteProcessSupplier, localCommandRunnable);
+      Assert.assertEquals(monitorService.getTopicPartitionIngestionStatus(topic, partition), ISOLATED);
       Assert.assertEquals(executionFlag.get(), 1);
 
-      // Resource metadata in-sync: Expect resource in forked process but found in main process. It should eventually
-      // execute command locally.
-      when(monitorService.getTopicPartitionIngestionStatus(topic, partition)).thenReturn(ISOLATED);
+    }
+  }
+
+  @Test
+  public void testBackendCanHandleErrorCorrectly() {
+    try (MainIngestionMonitorService monitorService = mock(MainIngestionMonitorService.class);
+        IsolatedIngestionBackend backend = mock(IsolatedIngestionBackend.class)) {
+      String topic = "testTopic";
+      int partition = 0;
+
+      when(backend.getMainIngestionMonitorService()).thenReturn(monitorService);
+      KafkaStoreIngestionService storeIngestionService = mock(KafkaStoreIngestionService.class);
+      when(storeIngestionService.isPartitionConsuming(topic, partition)).thenReturn(true);
+      when(backend.getStoreIngestionService()).thenReturn(storeIngestionService);
+
+      doCallRealMethod().when(backend).executeCommandWithRetry(anyString(), anyInt(), any(), any(), any());
+
+      AtomicInteger executionFlag = new AtomicInteger();
+      Runnable localCommandRunnable = () -> executionFlag.set(-1);
+
+      Map<String, MainTopicIngestionStatus> topicIngestionStatusMap = new VeniceConcurrentHashMap<>();
+      doCallRealMethod().when(monitorService).cleanupTopicPartitionState(topic, partition);
+      when(monitorService.getTopicPartitionIngestionStatus(topic, partition)).thenCallRealMethod();
+      when(monitorService.getTopicIngestionStatusMap()).thenReturn(topicIngestionStatusMap);
+
+      /**
+       * Test Case (1): Resource metadata in-sync: Expect resource in forked process but found in main process.
+       * It should eventually execute command locally.
+       */
+      MainTopicIngestionStatus topicIngestionStatus = new MainTopicIngestionStatus(topic);
+      topicIngestionStatus.setPartitionIngestionStatusToIsolatedIngestion(partition);
+      topicIngestionStatusMap.put(topic, topicIngestionStatus);
       executionFlag.set(0);
-      backend.executeCommandWithRetry(topic, partition, START_CONSUMPTION, () -> false, localCommandRunnable);
+      backend.executeCommandWithRetry(topic, partition, STOP_CONSUMPTION, () -> false, localCommandRunnable);
+      Assert.assertEquals(executionFlag.get(), -1);
+
+      /**
+       * Test Case (2): START_CONSUMPTION failed remotely. Ingestion status should be cleaned up so rollback can be
+       * successful.
+       */
+      executionFlag.set(0);
+      topicIngestionStatusMap.clear();
+      Assert.assertThrows(() -> {
+        backend.executeCommandWithRetry(topic, partition, START_CONSUMPTION, () -> {
+          monitorService.setVersionPartitionToIsolatedIngestion(topic, partition);
+          throw new VeniceException("Ingestion request failed due to timeout!");
+        }, localCommandRunnable);
+      });
+      Assert.assertEquals(monitorService.getTopicPartitionIngestionStatus(topic, partition), NOT_EXIST);
+      Assert.assertEquals(executionFlag.get(), 0);
+      backend.executeCommandWithRetry(topic, partition, STOP_CONSUMPTION, () -> false, localCommandRunnable);
       Assert.assertEquals(executionFlag.get(), -1);
     }
   }


### PR DESCRIPTION
## [server] Add resiliency to isolated ingestion remote requests
This PR adds resiliency to isolated ingestion remote request:

(1) startConsumption on forked process will set resource ingestion status, this PR makes sure it get reset (clean up) when exception is thrown (failure case), so following rollback(stopConsumption) triggered by Helix rollback operation will be successful. (Note: improvement for startConsumption slow down caused by zombie resource is not covered in this PR, will be covered by follow up PR)
(2) In case of regression or extreme request errors, a topic partition may be considered ingesting in remoted process but it might actually in main process. This can be blocking server shutdown if it happens to STOP_CONSUMPTION command.

To tackle this, this PR adds a simple logic to check if local ingestion service contains this resource when remote request is rejected. It will make sure in the extreme case, server will be able to shutdown successfully.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
Added new unit test to cover the logic.

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.