### PR TITLE
[fast-client] Allow using DaVinci client based store metadata fetch for fast client

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -630,6 +630,7 @@ ext.createDiffFile = { ->
         ':!services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceController.java',
         ':!services/venice-router/src/main/java/com/linkedin/venice/router/RouterServer.java',
         ':!services/venice-standalone/*', // exclude the entire standalone project
+        ':!clients/venice-client/src/main/java/com/linkedin/venice/fastclient/factory/ClientFactory.java',
 
         // Other files that have tests but are not executed in the regular unit test task
         ':!internal/alpini/*'

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/repository/DaVinciClientMetaStoreBasedRepository.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/repository/DaVinciClientMetaStoreBasedRepository.java
@@ -1,0 +1,296 @@
+package com.linkedin.davinci.repository;
+
+import static com.linkedin.venice.system.store.MetaStoreWriter.KEY_STRING_CLUSTER_NAME;
+import static com.linkedin.venice.system.store.MetaStoreWriter.KEY_STRING_STORE_NAME;
+
+import com.linkedin.davinci.client.DaVinciClient;
+import com.linkedin.davinci.client.DaVinciConfig;
+import com.linkedin.davinci.client.factory.CachingDaVinciClientFactory;
+import com.linkedin.venice.client.store.ClientConfig;
+import com.linkedin.venice.common.VeniceSystemStoreType;
+import com.linkedin.venice.exceptions.MissingKeyInStoreMetadataException;
+import com.linkedin.venice.exceptions.VeniceException;
+import com.linkedin.venice.exceptions.VeniceNoStoreException;
+import com.linkedin.venice.meta.ReadOnlyStore;
+import com.linkedin.venice.meta.Store;
+import com.linkedin.venice.meta.StoreConfig;
+import com.linkedin.venice.meta.SystemStore;
+import com.linkedin.venice.meta.ZKStore;
+import com.linkedin.venice.schema.SchemaData;
+import com.linkedin.venice.schema.SchemaEntry;
+import com.linkedin.venice.schema.SchemaReader;
+import com.linkedin.venice.store.StoreStateReader;
+import com.linkedin.venice.system.store.MetaStoreDataType;
+import com.linkedin.venice.systemstore.schemas.StoreMetaKey;
+import com.linkedin.venice.systemstore.schemas.StoreMetaValue;
+import com.linkedin.venice.systemstore.schemas.StoreProperties;
+import com.linkedin.venice.utils.Utils;
+import com.linkedin.venice.utils.VeniceProperties;
+import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import org.apache.avro.Schema;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+
+/**
+ * This implementation uses DaVinci client backed meta system store to provide data to the {@link NativeMetadataRepository}.
+ * The data is then cached and served from there. Deprecated due to cyclic dependency during initialization.
+ */
+@Deprecated
+public class DaVinciClientMetaStoreBasedRepository extends NativeMetadataRepository {
+  private static final int KEY_SCHEMA_ID = 1;
+  private static final Logger LOGGER = LogManager.getLogger(DaVinciClientMetaStoreBasedRepository.class);
+
+  // Map of user store name to their corresponding meta store which is used for finding the correct current version.
+  // TODO Store objects in this map are mocked locally based on client.meta.system.store.version.map config.
+
+  // A map of user store name to their corresponding daVinci client of the meta store.
+  private final Map<String, DaVinciClient<StoreMetaKey, StoreMetaValue>> daVinciClientMap =
+      new VeniceConcurrentHashMap<>();
+
+  // A map of mocked meta Store objects. Keep the meta stores separately from
+  // SystemStoreBasedRepository.subscribedStoreMap
+  // because these meta stores doesn't require refreshes.
+  private final Map<String, SystemStore> metaStoreMap = new VeniceConcurrentHashMap<>();
+
+  private final DaVinciConfig daVinciConfig = new DaVinciConfig();
+  private final CachingDaVinciClientFactory daVinciClientFactory;
+  private final SchemaReader metaStoreSchemaReader;
+
+  public DaVinciClientMetaStoreBasedRepository(
+      ClientConfig clientConfig,
+      VeniceProperties backendConfig,
+      CachingDaVinciClientFactory daVinciClientFactory,
+      SchemaReader metaStoreSchemaReader) {
+    super(clientConfig, backendConfig);
+    this.daVinciClientFactory = daVinciClientFactory;
+    this.metaStoreSchemaReader = metaStoreSchemaReader;
+  }
+
+  @Override
+  protected Store removeStore(String storeName) {
+    if (VeniceSystemStoreType.getSystemStoreType(storeName) == null) {
+      // We also need to release its corresponding meta system store resources.
+      Store metaSystemStore = metaStoreMap.remove(VeniceSystemStoreType.META_STORE.getSystemStoreName(storeName));
+      if (metaSystemStore != null) {
+        notifyStoreDeleted(metaSystemStore);
+      }
+      daVinciClientMap.remove(storeName);
+    }
+    return super.removeStore(storeName);
+  }
+
+  @Override
+  protected StoreMetaValue getStoreMetaValue(String storeName, StoreMetaKey key) {
+    StoreMetaValue value;
+    try {
+      value = getDaVinciClientForMetaStore(storeName).get(key).get();
+    } catch (InterruptedException | ExecutionException e) {
+      throw new VeniceException(
+          "Failed to get metadata from meta system store with DaVinci client for store: " + storeName + " with key: "
+              + key.toString(),
+          e);
+    }
+    if (value == null) {
+      throw new MissingKeyInStoreMetadataException(key.toString(), StoreMetaValue.class.getSimpleName());
+    }
+    return value;
+  }
+
+  @Override
+  public SchemaEntry getKeySchema(String storeName) {
+    if (VeniceSystemStoreType.getSystemStoreType(storeName) == VeniceSystemStoreType.META_STORE) {
+      return new SchemaEntry(KEY_SCHEMA_ID, metaStoreSchemaReader.getKeySchema());
+    } else {
+      return super.getKeySchema(storeName);
+    }
+  }
+
+  @Override
+  protected SchemaEntry getValueSchemaInternally(String storeName, int id) {
+    if (VeniceSystemStoreType.getSystemStoreType(storeName) == VeniceSystemStoreType.META_STORE) {
+      Schema schema = metaStoreSchemaReader.getValueSchema(id);
+      return schema == null ? null : new SchemaEntry(id, schema);
+    } else {
+      return super.getValueSchemaInternally(storeName, id);
+    }
+  }
+
+  @Override
+  public int getValueSchemaId(String storeName, String valueSchemaStr) {
+    if (VeniceSystemStoreType.getSystemStoreType(storeName) == VeniceSystemStoreType.META_STORE) {
+      return metaStoreSchemaReader.getValueSchemaId(Schema.parse(valueSchemaStr));
+    } else {
+      return super.getValueSchemaId(storeName, valueSchemaStr);
+    }
+  }
+
+  @Override
+  public Collection<SchemaEntry> getValueSchemas(String storeName) {
+    if (VeniceSystemStoreType.getSystemStoreType(storeName) == VeniceSystemStoreType.META_STORE) {
+      throw new UnsupportedOperationException("getValueSchemas not supported for store: " + storeName);
+    } else {
+      return super.getValueSchemas(storeName);
+    }
+  }
+
+  @Override
+  public SchemaEntry getSupersetOrLatestValueSchema(String storeName) {
+    if (VeniceSystemStoreType.getSystemStoreType(storeName) == VeniceSystemStoreType.META_STORE) {
+      return new SchemaEntry(
+          metaStoreSchemaReader.getLatestValueSchemaId(),
+          metaStoreSchemaReader.getLatestValueSchema());
+    } else {
+      return super.getSupersetOrLatestValueSchema(storeName);
+    }
+  }
+
+  @Override
+  public SchemaEntry getSupersetSchema(String storeName) {
+    if (VeniceSystemStoreType.getSystemStoreType(storeName) == VeniceSystemStoreType.META_STORE) {
+      throw new VeniceException("Meta store does not have superset schema. Store name: " + storeName);
+    } else {
+      return super.getSupersetSchema(storeName);
+    }
+  }
+
+  @Override
+  public void subscribe(String storeName) throws InterruptedException {
+    if (VeniceSystemStoreType.getSystemStoreType(storeName) == VeniceSystemStoreType.META_STORE) {
+      metaStoreMap.computeIfAbsent(storeName, k -> getMetaStore(storeName));
+      subscribedStoreMap.put(storeName, metaStoreMap.get(storeName));
+    } else {
+      super.subscribe(storeName);
+    }
+  }
+
+  @Override
+  public Store refreshOneStore(String storeName) {
+    if (VeniceSystemStoreType.getSystemStoreType(storeName) == VeniceSystemStoreType.META_STORE) {
+      // DaVinciClientMetaStoreBasedRepository also need to refresh the metadata for the corresponding meta system
+      // stores in case the system stores get a new current version.
+      SystemStore existingMetaStore = metaStoreMap.get(storeName);
+      SystemStore newMetaStore = existingMetaStore;
+      String userStoreName = VeniceSystemStoreType.META_STORE.extractRegularStoreName(storeName);
+      String clusterName = getStoreConfigFromMetaSystemStore(userStoreName).getCluster();
+      Store newStore = getStoreFromSystemStore(userStoreName, clusterName);
+      int newCurrentVersion =
+          newStore.getSystemStores().get(VeniceSystemStoreType.META_STORE.getPrefix()).getCurrentVersion();
+      if (newCurrentVersion != existingMetaStore.getCurrentVersion()) {
+        LOGGER.info(
+            "Meta system store: {} current version changed from {} to {}",
+            storeName,
+            existingMetaStore.getCurrentVersion(),
+            newCurrentVersion);
+        newMetaStore = getMetaStore(storeName);
+        metaStoreMap.put(storeName, newMetaStore);
+        subscribedStoreMap.put(storeName, newMetaStore);
+        notifyStoreChanged(newMetaStore);
+      }
+      return newMetaStore;
+    } else {
+      return super.refreshOneStore(storeName);
+    }
+  }
+
+  @Override
+  public Store getStore(String storeName) {
+    if (VeniceSystemStoreType.getSystemStoreType(storeName) == VeniceSystemStoreType.META_STORE) {
+      Store store = metaStoreMap.get(storeName);
+      return store == null ? null : new ReadOnlyStore(store);
+    } else {
+      return super.getStore(storeName);
+    }
+  }
+
+  @Override
+  public Store getStoreOrThrow(String storeName) throws VeniceNoStoreException {
+    if (VeniceSystemStoreType.getSystemStoreType(storeName) == VeniceSystemStoreType.META_STORE) {
+      Store store = metaStoreMap.get(storeName);
+      if (store != null) {
+        return new ReadOnlyStore(store);
+      }
+      throw new VeniceNoStoreException(storeName);
+    } else {
+      return super.getStoreOrThrow(storeName);
+    }
+  }
+
+  @Override
+  public boolean hasStore(String storeName) {
+    if (VeniceSystemStoreType.getSystemStoreType(storeName) == VeniceSystemStoreType.META_STORE) {
+      return metaStoreMap.containsKey(storeName);
+    } else {
+      return super.hasStore(storeName);
+    }
+  }
+
+  @Override
+  public void clear() {
+    subscribedStoreMap.clear();
+    daVinciClientFactory.close();
+    daVinciClientMap.clear();
+    Utils.closeQuietlyWithErrorLogged(metaStoreSchemaReader);
+    subscribedStoreMap.clear();
+  }
+
+  @Override
+  protected StoreConfig getStoreConfigFromSystemStore(String storeName) {
+    return getStoreConfigFromMetaSystemStore(storeName);
+  }
+
+  @Override
+  protected Store getStoreFromSystemStore(String storeName, String clusterName) {
+    StoreProperties storeProperties =
+        getStoreMetaValue(storeName, MetaStoreDataType.STORE_PROPERTIES.getStoreMetaKey(new HashMap<String, String>() {
+          {
+            put(KEY_STRING_STORE_NAME, storeName);
+            put(KEY_STRING_CLUSTER_NAME, clusterName);
+          }
+        })).storeProperties;
+    return new ZKStore(storeProperties);
+  }
+
+  protected SystemStore getMetaStore(String metaStoreName) {
+    ClientConfig clonedClientConfig = ClientConfig.cloneConfig(clientConfig).setStoreName(metaStoreName);
+    try (StoreStateReader storeStateReader = StoreStateReader.getInstance(clonedClientConfig)) {
+      Store metaStore = storeStateReader.getStore();
+      if (metaStore instanceof SystemStore) {
+        return (SystemStore) metaStore;
+      } else {
+        throw new VeniceException(
+            "Expecting a meta system store from StoreStateReader with name: " + metaStoreName
+                + " but got a non-system store instead");
+      }
+    }
+  }
+
+  @Override
+  protected SchemaData getSchemaDataFromSystemStore(String storeName) {
+    return getSchemaDataFromMetaSystemStore(storeName);
+  }
+
+  private DaVinciClient<StoreMetaKey, StoreMetaValue> getDaVinciClientForMetaStore(String storeName) {
+    return daVinciClientMap.computeIfAbsent(storeName, k -> {
+      long metaStoreDVCStartTime = System.currentTimeMillis();
+      DaVinciClient<StoreMetaKey, StoreMetaValue> client = daVinciClientFactory.getAndStartSpecificAvroClient(
+          VeniceSystemStoreType.META_STORE.getSystemStoreName(storeName),
+          daVinciConfig,
+          StoreMetaValue.class);
+      try {
+        client.subscribeAll().get();
+      } catch (InterruptedException | ExecutionException e) {
+        throw new VeniceException("Failed to construct DaVinci client for the meta store of store: " + storeName, e);
+      }
+      LOGGER.info(
+          "DaVinci client for the meta store of store: {} constructed, took: {} ms",
+          storeName,
+          System.currentTimeMillis() - metaStoreDVCStartTime);
+      return client;
+    });
+  }
+}

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/repository/NativeMetadataRepository.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/repository/NativeMetadataRepository.java
@@ -1,12 +1,15 @@
 package com.linkedin.davinci.repository;
 
 import static com.linkedin.venice.ConfigKeys.CLIENT_SYSTEM_STORE_REPOSITORY_REFRESH_INTERVAL_SECONDS;
+import static com.linkedin.venice.ConfigKeys.CLIENT_USE_DA_VINCI_BASED_SYSTEM_STORE_REPOSITORY;
 import static com.linkedin.venice.system.store.MetaStoreWriter.KEY_STRING_SCHEMA_ID;
 import static com.linkedin.venice.system.store.MetaStoreWriter.KEY_STRING_STORE_NAME;
 import static java.lang.Thread.currentThread;
 
+import com.linkedin.davinci.client.factory.CachingDaVinciClientFactory;
 import com.linkedin.venice.client.exceptions.ServiceDiscoveryException;
 import com.linkedin.venice.client.store.ClientConfig;
+import com.linkedin.venice.client.store.ClientFactory;
 import com.linkedin.venice.common.VeniceSystemStoreType;
 import com.linkedin.venice.exceptions.MissingKeyInStoreMetadataException;
 import com.linkedin.venice.exceptions.VeniceException;
@@ -23,7 +26,9 @@ import com.linkedin.venice.schema.SchemaData;
 import com.linkedin.venice.schema.SchemaEntry;
 import com.linkedin.venice.schema.rmd.RmdSchemaEntry;
 import com.linkedin.venice.schema.writecompute.DerivedSchemaEntry;
+import com.linkedin.venice.serialization.avro.AvroProtocolDefinition;
 import com.linkedin.venice.service.ICProvider;
+import com.linkedin.venice.stats.TehutiUtils;
 import com.linkedin.venice.system.store.MetaStoreDataType;
 import com.linkedin.venice.systemstore.schemas.StoreClusterConfig;
 import com.linkedin.venice.systemstore.schemas.StoreMetaKey;
@@ -36,6 +41,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.Executors;
@@ -116,11 +122,31 @@ public abstract class NativeMetadataRepository
       ClientConfig clientConfig,
       VeniceProperties backendConfig,
       ICProvider icProvider) {
-    LOGGER.info(
-        "Initializing {} with {}",
-        NativeMetadataRepository.class.getSimpleName(),
-        ThinClientMetaStoreBasedRepository.class.getSimpleName());
-    return new ThinClientMetaStoreBasedRepository(clientConfig, backendConfig, icProvider);
+    if (backendConfig.getBoolean(CLIENT_USE_DA_VINCI_BASED_SYSTEM_STORE_REPOSITORY, false)) {
+      LOGGER.info(
+          "Initializing {} with {}",
+          NativeMetadataRepository.class.getSimpleName(),
+          DaVinciClientMetaStoreBasedRepository.class.getSimpleName());
+      ClientConfig clonedClientConfig = ClientConfig.cloneConfig(clientConfig)
+          .setStoreName(AvroProtocolDefinition.METADATA_SYSTEM_SCHEMA_STORE.getSystemStoreName())
+          .setSpecificValueClass(StoreMetaValue.class);
+      return new DaVinciClientMetaStoreBasedRepository(
+          clientConfig,
+          backendConfig,
+          new CachingDaVinciClientFactory(
+              clientConfig.getD2Client(),
+              clientConfig.getD2ServiceName(),
+              Optional.ofNullable(clientConfig.getMetricsRepository())
+                  .orElse(TehutiUtils.getMetricsRepository("davinci-client")),
+              backendConfig),
+          ClientFactory.getSchemaReader(clonedClientConfig, null));
+    } else {
+      LOGGER.info(
+          "Initializing {} with {}",
+          NativeMetadataRepository.class.getSimpleName(),
+          ThinClientMetaStoreBasedRepository.class.getSimpleName());
+      return new ThinClientMetaStoreBasedRepository(clientConfig, backendConfig, icProvider);
+    }
   }
 
   @Override

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/repository/DaVinciClientMetaStoreBasedRepositoryTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/repository/DaVinciClientMetaStoreBasedRepositoryTest.java
@@ -140,6 +140,7 @@ public class DaVinciClientMetaStoreBasedRepositoryTest {
   public void testSubscribeAndRefresh() throws InterruptedException, ExecutionException {
     String storeName = "testStore";
     setupAndGetBasicMockMetaClient(storeName);
+    daVinciClientBasedRepository.start();
     daVinciClientBasedRepository.subscribe(storeName);
     Assert.assertNotNull(daVinciClientBasedRepository.getStore(storeName));
     Assert.assertEquals(

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/repository/DaVinciClientMetaStoreBasedRepositoryTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/repository/DaVinciClientMetaStoreBasedRepositoryTest.java
@@ -1,0 +1,188 @@
+package com.linkedin.davinci.repository;
+
+import static com.linkedin.venice.ConfigKeys.CLIENT_SYSTEM_STORE_REPOSITORY_REFRESH_INTERVAL_SECONDS;
+import static com.linkedin.venice.system.store.MetaStoreWriter.KEY_STRING_CLUSTER_NAME;
+import static com.linkedin.venice.system.store.MetaStoreWriter.KEY_STRING_SCHEMA_ID;
+import static com.linkedin.venice.system.store.MetaStoreWriter.KEY_STRING_STORE_NAME;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+
+import com.linkedin.davinci.client.DaVinciClient;
+import com.linkedin.davinci.client.factory.CachingDaVinciClientFactory;
+import com.linkedin.venice.client.store.ClientConfig;
+import com.linkedin.venice.common.VeniceSystemStoreType;
+import com.linkedin.venice.meta.SystemStore;
+import com.linkedin.venice.schema.SchemaReader;
+import com.linkedin.venice.system.store.MetaStoreDataType;
+import com.linkedin.venice.systemstore.schemas.StoreClusterConfig;
+import com.linkedin.venice.systemstore.schemas.StoreKeySchemas;
+import com.linkedin.venice.systemstore.schemas.StoreMetaKey;
+import com.linkedin.venice.systemstore.schemas.StoreMetaValue;
+import com.linkedin.venice.systemstore.schemas.StoreProperties;
+import com.linkedin.venice.systemstore.schemas.StoreValueSchema;
+import com.linkedin.venice.systemstore.schemas.StoreValueSchemas;
+import com.linkedin.venice.systemstore.schemas.StoreVersion;
+import com.linkedin.venice.utils.VeniceProperties;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import org.testng.Assert;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+
+public class DaVinciClientMetaStoreBasedRepositoryTest {
+  private DaVinciClientMetaStoreBasedRepository daVinciClientBasedRepository;
+  private ClientConfig clientConfig;
+  private VeniceProperties backendConfig;
+  private CachingDaVinciClientFactory daVinciClientFactory;
+  private SchemaReader metaStoreSchemaReader;
+  private String clusterName = "test-cluster";
+
+  @BeforeMethod
+  public void setupDaVinciBasedRepository() {
+    clientConfig = mock(ClientConfig.class);
+    backendConfig = mock(VeniceProperties.class);
+    doReturn(1L).when(backendConfig).getLong(eq(CLIENT_SYSTEM_STORE_REPOSITORY_REFRESH_INTERVAL_SECONDS), anyLong());
+    daVinciClientFactory = mock(CachingDaVinciClientFactory.class);
+    metaStoreSchemaReader = mock(SchemaReader.class);
+    daVinciClientBasedRepository = new DaVinciClientMetaStoreBasedRepository(
+        clientConfig,
+        backendConfig,
+        daVinciClientFactory,
+        metaStoreSchemaReader);
+  }
+
+  private DaVinciClient<StoreMetaKey, StoreMetaValue> setupAndGetBasicMockMetaClient(String storeName)
+      throws ExecutionException, InterruptedException {
+    DaVinciClient<StoreMetaKey, StoreMetaValue> metaDaVinciClient = mock(DaVinciClient.class);
+    doReturn(metaDaVinciClient).when(daVinciClientFactory)
+        .getAndStartSpecificAvroClient(
+            eq(VeniceSystemStoreType.META_STORE.getSystemStoreName(storeName)),
+            any(),
+            eq(StoreMetaValue.class));
+    // Store configs mocks
+    CompletableFuture<Void> future = mock(CompletableFuture.class);
+    doReturn(future).when(metaDaVinciClient).subscribeAll();
+    StoreMetaValue storeConfigValue = new StoreMetaValue();
+    storeConfigValue.setStoreClusterConfig(new StoreClusterConfig(clusterName, false, null, null, storeName));
+    CompletableFuture<StoreMetaValue> storeConfigFuture = mock(CompletableFuture.class);
+    doReturn(storeConfigValue).when(storeConfigFuture).get();
+    doReturn(storeConfigFuture).when(metaDaVinciClient)
+        .get(
+            MetaStoreDataType.STORE_CLUSTER_CONFIG
+                .getStoreMetaKey(Collections.singletonMap(KEY_STRING_STORE_NAME, storeName)));
+    // Store props mocks
+    CompletableFuture<StoreMetaValue> storePropFuture = mock(CompletableFuture.class);
+    StoreMetaValue storePropValue = new StoreMetaValue();
+    StoreProperties storeProperties = new StoreProperties();
+    storeProperties.setName(storeName);
+    StoreVersion storeVersion = new StoreVersion();
+    storeVersion.setStoreName(storeName);
+    storeVersion.setNumber(1);
+    storeVersion.setPushJobId("test-push");
+    storeVersion.setReplicationFactor(1);
+    storeVersion.setPartitionCount(1);
+    storeProperties.setVersions(Collections.singletonList(storeVersion));
+    storeProperties.setCurrentVersion(1);
+    storePropValue.setStoreProperties(storeProperties);
+    doReturn(storePropValue).when(storePropFuture).get();
+    doReturn(storePropFuture).when(metaDaVinciClient)
+        .get(MetaStoreDataType.STORE_PROPERTIES.getStoreMetaKey(new HashMap<String, String>() {
+          {
+            put(KEY_STRING_STORE_NAME, storeName);
+            put(KEY_STRING_CLUSTER_NAME, clusterName);
+          }
+        }));
+    // Store key schema mocks
+    CompletableFuture<StoreMetaValue> keySchemaFuture = mock(CompletableFuture.class);
+    StoreMetaValue keySchemaValue = new StoreMetaValue();
+    Map<CharSequence, CharSequence> keySchemaMap = new HashMap<>();
+    keySchemaMap.put("1", "\"string\"");
+    keySchemaValue.setStoreKeySchemas(new StoreKeySchemas(keySchemaMap));
+    doReturn(keySchemaValue).when(keySchemaFuture).get();
+    doReturn(keySchemaFuture).when(metaDaVinciClient)
+        .get(
+            MetaStoreDataType.STORE_KEY_SCHEMAS
+                .getStoreMetaKey(Collections.singletonMap(KEY_STRING_STORE_NAME, storeName)));
+    // Store value schema mocks
+    CompletableFuture<StoreMetaValue> valueSchemaFuture = mock(CompletableFuture.class);
+    StoreMetaValue valueSchemaValue = new StoreMetaValue();
+    Map<CharSequence, CharSequence> valueSchemaMap = new HashMap<>();
+    valueSchemaMap.put("1", "");
+    valueSchemaValue.setStoreValueSchemas(new StoreValueSchemas(valueSchemaMap));
+    doReturn(valueSchemaValue).when(valueSchemaFuture).get();
+    doReturn(valueSchemaFuture).when(metaDaVinciClient)
+        .get(
+            MetaStoreDataType.STORE_VALUE_SCHEMAS
+                .getStoreMetaKey(Collections.singletonMap(KEY_STRING_STORE_NAME, storeName)));
+    CompletableFuture<StoreMetaValue> indiValueSchemaFuture = mock(CompletableFuture.class);
+    StoreMetaValue indiSchemaValue = new StoreMetaValue();
+    indiSchemaValue.setStoreValueSchema(new StoreValueSchema("\"string\""));
+    doReturn(indiSchemaValue).when(indiValueSchemaFuture).get();
+    doReturn(indiValueSchemaFuture).when(metaDaVinciClient)
+        .get(MetaStoreDataType.STORE_VALUE_SCHEMA.getStoreMetaKey(new HashMap<String, String>() {
+          {
+            put(KEY_STRING_STORE_NAME, storeName);
+            put(KEY_STRING_SCHEMA_ID, "1");
+          }
+        }));
+    return metaDaVinciClient;
+  }
+
+  @Test
+  public void testSubscribeAndRefresh() throws InterruptedException, ExecutionException {
+    String storeName = "testStore";
+    setupAndGetBasicMockMetaClient(storeName);
+    daVinciClientBasedRepository.subscribe(storeName);
+    Assert.assertNotNull(daVinciClientBasedRepository.getStore(storeName));
+    Assert.assertEquals(
+        daVinciClientBasedRepository.getStore(storeName).getCurrentVersion(),
+        1,
+        "Unexpected current version");
+    Assert.assertEquals(
+        daVinciClientBasedRepository.getKeySchema(storeName).getSchemaStr(),
+        "\"string\"",
+        "Unexpected key schema string");
+    Assert.assertEquals(
+        daVinciClientBasedRepository.getValueSchema(storeName, 1).getSchemaStr(),
+        "\"string\"",
+        "Unexpected value schema string");
+    daVinciClientBasedRepository.refreshOneStore(storeName);
+    Assert.assertNotNull(daVinciClientBasedRepository.getStore(storeName));
+    Assert.assertEquals(
+        daVinciClientBasedRepository.getStore(storeName).getCurrentVersion(),
+        1,
+        "Unexpected current version");
+    Assert.assertEquals(
+        daVinciClientBasedRepository.getKeySchema(storeName).getSchemaStr(),
+        "\"string\"",
+        "Unexpected key schema string");
+    Assert.assertEquals(
+        daVinciClientBasedRepository.getValueSchema(storeName, 1).getSchemaStr(),
+        "\"string\"",
+        "Unexpected value schema string");
+  }
+
+  @Test
+  public void testSubscribeMetaStoreOnly() throws InterruptedException {
+    String storeName = "testStore";
+    String metaSystemStoreName = VeniceSystemStoreType.META_STORE.getSystemStoreName(storeName);
+    DaVinciClientMetaStoreBasedRepository repository = new DaVinciClientMetaStoreBasedRepository(
+        clientConfig,
+        backendConfig,
+        daVinciClientFactory,
+        metaStoreSchemaReader);
+    DaVinciClientMetaStoreBasedRepository spyRepository = spy(repository);
+    SystemStore systemStore = mock(SystemStore.class);
+    doReturn(systemStore).when(spyRepository).getMetaStore(metaSystemStoreName);
+    spyRepository.subscribe(metaSystemStoreName);
+    Assert.assertNotNull(spyRepository.getStore(metaSystemStoreName));
+  }
+}

--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/factory/ClientFactory.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/factory/ClientFactory.java
@@ -3,6 +3,7 @@ package com.linkedin.venice.fastclient.factory;
 import com.linkedin.venice.client.store.AvroGenericStoreClient;
 import com.linkedin.venice.client.store.AvroSpecificStoreClient;
 import com.linkedin.venice.client.store.transport.D2TransportClient;
+import com.linkedin.venice.exceptions.VeniceUnsupportedOperationException;
 import com.linkedin.venice.fastclient.ClientConfig;
 import com.linkedin.venice.fastclient.DispatchingAvroGenericStoreClient;
 import com.linkedin.venice.fastclient.DispatchingAvroSpecificStoreClient;
@@ -13,9 +14,11 @@ import com.linkedin.venice.fastclient.RetriableAvroGenericStoreClient;
 import com.linkedin.venice.fastclient.RetriableAvroSpecificStoreClient;
 import com.linkedin.venice.fastclient.StatsAvroGenericStoreClient;
 import com.linkedin.venice.fastclient.StatsAvroSpecificStoreClient;
+import com.linkedin.venice.fastclient.meta.DaVinciClientBasedMetadata;
 import com.linkedin.venice.fastclient.meta.RequestBasedMetadata;
 import com.linkedin.venice.fastclient.meta.StoreMetadata;
 import com.linkedin.venice.fastclient.meta.ThinClientBasedMetadata;
+import java.util.Objects;
 import org.apache.avro.specific.SpecificRecord;
 
 
@@ -27,14 +30,7 @@ public class ClientFactory {
 
   // Use Venice thin client based store metadata by default
   public static <K, V> AvroGenericStoreClient<K, V> getAndStartGenericStoreClient(ClientConfig clientConfig) {
-    StoreMetadata storeMetadata;
-    if (clientConfig.isRequestBasedMetadata()) {
-      storeMetadata = new RequestBasedMetadata(
-          clientConfig,
-          new D2TransportClient(clientConfig.getClusterDiscoveryD2Service(), clientConfig.getD2Client()));
-    } else {
-      storeMetadata = new ThinClientBasedMetadata(clientConfig, clientConfig.getThinClientForMetaStore());
-    }
+    StoreMetadata storeMetadata = constructStoreMetadataReader(clientConfig);
 
     return getAndStartGenericStoreClient(storeMetadata, clientConfig);
   }
@@ -44,19 +40,32 @@ public class ClientFactory {
       ClientConfig clientConfig) {
     /**
      * TODO:
-     * Need to construct {@link DaVinciClientBasedMetadata} inside store client, so that the store client could control
+     * Need to construct {@link StoreMetadata} inside store client, so that the store client could control
      * the lifecycle of the metadata instance.
      */
-    StoreMetadata storeMetadata;
-    if (clientConfig.isRequestBasedMetadata()) {
-      storeMetadata = new RequestBasedMetadata(
-          clientConfig,
-          new D2TransportClient(clientConfig.getClusterDiscoveryD2Service(), clientConfig.getD2Client()));
-    } else {
-      storeMetadata = new ThinClientBasedMetadata(clientConfig, clientConfig.getThinClientForMetaStore());
-    }
+    StoreMetadata storeMetadata = constructStoreMetadataReader(clientConfig);
 
     return getAndStartSpecificStoreClient(storeMetadata, clientConfig);
+  }
+
+  private static StoreMetadata constructStoreMetadataReader(ClientConfig clientConfig) {
+    switch (clientConfig.getStoreMetadataFetchMode()) {
+      case THIN_CLIENT_BASED_METADATA:
+        Objects.requireNonNull(clientConfig.getThinClientForMetaStore());
+        return new ThinClientBasedMetadata(clientConfig, clientConfig.getThinClientForMetaStore());
+      case SERVER_BASED_METADATA:
+        Objects.requireNonNull(clientConfig.getClusterDiscoveryD2Service());
+        Objects.requireNonNull(clientConfig.getD2Client());
+        return new RequestBasedMetadata(
+            clientConfig,
+            new D2TransportClient(clientConfig.getClusterDiscoveryD2Service(), clientConfig.getD2Client()));
+      case DA_VINCI_CLIENT_BASED_METADATA:
+        Objects.requireNonNull(clientConfig.getDaVinciClientForMetaStore());
+        return new DaVinciClientBasedMetadata(clientConfig, clientConfig.getDaVinciClientForMetaStore());
+      default:
+        throw new VeniceUnsupportedOperationException(
+            "Store metadata with " + clientConfig.getStoreMetadataFetchMode());
+    }
   }
 
   /**

--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/meta/StoreMetadataFetchMode.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/meta/StoreMetadataFetchMode.java
@@ -1,5 +1,23 @@
 package com.linkedin.venice.fastclient.meta;
 
+/**
+ * Modes that control how fast client will fetch store metadata
+ */
 public enum StoreMetadataFetchMode {
-  THIN_CLIENT_BASED_METADATA, DA_VINCI_CLIENT_BASED_METADATA, SERVER_BASED_METADATA
+  /**
+   * Use thin-client to query meta system store via routers
+   */
+  THIN_CLIENT_BASED_METADATA,
+
+  /**
+   * Use da-vinci-client to query the locally materialized meta system store.
+   * Note: Using da-vinci-client and fast-client with {@link DA_VINCI_CLIENT_BASED_METADATA} has a cyclic dependency
+   * issue, so only one of DaVinci or FC with DaVinci can be used.
+   */
+  DA_VINCI_CLIENT_BASED_METADATA,
+
+  /**
+   * Fast-client will make API calls to storage-nodes to get metadata information
+   */
+  SERVER_BASED_METADATA
 }

--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/meta/StoreMetadataFetchMode.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/meta/StoreMetadataFetchMode.java
@@ -1,0 +1,5 @@
+package com.linkedin.venice.fastclient.meta;
+
+public enum StoreMetadataFetchMode {
+  THIN_CLIENT_BASED_METADATA, DA_VINCI_CLIENT_BASED_METADATA, SERVER_BASED_METADATA
+}

--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/meta/VeniceClientBasedMetadata.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/meta/VeniceClientBasedMetadata.java
@@ -160,6 +160,8 @@ public abstract class VeniceClientBasedMetadata extends AbstractStoreMetadata {
         Thread.currentThread().interrupt();
       }
     }
+    // It might be helpful to add a random delay to offset the schema-refresh. However, this might be a premature
+    // optimization since given a large-enough fleet, the requests should get distributed inherently
     scheduler.scheduleAtFixedRate(this::refresh, refreshIntervalInSeconds, refreshIntervalInSeconds, TimeUnit.SECONDS);
   }
 

--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/meta/VeniceClientBasedMetadata.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/meta/VeniceClientBasedMetadata.java
@@ -160,7 +160,7 @@ public abstract class VeniceClientBasedMetadata extends AbstractStoreMetadata {
         Thread.currentThread().interrupt();
       }
     }
-    scheduler.scheduleAtFixedRate(this::refresh, 0, refreshIntervalInSeconds, TimeUnit.SECONDS);
+    scheduler.scheduleAtFixedRate(this::refresh, refreshIntervalInSeconds, refreshIntervalInSeconds, TimeUnit.SECONDS);
   }
 
   @Override

