### PR TITLE
[build] Disable parallel running for unit tests

### DIFF
--- a/.github/workflows/gh-ci.yml
+++ b/.github/workflows/gh-ci.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Build with Gradle
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: "-DmaxParallelForks=2  --parallel -x :internal:venice-avro-compatibility-test:test jacocoTestCoverageVerification diffCoverage --continue"
+          arguments: "-x :internal:venice-avro-compatibility-test:test jacocoTestCoverageVerification diffCoverage --continue"
 
   AvroCompatibilityTests:
     strategy:

--- a/.github/workflows/gh-ci.yml
+++ b/.github/workflows/gh-ci.yml
@@ -58,7 +58,7 @@ jobs:
           path: ${{ github.job }}-artifacts.tar.gz
           retention-days: 30
 
-  UnitTestsAndCodeCoverage:
+  UnitTestsAndModuleLevelCodeCoverage:
     strategy:
       fail-fast: false
       matrix:
@@ -86,7 +86,52 @@ jobs:
       - name: Build with Gradle
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: "-x :internal:venice-avro-compatibility-test:test jacocoTestCoverageVerification diffCoverage --continue"
+          arguments: "-DmaxParallelForks=2 --parallel -x :internal:venice-avro-compatibility-test:test jacocoTestCoverageVerification --continue"
+      - name: Package Build Artifacts
+        if: success() || failure()
+        shell: bash
+        run: |
+          mkdir ${{ github.job }}-artifacts
+          find . -path "**/build/reports/*" -or -path "**/build/test-results/*" > artifacts.list
+          rsync -R --files-from=artifacts.list . ${{ github.job }}-artifacts
+          tar -zcvf ${{ github.job }}-artifacts.tar.gz ${{ github.job }}-artifacts
+      - name: Upload Build Artifacts
+        if: success()
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ github.job }}
+          path: ${{ github.job }}-artifacts.tar.gz
+          retention-days: 30
+
+  DiffCodeCoverage:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        jdk: [11]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          java-version: ${{ matrix.jdk }}
+          distribution: 'microsoft'
+          cache: 'gradle'
+      - shell: bash
+        run: |
+          git remote set-head origin --auto
+          git remote add upstream https://github.com/linkedin/venice
+          git fetch upstream
+      - name: Validate Gradle wrapper
+        uses: gradle/wrapper-validation-action@v1
+      - name: Build with Gradle
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: "-DmaxParallelForks=2 --parallel -x :internal:venice-avro-compatibility-test:test diffCoverage --continue"
       - name: Package Build Artifacts
         if: success() || failure()
         shell: bash
@@ -965,7 +1010,7 @@ jobs:
         os: [ubuntu-latest]
         jdk: [11]
     runs-on: ${{ matrix.os }}
-    needs: [StaticAnalysis, UnitTestsAndCodeCoverage, AvroCompatibilityTests, IntegrationTestsA, IntegrationTestsB, IntegrationTestsC, IntegrationTestsD, IntegrationTestsE, IntegrationTestsF, IntegrationTestsG, IntegrationTestsH, IntegrationTestsI, IntegrationTestsJ, IntegrationTestsK, IntegrationTestsL, IntegrationTestsM, IntegrationTestsN, IntegrationTestsO, IntegrationTestsP, IntegrationTestsQ, IntegrationTestsZ]
+    needs: [StaticAnalysis, UnitTestsAndModuleLevelCodeCoverage, DiffCodeCoverage, AvroCompatibilityTests, IntegrationTestsA, IntegrationTestsB, IntegrationTestsC, IntegrationTestsD, IntegrationTestsE, IntegrationTestsF, IntegrationTestsG, IntegrationTestsH, IntegrationTestsI, IntegrationTestsJ, IntegrationTestsK, IntegrationTestsL, IntegrationTestsM, IntegrationTestsN, IntegrationTestsO, IntegrationTestsP, IntegrationTestsQ, IntegrationTestsZ]
     timeout-minutes: 120
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/gh-ci.yml
+++ b/.github/workflows/gh-ci.yml
@@ -58,7 +58,7 @@ jobs:
           path: ${{ github.job }}-artifacts.tar.gz
           retention-days: 30
 
-  UnitTestsAndModuleLevelCodeCoverage:
+  UnitTestsAndCodeCoverage:
     strategy:
       fail-fast: false
       matrix:
