### PR TITLE
[build] Enforce coverage only on leaf submodules

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -138,13 +138,20 @@ subprojects {
   group = rootProject.group
   version = rootProject.version
 
+  def isLeafSubModule = project.childProjects.isEmpty()
+
   apply {
     plugin 'idea'
-    plugin 'jacoco'
-    plugin 'com.form.diff-coverage'
     plugin 'java-library'
     plugin 'com.github.spotbugs'
     plugin 'org.gradle.test-retry'
+  }
+
+  if (isLeafSubModule) {
+    apply {
+      plugin 'jacoco'
+      plugin 'com.form.diff-coverage'
+    }
   }
 
   if (JavaVersion.current() >= JavaVersion.VERSION_1_9) {
@@ -388,59 +395,60 @@ subprojects {
     }
   }
 
-  jacocoTestReport {
-    dependsOn test // tests are required to run before generating the report
+  if (isLeafSubModule) {
+    jacocoTestReport {
+      dependsOn test // tests are required to run before generating the report
 
-    reports {
-      xml.enabled = true
-      html.enabled = true
+      reports {
+        xml.enabled = true
+        html.enabled = true
+      }
+
+      doLast {
+        parseJacocoXml("$buildDir/reports/jacoco/test/jacocoTestReport.xml")
+      }
     }
 
-    doLast {
-      parseJacocoXml("$buildDir/reports/jacoco/test/jacocoTestReport.xml")
-    }
-  }
+    afterEvaluate {
+      jacocoTestCoverageVerification {
+        dependsOn jacocoTestReport
 
-  afterEvaluate {
-    jacocoTestCoverageVerification {
-      dependsOn jacocoTestReport
+        violationRules {
+          rule {
+            def threshold = project.ext.has('jacocoCoverageThreshold') ? project.ext.jacocoCoverageThreshold : 0.6
 
-      violationRules {
-        rule {
-          def threshold = project.ext.has('jacocoCoverageThreshold') ?
-              project.ext.jacocoCoverageThreshold : 0.6
-
-          limit {
-            counter = 'BRANCH'
-            value = 'COVEREDRATIO'
-            minimum = threshold
+            limit {
+              counter = 'BRANCH'
+              value = 'COVEREDRATIO'
+              minimum = threshold
+            }
           }
         }
       }
-    }
 
-    diffCoverageReport {
-      diffSource.file = createDiffFile()
+      diffCoverageReport {
+        diffSource.file = createDiffFile()
 
-      // Report locates at <module_name>/build/reports/jacoco/diffCoverage/html/index.html
-      reports {
-        html = true
-        xml = true
+        // Report locates at <module_name>/build/reports/jacoco/diffCoverage/html/index.html
+        reports {
+          html = true
+          xml = true
+        }
+
+        violationRules {
+          minBranches = project.ext.has('diffCoverageThreshold') ? project.ext.diffCoverageThreshold : 0.33
+          failOnViolation = true
+        }
       }
 
-      violationRules {
-        minBranches = project.ext.has('diffCoverageThreshold') ? project.ext.diffCoverageThreshold : 0.33
-        failOnViolation = true
+      task logDiffCoverage {
+        doLast {
+          parseJacocoXml("$buildDir/reports/jacoco/diffCoverage/report.xml")
+        }
       }
-    }
 
-    task logDiffCoverage {
-      doLast {
-        parseJacocoXml("$buildDir/reports/jacoco/diffCoverage/report.xml")
-      }
+      diffCoverage.finalizedBy logDiffCoverage
     }
-
-    diffCoverage.finalizedBy logDiffCoverage
   }
 
   task flakyTest(type: Test) {
@@ -483,7 +491,7 @@ subprojects {
   }
 
   // Only publish artifacts for projects that are at the leaf level
-  if (project.childProjects.isEmpty()) {
+  if (isLeafSubModule) {
     publishing.configureArtifactPublishing(project, testJar)
   }
 }

--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/schema/RouterBackedSchemaReader.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/schema/RouterBackedSchemaReader.java
@@ -328,8 +328,4 @@ public class RouterBackedSchemaReader implements SchemaReader {
     }
     return alternativeWriterSchema;
   }
-
-  public void getSomeValueForTest() {
-    // No Op. Only for testing
-  }
 }

--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/schema/RouterBackedSchemaReader.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/schema/RouterBackedSchemaReader.java
@@ -328,4 +328,8 @@ public class RouterBackedSchemaReader implements SchemaReader {
     }
     return alternativeWriterSchema;
   }
+
+  public void getSomeValueForTest() {
+    // No Op. Only for testing
+  }
 }


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci], [server], [controller],
[router], [samza], [vpj], [fast-client], [thin-client], [alpini],
[admin-tool], [test], [build], [doc], [script]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Enforce coverage only on leaf submodules
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
Today, the code coverage check runs for all sub-modules. It does not check if it is a leaf. Our code structure uses nested sub-modules such as `:internal:venice-client-common`, `:internal:venice-common`, etc. 

If some code in a submodule is changed, which is not easily testable, we might choose to reduce the coverage threshold for that module. We have provision to do this via `diffCoverageThreshold` property in the `build.gradle` for that module.
However, the `diffCoverage` check runs on all modules. Hence, the coverage thresholds need to be applied to modules higher in the directory tree too - which might not be ideal.

This PR makes the coverage checks to be enforced only on modules that are at the leaf of the tree.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
GH CI. Adam is also testing it locally.

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.