### PR TITLE
[venice-common][test] Support unknown pubsub topic type and fix race condition in PartitionOffsetFetcherImpl

### DIFF
--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/CachedKafkaMetadataGetterTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/CachedKafkaMetadataGetterTest.java
@@ -13,7 +13,6 @@ import com.linkedin.venice.pubsub.api.PubSubTopic;
 import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
 import com.linkedin.venice.stats.StatsErrorCode;
 import com.linkedin.venice.utils.TestUtils;
-import com.linkedin.venice.utils.Utils;
 import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -65,7 +64,7 @@ public class CachedKafkaMetadataGetterTest {
     CachedKafkaMetadataGetter cachedKafkaMetadataGetter = new CachedKafkaMetadataGetter(1000);
     CachedKafkaMetadataGetter.KafkaMetadataCacheKey key = new CachedKafkaMetadataGetter.KafkaMetadataCacheKey(
         "server",
-        new PubSubTopicPartitionImpl(pubSubTopicRepository.getTopic(Utils.getUniqueTopicString("topic")), 1));
+        new PubSubTopicPartitionImpl(pubSubTopicRepository.getTopic(TestUtils.getUniqueTopicString("topic")), 1));
     Map<CachedKafkaMetadataGetter.KafkaMetadataCacheKey, CachedKafkaMetadataGetter.ValueAndExpiryTime<Long>> offsetCache =
         new VeniceConcurrentHashMap<>();
     CachedKafkaMetadataGetter.ValueAndExpiryTime<Long> valueCache =

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/adapter/kafka/admin/ApacheKafkaAdminAdapter.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/adapter/kafka/admin/ApacheKafkaAdminAdapter.java
@@ -313,7 +313,9 @@ public class ApacheKafkaAdminAdapter implements PubSubAdminAdapter {
     }
     // If not set, Kafka cluster defaults will apply
     pubSubTopicConfiguration.minInSyncReplicas()
-        .ifPresent(minIsrConfig -> topicProperties.put(TopicConfig.MIN_IN_SYNC_REPLICAS_CONFIG, minIsrConfig));
+        .ifPresent(
+            minIsrConfig -> topicProperties
+                .put(TopicConfig.MIN_IN_SYNC_REPLICAS_CONFIG, Integer.toString(minIsrConfig)));
     // Just in case the Kafka cluster isn't configured as expected.
     topicProperties.put(TopicConfig.MESSAGE_TIMESTAMP_TYPE_CONFIG, "LogAppendTime");
     return topicProperties;

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/PubSubTopicType.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/PubSubTopicType.java
@@ -1,12 +1,11 @@
 package com.linkedin.venice.pubsub.api;
 
-import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.views.VeniceView;
 
 
 public enum PubSubTopicType {
-  VERSION_TOPIC, REALTIME_TOPIC, REPROCESSING_TOPIC, ADMIN_TOPIC, VIEW_TOPIC;
+  VERSION_TOPIC, REALTIME_TOPIC, REPROCESSING_TOPIC, ADMIN_TOPIC, VIEW_TOPIC, UNKNOWN_TYPE_TOPIC;
 
   public static final String ADMIN_TOPIC_PREFIX = "venice_admin_";
 
@@ -22,7 +21,7 @@ public enum PubSubTopicType {
     } else if (VeniceView.isViewTopic(topicName)) {
       return VIEW_TOPIC;
     } else {
-      throw new VeniceException("Unsupported topic type for: " + topicName);
+      return UNKNOWN_TYPE_TOPIC;
     }
   }
 

--- a/internal/venice-common/src/main/java/com/linkedin/venice/utils/Utils.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/utils/Utils.java
@@ -544,6 +544,8 @@ public class Utils {
     } else if (pubSubTopicType.equals(PubSubTopicType.VIEW_TOPIC)) {
       return getUniqueString(prefix) + Version.VERSION_SEPARATOR + (version)
           + ChangeCaptureView.CHANGE_CAPTURE_TOPIC_SUFFIX;
+    } else if (pubSubTopicType.equals(PubSubTopicType.UNKNOWN_TYPE_TOPIC)) {
+      return getUniqueString(prefix);
     } else {
       throw new VeniceException("Unsupported topic type for: " + pubSubTopicType);
     }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/utils/Utils.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/utils/Utils.java
