### PR TITLE
[vpj][dvc][server][controller][test] Use a single object as producer callback and produce result future

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderProducerCallback.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderProducerCallback.java
@@ -20,7 +20,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 
-class LeaderProducerCallback implements ChunkAwareCallback {
+class LeaderProducerCallback extends ChunkAwareCallback {
   private static final Logger LOGGER = LogManager.getLogger(LeaderFollowerStoreIngestionTask.class);
 
   protected static final ChunkedValueManifestSerializer CHUNKED_VALUE_MANIFEST_SERIALIZER =

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/view/ChangeCaptureViewWriter.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/view/ChangeCaptureViewWriter.java
@@ -82,7 +82,7 @@ public class ChangeCaptureViewWriter extends VeniceViewWriter {
     // updatedKeyBytes = ChunkingUtils.KEY_WITH_CHUNKING_SUFFIX_SERIALIZER.serializeNonChunkedKey(key); (line 604
     // A/AIngestionTask?)
     try {
-      veniceWriter.put(key, recordChangeEvent, 1).get();
+      veniceWriter.syncPut(key, recordChangeEvent, 1);
     } catch (InterruptedException | ExecutionException e) {
       LOGGER
           .error("Failed to produce to Change Capture view topic for store: {} version: {}", store.getName(), version);

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
@@ -115,9 +115,11 @@ import com.linkedin.venice.partitioner.VenicePartitioner;
 import com.linkedin.venice.pubsub.ImmutablePubSubMessage;
 import com.linkedin.venice.pubsub.PubSubTopicPartitionImpl;
 import com.linkedin.venice.pubsub.PubSubTopicRepository;
+import com.linkedin.venice.pubsub.adapter.SimplePubSubProducerCallbackImpl;
 import com.linkedin.venice.pubsub.api.PubSubMessage;
 import com.linkedin.venice.pubsub.api.PubSubProduceResult;
 import com.linkedin.venice.pubsub.api.PubSubProducerAdapter;
+import com.linkedin.venice.pubsub.api.PubSubProducerCallback;
 import com.linkedin.venice.pubsub.api.PubSubTopic;
 import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
 import com.linkedin.venice.pubsub.consumer.PubSubConsumer;
@@ -1082,11 +1084,12 @@ public abstract class StoreIngestionTaskTest {
   @Test(dataProvider = "True-and-False", dataProviderClass = DataProviderUtils.class)
   public void testVeniceMessagesProcessing(boolean isActiveActiveReplicationEnabled) throws Exception {
     localVeniceWriter.broadcastStartOfPush(new HashMap<>());
-    PubSubProduceResult putMetadata = (PubSubProduceResult) localVeniceWriter
-        .put(putKeyFoo, putValue, EXISTING_SCHEMA_ID, PUT_KEY_FOO_TIMESTAMP, null)
-        .get();
-    PubSubProduceResult deleteMetadata =
-        (PubSubProduceResult) localVeniceWriter.delete(deleteKeyFoo, DELETE_KEY_FOO_TIMESTAMP, null).get();
+    PubSubProducerCallback putResult = new SimplePubSubProducerCallbackImpl();
+    localVeniceWriter.put(putKeyFoo, putValue, EXISTING_SCHEMA_ID, PUT_KEY_FOO_TIMESTAMP, putResult);
+    PubSubProduceResult putMetadata = putResult.get();
+    PubSubProducerCallback deleteResult = new SimplePubSubProducerCallbackImpl();
+    localVeniceWriter.delete(deleteKeyFoo, DELETE_KEY_FOO_TIMESTAMP, deleteResult);
+    PubSubProduceResult deleteMetadata = deleteResult.get();
 
     Queue<AbstractPollStrategy> pollStrategies = new LinkedList<>();
     pollStrategies.add(new RandomPollStrategy());
@@ -1161,8 +1164,12 @@ public abstract class StoreIngestionTaskTest {
           fooTopicPartition,
           new LeaderFollowerPartitionStateModel.LeaderSessionIdChecker(1, new AtomicLong(1)));
       try {
-        rtWriter.put(putKeyFoo, putValue, EXISTING_SCHEMA_ID, PUT_KEY_FOO_TIMESTAMP, null).get();
-        rtWriter.delete(deleteKeyFoo, DELETE_KEY_FOO_TIMESTAMP, null).get();
+        PubSubProducerCallback putResult = new SimplePubSubProducerCallbackImpl();
+        rtWriter.put(putKeyFoo, putValue, EXISTING_SCHEMA_ID, PUT_KEY_FOO_TIMESTAMP, putResult);
+        putResult.get();
+        PubSubProducerCallback deleteResult = new SimplePubSubProducerCallbackImpl();
+        rtWriter.delete(deleteKeyFoo, DELETE_KEY_FOO_TIMESTAMP, deleteResult);
+        deleteResult.get();
 
         verifyPutAndDelete(amplificationFactor, isActiveActiveReplicationEnabled, false);
       } catch (Exception e) {
@@ -1184,13 +1191,21 @@ public abstract class StoreIngestionTaskTest {
     when(mockTopicManager.isTopicCompactionEnabled(topic)).thenReturn(true);
 
     localVeniceWriter.broadcastStartOfPush(new HashMap<>());
-    PubSubProduceResult putMetadata1 =
-        (PubSubProduceResult) localVeniceWriter.put(putKeyFoo, putValueToCorrupt, SCHEMA_ID).get();
-    localVeniceWriter.put(putKeyFoo, putValue, SCHEMA_ID).get();
-    PubSubProduceResult putMetadata3 =
-        (PubSubProduceResult) localVeniceWriter.put(putKeyFoo2, putValueToCorrupt, SCHEMA_ID).get();
-    PubSubProduceResult putMetadata4 =
-        (PubSubProduceResult) localVeniceWriter.put(putKeyFoo2, putValue, SCHEMA_ID).get();
+    PubSubProducerCallback putResult1 = new SimplePubSubProducerCallbackImpl();
+    localVeniceWriter.put(putKeyFoo, putValueToCorrupt, SCHEMA_ID, putResult1);
+    PubSubProduceResult putMetadata1 = putResult1.get();
+
+    PubSubProducerCallback putResult2 = new SimplePubSubProducerCallbackImpl();
+    localVeniceWriter.put(putKeyFoo, putValue, SCHEMA_ID, putResult2);
+    putResult2.get();
+
+    PubSubProducerCallback putResult3 = new SimplePubSubProducerCallbackImpl();
+    localVeniceWriter.put(putKeyFoo2, putValueToCorrupt, SCHEMA_ID, putResult3);
+    PubSubProduceResult putMetadata3 = putResult3.get();
+
+    PubSubProducerCallback putResult4 = new SimplePubSubProducerCallbackImpl();
+    localVeniceWriter.put(putKeyFoo2, putValue, SCHEMA_ID, putResult4);
+    PubSubProduceResult putMetadata4 = putResult4.get();
 
     Queue<PubSubTopicPartitionOffset> pollDeliveryOrder = new LinkedList<>();
     /**
@@ -1230,7 +1245,9 @@ public abstract class StoreIngestionTaskTest {
   public void testVeniceMessagesProcessingWithExistingSchemaId(boolean isActiveActiveReplicationEnabled)
       throws Exception {
     localVeniceWriter.broadcastStartOfPush(new HashMap<>());
-    long fooLastOffset = getOffset(localVeniceWriter.put(putKeyFoo, putValue, EXISTING_SCHEMA_ID));
+    PubSubProducerCallback putResult = new SimplePubSubProducerCallbackImpl();
+    localVeniceWriter.put(putKeyFoo, putValue, EXISTING_SCHEMA_ID, putResult);
+    long fooLastOffset = getOffset(putResult);
 
     doReturn(true).when(mockSchemaRepo).hasValueSchema(storeNameWithoutVersionInfo, EXISTING_SCHEMA_ID);
 
@@ -1258,7 +1275,9 @@ public abstract class StoreIngestionTaskTest {
       throws Exception {
     localVeniceWriter.broadcastStartOfPush(new HashMap<>());
     localVeniceWriter.put(putKeyFoo, putValue, NON_EXISTING_SCHEMA_ID);
-    long existingSchemaOffset = getOffset(localVeniceWriter.put(putKeyFoo, putValue, EXISTING_SCHEMA_ID));
+    PubSubProducerCallback putResult = new SimplePubSubProducerCallbackImpl();
+    localVeniceWriter.put(putKeyFoo, putValue, EXISTING_SCHEMA_ID, putResult);
+    long existingSchemaOffset = getOffset(putResult);
 
     when(mockSchemaRepo.hasValueSchema(storeNameWithoutVersionInfo, NON_EXISTING_SCHEMA_ID))
         .thenReturn(false, false, true);
@@ -1331,8 +1350,15 @@ public abstract class StoreIngestionTaskTest {
   @Test(dataProvider = "True-and-False", dataProviderClass = DataProviderUtils.class)
   public void testNotifier(boolean isActiveActiveReplicationEnabled) throws Exception {
     localVeniceWriter.broadcastStartOfPush(new HashMap<>());
-    long fooLastOffset = getOffset(localVeniceWriter.put(putKeyFoo, putValue, SCHEMA_ID));
-    long barLastOffset = getOffset(localVeniceWriter.put(putKeyBar, putValue, SCHEMA_ID));
+
+    PubSubProducerCallback fooPutResult = new SimplePubSubProducerCallbackImpl();
+    localVeniceWriter.put(putKeyFoo, putValue, SCHEMA_ID, fooPutResult);
+    long fooLastOffset = getOffset(fooPutResult);
+
+    PubSubProducerCallback barPutResult = new SimplePubSubProducerCallbackImpl();
+    localVeniceWriter.put(putKeyBar, putValue, SCHEMA_ID, barPutResult);
+    long barLastOffset = getOffset(barPutResult);
+
     localVeniceWriter.broadcastEndOfPush(new HashMap<>());
     localVeniceWriter.broadcastEndOfPush(new HashMap<>());
 
@@ -1439,7 +1465,9 @@ public abstract class StoreIngestionTaskTest {
   @Test(dataProvider = "True-and-False", dataProviderClass = DataProviderUtils.class)
   public void testResetPartition(boolean isActiveActiveReplicationEnabled) throws Exception {
     localVeniceWriter.broadcastStartOfPush(new HashMap<>());
-    localVeniceWriter.put(putKeyFoo, putValue, SCHEMA_ID).get();
+    PubSubProducerCallback putResult = new SimplePubSubProducerCallbackImpl();
+    localVeniceWriter.put(putKeyFoo, putValue, SCHEMA_ID, putResult);
+    putResult.get();
 
     runTest(Utils.setOf(PARTITION_FOO), () -> {
       verify(mockAbstractStorageEngine, timeout(TEST_TIMEOUT_MS))
@@ -1456,7 +1484,9 @@ public abstract class StoreIngestionTaskTest {
   @Test(dataProvider = "True-and-False", dataProviderClass = DataProviderUtils.class)
   public void testResetPartitionAfterUnsubscription(boolean isActiveActiveReplicationEnabled) throws Exception {
     localVeniceWriter.broadcastStartOfPush(new HashMap<>());
-    localVeniceWriter.put(putKeyFoo, putValue, SCHEMA_ID).get();
+    PubSubProducerCallback putResult = new SimplePubSubProducerCallbackImpl();
+    localVeniceWriter.put(putKeyFoo, putValue, SCHEMA_ID, putResult);
+    putResult.get();
 
     doThrow(new UnsubscribedTopicPartitionException(fooTopicPartition)).when(mockLocalKafkaConsumer)
         .resetOffset(fooTopicPartition);
@@ -1482,8 +1512,14 @@ public abstract class StoreIngestionTaskTest {
   @Test(dataProvider = "True-and-False", dataProviderClass = DataProviderUtils.class)
   public void testDetectionOfMissingRecord(boolean isActiveActiveReplicationEnabled) throws Exception {
     localVeniceWriter.broadcastStartOfPush(new HashMap<>());
-    long fooLastOffset = getOffset(localVeniceWriter.put(putKeyFoo, putValue, SCHEMA_ID));
-    long barOffsetToSkip = getOffset(localVeniceWriter.put(putKeyBar, putValue, SCHEMA_ID));
+    PubSubProducerCallback fooPutResult = new SimplePubSubProducerCallbackImpl();
+    localVeniceWriter.put(putKeyFoo, putValue, SCHEMA_ID, fooPutResult);
+    long fooLastOffset = getOffset(fooPutResult);
+
+    PubSubProducerCallback barPutResult = new SimplePubSubProducerCallbackImpl();
+    localVeniceWriter.put(putKeyBar, putValue, SCHEMA_ID, barPutResult);
+    long barOffsetToSkip = getOffset(barPutResult);
+
     localVeniceWriter.put(putKeyBar, putValue, SCHEMA_ID);
     localVeniceWriter.broadcastEndOfPush(new HashMap<>());
 
@@ -1515,8 +1551,14 @@ public abstract class StoreIngestionTaskTest {
   @Test(dataProvider = "True-and-False", dataProviderClass = DataProviderUtils.class)
   public void testSkippingOfDuplicateRecord(boolean isActiveActiveReplicationEnabled) throws Exception {
     localVeniceWriter.broadcastStartOfPush(new HashMap<>());
-    long fooLastOffset = getOffset(localVeniceWriter.put(putKeyFoo, putValue, SCHEMA_ID));
-    long barOffsetToDupe = getOffset(localVeniceWriter.put(putKeyBar, putValue, SCHEMA_ID));
+    PubSubProducerCallback fooPutResult = new SimplePubSubProducerCallbackImpl();
+    localVeniceWriter.put(putKeyFoo, putValue, SCHEMA_ID, fooPutResult);
+    long fooLastOffset = getOffset(fooPutResult);
+
+    PubSubProducerCallback barPutResult = new SimplePubSubProducerCallbackImpl();
+    localVeniceWriter.put(putKeyBar, putValue, SCHEMA_ID, barPutResult);
+    long barOffsetToDupe = getOffset(barPutResult);
+
     localVeniceWriter.broadcastEndOfPush(new HashMap<>());
 
     PollStrategy pollStrategy = new DuplicatingPollStrategy(
@@ -1639,7 +1681,10 @@ public abstract class StoreIngestionTaskTest {
     VeniceWriter veniceWriterForDataAfterPush = getCorruptedVeniceWriter(putValueToCorrupt, inMemoryLocalKafkaBroker);
 
     localVeniceWriter.broadcastStartOfPush(new HashMap<>());
-    long lastOffsetBeforeEOP = getOffset(veniceWriterForDataDuringPush.put(putKeyBar, putValue, SCHEMA_ID));
+
+    PubSubProducerCallback putResult1 = new SimplePubSubProducerCallbackImpl();
+    veniceWriterForDataDuringPush.put(putKeyBar, putValue, SCHEMA_ID, putResult1);
+    long lastOffsetBeforeEOP = getOffset(putResult1);
     veniceWriterForDataDuringPush.close();
     localVeniceWriter.broadcastEndOfPush(new HashMap<>());
 
@@ -1647,8 +1692,13 @@ public abstract class StoreIngestionTaskTest {
     isCurrentVersion = () -> true;
 
     // After the end of push, we simulate a nearline writer, which somehow pushes corrupt data.
-    getOffset(veniceWriterForDataAfterPush.put(putKeyBar, putValueToCorrupt, SCHEMA_ID));
-    long lastOffset = getOffset(veniceWriterForDataAfterPush.put(putKeyBar, putValue, SCHEMA_ID));
+    PubSubProducerCallback corruptPutResult = new SimplePubSubProducerCallbackImpl();
+    veniceWriterForDataAfterPush.put(putKeyBar, putValueToCorrupt, SCHEMA_ID, corruptPutResult);
+    getOffset(corruptPutResult);
+
+    PubSubProducerCallback putResult2 = new SimplePubSubProducerCallbackImpl();
+    veniceWriterForDataAfterPush.put(putKeyBar, putValue, SCHEMA_ID, putResult2);
+    long lastOffset = getOffset(putResult2);
     veniceWriterForDataAfterPush.close();
 
     LOGGER.info("lastOffsetBeforeEOP: {}, lastOffset: {}", lastOffsetBeforeEOP, lastOffset);
@@ -1708,20 +1758,28 @@ public abstract class StoreIngestionTaskTest {
 
     // do a batch push
     veniceWriterCorrupted.broadcastStartOfPush(new HashMap<>());
-    long lastOffsetBeforeEOP = getOffset(veniceWriterCorrupted.put(putKeyBar, putValue, SCHEMA_ID));
+    PubSubProducerCallback putResult = new SimplePubSubProducerCallbackImpl();
+    veniceWriterCorrupted.put(putKeyBar, putValue, SCHEMA_ID, putResult);
+    long lastOffsetBeforeEOP = getOffset(putResult);
     veniceWriterCorrupted.broadcastEndOfPush(new HashMap<>());
 
     // simulate the version swap.
     isCurrentVersion = () -> true;
 
     // After the end of push, the venice writer continue puts a corrupt data and end the segment.
-    getOffset(veniceWriterCorrupted.put(putKeyFoo, putValueToCorrupt, SCHEMA_ID));
+    putResult = new SimplePubSubProducerCallbackImpl();
+    veniceWriterCorrupted.put(putKeyFoo, putValueToCorrupt, SCHEMA_ID, putResult);
+    getOffset(putResult);
     veniceWriterCorrupted.endSegment(PARTITION_FOO, true);
 
     // a missing msg
-    long fooOffsetToSkip = getOffset(veniceWriterCorrupted.put(putKeyFoo, putValue, SCHEMA_ID));
+    PubSubProducerCallback fooPutResult = new SimplePubSubProducerCallbackImpl();
+    veniceWriterCorrupted.put(putKeyFoo, putValue, SCHEMA_ID, fooPutResult);
+    long fooOffsetToSkip = getOffset(fooPutResult);
     // a normal msg
-    long lastOffset = getOffset(veniceWriterCorrupted.put(putKeyFoo2, putValue, SCHEMA_ID));
+    PubSubProducerCallback barPutResult = new SimplePubSubProducerCallbackImpl();
+    veniceWriterCorrupted.put(putKeyFoo2, putValue, SCHEMA_ID, barPutResult);
+    long lastOffset = getOffset(barPutResult);
     veniceWriterCorrupted.close();
 
     PollStrategy pollStrategy = new FilteringPollStrategy(
@@ -1753,8 +1811,14 @@ public abstract class StoreIngestionTaskTest {
     VeniceWriter veniceWriterForData = getCorruptedVeniceWriter(putValueToCorrupt, inMemoryLocalKafkaBroker);
 
     localVeniceWriter.broadcastStartOfPush(new HashMap<>());
-    long fooLastOffset = getOffset(veniceWriterForData.put(putKeyFoo, putValue, SCHEMA_ID));
-    getOffset(veniceWriterForData.put(putKeyBar, putValueToCorrupt, SCHEMA_ID));
+
+    PubSubProducerCallback putResult = new SimplePubSubProducerCallbackImpl();
+    veniceWriterForData.put(putKeyFoo, putValue, SCHEMA_ID, putResult);
+    long fooLastOffset = getOffset(putResult);
+
+    PubSubProducerCallback corruptPutResult = new SimplePubSubProducerCallbackImpl();
+    veniceWriterForData.put(putKeyBar, putValueToCorrupt, SCHEMA_ID, corruptPutResult);
+    getOffset(corruptPutResult);
     veniceWriterForData.close();
     localVeniceWriter.broadcastEndOfPush(new HashMap<>());
 
@@ -1951,7 +2015,9 @@ public abstract class StoreIngestionTaskTest {
       byte[] key = getNumberedKey(i);
       byte[] value = getNumberedValue(i);
 
-      PubSubProduceResult produceResult = (PubSubProduceResult) localVeniceWriter.put(key, value, SCHEMA_ID).get();
+      PubSubProducerCallback putResult = new SimplePubSubProducerCallbackImpl();
+      localVeniceWriter.put(key, value, SCHEMA_ID, putResult);
+      PubSubProduceResult produceResult = putResult.get();
 
       maxOffsetPerPartition.put(produceResult.getPartition(), produceResult.getOffset());
       pushedRecords.put(new Pair(produceResult.getPartition(), new ByteArray(key)), new ByteArray(value));
@@ -2061,7 +2127,9 @@ public abstract class StoreIngestionTaskTest {
   @Test(dataProvider = "True-and-False", dataProviderClass = DataProviderUtils.class)
   public void testKillAfterPartitionIsCompleted(boolean isActiveActiveReplicationEnabled) throws Exception {
     localVeniceWriter.broadcastStartOfPush(new HashMap<>());
-    long fooLastOffset = getOffset(localVeniceWriter.put(putKeyFoo, putValue, SCHEMA_ID));
+    PubSubProducerCallback putResult = new SimplePubSubProducerCallbackImpl();
+    localVeniceWriter.put(putKeyFoo, putValue, SCHEMA_ID, putResult);
+    long fooLastOffset = getOffset(putResult);
     localVeniceWriter.broadcastEndOfPush(new HashMap<>());
 
     runTest(Utils.setOf(PARTITION_FOO), () -> {
@@ -2131,9 +2199,15 @@ public abstract class StoreIngestionTaskTest {
   public void testVeniceMessagesProcessingWithSortedInput(boolean isActiveActiveReplicationEnabled) throws Exception {
     setStoreVersionStateSupplier(true);
     localVeniceWriter.broadcastStartOfPush(true, new HashMap<>());
-    PubSubProduceResult putMetadata =
-        (PubSubProduceResult) localVeniceWriter.put(putKeyFoo, putValue, EXISTING_SCHEMA_ID).get();
-    PubSubProduceResult deleteMetadata = (PubSubProduceResult) localVeniceWriter.delete(deleteKeyFoo, null).get();
+
+    PubSubProducerCallback putResult = new SimplePubSubProducerCallbackImpl();
+    localVeniceWriter.put(putKeyFoo, putValue, EXISTING_SCHEMA_ID, putResult);
+    PubSubProduceResult putMetadata = putResult.get();
+
+    PubSubProducerCallback deleteResult = new SimplePubSubProducerCallbackImpl();
+    localVeniceWriter.delete(deleteKeyFoo, deleteResult);
+    PubSubProduceResult deleteMetadata = deleteResult.get();
+
     localVeniceWriter.broadcastEndOfPush(new HashMap<>());
 
     runTest(Utils.setOf(PARTITION_FOO), () -> {
@@ -2168,7 +2242,11 @@ public abstract class StoreIngestionTaskTest {
     doReturn(false).when(rocksDBServerConfig).isRocksDBPlainTableFormatEnabled();
     setStoreVersionStateSupplier(true);
     localVeniceWriter.broadcastStartOfPush(true, new HashMap<>());
-    localVeniceWriter.put(putKeyFoo, putValue, SCHEMA_ID).get();
+
+    PubSubProducerCallback putResult = new SimplePubSubProducerCallbackImpl();
+    localVeniceWriter.put(putKeyFoo, putValue, SCHEMA_ID, putResult);
+    putResult.get();
+
     // intentionally not sending the EOP so that expectedSSTFileChecksum calculation does not get reset.
     // veniceWriter.broadcastEndOfPush(new HashMap<>());
 
@@ -2214,7 +2292,9 @@ public abstract class StoreIngestionTaskTest {
       localVeniceWriter.broadcastStartOfPush(Collections.emptyMap());
       for (int i = 0; i < MESSAGES_BEFORE_EOP; i++) {
         try {
-          localVeniceWriter.put(getNumberedKey(i), getNumberedValue(i), SCHEMA_ID).get();
+          PubSubProducerCallback putResult = new SimplePubSubProducerCallbackImpl();
+          localVeniceWriter.put(getNumberedKey(i), getNumberedValue(i), SCHEMA_ID, putResult);
+          putResult.get();
         } catch (InterruptedException | ExecutionException e) {
           throw new VeniceException(e);
         }
@@ -2233,7 +2313,9 @@ public abstract class StoreIngestionTaskTest {
 
       for (int i = 0; i < MESSAGES_AFTER_EOP; i++) {
         try {
-          localVeniceWriter.put(getNumberedKey(i), getNumberedValue(i), SCHEMA_ID).get();
+          PubSubProducerCallback putResult = new SimplePubSubProducerCallbackImpl();
+          localVeniceWriter.put(getNumberedKey(i), getNumberedValue(i), SCHEMA_ID, putResult);
+          putResult.get();
         } catch (InterruptedException | ExecutionException e) {
           throw new VeniceException(e);
         }
@@ -2293,12 +2375,19 @@ public abstract class StoreIngestionTaskTest {
   public void testIncrementalPush(boolean isActiveActiveReplicationEnabled) throws Exception {
     setStoreVersionStateSupplier(true);
     localVeniceWriter.broadcastStartOfPush(true, new HashMap<>());
-    long fooOffset = getOffset(localVeniceWriter.put(putKeyFoo, putValue, SCHEMA_ID));
+
+    PubSubProducerCallback putResult = new SimplePubSubProducerCallbackImpl();
+    localVeniceWriter.put(putKeyFoo, putValue, SCHEMA_ID, putResult);
+    long fooOffset = getOffset(putResult);
     localVeniceWriter.broadcastEndOfPush(new HashMap<>());
 
     String version = String.valueOf(System.currentTimeMillis());
     localVeniceWriter.broadcastStartOfIncrementalPush(version, new HashMap<>());
-    long fooNewOffset = getOffset(localVeniceWriter.put(putKeyFoo, putValue, SCHEMA_ID));
+
+    PubSubProducerCallback putResult2 = new SimplePubSubProducerCallbackImpl();
+    localVeniceWriter.put(putKeyFoo, putValue, SCHEMA_ID, putResult2);
+    long fooNewOffset = getOffset(putResult2);
+
     localVeniceWriter.broadcastEndOfIncrementalPush(version, new HashMap<>());
     // Records order are: StartOfSeg, StartOfPush, data, EndOfPush, EndOfSeg, StartOfSeg, StartOfIncrementalPush
     // data, EndOfIncrementalPush
@@ -2340,7 +2429,9 @@ public abstract class StoreIngestionTaskTest {
   public void testSchemaCacheWarming(boolean isActiveActiveReplicationEnabled) throws Exception {
     setStoreVersionStateSupplier(true);
     localVeniceWriter.broadcastStartOfPush(true, new HashMap<>());
-    long fooOffset = getOffset(localVeniceWriter.put(putKeyFoo, putValue, SCHEMA_ID));
+    PubSubProducerCallback putResult = new SimplePubSubProducerCallbackImpl();
+    localVeniceWriter.put(putKeyFoo, putValue, SCHEMA_ID, putResult);
+    long fooOffset = getOffset(putResult);
     localVeniceWriter.broadcastEndOfPush(new HashMap<>());
     SchemaEntry schemaEntry = new SchemaEntry(1, STRING_SCHEMA);
     // Records order are: StartOfSeg, StartOfPush, data, EndOfPush, EndOfSeg
@@ -2387,8 +2478,15 @@ public abstract class StoreIngestionTaskTest {
   @Test(dataProvider = "True-and-False", dataProviderClass = DataProviderUtils.class, timeOut = TEST_TIMEOUT_MS * 5)
   public void testPartitionExceptionIsolation(boolean isActiveActiveReplicationEnabled) throws Exception {
     localVeniceWriter.broadcastStartOfPush(new HashMap<>());
-    getOffset(localVeniceWriter.put(putKeyFoo, putValue, SCHEMA_ID));
-    long barLastOffset = getOffset(localVeniceWriter.put(putKeyBar, putValue, SCHEMA_ID));
+
+    PubSubProducerCallback fooPutResult = new SimplePubSubProducerCallbackImpl();
+    localVeniceWriter.put(putKeyFoo, putValue, SCHEMA_ID, fooPutResult);
+    getOffset(fooPutResult);
+
+    PubSubProducerCallback barPutResult = new SimplePubSubProducerCallbackImpl();
+    localVeniceWriter.put(putKeyBar, putValue, SCHEMA_ID, barPutResult);
+    long barLastOffset = getOffset(barPutResult);
+
     localVeniceWriter.broadcastEndOfPush(new HashMap<>());
 
     doThrow(new VeniceException("fake storage engine exception")).when(mockAbstractStorageEngine)
@@ -2586,11 +2684,15 @@ public abstract class StoreIngestionTaskTest {
 
     long recordsNum = 5L;
     for (int i = 0; i < recordsNum; i++) {
-      localRtWriter.put(putKeyFoo, putValue, EXISTING_SCHEMA_ID, PUT_KEY_FOO_TIMESTAMP, null).get();
+      PubSubProducerCallback putResult = new SimplePubSubProducerCallbackImpl();
+      localRtWriter.put(putKeyFoo, putValue, EXISTING_SCHEMA_ID, PUT_KEY_FOO_TIMESTAMP, putResult);
+      putResult.get();
     }
 
     for (int i = 0; i < recordsNum; i++) {
-      remoteRtWriter.put(putKeyFoo, putValue, EXISTING_SCHEMA_ID, PUT_KEY_FOO_TIMESTAMP, null).get();
+      PubSubProducerCallback putResult = new SimplePubSubProducerCallbackImpl();
+      remoteRtWriter.put(putKeyFoo, putValue, EXISTING_SCHEMA_ID, PUT_KEY_FOO_TIMESTAMP, putResult);
+      putResult.get();
     }
 
     waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, true, () -> {
@@ -2601,11 +2703,15 @@ public abstract class StoreIngestionTaskTest {
     // Pause remote kafka consumption
     remoteKafkaQuota.set(0);
     for (int i = 0; i < recordsNum; i++) {
-      localRtWriter.put(putKeyFoo, putValue, EXISTING_SCHEMA_ID, PUT_KEY_FOO_TIMESTAMP, null).get();
+      PubSubProducerCallback putResult = new SimplePubSubProducerCallbackImpl();
+      localRtWriter.put(putKeyFoo, putValue, EXISTING_SCHEMA_ID, PUT_KEY_FOO_TIMESTAMP, putResult);
+      putResult.get();
     }
 
     for (int i = 0; i < recordsNum; i++) {
-      remoteRtWriter.put(putKeyFoo, putValue, EXISTING_SCHEMA_ID, PUT_KEY_FOO_TIMESTAMP, null).get();
+      PubSubProducerCallback putResult = new SimplePubSubProducerCallbackImpl();
+      remoteRtWriter.put(putKeyFoo, putValue, EXISTING_SCHEMA_ID, PUT_KEY_FOO_TIMESTAMP, putResult);
+      putResult.get();
     }
 
     Long doubleRecordsNum = recordsNum * 2;

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/store/view/ViewWriterUtilsTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/store/view/ViewWriterUtilsTest.java
@@ -4,16 +4,13 @@ import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
 import com.linkedin.davinci.config.VeniceConfigLoader;
 import com.linkedin.davinci.config.VeniceServerConfig;
 import com.linkedin.venice.meta.Store;
-import com.linkedin.venice.pubsub.api.PubSubProduceResult;
 import com.linkedin.venice.utils.VeniceProperties;
 import com.linkedin.venice.views.ChangeCaptureView;
 import com.linkedin.venice.views.VeniceView;
 import com.linkedin.venice.views.ViewUtils;
-import com.linkedin.venice.writer.VeniceWriter;
 import it.unimi.dsi.fastutil.objects.Object2IntMap;
 import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
 import java.util.Collections;
-import java.util.concurrent.Future;
 import org.apache.avro.Schema;
 import org.mockito.Mockito;
 import org.testng.Assert;
@@ -28,10 +25,6 @@ public class ViewWriterUtilsTest {
     Store mockStore = Mockito.mock(Store.class);
     VeniceProperties props = new VeniceProperties();
     Object2IntMap<String> urlMappingMap = new Object2IntOpenHashMap<>();
-    Future<PubSubProduceResult> mockFuture = Mockito.mock(Future.class);
-
-    VeniceWriter mockVeniceWriter = Mockito.mock(VeniceWriter.class);
-    Mockito.when(mockVeniceWriter.put(Mockito.any(), Mockito.any(), Mockito.anyInt())).thenReturn(mockFuture);
 
     VeniceServerConfig mockVeniceServerConfig = Mockito.mock(VeniceServerConfig.class);
     Mockito.when(mockVeniceServerConfig.getKafkaClusterUrlToIdMap()).thenReturn(urlMappingMap);

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VeniceReducer.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VeniceReducer.java
@@ -126,7 +126,7 @@ public class VeniceReducer extends AbstractMapReduceTask
         } else if (enableWriteCompute && derivedValueSchemaId > 0) {
           writer.update(keyBytes, valueBytes, valueSchemaId, derivedValueSchemaId, callback);
         } else {
-          writer.put(keyBytes, valueBytes, valueSchemaId, callback, null);
+          writer.put(keyBytes, valueBytes, valueSchemaId, callback);
         }
       };
     }
@@ -576,7 +576,7 @@ public class VeniceReducer extends AbstractMapReduceTask
     this.exceedQuota = exceedQuota;
   }
 
-  protected class ReducerProduceCallback implements PubSubProducerCallback {
+  protected class ReducerProduceCallback extends PubSubProducerCallback {
     private final Reporter reporter;
 
     public ReducerProduceCallback(Reporter reporter) {

--- a/internal/venice-avro-compatibility-test/src/test/java/com/linkedin/venice/VeniceClusterInitializer.java
+++ b/internal/venice-avro-compatibility-test/src/test/java/com/linkedin/venice/VeniceClusterInitializer.java
@@ -15,6 +15,8 @@ import com.linkedin.venice.helix.HelixReadOnlySchemaRepository;
 import com.linkedin.venice.integration.utils.ServiceFactory;
 import com.linkedin.venice.integration.utils.VeniceClusterWrapper;
 import com.linkedin.venice.meta.Version;
+import com.linkedin.venice.pubsub.adapter.SimplePubSubProducerCallbackImpl;
+import com.linkedin.venice.pubsub.api.PubSubProducerCallback;
 import com.linkedin.venice.pushmonitor.ExecutionStatus;
 import com.linkedin.venice.serialization.DefaultSerializer;
 import com.linkedin.venice.serialization.VeniceKafkaSerializer;
@@ -200,7 +202,9 @@ public class VeniceClusterInitializer implements Closeable {
       veniceWriter.broadcastStartOfPush(Collections.emptyMap());
       Future[] writerFutures = new Future[ENTRY_COUNT];
       for (int i = 0; i < ENTRY_COUNT; i++) {
-        writerFutures[i] = veniceWriter.put(KEY_PREFIX + i, values.get(i), valueSchemaId);
+        PubSubProducerCallback putResult = new SimplePubSubProducerCallbackImpl();
+        veniceWriter.put(KEY_PREFIX + i, values.get(i), valueSchemaId, putResult);
+        writerFutures[i] = putResult;
       }
 
       // wait synchronously for them to succeed

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/adapter/PubSubSharedProducerAdapter.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/adapter/PubSubSharedProducerAdapter.java
@@ -3,7 +3,6 @@ package com.linkedin.venice.pubsub.adapter;
 import com.linkedin.venice.kafka.protocol.KafkaMessageEnvelope;
 import com.linkedin.venice.message.KafkaKey;
 import com.linkedin.venice.pubsub.api.PubSubMessageHeaders;
-import com.linkedin.venice.pubsub.api.PubSubProduceResult;
 import com.linkedin.venice.pubsub.api.PubSubProducerAdapter;
 import com.linkedin.venice.pubsub.api.PubSubProducerCallback;
 import com.linkedin.venice.stats.AbstractVeniceStats;
@@ -20,7 +19,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.Future;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -69,7 +67,7 @@ public class PubSubSharedProducerAdapter implements PubSubProducerAdapter {
    * @param callback - The callback function, which will be triggered when producer sends out the message.
    * */
   @Override
-  public Future<PubSubProduceResult> sendMessage(
+  public void sendMessage(
       String topic,
       Integer partition,
       KafkaKey key,
@@ -77,9 +75,8 @@ public class PubSubSharedProducerAdapter implements PubSubProducerAdapter {
       PubSubMessageHeaders headers,
       PubSubProducerCallback callback) {
     long startNs = System.nanoTime();
-    Future<PubSubProduceResult> result = producerAdapter.sendMessage(topic, partition, key, value, headers, callback);
+    producerAdapter.sendMessage(topic, partition, key, value, headers, callback);
     sharedProducerStats.recordProducerSendLatency(LatencyUtils.getLatencyInMS(startNs));
-    return result;
   }
 
   @Override

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/adapter/SimplePubSubProducerCallbackImpl.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/adapter/SimplePubSubProducerCallbackImpl.java
@@ -7,7 +7,7 @@ import com.linkedin.venice.pubsub.api.PubSubProducerCallback;
 /**
  * A simple implementation of PubSubProducerCallback interface for testing purposes.
  */
-public class SimplePubSubProducerCallbackImpl implements PubSubProducerCallback {
+public class SimplePubSubProducerCallbackImpl extends PubSubProducerCallback {
   private PubSubProduceResult produceResult;
   private Exception exception;
   private boolean isInvoked;

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/adapter/kafka/producer/ApacheKafkaProducerAdapter.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/adapter/kafka/producer/ApacheKafkaProducerAdapter.java
@@ -5,7 +5,6 @@ import com.linkedin.venice.kafka.protocol.KafkaMessageEnvelope;
 import com.linkedin.venice.message.KafkaKey;
 import com.linkedin.venice.pubsub.adapter.kafka.ApacheKafkaUtils;
 import com.linkedin.venice.pubsub.api.PubSubMessageHeaders;
-import com.linkedin.venice.pubsub.api.PubSubProduceResult;
 import com.linkedin.venice.pubsub.api.PubSubProducerAdapter;
 import com.linkedin.venice.pubsub.api.PubSubProducerCallback;
 import it.unimi.dsi.fastutil.objects.Object2DoubleMap;
@@ -14,7 +13,6 @@ import it.unimi.dsi.fastutil.objects.Object2DoubleOpenHashMap;
 import java.time.Duration;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerRecord;
@@ -68,7 +66,7 @@ public class ApacheKafkaProducerAdapter implements PubSubProducerAdapter {
    * @param pubsubProducerCallback - The callback function, which will be triggered when Kafka client sends out the message.
    * */
   @Override
-  public Future<PubSubProduceResult> sendMessage(
+  public void sendMessage(
       String topic,
       Integer partition,
       KafkaKey key,
@@ -85,7 +83,6 @@ public class ApacheKafkaProducerAdapter implements PubSubProducerAdapter {
     ApacheKafkaProducerCallback kafkaCallback = new ApacheKafkaProducerCallback(pubsubProducerCallback);
     try {
       producer.send(record, kafkaCallback);
-      return kafkaCallback.getProduceResultFuture();
     } catch (Exception e) {
       throw new VeniceException(
           "Got an error while trying to produce message into Kafka. Topic: '" + record.topic() + "', partition: "

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/PubSubProducerAdapter.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/PubSubProducerAdapter.java
@@ -36,13 +36,25 @@ public interface PubSubProducerAdapter {
     return future.get(timeout, timeUnit);
   }
 
-  Future<PubSubProduceResult> sendMessage(
+  /**
+   * @param topic      destination topic
+   * @param partition  partition in the target topic
+   * @param key        message key
+   * @param value      message value/payload
+   * @param headers    message headers (key-value pairs)
+   * @param pubSubProducerCallback   A CompletableFuture-come-callback which will be "invoked and completed" when
+   *                                message is sent successfully.
+   * All implementations of this interface MUST guarantee that "pubSubProducerCallback" will be
+   *   1) invoked (call PubSubProducerCallback::onCompletion) and
+   *   2) marked completed (PubSubProducerCallback::completeExceptionally or PubSubProducerCallback::complete).
+   */
+  void sendMessage(
       String topic,
       Integer partition,
       KafkaKey key,
       KafkaMessageEnvelope value,
       PubSubMessageHeaders headers,
-      PubSubProducerCallback callback);
+      PubSubProducerCallback pubSubProducerCallback);
 
   void flush();
 

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/PubSubProducerCallback.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/PubSubProducerCallback.java
@@ -1,12 +1,15 @@
 package com.linkedin.venice.pubsub.api;
 
+import java.util.concurrent.CompletableFuture;
+
+
 /**
  * A callback interface that users of PubSubProducerAdapter should implement if they want
  * to execute some code once PubSubProducerAdapter#sendMessage request is completed.
  */
-public interface PubSubProducerCallback {
+public abstract class PubSubProducerCallback extends CompletableFuture<PubSubProduceResult> {
   /**
    * exception will be null if request was completed without an error.
    */
-  void onCompletion(PubSubProduceResult produceResult, Exception exception);
+  public abstract void onCompletion(PubSubProduceResult produceResult, Exception exception);
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pushstatushelper/PushStatusStoreRecordDeleter.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pushstatushelper/PushStatusStoreRecordDeleter.java
@@ -1,7 +1,9 @@
 package com.linkedin.venice.pushstatushelper;
 
 import com.linkedin.venice.common.PushStatusStoreUtils;
+import com.linkedin.venice.pubsub.adapter.SimplePubSubProducerCallbackImpl;
 import com.linkedin.venice.pubsub.api.PubSubProduceResult;
+import com.linkedin.venice.pubsub.api.PubSubProducerCallback;
 import com.linkedin.venice.pushstatus.PushStatusKey;
 import com.linkedin.venice.utils.LatencyUtils;
 import com.linkedin.venice.writer.VeniceWriter;
@@ -54,7 +56,9 @@ public class PushStatusStoreRecordDeleter implements AutoCloseable {
         "Deleting incremental push status belonging to a partition:{}. pushStatusKey:{}",
         partitionId,
         pushStatusKey);
-    return veniceWriterCache.prepareVeniceWriter(storeName).delete(pushStatusKey, null);
+    PubSubProducerCallback callback = new SimplePubSubProducerCallbackImpl();
+    veniceWriterCache.prepareVeniceWriter(storeName).delete(pushStatusKey, callback);
+    return callback;
   }
 
   public void removePushStatusStoreVeniceWriter(String storeName) {

--- a/internal/venice-common/src/main/java/com/linkedin/venice/writer/AbstractVeniceWriter.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/writer/AbstractVeniceWriter.java
@@ -1,10 +1,8 @@
 package com.linkedin.venice.writer;
 
-import com.linkedin.venice.pubsub.api.PubSubProduceResult;
 import com.linkedin.venice.pubsub.api.PubSubProducerCallback;
 import java.io.Closeable;
 import java.io.IOException;
-import java.util.concurrent.Future;
 
 
 /**
@@ -25,32 +23,19 @@ public abstract class AbstractVeniceWriter<K, V, U> implements Closeable {
     return this.topicName;
   }
 
-  public Future<PubSubProduceResult> put(K key, V value, int valueSchemaId) {
-    return put(key, value, valueSchemaId, null);
+  public void put(K key, V value, int valueSchemaId) {
+    put(key, value, valueSchemaId, null);
   }
 
   public abstract void close(boolean gracefulClose) throws IOException;
 
-  public abstract Future<PubSubProduceResult> put(K key, V value, int valueSchemaId, PubSubProducerCallback callback);
+  public abstract void delete(K key, PubSubProducerCallback callback, DeleteMetadata deleteMetadata);
 
-  public abstract Future<PubSubProduceResult> put(
-      K key,
-      V value,
-      int valueSchemaId,
-      PubSubProducerCallback callback,
-      PutMetadata putMetadata);
+  public abstract void put(K key, V value, int valueSchemaId, PubSubProducerCallback callback);
 
-  public abstract Future<PubSubProduceResult> delete(
-      K key,
-      PubSubProducerCallback callback,
-      DeleteMetadata deleteMetadata);
+  public abstract void put(K key, V value, int valueSchemaId, PubSubProducerCallback callback, PutMetadata putMetadata);
 
-  public abstract Future<PubSubProduceResult> update(
-      K key,
-      U update,
-      int valueSchemaId,
-      int derivedSchemaId,
-      PubSubProducerCallback callback);
+  public abstract void update(K key, U update, int valueSchemaId, int derivedSchemaId, PubSubProducerCallback callback);
 
   public abstract void flush();
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/writer/ChunkAwareCallback.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/writer/ChunkAwareCallback.java
@@ -11,7 +11,7 @@ import java.nio.ByteBuffer;
  *  {@link #setChunkingInfo(byte[], ByteBuffer[], ChunkedValueManifest, ByteBuffer[], ChunkedValueManifest)} whenever
  *  processing a {@link MessageType#PUT}, whether it is chunked or not.
  */
-public interface ChunkAwareCallback extends PubSubProducerCallback {
+public abstract class ChunkAwareCallback extends PubSubProducerCallback {
   /**
    * For all PUT operations, the {@param key} is guaranteed to be passed via this function, whether chunking
    * is enabled or not, and whether the value is chunked or not. The other two parameters are null if the value
@@ -21,7 +21,7 @@ public interface ChunkAwareCallback extends PubSubProducerCallback {
    * @param valueChunks An array of {@link ByteBuffer} where the backing array has sufficient headroom to prepend Venice's header
    * @param chunkedValueManifest The {@link ChunkedValueManifest} of the chunked value
    */
-  void setChunkingInfo(
+  public abstract void setChunkingInfo(
       byte[] key,
       ByteBuffer[] valueChunks,
       ChunkedValueManifest chunkedValueManifest,

--- a/internal/venice-common/src/main/java/com/linkedin/venice/writer/CompletableFutureCallback.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/writer/CompletableFutureCallback.java
@@ -11,7 +11,7 @@ import java.util.concurrent.CompletableFuture;
  * changed and the callback will be called. The caller can pass a {@code CompletableFutureCallback} to a function
  * accepting a {@code Callback} parameter to get a {@code CompletableFuture} after the function returns.
  */
-public class CompletableFutureCallback implements PubSubProducerCallback {
+public class CompletableFutureCallback extends PubSubProducerCallback {
   private final CompletableFuture<Void> completableFuture;
   private PubSubProducerCallback callback = null;
 

--- a/internal/venice-common/src/main/java/com/linkedin/venice/writer/ErrorPropagationCallback.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/writer/ErrorPropagationCallback.java
@@ -7,7 +7,7 @@ import com.linkedin.venice.pubsub.api.PubSubProducerCallback;
 /**
  * Wraps another {@link PubSubProducerCallback} and propagates exceptions to it, but swallows successful completions.
  */
-class ErrorPropagationCallback implements PubSubProducerCallback {
+class ErrorPropagationCallback extends PubSubProducerCallback {
   private final PubSubProducerCallback callback;
 
   public ErrorPropagationCallback(PubSubProducerCallback callback) {

--- a/internal/venice-common/src/main/java/com/linkedin/venice/writer/SendMessageErrorLoggerCallback.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/writer/SendMessageErrorLoggerCallback.java
@@ -6,7 +6,7 @@ import com.linkedin.venice.pubsub.api.PubSubProducerCallback;
 import org.apache.logging.log4j.Logger;
 
 
-class SendMessageErrorLoggerCallback implements PubSubProducerCallback {
+class SendMessageErrorLoggerCallback extends PubSubProducerCallback {
   private final KafkaMessageEnvelope value;
   private final Logger logger;
 

--- a/internal/venice-common/src/main/java/com/linkedin/venice/writer/VeniceWriter.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/writer/VeniceWriter.java
@@ -32,6 +32,7 @@ import com.linkedin.venice.kafka.validation.checksum.CheckSumType;
 import com.linkedin.venice.message.KafkaKey;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.partitioner.VenicePartitioner;
+import com.linkedin.venice.pubsub.adapter.SimplePubSubProducerCallbackImpl;
 import com.linkedin.venice.pubsub.api.PubSubMessageHeaders;
 import com.linkedin.venice.pubsub.api.PubSubProduceResult;
 import com.linkedin.venice.pubsub.api.PubSubProducerAdapter;
@@ -57,7 +58,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.BiConsumer;
@@ -411,12 +411,9 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
    *
    * @param key - The key to delete in storage.
    * @param callback - callback will be executed after Kafka producer completes on sending the message.
-   * @return a java.util.concurrent.Future Future for the RecordMetadata that will be assigned to this
-   * record. Invoking java.util.concurrent.Future's get() on this future will block until the associated request
-   * completes and then return the metadata for the record or throw any exception that occurred while sending the record.
    */
-  public Future<PubSubProduceResult> delete(K key, PubSubProducerCallback callback) {
-    return delete(key, callback, DEFAULT_LEADER_METADATA_WRAPPER, APP_DEFAULT_LOGICAL_TS, null);
+  public void delete(K key, PubSubProducerCallback callback) {
+    delete(key, callback, DEFAULT_LEADER_METADATA_WRAPPER, APP_DEFAULT_LOGICAL_TS, null);
   }
 
   /**
@@ -425,12 +422,9 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
    * @param key - The key to delete in storage.
    * @param logicalTs - An timestamp field to indicate when this record was produced from apps point of view.
    * @param callback - callback will be executed after Kafka producer completes on sending the message.
-   * @return a java.util.concurrent.Future Future for the RecordMetadata that will be assigned to this
-   * record. Invoking java.util.concurrent.Future's get() on this future will block until the associated request
-   * completes and then return the metadata for the record or throw any exception that occurred while sending the record.
    */
-  public Future<PubSubProduceResult> delete(K key, long logicalTs, PubSubProducerCallback callback) {
-    return delete(key, callback, DEFAULT_LEADER_METADATA_WRAPPER, logicalTs, null);
+  public void delete(K key, long logicalTs, PubSubProducerCallback callback) {
+    delete(key, callback, DEFAULT_LEADER_METADATA_WRAPPER, logicalTs, null);
   }
 
   /**
@@ -443,15 +437,9 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
    *                              sending the message in VPJ plugin to the version topic;
    *                         >=0: Leader replica consumes a delete message from real-time topic, VeniceWriter in leader
    *                              is sending this message to version topic with extra info: offset in the real-time topic.
-   * @return a java.util.concurrent.Future Future for the RecordMetadata that will be assigned to this
-   * record. Invoking java.util.concurrent.Future's get() on this future will block until the associated request
-   * completes and then return the metadata for the record or throw any exception that occurred while sending the record.
    */
-  public Future<PubSubProduceResult> delete(
-      K key,
-      PubSubProducerCallback callback,
-      LeaderMetadataWrapper leaderMetadataWrapper) {
-    return delete(key, callback, leaderMetadataWrapper, APP_DEFAULT_LOGICAL_TS, null);
+  public void delete(K key, PubSubProducerCallback callback, LeaderMetadataWrapper leaderMetadataWrapper) {
+    delete(key, callback, leaderMetadataWrapper, APP_DEFAULT_LOGICAL_TS, null);
   }
 
   /**
@@ -465,16 +453,13 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
    *                             >=0: Leader replica consumes a delete message from real-time topic, VeniceWriter in leader
    *                                  is sending this message to version topic with extra info: offset in the real-time topic.
    * @param logicalTs - An timestamp field to indicate when this record was produced from apps point of view.
-   * @return a java.util.concurrent.Future Future for the RecordMetadata that will be assigned to this
-   * record. Invoking java.util.concurrent.Future's get() on this future will block until the associated request
-   * completes and then return the metadata for the record or throw any exception that occurred while sending the record.
    */
-  public Future<PubSubProduceResult> delete(
+  public void delete(
       K key,
       PubSubProducerCallback callback,
       LeaderMetadataWrapper leaderMetadataWrapper,
       long logicalTs) {
-    return delete(key, callback, leaderMetadataWrapper, logicalTs, null);
+    delete(key, callback, leaderMetadataWrapper, logicalTs, null);
   }
 
   /**
@@ -488,21 +473,18 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
    *                             >=0: Leader replica consumes a delete message from real-time topic, VeniceWriter in leader
    *                                  is sending this message to version topic with extra info: offset in the real-time topic.
    * @param deleteMetadata - a DeleteMetadata containing replication metadata related fields.
-   * @return a java.util.concurrent.Future Future for the RecordMetadata that will be assigned to this
-   * record. Invoking java.util.concurrent.Future's get() on this future will block until the associated request
-   * completes and then return the metadata for the record or throw any exception that occurred while sending the record.
    */
-  public Future<PubSubProduceResult> delete(
+  public void delete(
       K key,
       PubSubProducerCallback callback,
       LeaderMetadataWrapper leaderMetadataWrapper,
       DeleteMetadata deleteMetadata) {
-    return delete(key, callback, leaderMetadataWrapper, APP_DEFAULT_LOGICAL_TS, deleteMetadata);
+    delete(key, callback, leaderMetadataWrapper, APP_DEFAULT_LOGICAL_TS, deleteMetadata);
   }
 
   @Override
-  public Future<PubSubProduceResult> delete(K key, PubSubProducerCallback callback, DeleteMetadata deleteMetadata) {
-    return delete(key, callback, DEFAULT_LEADER_METADATA_WRAPPER, APP_DEFAULT_LOGICAL_TS, deleteMetadata);
+  public void delete(K key, PubSubProducerCallback callback, DeleteMetadata deleteMetadata) {
+    delete(key, callback, DEFAULT_LEADER_METADATA_WRAPPER, APP_DEFAULT_LOGICAL_TS, deleteMetadata);
   }
 
   /**
@@ -516,12 +498,8 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
    *                         >=0: Leader replica consumes a delete message from real-time topic, VeniceWriter in leader
    *                              is sending this message to version topic with extra info: offset in the real-time topic.
    * @param logicalTs - An timestamp field to indicate when this record was produced from apps point of view.
-   * @param deleteMetadata - a DeleteMetadata containing replication metadata related fields (can be null).
-   * @return a java.util.concurrent.Future Future for the RecordMetadata that will be assigned to this
-   * record. Invoking java.util.concurrent.Future's get() on this future will block until the associated request
-   * completes and then return the metadata for the record or throw any exception that occurred while sending the record.
    */
-  private Future<PubSubProduceResult> delete(
+  private void delete(
       K key,
       PubSubProducerCallback callback,
       LeaderMetadataWrapper leaderMetadataWrapper,
@@ -559,7 +537,7 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
       delete.replicationMetadataPayload = deleteMetadata.getRmdPayload();
     }
 
-    return sendMessage(
+    sendMessage(
         producerMetadata -> kafkaKey,
         MessageType.DELETE,
         delete,
@@ -581,25 +559,20 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
    * completes and then return the metadata for the record or throw any exception that occurred while sending the record.
    */
   @Override
-  public Future<PubSubProduceResult> put(K key, V value, int valueSchemaId, PubSubProducerCallback callback) {
-    return put(key, value, valueSchemaId, callback, DEFAULT_LEADER_METADATA_WRAPPER, APP_DEFAULT_LOGICAL_TS, null);
+  public void put(K key, V value, int valueSchemaId, PubSubProducerCallback callback) {
+    put(key, value, valueSchemaId, callback, DEFAULT_LEADER_METADATA_WRAPPER, APP_DEFAULT_LOGICAL_TS, null);
+  }
+
+  public PubSubProduceResult syncPut(K key, V value, int valueSchemaId)
+      throws ExecutionException, InterruptedException {
+    PubSubProducerCallback putResult = new SimplePubSubProducerCallbackImpl();
+    put(key, value, valueSchemaId, putResult, DEFAULT_LEADER_METADATA_WRAPPER, APP_DEFAULT_LOGICAL_TS, null);
+    return putResult.get();
   }
 
   @Override
-  public Future<PubSubProduceResult> put(
-      K key,
-      V value,
-      int valueSchemaId,
-      PubSubProducerCallback callback,
-      PutMetadata putMetadata) {
-    return put(
-        key,
-        value,
-        valueSchemaId,
-        callback,
-        DEFAULT_LEADER_METADATA_WRAPPER,
-        APP_DEFAULT_LOGICAL_TS,
-        putMetadata);
+  public void put(K key, V value, int valueSchemaId, PubSubProducerCallback callback, PutMetadata putMetadata) {
+    put(key, value, valueSchemaId, callback, DEFAULT_LEADER_METADATA_WRAPPER, APP_DEFAULT_LOGICAL_TS, putMetadata);
   }
 
   /**
@@ -610,17 +583,9 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
    * @param valueSchemaId - value schema id for the given value
    * @param logicalTs - A timestamp field to indicate when this record was produced from apps view.
    * @param callback - Callback function invoked by Kafka producer after sending the message
-   * @return a java.util.concurrent.Future Future for the RecordMetadata that will be assigned to this
-   * record. Invoking java.util.concurrent.Future's get() on this future will block until the associated request
-   * completes and then return the metadata for the record or throw any exception that occurred while sending the record.
    */
-  public Future<PubSubProduceResult> put(
-      K key,
-      V value,
-      int valueSchemaId,
-      long logicalTs,
-      PubSubProducerCallback callback) {
-    return put(key, value, valueSchemaId, callback, DEFAULT_LEADER_METADATA_WRAPPER, logicalTs, null);
+  public void put(K key, V value, int valueSchemaId, long logicalTs, PubSubProducerCallback callback) {
+    put(key, value, valueSchemaId, callback, DEFAULT_LEADER_METADATA_WRAPPER, logicalTs, null);
   }
 
   /**
@@ -632,13 +597,13 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
    * >=0: Leader replica consumes a put message from real-time topic, VeniceWriter in leader
    *      is sending this message to version topic with extra info: offset in the real-time topic.
    */
-  public Future<PubSubProduceResult> put(
+  public void put(
       K key,
       V value,
       int valueSchemaId,
       PubSubProducerCallback callback,
       LeaderMetadataWrapper leaderMetadataWrapper) {
-    return put(key, value, valueSchemaId, callback, leaderMetadataWrapper, APP_DEFAULT_LOGICAL_TS, null);
+    put(key, value, valueSchemaId, callback, leaderMetadataWrapper, APP_DEFAULT_LOGICAL_TS, null);
   }
 
   /**
@@ -661,7 +626,7 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
    * record. Invoking java.util.concurrent.Future's get() on this future will block until the associated request
    * completes and then return the metadata for the record or throw any exception that occurred while sending the record.
    */
-  public Future<PubSubProduceResult> put(
+  public void put(
       K key,
       V value,
       int valueSchemaId,
@@ -678,7 +643,7 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
     if (serializedKey.length + serializedValue.length
         + replicationMetadataPayloadSize > maxSizeForUserPayloadPerMessageInBytes) {
       if (isChunkingEnabled) {
-        return putLargeValue(
+        putLargeValue(
             serializedKey,
             serializedValue,
             valueSchemaId,
@@ -687,6 +652,7 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
             leaderMetadataWrapper,
             logicalTs,
             putMetadata);
+        return;
       } else {
         throw new RecordTooLargeException(
             "This record exceeds the maximum size. "
@@ -716,7 +682,7 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
       putPayload.replicationMetadataVersionId = putMetadata.getRmdVersionId();
       putPayload.replicationMetadataPayload = putMetadata.getRmdPayload();
     }
-    return sendMessage(
+    sendMessage(
         producerMetadata -> kafkaKey,
         MessageType.PUT,
         putPayload,
@@ -734,7 +700,7 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
    * TODO: move pass-through supports into a server-specific extension of VeniceWriter
    */
   @Deprecated
-  public Future<PubSubProduceResult> put(
+  public void put(
       KafkaKey kafkaKey,
       KafkaMessageEnvelope kafkaMessageEnvelope,
       PubSubProducerCallback callback,
@@ -752,7 +718,7 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
       ((ChunkAwareCallback) callback).setChunkingInfo(serializedKey, null, null, null, null);
     }
 
-    return sendMessage(producerMetadata -> kafkaKey, kafkaMessageEnvelopeProvider, upstreamPartition, callback, false);
+    sendMessage(producerMetadata -> kafkaKey, kafkaMessageEnvelopeProvider, upstreamPartition, callback, false);
   }
 
   private KafkaMessageEnvelopeProvider getKafkaMessageEnvelopeProvider(
@@ -770,7 +736,7 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
   /**
    * DIV pass-through mode for delete
    */
-  public Future<PubSubProduceResult> delete(
+  public void delete(
       KafkaKey kafkaKey,
       KafkaMessageEnvelope kafkaMessageEnvelope,
       PubSubProducerCallback callback,
@@ -787,20 +753,15 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
       ((ChunkAwareCallback) callback).setChunkingInfo(serializedKey, null, null, null, null);
     }
 
-    return sendMessage(producerMetadata -> kafkaKey, kafkaMessageEnvelopeProvider, upstreamPartition, callback, false);
+    sendMessage(producerMetadata -> kafkaKey, kafkaMessageEnvelopeProvider, upstreamPartition, callback, false);
   }
 
   @Override
-  public Future<PubSubProduceResult> update(
-      K key,
-      U update,
-      int valueSchemaId,
-      int derivedSchemaId,
-      PubSubProducerCallback callback) {
-    return update(key, update, valueSchemaId, derivedSchemaId, callback, APP_DEFAULT_LOGICAL_TS);
+  public void update(K key, U update, int valueSchemaId, int derivedSchemaId, PubSubProducerCallback callback) {
+    update(key, update, valueSchemaId, derivedSchemaId, callback, APP_DEFAULT_LOGICAL_TS);
   }
 
-  public Future<PubSubProduceResult> update(
+  public void update(
       K key,
       U update,
       int valueSchemaId,
@@ -829,7 +790,7 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
     updatePayLoad.schemaId = valueSchemaId;
     updatePayLoad.updateSchemaId = derivedSchemaId;
 
-    return sendMessage(
+    sendMessage(
         producerMetadata -> kafkaKey,
         MessageType.UPDATE,
         updatePayLoad,
@@ -1031,7 +992,7 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
   /**
    * Data message like PUT and DELETE should call this API to enable DIV check.
    */
-  private Future<PubSubProduceResult> sendMessage(
+  private void sendMessage(
       KeyProvider keyProvider,
       MessageType messageType,
       Object payload,
@@ -1039,19 +1000,10 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
       PubSubProducerCallback callback,
       LeaderMetadataWrapper leaderMetadataWrapper,
       long logicalTs) {
-    return sendMessage(
-        keyProvider,
-        messageType,
-        payload,
-        false,
-        partition,
-        callback,
-        true,
-        leaderMetadataWrapper,
-        logicalTs);
+    sendMessage(keyProvider, messageType, payload, false, partition, callback, true, leaderMetadataWrapper, logicalTs);
   }
 
-  private Future<PubSubProduceResult> sendMessage(
+  private void sendMessage(
       KeyProvider keyProvider,
       MessageType messageType,
       Object payload,
@@ -1067,7 +1019,36 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
       kafkaValue.payloadUnion = payload;
       return kafkaValue;
     };
-    return sendMessage(keyProvider, kafkaMessageEnvelopeProvider, partition, callback, updateDIV);
+    sendMessage(keyProvider, kafkaMessageEnvelopeProvider, partition, callback, updateDIV);
+  }
+
+  // visible for testing
+  public void syncSendMessage(
+      KeyProvider keyProvider,
+      MessageType messageType,
+      Object payload,
+      boolean isEndOfSegment,
+      int partition,
+      PubSubProducerCallback callback,
+      boolean updateDIV,
+      LeaderMetadataWrapper leaderMetadataWrapper,
+      long logicalTs) throws ExecutionException, InterruptedException {
+    // if caller does not pass Callback-come-Future arg, we need create one as we need it for block the thread
+    // until message is successfully sent. Also, we cannot reuse callback as it is also a Future object.
+    if (callback == null) {
+      callback = new SimplePubSubProducerCallbackImpl();
+    }
+    sendMessage(
+        keyProvider,
+        messageType,
+        payload,
+        isEndOfSegment,
+        partition,
+        callback,
+        updateDIV,
+        leaderMetadataWrapper,
+        logicalTs);
+    callback.get(); // infinite blocking call
   }
 
   /**
@@ -1094,7 +1075,7 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
    * @param updateDIV if true, the partition's segment's checksum will be updated and its sequence number incremented
    *                  if false, the checksum and seq# update are omitted, which is the right thing to do during retries
    */
-  private Future<PubSubProduceResult> sendMessage(
+  private void sendMessage(
       KeyProvider keyProvider,
       KafkaMessageEnvelopeProvider valueProvider,
       int partition,
@@ -1120,7 +1101,7 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
         }
       }
       try {
-        return producerAdapter.sendMessage(
+        producerAdapter.sendMessage(
             topicName,
             partition,
             key,
@@ -1167,7 +1148,7 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
   /**
    * This function implements chunking of a large value into many small values.
    */
-  private Future<PubSubProduceResult> putLargeValue(
+  private void putLargeValue(
       byte[] serializedKey,
       byte[] serializedValue,
       int valueSchemaId,
@@ -1251,7 +1232,7 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
 
     // We only return the last future (the one for the manifest) and assume that once this one is finished,
     // all the chunks should also be finished, since they were sent first, and ordering should be guaranteed.
-    return sendMessage(
+    sendMessage(
         manifestKeyProvider,
         MessageType.PUT,
         putManifestsPayload,
@@ -1393,7 +1374,7 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
       while (true) {
         try {
           boolean isEndOfSegment = ControlMessageType.valueOf(controlMessage).equals(ControlMessageType.END_OF_SEGMENT);
-          sendMessage(
+          syncSendMessage(
               this::getControlMessageKey,
               MessageType.CONTROL_MESSAGE,
               controlMessage,
@@ -1402,7 +1383,7 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
               callback,
               updateCheckSum,
               leaderMetadataWrapper,
-              VENICE_DEFAULT_LOGICAL_TS).get();
+              VENICE_DEFAULT_LOGICAL_TS); // infinite blocking call
           return;
         } catch (InterruptedException | ExecutionException e) {
           if (e.getMessage() != null && e.getMessage().contains(Errors.UNKNOWN_TOPIC_OR_PARTITION.message())) {
@@ -1440,7 +1421,7 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
    * Producer DIV will be recalculated (not DIV pass-through mode); checksum for the input partition in this producer
    * will also be updated.
    */
-  public Future<PubSubProduceResult> asyncSendControlMessage(
+  public void asyncSendControlMessage(
       ControlMessage controlMessage,
       int partition,
       Map<String, String> debugInfo,
@@ -1450,7 +1431,7 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
       controlMessage.debugInfo = getDebugInfo(debugInfo);
       boolean updateCheckSum = true;
       boolean isEndOfSegment = ControlMessageType.valueOf(controlMessage).equals(ControlMessageType.END_OF_SEGMENT);
-      return sendMessage(
+      sendMessage(
           this::getControlMessageKey,
           MessageType.CONTROL_MESSAGE,
           controlMessage,

--- a/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/adapter/kafka/producer/ApacheKafkaProducerAdapterTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/adapter/kafka/producer/ApacheKafkaProducerAdapterTest.java
@@ -19,7 +19,6 @@ import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.kafka.protocol.KafkaMessageEnvelope;
 import com.linkedin.venice.kafka.protocol.enums.MessageType;
 import com.linkedin.venice.message.KafkaKey;
-import com.linkedin.venice.pubsub.api.PubSubProduceResult;
 import com.linkedin.venice.pubsub.api.PubSubProducerCallback;
 import it.unimi.dsi.fastutil.objects.Object2DoubleMap;
 import java.time.Duration;
@@ -85,18 +84,14 @@ public class ApacheKafkaProducerAdapterTest {
 
     // interaction (1) when pubsub-callback is null
     when(kafkaProducerMock.send(any(ProducerRecord.class), isNull())).thenReturn(recordMetadataFutureMock);
-    Future<PubSubProduceResult> produceResultFuture =
-        producerAdapter.sendMessage(TOPIC_NAME, 42, testKafkaKey, testKafkaValue, null, null);
-    assertNotNull(produceResultFuture);
+    producerAdapter.sendMessage(TOPIC_NAME, 42, testKafkaKey, testKafkaValue, null, null);
     verify(kafkaProducerMock, never()).send(any(ProducerRecord.class), isNull());
     verify(kafkaProducerMock, times(1)).send(any(ProducerRecord.class), any(Callback.class));
 
     // interaction (1) when pubsub-callback is non-null
     PubSubProducerCallback producerCallbackMock = mock(PubSubProducerCallback.class);
     when(kafkaProducerMock.send(any(ProducerRecord.class), any(Callback.class))).thenReturn(recordMetadataFutureMock);
-    produceResultFuture =
-        producerAdapter.sendMessage(TOPIC_NAME, 42, testKafkaKey, testKafkaValue, null, producerCallbackMock);
-    assertNotNull(produceResultFuture);
+    producerAdapter.sendMessage(TOPIC_NAME, 42, testKafkaKey, testKafkaValue, null, producerCallbackMock);
     verify(kafkaProducerMock, never()).send(any(ProducerRecord.class), isNull());
     verify(kafkaProducerMock, times(2)).send(any(ProducerRecord.class), any(Callback.class));
   }

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/consumer/ConsumerIntegrationTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/consumer/ConsumerIntegrationTest.java
@@ -14,9 +14,11 @@ import com.linkedin.venice.kafka.protocol.KafkaMessageEnvelope;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.partitioner.DefaultVenicePartitioner;
 import com.linkedin.venice.partitioner.VenicePartitioner;
+import com.linkedin.venice.pubsub.adapter.SimplePubSubProducerCallbackImpl;
 import com.linkedin.venice.pubsub.adapter.kafka.producer.ApacheKafkaProducerAdapter;
 import com.linkedin.venice.pubsub.adapter.kafka.producer.ApacheKafkaProducerConfig;
 import com.linkedin.venice.pubsub.api.PubSubProducerAdapter;
+import com.linkedin.venice.pubsub.api.PubSubProducerCallback;
 import com.linkedin.venice.serialization.DefaultSerializer;
 import com.linkedin.venice.serialization.VeniceKafkaSerializer;
 import com.linkedin.venice.serialization.avro.AvroProtocolDefinition;
@@ -195,7 +197,9 @@ public abstract class ConsumerIntegrationTest {
       VeniceWriter<String, String, byte[]> veniceWriter,
       AvroGenericStoreClient client,
       String testValue) throws ExecutionException, InterruptedException {
-    veniceWriter.put(TEST_KEY, testValue, 1).get();
+    PubSubProducerCallback putResult = new SimplePubSubProducerCallbackImpl();
+    veniceWriter.put(TEST_KEY, testValue, 1, putResult);
+    putResult.get();
     TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, () -> {
       try {
         Object value = client.get(TEST_KEY).get();

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/controller/TestHolisticSeverHealthCheck.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/controller/TestHolisticSeverHealthCheck.java
@@ -15,6 +15,8 @@ import com.linkedin.venice.integration.utils.ServiceFactory;
 import com.linkedin.venice.integration.utils.VeniceClusterWrapper;
 import com.linkedin.venice.integration.utils.VeniceServerWrapper;
 import com.linkedin.venice.meta.PartitionAssignment;
+import com.linkedin.venice.pubsub.adapter.SimplePubSubProducerCallbackImpl;
+import com.linkedin.venice.pubsub.api.PubSubProducerCallback;
 import com.linkedin.venice.pushmonitor.ExecutionStatus;
 import com.linkedin.venice.utils.TestUtils;
 import com.linkedin.venice.utils.Time;
@@ -120,7 +122,9 @@ public class TestHolisticSeverHealthCheck {
 
     try (VeniceWriter<String, String, byte[]> veniceWriter = cluster.getVeniceWriter(topicName)) {
       veniceWriter.broadcastStartOfPush(new HashMap<>());
-      veniceWriter.put("test", "test", 1).get();
+      PubSubProducerCallback putResult = new SimplePubSubProducerCallbackImpl();
+      veniceWriter.put("test", "test", 1, putResult);
+      putResult.get();
       veniceWriter.broadcastEndOfPush(new HashMap<>());
     }
 

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/controller/kafka/consumer/AdminConsumptionTaskIntegrationTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/controller/kafka/consumer/AdminConsumptionTaskIntegrationTest.java
@@ -16,6 +16,8 @@ import com.linkedin.venice.integration.utils.VeniceControllerCreateOptions;
 import com.linkedin.venice.integration.utils.VeniceControllerWrapper;
 import com.linkedin.venice.integration.utils.ZkServerWrapper;
 import com.linkedin.venice.kafka.TopicManager;
+import com.linkedin.venice.pubsub.adapter.SimplePubSubProducerCallbackImpl;
+import com.linkedin.venice.pubsub.api.PubSubProducerCallback;
 import com.linkedin.venice.utils.IntegrationTestPushUtils;
 import com.linkedin.venice.utils.TestUtils;
 import com.linkedin.venice.utils.Time;
@@ -63,9 +65,9 @@ public class AdminConsumptionTaskIntegrationTest {
           VeniceWriter<byte[], byte[], byte[]> writer =
               TestUtils.getVeniceWriterFactory(kafka.getAddress()).createBasicVeniceWriter(adminTopic)) {
         byte[] message = getStoreCreationMessage(clusterName, storeName, owner, "invalid_key_schema", valueSchema, 1);
-        long badOffset = writer.put(new byte[0], message, AdminOperationSerializer.LATEST_SCHEMA_ID_FOR_ADMIN_OPERATION)
-            .get()
-            .getOffset();
+        PubSubProducerCallback putResult = new SimplePubSubProducerCallbackImpl();
+        writer.put(new byte[0], message, AdminOperationSerializer.LATEST_SCHEMA_ID_FOR_ADMIN_OPERATION, putResult);
+        long badOffset = putResult.get().getOffset();
 
         byte[] goodMessage = getStoreCreationMessage(clusterName, storeName, owner, keySchema, valueSchema, 2);
         writer.put(new byte[0], goodMessage, AdminOperationSerializer.LATEST_SCHEMA_ID_FOR_ADMIN_OPERATION);

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/DaVinciClientTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/DaVinciClientTest.java
@@ -61,6 +61,8 @@ import com.linkedin.venice.meta.IngestionMetadataUpdateType;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.offsets.OffsetRecord;
 import com.linkedin.venice.partitioner.ConstantVenicePartitioner;
+import com.linkedin.venice.pubsub.adapter.SimplePubSubProducerCallbackImpl;
+import com.linkedin.venice.pubsub.api.PubSubProducerCallback;
 import com.linkedin.venice.serialization.VeniceKafkaSerializer;
 import com.linkedin.venice.serialization.avro.AvroProtocolDefinition;
 import com.linkedin.venice.serialization.avro.VeniceAvroKafkaSerializer;
@@ -382,7 +384,9 @@ public class DaVinciClientTest {
       writer.broadcastStartOfPush(Collections.emptyMap());
       Future[] writerFutures = new Future[KEY_COUNT];
       for (int i = 0; i < KEY_COUNT; i++) {
-        writerFutures[i] = writer.put(i, pushVersion, valueSchemaId);
+        PubSubProducerCallback putResult = new SimplePubSubProducerCallbackImpl();
+        writer.put(i, pushVersion, valueSchemaId, putResult);
+        writerFutures[i] = putResult;
       }
       for (int i = 0; i < KEY_COUNT; i++) {
         writerFutures[i].get();
@@ -752,7 +756,9 @@ public class DaVinciClientTest {
       batchProducer.broadcastStartOfPush(Collections.emptyMap());
       Future[] writerFutures = new Future[KEY_COUNT];
       for (int i = 0; i < KEY_COUNT; i++) {
-        writerFutures[i] = batchProducer.put(i, i, valueSchemaId);
+        PubSubProducerCallback putResult = new SimplePubSubProducerCallbackImpl();
+        batchProducer.put(i, i, valueSchemaId, putResult);
+        writerFutures[i] = putResult;
       }
       for (int i = 0; i < KEY_COUNT; i++) {
         writerFutures[i].get();

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/DaVinciComputeTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/DaVinciComputeTest.java
@@ -32,6 +32,8 @@ import com.linkedin.venice.integration.utils.DaVinciTestContext;
 import com.linkedin.venice.integration.utils.ServiceFactory;
 import com.linkedin.venice.integration.utils.VeniceClusterWrapper;
 import com.linkedin.venice.integration.utils.VeniceRouterWrapper;
+import com.linkedin.venice.pubsub.adapter.SimplePubSubProducerCallbackImpl;
+import com.linkedin.venice.pubsub.api.PubSubProducerCallback;
 import com.linkedin.venice.serialization.VeniceKafkaSerializer;
 import com.linkedin.venice.serialization.avro.VeniceAvroKafkaSerializer;
 import com.linkedin.venice.utils.PropertyBuilder;
@@ -815,7 +817,9 @@ public class DaVinciComputeTest {
         value.put("companiesEmbedding", companiesEmbedding);
       }
       value.put("member_feature", mfEmbedding);
-      writer.put(i, value, valueSchemaId).get();
+      PubSubProducerCallback putResult = new SimplePubSubProducerCallbackImpl();
+      writer.put(i, value, valueSchemaId, putResult);
+      putResult.get();
     }
     writer.broadcastEndOfPush(Collections.emptyMap());
   }
@@ -827,7 +831,9 @@ public class DaVinciComputeTest {
 
     veniceWriter.broadcastStartOfPush(Collections.emptyMap());
     for (Map.Entry<Integer, GenericRecord> keyValue: valuesByKey.entrySet()) {
-      veniceWriter.put(keyValue.getKey(), keyValue.getValue(), valueSchemaId).get();
+      PubSubProducerCallback putResult = new SimplePubSubProducerCallbackImpl();
+      veniceWriter.put(keyValue.getKey(), keyValue.getValue(), valueSchemaId, putResult);
+      putResult.get();
     }
     veniceWriter.broadcastEndOfPush(Collections.emptyMap());
   }
@@ -845,7 +851,9 @@ public class DaVinciComputeTest {
       GenericRecord valueRecord = new GenericData.Record(valueSchema);
       valueRecord.put("int_field", i);
       valueRecord.put("float_field", i + 100.0f);
-      writer.put(KEY_PREFIX + i, valueRecord, valueSchemaId).get();
+      PubSubProducerCallback putResult = new SimplePubSubProducerCallbackImpl();
+      writer.put(KEY_PREFIX + i, valueRecord, valueSchemaId, putResult);
+      putResult.get();
     }
 
     writer.broadcastEndOfPush(Collections.emptyMap());
@@ -884,7 +892,9 @@ public class DaVinciComputeTest {
         value.put("companiesEmbedding", companiesEmbedding);
       }
       value.put("member_feature", mfEmbedding);
-      writer.put(key, value, valueSchemaId).get();
+      PubSubProducerCallback putResult = new SimplePubSubProducerCallbackImpl();
+      writer.put(key, value, valueSchemaId, putResult);
+      putResult.get();
     }
     writer.broadcastEndOfPush(Collections.emptyMap());
   }

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/DaVinciLiveUpdateSuppressionTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/DaVinciLiveUpdateSuppressionTest.java
@@ -24,6 +24,8 @@ import com.linkedin.venice.integration.utils.ServiceFactory;
 import com.linkedin.venice.integration.utils.VeniceClusterWrapper;
 import com.linkedin.venice.meta.IngestionMode;
 import com.linkedin.venice.meta.Version;
+import com.linkedin.venice.pubsub.adapter.SimplePubSubProducerCallbackImpl;
+import com.linkedin.venice.pubsub.api.PubSubProducerCallback;
 import com.linkedin.venice.serialization.VeniceKafkaSerializer;
 import com.linkedin.venice.serialization.avro.VeniceAvroKafkaSerializer;
 import com.linkedin.venice.utils.DataProviderUtils;
@@ -124,7 +126,9 @@ public class DaVinciLiveUpdateSuppressionTest {
         vwFactory.createVeniceWriter(topic, keySerializer, valueSerializer, false)) {
       batchProducer.broadcastStartOfPush(Collections.emptyMap());
       for (int i = 0; i < KEY_COUNT; i++) {
-        writerFutures[i] = batchProducer.put(i, i, valueSchemaId);
+        PubSubProducerCallback putResult = new SimplePubSubProducerCallbackImpl();
+        batchProducer.put(i, i, valueSchemaId, putResult);
+        writerFutures[i] = putResult;
       }
       for (int i = 0; i < KEY_COUNT; i++) {
         writerFutures[i].get();
@@ -149,7 +153,9 @@ public class DaVinciLiveUpdateSuppressionTest {
       client.subscribe(Collections.singleton(0)).get();
       writerFutures = new Future[KEY_COUNT];
       for (int i = 0; i < KEY_COUNT; i++) {
-        writerFutures[i] = realTimeProducer.put(i, i * 1000, valueSchemaId);
+        PubSubProducerCallback putResult = new SimplePubSubProducerCallbackImpl();
+        realTimeProducer.put(i, i * 1000, valueSchemaId, putResult);
+        writerFutures[i] = putResult;
       }
       for (int i = 0; i < KEY_COUNT; i++) {
         writerFutures[i].get();

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestHelixCustomizedView.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestHelixCustomizedView.java
@@ -13,6 +13,8 @@ import com.linkedin.venice.helix.ZkClientFactory;
 import com.linkedin.venice.integration.utils.ServiceFactory;
 import com.linkedin.venice.integration.utils.VeniceClusterWrapper;
 import com.linkedin.venice.meta.Version;
+import com.linkedin.venice.pubsub.adapter.SimplePubSubProducerCallbackImpl;
+import com.linkedin.venice.pubsub.api.PubSubProducerCallback;
 import com.linkedin.venice.pushmonitor.ExecutionStatus;
 import com.linkedin.venice.routerapi.ReplicaState;
 import com.linkedin.venice.routerapi.ResourceStateResponse;
@@ -144,7 +146,9 @@ public class TestHelixCustomizedView {
     for (int i = 0; i < 10; ++i) {
       GenericRecord record = new GenericData.Record(VALUE_SCHEMA);
       record.put(VALUE_FIELD_NAME, i);
-      veniceWriter.put(keyPrefix + i, record, valueSchemaId).get();
+      PubSubProducerCallback putResult = new SimplePubSubProducerCallbackImpl();
+      veniceWriter.put(keyPrefix + i, record, valueSchemaId, putResult);
+      putResult.get();
     }
     // Write end of push message to make node become ONLINE from BOOTSTRAP
     veniceWriter.broadcastEndOfPush(new HashMap<>());

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/fastclient/utils/AbstractClientEndToEndSetup.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/fastclient/utils/AbstractClientEndToEndSetup.java
@@ -34,6 +34,8 @@ import com.linkedin.venice.integration.utils.ServiceFactory;
 import com.linkedin.venice.integration.utils.VeniceClusterWrapper;
 import com.linkedin.venice.integration.utils.VeniceRouterWrapper;
 import com.linkedin.venice.meta.Version;
+import com.linkedin.venice.pubsub.adapter.SimplePubSubProducerCallbackImpl;
+import com.linkedin.venice.pubsub.api.PubSubProducerCallback;
 import com.linkedin.venice.serialization.VeniceKafkaSerializer;
 import com.linkedin.venice.serialization.avro.VeniceAvroKafkaSerializer;
 import com.linkedin.venice.system.store.MetaStoreDataType;
@@ -171,7 +173,9 @@ public abstract class AbstractClientEndToEndSetup {
     for (int i = 0; i < recordCnt; ++i) {
       GenericRecord record = new GenericData.Record(VALUE_SCHEMA);
       record.put(VALUE_FIELD_NAME, i);
-      veniceWriter.put(keyPrefix + i, record, valueSchemaId).get();
+      PubSubProducerCallback putResult = new SimplePubSubProducerCallbackImpl();
+      veniceWriter.put(keyPrefix + i, record, valueSchemaId, putResult);
+      putResult.get();
     }
     // Write end of push message to make node become ONLINE from BOOTSTRAP
     veniceWriter.broadcastEndOfPush(new HashMap<>());

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/kafka/KafkaConsumptionTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/kafka/KafkaConsumptionTest.java
@@ -29,9 +29,11 @@ import com.linkedin.venice.kafka.protocol.enums.MessageType;
 import com.linkedin.venice.message.KafkaKey;
 import com.linkedin.venice.pubsub.PubSubTopicPartitionImpl;
 import com.linkedin.venice.pubsub.PubSubTopicRepository;
+import com.linkedin.venice.pubsub.adapter.SimplePubSubProducerCallbackImpl;
 import com.linkedin.venice.pubsub.adapter.kafka.producer.ApacheKafkaProducerAdapter;
 import com.linkedin.venice.pubsub.adapter.kafka.producer.ApacheKafkaProducerConfig;
 import com.linkedin.venice.pubsub.api.PubSubProducerAdapter;
+import com.linkedin.venice.pubsub.api.PubSubProducerCallback;
 import com.linkedin.venice.pubsub.api.PubSubTopic;
 import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
 import com.linkedin.venice.pubsub.kafka.KafkaPubSubMessageDeserializer;
@@ -303,6 +305,8 @@ public class KafkaConsumptionTest {
       controlMessage.debugInfo = Collections.emptyMap();
       recordValue.payloadUnion = controlMessage;
     }
-    producerAdapter.sendMessage(topic, null, recordKey, recordValue, null, null).get();
+    PubSubProducerCallback sendResult = new SimplePubSubProducerCallbackImpl();
+    producerAdapter.sendMessage(topic, null, recordKey, recordValue, null, sendResult);
+    sendResult.get();
   }
 }

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/kafka/TopicManagerTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/kafka/TopicManagerTest.java
@@ -33,9 +33,11 @@ import com.linkedin.venice.meta.HybridStoreConfig;
 import com.linkedin.venice.meta.HybridStoreConfigImpl;
 import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.ZKStore;
+import com.linkedin.venice.pubsub.adapter.SimplePubSubProducerCallbackImpl;
 import com.linkedin.venice.pubsub.adapter.kafka.producer.ApacheKafkaProducerAdapter;
 import com.linkedin.venice.pubsub.adapter.kafka.producer.ApacheKafkaProducerConfig;
 import com.linkedin.venice.pubsub.api.PubSubProducerAdapter;
+import com.linkedin.venice.pubsub.api.PubSubProducerCallback;
 import com.linkedin.venice.serialization.KafkaKeySerializer;
 import com.linkedin.venice.serialization.avro.KafkaValueSerializer;
 import com.linkedin.venice.systemstore.schemas.StoreProperties;
@@ -218,7 +220,9 @@ public class TopicManagerTest {
       controlMessage.debugInfo = Collections.emptyMap();
       recordValue.payloadUnion = controlMessage;
     }
-    producer.sendMessage(topic, null, recordKey, recordValue, null, null).get();
+    PubSubProducerCallback sendResult = new SimplePubSubProducerCallbackImpl();
+    producer.sendMessage(topic, null, recordKey, recordValue, null, sendResult);
+    sendResult.get();
   }
 
   @Test

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/router/TestRead.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/router/TestRead.java
@@ -31,6 +31,8 @@ import com.linkedin.venice.integration.utils.VeniceClusterWrapper;
 import com.linkedin.venice.integration.utils.VeniceRouterWrapper;
 import com.linkedin.venice.integration.utils.VeniceServerWrapper;
 import com.linkedin.venice.meta.Version;
+import com.linkedin.venice.pubsub.adapter.SimplePubSubProducerCallbackImpl;
+import com.linkedin.venice.pubsub.api.PubSubProducerCallback;
 import com.linkedin.venice.router.api.VenicePathParser;
 import com.linkedin.venice.router.httpclient.StorageNodeClientType;
 import com.linkedin.venice.routerapi.ResourceStateResponse;
@@ -225,7 +227,9 @@ public abstract class TestRead {
     for (int i = 0; i < 100; ++i) {
       GenericRecord record = new GenericData.Record(VALUE_SCHEMA);
       record.put(VALUE_FIELD_NAME, i);
-      veniceWriter.put(KEY_PREFIX + i, record, valueSchemaId).get();
+      PubSubProducerCallback putResult = new SimplePubSubProducerCallbackImpl();
+      veniceWriter.put(KEY_PREFIX + i, record, valueSchemaId, putResult);
+      putResult.get();
     }
     // Write end of push message to make node become ONLINE from BOOTSTRAP
     veniceWriter.broadcastEndOfPush(new HashMap<>());

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/router/TestRouterRetry.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/router/TestRouterRetry.java
@@ -14,6 +14,8 @@ import com.linkedin.venice.integration.utils.ServiceFactory;
 import com.linkedin.venice.integration.utils.VeniceClusterWrapper;
 import com.linkedin.venice.meta.OfflinePushStrategy;
 import com.linkedin.venice.meta.Version;
+import com.linkedin.venice.pubsub.adapter.SimplePubSubProducerCallbackImpl;
+import com.linkedin.venice.pubsub.api.PubSubProducerCallback;
 import com.linkedin.venice.serialization.VeniceKafkaSerializer;
 import com.linkedin.venice.serialization.avro.VeniceAvroKafkaSerializer;
 import com.linkedin.venice.tehuti.MetricsUtils;
@@ -101,7 +103,9 @@ public class TestRouterRetry {
     for (int i = 0; i < 100; ++i) {
       GenericRecord record = new GenericData.Record(VALUE_SCHEMA);
       record.put(VALUE_FIELD_NAME, i);
-      veniceWriter.put(KEY_PREFIX + i, record, valueSchemaId).get();
+      PubSubProducerCallback putResult = new SimplePubSubProducerCallbackImpl();
+      veniceWriter.put(KEY_PREFIX + i, record, valueSchemaId, putResult);
+      putResult.get();
     }
     // Write end of push message to make node become ONLINE from BOOTSTRAP
     veniceWriter.broadcastEndOfPush(new HashMap<>());

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/router/TestStreaming.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/router/TestStreaming.java
@@ -33,6 +33,8 @@ import com.linkedin.venice.integration.utils.VeniceClusterWrapper;
 import com.linkedin.venice.integration.utils.VeniceRouterWrapper;
 import com.linkedin.venice.integration.utils.VeniceServerWrapper;
 import com.linkedin.venice.meta.Version;
+import com.linkedin.venice.pubsub.adapter.SimplePubSubProducerCallbackImpl;
+import com.linkedin.venice.pubsub.api.PubSubProducerCallback;
 import com.linkedin.venice.serialization.VeniceKafkaSerializer;
 import com.linkedin.venice.serialization.avro.VeniceAvroKafkaSerializer;
 import com.linkedin.venice.utils.DataProviderUtils;
@@ -154,7 +156,9 @@ public class TestStreaming {
       }
 
       byte[] value = compressor.compress(valueSerializer.serialize("", valueRecord));
-      veniceWriter.put(KEY_PREFIX + i, value, valueSchemaId).get();
+      PubSubProducerCallback putResult = new SimplePubSubProducerCallbackImpl();
+      veniceWriter.put(KEY_PREFIX + i, value, valueSchemaId, putResult);
+      putResult.get();
     }
     // Write end of push message to make node become ONLINE from BOOTSTRAP
     veniceWriter.broadcastEndOfPush(new HashMap<>());

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/storagenode/ReadComputeValidationTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/storagenode/ReadComputeValidationTest.java
@@ -20,6 +20,8 @@ import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.integration.utils.ServiceFactory;
 import com.linkedin.venice.integration.utils.VeniceClusterWrapper;
 import com.linkedin.venice.meta.Version;
+import com.linkedin.venice.pubsub.adapter.SimplePubSubProducerCallbackImpl;
+import com.linkedin.venice.pubsub.api.PubSubProducerCallback;
 import com.linkedin.venice.pushmonitor.ExecutionStatus;
 import com.linkedin.venice.serialization.DefaultSerializer;
 import com.linkedin.venice.serialization.VeniceKafkaSerializer;
@@ -398,7 +400,9 @@ public class ReadComputeValidationTest {
     for (Map.Entry<Integer, GenericRecord> keyValue: valuesByKey.entrySet()) {
       byte[] compressedValue = compressorFactory.getCompressor(CompressionStrategy.NO_OP)
           .compress(serializer.serialize(topic, keyValue.getValue()));
-      veniceWriter.put(keyValue.getKey(), compressedValue, valueSchemaId).get();
+      PubSubProducerCallback putResult = new SimplePubSubProducerCallbackImpl();
+      veniceWriter.put(keyValue.getKey(), compressedValue, valueSchemaId, putResult);
+      putResult.get();
     }
     // Write end of push message to make node become ONLINE from BOOTSTRAP
     veniceWriter.broadcastEndOfPush(Collections.emptyMap());
@@ -426,7 +430,9 @@ public class ReadComputeValidationTest {
       value.put("member_feature", MF_EMBEDDING);
       byte[] compressedValue =
           compressorFactory.getCompressor(CompressionStrategy.NO_OP).compress(serializer.serialize(topic, value));
-      veniceWriter.put(i, compressedValue, valueSchemaId).get();
+      PubSubProducerCallback putResult = new SimplePubSubProducerCallbackImpl();
+      veniceWriter.put(i, compressedValue, valueSchemaId, putResult);
+      putResult.get();
     }
     // Write end of push message to make node become ONLINE from BOOTSTRAP
     veniceWriter.broadcastEndOfPush(new HashMap<>());

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/storagenode/StorageNodeComputeTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/storagenode/StorageNodeComputeTest.java
@@ -22,6 +22,8 @@ import com.linkedin.venice.helix.HelixReadOnlySchemaRepository;
 import com.linkedin.venice.integration.utils.ServiceFactory;
 import com.linkedin.venice.integration.utils.VeniceClusterWrapper;
 import com.linkedin.venice.meta.Version;
+import com.linkedin.venice.pubsub.adapter.SimplePubSubProducerCallbackImpl;
+import com.linkedin.venice.pubsub.api.PubSubProducerCallback;
 import com.linkedin.venice.pushmonitor.ExecutionStatus;
 import com.linkedin.venice.serialization.DefaultSerializer;
 import com.linkedin.venice.serialization.VeniceKafkaSerializer;
@@ -435,7 +437,9 @@ public class StorageNodeComputeTest {
     Future[] writerFutures = new Future[numOfRecords];
     for (int i = 0; i < numOfRecords; i++) {
       byte[] compressedValue = compressor.compress(values.get(i));
-      writerFutures[i] = veniceWriter.put(keyPrefix + i, compressedValue, valueSchemaId);
+      PubSubProducerCallback putResult = new SimplePubSubProducerCallbackImpl();
+      veniceWriter.put(keyPrefix + i, compressedValue, valueSchemaId, putResult);
+      writerFutures[i] = putResult;
     }
 
     // wait synchronously for them to succeed

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/storagenode/StorageNodeReadTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/storagenode/StorageNodeReadTest.java
@@ -24,6 +24,8 @@ import com.linkedin.venice.meta.ServerAdminAction;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.partitioner.DefaultVenicePartitioner;
 import com.linkedin.venice.partitioner.VenicePartitioner;
+import com.linkedin.venice.pubsub.adapter.SimplePubSubProducerCallbackImpl;
+import com.linkedin.venice.pubsub.api.PubSubProducerCallback;
 import com.linkedin.venice.read.protocol.request.router.MultiGetRouterRequestKeyV1;
 import com.linkedin.venice.read.protocol.response.MultiGetResponseRecordV1;
 import com.linkedin.venice.schema.avro.ReadAvroProtocolDefinition;
@@ -362,7 +364,9 @@ public class StorageNodeReadTest {
     // Insert test record and wait synchronously for it to succeed
     Future[] writerFutures = new Future[numOfRecords];
     for (int i = 0; i < numOfRecords; i++) {
-      writerFutures[i] = veniceWriter.put(keyPrefix + i, valuePrefix + i, valueSchemaId);
+      PubSubProducerCallback putResult = new SimplePubSubProducerCallbackImpl();
+      veniceWriter.put(keyPrefix + i, valuePrefix + i, valueSchemaId, putResult);
+      writerFutures[i] = putResult;
     }
     for (int i = 0; i < numOfRecords; i++) {
       writerFutures[i].get();

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/storagenode/TestEarlyTermination.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/storagenode/TestEarlyTermination.java
@@ -15,6 +15,8 @@ import com.linkedin.venice.integration.utils.ServiceFactory;
 import com.linkedin.venice.integration.utils.VeniceClusterWrapper;
 import com.linkedin.venice.integration.utils.VeniceServerWrapper;
 import com.linkedin.venice.meta.Version;
+import com.linkedin.venice.pubsub.adapter.SimplePubSubProducerCallbackImpl;
+import com.linkedin.venice.pubsub.api.PubSubProducerCallback;
 import com.linkedin.venice.utils.SslUtils;
 import com.linkedin.venice.utils.TestUtils;
 import com.linkedin.venice.utils.Utils;
@@ -113,8 +115,9 @@ public class TestEarlyTermination {
     veniceWriter.broadcastStartOfPush(new HashMap<>());
     // Insert test record and wait synchronously for it to succeed
     for (int i = 0; i < 100; ++i) {
-
-      veniceWriter.put(keyPrefix + i, valuePrefix + i, valueSchemaId).get();
+      PubSubProducerCallback putResult = new SimplePubSubProducerCallbackImpl();
+      veniceWriter.put(keyPrefix + i, valuePrefix + i, valueSchemaId, putResult);
+      putResult.get();
     }
     // Write end of push message to make node become ONLINE from BOOTSTRAP
     veniceWriter.broadcastEndOfPush(new HashMap<>());

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/throttle/TestRouterReadQuotaThrottler.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/throttle/TestRouterReadQuotaThrottler.java
@@ -14,6 +14,8 @@ import com.linkedin.venice.integration.utils.ServiceFactory;
 import com.linkedin.venice.integration.utils.VeniceClusterWrapper;
 import com.linkedin.venice.integration.utils.VeniceRouterWrapper;
 import com.linkedin.venice.meta.Store;
+import com.linkedin.venice.pubsub.adapter.SimplePubSubProducerCallbackImpl;
+import com.linkedin.venice.pubsub.api.PubSubProducerCallback;
 import com.linkedin.venice.router.throttle.ReadRequestThrottler;
 import com.linkedin.venice.serialization.VeniceKafkaSerializer;
 import com.linkedin.venice.serialization.avro.VeniceAvroKafkaSerializer;
@@ -66,7 +68,9 @@ public class TestRouterReadQuotaThrottler {
 
       writer.broadcastStartOfPush(new HashMap<>());
       // Insert test record and wait synchronously for it to succeed
-      writer.put(key, value, valueSchemaId).get();
+      PubSubProducerCallback putResult = new SimplePubSubProducerCallbackImpl();
+      writer.put(key, value, valueSchemaId, putResult);
+      putResult.get();
       // Write end of push message to make node become ONLINE from BOOTSTRAP
       writer.broadcastEndOfPush(new HashMap<String, String>());
     }

--- a/internal/venice-test-common/src/main/java/com/linkedin/venice/unit/kafka/producer/MockInMemoryProducerAdapter.java
+++ b/internal/venice-test-common/src/main/java/com/linkedin/venice/unit/kafka/producer/MockInMemoryProducerAdapter.java
@@ -11,10 +11,6 @@ import com.linkedin.venice.unit.kafka.InMemoryKafkaBroker;
 import com.linkedin.venice.unit.kafka.InMemoryKafkaMessage;
 import it.unimi.dsi.fastutil.objects.Object2DoubleMap;
 import it.unimi.dsi.fastutil.objects.Object2DoubleMaps;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
 
 /**
@@ -34,7 +30,7 @@ public class MockInMemoryProducerAdapter implements PubSubProducerAdapter {
   }
 
   @Override
-  public Future<PubSubProduceResult> sendMessage(
+  public void sendMessage(
       String topic,
       Integer partition,
       KafkaKey key,
@@ -44,33 +40,7 @@ public class MockInMemoryProducerAdapter implements PubSubProducerAdapter {
     long offset = broker.produce(topic, partition, new InMemoryKafkaMessage(key, value));
     PubSubProduceResult produceResult = new SimplePubSubProduceResultImpl(topic, partition, offset, -1);
     callback.onCompletion(produceResult, null);
-    return new Future<PubSubProduceResult>() {
-      @Override
-      public boolean cancel(boolean mayInterruptIfRunning) {
-        return false;
-      }
-
-      @Override
-      public boolean isCancelled() {
-        return false;
-      }
-
-      @Override
-      public boolean isDone() {
-        return false;
-      }
-
-      @Override
-      public PubSubProduceResult get() throws InterruptedException, ExecutionException {
-        return produceResult;
-      }
-
-      @Override
-      public PubSubProduceResult get(long timeout, TimeUnit unit)
-          throws InterruptedException, ExecutionException, TimeoutException {
-        return produceResult;
-      }
-    };
+    callback.complete(produceResult);
   }
 
   @Override

--- a/internal/venice-test-common/src/main/java/com/linkedin/venice/unit/kafka/producer/TransformingProducerAdapter.java
+++ b/internal/venice-test-common/src/main/java/com/linkedin/venice/unit/kafka/producer/TransformingProducerAdapter.java
@@ -3,11 +3,9 @@ package com.linkedin.venice.unit.kafka.producer;
 import com.linkedin.venice.kafka.protocol.KafkaMessageEnvelope;
 import com.linkedin.venice.message.KafkaKey;
 import com.linkedin.venice.pubsub.api.PubSubMessageHeaders;
-import com.linkedin.venice.pubsub.api.PubSubProduceResult;
 import com.linkedin.venice.pubsub.api.PubSubProducerAdapter;
 import com.linkedin.venice.pubsub.api.PubSubProducerCallback;
 import it.unimi.dsi.fastutil.objects.Object2DoubleMap;
-import java.util.concurrent.Future;
 
 
 /**
@@ -32,7 +30,7 @@ public class TransformingProducerAdapter implements PubSubProducerAdapter {
   }
 
   @Override
-  public Future<PubSubProduceResult> sendMessage(
+  public void sendMessage(
       String topic,
       Integer partition,
       KafkaKey key,
@@ -40,7 +38,7 @@ public class TransformingProducerAdapter implements PubSubProducerAdapter {
       PubSubMessageHeaders headers,
       PubSubProducerCallback callback) {
     SendMessageParameters parameters = transformer.transform(topic, key, value, partition);
-    return baseProducer
+    baseProducer
         .sendMessage(parameters.topic, parameters.partition, parameters.key, parameters.value, headers, callback);
   }
 

--- a/internal/venice-test-common/src/main/java/com/linkedin/venice/utils/TestUtils.java
+++ b/internal/venice-test-common/src/main/java/com/linkedin/venice/utils/TestUtils.java
@@ -67,8 +67,10 @@ import com.linkedin.venice.meta.ZKStore;
 import com.linkedin.venice.offsets.OffsetRecord;
 import com.linkedin.venice.partitioner.DefaultVenicePartitioner;
 import com.linkedin.venice.partitioner.VenicePartitioner;
+import com.linkedin.venice.pubsub.adapter.SimplePubSubProducerCallbackImpl;
 import com.linkedin.venice.pubsub.adapter.kafka.producer.ApacheKafkaProducerAdapterFactory;
 import com.linkedin.venice.pubsub.adapter.kafka.producer.SharedKafkaProducerAdapterFactory;
+import com.linkedin.venice.pubsub.api.PubSubProducerCallback;
 import com.linkedin.venice.pubsub.consumer.PubSubConsumer;
 import com.linkedin.venice.pushmonitor.ExecutionStatus;
 import com.linkedin.venice.serialization.avro.AvroProtocolDefinition;
@@ -388,7 +390,9 @@ public class TestUtils {
         byte[] key = keySerializer.serialize(kafkaTopic, e.getKey());
         byte[] value = valueSerializer.serialize(kafkaTopic, e.getValue());
         value = compressor.compress(value);
-        putFutures.add(writer.put(key, value, valueSchemaId));
+        PubSubProducerCallback putResult = new SimplePubSubProducerCallbackImpl();
+        writer.put(key, value, valueSchemaId, putResult);
+        putFutures.add(putResult);
       }
       for (Future future: putFutures) {
         future.get();
@@ -419,7 +423,9 @@ public class TestUtils {
 
       LinkedList<Future> putFutures = new LinkedList<>();
       for (Map.Entry e: (Iterable<Map.Entry>) batchData::iterator) {
-        putFutures.add(writer.put(e.getKey(), e.getValue(), valueSchemaId));
+        PubSubProducerCallback putResult = new SimplePubSubProducerCallbackImpl();
+        writer.put(e.getKey(), e.getValue(), valueSchemaId, putResult);
+        putFutures.add(putResult);
       }
       for (Future future: putFutures) {
         future.get();

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
@@ -743,10 +743,8 @@ public class VeniceParentHelixAdmin implements Admin {
         VeniceWriter<byte[], byte[], byte[]> veniceWriter = veniceWriterMap.get(clusterName);
         byte[] serializedValue = adminOperationSerializer.serialize(message);
         try {
-          Future<PubSubProduceResult> future = veniceWriter
-              .put(emptyKeyByteArr, serializedValue, AdminOperationSerializer.LATEST_SCHEMA_ID_FOR_ADMIN_OPERATION);
-          PubSubProduceResult produceResult = future.get();
-
+          PubSubProduceResult produceResult = veniceWriter
+              .syncPut(emptyKeyByteArr, serializedValue, AdminOperationSerializer.LATEST_SCHEMA_ID_FOR_ADMIN_OPERATION);
           LOGGER.info("Sent message: {} to kafka, offset: {}", message, produceResult.getOffset());
         } catch (Exception e) {
           throw new VeniceException("Got exception during sending message to Kafka -- " + e.getMessage(), e);

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceParentHelixAdminWithAcl.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceParentHelixAdminWithAcl.java
@@ -1,7 +1,5 @@
 package com.linkedin.venice.controller;
 
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.anyInt;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.eq;
@@ -18,13 +16,11 @@ import com.linkedin.venice.exceptions.VeniceNoStoreException;
 import com.linkedin.venice.kafka.protocol.state.PartitionState;
 import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.offsets.OffsetRecord;
-import com.linkedin.venice.pubsub.adapter.SimplePubSubProduceResultImpl;
 import com.linkedin.venice.serialization.avro.AvroProtocolDefinition;
 import com.linkedin.venice.serialization.avro.InternalAvroSpecificSerializer;
 import com.linkedin.venice.utils.TestUtils;
 import java.util.Collection;
 import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
@@ -72,10 +68,6 @@ public class TestVeniceParentHelixAdminWithAcl extends AbstractTestVeniceParentH
       expectedAB.addAceEntry(wace);
     }
 
-    doReturn(CompletableFuture.completedFuture(new SimplePubSubProduceResultImpl(topicName, partitionId, 1, -1)))
-        .when(veniceWriter)
-        .put(any(), any(), anyInt());
-
     String keySchemaStr = "\"string\"";
     String valueSchemaStr = "\"string\"";
     initializeParentAdmin(Optional.of(authorizerService));
@@ -98,10 +90,6 @@ public class TestVeniceParentHelixAdminWithAcl extends AbstractTestVeniceParentH
     String accessPerm =
         "{\"AccessPermissions\":{\"Read\":[\"user:user1\",\"group:group1\",\"service:app1\"],\"Write\":[\"user:user1\",\"group:group1\",\"service:app1\"],}}";
 
-    doReturn(CompletableFuture.completedFuture(new SimplePubSubProduceResultImpl(topicName, partitionId, 1, -1)))
-        .when(veniceWriter)
-        .put(any(), any(), anyInt());
-
     String keySchemaStr = "\"string\"";
     String valueSchemaStr = "\"string\"";
     initializeParentAdmin(Optional.of(authorizerService));
@@ -120,10 +108,6 @@ public class TestVeniceParentHelixAdminWithAcl extends AbstractTestVeniceParentH
     Store store = TestUtils.createTestStore(storeName, owner, System.currentTimeMillis());
     doReturn(store).when(internalAdmin).getStore(eq(clusterName), eq(storeName));
     doReturn(store).when(internalAdmin).checkPreConditionForDeletion(eq(clusterName), eq(storeName));
-
-    doReturn(CompletableFuture.completedFuture(new SimplePubSubProduceResultImpl(topicName, partitionId, 1, -1)))
-        .when(veniceWriter)
-        .put(any(), any(), anyInt());
 
     when(zkClient.readData(zkMetadataNodePath, null)).thenReturn(null)
         .thenReturn(AdminTopicMetadataAccessor.generateMetadataMap(1, -1, 1));


### PR DESCRIPTION
## Use a single object as producer callback and produce result future

This PR combines `Future` returned by `PubSubProducerAdapter::sendMessage` and  
`PubSubProducerCallback` is one of the arguments for the `sendMessage` API.  The  
goal is to avoid the additional object allocation for `Future`  that happens during the   
conversion as it is only used at a few places for synchronous/blocking calls. Also, we   
would like to leverage `PubSubProducerCallback` to get a result of send action as we   
already use callback on every `sendMessage` call.  

All methods in `VeniceWriter::{put|update|delete}` now return `void`. Callers will callback  
passed to these VW APIs for async/blocking calls.


Follow up PR w.r.t. the following comment by @FelixGV 
> I took a look at the code and noticed that we almost never use the future returned from sendMessage. We use it in some control message scenario, and in a few tests, but I believe those should be not too hard to refactor into using callbacks. Can we do this, so that this function and all those that call it can return void instead? I think it would simplify our code, and would avoid the object allocation of this wrapper future which is almost always useless.





## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
GHCI and InternalCI

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.