### PR TITLE
[script] Docker: tag last images as latest-dev, allow to use custom tag in docker compose

### DIFF
--- a/docker/build-venice-docker-images.sh
+++ b/docker/build-venice-docker-images.sh
@@ -27,7 +27,7 @@ cp ../services/venice-router/build/libs/venice-router-all.jar venice-router/
 targets=(venice-controller venice-server venice-router venice-client)
 
 for target in ${targets[@]}; do
-    docker buildx build --load --platform linux/amd64 -t "$repository/$target:$version" $target
+    docker buildx build --load --platform linux/amd64 -t "$repository/$target:$version" -t "$repository/$target:latest-dev" $target
 done
 
 rm -f venice-client/venice-push-job-all.jar

--- a/quickstart/docker-compose.yaml
+++ b/quickstart/docker-compose.yaml
@@ -2,7 +2,7 @@ version: '3.8'
 
 services:
   zookeeper:
-    image: venicedb/zookeeper:latest
+    image: "venicedb/zookeeper:latest"
     container_name: zookeeper
     hostname: zookeeper
     healthcheck:
@@ -13,7 +13,7 @@ services:
         retries: 5
 
   kafka:
-    image: venicedb/kafka:latest
+    image: "venicedb/kafka:latest"
     container_name: kafka
     hostname: kafka
     depends_on:
@@ -27,7 +27,7 @@ services:
         retries: 5
 
   venice-controller:
-    image: venicedb/venice-controller:latest
+    image: "venicedb/venice-controller:${TAG:-latest}"
     container_name: venice-controller
     hostname: venice-controller
     depends_on:
@@ -41,7 +41,7 @@ services:
         retries: 5
 
   venice-server:
-    image: venicedb/venice-server:latest
+    image: "venicedb/venice-server:${TAG:-latest}"
     container_name: venice-server
     hostname: venice-server
     depends_on:
@@ -55,7 +55,7 @@ services:
         retries: 5
 
   venice-router:
-    image: venicedb/venice-router:latest
+    image: "venicedb/venice-router:${TAG:-latest}"
     container_name: venice-router
     hostname: venice-router
     depends_on:
@@ -69,7 +69,7 @@ services:
         retries: 5
 
   venice-client:
-    image: venicedb/venice-client:latest
+    image: "venicedb/venice-client:${TAG:-latest}"
     container_name: venice-client
     hostname: venice-client
     tty: true


### PR DESCRIPTION
## Summary

Docker compose pulls latest image from docker hub

The latest image is about 6 months old.

The change allows docker compose override of a tag.
To simplify  the dev workflow/scripting when version change, the build script also tags the latest built image as `latest-dev`.

## How was this PR tested?

```bash
cd ~/src/venice/docker
./build-venice-docker-images.sh
 docker image ls | grep latest-dev
 
cd ../quickstart
docker compose up -d
docker compose down

TAG=latest-dev docker compose up -d
docker compose down
```

## Does this PR introduce any user-facing changes?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.