### PR TITLE
[controller] Expose hooks in Controller to allow customized superset schema generation

### DIFF
--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -330,6 +330,12 @@ public class ConfigKeys {
   public static final String CONTROLLER_STORE_GRAVEYARD_CLEANUP_SLEEP_INTERVAL_BETWEEN_LIST_FETCH_MINUTES =
       "controller.store.graveyard.cleanup.sleep.interval.between.list.fetch.minutes";
 
+  /**
+   * Whether the superset schema generation in Parent Controller should be done via passed callback or not.
+   */
+  public static final String CONTROLLER_PARENT_EXTERNAL_SUPERSET_SCHEMA_GENERATION_ENABLED =
+      "controller.parent.external.superset.schema.generation.enabled";
+
   // Server specific configs
   public static final String LISTENER_PORT = "listener.port";
 

--- a/internal/venice-common/src/main/java/com/linkedin/venice/helix/HelixReadWriteSchemaRepository.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/helix/HelixReadWriteSchemaRepository.java
@@ -479,16 +479,6 @@ public class HelixReadWriteSchemaRepository implements ReadWriteSchemaRepository
   }
 
   @Override
-  public int getValueSchemaIdIgnoreFieldOrder(String storeName, SchemaEntry newSchemaEntry) {
-    for (SchemaEntry schemaEntry: getValueSchemas(storeName)) {
-      if (AvroSchemaUtils.compareSchemaIgnoreFieldOrder(schemaEntry.getSchema(), newSchemaEntry.getSchema())) {
-        return schemaEntry.getId();
-      }
-    }
-    return SchemaData.INVALID_VALUE_SCHEMA_ID;
-  }
-
-  @Override
   public GeneratedSchemaID getDerivedSchemaId(String storeName, String derivedSchemaStr) {
     preCheckStoreCondition(storeName);
     Schema derivedSchema = Schema.parse(derivedSchemaStr);

--- a/internal/venice-common/src/main/java/com/linkedin/venice/helix/HelixReadWriteSchemaRepositoryAdapter.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/helix/HelixReadWriteSchemaRepositoryAdapter.java
@@ -130,19 +130,6 @@ public class HelixReadWriteSchemaRepositoryAdapter implements ReadWriteSchemaRep
   }
 
   @Override
