### PR TITLE
[fast-client] Fix routing strategy issue when using request based metadata update

### DIFF
--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/ClientConfig.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/ClientConfig.java
@@ -120,7 +120,8 @@ public class ClientConfig<K, V, T extends SpecificRecord> {
     this.speculativeQueryEnabled = speculativeQueryEnabled;
     this.specificValueClass = specificValueClass;
     this.deserializationExecutor = deserializationExecutor;
-    this.clientRoutingStrategyType = clientRoutingStrategyType;
+    this.clientRoutingStrategyType =
+        clientRoutingStrategyType == null ? ClientRoutingStrategyType.LEAST_LOADED : clientRoutingStrategyType;
     this.dualReadEnabled = dualReadEnabled;
     this.genericThinClient = genericThinClient;
     this.specificThinClient = specificThinClient;

--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/ClientConfig.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/ClientConfig.java
@@ -6,7 +6,7 @@ import com.linkedin.r2.transport.common.Client;
 import com.linkedin.venice.client.exceptions.VeniceClientException;
 import com.linkedin.venice.client.store.AvroGenericStoreClient;
 import com.linkedin.venice.client.store.AvroSpecificStoreClient;
-import com.linkedin.venice.fastclient.meta.ClientRoutingStrategy;
+import com.linkedin.venice.fastclient.meta.ClientRoutingStrategyType;
 import com.linkedin.venice.fastclient.meta.StoreMetadataFetchMode;
 import com.linkedin.venice.fastclient.stats.ClusterStats;
 import com.linkedin.venice.fastclient.stats.FastClientStats;
@@ -30,7 +30,7 @@ public class ClientConfig<K, V, T extends SpecificRecord> {
   private final String storeName;
   private final Map<RequestType, FastClientStats> clientStatsMap = new VeniceConcurrentHashMap<>();
   private final Executor deserializationExecutor;
-  private final ClientRoutingStrategy clientRoutingStrategy;
+  private final ClientRoutingStrategyType clientRoutingStrategyType;
   /**
    * For dual-read support.
    */
@@ -76,7 +76,7 @@ public class ClientConfig<K, V, T extends SpecificRecord> {
       boolean speculativeQueryEnabled,
       Class<T> specificValueClass,
       Executor deserializationExecutor,
-      ClientRoutingStrategy clientRoutingStrategy,
+      ClientRoutingStrategyType clientRoutingStrategyType,
       boolean dualReadEnabled,
       AvroGenericStoreClient<K, V> genericThinClient,
       AvroSpecificStoreClient<K, T> specificThinClient,
@@ -120,7 +120,7 @@ public class ClientConfig<K, V, T extends SpecificRecord> {
     this.speculativeQueryEnabled = speculativeQueryEnabled;
     this.specificValueClass = specificValueClass;
     this.deserializationExecutor = deserializationExecutor;
-    this.clientRoutingStrategy = clientRoutingStrategy;
+    this.clientRoutingStrategyType = clientRoutingStrategyType;
     this.dualReadEnabled = dualReadEnabled;
     this.genericThinClient = genericThinClient;
     this.specificThinClient = specificThinClient;
@@ -200,6 +200,10 @@ public class ClientConfig<K, V, T extends SpecificRecord> {
         throw new VeniceClientException(
             "Both param: d2Client and param: clusterDiscoveryD2Service must be specified when request based metadata is enabled");
       }
+    }
+    if (clientRoutingStrategyType == ClientRoutingStrategyType.HELIX_ASSISTED
+        && this.storeMetadataFetchMode != StoreMetadataFetchMode.SERVER_BASED_METADATA) {
+      throw new VeniceClientException("Helix assisted routing is only available with server based metadata enabled");
     }
   }
 
@@ -296,8 +300,8 @@ public class ClientConfig<K, V, T extends SpecificRecord> {
     return isVsonStore;
   }
 
-  public ClientRoutingStrategy getClientRoutingStrategy() {
-    return clientRoutingStrategy;
+  public ClientRoutingStrategyType getClientRoutingStrategyType() {
+    return clientRoutingStrategyType;
   }
 
   public ClusterStats getClusterStats() {
@@ -323,7 +327,7 @@ public class ClientConfig<K, V, T extends SpecificRecord> {
     private Class<T> specificValueClass;
     private String storeName;
     private Executor deserializationExecutor;
-    private ClientRoutingStrategy clientRoutingStrategy;
+    private ClientRoutingStrategyType clientRoutingStrategyType;
     private Client r2Client;
     private boolean dualReadEnabled = false;
     private AvroGenericStoreClient<K, V> genericThinClient;
@@ -393,8 +397,9 @@ public class ClientConfig<K, V, T extends SpecificRecord> {
       return this;
     }
 
-    public ClientConfigBuilder<K, V, T> setClientRoutingStrategy(ClientRoutingStrategy clientRoutingStrategy) {
-      this.clientRoutingStrategy = clientRoutingStrategy;
+    public ClientConfigBuilder<K, V, T> setClientRoutingStrategyType(
+        ClientRoutingStrategyType clientRoutingStrategyType) {
+      this.clientRoutingStrategyType = clientRoutingStrategyType;
       return this;
     }
 
@@ -521,7 +526,7 @@ public class ClientConfig<K, V, T extends SpecificRecord> {
           .setSpeculativeQueryEnabled(speculativeQueryEnabled)
           .setSpecificValueClass(specificValueClass)
           .setDeserializationExecutor(deserializationExecutor)
-          .setClientRoutingStrategy(clientRoutingStrategy)
+          .setClientRoutingStrategyType(clientRoutingStrategyType)
           .setDualReadEnabled(dualReadEnabled)
           .setGenericThinClient(genericThinClient)
           .setSpecificThinClient(specificThinClient)
@@ -553,7 +558,7 @@ public class ClientConfig<K, V, T extends SpecificRecord> {
           speculativeQueryEnabled,
           specificValueClass,
           deserializationExecutor,
-          clientRoutingStrategy,
+          clientRoutingStrategyType,
           dualReadEnabled,
           genericThinClient,
           specificThinClient,

--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/meta/AbstractStoreMetadata.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/meta/AbstractStoreMetadata.java
@@ -37,6 +37,13 @@ public abstract class AbstractStoreMetadata implements StoreMetadata {
     this.storeName = clientConfig.getStoreName();
   }
 
+  /**
+   * For testing only.
+   */
+  public void setRoutingStrategy(ClientRoutingStrategy routingStrategy) {
+    this.routingStrategy = routingStrategy;
+  }
+
   @Override
   public String getStoreName() {
     return storeName;

--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/meta/ClientRoutingStrategyType.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/meta/ClientRoutingStrategyType.java
@@ -1,5 +1,12 @@
 package com.linkedin.venice.fastclient.meta;
 
+/**
+ * Different routing strategy types for client side routing:
+ *
+ * 1. LEAST_LOADED: select replicas based on the least number of pending requests from the local client's perspective.
+ * 2. HELIX_ASSISTED: select replicas prioritizing using hosts from the same helix/zone group to minimize request blast
+ *    radius for batch gets.
+ */
 public enum ClientRoutingStrategyType {
   LEAST_LOADED, HELIX_ASSISTED
 }

--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/meta/ClientRoutingStrategyType.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/meta/ClientRoutingStrategyType.java
@@ -1,0 +1,5 @@
+package com.linkedin.venice.fastclient.meta;
+
+public enum ClientRoutingStrategyType {
+  LEAST_LOADED, HELIX_ASSISTED
+}

--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/meta/HelixScatterGatherRoutingStrategy.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/meta/HelixScatterGatherRoutingStrategy.java
@@ -15,8 +15,12 @@ import java.util.stream.Collectors;
 public class HelixScatterGatherRoutingStrategy implements ClientRoutingStrategy {
   private Map<String, Integer> helixGroupInfo;
   private List<Integer> groupIds;
+  private final InstanceHealthMonitor instanceHealthMonitor;
 
-  public HelixScatterGatherRoutingStrategy(Map<String, Integer> helixGroupInfo) {
+  public HelixScatterGatherRoutingStrategy(
+      InstanceHealthMonitor instanceHealthMonitor,
+      Map<String, Integer> helixGroupInfo) {
+    this.instanceHealthMonitor = instanceHealthMonitor;
     this.helixGroupInfo = helixGroupInfo;
     this.groupIds = helixGroupInfo.values().stream().distinct().sorted().collect(Collectors.toList());
   }
@@ -36,7 +40,7 @@ public class HelixScatterGatherRoutingStrategy implements ClientRoutingStrategy 
         if (selectedReplicas.size() == requiredReplicaCount) {
           return selectedReplicas;
         }
-        if (helixGroupInfo.get(replica) == groupId) {
+        if (helixGroupInfo.get(replica) == groupId && !instanceHealthMonitor.isInstanceBlocked(replica)) {
           selectedReplicas.add(replica);
         }
       }

--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/meta/HelixScatterGatherRoutingStrategy.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/meta/HelixScatterGatherRoutingStrategy.java
@@ -15,7 +15,7 @@ import java.util.stream.Collectors;
  */
 public class HelixScatterGatherRoutingStrategy implements ClientRoutingStrategy {
   private Map<String, Integer> helixGroupInfo = new VeniceConcurrentHashMap<>();
-  private List<Integer> groupIds;
+  private List<Integer> groupIds = new ArrayList<>();
   private final InstanceHealthMonitor instanceHealthMonitor;
 
   public HelixScatterGatherRoutingStrategy(InstanceHealthMonitor instanceHealthMonitor) {

--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/meta/RequestBasedMetadata.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/meta/RequestBasedMetadata.java
@@ -269,8 +269,6 @@ public class RequestBasedMetadata extends AbstractStoreMetadata {
       if (updateCache(false)) {
         if (routingStrategy instanceof HelixScatterGatherRoutingStrategy) {
           ((HelixScatterGatherRoutingStrategy) routingStrategy).updateHelixGroupInfo(helixGroupInfo);
-        } else {
-          routingStrategy = new HelixScatterGatherRoutingStrategy(helixGroupInfo);
         }
       }
       isReady = true;

--- a/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/meta/HelixScatterGatherRoutingStrategyTest.java
+++ b/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/meta/HelixScatterGatherRoutingStrategyTest.java
@@ -1,7 +1,8 @@
 package com.linkedin.venice.fastclient.meta;
 
-import static org.mockito.Mockito.*;
-import static org.testng.Assert.*;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.testng.Assert.assertEquals;
 
 import java.util.Arrays;
 import java.util.HashMap;
@@ -39,8 +40,8 @@ public class HelixScatterGatherRoutingStrategyTest {
   }
 
   public void runTest(List<String> replicas, long requestId, int requiredReplicaCount, List<String> expectedReplicas) {
-    HelixScatterGatherRoutingStrategy strategy =
-        new HelixScatterGatherRoutingStrategy(instanceHealthMonitor, getHelixGroupInfo());
+    HelixScatterGatherRoutingStrategy strategy = new HelixScatterGatherRoutingStrategy(instanceHealthMonitor);
+    strategy.updateHelixGroupInfo(getHelixGroupInfo());
     List<String> selectedReplicas = strategy.getReplicas(requestId, replicas, requiredReplicaCount);
     assertEquals(selectedReplicas, expectedReplicas);
   }

--- a/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/meta/HelixScatterGatherRoutingStrategyTest.java
+++ b/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/meta/HelixScatterGatherRoutingStrategyTest.java
@@ -1,11 +1,13 @@
 package com.linkedin.venice.fastclient.meta;
 
+import static org.mockito.Mockito.*;
 import static org.testng.Assert.*;
 
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 
@@ -16,6 +18,8 @@ public class HelixScatterGatherRoutingStrategyTest {
   private final static String instance4 = "https://instance4:1234";
   private final static String instance5 = "https://instance5:1234";
   private final static String instance6 = "https://instance6:1234";
+
+  private InstanceHealthMonitor instanceHealthMonitor;
 
   private Map<String, Integer> getHelixGroupInfo() {
     Map<String, Integer> helixGroupInfo = new HashMap<>();
@@ -29,8 +33,14 @@ public class HelixScatterGatherRoutingStrategyTest {
     return helixGroupInfo;
   }
 
+  @BeforeMethod
+  public void setUp() {
+    instanceHealthMonitor = mock(InstanceHealthMonitor.class);
+  }
+
   public void runTest(List<String> replicas, long requestId, int requiredReplicaCount, List<String> expectedReplicas) {
-    HelixScatterGatherRoutingStrategy strategy = new HelixScatterGatherRoutingStrategy(getHelixGroupInfo());
+    HelixScatterGatherRoutingStrategy strategy =
+        new HelixScatterGatherRoutingStrategy(instanceHealthMonitor, getHelixGroupInfo());
     List<String> selectedReplicas = strategy.getReplicas(requestId, replicas, requiredReplicaCount);
     assertEquals(selectedReplicas, expectedReplicas);
   }
@@ -47,6 +57,18 @@ public class HelixScatterGatherRoutingStrategyTest {
     List<String> replicas = Arrays.asList(instance1, instance4, instance5, instance6);
     runTest(replicas, 0, 2, Arrays.asList(instance1, instance4));
     runTest(replicas, 1, 4, Arrays.asList(instance4, instance5, instance6, instance1));
+  }
+
+  @Test
+  public void testGetReplicaWithBlockedInstances() {
+    doReturn(true).when(instanceHealthMonitor).isInstanceBlocked(instance1);
+    doReturn(true).when(instanceHealthMonitor).isInstanceBlocked(instance4);
+    doReturn(true).when(instanceHealthMonitor).isInstanceBlocked(instance5);
+    doReturn(true).when(instanceHealthMonitor).isInstanceBlocked(instance6);
+    List<String> replicas = Arrays.asList(instance1, instance2, instance3, instance4, instance5, instance6);
+    runTest(replicas, 0, 2, Arrays.asList(instance2, instance3));
+    // 1, 4, 5, 6 are all blocked. Can only get 2 and 3 in order to meet the required replica of 2.
+    runTest(replicas, 1, 2, Arrays.asList(instance2, instance3));
   }
 
   @Test

--- a/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/meta/RequestBasedMetadataTest.java
+++ b/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/meta/RequestBasedMetadataTest.java
@@ -62,6 +62,7 @@ public class RequestBasedMetadataTest {
     doReturn(1L).when(clientConfig).getMetadataRefreshIntervalInSeconds();
     doReturn(storeName).when(clientConfig).getStoreName();
     doReturn(clusterStats).when(clientConfig).getClusterStats();
+    doReturn(ClientRoutingStrategyType.LEAST_LOADED).when(clientConfig).getClientRoutingStrategyType();
     return clientConfig;
   }
 

--- a/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/meta/VeniceClientBasedMetadataTest.java
+++ b/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/meta/VeniceClientBasedMetadataTest.java
@@ -69,6 +69,7 @@ public class VeniceClientBasedMetadataTest {
   private ClientConfig getBasicMockClientConfig(String storeName) {
     ClientConfig clientConfig = mock(ClientConfig.class);
     ClusterStats clusterStats = new ClusterStats(new MetricsRepository(), storeName);
+    doReturn(ClientRoutingStrategyType.LEAST_LOADED).when(clientConfig).getClientRoutingStrategyType();
     doReturn(1L).when(clientConfig).getMetadataRefreshIntervalInSeconds();
     doReturn(storeName).when(clientConfig).getStoreName();
     doReturn(clusterStats).when(clientConfig).getClusterStats();

--- a/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/utils/TestClientSimulator.java
+++ b/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/utils/TestClientSimulator.java
@@ -239,7 +239,9 @@ public class TestClientSimulator implements Client {
       for (MultiGetRouterRequestKeyV1 keyRecord: multiGetRouterRequestKeyV1s) {
         Utf8 key = keyDeserializer.deserialize(keyRecord.keyBytes);
         LOGGER.info("t:{} Received key {} on route {} ", currentTimeTick.get(), key, route);
-        Assert.assertTrue(expectedKeys.contains(key.toString()), "Unexpected key received " + key);
+        Assert.assertTrue(
+            expectedKeys.contains(key.toString()),
+            "Unexpected key received: " + key + " Expected keys: " + expectedKeys);
         expectedKeys.remove(key.toString());
         expectedRequestEvent.info.orderedKeys.add(key.toString());
       }
@@ -598,6 +600,14 @@ public class TestClientSimulator implements Client {
         return null;
       }
     };
+
+    metadata.setRoutingStrategy((requestId, replicas, requiredReplicaCount) -> {
+      List<String> retReplicas = new ArrayList<>();
+      for (int i = 0; i < requiredReplicaCount && i < replicas.size(); i++) {
+        retReplicas.add(replicas.get(i));
+      }
+      return retReplicas;
+    });
 
     return ClientFactory.getAndStartGenericStoreClient(metadata, clientConfig);
   }

--- a/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/utils/TestClientSimulator.java
+++ b/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/utils/TestClientSimulator.java
@@ -17,7 +17,6 @@ import com.linkedin.venice.compression.VeniceCompressor;
 import com.linkedin.venice.fastclient.ClientConfig;
 import com.linkedin.venice.fastclient.factory.ClientFactory;
 import com.linkedin.venice.fastclient.meta.AbstractStoreMetadata;
-import com.linkedin.venice.fastclient.meta.ClientRoutingStrategy;
 import com.linkedin.venice.read.protocol.request.router.MultiGetRouterRequestKeyV1;
 import com.linkedin.venice.read.protocol.response.MultiGetResponseRecordV1;
 import com.linkedin.venice.schema.writecompute.DerivedSchemaEntry;
@@ -520,16 +519,6 @@ public class TestClientSimulator implements Client {
       clientConfigBuilder
           .setLongTailRetryThresholdForSingleGetInMicroSeconds(longTailRetryThresholdForSingleGetInMicroseconds);
     }
-    clientConfigBuilder.setClientRoutingStrategy(new ClientRoutingStrategy() {
-      @Override
-      public List<String> getReplicas(long requestId, List<String> replicas, int requiredReplicaCount) {
-        List<String> retReplicas = new ArrayList<>();
-        for (int i = 0; i < requiredReplicaCount && i < replicas.size(); i++) {
-          retReplicas.add(replicas.get(i));
-        }
-        return retReplicas;
-      }
-    });
 
     // TODO: need to add tests for simulating dual read
     clientConfigBuilder.setDualReadEnabled(false);

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/fastclient/FastClientServerReadQuotaTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/fastclient/FastClientServerReadQuotaTest.java
@@ -46,14 +46,16 @@ public class FastClientServerReadQuotaTest extends AbstractClientEndToEndSetup {
       Assert.assertNotNull(serverMetric.getMetric(readQuotaRejectedString));
       Assert.assertNotNull(serverMetric.getMetric(readQuotaUsageRatio));
     });
-    Assert.assertTrue(serverMetric.getMetric(readQuotaRequestedString).value() >= 500);
+    Assert.assertTrue(
+        serverMetric.getMetric(readQuotaRequestedString).value() >= 250,
+        "Metric value: " + serverMetric.getMetric(readQuotaRequestedString).value());
     Assert.assertEquals(serverMetric.getMetric(readQuotaRejectedString).value(), 0d);
     Assert.assertTrue(serverMetric.getMetric(readQuotaUsageRatio).value() > 0);
 
     // Update the read quota to 100 and make 500 requests again.
     veniceCluster.useControllerClient(controllerClient -> {
       TestUtils
-          .assertCommand(controllerClient.updateStore(storeName, new UpdateStoreQueryParams().setReadQuotaInCU(100)));
+          .assertCommand(controllerClient.updateStore(storeName, new UpdateStoreQueryParams().setReadQuotaInCU(50)));
     });
     try {
       // Keep making requests until it gets rejected by read quota, it may take some time for the quota update to be


### PR DESCRIPTION
## Summary

1. RequestBasedMetadata was forcing the fast client routing strategy to be HelixScatterGatherRoutingStrategy which is unintended. The routing strategy should be selected based on config.

2. HelixScatterGatherRoutingStrategy did not take InstanceHealthMonitor into consideration. Meaning it will continue to route requests to bad hosts when routing table is out of sync. This is witnessed when servers are going through deployment in our certification cluster and causing latency spikes.

3. ClientRoutingStrategy is difficult to set/instantiate in factory. Changing the config to an enum and instantiate the actual strategy in AbstractStoreMetadata instead.

## How was this PR tested?
Existing unit and integration tests. Added new unit test for HelixScatterGatherRoutingStrategy.

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.