### PR TITLE
[controller] Check store existing A/A config when updating store type

### DIFF
--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/controller/TestClusterLevelConfigForActiveActiveReplication.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/controller/TestClusterLevelConfigForActiveActiveReplication.java
@@ -78,13 +78,13 @@ public class TestClusterLevelConfigForActiveActiveReplication extends AbstractTe
 
     // Version 1 should exist.
     Assert.assertEquals(veniceAdmin.getStore(clusterName, storeNameHybrid).getVersions().size(), 1);
-    // Check store level active active is enabled or not
-    Assert.assertEquals(veniceAdmin.getStore(clusterName, storeNameHybrid).isActiveActiveReplicationEnabled(), false);
+    // Check store level Active/Active is enabled or not
+    Assert.assertFalse(veniceAdmin.getStore(clusterName, storeNameHybrid).isActiveActiveReplicationEnabled());
     veniceAdmin.updateStore(
         clusterName,
         storeNameHybrid,
         new UpdateStoreQueryParams().setHybridRewindSeconds(1000L).setHybridOffsetLagThreshold(1000L));
-    Assert.assertEquals(veniceAdmin.getStore(clusterName, storeNameHybrid).isActiveActiveReplicationEnabled(), true);
+    Assert.assertTrue(veniceAdmin.getStore(clusterName, storeNameHybrid).isActiveActiveReplicationEnabled());
 
     // Set topic original topic manager back
     veniceAdmin.setTopicManagerRepository(originalTopicManagerRepository);
@@ -123,14 +123,15 @@ public class TestClusterLevelConfigForActiveActiveReplication extends AbstractTe
     // Version 1 should exist.
     Assert.assertEquals(veniceAdmin.getStore(clusterName, storeNameIncremental).getVersions().size(), 1);
 
-    // Check store level active active is enabled or not
+    // Check store level Active/Active is enabled or not
     veniceAdmin.setIncrementalPushEnabled(clusterName, storeNameIncremental, false);
-    Assert.assertEquals(
-        veniceAdmin.getStore(clusterName, storeNameIncremental).isActiveActiveReplicationEnabled(),
-        false);
+    Assert.assertFalse(veniceAdmin.getStore(clusterName, storeNameIncremental).isActiveActiveReplicationEnabled());
     veniceAdmin.setIncrementalPushEnabled(clusterName, storeNameIncremental, true);
-    Assert
-        .assertEquals(veniceAdmin.getStore(clusterName, storeNameIncremental).isActiveActiveReplicationEnabled(), true);
+    Assert.assertTrue(veniceAdmin.getStore(clusterName, storeNameIncremental).isActiveActiveReplicationEnabled());
+    veniceAdmin.setIncrementalPushEnabled(clusterName, storeNameIncremental, false);
+    // After inc push is disabled, even default A/A config for pure hybrid store is false, original store A/A config is
+    // enabled.
+    Assert.assertTrue(veniceAdmin.getStore(clusterName, storeNameIncremental).isActiveActiveReplicationEnabled());
 
     // Set topic original topic manager back
     veniceAdmin.setTopicManagerRepository(originalTopicManagerRepository);
@@ -169,25 +170,27 @@ public class TestClusterLevelConfigForActiveActiveReplication extends AbstractTe
     // Version 1 should exist.
     Assert.assertEquals(veniceAdmin.getStore(clusterName, storeNameBatchOnly).getVersions().size(), 1);
 
-    // Store level active active should be enabled since this store is a batch-only store by default
-    Assert.assertEquals(veniceAdmin.getStore(clusterName, storeNameBatchOnly).isActiveActiveReplicationEnabled(), true);
+    // Store level Active/Active replication should be enabled since this store is a batch-only store by default
+    Assert.assertTrue(veniceAdmin.getStore(clusterName, storeNameBatchOnly).isActiveActiveReplicationEnabled());
 
-    // After updating the store to have incremental push enabled, its A/A is disabled
+    // After updating the store to have incremental push enabled, it's A/A is still enabled
     veniceAdmin.setIncrementalPushEnabled(clusterName, storeNameBatchOnly, true);
