### PR TITLE
[server] Use block cache for RMD column family in PlainTable format

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/RocksDBServerConfig.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/RocksDBServerConfig.java
@@ -206,7 +206,7 @@ public class RocksDBServerConfig {
   public static final String ROCKSDB_SEPARATE_RMD_CACHE_ENABLED = "rocksdb.separate.rmd.cache.enabled";
   public static final String ROCKSDB_BLOCK_BASE_FORMAT_VERSION = "rocksdb.block.base.format.version";
 
-  public static final String ROCKSDB_BLOCK_CACHE_HIGH_PRI_POOL_RATIO = "rocksdb.block.base.high.pri.pool.ratio";
+  public static final String ROCKSDB_BLOCK_CACHE_HIGH_PRI_POOL_RATIO = "rocksdb.block.cache.base.high.pri.pool.ratio";
 
   private final boolean rocksDBUseDirectReads;
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/RocksDBServerConfig.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/RocksDBServerConfig.java
@@ -206,6 +206,8 @@ public class RocksDBServerConfig {
   public static final String ROCKSDB_SEPARATE_RMD_CACHE_ENABLED = "rocksdb.separate.rmd.cache.enabled";
   public static final String ROCKSDB_BLOCK_BASE_FORMAT_VERSION = "rocksdb.block.base.format.version";
 
+  public static final String ROCKSDB_BLOCK_CACHE_HIGH_PRI_POOL_RATIO = "rocksdb.block.base.high.pri.pool.ration";
+
   private final boolean rocksDBUseDirectReads;
 
   private final int rocksDBEnvFlushPoolSize;
@@ -264,6 +266,8 @@ public class RocksDBServerConfig {
   private final boolean atomicFlushEnabled;
   private final boolean separateRMDCacheEnabled;
   private int blockBaseFormatVersion;
+
+  private double cacheHighPriorityPoolRatio;
 
   public RocksDBServerConfig(VeniceProperties props) {
     // Do not use Direct IO for reads by default
@@ -372,10 +376,15 @@ public class RocksDBServerConfig {
     this.separateRMDCacheEnabled = props.getBoolean(ROCKSDB_SEPARATE_RMD_CACHE_ENABLED, false);
 
     this.blockBaseFormatVersion = props.getInt(ROCKSDB_BLOCK_BASE_FORMAT_VERSION, 2);
+    this.cacheHighPriorityPoolRatio = props.getDouble(ROCKSDB_BLOCK_CACHE_HIGH_PRI_POOL_RATIO, 0.1);
   }
 
   public int getLevel0FileNumCompactionTriggerWriteOnlyVersion() {
     return level0FileNumCompactionTriggerWriteOnlyVersion;
+  }
+
+  public double getCacheHighPriorityPoolRatio() {
+    return cacheHighPriorityPoolRatio;
   }
 
   public int getLevel0SlowdownWritesTriggerWriteOnlyVersion() {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/RocksDBServerConfig.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/RocksDBServerConfig.java
@@ -107,6 +107,8 @@ public class RocksDBServerConfig {
 
   public static final String ROCKSDB_PLAIN_TABLE_FORMAT_ENABLED = "rocksdb.plain.table.format.enabled";
 
+  public static final String ROCKSDB_RMD_BLOCK_CACHE_ENABLED = "rocksdb.rmd.block.cache.enabled";
+
   /**
    * Length of the capped prefix extractor used with RocksDB Plain Table. Be cautious when tweaking this config because
    * it might prevent reading old data written with a different extractor length. Therefore, changing it requires wiping
@@ -239,6 +241,9 @@ public class RocksDBServerConfig {
   private final boolean rocksDBStatisticsEnabled;
 
   private final boolean rocksDBPlainTableFormatEnabled;
+
+  private final boolean rocksDBBlockCacheRMDEnabled;
+
   private final boolean rocksDBStoreIndexInFile;
   private final int rocksDBHugePageTlbSize;
   private final int rocksDBBloomBitsPerKey;
@@ -338,6 +343,7 @@ public class RocksDBServerConfig {
 
     // DO NOT ENABLE except for new stores. https://github.com/facebook/rocksdb/wiki/PlainTable-Format
     this.rocksDBPlainTableFormatEnabled = props.getBoolean(ROCKSDB_PLAIN_TABLE_FORMAT_ENABLED, false);
+    this.rocksDBBlockCacheRMDEnabled = props.getBoolean(ROCKSDB_RMD_BLOCK_CACHE_ENABLED, false);
     if (rocksDBPlainTableFormatEnabled && rocksDBUseDirectReads) {
       throw new VeniceException(
           "Invalid configuration combination, " + ROCKSDB_OPTIONS_USE_DIRECT_READS + " must be disabled to enable "
@@ -547,6 +553,10 @@ public class RocksDBServerConfig {
 
   public boolean isAtomicFlushEnabled() {
     return atomicFlushEnabled;
+  }
+
+  public boolean isRocksDBBlockCacheRMDEnabled() {
+    return rocksDBBlockCacheRMDEnabled;
   }
 
   public boolean isUseSeparateRMDCacheEnabled() {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/RocksDBServerConfig.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/RocksDBServerConfig.java
@@ -206,7 +206,7 @@ public class RocksDBServerConfig {
   public static final String ROCKSDB_SEPARATE_RMD_CACHE_ENABLED = "rocksdb.separate.rmd.cache.enabled";
   public static final String ROCKSDB_BLOCK_BASE_FORMAT_VERSION = "rocksdb.block.base.format.version";
 
-  public static final String ROCKSDB_BLOCK_CACHE_HIGH_PRI_POOL_RATIO = "rocksdb.block.base.high.pri.pool.ration";
+  public static final String ROCKSDB_BLOCK_CACHE_HIGH_PRI_POOL_RATIO = "rocksdb.block.base.high.pri.pool.ratio";
 
   private final boolean rocksDBUseDirectReads;
 
@@ -267,7 +267,7 @@ public class RocksDBServerConfig {
   private final boolean separateRMDCacheEnabled;
   private int blockBaseFormatVersion;
 
-  private double cacheHighPriorityPoolRatio;
+  private double blockCacheHighPriorityPoolRatio;
 
   public RocksDBServerConfig(VeniceProperties props) {
     // Do not use Direct IO for reads by default
@@ -376,15 +376,15 @@ public class RocksDBServerConfig {
     this.separateRMDCacheEnabled = props.getBoolean(ROCKSDB_SEPARATE_RMD_CACHE_ENABLED, false);
 
     this.blockBaseFormatVersion = props.getInt(ROCKSDB_BLOCK_BASE_FORMAT_VERSION, 2);
-    this.cacheHighPriorityPoolRatio = props.getDouble(ROCKSDB_BLOCK_CACHE_HIGH_PRI_POOL_RATIO, 0.1);
+    this.blockCacheHighPriorityPoolRatio = props.getDouble(ROCKSDB_BLOCK_CACHE_HIGH_PRI_POOL_RATIO, 0.1);
   }
 
   public int getLevel0FileNumCompactionTriggerWriteOnlyVersion() {
     return level0FileNumCompactionTriggerWriteOnlyVersion;
   }
 
-  public double getCacheHighPriorityPoolRatio() {
-    return cacheHighPriorityPoolRatio;
+  public double getBlockCacheHighPriorityPoolRatio() {
+    return blockCacheHighPriorityPoolRatio;
   }
 
   public int getLevel0SlowdownWritesTriggerWriteOnlyVersion() {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/RocksDBStorageEngineFactory.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/RocksDBStorageEngineFactory.java
@@ -147,13 +147,13 @@ public class RocksDBStorageEngineFactory extends StorageEngineFactory {
           rocksDBServerConfig.getRocksDBBlockCacheSizeInBytes(),
           rocksDBServerConfig.getRocksDBBlockCacheShardBits(),
           rocksDBServerConfig.getRocksDBBlockCacheStrictCapacityLimit(),
-          rocksDBServerConfig.getCacheHighPriorityPoolRatio());
+          rocksDBServerConfig.getBlockCacheHighPriorityPoolRatio());
       if (rocksDBServerConfig.isUseSeparateRMDCacheEnabled()) {
         this.sharedRMDCache = new LRUCache(
             rocksDBServerConfig.getRocksDBRMDBlockCacheSizeInBytes(),
             rocksDBServerConfig.getRocksDBBlockCacheShardBits(),
             rocksDBServerConfig.getRocksDBBlockCacheStrictCapacityLimit(),
-            rocksDBServerConfig.getCacheHighPriorityPoolRatio());
+            rocksDBServerConfig.getBlockCacheHighPriorityPoolRatio());
       }
     }
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/RocksDBStorageEngineFactory.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/RocksDBStorageEngineFactory.java
@@ -146,12 +146,14 @@ public class RocksDBStorageEngineFactory extends StorageEngineFactory {
       this.sharedCache = new LRUCache(
           rocksDBServerConfig.getRocksDBBlockCacheSizeInBytes(),
           rocksDBServerConfig.getRocksDBBlockCacheShardBits(),
-          rocksDBServerConfig.getRocksDBBlockCacheStrictCapacityLimit());
+          rocksDBServerConfig.getRocksDBBlockCacheStrictCapacityLimit(),
+          rocksDBServerConfig.getCacheHighPriorityPoolRatio());
       if (rocksDBServerConfig.isUseSeparateRMDCacheEnabled()) {
         this.sharedRMDCache = new LRUCache(
             rocksDBServerConfig.getRocksDBRMDBlockCacheSizeInBytes(),
             rocksDBServerConfig.getRocksDBBlockCacheShardBits(),
-            rocksDBServerConfig.getRocksDBBlockCacheStrictCapacityLimit());
+            rocksDBServerConfig.getRocksDBBlockCacheStrictCapacityLimit(),
+            rocksDBServerConfig.getCacheHighPriorityPoolRatio());
       }
     }
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/RocksDBStoragePartition.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/RocksDBStoragePartition.java
@@ -203,7 +203,7 @@ public class RocksDBStoragePartition extends AbstractStoragePartition {
      */
     ColumnFamilyOptions columnFamilyOptions;
     for (byte[] name: columnFamilyNameList) {
-      if (name == REPLICATION_METADATA_COLUMN_FAMILY && !rocksDBServerConfig.isRocksDBPlainTableFormatEnabled()) {
+      if (name == REPLICATION_METADATA_COLUMN_FAMILY) {
         columnFamilyOptions = new ColumnFamilyOptions(getStoreOptions(storagePartitionConfig, true));
       } else {
         columnFamilyOptions = new ColumnFamilyOptions(options);

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/RocksDBStoragePartition.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/RocksDBStoragePartition.java
@@ -348,7 +348,7 @@ public class RocksDBStoragePartition extends AbstractStoragePartition {
 
     aggStatistics.ifPresent(options::setStatistics);
 
-    if (rocksDBServerConfig.isRocksDBPlainTableFormatEnabled()) {
+    if (rocksDBServerConfig.isRocksDBPlainTableFormatEnabled() && !isRMD) {
       PlainTableConfig tableConfig = new PlainTableConfig();
       tableConfig.setStoreIndexInFile(rocksDBServerConfig.isRocksDBStoreIndexInFile());
       tableConfig.setHugePageTlbSize(rocksDBServerConfig.getRocksDBHugePageTlbSize());
@@ -363,6 +363,8 @@ public class RocksDBStoragePartition extends AbstractStoragePartition {
       tableConfig.setBlockSize(rocksDBServerConfig.getRocksDBSSTFileBlockSizeInBytes());
       tableConfig.setBlockCache(factory.getSharedCache(isRMD));
       tableConfig.setCacheIndexAndFilterBlocks(rocksDBServerConfig.isRocksDBSetCacheIndexAndFilterBlocks());
+      tableConfig.setCacheIndexAndFilterBlocksWithHighPriority(true);
+      tableConfig.setPinL0FilterAndIndexBlocksInCache(true);
 
       // TODO Consider Adding "cache_index_and_filter_blocks_with_high_priority" to allow for preservation of indexes in
       // memory.

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/RocksDBStoragePartition.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/RocksDBStoragePartition.java
@@ -199,12 +199,13 @@ public class RocksDBStoragePartition extends AbstractStoragePartition {
 
     /**
      * There are some possible optimization opportunities for column families. For example, optimizeForSmallDb() option
-     * may be applied if we are sure replicationMetadata column family is smaller in size.
+     * may be applied if we are sure replicationMetadata column family is smaller.
      */
     ColumnFamilyOptions columnFamilyOptions;
     for (byte[] name: columnFamilyNameList) {
       if (name == REPLICATION_METADATA_COLUMN_FAMILY) {
-        columnFamilyOptions = new ColumnFamilyOptions(getStoreOptions(storagePartitionConfig, true));
+        columnFamilyOptions = new ColumnFamilyOptions(
+            getStoreOptions(storagePartitionConfig, rocksDBServerConfig.isRocksDBBlockCacheRMDEnabled()));
       } else {
         columnFamilyOptions = new ColumnFamilyOptions(options);
       }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/ActiveActiveReplicationForHybridTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/ActiveActiveReplicationForHybridTest.java
@@ -137,7 +137,7 @@ public class ActiveActiveReplicationForHybridTest {
      */
     serverProperties = new Properties();
     serverProperties.put(SERVER_PROMOTION_TO_LEADER_REPLICA_DELAY_SECONDS, 1L);
-    serverProperties.put(ROCKSDB_PLAIN_TABLE_FORMAT_ENABLED, false);
+    serverProperties.put(ROCKSDB_PLAIN_TABLE_FORMAT_ENABLED, true);
     serverProperties.put(SERVER_DATABASE_CHECKSUM_VERIFICATION_ENABLED, true);
     serverProperties.put(SERVER_DATABASE_SYNC_BYTES_INTERNAL_FOR_DEFERRED_WRITE_MODE, "300");
     serverProperties.put(SERVER_SHARED_KAFKA_PRODUCER_ENABLED, true);

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestActiveActiveIngestion.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestActiveActiveIngestion.java
@@ -123,7 +123,7 @@ public class TestActiveActiveIngestion {
     serializer = new AvroSerializer(AvroCompatibilityHelper.parse(stringSchemaStr));
     Properties serverProperties = new Properties();
     serverProperties.setProperty(ConfigKeys.SERVER_PROMOTION_TO_LEADER_REPLICA_DELAY_SECONDS, Long.toString(1));
-    serverProperties.put(ROCKSDB_PLAIN_TABLE_FORMAT_ENABLED, false);
+    serverProperties.put(ROCKSDB_PLAIN_TABLE_FORMAT_ENABLED, true);
     serverProperties.put(
         CHILD_DATA_CENTER_KAFKA_URL_PREFIX + "." + DEFAULT_PARENT_DATA_CENTER_REGION_NAME,
         "localhost:" + TestUtils.getFreePort());

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestPartialUpdateWithActiveActiveReplication.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestPartialUpdateWithActiveActiveReplication.java
@@ -120,7 +120,7 @@ public class TestPartialUpdateWithActiveActiveReplication {
   public void setUp() throws IOException {
     Properties serverProperties = new Properties();
     serverProperties.put(SERVER_PROMOTION_TO_LEADER_REPLICA_DELAY_SECONDS, 1L);
-    serverProperties.put(ROCKSDB_PLAIN_TABLE_FORMAT_ENABLED, false);
+    serverProperties.put(ROCKSDB_PLAIN_TABLE_FORMAT_ENABLED, true);
 
     Properties controllerProps = new Properties();
     controllerProps.put(DEFAULT_MAX_NUMBER_OF_PARTITIONS, 1);


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci], [server], [controller],
[router], [samza], [vpj], [fast-client], [thin-client], [alpini],
[admin-tool], [test], [build], [doc], [script]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

##  Use block cache for RMD column family in PlainTable format 

<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
Use block cache for RMD column family in PlainTable format as its used only in write path and need not be stored in memory as plain table. Also added more configs to control pool ratios for index blocks, currently it is enabling the `cacheIndexAndFilterBlocksWithHighPriority` but the the `LRUCache` is constructed with `highPriPoolRatio` set to 0. 
Setting default `highPriPoolRatio` to be 0.1, but probably needs tuning. 


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.