### PR TITLE
[da-vinci] Added DaVinci memory limiter support

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/DaVinciBackend.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/DaVinciBackend.java
@@ -283,7 +283,7 @@ public class DaVinciBackend implements Closeable {
         }
       } catch (VeniceNoStoreException e) {
         // The store does not exist in Venice anymore, so it will be deleted.
-        LOGGER.info("Store does not exist, will delete invalid local version: {}", storageEngineName);
+        LOGGER.warn("Store does not exist, will delete invalid local version: {}", storageEngineName);
         storeShouldBeDeleted = true;
       }
       if (storeShouldBeDeleted) {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/DaVinciBackend.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/DaVinciBackend.java
@@ -71,6 +71,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
 import org.apache.helix.zookeeper.impl.client.ZkClient;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -104,7 +105,7 @@ public class DaVinciBackend implements Closeable {
       Optional<Set<String>> managedClients,
       ICProvider icProvider,
       Optional<ObjectCacheConfig> cacheConfig) {
-    LOGGER.info("Creating Da Vinci backend");
+    LOGGER.info("Creating Da Vinci backend with managed clients: {}", managedClients);
     try {
       VeniceServerConfig backendConfig = configLoader.getVeniceServerConfig();
       this.configLoader = configLoader;
@@ -155,13 +156,19 @@ public class DaVinciBackend implements Closeable {
       // Add extra safeguards here to ensure we have released RocksDB database locks before we initialize storage
       // services.
       IsolatedIngestionUtils.destroyLingeringIsolatedIngestionProcess(configLoader);
+      /**
+       * The constructor of {@link #storageService} will take care of unused store/store version cleanup.
+       */
       storageService = new StorageService(
           configLoader,
           aggVersionedStorageEngineStats,
           rocksDBMemoryStats,
           storeVersionStateSerializer,
           partitionStateSerializer,
-          storeRepository);
+          storeRepository,
+          true,
+          true,
+          functionToCheckWhetherStorageEngineShouldBeKeptOrNot(managedClients));
       storageService.start();
 
       VeniceWriterFactory writerFactory = new VeniceWriterFactory(backendProps.toProperties());
@@ -237,7 +244,7 @@ public class DaVinciBackend implements Closeable {
             "Ingestion isolated and Cache are incompatible configs!!  Aborting start up!");
       }
 
-      bootstrap(managedClients);
+      bootstrap();
 
       storeRepository.registerStoreDataChangedListener(storeChangeListener);
       cacheBackend.ifPresent(
@@ -251,14 +258,69 @@ public class DaVinciBackend implements Closeable {
     }
   }
 
-  protected synchronized void bootstrap(Optional<Set<String>> managedClients) {
+  private Function<String, Boolean> functionToCheckWhetherStorageEngineShouldBeKeptOrNot(
+      Optional<Set<String>> managedClients) {
+    return storageEngineName -> {
+      String storeName = Version.parseStoreFromKafkaTopicName(storageEngineName);
+      if (VeniceSystemStoreType.META_STORE.isSystemStore(storeName)) {
+        // Do not bootstrap meta system store via DaVinci backend initialization since the operation is not supported by
+        // ThinClientMetaStoreBasedRepository. This shouldn't happen normally, but it's possible if the user was using
+        // DVC based metadata for the same store and switched to thin client based metadata.
+        return true;
+      }
+      /**
+       * If the corresponding Venice store doesn't even exist, the local storage engine will be removed.
+       * If the managed client feature is enabled, but the storage engine is not on the list, the local
+       * storage engine will be removed.
+       */
+      boolean storeShouldBeDeleted = false;
+      try {
+        StoreBackend storeBackend = getStoreOrThrow(storeName); // throws VeniceNoStoreException
+        if (managedClients.isPresent() && !managedClients.get().contains(storeName) && storeBackend.isManaged()) {
+          // If the store is not-managed, all its versions will be removed.
+          LOGGER.info("Will delete unused managed version: {}", storageEngineName);
+          storeShouldBeDeleted = true;
+        }
+      } catch (VeniceNoStoreException e) {
+        // The store does not exist in Venice anymore, so it will be deleted.
+        LOGGER.info("Store does not exist, will delete invalid local version: {}", storageEngineName);
+        storeShouldBeDeleted = true;
+      }
+      if (storeShouldBeDeleted) {
+        /**
+         * Clean up the local state.
+         * Since it is possible there could multiple versions for the same store, the following cleanup
+         * logic should work for multiple times of cleanup for the same store.
+         */
+        deleteStore(storeName);
+        String baseDataPath = configLoader.getVeniceServerConfig().getDataBasePath();
+        new StoreBackendConfig(baseDataPath, storeName).delete();
+        return false;
+      }
+
+      // Check whether the local storage engine belongs to any valid store version or not
+      Set<Integer> validVersionNumbers = new HashSet<>();
+      Optional<Version> latestVersion = getVeniceLatestNonFaultyVersion(storeName, Collections.emptySet());
+      Optional<Version> currentVersion = getVeniceCurrentVersion(storeName);
+      currentVersion.ifPresent(version -> validVersionNumbers.add(version.getNumber()));
+      latestVersion.ifPresent(version -> validVersionNumbers.add(version.getNumber()));
+
+      int versionNumber = Version.parseVersionFromKafkaTopicName(storageEngineName);
+      // The version is no longer valid (stale version), it will be deleted.
+      if (!validVersionNumbers.contains(versionNumber)) {
+        LOGGER.info("Will delete obsolete local version: {}", storageEngineName);
+        return false;
+      }
+      return true;
+    };
+  }
+
+  private synchronized void bootstrap() {
     List<AbstractStorageEngine> storageEngines =
         storageService.getStorageEngineRepository().getAllLocalStorageEngines();
-    LOGGER.info("Starting bootstrap, storageEngines: {}, managedClients: {}", storageEngines, managedClients);
-    Map<String, Set<Integer>> expectedBootstrapVersions = new HashMap<>();
+    LOGGER.info("Starting bootstrap, storageEngines: {}", storageEngines);
     Map<String, Version> storeNameToBootstrapVersionMap = new HashMap<>();
     Map<String, List<Integer>> storeNameToPartitionListMap = new HashMap<>();
-    Set<String> unusedStores = new HashSet<>();
     for (AbstractStorageEngine storageEngine: storageEngines) {
       String kafkaTopicName = storageEngine.getStoreName();
       String storeName = Version.parseStoreFromKafkaTopicName(kafkaTopicName);
@@ -270,39 +332,12 @@ public class DaVinciBackend implements Closeable {
       }
 
       try {
-        StoreBackend storeBackend = getStoreOrThrow(storeName); // throws VeniceNoStoreException
-        if (managedClients.isPresent() && !managedClients.get().contains(storeName) && storeBackend.isManaged()) {
-          // If the store is not-managed, all its versions will be removed.
-          LOGGER.info("Deleting unused managed version: {}", kafkaTopicName);
-          unusedStores.add(storeName);
-          storageService.removeStorageEngine(kafkaTopicName);
-          continue;
-        }
+        getStoreOrThrow(storeName); // throws VeniceNoStoreException
       } catch (VeniceNoStoreException e) {
-        // The store does not exist in Venice anymore, so it will be deleted.
-        LOGGER.info("Store does not exist, deleting invalid local version: {}", kafkaTopicName);
-        unusedStores.add(storeName);
-        storageService.removeStorageEngine(kafkaTopicName);
-        continue;
-      }
-
-      // Initialize expected version numbers for each store.
-      if (!expectedBootstrapVersions.containsKey(storeName)) {
-        Set<Integer> validVersionNumbers = new HashSet<>();
-        Optional<Version> latestVersion = getVeniceLatestNonFaultyVersion(storeName, Collections.emptySet());
-        Optional<Version> currentVersion = getVeniceCurrentVersion(storeName);
-        currentVersion.ifPresent(version -> validVersionNumbers.add(version.getNumber()));
-        latestVersion.ifPresent(version -> validVersionNumbers.add(version.getNumber()));
-        expectedBootstrapVersions.put(storeName, validVersionNumbers);
+        throw new VeniceException("Unexpected to encounter non-existing store here: " + storeName);
       }
 
       int versionNumber = Version.parseVersionFromKafkaTopicName(kafkaTopicName);
-      // The version is no longer valid (stale version), it will be deleted.
-      if (!expectedBootstrapVersions.get(storeName).contains(versionNumber)) {
-        LOGGER.info("Deleting obsolete local version: {}", kafkaTopicName);
-        storageService.removeStorageEngine(kafkaTopicName);
-        continue;
-      }
 
       Version version = storeRepository.getStoreOrThrow(storeName)
           .getVersion(versionNumber)
@@ -321,21 +356,6 @@ public class DaVinciBackend implements Closeable {
           && (storeNameToBootstrapVersionMap.get(storeName).getNumber() < versionNumber))) {
         storeNameToBootstrapVersionMap.put(storeName, version);
         storeNameToPartitionListMap.put(storeName, storageService.getUserPartitions(kafkaTopicName));
-      }
-    }
-    /**
-     * Remove unused store's {@link StoreBackend} to avoid duplicate metrics registration issues when iterating storage
-     * engines for different versions of the same store.
-     */
-    for (String unusedStoreName: unusedStores) {
-      deleteStore(unusedStoreName);
-    }
-
-    // Cleanup stale StaleBackendConfig
-    String baseDataPath = configLoader.getVeniceServerConfig().getDataBasePath();
-    for (String storeName: StoreBackendConfig.listConfigs(baseDataPath)) {
-      if (!storeByNameMap.containsKey(storeName)) {
-        new StoreBackendConfig(baseDataPath, storeName).delete();
       }
     }
 
@@ -594,9 +614,13 @@ public class DaVinciBackend implements Closeable {
       ingestionReportExecutor.submit(() -> {
         VersionBackend versionBackend = versionByTopicMap.get(kafkaTopic);
         if (versionBackend != null) {
+          /**
+           * Report push status needs to be executed before deleting the {@link VersionBackend}.
+           */
+          reportPushStatus(kafkaTopic, partitionId, ExecutionStatus.ERROR);
+
           versionBackend.completePartitionExceptionally(partitionId, e);
           versionBackend.tryStopHeartbeat();
-          reportPushStatus(kafkaTopic, partitionId, ExecutionStatus.ERROR);
         }
       });
     }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/StoreBackend.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/StoreBackend.java
@@ -206,6 +206,8 @@ public class StoreBackend {
         version.delete();
       }
     }
+    LOGGER.info("Finished the unsubscription from partitions {} of {}", partitions, storeName);
+
   }
 
   synchronized void trySubscribeDaVinciFutureVersion() {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/client/AvroGenericDaVinciClient.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/client/AvroGenericDaVinciClient.java
@@ -1,5 +1,6 @@
 package com.linkedin.davinci.client;
 
+import static com.linkedin.davinci.ingestion.utils.IsolatedIngestionUtils.INGESTION_ISOLATION_CONFIG_PREFIX;
 import static com.linkedin.davinci.store.rocksdb.RocksDBServerConfig.ROCKSDB_LEVEL0_FILE_NUM_COMPACTION_TRIGGER;
 import static com.linkedin.davinci.store.rocksdb.RocksDBServerConfig.ROCKSDB_LEVEL0_FILE_NUM_COMPACTION_TRIGGER_WRITE_ONLY_VERSION;
 import static com.linkedin.davinci.store.rocksdb.RocksDBServerConfig.ROCKSDB_LEVEL0_SLOWDOWN_WRITES_TRIGGER;
@@ -8,6 +9,7 @@ import static com.linkedin.davinci.store.rocksdb.RocksDBServerConfig.ROCKSDB_LEV
 import static com.linkedin.davinci.store.rocksdb.RocksDBServerConfig.ROCKSDB_LEVEL0_STOPS_WRITES_TRIGGER_WRITE_ONLY_VERSION;
 import static com.linkedin.davinci.store.rocksdb.RocksDBServerConfig.ROCKSDB_PLAIN_TABLE_FORMAT_ENABLED;
 import static com.linkedin.venice.ConfigKeys.CLUSTER_NAME;
+import static com.linkedin.venice.ConfigKeys.INGESTION_MEMORY_LIMIT;
 import static com.linkedin.venice.ConfigKeys.INGESTION_USE_DA_VINCI_CLIENT;
 import static com.linkedin.venice.ConfigKeys.KAFKA_ADMIN_CLASS;
 import static com.linkedin.venice.ConfigKeys.KAFKA_BOOTSTRAP_SERVERS;
@@ -618,6 +620,8 @@ public class AvroGenericDaVinciClient<K, V> implements DaVinciClient<K, V>, Avro
         .put(KAFKA_BOOTSTRAP_SERVERS, kafkaBootstrapServers)
         .put(ROCKSDB_PLAIN_TABLE_FORMAT_ENABLED, daVinciConfig.getStorageClass() == StorageClass.MEMORY_BACKED_BY_DISK)
         .put(INGESTION_USE_DA_VINCI_CLIENT, true)
+        .put(INGESTION_ISOLATION_CONFIG_PREFIX + "." + INGESTION_MEMORY_LIMIT, -1) // Explicitly disable memory limiter
+                                                                                   // in Isolated Process
         .build();
     logger.info("backendConfig=" + config.toString(true));
     return new VeniceConfigLoader(config, config);

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/main/MainIngestionRequestClient.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/main/MainIngestionRequestClient.java
@@ -11,7 +11,6 @@ import com.linkedin.davinci.config.VeniceConfigLoader;
 import com.linkedin.davinci.ingestion.HttpClientTransport;
 import com.linkedin.davinci.ingestion.isolated.IsolatedIngestionServer;
 import com.linkedin.davinci.ingestion.utils.IsolatedIngestionUtils;
-import com.linkedin.venice.ConfigKeys;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.ingestion.protocol.IngestionStorageMetadata;
 import com.linkedin.venice.ingestion.protocol.IngestionTaskCommand;
@@ -25,7 +24,6 @@ import com.linkedin.venice.security.SSLFactory;
 import com.linkedin.venice.utils.ForkedJavaProcess;
 import com.linkedin.venice.utils.Utils;
 import java.io.Closeable;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -59,14 +57,7 @@ public class MainIngestionRequestClient implements Closeable {
     int totalAttempts = 3;
     ForkedJavaProcess forkedIngestionProcess = null;
 
-    List<String> jvmArgs = new ArrayList<>();
-    for (String jvmArg: configLoader.getCombinedProperties()
-        .getString(ConfigKeys.SERVER_FORKED_PROCESS_JVM_ARGUMENT_LIST, "")
-        .split(";")) {
-      if (jvmArg.length() != 0) {
-        jvmArgs.add(jvmArg);
-      }
-    }
+    List<String> jvmArgs = configLoader.getVeniceServerConfig().getForkedProcessJvmArgList();
 
     // Prepare initialization config
     String configFilePath = buildAndSaveConfigsForForkedIngestionProcess(configLoader);

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionService.java
@@ -480,6 +480,8 @@ public class KafkaStoreIngestionService extends AbstractVeniceService implements
         .setCompressorFactory(compressorFactory)
         .setVeniceViewWriterFactory(viewWriterFactory)
         .setPubSubTopicRepository(pubSubTopicRepository)
+        .setRunnableForKillIngestionTasksForNonCurrentVersions(
+            serverConfig.getIngestionMemoryLimit() > 0 ? () -> killConsumptionTaskForNonCurrentVersions() : null)
         .build();
   }
 
@@ -918,6 +920,33 @@ public class KafkaStoreIngestionService extends AbstractVeniceService implements
         shutdownStoreIngestionTask(topicName);
       }
     }
