### PR TITLE
[dvc][controller][server][test] Support plugging in `PubSubClientFactory` for integration test and venice components.

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/DaVinciBackend.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/DaVinciBackend.java
@@ -41,9 +41,6 @@ import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.StoreDataChangedListener;
 import com.linkedin.venice.meta.SubscriptionBasedReadOnlyStoreRepository;
 import com.linkedin.venice.meta.Version;
-import com.linkedin.venice.pubsub.adapter.kafka.admin.ApacheKafkaAdminAdapterFactory;
-import com.linkedin.venice.pubsub.adapter.kafka.consumer.ApacheKafkaConsumerAdapterFactory;
-import com.linkedin.venice.pubsub.adapter.kafka.producer.ApacheKafkaProducerAdapterFactory;
 import com.linkedin.venice.pubsub.api.PubSubClientsFactory;
 import com.linkedin.venice.pushmonitor.ExecutionStatus;
 import com.linkedin.venice.pushstatushelper.PushStatusStoreWriter;
@@ -223,9 +220,9 @@ public class DaVinciBackend implements Closeable {
           .map(objectCacheConfig -> new ObjectCacheBackend(clientConfig, objectCacheConfig, schemaRepository));
 
       PubSubClientsFactory pubSubClientsFactory = new PubSubClientsFactory(
-          new ApacheKafkaProducerAdapterFactory(),
-          new ApacheKafkaConsumerAdapterFactory(),
-          new ApacheKafkaAdminAdapterFactory());
+          configLoader.getVeniceServerConfig().getPubSubProducerAdapterFactory(),
+          configLoader.getVeniceServerConfig().getPubSubConsumerAdapterFactory(),
+          configLoader.getVeniceServerConfig().getPubSubAdminAdapterFactory());
       ingestionService = new KafkaStoreIngestionService(
           storageService.getStorageEngineRepository(),
           configLoader,

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/DaVinciBackend.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/DaVinciBackend.java
@@ -181,8 +181,9 @@ public class DaVinciBackend implements Closeable {
           true,
           functionToCheckWhetherStorageEngineShouldBeKeptOrNot(managedClients));
       storageService.start();
-
-      VeniceWriterFactory writerFactory = new VeniceWriterFactory(backendProps.toProperties());
+      PubSubClientsFactory pubSubClientsFactory = configLoader.getVeniceServerConfig().getPubSubClientsFactory();
+      VeniceWriterFactory writerFactory =
+          new VeniceWriterFactory(backendProps.toProperties(), pubSubClientsFactory.getProducerAdapterFactory(), null);
       String instanceName = Utils.getHostName() + "_" + Utils.getPid();
       int derivedSchemaID = backendProps.getInt(PUSH_STATUS_STORE_DERIVED_SCHEMA_ID, 1);
       pushStatusStoreWriter = new PushStatusStoreWriter(writerFactory, instanceName, derivedSchemaID);
@@ -219,7 +220,6 @@ public class DaVinciBackend implements Closeable {
       cacheBackend = cacheConfig
           .map(objectCacheConfig -> new ObjectCacheBackend(clientConfig, objectCacheConfig, schemaRepository));
 
-      PubSubClientsFactory pubSubClientsFactory = configLoader.getVeniceServerConfig().getPubSubClientsFactory();
       ingestionService = new KafkaStoreIngestionService(
           storageService.getStorageEngineRepository(),
           configLoader,

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/DaVinciBackend.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/DaVinciBackend.java
@@ -219,10 +219,7 @@ public class DaVinciBackend implements Closeable {
       cacheBackend = cacheConfig
           .map(objectCacheConfig -> new ObjectCacheBackend(clientConfig, objectCacheConfig, schemaRepository));
 
-      PubSubClientsFactory pubSubClientsFactory = new PubSubClientsFactory(
-          configLoader.getVeniceServerConfig().getPubSubProducerAdapterFactory(),
-          configLoader.getVeniceServerConfig().getPubSubConsumerAdapterFactory(),
-          configLoader.getVeniceServerConfig().getPubSubAdminAdapterFactory());
+      PubSubClientsFactory pubSubClientsFactory = configLoader.getVeniceServerConfig().getPubSubClientsFactory();
       ingestionService = new KafkaStoreIngestionService(
           storageService.getStorageEngineRepository(),
           configLoader,

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
@@ -121,6 +121,9 @@ import com.linkedin.venice.exceptions.ConfigurationException;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.meta.IngestionMode;
 import com.linkedin.venice.pubsub.adapter.kafka.admin.ApacheKafkaAdminAdapter;
+import com.linkedin.venice.pubsub.adapter.kafka.admin.ApacheKafkaAdminAdapterFactory;
+import com.linkedin.venice.pubsub.adapter.kafka.consumer.ApacheKafkaConsumerAdapterFactory;
+import com.linkedin.venice.pubsub.adapter.kafka.producer.ApacheKafkaProducerAdapterFactory;
 import com.linkedin.venice.pubsub.api.PubSubAdminAdapterFactory;
 import com.linkedin.venice.pubsub.api.PubSubConsumerAdapterFactory;
 import com.linkedin.venice.pubsub.api.PubSubProducerAdapterFactory;
@@ -663,19 +666,16 @@ public class VeniceServerConfig extends VeniceClusterConfig {
     this.divProducerStateMaxAgeMs =
         serverProperties.getLong(DIV_PRODUCER_STATE_MAX_AGE_MS, KafkaDataIntegrityValidator.DISABLED);
     try {
-      String producerFactoryClassName = serverProperties.getString(
-          PUB_SUB_PRODUCER_ADAPTER_FACTORY_CLASS,
-          "com.linkedin.venice.pubsub.adapter.kafka.producer.ApacheKafkaProducerAdapterFactory");
+      String producerFactoryClassName = serverProperties
+          .getString(PUB_SUB_PRODUCER_ADAPTER_FACTORY_CLASS, ApacheKafkaProducerAdapterFactory.class.getName());
       pubSubProducerAdapterFactory =
           (PubSubProducerAdapterFactory) Class.forName(producerFactoryClassName).newInstance();
-      String consumerFactoryClassName = serverProperties.getString(
-          PUB_SUB_CONSUMER_ADAPTER_FACTORY_CLASS,
-          "com.linkedin.venice.pubsub.adapter.kafka.consumer.ApacheKafkaConsumerAdapterFactory");
+      String consumerFactoryClassName = serverProperties
+          .getString(PUB_SUB_CONSUMER_ADAPTER_FACTORY_CLASS, ApacheKafkaConsumerAdapterFactory.class.getName());
       pubSubConsumerAdapterFactory =
           (PubSubConsumerAdapterFactory) Class.forName(consumerFactoryClassName).newInstance();
-      String adminFactoryClassName = serverProperties.getString(
-          PUB_SUB_ADMIN_ADAPTER_FACTORY_CLASS,
-          "com.linkedin.venice.pubsub.adapter.kafka.admin.ApacheKafkaAdminAdapterFactory");
+      String adminFactoryClassName = serverProperties
+          .getString(PUB_SUB_ADMIN_ADAPTER_FACTORY_CLASS, ApacheKafkaAdminAdapterFactory.class.getName());
       pubSubAdminAdapterFactory = (PubSubAdminAdapterFactory) Class.forName(adminFactoryClassName).newInstance();
     } catch (ClassNotFoundException | IllegalAccessException | InstantiationException e) {
       LOGGER.error("Failed to create an instance of pub sub clients factory", e);

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/helix/HelixParticipationService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/helix/HelixParticipationService.java
@@ -26,6 +26,7 @@ import com.linkedin.venice.helix.ZkClientFactory;
 import com.linkedin.venice.meta.IngestionMode;
 import com.linkedin.venice.meta.Instance;
 import com.linkedin.venice.meta.ReadOnlyStoreRepository;
+import com.linkedin.venice.pubsub.api.PubSubProducerAdapterFactory;
 import com.linkedin.venice.pushmonitor.KillOfflinePushMessage;
 import com.linkedin.venice.pushstatushelper.PushStatusStoreWriter;
 import com.linkedin.venice.service.AbstractVeniceService;
@@ -290,8 +291,12 @@ public class HelixParticipationService extends AbstractVeniceService
     zkClient = ZkClientFactory.newZkClient(zkAddress);
 
     // we use push status store for persisting incremental push statuses
-    VeniceProperties veniceProperties = veniceConfigLoader.getVeniceServerConfig().getClusterProperties();
-    VeniceWriterFactory writerFactory = new VeniceWriterFactory(veniceProperties.toProperties());
+    VeniceServerConfig veniceServerConfig = veniceConfigLoader.getVeniceServerConfig();
+    VeniceProperties veniceProperties = veniceServerConfig.getClusterProperties();
+    PubSubProducerAdapterFactory pubSubProducerAdapterFactory =
+        veniceServerConfig.getPubSubClientsFactory().getProducerAdapterFactory();
+    VeniceWriterFactory writerFactory =
+        new VeniceWriterFactory(veniceProperties.toProperties(), pubSubProducerAdapterFactory, null);
     statusStoreWriter = new PushStatusStoreWriter(
         writerFactory,
         instance.getNodeId(),

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/isolated/IsolatedIngestionServer.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/isolated/IsolatedIngestionServer.java
@@ -41,9 +41,6 @@ import com.linkedin.venice.meta.ClusterInfoProvider;
 import com.linkedin.venice.meta.ReadOnlyLiveClusterConfigRepository;
 import com.linkedin.venice.meta.ReadOnlySchemaRepository;
 import com.linkedin.venice.meta.ReadOnlyStoreRepository;
-import com.linkedin.venice.pubsub.adapter.kafka.admin.ApacheKafkaAdminAdapterFactory;
-import com.linkedin.venice.pubsub.adapter.kafka.consumer.ApacheKafkaConsumerAdapterFactory;
-import com.linkedin.venice.pubsub.adapter.kafka.producer.ApacheKafkaProducerAdapterFactory;
 import com.linkedin.venice.pubsub.api.PubSubClientsFactory;
 import com.linkedin.venice.schema.SchemaReader;
 import com.linkedin.venice.security.SSLFactory;
@@ -738,9 +735,9 @@ public class IsolatedIngestionServer extends AbstractVeniceService {
 
     boolean isDaVinciClient = veniceMetadataRepositoryBuilder.isDaVinciClient();
     PubSubClientsFactory pubSubClientsFactory = new PubSubClientsFactory(
-        new ApacheKafkaProducerAdapterFactory(),
-        new ApacheKafkaConsumerAdapterFactory(),
-        new ApacheKafkaAdminAdapterFactory());
+        configLoader.getVeniceServerConfig().getPubSubProducerAdapterFactory(),
+        configLoader.getVeniceServerConfig().getPubSubConsumerAdapterFactory(),
+        configLoader.getVeniceServerConfig().getPubSubAdminAdapterFactory());
 
     // Create KafkaStoreIngestionService
     storeIngestionService = new KafkaStoreIngestionService(

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/isolated/IsolatedIngestionServer.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/isolated/IsolatedIngestionServer.java
@@ -734,10 +734,7 @@ public class IsolatedIngestionServer extends AbstractVeniceService {
         new StorageEngineBackedCompressorFactory(storageMetadataService);
 
     boolean isDaVinciClient = veniceMetadataRepositoryBuilder.isDaVinciClient();
-    PubSubClientsFactory pubSubClientsFactory = new PubSubClientsFactory(
-        configLoader.getVeniceServerConfig().getPubSubProducerAdapterFactory(),
-        configLoader.getVeniceServerConfig().getPubSubConsumerAdapterFactory(),
-        configLoader.getVeniceServerConfig().getPubSubAdminAdapterFactory());
+    PubSubClientsFactory pubSubClientsFactory = configLoader.getVeniceServerConfig().getPubSubClientsFactory();
 
     // Create KafkaStoreIngestionService
     storeIngestionService = new KafkaStoreIngestionService(

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionService.java
@@ -66,7 +66,6 @@ import com.linkedin.venice.offsets.OffsetRecord;
 import com.linkedin.venice.pubsub.PubSubConstants;
 import com.linkedin.venice.pubsub.PubSubTopicPartitionImpl;
 import com.linkedin.venice.pubsub.PubSubTopicRepository;
-import com.linkedin.venice.pubsub.adapter.kafka.consumer.ApacheKafkaConsumerAdapterFactory;
 import com.linkedin.venice.pubsub.adapter.kafka.producer.ApacheKafkaProducerAdapterFactory;
 import com.linkedin.venice.pubsub.adapter.kafka.producer.ApacheKafkaProducerConfig;
 import com.linkedin.venice.pubsub.adapter.kafka.producer.SharedKafkaProducerAdapterFactory;
@@ -407,7 +406,7 @@ public class KafkaStoreIngestionService extends AbstractVeniceService implements
         new LandFillObjectPool<>(KafkaMessageEnvelope::new));
 
     aggKafkaConsumerService = new AggKafkaConsumerService(
-        new ApacheKafkaConsumerAdapterFactory(),
+        pubSubClientsFactory.getConsumerAdapterFactory(),
         this::getPubSubSSLPropertiesFromServerConfig,
         serverConfig,
         bandwidthThrottler,

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionService.java
@@ -265,7 +265,8 @@ public class KafkaStoreIngestionService extends AbstractVeniceService implements
 
     VeniceWriterFactory veniceWriterFactory =
         new VeniceWriterFactory(veniceWriterProperties, producerAdapterFactory, metricsRepository);
-    VeniceWriterFactory veniceWriterFactoryForMetaStoreWriter = new VeniceWriterFactory(veniceWriterProperties);
+    VeniceWriterFactory veniceWriterFactoryForMetaStoreWriter =
+        new VeniceWriterFactory(veniceWriterProperties, producerAdapterFactory, null);
 
     EventThrottler bandwidthThrottler = new EventThrottler(
         serverConfig.getKafkaFetchQuotaBytesPerSecond(),

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionService.java
@@ -310,7 +310,7 @@ public class KafkaStoreIngestionService extends AbstractVeniceService implements
         .setPubSubTopicRepository(pubSubTopicRepository)
         .setMetricsRepository(metricsRepository)
         .setLocalKafkaBootstrapServers(serverConfig.getKafkaBootstrapServers())
-        .setPubSubConsumerAdapterFactory(new ApacheKafkaConsumerAdapterFactory())
+        .setPubSubConsumerAdapterFactory(pubSubClientsFactory.getConsumerAdapterFactory())
         .setTopicDeletionStatusPollIntervalMs(DEFAULT_TOPIC_DELETION_STATUS_POLL_INTERVAL_MS)
         .setTopicMinLogCompactionLagMs(DEFAULT_KAFKA_MIN_LOG_COMPACTION_LAG_MS)
         .setKafkaOperationTimeoutMs(DEFAULT_KAFKA_OPERATION_TIMEOUT_MS)

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/view/ChangeCaptureViewWriter.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/view/ChangeCaptureViewWriter.java
@@ -15,6 +15,7 @@ import com.linkedin.venice.meta.PartitionerConfig;
 import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.partitioner.VenicePartitioner;
+import com.linkedin.venice.pubsub.api.PubSubProducerAdapterFactory;
 import com.linkedin.venice.schema.rmd.RmdUtils;
 import com.linkedin.venice.serialization.VeniceKafkaSerializer;
 import com.linkedin.venice.serialization.avro.VeniceAvroKafkaSerializer;
@@ -42,8 +43,9 @@ public class ChangeCaptureViewWriter extends VeniceViewWriter {
   final private ChangeCaptureView internalView;
   private VeniceWriter veniceWriter;
   private final Object2IntMap<String> kafkaClusterUrlToIdMap;
-
   private final int maxColoIdValue;
+
+  private final PubSubProducerAdapterFactory pubSubProducerAdapterFactory;
 
   public ChangeCaptureViewWriter(
       VeniceConfigLoader props,
@@ -53,7 +55,9 @@ public class ChangeCaptureViewWriter extends VeniceViewWriter {
     super(props, store, keySchema, extraViewParameters);
     internalView = new ChangeCaptureView(props.getCombinedProperties().toProperties(), store, extraViewParameters);
     kafkaClusterUrlToIdMap = props.getVeniceServerConfig().getKafkaClusterUrlToIdMap();
+    pubSubProducerAdapterFactory = props.getVeniceServerConfig().getPubSubClientsFactory().getProducerAdapterFactory();
     maxColoIdValue = kafkaClusterUrlToIdMap.values().stream().max(Integer::compareTo).orElse(-1);
+
   }
 
   @Override
@@ -192,7 +196,8 @@ public class ChangeCaptureViewWriter extends VeniceViewWriter {
     if (veniceWriter != null) {
       return;
     }
-    veniceWriter = new VeniceWriterFactory(props).createVeniceWriter(buildWriterOptions(version));
+    veniceWriter = new VeniceWriterFactory(props, pubSubProducerAdapterFactory, null)
+        .createVeniceWriter(buildWriterOptions(version));
   }
 
   private ValueBytes constructValueBytes(ByteBuffer value, int schemaId) {

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionServiceTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionServiceTest.java
@@ -43,7 +43,10 @@ import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.meta.VersionImpl;
 import com.linkedin.venice.meta.VersionStatus;
 import com.linkedin.venice.meta.ZKStore;
+import com.linkedin.venice.pubsub.api.PubSubAdminAdapterFactory;
 import com.linkedin.venice.pubsub.api.PubSubClientsFactory;
+import com.linkedin.venice.pubsub.api.PubSubConsumerAdapterFactory;
+import com.linkedin.venice.pubsub.api.PubSubProducerAdapterFactory;
 import com.linkedin.venice.pushmonitor.ExecutionStatus;
 import com.linkedin.venice.schema.SchemaEntry;
 import com.linkedin.venice.serialization.avro.AvroProtocolDefinition;
@@ -97,7 +100,10 @@ public abstract class KafkaStoreIngestionServiceTest {
     mockCustomizedViewRepository = mock(HelixCustomizedViewOfflinePushRepository.class);
     mockHelixInstanceConfigRepository = mock(HelixInstanceConfigRepository.class);
     mockLiveClusterConfigRepo = mock(ReadOnlyLiveClusterConfigRepository.class);
-    mockPubSubClientsFactory = mock(PubSubClientsFactory.class);
+    mockPubSubClientsFactory = new PubSubClientsFactory(
+        mock(PubSubProducerAdapterFactory.class),
+        mock(PubSubConsumerAdapterFactory.class),
+        mock(PubSubAdminAdapterFactory.class));
     compressorFactory = new StorageEngineBackedCompressorFactory(storageMetadataService);
 
     setupMockConfig();

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/store/view/ChangeCaptureViewWriterTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/store/view/ChangeCaptureViewWriterTest.java
@@ -16,7 +16,9 @@ import com.linkedin.venice.kafka.protocol.VersionSwap;
 import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.meta.VersionImpl;
+import com.linkedin.venice.pubsub.api.PubSubClientsFactory;
 import com.linkedin.venice.pubsub.api.PubSubProduceResult;
+import com.linkedin.venice.pubsub.api.PubSubProducerAdapterFactory;
 import com.linkedin.venice.schema.rmd.RmdSchemaGenerator;
 import com.linkedin.venice.utils.VeniceProperties;
 import com.linkedin.venice.views.ChangeCaptureView;
@@ -93,6 +95,10 @@ public class ChangeCaptureViewWriterTest {
 
     VeniceServerConfig mockVeniceServerConfig = Mockito.mock(VeniceServerConfig.class);
     Mockito.when(mockVeniceServerConfig.getKafkaClusterUrlToIdMap()).thenReturn(urlMappingMap);
+    PubSubProducerAdapterFactory mockPubSubProducerAdapterFactory = Mockito.mock(PubSubProducerAdapterFactory.class);
+    PubSubClientsFactory mockPubSubClientsFactory = Mockito.mock(PubSubClientsFactory.class);
+    Mockito.when(mockPubSubClientsFactory.getProducerAdapterFactory()).thenReturn(mockPubSubProducerAdapterFactory);
+    Mockito.when(mockVeniceServerConfig.getPubSubClientsFactory()).thenReturn(mockPubSubClientsFactory);
 
     VeniceConfigLoader mockVeniceConfigLoader = Mockito.mock(VeniceConfigLoader.class);
     Mockito.when(mockVeniceConfigLoader.getCombinedProperties()).thenReturn(props);
@@ -168,6 +174,10 @@ public class ChangeCaptureViewWriterTest {
 
     VeniceConfigLoader mockVeniceConfigLoader = Mockito.mock(VeniceConfigLoader.class);
     Mockito.when(mockVeniceConfigLoader.getCombinedProperties()).thenReturn(props);
+    PubSubProducerAdapterFactory mockPubSubProducerAdapterFactory = Mockito.mock(PubSubProducerAdapterFactory.class);
+    PubSubClientsFactory mockPubSubClientsFactory = Mockito.mock(PubSubClientsFactory.class);
+    Mockito.when(mockPubSubClientsFactory.getProducerAdapterFactory()).thenReturn(mockPubSubProducerAdapterFactory);
+    Mockito.when(mockVeniceServerConfig.getPubSubClientsFactory()).thenReturn(mockPubSubClientsFactory);
     Mockito.when(mockVeniceConfigLoader.getVeniceServerConfig()).thenReturn(mockVeniceServerConfig);
 
     ChangeCaptureViewWriter changeCaptureViewWriter =
@@ -198,6 +208,10 @@ public class ChangeCaptureViewWriterTest {
     Mockito.when(mockVeniceServerConfig.getKafkaClusterUrlToIdMap()).thenReturn(urlMappingMap);
 
     VeniceConfigLoader mockVeniceConfigLoader = Mockito.mock(VeniceConfigLoader.class);
+    PubSubProducerAdapterFactory mockPubSubProducerAdapterFactory = Mockito.mock(PubSubProducerAdapterFactory.class);
+    PubSubClientsFactory mockPubSubClientsFactory = Mockito.mock(PubSubClientsFactory.class);
+    Mockito.when(mockPubSubClientsFactory.getProducerAdapterFactory()).thenReturn(mockPubSubProducerAdapterFactory);
+    Mockito.when(mockVeniceServerConfig.getPubSubClientsFactory()).thenReturn(mockPubSubClientsFactory);
     Mockito.when(mockVeniceConfigLoader.getCombinedProperties()).thenReturn(props);
     Mockito.when(mockVeniceConfigLoader.getVeniceServerConfig()).thenReturn(mockVeniceServerConfig);
 

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/store/view/VeniceViewWriterFactoryTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/store/view/VeniceViewWriterFactoryTest.java
@@ -8,6 +8,8 @@ import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.meta.VersionImpl;
 import com.linkedin.venice.meta.ViewConfig;
 import com.linkedin.venice.meta.ViewConfigImpl;
+import com.linkedin.venice.pubsub.api.PubSubClientsFactory;
+import com.linkedin.venice.pubsub.api.PubSubProducerAdapterFactory;
 import com.linkedin.venice.utils.VeniceProperties;
 import com.linkedin.venice.views.ChangeCaptureView;
 import it.unimi.dsi.fastutil.objects.Object2IntMap;
@@ -33,6 +35,11 @@ public class VeniceViewWriterFactoryTest {
     VeniceServerConfig mockVeniceServerConfig = Mockito.mock(VeniceServerConfig.class);
     Mockito.when(mockVeniceServerConfig.getKafkaClusterUrlToIdMap()).thenReturn(urlMappingMap);
     VeniceConfigLoader mockVeniceConfigLoader = Mockito.mock(VeniceConfigLoader.class);
+    Mockito.when(mockVeniceConfigLoader.getCombinedProperties()).thenReturn(props);
+    PubSubClientsFactory mockPubSubClientsFactory = Mockito.mock(PubSubClientsFactory.class);
+    PubSubProducerAdapterFactory mockPubSubProducerAdapterFactory = Mockito.mock(PubSubProducerAdapterFactory.class);
+    Mockito.when(mockPubSubClientsFactory.getProducerAdapterFactory()).thenReturn(mockPubSubProducerAdapterFactory);
+    Mockito.when(mockVeniceServerConfig.getPubSubClientsFactory()).thenReturn(mockPubSubClientsFactory);
     Mockito.when(mockVeniceConfigLoader.getCombinedProperties()).thenReturn(props);
     Mockito.when(mockVeniceConfigLoader.getVeniceServerConfig()).thenReturn(mockVeniceServerConfig);
 

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/store/view/ViewWriterUtilsTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/store/view/ViewWriterUtilsTest.java
@@ -4,7 +4,9 @@ import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
 import com.linkedin.davinci.config.VeniceConfigLoader;
 import com.linkedin.davinci.config.VeniceServerConfig;
 import com.linkedin.venice.meta.Store;
+import com.linkedin.venice.pubsub.api.PubSubClientsFactory;
 import com.linkedin.venice.pubsub.api.PubSubProduceResult;
+import com.linkedin.venice.pubsub.api.PubSubProducerAdapterFactory;
 import com.linkedin.venice.utils.VeniceProperties;
 import com.linkedin.venice.views.ChangeCaptureView;
 import com.linkedin.venice.views.VeniceView;
@@ -35,6 +37,10 @@ public class ViewWriterUtilsTest {
 
     VeniceServerConfig mockVeniceServerConfig = Mockito.mock(VeniceServerConfig.class);
     Mockito.when(mockVeniceServerConfig.getKafkaClusterUrlToIdMap()).thenReturn(urlMappingMap);
+    PubSubProducerAdapterFactory mockPubSubProducerAdapterFactory = Mockito.mock(PubSubProducerAdapterFactory.class);
+    PubSubClientsFactory mockPubSubClientsFactory = Mockito.mock(PubSubClientsFactory.class);
+    Mockito.when(mockPubSubClientsFactory.getProducerAdapterFactory()).thenReturn(mockPubSubProducerAdapterFactory);
+    Mockito.when(mockVeniceServerConfig.getPubSubClientsFactory()).thenReturn(mockPubSubClientsFactory);
 
     VeniceConfigLoader mockVeniceConfigLoader = Mockito.mock(VeniceConfigLoader.class);
     Mockito.when(mockVeniceConfigLoader.getCombinedProperties()).thenReturn(props);

--- a/clients/venice-producer/src/main/java/com/linkedin/venice/producer/AbstractVeniceProducer.java
+++ b/clients/venice-producer/src/main/java/com/linkedin/venice/producer/AbstractVeniceProducer.java
@@ -11,6 +11,7 @@ import com.linkedin.venice.SSLConfig;
 import com.linkedin.venice.controllerapi.VersionCreationResponse;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.partitioner.VenicePartitioner;
+import com.linkedin.venice.pubsub.adapter.kafka.producer.ApacheKafkaProducerAdapterFactory;
 import com.linkedin.venice.pubsub.api.PubSubProduceResult;
 import com.linkedin.venice.pubsub.api.PubSubProducerCallback;
 import com.linkedin.venice.schema.SchemaData;
@@ -147,7 +148,8 @@ public abstract class AbstractVeniceProducer<K, V> implements VeniceProducer<K, 
   protected VeniceWriter<byte[], byte[], byte[]> constructVeniceWriter(
       Properties properties,
       VeniceWriterOptions writerOptions) {
-    return new VeniceWriterFactory(properties).createVeniceWriter(writerOptions);
+    return new VeniceWriterFactory(properties, new ApacheKafkaProducerAdapterFactory(), null)
+        .createVeniceWriter(writerOptions);
   }
 
   protected RecordSerializer<Object> getSerializer(Schema schema) {

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
@@ -64,6 +64,7 @@ import com.linkedin.venice.meta.StoreInfo;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.partitioner.DefaultVenicePartitioner;
 import com.linkedin.venice.partitioner.VenicePartitioner;
+import com.linkedin.venice.pubsub.adapter.kafka.producer.ApacheKafkaProducerAdapterFactory;
 import com.linkedin.venice.pushmonitor.ExecutionStatus;
 import com.linkedin.venice.schema.AvroSchemaParseUtils;
 import com.linkedin.venice.security.SSLFactory;
@@ -2579,8 +2580,9 @@ public class VenicePushJob implements AutoCloseable {
 
   private synchronized VeniceWriter<KafkaKey, byte[], byte[]> getVeniceWriter(TopicInfo topicInfo) {
     if (veniceWriter == null) {
-      // Initialize VeniceWriter
-      VeniceWriterFactory veniceWriterFactory = new VeniceWriterFactory(getVeniceWriterProperties(topicInfo));
+      // Initialize VeniceWriter, TODO: passing configurable PubSubProducerAdapter
+      VeniceWriterFactory veniceWriterFactory =
+          new VeniceWriterFactory(getVeniceWriterProperties(topicInfo), new ApacheKafkaProducerAdapterFactory(), null);
       Properties partitionerProperties = new Properties();
       partitionerProperties.putAll(topicInfo.partitionerParams);
       VenicePartitioner venicePartitioner = PartitionUtils.getVenicePartitioner(

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VeniceReducer.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VeniceReducer.java
@@ -19,6 +19,7 @@ import com.linkedin.venice.guid.GuidUtils;
 import com.linkedin.venice.hadoop.utils.HadoopUtils;
 import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.partitioner.VenicePartitioner;
+import com.linkedin.venice.pubsub.adapter.kafka.producer.ApacheKafkaProducerAdapterFactory;
 import com.linkedin.venice.pubsub.api.PubSubProduceResult;
 import com.linkedin.venice.pubsub.api.PubSubProducerCallback;
 import com.linkedin.venice.serialization.DefaultSerializer;
@@ -387,7 +388,8 @@ public class VeniceReducer extends AbstractMapReduceTask
       LOGGER.warn("Unable to parse job tracker id, using default value for guid generation", e);
     }
     writerProps.put(ConfigKeys.PUSH_JOB_MAP_REDUCE_JOB_ID, mapReduceJobId.getId());
-    VeniceWriterFactory veniceWriterFactoryFactory = new VeniceWriterFactory(writerProps);
+    VeniceWriterFactory veniceWriterFactoryFactory =
+        new VeniceWriterFactory(writerProps, new ApacheKafkaProducerAdapterFactory(), null);
     boolean chunkingEnabled = props.getBoolean(VeniceWriter.ENABLE_CHUNKING, false);
     boolean rmdChunkingEnabled = props.getBoolean(VeniceWriter.ENABLE_RMD_CHUNKING, false);
     VenicePartitioner partitioner = PartitionUtils.getVenicePartitioner(props);

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/heartbeat/DefaultPushJobHeartbeatSenderFactory.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/heartbeat/DefaultPushJobHeartbeatSenderFactory.java
@@ -15,6 +15,7 @@ import com.linkedin.venice.meta.PartitionerConfig;
 import com.linkedin.venice.meta.StoreInfo;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.partitioner.VenicePartitioner;
+import com.linkedin.venice.pubsub.adapter.kafka.producer.ApacheKafkaProducerAdapterFactory;
 import com.linkedin.venice.serialization.avro.AvroProtocolDefinition;
 import com.linkedin.venice.utils.PartitionUtils;
 import com.linkedin.venice.utils.VeniceProperties;
@@ -132,9 +133,10 @@ public class DefaultPushJobHeartbeatSenderFactory implements PushJobHeartbeatSen
         partitionerConfig.getPartitionerClass(),
         partitionerConfig.getAmplificationFactor(),
         new VeniceProperties(partitionerProperties));
-    return new VeniceWriterFactory(veniceWriterProperties).createVeniceWriter(
-        new VeniceWriterOptions.Builder(heartbeatKafkaTopicName).setPartitioner(venicePartitioner)
-            .setPartitionCount(partitionNum)
-            .build());
+    return new VeniceWriterFactory(veniceWriterProperties, new ApacheKafkaProducerAdapterFactory(), null)
+        .createVeniceWriter(
+            new VeniceWriterOptions.Builder(heartbeatKafkaTopicName).setPartitioner(venicePartitioner)
+                .setPartitionCount(partitionNum)
+                .build());
   }
 }

--- a/clients/venice-samza/src/main/java/com/linkedin/venice/samza/VeniceSystemProducer.java
+++ b/clients/venice-samza/src/main/java/com/linkedin/venice/samza/VeniceSystemProducer.java
@@ -26,6 +26,7 @@ import com.linkedin.venice.controllerapi.VersionCreationResponse;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.partitioner.VenicePartitioner;
+import com.linkedin.venice.pubsub.adapter.kafka.producer.ApacheKafkaProducerAdapterFactory;
 import com.linkedin.venice.pubsub.api.PubSubProducerCallback;
 import com.linkedin.venice.pushmonitor.ExecutionStatus;
 import com.linkedin.venice.pushmonitor.HybridStoreQuotaStatus;
@@ -409,7 +410,8 @@ public class VeniceSystemProducer implements SystemProducer, Closeable {
     Properties finalWriterConfigs = new Properties();
     finalWriterConfigs.putAll(properties);
     finalWriterConfigs.putAll(additionalWriterConfigs);
-    return new VeniceWriterFactory(finalWriterConfigs).createVeniceWriter(writerOptions);
+    return new VeniceWriterFactory(finalWriterConfigs, new ApacheKafkaProducerAdapterFactory(), null)
+        .createVeniceWriter(writerOptions);
   }
 
   @Override

--- a/internal/venice-avro-compatibility-test/src/test/java/com/linkedin/venice/VeniceClusterInitializer.java
+++ b/internal/venice-avro-compatibility-test/src/test/java/com/linkedin/venice/VeniceClusterInitializer.java
@@ -13,6 +13,7 @@ import com.linkedin.venice.helix.HelixReadOnlySchemaRepository;
 import com.linkedin.venice.integration.utils.ServiceFactory;
 import com.linkedin.venice.integration.utils.VeniceClusterWrapper;
 import com.linkedin.venice.meta.Version;
+import com.linkedin.venice.pubsub.api.PubSubProducerAdapterFactory;
 import com.linkedin.venice.pushmonitor.ExecutionStatus;
 import com.linkedin.venice.serialization.VeniceKafkaSerializer;
 import com.linkedin.venice.serialization.avro.VeniceAvroKafkaSerializer;
@@ -181,8 +182,10 @@ public class VeniceClusterInitializer implements Closeable {
       values.add(i, serializedBytes);
     }
 
-    VeniceWriterFactory vwFactory =
-        TestUtils.getVeniceWriterFactory(veniceCluster.getPubSubBrokerWrapper().getAddress());
+    PubSubProducerAdapterFactory pubSubProducerAdapterFactory =
+        veniceCluster.getPubSubBrokerWrapper().getPubSubClientsFactory().getProducerAdapterFactory();
+    VeniceWriterFactory vwFactory = TestUtils
+        .getVeniceWriterFactory(veniceCluster.getPubSubBrokerWrapper().getAddress(), pubSubProducerAdapterFactory);
     try (VeniceWriter<Object, byte[], byte[]> veniceWriter = vwFactory.createVeniceWriter(
         new VeniceWriterOptions.Builder(pushVersionTopic).setKeySerializer(keySerializer).build())) {
       veniceWriter.broadcastStartOfPush(Collections.emptyMap());

--- a/internal/venice-avro-compatibility-test/src/test/java/com/linkedin/venice/VeniceClusterInitializer.java
+++ b/internal/venice-avro-compatibility-test/src/test/java/com/linkedin/venice/VeniceClusterInitializer.java
@@ -181,7 +181,8 @@ public class VeniceClusterInitializer implements Closeable {
       values.add(i, serializedBytes);
     }
 
-    VeniceWriterFactory vwFactory = TestUtils.getVeniceWriterFactory(veniceCluster.getKafka().getAddress());
+    VeniceWriterFactory vwFactory =
+        TestUtils.getVeniceWriterFactory(veniceCluster.getPubSubBrokerWrapper().getAddress());
     try (VeniceWriter<Object, byte[], byte[]> veniceWriter = vwFactory.createVeniceWriter(
         new VeniceWriterOptions.Builder(pushVersionTopic).setKeySerializer(keySerializer).build())) {
       veniceWriter.broadcastStartOfPush(Collections.emptyMap());

--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -1965,4 +1965,10 @@ public class ConfigKeys {
    * Old state clearing is disabled if this config is set to -1.
    */
   public static final String DIV_PRODUCER_STATE_MAX_AGE_MS = "div.producer.state.max.age.ms";
+
+  public static final String PUB_SUB_ADMIN_ADAPTER_FACTORY_CLASS = "pub.sub.admin.adapter.factory.class";
+
+  public static final String PUB_SUB_PRODUCER_ADAPTER_FACTORY_CLASS = "pub.sub.producer.adapter.factory.class";
+
+  public static final String PUB_SUB_CONSUMER_ADAPTER_FACTORY_CLASS = "pub.sub.consumer.adapter.factory.class";
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/writer/VeniceWriterFactory.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/writer/VeniceWriterFactory.java
@@ -15,10 +15,6 @@ public class VeniceWriterFactory {
   private final Properties properties;
   private final PubSubProducerAdapterFactory producerAdapterFactory;
 
-  public VeniceWriterFactory(Properties properties) {
-    this(properties, null, null);
-  }
-
   public VeniceWriterFactory(
       Properties properties,
       PubSubProducerAdapterFactory producerAdapterFactory,

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/consumer/ConsumerIntegrationTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/consumer/ConsumerIntegrationTest.java
@@ -161,7 +161,7 @@ public abstract class ConsumerIntegrationTest {
     Properties javaProps = new Properties();
     javaProps
         .put(ApacheKafkaProducerConfig.KAFKA_VALUE_SERIALIZER, KafkaValueSerializerWithNewerProtocol.class.getName());
-    javaProps.put(ApacheKafkaProducerConfig.KAFKA_BOOTSTRAP_SERVERS, cluster.getKafka().getAddress());
+    javaProps.put(ApacheKafkaProducerConfig.KAFKA_BOOTSTRAP_SERVERS, cluster.getPubSubBrokerWrapper().getAddress());
     VeniceProperties props = new VeniceProperties(javaProps);
     String stringSchema = "\"string\"";
     VeniceKafkaSerializer keySerializer = new VeniceAvroKafkaSerializer(stringSchema);

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestDeleteStoreDeletesRealtimeTopic.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestDeleteStoreDeletesRealtimeTopic.java
@@ -53,12 +53,8 @@ public class TestDeleteStoreDeletesRealtimeTopic {
     controllerClient =
         ControllerClient.constructClusterControllerClient(venice.getClusterName(), venice.getRandomRouterURL());
 
-    try (TopicManagerRepository topicManagerRepository = IntegrationTestPushUtils.getTopicManagerRepo(
-        DEFAULT_KAFKA_OPERATION_TIMEOUT_MS,
-        100,
-        0l,
-        venice.getKafka().getAddress(),
-        pubSubTopicRepository)) {
+    try (TopicManagerRepository topicManagerRepository = IntegrationTestPushUtils
+        .getTopicManagerRepo(DEFAULT_KAFKA_OPERATION_TIMEOUT_MS, 100, 0l, venice.getKafka(), pubSubTopicRepository)) {
       topicManager = topicManagerRepository.getTopicManager();
     }
 

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestDeleteStoreDeletesRealtimeTopic.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestDeleteStoreDeletesRealtimeTopic.java
@@ -53,8 +53,12 @@ public class TestDeleteStoreDeletesRealtimeTopic {
     controllerClient =
         ControllerClient.constructClusterControllerClient(venice.getClusterName(), venice.getRandomRouterURL());
 
-    try (TopicManagerRepository topicManagerRepository = IntegrationTestPushUtils
-        .getTopicManagerRepo(DEFAULT_KAFKA_OPERATION_TIMEOUT_MS, 100, 0l, venice.getKafka(), pubSubTopicRepository)) {
+    try (TopicManagerRepository topicManagerRepository = IntegrationTestPushUtils.getTopicManagerRepo(
+        DEFAULT_KAFKA_OPERATION_TIMEOUT_MS,
+        100,
+        0l,
+        venice.getPubSubBrokerWrapper(),
+        pubSubTopicRepository)) {
       topicManager = topicManagerRepository.getTopicManager();
     }
 

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestTopicRequestOnHybridDelete.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestTopicRequestOnHybridDelete.java
@@ -186,12 +186,8 @@ public class TestTopicRequestOnHybridDelete {
   @Test(timeOut = 60 * Time.MS_PER_SECOND)
   public void deleteStoreAfterStartedPushAllowsNewPush() {
     ControllerClient controllerClient = new ControllerClient(venice.getClusterName(), venice.getRandomRouterURL());
-    try (TopicManagerRepository topicManagerRepository = IntegrationTestPushUtils.getTopicManagerRepo(
-        DEFAULT_KAFKA_OPERATION_TIMEOUT_MS,
-        100,
-        0l,
-        venice.getKafka().getAddress(),
-        pubSubTopicRepository)) {
+    try (TopicManagerRepository topicManagerRepository = IntegrationTestPushUtils
+        .getTopicManagerRepo(DEFAULT_KAFKA_OPERATION_TIMEOUT_MS, 100, 0l, venice.getKafka(), pubSubTopicRepository)) {
 
       TopicManager topicManager = topicManagerRepository.getTopicManager();
 

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestTopicRequestOnHybridDelete.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestTopicRequestOnHybridDelete.java
@@ -186,8 +186,12 @@ public class TestTopicRequestOnHybridDelete {
   @Test(timeOut = 60 * Time.MS_PER_SECOND)
   public void deleteStoreAfterStartedPushAllowsNewPush() {
     ControllerClient controllerClient = new ControllerClient(venice.getClusterName(), venice.getRandomRouterURL());
-    try (TopicManagerRepository topicManagerRepository = IntegrationTestPushUtils
-        .getTopicManagerRepo(DEFAULT_KAFKA_OPERATION_TIMEOUT_MS, 100, 0l, venice.getKafka(), pubSubTopicRepository)) {
+    try (TopicManagerRepository topicManagerRepository = IntegrationTestPushUtils.getTopicManagerRepo(
+        DEFAULT_KAFKA_OPERATION_TIMEOUT_MS,
+        100,
+        0l,
+        venice.getPubSubBrokerWrapper(),
+        pubSubTopicRepository)) {
 
       TopicManager topicManager = topicManagerRepository.getTopicManager();
 

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/VeniceParentHelixAdminTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/VeniceParentHelixAdminTest.java
@@ -94,10 +94,13 @@ public class VeniceParentHelixAdminTest {
     properties.setProperty(TERMINAL_STATE_TOPIC_CHECK_DELAY_MS, String.valueOf(1000L));
     try (
         VeniceControllerWrapper parentController = ServiceFactory.getVeniceController(
-            new VeniceControllerCreateOptions.Builder(venice.getClusterName(), zkServerWrapper, venice.getKafka())
-                .childControllers(new VeniceControllerWrapper[] { venice.getLeaderVeniceController() })
-                .extraProperties(properties)
-                .build());
+            new VeniceControllerCreateOptions.Builder(
+                venice.getClusterName(),
+                zkServerWrapper,
+                venice.getPubSubBrokerWrapper())
+                    .childControllers(new VeniceControllerWrapper[] { venice.getLeaderVeniceController() })
+                    .extraProperties(properties)
+                    .build());
         ControllerClient parentControllerClient =
             new ControllerClient(venice.getClusterName(), parentController.getControllerUrl())) {
       String storeName = Utils.getUniqueString("testStore");
@@ -123,10 +126,13 @@ public class VeniceParentHelixAdminTest {
     properties.setProperty(REPLICATION_METADATA_VERSION, String.valueOf(1));
     try (
         VeniceControllerWrapper parentControllerWrapper = ServiceFactory.getVeniceController(
-            new VeniceControllerCreateOptions.Builder(venice.getClusterName(), zkServerWrapper, venice.getKafka())
-                .childControllers(new VeniceControllerWrapper[] { venice.getLeaderVeniceController() })
-                .extraProperties(properties)
-                .build());
+            new VeniceControllerCreateOptions.Builder(
+                venice.getClusterName(),
+                zkServerWrapper,
+                venice.getPubSubBrokerWrapper())
+                    .childControllers(new VeniceControllerWrapper[] { venice.getLeaderVeniceController() })
+                    .extraProperties(properties)
+                    .build());
         ControllerClient parentControllerClient =
             new ControllerClient(venice.getClusterName(), parentControllerWrapper.getControllerUrl())) {
       // Adding store
@@ -243,10 +249,13 @@ public class VeniceParentHelixAdminTest {
     properties.setProperty(CONTROLLER_AUTO_MATERIALIZE_DAVINCI_PUSH_STATUS_SYSTEM_STORE, String.valueOf(false));
     try (
         VeniceControllerWrapper parentController = ServiceFactory.getVeniceController(
-            new VeniceControllerCreateOptions.Builder(venice.getClusterName(), zkServerWrapper, venice.getKafka())
-                .childControllers(new VeniceControllerWrapper[] { venice.getLeaderVeniceController() })
-                .extraProperties(properties)
-                .build());
+            new VeniceControllerCreateOptions.Builder(
+                venice.getClusterName(),
+                zkServerWrapper,
+                venice.getPubSubBrokerWrapper())
+                    .childControllers(new VeniceControllerWrapper[] { venice.getLeaderVeniceController() })
+                    .extraProperties(properties)
+                    .build());
         ControllerClient parentControllerClient =
             new ControllerClient(venice.getClusterName(), parentController.getControllerUrl())) {
       String storeName = Utils.getUniqueString("testStore");
@@ -303,9 +312,12 @@ public class VeniceParentHelixAdminTest {
   @Test(timeOut = DEFAULT_TEST_TIMEOUT_MS)
   public void testHybridAndETLStoreConfig() {
     try (VeniceControllerWrapper parentControllerWrapper = ServiceFactory.getVeniceController(
-        new VeniceControllerCreateOptions.Builder(venice.getClusterName(), zkServerWrapper, venice.getKafka())
-            .childControllers(new VeniceControllerWrapper[] { venice.getLeaderVeniceController() })
-            .build())) {
+        new VeniceControllerCreateOptions.Builder(
+            venice.getClusterName(),
+            zkServerWrapper,
+            venice.getPubSubBrokerWrapper())
+                .childControllers(new VeniceControllerWrapper[] { venice.getLeaderVeniceController() })
+                .build())) {
       String controllerUrl = parentControllerWrapper.getControllerUrl();
 
       // Adding store

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/kafka/consumer/AdminConsumptionTaskIntegrationTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/kafka/consumer/AdminConsumptionTaskIntegrationTest.java
@@ -19,6 +19,7 @@ import com.linkedin.venice.integration.utils.VeniceControllerWrapper;
 import com.linkedin.venice.integration.utils.ZkServerWrapper;
 import com.linkedin.venice.kafka.TopicManager;
 import com.linkedin.venice.pubsub.PubSubTopicRepository;
+import com.linkedin.venice.pubsub.api.PubSubProducerAdapterFactory;
 import com.linkedin.venice.pubsub.api.PubSubTopic;
 import com.linkedin.venice.utils.IntegrationTestPushUtils;
 import com.linkedin.venice.utils.TestUtils;
@@ -74,8 +75,10 @@ public class AdminConsumptionTaskIntegrationTest {
               new VeniceControllerCreateOptions.Builder(clusterName, zkServer, pubSubBrokerWrapper)
                   .regionName(STANDALONE_REGION_NAME)
                   .build());
+          PubSubProducerAdapterFactory pubSubProducerAdapterFactory =
+              pubSubBrokerWrapper.getPubSubClientsFactory().getProducerAdapterFactory();
           VeniceWriter<byte[], byte[], byte[]> writer =
-              TestUtils.getVeniceWriterFactory(pubSubBrokerWrapper.getAddress())
+              TestUtils.getVeniceWriterFactory(pubSubBrokerWrapper.getAddress(), pubSubProducerAdapterFactory)
                   .createVeniceWriter(new VeniceWriterOptions.Builder(adminTopic.getName()).build())) {
         byte[] message = getStoreCreationMessage(clusterName, storeName, owner, "invalid_key_schema", valueSchema, 1);
         long badOffset = writer.put(new byte[0], message, AdminOperationSerializer.LATEST_SCHEMA_ID_FOR_ADMIN_OPERATION)

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/kafka/consumer/AdminConsumptionTaskIntegrationTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/kafka/consumer/AdminConsumptionTaskIntegrationTest.java
@@ -63,7 +63,7 @@ public class AdminConsumptionTaskIntegrationTest {
                     DEFAULT_KAFKA_OPERATION_TIMEOUT_MS,
                     100,
                     0l,
-                    pubSubBrokerWrapper.getAddress(),
+                    pubSubBrokerWrapper,
                     pubSubTopicRepository)
                 .getTopicManager()) {
       PubSubTopic adminTopic = pubSubTopicRepository.getTopic(AdminTopicUtils.getTopicNameFromClusterName(clusterName));

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/server/AbstractTestAdminSparkServer.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/server/AbstractTestAdminSparkServer.java
@@ -41,7 +41,7 @@ public class AbstractTestAdminSparkServer {
     extraProperties.setProperty(CONTROLLER_AUTO_MATERIALIZE_META_SYSTEM_STORE, "false");
     extraProperties.setProperty(CONTROLLER_AUTO_MATERIALIZE_DAVINCI_PUSH_STATUS_SYSTEM_STORE, "false");
     VeniceControllerCreateOptions options =
-        new VeniceControllerCreateOptions.Builder(cluster.getClusterName(), parentZk, cluster.getKafka())
+        new VeniceControllerCreateOptions.Builder(cluster.getClusterName(), parentZk, cluster.getPubSubBrokerWrapper())
             .replicationFactor(1)
             .childControllers(new VeniceControllerWrapper[] { cluster.getLeaderVeniceController() })
             .extraProperties(extraProperties)

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/DaVinciClientTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/DaVinciClientTest.java
@@ -358,7 +358,7 @@ public class DaVinciClientTest {
     VersionCreationResponse newVersion = cluster.getNewVersion(storeName);
     final int pushVersion = newVersion.getVersion();
     String topic = newVersion.getKafkaTopic();
-    VeniceWriterFactory vwFactory = TestUtils.getVeniceWriterFactory(cluster.getKafka().getAddress());
+    VeniceWriterFactory vwFactory = TestUtils.getVeniceWriterFactory(cluster.getPubSubBrokerWrapper().getAddress());
     VeniceKafkaSerializer keySerializer = new VeniceAvroKafkaSerializer(DEFAULT_KEY_SCHEMA);
     VeniceKafkaSerializer valueSerializer = new VeniceAvroKafkaSerializer(DEFAULT_VALUE_SCHEMA);
 
@@ -743,7 +743,7 @@ public class DaVinciClientTest {
 
     VersionCreationResponse newVersion = cluster.getNewVersion(storeName);
     String topic = newVersion.getKafkaTopic();
-    VeniceWriterFactory vwFactory = TestUtils.getVeniceWriterFactory(cluster.getKafka().getAddress());
+    VeniceWriterFactory vwFactory = TestUtils.getVeniceWriterFactory(cluster.getPubSubBrokerWrapper().getAddress());
     VeniceKafkaSerializer keySerializer = new VeniceAvroKafkaSerializer(DEFAULT_KEY_SCHEMA);
     VeniceKafkaSerializer valueSerializer = new VeniceAvroKafkaSerializer(DEFAULT_VALUE_SCHEMA);
     int valueSchemaId = HelixReadOnlySchemaRepository.VALUE_SCHEMA_STARTING_ID;

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/DaVinciClientTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/DaVinciClientTest.java
@@ -61,6 +61,7 @@ import com.linkedin.venice.meta.IngestionMetadataUpdateType;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.offsets.OffsetRecord;
 import com.linkedin.venice.partitioner.ConstantVenicePartitioner;
+import com.linkedin.venice.pubsub.api.PubSubProducerAdapterFactory;
 import com.linkedin.venice.serialization.VeniceKafkaSerializer;
 import com.linkedin.venice.serialization.avro.AvroProtocolDefinition;
 import com.linkedin.venice.serialization.avro.VeniceAvroKafkaSerializer;
@@ -116,6 +117,7 @@ public class DaVinciClientTest {
       "{\"type\":\"record\", \"name\":\"ValueRecord\", \"fields\": [{\"name\":\"number\", " + "\"type\":\"int\"}]}";
   private VeniceClusterWrapper cluster;
   private D2Client d2Client;
+  private PubSubProducerAdapterFactory pubSubProducerAdapterFactory;
 
   @BeforeClass
   public void setUp() {
@@ -127,6 +129,8 @@ public class DaVinciClientTest {
         .setZkSessionTimeout(3, TimeUnit.SECONDS)
         .setZkStartupTimeout(3, TimeUnit.SECONDS)
         .build();
+    pubSubProducerAdapterFactory =
+        cluster.getPubSubBrokerWrapper().getPubSubClientsFactory().getProducerAdapterFactory();
     D2ClientUtils.startClient(d2Client);
   }
 
@@ -358,7 +362,8 @@ public class DaVinciClientTest {
     VersionCreationResponse newVersion = cluster.getNewVersion(storeName);
     final int pushVersion = newVersion.getVersion();
     String topic = newVersion.getKafkaTopic();
-    VeniceWriterFactory vwFactory = TestUtils.getVeniceWriterFactory(cluster.getPubSubBrokerWrapper().getAddress());
+    VeniceWriterFactory vwFactory =
+        TestUtils.getVeniceWriterFactory(cluster.getPubSubBrokerWrapper().getAddress(), pubSubProducerAdapterFactory);
     VeniceKafkaSerializer keySerializer = new VeniceAvroKafkaSerializer(DEFAULT_KEY_SCHEMA);
     VeniceKafkaSerializer valueSerializer = new VeniceAvroKafkaSerializer(DEFAULT_VALUE_SCHEMA);
 
@@ -743,7 +748,8 @@ public class DaVinciClientTest {
 
     VersionCreationResponse newVersion = cluster.getNewVersion(storeName);
     String topic = newVersion.getKafkaTopic();
-    VeniceWriterFactory vwFactory = TestUtils.getVeniceWriterFactory(cluster.getPubSubBrokerWrapper().getAddress());
+    VeniceWriterFactory vwFactory =
+        TestUtils.getVeniceWriterFactory(cluster.getPubSubBrokerWrapper().getAddress(), pubSubProducerAdapterFactory);
     VeniceKafkaSerializer keySerializer = new VeniceAvroKafkaSerializer(DEFAULT_KEY_SCHEMA);
     VeniceKafkaSerializer valueSerializer = new VeniceAvroKafkaSerializer(DEFAULT_VALUE_SCHEMA);
     int valueSchemaId = HelixReadOnlySchemaRepository.VALUE_SCHEMA_STARTING_ID;

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/DaVinciClusterAgnosticTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/DaVinciClusterAgnosticTest.java
@@ -27,6 +27,7 @@ import com.linkedin.venice.integration.utils.VeniceRouterWrapper;
 import com.linkedin.venice.integration.utils.VeniceTwoLayerMultiRegionMultiClusterWrapper;
 import com.linkedin.venice.meta.PersistenceType;
 import com.linkedin.venice.meta.Version;
+import com.linkedin.venice.pubsub.api.PubSubProducerAdapterFactory;
 import com.linkedin.venice.utils.PropertyBuilder;
 import com.linkedin.venice.utils.TestUtils;
 import com.linkedin.venice.utils.Time;
@@ -126,12 +127,18 @@ public class DaVinciClusterAgnosticTest {
         assertFalse(
             parentControllerClient.createNewStore(storeName, "venice-test", INT_KEY_SCHEMA, INT_VALUE_SCHEMA)
                 .isError());
+        PubSubProducerAdapterFactory pubSubProducerAdapterFactory = multiClusterVenice.getClusters()
+            .get(cluster)
+            .getPubSubBrokerWrapper()
+            .getPubSubClientsFactory()
+            .getProducerAdapterFactory();
         VersionCreationResponse response = TestUtils.createVersionWithBatchData(
             parentControllerClient,
             storeName,
             INT_KEY_SCHEMA,
             INT_VALUE_SCHEMA,
-            IntStream.range(0, initialKeyCount).mapToObj(i -> new AbstractMap.SimpleEntry<>(i, value)));
+            IntStream.range(0, initialKeyCount).mapToObj(i -> new AbstractMap.SimpleEntry<>(i, value)),
+            pubSubProducerAdapterFactory);
         // Verify the data can be ingested by classical Venice before proceeding.
         TestUtils.waitForNonDeterministicPushCompletion(
             response.getKafkaTopic(),
@@ -169,12 +176,18 @@ public class DaVinciClusterAgnosticTest {
       // Verify new push works
       final int newValue = 1000;
       try (ControllerClient parentControllerClient = new ControllerClient(clusterNames[0], parentControllerURLs)) {
+        PubSubProducerAdapterFactory pubSubProducerAdapterFactory = multiClusterVenice.getClusters()
+            .get(clusterNames[0])
+            .getPubSubBrokerWrapper()
+            .getPubSubClientsFactory()
+            .getProducerAdapterFactory();
         VersionCreationResponse versionCreationResponse = TestUtils.createVersionWithBatchData(
             parentControllerClient,
             stores.get(0),
             INT_KEY_SCHEMA,
             INT_VALUE_SCHEMA,
-            IntStream.range(0, initialKeyCount).mapToObj(i -> new AbstractMap.SimpleEntry<>(i, newValue)));
+            IntStream.range(0, initialKeyCount).mapToObj(i -> new AbstractMap.SimpleEntry<>(i, newValue)),
+            pubSubProducerAdapterFactory);
         TestUtils.waitForNonDeterministicPushCompletion(
             versionCreationResponse.getKafkaTopic(),
             parentControllerClient,
@@ -195,12 +208,18 @@ public class DaVinciClusterAgnosticTest {
       migrateStore(migratedStoreName, srcCluster, destCluster);
       final int newMigratedStoreValue = 999;
       try (ControllerClient parentControllerClient = new ControllerClient(destCluster, parentControllerURLs)) {
+        PubSubProducerAdapterFactory pubSubProducerAdapterFactory = multiClusterVenice.getClusters()
+            .get(destCluster)
+            .getPubSubBrokerWrapper()
+            .getPubSubClientsFactory()
+            .getProducerAdapterFactory();
         VersionCreationResponse versionCreationResponse = TestUtils.createVersionWithBatchData(
             parentControllerClient,
             migratedStoreName,
             INT_KEY_SCHEMA,
             INT_VALUE_SCHEMA,
-            IntStream.range(0, initialKeyCount).mapToObj(i -> new AbstractMap.SimpleEntry<>(i, newMigratedStoreValue)));
+            IntStream.range(0, initialKeyCount).mapToObj(i -> new AbstractMap.SimpleEntry<>(i, newMigratedStoreValue)),
+            pubSubProducerAdapterFactory);
         TestUtils.waitForNonDeterministicPushCompletion(
             versionCreationResponse.getKafkaTopic(),
             parentControllerClient,
@@ -248,6 +267,11 @@ public class DaVinciClusterAgnosticTest {
     GenericRecord record1 = new GenericData.Record(schema);
     record1.put("field1", 1);
     try (ControllerClient parentControllerClient = new ControllerClient(cluster, parentControllerURLs)) {
+      PubSubProducerAdapterFactory pubSubProducerAdapterFactory = multiClusterVenice.getClusters()
+          .get(cluster)
+          .getPubSubBrokerWrapper()
+          .getPubSubClientsFactory()
+          .getProducerAdapterFactory();
       // Create venice store and materialize the corresponding meta system store
       assertFalse(
           parentControllerClient.createNewStore(storeName, "venice-test", INT_KEY_SCHEMA, RECORD_VALUE_SCHEMA)
@@ -258,7 +282,8 @@ public class DaVinciClusterAgnosticTest {
           INT_KEY_SCHEMA,
           RECORD_VALUE_SCHEMA,
           IntStream.range(0, keyCount).mapToObj(i -> new AbstractMap.SimpleEntry<>(i, record1)),
-          1);
+          1,
+          pubSubProducerAdapterFactory);
       // Verify the data can be ingested by classical Venice before proceeding.
       TestUtils.waitForNonDeterministicPushCompletion(
           response.getKafkaTopic(),
@@ -301,7 +326,8 @@ public class DaVinciClusterAgnosticTest {
             INT_KEY_SCHEMA,
             NEW_RECORD_VALUE_SCHEMA,
             IntStream.range(0, keyCount).mapToObj(i -> new AbstractMap.SimpleEntry<>(i, record2)),
-            2);
+            2,
+            pubSubProducerAdapterFactory);
 
         TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, true, () -> {
           for (int k = 0; k < keyCount; k++) {

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/DaVinciComputeTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/DaVinciComputeTest.java
@@ -32,6 +32,7 @@ import com.linkedin.venice.integration.utils.DaVinciTestContext;
 import com.linkedin.venice.integration.utils.ServiceFactory;
 import com.linkedin.venice.integration.utils.VeniceClusterWrapper;
 import com.linkedin.venice.integration.utils.VeniceRouterWrapper;
+import com.linkedin.venice.pubsub.api.PubSubProducerAdapterFactory;
 import com.linkedin.venice.serialization.VeniceKafkaSerializer;
 import com.linkedin.venice.serialization.avro.VeniceAvroKafkaSerializer;
 import com.linkedin.venice.utils.PropertyBuilder;
@@ -79,6 +80,8 @@ public class DaVinciComputeTest {
   private static final int TEST_TIMEOUT = 120_000; // ms
 
   private VeniceClusterWrapper cluster;
+
+  private PubSubProducerAdapterFactory pubSubProducerAdapterFactory;
   private D2Client d2Client;
   private final List<Float> mfEmbedding = generateRandomFloatList(100);
   private final List<Float> companiesEmbedding = generateRandomFloatList(100);
@@ -144,6 +147,8 @@ public class DaVinciComputeTest {
         .setZkStartupTimeout(3, TimeUnit.SECONDS)
         .build();
     D2ClientUtils.startClient(d2Client);
+    pubSubProducerAdapterFactory =
+        cluster.getPubSubBrokerWrapper().getPubSubClientsFactory().getProducerAdapterFactory();
   }
 
   @AfterClass
@@ -179,7 +184,8 @@ public class DaVinciComputeTest {
 
     VersionCreationResponse newVersion = cluster.getNewVersion(storeName);
     String topic = newVersion.getKafkaTopic();
-    VeniceWriterFactory vwFactory = TestUtils.getVeniceWriterFactory(cluster.getPubSubBrokerWrapper().getAddress());
+    VeniceWriterFactory vwFactory =
+        TestUtils.getVeniceWriterFactory(cluster.getPubSubBrokerWrapper().getAddress(), pubSubProducerAdapterFactory);
 
     VeniceKafkaSerializer keySerializer = new VeniceAvroKafkaSerializer(DEFAULT_KEY_SCHEMA);
     VeniceKafkaSerializer valueSerializer = new VeniceAvroKafkaSerializer(VALUE_SCHEMA_FOR_COMPUTE_NULLABLE_LIST_FIELD);
@@ -286,7 +292,8 @@ public class DaVinciComputeTest {
 
     VersionCreationResponse newVersion = cluster.getNewVersion(storeName);
     String topic = newVersion.getKafkaTopic();
-    VeniceWriterFactory vwFactory = TestUtils.getVeniceWriterFactory(cluster.getPubSubBrokerWrapper().getAddress());
+    VeniceWriterFactory vwFactory =
+        TestUtils.getVeniceWriterFactory(cluster.getPubSubBrokerWrapper().getAddress(), pubSubProducerAdapterFactory);
 
     VeniceKafkaSerializer keySerializer = new VeniceAvroKafkaSerializer(DEFAULT_KEY_SCHEMA);
     VeniceKafkaSerializer valueSerializer = new VeniceAvroKafkaSerializer(VALUE_SCHEMA_FOR_COMPUTE);
@@ -422,7 +429,8 @@ public class DaVinciComputeTest {
 
     VersionCreationResponse newVersion = cluster.getNewVersion(storeName);
     String topic = newVersion.getKafkaTopic();
-    VeniceWriterFactory vwFactory = TestUtils.getVeniceWriterFactory(cluster.getPubSubBrokerWrapper().getAddress());
+    VeniceWriterFactory vwFactory =
+        TestUtils.getVeniceWriterFactory(cluster.getPubSubBrokerWrapper().getAddress(), pubSubProducerAdapterFactory);
 
     VeniceKafkaSerializer keySerializer = new VeniceAvroKafkaSerializer(DEFAULT_KEY_SCHEMA);
     VeniceKafkaSerializer valueSerializer = new VeniceAvroKafkaSerializer(VALUE_SCHEMA_FOR_COMPUTE);
@@ -534,7 +542,8 @@ public class DaVinciComputeTest {
 
     VersionCreationResponse newVersion = cluster.getNewVersion(storeName);
     String topic = newVersion.getKafkaTopic();
-    VeniceWriterFactory vwFactory = TestUtils.getVeniceWriterFactory(cluster.getPubSubBrokerWrapper().getAddress());
+    VeniceWriterFactory vwFactory =
+        TestUtils.getVeniceWriterFactory(cluster.getPubSubBrokerWrapper().getAddress(), pubSubProducerAdapterFactory);
 
     VeniceKafkaSerializer keySerializer = new VeniceAvroKafkaSerializer(KEY_SCHEMA_STEAMING_COMPUTE);
     VeniceKafkaSerializer valueSerializer = new VeniceAvroKafkaSerializer(VALUE_SCHEMA_STREAMING_COMPUTE);
@@ -632,7 +641,8 @@ public class DaVinciComputeTest {
 
     VersionCreationResponse newVersion = cluster.getNewVersion(storeName);
     String topic = newVersion.getKafkaTopic();
-    VeniceWriterFactory vwFactory = TestUtils.getVeniceWriterFactory(cluster.getPubSubBrokerWrapper().getAddress());
+    VeniceWriterFactory vwFactory =
+        TestUtils.getVeniceWriterFactory(cluster.getPubSubBrokerWrapper().getAddress(), pubSubProducerAdapterFactory);
 
     VeniceKafkaSerializer keySerializer = new VeniceAvroKafkaSerializer(KEY_SCHEMA_PARTIAL_KEY_LOOKUP);
     VeniceKafkaSerializer valueSerializer = new VeniceAvroKafkaSerializer(VALUE_SCHEMA_FOR_COMPUTE);
@@ -732,7 +742,8 @@ public class DaVinciComputeTest {
 
     VersionCreationResponse newVersion = cluster.getNewVersion(storeName);
     String topic = newVersion.getKafkaTopic();
-    VeniceWriterFactory vwFactory = TestUtils.getVeniceWriterFactory(cluster.getPubSubBrokerWrapper().getAddress());
+    VeniceWriterFactory vwFactory =
+        TestUtils.getVeniceWriterFactory(cluster.getPubSubBrokerWrapper().getAddress(), pubSubProducerAdapterFactory);
 
     VeniceKafkaSerializer keySerializer = new VeniceAvroKafkaSerializer(KEY_SCHEMA_PARTIAL_KEY_LOOKUP);
     VeniceKafkaSerializer valueSerializer = new VeniceAvroKafkaSerializer(VALUE_SCHEMA_FOR_COMPUTE);

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/DaVinciComputeTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/DaVinciComputeTest.java
@@ -179,7 +179,7 @@ public class DaVinciComputeTest {
 
     VersionCreationResponse newVersion = cluster.getNewVersion(storeName);
     String topic = newVersion.getKafkaTopic();
-    VeniceWriterFactory vwFactory = TestUtils.getVeniceWriterFactory(cluster.getKafka().getAddress());
+    VeniceWriterFactory vwFactory = TestUtils.getVeniceWriterFactory(cluster.getPubSubBrokerWrapper().getAddress());
 
     VeniceKafkaSerializer keySerializer = new VeniceAvroKafkaSerializer(DEFAULT_KEY_SCHEMA);
     VeniceKafkaSerializer valueSerializer = new VeniceAvroKafkaSerializer(VALUE_SCHEMA_FOR_COMPUTE_NULLABLE_LIST_FIELD);
@@ -286,7 +286,7 @@ public class DaVinciComputeTest {
 
     VersionCreationResponse newVersion = cluster.getNewVersion(storeName);
     String topic = newVersion.getKafkaTopic();
-    VeniceWriterFactory vwFactory = TestUtils.getVeniceWriterFactory(cluster.getKafka().getAddress());
+    VeniceWriterFactory vwFactory = TestUtils.getVeniceWriterFactory(cluster.getPubSubBrokerWrapper().getAddress());
 
     VeniceKafkaSerializer keySerializer = new VeniceAvroKafkaSerializer(DEFAULT_KEY_SCHEMA);
     VeniceKafkaSerializer valueSerializer = new VeniceAvroKafkaSerializer(VALUE_SCHEMA_FOR_COMPUTE);
@@ -422,7 +422,7 @@ public class DaVinciComputeTest {
 
     VersionCreationResponse newVersion = cluster.getNewVersion(storeName);
     String topic = newVersion.getKafkaTopic();
-    VeniceWriterFactory vwFactory = TestUtils.getVeniceWriterFactory(cluster.getKafka().getAddress());
+    VeniceWriterFactory vwFactory = TestUtils.getVeniceWriterFactory(cluster.getPubSubBrokerWrapper().getAddress());
 
     VeniceKafkaSerializer keySerializer = new VeniceAvroKafkaSerializer(DEFAULT_KEY_SCHEMA);
     VeniceKafkaSerializer valueSerializer = new VeniceAvroKafkaSerializer(VALUE_SCHEMA_FOR_COMPUTE);
@@ -534,7 +534,7 @@ public class DaVinciComputeTest {
 
     VersionCreationResponse newVersion = cluster.getNewVersion(storeName);
     String topic = newVersion.getKafkaTopic();
-    VeniceWriterFactory vwFactory = TestUtils.getVeniceWriterFactory(cluster.getKafka().getAddress());
+    VeniceWriterFactory vwFactory = TestUtils.getVeniceWriterFactory(cluster.getPubSubBrokerWrapper().getAddress());
 
     VeniceKafkaSerializer keySerializer = new VeniceAvroKafkaSerializer(KEY_SCHEMA_STEAMING_COMPUTE);
     VeniceKafkaSerializer valueSerializer = new VeniceAvroKafkaSerializer(VALUE_SCHEMA_STREAMING_COMPUTE);
@@ -632,7 +632,7 @@ public class DaVinciComputeTest {
 
     VersionCreationResponse newVersion = cluster.getNewVersion(storeName);
     String topic = newVersion.getKafkaTopic();
-    VeniceWriterFactory vwFactory = TestUtils.getVeniceWriterFactory(cluster.getKafka().getAddress());
+    VeniceWriterFactory vwFactory = TestUtils.getVeniceWriterFactory(cluster.getPubSubBrokerWrapper().getAddress());
 
     VeniceKafkaSerializer keySerializer = new VeniceAvroKafkaSerializer(KEY_SCHEMA_PARTIAL_KEY_LOOKUP);
     VeniceKafkaSerializer valueSerializer = new VeniceAvroKafkaSerializer(VALUE_SCHEMA_FOR_COMPUTE);
@@ -732,7 +732,7 @@ public class DaVinciComputeTest {
 
     VersionCreationResponse newVersion = cluster.getNewVersion(storeName);
     String topic = newVersion.getKafkaTopic();
-    VeniceWriterFactory vwFactory = TestUtils.getVeniceWriterFactory(cluster.getKafka().getAddress());
+    VeniceWriterFactory vwFactory = TestUtils.getVeniceWriterFactory(cluster.getPubSubBrokerWrapper().getAddress());
 
     VeniceKafkaSerializer keySerializer = new VeniceAvroKafkaSerializer(KEY_SCHEMA_PARTIAL_KEY_LOOKUP);
     VeniceKafkaSerializer valueSerializer = new VeniceAvroKafkaSerializer(VALUE_SCHEMA_FOR_COMPUTE);

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/DaVinciLiveUpdateSuppressionTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/DaVinciLiveUpdateSuppressionTest.java
@@ -102,7 +102,7 @@ public class DaVinciLiveUpdateSuppressionTest {
 
     VersionCreationResponse newVersion = cluster.getNewVersion(storeName);
     String topic = newVersion.getKafkaTopic();
-    VeniceWriterFactory vwFactory = TestUtils.getVeniceWriterFactory(cluster.getKafka().getAddress());
+    VeniceWriterFactory vwFactory = TestUtils.getVeniceWriterFactory(cluster.getPubSubBrokerWrapper().getAddress());
     VeniceKafkaSerializer keySerializer = new VeniceAvroKafkaSerializer(DEFAULT_KEY_SCHEMA);
     VeniceKafkaSerializer valueSerializer = new VeniceAvroKafkaSerializer(DEFAULT_VALUE_SCHEMA);
 

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/DaVinciLiveUpdateSuppressionTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/DaVinciLiveUpdateSuppressionTest.java
@@ -23,6 +23,7 @@ import com.linkedin.venice.integration.utils.ServiceFactory;
 import com.linkedin.venice.integration.utils.VeniceClusterWrapper;
 import com.linkedin.venice.meta.IngestionMode;
 import com.linkedin.venice.meta.Version;
+import com.linkedin.venice.pubsub.api.PubSubProducerAdapterFactory;
 import com.linkedin.venice.serialization.VeniceKafkaSerializer;
 import com.linkedin.venice.serialization.avro.VeniceAvroKafkaSerializer;
 import com.linkedin.venice.utils.DataProviderUtils;
@@ -102,7 +103,10 @@ public class DaVinciLiveUpdateSuppressionTest {
 
     VersionCreationResponse newVersion = cluster.getNewVersion(storeName);
     String topic = newVersion.getKafkaTopic();
-    VeniceWriterFactory vwFactory = TestUtils.getVeniceWriterFactory(cluster.getPubSubBrokerWrapper().getAddress());
+    PubSubProducerAdapterFactory pubSubProducerAdapterFactory =
+        cluster.getPubSubBrokerWrapper().getPubSubClientsFactory().getProducerAdapterFactory();
+    VeniceWriterFactory vwFactory =
+        TestUtils.getVeniceWriterFactory(cluster.getPubSubBrokerWrapper().getAddress(), pubSubProducerAdapterFactory);
     VeniceKafkaSerializer keySerializer = new VeniceAvroKafkaSerializer(DEFAULT_KEY_SCHEMA);
     VeniceKafkaSerializer valueSerializer = new VeniceAvroKafkaSerializer(DEFAULT_VALUE_SCHEMA);
 

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/DataRecoveryTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/DataRecoveryTest.java
@@ -45,6 +45,7 @@ import com.linkedin.venice.integration.utils.VeniceTwoLayerMultiRegionMultiClust
 import com.linkedin.venice.meta.DataReplicationPolicy;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.pubsub.PubSubTopicRepository;
+import com.linkedin.venice.pubsub.api.PubSubProducerAdapterFactory;
 import com.linkedin.venice.samza.VeniceSystemFactory;
 import com.linkedin.venice.utils.TestUtils;
 import com.linkedin.venice.utils.Utils;
@@ -220,12 +221,15 @@ public class DataRecoveryTest {
           false,
           -1);
       Assert.assertFalse(versionCreationResponse.isError());
+      PubSubProducerAdapterFactory pubSubProducerAdapterFactory =
+          childDatacenters.get(0).getKafkaBrokerWrapper().getPubSubClientsFactory().getProducerAdapterFactory();
       TestUtils.writeBatchData(
           versionCreationResponse,
           STRING_SCHEMA,
           STRING_SCHEMA,
           IntStream.range(0, 10).mapToObj(i -> new AbstractMap.SimpleEntry<>(String.valueOf(i), String.valueOf(i))),
-          HelixReadOnlySchemaRepository.VALUE_SCHEMA_STARTING_ID);
+          HelixReadOnlySchemaRepository.VALUE_SCHEMA_STARTING_ID,
+          pubSubProducerAdapterFactory);
       TestUtils.waitForNonDeterministicPushCompletion(
           versionCreationResponse.getKafkaTopic(),
           parentControllerClient,

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/MetaSystemStoreTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/MetaSystemStoreTest.java
@@ -85,10 +85,13 @@ public class MetaSystemStoreTest {
     controllerClient = venice.getControllerClient();
     parentZkServer = ServiceFactory.getZkServer();
     parentController = ServiceFactory.getVeniceController(
-        new VeniceControllerCreateOptions.Builder(venice.getClusterName(), parentZkServer, venice.getKafka())
-            .childControllers(venice.getVeniceControllers().toArray(new VeniceControllerWrapper[0]))
-            .extraProperties(testProperties)
-            .build());
+        new VeniceControllerCreateOptions.Builder(
+            venice.getClusterName(),
+            parentZkServer,
+            venice.getPubSubBrokerWrapper())
+                .childControllers(venice.getVeniceControllers().toArray(new VeniceControllerWrapper[0]))
+                .extraProperties(testProperties)
+                .build());
   }
 
   @AfterClass

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/NearlineE2ELatencyTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/NearlineE2ELatencyTest.java
@@ -20,6 +20,7 @@ import com.linkedin.venice.integration.utils.VeniceControllerWrapper;
 import com.linkedin.venice.integration.utils.VeniceMultiClusterWrapper;
 import com.linkedin.venice.integration.utils.VeniceTwoLayerMultiRegionMultiClusterWrapper;
 import com.linkedin.venice.meta.Version;
+import com.linkedin.venice.pubsub.api.PubSubProducerAdapterFactory;
 import com.linkedin.venice.server.VeniceServer;
 import com.linkedin.venice.utils.TestUtils;
 import com.linkedin.venice.utils.Utils;
@@ -124,12 +125,15 @@ public class NearlineE2ELatencyTest {
           false,
           -1);
       Assert.assertFalse(versionCreationResponse.isError());
+      PubSubProducerAdapterFactory pubSubProducerAdapterFactory =
+          childDatacenters.get(0).getKafkaBrokerWrapper().getPubSubClientsFactory().getProducerAdapterFactory();
       TestUtils.writeBatchData(
           versionCreationResponse,
           STRING_SCHEMA,
           STRING_SCHEMA,
           IntStream.range(0, 10).mapToObj(i -> new AbstractMap.SimpleEntry<>(String.valueOf(i), String.valueOf(i))),
-          HelixReadOnlySchemaRepository.VALUE_SCHEMA_STARTING_ID);
+          HelixReadOnlySchemaRepository.VALUE_SCHEMA_STARTING_ID,
+          pubSubProducerAdapterFactory);
       JobStatusQueryResponse response = parentControllerCli
           .queryDetailedJobStatus(versionCreationResponse.getKafkaTopic(), childDatacenters.get(0).getRegionName());
       Assert.assertFalse(response.isError());

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/OneTouchDataRecoveryTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/OneTouchDataRecoveryTest.java
@@ -15,6 +15,7 @@ import com.linkedin.venice.integration.utils.VeniceMultiClusterWrapper;
 import com.linkedin.venice.integration.utils.VeniceTwoLayerMultiRegionMultiClusterWrapper;
 import com.linkedin.venice.meta.RegionPushDetails;
 import com.linkedin.venice.meta.Version;
+import com.linkedin.venice.pubsub.api.PubSubProducerAdapterFactory;
 import com.linkedin.venice.utils.TestUtils;
 import com.linkedin.venice.utils.Utils;
 import com.linkedin.venice.utils.VeniceProperties;
@@ -119,12 +120,18 @@ public class OneTouchDataRecoveryTest {
           false,
           -1);
       Assert.assertFalse(versionCreationResponse.isError());
+      PubSubProducerAdapterFactory pubSubProducerAdapterFactory = multiRegionMultiClusterWrapper.getChildRegions()
+          .get(0)
+          .getKafkaBrokerWrapper()
+          .getPubSubClientsFactory()
+          .getProducerAdapterFactory();
       TestUtils.writeBatchData(
           versionCreationResponse,
           STRING_SCHEMA,
           STRING_SCHEMA,
           IntStream.range(0, 10).mapToObj(i -> new AbstractMap.SimpleEntry<>(String.valueOf(i), String.valueOf(i))),
-          HelixReadOnlySchemaRepository.VALUE_SCHEMA_STARTING_ID);
+          HelixReadOnlySchemaRepository.VALUE_SCHEMA_STARTING_ID,
+          pubSubProducerAdapterFactory);
       JobStatusQueryResponse response = parentControllerCli
           .queryDetailedJobStatus(versionCreationResponse.getKafkaTopic(), childDatacenters.get(0).getRegionName());
       Assert.assertFalse(response.isError());

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/PartialUpdateTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/PartialUpdateTest.java
@@ -199,7 +199,7 @@ public class PartialUpdateTest {
       Properties props =
           IntegrationTestPushUtils.defaultVPJProps(multiRegionMultiClusterWrapper, "dummyInputPath", storeName);
       props.setProperty(SOURCE_KAFKA, "true");
-      props.setProperty(KAFKA_INPUT_BROKER_URL, veniceCluster.getKafka().getAddress());
+      props.setProperty(KAFKA_INPUT_BROKER_URL, veniceCluster.getPubSubBrokerWrapper().getAddress());
       props.setProperty(KAFKA_INPUT_MAX_RECORDS_PER_MAPPER, "5");
       // intentionally stop re-consuming from RT so stale records don't affect the testing results
       // props.put(REWIND_TIME_IN_SECONDS_OVERRIDE, 0);
@@ -626,7 +626,7 @@ public class PartialUpdateTest {
       Properties props =
           IntegrationTestPushUtils.defaultVPJProps(multiRegionMultiClusterWrapper, "dummyInputPath", storeName);
       props.setProperty(SOURCE_KAFKA, "true");
-      props.setProperty(KAFKA_INPUT_BROKER_URL, veniceCluster.getKafka().getAddress());
+      props.setProperty(KAFKA_INPUT_BROKER_URL, veniceCluster.getPubSubBrokerWrapper().getAddress());
       props.setProperty(KAFKA_INPUT_MAX_RECORDS_PER_MAPPER, "5");
       // intentionally stop re-consuming from RT so stale records don't affect the testing results
       props.put(REWIND_TIME_IN_SECONDS_OVERRIDE, 0);

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/ParticipantStoreTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/ParticipantStoreTest.java
@@ -90,7 +90,7 @@ public class ParticipantStoreTest {
         new VeniceControllerCreateOptions.Builder(
             veniceClusterWrapper.getClusterName(),
             parentZk,
-            veniceClusterWrapper.getKafka())
+            veniceClusterWrapper.getPubSubBrokerWrapper())
                 .childControllers(veniceClusterWrapper.getVeniceControllers().toArray(new VeniceControllerWrapper[0]))
                 .extraProperties(controllerConfig)
                 .build());

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/StoragePersonaTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/StoragePersonaTest.java
@@ -51,7 +51,7 @@ public class StoragePersonaTest {
     venice = ServiceFactory.getVeniceCluster(1, 1, 1, 2, 1000000, false, false, extraProperties);
     parentZk = ServiceFactory.getZkServer();
     parentController = ServiceFactory.getVeniceController(
-        new VeniceControllerCreateOptions.Builder(venice.getClusterName(), parentZk, venice.getKafka())
+        new VeniceControllerCreateOptions.Builder(venice.getClusterName(), parentZk, venice.getPubSubBrokerWrapper())
             .childControllers(new VeniceControllerWrapper[] { venice.getLeaderVeniceController() })
             .build());
     controllerClient = new ControllerClient(venice.getClusterName(), parentController.getControllerUrl());

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestActiveActiveIngestion.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestActiveActiveIngestion.java
@@ -325,7 +325,7 @@ public class TestActiveActiveIngestion {
 
     // run repush
     props.setProperty(SOURCE_KAFKA, "true");
-    props.setProperty(KAFKA_INPUT_BROKER_URL, clusterWrapper.getKafka().getAddress());
+    props.setProperty(KAFKA_INPUT_BROKER_URL, clusterWrapper.getPubSubBrokerWrapper().getAddress());
     props.setProperty(KAFKA_INPUT_MAX_RECORDS_PER_MAPPER, "5");
     // intentionally stop re-consuming from RT so stale records don't affect the testing results
     props.put(REWIND_TIME_IN_SECONDS_OVERRIDE, 0);
@@ -649,7 +649,7 @@ public class TestActiveActiveIngestion {
     });
     // run repush
     props.setProperty(SOURCE_KAFKA, "true");
-    props.setProperty(KAFKA_INPUT_BROKER_URL, clusterWrapper.getKafka().getAddress());
+    props.setProperty(KAFKA_INPUT_BROKER_URL, clusterWrapper.getPubSubBrokerWrapper().getAddress());
     props.setProperty(KAFKA_INPUT_MAX_RECORDS_PER_MAPPER, "5");
     // intentionally stop re-consuming from RT so stale records don't affect the testing results
     props.put(REWIND_TIME_IN_SECONDS_OVERRIDE, 0);

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestActiveActiveIngestion.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestActiveActiveIngestion.java
@@ -58,6 +58,7 @@ import com.linkedin.venice.integration.utils.ZkServerWrapper;
 import com.linkedin.venice.meta.VeniceUserStoreType;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.pubsub.api.PubSubMessage;
+import com.linkedin.venice.pubsub.api.PubSubProducerAdapterFactory;
 import com.linkedin.venice.pushmonitor.ExecutionStatus;
 import com.linkedin.venice.samza.VeniceSystemFactory;
 import com.linkedin.venice.samza.VeniceSystemProducer;
@@ -487,7 +488,9 @@ public class TestActiveActiveIngestion {
 
     String topic = versionCreationResponse.getKafkaTopic();
     String kafkaUrl = versionCreationResponse.getKafkaBootstrapServers();
-    VeniceWriterFactory veniceWriterFactory = TestUtils.getVeniceWriterFactory(kafkaUrl);
+    PubSubProducerAdapterFactory pubSubProducerAdapterFactory =
+        clusterWrapper.getPubSubBrokerWrapper().getPubSubClientsFactory().getProducerAdapterFactory();
+    VeniceWriterFactory veniceWriterFactory = TestUtils.getVeniceWriterFactory(kafkaUrl, pubSubProducerAdapterFactory);
     try (VeniceWriter<byte[], byte[], byte[]> veniceWriter =
         veniceWriterFactory.createVeniceWriter(new VeniceWriterOptions.Builder(topic).build())) {
       veniceWriter.broadcastStartOfPush(true, Collections.emptyMap());

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestBatch.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestBatch.java
@@ -389,7 +389,7 @@ public abstract class TestBatch {
     // Collect the dict of the current version.
     String sourceTopic = Version.composeKafkaTopic(storeName, 2);
     Properties props = new Properties();
-    props.setProperty(KAFKA_BOOTSTRAP_SERVERS, veniceCluster.getKafka().getAddress());
+    props.setProperty(KAFKA_BOOTSTRAP_SERVERS, veniceCluster.getPubSubBrokerWrapper().getAddress());
     VeniceProperties veniceProperties = new VeniceProperties(props);
     ByteBuffer sourceDict = DictionaryUtils.readDictionaryFromKafka(sourceTopic, veniceProperties);
 
@@ -643,7 +643,7 @@ public abstract class TestBatch {
         properties -> {
           properties.setProperty(SOURCE_KAFKA, "true");
           properties.setProperty(KAFKA_INPUT_TOPIC, Version.composeKafkaTopic(storeName, 1));
-          properties.setProperty(KAFKA_INPUT_BROKER_URL, veniceCluster.getKafka().getAddress());
+          properties.setProperty(KAFKA_INPUT_BROKER_URL, veniceCluster.getPubSubBrokerWrapper().getAddress());
           /**
            * This is used to make sure the first mapper doesn't contain any real messages, but just control messages.
            * So that {@link com.linkedin.venice.hadoop.AbstractVeniceMapper#maybeSprayAllPartitions} won't be invoked.
@@ -781,7 +781,7 @@ public abstract class TestBatch {
           inputDir -> new KeyAndValueSchemas(Schema.create(Schema.Type.NULL), Schema.create(Schema.Type.NULL)),
           properties -> {
             properties.setProperty(SOURCE_KAFKA, "true");
-            properties.setProperty(KAFKA_INPUT_BROKER_URL, veniceCluster.getKafka().getAddress());
+            properties.setProperty(KAFKA_INPUT_BROKER_URL, veniceCluster.getPubSubBrokerWrapper().getAddress());
             properties.setProperty(KAFKA_INPUT_MAX_RECORDS_PER_MAPPER, "5");
             properties.setProperty(KAFKA_INPUT_COMBINER_ENABLED, combiner);
           },
@@ -915,7 +915,7 @@ public abstract class TestBatch {
     testStoreWithLargeValues(enableChunkingOnPushJob, properties -> {
       properties.setProperty(SOURCE_KAFKA, "true");
       properties.setProperty(VENICE_STORE_NAME_PROP, storeName);
-      properties.setProperty(KAFKA_INPUT_BROKER_URL, veniceCluster.getKafka().getAddress());
+      properties.setProperty(KAFKA_INPUT_BROKER_URL, veniceCluster.getPubSubBrokerWrapper().getAddress());
       properties.setProperty(KAFKA_INPUT_MAX_RECORDS_PER_MAPPER, "5");
       properties.setProperty(SEND_CONTROL_MESSAGES_DIRECTLY, sendDirectControlMessage.toString());
     }, storeName);
@@ -1299,7 +1299,7 @@ public abstract class TestBatch {
         properties -> {
           properties.setProperty(SOURCE_KAFKA, "true");
           properties.setProperty(KAFKA_INPUT_TOPIC, Version.composeKafkaTopic(storeName, 1));
-          properties.setProperty(KAFKA_INPUT_BROKER_URL, veniceCluster.getKafka().getAddress());
+          properties.setProperty(KAFKA_INPUT_BROKER_URL, veniceCluster.getPubSubBrokerWrapper().getAddress());
           properties.setProperty(KAFKA_INPUT_MAX_RECORDS_PER_MAPPER, "5");
         },
         emptyValidator,

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestChangeCaptureIngestion.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestChangeCaptureIngestion.java
@@ -256,7 +256,7 @@ public class TestChangeCaptureIngestion {
     });
     // run repush
     props.setProperty(SOURCE_KAFKA, "true");
-    props.setProperty(KAFKA_INPUT_BROKER_URL, clusterWrapper.getKafka().getAddress());
+    props.setProperty(KAFKA_INPUT_BROKER_URL, clusterWrapper.getPubSubBrokerWrapper().getAddress());
     props.setProperty(KAFKA_INPUT_MAX_RECORDS_PER_MAPPER, "5");
     // intentionally stop re-consuming from RT so stale records don't affect the testing results
     props.put(REWIND_TIME_IN_SECONDS_OVERRIDE, 0);

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestEmptyPush.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestEmptyPush.java
@@ -83,7 +83,7 @@ public class TestEmptyPush {
                     DEFAULT_KAFKA_OPERATION_TIMEOUT_MS,
                     100,
                     0l,
-                    venice.getKafka().getAddress(),
+                    venice.getKafka(),
                     venice.getPubSubTopicRepository())
                 .getTopicManager()) {
       controllerClient.createNewStore(storeName, "owner", STRING_SCHEMA, STRING_SCHEMA);

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestEmptyPush.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestEmptyPush.java
@@ -64,7 +64,7 @@ public class TestEmptyPush {
   }
 
   private ByteBuffer getDictFromTopic(String topic, Properties properties) {
-    String kafkaUrl = venice.getKafka().getAddress();
+    String kafkaUrl = venice.getPubSubBrokerWrapper().getAddress();
 
     Properties props = (Properties) properties.clone();
     props.setProperty(KAFKA_BOOTSTRAP_SERVERS, kafkaUrl);
@@ -83,7 +83,7 @@ public class TestEmptyPush {
                     DEFAULT_KAFKA_OPERATION_TIMEOUT_MS,
                     100,
                     0l,
-                    venice.getKafka(),
+                    venice.getPubSubBrokerWrapper(),
                     venice.getPubSubTopicRepository())
                 .getTopicManager()) {
       controllerClient.createNewStore(storeName, "owner", STRING_SCHEMA, STRING_SCHEMA);

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestHelixCustomizedView.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestHelixCustomizedView.java
@@ -13,6 +13,7 @@ import com.linkedin.venice.helix.ZkClientFactory;
 import com.linkedin.venice.integration.utils.ServiceFactory;
 import com.linkedin.venice.integration.utils.VeniceClusterWrapper;
 import com.linkedin.venice.meta.Version;
+import com.linkedin.venice.pubsub.api.PubSubProducerAdapterFactory;
 import com.linkedin.venice.pushmonitor.ExecutionStatus;
 import com.linkedin.venice.routerapi.ReplicaState;
 import com.linkedin.venice.routerapi.ResourceStateResponse;
@@ -98,7 +99,10 @@ public class TestHelixCustomizedView {
     controllerClient = new ControllerClient(veniceCluster.getClusterName(), veniceCluster.getAllControllersURLs());
     keySerializer = new VeniceAvroKafkaSerializer(KEY_SCHEMA_STR);
     valueSerializer = new VeniceAvroKafkaSerializer(VALUE_SCHEMA_STR);
-    veniceWriter = TestUtils.getVeniceWriterFactory(veniceCluster.getPubSubBrokerWrapper().getAddress())
+    PubSubProducerAdapterFactory pubSubProducerAdapterFactory =
+        veniceCluster.getPubSubBrokerWrapper().getPubSubClientsFactory().getProducerAdapterFactory();
+    veniceWriter = TestUtils
+        .getVeniceWriterFactory(veniceCluster.getPubSubBrokerWrapper().getAddress(), pubSubProducerAdapterFactory)
         .createVeniceWriter(
             new VeniceWriterOptions.Builder(storeVersionName).setKeySerializer(keySerializer)
                 .setValueSerializer(valueSerializer)

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestHelixCustomizedView.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestHelixCustomizedView.java
@@ -98,7 +98,7 @@ public class TestHelixCustomizedView {
     controllerClient = new ControllerClient(veniceCluster.getClusterName(), veniceCluster.getAllControllersURLs());
     keySerializer = new VeniceAvroKafkaSerializer(KEY_SCHEMA_STR);
     valueSerializer = new VeniceAvroKafkaSerializer(VALUE_SCHEMA_STR);
-    veniceWriter = TestUtils.getVeniceWriterFactory(veniceCluster.getKafka().getAddress())
+    veniceWriter = TestUtils.getVeniceWriterFactory(veniceCluster.getPubSubBrokerWrapper().getAddress())
         .createVeniceWriter(
             new VeniceWriterOptions.Builder(storeVersionName).setKeySerializer(keySerializer)
                 .setValueSerializer(valueSerializer)

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestHybrid.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestHybrid.java
@@ -185,9 +185,12 @@ public class TestHybrid {
             ServiceFactory.getVeniceCluster(1, 2, 1, 1, 1000000, false, false, extraProperties);
         ZkServerWrapper parentZk = ServiceFactory.getZkServer();
         VeniceControllerWrapper parentController = ServiceFactory.getVeniceController(
-            new VeniceControllerCreateOptions.Builder(venice.getClusterName(), parentZk, venice.getKafka())
-                .childControllers(new VeniceControllerWrapper[] { venice.getLeaderVeniceController() })
-                .build());
+            new VeniceControllerCreateOptions.Builder(
+                venice.getClusterName(),
+                parentZk,
+                venice.getPubSubBrokerWrapper())
+                    .childControllers(new VeniceControllerWrapper[] { venice.getLeaderVeniceController() })
+                    .build());
         ControllerClient controllerClient =
             new ControllerClient(venice.getClusterName(), parentController.getControllerUrl());
         TopicManager topicManager =
@@ -196,7 +199,7 @@ public class TestHybrid {
                     DEFAULT_KAFKA_OPERATION_TIMEOUT_MS,
                     100,
                     0l,
-                    venice.getKafka(),
+                    venice.getPubSubBrokerWrapper(),
                     venice.getPubSubTopicRepository())
                 .getTopicManager()) {
       long streamingRewindSeconds = 25L;
@@ -329,7 +332,7 @@ public class TestHybrid {
                       DEFAULT_KAFKA_OPERATION_TIMEOUT_MS,
                       100,
                       0l,
-                      venice.getKafka(),
+                      venice.getPubSubBrokerWrapper(),
                       sharedVenice.getPubSubTopicRepository())
                   .getTopicManager()) {
 
@@ -862,7 +865,7 @@ public class TestHybrid {
        *  Build a producer that writes to {@link tmpTopic1}
        */
       Properties veniceWriterProperties = new Properties();
-      veniceWriterProperties.put(KAFKA_BOOTSTRAP_SERVERS, venice.getKafka().getAddress());
+      veniceWriterProperties.put(KAFKA_BOOTSTRAP_SERVERS, venice.getPubSubBrokerWrapper().getAddress());
       AvroSerializer<String> stringSerializer = new AvroSerializer(Schema.parse(STRING_SCHEMA));
       try (VeniceWriter<byte[], byte[], byte[]> tmpWriter1 = TestUtils.getVeniceWriterFactory(veniceWriterProperties)
           .createVeniceWriter(new VeniceWriterOptions.Builder(tmpTopic1.getName()).build())) {
@@ -902,12 +905,12 @@ public class TestHybrid {
               .createVeniceWriter(new VeniceWriterOptions.Builder(Version.composeRealTimeTopic(storeName)).build());) {
         // Build a producer to produce 2 TS messages into RT
         realTimeTopicWriter.broadcastTopicSwitch(
-            Collections.singletonList(venice.getKafka().getAddress()),
+            Collections.singletonList(venice.getPubSubBrokerWrapper().getAddress()),
             tmpTopic1.getName(),
             -1L,
             null);
         realTimeTopicWriter.broadcastTopicSwitch(
-            Collections.singletonList(venice.getKafka().getAddress()),
+            Collections.singletonList(venice.getPubSubBrokerWrapper().getAddress()),
             tmpTopic2.getName(),
             -1L,
             null);
@@ -1148,7 +1151,7 @@ public class TestHybrid {
                       DEFAULT_KAFKA_OPERATION_TIMEOUT_MS,
                       100L,
                       MIN_COMPACTION_LAG,
-                      venice.getKafka(),
+                      venice.getPubSubBrokerWrapper(),
                       sharedVenice.getPubSubTopicRepository())
                   .getTopicManager()) {
 
@@ -1284,7 +1287,7 @@ public class TestHybrid {
         String value2 = "duplicated_message_test_value_2";
         String key2 = "duplicated_message_test_key_2";
         Properties veniceWriterProperties = new Properties();
-        veniceWriterProperties.put(KAFKA_BOOTSTRAP_SERVERS, venice.getKafka().getAddress());
+        veniceWriterProperties.put(KAFKA_BOOTSTRAP_SERVERS, venice.getPubSubBrokerWrapper().getAddress());
         AvroSerializer<String> stringSerializer = new AvroSerializer(Schema.parse(STRING_SCHEMA));
         AvroGenericDeserializer<String> stringDeserializer =
             new AvroGenericDeserializer<>(Schema.parse(STRING_SCHEMA), Schema.parse(STRING_SCHEMA));
@@ -1567,7 +1570,7 @@ public class TestHybrid {
       runVPJ(vpjProperties, 1, controllerClient);
 
       Properties veniceWriterProperties = new Properties();
-      veniceWriterProperties.put(KAFKA_BOOTSTRAP_SERVERS, venice.getKafka().getAddress());
+      veniceWriterProperties.put(KAFKA_BOOTSTRAP_SERVERS, venice.getPubSubBrokerWrapper().getAddress());
       /**
        * Set max segment elapsed time to 0 to enforce creating small segments aggressively
        */
@@ -1633,7 +1636,7 @@ public class TestHybrid {
       // Do a VPJ push
       runVPJ(vpjProperties, 1, controllerClient);
       Properties veniceWriterProperties = new Properties();
-      veniceWriterProperties.put(KAFKA_BOOTSTRAP_SERVERS, venice.getKafka().getAddress());
+      veniceWriterProperties.put(KAFKA_BOOTSTRAP_SERVERS, venice.getPubSubBrokerWrapper().getAddress());
       /**
        * Set max segment elapsed time to 0 to enforce creating small segments aggressively
        */

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestHybrid.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestHybrid.java
@@ -196,7 +196,7 @@ public class TestHybrid {
                     DEFAULT_KAFKA_OPERATION_TIMEOUT_MS,
                     100,
                     0l,
-                    venice.getKafka().getAddress(),
+                    venice.getKafka(),
                     venice.getPubSubTopicRepository())
                 .getTopicManager()) {
       long streamingRewindSeconds = 25L;
@@ -329,7 +329,7 @@ public class TestHybrid {
                       DEFAULT_KAFKA_OPERATION_TIMEOUT_MS,
                       100,
                       0l,
-                      venice.getKafka().getAddress(),
+                      venice.getKafka(),
                       sharedVenice.getPubSubTopicRepository())
                   .getTopicManager()) {
 
@@ -1148,7 +1148,7 @@ public class TestHybrid {
                       DEFAULT_KAFKA_OPERATION_TIMEOUT_MS,
                       100L,
                       MIN_COMPACTION_LAG,
-                      venice.getKafka().getAddress(),
+                      venice.getKafka(),
                       sharedVenice.getPubSubTopicRepository())
                   .getTopicManager()) {
 

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestHybridQuota.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestHybridQuota.java
@@ -137,7 +137,7 @@ public class TestHybridQuota {
                     DEFAULT_KAFKA_OPERATION_TIMEOUT_MS,
                     100L,
                     0L,
-                    sharedVenice.getKafka().getAddress(),
+                    sharedVenice.getKafka(),
                     sharedVenice.getPubSubTopicRepository())
                 .getTopicManager()) {
 

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestHybridQuota.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestHybridQuota.java
@@ -137,7 +137,7 @@ public class TestHybridQuota {
                     DEFAULT_KAFKA_OPERATION_TIMEOUT_MS,
                     100L,
                     0L,
-                    sharedVenice.getKafka(),
+                    sharedVenice.getPubSubBrokerWrapper(),
                     sharedVenice.getPubSubTopicRepository())
                 .getTopicManager()) {
 

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestLeaderReplicaFailover.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestLeaderReplicaFailover.java
@@ -24,6 +24,7 @@ import com.linkedin.venice.meta.Instance;
 import com.linkedin.venice.meta.OfflinePushStrategy;
 import com.linkedin.venice.meta.VeniceUserStoreType;
 import com.linkedin.venice.meta.Version;
+import com.linkedin.venice.pubsub.api.PubSubProducerAdapterFactory;
 import com.linkedin.venice.serializer.AvroSerializer;
 import com.linkedin.venice.utils.TestUtils;
 import com.linkedin.venice.utils.Time;
@@ -133,7 +134,9 @@ public class TestLeaderReplicaFailover {
 
     String topic = versionCreationResponse.getKafkaTopic();
     String kafkaUrl = versionCreationResponse.getKafkaBootstrapServers();
-    VeniceWriterFactory veniceWriterFactory = TestUtils.getVeniceWriterFactory(kafkaUrl);
+    PubSubProducerAdapterFactory pubSubProducerAdapterFactory =
+        clusterWrapper.getPubSubBrokerWrapper().getPubSubClientsFactory().getProducerAdapterFactory();
+    VeniceWriterFactory veniceWriterFactory = TestUtils.getVeniceWriterFactory(kafkaUrl, pubSubProducerAdapterFactory);
     HelixBaseRoutingRepository routingDataRepo = clusterWrapper.getLeaderVeniceController()
         .getVeniceHelixAdmin()
         .getHelixVeniceClusterResources(clusterWrapper.getClusterName())

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestStoreUpdateStoragePersona.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestStoreUpdateStoragePersona.java
@@ -39,7 +39,7 @@ public class TestStoreUpdateStoragePersona {
     venice = ServiceFactory.getVeniceCluster(1, 1, 1, 2, 1000000, false, false, extraProperties);
     parentZk = ServiceFactory.getZkServer();
     parentController = ServiceFactory.getVeniceController(
-        new VeniceControllerCreateOptions.Builder(venice.getClusterName(), parentZk, venice.getKafka())
+        new VeniceControllerCreateOptions.Builder(venice.getClusterName(), parentZk, venice.getPubSubBrokerWrapper())
             .childControllers(new VeniceControllerWrapper[] { venice.getLeaderVeniceController() })
             .build());
     controllerClient = new ControllerClient(venice.getClusterName(), parentController.getControllerUrl());

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestVsonStoreBatch.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestVsonStoreBatch.java
@@ -265,7 +265,7 @@ public class TestVsonStoreBatch {
         properties -> {
           properties.setProperty(SOURCE_KAFKA, "true");
           properties.setProperty(KAFKA_INPUT_TOPIC, Version.composeKafkaTopic(storeName, 1));
-          properties.setProperty(KAFKA_INPUT_BROKER_URL, veniceCluster.getKafka().getAddress());
+          properties.setProperty(KAFKA_INPUT_BROKER_URL, veniceCluster.getPubSubBrokerWrapper().getAddress());
           properties.setProperty(KAFKA_INPUT_MAX_RECORDS_PER_MAPPER, "5");
         },
         validator,

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/fastclient/utils/AbstractClientEndToEndSetup.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/fastclient/utils/AbstractClientEndToEndSetup.java
@@ -42,6 +42,7 @@ import com.linkedin.venice.integration.utils.VeniceClusterCreateOptions;
 import com.linkedin.venice.integration.utils.VeniceClusterWrapper;
 import com.linkedin.venice.integration.utils.VeniceRouterWrapper;
 import com.linkedin.venice.meta.Version;
+import com.linkedin.venice.pubsub.api.PubSubProducerAdapterFactory;
 import com.linkedin.venice.serialization.VeniceKafkaSerializer;
 import com.linkedin.venice.serialization.avro.VeniceAvroKafkaSerializer;
 import com.linkedin.venice.system.store.MetaStoreDataType;
@@ -247,7 +248,10 @@ public abstract class AbstractClientEndToEndSetup {
     keySerializer = new VeniceAvroKafkaSerializer(KEY_SCHEMA_STR);
     valueSerializer = new VeniceAvroKafkaSerializer(VALUE_SCHEMA_STR);
 
-    veniceWriter = TestUtils.getVeniceWriterFactory(veniceCluster.getPubSubBrokerWrapper().getAddress())
+    PubSubProducerAdapterFactory pubSubProducerAdapterFactory =
+        veniceCluster.getPubSubBrokerWrapper().getPubSubClientsFactory().getProducerAdapterFactory();
+    veniceWriter = TestUtils
+        .getVeniceWriterFactory(veniceCluster.getPubSubBrokerWrapper().getAddress(), pubSubProducerAdapterFactory)
         .createVeniceWriter(
             new VeniceWriterOptions.Builder(storeVersionName).setKeySerializer(keySerializer)
                 .setValueSerializer(valueSerializer)

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/fastclient/utils/AbstractClientEndToEndSetup.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/fastclient/utils/AbstractClientEndToEndSetup.java
@@ -247,7 +247,7 @@ public abstract class AbstractClientEndToEndSetup {
     keySerializer = new VeniceAvroKafkaSerializer(KEY_SCHEMA_STR);
     valueSerializer = new VeniceAvroKafkaSerializer(VALUE_SCHEMA_STR);
 
-    veniceWriter = TestUtils.getVeniceWriterFactory(veniceCluster.getKafka().getAddress())
+    veniceWriter = TestUtils.getVeniceWriterFactory(veniceCluster.getPubSubBrokerWrapper().getAddress())
         .createVeniceWriter(
             new VeniceWriterOptions.Builder(storeVersionName).setKeySerializer(keySerializer)
                 .setValueSerializer(valueSerializer)

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/hadoop/TestVenicePushJob.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/hadoop/TestVenicePushJob.java
@@ -600,7 +600,7 @@ public class TestVenicePushJob {
     // setup repush job settings
     props.setProperty(SOURCE_KAFKA, "true");
     props.setProperty(KAFKA_INPUT_TOPIC, Version.composeKafkaTopic(storeName, 1));
-    props.setProperty(KAFKA_INPUT_BROKER_URL, veniceCluster.getKafka().getAddress());
+    props.setProperty(KAFKA_INPUT_BROKER_URL, veniceCluster.getPubSubBrokerWrapper().getAddress());
     props.setProperty(KAFKA_INPUT_MAX_RECORDS_PER_MAPPER, "5");
     // This repush should succeed
     TestWriteUtils.runPushJob("Test push job", props);

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/hadoop/input/kafka/TestKafkaInputFormat.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/hadoop/input/kafka/TestKafkaInputFormat.java
@@ -9,6 +9,7 @@ import com.linkedin.venice.integration.utils.PubSubBrokerWrapper;
 import com.linkedin.venice.integration.utils.ServiceFactory;
 import com.linkedin.venice.kafka.TopicManager;
 import com.linkedin.venice.pubsub.PubSubTopicRepository;
+import com.linkedin.venice.pubsub.api.PubSubProducerAdapterFactory;
 import com.linkedin.venice.utils.IntegrationTestPushUtils;
 import com.linkedin.venice.utils.TestUtils;
 import com.linkedin.venice.utils.Time;
@@ -61,7 +62,10 @@ public class TestKafkaInputFormat {
   public String getTopic(int numRecord, int numPartition) {
     String topicName = Utils.getUniqueString("test_kafka_input_format") + "_v1";
     manager.createTopic(pubSubTopicRepository.getTopic(topicName), numPartition, 1, true);
-    VeniceWriterFactory veniceWriterFactory = TestUtils.getVeniceWriterFactory(pubSubBrokerWrapper.getAddress());
+    PubSubProducerAdapterFactory pubSubProducerAdapterFactory =
+        pubSubBrokerWrapper.getPubSubClientsFactory().getProducerAdapterFactory();
+    VeniceWriterFactory veniceWriterFactory =
+        TestUtils.getVeniceWriterFactory(pubSubBrokerWrapper.getAddress(), pubSubProducerAdapterFactory);
     try (VeniceWriter<byte[], byte[], byte[]> veniceWriter =
         veniceWriterFactory.createVeniceWriter(new VeniceWriterOptions.Builder(topicName).build())) {
       for (int i = 0; i < numRecord; ++i) {

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/hadoop/input/kafka/TestKafkaInputFormat.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/hadoop/input/kafka/TestKafkaInputFormat.java
@@ -47,7 +47,7 @@ public class TestKafkaInputFormat {
                 DEFAULT_KAFKA_OPERATION_TIMEOUT_MS,
                 100L,
                 24 * Time.MS_PER_HOUR,
-                pubSubBrokerWrapper.getAddress(),
+                pubSubBrokerWrapper,
                 pubSubTopicRepository)
             .getTopicManager();
   }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/hadoop/input/kafka/TestKafkaInputRecordReader.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/hadoop/input/kafka/TestKafkaInputRecordReader.java
@@ -61,7 +61,9 @@ public class TestKafkaInputRecordReader {
   public String getTopic(int numRecord, Pair<Integer, Integer> updateRange, Pair<Integer, Integer> deleteRange) {
     String topicName = Utils.getUniqueString("test_kafka_input_format") + "_v1";
     manager.createTopic(pubSubTopicRepository.getTopic(topicName), 1, 1, true);
-    VeniceWriterFactory veniceWriterFactory = TestUtils.getVeniceWriterFactory(pubSubBrokerWrapper.getAddress());
+    VeniceWriterFactory veniceWriterFactory = TestUtils.getVeniceWriterFactory(
+        pubSubBrokerWrapper.getAddress(),
+        pubSubBrokerWrapper.getPubSubClientsFactory().getProducerAdapterFactory());
     try (VeniceWriter<byte[], byte[], byte[]> veniceWriter =
         veniceWriterFactory.createVeniceWriter(new VeniceWriterOptions.Builder(topicName).build())) {
       for (int i = 0; i < numRecord; ++i) {

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/hadoop/input/kafka/TestKafkaInputRecordReader.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/hadoop/input/kafka/TestKafkaInputRecordReader.java
@@ -34,20 +34,20 @@ public class TestKafkaInputRecordReader {
   private static final String KAFKA_MESSAGE_KEY_PREFIX = "key_";
   private static final String KAFKA_MESSAGE_VALUE_PREFIX = "value_";
 
-  private PubSubBrokerWrapper kafka;
+  private PubSubBrokerWrapper pubSubBrokerWrapper;
   private TopicManager manager;
   private PubSubTopicRepository pubSubTopicRepository = new PubSubTopicRepository();
 
   @BeforeClass
   public void setUp() {
-    kafka = ServiceFactory.getPubSubBroker();
+    pubSubBrokerWrapper = ServiceFactory.getPubSubBroker();
     manager =
         IntegrationTestPushUtils
             .getTopicManagerRepo(
                 DEFAULT_KAFKA_OPERATION_TIMEOUT_MS,
                 100L,
                 24 * Time.MS_PER_HOUR,
-                kafka.getAddress(),
+                pubSubBrokerWrapper,
                 pubSubTopicRepository)
             .getTopicManager();
   }
@@ -55,13 +55,13 @@ public class TestKafkaInputRecordReader {
   @AfterClass
   public void cleanUp() throws IOException {
     Utils.closeQuietlyWithErrorLogged(manager);
-    Utils.closeQuietlyWithErrorLogged(kafka);
+    Utils.closeQuietlyWithErrorLogged(pubSubBrokerWrapper);
   }
 
   public String getTopic(int numRecord, Pair<Integer, Integer> updateRange, Pair<Integer, Integer> deleteRange) {
     String topicName = Utils.getUniqueString("test_kafka_input_format") + "_v1";
     manager.createTopic(pubSubTopicRepository.getTopic(topicName), 1, 1, true);
-    VeniceWriterFactory veniceWriterFactory = TestUtils.getVeniceWriterFactory(kafka.getAddress());
+    VeniceWriterFactory veniceWriterFactory = TestUtils.getVeniceWriterFactory(pubSubBrokerWrapper.getAddress());
     try (VeniceWriter<byte[], byte[], byte[]> veniceWriter =
         veniceWriterFactory.createVeniceWriter(new VeniceWriterOptions.Builder(topicName).build())) {
       for (int i = 0; i < numRecord; ++i) {
@@ -83,7 +83,7 @@ public class TestKafkaInputRecordReader {
   @Test
   public void testNext() throws IOException {
     JobConf conf = new JobConf();
-    conf.set(KAFKA_INPUT_BROKER_URL, kafka.getAddress());
+    conf.set(KAFKA_INPUT_BROKER_URL, pubSubBrokerWrapper.getAddress());
     conf.set(VenicePushJob.KAFKA_SOURCE_KEY_SCHEMA_STRING_PROP, ChunkedKeySuffix.SCHEMA$.toString());
     String topic = getTopic(100, new Pair<>(-1, -1), new Pair<>(-1, -1));
     conf.set(KAFKA_INPUT_TOPIC, topic);
@@ -106,7 +106,7 @@ public class TestKafkaInputRecordReader {
   @Test
   public void testNextWithDeleteMessage() throws IOException {
     JobConf conf = new JobConf();
-    conf.set(KAFKA_INPUT_BROKER_URL, kafka.getAddress());
+    conf.set(KAFKA_INPUT_BROKER_URL, pubSubBrokerWrapper.getAddress());
     String topic = getTopic(100, new Pair<>(-1, -1), new Pair<>(0, 10));
     conf.set(KAFKA_INPUT_TOPIC, topic);
     conf.set(VenicePushJob.KAFKA_SOURCE_KEY_SCHEMA_STRING_PROP, ChunkedKeySuffix.SCHEMA$.toString());
@@ -134,7 +134,7 @@ public class TestKafkaInputRecordReader {
   @Test
   public void testNextWithUpdateMessage() throws IOException {
     JobConf conf = new JobConf();
-    conf.set(KAFKA_INPUT_BROKER_URL, kafka.getAddress());
+    conf.set(KAFKA_INPUT_BROKER_URL, pubSubBrokerWrapper.getAddress());
     String topic = getTopic(100, new Pair<>(21, 30), new Pair<>(11, 20));
     conf.set(KAFKA_INPUT_TOPIC, topic);
     conf.set(VenicePushJob.KAFKA_SOURCE_KEY_SCHEMA_STRING_PROP, ChunkedKeySuffix.SCHEMA$.toString());

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceClusterWrapper.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceClusterWrapper.java
@@ -31,6 +31,7 @@ import com.linkedin.venice.helix.Replica;
 import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.pubsub.PubSubTopicRepository;
+import com.linkedin.venice.pubsub.api.PubSubProducerAdapterFactory;
 import com.linkedin.venice.pushmonitor.ExecutionStatus;
 import com.linkedin.venice.serialization.VeniceKafkaSerializer;
 import com.linkedin.venice.serialization.avro.AvroProtocolDefinition;
@@ -109,6 +110,8 @@ public class VeniceClusterWrapper extends ProcessWrapper {
   // TODO: pass it to every venice component.
   private final PubSubTopicRepository pubSubTopicRepository = new PubSubTopicRepository();
 
+  private final PubSubProducerAdapterFactory pubSubProducerAdapterFactory;
+
   private static Process veniceClusterProcess;
   // Controller discovery URLs are controllers that's created outside of this cluster wrapper but are overseeing the
   // cluster. e.g. controllers in a multi cluster wrapper.
@@ -145,6 +148,7 @@ public class VeniceClusterWrapper extends ProcessWrapper {
     this.veniceRouterWrappers = veniceRouterWrappers;
     this.clusterToD2 = clusterToD2;
     this.clusterToServerD2 = clusterToServerD2;
+    this.pubSubProducerAdapterFactory = pubSubBrokerWrapper.getPubSubClientsFactory().getProducerAdapterFactory();
   }
 
   static ServiceProvider<VeniceClusterWrapper> generateService(VeniceClusterCreateOptions options) {
@@ -758,7 +762,7 @@ public class VeniceClusterWrapper extends ProcessWrapper {
     Properties properties = new Properties();
     properties.put(KAFKA_BOOTSTRAP_SERVERS, pubSubBrokerWrapper.getAddress());
     properties.put(ZOOKEEPER_ADDRESS, zkServerWrapper.getAddress());
-    VeniceWriterFactory factory = TestUtils.getVeniceWriterFactory(properties);
+    VeniceWriterFactory factory = TestUtils.getVeniceWriterFactory(properties, pubSubProducerAdapterFactory);
     String stringSchema = "\"string\"";
     VeniceKafkaSerializer keySerializer = new VeniceAvroKafkaSerializer(stringSchema);
     VeniceKafkaSerializer valueSerializer = new VeniceAvroKafkaSerializer(stringSchema);
@@ -774,7 +778,7 @@ public class VeniceClusterWrapper extends ProcessWrapper {
     properties.put(KAFKA_BOOTSTRAP_SERVERS, pubSubBrokerWrapper.getSSLAddress());
     properties.put(ZOOKEEPER_ADDRESS, zkServerWrapper.getAddress());
     properties.putAll(KafkaTestUtils.getLocalKafkaClientSSLConfig());
-    VeniceWriterFactory factory = TestUtils.getVeniceWriterFactory(properties);
+    VeniceWriterFactory factory = TestUtils.getVeniceWriterFactory(properties, pubSubProducerAdapterFactory);
 
     String stringSchema = "\"string\"";
     VeniceKafkaSerializer keySerializer = new VeniceAvroKafkaSerializer(stringSchema);
@@ -984,7 +988,8 @@ public class VeniceClusterWrapper extends ProcessWrapper {
         batchData,
         HelixReadOnlySchemaRepository.VALUE_SCHEMA_STARTING_ID,
         compressionStrategy,
-        compressionDictionaryGenerator);
+        compressionDictionaryGenerator,
+        pubSubProducerAdapterFactory);
 
     int versionId = response.getVersion();
     waitVersion(storeName, versionId, controllerClient.get());

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceClusterWrapper.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceClusterWrapper.java
@@ -443,7 +443,7 @@ public class VeniceClusterWrapper extends ProcessWrapper {
     return zkServerWrapper;
   }
 
-  public PubSubBrokerWrapper getKafka() {
+  public PubSubBrokerWrapper getPubSubBrokerWrapper() {
     return pubSubBrokerWrapper;
   }
 

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceServerWrapper.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceServerWrapper.java
@@ -14,6 +14,9 @@ import static com.linkedin.venice.ConfigKeys.LOCAL_D2_ZK_HOST;
 import static com.linkedin.venice.ConfigKeys.MAX_ONLINE_OFFLINE_STATE_TRANSITION_THREAD_NUMBER;
 import static com.linkedin.venice.ConfigKeys.PARTICIPANT_MESSAGE_CONSUMPTION_DELAY_MS;
 import static com.linkedin.venice.ConfigKeys.PERSISTENCE_TYPE;
+import static com.linkedin.venice.ConfigKeys.PUB_SUB_ADMIN_ADAPTER_FACTORY_CLASS;
+import static com.linkedin.venice.ConfigKeys.PUB_SUB_CONSUMER_ADAPTER_FACTORY_CLASS;
+import static com.linkedin.venice.ConfigKeys.PUB_SUB_PRODUCER_ADAPTER_FACTORY_CLASS;
 import static com.linkedin.venice.ConfigKeys.SERVER_DISK_FULL_THRESHOLD;
 import static com.linkedin.venice.ConfigKeys.SERVER_HTTP2_INBOUND_ENABLED;
 import static com.linkedin.venice.ConfigKeys.SERVER_INGESTION_ISOLATION_APPLICATION_PORT;
@@ -228,6 +231,15 @@ public class VeniceServerWrapper extends ProcessWrapper implements MetricsAware 
           .put(SYSTEM_SCHEMA_INITIALIZATION_AT_START_TIME_ENABLED, true)
           .put(LOCAL_CONTROLLER_D2_SERVICE_NAME, VeniceControllerWrapper.D2_SERVICE_NAME)
           .put(LOCAL_D2_ZK_HOST, zkAddress)
+          .put(
+              PUB_SUB_PRODUCER_ADAPTER_FACTORY_CLASS,
+              pubSubBrokerWrapper.getPubSubClientsFactory().getProducerAdapterFactory().getClass().getName())
+          .put(
+              PUB_SUB_CONSUMER_ADAPTER_FACTORY_CLASS,
+              pubSubBrokerWrapper.getPubSubClientsFactory().getConsumerAdapterFactory().getClass().getName())
+          .put(
+              PUB_SUB_ADMIN_ADAPTER_FACTORY_CLASS,
+              pubSubBrokerWrapper.getPubSubClientsFactory().getAdminAdapterFactory().getClass().getName())
           .put(configProperties);
       if (sslToKafka) {
         serverPropsBuilder.put(KAFKA_SECURITY_PROTOCOL, SecurityProtocol.SSL.name);
@@ -277,8 +289,7 @@ public class VeniceServerWrapper extends ProcessWrapper implements MetricsAware 
                 .setMetricsRepository(new MetricsRepository())
                 .setSslFactory(sslFactory)
                 .setClientConfigForConsumer(consumerClientConfig)
-                .setServiceDiscoveryAnnouncers(d2Servers)
-                .setPubSubClientsFactory(pubSubBrokerWrapper.getPubSubClientsFactory());
+                .setServiceDiscoveryAnnouncers(d2Servers);
 
         TestVeniceServer server = new TestVeniceServer(serverContextBuilder.build());
         return new VeniceServerWrapper(
@@ -407,7 +418,6 @@ public class VeniceServerWrapper extends ProcessWrapper implements MetricsAware 
             .setMetricsRepository(new MetricsRepository())
             .setSslFactory(sslFactory)
             .setClientConfigForConsumer(consumerClientConfig)
-            .setPubSubClientsFactory(pubSubClientsFactory)
             .build());
   }
 
@@ -481,7 +491,6 @@ public class VeniceServerWrapper extends ProcessWrapper implements MetricsAware 
         .setMetricsRepository(new MetricsRepository())
         .setSslFactory(ssl ? SslUtils.getVeniceLocalSslFactory() : null)
         .setClientConfigForConsumer(consumerClientConfig)
-        .setPubSubClientsFactory(ServiceFactory.getPubSubClientsFactory())
         .build();
     TestVeniceServer server = new TestVeniceServer(serverContext);
 

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceTwoLayerMultiRegionMultiClusterWrapper.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceTwoLayerMultiRegionMultiClusterWrapper.java
@@ -460,8 +460,8 @@ public class VeniceTwoLayerMultiRegionMultiClusterWrapper extends ProcessWrapper
             clusterWrapper.getRegionName(),
             clusterWrapper.getAllControllersURLs(),
             clusterWrapper.getZk(),
-            clusterWrapper.getKafka());
-        LOGGER.info("--> broker: {}", clusterWrapper.getKafka());
+            clusterWrapper.getPubSubBrokerWrapper());
+        LOGGER.info("--> broker: {}", clusterWrapper.getPubSubBrokerWrapper());
         for (VeniceControllerWrapper controller: clusterWrapper.getVeniceControllers()) {
           LOGGER.info("--> Controller: {}", controller.getControllerUrl());
         }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/kafka/KafkaConsumptionTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/kafka/KafkaConsumptionTest.java
@@ -107,7 +107,7 @@ public class KafkaConsumptionTest {
                 DEFAULT_KAFKA_OPERATION_TIMEOUT_MS,
                 100L,
                 MIN_COMPACTION_LAG,
-                localPubSubBroker.getAddress(),
+                localPubSubBroker,
                 pubSubTopicRepository)
             .getTopicManager();
     Cache cacheNothingCache = mock(Cache.class);
@@ -123,7 +123,7 @@ public class KafkaConsumptionTest {
                 DEFAULT_KAFKA_OPERATION_TIMEOUT_MS,
                 100L,
                 MIN_COMPACTION_LAG,
-                remotePubSubBroker.getAddress(),
+                remotePubSubBroker,
                 pubSubTopicRepository)
             .getTopicManager();
     Cache remoteCacheNothingCache = mock(Cache.class);

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/kafka/KafkaConsumptionTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/kafka/KafkaConsumptionTest.java
@@ -135,7 +135,6 @@ public class KafkaConsumptionTest {
   public void cleanUp() {
     topicManager.close();
     localPubSubBroker.close();
-
     remoteTopicManager.close();
     remotePubSubBroker.close();
   }
@@ -178,7 +177,8 @@ public class KafkaConsumptionTest {
     doReturn(clusterUrlToIdMap).when(veniceServerConfig).getKafkaClusterUrlToIdMap();
 
     TopicExistenceChecker topicExistenceChecker = mock(TopicExistenceChecker.class);
-    PubSubConsumerAdapterFactory pubSubConsumerAdapterFactory = IntegrationTestPushUtils.getVeniceConsumerFactory();
+    PubSubConsumerAdapterFactory pubSubConsumerAdapterFactory =
+        localPubSubBroker.getPubSubClientsFactory().getConsumerAdapterFactory();
     PubSubMessageDeserializer pubSubDeserializer = new PubSubMessageDeserializer(
         new OptimizedKafkaValueSerializer(),
         new LandFillObjectPool<>(KafkaMessageEnvelope::new),

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/kafka/TopicManagerIntegrationTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/kafka/TopicManagerIntegrationTest.java
@@ -43,7 +43,7 @@ public class TopicManagerIntegrationTest extends TopicManagerTest {
                 500L,
                 100L,
                 MIN_COMPACTION_LAG,
-                pubSubBrokerWrapper.getAddress(),
+                pubSubBrokerWrapper,
                 new PubSubTopicRepository())
             .getTopicManager();
   }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/kafka/TopicManagerIntegrationTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/kafka/TopicManagerIntegrationTest.java
@@ -37,15 +37,9 @@ public class TopicManagerIntegrationTest extends TopicManagerTest {
     TestMockTime mockTime = new TestMockTime();
     pubSubBrokerWrapper = ServiceFactory.getPubSubBroker(
         new PubSubBrokerConfigs.Builder().setMockTime(mockTime).setRegionName(STANDALONE_REGION_NAME).build());
-    topicManager =
-        IntegrationTestPushUtils
-            .getTopicManagerRepo(
-                500L,
-                100L,
-                MIN_COMPACTION_LAG,
-                pubSubBrokerWrapper,
-                new PubSubTopicRepository())
-            .getTopicManager();
+    topicManager = IntegrationTestPushUtils
+        .getTopicManagerRepo(500L, 100L, MIN_COMPACTION_LAG, pubSubBrokerWrapper, new PubSubTopicRepository())
+        .getTopicManager();
   }
 
   protected PubSubProducerAdapter createPubSubProducerAdapter() {

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/kafka/partitionoffset/PartitionOffsetFetcherTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/kafka/partitionoffset/PartitionOffsetFetcherTest.java
@@ -8,8 +8,8 @@ import com.linkedin.venice.kafka.TopicDoesNotExistException;
 import com.linkedin.venice.pubsub.PubSubTopicPartitionImpl;
 import com.linkedin.venice.pubsub.PubSubTopicRepository;
 import com.linkedin.venice.pubsub.api.PubSubAdminAdapterFactory;
+import com.linkedin.venice.pubsub.api.PubSubConsumerAdapterFactory;
 import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
-import com.linkedin.venice.utils.IntegrationTestPushUtils;
 import com.linkedin.venice.utils.Time;
 import com.linkedin.venice.utils.Utils;
 import com.linkedin.venice.utils.VeniceProperties;
@@ -40,11 +40,14 @@ public class PartitionOffsetFetcherTest {
   @Test
   public void testGetPartitionLatestOffsetAndRetry() {
 
-    PubSubAdminAdapterFactory pubSubAdminAdapterFactory = IntegrationTestPushUtils.getVeniceAdminFactory();
+    PubSubAdminAdapterFactory pubSubAdminAdapterFactory =
+        pubSubBrokerWrapper.getPubSubClientsFactory().getAdminAdapterFactory();
+    PubSubConsumerAdapterFactory pubSubConsumerAdapterFactory =
+        pubSubBrokerWrapper.getPubSubClientsFactory().getConsumerAdapterFactory();
     Properties properties = new Properties();
     properties.setProperty(KAFKA_BOOTSTRAP_SERVERS, pubSubBrokerWrapper.getAddress());
     try (PartitionOffsetFetcher fetcher = PartitionOffsetFetcherFactory.createDefaultPartitionOffsetFetcher(
-        IntegrationTestPushUtils.getVeniceConsumerFactory(),
+        pubSubConsumerAdapterFactory,
         new VeniceProperties(properties),
         pubSubBrokerWrapper.getAddress(),
         Lazy.of(() -> pubSubAdminAdapterFactory.create(new VeniceProperties(properties), pubSubTopicRepository)),

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/kafka/ssl/TestProduceWithSSL.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/kafka/ssl/TestProduceWithSSL.java
@@ -164,7 +164,7 @@ public class TestProduceWithSSL {
 
     // Re-push with Kafka Input Format
     props.setProperty(VenicePushJob.SOURCE_KAFKA, "true");
-    props.setProperty(VenicePushJob.KAFKA_INPUT_BROKER_URL, cluster.getKafka().getSSLAddress());
+    props.setProperty(VenicePushJob.KAFKA_INPUT_BROKER_URL, cluster.getPubSubBrokerWrapper().getSSLAddress());
     TestWriteUtils.runPushJob("Test Kafka re-push job", props);
     TestUtils.waitForNonDeterministicCompletion(30, TimeUnit.SECONDS, () -> {
       int currentVersion = controllerClient.getStore(storeName).getStore().getCurrentVersion();

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/restart/TestRestartServerAfterDeletingSstFilesWithActiveActiveIngestion.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/restart/TestRestartServerAfterDeletingSstFilesWithActiveActiveIngestion.java
@@ -40,6 +40,7 @@ import com.linkedin.venice.integration.utils.VeniceTwoLayerMultiRegionMultiClust
 import com.linkedin.venice.meta.PersistenceType;
 import com.linkedin.venice.meta.VeniceUserStoreType;
 import com.linkedin.venice.meta.Version;
+import com.linkedin.venice.pubsub.api.PubSubProducerAdapterFactory;
 import com.linkedin.venice.pushmonitor.ExecutionStatus;
 import com.linkedin.venice.serializer.AvroSerializer;
 import com.linkedin.venice.utils.ByteUtils;
@@ -266,7 +267,9 @@ public class TestRestartServerAfterDeletingSstFilesWithActiveActiveIngestion {
 
     String topic = versionCreationResponse.getKafkaTopic();
     String kafkaUrl = versionCreationResponse.getKafkaBootstrapServers();
-    VeniceWriterFactory veniceWriterFactory = TestUtils.getVeniceWriterFactory(kafkaUrl);
+    PubSubProducerAdapterFactory pubSubProducerAdapterFactory =
+        clusterWrapper.getPubSubBrokerWrapper().getPubSubClientsFactory().getProducerAdapterFactory();
+    VeniceWriterFactory veniceWriterFactory = TestUtils.getVeniceWriterFactory(kafkaUrl, pubSubProducerAdapterFactory);
 
     startKey += numKeys; // to have different version having different set of keys
     int endKey = startKey + numKeys;

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/router/TestRead.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/router/TestRead.java
@@ -31,6 +31,7 @@ import com.linkedin.venice.integration.utils.VeniceClusterWrapper;
 import com.linkedin.venice.integration.utils.VeniceRouterWrapper;
 import com.linkedin.venice.integration.utils.VeniceServerWrapper;
 import com.linkedin.venice.meta.Version;
+import com.linkedin.venice.pubsub.api.PubSubProducerAdapterFactory;
 import com.linkedin.venice.router.api.VenicePathParser;
 import com.linkedin.venice.router.httpclient.StorageNodeClientType;
 import com.linkedin.venice.routerapi.ResourceStateResponse;
@@ -185,8 +186,10 @@ public abstract class TestRead {
     // TODO: Make serializers parameterized so we test them all.
     keySerializer = new VeniceAvroKafkaSerializer(KEY_SCHEMA_STR);
     valueSerializer = new VeniceAvroKafkaSerializer(VALUE_SCHEMA_STR);
-
-    veniceWriter = TestUtils.getVeniceWriterFactory(veniceCluster.getPubSubBrokerWrapper().getAddress())
+    PubSubProducerAdapterFactory pubSubProducerAdapterFactory =
+        veniceCluster.getPubSubBrokerWrapper().getPubSubClientsFactory().getProducerAdapterFactory();
+    veniceWriter = TestUtils
+        .getVeniceWriterFactory(veniceCluster.getPubSubBrokerWrapper().getAddress(), pubSubProducerAdapterFactory)
         .createVeniceWriter(
             new VeniceWriterOptions.Builder(storeVersionName).setKeySerializer(keySerializer)
                 .setValueSerializer(valueSerializer)

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/router/TestRead.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/router/TestRead.java
@@ -186,7 +186,7 @@ public abstract class TestRead {
     keySerializer = new VeniceAvroKafkaSerializer(KEY_SCHEMA_STR);
     valueSerializer = new VeniceAvroKafkaSerializer(VALUE_SCHEMA_STR);
 
-    veniceWriter = TestUtils.getVeniceWriterFactory(veniceCluster.getKafka().getAddress())
+    veniceWriter = TestUtils.getVeniceWriterFactory(veniceCluster.getPubSubBrokerWrapper().getAddress())
         .createVeniceWriter(
             new VeniceWriterOptions.Builder(storeVersionName).setKeySerializer(keySerializer)
                 .setValueSerializer(valueSerializer)

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/router/TestRouterRetry.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/router/TestRouterRetry.java
@@ -89,7 +89,7 @@ public class TestRouterRetry {
     VeniceKafkaSerializer keySerializer = new VeniceAvroKafkaSerializer(KEY_SCHEMA_STR);
     VeniceKafkaSerializer valueSerializer = new VeniceAvroKafkaSerializer(VALUE_SCHEMA_STR);
 
-    veniceWriter = TestUtils.getVeniceWriterFactory(veniceCluster.getKafka().getAddress())
+    veniceWriter = TestUtils.getVeniceWriterFactory(veniceCluster.getPubSubBrokerWrapper().getAddress())
         .createVeniceWriter(
             new VeniceWriterOptions.Builder(storeVersionName).setKeySerializer(keySerializer)
                 .setValueSerializer(valueSerializer)

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/router/TestRouterRetry.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/router/TestRouterRetry.java
@@ -14,6 +14,7 @@ import com.linkedin.venice.integration.utils.ServiceFactory;
 import com.linkedin.venice.integration.utils.VeniceClusterWrapper;
 import com.linkedin.venice.meta.OfflinePushStrategy;
 import com.linkedin.venice.meta.Version;
+import com.linkedin.venice.pubsub.api.PubSubProducerAdapterFactory;
 import com.linkedin.venice.serialization.VeniceKafkaSerializer;
 import com.linkedin.venice.serialization.avro.VeniceAvroKafkaSerializer;
 import com.linkedin.venice.tehuti.MetricsUtils;
@@ -88,8 +89,10 @@ public class TestRouterRetry {
 
     VeniceKafkaSerializer keySerializer = new VeniceAvroKafkaSerializer(KEY_SCHEMA_STR);
     VeniceKafkaSerializer valueSerializer = new VeniceAvroKafkaSerializer(VALUE_SCHEMA_STR);
-
-    veniceWriter = TestUtils.getVeniceWriterFactory(veniceCluster.getPubSubBrokerWrapper().getAddress())
+    PubSubProducerAdapterFactory pubSubProducerAdapterFactory =
+        veniceCluster.getPubSubBrokerWrapper().getPubSubClientsFactory().getProducerAdapterFactory();
+    veniceWriter = TestUtils
+        .getVeniceWriterFactory(veniceCluster.getPubSubBrokerWrapper().getAddress(), pubSubProducerAdapterFactory)
         .createVeniceWriter(
             new VeniceWriterOptions.Builder(storeVersionName).setKeySerializer(keySerializer)
                 .setValueSerializer(valueSerializer)

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/router/TestStreaming.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/router/TestStreaming.java
@@ -138,7 +138,7 @@ public class TestStreaming {
     compressorFactory = new CompressorFactory();
     VeniceCompressor compressor = compressorFactory.getCompressor(compressionStrategy);
 
-    veniceWriter = TestUtils.getVeniceWriterFactory(veniceCluster.getKafka().getAddress())
+    veniceWriter = TestUtils.getVeniceWriterFactory(veniceCluster.getPubSubBrokerWrapper().getAddress())
         .createVeniceWriter(new VeniceWriterOptions.Builder(storeVersionName).setKeySerializer(keySerializer).build());
 
     final int pushVersion = Version.parseVersionFromKafkaTopicName(storeVersionName);

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/router/TestStreaming.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/router/TestStreaming.java
@@ -33,6 +33,7 @@ import com.linkedin.venice.integration.utils.VeniceClusterWrapper;
 import com.linkedin.venice.integration.utils.VeniceRouterWrapper;
 import com.linkedin.venice.integration.utils.VeniceServerWrapper;
 import com.linkedin.venice.meta.Version;
+import com.linkedin.venice.pubsub.api.PubSubProducerAdapterFactory;
 import com.linkedin.venice.serialization.VeniceKafkaSerializer;
 import com.linkedin.venice.serialization.avro.VeniceAvroKafkaSerializer;
 import com.linkedin.venice.utils.DataProviderUtils;
@@ -137,8 +138,10 @@ public class TestStreaming {
 
     compressorFactory = new CompressorFactory();
     VeniceCompressor compressor = compressorFactory.getCompressor(compressionStrategy);
-
-    veniceWriter = TestUtils.getVeniceWriterFactory(veniceCluster.getPubSubBrokerWrapper().getAddress())
+    PubSubProducerAdapterFactory pubSubProducerAdapterFactory =
+        veniceCluster.getPubSubBrokerWrapper().getPubSubClientsFactory().getProducerAdapterFactory();
+    veniceWriter = TestUtils
+        .getVeniceWriterFactory(veniceCluster.getPubSubBrokerWrapper().getAddress(), pubSubProducerAdapterFactory)
         .createVeniceWriter(new VeniceWriterOptions.Builder(storeVersionName).setKeySerializer(keySerializer).build());
 
     final int pushVersion = Version.parseVersionFromKafkaTopicName(storeVersionName);

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/storagenode/ReadComputeValidationTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/storagenode/ReadComputeValidationTest.java
@@ -20,6 +20,7 @@ import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.integration.utils.ServiceFactory;
 import com.linkedin.venice.integration.utils.VeniceClusterWrapper;
 import com.linkedin.venice.meta.Version;
+import com.linkedin.venice.pubsub.api.PubSubProducerAdapterFactory;
 import com.linkedin.venice.pushmonitor.ExecutionStatus;
 import com.linkedin.venice.serialization.DefaultSerializer;
 import com.linkedin.venice.serialization.VeniceKafkaSerializer;
@@ -142,9 +143,10 @@ public class ReadComputeValidationTest {
     VersionCreationResponse newVersion = veniceCluster.getNewVersion(storeName);
     final int pushVersion = newVersion.getVersion();
     String topic = newVersion.getKafkaTopic();
-
-    VeniceWriterFactory vwFactory =
-        TestUtils.getVeniceWriterFactory(veniceCluster.getPubSubBrokerWrapper().getAddress());
+    PubSubProducerAdapterFactory pubSubProducerAdapterFactory =
+        veniceCluster.getPubSubBrokerWrapper().getPubSubClientsFactory().getProducerAdapterFactory();
+    VeniceWriterFactory vwFactory = TestUtils
+        .getVeniceWriterFactory(veniceCluster.getPubSubBrokerWrapper().getAddress(), pubSubProducerAdapterFactory);
     try (
         VeniceWriter<Object, byte[], byte[]> veniceWriter = vwFactory.createVeniceWriter(
             new VeniceWriterOptions.Builder(topic).setKeySerializer(keySerializer)
@@ -227,9 +229,10 @@ public class ReadComputeValidationTest {
     VersionCreationResponse newVersion = veniceCluster.getNewVersion(storeName);
     final int pushVersion = newVersion.getVersion();
     String topic = newVersion.getKafkaTopic();
-
-    VeniceWriterFactory vwFactory =
-        TestUtils.getVeniceWriterFactory(veniceCluster.getPubSubBrokerWrapper().getAddress());
+    PubSubProducerAdapterFactory pubSubProducerAdapterFactory =
+        veniceCluster.getPubSubBrokerWrapper().getPubSubClientsFactory().getProducerAdapterFactory();
+    VeniceWriterFactory vwFactory = TestUtils
+        .getVeniceWriterFactory(veniceCluster.getPubSubBrokerWrapper().getAddress(), pubSubProducerAdapterFactory);
     try (
         VeniceWriter<Object, byte[], byte[]> veniceWriter = vwFactory
             .createVeniceWriter(new VeniceWriterOptions.Builder(topic).setKeySerializer(keySerializer).build());
@@ -341,9 +344,10 @@ public class ReadComputeValidationTest {
     Map<Integer, GenericRecord> valuesByKey = new HashMap<>(2);
     valuesByKey.put(key1, value1);
     valuesByKey.put(key2, value2);
-
-    VeniceWriterFactory vwFactory =
-        TestUtils.getVeniceWriterFactory(veniceCluster.getPubSubBrokerWrapper().getAddress());
+    PubSubProducerAdapterFactory pubSubProducerAdapterFactory =
+        veniceCluster.getPubSubBrokerWrapper().getPubSubClientsFactory().getProducerAdapterFactory();
+    VeniceWriterFactory vwFactory = TestUtils
+        .getVeniceWriterFactory(veniceCluster.getPubSubBrokerWrapper().getAddress(), pubSubProducerAdapterFactory);
     try (
         VeniceWriter<Object, byte[], byte[]> veniceWriter = vwFactory
             .createVeniceWriter(new VeniceWriterOptions.Builder(topic).setKeySerializer(keySerializer).build());

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/storagenode/ReadComputeValidationTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/storagenode/ReadComputeValidationTest.java
@@ -143,7 +143,8 @@ public class ReadComputeValidationTest {
     final int pushVersion = newVersion.getVersion();
     String topic = newVersion.getKafkaTopic();
 
-    VeniceWriterFactory vwFactory = TestUtils.getVeniceWriterFactory(veniceCluster.getKafka().getAddress());
+    VeniceWriterFactory vwFactory =
+        TestUtils.getVeniceWriterFactory(veniceCluster.getPubSubBrokerWrapper().getAddress());
     try (
         VeniceWriter<Object, byte[], byte[]> veniceWriter = vwFactory.createVeniceWriter(
             new VeniceWriterOptions.Builder(topic).setKeySerializer(keySerializer)
@@ -227,7 +228,8 @@ public class ReadComputeValidationTest {
     final int pushVersion = newVersion.getVersion();
     String topic = newVersion.getKafkaTopic();
 
-    VeniceWriterFactory vwFactory = TestUtils.getVeniceWriterFactory(veniceCluster.getKafka().getAddress());
+    VeniceWriterFactory vwFactory =
+        TestUtils.getVeniceWriterFactory(veniceCluster.getPubSubBrokerWrapper().getAddress());
     try (
         VeniceWriter<Object, byte[], byte[]> veniceWriter = vwFactory
             .createVeniceWriter(new VeniceWriterOptions.Builder(topic).setKeySerializer(keySerializer).build());
@@ -340,7 +342,8 @@ public class ReadComputeValidationTest {
     valuesByKey.put(key1, value1);
     valuesByKey.put(key2, value2);
 
-    VeniceWriterFactory vwFactory = TestUtils.getVeniceWriterFactory(veniceCluster.getKafka().getAddress());
+    VeniceWriterFactory vwFactory =
+        TestUtils.getVeniceWriterFactory(veniceCluster.getPubSubBrokerWrapper().getAddress());
     try (
         VeniceWriter<Object, byte[], byte[]> veniceWriter = vwFactory
             .createVeniceWriter(new VeniceWriterOptions.Builder(topic).setKeySerializer(keySerializer).build());

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/storagenode/StorageNodeComputeTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/storagenode/StorageNodeComputeTest.java
@@ -177,7 +177,8 @@ public class StorageNodeComputeTest {
     String keyPrefix = "key_";
     String valuePrefix = "value_";
 
-    VeniceWriterFactory vwFactory = TestUtils.getVeniceWriterFactory(veniceCluster.getKafka().getAddress());
+    VeniceWriterFactory vwFactory =
+        TestUtils.getVeniceWriterFactory(veniceCluster.getPubSubBrokerWrapper().getAddress());
     try (VeniceWriter<Object, byte[], byte[]> veniceWriter = vwFactory.createVeniceWriter(
         new VeniceWriterOptions.Builder(topic).setKeySerializer(keySerializer)
             .setValueSerializer(new DefaultSerializer())
@@ -288,7 +289,7 @@ public class StorageNodeComputeTest {
 
     try (
         VeniceWriter<Object, byte[], byte[]> veniceWriter = TestUtils
-            .getVeniceWriterFactory(veniceCluster.getKafka().getAddress())
+            .getVeniceWriterFactory(veniceCluster.getPubSubBrokerWrapper().getAddress())
             .createVeniceWriter(
                 new VeniceWriterOptions.Builder(newVersion.getKafkaTopic()).setKeySerializer(keySerializer).build());
         AvroGenericStoreClient<String, Object> storeClient = ClientFactory.getAndStartGenericAvroClient(

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/storagenode/StorageNodeComputeTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/storagenode/StorageNodeComputeTest.java
@@ -22,6 +22,7 @@ import com.linkedin.venice.helix.HelixReadOnlySchemaRepository;
 import com.linkedin.venice.integration.utils.ServiceFactory;
 import com.linkedin.venice.integration.utils.VeniceClusterWrapper;
 import com.linkedin.venice.meta.Version;
+import com.linkedin.venice.pubsub.api.PubSubProducerAdapterFactory;
 import com.linkedin.venice.pushmonitor.ExecutionStatus;
 import com.linkedin.venice.serialization.DefaultSerializer;
 import com.linkedin.venice.serialization.VeniceKafkaSerializer;
@@ -177,8 +178,10 @@ public class StorageNodeComputeTest {
     String keyPrefix = "key_";
     String valuePrefix = "value_";
 
-    VeniceWriterFactory vwFactory =
-        TestUtils.getVeniceWriterFactory(veniceCluster.getPubSubBrokerWrapper().getAddress());
+    PubSubProducerAdapterFactory pubSubProducerAdapterFactory =
+        veniceCluster.getPubSubBrokerWrapper().getPubSubClientsFactory().getProducerAdapterFactory();
+    VeniceWriterFactory vwFactory = TestUtils
+        .getVeniceWriterFactory(veniceCluster.getPubSubBrokerWrapper().getAddress(), pubSubProducerAdapterFactory);
     try (VeniceWriter<Object, byte[], byte[]> veniceWriter = vwFactory.createVeniceWriter(
         new VeniceWriterOptions.Builder(topic).setKeySerializer(keySerializer)
             .setValueSerializer(new DefaultSerializer())
@@ -288,8 +291,10 @@ public class StorageNodeComputeTest {
     final int pushVersion = newVersion.getVersion();
 
     try (
+        PubSubProducerAdapterFactory pubSubProducerAdapterFactory =
+            veniceCluster.getPubSubBrokerWrapper().getPubSubClientsFactory().getProducerAdapterFactory();
         VeniceWriter<Object, byte[], byte[]> veniceWriter = TestUtils
-            .getVeniceWriterFactory(veniceCluster.getPubSubBrokerWrapper().getAddress())
+            .getVeniceWriterFactory(veniceCluster.getPubSubBrokerWrapper().getAddress(), pubSubProducerAdapterFactory)
             .createVeniceWriter(
                 new VeniceWriterOptions.Builder(newVersion.getKafkaTopic()).setKeySerializer(keySerializer).build());
         AvroGenericStoreClient<String, Object> storeClient = ClientFactory.getAndStartGenericAvroClient(

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/storagenode/StorageNodeReadTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/storagenode/StorageNodeReadTest.java
@@ -112,7 +112,7 @@ public class StorageNodeReadTest {
     keySerializer = new VeniceAvroKafkaSerializer(stringSchema);
     valueSerializer = new VeniceAvroKafkaSerializer(stringSchema);
 
-    veniceWriter = TestUtils.getVeniceWriterFactory(veniceCluster.getKafka().getAddress())
+    veniceWriter = TestUtils.getVeniceWriterFactory(veniceCluster.getPubSubBrokerWrapper().getAddress())
         .createVeniceWriter(
             new VeniceWriterOptions.Builder(storeVersionName).setKeySerializer(keySerializer)
                 .setValueSerializer(valueSerializer)

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/storagenode/StorageNodeReadTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/storagenode/StorageNodeReadTest.java
@@ -24,6 +24,7 @@ import com.linkedin.venice.meta.ServerAdminAction;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.partitioner.DefaultVenicePartitioner;
 import com.linkedin.venice.partitioner.VenicePartitioner;
+import com.linkedin.venice.pubsub.api.PubSubProducerAdapterFactory;
 import com.linkedin.venice.read.protocol.request.router.MultiGetRouterRequestKeyV1;
 import com.linkedin.venice.read.protocol.response.MultiGetResponseRecordV1;
 import com.linkedin.venice.schema.avro.ReadAvroProtocolDefinition;
@@ -111,8 +112,10 @@ public class StorageNodeReadTest {
     String stringSchema = "\"string\"";
     keySerializer = new VeniceAvroKafkaSerializer(stringSchema);
     valueSerializer = new VeniceAvroKafkaSerializer(stringSchema);
-
-    veniceWriter = TestUtils.getVeniceWriterFactory(veniceCluster.getPubSubBrokerWrapper().getAddress())
+    PubSubProducerAdapterFactory pubSubProducerAdapterFactory =
+        veniceCluster.getPubSubBrokerWrapper().getPubSubClientsFactory().getProducerAdapterFactory();
+    veniceWriter = TestUtils
+        .getVeniceWriterFactory(veniceCluster.getPubSubBrokerWrapper().getAddress(), pubSubProducerAdapterFactory)
         .createVeniceWriter(
             new VeniceWriterOptions.Builder(storeVersionName).setKeySerializer(keySerializer)
                 .setValueSerializer(valueSerializer)

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/throttle/TestRouterReadQuotaThrottler.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/throttle/TestRouterReadQuotaThrottler.java
@@ -52,7 +52,7 @@ public class TestRouterReadQuotaThrottler {
     currentVersion = response.getVersion();
 
     String stringSchema = "\"string\"";
-    VeniceWriterFactory writerFactory = TestUtils.getVeniceWriterFactory(cluster.getKafka().getAddress());
+    VeniceWriterFactory writerFactory = TestUtils.getVeniceWriterFactory(cluster.getPubSubBrokerWrapper().getAddress());
     try (VeniceKafkaSerializer keySerializer = new VeniceAvroKafkaSerializer(stringSchema);
         VeniceKafkaSerializer valueSerializer = new VeniceAvroKafkaSerializer(stringSchema);
         VeniceWriter<Object, Object, Object> writer = writerFactory.createVeniceWriter(

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/throttle/TestRouterReadQuotaThrottler.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/throttle/TestRouterReadQuotaThrottler.java
@@ -14,6 +14,7 @@ import com.linkedin.venice.integration.utils.ServiceFactory;
 import com.linkedin.venice.integration.utils.VeniceClusterWrapper;
 import com.linkedin.venice.integration.utils.VeniceRouterWrapper;
 import com.linkedin.venice.meta.Store;
+import com.linkedin.venice.pubsub.api.PubSubProducerAdapterFactory;
 import com.linkedin.venice.router.throttle.ReadRequestThrottler;
 import com.linkedin.venice.serialization.VeniceKafkaSerializer;
 import com.linkedin.venice.serialization.avro.VeniceAvroKafkaSerializer;
@@ -52,7 +53,10 @@ public class TestRouterReadQuotaThrottler {
     currentVersion = response.getVersion();
 
     String stringSchema = "\"string\"";
-    VeniceWriterFactory writerFactory = TestUtils.getVeniceWriterFactory(cluster.getPubSubBrokerWrapper().getAddress());
+    PubSubProducerAdapterFactory pubSubProducerAdapterFactory =
+        cluster.getPubSubBrokerWrapper().getPubSubClientsFactory().getProducerAdapterFactory();
+    VeniceWriterFactory writerFactory =
+        TestUtils.getVeniceWriterFactory(cluster.getPubSubBrokerWrapper().getAddress(), pubSubProducerAdapterFactory);
     try (VeniceKafkaSerializer keySerializer = new VeniceAvroKafkaSerializer(stringSchema);
         VeniceKafkaSerializer valueSerializer = new VeniceAvroKafkaSerializer(stringSchema);
         VeniceWriter<Object, Object, Object> writer = writerFactory.createVeniceWriter(

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/utils/IntegrationTestPushUtils.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/utils/IntegrationTestPushUtils.java
@@ -41,10 +41,6 @@ import com.linkedin.venice.kafka.TopicManagerRepository;
 import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.pubsub.PubSubTopicRepository;
-import com.linkedin.venice.pubsub.adapter.kafka.admin.ApacheKafkaAdminAdapterFactory;
-import com.linkedin.venice.pubsub.adapter.kafka.consumer.ApacheKafkaConsumerAdapterFactory;
-import com.linkedin.venice.pubsub.api.PubSubAdminAdapterFactory;
-import com.linkedin.venice.pubsub.api.PubSubConsumerAdapterFactory;
 import com.linkedin.venice.samza.VeniceObjectWithTimestamp;
 import com.linkedin.venice.samza.VeniceSystemFactory;
 import java.util.Arrays;
@@ -213,14 +209,6 @@ public class IntegrationTestPushUtils {
     SystemProducer veniceProducer = factory.getProducer("venice", new MapConfig(samzaConfig), null);
     veniceProducer.start();
     return veniceProducer;
-  }
-
-  public static PubSubConsumerAdapterFactory getVeniceConsumerFactory() {
-    return new ApacheKafkaConsumerAdapterFactory();
-  }
-
-  public static PubSubAdminAdapterFactory getVeniceAdminFactory() {
-    return new ApacheKafkaAdminAdapterFactory();
   }
 
   public static ControllerClient createStoreForJob(String veniceClusterName, Schema recordSchema, Properties props) {

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/utils/IntegrationTestPushUtils.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/utils/IntegrationTestPushUtils.java
@@ -32,6 +32,7 @@ import com.linkedin.venice.controllerapi.UpdateStoreQueryParams;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.hadoop.VenicePushJob;
 import com.linkedin.venice.integration.utils.KafkaTestUtils;
+import com.linkedin.venice.integration.utils.PubSubBrokerWrapper;
 import com.linkedin.venice.integration.utils.VeniceClusterWrapper;
 import com.linkedin.venice.integration.utils.VeniceControllerWrapper;
 import com.linkedin.venice.integration.utils.VeniceMultiClusterWrapper;
@@ -375,16 +376,17 @@ public class IntegrationTestPushUtils {
       long kafkaOperationTimeoutMs,
       long topicDeletionStatusPollIntervalMs,
       long topicMinLogCompactionLagMs,
-      String pubSubBootstrapServers,
+      PubSubBrokerWrapper pubSubBrokerWrapper,
       PubSubTopicRepository pubSubTopicRepository) {
     Properties properties = new Properties();
+    String pubSubBootstrapServers = pubSubBrokerWrapper.getAddress();
     properties.put(KAFKA_BOOTSTRAP_SERVERS, pubSubBootstrapServers);
     return TopicManagerRepository.builder()
         .setPubSubProperties(k -> new VeniceProperties(properties))
         .setPubSubTopicRepository(pubSubTopicRepository)
         .setLocalKafkaBootstrapServers(pubSubBootstrapServers)
-        .setPubSubConsumerAdapterFactory(getVeniceConsumerFactory())
-        .setPubSubAdminAdapterFactory(getVeniceAdminFactory())
+        .setPubSubConsumerAdapterFactory(pubSubBrokerWrapper.getPubSubClientsFactory().getConsumerAdapterFactory())
+        .setPubSubAdminAdapterFactory(pubSubBrokerWrapper.getPubSubClientsFactory().getAdminAdapterFactory())
         .setKafkaOperationTimeoutMs(kafkaOperationTimeoutMs)
         .setTopicDeletionStatusPollIntervalMs(topicDeletionStatusPollIntervalMs)
         .setTopicMinLogCompactionLagMs(topicMinLogCompactionLagMs)

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/utils/TestDictionaryUtils.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/utils/TestDictionaryUtils.java
@@ -55,7 +55,6 @@ public class TestDictionaryUtils {
   private Properties getKafkaProperties() {
     Properties props = new Properties();
     props.put(ConfigKeys.KAFKA_BOOTSTRAP_SERVERS, manager.getKafkaBootstrapServers());
-    props.put(ConfigKeys.KAFKA_BOOTSTRAP_SERVERS, pubSubBrokerWrapper.getAddress());
     props.put(ConfigKeys.PARTITIONER_CLASS, DefaultVenicePartitioner.class.getName());
     return props;
   }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/utils/TestDictionaryUtils.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/utils/TestDictionaryUtils.java
@@ -14,6 +14,7 @@ import com.linkedin.venice.message.KafkaKey;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.partitioner.DefaultVenicePartitioner;
 import com.linkedin.venice.pubsub.PubSubTopicRepository;
+import com.linkedin.venice.pubsub.api.PubSubProducerAdapterFactory;
 import com.linkedin.venice.pubsub.api.PubSubTopic;
 import com.linkedin.venice.writer.VeniceWriter;
 import com.linkedin.venice.writer.VeniceWriterOptions;
@@ -37,6 +38,7 @@ public class TestDictionaryUtils {
   private PubSubBrokerWrapper pubSubBrokerWrapper;
   private TopicManager manager;
   private TestMockTime mockTime;
+  private PubSubProducerAdapterFactory pubSubProducerAdapterFactory;
   private final PubSubTopicRepository pubSubTopicRepository = new PubSubTopicRepository();
 
   private String getTopic() {
@@ -73,6 +75,7 @@ public class TestDictionaryUtils {
                 pubSubBrokerWrapper,
                 pubSubTopicRepository)
             .getTopicManager();
+    pubSubProducerAdapterFactory = pubSubBrokerWrapper.getPubSubClientsFactory().getProducerAdapterFactory();
   }
 
   @AfterClass
@@ -87,11 +90,12 @@ public class TestDictionaryUtils {
     byte[] dictionaryToSend = "TEST_DICT".getBytes();
     Properties props = getKafkaProperties();
 
-    try (VeniceWriter<KafkaKey, byte[], byte[]> veniceWriter = TestUtils.getVeniceWriterFactory(props)
-        .createVeniceWriter(
-            new VeniceWriterOptions.Builder(topic).setUseKafkaKeySerializer(true)
-                .setPartitionCount(PARTITION_COUNT)
-                .build())) {
+    try (VeniceWriter<KafkaKey, byte[], byte[]> veniceWriter =
+        TestUtils.getVeniceWriterFactory(props, pubSubProducerAdapterFactory)
+            .createVeniceWriter(
+                new VeniceWriterOptions.Builder(topic).setUseKafkaKeySerializer(true)
+                    .setPartitionCount(PARTITION_COUNT)
+                    .build())) {
       veniceWriter.broadcastStartOfPush(
           true,
           false,
@@ -110,11 +114,12 @@ public class TestDictionaryUtils {
     String topic = getTopic();
     Properties props = getKafkaProperties();
 
-    try (VeniceWriter<KafkaKey, byte[], byte[]> veniceWriter = TestUtils.getVeniceWriterFactory(props)
-        .createVeniceWriter(
-            new VeniceWriterOptions.Builder(topic).setUseKafkaKeySerializer(true)
-                .setPartitionCount(PARTITION_COUNT)
-                .build())) {
+    try (VeniceWriter<KafkaKey, byte[], byte[]> veniceWriter =
+        TestUtils.getVeniceWriterFactory(props, pubSubProducerAdapterFactory)
+            .createVeniceWriter(
+                new VeniceWriterOptions.Builder(topic).setUseKafkaKeySerializer(true)
+                    .setPartitionCount(PARTITION_COUNT)
+                    .build())) {
       veniceWriter.broadcastStartOfPush(true, false, CompressionStrategy.ZSTD_WITH_DICT, null);
       veniceWriter.broadcastEndOfPush(null);
     }
@@ -128,11 +133,12 @@ public class TestDictionaryUtils {
     String topic = getTopic();
     Properties props = getKafkaProperties();
 
-    try (VeniceWriter<KafkaKey, byte[], byte[]> veniceWriter = TestUtils.getVeniceWriterFactory(props)
-        .createVeniceWriter(
-            new VeniceWriterOptions.Builder(topic).setUseKafkaKeySerializer(true)
-                .setPartitionCount(PARTITION_COUNT)
-                .build())) {
+    try (VeniceWriter<KafkaKey, byte[], byte[]> veniceWriter =
+        TestUtils.getVeniceWriterFactory(props, pubSubProducerAdapterFactory)
+            .createVeniceWriter(
+                new VeniceWriterOptions.Builder(topic).setUseKafkaKeySerializer(true)
+                    .setPartitionCount(PARTITION_COUNT)
+                    .build())) {
       veniceWriter.put(new KafkaKey(MessageType.PUT, "blah".getBytes()), "blah".getBytes(), 1, null);
     }
 

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/utils/TestDictionaryUtils.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/utils/TestDictionaryUtils.java
@@ -54,6 +54,7 @@ public class TestDictionaryUtils {
 
   private Properties getKafkaProperties() {
     Properties props = new Properties();
+    props.put(ConfigKeys.KAFKA_BOOTSTRAP_SERVERS, manager.getKafkaBootstrapServers());
     props.put(ConfigKeys.KAFKA_BOOTSTRAP_SERVERS, pubSubBrokerWrapper.getAddress());
     props.put(ConfigKeys.PARTITIONER_CLASS, DefaultVenicePartitioner.class.getName());
     return props;
@@ -70,7 +71,7 @@ public class TestDictionaryUtils {
                 DEFAULT_KAFKA_OPERATION_TIMEOUT_MS,
                 100,
                 MIN_COMPACTION_LAG,
-                pubSubBrokerWrapper.getAddress(),
+                pubSubBrokerWrapper,
                 pubSubTopicRepository)
             .getTopicManager();
   }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/writer/PubSubSharedProducerAdapterFactoryTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/writer/PubSubSharedProducerAdapterFactoryTest.java
@@ -55,15 +55,9 @@ public class PubSubSharedProducerAdapterFactoryTest {
   public void setUp() {
     pubSubBrokerWrapper = ServiceFactory.getPubSubBroker();
     pubSubConsumerAdapterFactory = IntegrationTestPushUtils.getVeniceConsumerFactory();
-    topicManager =
-        IntegrationTestPushUtils
-            .getTopicManagerRepo(
-                DEFAULT_KAFKA_OPERATION_TIMEOUT_MS,
-                100,
-                0L,
-                pubSubBrokerWrapper.getAddress(),
-                pubSubTopicRepository)
-            .getTopicManager();
+    topicManager = IntegrationTestPushUtils
+        .getTopicManagerRepo(DEFAULT_KAFKA_OPERATION_TIMEOUT_MS, 100, 0L, pubSubBrokerWrapper, pubSubTopicRepository)
+        .getTopicManager();
   }
 
   @AfterClass

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/writer/PubSubSharedProducerAdapterFactoryTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/writer/PubSubSharedProducerAdapterFactoryTest.java
@@ -54,7 +54,7 @@ public class PubSubSharedProducerAdapterFactoryTest {
   @BeforeClass
   public void setUp() {
     pubSubBrokerWrapper = ServiceFactory.getPubSubBroker();
-    pubSubConsumerAdapterFactory = IntegrationTestPushUtils.getVeniceConsumerFactory();
+    pubSubConsumerAdapterFactory = pubSubBrokerWrapper.getPubSubClientsFactory().getConsumerAdapterFactory();
     topicManager = IntegrationTestPushUtils
         .getTopicManagerRepo(DEFAULT_KAFKA_OPERATION_TIMEOUT_MS, 100, 0L, pubSubBrokerWrapper, pubSubTopicRepository)
         .getTopicManager();

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/writer/VeniceWriterTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/writer/VeniceWriterTest.java
@@ -52,7 +52,7 @@ public class VeniceWriterTest {
   @BeforeClass
   public void setUp() {
     pubSubBrokerWrapper = ServiceFactory.getPubSubBroker();
-    pubSubConsumerAdapterFactory = IntegrationTestPushUtils.getVeniceConsumerFactory();
+    pubSubConsumerAdapterFactory = pubSubBrokerWrapper.getPubSubClientsFactory().getConsumerAdapterFactory();
     topicManager = IntegrationTestPushUtils
         .getTopicManagerRepo(DEFAULT_KAFKA_OPERATION_TIMEOUT_MS, 100L, 0L, pubSubBrokerWrapper, pubSubTopicRepository)
         .getTopicManager();

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/writer/VeniceWriterTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/writer/VeniceWriterTest.java
@@ -53,15 +53,9 @@ public class VeniceWriterTest {
   public void setUp() {
     pubSubBrokerWrapper = ServiceFactory.getPubSubBroker();
     pubSubConsumerAdapterFactory = IntegrationTestPushUtils.getVeniceConsumerFactory();
-    topicManager =
-        IntegrationTestPushUtils
-            .getTopicManagerRepo(
-                DEFAULT_KAFKA_OPERATION_TIMEOUT_MS,
-                100L,
-                0L,
-                pubSubBrokerWrapper.getAddress(),
-                pubSubTopicRepository)
-            .getTopicManager();
+    topicManager = IntegrationTestPushUtils
+        .getTopicManagerRepo(DEFAULT_KAFKA_OPERATION_TIMEOUT_MS, 100L, 0L, pubSubBrokerWrapper, pubSubTopicRepository)
+        .getTopicManager();
   }
 
   @AfterClass

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceController.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceController.java
@@ -15,9 +15,6 @@ import com.linkedin.venice.controller.supersetschema.SupersetSchemaGenerator;
 import com.linkedin.venice.d2.D2ClientFactory;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.pubsub.PubSubTopicRepository;
-import com.linkedin.venice.pubsub.adapter.kafka.admin.ApacheKafkaAdminAdapterFactory;
-import com.linkedin.venice.pubsub.adapter.kafka.consumer.ApacheKafkaConsumerAdapterFactory;
-import com.linkedin.venice.pubsub.adapter.kafka.producer.ApacheKafkaProducerAdapterFactory;
 import com.linkedin.venice.pubsub.api.PubSubClientsFactory;
 import com.linkedin.venice.serialization.avro.AvroProtocolDefinition;
 import com.linkedin.venice.service.AbstractVeniceService;
@@ -31,7 +28,6 @@ import io.tehuti.metrics.MetricsRepository;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -108,11 +104,6 @@ public class VeniceController {
             .setRouterClientConfig(routerClientConfig.orElse(null))
             .setIcProvider(icProvider.orElse(null))
             .setExternalSupersetSchemaGenerator(externalSupersetSchemaGenerator.orElse(null))
-            .setPubSubClientsFactory(
-                new PubSubClientsFactory(
-                    new ApacheKafkaProducerAdapterFactory(),
-                    new ApacheKafkaConsumerAdapterFactory(),
-                    new ApacheKafkaAdminAdapterFactory()))
             .build());
   }
 
@@ -128,7 +119,10 @@ public class VeniceController {
     this.routerClientConfig = Optional.ofNullable(ctx.getRouterClientConfig());
     this.icProvider = Optional.ofNullable(ctx.getIcProvider());
     this.externalSupersetSchemaGenerator = Optional.ofNullable(ctx.getExternalSupersetSchemaGenerator());
-    this.pubSubClientsFactory = Objects.requireNonNull(ctx.getPubSubClientsFactory(), "PubSubClientsFactory is null");
+    this.pubSubClientsFactory = new PubSubClientsFactory(
+        multiClusterConfigs.getPubSubProducerAdapterFactory(),
+        multiClusterConfigs.getPubSubConsumerAdapterFactory(),
+        multiClusterConfigs.getPubSubAdminAdapterFactory());
     createServices();
   }
 
@@ -303,17 +297,11 @@ public class VeniceController {
 
     String zkAddress = controllerProps.getString(ZOOKEEPER_ADDRESS);
     D2Client d2Client = D2ClientFactory.getD2Client(zkAddress, Optional.empty());
-
-    PubSubClientsFactory pubSubClientsFactory = new PubSubClientsFactory(
-        new ApacheKafkaProducerAdapterFactory(),
-        new ApacheKafkaConsumerAdapterFactory(),
-        new ApacheKafkaAdminAdapterFactory());
     VeniceController controller = new VeniceController(
         new VeniceControllerContext.Builder()
             .setPropertiesList(Arrays.asList(new VeniceProperties[] { controllerProps }))
             .setServiceDiscoveryAnnouncers(new ArrayList<>())
             .setD2Client(d2Client)
-            .setPubSubClientsFactory(pubSubClientsFactory)
             .build());
     controller.start();
     addShutdownHook(controller, zkAddress);

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceController.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceController.java
@@ -119,10 +119,7 @@ public class VeniceController {
     this.routerClientConfig = Optional.ofNullable(ctx.getRouterClientConfig());
     this.icProvider = Optional.ofNullable(ctx.getIcProvider());
     this.externalSupersetSchemaGenerator = Optional.ofNullable(ctx.getExternalSupersetSchemaGenerator());
-    this.pubSubClientsFactory = new PubSubClientsFactory(
-        multiClusterConfigs.getPubSubProducerAdapterFactory(),
-        multiClusterConfigs.getPubSubConsumerAdapterFactory(),
-        multiClusterConfigs.getPubSubAdminAdapterFactory());
+    this.pubSubClientsFactory = multiClusterConfigs.getPubSubClientsFactory();
     createServices();
   }
 

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerConfig.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerConfig.java
@@ -95,6 +95,9 @@ import com.linkedin.venice.client.store.ClientConfig;
 import com.linkedin.venice.controllerapi.ControllerRoute;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.pubsub.adapter.kafka.admin.ApacheKafkaAdminAdapter;
+import com.linkedin.venice.pubsub.adapter.kafka.admin.ApacheKafkaAdminAdapterFactory;
+import com.linkedin.venice.pubsub.adapter.kafka.consumer.ApacheKafkaConsumerAdapterFactory;
+import com.linkedin.venice.pubsub.adapter.kafka.producer.ApacheKafkaProducerAdapterFactory;
 import com.linkedin.venice.pubsub.api.PubSubAdminAdapterFactory;
 import com.linkedin.venice.pubsub.api.PubSubConsumerAdapterFactory;
 import com.linkedin.venice.pubsub.api.PubSubProducerAdapterFactory;
@@ -491,19 +494,16 @@ public class VeniceControllerConfig extends VeniceControllerClusterConfig {
         props.getBoolean(SYSTEM_SCHEMA_INITIALIZATION_AT_START_TIME_ENABLED, false);
 
     try {
-      String producerFactoryClassName = props.getString(
-          PUB_SUB_PRODUCER_ADAPTER_FACTORY_CLASS,
-          "com.linkedin.venice.pubsub.adapter.kafka.producer.ApacheKafkaProducerAdapterFactory");
+      String producerFactoryClassName =
+          props.getString(PUB_SUB_PRODUCER_ADAPTER_FACTORY_CLASS, ApacheKafkaProducerAdapterFactory.class.getName());
       pubSubProducerAdapterFactory =
           (PubSubProducerAdapterFactory) Class.forName(producerFactoryClassName).newInstance();
-      String consumerFactoryClassName = props.getString(
-          PUB_SUB_CONSUMER_ADAPTER_FACTORY_CLASS,
-          "com.linkedin.venice.pubsub.adapter.kafka.consumer.ApacheKafkaConsumerAdapterFactory");
+      String consumerFactoryClassName =
+          props.getString(PUB_SUB_CONSUMER_ADAPTER_FACTORY_CLASS, ApacheKafkaConsumerAdapterFactory.class.getName());
       pubSubConsumerAdapterFactory =
           (PubSubConsumerAdapterFactory) Class.forName(consumerFactoryClassName).newInstance();
-      String adminFactoryClassName = props.getString(
-          PUB_SUB_ADMIN_ADAPTER_FACTORY_CLASS,
-          "com.linkedin.venice.pubsub.adapter.kafka.admin.ApacheKafkaAdminAdapterFactory");
+      String adminFactoryClassName =
+          props.getString(PUB_SUB_ADMIN_ADAPTER_FACTORY_CLASS, ApacheKafkaAdminAdapterFactory.class.getName());
       pubSubAdminAdapterFactory = (PubSubAdminAdapterFactory) Class.forName(adminFactoryClassName).newInstance();
     } catch (ClassNotFoundException | IllegalAccessException | InstantiationException e) {
       LOGGER.error("Failed to create an instance of pub sub clients factory", e);

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerMultiClusterConfig.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerMultiClusterConfig.java
@@ -3,6 +3,9 @@ package com.linkedin.venice.controller;
 import com.linkedin.venice.SSLConfig;
 import com.linkedin.venice.controllerapi.ControllerRoute;
 import com.linkedin.venice.exceptions.VeniceNoClusterException;
+import com.linkedin.venice.pubsub.api.PubSubAdminAdapterFactory;
+import com.linkedin.venice.pubsub.api.PubSubConsumerAdapterFactory;
+import com.linkedin.venice.pubsub.api.PubSubProducerAdapterFactory;
 import com.linkedin.venice.utils.VeniceProperties;
 import java.time.Duration;
 import java.util.Collection;
@@ -255,5 +258,18 @@ public class VeniceControllerMultiClusterConfig {
 
   public int getGraveyardCleanupSleepIntervalBetweenListFetchMinutes() {
     return getCommonConfig().getStoreGraveyardCleanupSleepIntervalBetweenListFetchMinutes();
+  }
+
+  // TODO: Remove this method once we fully support cluster-level pub sub adapter configuration.
+  public PubSubProducerAdapterFactory getPubSubProducerAdapterFactory() {
+    return getCommonConfig().getPubSubProducerAdapterFactory();
+  }
+
+  public PubSubConsumerAdapterFactory getPubSubConsumerAdapterFactory() {
+    return getCommonConfig().getPubSubConsumerAdapterFactory();
+  }
+
+  public PubSubAdminAdapterFactory getPubSubAdminAdapterFactory() {
+    return getCommonConfig().getPubSubAdminAdapterFactory();
   }
 }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerMultiClusterConfig.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerMultiClusterConfig.java
@@ -3,9 +3,7 @@ package com.linkedin.venice.controller;
 import com.linkedin.venice.SSLConfig;
 import com.linkedin.venice.controllerapi.ControllerRoute;
 import com.linkedin.venice.exceptions.VeniceNoClusterException;
-import com.linkedin.venice.pubsub.api.PubSubAdminAdapterFactory;
-import com.linkedin.venice.pubsub.api.PubSubConsumerAdapterFactory;
-import com.linkedin.venice.pubsub.api.PubSubProducerAdapterFactory;
+import com.linkedin.venice.pubsub.api.PubSubClientsFactory;
 import com.linkedin.venice.utils.VeniceProperties;
 import java.time.Duration;
 import java.util.Collection;
@@ -261,15 +259,7 @@ public class VeniceControllerMultiClusterConfig {
   }
 
   // TODO: Remove this method once we fully support cluster-level pub sub adapter configuration.
-  public PubSubProducerAdapterFactory getPubSubProducerAdapterFactory() {
-    return getCommonConfig().getPubSubProducerAdapterFactory();
-  }
-
-  public PubSubConsumerAdapterFactory getPubSubConsumerAdapterFactory() {
-    return getCommonConfig().getPubSubConsumerAdapterFactory();
-  }
-
-  public PubSubAdminAdapterFactory getPubSubAdminAdapterFactory() {
-    return getCommonConfig().getPubSubAdminAdapterFactory();
+  public PubSubClientsFactory getPubSubClientsFactory() {
+    return getCommonConfig().getPubSubClientsFactory();
   }
 }

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/VeniceControllerContextTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/VeniceControllerContextTest.java
@@ -10,7 +10,6 @@ import com.linkedin.venice.acl.DynamicAccessController;
 import com.linkedin.venice.authorization.AuthorizerService;
 import com.linkedin.venice.client.store.ClientConfig;
 import com.linkedin.venice.controller.supersetschema.SupersetSchemaGenerator;
-import com.linkedin.venice.pubsub.api.PubSubClientsFactory;
 import com.linkedin.venice.service.ICProvider;
 import com.linkedin.venice.utils.VeniceProperties;
 import java.util.Collections;
@@ -37,7 +36,6 @@ public class VeniceControllerContextTest {
     ClientConfig routerClientConfig = mock(ClientConfig.class);
     ICProvider icProvider = mock(ICProvider.class);
     SupersetSchemaGenerator externalSupersetSchemaGenerator = mock(SupersetSchemaGenerator.class);
-    PubSubClientsFactory pubSubClientsFactory = mock(PubSubClientsFactory.class);
 
     VeniceControllerContext veniceControllerContext =
         new VeniceControllerContext.Builder().setPropertiesList(propertiesList)
@@ -47,7 +45,6 @@ public class VeniceControllerContextTest {
             .setRouterClientConfig(routerClientConfig)
             .setIcProvider(icProvider)
             .setExternalSupersetSchemaGenerator(externalSupersetSchemaGenerator)
-            .setPubSubClientsFactory(pubSubClientsFactory)
             .setMetricsRepository(null)
             .setServiceDiscoveryAnnouncers(null)
             .build();
@@ -60,6 +57,5 @@ public class VeniceControllerContextTest {
     assertEquals(veniceControllerContext.getD2Client(), d2Client);
     assertEquals(veniceControllerContext.getRouterClientConfig(), routerClientConfig);
     assertEquals(veniceControllerContext.getIcProvider(), icProvider);
-    assertEquals(veniceControllerContext.getPubSubClientsFactory(), pubSubClientsFactory);
   }
 }

--- a/services/venice-server/src/main/java/com/linkedin/venice/server/VeniceServer.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/server/VeniceServer.java
@@ -174,10 +174,7 @@ public class VeniceServer {
     this.icProvider = ctx.getIcProvider();
     this.serviceDiscoveryAnnouncers = ctx.getServiceDiscoveryAnnouncers();
     VeniceServerConfig veniceServerConfig = ctx.getVeniceConfigLoader().getVeniceServerConfig();
-    this.pubSubClientsFactory = new PubSubClientsFactory(
-        veniceServerConfig.getPubSubProducerAdapterFactory(),
-        veniceServerConfig.getPubSubConsumerAdapterFactory(),
-        veniceServerConfig.getPubSubAdminAdapterFactory());
+    this.pubSubClientsFactory = veniceServerConfig.getPubSubClientsFactory();
     this.sslFactory = Optional.ofNullable(ctx.getSslFactory());
     this.routerAccessController = Optional.ofNullable(ctx.getRouterAccessController());
     this.storeAccessController = Optional.ofNullable(ctx.getStoreAccessController());

--- a/services/venice-server/src/main/java/com/linkedin/venice/server/VeniceServer.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/server/VeniceServer.java
@@ -45,9 +45,6 @@ import com.linkedin.venice.meta.ReadOnlyLiveClusterConfigRepository;
 import com.linkedin.venice.meta.ReadOnlySchemaRepository;
 import com.linkedin.venice.meta.ReadOnlyStoreRepository;
 import com.linkedin.venice.meta.StaticClusterInfoProvider;
-import com.linkedin.venice.pubsub.adapter.kafka.admin.ApacheKafkaAdminAdapterFactory;
-import com.linkedin.venice.pubsub.adapter.kafka.consumer.ApacheKafkaConsumerAdapterFactory;
-import com.linkedin.venice.pubsub.adapter.kafka.producer.ApacheKafkaProducerAdapterFactory;
 import com.linkedin.venice.pubsub.api.PubSubClientsFactory;
 import com.linkedin.venice.schema.SchemaReader;
 import com.linkedin.venice.security.SSLFactory;
@@ -70,7 +67,6 @@ import io.tehuti.metrics.MetricsRepository;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -154,11 +150,6 @@ public class VeniceServer {
             .setClientConfigForConsumer(clientConfigForConsumer.orElse(null))
             .setIcProvider(icProvider)
             .setServiceDiscoveryAnnouncers(serviceDiscoveryAnnouncers)
-            .setPubSubClientsFactory(
-                new PubSubClientsFactory(
-                    new ApacheKafkaProducerAdapterFactory(),
-                    new ApacheKafkaConsumerAdapterFactory(),
-                    new ApacheKafkaAdminAdapterFactory()))
             .build());
   }
 
@@ -182,7 +173,11 @@ public class VeniceServer {
     this.metricsRepository = ctx.getMetricsRepository();
     this.icProvider = ctx.getIcProvider();
     this.serviceDiscoveryAnnouncers = ctx.getServiceDiscoveryAnnouncers();
-    this.pubSubClientsFactory = Objects.requireNonNull(ctx.getPubSubClientsFactory(), "PubSubClientsFactory is null");
+    VeniceServerConfig veniceServerConfig = ctx.getVeniceConfigLoader().getVeniceServerConfig();
+    this.pubSubClientsFactory = new PubSubClientsFactory(
+        veniceServerConfig.getPubSubProducerAdapterFactory(),
+        veniceServerConfig.getPubSubConsumerAdapterFactory(),
+        veniceServerConfig.getPubSubAdminAdapterFactory());
     this.sslFactory = Optional.ofNullable(ctx.getSslFactory());
     this.routerAccessController = Optional.ofNullable(ctx.getRouterAccessController());
     this.storeAccessController = Optional.ofNullable(ctx.getStoreAccessController());
@@ -726,13 +721,8 @@ public class VeniceServer {
   }
 
   public static void run(VeniceConfigLoader veniceConfigService, boolean joinThread) throws Exception {
-    PubSubClientsFactory pubSubClientsFactory = new PubSubClientsFactory(
-        new ApacheKafkaProducerAdapterFactory(),
-        new ApacheKafkaConsumerAdapterFactory(),
-        new ApacheKafkaAdminAdapterFactory());
-    VeniceServerContext serverContext = new VeniceServerContext.Builder().setVeniceConfigLoader(veniceConfigService)
-        .setPubSubClientsFactory(pubSubClientsFactory)
-        .build();
+    VeniceServerContext serverContext =
+        new VeniceServerContext.Builder().setVeniceConfigLoader(veniceConfigService).build();
     final VeniceServer server = new VeniceServer(serverContext);
     if (!server.isStarted()) {
       server.start();

--- a/services/venice-server/src/main/java/com/linkedin/venice/server/VeniceServerContext.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/server/VeniceServerContext.java
@@ -6,7 +6,6 @@ import com.linkedin.davinci.config.VeniceConfigLoader;
 import com.linkedin.venice.acl.DynamicAccessController;
 import com.linkedin.venice.acl.StaticAccessController;
 import com.linkedin.venice.client.store.ClientConfig;
-import com.linkedin.venice.pubsub.api.PubSubClientsFactory;
 import com.linkedin.venice.security.SSLFactory;
 import com.linkedin.venice.service.ICProvider;
 import com.linkedin.venice.servicediscovery.ServiceDiscoveryAnnouncer;
@@ -28,7 +27,6 @@ public class VeniceServerContext {
   private final ClientConfig clientConfigForConsumer;
   private final ICProvider icProvider;
   private final List<ServiceDiscoveryAnnouncer> serviceDiscoveryAnnouncers;
-  private final PubSubClientsFactory pubSubClientsFactory;
 
   public VeniceConfigLoader getVeniceConfigLoader() {
     return veniceConfigLoader;
@@ -62,10 +60,6 @@ public class VeniceServerContext {
     return serviceDiscoveryAnnouncers;
   }
 
-  public PubSubClientsFactory getPubSubClientsFactory() {
-    return pubSubClientsFactory;
-  }
-
   private VeniceServerContext(Builder builder) {
     this.veniceConfigLoader = builder.veniceConfigLoader;
     this.metricsRepository = builder.metricsRepository;
@@ -75,7 +69,6 @@ public class VeniceServerContext {
     this.clientConfigForConsumer = builder.clientConfigForConsumer;
     this.icProvider = builder.icProvider;
     this.serviceDiscoveryAnnouncers = builder.serviceDiscoveryAnnouncers;
-    this.pubSubClientsFactory = builder.pubSubClientsFactory;
   }
 
   public static class Builder {
@@ -89,7 +82,6 @@ public class VeniceServerContext {
     private ICProvider icProvider;
     private List<ServiceDiscoveryAnnouncer> serviceDiscoveryAnnouncers;
     private boolean isServiceDiscoveryAnnouncerSet;
-    private PubSubClientsFactory pubSubClientsFactory;
 
     public Builder setVeniceConfigLoader(VeniceConfigLoader veniceConfigLoader) {
       this.veniceConfigLoader = veniceConfigLoader;
@@ -130,11 +122,6 @@ public class VeniceServerContext {
     public Builder setServiceDiscoveryAnnouncers(List<ServiceDiscoveryAnnouncer> serviceDiscoveryAnnouncers) {
       this.isServiceDiscoveryAnnouncerSet = true;
       this.serviceDiscoveryAnnouncers = serviceDiscoveryAnnouncers;
-      return this;
-    }
-
-    public Builder setPubSubClientsFactory(PubSubClientsFactory pubSubClientsFactory) {
-      this.pubSubClientsFactory = pubSubClientsFactory;
       return this;
     }
 

--- a/services/venice-server/src/test/java/com/linkedin/venice/server/VeniceServerContextTest.java
+++ b/services/venice-server/src/test/java/com/linkedin/venice/server/VeniceServerContextTest.java
@@ -9,7 +9,6 @@ import com.linkedin.davinci.config.VeniceConfigLoader;
 import com.linkedin.venice.acl.DynamicAccessController;
 import com.linkedin.venice.acl.StaticAccessController;
 import com.linkedin.venice.client.store.ClientConfig;
-import com.linkedin.venice.pubsub.api.PubSubClientsFactory;
 import com.linkedin.venice.security.SSLFactory;
 import com.linkedin.venice.service.ICProvider;
 import java.util.Collections;
@@ -28,7 +27,6 @@ public class VeniceServerContextTest {
   @Test
   public void testVeniceServerContextCanSetValues() {
     VeniceConfigLoader veniceConfigLoaderMock = mock(VeniceConfigLoader.class);
-    PubSubClientsFactory pubSubClientsFactoryMock = mock(PubSubClientsFactory.class);
     SSLFactory sslFactoryMock = mock(SSLFactory.class);
     StaticAccessController routerAccessControllerMock = mock(StaticAccessController.class);
     DynamicAccessController storeAccessControllerMock = mock(DynamicAccessController.class);
@@ -42,7 +40,6 @@ public class VeniceServerContextTest {
             .setStoreAccessController(storeAccessControllerMock)
             .setClientConfigForConsumer(clientConfigForConsumerMock)
             .setIcProvider(icProviderMock)
-            .setPubSubClientsFactory(pubSubClientsFactoryMock)
             .setMetricsRepository(null)
             .setServiceDiscoveryAnnouncers(null)
             .build();
@@ -55,6 +52,5 @@ public class VeniceServerContextTest {
     assertEquals(veniceServerContext.getStoreAccessController(), storeAccessControllerMock);
     assertEquals(veniceServerContext.getClientConfigForConsumer(), clientConfigForConsumerMock);
     assertEquals(veniceServerContext.getIcProvider(), icProviderMock);
-    assertEquals(veniceServerContext.getPubSubClientsFactory(), pubSubClientsFactoryMock);
   }
 }


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Summary, imperative, start upper case, don't end with a period
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
This change supports plugging in `PubSubClientFactory` from server config and controller config. This will enable configuration passing specific combination of PubSubClients. For example, we may have admin factory and producer factory for one type of PubSub Client, consumer factory is in other type. This change will also benefit Ingestion Isolation and DaVinci client with specific PubSub Client. 
## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.