-  public int getValueSchemaIdIgnoreFieldOrder(String storeName, SchemaEntry newSchemaEntry) {
-    VeniceSystemStoreType systemStoreType = VeniceSystemStoreType.getSystemStoreType(storeName);
-    if (HelixReadOnlyStoreRepositoryAdapter.forwardToRegularRepository(systemStoreType)) {
-      return readWriteRegularStoreSchemaRepository.getValueSchemaIdIgnoreFieldOrder(storeName, newSchemaEntry);
-    }
-    throw new VeniceException(
-        errorMsgForUnsupportedOperationsAgainstSystemStore(
-            storeName,
-            systemStoreType,
-            "getValueSchemaIdIgnoreFieldOrder"));
-  }
-
-  @Override
   public int preCheckDerivedSchemaAndGetNextAvailableId(String storeName, int valueSchemaId, String derivedSchemaStr) {
     VeniceSystemStoreType systemStoreType = VeniceSystemStoreType.getSystemStoreType(storeName);
     if (HelixReadOnlyStoreRepositoryAdapter.forwardToRegularRepository(systemStoreType)) {

--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/ReadWriteSchemaRepository.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/ReadWriteSchemaRepository.java
@@ -60,8 +60,6 @@ public interface ReadWriteSchemaRepository extends ReadOnlySchemaRepository {
       String valueSchemaStr,
       DirectionalSchemaCompatibilityType expectedCompatibilityType);
 
-  int getValueSchemaIdIgnoreFieldOrder(String storeName, SchemaEntry newSchemaEntry);
-
   int preCheckDerivedSchemaAndGetNextAvailableId(String storeName, int valueSchemaId, String derivedSchemaStr);
 
   RmdSchemaEntry addReplicationMetadataSchema(

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/controller/VeniceParentHelixAdminTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/controller/VeniceParentHelixAdminTest.java
@@ -2,6 +2,7 @@ package com.linkedin.venice.controller;
 
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_AUTO_MATERIALIZE_DAVINCI_PUSH_STATUS_SYSTEM_STORE;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_AUTO_MATERIALIZE_META_SYSTEM_STORE;
+import static com.linkedin.venice.ConfigKeys.CONTROLLER_PARENT_EXTERNAL_SUPERSET_SCHEMA_GENERATION_ENABLED;
 import static com.linkedin.venice.ConfigKeys.REPLICATION_METADATA_VERSION;
 import static com.linkedin.venice.ConfigKeys.TERMINAL_STATE_TOPIC_CHECK_DELAY_MS;
 import static com.linkedin.venice.ConfigKeys.TOPIC_CLEANUP_SLEEP_INTERVAL_BETWEEN_TOPIC_LIST_FETCH_MS;
@@ -20,6 +21,8 @@ import static org.testng.Assert.assertTrue;
 
 import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
 import com.linkedin.venice.common.VeniceSystemStoreType;
+import com.linkedin.venice.controller.supersetschema.SupersetSchemaGenerator;
+import com.linkedin.venice.controller.supersetschema.SupersetSchemaGeneratorWithCustomProp;
 import com.linkedin.venice.controllerapi.ControllerClient;
 import com.linkedin.venice.controllerapi.ControllerResponse;
 import com.linkedin.venice.controllerapi.MultiSchemaResponse;
@@ -41,7 +44,6 @@ import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.schema.AvroSchemaParseUtils;
 import com.linkedin.venice.schema.writecompute.WriteComputeSchemaConverter;
 import com.linkedin.venice.security.SSLFactory;
-import com.linkedin.venice.utils.DataProviderUtils;
 import com.linkedin.venice.utils.SslUtils;
 import com.linkedin.venice.utils.TestWriteUtils;
 import com.linkedin.venice.utils.Utils;
@@ -56,6 +58,7 @@ import org.apache.avro.Schema;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 
@@ -381,14 +384,175 @@ public class VeniceParentHelixAdminTest {
     }
   }
 
-  @Test(dataProvider = "True-and-False", dataProviderClass = DataProviderUtils.class, timeOut = DEFAULT_TEST_TIMEOUT_MS
-      * 10)
-  public void testStoreMetaDataUpdateFromParentToChildController(boolean isControllerSslEnabled) throws IOException {
+  @Test(timeOut = DEFAULT_TEST_TIMEOUT_MS)
+  public void testSupersetSchemaWithCustomSupersetSchemaGenerator() throws IOException {
+    String clusterName = Utils.getUniqueString("testSupersetSchemaWithCustomSupersetSchemaGenerator");
+    final String CUSTOM_PROP = "custom_prop";
+    // Contains f0, f1
+    Schema valueSchemaV1 =
+        AvroCompatibilityHelper.parse(TestWriteUtils.loadFileAsString("supersetschemas/ValueV1.avsc"));
+    // Contains f2, f3
+    Schema valueSchemaV4 =
+        AvroCompatibilityHelper.parse(TestWriteUtils.loadFileAsString("supersetschemas/ValueV4.avsc"));
+    // Contains f0
+    Schema valueSchemaV6 =
+        AvroCompatibilityHelper.parse(TestWriteUtils.loadFileAsString("supersetschemas/ValueV6.avsc"));
+    Properties properties = new Properties();
+    // This cluster setup don't have server, we cannot perform push here.
+    properties.setProperty(CONTROLLER_AUTO_MATERIALIZE_META_SYSTEM_STORE, String.valueOf(false));
+    properties.setProperty(CONTROLLER_AUTO_MATERIALIZE_DAVINCI_PUSH_STATUS_SYSTEM_STORE, String.valueOf(false));
+    properties.setProperty(CONTROLLER_PARENT_EXTERNAL_SUPERSET_SCHEMA_GENERATION_ENABLED, String.valueOf(true));
+    properties
+        .put(VeniceControllerWrapper.SUPERSET_SCHEMA_GENERATOR, new SupersetSchemaGeneratorWithCustomProp(CUSTOM_PROP));
+
+    try (ZkServerWrapper zkServer = ServiceFactory.getZkServer();
+        KafkaBrokerWrapper kafkaBrokerWrapper = ServiceFactory.getKafkaBroker(zkServer);
+        VeniceControllerWrapper childControllerWrapper = ServiceFactory.getVeniceController(
+            new VeniceControllerCreateOptions.Builder(clusterName, zkServer, kafkaBrokerWrapper).build());
+        ZkServerWrapper parentZk = ServiceFactory.getZkServer();
+        VeniceControllerWrapper parentControllerWrapper = ServiceFactory.getVeniceController(
+            new VeniceControllerCreateOptions.Builder(clusterName, parentZk, kafkaBrokerWrapper)
+                .childControllers(new VeniceControllerWrapper[] { childControllerWrapper })
+                .extraProperties(properties)
+                .build())) {
+      String parentControllerUrl = parentControllerWrapper.getControllerUrl();
+      try (ControllerClient parentControllerClient = new ControllerClient(clusterName, parentControllerUrl)) {
+        // Create a new store
+        String storeName = Utils.getUniqueString("test_store_");
+        String owner = "test_owner";
+        String keySchemaStr = "\"long\"";
+        String valueSchemaStr = valueSchemaV1.toString();
+        NewStoreResponse newStoreResponse =
+            parentControllerClient.createNewStore(storeName, owner, keySchemaStr, valueSchemaStr);
+        Assert.assertNotNull(newStoreResponse);
+        Assert.assertFalse(newStoreResponse.isError(), "error in newStoreResponse: " + newStoreResponse.getError());
+        // Enable write compute
+        ControllerResponse updateStoreResponse = parentControllerClient
+            .updateStore(storeName, new UpdateStoreQueryParams().setWriteComputationEnabled(true));
+        Assert.assertFalse(updateStoreResponse.isError());
+
+        MultiSchemaResponse schemaResponse = parentControllerClient.getAllValueSchema(storeName);
+        Assert.assertNotNull(schemaResponse);
+        Assert.assertFalse(schemaResponse.isError(), "error in schemaResponse: " + schemaResponse.getError());
+        Assert.assertNotNull(schemaResponse.getSchemas());
+        Assert.assertEquals(schemaResponse.getSchemas().length, 1, "There should be one value schema.");
+
+        StoreResponse storeResponse = parentControllerClient.getStore(storeName);
+        Assert.assertNotNull(storeResponse);
+        Assert.assertFalse(storeResponse.isError(), "error in storeResponse: " + storeResponse.getError());
+        Assert.assertNotNull(storeResponse.getStore());
+        Assert.assertEquals(
+            storeResponse.getStore().getLatestSuperSetValueSchemaId(),
+            1,
+            "Superset schema ID should be the first schema");
+
+        // Add a new value schema with custom prop
+        String customPropValue = "custom_prop_value_for_v2";
+        valueSchemaV4.addProp(CUSTOM_PROP, customPropValue);
+        SchemaResponse addValueSchemaResponse =
+            parentControllerClient.addValueSchema(storeName, valueSchemaV4.toString());
+        Assert.assertFalse(addValueSchemaResponse.isError());
+
+        schemaResponse = parentControllerClient.getAllValueSchema(storeName);
+        Assert.assertNotNull(schemaResponse);
+        Assert.assertFalse(schemaResponse.isError(), "error in schemaResponse: " + schemaResponse.getError());
+        Assert.assertNotNull(schemaResponse.getSchemas());
+        Assert.assertEquals(schemaResponse.getSchemas().length, 3, "There should be 3 value schemas.");
+
+        // Verify superset schema id
+        storeResponse = parentControllerClient.getStore(storeName);
+        Assert.assertFalse(storeResponse.isError(), "error in storeResponse: " + storeResponse.getError());
+        Assert.assertEquals(
+            storeResponse.getStore().getLatestSuperSetValueSchemaId(),
+            3,
+            "Superset schema ID should be the last schema");
+
+        // Verify whether the superset schema contains the CUSTOM_PROP or not.
+        SchemaResponse supersetSchemaResponse = parentControllerClient.getValueSchema(storeName, 3);
+        Assert.assertFalse(supersetSchemaResponse.isError(), "error in schemaResponse: " + schemaResponse.getError());
+        Schema supersetSchema = AvroCompatibilityHelper.parse(supersetSchemaResponse.getSchemaStr());
+        assertEquals(supersetSchema.getProp(CUSTOM_PROP), customPropValue);
+
+        // Register a schema, which is identical to the superset schema, but with a different value for CUSTOM_PROP
+        String valueSchemaSameAsSupersetSchemaWithDifferentCustomProp = supersetSchemaResponse.getSchemaStr();
+        String newCustomPropValue = "new_custom_prop_value";
+        valueSchemaSameAsSupersetSchemaWithDifferentCustomProp =
+            valueSchemaSameAsSupersetSchemaWithDifferentCustomProp.replace(customPropValue, newCustomPropValue);
+        addValueSchemaResponse =
+            parentControllerClient.addValueSchema(storeName, valueSchemaSameAsSupersetSchemaWithDifferentCustomProp);
+        Assert.assertFalse(
+            addValueSchemaResponse.isError(),
+            "error in addValueSchemaResponse: " + addValueSchemaResponse.getError());
+        schemaResponse = parentControllerClient.getAllValueSchema(storeName);
+        Assert.assertNotNull(schemaResponse);
+        Assert.assertFalse(schemaResponse.isError(), "error in schemaResponse: " + schemaResponse.getError());
+        Assert.assertNotNull(schemaResponse.getSchemas());
+        Assert.assertEquals(schemaResponse.getSchemas().length, 4, "There should be 4 value schemas.");
+        storeResponse = parentControllerClient.getStore(storeName);
+        Assert.assertFalse(storeResponse.isError(), "error in storeResponse: " + storeResponse.getError());
+        Assert.assertEquals(
+            storeResponse.getStore().getLatestSuperSetValueSchemaId(),
+            4,
+            "Superset schema ID should be the last schema");
+        supersetSchemaResponse = parentControllerClient.getValueSchema(storeName, 4);
+        Assert.assertFalse(supersetSchemaResponse.isError(), "error in schemaResponse: " + schemaResponse.getError());
+        supersetSchema = AvroCompatibilityHelper.parse(supersetSchemaResponse.getSchemaStr());
+        assertEquals(supersetSchema.getProp(CUSTOM_PROP), newCustomPropValue);
+
+        // Register a schema, which is a subset of current superset schema, but with a different value for CUSTOM_PROP
+        Schema newValueSchemaWithSubsetOfFieldsWithDifferentCustomProp =
+            AvroCompatibilityHelper.parse(valueSchemaV6.toString());
+        String newCustomPropValueForNewValueSchemaWithSubsetOfFields =
+            "custom_prop_for_newValueSchemaWithSubsetOfFieldsWithDifferentCustomProp";
+        newValueSchemaWithSubsetOfFieldsWithDifferentCustomProp
+            .addProp(CUSTOM_PROP, newCustomPropValueForNewValueSchemaWithSubsetOfFields);
+        addValueSchemaResponse = parentControllerClient
+            .addValueSchema(storeName, newValueSchemaWithSubsetOfFieldsWithDifferentCustomProp.toString());
+        Assert.assertFalse(
+            addValueSchemaResponse.isError(),
+            "error in addValueSchemaResponse: " + addValueSchemaResponse.getError());
+        schemaResponse = parentControllerClient.getAllValueSchema(storeName);
+        Assert.assertNotNull(schemaResponse);
+        Assert.assertFalse(schemaResponse.isError(), "error in schemaResponse: " + schemaResponse.getError());
+        Assert.assertNotNull(schemaResponse.getSchemas());
+        Assert.assertEquals(schemaResponse.getSchemas().length, 6, "There should be 4 value schemas.");
+        storeResponse = parentControllerClient.getStore(storeName);
+        Assert.assertFalse(storeResponse.isError(), "error in storeResponse: " + storeResponse.getError());
+        Assert.assertEquals(
+            storeResponse.getStore().getLatestSuperSetValueSchemaId(),
+            6,
+            "Superset schema ID should be the last schema");
+        supersetSchemaResponse = parentControllerClient.getValueSchema(storeName, 6);
+        Assert.assertFalse(supersetSchemaResponse.isError(), "error in schemaResponse: " + schemaResponse.getError());
+        supersetSchema = AvroCompatibilityHelper.parse(supersetSchemaResponse.getSchemaStr());
+        assertEquals(supersetSchema.getProp(CUSTOM_PROP), newCustomPropValueForNewValueSchemaWithSubsetOfFields);
+        assertNotNull(supersetSchema.getField("f0"));
+        assertNotNull(supersetSchema.getField("f1"));
+        assertNotNull(supersetSchema.getField("f2"));
+        assertNotNull(supersetSchema.getField("f3"));
+      }
+    }
+  }
+
+  @DataProvider(name = "CONTROLLER_SSL_SUPERSET_SCHEMA_GENERATOR")
+  public static Object[][] controllerSSLAndSupersetSchemaGenerator() {
+    return new Object[][] { new Object[] { true, Optional.of(new SupersetSchemaGeneratorWithCustomProp("test_prop")) },
+        new Object[] { false, Optional.empty() } };
+  }
+
+  @Test(dataProvider = "CONTROLLER_SSL_SUPERSET_SCHEMA_GENERATOR", timeOut = DEFAULT_TEST_TIMEOUT_MS * 10)
+  public void testStoreMetaDataUpdateFromParentToChildController(
+      boolean isControllerSslEnabled,
+      Optional<SupersetSchemaGenerator> supersetSchemaGenerator) throws IOException {
     String clusterName = Utils.getUniqueString("testStoreMetadataUpdate");
     Properties properties = new Properties();
     // This cluster setup don't have server, we cannot perform push here.
     properties.setProperty(CONTROLLER_AUTO_MATERIALIZE_META_SYSTEM_STORE, String.valueOf(false));
     properties.setProperty(CONTROLLER_AUTO_MATERIALIZE_DAVINCI_PUSH_STATUS_SYSTEM_STORE, String.valueOf(false));
+    if (supersetSchemaGenerator.isPresent()) {
+      properties.setProperty(CONTROLLER_PARENT_EXTERNAL_SUPERSET_SCHEMA_GENERATION_ENABLED, String.valueOf(true));
+      properties.put(VeniceControllerWrapper.SUPERSET_SCHEMA_GENERATOR, supersetSchemaGenerator.get());
+    }
 
     try (ZkServerWrapper zkServer = ServiceFactory.getZkServer();
         KafkaBrokerWrapper kafkaBrokerWrapper = ServiceFactory.getKafkaBroker(zkServer);
@@ -858,4 +1022,5 @@ public class VeniceParentHelixAdminTest {
     schemaStr += "           ]\n" + "      }], " + "     \"default\": null\n" + "    }\n" + " ]\n" + "}";
     return AvroSchemaParseUtils.parseSchemaFromJSONStrictValidation(schemaStr);
   }
+
 }

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/integration/utils/VeniceControllerWrapper.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/integration/utils/VeniceControllerWrapper.java
@@ -50,6 +50,7 @@ import com.linkedin.venice.controller.Admin;
 import com.linkedin.venice.controller.VeniceController;
 import com.linkedin.venice.controller.VeniceHelixAdmin;
 import com.linkedin.venice.controller.kafka.consumer.AdminConsumerService;
+import com.linkedin.venice.controller.supersetschema.SupersetSchemaGenerator;
 import com.linkedin.venice.controllerapi.ControllerClient;
 import com.linkedin.venice.d2.D2Server;
 import com.linkedin.venice.kafka.admin.KafkaAdminClient;
@@ -88,6 +89,8 @@ public class VeniceControllerWrapper extends ProcessWrapper {
   public static final String D2_SERVICE_NAME = "ChildController";
   public static final String PARENT_D2_CLUSTER_NAME = "ParentControllerD2Cluster";
   public static final String PARENT_D2_SERVICE_NAME = "ParentController";
+
+  public static final String SUPERSET_SCHEMA_GENERATOR = "SupersetSchemaGenerator";
 
   public static final double DEFAULT_STORAGE_ENGINE_OVERHEAD_RATIO = 0.85d;
   public static final String DEFAULT_PARENT_DATA_CENTER_REGION_NAME = "dc-parent-0";
@@ -298,6 +301,11 @@ public class VeniceControllerWrapper extends ProcessWrapper {
       if (clientConfig != null && clientConfig instanceof ClientConfig) {
         consumerClientConfig = Optional.of((ClientConfig) clientConfig);
       }
+      Optional<SupersetSchemaGenerator> supersetSchemaGenerator = Optional.empty();
+      Object passedSupersetSchemaGenerator = options.getExtraProperties().get(SUPERSET_SCHEMA_GENERATOR);
+      if (passedSupersetSchemaGenerator != null && passedSupersetSchemaGenerator instanceof SupersetSchemaGenerator) {
+        supersetSchemaGenerator = Optional.of((SupersetSchemaGenerator) passedSupersetSchemaGenerator);
+      }
       VeniceController veniceController = new VeniceController(
           propertiesList,
           metricsRepository,
@@ -306,7 +314,8 @@ public class VeniceControllerWrapper extends ProcessWrapper {
           Optional.ofNullable(options.getAuthorizerService()),
           d2Client,
           consumerClientConfig,
-          Optional.empty());
+          Optional.empty(),
+          supersetSchemaGenerator);
       return new VeniceControllerWrapper(
           options.getRegionName(),
           serviceName,

--- a/internal/venice-test-common/src/integrationtest/resources/supersetschemas/ValueV6.avsc
+++ b/internal/venice-test-common/src/integrationtest/resources/supersetschemas/ValueV6.avsc
@@ -1,0 +1,8 @@
+{
+  "type" : "record",
+  "namespace" : "example.avro",
+  "name" : "ValueRecordName",
+  "fields" : [
+    { "name" : "f0", "type" : "int", "default" : -1 }
+  ]
+}

--- a/services/venice-controller/build.gradle
+++ b/services/venice-controller/build.gradle
@@ -41,6 +41,7 @@ dependencies {
   testImplementation project(':services:venice-router')
   testImplementation libraries.avroUtilFastserde
   testImplementation libraries.kafkaClientsTest // TODO: Get rid of Kafka dependency in venice-common (used by TopicCreator)
+  testImplementation project(':internal:venice-test-common')
 }
 
 jar {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceController.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceController.java
@@ -12,6 +12,7 @@ import com.linkedin.venice.client.store.ClientConfig;
 import com.linkedin.venice.controller.kafka.TopicCleanupService;
 import com.linkedin.venice.controller.kafka.TopicCleanupServiceForParentController;
 import com.linkedin.venice.controller.server.AdminSparkServer;
+import com.linkedin.venice.controller.supersetschema.SupersetSchemaGenerator;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.service.AbstractVeniceService;
 import com.linkedin.venice.service.ICProvider;
@@ -52,12 +53,13 @@ public class VeniceController {
   private final D2Client d2Client;
   private final Optional<ClientConfig> routerClientConfig;
   private final Optional<ICProvider> icProvider;
+  private final Optional<SupersetSchemaGenerator> externalSupersetSchemaGenerator;
   private static final String CONTROLLER_SERVICE_NAME = "venice-controller";
 
   /**
    * This constructor is being used in integration test.
    *
-   * @see #VeniceController(List, MetricsRepository, List, Optional, Optional, D2Client, Optional, Optional)
+   * @see #VeniceController(List, MetricsRepository, List, Optional, Optional, D2Client, Optional, Optional, Optional)
    */
   public VeniceController(
       List<VeniceProperties> propertiesList,
@@ -90,6 +92,7 @@ public class VeniceController {
         authorizerService,
         d2Client,
         routerClientConfig,
+        Optional.empty(),
         Optional.empty());
   }
 
@@ -121,7 +124,8 @@ public class VeniceController {
       Optional<AuthorizerService> authorizerService,
       D2Client d2Client,
       Optional<ClientConfig> routerClientConfig,
-      Optional<ICProvider> icProvider) {
+      Optional<ICProvider> icProvider,
+      Optional<SupersetSchemaGenerator> externalSupersetSchemaGenerator) {
     this.multiClusterConfigs = new VeniceControllerMultiClusterConfig(propertiesList);
     this.metricsRepository = metricsRepository;
     this.serviceDiscoveryAnnouncers = serviceDiscoveryAnnouncers;
@@ -132,6 +136,7 @@ public class VeniceController {
     this.d2Client = d2Client;
     this.routerClientConfig = routerClientConfig;
     this.icProvider = icProvider;
+    this.externalSupersetSchemaGenerator = externalSupersetSchemaGenerator;
     createServices();
   }
 
@@ -145,7 +150,8 @@ public class VeniceController {
         authorizerService,
         d2Client,
         routerClientConfig,
-        icProvider);
+        icProvider,
+        externalSupersetSchemaGenerator);
 
     adminServer = new AdminSparkServer(
         // no need to pass the hostname, we are binding to all the addresses

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerService.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerService.java
@@ -12,6 +12,7 @@ import com.linkedin.venice.controller.lingeringjob.DefaultLingeringStoreVersionC
 import com.linkedin.venice.controller.lingeringjob.HeartbeatBasedCheckerStats;
 import com.linkedin.venice.controller.lingeringjob.HeartbeatBasedLingeringStoreVersionChecker;
 import com.linkedin.venice.controller.lingeringjob.LingeringStoreVersionChecker;
+import com.linkedin.venice.controller.supersetschema.SupersetSchemaGenerator;
 import com.linkedin.venice.kafka.protocol.KafkaMessageEnvelope;
 import com.linkedin.venice.pubsub.PubSubTopicRepository;
 import com.linkedin.venice.pubsub.kafka.KafkaPubSubMessageDeserializer;
@@ -50,7 +51,8 @@ public class VeniceControllerService extends AbstractVeniceService {
       Optional<AuthorizerService> authorizerService,
       D2Client d2Client,
       Optional<ClientConfig> routerClientConfig,
-      Optional<ICProvider> icProvider) {
+      Optional<ICProvider> icProvider,
+      Optional<SupersetSchemaGenerator> externalSupersetSchemaGenerator) {
     this.multiClusterConfigs = multiClusterConfigs;
     VeniceHelixAdmin internalAdmin = new VeniceHelixAdmin(
         multiClusterConfigs,
@@ -70,7 +72,8 @@ public class VeniceControllerService extends AbstractVeniceService {
           accessController,
           authorizerService,
           createLingeringStoreVersionChecker(multiClusterConfigs, metricsRepository),
-          WriteComputeSchemaConverter.getInstance());
+          WriteComputeSchemaConverter.getInstance(),
+          externalSupersetSchemaGenerator);
       LOGGER.info("Controller works as a parent controller.");
     } else {
       this.admin = internalAdmin;

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -4771,11 +4771,21 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
     return schemaRepository.addValueSchema(storeName, valueSchema, valueSchemaId);
   }
 
-  int getValueSchemaIdIgnoreFieldOrder(String clusterName, String storeName, String valueSchemaStr) {
+  int getValueSchemaIdIgnoreFieldOrder(
+      String clusterName,
+      String storeName,
+      String valueSchemaStr,
+      Comparator<Schema> schemaComparator) {
     checkControllerLeadershipFor(clusterName);
     SchemaEntry valueSchemaEntry = new SchemaEntry(SchemaData.UNKNOWN_SCHEMA_ID, valueSchemaStr);
-    ReadWriteSchemaRepository schemaRepository = getHelixVeniceClusterResources(clusterName).getSchemaRepository();
-    return schemaRepository.getValueSchemaIdIgnoreFieldOrder(storeName, valueSchemaEntry);
+
+    for (SchemaEntry schemaEntry: getValueSchemas(clusterName, storeName)) {
+      if (schemaComparator.compare(schemaEntry.getSchema(), valueSchemaEntry.getSchema()) == 0) {
+        return schemaEntry.getId();
+      }
+    }
+    return SchemaData.INVALID_VALUE_SCHEMA_ID;
+
   }
 
   int checkPreConditionForAddValueSchemaAndGetNewSchemaId(

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/supersetschema/DefaultSupersetSchemaGenerator.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/supersetschema/DefaultSupersetSchemaGenerator.java
@@ -1,0 +1,25 @@
+package com.linkedin.venice.controller.supersetschema;
+
+import com.linkedin.venice.schema.SchemaEntry;
+import com.linkedin.venice.utils.AvroSchemaUtils;
+import com.linkedin.venice.utils.AvroSupersetSchemaUtils;
+import java.util.Collection;
+import org.apache.avro.Schema;
+
+
+public class DefaultSupersetSchemaGenerator implements SupersetSchemaGenerator {
+  @Override
+  public SchemaEntry generateSupersetSchemaFromSchemas(Collection<SchemaEntry> schemas) {
+    return AvroSchemaUtils.generateSupersetSchemaFromAllValueSchemas(schemas);
+  }
+
+  @Override
+  public boolean compareSchema(Schema s1, Schema s2) {
+    return AvroSchemaUtils.compareSchemaIgnoreFieldOrder(s1, s2);
+  }
+
+  @Override
+  public Schema generateSupersetSchema(Schema existingSchema, Schema newSchema) {
+    return AvroSupersetSchemaUtils.generateSuperSetSchema(existingSchema, newSchema);
+  }
+}

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/supersetschema/SupersetSchemaGenerator.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/supersetschema/SupersetSchemaGenerator.java
@@ -1,0 +1,28 @@
+package com.linkedin.venice.controller.supersetschema;
+
+import com.linkedin.venice.schema.SchemaEntry;
+import java.util.Collection;
+import org.apache.avro.Schema;
+
+
+public interface SupersetSchemaGenerator {
+  /**
+   * Function to generate a superset based on all the input schemas.
+   * @param schemas
+   * @return {@link SchemaEntry} to contain the generated superset schema and the corresponding schema id.
+   */
+  SchemaEntry generateSupersetSchemaFromSchemas(Collection<SchemaEntry> schemas);
+
+  /**
+   * Compare whether two schemas are equal or not with the consideration of superset schema.
+   */
+  boolean compareSchema(Schema s1, Schema s2);
+
+  /**
+   * Generate the superset schema based on two schemas.
+   * @param existingSchema : existing value schema or superset schema
+   * @param newSchema : the new value schema.
+   * @return
+   */
+  Schema generateSupersetSchema(Schema existingSchema, Schema newSchema);
+}

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/supersetschema/SupersetSchemaGeneratorWithCustomProp.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/supersetschema/SupersetSchemaGeneratorWithCustomProp.java
@@ -1,0 +1,84 @@
+package com.linkedin.venice.controller.supersetschema;
+
+import com.linkedin.venice.schema.AvroSchemaParseUtils;
+import com.linkedin.venice.schema.SchemaEntry;
+import com.linkedin.venice.utils.AvroSchemaUtils;
+import com.linkedin.venice.utils.AvroSupersetSchemaUtils;
+import java.util.Collection;
+import org.apache.avro.Schema;
+
+
+/**
+ * This class would copy the specified {@link #customProp} from the latest value schema to the generated
+ * superset schema and in the meantime, the compare method in this impl will consider this extra property as well.
+ */
+public class SupersetSchemaGeneratorWithCustomProp implements SupersetSchemaGenerator {
+  private final String customProp;
+
+  public SupersetSchemaGeneratorWithCustomProp(String customProp) {
+    this.customProp = customProp;
+  }
+
+  @Override
+  public SchemaEntry generateSupersetSchemaFromSchemas(Collection<SchemaEntry> schemas) {
+    if (schemas.isEmpty()) {
+      throw new IllegalArgumentException("Empty schema collection is unexpected");
+    }
+    SchemaEntry supersetSchemaEntry = AvroSchemaUtils.generateSupersetSchemaFromAllValueSchemas(schemas);
+
+    // Find the latest value schema
+    SchemaEntry latestValueSchemaEntry = null;
+    for (SchemaEntry se: schemas) {
+      if (latestValueSchemaEntry == null) {
+        latestValueSchemaEntry = se;
+      } else {
+        if (se.getId() > latestValueSchemaEntry.getId()) {
+          latestValueSchemaEntry = se;
+        }
+      }
+    }
+    /**
+     * Check whether the latest value schema contains {@link #customProp} or not.
+     */
+    String customPropInLatestValueSchema = latestValueSchemaEntry.getSchema().getProp(customProp);
+    if (customPropInLatestValueSchema != null) {
+      Schema newSupersetSchema = supersetSchemaEntry.clone().getSchema();
+      // Not empty, then copy it to the superset schema
+      newSupersetSchema.addProp(customProp, customPropInLatestValueSchema);
+      // Check whether this new schema exists or not
+      for (SchemaEntry se: schemas) {
+        if (compareSchema(se.getSchema(), newSupersetSchema)) {
+          return se;
+        }
+      }
+      return new SchemaEntry(latestValueSchemaEntry.getId() + 1, newSupersetSchema);
+    } else {
+      return supersetSchemaEntry;
+    }
+  }
+
+  @Override
+  public boolean compareSchema(Schema s1, Schema s2) {
+    if (!AvroSchemaUtils.compareSchemaIgnoreFieldOrder(s1, s2)) {
+      return false;
+    }
+    // Check custom prop
+    String customPropFromS1 = s1.getProp(customProp);
+    String customPropFromS2 = s2.getProp(customProp);
+
+    return (customPropFromS1 == null && customPropFromS2 == null)
+        || (customPropFromS1 != null && customPropFromS1.equals(customPropFromS2));
+  }
+
+  @Override
+  public Schema generateSupersetSchema(Schema existingSchema, Schema newSchema) {
+    Schema supersetSchema = AvroSupersetSchemaUtils.generateSuperSetSchema(existingSchema, newSchema);
+    String customPropInNewSchema = newSchema.getProp(customProp);
+    if (customPropInNewSchema != null) {
+      Schema newSupersetSchema = AvroSchemaParseUtils.parseSchemaFromJSONLooseValidation(supersetSchema.toString());
+      newSupersetSchema.addProp(customProp, customPropInNewSchema);
+      return newSupersetSchema;
+    }
+    return supersetSchema;
+  }
+}

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/supersetschema/TestSupersetSchemaGeneratorWithCustomProp.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/supersetschema/TestSupersetSchemaGeneratorWithCustomProp.java
@@ -1,0 +1,109 @@
+package com.linkedin.venice.controller.supersetschema;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
+import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
+import com.linkedin.venice.schema.SchemaEntry;
+import com.linkedin.venice.utils.TestWriteUtils;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+import org.apache.avro.Schema;
+import org.testng.annotations.Test;
+
+
+public class TestSupersetSchemaGeneratorWithCustomProp {
+  private static final String CUSTOM_PROP = "custom_prop";
+
+  private Schema schemaV1 =
+      AvroCompatibilityHelper.parse(TestWriteUtils.loadFileAsString("superset_schema_test/v1.avsc"));
+  private Schema schemaV1WithoutCustomProp = AvroCompatibilityHelper
+      .parse(TestWriteUtils.loadFileAsString("superset_schema_test/v1_without_custom_prop.avsc"));
+  private Schema schemaV2 =
+      AvroCompatibilityHelper.parse(TestWriteUtils.loadFileAsString("superset_schema_test/v2.avsc"));
+  private Schema schemaV3 =
+      AvroCompatibilityHelper.parse(TestWriteUtils.loadFileAsString("superset_schema_test/v3.avsc"));
+  private Schema schemaV4 = AvroCompatibilityHelper
+      .parse(TestWriteUtils.loadFileAsString("superset_schema_test/v4_without_custom_prop.avsc"));
+
+  private SupersetSchemaGenerator generator;
+
+  public TestSupersetSchemaGeneratorWithCustomProp() throws IOException {
+    this.generator = new SupersetSchemaGeneratorWithCustomProp(CUSTOM_PROP);
+  }
+
+  @Test
+  public void testGenerateSupersetSchemaFromSchemas() throws IOException {
+
+    // Two partially-overlapped schemas
+    Collection<SchemaEntry> schemaEntryCollection1 =
+        Arrays.asList(new SchemaEntry(1, schemaV1), new SchemaEntry(2, schemaV2));
+    SchemaEntry supersetSchemaEntry1 = generator.generateSupersetSchemaFromSchemas(schemaEntryCollection1);
+    assertEquals(supersetSchemaEntry1.getId(), 3);
+    Schema supersetSchema1 = supersetSchemaEntry1.getSchema();
+    assertEquals(supersetSchema1.getProp(CUSTOM_PROP), "custom_prop_value_for_v2");
+    assertNotNull(supersetSchema1.getField("f0"));
+    assertNotNull(supersetSchema1.getField("f1"));
+    assertNotNull(supersetSchema1.getField("f2"));
+
+    // v3 is a superset of v1 and v2
+    Collection<SchemaEntry> schemaEntryCollection2 =
+        Arrays.asList(new SchemaEntry(1, schemaV1), new SchemaEntry(2, schemaV2), new SchemaEntry(3, schemaV3));
+    SchemaEntry supersetSchemaEntry2 = generator.generateSupersetSchemaFromSchemas(schemaEntryCollection2);
+    assertEquals(supersetSchemaEntry2.getId(), 3);
+    assertEquals(supersetSchemaEntry2.getSchema(), schemaV3);
+    Schema supersetSchema2 = supersetSchemaEntry2.getSchema();
+    assertEquals(supersetSchema2.getProp(CUSTOM_PROP), "custom_prop_value_for_v3");
+
+    // v4 doesn't contain custom_prop
+    Collection<SchemaEntry> schemaEntryCollection3 = Arrays.asList(
+        new SchemaEntry(1, schemaV1),
+        new SchemaEntry(2, schemaV2),
+        new SchemaEntry(3, schemaV3),
+        new SchemaEntry(4, schemaV4));
+    SchemaEntry supersetSchemaEntry3 = generator.generateSupersetSchemaFromSchemas(schemaEntryCollection3);
+    assertEquals(supersetSchemaEntry3.getId(), 5);
+    Schema supersetSchema3 = supersetSchemaEntry3.getSchema();
+    assertNull(supersetSchema3.getProp(CUSTOM_PROP));
+    assertNotNull(supersetSchema3.getField("f0"));
+    assertNotNull(supersetSchema3.getField("f1"));
+    assertNotNull(supersetSchema3.getField("f2"));
+    assertNotNull(supersetSchema3.getField("f3"));
+  }
+
+  @Test
+  public void testCompareSchema() {
+    assertTrue(generator.compareSchema(schemaV1, schemaV1));
+
+    // Test schemas with diff prop
+    assertFalse(generator.compareSchema(schemaV1, schemaV1WithoutCustomProp));
+    assertFalse(generator.compareSchema(schemaV1WithoutCustomProp, schemaV1));
+
+    // Test schemas with different fields
+    assertFalse(generator.compareSchema(schemaV1, schemaV2));
+
+    // Two schemas without custom prop
+    assertTrue(generator.compareSchema(schemaV1WithoutCustomProp, schemaV1WithoutCustomProp));
+  }
+
+  @Test
+  public void testGenerateSupersetSchema() {
+    // Two schemas with custom prop
+    Schema supersetSchema1 = generator.generateSupersetSchema(schemaV1, schemaV2);
+    assertEquals(supersetSchema1.getProp(CUSTOM_PROP), "custom_prop_value_for_v2");
+    assertNotNull(supersetSchema1.getField("f0"));
+    assertNotNull(supersetSchema1.getField("f1"));
+    assertNotNull(supersetSchema1.getField("f2"));
+
+    // New schema without custom prop
+    Schema supersetSchema2 = generator.generateSupersetSchema(schemaV2, schemaV1WithoutCustomProp);
+    assertNull(supersetSchema2.getProp(CUSTOM_PROP));
+    assertNotNull(supersetSchema2.getField("f0"));
+    assertNotNull(supersetSchema2.getField("f1"));
+    assertNotNull(supersetSchema2.getField("f2"));
+  }
+}

--- a/services/venice-controller/src/test/resources/superset_schema_test/v1.avsc
+++ b/services/venice-controller/src/test/resources/superset_schema_test/v1.avsc
@@ -1,0 +1,10 @@
+{
+  "type" : "record",
+  "namespace" : "example.avro",
+  "name" : "ValueRecordName",
+  "fields" : [
+    { "name" : "f0", "type" : "int", "default" : -1 },
+    { "name" : "f1", "type" : "int", "default" : -1 }
+  ],
+  "custom_prop" : "custom_prop_value_for_v1"
+}

--- a/services/venice-controller/src/test/resources/superset_schema_test/v1_without_custom_prop.avsc
+++ b/services/venice-controller/src/test/resources/superset_schema_test/v1_without_custom_prop.avsc
@@ -1,0 +1,9 @@
+{
+  "type" : "record",
+  "namespace" : "example.avro",
+  "name" : "ValueRecordName",
+  "fields" : [
+    { "name" : "f0", "type" : "int", "default" : -1 },
+    { "name" : "f1", "type" : "int", "default" : -1 }
+  ]
+}

--- a/services/venice-controller/src/test/resources/superset_schema_test/v2.avsc
+++ b/services/venice-controller/src/test/resources/superset_schema_test/v2.avsc
@@ -1,0 +1,10 @@
+{
+  "type" : "record",
+  "namespace" : "example.avro",
+  "name" : "ValueRecordName",
+  "fields" : [
+    { "name" : "f1", "type" : "int", "default" : -1 },
+    { "name" : "f2", "type" : "int", "default" : -1 }
+  ],
+  "custom_prop" : "custom_prop_value_for_v2"
+}

--- a/services/venice-controller/src/test/resources/superset_schema_test/v3.avsc
+++ b/services/venice-controller/src/test/resources/superset_schema_test/v3.avsc
@@ -1,0 +1,11 @@
+{
+  "type" : "record",
+  "namespace" : "example.avro",
+  "name" : "ValueRecordName",
+  "fields" : [
+    { "name" : "f0", "type" : "int", "default" : -1 },
+    { "name" : "f1", "type" : "int", "default" : -1 },
+    { "name" : "f2", "type" : "int", "default" : -1 }
+  ],
+  "custom_prop" : "custom_prop_value_for_v3"
+}

--- a/services/venice-controller/src/test/resources/superset_schema_test/v4_without_custom_prop.avsc
+++ b/services/venice-controller/src/test/resources/superset_schema_test/v4_without_custom_prop.avsc
@@ -1,0 +1,8 @@
+{
+  "type" : "record",
+  "namespace" : "example.avro",
+  "name" : "ValueRecordName",
+  "fields" : [
+    { "name" : "f3", "type" : "int", "default" : -1 }
+  ]
+}


### PR DESCRIPTION
Currently, superset schema generation is ignoring all the properties from value schemas, which are critical for some use cases.
This code change exposes a hook to allow customized superset schema generation, so that different service deployment can apply customized logic during the generation.

This code change also provides a custom implementation, which takes a custom property name, and it will carry the custom property value to the superset schema during generation.

<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci], [server], [controller],
[router], [samza], [vpj], [fast-client], [thin-client], [alpini],
[admin-tool], [test], [build], [doc], [script]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->


<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->



## How was this PR tested?
Unit test and integration test
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.