### PR TITLE
[controller] Introduce AuthenticationService API

### DIFF
--- a/internal/venice-common/src/main/java/com/linkedin/venice/authentication/AuthenticationService.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/authentication/AuthenticationService.java
@@ -1,0 +1,30 @@
+package com.linkedin.venice.authentication;
+
+import com.linkedin.venice.authorization.Principal;
+import com.linkedin.venice.utils.VeniceProperties;
+import java.io.Closeable;
+import java.security.cert.X509Certificate;
+
+
+/**
+ * Performs authentication.
+ */
+public interface AuthenticationService extends Closeable {
+  default void initialise(VeniceProperties veniceProperties) throws Exception {
+  }
+
+  @Override
+  default void close() {
+  }
+
+  default Principal getPrincipalFromHttpRequest(HttpRequestAccessor requestAccessor) {
+    return null;
+  }
+
+  interface HttpRequestAccessor {
+    String getHeader(String headerName);
+
+    X509Certificate getCertificate();
+  }
+
+}

--- a/internal/venice-common/src/main/java/com/linkedin/venice/authentication/AuthenticationServiceUtils.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/authentication/AuthenticationServiceUtils.java
@@ -1,0 +1,34 @@
+package com.linkedin.venice.authentication;
+
+import com.linkedin.venice.utils.VeniceProperties;
+import java.util.Optional;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+
+public abstract class AuthenticationServiceUtils {
+  private static final Logger LOGGER = LogManager.getLogger(AuthenticationServiceUtils.class);
+
+  private AuthenticationServiceUtils() {
+  }
+
+  public static Optional<AuthenticationService> buildAuthenticationService(VeniceProperties veniceProperties) {
+    String className = veniceProperties.getString("authentication.service.class", "");
+    if (className.isEmpty()) {
+      return Optional.empty();
+    }
+    LOGGER.info("Building authentication service: {}", className);
+    try {
+      AuthenticationService authenticationService =
+          Class.forName(className, false, AuthenticationService.class.getClassLoader())
+              .asSubclass(AuthenticationService.class)
+              .getConstructor()
+              .newInstance();
+      authenticationService.initialise(veniceProperties);
+      return Optional.of(authenticationService);
+    } catch (Exception ex) {
+      throw new IllegalStateException(ex);
+    }
+  }
+
+}

--- a/internal/venice-common/src/main/java/com/linkedin/venice/authentication/LogOnlyAuthenticationService.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/authentication/LogOnlyAuthenticationService.java
@@ -1,0 +1,28 @@
+package com.linkedin.venice.authentication;
+
+import com.linkedin.venice.authorization.Principal;
+import com.linkedin.venice.utils.VeniceProperties;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+
+public class LogOnlyAuthenticationService implements AuthenticationService {
+  private static final Logger LOGGER = LogManager.getLogger(LogOnlyAuthenticationService.class);
+
+  @Override
+  public void initialise(VeniceProperties veniceProperties) throws Exception {
+    LOGGER.info("initialise {}", veniceProperties);
+  }
+
+  @Override
+  public void close() {
+    LOGGER.info("close");
+  }
+
+  @Override
+  public Principal getPrincipalFromHttpRequest(HttpRequestAccessor requestAccessor) {
+    LOGGER.info("getPrincipalFromHttpRequest {}", requestAccessor);
+    return null;
+  }
+
+}

