### PR TITLE
[controller][admin-tool] Added tooling to update topic minISR

### DIFF
--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/AdminTool.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/AdminTool.java
@@ -461,6 +461,9 @@ public class AdminTool {
         case UPDATE_KAFKA_TOPIC_RETENTION:
           updateKafkaTopicRetention(cmd);
           break;
+        case UPDATE_KAFKA_TOPIC_MIN_IN_SYNC_REPLICA:
+          updateKafkaTopicMinInSyncReplica(cmd);
+          break;
         case START_FABRIC_BUILDOUT:
           startFabricBuildout(cmd);
           break;
@@ -2374,6 +2377,14 @@ public class AdminTool {
       String kafkaTopicName = getRequiredArgument(cmd, Arg.KAFKA_TOPIC_NAME);
       long kafkaTopicRetentionTimeInMs = Long.parseLong(getRequiredArgument(cmd, Arg.KAFKA_TOPIC_RETENTION_IN_MS));
       return client.updateKafkaTopicRetention(kafkaTopicName, kafkaTopicRetentionTimeInMs);
+    });
+  }
+
+  private static void updateKafkaTopicMinInSyncReplica(CommandLine cmd) {
+    updateKafkaTopicConfig(cmd, client -> {
+      String kafkaTopicName = getRequiredArgument(cmd, Arg.KAFKA_TOPIC_NAME);
+      int kafkaTopicMinISR = Integer.parseInt(getRequiredArgument(cmd, Arg.KAFKA_TOPIC_MIN_IN_SYNC_REPLICA));
+      return client.updateKafkaTopicMinInSyncReplica(kafkaTopicName, kafkaTopicMinISR);
     });
   }
 

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/Arg.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/Arg.java
@@ -200,7 +200,7 @@ public enum Arg {
   ),
   KAFKA_TOPIC_RETENTION_IN_MS(
       "kafka-topic-retention-in-ms", "ktrim", true, "Kafka topic retention time in milliseconds"
-  ),
+  ), KAFKA_TOPIC_MIN_IN_SYNC_REPLICA("kafka-topic-min-in-sync-replica", "ktmisr", true, "Kafka topic minISR config"),
   CHILD_CONTROLLER_ADMIN_TOPIC_CONSUMPTION_ENABLED(
       ConfigKeys.CHILD_CONTROLLER_ADMIN_TOPIC_CONSUMPTION_ENABLED, "atc", true,
       "whether child controller consumes admin topic"

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/Command.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/Command.java
@@ -48,6 +48,7 @@ import static com.linkedin.venice.Arg.KAFKA_BOOTSTRAP_SERVERS;
 import static com.linkedin.venice.Arg.KAFKA_CONSUMER_CONFIG_FILE;
 import static com.linkedin.venice.Arg.KAFKA_OPERATION_TIMEOUT;
 import static com.linkedin.venice.Arg.KAFKA_TOPIC_LOG_COMPACTION_ENABLED;
+import static com.linkedin.venice.Arg.KAFKA_TOPIC_MIN_IN_SYNC_REPLICA;
 import static com.linkedin.venice.Arg.KAFKA_TOPIC_NAME;
 import static com.linkedin.venice.Arg.KAFKA_TOPIC_PARTITION;
 import static com.linkedin.venice.Arg.KAFKA_TOPIC_RETENTION_IN_MS;
@@ -396,6 +397,10 @@ public enum Command {
   UPDATE_KAFKA_TOPIC_RETENTION(
       "update-kafka-topic-retention", "Update retention config of a topic through controllers",
       new Arg[] { URL, KAFKA_TOPIC_NAME, KAFKA_TOPIC_RETENTION_IN_MS }, new Arg[] { CLUSTER }
+  ),
+  UPDATE_KAFKA_TOPIC_MIN_IN_SYNC_REPLICA(
+      "update-kafka-topic-min-in-sync-replica", "Update minISR of a topic through controllers",
+      new Arg[] { URL, KAFKA_TOPIC_NAME, KAFKA_TOPIC_MIN_IN_SYNC_REPLICA }, new Arg[] { CLUSTER }
   ),
   START_FABRIC_BUILDOUT(
       "start-fabric-buildout",

--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerApiConstants.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerApiConstants.java
@@ -195,7 +195,7 @@ public class ControllerApiConstants {
 
   public static final String KAFKA_TOPIC_LOG_COMPACTION_ENABLED = "kafka.topic.log.compaction.enabled";
   public static final String KAFKA_TOPIC_RETENTION_IN_MS = "kafka.topic.retention.in.ms";
-
+  public static final String KAFKA_TOPIC_MIN_IN_SYNC_REPLICA = "kafka.topic.min.in.sync.replica";
   public static final String UPSTREAM_OFFSET = "upstream_offset";
 
   public static final String PERSONA_NAME = "persona_name";

--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerClient.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerClient.java
@@ -21,6 +21,7 @@ import static com.linkedin.venice.controllerapi.ControllerApiConstants.INCLUDE_S
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.INCREMENTAL_PUSH_VERSION;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.IS_WRITE_COMPUTE_ENABLED;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.KAFKA_TOPIC_LOG_COMPACTION_ENABLED;
+import static com.linkedin.venice.controllerapi.ControllerApiConstants.KAFKA_TOPIC_MIN_IN_SYNC_REPLICA;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.KAFKA_TOPIC_RETENTION_IN_MS;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.KEY_SCHEMA;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.LOCKED_NODE_ID_LIST_SEPARATOR;
@@ -549,6 +550,11 @@ public class ControllerClient implements Closeable {
   public ControllerResponse updateKafkaTopicRetention(String kafkaTopicName, long retentionInMs) {
     QueryParams params = newParams().add(TOPIC, kafkaTopicName).add(KAFKA_TOPIC_RETENTION_IN_MS, retentionInMs);
     return request(ControllerRoute.UPDATE_KAFKA_TOPIC_RETENTION, params, ControllerResponse.class);
+  }
+
+  public ControllerResponse updateKafkaTopicMinInSyncReplica(String kafkaTopicName, int minISR) {
+    QueryParams params = newParams().add(TOPIC, kafkaTopicName).add(KAFKA_TOPIC_MIN_IN_SYNC_REPLICA, minISR);
+    return request(ControllerRoute.UPDATE_KAFKA_TOPIC_MIN_IN_SYNC_REPLICA, params, ControllerResponse.class);
   }
 
   public <R extends ControllerResponse> R retryableRequest(int totalAttempts, Function<ControllerClient, R> request) {

--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerRoute.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerRoute.java
@@ -36,6 +36,7 @@ import static com.linkedin.venice.controllerapi.ControllerApiConstants.INCREMENT
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.INSTANCE_VIEW;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.IS_SYSTEM_STORE;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.KAFKA_TOPIC_LOG_COMPACTION_ENABLED;
+import static com.linkedin.venice.controllerapi.ControllerApiConstants.KAFKA_TOPIC_MIN_IN_SYNC_REPLICA;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.KAFKA_TOPIC_RETENTION_IN_MS;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.KEY_SCHEMA;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.LARGEST_USED_VERSION_NUMBER;
@@ -256,6 +257,9 @@ public enum ControllerRoute {
   ),
   UPDATE_KAFKA_TOPIC_RETENTION(
       "/update_kafka_topic_retention", HttpMethod.GET, Arrays.asList(TOPIC, KAFKA_TOPIC_RETENTION_IN_MS)
+  ),
+  UPDATE_KAFKA_TOPIC_MIN_IN_SYNC_REPLICA(
+      "/update_kafka_topic_min_in_sync_replica", HttpMethod.GET, Arrays.asList(TOPIC, KAFKA_TOPIC_MIN_IN_SYNC_REPLICA)
   ), GET_ADMIN_TOPIC_METADATA("/get_admin_topic_metadata", HttpMethod.GET, Collections.singletonList(CLUSTER), NAME),
   UPDATE_ADMIN_TOPIC_METADATA(
       "/update_admin_topic_metadata", HttpMethod.POST, Arrays.asList(CLUSTER, EXECUTION_ID), NAME, OFFSET,

--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerRoute.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerRoute.java
@@ -253,13 +253,13 @@ public enum ControllerRoute {
       "/get_region_push_details", HttpMethod.GET, Arrays.asList(CLUSTER, NAME, PARTITION_DETAIL_ENABLED)
   ),
   UPDATE_KAFKA_TOPIC_LOG_COMPACTION(
-      "/update_kafka_topic_log_compaction", HttpMethod.GET, Arrays.asList(TOPIC, KAFKA_TOPIC_LOG_COMPACTION_ENABLED)
+      "/update_kafka_topic_log_compaction", HttpMethod.POST, Arrays.asList(TOPIC, KAFKA_TOPIC_LOG_COMPACTION_ENABLED)
   ),
   UPDATE_KAFKA_TOPIC_RETENTION(
-      "/update_kafka_topic_retention", HttpMethod.GET, Arrays.asList(TOPIC, KAFKA_TOPIC_RETENTION_IN_MS)
+      "/update_kafka_topic_retention", HttpMethod.POST, Arrays.asList(TOPIC, KAFKA_TOPIC_RETENTION_IN_MS)
   ),
   UPDATE_KAFKA_TOPIC_MIN_IN_SYNC_REPLICA(
-      "/update_kafka_topic_min_in_sync_replica", HttpMethod.GET, Arrays.asList(TOPIC, KAFKA_TOPIC_MIN_IN_SYNC_REPLICA)
+      "/update_kafka_topic_min_in_sync_replica", HttpMethod.POST, Arrays.asList(TOPIC, KAFKA_TOPIC_MIN_IN_SYNC_REPLICA)
   ), GET_ADMIN_TOPIC_METADATA("/get_admin_topic_metadata", HttpMethod.GET, Collections.singletonList(CLUSTER), NAME),
   UPDATE_ADMIN_TOPIC_METADATA(
       "/update_admin_topic_metadata", HttpMethod.POST, Arrays.asList(CLUSTER, EXECUTION_ID), NAME, OFFSET,

--- a/internal/venice-common/src/test/java/com/linkedin/venice/kafka/TestTopicManager.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/kafka/TestTopicManager.java
@@ -1,0 +1,38 @@
+package com.linkedin.venice.kafka;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import com.linkedin.venice.kafka.admin.KafkaAdminWrapper;
+import com.linkedin.venice.utils.Utils;
+import java.util.Properties;
+import org.apache.kafka.common.config.TopicConfig;
+import org.mockito.ArgumentCaptor;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class TestTopicManager {
+  @Test
+  public void testUpdateTopicMinISRCommand() {
+    String topicName = Utils.getUniqueString("testTopic");
+    Properties properties = new Properties();
+    properties.setProperty(TopicConfig.MIN_IN_SYNC_REPLICAS_CONFIG, "1");
+    KafkaAdminWrapper mockKafkaReadOnlyAdmin = mock(KafkaAdminWrapper.class);
+    doReturn(properties).when(mockKafkaReadOnlyAdmin).getTopicConfig(topicName);
+
+    int newMinISR = 2;
+    KafkaAdminWrapper mockKafkaWriteOnlyAdmin = mock(KafkaAdminWrapper.class);
+    ArgumentCaptor<Properties> propertiesArgumentCaptor = ArgumentCaptor.forClass(Properties.class);
+    TopicManager topicManager = new TopicManager(mockKafkaWriteOnlyAdmin, mockKafkaReadOnlyAdmin);
+    topicManager.updateTopicMinInSyncReplica(topicName, newMinISR);
+    verify(mockKafkaWriteOnlyAdmin, atLeastOnce()).setTopicConfig(eq(topicName), propertiesArgumentCaptor.capture());
+    Properties capturedProperties = propertiesArgumentCaptor.getValue();
+    Assert.assertEquals(
+        capturedProperties.getProperty(TopicConfig.MIN_IN_SYNC_REPLICAS_CONFIG),
+        Integer.toString(newMinISR));
+  }
+}

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/kafka/TopicManagerTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/kafka/TopicManagerTest.java
@@ -62,6 +62,7 @@ import java.util.concurrent.TimeUnit;
 import kafka.log.LogConfig;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.common.PartitionInfo;
+import org.apache.kafka.common.config.TopicConfig;
 import org.apache.kafka.common.errors.TimeoutException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -605,5 +606,17 @@ public class TopicManagerTest {
 
     topicManager.createTopic(topic, 1, 1, true);
     Assert.assertTrue(topicManager.containsTopicAndAllPartitionsAreOnline(topic));
+  }
+
+  @Test
+  public void testUpdateTopicMinISR() {
+    String topic = Utils.getUniqueString("topic");
+    topicManager.createTopic(topic, 1, 1, true);
+    Properties topicProperties = topicManager.getTopicConfig(topic);
+    Assert.assertEquals(topicProperties.getProperty(TopicConfig.MIN_IN_SYNC_REPLICAS_CONFIG), "1");
+    // Update minISR to 2
+    topicManager.updateTopicMinInSyncReplica(topic, 2);
+    topicProperties = topicManager.getTopicConfig(topic);
+    Assert.assertEquals(topicProperties.getProperty(TopicConfig.MIN_IN_SYNC_REPLICAS_CONFIG), "2");
   }
 }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/AdminSparkServer.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/AdminSparkServer.java
@@ -92,6 +92,7 @@ import static com.linkedin.venice.controllerapi.ControllerRoute.UPDATE_ACL;
 import static com.linkedin.venice.controllerapi.ControllerRoute.UPDATE_ADMIN_TOPIC_METADATA;
 import static com.linkedin.venice.controllerapi.ControllerRoute.UPDATE_CLUSTER_CONFIG;
 import static com.linkedin.venice.controllerapi.ControllerRoute.UPDATE_KAFKA_TOPIC_LOG_COMPACTION;
+import static com.linkedin.venice.controllerapi.ControllerRoute.UPDATE_KAFKA_TOPIC_MIN_IN_SYNC_REPLICA;
 import static com.linkedin.venice.controllerapi.ControllerRoute.UPDATE_KAFKA_TOPIC_RETENTION;
 import static com.linkedin.venice.controllerapi.ControllerRoute.UPDATE_STORAGE_PERSONA;
 import static com.linkedin.venice.controllerapi.ControllerRoute.UPDATE_STORE;
@@ -415,6 +416,9 @@ public class AdminSparkServer extends AbstractVeniceService {
     httpService.post(DATA_RECOVERY.getPath(), dataRecoveryRoutes.dataRecovery(admin));
     httpService.get(UPDATE_KAFKA_TOPIC_LOG_COMPACTION.getPath(), controllerRoutes.updateKafkaTopicLogCompaction(admin));
     httpService.get(UPDATE_KAFKA_TOPIC_RETENTION.getPath(), controllerRoutes.updateKafkaTopicRetention(admin));
+    httpService.get(
+        UPDATE_KAFKA_TOPIC_MIN_IN_SYNC_REPLICA.getPath(),
+        controllerRoutes.updateKafkaTopicMinInSyncReplica(admin));
 
     httpService.get(GET_ADMIN_TOPIC_METADATA.getPath(), adminTopicMetadataRoutes.getAdminTopicMetadata(admin));
     httpService.post(UPDATE_ADMIN_TOPIC_METADATA.getPath(), adminTopicMetadataRoutes.updateAdminTopicMetadata(admin));

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/AdminSparkServer.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/AdminSparkServer.java
@@ -414,9 +414,10 @@ public class AdminSparkServer extends AbstractVeniceService {
         IS_STORE_VERSION_READY_FOR_DATA_RECOVERY.getPath(),
         dataRecoveryRoutes.isStoreVersionReadyForDataRecovery(admin));
     httpService.post(DATA_RECOVERY.getPath(), dataRecoveryRoutes.dataRecovery(admin));
-    httpService.get(UPDATE_KAFKA_TOPIC_LOG_COMPACTION.getPath(), controllerRoutes.updateKafkaTopicLogCompaction(admin));
-    httpService.get(UPDATE_KAFKA_TOPIC_RETENTION.getPath(), controllerRoutes.updateKafkaTopicRetention(admin));
-    httpService.get(
+    httpService
+        .post(UPDATE_KAFKA_TOPIC_LOG_COMPACTION.getPath(), controllerRoutes.updateKafkaTopicLogCompaction(admin));
+    httpService.post(UPDATE_KAFKA_TOPIC_RETENTION.getPath(), controllerRoutes.updateKafkaTopicRetention(admin));
+    httpService.post(
         UPDATE_KAFKA_TOPIC_MIN_IN_SYNC_REPLICA.getPath(),
         controllerRoutes.updateKafkaTopicMinInSyncReplica(admin));
 

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/ControllerRoutes.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/ControllerRoutes.java
@@ -2,11 +2,13 @@ package com.linkedin.venice.controller.server;
 
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.CLUSTER;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.KAFKA_TOPIC_LOG_COMPACTION_ENABLED;
+import static com.linkedin.venice.controllerapi.ControllerApiConstants.KAFKA_TOPIC_MIN_IN_SYNC_REPLICA;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.KAFKA_TOPIC_RETENTION_IN_MS;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.TOPIC;
 import static com.linkedin.venice.controllerapi.ControllerRoute.LEADER_CONTROLLER;
 import static com.linkedin.venice.controllerapi.ControllerRoute.LIST_CHILD_CLUSTERS;
 import static com.linkedin.venice.controllerapi.ControllerRoute.UPDATE_KAFKA_TOPIC_LOG_COMPACTION;
+import static com.linkedin.venice.controllerapi.ControllerRoute.UPDATE_KAFKA_TOPIC_MIN_IN_SYNC_REPLICA;
 import static com.linkedin.venice.controllerapi.ControllerRoute.UPDATE_KAFKA_TOPIC_RETENTION;
 
 import com.linkedin.venice.HttpConstants;
@@ -106,6 +108,18 @@ public class ControllerRoutes extends AbstractRoute {
           Utils.parseLongFromString(adminRequest.queryParams(KAFKA_TOPIC_RETENTION_IN_MS), KAFKA_TOPIC_RETENTION_IN_MS);
       TopicManager topicManager = admin.getTopicManager();
       topicManager.updateTopicRetention(topicName, kafkaTopicRetentionIsMs);
+    });
+  }
+
+  public Route updateKafkaTopicMinInSyncReplica(Admin admin) {
+    return updateKafkaTopicConfig(admin, adminRequest -> {
+      AdminSparkServer.validateParams(adminRequest, UPDATE_KAFKA_TOPIC_MIN_IN_SYNC_REPLICA.getParams(), admin);
+      String topicName = adminRequest.queryParams(TOPIC);
+      int kafkaTopicMinISR = Utils.parseIntFromString(
+          adminRequest.queryParams(KAFKA_TOPIC_MIN_IN_SYNC_REPLICA),
+          KAFKA_TOPIC_MIN_IN_SYNC_REPLICA);
+      TopicManager topicManager = admin.getTopicManager();
+      topicManager.updateTopicMinInSyncReplica(topicName, kafkaTopicMinISR);
     });
   }
 


### PR DESCRIPTION
## Summary
New admin command:
--update-kafka-topic-min-in-sync-replica --url controller_url --kafka-topic-name topic_name --kafka-topic-min-in-sync-replica newMinISR

Controller will apply the changes locally, changing minISR for the topic in the local Kafka cluster only. Then Kafka cluster will adjust the replication factor number accordingly to minISR+2.

## How was this PR tested?
Added both unit test and integration test.

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.