### PR TITLE
[router] Add Property keys for configuring SSL for RouterServer.main()

### DIFF
--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -405,7 +405,7 @@ public class ConfigKeys {
    * provided via other properties. This should only be used for testing and defaults to true when running
    * RouterServer.main().
    */
-  public static final String ROUTER_USE_LOCAL_SSL_SETTINGS = "router.ssl.local.settings";
+  public static final String ROUTER_USE_LOCAL_SSL_SETTINGS = "router.local.ssl";
 
   /**
    * This instructs the router to open an ssl port. This defaults to true.

--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -400,6 +400,18 @@ public class ConfigKeys {
   public static final String ROUTER_MAX_READ_CAPACITY = "router.max.read.capacity";
   public static final String ROUTER_QUOTA_CHECK_WINDOW = "router.quota.check.window";
 
+  /**
+   * This instructs the router to start running with self signed TLS certificates as opposed to those
+   * provided via other properties. This should only be used for testing and defaults to true when running
+   * RouterServer.main().
+   */
+  public static final String ROUTER_USE_LOCAL_SSL_SETTINGS = "router.ssl.local.settings";
+
+  /**
+   * This instructs the router to open an ssl port. This defaults to true.
+   */
+  public static final String ROUTER_ENABLE_SSL = "router.enable.ssl";
+
   public static final String SERVER_REMOTE_INGESTION_REPAIR_SLEEP_INTERVAL_SECONDS =
       "server.remote.ingestion.repair.sleep.interval.seconds";
   /**

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/RouterServer.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/RouterServer.java
@@ -1,7 +1,7 @@
 package com.linkedin.venice.router;
 
-import static com.linkedin.venice.CommonConfigKeys.*;
-import static com.linkedin.venice.VeniceConstants.*;
+import static com.linkedin.venice.CommonConfigKeys.SSL_FACTORY_CLASS_NAME;
+import static com.linkedin.venice.VeniceConstants.DEFAULT_SSL_FACTORY_CLASS_NAME;
 
 import com.linkedin.alpini.base.concurrency.AsyncFuture;
 import com.linkedin.alpini.base.concurrency.TimeoutProcessor;


### PR DESCRIPTION
## Add Property keys for configuring SSL for RouterServer.main()

VeniceRouter.main() was not honoring passed in SSL parameters when running, opting to instead use the test environment settings by relying on a self signed certificate.  This PR preserves this default behavior (as it is useful in testing), but adds the ability to override this behavior so that custom options can be passed.

## How was this PR tested?
running normal test suite which relied on this path.

## Does this PR introduce any user-facing changes?
No
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.