### PR TITLE
[client] Re-use BinaryEncoder/OutputStream for serialization by default

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -453,6 +453,7 @@ subprojects {
         }
       }
 
+      diffCoverage.dependsOn jacocoTestReport
       diffCoverage.finalizedBy logDiffCoverage
     }
   }

--- a/build.gradle
+++ b/build.gradle
@@ -636,6 +636,7 @@ ext.createDiffFile = { ->
         ':!internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerClient.java',
         ':!services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceController.java',
         ':!services/venice-router/src/main/java/com/linkedin/venice/router/RouterServer.java',
+        ':!services/venice-router/src/main/java/com/linkedin/venice/router/streaming/VeniceChunkedResponse.java',
         ':!services/venice-standalone/*', // exclude the entire standalone project
         ':!clients/venice-client/src/main/java/com/linkedin/venice/fastclient/factory/ClientFactory.java',
         ':!clients/da-vinci-client/src/main/java/com/linkedin/davinci/DaVinciBackend.java',

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/VersionBackend.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/VersionBackend.java
@@ -235,7 +235,7 @@ public class VersionBackend {
   }
 
   public void computeWithKeyPrefixFilter(
-      byte[] prefixBytes,
+      byte[] keyPrefix,
       int partition,
       StreamingCallback<GenericRecord, GenericRecord> callback,
       ComputeRequestWrapper computeRequestWrapper,
@@ -273,7 +273,7 @@ public class VersionBackend {
         getStorageEngineOrThrow(),
         partition,
         version.getPartitionerConfig(),
-        prefixBytes,
+        keyPrefix,
         reusableValueRecord,
         reusableBinaryDecoder,
         keyRecordDeserializer,

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/client/DelegatingAvroGenericDaVinciClient.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/client/DelegatingAvroGenericDaVinciClient.java
@@ -7,14 +7,12 @@ import com.linkedin.venice.client.store.ComputeGenericRecord;
 import com.linkedin.venice.client.store.ComputeRequestBuilder;
 import com.linkedin.venice.client.store.streaming.StreamingCallback;
 import com.linkedin.venice.compute.ComputeRequestWrapper;
-import java.io.ByteArrayOutputStream;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericRecord;
-import org.apache.avro.io.BinaryEncoder;
 
 
 /**
@@ -109,25 +107,6 @@ public class DelegatingAvroGenericDaVinciClient<K, V>
       StreamingCallback<K, ComputeGenericRecord> callback,
       long preRequestTimeInNS) throws VeniceClientException {
     delegate.compute(computeRequestWrapper, keys, resultSchema, callback, preRequestTimeInNS);
-  }
-
-  @Override
-  public void compute(
-      ComputeRequestWrapper computeRequestWrapper,
-      Set<K> keys,
-      Schema resultSchema,
-      StreamingCallback<K, ComputeGenericRecord> callback,
-      long preRequestTimeInNS,
-      BinaryEncoder reusedEncoder,
-      ByteArrayOutputStream reusedOutputStream) throws VeniceClientException {
-    delegate.compute(
-        computeRequestWrapper,
-        keys,
-        resultSchema,
-        callback,
-        preRequestTimeInNS,
-        reusedEncoder,
-        reusedOutputStream);
   }
 
   @Override

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreWriteComputeProcessor.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreWriteComputeProcessor.java
@@ -75,7 +75,7 @@ public class StoreWriteComputeProcessor {
     if (updatedValue == null) {
       return null;
     }
-    return getValueSerializer(valueSchema).serialize(updatedValue, AvroSerializer.REUSE.get());
+    return getValueSerializer(valueSchema).serialize(updatedValue);
   }
 
   private ValueAndWriteComputeSchemas getValueAndWriteComputeSchemas(int valueSchemaId, int writeComputeSchemaId) {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/listener/response/AdminResponse.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/listener/response/AdminResponse.java
@@ -7,7 +7,6 @@ import com.linkedin.venice.admin.protocol.response.ServerConfigSnapshot;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.kafka.protocol.state.StoreVersionState;
 import com.linkedin.venice.serialization.avro.AvroProtocolDefinition;
-import com.linkedin.venice.serializer.AvroSerializer;
 import com.linkedin.venice.serializer.RecordSerializer;
 import com.linkedin.venice.serializer.SerializerDeserializerFactory;
 import io.netty.buffer.ByteBuf;
@@ -96,8 +95,7 @@ public class AdminResponse {
   public byte[] serializedResponse() {
     RecordSerializer<AdminResponseRecord> serializer =
         SerializerDeserializerFactory.getAvroGenericSerializer(AdminResponseRecord.SCHEMA$);
-
-    return serializer.serialize(this.responseRecord, AvroSerializer.REUSE.get());
+    return serializer.serialize(this.responseRecord);
   }
 
   public int getResponseSchemaIdHeader() {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/listener/response/MetadataResponse.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/listener/response/MetadataResponse.java
@@ -3,7 +3,6 @@ package com.linkedin.davinci.listener.response;
 import com.linkedin.venice.metadata.response.MetadataResponseRecord;
 import com.linkedin.venice.metadata.response.VersionProperties;
 import com.linkedin.venice.serialization.avro.AvroProtocolDefinition;
-import com.linkedin.venice.serializer.AvroSerializer;
 import com.linkedin.venice.serializer.RecordSerializer;
 import com.linkedin.venice.serializer.SerializerDeserializerFactory;
 import io.netty.buffer.ByteBuf;
@@ -59,8 +58,7 @@ public class MetadataResponse {
   private byte[] serializedResponse() {
     RecordSerializer<MetadataResponseRecord> serializer =
         SerializerDeserializerFactory.getAvroGenericSerializer(MetadataResponseRecord.SCHEMA$);
-
-    return serializer.serialize(responseRecord, AvroSerializer.REUSE.get());
+    return serializer.serialize(responseRecord);
   }
 
   public int getResponseSchemaIdHeader() {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/replication/merge/MergeGenericRecord.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/replication/merge/MergeGenericRecord.java
@@ -2,7 +2,7 @@ package com.linkedin.davinci.replication.merge;
 
 import static com.linkedin.venice.schema.rmd.RmdConstants.TIMESTAMP_FIELD_NAME;
 
-import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
+import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelperCommon;
 import com.linkedin.avroutil1.compatibility.AvroVersion;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.schema.merge.MergeRecordHelper;
@@ -30,7 +30,7 @@ import org.apache.commons.lang.Validate;
  * 3. Assumes new value to be GenericRecord type, does not support non-record values.
  */
 public class MergeGenericRecord extends AbstractMerge<GenericRecord> {
-  private static final AvroVersion RUNTIME_AVRO_VERSION = AvroCompatibilityHelper.getRuntimeAvroVersion();
+  private static final AvroVersion RUNTIME_AVRO_VERSION = AvroCompatibilityHelperCommon.getRuntimeAvroVersion();
   private final WriteComputeProcessor writeComputeProcessor;
   private final MergeRecordHelper mergeRecordHelper;
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/replication/merge/RmdSerDe.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/replication/merge/RmdSerDe.java
@@ -4,7 +4,6 @@ import com.linkedin.davinci.replication.RmdWithValueSchemaId;
 import com.linkedin.venice.annotation.Threadsafe;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.schema.rmd.RmdSchemaEntry;
-import com.linkedin.venice.serializer.AvroSerializer;
 import com.linkedin.venice.serializer.RecordDeserializer;
 import com.linkedin.venice.serializer.RecordSerializer;
 import com.linkedin.venice.serializer.avro.MapOrderingPreservingSerDeFactory;
@@ -67,7 +66,7 @@ public class RmdSerDe {
   }
 
   public ByteBuffer serializeRmdRecord(final int valueSchemaId, GenericRecord rmdRecord) {
-    byte[] rmdBytes = getRmdSerializer(valueSchemaId).serialize(rmdRecord, AvroSerializer.REUSE.get());
+    byte[] rmdBytes = getRmdSerializer(valueSchemaId).serialize(rmdRecord);
     return ByteBuffer.wrap(rmdBytes);
   }
 

--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/DispatchingAvroGenericStoreClient.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/DispatchingAvroGenericStoreClient.java
@@ -19,7 +19,6 @@ import com.linkedin.venice.fastclient.transport.TransportClientResponseForRoute;
 import com.linkedin.venice.read.protocol.request.router.MultiGetRouterRequestKeyV1;
 import com.linkedin.venice.read.protocol.response.MultiGetResponseRecordV1;
 import com.linkedin.venice.schema.avro.ReadAvroProtocolDefinition;
-import com.linkedin.venice.serializer.AvroSerializer;
 import com.linkedin.venice.serializer.FastSerializerDeserializerFactory;
 import com.linkedin.venice.serializer.RecordDeserializer;
 import com.linkedin.venice.serializer.RecordSerializer;
@@ -90,7 +89,7 @@ public class DispatchingAvroGenericStoreClient<K, V> extends InternalAvroStoreCl
     int currentVersion = getCurrentVersion();
     String resourceName = getResourceName(currentVersion);
     long beforeSerializationTimeStamp = System.nanoTime();
-    byte[] keyBytes = keySerializer.serialize(key, AvroSerializer.REUSE.get());
+    byte[] keyBytes = keySerializer.serialize(key);
     requestContext.requestSerializationTime = getLatencyInNS(beforeSerializationTimeStamp);
     int partitionId = metadata.getPartitionId(currentVersion, keyBytes);
     String b64EncodedKeyBytes = EncodingUtils.base64EncodeToString(keyBytes);
@@ -398,9 +397,8 @@ public class DispatchingAvroGenericStoreClient<K, V> extends InternalAvroStoreCl
     String uriForBatchGetRequest = composeURIForBatchGetRequest(requestContext);
     int currentVersion = requestContext.currentVersion;
     Map<Integer, List<String>> partitionRouteMap = new HashMap<>();
-    RecordSerializer.ReusableObjects reusableObjects = AvroSerializer.REUSE.get();
     for (K key: keys) {
-      byte[] keyBytes = keySerializer.serialize(key, reusableObjects);
+      byte[] keyBytes = keySerializer.serialize(key);
       // For each key determine partition
       int partitionId = metadata.getPartitionId(currentVersion, keyBytes);
       // Find routes for each partition
@@ -579,12 +577,11 @@ public class DispatchingAvroGenericStoreClient<K, V> extends InternalAvroStoreCl
 
   private byte[] serializeMultiGetRequest(List<BatchGetRequestContext.KeyInfo<K>> keyList) {
     List<MultiGetRouterRequestKeyV1> routerRequestKeys = new ArrayList<>(keyList.size());
-    AvroSerializer.ReusableObjects reusableObjects = AvroSerializer.REUSE.get();
     BatchGetRequestContext.KeyInfo<K> keyInfo;
     for (int i = 0; i < keyList.size(); i++) {
       keyInfo = keyList.get(i);
       MultiGetRouterRequestKeyV1 routerRequestKey = new MultiGetRouterRequestKeyV1();
-      byte[] keyBytes = keySerializer.serialize(keyInfo.getKey(), reusableObjects);
+      byte[] keyBytes = keySerializer.serialize(keyInfo.getKey());
       ByteBuffer keyByteBuffer = ByteBuffer.wrap(keyBytes);
       routerRequestKey.keyBytes = keyByteBuffer;
       routerRequestKey.keyIndex = i;

--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/InternalAvroStoreClient.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/InternalAvroStoreClient.java
@@ -33,7 +33,7 @@ public abstract class InternalAvroStoreClient<K, V> implements AvroGenericStoreC
    */
   public CompletableFuture<Map<K, V>> batchGet(Set<K> keys) throws VeniceClientException {
 
-    // Uncomment below line when batchGet with streaming has stabillized
+    // Uncomment below line when batchGet with streaming has stabilized
     // return batchGet(new BatchGetRequestContext<K,V>(keys), keys);
     throw new VeniceClientException("'batchGet' is not supported.");
   }
@@ -41,11 +41,11 @@ public abstract class InternalAvroStoreClient<K, V> implements AvroGenericStoreC
   protected abstract CompletableFuture<Map<K, V>> batchGet(BatchGetRequestContext<K, V> requestContext, Set<K> keys)
       throws VeniceClientException;
 
-  public void streamingBatchGet(final Set<K> keys, StreamingCallback<K, V> callback) throws VeniceClientException {
+  public void streamingBatchGet(Set<K> keys, StreamingCallback<K, V> callback) throws VeniceClientException {
     streamingBatchGet(new BatchGetRequestContext<K, V>(), keys, callback);
   }
 
-  public CompletableFuture<VeniceResponseMap<K, V>> streamingBatchGet(final Set<K> keys) throws VeniceClientException {
+  public CompletableFuture<VeniceResponseMap<K, V>> streamingBatchGet(Set<K> keys) throws VeniceClientException {
     return streamingBatchGet(new BatchGetRequestContext<K, V>(), keys);
   }
 

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/input/kafka/VeniceKafkaInputMapper.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/input/kafka/VeniceKafkaInputMapper.java
@@ -9,7 +9,6 @@ import com.linkedin.venice.hadoop.VenicePushJob;
 import com.linkedin.venice.hadoop.input.kafka.avro.KafkaInputMapperKey;
 import com.linkedin.venice.hadoop.input.kafka.avro.KafkaInputMapperValue;
 import com.linkedin.venice.hadoop.input.kafka.ttl.VeniceKafkaInputTTLFilter;
-import com.linkedin.venice.serializer.AvroSerializer;
 import com.linkedin.venice.serializer.FastSerializerDeserializerFactory;
 import com.linkedin.venice.serializer.RecordSerializer;
 import com.linkedin.venice.utils.VeniceProperties;
@@ -68,9 +67,9 @@ public class VeniceKafkaInputMapper extends AbstractVeniceMapper<KafkaInputMappe
       MRJobCounterHelper.incrRepushTtlFilterCount(reporter, 1L);
       return false;
     }
-    byte[] serializedKey = KAFKA_INPUT_MAPPER_KEY_SERIALIZER.serialize(inputKey, AvroSerializer.REUSE.get());
+    byte[] serializedKey = KAFKA_INPUT_MAPPER_KEY_SERIALIZER.serialize(inputKey);
     keyBW.set(serializedKey, 0, serializedKey.length);
-    byte[] serializedValue = KAFKA_INPUT_MAPPER_VALUE_SERIALIZER.serialize(inputValue, AvroSerializer.REUSE.get());
+    byte[] serializedValue = KAFKA_INPUT_MAPPER_VALUE_SERIALIZER.serialize(inputValue);
     valueBW.set(serializedValue, 0, serializedValue.length);
     return true;
   }

--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/AbstractAvroStoreClient.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/AbstractAvroStoreClient.java
@@ -36,7 +36,6 @@ import com.linkedin.venice.read.protocol.response.streaming.StreamingFooterRecor
 import com.linkedin.venice.schema.SchemaData;
 import com.linkedin.venice.schema.SchemaReader;
 import com.linkedin.venice.schema.avro.ReadAvroProtocolDefinition;
-import com.linkedin.venice.serializer.AvroSerializer;
 import com.linkedin.venice.serializer.FastSerializerDeserializerFactory;
 import com.linkedin.venice.serializer.RecordDeserializer;
 import com.linkedin.venice.serializer.RecordSerializer;
@@ -47,11 +46,11 @@ import com.linkedin.venice.utils.DaemonThreadFactory;
 import com.linkedin.venice.utils.EncodingUtils;
 import com.linkedin.venice.utils.LatencyUtils;
 import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.BitSet;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -68,7 +67,6 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericRecord;
-import org.apache.avro.io.BinaryEncoder;
 import org.apache.commons.codec.binary.Hex;
 import org.apache.commons.io.IOUtils;
 import org.apache.logging.log4j.LogManager;
@@ -146,18 +144,11 @@ public abstract class AbstractAvroStoreClient<K, V> extends InternalAvroStoreCli
   private RecordDeserializer<StreamingFooterRecordV1> streamingFooterRecordDeserializer;
 
   private TransportClient transportClient;
-  private final String storeName;
   private final Executor deserializationExecutor;
   private final BatchDeserializer<MultiGetResponseRecordV1, K, V> batchGetDeserializer;
   private final BatchDeserializer<ComputeResponseRecordV1, K, GenericRecord> computeDeserializer;
-
   private final CompressorFactory compressorFactory;
 
-  private final boolean useFastAvro;
-
-  private final boolean reuseObjectsForSerialization;
-
-  private final boolean forceClusterDiscoveryAtStartTime;
   private volatile boolean isServiceDiscovered;
 
   /**
@@ -203,26 +194,22 @@ public abstract class AbstractAvroStoreClient<K, V> extends InternalAvroStoreCli
       boolean needSchemaReader,
       ClientConfig clientConfig) {
     this.transportClient = transportClient;
-    this.storeName = clientConfig.getStoreName();
     this.clientConfig = clientConfig;
     this.needSchemaReader = needSchemaReader;
     this.deserializationExecutor =
         Optional.ofNullable(clientConfig.getDeserializationExecutor()).orElse(getDefaultDeserializationExecutor());
     this.batchGetDeserializer = clientConfig.getBatchGetDeserializer(this.deserializationExecutor);
     this.computeDeserializer = clientConfig.getBatchGetDeserializer(this.deserializationExecutor);
-    this.useFastAvro = clientConfig.isUseFastAvro();
-    this.reuseObjectsForSerialization = clientConfig.isReuseObjectsForSerialization();
-    this.forceClusterDiscoveryAtStartTime = clientConfig.isForceClusterDiscoveryAtStartTime();
     this.compressorFactory = new CompressorFactory();
-  }
-
-  protected final boolean isUseFastAvro() {
-    return useFastAvro;
   }
 
   @Override
   public String getStoreName() {
-    return storeName;
+    return clientConfig.getStoreName();
+  }
+
+  protected final ClientConfig getClientConfig() {
+    return clientConfig;
   }
 
   protected TransportClient getTransportClient() {
@@ -244,11 +231,11 @@ public abstract class AbstractAvroStoreClient<K, V> extends InternalAvroStoreCli
   }
 
   private String getStorageRequestPath() {
-    return TYPE_STORAGE + "/" + storeName;
+    return TYPE_STORAGE + "/" + getStoreName();
   }
 
   protected String getComputeRequestPath() {
-    return TYPE_COMPUTE + "/" + storeName;
+    return TYPE_COMPUTE + "/" + getStoreName();
   }
 
   // For testing
@@ -266,7 +253,7 @@ public abstract class AbstractAvroStoreClient<K, V> extends InternalAvroStoreCli
     }
     if (whetherStoreInitTriggeredByRequestFail) {
       // Store init already fails.
-      throw new VeniceClientException("Failed to init store client for store: " + storeName);
+      throw new VeniceClientException("Failed to init store client for store: " + getStoreName());
     }
     synchronized (this) {
       try {
@@ -354,7 +341,7 @@ public abstract class AbstractAvroStoreClient<K, V> extends InternalAvroStoreCli
           lastException = e;
         }
       }
-      throw new VeniceException("Failed to initializing Venice Client for store: " + storeName, lastException);
+      throw new VeniceException("Failed to initializing Venice Client for store: " + getStoreName(), lastException);
     }
   }
 
@@ -378,7 +365,7 @@ public abstract class AbstractAvroStoreClient<K, V> extends InternalAvroStoreCli
       }
       if (transportClient instanceof D2TransportClient) {
         D2TransportClient client = (D2TransportClient) transportClient;
-        client.setServiceName(new D2ServiceDiscovery().find(client, storeName, retryOnFailure).getD2Service());
+        client.setServiceName(new D2ServiceDiscovery().find(client, getStoreName(), retryOnFailure).getD2Service());
       }
       isServiceDiscovered = true;
     }
@@ -389,18 +376,18 @@ public abstract class AbstractAvroStoreClient<K, V> extends InternalAvroStoreCli
     if (needSchemaReader) {
       if (getSchemaReader() != null) {
         // init multi-get request serializer
-        this.multiGetRequestSerializer = useFastAvro
+        this.multiGetRequestSerializer = getClientConfig().isUseFastAvro()
             ? FastSerializerDeserializerFactory
                 .getAvroGenericSerializer(ReadAvroProtocolDefinition.MULTI_GET_CLIENT_REQUEST_V1.getSchema())
             : SerializerDeserializerFactory
                 .getAvroGenericSerializer(ReadAvroProtocolDefinition.MULTI_GET_CLIENT_REQUEST_V1.getSchema());
         // init compute request serializer
-        this.computeRequestClientKeySerializer = useFastAvro
+        this.computeRequestClientKeySerializer = getClientConfig().isUseFastAvro()
             ? FastSerializerDeserializerFactory
                 .getAvroGenericSerializer(ReadAvroProtocolDefinition.COMPUTE_REQUEST_CLIENT_KEY_V1.getSchema())
             : SerializerDeserializerFactory
                 .getAvroGenericSerializer(ReadAvroProtocolDefinition.COMPUTE_REQUEST_CLIENT_KEY_V1.getSchema());
-        this.streamingFooterRecordDeserializer = useFastAvro
+        this.streamingFooterRecordDeserializer = getClientConfig().isUseFastAvro()
             ? FastSerializerDeserializerFactory
                 .getFastAvroSpecificDeserializer(StreamingFooterRecordV1.SCHEMA$, StreamingFooterRecordV1.class)
             : SerializerDeserializerFactory
@@ -409,7 +396,7 @@ public abstract class AbstractAvroStoreClient<K, V> extends InternalAvroStoreCli
          * It is intentional to initialize {@link keySerializer} at last, so that other serializers are ready to use
          * once {@link keySerializer} is ready.
          */
-        this.keySerializer = useFastAvro
+        this.keySerializer = getClientConfig().isUseFastAvro()
             ? FastSerializerDeserializerFactory.getAvroGenericSerializer(getSchemaReader().getKeySchema())
             : SerializerDeserializerFactory.getAvroGenericSerializer(getSchemaReader().getKeySchema());
       } else {
@@ -425,11 +412,9 @@ public abstract class AbstractAvroStoreClient<K, V> extends InternalAvroStoreCli
   }
 
   @Override
-  public CompletableFuture<V> get(final K key, final Optional<ClientStats> stats, final long preRequestTimeInNS)
+  public CompletableFuture<V> get(K key, Optional<ClientStats> stats, long preRequestTimeInNS)
       throws VeniceClientException {
-    byte[] serializedKey = reuseObjectsForSerialization
-        ? getKeySerializerForRequest().serialize(key, AvroSerializer.REUSE.get())
-        : getKeySerializerForRequest().serialize(key);
+    byte[] serializedKey = getKeySerializerForRequest().serialize(key);
     String requestPath = getStorageRequestPathForSingleKey(serializedKey);
     CompletableFuture<V> valueFuture = new CompletableFuture<>();
 
@@ -512,19 +497,11 @@ public abstract class AbstractAvroStoreClient<K, V> extends InternalAvroStoreCli
 
   private byte[] serializeMultiGetRequest(List<K> keyList) {
     List<ByteBuffer> serializedKeyList = new ArrayList<>(keyList.size());
-    RecordSerializer serializer = getKeySerializerForRequest();
-    if (reuseObjectsForSerialization) {
-      AvroSerializer.ReusableObjects reusableObjects = AvroSerializer.REUSE.get();
-      for (int i = 0; i < keyList.size(); i++) {
-        serializedKeyList.add(ByteBuffer.wrap(serializer.serialize(keyList.get(i), reusableObjects)));
-      }
-      return multiGetRequestSerializer.serializeObjects(serializedKeyList, reusableObjects);
-    } else {
-      for (int i = 0; i < keyList.size(); i++) {
-        serializedKeyList.add(ByteBuffer.wrap(serializer.serialize(keyList.get(i))));
-      }
-      return multiGetRequestSerializer.serializeObjects(serializedKeyList);
+    RecordSerializer<K> keySerializer = getKeySerializerForRequest();
+    for (K key: keyList) {
+      serializedKeyList.add(ByteBuffer.wrap(keySerializer.serialize(key)));
     }
+    return multiGetRequestSerializer.serializeObjects(serializedKeyList);
   }
 
   private <T> T tryToDeserialize(RecordDeserializer<T> dataDeserializer, ByteBuffer data, int writerSchemaId, K key) {
@@ -565,7 +542,7 @@ public abstract class AbstractAvroStoreClient<K, V> extends InternalAvroStoreCli
       }
 
       try {
-        keyHex = Hex.encodeHexString(keySerializer.serialize(key, AvroSerializer.REUSE.get()));
+        keyHex = Hex.encodeHexString(keySerializer.serialize(key));
       } catch (Exception e3) {
         keyHex = "failed to serialize key and encode it as hex";
         LOGGER.error("{} ...", keyHex, e3);
@@ -610,11 +587,11 @@ public abstract class AbstractAvroStoreClient<K, V> extends InternalAvroStoreCli
    * @throws VeniceClientException
    */
   private <R> CompletableFuture<R> requestSubmissionWithStatsHandling(
-      final Optional<ClientStats> stats,
-      final long preRequestTimeInNS,
-      final boolean handleResponseOnDeserializationExecutor,
-      final Supplier<CompletableFuture<TransportClientResponse>> requestSubmitter,
-      final ResponseHandler<R> responseHandler) throws VeniceClientException {
+      Optional<ClientStats> stats,
+      long preRequestTimeInNS,
+      boolean handleResponseOnDeserializationExecutor,
+      Supplier<CompletableFuture<TransportClientResponse>> requestSubmitter,
+      ResponseHandler<R> responseHandler) throws VeniceClientException {
     final long preSubmitTimeInNS = System.nanoTime();
     CompletableFuture<TransportClientResponse> transportFuture = requestSubmitter.get();
 
@@ -651,50 +628,85 @@ public abstract class AbstractAvroStoreClient<K, V> extends InternalAvroStoreCli
   public ComputeRequestBuilder<K> compute(
       Optional<ClientStats> stats,
       Optional<ClientStats> streamingStats,
-      final long preRequestTimeInNS) {
+      long preRequestTimeInNS) {
     return compute(stats, streamingStats, this, preRequestTimeInNS);
   }
 
   @Override
   public ComputeRequestBuilder<K> compute(
-      final Optional<ClientStats> stats,
-      final Optional<ClientStats> streamingStats,
-      final InternalAvroStoreClient computeStoreClient,
-      final long preRequestTimeInNS) {
-    AbstractAvroComputeRequestBuilder<K> builder =
-        new AvroComputeRequestBuilderV3<K>(computeStoreClient, getLatestValueSchema()).setStats(streamingStats)
-            .setValidateProjectionFields(clientConfig.isProjectionFieldValidationEnabled());
-    if (reuseObjectsForSerialization) {
-      AvroSerializer.ReusableObjects reusableObjects = AvroSerializer.REUSE.get();
-      builder.setReuseObjects(reusableObjects.getBinaryEncoder(), reusableObjects.getByteArrayOutputStream());
+      Optional<ClientStats> stats,
+      Optional<ClientStats> streamingStats,
+      InternalAvroStoreClient computeStoreClient,
+      long preRequestTimeInNS) {
+    return new AvroComputeRequestBuilderV3<K>(computeStoreClient, getLatestValueSchema()).setStats(streamingStats)
+        .setValidateProjectionFields(getClientConfig().isProjectionFieldValidationEnabled());
+  }
+
+  @Override
+  public void compute(
+      ComputeRequestWrapper computeRequestWrapper,
+      Set<K> keys,
+      Schema resultSchema,
+      StreamingCallback<K, ComputeGenericRecord> callback,
+      long preRequestTimeInNS) throws VeniceClientException {
+    if (handleCallbackForEmptyKeySet(keys, callback)) {
+      // empty key set
+      return;
     }
-    return builder;
+
+    Optional<ClientStats> clientStats = Optional.empty();
+    if (callback instanceof TrackingStreamingCallback) {
+      clientStats = Optional.of(((TrackingStreamingCallback<K, V>) callback).getStats());
+    }
+
+    List<K> keyList = new ArrayList<>(keys);
+    long preRequestSerializationNanos = System.nanoTime();
+    byte[] serializedComputeRequest = serializeComputeRequest(computeRequestWrapper, keyList);
+    clientStats.ifPresent(
+        stats -> stats.recordRequestSerializationTime(LatencyUtils.getLatencyInMS(preRequestSerializationNanos)));
+
+    int schemaId = getSchemaReader().getValueSchemaId(computeRequestWrapper.getValueSchema());
+    Map<String, String> headerMap = new HashMap<>(
+        (computeRequestWrapper.getComputeRequestVersion() == COMPUTE_REQUEST_VERSION_V2)
+            ? COMPUTE_HEADER_MAP_FOR_STREAMING_V2
+            : COMPUTE_HEADER_MAP_FOR_STREAMING_V3);
+    headerMap.put(VENICE_KEY_COUNT, Integer.toString(keyList.size()));
+    headerMap.put(VENICE_COMPUTE_VALUE_SCHEMA_ID, Integer.toString(schemaId));
+
+    RecordDeserializer<GenericRecord> computeResultRecordDeserializer =
+        getComputeResultRecordDeserializer(resultSchema);
+
+    transportClient.streamPost(
+        getComputeRequestPath(),
+        headerMap,
+        serializedComputeRequest,
+        new StoreClientStreamingCallback<>(keyList, callback, envelopeSchemaId -> {
+          validateComputeResponseSchemaId(envelopeSchemaId);
+          return new ComputeResponseRecordV1ChunkedDeserializer();
+        },
+            // Compute doesn't support compression
+            (envelope, compressionStrategy) -> {
+              if (!envelope.value.hasRemaining()) {
+                // Safeguard to handle empty value, which indicates non-existing key.
+                return null;
+              }
+              return new ComputeGenericRecord(
+                  computeResultRecordDeserializer.deserialize(envelope.value),
+                  computeRequestWrapper.getValueSchema());
+            },
+            envelope -> envelope.keyIndex,
+            envelope -> streamingFooterRecordDeserializer.deserialize(envelope.value)),
+        keyList.size());
   }
 
-  private byte[] serializeComputeRequest(List<K> keyList, byte[] serializedComputeRequest) {
-    List<ByteBuffer> serializedKeyList = new ArrayList<>(keyList.size());
+  private byte[] serializeComputeRequest(ComputeRequestWrapper computeRequestWrapper, Collection<K> keys) {
     RecordSerializer keySerializer = getKeySerializerForRequest();
-    keyList.stream().forEach(key -> serializedKeyList.add(ByteBuffer.wrap(keySerializer.serialize(key))));
-    return computeRequestClientKeySerializer
-        .serializeObjects(serializedKeyList, ByteBuffer.wrap(serializedComputeRequest));
-  }
-
-  private byte[] serializeComputeRequest(
-      List<K> keyList,
-      byte[] serializedComputeRequest,
-      BinaryEncoder reusedEncoder,
-      ByteArrayOutputStream reusedOutputStream) {
-    List<ByteBuffer> serializedKeyList = new ArrayList<>(keyList.size());
-    RecordSerializer keySerializer = getKeySerializerForRequest();
-    keyList.stream()
-        .forEach(
-            key -> serializedKeyList
-                .add(ByteBuffer.wrap(keySerializer.serialize(key, reusedEncoder, reusedOutputStream))));
-    return computeRequestClientKeySerializer.serializeObjects(
-        serializedKeyList,
-        ByteBuffer.wrap(serializedComputeRequest),
-        reusedEncoder,
-        reusedOutputStream);
+    List<ByteBuffer> serializedKeyList = new ArrayList<>(keys.size());
+    ByteBuffer serializedComputeRequest = ByteBuffer.wrap(computeRequestWrapper.serialize());
+    for (K key: keys) {
+      serializedKeyList.add(ByteBuffer.wrap(keySerializer.serialize(key)));
+    }
+    return computeRequestClientKeySerializer.serializeObjects(serializedKeyList, serializedComputeRequest);
   }
 
   @Override
@@ -736,7 +748,7 @@ public abstract class AbstractAvroStoreClient<K, V> extends InternalAvroStoreCli
   public abstract RecordDeserializer<V> getDataRecordDeserializer(int schemaId) throws VeniceClientException;
 
   private void warmUpVeniceClient() {
-    if (forceClusterDiscoveryAtStartTime) {
+    if (getClientConfig().isForceClusterDiscoveryAtStartTime()) {
       /**
        * Force the client initialization and fail fast if any error happens.
        */
@@ -779,14 +791,14 @@ public abstract class AbstractAvroStoreClient<K, V> extends InternalAvroStoreCli
   }
 
   private RecordDeserializer<GenericRecord> getComputeResultRecordDeserializer(Schema resultSchema) {
-    if (useFastAvro) {
+    if (getClientConfig().isUseFastAvro()) {
       return FastSerializerDeserializerFactory.getFastAvroGenericDeserializer(resultSchema, resultSchema);
     }
     return SerializerDeserializerFactory.getAvroGenericDeserializer(resultSchema);
   }
 
   public String toString() {
-    return this.getClass().getSimpleName() + "(storeName: " + storeName + ", transportClient: "
+    return this.getClass().getSimpleName() + "(storeName: " + getStoreName() + ", transportClient: "
         + transportClient.toString() + ")";
   }
 
@@ -1056,14 +1068,15 @@ public abstract class AbstractAvroStoreClient<K, V> extends InternalAvroStoreCli
     if (callback instanceof TrackingStreamingCallback) {
       clientStats = Optional.of(((TrackingStreamingCallback<K, V>) callback).getStats());
     }
+
     List<K> keyList = new ArrayList<>(keys);
     long preRequestSerializationNS = System.nanoTime();
     byte[] multiGetBody = serializeMultiGetRequest(keyList);
     clientStats.ifPresent(
         stats -> stats.recordRequestSerializationTime(LatencyUtils.getLatencyInMS(preRequestSerializationNS)));
-    Map<Integer, RecordDeserializer<V>> deserializerCache = new VeniceConcurrentHashMap<>();
 
-    final Map<String, String> headerMap = new HashMap<>(MULTI_GET_HEADER_MAP_FOR_STREAMING);
+    Map<Integer, RecordDeserializer<V>> deserializerCache = new VeniceConcurrentHashMap<>();
+    Map<String, String> headerMap = new HashMap<>(MULTI_GET_HEADER_MAP_FOR_STREAMING);
     headerMap.put(VENICE_KEY_COUNT, Integer.toString(keyList.size()));
 
     transportClient.streamPost(
@@ -1083,79 +1096,6 @@ public abstract class AbstractAvroStoreClient<K, V> extends InternalAvroStoreCli
           ByteBuffer decompressedValue = decompressRecord(compressionStrategy, envelope.value);
           return recordDeserializer.deserialize(decompressedValue);
         }, envelope -> envelope.keyIndex, envelope -> streamingFooterRecordDeserializer.deserialize(envelope.value)),
-        keyList.size());
-  }
-
-  @Override
-  public void compute(
-      ComputeRequestWrapper computeRequestWrapper,
-      Set<K> keys,
-      Schema resultSchema,
-      StreamingCallback<K, ComputeGenericRecord> callback,
-      long preRequestTimeInNS) throws VeniceClientException {
-    compute(computeRequestWrapper, keys, resultSchema, callback, preRequestTimeInNS, null, null);
-  }
-
-  @Override
-  public void compute(
-      ComputeRequestWrapper computeRequestWrapper,
-      Set<K> keys,
-      Schema resultSchema,
-      StreamingCallback<K, ComputeGenericRecord> callback,
-      long preRequestTimeInNS,
-      BinaryEncoder reusedEncoder,
-      ByteArrayOutputStream reusedOutputStream) throws VeniceClientException {
-    if (handleCallbackForEmptyKeySet(keys, callback)) {
-      // empty key set
-      return;
-    }
-    Optional<ClientStats> clientStats = Optional.empty();
-    if (callback instanceof TrackingStreamingCallback) {
-      clientStats = Optional.of(((TrackingStreamingCallback<K, V>) callback).getStats());
-    }
-    long preRequestSerializationNS = System.nanoTime();
-    List<K> keyList = new ArrayList<>(keys);
-    boolean reuseObjects = (reusedEncoder != null && reusedOutputStream != null);
-    byte[] serializedComputeRequest = reuseObjects
-        ? computeRequestWrapper.serialize(reusedEncoder, reusedOutputStream)
-        : computeRequestWrapper.serialize();
-    byte[] serializedFullComputeRequest = reuseObjects
-        ? serializeComputeRequest(keyList, serializedComputeRequest, reusedEncoder, reusedOutputStream)
-        : serializeComputeRequest(keyList, serializedComputeRequest);
-    clientStats.ifPresent(
-        stats -> stats.recordRequestSerializationTime(LatencyUtils.getLatencyInMS(preRequestSerializationNS)));
-
-    final Map<String, String> headerMap =
-        (computeRequestWrapper.getComputeRequestVersion() == COMPUTE_REQUEST_VERSION_V2)
-            ? new HashMap<>(COMPUTE_HEADER_MAP_FOR_STREAMING_V2)
-            : new HashMap<>(COMPUTE_HEADER_MAP_FOR_STREAMING_V3);
-    int schemaId = getSchemaReader().getValueSchemaId(computeRequestWrapper.getValueSchema());
-    headerMap.put(VENICE_KEY_COUNT, Integer.toString(keyList.size()));
-    headerMap.put(VENICE_COMPUTE_VALUE_SCHEMA_ID, Integer.toString(schemaId));
-
-    RecordDeserializer<GenericRecord> computeResultRecordDeserializer =
-        getComputeResultRecordDeserializer(resultSchema);
-
-    transportClient.streamPost(
-        getComputeRequestPath(),
-        headerMap,
-        serializedFullComputeRequest,
-        new StoreClientStreamingCallback<>(keyList, callback, envelopeSchemaId -> {
-          validateComputeResponseSchemaId(envelopeSchemaId);
-          return new ComputeResponseRecordV1ChunkedDeserializer();
-        },
-            // Compute doesn't support compression
-            (envelope, compressionStrategy) -> {
-              if (!envelope.value.hasRemaining()) {
-                // Safeguard to handle empty value, which indicates non-existing key.
-                return null;
-              }
-              return new ComputeGenericRecord(
-                  computeResultRecordDeserializer.deserialize(envelope.value),
-                  computeRequestWrapper.getValueSchema());
-            },
-            envelope -> envelope.keyIndex,
-            envelope -> streamingFooterRecordDeserializer.deserialize(envelope.value)),
         keyList.size());
   }
 }

--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/AbstractAvroStoreClient.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/AbstractAvroStoreClient.java
@@ -5,7 +5,7 @@ import static com.linkedin.venice.HttpConstants.VENICE_KEY_COUNT;
 import static com.linkedin.venice.VeniceConstants.COMPUTE_REQUEST_VERSION_V2;
 import static com.linkedin.venice.streaming.StreamingConstants.KEY_ID_FOR_STREAMING_FOOTER;
 
-import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
+import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelperCommon;
 import com.linkedin.avroutil1.compatibility.AvroVersion;
 import com.linkedin.venice.HttpConstants;
 import com.linkedin.venice.client.exceptions.ServiceDiscoveryException;
@@ -127,7 +127,7 @@ public abstract class AbstractAvroStoreClient<K, V> extends InternalAvroStoreCli
     COMPUTE_HEADER_MAP_FOR_STREAMING_V3 = new HashMap<>(COMPUTE_HEADER_MAP_V3);
     COMPUTE_HEADER_MAP_FOR_STREAMING_V3.put(HttpConstants.VENICE_STREAMING, "1");
 
-    AvroVersion version = AvroCompatibilityHelper.getRuntimeAvroVersion();
+    AvroVersion version = AvroCompatibilityHelperCommon.getRuntimeAvroVersion();
     LOGGER.info("Detected: {} on the classpath.", version);
   }
 
@@ -148,6 +148,8 @@ public abstract class AbstractAvroStoreClient<K, V> extends InternalAvroStoreCli
   private final BatchDeserializer<MultiGetResponseRecordV1, K, V> batchGetDeserializer;
   private final BatchDeserializer<ComputeResponseRecordV1, K, GenericRecord> computeDeserializer;
   private final CompressorFactory compressorFactory;
+  private final String storageRequestPath;
+  private final String computeRequestPath;
 
   private volatile boolean isServiceDiscovered;
 
@@ -201,6 +203,8 @@ public abstract class AbstractAvroStoreClient<K, V> extends InternalAvroStoreCli
     this.batchGetDeserializer = clientConfig.getBatchGetDeserializer(this.deserializationExecutor);
     this.computeDeserializer = clientConfig.getBatchGetDeserializer(this.deserializationExecutor);
     this.compressorFactory = new CompressorFactory();
+    this.storageRequestPath = TYPE_STORAGE + "/" + getStoreName();
+    this.computeRequestPath = TYPE_COMPUTE + "/" + getStoreName();
   }
 
   @Override
@@ -231,11 +235,11 @@ public abstract class AbstractAvroStoreClient<K, V> extends InternalAvroStoreCli
   }
 
   private String getStorageRequestPath() {
-    return TYPE_STORAGE + "/" + getStoreName();
+    return storageRequestPath;
   }
 
   protected String getComputeRequestPath() {
-    return TYPE_COMPUTE + "/" + getStoreName();
+    return computeRequestPath;
   }
 
   // For testing

--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/AbstractAvroStoreClient.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/AbstractAvroStoreClient.java
@@ -203,8 +203,8 @@ public abstract class AbstractAvroStoreClient<K, V> extends InternalAvroStoreCli
     this.batchGetDeserializer = clientConfig.getBatchGetDeserializer(this.deserializationExecutor);
     this.computeDeserializer = clientConfig.getBatchGetDeserializer(this.deserializationExecutor);
     this.compressorFactory = new CompressorFactory();
-    this.storageRequestPath = TYPE_STORAGE + "/" + getStoreName();
-    this.computeRequestPath = TYPE_COMPUTE + "/" + getStoreName();
+    this.storageRequestPath = TYPE_STORAGE + "/" + clientConfig.getStoreName();
+    this.computeRequestPath = TYPE_COMPUTE + "/" + clientConfig.getStoreName();
   }
 
   @Override

--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/AvroComputeRequestBuilderV4.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/AvroComputeRequestBuilderV4.java
@@ -11,7 +11,6 @@ import com.linkedin.venice.client.store.predicate.Predicate;
 import com.linkedin.venice.client.store.streaming.StreamingCallback;
 import com.linkedin.venice.compute.ComputeRequestWrapper;
 import com.linkedin.venice.exceptions.VeniceException;
-import com.linkedin.venice.serializer.AvroSerializer;
 import com.linkedin.venice.serializer.FastSerializerDeserializerFactory;
 import com.linkedin.venice.serializer.RecordSerializer;
 import com.linkedin.venice.utils.Pair;
@@ -80,7 +79,7 @@ public class AvroComputeRequestBuilderV4<K> extends AvroComputeRequestBuilderV3<
     try {
       RecordSerializer<GenericRecord> serializer =
           FastSerializerDeserializerFactory.getFastAvroGenericSerializer(prefixSchema, false);
-      return serializer.serialize(prefix, AvroSerializer.REUSE.get());
+      return serializer.serialize(prefix);
     } catch (Exception e) {
       throw new VeniceClientException(
           "Cannot serialize partial key. Please ensure the leading fields are completely specified",

--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/AvroGenericReadComputeStoreClient.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/AvroGenericReadComputeStoreClient.java
@@ -4,12 +4,10 @@ import com.linkedin.venice.client.exceptions.VeniceClientException;
 import com.linkedin.venice.client.stats.ClientStats;
 import com.linkedin.venice.client.store.streaming.StreamingCallback;
 import com.linkedin.venice.compute.ComputeRequestWrapper;
-import java.io.ByteArrayOutputStream;
 import java.util.Optional;
 import java.util.Set;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericRecord;
-import org.apache.avro.io.BinaryEncoder;
 
 
 /**
@@ -19,28 +17,19 @@ import org.apache.avro.io.BinaryEncoder;
  */
 public interface AvroGenericReadComputeStoreClient<K, V> extends AvroGenericStoreClient<K, V> {
   ComputeRequestBuilder<K> compute(
-      final Optional<ClientStats> stats,
-      final Optional<ClientStats> streamingStats,
-      final long preRequestTimeInNS) throws VeniceClientException;
+      Optional<ClientStats> stats,
+      Optional<ClientStats> streamingStats,
+      long preRequestTimeInNS) throws VeniceClientException;
 
   void compute(
       ComputeRequestWrapper computeRequestWrapper,
       Set<K> keys,
       Schema resultSchema,
       StreamingCallback<K, ComputeGenericRecord> callback,
-      final long preRequestTimeInNS) throws VeniceClientException;
-
-  void compute(
-      ComputeRequestWrapper computeRequestWrapper,
-      Set<K> keys,
-      Schema resultSchema,
-      StreamingCallback<K, ComputeGenericRecord> callback,
-      final long preRequestTimeInNS,
-      BinaryEncoder reusedEncoder,
-      ByteArrayOutputStream reusedOutputStream) throws VeniceClientException;
+      long preRequestTimeInNS) throws VeniceClientException;
 
   void computeWithKeyPrefixFilter(
-      byte[] prefixBytes,
+      byte[] keyPrefix,
       ComputeRequestWrapper computeRequestWrapper,
-      StreamingCallback<GenericRecord, GenericRecord> callback);
+      StreamingCallback<GenericRecord, GenericRecord> callback) throws VeniceClientException;
 }

--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/AvroGenericStoreClient.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/AvroGenericStoreClient.java
@@ -81,7 +81,7 @@ public interface AvroGenericStoreClient<K, V> extends Closeable {
    * @param callback
    * @throws VeniceClientException
    */
-  default void streamingBatchGet(final Set<K> keys, StreamingCallback<K, V> callback) throws VeniceClientException {
+  default void streamingBatchGet(Set<K> keys, StreamingCallback<K, V> callback) throws VeniceClientException {
     throw new VeniceClientException(
         "Please use CachingVeniceStoreClientFactory#getAndStartAvroGenericStoreClient() "
             + "or VeniceGenericStoreClientFactory#createInstance() to generate a Venice avro generic client");

--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/AvroGenericStoreClientImpl.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/AvroGenericStoreClientImpl.java
@@ -23,7 +23,7 @@ public class AvroGenericStoreClientImpl<K, V> extends AbstractAvroStoreClient<K,
       ClientConfig clientConfig) {
     super(transportClient, needSchemaReader, clientConfig);
 
-    if (isUseFastAvro()) {
+    if (clientConfig.isUseFastAvro()) {
       FastSerializerDeserializerFactory.verifyWhetherFastGenericDeserializerWorks();
     }
   }
@@ -40,7 +40,7 @@ public class AvroGenericStoreClientImpl<K, V> extends AbstractAvroStoreClient<K,
   }
 
   @Override
-  public RecordDeserializer<V> getDataRecordDeserializer(final int writerSchemaId) throws VeniceClientException {
+  public RecordDeserializer<V> getDataRecordDeserializer(int writerSchemaId) throws VeniceClientException {
     SchemaReader schemaReader = getSchemaReader();
 
     // Get latest value schema
@@ -71,7 +71,7 @@ public class AvroGenericStoreClientImpl<K, V> extends AbstractAvroStoreClient<K,
   }
 
   protected RecordDeserializer<V> getDeserializerFromFactory(Schema writer, Schema reader) {
-    if (isUseFastAvro()) {
+    if (getClientConfig().isUseFastAvro()) {
       return FastSerializerDeserializerFactory.getFastAvroGenericDeserializer(writer, reader);
     } else {
       return SerializerDeserializerFactory.getAvroGenericDeserializer(writer, reader);

--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/AvroSpecificStoreClientImpl.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/AvroSpecificStoreClientImpl.java
@@ -31,7 +31,7 @@ public class AvroSpecificStoreClientImpl<K, V extends SpecificRecord> extends Ab
     super(transportClient, needSchemaReader, clientConfig);
     valueClass = clientConfig.getSpecificValueClass();
 
-    if (isUseFastAvro()) {
+    if (getClientConfig().isUseFastAvro()) {
       FastSerializerDeserializerFactory.verifyWhetherFastSpecificDeserializerWorks(valueClass);
     }
   }
@@ -49,7 +49,7 @@ public class AvroSpecificStoreClientImpl<K, V extends SpecificRecord> extends Ab
       throw new VeniceClientException(
           "Failed to get value schema for store: " + getStoreName() + " and id: " + schemaId);
     }
-    if (isUseFastAvro()) {
+    if (getClientConfig().isUseFastAvro()) {
       return FastSerializerDeserializerFactory.getFastAvroSpecificDeserializer(writeSchema, valueClass);
     } else {
       return SerializerDeserializerFactory.getAvroSpecificDeserializer(writeSchema, valueClass);

--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/ClientConfig.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/ClientConfig.java
@@ -51,7 +51,6 @@ public class ClientConfig<T extends SpecificRecord> {
   private int retryCount = 1;
   private long retryBackOffInMs = 0;
   private boolean useBlackHoleDeserializer = false;
-  private boolean reuseObjectsForSerialization = false;
   private boolean forceClusterDiscoveryAtStartTime = false;
   private boolean projectionFieldValidation = true;
   private Duration schemaRefreshPeriod = DEFAULT_SCHEMA_REFRESH_PERIOD;
@@ -104,7 +103,6 @@ public class ClientConfig<T extends SpecificRecord> {
         .setRetryCount(config.getRetryCount())
         .setRetryBackOffInMs(config.getRetryBackOffInMs())
         .setUseBlackHoleDeserializer(config.isUseBlackHoleDeserializer())
-        .setReuseObjectsForSerialization(config.isReuseObjectsForSerialization())
         // Security settings
         .setHttps(config.isHttps())
         .setSslFactory(config.getSslFactory())
@@ -385,15 +383,6 @@ public class ClientConfig<T extends SpecificRecord> {
 
   public ClientConfig<T> setUseBlackHoleDeserializer(boolean useBlackHoleDeserializer) {
     this.useBlackHoleDeserializer = useBlackHoleDeserializer;
-    return this;
-  }
-
-  public boolean isReuseObjectsForSerialization() {
-    return reuseObjectsForSerialization;
-  }
-
-  public ClientConfig<T> setReuseObjectsForSerialization(boolean reuseObjectsForSerialization) {
-    this.reuseObjectsForSerialization = reuseObjectsForSerialization;
     return this;
   }
 

--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/DelegatingStoreClient.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/DelegatingStoreClient.java
@@ -4,14 +4,12 @@ import com.linkedin.venice.client.exceptions.VeniceClientException;
 import com.linkedin.venice.client.stats.ClientStats;
 import com.linkedin.venice.client.store.streaming.StreamingCallback;
 import com.linkedin.venice.compute.ComputeRequestWrapper;
-import java.io.ByteArrayOutputStream;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import org.apache.avro.Schema;
-import org.apache.avro.io.BinaryEncoder;
 
 
 public class DelegatingStoreClient<K, V> extends InternalAvroStoreClient<K, V> {
@@ -70,27 +68,8 @@ public class DelegatingStoreClient<K, V> extends InternalAvroStoreClient<K, V> {
       Set<K> keys,
       Schema resultSchema,
       StreamingCallback<K, ComputeGenericRecord> callback,
-      final long preRequestTimeInNS) throws VeniceClientException {
+      long preRequestTimeInNS) throws VeniceClientException {
     innerStoreClient.compute(computeRequestWrapper, keys, resultSchema, callback, preRequestTimeInNS);
-  }
-
-  @Override
-  public void compute(
-      ComputeRequestWrapper computeRequestWrapper,
-      Set<K> keys,
-      Schema resultSchema,
-      StreamingCallback<K, ComputeGenericRecord> callback,
-      final long preRequestTimeInNS,
-      BinaryEncoder reusedEncoder,
-      ByteArrayOutputStream reusedOutputStream) throws VeniceClientException {
-    innerStoreClient.compute(
-        computeRequestWrapper,
-        keys,
-        resultSchema,
-        callback,
-        preRequestTimeInNS,
-        reusedEncoder,
-        reusedOutputStream);
   }
 
   @Override

--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/InternalAvroStoreClient.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/InternalAvroStoreClient.java
@@ -29,35 +29,33 @@ public abstract class InternalAvroStoreClient<K, V> implements AvroGenericReadCo
     return get(key, Optional.empty(), 0);
   }
 
-  @Override
-  public ComputeRequestBuilder<K> compute() throws VeniceClientException {
-    return compute(Optional.empty(), Optional.empty(), 0);
-  }
-
-  public abstract CompletableFuture<V> get(
-      final K key,
-      final Optional<ClientStats> stats,
-      final long preRequestTimeInNS) throws VeniceClientException;
+  public abstract CompletableFuture<V> get(K key, Optional<ClientStats> stats, long preRequestTimeInNS)
+      throws VeniceClientException;
 
   public abstract CompletableFuture<byte[]> getRaw(
-      final String requestPath,
-      final Optional<ClientStats> stats,
-      final long preRequestTimeInNS);
-
-  // The following function allows to pass one compute store client
-  public abstract ComputeRequestBuilder<K> compute(
-      final Optional<ClientStats> stats,
-      final Optional<ClientStats> streamingStats,
-      final InternalAvroStoreClient computeStoreClient,
-      final long preRequestTimeInNS) throws VeniceClientException;
+      String requestPath,
+      Optional<ClientStats> stats,
+      long preRequestTimeInNS);
 
   public Executor getDeserializationExecutor() {
     throw new VeniceClientException("getDeserializationExecutor is not supported!");
   }
 
   @Override
+  public ComputeRequestBuilder<K> compute() throws VeniceClientException {
+    return compute(Optional.empty(), Optional.empty(), 0);
+  }
+
+  // The following function allows to pass one compute store client
+  public abstract ComputeRequestBuilder<K> compute(
+      Optional<ClientStats> stats,
+      Optional<ClientStats> streamingStats,
+      InternalAvroStoreClient computeStoreClient,
+      long preRequestTimeInNS) throws VeniceClientException;
+
+  @Override
   public void computeWithKeyPrefixFilter(
-      byte[] prefixBytes,
+      byte[] keyPrefix,
       ComputeRequestWrapper computeRequestWrapper,
       StreamingCallback<GenericRecord, GenericRecord> callback) {
     throw new VeniceClientException("ComputeWithKeyPrefixFilter is not supported by Venice Avro Store Client");

--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/RetriableStoreClient.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/RetriableStoreClient.java
@@ -63,12 +63,12 @@ public class RetriableStoreClient<K, V> extends DelegatingStoreClient<K, V> {
   }
 
   private <T> CompletableFuture<T> retryOnError(
-      CompletableFuture<T> origFuture,
+      CompletableFuture<T> originalFuture,
       Supplier<CompletableFuture<T>> supplier,
       RequestType requestType) {
     CompletableFuture<T> retryFuture = new CompletableFuture<>();
 
-    origFuture.whenComplete((T val, Throwable throwable) -> {
+    originalFuture.whenComplete((T val, Throwable throwable) -> {
       if (throwable != null) {
         int attempt = 0;
         Throwable retryThrowable = throwable;

--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/StatTrackingStoreClient.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/StatTrackingStoreClient.java
@@ -14,7 +14,6 @@ import com.linkedin.venice.stats.TehutiUtils;
 import com.linkedin.venice.utils.LatencyUtils;
 import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
 import io.tehuti.metrics.MetricsRepository;
-import java.io.ByteArrayOutputStream;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Queue;
@@ -25,7 +24,6 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiFunction;
 import org.apache.avro.Schema;
-import org.apache.avro.io.BinaryEncoder;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -241,7 +239,7 @@ public class StatTrackingStoreClient<K, V> extends DelegatingStoreClient<K, V> {
       Set<K> keys,
       Schema resultSchema,
       StreamingCallback<K, ComputeGenericRecord> callback,
-      final long preRequestTimeInNS) throws VeniceClientException {
+      long preRequestTimeInNS) throws VeniceClientException {
     computeStreamingStats.recordRequestKeyCount(keys.size());
     super.compute(
         computeRequestWrapper,
@@ -249,26 +247,6 @@ public class StatTrackingStoreClient<K, V> extends DelegatingStoreClient<K, V> {
         resultSchema,
         new StatTrackingStreamingCallback<>(callback, computeStreamingStats, keys.size(), preRequestTimeInNS),
         preRequestTimeInNS);
-  }
-
-  @Override
-  public void compute(
-      ComputeRequestWrapper computeRequestWrapper,
-      Set<K> keys,
-      Schema resultSchema,
-      StreamingCallback<K, ComputeGenericRecord> callback,
-      final long preRequestTimeInNS,
-      BinaryEncoder reusedEncoder,
-      ByteArrayOutputStream reusedOutputStream) throws VeniceClientException {
-    computeStreamingStats.recordRequestKeyCount(keys.size());
-    super.compute(
-        computeRequestWrapper,
-        keys,
-        resultSchema,
-        new StatTrackingStreamingCallback<>(callback, computeStreamingStats, keys.size(), preRequestTimeInNS),
-        preRequestTimeInNS,
-        reusedEncoder,
-        reusedOutputStream);
   }
 
   private static void handleMetricTrackingForStreamingCallback(

--- a/clients/venice-thin-client/src/test/java/com/linkedin/venice/client/store/AbstractAvroStoreClientTest.java
+++ b/clients/venice-thin-client/src/test/java/com/linkedin/venice/client/store/AbstractAvroStoreClientTest.java
@@ -352,7 +352,7 @@ public class AbstractAvroStoreClientTest {
         true,
         AbstractAvroStoreClient.getDefaultDeserializationExecutor());
     CompletableFuture<Map<String, ComputeGenericRecord>> computeFuture =
-        storeClient.compute(Optional.empty(), Optional.empty(), 0).project("int_field").execute(keys);
+        storeClient.compute().project("int_field").execute(keys);
     computeFuture.get();
   }
 

--- a/clients/venice-thin-client/src/test/java/com/linkedin/venice/client/store/StatTrackingStoreClientTest.java
+++ b/clients/venice-thin-client/src/test/java/com/linkedin/venice/client/store/StatTrackingStoreClientTest.java
@@ -25,7 +25,6 @@ import com.linkedin.venice.utils.Utils;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.tehuti.Metric;
 import io.tehuti.metrics.MetricsRepository;
-import java.io.ByteArrayOutputStream;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -45,7 +44,6 @@ import java.util.concurrent.TimeoutException;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
-import org.apache.avro.io.BinaryEncoder;
 import org.testng.Assert;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
@@ -643,9 +641,7 @@ public class StatTrackingStoreClientTest {
           Set<K> keys,
           Schema resultSchema,
           StreamingCallback<K, ComputeGenericRecord> callback,
-          long preRequestTimeInNS,
-          BinaryEncoder reusedEncoder,
-          ByteArrayOutputStream reusedOutputStream) {
+          long preRequestTimeInNS) {
         Thread callbackThread = new Thread(() -> {
           for (int i = 0; i < 10; i += 2) {
             callback.onRecordReceived((K) ("key_" + i), mock(ComputeGenericRecord.class));

--- a/internal/venice-avro-compatibility-test/src/test/java/com/linkedin/venice/VeniceClientCompatibilityTest.java
+++ b/internal/venice-avro-compatibility-test/src/test/java/com/linkedin/venice/VeniceClientCompatibilityTest.java
@@ -4,7 +4,7 @@ import static com.linkedin.venice.VeniceClusterInitializer.ID_FIELD_PREFIX;
 import static com.linkedin.venice.VeniceClusterInitializer.KEY_PREFIX;
 import static com.linkedin.venice.VeniceClusterInitializer.ZK_ADDRESS_FIELD;
 
-import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
+import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelperCommon;
 import com.linkedin.avroutil1.compatibility.AvroVersion;
 import com.linkedin.davinci.client.DaVinciClient;
 import com.linkedin.venice.client.store.AvroGenericStoreClient;
@@ -55,9 +55,9 @@ public class VeniceClientCompatibilityTest {
 
   @BeforeClass
   public void setUp() throws Exception {
-    LOGGER.info("Avro version in unit test: {}", AvroCompatibilityHelper.getRuntimeAvroVersion());
+    LOGGER.info("Avro version in unit test: {}", AvroCompatibilityHelperCommon.getRuntimeAvroVersion());
     Assert.assertEquals(
-        AvroCompatibilityHelper.getRuntimeAvroVersion(),
+        AvroCompatibilityHelperCommon.getRuntimeAvroVersion(),
         AvroVersion.valueOf(System.getProperty("clientAvroVersion")));
     /**
      * The following port selection is not super safe since this port could be occupied when it is being used

--- a/internal/venice-avro-compatibility-test/src/test/java/com/linkedin/venice/VeniceClusterInitializer.java
+++ b/internal/venice-avro-compatibility-test/src/test/java/com/linkedin/venice/VeniceClusterInitializer.java
@@ -1,6 +1,6 @@
 package com.linkedin.venice;
 
-import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
+import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelperCommon;
 import com.linkedin.avroutil1.compatibility.AvroVersion;
 import com.linkedin.venice.client.store.AvroGenericStoreClient;
 import com.linkedin.venice.client.store.ClientConfig;
@@ -227,8 +227,8 @@ public class VeniceClusterInitializer implements Closeable {
    * @param args
    */
   public static void main(String[] args) {
-    LOGGER.info("Avro version in VeniceClusterInitializer: {}", AvroCompatibilityHelper.getRuntimeAvroVersion());
-    Assert.assertEquals(AvroCompatibilityHelper.getRuntimeAvroVersion(), AvroVersion.AVRO_1_9);
+    LOGGER.info("Avro version in VeniceClusterInitializer: {}", AvroCompatibilityHelperCommon.getRuntimeAvroVersion());
+    Assert.assertEquals(AvroCompatibilityHelperCommon.getRuntimeAvroVersion(), AvroVersion.AVRO_1_9);
     Assert.assertEquals(args.length, 2, "Store name and router port arguments are expected");
 
     String storeName = args[0];

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/compression/ZstdWithDictCompressor.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/compression/ZstdWithDictCompressor.java
@@ -168,7 +168,7 @@ public class ZstdWithDictCompressor extends VeniceCompressor {
       value.put("id", i);
       String name = i + "_name";
       value.put("name", name);
-      values.add(i, serializer.serialize(value, AvroSerializer.REUSE.get()));
+      values.add(i, serializer.serialize(value));
     }
     ZstdDictTrainer trainer = new ZstdDictTrainer(200 * BYTES_PER_MB, 100 * BYTES_PER_KB);
     for (byte[] value: values) {

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/compute/ComputeRequestWrapper.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/compute/ComputeRequestWrapper.java
@@ -10,13 +10,11 @@ import com.linkedin.venice.serializer.FastSerializerDeserializerFactory;
 import com.linkedin.venice.serializer.RecordDeserializer;
 import com.linkedin.venice.serializer.RecordSerializer;
 import com.linkedin.venice.serializer.SerializerDeserializerFactory;
-import java.io.ByteArrayOutputStream;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.apache.avro.Schema;
 import org.apache.avro.io.BinaryDecoder;
-import org.apache.avro.io.BinaryEncoder;
 import org.apache.avro.specific.SpecificRecord;
 
 
@@ -92,10 +90,6 @@ public class ComputeRequestWrapper {
 
   public byte[] serialize() {
     return SERIALIZER_MAP.get(version).serialize(computeRequest);
-  }
-
-  public byte[] serialize(BinaryEncoder reusedEncoder, ByteArrayOutputStream reusedOutputStream) {
-    return SERIALIZER_MAP.get(version).serialize(computeRequest, reusedEncoder, reusedOutputStream);
   }
 
   public void deserialize(BinaryDecoder decoder, boolean useFastAvro) {

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/schema/SchemaEntry.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/schema/SchemaEntry.java
@@ -7,6 +7,7 @@ import static com.linkedin.venice.schema.avro.SchemaCompatibility.SchemaCompatib
 import static com.linkedin.venice.schema.avro.SchemaCompatibility.checkReaderWriterCompatibility;
 
 import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
+import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelperCommon;
 import com.linkedin.avroutil1.compatibility.AvroVersion;
 import com.linkedin.venice.schema.avro.DirectionalSchemaCompatibilityType;
 import com.linkedin.venice.schema.avro.SchemaCompatibility;
@@ -47,7 +48,7 @@ public class SchemaEntry {
       this.schema = AvroSchemaParseUtils.parseSchemaFromJSONLooseValidation(schemaStr);
     } catch (Exception e) {
       if ((e instanceof AvroTypeException)
-          && (AvroCompatibilityHelper.getRuntimeAvroVersion().laterThan(AvroVersion.AVRO_1_8))) {
+          && (AvroCompatibilityHelperCommon.getRuntimeAvroVersion().laterThan(AvroVersion.AVRO_1_8))) {
         this.schema = Schema.create(Schema.Type.NULL);
         this.failedParsing = true;
         LOGGER.warn(

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/schema/rmd/RmdUtils.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/schema/rmd/RmdUtils.java
@@ -3,7 +3,6 @@ package com.linkedin.venice.schema.rmd;
 import static com.linkedin.venice.schema.rmd.RmdConstants.REPLICATION_CHECKPOINT_VECTOR_FIELD;
 import static com.linkedin.venice.schema.rmd.RmdConstants.TIMESTAMP_FIELD_NAME;
 
-import com.linkedin.venice.serializer.AvroSerializer;
 import com.linkedin.venice.serializer.RecordDeserializer;
 import com.linkedin.venice.serializer.RecordSerializer;
 import com.linkedin.venice.serializer.avro.MapOrderingPreservingSerDeFactory;
@@ -21,7 +20,7 @@ import org.apache.avro.generic.GenericRecord;
  */
 public class RmdUtils {
   public static ByteBuffer serializeRmdRecord(final Schema valueSchema, GenericRecord rmdRecord) {
-    byte[] rmdBytes = getRmdSerializer(valueSchema).serialize(rmdRecord, AvroSerializer.REUSE.get());
+    byte[] rmdBytes = getRmdSerializer(valueSchema).serialize(rmdRecord);
     return ByteBuffer.wrap(rmdBytes);
   }
 

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/serializer/AvroSerializer.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/serializer/AvroSerializer.java
@@ -1,7 +1,7 @@
 package com.linkedin.venice.serializer;
 
 import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
-import com.linkedin.avroutil1.compatibility.AvroVersion;
+import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelperCommon;
 import com.linkedin.venice.exceptions.VeniceException;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -34,8 +34,7 @@ public class AvroSerializer<K> implements RecordSerializer<K> {
   }
 
   static {
-    AvroVersion version = AvroCompatibilityHelper.getRuntimeAvroVersion();
-    LOGGER.info("Detected: {} on the classpath.", version);
+    LOGGER.info("Detected: {} on the classpath.", AvroCompatibilityHelperCommon.getRuntimeAvroVersion());
   }
 
   public AvroSerializer(Schema schema) {
@@ -69,7 +68,7 @@ public class AvroSerializer<K> implements RecordSerializer<K> {
       write(object, encoder);
       encoder.flush();
     } catch (IOException e) {
-      throw new VeniceException("Could not serialize the Avro object", e);
+      throw new VeniceException("Unable to serialize object", e);
     }
     return reusableObjects.outputStream.toByteArray();
   }
@@ -111,12 +110,12 @@ public class AvroSerializer<K> implements RecordSerializer<K> {
         try {
           write(object, encoder);
         } catch (IOException e) {
-          throw new VeniceException("Could not serialize the Avro object", e);
+          throw new VeniceException("Unable to serialize object", e);
         }
       }
       encoder.flush();
     } catch (IOException e) {
-      throw new VeniceException("Could not flush BinaryEncoder", e);
+      throw new VeniceException("Unable to flush BinaryEncoder", e);
     }
     return outputStream.toByteArray();
   }

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/serializer/AvroSerializer.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/serializer/AvroSerializer.java
@@ -21,34 +21,16 @@ import org.apache.logging.log4j.Logger;
  * {@code AvroSerializer} provides the functionality to serialize and deserialize objects by using Avro.
  */
 public class AvroSerializer<K> implements RecordSerializer<K> {
-  public static final ThreadLocal<ReusableObjects> REUSE = ThreadLocal.withInitial(AvroSerializerReusableObjects::new);
-
   private static final Logger LOGGER = LogManager.getLogger(AvroSerializer.class);
+  private static final ThreadLocal<ReusableObjects> REUSABLE_OBJECTS = ThreadLocal.withInitial(ReusableObjects::new);
+
   private final DatumWriter<K> genericDatumWriter;
   private final DatumWriter<K> specificDatumWriter;
   private final boolean buffered;
 
-  public static class AvroSerializerReusableObjects implements RecordSerializer.ReusableObjects {
-    public final BinaryEncoder binaryEncoder;
-    public final ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-
-    protected AvroSerializerReusableObjects() {
-      this(true);
-    }
-
-    public AvroSerializerReusableObjects(boolean buffered) {
-      this.binaryEncoder = AvroCompatibilityHelper.newBinaryEncoder(byteArrayOutputStream, buffered, null);
-    }
-
-    @Override
-    public BinaryEncoder getBinaryEncoder() {
-      return binaryEncoder;
-    }
-
-    @Override
-    public ByteArrayOutputStream getByteArrayOutputStream() {
-      return byteArrayOutputStream;
-    }
+  private static class ReusableObjects {
+    public final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+    public final BinaryEncoder binaryEncoder = AvroCompatibilityHelper.newBinaryEncoder(outputStream, true, null);
   }
 
   static {
@@ -77,94 +59,26 @@ public class AvroSerializer<K> implements RecordSerializer<K> {
     this.buffered = buffered;
   }
 
-  private void write(K object, Encoder encoder) throws IOException {
-    try {
-      if (object instanceof SpecificRecord) {
-        specificDatumWriter.write(object, encoder);
-      } else {
-        genericDatumWriter.write(object, encoder);
-      }
-    } catch (NullPointerException e) {
-      if (object instanceof SpecificRecord && specificDatumWriter == null) {
-        /**
-         * Defensive code...
-         *
-         * At the time of writing this commit, only the {@link VsonAvroGenericSerializer}
-         * uses the protected constructor to pass in a null {@link specificDatumWriter},
-         * and the Vson serializer should never be used with a SpecificRecord, so the NPE
-         * should never happen. If this assumption is broken in the future, and this code
-         * regresses, then hopefully this exception can help future maintainers to find
-         * the issue more easily.
-         */
-        throw new IllegalStateException(
-            "This instance of " + this.getClass().getSimpleName()
-                + " was instantiated with a null specificDatumWriter, and was used to serialize a SpecificRecord.",
-            e);
-      }
-      throw e;
-    }
-  }
-
   @Override
   public byte[] serialize(K object) throws VeniceException {
-    ByteArrayOutputStream output = new ByteArrayOutputStream();
-    try {
-      return serialize(object, null, output);
-    } finally {
-      try {
-        output.close();
-      } catch (IOException e) {
-        LOGGER.error("Failed to close stream", e);
-      }
-    }
-  }
-
-  @Override
-  public byte[] serialize(K object, ReusableObjects reuse) throws VeniceException {
-    return serialize(object, reuse.getBinaryEncoder(), reuse.getByteArrayOutputStream());
-  }
-
-  @Override
-  public byte[] serialize(K object, BinaryEncoder reusedEncoder, ByteArrayOutputStream reusedOutputStream)
-      throws VeniceException {
-    reusedOutputStream.reset();
-    Encoder encoder = AvroCompatibilityHelper.newBinaryEncoder(reusedOutputStream, buffered, reusedEncoder);
+    ReusableObjects reusableObjects = REUSABLE_OBJECTS.get();
+    reusableObjects.outputStream.reset();
+    Encoder encoder =
+        AvroCompatibilityHelper.newBinaryEncoder(reusableObjects.outputStream, buffered, reusableObjects.binaryEncoder);
     try {
       write(object, encoder);
       encoder.flush();
     } catch (IOException e) {
       throw new VeniceException("Could not serialize the Avro object", e);
     }
-    return reusedOutputStream.toByteArray();
+    return reusableObjects.outputStream.toByteArray();
   }
 
   @Override
   public byte[] serializeObjects(Iterable<K> objects) throws VeniceException {
-    return serializeObjects(objects, null, new ByteArrayOutputStream());
-  }
-
-  @Override
-  public byte[] serializeObjects(Iterable<K> objects, ReusableObjects reuse) throws VeniceException {
-    reuse.getByteArrayOutputStream().reset();
-    return serializeObjects(objects, reuse.getBinaryEncoder(), reuse.getByteArrayOutputStream());
-  }
-
-  private byte[] serializeObjects(Iterable<K> objects, BinaryEncoder reusedEncoder, ByteArrayOutputStream output)
-      throws VeniceException {
-    Encoder encoder = AvroCompatibilityHelper.newBinaryEncoder(output, buffered, reusedEncoder);
-    try {
-      objects.forEach(object -> {
-        try {
-          write(object, encoder);
-        } catch (IOException e) {
-          throw new VeniceException("Could not serialize the Avro object", e);
-        }
-      });
-      encoder.flush();
-      return output.toByteArray();
-    } catch (IOException e) {
-      throw new VeniceException("Could not flush BinaryEncoder", e);
-    }
+    ReusableObjects reusableObjects = REUSABLE_OBJECTS.get();
+    reusableObjects.outputStream.reset();
+    return serializeObjects(objects, reusableObjects.binaryEncoder, reusableObjects.outputStream);
   }
 
   /**
@@ -181,22 +95,57 @@ public class AvroSerializer<K> implements RecordSerializer<K> {
    */
   @Override
   public byte[] serializeObjects(Iterable<K> objects, ByteBuffer prefix) throws VeniceException {
-    return serializeObjects(objects, prefix, null, new ByteArrayOutputStream());
+    ReusableObjects reusableObjects = REUSABLE_OBJECTS.get();
+    reusableObjects.outputStream.reset();
+    reusableObjects.outputStream.write(prefix.array(), prefix.position(), prefix.remaining());
+    return serializeObjects(objects, reusableObjects.binaryEncoder, reusableObjects.outputStream);
   }
 
-  @Override
-  public byte[] serializeObjects(Iterable<K> objects, ByteBuffer prefix, ReusableObjects reuse) throws VeniceException {
-    return serializeObjects(objects, prefix, reuse.getBinaryEncoder(), reuse.getByteArrayOutputStream());
-  }
-
-  @Override
-  public byte[] serializeObjects(
+  protected byte[] serializeObjects(
       Iterable<K> objects,
-      ByteBuffer prefix,
       BinaryEncoder reusedEncoder,
-      ByteArrayOutputStream reusedOutputStream) throws VeniceException {
-    reusedOutputStream.reset();
-    reusedOutputStream.write(prefix.array(), prefix.position(), prefix.remaining());
-    return serializeObjects(objects, reusedEncoder, reusedOutputStream);
+      ByteArrayOutputStream outputStream) throws VeniceException {
+    Encoder encoder = AvroCompatibilityHelper.newBinaryEncoder(outputStream, buffered, reusedEncoder);
+    try {
+      for (K object: objects) {
+        try {
+          write(object, encoder);
+        } catch (IOException e) {
+          throw new VeniceException("Could not serialize the Avro object", e);
+        }
+      }
+      encoder.flush();
+    } catch (IOException e) {
+      throw new VeniceException("Could not flush BinaryEncoder", e);
+    }
+    return outputStream.toByteArray();
+  }
+
+  protected void write(K object, Encoder encoder) throws IOException {
+    try {
+      if (object instanceof SpecificRecord) {
+        specificDatumWriter.write(object, encoder);
+      } else {
+        genericDatumWriter.write(object, encoder);
+      }
+    } catch (NullPointerException e) {
+      if (object instanceof SpecificRecord && specificDatumWriter == null) {
+        /*
+         * Defensive code...
+         *
+         * At the time of writing this commit, only the {@link VsonAvroGenericSerializer}
+         * uses the protected constructor to pass in a null {@link specificDatumWriter},
+         * and the Vson serializer should never be used with a SpecificRecord, so the NPE
+         * should never happen. If this assumption is broken in the future, and this code
+         * regresses, then hopefully this exception can help future maintainers to find
+         * the issue more easily.
+         */
+        throw new IllegalStateException(
+            "This instance of " + this.getClass().getSimpleName()
+                + " was instantiated with a null specificDatumWriter, and was used to serialize a SpecificRecord.",
+            e);
+      }
+      throw e;
+    }
   }
 }

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/serializer/RecordSerializer.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/serializer/RecordSerializer.java
@@ -1,28 +1,13 @@
 package com.linkedin.venice.serializer;
 
 import com.linkedin.venice.exceptions.VeniceException;
-import java.io.ByteArrayOutputStream;
 import java.nio.ByteBuffer;
-import org.apache.avro.io.BinaryEncoder;
 
 
 public interface RecordSerializer<T> {
-  interface ReusableObjects {
-    BinaryEncoder getBinaryEncoder();
-
-    ByteArrayOutputStream getByteArrayOutputStream();
-  }
-
   byte[] serialize(T object) throws VeniceException;
 
-  byte[] serialize(T object, ReusableObjects reuse) throws VeniceException;
-
-  byte[] serialize(T object, BinaryEncoder reusedEncoder, ByteArrayOutputStream reusedOutputStream)
-      throws VeniceException;
-
   byte[] serializeObjects(Iterable<T> objects) throws VeniceException;
-
-  byte[] serializeObjects(Iterable<T> objects, ReusableObjects reuse) throws VeniceException;
 
   /**
    * Serialize a list of objects and put the prefix before the serialized objects.
@@ -37,12 +22,4 @@ public interface RecordSerializer<T> {
    * @throws VeniceException
    */
   byte[] serializeObjects(Iterable<T> objects, ByteBuffer prefix) throws VeniceException;
-
-  byte[] serializeObjects(Iterable<T> objects, ByteBuffer prefix, ReusableObjects reuse) throws VeniceException;
-
-  byte[] serializeObjects(
-      Iterable<T> objects,
-      ByteBuffer prefix,
-      BinaryEncoder reusedEncoder,
-      ByteArrayOutputStream reusedOutputStream) throws VeniceException;
 }

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/serializer/AvroSerializerTest.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/serializer/AvroSerializerTest.java
@@ -13,9 +13,9 @@ import org.testng.annotations.Test;
 
 
 public class AvroSerializerTest {
-  private final String value = "abc";
-  private final Schema schema = AvroCompatibilityHelper.parse("\"string\"");
-  private final RecordSerializer<String> serializer = new AvroSerializer<>(schema);
+  private static final String value = "abc";
+  private static final Schema schema = AvroCompatibilityHelper.parse("\"string\"");
+  private static final RecordSerializer<String> serializer = new AvroSerializer<>(schema);
 
   @Test
   public void testSerialize() {

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/serializer/AvroSerializerTest.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/serializer/AvroSerializerTest.java
@@ -1,0 +1,38 @@
+package com.linkedin.venice.serializer;
+
+import static org.testng.Assert.*;
+
+import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.List;
+import org.apache.avro.Schema;
+import org.apache.commons.lang.ArrayUtils;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class AvroSerializerTest {
+  private final String value = "abc";
+  private final Schema schema = AvroCompatibilityHelper.parse("\"string\"");
+  private final RecordSerializer<String> serializer = new AvroSerializer<>(schema);
+
+  @Test
+  public void testSerialize() {
+    byte[] serializedValue = serializer.serialize(value);
+    Assert.assertTrue(serializedValue.length > value.getBytes().length);
+  }
+
+  @Test
+  public void testSerializeObjects() {
+    List<String> array = Arrays.asList(value, value);
+    byte[] serializedValue = serializer.serialize(value);
+    byte[] expectedSerializedArray = ArrayUtils.addAll(serializedValue, serializedValue);
+    Assert.assertEquals(serializer.serializeObjects(array), expectedSerializedArray);
+
+    byte[] prefixBytes = "prefix".getBytes();
+    Assert.assertEquals(
+        serializer.serializeObjects(array, ByteBuffer.wrap(prefixBytes)),
+        ArrayUtils.addAll(prefixBytes, expectedSerializedArray));
+  }
+}

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/serializer/SerializerDeserializerFactoryTest.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/serializer/SerializerDeserializerFactoryTest.java
@@ -1,5 +1,6 @@
 package com.linkedin.venice.serializer;
 
+import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
 import com.linkedin.venice.client.exceptions.VeniceClientException;
 import com.linkedin.venice.client.store.schemas.TestValueRecord;
 import com.linkedin.venice.client.store.schemas.TestValueRecordWithMoreFields;
@@ -13,14 +14,19 @@ import org.testng.annotations.Test;
 public class SerializerDeserializerFactoryTest {
   @Test
   public void getAvroGenericSerializerTest() throws VeniceClientException {
-    String schemaStr = "\"string\"";
-    Schema schema = Schema.parse(schemaStr);
     String stringValue = "abc";
+    Schema schema = AvroCompatibilityHelper.parse("\"string\"");
     RecordSerializer<Object> serializer = SerializerDeserializerFactory.getAvroGenericSerializer(schema);
     Assert.assertNotEquals(serializer.serialize(stringValue), stringValue.getBytes());
 
     RecordSerializer<Object> anotherSerializer = SerializerDeserializerFactory.getAvroGenericSerializer(schema);
-    Assert.assertTrue(anotherSerializer == serializer);
+    Assert.assertSame(anotherSerializer, serializer);
+  }
+
+  @Test
+  public void getVsonSerializerTest() throws VeniceClientException {
+    RecordSerializer<Object> serializer = SerializerDeserializerFactory.getVsonSerializer(TestValueRecord.SCHEMA$);
+    Assert.assertThrows(IllegalStateException.class, () -> serializer.serialize(new TestValueRecord()));
   }
 
   @Test
@@ -29,7 +35,7 @@ public class SerializerDeserializerFactoryTest {
     Schema expectedSchema = TestValueRecordWithMoreFields.SCHEMA$;
 
     GenericData.Record actualObject = new GenericData.Record(actualSchema);
-    actualObject.put("long_field", 1000l);
+    actualObject.put("long_field", 1000L);
     actualObject.put("string_field", "abc");
     RecordSerializer<Object> serializer = SerializerDeserializerFactory.getAvroGenericSerializer(actualSchema);
     byte[] serializedValue = serializer.serialize(actualObject);
@@ -39,13 +45,13 @@ public class SerializerDeserializerFactoryTest {
 
     GenericData.Record expectedRecord = deserializer.deserialize(serializedValue);
     Assert.assertNotNull(expectedRecord);
-    Assert.assertEquals(expectedRecord.get("long_field"), 1000l);
+    Assert.assertEquals(expectedRecord.get("long_field"), 1000L);
     Assert.assertEquals(expectedRecord.get("string_field").toString(), "abc");
     Assert.assertEquals(expectedRecord.get("int_field"), 10);
 
     RecordDeserializer<GenericData.Record> anotherDeserializer =
         SerializerDeserializerFactory.getAvroGenericDeserializer(actualSchema, expectedSchema);
-    Assert.assertTrue(anotherDeserializer == deserializer);
+    Assert.assertSame(anotherDeserializer, deserializer);
   }
 
   @Test
@@ -53,7 +59,7 @@ public class SerializerDeserializerFactoryTest {
     Schema actualSchema = TestValueRecord.SCHEMA$;
 
     GenericData.Record actualObject = new GenericData.Record(actualSchema);
-    actualObject.put("long_field", 1000l);
+    actualObject.put("long_field", 1000L);
     actualObject.put("string_field", "abc");
 
     RecordSerializer<Object> serializer = SerializerDeserializerFactory.getAvroGenericSerializer(actualSchema);
@@ -63,12 +69,12 @@ public class SerializerDeserializerFactoryTest {
         SerializerDeserializerFactory.getAvroSpecificDeserializer(actualSchema, TestValueRecordWithMoreFields.class);
 
     TestValueRecordWithMoreFields expectedObject = deserializer.deserialize(serializedValue);
-    Assert.assertEquals(expectedObject.long_field, 1000l);
+    Assert.assertEquals(expectedObject.long_field, 1000L);
     Assert.assertEquals(expectedObject.string_field.toString(), "abc");
     Assert.assertEquals(expectedObject.int_field, 10);
 
     RecordDeserializer<TestValueRecordWithMoreFields> anotherDeserializer =
         SerializerDeserializerFactory.getAvroSpecificDeserializer(actualSchema, TestValueRecordWithMoreFields.class);
-    Assert.assertTrue(anotherDeserializer == deserializer);
+    Assert.assertSame(anotherDeserializer, deserializer);
   }
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/serialization/avro/VeniceAvroKafkaSerializer.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/serialization/avro/VeniceAvroKafkaSerializer.java
@@ -50,7 +50,7 @@ public class VeniceAvroKafkaSerializer implements VeniceKafkaSerializer<Object> 
   }
 
   public byte[] serialize(String topic, Object object) {
-    return this.serializer.serialize(object, AvroSerializer.REUSE.get());
+    return this.serializer.serialize(object);
   }
 
   public Object deserialize(String topic, byte[] bytes) {

--- a/internal/venice-common/src/main/java/org/apache/avro/io/OptimizedBinaryDecoderFactory.java
+++ b/internal/venice-common/src/main/java/org/apache/avro/io/OptimizedBinaryDecoderFactory.java
@@ -6,7 +6,7 @@ import java.nio.ByteBuffer;
 
 public class OptimizedBinaryDecoderFactory {
   private final ThreadLocal<OptimizedBinaryDecoder> localBinaryDecoder =
-      ThreadLocal.withInitial(() -> new OptimizedBinaryDecoder());
+      ThreadLocal.withInitial(OptimizedBinaryDecoder::new);
 
   private static OptimizedBinaryDecoderFactory DEFAULT_FACTORY = new OptimizedBinaryDecoderFactory();
 

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/storagenode/StorageNodeReadTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/storagenode/StorageNodeReadTest.java
@@ -267,36 +267,28 @@ public class StorageNodeReadTest {
       }
     }
 
-    /**
+    /*
      * Test with {@link AvroGenericStoreClient}.
      */
-    for (boolean reuseObjectsForSerialization: new boolean[] { false, true }) {
-      String assertionDetails = "{reuseObjectsForSerialization = " + reuseObjectsForSerialization + "}";
-      try (AvroGenericStoreClient<String, CharSequence> storeClient = ClientFactory.getAndStartGenericAvroClient(
-          ClientConfig.defaultGenericClientConfig(storeName)
-              .setVeniceURL(routerAddr)
-              .setReuseObjectsForSerialization(reuseObjectsForSerialization))) {
-        Set<String> keySet = new HashSet<>();
-        final int EXISTING_KEY_COUNT_IN_BATCH_GET_REQUEST = 10;
+    try (AvroGenericStoreClient<String, CharSequence> storeClient = ClientFactory
+        .getAndStartGenericAvroClient(ClientConfig.defaultGenericClientConfig(storeName).setVeniceURL(routerAddr))) {
+      Set<String> keySet = new HashSet<>();
+      final int EXISTING_KEY_COUNT_IN_BATCH_GET_REQUEST = 10;
+      for (int i = 0; i < EXISTING_KEY_COUNT_IN_BATCH_GET_REQUEST; ++i) {
+        keySet.add(keyPrefix + i);
+      }
+      keySet.add("unknown_key");
+      try {
+        Map<String, CharSequence> result = storeClient.batchGet(keySet).get();
+        Assert.assertEquals(result.size(), EXISTING_KEY_COUNT_IN_BATCH_GET_REQUEST, "Unexpected result size ");
         for (int i = 0; i < EXISTING_KEY_COUNT_IN_BATCH_GET_REQUEST; ++i) {
-          keySet.add(keyPrefix + i);
-        }
-        keySet.add("unknown_key");
-        try {
-          Map<String, CharSequence> result = storeClient.batchGet(keySet).get();
           Assert.assertEquals(
-              result.size(),
-              EXISTING_KEY_COUNT_IN_BATCH_GET_REQUEST,
-              "Unexpected result size " + assertionDetails);
-          for (int i = 0; i < EXISTING_KEY_COUNT_IN_BATCH_GET_REQUEST; ++i) {
-            Assert.assertEquals(
-                result.get(keyPrefix + i).toString(),
-                valuePrefix + i,
-                "Key " + i + " does not have expected value " + assertionDetails);
-          }
-        } catch (Exception e) {
-          Assert.fail("Batch get failed " + assertionDetails, e);
+              result.get(keyPrefix + i).toString(),
+              valuePrefix + i,
+              "Key " + i + " does not have expected value ");
         }
+      } catch (Exception e) {
+        Assert.fail("Batch get failed ", e);
       }
     }
   }

--- a/internal/venice-test-common/src/jmh/java/com/linkedin/venice/benchmark/BenchmarkUtils.java
+++ b/internal/venice-test-common/src/jmh/java/com/linkedin/venice/benchmark/BenchmarkUtils.java
@@ -12,7 +12,6 @@ import com.linkedin.venice.serializer.RecordSerializer;
 import com.linkedin.venice.serializer.SerializerDeserializerFactory;
 import com.linkedin.venice.utils.Utils;
 import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
 import java.lang.management.GarbageCollectorMXBean;
 import java.lang.management.ManagementFactory;
 import java.text.DecimalFormat;
@@ -29,7 +28,6 @@ import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.io.BinaryDecoder;
-import org.apache.avro.io.BinaryEncoder;
 import org.openjdk.jmh.infra.Blackhole;
 
 
@@ -147,20 +145,18 @@ public class BenchmarkUtils {
     List<Float> list;
     int i;
     int n;
-    ByteArrayOutputStream output = new ByteArrayOutputStream();
-    BinaryEncoder encoder = AvroCompatibilityHelper.newBinaryEncoder(output, false, null);
     BinaryDecoder decoder = AvroCompatibilityHelper.newBinaryDecoder(new byte[16]);
     byte[] bytes;
 
     // Initial serialization...
     recordToSerialize.put(fieldName, floats);
-    bytes = serializer.serialize(recordToSerialize, encoder, output);
+    bytes = serializer.serialize(recordToSerialize);
     ;
 
     for (i = 0; i < iteration; i++) {
       if (!serializeOnce) {
         recordToSerialize.put(fieldName, floats);
-        bytes = serializer.serialize(recordToSerialize, encoder, output);
+        bytes = serializer.serialize(recordToSerialize);
       }
       decoder = AvroCompatibilityHelper.newBinaryDecoder(new ByteArrayInputStream(bytes), false, decoder);
       recordToDeserialize = deserializer.deserialize(recordToDeserialize, decoder);

--- a/internal/venice-test-common/src/jmh/java/com/linkedin/venice/benchmark/ThreadLocalBenchmark.java
+++ b/internal/venice-test-common/src/jmh/java/com/linkedin/venice/benchmark/ThreadLocalBenchmark.java
@@ -7,8 +7,7 @@ import org.openjdk.jmh.annotations.Fork;
 import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
-import org.openjdk.jmh.annotations.Scope;
-import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
 import org.openjdk.jmh.annotations.Warmup;
 import org.openjdk.jmh.infra.Blackhole;
 import org.openjdk.jmh.runner.Runner;
@@ -21,14 +20,12 @@ import org.openjdk.jmh.runner.options.OptionsBuilder;
 @Measurement(iterations = 3)
 @BenchmarkMode(Mode.SampleTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-@State(Scope.Benchmark)
+@Threads(Threads.MAX)
 public class ThreadLocalBenchmark {
   private static final ThreadLocal<Object> threadLocal = ThreadLocal.withInitial(String::new);
 
   public static void main(String[] args) throws Exception {
-    Options options = new OptionsBuilder().include(ThreadLocalBenchmark.class.getSimpleName())
-        .threads(Runtime.getRuntime().availableProcessors())
-        .build();
+    Options options = new OptionsBuilder().include(ThreadLocalBenchmark.class.getSimpleName()).build();
     new Runner(options).run();
   }
 

--- a/internal/venice-test-common/src/jmh/java/com/linkedin/venice/benchmark/ThreadLocalBenchmark.java
+++ b/internal/venice-test-common/src/jmh/java/com/linkedin/venice/benchmark/ThreadLocalBenchmark.java
@@ -1,0 +1,44 @@
+package com.linkedin.venice.benchmark;
+
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+
+@Fork(value = 1)
+@Warmup(iterations = 1)
+@Measurement(iterations = 3)
+@BenchmarkMode(Mode.SampleTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Benchmark)
+public class ThreadLocalBenchmark {
+  private static final ThreadLocal<Object> threadLocal = ThreadLocal.withInitial(String::new);
+
+  public static void main(String[] args) throws Exception {
+    Options options = new OptionsBuilder().include(ThreadLocalBenchmark.class.getSimpleName())
+        .threads(Runtime.getRuntime().availableProcessors())
+        .build();
+    new Runner(options).run();
+  }
+
+  @Benchmark
+  public void load(Blackhole blackhole) {
+    blackhole.consume(threadLocal.get());
+  }
+
+  @Benchmark
+  public void noop(Blackhole blackhole) {
+    blackhole.consume(0);
+  }
+}

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -173,7 +173,6 @@ import com.linkedin.venice.serialization.avro.AvroProtocolDefinition;
 import com.linkedin.venice.serialization.avro.VeniceAvroKafkaSerializer;
 import com.linkedin.venice.serializer.AvroSerializer;
 import com.linkedin.venice.serializer.RecordDeserializer;
-import com.linkedin.venice.serializer.RecordSerializer;
 import com.linkedin.venice.serializer.SerializerDeserializerFactory;
 import com.linkedin.venice.service.ICProvider;
 import com.linkedin.venice.stats.AbstractVeniceAggStats;
@@ -4687,14 +4686,13 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
     Schema newSchema = AvroSchemaParseUtils.parseSchemaFromJSONStrictValidation(schemaStr);
     RandomRecordGenerator recordGenerator = new RandomRecordGenerator();
     RecordGenerationConfig genConfig = RecordGenerationConfig.newConfig().withAvoidNulls(true);
-    RecordSerializer.ReusableObjects reusableObjects = AvroSerializer.REUSE.get();
 
     for (int i = 0; i < RECORD_COUNT; i++) {
       // check if new records written with new schema can be read using existing older schema
       // Object record =
       Object record = recordGenerator.randomGeneric(newSchema, genConfig);
       serializer = new AvroSerializer<>(newSchema);
-      byte[] bytes = serializer.serialize(record, reusableObjects);
+      byte[] bytes = serializer.serialize(record);
       for (SchemaEntry schemaEntry: schemaEntries) {
         try {
           existingSchema = schemaEntry.getSchema();
@@ -4724,7 +4722,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
         try {
           Object record = recordGenerator.randomGeneric(schemaEntry.getSchema(), genConfig);
           serializer = new AvroSerializer(schemaEntry.getSchema());
-          byte[] bytes = serializer.serialize(record, reusableObjects);
+          byte[] bytes = serializer.serialize(record);
           existingSchema = schemaEntry.getSchema();
           if (!isValidAvroSchema(existingSchema)) {
             LOGGER.warn("Skip validating ill-formed schema for store: {}", storeName);

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/api/VeniceResponseDecompressor.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/api/VeniceResponseDecompressor.java
@@ -15,7 +15,6 @@ import com.linkedin.venice.read.RequestType;
 import com.linkedin.venice.read.protocol.response.MultiGetResponseRecordV1;
 import com.linkedin.venice.router.stats.AggRouterHttpRequestStats;
 import com.linkedin.venice.router.stats.RouterStats;
-import com.linkedin.venice.serializer.AvroSerializer;
 import com.linkedin.venice.serializer.FastSerializerDeserializerFactory;
 import com.linkedin.venice.serializer.RecordDeserializer;
 import com.linkedin.venice.serializer.RecordSerializer;
@@ -230,6 +229,6 @@ public class VeniceResponseDecompressor {
           .newVeniceExceptionAndTracking(Optional.of(storeName), Optional.of(requestType), BAD_GATEWAY, errorMsg);
     }
 
-    return Unpooled.wrappedBuffer(recordSerializer.serializeObjects(records, AvroSerializer.REUSE.get()));
+    return Unpooled.wrappedBuffer(recordSerializer.serializeObjects(records));
   }
 }

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/api/path/VeniceComputePath.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/api/path/VeniceComputePath.java
@@ -16,7 +16,6 @@ import com.linkedin.venice.router.api.RouterKey;
 import com.linkedin.venice.router.api.VenicePartitionFinder;
 import com.linkedin.venice.router.api.VenicePathParser;
 import com.linkedin.venice.schema.avro.ReadAvroProtocolDefinition;
-import com.linkedin.venice.serializer.AvroSerializer;
 import com.linkedin.venice.serializer.FastSerializerDeserializerFactory;
 import com.linkedin.venice.serializer.RecordDeserializer;
 import com.linkedin.venice.serializer.RecordSerializer;
@@ -187,10 +186,8 @@ public class VeniceComputePath extends VeniceMultiKeyPath<ComputeRouterRequestKe
     RecordSerializer<ComputeRouterRequestKeyV1> serializer =
         FastSerializerDeserializerFactory.getAvroGenericSerializer(ComputeRouterRequestKeyV1.getClassSchema());
 
-    return serializer.serializeObjects(
-        routerKeyMap.values(),
-        ByteBuffer.wrap(requestContent, 0, computeRequestLengthInBytes),
-        AvroSerializer.REUSE.get());
+    return serializer
+        .serializeObjects(routerKeyMap.values(), ByteBuffer.wrap(requestContent, 0, computeRequestLengthInBytes));
   }
 
   public int getValueSchemaId() {

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/api/path/VeniceMultiGetPath.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/api/path/VeniceMultiGetPath.java
@@ -16,7 +16,6 @@ import com.linkedin.venice.router.api.VenicePathParser;
 import com.linkedin.venice.router.stats.AggRouterHttpRequestStats;
 import com.linkedin.venice.router.stats.RouterStats;
 import com.linkedin.venice.schema.avro.ReadAvroProtocolDefinition;
-import com.linkedin.venice.serializer.AvroSerializer;
 import com.linkedin.venice.serializer.FastSerializerDeserializerFactory;
 import com.linkedin.venice.serializer.RecordDeserializer;
 import com.linkedin.venice.serializer.RecordSerializer;
@@ -147,8 +146,7 @@ public class VeniceMultiGetPath extends VeniceMultiKeyPath<MultiGetRouterRequest
   protected byte[] serializeRouterRequest() {
     RecordSerializer<MultiGetRouterRequestKeyV1> serializer =
         FastSerializerDeserializerFactory.getAvroGenericSerializer(MultiGetRouterRequestKeyV1.getClassSchema());
-
-    return serializer.serializeObjects(routerKeyMap.values(), AvroSerializer.REUSE.get());
+    return serializer.serializeObjects(routerKeyMap.values());
   }
 
   private static Iterable<ByteBuffer> deserialize(byte[] content) {

--- a/services/venice-server/src/main/java/com/linkedin/venice/listener/StorageReadRequestsHandler.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/listener/StorageReadRequestsHandler.java
@@ -50,7 +50,6 @@ import com.linkedin.venice.partitioner.VenicePartitioner;
 import com.linkedin.venice.read.RequestType;
 import com.linkedin.venice.read.protocol.request.router.MultiGetRouterRequestKeyV1;
 import com.linkedin.venice.read.protocol.response.MultiGetResponseRecordV1;
-import com.linkedin.venice.serializer.AvroSerializer;
 import com.linkedin.venice.serializer.FastSerializerDeserializerFactory;
 import com.linkedin.venice.serializer.RecordSerializer;
 import com.linkedin.venice.serializer.SerializerDeserializerFactory;
@@ -128,7 +127,7 @@ public class StorageReadRequestsHandler extends ChannelInboundHandlerAdapter {
   private final StorageEngineBackedCompressorFactory compressorFactory;
   private final Optional<ResourceReadUsageTracker> resourceReadUsageTracker;
 
-  private static class StorageExecReusableObjects extends AvroSerializer.AvroSerializerReusableObjects {
+  private static class StorageExecReusableObjects {
     // reuse buffer for rocksDB value object
     final ByteBuffer reusedByteBuffer = ByteBuffer.allocate(1024 * 1024);
 
@@ -750,7 +749,7 @@ public class StorageReadRequestsHandler extends ChannelInboundHandlerAdapter {
 
     // serialize the compute result
     long serializeStartTimeInNS = System.nanoTime();
-    responseRecord.value = ByteBuffer.wrap(resultSerializer.serialize(reuseResultRecord, reusableObjects));
+    responseRecord.value = ByteBuffer.wrap(resultSerializer.serialize(reuseResultRecord));
     response.addReadComputeSerializationLatency(LatencyUtils.getLatencyInMS(serializeStartTimeInNS));
 
     return responseRecord;

--- a/services/venice-server/src/main/java/com/linkedin/venice/listener/response/ComputeResponseWrapper.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/listener/response/ComputeResponseWrapper.java
@@ -2,7 +2,6 @@ package com.linkedin.venice.listener.response;
 
 import com.linkedin.venice.compute.protocol.response.ComputeResponseRecordV1;
 import com.linkedin.venice.schema.avro.ReadAvroProtocolDefinition;
-import com.linkedin.venice.serializer.AvroSerializer;
 import com.linkedin.venice.serializer.FastSerializerDeserializerFactory;
 import com.linkedin.venice.serializer.RecordSerializer;
 
@@ -17,7 +16,7 @@ public class ComputeResponseWrapper extends MultiKeyResponseWrapper<ComputeRespo
     RecordSerializer<ComputeResponseRecordV1> serializer =
         FastSerializerDeserializerFactory.getAvroGenericSerializer(ComputeResponseRecordV1.getClassSchema());
 
-    return serializer.serializeObjects(records, AvroSerializer.REUSE.get());
+    return serializer.serializeObjects(records);
   }
 
   @Override

--- a/services/venice-server/src/main/java/com/linkedin/venice/listener/response/MultiGetResponseWrapper.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/listener/response/MultiGetResponseWrapper.java
@@ -2,7 +2,6 @@ package com.linkedin.venice.listener.response;
 
 import com.linkedin.venice.read.protocol.response.MultiGetResponseRecordV1;
 import com.linkedin.venice.schema.avro.ReadAvroProtocolDefinition;
-import com.linkedin.venice.serializer.AvroSerializer;
 import com.linkedin.venice.serializer.FastSerializerDeserializerFactory;
 import com.linkedin.venice.serializer.RecordSerializer;
 
@@ -17,7 +16,7 @@ public class MultiGetResponseWrapper extends MultiKeyResponseWrapper<MultiGetRes
     RecordSerializer<MultiGetResponseRecordV1> serializer =
         FastSerializerDeserializerFactory.getAvroGenericSerializer(MultiGetResponseRecordV1.getClassSchema());
 
-    return serializer.serializeObjects(records, AvroSerializer.REUSE.get());
+    return serializer.serializeObjects(records);
   }
 
   @Override


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci], [server], [controller],
[router], [samza], [vpj], [fast-client], [thin-client], [alpini],
[admin-tool], [test], [build], [doc], [script]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Summary, imperative, start upper case, don't end with a period
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Re-use BinaryEncoder/OutputStream for Avro serialization by default. Encapsulated thread-local state inside `AvroSerializer`. DaVinciClient has been using the same mechanism from the inception, and as far as I know, there is really no downsides to it. In terms of the benefits, it's known to help reduce GC pressure. Also the change helped to simplify various apis across the code base.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
Internal CI

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [x] Yes. Removes `ClientConfig::isReuseObjectsForSerialization` and `ClientConfig::setReuseObjectsForSerialization`