### PR TITLE
[server] Additional safeguard to make sure server will always be able to shutdown successfully with ingestion isolation

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/helix/HelixParticipationService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/helix/HelixParticipationService.java
@@ -224,6 +224,7 @@ public class HelixParticipationService extends AbstractVeniceService
   @Override
   public void stopInner() throws IOException {
     LOGGER.info("Attempting to stop HelixParticipation service.");
+    ingestionBackend.prepareForShutdown();
     if (helixManager != null) {
       try {
         helixManager.disconnect();

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/IsolatedIngestionBackend.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/IsolatedIngestionBackend.java
@@ -31,6 +31,7 @@ import io.tehuti.metrics.MetricsRepository;
 import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -58,7 +59,7 @@ public class IsolatedIngestionBackend extends DefaultIngestionBackend
   private final VeniceConfigLoader configLoader;
   private final ExecutorService completionReportHandlingExecutor = Executors.newFixedThreadPool(10);
   private Process isolatedIngestionServiceProcess;
-  private boolean isShuttingDown = false;
+  private AtomicBoolean isShuttingDown = new AtomicBoolean(false);
 
   public IsolatedIngestionBackend(
       VeniceConfigLoader configLoader,
@@ -231,7 +232,7 @@ public class IsolatedIngestionBackend extends DefaultIngestionBackend
 
   @Override
   public void prepareForShutdown() {
-    isShuttingDown = true;
+    isShuttingDown.set(true);
   }
 
   public void setIsolatedIngestionServiceProcess(Process process) {
@@ -251,7 +252,7 @@ public class IsolatedIngestionBackend extends DefaultIngestionBackend
   }
 
   public boolean isShuttingDown() {
-    return isShuttingDown;
+    return isShuttingDown.get();
   }
 
   void removeTopicPartitionLocally(

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/VeniceIngestionBackend.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/VeniceIngestionBackend.java
@@ -24,4 +24,7 @@ public interface VeniceIngestionBackend extends IngestionBackendBase {
   // test only
   default void replaceAndAddTestPushStatusNotifier(VeniceNotifier pushStatusNotifier) {
   };
+
+  default void prepareForShutdown() {
+  }
 }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/ingestion/IsolatedIngestionBackendTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/ingestion/IsolatedIngestionBackendTest.java
@@ -258,4 +258,36 @@ public class IsolatedIngestionBackendTest {
       Assert.assertEquals(topicIngestionStatusMap.get(topic).getPartitionIngestionStatus(partition), NOT_EXIST);
     }
   }
+
+  @Test
+  public void testBackendShutdownSuccessfullyWithDivergedResourceMetadata() {
+    try (MainIngestionMonitorService monitorService = mock(MainIngestionMonitorService.class);
+        IsolatedIngestionBackend backend = mock(IsolatedIngestionBackend.class)) {
+      String topic = "testTopic_v1";
+      int partition = 0;
+      VeniceStoreVersionConfig storeVersionConfig = mock(VeniceStoreVersionConfig.class);
+      when(storeVersionConfig.getStoreVersionName()).thenReturn(topic);
+      MainIngestionRequestClient ingestionRequestClient = mock(MainIngestionRequestClient.class);
+      when(backend.getMainIngestionRequestClient()).thenReturn(ingestionRequestClient);
+      when(backend.getMainIngestionMonitorService()).thenReturn(monitorService);
+      Map<String, MainTopicIngestionStatus> topicIngestionStatusMap = new VeniceConcurrentHashMap<>();
+      MainTopicIngestionStatus topicIngestionStatus = new MainTopicIngestionStatus(topic);
+      topicIngestionStatus.setPartitionIngestionStatusToIsolatedIngestion(partition);
+      topicIngestionStatusMap.put(topic, topicIngestionStatus);
+      when(monitorService.getTopicPartitionIngestionStatus(topic, partition)).thenCallRealMethod();
+      when(monitorService.getTopicIngestionStatusMap()).thenReturn(topicIngestionStatusMap);
+      when(backend.isTopicPartitionHostedInMainProcess(anyString(), anyInt())).thenCallRealMethod();
+      when(backend.isTopicPartitionIngesting(anyString(), anyInt())).thenCallRealMethod();
+      doCallRealMethod().when(backend).stopConsumption(any(), anyInt());
+      doCallRealMethod().when(backend).executeCommandWithRetry(anyString(), anyInt(), any(), any(), any());
+      ReentrantReadWriteLock readWriteLock = new ReentrantReadWriteLock();
+      when(monitorService.getForkProcessActionLock()).thenReturn(readWriteLock);
+      KafkaStoreIngestionService storeIngestionService = mock(KafkaStoreIngestionService.class);
+      when(storeIngestionService.isPartitionConsuming(anyString(), anyInt())).thenReturn(false);
+      when(backend.getStoreIngestionService()).thenReturn(storeIngestionService);
+      when(ingestionRequestClient.stopConsumption(anyString(), anyInt())).thenReturn(false);
+      when(backend.isShuttingDown()).thenReturn(true);
+      backend.stopConsumption(storeVersionConfig, partition);
+    }
+  }
 }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/ingestion/IsolatedIngestionBackendTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/ingestion/IsolatedIngestionBackendTest.java
@@ -287,7 +287,12 @@ public class IsolatedIngestionBackendTest {
       when(backend.getStoreIngestionService()).thenReturn(storeIngestionService);
       when(ingestionRequestClient.stopConsumption(anyString(), anyInt())).thenReturn(false);
       when(backend.isShuttingDown()).thenReturn(true);
+
+      // Make the actual call and verify that it is actually calling remote process and execute only once and quit.
       backend.stopConsumption(storeVersionConfig, partition);
+      verify(storeIngestionService, times(1)).isPartitionConsuming(anyString(), anyInt());
+      verify(ingestionRequestClient, times(1)).stopConsumption(anyString(), anyInt());
+
     }
   }
 }


### PR DESCRIPTION

<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci], [server], [controller],
[router], [samza], [vpj], [fast-client], [thin-client], [alpini],
[admin-tool], [test], [build], [doc], [script]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## [server] Additional safeguard to make sure server will always be able to shutdown successfully with ingestion isolation
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

With all the recent bug fixes, it is unlikely that main process and isolation process will run out of sync for a particular resource's metadata. However, when real bug happens, current infinite retry logic might lead to blocking Venice server from shutting down, which is not acceptable as it needs manual shutdown for all impacted hosts in the cluster.
This PR adds an additional safeguard to guard this behavior. When HelixParticipantService is shutting down, we will inject a boolean into IsolatedIngestionBackend notifying it is preparing to shutdown. When Helix manager is sending stop consumption command to all the resources, if a resource has out-of-sync metadata and reject remote execution, we will skip the retry.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
Added new unit test to test the behavior. 
## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.