### PR TITLE
[server] Restart meta store writer when hitting produce exception

### DIFF
--- a/internal/venice-common/src/main/java/com/linkedin/venice/system/store/MetaStoreWriter.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/system/store/MetaStoreWriter.java
@@ -400,12 +400,12 @@ public class MetaStoreWriter implements Closeable {
         messageProduceRetryCount++;
         if (messageProduceRetryCount < maxMessageProduceRetryCount) {
           LOGGER.warn(
-              "Caught exception while trying to write message, will retry {}/{}",
+              "Caught exception while trying to write message, will restart Venice Writer and retry {}/{}",
               messageProduceRetryCount,
               maxMessageProduceRetryCount);
-        } else {
-          LOGGER.error("Caught exception while trying to write message, will shutdown writer.", e);
           closeVeniceWriter(metaStoreName, writer, true);
+        } else {
+          LOGGER.error("Fail to write message after {} attempts.", maxMessageProduceRetryCount, e);
           break;
         }
       } finally {

--- a/internal/venice-common/src/main/java/com/linkedin/venice/system/store/MetaStoreWriter.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/system/store/MetaStoreWriter.java
@@ -389,8 +389,8 @@ public class MetaStoreWriter implements Closeable {
     VeniceWriter writer = null;
     boolean messageProduced = false;
     while (!messageProduced) {
+      lock.lock();
       try {
-        lock.lock();
         writer = getOrCreateMetaStoreWriter(metaStoreName);
         writerConsumer.accept(writer);
         writer.flush();

--- a/internal/venice-common/src/test/java/com/linkedin/venice/system/store/MetaStoreWriterTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/system/store/MetaStoreWriterTest.java
@@ -1,0 +1,33 @@
+package com.linkedin.venice.system.store;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.linkedin.venice.exceptions.VeniceException;
+import com.linkedin.venice.writer.VeniceWriter;
+import java.util.concurrent.locks.ReentrantLock;
+import org.testng.annotations.Test;
+
+
+public class MetaStoreWriterTest {
+  @Test
+  public void testMetaStoreWriterWillRestartUponProduceFailure() {
+    MetaStoreWriter metaStoreWriter = mock(MetaStoreWriter.class);
+    String metaStoreName = "testStore";
+    ReentrantLock reentrantLock = new ReentrantLock();
+    when(metaStoreWriter.getOrCreateMetaStoreWriterLock(metaStoreName)).thenReturn(reentrantLock);
+    VeniceWriter badWriter = mock(VeniceWriter.class);
+    when(badWriter.delete(any(), any())).thenThrow(new VeniceException("Bad producer call"));
+    VeniceWriter goodWriter = mock(VeniceWriter.class);
+    when(metaStoreWriter.getOrCreateMetaStoreWriter(metaStoreName)).thenReturn(badWriter, goodWriter);
+    doCallRealMethod().when(metaStoreWriter).writeMessageWithRetry(anyString(), any());
+    metaStoreWriter.writeMessageWithRetry(metaStoreName, vw -> vw.delete("a", null));
+    verify(badWriter, times(1)).delete(any(), any());
+    verify(goodWriter, times(1)).delete(any(), any());
+  }
+}

--- a/internal/venice-common/src/test/java/com/linkedin/venice/system/store/MetaStoreWriterTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/system/store/MetaStoreWriterTest.java
@@ -25,6 +25,7 @@ public class MetaStoreWriterTest {
     when(badWriter.delete(any(), any())).thenThrow(new VeniceException("Bad producer call"));
     VeniceWriter goodWriter = mock(VeniceWriter.class);
     when(metaStoreWriter.getOrCreateMetaStoreWriter(metaStoreName)).thenReturn(badWriter, goodWriter);
+    doCallRealMethod().when(metaStoreWriter).removeMetaStoreWriter(anyString());
     doCallRealMethod().when(metaStoreWriter).writeMessageWithRetry(anyString(), any());
     metaStoreWriter.writeMessageWithRetry(metaStoreName, vw -> vw.delete("a", null));
     verify(badWriter, times(1)).delete(any(), any());


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci], [server], [controller],
[router], [samza], [vpj], [fast-client], [thin-client], [alpini],
[admin-tool], [test], [build], [doc], [script]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## [server] Restart meta store writer when hitting produce exception
This PR tries to enhance the produce logic in meta store writer. When VW#sendMessage throws exception that might be result from for example stale DNS information or failed internal state (like finalized checksum issue) due to bug, we might want to retry by restarting a new VW and clean internal state so it might be able to have healthy producer and internal state to produce the message. If it fails all retry we should log the error message.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
Add new unit test to cover the retry logic.
## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.