### PR TITLE
[samza][vpj][controller] Make SharedObjectFactory threadsafe

### DIFF
--- a/internal/venice-common/src/main/java/com/linkedin/venice/utils/SharedObjectFactory.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/utils/SharedObjectFactory.java
@@ -2,7 +2,6 @@ package com.linkedin.venice.utils;
 
 import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
@@ -73,14 +72,12 @@ public class SharedObjectFactory<T> {
    * managing an object with the identifier, returns 0
    */
   public int getReferenceCount(String identifier) {
-    AtomicInteger referenceCount = new AtomicInteger(0);
-    objectMap.compute(identifier, (id, referenceCounted) -> {
-      if (referenceCounted != null) {
-        referenceCount.set(referenceCounted.getReferenceCount());
-      }
-
-      return referenceCounted;
-    });
-    return referenceCount.get();
+    // It is possible that this method is not thread-safe, but since this is only used in tests currently, it is okay
+    ReferenceCounted<T> referenceCounted = objectMap.get(identifier);
+    if (referenceCounted == null) {
+      return 0;
+    } else {
+      return referenceCounted.getReferenceCount();
+    }
   }
 }

--- a/internal/venice-common/src/test/java/com/linkedin/venice/utils/SharedObjectFactoryTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/utils/SharedObjectFactoryTest.java
@@ -108,13 +108,12 @@ public class SharedObjectFactoryTest {
     Assert.assertEquals(factory.getReferenceCount(id1), numRunnables);
     Assert.assertEquals(factory.size(), 1);
 
-    AtomicInteger executionCount = new AtomicInteger(0);
     CountDownLatch latch2 = new CountDownLatch(numRunnables);
     String id2 = "id2";
     for (int i = 0; i < numRunnables; i++) {
       executorService.submit(() -> {
         // Get new object and close it immediately soon after
-        Object obj = factory.get(id2, TestSharedObject::new, TestSharedObject::close);
+        factory.get(id2, TestSharedObject::new, TestSharedObject::close);
         factory.release(id2);
         latch2.countDown();
       });

--- a/internal/venice-common/src/test/java/com/linkedin/venice/utils/SharedObjectFactoryTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/utils/SharedObjectFactoryTest.java
@@ -87,6 +87,7 @@ public class SharedObjectFactoryTest {
     Assert.assertTrue(factory.release(id3));
   }
 
+  @Test
   public void testMultiThreadedSharedObject() throws InterruptedException {
     SharedObjectFactory<TestSharedObject> factory = new SharedObjectFactory<>();
     int threadPoolSize = 10;


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Make `SharedObjectFactory` threadsafe
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
Currently, `SharedObjectFactory` is not thread-safe and if there are multiple threads trying to create an object that previously didn't exist, then there can be multiple objects created. While this may be okay in most cases, the issue occurs when releasing these objects, the objects do not have the correct refcount. Hence, there will be an `Reference counter underflow` error. This commit attempts to fix this issue by wrapping all operations using the synchronization offered by `ConcurrentHashMap#compute`

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
Added a unit test

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.