### PR TITLE
[controller] Make any controller able to register meta system store schemas

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -646,6 +646,7 @@ ext.createDiffFile = { ->
         ':!internal/venice-test-common/*',
         ':!services/venice-server/src/main/java/com/linkedin/venice/server/VeniceServer.java',
         ':!internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerClient.java',
+        ':!services/venice-controller/src/main/java/com/linkedin/venice/controller/init/*',
         ':!services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceController.java',
         ':!services/venice-router/src/main/java/com/linkedin/venice/router/RouterServer.java',
         ':!services/venice-router/src/main/java/com/linkedin/venice/router/streaming/VeniceChunkedResponse.java',

--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -364,6 +364,12 @@ public class ConfigKeys {
   public static final String CONTROLLER_PARENT_EXTERNAL_SUPERSET_SCHEMA_GENERATION_ENABLED =
       "controller.parent.external.superset.schema.generation.enabled";
 
+  /**
+   * Whether to initialize system schemas when controller starts. Default is true.
+   */
+  public static final String SYSTEM_SCHEMA_INITIALIZATION_AT_START_TIME_ENABLED =
+      "system.schema.initialization.at.start.time.enabled";
+
   // Server specific configs
   public static final String LISTENER_PORT = "listener.port";
 

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/restart/TestRestartController.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/restart/TestRestartController.java
@@ -182,7 +182,6 @@ public class TestRestartController {
 
     cluster.restartVeniceController(oldLeaderPort);
     controllerWrapper = cluster.getLeaderVeniceController();
-    Assert.assertEquals(controllerWrapper.getPort(), newLeaderPort);
     duration1 = controllerWrapper.getMetricRepository()
         .getMetric("." + storeName + "--successful_push_duration_sec_gauge.Gauge")
         .value();

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceController.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceController.java
@@ -14,7 +14,6 @@ import com.linkedin.venice.controller.kafka.TopicCleanupService;
 import com.linkedin.venice.controller.kafka.TopicCleanupServiceForParentController;
 import com.linkedin.venice.controller.server.AdminSparkServer;
 import com.linkedin.venice.controller.supersetschema.SupersetSchemaGenerator;
-import com.linkedin.venice.controllerapi.UpdateStoreQueryParams;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.pubsub.PubSubTopicRepository;
 import com.linkedin.venice.serialization.avro.AvroProtocolDefinition;
@@ -30,7 +29,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
-import java.util.concurrent.TimeUnit;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -249,19 +247,13 @@ public class VeniceController {
     if (!multiClusterConfigs.isParent() && multiClusterConfigs.isZkSharedMetaSystemSchemaStoreAutoCreationEnabled()
         && multiClusterConfigs.getControllerConfig(systemStoreCluster)
             .isSystemSchemaInitializationAtStartTimeEnabled()) {
-      UpdateStoreQueryParams metadataSystemStoreUpdate =
-          new UpdateStoreQueryParams().setHybridRewindSeconds(TimeUnit.DAYS.toSeconds(1)) // 1 day rewind
-              .setHybridOffsetLagThreshold(1)
-              .setHybridTimeLagThreshold(-1) // Explicitly disable hybrid time lag measurement on system store
-              .setWriteComputationEnabled(true)
-              .setPartitionCount(1);
       ControllerClientBackedSystemSchemaInitializer metaSystemStoreSchemaInitializer =
           new ControllerClientBackedSystemSchemaInitializer(
               AvroProtocolDefinition.METADATA_SYSTEM_SCHEMA_STORE,
               systemStoreCluster,
               (VeniceHelixAdmin) admin,
               AvroProtocolDefinition.METADATA_SYSTEM_SCHEMA_STORE_KEY.getCurrentProtocolVersionSchema(),
-              metadataSystemStoreUpdate,
+              VeniceHelixAdmin.DEFAULT_USER_SYSTEM_STORE_UPDATE_QUERY_PARAMS,
               true,
               multiClusterConfigs.isControllerEnforceSSLOnly());
       metaSystemStoreSchemaInitializer.execute();

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerConfig.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerConfig.java
@@ -73,6 +73,7 @@ import static com.linkedin.venice.ConfigKeys.PUSH_JOB_STATUS_STORE_CLUSTER_NAME;
 import static com.linkedin.venice.ConfigKeys.PUSH_STATUS_STORE_ENABLED;
 import static com.linkedin.venice.ConfigKeys.PUSH_STATUS_STORE_HEARTBEAT_EXPIRATION_TIME_IN_SECONDS;
 import static com.linkedin.venice.ConfigKeys.STORAGE_ENGINE_OVERHEAD_RATIO;
+import static com.linkedin.venice.ConfigKeys.SYSTEM_SCHEMA_INITIALIZATION_AT_START_TIME_ENABLED;
 import static com.linkedin.venice.ConfigKeys.TERMINAL_STATE_TOPIC_CHECK_DELAY_MS;
 import static com.linkedin.venice.ConfigKeys.TOPIC_CLEANUP_DELAY_FACTOR;
 import static com.linkedin.venice.ConfigKeys.TOPIC_CLEANUP_SEND_CONCURRENT_DELETES_REQUESTS;
@@ -259,6 +260,8 @@ public class VeniceControllerConfig extends VeniceControllerClusterConfig {
   private final int storeGraveyardCleanupSleepIntervalBetweenListFetchMinutes;
 
   private final boolean parentExternalSupersetSchemaGenerationEnabled;
+
+  private final boolean systemSchemaInitializationAtStartTimeEnabled;
 
   public VeniceControllerConfig(VeniceProperties props) {
     super(props);
@@ -459,6 +462,8 @@ public class VeniceControllerConfig extends VeniceControllerClusterConfig {
         props.getString(CLUSTER_DISCOVERY_D2_SERVICE, ClientConfig.DEFAULT_CLUSTER_DISCOVERY_D2_SERVICE_NAME);
     this.parentExternalSupersetSchemaGenerationEnabled =
         props.getBoolean(CONTROLLER_PARENT_EXTERNAL_SUPERSET_SCHEMA_GENERATION_ENABLED, false);
+    this.systemSchemaInitializationAtStartTimeEnabled =
+        props.getBoolean(SYSTEM_SCHEMA_INITIALIZATION_AT_START_TIME_ENABLED, true);
   }
 
   private void validateActiveActiveConfigs() {
@@ -845,6 +850,10 @@ public class VeniceControllerConfig extends VeniceControllerClusterConfig {
 
   public boolean isParentExternalSupersetSchemaGenerationEnabled() {
     return parentExternalSupersetSchemaGenerationEnabled;
+  }
+
+  public boolean isSystemSchemaInitializationAtStartTimeEnabled() {
+    return systemSchemaInitializationAtStartTimeEnabled;
   }
 
   /**

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -7733,6 +7733,10 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
     return pushStatusStoreReader;
   }
 
+  public Optional<SSLFactory> getSslFactory() {
+    return sslFactory;
+  }
+
   // Visible for testing
   VeniceControllerMultiClusterConfig getMultiClusterConfigs() {
     return multiClusterConfigs;

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -316,6 +316,13 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
 
   static final int VERSION_ID_UNSET = -1;
 
+  static final UpdateStoreQueryParams DEFAULT_USER_SYSTEM_STORE_UPDATE_QUERY_PARAMS =
+      new UpdateStoreQueryParams().setHybridRewindSeconds(TimeUnit.DAYS.toSeconds(1)) // 1 day rewind
+          .setHybridOffsetLagThreshold(1)
+          .setHybridTimeLagThreshold(-1) // Explicitly disable hybrid time lag measurement on system store
+          .setWriteComputationEnabled(true)
+          .setPartitionCount(1);
+
   // TODO remove this field and all invocations once we are fully on HaaS. Use the helixAdminClient instead.
   private final HelixAdmin admin;
   /**
@@ -561,36 +568,24 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
 
     if (multiClusterConfigs.isZkSharedMetaSystemSchemaStoreAutoCreationEnabled()) {
       // Add routine to create zk shared metadata system store
-      UpdateStoreQueryParams metadataSystemStoreUpdate =
-          new UpdateStoreQueryParams().setHybridRewindSeconds(TimeUnit.DAYS.toSeconds(1)) // 1 day rewind
-              .setHybridOffsetLagThreshold(1)
-              .setHybridTimeLagThreshold(-1) // Explicitly disable hybrid time lag measurement on system store
-              .setWriteComputationEnabled(true)
-              .setPartitionCount(1);
       initRoutines.add(
           new SystemSchemaInitializationRoutine(
               AvroProtocolDefinition.METADATA_SYSTEM_SCHEMA_STORE,
               multiClusterConfigs,
               this,
               Optional.of(AvroProtocolDefinition.METADATA_SYSTEM_SCHEMA_STORE_KEY.getCurrentProtocolVersionSchema()),
-              Optional.of(metadataSystemStoreUpdate),
+              Optional.of(DEFAULT_USER_SYSTEM_STORE_UPDATE_QUERY_PARAMS),
               true));
     }
     if (multiClusterConfigs.isZkSharedDaVinciPushStatusSystemSchemaStoreAutoCreationEnabled()) {
       // Add routine to create zk shared da vinci push status system store
-      UpdateStoreQueryParams daVinciPushStatusSystemStoreUpdate =
-          new UpdateStoreQueryParams().setHybridRewindSeconds(TimeUnit.DAYS.toSeconds(1)) // 1 day rewind
-              .setHybridOffsetLagThreshold(1)
-              .setHybridTimeLagThreshold(-1) // Explicitly disable hybrid time lag measurement on system store
-              .setWriteComputationEnabled(true)
-              .setPartitionCount(1);
       initRoutines.add(
           new SystemSchemaInitializationRoutine(
               AvroProtocolDefinition.PUSH_STATUS_SYSTEM_SCHEMA_STORE,
               multiClusterConfigs,
               this,
               Optional.of(AvroProtocolDefinition.PUSH_STATUS_SYSTEM_SCHEMA_STORE_KEY.getCurrentProtocolVersionSchema()),
-              Optional.of(daVinciPushStatusSystemStoreUpdate),
+              Optional.of(DEFAULT_USER_SYSTEM_STORE_UPDATE_QUERY_PARAMS),
               true));
     }
 

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/init/ControllerClientBackedSystemSchemaInitializer.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/init/ControllerClientBackedSystemSchemaInitializer.java
@@ -1,0 +1,246 @@
+package com.linkedin.venice.controller.init;
+
+import static com.linkedin.venice.ConfigKeys.CONTROLLER_SYSTEM_SCHEMA_CLUSTER_NAME;
+
+import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
+import com.linkedin.venice.VeniceConstants;
+import com.linkedin.venice.controller.VeniceHelixAdmin;
+import com.linkedin.venice.controllerapi.ControllerClient;
+import com.linkedin.venice.controllerapi.ControllerResponse;
+import com.linkedin.venice.controllerapi.MultiSchemaResponse;
+import com.linkedin.venice.controllerapi.NewStoreResponse;
+import com.linkedin.venice.controllerapi.SchemaResponse;
+import com.linkedin.venice.controllerapi.StoreResponse;
+import com.linkedin.venice.controllerapi.UpdateStoreQueryParams;
+import com.linkedin.venice.exceptions.VeniceException;
+import com.linkedin.venice.exceptions.VeniceNoStoreException;
+import com.linkedin.venice.schema.writecompute.WriteComputeSchemaConverter;
+import com.linkedin.venice.serialization.avro.AvroProtocolDefinition;
+import com.linkedin.venice.utils.Pair;
+import com.linkedin.venice.utils.Utils;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.avro.Schema;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+
+public class ControllerClientBackedSystemSchemaInitializer {
+  private static final Logger LOGGER = LogManager.getLogger(ControllerClientBackedSystemSchemaInitializer.class);
+  private static final String DEFAULT_KEY_SCHEMA_STR = "\"int\"";
+  private static final int DEFAULT_RETRY_TIMES = 10;
+
+  private final AvroProtocolDefinition protocolDefinition;
+  private final String clusterName;
+  private final VeniceHelixAdmin admin;
+  private final Schema keySchema;
+  private final UpdateStoreQueryParams storeMetadataUpdate;
+  private final boolean autoRegisterDerivedComputeSchema;
+  private final boolean enforceSSLOnly;
+  private ControllerClient controllerClient;
+
+  public ControllerClientBackedSystemSchemaInitializer(
+      AvroProtocolDefinition protocolDefinition,
+      String systemStoreCluster,
+      VeniceHelixAdmin admin,
+      Schema keySchema,
+      UpdateStoreQueryParams storeMetadataUpdate,
+      boolean autoRegisterDerivedComputeSchema,
+      boolean enforceSSLOnly) {
+    this.protocolDefinition = protocolDefinition;
+    this.clusterName = systemStoreCluster;
+    this.admin = admin;
+    this.keySchema = keySchema;
+    this.storeMetadataUpdate = storeMetadataUpdate;
+    this.autoRegisterDerivedComputeSchema = autoRegisterDerivedComputeSchema;
+    this.enforceSSLOnly = enforceSSLOnly;
+  }
+
+  public void execute() {
+    String storeName = protocolDefinition.getSystemStoreName();
+    Map<Integer, Schema> schemasInLocalResources = Utils.getAllSchemasFromResources(protocolDefinition);
+
+    String leaderControllerUrl = admin.getLeaderController(clusterName).getUrl(enforceSSLOnly);
+    controllerClient =
+        ControllerClient.constructClusterControllerClient(clusterName, leaderControllerUrl, admin.getSslFactory());
+    try {
+      Pair<String, String> clusterNameAndD2 = admin.discoverCluster(storeName);
+      String currSystemStoreCluster = clusterNameAndD2.getFirst();
+      if (!currSystemStoreCluster.equals(clusterName)) {
+        LOGGER.warn(
+            "The system store for {} already exists in cluster {}, "
+                + "which is inconsistent with the config {} which specifies that it "
+                + "should be in cluster {}. Will abort the initialization routine.",
+            protocolDefinition.name(),
+            currSystemStoreCluster,
+            CONTROLLER_SYSTEM_SCHEMA_CLUSTER_NAME,
+            clusterName);
+        return;
+      }
+    } catch (VeniceNoStoreException e) {
+      checkAndMayCreateSystemStore(storeName, schemasInLocalResources.get(1));
+    }
+
+    // Only verify the key schema if it is explicitly specified by the caller. We don't care about the dummy key schema.
+    if (keySchema != null) {
+      checkIfKeySchemaMatches(storeName);
+    }
+
+    MultiSchemaResponse multiSchemaResponse =
+        controllerClient.retryableRequest(DEFAULT_RETRY_TIMES, c -> c.getAllValueSchema(storeName));
+    if (multiSchemaResponse.isError()) {
+      throw new VeniceException(
+          "Error when getting all value schemas from system store " + storeName + " in cluster " + clusterName
+              + " after retries. Error: " + multiSchemaResponse.getError());
+    }
+    Map<Integer, Schema> schemasInZk = new HashMap<>();
+    Arrays.stream(multiSchemaResponse.getSchemas())
+        .forEach(schema -> schemasInZk.put(schema.getId(), AvroCompatibilityHelper.parse(schema.getSchemaStr())));
+    for (int version = 1; version <= protocolDefinition.getCurrentProtocolVersion(); version++) {
+      Schema schemaInLocalResources = schemasInLocalResources.get(version);
+      if (schemaInLocalResources == null) {
+        throw new VeniceException(
+            "Invalid protocol definition: " + protocolDefinition.name() + " does not have a version " + version
+                + " even though that is inferior to the current version ("
+                + protocolDefinition.getCurrentProtocolVersion() + ").");
+      }
+      checkAndMayRegisterValueSchema(storeName, version, schemasInZk.get(version), schemaInLocalResources);
+
+      if (autoRegisterDerivedComputeSchema) {
+        checkAndMayRegisterWriteComputeSchema(storeName, version, schemaInLocalResources);
+      }
+    }
+  }
+
+  private void checkAndMayCreateSystemStore(String storeName, Schema firstValueSchema) {
+    StoreResponse storeResponse = controllerClient.retryableRequest(
+        DEFAULT_RETRY_TIMES,
+        c -> c.getStore(storeName),
+        r -> r.getError().contains("does not exist"));
+    if (storeResponse.isError()) {
+      if (storeResponse.getError().contains("does not exist")) {
+        if (firstValueSchema == null) {
+          throw new VeniceException("Protocol definition: " + protocolDefinition.name() + " does not have version 1");
+        }
+        String firstKeySchemaStr = keySchema == null ? DEFAULT_KEY_SCHEMA_STR : keySchema.toString();
+        String firstValueSchemaStr = firstValueSchema.toString();
+        NewStoreResponse newStoreResponse = controllerClient.retryableRequest(
+            DEFAULT_RETRY_TIMES,
+            c -> c.createNewSystemStore(
+                storeName,
+                VeniceConstants.SYSTEM_STORE_OWNER,
+                firstKeySchemaStr,
+                firstValueSchemaStr),
+            r -> r.getError().contains("already exists"));
+        if (newStoreResponse.isError() && !newStoreResponse.getError().contains("already exists")) {
+          throw new VeniceException(
+              "Error when creating system store " + storeName + " in cluster " + clusterName + " after retries. Error: "
+                  + newStoreResponse.getError());
+        }
+
+        if (storeMetadataUpdate != null) {
+          ControllerResponse updateStoreResponse = controllerClient
+              .retryableRequest(DEFAULT_RETRY_TIMES, c -> c.updateStore(storeName, storeMetadataUpdate));
+          if (updateStoreResponse.isError()) {
+            throw new VeniceException(
+                "Error when updating system store " + storeName + " in cluster " + clusterName
+                    + " after retries. Error: " + updateStoreResponse.getError());
+          }
+          LOGGER.info("System store {} has been created.", storeName);
+        }
+      } else {
+        throw new VeniceException(
+            "Error when getting system store " + storeName + " from cluster " + clusterName + " after retries. Error: "
+                + storeResponse.getError());
+      }
+    }
+  }
+
+  private void checkIfKeySchemaMatches(String storeName) {
+    SchemaResponse keySchemaResponse =
+        controllerClient.retryableRequest(DEFAULT_RETRY_TIMES, c -> c.getKeySchema(storeName));
+    if (keySchemaResponse.isError()) {
+      throw new VeniceException(
+          "Error when getting key schema from system store " + storeName + " in cluster " + clusterName
+              + " after retries. Error: " + keySchemaResponse.getError());
+    }
+    Schema curKeySchema = AvroCompatibilityHelper.parse(keySchemaResponse.getSchemaStr());
+    if (!curKeySchema.equals(keySchema)) {
+      LOGGER.error(
+          "Key Schema of {} in cluster {} is already registered but it is INCONSISTENT with the local definition.\n"
+              + "Already registered: {}\n" + "Local definition: {}",
+          storeName,
+          clusterName,
+          curKeySchema.toString(true),
+          keySchema.toString(true));
+    }
+  }
+
+  private void checkAndMayRegisterValueSchema(
+      String storeName,
+      int valueSchemaId,
+      Schema schemaInZk,
+      Schema schemaInLocalResources) {
+    if (schemaInZk == null) {
+      SchemaResponse addValueSchemaResponse = controllerClient.retryableRequest(
+          DEFAULT_RETRY_TIMES,
+          c -> c.addValueSchema(storeName, schemaInLocalResources.toString(), valueSchemaId));
+      if (addValueSchemaResponse.isError()) {
+        throw new VeniceException(
+            "Error when adding value schema " + valueSchemaId + " to system store " + storeName + " in cluster "
+                + clusterName + " after retries. Error: " + addValueSchemaResponse.getError());
+      }
+      LOGGER.info("Added new schema v{} to system store {}.", valueSchemaId, storeName);
+    } else {
+      if (schemaInZk.equals(schemaInLocalResources)) {
+        LOGGER.info(
+            "Schema v{} in system store {} is already registered and consistent with the local definition.",
+            valueSchemaId,
+            storeName);
+      } else {
+        LOGGER.warn(
+            "Schema v{} in system store {} is already registered but it is INCONSISTENT with the local definition.\n"
+                + "Already registered: {}\n" + "Local definition: {}",
+            valueSchemaId,
+            storeName,
+            schemaInZk.toString(true),
+            schemaInLocalResources.toString(true));
+      }
+    }
+  }
+
+  private void checkAndMayRegisterWriteComputeSchema(
+      String storeName,
+      int valueSchemaId,
+      Schema schemaInLocalResources) {
+    String writeComputeSchema =
+        WriteComputeSchemaConverter.getInstance().convertFromValueRecordSchema(schemaInLocalResources).toString();
+    SchemaResponse getSchemaResponse = controllerClient.retryableRequest(
+        DEFAULT_RETRY_TIMES,
+        c -> c.getValueOrDerivedSchemaId(storeName, writeComputeSchema),
+        r -> r.getError().contains("Can not find any registered value schema nor derived schema"));
+    if (getSchemaResponse.isError()) {
+      if (getSchemaResponse.getError().contains("Can not find any registered value schema nor derived schema")) {
+        // The derived schema doesn't exist right now, try to register it.
+        SchemaResponse addDerivedSchemaResponse = controllerClient.retryableRequest(
+            DEFAULT_RETRY_TIMES,
+            c -> c.addDerivedSchema(storeName, valueSchemaId, writeComputeSchema));
+        if (addDerivedSchemaResponse.isError()) {
+          throw new VeniceException(
+              "Error when adding derived schema for value schema v" + valueSchemaId + " to system store " + storeName
+                  + " in cluster " + clusterName + " after retries. Error: " + addDerivedSchemaResponse.getError());
+        }
+        LOGGER.info(
+            "Added derived schema v{} for value schema v{} to system store {}.",
+            addDerivedSchemaResponse.getDerivedSchemaId(),
+            valueSchemaId,
+            storeName);
+      } else {
+        throw new VeniceException(
+            "Error when getting derived schema from system store " + storeName + " in cluster " + clusterName
+                + " after retries. Error: " + getSchemaResponse.getError());
+      }
+    }
+  }
+}


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Summary
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->



Problem: Today only system schema cluster leader controller is able to register new meta system store value and write compute schemas into local region system store. When meta system store value schema upgrades, we must deploy system schema cluster leader controller first, and then deploy other controllers, which is painful and error prone.

If another controller deploys first, does not register new schemas, but produces value with new schemas, servers could not find the schema in local region system store for deserialization. Meta system store ingestion will fail.

Fix: When any controller starts, call system schema cluster leader controller to register unknown meta system store value schema and write compute schema via controller client. If this step fails, controller start will fail too, to prevent controllers from producing with unknown meta system store schemas that servers could not find.

Note: The commit only enforces meta system store schema registeration at start time for child controllers. Parent controllers are not enforced for 2 reasons: (1) Add value schema with schema id is not yet supported in parent controllers. (2) Parent controller meta system store schema registeration order is not important as there is no server ingesting meta system store in parent region.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
Internal CI JDK11 and JDK8
All integration tests controller starts run the new code to check and register unknown meta system store value and write compute schemas.

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.