### PR TITLE
[thin-client] Async retry for store initialization when it fails

### DIFF
--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/utils/LatencyUtils.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/utils/LatencyUtils.java
@@ -23,4 +23,22 @@ public class LatencyUtils {
   public static long getElapsedTimeInMs(long startTimeInMs) {
     return System.currentTimeMillis() - startTimeInMs;
   }
+
+  /***
+   * Sleep until number of milliseconds have passed, or the operation is interrupted.  This method will swallow the
+   * InterruptedException and terminate, if this is used in a loop it may become difficult to cleanly break out
+   * of the loop.
+   *
+   * @param millis
+   * @return true on success and false if sleep was interrupted
+   */
+  public static boolean sleep(long millis) {
+    try {
+      Thread.sleep(millis);
+      return true;
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      return false;
+    }
+  }
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/utils/Utils.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/utils/Utils.java
@@ -268,13 +268,7 @@ public class Utils {
    * @return true on success and false if sleep was interrupted
    */
   public static boolean sleep(long millis) {
-    try {
-      Thread.sleep(millis);
-      return true;
-    } catch (InterruptedException e) {
-      Thread.currentThread().interrupt();
-      return false;
-    }
+    return LatencyUtils.sleep(millis);
   }
 
   public static int parseIntFromString(String value, String fieldName) {


### PR DESCRIPTION




## Summary, imperative, start upper case, don't end with a period
This code change added an infinite retry of store initialization when the first round of blocking initalization fails.
The infinite retry will happen in the background, and the request will fail before the async thread can successfully initialize the client. This is a resilience improvement and in theory, this behavior shouldn't happen often.


## How was this PR tested?
Unit test
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.