### PR TITLE
[server] Isolated ingestion server should only unsubscribe partition when completion report is successful

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/isolated/IsolatedIngestionServer.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/isolated/IsolatedIngestionServer.java
@@ -483,7 +483,6 @@ public class IsolatedIngestionServer extends AbstractVeniceService {
     int partitionId = report.partitionId;
     Future<?> executionFuture = submitStopConsumptionAndCloseStorageTask(report);
     getStatusReportingExecutor().execute(() -> {
-      LOGGER.info("DEBUGGING 1");
       try {
         executionFuture.get();
       } catch (ExecutionException | InterruptedException e) {
@@ -492,11 +491,8 @@ public class IsolatedIngestionServer extends AbstractVeniceService {
             partitionId,
             topicName);
       }
-      LOGGER.info("DEBUGGING 2");
       if (getReportClient().reportIngestionStatus(report)) {
-        LOGGER.info("DEBUGGING 3");
         setResourceToBeUnsubscribed(topicName, partitionId);
-        LOGGER.info("DEBUGGING 4");
       }
     });
   }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/isolated/IsolatedIngestionServer.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/isolated/IsolatedIngestionServer.java
@@ -415,8 +415,6 @@ public class IsolatedIngestionServer extends AbstractVeniceService {
             report.message);
       }
 
-      setResourceToBeUnsubscribed(topicName, partitionId);
-
       Future<?> executionFuture = submitStopConsumptionAndCloseStorageTask(report);
       statusReportingExecutor.execute(() -> {
         try {
@@ -427,7 +425,9 @@ public class IsolatedIngestionServer extends AbstractVeniceService {
               partitionId,
               topicName);
         }
-        reportClient.reportIngestionStatus(report);
+        if (reportClient.reportIngestionStatus(report)) {
+          setResourceToBeUnsubscribed(topicName, partitionId);
+        }
       });
     } else {
       statusReportingExecutor.execute(() -> reportClient.reportIngestionStatus(report));

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/isolated/IsolatedIngestionServer.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/isolated/IsolatedIngestionServer.java
@@ -415,20 +415,7 @@ public class IsolatedIngestionServer extends AbstractVeniceService {
             report.message);
       }
 
-      Future<?> executionFuture = submitStopConsumptionAndCloseStorageTask(report);
-      statusReportingExecutor.execute(() -> {
-        try {
-          executionFuture.get();
-        } catch (ExecutionException | InterruptedException e) {
-          LOGGER.warn(
-              "Encounter exception when trying to stop consumption and close storage for {} of topic: {}",
-              partitionId,
-              topicName);
-        }
-        if (reportClient.reportIngestionStatus(report)) {
-          setResourceToBeUnsubscribed(topicName, partitionId);
-        }
-      });
+      stopConsumptionAndReport(report);
     } else {
       statusReportingExecutor.execute(() -> reportClient.reportIngestionStatus(report));
     }
