### PR TITLE
[router] Fix initialization bug in router quota throttler

### DIFF
--- a/internal/venice-common/src/main/java/com/linkedin/venice/helix/ZkRoutersClusterManager.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/helix/ZkRoutersClusterManager.java
@@ -194,11 +194,6 @@ public class ZkRoutersClusterManager
   }
 
   @Override
-  public boolean isQuotaRebalanceEnabled() {
-    return routersClusterConfig.isQuotaRebalanceEnabled();
-  }
-
-  @Override
   public boolean isMaxCapacityProtectionEnabled() {
     return routersClusterConfig.isMaxCapacityProtectionEnabled();
   }
@@ -213,25 +208,6 @@ public class ZkRoutersClusterManager
       return currentData;
     });
     routersClusterConfig.setThrottlingEnabled(enable);
-  }
-
-  @Override
-  public void enableQuotaRebalance(boolean enable, int expectRouterCount) {
-    compareAndSetClusterConfig(currentData -> {
-      if (currentData == null) {
-        currentData = new RoutersClusterConfig();
-      }
-      currentData.setQuotaRebalanceEnabled(enable);
-      // While disabling the quota re-balance feature, an expected router count should be defined so that each router
-      // could use this count to calculate quota per router instead of depending on the live routers count.
-      if (!enable) {
-        validateExpectRouterCount(expectRouterCount);
-        currentData.setExpectedRouterCount(expectRouterCount);
-      }
-      return currentData;
-    });
-    routersClusterConfig.setQuotaRebalanceEnabled(enable);
-    routersClusterConfig.setExpectedRouterCount(expectRouterCount);
   }
 
   private void validateExpectRouterCount(int expectedRouterCount) {

--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/RoutersClusterConfig.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/RoutersClusterConfig.java
@@ -7,7 +7,6 @@ public class RoutersClusterConfig {
   private int expectedRouterCount;
 
   private boolean throttlingEnabled = true;
-  private boolean quotaRebalanceEnabled = true;
   private boolean maxCapacityProtectionEnabled = true;
 
   public RoutersClusterConfig() {
@@ -27,14 +26,6 @@ public class RoutersClusterConfig {
 
   public void setThrottlingEnabled(boolean throttlingEnabled) {
     this.throttlingEnabled = throttlingEnabled;
-  }
-
-  public boolean isQuotaRebalanceEnabled() {
-    return quotaRebalanceEnabled;
-  }
-
-  public void setQuotaRebalanceEnabled(boolean quotaRebalanceEnabled) {
-    this.quotaRebalanceEnabled = quotaRebalanceEnabled;
   }
 
   public boolean isMaxCapacityProtectionEnabled() {
@@ -62,9 +53,6 @@ public class RoutersClusterConfig {
     if (throttlingEnabled != config.throttlingEnabled) {
       return false;
     }
-    if (quotaRebalanceEnabled != config.quotaRebalanceEnabled) {
-      return false;
-    }
     return maxCapacityProtectionEnabled == config.maxCapacityProtectionEnabled;
   }
 
@@ -72,7 +60,6 @@ public class RoutersClusterConfig {
   public int hashCode() {
     int result = expectedRouterCount;
     result = 31 * result + (throttlingEnabled ? 1 : 0);
-    result = 31 * result + (quotaRebalanceEnabled ? 1 : 0);
     result = 31 * result + (maxCapacityProtectionEnabled ? 1 : 0);
     return result;
   }
@@ -80,7 +67,6 @@ public class RoutersClusterConfig {
   public RoutersClusterConfig cloneRoutesClusterConfig() {
     RoutersClusterConfig config = new RoutersClusterConfig();
     config.setThrottlingEnabled(isThrottlingEnabled());
-    config.setQuotaRebalanceEnabled(isQuotaRebalanceEnabled());
     config.setMaxCapacityProtectionEnabled(isMaxCapacityProtectionEnabled());
     config.setExpectedRouterCount(getExpectedRouterCount());
     return config;

--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/RoutersClusterManager.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/RoutersClusterManager.java
@@ -56,8 +56,6 @@ public interface RoutersClusterManager {
 
   boolean isThrottlingEnabled();
 
-  boolean isQuotaRebalanceEnabled();
-
   boolean isMaxCapacityProtectionEnabled();
 
   /**
@@ -65,12 +63,6 @@ public interface RoutersClusterManager {
    * request regardless of store's quota.
    */
   void enableThrottling(boolean enable);
-
-  /**
-   * Enable or disable read quota re-balance feature on router. If this feature is disabled, router will not update
-   * store's read quota while a router is removed from or added into the cluster.
-   */
-  void enableQuotaRebalance(boolean enable, int expectRouterCount);
 
   /**
    * Enable or disable max read capacity protection feature on router. If this feature is disabled, router will not

--- a/internal/venice-common/src/test/java/com/linkedin/venice/helix/RoutersClusterConfigJSONSerializerTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/helix/RoutersClusterConfigJSONSerializerTest.java
@@ -11,7 +11,6 @@ public class RoutersClusterConfigJSONSerializerTest {
   public void testSerializeAndDeserialize() throws IOException {
     RoutersClusterConfig config = new RoutersClusterConfig();
     config.setExpectedRouterCount(10);
-    config.setQuotaRebalanceEnabled(false);
 
     RouterClusterConfigJSONSerializer serializer = new RouterClusterConfigJSONSerializer();
     byte[] data = serializer.serialize(config, "");
@@ -26,7 +25,7 @@ public class RoutersClusterConfigJSONSerializerTest {
     RoutersClusterConfig config = serializer.deserialize(jsonStr.getBytes(), "");
     Assert.assertEquals(config.getExpectedRouterCount(), 10);
     Assert.assertTrue(
-        config.isMaxCapacityProtectionEnabled() && config.isQuotaRebalanceEnabled() && config.isThrottlingEnabled(),
+        config.isMaxCapacityProtectionEnabled() && config.isThrottlingEnabled(),
         "By default all feature should be enabled.");
   }
 }

--- a/internal/venice-common/src/test/java/com/linkedin/venice/meta/RoutersClusterConfigTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/meta/RoutersClusterConfigTest.java
@@ -21,14 +21,12 @@ public class RoutersClusterConfigTest {
     int expectedNumber = 10;
     RoutersClusterConfig config = new RoutersClusterConfig();
     Assert.assertTrue(
-        config.isMaxCapacityProtectionEnabled() && config.isQuotaRebalanceEnabled() && config.isThrottlingEnabled(),
+        config.isMaxCapacityProtectionEnabled() && config.isThrottlingEnabled(),
         "By default all feature should be enabled for the cluster.");
 
     config.setMaxCapacityProtectionEnabled(false);
     Assert.assertFalse(config.isMaxCapacityProtectionEnabled());
     config.setThrottlingEnabled(false);
     Assert.assertFalse(config.isThrottlingEnabled());
-    config.setQuotaRebalanceEnabled(false);
-    Assert.assertFalse(config.isQuotaRebalanceEnabled());
   }
 }

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/controller/server/TestAdminSparkServer.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/controller/server/TestAdminSparkServer.java
@@ -849,20 +849,6 @@ public class TestAdminSparkServer extends AbstractTestAdminSparkServer {
   }
 
   @Test(timeOut = TEST_TIMEOUT)
-  public void controllerClientCanEnableQuotaRebalance() {
-    int expectedRouterCount = 100;
-    controllerClient.enableQuotaRebalanced(false, expectedRouterCount);
-    Assert.assertFalse(controllerClient.getRoutersClusterConfig().getConfig().isQuotaRebalanceEnabled());
-    Assert.assertEquals(
-        controllerClient.getRoutersClusterConfig().getConfig().getExpectedRouterCount(),
-        expectedRouterCount);
-    // After enable this feature, Venice don't need expected router count, because it will use the live router count, so
-    // could give any expected router count here.
-    controllerClient.enableQuotaRebalanced(true, 0);
-    Assert.assertTrue(controllerClient.getRoutersClusterConfig().getConfig().isQuotaRebalanceEnabled());
-  }
-
-  @Test(timeOut = TEST_TIMEOUT)
   public void controllerClientCanDiscoverCluster() {
     String storeName = Utils.getUniqueString("controllerClientCanDiscoverCluster");
     controllerClient.createNewStore(storeName, "test", "\"string\"", "\"string\"");

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/helix/ZkRoutersClusterManagerTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/helix/ZkRoutersClusterManagerTest.java
@@ -111,21 +111,6 @@ public class ZkRoutersClusterManagerTest {
   }
 
   @Test
-  public void testEnableQuotaRebalance() {
-    int port = 10555;
-    String instanceId = Utils.getHelixNodeIdentifier(Utils.getHostName(), port);
-    ZkRoutersClusterManager manager = createManager(zkClient);
-    manager.registerRouter(instanceId);
-    int expectRouterNumber = 200;
-    manager.enableQuotaRebalance(false, expectRouterNumber);
-    Assert
-        .assertFalse(manager.isQuotaRebalanceEnabled(), "Quota re-balance has been disabled in cluster level config.");
-    Assert.assertEquals(manager.getExpectedRoutersCount(), expectRouterNumber);
-    manager.enableQuotaRebalance(true, expectRouterNumber);
-    Assert.assertTrue(manager.isQuotaRebalanceEnabled(), "Quota re-balance has been enabled in cluster level config.");
-  }
-
-  @Test
   public void testUPdateExpectRouterCount() {
     int port = 10555;
     String instanceId = Utils.getHelixNodeIdentifier(Utils.getHostName(), port);
@@ -187,8 +172,7 @@ public class ZkRoutersClusterManagerTest {
     TestUtils.waitForNonDeterministicCompletion(
         1,
         TimeUnit.SECONDS,
-        () -> (!router.isThrottlingEnabled()) && (!router.isMaxCapacityProtectionEnabled())
-            && router.isQuotaRebalanceEnabled());
+        () -> !router.isThrottlingEnabled() && !router.isMaxCapacityProtectionEnabled());
   }
 
   @Test

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -6311,9 +6311,6 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
     if (isMaxCapacityProtectionEnabled.isPresent()) {
       routersClusterManager.enableMaxCapacityProtection(isMaxCapacityProtectionEnabled.get());
     }
-    if (isQuotaRebalancedEnable.isPresent() && expectedRouterCount.isPresent()) {
-      routersClusterManager.enableQuotaRebalance(isQuotaRebalancedEnable.get(), expectedRouterCount.get());
-    }
   }
 
   /**

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/throttle/NoopRouterThrottler.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/throttle/NoopRouterThrottler.java
@@ -45,12 +45,8 @@ public class NoopRouterThrottler
   }
 
   private void buildStoreReadQuotaStats(String storeName, long storeReadQuota) {
-    int routerCount = zkRoutersManager.isQuotaRebalanceEnabled()
-        ? zkRoutersManager.getLiveRoutersCount()
-        : zkRoutersManager.getExpectedRoutersCount();
-
+    int routerCount = zkRoutersManager.getLiveRoutersCount();
     long storeQuotaPerRouter = routerCount > 0 ? storeReadQuota / routerCount : 0;
-
     stats.recordQuota(storeName, storeQuotaPerRouter);
   }
 

--- a/services/venice-router/src/test/java/com/linkedin/venice/router/throttle/ReadRequestThrottlerTest.java
+++ b/services/venice-router/src/test/java/com/linkedin/venice/router/throttle/ReadRequestThrottlerTest.java
@@ -18,7 +18,7 @@ import org.testng.annotations.Test;
 
 
 public class ReadRequestThrottlerTest {
-  private final double PER_STORE_ROUTER_QUOTA_BUFFER = 1.5;
+  private static final double PER_STORE_ROUTER_QUOTA_BUFFER = 1.5;
 
   private ReadOnlyStoreRepository storeRepository;
   private ZkRoutersClusterManager zkRoutersClusterManager;

--- a/services/venice-router/src/test/java/com/linkedin/venice/router/throttle/ReadRequestThrottlerTest.java
+++ b/services/venice-router/src/test/java/com/linkedin/venice/router/throttle/ReadRequestThrottlerTest.java
@@ -18,6 +18,8 @@ import org.testng.annotations.Test;
 
 
 public class ReadRequestThrottlerTest {
+  private final double PER_STORE_ROUTER_QUOTA_BUFFER = 1.5;
+
   private ReadOnlyStoreRepository storeRepository;
   private ZkRoutersClusterManager zkRoutersClusterManager;
   private RoutingDataRepository routingDataRepository;
@@ -28,6 +30,8 @@ public class ReadRequestThrottlerTest {
   private ReadRequestThrottler throttler;
   private final static long maxCapacity = 400;
   private VeniceRouterConfig routerConfig;
+
+  private long appliedQuotaBuffer = 1 + (long) PER_STORE_ROUTER_QUOTA_BUFFER;
 
   @BeforeMethod
   public void setUp() {
@@ -44,7 +48,6 @@ public class ReadRequestThrottlerTest {
     Mockito.doReturn(Arrays.asList(new Store[] { store })).when(storeRepository).getAllStores();
     Mockito.doReturn(totalQuota).when(storeRepository).getTotalStoreReadQuota();
     Mockito.doReturn(routerCount).when(zkRoutersClusterManager).getLiveRoutersCount();
-    Mockito.doReturn(true).when(zkRoutersClusterManager).isQuotaRebalanceEnabled();
     Mockito.doReturn(true).when(zkRoutersClusterManager).isThrottlingEnabled();
     Mockito.doReturn(true).when(zkRoutersClusterManager).isMaxCapacityProtectionEnabled();
     Mockito.doReturn(true).when(routerConfig).isPerRouterStorageNodeThrottlerEnabled();
@@ -56,7 +59,7 @@ public class ReadRequestThrottlerTest {
         maxCapacity,
         stats,
         0.0,
-        0.0,
+        PER_STORE_ROUTER_QUOTA_BUFFER,
         1000,
         1000,
         true);
@@ -64,12 +67,16 @@ public class ReadRequestThrottlerTest {
 
   @Test
   public void testCalculateStoreQuotaPerRouter() {
-    Assert.assertEquals(throttler.calculateStoreQuotaPerRouter(totalQuota), totalQuota / routerCount);
+    Assert.assertEquals(
+        throttler.calculateStoreQuotaPerRouter(totalQuota),
+        totalQuota / routerCount * appliedQuotaBuffer);
     // Mock one router has been crushed.
     routerCount = routerCount - 1;
     Mockito.doReturn(routerCount).when(zkRoutersClusterManager).getLiveRoutersCount();
     throttler.handleRouterCountChanged(routerCount);
-    Assert.assertEquals(throttler.calculateStoreQuotaPerRouter(totalQuota), totalQuota / routerCount);
+    Assert.assertEquals(
+        throttler.calculateStoreQuotaPerRouter(totalQuota),
+        totalQuota / routerCount * appliedQuotaBuffer);
     // Too many router failures, the ideal quota per router exceeds the max capacity
     routerCount = routerCount / 2;
     Mockito.doReturn(routerCount).when(zkRoutersClusterManager).getLiveRoutersCount();
@@ -82,14 +89,17 @@ public class ReadRequestThrottlerTest {
     int numberOfRequests = 10;
     try {
       for (int i = 0; i < numberOfRequests; i++) {
-        throttler.mayThrottleRead(store.getName(), (int) (totalQuota / routerCount / numberOfRequests), "test");
+        throttler.mayThrottleRead(
+            store.getName(),
+            (int) (totalQuota / routerCount / numberOfRequests) * appliedQuotaBuffer,
+            "test");
       }
     } catch (QuotaExceededException e) {
       Assert.fail("Usage has not exceeded the quota.");
     }
 
     try {
-      throttler.mayThrottleRead(store.getName(), 10, "test");
+      throttler.mayThrottleRead(store.getName(), 10 * appliedQuotaBuffer, "test");
       Assert.fail("Usage has exceed the quota. Should get the QuotaExceededException.");
     } catch (QuotaExceededException e) {
       // expected.
@@ -99,7 +109,7 @@ public class ReadRequestThrottlerTest {
   @Test
   public void testOnRouterCountChanged() {
     try {
-      throttler.mayThrottleRead(store.getName(), (int) (totalQuota / (routerCount - 1)), "test");
+      throttler.mayThrottleRead(store.getName(), (int) (totalQuota / (routerCount - 1)) * appliedQuotaBuffer, "test");
       Assert.fail("Usage has exceeded the quota.");
     } catch (QuotaExceededException e) {
       // expected.
@@ -112,7 +122,7 @@ public class ReadRequestThrottlerTest {
       throttler.mayThrottleRead(store.getName(), (int) (totalQuota / (routerCount - 1)), "test");
       Mockito.verify(stats, Mockito.atLeastOnce()).recordTotalQuota((double) totalQuota / (routerCount - 1));
       Mockito.verify(stats, Mockito.atLeastOnce())
-          .recordQuota(store.getName(), (double) totalQuota / (routerCount - 1));
+          .recordQuota(store.getName(), (double) totalQuota / (routerCount - 1) * appliedQuotaBuffer);
     } catch (QuotaExceededException e) {
       Assert.fail("Usage has not exceeded the quota.");
     }
@@ -129,7 +139,7 @@ public class ReadRequestThrottlerTest {
 
     long newQuota = totalQuota + 200;
     try {
-      throttler.mayThrottleRead(store.getName(), (double) newQuota / routerCount, "test");
+      throttler.mayThrottleRead(store.getName(), (double) newQuota / routerCount * appliedQuotaBuffer, "test");
       Assert.fail("Quota has not been updated.");
     } catch (QuotaExceededException e) {
       // expected
@@ -141,7 +151,8 @@ public class ReadRequestThrottlerTest {
 
     throttler.handleStoreChanged(store);
     Mockito.verify(stats, Mockito.atLeastOnce()).recordTotalQuota((double) newQuota / routerCount);
-    Mockito.verify(stats, Mockito.atLeastOnce()).recordQuota(store.getName(), (double) newQuota / routerCount);
+    Mockito.verify(stats, Mockito.atLeastOnce())
+        .recordQuota(store.getName(), (double) newQuota / routerCount * appliedQuotaBuffer);
 
     try {
       throttler.mayThrottleRead(store.getName(), (double) newQuota / routerCount, "test");
@@ -245,7 +256,7 @@ public class ReadRequestThrottlerTest {
     throttler.handleStoreChanged(newStore);
     Assert.assertEquals(
         throttler.getStoreReadThrottler("testOnStoreCreatedAndDeleted").getQuota(),
-        extraQuota / routerCount);
+        extraQuota / routerCount * appliedQuotaBuffer);
     // Mock delete the new store.
     Mockito.doReturn(Arrays.asList(store)).when(storeRepository).getAllStores();
     Mockito.doReturn(totalQuota).when(storeRepository).getTotalStoreReadQuota();
@@ -273,7 +284,9 @@ public class ReadRequestThrottlerTest {
     Mockito.doReturn(extraQuota).when(storeRepository).getTotalStoreReadQuota();
     throttler.handleStoreDeleted(store.getName());
     // Now the total quota per router falls back under the max capacity.
-    Assert.assertEquals(throttler.getStoreReadThrottler("testOnStoreCreatedAndDeleted").getQuota(), extraQuota);
+    Assert.assertEquals(
+        throttler.getStoreReadThrottler("testOnStoreCreatedAndDeleted").getQuota(),
+        extraQuota * appliedQuotaBuffer);
   }
 
   @Test
@@ -347,38 +360,6 @@ public class ReadRequestThrottlerTest {
   }
 
   @Test
-  public void testDisableQuotaRebalance() {
-    // disable quota rebalance
-    Mockito.doReturn(false).when(zkRoutersClusterManager).isQuotaRebalanceEnabled();
-    Mockito.doReturn(routerCount).when(zkRoutersClusterManager).getExpectedRoutersCount();
-
-    // Mock router count is changed.
-    Mockito.doReturn(routerCount - 1).when(zkRoutersClusterManager).getLiveRoutersCount();
-    throttler.handleRouterCountChanged(routerCount - 1);
-    try {
-      throttler.mayThrottleRead(store.getName(), (int) (totalQuota / (routerCount - 1)), "test");
-      Assert.fail(
-          "As quota re-balance has been disabled, quota per router should not be increased with one router failure.");
-    } catch (QuotaExceededException e) {
-      // expected.
-    }
-    try {
-      throttler.mayThrottleRead(store.getName(), (int) (totalQuota / routerCount), "test");
-    } catch (QuotaExceededException e) {
-      Assert.fail("Usage does not exceed the quota, should not throttle the request.");
-    }
-
-    // enable again
-    Mockito.doReturn(true).when(zkRoutersClusterManager).isQuotaRebalanceEnabled();
-    throttler.handleRouterClusterConfigChanged(null);
-    try {
-      throttler.mayThrottleRead(store.getName(), (int) (totalQuota / (routerCount - 1)), "test");
-    } catch (QuotaExceededException e) {
-      Assert.fail("Usage does not exceed the quota, should not throttle the request.");
-    }
-  }
-
-  @Test
   public void testDisableMaxCapacityProtection() {
     // disable router protection
     Mockito.doReturn(false).when(zkRoutersClusterManager).isMaxCapacityProtectionEnabled();
@@ -399,7 +380,7 @@ public class ReadRequestThrottlerTest {
     Mockito.doReturn(true).when(zkRoutersClusterManager).isMaxCapacityProtectionEnabled();
     throttler.handleRouterClusterConfigChanged(null);
     try {
-      throttler.mayThrottleRead(store.getName(), (int) totalQuota, "test");
+      throttler.mayThrottleRead(store.getName(), (int) totalQuota * appliedQuotaBuffer, "test");
       Assert.fail("As router protection has been enabled. Current usage exceeds the quota.");
     } catch (QuotaExceededException e) {
       // expected

--- a/services/venice-router/src/test/java/com/linkedin/venice/router/throttle/RouterRequestThrottlingTest.java
+++ b/services/venice-router/src/test/java/com/linkedin/venice/router/throttle/RouterRequestThrottlingTest.java
@@ -67,7 +67,6 @@ public class RouterRequestThrottlingTest {
     AggRouterHttpRequestStats stats = mock(AggRouterHttpRequestStats.class);
     ZkRoutersClusterManager zkRoutersClusterManager = mock(ZkRoutersClusterManager.class);
     doReturn(1).when(zkRoutersClusterManager).getLiveRoutersCount();
-    doReturn(true).when(zkRoutersClusterManager).isQuotaRebalanceEnabled();
     doReturn(true).when(zkRoutersClusterManager).isThrottlingEnabled();
     doReturn(true).when(zkRoutersClusterManager).isMaxCapacityProtectionEnabled();
     RoutingDataRepository routingDataRepository = mock(RoutingDataRepository.class);
@@ -78,14 +77,14 @@ public class RouterRequestThrottlingTest {
         2000,
         stats,
         0.0,
-        0.0,
+        1.5,
         1000,
         1000,
         true);
   }
 
   @Test(timeOut = 30000, groups = { "flaky" })
-  public void testSingleGetThrottling() throws Exception {
+  public void testSingleGetThrottling() {
     VeniceRouterConfig routerConfig = mock(VeniceRouterConfig.class);
     doReturn(Long.MAX_VALUE).when(routerConfig).getMaxPendingRequest();
     doReturn(LEAST_LOADED_ROUTING).when(routerConfig).getMultiKeyRoutingStrategy();
@@ -161,7 +160,7 @@ public class RouterRequestThrottlingTest {
 
     // Router should throttle the single-get requests if QPS exceeds 1000
     boolean singleGetThrottled = false;
-    for (int i = 0; i < totalQuota + 200; i++) {
+    for (int i = 0; i < totalQuota * 2 + 200; i++) {
       try {
         delegateMode.scatter(
             scatter,
@@ -195,7 +194,7 @@ public class RouterRequestThrottlingTest {
   public void testMultiKeyThrottling(RequestType requestType) throws Exception {
     // Allow 10 multi-key requests per second
     int batchGetSize = 100;
-    int allowedQPS = (int) totalQuota / batchGetSize;
+    int allowedQPS = (int) totalQuota / batchGetSize * 2;
 
     // mock a scatter gather helper for multi-key requests
     VeniceRouterConfig config = mock(VeniceRouterConfig.class);


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci], [server], [controller],
[router], [samza], [vpj], [fast-client], [thin-client], [alpini],
[admin-tool], [test], [build], [doc], [script]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## [router] Fix initialization bug in router quota throttler
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

There is a bug in how `ReadRequestThrottler` initialized store throttlers in the constructor. 
 `buildAllStoreReadThrottlers` relies on various config values , but they were initialized after the method was called. So after a router bounce it will initialize the store throttlers with buffer values of `0` but inside store update handler it will rebuild the throttler with proper value of the configs. This leads to diverted per store router quota in the same cluster depending on the state of start time of various hosts and store version changes.
This PR fixes the order of initialization and also removed code to update `quotaRebalanceEnabled` which is never called in router code.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
CI unit tests.

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.