@@ -86,52 +86,7 @@ jobs:
       - name: Build with Gradle
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: "-DmaxParallelForks=2 --parallel -x :internal:venice-avro-compatibility-test:test jacocoTestCoverageVerification --continue"
-      - name: Package Build Artifacts
-        if: success() || failure()
-        shell: bash
-        run: |
-          mkdir ${{ github.job }}-artifacts
-          find . -path "**/build/reports/*" -or -path "**/build/test-results/*" > artifacts.list
-          rsync -R --files-from=artifacts.list . ${{ github.job }}-artifacts
-          tar -zcvf ${{ github.job }}-artifacts.tar.gz ${{ github.job }}-artifacts
-      - name: Upload Build Artifacts
-        if: success()
-        uses: actions/upload-artifact@v3
-        with:
-          name: ${{ github.job }}
-          path: ${{ github.job }}-artifacts.tar.gz
-          retention-days: 30
-
-  DiffCodeCoverage:
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest]
-        jdk: [11]
-    runs-on: ${{ matrix.os }}
-    timeout-minutes: 60
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      - name: Set up JDK
-        uses: actions/setup-java@v3
-        with:
-          java-version: ${{ matrix.jdk }}
-          distribution: 'microsoft'
-          cache: 'gradle'
-      - shell: bash
-        run: |
-          git remote set-head origin --auto
-          git remote add upstream https://github.com/linkedin/venice
-          git fetch upstream
-      - name: Validate Gradle wrapper
-        uses: gradle/wrapper-validation-action@v1
-      - name: Build with Gradle
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: "-DmaxParallelForks=2 --parallel -x :internal:venice-avro-compatibility-test:test diffCoverage --continue"
+          arguments: "-x :internal:venice-avro-compatibility-test:test jacocoTestCoverageVerification diffCoverage --continue"
       - name: Package Build Artifacts
         if: success() || failure()
         shell: bash
@@ -1010,7 +965,7 @@ jobs:
         os: [ubuntu-latest]
         jdk: [11]
     runs-on: ${{ matrix.os }}
-    needs: [StaticAnalysis, UnitTestsAndModuleLevelCodeCoverage, DiffCodeCoverage, AvroCompatibilityTests, IntegrationTestsA, IntegrationTestsB, IntegrationTestsC, IntegrationTestsD, IntegrationTestsE, IntegrationTestsF, IntegrationTestsG, IntegrationTestsH, IntegrationTestsI, IntegrationTestsJ, IntegrationTestsK, IntegrationTestsL, IntegrationTestsM, IntegrationTestsN, IntegrationTestsO, IntegrationTestsP, IntegrationTestsQ, IntegrationTestsZ]
+    needs: [StaticAnalysis, UnitTestsAndCodeCoverage, AvroCompatibilityTests, IntegrationTestsA, IntegrationTestsB, IntegrationTestsC, IntegrationTestsD, IntegrationTestsE, IntegrationTestsF, IntegrationTestsG, IntegrationTestsH, IntegrationTestsI, IntegrationTestsJ, IntegrationTestsK, IntegrationTestsL, IntegrationTestsM, IntegrationTestsN, IntegrationTestsO, IntegrationTestsP, IntegrationTestsQ, IntegrationTestsZ]
     timeout-minutes: 120
     steps:
       - uses: actions/checkout@v3

