### PR TITLE
[router] Added openssl support to Router http client and removed Kafka openssl support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,7 +61,7 @@ ext.libraries = [
     commonsIo: 'commons-io:commons-io:2.11.0',
     commonsCli: 'commons-cli:commons-cli:1.5.0',
     commonsLang: 'commons-lang:commons-lang:2.6',
-    conscrypt: 'org.conscrypt:conscrypt-openjdk-uber:2.4.0',
+    conscrypt: 'org.conscrypt:conscrypt-openjdk-uber:2.5.2',
     d2: 'com.linkedin.pegasus:d2:' + pegasusVersion,
     failsafe: 'net.jodah:failsafe:2.4.0',
     fastUtil: 'it.unimi.dsi:fastutil:8.3.0',

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/client/AvroGenericDaVinciClient.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/client/AvroGenericDaVinciClient.java
@@ -11,7 +11,6 @@ import static com.linkedin.venice.ConfigKeys.CLUSTER_NAME;
 import static com.linkedin.venice.ConfigKeys.INGESTION_USE_DA_VINCI_CLIENT;
 import static com.linkedin.venice.ConfigKeys.KAFKA_ADMIN_CLASS;
 import static com.linkedin.venice.ConfigKeys.KAFKA_BOOTSTRAP_SERVERS;
-import static com.linkedin.venice.ConfigKeys.SERVER_ENABLE_KAFKA_OPENSSL;
 import static com.linkedin.venice.ConfigKeys.ZOOKEEPER_ADDRESS;
 import static com.linkedin.venice.client.store.ClientFactory.getAndStartAvroClient;
 import static com.linkedin.venice.client.store.ClientFactory.getTransportClient;
@@ -644,7 +643,6 @@ public class AvroGenericDaVinciClient<K, V> implements DaVinciClient<K, V>, Avro
       kafkaBootstrapServers = backendConfig.getString(KAFKA_BOOTSTRAP_SERVERS);
     }
     VeniceProperties config = new PropertyBuilder().put(KAFKA_ADMIN_CLASS, ApacheKafkaAdminAdapter.class.getName())
-        .put(SERVER_ENABLE_KAFKA_OPENSSL, false)
         .put(ROCKSDB_LEVEL0_FILE_NUM_COMPACTION_TRIGGER, 4) // RocksDB default config
         .put(ROCKSDB_LEVEL0_SLOWDOWN_WRITES_TRIGGER, 20) // RocksDB default config
         .put(ROCKSDB_LEVEL0_STOPS_WRITES_TRIGGER, 36) // RocksDB default config

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
@@ -39,7 +39,6 @@ import static com.linkedin.venice.ConfigKeys.SERVER_DISK_FULL_THRESHOLD;
 import static com.linkedin.venice.ConfigKeys.SERVER_DISK_HEALTH_CHECK_INTERVAL_IN_SECONDS;
 import static com.linkedin.venice.ConfigKeys.SERVER_DISK_HEALTH_CHECK_SERVICE_ENABLED;
 import static com.linkedin.venice.ConfigKeys.SERVER_DISK_HEALTH_CHECK_TIMEOUT_IN_SECONDS;
-import static com.linkedin.venice.ConfigKeys.SERVER_ENABLE_KAFKA_OPENSSL;
 import static com.linkedin.venice.ConfigKeys.SERVER_ENABLE_LIVE_CONFIG_BASED_KAFKA_THROTTLING;
 import static com.linkedin.venice.ConfigKeys.SERVER_ENABLE_PARALLEL_BATCH_GET;
 import static com.linkedin.venice.ConfigKeys.SERVER_HTTP2_HEADER_TABLE_SIZE;
