### PR TITLE
[server] Make A/A + partial update store always use field-level timestamp

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
@@ -130,7 +130,11 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
 
     this.rmdSerDe = new RmdSerDe(annotatedReadOnlySchemaRepository, rmdProtocolVersionID);
     this.mergeConflictResolver = MergeConflictResolverFactory.getInstance()
-        .createMergeConflictResolver(annotatedReadOnlySchemaRepository, rmdSerDe, getStoreName());
+        .createMergeConflictResolver(
+            annotatedReadOnlySchemaRepository,
+            rmdSerDe,
+            getStoreName(),
+            isWriteComputationEnabled);
     this.remoteIngestionRepairService = builder.getRemoteIngestionRepairService();
   }
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/replication/RmdWithValueSchemaId.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/replication/RmdWithValueSchemaId.java
@@ -11,8 +11,7 @@ import org.apache.avro.generic.GenericRecord;
  */
 public class RmdWithValueSchemaId {
   private final int valueSchemaID;
-  private final int rmdProtocolVersionID; // Note that it is NOT RMD schema ID which should have the format
-                                          // "<valueSchemaId>-<rmdProtocolVersionID>"
+  private final int rmdProtocolVersionID;
   private final GenericRecord rmdRecord;
 
   public RmdWithValueSchemaId(int valueSchemaID, int rmdProtocolVersionID, GenericRecord rmdRecord) {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/replication/merge/MergeConflictResolver.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/replication/merge/MergeConflictResolver.java
@@ -130,17 +130,16 @@ public class MergeConflictResolver {
           newValueSourceOffset,
           newValueSourceBrokerID,
           newValueSchemaID);
-    } else {
-      return mergePutWithValueLevelTimestamp(
-          oldValueBytesProvider,
-          oldRmdRecord,
-          putOperationTimestamp,
-          newValueBytes,
-          newValueColoID,
-          newValueSourceOffset,
-          newValueSourceBrokerID,
-          newValueSchemaID);
     }
+    return mergePutWithValueLevelTimestamp(
+        oldValueBytesProvider,
+        oldRmdRecord,
+        putOperationTimestamp,
+        newValueBytes,
+        newValueColoID,
+        newValueSourceOffset,
+        newValueSourceBrokerID,
+        newValueSchemaID);
   }
 
   /**
@@ -192,15 +191,14 @@ public class MergeConflictResolver {
           deleteOperationTimestamp,
           deleteOperationSourceOffset,
           deleteOperationSourceBrokerID);
-    } else {
-      return mergeDeleteWithValueLevelTimestamp(
-          oldValueSchemaID,
-          oldRmdRecord,
-          deleteOperationColoID,
-          deleteOperationTimestamp,
-          deleteOperationSourceOffset,
-          deleteOperationSourceBrokerID);
     }
+    return mergeDeleteWithValueLevelTimestamp(
+        oldValueSchemaID,
+        oldRmdRecord,
+        deleteOperationColoID,
+        deleteOperationTimestamp,
+        deleteOperationSourceOffset,
+        deleteOperationSourceBrokerID);
   }
 
   public MergeConflictResult update(

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/replication/merge/MergeConflictResolverFactory.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/replication/merge/MergeConflictResolverFactory.java
@@ -20,7 +20,8 @@ public class MergeConflictResolverFactory {
   public MergeConflictResolver createMergeConflictResolver(
       StringAnnotatedStoreSchemaCache annotatedReadOnlySchemaRepository,
       RmdSerDe rmdSerDe,
-      String storeName) {
+      String storeName,
+      boolean rmdUseFieldLevelTs) {
     MergeRecordHelper mergeRecordHelper = new CollectionTimestampMergeRecordHelper();
     return new MergeConflictResolver(
         annotatedReadOnlySchemaRepository,
@@ -29,6 +30,14 @@ public class MergeConflictResolverFactory {
         new MergeGenericRecord(new WriteComputeProcessor(mergeRecordHelper), mergeRecordHelper),
         new MergeByteBuffer(),
         new MergeResultValueSchemaResolverImpl(annotatedReadOnlySchemaRepository, storeName),
-        rmdSerDe);
+        rmdSerDe,
+        rmdUseFieldLevelTs);
+  }
+
+  public MergeConflictResolver createMergeConflictResolver(
+      StringAnnotatedStoreSchemaCache annotatedReadOnlySchemaRepository,
+      RmdSerDe rmdSerDe,
+      String storeName) {
+    return createMergeConflictResolver(annotatedReadOnlySchemaRepository, rmdSerDe, storeName, false);
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/replication/merge/MergeGenericRecord.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/replication/merge/MergeGenericRecord.java
@@ -118,7 +118,6 @@ public class MergeGenericRecord extends AbstractMerge<GenericRecord> {
     updateReplicationCheckpointVector(oldReplicationMetadata, sourceOffsetOfNewValue, newValueSourceBrokerID);
 
     List<Schema.Field> fieldsInNewRecord = newValue.getSchema().getFields();
-    boolean allFieldsNew = true;
     boolean noFieldUpdated = true;
     // Iterate fields in the new record because old record fields set must be a superset of the new record fields set.
     for (Schema.Field newRecordField: fieldsInNewRecord) {
@@ -130,11 +129,7 @@ public class MergeGenericRecord extends AbstractMerge<GenericRecord> {
           newValue.get(fieldName),
           putOperationTimestamp,
           putOperationColoID);
-      allFieldsNew &= (fieldUpdateResult == UpdateResultStatus.COMPLETELY_UPDATED);
       noFieldUpdated &= (fieldUpdateResult == UpdateResultStatus.NOT_UPDATED_AT_ALL);
-    }
-    if (allFieldsNew) {
-      oldReplicationMetadata.put(TIMESTAMP_FIELD_NAME, putOperationTimestamp);
     }
     if (noFieldUpdated) {
       oldValueAndRmd.setUpdateIgnored(true);
@@ -179,7 +174,7 @@ public class MergeGenericRecord extends AbstractMerge<GenericRecord> {
         if (recordDeleteResultStatus == UpdateResultStatus.COMPLETELY_UPDATED) {
           // Full delete
           oldValueAndRmd.setValue(null);
-          oldReplicationMetadata.put(TIMESTAMP_FIELD_NAME, deleteOperationTimestamp);
+          // oldReplicationMetadata.put(TIMESTAMP_FIELD_NAME, deleteOperationTimestamp);
         } else if (recordDeleteResultStatus == UpdateResultStatus.NOT_UPDATED_AT_ALL) {
           oldValueAndRmd.setUpdateIgnored(true);
         }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/replication/merge/MergeGenericRecord.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/replication/merge/MergeGenericRecord.java
@@ -174,7 +174,6 @@ public class MergeGenericRecord extends AbstractMerge<GenericRecord> {
         if (recordDeleteResultStatus == UpdateResultStatus.COMPLETELY_UPDATED) {
           // Full delete
           oldValueAndRmd.setValue(null);
-          // oldReplicationMetadata.put(TIMESTAMP_FIELD_NAME, deleteOperationTimestamp);
         } else if (recordDeleteResultStatus == UpdateResultStatus.NOT_UPDATED_AT_ALL) {
           oldValueAndRmd.setUpdateIgnored(true);
         }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/replication/merge/TestMergeDelete.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/replication/merge/TestMergeDelete.java
@@ -3,6 +3,7 @@ package com.linkedin.davinci.replication.merge;
 import static com.linkedin.davinci.replication.merge.TestMergeConflictResolver.RMD_VERSION_ID;
 import static com.linkedin.venice.schema.rmd.v1.CollectionRmdTimestamp.ACTIVE_ELEM_TS_FIELD_NAME;
 import static com.linkedin.venice.schema.rmd.v1.CollectionRmdTimestamp.PUT_ONLY_PART_LENGTH_FIELD_NAME;
+import static com.linkedin.venice.schema.rmd.v1.CollectionRmdTimestamp.TOP_LEVEL_COLO_ID_FIELD_NAME;
 import static com.linkedin.venice.schema.rmd.v1.CollectionRmdTimestamp.TOP_LEVEL_TS_FIELD_NAME;
 
 import com.linkedin.davinci.replication.RmdWithValueSchemaId;
@@ -53,7 +54,18 @@ public class TestMergeDelete extends TestMergeBase {
 
     Assert.assertFalse(result.isUpdateIgnored());
     Assert.assertNull(result.getNewValue());
-    Assert.assertEquals(result.getRmdRecord().get(RmdConstants.TIMESTAMP_FIELD_NAME), 2L);
+    GenericRecord rmdTimestampRecord = (GenericRecord) result.getRmdRecord().get(RmdConstants.TIMESTAMP_FIELD_NAME);
+    Assert.assertEquals(rmdTimestampRecord.get(REGULAR_FIELD_NAME), 2L);
+    Assert.assertEquals(((GenericRecord) rmdTimestampRecord.get(INT_MAP_FIELD_NAME)).get(TOP_LEVEL_TS_FIELD_NAME), 2L);
+    Assert.assertEquals(
+        ((GenericRecord) rmdTimestampRecord.get(INT_MAP_FIELD_NAME)).get(TOP_LEVEL_COLO_ID_FIELD_NAME),
+        0);
+    Assert.assertEquals(
+        ((GenericRecord) rmdTimestampRecord.get(STRING_ARRAY_FIELD_NAME)).get(TOP_LEVEL_TS_FIELD_NAME),
+        2L);
+    Assert.assertEquals(
+        ((GenericRecord) rmdTimestampRecord.get(STRING_ARRAY_FIELD_NAME)).get(TOP_LEVEL_COLO_ID_FIELD_NAME),
+        0);
   }
 
   /**

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/replication/merge/TestMergeDeleteWithFieldLevelTimestamp.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/replication/merge/TestMergeDeleteWithFieldLevelTimestamp.java
@@ -115,8 +115,11 @@ public class TestMergeDeleteWithFieldLevelTimestamp extends TestMergeConflictRes
     updatedRmd = result.getRmdRecord();
     Object timestampObj = updatedRmd.get(TIMESTAMP_FIELD_NAME);
     // Because all fields are deleted. Timestamp should be converted to be a value-level timestamp.
-    Assert.assertTrue(timestampObj instanceof Long);
-    Assert.assertEquals((long) timestampObj, 99L);
+    Assert.assertTrue(timestampObj instanceof GenericRecord);
+    GenericRecord timestampRecord = (GenericRecord) timestampObj;
+    Assert.assertEquals(timestampRecord.get("id"), 99L);
+    Assert.assertEquals(timestampRecord.get("name"), 99L);
+    Assert.assertEquals(timestampRecord.get("age"), 99L);
 
     // Because all fields being deleted is equivalent to the whole value record being deleted.
     updatedValueOptional = result.getNewValue();

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/replication/merge/TestMergePut.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/replication/merge/TestMergePut.java
@@ -3,6 +3,7 @@ package com.linkedin.davinci.replication.merge;
 import static com.linkedin.davinci.replication.merge.TestMergeConflictResolver.RMD_VERSION_ID;
 import static com.linkedin.venice.schema.rmd.v1.CollectionRmdTimestamp.ACTIVE_ELEM_TS_FIELD_NAME;
 import static com.linkedin.venice.schema.rmd.v1.CollectionRmdTimestamp.PUT_ONLY_PART_LENGTH_FIELD_NAME;
+import static com.linkedin.venice.schema.rmd.v1.CollectionRmdTimestamp.TOP_LEVEL_COLO_ID_FIELD_NAME;
 import static com.linkedin.venice.schema.rmd.v1.CollectionRmdTimestamp.TOP_LEVEL_TS_FIELD_NAME;
 
 import com.linkedin.davinci.replication.RmdWithValueSchemaId;
@@ -55,7 +56,18 @@ public class TestMergePut extends TestMergeBase {
     Assert.assertEquals(updatedValueRecord.get(REGULAR_FIELD_NAME).toString(), "newString");
     Assert.assertEquals(updatedValueRecord.get(INT_MAP_FIELD_NAME), Collections.singletonMap(new Utf8("key1"), 1));
     Assert.assertEquals(updatedValueRecord.get(STRING_ARRAY_FIELD_NAME), Collections.singletonList(new Utf8("item1")));
-    Assert.assertEquals(result.getRmdRecord().get(RmdConstants.TIMESTAMP_FIELD_NAME), 1L);
+    GenericRecord rmdTimestampRecord = (GenericRecord) result.getRmdRecord().get(RmdConstants.TIMESTAMP_FIELD_NAME);
+    Assert.assertEquals(rmdTimestampRecord.get(REGULAR_FIELD_NAME), 1L);
+    Assert.assertEquals(((GenericRecord) rmdTimestampRecord.get(INT_MAP_FIELD_NAME)).get(TOP_LEVEL_TS_FIELD_NAME), 1L);
+    Assert.assertEquals(
+        ((GenericRecord) rmdTimestampRecord.get(INT_MAP_FIELD_NAME)).get(TOP_LEVEL_COLO_ID_FIELD_NAME),
+        0);
+    Assert.assertEquals(
+        ((GenericRecord) rmdTimestampRecord.get(STRING_ARRAY_FIELD_NAME)).get(TOP_LEVEL_TS_FIELD_NAME),
+        1L);
+    Assert.assertEquals(
+        ((GenericRecord) rmdTimestampRecord.get(STRING_ARRAY_FIELD_NAME)).get(TOP_LEVEL_COLO_ID_FIELD_NAME),
+        0);
   }
 
   /**

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/schema/rmd/RmdUtils.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/schema/rmd/RmdUtils.java
@@ -46,7 +46,6 @@ public class RmdUtils {
    * Returns the type of union record given tsObject is. Right now it will be either root level long or
    * generic record of per field timestamp.
    * @param tsObject
-   * @return
    */
   public static RmdTimestampType getRmdTimestampType(Object tsObject) {
     if (tsObject instanceof Long) {

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/schema/writecompute/WriteComputeHandlerV2.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/schema/writecompute/WriteComputeHandlerV2.java
@@ -52,8 +52,6 @@ public class WriteComputeHandlerV2 extends WriteComputeHandlerV1 {
       currRecordAndRmd.setValue(SchemaUtils.createGenericRecord(currValueSchema));
     }
 
-    // TODO: RMD could be null or not have per-field timestamp. Caller of this method will handle these cases and ensure
-    // that RMD here does have per-field timestamp.
     Object timestampObject = currRecordAndRmd.getRmd().get(TIMESTAMP_FIELD_NAME);
     if (!(timestampObject instanceof GenericRecord)) {
       throw new IllegalStateException(

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/PartialUpdateTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/PartialUpdateTest.java
@@ -313,7 +313,7 @@ public class PartialUpdateTest {
         GenericRecord timestampRecord =
             (GenericRecord) rmdWithValueSchemaId.getRmdRecord().get(RmdConstants.TIMESTAMP_FIELD_NAME);
         GenericRecord stringMapTimestampRecord = (GenericRecord) timestampRecord.get("stringMap");
-        assertEquals(stringMapTimestampRecord.get(TOP_LEVEL_TS_FIELD_NAME), (long) (updateCount * 10));
+        assertEquals(stringMapTimestampRecord.get(TOP_LEVEL_TS_FIELD_NAME), (long) (updateCount) * 10);
       });
     } finally {
       veniceProducer.stop();


### PR DESCRIPTION
## [server] Make A/A + partial update store always use field-level timestamp
Mix use of value-level TS and field-level TS will result in race condition and result could be different when there are two PUT/UPDATE setField operations competing with each other.

This PR fixes the issue by making sure we always use field-level TS in A/A + WC store. When it sees a value level TS during RMD record initialization it will convert it to field level TS upon PUT/DELETE operation and will never collapse the field-level back to value-level.
Also, since WC flag is a store level flag, this PR also adds safeguard to existing version that has WC = false: when it sees its TS is field-level (due to UPDATE operation), it will still handle it correctly. (Ideally this version should be deprecated)

**Note for reviewer**: For changes in MergeConflictResolver, I only changed logic in put() and delete(), other part are just moving public method together, no actual code change.
## How was this PR tested?
Adjust unit test to make sure full PUT/DELETE won't reset timestamp record to value-level TS
## Does this PR introduce any user-facing changes?
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.