### PR TITLE
[dvc][server] Reduced hot path calls to the clock in metrics

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/AbstractStoreBufferService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/AbstractStoreBufferService.java
@@ -17,7 +17,7 @@ public abstract class AbstractStoreBufferService extends AbstractVeniceService {
       LeaderProducedRecordContext leaderProducedRecordContext,
       int subPartition,
       String kafkaUrl,
-      long beforeProcessingRecordTimestamp) throws InterruptedException;
+      long beforeProcessingRecordTimestampNs) throws InterruptedException;
 
   /**
    * This method will wait for all the messages to be processed (persisted to disk) that are already

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
@@ -432,13 +432,11 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
             consumerTaskId + " : Invalid/Unrecognized operation type submitted: " + kafkaValue.messageType);
     }
 
-    long currentTimeNs = System.nanoTime();
-    long currentTimeMs = currentTimeNs / Time.NS_PER_MS;
     aggVersionedIngestionStats.recordConsumedRecordEndToEndProcessingLatency(
         storeName,
         versionNumber,
-        LatencyUtils.convertLatencyFromNSToMS(currentTimeNs - beforeProcessingRecordTimestamp),
-        currentTimeMs);
+        LatencyUtils.getLatencyInMS(beforeProcessingRecordTimestamp),
+        System.currentTimeMillis());
 
     if (mergeConflictResult.isUpdateIgnored()) {
       hostLevelIngestionStats.recordUpdateIgnoredDCR();

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderProducerCallback.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderProducerCallback.java
@@ -15,6 +15,7 @@ import com.linkedin.venice.storage.protocol.ChunkedValueManifest;
 import com.linkedin.venice.utils.ByteUtils;
 import com.linkedin.venice.utils.LatencyUtils;
 import com.linkedin.venice.utils.RedundantExceptionFilter;
+import com.linkedin.venice.utils.Time;
 import com.linkedin.venice.writer.ChunkAwareCallback;
 import java.nio.ByteBuffer;
 import org.apache.logging.log4j.LogManager;
@@ -116,11 +117,14 @@ class LeaderProducerCallback implements ChunkAwareCallback {
       // queuing to drainer.
       // this indicates how much time kafka took to deliver the message to broker.
       if (!ingestionTask.isUserSystemStore()) {
+        long currentTimeNano = System.nanoTime();
+        long currentTimeMillis = currentTimeNano / Time.NS_PER_MS;
         ingestionTask.getVersionedDIVStats()
             .recordLeaderProducerCompletionTime(
                 ingestionTask.getStoreName(),
                 ingestionTask.versionNumber,
-                LatencyUtils.getLatencyInMS(produceTimeNs));
+                LatencyUtils.convertLatencyFromNSToMS(currentTimeNano - produceTimeNs),
+                currentTimeMillis);
       }
 
       int producedRecordNum = 0;

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderProducerCallback.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderProducerCallback.java
@@ -15,7 +15,6 @@ import com.linkedin.venice.storage.protocol.ChunkedValueManifest;
 import com.linkedin.venice.utils.ByteUtils;
 import com.linkedin.venice.utils.LatencyUtils;
 import com.linkedin.venice.utils.RedundantExceptionFilter;
-import com.linkedin.venice.utils.Time;
 import com.linkedin.venice.writer.ChunkAwareCallback;
 import java.nio.ByteBuffer;
 import org.apache.logging.log4j.LogManager;
@@ -117,14 +116,12 @@ class LeaderProducerCallback implements ChunkAwareCallback {
       // queuing to drainer.
       // this indicates how much time kafka took to deliver the message to broker.
       if (!ingestionTask.isUserSystemStore()) {
-        long currentTimeNano = System.nanoTime();
-        long currentTimeMillis = currentTimeNano / Time.NS_PER_MS;
         ingestionTask.getVersionedDIVStats()
             .recordLeaderProducerCompletionTime(
                 ingestionTask.getStoreName(),
                 ingestionTask.versionNumber,
-                LatencyUtils.convertLatencyFromNSToMS(currentTimeNano - produceTimeNs),
-                currentTimeMillis);
+                LatencyUtils.getLatencyInMS(produceTimeNs),
+                System.currentTimeMillis());
       }
 
       int producedRecordNum = 0;

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/SeparatedStoreBufferService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/SeparatedStoreBufferService.java
@@ -67,7 +67,7 @@ public class SeparatedStoreBufferService extends AbstractStoreBufferService {
       LeaderProducedRecordContext leaderProducedRecordContext,
       int subPartition,
       String kafkaUrl,
-      long beforeProcessingRecordTimestamp) throws InterruptedException {
+      long beforeProcessingRecordTimestampNs) throws InterruptedException {
     PartitionConsumptionState partitionConsumptionState = ingestionTask.getPartitionConsumptionState(subPartition);
     boolean sortedInput = false;
     if (partitionConsumptionState != null) {
@@ -104,7 +104,7 @@ public class SeparatedStoreBufferService extends AbstractStoreBufferService {
         leaderProducedRecordContext,
         subPartition,
         kafkaUrl,
-        beforeProcessingRecordTimestamp);
+        beforeProcessingRecordTimestampNs);
   }
 
   @Override

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/AggVersionedDIVStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/AggVersionedDIVStats.java
@@ -56,61 +56,53 @@ public class AggVersionedDIVStats extends AbstractVeniceAggVersionedStats<DIVSta
     recordVersionedAndTotalStat(storeName, version, DIVStats::recordSuccessMsg);
   }
 
-  public void recordCurrentIdleTime(String storeName, int version) {
-    // we don't record current idle time for total stats
-    Utils.computeIfNotNull(getStats(storeName, version), DIVStats::recordCurrentIdleTime);
-  }
-
-  public void recordOverallIdleTime(String storeName, int version) {
-    recordVersionedAndTotalStat(storeName, version, DIVStats::recordOverallIdleTime);
-  }
-
-  public void resetCurrentIdleTime(String storeName, int version) {
-    // we don't record current idle time for total stats
-    Utils.computeIfNotNull(getStats(storeName, version), DIVStats::resetCurrentIdleTime);
-  }
-
   public void recordLatencies(
       String storeName,
       int version,
+      long currentTimeMs,
       double producerBrokerLatencyMs,
       double brokerConsumerLatencyMs,
       double producerConsumerLatencyMs) {
     recordVersionedAndTotalStat(storeName, version, stat -> {
-      stat.recordProducerBrokerLatencyMs(producerBrokerLatencyMs);
-      stat.recordBrokerConsumerLatencyMs(brokerConsumerLatencyMs);
-      stat.recordProducerConsumerLatencyMs(producerConsumerLatencyMs);
+      stat.recordProducerBrokerLatencyMs(producerBrokerLatencyMs, currentTimeMs);
+      stat.recordBrokerConsumerLatencyMs(brokerConsumerLatencyMs, currentTimeMs);
+      stat.recordProducerConsumerLatencyMs(producerConsumerLatencyMs, currentTimeMs);
     });
   }
 
   public void recordLeaderLatencies(
       String storeName,
       int version,
+      long currentTimeMs,
       double producerBrokerLatencyMs,
       double brokerConsumerLatencyMs,
       double producerConsumerLatencyMs) {
     recordVersionedAndTotalStat(storeName, version, stat -> {
-      stat.recordProducerSourceBrokerLatencyMs(producerBrokerLatencyMs);
-      stat.recordSourceBrokerLeaderConsumerLatencyMs(brokerConsumerLatencyMs);
-      stat.recordProducerLeaderConsumerLatencyMs(producerConsumerLatencyMs);
+      stat.recordProducerSourceBrokerLatencyMs(producerBrokerLatencyMs, currentTimeMs);
+      stat.recordSourceBrokerLeaderConsumerLatencyMs(brokerConsumerLatencyMs, currentTimeMs);
+      stat.recordProducerLeaderConsumerLatencyMs(producerConsumerLatencyMs, currentTimeMs);
     });
   }
 
   public void recordFollowerLatencies(
       String storeName,
       int version,
+      long currentTimeMs,
       double producerBrokerLatencyMs,
       double brokerConsumerLatencyMs,
       double producerConsumerLatencyMs) {
     recordVersionedAndTotalStat(storeName, version, stat -> {
-      stat.recordProducerLocalBrokerLatencyMs(producerBrokerLatencyMs);
-      stat.recordLocalBrokerFollowerConsumerLatencyMs(brokerConsumerLatencyMs);
-      stat.recordProducerFollowerConsumerLatencyMs(producerConsumerLatencyMs);
+      stat.recordProducerLocalBrokerLatencyMs(producerBrokerLatencyMs, currentTimeMs);
+      stat.recordLocalBrokerFollowerConsumerLatencyMs(brokerConsumerLatencyMs, currentTimeMs);
+      stat.recordProducerFollowerConsumerLatencyMs(producerConsumerLatencyMs, currentTimeMs);
     });
   }
 
-  public void recordLeaderProducerCompletionTime(String storeName, int version, double value) {
-    recordVersionedAndTotalStat(storeName, version, stat -> stat.recordLeaderProducerCompletionLatencyMs(value));
+  public void recordLeaderProducerCompletionTime(String storeName, int version, double value, long currentTimeMs) {
+    recordVersionedAndTotalStat(
+        storeName,
+        version,
+        stat -> stat.recordLeaderProducerCompletionLatencyMs(value, currentTimeMs));
   }
 
   public void recordBenignLeaderOffsetRewind(String storeName, int version) {
@@ -166,6 +158,8 @@ public class AggVersionedDIVStats extends AbstractVeniceAggVersionedStats<DIVSta
     resetTotalStats(storeName, existingVersions, DIVStats::getMissingMsg, DIVStats::setMissingMsg);
     // Update total corrupt msg count
     resetTotalStats(storeName, existingVersions, DIVStats::getCorruptedMsg, DIVStats::setCorruptedMsg);
+    // Update total success msg count
+    resetTotalStats(storeName, existingVersions, DIVStats::getSuccessMsg, DIVStats::setSuccessMsg);
   }
 
   private void resetTotalStats(

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/AggVersionedIngestionStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/AggVersionedIngestionStats.java
@@ -85,11 +85,12 @@ public class AggVersionedIngestionStats
       int version,
       int regionId,
       long bytesConsumed,
-      long offsetConsumed) {
+      long offsetConsumed,
+      long currentTimeMs) {
     recordVersionedAndTotalStat(storeName, version, stat -> {
-      stat.recordRegionHybridBytesConsumed(regionId, bytesConsumed);
-      stat.recordRegionHybridRecordsConsumed(regionId, 1);
-      stat.recordRegionHybridAvgConsumedOffset(regionId, offsetConsumed);
+      stat.recordRegionHybridBytesConsumed(regionId, bytesConsumed, currentTimeMs);
+      stat.recordRegionHybridRecordsConsumed(regionId, 1, currentTimeMs);
+      stat.recordRegionHybridAvgConsumedOffset(regionId, offsetConsumed, currentTimeMs);
     });
   }
 
@@ -126,11 +127,19 @@ public class AggVersionedIngestionStats
   }
 
   public void recordSubscribePrepLatency(String storeName, int version, double value) {
-    recordVersionedAndTotalStat(storeName, version, stat -> stat.recordSubscribePrepLatency(value));
+    long currentTimeMs = System.currentTimeMillis();
+    recordVersionedAndTotalStat(storeName, version, stat -> stat.recordSubscribePrepLatency(value, currentTimeMs));
   }
 
-  public void recordConsumedRecordEndToEndProcessingLatency(String storeName, int version, double value) {
-    recordVersionedAndTotalStat(storeName, version, stat -> stat.recordConsumedRecordEndToEndProcessingLatency(value));
+  public void recordConsumedRecordEndToEndProcessingLatency(
+      String storeName,
+      int version,
+      double value,
+      long currentTimeMs) {
+    recordVersionedAndTotalStat(
+        storeName,
+        version,
+        stat -> stat.recordConsumedRecordEndToEndProcessingLatency(value, currentTimeMs));
   }
 
   public void recordVersionTopicEndOffsetRewind(String storeName, int version) {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/DIVStatsReporter.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/DIVStatsReporter.java
@@ -25,8 +25,6 @@ public class DIVStatsReporter extends AbstractVeniceStatsReporter<DIVStats> {
     registerSensor("missing_msg", new DIVStatsCounter(this, () -> (double) getStats().getMissingMsg()));
     registerSensor("corrupted_msg", new DIVStatsCounter(this, () -> (double) getStats().getCorruptedMsg()));
     registerSensor("success_msg", new DIVStatsCounter(this, () -> (double) getStats().getSuccessMsg()));
-    registerSensor("current_idle_time", new DIVStatsCounter(this, () -> (double) getStats().getCurrentIdleTime()));
-    registerSensor("overall_idle_time", new DIVStatsCounter(this, () -> (double) getStats().getOverallIdleTime()));
     registerSensor(
         "benign_leader_offset_rewind_count",
         new DIVStatsCounter(this, () -> (double) getStats().getBenignLeaderOffsetRewindCount()));

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/HostLevelIngestionStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/HostLevelIngestionStats.java
@@ -128,8 +128,6 @@ public class HostLevelIngestionStats extends AbstractVeniceStats {
    */
   private final LongAdderRateGauge totalTombstoneCreationDCRSensor = new LongAdderRateGauge();
 
