### PR TITLE
[server] Isolated ingestion backend will handle ingestion completion report in async way

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/IsolatedIngestionBackend.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/IsolatedIngestionBackend.java
@@ -262,6 +262,10 @@ public class IsolatedIngestionBackend extends DefaultIngestionBackend
     return completionReportHandlingExecutor;
   }
 
+  VeniceConfigLoader getConfigLoader() {
+    return configLoader;
+  }
+
   VeniceNotifier getIsolatedIngestionNotifier(VeniceNotifier notifier) {
     return new RelayNotifier(notifier) {
       @Override
@@ -271,12 +275,12 @@ public class IsolatedIngestionBackend extends DefaultIngestionBackend
           long offset,
           String message,
           Optional<LeaderFollowerStateType> leaderState) {
+        VeniceStoreVersionConfig config = getConfigLoader().getStoreConfig(kafkaTopic);
+        config.setRestoreDataPartitions(false);
+        config.setRestoreMetadataPartition(false);
         // Use thread pool to handle the completion reporting to make sure it is not blocking the report.
         if (isTopicPartitionIngesting(kafkaTopic, partition)) {
           getCompletionHandlingExecutor().submit(() -> {
-            VeniceStoreVersionConfig config = configLoader.getStoreConfig(kafkaTopic);
-            config.setRestoreDataPartitions(false);
-            config.setRestoreMetadataPartition(false);
             // Start partition consumption locally.
             startConsumption(config, partition, leaderState);
           });

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/IsolatedIngestionBackend.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/IsolatedIngestionBackend.java
@@ -31,7 +31,6 @@ import io.tehuti.metrics.MetricsRepository;
 import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -233,10 +232,7 @@ public class IsolatedIngestionBackend extends DefaultIngestionBackend
 
   public void close() {
     try {
-      completionReportHandlingExecutor.shutdown();
-      if (!completionReportHandlingExecutor.awaitTermination(5, TimeUnit.SECONDS)) {
-        completionReportHandlingExecutor.shutdownNow();
-      }
+      completionReportHandlingExecutor.shutdownNow();
       mainIngestionMonitorService.stopInner();
       mainIngestionRequestClient.shutdownForkedProcessComponent(IngestionComponentType.KAFKA_INGESTION_SERVICE);
       mainIngestionRequestClient.shutdownForkedProcessComponent(IngestionComponentType.STORAGE_SERVICE);

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/IsolatedIngestionBackend.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/IsolatedIngestionBackend.java
@@ -271,12 +271,12 @@ public class IsolatedIngestionBackend extends DefaultIngestionBackend
           long offset,
           String message,
           Optional<LeaderFollowerStateType> leaderState) {
-        VeniceStoreVersionConfig config = getConfigLoader().getStoreConfig(kafkaTopic);
-        config.setRestoreDataPartitions(false);
-        config.setRestoreMetadataPartition(false);
         // Use thread pool to handle the completion reporting to make sure it is not blocking the report.
         if (isTopicPartitionIngesting(kafkaTopic, partition)) {
           getCompletionHandlingExecutor().submit(() -> {
+            VeniceStoreVersionConfig config = getConfigLoader().getStoreConfig(kafkaTopic);
+            config.setRestoreDataPartitions(false);
+            config.setRestoreMetadataPartition(false);
             // Start partition consumption locally.
             startConsumption(config, partition, leaderState);
           });

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/ingestion/IsolatedIngestionBackendTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/ingestion/IsolatedIngestionBackendTest.java
@@ -14,6 +14,8 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.linkedin.davinci.config.VeniceConfigLoader;
+import com.linkedin.davinci.config.VeniceStoreVersionConfig;
 import com.linkedin.davinci.ingestion.main.MainIngestionMonitorService;
 import com.linkedin.davinci.ingestion.main.MainTopicIngestionStatus;
 import com.linkedin.davinci.kafka.consumer.KafkaStoreIngestionService;
@@ -183,10 +185,14 @@ public class IsolatedIngestionBackendTest {
   public void testIsolatedIngestionNotifierAsyncCompletionHandling() {
     IsolatedIngestionBackend backend = mock(IsolatedIngestionBackend.class);
     VeniceNotifier ingestionNotifier = mock(VeniceNotifier.class);
+    VeniceConfigLoader configLoader = mock(VeniceConfigLoader.class);
+    VeniceStoreVersionConfig storeVersionConfig = mock(VeniceStoreVersionConfig.class);
     ExecutorService executor = Executors.newFixedThreadPool(10);
     when(backend.getCompletionHandlingExecutor()).thenReturn(executor);
     when(backend.getIsolatedIngestionNotifier(any())).thenCallRealMethod();
+    when(backend.getConfigLoader()).thenReturn(configLoader);
     String topic = "topic_v1";
+    when(configLoader.getStoreConfig(topic)).thenReturn(storeVersionConfig);
     when(backend.isTopicPartitionIngesting(topic, 0)).thenReturn(false);
     when(backend.isTopicPartitionIngesting(topic, 1)).thenReturn(true);
     backend.getIsolatedIngestionNotifier(ingestionNotifier).completed(topic, 0, 123L, "", Optional.empty());

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/ingestion/IsolatedIngestionBackendTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/ingestion/IsolatedIngestionBackendTest.java
@@ -186,7 +186,12 @@ public class IsolatedIngestionBackendTest {
     ExecutorService executor = Executors.newFixedThreadPool(10);
     when(backend.getCompletionHandlingExecutor()).thenReturn(executor);
     when(backend.getIsolatedIngestionNotifier(any())).thenCallRealMethod();
-    backend.getIsolatedIngestionNotifier(ingestionNotifier).completed("topic_v1", 1, 123L, "", Optional.empty());
+    String topic = "topic_v1";
+    when(backend.isTopicPartitionIngesting(topic, 0)).thenReturn(false);
+    when(backend.isTopicPartitionIngesting(topic, 1)).thenReturn(true);
+    backend.getIsolatedIngestionNotifier(ingestionNotifier).completed(topic, 0, 123L, "", Optional.empty());
+    verify(backend, times(0)).getCompletionHandlingExecutor();
+    backend.getIsolatedIngestionNotifier(ingestionNotifier).completed(topic, 1, 123L, "", Optional.empty());
     verify(backend, times(1)).getCompletionHandlingExecutor();
   }
 }


### PR DESCRIPTION
## [server] Isolated ingestion backend will handle ingestion completion report in async way
This PR fixes an issue discovered in production deployment:
When a push is happening while bootstrapping an ingestion isolation enabled host at the same time, it is possible that old backup version is removed from the disk while the host already submitted the version partition ingestion request into child process. When the child process completes it will report COMPLETED back to main process and try to restart consumption on main process. Since the store version is gone in the store repo, the start consumption will wait 30s and throw. Also, the report client has 10 times retry and the report queue in isolated ingestion server is single threaded (to guarantee report order), each this kind of replica will take 300s and in that case it will end up taking too many time in bootstrap and might timeout the pre-stop hook in deployment.

This PR fixes the issue by adding an executor to allow async restart consumption happens on the main process and allow report communication to continue to complete fast.
## How was this PR tested?
Added a new unit test to make sure async execution is triggered.
## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.