### PR TITLE
[controller] system store admin messages should be processed in the same queue as their user store

### DIFF
--- a/internal/venice-common/src/main/java/com/linkedin/venice/common/VeniceSystemStoreType.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/common/VeniceSystemStoreType.java
@@ -211,7 +211,7 @@ public enum VeniceSystemStoreType {
       return null;
     }
     for (VeniceSystemStoreType systemStoreType: VALUES) {
-      if (storeName.startsWith(systemStoreType.getPrefix())) {
+      if (storeName.startsWith(systemStoreType.getPrefix()) && !systemStoreType.getPrefix().equals(storeName)) {
         return systemStoreType;
       }
     }
@@ -236,5 +236,17 @@ public enum VeniceSystemStoreType {
       enabledSystemStoreTypes.add(VeniceSystemStoreType.META_STORE);
     }
     return enabledSystemStoreTypes;
+  }
+
+  /**
+   * Extract the corresponding user store name from the given store name if it happens to be a system store.
+   */
+  public static String extractUserStoreName(String storeName) {
+    String userStoreName = storeName;
+    VeniceSystemStoreType systemStoreType = VeniceSystemStoreType.getSystemStoreType(storeName);
+    if (systemStoreType != null) {
+      userStoreName = systemStoreType.extractRegularStoreName(storeName);
+    }
+    return userStoreName;
   }
 }

--- a/internal/venice-common/src/test/java/com/linkedin/venice/common/TestVeniceSystemStoreType.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/common/TestVeniceSystemStoreType.java
@@ -1,0 +1,48 @@
+package com.linkedin.venice.common;
+
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+import com.linkedin.venice.meta.Store;
+import java.util.HashSet;
+import java.util.List;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class TestVeniceSystemStoreType {
+  @Test
+  public void testExtractUserStoreName() {
+    String userStoreName = "user_test_store";
+    String schemaStore = "venice_system_store_METADATA_SYSTEM_SCHEMA_STORE";
+    String heartBeatStore = VeniceSystemStoreType.BATCH_JOB_HEARTBEAT_STORE.getPrefix();
+
+    Assert.assertEquals(VeniceSystemStoreType.extractUserStoreName(userStoreName), userStoreName);
+    Assert.assertEquals(
+        VeniceSystemStoreType.extractUserStoreName(VeniceSystemStoreType.META_STORE.getSystemStoreName(userStoreName)),
+        userStoreName);
+    Assert.assertEquals(
+        VeniceSystemStoreType
+            .extractUserStoreName(VeniceSystemStoreType.DAVINCI_PUSH_STATUS_STORE.getSystemStoreName(userStoreName)),
+        userStoreName);
+    Assert.assertEquals(VeniceSystemStoreType.extractUserStoreName(schemaStore), schemaStore);
+    Assert.assertEquals(VeniceSystemStoreType.extractUserStoreName(heartBeatStore), heartBeatStore);
+    Assert.assertNull(VeniceSystemStoreType.extractUserStoreName(null));
+  }
+
+  @Test
+  public void testEnabledSystemStoreTypes() {
+    Store userStoreWithNothingEnabled = mock(Store.class);
+    Store userStoreWithSystemStoresEnabled = mock(Store.class);
+    doReturn(true).when(userStoreWithSystemStoresEnabled).isDaVinciPushStatusStoreEnabled();
+    doReturn(true).when(userStoreWithSystemStoresEnabled).isStoreMetaSystemStoreEnabled();
+
+    Assert.assertTrue(VeniceSystemStoreType.getEnabledSystemStoreTypes(userStoreWithNothingEnabled).isEmpty());
+    List<VeniceSystemStoreType> enabledSystemStores =
+        VeniceSystemStoreType.getEnabledSystemStoreTypes(userStoreWithSystemStoresEnabled);
+    Assert.assertEquals(enabledSystemStores.size(), 2);
+    HashSet<VeniceSystemStoreType> systemStoreSet = new HashSet<>(enabledSystemStores);
+    Assert.assertTrue(systemStoreSet.contains(VeniceSystemStoreType.META_STORE));
+    Assert.assertTrue(systemStoreSet.contains(VeniceSystemStoreType.DAVINCI_PUSH_STATUS_STORE));
+  }
+}

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -6265,8 +6265,9 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
     if (storeName == null) {
       return getLastSucceedExecutionId(clusterName);
     } else {
+      String userStoreName = VeniceSystemStoreType.extractUserStoreName(storeName);
       return adminConsumerServices.containsKey(clusterName)
-          ? adminConsumerServices.get(clusterName).getLastSucceededExecutionId(storeName)
+          ? adminConsumerServices.get(clusterName).getLastSucceededExecutionId(userStoreName)
           : null;
     }
   }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/kafka/consumer/AdminConsumptionTask.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/kafka/consumer/AdminConsumptionTask.java
@@ -829,10 +829,7 @@ public class AdminConsumptionTask implements Runnable, Closeable {
                   + " because it does not contain a storeName field");
         }
     }
