### PR TITLE
[test] Added integration test for server read quota

### DIFF
--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/fastclient/FastClientServerReadQuotaTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/fastclient/FastClientServerReadQuotaTest.java
@@ -1,0 +1,71 @@
+package com.linkedin.venice.fastclient;
+
+import static org.testng.AssertJUnit.assertEquals;
+
+import com.linkedin.venice.client.store.AvroGenericStoreClient;
+import com.linkedin.venice.controllerapi.UpdateStoreQueryParams;
+import com.linkedin.venice.fastclient.utils.AbstractClientEndToEndSetup;
+import com.linkedin.venice.utils.TestUtils;
+import io.tehuti.metrics.MetricsRepository;
+import java.util.concurrent.TimeUnit;
+import org.apache.avro.generic.GenericRecord;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class FastClientServerReadQuotaTest extends AbstractClientEndToEndSetup {
+  @Test
+  public void testServerReadQuota() throws Exception {
+    ClientConfig.ClientConfigBuilder clientConfigBuilder =
+        new ClientConfig.ClientConfigBuilder<>().setStoreName(storeName)
+            .setR2Client(r2Client)
+            .setSpeculativeQueryEnabled(false);
+    AvroGenericStoreClient<String, GenericRecord> genericFastClient =
+        getGenericFastClient(clientConfigBuilder, new MetricsRepository(), true);
+    // Update the read quota to 1000 and make 500 requests, all requests should be allowed.
+    veniceCluster.useControllerClient(controllerClient -> {
+      TestUtils
+          .assertCommand(controllerClient.updateStore(storeName, new UpdateStoreQueryParams().setReadQuotaInCU(1000)));
+    });
+    for (int j = 0; j < 5; j++) {
+      for (int i = 0; i < recordCnt; i++) {
+        String key = keyPrefix + i;
+        GenericRecord value = genericFastClient.get(key).get();
+        assertEquals((int) value.get(VALUE_FIELD_NAME), i);
+      }
+    }
+    MetricsRepository serverMetric = veniceCluster.getVeniceServers().get(0).getMetricsRepository();
+    String readQuotaRequestedString = "." + storeName + "--quota_rcu_requested.Count";
+    String readQuotaRejectedString = "." + storeName + "--quota_rcu_rejected.Count";
+    String readQuotaUsageRatio = "." + storeName + "--read_quota_usage_ratio.Gauge";
+    TestUtils.waitForNonDeterministicAssertion(10, TimeUnit.SECONDS, () -> {
+      Assert.assertNotNull(serverMetric.getMetric(readQuotaRequestedString));
+      Assert.assertNotNull(serverMetric.getMetric(readQuotaRejectedString));
+      Assert.assertNotNull(serverMetric.getMetric(readQuotaUsageRatio));
+    });
+    Assert.assertTrue(serverMetric.getMetric(readQuotaRequestedString).value() > 0);
+    Assert.assertEquals(serverMetric.getMetric(readQuotaRejectedString).value(), 0d);
+    Assert.assertTrue(serverMetric.getMetric(readQuotaUsageRatio).value() > 0);
+
+    // Update the read quota to 100 and make 500 requests again.
+    veniceCluster.useControllerClient(controllerClient -> {
+      TestUtils
+          .assertCommand(controllerClient.updateStore(storeName, new UpdateStoreQueryParams().setReadQuotaInCU(100)));
+    });
+    try {
+      // Keep making requests until it gets rejected by read quota, it may take some time for the quota update to be
+      // propagated to servers.
+      for (int j = 0; j < Integer.MAX_VALUE; j++) {
+        for (int i = 0; i < recordCnt; i++) {
+          String key = keyPrefix + i;
+          GenericRecord value = genericFastClient.get(key).get();
+          assertEquals((int) value.get(VALUE_FIELD_NAME), i);
+        }
+      }
+      Assert.fail("Exception should be thrown due to read quota violation");
+    } catch (Exception clientException) {
+      Assert.assertTrue(clientException.getMessage().contains("VeniceClientRateExceededException"));
+    }
+    Assert.assertTrue(serverMetric.getMetric(readQuotaRejectedString).value() > 0);
+  }
+}

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/fastclient/FastClientServerReadQuotaTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/fastclient/FastClientServerReadQuotaTest.java
@@ -43,7 +43,7 @@ public class FastClientServerReadQuotaTest extends AbstractClientEndToEndSetup {
       Assert.assertNotNull(serverMetric.getMetric(readQuotaRejectedString));
       Assert.assertNotNull(serverMetric.getMetric(readQuotaUsageRatio));
     });
