### PR TITLE
[changelog-consumer][client] Add seek by time API's to Venice Changelog Consumer

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumer.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumer.java
@@ -1,8 +1,10 @@
 package com.linkedin.davinci.consumer;
 
 import com.linkedin.venice.annotation.Experimental;
+import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.pubsub.api.PubSubMessage;
 import java.util.Collection;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
@@ -106,6 +108,27 @@ public interface VeniceChangelogConsumer<K, V> {
    * @throws a VeniceException if subscribe operation failed for any of the partitions
    */
   CompletableFuture<Void> subscribeAll();
+
+  /**
+   * Seek to the provided timestamps for the specified partitions.
+   *
+   * Note, this API can only be used to seek on nearline data applied to the current serving version in Venice.
+   * This will not seek on data transmitted via Batch Push. If the provided timestamp is lower then the earliest
+   * timestamp on a given stream, the earliest event will be returned.
+   *
+   * @param timeStamps a map keyed by a partition ID, and the timestamp checkpoints to seek for each partition.
+   * @return
+   * @throws VeniceException if seek operations failed for any of the specified partitions.
+   */
+  CompletableFuture<Void> seekToTimestamp(Map<Integer, Long> timeStamps);
+
+  /**
+   * Seek to the specified timestamp for all subscribed partitions. See {@link #seekToTimestamp(Map)} for more information.
+   *
+   * @return a future which completes when the operation has succeeded for all partitions.
+   * @throws VeniceException if seek operation failed for any of the partitions.
+   */
+  CompletableFuture<Void> seekToTimestamp(Long timestamp);
 
   /**
    * Stop ingesting messages from a set of partitions for a specific store.

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumer.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumer.java
@@ -114,7 +114,9 @@ public interface VeniceChangelogConsumer<K, V> {
    *
    * Note, this API can only be used to seek on nearline data applied to the current serving version in Venice.
    * This will not seek on data transmitted via Batch Push. If the provided timestamp is lower then the earliest
-   * timestamp on a given stream, the earliest event will be returned.
+   * timestamp on a given stream, the earliest event will be returned. THIS WILL NOT SEEK TO DATA WHICH WAS APPLIED
+   * ON A PREVIOUS VERSION.  You should never seek back in time to a timestamp which is smaller than the current time -
+   * rewindTimeInSeconds configured in the hybrid settings for this Venice store.
    *
    * @param timeStamps a map keyed by a partition ID, and the timestamp checkpoints to seek for each partition.
    * @return

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumer.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumer.java
@@ -110,13 +110,19 @@ public interface VeniceChangelogConsumer<K, V> {
   CompletableFuture<Void> subscribeAll();
 
   /**
-   * Seek to the provided timestamps for the specified partitions.
+   * Seek to the provided timestamps for the specified partitions based on wall clock time for when this message was
+   * processed by Venice and produced to change capture.
    *
    * Note, this API can only be used to seek on nearline data applied to the current serving version in Venice.
-   * This will not seek on data transmitted via Batch Push. If the provided timestamp is lower then the earliest
+   * This will not seek on data transmitted via Batch Push. If the provided timestamp is lower than the earliest
    * timestamp on a given stream, the earliest event will be returned. THIS WILL NOT SEEK TO DATA WHICH WAS APPLIED
    * ON A PREVIOUS VERSION.  You should never seek back in time to a timestamp which is smaller than the current time -
    * rewindTimeInSeconds configured in the hybrid settings for this Venice store.
+   *
+   * The timestamp passed to this function should be associated to timestamps processed by this interface. The timestamp
+   * returned by {@link PubSubMessage.getPubSubMessageTime()} refers to the time when Venice processed the event, and
+   * calls to this method will seek based on that sequence of events.  Note: it bears no relation to timestamps provided by
+   * upstream producers when writing to Venice where a user may optionally provide a timestamp at time of producing a record.
    *
    * @param timestamps a map keyed by a partition ID, and the timestamp checkpoints to seek for each partition.
    * @return

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumer.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumer.java
@@ -118,14 +118,14 @@ public interface VeniceChangelogConsumer<K, V> {
    * ON A PREVIOUS VERSION.  You should never seek back in time to a timestamp which is smaller than the current time -
    * rewindTimeInSeconds configured in the hybrid settings for this Venice store.
    *
-   * @param timeStamps a map keyed by a partition ID, and the timestamp checkpoints to seek for each partition.
+   * @param timestamps a map keyed by a partition ID, and the timestamp checkpoints to seek for each partition.
    * @return
    * @throws VeniceException if seek operations failed for any of the specified partitions.
    */
-  CompletableFuture<Void> seekToTimestamp(Map<Integer, Long> timeStamps);
+  CompletableFuture<Void> seekToTimestamps(Map<Integer, Long> timestamps);
 
   /**
-   * Seek to the specified timestamp for all subscribed partitions. See {@link #seekToTimestamp(Map)} for more information.
+   * Seek to the specified timestamp for all subscribed partitions. See {@link #seekToTimestamps(Map)} for more information.
    *
    * @return a future which completes when the operation has succeeded for all partitions.
    * @throws VeniceException if seek operation failed for any of the partitions.

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImpl.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImpl.java
@@ -62,6 +62,7 @@ import org.apache.avro.generic.GenericRecord;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.OffsetAndTimestamp;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -300,6 +301,36 @@ public class VeniceChangelogConsumerImpl<K, V> implements VeniceChangelogConsume
       allPartitions.add(partition);
     }
     return this.subscribe(allPartitions);
+  }
+
+  @Override
+  public CompletableFuture<Void> seekToTimestamp(Map<Integer, Long> timeStamps) {
+    // Get the latest change capture topic
+    storeRepository.refresh();
+    Store store = storeRepository.getStore(storeName);
+    int currentVersion = store.getCurrentVersion();
+    String topic = Version.composeKafkaTopic(storeName, currentVersion) + ChangeCaptureView.CHANGE_CAPTURE_TOPIC_SUFFIX;
+    Map<TopicPartition, Long> topicPartitionLongMap = new HashMap<>();
+    for (Map.Entry<Integer, Long> timestampPair: timeStamps.entrySet()) {
+      TopicPartition topicPartition = new TopicPartition(topic, timestampPair.getKey());
+      topicPartitionLongMap.put(topicPartition, timestampPair.getValue());
+    }
+    return internalSeek(timeStamps.keySet(), topic, (partitions) -> {
+      Map<TopicPartition, OffsetAndTimestamp> offsetsTimestamps = kafkaConsumer.offsetsForTimes(topicPartitionLongMap);
+      for (Map.Entry<TopicPartition, OffsetAndTimestamp> offsetTimestamp: offsetsTimestamps.entrySet()) {
+        kafkaConsumer.seek(offsetTimestamp.getKey(), offsetTimestamp.getValue().offset());
+      }
+    });
+  }
+
+  @Override
+  public CompletableFuture<Void> seekToTimestamp(Long timestamp) {
+    Set<TopicPartition> topicPartitionSet = new HashSet<>(kafkaConsumer.assignment());
+    Map<Integer, Long> partitionsToSeek = new HashMap<>();
+    for (TopicPartition partition: topicPartitionSet) {
+      partitionsToSeek.put(partition.partition(), timestamp);
+    }
+    return this.seekToTimestamp(partitionsToSeek);
   }
 
   public CompletableFuture<Void> internalSeek(Set<Integer> partitions, String targetTopic, SeekFunction seekAction) {

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImplTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImplTest.java
@@ -122,10 +122,16 @@ public class VeniceChangelogConsumerImplTest {
 
     veniceChangelogConsumer.setStoreRepository(mockRepository);
     veniceChangelogConsumer.subscribe(new HashSet<>(Arrays.asList(0))).get();
-    veniceChangelogConsumer.seekToEndOfPush();
+    veniceChangelogConsumer.seekToTimestamp(System.currentTimeMillis() - 10000L);
     HashSet<TopicPartition> topicPartitions = new HashSet<>();
     topicPartitions.add(new TopicPartition(oldVersionTopic, 0));
     verify(mockKafkaConsumer).assign(topicPartitions);
+
+    veniceChangelogConsumer.setStoreRepository(mockRepository);
+    veniceChangelogConsumer.subscribe(new HashSet<>(Arrays.asList(0))).get();
+    veniceChangelogConsumer.seekToEndOfPush();
+    topicPartitions.add(new TopicPartition(oldVersionTopic, 0));
+    verify(mockKafkaConsumer, times(2)).assign(topicPartitions);
 
     List<PubSubMessage<String, ChangeEvent<Utf8>, VeniceChangeCoordinate>> pubSubMessages =
         (List<PubSubMessage<String, ChangeEvent<Utf8>, VeniceChangeCoordinate>>) veniceChangelogConsumer.poll(100);


### PR DESCRIPTION
## Add Seek by time API's to Venice Changelog Consumer
This was a client feature request.  We expect underlying pubsub implementations to provide this functionality, so it seemed a low hanger.  Expected semantics of the behavior of the new API's s documented in the interface javadoc attached to this PR.

## How was this PR tested?
Added new integration test cases

## Does this PR introduce any user-facing changes?
Yes, but only extends the interface.  Will not impact current users.
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.