### PR TITLE
[dvc][server] Metrics clean up

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/AggVersionedDIVStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/AggVersionedDIVStats.java
@@ -109,10 +109,6 @@ public class AggVersionedDIVStats extends AbstractVeniceAggVersionedStats<DIVSta
     });
   }
 
-  public void recordDataValidationLatencyMs(String storeName, int version, double value) {
-    recordVersionedAndTotalStat(storeName, version, stat -> stat.recordDataValidationLatencyMs(value));
-  }
-
   public void recordLeaderProducerCompletionTime(String storeName, int version, double value) {
     recordVersionedAndTotalStat(storeName, version, stat -> stat.recordLeaderProducerCompletionLatencyMs(value));
   }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/DIVStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/DIVStats.java
@@ -24,7 +24,6 @@ public class DIVStats {
   private final WritePathLatencySensor producerLocalBrokerLatencySensor;
   private final WritePathLatencySensor localBrokerFollowerConsumerLatencySensor;
   private final WritePathLatencySensor producerFollowerConsumerLatencySensor;
-  private final WritePathLatencySensor dataValidationLatencySensor;
   private final WritePathLatencySensor leaderProducerCompletionLatencySensor;
 
   private long benignLeaderOffsetRewindCount = 0;
@@ -63,7 +62,6 @@ public class DIVStats {
         new WritePathLatencySensor(localRepository, metricConfig, "local_broker_to_follower_consumer_latency");
     producerFollowerConsumerLatencySensor =
         new WritePathLatencySensor(localRepository, metricConfig, "producer_to_follower_consumer_latency");
-    dataValidationLatencySensor = new WritePathLatencySensor(localRepository, metricConfig, "data_validation_latency");
     leaderProducerCompletionLatencySensor =
         new WritePathLatencySensor(localRepository, metricConfig, "leader_producer_completion_latency");
   }
@@ -210,14 +208,6 @@ public class DIVStats {
 
   public WritePathLatencySensor getLeaderProducerCompletionLatencySensor() {
     return leaderProducerCompletionLatencySensor;
-  }
-
-  public void recordDataValidationLatencyMs(double value) {
-    dataValidationLatencySensor.record(value);
-  }
-
-  public WritePathLatencySensor getDataValidationLatencySensor() {
-    return dataValidationLatencySensor;
   }
 
   public void recordBenignLeaderOffsetRewind() {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/DIVStatsReporter.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/DIVStatsReporter.java
@@ -51,7 +51,6 @@ public class DIVStatsReporter extends AbstractVeniceStatsReporter<DIVStats> {
       registerLatencySensor("producer_to_local_broker", DIVStats::getProducerLocalBrokerLatencySensor);
       registerLatencySensor("local_broker_to_follower_consumer", DIVStats::getLocalBrokerFollowerConsumerLatencySensor);
       registerLatencySensor("producer_to_follower_consumer", DIVStats::getProducerFollowerConsumerLatencySensor);
-      registerLatencySensor("data_validation", DIVStats::getDataValidationLatencySensor);
       registerLatencySensor("leader_producer_completion", DIVStats::getLeaderProducerCompletionLatencySensor);
     }
   }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/HostLevelIngestionStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/HostLevelIngestionStats.java
@@ -33,9 +33,10 @@ import java.util.function.Supplier;
  */
 public class HostLevelIngestionStats extends AbstractVeniceStats {
   // The aggregated bytes ingested rate for the entire host
-  private final Sensor totalBytesConsumedSensor;
+  private final LongAdderRateGauge totalBytesConsumedSensor = new LongAdderRateGauge();
   // The aggregated records ingested rate for the entire host
-  private final Sensor totalRecordsConsumedSensor;
+  private final LongAdderRateGauge totalRecordsConsumedSensor = new LongAdderRateGauge();
+
   /*
    * Bytes read from Kafka by store ingestion task as a total. This metric includes bytes read for all store versions
    * allocated in a storage node reported with its uncompressed data size.
@@ -46,9 +47,6 @@ public class HostLevelIngestionStats extends AbstractVeniceStats {
   // allowed.
   private final Sensor diskQuotaSensor;
 
-  /** Measure latency of Kafka consumer poll request and processing returned consumer records */
-  private final Sensor pollRequestSensor;
-  private final Sensor pollRequestLatencySensor;
   private final Sensor pollResultNumSensor;
   /** To measure 'put' latency of consumer records blocking queue */
   private final Sensor consumerRecordsQueuePutLatencySensor;
@@ -60,8 +58,8 @@ public class HostLevelIngestionStats extends AbstractVeniceStats {
   /**
    * Sensors for emitting if/when we detect DCR violations (such as a backwards timestamp or receding offset vector)
    */
-  private final Sensor totalTimestampRegressionDCRErrorRate;
-  private final Sensor totalOffsetRegressionDCRErrorRate;
+  private final LongAdderRateGauge totalTimestampRegressionDCRErrorRate = new LongAdderRateGauge();
+  private final LongAdderRateGauge totalOffsetRegressionDCRErrorRate = new LongAdderRateGauge();
   /**
    * A gauge reporting the total the percentage of hybrid quota used.
    */
@@ -80,45 +78,21 @@ public class HostLevelIngestionStats extends AbstractVeniceStats {
   private final Sensor processConsumerActionLatencySensor;
   // Measure the latency in checking long running task states, like leader promotion, TopicSwitch
   private final Sensor checkLongRunningTasksLatencySensor;
-  // Measure the latency in enforcing hybrid store disk quota
-  private final Sensor quotaEnforcementLatencySensor;
-  // Measure the latency from "after polling records from Kafka" to "successfully put records in to drainer queue"
-  private final Sensor consumerToQueueLatencySensor;
   // Measure the latency in putting data into storage engine
   private final Sensor storageEnginePutLatencySensor;
-  /**
-   * Measure the call count of {@literal StoreIngestionTask#produceToStoreBufferServiceOrKafka}.
-   */
-  private final Sensor produceToDrainerQueueCallCountSensor;
-  /**
-   * Measure the record number passed to {@literal StoreIngestionTask#produceToStoreBufferServiceOrKafka}.
-   */
-  private final Sensor produceToDrainerQueueRecordNumSensor;
 
-  /**
-   * Measure the number of record produced to kafka {@literal StoreIngestionTask#produceToStoreBufferServiceOrKafka}.
-   */
-  private final Sensor produceToKafkaRecordNumSensor;
-  /**
-   * This measures the latency of producing message to local kafka VT. This will be recorded only in Leader SN for a
-   * partition. It reports a sum of latency after processing a batch of messages, so this metric doesn't indicate the
-   * producer to broker latency for each message.
-   *
-   * @see StoreIngestionTask#produceToStoreBufferServiceOrKafka
-   */
-  private final Sensor produceToKafkaLatencySensor;
   /**
    * Measure the number of times a record was found in {@link PartitionConsumptionState#transientRecordMap} during UPDATE
    * message processing.
    */
   private final Sensor writeComputeCacheHitCount;
 
-  private final Sensor totalLeaderBytesConsumedSensor;
-  private final Sensor totalLeaderRecordsConsumedSensor;
-  private final Sensor totalFollowerBytesConsumedSensor;
-  private final Sensor totalFollowerRecordsConsumedSensor;
-  private final Sensor totalLeaderBytesProducedSensor;
-  private final Sensor totalLeaderRecordsProducedSensor;
+  private final LongAdderRateGauge totalLeaderBytesConsumedSensor = new LongAdderRateGauge();
+  private final LongAdderRateGauge totalLeaderRecordsConsumedSensor = new LongAdderRateGauge();
+  private final LongAdderRateGauge totalFollowerBytesConsumedSensor = new LongAdderRateGauge();
+  private final LongAdderRateGauge totalFollowerRecordsConsumedSensor = new LongAdderRateGauge();
+  private final LongAdderRateGauge totalLeaderBytesProducedSensor = new LongAdderRateGauge();
+  private final LongAdderRateGauge totalLeaderRecordsProducedSensor = new LongAdderRateGauge();
   private final List<Sensor> totalHybridBytesConsumedByRegionId;
   private final List<Sensor> totalHybridRecordsConsumedByRegionId;
 
@@ -147,12 +121,12 @@ public class HostLevelIngestionStats extends AbstractVeniceStats {
   /**
    * Measure the count of ignored updates due to conflict resolution
    */
-  private final Sensor totalUpdateIgnoredDCRSensor;
+  private final LongAdderRateGauge totalUpdateIgnoredDCRSensor = new LongAdderRateGauge();
 
   /**
    * Measure the count of tombstones created
    */
-  private final Sensor totalTombstoneCreationDCRSensor;
+  private final LongAdderRateGauge totalTombstoneCreationDCRSensor = new LongAdderRateGauge();
 
   private final Sensor totalLeaderDelegateRealTimeRecordLatencySensor;
 
@@ -173,6 +147,12 @@ public class HostLevelIngestionStats extends AbstractVeniceStats {
     return totalStats == null ? registerSensor(sensorName, stats) : totalSensor.get();
   }
 
+  private void registerOnlyTotal(String sensorName, HostLevelIngestionStats totalStats, MeasurableStat... stats) {
+    if (totalStats == null) {
+      registerSensor(sensorName, stats);
+    }
+  }
+
   /**
    * @param totalStats the total stats singleton instance, or null if we are constructing the total stats
    */
@@ -185,11 +165,9 @@ public class HostLevelIngestionStats extends AbstractVeniceStats {
     super(metricsRepository, storeName);
     // Stats which are total only:
 
-    this.totalBytesConsumedSensor =
-        registerOnlyTotal("bytes_consumed", totalStats, () -> totalStats.totalBytesConsumedSensor, new Rate());
+    registerOnlyTotal("bytes_consumed", totalStats, totalBytesConsumedSensor);
 
-    this.totalRecordsConsumedSensor =
-        registerOnlyTotal("records_consumed", totalStats, () -> totalStats.totalRecordsConsumedSensor, new Rate());
+    registerOnlyTotal("records_consumed", totalStats, totalRecordsConsumedSensor);
 
     this.totalBytesReadFromKafkaAsUncompressedSizeSensor = registerOnlyTotal(
         "bytes_read_from_kafka_as_uncompressed_size",
@@ -198,62 +176,25 @@ public class HostLevelIngestionStats extends AbstractVeniceStats {
         new Rate(),
         new Total());
 
-    this.totalLeaderBytesConsumedSensor = registerOnlyTotal(
-        "leader_bytes_consumed",
-        totalStats,
-        () -> totalStats.totalLeaderBytesConsumedSensor,
-        new Rate());
+    registerOnlyTotal("leader_bytes_consumed", totalStats, totalLeaderBytesConsumedSensor);
 
-    this.totalLeaderRecordsConsumedSensor = registerOnlyTotal(
-        "leader_records_consumed",
-        totalStats,
-        () -> totalStats.totalLeaderRecordsConsumedSensor,
-        new Rate());
+    registerOnlyTotal("leader_records_consumed", totalStats, totalLeaderRecordsConsumedSensor);
 
-    this.totalFollowerBytesConsumedSensor = registerOnlyTotal(
-        "follower_bytes_consumed",
-        totalStats,
-        () -> totalStats.totalFollowerBytesConsumedSensor,
-        new Rate());
+    registerOnlyTotal("follower_bytes_consumed", totalStats, totalFollowerBytesConsumedSensor);
 
-    this.totalFollowerRecordsConsumedSensor = registerOnlyTotal(
-        "follower_records_consumed",
-        totalStats,
-        () -> totalStats.totalFollowerRecordsConsumedSensor,
-        new Rate());
+    registerOnlyTotal("follower_records_consumed", totalStats, totalFollowerRecordsConsumedSensor);
 
-    this.totalLeaderBytesProducedSensor = registerOnlyTotal(
-        "leader_bytes_produced",
-        totalStats,
-        () -> totalStats.totalLeaderBytesProducedSensor,
-        new Rate());
+    registerOnlyTotal("leader_bytes_produced", totalStats, totalLeaderBytesProducedSensor);
 
-    this.totalLeaderRecordsProducedSensor = registerOnlyTotal(
-        "leader_records_produced",
-        totalStats,
-        () -> totalStats.totalLeaderRecordsProducedSensor,
-        new Rate());
+    registerOnlyTotal("leader_records_produced", totalStats, totalLeaderRecordsProducedSensor);
 
-    this.totalUpdateIgnoredDCRSensor =
-        registerOnlyTotal("update_ignored_dcr", totalStats, () -> totalStats.totalUpdateIgnoredDCRSensor, new Rate());
+    registerOnlyTotal("update_ignored_dcr", totalStats, totalUpdateIgnoredDCRSensor);
 
-    this.totalTombstoneCreationDCRSensor = registerOnlyTotal(
-        "tombstone_creation_dcr",
-        totalStats,
-        () -> totalStats.totalTombstoneCreationDCRSensor,
-        new Rate());
+    registerOnlyTotal("tombstone_creation_dcr", totalStats, totalTombstoneCreationDCRSensor);
 
-    this.totalTimestampRegressionDCRErrorRate = registerOnlyTotal(
-        "timestamp_regression_dcr_error",
-        totalStats,
-        () -> totalStats.totalTimestampRegressionDCRErrorRate,
-        new Rate());
+    registerOnlyTotal("timestamp_regression_dcr_error", totalStats, totalTimestampRegressionDCRErrorRate);
 
-    this.totalOffsetRegressionDCRErrorRate = registerOnlyTotal(
-        "offset_regression_dcr_error",
-        totalStats,
-        () -> totalStats.totalOffsetRegressionDCRErrorRate,
-        new Rate());
+    registerOnlyTotal("offset_regression_dcr_error", totalStats, totalOffsetRegressionDCRErrorRate);
 
     this.totalLeaderDelegateRealTimeRecordLatencySensor = registerOnlyTotal(
         "leader_delegate_real_time_record_latency",
@@ -330,15 +271,6 @@ public class HostLevelIngestionStats extends AbstractVeniceStats {
 
     // Stats which are both per-store and total:
 
-    this.pollRequestSensor =
-        registerPerStoreAndTotal("kafka_poll_request", totalStats, () -> totalStats.pollRequestSensor, new Count());
-
-    this.pollRequestLatencySensor = registerPerStoreAndTotal(
-        "kafka_poll_request_latency",
-        totalStats,
-        () -> totalStats.pollRequestLatencySensor,
-        avgAndMax());
-
     this.pollResultNumSensor = registerPerStoreAndTotal(
         "kafka_poll_result_num",
         totalStats,
@@ -397,18 +329,6 @@ public class HostLevelIngestionStats extends AbstractVeniceStats {
         () -> totalStats.checkLongRunningTasksLatencySensor,
         avgAndMax());
 
-    this.quotaEnforcementLatencySensor = registerPerStoreAndTotal(
-        "hybrid_quota_enforcement_latency",
-        totalStats,
-        () -> totalStats.quotaEnforcementLatencySensor,
-        avgAndMax());
-
-    this.consumerToQueueLatencySensor = registerPerStoreAndTotal(
-        "consumer_to_queue_latency",
-        totalStats,
-        () -> totalStats.quotaEnforcementLatencySensor,
-        avgAndMax());
-
     String storageEnginePutLatencySensorName = "storage_engine_put_latency";
     this.storageEnginePutLatencySensor = registerPerStoreAndTotal(
         storageEnginePutLatencySensorName,
@@ -417,30 +337,6 @@ public class HostLevelIngestionStats extends AbstractVeniceStats {
         new Avg(),
         new Max(),
         TehutiUtils.getPercentileStat(getName() + AbstractVeniceStats.DELIMITER + storageEnginePutLatencySensorName));
-
-    this.produceToDrainerQueueCallCountSensor = registerPerStoreAndTotal(
-        "produce_to_drainer_queue_call_count",
-        totalStats,
-        () -> totalStats.produceToDrainerQueueCallCountSensor,
-        new Rate());
-
-    this.produceToDrainerQueueRecordNumSensor = registerPerStoreAndTotal(
-        "produce_to_drainer_queue_record_num",
-        totalStats,
-        () -> totalStats.produceToDrainerQueueCallCountSensor,
-        avgAndMax());
-
-    this.produceToKafkaRecordNumSensor = registerPerStoreAndTotal(
-        "produce_to_kafka_record_num",
-        totalStats,
-        () -> totalStats.produceToKafkaRecordNumSensor,
-        avgAndMax());
-
-    this.produceToKafkaLatencySensor = registerPerStoreAndTotal(
-        "produce_to_kafka_latency",
-        totalStats,
-        () -> totalStats.produceToKafkaLatencySensor,
-        avgAndMax());
 
     this.writeComputeCacheHitCount = registerPerStoreAndTotal(
         "write_compute_cache_hit_count",
@@ -481,12 +377,12 @@ public class HostLevelIngestionStats extends AbstractVeniceStats {
 
   /** Record a host-level byte consumption rate across all store versions */
   public void recordTotalBytesConsumed(long bytes) {
-    totalBytesConsumedSensor.record(bytes);
+    totalBytesConsumedSensor.add(bytes);
   }
 
   /** Record a host-level record consumption rate across all store versions */
   public void recordTotalRecordsConsumed() {
-    totalRecordsConsumedSensor.record();
+    totalRecordsConsumedSensor.increment();
   }
 
   public void recordTotalBytesReadFromKafkaAsUncompressedSize(long bytes) {
@@ -501,11 +397,6 @@ public class HostLevelIngestionStats extends AbstractVeniceStats {
   public void recordDiskQuotaAllowed(long quotaAllowed) {
     diskQuotaAllowedGauge = quotaAllowed;
     diskQuotaSensor.record(quotaAllowed);
-  }
-
-  public void recordPollRequestLatency(double latency) {
-    pollRequestSensor.record();
-    pollRequestLatencySensor.record(latency);
   }
 
   public void recordPollResultNum(int count) {
@@ -568,29 +459,8 @@ public class HostLevelIngestionStats extends AbstractVeniceStats {
     checkLongRunningTasksLatencySensor.record(latency);
   }
 
-  public void recordQuotaEnforcementLatency(double latency) {
-    quotaEnforcementLatencySensor.record(latency);
-  }
-
-  public void recordConsumerToQueueLatency(double latency) {
-    consumerToQueueLatencySensor.record(latency);
-  }
-
   public void recordStorageEnginePutLatency(double latency) {
     storageEnginePutLatencySensor.record(latency);
-  }
-
-  public void recordProduceToDrainQueueRecordNum(int recordNum) {
-    produceToDrainerQueueCallCountSensor.record();
-    produceToDrainerQueueRecordNumSensor.record(recordNum);
-  }
-
-  public void recordProduceToKafkaRecordNum(int recordNum) {
-    produceToKafkaRecordNumSensor.record(recordNum);
-  }
-
-  public void recordProduceToKafkaLatency(double latency) {
-    produceToKafkaLatencySensor.record(latency);
   }
 
   public void recordWriteComputeCacheHitCount() {
@@ -602,27 +472,27 @@ public class HostLevelIngestionStats extends AbstractVeniceStats {
   }
 
   public void recordUpdateIgnoredDCR() {
-    totalUpdateIgnoredDCRSensor.record();
+    totalUpdateIgnoredDCRSensor.increment();
   }
 
   public void recordTombstoneCreatedDCR() {
-    totalTombstoneCreationDCRSensor.record();
+    totalTombstoneCreationDCRSensor.increment();
   }
 
   public void recordTotalLeaderBytesConsumed(long bytes) {
-    totalLeaderBytesConsumedSensor.record(bytes);
+    totalLeaderBytesConsumedSensor.add(bytes);
   }
 
   public void recordTotalLeaderRecordsConsumed() {
-    totalLeaderRecordsConsumedSensor.record();
+    totalLeaderRecordsConsumedSensor.increment();
   }
 
   public void recordTotalFollowerBytesConsumed(long bytes) {
-    totalFollowerBytesConsumedSensor.record(bytes);
+    totalFollowerBytesConsumedSensor.add(bytes);
   }
 
   public void recordTotalFollowerRecordsConsumed() {
-    totalFollowerRecordsConsumedSensor.record();
+    totalFollowerRecordsConsumedSensor.increment();
   }
 
   public void recordTotalRegionHybridBytesConsumed(int regionId, long bytes) {
@@ -638,11 +508,11 @@ public class HostLevelIngestionStats extends AbstractVeniceStats {
   }
 
   public void recordTotalLeaderBytesProduced(long bytes) {
-    totalLeaderBytesProducedSensor.record(bytes);
+    totalLeaderBytesProducedSensor.add(bytes);
   }
 
   public void recordTotalLeaderRecordsProduced(int count) {
-    totalLeaderRecordsProducedSensor.record(count);
+    totalLeaderRecordsProducedSensor.add(count);
   }
 
   public void recordChecksumVerificationFailure() {
@@ -650,11 +520,11 @@ public class HostLevelIngestionStats extends AbstractVeniceStats {
   }
 
   public void recordTimestampRegressionDCRError() {
-    totalTimestampRegressionDCRErrorRate.record();
+    totalTimestampRegressionDCRErrorRate.increment();
   }
 
   public void recordOffsetRegressionDCRError() {
-    totalOffsetRegressionDCRErrorRate.record();
+    totalOffsetRegressionDCRErrorRate.increment();
   }
 
   public void recordLeaderDelegateRealTimeRecordLatency(double latency) {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/HostLevelIngestionStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/HostLevelIngestionStats.java
@@ -377,12 +377,12 @@ public class HostLevelIngestionStats extends AbstractVeniceStats {
 
   /** Record a host-level byte consumption rate across all store versions */
   public void recordTotalBytesConsumed(long bytes) {
-    totalBytesConsumedSensor.add(bytes);
+    totalBytesConsumedSensor.record(bytes);
   }
 
   /** Record a host-level record consumption rate across all store versions */
   public void recordTotalRecordsConsumed() {
-    totalRecordsConsumedSensor.increment();
+    totalRecordsConsumedSensor.record();
   }
 
   public void recordTotalBytesReadFromKafkaAsUncompressedSize(long bytes) {
@@ -472,27 +472,27 @@ public class HostLevelIngestionStats extends AbstractVeniceStats {
   }
 
   public void recordUpdateIgnoredDCR() {
-    totalUpdateIgnoredDCRSensor.increment();
+    totalUpdateIgnoredDCRSensor.record();
   }
 
   public void recordTombstoneCreatedDCR() {
-    totalTombstoneCreationDCRSensor.increment();
+    totalTombstoneCreationDCRSensor.record();
   }
 
   public void recordTotalLeaderBytesConsumed(long bytes) {
-    totalLeaderBytesConsumedSensor.add(bytes);
+    totalLeaderBytesConsumedSensor.record(bytes);
   }
 
   public void recordTotalLeaderRecordsConsumed() {
-    totalLeaderRecordsConsumedSensor.increment();
+    totalLeaderRecordsConsumedSensor.record();
   }
 
   public void recordTotalFollowerBytesConsumed(long bytes) {
-    totalFollowerBytesConsumedSensor.add(bytes);
+    totalFollowerBytesConsumedSensor.record(bytes);
   }
 
   public void recordTotalFollowerRecordsConsumed() {
-    totalFollowerRecordsConsumedSensor.increment();
+    totalFollowerRecordsConsumedSensor.record();
   }
 
   public void recordTotalRegionHybridBytesConsumed(int regionId, long bytes) {
@@ -508,11 +508,11 @@ public class HostLevelIngestionStats extends AbstractVeniceStats {
   }
 
   public void recordTotalLeaderBytesProduced(long bytes) {
-    totalLeaderBytesProducedSensor.add(bytes);
+    totalLeaderBytesProducedSensor.record(bytes);
   }
 
   public void recordTotalLeaderRecordsProduced(int count) {
-    totalLeaderRecordsProducedSensor.add(count);
+    totalLeaderRecordsProducedSensor.record(count);
   }
 
   public void recordChecksumVerificationFailure() {
@@ -520,11 +520,11 @@ public class HostLevelIngestionStats extends AbstractVeniceStats {
   }
 
   public void recordTimestampRegressionDCRError() {
-    totalTimestampRegressionDCRErrorRate.increment();
+    totalTimestampRegressionDCRErrorRate.record();
   }
 
   public void recordOffsetRegressionDCRError() {
-    totalOffsetRegressionDCRErrorRate.increment();
+    totalOffsetRegressionDCRErrorRate.record();
   }
 
   public void recordLeaderDelegateRealTimeRecordLatency(double latency) {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/LongAdderRateGauge.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/LongAdderRateGauge.java
@@ -1,0 +1,27 @@
+package com.linkedin.davinci.stats;
+
+import com.linkedin.venice.utils.Time;
+import io.tehuti.metrics.MetricConfig;
+import io.tehuti.metrics.stats.Gauge;
+import java.util.concurrent.atomic.LongAdder;
+
+
+public class LongAdderRateGauge extends Gauge {
+  private final LongAdder adder = new LongAdder();
+  private long lastMeasurementTime = System.currentTimeMillis();
+
+  public void increment() {
+    this.adder.increment();
+  }
+
+  public void add(long amount) {
+    this.adder.add(amount);
+  }
+
+  @Override
+  public double measure(MetricConfig config, long now) {
+    long elapsedTimeInSeconds = (now - this.lastMeasurementTime) / Time.MS_PER_SECOND;
+    this.lastMeasurementTime = now;
+    return this.adder.sumThenReset() / elapsedTimeInSeconds;
+  }
+}

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/LongAdderRateGauge.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/LongAdderRateGauge.java
@@ -20,8 +20,8 @@ public class LongAdderRateGauge extends Gauge {
 
   @Override
   public double measure(MetricConfig config, long now) {
-    long elapsedTimeInSeconds = (now - this.lastMeasurementTime) / Time.MS_PER_SECOND;
+    double elapsedTimeInSeconds = (double) (now - this.lastMeasurementTime) / Time.MS_PER_SECOND;
     this.lastMeasurementTime = now;
-    return this.adder.sumThenReset() / elapsedTimeInSeconds;
+    return (double) this.adder.sumThenReset() / elapsedTimeInSeconds;
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/LongAdderRateGauge.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/LongAdderRateGauge.java
@@ -10,11 +10,11 @@ public class LongAdderRateGauge extends Gauge {
   private final LongAdder adder = new LongAdder();
   private long lastMeasurementTime = System.currentTimeMillis();
 
-  public void increment() {
+  public void record() {
     this.adder.increment();
   }
 
-  public void add(long amount) {
+  public void record(long amount) {
     this.adder.add(amount);
   }
 

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/utils/lazy/Lazy.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/utils/lazy/Lazy.java
@@ -32,6 +32,9 @@ import java.util.function.Supplier;
  * routine will happen at most once.
  */
 public interface Lazy<T> {
+  Lazy<Boolean> FALSE = Lazy.of(() -> false);
+  Lazy<Boolean> TRUE = Lazy.of(() -> true);
+
   /**
    * @param supplier to initialize the wrapped value
    * @return an instance of {@link Lazy} which will execute the {@param supplier} if needed

--- a/internal/venice-consumer/src/main/java/com/linkedin/venice/kafka/validation/KafkaDataIntegrityValidator.java
+++ b/internal/venice-consumer/src/main/java/com/linkedin/venice/kafka/validation/KafkaDataIntegrityValidator.java
@@ -7,6 +7,7 @@ import com.linkedin.venice.message.KafkaKey;
 import com.linkedin.venice.offsets.OffsetRecord;
 import com.linkedin.venice.pubsub.api.PubSubMessage;
 import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
+import com.linkedin.venice.utils.lazy.Lazy;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
@@ -52,7 +53,7 @@ public class KafkaDataIntegrityValidator {
   public void validateMessage(
       PubSubMessage<KafkaKey, KafkaMessageEnvelope, Long> consumerRecord,
       boolean endOfPushReceived,
-      boolean tolerateMissingMsgs) throws DataValidationException {
+      Lazy<Boolean> tolerateMissingMsgs) throws DataValidationException {
     final GUID producerGUID = consumerRecord.getValue().producerMetadata.producerGUID;
     ProducerTracker producerTracker = registerProducer(producerGUID);
     producerTracker.validateMessage(consumerRecord, endOfPushReceived, tolerateMissingMsgs);


### PR DESCRIPTION
Eliminated a bunch of metrics of dubious value.

Also replaced the total-only metrics in HostLevelIngestionStats with LongAdders, wrapped inside a new class called LongAdderRateGauge. If this works well, we can consider adopting it elsewhere as well, but we need to keep in mind that the memory footprint of LongAdder grows proportionally to contention and can be quite high in the worst case, so it may never be appropriate to use this for more numerous metrics, like per-store ones.

Also refactored some of the DIV code to eliminate a hot spot... according to profiling, the remaining portion of the DIV code is ~20% of the CPU of what the whole thing used to take.

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.