@@ -16,11 +16,9 @@ import com.linkedin.venice.meta.ReadOnlyStoreRepository;
 import com.linkedin.venice.meta.RoutingDataRepository;
 import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.Version;
-import com.linkedin.venice.pubsub.api.PubSubTopicType;
 import com.linkedin.venice.pushmonitor.ExecutionStatus;
 import com.linkedin.venice.serialization.avro.AvroProtocolDefinition;
 import com.linkedin.venice.serialization.avro.InternalAvroSpecificSerializer;
-import com.linkedin.venice.views.ChangeCaptureView;
 import java.io.Closeable;
 import java.io.File;
 import java.io.FileInputStream;
@@ -526,29 +524,6 @@ public class Utils {
 
   public static String getUniqueString(String prefix) {
     return String.format("%s_%x_%x", prefix, System.nanoTime(), ThreadLocalRandom.current().nextInt());
-  }
-
-  public static String getUniqueTopicString(String prefix) {
-    int typesNum = PubSubTopicType.values().length;
-    int pubSubTopicTypeIndex = Math.abs(ThreadLocalRandom.current().nextInt() % typesNum);
-    PubSubTopicType pubSubTopicType = PubSubTopicType.values()[pubSubTopicTypeIndex];
-    int version = Math.abs(ThreadLocalRandom.current().nextInt() % typesNum);
-    if (pubSubTopicType.equals(PubSubTopicType.REALTIME_TOPIC)) {
-      return getUniqueString(prefix) + Version.REAL_TIME_TOPIC_SUFFIX;
-    } else if (pubSubTopicType.equals(PubSubTopicType.REPROCESSING_TOPIC)) {
-      return getUniqueString(prefix) + Version.VERSION_SEPARATOR + (version) + Version.STREAM_REPROCESSING_TOPIC_SUFFIX;
-    } else if (pubSubTopicType.equals(PubSubTopicType.VERSION_TOPIC)) {
-      return getUniqueString(prefix) + Version.VERSION_SEPARATOR + (version);
-    } else if (pubSubTopicType.equals(PubSubTopicType.ADMIN_TOPIC)) {
-      return pubSubTopicType.ADMIN_TOPIC_PREFIX + getUniqueString(prefix);
-    } else if (pubSubTopicType.equals(PubSubTopicType.VIEW_TOPIC)) {
-      return getUniqueString(prefix) + Version.VERSION_SEPARATOR + (version)
-          + ChangeCaptureView.CHANGE_CAPTURE_TOPIC_SUFFIX;
-    } else if (pubSubTopicType.equals(PubSubTopicType.UNKNOWN_TYPE_TOPIC)) {
-      return getUniqueString(prefix);
-    } else {
-      throw new VeniceException("Unsupported topic type for: " + pubSubTopicType);
-    }
   }
 
   public static String getUniqueTempPath() {

--- a/internal/venice-common/src/test/java/com/linkedin/venice/kafka/TopicManagerTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/kafka/TopicManagerTest.java
@@ -35,7 +35,6 @@ import com.linkedin.venice.pubsub.PubSubTopicConfiguration;
 import com.linkedin.venice.pubsub.PubSubTopicPartitionImpl;
 import com.linkedin.venice.pubsub.PubSubTopicRepository;
 import com.linkedin.venice.pubsub.adapter.kafka.admin.ApacheKafkaAdminAdapterFactory;
-import com.linkedin.venice.pubsub.adapter.kafka.producer.ApacheKafkaProducerConfig;
 import com.linkedin.venice.pubsub.api.PubSubAdminAdapter;
 import com.linkedin.venice.pubsub.api.PubSubAdminAdapterFactory;
 import com.linkedin.venice.pubsub.api.PubSubConsumerAdapter;
@@ -44,8 +43,6 @@ import com.linkedin.venice.pubsub.api.PubSubProducerAdapter;
 import com.linkedin.venice.pubsub.api.PubSubProducerCallback;
 import com.linkedin.venice.pubsub.api.PubSubTopic;
 import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
-import com.linkedin.venice.serialization.KafkaKeySerializer;
-import com.linkedin.venice.serialization.avro.KafkaValueSerializer;
 import com.linkedin.venice.systemstore.schemas.StoreProperties;
 import com.linkedin.venice.unit.kafka.InMemoryKafkaBroker;
 import com.linkedin.venice.unit.kafka.MockInMemoryAdminAdapter;
@@ -65,7 +62,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
@@ -128,10 +124,6 @@ public class TopicManagerTest {
   }
 
   protected PubSubProducerAdapter createPubSubProducerAdapter() {
-    Properties props = new Properties();
-    props.put(ApacheKafkaProducerConfig.KAFKA_KEY_SERIALIZER, KafkaKeySerializer.class.getName());
-    props.put(ApacheKafkaProducerConfig.KAFKA_VALUE_SERIALIZER, KafkaValueSerializer.class.getName());
-    props.put(ApacheKafkaProducerConfig.KAFKA_BOOTSTRAP_SERVERS, "localhost:1234");
     return new MockInMemoryProducerAdapter(inMemoryKafkaBroker);
   }
 

--- a/internal/venice-common/src/test/java/com/linkedin/venice/kafka/TopicManagerTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/kafka/TopicManagerTest.java
@@ -52,7 +52,6 @@ import com.linkedin.venice.unit.kafka.producer.MockInMemoryProducerAdapter;
 import com.linkedin.venice.utils.AvroRecordUtils;
 import com.linkedin.venice.utils.TestUtils;
 import com.linkedin.venice.utils.Time;
-import com.linkedin.venice.utils.Utils;
 import com.linkedin.venice.utils.VeniceProperties;
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -175,7 +174,7 @@ public class TopicManagerTest {
 
   protected PubSubTopic getTopic() {
     String callingFunction = Thread.currentThread().getStackTrace()[2].getMethodName();
-    PubSubTopic topicName = pubSubTopicRepository.getTopic(Utils.getUniqueTopicString(callingFunction));
+    PubSubTopic topicName = pubSubTopicRepository.getTopic(TestUtils.getUniqueTopicString(callingFunction));
     int partitions = 1;
     int replicas = 1;
     topicManager.createTopic(topicName, partitions, replicas, false);
@@ -358,7 +357,7 @@ public class TopicManagerTest {
 
   @Test
   public void testGetTopicConfig() {
-    PubSubTopic topic = pubSubTopicRepository.getTopic(Utils.getUniqueTopicString("topic"));
+    PubSubTopic topic = pubSubTopicRepository.getTopic(TestUtils.getUniqueTopicString("topic"));
     topicManager.createTopic(topic, 1, 1, true);
     PubSubTopicConfiguration topicProperties = topicManager.getTopicConfig(topic);
     Assert.assertTrue(topicProperties.retentionInMs().isPresent());
@@ -367,13 +366,13 @@ public class TopicManagerTest {
 
   @Test(expectedExceptions = TopicDoesNotExistException.class)
   public void testGetTopicConfigWithUnknownTopic() {
-    PubSubTopic topic = pubSubTopicRepository.getTopic(Utils.getUniqueTopicString("topic"));
+    PubSubTopic topic = pubSubTopicRepository.getTopic(TestUtils.getUniqueTopicString("topic"));
     topicManager.getTopicConfig(topic);
   }
 
   @Test
   public void testUpdateTopicRetention() {
-    PubSubTopic topic = pubSubTopicRepository.getTopic(Utils.getUniqueTopicString("topic"));
+    PubSubTopic topic = pubSubTopicRepository.getTopic(TestUtils.getUniqueTopicString("topic"));
     topicManager.createTopic(topic, 1, 1, true);
     topicManager.updateTopicRetention(topic, 0);
     PubSubTopicConfiguration topicProperties = topicManager.getTopicConfig(topic);
@@ -384,9 +383,9 @@ public class TopicManagerTest {
   @Test
   public void testListAllTopics() {
     Set<PubSubTopic> expectTopics = new HashSet<>(topicManager.listTopics());
-    PubSubTopic topic1 = pubSubTopicRepository.getTopic(Utils.getUniqueTopicString("topic"));
-    PubSubTopic topic2 = pubSubTopicRepository.getTopic(Utils.getUniqueTopicString("topic"));
-    PubSubTopic topic3 = pubSubTopicRepository.getTopic(Utils.getUniqueTopicString("topic"));
+    PubSubTopic topic1 = pubSubTopicRepository.getTopic(TestUtils.getUniqueTopicString("topic"));
+    PubSubTopic topic2 = pubSubTopicRepository.getTopic(TestUtils.getUniqueTopicString("topic"));
+    PubSubTopic topic3 = pubSubTopicRepository.getTopic(TestUtils.getUniqueTopicString("topic"));
     // Create 1 topic, expect 1 topic in total
     topicManager.createTopic(topic1, 1, 1, true);
     expectTopics.add(topic1);
@@ -408,9 +407,9 @@ public class TopicManagerTest {
 
   @Test
   public void testGetAllTopicRetentions() {
-    PubSubTopic topic1 = pubSubTopicRepository.getTopic(Utils.getUniqueTopicString("topic"));
-    PubSubTopic topic2 = pubSubTopicRepository.getTopic(Utils.getUniqueTopicString("topic"));
-    PubSubTopic topic3 = pubSubTopicRepository.getTopic(Utils.getUniqueTopicString("topic"));
+    PubSubTopic topic1 = pubSubTopicRepository.getTopic(TestUtils.getUniqueTopicString("topic"));
+    PubSubTopic topic2 = pubSubTopicRepository.getTopic(TestUtils.getUniqueTopicString("topic"));
+    PubSubTopic topic3 = pubSubTopicRepository.getTopic(TestUtils.getUniqueTopicString("topic"));
     topicManager.createTopic(topic1, 1, 1, true);
     topicManager.createTopic(topic2, 1, 1, false);
     topicManager.createTopic(topic3, 1, 1, false);
@@ -448,7 +447,7 @@ public class TopicManagerTest {
 
   @Test
   public void testUpdateTopicCompactionPolicy() {
-    PubSubTopic topic = pubSubTopicRepository.getTopic(Utils.getUniqueTopicString("topic"));
+    PubSubTopic topic = pubSubTopicRepository.getTopic(TestUtils.getUniqueTopicString("topic"));
     topicManager.createTopic(topic, 1, 1, true);
     Assert.assertFalse(
         topicManager.isTopicCompactionEnabled(topic),
@@ -467,13 +466,13 @@ public class TopicManagerTest {
 
   @Test
   public void testGetConfigForNonExistingTopic() {
-    PubSubTopic nonExistingTopic = pubSubTopicRepository.getTopic(Utils.getUniqueTopicString("non-existing-topic"));
+    PubSubTopic nonExistingTopic = pubSubTopicRepository.getTopic(TestUtils.getUniqueTopicString("non-existing-topic"));
     Assert.assertThrows(TopicDoesNotExistException.class, () -> topicManager.getTopicConfig(nonExistingTopic));
   }
 
   @Test
   public void testGetLatestOffsetForNonExistingTopic() {
-    PubSubTopic nonExistingTopic = pubSubTopicRepository.getTopic(Utils.getUniqueTopicString("non-existing-topic"));
+    PubSubTopic nonExistingTopic = pubSubTopicRepository.getTopic(TestUtils.getUniqueTopicString("non-existing-topic"));
     Assert.assertThrows(
         TopicDoesNotExistException.class,
         () -> topicManager.getPartitionLatestOffsetAndRetry(new PubSubTopicPartitionImpl(nonExistingTopic, 0), 10));
@@ -481,7 +480,7 @@ public class TopicManagerTest {
 
   @Test
   public void testGetLatestProducerTimestampForNonExistingTopic() {
-    PubSubTopic nonExistingTopic = pubSubTopicRepository.getTopic(Utils.getUniqueTopicString("non-existing-topic"));
+    PubSubTopic nonExistingTopic = pubSubTopicRepository.getTopic(TestUtils.getUniqueTopicString("non-existing-topic"));
     Assert.assertThrows(
         TopicDoesNotExistException.class,
         () -> topicManager.getProducerTimestampOfLastDataRecord(new PubSubTopicPartitionImpl(nonExistingTopic, 0), 10));
@@ -489,7 +488,7 @@ public class TopicManagerTest {
 
   @Test
   public void testGetAndUpdateTopicRetentionForNonExistingTopic() {
-    PubSubTopic nonExistingTopic = pubSubTopicRepository.getTopic(Utils.getUniqueTopicString("non-existing-topic"));
+    PubSubTopic nonExistingTopic = pubSubTopicRepository.getTopic(TestUtils.getUniqueTopicString("non-existing-topic"));
     Assert.assertThrows(TopicDoesNotExistException.class, () -> topicManager.getTopicRetention(nonExistingTopic));
     Assert.assertThrows(
         TopicDoesNotExistException.class,
@@ -498,7 +497,7 @@ public class TopicManagerTest {
 
   @Test
   public void testUpdateTopicCompactionPolicyForNonExistingTopic() {
-    PubSubTopic nonExistingTopic = pubSubTopicRepository.getTopic(Utils.getUniqueTopicString("non-existing-topic"));
+    PubSubTopic nonExistingTopic = pubSubTopicRepository.getTopic(TestUtils.getUniqueTopicString("non-existing-topic"));
     Assert.assertThrows(
         TopicDoesNotExistException.class,
         () -> topicManager.updateTopicCompactionPolicy(nonExistingTopic, true));
@@ -506,7 +505,7 @@ public class TopicManagerTest {
 
   @Test
   public void testTimeoutOnGettingMaxOffset() throws IOException {
-    PubSubTopic topic = pubSubTopicRepository.getTopic(Utils.getUniqueTopicString("topic"));
+    PubSubTopic topic = pubSubTopicRepository.getTopic(TestUtils.getUniqueTopicString("topic"));
     PubSubTopicPartition pubSubTopicPartition = new PubSubTopicPartitionImpl(topic, 0);
     // Mock an admin client to pass topic existence check
     PubSubAdminAdapter mockPubSubAdminAdapter = mock(PubSubAdminAdapter.class);
@@ -541,7 +540,7 @@ public class TopicManagerTest {
   @Test
   public void testContainsTopicWithExpectationAndRetry() throws InterruptedException {
     // Case 1: topic does not exist
-    PubSubTopic nonExistingTopic = pubSubTopicRepository.getTopic(Utils.getUniqueTopicString("topic"));
+    PubSubTopic nonExistingTopic = pubSubTopicRepository.getTopic(TestUtils.getUniqueTopicString("topic"));
     Assert.assertFalse(topicManager.containsTopicWithExpectationAndRetry(nonExistingTopic, 3, true));
 
     // Case 2: topic exists
@@ -552,7 +551,7 @@ public class TopicManagerTest {
     // Case 3: topic does not exist initially but topic is created later.
     // This test case is to simulate the situation where the contains topic check fails on initial attempt(s) but
     // succeeds eventually.
-    PubSubTopic initiallyNotExistTopic = pubSubTopicRepository.getTopic(Utils.getUniqueTopicString("topic"));
+    PubSubTopic initiallyNotExistTopic = pubSubTopicRepository.getTopic(TestUtils.getUniqueTopicString("topic"));
 
     final long delayedTopicCreationInSeconds = 1;
     CountDownLatch delayedTopicCreationStartedSignal = new CountDownLatch(1);
@@ -633,7 +632,7 @@ public class TopicManagerTest {
 
   @Test
   public void testContainsTopicAndAllPartitionsAreOnline() {
-    PubSubTopic topic = pubSubTopicRepository.getTopic(Utils.getUniqueTopicString("a-new-topic"));
+    PubSubTopic topic = pubSubTopicRepository.getTopic(TestUtils.getUniqueTopicString("a-new-topic"));
     Assert.assertFalse(topicManager.containsTopicAndAllPartitionsAreOnline(topic)); // Topic does not exist yet
 
     topicManager.createTopic(topic, 1, 1, true);
@@ -642,7 +641,7 @@ public class TopicManagerTest {
 
   @Test
   public void testUpdateTopicMinISR() {
-    PubSubTopic topic = pubSubTopicRepository.getTopic(Utils.getUniqueTopicString("topic"));
+    PubSubTopic topic = pubSubTopicRepository.getTopic(TestUtils.getUniqueTopicString("topic"));
     topicManager.createTopic(topic, 1, 1, true);
     PubSubTopicConfiguration pubSubTopicConfiguration = topicManager.getTopicConfig(topic);
     Assert.assertTrue(pubSubTopicConfiguration.minInSyncReplicas().get() == 1);

--- a/internal/venice-common/src/test/java/com/linkedin/venice/kafka/TopicManagerTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/kafka/TopicManagerTest.java
@@ -103,7 +103,7 @@ public class TopicManagerTest {
 
   private InMemoryKafkaBroker inMemoryKafkaBroker;
 
-  private void createTopicManager() {
+  protected void createTopicManager() {
     inMemoryKafkaBroker = new InMemoryKafkaBroker("local");
     PubSubAdminAdapterFactory pubSubAdminAdapterFactory = mock(ApacheKafkaAdminAdapterFactory.class);
     MockInMemoryAdminAdapter mockInMemoryAdminAdapter = new MockInMemoryAdminAdapter(inMemoryKafkaBroker);
@@ -127,7 +127,11 @@ public class TopicManagerTest {
         .getTopicManager();
   }
 
-  private PubSubProducerAdapter createPubSubProducerAdapter() {
+  protected PubSubProducerAdapter createPubSubProducerAdapter() {
+    Properties props = new Properties();
+    props.put(ApacheKafkaProducerConfig.KAFKA_KEY_SERIALIZER, KafkaKeySerializer.class.getName());
+    props.put(ApacheKafkaProducerConfig.KAFKA_VALUE_SERIALIZER, KafkaValueSerializer.class.getName());
+    props.put(ApacheKafkaProducerConfig.KAFKA_BOOTSTRAP_SERVERS, "localhost:1234");
     return new MockInMemoryProducerAdapter(inMemoryKafkaBroker);
   }
 
@@ -145,12 +149,8 @@ public class TopicManagerTest {
    * @throws ExecutionException
    * @throws InterruptedException
    */
-  private void produceToKafka(PubSubTopic topic, boolean isDataRecord, long producerTimestamp)
+  protected void produceToKafka(PubSubTopic topic, boolean isDataRecord, long producerTimestamp)
       throws ExecutionException, InterruptedException {
-    Properties props = new Properties();
-    props.put(ApacheKafkaProducerConfig.KAFKA_KEY_SERIALIZER, KafkaKeySerializer.class.getName());
-    props.put(ApacheKafkaProducerConfig.KAFKA_VALUE_SERIALIZER, KafkaValueSerializer.class.getName());
-    props.put(ApacheKafkaProducerConfig.KAFKA_BOOTSTRAP_SERVERS, "localhost:1234");
     PubSubProducerAdapter producer = createPubSubProducerAdapter();
 
     final byte[] randomBytes = new byte[] { 0, 1 };
@@ -181,7 +181,7 @@ public class TopicManagerTest {
     producer.sendMessage(topic.getName(), 0, recordKey, recordValue, null, mock(PubSubProducerCallback.class)).get();
   }
 
-  private PubSubTopic getTopic() {
+  protected PubSubTopic getTopic() {
     String callingFunction = Thread.currentThread().getStackTrace()[2].getMethodName();
     PubSubTopic topicName = pubSubTopicRepository.getTopic(Utils.getUniqueTopicString(callingFunction));
     int partitions = 1;

--- a/internal/venice-test-common/build.gradle
+++ b/internal/venice-test-common/build.gradle
@@ -78,6 +78,7 @@ dependencies {
   }
   testImplementation project(':clients:venice-admin-tool')
   testImplementation project(':internal:alpini:common:alpini-common-base')
+  testImplementation project(":internal:venice-common").sourceSets.test.output
 
   jmhAnnotationProcessor libraries.jmhGenerator
   jmhImplementation libraries.jmhCore

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/kafka/KafkaConsumptionTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/kafka/KafkaConsumptionTest.java
@@ -46,7 +46,6 @@ import com.linkedin.venice.utils.IntegrationTestPushUtils;
 import com.linkedin.venice.utils.TestMockTime;
 import com.linkedin.venice.utils.TestUtils;
 import com.linkedin.venice.utils.Time;
-import com.linkedin.venice.utils.Utils;
 import com.linkedin.venice.utils.VeniceProperties;
 import com.linkedin.venice.utils.pools.LandFillObjectPool;
 import io.tehuti.metrics.MetricsRepository;
@@ -85,7 +84,7 @@ public class KafkaConsumptionTest {
 
   private PubSubTopic getTopic() {
     String callingFunction = Thread.currentThread().getStackTrace()[2].getMethodName();
-    PubSubTopic versionTopic = pubSubTopicRepository.getTopic(Utils.getUniqueTopicString(callingFunction));
+    PubSubTopic versionTopic = pubSubTopicRepository.getTopic(TestUtils.getUniqueTopicString(callingFunction));
     int partitions = 1;
     int replicas = 1;
     topicManager.createTopic(versionTopic, partitions, replicas, false);

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/kafka/TopicManagerITest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/kafka/TopicManagerITest.java
@@ -1,0 +1,101 @@
+package com.linkedin.venice.kafka;
+
+import com.linkedin.venice.integration.utils.PubSubBrokerConfigs;
+import com.linkedin.venice.integration.utils.PubSubBrokerWrapper;
+import com.linkedin.venice.integration.utils.ServiceFactory;
+import com.linkedin.venice.pubsub.PubSubTopicPartitionImpl;
+import com.linkedin.venice.pubsub.PubSubTopicRepository;
+import com.linkedin.venice.pubsub.adapter.kafka.producer.ApacheKafkaProducerAdapter;
+import com.linkedin.venice.pubsub.adapter.kafka.producer.ApacheKafkaProducerConfig;
+import com.linkedin.venice.pubsub.api.PubSubProducerAdapter;
+import com.linkedin.venice.pubsub.api.PubSubTopic;
+import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
+import com.linkedin.venice.serialization.KafkaKeySerializer;
+import com.linkedin.venice.serialization.avro.KafkaValueSerializer;
+import com.linkedin.venice.utils.IntegrationTestPushUtils;
+import com.linkedin.venice.utils.TestMockTime;
+import java.util.Properties;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.Test;
+
+
+public class TopicManagerITest extends TopicManagerTest {
+  private PubSubBrokerWrapper pubSubBrokerWrapper;
+
+  @AfterClass
+  public void tearDown() {
+    pubSubBrokerWrapper.close();
+    topicManager.close();
+  }
+
+  @Override
+  protected void createTopicManager() {
+    TestMockTime mockTime = new TestMockTime();
+    pubSubBrokerWrapper =
+        ServiceFactory.getPubSubBroker(new PubSubBrokerConfigs.Builder().setMockTime(mockTime).build());
+    topicManager =
+        IntegrationTestPushUtils
+            .getTopicManagerRepo(
+                500L,
+                100L,
+                MIN_COMPACTION_LAG,
+                pubSubBrokerWrapper.getAddress(),
+                new PubSubTopicRepository())
+            .getTopicManager();
+  }
+
+  protected PubSubProducerAdapter createPubSubProducerAdapter() {
+    Properties props = new Properties();
+    props.put(ApacheKafkaProducerConfig.KAFKA_KEY_SERIALIZER, KafkaKeySerializer.class.getName());
+    props.put(ApacheKafkaProducerConfig.KAFKA_VALUE_SERIALIZER, KafkaValueSerializer.class.getName());
+    props.put(ApacheKafkaProducerConfig.KAFKA_BOOTSTRAP_SERVERS, pubSubBrokerWrapper.getAddress());
+    return new ApacheKafkaProducerAdapter(new ApacheKafkaProducerConfig(props));
+  }
+
+  @Test
+  public void testRaceCondition() throws ExecutionException, InterruptedException {
+    final PubSubTopic topic = getTopic();
+    final PubSubTopicPartition pubSubTopicPartition = new PubSubTopicPartitionImpl(topic, 0);
+
+    long timestamp = System.currentTimeMillis();
+    produceToKafka(topic, true, timestamp); // This timestamp is expected to be retrieved
+    produceToKafka(topic, false, timestamp + 1000L); // produce a control message
+
+    long retrievedTimestamp = topicManager.getProducerTimestampOfLastDataRecord(pubSubTopicPartition, 1);
+    Assert.assertEquals(retrievedTimestamp, timestamp);
+
+    // Produce more data records to this topic partition
+    for (int i = 0; i < 100; i++) {
+      timestamp += 1000L;
+      produceToKafka(topic, true, timestamp);
+    }
+    // Produce several control messages at the end
+    for (int i = 1; i <= 3; i++) {
+      produceToKafka(topic, false, timestamp + i * 1000L);
+    }
+    long checkTimestamp = timestamp - 1000L;
+    int numberOfThreads = 50;
+    ExecutorService executorService = Executors.newFixedThreadPool(numberOfThreads);
+    Future[] vwFutures = new Future[numberOfThreads];
+    // Put all topic manager calls related to partition offset fetcher with admin and consumer here.
+    Runnable[] tasks = { () -> topicManager.getPartitionOffsetByTime(pubSubTopicPartition, checkTimestamp),
+        () -> topicManager.getProducerTimestampOfLastDataRecord(pubSubTopicPartition, 1),
+        () -> topicManager.partitionsFor(topic),
+        () -> topicManager.getPartitionEarliestOffsetAndRetry(pubSubTopicPartition, 1),
+        () -> topicManager.getPartitionLatestOffsetAndRetry(pubSubTopicPartition, 1),
+        () -> topicManager.getTopicLatestOffsets(topic) };
+
+    for (int i = 0; i < numberOfThreads; i++) {
+      vwFutures[i] = executorService.submit(tasks[i % tasks.length]);
+    }
+    for (int i = 0; i < numberOfThreads; i++) {
+      vwFutures[i].get();
+    }
+  }
+
+}

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/kafka/TopicManagerIntegrationTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/kafka/TopicManagerIntegrationTest.java
@@ -24,7 +24,7 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
 
 
-public class TopicManagerITest extends TopicManagerTest {
+public class TopicManagerIntegrationTest extends TopicManagerTest {
   private PubSubBrokerWrapper pubSubBrokerWrapper;
 
   @AfterClass

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/writer/VeniceWriterTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/writer/VeniceWriterTest.java
@@ -99,7 +99,7 @@ public class VeniceWriterTest {
       int numberOfThreads,
       java.util.function.Consumer<VeniceWriter<KafkaKey, byte[], byte[]>> veniceWriterTask)
       throws ExecutionException, InterruptedException {
-    String topicName = Utils.getUniqueTopicString("topic-for-vw-thread-safety");
+    String topicName = TestUtils.getUniqueTopicString("topic-for-vw-thread-safety");
     int partitionCount = 1;
     PubSubTopic pubSubTopic = pubSubTopicRepository.getTopic(topicName);
     topicManager.createTopic(pubSubTopic, partitionCount, 1, true);

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
@@ -1187,7 +1187,6 @@ public class VeniceParentHelixAdmin implements Admin {
     List<PubSubTopic> outputList = new ArrayList<>();
     TopicManager topicManager = getTopicManager();
     Set<PubSubTopic> topics = topicManager.listTopics();
-    System.out.println(topics.stream().collect(Collectors.toList()).get(0));
     String storeNameForCurrentTopic;
     for (PubSubTopic topic: topics) {
       if (AdminTopicUtils.isAdminTopic(topic.getName()) || AdminTopicUtils.isKafkaInternalTopic(topic.getName())


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci], [server], [controller],
[router], [samza], [vpj], [fast-client], [thin-client], [alpini],
[admin-tool], [test], [build], [doc], [script]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Summary, imperative, start upper case, don't end with a period
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Previous refactoring of `TopicManager` cause these issues:
1) When `PubSubAdminAdapter` listing topics, the pubsub system could involve unsupported venice pub sub topic type
2) There is race condition inside PartitionOffsetFetcherImpl, as internal kafka consumer is not thread safe. 
3) When `TopicManager` updating min in-sync replica configuration, the integer config is not converted to string. 

This PR adds Unknown pub sub topic type to avoid listing topic failure, unify the lock usage inside `PartitionOffsetFetcher` to avoid `ConcurrentModificationException`, and adds back the integration test `TopicManagerITest` for `TopicManager` test by constructing the `PubSubBroker`. Besides, a test case for testing race condition of `PartitionOffsetFetcherImpl` has been added to `TopicManagerIntegrationTest`. 

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.