### PR TITLE
[server] Force sync offset records when ingestion isolation reports ingestion completion

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/isolated/IsolatedIngestionServer.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/isolated/IsolatedIngestionServer.java
@@ -384,6 +384,8 @@ public class IsolatedIngestionServer extends AbstractVeniceService {
 
       // Collect the latest OffsetRecord ByteBuffer array and store version state before consumption stops.
       if (ingestionReportType.equals(IngestionReportType.COMPLETED)) {
+        // Force sync topic partition offsets before shutting down RocksDB and reopen in main process.
+        getStoreIngestionService().syncTopicPartitionOffset(topicName, partitionId);
         // Set offset record in ingestion report.
         report.offsetRecordArray = getStoreIngestionService().getPartitionOffsetRecords(topicName, partitionId);
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/main/MainIngestionReportHandler.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/main/MainIngestionReportHandler.java
@@ -174,7 +174,7 @@ public class MainIngestionReportHandler extends SimpleChannelInboundHandler<Full
         StoreVersionState storeVersionState =
             IsolatedIngestionUtils.deserializeStoreVersionState(topicName, report.storeVersionState.array());
         mainIngestionMonitorService.getStorageMetadataService().putStoreVersionState(topicName, storeVersionState);
-        LOGGER.info("Updated storeVersionState for topic: {} {}", topicName, storeVersionState.toString());
+        LOGGER.info("Updated storeVersionState: {} for topic: {}", storeVersionState.toString(), topicName);
       }
     }
   }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/main/MainIngestionStorageMetadataService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/main/MainIngestionStorageMetadataService.java
@@ -157,7 +157,7 @@ public class MainIngestionStorageMetadataService extends AbstractVeniceService i
    * putOffsetRecord will only put OffsetRecord into in-memory state, without persisting into metadata RocksDB partition.
    */
   public void putOffsetRecord(String topicName, int partitionId, OffsetRecord record) {
-    LOGGER.info("Updating OffsetRecord for {} {} {}", topicName, partitionId, record.getLocalVersionTopicOffset());
+    LOGGER.info("Updating OffsetRecord: {} for topic: {}, partition: {}", record.toString(), topicName, partitionId);
     Map<Integer, OffsetRecord> partitionOffsetRecordMap =
         topicPartitionOffsetRecordMap.computeIfAbsent(topicName, k -> new VeniceConcurrentHashMap<>());
     partitionOffsetRecordMap.put(partitionId, record);

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
@@ -918,6 +918,10 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
     defaultReadyToServeChecker.apply(partitionConsumptionState);
   }
 
+  /**
+   * Process {@link TopicSwitch} control message at given partition offset for a specific {@link PartitionConsumptionState}.
+   * Return whether we need to execute additional ready-to-serve check after this message is processed.
+   */
   @Override
   protected boolean processTopicSwitch(
       ControlMessage controlMessage,

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
@@ -950,6 +950,9 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
           localKafkaServer);
     }
 
+    // Force sync offset metadata in before processing TopicSwitch.
+    updateOffsetMetadataInOffsetRecord(partitionConsumptionState);
+
     TopicSwitch topicSwitch = (TopicSwitch) controlMessage.controlMessageUnion;
     statusReportAdapter.reportTopicSwitchReceived(partitionConsumptionState);
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
@@ -919,7 +919,7 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
   }
 
   @Override
-  protected void processTopicSwitch(
+  protected boolean processTopicSwitch(
       ControlMessage controlMessage,
       int partition,
       long offset,
@@ -1015,8 +1015,10 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
     syncTopicSwitchToIngestionMetadataService(topicSwitch, partitionConsumptionState, upstreamStartOffsetByKafkaURL);
     if (!isLeader(partitionConsumptionState)) {
       partitionConsumptionState.getOffsetRecord().setLeaderTopic(newSourceTopic);
-      this.defaultReadyToServeChecker.apply(partitionConsumptionState);
+      // this.defaultReadyToServeChecker.apply(partitionConsumptionState);
+      return true;
     }
+    return false;
   }
 
   @Override

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
@@ -950,9 +950,6 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
           localKafkaServer);
     }
 
