### PR TITLE
[server] Align nullable collection field behavior in A/A + Partial Update with existing non-AA logic

### DIFF
--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/schema/merge/CollectionFieldOperationHandler.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/schema/merge/CollectionFieldOperationHandler.java
@@ -1,6 +1,7 @@
 package com.linkedin.venice.schema.merge;
 
 import com.linkedin.venice.schema.rmd.v1.CollectionRmdTimestamp;
+import com.linkedin.venice.utils.IndexedHashMap;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.concurrent.ThreadSafe;
@@ -23,7 +24,7 @@ public abstract class CollectionFieldOperationHandler {
   public abstract UpdateResultStatus handlePutList(
       final long putTimestamp,
       final int coloID,
-      Object newFieldValue,
+      List<Object> newFieldValue,
       CollectionRmdTimestamp<Object> collectionFieldRmd,
       GenericRecord currValueRecord,
       String fieldName);
@@ -31,7 +32,7 @@ public abstract class CollectionFieldOperationHandler {
   public abstract UpdateResultStatus handlePutMap(
       final long putTimestamp,
       final int coloID,
-      Object newFieldValue,
+      IndexedHashMap<String, Object> newFieldValue,
       CollectionRmdTimestamp<String> collectionFieldRmd,
       GenericRecord currValueRecord,
       String fieldName);

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/schema/merge/CollectionFieldOperationHandler.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/schema/merge/CollectionFieldOperationHandler.java
@@ -1,7 +1,6 @@
 package com.linkedin.venice.schema.merge;
 
 import com.linkedin.venice.schema.rmd.v1.CollectionRmdTimestamp;
-import com.linkedin.venice.utils.IndexedHashMap;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.concurrent.ThreadSafe;
@@ -24,7 +23,7 @@ public abstract class CollectionFieldOperationHandler {
   public abstract UpdateResultStatus handlePutList(
       final long putTimestamp,
       final int coloID,
-      List<Object> newList,
+      Object newFieldValue,
       CollectionRmdTimestamp<Object> collectionFieldRmd,
       GenericRecord currValueRecord,
       String fieldName);
@@ -32,7 +31,7 @@ public abstract class CollectionFieldOperationHandler {
   public abstract UpdateResultStatus handlePutMap(
       final long putTimestamp,
       final int coloID,
-      IndexedHashMap<String, Object> newMap,
+      Object newFieldValue,
       CollectionRmdTimestamp<String> collectionFieldRmd,
       GenericRecord currValueRecord,
       String fieldName);

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/schema/merge/CollectionTimestampMergeRecordHelper.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/schema/merge/CollectionTimestampMergeRecordHelper.java
@@ -4,6 +4,7 @@ import static org.apache.avro.Schema.Type.ARRAY;
 import static org.apache.avro.Schema.Type.MAP;
 
 import com.linkedin.venice.schema.rmd.v1.CollectionRmdTimestamp;
+import com.linkedin.venice.utils.IndexedHashMap;
 import java.util.List;
 import java.util.Map;
 import org.apache.avro.Schema;
@@ -85,7 +86,7 @@ public class CollectionTimestampMergeRecordHelper extends PerFieldTimestampMerge
       return collectionFieldOperationHandler.handlePutList(
           putOperationTimestamp,
           putOperationColoID,
-          putFieldValue,
+          (List<Object>) putFieldValue,
           collectionRmd,
           currValueRecord,
           fieldName);
@@ -93,7 +94,7 @@ public class CollectionTimestampMergeRecordHelper extends PerFieldTimestampMerge
       return collectionFieldOperationHandler.handlePutMap(
           putOperationTimestamp,
           putOperationColoID,
-          putFieldValue,
+          (IndexedHashMap<String, Object>) putFieldValue,
           collectionRmd,
           currValueRecord,
           fieldName);

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/schema/merge/CollectionTimestampMergeRecordHelper.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/schema/merge/CollectionTimestampMergeRecordHelper.java
@@ -1,6 +1,7 @@
 package com.linkedin.venice.schema.merge;
 
 import static org.apache.avro.Schema.Type.ARRAY;
+import static org.apache.avro.Schema.Type.MAP;
 
 import com.linkedin.venice.schema.rmd.v1.CollectionRmdTimestamp;
 import com.linkedin.venice.utils.IndexedHashMap;
@@ -163,7 +164,7 @@ public class CollectionTimestampMergeRecordHelper extends PerFieldTimestampMerge
   }
 
   private boolean isSimpleMapSchema(Schema schema) {
-    return schema.getType().equals(ARRAY);
+    return schema.getType().equals(MAP);
   }
 
   private boolean isSimpleArraySchema(Schema schema) {

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/schema/merge/CollectionTimestampMergeRecordHelper.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/schema/merge/CollectionTimestampMergeRecordHelper.java
@@ -1,8 +1,6 @@
 package com.linkedin.venice.schema.merge;
 
 import static org.apache.avro.Schema.Type.ARRAY;
-import static org.apache.avro.Schema.Type.MAP;
-import static org.apache.avro.Schema.Type.UNION;
 
 import com.linkedin.venice.schema.rmd.v1.CollectionRmdTimestamp;
 import com.linkedin.venice.utils.IndexedHashMap;
@@ -36,8 +34,7 @@ public class CollectionTimestampMergeRecordHelper extends PerFieldTimestampMerge
       Object newFieldValue,
       final long newPutTimestamp,
       final int putOperationColoID) {
-    Object oldFieldValue = oldRecord.get(fieldName);
-    if (oldFieldValue instanceof List || oldFieldValue instanceof Map) {
+    if (isMapField(oldRecord, fieldName) || isArrayField(oldRecord, fieldName)) {
       // Collection field must have collection timestamp at this point.
       Object collectionFieldTimestampObj = oldTimestampRecord.get(fieldName);
       if (!(collectionFieldTimestampObj instanceof GenericRecord)) {
@@ -55,16 +52,14 @@ public class CollectionTimestampMergeRecordHelper extends PerFieldTimestampMerge
           fieldName,
           newPutTimestamp,
           putOperationColoID);
-
-    } else {
-      return super.putOnField(
-          oldRecord,
-          oldTimestampRecord,
-          fieldName,
-          newFieldValue,
-          newPutTimestamp,
-          putOperationColoID);
     }
+    return super.putOnField(
+        oldRecord,
+        oldTimestampRecord,
+        fieldName,
+        newFieldValue,
+        newPutTimestamp,
+        putOperationColoID);
   }
 
   /**
@@ -86,18 +81,15 @@ public class CollectionTimestampMergeRecordHelper extends PerFieldTimestampMerge
       final long putOperationTimestamp,
       final int putOperationColoID) {
     final CollectionRmdTimestamp collectionRmd = new CollectionRmdTimestamp(collectionFieldTimestampRecord);
-    Object currFieldValue = currValueRecord.get(fieldName);
-
-    if (currFieldValue instanceof List<?>) {
+    if (isArrayField(currValueRecord, fieldName)) {
       return collectionFieldOperationHandler.handlePutList(
           putOperationTimestamp,
           putOperationColoID,
-          (List<Object>) putFieldValue,
+          putFieldValue,
           collectionRmd,
           currValueRecord,
           fieldName);
-
-    } else if (currFieldValue instanceof Map) {
+    } else if (isMapField(currValueRecord, fieldName)) {
       if (!(putFieldValue instanceof IndexedHashMap)) {
         throw new IllegalStateException(
             "Expect the value to put on the field to be an IndexedHashMap. Got: " + putFieldValue.getClass());
@@ -105,16 +97,14 @@ public class CollectionTimestampMergeRecordHelper extends PerFieldTimestampMerge
       return collectionFieldOperationHandler.handlePutMap(
           putOperationTimestamp,
           putOperationColoID,
-          (IndexedHashMap<String, Object>) putFieldValue,
+          putFieldValue,
           collectionRmd,
           currValueRecord,
           fieldName);
-
-    } else {
-      throw new IllegalStateException(
-          "Expect a field that is of a collection type (Map or List). Got: " + currFieldValue + " for field "
-              + fieldName);
     }
+    throw new IllegalStateException(
+        "Expect a field that is of a collection type (Map or List). Got: " + currValueRecord.get(fieldName)
+            + " for field " + fieldName);
   }
 
   @Override
@@ -124,7 +114,7 @@ public class CollectionTimestampMergeRecordHelper extends PerFieldTimestampMerge
       final String fieldName,
       final long deleteTimestamp,
       final int coloID) {
-    if (isCollectionField(currValueRecord, fieldName)) {
+    if (isMapField(currValueRecord, fieldName) || isArrayField(currValueRecord, fieldName)) {
       Object timestamp = currTimestampRecord.get(fieldName);
       if (timestamp instanceof Long) {
         throw new IllegalStateException(
@@ -162,20 +152,29 @@ public class CollectionTimestampMergeRecordHelper extends PerFieldTimestampMerge
     }
   }
 
-  private boolean isCollectionField(GenericRecord currRecord, String fieldName) {
-    Object fieldValue = currRecord.get(fieldName);
-    if (fieldValue != null) {
-      return fieldValue instanceof List || fieldValue instanceof Map;
-    }
-
+  private boolean isMapField(GenericRecord currRecord, String fieldName) {
     Schema fieldSchema = currRecord.getSchema().getField(fieldName).schema();
-    if (fieldSchema.getType() == ARRAY) {
-      return true;
-    }
-    // Check if field is a nullable map.
-    if (fieldSchema.getType() == UNION && fieldSchema.getTypes().get(1).getType() == MAP) {
-      return true;
-    }
-    return false;
+    return isSimpleMapSchema(fieldSchema) || isNullableMapSchema(fieldSchema);
+  }
+
+  private boolean isArrayField(GenericRecord currRecord, String fieldName) {
+    Schema fieldSchema = currRecord.getSchema().getField(fieldName).schema();
+    return isSimpleArraySchema(fieldSchema) || isNullableArraySchema(fieldSchema);
+  }
+
+  private boolean isSimpleMapSchema(Schema schema) {
+    return schema.getType().equals(ARRAY);
+  }
+
+  private boolean isSimpleArraySchema(Schema schema) {
+    return schema.getType().equals(ARRAY);
+  }
+
+  private boolean isNullableMapSchema(Schema schema) {
+    return schema.isNullable() && isSimpleMapSchema(schema.getTypes().get(1));
+  }
+
+  private boolean isNullableArraySchema(Schema schema) {
+    return schema.isNullable() && isSimpleArraySchema(schema.getTypes().get(1));
   }
 }

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/schema/merge/CollectionTimestampMergeRecordHelper.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/schema/merge/CollectionTimestampMergeRecordHelper.java
@@ -91,6 +91,10 @@ public class CollectionTimestampMergeRecordHelper extends PerFieldTimestampMerge
           currValueRecord,
           fieldName);
     } else if (isMapField(currValueRecord, fieldName)) {
+      if ((putFieldValue != null) && (!(putFieldValue instanceof IndexedHashMap))) {
+        throw new IllegalStateException(
+            "Expect the value to put on the field to be an IndexedHashMap. Got: " + putFieldValue.getClass());
+      }
       return collectionFieldOperationHandler.handlePutMap(
           putOperationTimestamp,
           putOperationColoID,

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/schema/merge/CollectionTimestampMergeRecordHelper.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/schema/merge/CollectionTimestampMergeRecordHelper.java
@@ -4,7 +4,6 @@ import static org.apache.avro.Schema.Type.ARRAY;
 import static org.apache.avro.Schema.Type.MAP;
 
 import com.linkedin.venice.schema.rmd.v1.CollectionRmdTimestamp;
-import com.linkedin.venice.utils.IndexedHashMap;
 import java.util.List;
 import java.util.Map;
 import org.apache.avro.Schema;
@@ -91,10 +90,6 @@ public class CollectionTimestampMergeRecordHelper extends PerFieldTimestampMerge
           currValueRecord,
           fieldName);
     } else if (isMapField(currValueRecord, fieldName)) {
-      if (!(putFieldValue instanceof IndexedHashMap)) {
-        throw new IllegalStateException(
-            "Expect the value to put on the field to be an IndexedHashMap. Got: " + putFieldValue.getClass());
-      }
       return collectionFieldOperationHandler.handlePutMap(
           putOperationTimestamp,
           putOperationColoID,

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/schema/merge/SortBasedCollectionFieldOpHandler.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/schema/merge/SortBasedCollectionFieldOpHandler.java
@@ -31,7 +31,7 @@ public class SortBasedCollectionFieldOpHandler extends CollectionFieldOperationH
   public UpdateResultStatus handlePutList(
       final long putTimestamp,
       final int coloID,
-      Object newFieldValue,
+      List<Object> newFieldValue,
       CollectionRmdTimestamp<Object> collectionFieldRmd,
       GenericRecord currValueRecord,
       String fieldName) {
@@ -49,7 +49,7 @@ public class SortBasedCollectionFieldOpHandler extends CollectionFieldOperationH
     if (newFieldValue == null) {
       toPutList = Collections.emptyList();
     } else {
-      toPutList = (List<Object>) newFieldValue;
+      toPutList = newFieldValue;
     }
 
     if (collectionFieldRmd.isInPutOnlyState()) {
@@ -199,7 +199,7 @@ public class SortBasedCollectionFieldOpHandler extends CollectionFieldOperationH
   public UpdateResultStatus handlePutMap(
       final long putTimestamp,
       final int coloID,
-      Object newFieldValue,
+      IndexedHashMap<String, Object> newFieldValue,
       CollectionRmdTimestamp<String> collectionFieldRmd,
       GenericRecord currValueRecord,
       String fieldName) {
@@ -217,7 +217,7 @@ public class SortBasedCollectionFieldOpHandler extends CollectionFieldOperationH
         throw new IllegalStateException(
             "Expect the value to put on the field to be an IndexedHashMap. Got: " + newFieldValue.getClass());
       }
-      toPutMap = (IndexedHashMap<String, Object>) newFieldValue;
+      toPutMap = newFieldValue;
     }
 
     // Current map will be updated.
@@ -1069,7 +1069,10 @@ public class SortBasedCollectionFieldOpHandler extends CollectionFieldOperationH
   }
 
   private boolean shouldUpdateMapFieldItemValueWithSameTs(Object currentValue, Object newValue, Schema fieldSchema) {
-    // This is a safeguard not to compare with null value.
+    /**
+     * For complex map item value type, it is possible that the item value can be null. This is the safeguard to not
+     * compare with the null value and always let the not-null value win in the given case.
+     */
     if (currentValue == null) {
       return true;
     }

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/schema/merge/SortBasedCollectionFieldOpHandler.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/schema/merge/SortBasedCollectionFieldOpHandler.java
@@ -214,10 +214,6 @@ public class SortBasedCollectionFieldOpHandler extends CollectionFieldOperationH
     if (newFieldValue == null) {
       toPutMap = new IndexedHashMap<>();
     } else {
-      if (!(newFieldValue instanceof IndexedHashMap)) {
-        throw new IllegalStateException(
-            "Expect the value to put on the field to be an IndexedHashMap. Got: " + newFieldValue.getClass());
-      }
       toPutMap = newFieldValue;
     }
 

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/schema/merge/SortBasedCollectionFieldOpHandler.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/schema/merge/SortBasedCollectionFieldOpHandler.java
@@ -53,6 +53,7 @@ public class SortBasedCollectionFieldOpHandler extends CollectionFieldOperationH
     }
 
     if (collectionFieldRmd.isInPutOnlyState()) {
+      // This is to make sure we put the exact value when the new value is null.
       currValueRecord.put(fieldName, newFieldValue);
       collectionFieldRmd.setPutOnlyPartLength(toPutList.size());
       return UpdateResultStatus.COMPLETELY_UPDATED;
@@ -222,6 +223,7 @@ public class SortBasedCollectionFieldOpHandler extends CollectionFieldOperationH
 
     // Current map will be updated.
     if (collectionFieldRmd.isInPutOnlyState()) {
+      // This is to make sure we put the exact value when the new value is null.
       currValueRecord.put(fieldName, newFieldValue);
       collectionFieldRmd.setPutOnlyPartLength(toPutMap.size());
       return UpdateResultStatus.COMPLETELY_UPDATED;

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/schema/merge/SortBasedCollectionFieldOpHandler.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/schema/merge/SortBasedCollectionFieldOpHandler.java
@@ -1072,8 +1072,9 @@ public class SortBasedCollectionFieldOpHandler extends CollectionFieldOperationH
 
   private boolean shouldUpdateMapFieldItemValueWithSameTs(Object currentValue, Object newValue, Schema fieldSchema) {
     /**
-     * For complex map item value type, it is possible that the item value can be null. This is the safeguard to not
-     * compare with the null value and always let the not-null value win in the given case.
+     * For complex map item value type, for example union type [null, item value type], it is possible that the item
+     * value can be null. This is the safeguard to not compare with the null value and always let the not-null value win
+     * in the given case.
      */
     if (currentValue == null) {
       return true;

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/schema/TestSchemaUtils.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/schema/TestSchemaUtils.java
@@ -37,7 +37,9 @@ public class TestSchemaUtils {
   private static final Schema VALUE_SCHEMA =
       AvroSchemaParseUtils.parseSchemaFromJSONStrictValidation(loadSchemaFileAsString("testMergeSchema.avsc"));
   private static final String LIST_FIELD_NAME = "StringListField";
-  private static final String MAP_FIELD_NAME = "NullableIntMapField";
+  private static final String MAP_FIELD_NAME = "IntMapField";
+  private static final String NULLABLE_LIST_FIELD_NAME = "NullableStringListField";
+  private static final String NULLABLE_MAP_FIELD_NAME = "NullableIntMapField";
 
   @Test
   public void testAnnotateValueSchema() {
@@ -96,6 +98,8 @@ public class TestSchemaUtils {
     Schema tsSchema = rmdSchema.getField(TIMESTAMP_FIELD_NAME).schema().getTypes().get(1);
     Schema listFieldTsSchema = tsSchema.getField(LIST_FIELD_NAME).schema();
     Schema mapFieldTsSchema = tsSchema.getField(MAP_FIELD_NAME).schema();
+    Schema nullableListFieldTsSchema = tsSchema.getField(NULLABLE_LIST_FIELD_NAME).schema();
+    Schema nullableMapFieldTsSchema = tsSchema.getField(NULLABLE_MAP_FIELD_NAME).schema();
 
     GenericRecord listFieldTsRecord = new GenericData.Record(listFieldTsSchema);
     listFieldTsRecord.put(TOP_LEVEL_TS_FIELD_NAME, 1L);
@@ -113,9 +117,27 @@ public class TestSchemaUtils {
     mapFieldTsRecord.put(DELETED_ELEM_FIELD_NAME, Collections.singletonList("key2"));
     mapFieldTsRecord.put(DELETED_ELEM_TS_FIELD_NAME, Collections.singletonList(5L));
 
+    GenericRecord nullableListFieldTsRecord = new GenericData.Record(nullableListFieldTsSchema);
+    nullableListFieldTsRecord.put(TOP_LEVEL_TS_FIELD_NAME, 1L);
+    nullableListFieldTsRecord.put(TOP_LEVEL_COLO_ID_FIELD_NAME, 0);
+    nullableListFieldTsRecord.put(PUT_ONLY_PART_LENGTH_FIELD_NAME, 0);
+    nullableListFieldTsRecord.put(ACTIVE_ELEM_TS_FIELD_NAME, Collections.emptyList());
+    nullableListFieldTsRecord.put(DELETED_ELEM_FIELD_NAME, Collections.emptyList());
+    nullableListFieldTsRecord.put(DELETED_ELEM_TS_FIELD_NAME, Collections.emptyList());
+
+    GenericRecord nullableMapFieldTsRecord = new GenericData.Record(nullableMapFieldTsSchema);
+    nullableMapFieldTsRecord.put(TOP_LEVEL_TS_FIELD_NAME, 1L);
+    nullableMapFieldTsRecord.put(TOP_LEVEL_COLO_ID_FIELD_NAME, 0);
+    nullableMapFieldTsRecord.put(PUT_ONLY_PART_LENGTH_FIELD_NAME, 0);
+    nullableMapFieldTsRecord.put(ACTIVE_ELEM_TS_FIELD_NAME, Collections.emptyList());
+    nullableMapFieldTsRecord.put(DELETED_ELEM_FIELD_NAME, Collections.emptyList());
+    nullableMapFieldTsRecord.put(DELETED_ELEM_TS_FIELD_NAME, Collections.emptyList());
+
     GenericRecord tsRecord = new GenericData.Record(tsSchema);
     tsRecord.put(LIST_FIELD_NAME, listFieldTsRecord);
     tsRecord.put(MAP_FIELD_NAME, mapFieldTsRecord);
+    tsRecord.put(NULLABLE_LIST_FIELD_NAME, nullableListFieldTsRecord);
+    tsRecord.put(NULLABLE_MAP_FIELD_NAME, nullableMapFieldTsRecord);
     rmdRecord.put(TIMESTAMP_FIELD_NAME, tsRecord);
     rmdRecord.put(REPLICATION_CHECKPOINT_VECTOR_FIELD, Collections.emptyList());
     byte[] serializedBytes = getSerializer(rmdSchema).serialize(rmdRecord);

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/schema/merge/CollectionMergeTest.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/schema/merge/CollectionMergeTest.java
@@ -1,13 +1,22 @@
 package com.linkedin.venice.schema.merge;
 
 import static com.linkedin.venice.schema.Utils.loadSchemaFileAsString;
+import static com.linkedin.venice.schema.rmd.v1.CollectionRmdTimestamp.ACTIVE_ELEM_TS_FIELD_NAME;
+import static com.linkedin.venice.schema.rmd.v1.CollectionRmdTimestamp.DELETED_ELEM_FIELD_NAME;
+import static com.linkedin.venice.schema.rmd.v1.CollectionRmdTimestamp.DELETED_ELEM_TS_FIELD_NAME;
+import static com.linkedin.venice.schema.rmd.v1.CollectionRmdTimestamp.PUT_ONLY_PART_LENGTH_FIELD_NAME;
+import static com.linkedin.venice.schema.rmd.v1.CollectionRmdTimestamp.TOP_LEVEL_COLO_ID_FIELD_NAME;
+import static com.linkedin.venice.schema.rmd.v1.CollectionRmdTimestamp.TOP_LEVEL_TS_FIELD_NAME;
 
 import com.linkedin.venice.schema.AvroSchemaParseUtils;
+import com.linkedin.venice.schema.SchemaUtils;
 import com.linkedin.venice.schema.rmd.RmdConstants;
 import com.linkedin.venice.schema.rmd.RmdSchemaGenerator;
 import com.linkedin.venice.schema.rmd.v1.CollectionRmdTimestamp;
 import com.linkedin.venice.utils.IndexedHashMap;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -23,12 +32,187 @@ public class CollectionMergeTest {
   private static final Schema VALUE_SCHEMA =
       AvroSchemaParseUtils.parseSchemaFromJSONStrictValidation(loadSchemaFileAsString("testMergeSchema.avsc"));
   protected static final String LIST_FIELD_NAME = "StringListField";
-  protected static final String MAP_FIELD_NAME = "NullableIntMapField";
-  private static final Schema RMD_TIMESTAMP_SCHEMA = RmdSchemaGenerator.generateMetadataSchema(VALUE_SCHEMA)
-      .getField(RmdConstants.TIMESTAMP_FIELD_NAME)
-      .schema()
-      .getTypes()
-      .get(1);
+  protected static final String NULLABLE_LIST_FIELD_NAME = "NullableStringListField";
+  protected static final String MAP_FIELD_NAME = "IntMapField";
+  protected static final String NULLABLE_MAP_FIELD_NAME = "NullableIntMapField";
+
+  private static final Schema RMD_SCHEMA =
+      SchemaUtils.annotateRmdSchema(RmdSchemaGenerator.generateMetadataSchema(VALUE_SCHEMA));
+  private static final Schema RMD_TIMESTAMP_SCHEMA =
+      RMD_SCHEMA.getField(RmdConstants.TIMESTAMP_FIELD_NAME).schema().getTypes().get(1);
+
+  @Test
+  public void testHandleListOpWithNullValue() {
+    GenericRecord oldRecord = new GenericData.Record(VALUE_SCHEMA);
+    GenericRecord oldRmdRecord = initiateFieldLevelRmdRecord();
+    GenericRecord timestampRecord = (GenericRecord) oldRmdRecord.get(RmdConstants.TIMESTAMP_FIELD_NAME);
+    List<String> listValue = Collections.singletonList("item1");
+    GenericRecord nullableListTsRecord = (GenericRecord) timestampRecord.get(NULLABLE_LIST_FIELD_NAME);
+    nullableListTsRecord.put(TOP_LEVEL_TS_FIELD_NAME, 1L);
+    nullableListTsRecord.put(TOP_LEVEL_COLO_ID_FIELD_NAME, 1);
+    nullableListTsRecord.put(PUT_ONLY_PART_LENGTH_FIELD_NAME, 1);
+    oldRecord.put(NULLABLE_LIST_FIELD_NAME, listValue);
+    GenericRecord listTsRecord = (GenericRecord) timestampRecord.get(LIST_FIELD_NAME);
+    listTsRecord.put(TOP_LEVEL_TS_FIELD_NAME, 1L);
+    listTsRecord.put(TOP_LEVEL_COLO_ID_FIELD_NAME, 1);
+    listTsRecord.put(PUT_ONLY_PART_LENGTH_FIELD_NAME, 1);
+    oldRecord.put(LIST_FIELD_NAME, listValue);
+
+    UpdateResultStatus resultStatus;
+    CollectionTimestampMergeRecordHelper collectionTimestampMergeRecordHelper =
+        new CollectionTimestampMergeRecordHelper();
+    SortBasedCollectionFieldOpHandler handlerToTest =
+        new SortBasedCollectionFieldOpHandler(AvroCollectionElementComparator.INSTANCE);
+
+    List<String> newListValue = Collections.singletonList("item2");
+    // Case 1: Test LIST can handle setField to new list.
+    resultStatus = collectionTimestampMergeRecordHelper.putOnField(
+        oldRecord,
+        (GenericRecord) oldRmdRecord.get(RmdConstants.TIMESTAMP_FIELD_NAME),
+        NULLABLE_LIST_FIELD_NAME,
+        newListValue,
+        2,
+        1);
+    Assert.assertEquals(UpdateResultStatus.COMPLETELY_UPDATED, resultStatus);
+    Assert.assertEquals(((List<String>) oldRecord.get(NULLABLE_LIST_FIELD_NAME)).get(0), "item2");
+    resultStatus = collectionTimestampMergeRecordHelper.putOnField(
+        oldRecord,
+        (GenericRecord) oldRmdRecord.get(RmdConstants.TIMESTAMP_FIELD_NAME),
+        LIST_FIELD_NAME,
+        newListValue,
+        2,
+        1);
+    Assert.assertEquals(UpdateResultStatus.COMPLETELY_UPDATED, resultStatus);
+    Assert.assertEquals(((List<String>) oldRecord.get(LIST_FIELD_NAME)).get(0), "item2");
+
+    // Case 2: Test nullable LIST can handle setField to null.
+    resultStatus = collectionTimestampMergeRecordHelper.putOnField(
+        oldRecord,
+        (GenericRecord) oldRmdRecord.get(RmdConstants.TIMESTAMP_FIELD_NAME),
+        NULLABLE_LIST_FIELD_NAME,
+        null,
+        3,
+        1);
+    Assert.assertNull(oldRecord.get(NULLABLE_LIST_FIELD_NAME));
+    Assert.assertEquals(UpdateResultStatus.COMPLETELY_UPDATED, resultStatus);
+
+    // Case 3: Test nullable LIST can handle collection merge from null value.
+    List<Object> newEntries = Collections.singletonList("item3");
+    List<Object> toRemoveKeys = new LinkedList<>();
+    CollectionRmdTimestamp<Object> collectionRmdTimestamp = new CollectionRmdTimestamp<>(nullableListTsRecord);
+    resultStatus = handlerToTest
+        .handleModifyList(4L, collectionRmdTimestamp, oldRecord, NULLABLE_LIST_FIELD_NAME, newEntries, toRemoveKeys);
+    Assert.assertEquals(UpdateResultStatus.PARTIALLY_UPDATED, resultStatus);
+    Assert.assertEquals(((List<String>) oldRecord.get(NULLABLE_LIST_FIELD_NAME)).get(0), "item3");
+
+    // Case 4: Test nullable MAP can handle setField to null when there is active elements.
+    resultStatus = collectionTimestampMergeRecordHelper.putOnField(
+        oldRecord,
+        (GenericRecord) oldRmdRecord.get(RmdConstants.TIMESTAMP_FIELD_NAME),
+        NULLABLE_LIST_FIELD_NAME,
+        newListValue,
+        3,
+        2);
+    Assert.assertEquals(UpdateResultStatus.PARTIALLY_UPDATED, resultStatus);
+    Assert.assertEquals(((List<String>) oldRecord.get(NULLABLE_LIST_FIELD_NAME)).get(0), "item2");
+    resultStatus = collectionTimestampMergeRecordHelper.putOnField(
+        oldRecord,
+        (GenericRecord) oldRmdRecord.get(RmdConstants.TIMESTAMP_FIELD_NAME),
+        NULLABLE_LIST_FIELD_NAME,
+        null,
+        3,
+        3);
+    Assert.assertEquals(UpdateResultStatus.PARTIALLY_UPDATED, resultStatus);
+    Assert.assertEquals(((List<String>) oldRecord.get(NULLABLE_LIST_FIELD_NAME)).get(0), "item3");
+  }
+
+  @Test
+  public void testHandleMapOpWithNullValue() {
+    GenericRecord oldRecord = new GenericData.Record(VALUE_SCHEMA);
+    GenericRecord oldRmdRecord = initiateFieldLevelRmdRecord();
+    GenericRecord timestampRecord = (GenericRecord) oldRmdRecord.get(RmdConstants.TIMESTAMP_FIELD_NAME);
+    IndexedHashMap<String, Integer> mapValue = new IndexedHashMap<>();
+    mapValue.put("key1", 1);
+    GenericRecord nullableMapTsRecord = (GenericRecord) timestampRecord.get(NULLABLE_MAP_FIELD_NAME);
+    nullableMapTsRecord.put(TOP_LEVEL_TS_FIELD_NAME, 1L);
+    nullableMapTsRecord.put(TOP_LEVEL_COLO_ID_FIELD_NAME, 1);
+    nullableMapTsRecord.put(PUT_ONLY_PART_LENGTH_FIELD_NAME, 1);
+    oldRecord.put(NULLABLE_MAP_FIELD_NAME, mapValue);
+    GenericRecord mapTsRecord = (GenericRecord) timestampRecord.get(MAP_FIELD_NAME);
+    mapTsRecord.put(TOP_LEVEL_TS_FIELD_NAME, 1L);
+    mapTsRecord.put(TOP_LEVEL_COLO_ID_FIELD_NAME, 1);
+    mapTsRecord.put(PUT_ONLY_PART_LENGTH_FIELD_NAME, 1);
+    oldRecord.put(MAP_FIELD_NAME, mapValue);
+
+    UpdateResultStatus resultStatus;
+    CollectionTimestampMergeRecordHelper collectionTimestampMergeRecordHelper =
+        new CollectionTimestampMergeRecordHelper();
+    SortBasedCollectionFieldOpHandler handlerToTest =
+        new SortBasedCollectionFieldOpHandler(AvroCollectionElementComparator.INSTANCE);
+
+    IndexedHashMap<String, Integer> newMapValue = new IndexedHashMap<>();
+    newMapValue.put("key1", 2);
+    // Case 1: Test MAP can handle setField to new map.
+    resultStatus = collectionTimestampMergeRecordHelper.putOnField(
+        oldRecord,
+        (GenericRecord) oldRmdRecord.get(RmdConstants.TIMESTAMP_FIELD_NAME),
+        NULLABLE_MAP_FIELD_NAME,
+        newMapValue,
+        2,
+        1);
+    Assert.assertEquals(UpdateResultStatus.COMPLETELY_UPDATED, resultStatus);
+    Assert.assertEquals(((Map<String, Object>) oldRecord.get(NULLABLE_MAP_FIELD_NAME)).get("key1"), 2);
+    resultStatus = collectionTimestampMergeRecordHelper.putOnField(
+        oldRecord,
+        (GenericRecord) oldRmdRecord.get(RmdConstants.TIMESTAMP_FIELD_NAME),
+        MAP_FIELD_NAME,
+        newMapValue,
+        2,
+        1);
+    Assert.assertEquals(UpdateResultStatus.COMPLETELY_UPDATED, resultStatus);
+    Assert.assertEquals(((Map<String, Object>) oldRecord.get(MAP_FIELD_NAME)).get("key1"), 2);
+
+    // Case 2: Test nullable MAP can handle setField to null.
+    resultStatus = collectionTimestampMergeRecordHelper.putOnField(
+        oldRecord,
+        (GenericRecord) oldRmdRecord.get(RmdConstants.TIMESTAMP_FIELD_NAME),
+        NULLABLE_MAP_FIELD_NAME,
+        null,
+        3,
+        1);
+    Assert.assertNull(oldRecord.get(NULLABLE_MAP_FIELD_NAME));
+    Assert.assertEquals(UpdateResultStatus.COMPLETELY_UPDATED, resultStatus);
+
+    // Case 3: Test nullable MAP can handle collection merge from null value.
+    Map<String, Object> newEntries = Collections.singletonMap("key2", 2);
+    List<String> toRemoveKeys = new LinkedList<>();
+    CollectionRmdTimestamp<String> collectionRmdTimestamp = new CollectionRmdTimestamp<>(nullableMapTsRecord);
+    resultStatus = handlerToTest
+        .handleModifyMap(4L, collectionRmdTimestamp, oldRecord, NULLABLE_MAP_FIELD_NAME, newEntries, toRemoveKeys);
+    Assert.assertEquals(UpdateResultStatus.PARTIALLY_UPDATED, resultStatus);
+    Assert.assertEquals(((Map<String, Object>) oldRecord.get(NULLABLE_MAP_FIELD_NAME)).get("key2"), 2);
+
+    // Case 4: Test nullable MAP can handle setField to null when there is active elements.
+    resultStatus = collectionTimestampMergeRecordHelper.putOnField(
+        oldRecord,
+        (GenericRecord) oldRmdRecord.get(RmdConstants.TIMESTAMP_FIELD_NAME),
+        NULLABLE_MAP_FIELD_NAME,
+        newMapValue,
+        3,
+        2);
+    Assert.assertEquals(UpdateResultStatus.PARTIALLY_UPDATED, resultStatus);
+    Assert.assertEquals(((Map<String, Object>) oldRecord.get(NULLABLE_MAP_FIELD_NAME)).get("key1"), 2);
+    resultStatus = collectionTimestampMergeRecordHelper.putOnField(
+        oldRecord,
+        (GenericRecord) oldRmdRecord.get(RmdConstants.TIMESTAMP_FIELD_NAME),
+        NULLABLE_MAP_FIELD_NAME,
+        null,
+        3,
+        3);
+    Assert.assertEquals(UpdateResultStatus.PARTIALLY_UPDATED, resultStatus);
+    Assert.assertNull(((Map<String, Object>) oldRecord.get(NULLABLE_MAP_FIELD_NAME)).get("key1"));
+    Assert.assertEquals(((Map<String, Object>) oldRecord.get(NULLABLE_MAP_FIELD_NAME)).get("key2"), 2);
+  }
 
   @Test
   public void testHandleCollectionMergeMapOp() {
@@ -43,7 +227,8 @@ public class CollectionMergeTest {
     collectionTimestampBuilder.setDeletedElementTimestamps(Arrays.asList(2L, 3L, 4L));
     collectionTimestampBuilder
         .setDeletedElements(Schema.create(Schema.Type.STRING), Arrays.asList("key5", "key6", "key7"));
-    collectionTimestampBuilder.setCollectionTimestampSchema(RMD_TIMESTAMP_SCHEMA.getField(MAP_FIELD_NAME).schema());
+    collectionTimestampBuilder
+        .setCollectionTimestampSchema(RMD_TIMESTAMP_SCHEMA.getField(NULLABLE_MAP_FIELD_NAME).schema());
     CollectionRmdTimestamp<String> collectionMetadata =
         new CollectionRmdTimestamp<>(collectionTimestampBuilder.build());
     SortBasedCollectionFieldOpHandler handlerToTest =
@@ -55,7 +240,7 @@ public class CollectionMergeTest {
     mapValue.put("key2", 1);
     mapValue.put("key3", 1);
     mapValue.put("key4", 1);
-    currValueRecord.put(MAP_FIELD_NAME, mapValue);
+    currValueRecord.put(NULLABLE_MAP_FIELD_NAME, mapValue);
 
     Map<String, Object> newEntries = new HashMap<>();
     newEntries.put("key1", 2);
@@ -66,9 +251,10 @@ public class CollectionMergeTest {
     newEntries.put("key6", 2);
     newEntries.put("key7", 2);
     List<String> toRemoveKeys = new LinkedList<>();
-    handlerToTest.handleModifyMap(3L, collectionMetadata, currValueRecord, MAP_FIELD_NAME, newEntries, toRemoveKeys);
+    handlerToTest
+        .handleModifyMap(3L, collectionMetadata, currValueRecord, NULLABLE_MAP_FIELD_NAME, newEntries, toRemoveKeys);
 
-    Map<String, Integer> updatedMap = (Map<String, Integer>) currValueRecord.get(MAP_FIELD_NAME);
+    Map<String, Integer> updatedMap = (Map<String, Integer>) currValueRecord.get(NULLABLE_MAP_FIELD_NAME);
     Map<String, Integer> expectedMap = new HashMap<>();
     expectedMap.put("key1", 2);
     expectedMap.put("key2", 2);
@@ -107,4 +293,23 @@ public class CollectionMergeTest {
     Assert.assertEquals(updatedMap, Arrays.asList("key1", "key2", "key3", "key4"));
   }
 
+  private GenericRecord initiateFieldLevelRmdRecord() {
+    GenericRecord rmdRecord = new GenericData.Record(RMD_SCHEMA);
+    Schema fieldLevelTimestampSchema =
+        rmdRecord.getSchema().getField(RmdConstants.TIMESTAMP_FIELD_NAME).schema().getTypes().get(1);
+
+    GenericRecord timestampsRecord = new GenericData.Record(fieldLevelTimestampSchema);
+
+    for (Schema.Field field: timestampsRecord.getSchema().getFields()) {
+      // Below logic only works for collection field.
+      GenericRecord fieldRecord = new GenericData.Record(field.schema());
+      fieldRecord.put(ACTIVE_ELEM_TS_FIELD_NAME, Collections.emptyList());
+      fieldRecord.put(DELETED_ELEM_TS_FIELD_NAME, Collections.emptyList());
+      fieldRecord.put(DELETED_ELEM_FIELD_NAME, Collections.emptyList());
+      timestampsRecord.put(field.name(), fieldRecord);
+    }
+    rmdRecord.put(RmdConstants.TIMESTAMP_FIELD_NAME, timestampsRecord);
+    rmdRecord.put(RmdConstants.REPLICATION_CHECKPOINT_VECTOR_FIELD, new ArrayList<>());
+    return rmdRecord;
+  }
 }

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/schema/merge/CollectionMergeTest.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/schema/merge/CollectionMergeTest.java
@@ -48,10 +48,9 @@ public class CollectionMergeTest {
     GenericRecord timestampRecord = (GenericRecord) oldRmdRecord.get(RmdConstants.TIMESTAMP_FIELD_NAME);
     List<String> listValue = Collections.singletonList("item1");
     GenericRecord nullableListTsRecord = (GenericRecord) timestampRecord.get(NULLABLE_LIST_FIELD_NAME);
-    nullableListTsRecord.put(TOP_LEVEL_TS_FIELD_NAME, 1L);
-    nullableListTsRecord.put(TOP_LEVEL_COLO_ID_FIELD_NAME, 1);
-    nullableListTsRecord.put(PUT_ONLY_PART_LENGTH_FIELD_NAME, 1);
-    oldRecord.put(NULLABLE_LIST_FIELD_NAME, listValue);
+    nullableListTsRecord.put(TOP_LEVEL_TS_FIELD_NAME, 0L);
+    nullableListTsRecord.put(TOP_LEVEL_COLO_ID_FIELD_NAME, 0);
+    nullableListTsRecord.put(PUT_ONLY_PART_LENGTH_FIELD_NAME, 0);
     GenericRecord listTsRecord = (GenericRecord) timestampRecord.get(LIST_FIELD_NAME);
     listTsRecord.put(TOP_LEVEL_TS_FIELD_NAME, 1L);
     listTsRecord.put(TOP_LEVEL_COLO_ID_FIELD_NAME, 1);
@@ -134,10 +133,9 @@ public class CollectionMergeTest {
     IndexedHashMap<String, Integer> mapValue = new IndexedHashMap<>();
     mapValue.put("key1", 1);
     GenericRecord nullableMapTsRecord = (GenericRecord) timestampRecord.get(NULLABLE_MAP_FIELD_NAME);
-    nullableMapTsRecord.put(TOP_LEVEL_TS_FIELD_NAME, 1L);
-    nullableMapTsRecord.put(TOP_LEVEL_COLO_ID_FIELD_NAME, 1);
-    nullableMapTsRecord.put(PUT_ONLY_PART_LENGTH_FIELD_NAME, 1);
-    oldRecord.put(NULLABLE_MAP_FIELD_NAME, mapValue);
+    nullableMapTsRecord.put(TOP_LEVEL_TS_FIELD_NAME, 0L);
+    nullableMapTsRecord.put(TOP_LEVEL_COLO_ID_FIELD_NAME, 0);
+    nullableMapTsRecord.put(PUT_ONLY_PART_LENGTH_FIELD_NAME, 0);
     GenericRecord mapTsRecord = (GenericRecord) timestampRecord.get(MAP_FIELD_NAME);
     mapTsRecord.put(TOP_LEVEL_TS_FIELD_NAME, 1L);
     mapTsRecord.put(TOP_LEVEL_COLO_ID_FIELD_NAME, 1);

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/schema/merge/CollectionMergeTest.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/schema/merge/CollectionMergeTest.java
@@ -105,7 +105,7 @@ public class CollectionMergeTest {
     Assert.assertEquals(UpdateResultStatus.PARTIALLY_UPDATED, resultStatus);
     Assert.assertEquals(((List<String>) oldRecord.get(NULLABLE_LIST_FIELD_NAME)).get(0), "item3");
 
-    // Case 4: Test nullable MAP can handle setField to null when there is active elements.
+    // Case 4: Test nullable List can handle setField to null when there is active elements.
     resultStatus = collectionTimestampMergeRecordHelper.putOnField(
         oldRecord,
         (GenericRecord) oldRmdRecord.get(RmdConstants.TIMESTAMP_FIELD_NAME),

--- a/internal/venice-client-common/src/test/resources/testMergeSchema.avsc
+++ b/internal/venice-client-common/src/test/resources/testMergeSchema.avsc
@@ -12,6 +12,25 @@
       "default": []
     },
     {
+      "name": "NullableStringListField",
+      "type": [
+        "null",
+        {
+          "type": "array",
+          "items": "string"
+        }
+      ],
+      "default": null
+    },
+    {
+      "name": "IntMapField",
+      "type": {
+        "type": "map",
+        "values": "int"
+      },
+      "default": {}
+    },
+    {
       "name": "NullableIntMapField",
       "type": [
         "null",


### PR DESCRIPTION
## [server] Align nullable collection field behavior in A/A + Partial Update with existing non-AA logic
Current RMD/PartialUpdate schema generation consider [null, map] and [null, list] as legit collection field, same as simple map/list, so we need to handle it properly, especially for the NULL value.
Existing non-AA partial update logic treat null as a special type of empty collection:
When setting field to null, it does set the actual value to null. If there is another collection merge operation (add/remove entry), it will first initialize an empty collection and perform collection merge.

This PR address the feature gap by introducing the same logic to A/A PartialUpdate:
(1) When setting a field to null, if it is in put only state (no active elements), it will set to null. 
(2) When setting a field to null, if it is not in put only state (has active elements), it will initialize new empty collection and apply active elements. 
(3) When a nullable collection field is null, new collection merge operation will also initialize new empty collection and apply new operations.

## How was this PR tested?

Add new unit test in **CollectionMergeTest** test class to cover changed logics, it tested against map/list/nullableMap/nullableList
Adjust existing unit tests.

## Does this PR introduce any user-facing changes?
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.