### PR TITLE
[changelog] Add d2Client as a passable parameter to change capture client config

### DIFF
--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/D2ControllerClient.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/D2ControllerClient.java
@@ -136,7 +136,7 @@ public class D2ControllerClient extends ControllerClient {
   /**
    * Here, if discovery fails, we will throw a VeniceException.
    */
-  private static D2ServiceDiscoveryResponse discoverCluster(
+  public static D2ServiceDiscoveryResponse discoverCluster(
       D2Client d2Client,
       String d2ServiceName,
       String storeName,

--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/D2ControllerClientFactory.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/D2ControllerClientFactory.java
@@ -1,5 +1,6 @@
 package com.linkedin.venice.controllerapi;
 
+import com.linkedin.d2.balancer.D2Client;
 import com.linkedin.venice.security.SSLFactory;
 import com.linkedin.venice.utils.SharedObjectFactory;
 import java.util.HashMap;
@@ -34,6 +35,17 @@ public class D2ControllerClientFactory {
       return SHARED_OBJECT_FACTORY.release(clientIdentifier);
     }
     return true;
+  }
+
+  public static D2ControllerClient discoverAndConstructConrollerClient(
+      String storeName,
+      String d2ServiceName,
+      int retryAttempts,
+      D2Client d2Client) {
+    D2ServiceDiscoveryResponse discoResponse =
+        D2ControllerClient.discoverCluster(d2Client, d2ServiceName, storeName, retryAttempts);
+    String clusterName = discoResponse.getCluster();
+    return new D2ControllerClient(d2ServiceName, clusterName, d2Client);
   }
 
   public static D2ControllerClient discoverAndConstructControllerClient(

--- a/internal/venice-consumer/src/main/java/com/linkedin/venice/client/consumer/ChangelogClientConfig.java
+++ b/internal/venice-consumer/src/main/java/com/linkedin/venice/client/consumer/ChangelogClientConfig.java
@@ -1,5 +1,6 @@
 package com.linkedin.venice.client.consumer;
 
+import com.linkedin.d2.balancer.D2Client;
 import com.linkedin.venice.client.store.ClientConfig;
 import com.linkedin.venice.controllerapi.D2ControllerClient;
 import com.linkedin.venice.schema.SchemaReader;
@@ -13,6 +14,8 @@ public class ChangelogClientConfig<T extends SpecificRecord> {
   private String viewName;
   private ClientConfig<T> innerClientConfig;
   private D2ControllerClient d2ControllerClient;
+
+  private D2Client d2Client;
   private String controllerD2ServiceName;
   private int controllerRequestRetryCount;
 
@@ -87,6 +90,15 @@ public class ChangelogClientConfig<T extends SpecificRecord> {
     return this.d2ControllerClient;
   }
 
+  public ChangelogClientConfig<T> setD2Client(D2Client d2Client) {
+    this.d2Client = d2Client;
+    return this;
+  }
+
+  public D2Client getD2Client() {
+    return this.d2Client;
+  }
+
   public ChangelogClientConfig<T> setLocalD2ZkHosts(String localD2ZkHosts) {
     this.innerClientConfig.setVeniceURL(localD2ZkHosts);
     return this;
@@ -118,6 +130,7 @@ public class ChangelogClientConfig<T extends SpecificRecord> {
         .setViewName(config.getViewName())
         .setD2ControllerClient(config.getD2ControllerClient())
         .setControllerD2ServiceName(config.controllerD2ServiceName)
+        .setD2Client(config.getD2Client())
         .setControllerRequestRetryCount(config.getControllerRequestRetryCount());
     return newConfig;
   }

--- a/internal/venice-consumer/src/main/java/com/linkedin/venice/client/consumer/VeniceChangelogConsumerClientFactory.java
+++ b/internal/venice-consumer/src/main/java/com/linkedin/venice/client/consumer/VeniceChangelogConsumerClientFactory.java
@@ -25,14 +25,14 @@ public class VeniceChangelogConsumerClientFactory {
 
   private KafkaConsumer consumer;
 
-  protected ViewClassGetter defaultViewClassGetter;
+  protected ViewClassGetter viewClassGetter;
 
   public VeniceChangelogConsumerClientFactory(
       ChangelogClientConfig globalChangelogClientConfig,
       MetricsRepository metricsRepository) {
     this.globalChangelogClientConfig = globalChangelogClientConfig;
     this.metricsRepository = metricsRepository;
-    this.defaultViewClassGetter = getDefaultViewClassGetter();
+    this.viewClassGetter = getDefaultViewClassGetter();
   }
 
   protected void setD2ControllerClient(D2ControllerClient d2ControllerClient) {
@@ -96,7 +96,7 @@ public class VeniceChangelogConsumerClientFactory {
   }
 
   private String getViewClass(String storeName, String viewName, D2ControllerClient d2ControllerClient, int retries) {
-    return this.defaultViewClassGetter.apply(storeName, viewName, d2ControllerClient, retries);
+    return this.viewClassGetter.apply(storeName, viewName, d2ControllerClient, retries);
   }
 
   private ViewClassGetter getDefaultViewClassGetter() {
@@ -118,7 +118,7 @@ public class VeniceChangelogConsumerClientFactory {
   }
 
   protected void setViewClassGetter(ViewClassGetter viewClassGetter) {
-    this.defaultViewClassGetter = viewClassGetter;
+    this.viewClassGetter = viewClassGetter;
   }
 
   @FunctionalInterface

--- a/internal/venice-consumer/src/main/java/com/linkedin/venice/client/consumer/VeniceChangelogConsumerClientFactory.java
+++ b/internal/venice-consumer/src/main/java/com/linkedin/venice/client/consumer/VeniceChangelogConsumerClientFactory.java
@@ -48,6 +48,7 @@ public class VeniceChangelogConsumerClientFactory {
 
       ChangelogClientConfig newStoreChangelogClientConfig =
           ChangelogClientConfig.cloneConfig(globalChangelogClientConfig).setStoreName(storeName);
+      newStoreChangelogClientConfig.getInnerClientConfig().setMetricsRepository(metricsRepository);
 
       D2ControllerClient d2ControllerClient;
       if (this.d2ControllerClient != null) {
@@ -88,7 +89,6 @@ public class VeniceChangelogConsumerClientFactory {
             newStoreChangelogClientConfig,
             consumer != null ? consumer : new KafkaConsumer<>(newStoreChangelogClientConfig.getConsumerProperties()));
       }
-      newStoreChangelogClientConfig.getInnerClientConfig().setMetricsRepository(metricsRepository);
       return new VeniceAfterImageConsumerImpl(
           newStoreChangelogClientConfig,
           consumer != null ? consumer : new KafkaConsumer<>(newStoreChangelogClientConfig.getConsumerProperties()));

--- a/internal/venice-consumer/src/main/java/com/linkedin/venice/client/consumer/VeniceChangelogConsumerClientFactory.java
+++ b/internal/venice-consumer/src/main/java/com/linkedin/venice/client/consumer/VeniceChangelogConsumerClientFactory.java
@@ -7,6 +7,7 @@ import com.linkedin.venice.controllerapi.StoreResponse;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.meta.ViewConfig;
 import com.linkedin.venice.views.ChangeCaptureView;
+import io.tehuti.metrics.MetricsRepository;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -16,14 +17,22 @@ import org.apache.kafka.clients.consumer.KafkaConsumer;
 public class VeniceChangelogConsumerClientFactory {
   private final Map<String, VeniceChangelogConsumer> storeClientMap = new HashMap<>();
 
+  private final MetricsRepository metricsRepository;
+
   private final ChangelogClientConfig globalChangelogClientConfig;
 
   private D2ControllerClient d2ControllerClient;
 
   private KafkaConsumer consumer;
 
-  public VeniceChangelogConsumerClientFactory(ChangelogClientConfig globalChangelogClientConfig) {
+  protected ViewClassGetter defaultViewClassGetter;
+
+  public VeniceChangelogConsumerClientFactory(
+      ChangelogClientConfig globalChangelogClientConfig,
+      MetricsRepository metricsRepository) {
     this.globalChangelogClientConfig = globalChangelogClientConfig;
+    this.metricsRepository = metricsRepository;
+    this.defaultViewClassGetter = getDefaultViewClassGetter();
   }
 
   protected void setD2ControllerClient(D2ControllerClient d2ControllerClient) {
@@ -39,14 +48,24 @@ public class VeniceChangelogConsumerClientFactory {
 
       ChangelogClientConfig newStoreChangelogClientConfig =
           ChangelogClientConfig.cloneConfig(globalChangelogClientConfig).setStoreName(storeName);
-      D2ControllerClient d2ControllerClient = this.d2ControllerClient != null
-          ? this.d2ControllerClient
-          : D2ControllerClientFactory.discoverAndConstructControllerClient(
-              storeName,
-              globalChangelogClientConfig.getControllerD2ServiceName(),
-              globalChangelogClientConfig.getLocalD2ZkHosts(),
-              Optional.ofNullable(newStoreChangelogClientConfig.getInnerClientConfig().getSslFactory()),
-              globalChangelogClientConfig.getControllerRequestRetryCount());
+
+      D2ControllerClient d2ControllerClient;
+      if (this.d2ControllerClient != null) {
+        d2ControllerClient = this.d2ControllerClient;
+      } else if (newStoreChangelogClientConfig.getD2Client() != null) {
+        d2ControllerClient = D2ControllerClientFactory.discoverAndConstructConrollerClient(
+            storeName,
+            globalChangelogClientConfig.getControllerD2ServiceName(),
+            globalChangelogClientConfig.getControllerRequestRetryCount(),
+            newStoreChangelogClientConfig.getD2Client());
+      } else {
+        d2ControllerClient = D2ControllerClientFactory.discoverAndConstructControllerClient(
+            storeName,
+            globalChangelogClientConfig.getControllerD2ServiceName(),
+            globalChangelogClientConfig.getLocalD2ZkHosts(),
+            Optional.ofNullable(newStoreChangelogClientConfig.getInnerClientConfig().getSslFactory()),
+            globalChangelogClientConfig.getControllerRequestRetryCount());
+      }
       newStoreChangelogClientConfig.setD2ControllerClient(d2ControllerClient);
       if (newStoreChangelogClientConfig.getSchemaReader() == null) {
         newStoreChangelogClientConfig
@@ -69,6 +88,7 @@ public class VeniceChangelogConsumerClientFactory {
             newStoreChangelogClientConfig,
             consumer != null ? consumer : new KafkaConsumer<>(newStoreChangelogClientConfig.getConsumerProperties()));
       }
+      newStoreChangelogClientConfig.getInnerClientConfig().setMetricsRepository(metricsRepository);
       return new VeniceAfterImageConsumerImpl(
           newStoreChangelogClientConfig,
           consumer != null ? consumer : new KafkaConsumer<>(newStoreChangelogClientConfig.getConsumerProperties()));
@@ -76,18 +96,33 @@ public class VeniceChangelogConsumerClientFactory {
   }
 
   private String getViewClass(String storeName, String viewName, D2ControllerClient d2ControllerClient, int retries) {
-    StoreResponse response =
-        d2ControllerClient.retryableRequest(retries, controllerClient -> controllerClient.getStore(storeName));
-    if (response.isError()) {
-      throw new VeniceException(
-          "Couldn't retrieve store information when building change capture client for store " + storeName);
-    }
-    ViewConfig viewConfig = response.getStore().getViewConfigs().get(viewName);
-    if (viewConfig == null) {
-      throw new VeniceException(
-          "Couldn't retrieve store view information when building change capture client for store " + storeName
-              + " viewName " + viewName);
-    }
-    return viewConfig.getViewClassName();
+    return this.defaultViewClassGetter.apply(storeName, viewName, d2ControllerClient, retries);
+  }
+
+  private ViewClassGetter getDefaultViewClassGetter() {
+    return (String storeName, String viewName, D2ControllerClient d2ControllerClient, int retries) -> {
+      StoreResponse response =
+          d2ControllerClient.retryableRequest(retries, controllerClient -> controllerClient.getStore(storeName));
+      if (response.isError()) {
+        throw new VeniceException(
+            "Couldn't retrieve store information when building change capture client for store " + storeName);
+      }
+      ViewConfig viewConfig = response.getStore().getViewConfigs().get(viewName);
+      if (viewConfig == null) {
+        throw new VeniceException(
+            "Couldn't retrieve store view information when building change capture client for store " + storeName
+                + " viewName " + viewName);
+      }
+      return viewConfig.getViewClassName();
+    };
+  }
+
+  protected void setViewClassGetter(ViewClassGetter viewClassGetter) {
+    this.defaultViewClassGetter = viewClassGetter;
+  }
+
+  @FunctionalInterface
+  public interface ViewClassGetter {
+    String apply(String storeName, String viewName, D2ControllerClient d2ControllerClient, int retries);
   }
 }

--- a/internal/venice-consumer/src/test/java/com/linkedin/venice/client/consumer/VeniceChangelogConsumerClientFactoryTest.java
+++ b/internal/venice-consumer/src/test/java/com/linkedin/venice/client/consumer/VeniceChangelogConsumerClientFactoryTest.java
@@ -135,7 +135,6 @@ public class VeniceChangelogConsumerClientFactoryTest {
         new VeniceChangelogConsumerClientFactory(globalChangelogClientConfig, new MetricsRepository());
     D2ControllerClient mockControllerClient = Mockito.mock(D2ControllerClient.class);
 
-    // veniceChangelogConsumerClientFactory.setD2ControllerClient(mockControllerClient);
     veniceChangelogConsumerClientFactory.setConsumer(mockKafkaConsumer);
 
     StoreResponse mockStoreResponse = Mockito.mock(StoreResponse.class);

--- a/internal/venice-consumer/src/test/java/com/linkedin/venice/client/consumer/VeniceChangelogConsumerClientFactoryTest.java
+++ b/internal/venice-consumer/src/test/java/com/linkedin/venice/client/consumer/VeniceChangelogConsumerClientFactoryTest.java
@@ -1,10 +1,14 @@
 package com.linkedin.venice.client.consumer;
 
-import static com.linkedin.venice.integration.utils.VeniceControllerWrapper.*;
-import static org.testng.Assert.*;
+import static org.mockito.Mockito.*;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.linkedin.d2.balancer.D2Client;
+import com.linkedin.data.ByteString;
+import com.linkedin.r2.message.rest.RestResponse;
 import com.linkedin.venice.client.store.schemas.TestKeyRecord;
 import com.linkedin.venice.controllerapi.D2ControllerClient;
+import com.linkedin.venice.controllerapi.D2ServiceDiscoveryResponse;
 import com.linkedin.venice.controllerapi.StoreResponse;
 import com.linkedin.venice.meta.StoreInfo;
 import com.linkedin.venice.meta.ViewConfig;
@@ -12,10 +16,15 @@ import com.linkedin.venice.meta.ViewConfigImpl;
 import com.linkedin.venice.schema.SchemaReader;
 import com.linkedin.venice.serialization.KafkaKeySerializer;
 import com.linkedin.venice.serialization.avro.KafkaValueSerializer;
+import com.linkedin.venice.utils.ObjectMapperFactory;
 import com.linkedin.venice.views.ChangeCaptureView;
+import io.tehuti.metrics.MetricsRepository;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
 import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
@@ -27,9 +36,10 @@ import org.testng.annotations.Test;
 public class VeniceChangelogConsumerClientFactoryTest {
   private static final String STORE_NAME = "dybbuk_store";
   private static final String VIEW_NAME = "mazzikim_view";
+  private static final String TEST_CLUSTER = "golem_cluster";
 
   @Test
-  public void testGetChangelogConsumer() {
+  public void testGetChangelogConsumer() throws ExecutionException, InterruptedException, JsonProcessingException {
     Properties consumerProperties = new Properties();
     String localKafkaUrl = "http://www.fooAddress.linkedin.com:16337";
     consumerProperties.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, localKafkaUrl);
@@ -44,7 +54,7 @@ public class VeniceChangelogConsumerClientFactoryTest {
     ChangelogClientConfig globalChangelogClientConfig =
         new ChangelogClientConfig().setConsumerProperties(consumerProperties).setSchemaReader(mockSchemaReader);
     VeniceChangelogConsumerClientFactory veniceChangelogConsumerClientFactory =
-        new VeniceChangelogConsumerClientFactory(globalChangelogClientConfig);
+        new VeniceChangelogConsumerClientFactory(globalChangelogClientConfig, new MetricsRepository());
     D2ControllerClient mockControllerClient = Mockito.mock(D2ControllerClient.class);
 
     veniceChangelogConsumerClientFactory.setD2ControllerClient(mockControllerClient);
@@ -68,6 +78,42 @@ public class VeniceChangelogConsumerClientFactoryTest {
     globalChangelogClientConfig.setViewName(VIEW_NAME);
     consumer = veniceChangelogConsumerClientFactory.getChangelogConsumer(STORE_NAME);
     Assert.assertTrue(consumer instanceof VeniceChangelogConsumerImpl);
+
+    D2ServiceDiscoveryResponse serviceDiscoveryResponse = new D2ServiceDiscoveryResponse();
+    serviceDiscoveryResponse.setCluster(TEST_CLUSTER);
+    serviceDiscoveryResponse.setD2Service("TEST_ROUTER_D2_SERVICE");
+    serviceDiscoveryResponse.setServerD2Service("TEST_SERVER_D2_SERVICE");
+    serviceDiscoveryResponse.setName(STORE_NAME);
+    String discoverClusterResponse = ObjectMapperFactory.getInstance().writeValueAsString(serviceDiscoveryResponse);
+
+    RestResponse discoverClusterRestResponse = mock(RestResponse.class);
+    doReturn(ByteString.unsafeWrap(discoverClusterResponse.getBytes(StandardCharsets.UTF_8)))
+        .when(discoverClusterRestResponse)
+        .getEntity();
+
+    // Verify branches which have a managed D2Client passed in for the controller client
+    D2Client mockD2Client = Mockito.mock(D2Client.class);
+    Future mockClusterDiscoveryFuture = Mockito.mock(Future.class);
+    Mockito.when(mockClusterDiscoveryFuture.get()).thenReturn(discoverClusterRestResponse);
+    Mockito.when(mockD2Client.restRequest(Mockito.any())).thenReturn(mockClusterDiscoveryFuture);
+
+    globalChangelogClientConfig.setD2Client(mockD2Client).setD2ControllerClient(null).setControllerRequestRetryCount(1);
+
+    VeniceChangelogConsumerClientFactory.ViewClassGetter mockViewGetter = (
+        String storeName,
+        String viewName,
+        D2ControllerClient d2ControllerClient,
+        int retries) -> ChangeCaptureView.class.getCanonicalName();
+
+    veniceChangelogConsumerClientFactory =
+        new VeniceChangelogConsumerClientFactory(globalChangelogClientConfig, new MetricsRepository());
+    veniceChangelogConsumerClientFactory.setViewClassGetter(mockViewGetter);
+    veniceChangelogConsumerClientFactory.setD2ControllerClient(mockControllerClient);
+    veniceChangelogConsumerClientFactory.setConsumer(mockKafkaConsumer);
+
+    consumer = veniceChangelogConsumerClientFactory.getChangelogConsumer(STORE_NAME);
+    Assert.assertTrue(consumer instanceof VeniceChangelogConsumerImpl);
+
   }
 
   @Test
@@ -86,10 +132,10 @@ public class VeniceChangelogConsumerClientFactoryTest {
     ChangelogClientConfig globalChangelogClientConfig =
         new ChangelogClientConfig().setConsumerProperties(consumerProperties).setSchemaReader(mockSchemaReader);
     VeniceChangelogConsumerClientFactory veniceChangelogConsumerClientFactory =
-        new VeniceChangelogConsumerClientFactory(globalChangelogClientConfig);
+        new VeniceChangelogConsumerClientFactory(globalChangelogClientConfig, new MetricsRepository());
     D2ControllerClient mockControllerClient = Mockito.mock(D2ControllerClient.class);
 
-    veniceChangelogConsumerClientFactory.setD2ControllerClient(mockControllerClient);
+    // veniceChangelogConsumerClientFactory.setD2ControllerClient(mockControllerClient);
     veniceChangelogConsumerClientFactory.setConsumer(mockKafkaConsumer);
 
     StoreResponse mockStoreResponse = Mockito.mock(StoreResponse.class);

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestActiveActiveIngestion.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestActiveActiveIngestion.java
@@ -215,12 +215,12 @@ public class TestActiveActiveIngestion {
         .setLocalD2ZkHosts(localZkServer.getAddress())
         .setControllerRequestRetryCount(3);
     VeniceChangelogConsumerClientFactory veniceChangelogConsumerClientFactory =
-        new VeniceChangelogConsumerClientFactory(globalChangelogClientConfig);
+        new VeniceChangelogConsumerClientFactory(globalChangelogClientConfig, metricsRepository);
 
     ChangelogClientConfig globalAfterImageClientConfig =
         ChangelogClientConfig.cloneConfig(globalChangelogClientConfig).setViewName("");
     VeniceChangelogConsumerClientFactory veniceAfterImageConsumerClientFactory =
-        new VeniceChangelogConsumerClientFactory(globalAfterImageClientConfig);
+        new VeniceChangelogConsumerClientFactory(globalAfterImageClientConfig, metricsRepository);
 
     VeniceChangelogConsumer<Utf8, Utf8> veniceChangelogConsumer =
         veniceChangelogConsumerClientFactory.getChangelogConsumer(storeName);


### PR DESCRIPTION
## Add d2Client as a passable parameter to change capture client config

This will enable us to leverage offspring's lifecycle aware to manage the d2clients

## How was this PR tested?
Unit tests

## Does this PR introduce any user-facing changes?

Yes?  but it's a good one I promise!  Basically the underlying d2 client can now be configured and managed by LinkedIn's deployment infra.

- [ ] No. You can skip the rest of this section.
- [x] Yes. Make sure to explain your proposed changes and call out the behavior change.