+  }
+
+  /**
+   * This function will try to kill the ingestion tasks belonging to non-current versions.
+   * And this is mainly being used by memory limiter feature to free up resources when encountering memory
+   * exhausting issue.
+   *
+   */
+  private void killConsumptionTaskForNonCurrentVersions() {
+    // Find out all non-current versions
+    Set<String> topicNameSet = topicNameToIngestionTaskMap.keySet();
+    List<String> nonCurrentVersions = new ArrayList<>();
+    topicNameSet.forEach(topic -> {
+      String storeName = Version.parseStoreFromKafkaTopicName(topic);
+      int version = Version.parseVersionFromKafkaTopicName(topic);
+      Store store = metadataRepo.getStore(storeName);
+      if (store == null || version != store.getCurrentVersion()) {
+        nonCurrentVersions.add(topic);
+      }
+    });
+    if (nonCurrentVersions.isEmpty()) {
+      LOGGER.info("No ingestion task belonging to non-current version");
+      return;
+    }
+    LOGGER.info("Start killing the following ingestion tasks: {}", nonCurrentVersions);
+    nonCurrentVersions.forEach(topic -> killConsumptionTask(topic));
+    LOGGER.info("Finished killing the following ingestion tasks: {}", nonCurrentVersions);
   }
 
   /**

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -1082,7 +1082,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
         if (partitionException instanceof MemoryLimitExhaustedException
             || partitionException.getCause() instanceof MemoryLimitExhaustedException
                 && isCurrentVersion.getAsBoolean()) {
-          LOGGER.info(
+          LOGGER.warn(
               "Encountered MemoryLimitExhaustedException, and ingestion task will try to reopen the database and"
                   + " resume the consumption after killing ingestion tasks for non current versions");
           /**
@@ -1097,9 +1097,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
               pubSubTopicPartition.getPartitionNumber());
           runnableForKillIngestionTasksForNonCurrentVersions.run();
           if (storageEngine.hasMemorySpaceLeft()) {
-            if (partitionConsumptionStateMap.containsKey(exceptionPartition)) {
-              unSubscribePartition(pubSubTopicPartition);
-            }
+            unSubscribePartition(pubSubTopicPartition);
             /**
              * DaVinci ingestion hits memory limit and we would like to retry it in the following way:
              * 1. Kill the ingestion tasks for non-current versions.
@@ -3537,7 +3535,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
     return kafkaVersionTopic;
   }
 
-  public boolean isStuck() {
+  public boolean isStuckByMemoryConstraint() {
     for (PartitionExceptionInfo ex: partitionIngestionExceptionList) {
       if (ex == null) {
         continue;

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -30,6 +30,7 @@ import com.linkedin.venice.common.VeniceSystemStoreType;
 import com.linkedin.venice.common.VeniceSystemStoreUtils;
 import com.linkedin.venice.compression.CompressionStrategy;
 import com.linkedin.venice.compression.VeniceCompressor;
+import com.linkedin.venice.exceptions.MemoryLimitExhaustedException;
 import com.linkedin.venice.exceptions.PersistenceFailureException;
 import com.linkedin.venice.exceptions.UnsubscribedTopicPartitionException;
 import com.linkedin.venice.exceptions.VeniceChecksumException;
@@ -298,6 +299,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
   protected final boolean isChunked;
   protected final PubSubTopicRepository pubSubTopicRepository;
   private final String[] msgForLagMeasurement;
+  private final Runnable runnableForKillIngestionTasksForNonCurrentVersions;
 
   public StoreIngestionTask(
       StoreIngestionTaskFactory.Builder builder,
@@ -435,6 +437,8 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
     for (int i = 0; i < this.msgForLagMeasurement.length; i++) {
       this.msgForLagMeasurement[i] = kafkaVersionTopic + "_" + i;
     }
+    this.runnableForKillIngestionTasksForNonCurrentVersions =
+        builder.getRunnableForKillIngestionTasksForNonCurrentVersions();
   }
 
   /** Package-private on purpose, only intended for tests. Do not use for production use cases. */
@@ -1071,19 +1075,63 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
           */
         partitionIngestionExceptionList.set(exceptionPartition, null);
       } else {
-        if (!partitionConsumptionState.isCompletionReported()) {
-          reportError(partitionException.getMessage(), exceptionPartition, partitionException);
+        PubSubTopicPartition pubSubTopicPartition = new PubSubTopicPartitionImpl(versionTopic, exceptionPartition);
+        /**
+         * Special handling for current version when encountering {@link MemoryLimitExhaustedException}.
+         */
+        if (partitionException instanceof MemoryLimitExhaustedException
+            || partitionException.getCause() instanceof MemoryLimitExhaustedException
+                && isCurrentVersion.getAsBoolean()) {
+          LOGGER.info(
+              "Encountered MemoryLimitExhaustedException, and ingestion task will try to reopen the database and"
+                  + " resume the consumption after killing ingestion tasks for non current versions");
+          /**
+           * Pause topic consumption to avoid more damage.
+           * We can't unsubscribe it since in some scenario, all the partitions can be unsubscribed, and the ingestion task
+           * will end. Even later on, there are avaiable memory space, we can't resume the ingestion task.
+           */
+          pauseConsumption(pubSubTopicPartition.getPubSubTopic().getName(), pubSubTopicPartition.getPartitionNumber());
+          LOGGER.info(
+              "Pausing consumption of topic: {}, partition: {} because of hitting memory limit",
+              pubSubTopicPartition.getPubSubTopic().getName(),
+              pubSubTopicPartition.getPartitionNumber());
+          runnableForKillIngestionTasksForNonCurrentVersions.run();
+          if (storageEngine.hasMemorySpaceLeft()) {
+            if (partitionConsumptionStateMap.containsKey(exceptionPartition)) {
+              unSubscribePartition(pubSubTopicPartition);
+            }
+            /**
+             * DaVinci ingestion hits memory limit and we would like to retry it in the following way:
+             * 1. Kill the ingestion tasks for non-current versions.
+             * 2. Reopen the database since the current database in a bad state, where it can't write or sync even
+             *    there are rooms (bug in SSTFileManager implementation in RocksDB). Reopen will drop the not-yet-synced
+             *    memtable unfortunately.
+             * 3. Resubscribe the affected partition.
+             */
+            LOGGER.info(
+                "Ingestion for topic: {}, partition: {} can resume since there are more space reclaimed",
+                kafkaVersionTopic,
+                exceptionPartition);
+            storageEngine.reopenStoragePartition(exceptionPartition);
+            // DaVinci is always a follower.
+            subscribePartition(pubSubTopicPartition, Optional.empty());
+          }
         } else {
-          LOGGER.error(
-              "Ignoring exception for partition {} for store version {} since this partition is already online. "
-                  + "Please engage Venice DEV team immediately.",
-              exceptionPartition,
-              kafkaVersionTopic,
-              partitionException);
-        }
-        // Unsubscribe the partition to avoid more damages.
-        if (partitionConsumptionStateMap.containsKey(exceptionPartition)) {
-          unSubscribePartition(new PubSubTopicPartitionImpl(versionTopic, exceptionPartition));
+          if (!partitionConsumptionState.isCompletionReported()) {
+            reportError(partitionException.getMessage(), exceptionPartition, partitionException);
+
+          } else {
+            LOGGER.error(
+                "Ignoring exception for partition {} for store version {} since this partition is already online. "
+                    + "Please engage Venice DEV team immediately.",
+                exceptionPartition,
+                kafkaVersionTopic,
+                partitionException);
+          }
+          // Unsubscribe the partition to avoid more damages.
+          if (partitionConsumptionStateMap.containsKey(exceptionPartition)) {
+            unSubscribePartition(new PubSubTopicPartitionImpl(versionTopic, exceptionPartition));
+          }
         }
       }
     });
