### PR TITLE
[admin-tool] Terminates thread pools after estimating data recovery time

### DIFF
--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/datarecovery/DataRecoveryClient.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/datarecovery/DataRecoveryClient.java
@@ -67,6 +67,7 @@ public class DataRecoveryClient {
     }
 
     getEstimator().perform(storeNames, cmdParams);
+    getEstimator().shutdownAndAwaitTermination();
     Long totalRecoveryTime = 0L;
     for (DataRecoveryTask t: getEstimator().getTasks()) {
       totalRecoveryTime += ((EstimateDataRecoveryTimeCommand.Result) t.getTaskResult().getCmdResult())


### PR DESCRIPTION
In today's data recovery estimator, it does not clean up threads pool after all tasks are done, and it can cause admin tool not to exit properly. This rb fixes the issue by terminating the ExecutorService pool when tasks are completed.

## How was this PR tested?
Internal CI test

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.