### PR TITLE
[common] Support configuring SASL authentication to Kafka

### DIFF
--- a/internal/venice-common/src/main/java/com/linkedin/venice/utils/KafkaSSLUtils.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/utils/KafkaSSLUtils.java
@@ -73,15 +73,17 @@ public class KafkaSSLUtils {
    * @return
    */
   public static boolean isKafkaProtocolValid(String kafkaProtocol) {
-    return kafkaProtocol.equals(SecurityProtocol.PLAINTEXT.name()) || kafkaProtocol.equals(SecurityProtocol.SSL.name());
+    return kafkaProtocol.equals(SecurityProtocol.PLAINTEXT.name()) || kafkaProtocol.equals(SecurityProtocol.SSL.name())
+        || kafkaProtocol.equals(SecurityProtocol.SASL_PLAINTEXT.name())
+        || kafkaProtocol.equals(SecurityProtocol.SASL_SSL.name());
   }
 
   public static boolean isKafkaSSLProtocol(String kafkaProtocol) {
-    return kafkaProtocol.equals(SecurityProtocol.SSL.name());
+    return kafkaProtocol.equals(SecurityProtocol.SSL.name()) || kafkaProtocol.equals(SecurityProtocol.SASL_SSL.name());
   }
 
   public static boolean isKafkaSSLProtocol(SecurityProtocol kafkaProtocol) {
-    return kafkaProtocol == SecurityProtocol.SSL;
+    return kafkaProtocol == SecurityProtocol.SSL || kafkaProtocol == SecurityProtocol.SASL_SSL;
   }
 
   /**

--- a/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/adapter/kafka/admin/ApacheKafkaAdminConfigTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/adapter/kafka/admin/ApacheKafkaAdminConfigTest.java
@@ -1,0 +1,42 @@
+package com.linkedin.venice.pubsub.adapter.kafka.admin;
+
+import static org.testng.Assert.*;
+
+import com.linkedin.venice.utils.VeniceProperties;
+import java.util.Properties;
+import org.apache.kafka.common.protocol.SecurityProtocol;
+import org.testng.annotations.Test;
+
+
+public class ApacheKafkaAdminConfigTest {
+  private static final String SASL_JAAS_CONFIG =
+      "org.apache.kafka.common.security.plain.PlainLoginModule required " + "username=\"foo\" password=\"bar\"\n";
+
+  private static final String SASL_MECHANISM = "PLAIN";
+
+  @Test
+  public void testSetupSaslInKafkaAdminPlaintext() {
+    testSetupSaslInKafkaAdmin(SecurityProtocol.SASL_PLAINTEXT);
+  }
+
+  @Test
+  public void testSetupSaslInKafkaAdminSSL() {
+    testSetupSaslInKafkaAdmin(SecurityProtocol.SASL_SSL);
+  }
+
+  private void testSetupSaslInKafkaAdmin(SecurityProtocol securityProtocol) {
+    Properties properties = new Properties();
+    properties.put("cluster.name", "cluster");
+    properties.put("zookeeper.address", "localhost:2181");
+    properties.put("kafka.bootstrap.servers", "localhost:9092");
+    properties.put("kafka.sasl.jaas.config", SASL_JAAS_CONFIG);
+    properties.put("kafka.sasl.mechanism", SASL_MECHANISM);
+    properties.put("kafka.security.protocol", securityProtocol.name);
+    VeniceProperties veniceProperties = new VeniceProperties(properties);
+    ApacheKafkaAdminConfig serverConfig = new ApacheKafkaAdminConfig(veniceProperties);
+    Properties adminProperties = serverConfig.getAdminProperties();
+    assertEquals(SASL_JAAS_CONFIG, adminProperties.get("sasl.jaas.config"));
+    assertEquals(SASL_MECHANISM, adminProperties.get("sasl.mechanism"));
+    assertEquals(securityProtocol.name, adminProperties.get("security.protocol"));
+  }
+}

--- a/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/adapter/kafka/consumer/ApacheKafkaConsumerConfigTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/adapter/kafka/consumer/ApacheKafkaConsumerConfigTest.java
@@ -1,0 +1,35 @@
+package com.linkedin.venice.pubsub.adapter.kafka.consumer;
+
+import static com.linkedin.venice.pubsub.adapter.kafka.producer.ApacheKafkaProducerConfig.KAFKA_BOOTSTRAP_SERVERS;
+import static com.linkedin.venice.pubsub.adapter.kafka.producer.ApacheKafkaProducerConfig.SSL_KAFKA_BOOTSTRAP_SERVERS;
+import static com.linkedin.venice.pubsub.adapter.kafka.producer.ApacheKafkaProducerConfig.SSL_TO_KAFKA;
+import static org.testng.Assert.assertEquals;
+
+import com.linkedin.venice.pubsub.adapter.kafka.producer.ApacheKafkaProducerConfig;
+import java.util.Properties;
+import org.testng.annotations.Test;
+
+
+public class ApacheKafkaConsumerConfigTest {
+  private static final String KAFKA_BROKER_ADDR = "kafka.broker.com:8181";
+  private static final String SASL_JAAS_CONFIG =
+      "org.apache.kafka.common.security.plain.PlainLoginModule required " + "username=\"foo\" password=\"bar\"\n";
+
+  private static final String SASL_MECHANISM = "PLAIN";
+
+  @Test
+  public void testSaslConfiguration() {
+    Properties props = new Properties();
+    props.put(SSL_TO_KAFKA, true);
+    props.put(KAFKA_BOOTSTRAP_SERVERS, KAFKA_BROKER_ADDR);
+    props.put(SSL_KAFKA_BOOTSTRAP_SERVERS, "ssl.kafka.broker.com:8182");
+    props.put("kafka.sasl.jaas.config", SASL_JAAS_CONFIG);
+    props.put("kafka.sasl.mechanism", SASL_MECHANISM);
+    props.put("kafka.security.protocol", "SASL_SSL");
+    ApacheKafkaProducerConfig apacheKafkaProducerConfig = new ApacheKafkaProducerConfig(props);
+    Properties producerProperties = apacheKafkaProducerConfig.getProducerProperties();
+    assertEquals(SASL_JAAS_CONFIG, producerProperties.get("sasl.jaas.config"));
+    assertEquals(SASL_MECHANISM, producerProperties.get("sasl.mechanism"));
+    assertEquals("SASL_SSL", producerProperties.get("security.protocol"));
+  }
+}

--- a/internal/venice-common/src/test/java/com/linkedin/venice/utils/KafkaSSLUtilsTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/utils/KafkaSSLUtilsTest.java
@@ -1,0 +1,33 @@
+package com.linkedin.venice.utils;
+
+import static org.testng.Assert.*;
+
+import org.apache.kafka.common.protocol.SecurityProtocol;
+import org.testng.annotations.Test;
+
+
+public class KafkaSSLUtilsTest {
+  @Test
+  public void testIsKafkaProtocolValid() {
+    assertTrue(KafkaSSLUtils.isKafkaProtocolValid("SSL"));
+    assertTrue(KafkaSSLUtils.isKafkaProtocolValid("PLAINTEXT"));
+    assertTrue(KafkaSSLUtils.isKafkaProtocolValid("SASL_SSL"));
+    assertTrue(KafkaSSLUtils.isKafkaProtocolValid("SASL_PLAINTEXT"));
+  }
+
+  @Test
+  public void testIsKafkaSSLProtocol() {
+    assertTrue(KafkaSSLUtils.isKafkaSSLProtocol("SSL"));
+    assertFalse(KafkaSSLUtils.isKafkaSSLProtocol("PLAINTEXT"));
+    assertTrue(KafkaSSLUtils.isKafkaSSLProtocol("SASL_SSL"));
+    assertFalse(KafkaSSLUtils.isKafkaSSLProtocol("SASL_PLAINTEXT"));
+  }
+
+  @Test
+  public void testTestIsKafkaSSLProtocol() {
+    assertTrue(KafkaSSLUtils.isKafkaSSLProtocol(SecurityProtocol.SSL));
+    assertFalse(KafkaSSLUtils.isKafkaSSLProtocol(SecurityProtocol.PLAINTEXT));
+    assertTrue(KafkaSSLUtils.isKafkaSSLProtocol(SecurityProtocol.SASL_SSL));
+    assertFalse(KafkaSSLUtils.isKafkaSSLProtocol(SecurityProtocol.SASL_PLAINTEXT));
+  }
+}


### PR DESCRIPTION
## Summary, imperative, start upper case, don't end with a period

Allow to configure kafka.security.protocol=SASL_PLAINTEXT and SASL_SSL.

## How was this PR tested?

Added new tests. Tested manually

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.