### PR TITLE
[controller] Offline push status will also monitor Da Vinci push status store if enabled

### DIFF
--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -1640,6 +1640,14 @@ public class ConfigKeys {
    */
   public static final String PUSH_STATUS_STORE_ENABLED = "push.status.store.enabled";
 
+  // Config to check whether the offline push will also monitor Da Vinci push status.
+  public static final String OFFLINE_PUSH_MONITOR_DAVINCI_PUSH_STATUS_ENABLED =
+      "offline.push.monitor.davinci.push.status.enabled";
+
+  // Config to determine the Da Vinci push status scanning interval in seconds.
+  public static final String OFFLINE_PUSH_MONITOR_DAVINCI_PUSH_STATUS_SCAN_INTERVAL_IN_SECONDS =
+      "offline.push.monitor.davinci.push.status.scan.interval.in.seconds";
+
   public static final String CONTROLLER_ZK_SHARED_DAVINCI_PUSH_STATUS_SYSTEM_SCHEMA_STORE_AUTO_CREATION_ENABLED =
       "controller.zk.shared.davinci.push.status.system.schema.store.auto.creation.enabled";
 

--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -1648,6 +1648,10 @@ public class ConfigKeys {
   public static final String OFFLINE_PUSH_MONITOR_DAVINCI_PUSH_STATUS_SCAN_INTERVAL_IN_SECONDS =
       "offline.push.monitor.davinci.push.status.scan.interval.in.seconds";
 
+  // Config to determine the Da Vinci push status scanning worker thread number.
+  public static final String OFFLINE_PUSH_MONITOR_DAVINCI_PUSH_STATUS_SCAN_THREAD_NUMBER =
+      "offline.push.monitor.davinci.push.status.scan.thread.number";
+
   public static final String CONTROLLER_ZK_SHARED_DAVINCI_PUSH_STATUS_SYSTEM_SCHEMA_STORE_AUTO_CREATION_ENABLED =
       "controller.zk.shared.davinci.push.status.system.schema.store.auto.creation.enabled";
 

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/controller/TestVeniceHelixResources.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/controller/TestVeniceHelixResources.java
@@ -1,6 +1,8 @@
 package com.linkedin.venice.controller;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import com.linkedin.venice.helix.HelixAdapterSerializer;
 import com.linkedin.venice.helix.HelixReadOnlyZKSharedSchemaRepository;

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/controller/TestVeniceHelixResources.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/controller/TestVeniceHelixResources.java
@@ -1,7 +1,6 @@
 package com.linkedin.venice.controller;
 
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.*;
 
 import com.linkedin.venice.helix.HelixAdapterSerializer;
 import com.linkedin.venice.helix.HelixReadOnlyZKSharedSchemaRepository;
@@ -56,6 +55,11 @@ public class TestVeniceHelixResources {
         .getReadOnlyZKSharedSystemStoreRepository();
     doReturn(mock(HelixReadOnlyZKSharedSchemaRepository.class)).when(veniceHelixAdmin)
         .getReadOnlyZKSharedSchemaRepository();
+    VeniceControllerConfig controllerConfig = mock(VeniceControllerConfig.class);
+    when(controllerConfig.getOfflinePushMonitorDaVinciPushStatusScanThreadNumber()).thenReturn(4);
+    when(controllerConfig.getOfflinePushMonitorDaVinciPushStatusScanIntervalInSeconds()).thenReturn(5);
+    when(controllerConfig.isOfflinePushMonitorDaVinciPushStatusEnabled()).thenReturn(true);
+    when(controllerConfig.getOffLineJobWaitTimeInMilliseconds()).thenReturn(120000L);
     return new HelixVeniceClusterResources(
         cluster,
         zkClient,

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/PushStatusStoreTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/PushStatusStoreTest.java
@@ -2,6 +2,7 @@ package com.linkedin.venice.endToEnd;
 
 import static com.linkedin.venice.ConfigKeys.CLIENT_SYSTEM_STORE_REPOSITORY_REFRESH_INTERVAL_SECONDS;
 import static com.linkedin.venice.ConfigKeys.CLIENT_USE_SYSTEM_STORE_REPOSITORY;
+import static com.linkedin.venice.ConfigKeys.OFFLINE_PUSH_MONITOR_DAVINCI_PUSH_STATUS_SCAN_INTERVAL_IN_SECONDS;
 import static com.linkedin.venice.ConfigKeys.PUSH_STATUS_STORE_ENABLED;
 import static com.linkedin.venice.ConfigKeys.SERVER_PROMOTION_TO_LEADER_REPLICA_DELAY_SECONDS;
 import static com.linkedin.venice.ConfigKeys.USE_PUSH_STATUS_STORE_FOR_INCREMENTAL_PUSH;
@@ -141,6 +142,7 @@ public class PushStatusStoreTest {
     extraBackendConfigMap.put(CLIENT_USE_SYSTEM_STORE_REPOSITORY, true);
     extraBackendConfigMap.put(CLIENT_SYSTEM_STORE_REPOSITORY_REFRESH_INTERVAL_SECONDS, 10);
     extraBackendConfigMap.put(PUSH_STATUS_STORE_ENABLED, true);
+    extraBackendConfigMap.put(OFFLINE_PUSH_MONITOR_DAVINCI_PUSH_STATUS_SCAN_INTERVAL_IN_SECONDS, 5);
 
     try (DaVinciClient<Integer, Integer> daVinciClient = ServiceFactory.getGenericAvroDaVinciClientWithRetries(
         storeName,
@@ -308,6 +310,7 @@ public class PushStatusStoreTest {
 
   private PropertyBuilder getBackendConfigBuilder() {
     return DaVinciTestContext.getDaVinciPropertyBuilder(cluster.getZk().getAddress())
+        .put(OFFLINE_PUSH_MONITOR_DAVINCI_PUSH_STATUS_SCAN_INTERVAL_IN_SECONDS, 5)
         .put(PUSH_STATUS_STORE_ENABLED, true);
   }
 

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestStoreMigration.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestStoreMigration.java
@@ -1,6 +1,7 @@
 package com.linkedin.venice.endToEnd;
 
 import static com.linkedin.venice.ConfigKeys.OFFLINE_JOB_START_TIMEOUT_MS;
+import static com.linkedin.venice.ConfigKeys.OFFLINE_PUSH_MONITOR_DAVINCI_PUSH_STATUS_SCAN_INTERVAL_IN_SECONDS;
 import static com.linkedin.venice.ConfigKeys.PUSH_STATUS_STORE_ENABLED;
 import static com.linkedin.venice.ConfigKeys.SERVER_PROMOTION_TO_LEADER_REPLICA_DELAY_SECONDS;
 import static com.linkedin.venice.ConfigKeys.TOPIC_CLEANUP_SLEEP_INTERVAL_BETWEEN_TOPIC_LIST_FETCH_MS;
@@ -301,6 +302,7 @@ public class TestStoreMigration {
     VeniceProperties backendConfig =
         DaVinciTestContext.getDaVinciPropertyBuilder(multiClusterWrapper.getZkServerWrapper().getAddress())
             .put(PUSH_STATUS_STORE_ENABLED, true)
+            .put(OFFLINE_PUSH_MONITOR_DAVINCI_PUSH_STATUS_SCAN_INTERVAL_IN_SECONDS, 5)
             .build();
     D2Client d2Client =
         D2TestUtils.getAndStartD2Client(multiClusterWrapper.getClusters().get(srcClusterName).getZk().getAddress());

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/integration/utils/VeniceControllerWrapper.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/integration/utils/VeniceControllerWrapper.java
@@ -33,6 +33,7 @@ import static com.linkedin.venice.ConfigKeys.MIN_ACTIVE_REPLICA;
 import static com.linkedin.venice.ConfigKeys.NATIVE_REPLICATION_FABRIC_ALLOWLIST;
 import static com.linkedin.venice.ConfigKeys.NATIVE_REPLICATION_SOURCE_FABRIC;
 import static com.linkedin.venice.ConfigKeys.OFFLINE_JOB_START_TIMEOUT_MS;
+import static com.linkedin.venice.ConfigKeys.OFFLINE_PUSH_MONITOR_DAVINCI_PUSH_STATUS_SCAN_INTERVAL_IN_SECONDS;
 import static com.linkedin.venice.ConfigKeys.PARENT_KAFKA_CLUSTER_FABRIC_LIST;
 import static com.linkedin.venice.ConfigKeys.PERSISTENCE_TYPE;
 import static com.linkedin.venice.ConfigKeys.PUSH_STATUS_STORE_ENABLED;
@@ -197,6 +198,7 @@ public class VeniceControllerWrapper extends ProcessWrapper {
             .put(CONTROLLER_ZK_SHARED_META_SYSTEM_SCHEMA_STORE_AUTO_CREATION_ENABLED, true)
             .put(CONTROLLER_ZK_SHARED_DAVINCI_PUSH_STATUS_SYSTEM_SCHEMA_STORE_AUTO_CREATION_ENABLED, true)
             .put(PUSH_STATUS_STORE_ENABLED, true)
+            .put(OFFLINE_PUSH_MONITOR_DAVINCI_PUSH_STATUS_SCAN_INTERVAL_IN_SECONDS, 5)
             .put(CONCURRENT_INIT_ROUTINES_ENABLED, true)
             .put(CLUSTER_DISCOVERY_D2_SERVICE, VeniceRouterWrapper.CLUSTER_DISCOVERY_D2_SERVICE_NAME)
             .put(extraProps.toProperties());

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/Admin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/Admin.java
@@ -27,6 +27,7 @@ import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.persona.StoragePersona;
 import com.linkedin.venice.pubsub.api.PubSubConsumerAdapterFactory;
 import com.linkedin.venice.pushmonitor.ExecutionStatus;
+import com.linkedin.venice.pushstatushelper.PushStatusStoreReader;
 import com.linkedin.venice.pushstatushelper.PushStatusStoreRecordDeleter;
 import com.linkedin.venice.schema.GeneratedSchemaID;
 import com.linkedin.venice.schema.SchemaEntry;
@@ -892,4 +893,6 @@ public interface Admin extends AutoCloseable, Closeable {
 
   default void clearInstanceMonitor(String clusterName) {
   }
+
+  Optional<PushStatusStoreReader> getPushStatusStoreReader();
 }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/HelixVeniceClusterResources.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/HelixVeniceClusterResources.java
@@ -164,8 +164,7 @@ public class HelixVeniceClusterResources implements VeniceResource {
         aggregateRealTimeSourceKafkaUrl,
         getActiveActiveRealTimeSourceKafkaURLs(config),
         helixAdminClient,
-        config.isErrorLeaderReplicaFailOverEnabled(),
-        config.getOffLineJobWaitTimeInMilliseconds(),
+        config,
         admin.getPushStatusStoreReader().orElse(null));
 
     this.leakedPushStatusCleanUpService = new LeakedPushStatusCleanUpService(

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/HelixVeniceClusterResources.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/HelixVeniceClusterResources.java
@@ -165,7 +165,8 @@ public class HelixVeniceClusterResources implements VeniceResource {
         getActiveActiveRealTimeSourceKafkaURLs(config),
         helixAdminClient,
         config.isErrorLeaderReplicaFailOverEnabled(),
-        config.getOffLineJobWaitTimeInMilliseconds());
+        config.getOffLineJobWaitTimeInMilliseconds(),
+        admin.getPushStatusStoreReader().orElse(null));
 
     this.leakedPushStatusCleanUpService = new LeakedPushStatusCleanUpService(
         clusterName,

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerConfig.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerConfig.java
@@ -62,6 +62,8 @@ import static com.linkedin.venice.ConfigKeys.MIN_NUMBER_OF_UNUSED_KAFKA_TOPICS_T
 import static com.linkedin.venice.ConfigKeys.NATIVE_REPLICATION_FABRIC_ALLOWLIST;
 import static com.linkedin.venice.ConfigKeys.NATIVE_REPLICATION_FABRIC_WHITELIST;
 import static com.linkedin.venice.ConfigKeys.NATIVE_REPLICATION_SOURCE_FABRIC;
+import static com.linkedin.venice.ConfigKeys.OFFLINE_PUSH_MONITOR_DAVINCI_PUSH_STATUS_ENABLED;
+import static com.linkedin.venice.ConfigKeys.OFFLINE_PUSH_MONITOR_DAVINCI_PUSH_STATUS_SCAN_INTERVAL_IN_SECONDS;
 import static com.linkedin.venice.ConfigKeys.PARENT_CONTROLLER_MAX_ERRORED_TOPIC_NUM_TO_KEEP;
 import static com.linkedin.venice.ConfigKeys.PARENT_CONTROLLER_WAITING_TIME_FOR_CONSUMPTION_MS;
 import static com.linkedin.venice.ConfigKeys.PARENT_KAFKA_CLUSTER_FABRIC_LIST;
@@ -186,6 +188,9 @@ public class VeniceControllerConfig extends VeniceControllerClusterConfig {
    * To decide whether to initialize push status store related components.
    */
   private final boolean isDaVinciPushStatusStoreEnabled;
+
+  private final boolean offlinePushMonitorDaVinciPushStatusEnabled;
+  private final int offlinePushMonitorDaVinciPushStatusScanIntervalInSeconds;
 
   private final boolean zkSharedDaVinciPushStatusSystemSchemaStoreAutoCreationEnabled;
 
@@ -410,6 +415,10 @@ public class VeniceControllerConfig extends VeniceControllerClusterConfig {
     this.pushStatusStoreHeartbeatExpirationTimeInSeconds =
         props.getLong(PUSH_STATUS_STORE_HEARTBEAT_EXPIRATION_TIME_IN_SECONDS, TimeUnit.MINUTES.toSeconds(10));
     this.isDaVinciPushStatusStoreEnabled = props.getBoolean(PUSH_STATUS_STORE_ENABLED, false);
+    this.offlinePushMonitorDaVinciPushStatusEnabled =
+        props.getBoolean(OFFLINE_PUSH_MONITOR_DAVINCI_PUSH_STATUS_ENABLED, true) && isDaVinciPushStatusStoreEnabled;
+    this.offlinePushMonitorDaVinciPushStatusScanIntervalInSeconds =
+        props.getInt(OFFLINE_PUSH_MONITOR_DAVINCI_PUSH_STATUS_SCAN_INTERVAL_IN_SECONDS, 30);
     this.zkSharedDaVinciPushStatusSystemSchemaStoreAutoCreationEnabled =
         props.getBoolean(CONTROLLER_ZK_SHARED_DAVINCI_PUSH_STATUS_SYSTEM_SCHEMA_STORE_AUTO_CREATION_ENABLED, false);
     this.systemStoreAclSynchronizationDelayMs =
@@ -715,6 +724,14 @@ public class VeniceControllerConfig extends VeniceControllerClusterConfig {
 
   public boolean isDaVinciPushStatusStoreEnabled() {
     return isDaVinciPushStatusStoreEnabled;
+  }
+
+  public int getOfflinePushMonitorDaVinciPushStatusScanIntervalInSeconds() {
+    return offlinePushMonitorDaVinciPushStatusScanIntervalInSeconds;
+  }
+
+  public boolean isOfflinePushMonitorDaVinciPushStatusEnabled() {
+    return offlinePushMonitorDaVinciPushStatusEnabled;
   }
 
   public boolean isZkSharedDaVinciPushStatusSystemSchemaStoreAutoCreationEnabled() {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerConfig.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerConfig.java
@@ -64,6 +64,7 @@ import static com.linkedin.venice.ConfigKeys.NATIVE_REPLICATION_FABRIC_WHITELIST
 import static com.linkedin.venice.ConfigKeys.NATIVE_REPLICATION_SOURCE_FABRIC;
 import static com.linkedin.venice.ConfigKeys.OFFLINE_PUSH_MONITOR_DAVINCI_PUSH_STATUS_ENABLED;
 import static com.linkedin.venice.ConfigKeys.OFFLINE_PUSH_MONITOR_DAVINCI_PUSH_STATUS_SCAN_INTERVAL_IN_SECONDS;
+import static com.linkedin.venice.ConfigKeys.OFFLINE_PUSH_MONITOR_DAVINCI_PUSH_STATUS_SCAN_THREAD_NUMBER;
 import static com.linkedin.venice.ConfigKeys.PARENT_CONTROLLER_MAX_ERRORED_TOPIC_NUM_TO_KEEP;
 import static com.linkedin.venice.ConfigKeys.PARENT_CONTROLLER_WAITING_TIME_FOR_CONSUMPTION_MS;
 import static com.linkedin.venice.ConfigKeys.PARENT_KAFKA_CLUSTER_FABRIC_LIST;
@@ -191,6 +192,8 @@ public class VeniceControllerConfig extends VeniceControllerClusterConfig {
 
   private final boolean offlinePushMonitorDaVinciPushStatusEnabled;
   private final int offlinePushMonitorDaVinciPushStatusScanIntervalInSeconds;
+
+  private final int offlinePushMonitorDaVinciPushStatusScanThreadNumber;
 
   private final boolean zkSharedDaVinciPushStatusSystemSchemaStoreAutoCreationEnabled;
 
@@ -419,6 +422,9 @@ public class VeniceControllerConfig extends VeniceControllerClusterConfig {
         props.getBoolean(OFFLINE_PUSH_MONITOR_DAVINCI_PUSH_STATUS_ENABLED, true) && isDaVinciPushStatusStoreEnabled;
     this.offlinePushMonitorDaVinciPushStatusScanIntervalInSeconds =
         props.getInt(OFFLINE_PUSH_MONITOR_DAVINCI_PUSH_STATUS_SCAN_INTERVAL_IN_SECONDS, 30);
+    this.offlinePushMonitorDaVinciPushStatusScanThreadNumber =
+        props.getInt(OFFLINE_PUSH_MONITOR_DAVINCI_PUSH_STATUS_SCAN_THREAD_NUMBER, 4);
+
     this.zkSharedDaVinciPushStatusSystemSchemaStoreAutoCreationEnabled =
         props.getBoolean(CONTROLLER_ZK_SHARED_DAVINCI_PUSH_STATUS_SYSTEM_SCHEMA_STORE_AUTO_CREATION_ENABLED, false);
     this.systemStoreAclSynchronizationDelayMs =
@@ -732,6 +738,10 @@ public class VeniceControllerConfig extends VeniceControllerClusterConfig {
 
   public boolean isOfflinePushMonitorDaVinciPushStatusEnabled() {
     return offlinePushMonitorDaVinciPushStatusEnabled;
+  }
+
+  public int getOfflinePushMonitorDaVinciPushStatusScanThreadNumber() {
+    return offlinePushMonitorDaVinciPushStatusScanThreadNumber;
   }
 
   public boolean isZkSharedDaVinciPushStatusSystemSchemaStoreAutoCreationEnabled() {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -5343,13 +5343,11 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
     if (store.isDaVinciPushStatusStoreEnabled() && (versionNumber > 1 || incrementalPushVersion.isPresent())) {
       if (store.getVersion(versionNumber).isPresent()) {
         Version version = store.getVersion(versionNumber).get();
-        ExecutionStatusWithDetails daVinciStatusAndDetails = incrementalPushVersion.isPresent()
-            ? PushMonitorUtils.getDaVinciPushStatusAndDetails(
-                pushStatusStoreReader.orElse(null),
-                version.kafkaTopicName(),
-                version.getPartitionCount(),
-                incrementalPushVersion)
-            : monitor.getDaVinciPushStatus(version.kafkaTopicName(), version.getPartitionCount());
+        ExecutionStatusWithDetails daVinciStatusAndDetails = PushMonitorUtils.getDaVinciPushStatusAndDetails(
+            pushStatusStoreReader.orElse(null),
+            version.kafkaTopicName(),
+            version.getPartitionCount(),
+            incrementalPushVersion);
         ExecutionStatus daVinciStatus = daVinciStatusAndDetails.getStatus();
         String daVinciDetails = daVinciStatusAndDetails.getDetails();
         executionStatus = getOverallPushStatus(executionStatus, daVinciStatus);

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -5341,6 +5341,11 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
     // Retrieve Da Vinci push status
     // Da Vinci can only subscribe to an existing version, so skip 1st push
     if (store.isDaVinciPushStatusStoreEnabled() && (versionNumber > 1 || incrementalPushVersion.isPresent())) {
+      if (monitor.isOfflinePushMonitorDaVinciPushStatusEnabled() && !incrementalPushVersion.isPresent()) {
+        // The offline push status will contain Da Vinci push status when either server or Da Vinci push status becomes
+        // terminal.
+        return new OfflinePushStatusInfo(executionStatus, details);
+      }
       if (store.getVersion(versionNumber).isPresent()) {
         Version version = store.getVersion(versionNumber).get();
         ExecutionStatusWithDetails daVinciStatusAndDetails = PushMonitorUtils.getDaVinciPushStatusAndDetails(

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -7701,4 +7701,9 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
     checkKafkaTopicAndHelixResource(clusterName, storeName, true, true, true);
     storeGraveyard.removeStoreFromGraveyard(clusterName, storeName);
   }
+
+  @Override
+  public Optional<PushStatusStoreReader> getPushStatusStoreReader() {
+    return pushStatusStoreReader;
+  }
 }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -5343,11 +5343,13 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
     if (store.isDaVinciPushStatusStoreEnabled() && (versionNumber > 1 || incrementalPushVersion.isPresent())) {
       if (store.getVersion(versionNumber).isPresent()) {
         Version version = store.getVersion(versionNumber).get();
-        ExecutionStatusWithDetails daVinciStatusAndDetails = PushMonitorUtils.getDaVinciPushStatusAndDetails(
-            pushStatusStoreReader.orElse(null),
-            version.kafkaTopicName(),
-            version.getPartitionCount(),
-            incrementalPushVersion);
+        ExecutionStatusWithDetails daVinciStatusAndDetails = incrementalPushVersion.isPresent()
+            ? PushMonitorUtils.getDaVinciPushStatusAndDetails(
+                pushStatusStoreReader.orElse(null),
+                version.kafkaTopicName(),
+                version.getPartitionCount(),
+                incrementalPushVersion)
+            : monitor.getDaVinciPushStatus(version.kafkaTopicName(), version.getPartitionCount());
         ExecutionStatus daVinciStatus = daVinciStatusAndDetails.getStatus();
         String daVinciDetails = daVinciStatusAndDetails.getDetails();
         executionStatus = getOverallPushStatus(executionStatus, daVinciStatus);

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
@@ -177,6 +177,7 @@ import com.linkedin.venice.pubsub.api.PubSubConsumerAdapterFactory;
 import com.linkedin.venice.pubsub.api.PubSubProduceResult;
 import com.linkedin.venice.pubsub.api.PubSubTopic;
 import com.linkedin.venice.pushmonitor.ExecutionStatus;
+import com.linkedin.venice.pushstatushelper.PushStatusStoreReader;
 import com.linkedin.venice.pushstatushelper.PushStatusStoreRecordDeleter;
 import com.linkedin.venice.schema.AvroSchemaParseUtils;
 import com.linkedin.venice.schema.GeneratedSchemaID;
@@ -5092,5 +5093,10 @@ public class VeniceParentHelixAdmin implements Admin {
       }
     });
     getStoreGraveyard().removeStoreFromGraveyard(clusterName, storeName);
+  }
+
+  @Override
+  public Optional<PushStatusStoreReader> getPushStatusStoreReader() {
+    return getVeniceHelixAdmin().getPushStatusStoreReader();
   }
 }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
@@ -5097,6 +5097,6 @@ public class VeniceParentHelixAdmin implements Admin {
 
   @Override
   public Optional<PushStatusStoreReader> getPushStatusStoreReader() {
-    return getVeniceHelixAdmin().getPushStatusStoreReader();
+    throw new VeniceUnsupportedOperationException("Parent controller does not have Da Vinci push status store reader");
   }
 }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/AbstractPushMonitor.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/AbstractPushMonitor.java
@@ -9,6 +9,7 @@ import static com.linkedin.venice.pushmonitor.OfflinePushStatus.HELIX_ASSIGNMENT
 import static com.linkedin.venice.pushmonitor.OfflinePushStatus.HELIX_RESOURCE_NOT_CREATED;
 
 import com.linkedin.venice.controller.HelixAdminClient;
+import com.linkedin.venice.controller.VeniceControllerConfig;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.exceptions.VeniceNoStoreException;
 import com.linkedin.venice.helix.HelixCustomizedViewOfflinePushRepository;
@@ -96,8 +97,7 @@ public abstract class AbstractPushMonitor
       String aggregateRealTimeSourceKafkaUrl,
       List<String> activeActiveRealTimeSourceKafkaURLs,
       HelixAdminClient helixAdminClient,
-      boolean disableErrorLeaderReplica,
-      long offlineJobResourceAssignmentWaitTimeInMilliseconds,
+      VeniceControllerConfig controllerConfig,
       PushStatusStoreReader pushStatusStoreReader) {
     this.clusterName = clusterName;
     this.offlinePushAccessor = offlinePushAccessor;
@@ -110,10 +110,10 @@ public abstract class AbstractPushMonitor
     this.aggregateRealTimeSourceKafkaUrl = aggregateRealTimeSourceKafkaUrl;
     this.activeActiveRealTimeSourceKafkaURLs = activeActiveRealTimeSourceKafkaURLs;
     this.helixAdminClient = helixAdminClient;
-    this.disableErrorLeaderReplica = disableErrorLeaderReplica;
+    this.disableErrorLeaderReplica = controllerConfig.isErrorLeaderReplicaFailOverEnabled();
     this.helixClientThrottler =
         new EventThrottler(10, "push_monitor_helix_client_throttler", false, EventThrottler.BLOCK_STRATEGY);
-    this.offlineJobResourceAssignmentWaitTimeInMilliseconds = offlineJobResourceAssignmentWaitTimeInMilliseconds;
+    this.offlineJobResourceAssignmentWaitTimeInMilliseconds = controllerConfig.getOffLineJobWaitTimeInMilliseconds();
     this.pushStatusStoreReader = pushStatusStoreReader;
     this.pushStatusCollector = new PushStatusCollector(
         metadataRepository,

--- a/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/AbstractPushMonitor.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/AbstractPushMonitor.java
@@ -517,7 +517,6 @@ public abstract class AbstractPushMonitor
               + " timed out, strategy=" + strategy.toString() + ", replicationFactor=" + replicationFactor + ", reason="
               + notReadyReason.get();
           handleOfflinePushUpdate(pushStatus, ERROR, Optional.of(errorMsg));
-          // handleErrorPush(pushStatus, errorMsg);
           return new Pair<>(ExecutionStatus.ERROR, errorMsg);
         }
       } else {
@@ -856,7 +855,6 @@ public abstract class AbstractPushMonitor
       String statusDetails = "Helix resource for Topic:" + kafkaTopic + " is deleted, stopping the running push.";
       LOGGER.info(statusDetails);
       handleOfflinePushUpdate(pushStatus, ExecutionStatus.ERROR, Optional.of(statusDetails));
-      // handleErrorPush(pushStatus, statusDetails);
     }
   }
 
@@ -920,7 +918,6 @@ public abstract class AbstractPushMonitor
     routingDataRepository.unSubscribeRoutingDataChange(pushStatus.getKafkaTopic(), this);
 
     if (status.equals(ExecutionStatus.COMPLETED)) {
-      // handleCompletedPush(pushStatus);
       pushStatusCollector.handleServerPushStatusUpdate(pushStatus.getKafkaTopic(), COMPLETED, null);
     } else if (status.equals(ExecutionStatus.ERROR)) {
       String statusDetailsString = "STATUS DETAILS ABSENT.";
@@ -931,7 +928,6 @@ public abstract class AbstractPushMonitor
             "Status details should be provided in order to terminateOfflinePush, but they are missing.",
             new VeniceException("Exception not thrown, for stacktrace logging purposes."));
       }
-      // handleErrorPush(pushStatus, statusDetailsString);
       pushStatusCollector.handleServerPushStatusUpdate(pushStatus.getKafkaTopic(), ERROR, statusDetailsString);
     }
   }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/AbstractPushMonitor.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/AbstractPushMonitor.java
@@ -135,6 +135,7 @@ public abstract class AbstractPushMonitor
   }
 
   public void loadAllPushes(List<OfflinePushStatus> offlinePushStatusList) {
+    pushStatusCollector.start();
     try (AutoCloseableLock ignore = clusterLockManager.createClusterWriteLock()) {
       LOGGER.info("Load all pushes started for cluster {}'s {}", clusterName, getClass().getSimpleName());
       // Subscribe to changes first

--- a/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/AbstractPushMonitor.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/AbstractPushMonitor.java
@@ -84,6 +84,8 @@ public abstract class AbstractPushMonitor
 
   private final PushStatusCollector pushStatusCollector;
 
+  private final boolean isOfflinePushMonitorDaVinciPushStatusEnabled;
+
   public AbstractPushMonitor(
       String clusterName,
       OfflinePushAccessor offlinePushAccessor,
@@ -121,6 +123,7 @@ public abstract class AbstractPushMonitor
         controllerConfig.isOfflinePushMonitorDaVinciPushStatusEnabled(),
         controllerConfig.getOfflinePushMonitorDaVinciPushStatusScanIntervalInSeconds(),
         controllerConfig.getOfflinePushMonitorDaVinciPushStatusScanThreadNumber());
+    this.isOfflinePushMonitorDaVinciPushStatusEnabled = controllerConfig.isOfflinePushMonitorDaVinciPushStatusEnabled();
     pushStatusCollector.start();
   }
 
@@ -1070,5 +1073,10 @@ public abstract class AbstractPushMonitor
 
   public RealTimeTopicSwitcher getRealTimeTopicSwitcher() {
     return realTimeTopicSwitcher;
+  }
+
+  @Override
+  public boolean isOfflinePushMonitorDaVinciPushStatusEnabled() {
+    return isOfflinePushMonitorDaVinciPushStatusEnabled;
   }
 }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/AbstractPushMonitor.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/AbstractPushMonitor.java
@@ -120,7 +120,8 @@ public abstract class AbstractPushMonitor
         pushStatusStoreReader,
         (topic) -> handleCompletedPush(getOfflinePush(topic)),
         (topic, details) -> handleErrorPush(getOfflinePush(topic), details),
-        30);
+        10);
+    pushStatusCollector.start();
   }
 
   @Override

--- a/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/AbstractPushMonitor.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/AbstractPushMonitor.java
@@ -120,7 +120,9 @@ public abstract class AbstractPushMonitor
         pushStatusStoreReader,
         (topic) -> handleCompletedPush(getOfflinePush(topic)),
         (topic, details) -> handleErrorPush(getOfflinePush(topic), details));
+    LOGGER.info("DEBUGGING WE ARE HERE");
     pushStatusCollector.start();
+    LOGGER.info("DEBUGGING WE ARE HERE2");
   }
 
   @Override
@@ -284,7 +286,7 @@ public abstract class AbstractPushMonitor
         stopMonitorOfflinePush(kafkaTopic, false, false);
       }
       LOGGER.info("Successfully stopped monitoring push for all topics.");
-      pushStatusCollector.stop();
+      // pushStatusCollector.stop();
     } catch (Exception e) {
       LOGGER.error("Error when stopping monitoring push for all topics", e);
     }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/AbstractPushMonitor.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/AbstractPushMonitor.java
@@ -83,7 +83,6 @@ public abstract class AbstractPushMonitor
   private final long offlineJobResourceAssignmentWaitTimeInMilliseconds;
 
   private final PushStatusCollector pushStatusCollector;
-  private final PushStatusStoreReader pushStatusStoreReader;
 
   public AbstractPushMonitor(
       String clusterName,
@@ -114,14 +113,14 @@ public abstract class AbstractPushMonitor
     this.helixClientThrottler =
         new EventThrottler(10, "push_monitor_helix_client_throttler", false, EventThrottler.BLOCK_STRATEGY);
     this.offlineJobResourceAssignmentWaitTimeInMilliseconds = controllerConfig.getOffLineJobWaitTimeInMilliseconds();
-    this.pushStatusStoreReader = pushStatusStoreReader;
     this.pushStatusCollector = new PushStatusCollector(
         metadataRepository,
         pushStatusStoreReader,
         (topic) -> handleCompletedPush(getOfflinePush(topic)),
         (topic, details) -> handleErrorPush(getOfflinePush(topic), details),
         controllerConfig.isOfflinePushMonitorDaVinciPushStatusEnabled(),
-        controllerConfig.getOfflinePushMonitorDaVinciPushStatusScanIntervalInSeconds());
+        controllerConfig.getOfflinePushMonitorDaVinciPushStatusScanIntervalInSeconds(),
+        controllerConfig.getOfflinePushMonitorDaVinciPushStatusScanThreadNumber());
     pushStatusCollector.start();
   }
 

--- a/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/AbstractPushMonitor.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/AbstractPushMonitor.java
@@ -119,10 +119,8 @@ public abstract class AbstractPushMonitor
         metadataRepository,
         pushStatusStoreReader,
         (topic) -> handleCompletedPush(getOfflinePush(topic)),
-        (topic, details) -> handleErrorPush(getOfflinePush(topic), details));
-    LOGGER.info("DEBUGGING WE ARE HERE");
-    pushStatusCollector.start();
-    LOGGER.info("DEBUGGING WE ARE HERE2");
+        (topic, details) -> handleErrorPush(getOfflinePush(topic), details),
+        30);
   }
 
   @Override
@@ -286,7 +284,6 @@ public abstract class AbstractPushMonitor
         stopMonitorOfflinePush(kafkaTopic, false, false);
       }
       LOGGER.info("Successfully stopped monitoring push for all topics.");
-      // pushStatusCollector.stop();
     } catch (Exception e) {
       LOGGER.error("Error when stopping monitoring push for all topics", e);
     }
@@ -922,7 +919,7 @@ public abstract class AbstractPushMonitor
 
     if (status.equals(ExecutionStatus.COMPLETED)) {
       // handleCompletedPush(pushStatus);
-      pushStatusCollector.handleServerPushStatusUpdate(pushStatus.getKafkaTopic(), COMPLETED, Optional.empty());
+      pushStatusCollector.handleServerPushStatusUpdate(pushStatus.getKafkaTopic(), COMPLETED, null);
     } else if (status.equals(ExecutionStatus.ERROR)) {
       String statusDetailsString = "STATUS DETAILS ABSENT.";
       if (statusDetails.isPresent()) {
@@ -933,8 +930,7 @@ public abstract class AbstractPushMonitor
             new VeniceException("Exception not thrown, for stacktrace logging purposes."));
       }
       // handleErrorPush(pushStatus, statusDetailsString);
-      pushStatusCollector
-          .handleServerPushStatusUpdate(pushStatus.getKafkaTopic(), ERROR, Optional.of(statusDetailsString));
+      pushStatusCollector.handleServerPushStatusUpdate(pushStatus.getKafkaTopic(), ERROR, statusDetailsString);
     }
   }
 

