### PR TITLE
[server] Isolated ingestion backend will make sure topic partition metadata get cleaned up together in case of exception

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/main/MainIngestionMonitorService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/main/MainIngestionMonitorService.java
@@ -228,11 +228,13 @@ public class MainIngestionMonitorService extends AbstractVeniceService {
     if (partitionLeaderStatus != null) {
       partitionLeaderStatus.remove(partitionId);
     }
+    LOGGER.info("Ingestion status removed from main process for topic: {}, partition: {}", topicName, partitionId);
   }
 
   public void cleanupTopicState(String topicName) {
     getTopicIngestionStatusMap().remove(topicName);
     getTopicPartitionLeaderStatusMap().remove(topicName);
+    LOGGER.info("Ingestion status removed from main process for topic: {}", topicName);
   }
 
   public long getTopicPartitionCount(String topicName) {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/main/MainIngestionRequestClient.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/main/MainIngestionRequestClient.java
@@ -164,7 +164,7 @@ public class MainIngestionRequestClient implements Closeable {
     sendIngestionCommandWithRetry(ingestionTaskCommand, topicName, Optional.empty(), REQUEST_MAX_ATTEMPT);
   }
 
-  public boolean unsubscribeTopicPartition(String topicName, int partitionId) {
+  public boolean removeTopicPartition(String topicName, int partitionId) {
     IngestionTaskCommand ingestionTaskCommand = new IngestionTaskCommand();
     ingestionTaskCommand.commandType = IngestionCommandType.REMOVE_PARTITION.getValue();
     ingestionTaskCommand.topicName = topicName;

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/ingestion/IsolatedIngestionBackendTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/ingestion/IsolatedIngestionBackendTest.java
@@ -6,9 +6,11 @@ import static com.linkedin.davinci.ingestion.main.MainPartitionIngestionStatus.N
 import static com.linkedin.venice.ingestion.protocol.enums.IngestionCommandType.START_CONSUMPTION;
 import static com.linkedin.venice.ingestion.protocol.enums.IngestionCommandType.STOP_CONSUMPTION;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -17,6 +19,7 @@ import static org.mockito.Mockito.when;
 import com.linkedin.davinci.config.VeniceConfigLoader;
 import com.linkedin.davinci.config.VeniceStoreVersionConfig;
 import com.linkedin.davinci.ingestion.main.MainIngestionMonitorService;
+import com.linkedin.davinci.ingestion.main.MainIngestionRequestClient;
 import com.linkedin.davinci.ingestion.main.MainTopicIngestionStatus;
 import com.linkedin.davinci.kafka.consumer.KafkaStoreIngestionService;
 import com.linkedin.davinci.notifier.VeniceNotifier;
@@ -199,5 +202,59 @@ public class IsolatedIngestionBackendTest {
     verify(backend, times(0)).getCompletionHandlingExecutor();
     backend.getIsolatedIngestionNotifier(ingestionNotifier).completed(topic, 1, 123L, "", Optional.empty());
     verify(backend, times(1)).getCompletionHandlingExecutor();
+  }
+
+  @Test
+  public void testBackendCanMaintainMetadataCorrectlyForDroppingPartition() {
+    try (MainIngestionMonitorService monitorService = mock(MainIngestionMonitorService.class);
+        IsolatedIngestionBackend backend = mock(IsolatedIngestionBackend.class)) {
+      String topic = "testTopic_v1";
+      int partition = 0;
+      VeniceStoreVersionConfig storeVersionConfig = mock(VeniceStoreVersionConfig.class);
+      when(storeVersionConfig.getStoreVersionName()).thenReturn(topic);
+      MainIngestionRequestClient ingestionRequestClient = mock(MainIngestionRequestClient.class);
+      when(backend.getMainIngestionRequestClient()).thenReturn(ingestionRequestClient);
+      when(backend.getMainIngestionMonitorService()).thenReturn(monitorService);
+      Map<String, MainTopicIngestionStatus> topicIngestionStatusMap = new VeniceConcurrentHashMap<>();
+      MainTopicIngestionStatus topicIngestionStatus = new MainTopicIngestionStatus(topic);
+      topicIngestionStatus.setPartitionIngestionStatusToLocalIngestion(partition);
+      topicIngestionStatusMap.put(topic, topicIngestionStatus);
+      doCallRealMethod().when(monitorService).cleanupTopicPartitionState(topic, partition);
+      when(monitorService.getTopicPartitionIngestionStatus(topic, partition)).thenCallRealMethod();
+      when(monitorService.getTopicIngestionStatusMap()).thenReturn(topicIngestionStatusMap);
+      when(backend.isTopicPartitionHostedInMainProcess(anyString(), anyInt())).thenCallRealMethod();
+      when(backend.isTopicPartitionIngesting(anyString(), anyInt())).thenCallRealMethod();
+      doCallRealMethod().when(backend).dropStoragePartitionGracefully(any(), anyInt(), anyInt(), anyBoolean());
+      doCallRealMethod().when(backend).executeCommandWithRetry(anyString(), anyInt(), any(), any(), any());
+      when(monitorService.getTopicPartitionCount(topic)).thenReturn(2L);
+      ReentrantReadWriteLock readWriteLock = new ReentrantReadWriteLock();
+      when(monitorService.getForkProcessActionLock()).thenReturn(readWriteLock);
+
+      // Case 1
+      backend.dropStoragePartitionGracefully(storeVersionConfig, partition, 180, false);
+      verify(backend, times(1)).removeTopicPartitionLocally(any(), anyInt(), anyInt(), anyBoolean());
+      verify(ingestionRequestClient, times(1)).resetTopicPartition(topic, partition);
+      verify(monitorService, times(1)).cleanupTopicPartitionState(topic, partition);
+      Assert.assertEquals(topicIngestionStatusMap.get(topic).getPartitionIngestionStatus(partition), NOT_EXIST);
+
+      // Case 2
+      topicIngestionStatusMap.get(topic).setPartitionIngestionStatusToLocalIngestion(partition);
+      doThrow(new VeniceException("test")).when(backend)
+          .removeTopicPartitionLocally(any(), anyInt(), anyInt(), anyBoolean());
+      Assert.assertThrows(() -> backend.dropStoragePartitionGracefully(storeVersionConfig, partition, 180, false));
+      verify(backend, times(2)).removeTopicPartitionLocally(any(), anyInt(), anyInt(), anyBoolean());
+      verify(ingestionRequestClient, times(1)).resetTopicPartition(topic, partition);
+      verify(monitorService, times(1)).cleanupTopicPartitionState(topic, partition);
+      Assert.assertEquals(topicIngestionStatusMap.get(topic).getPartitionIngestionStatus(partition), MAIN);
+
+      // Case 3
+      topicIngestionStatusMap.get(topic).setPartitionIngestionStatusToIsolatedIngestion(partition);
+      when(ingestionRequestClient.removeTopicPartition(topic, partition)).thenReturn(true);
+      backend.dropStoragePartitionGracefully(storeVersionConfig, partition, 180, false);
+      verify(ingestionRequestClient, times(1)).removeTopicPartition(topic, partition);
+      verify(ingestionRequestClient, times(2)).resetTopicPartition(topic, partition);
+      verify(monitorService, times(2)).cleanupTopicPartitionState(topic, partition);
+      Assert.assertEquals(topicIngestionStatusMap.get(topic).getPartitionIngestionStatus(partition), NOT_EXIST);
+    }
   }
 }


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci], [server], [controller],
[router], [samza], [vpj], [fast-client], [thin-client], [alpini],
[admin-tool], [test], [build], [doc], [script]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## [server] Isolated ingestion backend will make sure topic partition metadata get cleaned up together in case of exception
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

This PR fixes an issue found in test env when testing store migration. When migration is aborted, store is deleted and store partition is dropped. However, the drop action throws exception in getStoreOrThrow in MetaSystemStoreReplicaStatusNotifier#report() method. This exception in non-II env should abort the drop partition behavior. For II, it did not drop the partition, same as non-II logic, but the resource ingestion status was cleared only in main process, but not in II process. (We maintain resource ingestion status: which process owns the resource in both processes together). This out of sync of metadata lead to II process reject future ingestion action of the same topic partition (likely triggered by a successful migration). 

Since we have a logic to retry indefinitely to make sure Helix message is eventually delivered, this will block server for stopping as expected.

This PR only fixes the buggy logic in REMOVE_PARTITION action to make sure metadata is always updated together. 
As noticed recently, the infinite retry caused by store metadata out of sync due to any buggy behavior/logic is not a good solution. We should either remove it or make server being able to stop as normal when this happens. This change will happen in a future PR.
This PR also renames: method unsubscribeTopicPartition() to removeTopicPartition() for MainIngestionRequesetClient.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
New unit tests covering remove partition logic.

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.