### PR TITLE
[server] Do not throw exception in MetaStoreNotifier for DROPPED action when store is being deleted

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/notifier/MetaSystemStoreReplicaStatusNotifier.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/notifier/MetaSystemStoreReplicaStatusNotifier.java
@@ -1,6 +1,7 @@
 package com.linkedin.davinci.notifier;
 
 import com.linkedin.venice.common.VeniceSystemStoreType;
+import com.linkedin.venice.exceptions.VeniceNoStoreException;
 import com.linkedin.venice.meta.Instance;
 import com.linkedin.venice.meta.ReadOnlyStoreRepository;
 import com.linkedin.venice.meta.Store;
@@ -39,7 +40,21 @@ public class MetaSystemStoreReplicaStatusNotifier implements VeniceNotifier {
       // No replica status reporting for meta system stores
       return;
     }
-    Store store = storeRepository.getStoreOrThrow(storeName);
+    Store store;
+    try {
+      store = storeRepository.getStoreOrThrow(storeName);
+    } catch (VeniceNoStoreException e) {
+      /**
+       * For store deletion, store removal in store repo might happen faster then {@link ExecutionStatus.DROPPED} action.
+       * This is to make sure the meta store notifier does not throw exception when this happens. For other status, this
+       * is not expected, so we should throw exception.
+       */
+      if (status.equals(ExecutionStatus.DROPPED)) {
+        LOGGER.warn("Store {} does not exist in store repository. Skip reporting status: {}", storeName, status);
+        return;
+      }
+      throw e;
+    }
     if (!store.isStoreMetaSystemStoreEnabled()) {
       // Meta system store is not enabled yet.
       LOGGER.info("Meta system store for topic: {} is not enabled yet", kafkaTopic);

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/notifier/TestMetaSystemStoreReplicaStatusNotifier.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/notifier/TestMetaSystemStoreReplicaStatusNotifier.java
@@ -1,0 +1,34 @@
+package com.linkedin.davinci.notifier;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.linkedin.venice.exceptions.VeniceNoStoreException;
+import com.linkedin.venice.meta.ReadOnlyStoreRepository;
+import com.linkedin.venice.system.store.MetaStoreWriter;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class TestMetaSystemStoreReplicaStatusNotifier {
+  @Test
+  public void testNotifierWillNotThrowExceptionWhenStoreIsDeleted() {
+    MetaSystemStoreReplicaStatusNotifier notifier = mock(MetaSystemStoreReplicaStatusNotifier.class);
+    ReadOnlyStoreRepository storeRepository = mock(ReadOnlyStoreRepository.class);
+    when(storeRepository.getStoreOrThrow("store")).thenThrow(VeniceNoStoreException.class);
+    MetaStoreWriter metaStoreWriter = mock(MetaStoreWriter.class);
+    when(notifier.getMetaStoreWriter()).thenReturn(metaStoreWriter);
+    when(notifier.getStoreRepository()).thenReturn(storeRepository);
+    doCallRealMethod().when(notifier).report(anyString(), anyInt(), any());
+    doCallRealMethod().when(notifier).drop(anyString(), anyInt());
+    doCallRealMethod().when(notifier).started(anyString(), anyInt(), anyString());
+    // For DROPPED action, no exception will be thrown.
+    notifier.drop("store_v1", 1);
+    // For other action, VeniceNoStoreException will be thrown.
+    Assert.assertThrows(VeniceNoStoreException.class, () -> notifier.started("store_v1", 1, ""));
+  }
+}


### PR DESCRIPTION

<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## [server] Do not throw exception in MetaStoreNotifier for DROPPED action when store is being deleted
Found this some time ago in Venice Server in test env with (both ingestion isolation on and off)
This may result in OFFLINE->DROPPED being rollbacked by Helix mechanism, which results in storage engine lingering. (Although it might eventually be cleaned up by cleaner service, I still think it is not good action to have).

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
Existing tests.

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.