### PR TITLE
[router] Implement per store quota in router

### DIFF
--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -819,6 +819,11 @@ public class ConfigKeys {
   public static final String ROUTER_MAX_OUTGOING_CONNECTION = "router.max.outgoing.connection";
 
   /**
+   * Enable per router per storage node throttler by distributing the store quota among the partitions and replicas.
+   */
+  public static final String ROUTER_PER_STORAGE_NODE_THROTTLER_ENABLED = "router.per.storage.node.throttler.enabled";
+
+  /**
    * This config is used to bound the pending request.
    * Without this config, the accumulated requests in Http Async Client could grow unlimitedly,
    * which would put Router in a non-recoverable state because of long GC pause introduced
@@ -852,11 +857,7 @@ public class ConfigKeys {
    */
   public static final String ROUTER_PER_STORAGE_NODE_READ_QUOTA_BUFFER = "router.per.storage.node.read.quota.buffer";
 
-  /**
-   * The TTL for each entry in router cache (millisecond)
-   * If 0, TTL is not enabled; other, cache TTL is enabled
-   */
-  public static final String ROUTER_CACHE_TTL_MILLIS = "router.cache.ttl.millis";
+  public static final String ROUTER_PER_STORE_ROUTER_QUOTA_BUFFER = "router.per.store.router.quota.buffer";
 
   /**
    * Whether to enable customized dns cache in router or not.

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/router/TestRead.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/router/TestRead.java
@@ -152,6 +152,7 @@ public abstract class TestRead {
     extraProperties.put(ConfigKeys.ROUTER_HTTP_CLIENT5_SKIP_CIPHER_CHECK_ENABLED, "true");
     extraProperties.put(ConfigKeys.ROUTER_HTTP2_INBOUND_ENABLED, isRouterHttp2Enabled());
     extraProperties.put(ConfigKeys.SERVER_HTTP2_INBOUND_ENABLED, true);
+    extraProperties.put(ConfigKeys.ROUTER_PER_STORE_ROUTER_QUOTA_BUFFER, 0.0);
 
     veniceCluster = ServiceFactory.getVeniceCluster(1, 1, 1, 2, 100, true, false, extraProperties);
     routerAddr = veniceCluster.getRandomRouterSslURL();

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/RouterServer.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/RouterServer.java
@@ -865,9 +865,8 @@ public class RouterServer extends AbstractVeniceService {
           routersClusterManager,
           metadataRepository,
           routingDataRepository,
-          config.getMaxReadCapacityCu(),
           routerStats.getStatsByType(RequestType.SINGLE_GET),
-          config.getPerStorageNodeReadQuotaBuffer());
+          config);
 
       noopRequestThrottler = new NoopRouterThrottler(
           routersClusterManager,

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/VeniceRouterConfig.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/VeniceRouterConfig.java
@@ -376,7 +376,7 @@ public class VeniceRouterConfig {
      */
     routerIOWorkerCount = props.getInt(ROUTER_IO_WORKER_COUNT, 24);
     perRouterStorageNodeThrottlerEnabled = props.getBoolean(ROUTER_PER_STORAGE_NODE_THROTTLER_ENABLED, true);
-    perStoreRouterQuotaBuffer = props.getDouble(ROUTER_PER_STORE_ROUTER_QUOTA_BUFFER, 3.0);
+    perStoreRouterQuotaBuffer = props.getDouble(ROUTER_PER_STORE_ROUTER_QUOTA_BUFFER, 1.5);
   }
 
   public double getPerStoreRouterQuotaBuffer() {

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/VeniceRouterConfig.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/VeniceRouterConfig.java
@@ -376,7 +376,7 @@ public class VeniceRouterConfig {
      */
     routerIOWorkerCount = props.getInt(ROUTER_IO_WORKER_COUNT, 24);
     perRouterStorageNodeThrottlerEnabled = props.getBoolean(ROUTER_PER_STORAGE_NODE_THROTTLER_ENABLED, true);
-    perStoreRouterQuotaBuffer = props.getDouble(ROUTER_PER_STORE_ROUTER_QUOTA_BUFFER, 5.0);
+    perStoreRouterQuotaBuffer = props.getDouble(ROUTER_PER_STORE_ROUTER_QUOTA_BUFFER, 3.0);
   }
 
   public double getPerStoreRouterQuotaBuffer() {

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/VeniceRouterConfig.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/VeniceRouterConfig.java
@@ -71,6 +71,8 @@ import static com.linkedin.venice.ConfigKeys.ROUTER_PENDING_CONNECTION_RESUME_TH
 import static com.linkedin.venice.ConfigKeys.ROUTER_PER_NODE_CLIENT_ENABLED;
 import static com.linkedin.venice.ConfigKeys.ROUTER_PER_NODE_CLIENT_THREAD_COUNT;
 import static com.linkedin.venice.ConfigKeys.ROUTER_PER_STORAGE_NODE_READ_QUOTA_BUFFER;
+import static com.linkedin.venice.ConfigKeys.ROUTER_PER_STORAGE_NODE_THROTTLER_ENABLED;
+import static com.linkedin.venice.ConfigKeys.ROUTER_PER_STORE_ROUTER_QUOTA_BUFFER;
 import static com.linkedin.venice.ConfigKeys.ROUTER_QUOTA_CHECK_WINDOW;
 import static com.linkedin.venice.ConfigKeys.ROUTER_READ_QUOTA_THROTTLING_LEASE_TIMEOUT_MS;
 import static com.linkedin.venice.ConfigKeys.ROUTER_SINGLEGET_TARDY_LATENCY_MS;
@@ -198,6 +200,8 @@ public class VeniceRouterConfig {
   private boolean metaStoreShadowReadEnabled;
   private boolean unregisterMetricForDeletedStoreEnabled;
   private int routerIOWorkerCount;
+  private boolean perRouterStorageNodeThrottlerEnabled;
+  private double perStoreRouterQuotaBuffer;
 
   public VeniceRouterConfig(VeniceProperties props) {
     try {
@@ -371,6 +375,12 @@ public class VeniceRouterConfig {
      * should consider to use some number, which is proportional to the available cores.
      */
     routerIOWorkerCount = props.getInt(ROUTER_IO_WORKER_COUNT, 24);
+    perRouterStorageNodeThrottlerEnabled = props.getBoolean(ROUTER_PER_STORAGE_NODE_THROTTLER_ENABLED, true);
+    perStoreRouterQuotaBuffer = props.getDouble(ROUTER_PER_STORE_ROUTER_QUOTA_BUFFER, 5.0);
+  }
+
+  public double getPerStoreRouterQuotaBuffer() {
+    return perStoreRouterQuotaBuffer;
   }
 
   public String getClusterName() {
@@ -796,5 +806,9 @@ public class VeniceRouterConfig {
 
   public int getRouterIOWorkerCount() {
     return routerIOWorkerCount;
+  }
+
+  public boolean isPerRouterStorageNodeThrottlerEnabled() {
+    return perRouterStorageNodeThrottlerEnabled;
   }
 }

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/api/VeniceDelegateMode.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/api/VeniceDelegateMode.java
@@ -284,7 +284,7 @@ public class VeniceDelegateMode extends ScatterGatherMode {
           readRequestThrottler.mayThrottleRead(
               storeName,
               keyCount * readRequestThrottler.getReadCapacity(),
-              Optional.of(veniceInstance.getNodeId()));
+              veniceInstance.getNodeId());
         } catch (QuotaExceededException e) {
           /**
            * Exception thrown here won't go through {@link VeniceResponseAggregator}, and DDS lib will return an error response

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/throttle/NoopRouterThrottler.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/throttle/NoopRouterThrottler.java
@@ -7,7 +7,6 @@ import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.StoreDataChangedListener;
 import com.linkedin.venice.router.stats.AggRouterHttpRequestStats;
 import java.util.List;
-import java.util.Optional;
 
 
 public class NoopRouterThrottler
@@ -29,7 +28,7 @@ public class NoopRouterThrottler
   }
 
   @Override
-  public void mayThrottleRead(String storeName, double readCapacityUnit, Optional<String> storageNodeId) {
+  public void mayThrottleRead(String storeName, double readCapacityUnit, String storageNodeId) {
     // noop
   }
 

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/throttle/ReadRequestThrottler.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/throttle/ReadRequestThrottler.java
@@ -215,6 +215,7 @@ public class ReadRequestThrottler implements RouterThrottler, RoutersClusterMana
     Optional<PartitionAssignment> partitionAssignment;
     if (perStorageNodeThrottlerEnabled && routingDataRepository.containsKafkaTopic(topicName)) {
       partitionAssignment = Optional.of(routingDataRepository.getPartitionAssignments(topicName));
+      routingDataRepository.subscribeRoutingDataChange(Version.composeKafkaTopic(storeName, currentVersion), this);
     } else {
       partitionAssignment = Optional.empty();
       LOGGER.warn(
@@ -344,6 +345,7 @@ public class ReadRequestThrottler implements RouterThrottler, RoutersClusterMana
         return;
       }
       stats.recordQuota(storeName, 0);
+      throttler.clearStorageNodesThrottlers();
       routingDataRepository
           .unSubscribeRoutingDataChange(Version.composeKafkaTopic(storeName, throttler.getCurrentVersion()), this);
     });

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/throttle/ReadRequestThrottler.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/throttle/ReadRequestThrottler.java
@@ -15,6 +15,7 @@ import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.StoreDataChangedListener;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.pushmonitor.ReadOnlyPartitionStatus;
+import com.linkedin.venice.router.VeniceRouterConfig;
 import com.linkedin.venice.router.stats.AggRouterHttpRequestStats;
 import com.linkedin.venice.throttle.EventThrottler;
 import java.util.List;
@@ -66,26 +67,29 @@ public class ReadRequestThrottler implements RouterThrottler, RoutersClusterMana
   private final AggRouterHttpRequestStats stats;
 
   private final double perStorageNodeReadQuotaBuffer;
+  private final double perStoreRouterQuotaBuffer;
 
   private final long storeQuotaCheckTimeWindow;
   private final long storageNodeQuotaCheckTimeWindow;
+  private final boolean perStorageNodeThrottlerEnabled;
 
   public ReadRequestThrottler(
       ZkRoutersClusterManager zkRoutersManager,
       ReadOnlyStoreRepository storeRepository,
       RoutingDataRepository routingDataRepository,
-      long maxRouterReadCapacity,
       AggRouterHttpRequestStats stats,
-      double perStorageNodeReadQuotaBuffer) {
+      VeniceRouterConfig routerConfig) {
     this(
         zkRoutersManager,
         storeRepository,
         routingDataRepository,
-        maxRouterReadCapacity,
+        routerConfig.getMaxReadCapacityCu(),
         stats,
-        perStorageNodeReadQuotaBuffer,
+        routerConfig.getPerStorageNodeReadQuotaBuffer(),
+        routerConfig.getPerStoreRouterQuotaBuffer(),
         DEFAULT_STORE_QUOTA_TIME_WINDOW,
-        DEFAULT_STORAGE_NODE_QUOTA_TIME_WINDOW);
+        DEFAULT_STORAGE_NODE_QUOTA_TIME_WINDOW,
+        routerConfig.isPerRouterStorageNodeThrottlerEnabled());
   }
 
   public ReadRequestThrottler(
@@ -95,8 +99,10 @@ public class ReadRequestThrottler implements RouterThrottler, RoutersClusterMana
       long maxRouterReadCapacity,
       AggRouterHttpRequestStats stats,
       double perStorageNodeReadQuotaBuffer,
+      double perStoreRouterQuotaBuffer,
       long storeQuotaCheckTimeWindow,
-      long storageNodeQuotaCheckTimeWindow) {
+      long storageNodeQuotaCheckTimeWindow,
+      boolean perStorageNodeThrottlerEnabled) {
     this.zkRoutersManager = zkRoutersManager;
     this.storeRepository = storeRepository;
     this.routingDataRepository = routingDataRepository;
@@ -108,8 +114,10 @@ public class ReadRequestThrottler implements RouterThrottler, RoutersClusterMana
     this.idealTotalQuotaPerRouter = calculateIdealTotalQuotaPerRouter();
     this.maxRouterReadCapacity = maxRouterReadCapacity;
     this.perStorageNodeReadQuotaBuffer = perStorageNodeReadQuotaBuffer;
+    this.perStorageNodeThrottlerEnabled = perStorageNodeThrottlerEnabled;
     this.storesThrottlers = new AtomicReference<>(buildAllStoreReadThrottlers());
     this.lastRouterCount = zkRoutersManager.getExpectedRoutersCount();
+    this.perStoreRouterQuotaBuffer = perStoreRouterQuotaBuffer;
   }
 
   /**
@@ -122,7 +130,7 @@ public class ReadRequestThrottler implements RouterThrottler, RoutersClusterMana
    * @throws QuotaExceededException if the usage exceeded the quota throw this exception to reject the request.
    */
   @Override
-  public void mayThrottleRead(String storeName, double readCapacityUnit, Optional<String> storageNodeId)
+  public void mayThrottleRead(String storeName, double readCapacityUnit, String storageNodeId)
       throws QuotaExceededException {
     if (!zkRoutersManager.isThrottlingEnabled()) {
       return;
@@ -131,7 +139,7 @@ public class ReadRequestThrottler implements RouterThrottler, RoutersClusterMana
     if (throttler == null) {
       throw new VeniceException("Could not find the throttler for store: " + storeName);
     } else {
-      throttler.mayThrottleRead(readCapacityUnit, storageNodeId);
+      throttler.mayThrottleRead(readCapacityUnit, perStorageNodeThrottlerEnabled ? storageNodeId : null);
     }
   }
 
@@ -143,7 +151,6 @@ public class ReadRequestThrottler implements RouterThrottler, RoutersClusterMana
   }
 
   protected long calculateStoreQuotaPerRouter(long storeQuota) {
-
     int routerCount = zkRoutersManager.isQuotaRebalanceEnabled()
         ? zkRoutersManager.getLiveRoutersCount()
         : zkRoutersManager.getExpectedRoutersCount();
@@ -167,7 +174,7 @@ public class ReadRequestThrottler implements RouterThrottler, RoutersClusterMana
 
     if (!zkRoutersManager.isMaxCapacityProtectionEnabled() || idealTotalQuotaPerRouter <= maxRouterReadCapacity) {
       // Current router's capacity is big enough to be allocated to each store's quota.
-      return idealStoreQuotaPerRouter;
+      return idealStoreQuotaPerRouter * (1 + (long) perStoreRouterQuotaBuffer);
     } else {
       // If we allocate ideal quota value to each store, the total quota would exceed the router's capacity.
       // The reason is the cluster does not have enough number of routers.(Might be caused by to manny router failures)
@@ -206,7 +213,7 @@ public class ReadRequestThrottler implements RouterThrottler, RoutersClusterMana
   private StoreReadThrottler buildStoreReadThrottler(String storeName, int currentVersion, long storeQuotaPerRouter) {
     String topicName = Version.composeKafkaTopic(storeName, currentVersion);
     Optional<PartitionAssignment> partitionAssignment;
-    if (routingDataRepository.containsKafkaTopic(topicName)) {
+    if (perStorageNodeThrottlerEnabled && routingDataRepository.containsKafkaTopic(topicName)) {
       partitionAssignment = Optional.of(routingDataRepository.getPartitionAssignments(topicName));
     } else {
       partitionAssignment = Optional.empty();
@@ -253,6 +260,9 @@ public class ReadRequestThrottler implements RouterThrottler, RoutersClusterMana
 
   @Override
   public void onExternalViewChange(PartitionAssignment partitionAssignment) {
+    if (!perStorageNodeThrottlerEnabled) {
+      return;
+    }
     String storeName = Version.parseStoreFromKafkaTopicName(partitionAssignment.getTopic());
     synchronized (storesThrottlers) {
       StoreReadThrottler storeReadThrottler =
@@ -370,7 +380,7 @@ public class ReadRequestThrottler implements RouterThrottler, RoutersClusterMana
                 VeniceSystemStoreUtils.getZkStoreName(store.getName()),
                 buildStoreReadThrottler(store.getName(), store.getCurrentVersion(), storeQuotaPerRouter));
       }
-      if (store.getCurrentVersion() != storeReadThrottler.getCurrentVersion()) {
+      if (store.getCurrentVersion() != storeReadThrottler.getCurrentVersion() && perStorageNodeThrottlerEnabled) {
         // Handle current version has been changed.
         LOGGER.info(
             "Current version has been changed for store: {} - oldVersion: {}, currentVersion: {}. Updating the storage node's throttlers only.",

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/throttle/RouterThrottler.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/throttle/RouterThrottler.java
@@ -1,20 +1,17 @@
 package com.linkedin.venice.router.throttle;
 
 import com.linkedin.venice.exceptions.QuotaExceededException;
-import java.util.Optional;
 
 
 public interface RouterThrottler {
   /**
    * Returns if the request should be allowed, throws a com.linkedin.venice.exceptions.QuotaExceededException if the
    * request is out of quota.
-   *
-   * @param storeName
+   *  @param storeName
    * @param readCapacityUnit
    * @param storageNodeId
    */
-  void mayThrottleRead(String storeName, double readCapacityUnit, Optional<String> storageNodeId)
-      throws QuotaExceededException;
+  void mayThrottleRead(String storeName, double readCapacityUnit, String storageNodeId) throws QuotaExceededException;
 
   int getReadCapacity();
 }

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/throttle/StoreReadThrottler.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/throttle/StoreReadThrottler.java
@@ -62,9 +62,9 @@ public class StoreReadThrottler {
     }
   }
 
-  public void mayThrottleRead(double readCapacityUnit, Optional<String> storageNodeId) {
-    if (storageNodeId.isPresent()) {
-      EventThrottler storageNodeThrottler = storageNodesThrottlers.get(storageNodeId.get());
+  public void mayThrottleRead(double readCapacityUnit, String storageNodeId) {
+    if (storageNodeId != null) {
+      EventThrottler storageNodeThrottler = storageNodesThrottlers.get(storageNodeId);
       // TODO While updating storage nodes' throttlers, there might be a very short period that we haven't create a
       // TODO throttler for the given storage node. Right now just accept this request, could add a default quota later.
       if (storageNodeThrottler != null) {

--- a/services/venice-router/src/test/java/com/linkedin/venice/router/api/TestVeniceDelegateMode.java
+++ b/services/venice-router/src/test/java/com/linkedin/venice/router/api/TestVeniceDelegateMode.java
@@ -482,7 +482,7 @@ public class TestVeniceDelegateMode {
     Assert.assertEquals(requests.size(), 3);
 
     // Verify throttling
-    verify(throttler).mayThrottleRead(storeName, 4, Optional.of(instance1.getNodeId()));
+    verify(throttler).mayThrottleRead(storeName, 4, instance1.getNodeId());
     verify(throttler, times(2)).mayThrottleRead(eq(storeName), eq(1.0d), any());
 
     // each request should only have one 'Instance'

--- a/services/venice-router/src/test/java/com/linkedin/venice/router/throttle/ReadRequestThrottlerTest.java
+++ b/services/venice-router/src/test/java/com/linkedin/venice/router/throttle/ReadRequestThrottlerTest.java
@@ -167,7 +167,7 @@ public class ReadRequestThrottlerTest {
     Mockito.doReturn(Arrays.asList(stores)).when(storeRepository).getAllStores();
     Mockito.doReturn(totalQuota).when(storeRepository).getTotalStoreReadQuota();
     Mockito.doReturn(routerCount).when(zkRoutersClusterManager).getLiveRoutersCount();
-    Mockito.doReturn(maxCapcity).when(routerConfig).getMaxRouterReadCapacityCu();
+    Mockito.doReturn(maxCapcity).when(routerConfig).getMaxReadCapacityCu();
     Mockito.doReturn(true).when(routerConfig).isPerRouterStorageNodeThrottlerEnabled();
 
     ReadRequestThrottler multiStoreThrottler =

--- a/services/venice-router/src/test/java/com/linkedin/venice/router/throttle/ReadRequestThrottlerTest.java
+++ b/services/venice-router/src/test/java/com/linkedin/venice/router/throttle/ReadRequestThrottlerTest.java
@@ -7,10 +7,10 @@ import com.linkedin.venice.meta.ReadOnlyStoreRepository;
 import com.linkedin.venice.meta.RoutingDataRepository;
 import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.Version;
+import com.linkedin.venice.router.VeniceRouterConfig;
 import com.linkedin.venice.router.stats.AggRouterHttpRequestStats;
 import com.linkedin.venice.utils.TestUtils;
 import java.util.Arrays;
-import java.util.Optional;
 import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
@@ -27,12 +27,14 @@ public class ReadRequestThrottlerTest {
   private int routerCount;
   private ReadRequestThrottler throttler;
   private final static long maxCapacity = 400;
+  private VeniceRouterConfig routerConfig;
 
   @BeforeMethod
   public void setUp() {
     storeRepository = Mockito.mock(ReadOnlyStoreRepository.class);
     zkRoutersClusterManager = Mockito.mock(ZkRoutersClusterManager.class);
     routingDataRepository = Mockito.mock(RoutingDataRepository.class);
+    routerConfig = Mockito.mock(VeniceRouterConfig.class);
     totalQuota = 1000;
     routerCount = 5;
     store = TestUtils.createTestStore("testGetQuotaForStore", "test", System.currentTimeMillis());
@@ -45,6 +47,7 @@ public class ReadRequestThrottlerTest {
     Mockito.doReturn(true).when(zkRoutersClusterManager).isQuotaRebalanceEnabled();
     Mockito.doReturn(true).when(zkRoutersClusterManager).isThrottlingEnabled();
     Mockito.doReturn(true).when(zkRoutersClusterManager).isMaxCapacityProtectionEnabled();
+    Mockito.doReturn(true).when(routerConfig).isPerRouterStorageNodeThrottlerEnabled();
     stats = Mockito.mock(AggRouterHttpRequestStats.class);
     throttler = new ReadRequestThrottler(
         zkRoutersClusterManager,
@@ -53,8 +56,10 @@ public class ReadRequestThrottlerTest {
         maxCapacity,
         stats,
         0.0,
+        0.0,
         1000,
-        1000);
+        1000,
+        true);
   }
 
   @Test
@@ -77,15 +82,14 @@ public class ReadRequestThrottlerTest {
     int numberOfRequests = 10;
     try {
       for (int i = 0; i < numberOfRequests; i++) {
-        throttler
-            .mayThrottleRead(store.getName(), (int) (totalQuota / routerCount / numberOfRequests), Optional.of("test"));
+        throttler.mayThrottleRead(store.getName(), (int) (totalQuota / routerCount / numberOfRequests), "test");
       }
     } catch (QuotaExceededException e) {
       Assert.fail("Usage has not exceeded the quota.");
     }
 
     try {
-      throttler.mayThrottleRead(store.getName(), 10, Optional.of("test"));
+      throttler.mayThrottleRead(store.getName(), 10, "test");
       Assert.fail("Usage has exceed the quota. Should get the QuotaExceededException.");
     } catch (QuotaExceededException e) {
       // expected.
@@ -95,7 +99,7 @@ public class ReadRequestThrottlerTest {
   @Test
   public void testOnRouterCountChanged() {
     try {
-      throttler.mayThrottleRead(store.getName(), (int) (totalQuota / (routerCount - 1)), Optional.of("test"));
+      throttler.mayThrottleRead(store.getName(), (int) (totalQuota / (routerCount - 1)), "test");
       Assert.fail("Usage has exceeded the quota.");
     } catch (QuotaExceededException e) {
       // expected.
@@ -105,7 +109,7 @@ public class ReadRequestThrottlerTest {
     Mockito.doReturn(routerCount - 1).when(zkRoutersClusterManager).getLiveRoutersCount();
     throttler.handleRouterCountChanged(routerCount - 1);
     try {
-      throttler.mayThrottleRead(store.getName(), (int) (totalQuota / (routerCount - 1)), Optional.of("test"));
+      throttler.mayThrottleRead(store.getName(), (int) (totalQuota / (routerCount - 1)), "test");
       Mockito.verify(stats, Mockito.atLeastOnce()).recordTotalQuota((double) totalQuota / (routerCount - 1));
       Mockito.verify(stats, Mockito.atLeastOnce())
           .recordQuota(store.getName(), (double) totalQuota / (routerCount - 1));
@@ -114,10 +118,7 @@ public class ReadRequestThrottlerTest {
     }
     throttler.handleRouterCountChanged((int) store.getReadQuotaInCU() + 1);
     try {
-      throttler.mayThrottleRead(
-          store.getName(),
-          (int) (totalQuota / ((int) store.getReadQuotaInCU() + 1)),
-          Optional.of("test"));
+      throttler.mayThrottleRead(store.getName(), (int) (totalQuota / ((int) store.getReadQuotaInCU() + 1)), "test");
     } catch (QuotaExceededException e) {
       Assert.fail("Usage should not exceed the quota as we have non-zero quota amount.");
     }
@@ -128,7 +129,7 @@ public class ReadRequestThrottlerTest {
 
     long newQuota = totalQuota + 200;
     try {
-      throttler.mayThrottleRead(store.getName(), (double) newQuota / routerCount, Optional.of("test"));
+      throttler.mayThrottleRead(store.getName(), (double) newQuota / routerCount, "test");
       Assert.fail("Quota has not been updated.");
     } catch (QuotaExceededException e) {
       // expected
@@ -143,7 +144,7 @@ public class ReadRequestThrottlerTest {
     Mockito.verify(stats, Mockito.atLeastOnce()).recordQuota(store.getName(), (double) newQuota / routerCount);
 
     try {
-      throttler.mayThrottleRead(store.getName(), (double) newQuota / routerCount, Optional.of("test"));
+      throttler.mayThrottleRead(store.getName(), (double) newQuota / routerCount, "test");
     } catch (QuotaExceededException e) {
       Assert.fail("Quota has been updated. Usage does not exceed the new quota.", e);
     }
@@ -166,13 +167,11 @@ public class ReadRequestThrottlerTest {
     Mockito.doReturn(Arrays.asList(stores)).when(storeRepository).getAllStores();
     Mockito.doReturn(totalQuota).when(storeRepository).getTotalStoreReadQuota();
     Mockito.doReturn(routerCount).when(zkRoutersClusterManager).getLiveRoutersCount();
-    ReadRequestThrottler multiStoreThrottler = new ReadRequestThrottler(
-        zkRoutersClusterManager,
-        storeRepository,
-        routingDataRepository,
-        maxCapcity,
-        stats,
-        0.0);
+    Mockito.doReturn(maxCapcity).when(routerConfig).getMaxRouterReadCapacityCu();
+    Mockito.doReturn(true).when(routerConfig).isPerRouterStorageNodeThrottlerEnabled();
+
+    ReadRequestThrottler multiStoreThrottler =
+        new ReadRequestThrottler(zkRoutersClusterManager, storeRepository, routingDataRepository, stats, routerConfig);
 
     for (int i = 0; i < storeCount; i++) {
       Assert.assertEquals(
@@ -330,7 +329,7 @@ public class ReadRequestThrottlerTest {
     try {
       for (int i = 0; i < numberOfRequests; i++) {
         // Every time send 10 time quota usage.
-        throttler.mayThrottleRead(store.getName(), (int) (totalQuota * 10), Optional.of("test"));
+        throttler.mayThrottleRead(store.getName(), (int) (totalQuota * 10), "test");
       }
     } catch (QuotaExceededException e) {
       Assert.fail("Throttling should be disabled.");
@@ -340,7 +339,7 @@ public class ReadRequestThrottlerTest {
     Mockito.doReturn(true).when(zkRoutersClusterManager).isThrottlingEnabled();
 
     try {
-      throttler.mayThrottleRead(store.getName(), (int) (totalQuota * 10), Optional.of("test"));
+      throttler.mayThrottleRead(store.getName(), (int) (totalQuota * 10), "test");
       Assert.fail("Usage has exceed the quota. Should get the QuotaExceededException.");
     } catch (QuotaExceededException e) {
       // expected.
@@ -357,14 +356,14 @@ public class ReadRequestThrottlerTest {
     Mockito.doReturn(routerCount - 1).when(zkRoutersClusterManager).getLiveRoutersCount();
     throttler.handleRouterCountChanged(routerCount - 1);
     try {
-      throttler.mayThrottleRead(store.getName(), (int) (totalQuota / (routerCount - 1)), Optional.of("test"));
+      throttler.mayThrottleRead(store.getName(), (int) (totalQuota / (routerCount - 1)), "test");
       Assert.fail(
           "As quota re-balance has been disabled, quota per router should not be increased with one router failure.");
     } catch (QuotaExceededException e) {
       // expected.
     }
     try {
-      throttler.mayThrottleRead(store.getName(), (int) (totalQuota / routerCount), Optional.of("test"));
+      throttler.mayThrottleRead(store.getName(), (int) (totalQuota / routerCount), "test");
     } catch (QuotaExceededException e) {
       Assert.fail("Usage does not exceed the quota, should not throttle the request.");
     }
@@ -373,7 +372,7 @@ public class ReadRequestThrottlerTest {
     Mockito.doReturn(true).when(zkRoutersClusterManager).isQuotaRebalanceEnabled();
     throttler.handleRouterClusterConfigChanged(null);
     try {
-      throttler.mayThrottleRead(store.getName(), (int) (totalQuota / (routerCount - 1)), Optional.of("test"));
+      throttler.mayThrottleRead(store.getName(), (int) (totalQuota / (routerCount - 1)), "test");
     } catch (QuotaExceededException e) {
       Assert.fail("Usage does not exceed the quota, should not throttle the request.");
     }
@@ -390,7 +389,7 @@ public class ReadRequestThrottlerTest {
     throttler.handleRouterClusterConfigChanged(null);
 
     try {
-      throttler.mayThrottleRead(store.getName(), (int) totalQuota, Optional.of("test"));
+      throttler.mayThrottleRead(store.getName(), (int) totalQuota, "test");
     } catch (QuotaExceededException e) {
       Assert.fail(
           "As router protection has been disable. Current usage does not exceed the quota, should not throttle the request.");
@@ -400,7 +399,7 @@ public class ReadRequestThrottlerTest {
     Mockito.doReturn(true).when(zkRoutersClusterManager).isMaxCapacityProtectionEnabled();
     throttler.handleRouterClusterConfigChanged(null);
     try {
-      throttler.mayThrottleRead(store.getName(), (int) totalQuota, Optional.of("test"));
+      throttler.mayThrottleRead(store.getName(), (int) totalQuota, "test");
       Assert.fail("As router protection has been enabled. Current usage exceeds the quota.");
     } catch (QuotaExceededException e) {
       // expected

--- a/services/venice-router/src/test/java/com/linkedin/venice/router/throttle/RouterRequestThrottlingTest.java
+++ b/services/venice-router/src/test/java/com/linkedin/venice/router/throttle/RouterRequestThrottlingTest.java
@@ -78,8 +78,10 @@ public class RouterRequestThrottlingTest {
         2000,
         stats,
         0.0,
+        0.0,
         1000,
-        1000);
+        1000,
+        true);
   }
 
   @Test(timeOut = 30000, groups = { "flaky" })

--- a/services/venice-router/src/test/java/com/linkedin/venice/router/throttle/StoreReadThrottlerTest.java
+++ b/services/venice-router/src/test/java/com/linkedin/venice/router/throttle/StoreReadThrottlerTest.java
@@ -118,24 +118,24 @@ public class StoreReadThrottlerTest {
         0.0,
         1000,
         1000);
-    throttler.mayThrottleRead(400, Optional.of(Utils.getHelixNodeIdentifier(10000)));
+    throttler.mayThrottleRead(400, Utils.getHelixNodeIdentifier(10000));
     try {
-      throttler.mayThrottleRead(100, Optional.of(Utils.getHelixNodeIdentifier(10000)));
+      throttler.mayThrottleRead(100, Utils.getHelixNodeIdentifier(10000));
       Assert.fail("Usage(500) exceed the quota(400) of Instance localhost_10000 ");
     } catch (QuotaExceededException e) {
       // expected
     }
 
     try {
-      throttler.mayThrottleRead(400, Optional.of(Utils.getHelixNodeIdentifier(10001)));
-      throttler.mayThrottleRead(100, Optional.of(Utils.getHelixNodeIdentifier(10002)));
+      throttler.mayThrottleRead(400, Utils.getHelixNodeIdentifier(10001));
+      throttler.mayThrottleRead(100, Utils.getHelixNodeIdentifier(10002));
     } catch (QuotaExceededException e) {
       Assert.fail("Usage has not exceeded the quota, should accept requests.", e);
     }
 
     throttler.clearStorageNodesThrottlers();
     try {
-      throttler.mayThrottleRead(100, Optional.of(Utils.getHelixNodeIdentifier(10000)));
+      throttler.mayThrottleRead(100, Utils.getHelixNodeIdentifier(10000));
     } catch (QuotaExceededException e) {
       Assert.fail("Throttler for storage node has been cleared, this store still have quota to accept this request.");
     }


### PR DESCRIPTION
## Implement per store quota in router
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Router quota of a store per node in router is distributed as follows.  

quota = store_quota/num_router/num_partitions/num_replica.  The calculated quota for  a store with very high partition count and cluster with many routers becomes very small and causes frequent quota rejection in router. This PR adds a config to disable such calculation and consider only router count to distribute the store quota. Also add a buffer for per store quota config and removes optional in storage host name param.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
unit tests
## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.