### PR TITLE
[test] Mitigate FC integration tests taking long time in CI

### DIFF
--- a/.github/workflows/gh-ci.yml
+++ b/.github/workflows/gh-ci.yml
@@ -887,6 +887,92 @@ jobs:
           path: ${{ github.job }}-artifacts.tar.gz
           retention-days: 30
 
+  IntegrationTestsR:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        jdk: [11]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          java-version: ${{ matrix.jdk }}
+          distribution: 'microsoft'
+          cache: 'gradle'
+      - shell: bash
+        run: |
+          git remote set-head origin --auto
+          git remote add upstream https://github.com/linkedin/venice
+          git fetch upstream
+      - name: Build with Gradle
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: "--stacktrace --continue --no-daemon -DforkEvery=1 -DmaxParallelForks=1 integrationTestR"
+      - name: Package Build Artifacts
+        if: success() || failure()
+        shell: bash
+        run: |
+          mkdir ${{ github.job }}-artifacts
+          find . -path "**/build/reports/*" -or -path "**/build/test-results/*" > artifacts.list
+          rsync -R --files-from=artifacts.list . ${{ github.job }}-artifacts
+          tar -zcvf ${{ github.job }}-artifacts.tar.gz ${{ github.job }}-artifacts
+      - name: Upload Build Artifacts
+        if: success() || failure()
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ github.job }}
+          path: ${{ github.job }}-artifacts.tar.gz
+          retention-days: 30
+
+  IntegrationTestsS:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        jdk: [11]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          java-version: ${{ matrix.jdk }}
+          distribution: 'microsoft'
+          cache: 'gradle'
+      - shell: bash
+        run: |
+          git remote set-head origin --auto
+          git remote add upstream https://github.com/linkedin/venice
+          git fetch upstream
+      - name: Build with Gradle
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: "--stacktrace --continue --no-daemon -DforkEvery=1 -DmaxParallelForks=1 integrationTestS"
+      - name: Package Build Artifacts
+        if: success() || failure()
+        shell: bash
+        run: |
+          mkdir ${{ github.job }}-artifacts
+          find . -path "**/build/reports/*" -or -path "**/build/test-results/*" > artifacts.list
+          rsync -R --files-from=artifacts.list . ${{ github.job }}-artifacts
+          tar -zcvf ${{ github.job }}-artifacts.tar.gz ${{ github.job }}-artifacts
+      - name: Upload Build Artifacts
+        if: success() || failure()
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ github.job }}
+          path: ${{ github.job }}-artifacts.tar.gz
+          retention-days: 30
+
   IntegrationTestsZ:
     strategy:
       fail-fast: false
@@ -1079,7 +1165,7 @@ jobs:
         os: [ubuntu-latest]
         jdk: [11]
     runs-on: ${{ matrix.os }}
-    needs: [ValidateGradleWrapper, StaticAnalysis, UnitTestsAndCodeCoverage, AvroCompatibilityTests, IntegrationTestsA, IntegrationTestsB, IntegrationTestsC, IntegrationTestsD, IntegrationTestsE, IntegrationTestsF, IntegrationTestsG, IntegrationTestsH, IntegrationTestsI, IntegrationTestsJ, IntegrationTestsK, IntegrationTestsL, IntegrationTestsM, IntegrationTestsN, IntegrationTestsO, IntegrationTestsP, IntegrationTestsQ, IntegrationTestsZ, AlpiniUnitTests, AlpiniFunctionalTests]
+    needs: [ValidateGradleWrapper, StaticAnalysis, UnitTestsAndCodeCoverage, AvroCompatibilityTests, IntegrationTestsA, IntegrationTestsB, IntegrationTestsC, IntegrationTestsD, IntegrationTestsE, IntegrationTestsF, IntegrationTestsG, IntegrationTestsH, IntegrationTestsI, IntegrationTestsJ, IntegrationTestsK, IntegrationTestsL, IntegrationTestsM, IntegrationTestsN, IntegrationTestsO, IntegrationTestsP, IntegrationTestsQ, IntegrationTestsR, IntegrationTestsS, IntegrationTestsZ, AlpiniUnitTests, AlpiniFunctionalTests]
     timeout-minutes: 120
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/gh-ci.yml
+++ b/.github/workflows/gh-ci.yml
@@ -887,49 +887,6 @@ jobs:
           path: ${{ github.job }}-artifacts.tar.gz
           retention-days: 30
 