-    Assert
-        .assertEquals(veniceAdmin.getStore(clusterName, storeNameBatchOnly).isActiveActiveReplicationEnabled(), false);
+    Assert.assertTrue(veniceAdmin.getStore(clusterName, storeNameBatchOnly).isActiveActiveReplicationEnabled());
 
-    // After updating the store back to a batch-only store, its A/A becomes enabled again
+    // Let's disable the A/A config for the store.
+    veniceAdmin.setActiveActiveReplicationEnabled(clusterName, storeNameBatchOnly, false);
+    Assert.assertFalse(veniceAdmin.getStore(clusterName, storeNameBatchOnly).isActiveActiveReplicationEnabled());
+
+    // After updating the store back to a batch-only store, it's A/A becomes enabled again
     veniceAdmin.setIncrementalPushEnabled(clusterName, storeNameBatchOnly, false);
-    Assert.assertEquals(veniceAdmin.getStore(clusterName, storeNameBatchOnly).isActiveActiveReplicationEnabled(), true);
+    Assert.assertTrue(veniceAdmin.getStore(clusterName, storeNameBatchOnly).isActiveActiveReplicationEnabled());
 
-    // After updating the store to be a hybrid store, its A/A is disabled is again
+    // After updating the store to be a hybrid store, it's A/A should still be enabled.
     veniceAdmin.updateStore(
         clusterName,
         storeNameBatchOnly,
         new UpdateStoreQueryParams().setHybridRewindSeconds(1000L).setHybridOffsetLagThreshold(1000L));
-    Assert
-        .assertEquals(veniceAdmin.getStore(clusterName, storeNameBatchOnly).isActiveActiveReplicationEnabled(), false);
+    Assert.assertTrue(veniceAdmin.getStore(clusterName, storeNameBatchOnly).isActiveActiveReplicationEnabled());
 
     // Set topic original topic manager back
     veniceAdmin.setTopicManagerRepository(originalTopicManagerRepository);
@@ -243,15 +246,15 @@ public class TestClusterLevelConfigForActiveActiveReplication extends AbstractTe
       boolean enableActiveActiveForBatchOnly) throws IOException {
     Properties props = super.getControllerProperties(clusterName);
     props.setProperty(ENABLE_NATIVE_REPLICATION_AS_DEFAULT_FOR_BATCH_ONLY, "true");
-    // enable active active replication for hybrid stores stores through cluster-level config
+    // Enable Active/Active replication for hybrid stores through cluster-level config
     props.setProperty(
         ENABLE_ACTIVE_ACTIVE_REPLICATION_AS_DEFAULT_FOR_HYBRID_STORE,
         Boolean.toString(enableActiveActiveForHybrid));
-    // enable active active replication for incremental stores through cluster-level config
+    // Enable Active/Active replication for incremental stores through cluster-level config
     props.setProperty(
         ENABLE_ACTIVE_ACTIVE_REPLICATION_AS_DEFAULT_FOR_INCREMENTAL_PUSH_STORE,
         Boolean.toString(enableActiveActiveForIncrementalPush));
-    // enable active active replication for batch-only stores through cluster-level config
+    // Enable Active/Active replication for batch-only stores through cluster-level config
     props.setProperty(
         ENABLE_ACTIVE_ACTIVE_REPLICATION_AS_DEFAULT_FOR_BATCH_ONLY_STORE,
         Boolean.toString(enableActiveActiveForBatchOnly));

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -3824,17 +3824,22 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
       VeniceControllerClusterConfig config = getHelixVeniceClusterResources(clusterName).getConfig();
       if (incrementalPushEnabled) {
         // Enabling incremental push
-        store.setActiveActiveReplicationEnabled(config.isActiveActiveReplicationEnabledAsDefaultForIncremental());
+        store.setActiveActiveReplicationEnabled(
+            store.isActiveActiveReplicationEnabled()
+                || config.isActiveActiveReplicationEnabledAsDefaultForIncremental());
         store.setNativeReplicationEnabled(config.isNativeReplicationEnabledAsDefaultForIncremental());
         store.setNativeReplicationSourceFabric(config.getNativeReplicationSourceFabricAsDefaultForIncremental());
       } else {
         // Disabling incremental push
         if (store.isHybrid()) {
-          store.setActiveActiveReplicationEnabled(config.isActiveActiveReplicationEnabledAsDefaultForHybrid());
+          store.setActiveActiveReplicationEnabled(
+              store.isActiveActiveReplicationEnabled() || config.isActiveActiveReplicationEnabledAsDefaultForHybrid());
           store.setNativeReplicationEnabled(config.isNativeReplicationEnabledAsDefaultForHybrid());
           store.setNativeReplicationSourceFabric(config.getNativeReplicationSourceFabricAsDefaultForHybrid());
         } else {
-          store.setActiveActiveReplicationEnabled(config.isActiveActiveReplicationEnabledAsDefaultForBatchOnly());
+          store.setActiveActiveReplicationEnabled(
+              store.isActiveActiveReplicationEnabled()
+                  || config.isActiveActiveReplicationEnabledAsDefaultForBatchOnly());
           store.setNativeReplicationEnabled(config.isNativeReplicationEnabledAsDefaultForBatchOnly());
           store.setNativeReplicationSourceFabric(config.getNativeReplicationSourceFabricAsDefaultForBatchOnly());
         }
@@ -3973,10 +3978,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
     });
   }
 
