### PR TITLE
[server] Make sure containsTopic check spent desired amount of time on retries

### DIFF
--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/utils/RetryUtils.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/utils/RetryUtils.java
@@ -257,9 +257,9 @@ public class RetryUtils {
       List<Class<? extends Throwable>> retryFailureTypes) {
     RetryPolicy<Object> retryPolicy = new RetryPolicy<>().handle(retryFailureTypes)
         .withDelay(
-            (result, failure, context) -> (durationPerAttempt.toMillis() > context.getElapsedAttemptTime().toMillis()
-                ? Duration.ofMillis(durationPerAttempt.toMillis() - context.getElapsedAttemptTime().toMillis())
-                : Duration.ZERO))
+            (result, failure, context) -> durationPerAttempt.compareTo(context.getElapsedAttemptTime()) > 0
+                ? durationPerAttempt.minus(context.getElapsedAttemptTime())
+                : Duration.ZERO)
         .withMaxRetries(maxRetry);
     retryPolicy.onFailedAttempt(RetryUtils::logAttemptWithFailure);
     return Failsafe.with(retryPolicy).get(supplier::get);

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/utils/RetryUtils.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/utils/RetryUtils.java
@@ -257,8 +257,9 @@ public class RetryUtils {
       List<Class<? extends Throwable>> retryFailureTypes) {
     RetryPolicy<Object> retryPolicy = new RetryPolicy<>().handle(retryFailureTypes)
         .withDelay(
-            (result, failure, context) -> Duration
-                .ofMillis(durationPerAttempt.toMillis() - context.getElapsedAttemptTime().toMillis()))
+            (result, failure, context) -> (durationPerAttempt.toMillis() > context.getElapsedAttemptTime().toMillis()
+                ? Duration.ofMillis(durationPerAttempt.toMillis() - context.getElapsedAttemptTime().toMillis())
+                : Duration.ZERO))
         .withMaxRetries(maxRetry);
     retryPolicy.onFailedAttempt(RetryUtils::logAttemptWithFailure);
     return Failsafe.with(retryPolicy).get(supplier::get);

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/utils/RetryUtils.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/utils/RetryUtils.java
@@ -240,6 +240,30 @@ public class RetryUtils {
     return Failsafe.with(retryPolicy).get(supplier::get);
   }
 
+  /**
+   * Execute a {@link Supplier} with maximum retries and fix duration per retry attempt. If all attempts are made and
+   * still no success, the last thrown exception will be thrown.
+   *
+   * @param supplier Execution unit which returns something ({@link T})
+   * @param maxRetry Total maximum retries made before giving up.
+   * @param durationPerAttempt Total duration per attempt. The delay after attempt will be the (duration per attempt - time spent in the current attempt).
+   * @param retryFailureTypes Types of failures upon which retry attempt is made. If a failure with type not specified
+   *                          in this list is thrown, it is thrown to the caller.
+   */
+  public static <T> T executeWithMaxRetriesAndFixedAttemptDuration(
+      VeniceCheckedSupplier<T> supplier,
+      final int maxRetry,
+      Duration durationPerAttempt,
+      List<Class<? extends Throwable>> retryFailureTypes) {
+    RetryPolicy<Object> retryPolicy = new RetryPolicy<>().handle(retryFailureTypes)
+        .withDelay(
+            (result, failure, context) -> Duration
+                .ofMillis(durationPerAttempt.toMillis() - context.getElapsedAttemptTime().toMillis()))
+        .withMaxRetries(maxRetry);
+    retryPolicy.onFailedAttempt(RetryUtils::logAttemptWithFailure);
+    return Failsafe.with(retryPolicy).get(supplier::get);
+  }
+
   private static <T> void logAttemptWithFailure(ExecutionAttemptedEvent<T> executionAttemptedEvent) {
     LOGGER.error(
         "Execution failed with message {} on attempt count {}",

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/utils/RetryUtilsTest.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/utils/RetryUtilsTest.java
@@ -292,7 +292,7 @@ public class RetryUtilsTest {
         (int) RetryUtils.executeWithMaxRetriesAndFixedAttemptDuration(
             () -> obj.getAnInteger() + 1,
             2,
-            Duration.ofMillis(100),
+            Duration.ofMillis(1000),
             Arrays.asList(IllegalStateException.class, IllegalArgumentException.class)),
         3);
     verify(obj, times(3)).getAnInteger();

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/utils/RetryUtilsTest.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/utils/RetryUtilsTest.java
@@ -287,7 +287,7 @@ public class RetryUtilsTest {
     when(obj.getAnInteger()).thenThrow(IllegalArgumentException.class)
         .thenThrow(IllegalStateException.class)
         .thenReturn(2);
-
+    long startTime = System.currentTimeMillis();
     Assert.assertEquals(
         (int) RetryUtils.executeWithMaxRetriesAndFixedAttemptDuration(
             () -> obj.getAnInteger() + 1,
@@ -295,6 +295,7 @@ public class RetryUtilsTest {
             Duration.ofMillis(1000),
             Arrays.asList(IllegalStateException.class, IllegalArgumentException.class)),
         3);
+    Assert.assertTrue((System.currentTimeMillis() - startTime) > 2000);
     verify(obj, times(3)).getAnInteger();
     reset(obj);
   }

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/utils/RetryUtilsTest.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/utils/RetryUtilsTest.java
@@ -266,4 +266,36 @@ public class RetryUtilsTest {
     verify(obj, times(3)).getAnInteger();
     reset(obj);
   }
+
+  @Test
+  public void testFixAttemptDurationOnSupplier() {
+    SomeObj obj = mock(SomeObj.class);
+
+    // Case 1: no failure
+    when(obj.getAnInteger()).thenReturn(1);
+    Assert.assertEquals(
+        (int) RetryUtils.executeWithMaxRetriesAndFixedAttemptDuration(
+            () -> obj.getAnInteger() + 1,
+            3,
+            Duration.ofMillis(100),
+            Collections.singletonList(IllegalStateException.class)),
+        2);
+    verify(obj, times(1)).getAnInteger();
+    reset(obj);
+
+    // Case 2: succeed on the last attempt
+    when(obj.getAnInteger()).thenThrow(IllegalArgumentException.class)
+        .thenThrow(IllegalStateException.class)
+        .thenReturn(2);
+
+    Assert.assertEquals(
+        (int) RetryUtils.executeWithMaxRetriesAndFixedAttemptDuration(
+            () -> obj.getAnInteger() + 1,
+            2,
+            Duration.ofMillis(100),
+            Arrays.asList(IllegalStateException.class, IllegalArgumentException.class)),
+        3);
+    verify(obj, times(3)).getAnInteger();
+    reset(obj);
+  }
 }


### PR DESCRIPTION


<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci], [server], [controller],
[router], [samza], [vpj], [fast-client], [thin-client], [pulsar-sink], [alpini],
[admin-tool], [test], [build], [doc], [script]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## [server] Make sure containsTopic check spent desired amount of time on retries
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

The contains topic check expects to spent at most 180s with 3 retries, however with current impl, it will spent a few hundred ms on 3 fast attempts and fail as we don't wait enough time to begin the next retry attempt.
This PR uses DelayFunction in FailSafe module to add a new retry mechanism to make sure after each attempt, it will wait until the desired attempt total duration is spent before it begins next attempt.
With the setup, in the worst case (topic does not exist), it will be:
Attempt 0, wait until T=60s, Retry 1, wait until T=120s, Retry 2, wait until T=180s, Retry 3, Fail loudly.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
Add a new unit test to make sure new try mechanism is working as expected.

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.