### PR TITLE
[thin-client] Add a new API to retrieve all value schemas in StoreSchemaFetcher

### DIFF
--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/schema/RouterBasedStoreSchemaFetcher.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/schema/RouterBasedStoreSchemaFetcher.java
@@ -15,9 +15,9 @@ import com.linkedin.venice.utils.ObjectMapperFactory;
 import com.linkedin.venice.utils.RetryUtils;
 import java.io.IOException;
 import java.time.Duration;
-import java.util.ArrayList;
 import java.util.Collections;
-import java.util.List;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import org.apache.avro.Schema;
@@ -77,18 +77,18 @@ public class RouterBasedStoreSchemaFetcher implements StoreSchemaFetcher {
   }
 
   @Override
-  public List<Schema> getAllValueSchemas() {
+  public Set<Schema> getAllValueSchemas() {
     String valueSchemaRequestPath = TYPE_VALUE_SCHEMA + "/" + storeClient.getStoreName();
     MultiSchemaResponse multiSchemaResponse = fetchAllValueSchemas(valueSchemaRequestPath);
-    List<Schema> schemaList = new ArrayList<>();
+    Set<Schema> schemaSet = new HashSet<>();
     try {
       for (MultiSchemaResponse.Schema schema: multiSchemaResponse.getSchemas()) {
-        schemaList.add(parseSchemaFromJSONLooseValidation(schema.getSchemaStr()));
+        schemaSet.add(parseSchemaFromJSONLooseValidation(schema.getSchemaStr()));
       }
     } catch (Exception e) {
       throw new VeniceException("Got exception while parsing value schema", e);
     }
-    return schemaList;
+    return schemaSet;
   }
 
   @Override

--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/schema/RouterBasedStoreSchemaFetcher.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/schema/RouterBasedStoreSchemaFetcher.java
@@ -15,7 +15,9 @@ import com.linkedin.venice.utils.ObjectMapperFactory;
 import com.linkedin.venice.utils.RetryUtils;
 import java.io.IOException;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import org.apache.avro.Schema;
@@ -72,6 +74,21 @@ public class RouterBasedStoreSchemaFetcher implements StoreSchemaFetcher {
     } catch (Exception e) {
       throw new VeniceException("Got exception while parsing latest value schema", e);
     }
+  }
+
+  @Override
+  public List<Schema> getAllValueSchemas() {
+    String valueSchemaRequestPath = TYPE_VALUE_SCHEMA + "/" + storeClient.getStoreName();
+    MultiSchemaResponse multiSchemaResponse = fetchAllValueSchemas(valueSchemaRequestPath);
+    List<Schema> schemaList = new ArrayList<>();
+    try {
+      for (MultiSchemaResponse.Schema schema: multiSchemaResponse.getSchemas()) {
+        schemaList.add(parseSchemaFromJSONLooseValidation(schema.getSchemaStr()));
+      }
+    } catch (Exception e) {
+      throw new VeniceException("Got exception while parsing value schema", e);
+    }
+    return schemaList;
   }
 
   @Override

--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/schema/StoreSchemaFetcher.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/schema/StoreSchemaFetcher.java
@@ -3,6 +3,7 @@ package com.linkedin.venice.client.schema;
 import com.linkedin.venice.exceptions.InvalidVeniceSchemaException;
 import com.linkedin.venice.exceptions.VeniceException;
 import java.io.Closeable;
+import java.util.List;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericRecord;
 
@@ -23,6 +24,11 @@ public interface StoreSchemaFetcher extends Closeable {
    * Returns the latest available Value schema of the store.
    */
   Schema getLatestValueSchema();
+
+  /**
+   * Returns all value schemas of the store.
+   */
+  List<Schema> getAllValueSchemas();
 
   /**
    * Returns the Update (Write Compute) schema of the provided Value schema. The returned schema is used to construct

--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/schema/StoreSchemaFetcher.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/schema/StoreSchemaFetcher.java
@@ -3,7 +3,7 @@ package com.linkedin.venice.client.schema;
 import com.linkedin.venice.exceptions.InvalidVeniceSchemaException;
 import com.linkedin.venice.exceptions.VeniceException;
 import java.io.Closeable;
-import java.util.List;
+import java.util.Set;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericRecord;
 
@@ -28,7 +28,7 @@ public interface StoreSchemaFetcher extends Closeable {
   /**
    * Returns all value schemas of the store.
    */
-  List<Schema> getAllValueSchemas();
+  Set<Schema> getAllValueSchemas();
 
   /**
    * Returns the Update (Write Compute) schema of the provided Value schema. The returned schema is used to construct

--- a/clients/venice-thin-client/src/test/java/com/linkedin/venice/client/schema/RouterBasedStoreSchemaFetcherTest.java
+++ b/clients/venice-thin-client/src/test/java/com/linkedin/venice/client/schema/RouterBasedStoreSchemaFetcherTest.java
@@ -94,8 +94,6 @@ public class RouterBasedStoreSchemaFetcherTest {
     StoreSchemaFetcher storeSchemaFetcher = new RouterBasedStoreSchemaFetcher(mockClient);
     List<Schema> allSchemas = storeSchemaFetcher.getAllValueSchemas();
 
-    // Each invocation should fetch the latest schema, but it is expected the object to not be the same as we don't
-    // implement cache.
     Assert.assertEquals(allSchemas.size(), 2);
     Assert.assertEquals(allSchemas.get(0), Schema.parse(valueSchemaStr1));
     Assert.assertEquals(allSchemas.get(1), Schema.parse(valueSchemaStr2));

--- a/clients/venice-thin-client/src/test/java/com/linkedin/venice/client/schema/RouterBasedStoreSchemaFetcherTest.java
+++ b/clients/venice-thin-client/src/test/java/com/linkedin/venice/client/schema/RouterBasedStoreSchemaFetcherTest.java
@@ -8,7 +8,7 @@ import com.linkedin.venice.controllerapi.SchemaResponse;
 import com.linkedin.venice.schema.writecompute.WriteComputeSchemaConverter;
 import com.linkedin.venice.utils.ObjectMapperFactory;
 import java.io.IOException;
-import java.util.List;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import org.apache.avro.Schema;
@@ -92,11 +92,11 @@ public class RouterBasedStoreSchemaFetcherTest {
 
     // Get all value schemas
     StoreSchemaFetcher storeSchemaFetcher = new RouterBasedStoreSchemaFetcher(mockClient);
-    List<Schema> allSchemas = storeSchemaFetcher.getAllValueSchemas();
+    Set<Schema> allSchemas = storeSchemaFetcher.getAllValueSchemas();
 
     Assert.assertEquals(allSchemas.size(), 2);
-    Assert.assertEquals(allSchemas.get(0), Schema.parse(valueSchemaStr1));
-    Assert.assertEquals(allSchemas.get(1), Schema.parse(valueSchemaStr2));
+    Assert.assertTrue(allSchemas.contains(Schema.parse(valueSchemaStr1)));
+    Assert.assertTrue(allSchemas.contains(Schema.parse(valueSchemaStr2)));
     Mockito.verify(mockClient, Mockito.timeout(TIMEOUT).times(1)).getRaw(Mockito.anyString());
   }
 


### PR DESCRIPTION
## [thin-client] Add a new API to retrieve all value schemas in StoreSchemaFetcher
Per user request, we add a new API to retrieve all value schemas in StoreSchemaFetcher so they can use this API to compare and match incoming record with a existing schema.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
New unit test

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.