### PR TITLE
[thin-client] Add an API to fetch the current superset schema for a store

### DIFF
--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/schema/StoreSchemaFetcher.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/schema/StoreSchemaFetcher.java
@@ -25,6 +25,15 @@ public interface StoreSchemaFetcher extends Closeable {
   Schema getLatestValueSchema();
 
   /**
+   * Get the superset value schema for a given store. Each store has at most one active superset schema. Specifically a
+   * store must have some features enabled (e.g. read compute, write compute) to have a superset value schema which
+   * evolves as new value schemas are added.
+   *
+   * @return Superset value schema or {@code null} if store {@param storeName} does not have any superset value schema.
+   */
+  Schema getSupersetSchema();
+
+  /**
    * Returns the Update (Write Compute) schema of the provided Value schema. The returned schema is used to construct
    * a {@link GenericRecord} that partially updates a record value that is associated with this value schema.
    * This method is expected to throw {@link InvalidVeniceSchemaException} when the provided value schema could not be

--- a/clients/venice-thin-client/src/test/java/com/linkedin/venice/client/schema/RouterBasedStoreSchemaFetcherTest.java
+++ b/clients/venice-thin-client/src/test/java/com/linkedin/venice/client/schema/RouterBasedStoreSchemaFetcherTest.java
@@ -31,6 +31,8 @@ public class RouterBasedStoreSchemaFetcherTest {
           + "  \"fields\": [           " + "       { \"name\": \"id\", \"type\": \"string\", \"default\": \"id\"},  "
           + "       { \"name\": \"name\", \"type\": \"string\", \"default\": \"id\"},  "
           + "       { \"name\": \"age\", \"type\": \"int\", \"default\": -1 }" + "  ] " + " } ";
+  private static final String valueSchemaStr3 =
+      "{    \"namespace\": \"example.avro\",    \"type\": \"record\",    \"name\": \"User\",    \"fields\": [        {            \"name\": \"name\",            \"type\": \"string\",            \"default\": \"id\"        },        {            \"name\": \"age\",            \"type\": \"int\",            \"default\": -1        }    ]}";
 
   private static final int TIMEOUT = 3;
 
@@ -72,7 +74,7 @@ public class RouterBasedStoreSchemaFetcherTest {
 
     // Each invocation should fetch the latest schema, but it is expected the object to not be the same as we don't
     // implement cache.
-    Schema expectedValueSchema = Schema.parse(valueSchemaStr2);
+    Schema expectedValueSchema = Schema.parse(valueSchemaStr3);
     Assert.assertEquals(valueSchema1, expectedValueSchema);
     Assert.assertEquals(valueSchema2, valueSchema1);
     Assert.assertNotSame(valueSchema1, valueSchema2);
@@ -101,20 +103,27 @@ public class RouterBasedStoreSchemaFetcherTest {
         .when(mockGetUpdateValueSchemaFuture2)
         .get();
     Mockito.doReturn(mockGetUpdateValueSchemaFuture2).when(mockClient).getRaw("update_schema/" + storeName + "/2");
+    CompletableFuture<byte[]> mockGetUpdateValueSchemaFuture3 = Mockito.mock(CompletableFuture.class);
+    Mockito.doReturn(OBJECT_MAPPER.writeValueAsBytes(createUpdateSchemaResponse(3, 1, valueSchemaStr3)))
+        .when(mockGetUpdateValueSchemaFuture3)
+        .get();
+    Mockito.doReturn(mockGetUpdateValueSchemaFuture3).when(mockClient).getRaw("update_schema/" + storeName + "/3");
 
     // Fetch both update schemas.
     StoreSchemaFetcher storeSchemaFetcher = new RouterBasedStoreSchemaFetcher(mockClient);
     Schema updateSchema1 = storeSchemaFetcher.getUpdateSchema(Schema.parse(valueSchemaStr1));
     Schema updateSchema2 = storeSchemaFetcher.getUpdateSchema(Schema.parse(valueSchemaStr2));
+    Schema updateSchema3 = storeSchemaFetcher.getUpdateSchema(Schema.parse(valueSchemaStr3));
     Assert.assertEquals(updateSchema1, UPDATE_SCHEMA_CONVERTER.convert(valueSchemaStr1));
     Assert.assertEquals(updateSchema2, UPDATE_SCHEMA_CONVERTER.convert(valueSchemaStr2));
+    Assert.assertEquals(updateSchema3, UPDATE_SCHEMA_CONVERTER.convert(valueSchemaStr3));
     // Each update schema fetch should call get value schemas first then get latest update schema.
-    Mockito.verify(mockClient, Mockito.timeout(TIMEOUT).times(4)).getRaw(Mockito.anyString());
+    Mockito.verify(mockClient, Mockito.timeout(TIMEOUT).times(6)).getRaw(Mockito.anyString());
   }
 
   private MultiSchemaResponse createValueSchemaMultiSchemaResponse() {
     MultiSchemaResponse multiSchemaResponse = new MultiSchemaResponse();
-    MultiSchemaResponse.Schema[] schemas = new MultiSchemaResponse.Schema[2];
+    MultiSchemaResponse.Schema[] schemas = new MultiSchemaResponse.Schema[3];
 
     MultiSchemaResponse.Schema schema1 = new MultiSchemaResponse.Schema();
     schema1.setId(1);
@@ -125,7 +134,14 @@ public class RouterBasedStoreSchemaFetcherTest {
     schema2.setId(2);
     schema2.setSchemaStr(valueSchemaStr2);
     schemas[1] = schema2;
+
+    MultiSchemaResponse.Schema schema3 = new MultiSchemaResponse.Schema();
+    schema3.setId(3);
+    schema3.setSchemaStr(valueSchemaStr3);
+    schemas[2] = schema3;
+
     multiSchemaResponse.setSchemas(schemas);
+    multiSchemaResponse.setSuperSetSchemaId(2);
     return multiSchemaResponse;
   }
 
@@ -135,5 +151,29 @@ public class RouterBasedStoreSchemaFetcherTest {
     schemaResponse.setDerivedSchemaId(derivedSchemaId);
     schemaResponse.setSchemaStr(UPDATE_SCHEMA_CONVERTER.convert(valueSchemaStr).toString());
     return schemaResponse;
+  }
+
+  @Test
+  public void testGetSupersetSchema()
+      throws IOException, ExecutionException, InterruptedException, VeniceClientException {
+    AbstractAvroStoreClient mockClient = Mockito.mock(AbstractAvroStoreClient.class);
+    Mockito.doReturn(storeName).when(mockClient).getStoreName();
+    // Set up mocks for value schemas
+    CompletableFuture<byte[]> mockFuture = Mockito.mock(CompletableFuture.class);
+    Mockito.doReturn(OBJECT_MAPPER.writeValueAsBytes(createValueSchemaMultiSchemaResponse())).when(mockFuture).get();
+    Mockito.doReturn(mockFuture).when(mockClient).getRaw("value_schema/" + storeName);
+
+    // Get latest value schema twice.
+    StoreSchemaFetcher storeSchemaFetcher = new RouterBasedStoreSchemaFetcher(mockClient);
+    Schema valueSchema1 = storeSchemaFetcher.getSupersetSchema();
+    Schema valueSchema2 = storeSchemaFetcher.getSupersetSchema();
+
+    // Each invocation should fetch the latest schema, but it is expected the object to not be the same as we don't
+    // implement cache.
+    Schema expectedValueSchema = Schema.parse(valueSchemaStr2);
+    Assert.assertEquals(valueSchema1, expectedValueSchema);
+    Assert.assertEquals(valueSchema2, valueSchema1);
+    Assert.assertNotSame(valueSchema1, valueSchema2);
+    Mockito.verify(mockClient, Mockito.timeout(TIMEOUT).times(2)).getRaw(Mockito.anyString());
   }
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/ReadOnlySchemaRepository.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/ReadOnlySchemaRepository.java
@@ -6,7 +6,6 @@ import com.linkedin.venice.schema.SchemaEntry;
 import com.linkedin.venice.schema.rmd.RmdSchemaEntry;
 import com.linkedin.venice.schema.writecompute.DerivedSchemaEntry;
 import java.util.Collection;
-import java.util.Optional;
 
 
 public interface ReadOnlySchemaRepository extends VeniceResource {
@@ -46,10 +45,10 @@ public interface ReadOnlySchemaRepository extends VeniceResource {
 
   /**
    * Get the superset value schema for a given store. Each store has at most one active superset schema. Specifically a
-   * store must have some features enabled (e.g. read compute) to have a superset value schema which evolves as new value
-   * schemas are added.
+   * store must have some features enabled (e.g. read compute, write compute) to have a superset value schema which
+   * evolves as new value schemas are added.
    *
-   * @return Superset value or {@link Optional#empty()} if store {@param storeName} does not have any superset value schema.
+   * @return Superset value schema or {@code null} if store {@param storeName} does not have any superset value schema.
    */
   SchemaEntry getSupersetSchema(String storeName);
 

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/api/RouterResourceType.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/api/RouterResourceType.java
@@ -7,7 +7,8 @@ import java.util.Map;
 public enum RouterResourceType {
   TYPE_LEADER_CONTROLLER("leader_controller"), @Deprecated
   TYPE_LEADER_CONTROLLER_LEGACY("master_controller"), TYPE_KEY_SCHEMA("key_schema"), TYPE_VALUE_SCHEMA("value_schema"),
-  TYPE_UPDATE_SCHEMA("update_schema"), TYPE_CLUSTER_DISCOVERY("discover_cluster"), TYPE_REQUEST_TOPIC("request_topic"),
+  TYPE_SUPERSET_SCHEMA("superset_schema"), TYPE_UPDATE_SCHEMA("update_schema"),
+  TYPE_CLUSTER_DISCOVERY("discover_cluster"), TYPE_REQUEST_TOPIC("request_topic"),
   TYPE_STREAM_HYBRID_STORE_QUOTA("stream_hybrid_store_quota"),
   TYPE_STREAM_REPROCESSING_HYBRID_STORE_QUOTA("stream_reprocessing_hybrid_store_quota"),
   TYPE_STORE_STATE("store_state"), TYPE_PUSH_STATUS("push_status"), TYPE_STORAGE("storage"), TYPE_COMPUTE("compute"),

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/api/VenicePathParser.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/api/VenicePathParser.java
@@ -75,14 +75,15 @@ public class VenicePathParser<HTTP_REQUEST extends BasicHttpRequest>
   @Deprecated
   public static final String TYPE_LEADER_CONTROLLER_LEGACY =
       ControllerRoute.MASTER_CONTROLLER.getPath().replace("/", "");
-  public static final String TYPE_KEY_SCHEMA = "key_schema";
-  public static final String TYPE_VALUE_SCHEMA = "value_schema";
-  public static final String TYPE_UPDATE_SCHEMA = "update_schema";
-  public static final String TYPE_CLUSTER_DISCOVERY = "discover_cluster";
-  public static final String TYPE_REQUEST_TOPIC = "request_topic";
-  public static final String TYPE_HEALTH_CHECK = "admin";
-  public static final String TYPE_ADMIN = "admin"; // Creating a new variable name for code sanity
-  public static final String TYPE_RESOURCE_STATE = "resource_state";
+  public static final String TYPE_KEY_SCHEMA = RouterResourceType.TYPE_KEY_SCHEMA.toString();
+  public static final String TYPE_VALUE_SCHEMA = RouterResourceType.TYPE_VALUE_SCHEMA.toString();
+  public static final String TYPE_UPDATE_SCHEMA = RouterResourceType.TYPE_UPDATE_SCHEMA.toString();
+  public static final String TYPE_CLUSTER_DISCOVERY = RouterResourceType.TYPE_CLUSTER_DISCOVERY.toString();
+  public static final String TYPE_REQUEST_TOPIC = RouterResourceType.TYPE_REQUEST_TOPIC.toString();
+  public static final String TYPE_HEALTH_CHECK = RouterResourceType.TYPE_ADMIN.toString();
+  public static final String TYPE_ADMIN = RouterResourceType.TYPE_ADMIN.toString(); // Creating a new variable name for
+                                                                                    // code sanity
+  public static final String TYPE_RESOURCE_STATE = RouterResourceType.TYPE_RESOURCE_STATE.toString();
 
   private final VeniceVersionFinder versionFinder;
   private final VenicePartitionFinder partitionFinder;

--- a/services/venice-router/src/test/java/com/linkedin/venice/router/TestMetaDataHandler.java
+++ b/services/venice-router/src/test/java/com/linkedin/venice/router/TestMetaDataHandler.java
@@ -355,6 +355,60 @@ public class TestMetaDataHandler {
   }
 
   @Test
+  public void testSupersetSchemaLookup() throws IOException {
+    String storeName = "test_store";
+    String valueSchemaStr = "\"string\"";
+    String clusterName = "test-cluster";
+    int valueSchemaId = 1;
+    // Mock ReadOnlySchemaRepository
+    ReadOnlySchemaRepository schemaRepo = Mockito.mock(ReadOnlySchemaRepository.class);
+    SchemaEntry supersetSchemaEntry = new SchemaEntry(valueSchemaId, valueSchemaStr);
+    Mockito.doReturn(supersetSchemaEntry).when(schemaRepo).getSupersetSchema(storeName);
+
+    FullHttpResponse response = passRequestToMetadataHandler(
+        "http://myRouterHost:4567/superset_schema/" + storeName,
+        null,
+        schemaRepo,
+        Mockito.mock(HelixReadOnlyStoreConfigRepository.class),
+        Collections.emptyMap(),
+        Collections.emptyMap());
+
+    Assert.assertEquals(response.status().code(), 200);
+    Assert.assertEquals(response.headers().get(CONTENT_TYPE), "application/json");
+    SchemaResponse schemaResponse = OBJECT_MAPPER.readValue(response.content().array(), SchemaResponse.class);
+
+    Assert.assertEquals(schemaResponse.getName(), storeName);
+    Assert.assertEquals(schemaResponse.getCluster(), clusterName);
+    Assert.assertFalse(schemaResponse.isError());
+    Assert.assertEquals(schemaResponse.getId(), valueSchemaId);
+    Assert.assertEquals(schemaResponse.getSchemaStr(), valueSchemaStr);
+  }
+
+  @Test
+  public void testSupersetSchemaLookupWithNoSupersetSchema() throws IOException {
+    String storeName = "test_store";
+
+    // Mock ReadOnlySchemaRepository
+    ReadOnlySchemaRepository schemaRepo = Mockito.mock(ReadOnlySchemaRepository.class);
+    Mockito.doReturn(null).when(schemaRepo).getSupersetSchema(storeName);
+
+    FullHttpResponse response = passRequestToMetadataHandler(
+        "http://myRouterHost:4567/superset_schema/" + storeName,
+        null,
+        schemaRepo,
+        Mockito.mock(HelixReadOnlyStoreConfigRepository.class),
+        Collections.emptyMap(),
+        Collections.emptyMap());
+
+    Assert.assertEquals(response.status().code(), 404);
+  }
+
+  @Test(expectedExceptions = VeniceException.class, expectedExceptionsMessageRegExp = ".*Resource name required.*")
+  public void testInvalidSupersetSchemaPath() throws IOException {
+    passRequestToMetadataHandler("http://myRouterHost:4567/superset_schema/", null, null);
+  }
+
+  @Test
   public void testUpdateSchemaLookup() throws IOException {
     String storeName = "test_store";
     String valueSchemaStr1 = "\"string\"";


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci], [server], [controller],
[router], [samza], [vpj], [fast-client], [thin-client], [alpini],
[admin-tool], [test], [build], [doc], [script]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Add an API to fetch the current superset schema for a store
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
After PR #323, when writing partial update values that do not conform to the schema specified in the `UpdateBuilderImpl` object, the values will be adapted to the schema specified; by filling default values for missing fields and dropping additional fields.
In the case where fields are dropped, from the user's perspective, this is a data-loss. To minimize such cases, the application/framework must always use a superset schema to create the `UpdateBuilderImpl` object. This commit adds an API on the routers to fetch the superset schema and a corresponding function in the `StoreSchemaFetcher` interface.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
Added unit tests. GH CI

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.