### PR TITLE
[controller] Check for cluster health during poll status query

### DIFF
--- a/internal/venice-common/src/main/java/com/linkedin/venice/utils/HelixUtils.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/utils/HelixUtils.java
@@ -21,6 +21,7 @@ import org.apache.helix.model.CustomizedStateConfig;
 import org.apache.helix.model.HelixConfigScope;
 import org.apache.helix.model.InstanceConfig;
 import org.apache.helix.model.LiveInstance;
+import org.apache.helix.model.MaintenanceSignal;
 import org.apache.helix.model.builder.HelixConfigScopeBuilder;
 import org.apache.helix.zookeeper.zkclient.DataUpdater;
 import org.apache.logging.log4j.LogManager;
@@ -166,20 +167,20 @@ public class HelixUtils {
     throw new ZkDataAccessException(path, "set", retryCount);
   }
 
-  public static <T> void updateChildren(ZkBaseDataAccessor<T> dataAccessor, List<String> pathes, List<T> data) {
-    updateChildren(dataAccessor, pathes, data, DEFAULT_HELIX_OP_RETRY_COUNT);
+  public static <T> void updateChildren(ZkBaseDataAccessor<T> dataAccessor, List<String> paths, List<T> data) {
+    updateChildren(dataAccessor, paths, data, DEFAULT_HELIX_OP_RETRY_COUNT);
   }
 
   // TODO there is not atomic operations to update multiple node to ZK. We should ask Helix library to rollback if it's
   // only partial successful.
   public static <T> void updateChildren(
       ZkBaseDataAccessor<T> dataAccessor,
-      List<String> pathes,
+      List<String> paths,
       List<T> data,
       int retryCount) {
     int retry = 0;
     while (retry < retryCount) {
-      boolean[] results = dataAccessor.setChildren(pathes, data, AccessOption.PERSISTENT);
+      boolean[] results = dataAccessor.setChildren(paths, data, AccessOption.PERSISTENT);
       boolean isAllSuccessful = true;
       for (Boolean r: results) {
         if (!r) {
@@ -193,7 +194,7 @@ public class HelixUtils {
       retry++;
       if (retry == retryCount) {
         throw new ZkDataAccessException(
-            pathes.get(0).substring(0, pathes.get(0).lastIndexOf('/')),
+            paths.get(0).substring(0, paths.get(0).lastIndexOf('/')),
             "update children",
             retryCount);
       }
@@ -333,6 +334,12 @@ public class HelixUtils {
     } else {
       return true;
     }
+  }
+
+  public static MaintenanceSignal getClusterMaintenanceSignal(String clusterName, SafeHelixManager manager) {
+    PropertyKey.Builder keyBuilder = new PropertyKey.Builder(clusterName);
+    SafeHelixDataAccessor accessor = manager.getHelixDataAccessor();
+    return accessor.getProperty(keyBuilder.maintenance());
   }
 
   /**

--- a/internal/venice-common/src/main/java/com/linkedin/venice/utils/HelixUtils.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/utils/HelixUtils.java
@@ -336,6 +336,13 @@ public class HelixUtils {
     }
   }
 
+  /**
+   * If a cluster is in maintenance mode it returns all the signals associated with it regarding the reason
+   * and other details for creating the maintenance mode.
+   * @param clusterName
+   * @param manager
+   * @return the maintenance mode signal if the cluster is in maintenance mode, otherwise returns null.
+   */
   public static MaintenanceSignal getClusterMaintenanceSignal(String clusterName, SafeHelixManager manager) {
     PropertyKey.Builder keyBuilder = new PropertyKey.Builder(clusterName);
     SafeHelixDataAccessor accessor = manager.getHelixDataAccessor();

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -5409,7 +5409,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
     MaintenanceSignal maintenanceSignal =
         HelixUtils.getClusterMaintenanceSignal(clusterName, resources.getHelixManager());
 
-    // Check if cluster is in maintenance mode due to too many offline instances
+    // Check if cluster is in maintenance mode due to too many offline instances or too many partitions per instance
     if (maintenanceSignal != null && maintenanceSignal
         .getAutoTriggerReason() == MaintenanceSignal.AutoTriggerReason.MAX_OFFLINE_INSTANCES_EXCEEDED) {
       String msg = "Push errored out for " + kafkaTopic + "due to too many offline instances. Reason: "
@@ -5428,9 +5428,8 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
     if (executionStatus.equals(ExecutionStatus.NOT_CREATED)) {
       StringBuilder moreDetailsBuilder = new StringBuilder(details == null ? "" : details + " and ");
 
-      // Check whether cluster is in manually triggered maintenance mode or not
-      if (maintenanceSignal != null
-          && maintenanceSignal.getTriggeringEntity() != MaintenanceSignal.TriggeringEntity.CONTROLLER) {
+      // Check whether cluster is in maintenance mode or not
+      if (maintenanceSignal != null) {
         moreDetailsBuilder.append("Cluster: ").append(clusterName).append(" is in maintenance mode");
       } else {
         moreDetailsBuilder.append("Version creation for topic: ").append(kafkaTopic).append(" got delayed");


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

##  Check for cluster health during poll status query
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

During push, if too many instances become offline and crosses per cluster config `MAX_OFFLINE_INSTANCES_ALLOWED` Helix puts the cluster into maintenance mode. This PR would detect such maintenance mode and marks such pushes as ERROR which will fail the pushjob. This will stop further pushes during target colo push or waiting infinitely for regular pushes when cluster in such state.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

GHCI

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.