### PR TITLE
[admin-tool] Some improvements to execute-data-recovery command

### DIFF
--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/AdminTool.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/AdminTool.java
@@ -608,6 +608,7 @@ public class AdminTool {
 
     String extraCommandArgs = getOptionalArgument(cmd, Arg.EXTRA_COMMAND_ARGS);
     boolean isDebuggingEnabled = cmd.hasOption(Arg.DEBUG.toString());
+    boolean isNonInteractive = cmd.hasOption(Arg.NON_INTERACTIVE.toString());
 
     StoreRepushCommand.Params cmdParams = new StoreRepushCommand.Params();
     cmdParams.setCommand(recoveryCommand);
@@ -618,7 +619,7 @@ public class AdminTool {
     cmdParams.setDebug(isDebuggingEnabled);
 
     DataRecoveryClient dataRecoveryClient = new DataRecoveryClient();
-    DataRecoveryClient.DataRecoveryParams params = new DataRecoveryClient.DataRecoveryParams(stores);
+    DataRecoveryClient.DataRecoveryParams params = new DataRecoveryClient.DataRecoveryParams(stores, isNonInteractive);
     dataRecoveryClient.execute(params, cmdParams);
   }
 

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/Arg.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/Arg.java
@@ -225,6 +225,7 @@ public enum Arg {
   RECOVERY_COMMAND("recovery-command", "rco", true, "command to execute the data recovery"),
   EXTRA_COMMAND_ARGS("extra-command-args", "eca", true, "extra command arguments"),
   ENABLE_DISABLED_REPLICA("enable-disabled-replicas", "edr", true, "Reenable disabled replicas"),
+  NON_INTERACTIVE("non-interactive", "nita", false, "non-interactive mode"),
   DEBUG("debug", "d", false, "Print debugging messages for execute-data-recovery");
 
   private final String argName;

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/Command.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/Command.java
@@ -57,6 +57,7 @@ import static com.linkedin.venice.Arg.MESSAGE_COUNT;
 import static com.linkedin.venice.Arg.MIGRATION_PUSH_STRATEGY;
 import static com.linkedin.venice.Arg.NATIVE_REPLICATION_ENABLED;
 import static com.linkedin.venice.Arg.NATIVE_REPLICATION_SOURCE_FABRIC;
+import static com.linkedin.venice.Arg.NON_INTERACTIVE;
 import static com.linkedin.venice.Arg.NUM_VERSIONS_TO_PRESERVE;
 import static com.linkedin.venice.Arg.OFFSET;
 import static com.linkedin.venice.Arg.OWNER;
@@ -435,7 +436,7 @@ public enum Command {
   ),
   EXECUTE_DATA_RECOVERY(
       "execute-data-recovery", "Execute data recovery for a group of stores",
-      new Arg[] { RECOVERY_COMMAND, STORES, SOURCE_FABRIC }, new Arg[] { EXTRA_COMMAND_ARGS, DEBUG }
+      new Arg[] { RECOVERY_COMMAND, STORES, SOURCE_FABRIC }, new Arg[] { EXTRA_COMMAND_ARGS, DEBUG, NON_INTERACTIVE }
   );
 
   private final String commandName;

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/datarecovery/DataRecoveryClient.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/datarecovery/DataRecoveryClient.java
@@ -34,11 +34,12 @@ public class DataRecoveryClient {
       LOGGER.warn("store list is empty, exit.");
       return;
     }
-    if (!confirmStores(storeNames)) {
+    if (!drParams.isNonInteractive && !confirmStores(storeNames)) {
       return;
     }
 
     getExecutor().perform(storeNames, cmdParams);
+    getExecutor().shutdownAndAwaitTermination();
   }
 
   public boolean confirmStores(Set<String> storeNames) {
@@ -52,10 +53,12 @@ public class DataRecoveryClient {
   public static class DataRecoveryParams {
     private final String multiStores;
     private final Set<String> recoveryStores;
+    private final boolean isNonInteractive;
 
-    public DataRecoveryParams(String multiStores) {
+    public DataRecoveryParams(String multiStores, boolean isNonInteractive) {
       this.multiStores = multiStores;
       this.recoveryStores = calculateRecoveryStoreNames(this.multiStores);
+      this.isNonInteractive = isNonInteractive;
     }
 
     public Set<String> getRecoveryStores() {

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/datarecovery/DataRecoveryExecutor.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/datarecovery/DataRecoveryExecutor.java
@@ -2,7 +2,6 @@ package com.linkedin.venice.datarecovery;
 
 import static java.lang.Thread.*;
 
-import java.io.Console;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -35,25 +34,38 @@ public class DataRecoveryExecutor {
     this.pool = Executors.newFixedThreadPool(this.poolSize);
   }
 
+  public boolean requiresSentinelRun(DataRecoveryTask task) {
+    return task.requiresSentinelRun();
+  }
+
   public void perform(Set<String> storeNames, StoreRepushCommand.Params params) {
-    String pass = getUserCredentials();
-    if (pass == null) {
-      LOGGER.error("Cannot get password, exit");
+    tasks = buildTasks(storeNames, params);
+    if (tasks.isEmpty()) {
       return;
     }
-    params.setPassword(pass);
 
-    tasks = buildTasks(storeNames, params);
-    List<CompletableFuture<Void>> taskFutures = tasks.stream()
+    List<DataRecoveryTask> concurrentTasks = tasks;
+    DataRecoveryTask firstTask = tasks.get(0);
+    if (requiresSentinelRun(firstTask)) {
+      // If sentinel run is required for a task, let the main thread to run it to completion.
+      DataRecoveryTask sentinel = firstTask;
+      sentinel.run();
+      if (sentinel.getTaskResult().isError()) {
+        displayTaskResult(sentinel);
+        return;
+      }
+      // Exclude the 1st item from the list as it has finished.
+      concurrentTasks = tasks.subList(1, tasks.size());
+    }
+
+    List<CompletableFuture<Void>> taskFutures = concurrentTasks.stream()
         .map(dataRecoveryTask -> CompletableFuture.runAsync(dataRecoveryTask, pool))
         .collect(Collectors.toList());
     taskFutures.stream().map(CompletableFuture::join).collect(Collectors.toList());
-    displayTaskResult();
-
-    shutdownAndAwaitTermination();
+    displayAllTasksResult();
   }
 
-  private void shutdownAndAwaitTermination() {
+  public void shutdownAndAwaitTermination() {
     pool.shutdown();
     try {
       if (!pool.awaitTermination(DEFAULT_POOL_TIMEOUT_IN_SECONDS, TimeUnit.SECONDS)) {
@@ -75,27 +87,18 @@ public class DataRecoveryExecutor {
     return tasks;
   }
 
-  public String getUserCredentials() {
-    Console console = System.console();
-    if (console == null) {
-      LOGGER.warn("System.console is null");
-      return null;
+  private void displayAllTasksResult() {
+    for (DataRecoveryTask dataRecoveryTask: tasks) {
+      displayTaskResult(dataRecoveryTask);
     }
-    // Read password into character array.
-    char[] passwordVip = console.readPassword("Enter Credentials: ");
-    return String.copyValueOf(passwordVip);
   }
 
-  private void displayTaskResult() {
-    for (DataRecoveryTask dataRecoveryTask: tasks) {
-      LOGGER.info(
-          "[store: {}, status: {}, message: {}]",
-          dataRecoveryTask.getTaskParams().getStore(),
-          dataRecoveryTask.getTaskResult().isError() ? "failed" : "started",
-          dataRecoveryTask.getTaskResult().isError()
-              ? dataRecoveryTask.getTaskResult().getError()
-              : dataRecoveryTask.getTaskResult().getMessage());
-    }
+  private void displayTaskResult(DataRecoveryTask task) {
+    LOGGER.info(
+        "[store: {}, status: {}, message: {}]",
+        task.getTaskParams().getStore(),
+        task.getTaskResult().isError() ? "failed" : "started",
+        task.getTaskResult().isError() ? task.getTaskResult().getError() : task.getTaskResult().getMessage());
   }
 
   public List<DataRecoveryTask> getTasks() {

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/datarecovery/DataRecoveryTask.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/datarecovery/DataRecoveryTask.java
@@ -19,7 +19,11 @@ public class DataRecoveryTask implements Runnable {
     taskResult = new TaskResult(command.getResult());
   }
 
-  public boolean requiresSentinelRun() {
+  /**
+   * For some task, it is benefit to wait for the first task to complete before starting to run the remaining ones.
+   * Thus, this is a task specific flag to set based on the purpose of the task.
+   */
+  public boolean needWaitForFirstTaskToComplete() {
     return true;
   }
 

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/datarecovery/DataRecoveryTask.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/datarecovery/DataRecoveryTask.java
@@ -19,6 +19,10 @@ public class DataRecoveryTask implements Runnable {
     taskResult = new TaskResult(command.getResult());
   }
 
+  public boolean requiresSentinelRun() {
+    return true;
+  }
+
   public TaskResult getTaskResult() {
     return taskResult;
   }

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/datarecovery/StoreRepushCommand.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/datarecovery/StoreRepushCommand.java
@@ -17,7 +17,7 @@ import org.apache.logging.log4j.Logger;
  * We expect the command to comply with the following contract:
  *
  * Input:
- *    <COMMAND> --store <store_name> --fabric <source_fabric> --password <credentials> [<EXTRA_COMMAND_ARGS>]
+ *    <COMMAND> [<EXTRA_COMMAND_ARGS>] --store <store_name> --fabric <source_fabric>
  * Output:
  *    success: link_to_running_task
  *    failure: failure_reason
@@ -58,10 +58,9 @@ public class StoreRepushCommand {
   private List<String> generateRepushCommand() {
     List<String> cmd = new ArrayList<>();
     cmd.add(this.params.command);
+    cmd.add(this.params.extraCommandArgs);
     cmd.add(String.format("--store '%s'", store));
     cmd.add(String.format("--fabric '%s'", this.params.sourceFabric));
-    cmd.add(String.format("--password '%s'", this.params.password));
-    cmd.add(this.params.extraCommandArgs);
     return cmd;
   }
 
@@ -131,10 +130,7 @@ public class StoreRepushCommand {
 
   @Override
   public String toString() {
-    String cmd = "StoreRepushCommand{\n" + String.join(" ", shellCmd) + "\n}";
-    // Hide user's password.
-    cmd = cmd.replace(params.getPassword(), "******");
-    return cmd;
+    return "StoreRepushCommand{\n" + String.join(" ", shellCmd) + "\n}";
   }
 
   public static class Params {
@@ -144,18 +140,8 @@ public class StoreRepushCommand {
     private String sourceFabric;
     // extra arguments to command.
     private String extraCommandArgs;
-    // User's credentials.
-    private String password;
     // Debug run.
     private boolean debug = false;
-
-    public void setPassword(String password) {
-      this.password = password;
-    }
-
-    public String getPassword() {
-      return this.password;
-    }
 
     public void setDebug(boolean debug) {
       this.debug = debug;

--- a/clients/venice-admin-tool/src/test/java/com/linkedin/venice/TestDataRecoveryClient.java
+++ b/clients/venice-admin-tool/src/test/java/com/linkedin/venice/TestDataRecoveryClient.java
@@ -41,7 +41,13 @@ public class TestDataRecoveryClient {
     } else {
       // Verify all stores are executed unsuccessfully.
       for (int i = 0; i < numOfStores; i++) {
-        Assert.assertTrue(executor.getTasks().get(i).getTaskResult().isError());
+        // For tasks that require sentinel run, if the first task is errored, then the remaining task wouldn't be
+        // executed.
+        if (i == 0) {
+          Assert.assertTrue(executor.getTasks().get(i).getTaskResult().isError());
+        } else {
+          Assert.assertNull(executor.getTasks().get(i).getTaskResult());
+        }
       }
     }
   }
@@ -53,7 +59,6 @@ public class TestDataRecoveryClient {
 
     // Partial mock of Module class to take password from console input.
     executor = spy(DataRecoveryExecutor.class);
-    doReturn("test").when(executor).getUserCredentials();
 
     // Mock command to mimic a successful repush result.
     List<String> mockCmd = new ArrayList<>();
@@ -80,7 +85,7 @@ public class TestDataRecoveryClient {
     doCallRealMethod().when(dataRecoveryClient).execute(any(), any());
     doReturn(true).when(dataRecoveryClient).confirmStores(any());
     // client executes three store recovery.
-    dataRecoveryClient.execute(new DataRecoveryClient.DataRecoveryParams("store1,store2,store3"), cmdParams);
+    dataRecoveryClient.execute(new DataRecoveryClient.DataRecoveryParams("store1,store2,store3", true), cmdParams);
   }
 
   private List<DataRecoveryTask> buildTasks(


### PR DESCRIPTION
This change does the following improvements to admin-tool execute-data-recovery command:

1. Remove password related codes as passing password plaintext from admin-tool to venice-tools is not an acceptable solution.

2. Support sentinel run in DataRecoveryExecutor. By having a sentinel run (normally requires manually inputting credentials thus creating a local Azkaban session file), the follow-up repush tasks can reuse the local session info for following interactions with Azkaban without the need to input user credentials before the session is expired. So, we only need to type in user credentials once for multiple stores.

   If the sentinel run succeeds, it will continue to run (probably in parallel but depends on the executor pool size configs) for remaining stores. However, if the sentinel run fails, then it stops to run remaining store and reports error message.

3. Add non-interactive support for testing automation purpose in future.

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.