-  private final Sensor totalLeaderDelegateRealTimeRecordLatencySensor;
-
   private Sensor registerPerStoreAndTotal(
       String sensorName,
       HostLevelIngestionStats totalStats,
@@ -195,12 +193,6 @@ public class HostLevelIngestionStats extends AbstractVeniceStats {
     registerOnlyTotal("timestamp_regression_dcr_error", totalStats, totalTimestampRegressionDCRErrorRate);
 
     registerOnlyTotal("offset_regression_dcr_error", totalStats, totalOffsetRegressionDCRErrorRate);
-
-    this.totalLeaderDelegateRealTimeRecordLatencySensor = registerOnlyTotal(
-        "leader_delegate_real_time_record_latency",
-        totalStats,
-        () -> totalStats.totalLeaderDelegateRealTimeRecordLatencySensor,
-        avgAndMax());
 
     Int2ObjectMap<String> kafkaClusterIdToAliasMap = serverConfig.getKafkaClusterIdToAliasMap();
     int listSize = kafkaClusterIdToAliasMap.isEmpty() ? 0 : Collections.max(kafkaClusterIdToAliasMap.keySet()) + 1;
@@ -495,15 +487,15 @@ public class HostLevelIngestionStats extends AbstractVeniceStats {
     totalFollowerRecordsConsumedSensor.record();
   }
 
-  public void recordTotalRegionHybridBytesConsumed(int regionId, long bytes) {
+  public void recordTotalRegionHybridBytesConsumed(int regionId, long bytes, long currentTimeMs) {
     Sensor sensor = totalHybridBytesConsumedByRegionId.get(regionId);
     if (sensor != null) {
-      sensor.record(bytes);
+      sensor.record(bytes, currentTimeMs);
     }
 
     sensor = totalHybridRecordsConsumedByRegionId.get(regionId);
     if (sensor != null) {
-      sensor.record(1);
+      sensor.record(1, currentTimeMs);
     }
   }
 
@@ -525,9 +517,5 @@ public class HostLevelIngestionStats extends AbstractVeniceStats {
 
   public void recordOffsetRegressionDCRError() {
     totalOffsetRegressionDCRErrorRate.record();
-  }
-
-  public void recordLeaderDelegateRealTimeRecordLatency(double latency) {
-    totalLeaderDelegateRealTimeRecordLatencySensor.record(latency);
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/HostLevelIngestionStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/HostLevelIngestionStats.java
@@ -451,8 +451,8 @@ public class HostLevelIngestionStats extends AbstractVeniceStats {
     checkLongRunningTasksLatencySensor.record(latency);
   }
 
-  public void recordStorageEnginePutLatency(double latency) {
-    storageEnginePutLatencySensor.record(latency);
+  public void recordStorageEnginePutLatency(double latency, long currentTimeMs) {
+    storageEnginePutLatencySensor.record(latency, currentTimeMs);
   }
 
   public void recordWriteComputeCacheHitCount() {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/IngestionStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/IngestionStats.java
@@ -299,8 +299,8 @@ public class IngestionStats {
     return subscribePrepLatencySensor.getMax();
   }
 
-  public void recordSubscribePrepLatency(double value) {
-    subscribePrepLatencySensor.record(value);
+  public void recordSubscribePrepLatency(double value, long currentTimeMs) {
+    subscribePrepLatencySensor.record(value, currentTimeMs);
   }
 
   public void recordStalePartitionsWithoutIngestionTask() {
@@ -323,8 +323,8 @@ public class IngestionStats {
     return consumedRecordEndToEndProcessingLatencySensor.getMax();
   }
 
-  public void recordConsumedRecordEndToEndProcessingLatency(double value) {
-    consumedRecordEndToEndProcessingLatencySensor.record(value);
+  public void recordConsumedRecordEndToEndProcessingLatency(double value, long currentTimeMs) {
+    consumedRecordEndToEndProcessingLatencySensor.record(value, currentTimeMs);
   }
 
   public double getRecordsConsumed() {
@@ -332,7 +332,7 @@ public class IngestionStats {
   }
 
   public void recordRecordsConsumed() {
-    recordsConsumedSensor.record();
+    recordsConsumedSensor.record(1);
   }
 
   public double getBytesConsumed() {
@@ -400,10 +400,10 @@ public class IngestionStats {
     return rate != null ? rate.measure(METRIC_CONFIG, System.currentTimeMillis()) : 0.0;
   }
 
-  public void recordRegionHybridBytesConsumed(int regionId, double value) {
+  public void recordRegionHybridBytesConsumed(int regionId, double value, long currentTimeMs) {
     Sensor sensor = regionIdToHybridBytesConsumedSensorMap.get(regionId);
     if (sensor != null) {
-      sensor.record(value);
+      sensor.record(value, currentTimeMs);
     }
   }
 
@@ -412,10 +412,10 @@ public class IngestionStats {
     return rate != null ? rate.measure(METRIC_CONFIG, System.currentTimeMillis()) : 0.0;
   }
 
-  public void recordRegionHybridRecordsConsumed(int regionId, double value) {
+  public void recordRegionHybridRecordsConsumed(int regionId, double value, long currentTimeMs) {
     Sensor sensor = regionIdToHybridRecordsConsumedSensorMap.get(regionId);
     if (sensor != null) {
-      sensor.record(value);
+      sensor.record(value, currentTimeMs);
     }
   }
 
@@ -424,10 +424,10 @@ public class IngestionStats {
     return avg != null ? avg.measure(METRIC_CONFIG, System.currentTimeMillis()) : 0.0;
   }
 
-  public void recordRegionHybridAvgConsumedOffset(int regionId, double value) {
+  public void recordRegionHybridAvgConsumedOffset(int regionId, double value, long currentTimeMs) {
     Sensor sensor = regionIdToHybridAvgConsumedOffsetSensorMap.get(regionId);
     if (sensor != null) {
-      sensor.record(value);
+      sensor.record(value, currentTimeMs);
     }
   }
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/WritePathLatencySensor.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/WritePathLatencySensor.java
@@ -42,7 +42,7 @@ public class WritePathLatencySensor {
   /**
    * Record the latency value.
    */
-  public void record(double value) {
-    sensor.record(value);
+  public void record(double value, long currentTimeMs) {
+    sensor.record(value, currentTimeMs);
   }
 }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
@@ -86,6 +86,7 @@ import com.linkedin.venice.kafka.TopicManager;
 import com.linkedin.venice.kafka.TopicManagerRepository;
 import com.linkedin.venice.kafka.protocol.ControlMessage;
 import com.linkedin.venice.kafka.protocol.KafkaMessageEnvelope;
+import com.linkedin.venice.kafka.protocol.ProducerMetadata;
 import com.linkedin.venice.kafka.protocol.Put;
 import com.linkedin.venice.kafka.protocol.TopicSwitch;
 import com.linkedin.venice.kafka.protocol.enums.ControlMessageType;
@@ -206,6 +207,7 @@ import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.mockito.ArgumentCaptor;
+import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
@@ -3217,34 +3219,47 @@ public abstract class StoreIngestionTaskTest {
     Assert.assertEquals(mockNotifierError.size(), 0);
   }
 
-  @Test
-  public void testProduceToStoreBufferService() throws Exception {
-    KafkaKey kafkaKey = new KafkaKey(MessageType.PUT, new byte[1]);
+  @Test(dataProvider = "True-and-False", dataProviderClass = DataProviderUtils.class)
+  public void testProduceToStoreBufferService(boolean activeActiveEnabled) throws Exception {
+    byte[] keyBytes = new byte[1];
+    KafkaKey kafkaKey = new KafkaKey(MessageType.PUT, keyBytes);
     KafkaMessageEnvelope kafkaMessageEnvelope = new KafkaMessageEnvelope();
     kafkaMessageEnvelope.messageType = MessageType.PUT.getValue();
     Put put = new Put();
-    put.putValue = ByteBuffer.allocate(1);
+    put.putValue = ByteBuffer.allocate(10);
+    put.putValue.position(4);
+    put.replicationMetadataPayload = ByteBuffer.allocate(10);
     kafkaMessageEnvelope.payloadUnion = put;
+    kafkaMessageEnvelope.producerMetadata = new ProducerMetadata();
     PubSubMessage<KafkaKey, KafkaMessageEnvelope, Long> pubSubMessage = new ImmutablePubSubMessage(
         kafkaKey,
         kafkaMessageEnvelope,
-        new PubSubTopicPartitionImpl(pubSubTopic, 1),
+        new PubSubTopicPartitionImpl(pubSubTopic, PARTITION_FOO),
         0,
         0,
         0);
 
     HostLevelIngestionStats stats = mock(HostLevelIngestionStats.class);
     when(mockAggStoreIngestionStats.getStoreStats(anyString())).thenReturn(stats);
+    LeaderProducedRecordContext leaderProducedRecordContext = mock(LeaderProducedRecordContext.class);
+    when(leaderProducedRecordContext.getMessageType()).thenReturn(MessageType.PUT);
+    when(leaderProducedRecordContext.getValueUnion()).thenReturn(put);
+    when(leaderProducedRecordContext.getKeyBytes()).thenReturn(keyBytes);
 
     runTest(Collections.singleton(PARTITION_FOO), () -> {
+      TestUtils.waitForNonDeterministicAssertion(
+          5,
+          TimeUnit.SECONDS,
+          () -> assertTrue(storeIngestionTaskUnderTest.hasAnySubscription()));
+
       Runnable produce = () -> {
         try {
           storeIngestionTaskUnderTest.produceToStoreBufferService(
               pubSubMessage,
-              mock(LeaderProducedRecordContext.class),
-              0,
+              leaderProducedRecordContext,
+              PARTITION_FOO,
               localKafkaConsumerService.kafkaUrl,
-              0);
+              System.nanoTime());
         } catch (InterruptedException e) {
           throw new VeniceException(e);
         }
@@ -3258,7 +3273,16 @@ public abstract class StoreIngestionTaskTest {
       storeIngestionTaskUnderTest.enableMetricsEmission();
       produce.run();
       verify(stats, times(2)).recordConsumerRecordsQueuePutLatency(anyDouble());
-    }, false);
+
+      long currentTimeMs = System.currentTimeMillis();
+      long errorMargin = 10_000;
+      verify(mockVersionedStorageIngestionStats, timeout(1000).times(3)).recordConsumedRecordEndToEndProcessingLatency(
+          anyString(),
+          anyInt(),
+          ArgumentMatchers.doubleThat(argument -> argument >= 0 && argument < 1000),
+          ArgumentMatchers
+              .longThat(argument -> argument > currentTimeMs - errorMargin && argument < currentTimeMs + errorMargin));
+    }, activeActiveEnabled);
   }
 
   @Test

--- a/services/venice-server/src/test/java/com/linkedin/venice/stats/VersionedDIVStatsReporterTest.java
+++ b/services/venice-server/src/test/java/com/linkedin/venice/stats/VersionedDIVStatsReporterTest.java
@@ -1,7 +1,5 @@
 package com.linkedin.venice.stats;
 
-import static com.linkedin.venice.stats.StatsErrorCode.NULL_DIV_STATS;
-
 import com.linkedin.davinci.stats.DIVStats;
 import com.linkedin.davinci.stats.DIVStatsReporter;
 import com.linkedin.davinci.stats.VeniceVersionedStatsReporter;
@@ -27,19 +25,12 @@ public class VersionedDIVStatsReporterTest {
         new VeniceVersionedStatsReporter<>(metricsRepository, storeName, DIVStatsReporter::new);
     DIVStats stats = new DIVStats();
 
-    stats.recordCurrentIdleTime();
     statsReporter.setFutureStats(1, stats);
     Assert.assertEquals(reporter.query("." + storeName + "--future_version.VersionStat").value(), 1d);
-    Assert.assertEquals(reporter.query("." + storeName + "_future--current_idle_time.DIVStatsCounter").value(), 1d);
 
     statsReporter.setFutureStats(0, null);
-    stats.recordCurrentIdleTime();
     statsReporter.setCurrentStats(1, stats);
     Assert.assertEquals(reporter.query("." + storeName + "--future_version.VersionStat").value(), 0d);
-    Assert.assertEquals(
-        reporter.query("." + storeName + "_future--current_idle_time.DIVStatsCounter").value(),
-        (double) NULL_DIV_STATS.code);
     Assert.assertEquals(reporter.query("." + storeName + "--current_version.VersionStat").value(), 1d);
-    Assert.assertEquals(reporter.query("." + storeName + "_current--current_idle_time.DIVStatsCounter").value(), 2d);
   }
 }


### PR DESCRIPTION
Removed ~30 calls to the clock / ingested message.

Fixed a concurrency correctness issue in DIVStats' manually-maintained counters and changed success and duplicate message counters into LongAdders, since they are expected to be hot path counters. Also added the code to reset the success msg counter, which was missing (all other counters in this class had it...).

Changed consumed_record_end_to_end_processing_latency so that it gets recorded on every message. Previously, it was recorded only when DCR determined that the write should be dropped, which seemed incorrect.

Removed following metrics:

- leader_delegate_real_time_record_latency (consistently very low, didn't seem useful)
- current_idle_time (unused)
- overall_idle_time (unused)