--- a/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/AbstractPushMonitor.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/AbstractPushMonitor.java
@@ -916,8 +916,6 @@ public abstract class AbstractPushMonitor
       OfflinePushStatus pushStatus,
       ExecutionStatus status,
       Optional<String> statusDetails) {
-    routingDataRepository.unSubscribeRoutingDataChange(pushStatus.getKafkaTopic(), this);
-
     if (status.equals(ExecutionStatus.COMPLETED)) {
       pushStatusCollector.handleServerPushStatusUpdate(pushStatus.getKafkaTopic(), COMPLETED, null);
     } else if (status.equals(ExecutionStatus.ERROR)) {
@@ -934,6 +932,7 @@ public abstract class AbstractPushMonitor
   }
 
   protected void handleCompletedPush(OfflinePushStatus pushStatus) {
+    routingDataRepository.unSubscribeRoutingDataChange(pushStatus.getKafkaTopic(), this);
     LOGGER.info(
         "Updating offline push status, push for: {} old status: {}, new status: {}",
         pushStatus.getKafkaTopic(),
@@ -972,6 +971,7 @@ public abstract class AbstractPushMonitor
   }
 
   protected void handleErrorPush(OfflinePushStatus pushStatus, String statusDetails) {
+    routingDataRepository.unSubscribeRoutingDataChange(pushStatus.getKafkaTopic(), this);
     LOGGER.info(
         "Updating offline push status, push for: {} is now {}, new status: {}, statusDetails: {}",
         pushStatus.getKafkaTopic(),
@@ -1070,10 +1070,5 @@ public abstract class AbstractPushMonitor
 
   public RealTimeTopicSwitcher getRealTimeTopicSwitcher() {
     return realTimeTopicSwitcher;
-  }
-
-  @Override
-  public ExecutionStatusWithDetails getDaVinciPushStatus(String topic, int partitionCount) {
-    return pushStatusCollector.getDaVinciPushStatus(topic, partitionCount);
   }
 }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/AbstractPushMonitor.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/AbstractPushMonitor.java
@@ -120,7 +120,8 @@ public abstract class AbstractPushMonitor
         pushStatusStoreReader,
         (topic) -> handleCompletedPush(getOfflinePush(topic)),
         (topic, details) -> handleErrorPush(getOfflinePush(topic), details),
-        10);
+        controllerConfig.isOfflinePushMonitorDaVinciPushStatusEnabled(),
+        controllerConfig.getOfflinePushMonitorDaVinciPushStatusScanIntervalInSeconds());
     pushStatusCollector.start();
   }
 

