### PR TITLE
[controller] Make sure push status handlers check OfflinePushStatus before action

### DIFF
--- a/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/AbstractPushMonitor.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/AbstractPushMonitor.java
@@ -118,8 +118,8 @@ public abstract class AbstractPushMonitor
     this.pushStatusCollector = new PushStatusCollector(
         metadataRepository,
         pushStatusStoreReader,
-        (topic) -> handleCompletedPush(getOfflinePush(topic)),
-        (topic, details) -> handleErrorPush(getOfflinePush(topic), details),
+        (topic) -> handleCompletedPush(topic),
+        (topic, details) -> handleErrorPush(topic, details),
         controllerConfig.isDaVinciPushStatusScanEnabled(),
         controllerConfig.getDaVinciPushStatusScanIntervalInSeconds(),
         controllerConfig.getDaVinciPushStatusScanThreadNumber(),
@@ -921,15 +921,19 @@ public abstract class AbstractPushMonitor
     }
   }
 
-  protected void handleCompletedPush(OfflinePushStatus pushStatus) {
-    routingDataRepository.unSubscribeRoutingDataChange(pushStatus.getKafkaTopic(), this);
+  protected void handleCompletedPush(String topic) {
+    routingDataRepository.unSubscribeRoutingDataChange(topic, this);
+    OfflinePushStatus pushStatus = getOfflinePush(topic);
+    if (pushStatus == null) {
+      LOGGER.warn("Could not find OfflinePushStatus for topic: {}, will skip push completion handling", topic);
+      return;
+    }
     LOGGER.info(
         "Updating offline push status, push for: {} old status: {}, new status: {}",
-        pushStatus.getKafkaTopic(),
+        topic,
         pushStatus.getCurrentStatus(),
         ExecutionStatus.COMPLETED);
 
-    String topic = pushStatus.getKafkaTopic();
     long durationSecs = getDurationInSec(pushStatus);
     pushStatus.setSuccessfulPushDurationInSecs(durationSecs);
     String storeName = Version.parseStoreFromKafkaTopicName(topic);
@@ -960,17 +964,22 @@ public abstract class AbstractPushMonitor
     LOGGER.info("Offline push for topic: {} is completed.", pushStatus.getKafkaTopic());
   }
 
-  protected void handleErrorPush(OfflinePushStatus pushStatus, String statusDetails) {
-    routingDataRepository.unSubscribeRoutingDataChange(pushStatus.getKafkaTopic(), this);
+  protected void handleErrorPush(String topic, String statusDetails) {
+    routingDataRepository.unSubscribeRoutingDataChange(topic, this);
+    OfflinePushStatus pushStatus = getOfflinePush(topic);
+    if (pushStatus == null) {
+      LOGGER.warn("Could not find OfflinePushStatus for topic: {}, will skip push error handling", topic);
+      return;
+    }
     LOGGER.info(
         "Updating offline push status, push for: {} is now {}, new status: {}, statusDetails: {}",
-        pushStatus.getKafkaTopic(),
+        topic,
         pushStatus.getCurrentStatus(),
         ExecutionStatus.ERROR,
         statusDetails);
     updatePushStatus(pushStatus, ExecutionStatus.ERROR, Optional.of(statusDetails));
-    String storeName = Version.parseStoreFromKafkaTopicName(pushStatus.getKafkaTopic());
-    int versionNumber = Version.parseVersionFromKafkaTopicName(pushStatus.getKafkaTopic());
+    String storeName = Version.parseStoreFromKafkaTopicName(topic);
+    int versionNumber = Version.parseVersionFromKafkaTopicName(topic);
     try {
       updateStoreVersionStatus(storeName, versionNumber, VersionStatus.ERROR);
       aggPushHealthStats.recordFailedPush(storeName, getDurationInSec(pushStatus));

--- a/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/PushStatusCollector.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/PushStatusCollector.java
@@ -175,21 +175,30 @@ public class PushStatusCollector {
           pushStatus.getTopicName(),
           serverStatus.getStatus(),
           daVinciStatus.getStatus());
-      if (serverStatus.getStatus().equals(ExecutionStatus.COMPLETED)
-          && daVinciStatus.getStatus().equals(ExecutionStatus.COMPLETED)) {
-        pushStatus.setMonitoring(false);
-        pushCompletedHandler.accept(pushStatus.getTopicName());
-      } else if (serverStatus.getStatus().equals(ExecutionStatus.ERROR)
-          || daVinciStatus.getStatus().equals(ExecutionStatus.ERROR)) {
-        pushStatus.setMonitoring(false);
-        StringBuilder pushErrorDetailStringBuilder = new StringBuilder();
-        if (serverStatus.getStatus().equals(ExecutionStatus.ERROR)) {
-          pushErrorDetailStringBuilder.append("Server push error: ").append(serverStatus.getDetails()).append("\n");
+      try {
+        if (serverStatus.getStatus().equals(ExecutionStatus.COMPLETED)
+            && daVinciStatus.getStatus().equals(ExecutionStatus.COMPLETED)) {
+          pushStatus.setMonitoring(false);
+          pushCompletedHandler.accept(pushStatus.getTopicName());
+        } else if (serverStatus.getStatus().equals(ExecutionStatus.ERROR)
+            || daVinciStatus.getStatus().equals(ExecutionStatus.ERROR)) {
+          pushStatus.setMonitoring(false);
+          StringBuilder pushErrorDetailStringBuilder = new StringBuilder();
+          if (serverStatus.getStatus().equals(ExecutionStatus.ERROR)) {
+            pushErrorDetailStringBuilder.append("Server push error: ").append(serverStatus.getDetails()).append("\n");
+          }
+          if (daVinciStatus.getStatus().equals(ExecutionStatus.ERROR)) {
+            pushErrorDetailStringBuilder.append("Da Vinci push error: ")
+                .append(daVinciStatus.getDetails())
+                .append("\n");
+          }
+          pushErrorHandler.accept(pushStatus.getTopicName(), pushErrorDetailStringBuilder.toString());
         }
-        if (daVinciStatus.getStatus().equals(ExecutionStatus.ERROR)) {
-          pushErrorDetailStringBuilder.append("Da Vinci push error: ").append(daVinciStatus.getDetails()).append("\n");
-        }
-        pushErrorHandler.accept(pushStatus.getTopicName(), pushErrorDetailStringBuilder.toString());
+      } catch (Exception e) {
+        LOGGER.error(
+            "Caught exception when calling handler for terminal push status for topic: {}",
+            pushStatus.getTopicName(),
+            e);
       }
     }
   }


### PR DESCRIPTION

<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## [controller] Make sure push status handlers check OfflinePushStatus before action
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

If the OfflinePushStatus was dropped right before handling COMPLETED/ERROR report, it will throw NPE in scanner's periodic scanning logic and lead to push status stuck. This PR fixes issue by checking if retrieved OfflinePushStatus is null before action. Also it adds a try catch in scanning logic to make sure if there is any exception happening in one topic, it will not break scanner.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.