### PR TITLE
[test] Fix flaky testProducerCloseDoesNotLeaveAnyFuturesIncomplete

### DIFF
--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/pubsub/adapter/kafka/producer/ApacheKafkaProducerAdapterITest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/pubsub/adapter/kafka/producer/ApacheKafkaProducerAdapterITest.java
@@ -3,7 +3,6 @@ package com.linkedin.venice.pubsub.adapter.kafka.producer;
 import static com.linkedin.venice.pubsub.adapter.kafka.producer.ApacheKafkaProducerConfig.KAFKA_BOOTSTRAP_SERVERS;
 import static com.linkedin.venice.pubsub.adapter.kafka.producer.ApacheKafkaProducerConfig.KAFKA_CLIENT_ID;
 import static com.linkedin.venice.utils.TestUtils.waitForNonDeterministicAssertion;
-import static com.linkedin.venice.utils.Time.MS_PER_MINUTE;
 import static com.linkedin.venice.utils.Time.MS_PER_SECOND;
 import static org.apache.kafka.common.config.TopicConfig.RETENTION_MS_CONFIG;
 import static org.testng.Assert.assertFalse;
@@ -93,7 +92,7 @@ public class ApacheKafkaProducerAdapterITest {
 
   @BeforeMethod(alwaysRun = true)
   public void setupProducerAdapter() {
-    topicName = Utils.getUniqueString("topic-for-sendMessage-thread-safety");
+    topicName = Utils.getUniqueString("test-topic");
     Properties properties = new Properties();
     properties.put(KAFKA_BOOTSTRAP_SERVERS, kafkaBrokerWrapper.getAddress());
     properties.put(KAFKA_CLIENT_ID, topicName);
@@ -143,7 +142,7 @@ public class ApacheKafkaProducerAdapterITest {
    * 2) doFlush == false: upon forceful close (timeout 0 and no flushing) producer doesn't forget to complete
    *                      any Future that it returned in response to sendMessage() call.
    */
-  @Test(timeOut = MS_PER_MINUTE, dataProvider = "True-and-False", dataProviderClass = DataProviderUtils.class)
+  @Test(timeOut = 90 * MS_PER_SECOND, dataProvider = "True-and-False", dataProviderClass = DataProviderUtils.class)
   public void testProducerCloseDoesNotLeaveAnyFuturesIncomplete(boolean doFlush) throws InterruptedException {
     Map<String, String> topicProps = Collections.singletonMap(RETENTION_MS_CONFIG, Long.toString(Long.MAX_VALUE));
     createTopic(topicName, 1, 1, topicProps);
@@ -184,6 +183,14 @@ public class ApacheKafkaProducerAdapterITest {
     // Since we're blocking ioThread in m0's callback calling it from current thread would lead to deadlock.
     Thread closeProducerThread = new Thread(() -> producerAdapter.close(doFlush ? Integer.MAX_VALUE : 0, doFlush));
     closeProducerThread.start();
+    // We need to make sure that the Producer::close is always invoked first to ensure the correctness of this test
+    waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, () -> {
+      assertTrue(
+          closeProducerThread.getState().equals(Thread.State.WAITING)
+              || closeProducerThread.getState().equals(Thread.State.TIMED_WAITING)
+              || closeProducerThread.getState().equals(Thread.State.BLOCKED)
+              || closeProducerThread.getState().equals(Thread.State.TERMINATED));
+    });
 
     // Let's make sure that none of the m2 to m99 are ACKed by Kafka yet
     produceResults.forEach((cb, future) -> {


### PR DESCRIPTION
## Fix flaky testProducerCloseDoesNotLeaveAnyFuturesIncomplete
In the test, we want to simulate a case in which there are some records in the producer's buffer that 
are not yet sent to Kafka when an ungraceful close is issued. However, when producer::close() is not  
run before unblocking the producer's ioThread, records are sent to Kafka, which is not what we want.
To prevent sending records to Kafka, this PR added a check that guarantees producer::close() is
invoked before unblocking ioThread.


Resolves #XXX

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

Ran 200x2 iterations with the change in this PR:  [[402 tests completed, 1 failed](https://github.com/sushantmane/venice/actions/runs/4425159730/jobs/7759865659)]. The test failed once but it was due to topic creation timeout. 

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.