--- a/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/AbstractPushMonitor.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/AbstractPushMonitor.java
@@ -284,6 +284,7 @@ public abstract class AbstractPushMonitor
         stopMonitorOfflinePush(kafkaTopic, false, false);
       }
       LOGGER.info("Successfully stopped monitoring push for all topics.");
+      pushStatusCollector.clear();
     } catch (Exception e) {
       LOGGER.error("Error when stopping monitoring push for all topics", e);
     }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/AbstractPushMonitor.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/AbstractPushMonitor.java
@@ -1071,4 +1071,9 @@ public abstract class AbstractPushMonitor
   public RealTimeTopicSwitcher getRealTimeTopicSwitcher() {
     return realTimeTopicSwitcher;
   }
+
+  @Override
+  public ExecutionStatusWithDetails getDaVinciPushStatus(String topic, int partitionCount) {
+    return pushStatusCollector.getDaVinciPushStatus(topic, partitionCount);
+  }
 }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/ExecutionStatusWithDetails.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/ExecutionStatusWithDetails.java
@@ -1,0 +1,19 @@
+package com.linkedin.venice.pushmonitor;
+
+public class ExecutionStatusWithDetails {
+  private final ExecutionStatus status;
+  private final String details;
+
+  public ExecutionStatusWithDetails(ExecutionStatus status, String details) {
+    this.status = status;
+    this.details = details;
+  }
+
+  public ExecutionStatus getStatus() {
+    return status;
+  }
+
+  public String getDetails() {
+    return details;
+  }
+}

