### PR TITLE
[controller] Return proper ErrorType in getFutureVersion API when Store doesn't exist

### DIFF
--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/server/TestAdminSparkServer.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/server/TestAdminSparkServer.java
@@ -592,14 +592,14 @@ public class TestAdminSparkServer extends AbstractTestAdminSparkServer {
   @Test(timeOut = TEST_TIMEOUT)
   public void controllerClientCanListFutureStoreVersions() {
     List<String> storeNames = new ArrayList<>();
-    storeNames.add(cluster.getNewStore("testStore").getName());
     try {
       ControllerClient parentControllerClient = ControllerClient
           .constructClusterControllerClient(cluster.getClusterName(), parentController.getControllerUrl());
+      storeNames.add(parentControllerClient.createNewStore("testStore", "owner", "\"string\"", "\"string\"").getName());
       MultiStoreStatusResponse storeResponse =
           parentControllerClient.getFutureVersions(cluster.getClusterName(), storeNames.get(0));
 
-      // Theres no version for this store and no future version coming, so we expect an entry with
+      // There's no version for this store and no future version coming, so we expect an entry with
       // Store.NON_EXISTING_VERSION
       Assert.assertTrue(storeResponse.getStoreStatusMap().containsKey("dc-0"));
       Assert.assertEquals(storeResponse.getStoreStatusMap().get("dc-0"), String.valueOf(Store.NON_EXISTING_VERSION));

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/StoresRoutes.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/StoresRoutes.java
@@ -323,6 +323,10 @@ public class StoresRoutes extends AbstractRoute {
         String clusterName = request.queryParams(CLUSTER);
         String storeName = request.queryParams(NAME);
         veniceResponse.setCluster(clusterName);
+        Store store = admin.getStore(clusterName, storeName);
+        if (store == null) {
+          throw new VeniceNoStoreException(storeName);
+        }
         Map<String, String> storeStatusMap = admin.getFutureVersionsForMultiColos(clusterName, storeName);
         if (storeStatusMap.isEmpty()) {
           // Non parent controllers will return an empty map, so we'll just return the childs version of this api

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/StoreRoutesTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/StoreRoutesTest.java
@@ -1,0 +1,146 @@
+package com.linkedin.venice.controller.server;
+
+import static com.linkedin.venice.exceptions.ErrorType.INCORRECT_CONTROLLER;
+import static com.linkedin.venice.exceptions.ErrorType.STORE_NOT_FOUND;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+import com.linkedin.venice.controller.Admin;
+import com.linkedin.venice.controller.VeniceHelixAdmin;
+import com.linkedin.venice.controller.VeniceParentHelixAdmin;
+import com.linkedin.venice.controllerapi.ControllerApiConstants;
+import com.linkedin.venice.controllerapi.MultiStoreStatusResponse;
+import com.linkedin.venice.meta.Store;
+import com.linkedin.venice.pubsub.PubSubTopicRepository;
+import com.linkedin.venice.utils.ObjectMapperFactory;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import spark.QueryParamsMap;
+import spark.Request;
+import spark.Response;
+import spark.Route;
+
+
+public class StoreRoutesTest {
+  private static final String TEST_CLUSTER = "test_cluster";
+  private static final String TEST_STORE_NAME = "test_store";
+
+  private final PubSubTopicRepository pubSubTopicRepository = new PubSubTopicRepository();
+
+  @Test
+  public void testGetFutureVersion() throws Exception {
+    Admin mockAdmin = mock(VeniceParentHelixAdmin.class);
+    doReturn(true).when(mockAdmin).isLeaderControllerFor(TEST_CLUSTER);
+
+    Store mockStore = mock(Store.class);
+    doReturn(mockStore).when(mockAdmin).getStore(TEST_CLUSTER, TEST_STORE_NAME);
+
+    Map<String, String> storeStatusMap = Collections.singletonMap("dc-0", "1");
+    doReturn(storeStatusMap).when(mockAdmin).getFutureVersionsForMultiColos(TEST_CLUSTER, TEST_STORE_NAME);
+
+    Request request = mock(Request.class);
+    doReturn(TEST_CLUSTER).when(request).queryParams(eq(ControllerApiConstants.CLUSTER));
+    doReturn(TEST_STORE_NAME).when(request).queryParams(eq(ControllerApiConstants.NAME));
+
+    Route getFutureVersionRoute =
+        new StoresRoutes(false, Optional.empty(), pubSubTopicRepository).getFutureVersion(mockAdmin);
+    MultiStoreStatusResponse multiStoreStatusResponse = ObjectMapperFactory.getInstance()
+        .readValue(
+            getFutureVersionRoute.handle(request, mock(Response.class)).toString(),
+            MultiStoreStatusResponse.class);
+    Assert.assertEquals(multiStoreStatusResponse.getCluster(), TEST_CLUSTER);
+    Assert.assertEquals(multiStoreStatusResponse.getStoreStatusMap(), storeStatusMap);
+  }
+
+  @Test
+  public void testGetFutureVersionForChildController() throws Exception {
+    Admin mockAdmin = mock(VeniceHelixAdmin.class);
+    doReturn(true).when(mockAdmin).isLeaderControllerFor(TEST_CLUSTER);
+
+    Store mockStore = mock(Store.class);
+    doReturn(mockStore).when(mockAdmin).getStore(TEST_CLUSTER, TEST_STORE_NAME);
+
+    doCallRealMethod().when(mockAdmin).getFutureVersionsForMultiColos(TEST_CLUSTER, TEST_STORE_NAME);
+    doReturn(1).when(mockAdmin).getFutureVersion(TEST_CLUSTER, TEST_STORE_NAME);
+
+    Request request = mock(Request.class);
+    doReturn(TEST_CLUSTER).when(request).queryParams(eq(ControllerApiConstants.CLUSTER));
+    doReturn(TEST_STORE_NAME).when(request).queryParams(eq(ControllerApiConstants.NAME));
+
+    Route getFutureVersionRoute =
+        new StoresRoutes(false, Optional.empty(), pubSubTopicRepository).getFutureVersion(mockAdmin);
+    MultiStoreStatusResponse multiStoreStatusResponse = ObjectMapperFactory.getInstance()
+        .readValue(
+            getFutureVersionRoute.handle(request, mock(Response.class)).toString(),
+            MultiStoreStatusResponse.class);
+    Assert.assertEquals(multiStoreStatusResponse.getCluster(), TEST_CLUSTER);
+    Assert.assertEquals(multiStoreStatusResponse.getStoreStatusMap(), Collections.singletonMap(TEST_STORE_NAME, "1"));
+  }
+
+  @Test
+  public void testGetFutureVersionWhenNotLeaderController() throws Exception {
+    Admin mockAdmin = mock(VeniceParentHelixAdmin.class);
+    doReturn(false).when(mockAdmin).isLeaderControllerFor(TEST_CLUSTER);
+
+    Store mockStore = mock(Store.class);
+    doReturn(mockStore).when(mockAdmin).getStore(TEST_CLUSTER, TEST_STORE_NAME);
+
+    Request request = mock(Request.class);
+    doReturn(TEST_CLUSTER).when(request).queryParams(eq(ControllerApiConstants.CLUSTER));
+    doReturn(TEST_STORE_NAME).when(request).queryParams(eq(ControllerApiConstants.NAME));
+
+    QueryParamsMap queryParamsMap = mock(QueryParamsMap.class);
+
+    Map<String, String[]> queryMap = new HashMap<>(2);
+    queryMap.put(ControllerApiConstants.CLUSTER, new String[] { TEST_CLUSTER });
+    queryMap.put(ControllerApiConstants.NAME, new String[] { TEST_STORE_NAME });
+
+    doReturn(queryMap).when(queryParamsMap).toMap();
+    doReturn(queryParamsMap).when(request).queryMap();
+
+    Route getFutureVersionRoute =
+        new StoresRoutes(false, Optional.empty(), pubSubTopicRepository).getFutureVersion(mockAdmin);
+    MultiStoreStatusResponse multiStoreStatusResponse = ObjectMapperFactory.getInstance()
+        .readValue(
+            getFutureVersionRoute.handle(request, mock(Response.class)).toString(),
+            MultiStoreStatusResponse.class);
+    Assert.assertTrue(multiStoreStatusResponse.isError());
+    Assert.assertEquals(multiStoreStatusResponse.getErrorType(), INCORRECT_CONTROLLER);
+  }
+
+  @Test
+  public void testGetFutureVersionWhenStoreNotExist() throws Exception {
+    Admin mockAdmin = mock(VeniceParentHelixAdmin.class);
+    doReturn(true).when(mockAdmin).isLeaderControllerFor(TEST_CLUSTER);
+
+    doReturn(null).when(mockAdmin).getStore(TEST_CLUSTER, TEST_STORE_NAME);
+
+    Request request = mock(Request.class);
+    doReturn(TEST_CLUSTER).when(request).queryParams(eq(ControllerApiConstants.CLUSTER));
+    doReturn(TEST_STORE_NAME).when(request).queryParams(eq(ControllerApiConstants.NAME));
+
+    QueryParamsMap queryParamsMap = mock(QueryParamsMap.class);
+
+    Map<String, String[]> queryMap = new HashMap<>(2);
+    queryMap.put(ControllerApiConstants.CLUSTER, new String[] { TEST_CLUSTER });
+    queryMap.put(ControllerApiConstants.NAME, new String[] { TEST_STORE_NAME });
+
+    doReturn(queryMap).when(queryParamsMap).toMap();
+    doReturn(queryParamsMap).when(request).queryMap();
+
+    Route getFutureVersionRoute =
+        new StoresRoutes(false, Optional.empty(), pubSubTopicRepository).getFutureVersion(mockAdmin);
+    MultiStoreStatusResponse multiStoreStatusResponse = ObjectMapperFactory.getInstance()
+        .readValue(
+            getFutureVersionRoute.handle(request, mock(Response.class)).toString(),
+            MultiStoreStatusResponse.class);
+    Assert.assertTrue(multiStoreStatusResponse.isError());
+    Assert.assertEquals(multiStoreStatusResponse.getErrorType(), STORE_NOT_FOUND);
+  }
+}


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Return proper `ErrorType` in `getFutureVersion` API when Store doesn't exist
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
When a store doesn't exist, the `list_future_versions` API on controllers returns a map with 0 as the future version. This commit changes the response to error with a `STORE_NOT_FOUND` ErrorType

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
Added unit tests

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [X] Yes. Make sure to explain your proposed changes and call out the behavior change.