### PR TITLE
[admin-tool] Support passing options to cluster_health_stores to enable disabled replicas

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -596,6 +596,7 @@ ext.createDiffFile = { ->
         ':!services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java',
         ':!internal/venice-test-common/*',
         ':!services/venice-server/src/main/java/com/linkedin/venice/server/VeniceServer.java',
+        ':!internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerClient.java',
 
         // Other files that have tests but are not executed in the regular unit test task
         ':!internal/alpini/*'

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/AdminTool.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/AdminTool.java
@@ -106,6 +106,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
@@ -306,7 +307,7 @@ public class AdminTool {
           printStorageNodeList();
           break;
         case CLUSTER_HEALTH_INSTANCES:
-          printInstancesStatuses();
+          printInstancesStatuses(cmd);
           break;
         case CLUSTER_HEALTH_STORES:
           printStoresStatuses();
@@ -1175,8 +1176,10 @@ public class AdminTool {
     printObject(nodeResponse);
   }
 
-  private static void printInstancesStatuses() {
-    MultiNodesStatusResponse nodeResponse = controllerClient.listInstancesStatuses();
+  private static void printInstancesStatuses(CommandLine cmd) {
+    String enableReplicas = getOptionalArgument(cmd, Arg.ENABLE_DISABLED_REPLICA);
+    MultiNodesStatusResponse nodeResponse =
+        controllerClient.listInstancesStatuses(Objects.equals(enableReplicas, "true"));
     printObject(nodeResponse);
   }
 

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/AdminTool.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/AdminTool.java
@@ -106,7 +106,6 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
@@ -1177,9 +1176,8 @@ public class AdminTool {
   }
 
   private static void printInstancesStatuses(CommandLine cmd) {
-    String enableReplicas = getOptionalArgument(cmd, Arg.ENABLE_DISABLED_REPLICA);
-    MultiNodesStatusResponse nodeResponse =
-        controllerClient.listInstancesStatuses(Objects.equals(enableReplicas, "true"));
+    String enableReplicas = getOptionalArgument(cmd, Arg.ENABLE_DISABLED_REPLICA, "false");
+    MultiNodesStatusResponse nodeResponse = controllerClient.listInstancesStatuses(enableReplicas.equals("true"));
     printObject(nodeResponse);
   }
 

--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerApiConstants.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerApiConstants.java
@@ -203,4 +203,6 @@ public class ControllerApiConstants {
   public static final String PERSONA_STORES = "persona_stores";
   public static final String PERSONA_QUOTA = "persona_quota";
   public static final String LATEST_SUPERSET_SCHEMA_ID = "latest_superset_schema_id";
+  public static final String ENABLE_DISABLED_REPLICAS = "ENABLE_DISBLED_REPLICAS";
+
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerApiConstants.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerApiConstants.java
@@ -203,6 +203,6 @@ public class ControllerApiConstants {
   public static final String PERSONA_STORES = "persona_stores";
   public static final String PERSONA_QUOTA = "persona_quota";
   public static final String LATEST_SUPERSET_SCHEMA_ID = "latest_superset_schema_id";
-  public static final String ENABLE_DISABLED_REPLICAS = "ENABLE_DISBLED_REPLICAS";
+  public static final String ENABLE_DISABLED_REPLICAS = "ENABLE_DISABLED_REPLICAS";
 
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerApiConstants.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerApiConstants.java
@@ -203,6 +203,6 @@ public class ControllerApiConstants {
   public static final String PERSONA_STORES = "persona_stores";
   public static final String PERSONA_QUOTA = "persona_quota";
   public static final String LATEST_SUPERSET_SCHEMA_ID = "latest_superset_schema_id";
-  public static final String ENABLE_DISABLED_REPLICAS = "ENABLE_DISABLED_REPLICAS";
+  public static final String ENABLE_DISABLED_REPLICAS = "enable_disabled_replicas";
 
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerClient.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerClient.java
@@ -11,6 +11,7 @@ import static com.linkedin.venice.controllerapi.ControllerApiConstants.DEFER_VER
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.DERIVED_SCHEMA;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.DERIVED_SCHEMA_ID;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.DEST_FABRIC;
+import static com.linkedin.venice.controllerapi.ControllerApiConstants.ENABLE_DISABLED_REPLICAS;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.EXECUTION_ID;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.EXPECTED_ROUTER_COUNT;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.FABRIC;
@@ -734,8 +735,12 @@ public class ControllerClient implements Closeable {
     return request(ControllerRoute.LIST_NODES, newParams(), MultiNodeResponse.class);
   }
 
-  public MultiNodesStatusResponse listInstancesStatuses() {
-    return request(ControllerRoute.ClUSTER_HEALTH_INSTANCES, newParams(), MultiNodesStatusResponse.class);
+  public MultiNodesStatusResponse listInstancesStatuses(boolean enableReplicas) {
+    QueryParams params = newParams();
+    if (enableReplicas) {
+      params.add(ENABLE_DISABLED_REPLICAS, "true");
+    }
+    return request(ControllerRoute.ClUSTER_HEALTH_INSTANCES, params, MultiNodesStatusResponse.class);
   }
 
   public MultiReplicaResponse listReplicas(String storeName, int version) {

--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerRoute.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerRoute.java
@@ -19,6 +19,7 @@ import static com.linkedin.venice.controllerapi.ControllerApiConstants.DERIVED_S
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.DEST_FABRIC;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.DISABLE_DAVINCI_PUSH_STATUS_STORE;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.DISABLE_META_STORE;
+import static com.linkedin.venice.controllerapi.ControllerApiConstants.ENABLE_DISABLED_REPLICAS;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.ENABLE_READS;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.ENABLE_WRITES;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.ETLED_PROXY_USER_ACCOUNT;
@@ -140,8 +141,9 @@ public enum ControllerRoute {
   LIST_CHILD_CLUSTERS("/list_child_clusters", HttpMethod.GET, Collections.emptyList()),
   LIST_NODES("/list_instances", HttpMethod.GET, Collections.emptyList()),
   CLUSTER_HEALTH_STORES("/cluster_health_stores", HttpMethod.GET, Collections.emptyList()),
-  ClUSTER_HEALTH_INSTANCES("/cluster_health_instances", HttpMethod.GET, Collections.emptyList(), "fd"),
-  LIST_REPLICAS("/list_replicas", HttpMethod.GET, Arrays.asList(NAME, VERSION)),
+  ClUSTER_HEALTH_INSTANCES(
+      "/cluster_health_instances", HttpMethod.GET, Collections.emptyList(), ENABLE_DISABLED_REPLICAS
+  ), LIST_REPLICAS("/list_replicas", HttpMethod.GET, Arrays.asList(NAME, VERSION)),
   NODE_REPLICAS("/storage_node_replicas", HttpMethod.GET, Collections.singletonList(STORAGE_NODE_ID)),
   NODE_REMOVABLE(
       "/node_removable", HttpMethod.GET, Collections.singletonList(STORAGE_NODE_ID), INSTANCE_VIEW,

--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerRoute.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerRoute.java
@@ -140,7 +140,7 @@ public enum ControllerRoute {
   LIST_CHILD_CLUSTERS("/list_child_clusters", HttpMethod.GET, Collections.emptyList()),
   LIST_NODES("/list_instances", HttpMethod.GET, Collections.emptyList()),
   CLUSTER_HEALTH_STORES("/cluster_health_stores", HttpMethod.GET, Collections.emptyList()),
-  ClUSTER_HEALTH_INSTANCES("/cluster_health_instances", HttpMethod.GET, Collections.emptyList()),
+  ClUSTER_HEALTH_INSTANCES("/cluster_health_instances", HttpMethod.GET, Collections.emptyList(), "fd"),
   LIST_REPLICAS("/list_replicas", HttpMethod.GET, Arrays.asList(NAME, VERSION)),
   NODE_REPLICAS("/storage_node_replicas", HttpMethod.GET, Collections.singletonList(STORAGE_NODE_ID)),
   NODE_REMOVABLE(

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/controller/server/TestAdminSparkServer.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/controller/server/TestAdminSparkServer.java
@@ -104,7 +104,7 @@ public class TestAdminSparkServer extends AbstractTestAdminSparkServer {
 
   @Test(timeOut = TEST_TIMEOUT)
   public void controllerClientCanQueryInstanceStatusInCluster() {
-    MultiNodesStatusResponse nodeResponse = controllerClient.listInstancesStatuses();
+    MultiNodesStatusResponse nodeResponse = controllerClient.listInstancesStatuses(false);
     Assert.assertFalse(nodeResponse.isError(), nodeResponse.getError());
     Assert.assertEquals(nodeResponse.getInstancesStatusMap().size(), STORAGE_NODE_COUNT, "Node count does not match");
     Assert.assertEquals(

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestHybrid.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestHybrid.java
@@ -438,7 +438,7 @@ public class TestHybrid {
           assertTrue(versions.contains(3));
         });
 
-        controllerClient.listInstancesStatuses()
+        controllerClient.listInstancesStatuses(false)
             .getInstancesStatusMap()
             .keySet()
             .forEach(
@@ -459,7 +459,7 @@ public class TestHybrid {
               storeStatus.get(storeName),
               "Should be UNDER_REPLICATED");
 
-          Map<String, String> instanceStatus = controllerClient.listInstancesStatuses().getInstancesStatusMap();
+          Map<String, String> instanceStatus = controllerClient.listInstancesStatuses(false).getInstancesStatusMap();
           Assert.assertTrue(
               instanceStatus.entrySet()
                   .stream()

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/NodesAndReplicas.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/NodesAndReplicas.java
@@ -1,6 +1,7 @@
 package com.linkedin.venice.controller.server;
 
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.CLUSTER;
+import static com.linkedin.venice.controllerapi.ControllerApiConstants.ENABLE_DISABLED_REPLICAS;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.INSTANCE_VIEW;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.LOCKED_NODE_ID_LIST_SEPARATOR;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.LOCKED_STORAGE_NODE_IDS;
@@ -94,7 +95,7 @@ public class NodesAndReplicas extends AbstractRoute {
       try {
         AdminSparkServer.validateParams(request, ClUSTER_HEALTH_INSTANCES.getParams(), admin);
         responseObject.setCluster(request.queryParams(CLUSTER));
-        String value = AdminSparkServer.getOptionalParameterValue(request, "enable-disabled-replicas");
+        String value = AdminSparkServer.getOptionalParameterValue(request, ENABLE_DISABLED_REPLICAS);
         Map<String, String> nodesStatusesMap =
             admin.getStorageNodesStatus(responseObject.getCluster(), Objects.equals(value, "true"));
         responseObject.setInstancesStatusMap(nodesStatusesMap);


### PR DESCRIPTION
## Support passing options to cluster_health_stores to enable disabled replicas
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Add manual tooling to enable disabled replicas through admin-tool `cluster-health-instances` command to take in optional parameter --enable-disabled-replicas which will call helix endpoint to reenable disabled replicas  which were previously disabled during some ingestion errors.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
CI
## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.