--- a/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/PartitionStatusBasedPushMonitor.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/PartitionStatusBasedPushMonitor.java
@@ -7,6 +7,7 @@ import com.linkedin.venice.meta.PartitionAssignment;
 import com.linkedin.venice.meta.ReadWriteStoreRepository;
 import com.linkedin.venice.meta.RoutingDataRepository;
 import com.linkedin.venice.meta.StoreCleaner;
+import com.linkedin.venice.pushstatushelper.PushStatusStoreReader;
 import com.linkedin.venice.utils.Pair;
 import com.linkedin.venice.utils.locks.ClusterLockManager;
 import java.util.List;
@@ -36,7 +37,8 @@ public class PartitionStatusBasedPushMonitor extends AbstractPushMonitor {
       List<String> childDataCenterKafkaUrls,
       HelixAdminClient helixAdminClient,
       boolean disableErrorLeaderReplica,
-      long offlineJobResourceAssignmentWaitTimeInMilliseconds) {
+      long offlineJobResourceAssignmentWaitTimeInMilliseconds,
+      PushStatusStoreReader pushStatusStoreReader) {
     super(
         clusterName,
         offlinePushAccessor,
@@ -50,7 +52,8 @@ public class PartitionStatusBasedPushMonitor extends AbstractPushMonitor {
         childDataCenterKafkaUrls,
         helixAdminClient,
         disableErrorLeaderReplica,
-        offlineJobResourceAssignmentWaitTimeInMilliseconds);
+        offlineJobResourceAssignmentWaitTimeInMilliseconds,
+        pushStatusStoreReader);
   }
 
   @Override

--- a/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/PartitionStatusBasedPushMonitor.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/PartitionStatusBasedPushMonitor.java
@@ -1,6 +1,7 @@
 package com.linkedin.venice.pushmonitor;
 
 import com.linkedin.venice.controller.HelixAdminClient;
+import com.linkedin.venice.controller.VeniceControllerConfig;
 import com.linkedin.venice.ingestion.control.RealTimeTopicSwitcher;
 import com.linkedin.venice.meta.Instance;
 import com.linkedin.venice.meta.PartitionAssignment;
@@ -36,8 +37,7 @@ public class PartitionStatusBasedPushMonitor extends AbstractPushMonitor {
       String aggregateRealTimeSourceKafkaUrl,
       List<String> childDataCenterKafkaUrls,
       HelixAdminClient helixAdminClient,
-      boolean disableErrorLeaderReplica,
-      long offlineJobResourceAssignmentWaitTimeInMilliseconds,
+      VeniceControllerConfig controllerConfig,
       PushStatusStoreReader pushStatusStoreReader) {
     super(
         clusterName,
@@ -51,8 +51,7 @@ public class PartitionStatusBasedPushMonitor extends AbstractPushMonitor {
         aggregateRealTimeSourceKafkaUrl,
         childDataCenterKafkaUrls,
         helixAdminClient,
-        disableErrorLeaderReplica,
-        offlineJobResourceAssignmentWaitTimeInMilliseconds,
+        controllerConfig,
         pushStatusStoreReader);
   }
 

--- a/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/PushMonitor.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/PushMonitor.java
@@ -137,4 +137,6 @@ public interface PushMonitor {
   void recordPushPreparationDuration(String topic, long offlinePushWaitTimeInSecond);
 
   List<Instance> getReadyToServeInstances(PartitionAssignment partitionAssignment, int partitionId);
+
+  boolean isOfflinePushMonitorDaVinciPushStatusEnabled();
 }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/PushMonitor.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/PushMonitor.java
@@ -137,6 +137,4 @@ public interface PushMonitor {
   void recordPushPreparationDuration(String topic, long offlinePushWaitTimeInSecond);
 
   List<Instance> getReadyToServeInstances(PartitionAssignment partitionAssignment, int partitionId);
-
-  ExecutionStatusWithDetails getDaVinciPushStatus(String topic, int partitionCount);
 }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/PushMonitor.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/PushMonitor.java
@@ -137,4 +137,6 @@ public interface PushMonitor {
   void recordPushPreparationDuration(String topic, long offlinePushWaitTimeInSecond);
 
   List<Instance> getReadyToServeInstances(PartitionAssignment partitionAssignment, int partitionId);
+
+  ExecutionStatusWithDetails getDaVinciPushStatus(String topic, int partitionCount);
 }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/PushMonitorDelegator.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/PushMonitorDelegator.java
@@ -215,4 +215,8 @@ public class PushMonitorDelegator implements PushMonitor {
     return getPushMonitor(partitionAssignment.getTopic()).getReadyToServeInstances(partitionAssignment, partitionId);
   }
 
+  @Override
+  public boolean isOfflinePushMonitorDaVinciPushStatusEnabled() {
+    return partitionStatusBasedPushStatusMonitor.isOfflinePushMonitorDaVinciPushStatusEnabled();
+  }
 }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/PushMonitorDelegator.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/PushMonitorDelegator.java
@@ -215,8 +215,4 @@ public class PushMonitorDelegator implements PushMonitor {
     return getPushMonitor(partitionAssignment.getTopic()).getReadyToServeInstances(partitionAssignment, partitionId);
   }
 
-  @Override
-  public ExecutionStatusWithDetails getDaVinciPushStatus(String topic, int partitionCount) {
-    return getPushMonitor(topic).getDaVinciPushStatus(topic, partitionCount);
-  }
 }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/PushMonitorDelegator.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/PushMonitorDelegator.java
@@ -56,7 +56,8 @@ public class PushMonitorDelegator implements PushMonitor {
       List<String> activeActiveRealTimeSourceKafkaURLs,
       HelixAdminClient helixAdminClient,
       boolean disableErrorLeaderReplica,
-      long offlineJobResourceAssignmentWaitTimeInMilliseconds) {
+      long offlineJobResourceAssignmentWaitTimeInMilliseconds,
+      PushStatusStoreReader pushStatusStoreReader) {
     this.clusterName = clusterName;
     this.metadataRepository = metadataRepository;
     this.offlinePushAccessor = offlinePushAccessor;
@@ -74,7 +75,8 @@ public class PushMonitorDelegator implements PushMonitor {
         activeActiveRealTimeSourceKafkaURLs,
         helixAdminClient,
         disableErrorLeaderReplica,
-        offlineJobResourceAssignmentWaitTimeInMilliseconds);
+        offlineJobResourceAssignmentWaitTimeInMilliseconds,
+        pushStatusStoreReader);
     this.clusterLockManager = clusterLockManager;
 
     this.topicToPushMonitorMap = new VeniceConcurrentHashMap<>();

--- a/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/PushMonitorDelegator.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/PushMonitorDelegator.java
@@ -1,6 +1,7 @@
 package com.linkedin.venice.pushmonitor;
 
 import com.linkedin.venice.controller.HelixAdminClient;
+import com.linkedin.venice.controller.VeniceControllerConfig;
 import com.linkedin.venice.exceptions.VeniceNoStoreException;
 import com.linkedin.venice.helix.HelixCustomizedViewOfflinePushRepository;
 import com.linkedin.venice.ingestion.control.RealTimeTopicSwitcher;
