### PR TITLE
[common] [server] Inlucdes TOPIC_SWITCH_RECEIVED and END_OF_PUSH_RECEI…

### DIFF
--- a/internal/venice-common/src/main/java/com/linkedin/venice/pushmonitor/ReplicaStatus.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pushmonitor/ReplicaStatus.java
@@ -131,11 +131,19 @@ public class ReplicaStatus {
       return;
     }
 
-    long completeCount = statusHistory.stream().filter(status -> status.getStatus() == COMPLETED).count();
-    long incPushCount = statusHistory.stream().filter(status -> isIncrementalPushStatus(status.getStatus())).count();
-    long topicSwitchCount =
-        statusHistory.stream().filter(status -> status.getStatus() == TOPIC_SWITCH_RECEIVED).count();
-    long endOfPushCount = statusHistory.stream().filter(status -> status.getStatus() == END_OF_PUSH_RECEIVED).count();
+    long completeCount = 0, incPushCount = 0, topicSwitchCount = 0, endOfPushCount = 0;
+    for (StatusSnapshot snapshot: statusHistory) {
+      ExecutionStatus status = snapshot.getStatus();
+      if (status == COMPLETED) {
+        completeCount++;
+      } else if (isIncrementalPushStatus(status)) {
+        incPushCount++;
+      } else if (status == TOPIC_SWITCH_RECEIVED) {
+        topicSwitchCount++;
+      } else if (status == END_OF_PUSH_RECEIVED) {
+        endOfPushCount++;
+      }
+    }
 
     Iterator<StatusSnapshot> itr = statusHistory.iterator();
     while (itr.hasNext()) {

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pushmonitor/ReplicaStatus.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pushmonitor/ReplicaStatus.java
@@ -112,8 +112,8 @@ public class ReplicaStatus {
     /**
      * Removed old statuses when status list is over MAX_HISTORY_LENGTH.
      * Preserve:
-     * 1. TOPIC_SWITCH_RECEIVED and END_OF_PUSH_RECEIVED
-     * 2. COMPLETED, inc pushes if there is only single copy
+     * 1. TOPIC_SWITCH_RECEIVED and END_OF_PUSH_RECEIVED, if there is only one single copy
+     * 2. COMPLETED and inc pushes, if there is only single copy
      *
      * TODO: If parallel inc push doesn't need inc status history, we can choose to keep only the current inc push status.
      */
@@ -133,31 +133,55 @@ public class ReplicaStatus {
 
     long completeCount = statusHistory.stream().filter(status -> status.getStatus() == COMPLETED).count();
     long incPushCount = statusHistory.stream().filter(status -> isIncrementalPushStatus(status.getStatus())).count();
-    Iterator<StatusSnapshot> itr = statusHistory.iterator();
+    long topicSwitchCount =
+        statusHistory.stream().filter(status -> status.getStatus() == TOPIC_SWITCH_RECEIVED).count();
+    long endOfPushCount = statusHistory.stream().filter(status -> status.getStatus() == END_OF_PUSH_RECEIVED).count();
 
+    Iterator<StatusSnapshot> itr = statusHistory.iterator();
     while (itr.hasNext()) {
       if (statusHistory.size() < MAX_HISTORY_LENGTH) {
         break;
       }
       StatusSnapshot oldSnapshot = itr.next();
       ExecutionStatus oldStatus = oldSnapshot.getStatus();
-      if (oldStatus == TOPIC_SWITCH_RECEIVED || oldStatus == END_OF_PUSH_RECEIVED || isIncrementalPushStatus(oldStatus)
+      if (isIncrementalPushStatus(oldStatus)
           && oldSnapshot.getIncrementalPushVersion().equals(incrementalPushVersion)) {
         continue;
       }
+
       if (oldStatus == COMPLETED) {
         if (completeCount > 1) {
           itr.remove();
           completeCount--;
         }
-      } else if (isIncrementalPushStatus(oldStatus)) {
+        continue;
+      }
+
+      if (isIncrementalPushStatus(oldStatus)) {
         if (incPushCount > 1) {
           itr.remove();
           incPushCount--;
         }
-      } else {
-        itr.remove();
+        continue;
       }
+
+      if (oldStatus == TOPIC_SWITCH_RECEIVED) {
+        if (topicSwitchCount > 1) {
+          itr.remove();
+          topicSwitchCount--;
+        }
+        continue;
+      }
+
+      if (oldStatus == END_OF_PUSH_RECEIVED) {
+        if (endOfPushCount > 1) {
+          itr.remove();
+          endOfPushCount--;
+        }
+        continue;
+      }
+
+      itr.remove();
     }
   }
 


### PR DESCRIPTION
…VED during old replica status removal

When updating the statusHistory for a given host on ZK, we take the chance to remove the old replica status when the list length is greater than MAX_HISTORY_LENGTH. However, today, this removal is only applied to COMPLETED or IncrementalPushStatus in the list. In real environment, we saw that TOPIC_SWITCH_RECEIVED and END_OF_PUSH_RECEIVED could also have a very long history, e.g. when Helix rebalances a partition back and forth on a particular host, thus causing the Znode size to increase beyond 1MB for example.

To fix the issue, this change improves the replica status removal logic by also considering and checking EOP and TS updates, and removes them when MAX_HISTORY_LENGTH is violated.

## How was this PR tested?
Tested in the EI environment.

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.