### PR TITLE
[vpj] Recompression support in KIF repush

### DIFF
--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/input/kafka/KafkaInputDictTrainer.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/input/kafka/KafkaInputDictTrainer.java
@@ -1,0 +1,181 @@
+package com.linkedin.venice.hadoop.input.kafka;
+
+import static com.linkedin.venice.hadoop.DefaultInputDataInfoProvider.*;
+import static com.linkedin.venice.hadoop.VenicePushJob.*;
+
+import com.github.luben.zstd.ZstdDictTrainer;
+import com.linkedin.venice.exceptions.VeniceException;
+import com.linkedin.venice.hadoop.PushJobZstdConfig;
+import com.linkedin.venice.hadoop.input.kafka.avro.KafkaInputMapperKey;
+import com.linkedin.venice.hadoop.input.kafka.avro.KafkaInputMapperValue;
+import com.linkedin.venice.utils.ByteUtils;
+import com.linkedin.venice.utils.VeniceProperties;
+import java.io.IOException;
+import java.util.Optional;
+import java.util.Properties;
+import org.apache.hadoop.mapred.InputSplit;
+import org.apache.hadoop.mapred.JobConf;
+import org.apache.hadoop.mapred.RecordReader;
+import org.apache.hadoop.mapred.Reporter;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+
+/**
+ * Zstd dict trainer for Kafka Repush.
+ * This class will try to read a few records from every partition as samples of dict trainer.
+ */
+public class KafkaInputDictTrainer {
+  public static class Param {
+    private String kafkaInputBroker;
+    private String topicName;
+    private String keySchema;
+    private Properties sslProperties;
+    private int compressionDictSize;
+    private int dictSampleSize;
+
+    Param(ParamBuilder builder) {
+      this.kafkaInputBroker = builder.kafkaInputBroker;
+      this.topicName = builder.topicName;
+      this.keySchema = builder.keySchema;
+      this.sslProperties = builder.sslProperties;
+      this.compressionDictSize = builder.compressionDictSize;
+      this.dictSampleSize = builder.dictSampleSize;
+    }
+  }
+
+  public static class ParamBuilder {
+    private String kafkaInputBroker;
+    private String topicName;
+    private String keySchema;
+    private Properties sslProperties;
+    private int compressionDictSize;
+    private int dictSampleSize;
+
+    public ParamBuilder setKafkaInputBroker(String kafkaInputBroker) {
+      this.kafkaInputBroker = kafkaInputBroker;
+      return this;
+    }
+
+    public ParamBuilder setTopicName(String topicName) {
+      this.topicName = topicName;
+      return this;
+    }
+
+    public ParamBuilder setKeySchema(String keySchema) {
+      this.keySchema = keySchema;
+      return this;
+    }
+
+    public ParamBuilder setSslProperties(Properties sslProperties) {
+      this.sslProperties = sslProperties;
+      return this;
+    }
+
+    public ParamBuilder setCompressionDictSize(int compressionDictSize) {
+      this.compressionDictSize = compressionDictSize;
+      return this;
+    }
+
+    public ParamBuilder setDictSampleSize(int dictSampleSize) {
+      this.dictSampleSize = dictSampleSize;
+      return this;
+    }
+
+    public Param build() {
+      return new Param(this);
+    }
+  }
+
+  private static final Logger LOGGER = LogManager.getLogger(KafkaInputDictTrainer.class);
+  private final VeniceProperties props;
+  private final JobConf jobConf;
+  private final String sourceTopicName;
+  private byte[] dict = null;
+  private final KafkaInputFormat kafkaInputFormat;
+  private final Optional<ZstdDictTrainer> trainerSupplier;
+
+  public KafkaInputDictTrainer(Param param) {
+    this(new KafkaInputFormat(), Optional.empty(), param);
+  }
+
+  // For testing only
+  protected KafkaInputDictTrainer(
+      KafkaInputFormat inputFormat,
+      Optional<ZstdDictTrainer> trainerSupplier,
+      Param param) {
+    this.kafkaInputFormat = inputFormat;
+    this.trainerSupplier = trainerSupplier;
+    Properties properties = new Properties();
+    properties.setProperty(KAFKA_INPUT_BROKER_URL, param.kafkaInputBroker);
+    properties.setProperty(KAFKA_INPUT_TOPIC, param.topicName);
+    properties.setProperty(KAFKA_SOURCE_KEY_SCHEMA_STRING_PROP, param.keySchema);
+    this.sourceTopicName = param.topicName;
+    properties.putAll(param.sslProperties);
+    properties.setProperty(COMPRESSION_DICTIONARY_SIZE_LIMIT, Integer.toString(param.compressionDictSize));
+    properties.setProperty(COMPRESSION_DICTIONARY_SAMPLE_SIZE, Integer.toString(param.dictSampleSize));
+
+    props = new VeniceProperties(properties);
+    jobConf = new JobConf();
+    properties.forEach((k, v) -> jobConf.set((String) k, (String) v));
+  }
+
+  public synchronized byte[] trainDict() {
+    if (dict != null) {
+      return dict;
+    }
+    // Prepare input
+    // Get one split per partition
+    InputSplit[] splits = kafkaInputFormat.getSplitsByRecordsPerSplit(jobConf, Long.MAX_VALUE);
+    // Try to gather some records from each partition
+    PushJobZstdConfig zstdConfig = new PushJobZstdConfig(props, splits.length);
+    ZstdDictTrainer trainer = trainerSupplier.isPresent() ? trainerSupplier.get() : zstdConfig.getZstdDictTrainer();
+    int maxBytesPerPartition = zstdConfig.getMaxBytesPerFile();
+
+    KafkaInputMapperKey mapperKey = null;
+    KafkaInputMapperValue mapperValue = null;
+
+    int currentPartition = 0;
+    long totalSampledRecordCnt = 0;
+    try {
+      for (InputSplit split: splits) {
+        long currentFilledSize = 0;
+        long sampledRecordCnt = 0;
+        RecordReader<KafkaInputMapperKey, KafkaInputMapperValue> recordReader =
+            kafkaInputFormat.getRecordReader(split, jobConf, Reporter.NULL);
+        try {
+          if (mapperKey == null) {
+            mapperKey = recordReader.createKey();
+          }
+          if (mapperValue == null) {
+            mapperValue = recordReader.createValue();
+          }
+          while (recordReader.next(mapperKey, mapperValue)) {
+            byte[] value = ByteUtils.extractByteArray(mapperValue.value);
+            currentFilledSize += value.length;
+            if (currentFilledSize > maxBytesPerPartition) {
+              break;
+            }
+            trainer.addSample(value);
+            ++sampledRecordCnt;
+          }
+          totalSampledRecordCnt += sampledRecordCnt;
+          LOGGER.info("Added {} samples into dict from partition: {}", sampledRecordCnt, currentPartition);
+          ++currentPartition;
+        } finally {
+          recordReader.close();
+        }
+      }
+    } catch (IOException e) {
+      throw new VeniceException("Encountered exception while reading source topic: " + sourceTopicName, e);
+    }
+    if (totalSampledRecordCnt == 0) {
+      throw new VeniceException("No record in the source topic: " + sourceTopicName + ", can't train the dict");
+    }
+    LOGGER.info("Added total {} records from {} partitions into dict", totalSampledRecordCnt, splits.length);
+    dict = trainer.trainSamples();
+    LOGGER.info("Successfully finished training dict");
+    return dict;
+  }
+
+}

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/input/kafka/KafkaInputFormat.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/input/kafka/KafkaInputFormat.java
@@ -61,6 +61,10 @@ public class KafkaInputFormat implements InputFormat<KafkaInputMapperKey, KafkaI
           "Invalid " + KAFKA_INPUT_MAX_RECORDS_PER_MAPPER + " value [" + maxRecordsPerSplit + "]");
     }
 
