### PR TITLE
[server], [controller], [router] Make advertised addresses configurable (K8S support)

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
@@ -15,6 +15,7 @@ import static com.linkedin.venice.ConfigKeys.KAFKA_READ_ONLY_ADMIN_CLASS;
 import static com.linkedin.venice.ConfigKeys.KAFKA_WRITE_ONLY_ADMIN_CLASS;
 import static com.linkedin.venice.ConfigKeys.KEY_VALUE_PROFILING_ENABLED;
 import static com.linkedin.venice.ConfigKeys.LEADER_FOLLOWER_STATE_TRANSITION_THREAD_POOL_STRATEGY;
+import static com.linkedin.venice.ConfigKeys.LISTENER_HOSTNAME;
 import static com.linkedin.venice.ConfigKeys.LISTENER_PORT;
 import static com.linkedin.venice.ConfigKeys.MAX_FUTURE_VERSION_LEADER_FOLLOWER_STATE_TRANSITION_THREAD_NUMBER;
 import static com.linkedin.venice.ConfigKeys.MAX_LEADER_FOLLOWER_STATE_TRANSITION_THREAD_NUMBER;
@@ -106,6 +107,7 @@ import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.kafka.admin.KafkaAdminClient;
 import com.linkedin.venice.meta.IngestionMode;
 import com.linkedin.venice.utils.Time;
+import com.linkedin.venice.utils.Utils;
 import com.linkedin.venice.utils.VeniceProperties;
 import java.nio.file.Paths;
 import java.util.Arrays;