@@ -2118,7 +2166,14 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
       return;
     }
     // Flush data partition
-    Map<String, String> dbCheckpointingInfo = storageEngineReloadedFromRepo.sync(partition);
+    final AtomicReference<Map<String, String>> dbCheckpointingInfoReference = new AtomicReference<>();
+    executeStorageEngineRunnable(partition, () -> {
+      Map<String, String> dbCheckpointingInfoFinal = storageEngineReloadedFromRepo.sync(partition);
+      dbCheckpointingInfoReference.set(dbCheckpointingInfoFinal);
+    });
+    if (dbCheckpointingInfoReference.get() == null) {
+      throw new VeniceException("The ingestion task has already stopped");
+    }
     storageUtilizationManager.notifyFlushToDisk(pcs);
 
     // Update the partition key in metadata partition
@@ -2128,7 +2183,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
     }
     OffsetRecord offsetRecord = pcs.getOffsetRecord();
     // Check-pointing info required by the underlying storage engine
-    offsetRecord.setDatabaseInfo(dbCheckpointingInfo);
+    offsetRecord.setDatabaseInfo(dbCheckpointingInfoReference.get());
     storageMetadataService.put(this.kafkaVersionTopic, partition, offsetRecord);
     pcs.resetProcessedRecordSizeSinceLastSync();
     String msg = "Offset synced for partition " + partition + " of topic " + topic + ": ";
@@ -2718,10 +2773,12 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
       int backupBytes = putValue.getInt();
       putValue.position(putValue.position() - ValueRecord.SCHEMA_HEADER_LENGTH);
       ByteUtils.writeInt(putValue.array(), put.schemaId, putValue.position());
-      writeToStorageEngine(partition, keyBytes, put, currentTimeMs);
-
-      /* We still want to recover the original position to make this function idempotent. */
-      putValue.putInt(backupBytes);
+      try {
+        writeToStorageEngine(partition, keyBytes, put, currentTimeMs);
+      } finally {
+        /* We still want to recover the original position to make this function idempotent. */
+        putValue.putInt(backupBytes);
+      }
     }
   }
 
@@ -2748,26 +2805,26 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
     }
   }
 
+  private void executeStorageEngineRunnable(int partition, Runnable storageEngineRunnable) {
+    try {
+      storageEngineRunnable.run();
+    } catch (VeniceException e) {
+      throwOrLogStorageFailureDependingIfStillSubscribed(partition, e);
+    }
+  }
+
   /**
    * Persist Put record to storage engine.
    */
   protected void putInStorageEngine(int partition, byte[] keyBytes, Put put) {
-    try {
-      storageEngine.put(partition, keyBytes, put.putValue);
-    } catch (PersistenceFailureException e) {
-      throwOrLogStorageFailureDependingIfStillSubscribed(partition, e);
-    }
+    executeStorageEngineRunnable(partition, () -> storageEngine.put(partition, keyBytes, put.putValue));
   }
 
   protected void removeFromStorageEngine(int partition, byte[] keyBytes, Delete delete) {
-    try {
-      storageEngine.delete(partition, keyBytes);
-    } catch (PersistenceFailureException e) {
-      throwOrLogStorageFailureDependingIfStillSubscribed(partition, e);
-    }
+    executeStorageEngineRunnable(partition, () -> storageEngine.delete(partition, keyBytes));
   }
 
