### PR TITLE
[common] Prevent NPE in case of Exception while writing to Kafka

### DIFF
--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/adapter/kafka/producer/ApacheKafkaProducerCallback.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/adapter/kafka/producer/ApacheKafkaProducerCallback.java
@@ -46,14 +46,14 @@ public class ApacheKafkaProducerCallback implements Callback {
    */
   @Override
   public void onCompletion(RecordMetadata metadata, Exception exception) {
-    PubSubProduceResult produceResult = new ApacheKafkaProduceResult(metadata);
+    PubSubProduceResult produceResult = metadata != null ? new ApacheKafkaProduceResult(metadata) : null;
     if (exception != null) {
       produceResultFuture.completeExceptionally(exception);
     } else {
       produceResultFuture.complete(produceResult);
     }
     if (pubsubProducerCallback != null) {
-      pubsubProducerCallback.onCompletion(new ApacheKafkaProduceResult(metadata), exception);
+      pubsubProducerCallback.onCompletion(produceResult, exception);
     }
   }
 


### PR DESCRIPTION
## Summary, imperative, start upper case, don't end with a period

In case of error while writing to Kafka the response from Kafka is null and this leads to a NPE.


## How was this PR tested?
Manually 

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.