### PR TITLE
[admin-tool][data-recovery] Fixes an issue with parameter instantiation.

### DIFF
--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/AdminTool.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/AdminTool.java
@@ -638,13 +638,12 @@ public class AdminTool {
     boolean isDebuggingEnabled = cmd.hasOption(Arg.DEBUG.toString());
     boolean isNonInteractive = cmd.hasOption(Arg.NON_INTERACTIVE.toString());
 
-    StoreRepushCommand.Params.Builder builder = new StoreRepushCommand.Params.Builder();
-    builder.setCommand(recoveryCommand);
-    builder.setDestFabric(destFabric);
-    builder.setSourceFabric(sourceFabric);
-    builder.setTimestamp(LocalDateTime.parse(timestamp, DateTimeFormatter.ISO_LOCAL_DATE_TIME));
-    builder.setSSLFactory(sslFactory);
-    builder.setUrl(url);
+    StoreRepushCommand.Params.Builder builder = new StoreRepushCommand.Params.Builder().setCommand(recoveryCommand)
+        .setDestFabric(destFabric)
+        .setSourceFabric(sourceFabric)
+        .setTimestamp(LocalDateTime.parse(timestamp, DateTimeFormatter.ISO_LOCAL_DATE_TIME))
+        .setSSLFactory(sslFactory)
+        .setUrl(url);
     if (extraCommandArgs != null) {
       builder.setExtraCommandArgs(extraCommandArgs);
     }
@@ -698,10 +697,9 @@ public class AdminTool {
 
     String intervalStr = getOptionalArgument(cmd, Arg.INTERVAL);
 
-    MonitorCommand.Params.Builder builder = new MonitorCommand.Params.Builder();
-    builder.setTargetRegion(destFabric);
-    builder.setParentUrl(parentUrl);
-    builder.setSSLFactory(sslFactory);
+    MonitorCommand.Params.Builder builder = new MonitorCommand.Params.Builder().setTargetRegion(destFabric)
+        .setParentUrl(parentUrl)
+        .setSSLFactory(sslFactory);
 
     try {
       builder.setDateTime(LocalDateTime.parse(dateTimeStr, DateTimeFormatter.ISO_LOCAL_DATE_TIME));

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/AdminTool.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/AdminTool.java
@@ -642,7 +642,7 @@ public class AdminTool {
     builder.setCommand(recoveryCommand);
     builder.setDestFabric(destFabric);
     builder.setSourceFabric(sourceFabric);
-    builder.setTimestamp((LocalDateTime) DateTimeFormatter.ISO_LOCAL_DATE_TIME.parse(timestamp));
+    builder.setTimestamp(LocalDateTime.parse(timestamp, DateTimeFormatter.ISO_LOCAL_DATE_TIME));
     builder.setSSLFactory(sslFactory);
     builder.setUrl(url);
     if (extraCommandArgs != null) {

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/datarecovery/DataRecoveryEstimator.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/datarecovery/DataRecoveryEstimator.java
@@ -33,10 +33,12 @@ public class DataRecoveryEstimator extends DataRecoveryWorker {
   @Override
   public List<DataRecoveryTask> buildTasks(Set<String> storeNames, Command.Params params) {
     List<DataRecoveryTask> tasks = new ArrayList<>();
+    EstimateDataRecoveryTimeCommand.Params.Builder builder =
+        new EstimateDataRecoveryTimeCommand.Params.Builder((EstimateDataRecoveryTimeCommand.Params) params);
     for (String storeName: storeNames) {
-      DataRecoveryTask.TaskParams taskParams = new DataRecoveryTask.TaskParams(storeName, params);
-      EstimateDataRecoveryTimeCommand.Params p =
-          new EstimateDataRecoveryTimeCommand.Params((EstimateDataRecoveryTimeCommand.Params) params);
+      EstimateDataRecoveryTimeCommand.Params p = builder.build();
+      p.setStore(storeName);
+      DataRecoveryTask.TaskParams taskParams = new DataRecoveryTask.TaskParams(storeName, p);
       tasks.add(new DataRecoveryTask(new EstimateDataRecoveryTimeCommand(p), taskParams));
     }
     return tasks;

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/datarecovery/DataRecoveryExecutor.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/datarecovery/DataRecoveryExecutor.java
@@ -23,12 +23,13 @@ public class DataRecoveryExecutor extends DataRecoveryWorker {
   @Override
   public List<DataRecoveryTask> buildTasks(Set<String> storeNames, Command.Params params) {
     List<DataRecoveryTask> tasks = new ArrayList<>();
+    StoreRepushCommand.Params.Builder builder =
+        new StoreRepushCommand.Params.Builder((StoreRepushCommand.Params) params);
     for (String name: storeNames) {
-      DataRecoveryTask.TaskParams taskParams = new DataRecoveryTask.TaskParams(name, params);
-      tasks.add(
-          new DataRecoveryTask(
-              new StoreRepushCommand((StoreRepushCommand.Params) taskParams.getCmdParams()),
-              taskParams));
+      StoreRepushCommand.Params p = builder.build();
+      p.setStore(name);
+      DataRecoveryTask.TaskParams taskParams = new DataRecoveryTask.TaskParams(name, p);
+      tasks.add(new DataRecoveryTask(new StoreRepushCommand(p), taskParams));
     }
     return tasks;
   }

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/datarecovery/DataRecoveryMonitor.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/datarecovery/DataRecoveryMonitor.java
@@ -21,10 +21,12 @@ public class DataRecoveryMonitor extends DataRecoveryWorker {
   @Override
   public List<DataRecoveryTask> buildTasks(Set<String> storeNames, Command.Params params) {
     List<DataRecoveryTask> tasks = new ArrayList<>();
+    MonitorCommand.Params.Builder builder = new MonitorCommand.Params.Builder((MonitorCommand.Params) params);
     for (String name: storeNames) {
-      DataRecoveryTask.TaskParams taskParams = new DataRecoveryTask.TaskParams(name, params);
-      tasks
-          .add(new DataRecoveryTask(new MonitorCommand((MonitorCommand.Params) taskParams.getCmdParams()), taskParams));
+      MonitorCommand.Params p = builder.build();
+      p.setStore(name);
+      DataRecoveryTask.TaskParams taskParams = new DataRecoveryTask.TaskParams(name, p);
+      tasks.add(new DataRecoveryTask(new MonitorCommand(p), taskParams));
     }
     return tasks;
   }

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/datarecovery/EstimateDataRecoveryTimeCommand.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/datarecovery/EstimateDataRecoveryTimeCommand.java
@@ -117,10 +117,10 @@ public class EstimateDataRecoveryTimeCommand extends Command {
           ControllerClient controllerClient,
           String parentUrl,
           Optional<SSLFactory> sslFactory) {
-        this.targetRegion = targetRegion;
-        this.pCtrlCliWithoutCluster = controllerClient;
-        this.parentUrl = parentUrl;
-        this.sslFactory = sslFactory;
+        this.setTargetRegion(targetRegion)
+            .setPCtrlCliWithoutCluster(controllerClient)
+            .setParentUrl(parentUrl)
+            .setSSLFactory(sslFactory);
       }
 
       public Builder(EstimateDataRecoveryTimeCommand.Params p) {
@@ -136,20 +136,25 @@ public class EstimateDataRecoveryTimeCommand extends Command {
         return ret;
       }
 
-      public void setTargetRegion(String targetRegion) {
+      public EstimateDataRecoveryTimeCommand.Params.Builder setTargetRegion(String targetRegion) {
         this.targetRegion = targetRegion;
+        return this;
       }
 
-      public void setParentUrl(String parentUrl) {
+      public EstimateDataRecoveryTimeCommand.Params.Builder setParentUrl(String parentUrl) {
         this.parentUrl = parentUrl;
+        return this;
       }
 
-      public void setSSLFactory(Optional<SSLFactory> sslFactory) {
+      public EstimateDataRecoveryTimeCommand.Params.Builder setSSLFactory(Optional<SSLFactory> sslFactory) {
         this.sslFactory = sslFactory;
+        return this;
       }
 
-      public void setPCtrlCliWithoutCluster(ControllerClient controllerClient) {
+      public EstimateDataRecoveryTimeCommand.Params.Builder setPCtrlCliWithoutCluster(
+          ControllerClient controllerClient) {
         this.pCtrlCliWithoutCluster = controllerClient;
+        return this;
       }
     }
   }

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/datarecovery/EstimateDataRecoveryTimeCommand.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/datarecovery/EstimateDataRecoveryTimeCommand.java
@@ -55,7 +55,7 @@ public class EstimateDataRecoveryTimeCommand extends Command {
   @Override
   public void execute() {
     // get store's push + partition info
-    String storeName = getParams().getStore();
+    String storeName = getParams().store;
     String clusterName = getParams().getPCtrlCliWithoutCluster().discoverCluster(storeName).getCluster();
 
     try (ControllerClient parentCtrlCli =
@@ -84,14 +84,6 @@ public class EstimateDataRecoveryTimeCommand extends Command {
     private String parentUrl;
     private Optional<SSLFactory> sslFactory;
 
-    public Params(Params p) {
-      setStore(p.getStore());
-      setPCtrlCliWithoutCluster(p.getPCtrlCliWithoutCluster());
-      setTargetRegion(p.getTargetRegion());
-      setSSLFactory(p.getSSLFactory());
-      setParentUrl((p.getParentUrl()));
-    }
-
     public Params() {
     }
 
@@ -99,32 +91,66 @@ public class EstimateDataRecoveryTimeCommand extends Command {
       return targetRegion;
     }
 
-    public void setTargetRegion(String targetRegion) {
-      this.targetRegion = targetRegion;
-    }
-
     public ControllerClient getPCtrlCliWithoutCluster() {
       return pCtrlCliWithoutCluster;
-    }
-
-    public void setPCtrlCliWithoutCluster(ControllerClient pCtrlCliWithoutCluster) {
-      this.pCtrlCliWithoutCluster = pCtrlCliWithoutCluster;
     }
 
     public Optional<SSLFactory> getSSLFactory() {
       return sslFactory;
     }
 
-    public void setSSLFactory(Optional<SSLFactory> sslFactory) {
-      this.sslFactory = sslFactory;
-    }
-
     public String getParentUrl() {
       return parentUrl;
     }
 
-    public void setParentUrl(String parentUrl) {
-      this.parentUrl = parentUrl;
+    public static class Builder {
+      private String targetRegion;
+      private ControllerClient pCtrlCliWithoutCluster;
+      private String parentUrl;
+      private Optional<SSLFactory> sslFactory;
+
+      public Builder() {
+      }
+
+      public Builder(
+          String targetRegion,
+          ControllerClient controllerClient,
+          String parentUrl,
+          Optional<SSLFactory> sslFactory) {
+        this.targetRegion = targetRegion;
+        this.pCtrlCliWithoutCluster = controllerClient;
+        this.parentUrl = parentUrl;
+        this.sslFactory = sslFactory;
+      }
+
+      public Builder(EstimateDataRecoveryTimeCommand.Params p) {
+        this(p.targetRegion, p.pCtrlCliWithoutCluster, p.parentUrl, p.sslFactory);
+      }
+
+      public EstimateDataRecoveryTimeCommand.Params build() {
+        EstimateDataRecoveryTimeCommand.Params ret = new EstimateDataRecoveryTimeCommand.Params();
+        ret.targetRegion = targetRegion;
+        ret.pCtrlCliWithoutCluster = pCtrlCliWithoutCluster;
+        ret.parentUrl = parentUrl;
+        ret.sslFactory = sslFactory;
+        return ret;
+      }
+
+      public void setTargetRegion(String targetRegion) {
+        this.targetRegion = targetRegion;
+      }
+
+      public void setParentUrl(String parentUrl) {
+        this.parentUrl = parentUrl;
+      }
+
+      public void setSSLFactory(Optional<SSLFactory> sslFactory) {
+        this.sslFactory = sslFactory;
+      }
+
+      public void setPCtrlCliWithoutCluster(ControllerClient controllerClient) {
+        this.pCtrlCliWithoutCluster = controllerClient;
+      }
     }
   }
 

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/datarecovery/MonitorCommand.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/datarecovery/MonitorCommand.java
@@ -212,11 +212,11 @@ public class MonitorCommand extends Command {
           String parentUrl,
           Optional<SSLFactory> sslFactory,
           LocalDateTime dateTime) {
-        this.targetRegion = targetRegion;
-        this.pCtrlCliWithoutCluster = controllerClient;
-        this.parentUrl = parentUrl;
-        this.sslFactory = sslFactory;
-        this.dateTime = dateTime;
+        this.setTargetRegion(targetRegion)
+            .setPCtrlCliWithoutCluster(controllerClient)
+            .setParentUrl(parentUrl)
+            .setSSLFactory(sslFactory)
+            .setDateTime(dateTime);
       }
 
       public Builder(MonitorCommand.Params p) {
@@ -233,24 +233,29 @@ public class MonitorCommand extends Command {
         return ret;
       }
 
-      public void setTargetRegion(String targetRegion) {
+      public MonitorCommand.Params.Builder setTargetRegion(String targetRegion) {
         this.targetRegion = targetRegion;
+        return this;
       }
 
-      public void setPCtrlCliWithoutCluster(ControllerClient pCtrlCliWithoutCluster) {
+      public MonitorCommand.Params.Builder setPCtrlCliWithoutCluster(ControllerClient pCtrlCliWithoutCluster) {
         this.pCtrlCliWithoutCluster = pCtrlCliWithoutCluster;
+        return this;
       }
 
-      public void setParentUrl(String parentUrl) {
+      public MonitorCommand.Params.Builder setParentUrl(String parentUrl) {
         this.parentUrl = parentUrl;
+        return this;
       }
 
-      public void setSSLFactory(Optional<SSLFactory> sslFactory) {
+      public MonitorCommand.Params.Builder setSSLFactory(Optional<SSLFactory> sslFactory) {
         this.sslFactory = sslFactory;
+        return this;
       }
 
-      public void setDateTime(LocalDateTime dateTime) {
+      public MonitorCommand.Params.Builder setDateTime(LocalDateTime dateTime) {
         this.dateTime = dateTime;
+        return this;
       }
 
     }

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/datarecovery/MonitorCommand.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/datarecovery/MonitorCommand.java
@@ -35,6 +35,10 @@ public class MonitorCommand extends Command {
     this.params = params;
   }
 
+  public MonitorCommand.Params getParams() {
+    return this.params;
+  }
+
   // For unit test only.
   public void setOngoingOfflinePushDetected(boolean val) {
     this.isOngoingOfflinePushDetected = val;
@@ -52,13 +56,14 @@ public class MonitorCommand extends Command {
 
   @Override
   public void execute() {
-    String storeName = params.store;
+    String storeName = getParams().store;
 
     // Find out cluster name.
-    String clusterName = params.pCtrlCliWithoutCluster.discoverCluster(storeName).getCluster();
+    String clusterName = getParams().getPCtrlCliWithoutCluster().discoverCluster(storeName).getCluster();
 
     // Create a new controller client with cluster name specified.
-    try (ControllerClient parentCtrlCli = buildControllerClient(clusterName, params.parentUrl, params.sslFactory)) {
+    try (ControllerClient parentCtrlCli =
+        buildControllerClient(clusterName, getParams().parentUrl, getParams().sslFactory)) {
       StoreResponse storeResponse = parentCtrlCli.getStore(storeName);
       if (storeResponse.isError()) {
         completeCoreWorkWithError(storeResponse.getError());
@@ -69,13 +74,13 @@ public class MonitorCommand extends Command {
 
       if (!isOngoingOfflinePushDetected) {
         LocalDateTime currentVersionStartDateTime = retrieveCurrentVersionDateTime(parentCtrlCli);
-        if (currentVersionStartDateTime.isAfter(params.dateTime)) {
+        if (currentVersionStartDateTime.isAfter(getParams().dateTime)) {
           // If we have a current version for the given store started after the given date time, claim done.
           completeCoreWorkWithMessage(
               String.format(
                   "current ver is newer (%s) than date time (%s)",
                   currentVersionStartDateTime,
-                  params.dateTime));
+                  getParams().dateTime));
           return;
         }
 
@@ -85,17 +90,17 @@ public class MonitorCommand extends Command {
          */
         MultiStoreStatusResponse response = parentCtrlCli.getFutureVersions(clusterName, storeName);
 
-        if (!response.getStoreStatusMap().containsKey(params.targetRegion)) {
-          completeCoreWorkWithError(String.format("No status for region: %s", params.targetRegion));
+        if (!response.getStoreStatusMap().containsKey(getParams().targetRegion)) {
+          completeCoreWorkWithError(String.format("No status for region: %s", getParams().targetRegion));
           return;
         }
 
-        int futureVersion = Integer.parseInt(response.getStoreStatusMap().get(params.targetRegion));
+        int futureVersion = Integer.parseInt(response.getStoreStatusMap().get(getParams().targetRegion));
         if (futureVersion == Store.NON_EXISTING_VERSION) {
           result.setMessage(
               String.format(
                   "No ongoing offline pushes detected after given date time (%s), keep polling",
-                  params.dateTime));
+                  getParams().dateTime));
           return;
         }
 
@@ -107,7 +112,7 @@ public class MonitorCommand extends Command {
 
       // Query job status.
       JobStatusQueryResponse jobStatusQueryResponse =
-          parentCtrlCli.queryDetailedJobStatus(result.kafKaTopic, params.targetRegion);
+          parentCtrlCli.queryDetailedJobStatus(result.kafKaTopic, getParams().targetRegion);
 
       if (jobStatusQueryResponse.isError()
           || jobStatusQueryResponse.getStatus().equalsIgnoreCase(ExecutionStatus.ERROR.toString())) {
@@ -130,8 +135,8 @@ public class MonitorCommand extends Command {
 
   // Retrieve the store's current version info.
   private LocalDateTime retrieveCurrentVersionDateTime(ControllerClient parentCtrlCli) {
-    StoreHealthAuditResponse storeHealth = parentCtrlCli.listStorePushInfo(params.store, false);
-    RegionPushDetails targetRegion = storeHealth.getRegionPushDetails().get(params.targetRegion);
+    StoreHealthAuditResponse storeHealth = parentCtrlCli.listStorePushInfo(getParams().store, false);
+    RegionPushDetails targetRegion = storeHealth.getRegionPushDetails().get(getParams().targetRegion);
     String dateTime = targetRegion.getPushStartTimestamp();
     return LocalDateTime.parse(dateTime, DateTimeFormatter.ISO_LOCAL_DATE_TIME);
   }
@@ -169,27 +174,85 @@ public class MonitorCommand extends Command {
     private ControllerClient pCtrlCliWithoutCluster;
     private String parentUrl;
     private Optional<SSLFactory> sslFactory;
-
     private LocalDateTime dateTime;
 
-    public void setTargetRegion(String fabric) {
-      this.targetRegion = fabric;
+    public String getTargetRegion() {
+      return targetRegion;
     }
 
-    public void setParentUrl(String parentUrl) {
-      this.parentUrl = parentUrl;
+    public ControllerClient getPCtrlCliWithoutCluster() {
+      return pCtrlCliWithoutCluster;
     }
 
-    public void setPCtrlCliWithoutCluster(ControllerClient parentCtrlCli) {
-      this.pCtrlCliWithoutCluster = parentCtrlCli;
+    public String getParentUrl() {
+      return parentUrl;
     }
 
-    public void setSSLFactory(Optional<SSLFactory> sslFactory) {
-      this.sslFactory = sslFactory;
+    public Optional<SSLFactory> getSSLFactory() {
+      return sslFactory;
     }
 
-    public void setDateTime(LocalDateTime dataTime) {
-      this.dateTime = dataTime;
+    public LocalDateTime getDateTime() {
+      return dateTime;
+    }
+
+    public static class Builder {
+      private String targetRegion;
+      private ControllerClient pCtrlCliWithoutCluster;
+      private String parentUrl;
+      private Optional<SSLFactory> sslFactory;
+      private LocalDateTime dateTime;
+
+      public Builder() {
+      }
+
+      public Builder(
+          String targetRegion,
+          ControllerClient controllerClient,
+          String parentUrl,
+          Optional<SSLFactory> sslFactory,
+          LocalDateTime dateTime) {
+        this.targetRegion = targetRegion;
+        this.pCtrlCliWithoutCluster = controllerClient;
+        this.parentUrl = parentUrl;
+        this.sslFactory = sslFactory;
+        this.dateTime = dateTime;
+      }
+
+      public Builder(MonitorCommand.Params p) {
+        this(p.targetRegion, p.pCtrlCliWithoutCluster, p.parentUrl, p.sslFactory, p.dateTime);
+      }
+
+      public MonitorCommand.Params build() {
+        MonitorCommand.Params ret = new MonitorCommand.Params();
+        ret.targetRegion = targetRegion;
+        ret.pCtrlCliWithoutCluster = pCtrlCliWithoutCluster;
+        ret.parentUrl = parentUrl;
+        ret.sslFactory = sslFactory;
+        ret.dateTime = dateTime;
+        return ret;
+      }
+
+      public void setTargetRegion(String targetRegion) {
+        this.targetRegion = targetRegion;
+      }
+
+      public void setPCtrlCliWithoutCluster(ControllerClient pCtrlCliWithoutCluster) {
+        this.pCtrlCliWithoutCluster = pCtrlCliWithoutCluster;
+      }
+
+      public void setParentUrl(String parentUrl) {
+        this.parentUrl = parentUrl;
+      }
+
+      public void setSSLFactory(Optional<SSLFactory> sslFactory) {
+        this.sslFactory = sslFactory;
+      }
+
+      public void setDateTime(LocalDateTime dateTime) {
+        this.dateTime = dateTime;
+      }
+
     }
   }
 

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/datarecovery/StoreRepushCommand.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/datarecovery/StoreRepushCommand.java
@@ -6,7 +6,6 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -49,6 +48,10 @@ public class StoreRepushCommand extends Command {
     this.params = params;
   }
 
+  public StoreRepushCommand.Params getParams() {
+    return this.params;
+  }
+
   @Override
   public StoreRepushCommand.Result getResult() {
     return result;
@@ -61,7 +64,7 @@ public class StoreRepushCommand extends Command {
 
   private List<String> generateRepushCommand() {
     List<String> cmd = new ArrayList<>();
-    cmd.add(this.params.command);
+    cmd.add(this.getParams().command);
     cmd.add(this.params.extraCommandArgs);
     cmd.add(String.format("--store '%s'", this.params.store));
     cmd.add(String.format("--fabric '%s'", this.params.sourceFabric));
@@ -156,20 +159,12 @@ public class StoreRepushCommand extends Command {
     private String url;
     private Optional<SSLFactory> sslFactory;
 
+    public String getCommand() {
+      return this.command;
+    }
+
     public String getUrl() {
       return url;
-    }
-
-    public void setUrl(String url) {
-      this.url = url;
-    }
-
-    public void setSSLFactory(Optional<SSLFactory> sslFactory) {
-      this.sslFactory = sslFactory;
-    }
-
-    public void setPCtrlCliWithoutCluster(ControllerClient cli) {
-      this.pCtrlCliWithoutCluster = cli;
     }
 
     public ControllerClient getPCtrlCliWithoutCluster() {
@@ -184,42 +179,117 @@ public class StoreRepushCommand extends Command {
       return this.destFabric;
     }
 
-    public void setDebug(boolean debug) {
-      this.debug = debug;
-    }
-
-    public void setCommand(String cmd) {
-      this.command = cmd;
-    }
-
-    public void setExtraCommandArgs(String args) {
-      this.extraCommandArgs = args;
-    }
-
-    public void setDestFabric(String fabric) {
-      this.destFabric = fabric;
-    }
-
-    public void setTimestamp(String timestamp) {
-      this.timestamp = LocalDateTime.parse(timestamp, DateTimeFormatter.ISO_LOCAL_DATE_TIME);
-    }
-
     public Optional<SSLFactory> getSSLFactory() {
       return sslFactory;
-    }
-
-    public void setTimestamp(LocalDateTime time) {
-      this.timestamp = time;
     }
 
     public String getSourceFabric() {
       return sourceFabric;
     }
 
-    public void setSourceFabric(String sourceFabric) {
-      this.sourceFabric = sourceFabric;
+    public boolean getDebug() {
+      return this.debug;
     }
 
+    public static class Builder {
+      private String command;
+      private String destFabric;
+      private String sourceFabric;
+      private String extraCommandArgs;
+      private LocalDateTime timestamp;
+      private ControllerClient pCtrlCliWithoutCluster;
+      private String url;
+      private Optional<SSLFactory> sslFactory;
+      private boolean debug = false;
+
+      public Builder() {
+      }
+
+      public Builder(
+          String command,
+          String destFabric,
+          String sourceFabric,
+          String extraCommandArgs,
+          LocalDateTime timestamp,
+          ControllerClient controllerClient,
+          String url,
+          Optional<SSLFactory> sslFactory,
+          boolean debug) {
+        this.command = command;
+        this.destFabric = destFabric;
+        this.sourceFabric = sourceFabric;
+        this.extraCommandArgs = extraCommandArgs;
+        this.timestamp = timestamp;
+        this.pCtrlCliWithoutCluster = controllerClient;
+        this.url = url;
+        this.sslFactory = sslFactory;
+        this.debug = debug;
+      }
+
+      public Builder(StoreRepushCommand.Params p) {
+        this(
+            p.command,
+            p.destFabric,
+            p.sourceFabric,
+            p.extraCommandArgs,
+            p.timestamp,
+            p.pCtrlCliWithoutCluster,
+            p.url,
+            p.sslFactory,
+            p.debug);
+      }
+
+      public StoreRepushCommand.Params build() {
+        StoreRepushCommand.Params ret = new StoreRepushCommand.Params();
+        ret.command = command;
+        ret.destFabric = destFabric;
+        ret.sourceFabric = sourceFabric;
+        ret.extraCommandArgs = extraCommandArgs;
+        ret.timestamp = timestamp;
+        ret.pCtrlCliWithoutCluster = pCtrlCliWithoutCluster;
+        ret.url = url;
+        ret.sslFactory = sslFactory;
+        ret.debug = debug;
+        return ret;
+      }
+
+      public void setCommand(String command) {
+        this.command = command;
+      }
+
+      public void setDestFabric(String destFabric) {
+        this.destFabric = destFabric;
+      }
+
+      public void setSourceFabric(String sourceFabric) {
+        this.sourceFabric = sourceFabric;
+      }
+
+      public void setExtraCommandArgs(String extraCommandArgs) {
+        this.extraCommandArgs = extraCommandArgs;
+      }
+
+      public void setTimestamp(LocalDateTime timestamp) {
+        this.timestamp = timestamp;
+      }
+
+      public void setPCtrlCliWithoutCluster(ControllerClient pCtrlCliWithoutCluster) {
+        this.pCtrlCliWithoutCluster = pCtrlCliWithoutCluster;
+      }
+
+      public void setUrl(String url) {
+        this.url = url;
+      }
+
+      public void setSSLFactory(Optional<SSLFactory> sslFactory) {
+        this.sslFactory = sslFactory;
+      }
+
+      public void setDebug(boolean debug) {
+        this.debug = debug;
+      }
+
+    }
   }
 
   public static class Result extends Command.Result {

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/datarecovery/StoreRepushCommand.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/datarecovery/StoreRepushCommand.java
@@ -215,15 +215,15 @@ public class StoreRepushCommand extends Command {
           String url,
           Optional<SSLFactory> sslFactory,
           boolean debug) {
-        this.command = command;
-        this.destFabric = destFabric;
-        this.sourceFabric = sourceFabric;
-        this.extraCommandArgs = extraCommandArgs;
-        this.timestamp = timestamp;
-        this.pCtrlCliWithoutCluster = controllerClient;
-        this.url = url;
-        this.sslFactory = sslFactory;
-        this.debug = debug;
+        this.setCommand(command)
+            .setDestFabric(destFabric)
+            .setSourceFabric(sourceFabric)
+            .setExtraCommandArgs(extraCommandArgs)
+            .setTimestamp(timestamp)
+            .setPCtrlCliWithoutCluster(controllerClient)
+            .setUrl(url)
+            .setSSLFactory(sslFactory)
+            .setDebug(debug);
       }
 
       public Builder(StoreRepushCommand.Params p) {
@@ -253,42 +253,50 @@ public class StoreRepushCommand extends Command {
         return ret;
       }
 
-      public void setCommand(String command) {
+      public StoreRepushCommand.Params.Builder setCommand(String command) {
         this.command = command;
+        return this;
       }
 
-      public void setDestFabric(String destFabric) {
+      public StoreRepushCommand.Params.Builder setDestFabric(String destFabric) {
         this.destFabric = destFabric;
+        return this;
       }
 
-      public void setSourceFabric(String sourceFabric) {
+      public StoreRepushCommand.Params.Builder setSourceFabric(String sourceFabric) {
         this.sourceFabric = sourceFabric;
+        return this;
       }
 
-      public void setExtraCommandArgs(String extraCommandArgs) {
+      public StoreRepushCommand.Params.Builder setExtraCommandArgs(String extraCommandArgs) {
         this.extraCommandArgs = extraCommandArgs;
+        return this;
       }
 
-      public void setTimestamp(LocalDateTime timestamp) {
+      public StoreRepushCommand.Params.Builder setTimestamp(LocalDateTime timestamp) {
         this.timestamp = timestamp;
+        return this;
       }
 
-      public void setPCtrlCliWithoutCluster(ControllerClient pCtrlCliWithoutCluster) {
+      public StoreRepushCommand.Params.Builder setPCtrlCliWithoutCluster(ControllerClient pCtrlCliWithoutCluster) {
         this.pCtrlCliWithoutCluster = pCtrlCliWithoutCluster;
+        return this;
       }
 
-      public void setUrl(String url) {
+      public StoreRepushCommand.Params.Builder setUrl(String url) {
         this.url = url;
+        return this;
       }
 
-      public void setSSLFactory(Optional<SSLFactory> sslFactory) {
+      public StoreRepushCommand.Params.Builder setSSLFactory(Optional<SSLFactory> sslFactory) {
         this.sslFactory = sslFactory;
+        return this;
       }
 
-      public void setDebug(boolean debug) {
+      public StoreRepushCommand.Params.Builder setDebug(boolean debug) {
         this.debug = debug;
+        return this;
       }
-
     }
   }
 

--- a/clients/venice-admin-tool/src/test/java/com/linkedin/venice/TestDataRecoveryClient.java
+++ b/clients/venice-admin-tool/src/test/java/com/linkedin/venice/TestDataRecoveryClient.java
@@ -107,11 +107,11 @@ public class TestDataRecoveryClient {
     ControllerClient controllerClient = mock(ControllerClient.class);
 
     Set<String> storeNames = new HashSet<>(Arrays.asList("store1", "store2"));
-    EstimateDataRecoveryTimeCommand.Params.Builder builder = new EstimateDataRecoveryTimeCommand.Params.Builder();
-    builder.setTargetRegion("region1");
-    builder.setParentUrl("https://localhost:7036");
-    builder.setPCtrlCliWithoutCluster(controllerClient);
-    builder.setSSLFactory(Optional.empty());
+    EstimateDataRecoveryTimeCommand.Params.Builder builder =
+        new EstimateDataRecoveryTimeCommand.Params.Builder().setTargetRegion("region1")
+            .setParentUrl("https://localhost:7036")
+            .setPCtrlCliWithoutCluster(controllerClient)
+            .setSSLFactory(Optional.empty());
     EstimateDataRecoveryTimeCommand.Params cmdParams = builder.build();
     EstimateDataRecoveryTimeCommand mockCmd = spy(EstimateDataRecoveryTimeCommand.class);
     List<DataRecoveryTask> tasks = buildEstimateDataRecoveryTasks(storeNames, mockCmd, cmdParams);
@@ -151,15 +151,14 @@ public class TestDataRecoveryClient {
 
   private void executeRecovery(boolean isSuccess) {
     ControllerClient controllerClient = mock(ControllerClient.class);
-    StoreRepushCommand.Params.Builder builder = new StoreRepushCommand.Params.Builder();
-    builder.setCommand("cmd");
-    builder.setExtraCommandArgs("args");
-    builder.setPCtrlCliWithoutCluster(controllerClient);
-    builder.setUrl("https://localhost:7036");
-    builder.setTimestamp(LocalDateTime.parse("2999-12-31T00:00:00", DateTimeFormatter.ISO_LOCAL_DATE_TIME));
-    builder.setSSLFactory(Optional.empty());
-    builder.setDestFabric("ei-ltx1");
-    builder.setSourceFabric("ei-ltx1");
+    StoreRepushCommand.Params.Builder builder = new StoreRepushCommand.Params.Builder().setCommand("cmd")
+        .setExtraCommandArgs("args")
+        .setPCtrlCliWithoutCluster(controllerClient)
+        .setUrl("https://localhost:7036")
+        .setTimestamp(LocalDateTime.parse("2999-12-31T00:00:00", DateTimeFormatter.ISO_LOCAL_DATE_TIME))
+        .setSSLFactory(Optional.empty())
+        .setDestFabric("ei-ltx1")
+        .setSourceFabric("ei-ltx1");
 
     StoreRepushCommand.Params cmdParams = builder.build();
 
@@ -323,12 +322,11 @@ public class TestDataRecoveryClient {
     doReturn(monitor).when(dataRecoveryClient).getMonitor();
     doCallRealMethod().when(dataRecoveryClient).monitor(any(), any());
 
-    MonitorCommand.Params.Builder builder = new MonitorCommand.Params.Builder();
-    builder.setTargetRegion(region);
-    builder.setDateTime(now);
-    builder.setPCtrlCliWithoutCluster(mockedCli);
-    builder.setParentUrl("https://localhost:7036");
-    builder.setSSLFactory(Optional.empty());
+    MonitorCommand.Params.Builder builder = new MonitorCommand.Params.Builder().setTargetRegion(region)
+        .setDateTime(now)
+        .setPCtrlCliWithoutCluster(mockedCli)
+        .setParentUrl("https://localhost:7036")
+        .setSSLFactory(Optional.empty());
     MonitorCommand.Params monitorParams = builder.build();
 
     MonitorCommand mockMonitorCmd = spy(MonitorCommand.class);

--- a/clients/venice-admin-tool/src/test/java/com/linkedin/venice/TestDataRecoveryClient.java
+++ b/clients/venice-admin-tool/src/test/java/com/linkedin/venice/TestDataRecoveryClient.java
@@ -28,6 +28,7 @@ import com.linkedin.venice.meta.StoreInfo;
 import com.linkedin.venice.meta.UncompletedPartition;
 import com.linkedin.venice.pushmonitor.ExecutionStatus;
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -62,9 +63,12 @@ public class TestDataRecoveryClient {
   private void verifyEstimationResults() {
     Long expectedRecoveryTime = 7200L;
     Long result = 0L;
+    Set<String> storeNames = new HashSet<>();
     for (DataRecoveryTask t: estimator.getTasks()) {
       result += ((EstimateDataRecoveryTimeCommand.Result) t.getTaskResult().getCmdResult())
           .getEstimatedRecoveryTimeInSeconds();
+      Assert.assertFalse(storeNames.contains(t.getTaskParams().getStore()));
+      storeNames.add(t.getTaskParams().getStore());
     }
     Assert.assertEquals(result, expectedRecoveryTime);
   }
@@ -76,6 +80,13 @@ public class TestDataRecoveryClient {
       // Verify all stores are executed successfully.
       for (int i = 0; i < numOfStores; i++) {
         Assert.assertFalse(executor.getTasks().get(i).getTaskResult().isError());
+      }
+      Set<String> storeNames = new HashSet<>();
+      // Double-check the stores recovered. We do not want to see duplicates in the final report.
+      for (int i = 0; i < numOfStores; i++) {
+        String storeName = executor.getTasks().get(i).getTaskParams().getCmdParams().getStore();
+        Assert.assertFalse(storeNames.contains(storeName));
+        storeNames.add(storeName);
       }
     } else {
       // Verify all stores are executed unsuccessfully.
@@ -96,12 +107,14 @@ public class TestDataRecoveryClient {
     ControllerClient controllerClient = mock(ControllerClient.class);
 
     Set<String> storeNames = new HashSet<>(Arrays.asList("store1", "store2"));
-    EstimateDataRecoveryTimeCommand.Params cmdParams = new EstimateDataRecoveryTimeCommand.Params();
-    cmdParams.setTargetRegion("region1");
-    cmdParams.setParentUrl("https://localhost:7036");
-    cmdParams.setPCtrlCliWithoutCluster(controllerClient);
+    EstimateDataRecoveryTimeCommand.Params.Builder builder = new EstimateDataRecoveryTimeCommand.Params.Builder();
+    builder.setTargetRegion("region1");
+    builder.setParentUrl("https://localhost:7036");
+    builder.setPCtrlCliWithoutCluster(controllerClient);
+    builder.setSSLFactory(Optional.empty());
+    EstimateDataRecoveryTimeCommand.Params cmdParams = builder.build();
     EstimateDataRecoveryTimeCommand mockCmd = spy(EstimateDataRecoveryTimeCommand.class);
-    List<DataRecoveryTask> tasks = buildTasks(storeNames, mockCmd, cmdParams);
+    List<DataRecoveryTask> tasks = buildEstimateDataRecoveryTasks(storeNames, mockCmd, cmdParams);
     doReturn(cmdParams).when(mockCmd).getParams();
     D2ServiceDiscoveryResponse r = new D2ServiceDiscoveryResponse();
     r.setCluster("test");
@@ -131,21 +144,24 @@ public class TestDataRecoveryClient {
 
     doReturn(mockResponse).when(controllerClient).listStorePushInfo(anyString(), anyBoolean());
     doReturn("test").when(controllerClient).getClusterName();
+    doReturn(cmdParams).when(mockCmd).getParams();
 
     dataRecoveryClient.estimateRecoveryTime(new DataRecoveryClient.DataRecoveryParams("store1,store2"), cmdParams);
   }
 
   private void executeRecovery(boolean isSuccess) {
     ControllerClient controllerClient = mock(ControllerClient.class);
-    StoreRepushCommand.Params cmdParams = new StoreRepushCommand.Params();
-    cmdParams.setCommand("cmd");
-    cmdParams.setExtraCommandArgs("args");
-    cmdParams.setPCtrlCliWithoutCluster(controllerClient);
-    cmdParams.setUrl("https://localhost:7036");
-    cmdParams.setTimestamp("2999-12-31T00:00:00");
-    cmdParams.setSSLFactory(Optional.empty());
-    cmdParams.setDestFabric("ei-ltx1");
-    cmdParams.setSourceFabric("ei-ltx1");
+    StoreRepushCommand.Params.Builder builder = new StoreRepushCommand.Params.Builder();
+    builder.setCommand("cmd");
+    builder.setExtraCommandArgs("args");
+    builder.setPCtrlCliWithoutCluster(controllerClient);
+    builder.setUrl("https://localhost:7036");
+    builder.setTimestamp(LocalDateTime.parse("2999-12-31T00:00:00", DateTimeFormatter.ISO_LOCAL_DATE_TIME));
+    builder.setSSLFactory(Optional.empty());
+    builder.setDestFabric("ei-ltx1");
+    builder.setSourceFabric("ei-ltx1");
+
+    StoreRepushCommand.Params cmdParams = builder.build();
 
     D2ServiceDiscoveryResponse r = new D2ServiceDiscoveryResponse();
     r.setCluster("test");
@@ -170,7 +186,7 @@ public class TestDataRecoveryClient {
 
     // Inject the mocked command into the running system.
     Set<String> storeName = new HashSet<>(Arrays.asList("store1", "store2", "store3"));
-    List<DataRecoveryTask> tasks = buildTasks(storeName, mockStoreRepushCmd, cmdParams);
+    List<DataRecoveryTask> tasks = buildExecuteDataRecoveryTasks(storeName, mockStoreRepushCmd, cmdParams);
     doReturn(tasks).when(executor).buildTasks(any(), any());
 
     // Store filtering mocks
@@ -204,7 +220,7 @@ public class TestDataRecoveryClient {
     // testing repush with invalid timestamps
 
     storeStatusMap.put("ei-ltx1", "7");
-    cmdParams.setTimestamp("1999-12-31T00:00:00");
+    builder.setTimestamp(LocalDateTime.parse("1999-12-31T00:00:00", DateTimeFormatter.ISO_LOCAL_DATE_TIME));
     doReturn("2999-12-31T23:59:59.171961").when(regionPushDetailsMock).getPushStartTimestamp();
     Assert.assertEquals(
         storeHealthInfoMock.getRegionPushDetails().get("ei-ltx1").getPushStartTimestamp(),
@@ -213,11 +229,53 @@ public class TestDataRecoveryClient {
     Assert.assertEquals(dataRecoveryClient.getExecutor().getSkippedStores().contains("store3"), true);
   }
 
-  private List<DataRecoveryTask> buildTasks(Set<String> storeNames, Command cmd, Command.Params params) {
+  private List<DataRecoveryTask> buildExecuteDataRecoveryTasks(
+      Set<String> storeNames,
+      Command cmd,
+      StoreRepushCommand.Params params) {
     List<DataRecoveryTask> tasks = new ArrayList<>();
+    StoreRepushCommand.Params.Builder builder = new StoreRepushCommand.Params.Builder(params);
     for (String name: storeNames) {
-      DataRecoveryTask.TaskParams taskParams = new DataRecoveryTask.TaskParams(name, params);
+      StoreRepushCommand.Params p = builder.build();
+      p.setStore(name);
+      DataRecoveryTask.TaskParams taskParams = new DataRecoveryTask.TaskParams(name, p);
       tasks.add(new DataRecoveryTask(cmd, taskParams));
+    }
+    return tasks;
+  }
+
+  private List<DataRecoveryTask> buildEstimateDataRecoveryTasks(
+      Set<String> storeNames,
+      Command cmd,
+      EstimateDataRecoveryTimeCommand.Params params) {
+    List<DataRecoveryTask> tasks = new ArrayList<>();
+    EstimateDataRecoveryTimeCommand.Params.Builder builder = new EstimateDataRecoveryTimeCommand.Params.Builder(params);
+    for (String name: storeNames) {
+      EstimateDataRecoveryTimeCommand.Params p = builder.build();
+      p.setStore(name);
+      DataRecoveryTask.TaskParams taskParams = new DataRecoveryTask.TaskParams(name, p);
+      EstimateDataRecoveryTimeCommand newCmd = spy(EstimateDataRecoveryTimeCommand.class);
+      doReturn(p).when(newCmd).getParams();
+      doReturn(p.getPCtrlCliWithoutCluster()).when(newCmd).buildControllerClient(anyString(), anyString(), any());
+      tasks.add(new DataRecoveryTask(newCmd, taskParams));
+    }
+    return tasks;
+  }
+
+  private List<DataRecoveryTask> buildMonitorDataRecoveryTasks(
+      Set<String> storeNames,
+      Command cmd,
+      MonitorCommand.Params params) {
+    List<DataRecoveryTask> tasks = new ArrayList<>();
+    MonitorCommand.Params.Builder builder = new MonitorCommand.Params.Builder(params);
+    for (String name: storeNames) {
+      MonitorCommand.Params p = builder.build();
+      p.setStore(name);
+      DataRecoveryTask.TaskParams taskParams = new DataRecoveryTask.TaskParams(name, p);
+      MonitorCommand newCmd = spy(MonitorCommand.class);
+      doReturn(p).when(newCmd).getParams();
+      doReturn(p.getPCtrlCliWithoutCluster()).when(newCmd).buildControllerClient(anyString(), anyString(), any());
+      tasks.add(new DataRecoveryTask(newCmd, taskParams));
     }
     return tasks;
   }
@@ -265,19 +323,24 @@ public class TestDataRecoveryClient {
     doReturn(monitor).when(dataRecoveryClient).getMonitor();
     doCallRealMethod().when(dataRecoveryClient).monitor(any(), any());
 
-    MonitorCommand.Params monitorParams = new MonitorCommand.Params();
-    monitorParams.setTargetRegion(region);
-    monitorParams.setDateTime(now);
-    monitorParams.setPCtrlCliWithoutCluster(mockedCli);
+    MonitorCommand.Params.Builder builder = new MonitorCommand.Params.Builder();
+    builder.setTargetRegion(region);
+    builder.setDateTime(now);
+    builder.setPCtrlCliWithoutCluster(mockedCli);
+    builder.setParentUrl("https://localhost:7036");
+    builder.setSSLFactory(Optional.empty());
+    MonitorCommand.Params monitorParams = builder.build();
 
     MonitorCommand mockMonitorCmd = spy(MonitorCommand.class);
     mockMonitorCmd.setParams(monitorParams);
     mockMonitorCmd.setOngoingOfflinePushDetected(false);
-    doReturn(mockedCli).when(mockMonitorCmd).buildControllerClient(any(), any(), any());
+    doReturn(mockedCli).when(mockMonitorCmd).buildControllerClient(anyString(), anyString(), any());
+
+    doReturn(monitorParams).when(mockMonitorCmd).getParams();
 
     // Inject the mocked command into the running system.
     Set<String> storeName = new HashSet<>(Arrays.asList("store1", "store2", "store3"));
-    List<DataRecoveryTask> tasks = buildTasks(storeName, mockMonitorCmd, monitorParams);
+    List<DataRecoveryTask> tasks = buildMonitorDataRecoveryTasks(storeName, mockMonitorCmd, monitorParams);
     doReturn(tasks).when(monitor).buildTasks(any(), any());
 
     // client monitors three store recovery progress.
@@ -362,6 +425,14 @@ public class TestDataRecoveryClient {
         Assert.assertTrue(monitor.getTasks().get(i).getTaskResult().isError());
         Assert.assertNull(monitor.getTasks().get(i).getTaskResult().getMessage());
       }
+    }
+
+    // duplicate check
+
+    Set<String> storeNames = new HashSet<>();
+    for (int i = 0; i < numOfStores; i++) {
+      Assert.assertFalse(storeNames.contains(monitor.getTasks().get(i).getTaskParams().getStore()));
+      storeNames.add(monitor.getTasks().get(i).getTaskParams().getStore());
     }
   }
 }


### PR DESCRIPTION
## Summary
This is a change intended to fix an issue discovered with the logic for instantiating new Params in the Data Recovery module. There were multiple Commands using the same Params pointer incorrectly, resulting in some inconsistencies between the intended target store, and which store may actually wind up being targeted by the command.

## How was this PR tested?
Local build, intent to test on EI store(s) before merge.

## Does this PR introduce any user-facing changes?
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.