--- a/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/meta/VeniceClientBasedMetadataTest.java
+++ b/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/meta/VeniceClientBasedMetadataTest.java
@@ -200,15 +200,6 @@ public class VeniceClientBasedMetadataTest {
             }));
       }
     }
-    // doReturn(replicaStatusFuture).when(metaStoreThinClient)
-    // .get(MetaStoreDataType.STORE_REPLICA_STATUSES.getStoreMetaKey(new HashMap<String, String>() {
-    // {
-    // put(KEY_STRING_STORE_NAME, storeName);
-    // put(KEY_STRING_CLUSTER_NAME, CLUSTER_NAME);
-    // put(KEY_STRING_VERSION_NUMBER, Integer.toString(1));
-    // put(KEY_STRING_PARTITION_ID, Integer.toString(0));
-    // }
-    // }));
     return metaStoreThinClient;
   }
 }

--- a/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/meta/VeniceClientBasedMetadataTest.java
+++ b/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/meta/VeniceClientBasedMetadataTest.java
@@ -27,6 +27,7 @@ import com.linkedin.venice.systemstore.schemas.StoreValueSchema;
 import com.linkedin.venice.systemstore.schemas.StoreValueSchemas;
 import com.linkedin.venice.systemstore.schemas.StoreVersion;
 import io.tehuti.metrics.MetricsRepository;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -41,7 +42,8 @@ public class VeniceClientBasedMetadataTest {
   private static final String CLUSTER_NAME = "test-cluster";
   private static final String REPLICA_NAME = "host1";
   private static final String KEY_SCHEMA = "\"string\"";
-  private static final String VALUE_SCHEMA = "\"string\"";
+  private static final String VALUE_SCHEMA1 = "\"string\"";
+  private static final String VALUE_SCHEMA2 = "\"long\"";
 
   @Test
   public void testMetadata() throws ExecutionException, InterruptedException {
@@ -58,9 +60,10 @@ public class VeniceClientBasedMetadataTest {
     Assert.assertEquals(replicas.size(), 1);
     Assert.assertEquals(replicas.iterator().next(), REPLICA_NAME);
     Assert.assertEquals(veniceClientBasedMetadata.getKeySchema().toString(), KEY_SCHEMA);
-    Assert.assertEquals(veniceClientBasedMetadata.getValueSchema(1).toString(), VALUE_SCHEMA);
-    Assert.assertEquals(veniceClientBasedMetadata.getLatestValueSchemaId(), Integer.valueOf(1));
-    Assert.assertEquals(veniceClientBasedMetadata.getLatestValueSchema().toString(), VALUE_SCHEMA);
+    Assert.assertEquals(veniceClientBasedMetadata.getValueSchema(1).toString(), VALUE_SCHEMA1);
+    Assert.assertEquals(veniceClientBasedMetadata.getValueSchema(2).toString(), VALUE_SCHEMA2);
+    Assert.assertEquals(veniceClientBasedMetadata.getLatestValueSchemaId(), Integer.valueOf(2));
+    Assert.assertEquals(veniceClientBasedMetadata.getLatestValueSchema().toString(), VALUE_SCHEMA2);
   }
 
   private ClientConfig getBasicMockClientConfig(String storeName) {
@@ -88,19 +91,31 @@ public class VeniceClientBasedMetadataTest {
     StoreMetaValue storePropValue = new StoreMetaValue();
     StoreProperties storeProperties = new StoreProperties();
     storeProperties.setName(storeName);
-    StoreVersion storeVersion = new StoreVersion();
-    storeVersion.setStoreName(storeName);
-    storeVersion.setNumber(1);
-    storeVersion.setPushJobId("test-push");
-    storeVersion.setReplicationFactor(1);
-    storeVersion.setPartitionCount(1);
+
     StorePartitionerConfig storePartitionerConfig = new StorePartitionerConfig();
     storePartitionerConfig.setPartitionerClass(DefaultVenicePartitioner.class.getName());
     storePartitionerConfig.setAmplificationFactor(1);
     storePartitionerConfig.setPartitionerParams(Collections.emptyMap());
-    storeVersion.setPartitionerConfig(storePartitionerConfig);
-    storeVersion.setCompressionStrategy(CompressionStrategy.NO_OP.getValue());
-    storeProperties.setVersions(Collections.singletonList(storeVersion));
+
+    StoreVersion storeVersion1 = new StoreVersion();
+    storeVersion1.setStoreName(storeName);
+    storeVersion1.setNumber(1);
+    storeVersion1.setPushJobId("test-push-1");
+    storeVersion1.setReplicationFactor(1);
+    storeVersion1.setPartitionCount(100);
+    storeVersion1.setPartitionerConfig(storePartitionerConfig);
+    storeVersion1.setCompressionStrategy(CompressionStrategy.NO_OP.getValue());
+
+    StoreVersion storeVersion2 = new StoreVersion();
+    storeVersion2.setStoreName(storeName);
+    storeVersion2.setNumber(2);
+    storeVersion2.setPushJobId("test-push-2");
+    storeVersion2.setReplicationFactor(1);
+    storeVersion2.setPartitionCount(100);
+    storeVersion2.setPartitionerConfig(storePartitionerConfig);
+    storeVersion2.setCompressionStrategy(CompressionStrategy.NO_OP.getValue());
+
+    storeProperties.setVersions(Arrays.asList(storeVersion1, storeVersion2));
     storeProperties.setCurrentVersion(1);
     storeProperties.setLatestSuperSetValueSchemaId(SchemaData.INVALID_VALUE_SCHEMA_ID);
     storePropValue.setStoreProperties(storeProperties);
@@ -128,6 +143,7 @@ public class VeniceClientBasedMetadataTest {
     StoreMetaValue valueSchemaValue = new StoreMetaValue();
     Map<CharSequence, CharSequence> valueSchemaMap = new HashMap<>();
     valueSchemaMap.put("1", "");
+    valueSchemaMap.put("2", "");
     valueSchemaValue.setStoreValueSchemas(new StoreValueSchemas(valueSchemaMap));
     doReturn(valueSchemaValue).when(valueSchemaFuture).get();
     doReturn(valueSchemaFuture).when(metaStoreThinClient)
@@ -136,7 +152,7 @@ public class VeniceClientBasedMetadataTest {
                 .getStoreMetaKey(Collections.singletonMap(KEY_STRING_STORE_NAME, storeName)));
     CompletableFuture<StoreMetaValue> indiValueSchemaFuture = mock(CompletableFuture.class);
     StoreMetaValue indiSchemaValue = new StoreMetaValue();
-    indiSchemaValue.setStoreValueSchema(new StoreValueSchema(VALUE_SCHEMA));
+    indiSchemaValue.setStoreValueSchema(new StoreValueSchema(VALUE_SCHEMA1));
     doReturn(indiSchemaValue).when(indiValueSchemaFuture).get();
     doReturn(indiValueSchemaFuture).when(metaStoreThinClient)
         .get(MetaStoreDataType.STORE_VALUE_SCHEMA.getStoreMetaKey(new HashMap<String, String>() {
@@ -145,24 +161,54 @@ public class VeniceClientBasedMetadataTest {
             put(KEY_STRING_SCHEMA_ID, "1");
           }
         }));
-    // Ready to serve replica mocks
-    CompletableFuture<StoreMetaValue> replicaStatusFuture = mock(CompletableFuture.class);
-    StoreMetaValue replicaStatusValue = new StoreMetaValue();
-    Map<CharSequence, StoreReplicaStatus> replicaStatusMap = new HashMap<>();
-    StoreReplicaStatus storeReplicaStatus = new StoreReplicaStatus();
-    storeReplicaStatus.setStatus(COMPLETED.getValue());
-    replicaStatusMap.put(REPLICA_NAME, storeReplicaStatus);
-    replicaStatusValue.setStoreReplicaStatuses(replicaStatusMap);
-    doReturn(replicaStatusValue).when(replicaStatusFuture).get();
-    doReturn(replicaStatusFuture).when(metaStoreThinClient)
-        .get(MetaStoreDataType.STORE_REPLICA_STATUSES.getStoreMetaKey(new HashMap<String, String>() {
+
+    CompletableFuture<StoreMetaValue> indiValueSchemaFuture2 = mock(CompletableFuture.class);
+    StoreMetaValue indiSchemaValue2 = new StoreMetaValue();
+    indiSchemaValue2.setStoreValueSchema(new StoreValueSchema(VALUE_SCHEMA2));
+    doReturn(indiSchemaValue2).when(indiValueSchemaFuture2).get();
+    doReturn(indiValueSchemaFuture2).when(metaStoreThinClient)
+        .get(MetaStoreDataType.STORE_VALUE_SCHEMA.getStoreMetaKey(new HashMap<String, String>() {
           {
             put(KEY_STRING_STORE_NAME, storeName);
-            put(KEY_STRING_CLUSTER_NAME, CLUSTER_NAME);
-            put(KEY_STRING_VERSION_NUMBER, Integer.toString(1));
-            put(KEY_STRING_PARTITION_ID, Integer.toString(0));
+            put(KEY_STRING_SCHEMA_ID, "2");
           }
         }));
+
+    // Ready to serve replica mocks
+    for (int version = 1; version <= 2; version++) {
+      for (int partition = 0; partition < 100; partition++) {
+        int finalPartition = partition;
+        int finalVersion = version;
+
+        CompletableFuture<StoreMetaValue> replicaStatusFuture = mock(CompletableFuture.class);
+        StoreMetaValue replicaStatusValue = new StoreMetaValue();
+        Map<CharSequence, StoreReplicaStatus> replicaStatusMap = new HashMap<>();
+        StoreReplicaStatus storeReplicaStatus = new StoreReplicaStatus();
+        storeReplicaStatus.setStatus(COMPLETED.getValue());
+        replicaStatusMap.put(REPLICA_NAME, storeReplicaStatus);
+        replicaStatusValue.setStoreReplicaStatuses(replicaStatusMap);
+        doReturn(replicaStatusValue).when(replicaStatusFuture).get();
+
+        doReturn(replicaStatusFuture).when(metaStoreThinClient)
+            .get(MetaStoreDataType.STORE_REPLICA_STATUSES.getStoreMetaKey(new HashMap<String, String>() {
+              {
+                put(KEY_STRING_STORE_NAME, storeName);
+                put(KEY_STRING_CLUSTER_NAME, CLUSTER_NAME);
+                put(KEY_STRING_VERSION_NUMBER, Integer.toString(finalVersion));
+                put(KEY_STRING_PARTITION_ID, Integer.toString(finalPartition));
+              }
+            }));
+      }
+    }
+    // doReturn(replicaStatusFuture).when(metaStoreThinClient)
+    // .get(MetaStoreDataType.STORE_REPLICA_STATUSES.getStoreMetaKey(new HashMap<String, String>() {
+    // {
+    // put(KEY_STRING_STORE_NAME, storeName);
+    // put(KEY_STRING_CLUSTER_NAME, CLUSTER_NAME);
+    // put(KEY_STRING_VERSION_NUMBER, Integer.toString(1));
+    // put(KEY_STRING_PARTITION_ID, Integer.toString(0));
+    // }
+    // }));
     return metaStoreThinClient;
   }
 }

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/fastclient/AvroStoreClientEndToEndTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/fastclient/AvroStoreClientEndToEndTest.java
@@ -1,7 +1,5 @@
 package com.linkedin.venice.fastclient;
 
-import static com.linkedin.venice.fastclient.utils.ClientTestUtils.FASTCLIENT_HTTP_VARIANTS;
-import static com.linkedin.venice.fastclient.utils.ClientTestUtils.STORE_METADATA_FETCH_MODES;
 import static org.testng.Assert.assertTrue;
 import static org.testng.AssertJUnit.assertEquals;
 
@@ -15,7 +13,6 @@ import com.linkedin.venice.fastclient.schema.TestValueSchema;
 import com.linkedin.venice.fastclient.utils.AbstractClientEndToEndSetup;
 import com.linkedin.venice.fastclient.utils.ClientTestUtils;
 import com.linkedin.venice.integration.utils.VeniceServerWrapper;
-import com.linkedin.venice.utils.DataProviderUtils;
 import io.tehuti.metrics.MetricsRepository;
 import java.util.HashSet;
 import java.util.Map;
@@ -24,7 +21,6 @@ import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.function.Consumer;
 import org.apache.avro.generic.GenericRecord;
-import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 
@@ -40,11 +36,6 @@ import org.testng.annotations.Test;
  */
 
 public class AvroStoreClientEndToEndTest extends AbstractClientEndToEndSetup {
-  @DataProvider(name = "fastClientHTTPVariantsAndStoreSchemaFetchModes")
-  public static Object[][] httpVariantsAndStoreSchemaFetchModes() {
-    return DataProviderUtils.allPermutationGenerator(FASTCLIENT_HTTP_VARIANTS, STORE_METADATA_FETCH_MODES);
-  }
-
   protected void runTest(
       ClientConfig.ClientConfigBuilder clientConfigBuilder,
       boolean batchGet,
@@ -227,7 +218,7 @@ public class AvroStoreClientEndToEndTest extends AbstractClientEndToEndSetup {
     }
   }
 
-  @Test(dataProvider = "FastClient-Four-Boolean-And-A-Number", timeOut = TIME_OUT)
+  @Test(dataProvider = "FastClient-Three-Boolean-Store-Metadata-Fetch-Mode-A-Number", timeOut = TIME_OUT)
   public void testFastClientGet(
       boolean multiGet,
       boolean dualRead,
@@ -347,7 +338,7 @@ public class AvroStoreClientEndToEndTest extends AbstractClientEndToEndSetup {
     }
   }
 
-  @Test(dataProvider = "fastClientHTTPVariantsAndStoreSchemaFetchModes", timeOut = TIME_OUT)
+  @Test(dataProvider = "fastClientHTTPVariantsAndStoreMetadataFetchModes", timeOut = TIME_OUT)
   public void testFastClientGetWithDifferentHTTPVariants(
       ClientTestUtils.FastClientHTTPVariant fastClientHTTPVariant,
       StoreMetadataFetchMode storeMetadataFetchMode) throws Exception {
@@ -364,7 +355,7 @@ public class AvroStoreClientEndToEndTest extends AbstractClientEndToEndSetup {
 
   // TODO This test fails for the first time and then succeeds when the entire fastclient
   // testsuite is run, but runs successfully when this test is run alone. Need to debug.
-  @Test(dataProvider = "True-and-False", dataProviderClass = DataProviderUtils.class)
+  @Test(dataProvider = "StoreMetadataFetchModes")
   public void testFastClientSingleGetLongTailRetry(StoreMetadataFetchMode storeMetadataFetchMode) throws Exception {
     ClientConfig.ClientConfigBuilder clientConfigBuilder =
         new ClientConfig.ClientConfigBuilder<>().setStoreName(storeName)

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/fastclient/BatchGetAvroStoreClientTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/fastclient/BatchGetAvroStoreClientTest.java
@@ -1,7 +1,5 @@
 package com.linkedin.venice.fastclient;
 
-import static com.linkedin.venice.fastclient.utils.ClientTestUtils.STORE_METADATA_FETCH_MODES;
-
 import com.linkedin.venice.client.store.AvroGenericStoreClient;
 import com.linkedin.venice.client.store.AvroSpecificStoreClient;
 import com.linkedin.venice.client.store.streaming.StreamingCallback;
@@ -11,7 +9,6 @@ import com.linkedin.venice.fastclient.schema.TestValueSchema;
 import com.linkedin.venice.fastclient.stats.FastClientStats;
 import com.linkedin.venice.fastclient.utils.AbstractClientEndToEndSetup;
 import com.linkedin.venice.read.RequestType;
-import com.linkedin.venice.utils.DataProviderUtils;
 import io.tehuti.Metric;
 import io.tehuti.metrics.MetricsRepository;
 import java.util.ArrayList;
@@ -32,7 +29,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.testng.Assert;
-import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 
@@ -43,11 +39,6 @@ import org.testng.annotations.Test;
  * Da Vinci metadata. Do we need to test with that? What is the use case when we use da vinci metadata
  */
 public class BatchGetAvroStoreClientTest extends AbstractClientEndToEndSetup {
-  @DataProvider(name = "StoreMetadataFetchModes")
-  public static Object[][] storeMetadataFetchModes() {
-    return DataProviderUtils.allPermutationGenerator(STORE_METADATA_FETCH_MODES);
-  }
-
   // Every test will print all stats if set to true. Should only be used locally
   private static boolean PRINT_STATS = false;
   private static final Logger LOGGER = LogManager.getLogger(BatchGetAvroStoreClientTest.class);

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/fastclient/FastClientDaVinciClientCompatTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/fastclient/FastClientDaVinciClientCompatTest.java
@@ -10,6 +10,7 @@ import com.linkedin.davinci.client.DaVinciClient;
 import com.linkedin.davinci.client.DaVinciConfig;
 import com.linkedin.davinci.client.factory.CachingDaVinciClientFactory;
 import com.linkedin.venice.client.store.AvroSpecificStoreClient;
+import com.linkedin.venice.fastclient.meta.StoreMetadataFetchMode;
 import com.linkedin.venice.fastclient.schema.TestValueSchema;
 import com.linkedin.venice.fastclient.utils.AbstractClientEndToEndSetup;
 import com.linkedin.venice.integration.utils.VeniceRouterWrapper;
@@ -35,8 +36,11 @@ public class FastClientDaVinciClientCompatTest extends AbstractClientEndToEndSet
             .setLongTailRetryEnabledForSingleGet(true)
             .setLongTailRetryThresholdForSingleGetInMicroSeconds(10);
 
-    AvroSpecificStoreClient<String, TestValueSchema> fastClient =
-        getSpecificFastClient(clientConfigBuilder, new MetricsRepository(), TestValueSchema.class, false);
+    AvroSpecificStoreClient<String, TestValueSchema> fastClient = getSpecificFastClient(
+        clientConfigBuilder,
+        new MetricsRepository(),
+        TestValueSchema.class,
+        StoreMetadataFetchMode.THIN_CLIENT_BASED_METADATA);
     Assert.assertNotNull(fastClient.get("key_1").get());
     try (DaVinciClient<String, TestValueSchema> daVinciClient = setupDaVinciClient(storeName)) {
       daVinciClient.subscribeAll().get();
@@ -61,11 +65,17 @@ public class FastClientDaVinciClientCompatTest extends AbstractClientEndToEndSet
     try (DaVinciClient<String, TestValueSchema> daVinciClient = setupDaVinciClient(storeName)) {
       daVinciClient.subscribeAll().get();
       Assert.assertNotNull(daVinciClient.get("key_1").get());
-      AvroSpecificStoreClient<String, TestValueSchema> fastClient =
-          getSpecificFastClient(clientConfigBuilder, new MetricsRepository(), TestValueSchema.class, false);
+      AvroSpecificStoreClient<String, TestValueSchema> fastClient = getSpecificFastClient(
+          clientConfigBuilder,
+          new MetricsRepository(),
+          TestValueSchema.class,
+          StoreMetadataFetchMode.THIN_CLIENT_BASED_METADATA);
       Assert.assertNotNull(fastClient.get("key_1").get());
-      AvroSpecificStoreClient<String, TestValueSchema> fastClient2 =
-          getSpecificFastClient(clientConfigBuilder, new MetricsRepository(), TestValueSchema.class, false);
+      AvroSpecificStoreClient<String, TestValueSchema> fastClient2 = getSpecificFastClient(
+          clientConfigBuilder,
+          new MetricsRepository(),
+          TestValueSchema.class,
+          StoreMetadataFetchMode.THIN_CLIENT_BASED_METADATA);
       Assert.assertNotNull(fastClient2.get("key_1").get());
     }
   }

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/fastclient/FastClientServerReadQuotaTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/fastclient/FastClientServerReadQuotaTest.java
@@ -4,6 +4,7 @@ import static org.testng.AssertJUnit.assertEquals;
 
 import com.linkedin.venice.client.store.AvroGenericStoreClient;
 import com.linkedin.venice.controllerapi.UpdateStoreQueryParams;
+import com.linkedin.venice.fastclient.meta.StoreMetadataFetchMode;
 import com.linkedin.venice.fastclient.utils.AbstractClientEndToEndSetup;
 import com.linkedin.venice.utils.TestUtils;
 import io.tehuti.metrics.MetricsRepository;
@@ -20,8 +21,10 @@ public class FastClientServerReadQuotaTest extends AbstractClientEndToEndSetup {
         new ClientConfig.ClientConfigBuilder<>().setStoreName(storeName)
             .setR2Client(r2Client)
             .setSpeculativeQueryEnabled(false);
-    AvroGenericStoreClient<String, GenericRecord> genericFastClient =
-        getGenericFastClient(clientConfigBuilder, new MetricsRepository(), true);
+    AvroGenericStoreClient<String, GenericRecord> genericFastClient = getGenericFastClient(
+        clientConfigBuilder,
+        new MetricsRepository(),
+        StoreMetadataFetchMode.SERVER_BASED_METADATA);
     // Update the read quota to 1000 and make 500 requests, all requests should be allowed.
     veniceCluster.useControllerClient(controllerClient -> {
       TestUtils

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/fastclient/utils/AbstractClientEndToEndSetup.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/fastclient/utils/AbstractClientEndToEndSetup.java
@@ -6,6 +6,8 @@ import static com.linkedin.venice.ConfigKeys.DATA_BASE_PATH;
 import static com.linkedin.venice.ConfigKeys.PERSISTENCE_TYPE;
 import static com.linkedin.venice.ConfigKeys.SERVER_HTTP2_INBOUND_ENABLED;
 import static com.linkedin.venice.ConfigKeys.SERVER_QUOTA_ENFORCEMENT_ENABLED;
+import static com.linkedin.venice.fastclient.utils.ClientTestUtils.FASTCLIENT_HTTP_VARIANTS;
+import static com.linkedin.venice.fastclient.utils.ClientTestUtils.STORE_METADATA_FETCH_MODES;
 import static com.linkedin.venice.meta.PersistenceType.ROCKS_DB;
 import static com.linkedin.venice.system.store.MetaStoreWriter.KEY_STRING_CLUSTER_NAME;
 import static com.linkedin.venice.system.store.MetaStoreWriter.KEY_STRING_PARTITION_ID;
@@ -114,13 +116,13 @@ public abstract class AbstractClientEndToEndSetup {
    */
   public final Object[] BATCH_GET_KEY_SIZE = { 2, recordCnt };
 
-  @DataProvider(name = "FastClient-Four-Boolean-And-A-Number")
+  @DataProvider(name = "FastClient-Three-Boolean-Store-Metadata-Fetch-Mode-A-Number")
   public Object[][] fourBooleanAndANumber() {
     return DataProviderUtils.allPermutationGenerator(
         DataProviderUtils.BOOLEAN,
         DataProviderUtils.BOOLEAN,
         DataProviderUtils.BOOLEAN,
-        DataProviderUtils.BOOLEAN,
+        STORE_METADATA_FETCH_MODES,
         BATCH_GET_KEY_SIZE);
   }
 
@@ -131,6 +133,16 @@ public abstract class AbstractClientEndToEndSetup {
         DataProviderUtils.BOOLEAN,
         DataProviderUtils.BOOLEAN,
         BATCH_GET_KEY_SIZE);
+  }
+
+  @DataProvider(name = "fastClientHTTPVariantsAndStoreMetadataFetchModes")
+  public static Object[][] httpVariantsAndStoreMetadataFetchModes() {
+    return DataProviderUtils.allPermutationGenerator(FASTCLIENT_HTTP_VARIANTS, STORE_METADATA_FETCH_MODES);
+  }
+
+  @DataProvider(name = "StoreMetadataFetchModes")
+  public static Object[][] storeMetadataFetchModes() {
+    return DataProviderUtils.allPermutationGenerator(STORE_METADATA_FETCH_MODES);
   }
 
   @BeforeClass(alwaysRun = true)

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/fastclient/utils/AbstractClientEndToEndSetup.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/fastclient/utils/AbstractClientEndToEndSetup.java
@@ -1,7 +1,12 @@
 package com.linkedin.venice.fastclient.utils;
 
+import static com.linkedin.venice.ConfigKeys.CLIENT_USE_DA_VINCI_BASED_SYSTEM_STORE_REPOSITORY;
+import static com.linkedin.venice.ConfigKeys.CLIENT_USE_SYSTEM_STORE_REPOSITORY;
+import static com.linkedin.venice.ConfigKeys.DATA_BASE_PATH;
+import static com.linkedin.venice.ConfigKeys.PERSISTENCE_TYPE;
 import static com.linkedin.venice.ConfigKeys.SERVER_HTTP2_INBOUND_ENABLED;
 import static com.linkedin.venice.ConfigKeys.SERVER_QUOTA_ENFORCEMENT_ENABLED;
+import static com.linkedin.venice.meta.PersistenceType.ROCKS_DB;
 import static com.linkedin.venice.system.store.MetaStoreWriter.KEY_STRING_CLUSTER_NAME;
 import static com.linkedin.venice.system.store.MetaStoreWriter.KEY_STRING_PARTITION_ID;
 import static com.linkedin.venice.system.store.MetaStoreWriter.KEY_STRING_STORE_NAME;
@@ -10,6 +15,9 @@ import static org.testng.Assert.assertFalse;
 import static org.testng.AssertJUnit.assertNotNull;
 
 import com.linkedin.d2.balancer.D2Client;
+import com.linkedin.davinci.client.DaVinciClient;
+import com.linkedin.davinci.client.DaVinciConfig;
+import com.linkedin.davinci.client.factory.CachingDaVinciClientFactory;
 import com.linkedin.r2.transport.common.Client;
 import com.linkedin.venice.D2.D2ClientUtils;
 import com.linkedin.venice.client.store.AvroGenericStoreClient;
@@ -19,6 +27,7 @@ import com.linkedin.venice.controllerapi.ControllerClient;
 import com.linkedin.venice.controllerapi.VersionCreationResponse;
 import com.linkedin.venice.fastclient.ClientConfig;
 import com.linkedin.venice.fastclient.factory.ClientFactory;
+import com.linkedin.venice.fastclient.meta.StoreMetadataFetchMode;
 import com.linkedin.venice.fastclient.schema.TestValueSchema;
 import com.linkedin.venice.helix.HelixReadOnlySchemaRepository;
 import com.linkedin.venice.integration.utils.D2TestUtils;
@@ -33,10 +42,12 @@ import com.linkedin.venice.system.store.MetaStoreDataType;
 import com.linkedin.venice.systemstore.schemas.StoreMetaKey;
 import com.linkedin.venice.systemstore.schemas.StoreMetaValue;
 import com.linkedin.venice.utils.DataProviderUtils;
+import com.linkedin.venice.utils.PropertyBuilder;
 import com.linkedin.venice.utils.SslUtils;
 import com.linkedin.venice.utils.TestUtils;
 import com.linkedin.venice.utils.Time;
 import com.linkedin.venice.utils.Utils;
+import com.linkedin.venice.utils.VeniceProperties;
 import com.linkedin.venice.writer.VeniceWriter;
 import com.linkedin.venice.writer.VeniceWriterOptions;
 import io.tehuti.metrics.MetricsRepository;
@@ -68,6 +79,12 @@ public abstract class AbstractClientEndToEndSetup {
   private VeniceWriter<Object, Object, Object> veniceWriter;
   protected Client r2Client;
   protected D2Client d2Client;
+
+  // da-vinci client for the da-vinci client based metadata
+  private VeniceProperties daVinciBackendConfig;
+  CachingDaVinciClientFactory daVinciClientFactory = null;
+  protected DaVinciClient<StoreMetaKey, StoreMetaValue> daVinciClientForMetaStore = null;
+
   // thin client for the thin client based metadata
   protected AvroSpecificStoreClient<StoreMetaKey, StoreMetaValue> thinClientForMetaStore = null;
 
@@ -195,6 +212,12 @@ public abstract class AbstractClientEndToEndSetup {
           TimeUnit.SECONDS);
     });
 
+    daVinciBackendConfig = new PropertyBuilder().put(DATA_BASE_PATH, Utils.getTempDataDirectory().getAbsolutePath())
+        .put(PERSISTENCE_TYPE, ROCKS_DB)
+        .put(CLIENT_USE_SYSTEM_STORE_REPOSITORY, true)
+        .put(CLIENT_USE_DA_VINCI_BASED_SYSTEM_STORE_REPOSITORY, true)
+        .build();
+
     // Verify meta system store received the snapshot writes.
     try (AvroSpecificStoreClient<StoreMetaKey, StoreMetaValue> metaClient =
         com.linkedin.venice.client.store.ClientFactory.getAndStartSpecificAvroClient(
@@ -241,9 +264,9 @@ public abstract class AbstractClientEndToEndSetup {
       ClientConfig.ClientConfigBuilder clientConfigBuilder,
       MetricsRepository metricsRepository,
       Optional<AvroGenericStoreClient> vsonThinClient,
-      boolean useRequestBasedMetadata) throws IOException {
+      StoreMetadataFetchMode storeMetadataFetchMode) throws IOException {
     clientConfigBuilder.setVsonStore(true);
-    setupStoreMetadata(clientConfigBuilder, useRequestBasedMetadata);
+    setupStoreMetadata(clientConfigBuilder, storeMetadataFetchMode);
 
     // clientConfigBuilder will be used for building multiple clients over this test flow,
     // so, always specify a new MetricsRepository to avoid conflicts.
@@ -262,8 +285,8 @@ public abstract class AbstractClientEndToEndSetup {
   protected AvroGenericStoreClient<String, GenericRecord> getGenericFastClient(
       ClientConfig.ClientConfigBuilder clientConfigBuilder,
       MetricsRepository metricsRepository,
-      boolean useRequestBasedMetadata) throws IOException {
-    setupStoreMetadata(clientConfigBuilder, useRequestBasedMetadata);
+      StoreMetadataFetchMode storeMetadataFetchMode) throws IOException {
+    setupStoreMetadata(clientConfigBuilder, storeMetadataFetchMode);
 
     // clientConfigBuilder will be used for building multiple clients over this test flow,
     // so, always specify a new MetricsRepository to avoid conflicts.
@@ -278,8 +301,8 @@ public abstract class AbstractClientEndToEndSetup {
       ClientConfig.ClientConfigBuilder clientConfigBuilder,
       MetricsRepository metricsRepository,
       Class specificValueClass,
-      boolean useRequestBasedMetadata) throws IOException {
-    setupStoreMetadata(clientConfigBuilder, useRequestBasedMetadata);
+      StoreMetadataFetchMode storeMetadataFetchMode) throws IOException {
+    setupStoreMetadata(clientConfigBuilder, storeMetadataFetchMode);
 
     // clientConfigBuilder will be used for building multiple clients over this test flow,
     // so, always specify a new MetricsRepository to avoid conflicts.
@@ -293,15 +316,21 @@ public abstract class AbstractClientEndToEndSetup {
 
   protected void setupStoreMetadata(
       ClientConfig.ClientConfigBuilder clientConfigBuilder,
-      boolean useRequestBasedMetadata) throws IOException {
-    if (useRequestBasedMetadata) {
-      clientConfigBuilder.setRequestBasedMetadata(true);
-      clientConfigBuilder.setD2Client(d2Client);
-      clientConfigBuilder.setClusterDiscoveryD2Service(VeniceRouterWrapper.CLUSTER_DISCOVERY_D2_SERVICE_NAME);
-      clientConfigBuilder.setMetadataRefreshIntervalInSeconds(1);
-    } else {
-      setupThinClientBasedStoreMetadata();
-      clientConfigBuilder.setThinClientForMetaStore(thinClientForMetaStore);
+      StoreMetadataFetchMode storeMetadataFetchMode) throws IOException {
+    clientConfigBuilder.setStoreMetadataFetchMode(storeMetadataFetchMode);
+    switch (storeMetadataFetchMode) {
+      case SERVER_BASED_METADATA:
+        clientConfigBuilder.setD2Client(d2Client);
+        clientConfigBuilder.setClusterDiscoveryD2Service(VeniceRouterWrapper.CLUSTER_DISCOVERY_D2_SERVICE_NAME);
+        clientConfigBuilder.setMetadataRefreshIntervalInSeconds(1);
+        break;
+      case THIN_CLIENT_BASED_METADATA:
+        setupThinClientBasedStoreMetadata();
+        clientConfigBuilder.setThinClientForMetaStore(thinClientForMetaStore);
+        break;
+      case DA_VINCI_CLIENT_BASED_METADATA:
+        setupDaVinciClientForMetaStore();
+        clientConfigBuilder.setDaVinciClientForMetaStore(daVinciClientForMetaStore);
     }
   }
 
@@ -314,6 +343,38 @@ public abstract class AbstractClientEndToEndSetup {
                   StoreMetaValue.class)
               .setVeniceURL(veniceCluster.getRandomRouterURL())
               .setSslFactory(SslUtils.getVeniceLocalSslFactory()));
+    }
+  }
+
+  private void setupDaVinciClientForMetaStore() {
+    cleanupDaVinciClientForMetaStore();
+    daVinciClientFactory = new CachingDaVinciClientFactory(
+        d2Client,
+        VeniceRouterWrapper.CLUSTER_DISCOVERY_D2_SERVICE_NAME,
+        new MetricsRepository(),
+        daVinciBackendConfig);
+    daVinciClientForMetaStore = daVinciClientFactory.getAndStartSpecificAvroClient(
+        VeniceSystemStoreType.META_STORE.getSystemStoreName(storeName),
+        new DaVinciConfig(),
+        StoreMetaValue.class);
+  }
+
+  // Helper for runTest()
+  /**
+   * Note that both daVinciClientBasedStoreMetadata and routerBasedStoreMetaData
+   * will be closed when the respective client closes. The below function
+   * needs to clean up the daVinciClient and its client factory alone.
+   *
+   * TODO: Explore to see if we can reuse these for all the tests rather than cleaning it up everytime.
+   * */
+  protected void cleanupDaVinciClientForMetaStore() {
+    if (daVinciClientForMetaStore != null) {
+      daVinciClientForMetaStore.close();
+      daVinciClientForMetaStore = null;
+    }
+    if (daVinciClientFactory != null) {
+      daVinciClientFactory.close();
+      daVinciClientFactory = null;
     }
   }
 

--- a/internal/venice-test-common/src/main/java/com/linkedin/venice/fastclient/utils/ClientTestUtils.java
+++ b/internal/venice-test-common/src/main/java/com/linkedin/venice/fastclient/utils/ClientTestUtils.java
@@ -6,13 +6,12 @@ import com.linkedin.r2.transport.common.bridge.client.TransportClientAdapter;
 import com.linkedin.r2.transport.http.client.HttpClientFactory;
 import com.linkedin.r2.transport.http.common.HttpProtocolVersion;
 import com.linkedin.venice.exceptions.VeniceException;
+import com.linkedin.venice.fastclient.meta.StoreMetadataFetchMode;
 import com.linkedin.venice.fastclient.transport.HttpClient5BasedR2Client;
 import com.linkedin.venice.security.SSLFactory;
-import com.linkedin.venice.utils.DataProviderUtils;
 import com.linkedin.venice.utils.SslUtils;
 import java.util.HashMap;
 import java.util.Map;
-import org.testng.annotations.DataProvider;
 
 
 public class ClientTestUtils {
@@ -23,10 +22,8 @@ public class ClientTestUtils {
   public static final Object[] FASTCLIENT_HTTP_VARIANTS = { FastClientHTTPVariant.HTTP_1_1_BASED_R2_CLIENT,
       FastClientHTTPVariant.HTTP_2_BASED_R2_CLIENT, FastClientHTTPVariant.HTTP_2_BASED_HTTPCLIENT5 };
 
-  @DataProvider(name = "fastClientHTTPVariantsAndBoolean")
-  public static Object[][] httpVersionsAndBoolean() {
-    return DataProviderUtils.allPermutationGenerator(FASTCLIENT_HTTP_VARIANTS, DataProviderUtils.BOOLEAN);
-  }
+  public static final Object[] STORE_METADATA_FETCH_MODES = { StoreMetadataFetchMode.THIN_CLIENT_BASED_METADATA,
+      StoreMetadataFetchMode.SERVER_BASED_METADATA, StoreMetadataFetchMode.DA_VINCI_CLIENT_BASED_METADATA };
 
   private static Client setupTransportClientFactory(FastClientHTTPVariant fastClientHTTPVariant) {
     /**


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci], [server], [controller],
[router], [samza], [vpj], [fast-client], [thin-client], [alpini],
[admin-tool], [test], [build], [doc], [script]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Allow using DaVinci client based store metadata fetch for fast client
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
Previously in PR #253, we deprecated the da-vinci client based metadata fetch in favor of a thin-client based metadata fetch. Recently, we saw in production that the thin-client based metadata fetch can cause quota exceeds exception when there are lots of fast-clients deployed.

This commit adds back the wiring for setting a da-vinci client based metadata fetcher to temporarily mitigate the issue. In the future, however, we would like to move completely to the server-based metadata fetch.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
GH CI

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [X] Yes. Make sure to explain your proposed changes and call out the behavior change.
    - By default fast-clients will use a DaVinci based metadata instead of a thin-client based metadata