### PR TITLE
[server][controller][da-vinci][vpj][samza] StartOfSegment/EndOfSegment will be produced asynchronously, MetaStoreWriter writes in server will have timeout

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
@@ -61,6 +61,7 @@ import static com.linkedin.venice.ConfigKeys.SERVER_LEAKED_RESOURCE_CLEANUP_ENAB
 import static com.linkedin.venice.ConfigKeys.SERVER_LEAKED_RESOURCE_CLEAN_UP_INTERVAL_IN_MINUTES;
 import static com.linkedin.venice.ConfigKeys.SERVER_LOCAL_CONSUMER_CONFIG_PREFIX;
 import static com.linkedin.venice.ConfigKeys.SERVER_MAX_REQUEST_SIZE;
+import static com.linkedin.venice.ConfigKeys.SERVER_META_SYSTEM_STORE_WRITE_TIMEOUT_IN_MS;
 import static com.linkedin.venice.ConfigKeys.SERVER_NETTY_GRACEFUL_SHUTDOWN_PERIOD_SECONDS;
 import static com.linkedin.venice.ConfigKeys.SERVER_NETTY_IDLE_TIME_SECONDS;
 import static com.linkedin.venice.ConfigKeys.SERVER_NETTY_WORKER_THREADS;
@@ -389,6 +390,8 @@ public class VeniceServerConfig extends VeniceClusterConfig {
    */
   private final int sslHandshakeQueueCapacity;
 
+  private final long metaSystemStoreWriteTimeoutInMs;
+
   public VeniceServerConfig(VeniceProperties serverProperties) throws ConfigurationException {
     this(serverProperties, Collections.emptyMap());
   }
@@ -492,6 +495,7 @@ public class VeniceServerConfig extends VeniceClusterConfig {
     ssdHealthCheckShutdownTimeMs = serverProperties.getLong(SERVER_SHUTDOWN_DISK_UNHEALTHY_TIME_MS, 200000);
     sslHandshakeThreadPoolSize = serverProperties.getInt(SERVER_SSL_HANDSHAKE_THREAD_POOL_SIZE, 0);
     sslHandshakeQueueCapacity = serverProperties.getInt(SERVER_SSL_HANDSHAKE_QUEUE_CAPACITY, Integer.MAX_VALUE);
+    metaSystemStoreWriteTimeoutInMs = serverProperties.getInt(SERVER_META_SYSTEM_STORE_WRITE_TIMEOUT_IN_MS, 180000);
 
     /**
      * In the test of feature store user case, when we did a rolling bounce of storage nodes, the high latency happened
@@ -1030,5 +1034,9 @@ public class VeniceServerConfig extends VeniceClusterConfig {
 
   public int getSslHandshakeQueueCapacity() {
     return sslHandshakeQueueCapacity;
+  }
+
+  public long getMetaSystemStoreWriteTimeoutInMs() {
+    return metaSystemStoreWriteTimeoutInMs;
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/notifier/MetaSystemStoreReplicaStatusNotifier.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/notifier/MetaSystemStoreReplicaStatusNotifier.java
@@ -2,13 +2,13 @@ package com.linkedin.davinci.notifier;
 
 import com.linkedin.davinci.stats.AggHostLevelIngestionStats;
 import com.linkedin.venice.common.VeniceSystemStoreType;
+import com.linkedin.venice.kafka.VeniceOperationAgainstKafkaTimedOut;
 import com.linkedin.venice.meta.Instance;
 import com.linkedin.venice.meta.ReadOnlyStoreRepository;
 import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.pushmonitor.ExecutionStatus;
 import com.linkedin.venice.system.store.MetaStoreWriter;
-import org.apache.kafka.common.errors.TimeoutException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -70,12 +70,13 @@ public class MetaSystemStoreReplicaStatusNotifier implements VeniceNotifier {
     } else {
       try {
         metaStoreWriter.writeStoreReplicaStatus(clusterName, storeName, version, partitionId, instance, status);
-      } catch (TimeoutException e) {
+      } catch (VeniceOperationAgainstKafkaTimedOut e) {
         LOGGER.error(
             "Timeout while trying to report replica status: {} for topic: {}, partition: {}",
             status,
             kafkaTopic,
-            partitionId);
+            partitionId,
+            e);
         this.aggHostLevelIngestionStats.getTotalStats().recordMetaSystemStoreWriteTimeout();
         throw e;
       }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/HostLevelIngestionStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/HostLevelIngestionStats.java
@@ -130,6 +130,8 @@ public class HostLevelIngestionStats extends AbstractVeniceStats {
    */
   private final LongAdderRateGauge totalTombstoneCreationDCRRate;
 
+  private final LongAdderRateGauge totalMetaSystemStoreWriteTimeoutRate;
+
   private Sensor registerPerStoreAndTotalSensor(
       String sensorName,
       HostLevelIngestionStats totalStats,
@@ -213,6 +215,11 @@ public class HostLevelIngestionStats extends AbstractVeniceStats {
         "offset_regression_dcr_error",
         totalStats,
         () -> totalStats.totalOffsetRegressionDCRErrorRate);
+
+    this.totalMetaSystemStoreWriteTimeoutRate = registerOnlyTotalRate(
+        "meta_system_store_write_timeout",
+        totalStats,
+        () -> totalStats.totalMetaSystemStoreWriteTimeoutRate);
 
     Int2ObjectMap<String> kafkaClusterIdToAliasMap = serverConfig.getKafkaClusterIdToAliasMap();
     int listSize = kafkaClusterIdToAliasMap.isEmpty() ? 0 : Collections.max(kafkaClusterIdToAliasMap.keySet()) + 1;
@@ -529,5 +536,9 @@ public class HostLevelIngestionStats extends AbstractVeniceStats {
 
   public void recordOffsetRegressionDCRError() {
     totalOffsetRegressionDCRErrorRate.record();
+  }
+
+  public void recordMetaSystemStoreWriteTimeout() {
+    totalMetaSystemStoreWriteTimeoutRate.record();
   }
 }

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/TestVeniceReducer.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/TestVeniceReducer.java
@@ -492,6 +492,11 @@ public class TestVeniceReducer extends AbstractTestVeniceMR {
       }
 
       @Override
+      public void flush(long timeoutInMs) {
+        // no-op
+      }
+
+      @Override
       public void close() {
         // no-op
       }
@@ -561,6 +566,11 @@ public class TestVeniceReducer extends AbstractTestVeniceMR {
 
       @Override
       public void flush() {
+        // no-op
+      }
+
+      @Override
+      public void flush(long timeoutInMs) {
         // no-op
       }
 

--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -1868,4 +1868,13 @@ public class ConfigKeys {
    * Config to control the queue capacity for the thread pool executor used for ssl handshake in servers.
    */
   public static final String SERVER_SSL_HANDSHAKE_QUEUE_CAPACITY = "server.ssl.handshake.queue.capacity";
+
+  /**
+   * Server would update replica status to meta system store. This config set timeout on all these replica status updates,
+   * which will make update to meta system store a best effort operation; as a result, ingestion and deployment will not
+   * be blocked, but fast-client could be at risk. We should monitor the timeout metrics of replica status updates until
+   * meta system store is no longer in the critical path of fast-client reads.
+   */
+  public static final String SERVER_META_SYSTEM_STORE_WRITE_TIMEOUT_IN_MS =
+      "server.meta.system.store.write.timeout.in.ms";
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/adapter/PubSubSharedProducerAdapter.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/adapter/PubSubSharedProducerAdapter.java
@@ -88,6 +88,11 @@ public class PubSubSharedProducerAdapter implements PubSubProducerAdapter {
   }
 
   @Override
+  public void flush(long timeoutInMs) {
+    producerAdapter.flush(timeoutInMs);
+  }
+
+  @Override
   public void close(int closeTimeOutMs, boolean doFlush) {
     producerAdapter.close(closeTimeOutMs, doFlush);
   }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/adapter/kafka/producer/ApacheKafkaProducerAdapter.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/adapter/kafka/producer/ApacheKafkaProducerAdapter.java
@@ -108,6 +108,13 @@ public class ApacheKafkaProducerAdapter implements PubSubProducerAdapter {
   }
 
   @Override
+  public void flush(long timeoutInMs) {
+    if (producer != null) {
+      producer.flush(timeoutInMs, TimeUnit.MILLISECONDS);
+    }
+  }
+
+  @Override
   public void close(int closeTimeOutMs, boolean doFlush) {
     if (producer == null) {
       return; // producer has been closed already

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/PubSubProducerAdapter.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/PubSubProducerAdapter.java
@@ -46,6 +46,8 @@ public interface PubSubProducerAdapter {
 
   void flush();
 
+  void flush(long timeoutInMs);
+
   void close(int closeTimeOutMs, boolean doFlush);
 
   default void close(String topic, int closeTimeOutMs, boolean doFlush) {

--- a/internal/venice-common/src/main/java/com/linkedin/venice/writer/AbstractVeniceWriter.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/writer/AbstractVeniceWriter.java
@@ -53,4 +53,6 @@ public abstract class AbstractVeniceWriter<K, V, U> implements Closeable {
       PubSubProducerCallback callback);
 
   public abstract void flush();
+
+  public abstract void flush(long timeoutInMs);
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/writer/VeniceWriter.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/writer/VeniceWriter.java
@@ -389,6 +389,16 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
   }
 
   @Override
+  public void flush(long timeoutInMs) {
+    if (timeoutInMs < 0) {
+      // infinite timeout
+      producerAdapter.flush();
+    } else {
+      producerAdapter.flush(timeoutInMs);
+    }
+  }
+
+  @Override
   public String toString() {
     return this.getClass().getSimpleName() + "{topicName: " + topicName + ", producerGUID: " + producerGUID
         + ", numberOfPartitions: " + numberOfPartitions + "}";
@@ -1281,7 +1291,7 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
     startOfSegment.checksumType = checkSumType.getValue();
     startOfSegment.upcomingAggregates = new ArrayList<>(); // TODO Add extra aggregates
     controlMessage.controlMessageUnion = startOfSegment;
-    sendControlMessage(controlMessage, partition, debugInfo, null, DEFAULT_LEADER_METADATA_WRAPPER);
+    asyncSendControlMessage(controlMessage, partition, debugInfo, null, DEFAULT_LEADER_METADATA_WRAPPER);
   }
 
   /**
@@ -1300,7 +1310,7 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
     endOfSegment.computedAggregates = new ArrayList<>(); // TODO Add extra aggregates
     endOfSegment.finalSegment = finalSegment;
     controlMessage.controlMessageUnion = endOfSegment;
-    sendControlMessage(controlMessage, partition, debugInfo, null, DEFAULT_LEADER_METADATA_WRAPPER);
+    asyncSendControlMessage(controlMessage, partition, debugInfo, null, DEFAULT_LEADER_METADATA_WRAPPER);
   }
 
   /**

--- a/internal/venice-test-common/src/main/java/com/linkedin/venice/unit/kafka/producer/MockInMemoryProducerAdapter.java
+++ b/internal/venice-test-common/src/main/java/com/linkedin/venice/unit/kafka/producer/MockInMemoryProducerAdapter.java
@@ -79,6 +79,11 @@ public class MockInMemoryProducerAdapter implements PubSubProducerAdapter {
   }
 
   @Override
+  public void flush(long timeoutInMs) {
+    // no-op
+  }
+
+  @Override
   public void close(int closeTimeOutMs, boolean flush) {
     // no-op
   }

--- a/internal/venice-test-common/src/main/java/com/linkedin/venice/unit/kafka/producer/TransformingProducerAdapter.java
+++ b/internal/venice-test-common/src/main/java/com/linkedin/venice/unit/kafka/producer/TransformingProducerAdapter.java
@@ -50,6 +50,11 @@ public class TransformingProducerAdapter implements PubSubProducerAdapter {
   }
 
   @Override
+  public void flush(long timeoutInMs) {
+    baseProducer.flush(timeoutInMs);
+  }
+
+  @Override
   public void close(int closeTimeOutMs, boolean flush) {
     baseProducer.close(closeTimeOutMs, flush);
   }


### PR DESCRIPTION
## Summary
This PR adds timeout for writes from MetaStoreWriter in server; default timeout is 3 minutes, which is configurable through new config:
server.meta.system.store.write.timeout.in.ms

As a result, writes to meta system store will be a best effort operation; ingestion and deployment will not be blocked due to failing to update meta system store, but fast-client could be at risk. We should monitor the timeout metrics of replica status updates until meta system store is no longer in the critical path of fast-client reads.

Besides, producing StartOfSegment/EndOfSegment will no longer be blocking; different from critical control messages like StartOfPush, TopicSwitch, there is no point blocking on SOS/EOS. SOS/EOS doesn't serve as a critical signal like SOP and TS, which indicates the version topic is ready to take writes from VPJ or Samza jobs.

Added metric to report timeout when writing to meta system stores: meta_system_store_write_timeout

## How was this PR tested?
WIP

## Does this PR introduce any user-facing changes?
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.