### PR TITLE
[test] Fix flaky unit test RetryUtilsTest#testFixAttemptDurationOnSupplier

### DIFF
--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/utils/RetryUtilsTest.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/utils/RetryUtilsTest.java
@@ -288,13 +288,11 @@ public class RetryUtilsTest {
         .thenThrow(IllegalStateException.class)
         .thenReturn(2);
     long startTime = System.currentTimeMillis();
-    Assert.assertEquals(
-        (int) RetryUtils.executeWithMaxRetriesAndFixedAttemptDuration(
-            () -> obj.getAnInteger() + 1,
-            2,
-            Duration.ofMillis(1000),
-            Arrays.asList(IllegalStateException.class, IllegalArgumentException.class)),
-        3);
+    Assert.assertEquals((int) RetryUtils.executeWithMaxRetriesAndFixedAttemptDuration(() -> {
+      // Give the action some non-trivial time to make sure no precision error.
+      Utils.sleep(100);
+      return obj.getAnInteger() + 1;
+    }, 2, Duration.ofMillis(1000), Arrays.asList(IllegalStateException.class, IllegalArgumentException.class)), 3);
     long timeSpentInMs = (System.currentTimeMillis() - startTime);
     Assert.assertTrue(timeSpentInMs > 2000, "Time spent in attempts " + timeSpentInMs + "ms");
     verify(obj, times(3)).getAnInteger();

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/utils/RetryUtilsTest.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/utils/RetryUtilsTest.java
@@ -295,7 +295,8 @@ public class RetryUtilsTest {
             Duration.ofMillis(1000),
             Arrays.asList(IllegalStateException.class, IllegalArgumentException.class)),
         3);
-    Assert.assertTrue((System.currentTimeMillis() - startTime) > 2000);
+    long timeSpentInMs = (System.currentTimeMillis() - startTime);
+    Assert.assertTrue(timeSpentInMs > 2000, "Time spent in attempts " + timeSpentInMs + "ms");
     verify(obj, times(3)).getAnInteger();
     reset(obj);
   }


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## [test] Fix flaky unit test RetryUtilsTest#testFixAttemptDurationOnSupplier
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

This PR fixes the flaky test by introducing some non-trivial time on the attempted action. With additional logging we found that the total time spent was 1999ms/2000ms, less than expected > 2000ms. This might be because the RetryUtils's calculation precision loss on wait time. In theory, the logic should be good enough, hence just make the action a bit longer to make sure 2 * 1 second wait + 3rd attempt > 2seconds.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
Unit test.
## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.