### PR TITLE
[build][script] Dockerimages: add tools to replace ENV variables (k8s support)

### DIFF
--- a/docker/apply-config-from-env-with-prefix.py
+++ b/docker/apply-config-from-env-with-prefix.py
@@ -1,22 +1,7 @@
 #!/usr/bin/env python3
-#
-# Licensed to the Apache Software Foundation (ASF) under one
-# or more contributor license agreements.  See the NOTICE file
-# distributed with this work for additional information
-# regarding copyright ownership.  The ASF licenses this file
-# to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance
-# with the License.  You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
-#
+
+# This file is inspired by the following script in Apache Pulsar (Apache License 2.0)
+# https://github.com/apache/pulsar/blob/master/docker/pulsar/scripts/apply-config-from-env-with-prefix.py
 
 ############################################################
 # Edit a properties config file and replace values based on

--- a/docker/apply-config-from-env-with-prefix.py
+++ b/docker/apply-config-from-env-with-prefix.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+############################################################
+# Edit a properties config file and replace values based on
+# the ENV variables
+# export prefix_my-key=new-value
+# ./apply-config-from-env-with-prefix prefix_ file.conf
+#
+# Environment variables that are prefixed with the command
+# line prefix will be used to updated file properties if
+# they exist and create new ones if they don't.
+#
+# Environment variables not prefixed will be used only to
+# update if they exist and ignored if they don't.
+#
+# Venice uses variables with dot notation, but k8s and bash
+# don't play well with dots, so the script replaces underscores with dots.
+
+# For instance:
+# listener.port=7777
+# 
+# This is mapped to
+# prefix_listener_port=7777
+#
+############################################################
+
+import os
+import sys
+
+if len(sys.argv) < 3:
+    print('Usage: %s <PREFIX> <FILE> [<FILE>...]' % (sys.argv[0]))
+    sys.exit(1)
+
+# Always apply env config to env scripts as well
+prefix = sys.argv[1]
+conf_files = sys.argv[2:]
+
+PF_ENV_DEBUG = (os.environ.get('PF_ENV_DEBUG','0') == '1')
+
+for conf_filename in conf_files:
+    lines = []  # List of config file lines
+    keys = {} # Map a key to its line number in the file
+
+    # Load conf file
+    for line in open(conf_filename):
+        lines.append(line)
+        line = line.strip()
+        if not line or line.startswith('#'):
+            continue
+
+        try:
+            k,v = line.split('=', 1)
+            keys[k] = len(lines) - 1
+        except:
+            if PF_ENV_DEBUG:
+                print("[%s] skip Processing %s" % (conf_filename, line))
+
+    # Update values from Env
+    for k in sorted(os.environ.keys()):
+        v = os.environ[k].strip()
+
+        # Hide the value in logs if is password.
+        if "password" in k.lower():
+            displayValue = "********"
+        else:
+            displayValue = v
+        if k.startswith(prefix):
+            k = k[len(prefix):].replace("_", ".")
+        if k in keys:
+            print('[%s] Applying config %s = %s' % (conf_filename, k, displayValue))
+            idx = keys[k]
+            lines[idx] = '%s=%s\n' % (k, v)
+
+
+    # Ensure we have a new-line at the end of the file, to avoid issue
+    # when appending more lines to the config
+    lines.append('\n')
+
+    # Add new keys from Env
+    for k in sorted(os.environ.keys()):
+        v = os.environ[k]
+        if not k.startswith(prefix):
+            continue
+
+        # Hide the value in logs if is password.
+        if "password" in k.lower():
+            displayValue = "********"
+        else:
+            displayValue = v
+
+        k = k[len(prefix):].replace("_", ".")
+        if k not in keys:
+            print('[%s] Adding config %s = %s' % (conf_filename, k, displayValue))
+            lines.append('%s=%s\n' % (k, v))
+        else:
+            print('[%s] Updating config %s = %s' % (conf_filename, k, displayValue))
+            lines[keys[k]] = '%s=%s\n' % (k, v)
+
+
+    # Store back the updated config in the same file
+    f = open(conf_filename, 'w')
+    for line in lines:
+        f.write(line)
+    f.close()
+

--- a/docker/build-venice-docker-images.sh
+++ b/docker/build-venice-docker-images.sh
@@ -2,21 +2,30 @@ cd ../
 ./gradlew shadowJar
 cd docker
 
-oss_release=0.4.17
+repository="${1:-venicedb}"
+oss_release="${2:-0.4.17}"
+
+set -x
+echo "Building docker images for repository $repository, version $oss_release"
+
 head_hash=$(git rev-parse --short HEAD)
 version=$oss_release
 
+cp *py venice-client/ 
 cp ../clients/venice-push-job/build/libs/venice-push-job-all.jar venice-client/
 cp ../clients/venice-thin-client/build/libs/venice-thin-client-all.jar venice-client/
 cp ../clients/venice-admin-tool/build/libs/venice-admin-tool-all.jar venice-client/
