### PR TITLE
[WIP][router] Use netty pooled buffer in router

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -156,7 +156,7 @@ subprojects {
 
   if (JavaVersion.current() >= JavaVersion.VERSION_1_9) {
     tasks.withType(JavaCompile) {
-      options.release = 8
+      options.release = 11
     }
   }
 

--- a/internal/alpini/router/alpini-router-impl/src/main/java/com/linkedin/alpini/router/impl/netty4/Router4Impl.java
+++ b/internal/alpini/router/alpini-router-impl/src/main/java/com/linkedin/alpini/router/impl/netty4/Router4Impl.java
@@ -1,5 +1,7 @@
 package com.linkedin.alpini.router.impl.netty4;
 
+import static com.linkedin.alpini.base.safealloc.SafeAllocator.POOLED_ALLOCATOR;
+
 import com.linkedin.alpini.base.concurrency.AsyncFuture;
 import com.linkedin.alpini.base.concurrency.AsyncPromise;
 import com.linkedin.alpini.base.misc.ImmutableMapEntry;
@@ -132,7 +134,8 @@ public class Router4Impl<C extends Channel> implements Router, ResourceRegistry.
 
     _bootstrapInitializer = () -> {
       ServerBootstrap bootstrap = new ServerBootstrap().channel(Objects.requireNonNull(channelClass, "channelClass"))
-          .group(bossPool, workerPool);
+          .group(bossPool, workerPool)
+          .childOption(ChannelOption.ALLOCATOR, POOLED_ALLOCATOR);
 
       for (Map.Entry<String, Object> entry: Optional.ofNullable(serverSocketOptions)
           .orElse(Collections.emptyMap())

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/api/DictionaryRetrievalService.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/api/DictionaryRetrievalService.java
@@ -254,7 +254,7 @@ public class DictionaryRetrievalService extends AbstractVeniceService {
       if (code != SC_OK) {
         LOGGER.warn("Dictionary fetch returns {} for {}", code, instanceUrl);
       } else {
-        ByteBuf byteBuf = response.getContentInByteBuf(false);
+        ByteBuf byteBuf = response.getContentInByteBuf(false, null);
         byte[] bytes = new byte[byteBuf.readableBytes()];
         byteBuf.readBytes(bytes);
         return bytes;

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/api/DictionaryRetrievalService.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/api/DictionaryRetrievalService.java
@@ -254,7 +254,7 @@ public class DictionaryRetrievalService extends AbstractVeniceService {
       if (code != SC_OK) {
         LOGGER.warn("Dictionary fetch returns {} for {}", code, instanceUrl);
       } else {
-        ByteBuf byteBuf = response.getContentInByteBuf();
+        ByteBuf byteBuf = response.getContentInByteBuf(false);
         byte[] bytes = new byte[byteBuf.readableBytes()];
         byteBuf.readBytes(bytes);
         return bytes;

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/api/VeniceDispatcher.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/api/VeniceDispatcher.java
@@ -272,13 +272,16 @@ public final class VeniceDispatcher implements PartitionDispatchHandler4<Instanc
     int statusCode = serverResponse.getStatusCode();
 
     if (PASS_THROUGH_ERROR_CODES.contains(statusCode)) {
-      return buildPlainTextResponse(HttpResponseStatus.valueOf(statusCode), serverResponse.getContentInByteBuf(false));
+      return buildPlainTextResponse(
+          HttpResponseStatus.valueOf(statusCode),
+          serverResponse.getContentInByteBuf(false, null));
     }
 
     CompressionStrategy contentCompression =
         VeniceResponseDecompressor.getCompressionStrategy(serverResponse.getFirstHeader(VENICE_COMPRESSION_STRATEGY));
 
-    ByteBuf content = serverResponse.getContentInByteBuf(contentCompression == CompressionStrategy.NO_OP);
+    ByteBuf content = serverResponse
+        .getContentInByteBuf(contentCompression == CompressionStrategy.NO_OP, path.getChannelHandlerContext());
 
     long decompressionTimeInNs = 0;
     if (statusCode != HttpStatus.SC_OK && statusCode != HttpStatus.SC_NOT_FOUND) {

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/api/VeniceFullHttpResponse.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/api/VeniceFullHttpResponse.java
@@ -21,6 +21,10 @@ public class VeniceFullHttpResponse extends DefaultFullHttpResponse {
     this.decompressionTimeInNs = decompressionTimeInNs;
   }
 
+  public ByteBuf getContent() {
+    return content();
+  }
+
   public long getDecompressionTimeInNs() {
     return decompressionTimeInNs;
   }

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/api/VeniceFullHttpResponse.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/api/VeniceFullHttpResponse.java
@@ -39,4 +39,10 @@ public class VeniceFullHttpResponse extends DefaultFullHttpResponse {
   public int hashCode() {
     return super.hashCode() * 31 * Long.hashCode(decompressionTimeInNs);
   }
+
+  @Override
+  public VeniceFullHttpResponse retain() {
+    super.retain();
+    return this;
+  }
 }

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/api/VenicePathParser.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/api/VenicePathParser.java
@@ -145,7 +145,8 @@ public class VenicePathParser<HTTP_REQUEST extends BasicHttpRequest>
 
       Optional<RouterStats<AggRouterHttpRequestStats>> statsOptional =
           routerConfig.isKeyValueProfilingEnabled() ? Optional.of(routerStats) : Optional.empty();
-
+      ChannelHandlerContext ctx =
+          fullHttpRequest.attr(VeniceChunkedWriteHandler.CHANNEL_HANDLER_CONTEXT_ATTRIBUTE_KEY).get();
       String method = fullHttpRequest.method().name();
       if (VeniceRouterUtils.isHttpGet(method)) {
         // single-get request
@@ -195,8 +196,7 @@ public class VenicePathParser<HTTP_REQUEST extends BasicHttpRequest>
           // Extract ChunkedWriteHandler reference
           VeniceChunkedWriteHandler chunkedWriteHandler =
               fullHttpRequest.attr(VeniceChunkedWriteHandler.CHUNKED_WRITE_HANDLER_ATTRIBUTE_KEY).get();
-          ChannelHandlerContext ctx =
-              fullHttpRequest.attr(VeniceChunkedWriteHandler.CHANNEL_HANDLER_CONTEXT_ATTRIBUTE_KEY).get();
+
           /**
            * If the streaming is disabled on Router, the following objects will be null since {@link VeniceChunkedWriteHandler}
            * won't be in the pipeline when streaming is disabled, check {@link RouterServer#addStreamingHandler} for more
@@ -232,7 +232,7 @@ public class VenicePathParser<HTTP_REQUEST extends BasicHttpRequest>
           version,
           compressorFactory);
       path.setResponseDecompressor(responseDecompressor);
-
+      path.setChannelHandlerContext(ctx);
       AggRouterHttpRequestStats stats = routerStats.getStatsByType(requestType);
       if (!requestType.equals(SINGLE_GET)) {
         /**

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/api/path/VeniceComputePath.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/api/path/VeniceComputePath.java
@@ -163,6 +163,7 @@ public class VeniceComputePath extends VeniceMultiKeyPath<ComputeRouterRequestKe
         getLongTailRetryMaxRouteForMultiKeyReq());
     subPath.setupRetryRelatedInfo(this);
     subPath.setValueSchemaId(this.getValueSchemaId());
+    subPath.setChannelHandlerContext(this.getChannelHandlerContext());
     return subPath;
   }
 

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/api/path/VeniceMultiGetPath.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/api/path/VeniceMultiGetPath.java
@@ -173,6 +173,7 @@ public class VeniceMultiGetPath extends VeniceMultiKeyPath<MultiGetRouterRequest
         getSmartLongTailRetryAbortThresholdMs(),
         getLongTailRetryMaxRouteForMultiKeyReq());
     subPath.setupRetryRelatedInfo(this);
+    subPath.setChannelHandlerContext(this.getChannelHandlerContext());
     return subPath;
   }
 

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/api/path/VenicePath.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/api/path/VenicePath.java
@@ -62,6 +62,8 @@ public abstract class VenicePath implements ResourcePath<RouterKey> {
   private long requestId = -1;
   private int helixGroupId = -1;
 
+  private ChannelHandlerContext ctx;
+
   public VenicePath(String resourceName, boolean smartLongTailRetryEnabled, int smartLongTailRetryAbortThresholdMs) {
     this(resourceName, smartLongTailRetryEnabled, smartLongTailRetryAbortThresholdMs, new SystemTime());
   }
@@ -77,6 +79,14 @@ public abstract class VenicePath implements ResourcePath<RouterKey> {
     this.smartLongTailRetryEnabled = smartLongTailRetryEnabled;
     this.smartLongTailRetryAbortThresholdMs = smartLongTailRetryAbortThresholdMs;
     this.time = time;
+  }
+
+  public void setChannelHandlerContext(ChannelHandlerContext ctx) {
+    this.ctx = ctx;
+  }
+
+  public ChannelHandlerContext getChannelHandlerContext() {
+    return this.ctx;
   }
 
   public synchronized long getRequestId() {

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/httpclient/ApacheHttpAsyncStorageNodeClient.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/httpclient/ApacheHttpAsyncStorageNodeClient.java
@@ -642,7 +642,7 @@ public class ApacheHttpAsyncStorageNodeClient implements StorageNodeClient {
     }
 
     @Override
-    public ByteBuf getContentInByteBuf() throws IOException {
+    public ByteBuf getContentInByteBuf(boolean userPooledBuffer) throws IOException {
       byte[] contentToByte;
       try (InputStream contentStream = httpResponse.getEntity().getContent()) {
         contentToByte = IOUtils.toByteArray(contentStream);

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/httpclient/ApacheHttpAsyncStorageNodeClient.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/httpclient/ApacheHttpAsyncStorageNodeClient.java
@@ -18,8 +18,8 @@ import com.linkedin.venice.utils.DaemonThreadFactory;
 import com.linkedin.venice.utils.Utils;
 import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.Unpooled;
-import io.netty.channel.ChannelHandlerContext;
 import io.tehuti.metrics.MetricsRepository;
 import java.io.IOException;
 import java.io.InputStream;
@@ -643,7 +643,7 @@ public class ApacheHttpAsyncStorageNodeClient implements StorageNodeClient {
     }
 
     @Override
-    public ByteBuf getContentInByteBuf(boolean userPooledBuffer, ChannelHandlerContext ctx) throws IOException {
+    public ByteBuf getContentInByteBuf(boolean usePooledBuffer, ByteBufAllocator allocator) throws IOException {
       byte[] contentToByte;
       try (InputStream contentStream = httpResponse.getEntity().getContent()) {
         contentToByte = IOUtils.toByteArray(contentStream);

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/httpclient/ApacheHttpAsyncStorageNodeClient.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/httpclient/ApacheHttpAsyncStorageNodeClient.java
@@ -19,6 +19,7 @@ import com.linkedin.venice.utils.Utils;
 import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelHandlerContext;
 import io.tehuti.metrics.MetricsRepository;
 import java.io.IOException;
 import java.io.InputStream;
@@ -642,7 +643,7 @@ public class ApacheHttpAsyncStorageNodeClient implements StorageNodeClient {
     }
 
     @Override
-    public ByteBuf getContentInByteBuf(boolean userPooledBuffer) throws IOException {
+    public ByteBuf getContentInByteBuf(boolean userPooledBuffer, ChannelHandlerContext ctx) throws IOException {
       byte[] contentToByte;
       try (InputStream contentStream = httpResponse.getEntity().getContent()) {
         contentToByte = IOUtils.toByteArray(contentStream);

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/httpclient/HttpClient5StorageNodeClient.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/httpclient/HttpClient5StorageNodeClient.java
@@ -9,8 +9,8 @@ import com.linkedin.venice.router.api.path.VenicePath;
 import com.linkedin.venice.security.SSLFactory;
 import com.linkedin.venice.utils.Utils;
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.PooledByteBufAllocator;
 import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelHandlerContext;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -130,9 +130,10 @@ public class HttpClient5StorageNodeClient implements StorageNodeClient {
     }
 
     @Override
-    public ByteBuf getContentInByteBuf(boolean usePooledBuffer) throws IOException {
+    public ByteBuf getContentInByteBuf(boolean usePooledBuffer, ChannelHandlerContext ctx) throws IOException {
       if (usePooledBuffer) {
-        ByteBuf byteBuf = PooledByteBufAllocator.DEFAULT.directBuffer(getRawByteArray().length);
+        // ByteBuf byteBuf = PooledByteBufAllocator.DEFAULT.directBuffer(getRawByteArray().length);
+        ByteBuf byteBuf = ctx.alloc().buffer(getRawByteArray().length);
         byteBuf.writeBytes(getRawByteArray());
         return byteBuf;
       }

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/httpclient/HttpClient5StorageNodeClient.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/httpclient/HttpClient5StorageNodeClient.java
@@ -9,8 +9,8 @@ import com.linkedin.venice.router.api.path.VenicePath;
 import com.linkedin.venice.security.SSLFactory;
 import com.linkedin.venice.utils.Utils;
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.Unpooled;
-import io.netty.channel.ChannelHandlerContext;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -130,16 +130,15 @@ public class HttpClient5StorageNodeClient implements StorageNodeClient {
     }
 
     @Override
-    public ByteBuf getContentInByteBuf(boolean usePooledBuffer, ChannelHandlerContext ctx) throws IOException {
+    public ByteBuf getContentInByteBuf(boolean usePooledBuffer, ByteBufAllocator allocator) throws IOException {
       if (usePooledBuffer) {
-        // ByteBuf byteBuf = PooledByteBufAllocator.DEFAULT.directBuffer(getRawByteArray().length);
-        ByteBuf byteBuf = ctx.alloc().buffer(getRawByteArray().length);
+        ByteBuf byteBuf = allocator.buffer(getRawByteArray().length);
         byteBuf.writeBytes(getRawByteArray());
         return byteBuf;
       }
 
       byte[] body = response.getBodyBytes();
-      return body == null ? Unpooled.EMPTY_BUFFER : Unpooled.wrappedBuffer(body);
+      return body == null || body.length == 0 ? Unpooled.EMPTY_BUFFER : Unpooled.wrappedBuffer(body);
     }
 
     private byte[] getRawByteArray() {

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/httpclient/PortableHttpResponse.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/httpclient/PortableHttpResponse.java
@@ -1,7 +1,7 @@
 package com.linkedin.venice.router.httpclient;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.channel.ChannelHandlerContext;
+import io.netty.buffer.ByteBufAllocator;
 import java.io.IOException;
 
 
@@ -20,7 +20,7 @@ public interface PortableHttpResponse {
    * @return
    * @throws IOException
    */
-  ByteBuf getContentInByteBuf(boolean usePooledBuffer, ChannelHandlerContext ctx) throws IOException;
+  ByteBuf getContentInByteBuf(boolean usePooledBuffer, ByteBufAllocator allocator) throws IOException;
 
   /**
    *

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/httpclient/PortableHttpResponse.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/httpclient/PortableHttpResponse.java
@@ -19,7 +19,7 @@ public interface PortableHttpResponse {
    * @return
    * @throws IOException
    */
-  ByteBuf getContentInByteBuf() throws IOException;
+  ByteBuf getContentInByteBuf(boolean usePooledBuffer) throws IOException;
 
   /**
    *

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/httpclient/PortableHttpResponse.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/httpclient/PortableHttpResponse.java
@@ -1,6 +1,7 @@
 package com.linkedin.venice.router.httpclient;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandlerContext;
 import java.io.IOException;
 
 
@@ -19,7 +20,7 @@ public interface PortableHttpResponse {
    * @return
    * @throws IOException
    */
-  ByteBuf getContentInByteBuf(boolean usePooledBuffer) throws IOException;
+  ByteBuf getContentInByteBuf(boolean usePooledBuffer, ChannelHandlerContext ctx) throws IOException;
 
   /**
    *


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci], [server], [controller],
[router], [samza], [vpj], [fast-client], [thin-client], [alpini],
[admin-tool], [test], [build], [doc], [script]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## [router] Use netty pooled buffer in router
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Router today uses `Unpooled` allocator for handing response from server. Try to use pooled allocator to improve GC.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.