### PR TITLE
[fc] retry for cluster discovery

### DIFF
--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/meta/RequestBasedMetadata.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/meta/RequestBasedMetadata.java
@@ -122,13 +122,13 @@ public class RequestBasedMetadata extends AbstractStoreMetadata {
   @Override
   public void start() {
     // perform cluster discovery work upfront and retrieve the server d2 service name
-    discoverD2Service(false);
+    discoverD2Service();
 
     // build a base for future metadata updates then start periodic refresh
     refresh();
   }
 
-  private void discoverD2Service(boolean retryOnFailure) {
+  private void discoverD2Service() {
     if (isServiceDiscovered) {
       return;
     }
@@ -137,8 +137,7 @@ public class RequestBasedMetadata extends AbstractStoreMetadata {
         return;
       }
       transportClient.setServiceName(clusterDiscoveryD2ServiceName);
-      String serverD2ServiceName =
-          d2ServiceDiscovery.find(transportClient, storeName, retryOnFailure).getServerD2Service();
+      String serverD2ServiceName = d2ServiceDiscovery.find(transportClient, storeName, true).getServerD2Service();
       transportClient.setServiceName(serverD2ServiceName);
       isServiceDiscovered = true;
     }
@@ -251,7 +250,7 @@ public class RequestBasedMetadata extends AbstractStoreMetadata {
       if (!onDemandRefresh) {
         LOGGER.warn("Metadata fetch operation has failed with exception {}", e.getMessage());
         isServiceDiscovered = false;
-        discoverD2Service(true);
+        discoverD2Service();
         updateCache(true);
       } else {
         // pass the error along if the on demand refresh also fails

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/fastclient/utils/AbstractClientEndToEndSetup.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/fastclient/utils/AbstractClientEndToEndSetup.java
@@ -118,6 +118,7 @@ public abstract class AbstractClientEndToEndSetup {
 
     prepareData();
     prepareMetaSystemStore();
+    waitForRouterD2();
   }
 
   protected void prepareData() throws Exception {
@@ -197,6 +198,22 @@ public abstract class AbstractClientEndToEndSetup {
           true,
           () -> assertNotNull(metaClient.get(replicaStatusKey).get()));
     }
+  }
+
+  private void waitForRouterD2() {
+    AvroGenericStoreClient<String, GenericRecord> thinClient =
+        com.linkedin.venice.client.store.ClientFactory.getAndStartGenericAvroClient(
+            com.linkedin.venice.client.store.ClientConfig.defaultGenericClientConfig(storeName)
+                .setVeniceURL(veniceCluster.getRandomRouterSslURL())
+                .setSslFactory(SslUtils.getVeniceLocalSslFactory())
+                .setD2Client(d2Client)
+                .setD2ServiceName(VeniceRouterWrapper.CLUSTER_DISCOVERY_D2_SERVICE_NAME));
+
+    TestUtils.waitForNonDeterministicAssertion(
+        30,
+        TimeUnit.SECONDS,
+        true,
+        () -> assertNotNull(thinClient.get(keyPrefix + "0")));
   }
 
   protected AvroGenericStoreClient<String, Object> getGenericFastVsonClient(


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci], [server], [controller],
[router], [samza], [vpj], [fast-client], [thin-client], [alpini],
[admin-tool], [test], [build], [doc], [script]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Summary, imperative, start upper case, don't end with a period
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Added retry for cluster discovery via router in `RequestBasedMetadata`. The current implementation has this set to false which is resulting in flakiness in the jenkins test runs.

Also added a non-deterministic wait which uses a thin client to query a key. This will ensure D2 and the router are running before the tests run.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
Testing suite
## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.