### PR TITLE
[controller] Make Controller Resilient to Parent Broker Unavailability

### DIFF
--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -3337,12 +3337,12 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
           .updateTopicRetention(pubSubTopicRepository.getTopic(kafkaTopicName), deprecatedJobTopicRetentionMs)) {
         return true;
       }
-    } catch (TopicDoesNotExistException e) {
+    } catch (Exception e) {
       LOGGER.warn(
-          "Unable to update the retention for topic {} in Kafka cluster {} since the topic doesn't exist in "
-              + "Kafka anymore, will skip the truncation",
+          "Unable to update the retention for topic {} in Kafka cluster {}, will skip the truncation",
           kafkaTopicName,
-          topicManager.getKafkaBootstrapServers());
+          topicManager.getKafkaBootstrapServers(),
+          e);
     }
     return false;
   }


### PR DESCRIPTION
## Make Controller Resilient to Parent Broker Unavailability
Fix for prod issue when decomming old parent broker. This should be all thats needed based on what calls we make to read the controller parent broker list. It's ok to barf an exception here at time of truncation and move on as if/when the broker comes back, topic clean up service will run through and clean up anything left behind.

## Does this PR introduce any user-facing changes?
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.