@@ -55,8 +56,7 @@ public class PushMonitorDelegator implements PushMonitor {
       String aggregateRealTimeSourceKafkaUrl,
       List<String> activeActiveRealTimeSourceKafkaURLs,
       HelixAdminClient helixAdminClient,
-      boolean disableErrorLeaderReplica,
-      long offlineJobResourceAssignmentWaitTimeInMilliseconds,
+      VeniceControllerConfig controllerConfig,
       PushStatusStoreReader pushStatusStoreReader) {
     this.clusterName = clusterName;
     this.metadataRepository = metadataRepository;
@@ -74,8 +74,7 @@ public class PushMonitorDelegator implements PushMonitor {
         aggregateRealTimeSourceKafkaUrl,
         activeActiveRealTimeSourceKafkaURLs,
         helixAdminClient,
-        disableErrorLeaderReplica,
-        offlineJobResourceAssignmentWaitTimeInMilliseconds,
+        controllerConfig,
         pushStatusStoreReader);
     this.clusterLockManager = clusterLockManager;
 

--- a/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/PushMonitorDelegator.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/PushMonitorDelegator.java
@@ -214,4 +214,9 @@ public class PushMonitorDelegator implements PushMonitor {
   public List<Instance> getReadyToServeInstances(PartitionAssignment partitionAssignment, int partitionId) {
     return getPushMonitor(partitionAssignment.getTopic()).getReadyToServeInstances(partitionAssignment, partitionId);
   }
+
+  @Override
+  public ExecutionStatusWithDetails getDaVinciPushStatus(String topic, int partitionCount) {
+    return getPushMonitor(topic).getDaVinciPushStatus(topic, partitionCount);
+  }
 }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/PushMonitorUtils.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/PushMonitorUtils.java
@@ -1,0 +1,106 @@
+package com.linkedin.venice.pushmonitor;
+
+import com.linkedin.venice.exceptions.VeniceException;
+import com.linkedin.venice.meta.Version;
+import com.linkedin.venice.pushstatushelper.PushStatusStoreReader;
+import com.linkedin.venice.utils.Pair;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+
+public class PushMonitorUtils {
+  private static final Logger LOGGER = LogManager.getLogger(PushMonitorUtils.class);
+
+  public static Pair<ExecutionStatus, String> getDaVinciPushStatusAndDetails(
+      PushStatusStoreReader reader,
+      String topicName,
+      int partitionCount,
+      Optional<String> incrementalPushVersion) {
+    if (reader == null) {
+      throw new VeniceException("D2Client must be provided to read from push status store.");
+    }
+    LOGGER.info("Getting Da Vinci push status for topic: {}", topicName);
+    boolean allMiddleStatusReceived = true;
+    ExecutionStatus completeStatus = incrementalPushVersion.isPresent()
+        ? ExecutionStatus.END_OF_INCREMENTAL_PUSH_RECEIVED
+        : ExecutionStatus.COMPLETED;
+    ExecutionStatus middleStatus = incrementalPushVersion.isPresent()
+        ? ExecutionStatus.START_OF_INCREMENTAL_PUSH_RECEIVED
+        : ExecutionStatus.END_OF_PUSH_RECEIVED;
+    Optional<String> erroredInstance = Optional.empty();
+    String storeName = Version.parseStoreFromKafkaTopicName(topicName);
+    int completedPartitions = 0;
+    int totalInstanceCount = 0;
+    int liveInstanceCount = 0;
+    Set<Integer> incompletePartition = new HashSet<>();
+    for (int partitionId = 0; partitionId < partitionCount; partitionId++) {
+      Map<CharSequence, Integer> instances = reader.getPartitionStatus(
+          storeName,
+          Version.parseVersionFromVersionTopicName(topicName),
+          partitionId,
+          incrementalPushVersion);
+      boolean allInstancesCompleted = true;
+      totalInstanceCount += instances.size();
+      for (Map.Entry<CharSequence, Integer> entry: instances.entrySet()) {
+        ExecutionStatus status = ExecutionStatus.fromInt(entry.getValue());
+        boolean isInstanceAlive = reader.isInstanceAlive(storeName, entry.getKey().toString());
+
+        if (isInstanceAlive) {
+          liveInstanceCount++;
+        }
+        if (status == middleStatus) {
+          if (allInstancesCompleted && isInstanceAlive) {
+            allInstancesCompleted = false;
+          }
+        } else if (status != completeStatus) {
+          if (allInstancesCompleted || allMiddleStatusReceived) {
+            if (isInstanceAlive) {
+              allInstancesCompleted = false;
+              allMiddleStatusReceived = false;
+              if (status == ExecutionStatus.ERROR) {
+                erroredInstance = Optional.of(entry.getKey().toString());
+                break;
+              }
+            }
+          }
+        }
+      }
+      if (allInstancesCompleted) {
+        completedPartitions++;
+      } else {
+        incompletePartition.add(partitionId);
+      }
+    }
+    String statusDetail = null;
+    String details = "";
+    if (completedPartitions > 0) {
+      details += completedPartitions + "/" + partitionCount + " partitions completed in" + totalInstanceCount
+          + " Da Vinci instances.";
+    }
+    if (erroredInstance.isPresent()) {
+      details += "Found a failed instance in Da Vinci: " + erroredInstance + ". live instances: " + liveInstanceCount
+          + " total instances : " + totalInstanceCount;
+    }
+    int incompleteSize = incompletePartition.size();
+    if (incompleteSize > 0 && incompleteSize <= 5) {
+      details += ". Following partitions still not complete " + incompletePartition + ". live instances: "
+          + liveInstanceCount + " total instances : " + totalInstanceCount;
+    }
+    if (details.length() != 0) {
+      statusDetail = details;
+    }
+    if (completedPartitions == partitionCount) {
+      return new Pair<>(completeStatus, statusDetail);
+    } else if (allMiddleStatusReceived) {
+      return new Pair<>(middleStatus, statusDetail);
+    } else if (erroredInstance.isPresent()) {
+      return new Pair<>(ExecutionStatus.ERROR, statusDetail);
+    } else {
+      return new Pair<>(ExecutionStatus.STARTED, statusDetail);
+    }
+  }
+}

--- a/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/PushStatusCollector.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/PushStatusCollector.java
@@ -1,0 +1,134 @@
+package com.linkedin.venice.pushmonitor;
+
+import static java.lang.Thread.currentThread;
+
+import com.linkedin.venice.meta.ReadWriteStoreRepository;
+import com.linkedin.venice.meta.Store;
+import com.linkedin.venice.meta.Version;
+import com.linkedin.venice.pushstatushelper.PushStatusStoreReader;
+import com.linkedin.venice.utils.Pair;
+import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+
+public class PushStatusCollector {
+  private static final Logger LOGGER = LogManager.getLogger(PushStatusCollector.class);
+
+  private final Map<String, ExecutionStatus> topicToDaVinciPushStatusMap = new VeniceConcurrentHashMap<>();
+  private final Map<String, ExecutionStatus> topicToServerPushStatusMap = new VeniceConcurrentHashMap<>();
+  private final Consumer<String> pushCompletedHandler;
+  private final BiConsumer<String, String> pushErrorHandler;
+  private final Set<String> subscribedTopicSet = new HashSet<>();
+  private final Map<String, Integer> topicToPartitionCountMap = new VeniceConcurrentHashMap<>();
+  private final Set<String> daVinciPushStatusEnabledTopicSet = new HashSet<>();
+  private final PushStatusStoreReader pushStatusStoreReader;
+
+  private final ReadWriteStoreRepository storeRepository;
+
+  private final ScheduledExecutorService offlinePushCheckScheduler = Executors.newScheduledThreadPool(1);
+
+  public PushStatusCollector(
+      ReadWriteStoreRepository storeRepository,
+      PushStatusStoreReader pushStatusStoreReader,
+      Consumer<String> pushCompletedHandler,
+      BiConsumer<String, String> pushErrorHandler) {
+    this.storeRepository = storeRepository;
+    this.pushStatusStoreReader = pushStatusStoreReader;
+    this.pushCompletedHandler = pushCompletedHandler;
+    this.pushErrorHandler = pushErrorHandler;
+  }
+
+  public void subscribeTopic(String topicName, int partitionCount) {
+    subscribedTopicSet.add(topicName);
+    topicToPartitionCountMap.put(topicName, partitionCount);
+    String storeName = Version.parseStoreFromKafkaTopicName(topicName);
+    Store store = storeRepository.getStore(storeName);
+    if (store == null) {
+      LOGGER.warn("Store {} not found in store repository, will not monitor Da Vinci push status", storeName);
+    } else {
+      if (store.isDaVinciPushStatusStoreEnabled()) {
+        daVinciPushStatusEnabledTopicSet.add(topicName);
+      }
+    }
+  }
+
+  public void unsubscribeTopic(String topicName) {
+    subscribedTopicSet.remove(topicName);
+    daVinciPushStatusEnabledTopicSet.remove(topicName);
+  }
+
+  public void handleServerPushStatusUpdate(
+      String topicName,
+      ExecutionStatus executionStatus,
+      Optional<String> detailsString) {
+    if (!daVinciPushStatusEnabledTopicSet.contains(topicName)) {
+      if (executionStatus.equals(ExecutionStatus.COMPLETED)) {
+        pushCompletedHandler.accept(topicName);
+      } else if (executionStatus.equals(ExecutionStatus.ERROR)) {
+        pushErrorHandler.accept(topicName, null);
+      }
+    } else {
+      // Update the server topic status in the data structure and wait for async DVC status scan thread to pick up.
+      topicToServerPushStatusMap.put(topicName, executionStatus);
+    }
+  }
+
+  public void scanDaVinciPushStatus() {
+    for (String topicName: daVinciPushStatusEnabledTopicSet) {
+      Pair<ExecutionStatus, String> topicDaVinciPushStatus = PushMonitorUtils.getDaVinciPushStatusAndDetails(
+          pushStatusStoreReader,
+          topicName,
+          topicToPartitionCountMap.get(topicName),
+          Optional.empty());
+      // TODO: Create a new object to wrap ExecutionStatus + StatusDetails.
+      topicToDaVinciPushStatusMap.put(topicName, topicDaVinciPushStatus.getFirst());
+      if (isOverallPushCompleted(topicName)) {
+        daVinciPushStatusEnabledTopicSet.remove(topicName);
+        subscribedTopicSet.remove(topicName);
+        pushCompletedHandler.accept(topicName);
+      } else if (isOverallPushError(topicName)) {
+        daVinciPushStatusEnabledTopicSet.remove(topicName);
+        subscribedTopicSet.remove(topicName);
+        pushErrorHandler.accept(topicName, "TODO: Add DVC status details");
+      }
+    }
+  }
+
+  public boolean isOverallPushCompleted(String topicName) {
+    ExecutionStatus serverStatus = topicToServerPushStatusMap.getOrDefault(topicName, ExecutionStatus.UNKNOWN);
+    ExecutionStatus daVinciStatus = topicToDaVinciPushStatusMap.getOrDefault(topicName, ExecutionStatus.UNKNOWN);
+    return serverStatus.equals(ExecutionStatus.COMPLETED) && daVinciStatus.equals(ExecutionStatus.COMPLETED);
+  }
+
+  public boolean isOverallPushError(String topicName) {
+    ExecutionStatus serverStatus = topicToServerPushStatusMap.getOrDefault(topicName, ExecutionStatus.UNKNOWN);
+    ExecutionStatus daVinciStatus = topicToDaVinciPushStatusMap.getOrDefault(topicName, ExecutionStatus.UNKNOWN);
+    return serverStatus.equals(ExecutionStatus.ERROR) || daVinciStatus.equals(ExecutionStatus.ERROR);
+  }
+
+  public void start() {
+    offlinePushCheckScheduler.scheduleAtFixedRate(this::scanDaVinciPushStatus, 0, 30, TimeUnit.SECONDS);
+  }
+
+  public void stop() {
+    offlinePushCheckScheduler.shutdown();
+    try {
+      if (!offlinePushCheckScheduler.awaitTermination(5, TimeUnit.SECONDS)) {
+        offlinePushCheckScheduler.shutdownNow();
+        LOGGER.info("offlinePushCheckScheduler has been shutdown.");
+      }
+    } catch (InterruptedException e) {
+      currentThread().interrupt();
+    }
+  }
+}

--- a/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/PushStatusCollector.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/PushStatusCollector.java
@@ -202,21 +202,6 @@ public class PushStatusCollector {
     }
   }
 
