### PR TITLE
[server] Isolated ingestion server should resume LEADER state when restarting forked ingestion process upon crash

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/IsolatedIngestionBackend.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/IsolatedIngestionBackend.java
@@ -291,6 +291,13 @@ public class IsolatedIngestionBackend extends DefaultIngestionBackend
         return;
       }
       LOGGER.info("Sending command {} of topic: {}, partition: {} to fork process.", command, topicName, partition);
+      try {
+        // Make sure forked process is not going through restart process.
+        getMainIngestionMonitorService().getForkProcessActionLatch().await();
+      } catch (InterruptedException e) {
+        LOGGER.warn("Waiting forked process action latch is interrupted.", e);
+        Thread.currentThread().interrupt();
+      }
       if (command.equals(START_CONSUMPTION)) {
         /**
          * StartConsumption operation may take long time to wait for non-existence store/version until it times out.

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/main/MainIngestionMonitorService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/main/MainIngestionMonitorService.java
@@ -77,7 +77,11 @@ public class MainIngestionMonitorService extends AbstractVeniceService {
   private long connectionTimeoutMs;
   private volatile long latestHeartbeatTimestamp = -1;
 
-  private final ReentrantReadWriteLock forkProcessLeaderStateActionLock = new ReentrantReadWriteLock();
+  /**
+   * This RW lock is introduced to make sure when forked process crashes and restarts, it will first resume all ongoing
+   * ingestion and restore LEADER replica status correctly, before accepting any new Helix topic partition state transition.
+   */
+  private final ReentrantReadWriteLock forkProcessActionLock = new ReentrantReadWriteLock();
 
   public MainIngestionMonitorService(IsolatedIngestionBackend ingestionBackend, VeniceConfigLoader configLoader) {
     this.configLoader = configLoader;
@@ -374,7 +378,7 @@ public class MainIngestionMonitorService extends AbstractVeniceService {
   }
 
   public ReentrantReadWriteLock getForkProcessActionLock() {
-    return forkProcessLeaderStateActionLock;
+    return forkProcessActionLock;
   }
 
 }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/ingestion/IsolatedIngestionBackendTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/ingestion/IsolatedIngestionBackendTest.java
@@ -24,6 +24,7 @@ import com.linkedin.venice.utils.Pair;
 import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.Supplier;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -55,12 +56,14 @@ public class IsolatedIngestionBackendTest {
       Runnable localCommandRunnable = () -> executionFlag.set(-1);
 
       Map<String, MainTopicIngestionStatus> topicIngestionStatusMap = new VeniceConcurrentHashMap<>();
+      ReentrantReadWriteLock readWriteLock = new ReentrantReadWriteLock();
       doCallRealMethod().when(monitorService).cleanupTopicPartitionState(topic, partition);
       doCallRealMethod().when(monitorService).setVersionPartitionToLocalIngestion(topic, partition);
       doCallRealMethod().when(monitorService).setVersionPartitionToIsolatedIngestion(topic, partition);
       when(monitorService.getTopicPartitionIngestionStatus(topic, partition)).thenCallRealMethod();
 
       when(monitorService.getTopicIngestionStatusMap()).thenReturn(topicIngestionStatusMap);
+      when(monitorService.getForkProcessActionLock()).thenReturn(readWriteLock);
 
       // Resource does not exist. Consumption request should be executed in remote.
       executionFlag.set(0);
@@ -115,9 +118,11 @@ public class IsolatedIngestionBackendTest {
       Runnable localCommandRunnable = () -> executionFlag.set(-1);
 
       Map<String, MainTopicIngestionStatus> topicIngestionStatusMap = new VeniceConcurrentHashMap<>();
+      ReentrantReadWriteLock readWriteLock = new ReentrantReadWriteLock();
       doCallRealMethod().when(monitorService).cleanupTopicPartitionState(topic, partition);
       when(monitorService.getTopicPartitionIngestionStatus(topic, partition)).thenCallRealMethod();
       when(monitorService.getTopicIngestionStatusMap()).thenReturn(topicIngestionStatusMap);
+      when(monitorService.getForkProcessActionLock()).thenReturn(readWriteLock);
 
       /**
        * Test Case (1): Resource metadata in-sync: Expect resource in forked process but found in main process.

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/ingestion/main/MainIngestionMonitorServiceTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/ingestion/main/MainIngestionMonitorServiceTest.java
@@ -11,8 +11,7 @@ import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
 import java.util.Collections;
 import java.util.Map;
-import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReentrantLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -43,11 +42,11 @@ public class MainIngestionMonitorServiceTest {
     when(monitorService.getTopicIngestionStatusMap()).thenReturn(topicIngestionStatusMap);
     when(monitorService.getTopicPartitionLeaderStatusMap()).thenReturn(topicPartitionLeaderStatusMap);
 
-    Lock lock = new ReentrantLock();
+    ReentrantReadWriteLock readWriteLock = new ReentrantReadWriteLock();
     when(monitorService.createClient()).thenReturn(client);
     when(monitorService.resumeOngoingIngestionTasks()).thenCallRealMethod();
     when(monitorService.isTopicPartitionInLeaderState(anyString(), anyInt())).thenCallRealMethod();
-    when(monitorService.getForkProcessLeaderStateActionLock()).thenReturn(lock);
+    when(monitorService.getForkProcessActionLock()).thenReturn(readWriteLock);
     Assert.assertTrue(monitorService.isTopicPartitionInLeaderState(topic, 3));
     Assert.assertEquals(monitorService.resumeOngoingIngestionTasks(), 2);
     verify(client, times(0)).promoteToLeader(topic, 2);

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/ingestion/main/MainIngestionMonitorServiceTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/ingestion/main/MainIngestionMonitorServiceTest.java
@@ -1,10 +1,15 @@
 package com.linkedin.davinci.ingestion.main;
 
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
+import java.util.Collections;
 import java.util.Map;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -21,7 +26,8 @@ public class MainIngestionMonitorServiceTest {
     mainTopicIngestionStatus.setPartitionIngestionStatusToIsolatedIngestion(2);
     mainTopicIngestionStatus.setPartitionIngestionStatusToIsolatedIngestion(3);
     topicIngestionStatusMap.put(topic, mainTopicIngestionStatus);
-
+    Map<String, Map<Integer, Boolean>> topicPartitionLeaderStatusMap = new VeniceConcurrentHashMap<>();
+    topicPartitionLeaderStatusMap.put(topic, Collections.singletonMap(3, Boolean.TRUE));
     MainIngestionRequestClient client = mock(MainIngestionRequestClient.class);
     when(client.startConsumption(topic, 0))
         .thenThrow(new VeniceException("Not expected to start remote consumption on local resource"));
@@ -29,12 +35,19 @@ public class MainIngestionMonitorServiceTest {
         .thenThrow(new VeniceException("Simulate zombie resource ingestion failure"));
     when(client.startConsumption(topic, 2)).thenReturn(Boolean.TRUE);
     when(client.startConsumption(topic, 3)).thenReturn(Boolean.TRUE);
+    when(client.promoteToLeader(topic, 3)).thenReturn(Boolean.TRUE);
 
     MainIngestionMonitorService monitorService = mock(MainIngestionMonitorService.class);
     when(monitorService.getTopicIngestionStatusMap()).thenReturn(topicIngestionStatusMap);
+    when(monitorService.getTopicPartitionLeaderStatusMap()).thenReturn(topicPartitionLeaderStatusMap);
+
     when(monitorService.createClient()).thenReturn(client);
     when(monitorService.resumeOngoingIngestionTasks()).thenCallRealMethod();
+    when(monitorService.isTopicPartitionInLeaderState(anyString(), anyInt())).thenCallRealMethod();
+    Assert.assertTrue(monitorService.isTopicPartitionInLeaderState(topic, 3));
     Assert.assertEquals(monitorService.resumeOngoingIngestionTasks(), 2);
+    verify(client, times(0)).promoteToLeader(topic, 2);
+    verify(client, times(1)).promoteToLeader(topic, 3);
 
   }
 }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/ingestion/main/MainIngestionMonitorServiceTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/ingestion/main/MainIngestionMonitorServiceTest.java
@@ -11,6 +11,8 @@ import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
 import java.util.Collections;
 import java.util.Map;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -41,9 +43,11 @@ public class MainIngestionMonitorServiceTest {
     when(monitorService.getTopicIngestionStatusMap()).thenReturn(topicIngestionStatusMap);
     when(monitorService.getTopicPartitionLeaderStatusMap()).thenReturn(topicPartitionLeaderStatusMap);
 
+    Lock lock = new ReentrantLock();
     when(monitorService.createClient()).thenReturn(client);
     when(monitorService.resumeOngoingIngestionTasks()).thenCallRealMethod();
     when(monitorService.isTopicPartitionInLeaderState(anyString(), anyInt())).thenCallRealMethod();
+    when(monitorService.getForkProcessLeaderStateActionLock()).thenReturn(lock);
     Assert.assertTrue(monitorService.isTopicPartitionInLeaderState(topic, 3));
     Assert.assertEquals(monitorService.resumeOngoingIngestionTasks(), 2);
     verify(client, times(0)).promoteToLeader(topic, 2);


### PR DESCRIPTION

<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci], [server], [controller],
[router], [samza], [vpj], [fast-client], [thin-client], [alpini],
[admin-tool], [test], [build], [doc], [script]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## [server] Isolated ingestion server should resume LEADER state when restarting forked ingestion process upon crash
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

When isolated ingestion process crash, we do have detection and restart mechanism but we do not keep leader status so when resuming ongoing TP ingestion, we will not resume the LEADER partition replica state correctly and LEADER partition could stuck forever.
This PR fixes it by keeping track of the LEADER status and resend STANDBY->LEADER for those LEADER replicas during restart of the forked process. No matter it was in LEADER or in transition to LEADER, this message will let it go through the promotion so it could become LEADER again.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
Add new logic to cover resume ongoing ingestion logic unit test.

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.