-  private void setActiveActiveReplicationEnabled(
-      String clusterName,
-      String storeName,
-      boolean activeActiveReplicationEnabled) {
+  void setActiveActiveReplicationEnabled(String clusterName, String storeName, boolean activeActiveReplicationEnabled) {
     storeMetadataUpdate(clusterName, storeName, store -> {
       store.setActiveActiveReplicationEnabled(activeActiveReplicationEnabled);
       return store;
@@ -4228,13 +4230,15 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
               store.setNativeReplicationSourceFabric(
                   clusterConfig.getNativeReplicationSourceFabricAsDefaultForBatchOnly());
               store.setActiveActiveReplicationEnabled(
-                  clusterConfig.isActiveActiveReplicationEnabledAsDefaultForBatchOnly());
+                  store.isActiveActiveReplicationEnabled()
+                      || clusterConfig.isActiveActiveReplicationEnabledAsDefaultForBatchOnly());
             } else {
               store.setNativeReplicationEnabled(clusterConfig.isNativeReplicationEnabledAsDefaultForIncremental());
               store.setNativeReplicationSourceFabric(
                   clusterConfig.getNativeReplicationSourceFabricAsDefaultForIncremental());
               store.setActiveActiveReplicationEnabled(
-                  clusterConfig.isActiveActiveReplicationEnabledAsDefaultForIncremental());
+                  store.isActiveActiveReplicationEnabled()
+                      || clusterConfig.isActiveActiveReplicationEnabledAsDefaultForIncremental());
             }
           } else {
             if (!store.isHybrid()) {
@@ -4247,7 +4251,8 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
                 // Enable/disable active-active replication for hybrid stores if the cluster level config for new hybrid
                 // stores is on
                 store.setActiveActiveReplicationEnabled(
-                    clusterConfig.isActiveActiveReplicationEnabledAsDefaultForHybrid());
+                    store.isActiveActiveReplicationEnabled()
+                        || clusterConfig.isActiveActiveReplicationEnabledAsDefaultForHybrid());
               } else {
                 // The native replication cluster level config for incremental push will cover all incremental push
                 // policy
@@ -4257,7 +4262,8 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
                 // The active-active replication cluster level config for incremental push will cover all incremental
                 // push policy
                 store.setActiveActiveReplicationEnabled(
-                    clusterConfig.isActiveActiveReplicationEnabledAsDefaultForIncremental());
+                    store.isActiveActiveReplicationEnabled()
+                        || clusterConfig.isActiveActiveReplicationEnabledAsDefaultForIncremental());
               }
             }
             store.setHybridStoreConfig(finalHybridConfig);


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## [controller] Check store existing A/A config when updating store type
This PR aims to fix the bug that when changing store type (e.g. batch <-> pure hybrid <-> inc push), we set the store A/A config based on default config only but not looking at store's existing A/A config: If the default A/A config for new store type is false and existing config is true, we should also keep A/A enabled.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
Update existing integration test to reflect the logic.

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.