### PR TITLE
[controller] Fix migrated store system store flags in parent region

### DIFF
--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -1958,6 +1958,8 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
           setUpDaVinciPushStatusStore(clusterName, systemStoreType.extractRegularStoreName(storeName));
         }
 
+        // Update the store object to avoid potential system store flags reversion during repository.updateStore(store).
+        store = repository.getStore(storeName);
         version.setPushType(pushType);
         store.addVersion(version);
         // Apply cluster-level native replication configs


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci], [server], [controller],
[router], [samza], [vpj], [fast-client], [thin-client], [alpini],
[admin-tool], [test], [build], [doc], [script]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Summary
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Problem: Migrated store system store flags in parent region are still false
after commit 1c31666. Even though addVersionOnly has code to enable system
store flags in the user store, existing store object is not updated and does
not have system store flag changes. Later, at repository.updateStore(store),
this store object is used to update store, and therefore, system store flag
changes are reverted.

Fix: In addVersionOnly, after the code of setting system store flags, obtain
the latest store and update the store object.

Test: Assert that migrated store system store flags in parent region are
enabled in the integ test. Test failed before the code change and passes now.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
Described in summary.

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.