### PR TITLE
[controller] Do not count previously disabled replica as ERROR replica

### DIFF
--- a/internal/venice-common/src/main/java/com/linkedin/venice/pushmonitor/PushStatusDecider.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pushmonitor/PushStatusDecider.java
@@ -274,7 +274,7 @@ public abstract class PushStatusDecider {
     // partitions can be completed. Vice versa, partitions will be in error state if leader is in error
     // state.
     boolean isLeaderCompleted = true;
-    int previouslyDisabledReplica = 0;
+    int previouslyDisabledErrorReplica = 0;
     for (Map.Entry<Instance, String> entry: instanceToStateMap.entrySet()) {
       ExecutionStatus currentStatus =
           getReplicaCurrentStatus(partitionStatus.getReplicaHistoricStatusList(entry.getKey().getNodeId()));
@@ -282,15 +282,17 @@ public abstract class PushStatusDecider {
         if (!currentStatus.equals(COMPLETED)) {
           isLeaderCompleted = false;
         }
-
-        if (currentStatus.equals(ERROR) && callback != null) {
+        if (currentStatus.equals(ERROR) && callback != null
+            && !callback.isReplicaDisabled(entry.getKey().getNodeId(), partitionStatus.getPartitionId())) {
           callback.disableReplica(entry.getKey().getNodeId(), partitionStatus.getPartitionId());
         }
       } else if (entry.getValue().equals(HelixState.OFFLINE_STATE)) {
         // If the replica is in offline state, check if its due to previously disabled replica or not.
         if (callback != null
             && callback.isReplicaDisabled(entry.getKey().getNodeId(), partitionStatus.getPartitionId())) {
-          previouslyDisabledReplica++;
+          if (!currentStatus.equals(ERROR)) { // Dont count previous replica if it is error status.
+            previouslyDisabledErrorReplica++;
+          }
         }
       }
       executionStatusMap.merge(currentStatus, 1, Integer::sum);
@@ -302,7 +304,7 @@ public abstract class PushStatusDecider {
     }
 
     if (executionStatusMap.containsKey(ERROR) && (executionStatusMap.get(ERROR)
-        + previouslyDisabledReplica > instanceToStateMap.size() - replicationFactor + numberOfToleratedErrors)) {
+        + previouslyDisabledErrorReplica > instanceToStateMap.size() - replicationFactor + numberOfToleratedErrors)) {
       return ERROR;
     }
 

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pushmonitor/PushStatusDecider.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pushmonitor/PushStatusDecider.java
@@ -290,9 +290,8 @@ public abstract class PushStatusDecider {
         // If the replica is in offline state, check if its due to previously disabled replica or not.
         if (callback != null
             && callback.isReplicaDisabled(entry.getKey().getNodeId(), partitionStatus.getPartitionId())) {
-          if (!currentStatus.equals(ERROR)) { // Dont count previous replica if it is not error status.
-            previouslyDisabledErrorReplica++;
-          }
+          previouslyDisabledErrorReplica++;
+          continue; // Dont add disabled replica to status map
         }
       }
       executionStatusMap.merge(currentStatus, 1, Integer::sum);

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pushmonitor/PushStatusDecider.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pushmonitor/PushStatusDecider.java
@@ -290,7 +290,7 @@ public abstract class PushStatusDecider {
         // If the replica is in offline state, check if its due to previously disabled replica or not.
         if (callback != null
             && callback.isReplicaDisabled(entry.getKey().getNodeId(), partitionStatus.getPartitionId())) {
-          if (!currentStatus.equals(ERROR)) { // Dont count previous replica if it is error status.
+          if (!currentStatus.equals(ERROR)) { // Dont count previous replica if it is not error status.
             previouslyDisabledErrorReplica++;
           }
         }


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci], [server], [controller],
[router], [samza], [vpj], [fast-client], [thin-client], [alpini],
[admin-tool], [test], [build], [doc], [script]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## [controller] Do not count previously disabled replica as ERROR replica
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

When Venice disables a leader replica due to error,  Helix ideally elects a new leader. But the while counting the number of error replicas, we include previously disabled replica count so that it does not disables more than 1 replica. But it  double counts the ERROR status of the disabled replica and previously disabled replica leading to fail the push. This PR fixes the double counting of ERROR replicas.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
CI
## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.