### PR TITLE
[samza] Use Fast-Avro serializer in VeniceSystemProducer

### DIFF
--- a/clients/venice-samza/src/main/java/com/linkedin/venice/samza/VeniceSystemProducer.java
+++ b/clients/venice-samza/src/main/java/com/linkedin/venice/samza/VeniceSystemProducer.java
@@ -31,7 +31,8 @@ import com.linkedin.venice.schema.writecompute.WriteComputeHandlerV1;
 import com.linkedin.venice.security.SSLFactory;
 import com.linkedin.venice.serialization.avro.AvroProtocolDefinition;
 import com.linkedin.venice.serialization.avro.SchemaPresenceChecker;
-import com.linkedin.venice.serialization.avro.VeniceAvroKafkaSerializer;
+import com.linkedin.venice.serializer.FastSerializerDeserializerFactory;
+import com.linkedin.venice.serializer.RecordSerializer;
 import com.linkedin.venice.utils.BoundedHashMap;
 import com.linkedin.venice.utils.Pair;
 import com.linkedin.venice.utils.PartitionUtils;
@@ -125,12 +126,6 @@ public class VeniceSystemProducer implements SystemProducer, Closeable {
 
   private final VeniceConcurrentHashMap<Pair<Integer, Integer>, Schema> valueSchemaIdsToSchemaMap =
       new VeniceConcurrentHashMap<>();
-
-  /**
-   * key is schema
-   * value is Avro serializer
-   */
-  private final Map<String, VeniceAvroKafkaSerializer> serializers = new VeniceConcurrentHashMap<>();
 
   // Mutable, lazily initialized, state
   private Schema keySchema;
@@ -611,7 +606,7 @@ public class VeniceSystemProducer implements SystemProducer, Closeable {
               + " which does not match Venice key schema " + canonicalKeySchemaStr + ".");
     }
 
-    byte[] key = serializeObject(topicName, keyObject);
+    byte[] key = serializeObject(keyObject);
     final CompletableFuture<Void> completableFuture = new CompletableFuture<>();
     final PubSubProducerCallback callback = new CompletableFutureCallback(completableFuture);
 
@@ -655,7 +650,7 @@ public class VeniceSystemProducer implements SystemProducer, Closeable {
         valueSchemaIdPair = new Pair<>(baseSchemaId, -1);
       }
 
-      byte[] value = serializeObject(topicName, valueObject);
+      byte[] value = serializeObject(valueObject);
 
       if (valueSchemaIdPair.getSecond() == -1) {
         if (logicalTimestamp > 0) {
@@ -728,11 +723,11 @@ public class VeniceSystemProducer implements SystemProducer, Closeable {
     }
   }
 
-  private byte[] serializeObject(String topic, Object input) {
+  private byte[] serializeObject(Object input) {
     if (input instanceof IndexedRecord) {
-      VeniceAvroKafkaSerializer serializer =
-          serializers.computeIfAbsent(((IndexedRecord) input).getSchema().toString(), VeniceAvroKafkaSerializer::new);
-      return serializer.serialize(topic, input);
+      RecordSerializer<Object> fastAvroSerializer =
+          FastSerializerDeserializerFactory.getFastAvroGenericSerializer(((IndexedRecord) input).getSchema());
+      return fastAvroSerializer.serialize(input);
     } else if (input instanceof CharSequence) {
       return serializePrimitive(new Utf8(input.toString()), STRING_DATUM_WRITER);
     } else if (input instanceof Integer) {


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci], [server], [controller],
[router], [samza], [vpj], [fast-client], [thin-client], [pulsar-sink], [alpini],
[admin-tool], [test], [build], [doc], [script]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## [samza] Use Fast-Avro serializer in VeniceSystemProducer
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

This PR tries to resolve slowness in VeniceSystemProducer's send() method. 
Through profiling we found that serializer is slow, in this PR we use FastAvro serializer instead.
Also schema-string based map is also found slow in get() as schema.toString() is heavy. We rely on FastAvro Factory's internal map cache to speed up. 

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
TODO

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.