-  /**
-   * Try to fetch Da Vinci status from cached result. If the topic is not subscribed it will fall back to call push
-   * status reader to read it directly from store.
-   */
-  public ExecutionStatusWithDetails getDaVinciPushStatus(String topic, int partitionCount) {
-    if (daVinciPushStatusScanEnabled && isStarted.get()) {
-      TopicPushStatus pushStatus = topicToPushStatusMap.get(topic);
-      if (pushStatus != null && pushStatus.getDaVinciStatus() != null) {
-        return pushStatus.getDaVinciStatus();
-      }
-    }
-    return PushMonitorUtils
-        .getDaVinciPushStatusAndDetails(pushStatusStoreReader, topic, partitionCount, Optional.empty());
-  }
-
   // Visible for testing.
   Map<String, TopicPushStatus> getTopicToPushStatusMap() {
     return topicToPushStatusMap;

--- a/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/PushStatusCollector.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/PushStatusCollector.java
@@ -6,10 +6,8 @@ import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.pushstatushelper.PushStatusStoreReader;
 import com.linkedin.venice.utils.Pair;
 import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -23,11 +21,10 @@ import org.apache.logging.log4j.Logger;
 public class PushStatusCollector {
   private static final Logger LOGGER = LogManager.getLogger(PushStatusCollector.class);
 
-  private final Map<String, ExecutionStatusWithDetails> topicToServerPushStatusMap = new VeniceConcurrentHashMap<>();
   private final Consumer<String> pushCompletedHandler;
   private final BiConsumer<String, String> pushErrorHandler;
-  private final Map<String, Integer> topicToPartitionCountMap = new VeniceConcurrentHashMap<>();
-  private final Set<String> daVinciPushStatusEnabledTopicSet = new HashSet<>();
+  private final Map<String, TopicPushStatus> daVinciStoreTopicToPartitionCountMap = new VeniceConcurrentHashMap<>();
+
   private final PushStatusStoreReader pushStatusStoreReader;
 
   private final ReadWriteStoreRepository storeRepository;
@@ -57,9 +54,6 @@ public class PushStatusCollector {
   }
 
   public void subscribeTopic(String topicName, int partitionCount) {
-    lock.lock();
-    topicToPartitionCountMap.put(topicName, partitionCount);
-    lock.unlock();
     String storeName = Version.parseStoreFromKafkaTopicName(topicName);
     Store store = storeRepository.getStore(storeName);
     if (store == null) {
@@ -68,7 +62,7 @@ public class PushStatusCollector {
       if (store.isDaVinciPushStatusStoreEnabled() && Version.parseVersionFromKafkaTopicName(topicName) > 1) {
         LOGGER.info("Will monitor Da Vinci push status for topic {}", topicName);
         lock.lock();
-        daVinciPushStatusEnabledTopicSet.add(topicName);
+        daVinciStoreTopicToPartitionCountMap.put(topicName, new TopicPushStatus(topicName, partitionCount));
         lock.unlock();
       }
     }
@@ -76,45 +70,62 @@ public class PushStatusCollector {
 
   public void unsubscribeTopic(String topicName) {
     lock.lock();
-    daVinciPushStatusEnabledTopicSet.remove(topicName);
+    daVinciStoreTopicToPartitionCountMap.remove(topicName);
     lock.unlock();
   }
 
   public void handleServerPushStatusUpdate(String topicName, ExecutionStatus executionStatus, String detailsString) {
-    if (!daVinciPushStatusEnabledTopicSet.contains(topicName)) {
+
+    TopicPushStatus topicPushStatus = daVinciStoreTopicToPartitionCountMap.get(topicName);
+    if (topicPushStatus == null) {
       if (executionStatus.equals(ExecutionStatus.COMPLETED)) {
         pushCompletedHandler.accept(topicName);
       } else if (executionStatus.equals(ExecutionStatus.ERROR)) {
-        pushErrorHandler.accept(topicName, null);
+        pushErrorHandler.accept(topicName, detailsString);
       }
     } else {
       // Update the server topic status in the data structure and wait for async DVC status scan thread to pick up.
       lock.lock();
-      topicToServerPushStatusMap.put(topicName, new ExecutionStatusWithDetails(executionStatus, detailsString));
+      topicPushStatus.setServerStatus(new ExecutionStatusWithDetails(executionStatus, detailsString));
       lock.unlock();
     }
   }
 
-  public void scanDaVinciPushStatus() {
+  private void scanDaVinciPushStatus() {
     lock.lock();
-    for (String topicName: daVinciPushStatusEnabledTopicSet) {
-      Pair<ExecutionStatus, String> topicDaVinciPushStatus = PushMonitorUtils.getDaVinciPushStatusAndDetails(
-          pushStatusStoreReader,
-          topicName,
-          topicToPartitionCountMap.get(topicName),
-          Optional.empty());
+    for (Map.Entry<String, TopicPushStatus> entry: daVinciStoreTopicToPartitionCountMap.entrySet()) {
+      String topicName = entry.getKey();
+      TopicPushStatus pushStatus = entry.getValue();
+      if (!pushStatus.isMonitoring()) {
+        continue;
+      }
+      ExecutionStatusWithDetails daVinciStatus = null;
+      if (pushStatus.getDaVinciStatus() != null && pushStatus.getDaVinciStatus().getStatus().isTerminal()) {
+        daVinciStatus = pushStatus.getDaVinciStatus();
+      } else {
+        Pair<ExecutionStatus, String> topicDaVinciPushStatus = PushMonitorUtils.getDaVinciPushStatusAndDetails(
+            pushStatusStoreReader,
+            topicName,
+            pushStatus.getPartitionCount(),
+            Optional.empty());
 
-      ExecutionStatusWithDetails daVinciStatus =
-          new ExecutionStatusWithDetails(topicDaVinciPushStatus.getFirst(), topicDaVinciPushStatus.getSecond());
-      ExecutionStatusWithDetails serverStatus = topicToServerPushStatusMap.get(topicName);
+        daVinciStatus =
+            new ExecutionStatusWithDetails(topicDaVinciPushStatus.getFirst(), topicDaVinciPushStatus.getSecond());
+        pushStatus.setDaVinciStatus(daVinciStatus);
+      }
+      ExecutionStatusWithDetails serverStatus = pushStatus.getServerStatus();
       if (serverStatus == null) {
         continue;
       }
+      LOGGER.info(
+          "Topic server push status: {}, Da Vinci push status: {}",
+          serverStatus.getStatus(),
+          daVinciStatus.getStatus());
       if (isOverallPushCompleted(serverStatus, daVinciStatus)) {
-        daVinciPushStatusEnabledTopicSet.remove(topicName);
+        pushStatus.setMonitoring(false);
         pushCompletedHandler.accept(topicName);
       } else if (isOverallPushError(serverStatus, daVinciStatus)) {
-        daVinciPushStatusEnabledTopicSet.remove(topicName);
+        pushStatus.setMonitoring(false);
         String overallErrorString = "";
         if (serverStatus.getStatus().equals(ExecutionStatus.ERROR)) {
           overallErrorString = overallErrorString + "Server push error: " + serverStatus.getDetails() + "\n";
@@ -128,21 +139,71 @@ public class PushStatusCollector {
     lock.unlock();
   }
 
-  public boolean isOverallPushCompleted(
+  private boolean isOverallPushCompleted(
       ExecutionStatusWithDetails serverStatus,
       ExecutionStatusWithDetails daVinciStatus) {
     return serverStatus.getStatus().equals(ExecutionStatus.COMPLETED)
         && daVinciStatus.getStatus().equals(ExecutionStatus.COMPLETED);
   }
 
-  public boolean isOverallPushError(ExecutionStatusWithDetails serverStatus, ExecutionStatusWithDetails daVinciStatus) {
+  private boolean isOverallPushError(
+      ExecutionStatusWithDetails serverStatus,
+      ExecutionStatusWithDetails daVinciStatus) {
     return serverStatus.getStatus().equals(ExecutionStatus.ERROR)
-        && daVinciStatus.getStatus().equals(ExecutionStatus.ERROR);
+        || daVinciStatus.getStatus().equals(ExecutionStatus.ERROR);
   }
 
   public void clear() {
     lock.lock();
-    daVinciPushStatusEnabledTopicSet.clear();
+    daVinciStoreTopicToPartitionCountMap.clear();
     lock.unlock();
+  }
+
+  // Visible for testing.
+  Map<String, TopicPushStatus> getDaVinciStoreTopicToPartitionCountMap() {
+    return daVinciStoreTopicToPartitionCountMap;
+  }
+
+  class TopicPushStatus {
+    private final String topicName;
+    private final int partitionCount;
+    private ExecutionStatusWithDetails serverStatus;
+    private ExecutionStatusWithDetails daVinciStatus;
+
+    private boolean isMonitoring;
+
+    public TopicPushStatus(String topicName, int partitionCount) {
+      this.topicName = topicName;
+      this.partitionCount = partitionCount;
+      this.isMonitoring = true;
+    }
+
+    public int getPartitionCount() {
+      return partitionCount;
+    }
+
+    public void setMonitoring(boolean monitoring) {
+      isMonitoring = monitoring;
+    }
+
+    public boolean isMonitoring() {
+      return isMonitoring;
+    }
+
+    public void setServerStatus(ExecutionStatusWithDetails serverStatus) {
+      this.serverStatus = serverStatus;
+    }
+
+    public ExecutionStatusWithDetails getServerStatus() {
+      return serverStatus;
+    }
+
+    public void setDaVinciStatus(ExecutionStatusWithDetails daVinciStatus) {
+      this.daVinciStatus = daVinciStatus;
+    }
+
+    public ExecutionStatusWithDetails getDaVinciStatus() {
+      return daVinciStatus;
+    }
   }
 }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/PushStatusCollector.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/PushStatusCollector.java
@@ -202,6 +202,21 @@ public class PushStatusCollector {
     }
   }
 
+  /**
+   * Try to fetch Da Vinci status from cached result. If the topic is not subscribed it will fall back to call push
+   * status reader to read it directly from store.
+   */
+  public ExecutionStatusWithDetails getDaVinciPushStatus(String topic, int partitionCount) {
+    if (daVinciPushStatusScanEnabled && isStarted.get()) {
+      TopicPushStatus pushStatus = topicToPushStatusMap.get(topic);
+      if (pushStatus != null && pushStatus.getDaVinciStatus() != null) {
+        return pushStatus.getDaVinciStatus();
+      }
+    }
+    return PushMonitorUtils
+        .getDaVinciPushStatusAndDetails(pushStatusStoreReader, topic, partitionCount, Optional.empty());
+  }
+
   // Visible for testing.
   Map<String, TopicPushStatus> getTopicToPushStatusMap() {
     return topicToPushStatusMap;

--- a/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/PushStatusCollector.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/PushStatusCollector.java
@@ -139,13 +139,16 @@ public class PushStatusCollector {
         continue;
       }
       LOGGER.info(
-          "Topic server push status: {}, Da Vinci push status: {}",
+          "Topic {} server push status: {}, Da Vinci push status: {}",
+          pushStatus.getTopicName(),
           serverStatus.getStatus(),
           daVinciStatus.getStatus());
-      if (isOverallPushCompleted(serverStatus, daVinciStatus)) {
+      if (serverStatus.getStatus().equals(ExecutionStatus.COMPLETED)
+          && daVinciStatus.getStatus().equals(ExecutionStatus.COMPLETED)) {
         pushStatus.setMonitoring(false);
         pushCompletedHandler.accept(pushStatus.getTopicName());
-      } else if (isOverallPushError(serverStatus, daVinciStatus)) {
+      } else if (serverStatus.getStatus().equals(ExecutionStatus.ERROR)
+          || daVinciStatus.getStatus().equals(ExecutionStatus.ERROR)) {
         pushStatus.setMonitoring(false);
         StringBuilder pushErrorDetailStringBuilder = new StringBuilder();
         if (serverStatus.getStatus().equals(ExecutionStatus.ERROR)) {
@@ -174,20 +177,6 @@ public class PushStatusCollector {
         pushErrorHandler.accept(topicName, detailsString);
       }
     }
-  }
-
-  private boolean isOverallPushCompleted(
-      ExecutionStatusWithDetails serverStatus,
-      ExecutionStatusWithDetails daVinciStatus) {
-    return serverStatus.getStatus().equals(ExecutionStatus.COMPLETED)
-        && daVinciStatus.getStatus().equals(ExecutionStatus.COMPLETED);
-  }
-
-  private boolean isOverallPushError(
-      ExecutionStatusWithDetails serverStatus,
-      ExecutionStatusWithDetails daVinciStatus) {
-    return serverStatus.getStatus().equals(ExecutionStatus.ERROR)
-        || daVinciStatus.getStatus().equals(ExecutionStatus.ERROR);
   }
 
   public void clear() {

--- a/services/venice-controller/src/test/java/com/linkedin/venice/pushmonitor/AbstractPushMonitorTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/pushmonitor/AbstractPushMonitorTest.java
@@ -97,7 +97,8 @@ public abstract class AbstractPushMonitorTest {
     mockPushHealthStats = mock(AggPushHealthStats.class);
     clusterLockManager = new ClusterLockManager(clusterName);
     mockControllerConfig = mock(VeniceControllerConfig.class);
-    when(mockControllerConfig.isErrorLeaderReplicaFailOverEnabled()).thenReturn(true);
+    when(mockControllerConfig.isOfflinePushMonitorDaVinciPushStatusEnabled()).thenReturn(true);
+    when(mockControllerConfig.getOfflinePushMonitorDaVinciPushStatusScanIntervalInSeconds()).thenReturn(5);
     when(mockControllerConfig.getOffLineJobWaitTimeInMilliseconds()).thenReturn(120000L);
     when(mockControllerConfig.getOfflinePushMonitorDaVinciPushStatusScanThreadNumber()).thenReturn(4);
     monitor = getPushMonitor();

--- a/services/venice-controller/src/test/java/com/linkedin/venice/pushmonitor/AbstractPushMonitorTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/pushmonitor/AbstractPushMonitorTest.java
@@ -17,6 +17,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.linkedin.venice.controller.VeniceControllerConfig;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.helix.HelixCustomizedViewOfflinePushRepository;
 import com.linkedin.venice.helix.HelixState;
@@ -66,6 +67,8 @@ public abstract class AbstractPushMonitorTest {
   private AggPushHealthStats mockPushHealthStats;
   protected ClusterLockManager clusterLockManager;
 
+  protected VeniceControllerConfig mockControllerConfig;
+
   private final static String clusterName = Utils.getUniqueString("test_cluster");
   private final static String aggregateRealTimeSourceKafkaUrl = "aggregate-real-time-source-kafka-url";
   private String storeName;
@@ -93,6 +96,9 @@ public abstract class AbstractPushMonitorTest {
     mockRoutingDataRepo = mock(RoutingDataRepository.class);
     mockPushHealthStats = mock(AggPushHealthStats.class);
     clusterLockManager = new ClusterLockManager(clusterName);
+    mockControllerConfig = mock(VeniceControllerConfig.class);
+    when(mockControllerConfig.isErrorLeaderReplicaFailOverEnabled()).thenReturn(true);
+    when(mockControllerConfig.getOffLineJobWaitTimeInMilliseconds()).thenReturn(120000L);
     monitor = getPushMonitor();
   }
 
@@ -937,6 +943,10 @@ public abstract class AbstractPushMonitorTest {
 
   protected ReadWriteStoreRepository getMockStoreRepo() {
     return mockStoreRepo;
+  }
+
+  protected VeniceControllerConfig getMockControllerConfig() {
+    return mockControllerConfig;
   }
 
   protected RoutingDataRepository getMockRoutingDataRepo() {

--- a/services/venice-controller/src/test/java/com/linkedin/venice/pushmonitor/AbstractPushMonitorTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/pushmonitor/AbstractPushMonitorTest.java
@@ -97,6 +97,7 @@ public abstract class AbstractPushMonitorTest {
     mockPushHealthStats = mock(AggPushHealthStats.class);
     clusterLockManager = new ClusterLockManager(clusterName);
     mockControllerConfig = mock(VeniceControllerConfig.class);
+    when(mockControllerConfig.isErrorLeaderReplicaFailOverEnabled()).thenReturn(true);
     when(mockControllerConfig.isOfflinePushMonitorDaVinciPushStatusEnabled()).thenReturn(true);
     when(mockControllerConfig.getOfflinePushMonitorDaVinciPushStatusScanIntervalInSeconds()).thenReturn(5);
     when(mockControllerConfig.getOffLineJobWaitTimeInMilliseconds()).thenReturn(120000L);

--- a/services/venice-controller/src/test/java/com/linkedin/venice/pushmonitor/AbstractPushMonitorTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/pushmonitor/AbstractPushMonitorTest.java
@@ -99,6 +99,7 @@ public abstract class AbstractPushMonitorTest {
     mockControllerConfig = mock(VeniceControllerConfig.class);
     when(mockControllerConfig.isErrorLeaderReplicaFailOverEnabled()).thenReturn(true);
     when(mockControllerConfig.getOffLineJobWaitTimeInMilliseconds()).thenReturn(120000L);
+    when(mockControllerConfig.getOfflinePushMonitorDaVinciPushStatusScanThreadNumber()).thenReturn(4);
     monitor = getPushMonitor();
   }
 

--- a/services/venice-controller/src/test/java/com/linkedin/venice/pushmonitor/ExecutionStatusWithDetailsTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/pushmonitor/ExecutionStatusWithDetailsTest.java
@@ -1,0 +1,15 @@
+package com.linkedin.venice.pushmonitor;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class ExecutionStatusWithDetailsTest {
+  @Test
+  public void testExecutionStatusWithDetailsGetter() {
+    ExecutionStatusWithDetails executionStatusWithDetails =
+        new ExecutionStatusWithDetails(ExecutionStatus.ERROR, "dummyString");
+    Assert.assertEquals(executionStatusWithDetails.getStatus(), ExecutionStatus.ERROR);
+    Assert.assertEquals(executionStatusWithDetails.getDetails(), "dummyString");
+  }
+}

--- a/services/venice-controller/src/test/java/com/linkedin/venice/pushmonitor/PartitionStatusBasedPushMonitorTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/pushmonitor/PartitionStatusBasedPushMonitorTest.java
@@ -60,7 +60,8 @@ public class PartitionStatusBasedPushMonitorTest extends AbstractPushMonitorTest
         Collections.emptyList(),
         helixAdminClient,
         true,
-        120000);
+        120000,
+        null);
   }
 
   @Override
@@ -78,7 +79,8 @@ public class PartitionStatusBasedPushMonitorTest extends AbstractPushMonitorTest
         Collections.emptyList(),
         mock(HelixAdminClient.class),
         true,
-        120000);
+        120000,
+        null);
   }
 
   @Test

--- a/services/venice-controller/src/test/java/com/linkedin/venice/pushmonitor/PartitionStatusBasedPushMonitorTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/pushmonitor/PartitionStatusBasedPushMonitorTest.java
@@ -59,8 +59,7 @@ public class PartitionStatusBasedPushMonitorTest extends AbstractPushMonitorTest
         getAggregateRealTimeSourceKafkaUrl(),
         Collections.emptyList(),
         helixAdminClient,
-        true,
-        120000,
+        getMockControllerConfig(),
         null);
   }
 
@@ -78,8 +77,7 @@ public class PartitionStatusBasedPushMonitorTest extends AbstractPushMonitorTest
         getAggregateRealTimeSourceKafkaUrl(),
         Collections.emptyList(),
         mock(HelixAdminClient.class),
-        true,
-        120000,
+        getMockControllerConfig(),
         null);
   }
 

--- a/services/venice-controller/src/test/java/com/linkedin/venice/pushmonitor/PushStatusCollectorTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/pushmonitor/PushStatusCollectorTest.java
@@ -53,12 +53,12 @@ public class PushStatusCollectorTest {
     pushStatusCollector.start();
 
     pushStatusCollector.subscribeTopic(regularStoreTopicV1, 10);
-    Assert.assertFalse(pushStatusCollector.getDaVinciStoreTopicToPartitionCountMap().containsKey(regularStoreTopicV1));
+    Assert.assertFalse(pushStatusCollector.getTopicToPushStatusMap().containsKey(regularStoreTopicV1));
     pushStatusCollector.handleServerPushStatusUpdate(regularStoreTopicV1, ExecutionStatus.COMPLETED, null);
     Assert.assertEquals(pushCompletedCount.get(), 1);
 
     pushStatusCollector.subscribeTopic(regularStoreTopicV2, 10);
-    Assert.assertFalse(pushStatusCollector.getDaVinciStoreTopicToPartitionCountMap().containsKey(regularStoreTopicV2));
+    Assert.assertFalse(pushStatusCollector.getTopicToPushStatusMap().containsKey(regularStoreTopicV2));
     pushStatusCollector.handleServerPushStatusUpdate(regularStoreTopicV2, ExecutionStatus.ERROR, "ERROR!!!");
     Assert.assertEquals(pushErrorCount.get(), 1);
 
@@ -78,13 +78,13 @@ public class PushStatusCollectorTest {
         .thenReturn(startedInstancePushStatus, errorInstancePushStatus);
     when(pushStatusStoreReader.isInstanceAlive(daVinciStoreName, "instance")).thenReturn(true);
     pushStatusCollector.subscribeTopic(daVinciStoreTopicV1, 1);
-    Assert.assertFalse(pushStatusCollector.getDaVinciStoreTopicToPartitionCountMap().containsKey(daVinciStoreTopicV1));
+    Assert.assertFalse(pushStatusCollector.getTopicToPushStatusMap().containsKey(daVinciStoreTopicV1));
 
     // Da Vinci Topic v2, DVC success, Server success
     pushCompletedCount.set(0);
     pushErrorCount.set(0);
     pushStatusCollector.subscribeTopic(daVinciStoreTopicV2, 1);
-    Assert.assertTrue(pushStatusCollector.getDaVinciStoreTopicToPartitionCountMap().containsKey(daVinciStoreTopicV2));
+    Assert.assertTrue(pushStatusCollector.getTopicToPushStatusMap().containsKey(daVinciStoreTopicV2));
     TestUtils.waitForNonDeterministicAssertion(
         2,
         TimeUnit.SECONDS,
@@ -102,7 +102,7 @@ public class PushStatusCollectorTest {
     pushCompletedCount.set(0);
     pushErrorCount.set(0);
     pushStatusCollector.subscribeTopic(daVinciStoreTopicV3, 1);
-    Assert.assertTrue(pushStatusCollector.getDaVinciStoreTopicToPartitionCountMap().containsKey(daVinciStoreTopicV3));
+    Assert.assertTrue(pushStatusCollector.getTopicToPushStatusMap().containsKey(daVinciStoreTopicV3));
     TestUtils.waitForNonDeterministicAssertion(
         2,
         TimeUnit.SECONDS,
@@ -120,7 +120,7 @@ public class PushStatusCollectorTest {
     pushCompletedCount.set(0);
     pushErrorCount.set(0);
     pushStatusCollector.subscribeTopic(daVinciStoreTopicV4, 1);
-    Assert.assertTrue(pushStatusCollector.getDaVinciStoreTopicToPartitionCountMap().containsKey(daVinciStoreTopicV4));
+    Assert.assertTrue(pushStatusCollector.getTopicToPushStatusMap().containsKey(daVinciStoreTopicV4));
     TestUtils.waitForNonDeterministicAssertion(
         2,
         TimeUnit.SECONDS,
@@ -138,7 +138,7 @@ public class PushStatusCollectorTest {
     pushCompletedCount.set(0);
     pushErrorCount.set(0);
     pushStatusCollector.subscribeTopic(daVinciStoreTopicV5, 1);
-    Assert.assertTrue(pushStatusCollector.getDaVinciStoreTopicToPartitionCountMap().containsKey(daVinciStoreTopicV5));
+    Assert.assertTrue(pushStatusCollector.getTopicToPushStatusMap().containsKey(daVinciStoreTopicV5));
     TestUtils.waitForNonDeterministicAssertion(
         2,
         TimeUnit.SECONDS,

--- a/services/venice-controller/src/test/java/com/linkedin/venice/pushmonitor/PushStatusCollectorTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/pushmonitor/PushStatusCollectorTest.java
@@ -8,10 +8,11 @@ import static org.mockito.Mockito.when;
 import com.linkedin.venice.meta.ReadWriteStoreRepository;
 import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.pushstatushelper.PushStatusStoreReader;
-import com.linkedin.venice.utils.Utils;
+import com.linkedin.venice.utils.TestUtils;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
@@ -84,48 +85,71 @@ public class PushStatusCollectorTest {
     pushErrorCount.set(0);
     pushStatusCollector.subscribeTopic(daVinciStoreTopicV2, 1);
     Assert.assertTrue(pushStatusCollector.getDaVinciStoreTopicToPartitionCountMap().containsKey(daVinciStoreTopicV2));
-    Utils.sleep(2000);
-    verify(pushStatusStoreReader, atLeast(1)).getPartitionStatus(daVinciStoreName, 2, 0, Optional.empty());
+    TestUtils.waitForNonDeterministicAssertion(
+        2,
+        TimeUnit.SECONDS,
+        true,
+        () -> verify(pushStatusStoreReader, atLeast(1)).getPartitionStatus(daVinciStoreName, 2, 0, Optional.empty()));
     Assert.assertEquals(pushCompletedCount.get(), 0);
     pushStatusCollector.handleServerPushStatusUpdate(daVinciStoreTopicV2, ExecutionStatus.COMPLETED, null);
-    Utils.sleep(2000);
-    Assert.assertEquals(pushCompletedCount.get(), 1);
+    TestUtils.waitForNonDeterministicAssertion(
+        2,
+        TimeUnit.SECONDS,
+        true,
+        () -> Assert.assertEquals(pushCompletedCount.get(), 1));
 
     // Da Vinci Topic v3, DVC success, Server ERROR
     pushCompletedCount.set(0);
     pushErrorCount.set(0);
     pushStatusCollector.subscribeTopic(daVinciStoreTopicV3, 1);
     Assert.assertTrue(pushStatusCollector.getDaVinciStoreTopicToPartitionCountMap().containsKey(daVinciStoreTopicV3));
-    Utils.sleep(2000);
-    verify(pushStatusStoreReader, atLeast(1)).getPartitionStatus(daVinciStoreName, 3, 0, Optional.empty());
+    TestUtils.waitForNonDeterministicAssertion(
+        2,
+        TimeUnit.SECONDS,
+        true,
+        () -> verify(pushStatusStoreReader, atLeast(1)).getPartitionStatus(daVinciStoreName, 3, 0, Optional.empty()));
     Assert.assertEquals(pushErrorCount.get(), 0);
     pushStatusCollector.handleServerPushStatusUpdate(daVinciStoreTopicV3, ExecutionStatus.ERROR, "ERROR!!!!");
-    Utils.sleep(2000);
-    Assert.assertEquals(pushErrorCount.get(), 1);
+    TestUtils.waitForNonDeterministicAssertion(
+        2,
+        TimeUnit.SECONDS,
+        true,
+        () -> Assert.assertEquals(pushErrorCount.get(), 1));
 
     // Da Vinci Topic v4, DVC ERROR, Server success
     pushCompletedCount.set(0);
     pushErrorCount.set(0);
     pushStatusCollector.subscribeTopic(daVinciStoreTopicV4, 1);
     Assert.assertTrue(pushStatusCollector.getDaVinciStoreTopicToPartitionCountMap().containsKey(daVinciStoreTopicV4));
-    Utils.sleep(2000);
-    verify(pushStatusStoreReader, atLeast(1)).getPartitionStatus(daVinciStoreName, 4, 0, Optional.empty());
+    TestUtils.waitForNonDeterministicAssertion(
+        2,
+        TimeUnit.SECONDS,
+        true,
+        () -> verify(pushStatusStoreReader, atLeast(1)).getPartitionStatus(daVinciStoreName, 4, 0, Optional.empty()));
     Assert.assertEquals(pushErrorCount.get(), 0);
     pushStatusCollector.handleServerPushStatusUpdate(daVinciStoreTopicV4, ExecutionStatus.COMPLETED, null);
-    Utils.sleep(2000);
-    Assert.assertEquals(pushErrorCount.get(), 1);
+    TestUtils.waitForNonDeterministicAssertion(
+        2,
+        TimeUnit.SECONDS,
+        true,
+        () -> Assert.assertEquals(pushErrorCount.get(), 1));
 
     // Da Vinci Topic v5, DVC ERROR, Server ERROR
     pushCompletedCount.set(0);
     pushErrorCount.set(0);
     pushStatusCollector.subscribeTopic(daVinciStoreTopicV5, 1);
     Assert.assertTrue(pushStatusCollector.getDaVinciStoreTopicToPartitionCountMap().containsKey(daVinciStoreTopicV5));
-    Utils.sleep(2000);
-    verify(pushStatusStoreReader, atLeast(1)).getPartitionStatus(daVinciStoreName, 5, 0, Optional.empty());
+    TestUtils.waitForNonDeterministicAssertion(
+        2,
+        TimeUnit.SECONDS,
+        true,
+        () -> verify(pushStatusStoreReader, atLeast(1)).getPartitionStatus(daVinciStoreName, 5, 0, Optional.empty()));
     Assert.assertEquals(pushErrorCount.get(), 0);
     pushStatusCollector.handleServerPushStatusUpdate(daVinciStoreTopicV5, ExecutionStatus.ERROR, null);
-    Utils.sleep(2000);
-    Assert.assertEquals(pushErrorCount.get(), 1);
-
+    TestUtils.waitForNonDeterministicAssertion(
+        2,
+        TimeUnit.SECONDS,
+        true,
+        () -> Assert.assertEquals(pushErrorCount.get(), 1));
   }
 }

--- a/services/venice-controller/src/test/java/com/linkedin/venice/pushmonitor/PushStatusCollectorTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/pushmonitor/PushStatusCollectorTest.java
@@ -1,0 +1,131 @@
+package com.linkedin.venice.pushmonitor;
+
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.linkedin.venice.meta.ReadWriteStoreRepository;
+import com.linkedin.venice.meta.Store;
+import com.linkedin.venice.pushstatushelper.PushStatusStoreReader;
+import com.linkedin.venice.utils.Utils;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class PushStatusCollectorTest {
+  @Test
+  public void testPushStatusCollector() {
+    ReadWriteStoreRepository storeRepository = mock(ReadWriteStoreRepository.class);
+    PushStatusStoreReader pushStatusStoreReader = mock(PushStatusStoreReader.class);
+
+    String daVinciStoreName = "daVinciStore";
+    String daVinciStoreTopicV1 = "daVinciStore_v1";
+    String daVinciStoreTopicV2 = "daVinciStore_v2";
+    String daVinciStoreTopicV3 = "daVinciStore_v3";
+    String daVinciStoreTopicV4 = "daVinciStore_v4";
+    String daVinciStoreTopicV5 = "daVinciStore_v5";
+    Store daVinciStore = mock(Store.class);
+    when(daVinciStore.isDaVinciPushStatusStoreEnabled()).thenReturn(true);
+    when(storeRepository.getStore(daVinciStoreName)).thenReturn(daVinciStore);
+
+    String regularStoreName = "regularStore";
+    String regularStoreTopicV1 = "regularStore_v1";
+    String regularStoreTopicV2 = "regularStore_v2";
+    Store regularStore = mock(Store.class);
+    when(regularStore.isDaVinciPushStatusStoreEnabled()).thenReturn(false);
+    when(storeRepository.getStore(regularStoreName)).thenReturn(regularStore);
+
+    AtomicInteger pushCompletedCount = new AtomicInteger();
+    AtomicInteger pushErrorCount = new AtomicInteger();
+
+    Consumer<String> pushCompleteConsumer = x -> pushCompletedCount.getAndIncrement();
+    BiConsumer<String, String> pushErrorConsumer = (x, y) -> pushErrorCount.getAndIncrement();
+    PushStatusCollector pushStatusCollector =
+        new PushStatusCollector(storeRepository, pushStatusStoreReader, pushCompleteConsumer, pushErrorConsumer, 1);
+    pushStatusCollector.start();
+
+    pushStatusCollector.subscribeTopic(regularStoreTopicV1, 10);
+    Assert.assertFalse(pushStatusCollector.getDaVinciStoreTopicToPartitionCountMap().containsKey(regularStoreTopicV1));
+    pushStatusCollector.handleServerPushStatusUpdate(regularStoreTopicV1, ExecutionStatus.COMPLETED, null);
+    Assert.assertEquals(pushCompletedCount.get(), 1);
+
+    pushStatusCollector.subscribeTopic(regularStoreTopicV2, 10);
+    Assert.assertFalse(pushStatusCollector.getDaVinciStoreTopicToPartitionCountMap().containsKey(regularStoreTopicV2));
+    pushStatusCollector.handleServerPushStatusUpdate(regularStoreTopicV2, ExecutionStatus.ERROR, "ERROR!!!");
+    Assert.assertEquals(pushErrorCount.get(), 1);
+
+    pushCompletedCount.set(0);
+    pushErrorCount.set(0);
+    Map<CharSequence, Integer> successfulInstancePushStatus = Collections.singletonMap("instance", 10);
+    Map<CharSequence, Integer> errorInstancePushStatus = Collections.singletonMap("instance", 12);
+    Map<CharSequence, Integer> startedInstancePushStatus = Collections.singletonMap("instance", 2);
+
+    when(pushStatusStoreReader.getPartitionStatus(daVinciStoreName, 2, 0, Optional.empty()))
+        .thenReturn(startedInstancePushStatus, successfulInstancePushStatus);
+    when(pushStatusStoreReader.getPartitionStatus(daVinciStoreName, 3, 0, Optional.empty()))
+        .thenReturn(startedInstancePushStatus, successfulInstancePushStatus);
+    when(pushStatusStoreReader.getPartitionStatus(daVinciStoreName, 4, 0, Optional.empty()))
+        .thenReturn(startedInstancePushStatus, errorInstancePushStatus);
+    when(pushStatusStoreReader.getPartitionStatus(daVinciStoreName, 5, 0, Optional.empty()))
+        .thenReturn(startedInstancePushStatus, errorInstancePushStatus);
+    when(pushStatusStoreReader.isInstanceAlive(daVinciStoreName, "instance")).thenReturn(true);
+    pushStatusCollector.subscribeTopic(daVinciStoreTopicV1, 1);
+    Assert.assertFalse(pushStatusCollector.getDaVinciStoreTopicToPartitionCountMap().containsKey(daVinciStoreTopicV1));
+
+    // Da Vinci Topic v2, DVC success, Server success
+    pushCompletedCount.set(0);
+    pushErrorCount.set(0);
+    pushStatusCollector.subscribeTopic(daVinciStoreTopicV2, 1);
+    Assert.assertTrue(pushStatusCollector.getDaVinciStoreTopicToPartitionCountMap().containsKey(daVinciStoreTopicV2));
+    Utils.sleep(2000);
+    verify(pushStatusStoreReader, atLeast(1)).getPartitionStatus(daVinciStoreName, 2, 0, Optional.empty());
+    Assert.assertEquals(pushCompletedCount.get(), 0);
+    pushStatusCollector.handleServerPushStatusUpdate(daVinciStoreTopicV2, ExecutionStatus.COMPLETED, null);
+    Utils.sleep(2000);
+    Assert.assertEquals(pushCompletedCount.get(), 1);
+
+    // Da Vinci Topic v3, DVC success, Server ERROR
+    pushCompletedCount.set(0);
+    pushErrorCount.set(0);
+    pushStatusCollector.subscribeTopic(daVinciStoreTopicV3, 1);
+    Assert.assertTrue(pushStatusCollector.getDaVinciStoreTopicToPartitionCountMap().containsKey(daVinciStoreTopicV3));
+    Utils.sleep(2000);
+    verify(pushStatusStoreReader, atLeast(1)).getPartitionStatus(daVinciStoreName, 3, 0, Optional.empty());
+    Assert.assertEquals(pushErrorCount.get(), 0);
+    pushStatusCollector.handleServerPushStatusUpdate(daVinciStoreTopicV3, ExecutionStatus.ERROR, "ERROR!!!!");
+    Utils.sleep(2000);
+    Assert.assertEquals(pushErrorCount.get(), 1);
+
+    // Da Vinci Topic v4, DVC ERROR, Server success
+    pushCompletedCount.set(0);
+    pushErrorCount.set(0);
+    pushStatusCollector.subscribeTopic(daVinciStoreTopicV4, 1);
+    Assert.assertTrue(pushStatusCollector.getDaVinciStoreTopicToPartitionCountMap().containsKey(daVinciStoreTopicV4));
+    Utils.sleep(2000);
+    verify(pushStatusStoreReader, atLeast(1)).getPartitionStatus(daVinciStoreName, 4, 0, Optional.empty());
+    Assert.assertEquals(pushErrorCount.get(), 0);
+    pushStatusCollector.handleServerPushStatusUpdate(daVinciStoreTopicV4, ExecutionStatus.COMPLETED, null);
+    Utils.sleep(2000);
+    Assert.assertEquals(pushErrorCount.get(), 1);
+
+    // Da Vinci Topic v5, DVC ERROR, Server ERROR
+    pushCompletedCount.set(0);
+    pushErrorCount.set(0);
+    pushStatusCollector.subscribeTopic(daVinciStoreTopicV5, 1);
+    Assert.assertTrue(pushStatusCollector.getDaVinciStoreTopicToPartitionCountMap().containsKey(daVinciStoreTopicV5));
+    Utils.sleep(2000);
+    verify(pushStatusStoreReader, atLeast(1)).getPartitionStatus(daVinciStoreName, 5, 0, Optional.empty());
+    Assert.assertEquals(pushErrorCount.get(), 0);
+    pushStatusCollector.handleServerPushStatusUpdate(daVinciStoreTopicV5, ExecutionStatus.ERROR, null);
+    Utils.sleep(2000);
+    Assert.assertEquals(pushErrorCount.get(), 1);
+
+  }
+}

--- a/services/venice-controller/src/test/java/com/linkedin/venice/pushmonitor/PushStatusCollectorTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/pushmonitor/PushStatusCollectorTest.java
@@ -54,7 +54,8 @@ public class PushStatusCollectorTest {
         pushCompleteConsumer,
         pushErrorConsumer,
         true,
-        1);
+        1,
+        4);
     pushStatusCollector.start();
 
     pushStatusCollector.subscribeTopic(regularStoreTopicV1, 10);

--- a/services/venice-controller/src/test/java/com/linkedin/venice/pushmonitor/PushStatusCollectorTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/pushmonitor/PushStatusCollectorTest.java
@@ -48,8 +48,13 @@ public class PushStatusCollectorTest {
 
     Consumer<String> pushCompleteConsumer = x -> pushCompletedCount.getAndIncrement();
     BiConsumer<String, String> pushErrorConsumer = (x, y) -> pushErrorCount.getAndIncrement();
-    PushStatusCollector pushStatusCollector =
-        new PushStatusCollector(storeRepository, pushStatusStoreReader, pushCompleteConsumer, pushErrorConsumer, 1);
+    PushStatusCollector pushStatusCollector = new PushStatusCollector(
+        storeRepository,
+        pushStatusStoreReader,
+        pushCompleteConsumer,
+        pushErrorConsumer,
+        true,
+        1);
     pushStatusCollector.start();
 
     pushStatusCollector.subscribeTopic(regularStoreTopicV1, 10);


### PR DESCRIPTION
## [controller] Offline push status will also monitor Da Vinci push status store if enabled
Offline Push monitor today only monitors Venice Server push status (changes from ZK). However, when Da Vinci is also reporting ingestion status to this store push job, only VPJ is monitoring the DVC push status store but not push monitor. When the failure from DVC is deterministic (OOM detected by memory limiter (not yet implemented) for example), it will lead to infinite retry of DVC future version ingestion (as the bad version becomes current version after backend push completed).

This PR fixes the issue by introducing a new PushStatusCollector class that has a scheduler thread to periodically scan DVC push status enabled store and aggregate server push status with Da Vinci push status to come up with the aggregated status. With this change, when controller detects server push status change, it will not directly mark overall push as COMPLETED unless DVC result is also COMPLETED. 

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
Added a new unit test.
## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.