-    // Force sync offset metadata in before processing TopicSwitch.
-    updateOffsetMetadataInOffsetRecord(partitionConsumptionState);
-
     TopicSwitch topicSwitch = (TopicSwitch) controlMessage.controlMessageUnion;
     statusReportAdapter.reportTopicSwitchReceived(partitionConsumptionState);
 
@@ -1015,7 +1012,6 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
     syncTopicSwitchToIngestionMetadataService(topicSwitch, partitionConsumptionState, upstreamStartOffsetByKafkaURL);
     if (!isLeader(partitionConsumptionState)) {
       partitionConsumptionState.getOffsetRecord().setLeaderTopic(newSourceTopic);
-      // this.defaultReadyToServeChecker.apply(partitionConsumptionState);
       return true;
     }
     return false;

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionService.java
@@ -1196,6 +1196,11 @@ public class KafkaStoreIngestionService extends AbstractVeniceService implements
     return offsetRecordArray;
   }
 
+  /**
+   * Updates offset metadata and sync to storage for specified topic partition.
+   * This method is invoked only when isolated ingestion process is reporting topic partition completion to make sure
+   * ingestion process is persisted.
+   */
   public void syncTopicPartitionOffset(String topicName, int partition) {
     StoreIngestionTask storeIngestionTask = getStoreIngestionTask(topicName);
     int amplificationFactor = storeIngestionTask.getAmplificationFactor();

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -1081,11 +1081,6 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
           localKafkaServer);
     }
 
-    // Force sync offset metadata in before processing TopicSwitch.
-    LOGGER.info("DEBUGGING RECEIVED TOPIC SWITCH AT: {}", offset);
-    LOGGER.info("DEBUGGING PRIOR TO TOPIC_SWITCH PCS: {}", partitionConsumptionState);
-    updateOffsetMetadataInOffsetRecord(partitionConsumptionState);
-
     TopicSwitch topicSwitch = (TopicSwitch) controlMessage.controlMessageUnion;
     /**
      * Currently just check whether the sourceKafkaServers list inside TopicSwitch control message only contains
@@ -1141,16 +1136,13 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
       partitionConsumptionState.getOffsetRecord().setLeaderTopic(newSourceTopic);
       partitionConsumptionState.getOffsetRecord()
           .setLeaderUpstreamOffset(OffsetRecord.NON_AA_REPLICATION_UPSTREAM_OFFSET_MAP_KEY, upstreamStartOffset);
-
       /**
-       * We need to measure offset lag here for follower; if real-time topic is empty and never gets any new message,
-       * follower replica will never become online.
-       *
+       * We need to measure offset lag after processing TopicSwitch for follower; if real-time topic is empty and never
+       * gets any new message, follower replica will never become online.
        * If we measure lag here for follower, follower might become online faster than leader in extreme case:
        * Real time topic for that partition is empty or the rewind start offset is very closed to the end, followers
        * calculate the lag of the leader and decides the lag is small enough.
        */
-      // this.defaultReadyToServeChecker.apply(partitionConsumptionState);
       return true;
     }
     return false;

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -1050,6 +1050,10 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
     return Objects.equals(partitionConsumptionState.getLeaderFollowerState(), LEADER);
   }
 
+  /**
+   * Process {@link TopicSwitch} control message at given partition offset for a specific {@link PartitionConsumptionState}.
+   * Return whether we need to execute additional ready-to-serve check after this message is processed.
+   */
   @Override
   protected boolean processTopicSwitch(
       ControlMessage controlMessage,

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -1081,6 +1081,10 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
           localKafkaServer);
     }
 