-  IntegrationTestsR:
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest]
-        jdk: [11]
-    runs-on: ${{ matrix.os }}
-    timeout-minutes: 120
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      - name: Set up JDK
-        uses: actions/setup-java@v3
-        with:
-          java-version: ${{ matrix.jdk }}
-          distribution: 'microsoft'
-          cache: 'gradle'
-      - shell: bash
-        run: |
-          git remote set-head origin --auto
-          git remote add upstream https://github.com/linkedin/venice
-          git fetch upstream
-      - name: Build with Gradle
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: "--stacktrace --continue --no-daemon -DforkEvery=1 -DmaxParallelForks=1 integrationTestR"
-      - name: Package Build Artifacts
-        if: success() || failure()
-        shell: bash
-        run: |
-          mkdir ${{ github.job }}-artifacts
-          find . -path "**/build/reports/*" -or -path "**/build/test-results/*" > artifacts.list
-          rsync -R --files-from=artifacts.list . ${{ github.job }}-artifacts
-          tar -zcvf ${{ github.job }}-artifacts.tar.gz ${{ github.job }}-artifacts
-      - name: Upload Build Artifacts
-        if: success() || failure()
-        uses: actions/upload-artifact@v3
-        with:
-          name: ${{ github.job }}
-          path: ${{ github.job }}-artifacts.tar.gz
-          retention-days: 30
-
   IntegrationTestsZ:
     strategy:
       fail-fast: false
@@ -1122,7 +1079,7 @@ jobs:
         os: [ubuntu-latest]
         jdk: [11]
     runs-on: ${{ matrix.os }}
-    needs: [ValidateGradleWrapper, StaticAnalysis, UnitTestsAndCodeCoverage, AvroCompatibilityTests, IntegrationTestsA, IntegrationTestsB, IntegrationTestsC, IntegrationTestsD, IntegrationTestsE, IntegrationTestsF, IntegrationTestsG, IntegrationTestsH, IntegrationTestsI, IntegrationTestsJ, IntegrationTestsK, IntegrationTestsL, IntegrationTestsM, IntegrationTestsN, IntegrationTestsO, IntegrationTestsP, IntegrationTestsQ, IntegrationTestsR, IntegrationTestsZ, AlpiniUnitTests, AlpiniFunctionalTests]
+    needs: [ValidateGradleWrapper, StaticAnalysis, UnitTestsAndCodeCoverage, AvroCompatibilityTests, IntegrationTestsA, IntegrationTestsB, IntegrationTestsC, IntegrationTestsD, IntegrationTestsE, IntegrationTestsF, IntegrationTestsG, IntegrationTestsH, IntegrationTestsI, IntegrationTestsJ, IntegrationTestsK, IntegrationTestsL, IntegrationTestsM, IntegrationTestsN, IntegrationTestsO, IntegrationTestsP, IntegrationTestsQ, IntegrationTestsZ, AlpiniUnitTests, AlpiniFunctionalTests]
     timeout-minutes: 120
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/gh-ci.yml
+++ b/.github/workflows/gh-ci.yml
@@ -930,49 +930,6 @@ jobs:
           path: ${{ github.job }}-artifacts.tar.gz
           retention-days: 30
 
-  IntegrationTestsS:
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest]
-        jdk: [11]
-    runs-on: ${{ matrix.os }}
-    timeout-minutes: 120
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      - name: Set up JDK
-        uses: actions/setup-java@v3
-        with:
-          java-version: ${{ matrix.jdk }}
-          distribution: 'microsoft'
-          cache: 'gradle'
-      - shell: bash
-        run: |
-          git remote set-head origin --auto
-          git remote add upstream https://github.com/linkedin/venice
-          git fetch upstream
-      - name: Build with Gradle
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: "--stacktrace --continue --no-daemon -DforkEvery=1 -DmaxParallelForks=1 integrationTestS"
-      - name: Package Build Artifacts
-        if: success() || failure()
-        shell: bash
-        run: |
-          mkdir ${{ github.job }}-artifacts
-          find . -path "**/build/reports/*" -or -path "**/build/test-results/*" > artifacts.list
-          rsync -R --files-from=artifacts.list . ${{ github.job }}-artifacts
-          tar -zcvf ${{ github.job }}-artifacts.tar.gz ${{ github.job }}-artifacts
-      - name: Upload Build Artifacts
-        if: success() || failure()
-        uses: actions/upload-artifact@v3
-        with:
-          name: ${{ github.job }}
-          path: ${{ github.job }}-artifacts.tar.gz
-          retention-days: 30
-
   IntegrationTestsZ:
     strategy:
       fail-fast: false
@@ -1165,7 +1122,7 @@ jobs:
         os: [ubuntu-latest]
         jdk: [11]
     runs-on: ${{ matrix.os }}
-    needs: [ValidateGradleWrapper, StaticAnalysis, UnitTestsAndCodeCoverage, AvroCompatibilityTests, IntegrationTestsA, IntegrationTestsB, IntegrationTestsC, IntegrationTestsD, IntegrationTestsE, IntegrationTestsF, IntegrationTestsG, IntegrationTestsH, IntegrationTestsI, IntegrationTestsJ, IntegrationTestsK, IntegrationTestsL, IntegrationTestsM, IntegrationTestsN, IntegrationTestsO, IntegrationTestsP, IntegrationTestsQ, IntegrationTestsR, IntegrationTestsS, IntegrationTestsZ, AlpiniUnitTests, AlpiniFunctionalTests]
+    needs: [ValidateGradleWrapper, StaticAnalysis, UnitTestsAndCodeCoverage, AvroCompatibilityTests, IntegrationTestsA, IntegrationTestsB, IntegrationTestsC, IntegrationTestsD, IntegrationTestsE, IntegrationTestsF, IntegrationTestsG, IntegrationTestsH, IntegrationTestsI, IntegrationTestsJ, IntegrationTestsK, IntegrationTestsL, IntegrationTestsM, IntegrationTestsN, IntegrationTestsO, IntegrationTestsP, IntegrationTestsQ, IntegrationTestsR, IntegrationTestsZ, AlpiniUnitTests, AlpiniFunctionalTests]
     timeout-minutes: 120
     steps:
       - uses: actions/checkout@v3

