### PR TITLE
[server] For dot-product/hadamard prodcut unroll by 8 for better performance

### DIFF
--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/compute/ComputeOperationUtils.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/compute/ComputeOperationUtils.java
@@ -51,19 +51,23 @@ public class ComputeOperationUtils {
   private static float dotProduct(int size, FloatSupplierByIndex floatSupplier1, FloatSupplierByIndex floatSupplier2) {
     float dotProductResult = 0.0f;
 
-    // round up size to the largest multiple of 4
+    // round up size to the largest multiple of 8
     int i = 0;
-    int limit = (size >> 2) << 2;
+    int limit = (size >> 3) << 3;
 
     // Unrolling mult-add into blocks of 4 multiply op and assign to 4 different variables so that CPU can take
     // advantage of out of order execution, making the operation faster (on a single thread ~2x improvement)
-    for (; i < limit; i += 4) {
+    for (; i < limit; i += 8) {
       float s0 = floatSupplier1.get(i) * floatSupplier2.get(i);
       float s1 = floatSupplier1.get(i + 1) * floatSupplier2.get(i + 1);
       float s2 = floatSupplier1.get(i + 2) * floatSupplier2.get(i + 2);
       float s3 = floatSupplier1.get(i + 3) * floatSupplier2.get(i + 3);
+      float s4 = floatSupplier1.get(i + 4) * floatSupplier2.get(i + 4);
+      float s5 = floatSupplier1.get(i + 5) * floatSupplier2.get(i + 5);
+      float s6 = floatSupplier1.get(i + 6) * floatSupplier2.get(i + 6);
+      float s7 = floatSupplier1.get(i + 7) * floatSupplier2.get(i + 7);
 
-      dotProductResult += (s0 + s1 + s2 + s3);
+      dotProductResult += (s0 + s1 + s2 + s3 + s4 + s5 + s6 + s7);
     }
 
     // Multiply the remaining elements
@@ -79,17 +83,21 @@ public class ComputeOperationUtils {
       FloatSupplierByIndex floatSupplier2) {
     float[] floats = new float[size];
 
-    // round up size to the largest multiple of 4
+    // round up size to the largest multiple of 8
     int i = 0;
-    int limit = (size >> 2) << 2;
+    int limit = (size >> 3) << 3;
 
     // Unrolling mult-add into blocks of 4 multiply op and assign to 4 different variables so that CPU can take
     // advantage of out of order execution, making the operation faster (on a single thread ~2x improvement)
-    for (; i < limit; i += 4) {
+    for (; i < limit; i += 8) {
       floats[i] = floatSupplier1.get(i) * floatSupplier2.get(i);
       floats[i + 1] = floatSupplier1.get(i + 1) * floatSupplier2.get(i + 1);
       floats[i + 2] = floatSupplier1.get(i + 2) * floatSupplier2.get(i + 2);
       floats[i + 3] = floatSupplier1.get(i + 3) * floatSupplier2.get(i + 3);
+      floats[i + 4] = floatSupplier1.get(i + 4) * floatSupplier2.get(i + 4);
+      floats[i + 5] = floatSupplier1.get(i + 5) * floatSupplier2.get(i + 5);
+      floats[i + 6] = floatSupplier1.get(i + 6) * floatSupplier2.get(i + 6);
+      floats[i + 7] = floatSupplier1.get(i + 7) * floatSupplier2.get(i + 7);
     }
 
     // Multiply the remaining elements


### PR DESCRIPTION
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

For dot-product/hadamard prodcut implement unroll by 8 for better performance. If we increase the unroll depth to 8, we see the following in a benchmark

Unroll 8
Benchmark                                                                    Mode  Cnt       Score       Error   Units
VeniceClientBenchmark.runAvroClientQueries                                   avgt    6  744557.109 ± 73220.617   ns/op
VeniceClientBenchmark.runAvroClientQueries:·gc.alloc.rate                    avgt    6     175.057 ±   135.780  MB/sec
VeniceClientBenchmark.runAvroClientQueries:·gc.alloc.rate.norm               avgt    6  170485.908 ± 11066.579    B/op
VeniceClientBenchmark.runAvroClientQueries:·gc.churn.PS_Eden_Space           avgt    6     185.603 ±   135.839  MB/sec
VeniceClientBenchmark.runAvroClientQueries:·gc.churn.PS_Eden_Space.norm      avgt    6  181543.753 ± 14182.641    B/op
VeniceClientBenchmark.runAvroClientQueries:·gc.churn.PS_Survivor_Space       avgt    6       0.010 ±     0.056  MB/sec
VeniceClientBenchmark.runAvroClientQueries:·gc.churn.PS_Survivor_Space.norm  avgt    6      13.308 ±    80.986    B/op
VeniceClientBenchmark.runAvroClientQueries:·gc.count                         avgt    6      12.000              counts
VeniceClientBenchmark.runAvroClientQueries:·gc.time                          avgt    6     118.000                  ms


Unroll 4
Benchmark                                                                    Mode  Cnt       Score       Error   Units
VeniceClientBenchmark.runAvroClientQueries                                   avgt    6  772569.740 ± 48214.391   ns/op
VeniceClientBenchmark.runAvroClientQueries:·gc.alloc.rate                    avgt    6     176.597 ±   137.740  MB/sec
VeniceClientBenchmark.runAvroClientQueries:·gc.alloc.rate.norm               avgt    6  175266.361 ± 11654.945    B/op
VeniceClientBenchmark.runAvroClientQueries:·gc.churn.PS_Eden_Space           avgt    6     184.524 ±   129.406  MB/sec
VeniceClientBenchmark.runAvroClientQueries:·gc.churn.PS_Eden_Space.norm      avgt    6  184566.700 ± 11537.068    B/op
VeniceClientBenchmark.runAvroClientQueries:·gc.churn.PS_Survivor_Space       avgt    6       0.049 ±     0.191  MB/sec
VeniceClientBenchmark.runAvroClientQueries:·gc.churn.PS_Survivor_Space.norm  avgt    6      53.521 ±   171.639    B/op
VeniceClientBenchmark.runAvroClientQueries:·gc.count                         avgt    6      12.000              counts
VeniceClientBenchmark.runAvroClientQueries:·gc.time                          avgt    6      97.000                  ms

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
CI
## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.