### PR TITLE
[online-producer] Add an interface for an online producer to write to Venice

### DIFF
--- a/clients/venice-producer/build.gradle
+++ b/clients/venice-producer/build.gradle
@@ -1,30 +1,3 @@
 dependencies {
-//    api (libraries.avro) {
-//        exclude group: 'org.jboss.netty' // older version of netty3 causes transitive conflicts with the router
-//        exclude group: 'org.mortbay.jetty' // jetty 6 conflicts with spark-java used in controller api
-//        exclude group: 'org.slf4j'        // Avro pulls in slf4j 1.5 which is API incompatible with 1.6
-//    }
-
-//    implementation (libraries.commonsIo) {
-//        exclude group: 'org.apapche.zookeeper'
-//    }
-//
-//    implementation libraries.bouncyCastle
-//    implementation libraries.httpAsyncClient
-//    implementation libraries.jacksonCore
-//    implementation libraries.jacksonDatabind
-//    implementation libraries.log4j2api
-//    implementation libraries.zookeeper
-//
-
     implementation project(':internal:venice-common')
-
-//    // Schema related dependencies
-//    implementation project(':internal:venice-client-common')
-//
-//    testImplementation project(':internal:venice-common')
-//    testImplementation project(':internal:venice-test-common')
-//    testImplementation libraries.kafkaClientsTest
-//    testImplementation libraries.kafkaClients
-//    testImplementation libraries.netty
 }

--- a/clients/venice-producer/build.gradle
+++ b/clients/venice-producer/build.gradle
@@ -1,0 +1,30 @@
+dependencies {
+//    api (libraries.avro) {
+//        exclude group: 'org.jboss.netty' // older version of netty3 causes transitive conflicts with the router
+//        exclude group: 'org.mortbay.jetty' // jetty 6 conflicts with spark-java used in controller api
+//        exclude group: 'org.slf4j'        // Avro pulls in slf4j 1.5 which is API incompatible with 1.6
+//    }
+
+//    implementation (libraries.commonsIo) {
+//        exclude group: 'org.apapche.zookeeper'
+//    }
+//
+//    implementation libraries.bouncyCastle
+//    implementation libraries.httpAsyncClient
+//    implementation libraries.jacksonCore
+//    implementation libraries.jacksonDatabind
+//    implementation libraries.log4j2api
+//    implementation libraries.zookeeper
+//
+
+    implementation project(':internal:venice-common')
+
+//    // Schema related dependencies
+//    implementation project(':internal:venice-client-common')
+//
+//    testImplementation project(':internal:venice-common')
+//    testImplementation project(':internal:venice-test-common')
+//    testImplementation libraries.kafkaClientsTest
+//    testImplementation libraries.kafkaClients
+//    testImplementation libraries.netty
+}

--- a/clients/venice-producer/src/main/java/com/linkedin/venice/producer/DurableWrite.java
+++ b/clients/venice-producer/src/main/java/com/linkedin/venice/producer/DurableWrite.java
@@ -1,0 +1,9 @@
+package com.linkedin.venice.producer;
+
+/**
+ * This class is used as the return type of the {@link java.util.concurrent.CompletableFuture} that is returned
+ * by the Venice producer. It only signifies that the write operation is durable in the PubSub system (and eventually in
+ * Venice storage). It does not imply that the data is available to readers.
+ */
+public class DurableWrite {
+}

