### PR TITLE
[controller] Calculate partition count for hybrid stores based on storage quota

### DIFF
--- a/internal/venice-common/src/main/java/com/linkedin/venice/writer/VeniceWriter.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/writer/VeniceWriter.java
@@ -330,6 +330,9 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
       } else {
         this.numberOfPartitions = this.producerAdapter.getNumberOfPartitions(topicName, 30, TimeUnit.SECONDS);
       }
+      if (this.numberOfPartitions <= 0) {
+        throw new VeniceException("Invalid number of partitions: " + this.numberOfPartitions);
+      }
       this.segmentsCreationTimeArray = new long[this.numberOfPartitions];
       // Prepare locks for all partitions instead of using map to avoid the searching and creation cost during
       // ingestion.

--- a/internal/venice-common/src/test/java/com/linkedin/venice/writer/VeniceWriterFactoryTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/writer/VeniceWriterFactoryTest.java
@@ -1,6 +1,7 @@
 package com.linkedin.venice.writer;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -17,12 +18,13 @@ import org.testng.annotations.Test;
 
 public class VeniceWriterFactoryTest {
   @Test
-  public void testVeniceWriterFactory() {
+  public void testVeniceWriterFactory() throws Exception {
     PubSubProducerAdapterFactory<PubSubProducerAdapter> producerFactoryMack = mock(PubSubProducerAdapterFactory.class);
     PubSubProducerAdapter producerAdapterMock = mock(PubSubProducerAdapter.class);
     ArgumentCaptor<String> brokerAddrCapture = ArgumentCaptor.forClass(String.class);
     when(producerFactoryMack.create(any(VeniceProperties.class), eq("store_v1"), brokerAddrCapture.capture()))
         .thenReturn(producerAdapterMock);
+    when(producerAdapterMock.getNumberOfPartitions(any(), anyInt(), any())).thenReturn(1);
 
     VeniceWriterFactory veniceWriterFactory = new VeniceWriterFactory(new Properties(), producerFactoryMack, null);
     VeniceWriter veniceWriter = veniceWriterFactory

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestParentControllerWithMultiDataCenter.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestParentControllerWithMultiDataCenter.java
@@ -1,6 +1,8 @@
 package com.linkedin.venice.controller;
 
+import static com.linkedin.venice.ConfigKeys.DEFAULT_MAX_NUMBER_OF_PARTITIONS;
 import static com.linkedin.venice.ConfigKeys.DEFAULT_NUMBER_OF_PARTITION_FOR_HYBRID;
+import static com.linkedin.venice.ConfigKeys.DEFAULT_PARTITION_SIZE;
 import static org.testng.Assert.assertEquals;
 
 import com.linkedin.venice.controllerapi.ControllerClient;
@@ -14,6 +16,7 @@ import com.linkedin.venice.integration.utils.ServiceFactory;
 import com.linkedin.venice.integration.utils.VeniceMultiClusterWrapper;
 import com.linkedin.venice.integration.utils.VeniceTwoLayerMultiRegionMultiClusterWrapper;
 import com.linkedin.venice.meta.BufferReplayPolicy;
+import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.StoreInfo;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.schema.rmd.RmdSchemaEntry;
@@ -58,6 +61,8 @@ public class TestParentControllerWithMultiDataCenter {
   public void setUp() {
     Properties controllerProps = new Properties();
     controllerProps.put(DEFAULT_NUMBER_OF_PARTITION_FOR_HYBRID, 2);
+    controllerProps.put(DEFAULT_MAX_NUMBER_OF_PARTITIONS, 3);
+    controllerProps.put(DEFAULT_PARTITION_SIZE, 1024);
     multiRegionMultiClusterWrapper = ServiceFactory.getVeniceTwoLayerMultiRegionMultiClusterWrapper(
         NUMBER_OF_CHILD_DATACENTERS,
         NUMBER_OF_CLUSTERS,
@@ -101,13 +106,13 @@ public class TestParentControllerWithMultiDataCenter {
       final long expectedHybridRewindSeconds = 100;
       final long expectedHybridOffsetLagThreshold = 100;
       final BufferReplayPolicy expectedHybridBufferReplayPolicy = BufferReplayPolicy.REWIND_FROM_SOP;
-      final UpdateStoreQueryParams updateStoreParams =
-          new UpdateStoreQueryParams().setHybridRewindSeconds(expectedHybridRewindSeconds)
-              .setHybridOffsetLagThreshold(expectedHybridOffsetLagThreshold)
-              .setHybridBufferReplayPolicy(expectedHybridBufferReplayPolicy)
-              .setChunkingEnabled(true)
-              .setRmdChunkingEnabled(true)
-              .setAmplificationFactor(2);
+      final UpdateStoreQueryParams updateStoreParams = new UpdateStoreQueryParams().setStorageQuotaInByte(1)
+          .setHybridRewindSeconds(expectedHybridRewindSeconds)
+          .setHybridOffsetLagThreshold(expectedHybridOffsetLagThreshold)
+          .setHybridBufferReplayPolicy(expectedHybridBufferReplayPolicy)
+          .setChunkingEnabled(true)
+          .setRmdChunkingEnabled(true)
+          .setAmplificationFactor(2);
 
       TestWriteUtils.updateStore(storeName, parentControllerClient, updateStoreParams);
 
@@ -138,11 +143,11 @@ public class TestParentControllerWithMultiDataCenter {
           Assert.assertEquals(storeInfo.getPartitionerConfig().getAmplificationFactor(), 2);
           Assert.assertTrue(storeInfo.isChunkingEnabled());
           Assert.assertTrue(storeInfo.isRmdChunkingEnabled());
-          Assert.assertEquals(storeInfo.getPartitionCount(), 2);
+          Assert.assertEquals(storeInfo.getPartitionCount(), 2); // hybrid partition count from the config
         }
       });
 
-      // Turn off hybrid config so we can update the partitioner config.
+      // Turn off hybrid config, so we can update the partitioner config.
       final UpdateStoreQueryParams updateStoreParams2 =
           new UpdateStoreQueryParams().setHybridRewindSeconds(-1).setHybridOffsetLagThreshold(-1);
       TestWriteUtils.updateStore(storeName, parentControllerClient, updateStoreParams2);
@@ -182,14 +187,15 @@ public class TestParentControllerWithMultiDataCenter {
       TestWriteUtils.updateStore(
           incPushStoreName,
           parentControllerClient,
-          new UpdateStoreQueryParams().setIncrementalPushEnabled(true));
+          new UpdateStoreQueryParams().setStorageQuotaInByte(Store.UNLIMITED_STORAGE_QUOTA)
+              .setIncrementalPushEnabled(true));
       TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, false, true, () -> {
         for (ControllerClient controllerClient: controllerClients) {
           StoreResponse storeResponse = controllerClient.getStore(incPushStoreName);
           Assert.assertFalse(storeResponse.isError());
           StoreInfo storeInfo = storeResponse.getStore();
           Assert.assertNotNull(storeInfo.getHybridStoreConfig());
-          Assert.assertEquals(storeInfo.getPartitionCount(), 2);
+          Assert.assertEquals(storeInfo.getPartitionCount(), 3); // max partition count from the config
         }
       });
     }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestVeniceHelixAdminWithSharedEnvironment.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestVeniceHelixAdminWithSharedEnvironment.java
@@ -193,8 +193,8 @@ public class TestVeniceHelixAdminWithSharedEnvironment extends AbstractTestVenic
   @Test(timeOut = TOTAL_TIMEOUT_FOR_SHORT_TEST_MS)
   public void testGetNumberOfPartition() {
     long partitionSize = controllerConfig.getPartitionSize();
-    int maxPartitionNumber = controllerConfig.getMaxNumberOfPartition();
-    int minPartitionNumber = controllerConfig.getNumberOfPartition();
+    int maxPartitionNumber = controllerConfig.getMaxNumberOfPartitions();
+    int minPartitionNumber = controllerConfig.getMinNumberOfPartitions();
     String storeName = Utils.getUniqueString("test");
 
     veniceAdmin.createStore(clusterName, storeName, "dev", KEY_SCHEMA, VALUE_SCHEMA);
@@ -235,8 +235,8 @@ public class TestVeniceHelixAdminWithSharedEnvironment extends AbstractTestVenic
   @Test(timeOut = TOTAL_TIMEOUT_FOR_SHORT_TEST_MS)
   public void testGetNumberOfPartitionsFromStoreLevelConfig() {
     long partitionSize = controllerConfig.getPartitionSize();
-    int maxPartitionNumber = controllerConfig.getMaxNumberOfPartition();
-    int minPartitionNumber = controllerConfig.getNumberOfPartition();
+    int maxPartitionNumber = controllerConfig.getMaxNumberOfPartitions();
+    int minPartitionNumber = controllerConfig.getMinNumberOfPartitions();
     String storeName = Utils.getUniqueString("test");
 
     veniceAdmin.createStore(clusterName, storeName, "dev", KEY_SCHEMA, VALUE_SCHEMA);

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestPushJobWithNativeReplication.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestPushJobWithNativeReplication.java
@@ -1023,11 +1023,17 @@ public class TestPushJobWithNativeReplication {
               systemStoreName + " is not ready for DC-" + iCopy);
 
           systemStoreName = VeniceSystemStoreType.DAVINCI_PUSH_STATUS_STORE.getSystemStoreName(storeName);
-          StoreResponse storeResponse2 =
-              controllerClient.getStore(VeniceSystemStoreType.DAVINCI_PUSH_STATUS_STORE.getSystemStoreName(storeName));
+          StoreResponse storeResponse2 = controllerClient.getStore(systemStoreName);
           Assert.assertFalse(storeResponse2.isError());
           Assert.assertTrue(
               storeResponse2.getStore().getCurrentVersion() > 0,
+              systemStoreName + " is not ready for DC-" + iCopy);
+
+          systemStoreName = VeniceSystemStoreType.BATCH_JOB_HEARTBEAT_STORE.getPrefix();
+          StoreResponse storeResponse3 = controllerClient.getStore(systemStoreName);
+          Assert.assertFalse(storeResponse3.isError());
+          Assert.assertTrue(
+              storeResponse3.getStore().getCurrentVersion() > 0,
               systemStoreName + " is not ready for DC-" + iCopy);
         });
       }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/restart/TestRestartServerAfterDeletingSstFilesWithActiveActiveIngestion.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/restart/TestRestartServerAfterDeletingSstFilesWithActiveActiveIngestion.java
@@ -151,7 +151,8 @@ public class TestRestartServerAfterDeletingSstFilesWithActiveActiveIngestion {
         .setHybridOffsetLagThreshold(2)
         .setNativeReplicationEnabled(true)
         .setBackupVersionRetentionMs(1)
-        .setIncrementalPushEnabled(true);
+        .setIncrementalPushEnabled(true)
+        .setPartitionCount(1);
     createStoreForJob(clusterName, keySchemaStr, valueSchemaStr, props, storeParms).close();
   }
 

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerClusterConfig.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerClusterConfig.java
@@ -111,9 +111,9 @@ public class VeniceControllerClusterConfig {
   private OfflinePushStrategy offlinePushStrategy;
   private RoutingStrategy routingStrategy;
   private int replicationFactor;
-  private int numberOfPartition;
-  private int numberOfPartitionForHybrid;
-  private int maxNumberOfPartition;
+  private int minNumberOfPartitions;
+  private int minNumberOfPartitionsForHybrid;
+  private int maxNumberOfPartitions;
   private long partitionSize;
   private boolean partitionCountRoundUpEnabled;
   private int partitionCountRoundUpSize;
@@ -297,11 +297,11 @@ public class VeniceControllerClusterConfig {
     kafkaMinLogCompactionLagInMs =
         props.getLong(KAFKA_MIN_LOG_COMPACTION_LAG_MS, DEFAULT_KAFKA_MIN_LOG_COMPACTION_LAG_MS);
     replicationFactor = props.getInt(DEFAULT_REPLICA_FACTOR);
-    numberOfPartition = props.getInt(DEFAULT_NUMBER_OF_PARTITION);
-    numberOfPartitionForHybrid = props.getInt(DEFAULT_NUMBER_OF_PARTITION_FOR_HYBRID, numberOfPartition);
+    minNumberOfPartitions = props.getInt(DEFAULT_NUMBER_OF_PARTITION);
+    minNumberOfPartitionsForHybrid = props.getInt(DEFAULT_NUMBER_OF_PARTITION_FOR_HYBRID, minNumberOfPartitions);
     kafkaBootstrapServers = props.getString(KAFKA_BOOTSTRAP_SERVERS);
     partitionSize = props.getSizeInBytes(DEFAULT_PARTITION_SIZE);
-    maxNumberOfPartition = props.getInt(DEFAULT_MAX_NUMBER_OF_PARTITIONS);
+    maxNumberOfPartitions = props.getInt(DEFAULT_MAX_NUMBER_OF_PARTITIONS);
     partitionCountRoundUpEnabled = props.getBoolean(ENABLE_PARTITION_COUNT_ROUND_UP, false);
     partitionCountRoundUpSize = props.getInt(PARTITION_COUNT_ROUND_UP_SIZE, 1);
     // If the timeout is longer than 3min, we need to update controller client's timeout as well, otherwise creating
@@ -463,12 +463,12 @@ public class VeniceControllerClusterConfig {
     return replicationFactor;
   }
 
-  public int getNumberOfPartition() {
-    return numberOfPartition;
+  public int getMinNumberOfPartitions() {
+    return minNumberOfPartitions;
   }
 
-  public int getNumberOfPartitionForHybrid() {
-    return numberOfPartitionForHybrid;
+  public int getMinNumberOfPartitionsForHybrid() {
+    return minNumberOfPartitionsForHybrid;
   }
 
   public int getKafkaReplicationFactor() {
@@ -487,8 +487,8 @@ public class VeniceControllerClusterConfig {
     return disableParentRequestTopicForStreamPushes;
   }
 
-  public int getMaxNumberOfPartition() {
-    return maxNumberOfPartition;
+  public int getMaxNumberOfPartitions() {
+    return maxNumberOfPartitions;
   }
 
   public boolean isPartitionCountRoundUpEnabled() {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -3653,7 +3653,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
       if (partitionCount != 0) {
         store.setPartitionCount(partitionCount);
       } else {
-        store.setPartitionCount(clusterConfig.getNumberOfPartition());
+        store.setPartitionCount(clusterConfig.getMinNumberOfPartitions());
       }
 
       return store;
@@ -3686,7 +3686,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
       throw new VeniceHttpException(HttpStatus.SC_BAD_REQUEST, errorMessage, ErrorType.INVALID_CONFIG);
     }
 
-    int maxPartitionNum = clusterConfig.getMaxNumberOfPartition();
+    int maxPartitionNum = clusterConfig.getMaxNumberOfPartitions();
     if (newPartitionCount > maxPartitionNum) {
       String errorMessage =
           errorMessagePrefix + "Partition count: " + newPartitionCount + " should be less than max: " + maxPartitionNum;
@@ -5820,8 +5820,8 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
         store.getStorageQuotaInByte(),
         store.getPartitionCount(),
         config.getPartitionSize(),
-        config.getNumberOfPartition(),
-        config.getMaxNumberOfPartition(),
+        config.getMinNumberOfPartitions(),
+        config.getMaxNumberOfPartitions(),
         config.isPartitionCountRoundUpEnabled(),
         config.getPartitionCountRoundUpSize());
   }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/init/InternalRTStoreInitializationRoutine.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/init/InternalRTStoreInitializationRoutine.java
@@ -64,7 +64,7 @@ public class InternalRTStoreInitializationRoutine implements ClusterLeaderInitia
     }
 
     if (store.getCurrentVersion() <= 0) {
-      int partitionCount = multiClusterConfigs.getControllerConfig(clusterName).getNumberOfPartition();
+      int partitionCount = multiClusterConfigs.getControllerConfig(clusterName).getMinNumberOfPartitions();
       int replicationFactor = admin.getReplicationFactor(clusterName, storeName);
       Version version = admin.incrementVersionIdempotent(
           clusterName,

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/AbstractTestVeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/AbstractTestVeniceParentHelixAdmin.java
@@ -190,7 +190,7 @@ public class AbstractTestVeniceParentHelixAdmin {
     Map<String, String> childClusterMap = new HashMap<>();
     childClusterMap.put(regionName, "localhost");
     doReturn(childClusterMap).when(config).getChildDataCenterControllerUrlMap();
-    doReturn(MAX_PARTITION_NUM).when(config).getMaxNumberOfPartition();
+    doReturn(MAX_PARTITION_NUM).when(config).getMaxNumberOfPartitions();
     doReturn(DefaultIdentityParser.class.getName()).when(config).getIdentityParserClassName();
     return config;
   }


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Summary, imperative, start upper case, don't end with a period
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
Ensures the number of partitions for a hybrid store is based on storage quota. This should help to better scale ingestion path. Also fixes a bug in `PartitionUtils` that caused the min partition count assigned when unlimited quota is specified.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
Updated TestParentControllerWithMultiDataCenter to verify new behavior.

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.