--- a/internal/venice-common/src/main/java/com/linkedin/venice/authorization/AuthorizerService.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/authorization/AuthorizerService.java
@@ -27,8 +27,8 @@ public interface AuthorizerService {
    * Check if the principal has the permission to perform the method on the resource. Implementation should define how to handle
    * duplicate/conflicting ACE entries present for the resource and also how to handle presence of no AceEntries for a resource.
    *
-   * @param method what method is being performed.
-   * @param resource what resource the method is being performed
+   * @param method    what method is being performed.
+   * @param resource  what resource the method is being performed
    * @param principal who is performing the method on the resource.
    * @return {@code true} if principal has the permission to perform the method on the resource, otherwise return {@code false}.
    */
@@ -38,8 +38,8 @@ public interface AuthorizerService {
    * Check if the principal has the permission to perform the method on the resource. Implementation should define how to handle
    * duplicate/conflicting ACE entries present for the resource and also how to handle presence of no AceEntries for a resource.
    *
-   * @param method what method is being performed.
-   * @param resource what resource the method is being performed
+   * @param method       what method is being performed.
+   * @param resource     what resource the method is being performed
    * @param accessorCert who is performing the method on the resource.
    * @return {@code true} if principal has the permission to perform the method on the resource, otherwise return {@code false}.
    */
@@ -48,6 +48,7 @@ public interface AuthorizerService {
   /**
    * Return a list of existing AceEntries present for the given resource.
    * Implementations should return an empty AclBinding object when no acl's are present for the resource.
+   *
    * @param resource
    * @return {@link AclBinding} object containg the list of existing aceEntries. The AceEntry list may be empty if there is no existing ACL's provisioned.
    */
@@ -90,24 +91,37 @@ public interface AuthorizerService {
   /**
    * This may perform any initialization steps that may be necessary before start provisioning any ACL's for a resource. This
    * may be used to setup/allocate any metadata/context about the resource.
-   *
+   * <p>
    * This is optional to implement.
    * Implementation should mandate if this needs to be called before start provisioning any ACL's for the resource.
+   *
    * @param resource
    */
   public default void setupResource(Resource resource) {
-  };
+  }
+
+  ;
 
   /**
    * This may perform any finalization steps that may be necessary after all ACL's for a resource is deleted and the resource will
    * not be used later. This may be used to clean up any metadata/context information about the resource that was setup in
    * {@link #setupResource}.
-   *
+   * <p>
    * This is optional to implement.
    * Implementation should mandate if this needs to be called after deleting all ACL's for the resource.
+   *
    * @param resource
    */
   public default void clearResource(Resource resource) {
-  };
+  }
+
+  /**
+   * Tells whether the user is a super user or not. This is used to bypass ACL checks.
+   * @param principal
+   * @return true or false
+   */
+  public default boolean isSuperUser(Principal principal, String storeName) {
+    return false;
+  }
 
 }

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/integration/utils/ServiceFactory.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/integration/utils/ServiceFactory.java
@@ -164,6 +164,8 @@ public class ServiceFactory {
           Optional.empty(),
           false,
           Optional.empty(),
+          Optional.empty(),
+          Optional.empty(),
           bannedRoutes,
           null,
           false,

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/integration/utils/VeniceControllerCreateOptions.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/integration/utils/VeniceControllerCreateOptions.java
@@ -8,6 +8,7 @@ import static com.linkedin.venice.integration.utils.VeniceClusterWrapperConstant
 import static com.linkedin.venice.integration.utils.VeniceClusterWrapperConstants.DEFAULT_REPLICATION_FACTOR;
 import static com.linkedin.venice.integration.utils.VeniceControllerWrapper.DEFAULT_PARENT_DATA_CENTER_REGION_NAME;
 
+import com.linkedin.venice.authentication.AuthenticationService;
 import com.linkedin.venice.authorization.AuthorizerService;
 import java.util.Arrays;
 import java.util.Map;
@@ -32,6 +33,7 @@ public class VeniceControllerCreateOptions {
   private final PubSubBrokerWrapper kafkaBroker;
   private final Properties extraProperties;
   private final AuthorizerService authorizerService;
+  private final AuthenticationService authenticationService;
   private final String regionName;
 
   private VeniceControllerCreateOptions(Builder builder) {
@@ -48,6 +50,7 @@ public class VeniceControllerCreateOptions {
     zkServer = builder.zkServer;
     kafkaBroker = builder.kafkaBroker;
     extraProperties = builder.extraProperties;
+    authenticationService = builder.authenticationService;
     authorizerService = builder.authorizerService;
     isParent = builder.childControllers != null && builder.childControllers.length != 0;
     regionName = builder.regionName;
@@ -172,6 +175,10 @@ public class VeniceControllerCreateOptions {
     return authorizerService;
   }
 
+  public AuthenticationService getAuthenticationService() {
+    return authenticationService;
+  }
+
   public String getRegionName() {
     return regionName;
   }
@@ -192,6 +199,7 @@ public class VeniceControllerCreateOptions {
     private VeniceControllerWrapper[] childControllers = null;
     private Properties extraProperties = new Properties();
     private AuthorizerService authorizerService;
+    private AuthenticationService authenticationService;
     private String regionName = "";
 
     public Builder(String[] clusterNames, ZkServerWrapper zkServer, PubSubBrokerWrapper kafkaBroker) {
@@ -258,6 +266,11 @@ public class VeniceControllerCreateOptions {
 
     public Builder authorizerService(AuthorizerService authorizerService) {
       this.authorizerService = authorizerService;
+      return this;
+    }
+
+    public Builder authenticationService(AuthenticationService authenticationService) {
+      this.authenticationService = authenticationService;
       return this;
     }
 

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/integration/utils/VeniceControllerWrapper.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/integration/utils/VeniceControllerWrapper.java
@@ -321,6 +321,7 @@ public class VeniceControllerWrapper extends ProcessWrapper {
           metricsRepository,
           d2ServerList,
           Optional.empty(),
+          Optional.ofNullable(options.getAuthenticationService()),
           Optional.ofNullable(options.getAuthorizerService()),
           d2Client,
           consumerClientConfig,
@@ -409,7 +410,7 @@ public class VeniceControllerWrapper extends ProcessWrapper {
       d2ServerList.add(createD2Server(zkAddress, securePort, true, isParent));
     }
     D2Client d2Client = D2TestUtils.getAndStartD2Client(zkAddress);
-    service = new VeniceController(configs, d2ServerList, Optional.empty(), d2Client);
+    service = new VeniceController(configs, d2ServerList, Optional.empty(), Optional.empty(), d2Client);
   }
 
   /***

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/AbstractRoute.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/AbstractRoute.java
@@ -6,6 +6,11 @@ import static com.linkedin.venice.controllerapi.ControllerApiConstants.NAME;
 
 import com.linkedin.venice.acl.AclException;
 import com.linkedin.venice.acl.DynamicAccessController;
+import com.linkedin.venice.authentication.AuthenticationService;
+import com.linkedin.venice.authorization.AuthorizerService;
+import com.linkedin.venice.authorization.Method;
+import com.linkedin.venice.authorization.Principal;
+import com.linkedin.venice.authorization.Resource;
 import com.linkedin.venice.exceptions.VeniceException;
 import java.security.cert.X509Certificate;
 import java.util.Optional;
@@ -31,8 +36,19 @@ public class AbstractRoute {
   private static final ResourceAclCheck READ_ACCESS_TO_TOPIC =
       (cert, resourceName, aclClient) -> aclClient.hasAccessToTopic(cert, resourceName, "Read");
 
+  private static final PermissionAssertion ASSERT_ACCESS_TO_STORE =
+      (principal, resource, auth) -> auth.canAccess(Method.GET, resource, principal);
+  // A singleton of acl check function against topic resource
+  private static final PermissionAssertion ASSERT_WRITE_ACCESS_TO_TOPIC =
+      (principal, resource, auth) -> auth.canAccess(Method.Write, resource, principal);
+
+  private static final PermissionAssertion ASSERT_READ_ACCESS_TO_TOPIC =
+      (principal, resource, auth) -> auth.canAccess(Method.Read, resource, principal);
+
   private final boolean sslEnabled;
   private final Optional<DynamicAccessController> accessController;
+  private final Optional<AuthenticationService> authenticationService;
+  private final Optional<AuthorizerService> authorizerService;
 
   /**
    * Default constructor for different controller request routes.
@@ -41,25 +57,48 @@ public class AbstractRoute {
    * through this constructor; make sure Nuage is also in the allowlist so that they can create stores
    * @param accessController the access client that check whether a certificate can access a resource
    */
-  public AbstractRoute(boolean sslEnabled, Optional<DynamicAccessController> accessController) {
+  public AbstractRoute(
+      boolean sslEnabled,
+      Optional<DynamicAccessController> accessController,
+      Optional<AuthenticationService> authenticationService,
+      Optional<AuthorizerService> authorizerService) {
     this.sslEnabled = sslEnabled;
+    this.authenticationService = authenticationService;
     this.accessController = accessController;
+    this.authorizerService = authorizerService;
   }
 
   /**
    * Check whether the user certificate in request has access to the store specified in
    * the request.
    */
-  private boolean hasAccess(Request request, ResourceAclCheck aclCheckFunction) {
+  private boolean hasAccess(Request request, ResourceAclCheck aclCheckFunction, PermissionAssertion assertion) {
+    Principal principal = getPrincipal(request);
+    LOGGER.info("hasAccess {} {} {}", request, principal, authenticationService);
+
+    String storeName = request.queryParams(NAME);
+
+    if (authorizerService.isPresent()) {
+      boolean allowed = assertion.apply(principal, new Resource(storeName), authorizerService.get());
+      if (!allowed) {
+        LOGGER.warn(
+            "Client {} [host:{} IP:{}] doesn't have access to store {}",
+            principal,
+            request.host(),
+            request.ip(),
+            storeName);
+        return false;
+      }
+    }
+
     if (!isAclEnabled()) {
       /**
        * Grant access if it's not required to check ACL.
        */
       return true;
     }
-    X509Certificate certificate = getCertificate(request);
 
-    String storeName = request.queryParams(NAME);
+    X509Certificate certificate = getCertificate(request);
     /**
      * Currently Nuage only supports adding GET/POST methods for a store resource
      * TODO: Feature request for Nuage to support other method like PUT or customized methods
@@ -92,20 +131,36 @@ public class AbstractRoute {
    * Check whether the user has "Write" method access to the related version topics.
    */
   protected boolean hasWriteAccessToTopic(Request request) {
-    return hasAccess(request, WRITE_ACCESS_TO_TOPIC);
+    return hasAccess(request, WRITE_ACCESS_TO_TOPIC, ASSERT_WRITE_ACCESS_TO_TOPIC);
   }
 
   /**
    * Check whether the user has "Read" method access to the related version topics.
    */
   protected boolean hasReadAccessToTopic(Request request) {
-    return hasAccess(request, READ_ACCESS_TO_TOPIC);
+    return hasAccess(request, READ_ACCESS_TO_TOPIC, ASSERT_READ_ACCESS_TO_TOPIC);
+  }
+
+  protected Principal getPrincipal(Request request) {
+    return authenticationService.map(service -> {
+      AuthenticationService.HttpRequestAccessor requestAccessor = new HttpRequestAccessor(request);
+      return service.getPrincipalFromHttpRequest(requestAccessor);
+    }).orElse(null);
   }
 
   /**
    * Get principal Id from request.
    */
   protected String getPrincipalId(Request request) {
+
+    if (authenticationService.isPresent()) {
+      Principal principal = getPrincipal(request);
+      if (principal != null) {
+        return principal.getName();
+      }
+      // fallback to legacy implementation
+    }
+
     if (!isSslEnabled()) {
       LOGGER.warn("SSL is not enabled. No certificate could be extracted from request.");
       return USER_UNKNOWN;
@@ -130,14 +185,22 @@ public class AbstractRoute {
    * ACL is not checked for requests that want to get metadata of a store/job.
    */
   protected boolean hasAccessToStore(Request request) {
-    return hasAccess(request, GET_ACCESS_TO_STORE);
+    return hasAccess(request, GET_ACCESS_TO_STORE, ASSERT_ACCESS_TO_STORE);
   }
 
   /**
    * Check whether the user is within the admin users allowlist.
    */
   protected boolean isAllowListUser(Request request) {
+    String storeName = request.queryParamOrDefault(NAME, STORE_UNKNOWN);
     if (!isAclEnabled()) {
+      if (authenticationService.isPresent()) {
+        Principal principal = getPrincipal(request);
+        if (authorizerService.isPresent()) {
+          return authorizerService.get().isSuperUser(principal, storeName);
+        }
+      }
+
       /**
        * Grant access if it's not required to check ACL.
        * {@link accessController} will be empty if ACL is not enabled.
@@ -145,8 +208,6 @@ public class AbstractRoute {
       return true;
     }
     X509Certificate certificate = getCertificate(request);
-
-    String storeName = request.queryParamOrDefault(NAME, STORE_UNKNOWN);
     return accessController.get().isAllowlistUsers(certificate, storeName, HTTP_GET);
   }
 
@@ -170,11 +231,16 @@ public class AbstractRoute {
   /**
    * Helper function to get certificate out of Spark request
    */
-  protected static X509Certificate getCertificate(Request request) {
+  protected X509Certificate getCertificate(Request request) {
     HttpServletRequest rawRequest = request.raw();
     Object certificateObject = rawRequest.getAttribute(CONTROLLER_SSL_CERTIFICATE_ATTRIBUTE_NAME);
     if (certificateObject == null) {
-      throw new VeniceException("Client request doesn't contain certificate for store: " + request.queryParams(NAME));
+      if (accessController.isPresent()) {
+        throw new VeniceException("Client request doesn't contain certificate for store: " + request.queryParams(NAME));
+      } else {
+        // it is okay to not have certificate if legacy accessController is not configured
+        return null;
+      }
     }
     return ((X509Certificate[]) certificateObject)[0];
   }
@@ -186,5 +252,33 @@ public class AbstractRoute {
   interface ResourceAclCheck {
     boolean apply(X509Certificate clientCert, String resource, DynamicAccessController accessController)
         throws AclException;
+  }
+
+  @FunctionalInterface
+  interface PermissionAssertion {
+    boolean apply(Principal principal, Resource resource, AuthorizerService authorizerService);
+  }
+
+  private class HttpRequestAccessor implements AuthenticationService.HttpRequestAccessor {
+    private final Request request;
+
+    public HttpRequestAccessor(Request request) {
+      this.request = request;
+    }
+
+    @Override
+    public String getHeader(String headerName) {
+      return request.headers(headerName);
+    }
+
+    @Override
+    public X509Certificate getCertificate() {
+      return AbstractRoute.this.getCertificate(request);
+    }
+
+    @Override
+    public String toString() {
+      return request.toString();
+    }
   }
 }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/AdminCommandExecutionRoutes.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/AdminCommandExecutionRoutes.java
@@ -8,6 +8,8 @@ import static com.linkedin.venice.controllerapi.ControllerRoute.LAST_SUCCEED_EXE
 import com.linkedin.venice.HttpConstants;
 import com.linkedin.venice.LastSucceedExecutionIdResponse;
 import com.linkedin.venice.acl.DynamicAccessController;
+import com.linkedin.venice.authentication.AuthenticationService;
+import com.linkedin.venice.authorization.AuthorizerService;
 import com.linkedin.venice.controller.Admin;
 import com.linkedin.venice.controller.AdminCommandExecutionTracker;
 import com.linkedin.venice.controllerapi.AdminCommandExecution;
@@ -17,8 +19,12 @@ import spark.Route;
 
 
 public class AdminCommandExecutionRoutes extends AbstractRoute {
-  public AdminCommandExecutionRoutes(boolean sslEnabled, Optional<DynamicAccessController> accessController) {
-    super(sslEnabled, accessController);
+  public AdminCommandExecutionRoutes(
+      boolean sslEnabled,
+      Optional<DynamicAccessController> accessController,
+      Optional<AuthenticationService> authenticationService,
+      Optional<AuthorizerService> authorizerService) {
+    super(sslEnabled, accessController, authenticationService, authorizerService);
   }
 
   /**

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/AdminTopicMetadataRoutes.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/AdminTopicMetadataRoutes.java
@@ -10,6 +10,8 @@ import static com.linkedin.venice.controllerapi.ControllerRoute.UPDATE_ADMIN_TOP
 
 import com.linkedin.venice.HttpConstants;
 import com.linkedin.venice.acl.DynamicAccessController;
+import com.linkedin.venice.authentication.AuthenticationService;
+import com.linkedin.venice.authorization.AuthorizerService;
 import com.linkedin.venice.controller.Admin;
 import com.linkedin.venice.controller.AdminTopicMetadataAccessor;
 import com.linkedin.venice.controllerapi.AdminTopicMetadataResponse;
@@ -24,8 +26,12 @@ import spark.Route;
 
 
 public class AdminTopicMetadataRoutes extends AbstractRoute {
-  public AdminTopicMetadataRoutes(boolean sslEnabled, Optional<DynamicAccessController> accessController) {
-    super(sslEnabled, accessController);
+  public AdminTopicMetadataRoutes(
+      boolean sslEnabled,
+      Optional<DynamicAccessController> accessController,
+      Optional<AuthenticationService> authenticationService,
+      Optional<AuthorizerService> authorizerService) {
+    super(sslEnabled, accessController, authenticationService, authorizerService);
   }
 
   /**

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/ClusterRoutes.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/ClusterRoutes.java
@@ -10,6 +10,8 @@ import static com.linkedin.venice.controllerapi.ControllerRoute.UPDATE_CLUSTER_C
 import static com.linkedin.venice.controllerapi.ControllerRoute.WIPE_CLUSTER;
 
 import com.linkedin.venice.acl.DynamicAccessController;
+import com.linkedin.venice.authentication.AuthenticationService;
+import com.linkedin.venice.authorization.AuthorizerService;
 import com.linkedin.venice.controller.Admin;
 import com.linkedin.venice.controllerapi.ControllerResponse;
 import com.linkedin.venice.controllerapi.MultiStoreTopicsResponse;
@@ -23,8 +25,12 @@ import spark.Route;
 
 
 public class ClusterRoutes extends AbstractRoute {
-  public ClusterRoutes(boolean sslEnabled, Optional<DynamicAccessController> accessController) {
-    super(sslEnabled, accessController);
+  public ClusterRoutes(
+      boolean sslEnabled,
+      Optional<DynamicAccessController> accessController,
+      Optional<AuthenticationService> authenticationService,
+      Optional<AuthorizerService> authorizerService) {
+    super(sslEnabled, accessController, authenticationService, authorizerService);
   }
 
   /**

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/ControllerRoutes.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/ControllerRoutes.java
@@ -13,6 +13,8 @@ import static com.linkedin.venice.controllerapi.ControllerRoute.UPDATE_KAFKA_TOP
 
 import com.linkedin.venice.HttpConstants;
 import com.linkedin.venice.acl.DynamicAccessController;
+import com.linkedin.venice.authentication.AuthenticationService;
+import com.linkedin.venice.authorization.AuthorizerService;
 import com.linkedin.venice.controller.Admin;
 import com.linkedin.venice.controllerapi.ChildAwareResponse;
 import com.linkedin.venice.controllerapi.ControllerResponse;
@@ -37,8 +39,10 @@ public class ControllerRoutes extends AbstractRoute {
   public ControllerRoutes(
       boolean sslEnabled,
       Optional<DynamicAccessController> accessController,
-      PubSubTopicRepository pubSubTopicRepository) {
-    super(sslEnabled, accessController);
+      PubSubTopicRepository pubSubTopicRepository,
+      Optional<AuthenticationService> authenticationService,
+      Optional<AuthorizerService> authorizerService) {
+    super(sslEnabled, accessController, authenticationService, authorizerService);
     this.pubSubTopicRepository = pubSubTopicRepository;
   }
 

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/CreateStore.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/CreateStore.java
@@ -14,6 +14,8 @@ import static com.linkedin.venice.controllerapi.ControllerRoute.UPDATE_ACL;
 
 import com.linkedin.venice.HttpConstants;
 import com.linkedin.venice.acl.DynamicAccessController;
+import com.linkedin.venice.authentication.AuthenticationService;
+import com.linkedin.venice.authorization.AuthorizerService;
 import com.linkedin.venice.controller.Admin;
 import com.linkedin.venice.controllerapi.AclResponse;
 import com.linkedin.venice.controllerapi.ControllerResponse;
@@ -24,8 +26,12 @@ import spark.Route;
 
 
 public class CreateStore extends AbstractRoute {
-  public CreateStore(boolean sslEnabled, Optional<DynamicAccessController> accessController) {
-    super(sslEnabled, accessController);
+  public CreateStore(
+      boolean sslEnabled,
+      Optional<DynamicAccessController> accessController,
+      Optional<AuthenticationService> authenticationService,
+      Optional<AuthorizerService> authorizerService) {
+    super(sslEnabled, accessController, authenticationService, authorizerService);
   }
 
   /**

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/CreateVersion.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/CreateVersion.java
@@ -27,6 +27,8 @@ import static com.linkedin.venice.meta.Version.REPLICATION_METADATA_VERSION_ID_U
 
 import com.linkedin.venice.HttpConstants;
 import com.linkedin.venice.acl.DynamicAccessController;
+import com.linkedin.venice.authentication.AuthenticationService;
+import com.linkedin.venice.authorization.AuthorizerService;
 import com.linkedin.venice.compression.CompressionStrategy;
 import com.linkedin.venice.controller.Admin;
 import com.linkedin.venice.controllerapi.ControllerResponse;
@@ -63,8 +65,10 @@ public class CreateVersion extends AbstractRoute {
       boolean sslEnabled,
       Optional<DynamicAccessController> accessController,
       boolean checkReadMethodForKafka,
-      boolean disableParentRequestTopicForStreamPushes) {
-    super(sslEnabled, accessController);
+      boolean disableParentRequestTopicForStreamPushes,
+      Optional<AuthenticationService> authenticationService,
+      Optional<AuthorizerService> authorizerService) {
+    super(sslEnabled, accessController, authenticationService, authorizerService);
     this.checkReadMethodForKafka = checkReadMethodForKafka;
     this.disableParentRequestTopicForStreamPushes = disableParentRequestTopicForStreamPushes;
   }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/DataRecoveryRoutes.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/DataRecoveryRoutes.java
@@ -13,6 +13,8 @@ import static com.linkedin.venice.controllerapi.ControllerRoute.IS_STORE_VERSION
 import static com.linkedin.venice.controllerapi.ControllerRoute.PREPARE_DATA_RECOVERY;
 
 import com.linkedin.venice.acl.DynamicAccessController;
+import com.linkedin.venice.authentication.AuthenticationService;
+import com.linkedin.venice.authorization.AuthorizerService;
 import com.linkedin.venice.controller.Admin;
 import com.linkedin.venice.controllerapi.ControllerResponse;
 import com.linkedin.venice.controllerapi.ReadyForDataRecoveryResponse;
@@ -31,8 +33,12 @@ import spark.Route;
 public class DataRecoveryRoutes extends AbstractRoute {
   private final VeniceJsonSerializer<Version> versionVeniceJsonSerializer = new VeniceJsonSerializer<>(Version.class);
 
-  public DataRecoveryRoutes(boolean sslEnabled, Optional<DynamicAccessController> accessController) {
-    super(sslEnabled, accessController);
+  public DataRecoveryRoutes(
+      boolean sslEnabled,
+      Optional<DynamicAccessController> accessController,
+      Optional<AuthenticationService> authenticationService,
+      Optional<AuthorizerService> authorizerService) {
+    super(sslEnabled, accessController, authenticationService, authorizerService);
   }
 
   /**

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/JobRoutes.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/JobRoutes.java
@@ -15,6 +15,8 @@ import static com.linkedin.venice.controllerapi.ControllerRoute.SEND_PUSH_JOB_DE
 import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
 import com.linkedin.venice.HttpConstants;
 import com.linkedin.venice.acl.DynamicAccessController;
+import com.linkedin.venice.authentication.AuthenticationService;
+import com.linkedin.venice.authorization.AuthorizerService;
 import com.linkedin.venice.controller.Admin;
 import com.linkedin.venice.controllerapi.ControllerResponse;
 import com.linkedin.venice.controllerapi.IncrementalPushVersionsResponse;
@@ -42,8 +44,12 @@ public class JobRoutes extends AbstractRoute {
   private final InternalAvroSpecificSerializer<PushJobDetails> pushJobDetailsSerializer =
       AvroProtocolDefinition.PUSH_JOB_DETAILS.getSerializer();
 
-  public JobRoutes(boolean sslEnabled, Optional<DynamicAccessController> accessController) {
-    super(sslEnabled, accessController);
+  public JobRoutes(
+      boolean sslEnabled,
+      Optional<DynamicAccessController> accessController,
+      Optional<AuthenticationService> authenticationService,
+      Optional<AuthorizerService> authorizerService) {
+    super(sslEnabled, accessController, authenticationService, authorizerService);
   }
 
   /**

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/MigrationRoutes.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/MigrationRoutes.java
@@ -6,6 +6,8 @@ import static com.linkedin.venice.controllerapi.ControllerRoute.SET_MIGRATION_PU
 
 import com.linkedin.venice.HttpConstants;
 import com.linkedin.venice.acl.DynamicAccessController;
+import com.linkedin.venice.authentication.AuthenticationService;
+import com.linkedin.venice.authorization.AuthorizerService;
 import com.linkedin.venice.controller.Admin;
 import com.linkedin.venice.controllerapi.ControllerResponse;
 import com.linkedin.venice.controllerapi.MigrationPushStrategyResponse;
@@ -16,8 +18,12 @@ import spark.Route;
 
 
 public class MigrationRoutes extends AbstractRoute {
-  public MigrationRoutes(boolean sslEnabled, Optional<DynamicAccessController> accessController) {
-    super(sslEnabled, accessController);
+  public MigrationRoutes(
+      boolean sslEnabled,
+      Optional<DynamicAccessController> accessController,
+      Optional<AuthenticationService> authenticationService,
+      Optional<AuthorizerService> authorizerService) {
+    super(sslEnabled, accessController, authenticationService, authorizerService);
   }
 
   /**

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/NewClusterBuildOutRoutes.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/NewClusterBuildOutRoutes.java
@@ -7,6 +7,8 @@ import static com.linkedin.venice.controllerapi.ControllerApiConstants.SOURCE_FA
 import static com.linkedin.venice.controllerapi.ControllerRoute.REPLICATE_META_DATA;
 
 import com.linkedin.venice.acl.DynamicAccessController;
+import com.linkedin.venice.authentication.AuthenticationService;
+import com.linkedin.venice.authorization.AuthorizerService;
 import com.linkedin.venice.controller.Admin;
 import com.linkedin.venice.controllerapi.StoreResponse;
 import com.linkedin.venice.meta.StoreInfo;
@@ -16,8 +18,12 @@ import spark.Route;
 
 
 public class NewClusterBuildOutRoutes extends AbstractRoute {
-  public NewClusterBuildOutRoutes(boolean sslEnabled, Optional<DynamicAccessController> accessController) {
-    super(sslEnabled, accessController);
+  public NewClusterBuildOutRoutes(
+      boolean sslEnabled,
+      Optional<DynamicAccessController> accessController,
+      Optional<AuthenticationService> authenticationService,
+      Optional<AuthorizerService> authorizerService) {
+    super(sslEnabled, accessController, authenticationService, authorizerService);
   }
 
   /**

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/NodesAndReplicas.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/NodesAndReplicas.java
@@ -20,6 +20,8 @@ import static com.linkedin.venice.controllerapi.ControllerRoute.REMOVE_NODE;
 
 import com.linkedin.venice.HttpConstants;
 import com.linkedin.venice.acl.DynamicAccessController;
+import com.linkedin.venice.authentication.AuthenticationService;
+import com.linkedin.venice.authorization.AuthorizerService;
 import com.linkedin.venice.controller.Admin;
 import com.linkedin.venice.controller.NodeRemovableResult;
 import com.linkedin.venice.controllerapi.ControllerResponse;
@@ -55,8 +57,12 @@ public class NodesAndReplicas extends AbstractRoute {
   /**
    * TODO: Make sure services "venice-hooks-deployable" is also in allowlist
    */
-  public NodesAndReplicas(boolean sslEnabled, Optional<DynamicAccessController> accessController) {
-    super(sslEnabled, accessController);
+  public NodesAndReplicas(
+      boolean sslEnabled,
+      Optional<DynamicAccessController> accessController,
+      Optional<AuthenticationService> authenticationService,
+      Optional<AuthorizerService> authorizerService) {
+    super(sslEnabled, accessController, authenticationService, authorizerService);
   }
 
   /**

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/RoutersClusterConfigRoutes.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/RoutersClusterConfigRoutes.java
@@ -9,6 +9,8 @@ import static com.linkedin.venice.controllerapi.ControllerRoute.ENABLE_THROTTLIN
 import static com.linkedin.venice.controllerapi.ControllerRoute.GET_ROUTERS_CLUSTER_CONFIG;
 
 import com.linkedin.venice.acl.DynamicAccessController;
+import com.linkedin.venice.authentication.AuthenticationService;
+import com.linkedin.venice.authorization.AuthorizerService;
 import com.linkedin.venice.controller.Admin;
 import com.linkedin.venice.controllerapi.ControllerResponse;
 import com.linkedin.venice.controllerapi.RoutersClusterConfigResponse;
@@ -19,8 +21,12 @@ import spark.Route;
 
 
 public class RoutersClusterConfigRoutes extends AbstractRoute {
-  public RoutersClusterConfigRoutes(boolean sslEnabled, Optional<DynamicAccessController> accessController) {
-    super(sslEnabled, accessController);
+  public RoutersClusterConfigRoutes(
+      boolean sslEnabled,
+      Optional<DynamicAccessController> accessController,
+      Optional<AuthenticationService> authenticationService,
+      Optional<AuthorizerService> authorizerService) {
+    super(sslEnabled, accessController, authenticationService, authorizerService);
   }
 
   /**

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/SchemaRoutes.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/SchemaRoutes.java
@@ -18,6 +18,8 @@ import static com.linkedin.venice.controllerapi.ControllerRoute.REMOVE_DERIVED_S
 
 import com.linkedin.venice.HttpConstants;
 import com.linkedin.venice.acl.DynamicAccessController;
+import com.linkedin.venice.authentication.AuthenticationService;
+import com.linkedin.venice.authorization.AuthorizerService;
 import com.linkedin.venice.controller.Admin;
 import com.linkedin.venice.controllerapi.ControllerApiConstants;
 import com.linkedin.venice.controllerapi.MultiSchemaResponse;
@@ -44,8 +46,12 @@ import spark.Route;
 
 
 public class SchemaRoutes extends AbstractRoute {
-  public SchemaRoutes(boolean sslEnabled, Optional<DynamicAccessController> accessController) {
-    super(sslEnabled, accessController);
+  public SchemaRoutes(
+      boolean sslEnabled,
+      Optional<DynamicAccessController> accessController,
+      Optional<AuthenticationService> authenticationService,
+      Optional<AuthorizerService> authorizerService) {
+    super(sslEnabled, accessController, authenticationService, authorizerService);
   }
 
   /**

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/SkipAdminRoute.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/SkipAdminRoute.java
@@ -7,6 +7,8 @@ import static com.linkedin.venice.controllerapi.ControllerRoute.SKIP_ADMIN;
 
 import com.linkedin.venice.HttpConstants;
 import com.linkedin.venice.acl.DynamicAccessController;
+import com.linkedin.venice.authentication.AuthenticationService;
+import com.linkedin.venice.authorization.AuthorizerService;
 import com.linkedin.venice.controller.Admin;
 import com.linkedin.venice.controllerapi.ControllerResponse;
 import com.linkedin.venice.exceptions.ErrorType;
@@ -17,8 +19,12 @@ import spark.Route;
 
 
 public class SkipAdminRoute extends AbstractRoute {
-  public SkipAdminRoute(boolean sslEnabled, Optional<DynamicAccessController> accessController) {
-    super(sslEnabled, accessController);
+  public SkipAdminRoute(
+      boolean sslEnabled,
+      Optional<DynamicAccessController> accessController,
+      Optional<AuthenticationService> authenticationService,
+      Optional<AuthorizerService> authorizerService) {
+    super(sslEnabled, accessController, authenticationService, authorizerService);
   }
 
   /**

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/StoragePersonaRoutes.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/StoragePersonaRoutes.java
@@ -11,6 +11,8 @@ import static com.linkedin.venice.controllerapi.ControllerRoute.GET_STORAGE_PERS
 import static com.linkedin.venice.controllerapi.ControllerRoute.UPDATE_STORAGE_PERSONA;
 
 import com.linkedin.venice.acl.DynamicAccessController;
+import com.linkedin.venice.authentication.AuthenticationService;
+import com.linkedin.venice.authorization.AuthorizerService;
 import com.linkedin.venice.controller.Admin;
 import com.linkedin.venice.controllerapi.ControllerResponse;
 import com.linkedin.venice.controllerapi.MultiStoragePersonaResponse;
@@ -27,8 +29,12 @@ import spark.Route;
 
 
 public class StoragePersonaRoutes extends AbstractRoute {
-  public StoragePersonaRoutes(boolean sslEnabled, Optional<DynamicAccessController> accessController) {
-    super(sslEnabled, accessController);
+  public StoragePersonaRoutes(
+      boolean sslEnabled,
+      Optional<DynamicAccessController> accessController,
+      Optional<AuthenticationService> authenticationService,
+      Optional<AuthorizerService> authorizerService) {
+    super(sslEnabled, accessController, authenticationService, authorizerService);
   }
 
   /**

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/StoresRoutes.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/StoresRoutes.java
@@ -53,6 +53,8 @@ import static com.linkedin.venice.controllerapi.ControllerRoute.UPDATE_STORE;
 
 import com.linkedin.venice.HttpConstants;
 import com.linkedin.venice.acl.DynamicAccessController;
+import com.linkedin.venice.authentication.AuthenticationService;
+import com.linkedin.venice.authorization.AuthorizerService;
 import com.linkedin.venice.controller.Admin;
 import com.linkedin.venice.controller.AdminCommandExecutionTracker;
 import com.linkedin.venice.controller.kafka.TopicCleanupService;
@@ -112,8 +114,10 @@ public class StoresRoutes extends AbstractRoute {
   public StoresRoutes(
       boolean sslEnabled,
       Optional<DynamicAccessController> accessController,
-      PubSubTopicRepository pubSubTopicRepository) {
-    super(sslEnabled, accessController);
+      PubSubTopicRepository pubSubTopicRepository,
+      Optional<AuthenticationService> authenticationService,
+      Optional<AuthorizerService> authorizerService) {
+    super(sslEnabled, accessController, authenticationService, authorizerService);
     this.pubSubTopicRepository = pubSubTopicRepository;
   }
 

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/VersionRoute.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/VersionRoute.java
@@ -4,6 +4,8 @@ import static com.linkedin.venice.controllerapi.ControllerApiConstants.CLUSTER;
 import static com.linkedin.venice.controllerapi.ControllerRoute.LIST_BOOTSTRAPPING_VERSIONS;
 
 import com.linkedin.venice.acl.DynamicAccessController;
+import com.linkedin.venice.authentication.AuthenticationService;
+import com.linkedin.venice.authorization.AuthorizerService;
 import com.linkedin.venice.controller.Admin;
 import com.linkedin.venice.controllerapi.MultiVersionStatusResponse;
 import java.util.Optional;
@@ -12,8 +14,12 @@ import spark.Route;
 
 
 public class VersionRoute extends AbstractRoute {
-  public VersionRoute(boolean sslEnabled, Optional<DynamicAccessController> accessController) {
-    super(sslEnabled, accessController);
+  public VersionRoute(
+      boolean sslEnabled,
+      Optional<DynamicAccessController> accessController,
+      Optional<AuthenticationService> authenticationService,
+      Optional<AuthorizerService> authorizerService) {
+    super(sslEnabled, accessController, authenticationService, authorizerService);
   }
 
   /**

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/ControllerRoutesTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/ControllerRoutesTest.java
@@ -40,7 +40,8 @@ public class ControllerRoutesTest {
     doReturn(TEST_CLUSTER).when(request).queryParams(eq(ControllerApiConstants.CLUSTER));
 
     Route leaderControllerRoute =
-        new ControllerRoutes(false, Optional.empty(), pubSubTopicRepository).getLeaderController(mockAdmin);
+        new ControllerRoutes(false, Optional.empty(), pubSubTopicRepository, Optional.empty(), Optional.empty())
+            .getLeaderController(mockAdmin);
     LeaderControllerResponse leaderControllerResponse = ObjectMapperFactory.getInstance()
         .readValue(
             leaderControllerRoute.handle(request, mock(Response.class)).toString(),
@@ -50,7 +51,8 @@ public class ControllerRoutesTest {
     Assert.assertEquals(leaderControllerResponse.getSecureUrl(), "https://" + TEST_HOST + ":" + TEST_SSL_PORT);
 
     Route leaderControllerSslRoute =
-        new ControllerRoutes(true, Optional.empty(), pubSubTopicRepository).getLeaderController(mockAdmin);
+        new ControllerRoutes(true, Optional.empty(), pubSubTopicRepository, Optional.empty(), Optional.empty())
+            .getLeaderController(mockAdmin);
     LeaderControllerResponse leaderControllerResponseSsl = ObjectMapperFactory.getInstance()
         .readValue(
             leaderControllerSslRoute.handle(request, mock(Response.class)).toString(),

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/CreateStoreTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/CreateStoreTest.java
@@ -53,7 +53,7 @@ public class CreateStoreTest {
     doReturn("\"long\"").when(request).queryParams(KEY_SCHEMA);
     doReturn("\"string\"").when(request).queryParams(VALUE_SCHEMA);
 
-    CreateStore createStoreRoute = new CreateStore(false, Optional.empty());
+    CreateStore createStoreRoute = new CreateStore(false, Optional.empty(), Optional.empty(), Optional.empty());
     Route createStoreRouter = createStoreRoute.createStore(admin);
     createStoreRouter.handle(request, response);
     verify(response).status(HttpStatus.SC_INTERNAL_SERVER_ERROR);
@@ -82,7 +82,7 @@ public class CreateStoreTest {
     doReturn("\"long\"").when(request).queryParams(KEY_SCHEMA);
     doReturn("\"string\"").when(request).queryParams(VALUE_SCHEMA);
 
-    CreateStore createStoreRoute = new CreateStore(false, Optional.empty());
+    CreateStore createStoreRoute = new CreateStore(false, Optional.empty(), Optional.empty(), Optional.empty());
     Route createStoreRouter = createStoreRoute.createStore(admin);
     createStoreRouter.handle(request, response);
   }
@@ -102,7 +102,7 @@ public class CreateStoreTest {
 
     doReturn(clusterName).when(request).queryParams(CLUSTER);
 
-    CreateStore createStoreRoute = new CreateStore(false, Optional.empty());
+    CreateStore createStoreRoute = new CreateStore(false, Optional.empty(), Optional.empty(), Optional.empty());
     Route createStoreRouter = createStoreRoute.createStore(admin);
     createStoreRouter.handle(request, response);
     verify(response).status(HttpStatus.SC_BAD_REQUEST);
@@ -127,7 +127,7 @@ public class CreateStoreTest {
     doReturn("\"long\"").when(request).queryParams(KEY_SCHEMA);
     doReturn("\"string\"").when(request).queryParams(VALUE_SCHEMA);
 
-    CreateStore createStoreRoute = new CreateStore(false, Optional.empty());
+    CreateStore createStoreRoute = new CreateStore(false, Optional.empty(), Optional.empty(), Optional.empty());
     Route createStoreRouter = createStoreRoute.createStore(admin);
     createStoreRouter.handle(request, response);
     verify(response).status(HttpConstants.SC_MISDIRECTED_REQUEST);

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/CreateVersionTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/CreateVersionTest.java
@@ -108,7 +108,8 @@ public class CreateVersionTest {
     /**
      * Build a CreateVersion route.
      */
-    CreateVersion createVersion = new CreateVersion(true, Optional.of(accessClient), checkReadMethod, false);
+    CreateVersion createVersion =
+        new CreateVersion(true, Optional.of(accessClient), checkReadMethod, false, Optional.empty(), Optional.empty());
     Route createVersionRoute = createVersion.requestTopicForPushing(admin);
 
     // Not an allowlist user.
@@ -169,7 +170,8 @@ public class CreateVersionTest {
     assertTrue(store.isIncrementalPushEnabled());
 
     // Build a CreateVersion route.
-    CreateVersion createVersion = new CreateVersion(true, Optional.of(accessClient), false, false);
+    CreateVersion createVersion =
+        new CreateVersion(true, Optional.of(accessClient), false, false, Optional.empty(), Optional.empty());
     Route createVersionRoute = createVersion.requestTopicForPushing(admin);
 
     Object result = createVersionRoute.handle(request, response);
@@ -221,7 +223,8 @@ public class CreateVersionTest {
     assertTrue(store.isIncrementalPushEnabled());
 
     // Build a CreateVersion route.
-    CreateVersion createVersion = new CreateVersion(true, Optional.of(accessClient), false, false);
+    CreateVersion createVersion =
+        new CreateVersion(true, Optional.of(accessClient), false, false, Optional.empty(), Optional.empty());
     Route createVersionRoute = createVersion.requestTopicForPushing(admin);
 
     Object result = createVersionRoute.handle(request, response);
@@ -273,7 +276,8 @@ public class CreateVersionTest {
     assertTrue(admin.isParent());
 
     // Build a CreateVersion route.
-    CreateVersion createVersion = new CreateVersion(true, Optional.of(accessClient), false, false);
+    CreateVersion createVersion =
+        new CreateVersion(true, Optional.of(accessClient), false, false, Optional.empty(), Optional.empty());
     Route createVersionRoute = createVersion.requestTopicForPushing(admin);
     Object result = createVersionRoute.handle(request, response);
     assertNotNull(result);

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/JobRoutesTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/JobRoutesTest.java
@@ -33,7 +33,7 @@ public class JobRoutesTest {
     String cluster = Utils.getUniqueString("cluster");
     String store = Utils.getUniqueString("store");
     int version = 5;
-    JobRoutes jobRoutes = new JobRoutes(false, Optional.empty());
+    JobRoutes jobRoutes = new JobRoutes(false, Optional.empty(), Optional.empty(), Optional.empty());
     JobStatusQueryResponse response =
         jobRoutes.populateJobStatus(cluster, store, version, mockAdmin, Optional.empty(), null);
 

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/SchemaRoutesTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/SchemaRoutesTest.java
@@ -24,7 +24,7 @@ public class SchemaRoutesTest {
     Admin admin = mock(Admin.class);
     when(admin.getValueSchemaId(cluster, store, schemaStr)).thenReturn(SchemaData.INVALID_VALUE_SCHEMA_ID);
     when(admin.getStore(cluster, store)).thenReturn(null);
-    SchemaRoutes schemaRoutes = new SchemaRoutes(false, Optional.empty());
+    SchemaRoutes schemaRoutes = new SchemaRoutes(false, Optional.empty(), Optional.empty(), Optional.empty());
     try {
       schemaRoutes.populateSchemaResponseForValueOrDerivedSchemaID(admin, cluster, store, schemaStr);
     } catch (VeniceNoStoreException e) {

--- a/services/venice-standalone/config/controller.properties
+++ b/services/venice-standalone/config/controller.properties
@@ -35,3 +35,6 @@ enable.offline.push.ssl.whitelist=false
 kafka.linger.ms=0
 default.partition.count=1
 controller.zk.shared.metadata.system.schema.store.auto.creation.enabled=true
+
+
+authentication.service.class=com.linkedin.venice.authentication.LogOnlyAuthenticationService


### PR DESCRIPTION
## Summary, imperative, start upper case, don't end with a period

Introduce a new AuthenticationService API to allow pluggable Authentication mechanisms.

The idea is to eventually move out of AbstractRoute the Authentication mechanism (that currently is basically about extracting the X509 Certificate, that is pre-validated by the TLS subystem).

The AuthenticationService maps a request to a Principal, then it will be the AuthorizationService that can decide if the given principal is allowed to access the resources. 

## How was this PR tested?

TODO

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.