### PR TITLE
[server][da-vinci-client] Skip recording metric for control messages

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -1916,24 +1916,25 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
     /*
      * Report ingestion throughput metric based on the store version
      */
-    versionedIngestionStats.recordBytesConsumed(storeName, versionNumber, recordSize);
-    versionedIngestionStats.recordRecordsConsumed(storeName, versionNumber);
+    if (recordSize != 0) { // skip control messages
+      versionedIngestionStats.recordBytesConsumed(storeName, versionNumber, recordSize);
+      versionedIngestionStats.recordRecordsConsumed(storeName, versionNumber);
 
-    /*
-     * Meanwhile, contribute to the host-level ingestion throughput rate, which aggregates the consumption rate across
-     * all store versions.
-     */
-    hostLevelIngestionStats.recordTotalBytesConsumed(recordSize);
-    hostLevelIngestionStats.recordTotalRecordsConsumed();
+      /*
+       * Meanwhile, contribute to the host-level ingestion throughput rate, which aggregates the consumption rate across
+       * all store versions.
+       */
+      hostLevelIngestionStats.recordTotalBytesConsumed(recordSize);
+      hostLevelIngestionStats.recordTotalRecordsConsumed();
 
-    /*
-     * Also update this stats separately for Leader and Follower.
-     */
-    recordProcessedRecordStats(partitionConsumptionState, recordSize);
-
+      /*
+       * Also update this stats separately for Leader and Follower.
+       */
+      recordProcessedRecordStats(partitionConsumptionState, recordSize);
+      partitionConsumptionState.incrementProcessedRecordSizeSinceLastSync(recordSize);
+    }
     reportIfCatchUpVersionTopicOffset(partitionConsumptionState);
 
-    partitionConsumptionState.incrementProcessedRecordSizeSinceLastSync(recordSize);
     long syncBytesInterval = partitionConsumptionState.isDeferredWrite()
         ? databaseSyncBytesIntervalForDeferredWriteMode
         : databaseSyncBytesIntervalForTransactionalMode;

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -1916,7 +1916,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
     /*
      * Report ingestion throughput metric based on the store version
      */
-    if (recordSize != 0) { // skip control messages
+    if (!record.getKey().isControlMessage()) { // skip control messages
       versionedIngestionStats.recordBytesConsumed(storeName, versionNumber, recordSize);
       versionedIngestionStats.recordRecordsConsumed(storeName, versionNumber);
 

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/router/TestRead.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/router/TestRead.java
@@ -393,6 +393,8 @@ public abstract class TestRead {
         Assert.assertEquals(getMaxServerMetricValue(".total--compute_request_part_count.Max"), 1.0);
       }
       // Verify storage node metrics
+      Assert.assertTrue(getMaxServerMetricValue(".total--records_consumed.Rate") > 0.0);
+
       Assert.assertTrue(getMaxServerMetricValue(".total--multiget_request_size_in_bytes.Max") > 0.0);
       Assert.assertTrue(getMaxServerMetricValue(".total--compute_request_size_in_bytes.Max") > 0.0);
       for (VeniceServerWrapper veniceServerWrapper: veniceCluster.getVeniceServers()) {


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci], [server], [controller],
[router], [samza], [vpj], [fast-client], [thin-client], [alpini],
[admin-tool], [test], [build], [doc], [script]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Skip recording metric for control messages
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Skip recording metric for control messages and the record size is returned as 0 anyways from downstream methods. Also fix stat 'LongAdderRateGauge' name to 'Rate' to match previous name and not break any existing alerts and added a check to LARG metric emission.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
CI
## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.