### PR TITLE
[samza] Adapt modified records in UpdateBuilderImpl to the specified update schema using default values

### DIFF
--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/Store.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/Store.java
@@ -1,20 +1,13 @@
 package com.linkedin.venice.meta;
 
-import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
 import com.linkedin.venice.common.VeniceSystemStoreType;
 import com.linkedin.venice.compression.CompressionStrategy;
-import com.linkedin.venice.exceptions.VeniceException;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import org.apache.avro.Schema;
-import org.apache.avro.specific.SpecificRecord;
 
 
 /**
@@ -57,77 +50,6 @@ public interface Store {
   static boolean isValidStoreName(String name) {
     Matcher matcher = storeNamePattern.matcher(name);
     return matcher.matches() && !name.contains("--");
-  }
-
-  /**
-   * This function is used to pre-fill the default value defined in schema.
-   * So far, it only support the followings:
-   * 1. Only top-level fields are supported.
-   * 2. All the primitive types are supported.
-   * 3. For union, only `null` default is supported.
-   * 4. For array/map, only empty list/map are supported.
-   *
-   * Other than the above, this function will throw exception.
-   *
-   * TODO: once the whole stack migrates to the modern avro version (avro-1.7+), we could leverage
-   * SpecificRecord builder to prefill the default value, which will be much more powerful.
-   * @param recordType
-   * @param <T>
-   * @return
-   */
-  static <T extends SpecificRecord> T prefillAvroRecordWithDefaultValue(T recordType) {
-    Schema schema = recordType.getSchema();
-    for (Schema.Field field: schema.getFields()) {
-      if (AvroCompatibilityHelper.fieldHasDefault(field)) {
-        // has default
-        Object defaultValue = AvroCompatibilityHelper.getSpecificDefaultValue(field);
-        Schema.Type fieldType = field.schema().getType();
-        switch (fieldType) {
-          case NULL:
-            throw new VeniceException("Default value for `null` type is not expected");
-          case BOOLEAN:
-          case INT:
-          case LONG:
-          case FLOAT:
-          case DOUBLE:
-          case STRING:
-            recordType.put(field.pos(), defaultValue);
-            break;
-          case UNION:
-            if (defaultValue == null) {
-              recordType.put(field.pos(), null);
-            } else {
-              throw new VeniceException("Non 'null' default value is not supported for union type: " + field.name());
-            }
-            break;
-          case ARRAY:
-            Collection collection = (Collection) defaultValue;
-            if (collection.isEmpty()) {
-              recordType.put(field.pos(), new ArrayList<>());
-            } else {
-              throw new VeniceException(
-                  "Non 'empty array' default value is not supported for array type: " + field.name());
-            }
-            break;
-          case MAP:
-            Map map = (Map) defaultValue;
-            if (map.isEmpty()) {
-              recordType.put(field.pos(), new HashMap<>());
-            } else {
-              throw new VeniceException("Non 'empty map' default value is not supported for map type: " + field.name());
-            }
-            break;
-          case ENUM:
-          case FIXED:
-          case BYTES:
-          case RECORD:
-            throw new VeniceException(
-                "Default value for field: " + field.name() + " with type: " + fieldType + " is not supported");
-        }
-      }
-    }
-
-    return recordType;
   }
 
   static boolean isSystemStore(String storeName) {

--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/StoreConfig.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/StoreConfig.java
@@ -2,6 +2,7 @@ package com.linkedin.venice.meta;
 
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.systemstore.schemas.StoreClusterConfig;
+import com.linkedin.venice.utils.AvroRecordUtils;
 
 
 /**
@@ -11,7 +12,7 @@ public class StoreConfig implements DataModelBackedStructure<StoreClusterConfig>
   private final StoreClusterConfig storeClusterConfig;
 
   public StoreConfig(String storeName) {
-    storeClusterConfig = Store.prefillAvroRecordWithDefaultValue(new StoreClusterConfig());
+    storeClusterConfig = AvroRecordUtils.prefillAvroRecordWithDefaultValue(new StoreClusterConfig());
     storeClusterConfig.storeName = storeName;
   }
 

--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/SystemStoreAttributesImpl.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/SystemStoreAttributesImpl.java
@@ -2,6 +2,7 @@ package com.linkedin.venice.meta;
 
 import com.linkedin.venice.systemstore.schemas.SystemStoreProperties;
 import com.linkedin.venice.utils.AvroCompatibilityUtils;
+import com.linkedin.venice.utils.AvroRecordUtils;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -10,7 +11,7 @@ public class SystemStoreAttributesImpl implements SystemStoreAttributes {
   private final SystemStoreProperties dataModel;
 
   public SystemStoreAttributesImpl() {
-    this(Store.prefillAvroRecordWithDefaultValue(new SystemStoreProperties()));
+    this(AvroRecordUtils.prefillAvroRecordWithDefaultValue(new SystemStoreProperties()));
   }
 
   SystemStoreAttributesImpl(SystemStoreProperties dataModel) {

--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/VersionImpl.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/VersionImpl.java
@@ -7,6 +7,7 @@ import com.linkedin.venice.compression.CompressionStrategy;
 import com.linkedin.venice.systemstore.schemas.StoreVersion;
 import com.linkedin.venice.systemstore.schemas.StoreViewConfig;
 import com.linkedin.venice.utils.AvroCompatibilityUtils;
+import com.linkedin.venice.utils.AvroRecordUtils;
 import java.time.Duration;
 import java.util.Map;
 import java.util.Objects;
@@ -55,7 +56,7 @@ public class VersionImpl implements Version {
       @JsonProperty("partitionCount") int partitionCount,
       @JsonProperty("partitionerConfig") PartitionerConfig partitionerConfig,
       @JsonProperty("dataRecoveryConfig") DataRecoveryVersionConfig dataRecoveryVersionConfig) {
-    this.storeVersion = Store.prefillAvroRecordWithDefaultValue(new StoreVersion());
+    this.storeVersion = AvroRecordUtils.prefillAvroRecordWithDefaultValue(new StoreVersion());
     this.storeVersion.storeName = storeName;
     this.storeVersion.number = number;
     this.storeVersion.createdTime = createdTime;

--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/ZKStore.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/ZKStore.java
@@ -9,6 +9,7 @@ import com.linkedin.venice.kafka.TopicManager;
 import com.linkedin.venice.systemstore.schemas.StoreProperties;
 import com.linkedin.venice.systemstore.schemas.StoreVersion;
 import com.linkedin.venice.utils.AvroCompatibilityUtils;
+import com.linkedin.venice.utils.AvroRecordUtils;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -96,7 +97,7 @@ public class ZKStore extends AbstractStore implements DataModelBackedStructure<S
       throw new VeniceException("Invalid store name: " + name);
     }
 
-    this.storeProperties = Store.prefillAvroRecordWithDefaultValue(new StoreProperties());
+    this.storeProperties = AvroRecordUtils.prefillAvroRecordWithDefaultValue(new StoreProperties());
     this.storeProperties.replicationFactor = replicationFactor;
 
     this.storeProperties.name = name;

--- a/internal/venice-common/src/main/java/com/linkedin/venice/schema/ListSchemaAdapter.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/schema/ListSchemaAdapter.java
@@ -1,0 +1,37 @@
+package com.linkedin.venice.schema;
+
+import com.linkedin.venice.exceptions.VeniceException;
+import java.util.Collection;
+import java.util.stream.Collectors;
+import org.apache.avro.Schema;
+
+
+class ListSchemaAdapter implements SchemaAdapter {
+  private static ListSchemaAdapter INSTANCE = new ListSchemaAdapter();
+
+  private ListSchemaAdapter() {
+  }
+
+  static ListSchemaAdapter getInstance() {
+    return INSTANCE;
+  }
+
+  @Override
+  public Collection<?> adapt(Schema expectedSchema, Object datum) {
+    if (!(datum instanceof Collection)) {
+      throw new VeniceException("Expected datum to be a Collection");
+    }
+
+    Collection<?> datumCollection = (Collection<?>) datum;
+
+    // Adapt List type - adapt all elements
+    Schema elementSchema = expectedSchema.getElementType();
+    if (SchemaAdapter.getSchemaAdapter(elementSchema.getType()) instanceof NoOpSchemaAdapter) {
+      return datumCollection;
+    } else {
+      return datumCollection.stream()
+          .map(element -> SchemaAdapter.adaptToSchema(elementSchema, element))
+          .collect(Collectors.toList());
+    }
+  }
+}

--- a/internal/venice-common/src/main/java/com/linkedin/venice/schema/MapSchemaAdapter.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/schema/MapSchemaAdapter.java
@@ -1,0 +1,38 @@
+package com.linkedin.venice.schema;
+
+import com.linkedin.venice.exceptions.VeniceException;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.apache.avro.Schema;
+
+
+class MapSchemaAdapter implements SchemaAdapter {
+  private static MapSchemaAdapter INSTANCE = new MapSchemaAdapter();
+
+  private MapSchemaAdapter() {
+  }
+
+  static MapSchemaAdapter getInstance() {
+    return INSTANCE;
+  }
+
+  @Override
+  public Map<String, ?> adapt(Schema expectedSchema, Object datum) {
+    if (!(datum instanceof Map)) {
+      throw new VeniceException("Expected datum to be of Map type");
+    }
+
+    // Adapt Map type - adapt all entries
+    Map<String, ?> datumMap = (Map<String, ?>) datum;
+    Schema elementSchema = expectedSchema.getValueType();
+    if (SchemaAdapter.getSchemaAdapter(elementSchema.getType()) instanceof NoOpSchemaAdapter) {
+      return datumMap;
+    } else {
+      return datumMap.entrySet()
+          .stream()
+          .collect(
+              Collectors
+                  .toMap(Map.Entry::getKey, entry -> SchemaAdapter.adaptToSchema(elementSchema, entry.getValue())));
+    }
+  }
+}

--- a/internal/venice-common/src/main/java/com/linkedin/venice/schema/NoOpSchemaAdapter.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/schema/NoOpSchemaAdapter.java
@@ -1,0 +1,20 @@
+package com.linkedin.venice.schema;
+
+import org.apache.avro.Schema;
+
+
+class NoOpSchemaAdapter implements SchemaAdapter {
+  private static NoOpSchemaAdapter INSTANCE = new NoOpSchemaAdapter();
+
+  private NoOpSchemaAdapter() {
+  }
+
+  static NoOpSchemaAdapter getInstance() {
+    return INSTANCE;
+  }
+
+  @Override
+  public Object adapt(Schema expectedSchema, Object datum) {
+    return datum;
+  }
+}

--- a/internal/venice-common/src/main/java/com/linkedin/venice/schema/RecordSchemaAdapter.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/schema/RecordSchemaAdapter.java
@@ -1,0 +1,46 @@
+package com.linkedin.venice.schema;
+
+import com.linkedin.venice.exceptions.VeniceException;
+import com.linkedin.venice.serializer.FastSerializerDeserializerFactory;
+import com.linkedin.venice.serializer.RecordDeserializer;
+import com.linkedin.venice.serializer.RecordSerializer;
+import com.linkedin.venice.serializer.VeniceSerializationException;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+
+
+class RecordSchemaAdapter implements SchemaAdapter {
+  private static RecordSchemaAdapter INSTANCE = new RecordSchemaAdapter();
+
+  private RecordSchemaAdapter() {
+  }
+
+  static RecordSchemaAdapter getInstance() {
+    return INSTANCE;
+  }
+
+  @Override
+  public IndexedRecord adapt(Schema expectedSchema, Object datum) {
+    if (!(datum instanceof IndexedRecord)) {
+      throw new VeniceException("Expected datum to be an IndexedRecord");
+    }
+
+    IndexedRecord datumRecord = ((IndexedRecord) datum);
+    Schema datumSchema = datumRecord.getSchema();
+
+    if (datumSchema.equals(expectedSchema)) {
+      return datumRecord;
+    }
+
+    RecordDeserializer<IndexedRecord> deserializer =
+        FastSerializerDeserializerFactory.getAvroGenericDeserializer(datumSchema, expectedSchema);
+    RecordSerializer<IndexedRecord> serializer =
+        FastSerializerDeserializerFactory.getAvroGenericSerializer(datumSchema);
+
+    try {
+      return deserializer.deserialize(serializer.serialize(datumRecord));
+    } catch (VeniceSerializationException e) {
+      throw new VeniceException(e);
+    }
+  }
+}

--- a/internal/venice-common/src/main/java/com/linkedin/venice/schema/SchemaAdapter.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/schema/SchemaAdapter.java
@@ -1,0 +1,63 @@
+package com.linkedin.venice.schema;
+
+import com.linkedin.venice.exceptions.VeniceException;
+import org.apache.avro.Schema;
+
+
+/**
+ * Try to adapt the {@param datum} to the {@param expectedSchema}.
+ * The following steps are followed:
+ * 1. If the schema type doesn't allow for adaptation, return the same value that was passed in input.
+ * 2. If the schema type allows for adaptation, then
+ *     2a. If the value doesn't specify a value for any field, the default value is used
+ *     2b. If a field is mandatory, but no default values are specified, then an Exception is thrown
+ *
+ * @param expectedSchema The type {@link Schema} that the value needs to be adapted to.
+ * @param datum The value that needs to be adapted to the specified schema
+ * @return
+ * @throws VeniceException
+ */
+public interface SchemaAdapter {
+  Object adapt(Schema expectedSchema, Object datum);
+
+  /**
+   * Checks if it is possible for some value to be modified to adapt to the provided schema type.
+   * @param expectedSchemaType The type {@link Schema.Type} that the value needs to be adapted to.
+   * @return {@code true} if a value can be modified to adapt to the provided schema type; {@code false} otherwise.
+   */
+  static SchemaAdapter getSchemaAdapter(Schema.Type expectedSchemaType) {
+    switch (expectedSchemaType) {
+      case ENUM:
+      case FIXED:
+      case STRING:
+      case BYTES:
+      case INT:
+      case LONG:
+      case FLOAT:
+      case DOUBLE:
+      case BOOLEAN:
+      case NULL:
+        return NoOpSchemaAdapter.getInstance();
+      case RECORD:
+        return RecordSchemaAdapter.getInstance();
+      case ARRAY:
+        return ListSchemaAdapter.getInstance();
+      case MAP:
+        return MapSchemaAdapter.getInstance();
+      case UNION:
+        return UnionSchemaAdapter.getInstance();
+      default:
+        // Defensive coding
+        throw new VeniceException("Unhandled Avro type. This is unexpected.");
+    }
+  }
+
+  /**
+   * Checks if it is possible for some value to be modified to adapt to the provided schema type.
+   * @param expectedSchemaType The type {@link Schema.Type} that the value needs to be adapted to.
+   * @return {@code true} if a value can be modified to adapt to the provided schema type; {@code false} otherwise.
+   */
+  static Object adaptToSchema(Schema expectedSchema, Object datum) {
+    return SchemaAdapter.getSchemaAdapter(expectedSchema.getType()).adapt(expectedSchema, datum);
+  }
+}

--- a/internal/venice-common/src/main/java/com/linkedin/venice/schema/UnionSchemaAdapter.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/schema/UnionSchemaAdapter.java
@@ -1,0 +1,28 @@
+package com.linkedin.venice.schema;
+
+import com.linkedin.venice.exceptions.VeniceException;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+
+
+class UnionSchemaAdapter implements SchemaAdapter {
+  private static UnionSchemaAdapter INSTANCE = new UnionSchemaAdapter();
+
+  private UnionSchemaAdapter() {
+  }
+
+  static UnionSchemaAdapter getInstance() {
+    return INSTANCE;
+  }
+
+  @Override
+  public Object adapt(Schema expectedSchema, Object datum) {
+    int index;
+    try {
+      index = GenericData.get().resolveUnion(expectedSchema, datum);
+    } catch (Exception e) {
+      throw new VeniceException(e);
+    }
+    return SchemaAdapter.adaptToSchema(expectedSchema.getTypes().get(index), datum);
+  }
+}

--- a/internal/venice-common/src/main/java/com/linkedin/venice/utils/AvroRecordUtils.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/utils/AvroRecordUtils.java
@@ -1,0 +1,235 @@
+package com.linkedin.venice.utils;
+
+import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
+import com.linkedin.venice.exceptions.VeniceException;
+import com.linkedin.venice.serializer.FastSerializerDeserializerFactory;
+import com.linkedin.venice.serializer.RecordDeserializer;
+import com.linkedin.venice.serializer.RecordSerializer;
+import com.linkedin.venice.serializer.VeniceSerializationException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.specific.SpecificRecord;
+
+
+public class AvroRecordUtils {
+  private AvroRecordUtils() {
+  }
+
+  /**
+   * This function is used to pre-fill the default value defined in schema.
+   * So far, it only support the followings:
+   * 1. Only top-level fields are supported.
+   * 2. All the primitive types are supported.
+   * 3. For union, only `null` default is supported.
+   * 4. For array/map, only empty list/map are supported.
+   *
+   * Other than the above, this function will throw exception.
+   *
+   * TODO: once the whole stack migrates to the modern avro version (avro-1.7+), we could leverage
+   * SpecificRecord builder to prefill the default value, which will be much more powerful.
+   * @param recordType
+   * @param <T>
+   * @return
+   */
+  public static <T extends SpecificRecord> T prefillAvroRecordWithDefaultValue(T recordType) {
+    Schema schema = recordType.getSchema();
+    for (Schema.Field field: schema.getFields()) {
+      if (AvroCompatibilityHelper.fieldHasDefault(field)) {
+        // has default
+        Object defaultValue = AvroCompatibilityHelper.getSpecificDefaultValue(field);
+        Schema.Type fieldType = field.schema().getType();
+        switch (fieldType) {
+          case NULL:
+            throw new VeniceException("Default value for `null` type is not expected");
+          case BOOLEAN:
+          case INT:
+          case LONG:
+          case FLOAT:
+          case DOUBLE:
+          case STRING:
+            recordType.put(field.pos(), defaultValue);
+            break;
+          case UNION:
+            if (defaultValue == null) {
+              recordType.put(field.pos(), null);
+            } else {
+              throw new VeniceException("Non 'null' default value is not supported for union type: " + field.name());
+            }
+            break;
+          case ARRAY:
+            Collection collection = (Collection) defaultValue;
+            if (collection.isEmpty()) {
+              recordType.put(field.pos(), new ArrayList<>());
+            } else {
+              throw new VeniceException(
+                  "Non 'empty array' default value is not supported for array type: " + field.name());
+            }
+            break;
+          case MAP:
+            Map map = (Map) defaultValue;
+            if (map.isEmpty()) {
+              recordType.put(field.pos(), new HashMap<>());
+            } else {
+              throw new VeniceException("Non 'empty map' default value is not supported for map type: " + field.name());
+            }
+            break;
+          case ENUM:
+          case FIXED:
+          case BYTES:
+          case RECORD:
+            throw new VeniceException(
+                "Default value for field: " + field.name() + " with type: " + fieldType + " is not supported");
+        }
+      }
+    }
+
+    return recordType;
+  }
+
+  /**
+   * Checks if it is possible for some value to be modified to adapt to the provided schema type.
+   * @param expectedSchemaType The type {@link Schema.Type} that the value needs to be adapted to.
+   * @return {@code true} if a value can be modified to adapt to the provided schema type; {@code false} otherwise.
+   */
+  private static boolean canSchemaTypeBeAdapted(Schema.Type expectedSchemaType) {
+    switch (expectedSchemaType) {
+      case ENUM:
+      case FIXED:
+      case STRING:
+      case BYTES:
+      case INT:
+      case LONG:
+      case FLOAT:
+      case DOUBLE:
+      case BOOLEAN:
+      case NULL:
+        return false;
+      case RECORD:
+      case ARRAY:
+      case MAP:
+      case UNION:
+        return true;
+      default:
+        // Defensive coding
+        throw new VeniceException("Unhandled Avro type. This is unexpected.");
+    }
+  }
+
+  /**
+   * Tries to adapt the {@param datum} to the {@param expectedSchema}.
+   * The following steps are followed:
+   * 1. If the schema type doesn't allow for adaptation, return the same value that was passed in input.
+   * 2. If the schema type allows for adaptation, then
+   *     2a. If the value doesn't specify a value for any field, the default value is used
+   *     2b. If a field is mandatory, but no default values are specified, then an Exception is thrown
+   *
+   * @param expectedSchema The type {@link Schema} that the value needs to be adapted to.
+   * @param datum The value that needs to be adapted to the specified schema
+   * @return
+   * @throws VeniceException
+   */
+  public static Object adaptToSchema(Schema expectedSchema, Object datum) throws VeniceException {
+    Schema.Type expectedSchemaType = expectedSchema.getType();
+    switch (expectedSchemaType) {
+      case ENUM:
+      case FIXED:
+      case STRING:
+      case BYTES:
+      case INT:
+      case LONG:
+      case FLOAT:
+      case DOUBLE:
+      case BOOLEAN:
+      case NULL:
+        return datum;
+      case RECORD:
+        return adaptRecordToSchema(expectedSchema, datum);
+      case ARRAY:
+        return adaptListToSchema(expectedSchema, datum);
+      case MAP:
+        return adaptMapToSchema(expectedSchema, datum);
+      case UNION:
+        return adaptUnionToSchema(expectedSchema, datum);
+      default:
+        // Defensive coding
+        throw new VeniceException("Unhandled Avro type. This is unexpected.");
+    }
+  }
+
+  private static Object adaptRecordToSchema(Schema expectedSchema, Object datum) {
+    if (!(datum instanceof IndexedRecord)) {
+      throw new VeniceException(); // TODO
+    }
+
+    IndexedRecord datumRecord = ((IndexedRecord) datum);
+    Schema datumSchema = datumRecord.getSchema();
+
+    if (datumSchema.equals(expectedSchema)) {
+      return datumRecord;
+    }
+
+    RecordDeserializer<IndexedRecord> deserializer =
+        FastSerializerDeserializerFactory.getAvroGenericDeserializer(datumSchema, expectedSchema);
+    RecordSerializer<IndexedRecord> serializer =
+        FastSerializerDeserializerFactory.getAvroGenericSerializer(datumSchema);
+
+    try {
+      return deserializer.deserialize(serializer.serialize(datumRecord));
+    } catch (VeniceSerializationException e) {
+      throw new VeniceException(e);
+    }
+  }
+
+  private static Collection<?> adaptListToSchema(Schema expectedSchema, Object datum) {
+    if (!(datum instanceof Collection)) {
+      throw new VeniceException(); // TODO
+    }
+
+    Collection<?> datumCollection = (Collection<?>) datum;
+
+    // Adapt List type - adapt all elements
+    Schema elementSchema = expectedSchema.getElementType();
+    if (AvroRecordUtils.canSchemaTypeBeAdapted(elementSchema.getType())) {
+      return datumCollection.stream()
+          .map(element -> AvroRecordUtils.adaptToSchema(elementSchema, element))
+          .collect(Collectors.toList());
+    } else {
+      return datumCollection;
+    }
+  }
+
+  private static Map<String, ?> adaptMapToSchema(Schema expectedSchema, Object datum) {
+    if (!(datum instanceof Map)) {
+      throw new VeniceException(); // TODO
+    }
+
+    // Adapt Map type - adapt all entries
+    Map<String, ?> datumMap = (Map<String, ?>) datum;
+    Schema elementSchema = expectedSchema.getValueType();
+    if (AvroRecordUtils.canSchemaTypeBeAdapted(elementSchema.getType())) {
+      return datumMap.entrySet()
+          .stream()
+          .collect(
+              Collectors
+                  .toMap(Map.Entry::getKey, entry -> AvroRecordUtils.adaptToSchema(elementSchema, entry.getValue())));
+    } else {
+      return datumMap;
+    }
+  }
+
+  private static Object adaptUnionToSchema(Schema expectedSchema, Object datum) {
+    int index;
+    try {
+      index = GenericData.get().resolveUnion(expectedSchema, datum);
+    } catch (Exception e) {
+      throw new VeniceException(e);
+    }
+    return adaptToSchema(expectedSchema.getTypes().get(index), datum);
+  }
+}

--- a/internal/venice-common/src/main/java/com/linkedin/venice/utils/AvroRecordUtils.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/utils/AvroRecordUtils.java
@@ -2,18 +2,11 @@ package com.linkedin.venice.utils;
 
 import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
 import com.linkedin.venice.exceptions.VeniceException;
-import com.linkedin.venice.serializer.FastSerializerDeserializerFactory;
-import com.linkedin.venice.serializer.RecordDeserializer;
-import com.linkedin.venice.serializer.RecordSerializer;
-import com.linkedin.venice.serializer.VeniceSerializationException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.stream.Collectors;
 import org.apache.avro.Schema;
-import org.apache.avro.generic.GenericData;
-import org.apache.avro.generic.IndexedRecord;
 import org.apache.avro.specific.SpecificRecord;
 
 
@@ -90,146 +83,5 @@ public class AvroRecordUtils {
     }
 
     return recordType;
-  }
-
-  /**
-   * Checks if it is possible for some value to be modified to adapt to the provided schema type.
-   * @param expectedSchemaType The type {@link Schema.Type} that the value needs to be adapted to.
-   * @return {@code true} if a value can be modified to adapt to the provided schema type; {@code false} otherwise.
-   */
-  private static boolean canSchemaTypeBeAdapted(Schema.Type expectedSchemaType) {
-    switch (expectedSchemaType) {
-      case ENUM:
-      case FIXED:
-      case STRING:
-      case BYTES:
-      case INT:
-      case LONG:
-      case FLOAT:
-      case DOUBLE:
-      case BOOLEAN:
-      case NULL:
-        return false;
-      case RECORD:
-      case ARRAY:
-      case MAP:
-      case UNION:
-        return true;
-      default:
-        // Defensive coding
-        throw new VeniceException("Unhandled Avro type. This is unexpected.");
-    }
-  }
-
-  /**
-   * Tries to adapt the {@param datum} to the {@param expectedSchema}.
-   * The following steps are followed:
-   * 1. If the schema type doesn't allow for adaptation, return the same value that was passed in input.
-   * 2. If the schema type allows for adaptation, then
-   *     2a. If the value doesn't specify a value for any field, the default value is used
-   *     2b. If a field is mandatory, but no default values are specified, then an Exception is thrown
-   *
-   * @param expectedSchema The type {@link Schema} that the value needs to be adapted to.
-   * @param datum The value that needs to be adapted to the specified schema
-   * @return
-   * @throws VeniceException
-   */
-  public static Object adaptToSchema(Schema expectedSchema, Object datum) throws VeniceException {
-    Schema.Type expectedSchemaType = expectedSchema.getType();
-    switch (expectedSchemaType) {
-      case ENUM:
-      case FIXED:
-      case STRING:
-      case BYTES:
-      case INT:
-      case LONG:
-      case FLOAT:
-      case DOUBLE:
-      case BOOLEAN:
-      case NULL:
-        return datum;
-      case RECORD:
-        return adaptRecordToSchema(expectedSchema, datum);
-      case ARRAY:
-        return adaptListToSchema(expectedSchema, datum);
-      case MAP:
-        return adaptMapToSchema(expectedSchema, datum);
-      case UNION:
-        return adaptUnionToSchema(expectedSchema, datum);
-      default:
-        // Defensive coding
-        throw new VeniceException("Unhandled Avro type. This is unexpected.");
-    }
-  }
-
-  private static Object adaptRecordToSchema(Schema expectedSchema, Object datum) {
-    if (!(datum instanceof IndexedRecord)) {
-      throw new VeniceException(); // TODO
-    }
-
-    IndexedRecord datumRecord = ((IndexedRecord) datum);
-    Schema datumSchema = datumRecord.getSchema();
-
-    if (datumSchema.equals(expectedSchema)) {
-      return datumRecord;
-    }
-
-    RecordDeserializer<IndexedRecord> deserializer =
-        FastSerializerDeserializerFactory.getAvroGenericDeserializer(datumSchema, expectedSchema);
-    RecordSerializer<IndexedRecord> serializer =
-        FastSerializerDeserializerFactory.getAvroGenericSerializer(datumSchema);
-
-    try {
-      return deserializer.deserialize(serializer.serialize(datumRecord));
-    } catch (VeniceSerializationException e) {
-      throw new VeniceException(e);
-    }
-  }
-
-  private static Collection<?> adaptListToSchema(Schema expectedSchema, Object datum) {
-    if (!(datum instanceof Collection)) {
-      throw new VeniceException(); // TODO
-    }
-
-    Collection<?> datumCollection = (Collection<?>) datum;
-
-    // Adapt List type - adapt all elements
-    Schema elementSchema = expectedSchema.getElementType();
-    if (AvroRecordUtils.canSchemaTypeBeAdapted(elementSchema.getType())) {
-      return datumCollection.stream()
-          .map(element -> AvroRecordUtils.adaptToSchema(elementSchema, element))
-          .collect(Collectors.toList());
-    } else {
-      return datumCollection;
-    }
-  }
-
-  private static Map<String, ?> adaptMapToSchema(Schema expectedSchema, Object datum) {
-    if (!(datum instanceof Map)) {
-      throw new VeniceException(); // TODO
-    }
-
-    // Adapt Map type - adapt all entries
-    Map<String, ?> datumMap = (Map<String, ?>) datum;
-    Schema elementSchema = expectedSchema.getValueType();
-    if (AvroRecordUtils.canSchemaTypeBeAdapted(elementSchema.getType())) {
-      return datumMap.entrySet()
-          .stream()
-          .collect(
-              Collectors
-                  .toMap(Map.Entry::getKey, entry -> AvroRecordUtils.adaptToSchema(elementSchema, entry.getValue())));
-    } else {
-      return datumMap;
-    }
-  }
-
-  private static Object adaptUnionToSchema(Schema expectedSchema, Object datum) {
-    int index;
-    try {
-      index = GenericData.get().resolveUnion(expectedSchema, datum);
-    } catch (Exception e) {
-      throw new VeniceException(e);
-    }
-    return adaptToSchema(expectedSchema.getTypes().get(index), datum);
   }
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/writer/update/UpdateBuilderImpl.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/writer/update/UpdateBuilderImpl.java
@@ -6,11 +6,11 @@ import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.schema.writecompute.WriteComputeConstants;
 import com.linkedin.venice.serializer.FastSerializerDeserializerFactory;
 import com.linkedin.venice.serializer.RecordSerializer;
