### PR TITLE
[da-vinci] Added some basic metrics for DaVinci read path

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/client/AvroSpecificDaVinciClient.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/client/AvroSpecificDaVinciClient.java
@@ -1,6 +1,5 @@
 package com.linkedin.davinci.client;
 
-import com.linkedin.davinci.storage.chunking.AbstractAvroChunkingAdapter;
 import com.linkedin.davinci.storage.chunking.SpecificRecordChunkingAdapter;
 import com.linkedin.venice.client.store.ClientConfig;
 import com.linkedin.venice.serializer.FastSerializerDeserializerFactory;
@@ -12,23 +11,22 @@ import org.apache.avro.specific.SpecificRecord;
 
 
 public class AvroSpecificDaVinciClient<K, V extends SpecificRecord> extends AvroGenericDaVinciClient<K, V> {
-  private final SpecificRecordChunkingAdapter<V> chunkingAdapter;
-
   public AvroSpecificDaVinciClient(
       DaVinciConfig daVinciConfig,
       ClientConfig clientConfig,
       VeniceProperties backendConfig,
       Optional<Set<String>> managedClients,
       ICProvider icProvider) {
-    super(daVinciConfig, clientConfig, backendConfig, managedClients, icProvider);
-
-    Class<V> valueClass = clientConfig.getSpecificValueClass();
-    FastSerializerDeserializerFactory.verifyWhetherFastSpecificDeserializerWorks(valueClass);
-    this.chunkingAdapter = new SpecificRecordChunkingAdapter<>(valueClass);
-  }
-
-  @Override
-  protected AbstractAvroChunkingAdapter<V> getAvroChunkingAdapter() {
-    return chunkingAdapter;
+    super(
+        daVinciConfig,
+        clientConfig,
+        backendConfig,
+        managedClients,
+        icProvider,
+        new SpecificRecordChunkingAdapter<>(clientConfig.getSpecificValueClass()),
+        () -> {
+          Class<V> valueClass = clientConfig.getSpecificValueClass();
+          FastSerializerDeserializerFactory.verifyWhetherFastSpecificDeserializerWorks(valueClass);
+        });
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/client/DaVinciConfig.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/client/DaVinciConfig.java
@@ -33,6 +33,13 @@ public class DaVinciConfig {
    */
   private ObjectCacheConfig cacheConfig;
 
+  /**
+   * Whether to enable read-path metrics.
+   * Metrics are expensive compared with the DaVinci performance and this feature should be disabled for
+   * the high throughput use cases.
+   */
+  private boolean readMetricsEnabled = false;
+
   public DaVinciConfig() {
   }
 
@@ -97,5 +104,13 @@ public class DaVinciConfig {
   public DaVinciConfig setCacheConfig(ObjectCacheConfig cacheConfig) {
     this.cacheConfig = cacheConfig;
     return this;
+  }
+
+  public boolean isReadMetricsEnabled() {
+    return readMetricsEnabled;
+  }
+
+  public void setReadMetricsEnabled(boolean readMetricsEnabled) {
+    this.readMetricsEnabled = readMetricsEnabled;
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/client/DelegatingAvroGenericDaVinciClient.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/client/DelegatingAvroGenericDaVinciClient.java
@@ -1,0 +1,140 @@
+package com.linkedin.davinci.client;
+
+import com.linkedin.venice.client.exceptions.VeniceClientException;
+import com.linkedin.venice.client.stats.ClientStats;
+import com.linkedin.venice.client.store.AvroGenericReadComputeStoreClient;
+import com.linkedin.venice.client.store.ComputeGenericRecord;
+import com.linkedin.venice.client.store.ComputeRequestBuilder;
+import com.linkedin.venice.client.store.streaming.StreamingCallback;
+import com.linkedin.venice.compute.ComputeRequestWrapper;
+import java.io.ByteArrayOutputStream;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.io.BinaryEncoder;
+
+
+/**
+ * Delegating layer for {@link DaVinciClient}.
+ */
+public class DelegatingAvroGenericDaVinciClient<K, V>
+    implements DaVinciClient<K, V>, AvroGenericReadComputeStoreClient<K, V> {
+  private final AvroGenericDaVinciClient<K, V> delegate;
+
+  public DelegatingAvroGenericDaVinciClient(AvroGenericDaVinciClient<K, V> delegate) {
+    this.delegate = delegate;
+  }
+
+  @Override
+  public CompletableFuture<Void> subscribeAll() {
+    return delegate.subscribeAll();
+  }
+
+  @Override
+  public CompletableFuture<Void> subscribe(Set<Integer> partitions) {
+    return delegate.subscribe(partitions);
+  }
+
+  @Override
+  public void unsubscribeAll() {
+    delegate.unsubscribeAll();
+  }
+
+  @Override
+  public void unsubscribe(Set<Integer> partitions) {
+    delegate.unsubscribe(partitions);
+  }
+
+  @Override
+  public int getPartitionCount() {
+    return delegate.getPartitionCount();
+  }
+
+  @Override
+  public CompletableFuture<V> get(K key) throws VeniceClientException {
+    return delegate.get(key);
+  }
+
+  @Override
+  public CompletableFuture<V> get(K key, V reusedValue) throws VeniceClientException {
+    return delegate.get(key, reusedValue);
+  }
+
+  @Override
+  public CompletableFuture<Map<K, V>> batchGet(Set<K> keys) throws VeniceClientException {
+    return delegate.batchGet(keys);
+  }
+
+  @Override
+  public void start() throws VeniceClientException {
+    delegate.start();
+  }
+
+  @Override
+  public void close() {
+    delegate.close();
+  }
+
+  @Override
+  public String getStoreName() {
+    return delegate.getStoreName();
+  }
+
+  @Override
+  public Schema getKeySchema() {
+    return delegate.getKeySchema();
+  }
+
+  @Override
+  public Schema getLatestValueSchema() {
+    return delegate.getLatestValueSchema();
+  }
+
+  @Override
+  public ComputeRequestBuilder<K> compute(
+      Optional<ClientStats> stats,
+      Optional<ClientStats> streamingStats,
+      long preRequestTimeInNS) throws VeniceClientException {
+    return delegate.compute(stats, streamingStats, preRequestTimeInNS);
+  }
+
+  @Override
+  public void compute(
+      ComputeRequestWrapper computeRequestWrapper,
+      Set<K> keys,
+      Schema resultSchema,
+      StreamingCallback<K, ComputeGenericRecord> callback,
+      long preRequestTimeInNS) throws VeniceClientException {
+    delegate.compute(computeRequestWrapper, keys, resultSchema, callback, preRequestTimeInNS);
+  }
+
+  @Override
+  public void compute(
+      ComputeRequestWrapper computeRequestWrapper,
+      Set<K> keys,
+      Schema resultSchema,
+      StreamingCallback<K, ComputeGenericRecord> callback,
+      long preRequestTimeInNS,
+      BinaryEncoder reusedEncoder,
+      ByteArrayOutputStream reusedOutputStream) throws VeniceClientException {
+    delegate.compute(
+        computeRequestWrapper,
+        keys,
+        resultSchema,
+        callback,
+        preRequestTimeInNS,
+        reusedEncoder,
+        reusedOutputStream);
+  }
+
+  @Override
+  public void computeWithKeyPrefixFilter(
+      byte[] prefixBytes,
+      ComputeRequestWrapper computeRequestWrapper,
+      StreamingCallback<GenericRecord, GenericRecord> callback) {
+    delegate.computeWithKeyPrefixFilter(prefixBytes, computeRequestWrapper, callback);
+  }
+}

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/client/StatsAvroGenericDaVinciClient.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/client/StatsAvroGenericDaVinciClient.java
@@ -1,0 +1,89 @@
+package com.linkedin.davinci.client;
+
+import com.linkedin.venice.client.exceptions.VeniceClientException;
+import com.linkedin.venice.client.stats.BasicClientStats;
+import com.linkedin.venice.client.store.ClientConfig;
+import com.linkedin.venice.read.RequestType;
+import com.linkedin.venice.utils.LatencyUtils;
+import io.tehuti.metrics.MetricsRepository;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Supplier;
+
+
+/**
+ * Currently, we only expose metrics for single-get and batch-get requests, and if there
+ * is a need to have metrics for other request types, we can add them later.
+ *
+ * So far, it only offers very basic metrics:
+ * 1. Healthy request rate.
+ * 2. Unhealthy request rate.
+ * 3. Healthy request latency.
+ * 4. Key count for batch-get request.
+ * 5. Success request/key count ratio.
+ */
+public class StatsAvroGenericDaVinciClient<K, V> extends DelegatingAvroGenericDaVinciClient<K, V> {
+  private final BasicClientStats clientStatsForSingleGet;
+  private final BasicClientStats clientStatsForBatchGet;
+
+  public StatsAvroGenericDaVinciClient(AvroGenericDaVinciClient<K, V> delegate, ClientConfig clientConfig) {
+    super(delegate);
+    MetricsRepository metricsRepository = clientConfig.getMetricsRepository();
+    if (metricsRepository == null) {
+      throw new VeniceClientException("MetricsRepository shouldn't be null");
+    }
+    this.clientStatsForSingleGet = BasicClientStats
+        .getClientStats(metricsRepository, clientConfig.getStoreName(), RequestType.SINGLE_GET, clientConfig);
+    this.clientStatsForBatchGet = BasicClientStats
+        .getClientStats(metricsRepository, clientConfig.getStoreName(), RequestType.MULTI_GET, clientConfig);
+  }
+
+  private static <T> CompletableFuture<T> trackRequest(
+      BasicClientStats stats,
+      Supplier<CompletableFuture<T>> futureSupplier) {
+    long startTimeInNS = System.nanoTime();
+    CompletableFuture<T> statFuture = new CompletableFuture<>();
+    try {
+      return futureSupplier.get().whenComplete((v, throwable) -> {
+        if (throwable != null) {
+          stats.recordUnhealthyRequest();
+          statFuture.completeExceptionally(throwable);
+        } else {
+          stats.recordHealthyRequest();
+          stats.recordHealthyLatency(LatencyUtils.getLatencyInMS(startTimeInNS));
+          statFuture.complete(v);
+        }
+      });
+    } catch (Exception e) {
+      stats.recordUnhealthyRequest();
+      throw e;
+    }
+  }
+
+  @Override
+  public CompletableFuture<V> get(K key) {
+    return get(key, null);
+  }
+
+  @Override
+  public CompletableFuture<V> get(K key, V reusableValue) {
+    clientStatsForSingleGet.recordRequestKeyCount(1);
+    return trackRequest(clientStatsForSingleGet, () -> super.get(key, reusableValue)).whenComplete((v, throwable) -> {
+      if (throwable == null && v != null) {
+        clientStatsForSingleGet.recordSuccessRequestKeyCount(1);
+      }
+    });
+  }
+
+  @Override
+  public CompletableFuture<Map<K, V>> batchGet(Set<K> keys) {
+    clientStatsForBatchGet.recordRequestKeyCount(keys.size());
+    return trackRequest(clientStatsForBatchGet, () -> super.batchGet(keys)).whenComplete((v, throwable) -> {
+      if (throwable == null && v != null) {
+        clientStatsForBatchGet.recordSuccessRequestKeyCount(v.size());
+      }
+    });
+  }
+
+}

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/client/StatsAvroSpecificDaVinciClient.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/client/StatsAvroSpecificDaVinciClient.java
@@ -1,0 +1,11 @@
+package com.linkedin.davinci.client;
+
+import com.linkedin.venice.client.store.ClientConfig;
+import org.apache.avro.specific.SpecificRecord;
+
+
+public class StatsAvroSpecificDaVinciClient<K, V extends SpecificRecord> extends StatsAvroGenericDaVinciClient<K, V> {
+  public StatsAvroSpecificDaVinciClient(AvroSpecificDaVinciClient<K, V> delegate, ClientConfig clientConfig) {
+    super(delegate, clientConfig);
+  }
+}

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/client/StatsAvroGenericDaVinciClientTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/client/StatsAvroGenericDaVinciClientTest.java
@@ -1,0 +1,107 @@
+package com.linkedin.davinci.client;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertThrows;
+import static org.testng.Assert.assertTrue;
+
+import com.linkedin.venice.client.store.ClientConfig;
+import com.linkedin.venice.utils.DataProviderUtils;
+import io.tehuti.Metric;
+import io.tehuti.metrics.MetricsRepository;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import org.testng.annotations.Test;
+
+
+public class StatsAvroGenericDaVinciClientTest {
+  @Test(dataProviderClass = DataProviderUtils.class, dataProvider = "True-and-False")
+  public void testGet(boolean reuseApi) throws ExecutionException, InterruptedException {
+    String storeName = "test_store";
+    AvroGenericDaVinciClient mockClient = mock(AvroGenericDaVinciClient.class);
+    CompletableFuture<String> errorFuture = new CompletableFuture<>();
+    errorFuture.completeExceptionally(new RuntimeException("mock_exception_thrown_by_async_future"));
+    CompletableFuture<String> okFuture = new CompletableFuture<>();
+    String okResult = "test_result";
+    okFuture.complete(okResult);
+    when(mockClient.get(any(), any())).thenReturn(okFuture)
+        .thenReturn(errorFuture)
+        .thenThrow(new RuntimeException("mock_exception_by_function_directly"));
+    when(mockClient.getStoreName()).thenReturn(storeName);
+
+    MetricsRepository metricsRepository = new MetricsRepository();
+    StatsAvroGenericDaVinciClient statsClient = new StatsAvroGenericDaVinciClient(
+        mockClient,
+        new ClientConfig(storeName).setMetricsRepository(metricsRepository));
+
+    Object result;
+    if (reuseApi) {
+      result = statsClient.get("test_key", null).get();
+    } else {
+      result = statsClient.get("test_key").get();
+    }
+    assertEquals(result, okResult);
+
+    if (reuseApi) {
+      assertThrows(ExecutionException.class, () -> statsClient.get("test_key", null).get());
+      assertThrows(RuntimeException.class, () -> statsClient.get("test_key", null));
+    } else {
+      assertThrows(ExecutionException.class, () -> statsClient.get("test_key").get());
+      assertThrows(RuntimeException.class, () -> statsClient.get("test_key"));
+    }
+    Map<String, ? extends Metric> metrics = metricsRepository.metrics();
+    assertTrue(metrics.get(".test_store--healthy_request.OccurrenceRate").value() > 0);
+    assertTrue(metrics.get(".test_store--unhealthy_request.OccurrenceRate").value() > 0);
+    assertTrue(metrics.get(".test_store--healthy_request_latency.Avg").value() > 0);
+    assertEquals(metrics.get(".test_store--success_request_key_count.Avg").value(), 1.0);
+    assertEquals(metrics.get(".test_store--success_request_key_count.Max").value(), 1.0);
+    assertTrue(metrics.get(".test_store--success_request_ratio.SimpleRatioStat").value() < 1.0);
+    assertTrue(metrics.get(".test_store--success_request_key_ratio.SimpleRatioStat").value() < 1.0);
+  }
+
+  @Test
+  public void testBatchGet() throws ExecutionException, InterruptedException {
+    String storeName = "test_store";
+    Set<String> keys = new HashSet<>(Arrays.asList("key1", "key2", "key3"));
+    AvroGenericDaVinciClient mockClient = mock(AvroGenericDaVinciClient.class);
+    CompletableFuture<String> errorFuture = new CompletableFuture<>();
+    errorFuture.completeExceptionally(new RuntimeException("mock_exception_thrown_by_async_future"));
+    CompletableFuture<Map<String, String>> okFuture = new CompletableFuture<>();
+    Map<String, String> resultMap = new HashMap<>();
+    resultMap.put("key1", "value1");
+    resultMap.put("key2", "value2");
+    okFuture.complete(resultMap);
+    when(mockClient.batchGet(any())).thenReturn(okFuture)
+        .thenReturn(errorFuture)
+        .thenThrow(new RuntimeException("mock_exception_by_function_directly"));
+    when(mockClient.getStoreName()).thenReturn(storeName);
+
+    MetricsRepository metricsRepository = new MetricsRepository();
+    StatsAvroGenericDaVinciClient statsClient = new StatsAvroGenericDaVinciClient(
+        mockClient,
+        new ClientConfig(storeName).setMetricsRepository(metricsRepository));
+
+    // No exception should happen
+    assertEquals(statsClient.batchGet(keys).get(), resultMap);
+
+    assertThrows(ExecutionException.class, () -> statsClient.batchGet(keys).get());
+    assertThrows(RuntimeException.class, () -> statsClient.batchGet(keys));
+    Map<String, ? extends Metric> metrics = metricsRepository.metrics();
+
+    assertTrue(metrics.get(".test_store--multiget_healthy_request.OccurrenceRate").value() > 0);
+    assertTrue(metrics.get(".test_store--multiget_unhealthy_request.OccurrenceRate").value() > 0);
+    assertTrue(metrics.get(".test_store--multiget_healthy_request_latency.Avg").value() > 0);
+    assertEquals(metrics.get(".test_store--multiget_success_request_key_count.Avg").value(), 2.0);
+    assertEquals(metrics.get(".test_store--multiget_success_request_key_count.Max").value(), 2.0);
+    assertTrue(metrics.get(".test_store--multiget_success_request_ratio.SimpleRatioStat").value() < 1.0);
+    assertTrue(metrics.get(".test_store--multiget_success_request_key_ratio.SimpleRatioStat").value() < 1.0);
+    System.out.println(metricsRepository.metrics());
+  }
+}

--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/stats/BasicClientStats.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/stats/BasicClientStats.java
@@ -1,0 +1,92 @@
+package com.linkedin.venice.client.stats;
+
+import com.linkedin.venice.client.store.ClientConfig;
+import com.linkedin.venice.read.RequestType;
+import com.linkedin.venice.stats.AbstractVeniceHttpStats;
+import com.linkedin.venice.stats.TehutiUtils;
+import io.tehuti.metrics.MetricsRepository;
+import io.tehuti.metrics.Sensor;
+import io.tehuti.metrics.stats.Avg;
+import io.tehuti.metrics.stats.Max;
+import io.tehuti.metrics.stats.OccurrenceRate;
+import io.tehuti.metrics.stats.Rate;
+
+
+/**
+ * This class offers very basic metrics for client, and right now, it is directly used by DaVinci.
+ */
+public class BasicClientStats extends AbstractVeniceHttpStats {
+  private final Sensor requestSensor;
+  private final Sensor healthySensor;
+  private final Sensor unhealthySensor;
+  private final Sensor healthyRequestLatencySensor;
+  private final Sensor requestKeyCountSensor;
+  private final Sensor successRequestKeyCountSensor;
+  private final Sensor successRequestRatioSensor;
+  private final Sensor successRequestKeyRatioSensor;
+  private final Rate requestRate = new OccurrenceRate();
+  private final Rate successRequestKeyCountRate = new Rate();
+
+  public static BasicClientStats getClientStats(
+      MetricsRepository metricsRepository,
+      String storeName,
+      RequestType requestType,
+      ClientConfig clientConfig) {
+    String prefix = clientConfig == null ? null : clientConfig.getStatsPrefix();
+    String metricName = prefix == null || prefix.isEmpty() ? storeName : prefix + "." + storeName;
+    return new BasicClientStats(metricsRepository, metricName, requestType);
+  }
+
+  protected BasicClientStats(MetricsRepository metricsRepository, String storeName, RequestType requestType) {
+    super(metricsRepository, storeName, requestType);
+    requestSensor = registerSensor("request", requestRate);
+    Rate healthyRequestRate = new OccurrenceRate();
+    healthySensor = registerSensor("healthy_request", healthyRequestRate);
+    unhealthySensor = registerSensor("unhealthy_request", new OccurrenceRate());
+    healthyRequestLatencySensor = registerSensorWithDetailedPercentiles("healthy_request_latency", new Avg());
+    successRequestRatioSensor =
+        registerSensor("success_request_ratio", new TehutiUtils.SimpleRatioStat(healthyRequestRate, requestRate));
+    Rate requestKeyCountRate = new Rate();
+    requestKeyCountSensor = registerSensor("request_key_count", requestKeyCountRate, new Avg(), new Max());
+    successRequestKeyCountSensor =
+        registerSensor("success_request_key_count", successRequestKeyCountRate, new Avg(), new Max());
+
+    successRequestKeyRatioSensor = registerSensor(
+        "success_request_key_ratio",
+        new TehutiUtils.SimpleRatioStat(successRequestKeyCountRate, requestKeyCountRate));
+  }
+
+  private void recordRequest() {
+    requestSensor.record();
+  }
+
+  public void recordHealthyRequest() {
+    recordRequest();
+    healthySensor.record();
+  }
+
+  public void recordUnhealthyRequest() {
+    recordRequest();
+    unhealthySensor.record();
+  }
+
+  public void recordHealthyLatency(double latency) {
+    healthyRequestLatencySensor.record(latency);
+  }
+
+  public void recordRequestKeyCount(int keyCount) {
+    requestKeyCountSensor.record(keyCount);
+  }
+
+  public void recordSuccessRequestKeyCount(int successKeyCount) {
+    successRequestKeyCountSensor.record(successKeyCount);
+  }
+
+  protected final Rate getRequestRate() {
+    return requestRate;
+  }
+
+  protected final Rate getSuccessRequestKeyCountRate() {
+    return successRequestKeyCountRate;
+  }
+}

--- a/clients/venice-thin-client/src/test/java/com/linkedin/venice/client/stats/BasicClientStatsTest.java
+++ b/clients/venice-thin-client/src/test/java/com/linkedin/venice/client/stats/BasicClientStatsTest.java
@@ -1,0 +1,38 @@
+package com.linkedin.venice.client.stats;
+
+import static org.testng.Assert.assertTrue;
+
+import com.linkedin.venice.client.store.ClientConfig;
+import com.linkedin.venice.read.RequestType;
+import io.tehuti.metrics.MetricsRepository;
+import org.testng.annotations.Test;
+
+
+public class BasicClientStatsTest {
+  @Test
+  public void testMetricPrefix() {
+    String storeName = "test_store";
+    MetricsRepository metricsRepository1 = new MetricsRepository();
+    // Without prefix
+    ClientConfig config1 = new ClientConfig(storeName);
+    BasicClientStats.getClientStats(metricsRepository1, storeName, RequestType.SINGLE_GET, config1);
+    // Check metric name
+    assertTrue(metricsRepository1.metrics().size() > 0);
+    String metricPrefix1 = "." + storeName;
+    metricsRepository1.metrics().forEach((k, v) -> {
+      assertTrue(k.startsWith(metricPrefix1));
+    });
+
+    // With prefix
+    String prefix = "test_prefix";
+    MetricsRepository metricsRepository2 = new MetricsRepository();
+    ClientConfig config2 = new ClientConfig(storeName).setStatsPrefix(prefix);
+    BasicClientStats.getClientStats(metricsRepository2, storeName, RequestType.SINGLE_GET, config2);
+    // Check metric name
+    assertTrue(metricsRepository2.metrics().size() > 0);
+    String metricPrefix2 = "." + prefix + "_" + storeName;
+    metricsRepository2.metrics().forEach((k, v) -> {
+      assertTrue(k.startsWith(metricPrefix2));
+    });
+  }
+}

--- a/internal/venice-test-common/src/main/java/com/linkedin/venice/utils/DataProviderUtils.java
+++ b/internal/venice-test-common/src/main/java/com/linkedin/venice/utils/DataProviderUtils.java
@@ -62,6 +62,7 @@ public class DataProviderUtils {
   @DataProvider(name = "dv-client-config-provider")
   public static Object[][] daVinciConfigProvider() {
     DaVinciConfig defaultDaVinciConfig = new DaVinciConfig();
+    defaultDaVinciConfig.setReadMetricsEnabled(true);
 
     DaVinciConfig cachingDaVinciConfig = new DaVinciConfig();
     cachingDaVinciConfig.setCacheConfig(new ObjectCacheConfig());


### PR DESCRIPTION
This code change adds the following basic metrics for DaVinci read path:
1. Request.
2. Healthy/Unhealthy request.
3. Healthy request latency.
4. Key count.
5. Successful ratio.

Currently, this code change only adds the above metrics for single-get and batch-get requests, and if there is need to support other request types, we can add them later.

Currently, this feature is controlled by `DaVinciConfig#readMetricsEnabled`, and it is off by default.

<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci], [server], [controller],
[router], [samza], [vpj], [fast-client], [thin-client], [alpini],
[admin-tool], [test], [build], [doc], [script]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->


## How was this PR tested?
CI
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [x] Yes. Make sure to explain your proposed changes and call out the behavior change.
If DaVinci customers would like to enable the read path metrics, they need to explicitly enable it by `DaVinciConfig#readMetricsEnabled`, which is off by default.