### PR TITLE
[NOT FOR MERGE][server] How zombie resources impact isolated ingestion upon server bootstrap

### DIFF
--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/IsolatedIngestionTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/IsolatedIngestionTest.java
@@ -1,0 +1,105 @@
+package com.linkedin.venice.endToEnd;
+
+import static com.linkedin.venice.ConfigKeys.SERVER_INGESTION_ISOLATION_HEARTBEAT_REQUEST_TIMEOUT_SECONDS;
+import static com.linkedin.venice.ConfigKeys.SERVER_INGESTION_ISOLATION_REQUEST_TIMEOUT_SECONDS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.linkedin.alpini.base.concurrency.Executors;
+import com.linkedin.davinci.config.VeniceConfigLoader;
+import com.linkedin.davinci.config.VeniceServerConfig;
+import com.linkedin.davinci.ingestion.main.MainIngestionRequestClient;
+import com.linkedin.davinci.ingestion.utils.IsolatedIngestionUtils;
+import com.linkedin.venice.utils.ForkedJavaProcess;
+import com.linkedin.venice.utils.SimpleServer;
+import com.linkedin.venice.utils.Utils;
+import com.linkedin.venice.utils.VeniceProperties;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class IsolatedIngestionTest {
+  private static final Logger LOGGER = LogManager.getLogger();
+
+  @Test(timeOut = 300000)
+  public void testBackendHandleZombieResource() throws Exception {
+    int serverPort = 27015;
+    IsolatedIngestionUtils.releaseTargetPortBinding(SimpleServer.class.getName(), serverPort);
+    ForkedJavaProcess forkedIngestionProcess = ForkedJavaProcess.exec(
+        SimpleServer.class,
+        Collections.singletonList(String.valueOf(serverPort)),
+        Collections.emptyList(),
+        false);
+    IsolatedIngestionUtils.waitPortBinding(serverPort, 100);
+    VeniceProperties veniceProperties = mock(VeniceProperties.class);
+    when(veniceProperties.getInt(SERVER_INGESTION_ISOLATION_HEARTBEAT_REQUEST_TIMEOUT_SECONDS, 5)).thenReturn(5);
+    when(veniceProperties.getInt(SERVER_INGESTION_ISOLATION_REQUEST_TIMEOUT_SECONDS, 120)).thenReturn(120);
+    VeniceServerConfig veniceServerConfig = mock(VeniceServerConfig.class);
+    when(veniceServerConfig.getIngestionServicePort()).thenReturn(serverPort);
+    VeniceConfigLoader configLoader = mock(VeniceConfigLoader.class);
+    when(configLoader.getCombinedProperties()).thenReturn(veniceProperties);
+    when(configLoader.getVeniceServerConfig()).thenReturn(veniceServerConfig);
+
+    MainIngestionRequestClient ingestionRequestClient = new MainIngestionRequestClient(configLoader);
+    Utils.sleep(1000);
+    LOGGER.info(ingestionRequestClient.sendHeartbeatRequest());
+    ExecutorService executorService = Executors.newFixedThreadPool(100);
+    List<Future<Long>> zombieTopicPartitionFutures = new ArrayList<>();
+    List<Future<Long>> goodTopicPartitionFutures = new ArrayList<>();
+    int zombieResourceCount = 10;
+    int goodResourceCount = 10;
+    for (int i = 0; i < zombieResourceCount; i++) {
+      zombieTopicPartitionFutures
+          .add(simulateHelixStartConsumption(executorService, ingestionRequestClient, "zombie_topic_v" + i, 0));
+    }
+    Utils.sleep(1000);
+    for (int i = 0; i < goodResourceCount; i++) {
+      goodTopicPartitionFutures
+          .add(simulateHelixStartConsumption(executorService, ingestionRequestClient, "good_topic_v" + i, 0));
+    }
+    for (int i = 0; i < goodResourceCount; i++) {
+      long requestCompletionTime = goodTopicPartitionFutures.get(i).get();
+      LOGGER.warn("Good topic {} completed in {} ms", i, requestCompletionTime);
+    }
+    for (int i = 0; i < zombieResourceCount; i++) {
+      long requestCompletionTime = zombieTopicPartitionFutures.get(i).get();
+      LOGGER.warn("Zombie topic {} completed in {} ms", i, requestCompletionTime);
+    }
+    try {
+      for (int i = 0; i < goodResourceCount; i++) {
+        Assert.assertTrue(goodTopicPartitionFutures.get(i).get() < 1000);
+      }
+    } finally {
+      forkedIngestionProcess.destroy();
+    }
+  }
+
+  Future<Long> simulateHelixStartConsumption(
+      ExecutorService executorService,
+      MainIngestionRequestClient client,
+      String topic,
+      int partition) {
+    return executorService.submit(() -> {
+      long startTimeMs = System.currentTimeMillis();
+      LOGGER.info("Start consumption of topic: {}, partition: {} at {}", topic, partition, startTimeMs);
+      long elapsedTimeMs;
+      try {
+        client.startConsumption(topic, partition);
+      } catch (Exception e) {
+        LOGGER.warn("Encounter exception when executing start consumption. {}", e.getMessage());
+      } finally {
+        long finishTime = System.currentTimeMillis();
+        elapsedTimeMs = finishTime - startTimeMs;
+        LOGGER.info("Completed consumption of topic: {}, partition: {} at {}", topic, partition, finishTime);
+      }
+      return elapsedTimeMs;
+    });
+  }
+}

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/utils/SimpleServer.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/utils/SimpleServer.java
@@ -1,0 +1,100 @@
+package com.linkedin.venice.utils;
+
+import com.linkedin.alpini.base.concurrency.Executors;
+import com.linkedin.venice.exceptions.VeniceException;
+import com.linkedin.venice.service.AbstractVeniceService;
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelOption;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.ServerChannel;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.nio.NioServerSocketChannel;
+import io.netty.util.concurrent.DefaultEventExecutorGroup;
+import io.netty.util.concurrent.EventExecutorGroup;
+import java.util.concurrent.ExecutorService;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+
+public class SimpleServer extends AbstractVeniceService {
+  private static final Logger LOGGER = LogManager.getLogger(SimpleServer.class);
+  Class<? extends ServerChannel> serverSocketChannelClass = NioServerSocketChannel.class;
+  private final EventExecutorGroup eventExecutorGroup = new DefaultEventExecutorGroup(16);
+  private final ExecutorService executorService = Executors.newFixedThreadPool(20);
+
+  ServerBootstrap bootstrap;
+  EventLoopGroup bossGroup;
+  EventLoopGroup workerGroup;
+  private ChannelFuture serverFuture;
+
+  private final int servicePort;
+
+  boolean isInitiated;
+
+  @Override
+  public boolean startInner() {
+    int maxAttempt = 100;
+    long waitTime = 500;
+    int retryCount = 0;
+    while (true) {
+      try {
+        serverFuture = bootstrap.bind(servicePort).sync();
+        break;
+      } catch (Exception e) {
+        retryCount += 1;
+        if (retryCount > maxAttempt) {
+          throw new VeniceException(
+              "Ingestion Service is unable to bind to target port " + servicePort + " after " + maxAttempt
+                  + " retries.");
+        }
+        LOGGER.warn("Failed to bind to port {}, will retry in {} ms.", servicePort, waitTime, e);
+        Utils.sleep(waitTime);
+      }
+    }
+    LOGGER.info("Listener service started on port: {}", servicePort);
+    isInitiated = true;
+    return true;
+  }
+
+  @Override
+  public void stopInner() throws Exception {
+    isInitiated = false;
+    ChannelFuture shutdown = serverFuture.channel().closeFuture();
+    workerGroup.shutdownGracefully();
+    bossGroup.shutdownGracefully();
+    shutdown.sync();
+  }
+
+  public SimpleServer(int servicePort) {
+    this.servicePort = servicePort;
+    bossGroup = new NioEventLoopGroup();
+    workerGroup = new NioEventLoopGroup();
+    bootstrap = new ServerBootstrap();
+    bootstrap.group(bossGroup, workerGroup)
+        .channel(serverSocketChannelClass)
+        .childHandler(new SimpleServerChannelInitializer(this))
+        .option(ChannelOption.SO_BACKLOG, 1000)
+        .childOption(ChannelOption.SO_KEEPALIVE, true)
+        .option(ChannelOption.SO_REUSEADDR, true)
+        .childOption(ChannelOption.TCP_NODELAY, true);
+  }
+
+  public boolean isInitiated() {
+    return isInitiated;
+  }
+
+  public EventExecutorGroup getEventExecutorGroup() {
+    return eventExecutorGroup;
+  }
+
+  public ExecutorService getExecutorService() {
+    return executorService;
+  }
+
+  public static void main(String[] args) {
+    SimpleServer simpleServer = new SimpleServer(Integer.parseInt(args[0]));
+    simpleServer.start();
+  }
+
+}

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/utils/SimpleServerChannelInitializer.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/utils/SimpleServerChannelInitializer.java
@@ -1,0 +1,35 @@
+package com.linkedin.venice.utils;
+
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.handler.codec.http.HttpObjectAggregator;
+import io.netty.handler.codec.http.HttpRequestDecoder;
+import io.netty.handler.codec.http.HttpResponseEncoder;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+
+public class SimpleServerChannelInitializer extends ChannelInitializer<SocketChannel> {
+  private static final AtomicInteger counter = new AtomicInteger();
+
+  private static final Logger LOGGER = LogManager.getLogger();
+
+  private final SimpleServer simpleServer;
+  private final int id = counter.getAndIncrement();
+
+  public SimpleServerChannelInitializer(SimpleServer simpleServer) {
+    this.simpleServer = simpleServer;
+    LOGGER.info("SimpleServerChannelInitializer created for channel index={}", id);
+  }
+
+  @Override
+  protected void initChannel(SocketChannel ch) {
+    ch.pipeline().addLast(new HttpRequestDecoder());
+    // Set the maximum allowed request size to 100MB as the initial metric report size is fairly large.
+    ch.pipeline().addLast(new HttpObjectAggregator(1024 * 1024 * 100));
+    ch.pipeline().addLast(new HttpResponseEncoder());
+    ch.pipeline().addLast(new SimpleServerHandler(simpleServer));
+    LOGGER.info("SimpleServerChannelInitializer initialized for channel index={}", id);
+  }
+}

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/utils/SimpleServerHandler.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/utils/SimpleServerHandler.java
@@ -1,0 +1,113 @@
+package com.linkedin.venice.utils;
+
+import static com.linkedin.davinci.ingestion.utils.IsolatedIngestionUtils.buildHttpResponse;
+import static com.linkedin.davinci.ingestion.utils.IsolatedIngestionUtils.createIngestionTaskReport;
+import static com.linkedin.davinci.ingestion.utils.IsolatedIngestionUtils.deserializeIngestionActionRequest;
+import static com.linkedin.davinci.ingestion.utils.IsolatedIngestionUtils.getDummyContent;
+import static com.linkedin.davinci.ingestion.utils.IsolatedIngestionUtils.readHttpRequestContent;
+import static com.linkedin.davinci.ingestion.utils.IsolatedIngestionUtils.serializeIngestionActionResponse;
+
+import com.linkedin.davinci.ingestion.utils.IsolatedIngestionUtils;
+import com.linkedin.venice.exceptions.VeniceException;
+import com.linkedin.venice.ingestion.protocol.IngestionTaskCommand;
+import com.linkedin.venice.ingestion.protocol.IngestionTaskReport;
+import com.linkedin.venice.ingestion.protocol.enums.IngestionAction;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.SimpleChannelInboundHandler;
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.util.concurrent.DefaultEventExecutorGroup;
+import io.netty.util.concurrent.EventExecutorGroup;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+
+public class SimpleServerHandler extends SimpleChannelInboundHandler<FullHttpRequest> {
+  private static final Logger LOGGER = LogManager.getLogger(SimpleServerHandler.class);
+  private static final AtomicInteger counter = new AtomicInteger();
+  private final int id = counter.getAndIncrement();
+  private final SimpleServer simpleServer;
+  static final EventExecutorGroup group = new DefaultEventExecutorGroup(16);
+
+  public SimpleServerHandler(SimpleServer simpleServer) {
+    super();
+    this.simpleServer = simpleServer;
+    LOGGER.info(
+        "{} id: {}, created for listener service at {}.",
+        SimpleServerHandler.class.getSimpleName(),
+        id,
+        (System.currentTimeMillis() % 1000000) / 1000.0d);
+
+  }
+
+  @Override
+  public void channelReadComplete(ChannelHandlerContext ctx) {
+    ctx.flush();
+  }
+
+  @Override
+  protected void channelRead0(ChannelHandlerContext ctx, FullHttpRequest msg) throws Exception {
+    simpleServer.getExecutorService().execute(() -> {
+      try {
+        IngestionAction action = IsolatedIngestionUtils.getIngestionActionFromRequest(msg);
+        byte[] result = getDummyContent();
+        if (!simpleServer.isInitiated()) {
+          throw new VeniceException("Server is not initialized yet!");
+        }
+        switch (action) {
+          case COMMAND:
+            IngestionTaskCommand ingestionTaskCommand =
+                deserializeIngestionActionRequest(action, readHttpRequestContent(msg));
+            IngestionTaskReport report = handleIngestionTaskCommand(ingestionTaskCommand);
+            result = serializeIngestionActionResponse(action, report);
+            break;
+          case HEARTBEAT:
+            LOGGER.info("Received heartbeat.");
+            break;
+          default:
+            throw new UnsupportedOperationException("Unrecognized ingestion action: " + action);
+        }
+        ctx.writeAndFlush(buildHttpResponse(HttpResponseStatus.OK, result));
+      } catch (UnsupportedOperationException e) {
+        // Here we only handles the bad requests exception. Other errors are handled in exceptionCaught() method.
+        LOGGER.error("Caught unrecognized request action:", e);
+        ctx.writeAndFlush(
+            buildHttpResponse(
+                HttpResponseStatus.BAD_REQUEST,
+                ExceptionUtils.compactExceptionDescription(e, "channelRead0")));
+      }
+    });
+  }
+
+  @Override
+  public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+    LOGGER.error("Encounter exception -  message: {}, cause: {}", cause.getMessage(), cause);
+    ctx.writeAndFlush(
+        buildHttpResponse(
+            HttpResponseStatus.INTERNAL_SERVER_ERROR,
+            ExceptionUtils.compactExceptionDescription(cause, "exceptionCaught")));
+    ctx.close();
+  }
+
+  private IngestionTaskReport handleIngestionTaskCommand(IngestionTaskCommand ingestionTaskCommand) {
+    String topicName = ingestionTaskCommand.topicName.toString();
+    int partitionId = ingestionTaskCommand.partitionId;
+    IngestionTaskReport report = createIngestionTaskReport(topicName, partitionId);
+    LOGGER.info("Handling consumption request for topic: {}, partition: {} {}", topicName, partitionId, logIndex());
+    if (topicName.contains("zombie_topic")) {
+      LOGGER.warn("Start sleeping for topic: {}, partition: {} {}", topicName, partitionId, logIndex());
+      Utils.sleep(10000);
+      LOGGER.warn("Finished sleeping for topic: {}, partition: {} {}", topicName, partitionId, logIndex());
+      report.isPositive = false;
+      report.exceptionThrown = true;
+      report.message = "Resource does not exist";
+      // throw new VeniceException("Topic: " + topicName + ", version: " + partitionId + " does not exist.");
+    }
+    return report;
+  }
+
+  private String logIndex() {
+    return " [index=" + id + "]";
+  }
+}


