### PR TITLE
[vpj][controller][doc] Add post validation and consumption for targeted region push

### DIFF
--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
@@ -1183,6 +1183,10 @@ public class VenicePushJob implements AutoCloseable {
         updatePushJobDetailsWithLivenessHeartbeatException(pushJobHeartbeatSender);
         sendPushJobDetailsToController();
 
+        // only kick off the validation and post-validation flow when everything has to be done in a single VPJ
+        if (!(pushJobSetting.isTargetedRegionPushEnabled && pushJobSetting.postValidationConsumption)) {
+          return;
+        }
         /**
          * Post validation + consumption
          */
@@ -1238,15 +1242,11 @@ public class VenicePushJob implements AutoCloseable {
    * @return a set of regions that haven't been pushed yet.
    */
   private Set<String> getRegionsForPostValidationConsumption() {
-    // only kick off the validation and post-validation flow when everything has to be done in a single VPJ
-    if (pushJobSetting.isTargetedRegionPushEnabled && pushJobSetting.postValidationConsumption) {
-      Set<String> targetedRegions = RegionUtils.parseRegionsFilterList(pushJobSetting.targetedRegions);
-      Set<String> candidateRegions =
-          new HashSet<>(storeSetting.storeResponse.getStore().getColoToCurrentVersions().keySet());
-      candidateRegions.removeAll(targetedRegions);
-      return candidateRegions;
-    }
-    return Collections.emptySet();
+    Set<String> targetedRegions = RegionUtils.parseRegionsFilterList(pushJobSetting.targetedRegions);
+    Set<String> candidateRegions =
+        new HashSet<>(storeSetting.storeResponse.getStore().getColoToCurrentVersions().keySet());
+    candidateRegions.removeAll(targetedRegions);
+    return candidateRegions;
   }
 
   /**

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
@@ -54,6 +54,8 @@ import com.linkedin.venice.hadoop.schema.HDFSRmdSchemaSource;
 import com.linkedin.venice.hadoop.ssl.TempFileSSLConfigurator;
 import com.linkedin.venice.hadoop.utils.HadoopUtils;
 import com.linkedin.venice.hadoop.utils.VPJSSLUtils;
+import com.linkedin.venice.hadoop.validation.NoOpValidator;
+import com.linkedin.venice.hadoop.validation.Validator;
 import com.linkedin.venice.message.KafkaKey;
 import com.linkedin.venice.meta.BufferReplayPolicy;
 import com.linkedin.venice.meta.HybridStoreConfig;
@@ -73,6 +75,7 @@ import com.linkedin.venice.status.protocol.PushJobDetailsStatusTuple;
 import com.linkedin.venice.utils.DictionaryUtils;
 import com.linkedin.venice.utils.EncodingUtils;
 import com.linkedin.venice.utils.PartitionUtils;
+import com.linkedin.venice.utils.RegionUtils;
 import com.linkedin.venice.utils.Time;
 import com.linkedin.venice.utils.Utils;
 import com.linkedin.venice.utils.VeniceProperties;
@@ -409,6 +412,11 @@ public class VenicePushJob implements AutoCloseable {
   public static final String TARGETED_REGION_PUSH_LIST = "targeted.region.push.list";
 
   /**
+   * Config to enable post validation and consumption in VPJ when {@link #TARGETED_REGION_PUSH_ENABLED} is true.
+   */
+  public static final String POST_VALIDATION_CONSUMPTION_ENABLED = "post.validation.consumption.enabled";
+
+  /**
    * Since the job is calculating the raw data file size, which is not accurate because of compression,
    * key/value schema and backend storage overhead, we are applying this factor to provide a more
    * reasonable estimation.
@@ -517,6 +525,7 @@ public class VenicePushJob implements AutoCloseable {
     boolean d2Routing;
     String targetedRegions;
     boolean isTargetedRegionPushEnabled;
+    boolean postValidationConsumption;
   }
 
   protected PushJobSetting pushJobSetting;
@@ -537,6 +546,7 @@ public class VenicePushJob implements AutoCloseable {
     int amplificationFactor;
     boolean chunkingEnabled;
     boolean rmdChunkingEnabled;
+    String kafkaSourceRegion;
   }
 
   private TopicInfo kafkaTopicInfo;
@@ -690,6 +700,10 @@ public class VenicePushJob implements AutoCloseable {
     pushJobSettingToReturn.repushTTLEnabled = props.getBoolean(REPUSH_TTL_ENABLE, false);
     pushJobSettingToReturn.repushTTLInSeconds = NOT_SET;
     pushJobSettingToReturn.isTargetedRegionPushEnabled = props.getBoolean(TARGETED_REGION_PUSH_ENABLED, false);
+    pushJobSettingToReturn.postValidationConsumption = props.getBoolean(POST_VALIDATION_CONSUMPTION_ENABLED, true);
+    if (pushJobSettingToReturn.isIncrementalPush && pushJobSettingToReturn.isTargetedRegionPushEnabled) {
+      throw new VeniceException("Incremental push is not supported while using targeted region push mode");
+    }
     if (props.containsKey(TARGETED_REGION_PUSH_LIST)) {
       if (pushJobSettingToReturn.isTargetedRegionPushEnabled) {
         pushJobSettingToReturn.targetedRegions = props.getString(TARGETED_REGION_PUSH_LIST);
@@ -1167,6 +1181,17 @@ public class VenicePushJob implements AutoCloseable {
         updatePushJobDetailsWithConfigs();
         updatePushJobDetailsWithLivenessHeartbeatException(pushJobHeartbeatSender);
         sendPushJobDetailsToController();
+
+        /**
+         * Post validation + consumption
+         */
+        Set<String> candidateRegions = getCandidateRegions();
+        if (candidateRegions.isEmpty()) {
+          LOGGER.info("No region that needs post-validation consumption identified. Finish the job now.");
+          return;
+        }
+        postPushValidation();
+        postValidationConsumption(candidateRegions);
       }
     } catch (Throwable e) {
       LOGGER.error("Failed to run job.", e);
@@ -1204,6 +1229,73 @@ public class VenicePushJob implements AutoCloseable {
       if (pushJobSetting.rmdSchemaDir != null) {
         HadoopUtils.cleanUpHDFSPath(pushJobSetting.rmdSchemaDir, true);
       }
+    }
+  }
+
+  /**
+   * Get the set of regions that haven't been pushed yet.
+   * @return a set of regions that haven't been pushed yet.
+   */
+  private Set<String> getCandidateRegions() {
+    // only kick off the validation and post-validation flow when everything has to be done in a single VPJ
+    if (pushJobSetting.isTargetedRegionPushEnabled && pushJobSetting.postValidationConsumption) {
+      Set<String> targetedRegions = RegionUtils.parseRegionsFilterList(pushJobSetting.targetedRegions);
+      Set<String> candidateRegions =
+          new HashSet<>(storeSetting.storeResponse.getStore().getColoToCurrentVersions().keySet());
+      candidateRegions.removeAll(targetedRegions);
+      return candidateRegions;
+    }
+    return new HashSet<>();
+  }
+
+  /**
+   * Start a group of validation job to verify result from the previous targeted region push is healthy.
+   */
+  void postPushValidation() {
+    if (kafkaTopicInfo.kafkaSourceRegion == null) {
+      throw new VeniceException("Post-validation consumption halted due to no available source region found");
+    }
+
+    // TODO: Add parallelism support when we have more validators. It's premature to do so now.
+    Validator noOpValidator = new NoOpValidator();
+    noOpValidator.validate();
+  }
+
+  /**
+   * Kick off the post-validation consumption on the rest of regions that haven't been pushed yet.
+   * @param candidateRegions
+   */
+  private void postValidationConsumption(Set<String> candidateRegions) {
+    // get the latest version of the store for data recovery
+    Version sourceVersion = getStoreVersion(pushJobSetting.storeName, kafkaTopicInfo.version);
+
+    if (sourceVersion.getHybridStoreConfig() != null) {
+      // perform data recovery for HYBRID stores
+      pushJobSetting.isTargetedRegionPushEnabled = false;
+      pushJobSetting.targetedRegions = null;
+      // set up repush
+      pushJobSetting.isSourceKafka = true;
+      pushJobSetting.kafkaInputBrokerUrl = kafkaTopicInfo.kafkaUrl;
+      pushJobSetting.kafkaInputTopic = kafkaTopicInfo.topic;
+      this.run();
+    } else {
+      // perform data recovery for BATCH stores
+      for (String region: candidateRegions) {
+        ControllerResponse response = controllerClient.dataRecovery(
+            kafkaTopicInfo.kafkaSourceRegion,
+            region,
+            pushJobSetting.storeName,
+            sourceVersion.getNumber(),
+            true,
+            true,
+            Optional.of(sourceVersion));
+        if (response.isError()) {
+          throw new VeniceException("Can't perform data recovery for region " + region + ". " + response.getError());
+        }
+      }
+      // Essentially, the remaining regions are "targeted" regions now
+      pushJobSetting.targetedRegions = RegionUtils.composeRegionList(candidateRegions);
+      pollStatusUntilComplete(Optional.empty(), controllerClient, pushJobSetting, kafkaTopicInfo);
     }
   }
 