+    // Force sync offset metadata in before processing TopicSwitch.
+    LOGGER.info("DEBUGGING PRIOR TO TOPIC_SWITCH PCS: {}", partitionConsumptionState);
+    updateOffsetMetadataInOffsetRecord(partitionConsumptionState);
+
     TopicSwitch topicSwitch = (TopicSwitch) controlMessage.controlMessageUnion;
     /**
      * Currently just check whether the sourceKafkaServers list inside TopicSwitch control message only contains

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -1051,7 +1051,7 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
   }
 
   @Override
-  protected void processTopicSwitch(
+  protected boolean processTopicSwitch(
       ControlMessage controlMessage,
       int partition,
       long offset,
@@ -1082,6 +1082,7 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
     }
 
     // Force sync offset metadata in before processing TopicSwitch.
+    LOGGER.info("DEBUGGING RECEIVED TOPIC SWITCH AT: {}", offset);
     LOGGER.info("DEBUGGING PRIOR TO TOPIC_SWITCH PCS: {}", partitionConsumptionState);
     updateOffsetMetadataInOffsetRecord(partitionConsumptionState);
 
@@ -1149,8 +1150,10 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
        * Real time topic for that partition is empty or the rewind start offset is very closed to the end, followers
        * calculate the lag of the leader and decides the lag is small enough.
        */
-      this.defaultReadyToServeChecker.apply(partitionConsumptionState);
+      // this.defaultReadyToServeChecker.apply(partitionConsumptionState);
+      return true;
     }
