### PR TITLE
[server][test] Reduce number of permutation of read compute test

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreBufferService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreBufferService.java
@@ -532,7 +532,7 @@ public class StoreBufferService extends AbstractStoreBufferService {
         LOGGER.info(
             "Drainer number {} hosting {} partitions, has memory usage of {}",
             index,
-            drainer.topicToTimeSpent.size(),
+            drainer.blockingQueue.size(),
             queue.getMemoryUsage());
       }
       drainer.topicToTimeSpent.clear();


### PR DESCRIPTION


## Summary, imperative, start upper case, don't end with a period
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Remove non default values for read compute client permutation from the test. 
Also fix the logging issue reporting 0 partitions in drainer buffer during slow ingestions.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
CI build.
## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.