### PR TITLE
[controller] Report push error if too many DVC instances are dead

### DIFF
--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -1654,24 +1654,25 @@ public class ConfigKeys {
   public static final String PUSH_STATUS_STORE_ENABLED = "push.status.store.enabled";
 
   // Config to check whether the offline push will also monitor Da Vinci push status.
-  public static final String OFFLINE_PUSH_MONITOR_DAVINCI_PUSH_STATUS_ENABLED =
-      "offline.push.monitor.davinci.push.status.enabled";
+  public static final String DAVINCI_PUSH_STATUS_SCAN_ENABLED = "davinci.push.status.scan.enabled";
 
   // Config to determine the Da Vinci push status scanning interval in seconds.
-  public static final String OFFLINE_PUSH_MONITOR_DAVINCI_PUSH_STATUS_SCAN_INTERVAL_IN_SECONDS =
-      "offline.push.monitor.davinci.push.status.scan.interval.in.seconds";
+  public static final String DAVINCI_PUSH_STATUS_SCAN_INTERVAL_IN_SECONDS =
+      "davinci.push.status.scan.interval.in.seconds";
 
   // Config to determine the Da Vinci push status scanning worker thread number.
-  public static final String OFFLINE_PUSH_MONITOR_DAVINCI_PUSH_STATUS_SCAN_THREAD_NUMBER =
-      "offline.push.monitor.davinci.push.status.scan.thread.number";
+  public static final String DAVINCI_PUSH_STATUS_SCAN_THREAD_NUMBER = "davinci.push.status.scan.thread.number";
 
   /**
    * Max retry when not receiving any DaVinci status report.
    * This is mainly for testing purpose since in local integration test, the push job runs too fast in the backend,
    * and no DaVinci status report will mark the push job succeed right away.
    */
-  public static final String OFFLINE_PUSH_MONITOR_DAVINCI_PUSH_STATUS_SCAN_NO_DAVINCI_STATUS_REPORT_RETRY_MAX_ATTEMPTS =
-      "offline.push.monitor.davinci.push.status.scan.no.davinci.status.report.retry.max.attempts";
+  public static final String DAVINCI_PUSH_STATUS_SCAN_NO_REPORT_RETRY_MAX_ATTEMPTS =
+      "davinci.push.status.scan.no.report.retry.max.attempts";
+
+  public static final String DAVINCI_PUSH_STATUS_SCAN_MAX_OFFLINE_INSTANCE =
+      "davinci.push.status.scan.max.offline.instance";
 
   public static final String CONTROLLER_ZK_SHARED_DAVINCI_PUSH_STATUS_SYSTEM_SCHEMA_STORE_AUTO_CREATION_ENABLED =
       "controller.zk.shared.davinci.push.status.system.schema.store.auto.creation.enabled";

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/controller/TestVeniceHelixResources.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/controller/TestVeniceHelixResources.java
@@ -58,9 +58,9 @@ public class TestVeniceHelixResources {
     doReturn(mock(HelixReadOnlyZKSharedSchemaRepository.class)).when(veniceHelixAdmin)
         .getReadOnlyZKSharedSchemaRepository();
     VeniceControllerConfig controllerConfig = mock(VeniceControllerConfig.class);
-    when(controllerConfig.getOfflinePushMonitorDaVinciPushStatusScanThreadNumber()).thenReturn(4);
-    when(controllerConfig.getOfflinePushMonitorDaVinciPushStatusScanIntervalInSeconds()).thenReturn(5);
-    when(controllerConfig.isOfflinePushMonitorDaVinciPushStatusEnabled()).thenReturn(true);
+    when(controllerConfig.getDaVinciPushStatusScanThreadNumber()).thenReturn(4);
+    when(controllerConfig.getDaVinciPushStatusScanIntervalInSeconds()).thenReturn(5);
+    when(controllerConfig.isDaVinciPushStatusEnabled()).thenReturn(true);
     when(controllerConfig.getOffLineJobWaitTimeInMilliseconds()).thenReturn(120000L);
     return new HelixVeniceClusterResources(
         cluster,

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/DaVinciClientMemoryLimitTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/DaVinciClientMemoryLimitTest.java
@@ -7,8 +7,8 @@ import static com.linkedin.venice.ConfigKeys.CLIENT_USE_SYSTEM_STORE_REPOSITORY;
 import static com.linkedin.venice.ConfigKeys.CLUSTER_DISCOVERY_D2_SERVICE;
 import static com.linkedin.venice.ConfigKeys.D2_ZK_HOSTS_ADDRESS;
 import static com.linkedin.venice.ConfigKeys.DATA_BASE_PATH;
+import static com.linkedin.venice.ConfigKeys.DAVINCI_PUSH_STATUS_SCAN_NO_REPORT_RETRY_MAX_ATTEMPTS;
 import static com.linkedin.venice.ConfigKeys.INGESTION_MEMORY_LIMIT;
-import static com.linkedin.venice.ConfigKeys.OFFLINE_PUSH_MONITOR_DAVINCI_PUSH_STATUS_SCAN_NO_DAVINCI_STATUS_REPORT_RETRY_MAX_ATTEMPTS;
 import static com.linkedin.venice.ConfigKeys.PERSISTENCE_TYPE;
 import static com.linkedin.venice.ConfigKeys.PUSH_STATUS_STORE_ENABLED;
 import static com.linkedin.venice.ConfigKeys.SERVER_FORKED_PROCESS_JVM_ARGUMENT_LIST;
@@ -78,7 +78,7 @@ public class DaVinciClientMemoryLimitTest {
     Properties clusterConfig = new Properties();
     clusterConfig.put(SERVER_PROMOTION_TO_LEADER_REPLICA_DELAY_SECONDS, 10L);
     // To allow more times for DaVinci clients to report status
-    clusterConfig.put(OFFLINE_PUSH_MONITOR_DAVINCI_PUSH_STATUS_SCAN_NO_DAVINCI_STATUS_REPORT_RETRY_MAX_ATTEMPTS, 5);
+    clusterConfig.put(DAVINCI_PUSH_STATUS_SCAN_NO_REPORT_RETRY_MAX_ATTEMPTS, 5);
     venice = ServiceFactory.getVeniceCluster(1, 2, 1, 1, 100, false, false, clusterConfig);
     d2Client = new D2ClientBuilder().setZkHosts(venice.getZk().getAddress())
         .setZkSessionTimeout(3, TimeUnit.SECONDS)

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/PushStatusStoreTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/PushStatusStoreTest.java
@@ -2,7 +2,7 @@ package com.linkedin.venice.endToEnd;
 
 import static com.linkedin.venice.ConfigKeys.CLIENT_SYSTEM_STORE_REPOSITORY_REFRESH_INTERVAL_SECONDS;
 import static com.linkedin.venice.ConfigKeys.CLIENT_USE_SYSTEM_STORE_REPOSITORY;
-import static com.linkedin.venice.ConfigKeys.OFFLINE_PUSH_MONITOR_DAVINCI_PUSH_STATUS_SCAN_INTERVAL_IN_SECONDS;
+import static com.linkedin.venice.ConfigKeys.DAVINCI_PUSH_STATUS_SCAN_INTERVAL_IN_SECONDS;
 import static com.linkedin.venice.ConfigKeys.PUSH_STATUS_STORE_ENABLED;
 import static com.linkedin.venice.ConfigKeys.SERVER_PROMOTION_TO_LEADER_REPLICA_DELAY_SECONDS;
 import static com.linkedin.venice.ConfigKeys.USE_PUSH_STATUS_STORE_FOR_INCREMENTAL_PUSH;
@@ -143,7 +143,7 @@ public class PushStatusStoreTest {
     extraBackendConfigMap.put(CLIENT_USE_SYSTEM_STORE_REPOSITORY, true);
     extraBackendConfigMap.put(CLIENT_SYSTEM_STORE_REPOSITORY_REFRESH_INTERVAL_SECONDS, 10);
     extraBackendConfigMap.put(PUSH_STATUS_STORE_ENABLED, true);
-    extraBackendConfigMap.put(OFFLINE_PUSH_MONITOR_DAVINCI_PUSH_STATUS_SCAN_INTERVAL_IN_SECONDS, 5);
+    extraBackendConfigMap.put(DAVINCI_PUSH_STATUS_SCAN_INTERVAL_IN_SECONDS, 5);
 
     try (DaVinciClient<Integer, Integer> daVinciClient = ServiceFactory.getGenericAvroDaVinciClientWithRetries(
         storeName,
@@ -311,7 +311,7 @@ public class PushStatusStoreTest {
 
   private PropertyBuilder getBackendConfigBuilder() {
     return DaVinciTestContext.getDaVinciPropertyBuilder(cluster.getZk().getAddress())
-        .put(OFFLINE_PUSH_MONITOR_DAVINCI_PUSH_STATUS_SCAN_INTERVAL_IN_SECONDS, 5)
+        .put(DAVINCI_PUSH_STATUS_SCAN_INTERVAL_IN_SECONDS, 5)
         .put(PUSH_STATUS_STORE_ENABLED, true);
   }
 

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestStoreMigration.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestStoreMigration.java
@@ -1,7 +1,7 @@
 package com.linkedin.venice.endToEnd;
 
+import static com.linkedin.venice.ConfigKeys.DAVINCI_PUSH_STATUS_SCAN_INTERVAL_IN_SECONDS;
 import static com.linkedin.venice.ConfigKeys.OFFLINE_JOB_START_TIMEOUT_MS;
-import static com.linkedin.venice.ConfigKeys.OFFLINE_PUSH_MONITOR_DAVINCI_PUSH_STATUS_SCAN_INTERVAL_IN_SECONDS;
 import static com.linkedin.venice.ConfigKeys.PUSH_STATUS_STORE_ENABLED;
 import static com.linkedin.venice.ConfigKeys.SERVER_PROMOTION_TO_LEADER_REPLICA_DELAY_SECONDS;
 import static com.linkedin.venice.ConfigKeys.TOPIC_CLEANUP_SLEEP_INTERVAL_BETWEEN_TOPIC_LIST_FETCH_MS;
@@ -302,7 +302,7 @@ public class TestStoreMigration {
     VeniceProperties backendConfig =
         DaVinciTestContext.getDaVinciPropertyBuilder(multiClusterWrapper.getZkServerWrapper().getAddress())
             .put(PUSH_STATUS_STORE_ENABLED, true)
-            .put(OFFLINE_PUSH_MONITOR_DAVINCI_PUSH_STATUS_SCAN_INTERVAL_IN_SECONDS, 5)
+            .put(DAVINCI_PUSH_STATUS_SCAN_INTERVAL_IN_SECONDS, 5)
             .build();
     D2Client d2Client =
         D2TestUtils.getAndStartD2Client(multiClusterWrapper.getClusters().get(srcClusterName).getZk().getAddress());

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/integration/utils/VeniceControllerWrapper.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/integration/utils/VeniceControllerWrapper.java
@@ -18,6 +18,7 @@ import static com.linkedin.venice.ConfigKeys.CONTROLLER_SSL_ENABLED;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_SYSTEM_SCHEMA_CLUSTER_NAME;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_ZK_SHARED_DAVINCI_PUSH_STATUS_SYSTEM_SCHEMA_STORE_AUTO_CREATION_ENABLED;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_ZK_SHARED_META_SYSTEM_SCHEMA_STORE_AUTO_CREATION_ENABLED;
+import static com.linkedin.venice.ConfigKeys.DAVINCI_PUSH_STATUS_SCAN_INTERVAL_IN_SECONDS;
 import static com.linkedin.venice.ConfigKeys.DEFAULT_MAX_NUMBER_OF_PARTITIONS;
 import static com.linkedin.venice.ConfigKeys.DEFAULT_NUMBER_OF_PARTITION;
 import static com.linkedin.venice.ConfigKeys.DEFAULT_PARTITION_SIZE;
@@ -33,7 +34,6 @@ import static com.linkedin.venice.ConfigKeys.MIN_ACTIVE_REPLICA;
 import static com.linkedin.venice.ConfigKeys.NATIVE_REPLICATION_FABRIC_ALLOWLIST;
 import static com.linkedin.venice.ConfigKeys.NATIVE_REPLICATION_SOURCE_FABRIC;
 import static com.linkedin.venice.ConfigKeys.OFFLINE_JOB_START_TIMEOUT_MS;
-import static com.linkedin.venice.ConfigKeys.OFFLINE_PUSH_MONITOR_DAVINCI_PUSH_STATUS_SCAN_INTERVAL_IN_SECONDS;
 import static com.linkedin.venice.ConfigKeys.PARENT_KAFKA_CLUSTER_FABRIC_LIST;
 import static com.linkedin.venice.ConfigKeys.PERSISTENCE_TYPE;
 import static com.linkedin.venice.ConfigKeys.PUSH_STATUS_STORE_ENABLED;
@@ -204,7 +204,7 @@ public class VeniceControllerWrapper extends ProcessWrapper {
             .put(CONTROLLER_ZK_SHARED_META_SYSTEM_SCHEMA_STORE_AUTO_CREATION_ENABLED, true)
             .put(CONTROLLER_ZK_SHARED_DAVINCI_PUSH_STATUS_SYSTEM_SCHEMA_STORE_AUTO_CREATION_ENABLED, true)
             .put(PUSH_STATUS_STORE_ENABLED, true)
-            .put(OFFLINE_PUSH_MONITOR_DAVINCI_PUSH_STATUS_SCAN_INTERVAL_IN_SECONDS, 5)
+            .put(DAVINCI_PUSH_STATUS_SCAN_INTERVAL_IN_SECONDS, 5)
             .put(CONCURRENT_INIT_ROUTINES_ENABLED, true)
             .put(CLUSTER_DISCOVERY_D2_SERVICE, VeniceRouterWrapper.CLUSTER_DISCOVERY_D2_SERVICE_NAME)
             .put(extraProps.toProperties());

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -5431,7 +5431,8 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
             pushStatusStoreReader.orElse(null),
             version.kafkaTopicName(),
             version.getPartitionCount(),
-            incrementalPushVersion);
+            incrementalPushVersion,
+            multiClusterConfigs.getControllerConfig(clusterName).getDaVinciPushStatusScanMaxOfflineInstance());
         ExecutionStatus daVinciStatus = daVinciStatusAndDetails.getStatus();
         String daVinciDetails = daVinciStatusAndDetails.getDetails();
         executionStatus = getOverallPushStatus(executionStatus, daVinciStatus);

--- a/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/AbstractPushMonitor.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/AbstractPushMonitor.java
@@ -120,11 +120,12 @@ public abstract class AbstractPushMonitor
         pushStatusStoreReader,
         (topic) -> handleCompletedPush(getOfflinePush(topic)),
         (topic, details) -> handleErrorPush(getOfflinePush(topic), details),
-        controllerConfig.isOfflinePushMonitorDaVinciPushStatusEnabled(),
-        controllerConfig.getOfflinePushMonitorDaVinciPushStatusScanIntervalInSeconds(),
-        controllerConfig.getOfflinePushMonitorDaVinciPushStatusScanThreadNumber(),
-        controllerConfig.getOfflinePushMonitorDaVinciPushStatusScanNoDaVinciStatusReportRetryMaxAttempt());
-    this.isOfflinePushMonitorDaVinciPushStatusEnabled = controllerConfig.isOfflinePushMonitorDaVinciPushStatusEnabled();
+        controllerConfig.isDaVinciPushStatusScanEnabled(),
+        controllerConfig.getDaVinciPushStatusScanIntervalInSeconds(),
+        controllerConfig.getDaVinciPushStatusScanThreadNumber(),
+        controllerConfig.getDaVinciPushStatusScanNoReportRetryMaxAttempt(),
+        controllerConfig.getDaVinciPushStatusScanMaxOfflineInstance());
+    this.isOfflinePushMonitorDaVinciPushStatusEnabled = controllerConfig.isDaVinciPushStatusEnabled();
     pushStatusCollector.start();
   }
 

--- a/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/PushMonitorUtils.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/PushMonitorUtils.java
@@ -96,7 +96,8 @@ public class PushMonitorUtils {
           return new ExecutionStatusWithDetails(
               ExecutionStatus.ERROR,
               " To many dead instances " + (totalReplicaCount - liveReplicaCount) + ", total instances "
-                  + totalReplicaCount, noDaVinciStatusReported);
+                  + totalReplicaCount,
+              noDaVinciStatusReported);
         }
       } else {
         storeVersionToDVCDeadInstanceTimeMap.put(topicName, System.currentTimeMillis());

--- a/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/PushMonitorUtils.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/PushMonitorUtils.java
@@ -17,7 +17,7 @@ import org.apache.logging.log4j.Logger;
  * This class contains some common util methods for push monitoring purpose.
  */
 public class PushMonitorUtils {
-  private static final long DAVINCI_DEAD_INSTANCE_REPORT_ERROR_WAIT = TimeUnit.MINUTES.toMillis(5);
+  private static long daVinciErrorInstanceWaitTime = 5;
 
   private static final Map<String, Long> storeVersionToDVCDeadInstanceTimeMap = new ConcurrentHashMap<>();
   private static final Logger LOGGER = LogManager.getLogger(PushMonitorUtils.class);
@@ -31,7 +31,8 @@ public class PushMonitorUtils {
       PushStatusStoreReader reader,
       String topicName,
       int partitionCount,
-      Optional<String> incrementalPushVersion) {
+      Optional<String> incrementalPushVersion,
+      int maxOfflineInstance) {
     if (reader == null) {
       throw new VeniceException("PushStatusStoreReader is null");
     }
@@ -88,21 +89,21 @@ public class PushMonitorUtils {
     boolean noDaVinciStatusReported = totalReplicaCount == 0;
 
     // Report error if too many davinci instances are not alive for over 5 mins
-    if (totalReplicaCount > 6 && liveReplicaCount < 0.5 * totalReplicaCount) {
+    if (totalReplicaCount - liveReplicaCount > maxOfflineInstance) {
       Long lastUpdateTime = storeVersionToDVCDeadInstanceTimeMap.get(topicName);
       if (lastUpdateTime != null) {
-        if (lastUpdateTime + DAVINCI_DEAD_INSTANCE_REPORT_ERROR_WAIT < System.currentTimeMillis()) {
+        if (lastUpdateTime + TimeUnit.MINUTES.toMillis(daVinciErrorInstanceWaitTime) < System.currentTimeMillis()) {
           storeVersionToDVCDeadInstanceTimeMap.remove(topicName);
           return new ExecutionStatusWithDetails(
               ExecutionStatus.ERROR,
-              " To many dead instances " + (totalReplicaCount - liveReplicaCount) + ", total instances "
+              " Too many dead instances: " + (totalReplicaCount - liveReplicaCount) + ", total instances: "
                   + totalReplicaCount,
               noDaVinciStatusReported);
         }
       } else {
         storeVersionToDVCDeadInstanceTimeMap.put(topicName, System.currentTimeMillis());
       }
-    } else if (liveReplicaCount > 0.5 * totalReplicaCount) {
+    } else {
       storeVersionToDVCDeadInstanceTimeMap.remove(topicName);
     }
 
@@ -148,5 +149,9 @@ public class PushMonitorUtils {
       return new ExecutionStatusWithDetails(ExecutionStatus.ERROR, statusDetail, noDaVinciStatusReported);
     }
     return new ExecutionStatusWithDetails(ExecutionStatus.STARTED, statusDetail, noDaVinciStatusReported);
+  }
+
+  static void setDaVinciErrorInstanceWaitTime(int time) {
+    daVinciErrorInstanceWaitTime = time;
   }
 }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/PushStatusCollector.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/PushStatusCollector.java
@@ -44,6 +44,8 @@ public class PushStatusCollector {
   private final int daVinciPushStatusScanThreadNumber;
   private final boolean daVinciPushStatusScanEnabled;
   private final int daVinciPushStatusNoReportRetryMaxAttempts;
+
+  private final int daVinciPushStatusScanMaxOfflineInstance;
   private ScheduledExecutorService offlinePushCheckScheduler;
   private ExecutorService pushStatusStoreScanExecutor;
   private final AtomicBoolean isStarted = new AtomicBoolean(false);
@@ -58,7 +60,8 @@ public class PushStatusCollector {
       boolean daVinciPushStatusScanEnabled,
       int daVinciPushStatusScanIntervalInSeconds,
       int daVinciPushStatusScanThreadNumber,
-      int daVinciPushStatusNoReportRetryMaxAttempts) {
+      int daVinciPushStatusNoReportRetryMaxAttempts,
+      int daVinciPushStatusScanMaxOfflineInstance) {
     this.storeRepository = storeRepository;
     this.pushStatusStoreReader = pushStatusStoreReader;
     this.pushCompletedHandler = pushCompletedHandler;
@@ -67,6 +70,7 @@ public class PushStatusCollector {
     this.daVinciPushStatusScanPeriodInSeconds = daVinciPushStatusScanIntervalInSeconds;
     this.daVinciPushStatusScanThreadNumber = daVinciPushStatusScanThreadNumber;
     this.daVinciPushStatusNoReportRetryMaxAttempts = daVinciPushStatusNoReportRetryMaxAttempts;
+    this.daVinciPushStatusScanMaxOfflineInstance = daVinciPushStatusScanMaxOfflineInstance;
   }
 
   public void start() {
@@ -128,7 +132,8 @@ public class PushStatusCollector {
               pushStatusStoreReader,
               topicName,
               pushStatus.getPartitionCount(),
-              Optional.empty());
+              Optional.empty(),
+              daVinciPushStatusScanMaxOfflineInstance);
           pushStatus.setDaVinciStatus(statusWithDetails);
           return pushStatus;
         }, pushStatusStoreScanExecutor));

--- a/services/venice-controller/src/test/java/com/linkedin/venice/pushmonitor/AbstractPushMonitorTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/pushmonitor/AbstractPushMonitorTest.java
@@ -98,10 +98,10 @@ public abstract class AbstractPushMonitorTest {
     clusterLockManager = new ClusterLockManager(clusterName);
     mockControllerConfig = mock(VeniceControllerConfig.class);
     when(mockControllerConfig.isErrorLeaderReplicaFailOverEnabled()).thenReturn(true);
-    when(mockControllerConfig.isOfflinePushMonitorDaVinciPushStatusEnabled()).thenReturn(true);
-    when(mockControllerConfig.getOfflinePushMonitorDaVinciPushStatusScanIntervalInSeconds()).thenReturn(5);
+    when(mockControllerConfig.isDaVinciPushStatusEnabled()).thenReturn(true);
+    when(mockControllerConfig.getDaVinciPushStatusScanIntervalInSeconds()).thenReturn(5);
     when(mockControllerConfig.getOffLineJobWaitTimeInMilliseconds()).thenReturn(120000L);
-    when(mockControllerConfig.getOfflinePushMonitorDaVinciPushStatusScanThreadNumber()).thenReturn(4);
+    when(mockControllerConfig.getDaVinciPushStatusScanThreadNumber()).thenReturn(4);
     monitor = getPushMonitor();
   }
 

--- a/services/venice-controller/src/test/java/com/linkedin/venice/pushmonitor/PushMonitorUtilsTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/pushmonitor/PushMonitorUtilsTest.java
@@ -1,0 +1,40 @@
+package com.linkedin.venice.pushmonitor;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+import com.linkedin.venice.pushstatushelper.PushStatusStoreReader;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class PushMonitorUtilsTest {
+  @Test
+  public void testDaVinciPushStatusScan() {
+    String topicName = "store_v1";
+    PushMonitorUtils.setDaVinciErrorInstanceWaitTime(0);
+    PushStatusStoreReader reader = mock(PushStatusStoreReader.class);
+    Map<CharSequence, Integer> map = new HashMap<>();
+    map.put("a", 3);
+    map.put("b", 3);
+    map.put("c", 3);
+    map.put("d", 10);
+    doReturn(map).when(reader).getPartitionStatus("store", 1, 0, Optional.empty());
+    doReturn(true).when(reader).isInstanceAlive(eq("store"), eq("a"));
+    doReturn(false).when(reader).isInstanceAlive(eq("store"), eq("b"));
+    doReturn(false).when(reader).isInstanceAlive(eq("store"), eq("c"));
+    doReturn(false).when(reader).isInstanceAlive(eq("store"), eq("d"));
+
+    ExecutionStatusWithDetails executionStatusWithDetails =
+        PushMonitorUtils.getDaVinciPushStatusAndDetails(reader, topicName, 1, Optional.empty(), 2);
+    Assert.assertEquals(executionStatusWithDetails.getStatus(), ExecutionStatus.STARTED);
+    executionStatusWithDetails =
+        PushMonitorUtils.getDaVinciPushStatusAndDetails(reader, topicName, 1, Optional.empty(), 2);
+    Assert.assertEquals(executionStatusWithDetails.getStatus(), ExecutionStatus.ERROR);
+    Assert.assertEquals(executionStatusWithDetails.getDetails(), " Too many dead instances: 3, total instances: 4");
+  }
+}

--- a/services/venice-controller/src/test/java/com/linkedin/venice/pushmonitor/PushStatusCollectorTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/pushmonitor/PushStatusCollectorTest.java
@@ -57,7 +57,8 @@ public class PushStatusCollectorTest {
         true,
         1,
         4,
-        1);
+        1,
+        20);
     pushStatusCollector.start();
 
     pushStatusCollector.subscribeTopic(regularStoreTopicV1, 10);
@@ -188,7 +189,8 @@ public class PushStatusCollectorTest {
         true,
         1,
         4,
-        1);
+        1,
+        20);
     pushStatusCollector.start();
 
     pushCompletedCount.set(0);


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## [controller] Report push error if too many DVC instances are dead
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

If many instances are not reporting heartbeat status to DaVinci pushstatus store, we can assume the ongoing push is not healthy. In this PR if more than certain number of instances are not alive, and its been more 5 mins its returns ERROR and fails the push job.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
CI build
## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.