### PR TITLE
[da-vinci][server] Introduced configs to control maximum database size

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
@@ -29,6 +29,8 @@ import static com.linkedin.venice.ConfigKeys.SERVER_CONSUMER_POOL_SIZE_PER_KAFKA
 import static com.linkedin.venice.ConfigKeys.SERVER_DATABASE_CHECKSUM_VERIFICATION_ENABLED;
 import static com.linkedin.venice.ConfigKeys.SERVER_DATABASE_LOOKUP_QUEUE_CAPACITY;
 import static com.linkedin.venice.ConfigKeys.SERVER_DATABASE_MEMORY_STATS_ENABLED;
+import static com.linkedin.venice.ConfigKeys.SERVER_DATABASE_SIZE_LIMIT;
+import static com.linkedin.venice.ConfigKeys.SERVER_DATABASE_SIZE_MEASURE_INTERVAL;
 import static com.linkedin.venice.ConfigKeys.SERVER_DATABASE_SYNC_BYTES_INTERNAL_FOR_DEFERRED_WRITE_MODE;
 import static com.linkedin.venice.ConfigKeys.SERVER_DATABASE_SYNC_BYTES_INTERNAL_FOR_TRANSACTIONAL_MODE;
 import static com.linkedin.venice.ConfigKeys.SERVER_DB_READ_ONLY_FOR_BATCH_ONLY_STORE_ENABLED;
