### PR TITLE
[all][tc][controller] Always close SchemaReader in AvroStoreClients. Reuse store clients in Controller

### DIFF
--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/AbstractAvroStoreClient.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/AbstractAvroStoreClient.java
@@ -21,7 +21,6 @@ import com.linkedin.venice.client.store.streaming.ReadEnvelopeChunkedDeserialize
 import com.linkedin.venice.client.store.streaming.StreamingCallback;
 import com.linkedin.venice.client.store.streaming.TrackingStreamingCallback;
 import com.linkedin.venice.client.store.transport.D2TransportClient;
-import com.linkedin.venice.client.store.transport.HttpTransportClient;
 import com.linkedin.venice.client.store.transport.TransportClient;
 import com.linkedin.venice.client.store.transport.TransportClientResponse;
 import com.linkedin.venice.client.store.transport.TransportClientStreamingCallback;
@@ -717,7 +716,7 @@ public abstract class AbstractAvroStoreClient<K, V> extends InternalAvroStoreCli
   public void start() throws VeniceClientException {
     if (needSchemaReader) {
       this.schemaReader = new RouterBackedSchemaReader(
-          this::getStoreClientForSchemaReader,
+          this,
           getReaderSchema(),
           clientConfig.getPreferredSchemaFilter(),
           clientConfig.getSchemaRefreshPeriod(),
@@ -731,12 +730,8 @@ public abstract class AbstractAvroStoreClient<K, V> extends InternalAvroStoreCli
    */
   @Override
   public void close() {
-    boolean isHttp = transportClient instanceof HttpTransportClient;
     IOUtils.closeQuietly(transportClient, LOGGER::error);
-    if (isHttp) { // TODO make d2client close method idempotent. d2client re-uses the transport client for the schema
-                  // reader
-      IOUtils.closeQuietly(schemaReader, LOGGER::error);
-    }
+    IOUtils.closeQuietly(schemaReader, LOGGER::error);
     IOUtils.closeQuietly(compressorFactory, LOGGER::error);
     if (asyncStoreInitThread != null) {
       asyncStoreInitThread.interrupt();
@@ -746,8 +741,6 @@ public abstract class AbstractAvroStoreClient<K, V> extends InternalAvroStoreCli
   protected Optional<Schema> getReaderSchema() {
     return Optional.empty();
   }
-
-  protected abstract AbstractAvroStoreClient<K, V> getStoreClientForSchemaReader();
 
   public abstract RecordDeserializer<V> getDataRecordDeserializer(int schemaId) throws VeniceClientException;
 

--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/AbstractAvroStoreClient.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/AbstractAvroStoreClient.java
@@ -581,7 +581,7 @@ public abstract class AbstractAvroStoreClient<K, V> extends InternalAvroStoreCli
    *
    * @param stats The {@link ClientStats} object to record into. Should be the one passed by the {@link StatTrackingStoreClient}.
    * @param preRequestTimeInNS The request start time. Should be the one passed by the {@link StatTrackingStoreClient}.
-   * @param handleResponseOnDeserializationExecutor if true, will execute the {@param responseHandler} on the {@link #deserializationExecutor}
+   * @param handleResponseOnDeserializationExecutor if true, will execute the {@param responseHandler} on the {@link deserializationExecutor}
    *                                                if false, will execute the {@param responseHandler} on the same thread.
    * @param requestSubmitter A closure which ONLY submits the request to the backend. Should not include any pre-submission work (i.e.: serialization).
    * @param responseHandler A closure which interprets the response from the backend (i.e.: deserialization).

--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/AvroGenericStoreClientImpl.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/AvroGenericStoreClientImpl.java
@@ -28,17 +28,6 @@ public class AvroGenericStoreClientImpl<K, V> extends AbstractAvroStoreClient<K,
     }
   }
 
-  /**
-   * To avoid cycle dependency, we need to initialize another store client for schema reader.
-   */
-  @Override
-  protected AbstractAvroStoreClient<K, V> getStoreClientForSchemaReader() {
-    return new AvroGenericStoreClientImpl<K, V>(
-        getTransportClient().getCopyIfNotUsableInCallback(),
-        false,
-        ClientConfig.defaultGenericClientConfig(getStoreName()));
-  }
-
   @Override
   public RecordDeserializer<V> getDataRecordDeserializer(int writerSchemaId) throws VeniceClientException {
     SchemaReader schemaReader = getSchemaReader();

--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/AvroSpecificStoreClientImpl.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/AvroSpecificStoreClientImpl.java
@@ -56,19 +56,6 @@ public class AvroSpecificStoreClientImpl<K, V extends SpecificRecord> extends Ab
     }
   }
 
-  /**
-   * To avoid cycle dependency, we need to initialize another store client for schema reader.
-   * @return
-   * @throws VeniceClientException
-   */
-  @Override
-  protected AbstractAvroStoreClient<K, V> getStoreClientForSchemaReader() {
-    return new AvroSpecificStoreClientImpl<K, V>(
-        getTransportClient().getCopyIfNotUsableInCallback(),
-        false,
-        ClientConfig.defaultSpecificClientConfig(getStoreName(), valueClass));
-  }
-
   @Override
   protected Optional<Schema> getReaderSchema() {
     return Optional.of(SpecificData.get().getSchema(valueClass));

--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/VsonGenericStoreClientImpl.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/VsonGenericStoreClientImpl.java
@@ -22,14 +22,6 @@ public class VsonGenericStoreClientImpl<K, V> extends AvroGenericStoreClientImpl
   }
 
   @Override
-  protected AbstractAvroStoreClient<K, V> getStoreClientForSchemaReader() {
-    return new VsonGenericStoreClientImpl<K, V>(
-        getTransportClient().getCopyIfNotUsableInCallback(),
-        false,
-        ClientConfig.defaultVsonGenericClientConfig(getStoreName()));
-  }
-
-  @Override
   protected RecordDeserializer<V> getDeserializerFromFactory(Schema writer, Schema reader) {
     return SerializerDeserializerFactory.getVsonDeserializer(writer, reader);
   }

--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/transport/HttpTransportClient.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/transport/HttpTransportClient.java
@@ -46,6 +46,12 @@ public class HttpTransportClient extends TransportClient {
     httpClient.start();
   }
 
+  /**
+   * Note: The callback that is triggered by {@link CloseableHttpAsyncClient} runs in the same thread as one of it's worker
+   * threads and if the users of the future run tasks that block the release of the future thread, a deadlock will occur.
+   * Hence, use the async handlers of {@link CompletableFuture} if you plan to use the same client to make multiple
+   * requests sequentially.
+   */
   @Override
   public CompletableFuture<TransportClientResponse> get(String requestPath, Map<String, String> headers) {
     HttpGet request = getHttpGetRequest(requestPath, headers);
@@ -54,6 +60,12 @@ public class HttpTransportClient extends TransportClient {
     return valueFuture;
   }
 
+  /**
+   * Note: The callback that is triggered by {@link CloseableHttpAsyncClient} runs in the same thread as one of it's worker
+   * threads and if the users of the future run tasks that block the release of the future thread, a deadlock will occur.
+   * Hence, use the async handlers of {@link CompletableFuture} if you plan to use the same client to make multiple
+   * requests sequentially.
+   */
   @Override
   public CompletableFuture<TransportClientResponse> post(
       String requestPath,
@@ -67,6 +79,10 @@ public class HttpTransportClient extends TransportClient {
 
   /**
    * Leverage non-streaming post to achieve feature parity.
+   * Note: The callback that is triggered by {@link CloseableHttpAsyncClient} runs in the same thread as one of it's worker
+   * threads and if the users of the future run tasks that block the release of the future thread, a deadlock will occur.
+   * Hence, use the async handlers of {@link CompletableFuture} if you plan to use the same client to make multiple
+   * requests sequentially.
    */
   @Override
   public void streamPost(
@@ -134,15 +150,6 @@ public class HttpTransportClient extends TransportClient {
     }
   }
 
-  /**
-   * The same {@link CloseableHttpAsyncClient} could not be used to send out another request in its own callback function.
-   * @return
-   */
-  @Override
-  public TransportClient getCopyIfNotUsableInCallback() {
-    return new HttpTransportClient(routerUrl);
-  }
-
   private static class HttpTransportClientCallback extends TransportClientCallback
       implements FutureCallback<HttpResponse> {
     public HttpTransportClientCallback(CompletableFuture<TransportClientResponse> valueFuture) {
@@ -190,7 +197,7 @@ public class HttpTransportClient extends TransportClient {
     }
   }
 
-  public static String ensureTrailingSlash(String input) {
+  private static String ensureTrailingSlash(String input) {
     if (input.endsWith("/")) {
       return input;
     } else {

--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/transport/HttpsTransportClient.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/transport/HttpsTransportClient.java
@@ -8,13 +8,10 @@ import org.apache.http.nio.conn.ssl.SSLIOSessionStrategy;
 
 
 public class HttpsTransportClient extends HttpTransportClient {
-  private SSLFactory sslFactory;
-
   public HttpsTransportClient(String routerUrl, SSLFactory sslFactory) {
     this(
         routerUrl,
         HttpAsyncClients.custom().setSSLStrategy(new SSLIOSessionStrategy(sslFactory.getSSLContext())).build());
-    this.sslFactory = sslFactory;
   }
 
   public HttpsTransportClient(String routerUrl, CloseableHttpAsyncClient client) {
@@ -22,14 +19,5 @@ public class HttpsTransportClient extends HttpTransportClient {
     if (!routerUrl.startsWith(HTTPS)) {
       throw new VeniceException("Must use https url with HttpsTransportClient, found: " + routerUrl);
     }
-  }
-
-  /**
-   * The same {@link CloseableHttpAsyncClient} could not be used to send out another request in its own callback function.
-   * @return
-   */
-  @Override
-  public TransportClient getCopyIfNotUsableInCallback() {
-    return new HttpsTransportClient(routerUrl, sslFactory);
   }
 }

--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/transport/TransportClient.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/transport/TransportClient.java
@@ -34,14 +34,4 @@ public abstract class TransportClient implements Closeable {
       byte[] requestBody,
       TransportClientStreamingCallback callback,
       int keyCount);
-
-  /**
-   * If the internal client could not be used by its callback function,
-   * implementation of this function should return a new copy.
-   * The default implementation is to return itself.
-   * @return
-   */
-  public TransportClient getCopyIfNotUsableInCallback() {
-    return this;
-  }
 }

--- a/clients/venice-thin-client/src/test/java/com/linkedin/venice/client/store/AbstractAvroStoreClientTest.java
+++ b/clients/venice-thin-client/src/test/java/com/linkedin/venice/client/store/AbstractAvroStoreClientTest.java
@@ -74,11 +74,6 @@ public class AbstractAvroStoreClientTest {
     }
 
     @Override
-    protected AbstractAvroStoreClient<K, V> getStoreClientForSchemaReader() {
-      return this;
-    }
-
-    @Override
     public RecordDeserializer<V> getDataRecordDeserializer(int schemaId) throws VeniceClientException {
       return null;
     }

--- a/clients/venice-thin-client/src/test/java/com/linkedin/venice/client/store/StatTrackingStoreClientTest.java
+++ b/clients/venice-thin-client/src/test/java/com/linkedin/venice/client/store/StatTrackingStoreClientTest.java
@@ -67,11 +67,6 @@ public class StatTrackingStoreClientTest {
     }
 
     @Override
-    protected AbstractAvroStoreClient<K, V> getStoreClientForSchemaReader() {
-      return null;
-    }
-
-    @Override
     public RecordDeserializer<V> getDataRecordDeserializer(int schemaId) throws VeniceClientException {
       return null;
     }

--- a/clients/venice-thin-client/src/test/java/com/linkedin/venice/client/store/TestAvroStoreClient.java
+++ b/clients/venice-thin-client/src/test/java/com/linkedin/venice/client/store/TestAvroStoreClient.java
@@ -46,7 +46,6 @@ public class TestAvroStoreClient {
   @BeforeClass
   public void setUp() throws VeniceClientException, IOException {
     mockTransportClient = mock(TransportClient.class);
-    doReturn(mockTransportClient).when(mockTransportClient).getCopyIfNotUsableInCallback();
 
     byte[] schemaResponseInBytes = StoreClientTestUtils.constructSchemaResponseInBytes(STORE_NAME, 1, KEY_SCHEMA_STR);
     setupSchemaResponse(schemaResponseInBytes, RouterBackedSchemaReader.TYPE_KEY_SCHEMA + "/" + STORE_NAME);

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -200,6 +200,7 @@ import com.linkedin.venice.utils.SslUtils;
 import com.linkedin.venice.utils.Time;
 import com.linkedin.venice.utils.Utils;
 import com.linkedin.venice.utils.VeniceProperties;
+import com.linkedin.venice.utils.concurrent.ConcurrencyUtils;
 import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
 import com.linkedin.venice.utils.locks.AutoCloseableLock;
 import com.linkedin.venice.views.VeniceView;
@@ -232,7 +233,6 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import org.apache.avro.Schema;
-import org.apache.avro.specific.SpecificRecord;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.Validate;
 import org.apache.helix.AccessOption;
@@ -398,6 +398,12 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
   private DataRecoveryManager dataRecoveryManager;
 
   protected final PubSubTopicRepository pubSubTopicRepository;
+
+  private final Object PUSH_JOB_DETAILS_CLIENT_LOCK = new Object();
+  private AvroSpecificStoreClient<PushJobStatusRecordKey, PushJobDetails> pushJobDetailsStoreClient = null;
+
+  private final Object LIVENESS_HEARTBEAT_CLIENT_LOCK = new Object();
+  private AvroSpecificStoreClient<BatchJobHeartbeatKey, BatchJobHeartbeatValue> livenessHeartbeatStoreClient = null;
 
   public VeniceHelixAdmin(
       VeniceControllerMultiClusterConfig multiClusterConfigs,
@@ -1188,9 +1194,19 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
   @Override
   public PushJobDetails getPushJobDetails(@Nonnull PushJobStatusRecordKey key) {
     Validate.notNull(key);
-    String storeName = VeniceSystemStoreUtils.getPushJobDetailsStoreName();
-    String d2Service = discoverCluster(storeName).getSecond();
-    return readValue(key, storeName, d2Service, PushJobDetails.class);
+    ConcurrencyUtils.executeUnderConditionalLock(() -> {
+      String storeName = VeniceSystemStoreUtils.getPushJobDetailsStoreName();
+      String d2Service = discoverCluster(storeName).getSecond();
+      pushJobDetailsStoreClient = ClientFactory.getAndStartSpecificAvroClient(
+          ClientConfig.defaultSpecificClientConfig(storeName, PushJobDetails.class)
+              .setD2ServiceName(d2Service)
+              .setD2Client(this.d2Client));
+    }, () -> pushJobDetailsStoreClient == null, PUSH_JOB_DETAILS_CLIENT_LOCK);
+    try {
+      return pushJobDetailsStoreClient.get(key).get();
+    } catch (Exception e) {
+      throw new VeniceException(e);
+    }
   }
 
   /**
@@ -1199,22 +1215,16 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
   @Override
   public BatchJobHeartbeatValue getBatchJobHeartbeatValue(@Nonnull BatchJobHeartbeatKey batchJobHeartbeatKey) {
     Validate.notNull(batchJobHeartbeatKey);
-    String storeName = VeniceSystemStoreType.BATCH_JOB_HEARTBEAT_STORE.getPrefix();
-    String d2Service = discoverCluster(storeName).getSecond();
-    return readValue(batchJobHeartbeatKey, storeName, d2Service, BatchJobHeartbeatValue.class);
-  }
-
-  private <K, V extends SpecificRecord> V readValue(
-      K key,
-      String storeName,
-      String d2Service,
-      Class<V> specificValueClass) {
-    // TODO: we may need to use the ICProvider interface to avoid missing IC warning logs when making these client calls
-    try (AvroSpecificStoreClient<K, V> client = ClientFactory.getAndStartSpecificAvroClient(
-        ClientConfig.defaultSpecificClientConfig(storeName, specificValueClass)
-            .setD2ServiceName(d2Service)
-            .setD2Client(this.d2Client))) {
-      return client.get(key).get();
+    ConcurrencyUtils.executeUnderConditionalLock(() -> {
+      String storeName = VeniceSystemStoreType.BATCH_JOB_HEARTBEAT_STORE.getPrefix();
+      String d2Service = discoverCluster(storeName).getSecond();
+      livenessHeartbeatStoreClient = ClientFactory.getAndStartSpecificAvroClient(
+          ClientConfig.defaultSpecificClientConfig(storeName, BatchJobHeartbeatValue.class)
+              .setD2ServiceName(d2Service)
+              .setD2Client(this.d2Client));
+    }, () -> livenessHeartbeatStoreClient == null, LIVENESS_HEARTBEAT_CLIENT_LOCK);
+    try {
+      return livenessHeartbeatStoreClient.get(batchJobHeartbeatKey).get();
     } catch (Exception e) {
       throw new VeniceException(e);
     }
@@ -6505,6 +6515,8 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
     pushStatusStoreReader.ifPresent(PushStatusStoreReader::close);
     pushStatusStoreWriter.ifPresent(PushStatusStoreWriter::close);
     pushStatusStoreDeleter.ifPresent(PushStatusStoreRecordDeleter::close);
+    Utils.closeQuietlyWithErrorLogged(pushJobDetailsStoreClient);
+    Utils.closeQuietlyWithErrorLogged(livenessHeartbeatStoreClient);
     clusterControllerClientPerColoMap.forEach(
         (clusterName, controllerClientMap) -> controllerClientMap.values().forEach(Utils::closeQuietlyWithErrorLogged));
     D2ClientUtils.shutdownClient(d2Client);


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Always close `SchemaReader` in `AbstractAvroStoreClient`
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
There is a cyclic dependency between `AbstractAvroStoreClient` and `RouterBackedSchemaReader` which needed creating a new store client for each internal `RouterBackedSchemaReader` so that `RouterBackedSchemaReader` could release resources when it is closed.

Recently, we've added the notion of ownership of the store client in `RouterBackedSchemaReader`. With this change, we no longer need to create a new store client for each `RouterBackedSchemaReader` and so, we can now always close the `SchemaReader` object when the store client itself is closed.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
GH CI

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [X] Yes. Make sure to explain your proposed changes and call out the behavior change.
This commit introduces breaking changes to the public API of two classes:
1. `AbstractAvroStoreClient`: Removed the `getStoreClientForSchemaReader` method
2. `HttpTransportClient`: Removed the `getCopyIfNotUsableInCallback` method
However, given that all implementations and usages of the two classes were internal to the same `venice-thin-client` module, they will all be atomically upgraded and hence, it should be okay