### PR TITLE
[controller][server] Move ideal state listener to EV repository and read Store Metadata for CV updates

### DIFF
--- a/internal/venice-common/src/main/java/com/linkedin/venice/helix/HelixBaseRoutingRepository.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/helix/HelixBaseRoutingRepository.java
@@ -91,7 +91,6 @@ public abstract class HelixBaseRoutingRepository
       // After adding the listener, helix will initialize the callback which will get the entire external view
       // and trigger the external view change event. In other words, venice will read the newest external view
       // immediately.
-      // manager.addIdealStateChangeListener(this);
       manager.addControllerListener(this);
       // Use routing table provider to get the notification of the external view change, customized view change,
       // and live instances change.
@@ -122,7 +121,6 @@ public abstract class HelixBaseRoutingRepository
   public void clear() {
     // removeListener method is a thread safe method, we don't need to lock here again.
     manager.removeListener(keyBuilder.controller(), this);
-    // manager.removeListener(keyBuilder.idealStates(), this);
     if (routingTableProvider != null) {
       routingTableProvider.removeRoutingTableChangeListener(this);
       try {

--- a/internal/venice-common/src/main/java/com/linkedin/venice/helix/HelixBaseRoutingRepository.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/helix/HelixBaseRoutingRepository.java
@@ -23,9 +23,7 @@ import org.apache.helix.PropertyKey;
 import org.apache.helix.PropertyType;
 import org.apache.helix.api.listeners.BatchMode;
 import org.apache.helix.api.listeners.ControllerChangeListener;
-import org.apache.helix.api.listeners.IdealStateChangeListener;
 import org.apache.helix.api.listeners.RoutingTableChangeListener;
-import org.apache.helix.model.IdealState;
 import org.apache.helix.model.LiveInstance;
 import org.apache.helix.spectator.RoutingTableProvider;
 import org.apache.helix.spectator.RoutingTableSnapshot;
@@ -47,7 +45,7 @@ import org.apache.logging.log4j.Logger;
  */
 @BatchMode
 public abstract class HelixBaseRoutingRepository
-    implements RoutingDataRepository, ControllerChangeListener, IdealStateChangeListener, RoutingTableChangeListener {
+    implements RoutingDataRepository, ControllerChangeListener, RoutingTableChangeListener {
   private static final Logger LOGGER = LogManager.getLogger(HelixBaseRoutingRepository.class);
 
   /**
@@ -69,8 +67,6 @@ public abstract class HelixBaseRoutingRepository
 
   protected final Lock liveInstancesMapLock = new ReentrantLock();
   protected Map<String, Instance> liveInstancesMap = new HashMap<>();
-
-  protected volatile Map<String, Integer> resourceToIdealPartitionCountMap;
 
   private long leaderControllerChangeTimeMs = -1;
 
@@ -95,7 +91,7 @@ public abstract class HelixBaseRoutingRepository
       // After adding the listener, helix will initialize the callback which will get the entire external view
       // and trigger the external view change event. In other words, venice will read the newest external view
       // immediately.
-      manager.addIdealStateChangeListener(this);
+      // manager.addIdealStateChangeListener(this);
       manager.addControllerListener(this);
       // Use routing table provider to get the notification of the external view change, customized view change,
       // and live instances change.
@@ -126,7 +122,7 @@ public abstract class HelixBaseRoutingRepository
   public void clear() {
     // removeListener method is a thread safe method, we don't need to lock here again.
     manager.removeListener(keyBuilder.controller(), this);
-    manager.removeListener(keyBuilder.idealStates(), this);
+    // manager.removeListener(keyBuilder.idealStates(), this);
     if (routingTableProvider != null) {
       routingTableProvider.removeRoutingTableChangeListener(this);
       try {
@@ -275,22 +271,6 @@ public abstract class HelixBaseRoutingRepository
         liveInstance.getId(),
         Utils.parseHostFromHelixNodeIdentifier(liveInstance.getId()),
         Utils.parsePortFromHelixNodeIdentifier(liveInstance.getId()));
-  }
-
-  @Override
-  public void onIdealStateChange(List<IdealState> idealStates, NotificationContext changeContext) {
-    refreshResourceToIdealPartitionCountMap(idealStates);
-  }
-
-  protected void refreshResourceToIdealPartitionCountMap(List<IdealState> idealStates) {
-    HashMap<String, Integer> partitionCountMap = new HashMap<>();
-    for (IdealState idealState: idealStates) {
-      // Ideal state could be null, if a resource has already been deleted.
-      if (idealState != null) {
-        partitionCountMap.put(idealState.getResourceName(), idealState.getNumPartitions());
-      }
-    }
-    this.resourceToIdealPartitionCountMap = Collections.unmodifiableMap(partitionCountMap);
   }
 
   @Override

--- a/internal/venice-common/src/main/java/com/linkedin/venice/helix/HelixCustomizedViewOfflinePushRepository.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/helix/HelixCustomizedViewOfflinePushRepository.java
@@ -207,16 +207,6 @@ public class HelixCustomizedViewOfflinePushRepository extends HelixBaseRoutingRe
     }
   }
 
-  // public void refresh() {
-  // manager.addControllerListener(this);
-  // super.refresh();
-  // }
-
-  // public void clear() {
-  // manager.removeListener(keyBuilder.controller(), this);
-  // super.clear();
-  // }
-
   @Override
   public void refreshRoutingDataForResource(String kafkaTopic) {
     throw new VeniceException("The function of refreshRoutingDataForResource is not implemented");

--- a/internal/venice-common/src/main/java/com/linkedin/venice/helix/HelixCustomizedViewOfflinePushRepository.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/helix/HelixCustomizedViewOfflinePushRepository.java
@@ -100,6 +100,11 @@ public class HelixCustomizedViewOfflinePushRepository extends HelixBaseRoutingRe
   }
 
   @Override
+  public void clear() {
+    this.resourceToPartitionCountMap.clear();
+  }
+
+  @Override
   protected void onCustomizedViewDataChange(RoutingTableSnapshot routingTableSnapshot) {
     Collection<CustomizedView> customizedViewCollection = routingTableSnapshot.getCustomizeViews();
     if (customizedViewCollection == null) {
@@ -128,15 +133,14 @@ public class HelixCustomizedViewOfflinePushRepository extends HelixBaseRoutingRe
             LOGGER.warn("Cannot find store for resource: {}.", resourceName);
             continue;
           }
-          boolean isValidVersion = store.getVersions().stream().anyMatch(v -> v.getNumber() == version);
-          if (!isValidVersion) {
+
+          if (!store.getVersion(version).isPresent()) {
             LOGGER.warn("Version not found in store for resource: {}.", resourceName);
             continue;
           }
           partitionCount = store.getVersion(version).get().getPartitionCount();
           resourceToPartitionCountMap.put(resourceName, partitionCount);
         }
-
         PartitionAssignment partitionAssignment = new PartitionAssignment(resourceName, partitionCount);
         for (String partitionName: customizedView.getPartitionSet()) {
           // Get instance to customized state map for this partition from local memory.

--- a/internal/venice-common/src/main/java/com/linkedin/venice/helix/HelixCustomizedViewOfflinePushRepository.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/helix/HelixCustomizedViewOfflinePushRepository.java
@@ -1,7 +1,7 @@
 package com.linkedin.venice.helix;
 
-import static com.linkedin.venice.helix.ResourceAssignment.*;
-import static com.linkedin.venice.pushmonitor.ExecutionStatus.*;
+import static com.linkedin.venice.helix.ResourceAssignment.ResourceAssignmentChanges;
+import static com.linkedin.venice.pushmonitor.ExecutionStatus.COMPLETED;
 
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.meta.Instance;

--- a/internal/venice-common/src/main/java/com/linkedin/venice/helix/HelixCustomizedViewOfflinePushRepository.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/helix/HelixCustomizedViewOfflinePushRepository.java
@@ -221,7 +221,12 @@ public class HelixCustomizedViewOfflinePushRepository extends HelixBaseRoutingRe
     throw new VeniceException("The function of refreshRoutingDataForResource is not implemented");
   }
 
-  private class StoreChangeListener implements StoreDataChangedListener {
+  // test only
+  public Map<String, Integer> getResourceToPartitionCountMap() {
+    return this.resourceToPartitionCountMap;
+  }
+
+  public class StoreChangeListener implements StoreDataChangedListener {
     @Override
     public void handleStoreCreated(Store store) {
       int currentVersion = store.getCurrentVersion();

--- a/internal/venice-common/src/main/java/com/linkedin/venice/helix/HelixCustomizedViewOfflinePushRepository.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/helix/HelixCustomizedViewOfflinePushRepository.java
@@ -222,8 +222,8 @@ public class HelixCustomizedViewOfflinePushRepository extends HelixBaseRoutingRe
   }
 
   // test only
-  public Map<String, Integer> getResourceToPartitionCountMap() {
-    return this.resourceToPartitionCountMap;
+  Map<String, Integer> getResourceToPartitionCountMap() {
+    return Collections.unmodifiableMap(this.resourceToPartitionCountMap);
   }
 
   public class StoreChangeListener implements StoreDataChangedListener {

--- a/internal/venice-common/src/main/java/com/linkedin/venice/helix/HelixCustomizedViewOfflinePushRepository.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/helix/HelixCustomizedViewOfflinePushRepository.java
@@ -46,7 +46,7 @@ public class HelixCustomizedViewOfflinePushRepository extends HelixBaseRoutingRe
 
   private final Map<String, Integer> resourceToPartitionCountMap = new VeniceConcurrentHashMap<>();
 
-  private ReadOnlyStoreRepository storeRepository;
+  private final ReadOnlyStoreRepository storeRepository;
 
   public HelixCustomizedViewOfflinePushRepository(SafeHelixManager manager, ReadOnlyStoreRepository storeRepository) {
     super(manager);

--- a/internal/venice-common/src/main/java/com/linkedin/venice/helix/HelixCustomizedViewOfflinePushRepository.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/helix/HelixCustomizedViewOfflinePushRepository.java
@@ -52,6 +52,7 @@ public class HelixCustomizedViewOfflinePushRepository extends HelixBaseRoutingRe
     super(manager);
     dataSource.put(PropertyType.CUSTOMIZEDVIEW, Collections.singletonList(HelixPartitionState.OFFLINE_PUSH.name()));
     this.storeRepository = storeRepository;
+    this.storeRepository.registerStoreDataChangedListener(this);
   }
 
   @Override

--- a/internal/venice-common/src/main/java/com/linkedin/venice/helix/HelixExternalViewRepository.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/helix/HelixExternalViewRepository.java
@@ -37,7 +37,7 @@ import org.apache.logging.log4j.Logger;
 public class HelixExternalViewRepository extends HelixBaseRoutingRepository implements IdealStateChangeListener {
   private static final Logger LOGGER = LogManager.getLogger(HelixExternalViewRepository.class);
 
-  protected volatile Map<String, Integer> resourceToIdealPartitionCountMap;
+  private volatile Map<String, Integer> resourceToIdealPartitionCountMap;
 
   private static final String ONLINE_OFFLINE_VENICE_STATE_FILLER = "N/A";
 

--- a/internal/venice-common/src/main/java/com/linkedin/venice/helix/HelixExternalViewRepository.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/helix/HelixExternalViewRepository.java
@@ -17,10 +17,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+import org.apache.helix.NotificationContext;
 import org.apache.helix.PropertyKey;
 import org.apache.helix.PropertyType;
 import org.apache.helix.api.exceptions.HelixMetaDataAccessException;
 import org.apache.helix.api.listeners.BatchMode;
+import org.apache.helix.api.listeners.IdealStateChangeListener;
 import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.IdealState;
 import org.apache.helix.spectator.RoutingTableSnapshot;
@@ -32,8 +34,10 @@ import org.apache.logging.log4j.Logger;
  * Extend HelixBaseRoutingRepository to leverage external view data.
  */
 @BatchMode
-public class HelixExternalViewRepository extends HelixBaseRoutingRepository {
+public class HelixExternalViewRepository extends HelixBaseRoutingRepository implements IdealStateChangeListener {
   private static final Logger LOGGER = LogManager.getLogger(HelixExternalViewRepository.class);
+
+  protected volatile Map<String, Integer> resourceToIdealPartitionCountMap;
 
   private static final String ONLINE_OFFLINE_VENICE_STATE_FILLER = "N/A";
 
@@ -79,6 +83,29 @@ public class HelixExternalViewRepository extends HelixBaseRoutingRepository {
       assignment.addPartition(new Partition(HelixUtils.getPartitionId(partition), stateToInstanceMap));
     }
     return assignment;
+  }
+
+  @Override
+  public void onIdealStateChange(List<IdealState> idealStates, NotificationContext changeContext) {
+    refreshResourceToIdealPartitionCountMap(idealStates);
+  }
+
+  public void refresh() {
+    try {
+      manager.addIdealStateChangeListener(this);
+      // manager.addControllerListener(this);
+      super.refresh();
+    } catch (Exception e) {
+      String errorMessage = "Cannot refresh routing table from Helix for cluster " + manager.getClusterName();
+      LOGGER.error(errorMessage, e);
+      throw new VeniceException(errorMessage, e);
+    }
+  }
+
+  public void clear() {
+    // manager.removeListener(keyBuilder.controller(), this);
+    manager.removeListener(keyBuilder.idealStates(), this);
+    super.clear();
   }
 
   @Override
@@ -208,6 +235,17 @@ public class HelixExternalViewRepository extends HelixBaseRoutingRepository {
     for (String kafkaTopic: updates.getDeletedResource()) {
       listenerManager.trigger(kafkaTopic, listener -> listener.onRoutingDataDeleted(kafkaTopic));
     }
+  }
+
+  private void refreshResourceToIdealPartitionCountMap(List<IdealState> idealStates) {
+    HashMap<String, Integer> partitionCountMap = new HashMap<>();
+    for (IdealState idealState: idealStates) {
+      // Ideal state could be null, if a resource has already been deleted.
+      if (idealState != null) {
+        partitionCountMap.put(idealState.getResourceName(), idealState.getNumPartitions());
+      }
+    }
+    this.resourceToIdealPartitionCountMap = Collections.unmodifiableMap(partitionCountMap);
   }
 
   protected void onCustomizedViewDataChange(RoutingTableSnapshot routingTableSnapshot) {

--- a/internal/venice-common/src/main/java/com/linkedin/venice/helix/HelixExternalViewRepository.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/helix/HelixExternalViewRepository.java
@@ -93,7 +93,6 @@ public class HelixExternalViewRepository extends HelixBaseRoutingRepository impl
   public void refresh() {
     try {
       manager.addIdealStateChangeListener(this);
-      // manager.addControllerListener(this);
       super.refresh();
     } catch (Exception e) {
       String errorMessage = "Cannot refresh routing table from Helix for cluster " + manager.getClusterName();
@@ -103,7 +102,6 @@ public class HelixExternalViewRepository extends HelixBaseRoutingRepository impl
   }
 
   public void clear() {
-    // manager.removeListener(keyBuilder.controller(), this);
     manager.removeListener(keyBuilder.idealStates(), this);
     super.clear();
   }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/helix/HelixReadOnlyStoreRepositoryAdapter.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/helix/HelixReadOnlyStoreRepositoryAdapter.java
@@ -7,6 +7,7 @@ import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.StoreDataChangedListener;
 import com.linkedin.venice.meta.SystemStore;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
@@ -85,8 +86,8 @@ public class HelixReadOnlyStoreRepositoryAdapter implements ReadOnlyStoreReposit
   }
 
   // test only
-  public Set<StoreDataChangedListener> getListeners() {
-    return listeners;
+  Set<StoreDataChangedListener> getListeners() {
+    return Collections.unmodifiableSet(listeners);
   }
 
   @Override

--- a/internal/venice-common/src/main/java/com/linkedin/venice/helix/HelixReadOnlyStoreRepositoryAdapter.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/helix/HelixReadOnlyStoreRepositoryAdapter.java
@@ -84,6 +84,11 @@ public class HelixReadOnlyStoreRepositoryAdapter implements ReadOnlyStoreReposit
     return store;
   }
 
+  // test only
+  public Set<StoreDataChangedListener> getListeners() {
+    return listeners;
+  }
+
   @Override
   public boolean hasStore(String storeName) {
     VeniceSystemStoreType systemStoreType = VeniceSystemStoreType.getSystemStoreType(storeName);
@@ -270,7 +275,7 @@ public class HelixReadOnlyStoreRepositoryAdapter implements ReadOnlyStoreReposit
   /**
    * {@link StoreDataChangedListener} to handle all the events from {@link #regularStoreDataChangedListener}.
    */
-  private class VeniceStoreDataChangedListener implements StoreDataChangedListener {
+  public class VeniceStoreDataChangedListener implements StoreDataChangedListener {
     /**
      * Notify the store creation and maybe the corresponding system store creation.
      * TODO: so far, this function only supports {@link VeniceSystemStoreType#META_STORE}, and if you plan to support
@@ -339,7 +344,7 @@ public class HelixReadOnlyStoreRepositoryAdapter implements ReadOnlyStoreReposit
      */
     public void handleStoreDeleted(Store store) {
       String storeName = store.getName();
-      listeners.forEach(listener -> {
+      getListeners().forEach(listener -> {
         // Notify the regular store deletion
         try {
           listener.handleStoreDeleted(store);

--- a/internal/venice-common/src/main/java/com/linkedin/venice/helix/HelixReadOnlyStoreRepositoryAdapter.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/helix/HelixReadOnlyStoreRepositoryAdapter.java
@@ -350,16 +350,15 @@ public class HelixReadOnlyStoreRepositoryAdapter implements ReadOnlyStoreReposit
               storeName,
               t);
         }
+
         String metaSystemStoreName = VeniceSystemStoreType.META_STORE.getSystemStoreName(storeName);
-        SystemStore metaSystemStore = new SystemStore(
-            systemStoreRepository.getStoreOrThrow(VeniceSystemStoreType.META_STORE.getZkSharedStoreName()),
-            VeniceSystemStoreType.META_STORE,
-            store);
-
         try {
-
           // Notify the meta system store deletion
-          listener.handleStoreDeleted(metaSystemStore);
+          Store metaStore = systemStoreRepository.getStore(VeniceSystemStoreType.META_STORE.getZkSharedStoreName());
+          if (metaStore != null) {
+            SystemStore metaSystemStore = new SystemStore(metaStore, VeniceSystemStoreType.META_STORE, store);
+            listener.handleStoreDeleted(metaSystemStore);
+          }
         } catch (Throwable t) {
           LOGGER.error(
               "Received exception while invoking `handleStoreDeleted` of listener: {} with system store: {}.",

--- a/internal/venice-common/src/test/java/com/linkedin/venice/helix/HelixCustomizedViewOfflinePushRepositoryTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/helix/HelixCustomizedViewOfflinePushRepositoryTest.java
@@ -1,0 +1,52 @@
+package com.linkedin.venice.helix;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import com.linkedin.venice.meta.ReadOnlyStoreRepository;
+import com.linkedin.venice.meta.Store;
+import com.linkedin.venice.meta.VersionImpl;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Optional;
+import org.apache.helix.model.CustomizedView;
+import org.apache.helix.model.LiveInstance;
+import org.apache.helix.spectator.RoutingTableSnapshot;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class HelixCustomizedViewOfflinePushRepositoryTest {
+  @Test
+  public void testCustomizedViewStoreHandle() {
+    SafeHelixManager manager = mock(SafeHelixManager.class);
+    ReadOnlyStoreRepository storeRepository = mock(ReadOnlyStoreRepository.class);
+    Store store = mock(Store.class);
+    VersionImpl version = new VersionImpl("abc", 1, "jobID");
+    version.setPartitionCount(1);
+    when(store.getVersion(anyInt())).thenReturn(Optional.of(version));
+    when(store.getName()).thenReturn("abc");
+    when(store.getCurrentVersion()).thenReturn(1);
+    when(storeRepository.getStore(anyString())).thenReturn(store);
+    HelixCustomizedViewOfflinePushRepository customizedViewOfflinePushRepository =
+        new HelixCustomizedViewOfflinePushRepository(manager, storeRepository);
+    RoutingTableSnapshot routingTableSnapshot = mock(RoutingTableSnapshot.class);
+    Collection views = new ArrayList();
+    views.add(new CustomizedView("abc_v1"));
+    when(routingTableSnapshot.getCustomizeViews()).thenReturn(views);
+    when(routingTableSnapshot.getCustomizedStateType()).thenReturn(HelixPartitionState.OFFLINE_PUSH.name());
+    Collection instances = new ArrayList();
+    instances.add(new LiveInstance("host_1234"));
+    when(routingTableSnapshot.getLiveInstances()).thenReturn(instances);
+    customizedViewOfflinePushRepository.onCustomizedViewDataChange(routingTableSnapshot);
+    verify(storeRepository, times(1)).getStore(any());
+    HelixCustomizedViewOfflinePushRepository.StoreChangeListener storeChangeListener =
+        customizedViewOfflinePushRepository.new StoreChangeListener();
+    storeChangeListener.handleStoreCreated(store);
+    storeChangeListener.handleStoreChanged(store);
+    Assert
+        .assertEquals(customizedViewOfflinePushRepository.getResourceToPartitionCountMap().get("abc_v1").intValue(), 1);
+    storeChangeListener.handleStoreDeleted("abc");
+    Assert.assertTrue(customizedViewOfflinePushRepository.getResourceToPartitionCountMap().isEmpty());
+  }
+}

--- a/internal/venice-common/src/test/java/com/linkedin/venice/helix/HelixReadOnlyStoreRepositoryAdapterTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/helix/HelixReadOnlyStoreRepositoryAdapterTest.java
@@ -1,0 +1,32 @@
+package com.linkedin.venice.helix;
+
+import static org.mockito.Mockito.*;
+import static org.testng.AssertJUnit.*;
+
+import com.linkedin.venice.meta.Store;
+import com.linkedin.venice.meta.StoreDataChangedListener;
+import java.util.HashSet;
+import java.util.Set;
+import org.testng.annotations.Test;
+
+
+public class HelixReadOnlyStoreRepositoryAdapterTest {
+  @Test
+  public void testStoreDeleteHandler() {
+    HelixReadOnlyStoreRepositoryAdapter adapter = mock(HelixReadOnlyStoreRepositoryAdapter.class);
+    Set<StoreDataChangedListener> dataChangedListenerSet = new HashSet<>();
+    StoreDataChangedListener dataChangedListener = mock(StoreDataChangedListener.class);
+    dataChangedListenerSet.add(dataChangedListener);
+    when(adapter.getListeners()).thenReturn(dataChangedListenerSet);
+    HelixReadOnlyStoreRepositoryAdapter.VeniceStoreDataChangedListener listener =
+        adapter.new VeniceStoreDataChangedListener();
+    Store store = mock(Store.class);
+    when(store.getName()).thenReturn("abc");
+    try {
+      listener.handleStoreDeleted(store);
+    } catch (Exception e) {
+      fail("Should be able to handle delete store");
+    }
+  }
+
+}

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/controller/TestVeniceHelixAdminWithSharedEnvironment.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/controller/TestVeniceHelixAdminWithSharedEnvironment.java
@@ -1072,11 +1072,10 @@ public class TestVeniceHelixAdminWithSharedEnvironment extends AbstractTestVenic
     veniceAdmin.incrementVersionIdempotent(clusterName, storeName, Version.guidBasedDummyPushId(), 1, 1);
     veniceAdmin.incrementVersionIdempotent(clusterName, storeName, Version.guidBasedDummyPushId(), 1, 1);
 
-    TestUtils.waitForNonDeterministicCompletion(TOTAL_TIMEOUT_FOR_LONG_TEST_MS, TimeUnit.MILLISECONDS, () -> {
-      System.out.println(
-          "sidian's log: current version is : " + veniceAdmin.getStore(clusterName, storeName).getCurrentVersion());
-      return veniceAdmin.getStore(clusterName, storeName).getCurrentVersion() == 3;
-    });
+    TestUtils.waitForNonDeterministicCompletion(
+        TOTAL_TIMEOUT_FOR_LONG_TEST_MS,
+        TimeUnit.MILLISECONDS,
+        () -> veniceAdmin.getStore(clusterName, storeName).getCurrentVersion() == 3);
     veniceAdmin.retireOldStoreVersions(clusterName, storeName, true, VERSION_ID_UNSET);
     veniceAdmin.setStoreReadability(clusterName, storeName, false);
     veniceAdmin.retireOldStoreVersions(clusterName, storeName, false, VERSION_ID_UNSET);

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestBatch.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestBatch.java
@@ -231,10 +231,9 @@ public abstract class TestBatch {
     }
   }
 
-  @Test
-  public void testCompressingRecord() throws Exception {
-    boolean compressionMetricCollectionEnabled = false;
-    boolean useMapperToBuildDict = false;
+  @Test(dataProvider = "Two-True-and-False", dataProviderClass = DataProviderUtils.class)
+  public void testCompressingRecord(boolean compressionMetricCollectionEnabled, boolean useMapperToBuildDict)
+      throws Exception {
     VPJValidator validator = (avroClient, vsonClient, metricsRepository) -> {
       // test single get
       for (int i = 1; i <= 100; i++) {

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestBatch.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestBatch.java
@@ -231,9 +231,10 @@ public abstract class TestBatch {
     }
   }
 
-  @Test(dataProvider = "Two-True-and-False", dataProviderClass = DataProviderUtils.class)
-  public void testCompressingRecord(boolean compressionMetricCollectionEnabled, boolean useMapperToBuildDict)
-      throws Exception {
+  @Test
+  public void testCompressingRecord() throws Exception {
+    boolean compressionMetricCollectionEnabled = false;
+    boolean useMapperToBuildDict = false;
     VPJValidator validator = (avroClient, vsonClient, metricsRepository) -> {
       // test single get
       for (int i = 1; i <= 100; i++) {

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestHybridQuota.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestHybridQuota.java
@@ -161,7 +161,7 @@ public class TestHybridQuota {
               InstanceType.SPECTATOR,
               sharedVenice.getZk().getAddress()));
       readManager.connect();
-      offlinePushRepository = new HelixCustomizedViewOfflinePushRepository(readManager);
+      offlinePushRepository = new HelixCustomizedViewOfflinePushRepository(readManager, null);
       hybridStoreQuotaOnlyRepository = new HelixHybridStoreQuotaRepository(readManager);
       offlinePushRepository.refresh();
       hybridStoreQuotaOnlyRepository.refresh();

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestHybridQuota.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestHybridQuota.java
@@ -22,19 +22,27 @@ import com.linkedin.venice.controllerapi.ControllerClient;
 import com.linkedin.venice.controllerapi.ControllerResponse;
 import com.linkedin.venice.controllerapi.UpdateStoreQueryParams;
 import com.linkedin.venice.exceptions.VeniceException;
+import com.linkedin.venice.helix.HelixAdapterSerializer;
 import com.linkedin.venice.helix.HelixCustomizedViewOfflinePushRepository;
 import com.linkedin.venice.helix.HelixHybridStoreQuotaRepository;
+import com.linkedin.venice.helix.HelixReadWriteStoreRepository;
 import com.linkedin.venice.helix.SafeHelixManager;
+import com.linkedin.venice.helix.ZkClientFactory;
 import com.linkedin.venice.integration.utils.ServiceFactory;
 import com.linkedin.venice.integration.utils.VeniceClusterWrapper;
 import com.linkedin.venice.kafka.TopicManager;
 import com.linkedin.venice.meta.PersistenceType;
+import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.Version;
+import com.linkedin.venice.meta.VersionImpl;
 import com.linkedin.venice.pushmonitor.HybridStoreQuotaStatus;
 import com.linkedin.venice.utils.IntegrationTestPushUtils;
+import com.linkedin.venice.utils.TestUtils;
 import com.linkedin.venice.utils.Time;
 import com.linkedin.venice.utils.Utils;
+import com.linkedin.venice.utils.locks.ClusterLockManager;
 import java.io.File;
+import java.util.Optional;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 import org.apache.avro.Schema;
@@ -42,6 +50,7 @@ import org.apache.helix.HelixAdmin;
 import org.apache.helix.HelixManagerFactory;
 import org.apache.helix.InstanceType;
 import org.apache.helix.manager.zk.ZKHelixAdmin;
+import org.apache.helix.zookeeper.impl.client.ZkClient;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.samza.system.SystemProducer;
@@ -106,7 +115,6 @@ public class TestHybridQuota {
   public void testHybridStoreQuota(boolean chunkingEnabled, boolean isStreamReprocessing, boolean recoverFromViolation)
       throws Exception {
     SystemProducer veniceProducer = null;
-
     long streamingRewindSeconds = 10L;
     long streamingMessageLag = 2L;
 
@@ -161,7 +169,29 @@ public class TestHybridQuota {
               InstanceType.SPECTATOR,
               sharedVenice.getZk().getAddress()));
       readManager.connect();
-      offlinePushRepository = new HelixCustomizedViewOfflinePushRepository(readManager, null);
+      String zkAddress = sharedVenice.getZk().getAddress();
+      ZkClient zkClient = ZkClientFactory.newZkClient(zkAddress);
+      HelixAdapterSerializer adapter = new HelixAdapterSerializer();
+      HelixReadWriteStoreRepository writeStoreRepository = new HelixReadWriteStoreRepository(
+          zkClient,
+          adapter,
+          zkAddress,
+          Optional.empty(),
+          new ClusterLockManager(sharedVenice.getClusterName()));
+
+      Store store = TestUtils.createTestStore(storeName, "owner", System.currentTimeMillis());
+      store.setPartitionCount(3);
+      Version version = new VersionImpl(storeName, 1, "pushId");
+      version.setPartitionCount(3);
+      store.addVersion(version);
+      version = new VersionImpl(storeName, 2, "pushId");
+      version.setPartitionCount(3);
+      store.addVersion(version);
+      version = new VersionImpl(storeName, 3, "pushId");
+      version.setPartitionCount(3);
+      store.addVersion(version);
+      writeStoreRepository.addStore(store);
+      offlinePushRepository = new HelixCustomizedViewOfflinePushRepository(readManager, writeStoreRepository);
       hybridStoreQuotaOnlyRepository = new HelixHybridStoreQuotaRepository(readManager);
       offlinePushRepository.refresh();
       hybridStoreQuotaOnlyRepository.refresh();

--- a/internal/venice-test-common/src/main/java/com/linkedin/venice/utils/MockTestStateModelFactory.java
+++ b/internal/venice-test-common/src/main/java/com/linkedin/venice/utils/MockTestStateModelFactory.java
@@ -5,6 +5,7 @@ import com.linkedin.venice.helix.HelixState;
 import com.linkedin.venice.helix.VeniceOfflinePushMonitorAccessor;
 import com.linkedin.venice.pushmonitor.ExecutionStatus;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -70,7 +71,7 @@ public class MockTestStateModelFactory extends StateModelFactory<StateModel> {
   }
 
   public List<OnlineOfflineStateModel> getModelList(String resourceName, int partitionId) {
-    return modelToModelListMap.get(resourceName + "_" + partitionId);
+    return modelToModelListMap.getOrDefault(resourceName + "_" + partitionId, Collections.emptyList());
   }
 
   public void makeTransitionError(String resourceName, int partitionId) {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/HelixVeniceClusterResources.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/HelixVeniceClusterResources.java
@@ -137,7 +137,7 @@ public class HelixVeniceClusterResources implements VeniceResource {
       spectatorManager = getSpectatorManager(clusterName, zkClient.getServers());
     }
     this.routingDataRepository = new HelixExternalViewRepository(spectatorManager);
-    this.customizedViewRepo = new HelixCustomizedViewOfflinePushRepository(this.helixManager);
+    this.customizedViewRepo = new HelixCustomizedViewOfflinePushRepository(this.helixManager, storeMetadataRepository);
     this.messageChannel = new HelixStatusMessageChannel(
         helixManager,
         new HelixMessageChannelStats(metricsRepository, clusterName),

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/RouterServer.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/RouterServer.java
@@ -288,7 +288,7 @@ public class RouterServer extends AbstractVeniceService {
     this.metaStoreShadowReader = config.isMetaStoreShadowReadEnabled()
         ? Optional.of(new MetaStoreShadowReader(this.schemaRepository))
         : Optional.empty();
-    this.routingDataRepository = new HelixCustomizedViewOfflinePushRepository(manager);
+    this.routingDataRepository = new HelixCustomizedViewOfflinePushRepository(manager, metadataRepository);
     this.hybridStoreQuotaRepository = config.isHelixHybridStoreQuotaEnabled()
         ? Optional.of(new HelixHybridStoreQuotaRepository(manager))
         : Optional.empty();

--- a/services/venice-server/src/main/java/com/linkedin/venice/server/VeniceServer.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/server/VeniceServer.java
@@ -335,7 +335,7 @@ public class VeniceServer {
     CompletableFuture<HelixCustomizedViewOfflinePushRepository> customizedViewFuture =
         managerFuture.thenApply(manager -> {
           HelixCustomizedViewOfflinePushRepository customizedView =
-              new HelixCustomizedViewOfflinePushRepository(manager);
+              new HelixCustomizedViewOfflinePushRepository(manager, metadataRepo);
           customizedView.refresh();
           return customizedView;
         });


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci], [server], [controller],
[router], [samza], [vpj], [fast-client], [thin-client], [alpini],
[admin-tool], [test], [build], [doc], [script]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Move ideal state listener to EV repository and read Store Metadata for CV updates
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

ExternalView(EV) and CustomizedView (CV) repository listens to IdealState from Helix to filter invalid state changes. This add a lots of delay to execute those callbacks (Helix callbackHandler).  Currently EV is used by the controller and CV is used by router and servers to query replica statuses and mostly server and routers would be exposed to the problem of slow transitions. 

This PR
1.  moves the ideal state watch to EV.
2.  make CV repository filter invalid states by query store version metadata. 
That way updates router and servers host wont add many callbacks to helix and hopefully results in faster state transitions.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
test WIP
## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.