--- a/internal/venice-test-common/build.gradle
+++ b/internal/venice-test-common/build.gradle
@@ -218,10 +218,15 @@ task generateGHCI() {
   appendToGHCI(paramFileContent, targetFilePath, staticAnalysis, 20, staticAnalysisFlowGradleArgs)
   jobs << staticAnalysis
 
-  def unitTestsAndCodeCoverage = "UnitTestsAndCodeCoverage"
-  def unitTestsFlowGradleArgs = "-x :internal:venice-avro-compatibility-test:test jacocoTestCoverageVerification diffCoverage --continue"
-  appendToGHCI(paramFileContent, targetFilePath, unitTestsAndCodeCoverage, 60, unitTestsFlowGradleArgs)
-  jobs << unitTestsAndCodeCoverage
+  def moduleLevelCodeCoverage = "UnitTestsAndModuleLevelCodeCoverage"
+  def moduleLevelCodeCoverageGradleArgs = "-DmaxParallelForks=2 --parallel -x :internal:venice-avro-compatibility-test:test jacocoTestCoverageVerification --continue"
+  appendToGHCI(paramFileContent, targetFilePath, moduleLevelCodeCoverage, 60, moduleLevelCodeCoverageGradleArgs)
+  jobs << moduleLevelCodeCoverage
+
+  def diffCodeCoverage = "DiffCodeCoverage"
+  def diffCoverageGradleArgs = "-DmaxParallelForks=2 --parallel -x :internal:venice-avro-compatibility-test:test diffCoverage --continue"
+  appendToGHCI(paramFileContent, targetFilePath, diffCodeCoverage, 60, diffCoverageGradleArgs)
+  jobs << diffCodeCoverage
 
   def avroCompatibilityTests = "AvroCompatibilityTests"
   def avroCompatibilityFlowGradleArgs = "-DmaxParallelForks=2 --parallel :internal:venice-avro-compatibility-test:test --continue"

--- a/internal/venice-test-common/build.gradle
+++ b/internal/venice-test-common/build.gradle
@@ -210,7 +210,7 @@ task generateGHCI() {
   jobs << staticAnalysis
 
   def unitTestsAndCodeCoverage = "UnitTestsAndCodeCoverage"
-  def unitTestsFlowGradleArgs = "-DmaxParallelForks=2  --parallel -x :internal:venice-avro-compatibility-test:test jacocoTestCoverageVerification diffCoverage --continue"
+  def unitTestsFlowGradleArgs = "-x :internal:venice-avro-compatibility-test:test jacocoTestCoverageVerification diffCoverage --continue"
   appendToGHCI(paramFileContent, targetFilePath, unitTestsAndCodeCoverage, 60, unitTestsFlowGradleArgs)
   jobs << unitTestsAndCodeCoverage
 

--- a/internal/venice-test-common/build.gradle
+++ b/internal/venice-test-common/build.gradle
@@ -218,15 +218,10 @@ task generateGHCI() {
   appendToGHCI(paramFileContent, targetFilePath, staticAnalysis, 20, staticAnalysisFlowGradleArgs)
   jobs << staticAnalysis
 
-  def moduleLevelCodeCoverage = "UnitTestsAndModuleLevelCodeCoverage"
-  def moduleLevelCodeCoverageGradleArgs = "-DmaxParallelForks=2 --parallel -x :internal:venice-avro-compatibility-test:test jacocoTestCoverageVerification --continue"
-  appendToGHCI(paramFileContent, targetFilePath, moduleLevelCodeCoverage, 60, moduleLevelCodeCoverageGradleArgs)
-  jobs << moduleLevelCodeCoverage
-
-  def diffCodeCoverage = "DiffCodeCoverage"
-  def diffCoverageGradleArgs = "-DmaxParallelForks=2 --parallel -x :internal:venice-avro-compatibility-test:test diffCoverage --continue"
-  appendToGHCI(paramFileContent, targetFilePath, diffCodeCoverage, 60, diffCoverageGradleArgs)
-  jobs << diffCodeCoverage
+  def unitTestsAndCodeCoverage = "UnitTestsAndCodeCoverage"
+  def unitTestsFlowGradleArgs = "-x :internal:venice-avro-compatibility-test:test jacocoTestCoverageVerification diffCoverage --continue"
+  appendToGHCI(paramFileContent, targetFilePath, unitTestsAndCodeCoverage, 60, unitTestsFlowGradleArgs)
+  jobs << unitTestsAndCodeCoverage
 
   def avroCompatibilityTests = "AvroCompatibilityTests"
   def avroCompatibilityFlowGradleArgs = "-DmaxParallelForks=2 --parallel :internal:venice-avro-compatibility-test:test --continue"


### PR DESCRIPTION

## Summary

We introduced the Gradle flag to run unit tests in parallel in #262 and hope it can run tasks faster but turned out for some reasons, Gradle will run `diffCoverage` and `JacocoTestCoverageVerification` together at first, though the first task should depend on the latter one.

We didn't figure out how to make `diffCoverage` depends on the `JacocoTestCoverageVerification` yet so the changes above will cause the  `diffCoverage` fail immediately because the Jacoco coverage reports aren't ready yet - it's still running.

Right now, let's disable it and unblock other PRs (reported by #250 )

## How was this PR tested?

Github CI
