### PR TITLE
[controller] Make job status api able to report uncompleted partitions and replicas

### DIFF
--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerClient.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerClient.java
@@ -621,6 +621,18 @@ public class ControllerClient implements Closeable {
     return request(ControllerRoute.JOB, params, JobStatusQueryResponse.class, timeoutMs, 1, null);
   }
 
+  /**
+   * This method will retrieve detailed job status, including uncompleted partitions and replicas from a child region.
+   * If the request is sent to a parent controller, it will be forwarded to a child controller in the specified region.
+   * This method is used for data recovery progress monitoring.
+   */
+  public JobStatusQueryResponse queryDetailedJobStatus(String kafkaTopic, String region) {
+    String storeName = Version.parseStoreFromKafkaTopicName(kafkaTopic);
+    int version = Version.parseVersionFromKafkaTopicName(kafkaTopic);
+    QueryParams params = newParams().add(NAME, storeName).add(VERSION, version).add(FABRIC, region);
+    return request(ControllerRoute.JOB, params, JobStatusQueryResponse.class, QUERY_JOB_STATUS_TIMEOUT, 1, null);
+  }
+
   // TODO remove passing PushJobDetails as JSON string once all VPJ plugins are updated.
   public ControllerResponse sendPushJobDetails(String storeName, int version, String pushJobDetailsString) {
     QueryParams params =

--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/JobStatusQueryResponse.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/JobStatusQueryResponse.java
@@ -103,6 +103,6 @@ public class JobStatusQueryResponse
   public String toString() {
     return JobStatusQueryResponse.class.getSimpleName() + "(\n" + "version: " + version + ",\n" + "status: " + status
         + ",\n" + "statusDetails: " + statusDetails + ",\n" + "extraInfo: " + extraInfo + ",\n" + "extraDetails: "
-        + extraDetails + ",\n" + "uncompletedPartitions: " + uncompletedPartitions + ",\n" + super.toString() + ")";
+        + extraDetails + ",\n" + super.toString() + ")";
   }
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/JobStatusQueryResponse.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/JobStatusQueryResponse.java
@@ -1,7 +1,9 @@
 package com.linkedin.venice.controllerapi;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.linkedin.venice.meta.UncompletedPartition;
 import com.linkedin.venice.pushmonitor.ExecutionStatus;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -17,11 +19,7 @@ public class JobStatusQueryResponse
   private Map<String, String> extraInfo;
   private Map<String, String> extraDetails;
 
-  // The folllowing progress info won't be valid any more, and they could be removed eventually in the future.
-  private long messagesConsumed;
-  private long messagesAvailable;
-  private Map<String, Long> perTaskProgress;
-  private Map<Integer, Long> perPartitionCapacity;
+  private List<UncompletedPartition> uncompletedPartitions;
 
   public int getVersion() {
     return version;
@@ -60,47 +58,6 @@ public class JobStatusQueryResponse
   }
 
   /**
-   * Aggregate number of kafka offsets consumed by all storage nodes for this store version
-   * @return
-   */
-  public long getMessagesConsumed() {
-    return messagesConsumed;
-  }
-
-  public void setMessagesConsumed(long messagesConsumed) {
-    this.messagesConsumed = messagesConsumed;
-  }
-
-  /**
-   * Current aggregate number of kafka offsets available to storage nodes for this store version.
-   * Effectively this is the sum of the highest offset for each partition times the Venice replication factor
-   * @return
-   */
-  public long getMessagesAvailable() {
-    return messagesAvailable;
-  }
-
-  public void setMessagesAvailable(long messagesAvailable) {
-    this.messagesAvailable = messagesAvailable;
-  }
-
-  public Map<String, Long> getPerTaskProgress() {
-    return perTaskProgress;
-  }
-
-  public void setPerTaskProgress(Map<String, Long> perTaskProgress) {
-    this.perTaskProgress = perTaskProgress;
-  }
-
-  public Map<Integer, Long> getPerPartitionCapacity() {
-    return perPartitionCapacity;
-  }
-
-  public void setPerPartitionCapacity(Map<Integer, Long> perPartitionCapacity) {
-    this.perPartitionCapacity = perPartitionCapacity;
-  }
-
-  /**
    * N.B.: The values in this map conform to {@link ExecutionStatus} values.
    *
    * @return A map of datacenter -> status, which can be returned by a parent controller.
@@ -135,15 +92,17 @@ public class JobStatusQueryResponse
     this.extraDetails = extraDetails;
   }
 
-  public static JobStatusQueryResponse createErrorResponse(String errorMessage) {
-    JobStatusQueryResponse response = new JobStatusQueryResponse();
-    response.setError(errorMessage);
-    return response;
+  public void setUncompletedPartitions(List<UncompletedPartition> uncompletedPartitions) {
+    this.uncompletedPartitions = uncompletedPartitions;
+  }
+
+  public List<UncompletedPartition> getUncompletedPartitions() {
+    return uncompletedPartitions;
   }
 
   public String toString() {
     return JobStatusQueryResponse.class.getSimpleName() + "(\n" + "version: " + version + ",\n" + "status: " + status
         + ",\n" + "statusDetails: " + statusDetails + ",\n" + "extraInfo: " + extraInfo + ",\n" + "extraDetails: "
-        + extraDetails + ",\n" + super.toString() + ")";
+        + extraDetails + ",\n" + "uncompletedPartitions: " + uncompletedPartitions + ",\n" + super.toString() + ")";
   }
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/UncompletedPartition.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/UncompletedPartition.java
@@ -1,0 +1,39 @@
+package com.linkedin.venice.meta;
+
+import java.util.List;
+
+
+public class UncompletedPartition {
+  private int partitionId;
+  private List<UncompletedReplica> uncompletedReplicas;
+
+  public UncompletedPartition() {
+  }
+
+  public UncompletedPartition(int partitionId, List<UncompletedReplica> uncompletedReplicas) {
+    this.partitionId = partitionId;
+    this.uncompletedReplicas = uncompletedReplicas;
+  }
+
+  public int getPartitionId() {
+    return partitionId;
+  }
+
+  public void setPartitionId(int partitionId) {
+    this.partitionId = partitionId;
+  }
+
+  public List<UncompletedReplica> getUncompletedReplicas() {
+    return uncompletedReplicas;
+  }
+
+  public void setUncompletedReplicas(List<UncompletedReplica> uncompletedReplicas) {
+    this.uncompletedReplicas = uncompletedReplicas;
+  }
+
+  @Override
+  public String toString() {
+    return "UncompletedPartition{" + "partitionId=" + partitionId + ", uncompletedReplicas=" + uncompletedReplicas
+        + "}";
+  }
+}

--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/UncompletedReplica.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/UncompletedReplica.java
@@ -1,0 +1,59 @@
+package com.linkedin.venice.meta;
+
+import com.linkedin.venice.pushmonitor.ExecutionStatus;
+
+
+public class UncompletedReplica {
+  private String instanceId;
+  private ExecutionStatus status;
+  private long currentOffset;
+  private String statusDetails;
+
+  public UncompletedReplica() {
+  }
+
+  public UncompletedReplica(String instanceId, ExecutionStatus status, long currentOffset, String statusDetails) {
+    this.instanceId = instanceId;
+    this.status = status;
+    this.currentOffset = currentOffset;
+    this.statusDetails = statusDetails;
+  }
+
+  public String getInstanceId() {
+    return instanceId;
+  }
+
+  public void setInstanceId(String instanceId) {
+    this.instanceId = instanceId;
+  }
+
+  public ExecutionStatus getStatus() {
+    return status;
+  }
+
+  public void setStatus(ExecutionStatus status) {
+    this.status = status;
+  }
+
+  public long getCurrentOffset() {
+    return currentOffset;
+  }
+
+  public void setCurrentOffset(long currentOffset) {
+    this.currentOffset = currentOffset;
+  }
+
+  public String getStatusDetails() {
+    return statusDetails;
+  }
+
+  public void setStatusDetails(String statusDetails) {
+    this.statusDetails = statusDetails;
+  }
+
+  @Override
+  public String toString() {
+    return "ReplicaDetail{" + "instanceId=" + instanceId + ", status=" + status.toString() + ", currentOffset="
+        + currentOffset + ", statusDetails=" + statusDetails + "}";
+  }
+}

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/controller/TestIncrementalPush.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/controller/TestIncrementalPush.java
@@ -87,7 +87,7 @@ public class TestIncrementalPush {
         TimeUnit.SECONDS,
         () -> cluster.getLeaderVeniceController()
             .getVeniceAdmin()
-            .getOffLinePushStatus(cluster.getClusterName(), finalTopicName1, Optional.of(finalIncPushVerison1))
+            .getOffLinePushStatus(cluster.getClusterName(), finalTopicName1, Optional.of(finalIncPushVerison1), null)
             .getExecutionStatus()
             .equals(ExecutionStatus.END_OF_INCREMENTAL_PUSH_RECEIVED));
 
@@ -101,7 +101,7 @@ public class TestIncrementalPush {
         TimeUnit.SECONDS,
         () -> cluster.getLeaderVeniceController()
             .getVeniceAdmin()
-            .getOffLinePushStatus(cluster.getClusterName(), finalTopicName, Optional.of(finalIncPushVerison))
+            .getOffLinePushStatus(cluster.getClusterName(), finalTopicName, Optional.of(finalIncPushVerison), null)
             .getExecutionStatus()
             .equals(ExecutionStatus.START_OF_INCREMENTAL_PUSH_RECEIVED));
   }

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/controller/TestVeniceHelixAdminWithSharedEnvironment.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/controller/TestVeniceHelixAdminWithSharedEnvironment.java
@@ -266,8 +266,8 @@ public class TestVeniceHelixAdminWithSharedEnvironment extends AbstractTestVenic
     offlinePushStatus =
         veniceAdmin.getOffLinePushStatus(clusterName, Version.composeKafkaTopic(storeName, versionNumber));
     Assert.assertEquals(offlinePushStatus.getExecutionStatus(), ExecutionStatus.ERROR);
-    Assert.assertTrue(offlinePushStatus.getStatusDetails().isPresent());
-    Assert.assertEquals(offlinePushStatus.getStatusDetails().get(), statusDetails);
+    Assert.assertNotNull(offlinePushStatus.getStatusDetails());
+    Assert.assertEquals(offlinePushStatus.getStatusDetails(), statusDetails);
 
     delayParticipantJobCompletion(false);
     stateModelFactoryByNodeID
@@ -610,7 +610,7 @@ public class TestVeniceHelixAdminWithSharedEnvironment extends AbstractTestVenic
     Admin.OfflinePushStatusInfo statusInfo =
         veniceAdmin.getOffLinePushStatus(clusterName, Version.composeKafkaTopic(storeName, 101));
     Assert.assertEquals(statusInfo.getExecutionStatus(), ExecutionStatus.NOT_CREATED);
-    Assert.assertTrue(statusInfo.getStatusDetails().get().contains("in maintenance mode"));
+    Assert.assertTrue(statusInfo.getStatusDetails().contains("in maintenance mode"));
 
     // disable maintenance mode
     veniceAdmin.getHelixAdmin().enableMaintenanceMode(clusterName, false);

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/OneTouchDataRecoveryTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/OneTouchDataRecoveryTest.java
@@ -1,9 +1,10 @@
 package com.linkedin.venice.endToEnd;
 
-import static com.linkedin.venice.ConfigKeys.*;
-import static com.linkedin.venice.utils.TestWriteUtils.*;
+import static com.linkedin.venice.ConfigKeys.SERVER_PROMOTION_TO_LEADER_REPLICA_DELAY_SECONDS;
+import static com.linkedin.venice.utils.TestWriteUtils.STRING_SCHEMA;
 
 import com.linkedin.venice.controllerapi.ControllerClient;
+import com.linkedin.venice.controllerapi.JobStatusQueryResponse;
 import com.linkedin.venice.controllerapi.StoreHealthAuditResponse;
 import com.linkedin.venice.controllerapi.UpdateStoreQueryParams;
 import com.linkedin.venice.controllerapi.VersionCreationResponse;
@@ -124,6 +125,9 @@ public class OneTouchDataRecoveryTest {
           STRING_SCHEMA,
           IntStream.range(0, 10).mapToObj(i -> new AbstractMap.SimpleEntry<>(String.valueOf(i), String.valueOf(i))),
           HelixReadOnlySchemaRepository.VALUE_SCHEMA_STARTING_ID);
+      JobStatusQueryResponse response = parentControllerCli
+          .queryDetailedJobStatus(versionCreationResponse.getKafkaTopic(), childDatacenters.get(0).getRegionName());
+      Assert.assertFalse(response.isError());
       TestUtils.waitForNonDeterministicPushCompletion(
           versionCreationResponse.getKafkaTopic(),
           parentControllerCli,

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/Admin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/Admin.java
@@ -22,6 +22,7 @@ import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.StoreDataAudit;
 import com.linkedin.venice.meta.StoreGraveyard;
 import com.linkedin.venice.meta.StoreInfo;
+import com.linkedin.venice.meta.UncompletedPartition;
 import com.linkedin.venice.meta.VeniceUserStoreType;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.persona.StoragePersona;
@@ -57,8 +58,9 @@ public interface Admin extends AutoCloseable, Closeable {
   class OfflinePushStatusInfo {
     private ExecutionStatus executionStatus;
     private Map<String, String> extraInfo;
-    private Optional<String> statusDetails;
+    private String statusDetails;
     private Map<String, String> extraDetails;
+    private List<UncompletedPartition> uncompletedPartitions;
 
     /** N.B.: Test-only constructor ): */
     public OfflinePushStatusInfo(ExecutionStatus executionStatus) {
@@ -67,11 +69,11 @@ public interface Admin extends AutoCloseable, Closeable {
 
     /** N.B.: Test-only constructor ): */
     public OfflinePushStatusInfo(ExecutionStatus executionStatus, Map<String, String> extraInfo) {
-      this(executionStatus, extraInfo, Optional.empty(), new HashMap<>());
+      this(executionStatus, extraInfo, null, new HashMap<>());
     }
 
     /** Used by single datacenter (child) controllers, hence, no extra info nor extra details */
-    public OfflinePushStatusInfo(ExecutionStatus executionStatus, Optional<String> statusDetails) {
+    public OfflinePushStatusInfo(ExecutionStatus executionStatus, String statusDetails) {
       this(executionStatus, new HashMap<>(), statusDetails, new HashMap<>());
     }
 
@@ -79,7 +81,7 @@ public interface Admin extends AutoCloseable, Closeable {
     public OfflinePushStatusInfo(
         ExecutionStatus executionStatus,
         Map<String, String> extraInfo,
-        Optional<String> statusDetails,
+        String statusDetails,
         Map<String, String> extraDetails) {
       this.executionStatus = executionStatus;
       this.extraInfo = extraInfo;
@@ -95,12 +97,20 @@ public interface Admin extends AutoCloseable, Closeable {
       return extraInfo;
     }
 
-    public Optional<String> getStatusDetails() {
+    public String getStatusDetails() {
       return statusDetails;
     }
 
     public Map<String, String> getExtraDetails() {
       return extraDetails;
+    }
+
+    public List<UncompletedPartition> getUncompletedPartitions() {
+      return uncompletedPartitions;
+    }
+
+    public void setUncompletedPartitions(List<UncompletedPartition> uncompletedPartitions) {
+      this.uncompletedPartitions = uncompletedPartitions;
     }
   }
 
@@ -403,9 +413,8 @@ public interface Admin extends AutoCloseable, Closeable {
   OfflinePushStatusInfo getOffLinePushStatus(
       String clusterName,
       String kafkaTopic,
-      Optional<String> incrementalPushVersion);
-
-  Map<String, Long> getOfflinePushProgress(String clusterName, String kafkaTopic);
+      Optional<String> incrementalPushVersion,
+      String region);
 
   /**
    * Return the ssl or non-ssl bootstrap servers based on the given flag.

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -5072,7 +5072,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
     if (!incrementalPushVersion.isPresent()) {
       OfflinePushStatusInfo offlinePushStatusInfo =
           getOfflinePushStatusInfo(clusterName, kafkaTopic, incrementalPushVersion, monitor, store, versionNumber);
-      if (region != null && !offlinePushStatusInfo.getExecutionStatus().equals(ExecutionStatus.COMPLETED)) {
+      if (region != null) {
         offlinePushStatusInfo.setUncompletedPartitions(monitor.getUncompletedPartitions(kafkaTopic));
       }
       return offlinePushStatusInfo;

--- a/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/AbstractPushMonitor.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/AbstractPushMonitor.java
@@ -486,7 +486,7 @@ public abstract class AbstractPushMonitor
   @Override
   public List<UncompletedPartition> getUncompletedPartitions(String topic) {
     OfflinePushStatus pushStatus = getOfflinePush(topic);
-    if (pushStatus == null) {
+    if (pushStatus == null || pushStatus.getCurrentStatus().equals(COMPLETED)) {
       return Collections.emptyList();
     }
     PushStatusDecider decider = PushStatusDecider.getDecider(pushStatus.getStrategy());

--- a/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/AbstractPushMonitor.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/AbstractPushMonitor.java
@@ -1,5 +1,6 @@
 package com.linkedin.venice.pushmonitor;
 
+import static com.linkedin.venice.pushmonitor.ExecutionStatus.COMPLETED;
 import static com.linkedin.venice.pushmonitor.ExecutionStatus.END_OF_INCREMENTAL_PUSH_RECEIVED;
 import static com.linkedin.venice.pushmonitor.ExecutionStatus.ERROR;
 import static com.linkedin.venice.pushmonitor.ExecutionStatus.NOT_CREATED;
@@ -17,6 +18,8 @@ import com.linkedin.venice.meta.ReadWriteStoreRepository;
 import com.linkedin.venice.meta.RoutingDataRepository;
 import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.StoreCleaner;
+import com.linkedin.venice.meta.UncompletedPartition;
+import com.linkedin.venice.meta.UncompletedReplica;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.meta.VersionStatus;
 import com.linkedin.venice.pushstatushelper.PushStatusStoreReader;
@@ -295,13 +298,13 @@ public abstract class AbstractPushMonitor
   }
 
   @Override
-  public Pair<ExecutionStatus, Optional<String>> getIncrementalPushStatusAndDetails(
+  public Pair<ExecutionStatus, String> getIncrementalPushStatusAndDetails(
       String kafkaTopic,
       String incrementalPushVersion,
       HelixCustomizedViewOfflinePushRepository customizedViewRepo) {
     OfflinePushStatus pushStatus = getOfflinePush(kafkaTopic);
     if (pushStatus == null) {
-      return new Pair<>(ExecutionStatus.NOT_CREATED, Optional.of("Offline job hasn't been created yet."));
+      return new Pair<>(ExecutionStatus.NOT_CREATED, "Offline job hasn't been created yet.");
     }
     Map<Integer, Map<CharSequence, Integer>> pushStatusMap = pushStatus.getIncrementalPushStatus(
         getRoutingDataRepository().getPartitionAssignments(kafkaTopic),
@@ -316,18 +319,18 @@ public abstract class AbstractPushMonitor
             incrementalPushVersion,
             pushStatus.getNumberOfPartition(),
             pushStatus.getReplicationFactor()),
-        Optional.empty());
+        null);
   }
 
   @Override
-  public Pair<ExecutionStatus, Optional<String>> getIncrementalPushStatusFromPushStatusStore(
+  public Pair<ExecutionStatus, String> getIncrementalPushStatusFromPushStatusStore(
       String kafkaTopic,
       String incrementalPushVersion,
       HelixCustomizedViewOfflinePushRepository customizedViewRepo,
       PushStatusStoreReader pushStatusStoreReader) {
     OfflinePushStatus pushStatus = getOfflinePush(kafkaTopic);
     if (pushStatus == null) {
-      return new Pair<>(ExecutionStatus.NOT_CREATED, Optional.of("Offline job hasn't been created yet."));
+      return new Pair<>(ExecutionStatus.NOT_CREATED, "Offline job hasn't been created yet.");
     }
     return getIncrementalPushStatusFromPushStatusStore(
         kafkaTopic,
@@ -338,7 +341,7 @@ public abstract class AbstractPushMonitor
         pushStatus.getReplicationFactor());
   }
 
-  public Pair<ExecutionStatus, Optional<String>> getIncrementalPushStatusFromPushStatusStore(
+  public Pair<ExecutionStatus, String> getIncrementalPushStatusFromPushStatusStore(
       String kafkaTopic,
       String incrementalPushVersion,
       HelixCustomizedViewOfflinePushRepository customizedViewRepo,
@@ -359,7 +362,7 @@ public abstract class AbstractPushMonitor
             incrementalPushVersion,
             numberOfPartitions,
             replicationFactor),
-        Optional.empty());
+        null);
   }
 
   private ExecutionStatus checkIncrementalPushStatus(
@@ -460,12 +463,12 @@ public abstract class AbstractPushMonitor
   }
 
   @Override
-  public Pair<ExecutionStatus, Optional<String>> getPushStatusAndDetails(String topic) {
+  public Pair<ExecutionStatus, String> getPushStatusAndDetails(String topic) {
     OfflinePushStatus pushStatus = getOfflinePush(topic);
     if (pushStatus == null) {
-      return new Pair<>(ExecutionStatus.NOT_CREATED, Optional.of("Offline job hasn't been created yet."));
+      return new Pair<>(ExecutionStatus.NOT_CREATED, "Offline job hasn't been created yet.");
     }
-    return new Pair<>(pushStatus.getCurrentStatus(), pushStatus.getOptionalStatusDetails());
+    return new Pair<>(pushStatus.getCurrentStatus(), pushStatus.getStatusDetails());
   }
 
   @Override
@@ -481,16 +484,34 @@ public abstract class AbstractPushMonitor
   }
 
   @Override
-  public Map<String, Long> getOfflinePushProgress(String topic) {
+  public List<UncompletedPartition> getUncompletedPartitions(String topic) {
     OfflinePushStatus pushStatus = getOfflinePush(topic);
     if (pushStatus == null) {
-      return Collections.emptyMap();
+      return Collections.emptyList();
     }
-    Map<String, Long> progress = new HashMap<>(pushStatus.getProgress());
-    progress.keySet()
-        .removeIf(
-            replicaId -> !routingDataRepository.isLiveInstance(ReplicaStatus.getInstanceIdFromReplicaId(replicaId)));
-    return progress;
+    PushStatusDecider decider = PushStatusDecider.getDecider(pushStatus.getStrategy());
+    List<UncompletedPartition> uncompletedPartitions = new ArrayList<>();
+    for (PartitionStatus partitionStatus: pushStatus.getPartitionStatuses()) {
+      int completedReplicaInPartition = 0;
+      List<UncompletedReplica> uncompletedReplicas = new ArrayList<>();
+      for (ReplicaStatus replicaStatus: partitionStatus.getReplicaStatuses()) {
+        ExecutionStatus currentStatus = PushStatusDecider.getReplicaCurrentStatus(replicaStatus.getStatusHistory());
+        if (currentStatus.equals(COMPLETED)) {
+          completedReplicaInPartition++;
+        } else {
+          UncompletedReplica uncompletedReplica = new UncompletedReplica(
+              replicaStatus.getInstanceId(),
+              currentStatus,
+              replicaStatus.getCurrentProgress(),
+              replicaStatus.getIncrementalPushVersion());
+          uncompletedReplicas.add(uncompletedReplica);
+        }
+      }
+      if (!decider.hasEnoughReplicasForOnePartition(completedReplicaInPartition, pushStatus.getReplicationFactor())) {
+        uncompletedPartitions.add(new UncompletedPartition(partitionStatus.getPartitionId(), uncompletedReplicas));
+      }
+    }
+    return uncompletedPartitions;
   }
 
   @Override

--- a/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/PushMonitor.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/PushMonitor.java
@@ -4,10 +4,10 @@ import com.linkedin.venice.helix.HelixCustomizedViewOfflinePushRepository;
 import com.linkedin.venice.meta.Instance;
 import com.linkedin.venice.meta.OfflinePushStrategy;
 import com.linkedin.venice.meta.PartitionAssignment;
+import com.linkedin.venice.meta.UncompletedPartition;
 import com.linkedin.venice.pushstatushelper.PushStatusStoreReader;
 import com.linkedin.venice.utils.Pair;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
@@ -72,12 +72,14 @@ public interface PushMonitor {
   /**
    * @return return the current status. If it's in error, some debugging info is also presented.
    */
-  Pair<ExecutionStatus, Optional<String>> getPushStatusAndDetails(String topic);
+  Pair<ExecutionStatus, String> getPushStatusAndDetails(String topic);
+
+  List<UncompletedPartition> getUncompletedPartitions(String topic);
 
   /**
    * Returns incremental push's status read from (ZooKeeper backed) OfflinePushStatus
    */
-  Pair<ExecutionStatus, Optional<String>> getIncrementalPushStatusAndDetails(
+  Pair<ExecutionStatus, String> getIncrementalPushStatusAndDetails(
       String kafkaTopic,
       String incrementalPushVersion,
       HelixCustomizedViewOfflinePushRepository customizedViewOfflinePushRepository);
@@ -85,7 +87,7 @@ public interface PushMonitor {
   /**
    * Returns incremental push's status read from push status store
    */
-  Pair<ExecutionStatus, Optional<String>> getIncrementalPushStatusFromPushStatusStore(
+  Pair<ExecutionStatus, String> getIncrementalPushStatusFromPushStatusStore(
       String kafkaTopic,
       String incrementalPushVersion,
       HelixCustomizedViewOfflinePushRepository customizedViewRepo,
@@ -104,12 +106,6 @@ public interface PushMonitor {
    * Find all ongoing pushes then return the topics associated to those pushes.
    */
   List<String> getTopicsOfOngoingOfflinePushes();
-
-  /**
-   * Get the progress of the given offline push.
-   * @return a map which's key is replica id and value is the kafka offset that replica already consumed.
-   */
-  Map<String, Long> getOfflinePushProgress(String topic);
 
   /**
    * Mark a push to be as error. This is usually called when push is killed.

--- a/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/PushMonitorDelegator.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/PushMonitorDelegator.java
@@ -11,6 +11,7 @@ import com.linkedin.venice.meta.ReadWriteStoreRepository;
 import com.linkedin.venice.meta.RoutingDataRepository;
 import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.StoreCleaner;
+import com.linkedin.venice.meta.UncompletedPartition;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.pushstatushelper.PushStatusStoreReader;
 import com.linkedin.venice.utils.Pair;
@@ -138,12 +139,17 @@ public class PushMonitorDelegator implements PushMonitor {
   }
 
   @Override
-  public Pair<ExecutionStatus, Optional<String>> getPushStatusAndDetails(String topic) {
+  public Pair<ExecutionStatus, String> getPushStatusAndDetails(String topic) {
     return getPushMonitor(topic).getPushStatusAndDetails(topic);
   }
 
   @Override
-  public Pair<ExecutionStatus, Optional<String>> getIncrementalPushStatusAndDetails(
+  public List<UncompletedPartition> getUncompletedPartitions(String topic) {
+    return getPushMonitor(topic).getUncompletedPartitions(topic);
+  }
+
+  @Override
+  public Pair<ExecutionStatus, String> getIncrementalPushStatusAndDetails(
       String kafkaTopic,
       String incrementalPushVersion,
       HelixCustomizedViewOfflinePushRepository customizedViewRepo) {
@@ -152,7 +158,7 @@ public class PushMonitorDelegator implements PushMonitor {
   }
 
   @Override
-  public Pair<ExecutionStatus, Optional<String>> getIncrementalPushStatusFromPushStatusStore(
+  public Pair<ExecutionStatus, String> getIncrementalPushStatusFromPushStatusStore(
       String kafkaTopic,
       String incrementalPushVersion,
       HelixCustomizedViewOfflinePushRepository customizedViewRepo,
@@ -177,11 +183,6 @@ public class PushMonitorDelegator implements PushMonitor {
   @Override
   public List<String> getTopicsOfOngoingOfflinePushes() {
     return partitionStatusBasedPushStatusMonitor.getTopicsOfOngoingOfflinePushes();
-  }
-
-  @Override
-  public Map<String, Long> getOfflinePushProgress(String topic) {
-    return getPushMonitor(topic).getOfflinePushProgress(topic);
   }
 
   @Override

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceParentHelixAdmin.java
@@ -1708,38 +1708,6 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
   }
 
   @Test
-  public void testGetProgress() {
-    JobStatusQueryResponse tenResponse = new JobStatusQueryResponse();
-    Map<String, Long> tenPerTaskProgress = new HashMap<>();
-    tenPerTaskProgress.put("task1", 10L);
-    tenPerTaskProgress.put("task2", 10L);
-    tenResponse.setPerTaskProgress(tenPerTaskProgress);
-    ControllerClient tenStatusClient = mock(ControllerClient.class);
-    doReturn(tenResponse).when(tenStatusClient).queryJobStatus(anyString());
-
-    JobStatusQueryResponse failResponse = new JobStatusQueryResponse();
-    failResponse.setError("error2");
-    ControllerClient failClient = mock(ControllerClient.class);
-    doReturn(failResponse).when(failClient).queryJobStatus(anyString());
-
-    // Clients work as expected
-    JobStatusQueryResponse status = tenStatusClient.queryJobStatus("topic");
-    Map<String, Long> perTask = status.getPerTaskProgress();
-    Assert.assertEquals((long) perTask.get("task1"), 10L);
-    Assert.assertTrue(failClient.queryJobStatus("topic").isError());
-
-    // Test logic
-    Map<String, ControllerClient> tenMap = new HashMap<>();
-    tenMap.put("cluster1", tenStatusClient);
-    tenMap.put("cluster2", tenStatusClient);
-    tenMap.put("cluster3", failClient);
-    Map<String, Long> tenProgress = VeniceParentHelixAdmin.getOfflineJobProgress("cluster", "topic", tenMap);
-    Assert.assertEquals(tenProgress.values().size(), 4); // nothing from fail client
-    Assert.assertEquals((long) tenProgress.get("cluster1_task1"), 10L);
-    Assert.assertEquals((long) tenProgress.get("cluster2_task2"), 10L);
-  }
-
-  @Test
   public void testUpdateStore() {
     String storeName = Utils.getUniqueString("testUpdateStore");
     Store store = TestUtils.createTestStore(storeName, "test", System.currentTimeMillis());

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/JobRoutesTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/JobRoutesTest.java
@@ -8,14 +8,8 @@ import static org.mockito.Mockito.mock;
 import com.linkedin.venice.controller.Admin;
 import com.linkedin.venice.controller.VeniceParentHelixAdmin;
 import com.linkedin.venice.controllerapi.JobStatusQueryResponse;
-import com.linkedin.venice.kafka.TopicManager;
 import com.linkedin.venice.pushmonitor.ExecutionStatus;
 import com.linkedin.venice.utils.Utils;
-import it.unimi.dsi.fastutil.ints.Int2LongMap;
-import it.unimi.dsi.fastutil.ints.Int2LongOpenHashMap;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import org.apache.logging.log4j.LogManager;
@@ -32,39 +26,16 @@ public class JobRoutesTest {
     Admin mockAdmin = mock(VeniceParentHelixAdmin.class);
     doReturn(true).when(mockAdmin).isLeaderControllerFor(anyString());
     doReturn(new Admin.OfflinePushStatusInfo(ExecutionStatus.COMPLETED)).when(mockAdmin)
-        .getOffLinePushStatus(anyString(), anyString(), any());
-
-    TopicManager mockTopicManager = mock(TopicManager.class);
-    // 3 partitions, with latest offsets 100, 110, and 120
-    Int2LongMap map = new Int2LongOpenHashMap();
-    map.put(0, 100L);
-    map.put(1, 110L);
-    map.put(2, 120L);
-    doReturn(map).when(mockTopicManager).getTopicLatestOffsets(anyString());
-    doReturn(mockTopicManager).when(mockAdmin).getTopicManager();
+        .getOffLinePushStatus(anyString(), anyString(), any(), any());
 
     doReturn(2).when(mockAdmin).getReplicationFactor(anyString(), anyString());
-    Map<String, Long> jobProgress = new HashMap<>();
-    List<String> clusters = Arrays.asList("cluster1", "cluster2", "cluster3");
-    for (String cluster: clusters) {
-      for (int partition = 0; partition < mockTopicManager.getTopicLatestOffsets("").size(); partition++) {
-        for (int replica = 0; replica < mockAdmin.getReplicationFactor("", ""); replica++) {
-          String worker = cluster + "_p" + partition + "-r" + replica;
-          jobProgress.put(worker, mockTopicManager.getTopicLatestOffsets("").get(partition)); // all workers complete
-        }
-      }
-    }
-    doReturn(jobProgress).when(mockAdmin).getOfflinePushProgress(anyString(), anyString());
-    doReturn(clusters.size()).when(mockAdmin).getDatacenterCount(anyString());
 
     String cluster = Utils.getUniqueString("cluster");
     String store = Utils.getUniqueString("store");
     int version = 5;
     JobRoutes jobRoutes = new JobRoutes(false, Optional.empty());
-    JobStatusQueryResponse response = jobRoutes.populateJobStatus(cluster, store, version, mockAdmin, Optional.empty());
-
-    long available = response.getMessagesAvailable();
-    long consumed = response.getMessagesConsumed();
+    JobStatusQueryResponse response =
+        jobRoutes.populateJobStatus(cluster, store, version, mockAdmin, Optional.empty(), null);
 
     Map<String, String> extraInfo = response.getExtraInfo();
     LOGGER.info("extraInfo: {}", extraInfo);
@@ -73,9 +44,5 @@ public class JobRoutesTest {
     Map<String, String> extraDetails = response.getExtraDetails();
     LOGGER.info("extraDetails: {}", extraDetails);
     Assert.assertNotNull(extraDetails);
-
-    Assert.assertTrue(
-        consumed <= available,
-        "Messages consumed: " + consumed + " must be less than or equal to available messages: " + available);
   }
 }

--- a/services/venice-controller/src/test/java/com/linkedin/venice/pushmonitor/AbstractPushMonitorTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/pushmonitor/AbstractPushMonitorTest.java
@@ -46,6 +46,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -882,6 +883,19 @@ public abstract class AbstractPushMonitorTest {
     } finally {
       TestUtils.shutdownExecutor(asyncExecutor);
     }
+  }
+
+  @Test
+  public void testGetUncompletedPartitions() {
+    monitor.startMonitorOfflinePush(
+        topic,
+        numberOfPartition,
+        replicationFactor,
+        OfflinePushStrategy.WAIT_N_MINUS_ONE_REPLCIA_PER_PARTITION);
+    Assert.assertEquals(monitor.getUncompletedPartitions(topic).size(), numberOfPartition);
+    OfflinePushStatus pushStatus = monitor.getOfflinePushOrThrow(topic);
+    monitor.updatePushStatus(pushStatus, ExecutionStatus.COMPLETED, Optional.empty());
+    Assert.assertTrue(monitor.getUncompletedPartitions(topic).isEmpty());
   }
 
   protected Store prepareMockStore(String topic) {


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci], [server], [controller],
[router], [samza], [vpj], [fast-client], [thin-client], [alpini],
[admin-tool], [test], [build], [doc], [script]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Make job status api able to report uncompleted partitions and replicas
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
In the report of data recovery progress, in addition to job status in the recovering
region, we also want to know which partitions and replicas are still in progress or
in trouble. This commit makes job status api able to report uncompleted partitions
and replicas, as well as replica status, consumed offset, and status details like
the reason of failure.

Other changes:
1. Removes unused fields in JobStatusQueryResponse including messagesConsumed,
messagesAvailable, perTaskProgress, perPartitionCapacity, their related methods
and tests.
2. Removes Optional for statusDetails in OfflinePushStatusInfo.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
Tested the improved api in testBatchOnlyDataRecoveryAPIs.
## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.