--- a/clients/venice-producer/src/main/java/com/linkedin/venice/producer/VeniceProducer.java
+++ b/clients/venice-producer/src/main/java/com/linkedin/venice/producer/VeniceProducer.java
@@ -1,0 +1,77 @@
+package com.linkedin.venice.producer;
+
+import com.linkedin.venice.writer.update.UpdateBuilder;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
+
+
+/**
+ * The API for online applications to write to Venice. These APIs are only eventually consistent and the futures
+ * returned by them only guarantee that the write operation was durable. There is no option to block until the data
+ * is readable.
+ * @param <K> Key of the record that needs to be updated
+ * @param <V> Value that needs to be written
+ */
+public interface VeniceProducer<K, V> {
+  /**
+   * A write operation where a full value is written to replace the existing value.
+   * @param key Key of the record that needs to be updated
+   * @param value The full value that needs to be written
+   * @return A {@link CompletableFuture} that completes when the write operation is durable. It does not imply that the
+   *         data is available to readers.
+   */
+  CompletableFuture<DurableWrite> asyncPut(K key, V value);
+
+  /**
+   * A write operation where a full value is written to replace the existing value. It offers the writers to specify a
+   * logical time. This value is used to specify the ordering of operations and perform conflict resolution in
+   * Active/Active replication.
+   * @param logicalTime The value used during conflict resolution in Active/Active replication
+   * @param key Key of the record that needs to be updated
+   * @param value The full value that needs to be written
+   * @return A {@link CompletableFuture} that completes when the write operation is durable. It does not imply that the
+   *         data is available to readers.
+   */
+  CompletableFuture<DurableWrite> asyncPut(long logicalTime, K key, V value);
+
+  /**
+   * A write operation to delete the record for a key.
+   * @param key The key associated with the record that should be deleted
+   * @return A {@link CompletableFuture} that completes when the write operation is durable. It does not imply that the
+   *         data is available to readers.
+   */
+  CompletableFuture<DurableWrite> asyncDelete(K key);
+
+  /**
+   * A write operation to delete the record for a key. It offers the writers to specify a logical time. This value is
+   * used to specify the ordering of operations and perform conflict resolution in Active/Active replication.
+   * @param logicalTime The value used during conflict resolution in Active/Active replication
+   * @param key Key of the record that needs to be deleted
+   * @return A {@link CompletableFuture} that completes when the write operation is durable. It does not imply that the
+   *         data is available to readers.
+   */
+  CompletableFuture<DurableWrite> asyncDelete(long logicalTime, K key);
+
+  /**
+   * A write operation to modify a subset of fields in the record for a key.
+   * @param key Key of the record that needs to be updated
+   * @param updateFunction A {@link Consumer} that takes in an {@link UpdateBuilder} object and updates it to specify
+   *                       which fields to modify and the operations that must be done on them.
+   * @return A {@link CompletableFuture} that completes when the write operation is durable. It does not imply that the
+   *         data is available to readers.
+   */
+  CompletableFuture<DurableWrite> asyncUpdate(K key, Consumer<UpdateBuilder> updateFunction);
+
+  /**
+   * A write operation to modify a subset of fields in the record for a key. It offers the writers to specify a logical
+   * time. This value is used to specify the ordering of operations and perform conflict resolution in Active/Active
+   * replication.
+   * @param logicalTime The value used during conflict resolution in Active/Active replication
+   * @param key Key of the record that needs to be updated
+   * @param updateFunction A {@link Consumer} that takes in an {@link UpdateBuilder} object and updates it to specify
+   *                       which fields to modify and the operations that must be done on them.
+   * @return A {@link CompletableFuture} that completes when the write operation is durable. It does not imply that the
+   *         data is available to readers.
+   */
+  CompletableFuture<DurableWrite> asyncUpdate(long logicalTime, K key, Consumer<UpdateBuilder> updateFunction);
+}

--- a/clients/venice-producer/src/main/java/com/linkedin/venice/producer/VeniceProducer.java
+++ b/clients/venice-producer/src/main/java/com/linkedin/venice/producer/VeniceProducer.java
@@ -9,6 +9,17 @@ import java.util.function.Consumer;
  * The API for online applications to write to Venice. These APIs are only eventually consistent and the futures
  * returned by them only guarantee that the write operation was durable. There is no option to block until the data
  * is readable.
+ *
+ * All of these APIs have at least two versions - one that accepts a logical timestamp and one that doesn't.
+ * 1. Logical timestamps (in ms) are what Venice backend will use to resolve conflicts in case multiple writes modify
+ * the same record. An update to Venice could be triggered due to some trigger that can be attributed to a specific
+ * point in time. In such cases, it might be beneficial for applications to mark their updates to Venice with that
+ * timestamp and Venice will persist the record as if it had been received at that point in time - either by applying
+ * the update, dropping the update if a newer update has already been persisted, or applying an update partially only to
+ * fields that have not received an update with a newer timestamp yet.
+ * 2. In case the write requests are made without specifying the logical timestamp, then the time at which the message
+ * was produced is used as the logical timestamp during conflict resolution.
+ *
  * @param <K> Key of the record that needs to be updated
  * @param <V> Value that needs to be written
  */

--- a/settings.gradle
+++ b/settings.gradle
@@ -38,6 +38,7 @@ dependencyResolutionManagement {
 include 'clients:da-vinci-client'
 include 'clients:venice-admin-tool'
 include 'clients:venice-client'
+include 'clients:venice-producer'
 include 'clients:venice-push-job'
 include 'clients:venice-samza'
 include 'clients:venice-thin-client'


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci], [server], [controller],
[router], [samza], [vpj], [fast-client], [thin-client], [alpini],
[admin-tool], [test], [build], [doc], [script]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Add an interface for an online producer to write to Venice
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
Today, Venice only allows updates to it's records via nearline frameworks (currently, only Samza) or incremental pushes. This commit adds an API that online applications can use to write data to Venice. The writes are only eventaually consistent and read-after-write patterns are still not supported

Resolves #XXX

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
Github CI

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.