+cp *py venice-server/ 
 cp ../services/venice-server/build/libs/venice-server-all.jar venice-server/
+cp *py venice-controller/ 
 cp ../services/venice-controller/build/libs/venice-controller-all.jar venice-controller/
+cp *py venice-router/ 
 cp ../services/venice-router/build/libs/venice-router-all.jar venice-router/
 
 targets=(venice-controller venice-server venice-router venice-client)
 
 for target in ${targets[@]}; do
-    docker build -t "venicedb/$target:$version" $target
+    docker buildx build --load --platform linux/amd64 -t "$repository/$target:$version" $target
 done
 
 rm -f venice-client/venice-push-job-all.jar
@@ -25,3 +34,5 @@ rm -f venice-client/venice-admin-tool-all.jar
 rm -f venice-server/venice-server-all.jar
 rm -f venice-controller/venice-controller-all.jar
 rm -f venice-router/venice-router-all.jar
+rm */*.py
+

--- a/docker/build-venice-docker-images.sh
+++ b/docker/build-venice-docker-images.sh
@@ -1,4 +1,6 @@
-cd ../
+CURRENTDIR=$(dirname "$0")
+
+pushd $CURRENTDIR/..
 ./gradlew shadowJar
 cd docker
 
@@ -36,3 +38,4 @@ rm -f venice-controller/venice-controller-all.jar
 rm -f venice-router/venice-router-all.jar
 rm */*.py
 
+popd

--- a/docker/venice-client/Dockerfile
+++ b/docker/venice-client/Dockerfile
@@ -3,9 +3,7 @@ FROM  mcr.microsoft.com/openjdk/jdk:11-ubuntu
 ENV VENICE_DIR=/opt/venice
 
 RUN apt-get update
-RUN apt-get install netcat -y
-RUN apt-get install tree -y
-RUN apt-get install wget -y
+RUN apt-get install netcat tree wget python3 -y
 RUN mkdir -p "${VENICE_DIR}/bin"
 RUN wget -O ${VENICE_DIR}/bin/avro-tools.jar https://downloads.apache.org/avro/stable/java/avro-tools-1.11.1.jar
 RUN wget -O ${VENICE_DIR}/bin/hadoop-mapreduce-client-core.jar https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-mapreduce-client-core/2.3.0/hadoop-mapreduce-client-core-2.3.0.jar

--- a/docker/venice-controller/Dockerfile
+++ b/docker/venice-controller/Dockerfile
@@ -3,12 +3,13 @@ FROM  mcr.microsoft.com/openjdk/jdk:11-ubuntu
 ENV VENICE_DIR=/opt/venice
 
 RUN apt-get update
-RUN apt-get install tree -y
+RUN apt-get install tree python3 -y
 RUN mkdir -p ${VENICE_DIR}/bin && mkdir -p ${VENICE_DIR}/configs
 
 WORKDIR ${VENICE_DIR}
 
 COPY venice-controller-all.jar bin/venice-controller-all.jar
+COPY *py bin/
 COPY single-dc-configs configs/single-dc
 COPY multi-dc-configs configs/multi-dc
 

--- a/docker/venice-router/Dockerfile
+++ b/docker/venice-router/Dockerfile
@@ -3,12 +3,13 @@ FROM  mcr.microsoft.com/openjdk/jdk:11-ubuntu
 ENV VENICE_DIR=/opt/venice
 
 RUN apt-get update
-RUN apt-get install tree -y
+RUN apt-get install tree python3 -y
 RUN mkdir -p ${VENICE_DIR}/bin && mkdir -p ${VENICE_DIR}/configs
 
 WORKDIR ${VENICE_DIR}
 
 COPY venice-router-all.jar bin/venice-router-all.jar
+COPY *py bin/
 COPY single-dc-configs configs/single-dc
 COPY multi-dc-configs configs/multi-dc
 

--- a/docker/venice-server/Dockerfile
+++ b/docker/venice-server/Dockerfile
@@ -3,12 +3,13 @@ FROM  mcr.microsoft.com/openjdk/jdk:11-ubuntu
 ENV VENICE_DIR=/opt/venice
 
 RUN apt-get update
-RUN apt-get install tree -y
+RUN apt-get install tree python3 -y
 RUN mkdir -p ${VENICE_DIR}/bin && mkdir -p ${VENICE_DIR}/configs && mkdir -p ${VENICE_DIR}/rocksdb
 
 WORKDIR ${VENICE_DIR}
 
 COPY venice-server-all.jar bin/venice-server-all.jar
+COPY *py bin/
 COPY single-dc-configs configs/single-dc
 COPY multi-dc-configs configs/multi-dc
 


### PR DESCRIPTION
## Summary
This patches imports a file inspired by the Pulsar scripts that allows injecting configuration variables from the ENV.
This is pretty common in K8S as you can use `configmaps` to configure the system.

Changes:
- adapt apply-config-from-env-with-prefix.py from Apache Pulsar
- support building on Mac M1 using docker buildx


## How was this PR tested?

This code is used by the Helm Chart that I am building