+    return getSplitsByRecordsPerSplit(job, maxRecordsPerSplit);
+  }
+
+  public InputSplit[] getSplitsByRecordsPerSplit(JobConf job, long maxRecordsPerSplit) {
     Map<TopicPartition, Long> latestOffsets = getLatestOffsets(job);
     List<InputSplit> splits = new LinkedList<>();
     latestOffsets.forEach((topicPartition, end) -> {

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/input/kafka/KafkaInputRecordReader.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/input/kafka/KafkaInputRecordReader.java
@@ -202,13 +202,15 @@ public class KafkaInputRecordReader implements RecordReader<KafkaInputMapperKey,
                 "Unexpected '" + messageType + "' message from Kafka topic partition: " + topicPartition
                     + " with offset: " + pubSubMessage.getOffset());
         }
-        MRJobCounterHelper.incrTotalPutOrDeleteRecordCount(reporter, 1);
-        long recordCount = MRJobCounterHelper.getTotalPutOrDeleteRecordsCount(reporter);
-        if (recordCount % LOG_RECORD_INTERVAL == 0) {
-          LOGGER.info(
-              "KafkaInputRecordReader for TopicPartition: {} has processed {} records",
-              this.topicPartition,
-              recordCount);
+        if (reporter != null && !reporter.equals(Reporter.NULL)) {
+          MRJobCounterHelper.incrTotalPutOrDeleteRecordCount(reporter, 1);
+          long recordCount = MRJobCounterHelper.getTotalPutOrDeleteRecordsCount(reporter);
+          if (recordCount % LOG_RECORD_INTERVAL == 0) {
+            LOGGER.info(
+                "KafkaInputRecordReader for TopicPartition: {} has processed {} records",
+                this.topicPartition,
+                recordCount);
+          }
         }
         return true;
       } else {

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/input/kafka/VeniceKafkaInputMapper.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/input/kafka/VeniceKafkaInputMapper.java
@@ -52,8 +52,7 @@ public class VeniceKafkaInputMapper extends AbstractVeniceMapper<KafkaInputMappe
   @Override
   protected void configureTask(VeniceProperties props, JobConf job) {
     /**
-     * Do nothing but create the filter for {@link KafkaInputFormat} for now, and if we need to support compression rebuild during re-push,
-     * this function needs to be changed.
+     * Do nothing but create the filter for {@link KafkaInputFormat}.
      */
     this.veniceFilterChain = getFilterChain(props);
   }

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/utils/VPJSSLUtils.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/utils/VPJSSLUtils.java
@@ -49,6 +49,7 @@ public class VPJSSLUtils {
     Properties sslWriterProperties =
         sslConfigurator.setupSSLConfig(newSslProperties, UserCredentialsFactory.getUserCredentialsFromTokenFile());
     newSslProperties.putAll(sslWriterProperties);
+    newSslProperties.put(SSL_CONFIGURATOR_CLASS_CONFIG, sslConfigurator.getClass().getName());
     return newSslProperties;
   }
 

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/VenicePushJobTest.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/VenicePushJobTest.java
@@ -41,6 +41,7 @@ import java.util.Collections;
 import java.util.Properties;
 import java.util.Set;
 import java.util.function.Consumer;
+import org.apache.avro.Schema;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -210,6 +211,12 @@ public class VenicePushJobTest {
     StoreResponse storeResponse = new StoreResponse();
     storeResponse.setStore(getStoreInfo(storeInfo));
     doReturn(storeResponse).when(client).getStore(TEST_STORE);
+
+    // mock key schema
+    SchemaResponse keySchemaResponse = new SchemaResponse();
+    keySchemaResponse.setId(1);
+    keySchemaResponse.setSchemaStr(Schema.create(Schema.Type.STRING).toString());
+    doReturn(keySchemaResponse).when(client).getKeySchema(TEST_STORE);
 
     return client;
   }

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/input/kafka/KafkaInputRecordReaderTest.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/input/kafka/KafkaInputRecordReaderTest.java
@@ -31,6 +31,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.apache.hadoop.mapred.JobConf;
+import org.apache.hadoop.mapred.Reporter;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -80,7 +81,7 @@ public class KafkaInputRecordReaderTest {
 
     KafkaInputSplit split = new KafkaInputSplit(topic, 0, 0, 102);
     try (KafkaInputRecordReader reader =
-        new KafkaInputRecordReader(split, conf, null, consumer, pubSubTopicRepository)) {
+        new KafkaInputRecordReader(split, conf, Reporter.NULL, consumer, pubSubTopicRepository)) {
       for (int i = 0; i < numRecord; ++i) {
         KafkaInputMapperKey key = new KafkaInputMapperKey();
         KafkaInputMapperValue value = new KafkaInputMapperValue();

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/input/kafka/TestKafkaInputDictTrainer.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/input/kafka/TestKafkaInputDictTrainer.java
@@ -1,0 +1,148 @@
+package com.linkedin.venice.hadoop.input.kafka;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.github.luben.zstd.ZstdDictTrainer;
+import com.linkedin.venice.exceptions.VeniceException;
+import com.linkedin.venice.hadoop.input.kafka.avro.KafkaInputMapperKey;
+import com.linkedin.venice.hadoop.input.kafka.avro.KafkaInputMapperValue;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.Properties;
+import org.apache.hadoop.mapred.InputSplit;
+import org.apache.hadoop.mapred.RecordReader;
+import org.testng.annotations.Test;
+
+
+public class TestKafkaInputDictTrainer {
+  private KafkaInputDictTrainer.Param getParam(int sampleSize) {
+    return new KafkaInputDictTrainer.ParamBuilder().setKafkaInputBroker("test_url")
+        .setTopicName("test_topic")
+        .setKeySchema("\"string\"")
+        .setCompressionDictSize(900 * 1024)
+        .setDictSampleSize(sampleSize)
+        .setSslProperties(new Properties())
+        .build();
+  }
+
+  @Test(expectedExceptions = VeniceException.class, expectedExceptionsMessageRegExp = "No record.*")
+  public void testEmptyTopic() throws IOException {
+    KafkaInputFormat mockFormat = mock(KafkaInputFormat.class);
+    InputSplit[] splits = new KafkaInputSplit[] { new KafkaInputSplit("test_topic", 0, 0, 0) };
+    doReturn(splits).when(mockFormat).getSplitsByRecordsPerSplit(any(), anyLong());
+    RecordReader<KafkaInputMapperKey, KafkaInputMapperValue> mockRecordReader = mock(RecordReader.class);
+    doReturn(false).when(mockRecordReader).next(any(), any());
+    doReturn(mockRecordReader).when(mockFormat).getRecordReader(any(), any(), any());
+
+    KafkaInputDictTrainer trainer = new KafkaInputDictTrainer(mockFormat, Optional.empty(), getParam(100));
+    trainer.trainDict();
+  }
+
+  interface ResettableRecordReader<K, V> extends RecordReader<K, V> {
+    void reset();
+  }
+
+  private ResettableRecordReader<KafkaInputMapperKey, KafkaInputMapperValue> mockReader(List<byte[]> values) {
+    ResettableRecordReader<KafkaInputMapperKey, KafkaInputMapperValue> mockRecordReader =
+        new ResettableRecordReader<KafkaInputMapperKey, KafkaInputMapperValue>() {
+          @Override
+          public void reset() {
+            cur = 0;
+          }
+
+          int cur = 0;
+
+          @Override
+          public boolean next(KafkaInputMapperKey key, KafkaInputMapperValue value) throws IOException {
+            if (values.size() <= cur) {
+              return false;
+            }
+            key.offset = cur;
+            key.key = ByteBuffer.wrap(("test_key" + cur).getBytes());
+            value.offset = cur;
+            value.value = ByteBuffer.wrap(values.get(cur));
+            ++cur;
+            return true;
+          }
+
+          @Override
+          public KafkaInputMapperKey createKey() {
+            return new KafkaInputMapperKey();
+          }
+
+          @Override
+          public KafkaInputMapperValue createValue() {
+            return new KafkaInputMapperValue();
+          }
+
+          @Override
+          public long getPos() throws IOException {
+            return 0;
+          }
+
+          @Override
+          public void close() throws IOException {
+
+          }
+
+          @Override
+          public float getProgress() throws IOException {
+            return 0;
+          }
+        };
+
+    return mockRecordReader;
+  }
+
+  @Test
+  public void testSamplingFromMultiplePartitions() throws IOException {
+    KafkaInputFormat mockFormat = mock(KafkaInputFormat.class);
+    InputSplit[] splits = new KafkaInputSplit[] { new KafkaInputSplit("test_topic", 0, 0, 2),
+        new KafkaInputSplit("test_topic", 0, 0, 2) };
+    doReturn(splits).when(mockFormat).getSplitsByRecordsPerSplit(any(), anyLong());
+
+    // Return 3 records
+    ResettableRecordReader<KafkaInputMapperKey, KafkaInputMapperValue> readerForP0 =
+        mockReader(Arrays.asList("p0_value0".getBytes(), "p0_value1".getBytes(), "p0_value2".getBytes()));
+
+    ResettableRecordReader<KafkaInputMapperKey, KafkaInputMapperValue> readerForP1 =
+        mockReader(Arrays.asList("p1_value0".getBytes(), "p1_value1".getBytes(), "p1_value2".getBytes()));
+
+    doReturn(readerForP0).when(mockFormat).getRecordReader(eq(splits[0]), any(), any());
+    doReturn(readerForP1).when(mockFormat).getRecordReader(eq(splits[1]), any(), any());
+
+    // Big sampling will collect every record.
+    ZstdDictTrainer mockTrainer1 = mock(ZstdDictTrainer.class);
+    KafkaInputDictTrainer trainer1 = new KafkaInputDictTrainer(mockFormat, Optional.of(mockTrainer1), getParam(1000));
+    trainer1.trainDict();
+
+    verify(mockTrainer1).addSample(eq("p0_value0".getBytes()));
+    verify(mockTrainer1).addSample(eq("p0_value1".getBytes()));
+    verify(mockTrainer1).addSample(eq("p0_value2".getBytes()));
+    verify(mockTrainer1).addSample(eq("p1_value0".getBytes()));
+    verify(mockTrainer1).addSample(eq("p1_value1".getBytes()));
+    verify(mockTrainer1).addSample(eq("p1_value2".getBytes()));
+
+    // Small sampling will collect the first several records
+    readerForP0.reset();
+    readerForP1.reset();
+    ZstdDictTrainer mockTrainer2 = mock(ZstdDictTrainer.class);
+    KafkaInputDictTrainer trainer2 = new KafkaInputDictTrainer(mockFormat, Optional.of(mockTrainer2), getParam(20));
+    trainer2.trainDict();
+    verify(mockTrainer2).addSample(eq("p0_value0".getBytes()));
+    verify(mockTrainer2, never()).addSample(eq("p0_value1".getBytes()));
+    verify(mockTrainer2, never()).addSample(eq("p0_value2".getBytes()));
+    verify(mockTrainer2).addSample(eq("p1_value0".getBytes()));
+    verify(mockTrainer2, never()).addSample(eq("p1_value1".getBytes()));
+    verify(mockTrainer2, never()).addSample(eq("p1_value2".getBytes()));
+  }
+}

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/compression/GzipCompressor.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/compression/GzipCompressor.java
@@ -100,6 +100,11 @@ public class GzipCompressor extends VeniceCompressor {
     return new GZIPInputStream(inputStream);
   }
 
+  @Override
+  public int hashCode() {
+    return super.hashCode();
+  }
+
   private static class ZeroCopyByteArrayOutputStream extends ByteArrayOutputStream {
     public ZeroCopyByteArrayOutputStream(int size) {
       super(size);
@@ -109,5 +114,13 @@ public class GzipCompressor extends VeniceCompressor {
     public synchronized byte[] toByteArray() {
       return buf;
     }
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o == this) {
+      return true;
+    }
+    return o != null && o instanceof GzipCompressor;
   }
 }

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/compression/NoopCompressor.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/compression/NoopCompressor.java
@@ -24,6 +24,11 @@ public class NoopCompressor extends VeniceCompressor {
   }
 
   @Override
+  public int hashCode() {
+    return super.hashCode();
+  }
+
+  @Override
   public ByteBuffer decompress(ByteBuffer data) throws IOException {
     return data;
   }
@@ -36,5 +41,13 @@ public class NoopCompressor extends VeniceCompressor {
   @Override
   public InputStream decompress(InputStream inputStream) throws IOException {
     return inputStream;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o == this) {
+      return true;
+    }
+    return o != null && o instanceof NoopCompressor;
   }
 }

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/compression/VeniceCompressor.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/compression/VeniceCompressor.java
@@ -30,4 +30,5 @@ public abstract class VeniceCompressor implements Closeable {
   public void close() throws IOException {
     return;
   }
+
 }

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/compression/ZstdWithDictCompressor.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/compression/ZstdWithDictCompressor.java
@@ -18,6 +18,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
@@ -29,9 +30,13 @@ public class ZstdWithDictCompressor extends VeniceCompressor {
   private final CloseableThreadLocal<ZstdDecompressCtx> decompressor;
   private final ZstdDictCompress dictCompress;
   private final ZstdDictDecompress dictDecompress;
+  private final byte[] dictionary;
+  private final int level;
 
   public ZstdWithDictCompressor(final byte[] dictionary, int level) {
     super(CompressionStrategy.ZSTD_WITH_DICT);
+    this.dictionary = dictionary;
+    this.level = level;
     this.dictCompress = new ZstdDictCompress(dictionary, level);
     this.dictDecompress = new ZstdDictDecompress(dictionary);
     this.compressor = new CloseableThreadLocal<>(() -> new ZstdCompressCtx().loadDict(dictCompress).setLevel(level));
@@ -170,5 +175,23 @@ public class ZstdWithDictCompressor extends VeniceCompressor {
       trainer.addSample(value);
     }
     return trainer.trainSamples();
+  }
+
+  @Override
+  public int hashCode() {
+    return super.hashCode();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o == this) {
+      return true;
+    }
+    if (o == null || !(o instanceof ZstdWithDictCompressor)) {
+      return false;
+    }
+    // Compare dictionary and level
+    return Arrays.equals(dictionary, ((ZstdWithDictCompressor) o).dictionary)
+        && level == ((ZstdWithDictCompressor) o).level;
   }
 }

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/compression/TestVeniceCompressor.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/compression/TestVeniceCompressor.java
@@ -135,4 +135,32 @@ public class TestVeniceCompressor {
   private enum SourceDataType {
     DIRECT_BYTE_BUFFER, NON_DIRECT_BYTE_BUFFER, BYTE_ARRAY
   }
+
+  @Test
+  public void testCompressorEqual() {
+    VeniceCompressor[] compressors1 = new VeniceCompressor[] { new NoopCompressor(), new GzipCompressor(),
+        new ZstdWithDictCompressor("abc".getBytes(), Zstd.maxCompressionLevel()),
+        new ZstdWithDictCompressor("def".getBytes(), Zstd.maxCompressionLevel()) };
+    VeniceCompressor[] compressors2 = new VeniceCompressor[] { new NoopCompressor(), new GzipCompressor(),
+        new ZstdWithDictCompressor("abc".getBytes(), Zstd.maxCompressionLevel()),
+        new ZstdWithDictCompressor("def".getBytes(), Zstd.maxCompressionLevel()) };
+    for (int i = 0; i < compressors1.length; ++i) {
+      for (int j = 0; j < compressors1.length; ++j) {
+        if (i == j) {
+          Assert.assertEquals(compressors1[i], compressors1[j]);
+        } else {
+          Assert.assertNotEquals(compressors1[i], compressors1[j]);
+        }
+      }
+    }
+    for (int i = 0; i < compressors1.length; ++i) {
+      for (int j = 0; j < compressors2.length; ++j) {
+        if (i == j) {
+          Assert.assertEquals(compressors1[i], compressors2[j]);
+        } else {
+          Assert.assertNotEquals(compressors1[i], compressors2[j]);
+        }
+      }
+    }
+  }
 }


### PR DESCRIPTION
This code change adds re-compression support in KIF repush, which means the new dest version can use a different compression algo from the source version.
Even for the same compression algo: dict compression, KIF repush will re-train a new dict in the dest version by default, and here is the config to reuse the same dict from the source version:
kafka.input.compression.build.new.dict.enabled: default `true`

This option is especially useful for streaming-only store since when dict compression is enabled for a streaming only store, the dict is built on dummy records, which are not quite representative.

Currently, dict build in KIF repush is built inside Azkaban Job thread and it doesn't support MR-based dict build yet.

<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci], [server], [controller],
[router], [samza], [vpj], [fast-client], [thin-client], [alpini],
[admin-tool], [test], [build], [doc], [script]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->



## How was this PR tested?
Venice CI.
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [x] Yes. Make sure to explain your proposed changes and call out the behavior change.