### PR TITLE
[client] Allow to configure the number of connections and upgrade HttpClient to 5.x async with HTTP2 support

### DIFF
--- a/clients/venice-samza/src/main/java/com/linkedin/venice/samza/VeniceSystemProducer.java
+++ b/clients/venice-samza/src/main/java/com/linkedin/venice/samza/VeniceSystemProducer.java
@@ -446,9 +446,9 @@ public class VeniceSystemProducer implements SystemProducer, Closeable {
       }
 
       if (sslFactory.isPresent()) {
-        transportClient = new HttpsTransportClient(discoveryUrl.get(), sslFactory.get());
+        transportClient = new HttpsTransportClient(discoveryUrl.get(), 0, 0, false, sslFactory.get());
       } else {
-        transportClient = new HttpTransportClient(discoveryUrl.get());
+        transportClient = new HttpTransportClient(discoveryUrl.get(), 0, 0);
       }
     } else {
       this.primaryControllerColoD2Client = getStartedD2Client(primaryControllerColoD2ZKHost);

--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/ClientConfig.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/ClientConfig.java
@@ -60,6 +60,13 @@ public class ClientConfig<T extends SpecificRecord> {
   private boolean isHttps = false;
   private SSLFactory sslFactory = null;
 
+  // HttpTransport settings
+  private int maxConnectionsPerRoute; // only for HTTP1
+
+  private int maxConnectionsTotal; // only for HTTP1
+
+  private boolean httpClient5Http2Enabled;
+
   // Test settings
   private Time time = new SystemTime();
 
@@ -107,11 +114,15 @@ public class ClientConfig<T extends SpecificRecord> {
         // Security settings
         .setHttps(config.isHttps())
         .setSslFactory(config.getSslFactory())
-
         .setForceClusterDiscoveryAtStartTime(config.isForceClusterDiscoveryAtStartTime())
         .setProjectionFieldValidationEnabled(config.isProjectionFieldValidationEnabled())
         .setPreferredSchemaFilter(config.getPreferredSchemaFilter().orElse(null))
         .setSchemaRefreshPeriod(config.getSchemaRefreshPeriod())
+
+        // HttpTransport settings
+        .setMaxConnectionsPerRoute(config.getMaxConnectionsPerRoute())
+        .setMaxConnectionsTotal(config.getMaxConnectionsTotal())
+        .setHttpClient5Http2Enabled(config.isHttpClient5Http2Enabled())
 
         // Test settings
         .setTime(config.getTime());
@@ -253,6 +264,33 @@ public class ClientConfig<T extends SpecificRecord> {
 
   public ClientConfig<T> setSslFactory(SSLFactory sslEngineComponentFactory) {
     this.sslFactory = sslEngineComponentFactory;
+    return this;
+  }
+
+  public int getMaxConnectionsPerRoute() {
+    return maxConnectionsPerRoute;
+  }
+
+  public ClientConfig<T> setMaxConnectionsPerRoute(int maxConnectionsPerRoute) {
+    this.maxConnectionsPerRoute = maxConnectionsPerRoute;
+    return this;
+  }
+
+  public int getMaxConnectionsTotal() {
+    return maxConnectionsTotal;
+  }
+
+  public ClientConfig<T> setMaxConnectionsTotal(int maxConnectionsTotal) {
+    this.maxConnectionsTotal = maxConnectionsTotal;
+    return this;
+  }
+
+  public boolean isHttpClient5Http2Enabled() {
+    return httpClient5Http2Enabled;
+  }
+
+  public ClientConfig<T> setHttpClient5Http2Enabled(boolean httpClient5Http2Enabled) {
+    this.httpClient5Http2Enabled = httpClient5Http2Enabled;
     return this;
   }
 

--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/ClientFactory.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/ClientFactory.java
@@ -122,9 +122,17 @@ public class ClientFactory {
         throw new VeniceClientException("Must use SSL factory method for client to communicate with https");
       }
 
-      return new HttpsTransportClient(bootstrapUrl, clientConfig.getSslFactory());
+      return new HttpsTransportClient(
+          bootstrapUrl,
+          clientConfig.getMaxConnectionsTotal(),
+          clientConfig.getMaxConnectionsPerRoute(),
+          clientConfig.isHttpClient5Http2Enabled(),
+          clientConfig.getSslFactory());
     } else {
-      return new HttpTransportClient(bootstrapUrl);
+      return new HttpTransportClient(
+          bootstrapUrl,
+          clientConfig.getMaxConnectionsTotal(),
+          clientConfig.getMaxConnectionsPerRoute());
     }
   }
 }

--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/transport/HttpTransportClient.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/transport/HttpTransportClient.java
@@ -3,25 +3,28 @@ package com.linkedin.venice.client.store.transport;
 import com.linkedin.venice.HttpConstants;
 import com.linkedin.venice.client.exceptions.VeniceClientException;
 import com.linkedin.venice.compression.CompressionStrategy;
+import com.linkedin.venice.httpclient5.HttpClient5Utils;
 import com.linkedin.venice.schema.SchemaData;
-import java.io.ByteArrayInputStream;
+import com.linkedin.venice.security.SSLFactory;
 import java.io.IOException;
-import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import org.apache.commons.httpclient.HttpStatus;
-import org.apache.commons.io.IOUtils;
-import org.apache.http.Header;
-import org.apache.http.HttpResponse;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.concurrent.FutureCallback;
-import org.apache.http.entity.BasicHttpEntity;
-import org.apache.http.impl.nio.client.CloseableHttpAsyncClient;
-import org.apache.http.impl.nio.client.HttpAsyncClients;
+import org.apache.hc.client5.http.async.methods.SimpleHttpResponse;
+import org.apache.hc.client5.http.async.methods.SimpleResponseConsumer;
+import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient;
+import org.apache.hc.client5.http.impl.async.HttpAsyncClients;
+import org.apache.hc.client5.http.impl.nio.PoolingAsyncClientConnectionManagerBuilder;
+import org.apache.hc.client5.http.ssl.ClientTlsStrategyBuilder;
+import org.apache.hc.core5.concurrent.FutureCallback;
+import org.apache.hc.core5.http.ContentType;
+import org.apache.hc.core5.http.Header;
+import org.apache.hc.core5.http.nio.AsyncRequestProducer;
+import org.apache.hc.core5.http.nio.support.AsyncRequestBuilder;
+import org.apache.hc.core5.http2.HttpVersionPolicy;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -30,14 +33,18 @@ import org.apache.logging.log4j.Logger;
  * {@link CloseableHttpAsyncClient} based TransportClient implementation.
  */
 public class HttpTransportClient extends TransportClient {
-  private final Logger logger = LogManager.getLogger(HttpTransportClient.class);
+  private final static Logger LOGGER = LogManager.getLogger(HttpTransportClient.class);
 
   // Example: 'http://router-host:80/'
   protected final String routerUrl;
+  protected int maxConnectionsTotal;
+  protected int maxConnectionsPerRoute;
   private final CloseableHttpAsyncClient httpClient;
 
-  public HttpTransportClient(String routerUrl) {
-    this(routerUrl, HttpAsyncClients.createDefault());
+  public HttpTransportClient(String routerUrl, int maxConnectionsTotal, int maxConnectionsPerRoute) {
+    this(routerUrl, buildClient(routerUrl, maxConnectionsTotal, maxConnectionsPerRoute, false, null));
+    this.maxConnectionsTotal = maxConnectionsTotal;
+    this.maxConnectionsPerRoute = maxConnectionsPerRoute;
   }
 
   public HttpTransportClient(String routerUrl, CloseableHttpAsyncClient httpClient) {
@@ -51,12 +58,44 @@ public class HttpTransportClient extends TransportClient {
    * threads and if the users of the future run tasks that block the release of the future thread, a deadlock will occur.
    * Hence, use the async handlers of {@link CompletableFuture} if you plan to use the same client to make multiple
    * requests sequentially.
-   */
+   **/
+  protected static CloseableHttpAsyncClient buildClient(
+      String routerUrl,
+      int maxConnectionsTotal,
+      int maxConnectionsPerRoute,
+      boolean requireHHtp2,
+      SSLFactory sslFactory) {
+
+    if (requireHHtp2) {
+      // HTTP2 only client doesn't allow you to configure the ConnectionManager
+      LOGGER.info("Creating a TLS HTTP2 only client to {}", routerUrl);
+      return new HttpClient5Utils.HttpClient5Builder().setSslContext(sslFactory.getSSLContext()).build();
+    }
+
+    LOGGER.info(
+        "Creating a HTTP1 only client to {} ({} maxConnections, {} maxConnectionsPerRoute)",
+        routerUrl,
+        maxConnectionsTotal,
+        maxConnectionsPerRoute);
+    return HttpAsyncClients.custom()
+        .setVersionPolicy(HttpVersionPolicy.FORCE_HTTP_1)
+        .setConnectionManager(
+            PoolingAsyncClientConnectionManagerBuilder.create()
+                .setMaxConnTotal(maxConnectionsTotal)
+                .setMaxConnPerRoute(maxConnectionsPerRoute)
+                .setTlsStrategy(
+                    sslFactory != null
+                        ? ClientTlsStrategyBuilder.create().setSslContext(sslFactory.getSSLContext()).build()
+                        : null)
+                .build())
+        .build();
+  }
+
   @Override
   public CompletableFuture<TransportClientResponse> get(String requestPath, Map<String, String> headers) {
-    HttpGet request = getHttpGetRequest(requestPath, headers);
+    AsyncRequestProducer request = getHttpGetRequest(requestPath, headers);
     CompletableFuture<TransportClientResponse> valueFuture = new CompletableFuture<>();
-    httpClient.execute(request, new HttpTransportClientCallback(valueFuture));
+    httpClient.execute(request, SimpleResponseConsumer.create(), new HttpTransportClientCallback(valueFuture));
     return valueFuture;
   }
 
@@ -71,9 +110,9 @@ public class HttpTransportClient extends TransportClient {
       String requestPath,
       Map<String, String> headers,
       byte[] requestBody) {
-    HttpPost request = getHttpPostRequest(requestPath, headers, requestBody);
+    AsyncRequestProducer request = getHttpPostRequest(requestPath, headers, requestBody);
     CompletableFuture<TransportClientResponse> valueFuture = new CompletableFuture<>();
-    httpClient.execute(request, new HttpTransportClientCallback(valueFuture));
+    httpClient.execute(request, SimpleResponseConsumer.create(), new HttpTransportClientCallback(valueFuture));
     return valueFuture;
   }
 
@@ -120,38 +159,35 @@ public class HttpTransportClient extends TransportClient {
     return routerUrl + requestPath;
   }
 
-  private HttpGet getHttpGetRequest(String requestPath, Map<String, String> headers) {
-    HttpGet httpGet = new HttpGet(getHttpRequestUrl(requestPath));
+  private AsyncRequestProducer getHttpGetRequest(String requestPath, Map<String, String> headers) {
+    AsyncRequestBuilder httpGet = AsyncRequestBuilder.get(getHttpRequestUrl(requestPath));
     headers.forEach((K, V) -> {
       httpGet.addHeader(K, V);
     });
-    return httpGet;
+    return httpGet.build();
   }
 
-  private HttpPost getHttpPostRequest(String requestPath, Map<String, String> headers, byte[] body) {
-    HttpPost httpPost = new HttpPost(getHttpRequestUrl(requestPath));
+  private AsyncRequestProducer getHttpPostRequest(String requestPath, Map<String, String> headers, byte[] body) {
+    AsyncRequestBuilder httpPost = AsyncRequestBuilder.post(getHttpRequestUrl(requestPath));
     headers.forEach((K, V) -> {
       httpPost.setHeader(K, V);
     });
-    BasicHttpEntity entity = new BasicHttpEntity();
-    entity.setContent(new ByteArrayInputStream(body));
-    httpPost.setEntity(entity);
-
-    return httpPost;
+    httpPost.setEntity(body, ContentType.APPLICATION_OCTET_STREAM);
+    return httpPost.build();
   }
 
   @Override
   public void close() {
     try {
       httpClient.close();
-      logger.debug("HttpStoreClient closed");
+      LOGGER.debug("HttpStoreClient closed");
     } catch (IOException e) {
-      logger.error("Failed to close internal CloseableHttpAsyncClient", e);
+      LOGGER.error("Failed to close internal CloseableHttpAsyncClient", e);
     }
   }
 
   private static class HttpTransportClientCallback extends TransportClientCallback
-      implements FutureCallback<HttpResponse> {
+      implements FutureCallback<SimpleHttpResponse> {
     public HttpTransportClientCallback(CompletableFuture<TransportClientResponse> valueFuture) {
       super(valueFuture);
     }
@@ -167,8 +203,8 @@ public class HttpTransportClient extends TransportClient {
     }
 
     @Override
-    public void completed(HttpResponse result) {
-      int statusCode = result.getStatusLine().getStatusCode();
+    public void completed(SimpleHttpResponse result) {
+      int statusCode = result.getCode();
 
       int schemaId = SchemaData.INVALID_VALUE_SCHEMA_ID;
       // If we try to retrieve the header value directly, and the 'getValue' will hang if the header doesn't exist.
@@ -185,14 +221,7 @@ public class HttpTransportClient extends TransportClient {
         compressionStrategy = CompressionStrategy.valueOf(Integer.parseInt(compressionHeader.getValue()));
       }
 
-      byte[] body;
-      try (InputStream bodyStream = result.getEntity().getContent()) {
-        body = IOUtils.toByteArray(bodyStream);
-      } catch (IOException e) {
-        getValueFuture().completeExceptionally(new VeniceClientException(e));
-        return;
-      }
-
+      byte[] body = result.getBody() != null ? result.getBody().getBodyBytes() : null;
       completeFuture(statusCode, schemaId, compressionStrategy, body);
     }
   }
@@ -207,5 +236,13 @@ public class HttpTransportClient extends TransportClient {
 
   public String toString() {
     return this.getClass().getSimpleName() + "(routerUrl: " + routerUrl + ")";
+  }
+
+  public int getMaxConnectionsTotal() {
+    return maxConnectionsTotal;
+  }
+
+  public int getMaxConnectionsPerRoute() {
+    return maxConnectionsPerRoute;
   }
 }

--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/transport/HttpsTransportClient.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/transport/HttpsTransportClient.java
@@ -2,16 +2,22 @@ package com.linkedin.venice.client.store.transport;
 
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.security.SSLFactory;
-import org.apache.http.impl.nio.client.CloseableHttpAsyncClient;
-import org.apache.http.impl.nio.client.HttpAsyncClients;
-import org.apache.http.nio.conn.ssl.SSLIOSessionStrategy;
+import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient;
 
 
 public class HttpsTransportClient extends HttpTransportClient {
-  public HttpsTransportClient(String routerUrl, SSLFactory sslFactory) {
-    this(
-        routerUrl,
-        HttpAsyncClients.custom().setSSLStrategy(new SSLIOSessionStrategy(sslFactory.getSSLContext())).build());
+  private boolean requireHTTP2;
+
+  public HttpsTransportClient(
+      String routerUrl,
+      int maxConnectionsTotal,
+      int maxConnectionsPerRoute,
+      boolean requireHTTP2,
+      SSLFactory sslFactory) {
+    this(routerUrl, buildClient(routerUrl, maxConnectionsTotal, maxConnectionsPerRoute, requireHTTP2, sslFactory));
+    this.maxConnectionsTotal = maxConnectionsTotal;
+    this.maxConnectionsPerRoute = maxConnectionsPerRoute;
+    this.requireHTTP2 = requireHTTP2;
   }
 
   public HttpsTransportClient(String routerUrl, CloseableHttpAsyncClient client) {
@@ -19,5 +25,9 @@ public class HttpsTransportClient extends HttpTransportClient {
     if (!routerUrl.startsWith(HTTPS)) {
       throw new VeniceException("Must use https url with HttpsTransportClient, found: " + routerUrl);
     }
+  }
+
+  public boolean isRequireHTTP2() {
+    return requireHTTP2;
   }
 }

--- a/clients/venice-thin-client/src/test/java/com/linkedin/venice/client/store/ClientFactoryTest.java
+++ b/clients/venice-thin-client/src/test/java/com/linkedin/venice/client/store/ClientFactoryTest.java
@@ -1,0 +1,67 @@
+package com.linkedin.venice.client.store;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.linkedin.venice.client.store.transport.HttpTransportClient;
+import com.linkedin.venice.client.store.transport.HttpsTransportClient;
+import com.linkedin.venice.client.store.transport.TransportClient;
+import com.linkedin.venice.security.SSLFactory;
+import javax.net.ssl.SSLContext;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+
+public class ClientFactoryTest {
+  @DataProvider(name = "protocol")
+  public static Object[][] protocol() {
+    return new Object[][] { { "http" }, { "https" } };
+  }
+
+  @Test(dataProvider = "protocol")
+  public void testHttpConfig(String protocol) throws Exception {
+
+    ClientConfig config = ClientConfig.defaultGenericClientConfig("store");
+    config.setMaxConnectionsPerRoute(7);
+    config.setMaxConnectionsTotal(8);
+    config.setVeniceURL(protocol + "://localhost:8080");
+    config.setSslFactory(mock(SSLFactory.class));
+
+    TransportClient transport = ClientFactory.getTransportClient(config);
+    HttpTransportClient httpTransport = (HttpTransportClient) transport;
+    if (protocol.equals("https")) {
+      Assert.assertTrue(httpTransport instanceof HttpsTransportClient);
+    }
+    Assert.assertEquals(httpTransport.getMaxConnectionsPerRoute(), 7);
+    Assert.assertEquals(httpTransport.getMaxConnectionsTotal(), 8);
+
+    transport.close();
+  }
+
+  @DataProvider(name = "httpClient5Http2Enabled")
+  public static Object[][] httpClient5Http2Enabled() {
+    return new Object[][] { { true }, { false } };
+  }
+
+  @Test(dataProvider = "httpClient5Http2Enabled")
+  public void testRequireHTTP2(boolean httpClient5Http2Enabled) throws Exception {
+
+    ClientConfig config = ClientConfig.defaultGenericClientConfig("store");
+    config.setMaxConnectionsPerRoute(7);
+    config.setMaxConnectionsTotal(8);
+    config.setHttpClient5Http2Enabled(httpClient5Http2Enabled);
+    config.setVeniceURL("https://localhost:8080");
+    SSLFactory sslFactory = mock(SSLFactory.class);
+    SSLContext sslContext = mock(SSLContext.class);
+    when(sslFactory.getSSLContext()).thenReturn(sslContext);
+    config.setSslFactory(sslFactory);
+
+    TransportClient transport = ClientFactory.getTransportClient(config);
+    HttpsTransportClient httpTransport = (HttpsTransportClient) transport;
+    Assert.assertEquals(httpTransport.isRequireHTTP2(), httpClient5Http2Enabled);
+
+    transport.close();
+
+  }
+}

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/httpclient5/HttpClient5Utils.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/httpclient5/HttpClient5Utils.java
@@ -63,7 +63,7 @@ public class HttpClient5Utils {
       return this;
     }
 
-    public CloseableHttpAsyncClient buildAndStart() {
+    public CloseableHttpAsyncClient build() {
       if (sslContext == null) {
         throw new IllegalArgumentException("'sslContext' needs to be specified.");
       }
@@ -95,7 +95,11 @@ public class HttpClient5Utils {
                   .setConnectionRequestTimeout(CONNECT_TIMEOUT_IN_MILLISECONDS)
                   .build())
           .build();
+      return client;
+    }
 
+    public CloseableHttpAsyncClient buildAndStart() {
+      CloseableHttpAsyncClient client = build();
       client.start();
       return client;
     }

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/client/store/TestSslTransportClient.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/client/store/TestSslTransportClient.java
@@ -33,7 +33,8 @@ public class TestSslTransportClient {
         MockVeniceRouterWrapper router =
             ServiceFactory.getMockVeniceRouter(zkServer.getAddress(), true, new Properties())) {
       String routerSslUrl = "https://" + router.getHost() + ":" + router.getSslPort();
-      try (HttpsTransportClient client = new HttpsTransportClient(routerSslUrl, SslUtils.getVeniceLocalSslFactory())) {
+      try (HttpsTransportClient client =
+          new HttpsTransportClient(routerSslUrl, 0, 0, false, SslUtils.getVeniceLocalSslFactory())) {
 
         TransportClientResponse transportClientResponse = client.get(leaderControllerPath).get();
         byte[] response = transportClientResponse.getBody();


### PR DESCRIPTION

## Summary

The Store Client currently has some limitations about performances: it uses only HTTP 1.1 and opens only at most 2 connections. This means that you cannot have more than 2 inflight requests.

Un order to achieve better latencies this patch introduces:
- configuration parameters to tune the number. of HTTP 1.x connections
- upgrade of HttpClient to 5.x, with HTTP2 support
- a configuration flag to require HTTP2

Please note that HTTP2 works only with TLS enabled on the Router  


## How was this PR tested?
The code change is almost covered by existing tests, as the core of the change is the upgrade of HC to 5.x.


## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.

Currently there is no documentation about the client