### PR TITLE
[server] Fix bugs in nullable collection field in A/A Partial Update

### DIFF
--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/replication/merge/TestMergeBase.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/replication/merge/TestMergeBase.java
@@ -27,6 +27,8 @@ public class TestMergeBase {
   protected static final String REGULAR_FIELD_NAME = "regularField";
   protected static final String STRING_ARRAY_FIELD_NAME = "stringArrayField";
   protected static final String INT_MAP_FIELD_NAME = "intMapField";
+  protected static final String NULLABLE_STRING_ARRAY_FIELD_NAME = "nullableStringArrayField";
+  protected static final String NULLABLE_INT_MAP_FIELD_NAME = "nullableIntMapField";
 
   protected static final String storeName = "testStore";
   protected ValueAndDerivedSchemas schemaSet;
@@ -98,6 +100,8 @@ public class TestMergeBase {
       r.put(REGULAR_FIELD_NAME, "defaultVenice");
       r.put(STRING_ARRAY_FIELD_NAME, Collections.emptyList());
       r.put(INT_MAP_FIELD_NAME, new IndexedHashMap<>());
+      r.put(NULLABLE_STRING_ARRAY_FIELD_NAME, null);
+      r.put(NULLABLE_INT_MAP_FIELD_NAME, null);
     });
   }
 

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/replication/merge/TestMergePut.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/replication/merge/TestMergePut.java
@@ -31,7 +31,9 @@ public class TestMergePut extends TestMergeBase {
     GenericRecord oldValueRecord = createValueRecord(r -> {
       r.put(REGULAR_FIELD_NAME, "defaultVenice");
       r.put(STRING_ARRAY_FIELD_NAME, Collections.emptyList());
+      r.put(NULLABLE_STRING_ARRAY_FIELD_NAME, Collections.emptyList());
       r.put(INT_MAP_FIELD_NAME, Collections.emptyMap());
+      r.put(NULLABLE_INT_MAP_FIELD_NAME, Collections.emptyMap());
     });
     GenericRecord oldRmdRecord = initiateFieldLevelRmdRecord(oldValueRecord, 0);
 
@@ -39,6 +41,8 @@ public class TestMergePut extends TestMergeBase {
       r.put(REGULAR_FIELD_NAME, "newString");
       r.put(STRING_ARRAY_FIELD_NAME, Collections.singletonList("item1"));
       r.put(INT_MAP_FIELD_NAME, Collections.singletonMap("key1", 1));
+      r.put(NULLABLE_STRING_ARRAY_FIELD_NAME, null);
+      r.put(NULLABLE_INT_MAP_FIELD_NAME, null);
     });
 
     MergeConflictResult result = mergeConflictResolver.put(
@@ -56,6 +60,8 @@ public class TestMergePut extends TestMergeBase {
     Assert.assertEquals(updatedValueRecord.get(REGULAR_FIELD_NAME).toString(), "newString");
     Assert.assertEquals(updatedValueRecord.get(INT_MAP_FIELD_NAME), Collections.singletonMap(new Utf8("key1"), 1));
     Assert.assertEquals(updatedValueRecord.get(STRING_ARRAY_FIELD_NAME), Collections.singletonList(new Utf8("item1")));
+    Assert.assertNull(updatedValueRecord.get(NULLABLE_STRING_ARRAY_FIELD_NAME));
+    Assert.assertNull(updatedValueRecord.get(NULLABLE_INT_MAP_FIELD_NAME));
     GenericRecord rmdTimestampRecord = (GenericRecord) result.getRmdRecord().get(RmdConstants.TIMESTAMP_FIELD_NAME);
     Assert.assertEquals(rmdTimestampRecord.get(REGULAR_FIELD_NAME), 1L);
     Assert.assertEquals(((GenericRecord) rmdTimestampRecord.get(INT_MAP_FIELD_NAME)).get(TOP_LEVEL_TS_FIELD_NAME), 1L);

--- a/clients/da-vinci-client/src/test/resources/avro/PartialUpdateWithMapField.avsc
+++ b/clients/da-vinci-client/src/test/resources/avro/PartialUpdateWithMapField.avsc
@@ -1,7 +1,7 @@
 {
   "type": "record",
-  "name": "PartialUpdateWithMapField",
   "namespace": "com.linkedin.avro",
+  "name": "TestRecord",
   "fields": [
     {
       "name": "regularField",
@@ -17,12 +17,34 @@
       "default": []
     },
     {
+      "name": "nullableStringArrayField",
+      "type": [
+        "null",
+        {
+          "type": "array",
+          "items": "string"
+        }
+      ],
+      "default": null
+    },
+    {
       "name": "intMapField",
       "type": {
         "type": "map",
         "values": "int"
       },
       "default": {}
+    },
+    {
+      "name": "nullableIntMapField",
+      "type": [
+        "null",
+        {
+          "type": "map",
+          "values": "int"
+        }
+      ],
+      "default": null
     }
   ]
 }

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/schema/SchemaUtils.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/schema/SchemaUtils.java
@@ -252,4 +252,30 @@ public class SchemaUtils {
       annotateStringArraySchema(schema);
     }
   }
+
+  public static boolean isMapField(GenericRecord currRecord, String fieldName) {
+    Schema fieldSchema = currRecord.getSchema().getField(fieldName).schema();
+    return isSimpleMapSchema(fieldSchema) || isNullableMapSchema(fieldSchema);
+  }
+
+  public static boolean isArrayField(GenericRecord currRecord, String fieldName) {
+    Schema fieldSchema = currRecord.getSchema().getField(fieldName).schema();
+    return isSimpleArraySchema(fieldSchema) || isNullableArraySchema(fieldSchema);
+  }
+
+  private static boolean isSimpleMapSchema(Schema schema) {
+    return schema.getType().equals(MAP);
+  }
+
+  private static boolean isSimpleArraySchema(Schema schema) {
+    return schema.getType().equals(ARRAY);
+  }
+
+  private static boolean isNullableMapSchema(Schema schema) {
+    return schema.isNullable() && isSimpleMapSchema(schema.getTypes().get(1));
+  }
+
+  private static boolean isNullableArraySchema(Schema schema) {
+    return schema.isNullable() && isSimpleArraySchema(schema.getTypes().get(1));
+  }
 }

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/schema/merge/SortBasedCollectionFieldOpHandler.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/schema/merge/SortBasedCollectionFieldOpHandler.java
@@ -137,7 +137,9 @@ public class SortBasedCollectionFieldOpHandler extends CollectionFieldOperationH
       newDeletedTimestamps.add(deletedTimestamp);
     });
     collectionFieldRmd.setDeletedElementsAndTimestamps(newDeletedElements, newDeletedTimestamps);
