### PR TITLE
Revert "[thin-client] Add an API to fetch the current superset schema for a store"

### DIFF
--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/schema/RouterBasedStoreSchemaFetcher.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/schema/RouterBasedStoreSchemaFetcher.java
@@ -32,7 +32,6 @@ public class RouterBasedStoreSchemaFetcher implements StoreSchemaFetcher {
   public static final String TYPE_KEY_SCHEMA = "key_schema";
   public static final String TYPE_VALUE_SCHEMA = "value_schema";
   public static final String TYPE_UPDATE_SCHEMA = "update_schema";
-  public static final String TYPE_SUPERSET_SCHEMA = "superset_schema";
   private final AbstractAvroStoreClient storeClient;
   private static final ObjectMapper OBJECT_MAPPER = ObjectMapperFactory.getInstance();
 
@@ -73,20 +72,6 @@ public class RouterBasedStoreSchemaFetcher implements StoreSchemaFetcher {
     } catch (Exception e) {
       throw new VeniceException("Got exception while parsing latest value schema", e);
     }
-  }
-
-  @Override
-  public Schema getSupersetSchema() {
-    // Fetch the latest superset schema for the specified value schema.
-    String supersetSchemaRequestPath = TYPE_SUPERSET_SCHEMA + "/" + storeClient.getStoreName();
-    String supersetSchemaStr = fetchSingleSchemaString(supersetSchemaRequestPath);
-    Schema supersetSchema;
-    try {
-      supersetSchema = parseSchemaFromJSONLooseValidation(supersetSchemaStr);
-    } catch (Exception e) {
-      throw new VeniceException("Got exception while parsing superset schema", e);
-    }
-    return supersetSchema;
   }
 
   @Override

