### PR TITLE
[admin-tool][controller] Added tooling to get kafka topic configs

### DIFF
--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/Command.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/Command.java
@@ -390,6 +390,9 @@ public enum Command {
       "list-store-push-info", "List information about current pushes and push history for a specific store.",
       new Arg[] { URL, CLUSTER, STORE }, new Arg[] { PARTITION_DETAIL_ENABLED }
   ),
+  GET_KAFKA_TOPIC_CONFIGS(
+      "get-kafka-topic-configs", "Get configs of a topic through controllers", new Arg[] { URL, KAFKA_TOPIC_NAME }
+  ),
   UPDATE_KAFKA_TOPIC_LOG_COMPACTION(
       "update-kafka-topic-log-compaction", "Update log compaction config of a topic through controllers",
       new Arg[] { URL, KAFKA_TOPIC_NAME, KAFKA_TOPIC_LOG_COMPACTION_ENABLED }, new Arg[] { CLUSTER }

--- a/clients/venice-admin-tool/src/test/java/com/linkedin/venice/TestAdminTool.java
+++ b/clients/venice-admin-tool/src/test/java/com/linkedin/venice/TestAdminTool.java
@@ -10,6 +10,7 @@ import com.linkedin.venice.controllerapi.MultiReplicaResponse;
 import com.linkedin.venice.controllerapi.StoreResponse;
 import com.linkedin.venice.controllerapi.UpdateClusterConfigQueryParams;
 import com.linkedin.venice.controllerapi.UpdateStoreQueryParams;
+import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.meta.StoreInfo;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.meta.VersionImpl;
@@ -135,5 +136,13 @@ public class TestAdminTool {
       storeInfo.setVersions(Collections.emptyList());
     }
     return storeInfo;
+  }
+
+  @Test
+  public void testGetPubSubTopicConfigsRequiresValidTopicName() {
+    String badTopicName = "badTopicName_v_rt_0";
+    String[] args =
+        { "--get-kafka-topic-configs", "--url", "http://localhost:7036", "--kafka-topic-name", badTopicName };
+    Assert.assertThrows(VeniceException.class, () -> AdminTool.main(args));
   }
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerClient.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerClient.java
@@ -541,6 +541,11 @@ public class ControllerClient implements Closeable {
     return request(ControllerRoute.SKIP_ADMIN, params, ControllerResponse.class);
   }
 