-  protected void throwOrLogStorageFailureDependingIfStillSubscribed(int partition, PersistenceFailureException e) {
+  protected void throwOrLogStorageFailureDependingIfStillSubscribed(int partition, VeniceException e) {
     if (partitionConsumptionStateMap.containsKey(partition)) {
       throw new VeniceException(
           "Caught an exception while trying to interact with the storage engine for partition " + partition
@@ -3478,6 +3535,20 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
 
   protected String getKafkaVersionTopic() {
     return kafkaVersionTopic;
+  }
+
+  public boolean isStuck() {
+    for (PartitionExceptionInfo ex: partitionIngestionExceptionList) {
+      if (ex == null) {
+        continue;
+      }
+      Exception partitionIngestionException = ex.getException();
+      if (partitionIngestionException instanceof MemoryLimitExhaustedException
+          || partitionIngestionException.getCause() instanceof MemoryLimitExhaustedException) {
+        return true;
+      }
+    }
+    return false;
   }
 
   /**

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskFactory.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskFactory.java
@@ -109,6 +109,7 @@ public class StoreIngestionTaskFactory {
     private MetaStoreWriter metaStoreWriter;
     private StorageEngineBackedCompressorFactory compressorFactory;
     private PubSubTopicRepository pubSubTopicRepository;
+    private Runnable runnableForKillIngestionTasksForNonCurrentVersions;
 
     private interface Setter {
       void apply();
@@ -302,6 +303,14 @@ public class StoreIngestionTaskFactory {
 
     public Builder setPubSubTopicRepository(PubSubTopicRepository pubSubTopicRepository) {
       return set(() -> this.pubSubTopicRepository = pubSubTopicRepository);
+    }
+
+    public Runnable getRunnableForKillIngestionTasksForNonCurrentVersions() {
+      return runnableForKillIngestionTasksForNonCurrentVersions;
+    }
+
+    public Builder setRunnableForKillIngestionTasksForNonCurrentVersions(Runnable runnable) {
+      return set(() -> this.runnableForKillIngestionTasksForNonCurrentVersions = runnable);
     }
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/HostLevelIngestionStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/HostLevelIngestionStats.java
@@ -258,12 +258,12 @@ public class HostLevelIngestionStats extends AbstractVeniceStats {
                         : task.getStorageEngine().getRMDSizeInBytes())
                 .sum()));
     registerSensor(
-        "stuck_ingestion",
+        "ingestion_stuck_by_memory_constraint",
         new Gauge(
             () -> ingestionTaskMap.values()
                 .stream()
                 .filter(task -> isTotalStats ? true : task.getStoreName().equals(storeName))
-                .mapToLong(task -> task.isStuck() ? 1 : 0)
+                .mapToLong(task -> task.isStuckByMemoryConstraint() ? 1 : 0)
                 .sum()));
 
     // Stats which are per-store only:

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/HostLevelIngestionStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/HostLevelIngestionStats.java
@@ -257,6 +257,14 @@ public class HostLevelIngestionStats extends AbstractVeniceStats {
                         ? task.getStorageEngine().getCachedRMDSizeInBytes()
                         : task.getStorageEngine().getRMDSizeInBytes())
                 .sum()));
+    registerSensor(
+        "stuck_ingestion",
+        new Gauge(
+            () -> ingestionTaskMap.values()
+                .stream()
+                .filter(task -> isTotalStats ? true : task.getStoreName().equals(storeName))
+                .mapToLong(task -> task.isStuck() ? 1 : 0)
+                .sum()));
 
     // Stats which are per-store only:
     this.diskQuotaSensor =

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/AbstractStorageEngine.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/AbstractStorageEngine.java
@@ -719,4 +719,8 @@ public abstract class AbstractStorageEngine<Partition extends AbstractStoragePar
     StoreVersionState svs = getStoreVersionState();
     return svs == null ? false : svs.chunked;
   }
+
+  public boolean hasMemorySpaceLeft() {
+    return true;
+  }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/StorageEngineFactory.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/StorageEngineFactory.java
@@ -55,6 +55,11 @@ public abstract class StorageEngineFactory {
   public abstract void removeStorageEngine(AbstractStorageEngine engine);
 
   /**
+   * Remove the storage engine without opening it.
+   */
+  public abstract void removeStorageEngine(String storeName);
+
+  /**
    * Close the storage engine from the underlying storage configuration
    *
    * @param engine Specifies the storage engine to be removed

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/blackhole/BlackHoleStorageEngineFactory.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/blackhole/BlackHoleStorageEngineFactory.java
@@ -32,6 +32,11 @@ public class BlackHoleStorageEngineFactory extends StorageEngineFactory {
   }
 
   @Override
+  public void removeStorageEngine(String storeName) {
+    // Right away!
+  }
+
+  @Override
   public void closeStorageEngine(AbstractStorageEngine engine) {
     // Right away!
   }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/memory/InMemoryStorageEngineFactory.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/memory/InMemoryStorageEngineFactory.java
@@ -47,6 +47,11 @@ public class InMemoryStorageEngineFactory extends StorageEngineFactory {
   }
 
   @Override
+  public void removeStorageEngine(String storeName) {
+    // Nothing to do here since we do not track the created storage engine
+  }
+
+  @Override
   public void closeStorageEngine(AbstractStorageEngine engine) {
     // Nothing to do here since we do not track the created storage engine
   }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/config/VeniceServerConfigTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/config/VeniceServerConfigTest.java
@@ -1,0 +1,108 @@
+package com.linkedin.davinci.config;
+
+import static com.linkedin.davinci.store.rocksdb.RocksDBServerConfig.ROCKSDB_PLAIN_TABLE_FORMAT_ENABLED;
+import static com.linkedin.davinci.store.rocksdb.RocksDBServerConfig.ROCKSDB_TOTAL_MEMTABLE_USAGE_CAP_IN_BYTES;
+import static com.linkedin.venice.ConfigKeys.CLUSTER_NAME;
+import static com.linkedin.venice.ConfigKeys.INGESTION_MEMORY_LIMIT;
+import static com.linkedin.venice.ConfigKeys.INGESTION_USE_DA_VINCI_CLIENT;
+import static com.linkedin.venice.ConfigKeys.KAFKA_BOOTSTRAP_SERVERS;
+import static com.linkedin.venice.ConfigKeys.SERVER_FORKED_PROCESS_JVM_ARGUMENT_LIST;
+import static com.linkedin.venice.ConfigKeys.SERVER_INGESTION_MODE;
+import static com.linkedin.venice.ConfigKeys.ZOOKEEPER_ADDRESS;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.expectThrows;
+
+import com.linkedin.venice.exceptions.VeniceException;
+import com.linkedin.venice.meta.IngestionMode;
+import com.linkedin.venice.utils.VeniceProperties;
+import java.util.List;
+import java.util.Properties;
+import org.testng.annotations.Test;
+
+
+public class VeniceServerConfigTest {
+  private Properties populatedBasicProperties() {
+    Properties props = new Properties();
+    props.setProperty(CLUSTER_NAME, "test_cluster");
+    props.setProperty(ZOOKEEPER_ADDRESS, "fake_zk_addr");
+    props.setProperty(KAFKA_BOOTSTRAP_SERVERS, "fake_kafka_addr");
+    props.setProperty(INGESTION_USE_DA_VINCI_CLIENT, "true");
+
+    return props;
+  }
+
+  @Test
+  public void testForkedJVMParams() {
+    Properties props = populatedBasicProperties();
+    props.put(SERVER_FORKED_PROCESS_JVM_ARGUMENT_LIST, "-Xms256M;  -Xmx256G");
+
+    VeniceServerConfig config = new VeniceServerConfig(new VeniceProperties(props));
+
+    List<String> jvmArgs = config.getForkedProcessJvmArgList();
+    assertEquals(jvmArgs.size(), 2);
+    assertEquals(jvmArgs.get(0), "-Xms256M");
+    assertEquals(jvmArgs.get(1), "-Xmx256G");
+  }
+
+  @Test
+  public void testMemoryLimitConfigWithoutIngestionIsolation() {
+    Properties propsForNonDaVinci = populatedBasicProperties();
+    propsForNonDaVinci.setProperty(INGESTION_USE_DA_VINCI_CLIENT, "false");
+    propsForNonDaVinci.setProperty(INGESTION_MEMORY_LIMIT, "100MB");
+
+    VeniceException e =
+        expectThrows(VeniceException.class, () -> new VeniceServerConfig(new VeniceProperties(propsForNonDaVinci)));
+    assertTrue(e.getMessage().contains("only meaningful for DaVinci"));
+
+    Properties props1 = populatedBasicProperties();
+    props1.setProperty(INGESTION_MEMORY_LIMIT, "100MB");
+    e = expectThrows(VeniceException.class, () -> new VeniceServerConfig(new VeniceProperties(props1)));
+    assertTrue(e.getMessage().contains("meaningful when using RocksDB plaintable format"));
+
+    Properties props2 = populatedBasicProperties();
+    props2.setProperty(INGESTION_MEMORY_LIMIT, "100MB");
+    props2.setProperty(ROCKSDB_PLAIN_TABLE_FORMAT_ENABLED, "true");
+    e = expectThrows(VeniceException.class, () -> new VeniceServerConfig(new VeniceProperties(props2)));
+    assertTrue(e.getMessage().contains("should be bigger than total memtable usage cap"));
+
+    Properties props3 = populatedBasicProperties();
+    props3.setProperty(INGESTION_MEMORY_LIMIT, "100MB");
+    props3.setProperty(ROCKSDB_PLAIN_TABLE_FORMAT_ENABLED, "true");
+    props3.setProperty(ROCKSDB_TOTAL_MEMTABLE_USAGE_CAP_IN_BYTES, "32MB");
+    VeniceServerConfig config1 = new VeniceServerConfig(new VeniceProperties(props3));
+    assertEquals(config1.getIngestionMemoryLimit(), 68 * 1024 * 1024l);
+  }
+
+  @Test
+  public void testMemoryLimitConfigWithIngestionIsolation() {
+    Properties props1 = populatedBasicProperties();
+    props1.setProperty(INGESTION_MEMORY_LIMIT, "100MB");
+    props1.setProperty(SERVER_INGESTION_MODE, IngestionMode.ISOLATED.toString());
+    props1.setProperty(ROCKSDB_PLAIN_TABLE_FORMAT_ENABLED, "true");
+
+    VeniceException e = expectThrows(VeniceException.class, () -> new VeniceServerConfig(new VeniceProperties(props1)));
+    assertTrue(
+        e.getMessage()
+            .contains(
+                "The max heap size of isolated process needs to be configured explicitly when enabling memory limiter"));
+
+    Properties props2 = populatedBasicProperties();
+    props2.setProperty(INGESTION_MEMORY_LIMIT, "100MB");
+    props2.setProperty(SERVER_INGESTION_MODE, IngestionMode.ISOLATED.toString());
+    props2.put(SERVER_FORKED_PROCESS_JVM_ARGUMENT_LIST, "-Xms32MB;-Xmx32MB");
+    props2.setProperty(ROCKSDB_TOTAL_MEMTABLE_USAGE_CAP_IN_BYTES, "50MB");
+    props2.setProperty(ROCKSDB_PLAIN_TABLE_FORMAT_ENABLED, "true");
+    e = expectThrows(VeniceException.class, () -> new VeniceServerConfig(new VeniceProperties(props2)));
+    assertTrue(e.getMessage().contains("should be positive after subtracting the usage from other components"));
+
+    Properties props3 = populatedBasicProperties();
+    props3.setProperty(INGESTION_MEMORY_LIMIT, "100MB");
+    props3.setProperty(SERVER_INGESTION_MODE, IngestionMode.ISOLATED.toString());
+    props3.put(SERVER_FORKED_PROCESS_JVM_ARGUMENT_LIST, "-Xms32MB;-Xmx32MB");
+    props3.setProperty(ROCKSDB_TOTAL_MEMTABLE_USAGE_CAP_IN_BYTES, "32MB");
+    props3.setProperty(ROCKSDB_PLAIN_TABLE_FORMAT_ENABLED, "true");
+    VeniceServerConfig config1 = new VeniceServerConfig(new VeniceProperties(props3));
+    assertEquals(config1.getIngestionMemoryLimit(), 4 * 1024 * 1024l);
+  }
+}

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/DeepCopyStorageEngine.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/DeepCopyStorageEngine.java
@@ -193,4 +193,9 @@ public class DeepCopyStorageEngine extends AbstractStorageEngine<AbstractStorage
   public long getStoreSizeInBytes() {
     return this.delegate.getStoreSizeInBytes();
   }
+
+  @Override
+  public void reopenStoragePartition(int partitionId) {
+    this.delegate.reopenStoragePartition(partitionId);
+  }
 }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/store/rocksdb/RocksDBStoragePartitionTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/store/rocksdb/RocksDBStoragePartitionTest.java
@@ -7,12 +7,18 @@ import static com.linkedin.davinci.store.rocksdb.RocksDBServerConfig.ROCKSDB_LEV
 import static com.linkedin.davinci.store.rocksdb.RocksDBServerConfig.ROCKSDB_LEVEL0_SLOWDOWN_WRITES_TRIGGER_WRITE_ONLY_VERSION;
 import static com.linkedin.davinci.store.rocksdb.RocksDBServerConfig.ROCKSDB_LEVEL0_STOPS_WRITES_TRIGGER;
 import static com.linkedin.davinci.store.rocksdb.RocksDBServerConfig.ROCKSDB_LEVEL0_STOPS_WRITES_TRIGGER_WRITE_ONLY_VERSION;
+import static com.linkedin.davinci.store.rocksdb.RocksDBServerConfig.ROCKSDB_MAX_MEMTABLE_COUNT;
+import static com.linkedin.davinci.store.rocksdb.RocksDBServerConfig.ROCKSDB_MEMTABLE_SIZE_IN_BYTES;
 import static com.linkedin.davinci.store.rocksdb.RocksDBServerConfig.ROCKSDB_PLAIN_TABLE_FORMAT_ENABLED;
+import static com.linkedin.davinci.store.rocksdb.RocksDBServerConfig.ROCKSDB_TOTAL_MEMTABLE_USAGE_CAP_IN_BYTES;
+import static com.linkedin.venice.ConfigKeys.INGESTION_MEMORY_LIMIT;
+import static com.linkedin.venice.ConfigKeys.INGESTION_USE_DA_VINCI_CLIENT;
 import static com.linkedin.venice.ConfigKeys.PERSISTENCE_TYPE;
 
 import com.linkedin.davinci.config.VeniceServerConfig;
 import com.linkedin.davinci.store.AbstractStorageEngineTest;
 import com.linkedin.davinci.store.StoragePartitionConfig;
+import com.linkedin.venice.exceptions.MemoryLimitExhaustedException;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.kafka.validation.checksum.CheckSum;
 import com.linkedin.venice.kafka.validation.checksum.CheckSumType;
@@ -651,5 +657,81 @@ public class RocksDBStoragePartitionTest {
 
     storagePartition.drop();
     removeDir(storeDir);
+  }
+
+  @Test
+  public void checkMemoryLimitAtDatabaseOpen() {
+    String storeName = Utils.getUniqueString("test_store");
+    String storeDir = getTempDatabaseDir(storeName);
+    RocksDBStoragePartition storagePartition = null;
+    try {
+      Properties extraProps = new Properties();
+      extraProps.setProperty(INGESTION_USE_DA_VINCI_CLIENT, "true");
+      extraProps.setProperty(INGESTION_MEMORY_LIMIT, "1MB");
+      extraProps.setProperty(ROCKSDB_MAX_MEMTABLE_COUNT, "2");
+      extraProps.setProperty(ROCKSDB_MEMTABLE_SIZE_IN_BYTES, "128KB");
+      extraProps.setProperty(ROCKSDB_TOTAL_MEMTABLE_USAGE_CAP_IN_BYTES, "512KB");
+      extraProps.setProperty(ROCKSDB_PLAIN_TABLE_FORMAT_ENABLED, "true");
+
+      VeniceProperties veniceServerProperties =
+          AbstractStorageEngineTest.getServerProperties(PersistenceType.ROCKS_DB, extraProps);
+      RocksDBServerConfig rocksDBServerConfig = new RocksDBServerConfig(veniceServerProperties);
+
+      int partitionId = 0;
+      StoragePartitionConfig partitionConfig = new StoragePartitionConfig(storeName, partitionId);
+
+      VeniceServerConfig serverConfig = new VeniceServerConfig(veniceServerProperties);
+      RocksDBStorageEngineFactory factory = new RocksDBStorageEngineFactory(serverConfig);
+      storagePartition = new RocksDBStoragePartition(
+          partitionConfig,
+          factory,
+          DATA_BASE_DIR,
+          null,
+          ROCKSDB_THROTTLER,
+          rocksDBServerConfig);
+      RocksDBStoragePartition finalStoragePartition = storagePartition;
+      Assert.expectThrows(MemoryLimitExhaustedException.class, () -> {
+        String keyPrefix = "key_prefix_";
+        String valuePrefix = "value_prefix________________________________________";
+        for (int i = 0; i < 100000; ++i) {
+          finalStoragePartition.put((keyPrefix + i).getBytes(), (valuePrefix + i).getBytes());
+        }
+        ;
+      });
+
+      Assert.expectThrows(MemoryLimitExhaustedException.class, () -> {
+        String keyPrefix = "key_prefix1_";
+        for (int i = 0; i < 100000; ++i) {
+          finalStoragePartition.delete((keyPrefix + i).getBytes());
+        }
+        ;
+      });
+
+      Assert.expectThrows(MemoryLimitExhaustedException.class, () -> finalStoragePartition.sync());
+      storagePartition.close();
+
+      extraProps.setProperty(INGESTION_MEMORY_LIMIT, "800KB");
+      // With a tighter memory limiter, the database open should fail
+      veniceServerProperties = AbstractStorageEngineTest.getServerProperties(PersistenceType.ROCKS_DB, extraProps);
+      RocksDBServerConfig finalRocksDBServerConfig = new RocksDBServerConfig(veniceServerProperties);
+
+      serverConfig = new VeniceServerConfig(veniceServerProperties);
+      RocksDBStorageEngineFactory finalFactory = new RocksDBStorageEngineFactory(serverConfig);
+      Assert.expectThrows(
+          MemoryLimitExhaustedException.class,
+          () -> new RocksDBStoragePartition(
+              partitionConfig,
+              finalFactory,
+              DATA_BASE_DIR,
+              null,
+              ROCKSDB_THROTTLER,
+              finalRocksDBServerConfig));
+    } finally {
+      if (storagePartition != null) {
+        storagePartition.close();
+        storagePartition.drop();
+      }
+      removeDir(storeDir);
+    }
   }
 }

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/exceptions/MemoryLimitExhaustedException.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/exceptions/MemoryLimitExhaustedException.java
@@ -1,0 +1,13 @@
+package com.linkedin.venice.exceptions;
+
+public class MemoryLimitExhaustedException extends VeniceException {
+  public MemoryLimitExhaustedException(String storeName, int partitionId, long currentUsage) {
+    super(
+        "Partition: " + partitionId + " of store: " + storeName
+            + "  update has already hit memory limit, and current usage: " + currentUsage);
+  }
+
+  public MemoryLimitExhaustedException(String msg) {
+    super(msg);
+  }
+}

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/utils/VeniceProperties.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/utils/VeniceProperties.java
@@ -359,21 +359,25 @@ public class VeniceProperties {
     }
 
     String bytes = get(name);
-    String bytesLc = bytes.toLowerCase().trim();
-    if (bytesLc.endsWith("kb")) {
-      return Long.parseLong(bytes.substring(0, bytes.length() - 2)) * 1024;
-    } else if (bytesLc.endsWith("k")) {
-      return Long.parseLong(bytes.substring(0, bytes.length() - 1)) * 1024;
-    } else if (bytesLc.endsWith("mb")) {
-      return Long.parseLong(bytes.substring(0, bytes.length() - 2)) * 1024 * 1024;
-    } else if (bytesLc.endsWith("m")) {
-      return Long.parseLong(bytes.substring(0, bytes.length() - 1)) * 1024 * 1024;
-    } else if (bytesLc.endsWith("gb")) {
-      return Long.parseLong(bytes.substring(0, bytes.length() - 2)) * 1024 * 1024 * 1024;
-    } else if (bytesLc.endsWith("g")) {
-      return Long.parseLong(bytes.substring(0, bytes.length() - 1)) * 1024 * 1024 * 1024;
+    return convertSizeFromLiteral(bytes);
+  }
+
+  public static long convertSizeFromLiteral(String size) {
+    String sizeLc = size.toLowerCase().trim();
+    if (sizeLc.endsWith("kb")) {
+      return Long.parseLong(size.substring(0, size.length() - 2)) * 1024;
+    } else if (sizeLc.endsWith("k")) {
+      return Long.parseLong(size.substring(0, size.length() - 1)) * 1024;
+    } else if (sizeLc.endsWith("mb")) {
+      return Long.parseLong(size.substring(0, size.length() - 2)) * 1024 * 1024;
+    } else if (sizeLc.endsWith("m")) {
+      return Long.parseLong(size.substring(0, size.length() - 1)) * 1024 * 1024;
+    } else if (sizeLc.endsWith("gb")) {
+      return Long.parseLong(size.substring(0, size.length() - 2)) * 1024 * 1024 * 1024;
+    } else if (sizeLc.endsWith("g")) {
+      return Long.parseLong(size.substring(0, size.length() - 1)) * 1024 * 1024 * 1024;
     } else {
-      return Long.parseLong(bytes);
+      return Long.parseLong(size);
     }
   }
 

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/utils/VenicePropertiesTest.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/utils/VenicePropertiesTest.java
@@ -1,0 +1,18 @@
+package com.linkedin.venice.utils;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class VenicePropertiesTest {
+  @Test
+  public void testConvertSizeFromLiteral() {
+    Assert.assertEquals(VeniceProperties.convertSizeFromLiteral("512"), 512l);
+    Assert.assertEquals(VeniceProperties.convertSizeFromLiteral("1KB"), 1024l);
+    Assert.assertEquals(VeniceProperties.convertSizeFromLiteral("1k"), 1024l);
+    Assert.assertEquals(VeniceProperties.convertSizeFromLiteral("1MB"), 1024 * 1024l);
+    Assert.assertEquals(VeniceProperties.convertSizeFromLiteral("1m"), 1024 * 1024l);
+    Assert.assertEquals(VeniceProperties.convertSizeFromLiteral("1GB"), 1024 * 1024 * 1024l);
+    Assert.assertEquals(VeniceProperties.convertSizeFromLiteral("1g"), 1024 * 1024 * 1024l);
+  }
+}

--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -1665,6 +1665,14 @@ public class ConfigKeys {
   public static final String OFFLINE_PUSH_MONITOR_DAVINCI_PUSH_STATUS_SCAN_THREAD_NUMBER =
       "offline.push.monitor.davinci.push.status.scan.thread.number";
 
+  /**
+   * Max retry when not receiving any DaVinci status report.
+   * This is mainly for testing purpose since in local integration test, the push job runs too fast in the backend,
+   * and no DaVinci status report will mark the push job succeed right away.
+   */
+  public static final String OFFLINE_PUSH_MONITOR_DAVINCI_PUSH_STATUS_SCAN_NO_DAVINCI_STATUS_REPORT_RETRY_MAX_ATTEMPTS =
+      "offline.push.monitor.davinci.push.status.scan.no.davinci.status.report.retry.max.attempts";
+
   public static final String CONTROLLER_ZK_SHARED_DAVINCI_PUSH_STATUS_SYSTEM_SCHEMA_STORE_AUTO_CREATION_ENABLED =
       "controller.zk.shared.davinci.push.status.system.schema.store.auto.creation.enabled";
 
@@ -1918,4 +1926,20 @@ public class ConfigKeys {
    */
   public static final String CLIENT_PRODUCER_SCHEMA_REFRESH_INTERVAL_SECONDS =
       "client.producer.schema.refresh.interval.seconds";
+
+  /*
+   * The memory up-limit for the ingestion path while using RocksDB Plaintable format.
+   * Currently, this option is only meaningful for DaVinci use cases.
+   */
+  public static final String INGESTION_MEMORY_LIMIT = "ingestion.memory.limit";
+
+  /**
+   * Whether the ingestion is using mlock or not.
+   * Currently, this option is only meaningful for DaVinci use cases.
+   *
+   * Actually, this config option is being actively used, and it is a placeholder for the future optimization.
+   * The memory limit logic implemented today is assuming mlock usage, and to make it backward compatible when
+   * we want to do more optimization for non-mlock usage, we will ask the mlock user to enable this flag.
+   */
+  public static final String INGESTION_MLOCK_ENABLED = "ingestion.mlock.enabled";
 }

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/DaVinciClientMemoryLimitTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/DaVinciClientMemoryLimitTest.java
@@ -1,0 +1,485 @@
+package com.linkedin.venice.endToEnd;
+
+import static com.linkedin.davinci.store.rocksdb.RocksDBServerConfig.ROCKSDB_MEMTABLE_SIZE_IN_BYTES;
+import static com.linkedin.davinci.store.rocksdb.RocksDBServerConfig.ROCKSDB_TOTAL_MEMTABLE_USAGE_CAP_IN_BYTES;
+import static com.linkedin.venice.ConfigKeys.CLIENT_SYSTEM_STORE_REPOSITORY_REFRESH_INTERVAL_SECONDS;
+import static com.linkedin.venice.ConfigKeys.CLIENT_USE_SYSTEM_STORE_REPOSITORY;
+import static com.linkedin.venice.ConfigKeys.CLUSTER_DISCOVERY_D2_SERVICE;
+import static com.linkedin.venice.ConfigKeys.D2_ZK_HOSTS_ADDRESS;
+import static com.linkedin.venice.ConfigKeys.DATA_BASE_PATH;
+import static com.linkedin.venice.ConfigKeys.INGESTION_MEMORY_LIMIT;
+import static com.linkedin.venice.ConfigKeys.OFFLINE_PUSH_MONITOR_DAVINCI_PUSH_STATUS_SCAN_NO_DAVINCI_STATUS_REPORT_RETRY_MAX_ATTEMPTS;
+import static com.linkedin.venice.ConfigKeys.PERSISTENCE_TYPE;
+import static com.linkedin.venice.ConfigKeys.PUSH_STATUS_STORE_ENABLED;
+import static com.linkedin.venice.ConfigKeys.SERVER_FORKED_PROCESS_JVM_ARGUMENT_LIST;
+import static com.linkedin.venice.ConfigKeys.SERVER_INGESTION_ISOLATION_APPLICATION_PORT;
+import static com.linkedin.venice.ConfigKeys.SERVER_INGESTION_ISOLATION_SERVICE_PORT;
+import static com.linkedin.venice.ConfigKeys.SERVER_INGESTION_MODE;
+import static com.linkedin.venice.ConfigKeys.SERVER_PROMOTION_TO_LEADER_REPLICA_DELAY_SECONDS;
+import static com.linkedin.venice.meta.PersistenceType.ROCKS_DB;
+import static com.linkedin.venice.utils.IntegrationTestPushUtils.createStoreForJob;
+import static com.linkedin.venice.utils.IntegrationTestPushUtils.defaultVPJProps;
+import static com.linkedin.venice.utils.IntegrationTestPushUtils.getSamzaProducer;
+import static com.linkedin.venice.utils.IntegrationTestPushUtils.runVPJ;
+import static com.linkedin.venice.utils.IntegrationTestPushUtils.sendCustomSizeStreamingRecord;
+import static com.linkedin.venice.utils.TestWriteUtils.getTempDataDirectory;
+import static com.linkedin.venice.utils.TestWriteUtils.writeSimpleAvroFileWithUserSchema;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.expectThrows;
+
+import com.linkedin.d2.balancer.D2Client;
+import com.linkedin.d2.balancer.D2ClientBuilder;
+import com.linkedin.davinci.client.DaVinciClient;
+import com.linkedin.davinci.client.DaVinciConfig;
+import com.linkedin.davinci.client.StorageClass;
+import com.linkedin.davinci.client.factory.CachingDaVinciClientFactory;
+import com.linkedin.venice.D2.D2ClientUtils;
+import com.linkedin.venice.client.store.AvroGenericStoreClient;
+import com.linkedin.venice.client.store.ClientConfig;
+import com.linkedin.venice.client.store.ClientFactory;
+import com.linkedin.venice.controllerapi.ControllerClient;
+import com.linkedin.venice.controllerapi.ControllerResponse;
+import com.linkedin.venice.controllerapi.NewStoreResponse;
+import com.linkedin.venice.controllerapi.StoreResponse;
+import com.linkedin.venice.controllerapi.UpdateStoreQueryParams;
+import com.linkedin.venice.exceptions.VeniceException;
+import com.linkedin.venice.integration.utils.ServiceFactory;
+import com.linkedin.venice.integration.utils.VeniceClusterWrapper;
+import com.linkedin.venice.integration.utils.VeniceRouterWrapper;
+import com.linkedin.venice.meta.IngestionMode;
+import com.linkedin.venice.meta.Version;
+import com.linkedin.venice.utils.DataProviderUtils;
+import com.linkedin.venice.utils.PropertyBuilder;
+import com.linkedin.venice.utils.TestUtils;
+import com.linkedin.venice.utils.Utils;
+import com.linkedin.venice.utils.VeniceProperties;
+import io.tehuti.metrics.MetricsRepository;
+import java.io.File;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+import org.apache.avro.Schema;
+import org.apache.samza.system.SystemProducer;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+
+public class DaVinciClientMemoryLimitTest {
+  private static final int TEST_TIMEOUT = 120_000;
+  private VeniceClusterWrapper venice;
+  private D2Client d2Client;
+
+  @BeforeClass
+  public void setUp() {
+    Utils.thisIsLocalhost();
+    Properties clusterConfig = new Properties();
+    clusterConfig.put(SERVER_PROMOTION_TO_LEADER_REPLICA_DELAY_SECONDS, 10L);
+    clusterConfig.put(OFFLINE_PUSH_MONITOR_DAVINCI_PUSH_STATUS_SCAN_NO_DAVINCI_STATUS_REPORT_RETRY_MAX_ATTEMPTS, 5); // To
+                                                                                                                     // allow
+                                                                                                                     // more
+                                                                                                                     // times
+                                                                                                                     // for
+                                                                                                                     // DaVinci
+                                                                                                                     // clients
+                                                                                                                     // to
+                                                                                                                     // report
+                                                                                                                     // status
+    venice = ServiceFactory.getVeniceCluster(1, 2, 1, 1, 100, false, false, clusterConfig);
+    d2Client = new D2ClientBuilder().setZkHosts(venice.getZk().getAddress())
+        .setZkSessionTimeout(3, TimeUnit.SECONDS)
+        .setZkStartupTimeout(3, TimeUnit.SECONDS)
+        .build();
+    D2ClientUtils.startClient(d2Client);
+  }
+
+  @AfterClass
+  public void cleanUp() {
+    if (d2Client != null) {
+      D2ClientUtils.shutdownClient(d2Client);
+    }
+    Utils.closeQuietlyWithErrorLogged(venice);
+  }
+
+  private VeniceProperties getDaVinciBackendConfig(boolean ingestionIsolationEnabledInDaVinci) {
+    String baseDataPath = Utils.getTempDataDirectory().getAbsolutePath();
+    PropertyBuilder venicePropertyBuilder = new PropertyBuilder();
+    venicePropertyBuilder.put(CLIENT_USE_SYSTEM_STORE_REPOSITORY, true)
+        .put(CLIENT_SYSTEM_STORE_REPOSITORY_REFRESH_INTERVAL_SECONDS, 1)
+        .put(DATA_BASE_PATH, baseDataPath)
+        .put(PERSISTENCE_TYPE, ROCKS_DB)
+        .put(PUSH_STATUS_STORE_ENABLED, true)
+        .put(D2_ZK_HOSTS_ADDRESS, venice.getZk().getAddress())
+        .put(CLUSTER_DISCOVERY_D2_SERVICE, VeniceRouterWrapper.CLUSTER_DISCOVERY_D2_SERVICE_NAME)
+        .put(ROCKSDB_MEMTABLE_SIZE_IN_BYTES, "2MB")
+        .put(ROCKSDB_TOTAL_MEMTABLE_USAGE_CAP_IN_BYTES, "10MB");
+    if (ingestionIsolationEnabledInDaVinci) {
+      venicePropertyBuilder.put(SERVER_INGESTION_MODE, IngestionMode.ISOLATED);
+      venicePropertyBuilder.put(SERVER_INGESTION_ISOLATION_APPLICATION_PORT, Utils.getFreePort());
+      venicePropertyBuilder.put(SERVER_INGESTION_ISOLATION_SERVICE_PORT, Utils.getFreePort());
+      venicePropertyBuilder.put(SERVER_FORKED_PROCESS_JVM_ARGUMENT_LIST, "-Xms256M;-Xmx256M");
+      venicePropertyBuilder.put(INGESTION_MEMORY_LIMIT, "296MB"); // 256M + 10M + 30M
+    } else {
+      venicePropertyBuilder.put(INGESTION_MEMORY_LIMIT, "30MB");
+    }
+
+    return venicePropertyBuilder.build();
+  }
+
+  @Test(timeOut = TEST_TIMEOUT, dataProviderClass = DataProviderUtils.class, dataProvider = "True-and-False")
+  public void testDaVinciMemoryLimitShouldFailLargeDataPush(boolean ingestionIsolationEnabledInDaVinci)
+      throws Exception {
+    String storeName = Utils.getUniqueString("davinci_memory_limit_test");
+    // Test a small push
+    File inputDir = getTempDataDirectory();
+    String inputDirPath = "file://" + inputDir.getAbsolutePath();
+    Schema recordSchema = writeSimpleAvroFileWithUserSchema(inputDir, true, 100, 100);
+    Properties vpjProperties = defaultVPJProps(venice, inputDirPath, storeName);
+
+    try (ControllerClient controllerClient = createStoreForJob(venice.getClusterName(), recordSchema, vpjProperties);
+        AvroGenericStoreClient client = ClientFactory.getAndStartGenericAvroClient(
+            ClientConfig.defaultGenericClientConfig(storeName).setVeniceURL(venice.getRandomRouterURL()))) {
+      venice.createMetaSystemStore(storeName);
+      venice.createPushStatusSystemStore(storeName);
+
+      // Make sure DaVinci push status system store is enabled
+      StoreResponse storeResponse = controllerClient.getStore(storeName);
+      assertFalse(storeResponse.isError(), "Store response receives an error: " + storeResponse.getError());
+      assertTrue(storeResponse.getStore().isDaVinciPushStatusStoreEnabled());
+
+      // Do an VPJ push
+      runVPJ(vpjProperties, 1, controllerClient);
+
+      // Verify some records (note, records 1-100 have been pushed)
+      TestUtils.waitForNonDeterministicAssertion(10, TimeUnit.SECONDS, true, () -> {
+        try {
+          for (int i = 1; i <= 100; i++) {
+            String key = Integer.toString(i);
+            Object value = client.get(key).get();
+            assertNotNull(value, "Key " + i + " should not be missing!");
+          }
+        } catch (Exception e) {
+          throw new VeniceException(e);
+        }
+      });
+
+      // Spin up DaVinci client
+      VeniceProperties backendConfig = getDaVinciBackendConfig(ingestionIsolationEnabledInDaVinci);
+      MetricsRepository metricsRepository = new MetricsRepository();
+      try (CachingDaVinciClientFactory factory = new CachingDaVinciClientFactory(
+          d2Client,
+          VeniceRouterWrapper.CLUSTER_DISCOVERY_D2_SERVICE_NAME,
+          metricsRepository,
+          backendConfig)) {
+
+        DaVinciClient daVinciClient = factory.getGenericAvroClient(
+            storeName,
+            new DaVinciConfig().setIsolated(true).setStorageClass(StorageClass.MEMORY_BACKED_BY_DISK));
+        daVinciClient.start();
+        daVinciClient.subscribeAll().get(30, TimeUnit.SECONDS);
+
+        // Validate some entries
+        for (int i = 1; i <= 100; i++) {
+          String key = Integer.toString(i);
+          Object value = daVinciClient.get(key).get();
+          assertNotNull(value, "Key " + i + " should not be missing!");
+        }
+
+        // Run a bigger push and the push should fail
+        inputDir = getTempDataDirectory();
+        inputDirPath = "file://" + inputDir.getAbsolutePath();
+        writeSimpleAvroFileWithUserSchema(inputDir, true, 1000, 100000);
+        final Properties vpjPropertiesForV2 = defaultVPJProps(venice, inputDirPath, storeName);
+
+        VeniceException exception =
+            expectThrows(VeniceException.class, () -> runVPJ(vpjPropertiesForV2, 2, controllerClient));
+        assertTrue(exception.getMessage().contains("Found a failed partition replica in Da Vinci"));
+      }
+    }
+  }
+
+  @Test(timeOut = TEST_TIMEOUT, dataProviderClass = DataProviderUtils.class, dataProvider = "True-and-False")
+  public void testDaVinciMemoryLimitShouldFailLargeDataPushAndResumeHybridStore(
+      boolean ingestionIsolationEnabledInDaVinci) throws Exception {
+    String batchOnlyStoreName = Utils.getUniqueString("davinci_memory_limit_test_batch_only");
+    // Test a small push
+    File inputDir = getTempDataDirectory();
+    String inputDirPath = "file://" + inputDir.getAbsolutePath();
+    Schema recordSchema = writeSimpleAvroFileWithUserSchema(inputDir, true, 100, 100);
+    Properties vpjProperties = defaultVPJProps(venice, inputDirPath, batchOnlyStoreName);
+
+    try (ControllerClient controllerClient = createStoreForJob(venice.getClusterName(), recordSchema, vpjProperties);
+        AvroGenericStoreClient client = ClientFactory.getAndStartGenericAvroClient(
+            ClientConfig.defaultGenericClientConfig(batchOnlyStoreName).setVeniceURL(venice.getRandomRouterURL()))) {
+      venice.createMetaSystemStore(batchOnlyStoreName);
+      venice.createPushStatusSystemStore(batchOnlyStoreName);
+
+      // Make sure DaVinci push status system store is enabled
+      StoreResponse storeResponseForBatchOnlyStore = controllerClient.getStore(batchOnlyStoreName);
+      assertFalse(
+          storeResponseForBatchOnlyStore.isError(),
+          "Store response receives an error: " + storeResponseForBatchOnlyStore.getError());
+      assertTrue(storeResponseForBatchOnlyStore.getStore().isDaVinciPushStatusStoreEnabled());
+
+      // Create a hybrid store
+      String hybridStoreName = Utils.getUniqueString("davinci_memory_limit_test_hybrid");
+      String hybridKeySchemaStr = "\"string\"";
+      String hybridValueSchemaStr = "\"string\"";
+      NewStoreResponse storeCreationResponseForHybridStore =
+          controllerClient.createNewStore(hybridStoreName, "test_owner", hybridKeySchemaStr, hybridValueSchemaStr);
+      assertFalse(
+          storeCreationResponseForHybridStore.isError(),
+          "Received error when creating a store: " + storeCreationResponseForHybridStore.getError());
+      // Update it to hybrid
+      ControllerResponse updateStoreResponseForHybridStore = controllerClient.updateStore(
+          hybridStoreName,
+          new UpdateStoreQueryParams().setHybridRewindSeconds(60).setHybridOffsetLagThreshold(1));
+      assertFalse(
+          updateStoreResponseForHybridStore.isError(),
+          "Received error when converting a hybrid store: " + updateStoreResponseForHybridStore.getError());
+      venice.createMetaSystemStore(hybridStoreName);
+      venice.createPushStatusSystemStore(hybridStoreName);
+
+      ControllerResponse emptyPushForHybridStore =
+          controllerClient.sendEmptyPushAndWait(hybridStoreName, "test_hybrid_push_v1", 1024 * 1024 * 100l, 30 * 1000);
+      assertFalse(
+          emptyPushForHybridStore.isError(),
+          "Failed to empty push to the hybrid store: " + emptyPushForHybridStore.getError());
+
+      // Do an VPJ push to the batch-only store
+      runVPJ(vpjProperties, 1, controllerClient);
+
+      // Verify some records (note, records 1-100 have been pushed)
+      TestUtils.waitForNonDeterministicAssertion(10, TimeUnit.SECONDS, true, () -> {
+        try {
+          for (int i = 1; i <= 100; i++) {
+            String key = Integer.toString(i);
+            Object value = client.get(key).get();
+            assertNotNull(value, "Key " + i + " should not be missing!");
+          }
+        } catch (Exception e) {
+          throw new VeniceException(e);
+        }
+      });
+
+      // Spin up DaVinci client
+      VeniceProperties backendConfig = getDaVinciBackendConfig(ingestionIsolationEnabledInDaVinci);
+      MetricsRepository metricsRepository = new MetricsRepository();
+      try (CachingDaVinciClientFactory factory = new CachingDaVinciClientFactory(
+          d2Client,
+          VeniceRouterWrapper.CLUSTER_DISCOVERY_D2_SERVICE_NAME,
+          metricsRepository,
+          backendConfig)) {
+
+        DaVinciClient daVinciClientForBatchOnlyStore = factory.getGenericAvroClient(
+            batchOnlyStoreName,
+            new DaVinciConfig().setStorageClass(StorageClass.MEMORY_BACKED_BY_DISK));
+        daVinciClientForBatchOnlyStore.start();
+        daVinciClientForBatchOnlyStore.subscribeAll().get(30, TimeUnit.SECONDS);
+
+        // Validate some entries
+        for (int i = 1; i <= 100; i++) {
+          String key = Integer.toString(i);
+          Object value = daVinciClientForBatchOnlyStore.get(key).get();
+          assertNotNull(value, "Key " + i + " should not be missing!");
+        }
+
+        DaVinciClient daVinciClientForHybridStore = factory.getGenericAvroClient(
+            hybridStoreName,
+            new DaVinciConfig().setStorageClass(StorageClass.MEMORY_BACKED_BY_DISK));
+        daVinciClientForHybridStore.start();
+        daVinciClientForHybridStore.subscribeAll().get(30, TimeUnit.SECONDS);
+
+        // Write some records and verify
+        SystemProducer veniceProducer = getSamzaProducer(venice, hybridStoreName, Version.PushType.STREAM);
+
+        int hybridStoreKeyId = 0;
+        for (; hybridStoreKeyId <= 100; ++hybridStoreKeyId) {
+          sendCustomSizeStreamingRecord(veniceProducer, hybridStoreName, hybridStoreKeyId, 1000);
+        }
+
+        TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, true, () -> {
+          for (int i = 0; i <= 100; ++i) {
+            try {
+              assertNotNull(
+                  daVinciClientForHybridStore.get(Integer.toString(i)).get(),
+                  "Value for key: " + i + " shouldn't be null");
+            } catch (Exception e) {
+              throw new VeniceException(e);
+            }
+          }
+        });
+
+        // Run a bigger push and the push should fail
+        inputDir = getTempDataDirectory();
+        inputDirPath = "file://" + inputDir.getAbsolutePath();
+        writeSimpleAvroFileWithUserSchema(inputDir, true, 1000, 100000);
+        final Properties vpjPropertiesForV2 = defaultVPJProps(venice, inputDirPath, batchOnlyStoreName);
+
+        VeniceException exception =
+            expectThrows(VeniceException.class, () -> runVPJ(vpjPropertiesForV2, 2, controllerClient));
+        assertTrue(exception.getMessage().contains("Found a failed partition replica in Da Vinci"));
+
+        // Write more records to the hybrid store.
+        for (; hybridStoreKeyId < 200; ++hybridStoreKeyId) {
+          sendCustomSizeStreamingRecord(veniceProducer, hybridStoreName, hybridStoreKeyId, 1000);
+        }
+
+        TestUtils.waitForNonDeterministicAssertion(10, TimeUnit.SECONDS, true, () -> {
+          for (int i = 0; i < 200; ++i) {
+            try {
+              assertNotNull(
+                  daVinciClientForHybridStore.get(Integer.toString(i)).get(),
+                  "Value for key: " + i + " shouldn't be null");
+            } catch (Exception e) {
+              throw new VeniceException(e);
+            }
+          }
+        });
+      }
+    }
+  }
+
+  @Test(timeOut = TEST_TIMEOUT, dataProviderClass = DataProviderUtils.class, dataProvider = "True-and-False")
+  public void testHybridStoreHittingMemoryLimiterShouldResumeAfterFreeUpResource(// ) throws Exception {
+      boolean ingestionIsolationEnabledInDaVinci) throws Exception {
+    String batchOnlyStoreName = Utils.getUniqueString("davinci_memory_limit_test_batch_only");
+    // Test a medium push close to the memory limit
+    File inputDir = getTempDataDirectory();
+    String inputDirPath = "file://" + inputDir.getAbsolutePath();
+    Schema recordSchema = writeSimpleAvroFileWithUserSchema(inputDir, true, 190, 100000); // ~19MB
+    Properties vpjProperties = defaultVPJProps(venice, inputDirPath, batchOnlyStoreName);
+
+    try (ControllerClient controllerClient = createStoreForJob(venice.getClusterName(), recordSchema, vpjProperties);
+        AvroGenericStoreClient client = ClientFactory.getAndStartGenericAvroClient(
+            ClientConfig.defaultGenericClientConfig(batchOnlyStoreName).setVeniceURL(venice.getRandomRouterURL()))) {
+      venice.createMetaSystemStore(batchOnlyStoreName);
+      venice.createPushStatusSystemStore(batchOnlyStoreName);
+
+      // Make sure DaVinci push status system store is enabled
+      StoreResponse storeResponseForBatchOnlyStore = controllerClient.getStore(batchOnlyStoreName);
+      assertFalse(
+          storeResponseForBatchOnlyStore.isError(),
+          "Store response receives an error: " + storeResponseForBatchOnlyStore.getError());
+      assertTrue(storeResponseForBatchOnlyStore.getStore().isDaVinciPushStatusStoreEnabled());
+
+      // Create a hybrid store
+      String hybridStoreName = Utils.getUniqueString("davinci_memory_limit_test_hybrid");
+      String hybridKeySchemaStr = "\"string\"";
+      String hybridValueSchemaStr = "\"string\"";
+      NewStoreResponse storeCreationResponseForHybridStore =
+          controllerClient.createNewStore(hybridStoreName, "test_owner", hybridKeySchemaStr, hybridValueSchemaStr);
+      assertFalse(
+          storeCreationResponseForHybridStore.isError(),
+          "Received error when creating a store: " + storeCreationResponseForHybridStore.getError());
+      // Update it to hybrid
+      ControllerResponse updateStoreResponseForHybridStore = controllerClient.updateStore(
+          hybridStoreName,
+          new UpdateStoreQueryParams().setHybridRewindSeconds(60).setHybridOffsetLagThreshold(1));
+      assertFalse(
+          updateStoreResponseForHybridStore.isError(),
+          "Received error when converting a hybrid store: " + updateStoreResponseForHybridStore.getError());
+      venice.createMetaSystemStore(hybridStoreName);
+      venice.createPushStatusSystemStore(hybridStoreName);
+
+      ControllerResponse emptyPushForHybridStore =
+          controllerClient.sendEmptyPushAndWait(hybridStoreName, "test_hybrid_push_v1", 1024 * 1024 * 100l, 30 * 1000);
+      assertFalse(
+          emptyPushForHybridStore.isError(),
+          "Failed to empty push to the hybrid store: " + emptyPushForHybridStore.getError());
+
+      // Do an VPJ push to the batch-only store
+      runVPJ(vpjProperties, 1, controllerClient);
+
+      // Verify some records (note, records 1-150 have been pushed)
+      TestUtils.waitForNonDeterministicAssertion(10, TimeUnit.SECONDS, true, () -> {
+        try {
+          for (int i = 1; i <= 150; i++) {
+            String key = Integer.toString(i);
+            Object value = client.get(key).get();
+            assertNotNull(value, "Key " + i + " should not be missing!");
+          }
+        } catch (Exception e) {
+          throw new VeniceException(e);
+        }
+      });
+
+      // Spin up DaVinci client
+      VeniceProperties backendConfig = getDaVinciBackendConfig(ingestionIsolationEnabledInDaVinci);
+      MetricsRepository metricsRepository = new MetricsRepository();
+      try (CachingDaVinciClientFactory factory = new CachingDaVinciClientFactory(
+          d2Client,
+          VeniceRouterWrapper.CLUSTER_DISCOVERY_D2_SERVICE_NAME,
+          metricsRepository,
+          backendConfig)) {
+
+        DaVinciClient daVinciClientForBatchOnlyStore = factory.getGenericAvroClient(
+            batchOnlyStoreName,
+            new DaVinciConfig().setStorageClass(StorageClass.MEMORY_BACKED_BY_DISK));
+        daVinciClientForBatchOnlyStore.start();
+        daVinciClientForBatchOnlyStore.subscribeAll().get(30, TimeUnit.SECONDS);
+
+        // Validate some entries
+        for (int i = 1; i <= 150; i++) {
+          String key = Integer.toString(i);
+          Object value = daVinciClientForBatchOnlyStore.get(key).get();
+          assertNotNull(value, "Key " + i + " should not be missing!");
+        }
+
+        DaVinciClient daVinciClientForHybridStore = factory.getGenericAvroClient(
+            hybridStoreName,
+            new DaVinciConfig().setStorageClass(StorageClass.MEMORY_BACKED_BY_DISK));
+        daVinciClientForHybridStore.start();
+        daVinciClientForHybridStore.subscribeAll().get(30, TimeUnit.SECONDS);
+
+        // Write some large records and verify
+        SystemProducer veniceProducer = getSamzaProducer(venice, hybridStoreName, Version.PushType.STREAM);
+
+        int hybridStoreKeyId = 0;
+        for (; hybridStoreKeyId < 100; ++hybridStoreKeyId) {
+          sendCustomSizeStreamingRecord(veniceProducer, hybridStoreName, hybridStoreKeyId, 100000);
+        }
+
+        // Hybrid store ingestion should be stuck and verify the metrics
+        TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, true, () -> {
+          assertEquals(
+              metricsRepository.metrics().get("." + hybridStoreName + "--stuck_ingestion.Gauge").value(),
+              1.0d);
+          assertEquals(metricsRepository.metrics().get(".total--stuck_ingestion.Gauge").value(), 1.0d);
+          assertEquals(
+              metricsRepository.metrics().get("." + batchOnlyStoreName + "--stuck_ingestion.Gauge").value(),
+              0.0d);
+        });
+
+        // DaVinci unsubscribes the batch only store
+        daVinciClientForBatchOnlyStore.unsubscribeAll();
+
+        // After removing the batch-only store, the hybrid store should resume
+        TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, true, () -> {
+          assertEquals(
+              metricsRepository.metrics().get("." + hybridStoreName + "--stuck_ingestion.Gauge").value(),
+              0.0d);
+          assertEquals(metricsRepository.metrics().get(".total--stuck_ingestion.Gauge").value(), 0.0d);
+          assertEquals(
+              metricsRepository.metrics().get("." + batchOnlyStoreName + "--stuck_ingestion.Gauge").value(),
+              0.0d);
+        });
+
+        // Ingestion of hybrid store current version should resume
+        TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, true, () -> {
+          for (int i = 0; i < 100; ++i) {
+            try {
+              assertNotNull(
+                  daVinciClientForHybridStore.get(Integer.toString(i)).get(),
+                  "Value for key: " + i + " shouldn't be null");
+            } catch (Exception e) {
+              throw new VeniceException(e);
+            }
+          }
+        });
+      }
+    }
+  }
+}

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/integration/utils/VeniceClusterWrapper.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/integration/utils/VeniceClusterWrapper.java
@@ -864,6 +864,12 @@ public class VeniceClusterWrapper extends ProcessWrapper {
     waitVersion(metaSystemStoreName, 1);
   }
 