--- a/internal/venice-test-common/build.gradle
+++ b/internal/venice-test-common/build.gradle
@@ -170,8 +170,7 @@ def integrationTestBuckets = [
   "Q": [
       "com.linkedin.venice.controller.Test*"],
   "R": [
-      "com.linkedin.venice.fastclient.AvroStoreClientGzipEndToEndTest"],
-  "S": [
+      "com.linkedin.venice.fastclient.AvroStoreClientGzipEndToEndTest",
       "com.linkedin.venice.fastclient.AvroStoreClientZstdEndToEndTest"]
 ]
 

--- a/internal/venice-test-common/build.gradle
+++ b/internal/venice-test-common/build.gradle
@@ -139,7 +139,7 @@ def integrationTestBuckets = [
       "com.linkedin.venice.fastclient.meta.*",
       "com.linkedin.venice.endToEnd.TestEmptyPush"],
   "I": [
-      "com.linkedin.venice.fastclient.AvroStore*"],
+      "com.linkedin.venice.fastclient.AvroStoreClientEndToEndTest"],
   "J": [
       "com.linkedin.venice.hadoop.*",
       "com.linkedin.venice.endToEnd.TestVson*",
@@ -168,7 +168,11 @@ def integrationTestBuckets = [
       "com.linkedin.venice.controller.AdminTool*",
       "com.linkedin.venice.controller.VeniceParentHelixAdminTest"],
   "Q": [
-      "com.linkedin.venice.controller.Test*"]
+      "com.linkedin.venice.controller.Test*"],
+  "R": [
+      "com.linkedin.venice.fastclient.AvroStoreClientGzipEndToEndTest"],
+  "S": [
+      "com.linkedin.venice.fastclient.AvroStoreClientZstdEndToEndTest"]
 ]
 
 integrationTestBuckets.each { name, patterns ->

--- a/internal/venice-test-common/build.gradle
+++ b/internal/venice-test-common/build.gradle
@@ -132,7 +132,9 @@ def integrationTestBuckets = [
       "com.linkedin.venice.storagenode.*",
       "com.linkedin.venice.restart.*"],
   "G": [
-      "com.linkedin.venice.router.*"],
+      "com.linkedin.venice.router.*",
+      "com.linkedin.venice.fastclient.AvroStoreClientGzipEndToEndTest",
+      "com.linkedin.venice.fastclient.AvroStoreClientZstdEndToEndTest"],
   "H": [
       "com.linkedin.venice.fastclient.BatchGet*",
       "com.linkedin.venice.fastclient.schema.*",
@@ -168,10 +170,7 @@ def integrationTestBuckets = [
       "com.linkedin.venice.controller.AdminTool*",
       "com.linkedin.venice.controller.VeniceParentHelixAdminTest"],
   "Q": [
-      "com.linkedin.venice.controller.Test*"],
-  "R": [
-      "com.linkedin.venice.fastclient.AvroStoreClientGzipEndToEndTest",
-      "com.linkedin.venice.fastclient.AvroStoreClientZstdEndToEndTest"]
+      "com.linkedin.venice.controller.Test*"]
 ]
 
 integrationTestBuckets.each { name, patterns ->

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/fastclient/AvroStoreClientEndToEndTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/fastclient/AvroStoreClientEndToEndTest.java
@@ -425,7 +425,7 @@ public class AvroStoreClientEndToEndTest extends AbstractClientEndToEndSetup {
         storeMetadataFetchMode);
   }
 
