### PR TITLE
[test] Exclude DaVinciBackend from unit test coverage requirement

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -630,6 +630,7 @@ ext.createDiffFile = { ->
         ':!services/venice-router/src/main/java/com/linkedin/venice/router/RouterServer.java',
         ':!services/venice-standalone/*', // exclude the entire standalone project
         ':!clients/venice-client/src/main/java/com/linkedin/venice/fastclient/factory/ClientFactory.java',
+        ':!clients/da-vinci-client/src/main/java/com/linkedin/davinci/DaVinciBackend.java',
 
         // Other files that have tests but are not executed in the regular unit test task
         ':!internal/alpini/*'


### PR DESCRIPTION
## Summary
DaVinciBackend currently is not unit testable and would require major refactor before we can write unit tests for it. Similar to VeniceHelixAdmin, hence adding it to the exclude list.

## How was this PR tested?
Test only change, existing tests

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.