--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/schema/StoreSchemaFetcher.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/schema/StoreSchemaFetcher.java
@@ -25,15 +25,6 @@ public interface StoreSchemaFetcher extends Closeable {
   Schema getLatestValueSchema();
 
   /**
-   * Get the superset value schema for a given store. Each store has at most one active superset schema. Specifically a
-   * store must have some features enabled (e.g. read compute, write compute) to have a superset value schema which
-   * evolves as new value schemas are added.
-   *
-   * @return Superset value schema or {@code null} if store {@param storeName} does not have any superset value schema.
-   */
-  Schema getSupersetSchema();
-
-  /**
    * Returns the Update (Write Compute) schema of the provided Value schema. The returned schema is used to construct
    * a {@link GenericRecord} that partially updates a record value that is associated with this value schema.
    * This method is expected to throw {@link InvalidVeniceSchemaException} when the provided value schema could not be

--- a/clients/venice-thin-client/src/test/java/com/linkedin/venice/client/schema/RouterBasedStoreSchemaFetcherTest.java
+++ b/clients/venice-thin-client/src/test/java/com/linkedin/venice/client/schema/RouterBasedStoreSchemaFetcherTest.java
@@ -31,8 +31,6 @@ public class RouterBasedStoreSchemaFetcherTest {
           + "  \"fields\": [           " + "       { \"name\": \"id\", \"type\": \"string\", \"default\": \"id\"},  "
           + "       { \"name\": \"name\", \"type\": \"string\", \"default\": \"id\"},  "
           + "       { \"name\": \"age\", \"type\": \"int\", \"default\": -1 }" + "  ] " + " } ";
-  private static final String valueSchemaStr3 =
-      "{    \"namespace\": \"example.avro\",    \"type\": \"record\",    \"name\": \"User\",    \"fields\": [        {            \"name\": \"name\",            \"type\": \"string\",            \"default\": \"id\"        },        {            \"name\": \"age\",            \"type\": \"int\",            \"default\": -1        }    ]}";
 
   private static final int TIMEOUT = 3;
 
@@ -74,7 +72,7 @@ public class RouterBasedStoreSchemaFetcherTest {
 
     // Each invocation should fetch the latest schema, but it is expected the object to not be the same as we don't
     // implement cache.
-    Schema expectedValueSchema = Schema.parse(valueSchemaStr3);
+    Schema expectedValueSchema = Schema.parse(valueSchemaStr2);
     Assert.assertEquals(valueSchema1, expectedValueSchema);
     Assert.assertEquals(valueSchema2, valueSchema1);
     Assert.assertNotSame(valueSchema1, valueSchema2);
@@ -103,27 +101,20 @@ public class RouterBasedStoreSchemaFetcherTest {
         .when(mockGetUpdateValueSchemaFuture2)
         .get();
     Mockito.doReturn(mockGetUpdateValueSchemaFuture2).when(mockClient).getRaw("update_schema/" + storeName + "/2");
-    CompletableFuture<byte[]> mockGetUpdateValueSchemaFuture3 = Mockito.mock(CompletableFuture.class);
-    Mockito.doReturn(OBJECT_MAPPER.writeValueAsBytes(createUpdateSchemaResponse(3, 1, valueSchemaStr3)))
-        .when(mockGetUpdateValueSchemaFuture3)
-        .get();
-    Mockito.doReturn(mockGetUpdateValueSchemaFuture3).when(mockClient).getRaw("update_schema/" + storeName + "/3");
 
     // Fetch both update schemas.
     StoreSchemaFetcher storeSchemaFetcher = new RouterBasedStoreSchemaFetcher(mockClient);
     Schema updateSchema1 = storeSchemaFetcher.getUpdateSchema(Schema.parse(valueSchemaStr1));
     Schema updateSchema2 = storeSchemaFetcher.getUpdateSchema(Schema.parse(valueSchemaStr2));
-    Schema updateSchema3 = storeSchemaFetcher.getUpdateSchema(Schema.parse(valueSchemaStr3));
     Assert.assertEquals(updateSchema1, UPDATE_SCHEMA_CONVERTER.convert(valueSchemaStr1));
     Assert.assertEquals(updateSchema2, UPDATE_SCHEMA_CONVERTER.convert(valueSchemaStr2));
-    Assert.assertEquals(updateSchema3, UPDATE_SCHEMA_CONVERTER.convert(valueSchemaStr3));
     // Each update schema fetch should call get value schemas first then get latest update schema.
-    Mockito.verify(mockClient, Mockito.timeout(TIMEOUT).times(6)).getRaw(Mockito.anyString());
+    Mockito.verify(mockClient, Mockito.timeout(TIMEOUT).times(4)).getRaw(Mockito.anyString());
   }
 
   private MultiSchemaResponse createValueSchemaMultiSchemaResponse() {
     MultiSchemaResponse multiSchemaResponse = new MultiSchemaResponse();
-    MultiSchemaResponse.Schema[] schemas = new MultiSchemaResponse.Schema[3];
+    MultiSchemaResponse.Schema[] schemas = new MultiSchemaResponse.Schema[2];
 
     MultiSchemaResponse.Schema schema1 = new MultiSchemaResponse.Schema();
     schema1.setId(1);
@@ -134,41 +125,8 @@ public class RouterBasedStoreSchemaFetcherTest {
     schema2.setId(2);
     schema2.setSchemaStr(valueSchemaStr2);
     schemas[1] = schema2;
-
-    MultiSchemaResponse.Schema schema3 = new MultiSchemaResponse.Schema();
-    schema3.setId(3);
-    schema3.setSchemaStr(valueSchemaStr3);
-    schemas[2] = schema3;
-
     multiSchemaResponse.setSchemas(schemas);
-    multiSchemaResponse.setSuperSetSchemaId(2);
     return multiSchemaResponse;
-  }
-
-  @Test
-  public void testGetSupersetSchema()
-      throws IOException, ExecutionException, InterruptedException, VeniceClientException {
-    AbstractAvroStoreClient mockClient = Mockito.mock(AbstractAvroStoreClient.class);
-    Mockito.doReturn(storeName).when(mockClient).getStoreName();
-    // Set up mocks for value schemas
-    CompletableFuture<byte[]> mockFuture = Mockito.mock(CompletableFuture.class);
-    Mockito.doReturn(OBJECT_MAPPER.writeValueAsBytes(createSupersetSchemaResponse(2, valueSchemaStr2)))
-        .when(mockFuture)
-        .get();
-    Mockito.doReturn(mockFuture).when(mockClient).getRaw("superset_schema/" + storeName);
-
-    // Get superset value schema twice.
-    StoreSchemaFetcher storeSchemaFetcher = new RouterBasedStoreSchemaFetcher(mockClient);
-    Schema valueSchema1 = storeSchemaFetcher.getSupersetSchema();
-    Schema valueSchema2 = storeSchemaFetcher.getSupersetSchema();
-
-    // Each invocation should fetch the latest superset schema, but it is expected the object to not be the same as we
-    // don't implement cache.
-    Schema expectedValueSchema = Schema.parse(valueSchemaStr2);
-    Assert.assertEquals(valueSchema1, expectedValueSchema);
-    Assert.assertEquals(valueSchema2, valueSchema1);
-    Assert.assertNotSame(valueSchema1, valueSchema2);
-    Mockito.verify(mockClient, Mockito.timeout(TIMEOUT).times(2)).getRaw(Mockito.anyString());
   }
 
   private SchemaResponse createUpdateSchemaResponse(int valueSchemaId, int derivedSchemaId, String valueSchemaStr) {
@@ -176,13 +134,6 @@ public class RouterBasedStoreSchemaFetcherTest {
     schemaResponse.setId(valueSchemaId);
     schemaResponse.setDerivedSchemaId(derivedSchemaId);
     schemaResponse.setSchemaStr(UPDATE_SCHEMA_CONVERTER.convert(valueSchemaStr).toString());
-    return schemaResponse;
-  }
-
-  private SchemaResponse createSupersetSchemaResponse(int supersetSchemaId, String supersetSchemaStr) {
-    SchemaResponse schemaResponse = new SchemaResponse();
-    schemaResponse.setId(supersetSchemaId);
-    schemaResponse.setSchemaStr(supersetSchemaStr);
     return schemaResponse;
   }
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/ReadOnlySchemaRepository.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/ReadOnlySchemaRepository.java
@@ -6,6 +6,7 @@ import com.linkedin.venice.schema.SchemaEntry;
 import com.linkedin.venice.schema.rmd.RmdSchemaEntry;
 import com.linkedin.venice.schema.writecompute.DerivedSchemaEntry;
 import java.util.Collection;
+import java.util.Optional;
 
 
 public interface ReadOnlySchemaRepository extends VeniceResource {
@@ -45,10 +46,10 @@ public interface ReadOnlySchemaRepository extends VeniceResource {
 
   /**
    * Get the superset value schema for a given store. Each store has at most one active superset schema. Specifically a
-   * store must have some features enabled (e.g. read compute, write compute) to have a superset value schema which
-   * evolves as new value schemas are added.
+   * store must have some features enabled (e.g. read compute) to have a superset value schema which evolves as new value
+   * schemas are added.
    *
-   * @return Superset value schema or {@code null} if store {@param storeName} does not have any superset value schema.
+   * @return Superset value or {@link Optional#empty()} if store {@param storeName} does not have any superset value schema.
    */
   SchemaEntry getSupersetSchema(String storeName);
 

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/MetaDataHandler.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/MetaDataHandler.java
@@ -8,11 +8,13 @@ import static com.linkedin.venice.controllerapi.ControllerApiConstants.PARTITION
 import static com.linkedin.venice.controllerapi.D2ServiceDiscoveryResponseV2.D2_SERVICE_DISCOVERY_RESPONSE_V2_ENABLED;
 import static com.linkedin.venice.meta.DataReplicationPolicy.ACTIVE_ACTIVE;
 import static com.linkedin.venice.meta.DataReplicationPolicy.NON_AGGREGATE;
-import static com.linkedin.venice.router.api.RouterResourceType.TYPE_SUPERSET_SCHEMA;
 import static com.linkedin.venice.router.api.VenicePathParser.TYPE_CLUSTER_DISCOVERY;
 import static com.linkedin.venice.router.api.VenicePathParser.TYPE_KEY_SCHEMA;
+import static com.linkedin.venice.router.api.VenicePathParser.TYPE_LEADER_CONTROLLER;
+import static com.linkedin.venice.router.api.VenicePathParser.TYPE_LEADER_CONTROLLER_LEGACY;
 import static com.linkedin.venice.router.api.VenicePathParser.TYPE_REQUEST_TOPIC;
 import static com.linkedin.venice.router.api.VenicePathParser.TYPE_RESOURCE_STATE;
+import static com.linkedin.venice.router.api.VenicePathParser.TYPE_UPDATE_SCHEMA;
 import static com.linkedin.venice.router.api.VenicePathParser.TYPE_VALUE_SCHEMA;
 import static com.linkedin.venice.router.api.VenicePathParserHelper.parseRequest;
 import static com.linkedin.venice.utils.NettyUtils.setupResponseAndFlush;
@@ -173,11 +175,6 @@ public class MetaDataHandler extends SimpleChannelInboundHandler<HttpRequest> {
         // URI: /value_schema/{$storeName}/{$valueSchemaId} - Get single value schema
         handleValueSchemaLookup(ctx, helper);
         break;
-      case TYPE_SUPERSET_SCHEMA:
-        // The request could fetch the latest superset schema for the given store
-        // URI: /superset_schema/{$storeName} - Get all the value schema
-        handleSupersetSchemaLookup(ctx, helper);
-        break;
       case TYPE_UPDATE_SCHEMA:
         // URI: /update_schema/{$storeName}/{$valueSchemaId}
         // The request could fetch the latest derived update schema of a specific value schema
@@ -288,26 +285,6 @@ public class MetaDataHandler extends SimpleChannelInboundHandler<HttpRequest> {
       responseObject.setSchemaStr(valueSchema.getSchema().toString());
       setupResponseAndFlush(OK, OBJECT_MAPPER.writeValueAsBytes(responseObject), true, ctx);
     }
-  }
-
-  private void handleSupersetSchemaLookup(ChannelHandlerContext ctx, VenicePathParserHelper helper) throws IOException {
-    String storeName = helper.getResourceName();
-    checkResourceName(storeName, "/" + TYPE_SUPERSET_SCHEMA + "/${storeName}");
-
-    // URI: /superset_schema/{$storeName}
-    // Get the latest superset schema
-    SchemaResponse responseObject = new SchemaResponse();
-    responseObject.setCluster(clusterName);
-    responseObject.setName(storeName);
-    SchemaEntry supersetSchemaEntry = schemaRepo.getSupersetSchema(storeName);
-    if (supersetSchemaEntry == null) {
-      byte[] errBody = ("Superset schema doesn't exist for store: " + storeName).getBytes();
-      setupResponseAndFlush(NOT_FOUND, errBody, false, ctx);
-      return;
-    }
-    responseObject.setId(supersetSchemaEntry.getId());
-    responseObject.setSchemaStr(supersetSchemaEntry.getSchemaStr());
-    setupResponseAndFlush(OK, OBJECT_MAPPER.writeValueAsBytes(responseObject), true, ctx);
   }
 
   private void handleUpdateSchemaLookup(ChannelHandlerContext ctx, VenicePathParserHelper helper) throws IOException {

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/api/RouterResourceType.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/api/RouterResourceType.java
@@ -7,8 +7,7 @@ import java.util.Map;
 public enum RouterResourceType {
   TYPE_LEADER_CONTROLLER("leader_controller"), @Deprecated
   TYPE_LEADER_CONTROLLER_LEGACY("master_controller"), TYPE_KEY_SCHEMA("key_schema"), TYPE_VALUE_SCHEMA("value_schema"),
-  TYPE_SUPERSET_SCHEMA("superset_schema"), TYPE_UPDATE_SCHEMA("update_schema"),
-  TYPE_CLUSTER_DISCOVERY("discover_cluster"), TYPE_REQUEST_TOPIC("request_topic"),
+  TYPE_UPDATE_SCHEMA("update_schema"), TYPE_CLUSTER_DISCOVERY("discover_cluster"), TYPE_REQUEST_TOPIC("request_topic"),
   TYPE_STREAM_HYBRID_STORE_QUOTA("stream_hybrid_store_quota"),
   TYPE_STREAM_REPROCESSING_HYBRID_STORE_QUOTA("stream_reprocessing_hybrid_store_quota"),
   TYPE_STORE_STATE("store_state"), TYPE_PUSH_STATUS("push_status"), TYPE_STORAGE("storage"), TYPE_COMPUTE("compute"),

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/api/VenicePathParser.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/api/VenicePathParser.java
@@ -75,15 +75,14 @@ public class VenicePathParser<HTTP_REQUEST extends BasicHttpRequest>
   @Deprecated
   public static final String TYPE_LEADER_CONTROLLER_LEGACY =
       ControllerRoute.MASTER_CONTROLLER.getPath().replace("/", "");
-  public static final String TYPE_KEY_SCHEMA = RouterResourceType.TYPE_KEY_SCHEMA.toString();
-  public static final String TYPE_VALUE_SCHEMA = RouterResourceType.TYPE_VALUE_SCHEMA.toString();
-  public static final String TYPE_UPDATE_SCHEMA = RouterResourceType.TYPE_UPDATE_SCHEMA.toString();
-  public static final String TYPE_CLUSTER_DISCOVERY = RouterResourceType.TYPE_CLUSTER_DISCOVERY.toString();
-  public static final String TYPE_REQUEST_TOPIC = RouterResourceType.TYPE_REQUEST_TOPIC.toString();
-  public static final String TYPE_HEALTH_CHECK = RouterResourceType.TYPE_ADMIN.toString();
-  public static final String TYPE_ADMIN = RouterResourceType.TYPE_ADMIN.toString(); // Creating a new variable name for
-                                                                                    // code sanity
-  public static final String TYPE_RESOURCE_STATE = RouterResourceType.TYPE_RESOURCE_STATE.toString();
+  public static final String TYPE_KEY_SCHEMA = "key_schema";
+  public static final String TYPE_VALUE_SCHEMA = "value_schema";
+  public static final String TYPE_UPDATE_SCHEMA = "update_schema";
+  public static final String TYPE_CLUSTER_DISCOVERY = "discover_cluster";
+  public static final String TYPE_REQUEST_TOPIC = "request_topic";
+  public static final String TYPE_HEALTH_CHECK = "admin";
+  public static final String TYPE_ADMIN = "admin"; // Creating a new variable name for code sanity
+  public static final String TYPE_RESOURCE_STATE = "resource_state";
 
   private final VeniceVersionFinder versionFinder;
   private final VenicePartitionFinder partitionFinder;

--- a/services/venice-router/src/test/java/com/linkedin/venice/router/TestMetaDataHandler.java
+++ b/services/venice-router/src/test/java/com/linkedin/venice/router/TestMetaDataHandler.java
@@ -355,60 +355,6 @@ public class TestMetaDataHandler {
   }
 
   @Test
-  public void testSupersetSchemaLookup() throws IOException {
-    String storeName = "test_store";
-    String valueSchemaStr = "\"string\"";
-    String clusterName = "test-cluster";
-    int valueSchemaId = 1;
-    // Mock ReadOnlySchemaRepository
-    ReadOnlySchemaRepository schemaRepo = Mockito.mock(ReadOnlySchemaRepository.class);
-    SchemaEntry supersetSchemaEntry = new SchemaEntry(valueSchemaId, valueSchemaStr);
-    Mockito.doReturn(supersetSchemaEntry).when(schemaRepo).getSupersetSchema(storeName);
-
-    FullHttpResponse response = passRequestToMetadataHandler(
-        "http://myRouterHost:4567/superset_schema/" + storeName,
-        null,
-        schemaRepo,
-        Mockito.mock(HelixReadOnlyStoreConfigRepository.class),
-        Collections.emptyMap(),
-        Collections.emptyMap());
-
-    Assert.assertEquals(response.status().code(), 200);
-    Assert.assertEquals(response.headers().get(CONTENT_TYPE), "application/json");
-    SchemaResponse schemaResponse = OBJECT_MAPPER.readValue(response.content().array(), SchemaResponse.class);
-
-    Assert.assertEquals(schemaResponse.getName(), storeName);
-    Assert.assertEquals(schemaResponse.getCluster(), clusterName);
-    Assert.assertFalse(schemaResponse.isError());
-    Assert.assertEquals(schemaResponse.getId(), valueSchemaId);
-    Assert.assertEquals(schemaResponse.getSchemaStr(), valueSchemaStr);
-  }
-
-  @Test
-  public void testSupersetSchemaLookupWithNoSupersetSchema() throws IOException {
-    String storeName = "test_store";
-
-    // Mock ReadOnlySchemaRepository
-    ReadOnlySchemaRepository schemaRepo = Mockito.mock(ReadOnlySchemaRepository.class);
-    Mockito.doReturn(null).when(schemaRepo).getSupersetSchema(storeName);
-
-    FullHttpResponse response = passRequestToMetadataHandler(
-        "http://myRouterHost:4567/superset_schema/" + storeName,
-        null,
-        schemaRepo,
-        Mockito.mock(HelixReadOnlyStoreConfigRepository.class),
-        Collections.emptyMap(),
-        Collections.emptyMap());
-
-    Assert.assertEquals(response.status().code(), 404);
-  }
-
-  @Test(expectedExceptions = VeniceException.class, expectedExceptionsMessageRegExp = ".*Resource name required.*")
-  public void testInvalidSupersetSchemaPath() throws IOException {
-    passRequestToMetadataHandler("http://myRouterHost:4567/superset_schema/", null, null);
-  }
-
-  @Test
   public void testUpdateSchemaLookup() throws IOException {
     String storeName = "test_store";
     String valueSchemaStr1 = "\"string\"";


### PR DESCRIPTION
This reverts commit 2499edfce9d127af870c6890239a0b1943027f08.

<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci], [server], [controller],
[router], [samza], [vpj], [fast-client], [thin-client], [alpini],
[admin-tool], [test], [build], [doc], [script]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Summary, imperative, start upper case, don't end with a period
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
In [a discussion](https://github.com/linkedin/venice/pull/327#discussion_r1157488958) on PR #327, we decided to revert this change as we would not like to expose the superset schema concept to users. I will raise a separate PR to return the superset schema in the `getLatestValueSchema` call to align it with the behavior of `thin-client` and `da-vinci-client`

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
GH CI will run

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [X] Yes. Make sure to explain your proposed changes and call out the behavior change.
Since this is a revert commit, the APIs added to the router and functions added to StoreSchemaFetcher will have been removed. This is okay since we have not yet cut a release tag, and this would not be a breaking change