### PR TITLE
[server] Fix bug in A/A partial update Map field merge update timestamp tie braking logic bug

### DIFF
--- a/internal/venice-test-common/src/integrationTest/resources/PartialUpdateWithRecordMapField.avsc
+++ b/internal/venice-test-common/src/integrationTest/resources/PartialUpdateWithRecordMapField.avsc
@@ -1,0 +1,32 @@
+{
+  "type": "record",
+  "name": "TestRecord",
+  "namespace": "com.linkedin.avro",
+  "fields": [
+    {
+      "name": "nullableMapField",
+      "type": [
+        "null",
+        {
+          "type": "map",
+          "values": {
+            "type": "record",
+            "name": "TestMapRecord",
+            "doc": "",
+            "fields": [
+              {
+                "name": "longField",
+                "type": [
+                  "null",
+                  "long"
+                ],
+                "default": null
+              }
+            ]
+          }
+        }
+      ],
+      "default": null
+    }
+  ]
+}


### PR DESCRIPTION
## [server] Fix bug in A/A partial update Map field merge update timestamp tie braking logic bug

This PR fixes the bug in A/A partial update map collection merge tie breaking logic.

**Problem:**
Existing logic tries to get the map schema and then try to compare the value of two active keys that have same TS.
However, there are issues: We are actually not comparing the map item value but instead we are putting KeyValPair (which contains key and value) to the comparator and in certain case it will lead to exception and SIT ingestion failure. If the map value type is primitive (int/string or so) it will be fine as the logic in comparator won't cast the value, however if it is record, then the logic will try to cast the value and throw.

**Change in this PR:**
Instead of comparing value, let's only compare KV's key string to break tie. This should be more performant considering (1) we don't need to extract map value schema (2) Usually value type is complex record.
In this PR, I also change the logic to add a new private method for sorting logic in map only to differentiate with list type. This method will be applied to both added key-value pairs and deleted keys.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
Added new integration test
## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.