### PR TITLE
[router] Fixed a NPE occurring in router's streaming batch get

### DIFF
--- a/services/venice-router/src/main/java/com/linkedin/venice/router/streaming/VeniceChunkedResponse.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/streaming/VeniceChunkedResponse.java
@@ -284,8 +284,8 @@ public class VeniceChunkedResponse {
       }
     }
 
-    boolean isMultiGet = this.requestType.equals(RequestType.MULTI_GET_STREAMING);
-    if (isMultiGet && !this.responseCompression.equals(compression)) {
+    boolean isMultiGetStreaming = this.requestType.equals(RequestType.MULTI_GET_STREAMING);
+    if (isMultiGetStreaming && !this.responseCompression.equals(compression)) {
       // Defensive code, not expected
       LOGGER.error(
           "Received inconsistent compression for the new write: {}, and previous compression: {}",
@@ -308,7 +308,7 @@ public class VeniceChunkedResponse {
       // Send out response metadata
       ChannelPromise writePromise = ctx.newPromise().addListener(new ResponseMetadataWriteListener());
       HttpResponse responseMetadata =
-          isMultiGet ? RESPONSE_META_MAP_FOR_MULTI_GET.get(compression) : RESPONSE_META_FOR_COMPUTE;
+          isMultiGetStreaming ? RESPONSE_META_MAP_FOR_MULTI_GET.get(compression) : RESPONSE_META_FOR_COMPUTE;
       chunkedWriteHandler.write(ctx, responseMetadata, writePromise);
       /**
        * {@link ChunkedWriteHandler#resumeTransfer()} invocation will try to flush more data to the client since more

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/streaming/VeniceChunkedResponse.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/streaming/VeniceChunkedResponse.java
@@ -51,7 +51,6 @@ import java.util.Map;
 import java.util.Queue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentLinkedQueue;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import org.apache.logging.log4j.LogManager;
@@ -103,15 +102,16 @@ public class VeniceChunkedResponse {
 
   // Whether the response has already completed or not
   private boolean responseCompleteCalled = false;
-  // Whether the response metadata has been sent or not
-  private final AtomicBoolean responseMetadataWriteInitiated = new AtomicBoolean(false);
-
   private final AtomicLong totalBytesReceived = new AtomicLong(0);
   private final Queue<Chunk> chunksToWrite = new ConcurrentLinkedQueue<Chunk>();
   private final Queue<Chunk> chunksAwaitingCallback = new ConcurrentLinkedQueue<Chunk>();
 
-  // Response metadata should be sent when everything is good.
-  private HttpResponse responseMetadata;
+  /**
+   * Initialized upon the first write. If null, then no writes occurred yet, and therefore the response metadata was
+   * not sent either.
+   *
+   * In the case of streaming batch gets, we expect that all servers should return the same value for this.
+   */
   private volatile CompressionStrategy responseCompression = null;
 
   protected static final RedundantExceptionFilter REDUNDANT_LOGGING_FILTER =
@@ -230,7 +230,7 @@ public class VeniceChunkedResponse {
         finish(new StreamingCallbackOnlyFreeResponseOnSuccess<>(((SuccessfulStreamingResponse) msg), promise));
         return true;
       } else if (msg instanceof FullHttpResponse) {
-        if (!responseMetadataWriteInitiated.get()) {
+        if (VeniceChunkedResponse.this.responseCompression == null) {
           // Error response before sending out any data yet
           return false;
         }
@@ -246,7 +246,7 @@ public class VeniceChunkedResponse {
               "Unexpected response status: " + status + ", and only non 200 status is expected here");
         }
       }
-      throw new VeniceException("Unexpected message type received: " + msg.getClass());
+      throw new VeniceException("Unexpected message type received: " + (msg == null ? "null" : msg.getClass()));
     }
   }
 
@@ -274,40 +274,41 @@ public class VeniceChunkedResponse {
       ByteBuf byteBuf,
       CompressionStrategy compression,
       StreamingCallback<Long> callback) {
-    if (this.requestType.equals(RequestType.MULTI_GET_STREAMING)) {
-      if (this.responseCompression == null) {
-        synchronized (this) {
-          if (this.responseCompression == null) {
-            this.responseCompression = compression;
-            this.responseMetadata = RESPONSE_META_MAP_FOR_MULTI_GET.get(compression);
-          }
+    boolean isFirstWrite = false;
+    if (this.responseCompression == null) {
+      synchronized (this) {
+        if (this.responseCompression == null) {
+          this.responseCompression = compression;
+          isFirstWrite = true;
         }
       }
-      if (!this.responseCompression.equals(compression)) {
-        // Defensive code, not expected
-        LOGGER.error(
-            "Received inconsistent compression for the new write: {}, and previous compression: {}",
-            compression,
-            this.responseCompression);
-        /**
-         * Skip the write with wrong compression.
-         * {@link VeniceResponseAggregator#buildStreamingResponse} will perform the same check
-         * when all the responses returned by storage nodes are ready, and when the inconsistency happens,
-         * {@link VeniceResponseAggregator} will return an error response instead to indicate the issue.
-         */
-        return CompletableFuture.completedFuture(0l);
-      }
-    } else {
-      responseMetadata = RESPONSE_META_FOR_COMPUTE;
+    }
+
+    boolean isMultiGet = this.requestType.equals(RequestType.MULTI_GET_STREAMING);
+    if (isMultiGet && !this.responseCompression.equals(compression)) {
+      // Defensive code, not expected
+      LOGGER.error(
+          "Received inconsistent compression for the new write: {}, and previous compression: {}",
+          compression,
+          this.responseCompression);
+      /**
+       * Skip the write with wrong compression.
+       * {@link VeniceResponseAggregator#buildStreamingResponse} will perform the same check
+       * when all the responses returned by storage nodes are ready, and when the inconsistency happens,
+       * {@link VeniceResponseAggregator} will return an error response instead to indicate the issue.
+       */
+      return CompletableFuture.completedFuture(0l);
     }
 
     /**
      * We would like to send out response metadata as late as possible, so that the error happened earlier
      * (such as request parsing error) could still be sent out with the right status code
      */
-    if (responseMetadataWriteInitiated.compareAndSet(false, true)) {
+    if (isFirstWrite) {
       // Send out response metadata
       ChannelPromise writePromise = ctx.newPromise().addListener(new ResponseMetadataWriteListener());
+      HttpResponse responseMetadata =
+          isMultiGet ? RESPONSE_META_MAP_FOR_MULTI_GET.get(compression) : RESPONSE_META_FOR_COMPUTE;
       chunkedWriteHandler.write(ctx, responseMetadata, writePromise);
       /**
        * {@link ChunkedWriteHandler#resumeTransfer()} invocation will try to flush more data to the client since more

--- a/services/venice-router/src/test/java/com/linkedin/venice/router/streaming/VeniceChunkedResponseTest.java
+++ b/services/venice-router/src/test/java/com/linkedin/venice/router/streaming/VeniceChunkedResponseTest.java
@@ -1,0 +1,30 @@
+package com.linkedin.venice.router.streaming;
+
+import static org.mockito.Mockito.mock;
+import static org.testng.Assert.assertThrows;
+
+import com.linkedin.venice.exceptions.VeniceException;
+import com.linkedin.venice.read.RequestType;
+import com.linkedin.venice.router.stats.RouterStats;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPromise;
+import org.testng.annotations.Test;
+
+
+public class VeniceChunkedResponseTest {
+  @Test
+  public void whetherToSkipMessage() {
+    VeniceChunkedWriteHandler chunkedWriteHandler = new VeniceChunkedWriteHandler();
+    /** The {@link VeniceChunkedResponse} is only instantiated so that it registers its callback into the handler */
+    new VeniceChunkedResponse(
+        "storeName",
+        RequestType.MULTI_GET_STREAMING,
+        mock(ChannelHandlerContext.class),
+        chunkedWriteHandler,
+        mock(RouterStats.class));
+    assertThrows(
+        // This used to throw a NPE as part of a previous regression, we want a better error message
+        VeniceException.class,
+        () -> chunkedWriteHandler.write(mock(ChannelHandlerContext.class), null, mock(ChannelPromise.class)));
+  }
+}


### PR DESCRIPTION
This commit fixes a regression introduced in PR #412, where a race condition would result in VeniceChunkedResponse's responseMetadata to be not initialized yet. The field is actually not necessary at all, and its content can be determined the one and only time it's used, rather than stored ahead of time. Also eliminated the responseMetadataWriteInitiated AtomicBoolean, since the responseCompression field being null already has an equivalent meaning. Therefore, VeniceChunkedResponse now carries two fewer properties.