### PR TITLE
[doc] Aggregate javadoc and publish

### DIFF
--- a/.github/workflows/publish-javadoc.yml
+++ b/.github/workflows/publish-javadoc.yml
@@ -1,0 +1,40 @@
+name: Deploy Javadoc
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+
+jobs:
+  PublishJavaDoc:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - shell: bash
+        run: |
+          git remote set-head origin --auto
+          git remote add upstream https://github.com/linkedin/venice
+          git fetch upstream
+          git config --global user.name "JavaDoc Bot"
+          git config --global user.email "javadoc_bot@invalid.com"
+          git switch -C javadoc
+          git rebase upstream/main
+          git push -f origin javadoc
+      - name: Validate Gradle wrapper
+        uses: gradle/wrapper-validation-action@v1
+      - name: Build with Gradle
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: "aggregateJavadoc"
+      - name: Deploy to GitHub Page
+        uses: JamesIves/github-pages-deploy-action@v4.4.1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: javadoc
+          clean: true
+          folder: "build/javadoc"
+          target-folder: docs/javadoc

--- a/build.gradle
+++ b/build.gradle
@@ -503,6 +503,18 @@ subprojects {
   }
 }
 
+task aggregateJavadoc(type: Javadoc) {
+  source subprojects.collect { project ->
+    project.sourceSets.main.allJava
+  }
+  classpath = files(subprojects.collect { project ->
+    project.sourceSets.main.compileClasspath
+  })
+  // generate javadoc with no warnings
+  getOptions().addStringOption('Xdoclint:none', '-quiet')
+  destinationDir = new File(buildDir, 'javadoc')
+}
+
 spotless {
   ratchetFrom "${git.getUpstreamRemote()}/main"
   java {

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,2 +1,6 @@
 title: Venice
 remote_theme: just-the-docs/just-the-docs
+nav_external_links:
+  - title: Venice Java doc
+    url: ./javadoc/index.html
+    hide_icon: false


### PR DESCRIPTION
## Summary
Our Javadocs are not generated and hosted anywhere due to 
1. Some java doc are broken due to syntax issues
2. We haven't moved on to Central Maven which provides easy access hosting Javadoc on https://javadoc.io/

It'd be great to generate Javadocs for both internal and external use cases so this PR is trying to host Javadocs on the existing Github Page.

## How it works
The idea is to create a dummy branch `javadoc` and generate all Javadocs under `/doc/javadoc`. Then provides one navigation link to it in our Github page setup. We will also have to render Github page from `javadoc` branch instead of `main`

## How often the Javadoc is generated and published

The workflow will run for every push on `main` branch and a dummy user will be setup to sync the `main` branch and `javadoc` branch, finally the new GH action `JamesIves/github-pages-deploy-action@v4.4.1` would copy the aggregated javadoc to `/doc/javadoc` for branch `javadoc`.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

https://adamxchen.github.io/venice/ (on the left navigation table)
https://adamxchen.github.io/venice/javadoc/index.html

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.