### PR TITLE
[vpj][test] Make GZIP compressor and its reusableObjectsThreadLocal to be instance variables

### DIFF
--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/compression/CompressorFactory.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/compression/CompressorFactory.java
@@ -12,8 +12,8 @@ import org.apache.logging.log4j.Logger;
 
 public class CompressorFactory implements Closeable, AutoCloseable {
   private static final Logger LOGGER = LogManager.getLogger(CompressorFactory.class);
-  private static final VeniceCompressor NO_OP_COMPRESSOR = new NoopCompressor();
-  private static final VeniceCompressor GZIP_COMPRESSOR = new GzipCompressor();
+  private final VeniceCompressor NO_OP_COMPRESSOR = new NoopCompressor();
+  private final VeniceCompressor GZIP_COMPRESSOR = new GzipCompressor();
   private final Map<String, VeniceCompressor> versionSpecificCompressorMap = new VeniceConcurrentHashMap<>();
 
   public VeniceCompressor getCompressor(CompressionStrategy compressionStrategy) {

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/compression/GzipPool.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/compression/GzipPool.java
@@ -22,7 +22,7 @@ class GzipPool implements AutoCloseable {
     }
   }
 
-  private static final CloseableThreadLocal<ReusableObjects> reusableObjectsThreadLocal =
+  private final CloseableThreadLocal<ReusableObjects> reusableObjectsThreadLocal =
       new CloseableThreadLocal(ReusableObjects::new);
 
   /**


### PR DESCRIPTION
## Summary
1. Moved mapper creation as try-with-resources in `TestVeniceAvroMapper.java` to close properly.
2. This ends up closing the mapper leading to closing the `CompressorFactory->GzipCompressor->GzipPool->reusableObjectsThreadLocal`. But because `GZIP_COMPRESSOR` in `CompressorFactory` and `reusableObjectsThreadLocal` in `GzipPool` are defined to be static, it is not recreated for the next mapper instance for the next tests leading to failures. Changed them to be instance variables. 

## How was this PR tested?
Internal CI

## Does this PR introduce any user-facing changes?
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.