@@ -134,6 +136,7 @@ public class VeniceServerConfig extends VeniceClusterConfig {
   public static final int MINIMUM_CONSUMER_NUM_IN_CONSUMER_POOL_PER_KAFKA_CLUSTER = 3;
 
   private final int listenerPort;
+  private final String listernerHostname;
   private final String dataBasePath;
   private final RocksDBServerConfig rocksDBServerConfig;
   private final boolean enableServerAllowList;
@@ -374,6 +377,7 @@ public class VeniceServerConfig extends VeniceClusterConfig {
       throws ConfigurationException {
     super(serverProperties, kafkaClusterMap);
     listenerPort = serverProperties.getInt(LISTENER_PORT, 0);
+    listernerHostname = serverProperties.getString(LISTENER_HOSTNAME, () -> Utils.getHostName());
     dataBasePath = serverProperties.getString(
         DATA_BASE_PATH,
         Paths.get(System.getProperty("java.io.tmpdir"), "venice-server-data").toAbsolutePath().toString());
@@ -591,6 +595,10 @@ public class VeniceServerConfig extends VeniceClusterConfig {
 
   public int getListenerPort() {
     return listenerPort;
+  }
+
+  public String getListenerHostname() {
+    return listernerHostname;
   }
 
   /**

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/helix/HelixParticipationService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/helix/HelixParticipationService.java
@@ -100,17 +100,24 @@ public class HelixParticipationService extends AbstractVeniceService
       String zkAddress,
       String clusterName,
       int port,
+      String hostname,
       CompletableFuture<SafeHelixManager> managerFuture) {
     this.ingestionService = storeIngestionService;
     this.storageService = storageService;
     this.clusterName = clusterName;
     // The format of instance name must be "$host_$port", otherwise Helix can not get these information correctly.
-    this.participantName = Utils.getHelixNodeIdentifier(port);
+    this.participantName = Utils.getHelixNodeIdentifier(hostname, port);
     this.zkAddress = zkAddress;
     this.veniceConfigLoader = veniceConfigLoader;
     this.helixReadOnlyStoreRepository = helixReadOnlyStoreRepository;
     this.metricsRepository = metricsRepository;
-    this.instance = new Instance(participantName, Utils.getHostName(), port);
+    this.instance = new Instance(participantName, hostname, port);
+    LOGGER.info(
+        "Instance name: {}, hostname: {}, port: {}, url {}",
+        participantName,
+        hostname,
+        port,
+        instance.getUrl(false));
     this.managerFuture = managerFuture;
     this.partitionPushStatusAccessorFuture = new CompletableFuture<>();
     if (!(storeIngestionService instanceof KafkaStoreIngestionService)) {

--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -12,6 +12,8 @@ public class ConfigKeys {
   public static final String ZOOKEEPER_ADDRESS = "zookeeper.address";
 
   public static final String ADMIN_PORT = "admin.port";
+  public static final String ADMIN_HOSTNAME = "admin.hostname";
+
   public static final String ADMIN_SECURE_PORT = "admin.secure.port";
 
   /**
@@ -330,6 +332,9 @@ public class ConfigKeys {
 
   // Server specific configs
   public static final String LISTENER_PORT = "listener.port";
+
+  public static final String LISTENER_HOSTNAME = "listener.hostname";
+
   public static final String DATA_BASE_PATH = "data.base.path";
   public static final String AUTOCREATE_DATA_PATH = "autocreate.data.path";
   public static final String ENABLE_SERVER_ALLOW_LIST = "enable.server.allowlist";

--- a/internal/venice-common/src/main/java/com/linkedin/venice/utils/Utils.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/utils/Utils.java
@@ -249,6 +249,7 @@ public class Utils {
     }
     try {
       String hostName = InetAddress.getLocalHost().getHostName();
+      LOGGER.info("Resolved local hostname from InetAddress.getLocalHost() {}", hostName);
       if (StringUtils.isEmpty(hostName)) {
         throw new VeniceException("Unable to get the hostname.");
       }
@@ -330,8 +331,8 @@ public class Utils {
     }
   }
 
-  public static String getHelixNodeIdentifier(int port) {
-    return Utils.getHostName() + "_" + port;
+  public static String getHelixNodeIdentifier(String hostname, int port) {
+    return hostname + "_" + port;
   }
 
   public static String parseHostFromHelixNodeIdentifier(String nodeId) {

--- a/internal/venice-common/src/test/java/com/linkedin/venice/utils/UtilsTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/utils/UtilsTest.java
@@ -25,15 +25,24 @@ public class UtilsTest {
   @Test
   public void testGetHelixNodeIdentifier() {
     int port = 1234;
-    String identifier = Utils.getHelixNodeIdentifier(1234);
-    assertEquals(identifier, Utils.getHostName() + "_" + port, "Identifier is not the valid format required by Helix.");
+    assertEquals(
+        Utils.getHelixNodeIdentifier(Utils.getHostName(), 1234),
+        Utils.getHostName() + "_" + port,
+        "Identifier is not the valid format required by Helix.");
+
+    String fixedHostname = "my_host";
+    assertEquals(
+        Utils.getHelixNodeIdentifier(fixedHostname, 1234),
+        fixedHostname + "_" + port,
+        "Identifier is not the valid format required by Helix.");
   }
 
   @Test
   public void testParseHostAndPortFromNodeIdentifier() {
     int port = 1234;
-    String identifier = Utils.getHelixNodeIdentifier(1234);
-    assertEquals(Utils.parseHostFromHelixNodeIdentifier(identifier), Utils.getHostName());
+    String host = Utils.getHostName();
+    String identifier = Utils.getHelixNodeIdentifier(host, 1234);
+    assertEquals(Utils.parseHostFromHelixNodeIdentifier(identifier), host);
     assertEquals(Utils.parsePortFromHelixNodeIdentifier(identifier), port);
 
     identifier = "my_host_" + port;

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/controller/TestAdminToolEndToEnd.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/controller/TestAdminToolEndToEnd.java
@@ -154,7 +154,7 @@ public class TestAdminToolEndToEnd {
     VeniceServerWrapper server = venice.getVeniceServers().get(0);
     String[] nodeReplicasReadinessArgs =
         { "--node-replicas-readiness", "--url", venice.getLeaderVeniceController().getControllerUrl(), "--cluster",
-            clusterName, "--storage-node", Utils.getHelixNodeIdentifier(server.getPort()) };
+            clusterName, "--storage-node", Utils.getHelixNodeIdentifier(Utils.getHostName(), server.getPort()) };
     AdminTool.main(nodeReplicasReadinessArgs);
   }
 }

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/controller/TestDelayedRebalance.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/controller/TestDelayedRebalance.java
@@ -107,7 +107,8 @@ public class TestDelayedRebalance {
     PartitionAssignment partitionAssignment =
         cluster.getRandomVeniceRouter().getRoutingDataRepository().getPartitionAssignments(topicName);
     Assert.assertNull(
-        partitionAssignment.getPartition(0).getInstanceStatusById(Utils.getHelixNodeIdentifier(failServerPort)));
+        partitionAssignment.getPartition(0)
+            .getInstanceStatusById(Utils.getHelixNodeIdentifier(Utils.getHostName(), failServerPort)));
   }
 
   @Test
@@ -157,7 +158,7 @@ public class TestDelayedRebalance {
       RoutingDataRepository routingDataRepository = cluster.getRandomVeniceRouter().getRoutingDataRepository();
       Assert.assertTrue(routingDataRepository.containsKafkaTopic(topicName));
       Assert.assertEquals(routingDataRepository.getReadyToServeInstances(topicName, 0).size(), 2);
-      String instanceId = Utils.getHelixNodeIdentifier(failServerPort);
+      String instanceId = Utils.getHelixNodeIdentifier(Utils.getHostName(), failServerPort);
       Assert.assertNull(
           routingDataRepository.getPartitionAssignments(topicName).getPartition(0).getInstanceStatusById(instanceId));
     });
@@ -200,7 +201,8 @@ public class TestDelayedRebalance {
         cluster.getRandomVeniceRouter().getRoutingDataRepository().getPartitionAssignments(topicName);
     // The restart server get the original replica and become ONLINE again.
     Assert.assertEquals(
-        partitionAssignment.getPartition(0).getInstanceStatusById(Utils.getHelixNodeIdentifier(failServerPort)),
+        partitionAssignment.getPartition(0)
+            .getInstanceStatusById(Utils.getHelixNodeIdentifier(Utils.getHostName(), failServerPort)),
         ExecutionStatus.COMPLETED.name());
   }
 

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/controller/TestHolisticSeverHealthCheck.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/controller/TestHolisticSeverHealthCheck.java
@@ -66,7 +66,7 @@ public class TestHolisticSeverHealthCheck {
   private void verifyNodesAreReady() {
     String wrongNodeId = "incorrect_node_id";
     for (VeniceServerWrapper server: cluster.getVeniceServers()) {
-      String nodeId = Utils.getHelixNodeIdentifier(server.getPort());
+      String nodeId = Utils.getHelixNodeIdentifier(Utils.getHostName(), server.getPort());
       Assert.assertTrue(verifyNodeReplicasState(nodeId, NodeReplicasReadinessState.READY));
       Assert.assertTrue(verifyNodeIsError(wrongNodeId));
     }
@@ -74,7 +74,7 @@ public class TestHolisticSeverHealthCheck {
 
   private void verifyNodesAreInExpectedState(NodeReplicasReadinessState state) {
     for (VeniceServerWrapper server: cluster.getVeniceServers()) {
-      String nodeId = Utils.getHelixNodeIdentifier(server.getPort());
+      String nodeId = Utils.getHelixNodeIdentifier(Utils.getHostName(), server.getPort());
       Assert.assertTrue(verifyNodeReplicasState(nodeId, state));
     }
   }
@@ -157,7 +157,7 @@ public class TestHolisticSeverHealthCheck {
 
     // Wait until the servers are in the ready state again.
     for (VeniceServerWrapper server: cluster.getVeniceServers()) {
-      String nodeId = Utils.getHelixNodeIdentifier(server.getPort());
+      String nodeId = Utils.getHelixNodeIdentifier(Utils.getHostName(), server.getPort());
       TestUtils.waitForNonDeterministicCompletion(
           120,
           TimeUnit.SECONDS,

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/controller/TestInstanceRemovable.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/controller/TestInstanceRemovable.java
@@ -79,20 +79,26 @@ public class TestInstanceRemovable {
       int serverPort3 = cluster.getVeniceServers().get(2).getPort();
 
       try (ControllerClient client = new ControllerClient(clusterName, urls)) {
-        Assert.assertTrue(client.isNodeRemovable(Utils.getHelixNodeIdentifier(serverPort1)).isRemovable());
-        Assert.assertTrue(client.isNodeRemovable(Utils.getHelixNodeIdentifier(serverPort2)).isRemovable());
-        Assert.assertTrue(client.isNodeRemovable(Utils.getHelixNodeIdentifier(serverPort3)).isRemovable());
+        Assert.assertTrue(
+            client.isNodeRemovable(Utils.getHelixNodeIdentifier(Utils.getHostName(), serverPort1)).isRemovable());
+        Assert.assertTrue(
+            client.isNodeRemovable(Utils.getHelixNodeIdentifier(Utils.getHostName(), serverPort2)).isRemovable());
+        Assert.assertTrue(
+            client.isNodeRemovable(Utils.getHelixNodeIdentifier(Utils.getHostName(), serverPort3)).isRemovable());
 
         /*
          * This is the same scenario as we would do later in the following test steps.
          * If hosts serverPort1 and serverPort2 were stopped, host serverPort3 would still be removable.
          */
-        Assert.assertTrue(
-            client
-                .isNodeRemovable(
-                    Utils.getHelixNodeIdentifier(serverPort3),
-                    Arrays.asList(Utils.getHelixNodeIdentifier(serverPort1), Utils.getHelixNodeIdentifier(serverPort2)))
-                .isRemovable());
+        Assert
+            .assertTrue(
+                client
+                    .isNodeRemovable(
+                        Utils.getHelixNodeIdentifier(Utils.getHostName(), serverPort3),
+                        Arrays.asList(
+                            Utils.getHelixNodeIdentifier(Utils.getHostName(), serverPort1),
+                            Utils.getHelixNodeIdentifier(Utils.getHostName(), serverPort2)))
+                    .isRemovable());
 
         // stop a server during push
         cluster.stopVeniceServer(serverPort1);
@@ -101,8 +107,10 @@ public class TestInstanceRemovable {
             TimeUnit.SECONDS,
             () -> cluster.getLeaderVeniceController().getVeniceAdmin().getReplicas(clusterName, topicName).size() == 4);
         // could remove the rest of nodes as well
-        Assert.assertTrue(client.isNodeRemovable(Utils.getHelixNodeIdentifier(serverPort2)).isRemovable());
-        Assert.assertTrue(client.isNodeRemovable(Utils.getHelixNodeIdentifier(serverPort3)).isRemovable());
+        Assert.assertTrue(
+            client.isNodeRemovable(Utils.getHelixNodeIdentifier(Utils.getHostName(), serverPort2)).isRemovable());
+        Assert.assertTrue(
+            client.isNodeRemovable(Utils.getHelixNodeIdentifier(Utils.getHostName(), serverPort3)).isRemovable());
         // stop one more server
         cluster.stopVeniceServer(serverPort2);
         TestUtils.waitForNonDeterministicCompletion(
@@ -110,7 +118,8 @@ public class TestInstanceRemovable {
             TimeUnit.SECONDS,
             () -> cluster.getLeaderVeniceController().getVeniceAdmin().getReplicas(clusterName, topicName).size() == 2);
         // Even if there are no alive storage nodes, push should not fail.
-        Assert.assertTrue(client.isNodeRemovable(Utils.getHelixNodeIdentifier(serverPort3)).isRemovable());
+        Assert.assertTrue(
+            client.isNodeRemovable(Utils.getHelixNodeIdentifier(Utils.getHostName(), serverPort3)).isRemovable());
         // Add the storage servers back and the ingestion should still be able to complete.
         cluster.addVeniceServer(new Properties(), new Properties());
         cluster.addVeniceServer(new Properties(), new Properties());
@@ -168,18 +177,19 @@ public class TestInstanceRemovable {
      * 3. If serverPort1 were stopped, host serverPort3 is non-removable.
      */
     try (ControllerClient client = new ControllerClient(clusterName, urls)) {
-      Assert.assertTrue(client.isNodeRemovable(Utils.getHelixNodeIdentifier(serverPort1)).isRemovable());
+      Assert.assertTrue(
+          client.isNodeRemovable(Utils.getHelixNodeIdentifier(Utils.getHostName(), serverPort1)).isRemovable());
       Assert.assertFalse(
           client
               .isNodeRemovable(
-                  Utils.getHelixNodeIdentifier(serverPort2),
-                  Arrays.asList(Utils.getHelixNodeIdentifier(serverPort1)))
+                  Utils.getHelixNodeIdentifier(Utils.getHostName(), serverPort2),
+                  Arrays.asList(Utils.getHelixNodeIdentifier(Utils.getHostName(), serverPort1)))
               .isRemovable());
       Assert.assertFalse(
           client
               .isNodeRemovable(
-                  Utils.getHelixNodeIdentifier(serverPort3),
-                  Arrays.asList(Utils.getHelixNodeIdentifier(serverPort1)))
+                  Utils.getHelixNodeIdentifier(Utils.getHostName(), serverPort3),
+                  Arrays.asList(Utils.getHelixNodeIdentifier(Utils.getHostName(), serverPort1)))
               .isRemovable());
     }
 
@@ -190,9 +200,12 @@ public class TestInstanceRemovable {
         () -> cluster.getLeaderVeniceController().getVeniceAdmin().getReplicas(clusterName, topicName).size() == 4);
     // Can not remove node cause, it will trigger re-balance.
     try (ControllerClient client = new ControllerClient(clusterName, urls)) {
-      Assert.assertTrue(client.isNodeRemovable(Utils.getHelixNodeIdentifier(serverPort1)).isRemovable());
-      Assert.assertFalse(client.isNodeRemovable(Utils.getHelixNodeIdentifier(serverPort2)).isRemovable());
-      Assert.assertFalse(client.isNodeRemovable(Utils.getHelixNodeIdentifier(serverPort3)).isRemovable());
+      Assert.assertTrue(
+          client.isNodeRemovable(Utils.getHelixNodeIdentifier(Utils.getHostName(), serverPort1)).isRemovable());
+      Assert.assertFalse(
+          client.isNodeRemovable(Utils.getHelixNodeIdentifier(Utils.getHostName(), serverPort2)).isRemovable());
+      Assert.assertFalse(
+          client.isNodeRemovable(Utils.getHelixNodeIdentifier(Utils.getHostName(), serverPort3)).isRemovable());
 
       VeniceServerWrapper newServer = cluster.addVeniceServer(false, false);
       int serverPort4 = newServer.getPort();
@@ -201,31 +214,34 @@ public class TestInstanceRemovable {
           TimeUnit.SECONDS,
           () -> cluster.getLeaderVeniceController()
               .getVeniceAdmin()
-              .getReplicasOfStorageNode(clusterName, Utils.getHelixNodeIdentifier(serverPort4))
+              .getReplicasOfStorageNode(clusterName, Utils.getHelixNodeIdentifier(Utils.getHostName(), serverPort4))
               .size() == 2);
       // After replica number back to 3, all of node could be removed.
-      Assert.assertTrue(client.isNodeRemovable(Utils.getHelixNodeIdentifier(serverPort2)).isRemovable());
-      Assert.assertTrue(client.isNodeRemovable(Utils.getHelixNodeIdentifier(serverPort3)).isRemovable());
-      Assert.assertTrue(client.isNodeRemovable(Utils.getHelixNodeIdentifier(serverPort4)).isRemovable());
+      Assert.assertTrue(
+          client.isNodeRemovable(Utils.getHelixNodeIdentifier(Utils.getHostName(), serverPort2)).isRemovable());
+      Assert.assertTrue(
+          client.isNodeRemovable(Utils.getHelixNodeIdentifier(Utils.getHostName(), serverPort3)).isRemovable());
+      Assert.assertTrue(
+          client.isNodeRemovable(Utils.getHelixNodeIdentifier(Utils.getHostName(), serverPort4)).isRemovable());
 
       // After adding a new server, all servers are removable, even serverPort1 is still stopped.
       Assert.assertTrue(
           client
               .isNodeRemovable(
-                  Utils.getHelixNodeIdentifier(serverPort2),
-                  Arrays.asList(Utils.getHelixNodeIdentifier(serverPort1)))
+                  Utils.getHelixNodeIdentifier(Utils.getHostName(), serverPort2),
+                  Arrays.asList(Utils.getHelixNodeIdentifier(Utils.getHostName(), serverPort1)))
               .isRemovable());
       Assert.assertTrue(
           client
               .isNodeRemovable(
-                  Utils.getHelixNodeIdentifier(serverPort3),
-                  Arrays.asList(Utils.getHelixNodeIdentifier(serverPort1)))
+                  Utils.getHelixNodeIdentifier(Utils.getHostName(), serverPort3),
+                  Arrays.asList(Utils.getHelixNodeIdentifier(Utils.getHostName(), serverPort1)))
               .isRemovable());
       Assert.assertTrue(
           client
               .isNodeRemovable(
-                  Utils.getHelixNodeIdentifier(serverPort4),
-                  Arrays.asList(Utils.getHelixNodeIdentifier(serverPort1)))
+                  Utils.getHelixNodeIdentifier(Utils.getHostName(), serverPort4),
+                  Arrays.asList(Utils.getHelixNodeIdentifier(Utils.getHostName(), serverPort1)))
               .isRemovable());
 
       // Test if all instances of a partition are removed via a combination of locked instances and the requested node.
@@ -233,11 +249,11 @@ public class TestInstanceRemovable {
           .assertFalse(
               client
                   .isNodeRemovable(
-                      Utils.getHelixNodeIdentifier(serverPort4),
+                      Utils.getHelixNodeIdentifier(Utils.getHostName(), serverPort4),
                       Arrays.asList(
-                          Utils.getHelixNodeIdentifier(serverPort1),
-                          Utils.getHelixNodeIdentifier(serverPort2),
-                          Utils.getHelixNodeIdentifier(serverPort3)))
+                          Utils.getHelixNodeIdentifier(Utils.getHostName(), serverPort1),
+                          Utils.getHelixNodeIdentifier(Utils.getHostName(), serverPort2),
+                          Utils.getHelixNodeIdentifier(Utils.getHostName(), serverPort3)))
                   .isRemovable());
     }
   }

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/controller/TestVeniceHelixAdminWithIsolatedEnvironment.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/controller/TestVeniceHelixAdminWithIsolatedEnvironment.java
@@ -306,7 +306,7 @@ public class TestVeniceHelixAdminWithIsolatedEnvironment extends AbstractTestVen
   public void testGetLeaderController() {
     Assert.assertEquals(
         veniceAdmin.getLeaderController(clusterName).getNodeId(),
-        Utils.getHelixNodeIdentifier(controllerConfig.getAdminPort()));
+        Utils.getHelixNodeIdentifier(controllerConfig.getAdminHostname(), controllerConfig.getAdminPort()));
     // Create a new controller and test getLeaderController again.
     int newAdminPort = controllerConfig.getAdminPort() - 10;
     PropertyBuilder builder = new PropertyBuilder().put(controllerProps.toProperties()).put("admin.port", newAdminPort);
