### PR TITLE
[server][da-vinci-client] Do not emit metrics for backup version

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/AbstractVeniceAggVersionedStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/AbstractVeniceAggVersionedStats.java
@@ -145,9 +145,6 @@ public abstract class AbstractVeniceAggVersionedStats<STATS, STATS_REPORTER exte
     if (futureVersion != versionedDIVStats.getFutureVersion()) {
       versionedDIVStats.setFutureVersion(futureVersion);
     }
-    if (backupVersion != versionedDIVStats.getBackupVersion()) {
-      versionedDIVStats.setBackupVersion(backupVersion);
-    }
 
     /**
      * Since versions are changed, update the total stats accordingly.
@@ -197,9 +194,6 @@ public abstract class AbstractVeniceAggVersionedStats<STATS, STATS_REPORTER exte
   /**
    * return {@link Store#NON_EXISTING_VERSION} if backup version doesn't exist.
    */
-  protected int getBackupVersion(String storeName) {
-    return getVersionedStats(storeName).getBackupVersion();
-  }
 
   /**
    * Some versioned stats might always increasing; in this case, the value in the total stats should be updated with

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/AggVersionedDIVStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/AggVersionedDIVStats.java
@@ -136,7 +136,6 @@ public class AggVersionedDIVStats extends AbstractVeniceAggVersionedStats<DIVSta
   @Override
   protected void updateTotalStats(String storeName) {
     IntSet existingVersions = new IntOpenHashSet(3);
-    existingVersions.add(getBackupVersion(storeName));
     existingVersions.add(getCurrentVersion(storeName));
     existingVersions.add(getFutureVersion(storeName));
     existingVersions.remove(NON_EXISTING_VERSION);

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/VeniceVersionedStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/VeniceVersionedStats.java
@@ -55,20 +55,12 @@ public class VeniceVersionedStats<STATS, STATS_REPORTER extends AbstractVeniceSt
     return reporters.getFutureVersion();
   }
 
-  public int getBackupVersion() {
-    return reporters.getBackupVersion();
-  }
-
   public void setCurrentVersion(int version) {
     reporters.setCurrentStats(version, getStats(version));
   }
 
   public void setFutureVersion(int version) {
     reporters.setFutureStats(version, getStats(version));
-  }
-
-  public void setBackupVersion(int version) {
-    reporters.setBackupStats(version, getStats(version));
   }
 
   /**

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/VeniceVersionedStatsReporter.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/VeniceVersionedStatsReporter.java
@@ -17,11 +17,9 @@ public class VeniceVersionedStatsReporter<STATS, STATS_REPORTER extends Abstract
 
   private int currentVersion = NON_EXISTING_VERSION;
   private int futureVersion = NON_EXISTING_VERSION;
-  private int backupVersion = NON_EXISTING_VERSION;
 
   private final STATS_REPORTER currentStatsReporter;
   private final STATS_REPORTER futureStatsReporter;
-  private final STATS_REPORTER backupStatsReporter;
   private final STATS_REPORTER totalStatsReporter;
   private final boolean isSystemStore;
 
@@ -46,18 +44,15 @@ public class VeniceVersionedStatsReporter<STATS, STATS_REPORTER extends Abstract
       registerSensor("current_version", new VersionStat(() -> (double) currentVersion));
       if (!isSystemStore) {
         registerSensor("future_version", new VersionStat(() -> (double) futureVersion));
-        registerSensor("backup_version", new VersionStat(() -> (double) backupVersion));
       }
     }
 
     this.currentStatsReporter = statsSupplier.get(metricsRepository, storeName + "_current");
     if (!isSystemStore) {
       this.futureStatsReporter = statsSupplier.get(metricsRepository, storeName + "_future");
-      this.backupStatsReporter = statsSupplier.get(metricsRepository, storeName + "_backup");
       this.totalStatsReporter = statsSupplier.get(metricsRepository, storeName + "_total");
     } else {
       this.futureStatsReporter = null;
-      this.backupStatsReporter = null;
       this.totalStatsReporter = null;
     }
   }
@@ -66,7 +61,6 @@ public class VeniceVersionedStatsReporter<STATS, STATS_REPORTER extends Abstract
     this.currentStatsReporter.registerConditionalStats();
     if (!isSystemStore) {
       this.futureStatsReporter.registerConditionalStats();
-      this.backupStatsReporter.registerConditionalStats();
       this.totalStatsReporter.registerConditionalStats();
     }
   }
@@ -75,7 +69,6 @@ public class VeniceVersionedStatsReporter<STATS, STATS_REPORTER extends Abstract
     this.currentStatsReporter.unregisterStats();
     if (!isSystemStore) {
       this.futureStatsReporter.unregisterStats();
-      this.backupStatsReporter.unregisterStats();
       this.totalStatsReporter.unregisterStats();
     }
     super.unregisterAllSensors();
@@ -89,10 +82,6 @@ public class VeniceVersionedStatsReporter<STATS, STATS_REPORTER extends Abstract
     return futureVersion;
   }
 
-  public int getBackupVersion() {
-    return backupVersion;
-  }
-
   public void setCurrentStats(int version, STATS stats) {
     currentVersion = version;
     linkStatsWithReporter(currentStatsReporter, stats);
@@ -101,11 +90,6 @@ public class VeniceVersionedStatsReporter<STATS, STATS_REPORTER extends Abstract
   public void setFutureStats(int version, STATS stats) {
     futureVersion = version;
     linkStatsWithReporter(futureStatsReporter, stats);
-  }
-
-  public void setBackupStats(int version, STATS stats) {
-    backupVersion = version;
-    linkStatsWithReporter(backupStatsReporter, stats);
   }
 
   public void setTotalStats(STATS totalStats) {

--- a/services/venice-server/src/test/java/com/linkedin/venice/stats/AggVersionedDIVStatsTest.java
+++ b/services/venice-server/src/test/java/com/linkedin/venice/stats/AggVersionedDIVStatsTest.java
@@ -79,9 +79,6 @@ public class AggVersionedDIVStatsTest {
         reporter.query("." + storeName + "_current--duplicate_msg.DIVStatsCounter").value(),
         (double) NULL_DIV_STATS.code);
     Assert.assertEquals(
-        reporter.query("." + storeName + "_backup--missing_msg.DIVStatsCounter").value(),
-        (double) NULL_DIV_STATS.code);
-    Assert.assertEquals(
         reporter.query("." + storeName + "_future--corrupted_msg.DIVStatsCounter").value(),
         (double) NULL_DIV_STATS.code);
   }
@@ -100,9 +97,6 @@ public class AggVersionedDIVStatsTest {
 
     Assert.assertEquals(
         reporter.query("." + storeName + "_current--current_idle_time.DIVStatsCounter").value(),
-        (double) NULL_DIV_STATS.code);
-    Assert.assertEquals(
-        reporter.query("." + storeName + "_backup--overall_idle_time.DIVStatsCounter").value(),
         (double) NULL_DIV_STATS.code);
     Assert.assertEquals(reporter.query("." + storeName + "_total--corrupted_msg.DIVStatsCounter").value(), 0d);
     Assert.assertEquals(reporter.query("." + storeName + "_total--success_msg.DIVStatsCounter").value(), 0d);
@@ -269,7 +263,6 @@ public class AggVersionedDIVStatsTest {
     // v2's stats on backup reporter
     Assert.assertEquals(reporter.query("." + storeName + "_current--current_idle_time.DIVStatsCounter").value(), 2d);
     Assert.assertEquals(reporter.query("." + storeName + "_future--duplicate_msg.DIVStatsCounter").value(), 0d);
-    Assert.assertEquals(reporter.query("." + storeName + "_backup--duplicate_msg.DIVStatsCounter").value(), 1d);
 
     // v2 becomes the current version
     mockStore.setCurrentVersionWithoutCheck(2);
@@ -277,19 +270,12 @@ public class AggVersionedDIVStatsTest {
 
     // expect to see v2's stats on current reporter and v1's stats on backup reporter
     Assert.assertEquals(reporter.query("." + storeName + "_current--duplicate_msg.DIVStatsCounter").value(), 1d);
-    Assert.assertEquals(reporter.query("." + storeName + "_backup--current_idle_time.DIVStatsCounter").value(), 2d);
     Assert.assertEquals(
         reporter.query("." + storeName + "_current--broker_to_consumer_latency_avg_ms.DIVStatsCounter").value(),
         v2BrokerConsumerLatencyMs);
     Assert.assertEquals(
         reporter.query("." + storeName + "_current--broker_to_consumer_latency_max_ms.DIVStatsCounter").value(),
         v2BrokerConsumerLatencyMs);
-    Assert.assertEquals(
-        reporter.query("." + storeName + "_backup--producer_to_broker_latency_avg_ms.DIVStatsCounter").value(),
-        v1ProducerBrokerLatencyMs);
-    Assert.assertEquals(
-        reporter.query("." + storeName + "_backup--producer_to_broker_latency_max_ms.DIVStatsCounter").value(),
-        v1ProducerBrokerLatencyMs);
 
     // v3 finishes pushing and the status becomes to be online
     Version version3 = new VersionImpl(storeName, 3);
@@ -298,9 +284,6 @@ public class AggVersionedDIVStatsTest {
     mockStore.deleteVersion(1);
     stats.handleStoreChanged(mockStore);
     stats.recordMissingMsg(storeName, 3);
-
-    // expect to see v1 stats being removed from reporters
-    Assert.assertEquals(reporter.query("." + storeName + "_backup--missing_msg.DIVStatsCounter").value(), 1d);
   }
 
   @Test(dependsOnMethods = { "testStatsCanLoadAllStoresInTime" })

--- a/services/venice-server/src/test/java/com/linkedin/venice/stats/AggVersionedIngestionStatsTest.java
+++ b/services/venice-server/src/test/java/com/linkedin/venice/stats/AggVersionedIngestionStatsTest.java
@@ -50,7 +50,6 @@ public class AggVersionedIngestionStatsTest {
     String prefix = "." + STORE_FOO;
     String postfix = IngestionStats.VERSION_TOPIC_END_OFFSET_REWIND_COUNT + ".IngestionStatsGauge";
     totalKey = prefix + "_total--" + postfix;
-    backupKey = prefix + "_backup--" + postfix;
     currentKey = prefix + "_current--" + postfix;
     futureKey = prefix + "_future--" + postfix;
 
@@ -102,17 +101,17 @@ public class AggVersionedIngestionStatsTest {
     for (int i = 0; i < backupVerCnt; i++) {
       aggIngestionStats.recordVersionTopicEndOffsetRewind(STORE_FOO, backupVer.getNumber());
     }
-    verifyCounters(backupVerCnt, backupVerCnt, 0, 0);
+    verifyCounters(backupVerCnt, 0, 0);
 
     for (int i = 0; i < curVerCnt; i++) {
       aggIngestionStats.recordVersionTopicEndOffsetRewind(STORE_FOO, currentVer.getNumber());
     }
-    verifyCounters(backupVerCnt + curVerCnt, backupVerCnt, curVerCnt, 0);
+    verifyCounters(backupVerCnt + curVerCnt, curVerCnt, 0);
 
     for (int i = 0; i < futureVerCnt; i++) {
       aggIngestionStats.recordVersionTopicEndOffsetRewind(STORE_FOO, futureVer.getNumber());
     }
-    verifyCounters(backupVerCnt + curVerCnt + futureVerCnt, backupVerCnt, curVerCnt, futureVerCnt);
+    verifyCounters(backupVerCnt + curVerCnt + futureVerCnt, curVerCnt, futureVerCnt);
 
     aggIngestionStats.handleStoreDeleted(STORE_FOO);
     // Metrics are unregistered when UNREGISTER_METRIC_FOR_DELETED_STORE_ENABLED is enabled.
@@ -133,16 +132,14 @@ public class AggVersionedIngestionStatsTest {
         1);
   }
 
-  private void verifyCounters(double total, double backup, double current, double future) {
+  private void verifyCounters(double total, double current, double future) {
     Assert.assertEquals(reporter.query(totalKey).value(), total);
-    Assert.assertEquals(reporter.query(backupKey).value(), backup);
     Assert.assertEquals(reporter.query(currentKey).value(), current);
     Assert.assertEquals(reporter.query(futureKey).value(), future);
   }
 
   private void verifyNoMetrics() {
     Assert.assertNull(metricsRepo.getMetric(totalKey));
-    Assert.assertNull(metricsRepo.getMetric(backupKey));
     Assert.assertNull(metricsRepo.getMetric(currentKey));
     Assert.assertNull(metricsRepo.getMetric(futureKey));
   }

--- a/services/venice-server/src/test/java/com/linkedin/venice/stats/AggVersionedIngestionStatsTest.java
+++ b/services/venice-server/src/test/java/com/linkedin/venice/stats/AggVersionedIngestionStatsTest.java
@@ -35,7 +35,6 @@ public class AggVersionedIngestionStatsTest {
   private final VeniceServerConfig mockVeniceServerConfig = Mockito.mock(VeniceServerConfig.class);
 
   private String totalKey;
-  private String backupKey;
   private String currentKey;
   private String futureKey;
 


### PR DESCRIPTION
## [server][da-vinci-client] Do not emit metrics for backup version
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
Venice keep a backup version for possible rollback from an accidental bad/wrong push or other transient issues.
But Venice backup versions are deleted 
1. eagerly whenever a new push comes.
2. After a week of current version being online.
 
Since its a keep as a possible rollback, there is not much point in emitting tons of metrics for it. This PR restrict metric emission only to future and current versions.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.