### PR TITLE
[router][fast-client] Picked up the latest release of httpcore5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -73,8 +73,8 @@ ext.libraries = [
     helix: 'org.apache.helix:helix-core:1.0.4',
     httpAsyncClient: 'org.apache.httpcomponents:httpasyncclient:4.1.2',
     httpClient5: 'org.apache.httpcomponents.client5:httpclient5:5.2.1',
-    httpCore5: 'org.apache.httpcomponents.core5:httpcore5:5.2.1',
-    httpCore5H2: 'org.apache.httpcomponents.core5:httpcore5-h2:5.2.1',
+    httpCore5: 'org.apache.httpcomponents.core5:httpcore5:5.2.2',
+    httpCore5H2: 'org.apache.httpcomponents.core5:httpcore5-h2:5.2.2',
     httpClient: 'org.apache.httpcomponents:httpclient:4.5.2',
     httpCore: 'org.apache.httpcomponents:httpcore:4.4.5',
     jacksonCore: 'com.fasterxml.jackson.core:jackson-core:' + jacksonVersion,
@@ -440,18 +440,18 @@ subprojects {
       def testName = removeSquareBrackets(descriptor.displayName)
       def out = services.get(StyledTextOutputFactory).create("an-ouput")
 
-      def style = result.resultType == TestResult.ResultType.SUCCESS 
-        ? Style.Identifier 
+      def style = result.resultType == TestResult.ResultType.SUCCESS
+        ? Style.Identifier
         : result.resultType == TestResult.ResultType.FAILURE
           ? Style.Failure
           : Style.Normal
 
-      def status = result.resultType == TestResult.ResultType.SUCCESS 
-        ? 'PASSED ' 
+      def status = result.resultType == TestResult.ResultType.SUCCESS
+        ? 'PASSED '
         : result.resultType == TestResult.ResultType.FAILURE
           ? 'FAILED '
           : 'SKIPPED '
- 
+
       out.style(Style.Normal).text("$descriptor.className > $testName ")
           .style(style).text(status)
           .style(Style.Normal).println("($prettyTime)")


### PR DESCRIPTION


<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Summary, imperative, start upper case, don't end with a period
The OSS maintainer has already released the fix required by Venice in 5.2.2: https://issues.apache.org/jira/browse/HTTPCORE-750
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->


## How was this PR tested?
CI
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.