### PR TITLE
[all] Raise ConnectException only if all hosts in ControllerClient are unreachable

### DIFF
--- a/internal/venice-avro-compatibility-test/src/test/java/com/linkedin/venice/VeniceClientCompatibilityTest.java
+++ b/internal/venice-avro-compatibility-test/src/test/java/com/linkedin/venice/VeniceClientCompatibilityTest.java
@@ -65,7 +65,7 @@ public class VeniceClientCompatibilityTest {
      *
      * If it is flaky, maybe we could add some retry logic to make it more resilient in the future.
      */
-    String routerPort = Integer.toString(Utils.getFreePort());
+    String routerPort = Integer.toString(TestUtils.getFreePort());
     String routerAddress = "http://localhost:" + routerPort;
     LOGGER.info("Router address in unit test: {}", routerAddress);
 

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/httpclient5/HttpClient5Test.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/httpclient5/HttpClient5Test.java
@@ -5,7 +5,6 @@ import com.linkedin.venice.security.SSLFactory;
 import com.linkedin.venice.utils.ForkedJavaProcess;
 import com.linkedin.venice.utils.SslUtils;
 import com.linkedin.venice.utils.TestUtils;
-import com.linkedin.venice.utils.Utils;
 import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
@@ -44,7 +43,7 @@ public class HttpClient5Test {
    * This is not very safe since the port can be grabbed by some parallel tests.
    * Will tune this logic if this test become very flaky.
    */
-  private final int port = Utils.getFreePort();
+  private final int port = TestUtils.getFreePort();
 
   private void sendRequest(CloseableHttpAsyncClient httpClient, int iteration, boolean failOnTimeout) {
     LOGGER.info("Iteration: {}", iteration);

--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerClient.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerClient.java
@@ -74,6 +74,7 @@ import static com.linkedin.venice.meta.Version.PushType;
 import com.linkedin.venice.HttpConstants;
 import com.linkedin.venice.LastSucceedExecutionIdResponse;
 import com.linkedin.venice.controllerapi.routes.AdminCommandExecutionResponse;
+import com.linkedin.venice.exceptions.ErrorType;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.exceptions.VeniceHttpException;
 import com.linkedin.venice.helix.VeniceJsonSerializer;
@@ -81,10 +82,12 @@ import com.linkedin.venice.meta.VeniceUserStoreType;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.pushmonitor.ExecutionStatus;
 import com.linkedin.venice.security.SSLFactory;
+import com.linkedin.venice.utils.ExceptionUtils;
 import com.linkedin.venice.utils.Time;
 import com.linkedin.venice.utils.Utils;
 import java.io.Closeable;
 import java.io.IOException;
+import java.net.ConnectException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -184,6 +187,7 @@ public class ControllerClient implements Closeable {
     List<String> urls = new ArrayList<>(this.controllerDiscoveryUrls);
     Collections.shuffle(urls);
 
+    Exception lastConnectException = null;
     Exception lastException = null;
     try (ControllerTransport transport = new ControllerTransport(sslFactory)) {
       for (String url: urls) {
@@ -195,10 +199,28 @@ public class ControllerClient implements Closeable {
           return leaderControllerUrl;
         } catch (Exception e) {
           LOGGER.warn("Unable to discover leader controller from {}", url);
-          lastException = e;
+          if (ExceptionUtils.recursiveClassEquals(e, ConnectException.class)) {
+            lastConnectException = e;
+          } else {
+            lastException = e;
+          }
         }
       }
     }
+
+    /**
+     * During normal operation, some hosts might be down for maintenance. Over time, the host list might even get
+     * stale. So, when requests are made to hosts which no longer host venice controllers or routers,
+     * {@link ConnectException} will be thrown. When the request actually leads to an error, all active hosts in
+     * the host list will throw this error and the inactive hosts will throw the {@link ConnectException}. In such
+     * cases, the {@link ConnectException} is not actionable by the user. If after trying all controllers and routers,
+     * we still don't have any other non-{@link ConnectException}, the {@link ConnectException} is the most actionable
+     * exception, and we throw that.
+     */
+    if (lastException == null) {
+      lastException = lastConnectException;
+    }
+
     String message = "Unable to discover leader controller from " + this.controllerDiscoveryUrls;
     LOGGER.error(message, lastException);
     throw new VeniceException(message, lastException);
@@ -1105,6 +1127,7 @@ public class ControllerClient implements Closeable {
     List<String> urls = new ArrayList<>(this.controllerDiscoveryUrls);
     Collections.shuffle(urls);
 
+    Exception lastConnectException = null;
     Exception lastException = null;
     try (ControllerTransport transport = new ControllerTransport(sslFactory)) {
       for (String url: urls) {
@@ -1119,15 +1142,43 @@ public class ControllerClient implements Closeable {
             // TODO: Routers also support fetching the store name via query params. So, once sufficient time has passed,
             // this check can be changed to break out of the loop on non-5XX errors.
 
+            // Temporary hack to not attempt querying further if controller explicitly returns that store was not found
+            // If Controllers have not been upgraded recently, they will return a 404 status with GENERAL_ERROR as the
+            // ErrorType. If they have been upgraded to recent versions, they will return the proper STORE_NOT_FOUND
+            // ErrorType.
+            if (e.getErrorType() == ErrorType.STORE_NOT_FOUND
+                || (e.getErrorType() == ErrorType.GENERAL_ERROR && e.getHttpStatusCode() == 404)) {
+              lastException = e;
+              break;
+            }
+
             String routerPath = ControllerRoute.CLUSTER_DISCOVERY.getPath() + "/" + storeName;
             return transport.executeGet(url, routerPath, new QueryParams(), D2ServiceDiscoveryResponse.class);
           }
         } catch (Exception e) {
           LOGGER.warn("Unable to discover cluster for store {} from {}", storeName, url);
-          lastException = e;
+          if (ExceptionUtils.recursiveClassEquals(e, ConnectException.class)) {
+            lastConnectException = e;
+          } else {
+            lastException = e;
+          }
         }
       }
     }
+
+    /**
+     * During normal operation, some hosts might be down for maintenance. Over time, the host list might even get
+     * stale. So, when requests are made to hosts which no longer host venice controllers or routers,
+     * {@link ConnectException} will be thrown. When the request actually leads to an error, all active hosts in
+     * the host list will throw this error and the inactive hosts will throw the {@link ConnectException}. In such
+     * cases, the {@link ConnectException} is not actionable by the user. If after trying all controllers and routers,
+     * we still don't have any other non-{@link ConnectException}, the {@link ConnectException} is the most actionable
+     * exception, and we throw that.
+     */
+    if (lastException == null) {
+      lastException = lastConnectException;
+    }
+
     String message = "Unable to discover cluster for store " + storeName + " from " + this.controllerDiscoveryUrls;
     return makeErrorResponse(message, lastException, D2ServiceDiscoveryResponse.class);
   }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/D2ControllerClient.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/D2ControllerClient.java
@@ -120,14 +120,24 @@ public class D2ControllerClient extends ControllerClient {
         D2ServiceDiscoveryResponse.class);
   }
 
+  @Deprecated
   public static D2ServiceDiscoveryResponse discoverCluster(
       String d2ZkHost,
       String d2ServiceName,
       String storeName,
       int retryAttempts) {
+    return discoverCluster(d2ZkHost, d2ServiceName, storeName, retryAttempts, Optional.empty());
+  }
+
+  public static D2ServiceDiscoveryResponse discoverCluster(
+      String d2ZkHost,
+      String d2ServiceName,
+      String storeName,
+      int retryAttempts,
+      Optional<SSLFactory> sslFactory) {
     D2Client d2Client;
     try {
-      d2Client = D2ClientFactory.getD2Client(d2ZkHost, Optional.empty());
+      d2Client = D2ClientFactory.getD2Client(d2ZkHost, sslFactory);
       return discoverCluster(d2Client, d2ServiceName, storeName, retryAttempts);
     } finally {
       D2ClientFactory.release(d2ZkHost);

--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/D2ControllerClientFactory.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/D2ControllerClientFactory.java
@@ -58,7 +58,7 @@ public class D2ControllerClientFactory {
       Optional<SSLFactory> sslFactory,
       int retryAttempts) {
     D2ServiceDiscoveryResponse discoveryResponse =
-        D2ControllerClient.discoverCluster(d2ZkHost, d2ServiceName, storeName, retryAttempts);
+        D2ControllerClient.discoverCluster(d2ZkHost, d2ServiceName, storeName, retryAttempts, sslFactory);
     checkDiscoveryResponse(storeName, discoveryResponse);
     return getControllerClient(d2ServiceName, discoveryResponse.getCluster(), d2ZkHost, sslFactory);
   }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/utils/Utils.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/utils/Utils.java
@@ -26,7 +26,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.lang.management.ManagementFactory;
 import java.net.InetAddress;
-import java.net.ServerSocket;
 import java.net.UnknownHostException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -499,21 +498,6 @@ public class Utils {
     double divider = Math.pow(1000, suffixIndex);
     int prettyNumber = (int) Math.round(doubleNumber / divider);
     return prettyNumber + LARGE_NUMBER_SUFFIXES[suffixIndex];
-  }
-
-  /**
-   * WARNING: The code which generates the free port and uses it must always be called within
-   * a try/catch and a loop. There is no guarantee that the port returned will still be
-   * available at the time it is used. This is best-effort only.
-   *
-   * @return a free port to be used by tests.
-   */
-  public static int getFreePort() {
-    try (ServerSocket socket = new ServerSocket(0)) {
-      return socket.getLocalPort();
-    } catch (IOException e) {
-      throw new RuntimeException(e);
-    }
   }
 
   public static String getUniqueString() {

--- a/internal/venice-common/src/main/java/com/linkedin/venice/utils/Utils.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/utils/Utils.java
@@ -506,8 +506,6 @@ public class Utils {
    * a try/catch and a loop. There is no guarantee that the port returned will still be
    * available at the time it is used. This is best-effort only.
    *
-   * N.B.: Visibility is package-private on purpose.
-   *
    * @return a free port to be used by tests.
    */
   public static int getFreePort() {

--- a/internal/venice-common/src/test/java/com/linkedin/venice/controllerapi/TestD2ControllerClient.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/controllerapi/TestD2ControllerClient.java
@@ -49,6 +49,7 @@ public class TestD2ControllerClient {
   public void testConstructD2ControllerClient() {
     try (D2ControllerClient controllerClient =
         new D2ControllerClient(TEST_CONTROLLER_D2_SERVICE, TEST_CLUSTER, TEST_ZK_ADDRESS, Optional.empty())) {
+      // Do nothing since we only want to test the constructor
     }
   }
 
@@ -79,8 +80,8 @@ public class TestD2ControllerClient {
 
     D2ClientFactory.setD2Client(TEST_ZK_ADDRESS, mockD2Client);
 
-    D2ServiceDiscoveryResponse response =
-        D2ControllerClient.discoverCluster(TEST_ZK_ADDRESS, TEST_CONTROLLER_D2_SERVICE, TEST_STORE, 1);
+    D2ServiceDiscoveryResponse response = D2ControllerClient
+        .discoverCluster(TEST_ZK_ADDRESS, TEST_CONTROLLER_D2_SERVICE, TEST_STORE, 1, Optional.empty());
     Assert.assertEquals(response.getCluster(), TEST_CLUSTER);
 
     try (D2ControllerClient controllerClient =
@@ -117,7 +118,8 @@ public class TestD2ControllerClient {
 
     D2ClientFactory.setD2Client(TEST_ZK_ADDRESS, mockD2Client);
     Assert.assertTrue(
-        D2ControllerClient.discoverCluster(TEST_ZK_ADDRESS, TEST_CONTROLLER_D2_SERVICE, TEST_STORE, 1).isError());
+        D2ControllerClient.discoverCluster(TEST_ZK_ADDRESS, TEST_CONTROLLER_D2_SERVICE, TEST_STORE, 1, Optional.empty())
+            .isError());
 
     Assert.assertTrue(
         D2ControllerClient.discoverCluster(mockD2Client, TEST_CONTROLLER_D2_SERVICE, TEST_STORE, 1).isError());

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/davinci/ingestion/IsolatedIngestionServerTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/davinci/ingestion/IsolatedIngestionServerTest.java
@@ -48,7 +48,7 @@ public class IsolatedIngestionServerTest {
 
   @Test(timeOut = TIMEOUT_MS)
   public void testShutdownAfterHeartbeatTimeout() {
-    int servicePort = Utils.getFreePort();
+    int servicePort = TestUtils.getFreePort();
     VeniceConfigLoader configLoader = getConfigLoader(servicePort);
     try (MainIngestionRequestClient client = new MainIngestionRequestClient(configLoader)) {
       Process isolatedIngestionService = client.startForkedIngestionProcess(configLoader);
@@ -67,7 +67,7 @@ public class IsolatedIngestionServerTest {
 
   @Test(timeOut = TIMEOUT_MS)
   public void testReleaseTargetPortBinding() {
-    int servicePort = Utils.getFreePort();
+    int servicePort = TestUtils.getFreePort();
     VeniceConfigLoader configLoader = getConfigLoader(servicePort);
     try (MainIngestionRequestClient client = new MainIngestionRequestClient(configLoader)) {
       // Make sure the process is forked successfully.
@@ -109,7 +109,7 @@ public class IsolatedIngestionServerTest {
     String testRegion = "ei-ltx1";
     // Set app region system property.
     System.setProperty(SYSTEM_PROPERTY_FOR_APP_RUNNING_REGION, testRegion);
-    VeniceConfigLoader configLoader = getConfigLoader(Utils.getFreePort());
+    VeniceConfigLoader configLoader = getConfigLoader(TestUtils.getFreePort());
     // Build and save config to file.
     String configFilePath = buildAndSaveConfigsForForkedIngestionProcess(configLoader);
     // Load config from saved config file.

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/controllerapi/TestControllerClient.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/controllerapi/TestControllerClient.java
@@ -97,8 +97,8 @@ public class TestControllerClient {
     String errorResponseStoreName = Utils.getUniqueString("test-error-store");
     String fakeLeaderControllerUrl = "http://fake.leader.controller.url";
 
-    String nonExistentControllerUrl1 = "http://localhost:22";
-    String nonExistentControllerUrl2 = "http://localhost:23";
+    String nonExistentControllerUrl1 = "http://localhost:1100";
+    String nonExistentControllerUrl2 = "http://localhost:1101";
 
     try (MockHttpServerWrapper mockController = ServiceFactory.getMockHttpServer("mock_controller");
         MockHttpServerWrapper mockLegacyHost = ServiceFactory.getMockHttpServer("mock_legacy_router")) {
@@ -164,7 +164,9 @@ public class TestControllerClient {
       D2ServiceDiscoveryResponse discoResponseInvalidControllers = ControllerClient
           .discoverCluster(nonExistentControllerUrl1 + "," + nonExistentControllerUrl2, storeName, Optional.empty(), 1);
       Assert.assertTrue(discoResponseInvalidControllers.isError());
-      Assert.assertTrue(discoResponseInvalidControllers.getError().contains(ConnectException.class.getCanonicalName()));
+      Assert.assertTrue(
+          discoResponseInvalidControllers.getError().contains(ConnectException.class.getCanonicalName()),
+          discoResponseInvalidControllers.getError());
 
       // When only some controllers are missing, the ConnectException should never be bubbled up. Since this behavior is
       // triggered from Java libs, and we randomise the controller list to do some load balancing, the best way to

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/controllerapi/TestControllerClient.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/controllerapi/TestControllerClient.java
@@ -97,8 +97,8 @@ public class TestControllerClient {
     String errorResponseStoreName = Utils.getUniqueString("test-error-store");
     String fakeLeaderControllerUrl = "http://fake.leader.controller.url";
 
-    String nonExistentControllerUrl1 = "http://localhost:1100";
-    String nonExistentControllerUrl2 = "http://localhost:1101";
+    String nonExistentControllerUrl1 = "http://localhost:" + Utils.getFreePort();
+    String nonExistentControllerUrl2 = "http://localhost:" + Utils.getFreePort();
 
     try (MockHttpServerWrapper mockController = ServiceFactory.getMockHttpServer("mock_controller");
         MockHttpServerWrapper mockLegacyHost = ServiceFactory.getMockHttpServer("mock_legacy_router")) {

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/controllerapi/TestControllerClient.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/controllerapi/TestControllerClient.java
@@ -1,9 +1,11 @@
 package com.linkedin.venice.controllerapi;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.linkedin.d2.balancer.D2Client;
 import com.linkedin.d2.balancer.D2ClientBuilder;
 import com.linkedin.venice.D2.D2ClientUtils;
+import com.linkedin.venice.exceptions.ErrorType;
 import com.linkedin.venice.integration.utils.MockD2ServerWrapper;
 import com.linkedin.venice.integration.utils.MockHttpServerWrapper;
 import com.linkedin.venice.integration.utils.ServiceFactory;
@@ -17,6 +19,7 @@ import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpVersion;
 import java.io.IOException;
+import java.net.ConnectException;
 import java.util.Optional;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -87,6 +90,118 @@ public class TestControllerClient {
   }
 
   @Test
+  public void testControllerClientWithInvalidUrls() throws IOException {
+    String clusterName = Utils.getUniqueString("test-cluster");
+    String storeName = Utils.getUniqueString("test-store");
+    String nonExistentStoreName = Utils.getUniqueString("test-missing-store");
+    String fakeLeaderControllerUrl = "http://fake.leader.controller.url";
+
+    String nonExistentControllerUrl1 = "http://localhost:22";
+    String nonExistentControllerUrl2 = "http://localhost:23";
+
+    try (MockHttpServerWrapper mockController = ServiceFactory.getMockHttpServer("mock_controller");
+        MockHttpServerWrapper mockLegacyHost = ServiceFactory.getMockHttpServer("mock_legacy_router")) {
+      String validControllerUrl = "http://" + mockController.getAddress();
+      String legacyControllerUrl = "http://" + mockLegacyHost.getAddress();
+
+      LeaderControllerResponse controllerResponse = new LeaderControllerResponse();
+      controllerResponse.setCluster(clusterName);
+      controllerResponse.setUrl(fakeLeaderControllerUrl);
+
+      FullHttpResponse response = wrapControllerResponseAsFullHttpResponse(controllerResponse, HttpResponseStatus.OK);
+      mockController.addResponseForUriPattern(ControllerRoute.LEADER_CONTROLLER.getPath() + ".*", response);
+
+      D2ServiceDiscoveryResponse discoveryResponse = new D2ServiceDiscoveryResponse();
+      discoveryResponse.setName(storeName);
+      discoveryResponse.setCluster(clusterName);
+
+      FullHttpResponse discoHttpResponse =
+          wrapControllerResponseAsFullHttpResponse(discoveryResponse, HttpResponseStatus.OK);
+      mockController.addResponseForUriPattern(
+          ControllerRoute.CLUSTER_DISCOVERY.getPath() + ".*store_name=" + storeName + ".*",
+          discoHttpResponse);
+
+      D2ServiceDiscoveryResponse nonExistentStoreDiscoveryResponse = new D2ServiceDiscoveryResponse();
+      nonExistentStoreDiscoveryResponse.setName(nonExistentStoreName);
+      nonExistentStoreDiscoveryResponse.setError("Store " + nonExistentStoreName + " doesn't exist");
+      nonExistentStoreDiscoveryResponse.setErrorType(ErrorType.STORE_NOT_FOUND);
+
+      FullHttpResponse nonExistentStoreDiscoHttpResponse =
+          wrapControllerResponseAsFullHttpResponse(nonExistentStoreDiscoveryResponse, HttpResponseStatus.NOT_FOUND);
+      mockController.addResponseForUriPattern(
+          ControllerRoute.CLUSTER_DISCOVERY.getPath() + ".*store_name=" + nonExistentStoreName + ".*",
+          nonExistentStoreDiscoHttpResponse);
+
+      D2ServiceDiscoveryResponse nonExistentStoreLegacyDiscoveryResponse = new D2ServiceDiscoveryResponse();
+      nonExistentStoreLegacyDiscoveryResponse.setName(nonExistentStoreName);
+      nonExistentStoreLegacyDiscoveryResponse.setError("Store " + nonExistentStoreName + " doesn't exist");
+      nonExistentStoreLegacyDiscoveryResponse.setErrorType(ErrorType.GENERAL_ERROR);
+
+      FullHttpResponse nonExistentStoreLegacyDiscoRouterHttpResponse = wrapControllerResponseAsFullHttpResponse(
+          nonExistentStoreLegacyDiscoveryResponse,
+          HttpResponseStatus.NOT_FOUND);
+      mockLegacyHost.addResponseForUriPattern(
+          ControllerRoute.CLUSTER_DISCOVERY.getPath() + ".*store_name=" + nonExistentStoreName + ".*",
+          nonExistentStoreLegacyDiscoRouterHttpResponse);
+      mockLegacyHost.addResponseForUriPattern(
+          ControllerRoute.CLUSTER_DISCOVERY.getPath() + "/" + nonExistentStoreName + ".*",
+          nonExistentStoreLegacyDiscoRouterHttpResponse);
+
+      // When all controllers are missing, the ConnectException should be bubbled up
+      D2ServiceDiscoveryResponse discoResponseInvalidControllers = ControllerClient
+          .discoverCluster(nonExistentControllerUrl1 + "," + nonExistentControllerUrl2, storeName, Optional.empty(), 1);
+      Assert.assertTrue(discoResponseInvalidControllers.isError());
+      Assert.assertTrue(discoResponseInvalidControllers.getError().contains(ConnectException.class.getCanonicalName()));
+
+      // When only some controllers are missing, the ConnectException should never be bubbled up. Since this behavior is
+      // triggered from Java libs, and we randomise the controller list to do some load balancing, the best way to
+      // validate is to try multiple invocations
+      for (int i = 0; i < 100; i++) {
+        D2ServiceDiscoveryResponse discoResponsePartialValidController = ControllerClient
+            .discoverCluster(nonExistentControllerUrl1 + "," + validControllerUrl, storeName, Optional.empty(), 1);
+        Assert.assertFalse(discoResponsePartialValidController.isError());
+
+        D2ServiceDiscoveryResponse nonExistentStoreDiscoResponsePartialValidController =
+            ControllerClient.discoverCluster(
+                nonExistentControllerUrl1 + "," + validControllerUrl,
+                nonExistentStoreName,
+                Optional.empty(),
+                1);
+        Assert.assertTrue(nonExistentStoreDiscoResponsePartialValidController.isError());
+        Assert.assertEquals(
+            nonExistentStoreDiscoResponsePartialValidController.getErrorType(),
+            ErrorType.STORE_NOT_FOUND);
+
+        D2ServiceDiscoveryResponse nonExistentStoreDiscoResponseValidInvalidAndLegacy =
+            ControllerClient.discoverCluster(
+                nonExistentControllerUrl1 + "," + legacyControllerUrl + "," + validControllerUrl,
+                nonExistentStoreName,
+                Optional.empty(),
+                1);
+        Assert.assertTrue(nonExistentStoreDiscoResponseValidInvalidAndLegacy.isError());
+        Assert
+            .assertEquals(nonExistentStoreDiscoResponseValidInvalidAndLegacy.getErrorType(), ErrorType.STORE_NOT_FOUND);
+
+        // Backward compatibility test. When the controller/router doesn't return STORE_NOT_FOUND, bubble up the error
+        // type
+        D2ServiceDiscoveryResponse nonExistentStoreDiscoResponseInvalidAndLegacy = ControllerClient.discoverCluster(
+            nonExistentControllerUrl1 + "," + legacyControllerUrl,
+            nonExistentStoreName,
+            Optional.empty(),
+            1);
+        Assert.assertTrue(nonExistentStoreDiscoResponseInvalidAndLegacy.isError());
+        Assert.assertEquals(nonExistentStoreDiscoResponseInvalidAndLegacy.getErrorType(), ErrorType.GENERAL_ERROR);
+      }
+
+      try (ControllerClient controllerClient =
+          ControllerClientFactory.getControllerClient(clusterName, validControllerUrl, Optional.empty())) {
+        String leaderControllerUrl = controllerClient.getLeaderControllerUrl();
+        Assert.assertEquals(leaderControllerUrl, fakeLeaderControllerUrl);
+      }
+    }
+  }
+
+  @Test
   public void testD2ControllerClient() throws Exception {
     String d2ServiceName = Utils.getUniqueString("VeniceController");
     String veniceClusterName = Utils.getUniqueString("test-cluster");
@@ -140,5 +255,17 @@ public class TestControllerClient {
     httpResponse.headers().set(HttpHeaderNames.CONTENT_LENGTH, httpResponse.content().readableBytes());
 
     return httpResponse;
+  }
+
+  private FullHttpResponse wrapControllerResponseAsFullHttpResponse(
+      ControllerResponse controllerResponse,
+      HttpResponseStatus responseStatus) throws JsonProcessingException {
+    ByteBuf body = Unpooled.wrappedBuffer(ObjectMapperFactory.getInstance().writeValueAsBytes(controllerResponse));
+    FullHttpResponse response = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, responseStatus, body);
+    response.headers().set(HttpHeaderNames.CONTENT_TYPE, "application/json");
+    // We must specify content_length header, otherwise netty will keep polling, since it
+    // doesn't know when to finish writing the response.
+    response.headers().set(HttpHeaderNames.CONTENT_LENGTH, response.content().readableBytes());
+    return response;
   }
 }

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/controllerapi/TestControllerClient.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/controllerapi/TestControllerClient.java
@@ -10,6 +10,7 @@ import com.linkedin.venice.integration.utils.MockD2ServerWrapper;
 import com.linkedin.venice.integration.utils.MockHttpServerWrapper;
 import com.linkedin.venice.integration.utils.ServiceFactory;
 import com.linkedin.venice.utils.ObjectMapperFactory;
+import com.linkedin.venice.utils.TestUtils;
 import com.linkedin.venice.utils.Utils;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
@@ -97,8 +98,8 @@ public class TestControllerClient {
     String errorResponseStoreName = Utils.getUniqueString("test-error-store");
     String fakeLeaderControllerUrl = "http://fake.leader.controller.url";
 
-    String nonExistentControllerUrl1 = "http://localhost:" + Utils.getFreePort();
-    String nonExistentControllerUrl2 = "http://localhost:" + Utils.getFreePort();
+    String nonExistentControllerUrl1 = "http://localhost:" + TestUtils.getFreePort();
+    String nonExistentControllerUrl2 = "http://localhost:" + TestUtils.getFreePort();
 
     try (MockHttpServerWrapper mockController = ServiceFactory.getMockHttpServer("mock_controller");
         MockHttpServerWrapper mockLegacyHost = ServiceFactory.getMockHttpServer("mock_legacy_router")) {

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/DaVinciClientMemoryLimitTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/DaVinciClientMemoryLimitTest.java
@@ -109,8 +109,8 @@ public class DaVinciClientMemoryLimitTest {
         .put(ROCKSDB_TOTAL_MEMTABLE_USAGE_CAP_IN_BYTES, "10MB");
     if (ingestionIsolationEnabledInDaVinci) {
       venicePropertyBuilder.put(SERVER_INGESTION_MODE, IngestionMode.ISOLATED);
-      venicePropertyBuilder.put(SERVER_INGESTION_ISOLATION_APPLICATION_PORT, Utils.getFreePort());
-      venicePropertyBuilder.put(SERVER_INGESTION_ISOLATION_SERVICE_PORT, Utils.getFreePort());
+      venicePropertyBuilder.put(SERVER_INGESTION_ISOLATION_APPLICATION_PORT, TestUtils.getFreePort());
+      venicePropertyBuilder.put(SERVER_INGESTION_ISOLATION_SERVICE_PORT, TestUtils.getFreePort());
       venicePropertyBuilder.put(SERVER_FORKED_PROCESS_JVM_ARGUMENT_LIST, "-Xms256M;-Xmx256M");
       venicePropertyBuilder.put(INGESTION_MEMORY_LIMIT, "296MB"); // 256M + 10M + 30M
     } else {

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestActiveActiveIngestion.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestActiveActiveIngestion.java
@@ -125,7 +125,7 @@ public class TestActiveActiveIngestion {
     serverProperties.put(ROCKSDB_PLAIN_TABLE_FORMAT_ENABLED, false);
     serverProperties.put(
         CHILD_DATA_CENTER_KAFKA_URL_PREFIX + "." + DEFAULT_PARENT_DATA_CENTER_REGION_NAME,
-        "localhost:" + Utils.getFreePort());
+        "localhost:" + TestUtils.getFreePort());
     multiRegionMultiClusterWrapper = ServiceFactory.getVeniceTwoLayerMultiRegionMultiClusterWrapper(
         1,
         1,

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestChangeCaptureIngestion.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/endToEnd/TestChangeCaptureIngestion.java
@@ -95,7 +95,7 @@ public class TestChangeCaptureIngestion {
     serverProperties.put(ROCKSDB_PLAIN_TABLE_FORMAT_ENABLED, false);
     serverProperties.put(
         CHILD_DATA_CENTER_KAFKA_URL_PREFIX + "." + DEFAULT_PARENT_DATA_CENTER_REGION_NAME,
-        "localhost:" + Utils.getFreePort());
+        "localhost:" + TestUtils.getFreePort());
     multiRegionMultiClusterWrapper = ServiceFactory.getVeniceTwoLayerMultiRegionMultiClusterWrapper(
         1,
         1,

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/integration/utils/DaVinciTestContext.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/integration/utils/DaVinciTestContext.java
@@ -19,6 +19,7 @@ import com.linkedin.venice.client.store.ClientConfig;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.meta.PersistenceType;
 import com.linkedin.venice.utils.PropertyBuilder;
+import com.linkedin.venice.utils.TestUtils;
 import com.linkedin.venice.utils.Utils;
 import com.linkedin.venice.utils.VeniceProperties;
 import io.tehuti.metrics.MetricsRepository;
@@ -125,8 +126,8 @@ public class DaVinciTestContext<K, V> {
   public static PropertyBuilder getDaVinciPropertyBuilder(String zkAddress) {
     return new PropertyBuilder().put(DATA_BASE_PATH, Utils.getTempDataDirectory().getAbsolutePath())
         .put(PERSISTENCE_TYPE, PersistenceType.ROCKS_DB)
-        .put(SERVER_INGESTION_ISOLATION_APPLICATION_PORT, Utils.getFreePort())
-        .put(SERVER_INGESTION_ISOLATION_SERVICE_PORT, Utils.getFreePort())
+        .put(SERVER_INGESTION_ISOLATION_APPLICATION_PORT, TestUtils.getFreePort())
+        .put(SERVER_INGESTION_ISOLATION_SERVICE_PORT, TestUtils.getFreePort())
         .put(SERVER_ROCKSDB_STORAGE_CONFIG_CHECK_ENABLED, true)
         .put(CLIENT_USE_SYSTEM_STORE_REPOSITORY, true)
         .put(CLIENT_SYSTEM_STORE_REPOSITORY_REFRESH_INTERVAL_SECONDS, 1)

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/integration/utils/KafkaBrokerFactory.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/integration/utils/KafkaBrokerFactory.java
@@ -9,6 +9,7 @@ import com.linkedin.venice.pubsub.adapter.kafka.producer.ApacheKafkaProducerAdap
 import com.linkedin.venice.pubsub.api.PubSubClientsFactory;
 import com.linkedin.venice.utils.KafkaSSLUtils;
 import com.linkedin.venice.utils.TestMockTime;
+import com.linkedin.venice.utils.TestUtils;
 import com.linkedin.venice.utils.Utils;
 import java.io.File;
 import java.util.ArrayList;
@@ -45,8 +46,8 @@ class KafkaBrokerFactory implements PubSubBrokerFactory {
   @Override
   public StatefulServiceProvider<PubSubBrokerWrapper> generateService(PubSubBrokerConfigs configs) {
     return (String serviceName, File dir) -> {
-      int port = Utils.getFreePort();
-      int sslPort = Utils.getFreePort();
+      int port = TestUtils.getFreePort();
+      int sslPort = TestUtils.getFreePort();
       Map<String, Object> configMap = new HashMap<>();
 
       boolean shouldCloseZkServer = false;

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/integration/utils/MockD2ServerWrapper.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/integration/utils/MockD2ServerWrapper.java
@@ -1,7 +1,7 @@
 package com.linkedin.venice.integration.utils;
 
 import com.linkedin.venice.d2.D2Server;
-import com.linkedin.venice.utils.Utils;
+import com.linkedin.venice.utils.TestUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -12,7 +12,7 @@ public class MockD2ServerWrapper extends MockHttpServerWrapper {
   private final D2Server d2Server;
 
   static StatefulServiceProvider<MockD2ServerWrapper> generateService(String d2ServiceName) {
-    return (serviceName, dataDirectory) -> new MockD2ServerWrapper(serviceName, Utils.getFreePort(), d2ServiceName);
+    return (serviceName, dataDirectory) -> new MockD2ServerWrapper(serviceName, TestUtils.getFreePort(), d2ServiceName);
   }
 
   public MockD2ServerWrapper(String serviceName, int port, String d2ServiceName) {

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/integration/utils/MockHttpServerWrapper.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/integration/utils/MockHttpServerWrapper.java
@@ -1,6 +1,6 @@
 package com.linkedin.venice.integration.utils;
 
-import com.linkedin.venice.utils.Utils;
+import com.linkedin.venice.utils.TestUtils;
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelFuture;
@@ -40,7 +40,7 @@ public class MockHttpServerWrapper extends ProcessWrapper {
   private final Map<String, FullHttpResponse> uriPatternToResponseMap = new ConcurrentHashMap<>();
 
   static StatefulServiceProvider<MockHttpServerWrapper> generateService() {
-    return (serviceName, dataDirectory) -> new MockHttpServerWrapper(serviceName, Utils.getFreePort());
+    return (serviceName, dataDirectory) -> new MockHttpServerWrapper(serviceName, TestUtils.getFreePort());
   }
 
   public MockHttpServerWrapper(String serviceName, int port) {

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/integration/utils/MockVeniceRouterWrapper.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/integration/utils/MockVeniceRouterWrapper.java
@@ -111,7 +111,7 @@ public class MockVeniceRouterWrapper extends ProcessWrapper {
     final String kafkaBootstrapServers = "localhost:1234";
 
     return (serviceName, dataDirectory) -> {
-      int port = Utils.getFreePort();
+      int port = TestUtils.getFreePort();
       String httpURI = "http://localhost:" + port;
       String httpsURI = "https://localhost:" + sslPortFromPort(port);
       List<ServiceDiscoveryAnnouncer> d2ServerList = new ArrayList<>();

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/integration/utils/ServiceFactory.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/integration/utils/ServiceFactory.java
@@ -156,7 +156,7 @@ public class ServiceFactory {
       Set<String> clusters = new HashSet<>();
       clusters.add(cluster);
       AdminSparkServer server = new AdminSparkServer(
-          Utils.getFreePort(),
+          TestUtils.getFreePort(),
           admin,
           new MetricsRepository(),
           clusters,

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/integration/utils/VeniceControllerWrapper.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/integration/utils/VeniceControllerWrapper.java
@@ -139,8 +139,8 @@ public class VeniceControllerWrapper extends ProcessWrapper {
 
   static StatefulServiceProvider<VeniceControllerWrapper> generateService(VeniceControllerCreateOptions options) {
     return (serviceName, dataDirectory) -> {
-      int adminPort = Utils.getFreePort();
-      int adminSecurePort = Utils.getFreePort();
+      int adminPort = TestUtils.getFreePort();
+      int adminSecurePort = TestUtils.getFreePort();
       List<VeniceProperties> propertiesList = new ArrayList<>();
 
       VeniceProperties extraProps = new VeniceProperties(options.getExtraProperties());

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/integration/utils/VeniceRouterWrapper.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/integration/utils/VeniceRouterWrapper.java
@@ -110,8 +110,8 @@ public class VeniceRouterWrapper extends ProcessWrapper implements MetricsAware 
     }
 
     return (serviceName, dataDirectory) -> {
-      int port = Utils.getFreePort();
-      int sslPort = Utils.getFreePort();
+      int port = TestUtils.getFreePort();
+      int sslPort = TestUtils.getFreePort();
       PropertyBuilder builder = new PropertyBuilder().put(CLUSTER_NAME, clusterName)
           .put(LISTENER_PORT, port)
           .put(LISTENER_SSL_PORT, sslPort)

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/integration/utils/VeniceServerWrapper.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/integration/utils/VeniceServerWrapper.java
@@ -199,11 +199,11 @@ public class VeniceServerWrapper extends ProcessWrapper implements MetricsAware 
       clusterProps.storeFlattened(clusterConfigFile);
 
       // Generate server.properties in config directory
-      int listenPort = Utils.getFreePort();
-      int ingestionIsolationApplicationPort = Utils.getFreePort();
-      int ingestionIsolationServicePort = Utils.getFreePort();
+      int listenPort = TestUtils.getFreePort();
+      int ingestionIsolationApplicationPort = TestUtils.getFreePort();
+      int ingestionIsolationServicePort = TestUtils.getFreePort();
       PropertyBuilder serverPropsBuilder = new PropertyBuilder().put(LISTENER_PORT, listenPort)
-          .put(ADMIN_PORT, Utils.getFreePort())
+          .put(ADMIN_PORT, TestUtils.getFreePort())
           .put(DATA_BASE_PATH, dataDirectory.getAbsolutePath())
           .put(ENABLE_SERVER_ALLOW_LIST, enableServerAllowlist)
           .put(SERVER_REST_SERVICE_STORAGE_THREAD_NUM, 4)

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/integration/utils/ZkServerWrapper.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/integration/utils/ZkServerWrapper.java
@@ -67,13 +67,13 @@ public class ZkServerWrapper extends ProcessWrapper {
   static StatefulServiceProvider<ZkServerWrapper> generateService() {
     return (String serviceName, File dataDirectory) -> {
       if (!isSingleton) {
-        return createRealZkServerWrapper(serviceName, Utils.getFreePort(), dataDirectory);
+        return createRealZkServerWrapper(serviceName, TestUtils.getFreePort(), dataDirectory);
       }
 
       synchronized (ZkServerWrapper.class) {
         if (INSTANCE == null) {
           try {
-            INSTANCE = createRealZkServerWrapper(serviceName, Utils.getFreePort(), dataDirectory);
+            INSTANCE = createRealZkServerWrapper(serviceName, TestUtils.getFreePort(), dataDirectory);
             Runtime.getRuntime().addShutdownHook(new Thread(INSTANCE::close));
             INSTANCE.start();
           } catch (Exception e) {

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/restart/TestRestartServerAfterDeletingSstFilesWithActiveActiveIngestion.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/restart/TestRestartServerAfterDeletingSstFilesWithActiveActiveIngestion.java
@@ -111,7 +111,7 @@ public class TestRestartServerAfterDeletingSstFilesWithActiveActiveIngestion {
     serverProperties.setProperty(SERVER_DATABASE_SYNC_BYTES_INTERNAL_FOR_DEFERRED_WRITE_MODE, "300");
     serverProperties.put(
         CHILD_DATA_CENTER_KAFKA_URL_PREFIX + "." + DEFAULT_PARENT_DATA_CENTER_REGION_NAME,
-        "localhost:" + Utils.getFreePort());
+        "localhost:" + TestUtils.getFreePort());
     multiRegionMultiClusterWrapper = ServiceFactory.getVeniceTwoLayerMultiRegionMultiClusterWrapper(
         1,
         1,

--- a/internal/venice-test-common/src/main/java/com/linkedin/venice/unit/kafka/InMemoryKafkaBroker.java
+++ b/internal/venice-test-common/src/main/java/com/linkedin/venice/unit/kafka/InMemoryKafkaBroker.java
@@ -1,7 +1,7 @@
 package com.linkedin.venice.unit.kafka;
 
 import com.linkedin.venice.unit.kafka.producer.MockInMemoryProducerAdapter;
-import com.linkedin.venice.utils.Utils;
+import com.linkedin.venice.utils.TestUtils;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -22,7 +22,7 @@ public class InMemoryKafkaBroker {
   private final String brokerNamePrefix;
 
   public InMemoryKafkaBroker(String brokerNamePrefix) {
-    port = Utils.getFreePort();
+    port = TestUtils.getFreePort();
     this.brokerNamePrefix = brokerNamePrefix;
   }
 

--- a/internal/venice-test-common/src/main/java/com/linkedin/venice/utils/TestUtils.java
+++ b/internal/venice-test-common/src/main/java/com/linkedin/venice/utils/TestUtils.java
@@ -79,6 +79,7 @@ import com.linkedin.venice.writer.VeniceWriterFactory;
 import com.linkedin.venice.writer.VeniceWriterOptions;
 import io.tehuti.metrics.MetricsRepository;
 import java.io.IOException;
+import java.net.ServerSocket;
 import java.nio.ByteBuffer;
 import java.nio.file.Paths;
 import java.security.Permission;
@@ -822,6 +823,21 @@ public class TestUtils {
       return getUniqueString(prefix);
     } else {
       throw new VeniceException("Unsupported topic type for: " + pubSubTopicType);
+    }
+  }
+
+  /**
+   * WARNING: The code which generates the free port and uses it must always be called within
+   * a try/catch and a loop. There is no guarantee that the port returned will still be
+   * available at the time it is used. This is best-effort only.
+   *
+   * @return a free port to be used by tests.
+   */
+  public static int getFreePort() {
+    try (ServerSocket socket = new ServerSocket(0)) {
+      return socket.getLocalPort();
+    } catch (IOException e) {
+      throw new RuntimeException(e);
     }
   }
 }


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Raise `ConnectException` only if all hosts in `ControllerClient` are unreachable
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
To instantiate a URL based ControllerClient, we need to pass in a list of Router or Controller URLs. Since this is a static list that might be configured by operators, it can grow stale over time to include hosts that are no longer running Venice routers or controllers on that port. When querying these endpoints the following cases are possible:
1. A different service is now listening on that port and it is likely to throw a 4XX for route not supported or some 5XX that might trigger some error scenarios in the new service.
2. `java.net.ConnectException` is thrown. This is the most probable option since even though different services might get deployed on that host, the ports are kept mutually exclusive.

In error scenarios, we wish to try our best to provide the user with an actionable error and only return a `ConnectException`
when all hosts throw it. In that case, the `ConnectException` is the most actionable error.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
GH CI

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.