### PR TITLE
[router] some SSLConfig fields are not considered

### DIFF
--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/security/SSLConfig.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/security/SSLConfig.java
@@ -4,6 +4,7 @@ import static com.linkedin.venice.CommonConfigKeys.SSL_ENABLED;
 import static com.linkedin.venice.CommonConfigKeys.SSL_KEYSTORE_LOCATION;
 import static com.linkedin.venice.CommonConfigKeys.SSL_KEYSTORE_PASSWORD;
 import static com.linkedin.venice.CommonConfigKeys.SSL_KEYSTORE_TYPE;
+import static com.linkedin.venice.CommonConfigKeys.SSL_NEEDS_CLIENT_CERT;
 import static com.linkedin.venice.CommonConfigKeys.SSL_TRUSTSTORE_LOCATION;
 import static com.linkedin.venice.CommonConfigKeys.SSL_TRUSTSTORE_PASSWORD;
 
@@ -11,6 +12,7 @@ import java.util.Properties;
 
 
 public class SSLConfig {
+  public static final boolean SSL_REQUIRE_CLIENT_CERTS_DEFAULT_VALUE = true;
   private String _keyStoreData = "";
   private String _keyStorePassword = "";
   private String _keyStoreType = "jks";
@@ -18,7 +20,7 @@ public class SSLConfig {
   private String _trustStoreFilePath = "";
   private String _trustStoreFilePassword = "";
   private boolean _sslEnabled = false;
-  private boolean _sslRequireClientCerts = true;
+  private boolean _sslRequireClientCerts = SSL_REQUIRE_CLIENT_CERTS_DEFAULT_VALUE;
   private boolean _requireClientCertOnLocalHost = false;
 
   public void setKeyStoreData(String keyStoreData) {
@@ -104,6 +106,8 @@ public class SSLConfig {
     config.setTrustStoreFilePath(sslProperties.getProperty(SSL_TRUSTSTORE_LOCATION));
     config.setKeyStorePassword(sslProperties.getProperty(SSL_KEYSTORE_PASSWORD));
     config.setTrustStoreFilePassword(sslProperties.getProperty(SSL_TRUSTSTORE_PASSWORD));
+    config.setSslRequireClientCerts(
+        Boolean.valueOf(sslProperties.getProperty(SSL_NEEDS_CLIENT_CERT, SSL_REQUIRE_CLIENT_CERTS_DEFAULT_VALUE + "")));
     return config;
   }
 

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/utils/SslUtils.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/utils/SslUtils.java
@@ -202,6 +202,8 @@ public class SslUtils {
     config.setKeyStoreFilePath(sslConfig.getKeyStoreFilePath());
     config.setTrustStoreFilePath(sslConfig.getTrustStoreFilePath());
     config.setTrustStoreFilePassword(sslConfig.getTrustStoreFilePassword());
+    config.setSslRequireClientCerts(sslConfig.doesSslRequireClientCerts());
+    config.setRequireClientCertOnLocalHost(sslConfig.isRequireClientCertOnLocalHost());
     return config;
   }
 

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/security/SSLConfigTest.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/security/SSLConfigTest.java
@@ -1,0 +1,30 @@
+package com.linkedin.venice.security;
+
+import static org.testng.Assert.*;
+
+import com.linkedin.venice.CommonConfigKeys;
+import java.util.Properties;
+import org.testng.annotations.Test;
+
+
+public class SSLConfigTest {
+  @Test
+  public void testBuildFromProperties() {
+    final Properties properties = new Properties();
+    properties.setProperty(CommonConfigKeys.SSL_ENABLED, "true");
+    properties.setProperty(CommonConfigKeys.SSL_KEYSTORE_TYPE, "JKS");
+    properties.setProperty(CommonConfigKeys.SSL_KEYSTORE_LOCATION, "/local/path");
+    properties.setProperty(CommonConfigKeys.SSL_TRUSTSTORE_LOCATION, "/local/pathts");
+    properties.setProperty(CommonConfigKeys.SSL_KEYSTORE_PASSWORD, "keystorepwd");
+    properties.setProperty(CommonConfigKeys.SSL_TRUSTSTORE_PASSWORD, "truststorepwd");
+    properties.setProperty(CommonConfigKeys.SSL_NEEDS_CLIENT_CERT, "false");
+    final SSLConfig sslConfig = SSLConfig.buildConfig(properties);
+    assertTrue(sslConfig.getSslEnabled());
+    assertEquals(sslConfig.getKeyStoreFilePath(), "/local/path");
+    assertEquals(sslConfig.getKeyStorePassword(), "keystorepwd");
+    assertEquals(sslConfig.getKeyStoreType(), "JKS");
+    assertEquals(sslConfig.getTrustStoreFilePassword(), "truststorepwd");
+    assertEquals(sslConfig.getTrustStoreFilePath(), "/local/pathts");
+    assertFalse(sslConfig.doesSslRequireClientCerts());
+  }
+}

--- a/internal/venice-common/src/main/java/com/linkedin/venice/acl/handler/StoreAclHandler.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/acl/handler/StoreAclHandler.java
@@ -17,6 +17,7 @@ import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.ssl.SslHandler;
 import io.netty.util.ReferenceCountUtil;
 import java.net.URI;
+import java.security.cert.Certificate;
 import java.security.cert.X509Certificate;
 import java.util.stream.Collectors;
 import javax.net.ssl.SSLPeerUnverifiedException;
@@ -48,7 +49,7 @@ public class StoreAclHandler extends SimpleChannelInboundHandler<HttpRequest> {
     return resourceName;
   }
 
-  protected X509Certificate extractClientCert(ChannelHandlerContext ctx) throws SSLPeerUnverifiedException {
+  protected X509Certificate extractClientCert(ChannelHandlerContext ctx) {
     SslHandler sslHandler = ctx.pipeline().get(SslHandler.class);
     if (sslHandler == null) {
       /**
@@ -56,7 +57,14 @@ public class StoreAclHandler extends SimpleChannelInboundHandler<HttpRequest> {
        */
       sslHandler = ctx.channel().parent().pipeline().get(SslHandler.class);
     }
-    return SslUtils.getX509Certificate(sslHandler.engine().getSession().getPeerCertificates()[0]);
+    final Certificate[] peerCertificates;
+    try {
+      peerCertificates = sslHandler.engine().getSession().getPeerCertificates();
+    } catch (SSLPeerUnverifiedException exception) {
+      return null;
+    }
+
+    return SslUtils.getX509Certificate(peerCertificates[0]);
   }
 
   /**

--- a/services/venice-server/src/main/java/com/linkedin/venice/listener/ServerStoreAclHandler.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/listener/ServerStoreAclHandler.java
@@ -2,16 +2,12 @@ package com.linkedin.venice.listener;
 
 import com.linkedin.venice.acl.DynamicAccessController;
 import com.linkedin.venice.acl.handler.StoreAclHandler;
-import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.meta.ReadOnlyStoreRepository;
 import com.linkedin.venice.meta.Version;
-import com.linkedin.venice.utils.SslUtils;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http.HttpRequest;
-import io.netty.handler.ssl.SslHandler;
 import io.netty.util.Attribute;
 import io.netty.util.ReferenceCountUtil;
-import java.security.cert.X509Certificate;
 import javax.net.ssl.SSLPeerUnverifiedException;
 
 
@@ -46,16 +42,6 @@ public class ServerStoreAclHandler extends StoreAclHandler {
       ctx.fireChannelRead(req);
     } else {
       super.channelRead0(ctx, req);
-    }
-  }
-
-  @Override
-  protected X509Certificate extractClientCert(ChannelHandlerContext ctx) throws SSLPeerUnverifiedException {
-    SslHandler sslHandler = ServerHandlerUtils.extractSslHandler(ctx);
-    if (sslHandler != null) {
-      return SslUtils.getX509Certificate(sslHandler.engine().getSession().getPeerCertificates()[0]);
-    } else {
-      throw new VeniceException("Failed to extract client cert from the incoming request");
     }
   }
 


### PR DESCRIPTION
## Summary, imperative, start upper case, don't end with a period

It's not possible to configure the ssl field `sslRequireClientCerts` via configuration. 
With the new authentication provider, mTLS auth is not required when TLS is enabled and therefore must be configurable in the router component.

Changes: 
* Copy the value `ssl.needs.client.cert` from the properties
* Reduce log for `SSLPeerUnverifiedException` when `needClientAuth=false`
* Allow storeAcl (both for Router and Server) to perform acl without a client certificate 


## How was this PR tested?
Added unit tests and tested manually.

## Does this PR introduce any user-facing changes?
- [ ] No. You can skip the rest of this section.
- [x] Yes. Make sure to explain your proposed changes and call out the behavior change.

`ssl.needs.client.cert` is now considered in the router SSL config