-    Assert.assertTrue(serverMetric.getMetric(readQuotaRequestedString).value() > 0);
+    Assert.assertTrue(serverMetric.getMetric(readQuotaRequestedString).value() >= 500);
     Assert.assertEquals(serverMetric.getMetric(readQuotaRejectedString).value(), 0d);
     Assert.assertTrue(serverMetric.getMetric(readQuotaUsageRatio).value() > 0);
 

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/fastclient/utils/AbstractClientEndToEndSetup.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/fastclient/utils/AbstractClientEndToEndSetup.java
@@ -1,6 +1,7 @@
 package com.linkedin.venice.fastclient.utils;
 
 import static com.linkedin.venice.ConfigKeys.SERVER_HTTP2_INBOUND_ENABLED;
+import static com.linkedin.venice.ConfigKeys.SERVER_QUOTA_ENFORCEMENT_ENABLED;
 import static com.linkedin.venice.system.store.MetaStoreWriter.KEY_STRING_CLUSTER_NAME;
 import static com.linkedin.venice.system.store.MetaStoreWriter.KEY_STRING_PARTITION_ID;
 import static com.linkedin.venice.system.store.MetaStoreWriter.KEY_STRING_STORE_NAME;
@@ -22,6 +23,7 @@ import com.linkedin.venice.fastclient.schema.TestValueSchema;
 import com.linkedin.venice.helix.HelixReadOnlySchemaRepository;
 import com.linkedin.venice.integration.utils.D2TestUtils;
 import com.linkedin.venice.integration.utils.ServiceFactory;
+import com.linkedin.venice.integration.utils.VeniceClusterCreateOptions;
 import com.linkedin.venice.integration.utils.VeniceClusterWrapper;
 import com.linkedin.venice.integration.utils.VeniceRouterWrapper;
 import com.linkedin.venice.meta.Version;
@@ -92,7 +94,7 @@ public abstract class AbstractClientEndToEndSetup {
    * is faster than the counter decrement following a successful get, so some get() calls will
    * not be sent due to blocked instances. Setting this variable to be 100 from the tests for now.
    * This needs to be discussed further.
-    */
+   */
   public final Object[] BATCH_GET_KEY_SIZE = { 2, /*recordCnt*/ };
 
   @DataProvider(name = "FastClient-Four-Boolean-And-A-Number")
@@ -110,7 +112,17 @@ public abstract class AbstractClientEndToEndSetup {
     Utils.thisIsLocalhost();
     Properties props = new Properties();
     props.put(SERVER_HTTP2_INBOUND_ENABLED, "true");
-    veniceCluster = ServiceFactory.getVeniceCluster(1, 2, 1, 2, 100, true, false, props);
+    props.put(SERVER_QUOTA_ENFORCEMENT_ENABLED, "true");
+    VeniceClusterCreateOptions createOptions = new VeniceClusterCreateOptions.Builder().numberOfControllers(1)
+        .numberOfServers(2)
+        .numberOfRouters(1)
+        .replicationFactor(2)
+        .partitionSize(100)
+        .sslToStorageNodes(true)
+        .sslToKafka(false)
+        .extraProperties(props)
+        .build();
+    veniceCluster = ServiceFactory.getVeniceCluster(createOptions);
 
     r2Client = ClientTestUtils.getR2Client(ClientTestUtils.FastClientHTTPVariant.HTTP_2_BASED_HTTPCLIENT5);
 


### PR DESCRIPTION
## [test] Added integration test for server read quota
1. Venice storage node quota is enabled by default for test classes using the AbstractClientEndToEndSetup.

2. Added a new integration test verifying storage node read quota behavior using fast client.


## How was this PR tested?
Existing and new tests

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.