### PR TITLE
[server][common] Server ssl handshake throttling using dedicated thread pool executor

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
@@ -490,7 +490,7 @@ public class VeniceServerConfig extends VeniceClusterConfig {
     helixHybridStoreQuotaEnabled = serverProperties.getBoolean(HELIX_HYBRID_STORE_QUOTA_ENABLED, false);
     ssdHealthCheckShutdownTimeMs = serverProperties.getLong(SERVER_SHUTDOWN_DISK_UNHEALTHY_TIME_MS, 200000);
     sslHandshakeThreadPoolSize = serverProperties.getInt(SERVER_SSL_HANDSHAKE_THREAD_POOL_SIZE, 100);
-    sslHandshakeQueueCapacity = serverProperties.getInt(SERVER_SSL_HANDSHAKE_QUEUE_CAPACITY, 10000);
+    sslHandshakeQueueCapacity = serverProperties.getInt(SERVER_SSL_HANDSHAKE_QUEUE_CAPACITY, Integer.MAX_VALUE);
 
     /**
      * In the test of feature store user case, when we did a rolling bounce of storage nodes, the high latency happened

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
@@ -490,7 +490,7 @@ public class VeniceServerConfig extends VeniceClusterConfig {
     helixHybridStoreQuotaEnabled = serverProperties.getBoolean(HELIX_HYBRID_STORE_QUOTA_ENABLED, false);
     ssdHealthCheckShutdownTimeMs = serverProperties.getLong(SERVER_SHUTDOWN_DISK_UNHEALTHY_TIME_MS, 200000);
     sslHandshakeThreadPoolSize = serverProperties.getInt(SERVER_SSL_HANDSHAKE_THREAD_POOL_SIZE, 100);
-    sslHandshakeQueueCapacity = serverProperties.getInt(SERVER_SSL_HANDSHAKE_QUEUE_CAPACITY, Integer.MAX_VALUE);
+    sslHandshakeQueueCapacity = serverProperties.getInt(SERVER_SSL_HANDSHAKE_QUEUE_CAPACITY, 10000);
 
     /**
      * In the test of feature store user case, when we did a rolling bounce of storage nodes, the high latency happened

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
@@ -86,6 +86,8 @@ import static com.linkedin.venice.ConfigKeys.SERVER_SHARED_CONSUMER_NON_EXISTING
 import static com.linkedin.venice.ConfigKeys.SERVER_SHARED_KAFKA_PRODUCER_ENABLED;
 import static com.linkedin.venice.ConfigKeys.SERVER_SHUTDOWN_DISK_UNHEALTHY_TIME_MS;
 import static com.linkedin.venice.ConfigKeys.SERVER_SOURCE_TOPIC_OFFSET_CHECK_INTERVAL_MS;
+import static com.linkedin.venice.ConfigKeys.SERVER_SSL_HANDSHAKE_QUEUE_CAPACITY;
+import static com.linkedin.venice.ConfigKeys.SERVER_SSL_HANDSHAKE_THREAD_POOL_SIZE;
 import static com.linkedin.venice.ConfigKeys.SERVER_STORE_TO_EARLY_TERMINATION_THRESHOLD_MS_MAP;
 import static com.linkedin.venice.ConfigKeys.SERVER_SYSTEM_STORE_PROMOTION_TO_LEADER_REPLICA_DELAY_SECONDS;
 import static com.linkedin.venice.ConfigKeys.SERVER_UNSUB_AFTER_BATCHPUSH;
@@ -376,6 +378,16 @@ public class VeniceServerConfig extends VeniceClusterConfig {
   private final boolean readOnlyForBatchOnlyStoreEnabled; // TODO: remove this config as its never used in prod
   private final int fastAvroFieldLimitPerMethod;
 
+  /**
+   * The number of threads used to limit the concurrency of ssl handshake for servers.
+   */
+  private final int sslHandshakeThreadPoolSize;
+
+  /**
+   * The queue capacity for ssl handshake threadpool executor.
+   */
+  private final int sslHandshakeQueueCapacity;
+
   public VeniceServerConfig(VeniceProperties serverProperties) throws ConfigurationException {
     this(serverProperties, Collections.emptyMap());
   }
@@ -477,6 +489,8 @@ public class VeniceServerConfig extends VeniceClusterConfig {
     kafkaOpenSSLEnabled = serverProperties.getBoolean(SERVER_ENABLE_KAFKA_OPENSSL, false);
     helixHybridStoreQuotaEnabled = serverProperties.getBoolean(HELIX_HYBRID_STORE_QUOTA_ENABLED, false);
     ssdHealthCheckShutdownTimeMs = serverProperties.getLong(SERVER_SHUTDOWN_DISK_UNHEALTHY_TIME_MS, 200000);
+    sslHandshakeThreadPoolSize = serverProperties.getInt(SERVER_SSL_HANDSHAKE_THREAD_POOL_SIZE, 100);
+    sslHandshakeQueueCapacity = serverProperties.getInt(SERVER_SSL_HANDSHAKE_QUEUE_CAPACITY, Integer.MAX_VALUE);
 
     /**
      * In the test of feature store user case, when we did a rolling bounce of storage nodes, the high latency happened
@@ -1007,5 +1021,13 @@ public class VeniceServerConfig extends VeniceClusterConfig {
 
   public int getFastAvroFieldLimitPerMethod() {
     return fastAvroFieldLimitPerMethod;
+  }
+
+  public int getSslHandshakeThreadPoolSize() {
+    return sslHandshakeThreadPoolSize;
+  }
+
+  public int getSslHandshakeQueueCapacity() {
+    return sslHandshakeQueueCapacity;
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
@@ -379,7 +379,8 @@ public class VeniceServerConfig extends VeniceClusterConfig {
   private final int fastAvroFieldLimitPerMethod;
 
   /**
-   * The number of threads used to limit the concurrency of ssl handshake for servers.
+   * The number of threads used to limit the concurrency of ssl handshake for servers. The feature to use a thread pool
+   * executor for handling ssl handshakes is disabled if the value of this config is <= 0. The default value is 0.
    */
   private final int sslHandshakeThreadPoolSize;
 
@@ -489,7 +490,7 @@ public class VeniceServerConfig extends VeniceClusterConfig {
     kafkaOpenSSLEnabled = serverProperties.getBoolean(SERVER_ENABLE_KAFKA_OPENSSL, false);
     helixHybridStoreQuotaEnabled = serverProperties.getBoolean(HELIX_HYBRID_STORE_QUOTA_ENABLED, false);
     ssdHealthCheckShutdownTimeMs = serverProperties.getLong(SERVER_SHUTDOWN_DISK_UNHEALTHY_TIME_MS, 200000);
-    sslHandshakeThreadPoolSize = serverProperties.getInt(SERVER_SSL_HANDSHAKE_THREAD_POOL_SIZE, 100);
+    sslHandshakeThreadPoolSize = serverProperties.getInt(SERVER_SSL_HANDSHAKE_THREAD_POOL_SIZE, 0);
     sslHandshakeQueueCapacity = serverProperties.getInt(SERVER_SSL_HANDSHAKE_QUEUE_CAPACITY, Integer.MAX_VALUE);
 
     /**

--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -1856,4 +1856,15 @@ public class ConfigKeys {
    * but that can have other side effects, so it may not be preferred.
    */
   public static final String FAST_AVRO_FIELD_LIMIT_PER_METHOD = "fast.avro.field.limit.per.method";
+
+  /**
+   * Config to control the number of threads in the thread pool executor used for ssl handshake in servers. The purpose
+   * is to limit the concurrency of ssl handshakes.
+   */
+  public static final String SERVER_SSL_HANDSHAKE_THREAD_POOL_SIZE = "server.ssl.handshake.thread.pool.size";
+
+  /**
+   * Config to control the queue capacity for the thread pool executor used for ssl handshake in servers.
+   */
+  public static final String SERVER_SSL_HANDSHAKE_QUEUE_CAPACITY = "server.ssl.handshake.queue.capacity";
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -1859,7 +1859,8 @@ public class ConfigKeys {
 
   /**
    * Config to control the number of threads in the thread pool executor used for ssl handshake in servers. The purpose
-   * is to limit the concurrency of ssl handshakes.
+   * is to limit the concurrency of ssl handshakes. The feature to use a thread pool executor for handling ssl
+   * handshakes is disabled if the value of this config is <= 0. The default value is 0.
    */
   public static final String SERVER_SSL_HANDSHAKE_THREAD_POOL_SIZE = "server.ssl.handshake.thread.pool.size";
 

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/integration/utils/VeniceServerWrapper.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/integration/utils/VeniceServerWrapper.java
@@ -21,6 +21,7 @@ import static com.linkedin.venice.ConfigKeys.SERVER_NETTY_GRACEFUL_SHUTDOWN_PERI
 import static com.linkedin.venice.ConfigKeys.SERVER_PARTITION_GRACEFUL_DROP_DELAY_IN_SECONDS;
 import static com.linkedin.venice.ConfigKeys.SERVER_PROMOTION_TO_LEADER_REPLICA_DELAY_SECONDS;
 import static com.linkedin.venice.ConfigKeys.SERVER_REST_SERVICE_STORAGE_THREAD_NUM;
+import static com.linkedin.venice.ConfigKeys.SERVER_SSL_HANDSHAKE_THREAD_POOL_SIZE;
 import static com.linkedin.venice.ConfigKeys.SYSTEM_SCHEMA_CLUSTER_NAME;
 import static com.linkedin.venice.meta.PersistenceType.ROCKS_DB;
 
@@ -223,6 +224,7 @@ public class VeniceServerWrapper extends ProcessWrapper implements MetricsAware 
           .put(SERVER_INGESTION_ISOLATION_SERVICE_PORT, ingestionIsolationServicePort)
           .put(SERVER_PROMOTION_TO_LEADER_REPLICA_DELAY_SECONDS, Long.toString(1L))
           .put(CLUSTER_DISCOVERY_D2_SERVICE, VeniceRouterWrapper.CLUSTER_DISCOVERY_D2_SERVICE_NAME)
+          .put(SERVER_SSL_HANDSHAKE_THREAD_POOL_SIZE, 10)
           .put(configProperties);
       if (sslToKafka) {
         serverPropsBuilder.put(KAFKA_SECURITY_PROTOCOL, SecurityProtocol.SSL.name);

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/router/TestRead.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/router/TestRead.java
@@ -162,6 +162,7 @@ public abstract class TestRead {
     serverProperties.put(ConfigKeys.SERVER_DATABASE_LOOKUP_QUEUE_CAPACITY, 1); // test bounded queue
     serverProperties.put(ConfigKeys.SERVER_COMPUTE_QUEUE_CAPACITY, 1);
     serverProperties.put(ConfigKeys.SERVER_BLOCKING_QUEUE_TYPE, ARRAY_BLOCKING_QUEUE.name());
+    serverProperties.put(ConfigKeys.SERVER_SSL_HANDSHAKE_QUEUE_CAPACITY, 10000);
     serverProperties.put(ConfigKeys.SERVER_PARALLEL_BATCH_GET_CHUNK_SIZE, 3);
     serverProperties.put(ConfigKeys.SERVER_REST_SERVICE_EPOLL_ENABLED, true);
     serverProperties.put(ConfigKeys.SERVER_STORE_TO_EARLY_TERMINATION_THRESHOLD_MS_MAP, "");

--- a/services/venice-server/src/main/java/com/linkedin/venice/listener/HttpChannelInitializer.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/listener/HttpChannelInitializer.java
@@ -27,6 +27,7 @@ import io.netty.handler.timeout.IdleStateHandler;
 import io.tehuti.metrics.MetricsRepository;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -39,6 +40,7 @@ public class HttpChannelInitializer extends ChannelInitializer<SocketChannel> {
   private final AggServerHttpRequestStats multiGetStats;
   private final AggServerHttpRequestStats computeStats;
   private final Optional<SSLFactory> sslFactory;
+  private final Optional<Executor> sslHandshakeExecutor;
   private final Optional<ServerAclHandler> aclHandler;
   private final Optional<ServerStoreAclHandler> storeAclHandler;
   private final VerifySslHandler verifySsl = new VerifySslHandler();
@@ -53,6 +55,7 @@ public class HttpChannelInitializer extends ChannelInitializer<SocketChannel> {
       CompletableFuture<HelixCustomizedViewOfflinePushRepository> customizedViewRepository,
       MetricsRepository metricsRepository,
       Optional<SSLFactory> sslFactory,
+      Optional<Executor> sslHandshakeExecutor,
       VeniceServerConfig serverConfig,
       Optional<StaticAccessController> routerAccessController,
       Optional<DynamicAccessController> storeAccessController,
@@ -87,6 +90,7 @@ public class HttpChannelInitializer extends ChannelInitializer<SocketChannel> {
     }
 
     this.sslFactory = sslFactory;
+    this.sslHandshakeExecutor = sslHandshakeExecutor;
     this.storeAclHandler = storeAccessController.isPresent()
         ? Optional.of(new ServerStoreAclHandler(storeAccessController.get(), storeMetadataRepository))
         : Optional.empty();
@@ -143,7 +147,9 @@ public class HttpChannelInitializer extends ChannelInitializer<SocketChannel> {
   @Override
   public void initChannel(SocketChannel ch) {
     if (sslFactory.isPresent()) {
-      ch.pipeline().addLast(new SslInitializer(SslUtils.toAlpiniSSLFactory(sslFactory.get()), false));
+      SslInitializer sslInitializer = new SslInitializer(SslUtils.toAlpiniSSLFactory(sslFactory.get()), false);
+      sslHandshakeExecutor.ifPresent(sslInitializer::enableSslTaskExecutor);
+      ch.pipeline().addLast(sslInitializer);
     }
     ChannelPipelineConsumer httpPipelineInitializer = (pipeline, whetherNeedServerCodec) -> {
       StatsHandler statsHandler = new StatsHandler(singleGetStats, multiGetStats, computeStats);

--- a/services/venice-server/src/main/java/com/linkedin/venice/listener/HttpChannelInitializer.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/listener/HttpChannelInitializer.java
@@ -40,7 +40,7 @@ public class HttpChannelInitializer extends ChannelInitializer<SocketChannel> {
   private final AggServerHttpRequestStats multiGetStats;
   private final AggServerHttpRequestStats computeStats;
   private final Optional<SSLFactory> sslFactory;
-  private final Optional<Executor> sslHandshakeExecutor;
+  private final Executor sslHandshakeExecutor;
   private final Optional<ServerAclHandler> aclHandler;
   private final Optional<ServerStoreAclHandler> storeAclHandler;
   private final VerifySslHandler verifySsl = new VerifySslHandler();
@@ -55,7 +55,7 @@ public class HttpChannelInitializer extends ChannelInitializer<SocketChannel> {
       CompletableFuture<HelixCustomizedViewOfflinePushRepository> customizedViewRepository,
       MetricsRepository metricsRepository,
       Optional<SSLFactory> sslFactory,
-      Optional<Executor> sslHandshakeExecutor,
+      Executor sslHandshakeExecutor,
       VeniceServerConfig serverConfig,
       Optional<StaticAccessController> routerAccessController,
       Optional<DynamicAccessController> storeAccessController,
@@ -148,7 +148,9 @@ public class HttpChannelInitializer extends ChannelInitializer<SocketChannel> {
   public void initChannel(SocketChannel ch) {
     if (sslFactory.isPresent()) {
       SslInitializer sslInitializer = new SslInitializer(SslUtils.toAlpiniSSLFactory(sslFactory.get()), false);
-      sslHandshakeExecutor.ifPresent(sslInitializer::enableSslTaskExecutor);
+      if (sslHandshakeExecutor != null) {
+        sslInitializer.enableSslTaskExecutor(sslHandshakeExecutor);
+      }
       ch.pipeline().addLast(sslInitializer);
     }
     ChannelPipelineConsumer httpPipelineInitializer = (pipeline, whetherNeedServerCodec) -> {

--- a/services/venice-server/src/main/java/com/linkedin/venice/listener/ListenerService.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/listener/ListenerService.java
@@ -27,7 +27,6 @@ import io.netty.channel.socket.nio.NioServerSocketChannel;
 import io.tehuti.metrics.MetricsRepository;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executor;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import org.apache.logging.log4j.LogManager;
@@ -84,14 +83,12 @@ public class ListenerService extends AbstractVeniceService {
         serverConfig.getComputeQueueCapacity());
     new ThreadPoolStats(metricsRepository, computeExecutor, "storage_compute_thread_pool");
 
-    Optional<Executor> sslHandshakeExecutor = Optional.empty();
-    if (sslFactory.isPresent()) {
+    if (sslFactory.isPresent() && serverConfig.getSslHandshakeThreadPoolSize() > 0) {
       this.sslHandshakeExecutor = createThreadPool(
           serverConfig.getSslHandshakeThreadPoolSize(),
           "SSLHandShakeThread",
           serverConfig.getSslHandshakeQueueCapacity());
       new ThreadPoolStats(metricsRepository, this.sslHandshakeExecutor, "ssl_handshake_thread_pool");
-      sslHandshakeExecutor = Optional.of(this.sslHandshakeExecutor);
     }
 
     StorageReadRequestsHandler requestHandler = createRequestHandler(

--- a/services/venice-server/src/test/java/com/linkedin/venice/listener/HttpChannelInitializerTest.java
+++ b/services/venice-server/src/test/java/com/linkedin/venice/listener/HttpChannelInitializerTest.java
@@ -12,6 +12,7 @@ import com.linkedin.venice.security.SSLFactory;
 import io.tehuti.metrics.MetricsRepository;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
 import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -22,6 +23,7 @@ public class HttpChannelInitializerTest {
   private CompletableFuture<HelixCustomizedViewOfflinePushRepository> customizedViewRepository;
   private MetricsRepository metricsRepository;
   private Optional<SSLFactory> sslFactory;
+  private Optional<Executor> sslHandshakeExecutor;
   private VeniceServerConfig serverConfig;
   private Optional<StaticAccessController> accessController;
   private Optional<DynamicAccessController> storeAccessController;
@@ -32,6 +34,7 @@ public class HttpChannelInitializerTest {
     storeMetadataRepository = mock(ReadOnlyStoreRepository.class);
     metricsRepository = new MetricsRepository();
     sslFactory = Optional.of(mock(SSLFactory.class));
+    sslHandshakeExecutor = Optional.of(mock(Executor.class));
     accessController = Optional.of(mock(StaticAccessController.class));
     storeAccessController = Optional.of(mock(DynamicAccessController.class));
     requestHandler = mock(StorageReadRequestsHandler.class);
@@ -48,6 +51,7 @@ public class HttpChannelInitializerTest {
         customizedViewRepository,
         metricsRepository,
         sslFactory,
+        sslHandshakeExecutor,
         serverConfig,
         accessController,
         storeAccessController,
@@ -64,6 +68,7 @@ public class HttpChannelInitializerTest {
         customizedViewRepository,
         metricsRepository,
         sslFactory,
+        sslHandshakeExecutor,
         serverConfig,
         accessController,
         storeAccessController,

--- a/services/venice-server/src/test/java/com/linkedin/venice/listener/HttpChannelInitializerTest.java
+++ b/services/venice-server/src/test/java/com/linkedin/venice/listener/HttpChannelInitializerTest.java
@@ -29,7 +29,7 @@ public class HttpChannelInitializerTest {
   private Optional<SSLFactory> sslFactoryOptional;
 
   private SSLFactory sslFactory;
-  private Optional<Executor> sslHandshakeExecutor;
+  private Executor sslHandshakeExecutor;
   private VeniceServerConfig serverConfig;
   private Optional<StaticAccessController> accessController;
   private Optional<DynamicAccessController> storeAccessController;
@@ -41,7 +41,7 @@ public class HttpChannelInitializerTest {
     metricsRepository = new MetricsRepository();
     sslFactory = mock(SSLFactory.class);
     sslFactoryOptional = Optional.of(sslFactory);
-    sslHandshakeExecutor = Optional.of(mock(Executor.class));
+    sslHandshakeExecutor = mock(Executor.class);
     accessController = Optional.of(mock(StaticAccessController.class));
     storeAccessController = Optional.of(mock(DynamicAccessController.class));
     requestHandler = mock(StorageReadRequestsHandler.class);

--- a/services/venice-server/src/test/java/com/linkedin/venice/listener/ListenerServiceTest.java
+++ b/services/venice-server/src/test/java/com/linkedin/venice/listener/ListenerServiceTest.java
@@ -1,0 +1,89 @@
+package com.linkedin.venice.listener;
+
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+import com.linkedin.davinci.compression.StorageEngineBackedCompressorFactory;
+import com.linkedin.davinci.config.VeniceServerConfig;
+import com.linkedin.davinci.storage.DiskHealthCheckService;
+import com.linkedin.davinci.storage.MetadataRetriever;
+import com.linkedin.davinci.storage.StorageEngineRepository;
+import com.linkedin.venice.acl.DynamicAccessController;
+import com.linkedin.venice.acl.StaticAccessController;
+import com.linkedin.venice.cleaner.ResourceReadUsageTracker;
+import com.linkedin.venice.helix.HelixCustomizedViewOfflinePushRepository;
+import com.linkedin.venice.meta.ReadOnlySchemaRepository;
+import com.linkedin.venice.meta.ReadOnlyStoreRepository;
+import com.linkedin.venice.security.SSLFactory;
+import io.tehuti.metrics.MetricsRepository;
+import java.util.Optional;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CompletableFuture;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+
+public class ListenerServiceTest {
+  StorageEngineRepository storageEngineRepository;
+  ReadOnlyStoreRepository storeMetadataRepository;
+  ReadOnlySchemaRepository schemaRepository;
+  CompletableFuture<HelixCustomizedViewOfflinePushRepository> cvRepository;
+  MetadataRetriever metadataRetriever;
+  VeniceServerConfig serverConfig;
+  MetricsRepository metricsRepository;
+  Optional<SSLFactory> sslFactory;
+  Optional<StaticAccessController> routerAccessController;
+  Optional<DynamicAccessController> storeAccessController;
+  DiskHealthCheckService diskHealthService;
+  StorageEngineBackedCompressorFactory compressorFactory;
+  Optional<ResourceReadUsageTracker> resourceReadUsageTracker;
+
+  @BeforeMethod
+  public void setUp() {
+    storageEngineRepository = mock(StorageEngineRepository.class);
+    storeMetadataRepository = mock(ReadOnlyStoreRepository.class);
+    schemaRepository = mock(ReadOnlySchemaRepository.class);
+    cvRepository = mock(CompletableFuture.class);
+    metadataRetriever = mock(MetadataRetriever.class);
+    serverConfig = mock(VeniceServerConfig.class);
+    metricsRepository = new MetricsRepository();
+    sslFactory = Optional.of(mock(SSLFactory.class));
+    routerAccessController = Optional.of(mock(StaticAccessController.class));
+    storeAccessController = Optional.of(mock(DynamicAccessController.class));
+    diskHealthService = mock(DiskHealthCheckService.class);
+    compressorFactory = mock(StorageEngineBackedCompressorFactory.class);
+    resourceReadUsageTracker = Optional.of(mock(ResourceReadUsageTracker.class));
+    doReturn(1234).when(serverConfig).getListenerPort();
+    BlockingQueue<Runnable> executionQueue = mock(BlockingQueue.class);
+    doReturn(executionQueue).when(serverConfig).getExecutionQueue(anyInt());
+    doReturn(10).when(serverConfig).getRestServiceStorageThreadNum();
+    doReturn(10).when(serverConfig).getDatabaseLookupQueueCapacity();
+    doReturn(10).when(serverConfig).getServerComputeThreadNum();
+    doReturn(10).when(serverConfig).getComputeQueueCapacity();
+    doReturn(10).when(serverConfig).getSslHandshakeThreadPoolSize();
+    doReturn(10).when(serverConfig).getSslHandshakeQueueCapacity();
+    doReturn(false).when(serverConfig).isRestServiceEpollEnabled();
+    doReturn(10).when(serverConfig).getNettyWorkerThreadCount();
+  }
+
+  @Test
+  public void testConstructor() {
+    ListenerService listenerService = new ListenerService(
+        storageEngineRepository,
+        storeMetadataRepository,
+        schemaRepository,
+        cvRepository,
+        metadataRetriever,
+        serverConfig,
+        metricsRepository,
+        sslFactory,
+        routerAccessController,
+        storeAccessController,
+        diskHealthService,
+        compressorFactory,
+        resourceReadUsageTracker);
+    // dummy method call
+    listenerService.getName();
+  }
+}


### PR DESCRIPTION

## Summary, imperative, start upper case, don't end with a period
1. Two new configs to limit the concurrency of ssl handshakes for Venice servers: server.ssl.handshake.thread.pool.size server.ssl.handshake.queue.capacity

2. The ssl handshake executor will emit ThreadPoolStats which includes: active_thread_number, max_thread_number and queued_task_number
Resolves #XXX

## How was this PR tested?
Existing unit and integration tests, will also test in EI with VSC

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.