+  public void createPushStatusSystemStore(String storeName) {
+    String pushStatusSystemStoreName = VeniceSystemStoreType.DAVINCI_PUSH_STATUS_STORE.getSystemStoreName(storeName);
+    assertCommand(controllerClient.get().emptyPush(pushStatusSystemStoreName, "createPushStatusSystemStore", 1L));
+    waitVersion(pushStatusSystemStoreName, 1);
+  }
+
   public static final String DEFAULT_KEY_SCHEMA = "\"int\"";
   public static final String DEFAULT_VALUE_SCHEMA = "\"int\"";
 

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerConfig.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerConfig.java
@@ -64,6 +64,7 @@ import static com.linkedin.venice.ConfigKeys.NATIVE_REPLICATION_FABRIC_WHITELIST
 import static com.linkedin.venice.ConfigKeys.NATIVE_REPLICATION_SOURCE_FABRIC;
 import static com.linkedin.venice.ConfigKeys.OFFLINE_PUSH_MONITOR_DAVINCI_PUSH_STATUS_ENABLED;
 import static com.linkedin.venice.ConfigKeys.OFFLINE_PUSH_MONITOR_DAVINCI_PUSH_STATUS_SCAN_INTERVAL_IN_SECONDS;
+import static com.linkedin.venice.ConfigKeys.OFFLINE_PUSH_MONITOR_DAVINCI_PUSH_STATUS_SCAN_NO_DAVINCI_STATUS_REPORT_RETRY_MAX_ATTEMPTS;
 import static com.linkedin.venice.ConfigKeys.OFFLINE_PUSH_MONITOR_DAVINCI_PUSH_STATUS_SCAN_THREAD_NUMBER;
 import static com.linkedin.venice.ConfigKeys.PARENT_CONTROLLER_MAX_ERRORED_TOPIC_NUM_TO_KEEP;
 import static com.linkedin.venice.ConfigKeys.PARENT_CONTROLLER_WAITING_TIME_FOR_CONSUMPTION_MS;