-
+    if (collectionFieldRmd.isInPutOnlyState() && newFieldValue == null) {
+      currValueRecord.put(fieldName, null);
+    }
     return collectionFieldRmd.isInPutOnlyState()
         ? UpdateResultStatus.COMPLETELY_UPDATED
         : UpdateResultStatus.PARTIALLY_UPDATED;
@@ -287,7 +289,9 @@ public class SortBasedCollectionFieldOpHandler extends CollectionFieldOperationH
     });
 
     collectionFieldRmd.setDeletedElementsAndTimestamps(newDeletedKeys, newDeletedTimestamps);
-
+    if (collectionFieldRmd.isInPutOnlyState() && newFieldValue == null) {
+      currValueRecord.put(fieldName, null);
+    }
     return collectionFieldRmd.isInPutOnlyState()
         ? UpdateResultStatus.COMPLETELY_UPDATED
         : UpdateResultStatus.PARTIALLY_UPDATED;

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/schema/writecompute/WriteComputeOperation.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/schema/writecompute/WriteComputeOperation.java
@@ -9,7 +9,6 @@ import static com.linkedin.venice.schema.writecompute.WriteComputeConstants.SET_
 import static com.linkedin.venice.schema.writecompute.WriteComputeConstants.WRITE_COMPUTE_RECORD_SCHEMA_SUFFIX;
 
 import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
-import io.tehuti.utils.Utils;
 import java.util.Collections;
 import java.util.Optional;
 import java.util.function.Function;
@@ -93,7 +92,6 @@ public enum WriteComputeOperation {
   }
 
   public static WriteComputeOperation getFieldOperationType(Object writeComputeFieldValue) {
-    Utils.notNull(writeComputeFieldValue);
 
     if (writeComputeFieldValue instanceof IndexedRecord) {
       IndexedRecord writeComputeFieldRecord = (IndexedRecord) writeComputeFieldValue;


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci], [server], [controller],
[router], [samza], [vpj], [fast-client], [thin-client], [alpini],
[admin-tool], [test], [build], [doc], [script]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## [server] Fix bugs in nullable collection field in A/A Partial Update
Previous fixes only validates nullable collection field in low level unit tests, while there happens to have a lot of incorrect safeguard in the WC handler level.
This PR fixes the nullable collection partial update bug found in experiments:
1. setField to null should work for nullable collection
2. add/delete items to a nullable collection field which has null value should work.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
Add a lot of new unit test logics in higher level to cover the changes and cases.
## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.