### PR DESCRIPTION
## [server] How zombie resources impact isolated ingestion upon server bootstrap
Created this PR to reproduce the case where isolated ingestion enabled server was impacted by zombie resources.
Here I created a simple Netty server simulate forked ingestion service. It will sleep 10s and throw exception when a zombie topic start consumption comes in and will return good response for other topics.

Base on my testing, if there is only 1 zombie topic resource, it is fine. If there is more than 1 zombie resources stuck in the startConsumption request it will slow down good topic ingestion request greatly.  (In my test locally if zombie resource count = 2, good resource will take ~9s to complete).

This is why it leads to slow down in ei4 mt-0 slow bootstrap and occasionally it will make a few resources ingestion failure. Although we just rotate II to ei-ltx1 mt-0, but it is still valid problem and should be resolved.
My understanding here is all requests goes to server should be short, however for non-exist topic, waitVersionOrThrow will take 1 minute to wait and throw. If we want to avoid this, we may want to split the forked process startConsumption into two stages  (1) send request to server, server ack, create a latch or something like this. (2) when server finish request, it send another request and helix thread could either complete or throw.
Although what I don't fully understand is:
(1) How many server threads are there to handle requests? How can we check and tune it? (I did not find the config...) Although it is not good to create a large amount of handler threads in order to handle this bad case.



## How was this PR tested?
New Integration Test

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.