### PR TITLE
[server] Do not emit per store total metrics

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/AbstractVeniceAggVersionedStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/AbstractVeniceAggVersionedStats.java
@@ -59,12 +59,7 @@ public abstract class AbstractVeniceAggVersionedStats<STATS, STATS_REPORTER exte
 
   protected void recordVersionedAndTotalStat(String storeName, int version, Consumer<STATS> function) {
     VeniceVersionedStats<STATS, STATS_REPORTER> stats = getVersionedStats(storeName);
-    Utils.computeIfNotNull(stats.getTotalStats(), function);
     Utils.computeIfNotNull(stats.getStats(version), function);
-  }
-
-  protected STATS getTotalStats(String storeName) {
-    return getVersionedStats(storeName).getTotalStats();
   }
 
   protected STATS getStats(String storeName, int version) {
@@ -196,7 +191,7 @@ public abstract class AbstractVeniceAggVersionedStats<STATS, STATS_REPORTER exte
    */
 
   /**
-   * Some versioned stats might always increasing; in this case, the value in the total stats should be updated with
+   * Some versioned stats might be always increasing; in this case, the value in the total stats should be updated with
    * the aggregated values across the new version list.
    */
   protected void updateTotalStats(String storeName) {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/AggVersionedDIVStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/AggVersionedDIVStats.java
@@ -177,6 +177,5 @@ public class AggVersionedDIVStats extends AbstractVeniceAggVersionedStats<DIVSta
     IntConsumer versionConsumer = v -> Utils
         .computeIfNotNull(getStats(storeName, v), stat -> totalStatCount.addAndGet(statValueSupplier.apply(stat)));
     existingVersions.forEach(versionConsumer);
-    Utils.computeIfNotNull(getTotalStats(storeName), stat -> statsUpdater.accept(stat, totalStatCount.get()));
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/AggVersionedStorageEngineStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/AggVersionedStorageEngineStats.java
@@ -1,6 +1,7 @@
 package com.linkedin.davinci.stats;
 
 import com.linkedin.davinci.store.AbstractStorageEngine;
+import com.linkedin.venice.common.VeniceSystemStoreUtils;
 import com.linkedin.venice.meta.ReadOnlyStoreRepository;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.stats.Gauge;
@@ -30,6 +31,9 @@ public class AggVersionedStorageEngineStats extends
   public void setStorageEngine(String topicName, AbstractStorageEngine storageEngine) {
     if (!Version.isVersionTopicOrStreamReprocessingTopic(topicName)) {
       LOGGER.warn("Invalid topic name: {}", topicName);
+      return;
+    }
+    if (VeniceSystemStoreUtils.isSystemStore(topicName)) {
       return;
     }
     String storeName = Version.parseStoreFromKafkaTopicName(topicName);

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/VeniceVersionedStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/VeniceVersionedStats.java
@@ -19,7 +19,6 @@ public class VeniceVersionedStats<STATS, STATS_REPORTER extends AbstractVeniceSt
   private final VeniceVersionedStatsReporter<STATS, STATS_REPORTER> reporters;
 
   private final Supplier<STATS> statsInitiator;
-  private final STATS totalStats;
 
   public VeniceVersionedStats(
       MetricsRepository metricsRepository,
@@ -30,13 +29,6 @@ public class VeniceVersionedStats<STATS, STATS_REPORTER extends AbstractVeniceSt
     this.versionedStats = new Int2ObjectOpenHashMap<>();
     this.reporters = new VeniceVersionedStatsReporter<>(metricsRepository, storeName, reporterSupplier);
     this.statsInitiator = statsInitiator;
-
-    this.totalStats = statsInitiator.get();
-    reporters.setTotalStats(totalStats);
-  }
-
-  protected STATS getTotalStats() {
-    return totalStats;
   }
 
   public void registerConditionalStats() {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/VeniceVersionedStatsReporter.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/VeniceVersionedStatsReporter.java
@@ -20,7 +20,6 @@ public class VeniceVersionedStatsReporter<STATS, STATS_REPORTER extends Abstract
 
   private final STATS_REPORTER currentStatsReporter;
   private final STATS_REPORTER futureStatsReporter;
-  private final STATS_REPORTER totalStatsReporter;
   private final boolean isSystemStore;
 
   public VeniceVersionedStatsReporter(
@@ -50,10 +49,8 @@ public class VeniceVersionedStatsReporter<STATS, STATS_REPORTER extends Abstract
     this.currentStatsReporter = statsSupplier.get(metricsRepository, storeName + "_current");
     if (!isSystemStore) {
       this.futureStatsReporter = statsSupplier.get(metricsRepository, storeName + "_future");
-      this.totalStatsReporter = statsSupplier.get(metricsRepository, storeName + "_total");
     } else {
       this.futureStatsReporter = null;
-      this.totalStatsReporter = null;
     }
   }
 
@@ -61,7 +58,6 @@ public class VeniceVersionedStatsReporter<STATS, STATS_REPORTER extends Abstract
     this.currentStatsReporter.registerConditionalStats();
     if (!isSystemStore) {
       this.futureStatsReporter.registerConditionalStats();
-      this.totalStatsReporter.registerConditionalStats();
     }
   }
 
@@ -69,7 +65,6 @@ public class VeniceVersionedStatsReporter<STATS, STATS_REPORTER extends Abstract
     this.currentStatsReporter.unregisterStats();
     if (!isSystemStore) {
       this.futureStatsReporter.unregisterStats();
-      this.totalStatsReporter.unregisterStats();
     }
     super.unregisterAllSensors();
   }
@@ -90,10 +85,6 @@ public class VeniceVersionedStatsReporter<STATS, STATS_REPORTER extends Abstract
   public void setFutureStats(int version, STATS stats) {
     futureVersion = version;
     linkStatsWithReporter(futureStatsReporter, stats);
-  }
-
-  public void setTotalStats(STATS totalStats) {
-    linkStatsWithReporter(totalStatsReporter, totalStats);
   }
 
   private void linkStatsWithReporter(STATS_REPORTER reporter, STATS stats) {

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/stats/RouterHttpRequestStats.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/stats/RouterHttpRequestStats.java
@@ -1,6 +1,7 @@
 package com.linkedin.venice.router.stats;
 
 import com.linkedin.alpini.router.monitoring.ScatterGatherStats;
+import com.linkedin.venice.common.VeniceSystemStoreUtils;
 import com.linkedin.venice.read.RequestType;
 import com.linkedin.venice.stats.AbstractVeniceHttpStats;
 import com.linkedin.venice.stats.LambdaStat;
@@ -148,7 +149,7 @@ public class RouterHttpRequestStats extends AbstractVeniceHttpStats {
     inFlightRequestSensor = registerSensor("in_flight_request_count", new Min(), new Max(0), new Avg());
 
     String responseSizeSensorName = "response_size";
-    if (isKeyValueProfilingEnabled) {
+    if (isKeyValueProfilingEnabled && !VeniceSystemStoreUtils.isSystemStore(storeName)) {
       String keySizeSensorName = "key_size_in_byte";
       keySizeSensor = registerSensor(
           keySizeSensorName,


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci], [server], [controller],
[router], [samza], [vpj], [fast-client], [thin-client], [alpini],
[admin-tool], [test], [build], [doc], [script]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Do not emit per store total metrics
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Since each store now just emit current and future metrics, total  per store metric may be not be that useful. This PR removes per store total metric for ingestion path.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
CI build
## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.