### PR TITLE
[admin-tool] Support a new datetime argument in data-recovery monitor

### DIFF
--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/AdminTool.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/AdminTool.java
@@ -101,7 +101,6 @@ import java.nio.file.Paths;
 import java.text.SimpleDateFormat;
 import java.time.Duration;
 import java.time.LocalDateTime;
-import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
@@ -680,32 +679,24 @@ public class AdminTool {
     String parentUrl = getRequiredArgument(cmd, Arg.URL);
     String destFabric = getRequiredArgument(cmd, Arg.DEST_FABRIC);
     String stores = getRequiredArgument(cmd, Arg.STORES);
+    String dateTimeStr = getRequiredArgument(cmd, Arg.DATETIME);
 
     String intervalStr = getOptionalArgument(cmd, Arg.INTERVAL);
-    String dateTimeStr = getOptionalArgument(cmd, Arg.DATETIME);
 
     MonitorCommand.Params monitorParams = new MonitorCommand.Params();
     monitorParams.setTargetRegion(destFabric);
     monitorParams.setParentUrl(parentUrl);
     monitorParams.setSslFactory(sslFactory);
 
-    LocalDateTime dateTime = null;
-    if (dateTimeStr != null) {
-      try {
-        dateTime = LocalDateTime.parse(dateTimeStr, DateTimeFormatter.ISO_LOCAL_DATE_TIME);
-      } catch (DateTimeParseException e) {
-        throw new VeniceException(
-            String.format(
-                "Can not parse: %s, supported format: %s",
-                e.getParsedString(),
-                DateTimeFormatter.ISO_LOCAL_DATE_TIME));
-      }
-    } else {
-      // Use current time in UTC as the default value, if no input.
-      dateTime = LocalDateTime.now(ZoneOffset.UTC);
-      System.out.println(String.format("Using default date time: %s", dateTime));
+    try {
+      monitorParams.setDateTime(LocalDateTime.parse(dateTimeStr, DateTimeFormatter.ISO_LOCAL_DATE_TIME));
+    } catch (DateTimeParseException e) {
+      throw new VeniceException(
+          String.format(
+              "Can not parse: %s, supported format: %s",
+              e.getParsedString(),
+              DateTimeFormatter.ISO_LOCAL_DATE_TIME));
     }
-    monitorParams.setDateTime(dateTime);
 
     DataRecoveryClient dataRecoveryClient = new DataRecoveryClient();
     DataRecoveryClient.DataRecoveryParams params = new DataRecoveryClient.DataRecoveryParams(stores);

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/AdminTool.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/AdminTool.java
@@ -100,6 +100,10 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.text.SimpleDateFormat;
 import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -678,11 +682,30 @@ public class AdminTool {
     String stores = getRequiredArgument(cmd, Arg.STORES);
 
     String intervalStr = getOptionalArgument(cmd, Arg.INTERVAL);
+    String dateTimeStr = getOptionalArgument(cmd, Arg.DATETIME);
 
     MonitorCommand.Params monitorParams = new MonitorCommand.Params();
     monitorParams.setTargetRegion(destFabric);
     monitorParams.setParentUrl(parentUrl);
     monitorParams.setSslFactory(sslFactory);
+
+    LocalDateTime dateTime = null;
+    if (dateTimeStr != null) {
+      try {
+        dateTime = LocalDateTime.parse(dateTimeStr, DateTimeFormatter.ISO_LOCAL_DATE_TIME);
+      } catch (DateTimeParseException e) {
+        throw new VeniceException(
+            String.format(
+                "Can not parse: %s, supported format: %s",
+                e.getParsedString(),
+                DateTimeFormatter.ISO_LOCAL_DATE_TIME));
+      }
+    } else {
+      // Use current time in UTC as the default value, if no input.
+      dateTime = LocalDateTime.now(ZoneOffset.UTC);
+      System.out.println(String.format("Using default date time: %s", dateTime));
+    }
+    monitorParams.setDateTime(dateTime);
 
     DataRecoveryClient dataRecoveryClient = new DataRecoveryClient();
     DataRecoveryClient.DataRecoveryParams params = new DataRecoveryClient.DataRecoveryParams(stores);

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/Arg.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/Arg.java
@@ -230,7 +230,7 @@ public enum Arg {
   INTERVAL(
       "interval", "itv", true,
       "monitor data recovery progress at seconds close to the number specified by the interval parameter until tasks are finished"
-  ), DATETIME("datetime", "dtm", true, "Date and time stamp (DD/MM/YYYY HH:MM:SS) for data recovery"),
+  ), DATETIME("datetime", "dtm", true, "Date and time stamp (YYYY-MM-DDTHH:MM:SS) for data recovery"),
   DEBUG("debug", "d", false, "Print debugging messages for execute-data-recovery");
 
   private final String argName;

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/Arg.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/Arg.java
@@ -230,7 +230,8 @@ public enum Arg {
   INTERVAL(
       "interval", "itv", true,
       "monitor data recovery progress at seconds close to the number specified by the interval parameter until tasks are finished"
-  ), DEBUG("debug", "d", false, "Print debugging messages for execute-data-recovery");
+  ), DATETIME("datetime", "dtm", true, "Date and time stamp (DD/MM/YYYY HH:MM:SS) for data recovery"),
+  DEBUG("debug", "d", false, "Print debugging messages for execute-data-recovery");
 
   private final String argName;
   private final String first;

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/Arg.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/Arg.java
@@ -230,7 +230,7 @@ public enum Arg {
   INTERVAL(
       "interval", "itv", true,
       "monitor data recovery progress at seconds close to the number specified by the interval parameter until tasks are finished"
-  ), DATETIME("datetime", "dtm", true, "Date and time stamp (YYYY-MM-DDTHH:MM:SS) for data recovery"),
+  ), DATETIME("datetime", "dtm", true, "Date and time stamp (YYYY-MM-DDTHH:MM:SS) in UTC time zone for data recovery"),
   DEBUG("debug", "d", false, "Print debugging messages for execute-data-recovery");
 
   private final String argName;

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/Command.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/Command.java
@@ -17,6 +17,7 @@ import static com.linkedin.venice.Arg.CLUSTER;
 import static com.linkedin.venice.Arg.CLUSTER_DEST;
 import static com.linkedin.venice.Arg.CLUSTER_SRC;
 import static com.linkedin.venice.Arg.COMPRESSION_STRATEGY;
+import static com.linkedin.venice.Arg.DATETIME;
 import static com.linkedin.venice.Arg.DEBUG;
 import static com.linkedin.venice.Arg.DERIVED_SCHEMA;
 import static com.linkedin.venice.Arg.DERIVED_SCHEMA_ID;
@@ -454,7 +455,7 @@ public enum Command {
   ),
   MONITOR_DATA_RECOVERY(
       "monitor-data-recovery", "Monitor data recovery progress for a group of stores",
-      new Arg[] { URL, STORES, DEST_FABRIC }, new Arg[] { INTERVAL }
+      new Arg[] { URL, STORES, DEST_FABRIC }, new Arg[] { INTERVAL, DATETIME }
   );
 
   private final String commandName;

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/Command.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/Command.java
@@ -455,7 +455,7 @@ public enum Command {
   ),
   MONITOR_DATA_RECOVERY(
       "monitor-data-recovery", "Monitor data recovery progress for a group of stores",
-      new Arg[] { URL, STORES, DEST_FABRIC }, new Arg[] { INTERVAL, DATETIME }
+      new Arg[] { URL, STORES, DEST_FABRIC, DATETIME }, new Arg[] { INTERVAL }
   );
 
   private final String commandName;

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/datarecovery/DataRecoveryWorker.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/datarecovery/DataRecoveryWorker.java
@@ -73,11 +73,9 @@ public abstract class DataRecoveryWorker {
      * Keep polling the states (for monitor) of all tasks at given intervals when interval is set to certain value
      * plus not all tasks are finished. Otherwise, if interval is unset, just do a one time execution for all tasks.
      */
-    boolean requireSleep = false;
     do {
-      final boolean finalRequireSleep = requireSleep;
       try (Timer ignored = Timer.run(elapsedTimeInMs -> {
-        if (finalRequireSleep) {
+        if (continuePollingState()) {
           Utils.sleep(computeTimeToSleepInMillis(elapsedTimeInMs));
         }
       })) {
@@ -89,7 +87,7 @@ public abstract class DataRecoveryWorker {
         processData();
         displayAllTasksResult();
       }
-    } while (requireSleep = continuePollingState());
+    } while (continuePollingState());
   }
 
   public void processData() {

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/datarecovery/MonitorCommand.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/datarecovery/MonitorCommand.java
@@ -97,12 +97,12 @@ public class MonitorCommand extends Command {
                   "No ongoing offline pushes detected after given date time (%s), keep polling",
                   params.dateTime));
           return;
-        } else {
-          isOngoingOfflinePushDetected = true;
-          String kafkaTopic = Version.composeKafkaTopic(storeName, futureVersion);
-          result.setFutureVersion(futureVersion);
-          result.setKafKaTopic(kafkaTopic);
         }
+
+        isOngoingOfflinePushDetected = true;
+        String kafkaTopic = Version.composeKafkaTopic(storeName, futureVersion);
+        result.setFutureVersion(futureVersion);
+        result.setKafKaTopic(kafkaTopic);
       }
 
       // Query job status.
@@ -170,7 +170,6 @@ public class MonitorCommand extends Command {
     private String parentUrl;
     private Optional<SSLFactory> sslFactory;
 
-    // expected completion timestamp
     private LocalDateTime dateTime;
 
     public void setTargetRegion(String fabric) {

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/datarecovery/MonitorCommand.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/datarecovery/MonitorCommand.java
@@ -3,18 +3,24 @@ package com.linkedin.venice.datarecovery;
 import com.linkedin.venice.controllerapi.ControllerClient;
 import com.linkedin.venice.controllerapi.JobStatusQueryResponse;
 import com.linkedin.venice.controllerapi.MultiStoreStatusResponse;
+import com.linkedin.venice.controllerapi.StoreHealthAuditResponse;
 import com.linkedin.venice.controllerapi.StoreResponse;
+import com.linkedin.venice.meta.RegionPushDetails;
 import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.StoreInfo;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.pushmonitor.ExecutionStatus;
 import com.linkedin.venice.security.SSLFactory;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Optional;
 
 
 public class MonitorCommand extends Command {
   private MonitorCommand.Params params;
   private final MonitorCommand.Result result = new MonitorCommand.Result();
+
+  private boolean isOngoingOfflinePushDetected = false;
 
   // For unit test only.
   public MonitorCommand() {
@@ -27,6 +33,11 @@ public class MonitorCommand extends Command {
   // For unit test only.
   public void setParams(MonitorCommand.Params params) {
     this.params = params;
+  }
+
+  // For unit test only.
+  public void setOngoingOfflinePushDetected(boolean val) {
+    this.isOngoingOfflinePushDetected = val;
   }
 
   @Override
@@ -55,30 +66,48 @@ public class MonitorCommand extends Command {
       }
 
       result.setStoreInfo(storeResponse.getStore());
-      /*
-       * Find out store future version. A store has a meaningful future version only when there is an ongoing
-       * offline push for the store.
-       */
-      MultiStoreStatusResponse response = parentCtrlCli.getFutureVersions(clusterName, storeName);
 
-      if (!response.getStoreStatusMap().containsKey(params.targetRegion)) {
-        completeCoreWorkWithError(String.format("No status for region: %s", params.targetRegion));
-        return;
+      if (!isOngoingOfflinePushDetected) {
+        LocalDateTime currentVersionStartDateTime = retrieveCurrentVersionDateTime(parentCtrlCli);
+        if (currentVersionStartDateTime.isAfter(params.dateTime)) {
+          // If we have a current version for the given store started after the given date time, claim done.
+          completeCoreWorkWithMessage(
+              String.format(
+                  "current ver is newer (%s) than date time (%s)",
+                  currentVersionStartDateTime,
+                  params.dateTime));
+          return;
+        }
+
+        /*
+         * Find out store future version. A store has a meaningful future version only when there is an ongoing
+         * offline push for the store.
+         */
+        MultiStoreStatusResponse response = parentCtrlCli.getFutureVersions(clusterName, storeName);
+
+        if (!response.getStoreStatusMap().containsKey(params.targetRegion)) {
+          completeCoreWorkWithError(String.format("No status for region: %s", params.targetRegion));
+          return;
+        }
+
+        int futureVersion = Integer.parseInt(response.getStoreStatusMap().get(params.targetRegion));
+        if (futureVersion == Store.NON_EXISTING_VERSION) {
+          result.setMessage(
+              String.format(
+                  "No ongoing offline pushes detected after given date time (%s), keep polling",
+                  params.dateTime));
+          return;
+        } else {
+          isOngoingOfflinePushDetected = true;
+          String kafkaTopic = Version.composeKafkaTopic(storeName, futureVersion);
+          result.setFutureVersion(futureVersion);
+          result.setKafKaTopic(kafkaTopic);
+        }
       }
-
-      int futureVersion = Integer.parseInt(response.getStoreStatusMap().get(params.targetRegion));
-      if (futureVersion == Store.NON_EXISTING_VERSION) {
-        completeCoreWorkWithMessage("No ongoing offline pushes");
-        return;
-      }
-
-      String kafkaTopic = Version.composeKafkaTopic(storeName, futureVersion);
-      result.setFutureVersion(futureVersion);
-      result.setKafKaTopic(kafkaTopic);
 
       // Query job status.
       JobStatusQueryResponse jobStatusQueryResponse =
-          parentCtrlCli.queryDetailedJobStatus(kafkaTopic, params.targetRegion);
+          parentCtrlCli.queryDetailedJobStatus(result.kafKaTopic, params.targetRegion);
 
       if (jobStatusQueryResponse.isError()
           || jobStatusQueryResponse.getStatus().equalsIgnoreCase(ExecutionStatus.ERROR.toString())) {
@@ -97,6 +126,14 @@ public class MonitorCommand extends Command {
       // For other cases, report current status.
       result.setMessage(createReportMessage(jobStatusQueryResponse));
     }
+  }
+
+  // Retrieve the store's current version info.
+  private LocalDateTime retrieveCurrentVersionDateTime(ControllerClient parentCtrlCli) {
+    StoreHealthAuditResponse storeHealth = parentCtrlCli.listStorePushInfo(params.store, false);
+    RegionPushDetails targetRegion = storeHealth.getRegionPushDetails().get(params.targetRegion);
+    String dateTime = targetRegion.getPushStartTimestamp();
+    return LocalDateTime.parse(dateTime, DateTimeFormatter.ISO_LOCAL_DATE_TIME);
   }
 
   // A placeholder function for future improvement.
@@ -133,6 +170,9 @@ public class MonitorCommand extends Command {
     private String parentUrl;
     private Optional<SSLFactory> sslFactory;
 
+    // expected completion timestamp
+    private LocalDateTime dateTime;
+
     public void setTargetRegion(String fabric) {
       this.targetRegion = fabric;
     }
@@ -147,6 +187,10 @@ public class MonitorCommand extends Command {
 
     public void setSslFactory(Optional<SSLFactory> sslFactory) {
       this.sslFactory = sslFactory;
+    }
+
+    public void setDateTime(LocalDateTime dataTime) {
+      this.dateTime = dataTime;
     }
   }
 


### PR DESCRIPTION
This rb supports a new argument (datetime) in the admin-tool data-recovery monitor command. With this new argument, monitor command checks if there exists a successfully pushed version (current version) for the given store in the target region whose start time is newer than the input argument. If it does, monitor can report success, otherwise, it keeps polling/reporting a future version push job status until the future version is finished. During the real data recovery scenario, we can set the datetime argument to a timestamp at which we believe all related components (e.g. Kafka service) are recovered. If the argument is unspecified, we choose `now` as the default value.

## How was this PR tested?
- Unit test
- Internal CI test
- Manually tested against EI environment
example output (with masks)
```
lelu@lelu-mn1 venice % java -jar ./clients/venice-admin-tool/build/libs/venice-admin-tool-all.jar --monitor-data-recovery --url xxxxx --dest-fabric ei4 --stores xxxxx --interval 60
[WARN] Running admin tool without SSL.
Using default date time: 2023-05-23T22:41:25.948936
...
2023-05-23 15:47:27 INFO [DataRecoveryMonitor] [main] [store: xxxxx, msg: No ongoing offline pushes detected after given date time (2023-05-23T22:41:25.948936), keep polling]
2023-05-23 15:47:27 INFO [DataRecoveryWorker] [main] Total: 1, Succeeded: 0, Error: 0, Uncompleted: 1
2023-05-23 15:48:28 INFO [DataRecoveryMonitor] [main] [store: xxxxx, msg: ver: 16082, status: STARTED, uncompleted ptn: 4/4]
2023-05-23 15:48:28 INFO [DataRecoveryWorker] [main] Total: 1, Succeeded: 0, Error: 0, Uncompleted: 1
2023-05-23 15:49:27 INFO [DataRecoveryMonitor] [main] [store: xxxxx, msg: ver: 16082, status: STARTED, uncompleted ptn: 4/4]
2023-05-23 15:49:27 INFO [DataRecoveryWorker] [main] Total: 1, Succeeded: 0, Error: 0, Uncompleted: 1
...
2023-05-23 15:54:27 INFO [DataRecoveryMonitor] [main] [store: xxxxx, msg: ver: 16082, status: COMPLETED]
2023-05-23 15:54:27 INFO [DataRecoveryWorker] [main] Total: 1, Succeeded: 1, Error: 0, Uncompleted: 0
```


## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.