### PR TITLE
[test] Fix flaky test TestAdminToolEndToEnd.testWipeClusterCommand

### DIFF
--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/controller/TestAdminToolEndToEnd.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/controller/TestAdminToolEndToEnd.java
@@ -3,6 +3,7 @@ package com.linkedin.venice.controller;
 import static com.linkedin.venice.ConfigKeys.ALLOW_CLUSTER_WIPE;
 import static com.linkedin.venice.ConfigKeys.LOCAL_REGION_NAME;
 import static com.linkedin.venice.ConfigKeys.TOPIC_CLEANUP_DELAY_FACTOR;
+import static org.testng.Assert.assertFalse;
 
 import com.linkedin.venice.AdminTool;
 import com.linkedin.venice.Arg;
@@ -18,6 +19,10 @@ import com.linkedin.venice.helix.ZkClientFactory;
 import com.linkedin.venice.integration.utils.ServiceFactory;
 import com.linkedin.venice.integration.utils.VeniceClusterWrapper;
 import com.linkedin.venice.integration.utils.VeniceServerWrapper;
+import com.linkedin.venice.kafka.TopicManager;
+import com.linkedin.venice.meta.Version;
+import com.linkedin.venice.pubsub.PubSubTopicRepository;
+import com.linkedin.venice.pubsub.api.PubSubTopic;
 import com.linkedin.venice.utils.TestUtils;
 import com.linkedin.venice.utils.Time;
 import com.linkedin.venice.utils.Utils;
@@ -139,6 +144,20 @@ public class TestAdminToolEndToEnd {
       AdminTool.main(wipeClusterArgs3);
       MultiStoreResponse multiStoreResponse = controllerClient.queryStoreList(false);
       Assert.assertEquals(multiStoreResponse.getStores().length, 0);
+
+      // Wait until all topics are indeed removed from Kafka service.
+      PubSubTopicRepository pubSubTopicRepository = new PubSubTopicRepository();
+
+      PubSubTopic testStoreTopic1 = pubSubTopicRepository.getTopic(Version.composeKafkaTopic(testStoreName1, 1));
+      PubSubTopic testStoreTopic2 = pubSubTopicRepository.getTopic(Version.composeKafkaTopic(testStoreName1, 2));
+      PubSubTopic testStoreTopic3 = pubSubTopicRepository.getTopic(Version.composeKafkaTopic(testStoreName2, 1));
+
+      TopicManager topicManager = venice.getLeaderVeniceController().getVeniceAdmin().getTopicManager();
+      TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, true, () -> {
+        assertFalse(topicManager.containsTopic(testStoreTopic1));
+        assertFalse(topicManager.containsTopic(testStoreTopic2));
+        assertFalse(topicManager.containsTopic(testStoreTopic3));
+      });
 
       // Redo fabric buildup. Create the store and version again.
       newStoreResponse = controllerClient.createNewStore(testStoreName1, "test", "\"string\"", "\"string\"");


### PR DESCRIPTION
On Kafka side, if a topic hasn't been fully deleted before asked to create a new topic with the same name, it can fail. This change fixes the issue by waiting all topics to be fully removed from Kafka service before proceeding to the next steps in the test.

## How was this PR tested?
Internal CI (No testWipeClusterCommand failure in Venice-WcTest: #8046, #8047; Venice-WcTest8 #1225, #1226)

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.