### PR TITLE
[controller][da-vinci] Updated PushStatusCollector to allow more chances to poll DaVinci status and fixed several DVC memory limiter issues

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/DefaultIngestionBackend.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/DefaultIngestionBackend.java
@@ -95,7 +95,7 @@ public class DefaultIngestionBackend implements DaVinciIngestionBackend, VeniceI
     getStoreIngestionService().getMetaSystemStoreReplicaStatusNotifier()
         .ifPresent(systemStoreReplicaStatusNotifier -> systemStoreReplicaStatusNotifier.drop(topicName, partition));
     // Stop consumption of the partition.
-    getStoreIngestionService().stopConsumptionAndWait(storeConfig, partition, 1, timeoutInSeconds);
+    getStoreIngestionService().stopConsumptionAndWait(storeConfig, partition, 1, timeoutInSeconds, true);
     // Drops corresponding data partition from storage.
     getStorageService().dropStorePartition(storeConfig, partition, removeEmptyStorageEngine);
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/isolated/IsolatedIngestionServer.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/isolated/IsolatedIngestionServer.java
@@ -534,7 +534,8 @@ public class IsolatedIngestionServer extends AbstractVeniceService {
         VeniceStoreVersionConfig storeConfig = getConfigLoader().getStoreConfig(topicName);
         // Make sure partition is not consuming, so we can safely close the rocksdb partition
         long startTimeInMs = System.currentTimeMillis();
-        getStoreIngestionService().stopConsumptionAndWait(storeConfig, partitionId, 1, stopConsumptionWaitRetriesNum);
+        getStoreIngestionService()
+            .stopConsumptionAndWait(storeConfig, partitionId, 1, stopConsumptionWaitRetriesNum, false);
         // Close all RocksDB sub-Partitions in Ingestion Service.
         getStorageService().closeStorePartition(storeConfig, partitionId);
         LOGGER.info(

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionService.java
@@ -874,7 +874,8 @@ public class KafkaStoreIngestionService extends AbstractVeniceService implements
       VeniceStoreVersionConfig veniceStore,
       int partitionId,
       int sleepSeconds,
-      int numRetries) {
+      int numRetries,
+      boolean whetherToResetOffset) {
     String topicName = veniceStore.getStoreVersionName();
     if (isPartitionConsuming(topicName, partitionId)) {
       stopConsumption(veniceStore, partitionId);
@@ -903,7 +904,10 @@ public class KafkaStoreIngestionService extends AbstractVeniceService implements
     } else {
       LOGGER.warn("Partition: {} of topic: {} is not consuming, skipped the stop consumption.", partitionId, topicName);
     }
-    resetConsumptionOffset(veniceStore, partitionId);
+    if (whetherToResetOffset) {
+      resetConsumptionOffset(veniceStore, partitionId);
+      LOGGER.info("Reset consumption offset for topic: {}, partition: {}", topicName, partitionId);
+    }
     if (!ingestionTaskHasAnySubscription(topicName)) {
       if (isIsolatedIngestion) {
         LOGGER.info("Ingestion task for topic {} will be kept open for the access from main process.", topicName);

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionService.java
@@ -41,12 +41,13 @@ public interface StoreIngestionService extends MetadataRetriever {
   /**
    * Stops consuming messages from Kafka Partition corresponding to Venice Partition and wait up to
    * (sleepSeconds * numRetires) to make sure partition consumption is stopped.
-   * @param veniceStore Venice Store for the partition.
-   * @param partitionId Venice partition's id.
-   * @param sleepSeconds
-   * @param numRetries
    */
-  void stopConsumptionAndWait(VeniceStoreVersionConfig veniceStore, int partitionId, int sleepSeconds, int numRetries);
+  void stopConsumptionAndWait(
+      VeniceStoreVersionConfig veniceStore,
+      int partitionId,
+      int sleepSeconds,
+      int numRetries,
+      boolean whetherToResetOffset);
 
   /**
    * Kill all of running consumptions of given store.

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/storage/StorageService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/storage/StorageService.java
@@ -383,6 +383,16 @@ public class StorageService extends AbstractVeniceService {
     factory.removeStorageEngine(storageEngine);
   }
 
+  /**
+   * This function is used to forcely clean up all the databases belonging to {@param kafkaTopic}.
+   * This function will only be used when the {@link #removeStorageEngine(String)} function can't
+   * handle some edge case, such as some partitions are lingering, which are not visible to the corresponding
+   * {@link AbstractStorageEngine}
+   */
+  public synchronized void forceStorageEngineCleanup(String kafkaTopic) {
+    persistenceTypeToStorageEngineFactoryMap.values().forEach(factory -> factory.removeStorageEngine(kafkaTopic));
+  }
+
   public synchronized void closeStorageEngine(String kafkaTopic) {
     AbstractStorageEngine<?> storageEngine = getStorageEngineRepository().removeLocalStorageEngine(kafkaTopic);
     if (storageEngine == null) {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/RocksDBStorageEngineFactory.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/RocksDBStorageEngineFactory.java
@@ -184,7 +184,10 @@ public class RocksDBStorageEngineFactory extends StorageEngineFactory {
         DEFAULT_FAIRNESS,
         DEFAULT_MODE,
         rocksDBServerConfig.isAutoTunedRateLimiterEnabled());
-
+    if (this.memoryLimit > 0) {
+      rocksDBMemoryStats.setMemoryLimit(this.memoryLimit);
+      rocksDBMemoryStats.setSstFileManager(this.sstFileManager);
+    }
   }
 
   public long getMemoryLimit() {
@@ -296,10 +299,8 @@ public class RocksDBStorageEngineFactory extends StorageEngineFactory {
   }
 
   /**
-   * The following function shouldn't be invoked at runtime (only at startup time), so we didn't apply
-   * any throttling here, and if the above condition changes in the future, we may need to consider
-   * throttling the deletion to reduce the IO impact to the database disk, which may result in some
-   * side effect in the read path.
+   * Currently, this function doesn't apply any IO throttling and if there is a side effect
+   * discovered in the read path in the future, we will need to apply some optimization here.
    */
   @Override
   public synchronized void removeStorageEngine(String storeName) {

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionServiceTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionServiceTest.java
@@ -421,7 +421,7 @@ public abstract class KafkaStoreIngestionServiceTest {
     VeniceProperties veniceProperties = AbstractStorageEngineTest.getServerProperties(PersistenceType.ROCKS_DB);
     VeniceStoreVersionConfig config = new VeniceStoreVersionConfig(topicName, veniceProperties);
     kafkaStoreIngestionService.startConsumption(config, 0);
-    kafkaStoreIngestionService.stopConsumptionAndWait(config, 0, 1, 1);
+    kafkaStoreIngestionService.stopConsumptionAndWait(config, 0, 1, 1, true);
     StoreIngestionTask storeIngestionTask = kafkaStoreIngestionService.getStoreIngestionTask(topicName);
     if (isIsolatedIngestion) {
       Assert.assertNotNull(storeIngestionTask);
@@ -431,7 +431,7 @@ public abstract class KafkaStoreIngestionServiceTest {
     kafkaStoreIngestionService.startConsumption(config, 0);
     storeIngestionTask = kafkaStoreIngestionService.getStoreIngestionTask(topicName);
     storeIngestionTask.setPartitionConsumptionState(1, mock(PartitionConsumptionState.class));
-    kafkaStoreIngestionService.stopConsumptionAndWait(config, 0, 1, 1);
+    kafkaStoreIngestionService.stopConsumptionAndWait(config, 0, 1, 1, true);
     Assert.assertNotNull(storeIngestionTask);
   }
 

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/DaVinciClientTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/DaVinciClientTest.java
@@ -510,6 +510,8 @@ public class DaVinciClientTest {
         extraBackendConfigMap);
     try (CachingDaVinciClientFactory factory = daVinciTestContext.getDaVinciClientFactory()) {
       DaVinciClient<Integer, Integer> client = daVinciTestContext.getDaVinciClient();
+      // Subscribe to data partition.
+      client.subscribe(Collections.singleton(dataPartition)).get();
       TestUtils.waitForNonDeterministicAssertion(TEST_TIMEOUT, TimeUnit.MILLISECONDS, true, true, () -> {
         for (Integer i = 0; i < KEY_COUNT; i++) {
           assertEquals(client.get(i).get(), i);

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceControllerWrapper.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceControllerWrapper.java
@@ -203,9 +203,9 @@ public class VeniceControllerWrapper extends ProcessWrapper {
             .put(CONTROLLER_ZK_SHARED_META_SYSTEM_SCHEMA_STORE_AUTO_CREATION_ENABLED, true)
             .put(CONTROLLER_ZK_SHARED_DAVINCI_PUSH_STATUS_SYSTEM_SCHEMA_STORE_AUTO_CREATION_ENABLED, true)
             .put(PUSH_STATUS_STORE_ENABLED, true)
-            .put(DAVINCI_PUSH_STATUS_SCAN_INTERVAL_IN_SECONDS, 5)
             .put(CONCURRENT_INIT_ROUTINES_ENABLED, true)
             .put(CLUSTER_DISCOVERY_D2_SERVICE, VeniceRouterWrapper.CLUSTER_DISCOVERY_D2_SERVICE_NAME)
+            .put(DAVINCI_PUSH_STATUS_SCAN_INTERVAL_IN_SECONDS, 1)
             .put(extraProps.toProperties());
 
         if (sslEnabled) {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerConfig.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerConfig.java
@@ -438,7 +438,7 @@ public class VeniceControllerConfig extends VeniceControllerClusterConfig {
     this.daVinciPushStatusScanIntervalInSeconds = props.getInt(DAVINCI_PUSH_STATUS_SCAN_INTERVAL_IN_SECONDS, 30);
     this.daVinciPushStatusScanThreadNumber = props.getInt(DAVINCI_PUSH_STATUS_SCAN_THREAD_NUMBER, 4);
     this.daVinciPushStatusScanNoReportRetryMaxAttempt =
-        props.getInt(DAVINCI_PUSH_STATUS_SCAN_NO_REPORT_RETRY_MAX_ATTEMPTS, 0);
+        props.getInt(DAVINCI_PUSH_STATUS_SCAN_NO_REPORT_RETRY_MAX_ATTEMPTS, 6);
     this.daVinciPushStatusScanMaxOfflineInstance = props.getInt(DAVINCI_PUSH_STATUS_SCAN_MAX_OFFLINE_INSTANCE, 10);
 
     this.zkSharedDaVinciPushStatusSystemSchemaStoreAutoCreationEnabled =

--- a/services/venice-controller/src/test/java/com/linkedin/venice/pushmonitor/PushStatusCollectorTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/pushmonitor/PushStatusCollectorTest.java
@@ -243,4 +243,91 @@ public class PushStatusCollectorTest {
         false,
         () -> Assert.assertEquals(pushErrorCount.get(), 1));
   }
+
+  @Test
+  public void testPushStatusCollectorDaVinciStatusPollingRetryWhenEmptyResultUntilServerCompleteOrNonEmptyResult() {
+    ReadWriteStoreRepository storeRepository = mock(ReadWriteStoreRepository.class);
+    PushStatusStoreReader pushStatusStoreReader = mock(PushStatusStoreReader.class);
+
+    String daVinciStoreName = "daVinciStore";
+    String daVinciStoreTopicV1 = "daVinciStore_v1";
+    String daVinciStoreTopicV2 = "daVinciStore_v2";
+    String daVinciStoreTopicV3 = "daVinciStore_v3";
+
+    Store daVinciStore = mock(Store.class);
+    when(daVinciStore.isDaVinciPushStatusStoreEnabled()).thenReturn(true);
+    when(storeRepository.getStore(daVinciStoreName)).thenReturn(daVinciStore);
+
+    AtomicInteger pushCompletedCount = new AtomicInteger();
+    AtomicInteger pushErrorCount = new AtomicInteger();
+
+    Consumer<String> pushCompleteConsumer = x -> pushCompletedCount.getAndIncrement();
+    BiConsumer<String, String> pushErrorConsumer = (x, y) -> pushErrorCount.getAndIncrement();
+    PushStatusCollector pushStatusCollector = new PushStatusCollector(
+        storeRepository,
+        pushStatusStoreReader,
+        pushCompleteConsumer,
+        pushErrorConsumer,
+        true,
+        1,
+        4,
+        0,
+        20);
+    pushStatusCollector.start();
+
+    pushCompletedCount.set(0);
+    pushErrorCount.set(0);
+    Map<CharSequence, Integer> successfulInstancePushStatus = Collections.singletonMap("instance", 10);
+    Map<CharSequence, Integer> startedInstancePushStatus = Collections.singletonMap("instance", 2);
+
+    when(pushStatusStoreReader.getPartitionStatus(daVinciStoreName, 2, 0, Optional.empty()))
+        .thenReturn(Collections.emptyMap());
+    when(pushStatusStoreReader.isInstanceAlive(daVinciStoreName, "instance")).thenReturn(true);
+    pushStatusCollector.subscribeTopic(daVinciStoreTopicV1, 1);
+    Assert.assertFalse(pushStatusCollector.getTopicToPushStatusMap().containsKey(daVinciStoreTopicV1));
+
+    // Da Vinci Topic v2, DVC success, Server success
+    pushCompletedCount.set(0);
+    pushErrorCount.set(0);
+    pushStatusCollector.subscribeTopic(daVinciStoreTopicV2, 1);
+    Assert.assertTrue(pushStatusCollector.getTopicToPushStatusMap().containsKey(daVinciStoreTopicV2));
+    TestUtils.waitForNonDeterministicAssertion(
+        5,
+        TimeUnit.SECONDS,
+        false,
+        () -> verify(pushStatusStoreReader, atLeast(3)).getPartitionStatus(daVinciStoreName, 2, 0, Optional.empty()));
+    Assert.assertEquals(pushCompletedCount.get(), 0);
+    pushStatusCollector.handleServerPushStatusUpdate(daVinciStoreTopicV2, ExecutionStatus.COMPLETED, null);
+    TestUtils.waitForNonDeterministicAssertion(
+        2,
+        TimeUnit.SECONDS,
+        false,
+        () -> Assert.assertEquals(pushCompletedCount.get(), 1));
+
+    // Da Vinci Topic v3, DVC COMPLETE, Server COMPLETED
+    pushCompletedCount.set(0);
+    pushErrorCount.set(0);
+
+    when(pushStatusStoreReader.getPartitionStatus(daVinciStoreName, 3, 0, Optional.empty())).thenReturn(
+        Collections.emptyMap(),
+        Collections.emptyMap(),
+        Collections.emptyMap(),
+        startedInstancePushStatus,
+        successfulInstancePushStatus);
+
+    pushStatusCollector.subscribeTopic(daVinciStoreTopicV3, 1);
+    Assert.assertTrue(pushStatusCollector.getTopicToPushStatusMap().containsKey(daVinciStoreTopicV3));
+    TestUtils.waitForNonDeterministicAssertion(
+        10,
+        TimeUnit.SECONDS,
+        false,
+        () -> verify(pushStatusStoreReader, times(5)).getPartitionStatus(daVinciStoreName, 3, 0, Optional.empty()));
+    Assert.assertEquals(pushCompletedCount.get(), 0);
+    pushStatusCollector.handleServerPushStatusUpdate(daVinciStoreTopicV3, ExecutionStatus.COMPLETED, null);
+    TestUtils.waitForNonDeterministicAssertion(
+        2,
+        TimeUnit.SECONDS,
+        false,
+        () -> Assert.assertEquals(pushCompletedCount.get(), 1));
+  }
 }


### PR DESCRIPTION
## Summary, imperative, start upper case, don't end with a period
    This code change makes the following changes:
    1. Keeping polling DaVinci status if it is empty before encountering the following conditions:
      a. DaVinci status becomes non-empty.
      b. Server ingestion status becomes terminal: Complete or Error.
    2. Updated the default DaVinci empty status retry to be 6 (3 mins).
    
    The reason to have more empty retry is as follows:
    1. When firstly create the version, DaVinci may not send ingestion status quickly enough before
       PushStatusCollector polls the push status system store, which might return empty result, which would lead
       Controller think that all DaVinci instances have completed the ingestion.
    2. Right now, there are two logic, which will trigger empty DaVinci status retry to minimize the risk, but it is
       still a best effort:
       a. Before DaVinci status report becomes non-empty and Server reports terminal status, DaVinci status polling
          will be retried.
       b. If Server finishes the ingestion too quick and DaVinci ingestion hasn't started yet, and DaVinci status
          polling will retry up to the configured number.
    
    This code change also fixed several DVC memory limiter related issues:
    1. Fixed the memory limit calculation in VeniceServerConfig.
    2. Make sure `VersionBackend.delete` will delete all the partitions even some of them can't be opened because of memory restriction.
    3. Fixed an issue that Isolated Process won't reset ingestion offset when reporting completed or error.
    4. Added two new metrics for DaVinci memory limiter:
       a. RocksDBMemoryStats--memory_limit.Gauge : Memory Limit
       b. RocksDBMemoryStats--memory_usage.Gauge : Memory Usage
    5. DaVinciBackend won't open the hosted data partitions when II is enabled:
       a. It is a waste of effort to open and close them when II is enabled.
       b. SSTFileManager can't handle reopen well in the main process if the database changes in between. For example, if II process deletes
          some sst files because of compaction, and these deleted files will still be tracked by the SSTFileManager when the main process reopens it.
          Hope we can fix this behavior inside RocksDB in the future.
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->


<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->


## How was this PR tested?
unit test
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.