-  @Test(dataProvider = "True-and-False", timeOut = TIME_OUT)
+  @Test(dataProvider = "FastClient-One-Boolean", timeOut = TIME_OUT)
   public void testFastClientWithLongTailRetry(boolean batchGet) throws Exception {
     ClientConfig.ClientConfigBuilder clientConfigBuilder =
         new ClientConfig.ClientConfigBuilder<>().setStoreName(storeName).setR2Client(r2Client);

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/fastclient/AvroStoreClientEndToEndTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/fastclient/AvroStoreClientEndToEndTest.java
@@ -13,12 +13,14 @@ import com.linkedin.venice.fastclient.schema.TestValueSchema;
 import com.linkedin.venice.fastclient.utils.AbstractClientEndToEndSetup;
 import com.linkedin.venice.fastclient.utils.ClientTestUtils;
 import com.linkedin.venice.integration.utils.VeniceServerWrapper;
+import com.linkedin.venice.utils.TestUtils;
 import io.tehuti.metrics.MetricsRepository;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import org.apache.avro.generic.GenericRecord;
 import org.testng.Assert;
@@ -265,11 +267,14 @@ public class AvroStoreClientEndToEndTest extends AbstractClientEndToEndSetup {
         clientConfigBuilder.setSpecificThinClient(specificThinClient);
         genericVsonThinClient = getGenericVsonThinClient();
         thinClientStatsValidation = metricsRepository -> {
-          Assert.assertTrue(
-              metricsRepository.metrics()
-                  .get("." + storeName + (batchGet ? "--multiget_streaming_" : "--") + "request_key_count.Rate")
-                  .value() > 0,
-              "Dual read metrics should be incremented when dual read is enabled");
+          TestUtils.waitForNonDeterministicAssertion(
+              10,
+              TimeUnit.SECONDS,
+              () -> Assert.assertTrue(
+                  metricsRepository.metrics()
+                      .get("." + storeName + (batchGet ? "--multiget_streaming_" : "--") + "request_key_count.Rate")
+                      .value() > 0,
+                  "Thin client metrics should be incremented when dual read is enabled"));
         };
       } else {
         thinClientStatsValidation = metricsRepository -> {
@@ -282,22 +287,26 @@ public class AvroStoreClientEndToEndTest extends AbstractClientEndToEndSetup {
       }
 
       Consumer<MetricsRepository> fastClientStatsValidation = metricsRepository -> {
-        assertTrue(
-            metricsRepository.metrics()
-                .get(
-                    "." + storeName + (useStreamingBatchGetAsDefault ? "--multiget_" : "--") + "request_key_count.Rate")
-                .value() > 0,
-            "Respective request_key_count should have been incremented");
-        Assert.assertFalse(
-            metricsRepository.metrics()
-                .get(
-                    "." + storeName + (useStreamingBatchGetAsDefault ? "--" : "--multiget_") + "request_key_count.Rate")
-                .value() > 0,
-            "Incorrect request_key_count should not be incremented");
-        metricsRepository.metrics().forEach((mName, metric) -> {
-          if (mName.contains("long_tail_retry_request")) {
-            assertTrue(metric.value() == 0, "Long tail retry should not be triggered");
-          }
+        TestUtils.waitForNonDeterministicAssertion(10, TimeUnit.SECONDS, () -> {
+          assertTrue(
+              metricsRepository.metrics()
+                  .get(
+                      "." + storeName + (useStreamingBatchGetAsDefault ? "--multiget_" : "--")
+                          + "request_key_count.Rate")
+                  .value() > 0,
+              "Respective request_key_count should have been incremented");
+          Assert.assertFalse(
+              metricsRepository.metrics()
+                  .get(
+                      "." + storeName + (useStreamingBatchGetAsDefault ? "--" : "--multiget_")
+                          + "request_key_count.Rate")
+                  .value() > 0,
+              "Incorrect request_key_count should not be incremented");
+          metricsRepository.metrics().forEach((mName, metric) -> {
+            if (mName.contains("long_tail_retry_request")) {
+              assertTrue(metric.value() == 0, "Long tail retry should not be triggered");
+            }
+          });
         });
       };
 
@@ -416,9 +425,8 @@ public class AvroStoreClientEndToEndTest extends AbstractClientEndToEndSetup {
         storeMetadataFetchMode);
   }
 
-  @Test(dataProvider = "FastClient-One-Boolean-Store-Metadata-Fetch-Mode", timeOut = TIME_OUT)
-  public void testFastClientWithLongTailRetry(boolean batchGet, StoreMetadataFetchMode storeMetadataFetchMode)
-      throws Exception {
+  @Test(dataProvider = "True-and-False", timeOut = TIME_OUT)
+  public void testFastClientWithLongTailRetry(boolean batchGet) throws Exception {
     ClientConfig.ClientConfigBuilder clientConfigBuilder =
         new ClientConfig.ClientConfigBuilder<>().setStoreName(storeName).setR2Client(r2Client);
 
@@ -458,6 +466,6 @@ public class AvroStoreClientEndToEndTest extends AbstractClientEndToEndSetup {
         m -> {},
         null,
         Optional.empty(),
-        storeMetadataFetchMode);
+        StoreMetadataFetchMode.SERVER_BASED_METADATA);
   }
 }

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/fastclient/AvroStoreClientGzipEndToEndTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/fastclient/AvroStoreClientGzipEndToEndTest.java
@@ -1,17 +1,80 @@
 package com.linkedin.venice.fastclient;
 
+import static com.linkedin.venice.fastclient.utils.ClientTestUtils.STORE_METADATA_FETCH_MODES;
+
 import com.linkedin.venice.compression.CompressionStrategy;
+import com.linkedin.venice.fastclient.meta.StoreMetadataFetchMode;
 import com.linkedin.venice.helix.HelixReadOnlySchemaRepository;
 import com.linkedin.venice.serialization.avro.VeniceAvroKafkaSerializer;
+import com.linkedin.venice.utils.DataProviderUtils;
 import java.util.AbstractMap;
 import java.util.Map;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
+import org.testng.annotations.DataProvider;
 
 
 public class AvroStoreClientGzipEndToEndTest extends AvroStoreClientEndToEndTest {
+  @Override
+  @DataProvider(name = "FastClient-Four-Boolean-A-Number-Store-Metadata-Fetch-Mode")
+  public Object[][] fourBooleanANumberStoreMetadataFetchMode() {
+    return DataProviderUtils.allPermutationGenerator((permutation) -> {
+      boolean batchGet = (boolean) permutation[2];
+      boolean useStreamingBatchGetAsDefault = (boolean) permutation[3];
+      int batchGetKeySize = (int) permutation[4];
+      StoreMetadataFetchMode storeMetadataFetchMode = (StoreMetadataFetchMode) permutation[5];
+      if (!batchGet) {
+        if (useStreamingBatchGetAsDefault || batchGetKeySize != (int) BATCH_GET_KEY_SIZE.get(0)) {
+          // these parameters are related only to batchGet, so just allowing 1 set
+          // to avoid duplicate tests
+          return false;
+        }
+      }
+      if (storeMetadataFetchMode == StoreMetadataFetchMode.DA_VINCI_CLIENT_BASED_METADATA) {
+        return false;
+      }
+      return true;
+    },
+        DataProviderUtils.BOOLEAN_FALSE, // dualRead
+        DataProviderUtils.BOOLEAN_FALSE, // speculativeQueryEnabled
+        DataProviderUtils.BOOLEAN, // batchGet
+        DataProviderUtils.BOOLEAN_TRUE, // useStreamingBatchGetAsDefault
+        BATCH_GET_KEY_SIZE.toArray(), // batchGetKeySize
+        STORE_METADATA_FETCH_MODES); // storeMetadataFetchMode
+  }
+
+  @Override
+  @DataProvider(name = "FastClient-Three-Boolean-And-A-Number")
+  public Object[][] threeBooleanAndANumber() {
+    return DataProviderUtils.allPermutationGenerator((permutation) -> {
+      boolean batchGet = (boolean) permutation[0];
+      int batchGetKeySize = (int) permutation[3];
+      if (!batchGet) {
+        if (batchGetKeySize != (int) BATCH_GET_KEY_SIZE.get(0)) {
+          // these parameters are related only to batchGet, so just allowing 1 set
+          // to avoid duplicate tests
+          return false;
+        }
+      }
+      return true;
+    },
+        DataProviderUtils.BOOLEAN, // batchGet
+        DataProviderUtils.BOOLEAN_FALSE, // dualRead
+        DataProviderUtils.BOOLEAN_FALSE, // speculativeQueryEnabled
+        BATCH_GET_KEY_SIZE.toArray());
+  }
+
+  /** the below tests are used for long tail retry cases which are flaky, so disabling them
+   * for this class */
+  @Override
+  @DataProvider(name = "FastClient-One-Boolean-Store-Metadata-Fetch-Mode")
+  public Object[][] oneBooleanStoreMetadataFetchMode() {
+    return DataProviderUtils
+        .allPermutationGenerator((permutation) -> false, DataProviderUtils.BOOLEAN, STORE_METADATA_FETCH_MODES);
+  }
+
   @Override
   protected void prepareData() throws Exception {
     keySerializer = new VeniceAvroKafkaSerializer(KEY_SCHEMA_STR);

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/fastclient/AvroStoreClientGzipEndToEndTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/fastclient/AvroStoreClientGzipEndToEndTest.java
@@ -66,13 +66,12 @@ public class AvroStoreClientGzipEndToEndTest extends AvroStoreClientEndToEndTest
         BATCH_GET_KEY_SIZE.toArray());
   }
 
-  /** the below tests are used for long tail retry cases which are flaky, so disabling them
-   * for this class */
+  /** the below tests are used for long tail retry cases which are flaky,
+   * so disabling them for this class */
   @Override
-  @DataProvider(name = "FastClient-One-Boolean-Store-Metadata-Fetch-Mode")
-  public Object[][] oneBooleanStoreMetadataFetchMode() {
-    return DataProviderUtils
-        .allPermutationGenerator((permutation) -> false, DataProviderUtils.BOOLEAN, STORE_METADATA_FETCH_MODES);
+  @DataProvider(name = "FastClient-One-Boolean")
+  public Object[][] oneBoolean() {
+    return DataProviderUtils.allPermutationGenerator((permutation) -> false, DataProviderUtils.BOOLEAN);
   }
 
   @Override

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/fastclient/AvroStoreClientZstdEndToEndTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/fastclient/AvroStoreClientZstdEndToEndTest.java
@@ -70,13 +70,12 @@ public class AvroStoreClientZstdEndToEndTest extends AvroStoreClientEndToEndTest
         BATCH_GET_KEY_SIZE.toArray());
   }
 
-  /** the below tests are used for long tail retry cases which are flaky, so disabling them
-   * for this class */
+  /** the below tests are used for long tail retry cases which are flaky,
+   * so disabling them for this class */
   @Override
-  @DataProvider(name = "FastClient-One-Boolean-Store-Metadata-Fetch-Mode")
-  public Object[][] oneBooleanStoreMetadataFetchMode() {
-    return DataProviderUtils
-        .allPermutationGenerator((permutation) -> false, DataProviderUtils.BOOLEAN, STORE_METADATA_FETCH_MODES);
+  @DataProvider(name = "FastClient-One-Boolean")
+  public Object[][] oneBoolean() {
+    return DataProviderUtils.allPermutationGenerator((permutation) -> false, DataProviderUtils.BOOLEAN);
   }
 
   @Override

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/fastclient/AvroStoreClientZstdEndToEndTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/fastclient/AvroStoreClientZstdEndToEndTest.java
@@ -1,12 +1,15 @@
 package com.linkedin.venice.fastclient;
 
+import static com.linkedin.venice.fastclient.utils.ClientTestUtils.STORE_METADATA_FETCH_MODES;
 import static com.linkedin.venice.utils.ByteUtils.BYTES_PER_KB;
 import static com.linkedin.venice.utils.ByteUtils.BYTES_PER_MB;
 
 import com.github.luben.zstd.ZstdDictTrainer;
 import com.linkedin.venice.compression.CompressionStrategy;
+import com.linkedin.venice.fastclient.meta.StoreMetadataFetchMode;
 import com.linkedin.venice.helix.HelixReadOnlySchemaRepository;
 import com.linkedin.venice.serialization.avro.VeniceAvroKafkaSerializer;
+import com.linkedin.venice.utils.DataProviderUtils;
 import java.nio.ByteBuffer;
 import java.util.AbstractMap;
 import java.util.Map;
@@ -14,9 +17,68 @@ import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
+import org.testng.annotations.DataProvider;
 
 
 public class AvroStoreClientZstdEndToEndTest extends AvroStoreClientEndToEndTest {
+  @Override
+  @DataProvider(name = "FastClient-Four-Boolean-A-Number-Store-Metadata-Fetch-Mode")
+  public Object[][] fourBooleanANumberStoreMetadataFetchMode() {
+    return DataProviderUtils.allPermutationGenerator((permutation) -> {
+      boolean batchGet = (boolean) permutation[2];
+      boolean useStreamingBatchGetAsDefault = (boolean) permutation[3];
+      int batchGetKeySize = (int) permutation[4];
+      StoreMetadataFetchMode storeMetadataFetchMode = (StoreMetadataFetchMode) permutation[5];
+      if (!batchGet) {
+        if (useStreamingBatchGetAsDefault || batchGetKeySize != (int) BATCH_GET_KEY_SIZE.get(0)) {
+          // these parameters are related only to batchGet, so just allowing 1 set
+          // to avoid duplicate tests
+          return false;
+        }
+      }
+      if (storeMetadataFetchMode == StoreMetadataFetchMode.DA_VINCI_CLIENT_BASED_METADATA) {
+        return false;
+      }
+      return true;
+    },
+        DataProviderUtils.BOOLEAN_FALSE, // dualRead
+        DataProviderUtils.BOOLEAN_FALSE, // speculativeQueryEnabled
+        DataProviderUtils.BOOLEAN, // batchGet
+        DataProviderUtils.BOOLEAN_TRUE, // useStreamingBatchGetAsDefault
+        BATCH_GET_KEY_SIZE.toArray(), // batchGetKeySize
+        STORE_METADATA_FETCH_MODES); // storeMetadataFetchMode
+  }
+
+  @Override
+  @DataProvider(name = "FastClient-Three-Boolean-And-A-Number")
+  public Object[][] threeBooleanAndANumber() {
+    return DataProviderUtils.allPermutationGenerator((permutation) -> {
+      boolean batchGet = (boolean) permutation[0];
+      int batchGetKeySize = (int) permutation[3];
+      if (!batchGet) {
+        if (batchGetKeySize != (int) BATCH_GET_KEY_SIZE.get(0)) {
+          // these parameters are related only to batchGet, so just allowing 1 set
+          // to avoid duplicate tests
+          return false;
+        }
+      }
+      return true;
+    },
+        DataProviderUtils.BOOLEAN, // batchGet
+        DataProviderUtils.BOOLEAN_FALSE, // dualRead
+        DataProviderUtils.BOOLEAN_FALSE, // speculativeQueryEnabled
+        BATCH_GET_KEY_SIZE.toArray());
+  }
+
+  /** the below tests are used for long tail retry cases which are flaky, so disabling them
+   * for this class */
+  @Override
+  @DataProvider(name = "FastClient-One-Boolean-Store-Metadata-Fetch-Mode")
+  public Object[][] oneBooleanStoreMetadataFetchMode() {
+    return DataProviderUtils
+        .allPermutationGenerator((permutation) -> false, DataProviderUtils.BOOLEAN, STORE_METADATA_FETCH_MODES);
+  }
+
   @Override
   protected void prepareData() throws Exception {
     keySerializer = new VeniceAvroKafkaSerializer(KEY_SCHEMA_STR);

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/fastclient/BatchGetAvroStoreClientTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/fastclient/BatchGetAvroStoreClientTest.java
@@ -112,7 +112,7 @@ public class BatchGetAvroStoreClientTest extends AbstractClientEndToEndSetup {
   /**
    * Creates a batchget request which uses scatter gather to fetch all keys from different replicas.
    */
-  @Test(dataProvider = "FastClient-One-Boolean-Store-Metadata-Fetch-Mode")
+  @Test(dataProvider = "FastClient-One-Boolean-Store-Metadata-Fetch-Mode", timeOut = TIME_OUT)
   public void testBatchGetGenericClient(
       boolean useStreamingBatchGetAsDefault,
       StoreMetadataFetchMode storeMetadataFetchMode) throws Exception {
@@ -163,7 +163,7 @@ public class BatchGetAvroStoreClientTest extends AbstractClientEndToEndSetup {
     printAllStats();
   }
 
-  @Test(dataProvider = "FastClient-One-Boolean-Store-Metadata-Fetch-Mode")
+  @Test(dataProvider = "FastClient-One-Boolean-Store-Metadata-Fetch-Mode", timeOut = TIME_OUT)
   public void testBatchGetSpecificClient(
       boolean useStreamingBatchGetAsDefault,
       StoreMetadataFetchMode storeMetadataFetchMode) throws Exception {
@@ -212,7 +212,7 @@ public class BatchGetAvroStoreClientTest extends AbstractClientEndToEndSetup {
     printAllStats();
   }
 
-  @Test(dataProvider = "StoreMetadataFetchModes")
+  @Test(dataProvider = "StoreMetadataFetchModes", timeOut = TIME_OUT)
   public void testStreamingBatchGetGenericClient(StoreMetadataFetchMode storeMetadataFetchMode) throws Exception {
     ClientConfig.ClientConfigBuilder clientConfigBuilder =
         new ClientConfig.ClientConfigBuilder<>().setStoreName(storeName)
@@ -266,7 +266,7 @@ public class BatchGetAvroStoreClientTest extends AbstractClientEndToEndSetup {
         "Incorrect request_key_count should not be incremented");
   }
 
-  @Test(dataProvider = "StoreMetadataFetchModes")
+  @Test(dataProvider = "StoreMetadataFetchModes", timeOut = TIME_OUT)
   public void testStreamingBatchGetWithCallbackGenericClient(StoreMetadataFetchMode storeMetadataFetchMode)
       throws Exception {
     ClientConfig.ClientConfigBuilder clientConfigBuilder =

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/fastclient/FastClientServerReadQuotaTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/fastclient/FastClientServerReadQuotaTest.java
@@ -15,7 +15,7 @@ import org.testng.annotations.Test;
 
 
 public class FastClientServerReadQuotaTest extends AbstractClientEndToEndSetup {
-  @Test
+  @Test(timeOut = TIME_OUT)
   public void testServerReadQuota() throws Exception {
     ClientConfig.ClientConfigBuilder clientConfigBuilder =
         new ClientConfig.ClientConfigBuilder<>().setStoreName(storeName)

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/fastclient/utils/AbstractClientEndToEndSetup.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/fastclient/utils/AbstractClientEndToEndSetup.java
@@ -16,6 +16,7 @@ import static com.linkedin.venice.system.store.MetaStoreWriter.KEY_STRING_VERSIO
 import static org.testng.Assert.assertFalse;
 import static org.testng.AssertJUnit.assertNotNull;
 
+import com.google.common.collect.ImmutableList;
 import com.linkedin.d2.balancer.D2Client;
 import com.linkedin.davinci.client.DaVinciClient;
 import com.linkedin.davinci.client.DaVinciConfig;
@@ -116,7 +117,7 @@ public abstract class AbstractClientEndToEndSetup {
    * not be sent due to blocked instances. Setting this variable to be 100 from the tests for now.
    * This needs to be discussed further.
    */
-  static final Object[] BATCH_GET_KEY_SIZE = { 2, recordCnt };
+  protected static final ImmutableList<Object> BATCH_GET_KEY_SIZE = ImmutableList.of(2, recordCnt);
 
   @DataProvider(name = "FastClient-Four-Boolean-A-Number-Store-Metadata-Fetch-Mode")
   public Object[][] fourBooleanANumberStoreMetadataFetchMode() {
@@ -125,7 +126,7 @@ public abstract class AbstractClientEndToEndSetup {
       boolean useStreamingBatchGetAsDefault = (boolean) permutation[3];
       int batchGetKeySize = (int) permutation[4];
       if (!batchGet) {
-        if (useStreamingBatchGetAsDefault || batchGetKeySize != (int) BATCH_GET_KEY_SIZE[0]) {
+        if (useStreamingBatchGetAsDefault || batchGetKeySize != (int) BATCH_GET_KEY_SIZE.get(0)) {
           // these parameters are related only to batchGet, so just allowing 1 set
           // to avoid duplicate tests
           return false;
@@ -137,7 +138,7 @@ public abstract class AbstractClientEndToEndSetup {
         DataProviderUtils.BOOLEAN, // speculativeQueryEnabled
         DataProviderUtils.BOOLEAN, // batchGet
         DataProviderUtils.BOOLEAN, // useStreamingBatchGetAsDefault
-        BATCH_GET_KEY_SIZE, // batchGetKeySize
+        BATCH_GET_KEY_SIZE.toArray(), // batchGetKeySize
         STORE_METADATA_FETCH_MODES); // storeMetadataFetchMode
   }
 
@@ -167,11 +168,22 @@ public abstract class AbstractClientEndToEndSetup {
 
   @DataProvider(name = "FastClient-Three-Boolean-And-A-Number")
   public Object[][] threeBooleanAndANumber() {
-    return DataProviderUtils.allPermutationGenerator(
-        DataProviderUtils.BOOLEAN,
-        DataProviderUtils.BOOLEAN,
-        DataProviderUtils.BOOLEAN,
-        BATCH_GET_KEY_SIZE);
+    return DataProviderUtils.allPermutationGenerator((permutation) -> {
+      boolean batchGet = (boolean) permutation[0];
+      int batchGetKeySize = (int) permutation[3];
+      if (!batchGet) {
+        if (batchGetKeySize != (int) BATCH_GET_KEY_SIZE.get(0)) {
+          // these parameters are related only to batchGet, so just allowing 1 set
+          // to avoid duplicate tests
+          return false;
+        }
+      }
+      return true;
+    },
+        DataProviderUtils.BOOLEAN, // batchGet
+        DataProviderUtils.BOOLEAN, // dualRead
+        DataProviderUtils.BOOLEAN, // speculativeQueryEnabled
+        BATCH_GET_KEY_SIZE.toArray());
   }
 
   @DataProvider(name = "fastClientHTTPVariantsAndStoreMetadataFetchModes")

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/fastclient/utils/AbstractClientEndToEndSetup.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/fastclient/utils/AbstractClientEndToEndSetup.java
@@ -186,6 +186,11 @@ public abstract class AbstractClientEndToEndSetup {
         BATCH_GET_KEY_SIZE.toArray());
   }
 
+  @DataProvider(name = "FastClient-One-Boolean")
+  public Object[][] oneBoolean() {
+    return DataProviderUtils.allPermutationGenerator(DataProviderUtils.BOOLEAN);
+  }
+
   @DataProvider(name = "fastClientHTTPVariantsAndStoreMetadataFetchModes")
   public static Object[][] httpVariantsAndStoreMetadataFetchModes() {
     return DataProviderUtils.allPermutationGenerator(FASTCLIENT_HTTP_VARIANTS, STORE_METADATA_FETCH_MODES);

--- a/internal/venice-test-common/src/main/java/com/linkedin/venice/utils/DataProviderUtils.java
+++ b/internal/venice-test-common/src/main/java/com/linkedin/venice/utils/DataProviderUtils.java
@@ -22,6 +22,8 @@ import org.testng.collections.Lists;
  */
 public class DataProviderUtils {
   public static final Object[] BOOLEAN = { false, true };
+  public static final Object[] BOOLEAN_FALSE = { false };
+  public static final Object[] BOOLEAN_TRUE = { true };
   public static final Object[] COMPRESSION_STRATEGIES = { NO_OP, GZIP, ZSTD_WITH_DICT };
   public static final Object[] PARTITION_COUNTS = { 1, 2, 3, 4, 8, 10, 16, 19, 92, 128 };
 


### PR DESCRIPTION
## Summary
1. Moved `AvroStoreClientGzipEndToEndTest` and `AvroStoreClientZstdEndToEndTest` to `IntegrationTestsG` as it was taking too much time in `IntegrationTestsI`
2. Trimmed down the number of tests run for the above classes
3. Trimmed down the number of tests in `testFastClientWithLongTailRetry` which needs to be fixed further as its flaky, will handle it as a separate task, as these issues are blocking other PRs to be merged due to test failures.
4. Added timeouts for all tests

These tests will be be cleaned up further:
1. once we validate `SERVER_BASED_METADATA`, we will probably remove the cases with `DA_VINCI_CLIENT_BASED_METADATA` and `THIN_CLIENT_BASED_METADATA`
2. once `useStreamingBatchGetAsDefault` is validated, the code and tests for single get based batch get will be removed

## How was this PR tested?
GH CI

## Does this PR introduce any user-facing changes?
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.