### PR TITLE
[samza] Use FastSerializerDeserializerFactory to fetch schema on cache when creating UpdateBuilderImpl

### DIFF
--- a/internal/venice-common/src/main/java/com/linkedin/venice/writer/update/UpdateBuilderImpl.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/writer/update/UpdateBuilderImpl.java
@@ -4,7 +4,8 @@ import com.linkedin.venice.annotation.Experimental;
 import com.linkedin.venice.annotation.NotThreadsafe;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.schema.writecompute.WriteComputeConstants;
-import com.linkedin.venice.serializer.AvroSerializer;
+import com.linkedin.venice.serializer.RecordSerializer;
+import com.linkedin.venice.serializer.SerializerDeserializerFactory;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -21,7 +22,7 @@ import org.apache.commons.lang3.Validate;
 @Experimental
 public class UpdateBuilderImpl implements UpdateBuilder {
   private final GenericRecord updateRecord;
-  private final AvroSerializer<GenericRecord> serializer;
+  private final RecordSerializer<GenericRecord> serializer;
   private final Set<String> updateFieldNameSet;
   private final Set<String> collectionMergeFieldNameSet;
 
@@ -31,7 +32,7 @@ public class UpdateBuilderImpl implements UpdateBuilder {
   public UpdateBuilderImpl(Schema updateSchema) {
     validateUpdateSchema(updateSchema);
     this.updateRecord = new GenericData.Record(updateSchema);
-    this.serializer = new AvroSerializer<>(updateSchema);
+    this.serializer = SerializerDeserializerFactory.getAvroGenericSerializer(updateSchema);
     this.updateFieldNameSet = new HashSet<>();
     this.collectionMergeFieldNameSet = new HashSet<>();
   }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/writer/update/UpdateBuilderImpl.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/writer/update/UpdateBuilderImpl.java
@@ -4,8 +4,8 @@ import com.linkedin.venice.annotation.Experimental;
 import com.linkedin.venice.annotation.NotThreadsafe;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.schema.writecompute.WriteComputeConstants;
+import com.linkedin.venice.serializer.FastSerializerDeserializerFactory;
 import com.linkedin.venice.serializer.RecordSerializer;
-import com.linkedin.venice.serializer.SerializerDeserializerFactory;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -32,7 +32,7 @@ public class UpdateBuilderImpl implements UpdateBuilder {
   public UpdateBuilderImpl(Schema updateSchema) {
     validateUpdateSchema(updateSchema);
     this.updateRecord = new GenericData.Record(updateSchema);
-    this.serializer = SerializerDeserializerFactory.getAvroGenericSerializer(updateSchema);
+    this.serializer = FastSerializerDeserializerFactory.getAvroGenericSerializer(updateSchema);
     this.updateFieldNameSet = new HashSet<>();
     this.collectionMergeFieldNameSet = new HashSet<>();
   }


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci], [server], [controller],
[router], [samza], [vpj], [fast-client], [thin-client], [alpini],
[admin-tool], [test], [build], [doc], [script]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## [samza] Use FastSerializerDeserializerFactory to fetch schema on cache when creating UpdateBuilderImpl
This PR improves UpdateBuilderImpl by using SerializerDeserializerFactory to create serializer, so it should create one serializer per schema and reuse it per container instance. 
## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.