### PR TITLE
[da-vinci-client] Do not attempt to restore meta system store on DaVinciBackend initialization

### DIFF
--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/fastclient/utils/AbstractClientEndToEndSetup.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/fastclient/utils/AbstractClientEndToEndSetup.java
@@ -54,6 +54,7 @@ import com.linkedin.venice.writer.VeniceWriter;
 import com.linkedin.venice.writer.VeniceWriterOptions;
 import io.tehuti.metrics.MetricsRepository;
 import java.io.IOException;
+import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Optional;
 import java.util.Properties;
@@ -75,6 +76,7 @@ public abstract class AbstractClientEndToEndSetup {
   protected String storeVersionName;
   protected int valueSchemaId;
   protected String storeName;
+  protected String dataPath;
 
   protected VeniceKafkaSerializer keySerializer;
   protected VeniceKafkaSerializer valueSerializer;
@@ -166,6 +168,8 @@ public abstract class AbstractClientEndToEndSetup {
 
     d2Client = D2TestUtils.getAndStartHttpsD2Client(veniceCluster.getZk().getAddress());
 
+    dataPath = Paths.get(System.getProperty("java.io.tmpdir"), "venice-server-data").toAbsolutePath().toString();
+
     prepareData();
     prepareMetaSystemStore();
     waitForRouterD2();
@@ -228,6 +232,7 @@ public abstract class AbstractClientEndToEndSetup {
         .put(PERSISTENCE_TYPE, ROCKS_DB)
         .put(CLIENT_USE_SYSTEM_STORE_REPOSITORY, true)
         .put(CLIENT_USE_DA_VINCI_BASED_SYSTEM_STORE_REPOSITORY, true)
+        .put(DATA_BASE_PATH, dataPath)
         .build();
 
     // Verify meta system store received the snapshot writes.


### PR DESCRIPTION
## Summary, imperative, start upper case, don't end with a period
Users that have ran DaVinci based metadata or store repository will run into the following exception: java.lang.UnsupportedOperationException: The implementation ThinClientMetaStoreBasedRepository should not be subscribing to system store...
when they try to run DaVinci client with thin client based store repository. This is because DaVinci backend will try to restore all on disk stores upon initialization, including meta system stores. User would then have to perform manual cleanup in the data.base.path in order to proceed.

1. Added logic to skip restoring meta system stores so they will only be subscribed explictly when needed.

2. Added an integration test with static data.base.path to reproduce the exact problem.

## How was this PR tested?
Existing tests and added new integration test

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.