+import com.linkedin.venice.utils.AvroRecordUtils;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
@@ -47,7 +47,9 @@ public class UpdateBuilderImpl implements UpdateBuilder {
   @Override
   public UpdateBuilder setNewFieldValue(String fieldName, Object newFieldValue) {
     validateNoCollectionMergeOnField(fieldName);
-    updateRecord.put(fieldName, newFieldValue);
+    updateRecord.put(
+        fieldName,
+        AvroRecordUtils.adaptToSchema(updateRecord.getSchema().getField(fieldName).schema(), newFieldValue));
     updateFieldNameSet.add(fieldName);
     return this;
   }
@@ -57,7 +59,9 @@ public class UpdateBuilderImpl implements UpdateBuilder {
     validateFieldType(Validate.notNull(listFieldName), Schema.Type.ARRAY);
     validateFieldNotSet(listFieldName);
     if (!elementsToAdd.isEmpty()) {
-      getOrCreateListMergeRecord(listFieldName).put(WriteComputeConstants.SET_UNION, elementsToAdd);
+      getOrCreateListMergeRecord(listFieldName).put(
+          WriteComputeConstants.SET_UNION,
+          AvroRecordUtils.adaptToSchema(getCorrespondingValueFieldSchema(listFieldName), elementsToAdd));
       collectionMergeFieldNameSet.add(listFieldName);
     }
     return this;
@@ -79,7 +83,9 @@ public class UpdateBuilderImpl implements UpdateBuilder {
     validateFieldType(Validate.notNull(mapFieldName), Schema.Type.MAP);
     validateFieldNotSet(mapFieldName);
     if (!entriesToAdd.isEmpty()) {
-      getOrCreateMapMergeRecord(mapFieldName).put(WriteComputeConstants.MAP_UNION, entriesToAdd);
+      getOrCreateMapMergeRecord(mapFieldName).put(
+          WriteComputeConstants.MAP_UNION,
+          AvroRecordUtils.adaptToSchema(getCorrespondingValueFieldSchema(mapFieldName), entriesToAdd));
       collectionMergeFieldNameSet.add(mapFieldName);
     }
     return this;
@@ -111,7 +117,7 @@ public class UpdateBuilderImpl implements UpdateBuilder {
       // This field has no field set and no collection merge.
       updateRecord.put(fieldName, createNoOpRecord(updateField));
     }
-    Exception serializationException = validateUpdateRecordIsSerializable(updateRecord).orElse(null);
+    Exception serializationException = validateUpdateRecordIsSerializable(updateRecord);
     if (serializationException != null) {
       throw new VeniceException(
           "The built partial-update record failed to be serialized. It could be caused by setting "
@@ -121,13 +127,39 @@ public class UpdateBuilderImpl implements UpdateBuilder {
     return updateRecord;
   }
 
-  private Optional<Exception> validateUpdateRecordIsSerializable(GenericRecord updateRecord) {
+  private Exception validateUpdateRecordIsSerializable(GenericRecord updateRecord) {
     try {
       serializer.serialize(updateRecord);
     } catch (Exception serializationException) {
-      return Optional.of(serializationException);
+      return serializationException;
     }
-    return Optional.empty();
+    return null;
+  }
+
+  /**
+   * Given a field from the partial update schema and find the schema of its corresponding value field.
+   *
+   * @param updateField A field from the partial update schema.
+   * @return Schema of its corresponding value field.
+   */
+  private Schema getCorrespondingValueFieldSchema(String updateFieldName) {
+    // Each field in partial update schema is a union of multiple schemas.
+    List<Schema> updateFieldSchemas = updateRecord.getSchema().getField(updateFieldName).schema().getTypes();
+    // The last schema in the union is the schema of the field in the corresponding value schema.
+    return updateFieldSchemas.get(updateFieldSchemas.size() - 1);
+  }
+
+  /**
+   * Given a field from the partial update schema and find the schema of its corresponding value field.
+   *
+   * @param updateField A field from the partial update schema.
+   * @return Schema of its corresponding value field.
+   */
+  private Schema getCorrespondingValueFieldSchema(Schema.Field updateField) {
+    // Each field in partial update schema is a union of multiple schemas.
+    List<Schema> updateFieldSchemas = updateField.schema().getTypes();
+    // The last schema in the union is the schema of the field in the corresponding value schema.
+    return updateFieldSchemas.get(updateFieldSchemas.size() - 1);
   }
 
   /**
@@ -137,10 +169,7 @@ public class UpdateBuilderImpl implements UpdateBuilder {
    * @return Type of its corresponding value field.
    */
   private Schema.Type getCorrespondingValueFieldType(Schema.Field updateField) {
-    // Each field in partial update schema is a union of multiple schemas.
-    List<Schema> updateFieldSchemas = updateField.schema().getTypes();
-    // The last schema in the union is the schema of the field in the corresponding value schema.
-    return updateFieldSchemas.get(updateFieldSchemas.size() - 1).getType();
+    return getCorrespondingValueFieldSchema(updateField).getType();
   }
 
   private void validateFieldNotSet(String fieldName) {

--- a/internal/venice-common/src/test/java/com/linkedin/venice/schema/SchemaAdapterTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/schema/SchemaAdapterTest.java
@@ -1,7 +1,6 @@
-package com.linkedin.venice.utils;
+package com.linkedin.venice.schema;
 
 import com.linkedin.alpini.io.IOUtils;
-import com.linkedin.venice.schema.AvroSchemaParseUtils;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.LinkedHashMap;
@@ -17,8 +16,8 @@ import org.testng.Assert;
 import org.testng.annotations.Test;
 
 
-public class AvroRecordUtilsTest {
-  private static final Logger LOGGER = LogManager.getLogger(AvroRecordUtilsTest.class);
+public class SchemaAdapterTest {
+  private static final Logger LOGGER = LogManager.getLogger(SchemaAdapterTest.class);
   private static final Schema SIMPLE_RECORD_SCHEMA = AvroSchemaParseUtils
       .parseSchemaFromJSONStrictValidation(loadFileAsString("AvroRecordUtilsTest/SimpleRecordSchema.avsc"));
   private static final Schema OLD_RECORD_SCHEMA = AvroSchemaParseUtils
@@ -42,7 +41,7 @@ public class AvroRecordUtilsTest {
     GenericRecord record = new GenericData.Record(SIMPLE_RECORD_SCHEMA);
     record.put("field", 1);
 
-    Object adaptedRecord = AvroRecordUtils.adaptToSchema(SIMPLE_RECORD_SCHEMA, record);
+    Object adaptedRecord = SchemaAdapter.adaptToSchema(SIMPLE_RECORD_SCHEMA, record);
     Assert.assertSame(adaptedRecord, record);
   }
 
@@ -53,7 +52,7 @@ public class AvroRecordUtilsTest {
     inputSubRecord.put("field1_1", 1);
     inputRecord.put("field1", inputSubRecord);
 
-    Object adaptedRecord = AvroRecordUtils.adaptToSchema(EVOLVED_RECORD_SCHEMA, inputRecord);
+    Object adaptedRecord = SchemaAdapter.adaptToSchema(EVOLVED_RECORD_SCHEMA, inputRecord);
     Assert.assertTrue(adaptedRecord instanceof GenericRecord);
     GenericRecord adaptedGenericRecord = (GenericRecord) adaptedRecord;
     Assert.assertEquals(adaptedGenericRecord.getSchema(), EVOLVED_RECORD_SCHEMA);
@@ -72,7 +71,7 @@ public class AvroRecordUtilsTest {
     inputRecord.put("field1", inputSubRecord);
     inputRecord.put("field2", 3);
 
-    Object adaptedRecord = AvroRecordUtils.adaptToSchema(OLD_RECORD_SCHEMA, inputRecord);
+    Object adaptedRecord = SchemaAdapter.adaptToSchema(OLD_RECORD_SCHEMA, inputRecord);
     Assert.assertTrue(adaptedRecord instanceof GenericRecord);
     GenericRecord adaptedGenericRecord = (GenericRecord) adaptedRecord;
     Assert.assertEquals(adaptedGenericRecord.getSchema(), OLD_RECORD_SCHEMA);
@@ -98,7 +97,7 @@ public class AvroRecordUtilsTest {
     inputRecord2.put("field1", inputSubRecord2);
     inputRecord2.put("field2", 10);
 
-    Object adaptedList = AvroRecordUtils.adaptToSchema(arraySchema, Arrays.asList(inputRecord, inputRecord2));
+    Object adaptedList = SchemaAdapter.adaptToSchema(arraySchema, Arrays.asList(inputRecord, inputRecord2));
     Assert.assertTrue(adaptedList instanceof List);
 
     Object adaptedRecord = ((List<?>) adaptedList).get(0);
@@ -136,7 +135,7 @@ public class AvroRecordUtilsTest {
     recordMap.put("testEvolveSchema", inputRecord);
     recordMap.put("testSameSchema", inputRecord2);
 
-    Object adaptedMap = AvroRecordUtils.adaptToSchema(mapSchema, recordMap);
+    Object adaptedMap = SchemaAdapter.adaptToSchema(mapSchema, recordMap);
     Assert.assertTrue(adaptedMap instanceof Map);
 
     Assert.assertEquals(((Map<String, ?>) adaptedMap).size(), 2);
@@ -172,7 +171,7 @@ public class AvroRecordUtilsTest {
     inputRecord2.put("field1", inputSubRecord2);
     inputRecord2.put("field2", 10);
 
-    Object adaptedRecord = AvroRecordUtils.adaptToSchema(unionSchema, inputRecord);
+    Object adaptedRecord = SchemaAdapter.adaptToSchema(unionSchema, inputRecord);
     Assert.assertTrue(adaptedRecord instanceof GenericRecord);
     GenericRecord adaptedGenericRecord = (GenericRecord) adaptedRecord;
     Assert.assertEquals(adaptedGenericRecord.getSchema(), EVOLVED_RECORD_SCHEMA);
@@ -182,7 +181,7 @@ public class AvroRecordUtilsTest {
     Assert.assertEquals(adaptedGenericRecord.get("field2"), -10);
 
     // If a record follows the same schema as the required schema, don't evolve it
-    Object adaptedRecord2 = AvroRecordUtils.adaptToSchema(unionSchema, inputRecord2);
+    Object adaptedRecord2 = SchemaAdapter.adaptToSchema(unionSchema, inputRecord2);
     Assert.assertTrue(adaptedRecord2 instanceof GenericRecord);
     Assert.assertSame(adaptedRecord2, inputRecord2);
   }

--- a/internal/venice-common/src/test/java/com/linkedin/venice/utils/AvroRecordUtilsTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/utils/AvroRecordUtilsTest.java
@@ -1,0 +1,189 @@
+package com.linkedin.venice.utils;
+
+import com.linkedin.alpini.io.IOUtils;
+import com.linkedin.venice.schema.AvroSchemaParseUtils;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class AvroRecordUtilsTest {
+  private static final Logger LOGGER = LogManager.getLogger(AvroRecordUtilsTest.class);
+  private static final Schema SIMPLE_RECORD_SCHEMA = AvroSchemaParseUtils
+      .parseSchemaFromJSONStrictValidation(loadFileAsString("AvroRecordUtilsTest/SimpleRecordSchema.avsc"));
+  private static final Schema OLD_RECORD_SCHEMA = AvroSchemaParseUtils
+      .parseSchemaFromJSONStrictValidation(loadFileAsString("AvroRecordUtilsTest/OldRecordSchema.avsc"));
+  private static final Schema EVOLVED_RECORD_SCHEMA = AvroSchemaParseUtils
+      .parseSchemaFromJSONStrictValidation(loadFileAsString("AvroRecordUtilsTest/EvolvedRecordSchema.avsc"));
+
+  private static String loadFileAsString(String fileName) {
+    try {
+      return IOUtils.toString(
+          Objects.requireNonNull(Thread.currentThread().getContextClassLoader().getResourceAsStream(fileName)),
+          StandardCharsets.UTF_8);
+    } catch (Exception e) {
+      LOGGER.error(e);
+      return null;
+    }
+  }
+
+  @Test
+  public void testAdaptRecordWithSameSchema() {
+    GenericRecord record = new GenericData.Record(SIMPLE_RECORD_SCHEMA);
+    record.put("field", 1);
+
+    Object adaptedRecord = AvroRecordUtils.adaptToSchema(SIMPLE_RECORD_SCHEMA, record);
+    Assert.assertSame(adaptedRecord, record);
+  }
+
+  @Test
+  public void testAdaptRecordFillMissingField() {
+    GenericRecord inputRecord = new GenericData.Record(OLD_RECORD_SCHEMA);
+    GenericRecord inputSubRecord = new GenericData.Record(OLD_RECORD_SCHEMA.getField("field1").schema());
+    inputSubRecord.put("field1_1", 1);
+    inputRecord.put("field1", inputSubRecord);
+
+    Object adaptedRecord = AvroRecordUtils.adaptToSchema(EVOLVED_RECORD_SCHEMA, inputRecord);
+    Assert.assertTrue(adaptedRecord instanceof GenericRecord);
+    GenericRecord adaptedGenericRecord = (GenericRecord) adaptedRecord;
+    Assert.assertEquals(adaptedGenericRecord.getSchema(), EVOLVED_RECORD_SCHEMA);
+    Assert.assertTrue(adaptedGenericRecord.get("field1") instanceof GenericRecord);
+    Assert.assertEquals(((GenericRecord) adaptedGenericRecord.get("field1")).get("field1_1"), 1);
+    Assert.assertEquals(((GenericRecord) adaptedGenericRecord.get("field1")).get("field1_2"), -5);
+    Assert.assertEquals(adaptedGenericRecord.get("field2"), -10);
+  }
+
+  @Test
+  public void testAdaptRecordRemoveExtraField() {
+    GenericRecord inputRecord = new GenericData.Record(EVOLVED_RECORD_SCHEMA);
+    GenericRecord inputSubRecord = new GenericData.Record(EVOLVED_RECORD_SCHEMA.getField("field1").schema());
+    inputSubRecord.put("field1_1", 1);
+    inputSubRecord.put("field1_2", 5);
+    inputRecord.put("field1", inputSubRecord);
+    inputRecord.put("field2", 3);
+
+    Object adaptedRecord = AvroRecordUtils.adaptToSchema(OLD_RECORD_SCHEMA, inputRecord);
+    Assert.assertTrue(adaptedRecord instanceof GenericRecord);
+    GenericRecord adaptedGenericRecord = (GenericRecord) adaptedRecord;
+    Assert.assertEquals(adaptedGenericRecord.getSchema(), OLD_RECORD_SCHEMA);
+    Assert.assertTrue(adaptedGenericRecord.get("field1") instanceof GenericRecord);
+    Assert.assertEquals(((GenericRecord) adaptedGenericRecord.get("field1")).get("field1_1"), 1);
+    Assert.assertNull(((GenericRecord) adaptedGenericRecord.get("field1")).get("field1_2"));
+    Assert.assertNull(adaptedGenericRecord.get("field2"));
+  }
+
+  @Test
+  public void testAdaptRecordInArraySchema() {
+    Schema arraySchema = Schema.createArray(EVOLVED_RECORD_SCHEMA);
+
+    GenericRecord inputRecord = new GenericData.Record(OLD_RECORD_SCHEMA);
+    GenericRecord inputSubRecord = new GenericData.Record(OLD_RECORD_SCHEMA.getField("field1").schema());
+    inputSubRecord.put("field1_1", 1);
+    inputRecord.put("field1", inputSubRecord);
+
+    GenericRecord inputRecord2 = new GenericData.Record(EVOLVED_RECORD_SCHEMA);
+    GenericRecord inputSubRecord2 = new GenericData.Record(EVOLVED_RECORD_SCHEMA.getField("field1").schema());
+    inputSubRecord2.put("field1_1", 1);
+    inputSubRecord2.put("field1_2", 5);
+    inputRecord2.put("field1", inputSubRecord2);
+    inputRecord2.put("field2", 10);
+
+    Object adaptedList = AvroRecordUtils.adaptToSchema(arraySchema, Arrays.asList(inputRecord, inputRecord2));
+    Assert.assertTrue(adaptedList instanceof List);
+
+    Object adaptedRecord = ((List<?>) adaptedList).get(0);
+    Assert.assertTrue(adaptedRecord instanceof GenericRecord);
+    GenericRecord adaptedGenericRecord = (GenericRecord) adaptedRecord;
+    Assert.assertEquals(adaptedGenericRecord.getSchema(), EVOLVED_RECORD_SCHEMA);
+    Assert.assertTrue(adaptedGenericRecord.get("field1") instanceof GenericRecord);
+    Assert.assertEquals(((GenericRecord) adaptedGenericRecord.get("field1")).get("field1_1"), 1);
+    Assert.assertEquals(((GenericRecord) adaptedGenericRecord.get("field1")).get("field1_2"), -5);
+    Assert.assertEquals(adaptedGenericRecord.get("field2"), -10);
+
+    // If a record follows the same schema as the required schema, don't evolve it
+    Object adaptedRecord2 = ((List<?>) adaptedList).get(1);
+    Assert.assertTrue(adaptedRecord2 instanceof GenericRecord);
+    Assert.assertSame(adaptedRecord2, inputRecord2);
+  }
+
+  @Test
+  public void testAdaptRecordInMapSchema() {
+    Schema mapSchema = Schema.createMap(EVOLVED_RECORD_SCHEMA);
+
+    GenericRecord inputRecord = new GenericData.Record(OLD_RECORD_SCHEMA);
+    GenericRecord inputSubRecord = new GenericData.Record(OLD_RECORD_SCHEMA.getField("field1").schema());
+    inputSubRecord.put("field1_1", 1);
+    inputRecord.put("field1", inputSubRecord);
+
+    GenericRecord inputRecord2 = new GenericData.Record(EVOLVED_RECORD_SCHEMA);
+    GenericRecord inputSubRecord2 = new GenericData.Record(EVOLVED_RECORD_SCHEMA.getField("field1").schema());
+    inputSubRecord2.put("field1_1", 1);
+    inputSubRecord2.put("field1_2", 5);
+    inputRecord2.put("field1", inputSubRecord2);
+    inputRecord2.put("field2", 10);
+
+    Map<String, GenericRecord> recordMap = new LinkedHashMap<>();
+    recordMap.put("testEvolveSchema", inputRecord);
+    recordMap.put("testSameSchema", inputRecord2);
+
+    Object adaptedMap = AvroRecordUtils.adaptToSchema(mapSchema, recordMap);
+    Assert.assertTrue(adaptedMap instanceof Map);
+
+    Assert.assertEquals(((Map<String, ?>) adaptedMap).size(), 2);
+
+    Object adaptedRecord = ((Map<String, ?>) adaptedMap).get("testEvolveSchema");
+    Assert.assertTrue(adaptedRecord instanceof GenericRecord);
+    GenericRecord adaptedGenericRecord = (GenericRecord) adaptedRecord;
+    Assert.assertEquals(adaptedGenericRecord.getSchema(), EVOLVED_RECORD_SCHEMA);
+    Assert.assertTrue(adaptedGenericRecord.get("field1") instanceof GenericRecord);
+    Assert.assertEquals(((GenericRecord) adaptedGenericRecord.get("field1")).get("field1_1"), 1);
+    Assert.assertEquals(((GenericRecord) adaptedGenericRecord.get("field1")).get("field1_2"), -5);
+    Assert.assertEquals(adaptedGenericRecord.get("field2"), -10);
+
+    // If a record follows the same schema as the required schema, don't evolve it
+    Object adaptedRecord2 = ((Map<String, ?>) adaptedMap).get("testSameSchema");
+    Assert.assertTrue(adaptedRecord2 instanceof GenericRecord);
+    Assert.assertSame(adaptedRecord2, inputRecord2);
+  }
+
+  @Test
+  public void testAdaptRecordInUnionSchema() {
+    Schema unionSchema = Schema.createUnion(EVOLVED_RECORD_SCHEMA, Schema.create(Schema.Type.NULL));
+
+    GenericRecord inputRecord = new GenericData.Record(OLD_RECORD_SCHEMA);
+    GenericRecord inputSubRecord = new GenericData.Record(OLD_RECORD_SCHEMA.getField("field1").schema());
+    inputSubRecord.put("field1_1", 1);
+    inputRecord.put("field1", inputSubRecord);
+
+    GenericRecord inputRecord2 = new GenericData.Record(EVOLVED_RECORD_SCHEMA);
+    GenericRecord inputSubRecord2 = new GenericData.Record(EVOLVED_RECORD_SCHEMA.getField("field1").schema());
+    inputSubRecord2.put("field1_1", 1);
+    inputSubRecord2.put("field1_2", 5);
+    inputRecord2.put("field1", inputSubRecord2);
+    inputRecord2.put("field2", 10);
+
+    Object adaptedRecord = AvroRecordUtils.adaptToSchema(unionSchema, inputRecord);
+    Assert.assertTrue(adaptedRecord instanceof GenericRecord);
+    GenericRecord adaptedGenericRecord = (GenericRecord) adaptedRecord;
+    Assert.assertEquals(adaptedGenericRecord.getSchema(), EVOLVED_RECORD_SCHEMA);
+    Assert.assertTrue(adaptedGenericRecord.get("field1") instanceof GenericRecord);
+    Assert.assertEquals(((GenericRecord) adaptedGenericRecord.get("field1")).get("field1_1"), 1);
+    Assert.assertEquals(((GenericRecord) adaptedGenericRecord.get("field1")).get("field1_2"), -5);
+    Assert.assertEquals(adaptedGenericRecord.get("field2"), -10);
+
+    // If a record follows the same schema as the required schema, don't evolve it
+    Object adaptedRecord2 = AvroRecordUtils.adaptToSchema(unionSchema, inputRecord2);
+    Assert.assertTrue(adaptedRecord2 instanceof GenericRecord);
+    Assert.assertSame(adaptedRecord2, inputRecord2);
+  }
+}

--- a/internal/venice-common/src/test/resources/AvroRecordUtilsTest/EvolvedRecordSchema.avsc
+++ b/internal/venice-common/src/test/resources/AvroRecordUtilsTest/EvolvedRecordSchema.avsc
@@ -1,0 +1,30 @@
+{
+  "name": "record",
+  "type": "record",
+  "fields": [
+    {
+      "name": "field1",
+      "type": {
+        "name": "FieldRecord",
+        "type": "record",
+        "fields": [
+          {
+            "name": "field1_1",
+            "type": "int",
+            "default": -1
+          },
+          {
+            "name": "field1_2",
+            "type": "int",
+            "default": -5
+          }
+        ]
+      }
+    },
+    {
+      "name": "field2",
+      "type": "int",
+      "default": -10
+    }
+  ]
+}

--- a/internal/venice-common/src/test/resources/AvroRecordUtilsTest/OldRecordSchema.avsc
+++ b/internal/venice-common/src/test/resources/AvroRecordUtilsTest/OldRecordSchema.avsc
@@ -1,0 +1,20 @@
+{
+  "name": "record",
+  "type": "record",
+  "fields": [
+    {
+      "name": "field1",
+      "type": {
+        "name": "FieldRecord",
+        "type": "record",
+        "fields": [
+          {
+            "name": "field1_1",
+            "type": "int",
+            "default": -1
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/internal/venice-common/src/test/resources/AvroRecordUtilsTest/SimpleRecordSchema.avsc
+++ b/internal/venice-common/src/test/resources/AvroRecordUtilsTest/SimpleRecordSchema.avsc
@@ -1,0 +1,10 @@
+{
+  "name": "record",
+  "type": "record",
+  "fields": [
+    {
+      "name": "field",
+      "type": "int"
+    }
+  ]
+}

--- a/internal/venice-common/src/test/resources/TestEvolvedWriteComputeBuilder.avsc
+++ b/internal/venice-common/src/test/resources/TestEvolvedWriteComputeBuilder.avsc
@@ -1,0 +1,106 @@
+{
+  "name": "Person",
+  "type": "record",
+  "fields": [
+    {
+      "name": "name",
+      "type": "string",
+      "default": "default_name"
+    },
+    {
+      "name": "age",
+      "type": "int",
+      "default": -1
+    },
+    {
+      "name": "address",
+      "type": [
+        "null",
+        {
+          "type": "record",
+          "name": "AddressUSRecord",
+          "fields": [
+            {
+              "name": "state",
+              "type": "string",
+              "default": "California"
+            },
+            {
+              "name": "streetaddress",
+              "type": "string",
+              "default": "unknown"
+            },
+            {
+              "name": "city",
+              "type": "string",
+              "default": "Sunnyvale"
+            }
+          ]
+        }
+      ],
+      "default": null
+    },
+    {
+      "name": "intArray",
+      "type": {
+        "type": "array",
+        "items": "int"
+      },
+      "default": []
+    },
+    {
+      "name": "recordArray",
+      "type": {
+        "type": "array",
+        "items": {
+          "type": "record",
+          "name": "ArrayRecord",
+          "fields": [
+            {
+              "name": "name",
+              "type": "string",
+              "default": "venice"
+            },
+            {
+              "name": "number",
+              "type": "int",
+              "default": -1
+            }
+          ]
+        }
+      },
+      "default": []
+    },
+    {
+      "name": "stringMap",
+      "type": {
+        "type": "map",
+        "values": "string"
+      },
+      "default": {}
+    },
+    {
+      "name": "recordMap",
+      "type": {
+        "type": "map",
+        "values": {
+          "type": "record",
+          "name": "MapRecord",
+          "fields": [
+            {
+              "name": "name",
+              "type": "string",
+              "default": "venice"
+            },
+            {
+              "name": "number",
+              "type": "int",
+              "default": -1
+            }
+          ]
+        }
+      },
+      "default": []
+    }
+  ]
+}

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestHybrid.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestHybrid.java
@@ -85,6 +85,7 @@ import com.linkedin.venice.samza.VeniceSystemProducer;
 import com.linkedin.venice.serializer.AvroGenericDeserializer;
 import com.linkedin.venice.serializer.AvroSerializer;
 import com.linkedin.venice.systemstore.schemas.StoreProperties;
+import com.linkedin.venice.utils.AvroRecordUtils;
 import com.linkedin.venice.utils.ByteUtils;
 import com.linkedin.venice.utils.DataProviderUtils;
 import com.linkedin.venice.utils.IntegrationTestPushUtils;
@@ -227,7 +228,7 @@ public class TestHybrid {
       // And real-time topic should exist now.
       assertTrue(topicManager.containsTopicAndAllPartitionsAreOnline(Version.composeRealTimeTopic(storeName)));
       // Creating a store object with default values since we're not updating bootstrap to online timeout
-      StoreProperties storeProperties = Store.prefillAvroRecordWithDefaultValue(new StoreProperties());
+      StoreProperties storeProperties = AvroRecordUtils.prefillAvroRecordWithDefaultValue(new StoreProperties());
       storeProperties.name = storeName;
       storeProperties.owner = "owner";
       storeProperties.createdTime = System.currentTimeMillis();

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/kafka/TopicManagerTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/kafka/TopicManagerTest.java
@@ -39,6 +39,7 @@ import com.linkedin.venice.pubsub.api.PubSubProducerAdapter;
 import com.linkedin.venice.serialization.KafkaKeySerializer;
 import com.linkedin.venice.serialization.avro.KafkaValueSerializer;
 import com.linkedin.venice.systemstore.schemas.StoreProperties;
+import com.linkedin.venice.utils.AvroRecordUtils;
 import com.linkedin.venice.utils.IntegrationTestPushUtils;
 import com.linkedin.venice.utils.TestMockTime;
 import com.linkedin.venice.utils.TestUtils;
@@ -560,7 +561,7 @@ public class TopicManagerTest {
 
   @Test
   public void testMinimumExpectedRetentionTime() {
-    StoreProperties storeProperties = Store.prefillAvroRecordWithDefaultValue(new StoreProperties());
+    StoreProperties storeProperties = AvroRecordUtils.prefillAvroRecordWithDefaultValue(new StoreProperties());
     storeProperties.name = "storeName";
     storeProperties.owner = "owner";
     storeProperties.createdTime = System.currentTimeMillis();
@@ -581,7 +582,7 @@ public class TopicManagerTest {
 
   @Test
   public void testExpectedRetentionTime() {
-    StoreProperties storeProperties = Store.prefillAvroRecordWithDefaultValue(new StoreProperties());
+    StoreProperties storeProperties = AvroRecordUtils.prefillAvroRecordWithDefaultValue(new StoreProperties());
     storeProperties.name = "storeName";
     storeProperties.owner = "owner";
     storeProperties.createdTime = System.currentTimeMillis();


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci], [server], [controller],
[router], [samza], [vpj], [fast-client], [thin-client], [alpini],
[admin-tool], [test], [build], [doc], [script]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Adapt modified records in `UpdateBuilderImpl` to the specified update schema using default values
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
The original intention of creating the `UpdateBuilder` abstraction was that the users need not be aware of other fields in the schema when making partial updates to records. Hence, it is possible that a framework generates the base `UpdateBuilder` object and the user code only fills in the fields they wish to update. In such a case, the schema of the value object might be different from what is used by the `UpdateBuilderImpl` object. This is possible if sub fields are evolved, but the writer is still only writing using older schemas.

To reduce the number of user disruptions, the `UpdateBuilderImpl` will make a best effort to adapt the records specified by the user to the schema that the `UpdateBuilderImpl` object uses. This is achieved by:
1. Filling in default values for fields that are present in the update schema but not present in the user-provided object
    1. The new fields must have default values since the records must be fully compatible.
2. Removing extra values that are not in update schema
    1. The fields that are not present in the update schema, but are present in the user-specified object, will not be written to Venice.
    2. From the user's perspective, this is a case of "data loss", but it can be avoided by the framework/application
    3.  To reduce the occurrence of such best-effort adaptations, the application/framework must try to always use the latest superset schema to create the `UpdateBuilderImpl` object

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
Added unit tests. GH CI

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [X] Yes. Make sure to explain your proposed changes and call out the behavior change.

The `UpdateBuilderImpl` will make a best-effort to adapt the partial update records to the update schema