@@ -195,6 +196,8 @@ public class VeniceControllerConfig extends VeniceControllerClusterConfig {
   private final int offlinePushMonitorDaVinciPushStatusScanIntervalInSeconds;
 
   private final int offlinePushMonitorDaVinciPushStatusScanThreadNumber;
+
+  private final int offlinePushMonitorDaVinciPushStatusScanNoDaVinciStatusReportRetryMaxAttempt;
 
   private final boolean zkSharedDaVinciPushStatusSystemSchemaStoreAutoCreationEnabled;
 
@@ -427,6 +430,8 @@ public class VeniceControllerConfig extends VeniceControllerClusterConfig {
         props.getInt(OFFLINE_PUSH_MONITOR_DAVINCI_PUSH_STATUS_SCAN_INTERVAL_IN_SECONDS, 30);
     this.offlinePushMonitorDaVinciPushStatusScanThreadNumber =
         props.getInt(OFFLINE_PUSH_MONITOR_DAVINCI_PUSH_STATUS_SCAN_THREAD_NUMBER, 4);
+    this.offlinePushMonitorDaVinciPushStatusScanNoDaVinciStatusReportRetryMaxAttempt =
+        props.getInt(OFFLINE_PUSH_MONITOR_DAVINCI_PUSH_STATUS_SCAN_NO_DAVINCI_STATUS_REPORT_RETRY_MAX_ATTEMPTS, 0);
 
     this.zkSharedDaVinciPushStatusSystemSchemaStoreAutoCreationEnabled =
         props.getBoolean(CONTROLLER_ZK_SHARED_DAVINCI_PUSH_STATUS_SYSTEM_SCHEMA_STORE_AUTO_CREATION_ENABLED, false);
@@ -747,6 +752,10 @@ public class VeniceControllerConfig extends VeniceControllerClusterConfig {
 
   public int getOfflinePushMonitorDaVinciPushStatusScanThreadNumber() {
     return offlinePushMonitorDaVinciPushStatusScanThreadNumber;
+  }
+
+  public int getOfflinePushMonitorDaVinciPushStatusScanNoDaVinciStatusReportRetryMaxAttempt() {
+    return offlinePushMonitorDaVinciPushStatusScanNoDaVinciStatusReportRetryMaxAttempt;
   }
 
   public boolean isZkSharedDaVinciPushStatusSystemSchemaStoreAutoCreationEnabled() {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/AbstractPushMonitor.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/AbstractPushMonitor.java
@@ -122,7 +122,8 @@ public abstract class AbstractPushMonitor
         (topic, details) -> handleErrorPush(getOfflinePush(topic), details),
         controllerConfig.isOfflinePushMonitorDaVinciPushStatusEnabled(),
         controllerConfig.getOfflinePushMonitorDaVinciPushStatusScanIntervalInSeconds(),
-        controllerConfig.getOfflinePushMonitorDaVinciPushStatusScanThreadNumber());
+        controllerConfig.getOfflinePushMonitorDaVinciPushStatusScanThreadNumber(),
+        controllerConfig.getOfflinePushMonitorDaVinciPushStatusScanNoDaVinciStatusReportRetryMaxAttempt());
     this.isOfflinePushMonitorDaVinciPushStatusEnabled = controllerConfig.isOfflinePushMonitorDaVinciPushStatusEnabled();
     pushStatusCollector.start();
   }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/ExecutionStatusWithDetails.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/ExecutionStatusWithDetails.java
@@ -3,10 +3,12 @@ package com.linkedin.venice.pushmonitor;
 public class ExecutionStatusWithDetails {
   private final ExecutionStatus status;
   private final String details;
+  private final boolean noDaVinciStatusReport;
 
-  public ExecutionStatusWithDetails(ExecutionStatus status, String details) {
+  public ExecutionStatusWithDetails(ExecutionStatus status, String details, boolean noDaVinciStatusReport) {
     this.status = status;
     this.details = details;
+    this.noDaVinciStatusReport = noDaVinciStatusReport;
   }
 
   public ExecutionStatus getStatus() {
@@ -15,5 +17,9 @@ public class ExecutionStatusWithDetails {
 
   public String getDetails() {
     return details;
+  }
+
+  public boolean isNoDaVinciStatusReport() {
+    return noDaVinciStatusReport;
   }
 }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/PushMonitorUtils.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/PushMonitorUtils.java
@@ -112,15 +112,16 @@ public class PushMonitorUtils {
           .append(totalReplicaCount);
     }
     String statusDetail = statusDetailStringBuilder.toString();
+    boolean noDaVinciStatusReported = totalReplicaCount == 0;
     if (completedPartitions == partitionCount) {
-      return new ExecutionStatusWithDetails(completeStatus, statusDetail);
+      return new ExecutionStatusWithDetails(completeStatus, statusDetail, noDaVinciStatusReported);
     }
     if (allMiddleStatusReceived) {
-      return new ExecutionStatusWithDetails(middleStatus, statusDetail);
+      return new ExecutionStatusWithDetails(middleStatus, statusDetail, noDaVinciStatusReported);
     }
     if (erroredReplica.isPresent()) {
-      return new ExecutionStatusWithDetails(ExecutionStatus.ERROR, statusDetail);
+      return new ExecutionStatusWithDetails(ExecutionStatus.ERROR, statusDetail, noDaVinciStatusReported);
     }
-    return new ExecutionStatusWithDetails(ExecutionStatus.STARTED, statusDetail);
+    return new ExecutionStatusWithDetails(ExecutionStatus.STARTED, statusDetail, noDaVinciStatusReported);
   }
 }

--- a/services/venice-controller/src/test/java/com/linkedin/venice/pushmonitor/ExecutionStatusWithDetailsTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/pushmonitor/ExecutionStatusWithDetailsTest.java
@@ -8,7 +8,7 @@ public class ExecutionStatusWithDetailsTest {
   @Test
   public void testExecutionStatusWithDetailsGetter() {
     ExecutionStatusWithDetails executionStatusWithDetails =
-        new ExecutionStatusWithDetails(ExecutionStatus.ERROR, "dummyString");
+        new ExecutionStatusWithDetails(ExecutionStatus.ERROR, "dummyString", false);
     Assert.assertEquals(executionStatusWithDetails.getStatus(), ExecutionStatus.ERROR);
     Assert.assertEquals(executionStatusWithDetails.getDetails(), "dummyString");
   }


### PR DESCRIPTION
When DaVinci is using `MEMORY_BACKED_BY_DISK` mode, the application could encounter OOM issue when configuring mlockall (pre-allocate/load all the data when invoking mmap) with a big data push (required memory exceeds RAM capacity) regardless of Ingestion Isolation.

To mitigate this risk triggered by unexpected large data pushes, this code change introduces two configs:
 /*
   * The memory up-limit for the ingestion path while using RocksDB Plaintable format.
   * Currently, this option is only meaningful for DaVinci use cases. */ public static final String INGESTION_MEMORY_LIMIT = "ingestion.memory.limit";

  /**
   * Whether the ingestion is using mlock or not.
   * Currently, this option is only meaningful for DaVinci use cases. *
   * Actually, this config option is being actively used, and it is a placeholder for the future optimization.
   * The memory limit logic implemented today is assuming mlock usage, and to make it backward compatible when
   * we want to do more optimization for non-mlock usage, we will ask the mlock user to enable this flag. */ public static final String INGESTION_MLOCK_ENABLED = "ingestion.mlock.enabled";

Internally it is mainly using SSTFileManager to control max size of all SST files: https://github.com/facebook/rocksdb/wiki/Managing-Disk-Space-Utilization There is a shortcoming with this feature since it doesn't check sst file size when opening up an existing database, so this code change backfills this feature gap.

Actions when hitting the memory limit:
1. For the new pushes (future versions): DaVinci ingestion will fail the new push and report error to the push job status system store, and the push job should fail with such error.

2. For the current versions. DaVinci will try to kill the ingestions belonging to non-current versions, and once there are spaces reclaimed, the ingestion of current versions will resume.

Current version ingestion resumption is still a best effort, and there could be unknown corner cases, which current logic can't handle, and the following metric will notify the DaVinci users to take more actions if it lasts for a long time, such as restarting the instance or reduce the total number of DaVinci stores being used.

This code change exposes a metric to monitor the ingestion status:
--stuck_ingestion.Gauge : store-level and aggregate

In this code change, I also discovered some inproper implementations in RocksDB SSTFileManager regarding enforcing size limit:
1. SSTFileManager doesn't enforce the size limit when opening up an existing database.
2. SSTFileManager still tracks the sst files event after closing the RocksDB and RocksDB destroy function will completely remove the tracking (maybe this is expected?)
3. An existing RocksDB can't resume even there are more space left after removing some other database. To workaround this issue, this code change will abandon the in-memory memtable by reopening the database and re-consume from the previous checkpoint.

<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->



## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
unit test/integration test

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [x] Yes. Make sure to explain your proposed changes and call out the behavior change.
Please refer to the above section to find new configs.

This PR depends on https://github.com/linkedin/venice/pull/437