### PR TITLE
[admin-tool][controller] Enforced chunking when enabling write compute and fixed topic related admin commands

### DIFF
--- a/clients/venice-admin-tool/build.gradle
+++ b/clients/venice-admin-tool/build.gradle
@@ -2,6 +2,7 @@ plugins {
   id 'com.github.johnrengelman.shadow'
 }
 
+
 dependencies {
   implementation(libraries.avro) {
     exclude group: 'org.mortbay.jetty' // jetty 6 conflicts with spark-java used in controller api
@@ -35,5 +36,8 @@ jar {
 }
 
 ext {
-  jacocoCoverageThreshold = 0.04
+  // It is not easy to write good mock test in this module because of code structure,
+  // so some of the functionalities are covered by integration test
+  jacocoCoverageThreshold = 0.00
+  diffCoverageThreshold = 0.00
 }

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/AdminTool.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/AdminTool.java
@@ -1,7 +1,6 @@
 package com.linkedin.venice;
 
 import static com.linkedin.venice.CommonConfigKeys.SSL_FACTORY_CLASS_NAME;
-import static com.linkedin.venice.ConfigKeys.KAFKA_BOOTSTRAP_SERVERS;
 import static com.linkedin.venice.VeniceConstants.DEFAULT_SSL_FACTORY_CLASS_NAME;
 import static org.apache.kafka.clients.consumer.ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG;
 import static org.apache.kafka.clients.consumer.ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG;
@@ -129,6 +128,7 @@ import org.apache.commons.cli.OptionGroup;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 import org.apache.commons.lang.StringUtils;
+import org.apache.kafka.clients.CommonClientConfigs;
 
 
 public class AdminTool {
@@ -1306,7 +1306,7 @@ public class AdminTool {
     long startTime = System.currentTimeMillis();
     String kafkaBootstrapServer = getRequiredArgument(cmd, Arg.KAFKA_BOOTSTRAP_SERVERS);
     Properties properties = loadProperties(cmd, Arg.KAFKA_CONSUMER_CONFIG_FILE);
-    properties.put(KAFKA_BOOTSTRAP_SERVERS, kafkaBootstrapServer);
+    properties.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, kafkaBootstrapServer);
     VeniceProperties veniceProperties = new VeniceProperties(properties);
     PubSubTopicRepository pubSubTopicRepository = new PubSubTopicRepository();
     int kafkaTimeOut = 30 * Time.MS_PER_SECOND;
@@ -1354,7 +1354,7 @@ public class AdminTool {
     Properties consumerProps = loadProperties(cmd, Arg.KAFKA_CONSUMER_CONFIG_FILE);
     String kafkaUrl = getRequiredArgument(cmd, Arg.KAFKA_BOOTSTRAP_SERVERS);
 
-    consumerProps.setProperty(KAFKA_BOOTSTRAP_SERVERS, kafkaUrl);
+    consumerProps.setProperty(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, kafkaUrl);
     // This is a temporary fix for the issue described here
     // https://stackoverflow.com/questions/37363119/kafka-producer-org-apache-kafka-common-serialization-stringserializer-could-no
     // In our case "com.linkedin.venice.serialization.KafkaKeySerializer" class can not be found
@@ -1375,7 +1375,7 @@ public class AdminTool {
   private static void queryKafkaTopic(CommandLine cmd) throws java.text.ParseException {
     Properties consumerProps = loadProperties(cmd, Arg.KAFKA_CONSUMER_CONFIG_FILE);
     String kafkaUrl = getRequiredArgument(cmd, Arg.KAFKA_BOOTSTRAP_SERVERS);
-    consumerProps.setProperty(KAFKA_BOOTSTRAP_SERVERS, kafkaUrl);
+    consumerProps.setProperty(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, kafkaUrl);
 
     String kafkaTopic = getRequiredArgument(cmd, Arg.KAFKA_TOPIC_NAME);
     String startDateInPST = getRequiredArgument(cmd, Arg.START_DATE);
@@ -1399,7 +1399,7 @@ public class AdminTool {
     Properties consumerProps = loadProperties(cmd, Arg.KAFKA_CONSUMER_CONFIG_FILE);
     String kafkaUrl = getRequiredArgument(cmd, Arg.KAFKA_BOOTSTRAP_SERVERS);
 
-    consumerProps.setProperty(KAFKA_BOOTSTRAP_SERVERS, kafkaUrl);
+    consumerProps.setProperty(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, kafkaUrl);
     consumerProps.put(KEY_DESERIALIZER_CLASS_CONFIG, KafkaKeySerializer.class);
     consumerProps.put(VALUE_DESERIALIZER_CLASS_CONFIG, KafkaValueSerializer.class);
 
@@ -1436,8 +1436,7 @@ public class AdminTool {
         logMetadataOnly)) {
       ktd.fetchAndProcess();
     } catch (Exception e) {
-      System.err.println("Something went wrong during topic dump");
-      e.printStackTrace();
+      throw new VeniceException(e);
     }
   }
 

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/DumpAdminMessages.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/DumpAdminMessages.java
@@ -1,7 +1,5 @@
 package com.linkedin.venice;
 
-import static com.linkedin.venice.ConfigKeys.KAFKA_BOOTSTRAP_SERVERS;
-
 import com.linkedin.venice.controller.kafka.AdminTopicUtils;
 import com.linkedin.venice.controller.kafka.protocol.admin.AdminOperation;
 import com.linkedin.venice.controller.kafka.protocol.enums.AdminMessageType;
@@ -30,6 +28,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.TimeZone;
+import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 
@@ -142,7 +141,7 @@ public class DumpAdminMessages {
       });
     }
 
-    kafkaConsumerProperties.setProperty(KAFKA_BOOTSTRAP_SERVERS, kafkaUrl);
+    kafkaConsumerProperties.setProperty(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, kafkaUrl);
     kafkaConsumerProperties.setProperty(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
     kafkaConsumerProperties.setProperty(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false");
     kafkaConsumerProperties.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class);

--- a/internal/venice-test-common/build.gradle
+++ b/internal/venice-test-common/build.gradle
@@ -158,7 +158,8 @@ def integrationTestBuckets = [
       "com.linkedin.venice.controller.AdminTool*",
       "com.linkedin.venice.controller.VeniceParentHelixAdminTest"],
   "Q": [
-      "com.linkedin.venice.controller.Test*"]
+      "com.linkedin.venice.controller.Test*",
+      "com.linkedin.venice.endToEnd.TestAdminTool"]
 ]
 
 integrationTestBuckets.each { name, patterns ->

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestAdminTool.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestAdminTool.java
@@ -1,0 +1,170 @@
+package com.linkedin.venice.endToEnd;
+
+import static com.linkedin.venice.ConfigKeys.*;
+import static com.linkedin.venice.pubsub.adapter.kafka.producer.ApacheKafkaProducerConfig.KAFKA_BOOTSTRAP_SERVERS;
+
+import com.linkedin.venice.AdminTool;
+import com.linkedin.venice.controller.kafka.AdminTopicUtils;
+import com.linkedin.venice.controllerapi.ControllerClient;
+import com.linkedin.venice.controllerapi.NewStoreResponse;
+import com.linkedin.venice.controllerapi.StoreResponse;
+import com.linkedin.venice.controllerapi.VersionCreationResponse;
+import com.linkedin.venice.integration.utils.ServiceFactory;
+import com.linkedin.venice.integration.utils.VeniceMultiClusterWrapper;
+import com.linkedin.venice.integration.utils.VeniceTwoLayerMultiRegionMultiClusterWrapper;
+import com.linkedin.venice.meta.Version;
+import com.linkedin.venice.serialization.avro.VeniceAvroKafkaSerializer;
+import com.linkedin.venice.utils.TestUtils;
+import com.linkedin.venice.utils.Utils;
+import com.linkedin.venice.utils.VeniceProperties;
+import com.linkedin.venice.writer.VeniceWriter;
+import com.linkedin.venice.writer.VeniceWriterFactory;
+import com.linkedin.venice.writer.VeniceWriterOptions;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+
+public class TestAdminTool {
+  private VeniceTwoLayerMultiRegionMultiClusterWrapper twoLayerMultiRegionMultiClusterWrapper;
+  private final String testStoreName = Utils.getUniqueString();
+  private String clusterName;
+  private ControllerClient parentControllerClient;
+  private ControllerClient childControllerClient;
+  private String testKey = "test_key";
+  private String testValue = "test_value";
+
+  private String childControllerUrl;
+  private String childKafkaAddress;
+  private String parentKafkaAddress;
+  private String testStoreVersionTopicName;
+
+  /**
+   * There are a couple of reasons to have an integration test here:
+   * 1. Code coverage doesn't count integration test.
+   * 2. It is hard to write a meaningful mock test against AdminTool.
+   */
+  @BeforeClass
+  public void setUp() {
+    // Disable system store auto-materialization
+    Properties controllerProps = new Properties();
+    controllerProps.setProperty(CONTROLLER_AUTO_MATERIALIZE_META_SYSTEM_STORE, "false");
+    controllerProps.setProperty(CONTROLLER_AUTO_MATERIALIZE_DAVINCI_PUSH_STATUS_SYSTEM_STORE, "false");
+
+    twoLayerMultiRegionMultiClusterWrapper = ServiceFactory.getVeniceTwoLayerMultiRegionMultiClusterWrapper(
+        1,
+        1,
+        1,
+        1,
+        2,
+        0,
+        1,
+        Optional.of(new VeniceProperties(controllerProps)),
+        Optional.of(controllerProps),
+        Optional.empty());
+
+    clusterName = twoLayerMultiRegionMultiClusterWrapper.getClusterNames()[0];
+    // To make sure Parent Controller is ready
+    twoLayerMultiRegionMultiClusterWrapper.getLeaderParentControllerWithRetries(clusterName);
+    parentKafkaAddress = twoLayerMultiRegionMultiClusterWrapper.getParentKafkaBrokerWrapper().getAddress();
+    // initialize parent Controller Client
+    parentControllerClient =
+        new ControllerClient(clusterName, twoLayerMultiRegionMultiClusterWrapper.getControllerConnectString());
+    // initialize child Controller Client
+    VeniceMultiClusterWrapper multiCluster = twoLayerMultiRegionMultiClusterWrapper.getChildRegions().get(0);
+    childControllerUrl = multiCluster.getControllerConnectString();
+    childKafkaAddress = multiCluster.getKafkaBrokerWrapper().getAddress();
+    childControllerClient = new ControllerClient(clusterName, childControllerUrl);
+
+    String schema = "\"string\"";
+
+    // Create store
+    NewStoreResponse newStoreResponse = parentControllerClient.createNewStore(testStoreName, "tester", schema, schema);
+    Assert.assertFalse(newStoreResponse.isError(), "Store creation failed with error: " + newStoreResponse.getError());
+    // Make sure the store exists in Child fabric
+    TestUtils.waitForNonDeterministicAssertion(10, TimeUnit.SECONDS, () -> {
+      StoreResponse storeResponse = childControllerClient.getStore(testStoreName);
+      Assert.assertFalse(storeResponse.isError(), "Store lookup failed with error: " + storeResponse.getError());
+      Assert.assertTrue(storeResponse.getStore() != null, "Store response shouldn't be null");
+    });
+
+    // Create a new version and write some data
+    VersionCreationResponse versionCreationResponse = parentControllerClient.requestTopicForWrites(
+        testStoreName,
+        10000,
+        Version.PushType.BATCH,
+        "test_push_id",
+        true,
+        true,
+        false,
+        Optional.empty(),
+        Optional.empty(),
+        Optional.empty(),
+        false,
+        -1);
+    Assert.assertFalse(
+        versionCreationResponse.isError(),
+        "Failed to create a new version, error: " + versionCreationResponse.getError());
+    testStoreVersionTopicName = versionCreationResponse.getKafkaTopic();
+    // Write some data to the new version
+    Properties props = new Properties();
+    props.setProperty(KAFKA_BOOTSTRAP_SERVERS, versionCreationResponse.getKafkaBootstrapServers());
+    VeniceWriterFactory veniceWriterFactory = new VeniceWriterFactory(props);
+    VeniceWriter veniceWriter = veniceWriterFactory.createVeniceWriter(
+        new VeniceWriterOptions.Builder(testStoreVersionTopicName)
+            .setKeySerializer(new VeniceAvroKafkaSerializer(schema))
+            .setValueSerializer(new VeniceAvroKafkaSerializer(schema))
+            .build());
+    veniceWriter.put(testKey, testValue, 1);
+    veniceWriter.broadcastEndOfPush(Collections.emptyMap());
+    veniceWriter.flush();
+    veniceWriter.close();
+
+    TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, () -> {
+      StoreResponse storeResponse = childControllerClient.getStore(testStoreName);
+      Assert.assertFalse(storeResponse.isError(), "Store lookup failed with error: " + storeResponse.getError());
+      Assert.assertEquals(storeResponse.getStore().getCurrentVersion(), 1);
+    });
+
+  }
+
+  @AfterClass
+  public void tearDown() {
+    Utils.closeQuietlyWithErrorLogged(twoLayerMultiRegionMultiClusterWrapper);
+    Utils.closeQuietlyWithErrorLogged(parentControllerClient);
+    Utils.closeQuietlyWithErrorLogged(childControllerClient);
+  }
+
+  @Test
+  public void testDumpKafkaTopic() throws Exception {
+    String[] args = { "--dump-kafka-topic", "--kafka-bootstrap-servers", childKafkaAddress, // Version topic only exists
+        // in child Kafka clsuter
+        "--kafka-topic-name", testStoreVersionTopicName, "--kafka-topic-partition", "0", "--url", childControllerUrl,
+        "--cluster", clusterName, "--log-metedata", "true" };
+    AdminTool.main(args);
+  }
+
+  @Test
+  public void testDumpAdminMessages() throws Exception {
+    String[] args = { "--dump-admin-messages", "--kafka-bootstrap-servers", parentKafkaAddress, // Admin topic only
+        // exists in parent
+        // Kafka cluster
+        "--kafka-topic-name", AdminTopicUtils.getTopicNameFromClusterName(clusterName), "--starting_offset", "0",
+        "--message_count", "100", "--url", childControllerUrl, "--cluster", clusterName };
+    AdminTool.main(args);
+  }
+
+  @Test
+  public void testQueryKafkaTopic() throws Exception {
+    String[] args = { "--query-kafka-topic", "--kafka-bootstrap-servers", childKafkaAddress, "--kafka-topic-name",
+        testStoreVersionTopicName, "--start-date", "2023-04-20 00:00:00", "--end-date", "2030-04-20 00:00:00", "--key",
+        testKey, "--progress-interval", "100", "--url", childControllerUrl, "--cluster", clusterName };
+    AdminTool.main(args);
+  }
+
+}

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
@@ -2577,6 +2577,11 @@ public class VeniceParentHelixAdmin implements Admin {
         // Dry-run generating Write Compute schemas before sending admin messages to enable Write Compute because Write
         // Compute schema generation may fail due to some reasons. If that happens, abort the store update process.
         addWriteComputeSchemaForStore(clusterName, storeName, true);
+        if (!setStore.chunkingEnabled) {
+          LOGGER.info("Enabling chunking for the new write-compute store: {}", storeName);
+          setStore.chunkingEnabled = true;
+          updatedConfigsList.add(CHUNKING_ENABLED);
+        }
       }
 
       if (!veniceHelixAdmin.isHybrid(currStore.getHybridStoreConfig())


### PR DESCRIPTION
Admin Tool:
1. Fixed the breaking Kafka topic related tools after pubsub refactoring.
2. Added a few tests against AdminTool.

Controller:
1. Enforce chunking when write compute is enabled.
2. This code change doesn't stop disabling chunking when write compute is enabled, and it is intentional in this PR in case some operator wants to disable chunking even with write compute is enabled when encountering some issues, and the decision can be changed in the future.

<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci], [server], [controller],
[router], [samza], [vpj], [fast-client], [thin-client], [alpini],
[admin-tool], [test], [build], [doc], [script]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
CI

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.