### PR TITLE
[admin-tool] Add a data recovery monitoring command in admin-tool

### DIFF
--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/Arg.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/Arg.java
@@ -226,7 +226,10 @@ public enum Arg {
   EXTRA_COMMAND_ARGS("extra-command-args", "eca", true, "extra command arguments"),
   ENABLE_DISABLED_REPLICA("enable-disabled-replicas", "edr", true, "Reenable disabled replicas"),
   NON_INTERACTIVE("non-interactive", "nita", false, "non-interactive mode"),
-  DEBUG("debug", "d", false, "Print debugging messages for execute-data-recovery");
+  INTERVAL(
+      "interval", "itv", true,
+      "monitor data recovery progress at seconds close to the number specified by the interval parameter until tasks are finished"
+  ), DEBUG("debug", "d", false, "Print debugging messages for execute-data-recovery");
 
   private final String argName;
   private final String first;

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/Command.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/Command.java
@@ -43,6 +43,7 @@ import static com.linkedin.venice.Arg.HYBRID_STORE_OVERHEAD_BYPASS;
 import static com.linkedin.venice.Arg.HYBRID_TIME_LAG;
 import static com.linkedin.venice.Arg.INCLUDE_SYSTEM_STORES;
 import static com.linkedin.venice.Arg.INCREMENTAL_PUSH_ENABLED;
+import static com.linkedin.venice.Arg.INTERVAL;
 import static com.linkedin.venice.Arg.KAFKA_BOOTSTRAP_SERVERS;
 import static com.linkedin.venice.Arg.KAFKA_CONSUMER_CONFIG_FILE;
 import static com.linkedin.venice.Arg.KAFKA_OPERATION_TIMEOUT;
@@ -437,6 +438,10 @@ public enum Command {
   EXECUTE_DATA_RECOVERY(
       "execute-data-recovery", "Execute data recovery for a group of stores",
       new Arg[] { RECOVERY_COMMAND, STORES, SOURCE_FABRIC }, new Arg[] { EXTRA_COMMAND_ARGS, DEBUG, NON_INTERACTIVE }
+  ),
+  MONITOR_DATA_RECOVERY(
+      "monitor-data-recovery", "Monitor data recovery progress for a group of stores",
+      new Arg[] { URL, STORES, DEST_FABRIC }, new Arg[] { INTERVAL }
   );
 
   private final String commandName;

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/datarecovery/Command.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/datarecovery/Command.java
@@ -1,0 +1,76 @@
+package com.linkedin.venice.datarecovery;
+
+public abstract class Command {
+  public abstract void execute();
+
+  public abstract Result getResult();
+
+  public abstract boolean needWaitForFirstTaskToComplete();
+
+  public abstract static class Params {
+    // Store name.
+    protected String store;
+
+    public String getStore() {
+      return store;
+    }
+
+    public void setStore(String store) {
+      this.store = store;
+    }
+  }
+
+  public abstract static class Result {
+    private String cluster;
+    private String store;
+    protected String error;
+    protected String message;
+
+    // isCoreWorkDone indicates if the core task is finished when an interval is specified.
+    protected boolean isCoreWorkDone = false;
+
+    public String getCluster() {
+      return cluster;
+    }
+
+    public void setCluster(String cluster) {
+      this.cluster = cluster;
+    }
+
+    public String getStore() {
+      return store;
+    }
+
+    public void setStore(String store) {
+      this.store = store;
+    }
+
+    public boolean isError() {
+      return error != null;
+    }
+
+    public void setError(String error) {
+      this.error = error;
+    }
+
+    public String getError() {
+      return error;
+    }
+
+    public String getMessage() {
+      return message;
+    }
+
+    public void setMessage(String message) {
+      this.message = message;
+    }
+
+    public boolean isCoreWorkDone() {
+      return isCoreWorkDone;
+    }
+
+    public void setCoreWorkDone(boolean done) {
+      isCoreWorkDone = done;
+    }
+  }
+}

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/datarecovery/DataRecoveryClient.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/datarecovery/DataRecoveryClient.java
@@ -1,5 +1,7 @@
 package com.linkedin.venice.datarecovery;
 
+import static com.linkedin.venice.datarecovery.DataRecoveryWorker.INTERVAL_UNSET;
+
 import com.linkedin.venice.utils.Utils;
 import java.util.Scanner;
 import java.util.Set;
@@ -15,17 +17,23 @@ import org.apache.logging.log4j.Logger;
 public class DataRecoveryClient {
   private static final Logger LOGGER = LogManager.getLogger(DataRecoveryClient.class);
   private final DataRecoveryExecutor executor;
+  private final DataRecoveryMonitor monitor;
 
   public DataRecoveryClient() {
-    this(new DataRecoveryExecutor());
+    this(new DataRecoveryExecutor(), new DataRecoveryMonitor());
   }
 
-  public DataRecoveryClient(DataRecoveryExecutor module) {
-    this.executor = module;
+  public DataRecoveryClient(DataRecoveryExecutor executor, DataRecoveryMonitor monitor) {
+    this.executor = executor;
+    this.monitor = monitor;
   }
 
   public DataRecoveryExecutor getExecutor() {
     return executor;
+  }
+
+  public DataRecoveryMonitor getMonitor() {
+    return monitor;
   }
 
   public void execute(DataRecoveryParams drParams, StoreRepushCommand.Params cmdParams) {
@@ -42,6 +50,18 @@ public class DataRecoveryClient {
     getExecutor().shutdownAndAwaitTermination();
   }
 
+  public void monitor(DataRecoveryParams drParams, MonitorCommand.Params monitorParams) {
+    Set<String> storeNames = drParams.getRecoveryStores();
+    if (storeNames == null || storeNames.isEmpty()) {
+      LOGGER.warn("store list is empty, exit.");
+      return;
+    }
+
+    getMonitor().setInterval(drParams.interval);
+    getMonitor().perform(storeNames, monitorParams);
+    getMonitor().shutdownAndAwaitTermination();
+  }
+
   public boolean confirmStores(Set<String> storeNames) {
     LOGGER.info("stores to recover: " + storeNames);
     LOGGER.info("Recover " + storeNames.size() + " stores, please confirm (yes/no) [y/n]:");
@@ -53,12 +73,12 @@ public class DataRecoveryClient {
   public static class DataRecoveryParams {
     private final String multiStores;
     private final Set<String> recoveryStores;
-    private final boolean isNonInteractive;
+    private boolean isNonInteractive = false;
+    private int interval = INTERVAL_UNSET;
 
-    public DataRecoveryParams(String multiStores, boolean isNonInteractive) {
+    public DataRecoveryParams(String multiStores) {
       this.multiStores = multiStores;
       this.recoveryStores = calculateRecoveryStoreNames(this.multiStores);
-      this.isNonInteractive = isNonInteractive;
     }
 
     public Set<String> getRecoveryStores() {
@@ -71,6 +91,14 @@ public class DataRecoveryClient {
         storeNames = Utils.parseCommaSeparatedStringToSet(multiStores);
       }
       return storeNames;
+    }
+
+    public void setInterval(int interval) {
+      this.interval = interval;
+    }
+
+    public void setNonInteractive(boolean isNonInteractive) {
+      this.isNonInteractive = isNonInteractive;
     }
   }
 }

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/datarecovery/DataRecoveryMonitor.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/datarecovery/DataRecoveryMonitor.java
@@ -7,14 +7,15 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 
-/**
- * DataRecoveryExecutor is the engine to run tasks in data recovery.
- */
-public class DataRecoveryExecutor extends DataRecoveryWorker {
-  private final Logger LOGGER = LogManager.getLogger(DataRecoveryExecutor.class);
+public class DataRecoveryMonitor extends DataRecoveryWorker {
+  private final Logger LOGGER = LogManager.getLogger(DataRecoveryMonitor.class);
 
-  public DataRecoveryExecutor() {
+  public DataRecoveryMonitor() {
     super();
+  }
+
+  public void setInterval(int interval) {
+    this.interval = interval;
   }
 
   @Override
@@ -22,10 +23,8 @@ public class DataRecoveryExecutor extends DataRecoveryWorker {
     List<DataRecoveryTask> tasks = new ArrayList<>();
     for (String name: storeNames) {
       DataRecoveryTask.TaskParams taskParams = new DataRecoveryTask.TaskParams(name, params);
-      tasks.add(
-          new DataRecoveryTask(
-              new StoreRepushCommand((StoreRepushCommand.Params) taskParams.getCmdParams()),
-              taskParams));
+      tasks
+          .add(new DataRecoveryTask(new MonitorCommand((MonitorCommand.Params) taskParams.getCmdParams()), taskParams));
     }
     return tasks;
   }
@@ -33,9 +32,9 @@ public class DataRecoveryExecutor extends DataRecoveryWorker {
   @Override
   public void displayTaskResult(DataRecoveryTask task) {
     LOGGER.info(
-        "[store: {}, status: {}, message: {}]",
+        "[store: {}, {}: {}]",
         task.getTaskParams().getStore(),
-        task.getTaskResult().isError() ? "failed" : "started",
+        task.getTaskResult().isError() ? "err" : "msg",
         task.getTaskResult().isError() ? task.getTaskResult().getError() : task.getTaskResult().getMessage());
   }
 }

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/datarecovery/DataRecoveryTask.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/datarecovery/DataRecoveryTask.java
@@ -5,10 +5,10 @@ package com.linkedin.venice.datarecovery;
  */
 public class DataRecoveryTask implements Runnable {
   private final TaskParams taskParams;
-  private final StoreRepushCommand command;
+  private final Command command;
   private TaskResult taskResult;
 
-  public DataRecoveryTask(StoreRepushCommand command, TaskParams params) {
+  public DataRecoveryTask(Command command, DataRecoveryTask.TaskParams params) {
     this.taskParams = params;
     this.command = command;
   }
@@ -16,7 +16,7 @@ public class DataRecoveryTask implements Runnable {
   @Override
   public void run() {
     command.execute();
-    taskResult = new TaskResult(command.getResult());
+    taskResult = new DataRecoveryTask.TaskResult(command.getResult());
   }
 
   /**
@@ -24,7 +24,7 @@ public class DataRecoveryTask implements Runnable {
    * Thus, this is a task specific flag to set based on the purpose of the task.
    */
   public boolean needWaitForFirstTaskToComplete() {
-    return true;
+    return command.needWaitForFirstTaskToComplete();
   }
 
   public TaskResult getTaskResult() {
@@ -36,9 +36,9 @@ public class DataRecoveryTask implements Runnable {
   }
 
   public static class TaskResult {
-    private final StoreRepushCommand.Result cmdResult;
+    private final Command.Result cmdResult;
 
-    public TaskResult(StoreRepushCommand.Result cmdResult) {
+    public TaskResult(Command.Result cmdResult) {
       this.cmdResult = cmdResult;
     }
 
@@ -53,24 +53,29 @@ public class DataRecoveryTask implements Runnable {
     public String getMessage() {
       return cmdResult.getMessage();
     }
+
+    public boolean isCoreWorkDone() {
+      return cmdResult.isCoreWorkDone();
+    }
   }
 
   public static class TaskParams {
     // Store name.
     private final String store;
-    private final StoreRepushCommand.Params cmdParams;
+    private final Command.Params cmdParams;
 
-    public TaskParams(String storeName, StoreRepushCommand.Params cmdParams) {
+    public TaskParams(String storeName, Command.Params cmdParams) {
       this.store = storeName;
       this.cmdParams = cmdParams;
+      this.cmdParams.setStore(this.store);
     }
 
     public String getStore() {
       return store;
     }
 
-    public StoreRepushCommand.Params getCmdParams() {
-      return this.cmdParams;
+    public Command.Params getCmdParams() {
+      return cmdParams;
     }
   }
 }

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/datarecovery/DataRecoveryWorker.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/datarecovery/DataRecoveryWorker.java
@@ -1,0 +1,150 @@
+package com.linkedin.venice.datarecovery;
+
+import static java.lang.Thread.*;
+
+import com.linkedin.venice.utils.Timer;
+import com.linkedin.venice.utils.Utils;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+
+public abstract class DataRecoveryWorker {
+  private final Logger LOGGER = LogManager.getLogger(DataRecoveryWorker.class);
+  private final static int DEFAULT_POOL_SIZE = 10;
+  private final static int DEFAULT_POOL_TIMEOUT_IN_SECONDS = 30;
+  public static final int INTERVAL_UNSET = -1;
+  protected final int poolSize;
+  protected int interval = INTERVAL_UNSET;
+  protected final ExecutorService pool;
+  protected List<DataRecoveryTask> tasks;
+
+  public DataRecoveryWorker() {
+    this(DEFAULT_POOL_SIZE);
+  }
+
+  public DataRecoveryWorker(int poolSize) {
+    this.poolSize = poolSize;
+    this.pool = Executors.newFixedThreadPool(this.poolSize);
+  }
+
+  abstract List<DataRecoveryTask> buildTasks(Set<String> storeNames, Command.Params params);
+
+  abstract void displayTaskResult(DataRecoveryTask task);
+
+  public List<DataRecoveryTask> getTasks() {
+    return tasks;
+  }
+
+  /**
+   * For some task, it is benefit to wait for the first task to complete before starting to run the remaining ones.
+   * e.g. the first run of task can set up local session files that can be used by follow-up tasks.
+   */
+  public boolean needWaitForFirstTaskToComplete(DataRecoveryTask task) {
+    return task.needWaitForFirstTaskToComplete();
+  }
+
+  public void perform(Set<String> storeNames, Command.Params params) {
+    tasks = buildTasks(storeNames, params);
+    if (tasks.isEmpty()) {
+      return;
+    }
+
+    List<DataRecoveryTask> concurrentTasks = tasks;
+    DataRecoveryTask firstTask = tasks.get(0);
+    if (needWaitForFirstTaskToComplete(firstTask)) {
+      // Let the main thread run the first task to completion if there is a need.
+      firstTask.run();
+      if (firstTask.getTaskResult().isError()) {
+        displayTaskResult(firstTask);
+        return;
+      }
+      // Exclude the 1st item from the list as it has finished.
+      concurrentTasks = tasks.subList(1, tasks.size());
+    }
+
+    /*
+     * Keep polling the states (for monitor) of all tasks at given intervals when interval is set to certain value
+     * plus not all tasks are finished. Otherwise, if interval is unset, just do a one time execution for all tasks.
+     */
+    boolean requireSleep = false;
+    do {
+      final boolean finalRequireSleep = requireSleep;
+      try (Timer ignored = Timer.run(elapsedTimeInMs -> {
+        if (finalRequireSleep) {
+          Utils.sleep(computeTimeToSleepInMillis(elapsedTimeInMs));
+        }
+      })) {
+        List<CompletableFuture<Void>> taskFutures = concurrentTasks.stream()
+            .map(dataRecoveryTask -> CompletableFuture.runAsync(dataRecoveryTask, pool))
+            .collect(Collectors.toList());
+        taskFutures.stream().map(CompletableFuture::join).collect(Collectors.toList());
+        displayAllTasksResult();
+      }
+    } while (requireSleep = continuePollingState());
+  }
+
+  private void displayAllTasksResult() {
+    int numDoneTasks = 0;
+    int numSuccessfullyDoneTasks = 0;
+
+    for (DataRecoveryTask dataRecoveryTask: tasks) {
+      displayTaskResult(dataRecoveryTask);
+      if (dataRecoveryTask.getTaskResult().isCoreWorkDone()) {
+        numDoneTasks++;
+        if (!dataRecoveryTask.getTaskResult().isError()) {
+          numSuccessfullyDoneTasks++;
+        }
+      }
+    }
+    LOGGER.info(
+        "Total: {}, Succeeded: {}, Error: {}, Uncompleted: {}",
+        tasks.size(),
+        numSuccessfullyDoneTasks,
+        numDoneTasks - numSuccessfullyDoneTasks,
+        tasks.size() - numDoneTasks);
+  }
+
+  private boolean continuePollingState() {
+    return isIntervalSet() && !areAllCoreWorkDone();
+  }
+
+  private boolean isIntervalSet() {
+    return interval != INTERVAL_UNSET;
+  }
+
+  private boolean areAllCoreWorkDone() {
+    for (DataRecoveryTask task: tasks) {
+      if (!task.getTaskResult().isCoreWorkDone()) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /**
+   * Calculate the sleep time based on the interval setting and the latency that has already occurred.
+   */
+  private long computeTimeToSleepInMillis(double latency) {
+    long sleepTime = TimeUnit.SECONDS.toMillis(interval) - (long) latency;
+    return sleepTime > 0 ? sleepTime : 0;
+  }
+
+  public void shutdownAndAwaitTermination() {
+    pool.shutdown();
+    try {
+      if (!pool.awaitTermination(DEFAULT_POOL_TIMEOUT_IN_SECONDS, TimeUnit.SECONDS)) {
+        // Cancel currently executing tasks.
+        pool.shutdownNow();
+      }
+    } catch (InterruptedException e) {
+      currentThread().interrupt();
+    }
+  }
+}

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/datarecovery/MonitorCommand.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/datarecovery/MonitorCommand.java
@@ -1,0 +1,177 @@
+package com.linkedin.venice.datarecovery;
+
+import com.linkedin.venice.controllerapi.ControllerClient;
+import com.linkedin.venice.controllerapi.JobStatusQueryResponse;
+import com.linkedin.venice.controllerapi.MultiStoreStatusResponse;
+import com.linkedin.venice.controllerapi.StoreResponse;
+import com.linkedin.venice.meta.Store;
+import com.linkedin.venice.meta.StoreInfo;
+import com.linkedin.venice.meta.Version;
+import com.linkedin.venice.pushmonitor.ExecutionStatus;
+import com.linkedin.venice.security.SSLFactory;
+import java.util.Optional;
+
+
+public class MonitorCommand extends Command {
+  private MonitorCommand.Params params;
+  private final MonitorCommand.Result result = new MonitorCommand.Result();
+
+  // For unit test only.
+  public MonitorCommand() {
+  }
+
+  public MonitorCommand(MonitorCommand.Params params) {
+    this.params = params;
+  }
+
+  // For unit test only.
+  public void setParams(MonitorCommand.Params params) {
+    this.params = params;
+  }
+
+  @Override
+  public MonitorCommand.Result getResult() {
+    return result;
+  }
+
+  @Override
+  public boolean needWaitForFirstTaskToComplete() {
+    return false;
+  }
+
+  @Override
+  public void execute() {
+    String storeName = params.store;
+
+    // Find out cluster name.
+    String clusterName = params.pCtrlCliWithoutCluster.discoverCluster(storeName).getCluster();
+
+    // Create a new controller client with cluster name specified.
+    try (ControllerClient parentCtrlCli = buildControllerClient(clusterName, params.parentUrl, params.sslFactory)) {
+      StoreResponse storeResponse = parentCtrlCli.getStore(storeName);
+      if (storeResponse.isError()) {
+        completeCoreWorkWithError(storeResponse.getError());
+        return;
+      }
+
+      result.setStoreInfo(storeResponse.getStore());
+      /*
+       * Find out store future version. A store has a meaningful future version only when there is an ongoing
+       * offline push for the store.
+       */
+      MultiStoreStatusResponse response = parentCtrlCli.getFutureVersions(clusterName, storeName);
+
+      if (!response.getStoreStatusMap().containsKey(params.targetRegion)) {
+        completeCoreWorkWithError(String.format("No status for region: %s", params.targetRegion));
+        return;
+      }
+
+      int futureVersion = Integer.parseInt(response.getStoreStatusMap().get(params.targetRegion));
+      if (futureVersion == Store.NON_EXISTING_VERSION) {
+        completeCoreWorkWithMessage("No ongoing offline pushes");
+        return;
+      }
+
+      String kafkaTopic = Version.composeKafkaTopic(storeName, futureVersion);
+      result.setFutureVersion(futureVersion);
+      result.setKafKaTopic(kafkaTopic);
+
+      // Query job status.
+      JobStatusQueryResponse jobStatusQueryResponse = parentCtrlCli.queryJobStatus(kafkaTopic);
+
+      if (jobStatusQueryResponse.isError()
+          || jobStatusQueryResponse.getStatus().equalsIgnoreCase(ExecutionStatus.ERROR.toString())) {
+        completeCoreWorkWithError(jobStatusQueryResponse.getStatusDetails());
+        return;
+      }
+
+      if (jobStatusQueryResponse.getStatus().equalsIgnoreCase(ExecutionStatus.COMPLETED.toString())) {
+        completeCoreWorkWithMessage(
+            String.format(
+                "ver: %d, status: %s",
+                jobStatusQueryResponse.getVersion(),
+                jobStatusQueryResponse.getStatus()));
+        return;
+      }
+      // For other cases, report current status.
+      result.setMessage(createReportMessage(jobStatusQueryResponse));
+    }
+  }
+
+  // A placeholder function for future improvement.
+  private String createReportMessage(JobStatusQueryResponse resp) {
+    return String.format(
+        "ver: %d, status: %s, uncompleted ptn: %d/%d",
+        resp.getVersion(),
+        resp.getStatus(),
+        resp.getUncompletedPartitions().size(),
+        result.storeInfo.getPartitionCount());
+  }
+
+  private void completeCoreWorkWithError(String error) {
+    result.setError(error);
+    result.setCoreWorkDone(true);
+  }
+
+  private void completeCoreWorkWithMessage(String message) {
+    result.setMessage(message);
+    result.setCoreWorkDone(true);
+  }
+
+  public ControllerClient buildControllerClient(
+      String clusterName,
+      String discoveryUrls,
+      Optional<SSLFactory> sslFactory) {
+    return new ControllerClient(clusterName, discoveryUrls, sslFactory);
+  }
+
+  public static class Params extends Command.Params {
+    // Target region.
+    private String targetRegion;
+    private ControllerClient pCtrlCliWithoutCluster;
+    private String parentUrl;
+    private Optional<SSLFactory> sslFactory;
+
+    public void setTargetRegion(String fabric) {
+      this.targetRegion = fabric;
+    }
+
+    public void setParentUrl(String parentUrl) {
+      this.parentUrl = parentUrl;
+    }
+
+    public void setPCtrlCliWithoutCluster(ControllerClient parentCtrlCli) {
+      this.pCtrlCliWithoutCluster = parentCtrlCli;
+    }
+
+    public void setSslFactory(Optional<SSLFactory> sslFactory) {
+      this.sslFactory = sslFactory;
+    }
+  }
+
+  public static class Result extends Command.Result {
+    private int futureVersion = Store.NON_EXISTING_VERSION;
+    private String kafKaTopic;
+    private StoreInfo storeInfo;
+
+    public void setFutureVersion(int futureVersion) {
+      this.futureVersion = futureVersion;
+    }
+
+    public void setKafKaTopic(String kafKaTopic) {
+      this.kafKaTopic = kafKaTopic;
+    }
+
+    public int getFutureVersion() {
+      return futureVersion;
+    }
+
+    public String getKafKaTopic() {
+      return kafKaTopic;
+    }
+
+    public void setStoreInfo(StoreInfo storeInfo) {
+      this.storeInfo = storeInfo;
+    }
+  }
+}


### PR DESCRIPTION
This change adds a command in admin-tool to monitoring the progresses of one/multiple triggered data recovery job(s). If the recovery job is still ongoing, it reports the progress in terms of uncompleted partitions. This is done by leveraging the newly improved job status API which returns the status of uncompleted partitions and replicas. Since we have the raw data of the uncompleted ones, we could further improve the reporting part to make it more readable to users.

This change also refactors the existing class hierarchy to make it easy to add new commands in the future. DataRecoveryWorker and Command are introduced as new base classes to abstract out the common logic, so that subclasses can be simplified and focus more on their special logic.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
Internal CI passed.
Unit tests passed.
Manually tested in EI environment.
## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.