@@ -313,7 +312,6 @@ public class VeniceServerConfig extends VeniceClusterConfig {
   private final String kafkaAdminClass;
   private final String kafkaWriteOnlyClass;
   private final String kafkaReadOnlyClass;
-  private final boolean kafkaOpenSSLEnabled;
   private final long routerConnectionWarmingDelayMs;
   private final boolean helixHybridStoreQuotaEnabled;
   private final long ssdHealthCheckShutdownTimeMs;
@@ -487,7 +485,6 @@ public class VeniceServerConfig extends VeniceClusterConfig {
             .put(storeName, Integer.parseInt(thresholdStr.trim())));
     databaseLookupQueueCapacity = serverProperties.getInt(SERVER_DATABASE_LOOKUP_QUEUE_CAPACITY, Integer.MAX_VALUE);
     computeQueueCapacity = serverProperties.getInt(SERVER_COMPUTE_QUEUE_CAPACITY, Integer.MAX_VALUE);
-    kafkaOpenSSLEnabled = serverProperties.getBoolean(SERVER_ENABLE_KAFKA_OPENSSL, false);
     helixHybridStoreQuotaEnabled = serverProperties.getBoolean(HELIX_HYBRID_STORE_QUOTA_ENABLED, false);
     ssdHealthCheckShutdownTimeMs = serverProperties.getLong(SERVER_SHUTDOWN_DISK_UNHEALTHY_TIME_MS, 200000);
     sslHandshakeThreadPoolSize = serverProperties.getInt(SERVER_SSL_HANDSHAKE_THREAD_POOL_SIZE, 0);
@@ -834,10 +831,6 @@ public class VeniceServerConfig extends VeniceClusterConfig {
 
   public String getKafkaReadOnlyClass() {
     return kafkaReadOnlyClass;
-  }
-
-  public boolean isKafkaOpenSSLEnabled() {
-    return kafkaOpenSSLEnabled;
   }
 
   public long getRouterConnectionWarmingDelayMs() {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionService.java
@@ -2,7 +2,6 @@ package com.linkedin.davinci.kafka.consumer;
 
 import static com.linkedin.venice.ConfigConstants.DEFAULT_KAFKA_BATCH_SIZE;
 import static com.linkedin.venice.ConfigConstants.DEFAULT_KAFKA_LINGER_MS;
-import static com.linkedin.venice.ConfigConstants.DEFAULT_KAFKA_SSL_CONTEXT_PROVIDER_CLASS_NAME;
 import static com.linkedin.venice.ConfigConstants.DEFAULT_TOPIC_DELETION_STATUS_POLL_INTERVAL_MS;
 import static com.linkedin.venice.ConfigKeys.KAFKA_AUTO_OFFSET_RESET_CONFIG;
 import static com.linkedin.venice.ConfigKeys.KAFKA_BATCH_SIZE;
@@ -20,7 +19,6 @@ import static com.linkedin.venice.kafka.TopicManager.DEFAULT_KAFKA_MIN_LOG_COMPA
 import static com.linkedin.venice.kafka.TopicManager.DEFAULT_KAFKA_OPERATION_TIMEOUT_MS;
 import static java.lang.Thread.currentThread;
 import static java.lang.Thread.sleep;
-import static org.apache.kafka.common.config.SslConfigs.SSL_CONTEXT_PROVIDER_CLASS_CONFIG;
 
 import com.linkedin.davinci.compression.StorageEngineBackedCompressorFactory;
 import com.linkedin.davinci.config.VeniceConfigLoader;
@@ -250,10 +248,6 @@ public class KafkaStoreIngestionService extends AbstractVeniceService implements
     VeniceServerConfig serverConfig = veniceConfigLoader.getVeniceServerConfig();
     Properties veniceWriterProperties =
         veniceConfigLoader.getVeniceClusterConfig().getClusterProperties().toProperties();
-    if (serverConfig.isKafkaOpenSSLEnabled()) {
-      veniceWriterProperties
-          .setProperty(SSL_CONTEXT_PROVIDER_CLASS_CONFIG, DEFAULT_KAFKA_SSL_CONTEXT_PROVIDER_CLASS_NAME);
-    }
 
     /**
      * Setup default batch size and linger time for better producing performance during server new push ingestion.
@@ -1057,12 +1051,6 @@ public class KafkaStoreIngestionService extends AbstractVeniceService implements
         throw new VeniceException("SSLConfig should be present when Kafka SSL is enabled");
       }
       properties.putAll(sslConfig.get().getKafkaSSLConfig());
-      /**
-       * Check whether openssl is enabled for the kafka consumers in ingestion service.
-       */
-      if (serverConfig.isKafkaOpenSSLEnabled()) {
-        properties.setProperty(SSL_CONTEXT_PROVIDER_CLASS_CONFIG, DEFAULT_KAFKA_SSL_CONTEXT_PROVIDER_CLASS_NAME);
-      }
     }
     properties.setProperty(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, securityProtocol.name);
     return new VeniceProperties(properties);

--- a/internal/venice-client-common/build.gradle
+++ b/internal/venice-client-common/build.gradle
@@ -38,6 +38,7 @@ dependencies {
   implementation libraries.failsafe
   implementation libraries.log4j2api
   implementation libraries.zstd
+  implementation libraries.conscrypt
 
   testImplementation project(':internal:venice-test-common')
   testImplementation project(':clients:venice-thin-client')

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/utils/SslUtilsTest.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/utils/SslUtilsTest.java
@@ -1,0 +1,40 @@
+package com.linkedin.venice.utils;
+
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+import com.linkedin.venice.security.SSLFactory;
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
+import org.conscrypt.Conscrypt;
+import org.testng.annotations.Test;
+
+
+public class SslUtilsTest {
+  private static Logger LOGGER = LogManager.getLogger(SslUtilsTest.class);
+
+  @Test
+  public void testIsConscryptAvailable() {
+    String osName = System.getProperty("os.name");
+    String osArch = System.getProperty("os.arch");
+    if (osName.equalsIgnoreCase("MAC OS X") && osArch.equalsIgnoreCase("aarch64")) {
+      assertFalse(SslUtils.isConscryptAvailable(), "Conscrypt shouldn't be available for MAC OS X with aarch64");
+    }
+    if (osName.equalsIgnoreCase("linux") && osArch.contains("64")) {
+      assertTrue(SslUtils.isConscryptAvailable(), "Conscrypt shouldn be available for 64-bit Linux");
+    }
+  }
+
+  @Test
+  public void testSSLFactoryWithOpensslSupport() {
+    SSLFactory sslFactory = SslUtils.getVeniceLocalSslFactory();
+    if (SslUtils.isConscryptAvailable()) {
+      SSLFactory adaptedSSLFactory = SslUtils.toSSLFactoryWithOpenSSLSupport(sslFactory);
+      assertTrue(
+          Conscrypt.isConscrypt(adaptedSSLFactory.getSSLContext()),
+          "The adapted SSLContext should be backed by openssl");
+    } else {
+      LOGGER.info("testSSLFactoryWithOpensslSupport will be skipped since 'Conscrypt' is not available");
+    }
+  }
+}

--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigConstants.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigConstants.java
@@ -1,11 +1,8 @@
 package com.linkedin.venice;
 
 import com.linkedin.venice.utils.Time;
-import java.util.function.Supplier;
-import org.apache.kafka.common.config.SslConfigs;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.conscrypt.Conscrypt;
 
 
 public class ConfigConstants {
@@ -28,24 +25,6 @@ public class ConfigConstants {
    */
 
   // Start of server config default value
-
-  /**
-   * Default Kafka SSL context provider class name.
-   *
-   * {@link org.apache.kafka.common.security.ssl.BoringSslContextProvider} supports openssl.
-   * BoringSSL is the c implementation of OpenSSL, and conscrypt add a java wrapper around BoringSSL.
-   * The default BoringSslContextProvider mainly relies on conscrypt.
-   */
-  public static final String DEFAULT_KAFKA_SSL_CONTEXT_PROVIDER_CLASS_NAME = ((Supplier<String>) () -> {
-    try {
-      Conscrypt.checkAvailability();
-      return "org.apache.kafka.common.security.ssl.BoringSslContextProvider";
-    } catch (UnsatisfiedLinkError e) {
-      LOGGER.warn("Conscrypt is not available, falling back to {}", SslConfigs.DEFAULT_SSL_CONTEXT_PROVIDER_CLASS, e);
-      return SslConfigs.DEFAULT_SSL_CONTEXT_PROVIDER_CLASS;
-    }
-  }).get();
-
   /**
    * Default Kafka batch size and linger time for better producer performance during ingestion.
    */

--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -549,11 +549,6 @@ public class ConfigKeys {
   public static final String SERVER_BLOCKING_QUEUE_TYPE = "server.blocking.queue.type";
 
   /**
-   * This config is used to control whether openssl is enabled for Kafka consumers in server.
-   */
-  public static final String SERVER_ENABLE_KAFKA_OPENSSL = "server.enable.kafka.openssl";
-
-  /**
    * This config is used to control how much time Server will wait for connection warming from Routers.
    * This is trying to avoid availability issue when router connection warming happens when Server restarts.
    * In theory, this config should be equal to or bigger than {@link #ROUTER_HTTPASYNCCLIENT_CONNECTION_WARMING_NEW_INSTANCE_DELAY_JOIN_MS}.
@@ -1401,6 +1396,11 @@ public class ConfigKeys {
    * header field.
    */
   public static final String ROUTER_HTTP2_MAX_HEADER_LIST_SIZE = "router.http2.max.header.list.size";
+
+  /**
+   * Whether to enable openssl in the Router http client when talking to server.
+   */
+  public static final String ROUTER_HTTP_CLIENT_OPENSSL_ENABLED = "router.http.client.openssl.enabled";
 
   /**
    * In Leader/Follower state transition model, in order to avoid split brain problem (multiple leaders) as much as possible,

--- a/internal/venice-common/src/main/java/com/linkedin/venice/utils/KafkaSSLUtils.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/utils/KafkaSSLUtils.java
@@ -1,6 +1,5 @@
 package com.linkedin.venice.utils;
 
-import static com.linkedin.venice.ConfigConstants.DEFAULT_KAFKA_SSL_CONTEXT_PROVIDER_CLASS_NAME;
 import static com.linkedin.venice.utils.SslUtils.LOCAL_KEYSTORE_JKS;
 import static com.linkedin.venice.utils.SslUtils.LOCAL_PASSWORD;
 
@@ -37,7 +36,6 @@ public class KafkaSSLUtils {
     // Listen on two ports, one for ssl one for non-ssl
     properties.put(KafkaConfig.ListenersProp(), "PLAINTEXT://" + host + ":" + port + ",SSL://" + host + ":" + sslPort);
     properties.putAll(getLocalCommonKafkaSSLConfig());
-    properties.put(SslConfigs.SSL_CONTEXT_PROVIDER_CLASS_CONFIG, DEFAULT_KAFKA_SSL_CONTEXT_PROVIDER_CLASS_NAME);
     return properties;
   }
 

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/integration/utils/VeniceClusterCreateOptions.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/integration/utils/VeniceClusterCreateOptions.java
@@ -36,7 +36,6 @@ public class VeniceClusterCreateOptions {
   private final boolean enableAutoJoinAllowlist;
   private final boolean sslToStorageNodes;
   private final boolean sslToKafka;
-  private final boolean isKafkaOpenSSLEnabled;
   private final boolean forkServer;
   private final Properties extraProperties;
   private final Map<String, Map<String, String>> kafkaClusterMap;
@@ -62,7 +61,6 @@ public class VeniceClusterCreateOptions {
     this.enableAutoJoinAllowlist = builder.enableAutoJoinAllowlist;
     this.sslToStorageNodes = builder.sslToStorageNodes;
     this.sslToKafka = builder.sslToKafka;
-    this.isKafkaOpenSSLEnabled = builder.isKafkaOpenSSLEnabled;
     this.forkServer = builder.forkServer;
     this.extraProperties = builder.extraProperties;
     this.kafkaClusterMap = builder.kafkaClusterMap;
@@ -142,10 +140,6 @@ public class VeniceClusterCreateOptions {
     return sslToKafka;
   }
 
-  public boolean isKafkaOpenSSLEnabled() {
-    return isKafkaOpenSSLEnabled;
-  }
-
   public boolean isForkServer() {
     return forkServer;
   }
@@ -217,9 +211,6 @@ public class VeniceClusterCreateOptions {
         .append("sslToKafka:")
         .append(sslToKafka)
         .append(", ")
-        .append("isKafkaOpenSSLEnabled:")
-        .append(isKafkaOpenSSLEnabled)
-        .append(", ")
         .append("forkServer:")
         .append(forkServer)
         .append(", ")
@@ -262,7 +253,6 @@ public class VeniceClusterCreateOptions {
     private boolean enableAutoJoinAllowlist;
     private boolean sslToStorageNodes = DEFAULT_SSL_TO_STORAGE_NODES;
     private boolean sslToKafka = DEFAULT_SSL_TO_KAFKA;
-    private boolean isKafkaOpenSSLEnabled = false;
     private boolean forkServer;
     private boolean isMinActiveReplicaSet = false;
     private Properties extraProperties;
@@ -358,11 +348,6 @@ public class VeniceClusterCreateOptions {
 
     public Builder sslToKafka(boolean sslToKafka) {
       this.sslToKafka = sslToKafka;
-      return this;
-    }
-
-    public Builder isKafkaOpenSSLEnabled(boolean isKafkaOpenSSLEnabled) {
-      this.isKafkaOpenSSLEnabled = isKafkaOpenSSLEnabled;
       return this;
     }
 

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/integration/utils/VeniceClusterWrapper.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/integration/utils/VeniceClusterWrapper.java
@@ -252,7 +252,6 @@ public class VeniceClusterWrapper extends ProcessWrapper {
               .setSslFactory(SslUtils.getVeniceLocalSslFactory());
           featureProperties.put(CLIENT_CONFIG_FOR_CONSUMER, clientConfig);
         }
-        featureProperties.setProperty(SERVER_ENABLE_KAFKA_OPENSSL, Boolean.toString(options.isKafkaOpenSSLEnabled()));
 
         String serverName = "";
         if (!options.getRegionName().isEmpty() && !options.getClusterName().isEmpty()) {

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/integration/utils/VeniceServerWrapper.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/integration/utils/VeniceServerWrapper.java
@@ -13,7 +13,6 @@ import static com.linkedin.venice.ConfigKeys.MAX_ONLINE_OFFLINE_STATE_TRANSITION
 import static com.linkedin.venice.ConfigKeys.PARTICIPANT_MESSAGE_CONSUMPTION_DELAY_MS;
 import static com.linkedin.venice.ConfigKeys.PERSISTENCE_TYPE;
 import static com.linkedin.venice.ConfigKeys.SERVER_DISK_FULL_THRESHOLD;
-import static com.linkedin.venice.ConfigKeys.SERVER_ENABLE_KAFKA_OPENSSL;
 import static com.linkedin.venice.ConfigKeys.SERVER_HTTP2_INBOUND_ENABLED;
 import static com.linkedin.venice.ConfigKeys.SERVER_INGESTION_ISOLATION_APPLICATION_PORT;
 import static com.linkedin.venice.ConfigKeys.SERVER_INGESTION_ISOLATION_SERVICE_PORT;
@@ -185,8 +184,6 @@ public class VeniceServerWrapper extends ProcessWrapper implements MetricsAware 
       boolean enableServerAllowlist =
           Boolean.parseBoolean(featureProperties.getProperty(SERVER_ENABLE_SERVER_ALLOW_LIST, "false"));
       boolean sslToKafka = Boolean.parseBoolean(featureProperties.getProperty(SERVER_SSL_TO_KAFKA, "false"));
-      boolean isKafkaOpenSSLEnabled =
-          Boolean.parseBoolean(featureProperties.getProperty(SERVER_ENABLE_KAFKA_OPENSSL, "false"));
       boolean ssl = Boolean.parseBoolean(featureProperties.getProperty(SERVER_ENABLE_SSL, "false"));
       boolean isAutoJoin = Boolean.parseBoolean(featureProperties.getProperty(SERVER_IS_AUTO_JOIN, "false"));
       ClientConfig consumerClientConfig = (ClientConfig) featureProperties.get(CLIENT_CONFIG_FOR_CONSUMER);
@@ -229,9 +226,6 @@ public class VeniceServerWrapper extends ProcessWrapper implements MetricsAware 
       if (sslToKafka) {
         serverPropsBuilder.put(KAFKA_SECURITY_PROTOCOL, SecurityProtocol.SSL.name);
         serverPropsBuilder.put(KafkaSSLUtils.getLocalCommonKafkaSSLConfig());
-        if (isKafkaOpenSSLEnabled) {
-          serverPropsBuilder.put(SERVER_ENABLE_KAFKA_OPENSSL, true);
-        }
       }
 
       VeniceProperties serverProps = serverPropsBuilder.build();

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/kafka/ssl/TestProduceWithSSL.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/kafka/ssl/TestProduceWithSSL.java
@@ -19,7 +19,6 @@ import com.linkedin.venice.hadoop.input.kafka.KafkaInputRecordReader;
 import com.linkedin.venice.integration.utils.ServiceFactory;
 import com.linkedin.venice.integration.utils.VeniceClusterCreateOptions;
 import com.linkedin.venice.integration.utils.VeniceClusterWrapper;
-import com.linkedin.venice.utils.DataProviderUtils;
 import com.linkedin.venice.utils.KafkaSSLUtils;
 import com.linkedin.venice.utils.SslUtils;
 import com.linkedin.venice.utils.TestUtils;
@@ -54,8 +53,7 @@ public class TestProduceWithSSL {
   @BeforeClass
   public void setUp() {
     Utils.thisIsLocalhost();
-    VeniceClusterCreateOptions options =
-        new VeniceClusterCreateOptions.Builder().sslToKafka(true).isKafkaOpenSSLEnabled(false).build();
+    VeniceClusterCreateOptions options = new VeniceClusterCreateOptions.Builder().sslToKafka(true).build();
     cluster = ServiceFactory.getVeniceCluster(options);
   }
 
@@ -107,105 +105,94 @@ public class TestProduceWithSSL {
     }
   }
 
-  @Test(dataProvider = "True-and-False", dataProviderClass = DataProviderUtils.class, timeOut = 90 * Time.MS_PER_SECOND)
-  public void testVenicePushJobSupportSSL(boolean isOpenSSLEnabled) throws Exception {
+  @Test(timeOut = 90 * Time.MS_PER_SECOND)
+  public void testVenicePushJobSupportSSL() throws Exception {
     VeniceClusterWrapper cluster = this.cluster;
-    try {
-      if (isOpenSSLEnabled) {
-        VeniceClusterCreateOptions options =
-            new VeniceClusterCreateOptions.Builder().sslToKafka(true).isKafkaOpenSSLEnabled(true).build();
-        cluster = ServiceFactory.getVeniceCluster(options);
-      }
-      File inputDir = getTempDataDirectory();
-      String storeName = Utils.getUniqueString("store");
-      Schema recordSchema = writeSimpleAvroFileWithUserSchema(inputDir);
-      String inputDirPath = "file://" + inputDir.getAbsolutePath();
-      Properties props = sslVPJProps(cluster, inputDirPath, storeName);
+    File inputDir = getTempDataDirectory();
+    String storeName = Utils.getUniqueString("store");
+    Schema recordSchema = writeSimpleAvroFileWithUserSchema(inputDir);
+    String inputDirPath = "file://" + inputDir.getAbsolutePath();
+    Properties props = sslVPJProps(cluster, inputDirPath, storeName);
 
-      String keyStorePropertyName = "ssl.identity";
-      String trustStorePropertyName = "ssl.truststore";
-      String keyStorePwdPropertyName = "ssl.identity.keystore.password";
-      String keyPwdPropertyName = "ssl.identity.key.password";
+    String keyStorePropertyName = "ssl.identity";
+    String trustStorePropertyName = "ssl.truststore";
+    String keyStorePwdPropertyName = "ssl.identity.keystore.password";
+    String keyPwdPropertyName = "ssl.identity.key.password";
 
-      props.setProperty(VenicePushJob.ENABLE_SSL, Boolean.TRUE.toString());
-      props.setProperty(VenicePushJob.SSL_KEY_STORE_PROPERTY_NAME, keyStorePropertyName);
-      props.setProperty(VenicePushJob.SSL_TRUST_STORE_PROPERTY_NAME, trustStorePropertyName);
-      props.setProperty(VenicePushJob.SSL_KEY_STORE_PASSWORD_PROPERTY_NAME, keyStorePwdPropertyName);
-      props.setProperty(VenicePushJob.SSL_KEY_PASSWORD_PROPERTY_NAME, keyPwdPropertyName);
-      props.setProperty(
-          KafkaInputRecordReader.KIF_RECORD_READER_KAFKA_CONFIG_PREFIX + "send.buffer.bytes",
-          Integer.toString(4 * 1024 * 1024));
+    props.setProperty(VenicePushJob.ENABLE_SSL, Boolean.TRUE.toString());
+    props.setProperty(VenicePushJob.SSL_KEY_STORE_PROPERTY_NAME, keyStorePropertyName);
+    props.setProperty(VenicePushJob.SSL_TRUST_STORE_PROPERTY_NAME, trustStorePropertyName);
+    props.setProperty(VenicePushJob.SSL_KEY_STORE_PASSWORD_PROPERTY_NAME, keyStorePwdPropertyName);
+    props.setProperty(VenicePushJob.SSL_KEY_PASSWORD_PROPERTY_NAME, keyPwdPropertyName);
+    props.setProperty(
+        KafkaInputRecordReader.KIF_RECORD_READER_KAFKA_CONFIG_PREFIX + "send.buffer.bytes",
+        Integer.toString(4 * 1024 * 1024));
 
-      // put cert into hadoop user credentials.
-      Properties sslProps = KafkaSSLUtils.getLocalCommonKafkaSSLConfig();
-      byte[] keyStoreCert = readFile(sslProps.getProperty(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG));
-      byte[] trustStoreCert = readFile(sslProps.getProperty(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG));
-      Credentials credentials = new Credentials();
-      credentials.addSecretKey(new Text(keyStorePropertyName), keyStoreCert);
-      credentials.addSecretKey(new Text(trustStorePropertyName), trustStoreCert);
-      credentials.addSecretKey(
-          new Text(keyStorePwdPropertyName),
-          sslProps.getProperty(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG).getBytes(StandardCharsets.UTF_8));
-      credentials.addSecretKey(
-          new Text(keyPwdPropertyName),
-          sslProps.getProperty(SslConfigs.SSL_KEY_PASSWORD_CONFIG).getBytes(StandardCharsets.UTF_8));
-      UserGroupInformation.getCurrentUser().addCredentials(credentials);
-      // Setup token file
-      String filePath = getTempDataDirectory().getAbsolutePath() + "/testHadoopToken";
-      credentials.writeTokenStorageFile(new Path(filePath), new Configuration());
-      System.setProperty(UserGroupInformation.HADOOP_TOKEN_FILE_LOCATION, filePath);
+    // put cert into hadoop user credentials.
+    Properties sslProps = KafkaSSLUtils.getLocalCommonKafkaSSLConfig();
+    byte[] keyStoreCert = readFile(sslProps.getProperty(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG));
+    byte[] trustStoreCert = readFile(sslProps.getProperty(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG));
+    Credentials credentials = new Credentials();
+    credentials.addSecretKey(new Text(keyStorePropertyName), keyStoreCert);
+    credentials.addSecretKey(new Text(trustStorePropertyName), trustStoreCert);
+    credentials.addSecretKey(
+        new Text(keyStorePwdPropertyName),
+        sslProps.getProperty(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG).getBytes(StandardCharsets.UTF_8));
+    credentials.addSecretKey(
+        new Text(keyPwdPropertyName),
+        sslProps.getProperty(SslConfigs.SSL_KEY_PASSWORD_CONFIG).getBytes(StandardCharsets.UTF_8));
+    UserGroupInformation.getCurrentUser().addCredentials(credentials);
+    // Setup token file
+    String filePath = getTempDataDirectory().getAbsolutePath() + "/testHadoopToken";
+    credentials.writeTokenStorageFile(new Path(filePath), new Configuration());
+    System.setProperty(UserGroupInformation.HADOOP_TOKEN_FILE_LOCATION, filePath);
 
-      Assert.assertEquals(System.getProperty(UserGroupInformation.HADOOP_TOKEN_FILE_LOCATION), filePath);
+    Assert.assertEquals(System.getProperty(UserGroupInformation.HADOOP_TOKEN_FILE_LOCATION), filePath);
 
-      createStoreForJob(cluster.getClusterName(), recordSchema, props).close();
-      String controllerUrl = cluster.getAllControllersURLs();
-      ControllerClient controllerClient = new ControllerClient(cluster.getClusterName(), controllerUrl);
-      Assert.assertEquals(
-          controllerClient.getStore(storeName).getStore().getCurrentVersion(),
-          0,
-          "Push has not been start, current should be 0");
+    createStoreForJob(cluster.getClusterName(), recordSchema, props).close();
+    String controllerUrl = cluster.getAllControllersURLs();
+    ControllerClient controllerClient = new ControllerClient(cluster.getClusterName(), controllerUrl);
+    Assert.assertEquals(
+        controllerClient.getStore(storeName).getStore().getCurrentVersion(),
+        0,
+        "Push has not been start, current should be 0");
 
-      // First push to verify regular push job works fine
-      TestWriteUtils.runPushJob("Test push job", props);
-      TestUtils.waitForNonDeterministicCompletion(30, TimeUnit.SECONDS, () -> {
-        int currentVersion = controllerClient.getStore(storeName).getStore().getCurrentVersion();
-        return currentVersion == 1;
-      });
+    // First push to verify regular push job works fine
+    TestWriteUtils.runPushJob("Test push job", props);
+    TestUtils.waitForNonDeterministicCompletion(30, TimeUnit.SECONDS, () -> {
+      int currentVersion = controllerClient.getStore(storeName).getStore().getCurrentVersion();
+      return currentVersion == 1;
+    });
 
-      // Re-push with Kafka Input Format
-      props.setProperty(VenicePushJob.SOURCE_KAFKA, "true");
-      props.setProperty(VenicePushJob.KAFKA_INPUT_BROKER_URL, cluster.getKafka().getSSLAddress());
-      TestWriteUtils.runPushJob("Test Kafka re-push job", props);
-      TestUtils.waitForNonDeterministicCompletion(30, TimeUnit.SECONDS, () -> {
-        int currentVersion = controllerClient.getStore(storeName).getStore().getCurrentVersion();
-        return currentVersion == 2;
-      });
+    // Re-push with Kafka Input Format
+    props.setProperty(VenicePushJob.SOURCE_KAFKA, "true");
+    props.setProperty(VenicePushJob.KAFKA_INPUT_BROKER_URL, cluster.getKafka().getSSLAddress());
+    TestWriteUtils.runPushJob("Test Kafka re-push job", props);
+    TestUtils.waitForNonDeterministicCompletion(30, TimeUnit.SECONDS, () -> {
+      int currentVersion = controllerClient.getStore(storeName).getStore().getCurrentVersion();
+      return currentVersion == 2;
+    });
 
-      // Enable dictionary compression and do a regular push
-      ControllerResponse response = controllerClient.updateStore(
-          storeName,
-          new UpdateStoreQueryParams().setCompressionStrategy(CompressionStrategy.ZSTD_WITH_DICT));
-      if (response.isError()) {
-        throw new VeniceException(response.getError());
-      }
-      props.setProperty(VenicePushJob.SOURCE_KAFKA, "false");
-      TestWriteUtils.runPushJob("Test push job with dictionary compression", props);
-      TestUtils.waitForNonDeterministicCompletion(30, TimeUnit.SECONDS, () -> {
-        int currentVersion = controllerClient.getStore(storeName).getStore().getCurrentVersion();
-        return currentVersion == 3;
-      });
-
-      // Re-push with Kafka Input Format and dictionary compression enabled
-      props.setProperty(VenicePushJob.SOURCE_KAFKA, "true");
-      TestWriteUtils.runPushJob("Test Kafka re-push job with dictionary compression", props);
-      TestUtils.waitForNonDeterministicCompletion(30, TimeUnit.SECONDS, () -> {
-        int currentVersion = controllerClient.getStore(storeName).getStore().getCurrentVersion();
-        return currentVersion == 4;
-      });
-    } finally {
-      if (isOpenSSLEnabled) {
-        cluster.close();
-      }
+    // Enable dictionary compression and do a regular push
+    ControllerResponse response = controllerClient.updateStore(
+        storeName,
+        new UpdateStoreQueryParams().setCompressionStrategy(CompressionStrategy.ZSTD_WITH_DICT));
+    if (response.isError()) {
+      throw new VeniceException(response.getError());
     }
+    props.setProperty(VenicePushJob.SOURCE_KAFKA, "false");
+    TestWriteUtils.runPushJob("Test push job with dictionary compression", props);
+    TestUtils.waitForNonDeterministicCompletion(30, TimeUnit.SECONDS, () -> {
+      int currentVersion = controllerClient.getStore(storeName).getStore().getCurrentVersion();
+      return currentVersion == 3;
+    });
+
+    // Re-push with Kafka Input Format and dictionary compression enabled
+    props.setProperty(VenicePushJob.SOURCE_KAFKA, "true");
+    TestWriteUtils.runPushJob("Test Kafka re-push job with dictionary compression", props);
+    TestUtils.waitForNonDeterministicCompletion(30, TimeUnit.SECONDS, () -> {
+      int currentVersion = controllerClient.getStore(storeName).getStore().getCurrentVersion();
+      return currentVersion == 4;
+    });
   }
 }

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/RouterServer.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/RouterServer.java
@@ -390,7 +390,17 @@ public class RouterServer extends AbstractVeniceService {
      */
     timeoutProcessor = new TimeoutProcessor(registry, true, 1);
 
-    Optional<SSLFactory> sslFactoryForRequests = config.isSslToStorageNodes() ? sslFactory : Optional.empty();
+    Optional<SSLFactory> sslFactoryForRequests = Optional.empty();
+    if (config.isSslToStorageNodes()) {
+      if (!sslFactory.isPresent()) {
+        throw new VeniceException("SSLFactory is required when enabling ssl to storage nodes");
+      }
+      if (config.isHttpClientOpensslEnabled()) {
+        sslFactoryForRequests = Optional.of(SslUtils.toSSLFactoryWithOpenSSLSupport(sslFactory.get()));
+      } else {
+        sslFactoryForRequests = sslFactory;
+      }
+    }
     VenicePartitionFinder partitionFinder = new VenicePartitionFinder(routingDataRepository, metadataRepository);
     Class<? extends AbstractChannel> serverSocketChannelClass;
     boolean useEpoll = true;

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/VeniceRouterConfig.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/VeniceRouterConfig.java
@@ -50,6 +50,7 @@ import static com.linkedin.venice.ConfigKeys.ROUTER_HTTPAYSNCCLIENT_CONNECTION_W
 import static com.linkedin.venice.ConfigKeys.ROUTER_HTTP_CLIENT5_POOL_SIZE;
 import static com.linkedin.venice.ConfigKeys.ROUTER_HTTP_CLIENT5_SKIP_CIPHER_CHECK_ENABLED;
 import static com.linkedin.venice.ConfigKeys.ROUTER_HTTP_CLIENT5_TOTAL_IO_THREAD_COUNT;
+import static com.linkedin.venice.ConfigKeys.ROUTER_HTTP_CLIENT_OPENSSL_ENABLED;
 import static com.linkedin.venice.ConfigKeys.ROUTER_HTTP_CLIENT_POOL_SIZE;
 import static com.linkedin.venice.ConfigKeys.ROUTER_IDLE_CONNECTION_TO_SERVER_CLEANUP_ENABLED;
 import static com.linkedin.venice.ConfigKeys.ROUTER_IDLE_CONNECTION_TO_SERVER_CLEANUP_THRESHOLD_MINS;
@@ -208,6 +209,7 @@ public class VeniceRouterConfig {
   private int routerIOWorkerCount;
   private boolean perRouterStorageNodeThrottlerEnabled;
   private double perStoreRouterQuotaBuffer;
+  private boolean httpClientOpensslEnabled;
 
   public VeniceRouterConfig(VeniceProperties props) {
     try {
@@ -385,6 +387,7 @@ public class VeniceRouterConfig {
     routerIOWorkerCount = props.getInt(ROUTER_IO_WORKER_COUNT, 24);
     perRouterStorageNodeThrottlerEnabled = props.getBoolean(ROUTER_PER_STORAGE_NODE_THROTTLER_ENABLED, true);
     perStoreRouterQuotaBuffer = props.getDouble(ROUTER_PER_STORE_ROUTER_QUOTA_BUFFER, 1.5);
+    httpClientOpensslEnabled = props.getBoolean(ROUTER_HTTP_CLIENT_OPENSSL_ENABLED, true);
   }
 
   public double getPerStoreRouterQuotaBuffer() {
@@ -826,5 +829,9 @@ public class VeniceRouterConfig {
 
   public boolean isPerRouterStorageNodeThrottlerEnabled() {
     return perRouterStorageNodeThrottlerEnabled;
+  }
+
+  public boolean isHttpClientOpensslEnabled() {
+    return httpClientOpensslEnabled;
   }
 }


### PR DESCRIPTION
This code change is leveraging `conscrypt-openjdk-uber` lib to support openssl in Http Client lib being used by Router. Once this is verified in Router, we will apply the similar optimization to fast-client.

New Router config:
router.http.client.openssl.enabled: default false

This code change also removed the Kafka openssl support, which was proved to be unstable.

<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci], [server], [controller],
[router], [samza], [vpj], [fast-client], [thin-client], [alpini],
[admin-tool], [test], [build], [doc], [script]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Resolves #XXX

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
CI

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.