@@ -452,14 +439,14 @@ public class IsolatedIngestionServer extends AbstractVeniceService {
 
   // Set the topic partition state to be unsubscribed.
   public void setResourceToBeUnsubscribed(String topicName, int partition) {
-    topicPartitionSubscriptionMap.computeIfAbsent(topicName, s -> new VeniceConcurrentHashMap<>())
+    getTopicPartitionSubscriptionMap().computeIfAbsent(topicName, s -> new VeniceConcurrentHashMap<>())
         .computeIfAbsent(partition, p -> new AtomicBoolean(false))
         .set(false);
   }
 
   // Set the topic partition state to be subscribed.
   public void setResourceToBeSubscribed(String topicName, int partition) {
-    topicPartitionSubscriptionMap.computeIfAbsent(topicName, s -> new VeniceConcurrentHashMap<>())
+    getTopicPartitionSubscriptionMap().computeIfAbsent(topicName, s -> new VeniceConcurrentHashMap<>())
         .computeIfAbsent(partition, p -> new AtomicBoolean(true))
         .set(true);
   }
@@ -475,7 +462,7 @@ public class IsolatedIngestionServer extends AbstractVeniceService {
   }
 
   public void maybeSubscribeNewResource(String topicName, int partition) {
-    topicPartitionSubscriptionMap.computeIfAbsent(topicName, s -> new VeniceConcurrentHashMap<>())
+    getTopicPartitionSubscriptionMap().computeIfAbsent(topicName, s -> new VeniceConcurrentHashMap<>())
         .computeIfAbsent(partition, p -> new AtomicBoolean(true));
   }
 
@@ -483,11 +470,42 @@ public class IsolatedIngestionServer extends AbstractVeniceService {
     return topicPartitionSubscriptionMap;
   }
 
+  ExecutorService getStatusReportingExecutor() {
+    return statusReportingExecutor;
+  }
+
+  IsolatedIngestionRequestClient getReportClient() {
+    return reportClient;
+  }
+
+  void stopConsumptionAndReport(IngestionTaskReport report) {
+    String topicName = report.topicName.toString();
+    int partitionId = report.partitionId;
+    Future<?> executionFuture = submitStopConsumptionAndCloseStorageTask(report);
+    getStatusReportingExecutor().execute(() -> {
+      LOGGER.info("DEBUGGING 1");
+      try {
+        executionFuture.get();
+      } catch (ExecutionException | InterruptedException e) {
+        LOGGER.warn(
+            "Encounter exception when trying to stop consumption and close storage for {} of topic: {}",
+            partitionId,
+            topicName);
+      }
+      LOGGER.info("DEBUGGING 2");
+      if (getReportClient().reportIngestionStatus(report)) {
+        LOGGER.info("DEBUGGING 3");
+        setResourceToBeUnsubscribed(topicName, partitionId);
+        LOGGER.info("DEBUGGING 4");
+      }
+    });
+  }
+
   /**
    * Handle the logic of COMPLETED/ERROR here since we need to stop related ingestion task and close RocksDB partition.
    * Since the logic takes time to wait for completion, we need to execute it in async fashion to prevent blocking other operations.
    */
-  private Future<?> submitStopConsumptionAndCloseStorageTask(IngestionTaskReport report) {
+  Future<?> submitStopConsumptionAndCloseStorageTask(IngestionTaskReport report) {
     String topicName = report.topicName.toString();
     int partitionId = report.partitionId;
     return longRunningTaskExecutor.submit(() -> {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionService.java
@@ -104,6 +104,7 @@ import com.linkedin.venice.writer.VeniceWriterFactory;
 import io.tehuti.metrics.MetricsRepository;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -1211,7 +1212,7 @@ public class KafkaStoreIngestionService extends AbstractVeniceService implements
       } catch (Exception e) {
         LOGGER.error(
             "Caught exception when deserializing offset record byte array: {} for topic: {}, subPartition: {}.",
-            offsetRecordByteArray,
+            Arrays.toString(offsetRecordByteArray),
             topicName,
             subPartition);
         throw e;

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/ingestion/isolated/IsolatedIngestionRequestClientTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/ingestion/isolated/IsolatedIngestionRequestClientTest.java
@@ -1,0 +1,42 @@
+package com.linkedin.davinci.ingestion.isolated;
+
+import static com.linkedin.venice.ConfigKeys.SERVER_INGESTION_ISOLATION_REQUEST_TIMEOUT_SECONDS;
+import static com.linkedin.venice.ConfigKeys.SERVER_INGESTION_ISOLATION_SSL_ENABLED;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.linkedin.davinci.config.VeniceConfigLoader;
+import com.linkedin.davinci.config.VeniceServerConfig;
+import com.linkedin.davinci.ingestion.HttpClientTransport;
+import com.linkedin.venice.exceptions.VeniceException;
+import com.linkedin.venice.ingestion.protocol.IngestionTaskReport;
+import com.linkedin.venice.utils.VeniceProperties;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class IsolatedIngestionRequestClientTest {
+  @Test
+  public void testClientReportStatus() {
+
+    VeniceProperties properties = mock(VeniceProperties.class);
+    when(properties.getInt(SERVER_INGESTION_ISOLATION_REQUEST_TIMEOUT_SECONDS, 120)).thenReturn(120);
+    when(properties.getBoolean(SERVER_INGESTION_ISOLATION_SSL_ENABLED, false)).thenReturn(false);
+    VeniceServerConfig veniceServerConfig = mock(VeniceServerConfig.class);
+    when(veniceServerConfig.getIngestionApplicationPort()).thenReturn(27105);
+    VeniceConfigLoader configLoader = mock(VeniceConfigLoader.class);
+    when(configLoader.getVeniceServerConfig()).thenReturn(veniceServerConfig);
+    when(configLoader.getCombinedProperties()).thenReturn(properties);
+    HttpClientTransport transport = mock(HttpClientTransport.class);
+    IsolatedIngestionRequestClient client = new IsolatedIngestionRequestClient(configLoader);
+    client.setHttpClientTransport(transport);
+    IngestionTaskReport report = new IngestionTaskReport();
+    report.topicName = "topic";
+    report.partitionId = 1;
+    report.reportType = 0;
+    Assert.assertTrue(client.reportIngestionStatus(report));
+    when(transport.sendRequest(any(), any())).thenThrow(new VeniceException("test"));
+    Assert.assertFalse(client.reportIngestionStatus(report));
+  }
+}

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/ingestion/isolated/IsolatedIngestionServerTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/ingestion/isolated/IsolatedIngestionServerTest.java
@@ -1,5 +1,8 @@
 package com.linkedin.davinci.ingestion.isolated;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -8,11 +11,17 @@ import static org.mockito.Mockito.when;
 
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.ingestion.protocol.IngestionMetricsReport;
+import com.linkedin.venice.ingestion.protocol.IngestionTaskReport;
 import com.linkedin.venice.utils.RedundantExceptionFilter;
+import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
 import io.tehuti.metrics.MetricsRepository;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.mockito.ArgumentCaptor;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -46,5 +55,37 @@ public class IsolatedIngestionServerTest {
     Assert.assertEquals(argumentCaptor.getAllValues().get(0).aggregatedMetrics.size(), 1);
     Assert.assertEquals(argumentCaptor.getAllValues().get(1).aggregatedMetrics.size(), 1);
     Assert.assertEquals(argumentCaptor.getAllValues().get(2).aggregatedMetrics.size(), 0);
+  }
+
+  @Test
+  public void testStopConsumptionAndReport() {
+    Map<String, Map<Integer, AtomicBoolean>> topicPartitionSubscriptionMap = new VeniceConcurrentHashMap<>();
+    IsolatedIngestionServer isolatedIngestionServer = mock(IsolatedIngestionServer.class);
+    when(isolatedIngestionServer.getTopicPartitionSubscriptionMap()).thenReturn(topicPartitionSubscriptionMap);
+    ExecutorService statusReportingExecutor = Executors.newSingleThreadExecutor();
+    when(isolatedIngestionServer.getStatusReportingExecutor()).thenReturn(statusReportingExecutor);
+    doCallRealMethod().when(isolatedIngestionServer).stopConsumptionAndReport(any());
+    doCallRealMethod().when(isolatedIngestionServer).setResourceToBeUnsubscribed(anyString(), anyInt());
+    when(isolatedIngestionServer.submitStopConsumptionAndCloseStorageTask(any()))
+        .thenReturn(CompletableFuture.completedFuture(null));
+    IsolatedIngestionRequestClient client = mock(IsolatedIngestionRequestClient.class);
+    when(isolatedIngestionServer.getReportClient()).thenReturn(client);
+
+    IngestionTaskReport badReport = new IngestionTaskReport();
+    badReport.topicName = "topic";
+    badReport.partitionId = 0;
+    badReport.reportType = 0;
+    when(client.reportIngestionStatus(badReport)).thenReturn(false);
+    isolatedIngestionServer.stopConsumptionAndReport(badReport);
+
+    IngestionTaskReport goodReport = new IngestionTaskReport();
+    goodReport.topicName = "topic";
+    goodReport.partitionId = 1;
+    goodReport.reportType = 0;
+    when(client.reportIngestionStatus(goodReport)).thenReturn(true);
+    isolatedIngestionServer.stopConsumptionAndReport(goodReport);
+
+    verify(isolatedIngestionServer, times(0)).setResourceToBeUnsubscribed("topic", 0);
+    verify(isolatedIngestionServer, times(1)).setResourceToBeUnsubscribed("topic", 1);
   }
 }


### PR DESCRIPTION
## [server] Isolated ingestion server should only unsubscribe partition when completion report is successful
We observed a transient issue in test env that an OffsetRecord failed to be deserialized result in COMPLETED report failed. The expected behavior would be failing the push, however, server also failed to stop because we unsubscribe the topic partition in child process first before we check report result. Thus when new Helix ST comes in to this topic partition, non of the process will take it and hence stuck the stop progress.

This fix checks report before unsubscribe. If COMPLETED report failed (with retries), it should not do the unsubscribe. New Helix ST towards this topic partition (like standby->offline / leader->standby) should be accepted and executed and hence the server stop will not be stuck.


## How was this PR tested?
New unit test.

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.