### PR TITLE
[vpj] dict compression for empty push to the hybrid store

### DIFF
--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/input/kafka/KafkaInputDictTrainer.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/input/kafka/KafkaInputDictTrainer.java
@@ -4,6 +4,9 @@ import static com.linkedin.venice.hadoop.DefaultInputDataInfoProvider.*;
 import static com.linkedin.venice.hadoop.VenicePushJob.*;
 
 import com.github.luben.zstd.ZstdDictTrainer;
+import com.linkedin.venice.compression.CompressionStrategy;
+import com.linkedin.venice.compression.CompressorFactory;
+import com.linkedin.venice.compression.VeniceCompressor;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.hadoop.PushJobZstdConfig;
 import com.linkedin.venice.hadoop.input.kafka.avro.KafkaInputMapperKey;
@@ -11,6 +14,8 @@ import com.linkedin.venice.hadoop.input.kafka.avro.KafkaInputMapperValue;
 import com.linkedin.venice.utils.ByteUtils;
 import com.linkedin.venice.utils.VeniceProperties;
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.Comparator;
 import java.util.Optional;
 import java.util.Properties;
 import org.apache.hadoop.mapred.InputSplit;
@@ -33,6 +38,7 @@ public class KafkaInputDictTrainer {
     private Properties sslProperties;
     private int compressionDictSize;
     private int dictSampleSize;
+    private CompressionStrategy sourceVersionCompressionStrategy;
 
     Param(ParamBuilder builder) {
       this.kafkaInputBroker = builder.kafkaInputBroker;
@@ -41,6 +47,7 @@ public class KafkaInputDictTrainer {
       this.sslProperties = builder.sslProperties;
       this.compressionDictSize = builder.compressionDictSize;
       this.dictSampleSize = builder.dictSampleSize;
+      this.sourceVersionCompressionStrategy = builder.sourceVersionCompressionStrategy;
     }
   }
 
@@ -51,6 +58,7 @@ public class KafkaInputDictTrainer {
     private Properties sslProperties;
     private int compressionDictSize;
     private int dictSampleSize;
+    private CompressionStrategy sourceVersionCompressionStrategy;
 
     public ParamBuilder setKafkaInputBroker(String kafkaInputBroker) {
       this.kafkaInputBroker = kafkaInputBroker;
@@ -82,6 +90,11 @@ public class KafkaInputDictTrainer {
       return this;
     }
 
+    public ParamBuilder setSourceVersionCompressionStrategy(CompressionStrategy compressionStrategy) {
+      this.sourceVersionCompressionStrategy = compressionStrategy;
+      return this;
+    }
+
     public Param build() {
       return new Param(this);
     }
@@ -94,18 +107,36 @@ public class KafkaInputDictTrainer {
   private byte[] dict = null;
   private final KafkaInputFormat kafkaInputFormat;
   private final Optional<ZstdDictTrainer> trainerSupplier;
+  private final CompressionStrategy sourceVersionCompressionStrategy;
+  private final CompressorBuilder compressorBuilder;
 
   public KafkaInputDictTrainer(Param param) {
-    this(new KafkaInputFormat(), Optional.empty(), param);
+    this(
+        new KafkaInputFormat(),
+        Optional.empty(),
+        param,
+        (compressorFactory, compressionStrategy, kafkaUrl, topic, props) -> KafkaInputUtils
+            .getCompressor(compressorFactory, compressionStrategy, kafkaUrl, topic, props));
+  }
+
+  interface CompressorBuilder {
+    VeniceCompressor getCompressor(
+        CompressorFactory compressorFactory,
+        CompressionStrategy compressionStrategy,
+        String kafkaUrl,
+        String topic,
+        VeniceProperties props);
   }
 
   // For testing only
   protected KafkaInputDictTrainer(
       KafkaInputFormat inputFormat,
       Optional<ZstdDictTrainer> trainerSupplier,
-      Param param) {
+      Param param,
+      CompressorBuilder compressorBuilder) {
     this.kafkaInputFormat = inputFormat;
     this.trainerSupplier = trainerSupplier;
+    this.sourceVersionCompressionStrategy = param.sourceVersionCompressionStrategy;
     Properties properties = new Properties();
     properties.setProperty(KAFKA_INPUT_BROKER_URL, param.kafkaInputBroker);
     properties.setProperty(KAFKA_INPUT_TOPIC, param.topicName);
@@ -118,25 +149,42 @@ public class KafkaInputDictTrainer {
     props = new VeniceProperties(properties);
     jobConf = new JobConf();
     properties.forEach((k, v) -> jobConf.set((String) k, (String) v));
+
+    this.compressorBuilder = compressorBuilder;
   }
 
   public synchronized byte[] trainDict() {
     if (dict != null) {
       return dict;
     }
+
     // Prepare input
     // Get one split per partition
-    InputSplit[] splits = kafkaInputFormat.getSplitsByRecordsPerSplit(jobConf, Long.MAX_VALUE);
+    KafkaInputSplit[] splits = (KafkaInputSplit[]) kafkaInputFormat.getSplitsByRecordsPerSplit(jobConf, Long.MAX_VALUE);
+    // The following sort is trying to get a deterministic dict with the same input.
+    Arrays.sort(splits, Comparator.comparingInt(o -> o.getTopicPartition().partition()));
     // Try to gather some records from each partition
     PushJobZstdConfig zstdConfig = new PushJobZstdConfig(props, splits.length);
     ZstdDictTrainer trainer = trainerSupplier.isPresent() ? trainerSupplier.get() : zstdConfig.getZstdDictTrainer();
     int maxBytesPerPartition = zstdConfig.getMaxBytesPerFile();
+
+    // Get the compressor for source version
+    CompressorFactory compressorFactory = new CompressorFactory();
+    VeniceCompressor sourceVersionCompressor = compressorBuilder.getCompressor(
+        compressorFactory,
+        sourceVersionCompressionStrategy,
+        jobConf.get(KAFKA_INPUT_BROKER_URL),
+        jobConf.get(KAFKA_INPUT_TOPIC),
+        props);
+    boolean isSourceVersionUsingNoopCompressionStrategy =
+        sourceVersionCompressor.getCompressionStrategy().equals(CompressionStrategy.NO_OP);
 
     KafkaInputMapperKey mapperKey = null;
     KafkaInputMapperValue mapperValue = null;
 
     int currentPartition = 0;
     long totalSampledRecordCnt = 0;
+
     try {
       for (InputSplit split: splits) {
         long currentFilledSize = 0;
@@ -151,12 +199,33 @@ public class KafkaInputDictTrainer {
             mapperValue = recordReader.createValue();
           }
           while (recordReader.next(mapperKey, mapperValue)) {
-            byte[] value = ByteUtils.extractByteArray(mapperValue.value);
-            currentFilledSize += value.length;
+            /**
+             * We can only decompress full compressed value here.
+             * If the source version is using {@link CompressionStrategy.NO_OP}, the value will be passed to the dict directly.
+             * If the source version is using other compression strategies, since we can only decompress the full value here, and the
+             * chunked values will be skipped.
+             *
+             * This logic may have a side effect if only the chunked payloads contain enough materials to build the dict,
+             * with this, the dict built won't be very efficient.
+             * Since the above is an edge case, and solving it would require a lot of efforts here to
+             * assemble the chunks into a full value, we will evaluate this after gaining more experience with this feature.
+             */
+            byte[] decompressedValue;
+            if (isSourceVersionUsingNoopCompressionStrategy) {
+              decompressedValue = ByteUtils.extractByteArray(mapperValue.value);
+            } else {
+              if (mapperValue.schemaId <= 0) {
+                // We can't decompress some chunks of a compressed value here.
+                continue;
+              } else {
+                decompressedValue = ByteUtils.extractByteArray(sourceVersionCompressor.decompress(mapperValue.value));
+              }
+            }
+            currentFilledSize += decompressedValue.length;
             if (currentFilledSize > maxBytesPerPartition) {
               break;
             }
-            trainer.addSample(value);
+            trainer.addSample(decompressedValue);
             ++sampledRecordCnt;
           }
           totalSampledRecordCnt += sampledRecordCnt;
@@ -168,6 +237,10 @@ public class KafkaInputDictTrainer {
       }
     } catch (IOException e) {
       throw new VeniceException("Encountered exception while reading source topic: " + sourceTopicName, e);
+    } finally {
+      if (compressorFactory != null) {
+        compressorFactory.close();
+      }
     }
     if (totalSampledRecordCnt == 0) {
       throw new VeniceException("No record in the source topic: " + sourceTopicName + ", can't train the dict");

--- a/internal/venice-test-common/build.gradle
+++ b/internal/venice-test-common/build.gradle
@@ -125,7 +125,8 @@ def integrationTestBuckets = [
   "H": [
       "com.linkedin.venice.fastclient.BatchGet*",
       "com.linkedin.venice.fastclient.schema.*",
-      "com.linkedin.venice.fastclient.meta.*"],
+      "com.linkedin.venice.fastclient.meta.*",
+      "com.linkedin.venice.endToEnd.TestEmptyPush"],
   "I": [
       "com.linkedin.venice.fastclient.AvroStore*"],
   "J": [

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestEmptyPush.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestEmptyPush.java
@@ -1,0 +1,167 @@
+package com.linkedin.venice.endToEnd;
+
+import static com.linkedin.venice.kafka.TopicManager.DEFAULT_KAFKA_OPERATION_TIMEOUT_MS;
+import static com.linkedin.venice.utils.IntegrationTestPushUtils.defaultVPJProps;
+import static com.linkedin.venice.utils.IntegrationTestPushUtils.runVPJ;
+import static com.linkedin.venice.utils.IntegrationTestPushUtils.sendStreamingRecord;
+import static com.linkedin.venice.utils.TestWriteUtils.STRING_SCHEMA;
+import static com.linkedin.venice.utils.TestWriteUtils.getTempDataDirectory;
+import static com.linkedin.venice.utils.TestWriteUtils.writeEmptyAvroFileWithUserSchema;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
+import com.linkedin.venice.client.store.AvroGenericStoreClient;
+import com.linkedin.venice.client.store.ClientConfig;
+import com.linkedin.venice.client.store.ClientFactory;
+import com.linkedin.venice.compression.CompressionStrategy;
+import com.linkedin.venice.controllerapi.ControllerClient;
+import com.linkedin.venice.controllerapi.UpdateStoreQueryParams;
+import com.linkedin.venice.exceptions.VeniceException;
+import com.linkedin.venice.integration.utils.ServiceFactory;
+import com.linkedin.venice.integration.utils.VeniceClusterCreateOptions;
+import com.linkedin.venice.integration.utils.VeniceClusterWrapper;
+import com.linkedin.venice.kafka.TopicManager;
+import com.linkedin.venice.meta.Store;
+import com.linkedin.venice.meta.Version;
+import com.linkedin.venice.utils.DictionaryUtils;
+import com.linkedin.venice.utils.IntegrationTestPushUtils;
+import com.linkedin.venice.utils.TestUtils;
+import com.linkedin.venice.utils.Utils;
+import com.linkedin.venice.utils.VeniceProperties;
+import java.io.File;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+import org.apache.kafka.clients.CommonClientConfigs;
+import org.apache.samza.system.SystemProducer;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+
+public class TestEmptyPush {
+  private VeniceClusterWrapper venice;
+
+  @BeforeClass(alwaysRun = true)
+  public void setUp() {
+    VeniceClusterCreateOptions options = new VeniceClusterCreateOptions.Builder().numberOfControllers(1)
+        .numberOfRouters(1)
+        .numberOfServers(2)
+        .sslToKafka(false)
+        .sslToStorageNodes(false)
+        .build();
+    venice = ServiceFactory.getVeniceCluster(options);
+  }
+
+  @AfterClass(alwaysRun = true)
+  public void tearDown() {
+    Utils.closeQuietlyWithErrorLogged(venice);
+  }
+
+  private ByteBuffer getDictFromTopic(String topic, Properties properties) {
+    String kafkaUrl = venice.getKafka().getAddress();
+
+    Properties props = (Properties) properties.clone();
+    props.setProperty(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, kafkaUrl);
+    return DictionaryUtils.readDictionaryFromKafka(topic, new VeniceProperties(props));
+  }
+
+  @Test(timeOut = 120 * 1000)
+  public void testEmptyPushByChangingCompressionStrategy() throws IOException {
+    String storeName = Utils.getUniqueString("test_empty_push_store");
+    try (
+        ControllerClient controllerClient =
+            new ControllerClient(venice.getClusterName(), venice.getAllControllersURLs());
+        TopicManager topicManager = new TopicManager(
+            DEFAULT_KAFKA_OPERATION_TIMEOUT_MS,
+            100,
+            0L,
+            IntegrationTestPushUtils.getVeniceConsumerFactory(venice.getKafka()))) {
+      controllerClient.createNewStore(storeName, "owner", STRING_SCHEMA, STRING_SCHEMA);
+      controllerClient.updateStore(
+          storeName,
+          new UpdateStoreQueryParams().setStorageQuotaInByte(Store.UNLIMITED_STORAGE_QUOTA)
+              .setHybridRewindSeconds(60)
+              .setHybridOffsetLagThreshold(10)
+              .setCompressionStrategy(CompressionStrategy.ZSTD_WITH_DICT));
+
+      File inputDir = getTempDataDirectory();
+      String inputDirPath = "file://" + inputDir.getAbsolutePath();
+      writeEmptyAvroFileWithUserSchema(inputDir);
+
+      // First empty push with dict compression enabled.
+      Properties vpjProperties = defaultVPJProps(venice, inputDirPath, storeName);
+      runVPJ(vpjProperties, 1, controllerClient);
+      ByteBuffer dictForVersion1 = getDictFromTopic(Version.composeKafkaTopic(storeName, 1), vpjProperties);
+      assertNotNull(
+          dictForVersion1,
+          "Dict shouldn't be null for the empty push to a hybrid store without any records in RT");
+      assertTrue(topicManager.containsTopicAndAllPartitionsAreOnline(Version.composeRealTimeTopic(storeName)));
+
+      // Start writing some real-time records
+      SystemProducer veniceProducer =
+          IntegrationTestPushUtils.getSamzaProducer(venice, storeName, Version.PushType.STREAM);
+
+      String keyPrefix = "test_key_";
+      String valuePrefix = "test_value_";
+
+      for (int i = 1; i <= 1000; i++) {
+        sendStreamingRecord(veniceProducer, storeName, keyPrefix + i, valuePrefix + i);
+      }
+
+      Runnable dataValidator = () -> {
+        try (AvroGenericStoreClient client = ClientFactory.getAndStartGenericAvroClient(
+            ClientConfig.defaultGenericClientConfig(storeName).setVeniceURL(venice.getRandomRouterURL()))) {
+          TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, () -> {
+            try {
+              for (int i = 1; i <= 1000; ++i) {
+                String key = keyPrefix + i;
+                Object value = client.get(key).get();
+                assertNotNull(value, "value for key: " + key + " shouldn't be null");
+                assertEquals(value.toString(), valuePrefix + i);
+              }
+            } catch (Exception e) {
+              throw new VeniceException(e);
+            }
+          });
+        }
+      };
+      dataValidator.run();
+
+      // Enable Gzip compression
+      controllerClient
+          .updateStore(storeName, new UpdateStoreQueryParams().setCompressionStrategy(CompressionStrategy.GZIP));
+      // 2nd empty push with Gzip enabled
+      runVPJ(vpjProperties, 2, controllerClient);
+      ByteBuffer dictForVersion2 = getDictFromTopic(Version.composeKafkaTopic(storeName, 2), vpjProperties);
+      assertNull(dictForVersion2, "Dict should be null since `gzip` doesn't require any dict");
+      dataValidator.run();
+
+      // Reenable dict compression
+      controllerClient.updateStore(
+          storeName,
+          new UpdateStoreQueryParams().setCompressionStrategy(CompressionStrategy.ZSTD_WITH_DICT));
+      // 3rd empty push with zstd dict enabled
+      runVPJ(vpjProperties, 3, controllerClient);
+      ByteBuffer dictForVersion3 = getDictFromTopic(Version.composeKafkaTopic(storeName, 3), vpjProperties);
+      assertNotNull(dictForVersion3, "Dict shouldn't be null for empty push to a hybrid store");
+      assertNotEquals(
+          dictForVersion3,
+          dictForVersion1,
+          "Dict built with a current version will be different from the dummy dict built in the very first empty push");
+      dataValidator.run();
+
+      // 4th empty push with zstd dict enabled
+      runVPJ(vpjProperties, 4, controllerClient);
+      ByteBuffer dictForVersion4 = getDictFromTopic(Version.composeKafkaTopic(storeName, 4), vpjProperties);
+      assertNotNull(dictForVersion4, "Dict shouldn't be null for empty push to a hybrid store");
+      assertEquals(dictForVersion4, dictForVersion3, "Venice Push Job should build a same dict for the same input");
+      dataValidator.run();
+    }
+
+  }
+}

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestHybrid.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestHybrid.java
@@ -22,6 +22,7 @@ import static com.linkedin.venice.utils.IntegrationTestPushUtils.createStoreForJ
 import static com.linkedin.venice.utils.IntegrationTestPushUtils.defaultVPJProps;
 import static com.linkedin.venice.utils.IntegrationTestPushUtils.getSamzaProducer;
 import static com.linkedin.venice.utils.IntegrationTestPushUtils.getSamzaProducerConfig;
+import static com.linkedin.venice.utils.IntegrationTestPushUtils.runVPJ;
 import static com.linkedin.venice.utils.IntegrationTestPushUtils.sendCustomSizeStreamingRecord;
 import static com.linkedin.venice.utils.IntegrationTestPushUtils.sendStreamingRecord;
 import static com.linkedin.venice.utils.TestWriteUtils.STRING_SCHEMA;
@@ -51,7 +52,6 @@ import com.linkedin.venice.controllerapi.UpdateStoreQueryParams;
 import com.linkedin.venice.controllerapi.VersionCreationResponse;
 import com.linkedin.venice.exceptions.RecordTooLargeException;
 import com.linkedin.venice.exceptions.VeniceException;
-import com.linkedin.venice.hadoop.VenicePushJob;
 import com.linkedin.venice.helix.HelixBaseRoutingRepository;
 import com.linkedin.venice.integration.utils.ServiceFactory;
 import com.linkedin.venice.integration.utils.VeniceClusterWrapper;
@@ -1761,24 +1761,6 @@ public class TestHybrid {
     kafkaValue.leaderMetadataFooter = new LeaderMetadata();
     kafkaValue.leaderMetadataFooter.upstreamOffset = upstreamOffset;
     return Pair.create(kafkaKey, kafkaValue);
-  }
-
-  /**
-   * Blocking, waits for new version to go online
-   */
-  public static void runVPJ(Properties vpjProperties, int expectedVersionNumber, ControllerClient controllerClient) {
-    long vpjStart = System.currentTimeMillis();
-    String jobName = Utils.getUniqueString("hybrid-job-" + expectedVersionNumber);
-    try (VenicePushJob job = new VenicePushJob(jobName, vpjProperties)) {
-      job.run();
-      TestUtils.waitForNonDeterministicCompletion(
-          5,
-          TimeUnit.SECONDS,
-          () -> controllerClient.getStore((String) vpjProperties.get(VenicePushJob.VENICE_STORE_NAME_PROP))
-              .getStore()
-              .getCurrentVersion() == expectedVersionNumber);
-      LOGGER.info("**TIME** VPJ #{} takes {} ms", expectedVersionNumber, (System.currentTimeMillis() - vpjStart));
-    }
   }
 
   private static VeniceClusterWrapper setUpCluster(

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestHybridQuota.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestHybridQuota.java
@@ -10,6 +10,7 @@ import static com.linkedin.venice.kafka.TopicManager.DEFAULT_KAFKA_OPERATION_TIM
 import static com.linkedin.venice.utils.IntegrationTestPushUtils.createStoreForJob;
 import static com.linkedin.venice.utils.IntegrationTestPushUtils.defaultVPJProps;
 import static com.linkedin.venice.utils.IntegrationTestPushUtils.getSamzaProducer;
+import static com.linkedin.venice.utils.IntegrationTestPushUtils.runVPJ;
 import static com.linkedin.venice.utils.IntegrationTestPushUtils.sendCustomSizeStreamingRecord;
 import static com.linkedin.venice.utils.IntegrationTestPushUtils.sendStreamingRecord;
 import static com.linkedin.venice.utils.TestWriteUtils.getTempDataDirectory;
@@ -162,11 +163,11 @@ public class TestHybridQuota {
       hybridStoreQuotaOnlyRepository.refresh();
 
       // Do an VPJ push
-      TestHybrid.runVPJ(vpjProperties, 1, controllerClient);
+      runVPJ(vpjProperties, 1, controllerClient);
       String topicForStoreVersion1 = Version.composeKafkaTopic(storeName, 1);
 
       // Do an VPJ push
-      TestHybrid.runVPJ(vpjProperties, 2, controllerClient);
+      runVPJ(vpjProperties, 2, controllerClient);
       String topicForStoreVersion2 = Version.composeKafkaTopic(storeName, 2);
       Assert.assertTrue(
           topicManager.isTopicCompactionEnabled(topicForStoreVersion1),
@@ -184,7 +185,7 @@ public class TestHybridQuota {
       assertTrue(offlinePushRepository.containsKafkaTopic(topicForStoreVersion2));
 
       // Do an VPJ push
-      TestHybrid.runVPJ(vpjProperties, 3, controllerClient);
+      runVPJ(vpjProperties, 3, controllerClient);
       String topicForStoreVersion3 = Version.composeKafkaTopic(storeName, 3);
       long storageQuotaInByte = 60000; // A small quota, easily violated.
 


### PR DESCRIPTION
For many real-time only stores, it is quite common to schedule an empty push to deprecate the stale entries.
This code change adds the dict compression support for the empty push to the hybrid stores.

In the meantime, this code change also fixes a bug in the existing KIF dict compression support, and it will decompress the payload in the source topic if the compression is enabled.

<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci], [server], [controller],
[router], [samza], [vpj], [fast-client], [thin-client], [alpini],
[admin-tool], [test], [build], [doc], [script]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->


<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->


## How was this PR tested?
CI
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.