### PR TITLE
[router][fast-client] Picked up the new connect timeout builder from httpclient5

### DIFF
--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/httpclient5/HttpClient5Utils.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/httpclient5/HttpClient5Utils.java
@@ -2,6 +2,7 @@ package com.linkedin.venice.httpclient5;
 
 import java.util.concurrent.TimeUnit;
 import javax.net.ssl.SSLContext;
+import org.apache.hc.client5.http.config.ConnectionConfig;
 import org.apache.hc.client5.http.config.RequestConfig;
 import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient;
 import org.apache.hc.client5.http.impl.async.HttpAsyncClients;
@@ -83,11 +84,15 @@ public class HttpClient5Utils {
       final CloseableHttpAsyncClient client = HttpAsyncClients.customHttp2()
           .setTlsStrategy(tlsStrategy)
           .setIOReactorConfig(ioReactorConfig)
+          .setDefaultConnectionConfig(
+              ConnectionConfig.custom()
+                  .setConnectTimeout(CONNECT_TIMEOUT_IN_MILLISECONDS)
+                  .setSocketTimeout(CONNECT_TIMEOUT_IN_MILLISECONDS)
+                  .build())
           .setDefaultRequestConfig(
               RequestConfig.custom()
                   .setResponseTimeout(Timeout.ofMilliseconds(requestTimeOutInMilliseconds))
                   .setConnectionRequestTimeout(CONNECT_TIMEOUT_IN_MILLISECONDS)
-                  .setConnectTimeout(CONNECT_TIMEOUT_IN_MILLISECONDS)
                   .build())
           .build();
 


### PR DESCRIPTION
## Summary

With the latest bump of httpclient5 lib, we saw a lot of ConnectionClosedException in some prod cluster and it seems this is caused by the newly introduced connection config builder, which Venice wasn't using.

I manually tested this code change in prod, and the exception disapeared.

<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci], [server], [controller],
[router], [samza], [vpj], [fast-client], [thin-client], [alpini],
[admin-tool], [test], [build], [doc], [script]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->


## How was this PR tested?
CI

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.