### PR TITLE
[test] Fix argument match bug in TestDataRecoveryClient.testMon…

### DIFF
--- a/clients/venice-admin-tool/src/test/java/com/linkedin/venice/TestDataRecoveryClient.java
+++ b/clients/venice-admin-tool/src/test/java/com/linkedin/venice/TestDataRecoveryClient.java
@@ -217,7 +217,7 @@ public class TestDataRecoveryClient {
     doReturn(storeResponse).when(mockedCli).getStore(anyString());
     doReturn(discoveryResponse).when(mockedCli).discoverCluster(anyString());
     doReturn(statusResponse).when(mockedCli).getFutureVersions(anyString(), anyString());
-    doReturn(queryResponse).when(mockedCli).queryDetailedJobStatus(anyString(), anyString());
+    doReturn(queryResponse).when(mockedCli).queryDetailedJobStatus(any(), anyString());
     doReturn(storeHealthResp).when(mockedCli).listStorePushInfo(anyString(), anyBoolean());
 
     DataRecoveryClient dataRecoveryClient = mock(DataRecoveryClient.class);


### PR DESCRIPTION
…itor

## Summary, imperative, start upper case, don't end with a period

mockito.anyString matches any non-null String, but in the unit test, a null String is possible, thus cannot match the function signature, which leads to a Nullpointer in later steps.

This rb fixes the issue by using a mockito.any() to include null.

## How was this PR tested?
Internal CI (Venice-WcTest8, #1223; Venice-WcTest, #8033, no TestDataRecoveryClient.testMonitor failure) 

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.