+  public PubSubTopicConfigResponse getKafkaTopicConfigs(String kafkaTopicName) {
+    QueryParams params = newParams().add(TOPIC, kafkaTopicName);
+    return request(ControllerRoute.GET_KAFKA_TOPIC_CONFIGS, params, PubSubTopicConfigResponse.class);
+  }
+
   public ControllerResponse updateKafkaTopicLogCompaction(String kafkaTopicName, boolean logCompactionEnabled) {
     QueryParams params =
         newParams().add(TOPIC, kafkaTopicName).add(KAFKA_TOPIC_LOG_COMPACTION_ENABLED, logCompactionEnabled);

--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerRoute.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerRoute.java
@@ -251,7 +251,7 @@ public enum ControllerRoute {
   LIST_STORE_PUSH_INFO("/list_store_push_info", HttpMethod.GET, Arrays.asList(CLUSTER, NAME, PARTITION_DETAIL_ENABLED)),
   GET_REGION_PUSH_DETAILS(
       "/get_region_push_details", HttpMethod.GET, Arrays.asList(CLUSTER, NAME, PARTITION_DETAIL_ENABLED)
-  ),
+  ), GET_KAFKA_TOPIC_CONFIGS("/get_kafka_topic_configs", HttpMethod.GET, Arrays.asList(TOPIC)),
   UPDATE_KAFKA_TOPIC_LOG_COMPACTION(
       "/update_kafka_topic_log_compaction", HttpMethod.POST, Arrays.asList(TOPIC, KAFKA_TOPIC_LOG_COMPACTION_ENABLED)
   ),

--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/PubSubTopicConfigResponse.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/PubSubTopicConfigResponse.java
@@ -1,0 +1,13 @@
+package com.linkedin.venice.controllerapi;
+
+public class PubSubTopicConfigResponse extends ControllerResponse {
+  private String topicConfigsResponse;
+
+  public void setTopicConfigsResponse(String topicConfigsResponse) {
+    this.topicConfigsResponse = topicConfigsResponse;
+  }
+
+  public String getTopicConfigsResponse() {
+    return topicConfigsResponse;
+  }
+}

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/AdminSparkServer.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/AdminSparkServer.java
@@ -40,6 +40,7 @@ import static com.linkedin.venice.controllerapi.ControllerRoute.GET_ALL_VALUE_AN
 import static com.linkedin.venice.controllerapi.ControllerRoute.GET_ALL_VALUE_SCHEMA;
 import static com.linkedin.venice.controllerapi.ControllerRoute.GET_CLUSTER_STORAGE_PERSONAS;
 import static com.linkedin.venice.controllerapi.ControllerRoute.GET_DELETABLE_STORE_TOPICS;
+import static com.linkedin.venice.controllerapi.ControllerRoute.GET_KAFKA_TOPIC_CONFIGS;
 import static com.linkedin.venice.controllerapi.ControllerRoute.GET_KEY_SCHEMA;
 import static com.linkedin.venice.controllerapi.ControllerRoute.GET_ONGOING_INCREMENTAL_PUSH_VERSIONS;
 import static com.linkedin.venice.controllerapi.ControllerRoute.GET_REGION_PUSH_DETAILS;
@@ -418,6 +419,7 @@ public class AdminSparkServer extends AbstractVeniceService {
         IS_STORE_VERSION_READY_FOR_DATA_RECOVERY.getPath(),
         dataRecoveryRoutes.isStoreVersionReadyForDataRecovery(admin));
     httpService.post(DATA_RECOVERY.getPath(), dataRecoveryRoutes.dataRecovery(admin));
+    httpService.get(GET_KAFKA_TOPIC_CONFIGS.getPath(), controllerRoutes.getKafkaTopicConfigs(admin));
     httpService
         .post(UPDATE_KAFKA_TOPIC_LOG_COMPACTION.getPath(), controllerRoutes.updateKafkaTopicLogCompaction(admin));
     httpService.post(UPDATE_KAFKA_TOPIC_RETENTION.getPath(), controllerRoutes.updateKafkaTopicRetention(admin));

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/ControllerRoutes.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/ControllerRoutes.java
@@ -119,7 +119,7 @@ public class ControllerRoutes extends AbstractRoute {
         responseObject.setCluster("");
         PubSubTopic topicName = pubSubTopicRepository.getTopic(request.queryParams(TOPIC));
         TopicManager topicManager = admin.getTopicManager();
-        PubSubTopicConfiguration pubSubTopicConfiguration = topicManager.getCachedTopicConfig(topicName);
+        PubSubTopicConfiguration pubSubTopicConfiguration = topicManager.getTopicConfigWithRetry(topicName);
         responseObject.setTopicConfigsResponse(pubSubTopicConfiguration.toString());
       } catch (Throwable e) {
         responseObject.setError(e);

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/ControllerRoutes.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/ControllerRoutes.java
@@ -17,9 +17,11 @@ import com.linkedin.venice.controller.Admin;
 import com.linkedin.venice.controllerapi.ChildAwareResponse;
 import com.linkedin.venice.controllerapi.ControllerResponse;
 import com.linkedin.venice.controllerapi.LeaderControllerResponse;
+import com.linkedin.venice.controllerapi.PubSubTopicConfigResponse;
 import com.linkedin.venice.exceptions.ErrorType;
 import com.linkedin.venice.kafka.TopicManager;
 import com.linkedin.venice.meta.Instance;
+import com.linkedin.venice.pubsub.PubSubTopicConfiguration;
 import com.linkedin.venice.pubsub.PubSubTopicRepository;
 import com.linkedin.venice.pubsub.api.PubSubTopic;
 import com.linkedin.venice.utils.Utils;
@@ -103,6 +105,29 @@ public class ControllerRoutes extends AbstractRoute {
       TopicManager topicManager = admin.getTopicManager();
       topicManager.updateTopicCompactionPolicy(topicName, kafkaTopicLogCompactionEnabled);
     });
+  }
+
+  /**
+   * No ACL check; any user is allowed to check topic configs.
+   */
+  public Route getKafkaTopicConfigs(Admin admin) {
+    return (request, response) -> {
+      PubSubTopicConfigResponse responseObject = new PubSubTopicConfigResponse();
+      response.type(HttpConstants.JSON);
+
+      try {
+        responseObject.setCluster("");
+        PubSubTopic topicName = pubSubTopicRepository.getTopic(request.queryParams(TOPIC));
+        TopicManager topicManager = admin.getTopicManager();
+        PubSubTopicConfiguration pubSubTopicConfiguration = topicManager.getCachedTopicConfig(topicName);
+        responseObject.setTopicConfigsResponse(pubSubTopicConfiguration.toString());
+      } catch (Throwable e) {
+        responseObject.setError(e);
+        AdminSparkServer.handleError(e, request, response);
+      }
+      response.type(HttpConstants.JSON);
+      return AdminSparkServer.OBJECT_MAPPER.writeValueAsString(responseObject);
+    };
   }
 
   /**


### PR DESCRIPTION
## Summary, imperative, start upper case, don't end with a period
New admin command:
--get-kafka-topic-configs --url <controller_url> --kafka-topic-name <kafka-topic-name>


## How was this PR tested?
WIP

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.