### PR TITLE
[Server] Increase default worker threads for admin tasks to avoid starvation

### DIFF
--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerConfig.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerConfig.java
@@ -329,7 +329,8 @@ public class VeniceControllerConfig extends VeniceControllerClusterConfig {
     this.adminConsumptionTimeoutMinute = props.getLong(ADMIN_CONSUMPTION_TIMEOUT_MINUTES, TimeUnit.DAYS.toMinutes(5));
     this.adminConsumptionCycleTimeoutMs =
         props.getLong(ADMIN_CONSUMPTION_CYCLE_TIMEOUT_MS, TimeUnit.MINUTES.toMillis(30));
-    this.adminConsumptionMaxWorkerThreadPoolSize = props.getInt(ADMIN_CONSUMPTION_MAX_WORKER_THREAD_POOL_SIZE, 1);
+    // A value of one will result in a bad message for one store to block the consumption of all stores.
+    this.adminConsumptionMaxWorkerThreadPoolSize = props.getInt(ADMIN_CONSUMPTION_MAX_WORKER_THREAD_POOL_SIZE, 3);
     this.storageEngineOverheadRatio = props.getDouble(STORAGE_ENGINE_OVERHEAD_RATIO, 0.85d);
 
     // The default retention will allow Kafka remove as much data as possible.

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerConfig.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerConfig.java
@@ -329,8 +329,9 @@ public class VeniceControllerConfig extends VeniceControllerClusterConfig {
     this.adminConsumptionTimeoutMinute = props.getLong(ADMIN_CONSUMPTION_TIMEOUT_MINUTES, TimeUnit.DAYS.toMinutes(5));
     this.adminConsumptionCycleTimeoutMs =
         props.getLong(ADMIN_CONSUMPTION_CYCLE_TIMEOUT_MS, TimeUnit.MINUTES.toMillis(30));
-    // A value of one will result in a bad message for one store to block the consumption of all stores.
-    this.adminConsumptionMaxWorkerThreadPoolSize = props.getInt(ADMIN_CONSUMPTION_MAX_WORKER_THREAD_POOL_SIZE, 3);
+    // A value of one will result in a bad message for one store to block the admin message consumption of other stores.
+    // Consider changing the config to > 1
+    this.adminConsumptionMaxWorkerThreadPoolSize = props.getInt(ADMIN_CONSUMPTION_MAX_WORKER_THREAD_POOL_SIZE, 1);
     this.storageEngineOverheadRatio = props.getDouble(STORAGE_ENGINE_OVERHEAD_RATIO, 0.85d);
 
     // The default retention will allow Kafka remove as much data as possible.

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/kafka/consumer/AdminConsumptionTask.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/kafka/consumer/AdminConsumptionTask.java
@@ -64,6 +64,10 @@ import org.apache.logging.log4j.Logger;
  * This class is used to create a task, which will consume the admin messages from the special admin topics.
  */
 public class AdminConsumptionTask implements Runnable, Closeable {
+  // Setting this to a value so that admin queue will not go out of memory in case of too many admin messages.
+  // If we hit this number , there is most likely something seriously wrong with the system.
+  private static final int MAX_WORKER_QUEUE_SIZE = 10000;
+
   private static class AdminErrorInfo {
     long offset;
     Exception exception;
@@ -280,7 +284,7 @@ public class AdminConsumptionTask implements Runnable, Closeable {
         maxWorkerThreadPoolSize,
         60,
         TimeUnit.SECONDS,
-        new LinkedBlockingQueue<>(),
+        new LinkedBlockingQueue<>(MAX_WORKER_QUEUE_SIZE),
         new DaemonThreadFactory("Venice-Admin-Execution-Task"));
     this.undelegatedRecords = new LinkedList<>();
     this.stats.setAdminConsumptionFailedOffset(failingOffset);

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/kafka/consumer/AdminConsumptionTask.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/kafka/consumer/AdminConsumptionTask.java
@@ -274,8 +274,9 @@ public class AdminConsumptionTask implements Runnable, Closeable {
 
     this.storeAdminOperationsMapWithOffset = new ConcurrentHashMap<>();
     this.problematicStores = new ConcurrentHashMap<>();
+    // since we use an unbounded queue the core pool size is really the max pool size
     this.executorService = new ThreadPoolExecutor(
-        1,
+        maxWorkerThreadPoolSize,
         maxWorkerThreadPoolSize,
         60,
         TimeUnit.SECONDS,

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/kafka/consumer/AdminConsumptionTaskTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/kafka/consumer/AdminConsumptionTaskTest.java
@@ -1440,7 +1440,7 @@ public class AdminConsumptionTaskTest {
   @Test(expectedExceptions = VeniceException.class, expectedExceptionsMessageRegExp = "Admin topic remote consumption is enabled but no config found for the source Kafka bootstrap server url")
   public void testRemoteConsumptionEnabledButRemoteBootstrapUrlsAreMissing() {
     AdminConsumptionStats stats = mock(AdminConsumptionStats.class);
-    getAdminConsumptionTask(new RandomPollStrategy(), true, stats, 0, true, null, 1);
+    getAdminConsumptionTask(new RandomPollStrategy(), true, stats, 0, true, null, 3);
   }
 
   @Test
@@ -1448,13 +1448,13 @@ public class AdminConsumptionTaskTest {
     AdminConsumptionStats stats = mock(AdminConsumptionStats.class);
     TopicManager topicManager = mock(TopicManager.class);
     doReturn(topicManager).when(admin).getTopicManager("remote.pubsub");
-    AdminConsumptionTask task = getAdminConsumptionTask(null, true, stats, 0, true, "remote.pubsub", 1);
+    AdminConsumptionTask task = getAdminConsumptionTask(null, true, stats, 0, true, "remote.pubsub", 3);
     Assert.assertEquals(task.getSourceKafkaClusterTopicManager(), topicManager);
   }
 
   @Test(timeOut = TIMEOUT)
   public void testLongRunningBadTask() throws Exception {
-    // This test will fail when the number of threads is 1.
+    // This test will fail when the AdminConsumptionTask maxWorkerThreadPoolSize is 1
     String storeName1 = "test_store1";
     String storeName2 = "test_store2";
     String storeTopicName1 = storeName1 + "_v1";
@@ -1497,7 +1497,7 @@ public class AdminConsumptionTaskTest {
 
     executor.submit(task);
 
-    // This will fail if the number of threads is 1
+    // Make sure that the "good" store tasks make progress while the "bad" store task is stuck
     TestUtils.waitForNonDeterministicAssertion(
         TIMEOUT,
         TimeUnit.MILLISECONDS,


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

[Server] When processing per-store Admin messages, the default threadpool size of 1 would result in one bad admin message
to cause timeouts for other stores admin operations. In effect breaking the isolation of stores.
Added test to demonstrate this effect. Changed default thread pool size to 3 to prevent this situation
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
Added unit tests

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.