### PR TITLE
[fast-client] Blocking Retry FC Metadata Init

### DIFF
--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/DispatchingAvroGenericStoreClient.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/DispatchingAvroGenericStoreClient.java
@@ -127,6 +127,7 @@ public class DispatchingAvroGenericStoreClient<K, V> extends InternalAvroStoreCl
 
   @Override
   protected CompletableFuture<V> get(GetRequestContext requestContext, K key) throws VeniceClientException {
+    checkPrerequisites();
     requestContext.instanceHealthMonitor = metadata.getInstanceHealthMonitor();
     if (requestContext.requestUri == null) {
       /**
@@ -283,6 +284,7 @@ public class DispatchingAvroGenericStoreClient<K, V> extends InternalAvroStoreCl
   @Override
   protected CompletableFuture<Map<K, V>> batchGet(BatchGetRequestContext<K, V> requestContext, Set<K> keys)
       throws VeniceClientException {
+    checkPrerequisites();
     CompletableFuture<Map<K, V>> responseFuture = new CompletableFuture<>();
     CompletableFuture<VeniceResponseMap<K, V>> streamingResponseFuture = streamingBatchGet(requestContext, keys);
     streamingResponseFuture.whenComplete((response, throwable) -> {
@@ -308,6 +310,7 @@ public class DispatchingAvroGenericStoreClient<K, V> extends InternalAvroStoreCl
   protected CompletableFuture<VeniceResponseMap<K, V>> streamingBatchGet(
       BatchGetRequestContext<K, V> requestContext,
       Set<K> keys) throws VeniceClientException {
+    checkPrerequisites();
     // keys that do not exist in the storage nodes
     Queue<K> nonExistingKeys = new ConcurrentLinkedQueue<>();
     VeniceConcurrentHashMap<K, V> valueMap = new VeniceConcurrentHashMap<>();
@@ -353,7 +356,7 @@ public class DispatchingAvroGenericStoreClient<K, V> extends InternalAvroStoreCl
       BatchGetRequestContext<K, V> requestContext,
       Set<K> keys,
       StreamingCallback<K, V> callback) {
-
+    checkPrerequisites();
     /* This implementation is intentionally designed to separate the request phase (scatter) and the response handling
      * phase (gather). These internal methods help to keep this separation and leaves room for future fine-grained control. */
     streamingBatchGetInternal(requestContext, keys, (transportClientResponse, throwable) -> {
@@ -595,11 +598,19 @@ public class DispatchingAvroGenericStoreClient<K, V> extends InternalAvroStoreCl
     return System.nanoTime() - startTimeStamp;
   }
 
+  private void checkPrerequisites() throws VeniceClientException {
+    if (!metadata.isReady()) {
+      throw new VeniceClientException("Store metadata is not ready");
+    }
+    if (keySerializer == null) {
+      keySerializer = getKeySerializer(getKeySchema());
+    }
+  }
+
   @Override
   public void start() throws VeniceClientException {
     metadata.start();
-    // Initialize key serializer after metadata.start().
-    this.keySerializer = getKeySerializer(getKeySchema());
+
     this.multiGetSerializer =
         FastSerializerDeserializerFactory.getAvroGenericSerializer(MultiGetRouterRequestKeyV1.SCHEMA$);
   }

--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/meta/RequestBasedMetadata.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/meta/RequestBasedMetadata.java
@@ -71,7 +71,7 @@ public class RequestBasedMetadata extends AbstractStoreMetadata {
   private final ClusterStats clusterStats;
   private final FastClientStats clientStats;
   private volatile boolean isServiceDiscovered;
-  private boolean isReady = false;
+  private volatile boolean isReady;
 
   public RequestBasedMetadata(ClientConfig clientConfig, D2TransportClient transportClient) {
     super(clientConfig);

--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/meta/StoreMetadata.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/meta/StoreMetadata.java
@@ -52,4 +52,8 @@ public interface StoreMetadata extends SchemaReader {
   VeniceCompressor getCompressor(CompressionStrategy compressionStrategy, int version);
 
   void start();
+
+  default boolean isReady() {
+    return true;
+  }
 }


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci], [server], [controller],
[router], [samza], [vpj], [fast-client], [thin-client], [alpini],
[admin-tool], [test], [build], [doc], [script]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Summary, imperative, start upper case, don't end with a period
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

The FC currently throws a NPE if it tries to handle requests when it can't reach the servers and initialize its metadata. It does retry the metadata fetch but the issue is it doesn't block FC.

This PR adds logic to block FC requests if the metadata hasn't been initialized. This should also handle the case for when Dual Read is enabled so the FC will be blocked but the TC can still handle requests while the FC is retrying metadata initialization.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.