### PR TITLE
[changelog] Move d2Client to innerclient config

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/ChangelogClientConfig.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/ChangelogClientConfig.java
@@ -15,7 +15,6 @@ public class ChangelogClientConfig<T extends SpecificRecord> {
   private ClientConfig<T> innerClientConfig;
   private D2ControllerClient d2ControllerClient;
 
-  private D2Client d2Client;
   private String controllerD2ServiceName;
   private int controllerRequestRetryCount;
 
@@ -91,12 +90,12 @@ public class ChangelogClientConfig<T extends SpecificRecord> {
   }
 
   public ChangelogClientConfig<T> setD2Client(D2Client d2Client) {
-    this.d2Client = d2Client;
+    this.innerClientConfig.setD2Client(d2Client);
     return this;
   }
 
   public D2Client getD2Client() {
-    return this.d2Client;
+    return this.innerClientConfig.getD2Client();
   }
 
   public ChangelogClientConfig<T> setLocalD2ZkHosts(String localD2ZkHosts) {


### PR DESCRIPTION
## [changelog] Move d2Client to innerclient config
It seems this causes some bad behavior, otherwise the effect is that the internal schema reader will try and make it's own d2client

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.