@@ -2312,9 +2404,6 @@ public class VenicePushJob implements AutoCloseable {
         throw new VeniceException(
             "The store either does not have native replication mode enabled or set up default source fabric.");
       }
-      if (setting.isIncrementalPush) {
-        throw new VeniceException("Incremental push is not supported while using targeted region push mode");
-      }
     }
 
     HybridStoreConfig hybridStoreConfig = storeResponse.getStore().getHybridStoreConfig();
@@ -2458,6 +2547,7 @@ public class VenicePushJob implements AutoCloseable {
     kafkaTopicInfo.amplificationFactor = versionCreationResponse.getAmplificationFactor();
     kafkaTopicInfo.chunkingEnabled = storeSetting.isChunkingEnabled && !Version.isRealTimeTopic(kafkaTopicInfo.topic);
     kafkaTopicInfo.rmdChunkingEnabled = kafkaTopicInfo.chunkingEnabled && storeSetting.isRmdChunkingEnabled;
+    kafkaTopicInfo.kafkaSourceRegion = versionCreationResponse.getKafkaSourceRegion();
 
     if (pushJobSetting.isSourceKafka) {
       /**
@@ -2472,35 +2562,20 @@ public class VenicePushJob implements AutoCloseable {
        *
        * TODO: maybe we should fail fast before creating a new version.
        */
-      StoreResponse storeResponse = ControllerClient
-          .retryableRequest(controllerClient, setting.controllerRetries, c -> c.getStore(setting.storeName));
-      if (storeResponse.isError()) {
-        throw new VeniceException(
-            "Failed to retrieve store response with urls: " + setting.veniceControllerUrl + ", error: "
-                + storeResponse.getError());
-      }
-      int newVersionNum = kafkaTopicInfo.version;
-      Optional<Version> newVersionOptional = storeResponse.getStore().getVersion(newVersionNum);
-      if (!newVersionOptional.isPresent()) {
-        throw new VeniceException(
-            "Couldn't fetch the newly created version: " + newVersionNum + " for store: " + setting.storeName
-                + " with urls: " + setting.veniceControllerUrl);
-      }
-      Version newVersion = newVersionOptional.get();
+      Version newVersion = getStoreVersion(setting.storeName, kafkaTopicInfo.version);
       Version sourceVersion = storeSetting.sourceKafkaInputVersionInfo;
 
       // Chunked source version cannot be repushed if new version is not chunking enabled.
       if (sourceVersion.isChunkingEnabled() && !newVersion.isChunkingEnabled()) {
         throw new VeniceException(
-            "Chunking config mismatch between the source and the new version of store "
-                + storeResponse.getStore().getName() + ". Source version: " + sourceVersion.getNumber() + " is using: "
-                + sourceVersion.isChunkingEnabled() + ", new version: " + newVersion.getNumber() + " is using: "
-                + newVersion.isChunkingEnabled());
+            "Chunking config mismatch between the source and the new version of store " + setting.storeName
+                + ". Source version: " + sourceVersion.getNumber() + " is using: " + sourceVersion.isChunkingEnabled()
+                + ", new version: " + newVersion.getNumber() + " is using: " + newVersion.isChunkingEnabled());
       }
       if (sourceVersion.isRmdChunkingEnabled() && !newVersion.isRmdChunkingEnabled()) {
         throw new VeniceException(
-            "RMD Chunking config mismatch between the source and the new version of store "
-                + storeResponse.getStore().getName() + ". Source version: " + sourceVersion.getNumber() + " is using: "
+            "RMD Chunking config mismatch between the source and the new version of store " + setting.storeName
+                + ". Source version: " + sourceVersion.getNumber() + " is using: "
                 + sourceVersion.isRmdChunkingEnabled() + ", new version: " + newVersion.getNumber() + " is using: "
                 + newVersion.isRmdChunkingEnabled());
       }
@@ -3103,6 +3178,30 @@ public class VenicePushJob implements AutoCloseable {
      * These values were populated to schemaInfo in the same function but in driver */
     conf.set(KEY_FIELD_PROP, pushJobSchemaInfo.getKeyField());
     conf.set(VALUE_FIELD_PROP, pushJobSchemaInfo.getValueField());
+  }
+
+  /**
+   * Query the controller to retrieve a specific version
+   * @param storeName
+   * @param version
+   * @return
+   */
+  private Version getStoreVersion(String storeName, int version) {
+    StoreResponse storeResponse = ControllerClient
+        .retryableRequest(controllerClient, pushJobSetting.controllerRetries, c -> c.getStore(storeName));
+    if (storeResponse.isError()) {
+      throw new VeniceException(
+          "Failed to retrieve store response with urls: " + pushJobSetting.veniceControllerUrl + ", error: "
+              + storeResponse.getError());
+    }
+    Optional<Version> newVersion = storeResponse.getStore().getVersion(version);
+    if (!newVersion.isPresent()) {
+      throw new VeniceException(
+          "Couldn't fetch the newly created version: " + version + " for store: " + storeName + " with urls: "
+              + pushJobSetting.veniceControllerUrl);
+    }
+
+    return newVersion.get();
   }
 
   private void logPushJobProperties(

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
@@ -1266,7 +1266,7 @@ public class VenicePushJob implements AutoCloseable {
    * Kick off the post-validation consumption on the rest of regions that haven't been pushed yet.
    * @param candidateRegions
    */
-  private void postValidationConsumption(Set<String> candidateRegions) {
+  void postValidationConsumption(Set<String> candidateRegions) {
     // get the latest version of the store for data recovery
     Version sourceVersion = getStoreVersion(pushJobSetting.storeName, kafkaTopicInfo.version);
 
@@ -1291,7 +1291,7 @@ public class VenicePushJob implements AutoCloseable {
             true,
             Optional.of(sourceVersion));
         if (response.isError()) {
-          throw new VeniceException("Can't perform data recovery for region " + region + ". " + response.getError());
+          throw new VeniceException("Can't push data for region " + region + ". " + response.getError());
         }
       }
       // Essentially, the remaining regions are "targeted" regions now

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
@@ -1185,7 +1185,7 @@ public class VenicePushJob implements AutoCloseable {
         /**
          * Post validation + consumption
          */
-        Set<String> candidateRegions = getCandidateRegions();
+        Set<String> candidateRegions = getRegionsForTargetedRegionPush();
         if (candidateRegions.isEmpty()) {
           LOGGER.info("No region that needs post-validation consumption identified. Finish the job now.");
           return;
@@ -1233,10 +1233,10 @@ public class VenicePushJob implements AutoCloseable {
   }
 
   /**
-   * Get the set of regions that haven't been pushed yet.
+   * Get the set of regions that haven't been pushed yet for targeted region push.
    * @return a set of regions that haven't been pushed yet.
    */
-  private Set<String> getCandidateRegions() {
+  private Set<String> getRegionsForTargetedRegionPush() {
     // only kick off the validation and post-validation flow when everything has to be done in a single VPJ
     if (pushJobSetting.isTargetedRegionPushEnabled && pushJobSetting.postValidationConsumption) {
       Set<String> targetedRegions = RegionUtils.parseRegionsFilterList(pushJobSetting.targetedRegions);
@@ -1245,7 +1245,7 @@ public class VenicePushJob implements AutoCloseable {
       candidateRegions.removeAll(targetedRegions);
       return candidateRegions;
     }
-    return new HashSet<>();
+    return Collections.emptySet();
   }
 
   /**

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
@@ -1185,7 +1185,7 @@ public class VenicePushJob implements AutoCloseable {
         /**
          * Post validation + consumption
          */
-        Set<String> candidateRegions = getRegionsForTargetedRegionPush();
+        Set<String> candidateRegions = getRegionsForPostValidationConsumption();
         if (candidateRegions.isEmpty()) {
           LOGGER.info("No region that needs post-validation consumption identified. Finish the job now.");
           return;
@@ -1233,10 +1233,10 @@ public class VenicePushJob implements AutoCloseable {
   }
 
   /**
-   * Get the set of regions that haven't been pushed yet for targeted region push.
+   * Get the set of regions that haven't been pushed yet after targeted region push.
    * @return a set of regions that haven't been pushed yet.
    */
-  private Set<String> getRegionsForTargetedRegionPush() {
+  private Set<String> getRegionsForPostValidationConsumption() {
     // only kick off the validation and post-validation flow when everything has to be done in a single VPJ
     if (pushJobSetting.isTargetedRegionPushEnabled && pushJobSetting.postValidationConsumption) {
       Set<String> targetedRegions = RegionUtils.parseRegionsFilterList(pushJobSetting.targetedRegions);

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/exceptions/VeniceValidationException.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/exceptions/VeniceValidationException.java
@@ -1,0 +1,19 @@
+package com.linkedin.venice.hadoop.exceptions;
+
+import com.linkedin.venice.exceptions.VeniceException;
+import com.linkedin.venice.hadoop.VenicePushJob;
+
+
+/**
+ * Customized exception for validation error for targeted colo push
+ * in {@link VenicePushJob}
+ */
+public class VeniceValidationException extends VeniceException {
+  public VeniceValidationException(String message) {
+    super(message);
+  }
+
+  public VeniceValidationException(String message, Throwable throwable) {
+    super(message, throwable);
+  }
+}

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/validation/NoOpValidator.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/validation/NoOpValidator.java
@@ -1,0 +1,15 @@
+package com.linkedin.venice.hadoop.validation;
+
+import com.linkedin.venice.hadoop.exceptions.VeniceValidationException;
+
+
+/**
+ * No Op validator. Always returns true.
+ */
+public class NoOpValidator implements Validator {
+  @Override
+  public void validate() throws VeniceValidationException {
+    // No Op
+    return;
+  }
+}

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/validation/Validator.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/validation/Validator.java
@@ -1,0 +1,11 @@
+package com.linkedin.venice.hadoop.validation;
+
+import com.linkedin.venice.hadoop.exceptions.VeniceValidationException;
+
+
+/**
+ * Interface for targeted region push validation.
+ */
+public interface Validator {
+  void validate() throws VeniceValidationException;
+}

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/VenicePushJobTest.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/VenicePushJobTest.java
@@ -194,7 +194,7 @@ public class VenicePushJobTest {
     pushJob.storeSetting.storeResponse.setStore(storeInfo);
     VeniceException exception = Assert.expectThrows(
         VeniceException.class,
-        () -> pushJob.pollStatusUntilComplete(Optional.empty(), client, pushJobSetting, topicInfo));
+        () -> pushJob.pollStatusUntilComplete(Optional.empty(), client, pushJobSetting, topicInfo, null));
     Assert.assertEquals(exception.getMessage(), "Failing push-job for store abc which is still running after 0 hours.");
   }
 

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/VenicePushJobTest.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/VenicePushJobTest.java
@@ -7,6 +7,7 @@ import static com.linkedin.venice.hadoop.VenicePushJob.LEGACY_AVRO_KEY_FIELD_PRO
 import static com.linkedin.venice.hadoop.VenicePushJob.LEGACY_AVRO_VALUE_FIELD_PROP;
 import static com.linkedin.venice.hadoop.VenicePushJob.MULTI_REGION;
 import static com.linkedin.venice.hadoop.VenicePushJob.PARENT_CONTROLLER_REGION_NAME;
+import static com.linkedin.venice.hadoop.VenicePushJob.POST_VALIDATION_CONSUMPTION_ENABLED;
 import static com.linkedin.venice.hadoop.VenicePushJob.REPUSH_TTL_ENABLE;
 import static com.linkedin.venice.hadoop.VenicePushJob.SOURCE_ETL;
 import static com.linkedin.venice.hadoop.VenicePushJob.SOURCE_KAFKA;
@@ -22,10 +23,13 @@ import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
@@ -97,7 +101,15 @@ public class VenicePushJobTest {
   public void testRepushTTLJobWithBatchStore() {
     Properties repushProps = getRepushReadyProps();
 
-    ControllerClient client = getClient();
+    ControllerClient client = getClient(storeInfo -> {
+      storeInfo.setColoToCurrentVersions(new HashMap<String, Integer>() {
+        {
+          // the initial version for all regions is 1, otherwise the topic name would mismatch
+          put("dc-0", 1);
+          put("dc-1", 1);
+        }
+      });
+    });
     VenicePushJob pushJob = getSpyVenicePushJob(repushProps, client);
     pushJob.run();
   }
@@ -111,6 +123,13 @@ public class VenicePushJobTest {
       storeInfo.setWriteComputationEnabled(true);
       storeInfo.setVersions(Collections.singletonList(version));
       storeInfo.setHybridStoreConfig(new HybridStoreConfigImpl(0, 0, 0, null, null));
+      storeInfo.setColoToCurrentVersions(new HashMap<String, Integer>() {
+        {
+          // the initial version for all regions is 1, otherwise the topic name would mismatch
+          put("dc-0", 1);
+          put("dc-1", 1);
+        }
+      });
     });
     VenicePushJob pushJob = getSpyVenicePushJob(repushProps, client);
     pushJob.run();
@@ -233,10 +252,14 @@ public class VenicePushJobTest {
   }
 
   private ControllerClient getClient() {
-    return getClient(storeInfo -> {});
+    return getClient(storeInfo -> {}, false);
   }
 
   private ControllerClient getClient(Consumer<StoreInfo> storeInfo) {
+    return getClient(storeInfo, false);
+  }
+
+  private ControllerClient getClient(Consumer<StoreInfo> storeInfo, boolean applyFirst) {
     ControllerClient client = mock(ControllerClient.class);
     // mock discover cluster
     D2ServiceDiscoveryResponse clusterResponse = new D2ServiceDiscoveryResponse();
@@ -249,9 +272,22 @@ public class VenicePushJobTest {
     doReturn(schemaResponse).when(client).getValueSchema(anyString(), anyInt());
 
     // mock storeinfo response
-    StoreResponse storeResponse = new StoreResponse();
-    storeResponse.setStore(getStoreInfo(storeInfo));
-    doReturn(storeResponse).when(client).getStore(TEST_STORE);
+    StoreResponse storeResponse1 = new StoreResponse();
+    storeResponse1.setStore(getStoreInfo(storeInfo, applyFirst));
+
+    // simulating a version bump in a targeted colo push
+    StoreResponse storeResponse2 = new StoreResponse();
+    storeResponse2.setStore(getStoreInfo(info -> {
+      info.setColoToCurrentVersions(new HashMap<String, Integer>() {
+        {
+          put("dc-0", 1);
+          put("dc-1", 0);
+        }
+      });
+
+      storeInfo.accept(info);
+    }, applyFirst));
+    doReturn(storeResponse1).doReturn(storeResponse2).when(client).getStore(TEST_STORE);
 
     // mock key schema
     SchemaResponse keySchemaResponse = new SchemaResponse();
@@ -260,33 +296,7 @@ public class VenicePushJobTest {
     doReturn(keySchemaResponse).when(client).getKeySchema(TEST_STORE);
 
     // mock version creation
-    VersionCreationResponse versionCreationResponse = new VersionCreationResponse();
-    versionCreationResponse.setKafkaTopic("kafka-topic");
-    versionCreationResponse.setVersion(1);
-    versionCreationResponse.setKafkaBootstrapServers("kafka-bootstrap-server");
-    versionCreationResponse.setPartitions(1);
-    versionCreationResponse.setEnableSSL(false);
-    versionCreationResponse.setCompressionStrategy(CompressionStrategy.NO_OP);
-    versionCreationResponse.setDaVinciPushStatusStoreEnabled(false);
-    versionCreationResponse.setPartitionerClass("PartitionerClass");
-    versionCreationResponse.setPartitionerParams(Collections.emptyMap());
-
-    doReturn(versionCreationResponse).when(client)
-        .requestTopicForWrites(
-            anyString(),
-            anyLong(),
-            any(),
-            anyString(),
-            anyBoolean(),
-            anyBoolean(),
-            anyBoolean(),
-            any(),
-            any(),
-            any(),
-            anyBoolean(),
-            anyLong(),
-            anyBoolean(),
-            any());
+    mockVersionCreationResponse(client);
 
     ControllerResponse response = new ControllerResponse();
     doReturn(response).when(client).writeEndOfPush(anyString(), anyInt());
@@ -294,8 +304,16 @@ public class VenicePushJobTest {
     return client;
   }
 
-  private StoreInfo getStoreInfo(Consumer<StoreInfo> info) {
+  /**
+   * Create a StoreInfo and associated Version for testing
+   * @param info, supplemented StoreInfo that should be added in the result.
+   * @param applyFirst, if true, apply the StoreInfo first before creating Version, otherwise apply the default values only.
+   *                    This is useful for testing different Version objects returned by the StoreInfo.
+   * @return
+   */
+  private StoreInfo getStoreInfo(Consumer<StoreInfo> info, boolean applyFirst) {
     StoreInfo storeInfo = new StoreInfo();
+
     storeInfo.setCurrentVersion(REPUSH_VERSION);
     storeInfo.setIncrementalPushEnabled(false);
     storeInfo.setStorageQuotaInByte(1L);
@@ -305,10 +323,22 @@ public class VenicePushJobTest {
     storeInfo.setWriteComputationEnabled(false);
     storeInfo.setIncrementalPushEnabled(false);
     storeInfo.setNativeReplicationSourceFabric("dc-0");
-
+    Map<String, Integer> coloMaps = new HashMap<String, Integer>() {
+      {
+        put("dc-0", 0);
+        put("dc-1", 0);
+      }
+    };
+    storeInfo.setColoToCurrentVersions(coloMaps);
+    if (applyFirst) {
+      info.accept(storeInfo);
+    }
     Version version = new VersionImpl(TEST_STORE, REPUSH_VERSION, TEST_PUSH);
+    version.setHybridStoreConfig(storeInfo.getHybridStoreConfig());
     storeInfo.setVersions(Collections.singletonList(version));
-    info.accept(storeInfo);
+    if (!applyFirst) {
+      info.accept(storeInfo);
+    }
     return storeInfo;
   }
 
@@ -523,13 +553,8 @@ public class VenicePushJobTest {
     }
 
     props.put(TARGETED_REGION_PUSH_ENABLED, true);
-    props.remove(TARGETED_REGION_PUSH_LIST);
     props.put(INCREMENTAL_PUSH, true);
-    ControllerClient client = getClient();
-    VenicePushJob pushJob = getSpyVenicePushJob(props, client);
-    skipVPJValidation(pushJob);
-    try {
-      pushJob.run();
+    try (VenicePushJob pushJob = new VenicePushJob(PUSH_JOB_ID, props)) {
       Assert.fail("Test should fail, but doesn't.");
     } catch (VeniceException e) {
       assertEquals(e.getMessage(), "Incremental push is not supported while using targeted region push mode");
@@ -540,12 +565,14 @@ public class VenicePushJobTest {
   public void testTargetedRegionPushConfigOverride() throws Exception {
     Properties props = getVpjRequiredProperties();
     props.put(TARGETED_REGION_PUSH_ENABLED, true);
+    props.put(POST_VALIDATION_CONSUMPTION_ENABLED, false);
     // when targeted region push is enabled, but store doesn't have source fabric set.
     ControllerClient client = getClient(store -> {
       store.setNativeReplicationSourceFabric("");
     });
     VenicePushJob pushJob = getSpyVenicePushJob(props, client);
-    mockJobStatusQuery(client);
+    JobStatusQueryResponse response = mockJobStatusQuery();
+    doReturn(response).when(client).queryOverallJobStatus(anyString(), any(), anyString());
     skipVPJValidation(pushJob);
     try {
       pushJob.run();
@@ -560,7 +587,7 @@ public class VenicePushJobTest {
     props.put(TARGETED_REGION_PUSH_LIST, "dc-0, dc-1");
     client = getClient();
     pushJob = getSpyVenicePushJob(props, client);
-    mockJobStatusQuery(client);
+    doReturn(response).when(client).queryOverallJobStatus(anyString(), any(), anyString());
     skipVPJValidation(pushJob);
     pushJob.run();
     Assert.assertEquals(pushJob.pushJobSetting.targetedRegions, "dc-0, dc-1");
@@ -570,36 +597,96 @@ public class VenicePushJobTest {
   public void testTargetedRegionPushReporting() throws Exception {
     Properties props = getVpjRequiredProperties();
     props.put(TARGETED_REGION_PUSH_ENABLED, true);
+    props.put(POST_VALIDATION_CONSUMPTION_ENABLED, false);
     props.put(TARGETED_REGION_PUSH_LIST, "dc-0, dc-1");
     ControllerClient client = getClient();
     VenicePushJob pushJob = getSpyVenicePushJob(props, client);
     skipVPJValidation(pushJob);
 
-    JobStatusQueryResponse response = new JobStatusQueryResponse();
-    response.setStatus(ExecutionStatus.COMPLETED.toString());
-    response.setStatusDetails("nothing");
-    response.setVersion(1);
-    response.setName(TEST_STORE);
-    response.setCluster(TEST_CLUSTER);
-    Map<String, String> extraInfo = new HashMap<>();
-    extraInfo.put("dc-0", ExecutionStatus.COMPLETED.toString());
-    extraInfo.put("dc-1", ExecutionStatus.COMPLETED.toString());
-    response.setExtraInfo(extraInfo);
-    doReturn(response).when(client).queryOverallJobStatus(anyString(), any(), anyString());
-    // only one region is completed, so should succeed
-    pushJob.run();
-
+    JobStatusQueryResponse response = mockJobStatusQuery();
+    Map<String, String> extraInfo = response.getExtraInfo();
     // one of the regions failed, so should fail
     extraInfo.put("dc-0", ExecutionStatus.NOT_STARTED.toString());
+    doReturn(response).when(client).queryOverallJobStatus(anyString(), any(), anyString());
     try {
       pushJob.run();
       Assert.fail("Test should fail, but doesn't.");
     } catch (VeniceException e) {
       assertTrue(e.getMessage().contains("Push job error"));
     }
+
+    extraInfo.put("dc-0", ExecutionStatus.COMPLETED.toString());
+    extraInfo.put("dc-1", ExecutionStatus.COMPLETED.toString());
+    // both regions completed, so should succeed
+    pushJob.run();
   }
 
-  private void mockJobStatusQuery(ControllerClient client) {
+  @Test
+  public void testTargetedRegionPushPostValidationConsumptionForBatchStore() throws Exception {
+    Properties props = getVpjRequiredProperties();
+    props.put(TARGETED_REGION_PUSH_ENABLED, true);
+    props.put(POST_VALIDATION_CONSUMPTION_ENABLED, true);
+    ControllerClient client = getClient();
+    VenicePushJob pushJob = getSpyVenicePushJob(props, client);
+    skipVPJValidation(pushJob);
+
+    JobStatusQueryResponse response = mockJobStatusQuery();
+    doReturn(response).when(client).queryOverallJobStatus(anyString(), any(), anyString());
+
+    VersionCreationResponse mockVersionCreationResponse = mockVersionCreationResponse(client);
+    mockVersionCreationResponse.setKafkaSourceRegion(null);
+
+    // verify the kafka source region must be present when kick off post-validation consumption
+    try {
+      pushJob.run();
+      Assert.fail("Test should fail, but doesn't.");
+    } catch (VeniceException e) {
+      assertTrue(e.getMessage().contains("Post-validation consumption halted due to no available source region found"));
+    }
+    mockVersionCreationResponse.setKafkaSourceRegion("dc-0");
+    verify(pushJob, times(1)).postPushValidation();
+
+    ControllerResponse badDataRecoveryResponse = new ControllerResponse();
+    badDataRecoveryResponse.setError("error");
+    doReturn(badDataRecoveryResponse).when(client)
+        .dataRecovery(anyString(), anyString(), anyString(), anyInt(), anyBoolean(), anyBoolean(), any());
+    // verify failure of data recovery will fail the push job
+    try {
+      pushJob.run();
+    } catch (VeniceException e) {
+      assertTrue(e.getMessage().contains("Can't perform data recovery for region"));
+    }
+
+    ControllerResponse goodDataRecoveryResponse = new ControllerResponse();
+    doReturn(goodDataRecoveryResponse).when(client)
+        .dataRecovery(anyString(), anyString(), anyString(), anyInt(), anyBoolean(), anyBoolean(), any());
+
+    // the job should succeed
+    pushJob.run();
+  }
+
+  @Test
+  public void testTargetedRegionPushPostValidationConsumptionForHybridStore() throws Exception {
+    Properties props = getVpjRequiredProperties();
+    props.put(TARGETED_REGION_PUSH_ENABLED, true);
+    props.put(POST_VALIDATION_CONSUMPTION_ENABLED, true);
+    ControllerClient client = getClient(storeInfo -> {
+      storeInfo.setHybridStoreConfig(new HybridStoreConfigImpl(0, 0, 0, null, null));
+    }, true);
+    VenicePushJob pushJob = getSpyVenicePushJob(props, client);
+    skipVPJValidation(pushJob);
+
+    JobStatusQueryResponse response = mockJobStatusQuery();
+    doReturn(response).when(client).queryOverallJobStatus(anyString(), any(), anyString());
+    // skip the mocking for repush
+    doCallRealMethod().doNothing().when(pushJob).run();
+    pushJob.run();
+
+    // for hybrid store, the job is supposed to ran twice, one for targeted region push and another is for repush
+    verify(pushJob, times(2)).run();
+  }
+
+  private JobStatusQueryResponse mockJobStatusQuery() {
     JobStatusQueryResponse response = new JobStatusQueryResponse();
     response.setStatus(ExecutionStatus.COMPLETED.toString());
     response.setStatusDetails("nothing");
@@ -610,7 +697,42 @@ public class VenicePushJobTest {
     extraInfo.put("dc-0", ExecutionStatus.COMPLETED.toString());
     extraInfo.put("dc-1", ExecutionStatus.COMPLETED.toString());
     response.setExtraInfo(extraInfo);
-    doReturn(response).when(client).queryOverallJobStatus(anyString(), any(), anyString());
+    return response;
+  }
+
+  private VersionCreationResponse mockVersionCreationResponse(ControllerClient client) {
+    VersionCreationResponse versionCreationResponse = new VersionCreationResponse();
+    versionCreationResponse.setKafkaTopic("kafka-topic");
+    versionCreationResponse.setVersion(1);
+    versionCreationResponse.setKafkaSourceRegion("dc-0");
+    versionCreationResponse.setKafkaBootstrapServers("kafka-bootstrap-server");
+    versionCreationResponse.setPartitions(1);
+    versionCreationResponse.setEnableSSL(false);
+    versionCreationResponse.setCompressionStrategy(CompressionStrategy.NO_OP);
+    versionCreationResponse.setDaVinciPushStatusStoreEnabled(false);
+    versionCreationResponse.setPartitionerClass("PartitionerClass");
+    versionCreationResponse.setPartitionerParams(Collections.emptyMap());
+
+    if (client != null) {
+      doReturn(versionCreationResponse).when(client)
+          .requestTopicForWrites(
+              anyString(),
+              anyLong(),
+              any(),
+              anyString(),
+              anyBoolean(),
+              anyBoolean(),
+              anyBoolean(),
+              any(),
+              any(),
+              any(),
+              anyBoolean(),
+              anyLong(),
+              anyBoolean(),
+              any());
+    }
+
+    return versionCreationResponse;
   }
 
   private void skipVPJValidation(VenicePushJob pushJob) throws Exception {

--- a/docs/user_guide/write_api/push_job.md
+++ b/docs/user_guide/write_api/push_job.md
@@ -34,7 +34,8 @@ subset of global regions/data centers, whereas full push writes globally at once
 By default, it automatically pushes data to the rest of unspecified regions after the targeted region push is completed.
 We are working on to implement more validations in between to ensure the targeted regions are healthy after the first push. 
 Users may turn off this automation and perform validations and chain it with another full push/targeted region push to 
-achieve the same effect as full push.
+achieve the same effect as full push in terms of data integrity, but the store versions across different regions might be 
+not the same depending on the exact setup.
 
 ## Usage
 The Push Job is designed to require as few configs as possible. The following mandatory configs should be unique to each

--- a/docs/user_guide/write_api/push_job.md
+++ b/docs/user_guide/write_api/push_job.md
@@ -31,9 +31,10 @@ Hybrid.
 Technically, targeted region push is an option of full push _(hence not a new mode)_, but it allows writing data into a 
 subset of global regions/data centers, whereas full push writes globally at once.
 
-Please note that this functionality is still under active development. It doesn't push data to the rest of unspecified regions
-automatically yet. Users may perform validations and chain it with another full push/targeted region push to achieve the
-same effect as full push.
+By default, it automatically pushes data to the rest of unspecified regions after the targeted region push is completed.
+We are working on to implement more validations in between to ensure the targeted regions are healthy after the first push. 
+Users may turn off this automation and perform validations and chain it with another full push/targeted region push to 
+achieve the same effect as full push.
 
 ## Usage
 The Push Job is designed to require as few configs as possible. The following mandatory configs should be unique to each
@@ -65,6 +66,8 @@ The user may choose to specify the following configs:
 - `targeted.region.push.list`: This config takes effect only when targeted region push flag is enabled. 
   Optionally specify a list of target region(s) to push data into. See full details at 
   [TARGETED_REGION_PUSH_LIST](https://venicedb.org/javadoc/com/linkedin/venice/hadoop/VenicePushJob.html#TARGETED_REGION_PUSH_LIST).
+- `post.validation.consumption`: Whether to perform post validation consumption after targeted region push is finished. 
+   Default: `true`.
 
 The push job also supports using D2 URLs for automated controller service discovery. To use this, the user or operator
 must specify the following configs:

--- a/docs/user_guide/write_api/push_job.md
+++ b/docs/user_guide/write_api/push_job.md
@@ -68,7 +68,7 @@ The user may choose to specify the following configs:
   Optionally specify a list of target region(s) to push data into. See full details at 
   [TARGETED_REGION_PUSH_LIST](https://venicedb.org/javadoc/com/linkedin/venice/hadoop/VenicePushJob.html#TARGETED_REGION_PUSH_LIST).
 - `post.validation.consumption`: Whether to perform post validation consumption after targeted region push is finished. 
-   Default: `true`.
+   Default: `true`. Set this to `false` if you want to achieve a true single colo push.
 
 The push job also supports using D2 URLs for automated controller service discovery. To use this, the user or operator
 must specify the following configs:

--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/VersionCreationResponse.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/VersionCreationResponse.java
@@ -27,6 +27,8 @@ public class VersionCreationResponse extends VersionResponse {
 
   private boolean daVinciPushStatusStoreEnabled = false;
 
+  private String kafkaSourceRegion = null;
+
   public void setPartitions(int partitions) {
     this.partitions = partitions;
   }
@@ -43,6 +45,10 @@ public class VersionCreationResponse extends VersionResponse {
     this.kafkaBootstrapServers = kafkaBootstrapServers;
   }
 
+  public void setKafkaSourceRegion(String kafkaSourceRegion) {
+    this.kafkaSourceRegion = kafkaSourceRegion;
+  }
+
   public int getPartitions() {
     return partitions;
   }
@@ -57,6 +63,10 @@ public class VersionCreationResponse extends VersionResponse {
 
   public String getKafkaBootstrapServers() {
     return kafkaBootstrapServers;
+  }
+
+  public String getKafkaSourceRegion() {
+    return kafkaSourceRegion;
   }
 
   public boolean isEnableSSL() {
@@ -110,10 +120,10 @@ public class VersionCreationResponse extends VersionResponse {
   @JsonIgnore
   public String toString() {
     return VersionCreationResponse.class.getSimpleName() + "(partitions: " + partitions + ", replicas: " + replicas
-        + ", kafkaTopic: " + kafkaTopic + ", kafkaBootstrapServers: " + kafkaBootstrapServers + ", enableSSL: "
-        + enableSSL + ", compressionStrategy: " + compressionStrategy.toString() + ", partitionerClass: "
-        + partitionerClass + ", partitionerParams: " + partitionerParams + ", amplificationFactor: "
-        + amplificationFactor + ", daVinciPushStatusStoreEnabled: " + daVinciPushStatusStoreEnabled + ", super: "
-        + super.toString() + ")";
+        + ", kafkaTopic: " + kafkaTopic + ", kafkaBootstrapServers: " + kafkaBootstrapServers + ", kafkaSourceRegion: "
+        + kafkaSourceRegion + ", enableSSL: " + enableSSL + ", compressionStrategy: " + compressionStrategy.toString()
+        + ", partitionerClass: " + partitionerClass + ", partitionerParams: " + partitionerParams
+        + ", amplificationFactor: " + amplificationFactor + ", daVinciPushStatusStoreEnabled: "
+        + daVinciPushStatusStoreEnabled + ", super: " + super.toString() + ")";
   }
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/utils/RegionUtils.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/utils/RegionUtils.java
@@ -59,4 +59,14 @@ public class RegionUtils {
     }
     return Stream.of(regionsFilterList.trim().split(REGION_FILTER_LIST_SEPARATOR)).collect(Collectors.toSet());
   }
+
+  /**
+   * A helper function to compose a region list with {@link #REGION_FILTER_LIST_SEPARATOR}.
+   * This is the reverse of {@link #parseRegionsFilterList(String)}.
+   * @param regions, a set of regions
+   * @return a string of regions separated by {@link #REGION_FILTER_LIST_SEPARATOR}
+   */
+  public static String composeRegionList(Set<String> regions) {
+    return String.join(",", regions);
+  }
 }

--- a/internal/venice-common/src/test/java/com/linkedin/venice/utils/TestRegionUtils.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/utils/TestRegionUtils.java
@@ -44,6 +44,7 @@ public class TestRegionUtils {
     Set<String> regionName = RegionUtils.parseRegionsFilterList(single);
     Assert.assertTrue(regionName.contains(TEST_DC_1));
     Assert.assertEquals(regionName.size(), 1);
+    Assert.assertEquals(RegionUtils.composeRegionList(regionName), single);
 
     String multiple = "dc-0,dc-1";
     regionName = RegionUtils.parseRegionsFilterList(multiple);

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestPushJobWithNativeReplication.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestPushJobWithNativeReplication.java
@@ -16,6 +16,7 @@ import static com.linkedin.venice.hadoop.VenicePushJob.INPUT_PATH_PROP;
 import static com.linkedin.venice.hadoop.VenicePushJob.KAFKA_INPUT_BROKER_URL;
 import static com.linkedin.venice.hadoop.VenicePushJob.KAFKA_INPUT_MAX_RECORDS_PER_MAPPER;
 import static com.linkedin.venice.hadoop.VenicePushJob.KAFKA_INPUT_TOPIC;
+import static com.linkedin.venice.hadoop.VenicePushJob.POST_VALIDATION_CONSUMPTION_ENABLED;
 import static com.linkedin.venice.hadoop.VenicePushJob.SEND_CONTROL_MESSAGES_DIRECTLY;
 import static com.linkedin.venice.hadoop.VenicePushJob.SOURCE_KAFKA;
 import static com.linkedin.venice.hadoop.VenicePushJob.TARGETED_REGION_PUSH_ENABLED;
@@ -35,6 +36,7 @@ import static com.linkedin.venice.samza.VeniceSystemFactory.VENICE_STORE;
 import static com.linkedin.venice.utils.IntegrationTestPushUtils.createStoreForJob;
 import static com.linkedin.venice.utils.IntegrationTestPushUtils.sendStreamingRecord;
 import static com.linkedin.venice.utils.TestUtils.assertCommand;
+import static com.linkedin.venice.utils.TestWriteUtils.DEFAULT_USER_DATA_VALUE_PREFIX;
 import static com.linkedin.venice.utils.TestWriteUtils.STRING_SCHEMA;
 import static com.linkedin.venice.utils.TestWriteUtils.getTempDataDirectory;
 import static com.linkedin.venice.utils.TestWriteUtils.writeSimpleAvroFileWithUserSchema;
@@ -47,6 +49,7 @@ import com.linkedin.venice.client.store.AvroGenericStoreClient;
 import com.linkedin.venice.client.store.ClientConfig;
 import com.linkedin.venice.client.store.ClientFactory;
 import com.linkedin.venice.common.VeniceSystemStoreType;
+import com.linkedin.venice.common.VeniceSystemStoreUtils;
 import com.linkedin.venice.controllerapi.ControllerClient;
 import com.linkedin.venice.controllerapi.NewStoreResponse;
 import com.linkedin.venice.controllerapi.StoreResponse;
@@ -875,14 +878,94 @@ public class TestPushJobWithNativeReplication {
         updateStoreQueryParams -> updateStoreQueryParams.setPartitionCount(1),
         100,
         (parentControllerClient, clusterName, storeName, props, inputDir) -> {
-          // start a regular push job
+          // start a targeted region push which should only increase the version to 1 in dc-0
+          props.put(TARGETED_REGION_PUSH_ENABLED, true);
+          props.put(POST_VALIDATION_CONSUMPTION_ENABLED, false);
           try (VenicePushJob job = new VenicePushJob("Test push job 1", props)) {
-            job.run();
-            // Verify the kafka URL being returned to the push job is the same as dc-0 kafka url.
-            Assert.assertEquals(job.getKafkaUrl(), childDatacenters.get(0).getKafkaBrokerWrapper().getAddress());
+            job.run(); // the job should succeed
+
+            TestUtils.waitForNonDeterministicAssertion(45, TimeUnit.SECONDS, () -> {
+              Map<String, Integer> coloVersions =
+                  parentControllerClient.getStore(storeName).getStore().getColoToCurrentVersions();
+
+              coloVersions.forEach((colo, version) -> {
+                if (colo.equals(DEFAULT_NATIVE_REPLICATION_SOURCE)) {
+                  Assert.assertEquals((int) version, 1);
+                } else {
+                  Assert.assertEquals((int) version, 0);
+                }
+              });
+            });
+          }
+
+          // specify two regions, so both dc-0 and dc-1 is updated to version 2
+          props.setProperty(TARGETED_REGION_PUSH_LIST, "dc-0, dc-1");
+          try (VenicePushJob job = new VenicePushJob("Test push job 2", props)) {
+            job.run(); // the job should succeed
 
             TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, () -> {
               // Current version should become 1 at both 2 data centers
+              for (int version: parentControllerClient.getStore(storeName)
+                  .getStore()
+                  .getColoToCurrentVersions()
+                  .values()) {
+                Assert.assertEquals(version, 2);
+              }
+            });
+          }
+
+          // emergency source is dc-0 so dc-1 isn't selected to be the source fabric but the push should still complete
+          props.setProperty(TARGETED_REGION_PUSH_LIST, "dc-1");
+          try (VenicePushJob job = new VenicePushJob("Test push job 3", props)) {
+            job.run(); // the job should succeed
+
+            TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, () -> {
+              Map<String, Integer> coloVersions =
+                  parentControllerClient.getStore(storeName).getStore().getColoToCurrentVersions();
+
+              coloVersions.forEach((colo, version) -> {
+                if (colo.equals("dc-1")) {
+                  Assert.assertEquals((int) version, 3);
+                } else {
+                  Assert.assertEquals((int) version, 2);
+                }
+              });
+            });
+          }
+        });
+  }
+
+  @Test(timeOut = TEST_TIMEOUT * 2)
+  public void testTargetedRegionPushJobFullConsumptionForBatchStore() throws Exception {
+    // make sure the participant store is up and running in dest region otherwise the test will be flaky
+    // the participant store is needed for data recovery
+    String destClusterName = CLUSTER_NAMES[0];
+
+    try (ControllerClient controllerClient =
+        new ControllerClient(destClusterName, childDatacenters.get(1).getControllerConnectString())) {
+      // Verify the participant store is up and running in dest region.
+      // Participant store is needed for checking kill record existence and dest region readiness for data recovery.
+      String participantStoreName = VeniceSystemStoreUtils.getParticipantStoreNameForCluster(destClusterName);
+      TestUtils.waitForNonDeterministicPushCompletion(
+          Version.composeKafkaTopic(participantStoreName, 1),
+          controllerClient,
+          100,
+          TimeUnit.MINUTES);
+    }
+
+    motherOfAllTests(
+        "testTargetedRegionPushJobBatchStore",
+        updateStoreQueryParams -> updateStoreQueryParams.setPartitionCount(1),
+        100,
+        (parentControllerClient, clusterName, storeName, props, inputDir) -> {
+          props.put(TARGETED_REGION_PUSH_ENABLED, true);
+          // no need to set but add here for clarity
+          props.put(POST_VALIDATION_CONSUMPTION_ENABLED, true);
+          try (VenicePushJob job = new VenicePushJob("Test push job 1", props)) {
+            job.run(); // the job should succeed
+
+            TestUtils.waitForNonDeterministicAssertion(45, TimeUnit.SECONDS, () -> {
+              // Current version should become 1
               for (int version: parentControllerClient.getStore(storeName)
                   .getStore()
                   .getColoToCurrentVersions()
@@ -892,58 +975,46 @@ public class TestPushJobWithNativeReplication {
             });
           }
 
-          // start a targeted region push which should only increase the version to 2 in dc-0
-          props.put(TARGETED_REGION_PUSH_ENABLED, true);
-          try (VenicePushJob job = new VenicePushJob("Test push job 2", props)) {
-            job.run(); // the job should succeed
-
-            TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, () -> {
-              Map<String, Integer> coloVersions =
-                  parentControllerClient.getStore(storeName).getStore().getColoToCurrentVersions();
-
-              coloVersions.forEach((colo, version) -> {
-                if (colo.equals(DEFAULT_NATIVE_REPLICATION_SOURCE)) {
-                  Assert.assertEquals((int) version, 2);
-                } else {
-                  Assert.assertEquals((int) version, 1);
-                }
-              });
-            });
+          // verify the reads for both DCs
+          for (int dataCenterIndex = 0; dataCenterIndex < NUMBER_OF_CHILD_DATACENTERS; dataCenterIndex++) {
+            String routerUrl =
+                childDatacenters.get(dataCenterIndex).getClusters().get(clusterName).getRandomRouterURL();
+            verifyVeniceStoreData(storeName, routerUrl, DEFAULT_USER_DATA_VALUE_PREFIX, 10);
           }
+        });
+  }
 
-          // specify two regions, so both dc-0 and dc-1 is updated to version 3
-          props.setProperty(TARGETED_REGION_PUSH_LIST, "dc-0, dc-1");
-          try (VenicePushJob job = new VenicePushJob("Test push job 3", props)) {
+  @Test(timeOut = TEST_TIMEOUT * 2)
+  public void testTargetedRegionPushJobFullConsumptionForHybridStore() throws Exception {
+    motherOfAllTests(
+        "testTargetedRegionPushJobHybridStorse",
+        updateStoreQueryParams -> updateStoreQueryParams.setPartitionCount(1)
+            .setHybridRewindSeconds(10)
+            .setHybridOffsetLagThreshold(2),
+        100,
+        (parentControllerClient, clusterName, storeName, props, inputDir) -> {
+          props.put(TARGETED_REGION_PUSH_ENABLED, true);
+          // no need to set but add here for clarity
+          props.put(POST_VALIDATION_CONSUMPTION_ENABLED, true);
+          try (VenicePushJob job = new VenicePushJob("Test push job 1", props)) {
             job.run(); // the job should succeed
 
-            TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, () -> {
-              // Current version should become 1 at both 2 data centers
+            TestUtils.waitForNonDeterministicAssertion(45, TimeUnit.SECONDS, () -> {
+              // Current version should become 2
               for (int version: parentControllerClient.getStore(storeName)
                   .getStore()
                   .getColoToCurrentVersions()
                   .values()) {
-                Assert.assertEquals(version, 3);
+                Assert.assertEquals(version, 2);
               }
             });
           }
 
-          // emergency source is dc-0 so dc-1 isn't selected to be the source fabric but the push should still complete
-          props.setProperty(TARGETED_REGION_PUSH_LIST, "dc-1");
-          try (VenicePushJob job = new VenicePushJob("Test push job 4", props)) {
-            job.run(); // the job should succeed
-
-            TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, () -> {
-              Map<String, Integer> coloVersions =
-                  parentControllerClient.getStore(storeName).getStore().getColoToCurrentVersions();
-
-              coloVersions.forEach((colo, version) -> {
-                if (colo.equals("dc-1")) {
-                  Assert.assertEquals((int) version, 4);
-                } else {
-                  Assert.assertEquals((int) version, 3);
-                }
-              });
-            });
+          // verify the reads for both DCs
+          for (int dataCenterIndex = 0; dataCenterIndex < NUMBER_OF_CHILD_DATACENTERS; dataCenterIndex++) {
+            String routerUrl =
+                childDatacenters.get(dataCenterIndex).getClusters().get(clusterName).getRandomRouterURL();
+            verifyVeniceStoreData(storeName, routerUrl, DEFAULT_USER_DATA_VALUE_PREFIX, 10);
           }
         });
   }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestPushJobWithNativeReplication.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestPushJobWithNativeReplication.java
@@ -36,7 +36,6 @@ import static com.linkedin.venice.samza.VeniceSystemFactory.VENICE_STORE;
 import static com.linkedin.venice.utils.IntegrationTestPushUtils.createStoreForJob;
 import static com.linkedin.venice.utils.IntegrationTestPushUtils.sendStreamingRecord;
 import static com.linkedin.venice.utils.TestUtils.assertCommand;
-import static com.linkedin.venice.utils.TestWriteUtils.DEFAULT_USER_DATA_VALUE_PREFIX;
 import static com.linkedin.venice.utils.TestWriteUtils.STRING_SCHEMA;
 import static com.linkedin.venice.utils.TestWriteUtils.getTempDataDirectory;
 import static com.linkedin.venice.utils.TestWriteUtils.writeSimpleAvroFileWithUserSchema;
@@ -974,20 +973,13 @@ public class TestPushJobWithNativeReplication {
               }
             });
           }
-
-          // verify the reads for both DCs
-          for (int dataCenterIndex = 0; dataCenterIndex < NUMBER_OF_CHILD_DATACENTERS; dataCenterIndex++) {
-            String routerUrl =
-                childDatacenters.get(dataCenterIndex).getClusters().get(clusterName).getRandomRouterURL();
-            verifyVeniceStoreData(storeName, routerUrl, DEFAULT_USER_DATA_VALUE_PREFIX, 10);
-          }
         });
   }
 
   @Test(timeOut = TEST_TIMEOUT * 2)
   public void testTargetedRegionPushJobFullConsumptionForHybridStore() throws Exception {
     motherOfAllTests(
-        "testTargetedRegionPushJobHybridStorse",
+        "testTargetedRegionPushJobHybridStore",
         updateStoreQueryParams -> updateStoreQueryParams.setPartitionCount(1)
             .setHybridRewindSeconds(10)
             .setHybridOffsetLagThreshold(2),
@@ -1008,13 +1000,6 @@ public class TestPushJobWithNativeReplication {
                 Assert.assertEquals(version, 2);
               }
             });
-          }
-
-          // verify the reads for both DCs
-          for (int dataCenterIndex = 0; dataCenterIndex < NUMBER_OF_CHILD_DATACENTERS; dataCenterIndex++) {
-            String routerUrl =
-                childDatacenters.get(dataCenterIndex).getClusters().get(clusterName).getRandomRouterURL();
-            verifyVeniceStoreData(storeName, routerUrl, DEFAULT_USER_DATA_VALUE_PREFIX, 10);
           }
         });
   }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/Admin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/Admin.java
@@ -460,6 +460,12 @@ public interface Admin extends AutoCloseable, Closeable {
    */
   String getKafkaBootstrapServers(boolean isSSL);
 
+  /**
+   * Return the region name of this Admin
+   * @return the region name of this controller
+   */
+  String getRegionName();
+
   String getNativeReplicationKafkaBootstrapServerAddress(String sourceFabric);
 
   String getNativeReplicationSourceFabric(

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -5660,6 +5660,11 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
     }
   }
 
+  @Override
+  public String getRegionName() {
+    return multiClusterConfigs.getRegionName();
+  }
+
   /**
    * @return KafkaUrl for the given fabric.
    * @see ConfigKeys#CHILD_DATA_CENTER_KAFKA_URL_PREFIX

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
@@ -1600,9 +1600,7 @@ public class VeniceParentHelixAdmin implements Admin {
     if (pushType.isIncremental()) {
       newVersion = getVeniceHelixAdmin().getIncrementalPushVersion(clusterName, storeName);
     } else {
-      if (StringUtils.isNotEmpty(targetedRegions)) {
-        validateTargetedRegions(targetedRegions, clusterName);
-      }
+      validateTargetedRegions(targetedRegions, clusterName);
 
       newVersion = addVersionAndTopicOnly(
           clusterName,
@@ -1643,6 +1641,9 @@ public class VeniceParentHelixAdmin implements Admin {
    * @param clusterName
    */
   private void validateTargetedRegions(String targetedRegions, String clusterName) throws VeniceException {
+    if (StringUtils.isEmpty(targetedRegions)) {
+      return;
+    }
     Set<String> targetedRegionSet = RegionUtils.parseRegionsFilterList(targetedRegions);
     Map<String, ControllerClient> clientMap = getVeniceHelixAdmin().getControllerClientMap(clusterName);
     for (String region: targetedRegionSet) {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
@@ -1600,7 +1600,9 @@ public class VeniceParentHelixAdmin implements Admin {
     if (pushType.isIncremental()) {
       newVersion = getVeniceHelixAdmin().getIncrementalPushVersion(clusterName, storeName);
     } else {
-      validateTargetedRegions(targetedRegions, clusterName);
+      if (StringUtils.isNotEmpty(targetedRegions)) {
+        validateTargetedRegions(targetedRegions, clusterName);
+      }
 
       newVersion = addVersionAndTopicOnly(
           clusterName,
@@ -3580,6 +3582,11 @@ public class VeniceParentHelixAdmin implements Admin {
   @Override
   public String getKafkaBootstrapServers(boolean isSSL) {
     return getVeniceHelixAdmin().getKafkaBootstrapServers(isSSL);
+  }
+
+  @Override
+  public String getRegionName() {
+    return getVeniceHelixAdmin().getRegionName();
   }
 
   /**

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/datarecovery/DataRecoveryManager.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/datarecovery/DataRecoveryManager.java
@@ -192,7 +192,7 @@ public class DataRecoveryManager implements Closeable {
         throw new VeniceException("Previous kill record for " + versionTopic + " still exists");
       }
     } catch (Exception e) {
-      throw new VeniceException("Unable to check if the store version kill record is null", e);
+      throw new VeniceException(e);
     }
   }
 

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/CreateVersion.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/CreateVersion.java
@@ -171,6 +171,7 @@ public class CreateVersion extends AbstractRoute {
 
         boolean isSSL = admin.isSSLEnabledForPush(clusterName, storeName);
         responseObject.setKafkaBootstrapServers(admin.getKafkaBootstrapServers(isSSL));
+        responseObject.setKafkaSourceRegion(admin.getRegionName());
         responseObject.setEnableSSL(isSSL);
 
         String pushJobId = request.queryParams(PUSH_JOB_ID);
@@ -292,6 +293,9 @@ public class CreateVersion extends AbstractRoute {
               responseObject.setPartitions(version.getPartitionCount());
             }
             String responseTopic;
+            /**
+             * Override the source fabric to respect the native replication source fabric selection.
+             */
             boolean overrideSourceFabric = true;
             boolean isTopicRT = false;
             if (pushType.isStreamReprocessing()) {
@@ -326,6 +330,7 @@ public class CreateVersion extends AbstractRoute {
               if (childDataCenterKafkaBootstrapServer != null) {
                 responseObject.setKafkaBootstrapServers(childDataCenterKafkaBootstrapServer);
               }
+              responseObject.setKafkaSourceRegion(version.getNativeReplicationSourceFabric());
             }
 
             if (pushType.isIncremental() && admin.isParent()) {

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/CreateVersionTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/CreateVersionTest.java
@@ -244,6 +244,7 @@ public class CreateVersionTest {
     Version version = new VersionImpl(STORE_NAME, 1, JOB_ID);
     Optional<String> emergencySrcRegion = Optional.of("dc-1");
 
+    doReturn("dc-0").when(admin).getRegionName();
     doReturn(true).when(admin).whetherEnableBatchPushFromAdmin(STORE_NAME);
     doReturn(true).when(admin).isParent();
     doReturn(true).when(admin).isActiveActiveReplicationEnabledInAllRegion(any(), any(), anyBoolean());
@@ -283,6 +284,7 @@ public class CreateVersionTest {
     VersionCreationResponse versionCreationResponse =
         OBJECT_MAPPER.readValue(result.toString(), VersionCreationResponse.class);
     assertEquals(versionCreationResponse.getKafkaBootstrapServers(), "dc-1.region.io");
+    assertEquals(versionCreationResponse.getKafkaSourceRegion(), "dc-0");
   }
 
   private Store getHybridTestStore() {


### PR DESCRIPTION

<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Summary
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

This commit completes the targeted region push feature by adding the functionality of automatically pushing data to the rest of regions when targeted region push is used. User can turn off this config so they can chain the targeted region push as they want.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

newly added unit tests and integ tests.

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [x] Yes. Make sure to explain your proposed changes and call out the behavior change.
 See the newly added doc for this.