### PR TITLE
[controller][vpj][changelog][admin-tool] Shutdown D2 client if it fails startup

### DIFF
--- a/docs/dev_guide/recommended_development_workflow.md
+++ b/docs/dev_guide/recommended_development_workflow.md
@@ -22,8 +22,8 @@ The GitHub issue should contain the detailed problem statement.
 4. Run all tests as described in the project's [Workspace setup guide](../dev_guide/workspace_setup.md#run-the-test-suite).
 5. Open a pull request against the `main` branch of `linkedin/venice`. (Only in special cases would the PR be opened against other branches.)
 6. The PR title should usually be of the form `[component1]...[componentN]: Concise commit message`.
-   * Valid component tags are: `[da-vinci]`, `[server]`, `[controller]`,
-      `[router]`, `[samza]`, `[vpj]`, `[fast-client]`, `[thin-client]`, `[alpini]`,
+   * Valid tags are: `[da-vinci]` (or `[dvc]`), `[server]`, `[controller]`, `[router]`, `[samza]`,
+      `[vpj]`, `[fast-client]` (or `[fc]`), `[thin-client]` (or `[tc]`), `[changelog]` (or `[cc]`),
       `[admin-tool]`, `[test]`, `[build]`, `[doc]`, `[script]`, `[compat]`
    * `[compat]` tag means there are compatibility related changes in this PR, including upgrading protocol version, upgrading system store value schemas, etc. When there is a compatibility related change, it usually requires a specific deployment order, like upgrading controller before upgrading server. In this case, please explicitly call out the required deployment order in the commit message.
 7. If the pull request is still a work in progress, and so is not ready to be merged, but needs to be pushed to GitHub to facilitate review,


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci], [server], [controller],
[router], [samza], [vpj], [fast-client], [thin-client], [alpini],
[admin-tool], [test], [build], [doc], [script]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Shutdown D2 client if it fails startup
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
We saw a case when rolling `D2ClientFactory` out where the D2 client startup failed to start up. In this instance, it didn't clean up the partial resources it had acquired. Some threads inside the D2 client held up the shutdown of the application. To force release of resources, we explicitly shut down the client if it fails during start up.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
Will wait for GH CI

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.