### PR TITLE
[router] Make key/value profiling sensor per router only

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,5 +4,11 @@ org.gradle.caching=true
 pulsarGroup = org.apache.pulsar
 pulsarVersion = 2.10.3
 
-
+org.gradle.jvmargs= \
+--add-exports=java.base/sun.nio.ch=ALL-UNNAMED \
+--add-opens=java.base/java.lang=ALL-UNNAMED \
+--add-opens=java.base/java.lang.reflect=ALL-UNNAMED \
+--add-opens=java.base/java.io=ALL-UNNAMED \
+--add-opens=java.base/sun.net=ALL-UNNAMED \
+--add-exports=jdk.unsupported/sun.misc=ALL-UNNAMED
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,11 +4,4 @@ org.gradle.caching=true
 pulsarGroup = org.apache.pulsar
 pulsarVersion = 2.10.3
 
-org.gradle.jvmargs= \
---add-exports=java.base/sun.nio.ch=ALL-UNNAMED \
---add-opens=java.base/java.lang=ALL-UNNAMED \
---add-opens=java.base/java.lang.reflect=ALL-UNNAMED \
---add-opens=java.base/java.io=ALL-UNNAMED \
---add-opens=java.base/sun.net=ALL-UNNAMED \
---add-exports=jdk.unsupported/sun.misc=ALL-UNNAMED
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,4 +4,11 @@ org.gradle.caching=true
 pulsarGroup = org.apache.pulsar
 pulsarVersion = 2.10.3
 
+org.gradle.jvmargs= \
+--add-exports=java.base/sun.nio.ch=ALL-UNNAMED \
+--add-opens=java.base/java.lang=ALL-UNNAMED \
+--add-opens=java.base/java.lang.reflect=ALL-UNNAMED \
+--add-opens=java.base/java.io=ALL-UNNAMED \
+--add-opens=java.base/sun.net=ALL-UNNAMED \
+--add-exports=jdk.unsupported/sun.misc=ALL-UNNAMED
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,11 +4,5 @@ org.gradle.caching=true
 pulsarGroup = org.apache.pulsar
 pulsarVersion = 2.10.3
 
-org.gradle.jvmargs= \
---add-exports=java.base/sun.nio.ch=ALL-UNNAMED \
---add-opens=java.base/java.lang=ALL-UNNAMED \
---add-opens=java.base/java.lang.reflect=ALL-UNNAMED \
---add-opens=java.base/java.io=ALL-UNNAMED \
---add-opens=java.base/sun.net=ALL-UNNAMED \
---add-exports=jdk.unsupported/sun.misc=ALL-UNNAMED
+
 

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/api/VenicePathParser.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/api/VenicePathParser.java
@@ -142,14 +142,18 @@ public class VenicePathParser<HTTP_REQUEST extends BasicHttpRequest>
       // this method may throw store not exist exception; track the exception under unhealthy request metric
       int version = versionFinder.getVersion(storeName, fullHttpRequest);
       String resourceName = Version.composeKafkaTopic(storeName, version);
-
-      RouterStats<AggRouterHttpRequestStats> stats = routerConfig.isKeyValueProfilingEnabled() ? routerStats : null;
-
       String method = fullHttpRequest.method().name();