+    return false;
   }
 
   protected void syncTopicSwitchToIngestionMetadataService(

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StatusReportAdapter.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StatusReportAdapter.java
@@ -15,7 +15,6 @@ import com.linkedin.venice.exceptions.VeniceIngestionTaskKilledException;
 import com.linkedin.venice.pushmonitor.SubPartitionStatus;
 import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -227,9 +226,6 @@ public class StatusReportAdapter {
         String versionAwareStatus,
         Runnable report,
         boolean logStatus) {
-      if (status.equals(COMPLETED)) {
-        LOGGER.info("DEBUGGING COMPLETED THREAD: " + Arrays.toString(Thread.currentThread().getStackTrace()));
-      }
       // This is a safeguard to make sure we only report exactly once for each status.
       if (statusReportIndicatorMap.get(versionAwareStatus).compareAndSet(false, true)) {
         if (logStatus) {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StatusReportAdapter.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StatusReportAdapter.java
@@ -15,6 +15,7 @@ import com.linkedin.venice.exceptions.VeniceIngestionTaskKilledException;
 import com.linkedin.venice.pushmonitor.SubPartitionStatus;
 import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -226,6 +227,9 @@ public class StatusReportAdapter {
         String versionAwareStatus,
         Runnable report,
         boolean logStatus) {
+      if (status.equals(COMPLETED)) {
+        LOGGER.info("DEBUGGING COMPLETED THREAD: " + Arrays.toString(Thread.currentThread().getStackTrace()));
+      }
       // This is a safeguard to make sure we only report exactly once for each status.
       if (statusReportIndicatorMap.get(versionAwareStatus).compareAndSet(false, true)) {
         if (logStatus) {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -3372,4 +3372,12 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
     KafkaMessageEnvelope kafkaValue = consumerRecord.getValue();
     return kafkaValue.leaderMetadataFooter != null && kafkaValue.leaderMetadataFooter.upstreamOffset >= 0;
   }
+
+  public void updateOffsetMetadataAndSync(String topic, int partitionId) {
+    PartitionConsumptionState pcs = getPartitionConsumptionState(partitionId);
+    LOGGER.info("DEBUGGING before sync: topic: {}, partition: {}, PCS: {}", topic, partitionId, pcs);
+    updateOffsetMetadataInOffsetRecord(pcs);
+    syncOffset(topic, pcs);
+    LOGGER.info("DEBUGGING after sync: topic: {}, partition: {}, PCS: {}", topic, partitionId, pcs);
+  }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -2493,8 +2493,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
           leaderProducedRecordContext,
           kafkaUrl);
       if (checkReadyToServeAfterProcess) {
-        LOGGER.info("DEBUGGING NEW READY TO SERVE CHECK RUN: " + partitionConsumptionState);
-        this.defaultReadyToServeChecker.apply(partitionConsumptionState);
+        defaultReadyToServeChecker.apply(partitionConsumptionState);
       }
     }
     return sizeOfPersistedData;
@@ -3254,6 +3253,12 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
     return serverConfig;
   }
 
+  public void updateOffsetMetadataAndSync(String topic, int partitionId) {
+    PartitionConsumptionState pcs = getPartitionConsumptionState(partitionId);
+    updateOffsetMetadataInOffsetRecord(pcs);
+    syncOffset(topic, pcs);
+  }
+
   /**
    * The function returns local or remote topic manager.
    * @param sourceKafkaServer The address of source kafka bootstrap server.
@@ -3381,11 +3386,4 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
     return kafkaValue.leaderMetadataFooter != null && kafkaValue.leaderMetadataFooter.upstreamOffset >= 0;
   }
 
-  public void updateOffsetMetadataAndSync(String topic, int partitionId) {
-    PartitionConsumptionState pcs = getPartitionConsumptionState(partitionId);
-    LOGGER.info("DEBUGGING before sync: topic: {}, partition: {}, PCS: {}", topic, partitionId, pcs);
-    updateOffsetMetadataInOffsetRecord(pcs);
-    syncOffset(topic, pcs);
-    LOGGER.info("DEBUGGING after sync: topic: {}, partition: {}, PCS: {}", topic, partitionId, pcs);
-  }
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/offsets/OffsetRecord.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/offsets/OffsetRecord.java
@@ -268,7 +268,8 @@ public class OffsetRecord {
 
   @Override
   public String toString() {
-    return "OffsetRecord{" + "localVersionTopicOffset=" + getLocalVersionTopicOffset() + ", offsetLag=" + getOffsetLag()
+    return "OffsetRecord{" + "localVersionTopicOffset=" + getLocalVersionTopicOffset() + ", upstreamOffset="
+        + getPartitionUpstreamOffsetString() + ", leaderTopic=" + getLeaderTopic() + ", offsetLag=" + getOffsetLag()
         + ", eventTimeEpochMs=" + getEventTimeEpochMs() + ", latestProducerProcessingTimeInMs="
         + getLatestProducerProcessingTimeInMs() + ", isEndOfPushReceived=" + isEndOfPushReceived() + ", databaseInfo="
         + getDatabaseInfo() + '}';

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestHybrid.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestHybrid.java
@@ -1472,7 +1472,14 @@ public class TestHybrid {
       LogManager.getLogger().info("DEBUGGING2 " + status.getExecutionStatus().toString());
       LogManager.getLogger().info("DEBUGGING2 " + status.getExtraInfo());
       LogManager.getLogger().info("DEBUGGING2 " + status.getExtraDetails());
-
+      LogManager.getLogger()
+          .info(
+              venice.getVeniceServers()
+                  .get(0)
+                  .getVeniceServer()
+                  .getHelixParticipationService()
+                  .getVeniceOfflinePushMonitorAccessor()
+                  .getOfflinePushStatusAndItsPartitionStatuses(storeName + "_v2"));
     } finally {
       if (veniceProducer != null) {
         veniceProducer.stop();


### PR DESCRIPTION
## Summary
**Issue:**
When there is no sufficient realtime messages compared to store hybrid lag setup, replica can report completion when processing TOPIC_SWITCH_RECEIVED. There is an additional ready-to-serve check in follower replica in TOPIC_SWTICH processing logic, but it could be a bit problematic with ingestion isolation.
If TS message is at offset X, when ingestion to this message, ready to serve check will report completed and II will shutdown and storage engine. However, the X is not checkpoint to OffsetRecord and when main process starts ingestion, it will re-consume TS message and report. 

**Impact:**
No impact to read/write/server restart, only additional TS is written into OfflinePushStatus only (not CV).

**Fix:**
1. Add force offset sync-up when II report completion
2. Since when doing the additional ready-to-serve check, X is not updated to in-memory PCS, thus the sync step in (1) cannot protect the re-consume TS message issue. This PR moves the additional ready-to-serve check to after PCS update so that it will sync and report the correct offset.

## How was this PR tested?
Added a new integration test to validate the OfflinePushStatus node does not end up with TOPIC_SWITCH_RECEIVED in the case.

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.