@@ -244,6 +246,10 @@ public class VeniceServerConfig extends VeniceClusterConfig {
 
   private final double diskFullThreshold;
 
+  private final long databaseSizeLimit;
+
+  private final long databaseSizeMeasurementInterval;
+
   private final int partitionGracefulDropDelaySeconds;
 
   private final long leakedResourceCleanUpIntervalInMS;
@@ -436,6 +442,9 @@ public class VeniceServerConfig extends VeniceClusterConfig {
     databaseSyncBytesIntervalForDeferredWriteMode =
         serverProperties.getSizeInBytes(SERVER_DATABASE_SYNC_BYTES_INTERNAL_FOR_DEFERRED_WRITE_MODE, 60 * 1024 * 1024);
     diskFullThreshold = serverProperties.getDouble(SERVER_DISK_FULL_THRESHOLD, 0.95);
+    databaseSizeLimit = serverProperties.getSizeInBytes(SERVER_DATABASE_SIZE_LIMIT, -1); // -1 means no limit
+    databaseSizeMeasurementInterval =
+        serverProperties.getSizeInBytes(SERVER_DATABASE_SIZE_MEASURE_INTERVAL, 256 * 1024 * 1024); // Default: 256MB
     partitionGracefulDropDelaySeconds = serverProperties.getInt(SERVER_PARTITION_GRACEFUL_DROP_DELAY_IN_SECONDS, 30);
     leakedResourceCleanUpIntervalInMS =
         TimeUnit.MINUTES.toMillis(serverProperties.getLong(SERVER_LEAKED_RESOURCE_CLEAN_UP_INTERVAL_IN_MINUTES, 10));
@@ -697,6 +706,14 @@ public class VeniceServerConfig extends VeniceClusterConfig {
 
   public double getDiskFullThreshold() {
     return diskFullThreshold;
+  }
+
+  public long getDatabaseSizeLimit() {
+    return databaseSizeLimit;
+  }
+
+  public long getDatabaseSizeMeasurementInterval() {
+    return databaseSizeMeasurementInterval;
   }
 
   public int getPartitionGracefulDropDelaySeconds() {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionService.java
@@ -193,6 +193,8 @@ public class KafkaStoreIngestionService extends AbstractVeniceService implements
 
   private final PubSubTopicRepository pubSubTopicRepository = new PubSubTopicRepository();
 
+  private final DiskUsage diskUsage;
+
   public KafkaStoreIngestionService(
       StorageEngineRepository storageEngineRepository,
       VeniceConfigLoader veniceConfigLoader,
@@ -448,9 +450,11 @@ public class KafkaStoreIngestionService extends AbstractVeniceService implements
      * Use the same diskUsage instance for all ingestion tasks; so that all the ingestion tasks can update the same
      * remaining disk space state to provide a more accurate alert.
      */
-    DiskUsage diskUsage = new DiskUsage(
+    diskUsage = new DiskUsage(
         veniceConfigLoader.getVeniceServerConfig().getDataBasePath(),
-        veniceConfigLoader.getVeniceServerConfig().getDiskFullThreshold());
+        veniceConfigLoader.getVeniceServerConfig().getDiskFullThreshold(),
+        veniceConfigLoader.getVeniceServerConfig().getDatabaseSizeLimit(),
+        veniceConfigLoader.getVeniceServerConfig().getDatabaseSizeMeasurementInterval());
 
     VeniceViewWriterFactory viewWriterFactory = new VeniceViewWriterFactory(veniceConfigLoader);
 
@@ -614,6 +618,7 @@ public class KafkaStoreIngestionService extends AbstractVeniceService implements
     Utils.closeQuietlyWithErrorLogged(storeBufferService);
     Utils.closeQuietlyWithErrorLogged(topicManagerRepository);
     Utils.closeQuietlyWithErrorLogged(topicManagerRepositoryJavaBased);
+    Utils.closeQuietlyWithErrorLogged(diskUsage);
     topicLockManager.removeAllLocks();
   }
 

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionServiceTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionServiceTest.java
@@ -112,6 +112,7 @@ public abstract class KafkaStoreIngestionServiceTest {
     doReturn(0.9d).when(mockVeniceServerConfig).getDiskFullThreshold();
     doReturn(Int2ObjectMaps.emptyMap()).when(mockVeniceServerConfig).getKafkaClusterIdToAliasMap();
     doReturn(Object2IntMaps.emptyMap()).when(mockVeniceServerConfig).getKafkaClusterUrlToIdMap();
+    doReturn(10l).when(mockVeniceServerConfig).getDatabaseSizeMeasurementInterval();
 
     // Consumer related configs for preparing kafka consumer service.
     doReturn(dummyKafkaUrl).when(mockVeniceServerConfig).getKafkaBootstrapServers();

--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -1239,6 +1239,17 @@ public class ConfigKeys {
   public static final String SERVER_DISK_FULL_THRESHOLD = "disk.full.threshold";
 
   /**
+   * Ingestion will be paused or fail when the disk usage hits either {@link #SERVER_DISK_FULL_THRESHOLD} or {@link #SERVER_DATABASE_SIZE_LIMIT}
+   */
+  public static final String SERVER_DATABASE_SIZE_LIMIT = "database.size.limit";
+
+  /**
+   * Database size measurement is an expensive operation, and we would like to make the measurement interval
+   * configurable to tune the performance.
+   */
+  public static final String SERVER_DATABASE_SIZE_MEASURE_INTERVAL = "database.size.measure.interval";
+
+  /**
    * If a request is slower than this, it will be reported as tardy in the router metrics
    */
   public static final String ROUTER_SINGLEGET_TARDY_LATENCY_MS = "router.singleget.tardy.latency.ms";

--- a/internal/venice-common/src/main/java/com/linkedin/venice/utils/DiskUsage.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/utils/DiskUsage.java
@@ -1,11 +1,23 @@
 package com.linkedin.venice.utils;
 
+import static com.linkedin.venice.utils.DiskUsage.DatabaseSizeLimiter.DEFAULT_DATABASE_SIZE_MEASURE_INTERVAL;
+import static java.lang.Thread.currentThread;
+
 import com.linkedin.venice.exceptions.VeniceException;
+import io.netty.util.concurrent.DefaultThreadFactory;
+import java.io.Closeable;
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.FileStore;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Supplier;
+import org.apache.commons.io.FileUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -21,9 +33,17 @@ import org.apache.logging.log4j.Logger;
  *
  * We calculate reserve space as 0.001 of required free space to allow 1000 concurrent tasks to write to disk without
  * risk of blowing past the disk full threshold and actually reaching 100% disk usage.
+ *
+ * We add another way to limit the total amount of data, which can be writen locally.
+ * For DaVinci use cases, the database folder can share the same disk as other components, such as logging or system files, so
+ * it is hard to limit the total size of the database by measuring the disk usage ratio, plus different DaVinci instances
+ * might have different database path setup as well.
+ * The database size is especially important when using DaVinci in-memory mode, and we would like to use this way to
+ * limit the maximum data mapped to memory (not fully accurate).
  */
-public class DiskUsage {
+public class DiskUsage implements Closeable {
   private static final Logger LOGGER = LogManager.getLogger(DiskUsage.class);
+
   private final String diskPath;
   private final long totalSpaceBytes;
   private final long freeSpaceBytesRequired; // less than this means disk full (over threshold)
@@ -36,11 +56,30 @@ public class DiskUsage {
   private long freeSpaceBytes; // This doesn't stay up-to-date, but is refreshed periodically
   private final AtomicLong reserveSpaceBytesRemaining = new AtomicLong();
 
+  private final DatabaseSizeLimiter databaseSizeLimiter;
+
   public DiskUsage(String path, double diskFullThreshold) {
-    this.diskPath = path;
+    this(path, diskFullThreshold, -1, DEFAULT_DATABASE_SIZE_MEASURE_INTERVAL);
+  }
+
+  public DiskUsage(
+      String path,
+      double diskFullThreshold,
+      long databaseSizeLimit,
+      long databaseSizeMeasurementInterval) {
+    if (databaseSizeMeasurementInterval <= 0) {
+      throw new IllegalArgumentException(
+          "Database size measurement interval should be positive, but got: " + databaseSizeMeasurementInterval);
+    }
     if (diskFullThreshold < 0 || diskFullThreshold > 1) {
       throw new IllegalArgumentException(
           "Disk full threshold must be a double between 0 and 1. " + diskFullThreshold + " is not valid");
+    }
+    this.diskPath = path;
+    if (databaseSizeLimit > 0) {
+      this.databaseSizeLimiter = new DatabaseSizeLimiter(path, databaseSizeLimit, databaseSizeMeasurementInterval);
+    } else {
+      this.databaseSizeLimiter = null;
     }
     try {
       this.disk = Files.getFileStore(Paths.get(path));
@@ -73,6 +112,9 @@ public class DiskUsage {
    * construction then it will return true.  Otherwise it returns false.
    */
   public boolean isDiskFull(long bytesWritten) {
+    if (databaseSizeLimiter != null && databaseSizeLimiter.hitDatabaseSizeLimit(bytesWritten)) {
+      return true;
+    }
     // Here we're using -1 to subtract the newly written data from the reserve space remaining.
     // If the reserve space remaining is still greater than 0, report disk not full. Otherwise,
     // check the actual state of the disk.
@@ -85,8 +127,130 @@ public class DiskUsage {
   }
 
   public String getDiskStatus() {
-    return "Disk at path: " + diskPath + " has " + totalSpaceBytes + " total bytes and " + freeSpaceBytes
-        + " bytes free.  " + "Disk is marked 'full' when there are less than " + freeSpaceBytesRequired
-        + " bytes free.";
+    StringBuilder sb = new StringBuilder();
+    if (databaseSizeLimiter != null) {
+      sb.append(databaseSizeLimiter.getDatabaseStatus()).append(", ");
+    }
+    sb.append("Disk at path: ")
+        .append(diskPath)
+        .append(" has ")
+        .append(totalSpaceBytes)
+        .append(" total bytes and ")
+        .append(freeSpaceBytes)
+        .append(" bytes free. ")
+        .append("Disk is marked 'full' when there are less than ")
+        .append(freeSpaceBytesRequired)
+        .append(" bytes free.");
+    return sb.toString();
+  }
+
+  @Override
+  public void close() throws IOException {
+    if (databaseSizeLimiter != null) {
+      databaseSizeLimiter.shutdown();
+    }
+  }
+
+  /**
+   * This class is used to measure whether the current database size exceeds the limit or not.
+   * It will measure the size after writing a configured amount of bytes, and the measurement
+   * won't be very accurate since the measurement is independent of the database write operation,
+   * and it was designed in this way to minimize the overhead of this class in the write path.
+   */
+  public static class DatabaseSizeLimiter {
+    private static final Logger LOGGER = LogManager.getLogger(DatabaseSizeLimiter.class);
+    public static final long DEFAULT_DATABASE_SIZE_MEASURE_INTERVAL = 256 * 1024 * 1024; // 256MB
+
+    private final String databasePath;
+    private final long databaseSizeLimit;
+    private final long databaseSizeMeasurementInterval;
+    private final AtomicLong currentDatabaseSize = new AtomicLong();
+    private final Supplier<Long> databaseSizeSupplier;
+    private final AtomicLong accumulatedByteSize = new AtomicLong();
+    private final AtomicBoolean hasOngoingMeasurement = new AtomicBoolean(false);
+    private final ExecutorService databaseSizeMeasurementExecutor =
+        Executors.newSingleThreadExecutor(new DefaultThreadFactory("Database_Size_Measurement"));
+    private boolean exceedDatabaseSizeLimit = false;
+
+    public DatabaseSizeLimiter(String databasePath, long databaseSizeLimit, long databaseSizeMeasurementInterval) {
+      this(
+          databasePath,
+          databaseSizeLimit,
+          databaseSizeMeasurementInterval,
+          () -> FileUtils.sizeOf(new File(databasePath)));
+    }
+
+    // For testing
+    public DatabaseSizeLimiter(
+        String databasePath,
+        long databaseSizeLimit,
+        long databaseSizeMeasurementInterval,
+        Supplier<Long> databaseSizeSupplier) {
+      this.databasePath = databasePath;
+      this.databaseSizeLimit = databaseSizeLimit;
+      this.databaseSizeMeasurementInterval = databaseSizeMeasurementInterval;
+      this.databaseSizeSupplier = databaseSizeSupplier;
+    }
+
+    public boolean hitDatabaseSizeLimit(long bytesWritten) {
+      if (databaseSizeLimit <= 0) {
+        return false;
+      }
+      if (exceedDatabaseSizeLimit) {
+        return true;
+      }
+      long accumulatedBytes = accumulatedByteSize.addAndGet(bytesWritten);
+      if (accumulatedBytes > databaseSizeMeasurementInterval && hasOngoingMeasurement.compareAndSet(false, true)) {
+        /**
+         * Reset the counter and submit a database measurement task.
+         *
+         * The {@link #accumulatedByteSize} won't be very accurate because of race condition, but it is fine since
+         * we would like to minimize the calls to measure the database size, which is an expensive operation.
+          */
+        accumulatedByteSize.set(0);
+        databaseSizeMeasurementExecutor.execute(() -> {
+          try {
+            long startTime = System.currentTimeMillis();
+            long databaseSize = databaseSizeSupplier.get();
+            currentDatabaseSize.set(databaseSize);
+            if (databaseSize >= databaseSizeLimit) {
+              exceedDatabaseSizeLimit = true;
+            }
+            LOGGER.info(
+                "Measured database size: {} for path: {}, and it took {} ms",
+                databaseSize,
+                databasePath,
+                LatencyUtils.getElapsedTimeInMs(startTime));
+          } catch (Exception e) {
+            LOGGER.error("Failed to measure the size of database path: {}", databasePath, e);
+          } finally {
+            hasOngoingMeasurement.set(false);
+          }
+        });
+      }
+      return exceedDatabaseSizeLimit;
+    }
+
+    public String getDatabaseStatus() {
+      StringBuilder sb = new StringBuilder("Database path: ").append(databasePath)
+          .append(", current database size: ")
+          .append(currentDatabaseSize.get())
+          .append("bytes")
+          .append(", and limit: ")
+          .append(databaseSizeLimit)
+          .append("bytes");
+      return sb.toString();
+    }
+
+    public void shutdown() {
+      databaseSizeMeasurementExecutor.shutdown();
+      try {
+        if (!databaseSizeMeasurementExecutor.awaitTermination(10, TimeUnit.SECONDS)) {
+          databaseSizeMeasurementExecutor.shutdownNow();
+        }
+      } catch (InterruptedException e) {
+        currentThread().interrupt();
+      }
+    }
   }
 }

--- a/internal/venice-common/src/test/java/com/linkedin/venice/utils/TestDiskUsage.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/utils/TestDiskUsage.java
@@ -4,6 +4,9 @@ import java.io.IOException;
 import java.nio.file.FileStore;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Supplier;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -24,5 +27,26 @@ public class TestDiskUsage {
     // set full threshold to 100%, disk must not report full
     DiskUsage notFullUsage = new DiskUsage(path, 0.999);
     Assert.assertFalse(notFullUsage.isDiskFull(1), "Disk must not report full: " + notFullUsage.getDiskStatus());
+  }
+
+  @Test
+  public void testDatabaseSizeLimiter() {
+    AtomicLong databaseSize = new AtomicLong(0);
+
+    String databasePath = "./";
+    long databaseSizeLimit = 100;
+    long measurementInterval = 10;
+    Supplier<Long> databaseSizeSupplier = () -> databaseSize.get();
+
+    DiskUsage.DatabaseSizeLimiter limiter =
+        new DiskUsage.DatabaseSizeLimiter(databasePath, databaseSizeLimit, measurementInterval, databaseSizeSupplier);
+    Assert.assertFalse(limiter.hitDatabaseSizeLimit(databaseSize.addAndGet(10)));
+    Assert.assertFalse(limiter.hitDatabaseSizeLimit(databaseSize.addAndGet(90)));
+
+    TestUtils.waitForNonDeterministicAssertion(3, TimeUnit.SECONDS, () -> {
+      Assert.assertTrue(limiter.hitDatabaseSizeLimit(databaseSize.addAndGet(10)));
+    });
+
+    limiter.shutdown();
   }
 }

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestDiskDatabaseLimiter.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestDiskDatabaseLimiter.java
@@ -1,0 +1,78 @@
+package com.linkedin.venice.endToEnd;
+
+import static com.linkedin.davinci.store.rocksdb.RocksDBServerConfig.ROCKSDB_PLAIN_TABLE_FORMAT_ENABLED;
+import static com.linkedin.venice.ConfigKeys.PERSISTENCE_TYPE;
+import static com.linkedin.venice.ConfigKeys.ROUTER_CLIENT_DECOMPRESSION_ENABLED;
+import static com.linkedin.venice.ConfigKeys.SERVER_DATABASE_CHECKSUM_VERIFICATION_ENABLED;
+import static com.linkedin.venice.ConfigKeys.SERVER_DATABASE_SIZE_LIMIT;
+import static com.linkedin.venice.ConfigKeys.SERVER_DATABASE_SIZE_MEASURE_INTERVAL;
+import static com.linkedin.venice.ConfigKeys.SERVER_DATABASE_SYNC_BYTES_INTERNAL_FOR_DEFERRED_WRITE_MODE;
+import static com.linkedin.venice.ConfigKeys.SERVER_PROMOTION_TO_LEADER_REPLICA_DELAY_SECONDS;
+import static com.linkedin.venice.utils.IntegrationTestPushUtils.defaultVPJProps;
+import static com.linkedin.venice.utils.IntegrationTestPushUtils.runVPJ;
+import static com.linkedin.venice.utils.TestWriteUtils.STRING_SCHEMA;
+import static com.linkedin.venice.utils.TestWriteUtils.getTempDataDirectory;
+import static com.linkedin.venice.utils.TestWriteUtils.writeSimpleAvroFileWithCustomSize;
+
+import com.linkedin.venice.controllerapi.ControllerClient;
+import com.linkedin.venice.controllerapi.UpdateStoreQueryParams;
+import com.linkedin.venice.exceptions.VeniceException;
+import com.linkedin.venice.integration.utils.ServiceFactory;
+import com.linkedin.venice.integration.utils.VeniceClusterWrapper;
+import com.linkedin.venice.meta.PersistenceType;
+import com.linkedin.venice.meta.Store;
+import com.linkedin.venice.utils.Utils;
+import java.io.File;
+import java.io.IOException;
+import java.util.Properties;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+
+public class TestDiskDatabaseLimiter {
+  protected VeniceClusterWrapper veniceCluster;
+
+  @BeforeClass(alwaysRun = true)
+  public void setUp() {
+    veniceCluster = ServiceFactory.getVeniceCluster(1, 0, 0);
+    Properties serverProperties = new Properties();
+    serverProperties.put(PERSISTENCE_TYPE, PersistenceType.ROCKS_DB);
+    serverProperties.put(SERVER_PROMOTION_TO_LEADER_REPLICA_DELAY_SECONDS, Long.toString(1L));
+    serverProperties.setProperty(ROCKSDB_PLAIN_TABLE_FORMAT_ENABLED, "false");
+    serverProperties.setProperty(SERVER_DATABASE_CHECKSUM_VERIFICATION_ENABLED, "true");
+    serverProperties.setProperty(SERVER_DATABASE_SYNC_BYTES_INTERNAL_FOR_DEFERRED_WRITE_MODE, "300");
+    serverProperties.setProperty(SERVER_DATABASE_SIZE_LIMIT, Long.toString(10));
+    serverProperties.setProperty(SERVER_DATABASE_SIZE_MEASURE_INTERVAL, Long.toString(10));
+    veniceCluster.addVeniceServer(new Properties(), serverProperties);
+    veniceCluster.addVeniceServer(new Properties(), serverProperties);
+
+    Properties routerProperties = new Properties();
+    routerProperties.put(ROUTER_CLIENT_DECOMPRESSION_ENABLED, "true");
+    veniceCluster.addVeniceRouter(routerProperties);
+  }
+
+  @AfterClass(alwaysRun = true)
+  public void cleanUp() {
+    Utils.closeQuietlyWithErrorLogged(veniceCluster);
+  }
+
+  @Test(expectedExceptions = VeniceException.class, expectedExceptionsMessageRegExp = "Push job error.*")
+  public void testPushJobFailureWhenHittingDatabaseLimit() {
+    String storeName = Utils.getUniqueString("test_empty_push_store");
+    try (ControllerClient controllerClient =
+        new ControllerClient(veniceCluster.getClusterName(), veniceCluster.getAllControllersURLs())) {
+      controllerClient.createNewStore(storeName, "owner", STRING_SCHEMA, STRING_SCHEMA);
+      controllerClient
+          .updateStore(storeName, new UpdateStoreQueryParams().setStorageQuotaInByte(Store.UNLIMITED_STORAGE_QUOTA));
+      File inputDir = getTempDataDirectory();
+      String inputDirPath = "file://" + inputDir.getAbsolutePath();
+      writeSimpleAvroFileWithCustomSize(inputDir, 1000, 1000, 5000);
+
+      Properties vpjProperties = defaultVPJProps(veniceCluster, inputDirPath, storeName);
+      runVPJ(vpjProperties, 1, controllerClient);
+    } catch (IOException e) {
+      throw new VeniceException(e);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
This code change introduces two configs:
/**
   * Ingestion will be paused or fail when the disk usage hits either {@link #SERVER_DISK_FULL_THRESHOLD} or {@link #SERVER_DATABASE_SIZE_LIMIT}
   * Default: -1, disabled. */ public static final String SERVER_DATABASE_SIZE_LIMIT = "database.size.limit";

  /**
   * Database size measurement is an expensive operation, and we would like to make the measurement interval
   * configurable to tune the performance.
   * Default: 256MB */ public static final String SERVER_DATABASE_SIZE_MEASURE_INTERVAL = "database.size.measure.interval";

If the persisted database size exceeds the configured maximum size, the ingestion will fail for batch push and pause for hybrid stores. This feature is mainly introduced for PlainTable use cases especially with DaVinci since Venice will try to mmap all the data files into memory, and it is good to have a uppper limit to avoid OOM.

<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci], [server], [controller],
[router], [samza], [vpj], [fast-client], [thin-client], [alpini],
[admin-tool], [test], [build], [doc], [script]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->






## How was this PR tested?
CI

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [X] Yes. Make sure to explain your proposed changes and call out the behavior change.
Please check the above new configs.