+
       if (VeniceRouterUtils.isHttpGet(method)) {
         // single-get request
-        path =
-            new VeniceSingleGetPath(storeName, version, resourceName, pathHelper.getKey(), uri, partitionFinder, stats);
+        path = new VeniceSingleGetPath(
+            storeName,
+            version,
+            resourceName,
+            pathHelper.getKey(),
+            uri,
+            partitionFinder,
+            routerStats);
       } else if (VeniceRouterUtils.isHttpPost(method)) {
         if (resourceType == RouterResourceType.TYPE_STORAGE) {
           // multi-get request
@@ -162,7 +166,7 @@ public class VenicePathParser<HTTP_REQUEST extends BasicHttpRequest>
               getBatchGetLimit(storeName),
               routerConfig.isSmartLongTailRetryEnabled(),
               routerConfig.getSmartLongTailRetryAbortThresholdMs(),
-              stats,
+              routerStats,
               routerConfig.getLongTailRetryMaxRouteForMultiKeyReq());
         } else if (resourceType == RouterResourceType.TYPE_COMPUTE) {
           // read compute request

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/api/path/VeniceSingleGetPath.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/api/path/VeniceSingleGetPath.java
@@ -57,9 +57,7 @@ public class VeniceSingleGetPath extends VenicePath {
       routerKey = RouterKey.fromString(key);
     }
 
-    if (stats != null) {
-      stats.getStatsByType(RequestType.SINGLE_GET).recordKeySize(storeName, routerKey.getKeySize());
-    }
+    stats.getStatsByType(RequestType.SINGLE_GET).recordKeySize(storeName, routerKey.getKeySize());
 
     try {
       int partitionNum = partitionFinder.getNumPartitions(resourceName);

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/stats/AggRouterHttpRequestStats.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/stats/AggRouterHttpRequestStats.java
@@ -159,6 +159,7 @@ public class AggRouterHttpRequestStats extends AbstractVeniceAggStoreStats<Route
 
   public void recordResponseSize(String storeName, double valueSize) {
     totalStats.recordResponseSize(valueSize);
+    totalStats.recordValueSize(valueSize);
     getStoreStats(storeName).recordResponseSize(valueSize);
   }
 
@@ -267,7 +268,6 @@ public class AggRouterHttpRequestStats extends AbstractVeniceAggStoreStats<Route
 
   public void recordKeySize(String storeName, long keySize) {
     totalStats.recordKeySizeInByte(keySize);
-    getStoreStats(storeName).recordKeySizeInByte(keySize);
   }
 
   public void recordAllowedRetryRequest(String storeName) {

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/stats/AggRouterHttpRequestStats.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/stats/AggRouterHttpRequestStats.java
@@ -159,7 +159,6 @@ public class AggRouterHttpRequestStats extends AbstractVeniceAggStoreStats<Route
 
   public void recordResponseSize(String storeName, double valueSize) {
     totalStats.recordResponseSize(valueSize);
-    totalStats.recordValueSize(valueSize);
     getStoreStats(storeName).recordResponseSize(valueSize);
   }
 

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/stats/RouterHttpRequestStats.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/stats/RouterHttpRequestStats.java
@@ -58,8 +58,6 @@ public class RouterHttpRequestStats extends AbstractVeniceHttpStats {
   private final Sensor inFlightRequestSensor;
   private Sensor keySizeSensor;
 
-  private Sensor valueSizeSensor;
-
   private final AtomicInteger currentInFlightRequest;
   private final Sensor unavailableReplicaStreamingRequestSensor;
   private final Sensor allowedRetryRequestSensor;

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/stats/RouterHttpRequestStats.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/stats/RouterHttpRequestStats.java
@@ -167,7 +167,7 @@ public class RouterHttpRequestStats extends AbstractVeniceHttpStats {
           valueSizeSensorName,
           new Avg(),
           new Max(),
-          TehutiUtils.getFineGrainedPercentileStat(getName(), getFullMetricName(responseSizeSensorName)));
+          TehutiUtils.getFineGrainedPercentileStat(getName(), getFullMetricName(valueSizeSensorName)));
     }
 
     responseSizeSensor = registerSensor(

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/stats/RouterHttpRequestStats.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/stats/RouterHttpRequestStats.java
@@ -55,6 +55,9 @@ public class RouterHttpRequestStats extends AbstractVeniceHttpStats {
   private final Sensor readQuotaUsageSensor;
   private final Sensor inFlightRequestSensor;
   private Sensor keySizeSensor;
+
+  private Sensor valueSizeSensor;
+
   private final AtomicInteger currentInFlightRequest;
   private final Sensor unavailableReplicaStreamingRequestSensor;
   private final Sensor allowedRetryRequestSensor;
@@ -156,18 +159,19 @@ public class RouterHttpRequestStats extends AbstractVeniceHttpStats {
           new Max(),
           TehutiUtils.getFineGrainedPercentileStat(getName(), getFullMetricName(keySizeSensorName)));
 
-      responseSizeSensor = registerSensor(
-          responseSizeSensorName,
+      String valueSizeSensorName = "value_size_in_byte";
+      valueSizeSensor = registerSensor(
+          valueSizeSensorName,
           new Avg(),
           new Max(),
           TehutiUtils.getFineGrainedPercentileStat(getName(), getFullMetricName(responseSizeSensorName)));
-    } else {
-      responseSizeSensor = registerSensor(
-          responseSizeSensorName,
-          new Avg(),
-          new Max(),
-          TehutiUtils.getPercentileStat(getName(), getFullMetricName(responseSizeSensorName)));
     }
+
+    responseSizeSensor = registerSensor(
+        responseSizeSensorName,
+        new Avg(),
+        new Max(),
+        TehutiUtils.getPercentileStat(getName(), getFullMetricName(responseSizeSensorName)));
 
     currentInFlightRequest = new AtomicInteger();
 
@@ -271,9 +275,13 @@ public class RouterHttpRequestStats extends AbstractVeniceHttpStats {
     compressedResponseSizeSensor.record(compressedResponseSize);
   }
 
+  public void recordValueSize(double responseSize) {
+    valueSizeSensor.record(responseSize);
+  }
+
   public void recordResponseSize(double responseSize) {
     responseSizeSensor.record(responseSize);
-  };
+  }
 
   public void recordDecompressionTime(double decompressionTime) {
     decompressionTimeSensor.record(decompressionTime);

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/stats/RouterHttpRequestStats.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/stats/RouterHttpRequestStats.java
@@ -66,6 +66,8 @@ public class RouterHttpRequestStats extends AbstractVeniceHttpStats {
   private final Sensor retryDelaySensor;
   private final Sensor metaStoreShadowReadSensor;
 
+  private final boolean isKeyValueProfilingEnabled;
+
   // QPS metrics
   public RouterHttpRequestStats(
       MetricsRepository metricsRepository,
@@ -83,6 +85,7 @@ public class RouterHttpRequestStats extends AbstractVeniceHttpStats {
     unhealthySensor = registerSensor("unhealthy_request", new Count());
     unavailableReplicaStreamingRequestSensor = registerSensor("unavailable_replica_streaming_request", new Count());
     tardySensor = registerSensor("tardy_request", new Count(), tardyRequestRate);
+    this.isKeyValueProfilingEnabled = isKeyValueProfilingEnabled;
     healthyRequestRateSensor =
         registerSensor("healthy_request_ratio", new TehutiUtils.SimpleRatioStat(healthyRequestRate, requestRate));
     tardyRequestRatioSensor =
@@ -276,7 +279,9 @@ public class RouterHttpRequestStats extends AbstractVeniceHttpStats {
   }
 
   public void recordValueSize(double responseSize) {
-    valueSizeSensor.record(responseSize);
+    if (isKeyValueProfilingEnabled) {
+      valueSizeSensor.record(responseSize);
+    }
   }
 
   public void recordResponseSize(double responseSize) {

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/stats/RouterHttpRequestStats.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/stats/RouterHttpRequestStats.java
@@ -330,7 +330,9 @@ public class RouterHttpRequestStats extends AbstractVeniceHttpStats {
   }
 
   public void recordKeySizeInByte(long keySize) {
-    keySizeSensor.record(keySize);
+    if (keySizeSensor != null) {
+      keySizeSensor.record(keySize);
+    }
   }
 
   public void recordResponse() {

--- a/services/venice-router/src/test/java/com/linkedin/venice/router/AggRouterHttpRequestStatsTest.java
+++ b/services/venice-router/src/test/java/com/linkedin/venice/router/AggRouterHttpRequestStatsTest.java
@@ -69,10 +69,9 @@ public class AggRouterHttpRequestStatsTest {
     Assert.assertEquals((int) reporter.query(".total--compute_key_size_in_byte.2thPercentile").value(), 2);
     Assert.assertEquals((int) reporter.query(".total--compute_key_size_in_byte.3thPercentile").value(), 3);
     Assert.assertEquals((int) reporter.query(".total--compute_key_size_in_byte.4thPercentile").value(), 4);
-    Assert.assertEquals((int) reporter.query(".total--compute_value_size_in_byte.1thPercentile").value(), 1);
-    Assert.assertEquals((int) reporter.query(".total--compute_value_size_in_byte.2thPercentile").value(), 2);
-    Assert.assertEquals((int) reporter.query(".total--compute_value_size_in_byte.3thPercentile").value(), 3);
-    Assert.assertEquals((int) reporter.query(".total--compute_value_size_in_byte.4thPercentile").value(), 4);
-
+    Assert.assertEquals((int) reporter.query(".total--compute_response_size.1thPercentile").value(), 1);
+    Assert.assertEquals((int) reporter.query(".total--compute_response_size.2thPercentile").value(), 2);
+    Assert.assertEquals((int) reporter.query(".total--compute_response_size.3thPercentile").value(), 3);
+    Assert.assertEquals((int) reporter.query(".total--compute_response_size.4thPercentile").value(), 4);
   }
 }

--- a/services/venice-router/src/test/java/com/linkedin/venice/router/AggRouterHttpRequestStatsTest.java
+++ b/services/venice-router/src/test/java/com/linkedin/venice/router/AggRouterHttpRequestStatsTest.java
@@ -66,7 +66,7 @@ public class AggRouterHttpRequestStatsTest {
 
     Assert.assertEquals((int) reporter.query(".total--compute_key_size_in_byte.1thPercentile").value(), 1);
     Assert.assertEquals((int) reporter.query(".total--compute_key_size_in_byte.2thPercentile").value(), 2);
-    Assert.assertEquals((int) reporter.query(".store1--compute_key_size_in_byte.3thPercentile").value(), 3);
-    Assert.assertEquals((int) reporter.query(".store1--compute_key_size_in_byte.4thPercentile").value(), 4);
+    Assert.assertEquals((int) reporter.query(".total--compute_key_size_in_byte.3thPercentile").value(), 3);
+    Assert.assertEquals((int) reporter.query(".total--compute_key_size_in_byte.4thPercentile").value(), 4);
   }
 }

--- a/services/venice-router/src/test/java/com/linkedin/venice/router/AggRouterHttpRequestStatsTest.java
+++ b/services/venice-router/src/test/java/com/linkedin/venice/router/AggRouterHttpRequestStatsTest.java
@@ -62,11 +62,17 @@ public class AggRouterHttpRequestStatsTest {
 
     for (int i = 1; i <= 100; i += 1) {
       stats.recordKeySize("store1", i);
+      stats.recordResponseSize("store1", i);
     }
 
     Assert.assertEquals((int) reporter.query(".total--compute_key_size_in_byte.1thPercentile").value(), 1);
     Assert.assertEquals((int) reporter.query(".total--compute_key_size_in_byte.2thPercentile").value(), 2);
     Assert.assertEquals((int) reporter.query(".total--compute_key_size_in_byte.3thPercentile").value(), 3);
     Assert.assertEquals((int) reporter.query(".total--compute_key_size_in_byte.4thPercentile").value(), 4);
+    Assert.assertEquals((int) reporter.query(".total--compute_value_size_in_byte.1thPercentile").value(), 1);
+    Assert.assertEquals((int) reporter.query(".total--compute_value_size_in_byte.2thPercentile").value(), 2);
+    Assert.assertEquals((int) reporter.query(".total--compute_value_size_in_byte.3thPercentile").value(), 3);
+    Assert.assertEquals((int) reporter.query(".total--compute_value_size_in_byte.4thPercentile").value(), 4);
+
   }
 }


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Make key/value profiling sensor per router only
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Currently is KV profiling is enabled it generates key value fine grained profiling stats for each store which creates many metrics (num_stores X 20 X 2 X 2). This PR makes KV profiling metrics emit per router total only. 
## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
GHCI
## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [x] Yes. Make sure to explain your proposed changes and call out the behavior change.
   Added a new metric named `value_size_in_byte` but kept the per store response_size metrics intact. 