### PR TITLE
[router][producer] A couple of fixes related to SSL for online producer

### DIFF
--- a/clients/venice-producer/src/main/java/com/linkedin/venice/producer/AbstractVeniceProducer.java
+++ b/clients/venice-producer/src/main/java/com/linkedin/venice/producer/AbstractVeniceProducer.java
@@ -2,8 +2,9 @@ package com.linkedin.venice.producer;
 
 import static com.linkedin.venice.ConfigKeys.CLIENT_PRODUCER_THREAD_NUM;
 import static com.linkedin.venice.ConfigKeys.KAFKA_BOOTSTRAP_SERVERS;
+import static com.linkedin.venice.ConfigKeys.KAFKA_OVER_SSL;
+import static com.linkedin.venice.ConfigKeys.KAFKA_SECURITY_PROTOCOL;
 import static com.linkedin.venice.ConfigKeys.SSL_KAFKA_BOOTSTRAP_SERVERS;
-import static com.linkedin.venice.ConfigKeys.SSL_TO_KAFKA;
 import static com.linkedin.venice.writer.VeniceWriter.APP_DEFAULT_LOGICAL_TS;
 
 import com.linkedin.venice.SSLConfig;
@@ -112,8 +113,9 @@ public abstract class AbstractVeniceProducer<K, V> implements VeniceProducer<K, 
     Properties writerProps = new Properties();
 
     if (versionCreationResponse.isEnableSSL()) {
-      writerProps.put(SSL_TO_KAFKA, "true");
+      writerProps.put(KAFKA_OVER_SSL, "true");
       writerProps.put(SSL_KAFKA_BOOTSTRAP_SERVERS, versionCreationResponse.getKafkaBootstrapServers());
+      writerProps.put(KAFKA_SECURITY_PROTOCOL, producerConfigs.getString(KAFKA_SECURITY_PROTOCOL));
       writerProps.putAll(new SSLConfig(producerConfigs).getKafkaSSLConfig());
     } else {
       writerProps.put(KAFKA_BOOTSTRAP_SERVERS, versionCreationResponse.getKafkaBootstrapServers());
@@ -412,9 +414,11 @@ public abstract class AbstractVeniceProducer<K, V> implements VeniceProducer<K, 
   @Override
   public void close() throws IOException {
     closed = true;
-    producerExecutor.shutdownNow();
+    producerExecutor.shutdown();
     try {
-      producerExecutor.awaitTermination(60, TimeUnit.SECONDS);
+      if (!producerExecutor.awaitTermination(60, TimeUnit.SECONDS)) {
+        producerExecutor.shutdownNow();
+      }
     } catch (InterruptedException e) {
       LOGGER.warn("Caught InterruptedException while closing the Venice producer ExecutorService", e);
     }

--- a/clients/venice-producer/src/main/java/com/linkedin/venice/producer/AbstractVeniceProducer.java
+++ b/clients/venice-producer/src/main/java/com/linkedin/venice/producer/AbstractVeniceProducer.java
@@ -414,11 +414,9 @@ public abstract class AbstractVeniceProducer<K, V> implements VeniceProducer<K, 
   @Override
   public void close() throws IOException {
     closed = true;
-    producerExecutor.shutdown();
+    producerExecutor.shutdownNow();
     try {
-      if (!producerExecutor.awaitTermination(60, TimeUnit.SECONDS)) {
-        producerExecutor.shutdownNow();
-      }
+      producerExecutor.awaitTermination(60, TimeUnit.SECONDS);
     } catch (InterruptedException e) {
       LOGGER.warn("Caught InterruptedException while closing the Venice producer ExecutorService", e);
     }

--- a/clients/venice-producer/src/main/java/com/linkedin/venice/producer/online/OnlineProducerFactory.java
+++ b/clients/venice-producer/src/main/java/com/linkedin/venice/producer/online/OnlineProducerFactory.java
@@ -8,6 +8,7 @@ import com.linkedin.venice.kafka.protocol.KafkaMessageEnvelope;
 import com.linkedin.venice.schema.SchemaReader;
 import com.linkedin.venice.serialization.avro.AvroProtocolDefinition;
 import com.linkedin.venice.service.ICProvider;
+import com.linkedin.venice.utils.Utils;
 import com.linkedin.venice.utils.VeniceProperties;
 
 
@@ -28,11 +29,16 @@ public class OnlineProducerFactory {
         .setSpecificValueClass(KafkaMessageEnvelope.class);
 
     SchemaReader kmeSchemaReader = ClientFactory.getSchemaReader(kmeClientConfig, icProvider);
-    return new OnlineVeniceProducer<>(
+    OnlineVeniceProducer producer = new OnlineVeniceProducer<>(
         (InternalAvroStoreClient<K, V>) storeClient,
         kmeSchemaReader,
         producerConfigs,
         storeClientConfig.getMetricsRepository(),
         icProvider);
+
+    // KME SchemaReader is not needed after constructor. We can close it now.
+    Utils.closeQuietlyWithErrorLogged(kmeSchemaReader);
+
+    return producer;
   }
 }

--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/schema/RouterBackedSchemaReader.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/schema/RouterBackedSchemaReader.java
@@ -238,13 +238,10 @@ public class RouterBackedSchemaReader implements SchemaReader {
   @Override
   public void close() throws IOException {
     schemaRefreshFuture.cancel(true);
-    refreshSchemaExecutor.shutdown();
+    refreshSchemaExecutor.shutdownNow();
     try {
-      if (!refreshSchemaExecutor.awaitTermination(60, TimeUnit.SECONDS)) {
-        refreshSchemaExecutor.shutdownNow();
-      }
+      refreshSchemaExecutor.awaitTermination(60, TimeUnit.SECONDS);
     } catch (InterruptedException e) {
-      refreshSchemaExecutor.shutdownNow();
       LOGGER.warn("Caught InterruptedException while closing the Venice producer ExecutorService", e);
     }
     if (!externalClient) {
@@ -445,6 +442,7 @@ public class RouterBackedSchemaReader implements SchemaReader {
       if (e instanceof InterruptedException) {
         throw e;
       }
+
       throw new VeniceClientException(
           "Got exception while trying to fetch all value schemas. " + getExceptionDetails(requestPath),
           e);

--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/schema/RouterBackedSchemaReader.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/schema/RouterBackedSchemaReader.java
@@ -16,6 +16,7 @@ import com.linkedin.venice.schema.SchemaReader;
 import com.linkedin.venice.schema.writecompute.DerivedSchemaEntry;
 import com.linkedin.venice.service.ICProvider;
 import com.linkedin.venice.utils.AvroSchemaUtils;
+import com.linkedin.venice.utils.DaemonThreadFactory;
 import com.linkedin.venice.utils.ObjectMapperFactory;
 import com.linkedin.venice.utils.RetryUtils;
 import com.linkedin.venice.utils.concurrent.ConcurrencyUtils;
@@ -69,7 +70,6 @@ public class RouterBackedSchemaReader implements SchemaReader {
    * schema are the latest value and update schemas.
    */
   private final Predicate<Schema> preferredSchemaFilter;
-  private final Duration valueSchemaRefreshPeriod;
   private final ScheduledExecutorService refreshSchemaExecutor;
   private final ScheduledFuture schemaRefreshFuture;
   private final ICProvider icProvider;
@@ -133,10 +133,9 @@ public class RouterBackedSchemaReader implements SchemaReader {
     this.readerSchema = readerSchema;
     this.preferredSchemaFilter = preferredSchemaFilter.orElse(schema -> false);
     readerSchema.ifPresent(AvroSchemaUtils::validateAvroSchemaStr);
-    this.valueSchemaRefreshPeriod = valueSchemaRefreshPeriod;
     this.icProvider = icProvider;
 
-    this.refreshSchemaExecutor = Executors.newSingleThreadScheduledExecutor();
+    this.refreshSchemaExecutor = Executors.newSingleThreadScheduledExecutor(new DaemonThreadFactory("schema-refresh"));
     schemaRefreshFuture = refreshSchemaExecutor.scheduleAtFixedRate(
         () -> this.ensureSchemasAreRefreshed(loadUpdateSchemas.get(), true),
         valueSchemaRefreshPeriod.getSeconds(),
@@ -239,10 +238,13 @@ public class RouterBackedSchemaReader implements SchemaReader {
   @Override
   public void close() throws IOException {
     schemaRefreshFuture.cancel(true);
-    refreshSchemaExecutor.shutdownNow();
+    refreshSchemaExecutor.shutdown();
     try {
-      refreshSchemaExecutor.awaitTermination(60, TimeUnit.SECONDS);
+      if (!refreshSchemaExecutor.awaitTermination(60, TimeUnit.SECONDS)) {
+        refreshSchemaExecutor.shutdownNow();
+      }
     } catch (InterruptedException e) {
+      refreshSchemaExecutor.shutdownNow();
       LOGGER.warn("Caught InterruptedException while closing the Venice producer ExecutorService", e);
     }
     if (!externalClient) {
@@ -440,6 +442,9 @@ public class RouterBackedSchemaReader implements SchemaReader {
         }
       }
     } catch (Exception e) {
+      if (e instanceof InterruptedException) {
+        throw e;
+      }
       throw new VeniceClientException(
           "Got exception while trying to fetch all value schemas. " + getExceptionDetails(requestPath),
           e);
@@ -463,6 +468,10 @@ public class RouterBackedSchemaReader implements SchemaReader {
             .computeIfAbsent(valueSchemaId, id -> new DerivedSchemaEntry(valueSchemaId, updateSchemaId, schemaStr));
       }
     } catch (Exception e) {
+      if (e instanceof InterruptedException) {
+        throw e;
+      }
+
       throw new VeniceClientException(
           "Got exception while trying to fetch all update schemas. " + getExceptionDetails(requestPath),
           e);

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/schema/vson/VsonAvroSchemaAdapter.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/schema/vson/VsonAvroSchemaAdapter.java
@@ -116,7 +116,7 @@ public class VsonAvroSchemaAdapter extends AbstractVsonSchemaAdapter<Schema> {
 
   public static Schema stripFromUnion(Schema schema) {
     if (schema.getType() != Schema.Type.UNION) {
-      throw new IllegalArgumentException("Schema: " + schema.toString() + "has to be Union");
+      throw new IllegalArgumentException("Schema: " + schema + " has to be Union");
     }
 
     List<Schema> subtypes = schema.getTypes();

--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -394,7 +394,14 @@ public class ConfigKeys {
   public static final String SERVER_NETTY_GRACEFUL_SHUTDOWN_PERIOD_SECONDS =
       "server.netty.graceful.shutdown.period.seconds";
   public static final String SERVER_NETTY_WORKER_THREADS = "server.netty.worker.threads";
-  public static final String SSL_TO_KAFKA = ApacheKafkaProducerConfig.SSL_TO_KAFKA;
+
+  /**
+   * This config key is a misspelling. It is now considered deprecated.
+   * @deprecated Use {@link KAFKA_OVER_SSL}
+   */
+  @Deprecated
+  public static final String SSL_TO_KAFKA_LEGACY = ApacheKafkaProducerConfig.SSL_TO_KAFKA_LEGACY;
+  public static final String KAFKA_OVER_SSL = ApacheKafkaProducerConfig.KAFKA_OVER_SSL;
   public static final String SERVER_COMPUTE_THREAD_NUM = "server.compute.thread.num";
   public static final String HYBRID_QUOTA_ENFORCEMENT_ENABLED = "server.hybrid.quota.enforcement.enabled";
   public static final String SERVER_DATABASE_MEMORY_STATS_ENABLED = "server.database.memory.stats.enabled";

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/adapter/kafka/producer/ApacheKafkaProducerConfig.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/adapter/kafka/producer/ApacheKafkaProducerConfig.java
@@ -35,9 +35,14 @@ public class ApacheKafkaProducerConfig {
   public static final String KAFKA_PRODUCER_REQUEST_TIMEOUT_MS =
       KAFKA_CONFIG_PREFIX + ProducerConfig.REQUEST_TIMEOUT_MS_CONFIG;
   public static final String SSL_KAFKA_BOOTSTRAP_SERVERS = "ssl." + KAFKA_BOOTSTRAP_SERVERS;
-  // N.B. do not attempt to change spelling, "kakfa", without carefully replacing all instances in use and some
-  // of them may be external to this repo
-  public static final String SSL_TO_KAFKA = "ssl.to.kakfa";
+  /**
+   * N.B. do not attempt to change spelling, "kakfa", without carefully replacing all instances in use and some of them
+   * may be external to this repo
+   * @deprecated Use {@link KAFKA_OVER_SSL}
+   */
+  @Deprecated
+  public static final String SSL_TO_KAFKA_LEGACY = "ssl.to.kakfa";
+  public static final String KAFKA_OVER_SSL = KAFKA_CONFIG_PREFIX + "over.ssl";
 
   private final Properties producerProperties;
 
@@ -72,7 +77,7 @@ public class ApacheKafkaProducerConfig {
   }
 
   public static String getPubsubBrokerAddress(VeniceProperties properties) {
-    if (Boolean.parseBoolean(properties.getString(SSL_TO_KAFKA, "false"))) {
+    if (Boolean.parseBoolean(properties.getStringWithAlternative(SSL_TO_KAFKA_LEGACY, KAFKA_OVER_SSL, "false"))) {
       checkProperty(properties, SSL_KAFKA_BOOTSTRAP_SERVERS);
       return properties.getString(SSL_KAFKA_BOOTSTRAP_SERVERS);
     }

--- a/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/adapter/kafka/consumer/ApacheKafkaConsumerConfigTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/adapter/kafka/consumer/ApacheKafkaConsumerConfigTest.java
@@ -2,7 +2,7 @@ package com.linkedin.venice.pubsub.adapter.kafka.consumer;
 
 import static com.linkedin.venice.pubsub.adapter.kafka.producer.ApacheKafkaProducerConfig.KAFKA_BOOTSTRAP_SERVERS;
 import static com.linkedin.venice.pubsub.adapter.kafka.producer.ApacheKafkaProducerConfig.SSL_KAFKA_BOOTSTRAP_SERVERS;
-import static com.linkedin.venice.pubsub.adapter.kafka.producer.ApacheKafkaProducerConfig.SSL_TO_KAFKA;
+import static com.linkedin.venice.pubsub.adapter.kafka.producer.ApacheKafkaProducerConfig.SSL_TO_KAFKA_LEGACY;
 import static org.testng.Assert.assertEquals;
 
 import com.linkedin.venice.pubsub.adapter.kafka.producer.ApacheKafkaProducerConfig;
@@ -20,7 +20,7 @@ public class ApacheKafkaConsumerConfigTest {
   @Test
   public void testSaslConfiguration() {
     Properties props = new Properties();
-    props.put(SSL_TO_KAFKA, true);
+    props.put(SSL_TO_KAFKA_LEGACY, true);
     props.put(KAFKA_BOOTSTRAP_SERVERS, KAFKA_BROKER_ADDR);
     props.put(SSL_KAFKA_BOOTSTRAP_SERVERS, "ssl.kafka.broker.com:8182");
     props.put("kafka.sasl.jaas.config", SASL_JAAS_CONFIG);

--- a/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/adapter/kafka/producer/ApacheKafkaProducerConfigTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/adapter/kafka/producer/ApacheKafkaProducerConfigTest.java
@@ -4,7 +4,7 @@ import static com.linkedin.venice.pubsub.adapter.kafka.producer.ApacheKafkaProdu
 import static com.linkedin.venice.pubsub.adapter.kafka.producer.ApacheKafkaProducerConfig.KAFKA_KEY_SERIALIZER;
 import static com.linkedin.venice.pubsub.adapter.kafka.producer.ApacheKafkaProducerConfig.KAFKA_VALUE_SERIALIZER;
 import static com.linkedin.venice.pubsub.adapter.kafka.producer.ApacheKafkaProducerConfig.SSL_KAFKA_BOOTSTRAP_SERVERS;
-import static com.linkedin.venice.pubsub.adapter.kafka.producer.ApacheKafkaProducerConfig.SSL_TO_KAFKA;
+import static com.linkedin.venice.pubsub.adapter.kafka.producer.ApacheKafkaProducerConfig.SSL_TO_KAFKA_LEGACY;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
@@ -85,7 +85,7 @@ public class ApacheKafkaProducerConfigTest {
   public void testGetBrokerAddressReturnsSslAddrIfKafkaSslIsEnabled() {
     // broker address from props should be used
     Properties props = new Properties();
-    props.put(SSL_TO_KAFKA, true);
+    props.put(SSL_TO_KAFKA_LEGACY, true);
     props.put(KAFKA_BOOTSTRAP_SERVERS, KAFKA_BROKER_ADDR);
     props.put(SSL_KAFKA_BOOTSTRAP_SERVERS, "ssl.kafka.broker.com:8182");
     assertEquals(new ApacheKafkaProducerConfig(props).getBrokerAddress(), "ssl.kafka.broker.com:8182");
@@ -95,7 +95,7 @@ public class ApacheKafkaProducerConfigTest {
   public void testSaslConfiguration() {
     // broker address from props should be used
     Properties props = new Properties();
-    props.put(SSL_TO_KAFKA, true);
+    props.put(SSL_TO_KAFKA_LEGACY, true);
     props.put(KAFKA_BOOTSTRAP_SERVERS, KAFKA_BROKER_ADDR);
     props.put(SSL_KAFKA_BOOTSTRAP_SERVERS, "ssl.kafka.broker.com:8182");
     props.put("kafka.sasl.jaas.config", SASL_JAAS_CONFIG);

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/controller/TestEnablingSSLPushInVeniceHelixAdminWithIsolatedEnvironment.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/controller/TestEnablingSSLPushInVeniceHelixAdminWithIsolatedEnvironment.java
@@ -34,7 +34,7 @@ public class TestEnablingSSLPushInVeniceHelixAdminWithIsolatedEnvironment extend
   @Override
   protected Properties getControllerProperties(String clusterName) throws IOException {
     Properties properties = super.getControllerProperties(clusterName);
-    properties.put(ConfigKeys.SSL_TO_KAFKA, true);
+    properties.put(ConfigKeys.SSL_TO_KAFKA_LEGACY, true);
     properties.put(ConfigKeys.SSL_KAFKA_BOOTSTRAP_SERVERS, pubSubBrokerWrapper.getSSLAddress());
     properties.put(ConfigKeys.ENABLE_OFFLINE_PUSH_SSL_ALLOWLIST, true);
     properties.put(ConfigKeys.ENABLE_HYBRID_PUSH_SSL_ALLOWLIST, false);

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestHybrid.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestHybrid.java
@@ -10,7 +10,7 @@ import static com.linkedin.venice.ConfigKeys.SERVER_DATABASE_SYNC_BYTES_INTERNAL
 import static com.linkedin.venice.ConfigKeys.SERVER_DEDICATED_DRAINER_FOR_SORTED_INPUT_ENABLED;
 import static com.linkedin.venice.ConfigKeys.SERVER_PROMOTION_TO_LEADER_REPLICA_DELAY_SECONDS;
 import static com.linkedin.venice.ConfigKeys.SERVER_SHARED_CONSUMER_ASSIGNMENT_STRATEGY;
-import static com.linkedin.venice.ConfigKeys.SSL_TO_KAFKA;
+import static com.linkedin.venice.ConfigKeys.SSL_TO_KAFKA_LEGACY;
 import static com.linkedin.venice.hadoop.VenicePushJob.DEFER_VERSION_SWAP;
 import static com.linkedin.venice.integration.utils.VeniceClusterWrapper.DEFAULT_KEY_SCHEMA;
 import static com.linkedin.venice.integration.utils.VeniceClusterWrapper.DEFAULT_VALUE_SCHEMA;
@@ -1938,7 +1938,7 @@ public class TestHybrid {
     serverProperties.setProperty(SERVER_DATABASE_CHECKSUM_VERIFICATION_ENABLED, "true");
     serverProperties.setProperty(SERVER_DATABASE_SYNC_BYTES_INTERNAL_FOR_DEFERRED_WRITE_MODE, "300");
 
-    serverProperties.setProperty(SSL_TO_KAFKA, "false");
+    serverProperties.setProperty(SSL_TO_KAFKA_LEGACY, "false");
     serverProperties.setProperty(SERVER_CONSUMER_POOL_SIZE_PER_KAFKA_CLUSTER, "3");
     serverProperties.setProperty(SERVER_DEDICATED_DRAINER_FOR_SORTED_INPUT_ENABLED, "true");
 

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestHybridQuota.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestHybridQuota.java
@@ -5,7 +5,7 @@ import static com.linkedin.venice.ConfigKeys.HYBRID_QUOTA_ENFORCEMENT_ENABLED;
 import static com.linkedin.venice.ConfigKeys.PERSISTENCE_TYPE;
 import static com.linkedin.venice.ConfigKeys.SERVER_CONSUMER_POOL_SIZE_PER_KAFKA_CLUSTER;
 import static com.linkedin.venice.ConfigKeys.SERVER_PROMOTION_TO_LEADER_REPLICA_DELAY_SECONDS;
-import static com.linkedin.venice.ConfigKeys.SSL_TO_KAFKA;
+import static com.linkedin.venice.ConfigKeys.SSL_TO_KAFKA_LEGACY;
 import static com.linkedin.venice.kafka.TopicManager.DEFAULT_KAFKA_OPERATION_TIMEOUT_MS;
 import static com.linkedin.venice.utils.IntegrationTestPushUtils.createStoreForJob;
 import static com.linkedin.venice.utils.IntegrationTestPushUtils.defaultVPJProps;
@@ -81,7 +81,7 @@ public class TestHybridQuota {
     sharedVenice.addVeniceRouter(routerProperties);
     // Added a server with shared consumer enabled.
     Properties serverPropertiesWithSharedConsumer = new Properties();
-    serverPropertiesWithSharedConsumer.setProperty(SSL_TO_KAFKA, "false");
+    serverPropertiesWithSharedConsumer.setProperty(SSL_TO_KAFKA_LEGACY, "false");
     extraProperties.put(HELIX_HYBRID_STORE_QUOTA_ENABLED, true);
     extraProperties.put(HYBRID_QUOTA_ENFORCEMENT_ENABLED, true);
     extraProperties.setProperty(SERVER_CONSUMER_POOL_SIZE_PER_KAFKA_CLUSTER, "3");

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/integration/utils/VeniceControllerWrapper.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/integration/utils/VeniceControllerWrapper.java
@@ -37,7 +37,7 @@ import static com.linkedin.venice.ConfigKeys.PARENT_KAFKA_CLUSTER_FABRIC_LIST;
 import static com.linkedin.venice.ConfigKeys.PERSISTENCE_TYPE;
 import static com.linkedin.venice.ConfigKeys.PUSH_STATUS_STORE_ENABLED;
 import static com.linkedin.venice.ConfigKeys.SSL_KAFKA_BOOTSTRAP_SERVERS;
-import static com.linkedin.venice.ConfigKeys.SSL_TO_KAFKA;
+import static com.linkedin.venice.ConfigKeys.SSL_TO_KAFKA_LEGACY;
 import static com.linkedin.venice.ConfigKeys.STORAGE_ENGINE_OVERHEAD_RATIO;
 import static com.linkedin.venice.ConfigKeys.TOPIC_CLEANUP_DELAY_FACTOR;
 import static com.linkedin.venice.ConfigKeys.TOPIC_CLEANUP_SEND_CONCURRENT_DELETES_REQUESTS;
@@ -178,7 +178,7 @@ public class VeniceControllerWrapper extends ProcessWrapper {
             .put(STORAGE_ENGINE_OVERHEAD_RATIO, DEFAULT_STORAGE_ENGINE_OVERHEAD_RATIO)
             .put(CLUSTER_TO_D2, TestUtils.getClusterToD2String(clusterToD2))
             .put(CLUSTER_TO_SERVER_D2, TestUtils.getClusterToD2String(clusterToServerD2))
-            .put(SSL_TO_KAFKA, options.isSslToKafka())
+            .put(SSL_TO_KAFKA_LEGACY, options.isSslToKafka())
             .put(SSL_KAFKA_BOOTSTRAP_SERVERS, options.getKafkaBroker().getSSLAddress())
             .put(ENABLE_OFFLINE_PUSH_SSL_WHITELIST, false)
             .put(ENABLE_HYBRID_PUSH_SSL_WHITELIST, false)

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerClusterConfig.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerClusterConfig.java
@@ -45,6 +45,7 @@ import static com.linkedin.venice.ConfigKeys.KAFKA_MIN_IN_SYNC_REPLICAS;
 import static com.linkedin.venice.ConfigKeys.KAFKA_MIN_IN_SYNC_REPLICAS_ADMIN_TOPICS;
 import static com.linkedin.venice.ConfigKeys.KAFKA_MIN_IN_SYNC_REPLICAS_RT_TOPICS;
 import static com.linkedin.venice.ConfigKeys.KAFKA_MIN_LOG_COMPACTION_LAG_MS;
+import static com.linkedin.venice.ConfigKeys.KAFKA_OVER_SSL;
 import static com.linkedin.venice.ConfigKeys.KAFKA_REPLICATION_FACTOR;
 import static com.linkedin.venice.ConfigKeys.KAFKA_REPLICATION_FACTOR_RT_TOPICS;
 import static com.linkedin.venice.ConfigKeys.KAFKA_SECURITY_PROTOCOL;
@@ -64,7 +65,7 @@ import static com.linkedin.venice.ConfigKeys.REFRESH_ATTEMPTS_FOR_ZK_RECONNECT;
 import static com.linkedin.venice.ConfigKeys.REFRESH_INTERVAL_FOR_ZK_RECONNECT_MS;
 import static com.linkedin.venice.ConfigKeys.REPLICATION_METADATA_VERSION;
 import static com.linkedin.venice.ConfigKeys.SSL_KAFKA_BOOTSTRAP_SERVERS;
-import static com.linkedin.venice.ConfigKeys.SSL_TO_KAFKA;
+import static com.linkedin.venice.ConfigKeys.SSL_TO_KAFKA_LEGACY;
 import static com.linkedin.venice.ConfigKeys.ZOOKEEPER_ADDRESS;
 import static com.linkedin.venice.SSLConfig.DEFAULT_CONTROLLER_SSL_ENABLED;
 import static com.linkedin.venice.VeniceConstants.DEFAULT_PER_ROUTER_READ_QUOTA;
@@ -357,7 +358,7 @@ public class VeniceControllerClusterConfig {
 
     clusterToD2Map = props.getMap(CLUSTER_TO_D2);
     clusterToServerD2Map = props.getMap(CLUSTER_TO_SERVER_D2, Collections.emptyMap());
-    this.sslToKafka = props.getBoolean(SSL_TO_KAFKA, false);
+    this.sslToKafka = props.getBooleanWithAlternative(KAFKA_OVER_SSL, SSL_TO_KAFKA_LEGACY, false);
     // Enable ssl to kafka
     if (sslToKafka) {
       // In that case , ssl kafka broker list is an mandatory field

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -3,10 +3,11 @@ package com.linkedin.venice.controller;
 import static com.linkedin.venice.ConfigConstants.DEFAULT_TOPIC_DELETION_STATUS_POLL_INTERVAL_MS;
 import static com.linkedin.venice.ConfigKeys.KAFKA_BOOTSTRAP_SERVERS;
 import static com.linkedin.venice.ConfigKeys.KAFKA_MIN_IN_SYNC_REPLICAS;
+import static com.linkedin.venice.ConfigKeys.KAFKA_OVER_SSL;
 import static com.linkedin.venice.ConfigKeys.KAFKA_REPLICATION_FACTOR;
 import static com.linkedin.venice.ConfigKeys.PUSH_STATUS_STORE_DERIVED_SCHEMA_ID;
 import static com.linkedin.venice.ConfigKeys.SSL_KAFKA_BOOTSTRAP_SERVERS;
-import static com.linkedin.venice.ConfigKeys.SSL_TO_KAFKA;
+import static com.linkedin.venice.ConfigKeys.SSL_TO_KAFKA_LEGACY;
 import static com.linkedin.venice.controller.UserSystemStoreLifeCycleHelper.AUTO_META_SYSTEM_STORE_PUSH_ID_PREFIX;
 import static com.linkedin.venice.kafka.TopicManager.DEFAULT_KAFKA_MIN_LOG_COMPACTION_LAG_MS;
 import static com.linkedin.venice.kafka.TopicManager.DEFAULT_KAFKA_OPERATION_TIMEOUT_MS;
@@ -660,7 +661,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
 
     VeniceProperties originalPros = controllerConfig.getProps();
     Properties clonedProperties = originalPros.toProperties();
-    if (originalPros.getBoolean(SSL_TO_KAFKA, false)) {
+    if (originalPros.getBooleanWithAlternative(KAFKA_OVER_SSL, SSL_TO_KAFKA_LEGACY, false)) {
       clonedProperties.setProperty(SSL_KAFKA_BOOTSTRAP_SERVERS, pubSubBootstrapServers);
     } else {
       clonedProperties.setProperty(KAFKA_BOOTSTRAP_SERVERS, pubSubBootstrapServers);
@@ -5718,7 +5719,8 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
 
   /**
    * Test if ssl is enabled to Kafka.
-   * @see ConfigKeys#SSL_TO_KAFKA
+   * @see ConfigKeys#SSL_TO_KAFKA_LEGACY
+   * @see ConfigKeys#KAFKA_OVER_SSL
    */
   @Override
   public boolean isSslToKafka() {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/ingestion/control/RealTimeTopicSwitcher.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/ingestion/control/RealTimeTopicSwitcher.java
@@ -60,9 +60,10 @@ public class RealTimeTopicSwitcher {
     this.veniceWriterFactory = veniceWriterFactory;
     this.pubSubTopicRepository = pubSubTopicRepository;
     this.timer = new SystemTime();
-    this.destKafkaBootstrapServers = veniceProperties.getBoolean(ConfigKeys.SSL_TO_KAFKA, false)
-        ? veniceProperties.getString(ConfigKeys.SSL_KAFKA_BOOTSTRAP_SERVERS)
-        : veniceProperties.getString(ConfigKeys.KAFKA_BOOTSTRAP_SERVERS);
+    this.destKafkaBootstrapServers =
+        veniceProperties.getBooleanWithAlternative(ConfigKeys.KAFKA_OVER_SSL, ConfigKeys.SSL_TO_KAFKA_LEGACY, false)
+            ? veniceProperties.getString(ConfigKeys.SSL_KAFKA_BOOTSTRAP_SERVERS)
+            : veniceProperties.getString(ConfigKeys.KAFKA_BOOTSTRAP_SERVERS);
     int kafkaReplicationFactor = veniceProperties.getInt(KAFKA_REPLICATION_FACTOR, DEFAULT_KAFKA_REPLICATION_FACTOR);
     this.kafkaReplicationFactorForRTTopics =
         veniceProperties.getInt(KAFKA_REPLICATION_FACTOR_RT_TOPICS, kafkaReplicationFactor);

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/MetaDataHandler.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/MetaDataHandler.java
@@ -111,6 +111,7 @@ public class MetaDataHandler extends SimpleChannelInboundHandler<HttpRequest> {
   private final String clusterName;
   private final String zkAddress;
   private final String kafkaBootstrapServers;
+  private final boolean isSslToKafka;
 
   static final String REQUEST_TOPIC_ERROR_WRITES_DISABLED = "Write operations to the store are disabled.";
   static final String REQUEST_TOPIC_ERROR_BATCH_ONLY_STORE = "Online writes are only supported for hybrid stores.";
@@ -136,7 +137,8 @@ public class MetaDataHandler extends SimpleChannelInboundHandler<HttpRequest> {
       Optional<HelixHybridStoreQuotaRepository> hybridStoreQuotaRepository,
       String clusterName,
       String zkAddress,
-      String kafkaBootstrapServers) {
+      String kafkaBootstrapServers,
+      boolean isSslToKafka) {
     super();
     this.routingDataRepository = routingDataRepository;
     this.schemaRepo = schemaRepo;
@@ -148,6 +150,7 @@ public class MetaDataHandler extends SimpleChannelInboundHandler<HttpRequest> {
     this.clusterName = clusterName;
     this.zkAddress = zkAddress;
     this.kafkaBootstrapServers = kafkaBootstrapServers;
+    this.isSslToKafka = isSslToKafka;
   }
 
   @Override
@@ -628,11 +631,13 @@ public class MetaDataHandler extends SimpleChannelInboundHandler<HttpRequest> {
     responseObject.setName(storeName);
     responseObject.setPartitions(currentVersion.getPartitionCount());
     responseObject.setKafkaTopic(Version.composeRealTimeTopic(storeName));
+
     // RT topic only supports NO_OP compression
     responseObject.setCompressionStrategy(CompressionStrategy.NO_OP);
     // disable amplificationFactor logic on real-time topic
     responseObject.setAmplificationFactor(1);
     responseObject.setKafkaBootstrapServers(kafkaBootstrapServers);
+    responseObject.setEnableSSL(isSslToKafka);
     responseObject.setDaVinciPushStatusStoreEnabled(store.isDaVinciPushStatusStoreEnabled());
     responseObject.setPartitionerClass(storePartitionerConfig.getPartitionerClass());
     responseObject.setPartitionerParams(storePartitionerConfig.getPartitionerParams());

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/RouterServer.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/RouterServer.java
@@ -494,7 +494,8 @@ public class RouterServer extends AbstractVeniceService {
         hybridStoreQuotaRepository,
         config.getClusterName(),
         config.getZkConnection(),
-        config.getKafkaBootstrapServers());
+        config.getKafkaBootstrapServers(),
+        config.isSslToKafka());
 
     VeniceHostFinder hostFinder = new VeniceHostFinder(routingDataRepository, routerStats, healthMonitor);
 

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/VeniceRouterConfig.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/VeniceRouterConfig.java
@@ -8,6 +8,7 @@ import static com.linkedin.venice.ConfigKeys.HEARTBEAT_CYCLE;
 import static com.linkedin.venice.ConfigKeys.HEARTBEAT_TIMEOUT;
 import static com.linkedin.venice.ConfigKeys.HELIX_HYBRID_STORE_QUOTA_ENABLED;
 import static com.linkedin.venice.ConfigKeys.KAFKA_BOOTSTRAP_SERVERS;
+import static com.linkedin.venice.ConfigKeys.KAFKA_OVER_SSL;
 import static com.linkedin.venice.ConfigKeys.KEY_VALUE_PROFILING_ENABLED;
 import static com.linkedin.venice.ConfigKeys.LISTENER_HOSTNAME;
 import static com.linkedin.venice.ConfigKeys.LISTENER_PORT;
@@ -87,6 +88,7 @@ import static com.linkedin.venice.ConfigKeys.ROUTER_STORAGE_NODE_CLIENT_TYPE;
 import static com.linkedin.venice.ConfigKeys.ROUTER_THROTTLE_CLIENT_SSL_HANDSHAKES;
 import static com.linkedin.venice.ConfigKeys.ROUTER_UNHEALTHY_PENDING_CONNECTION_THRESHOLD_PER_ROUTE;
 import static com.linkedin.venice.ConfigKeys.ROUTE_DNS_CACHE_HOST_PATTERN;
+import static com.linkedin.venice.ConfigKeys.SSL_TO_KAFKA_LEGACY;
 import static com.linkedin.venice.ConfigKeys.SSL_TO_STORAGE_NODES;
 import static com.linkedin.venice.ConfigKeys.SYSTEM_SCHEMA_CLUSTER_NAME;
 import static com.linkedin.venice.ConfigKeys.UNREGISTER_METRIC_FOR_DELETED_STORE_ENABLED;
@@ -167,6 +169,7 @@ public class VeniceRouterConfig {
   private long leakedFutureCleanupPollIntervalMs;
   private long leakedFutureCleanupThresholdMs;
   private String kafkaBootstrapServers;
+  private boolean sslToKafka;
   private boolean idleConnectionToServerCleanupEnabled;
   private long idleConnectionToServerCleanupThresholdMins;
   private long fullPendingQueueServerOORMs;
@@ -229,6 +232,7 @@ public class VeniceRouterConfig {
     sslPort = props.getInt(LISTENER_SSL_PORT);
     zkConnection = props.getString(ZOOKEEPER_ADDRESS);
     kafkaBootstrapServers = props.getString(KAFKA_BOOTSTRAP_SERVERS);
+    sslToKafka = props.getBooleanWithAlternative(KAFKA_OVER_SSL, SSL_TO_KAFKA_LEGACY, false);
     heartbeatTimeoutMs = props.getDouble(HEARTBEAT_TIMEOUT, TimeUnit.MINUTES.toMillis(1));
     heartbeatCycleMs = props.getLong(HEARTBEAT_CYCLE, TimeUnit.SECONDS.toMillis(5));
     sslToStorageNodes = props.getBoolean(SSL_TO_STORAGE_NODES, false);
@@ -588,6 +592,10 @@ public class VeniceRouterConfig {
 
   public String getKafkaBootstrapServers() {
     return kafkaBootstrapServers;
+  }
+
+  public boolean isSslToKafka() {
+    return sslToKafka;
   }
 
   public boolean isIdleConnectionToServerCleanupEnabled() {

--- a/services/venice-router/src/test/java/com/linkedin/venice/router/TestMetaDataHandler.java
+++ b/services/venice-router/src/test/java/com/linkedin/venice/router/TestMetaDataHandler.java
@@ -154,7 +154,8 @@ public class TestMetaDataHandler {
         Optional.of(hybridStoreQuotaRepository),
         "test-cluster",
         ZK_ADDRESS,
-        KAFKA_BOOTSTRAP_SERVERS);
+        KAFKA_BOOTSTRAP_SERVERS,
+        false);
     handler.channelRead0(ctx, httpRequest);
     ArgumentCaptor<Object> captor = ArgumentCaptor.forClass(Object.class);
     Mockito.verify(ctx).writeAndFlush(captor.capture());
@@ -828,7 +829,8 @@ public class TestMetaDataHandler {
         Optional.of(hybridStoreQuotaRepository),
         clusterName,
         ZK_ADDRESS,
-        KAFKA_BOOTSTRAP_SERVERS);
+        KAFKA_BOOTSTRAP_SERVERS,
+        false);
     handler.channelRead0(ctx, httpRequest);
     // '/storage' request should be handled by upstream, instead of current MetaDataHandler
     Mockito.verify(ctx, Mockito.times(1)).fireChannelRead(Mockito.any());


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## A couple of fixes related to SSL for online producer
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
1. Make routers return if the Kafka cluster is SSL enabled in request_topic call
2. Set Kafka `security.protocol` config for online producer
3. Deprecated `ssl.to.kakfa` due to the misspelling and added a config `kafka.over.ssl` to replace it

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
Manual tested so far

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.