@@ -324,18 +324,18 @@ public class TestVeniceHelixAdminWithIsolatedEnvironment extends AbstractTestVen
     if (veniceAdmin.isLeaderControllerFor(clusterName)) {
       Assert.assertEquals(
           veniceAdmin.getLeaderController(clusterName).getNodeId(),
-          Utils.getHelixNodeIdentifier(controllerConfig.getAdminPort()));
+          Utils.getHelixNodeIdentifier(controllerConfig.getAdminHostname(), controllerConfig.getAdminPort()));
     } else {
       Assert.assertEquals(
           veniceAdmin.getLeaderController(clusterName).getNodeId(),
-          Utils.getHelixNodeIdentifier(newAdminPort));
+          Utils.getHelixNodeIdentifier(controllerConfig.getAdminHostname(), newAdminPort));
     }
     newLeaderAdmin.stop(clusterName);
     admins.remove(newLeaderAdmin);
     waitForALeader(admins, clusterName, LEADER_CHANGE_TIMEOUT_MS);
     Assert.assertEquals(
         veniceAdmin.getLeaderController(clusterName).getNodeId(),
-        Utils.getHelixNodeIdentifier(controllerConfig.getAdminPort()),
+        Utils.getHelixNodeIdentifier(controllerConfig.getAdminHostname(), controllerConfig.getAdminPort()),
         "Controller should be back to original one.");
     veniceAdmin.stop(clusterName);
     TestUtils.waitForNonDeterministicCompletion(

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/controller/TestVeniceHelixAdminWithSharedEnvironment.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/controller/TestVeniceHelixAdminWithSharedEnvironment.java
@@ -826,7 +826,7 @@ public class TestVeniceHelixAdminWithSharedEnvironment extends AbstractTestVenic
     int testPort = 5555;
     Assert.assertEquals(veniceAdmin.getAllowlist(clusterName).size(), 0, "Allow list should be empty.");
 
-    veniceAdmin.addInstanceToAllowlist(clusterName, Utils.getHelixNodeIdentifier(testPort));
+    veniceAdmin.addInstanceToAllowlist(clusterName, Utils.getHelixNodeIdentifier(Utils.getHostName(), testPort));
     Assert.assertEquals(
         veniceAdmin.getAllowlist(clusterName).size(),
         1,
@@ -834,9 +834,9 @@ public class TestVeniceHelixAdminWithSharedEnvironment extends AbstractTestVenic
 
     Assert.assertEquals(
         veniceAdmin.getAllowlist(clusterName).iterator().next(),
-        Utils.getHelixNodeIdentifier(testPort),
+        Utils.getHelixNodeIdentifier(Utils.getHostName(), testPort),
         "Instance in the allowlist is not the one added before.");
-    veniceAdmin.removeInstanceFromAllowList(clusterName, Utils.getHelixNodeIdentifier(testPort));
+    veniceAdmin.removeInstanceFromAllowList(clusterName, Utils.getHelixNodeIdentifier(Utils.getHostName(), testPort));
     Assert.assertEquals(
         veniceAdmin.getAllowlist(clusterName).size(),
         0,
@@ -847,7 +847,7 @@ public class TestVeniceHelixAdminWithSharedEnvironment extends AbstractTestVenic
   public void testKillOfflinePush() throws Exception {
     String participantStoreRTTopic =
         Version.composeRealTimeTopic(VeniceSystemStoreUtils.getParticipantStoreNameForCluster(clusterName));
-    String newNodeId = Utils.getHelixNodeIdentifier(9786);
+    String newNodeId = Utils.getHelixNodeIdentifier(Utils.getHostName(), 9786);
     // Ensure original participant store would hang on bootstrap state.
     delayParticipantJobCompletion(true);
     startParticipant(true, newNodeId);

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/controller/server/TestAdminSparkServer.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/controller/server/TestAdminSparkServer.java
@@ -470,7 +470,7 @@ public class TestAdminSparkServer extends AbstractTestAdminSparkServer {
   @Test(timeOut = TEST_TIMEOUT)
   public void controllerClientCanQueryRemovability() {
     VeniceServerWrapper server = cluster.getVeniceServers().get(0);
-    String nodeId = Utils.getHelixNodeIdentifier(server.getPort());
+    String nodeId = Utils.getHelixNodeIdentifier(Utils.getHostName(), server.getPort());
 
     ControllerResponse response = controllerClient.isNodeRemovable(nodeId);
     Assert.assertFalse(response.isError(), response.getError());
@@ -612,7 +612,7 @@ public class TestAdminSparkServer extends AbstractTestAdminSparkServer {
   public void controllerClientCanUpdateAllowList() {
     Admin admin = cluster.getLeaderVeniceController().getVeniceAdmin();
 
-    String nodeId = Utils.getHelixNodeIdentifier(34567);
+    String nodeId = Utils.getHelixNodeIdentifier(Utils.getHostName(), 34567);
     Assert.assertFalse(
         admin.getAllowlist(cluster.getClusterName()).contains(nodeId),
         nodeId + " has not been added into allowlist.");

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/controller/server/TestAdminSparkServerWithMultiServers.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/controller/server/TestAdminSparkServerWithMultiServers.java
@@ -440,7 +440,7 @@ public class TestAdminSparkServerWithMultiServers {
   public void controllerClientCanRemoveNodeFromCluster() {
     Admin admin = cluster.getLeaderVeniceController().getVeniceAdmin();
     VeniceServerWrapper server = cluster.getVeniceServers().get(0);
-    String nodeId = Utils.getHelixNodeIdentifier(server.getPort());
+    String nodeId = Utils.getHelixNodeIdentifier(Utils.getHostName(), server.getPort());
     // Trying to remove a live node.
     ControllerResponse response = controllerClient.removeNodeFromCluster(nodeId);
     Assert.assertTrue(response.isError(), "Node is still connected to cluster, could not be removed.");

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/helix/HelixPartitionPushStatusAccessorTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/helix/HelixPartitionPushStatusAccessorTest.java
@@ -62,7 +62,7 @@ public class HelixPartitionPushStatusAccessorTest {
     httpPort1 = 50000 + (int) (System.currentTimeMillis() % 10000);
     manager1 = TestUtils.getParticipant(
         clusterName,
-        Utils.getHelixNodeIdentifier(httpPort1),
+        Utils.getHelixNodeIdentifier(Utils.getHostName(), httpPort1),
         zkAddress,
         httpPort1,
         MockTestStateModel.UNIT_TEST_STATE_MODEL);
@@ -74,7 +74,7 @@ public class HelixPartitionPushStatusAccessorTest {
     httpPort2 = 50000 + (int) (System.currentTimeMillis() % 10000) + 1;
     manager2 = TestUtils.getParticipant(
         clusterName,
-        Utils.getHelixNodeIdentifier(httpPort2),
+        Utils.getHelixNodeIdentifier(Utils.getHostName(), httpPort2),
         zkAddress,
         httpPort2,
         MockTestStateModel.UNIT_TEST_STATE_MODEL);

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/helix/TestHelixCustomizedViewOfflinePushRepository.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/helix/TestHelixCustomizedViewOfflinePushRepository.java
@@ -92,12 +92,12 @@ public class TestHelixCustomizedViewOfflinePushRepository {
         HelixControllerMain.startHelixController(
             zkAddress,
             clusterName,
-            Utils.getHelixNodeIdentifier(adminPort),
+            Utils.getHelixNodeIdentifier(Utils.getHostName(), adminPort),
             HelixControllerMain.STANDALONE));
 
     manager0 = TestUtils.getParticipant(
         clusterName,
-        Utils.getHelixNodeIdentifier(httpPort0),
+        Utils.getHelixNodeIdentifier(Utils.getHostName(), httpPort0),
         zkAddress,
         httpPort0,
         MockTestStateModel.UNIT_TEST_STATE_MODEL);
@@ -107,7 +107,7 @@ public class TestHelixCustomizedViewOfflinePushRepository {
 
     manager1 = TestUtils.getParticipant(
         clusterName,
-        Utils.getHelixNodeIdentifier(httpPort1),
+        Utils.getHelixNodeIdentifier(Utils.getHostName(), httpPort1),
         zkAddress,
         httpPort1,
         MockTestStateModel.UNIT_TEST_STATE_MODEL);
@@ -230,7 +230,7 @@ public class TestHelixCustomizedViewOfflinePushRepository {
     int newHttpPort = httpPort0 + 10;
     SafeHelixManager newManager = TestUtils.getParticipant(
         clusterName,
-        Utils.getHelixNodeIdentifier(newHttpPort),
+        Utils.getHelixNodeIdentifier(Utils.getHostName(), newHttpPort),
         zkAddress,
         newHttpPort,
         MockTestStateModel.UNIT_TEST_STATE_MODEL);

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/helix/TestHelixExternalViewRepository.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/helix/TestHelixExternalViewRepository.java
@@ -78,12 +78,12 @@ public class TestHelixExternalViewRepository {
         HelixControllerMain.startHelixController(
             zkAddress,
             clusterName,
-            Utils.getHelixNodeIdentifier(adminPort),
+            Utils.getHelixNodeIdentifier(Utils.getHostName(), adminPort),
             HelixControllerMain.STANDALONE));
 
     manager = TestUtils.getParticipant(
         clusterName,
-        Utils.getHelixNodeIdentifier(httpPort),
+        Utils.getHelixNodeIdentifier(Utils.getHostName(), httpPort),
         zkAddress,
         httpPort,
         MockTestStateModel.UNIT_TEST_STATE_MODEL);
@@ -130,7 +130,7 @@ public class TestHelixExternalViewRepository {
     int newHttpPort = httpPort + 10;
     SafeHelixManager newManager = TestUtils.getParticipant(
         clusterName,
-        Utils.getHelixNodeIdentifier(newHttpPort),
+        Utils.getHelixNodeIdentifier(Utils.getHostName(), newHttpPort),
         zkAddress,
         newHttpPort,
         MockTestStateModel.UNIT_TEST_STATE_MODEL);
@@ -259,7 +259,7 @@ public class TestHelixExternalViewRepository {
     SafeHelixManager newLeader = new SafeHelixManager(
         HelixManagerFactory.getZKHelixManager(
             clusterName,
-            Utils.getHelixNodeIdentifier(newAdminPort),
+            Utils.getHelixNodeIdentifier(Utils.getHostName(), newAdminPort),
             InstanceType.CONTROLLER,
             zkAddress));
     newLeader.connect();
@@ -301,7 +301,7 @@ public class TestHelixExternalViewRepository {
     factory.setBlockTransition(true);
     manager = TestUtils.getParticipant(
         clusterName,
-        Utils.getHelixNodeIdentifier(httpPort + 1),
+        Utils.getHelixNodeIdentifier(Utils.getHostName(), httpPort + 1),
         zkAddress,
         httpPort + 1,
         factory,
@@ -350,7 +350,7 @@ public class TestHelixExternalViewRepository {
 
     SafeHelixManager newManager = TestUtils.getParticipant(
         clusterName,
-        Utils.getHelixNodeIdentifier(httpPort + 1000),
+        Utils.getHelixNodeIdentifier(Utils.getHostName(), httpPort + 1000),
         zkAddress,
         httpPort + 1000,
         MockTestStateModel.UNIT_TEST_STATE_MODEL);

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/helix/TestHelixStatusMessageChannel.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/helix/TestHelixStatusMessageChannel.java
@@ -75,7 +75,7 @@ public class TestHelixStatusMessageChannel {
         HelixControllerMain
             .startHelixController(zkAddress, cluster, "UnitTestController", HelixControllerMain.STANDALONE));
     controller.connect();
-    instanceId = Utils.getHelixNodeIdentifier(port);
+    instanceId = Utils.getHelixNodeIdentifier(Utils.getHostName(), port);
     manager = TestUtils.getParticipant(cluster, instanceId, zkAddress, port, MockTestStateModel.UNIT_TEST_STATE_MODEL);
     manager.connect();
     helixMessageChannelStats = new HelixMessageChannelStats(new MetricsRepository(), cluster);
@@ -240,7 +240,7 @@ public class TestHelixStatusMessageChannel {
     // Start a new participant
     SafeHelixManager newParticipant = TestUtils.getParticipant(
         cluster,
-        Utils.getHelixNodeIdentifier(port + 1),
+        Utils.getHelixNodeIdentifier(Utils.getHostName(), port + 1),
         zkAddress,
         port + 1,
         MockTestStateModel.UNIT_TEST_STATE_MODEL);
@@ -277,7 +277,7 @@ public class TestHelixStatusMessageChannel {
     // Start a new participant
     SafeHelixManager newParticipant = TestUtils.getParticipant(
         cluster,
-        Utils.getHelixNodeIdentifier(port + 1),
+        Utils.getHelixNodeIdentifier(Utils.getHostName(), port + 1),
         zkAddress,
         port + 1,
         MockTestStateModel.UNIT_TEST_STATE_MODEL);
@@ -290,7 +290,7 @@ public class TestHelixStatusMessageChannel {
     TestUtils.waitForNonDeterministicCompletion(
         WAIT_ZK_TIME,
         TimeUnit.MILLISECONDS,
-        () -> routingDataRepository.isLiveInstance(Utils.getHelixNodeIdentifier(port + 1)));
+        () -> routingDataRepository.isLiveInstance(Utils.getHelixNodeIdentifier(Utils.getHostName(), port + 1)));
 
     HelixStatusMessageChannel controllerChannel =
         getControllerChannel(new TimeoutTestStoreStatusMessageHandler(timeoutCount));
@@ -313,7 +313,7 @@ public class TestHelixStatusMessageChannel {
     // Start a new participant
     SafeHelixManager newParticipant = TestUtils.getParticipant(
         cluster,
-        Utils.getHelixNodeIdentifier(port + 1),
+        Utils.getHelixNodeIdentifier(Utils.getHostName(), port + 1),
         zkAddress,
         port + 1,
         MockTestStateModel.UNIT_TEST_STATE_MODEL);
@@ -390,7 +390,7 @@ public class TestHelixStatusMessageChannel {
       }
     });
 
-    String id = Utils.getHelixNodeIdentifier(port + 10);
+    String id = Utils.getHelixNodeIdentifier(Utils.getHostName(), port + 10);
     SafeHelixManager newClusterParticipant =
         TestUtils.getParticipant(newCluster, id, zkAddress, port + 10, MockTestStateModel.UNIT_TEST_STATE_MODEL);
     newClusterParticipant.connect();

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/helix/ZkAllowlistAccessorTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/helix/ZkAllowlistAccessorTest.java
@@ -35,7 +35,7 @@ public class ZkAllowlistAccessorTest {
 
   @Test
   public void testAddInstanceIntoAllowlist() {
-    String helixNodeId = Utils.getHelixNodeIdentifier(port);
+    String helixNodeId = Utils.getHelixNodeIdentifier(Utils.getHostName(), port);
     Assert.assertFalse(
         accessor.isInstanceInAllowlist(cluster, helixNodeId),
         "Instance has not been added into the allowlist.");
@@ -47,7 +47,7 @@ public class ZkAllowlistAccessorTest {
 
   @Test
   public void testRemoveInstanceFromAllowlist() {
-    String helixNodeId = Utils.getHelixNodeIdentifier(port);
+    String helixNodeId = Utils.getHelixNodeIdentifier(Utils.getHostName(), port);
     accessor.removeInstanceFromAllowList(cluster, helixNodeId);
     accessor.addInstanceToAllowList(cluster, helixNodeId);
     Assert.assertTrue(
@@ -62,11 +62,12 @@ public class ZkAllowlistAccessorTest {
 
   @Test
   public void testGetAllowlist() {
-    Assert.assertFalse(accessor.isInstanceInAllowlist(cluster, Utils.getHelixNodeIdentifier(port)));
+    Assert
+        .assertFalse(accessor.isInstanceInAllowlist(cluster, Utils.getHelixNodeIdentifier(Utils.getHostName(), port)));
     Assert.assertTrue(accessor.getAllowList(cluster).isEmpty(), "allowlist should be empty.");
     int instanceCount = 3;
     for (int i = 0; i < instanceCount; i++) {
-      accessor.addInstanceToAllowList(cluster, Utils.getHelixNodeIdentifier(port + i));
+      accessor.addInstanceToAllowList(cluster, Utils.getHelixNodeIdentifier(Utils.getHostName(), port + i));
     }
 
     Assert.assertEquals(accessor.getAllowList(cluster).size(), instanceCount);

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/helix/ZkRoutersClusterManagerTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/helix/ZkRoutersClusterManagerTest.java
@@ -41,7 +41,7 @@ public class ZkRoutersClusterManagerTest {
     ZkRoutersClusterManager[] managers = new ZkRoutersClusterManager[routersCount];
     for (int i = 0; i < routersCount; i++) {
       int port = 10555 + i;
-      String instanceId = Utils.getHelixNodeIdentifier(port);
+      String instanceId = Utils.getHelixNodeIdentifier(Utils.getHostName(), port);
       ZkRoutersClusterManager manager = createManager(zkClient);
       managers[i] = manager;
       manager.registerRouter(instanceId);
@@ -69,8 +69,8 @@ public class ZkRoutersClusterManagerTest {
     ZkClient failedZkClient = new ZkClient(zkServerWrapper.getAddress());
     ZkRoutersClusterManager failedManager = createManager(failedZkClient);
     // Register two routers through different zk clients.
-    manager.registerRouter(Utils.getHelixNodeIdentifier(port));
-    failedManager.registerRouter(Utils.getHelixNodeIdentifier(port + 1));
+    manager.registerRouter(Utils.getHelixNodeIdentifier(Utils.getHostName(), port));
+    failedManager.registerRouter(Utils.getHelixNodeIdentifier(Utils.getHostName(), port + 1));
     // Eventually both manager wil get notification to update router count.
     TestUtils.waitForNonDeterministicCompletion(1, TimeUnit.SECONDS, () -> manager.getLiveRoutersCount() == 2);
     TestUtils.waitForNonDeterministicCompletion(1, TimeUnit.SECONDS, () -> failedManager.getLiveRoutersCount() == 2);
@@ -83,7 +83,7 @@ public class ZkRoutersClusterManagerTest {
   @Test
   public void testUnregisterLiveOuter() {
     int port = 10555;
-    String instanceId = Utils.getHelixNodeIdentifier(port);
+    String instanceId = Utils.getHelixNodeIdentifier(Utils.getHostName(), port);
     ZkRoutersClusterManager manager = createManager(zkClient);
     manager.registerRouter(instanceId);
     Assert.assertEquals(
@@ -100,7 +100,7 @@ public class ZkRoutersClusterManagerTest {
   @Test
   public void testEnableThrottling() {
     int port = 10555;
-    String instanceId = Utils.getHelixNodeIdentifier(port);
+    String instanceId = Utils.getHelixNodeIdentifier(Utils.getHostName(), port);
     ZkRoutersClusterManager manager = createManager(zkClient);
     manager.registerRouter(instanceId);
 
@@ -113,7 +113,7 @@ public class ZkRoutersClusterManagerTest {
   @Test
   public void testEnableQuotaRebalance() {
     int port = 10555;
-    String instanceId = Utils.getHelixNodeIdentifier(port);
+    String instanceId = Utils.getHelixNodeIdentifier(Utils.getHostName(), port);
     ZkRoutersClusterManager manager = createManager(zkClient);
     manager.registerRouter(instanceId);
     int expectRouterNumber = 200;
@@ -128,7 +128,7 @@ public class ZkRoutersClusterManagerTest {
   @Test
   public void testUPdateExpectRouterCount() {
     int port = 10555;
-    String instanceId = Utils.getHelixNodeIdentifier(port);
+    String instanceId = Utils.getHelixNodeIdentifier(Utils.getHostName(), port);
     ZkRoutersClusterManager manager = createManager(zkClient);
     manager.registerRouter(instanceId);
     int expectRouterNumber = -1;
@@ -149,7 +149,7 @@ public class ZkRoutersClusterManagerTest {
   @Test
   public void testEnableMaxCapacityProtection() {
     int port = 10555;
-    String instanceId = Utils.getHelixNodeIdentifier(port);
+    String instanceId = Utils.getHelixNodeIdentifier(Utils.getHostName(), port);
     ZkRoutersClusterManager manager = createManager(zkClient);
     manager.registerRouter(instanceId);
 
@@ -166,7 +166,7 @@ public class ZkRoutersClusterManagerTest {
   @Test
   public void testHandleRouterClusterConfigChange() {
     int port = 10555;
-    String instanceId = Utils.getHelixNodeIdentifier(port);
+    String instanceId = Utils.getHelixNodeIdentifier(Utils.getHostName(), port);
     ZkRoutersClusterManager controller = createManager(zkClient);
     ZkRoutersClusterManager router = createManager(new ZkClient(zkServerWrapper.getAddress()));
     router.registerRouter(instanceId);
@@ -194,7 +194,7 @@ public class ZkRoutersClusterManagerTest {
   @Test
   public void testTriggerRouterClusterConfigChangedEvent() {
     int port = 10555;
-    String instanceId = Utils.getHelixNodeIdentifier(port);
+    String instanceId = Utils.getHelixNodeIdentifier(Utils.getHostName(), port);
     ZkRoutersClusterManager manager = createManager(zkClient);
     manager.registerRouter(instanceId);
     int expectedNumber = 100;

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/helixrebalance/TestRebalanceByDefaultStrategy.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/helixrebalance/TestRebalanceByDefaultStrategy.java
@@ -86,7 +86,7 @@ public class TestRebalanceByDefaultStrategy {
     Set<Integer> ports = new HashSet<>();
     cluster.getVeniceServers().forEach(wrapper -> ports.add(wrapper.getPort()));
     for (Integer port: ports) {
-      String instanceId = Utils.getHelixNodeIdentifier(port);
+      String instanceId = Utils.getHelixNodeIdentifier(Utils.getHostName(), port);
       TestUtils.waitForNonDeterministicCompletion(RETRY_REMOVE_TIMEOUT_MS, TimeUnit.MILLISECONDS, () -> {
         try {
           if (cluster.getLeaderVeniceController()

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/integration/utils/VeniceClusterWrapper.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/integration/utils/VeniceClusterWrapper.java
@@ -667,7 +667,8 @@ public class VeniceClusterWrapper extends ProcessWrapper {
    */
   public synchronized List<Replica> stopVeniceServer(int port) {
     Admin admin = getLeaderVeniceController().getVeniceAdmin();
-    List<Replica> effectedReplicas = admin.getReplicasOfStorageNode(clusterName, Utils.getHelixNodeIdentifier(port));
+    List<Replica> effectedReplicas =
+        admin.getReplicasOfStorageNode(clusterName, Utils.getHelixNodeIdentifier(Utils.getHostName(), port));
     stopVeniceComponent(veniceServerWrappers, port);
     return effectedReplicas;
   }

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/integration/utils/VeniceServerWrapper.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/integration/utils/VeniceServerWrapper.java
@@ -281,7 +281,7 @@ public class VeniceServerWrapper extends ProcessWrapper implements MetricsAware 
 
   private static void joinClusterAllowlist(String zkAddress, String clusterName, int port) throws IOException {
     try (AllowlistAccessor accessor = new ZkAllowlistAccessor(zkAddress)) {
-      accessor.addInstanceToAllowList(clusterName, Utils.getHelixNodeIdentifier(port));
+      accessor.addInstanceToAllowList(clusterName, Utils.getHelixNodeIdentifier(Utils.getHostName(), port));
     }
   }
 

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/server/VeniceServerTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/server/VeniceServerTest.java
@@ -125,7 +125,7 @@ public class VeniceServerTest {
       cluster.stopVeniceServer(server.getPort());
       try (ControllerClient client = ControllerClient
           .constructClusterControllerClient(cluster.getClusterName(), cluster.getAllControllersURLs())) {
-        client.removeNodeFromCluster(Utils.getHelixNodeIdentifier(server.getPort()));
+        client.removeNodeFromCluster(Utils.getHelixNodeIdentifier(Utils.getHostName(), server.getPort()));
       }
 
       cluster.restartVeniceServer(server.getPort());

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/testStatusMessage/integration/SendStatusMessageIntegrationTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/testStatusMessage/integration/SendStatusMessageIntegrationTest.java
@@ -72,7 +72,7 @@ public class SendStatusMessageIntegrationTest {
     DelayedZkClientUtils.startDelayingSocketIoForNewZkClients(lowerDelay, upperDelay);
     SafeHelixManager participant = TestUtils.getParticipant(
         cluster,
-        Utils.getHelixNodeIdentifier(port),
+        Utils.getHelixNodeIdentifier(Utils.getHostName(), port),
         zkAddress,
         port,
         MockTestStateModel.UNIT_TEST_STATE_MODEL);


### PR DESCRIPTION


## Summary, imperative, start upper case, don't end with a period

Allow to configure Router, Controller and Server hostnames. In K8S you don't want to use InetAddress.getLocalhost().getHostname() as it doesn't return the FQDN. This change makes the addresses configurable, this way the infrastructure (K8S/Helm) can inject the values

The core of the change is about changing the signature of this method:
` public static String getHelixNodeIdentifier(int port) {`
 
to:
` public static String getHelixNodeIdentifier(String hostname, int port) {`

## How was this PR tested?
Current tests should pass. 
I have added a small additional case in the Utils tests.
Many tests have been changed in order to explicitly pass the hostname to getNodeIdentifier

## Does this PR introduce any user-facing changes?

The default behaviour is preserved.
Now users can configure admin.hostname and listener.hostname in order to customize the hostname advertised on Helix for the Router, the Server and the Controller.
