### PR TITLE
[all] Fix Avro serialization errors when map contains keys of different subclasses

### DIFF
--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/serializer/AvroSerializer.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/serializer/AvroSerializer.java
@@ -18,7 +18,7 @@ import org.apache.logging.log4j.Logger;
 
 
 /**
- * {@code AvroSerializer} provides the functionality to serialize and deserialize objects by using Avro.
+ * {@code AvroSerializer} provides the functionality to serialize objects by using Avro.
  */
 public class AvroSerializer<K> implements RecordSerializer<K> {
   private static final Logger LOGGER = LogManager.getLogger(AvroSerializer.class);

--- a/internal/venice-client-common/src/main/java/org/apache/avro/generic/DeterministicMapOrderDatumWriter.java
+++ b/internal/venice-client-common/src/main/java/org/apache/avro/generic/DeterministicMapOrderDatumWriter.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.util.ConcurrentModificationException;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 import org.apache.avro.Schema;
 import org.apache.avro.io.Encoder;
@@ -18,16 +19,36 @@ public interface DeterministicMapOrderDatumWriter {
 
   default void writeMapWithDeterministicOrder(Schema schema, Object datum, Encoder out) throws IOException {
     Schema valueSchemaType = schema.getValueType();
-    Map map = (Map) datum;
+    Map<? extends CharSequence, Object> map = (Map<? extends CharSequence, Object>) datum;
     final int expectedMapSize = map.size();
     int actualSize = 0;
     out.writeMapStart();
     out.setItemCount(expectedMapSize);
 
-    List<Map.Entry> sortedEntryList =
-        (List<Map.Entry>) map.entrySet().stream().sorted(Map.Entry.comparingByKey()).collect(Collectors.toList());
+    List<Map.Entry<? extends CharSequence, Object>> sortedEntryList = map.entrySet().stream().sorted((e1, e2) -> {
+      // TODO: Replace with CharSequence#compare once the code has completely migrated to JDK11+
+      CharSequence cs1 = e1.getKey();
+      CharSequence cs2 = e2.getKey();
+      if (Objects.requireNonNull(cs1) == Objects.requireNonNull(cs2)) {
+        return 0;
+      }
 
-    for (Map.Entry entry: sortedEntryList) {
+      if (cs1.getClass() == cs2.getClass() && cs1 instanceof Comparable) {
+        return ((Comparable<Object>) cs1).compareTo(cs2);
+      }
+
+      for (int i = 0, len = Math.min(cs1.length(), cs2.length()); i < len; i++) {
+        char a = cs1.charAt(i);
+        char b = cs2.charAt(i);
+        if (a != b) {
+          return a - b;
+        }
+      }
+
+      return cs1.length() - cs2.length();
+    }).collect(Collectors.toList());
+
+    for (Map.Entry<? extends CharSequence, Object> entry: sortedEntryList) {
       out.startItem();
       out.writeString((CharSequence) entry.getKey().toString());
       internalWrite(valueSchemaType, entry.getValue(), out);

--- a/internal/venice-client-common/src/main/java/org/apache/avro/generic/DeterministicMapOrderDatumWriter.java
+++ b/internal/venice-client-common/src/main/java/org/apache/avro/generic/DeterministicMapOrderDatumWriter.java
@@ -1,11 +1,12 @@
 package org.apache.avro.generic;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.ConcurrentModificationException;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.stream.Collectors;
 import org.apache.avro.Schema;
 import org.apache.avro.io.Encoder;
 
@@ -15,38 +16,44 @@ import org.apache.avro.io.Encoder;
  * the same as natural ordering of map keys.
  */
 public interface DeterministicMapOrderDatumWriter {
+  Comparator<Map.Entry<? extends CharSequence, Object>> COMPARATOR = (e1, e2) -> {
+    // TODO: Replace with CharSequence#compare once the code has completely migrated to JDK11+
+    CharSequence cs1 = e1.getKey();
+    CharSequence cs2 = e2.getKey();
+    if (Objects.requireNonNull(cs1) == Objects.requireNonNull(cs2)) {
+      return 0;
+    }
+
+    if (cs1.getClass() == cs2.getClass() && cs1 instanceof Comparable) {
+      return ((Comparable<Object>) cs1).compareTo(cs2);
+    }
+
+    for (int i = 0, len = Math.min(cs1.length(), cs2.length()); i < len; i++) {
+      char a = cs1.charAt(i);
+      char b = cs2.charAt(i);
+      if (a != b) {
+        return a - b;
+      }
+    }
+
+    return cs1.length() - cs2.length();
+  };
+
   void internalWrite(Schema schema, Object datum, Encoder out) throws IOException;
 
   default void writeMapWithDeterministicOrder(Schema schema, Object datum, Encoder out) throws IOException {
     Schema valueSchemaType = schema.getValueType();
+
+    @SuppressWarnings("unchecked")
     Map<? extends CharSequence, Object> map = (Map<? extends CharSequence, Object>) datum;
+
     final int expectedMapSize = map.size();
     int actualSize = 0;
     out.writeMapStart();
     out.setItemCount(expectedMapSize);
 
-    List<Map.Entry<? extends CharSequence, Object>> sortedEntryList = map.entrySet().stream().sorted((e1, e2) -> {
-      // TODO: Replace with CharSequence#compare once the code has completely migrated to JDK11+
-      CharSequence cs1 = e1.getKey();
-      CharSequence cs2 = e2.getKey();
-      if (Objects.requireNonNull(cs1) == Objects.requireNonNull(cs2)) {
-        return 0;
-      }
-
-      if (cs1.getClass() == cs2.getClass() && cs1 instanceof Comparable) {
-        return ((Comparable<Object>) cs1).compareTo(cs2);
-      }
-
-      for (int i = 0, len = Math.min(cs1.length(), cs2.length()); i < len; i++) {
-        char a = cs1.charAt(i);
-        char b = cs2.charAt(i);
-        if (a != b) {
-          return a - b;
-        }
-      }
-
-      return cs1.length() - cs2.length();
-    }).collect(Collectors.toList());
+    List<Map.Entry<? extends CharSequence, Object>> sortedEntryList = new ArrayList<>(map.entrySet());
+    sortedEntryList.sort(COMPARATOR);
 
     for (Map.Entry<? extends CharSequence, Object> entry: sortedEntryList) {
       out.startItem();

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/serializer/AvroSerializerTest.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/serializer/AvroSerializerTest.java
@@ -1,12 +1,15 @@
 package com.linkedin.venice.serializer;
 
-import static org.testng.Assert.*;
-
 import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.util.Utf8;
 import org.apache.commons.lang.ArrayUtils;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -34,5 +37,28 @@ public class AvroSerializerTest {
     Assert.assertEquals(
         serializer.serializeObjects(array, ByteBuffer.wrap(prefixBytes)),
         ArrayUtils.addAll(prefixBytes, expectedSerializedArray));
+  }
+
+  @Test
+  public void testDeterministicallySerializeMapWithDifferentSubclass() {
+    String recordSchema = "{\n" + "    \"type\": \"record\",\n" + "    \"namespace\": \"com.linkedin.avro\",\n"
+        + "    \"name\": \"Person\",\n" + "    \"fields\": [\n" + "        {\n"
+        + "            \"name\": \"MapField\",\n" + "            \"type\": {\n" + "                \"type\": \"map\",\n"
+        + "                \"values\": \"string\"\n" + "            }\n" + "        }\n" + "    ]\n" + "}";
+
+    Schema valueSchema = AvroCompatibilityHelper.parse(recordSchema);
+    AvroSerializer<GenericRecord> serializer = new AvroSerializer<>(valueSchema);
+
+    Map<CharSequence, CharSequence> map = new LinkedHashMap<>();
+    map.put("key1", "valueStr");
+    map.put(new Utf8("key2"), "valueUtf8");
+    map.put(new Utf8("key3"), "valueUtf8_2");
+    map.put("key4", "valueStr_2");
+
+    GenericRecord record = new GenericData.Record(valueSchema);
+    record.put("MapField", map);
+
+    // Verify no error is thrown
+    serializer.serialize(record);
   }
 }

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/serializer/AvroSerializerTest.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/serializer/AvroSerializerTest.java
@@ -58,7 +58,7 @@ public class AvroSerializerTest {
     GenericRecord record = new GenericData.Record(valueSchema);
     record.put("MapField", map);
 
-    // Verify no error is thrown
+    // Verify no exception is thrown
     serializer.serialize(record);
   }
 }

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/serializer/AvroSerializerTest.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/serializer/AvroSerializerTest.java
@@ -49,11 +49,12 @@ public class AvroSerializerTest {
     Schema valueSchema = AvroCompatibilityHelper.parse(recordSchema);
     AvroSerializer<GenericRecord> serializer = new AvroSerializer<>(valueSchema);
 
-    Map<CharSequence, CharSequence> map = new LinkedHashMap<>();
+    Map<Object, Object> map = new LinkedHashMap<>();
     map.put("key1", "valueStr");
     map.put(new Utf8("key2"), "valueUtf8");
     map.put(new Utf8("key3"), "valueUtf8_2");
     map.put("key4", "valueStr_2");
+    map.put(10L, "valueStr_2");
 
     GenericRecord record = new GenericData.Record(valueSchema);
     record.put("MapField", map);


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Fix Avro serialization errors when map contains keys of different subclasses
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
When using `DeterministicMapOrderDatumWriter`, the code compares the keys to sort them. However, it assumes that the datatype is a `Comparable`. The code also doesn't specify the generic classes, leaving it up to the runtime to figure that out. Since `CharSequence` is not a comparable, If the map contains a `String` and a `Utf8`, the runtime will use either one of the two as the class for the generic type (say `Utf8`) and on running `compareTo`, it will try to cast `String` to `Utf8` which throws an exception:
```class java.lang.String cannot be cast to class org.apache.avro.util.Utf8```
This change copies code from `CharSequence#compare` (only available in JDK11+) to allow comparing two `CharSequence` objects.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
Added UT. GH CI.

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.