-    VeniceSystemStoreType systemStoreType = VeniceSystemStoreType.getSystemStoreType(storeName);
-    if (systemStoreType != null) {
-      storeName = systemStoreType.extractRegularStoreName(storeName);
-    }
+    storeName = VeniceSystemStoreType.extractUserStoreName(storeName);
     return storeName;
   }
 

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/kafka/consumer/AdminConsumptionTask.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/kafka/consumer/AdminConsumptionTask.java
@@ -1,5 +1,6 @@
 package com.linkedin.venice.controller.kafka.consumer;
 
+import com.linkedin.venice.common.VeniceSystemStoreType;
 import com.linkedin.venice.controller.AdminTopicMetadataAccessor;
 import com.linkedin.venice.controller.ExecutionIdAccessor;
 import com.linkedin.venice.controller.VeniceHelixAdmin;
@@ -827,6 +828,10 @@ public class AdminConsumptionTask implements Runnable, Closeable {
               "Failed to handle operation type: " + adminOperation.operationType
                   + " because it does not contain a storeName field");
         }
+    }
+    VeniceSystemStoreType systemStoreType = VeniceSystemStoreType.getSystemStoreType(storeName);
+    if (systemStoreType != null) {
+      storeName = systemStoreType.extractRegularStoreName(storeName);
     }
     return storeName;
   }

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/kafka/consumer/AdminConsumptionTaskTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/kafka/consumer/AdminConsumptionTaskTest.java
@@ -38,6 +38,7 @@ import static org.mockito.Mockito.when;
 
 import com.linkedin.venice.admin.InMemoryAdminTopicMetadataAccessor;
 import com.linkedin.venice.admin.InMemoryExecutionIdAccessor;
+import com.linkedin.venice.common.VeniceSystemStoreType;
 import com.linkedin.venice.controller.AdminTopicMetadataAccessor;
 import com.linkedin.venice.controller.ExecutionIdAccessor;
 import com.linkedin.venice.controller.VeniceHelixAdmin;
@@ -1599,5 +1600,48 @@ public class AdminConsumptionTaskTest {
     verify(admin, atLeastOnce()).createStore(clusterName, storeName1, owner, keySchema, valueSchema, false);
     verify(admin, times(1)).createStore(clusterName, storeName2, owner, keySchema, valueSchema, false);
 
+  }
+
+  @Test(timeOut = TIMEOUT)
+  public void testSystemStoreMessageOrder() throws InterruptedException, IOException {
+    doThrow(new VeniceException("Prevent store creation")).when(admin)
+        .createStore(clusterName, storeName, owner, keySchema, valueSchema, false);
+    AdminConsumptionTask task = getAdminConsumptionTask(new RandomPollStrategy(), false);
+    executor.submit(task);
+    String sysStorePushId = "empty_push";
+    int sysStoreVersion = 1;
+    int sysStorePartition = 1;
+    veniceWriter.put(
+        emptyKeyBytes,
+        getStoreCreationMessage(clusterName, storeName, owner, keySchema, valueSchema, 1L),
+        AdminOperationSerializer.LATEST_SCHEMA_ID_FOR_ADMIN_OPERATION);
+    String systemStoreName = VeniceSystemStoreType.DAVINCI_PUSH_STATUS_STORE.getSystemStoreName(storeName);
+    veniceWriter.put(
+        emptyKeyBytes,
+        getAddVersionMessage(clusterName, systemStoreName, sysStorePushId, sysStoreVersion, sysStorePartition, 2L),
+        AdminOperationSerializer.LATEST_SCHEMA_ID_FOR_ADMIN_OPERATION);
+
+    // Give the consumption task at least two cycles to retry the failing user store creation message. The corresponding
+    // system store message should remain blocked/unprocessed.
+    TestUtils.waitForNonDeterministicAssertion(
+        TIMEOUT,
+        TimeUnit.MILLISECONDS,
+        () -> verify(admin, times(2)).createStore(clusterName, storeName, owner, keySchema, valueSchema, false));
+
+    verify(admin, never()).addVersionAndStartIngestion(
+        clusterName,
+        systemStoreName,
+        sysStorePushId,
+        sysStoreVersion,
+        sysStorePartition,
+        Version.PushType.BATCH,
+        null,
+        -1,
+        1,
+        false);
+
+    task.close();
+    executor.shutdown();
+    executor.awaitTermination(TIMEOUT, TimeUnit.MILLISECONDS);
   }
 }


### PR DESCRIPTION
## Summary,

1. Execution order of admin messages for user store and their corresponding system store matters.

If the messages are processed in separate queues in AdminConsumptionTask then the following race is possible: expected order: create user store -> empty push to system store -> delete user store execution order: empty push to system store -> create user store -> delete user store or create user store -> delete user store -> empty push to system store.

The empty push to system store will fail due to VeniceNoStoreException.

2. Added new unit test for similar scenario as the race described above.

## How was this PR tested?
Existing tests and added a new test

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.