### PR TITLE
[server] Fix array comparator schema bug in nullable array field in A/A Partial Update

### DIFF
--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/replication/merge/TestMergeBase.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/replication/merge/TestMergeBase.java
@@ -26,9 +26,9 @@ public class TestMergeBase {
   protected static final int RMD_SCHEMA_PROTOCOL_VERSION = RmdSchemaGenerator.getLatestVersion();
   protected static final String REGULAR_FIELD_NAME = "regularField";
   protected static final String STRING_ARRAY_FIELD_NAME = "stringArrayField";
-  protected static final String INT_MAP_FIELD_NAME = "intMapField";
+  protected static final String STRING_MAP_FIELD_NAME = "stringMapField";
   protected static final String NULLABLE_STRING_ARRAY_FIELD_NAME = "nullableStringArrayField";
-  protected static final String NULLABLE_INT_MAP_FIELD_NAME = "nullableIntMapField";
+  protected static final String NULLABLE_STRING_MAP_FIELD_NAME = "nullableStringMapField";
 
   protected static final String storeName = "testStore";
   protected ValueAndDerivedSchemas schemaSet;
@@ -99,9 +99,9 @@ public class TestMergeBase {
     return createValueRecord(r -> {
       r.put(REGULAR_FIELD_NAME, "defaultVenice");
       r.put(STRING_ARRAY_FIELD_NAME, Collections.emptyList());
-      r.put(INT_MAP_FIELD_NAME, new IndexedHashMap<>());
+      r.put(STRING_MAP_FIELD_NAME, new IndexedHashMap<>());
       r.put(NULLABLE_STRING_ARRAY_FIELD_NAME, null);
-      r.put(NULLABLE_INT_MAP_FIELD_NAME, null);
+      r.put(NULLABLE_STRING_MAP_FIELD_NAME, null);
     });
   }
 

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/replication/merge/TestMergeDelete.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/replication/merge/TestMergeDelete.java
@@ -32,14 +32,14 @@ public class TestMergeDelete extends TestMergeBase {
     GenericRecord oldValueRecord = createValueRecord(r -> {
       r.put(REGULAR_FIELD_NAME, "defaultVenice");
       r.put(STRING_ARRAY_FIELD_NAME, Collections.emptyList());
-      IndexedHashMap<String, Integer> intMap = new IndexedHashMap<>();
-      intMap.put("key1", 1);
-      intMap.put("key2", 1);
-      r.put(INT_MAP_FIELD_NAME, intMap);
+      IndexedHashMap<String, String> mapValue = new IndexedHashMap<>();
+      mapValue.put("key1", "1");
+      mapValue.put("key2", "1");
+      r.put(STRING_MAP_FIELD_NAME, mapValue);
     });
     GenericRecord oldRmdRecord = initiateFieldLevelRmdRecord(oldValueRecord, 1);
     GenericRecord timestampRecord = (GenericRecord) oldRmdRecord.get(RmdConstants.TIMESTAMP_FIELD_NAME);
-    GenericRecord fieldTsRecord = (GenericRecord) timestampRecord.get(INT_MAP_FIELD_NAME);
+    GenericRecord fieldTsRecord = (GenericRecord) timestampRecord.get(STRING_MAP_FIELD_NAME);
     fieldTsRecord.put(TOP_LEVEL_TS_FIELD_NAME, 1L);
     fieldTsRecord.put(PUT_ONLY_PART_LENGTH_FIELD_NAME, 1);
     fieldTsRecord.put(ACTIVE_ELEM_TS_FIELD_NAME, Collections.singletonList(2L));
@@ -56,9 +56,10 @@ public class TestMergeDelete extends TestMergeBase {
     Assert.assertNull(result.getNewValue());
     GenericRecord rmdTimestampRecord = (GenericRecord) result.getRmdRecord().get(RmdConstants.TIMESTAMP_FIELD_NAME);
     Assert.assertEquals(rmdTimestampRecord.get(REGULAR_FIELD_NAME), 2L);
-    Assert.assertEquals(((GenericRecord) rmdTimestampRecord.get(INT_MAP_FIELD_NAME)).get(TOP_LEVEL_TS_FIELD_NAME), 2L);
+    Assert
+        .assertEquals(((GenericRecord) rmdTimestampRecord.get(STRING_MAP_FIELD_NAME)).get(TOP_LEVEL_TS_FIELD_NAME), 2L);
     Assert.assertEquals(
-        ((GenericRecord) rmdTimestampRecord.get(INT_MAP_FIELD_NAME)).get(TOP_LEVEL_COLO_ID_FIELD_NAME),
+        ((GenericRecord) rmdTimestampRecord.get(STRING_MAP_FIELD_NAME)).get(TOP_LEVEL_COLO_ID_FIELD_NAME),
         0);
     Assert.assertEquals(
         ((GenericRecord) rmdTimestampRecord.get(STRING_ARRAY_FIELD_NAME)).get(TOP_LEVEL_TS_FIELD_NAME),
@@ -76,18 +77,18 @@ public class TestMergeDelete extends TestMergeBase {
   @Test
   public void testPartiallyDelete() {
     // Case 1: Partially delete regular field.
-    IndexedHashMap<String, Integer> initialIntMap = new IndexedHashMap<>();
-    initialIntMap.put("key1", 1);
-    initialIntMap.put("key2", 1);
-    initialIntMap.put("key3", 1);
+    IndexedHashMap<String, String> initialIntMap = new IndexedHashMap<>();
+    initialIntMap.put("key1", "1");
+    initialIntMap.put("key2", "1");
+    initialIntMap.put("key3", "1");
     GenericRecord oldValueRecord = createValueRecord(r -> {
       r.put(REGULAR_FIELD_NAME, "DaVinci");
       r.put(STRING_ARRAY_FIELD_NAME, Collections.emptyList());
-      r.put(INT_MAP_FIELD_NAME, initialIntMap);
+      r.put(STRING_MAP_FIELD_NAME, initialIntMap);
     });
     GenericRecord oldRmdRecord = initiateFieldLevelRmdRecord(oldValueRecord, 1);
     GenericRecord timestampRecord = (GenericRecord) oldRmdRecord.get(RmdConstants.TIMESTAMP_FIELD_NAME);
-    GenericRecord fieldTsRecord = (GenericRecord) timestampRecord.get(INT_MAP_FIELD_NAME);
+    GenericRecord fieldTsRecord = (GenericRecord) timestampRecord.get(STRING_MAP_FIELD_NAME);
     fieldTsRecord.put(TOP_LEVEL_TS_FIELD_NAME, 3L);
     fieldTsRecord.put(PUT_ONLY_PART_LENGTH_FIELD_NAME, 1);
     fieldTsRecord.put(ACTIVE_ELEM_TS_FIELD_NAME, Arrays.asList(4L, 5L));
@@ -103,14 +104,14 @@ public class TestMergeDelete extends TestMergeBase {
     Assert.assertFalse(result.isUpdateIgnored());
     GenericRecord updatedValueRecord = deserializeValueRecord(result.getNewValue());
     Assert.assertEquals(updatedValueRecord.get(REGULAR_FIELD_NAME), new Utf8("defaultVenice"));
-    IndexedHashMap<Utf8, Integer> utf8Map = new IndexedHashMap<>();
-    utf8Map.put(new Utf8("key1"), 1);
-    utf8Map.put(new Utf8("key2"), 1);
-    utf8Map.put(new Utf8("key3"), 1);
-    Assert.assertEquals(updatedValueRecord.get(INT_MAP_FIELD_NAME), utf8Map);
+    IndexedHashMap<Utf8, Utf8> utf8Map = new IndexedHashMap<>();
+    utf8Map.put(new Utf8("key1"), new Utf8("1"));
+    utf8Map.put(new Utf8("key2"), new Utf8("1"));
+    utf8Map.put(new Utf8("key3"), new Utf8("1"));
+    Assert.assertEquals(updatedValueRecord.get(STRING_MAP_FIELD_NAME), utf8Map);
     GenericRecord updatedRmdTsRecord = (GenericRecord) result.getRmdRecord().get(RmdConstants.TIMESTAMP_FIELD_NAME);
     Assert.assertEquals(updatedRmdTsRecord.get(REGULAR_FIELD_NAME), 2L);
-    GenericRecord updatedFieldTsRecord = (GenericRecord) updatedRmdTsRecord.get(INT_MAP_FIELD_NAME);
+    GenericRecord updatedFieldTsRecord = (GenericRecord) updatedRmdTsRecord.get(STRING_MAP_FIELD_NAME);
     Assert.assertEquals(updatedFieldTsRecord.get(TOP_LEVEL_TS_FIELD_NAME), 3L);
     Assert.assertEquals(updatedFieldTsRecord.get(ACTIVE_ELEM_TS_FIELD_NAME), Arrays.asList(4L, 5L));
     Assert.assertEquals(updatedFieldTsRecord.get(PUT_ONLY_PART_LENGTH_FIELD_NAME), 1);
@@ -127,11 +128,11 @@ public class TestMergeDelete extends TestMergeBase {
     updatedValueRecord = deserializeValueRecord(result.getNewValue());
     Assert.assertEquals(updatedValueRecord.get(REGULAR_FIELD_NAME), new Utf8("defaultVenice"));
     utf8Map = new IndexedHashMap<>();
-    utf8Map.put(new Utf8("key3"), 1);
-    Assert.assertEquals(updatedValueRecord.get(INT_MAP_FIELD_NAME), utf8Map);
+    utf8Map.put(new Utf8("key3"), new Utf8("1"));
+    Assert.assertEquals(updatedValueRecord.get(STRING_MAP_FIELD_NAME), utf8Map);
     updatedRmdTsRecord = (GenericRecord) result.getRmdRecord().get(RmdConstants.TIMESTAMP_FIELD_NAME);
     Assert.assertEquals(updatedRmdTsRecord.get(REGULAR_FIELD_NAME), 4L);
-    updatedFieldTsRecord = (GenericRecord) updatedRmdTsRecord.get(INT_MAP_FIELD_NAME);
+    updatedFieldTsRecord = (GenericRecord) updatedRmdTsRecord.get(STRING_MAP_FIELD_NAME);
     Assert.assertEquals(updatedFieldTsRecord.get(TOP_LEVEL_TS_FIELD_NAME), 4L);
     Assert.assertEquals(updatedFieldTsRecord.get(ACTIVE_ELEM_TS_FIELD_NAME), Collections.singletonList(5L));
     Assert.assertEquals(updatedFieldTsRecord.get(PUT_ONLY_PART_LENGTH_FIELD_NAME), 0);
@@ -146,18 +147,18 @@ public class TestMergeDelete extends TestMergeBase {
   @Test
   public void testDeleteIgnored() {
     // Case 1: Delete ignored due to smaller TS in all fields
-    IndexedHashMap<String, Integer> initialIntMap = new IndexedHashMap<>();
-    initialIntMap.put("key1", 1);
-    initialIntMap.put("key2", 1);
-    initialIntMap.put("key3", 1);
+    IndexedHashMap<String, String> initialIntMap = new IndexedHashMap<>();
+    initialIntMap.put("key1", "1");
+    initialIntMap.put("key2", "1");
+    initialIntMap.put("key3", "1");
     GenericRecord oldValueRecord = createValueRecord(r -> {
       r.put(REGULAR_FIELD_NAME, "DaVinci");
       r.put(STRING_ARRAY_FIELD_NAME, Collections.emptyList());
-      r.put(INT_MAP_FIELD_NAME, initialIntMap);
+      r.put(STRING_MAP_FIELD_NAME, initialIntMap);
     });
     GenericRecord oldRmdRecord = initiateFieldLevelRmdRecord(oldValueRecord, 3);
     GenericRecord timestampRecord = (GenericRecord) oldRmdRecord.get(RmdConstants.TIMESTAMP_FIELD_NAME);
-    GenericRecord fieldTsRecord = (GenericRecord) timestampRecord.get(INT_MAP_FIELD_NAME);
+    GenericRecord fieldTsRecord = (GenericRecord) timestampRecord.get(STRING_MAP_FIELD_NAME);
     fieldTsRecord.put(TOP_LEVEL_TS_FIELD_NAME, 3L);
     fieldTsRecord.put(PUT_ONLY_PART_LENGTH_FIELD_NAME, 1);
     fieldTsRecord.put(ACTIVE_ELEM_TS_FIELD_NAME, Arrays.asList(4L, 5L));
@@ -174,7 +175,7 @@ public class TestMergeDelete extends TestMergeBase {
     // Case 2: Delete ignored as collection field has same TS but smaller colo ID.
     oldRmdRecord = initiateFieldLevelRmdRecord(oldValueRecord, 4);
     timestampRecord = (GenericRecord) oldRmdRecord.get(RmdConstants.TIMESTAMP_FIELD_NAME);
-    fieldTsRecord = (GenericRecord) timestampRecord.get(INT_MAP_FIELD_NAME);
+    fieldTsRecord = (GenericRecord) timestampRecord.get(STRING_MAP_FIELD_NAME);
     fieldTsRecord.put(TOP_LEVEL_TS_FIELD_NAME, 3L);
     fieldTsRecord.put(PUT_ONLY_PART_LENGTH_FIELD_NAME, 1);
     fieldTsRecord.put(ACTIVE_ELEM_TS_FIELD_NAME, Arrays.asList(4L, 5L));
@@ -190,7 +191,7 @@ public class TestMergeDelete extends TestMergeBase {
     // Case 3: Delete ignored as collection field has smaller top level TS but active elements has higher TS.
     oldRmdRecord = initiateFieldLevelRmdRecord(oldValueRecord, 4);
     timestampRecord = (GenericRecord) oldRmdRecord.get(RmdConstants.TIMESTAMP_FIELD_NAME);
-    fieldTsRecord = (GenericRecord) timestampRecord.get(INT_MAP_FIELD_NAME);
+    fieldTsRecord = (GenericRecord) timestampRecord.get(STRING_MAP_FIELD_NAME);
     fieldTsRecord.put(TOP_LEVEL_TS_FIELD_NAME, 2L);
     fieldTsRecord.put(PUT_ONLY_PART_LENGTH_FIELD_NAME, 0);
     fieldTsRecord.put(ACTIVE_ELEM_TS_FIELD_NAME, Arrays.asList(4L, 4L, 4L));

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/replication/merge/TestMergePut.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/replication/merge/TestMergePut.java
@@ -32,17 +32,17 @@ public class TestMergePut extends TestMergeBase {
       r.put(REGULAR_FIELD_NAME, "defaultVenice");
       r.put(STRING_ARRAY_FIELD_NAME, Collections.emptyList());
       r.put(NULLABLE_STRING_ARRAY_FIELD_NAME, Collections.emptyList());
-      r.put(INT_MAP_FIELD_NAME, Collections.emptyMap());
-      r.put(NULLABLE_INT_MAP_FIELD_NAME, Collections.emptyMap());
+      r.put(STRING_MAP_FIELD_NAME, Collections.emptyMap());
+      r.put(NULLABLE_STRING_MAP_FIELD_NAME, Collections.emptyMap());
     });
     GenericRecord oldRmdRecord = initiateFieldLevelRmdRecord(oldValueRecord, 0);
 
     GenericRecord newValueRecord = createValueRecord(r -> {
       r.put(REGULAR_FIELD_NAME, "newString");
       r.put(STRING_ARRAY_FIELD_NAME, Collections.singletonList("item1"));
-      r.put(INT_MAP_FIELD_NAME, Collections.singletonMap("key1", 1));
+      r.put(STRING_MAP_FIELD_NAME, Collections.singletonMap("key1", "1"));
       r.put(NULLABLE_STRING_ARRAY_FIELD_NAME, null);
-      r.put(NULLABLE_INT_MAP_FIELD_NAME, null);
+      r.put(NULLABLE_STRING_MAP_FIELD_NAME, null);
     });
 
     MergeConflictResult result = mergeConflictResolver.put(
@@ -58,15 +58,18 @@ public class TestMergePut extends TestMergeBase {
     Assert.assertFalse(result.isUpdateIgnored());
     GenericRecord updatedValueRecord = deserializeValueRecord(result.getNewValue());
     Assert.assertEquals(updatedValueRecord.get(REGULAR_FIELD_NAME).toString(), "newString");
-    Assert.assertEquals(updatedValueRecord.get(INT_MAP_FIELD_NAME), Collections.singletonMap(new Utf8("key1"), 1));
+    Assert.assertEquals(
+        updatedValueRecord.get(STRING_MAP_FIELD_NAME),
+        Collections.singletonMap(new Utf8("key1"), new Utf8("1")));
     Assert.assertEquals(updatedValueRecord.get(STRING_ARRAY_FIELD_NAME), Collections.singletonList(new Utf8("item1")));
     Assert.assertNull(updatedValueRecord.get(NULLABLE_STRING_ARRAY_FIELD_NAME));
-    Assert.assertNull(updatedValueRecord.get(NULLABLE_INT_MAP_FIELD_NAME));
+    Assert.assertNull(updatedValueRecord.get(NULLABLE_STRING_MAP_FIELD_NAME));
     GenericRecord rmdTimestampRecord = (GenericRecord) result.getRmdRecord().get(RmdConstants.TIMESTAMP_FIELD_NAME);
     Assert.assertEquals(rmdTimestampRecord.get(REGULAR_FIELD_NAME), 1L);
-    Assert.assertEquals(((GenericRecord) rmdTimestampRecord.get(INT_MAP_FIELD_NAME)).get(TOP_LEVEL_TS_FIELD_NAME), 1L);
+    Assert
+        .assertEquals(((GenericRecord) rmdTimestampRecord.get(STRING_MAP_FIELD_NAME)).get(TOP_LEVEL_TS_FIELD_NAME), 1L);
     Assert.assertEquals(
-        ((GenericRecord) rmdTimestampRecord.get(INT_MAP_FIELD_NAME)).get(TOP_LEVEL_COLO_ID_FIELD_NAME),
+        ((GenericRecord) rmdTimestampRecord.get(STRING_MAP_FIELD_NAME)).get(TOP_LEVEL_COLO_ID_FIELD_NAME),
         0);
     Assert.assertEquals(
         ((GenericRecord) rmdTimestampRecord.get(STRING_ARRAY_FIELD_NAME)).get(TOP_LEVEL_TS_FIELD_NAME),
@@ -87,16 +90,16 @@ public class TestMergePut extends TestMergeBase {
     GenericRecord oldValueRecord = createValueRecord(r -> {
       r.put(REGULAR_FIELD_NAME, "defaultVenice");
       r.put(STRING_ARRAY_FIELD_NAME, Collections.emptyList());
-      r.put(INT_MAP_FIELD_NAME, new IndexedHashMap<>());
+      r.put(STRING_MAP_FIELD_NAME, new IndexedHashMap<>());
     });
     GenericRecord oldRmdRecord = initiateFieldLevelRmdRecord(oldValueRecord, 2);
 
     GenericRecord newValueRecord = createValueRecord(r -> {
       r.put(REGULAR_FIELD_NAME, "defaultVenice");
       r.put(STRING_ARRAY_FIELD_NAME, Collections.singletonList("item1"));
-      IndexedHashMap<String, Integer> hashMap = new IndexedHashMap<>();
-      hashMap.put("key1", 1);
-      r.put(INT_MAP_FIELD_NAME, hashMap);
+      IndexedHashMap<String, String> hashMap = new IndexedHashMap<>();
+      hashMap.put("key1", "1");
+      r.put(STRING_MAP_FIELD_NAME, hashMap);
     });
 
     MergeConflictResult result = mergeConflictResolver.put(
@@ -134,9 +137,9 @@ public class TestMergePut extends TestMergeBase {
     GenericRecord oldValueRecord = createValueRecord(r -> {
       r.put(REGULAR_FIELD_NAME, "defaultVenice");
       r.put(STRING_ARRAY_FIELD_NAME, Collections.singletonList("item1"));
-      IndexedHashMap<String, Integer> hashMap = new IndexedHashMap<>();
-      hashMap.put("key1", 1);
-      r.put(INT_MAP_FIELD_NAME, hashMap);
+      IndexedHashMap<String, String> hashMap = new IndexedHashMap<>();
+      hashMap.put("key1", "1");
+      r.put(STRING_MAP_FIELD_NAME, hashMap);
     });
     GenericRecord oldRmdRecord = initiateFieldLevelRmdRecord(oldValueRecord, 2);
     setRegularFieldTimestamp(oldRmdRecord, 1);
@@ -144,9 +147,9 @@ public class TestMergePut extends TestMergeBase {
     GenericRecord newValueRecord = createValueRecord(r -> {
       r.put(REGULAR_FIELD_NAME, "newString");
       r.put(STRING_ARRAY_FIELD_NAME, Collections.singletonList("item2"));
-      IndexedHashMap<String, Integer> hashMap = new IndexedHashMap<>();
-      hashMap.put("key1", 2);
-      r.put(INT_MAP_FIELD_NAME, hashMap);
+      IndexedHashMap<String, String> hashMap = new IndexedHashMap<>();
+      hashMap.put("key1", "2");
+      r.put(STRING_MAP_FIELD_NAME, hashMap);
     });
 
     MergeConflictResult result = mergeConflictResolver.put(
@@ -162,7 +165,9 @@ public class TestMergePut extends TestMergeBase {
     Assert.assertFalse(result.isUpdateIgnored());
     GenericRecord updatedValueRecord = deserializeValueRecord(result.getNewValue());
     Assert.assertEquals(updatedValueRecord.get(REGULAR_FIELD_NAME).toString(), "newString");
-    Assert.assertEquals(updatedValueRecord.get(INT_MAP_FIELD_NAME), Collections.singletonMap(new Utf8("key1"), 1));
+    Assert.assertEquals(
+        updatedValueRecord.get(STRING_MAP_FIELD_NAME),
+        Collections.singletonMap(new Utf8("key1"), new Utf8("1")));
     Assert.assertEquals(updatedValueRecord.get(STRING_ARRAY_FIELD_NAME), Collections.singletonList(new Utf8("item1")));
 
     GenericRecord updatedRmdTsRecord = (GenericRecord) result.getRmdRecord().get(RmdConstants.TIMESTAMP_FIELD_NAME);
@@ -170,14 +175,15 @@ public class TestMergePut extends TestMergeBase {
     Assert.assertEquals(
         ((GenericRecord) updatedRmdTsRecord.get(STRING_ARRAY_FIELD_NAME)).get(TOP_LEVEL_TS_FIELD_NAME),
         2L);
-    Assert.assertEquals(((GenericRecord) updatedRmdTsRecord.get(INT_MAP_FIELD_NAME)).get(TOP_LEVEL_TS_FIELD_NAME), 2L);
+    Assert
+        .assertEquals(((GenericRecord) updatedRmdTsRecord.get(STRING_MAP_FIELD_NAME)).get(TOP_LEVEL_TS_FIELD_NAME), 2L);
 
     // Case 2: Regular field is updated, but collection field is not due to same top level TS but smaller top level colo
     // ID.
     newValueRecord = createValueRecord(r -> {
       r.put(REGULAR_FIELD_NAME, "newString2");
       r.put(STRING_ARRAY_FIELD_NAME, Collections.singletonList("item2"));
-      r.put(INT_MAP_FIELD_NAME, Collections.singletonMap("key1", 2));
+      r.put(STRING_MAP_FIELD_NAME, Collections.singletonMap("key1", "2"));
     });
 
     result = mergeConflictResolver.put(
@@ -192,7 +198,9 @@ public class TestMergePut extends TestMergeBase {
     Assert.assertFalse(result.isUpdateIgnored());
     updatedValueRecord = deserializeValueRecord(result.getNewValue());
     Assert.assertEquals(updatedValueRecord.get(REGULAR_FIELD_NAME).toString(), "newString2");
-    Assert.assertEquals(updatedValueRecord.get(INT_MAP_FIELD_NAME), Collections.singletonMap(new Utf8("key1"), 1));
+    Assert.assertEquals(
+        updatedValueRecord.get(STRING_MAP_FIELD_NAME),
+        Collections.singletonMap(new Utf8("key1"), new Utf8("1")));
     Assert.assertEquals(updatedValueRecord.get(STRING_ARRAY_FIELD_NAME), Collections.singletonList(new Utf8("item1")));
 
     updatedRmdTsRecord = (GenericRecord) result.getRmdRecord().get(RmdConstants.TIMESTAMP_FIELD_NAME);
@@ -200,7 +208,8 @@ public class TestMergePut extends TestMergeBase {
     Assert.assertEquals(
         ((GenericRecord) updatedRmdTsRecord.get(STRING_ARRAY_FIELD_NAME)).get(TOP_LEVEL_TS_FIELD_NAME),
         2L);
-    Assert.assertEquals(((GenericRecord) updatedRmdTsRecord.get(INT_MAP_FIELD_NAME)).get(TOP_LEVEL_TS_FIELD_NAME), 2L);
+    Assert
+        .assertEquals(((GenericRecord) updatedRmdTsRecord.get(STRING_MAP_FIELD_NAME)).get(TOP_LEVEL_TS_FIELD_NAME), 2L);
   }
 
   /**
@@ -212,14 +221,14 @@ public class TestMergePut extends TestMergeBase {
     GenericRecord oldValueRecord = createValueRecord(r -> {
       r.put(REGULAR_FIELD_NAME, "defaultVenice");
       r.put(STRING_ARRAY_FIELD_NAME, Collections.singletonList("item1"));
-      IndexedHashMap<String, Integer> map = new IndexedHashMap<>();
-      map.put("key1", 3);
-      map.put("key2", 3);
-      r.put(INT_MAP_FIELD_NAME, map);
+      IndexedHashMap<String, String> map = new IndexedHashMap<>();
+      map.put("key1", "3");
+      map.put("key2", "3");
+      r.put(STRING_MAP_FIELD_NAME, map);
     });
     GenericRecord oldRmdRecord = initiateFieldLevelRmdRecord(oldValueRecord, 2);
     GenericRecord timestampRecord = (GenericRecord) oldRmdRecord.get(RmdConstants.TIMESTAMP_FIELD_NAME);
-    GenericRecord fieldTsRecord = (GenericRecord) timestampRecord.get(INT_MAP_FIELD_NAME);
+    GenericRecord fieldTsRecord = (GenericRecord) timestampRecord.get(STRING_MAP_FIELD_NAME);
     fieldTsRecord.put(TOP_LEVEL_TS_FIELD_NAME, 1L);
     fieldTsRecord.put(PUT_ONLY_PART_LENGTH_FIELD_NAME, 1);
     fieldTsRecord.put(ACTIVE_ELEM_TS_FIELD_NAME, Collections.singletonList(3L));
@@ -227,10 +236,10 @@ public class TestMergePut extends TestMergeBase {
     GenericRecord newValueRecord = createValueRecord(r -> {
       r.put(REGULAR_FIELD_NAME, "defaultVenice");
       r.put(STRING_ARRAY_FIELD_NAME, Collections.singletonList("item1"));
-      IndexedHashMap<String, Integer> map = new IndexedHashMap<>();
-      map.put("key1", 2);
-      map.put("key2", 2);
-      r.put(INT_MAP_FIELD_NAME, map);
+      IndexedHashMap<String, String> map = new IndexedHashMap<>();
+      map.put("key1", "2");
+      map.put("key2", "2");
+      r.put(STRING_MAP_FIELD_NAME, map);
     });
 
     MergeConflictResult result = mergeConflictResolver.put(
@@ -244,24 +253,25 @@ public class TestMergePut extends TestMergeBase {
         -2);
     Assert.assertFalse(result.isUpdateIgnored());
     GenericRecord updatedValueRecord = deserializeValueRecord(result.getNewValue());
-    IndexedHashMap<Utf8, Integer> expectedMap = new IndexedHashMap<>();
-    expectedMap.put(new Utf8("key1"), 2);
-    expectedMap.put(new Utf8("key2"), 3);
-    Assert.assertEquals(updatedValueRecord.get(INT_MAP_FIELD_NAME), expectedMap);
+    IndexedHashMap<Utf8, Utf8> expectedMap = new IndexedHashMap<>();
+    expectedMap.put(new Utf8("key1"), new Utf8("2"));
+    expectedMap.put(new Utf8("key2"), new Utf8("3"));
+    Assert.assertEquals(updatedValueRecord.get(STRING_MAP_FIELD_NAME), expectedMap);
 
     GenericRecord updatedRmdTsRecord = (GenericRecord) result.getRmdRecord().get(RmdConstants.TIMESTAMP_FIELD_NAME);
-    Assert.assertEquals(((GenericRecord) updatedRmdTsRecord.get(INT_MAP_FIELD_NAME)).get(TOP_LEVEL_TS_FIELD_NAME), 2L);
+    Assert
+        .assertEquals(((GenericRecord) updatedRmdTsRecord.get(STRING_MAP_FIELD_NAME)).get(TOP_LEVEL_TS_FIELD_NAME), 2L);
     Assert.assertEquals(
-        ((GenericRecord) updatedRmdTsRecord.get(INT_MAP_FIELD_NAME)).get(ACTIVE_ELEM_TS_FIELD_NAME),
+        ((GenericRecord) updatedRmdTsRecord.get(STRING_MAP_FIELD_NAME)).get(ACTIVE_ELEM_TS_FIELD_NAME),
         Collections.singletonList(3L));
 
     newValueRecord = createValueRecord(r -> {
       r.put(REGULAR_FIELD_NAME, "defaultVenice");
       r.put(STRING_ARRAY_FIELD_NAME, Collections.singletonList("item1"));
-      IndexedHashMap<String, Integer> map = new IndexedHashMap<>();
-      map.put("key1", 1);
-      map.put("key2", 1);
-      r.put(INT_MAP_FIELD_NAME, map);
+      IndexedHashMap<String, String> map = new IndexedHashMap<>();
+      map.put("key1", "1");
+      map.put("key2", "1");
+      r.put(STRING_MAP_FIELD_NAME, map);
     });
     setRegularFieldTimestamp(oldRmdRecord, 10L);
 
@@ -277,14 +287,15 @@ public class TestMergePut extends TestMergeBase {
     Assert.assertFalse(result.isUpdateIgnored());
     updatedValueRecord = deserializeValueRecord(result.getNewValue());
     expectedMap = new IndexedHashMap<>();
-    expectedMap.put(new Utf8("key1"), 1);
-    expectedMap.put(new Utf8("key2"), 1);
-    Assert.assertEquals(updatedValueRecord.get(INT_MAP_FIELD_NAME), expectedMap);
+    expectedMap.put(new Utf8("key1"), new Utf8("1"));
+    expectedMap.put(new Utf8("key2"), new Utf8("1"));
+    Assert.assertEquals(updatedValueRecord.get(STRING_MAP_FIELD_NAME), expectedMap);
 
     updatedRmdTsRecord = (GenericRecord) result.getRmdRecord().get(RmdConstants.TIMESTAMP_FIELD_NAME);
-    Assert.assertEquals(((GenericRecord) updatedRmdTsRecord.get(INT_MAP_FIELD_NAME)).get(TOP_LEVEL_TS_FIELD_NAME), 3L);
+    Assert
+        .assertEquals(((GenericRecord) updatedRmdTsRecord.get(STRING_MAP_FIELD_NAME)).get(TOP_LEVEL_TS_FIELD_NAME), 3L);
     Assert.assertEquals(
-        ((GenericRecord) updatedRmdTsRecord.get(INT_MAP_FIELD_NAME)).get(ACTIVE_ELEM_TS_FIELD_NAME),
+        ((GenericRecord) updatedRmdTsRecord.get(STRING_MAP_FIELD_NAME)).get(ACTIVE_ELEM_TS_FIELD_NAME),
         Collections.emptyList());
   }
 }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/replication/merge/TestMergeUpdate.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/replication/merge/TestMergeUpdate.java
@@ -71,20 +71,20 @@ public class TestMergeUpdate extends TestMergeBase {
       boolean isUpdateTsSmallerThanRmdTs) {
     long baselineRmdTs = 2L;
     int baselineColoID = -1;
-    IndexedHashMap<String, Integer> updateMapValue = new IndexedHashMap<>();
-    updateMapValue.put("key1", 2);
-    updateMapValue.put("key2", 2);
+    IndexedHashMap<String, String> updateMapValue = new IndexedHashMap<>();
+    updateMapValue.put("key1", "2");
+    updateMapValue.put("key2", "2");
     List<String> updateListValue = Arrays.asList("item1", "item2");
     GenericRecord partialUpdateRecord =
-        new UpdateBuilderImpl(schemaSet.getUpdateSchema()).setNewFieldValue(INT_MAP_FIELD_NAME, updateMapValue)
+        new UpdateBuilderImpl(schemaSet.getUpdateSchema()).setNewFieldValue(STRING_MAP_FIELD_NAME, updateMapValue)
             .setNewFieldValue(STRING_ARRAY_FIELD_NAME, updateListValue)
             .build();
 
     GenericRecord oldValueRecord = createDefaultValueRecord();
-    IndexedHashMap<String, Integer> initialMapValue = new IndexedHashMap<>();
-    initialMapValue.put("key1", 1);
-    initialMapValue.put("key2", 1);
-    oldValueRecord.put(INT_MAP_FIELD_NAME, initialMapValue);
+    IndexedHashMap<String, String> initialMapValue = new IndexedHashMap<>();
+    initialMapValue.put("key1", "1");
+    initialMapValue.put("key2", "1");
+    oldValueRecord.put(STRING_MAP_FIELD_NAME, initialMapValue);
     oldValueRecord.put(STRING_ARRAY_FIELD_NAME, Arrays.asList("item0", "item1"));
 
     GenericRecord oldRmdRecord = rmdStartsWithFieldLevelTs
@@ -115,31 +115,31 @@ public class TestMergeUpdate extends TestMergeBase {
       boolean updateOnActiveElement,
       boolean isUpdateTsSmallerThanElementTs) {
     long baselineRmdTs = 2L;
-    IndexedHashMap<String, Integer> addToMapValue = new IndexedHashMap<>();
+    IndexedHashMap<String, String> addToMapValue = new IndexedHashMap<>();
     List<String> addToListValue;
     if (updateOnActiveElement) {
-      addToMapValue.put("key2", 0);
+      addToMapValue.put("key2", "0");
       addToListValue = Collections.singletonList("item2");
     } else {
-      addToMapValue.put("key1", 0);
+      addToMapValue.put("key1", "0");
       addToListValue = Collections.singletonList("item1");
     }
 
     GenericRecord partialUpdateRecord = new UpdateBuilderImpl(schemaSet.getUpdateSchema())
         .setElementsToAddToListField(STRING_ARRAY_FIELD_NAME, addToListValue)
-        .setEntriesToAddToMapField(INT_MAP_FIELD_NAME, addToMapValue)
+        .setEntriesToAddToMapField(STRING_MAP_FIELD_NAME, addToMapValue)
         .build();
 
     GenericRecord oldValueRecord = createDefaultValueRecord();
-    IndexedHashMap<String, Integer> initialMapValue = new IndexedHashMap<>();
-    initialMapValue.put("key1", 1);
-    initialMapValue.put("key2", 1);
-    oldValueRecord.put(INT_MAP_FIELD_NAME, initialMapValue);
+    IndexedHashMap<String, String> initialMapValue = new IndexedHashMap<>();
+    initialMapValue.put("key1", "1");
+    initialMapValue.put("key2", "1");
+    oldValueRecord.put(STRING_MAP_FIELD_NAME, initialMapValue);
     oldValueRecord.put(STRING_ARRAY_FIELD_NAME, Arrays.asList("item1", "item2"));
     GenericRecord oldRmdRecord = initiateFieldLevelRmdRecord(oldValueRecord, baselineRmdTs);
 
     GenericRecord timestampRecord = (GenericRecord) oldRmdRecord.get(RmdConstants.TIMESTAMP_FIELD_NAME);
-    GenericRecord mapTsRecord = (GenericRecord) timestampRecord.get(INT_MAP_FIELD_NAME);
+    GenericRecord mapTsRecord = (GenericRecord) timestampRecord.get(STRING_MAP_FIELD_NAME);
     mapTsRecord.put(TOP_LEVEL_TS_FIELD_NAME, baselineRmdTs);
     mapTsRecord.put(PUT_ONLY_PART_LENGTH_FIELD_NAME, 1);
     mapTsRecord.put(ACTIVE_ELEM_TS_FIELD_NAME, Collections.singletonList(baselineRmdTs + 1));
@@ -184,19 +184,19 @@ public class TestMergeUpdate extends TestMergeBase {
 
     GenericRecord partialUpdateRecord = new UpdateBuilderImpl(schemaSet.getUpdateSchema())
         .setElementsToRemoveFromListField(STRING_ARRAY_FIELD_NAME, removeFromListValue)
-        .setKeysToRemoveFromMapField(INT_MAP_FIELD_NAME, removeFromMapValue)
+        .setKeysToRemoveFromMapField(STRING_MAP_FIELD_NAME, removeFromMapValue)
         .build();
 
     GenericRecord oldValueRecord = createDefaultValueRecord();
-    IndexedHashMap<String, Integer> initialMapValue = new IndexedHashMap<>();
-    initialMapValue.put("key1", 1);
-    initialMapValue.put("key2", 1);
-    oldValueRecord.put(INT_MAP_FIELD_NAME, initialMapValue);
+    IndexedHashMap<String, String> initialMapValue = new IndexedHashMap<>();
+    initialMapValue.put("key1", "1");
+    initialMapValue.put("key2", "1");
+    oldValueRecord.put(STRING_MAP_FIELD_NAME, initialMapValue);
     oldValueRecord.put(STRING_ARRAY_FIELD_NAME, Arrays.asList("item1", "item2"));
     GenericRecord oldRmdRecord = initiateFieldLevelRmdRecord(oldValueRecord, baselineRmdTs);
 
     GenericRecord timestampRecord = (GenericRecord) oldRmdRecord.get(RmdConstants.TIMESTAMP_FIELD_NAME);
-    GenericRecord mapTsRecord = (GenericRecord) timestampRecord.get(INT_MAP_FIELD_NAME);
+    GenericRecord mapTsRecord = (GenericRecord) timestampRecord.get(STRING_MAP_FIELD_NAME);
     mapTsRecord.put(TOP_LEVEL_TS_FIELD_NAME, baselineRmdTs);
     mapTsRecord.put(PUT_ONLY_PART_LENGTH_FIELD_NAME, 1);
     mapTsRecord.put(ACTIVE_ELEM_TS_FIELD_NAME, Collections.singletonList(baselineRmdTs + 1));
@@ -232,20 +232,20 @@ public class TestMergeUpdate extends TestMergeBase {
   public void testMapFieldAddEntriesUpdateIgnoredOnValueLevelTs(boolean updateTsSmallerThanRmdTs) {
     long baselineRmdTs = 2L;
 
-    IndexedHashMap<String, Integer> addToMapValue = new IndexedHashMap<>();
-    addToMapValue.put("key1", 2);
-    addToMapValue.put("key2", 2);
+    IndexedHashMap<String, String> addToMapValue = new IndexedHashMap<>();
+    addToMapValue.put("key1", "2");
+    addToMapValue.put("key2", "2");
     List<String> addToListValue = Collections.singletonList("item1");
     GenericRecord partialUpdateRecord = new UpdateBuilderImpl(schemaSet.getUpdateSchema())
         .setElementsToAddToListField(STRING_ARRAY_FIELD_NAME, addToListValue)
-        .setEntriesToAddToMapField(INT_MAP_FIELD_NAME, addToMapValue)
+        .setEntriesToAddToMapField(STRING_MAP_FIELD_NAME, addToMapValue)
         .build();
 
     GenericRecord oldValueRecord = createDefaultValueRecord();
-    IndexedHashMap<String, Integer> initialMapValue = new IndexedHashMap<>();
-    initialMapValue.put("key1", 1);
-    initialMapValue.put("key2", 1);
-    oldValueRecord.put(INT_MAP_FIELD_NAME, initialMapValue);
+    IndexedHashMap<String, String> initialMapValue = new IndexedHashMap<>();
+    initialMapValue.put("key1", "1");
+    initialMapValue.put("key2", "1");
+    oldValueRecord.put(STRING_MAP_FIELD_NAME, initialMapValue);
     oldValueRecord.put(STRING_ARRAY_FIELD_NAME, Collections.singletonList("item2"));
     GenericRecord oldRmdRecord = initiateValueLevelRmdRecord(baselineRmdTs);
     long updateTs = updateTsSmallerThanRmdTs ? baselineRmdTs - 1 : baselineRmdTs;
@@ -264,17 +264,17 @@ public class TestMergeUpdate extends TestMergeBase {
 
   @Test
   public void testSetCollectionFieldOnFieldValueTs() {
-    IndexedHashMap<String, Integer> updateMapValue = new IndexedHashMap<>();
-    updateMapValue.put("key1", 2);
-    updateMapValue.put("key2", 2);
-    updateMapValue.put("key3", 2);
-    updateMapValue.put("key4", 2);
-    updateMapValue.put("key5", 2);
-    updateMapValue.put("key6", 2);
+    IndexedHashMap<String, String> updateMapValue = new IndexedHashMap<>();
+    updateMapValue.put("key1", "2");
+    updateMapValue.put("key2", "2");
+    updateMapValue.put("key3", "2");
+    updateMapValue.put("key4", "2");
+    updateMapValue.put("key5", "2");
+    updateMapValue.put("key6", "2");
     GenericRecord partialUpdateRecord =
-        new UpdateBuilderImpl(schemaSet.getUpdateSchema()).setNewFieldValue(INT_MAP_FIELD_NAME, updateMapValue)
+        new UpdateBuilderImpl(schemaSet.getUpdateSchema()).setNewFieldValue(STRING_MAP_FIELD_NAME, updateMapValue)
             .setNewFieldValue(STRING_ARRAY_FIELD_NAME, Arrays.asList("key1", "key2", "key3", "key4", "key5", "key6"))
-            .setNewFieldValue(NULLABLE_INT_MAP_FIELD_NAME, null)
+            .setNewFieldValue(NULLABLE_STRING_MAP_FIELD_NAME, null)
             .setNewFieldValue(NULLABLE_STRING_ARRAY_FIELD_NAME, null)
             .build();
 
@@ -282,13 +282,13 @@ public class TestMergeUpdate extends TestMergeBase {
     List<String> listValue = Arrays.asList("key1", "key2", "key3");
     oldValueRecord.put(STRING_ARRAY_FIELD_NAME, listValue);
     oldValueRecord.put(NULLABLE_STRING_ARRAY_FIELD_NAME, listValue);
-    IndexedHashMap<String, Integer> mapValue = new IndexedHashMap<>();
-    mapValue.put("key1", 1); // Put Only Part
-    mapValue.put("key2", 1); // Same TS, value is smaller than incoming update.
-    mapValue.put("key3", 4); // Same TS, value is bigger than incoming update.
-    mapValue.put("key4", 1); // Higher TS
-    oldValueRecord.put(INT_MAP_FIELD_NAME, mapValue);
-    oldValueRecord.put(NULLABLE_INT_MAP_FIELD_NAME, mapValue);
+    IndexedHashMap<String, String> mapValue = new IndexedHashMap<>();
+    mapValue.put("key1", "1"); // Put Only Part
+    mapValue.put("key2", "1"); // Same TS, value is smaller than incoming update.
+    mapValue.put("key3", "4"); // Same TS, value is bigger than incoming update.
+    mapValue.put("key4", "1"); // Higher TS
+    oldValueRecord.put(STRING_MAP_FIELD_NAME, mapValue);
+    oldValueRecord.put(NULLABLE_STRING_MAP_FIELD_NAME, mapValue);
 
     GenericRecord oldRmdRecord = initiateFieldLevelRmdRecord(oldValueRecord, 2);
     GenericRecord timestampRecord = (GenericRecord) oldRmdRecord.get(RmdConstants.TIMESTAMP_FIELD_NAME);
@@ -306,14 +306,14 @@ public class TestMergeUpdate extends TestMergeBase {
     nullableListTsRecord.put(DELETED_ELEM_FIELD_NAME, Arrays.asList("key4", "key5"));
     nullableListTsRecord.put(DELETED_ELEM_TS_FIELD_NAME, Arrays.asList(2L, 3L));
 
-    GenericRecord mapTsRecord = (GenericRecord) timestampRecord.get(INT_MAP_FIELD_NAME);
+    GenericRecord mapTsRecord = (GenericRecord) timestampRecord.get(STRING_MAP_FIELD_NAME);
     mapTsRecord.put(TOP_LEVEL_TS_FIELD_NAME, 1L);
     mapTsRecord.put(PUT_ONLY_PART_LENGTH_FIELD_NAME, 1);
     mapTsRecord.put(ACTIVE_ELEM_TS_FIELD_NAME, Arrays.asList(2L, 2L, 3L));
     mapTsRecord.put(DELETED_ELEM_FIELD_NAME, Arrays.asList("key5", "key6"));
     mapTsRecord.put(DELETED_ELEM_TS_FIELD_NAME, Arrays.asList(2L, 3L));
 
-    GenericRecord nullableMapTsRecord = (GenericRecord) timestampRecord.get(NULLABLE_INT_MAP_FIELD_NAME);
+    GenericRecord nullableMapTsRecord = (GenericRecord) timestampRecord.get(NULLABLE_STRING_MAP_FIELD_NAME);
     nullableMapTsRecord.put(TOP_LEVEL_TS_FIELD_NAME, 1L);
     nullableMapTsRecord.put(PUT_ONLY_PART_LENGTH_FIELD_NAME, 1);
     nullableMapTsRecord.put(ACTIVE_ELEM_TS_FIELD_NAME, Arrays.asList(2L, 2L, 3L));
@@ -335,20 +335,20 @@ public class TestMergeUpdate extends TestMergeBase {
     Assert.assertEquals(
         updatedValueRecord.get(NULLABLE_STRING_ARRAY_FIELD_NAME),
         Collections.singletonList(new Utf8("key3")));
-    IndexedHashMap<Utf8, Integer> expectedNullableMap = new IndexedHashMap<>();
-    expectedNullableMap.put(new Utf8("key4"), 1);
-    Assert.assertEquals(updatedValueRecord.get(NULLABLE_INT_MAP_FIELD_NAME), expectedNullableMap);
+    IndexedHashMap<Utf8, Utf8> expectedNullableMap = new IndexedHashMap<>();
+    expectedNullableMap.put(new Utf8("key4"), new Utf8("1"));
+    Assert.assertEquals(updatedValueRecord.get(NULLABLE_STRING_MAP_FIELD_NAME), expectedNullableMap);
     Assert.assertEquals(
         updatedValueRecord.get(STRING_ARRAY_FIELD_NAME),
         Arrays.asList(new Utf8("key1"), new Utf8("key2"), new Utf8("key6"), new Utf8("key3")));
 
-    IndexedHashMap<Utf8, Integer> expectedMap = new IndexedHashMap<>();
-    expectedMap.put(new Utf8("key1"), 2);
-    expectedMap.put(new Utf8("key2"), 2);
-    expectedMap.put(new Utf8("key3"), 2);
-    expectedMap.put(new Utf8("key4"), 1);
+    IndexedHashMap<Utf8, Utf8> expectedMap = new IndexedHashMap<>();
+    expectedMap.put(new Utf8("key1"), new Utf8("2"));
+    expectedMap.put(new Utf8("key2"), new Utf8("2"));
+    expectedMap.put(new Utf8("key3"), new Utf8("2"));
+    expectedMap.put(new Utf8("key4"), new Utf8("1"));
 
-    Assert.assertEquals(updatedValueRecord.get(INT_MAP_FIELD_NAME), expectedMap);
+    Assert.assertEquals(updatedValueRecord.get(STRING_MAP_FIELD_NAME), expectedMap);
 
     GenericRecord updateRmdRecord = result.getRmdRecord();
     GenericRecord updatedRmdTsRecord = (GenericRecord) updateRmdRecord.get(RmdConstants.TIMESTAMP_FIELD_NAME);
@@ -359,7 +359,7 @@ public class TestMergeUpdate extends TestMergeBase {
     Assert.assertEquals(updatedListTsRecord.get(DELETED_ELEM_FIELD_NAME), Arrays.asList("key4", "key5"));
     Assert.assertEquals(updatedListTsRecord.get(DELETED_ELEM_TS_FIELD_NAME), Arrays.asList(2L, 3L));
 
-    GenericRecord updatedMapTsRecord = (GenericRecord) updatedRmdTsRecord.get(INT_MAP_FIELD_NAME);
+    GenericRecord updatedMapTsRecord = (GenericRecord) updatedRmdTsRecord.get(STRING_MAP_FIELD_NAME);
     Assert.assertEquals(updatedMapTsRecord.get(TOP_LEVEL_TS_FIELD_NAME), 2L);
     Assert.assertEquals(updatedMapTsRecord.get(PUT_ONLY_PART_LENGTH_FIELD_NAME), 3);
     Assert.assertEquals(updatedMapTsRecord.get(ACTIVE_ELEM_TS_FIELD_NAME), Collections.singletonList(3L));
@@ -374,7 +374,7 @@ public class TestMergeUpdate extends TestMergeBase {
     Assert.assertEquals(updatedNullableListTsRecord.get(DELETED_ELEM_FIELD_NAME), Arrays.asList("key4", "key5"));
     Assert.assertEquals(updatedNullableListTsRecord.get(DELETED_ELEM_TS_FIELD_NAME), Arrays.asList(2L, 3L));
 
-    GenericRecord updatedNullableMapTsRecord = (GenericRecord) updatedRmdTsRecord.get(NULLABLE_INT_MAP_FIELD_NAME);
+    GenericRecord updatedNullableMapTsRecord = (GenericRecord) updatedRmdTsRecord.get(NULLABLE_STRING_MAP_FIELD_NAME);
     Assert.assertEquals(updatedNullableMapTsRecord.get(TOP_LEVEL_TS_FIELD_NAME), 2L);
     Assert.assertEquals(updatedNullableMapTsRecord.get(PUT_ONLY_PART_LENGTH_FIELD_NAME), 0);
     Assert.assertEquals(updatedNullableMapTsRecord.get(ACTIVE_ELEM_TS_FIELD_NAME), Collections.singletonList(3L));
@@ -383,7 +383,7 @@ public class TestMergeUpdate extends TestMergeBase {
 
     // Set nullable collection field to NULL value by updating it in a large enough TS.
     partialUpdateRecord =
-        new UpdateBuilderImpl(schemaSet.getUpdateSchema()).setNewFieldValue(NULLABLE_INT_MAP_FIELD_NAME, null)
+        new UpdateBuilderImpl(schemaSet.getUpdateSchema()).setNewFieldValue(NULLABLE_STRING_MAP_FIELD_NAME, null)
             .setNewFieldValue(NULLABLE_STRING_ARRAY_FIELD_NAME, null)
             .build();
     result = mergeConflictResolver.update(
@@ -399,7 +399,7 @@ public class TestMergeUpdate extends TestMergeBase {
 
     GenericRecord newUpdatedValueRecord = deserializeValueRecord(result.getNewValue());
     Assert.assertNull(newUpdatedValueRecord.get(NULLABLE_STRING_ARRAY_FIELD_NAME));
-    Assert.assertNull(newUpdatedValueRecord.get(NULLABLE_INT_MAP_FIELD_NAME));
+    Assert.assertNull(newUpdatedValueRecord.get(NULLABLE_STRING_MAP_FIELD_NAME));
     GenericRecord newUpdatedRmdRecord = result.getRmdRecord();
     GenericRecord newUpdatedRmdTsRecord = (GenericRecord) newUpdatedRmdRecord.get(RmdConstants.TIMESTAMP_FIELD_NAME);
 
@@ -410,7 +410,7 @@ public class TestMergeUpdate extends TestMergeBase {
     Assert.assertEquals(updatedNullableListTsRecord.get(DELETED_ELEM_FIELD_NAME), Collections.emptyList());
     Assert.assertEquals(updatedNullableListTsRecord.get(DELETED_ELEM_TS_FIELD_NAME), Collections.emptyList());
 
-    updatedNullableMapTsRecord = (GenericRecord) newUpdatedRmdTsRecord.get(NULLABLE_INT_MAP_FIELD_NAME);
+    updatedNullableMapTsRecord = (GenericRecord) newUpdatedRmdTsRecord.get(NULLABLE_STRING_MAP_FIELD_NAME);
     Assert.assertEquals(updatedNullableMapTsRecord.get(TOP_LEVEL_TS_FIELD_NAME), 10L);
     Assert.assertEquals(updatedNullableMapTsRecord.get(PUT_ONLY_PART_LENGTH_FIELD_NAME), 0);
     Assert.assertEquals(updatedNullableMapTsRecord.get(ACTIVE_ELEM_TS_FIELD_NAME), Collections.emptyList());
@@ -420,29 +420,29 @@ public class TestMergeUpdate extends TestMergeBase {
 
   @Test
   public void testAddToCollectionFieldOnFieldValueTs() {
-    IndexedHashMap<String, Integer> addToMapValue = new IndexedHashMap<>();
-    addToMapValue.put("key1", 2);
-    addToMapValue.put("key2", 2);
-    addToMapValue.put("key3", 2);
-    addToMapValue.put("key4", 2);
-    addToMapValue.put("key5", 2);
-    GenericRecord partialUpdateRecord =
-        new UpdateBuilderImpl(schemaSet.getUpdateSchema()).setEntriesToAddToMapField(INT_MAP_FIELD_NAME, addToMapValue)
-            .setElementsToAddToListField(
-                STRING_ARRAY_FIELD_NAME,
-                Arrays.asList("key1", "key2", "key3", "key4", "key5", "key6"))
-            .setElementsToAddToListField(NULLABLE_STRING_ARRAY_FIELD_NAME, Collections.singletonList("key1"))
-            .setEntriesToAddToMapField(NULLABLE_INT_MAP_FIELD_NAME, Collections.singletonMap("key1", 1))
-            .build();
+    IndexedHashMap<String, String> addToMapValue = new IndexedHashMap<>();
+    addToMapValue.put("key1", "2");
+    addToMapValue.put("key2", "2");
+    addToMapValue.put("key3", "2");
+    addToMapValue.put("key4", "2");
+    addToMapValue.put("key5", "2");
+    GenericRecord partialUpdateRecord = new UpdateBuilderImpl(schemaSet.getUpdateSchema())
+        .setEntriesToAddToMapField(STRING_MAP_FIELD_NAME, addToMapValue)
+        .setElementsToAddToListField(
+            STRING_ARRAY_FIELD_NAME,
+            Arrays.asList("key1", "key2", "key3", "key4", "key5", "key6"))
+        .setElementsToAddToListField(NULLABLE_STRING_ARRAY_FIELD_NAME, Collections.singletonList("key1"))
+        .setEntriesToAddToMapField(NULLABLE_STRING_MAP_FIELD_NAME, Collections.singletonMap("key1", "1"))
+        .build();
 
     GenericRecord oldValueRecord = createDefaultValueRecord();
     oldValueRecord.put(STRING_ARRAY_FIELD_NAME, Arrays.asList("key1", "key2", "key3"));
-    IndexedHashMap<String, Integer> mapValue = new IndexedHashMap<>();
-    mapValue.put("key1", 1);
-    mapValue.put("key2", 1); // Value is smaller than incoming update.
-    mapValue.put("key3", 4); // Value is bigger than incoming update.
-    mapValue.put("key4", 1);
-    oldValueRecord.put(INT_MAP_FIELD_NAME, mapValue);
+    IndexedHashMap<String, String> mapValue = new IndexedHashMap<>();
+    mapValue.put("key1", "1");
+    mapValue.put("key2", "1"); // Value is smaller than incoming update.
+    mapValue.put("key3", "4"); // Value is bigger than incoming update.
+    mapValue.put("key4", "1");
+    oldValueRecord.put(STRING_MAP_FIELD_NAME, mapValue);
 
     GenericRecord oldRmdRecord = initiateFieldLevelRmdRecord(oldValueRecord, 2);
     GenericRecord timestampRecord = (GenericRecord) oldRmdRecord.get(RmdConstants.TIMESTAMP_FIELD_NAME);
@@ -450,7 +450,7 @@ public class TestMergeUpdate extends TestMergeBase {
     GenericRecord nullableListTsRecord = (GenericRecord) timestampRecord.get(NULLABLE_STRING_ARRAY_FIELD_NAME);
     nullableListTsRecord.put(TOP_LEVEL_TS_FIELD_NAME, 1L);
 
-    GenericRecord nullableMapTsRecord = (GenericRecord) timestampRecord.get(NULLABLE_INT_MAP_FIELD_NAME);
+    GenericRecord nullableMapTsRecord = (GenericRecord) timestampRecord.get(NULLABLE_STRING_MAP_FIELD_NAME);
     nullableMapTsRecord.put(TOP_LEVEL_TS_FIELD_NAME, 1L);
 
     GenericRecord listTsRecord = (GenericRecord) timestampRecord.get(STRING_ARRAY_FIELD_NAME);
@@ -460,7 +460,7 @@ public class TestMergeUpdate extends TestMergeBase {
     listTsRecord.put(DELETED_ELEM_FIELD_NAME, Arrays.asList("key4", "key5", "key6"));
     listTsRecord.put(DELETED_ELEM_TS_FIELD_NAME, Arrays.asList(1L, 2L, 3L));
 
-    GenericRecord mapTsRecord = (GenericRecord) timestampRecord.get(INT_MAP_FIELD_NAME);
+    GenericRecord mapTsRecord = (GenericRecord) timestampRecord.get(STRING_MAP_FIELD_NAME);
     mapTsRecord.put(TOP_LEVEL_TS_FIELD_NAME, 1L);
     mapTsRecord.put(PUT_ONLY_PART_LENGTH_FIELD_NAME, 1);
     mapTsRecord.put(ACTIVE_ELEM_TS_FIELD_NAME, Arrays.asList(2L, 2L, 3L));
@@ -480,21 +480,21 @@ public class TestMergeUpdate extends TestMergeBase {
     Assert.assertEquals(
         updatedValueRecord.get(NULLABLE_STRING_ARRAY_FIELD_NAME),
         Collections.singletonList(new Utf8("key1")));
-    IndexedHashMap<Utf8, Integer> expectedNullableMap = new IndexedHashMap<>();
-    expectedNullableMap.put(new Utf8("key1"), 1);
-    Assert.assertEquals(updatedValueRecord.get(NULLABLE_INT_MAP_FIELD_NAME), expectedNullableMap);
+    IndexedHashMap<Utf8, Utf8> expectedNullableMap = new IndexedHashMap<>();
+    expectedNullableMap.put(new Utf8("key1"), new Utf8("1"));
+    Assert.assertEquals(updatedValueRecord.get(NULLABLE_STRING_MAP_FIELD_NAME), expectedNullableMap);
 
     Assert.assertEquals(
         updatedValueRecord.get(STRING_ARRAY_FIELD_NAME),
         Arrays.asList(new Utf8("key1"), new Utf8("key2"), new Utf8("key3"), new Utf8("key4")));
 
-    IndexedHashMap<Utf8, Integer> expectedMap = new IndexedHashMap<>();
-    expectedMap.put(new Utf8("key1"), 2);
-    expectedMap.put(new Utf8("key2"), 2);
-    expectedMap.put(new Utf8("key3"), 4);
-    expectedMap.put(new Utf8("key4"), 1);
-    expectedMap.put(new Utf8("key5"), 2);
-    Assert.assertEquals(updatedValueRecord.get(INT_MAP_FIELD_NAME), expectedMap);
+    IndexedHashMap<Utf8, Utf8> expectedMap = new IndexedHashMap<>();
+    expectedMap.put(new Utf8("key1"), new Utf8("2"));
+    expectedMap.put(new Utf8("key2"), new Utf8("2"));
+    expectedMap.put(new Utf8("key3"), new Utf8("4"));
+    expectedMap.put(new Utf8("key4"), new Utf8("1"));
+    expectedMap.put(new Utf8("key5"), new Utf8("2"));
+    Assert.assertEquals(updatedValueRecord.get(STRING_MAP_FIELD_NAME), expectedMap);
 
     GenericRecord updatedRmdTsRecord = (GenericRecord) result.getRmdRecord().get(RmdConstants.TIMESTAMP_FIELD_NAME);
     GenericRecord updatedListTsRecord = (GenericRecord) updatedRmdTsRecord.get(STRING_ARRAY_FIELD_NAME);
@@ -504,7 +504,7 @@ public class TestMergeUpdate extends TestMergeBase {
     Assert.assertEquals(updatedListTsRecord.get(DELETED_ELEM_FIELD_NAME), Arrays.asList("key5", "key6"));
     Assert.assertEquals(updatedListTsRecord.get(DELETED_ELEM_TS_FIELD_NAME), Arrays.asList(2L, 3L));
 
-    GenericRecord updatedMapTsRecord = (GenericRecord) updatedRmdTsRecord.get(INT_MAP_FIELD_NAME);
+    GenericRecord updatedMapTsRecord = (GenericRecord) updatedRmdTsRecord.get(STRING_MAP_FIELD_NAME);
     Assert.assertEquals(updatedMapTsRecord.get(TOP_LEVEL_TS_FIELD_NAME), 1L);
     Assert.assertEquals(updatedMapTsRecord.get(ACTIVE_ELEM_TS_FIELD_NAME), Arrays.asList(2L, 2L, 2L, 2L, 3L));
     Assert.assertEquals(updatedMapTsRecord.get(PUT_ONLY_PART_LENGTH_FIELD_NAME), 0);
@@ -513,25 +513,25 @@ public class TestMergeUpdate extends TestMergeBase {
   @Test
   public void testRemoveFromCollectionFieldOnFieldLevelTs() {
     GenericRecord partialUpdateRecord = new UpdateBuilderImpl(schemaSet.getUpdateSchema())
-        .setKeysToRemoveFromMapField(INT_MAP_FIELD_NAME, Arrays.asList("key1", "key2", "key3", "key4"))
+        .setKeysToRemoveFromMapField(STRING_MAP_FIELD_NAME, Arrays.asList("key1", "key2", "key3", "key4"))
         .setElementsToRemoveFromListField(
             STRING_ARRAY_FIELD_NAME,
             Arrays.asList("key1", "key2", "key3", "key4", "key5", "key6"))
-        .setKeysToRemoveFromMapField(NULLABLE_INT_MAP_FIELD_NAME, Collections.singletonList("key1"))
+        .setKeysToRemoveFromMapField(NULLABLE_STRING_MAP_FIELD_NAME, Collections.singletonList("key1"))
         .setElementsToRemoveFromListField(NULLABLE_STRING_ARRAY_FIELD_NAME, Collections.singletonList("key1"))
         .build();
 
     GenericRecord oldValueRecord = createDefaultValueRecord();
-    IndexedHashMap<String, Integer> mapValue = new IndexedHashMap<>();
-    mapValue.put("key1", 1);
-    mapValue.put("key2", 1);
-    mapValue.put("key3", 1);
-    oldValueRecord.put(INT_MAP_FIELD_NAME, mapValue);
+    IndexedHashMap<String, String> mapValue = new IndexedHashMap<>();
+    mapValue.put("key1", "1");
+    mapValue.put("key2", "1");
+    mapValue.put("key3", "1");
+    oldValueRecord.put(STRING_MAP_FIELD_NAME, mapValue);
     oldValueRecord.put(STRING_ARRAY_FIELD_NAME, Arrays.asList("key1", "key2", "key3"));
 
     GenericRecord oldRmdRecord = initiateFieldLevelRmdRecord(oldValueRecord, 2);
     GenericRecord timestampRecord = (GenericRecord) oldRmdRecord.get(RmdConstants.TIMESTAMP_FIELD_NAME);
-    GenericRecord mapTsRecord = (GenericRecord) timestampRecord.get(INT_MAP_FIELD_NAME);
+    GenericRecord mapTsRecord = (GenericRecord) timestampRecord.get(STRING_MAP_FIELD_NAME);
     mapTsRecord.put(TOP_LEVEL_TS_FIELD_NAME, 1L);
     mapTsRecord.put(PUT_ONLY_PART_LENGTH_FIELD_NAME, 1);
     mapTsRecord.put(ACTIVE_ELEM_TS_FIELD_NAME, Arrays.asList(3L, 4L));
@@ -555,23 +555,23 @@ public class TestMergeUpdate extends TestMergeBase {
         0);
     GenericRecord updatedValueRecord = deserializeValueRecord(result.getNewValue());
     Assert.assertEquals(updatedValueRecord.get(NULLABLE_STRING_ARRAY_FIELD_NAME), Collections.emptyList());
-    IndexedHashMap<Utf8, Integer> expectedNullableMap = new IndexedHashMap<>();
-    Assert.assertEquals(updatedValueRecord.get(NULLABLE_INT_MAP_FIELD_NAME), expectedNullableMap);
+    IndexedHashMap<Utf8, Utf8> expectedNullableMap = new IndexedHashMap<>();
+    Assert.assertEquals(updatedValueRecord.get(NULLABLE_STRING_MAP_FIELD_NAME), expectedNullableMap);
 
-    IndexedHashMap<Utf8, Integer> expectedMap = new IndexedHashMap<>();
-    expectedMap.put(new Utf8("key3"), 1);
-    Assert.assertEquals(updatedValueRecord.get(INT_MAP_FIELD_NAME), expectedMap);
+    IndexedHashMap<Utf8, Utf8> expectedMap = new IndexedHashMap<>();
+    expectedMap.put(new Utf8("key3"), new Utf8("1"));
+    Assert.assertEquals(updatedValueRecord.get(STRING_MAP_FIELD_NAME), expectedMap);
     Assert.assertEquals(updatedValueRecord.get(STRING_ARRAY_FIELD_NAME), Collections.singletonList(new Utf8("key3")));
 
     GenericRecord updatedRmdTsRecord = (GenericRecord) result.getRmdRecord().get(RmdConstants.TIMESTAMP_FIELD_NAME);
-    GenericRecord updatedMapTsRecord = (GenericRecord) updatedRmdTsRecord.get(INT_MAP_FIELD_NAME);
+    GenericRecord updatedMapTsRecord = (GenericRecord) updatedRmdTsRecord.get(STRING_MAP_FIELD_NAME);
     Assert.assertEquals(updatedMapTsRecord.get(TOP_LEVEL_TS_FIELD_NAME), 1L);
     Assert.assertEquals(updatedMapTsRecord.get(ACTIVE_ELEM_TS_FIELD_NAME), Collections.singletonList(4L));
     Assert.assertEquals(updatedMapTsRecord.get(PUT_ONLY_PART_LENGTH_FIELD_NAME), 0);
     Assert.assertEquals(updatedMapTsRecord.get(DELETED_ELEM_FIELD_NAME), Arrays.asList("key1", "key2", "key4"));
     Assert.assertEquals(updatedMapTsRecord.get(DELETED_ELEM_TS_FIELD_NAME), Arrays.asList(3L, 3L, 3L));
 
-    GenericRecord updatedNullableMapTsRecord = (GenericRecord) updatedRmdTsRecord.get(NULLABLE_INT_MAP_FIELD_NAME);
+    GenericRecord updatedNullableMapTsRecord = (GenericRecord) updatedRmdTsRecord.get(NULLABLE_STRING_MAP_FIELD_NAME);
     Assert.assertEquals(updatedNullableMapTsRecord.get(TOP_LEVEL_TS_FIELD_NAME), 2L);
     Assert.assertEquals(updatedNullableMapTsRecord.get(DELETED_ELEM_FIELD_NAME), Collections.singletonList("key1"));
     Assert.assertEquals(updatedNullableMapTsRecord.get(DELETED_ELEM_TS_FIELD_NAME), Collections.singletonList(3L));
@@ -598,8 +598,8 @@ public class TestMergeUpdate extends TestMergeBase {
    */
   @Test
   public void testNullableCollectionFieldUpdateOperations() {
-    MergeConflictResult result = null;
-    IndexedHashMap<Utf8, Integer> expectedMapValue = new IndexedHashMap<>();
+    MergeConflictResult result;
+    IndexedHashMap<Utf8, Utf8> expectedMapValue = new IndexedHashMap<>();
     List<Utf8> expectedListValue = new ArrayList<>();
     long operationTs = 1L;
 
@@ -620,14 +620,14 @@ public class TestMergeUpdate extends TestMergeBase {
     // Operation 3: Add entries to collection starting from null.
     for (int i = 0; i < 3; i++) {
       String itemKey = "key_" + i;
-      expectedMapValue.put(new Utf8(itemKey), 1);
+      expectedMapValue.put(new Utf8(itemKey), new Utf8("1"));
       expectedListValue.add(new Utf8(itemKey));
       operationTs++;
       result = updateNullableCollection(
           result,
           operationTs,
           UpdateOperationType.ADD_ENTRY,
-          Collections.singletonMap(itemKey, 1),
+          Collections.singletonMap(itemKey, "1"),
           Collections.singletonList(itemKey));
       validateNullableCollectionUpdateResult(result, expectedMapValue, expectedListValue);
     }
@@ -665,14 +665,14 @@ public class TestMergeUpdate extends TestMergeBase {
     // Operation 7: Add entries to collection starting from empty collection.
     for (int i = 0; i < 3; i++) {
       String itemKey = "key_" + i;
-      expectedMapValue.put(new Utf8(itemKey), 1);
+      expectedMapValue.put(new Utf8(itemKey), new Utf8("1"));
       expectedListValue.add(new Utf8(itemKey));
       operationTs++;
       result = updateNullableCollection(
           result,
           operationTs,
           UpdateOperationType.ADD_ENTRY,
-          Collections.singletonMap(itemKey, 1),
+          Collections.singletonMap(itemKey, "1"),
           Collections.singletonList(itemKey));
       validateNullableCollectionUpdateResult(result, expectedMapValue, expectedListValue);
     }
@@ -680,28 +680,28 @@ public class TestMergeUpdate extends TestMergeBase {
     // Operation 8: Add entries to collection starting from empty collection.
     expectedMapValue = new IndexedHashMap<>();
     expectedListValue = new ArrayList<>();
-    expectedMapValue.put(new Utf8("putOnly"), 1);
+    expectedMapValue.put(new Utf8("putOnly"), new Utf8("1"));
     expectedListValue.add(new Utf8("putOnly"));
     operationTs++;
     result = updateNullableCollection(
         result,
         operationTs,
         UpdateOperationType.SET_FIELD,
-        Collections.singletonMap("putOnly", 1),
+        Collections.singletonMap("putOnly", "1"),
         Collections.singletonList("putOnly"));
     validateNullableCollectionUpdateResult(result, expectedMapValue, expectedListValue);
 
     // Operation 9: Add entries to collection starting from null.
     for (int i = 0; i < 3; i++) {
       String itemKey = "key_" + i;
-      expectedMapValue.put(new Utf8(itemKey), 1);
+      expectedMapValue.put(new Utf8(itemKey), new Utf8("1"));
       expectedListValue.add(new Utf8(itemKey));
       operationTs++;
       result = updateNullableCollection(
           result,
           operationTs,
           UpdateOperationType.ADD_ENTRY,
-          Collections.singletonMap(itemKey, 1),
+          Collections.singletonMap(itemKey, "1"),
           Collections.singletonList(itemKey));
       validateNullableCollectionUpdateResult(result, expectedMapValue, expectedListValue);
     }
@@ -734,17 +734,17 @@ public class TestMergeUpdate extends TestMergeBase {
     if (operationType.equals(UpdateOperationType.ADD_ENTRY)) {
       partialUpdateRecord = new UpdateBuilderImpl(schemaSet.getUpdateSchema())
           .setElementsToAddToListField(NULLABLE_STRING_ARRAY_FIELD_NAME, (List<?>) listFieldValue)
-          .setEntriesToAddToMapField(NULLABLE_INT_MAP_FIELD_NAME, (Map<String, ?>) mapFieldValue)
+          .setEntriesToAddToMapField(NULLABLE_STRING_MAP_FIELD_NAME, (Map<String, ?>) mapFieldValue)
           .build();
     } else if (operationType.equals(UpdateOperationType.REMOVE_ENTRY)) {
       partialUpdateRecord = new UpdateBuilderImpl(schemaSet.getUpdateSchema())
           .setElementsToRemoveFromListField(NULLABLE_STRING_ARRAY_FIELD_NAME, (List<?>) listFieldValue)
-          .setKeysToRemoveFromMapField(NULLABLE_INT_MAP_FIELD_NAME, (List<String>) mapFieldValue)
+          .setKeysToRemoveFromMapField(NULLABLE_STRING_MAP_FIELD_NAME, (List<String>) mapFieldValue)
           .build();
     } else {
       partialUpdateRecord = new UpdateBuilderImpl(schemaSet.getUpdateSchema())
           .setNewFieldValue(NULLABLE_STRING_ARRAY_FIELD_NAME, listFieldValue)
-          .setNewFieldValue(NULLABLE_INT_MAP_FIELD_NAME, mapFieldValue)
+          .setNewFieldValue(NULLABLE_STRING_MAP_FIELD_NAME, mapFieldValue)
           .build();
     }
 
@@ -771,7 +771,7 @@ public class TestMergeUpdate extends TestMergeBase {
       List expectedStringValue) {
     GenericRecord valueRecord = deserializeValueRecord(result.getNewValue());
     Assert.assertEquals(valueRecord.get(NULLABLE_STRING_ARRAY_FIELD_NAME), expectedStringValue);
-    Assert.assertEquals(valueRecord.get(NULLABLE_INT_MAP_FIELD_NAME), expectedMapValue);
+    Assert.assertEquals(valueRecord.get(NULLABLE_STRING_MAP_FIELD_NAME), expectedMapValue);
   }
 
   enum UpdateOperationType {

--- a/clients/da-vinci-client/src/test/resources/avro/PartialUpdateWithMapField.avsc
+++ b/clients/da-vinci-client/src/test/resources/avro/PartialUpdateWithMapField.avsc
@@ -28,20 +28,20 @@
       "default": null
     },
     {
-      "name": "intMapField",
+      "name": "stringMapField",
       "type": {
         "type": "map",
-        "values": "int"
+        "values": "string"
       },
       "default": {}
     },
     {
-      "name": "nullableIntMapField",
+      "name": "nullableStringMapField",
       "type": [
         "null",
         {
           "type": "map",
-          "values": "int"
+          "values": "string"
         }
       ],
       "default": null

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/schema/merge/SortBasedCollectionFieldOpHandler.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/schema/merge/SortBasedCollectionFieldOpHandler.java
@@ -1002,15 +1002,15 @@ public class SortBasedCollectionFieldOpHandler extends CollectionFieldOperationH
   }
 
   private Schema getArraySchema(GenericRecord currValueRecord, String arrayFieldName) {
-    Schema mapFieldSchema = currValueRecord.getSchema().getField(arrayFieldName).schema();
-    switch (mapFieldSchema.getType()) {
+    Schema arrayFieldSchema = currValueRecord.getSchema().getField(arrayFieldName).schema();
+    switch (arrayFieldSchema.getType()) {
       case ARRAY:
-        return mapFieldSchema;
+        return arrayFieldSchema;
       case UNION:
-        return getSchemaFromNullableCollectionSchema(mapFieldSchema, Schema.Type.ARRAY);
+        return getSchemaFromNullableCollectionSchema(arrayFieldSchema, Schema.Type.ARRAY);
 
       default:
-        throw new IllegalStateException("Expect a map or a union schema. Got: " + mapFieldSchema);
+        throw new IllegalStateException("Expect an array or a union schema. Got: " + arrayFieldSchema);
     }
   }
 

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/schema/merge/SortBasedCollectionFieldOpHandler.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/schema/merge/SortBasedCollectionFieldOpHandler.java
@@ -525,8 +525,7 @@ public class SortBasedCollectionFieldOpHandler extends CollectionFieldOperationH
   }
 
   private Comparator<Object> getListElementComparator(GenericRecord currValueRecord, String fieldName) {
-    Supplier<Schema> elementSchemaSupplier =
-        () -> currValueRecord.getSchema().getField(fieldName).schema().getElementType();
+    Supplier<Schema> elementSchemaSupplier = () -> getArraySchema(currValueRecord, fieldName).getElementType();
     // TODO: handle the situation where two elements have different schemas (e.g. element schema evolution). Assume
     // element schemas are always the same for now.
     return (o1, o2) -> this.avroElementComparator.compare(o1, o2, elementSchemaSupplier.get());
@@ -995,14 +994,27 @@ public class SortBasedCollectionFieldOpHandler extends CollectionFieldOperationH
       case MAP:
         return mapFieldSchema;
       case UNION:
-        return getSchemaFromNullableSchema(mapFieldSchema, Schema.Type.MAP);
+        return getSchemaFromNullableCollectionSchema(mapFieldSchema, Schema.Type.MAP);
 
       default:
         throw new IllegalStateException("Expect a map or a union schema. Got: " + mapFieldSchema);
     }
   }
 
-  private Schema getSchemaFromNullableSchema(Schema nullableSchema, Schema.Type expectedNullableType) {
+  private Schema getArraySchema(GenericRecord currValueRecord, String arrayFieldName) {
+    Schema mapFieldSchema = currValueRecord.getSchema().getField(arrayFieldName).schema();
+    switch (mapFieldSchema.getType()) {
+      case ARRAY:
+        return mapFieldSchema;
+      case UNION:
+        return getSchemaFromNullableCollectionSchema(mapFieldSchema, Schema.Type.ARRAY);
+
+      default:
+        throw new IllegalStateException("Expect a map or a union schema. Got: " + mapFieldSchema);
+    }
+  }
+
+  private Schema getSchemaFromNullableCollectionSchema(Schema nullableSchema, Schema.Type expectedNullableType) {
     if (nullableSchema.getType() != Schema.Type.UNION) {
       throw new IllegalStateException(
           "Expect nullable " + expectedNullableType + " schema. But got: " + nullableSchema);


### PR DESCRIPTION

<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci], [server], [controller],
[router], [samza], [vpj], [fast-client], [thin-client], [alpini],
[admin-tool], [test], [build], [doc], [script]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## [server] Fix array comparator schema bug in nullable array field in A/A Partial Update
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

This PR fixes bug that list object comparator fail to parse array schema in the nullable array field. This PR fixes the issue by parsing the union field and fetch the array branch.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
Add more unit tests to cover different scenarios. 

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.