### PR TITLE
[vpj] Fail pushjobs running over 24 hr bootstrap limit

### DIFF
--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
@@ -2593,7 +2593,7 @@ public class VenicePushJob implements AutoCloseable {
    * If any datacenter report an explicit error status, we throw an exception and fail the job. However, datacenters
    * with COMPLETED status will be serving new data.
    */
-  private void pollStatusUntilComplete(
+  void pollStatusUntilComplete(
       Optional<String> incrementalPushVersion,
       ControllerClient controllerClient,
       PushJobSetting pushJobSetting,

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
@@ -2676,11 +2676,11 @@ public class VenicePushJob implements AutoCloseable {
         return;
       }
       long bootstrapToOnlineTimeoutInHours = storeSetting.storeResponse.getStore().getBootstrapToOnlineTimeoutInHours();
-      long durationInHr = TimeUnit.MILLISECONDS.toHours(System.currentTimeMillis() - pollStartTimeMs);
-      if (durationInHr > bootstrapToOnlineTimeoutInHours) {
+      long durationMs = System.currentTimeMillis() - pollStartTimeMs;
+      if (durationMs > TimeUnit.HOURS.toMillis(bootstrapToOnlineTimeoutInHours)) {
         throw new VeniceException(
             "Failing push-job for store " + storeSetting.storeResponse.getName() + " which is still running after "
-                + durationInHr + " hours.");
+                + TimeUnit.MILLISECONDS.toHours(durationMs) + " hours.");
       }
       if (!overallStatus.equals(ExecutionStatus.UNKNOWN)) {
         unknownStateStartTimeMs = 0;

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/VenicePushJobTest.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/VenicePushJobTest.java
@@ -154,7 +154,7 @@ public class VenicePushJobTest {
     ControllerClient client = mock(ControllerClient.class);
     JobStatusQueryResponse response = mock(JobStatusQueryResponse.class);
     doReturn("UNKNOWN").when(response).getStatus();
-    doReturn(response).when(client).queryOverallJobStatus(anyString(), eq(Optional.empty()));
+    doReturn(response).when(client).queryOverallJobStatus(anyString(), eq(Optional.empty()), eq(null));
     VenicePushJob pushJob = getSpyVenicePushJob(vpjProps, client);
     VenicePushJob.PushJobSetting pushJobSetting = pushJob.getPushJobSetting();
     pushJobSetting.jobStatusInUnknownStateTimeoutMs = 10;

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/VenicePushJobTest.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/VenicePushJobTest.java
@@ -22,6 +22,7 @@ import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doNothing;
+>>>>>>> eb14ad121 (added unit test)
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -48,8 +49,12 @@ import com.linkedin.venice.pushmonitor.ExecutionStatus;
 import com.linkedin.venice.utils.TestWriteUtils;
 import com.linkedin.venice.utils.VeniceProperties;
 import java.util.Collections;
+<<<<<<< HEAD
 import java.util.HashMap;
 import java.util.Map;
+=======
+import java.util.Optional;
+>>>>>>> eb14ad121 (added unit test)
 import java.util.Properties;
 import java.util.Set;
 import java.util.function.Consumer;
@@ -148,6 +153,31 @@ public class VenicePushJobTest {
     VenicePushJob pushJob = getSpyVenicePushJob(vpjProps, client);
     VenicePushJob.PushJobSetting pushJobSetting = pushJob.getPushJobSetting();
     Assert.assertTrue(pushJobSetting.livenessHeartbeatEnabled);
+  }
+
+  @Test
+  public void testPushJobPollStatus() {
+    Properties vpjProps = new Properties();
+    vpjProps.setProperty(HEARTBEAT_ENABLED_CONFIG.getConfigName(), "true");
+    ControllerClient client = mock(ControllerClient.class);
+    JobStatusQueryResponse response = mock(JobStatusQueryResponse.class);
+    doReturn("UNKNOWN").when(response).getStatus();
+    doReturn(response).when(client).queryOverallJobStatus(anyString(), eq(Optional.empty()));
+    VenicePushJob pushJob = getSpyVenicePushJob(vpjProps, client);
+    VenicePushJob.PushJobSetting pushJobSetting = pushJob.getPushJobSetting();
+    pushJobSetting.jobStatusInUnknownStateTimeoutMs = 10;
+    Assert.assertTrue(pushJobSetting.livenessHeartbeatEnabled);
+    VenicePushJob.TopicInfo topicInfo = new VenicePushJob.TopicInfo();
+    topicInfo.version = 1;
+    topicInfo.topic = "abc";
+    pushJob.storeSetting = new VenicePushJob.StoreSetting();
+    pushJob.storeSetting.storeResponse = new StoreResponse();
+    StoreInfo storeInfo = new StoreInfo();
+    storeInfo.setBootstrapToOnlineTimeoutInHours(1);
+    pushJob.storeSetting.storeResponse.setStore(storeInfo);
+    Assert.expectThrows(
+        VeniceException.class,
+        () -> pushJob.pollStatusUntilComplete(Optional.empty(), client, pushJobSetting, topicInfo));
   }
 
   private Properties getRepushReadyProps() {

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/VenicePushJobTest.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/VenicePushJobTest.java
@@ -16,7 +16,12 @@ import static com.linkedin.venice.hadoop.VenicePushJob.VALUE_FIELD_PROP;
 import static com.linkedin.venice.hadoop.VenicePushJob.VENICE_DISCOVER_URL_PROP;
 import static com.linkedin.venice.hadoop.VenicePushJob.VENICE_STORE_NAME_PROP;
 import static com.linkedin.venice.status.BatchJobHeartbeatConfigs.HEARTBEAT_ENABLED_CONFIG;
-import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -164,12 +169,14 @@ public class VenicePushJobTest {
     topicInfo.topic = "abc";
     pushJob.storeSetting = new VenicePushJob.StoreSetting();
     pushJob.storeSetting.storeResponse = new StoreResponse();
+    pushJob.storeSetting.storeResponse.setName("abc");
     StoreInfo storeInfo = new StoreInfo();
-    storeInfo.setBootstrapToOnlineTimeoutInHours(1);
+    storeInfo.setBootstrapToOnlineTimeoutInHours(0);
     pushJob.storeSetting.storeResponse.setStore(storeInfo);
-    Assert.expectThrows(
+    VeniceException exception = Assert.expectThrows(
         VeniceException.class,
         () -> pushJob.pollStatusUntilComplete(Optional.empty(), client, pushJobSetting, topicInfo));
+    Assert.assertEquals(exception.getMessage(), "Failing push-job for store abc which is still running after 0 hours.");
   }
 
   private Properties getRepushReadyProps() {

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/VenicePushJobTest.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/VenicePushJobTest.java
@@ -16,13 +16,8 @@ import static com.linkedin.venice.hadoop.VenicePushJob.VALUE_FIELD_PROP;
 import static com.linkedin.venice.hadoop.VenicePushJob.VENICE_DISCOVER_URL_PROP;
 import static com.linkedin.venice.hadoop.VenicePushJob.VENICE_STORE_NAME_PROP;
 import static com.linkedin.venice.status.BatchJobHeartbeatConfigs.HEARTBEAT_ENABLED_CONFIG;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyBoolean;
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.doNothing;
->>>>>>> eb14ad121 (added unit test)
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -49,12 +44,9 @@ import com.linkedin.venice.pushmonitor.ExecutionStatus;
 import com.linkedin.venice.utils.TestWriteUtils;
 import com.linkedin.venice.utils.VeniceProperties;
 import java.util.Collections;
-<<<<<<< HEAD
 import java.util.HashMap;
 import java.util.Map;
-=======
 import java.util.Optional;
->>>>>>> eb14ad121 (added unit test)
 import java.util.Properties;
 import java.util.Set;
 import java.util.function.Consumer;


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Fail pushjobs running over 24 hr bootstrap limit
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Today pushjobs are failed if they run over `bootstrapToOnlineTimeoutInHours` time limit, but its checked in server in `checkLongRunningTaskState` which kicks in only if its actively ingesting. But if due to some reason it does not ingest the job is left hanging forever. This PR add a check in vpj to honor the bootstrap time limit config and fail the push proactively.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.