### PR TITLE
[vpj] Consolidate controller requests for retrieving store info

### DIFF
--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
@@ -828,10 +828,7 @@ public class VenicePushJob implements AutoCloseable {
 
     // This mode of passing the topic name to VPJ is going to be deprecated.
     if (userProvidedTopicNameOptional.isPresent()) {
-      return getUserProvidedTopicName(
-          userProvidedStoreName,
-          userProvidedTopicNameOptional.get(),
-          pushJobSetting.controllerRetries);
+      return getUserProvidedTopicName(userProvidedStoreName, userProvidedTopicNameOptional.get());
     }
     // If VPJ has fabric name available use that to find the child colo version otherwise
     // use the largest version among the child colo to use as KIF input topic.
@@ -851,10 +848,7 @@ public class VenicePushJob implements AutoCloseable {
     return Version.composeKafkaTopic(userProvidedStoreName, version);
   }
 
-  private String getUserProvidedTopicName(
-      final String userProvidedStoreName,
-      String userProvidedTopicName,
-      int retryAttempts) {
+  private String getUserProvidedTopicName(final String userProvidedStoreName, String userProvidedTopicName) {
     String derivedStoreName = Version.parseStoreFromKafkaTopicName(userProvidedTopicName);
     if (!Objects.equals(derivedStoreName, userProvidedStoreName)) {
       throw new IllegalArgumentException(
@@ -866,15 +860,7 @@ public class VenicePushJob implements AutoCloseable {
     }
 
     LOGGER.info("userProvidedStoreName: {}", userProvidedStoreName);
-    StoreResponse storeResponse =
-        ControllerClient.retryableRequest(controllerClient, retryAttempts, c -> c.getStore(userProvidedStoreName));
-    if (storeResponse.isError()) {
-      throw new VeniceException(
-          String.format(
-              "Fail to get store information for store %s with error %s",
-              userProvidedStoreName,
-              storeResponse.getError()));
-    }
+    StoreResponse storeResponse = getStoreResponse(userProvidedStoreName);
     Map<String, Integer> coloToCurrentVersions = getCurrentStoreVersions(storeResponse);
     if (new HashSet<>(coloToCurrentVersions.values()).size() > 1) {
       LOGGER.info(
@@ -965,7 +951,7 @@ public class VenicePushJob implements AutoCloseable {
       validateKafkaMessageEnvelopeSchema(pushJobSetting);
       validateRemoteHybridSettings(pushJobSetting);
       inputDirectory = getInputURI(props);
-      storeSetting = getSettingsFromController(controllerClient, pushJobSetting);
+      validateStoreSettingAndPopulate(controllerClient, pushJobSetting);
       inputStorageQuotaTracker = new InputStorageQuotaTracker(storeSetting.storeStorageQuota);
 
       if (pushJobSetting.repushTTLEnabled && storeSetting.isWriteComputeEnabled) {
@@ -2260,12 +2246,7 @@ public class VenicePushJob implements AutoCloseable {
 
   protected void validateRemoteHybridSettings(PushJobSetting setting) {
     if (setting.validateRemoteReplayPolicy != null) {
-      StoreResponse response = ControllerClient
-          .retryableRequest(controllerClient, setting.controllerRetries, c -> c.getStore(setting.storeName));
-      if (response.isError()) {
-        throw new VeniceException(
-            "Failed to get store information to validate push settings! Error: " + response.getError());
-      }
+      StoreResponse response = getStoreResponse(setting.storeName);
       HybridStoreConfig hybridStoreConfig = response.getStore().getHybridStoreConfig();
       if (!setting.validateRemoteReplayPolicy.equals(hybridStoreConfig.getBufferReplayPolicy())) {
         throw new VeniceException(
@@ -2384,36 +2365,26 @@ public class VenicePushJob implements AutoCloseable {
     }
   }
 
-  private StoreSetting getSettingsFromController(ControllerClient controllerClient, PushJobSetting setting) {
-    StoreSetting storeSetting = new StoreSetting();
-    StoreResponse storeResponse = ControllerClient
-        .retryableRequest(controllerClient, setting.controllerRetries, c -> c.getStore(setting.storeName));
+  /**
+   * Validate the store settings against the Push job settings and populate additional information, e.g. keySchema, if needed.
+   * @param controllerClient
+   * @param jobSetting
+   * @return
+   */
+  private StoreSetting validateStoreSettingAndPopulate(ControllerClient controllerClient, PushJobSetting jobSetting) {
+    StoreResponse storeResponse = getStoreResponse(pushJobSetting.storeName);
 
-    if (storeResponse.isError()) {
-      throw new VeniceException("Can't get store info. " + storeResponse.getError());
-    }
-    storeSetting.storeResponse = storeResponse;
-    storeSetting.storeStorageQuota = storeResponse.getStore().getStorageQuotaInByte();
-    storeSetting.isSchemaAutoRegisterFromPushJobEnabled =
-        storeResponse.getStore().isSchemaAutoRegisterFromPushJobEnabled();
-    storeSetting.isChunkingEnabled = storeResponse.getStore().isChunkingEnabled();
-    storeSetting.isRmdChunkingEnabled = storeResponse.getStore().isRmdChunkingEnabled();
-    storeSetting.compressionStrategy = storeResponse.getStore().getCompressionStrategy();
-    storeSetting.isWriteComputeEnabled = storeResponse.getStore().isWriteComputationEnabled();
-    storeSetting.isIncrementalPushEnabled = storeResponse.getStore().isIncrementalPushEnabled();
-    storeSetting.storeRewindTimeInSeconds = DEFAULT_RE_PUSH_REWIND_IN_SECONDS_OVERRIDE;
-    if (setting.isTargetedRegionPushEnabled && setting.targetedRegions == null) {
+    if (jobSetting.isTargetedRegionPushEnabled && jobSetting.targetedRegions == null) {
       // only override the targeted regions if it is not set and it is a single region push
-      setting.targetedRegions = storeResponse.getStore().getNativeReplicationSourceFabric();
-      if (StringUtils.isEmpty(setting.targetedRegions)) {
+      jobSetting.targetedRegions = storeResponse.getStore().getNativeReplicationSourceFabric();
+      if (StringUtils.isEmpty(jobSetting.targetedRegions)) {
         throw new VeniceException(
             "The store either does not have native replication mode enabled or set up default source fabric.");
       }
     }
 
     HybridStoreConfig hybridStoreConfig = storeResponse.getStore().getHybridStoreConfig();
-    storeSetting.hybridStoreConfig = hybridStoreConfig;
-    if (setting.repushTTLEnabled) {
+    if (jobSetting.repushTTLEnabled) {
       if (hybridStoreConfig == null) {
         throw new VeniceException("Repush TTL is only supported for real-time only store.");
       } else {
@@ -2421,27 +2392,28 @@ public class VenicePushJob implements AutoCloseable {
       }
     }
 
-    if (setting.enableWriteCompute && !storeSetting.isWriteComputeEnabled) {
+    if (jobSetting.enableWriteCompute && !storeSetting.isWriteComputeEnabled) {
       throw new VeniceException("Store does not have write compute enabled.");
     }
 
-    if (setting.enableWriteCompute && (!storeSetting.isIncrementalPushEnabled || !setting.isIncrementalPush)) {
+    if (jobSetting.enableWriteCompute && (!storeSetting.isIncrementalPushEnabled || !jobSetting.isIncrementalPush)) {
       throw new VeniceException("Write compute is only available for incremental push jobs.");
     }
 
-    if (setting.enableWriteCompute && storeSetting.isWriteComputeEnabled) {
+    if (jobSetting.enableWriteCompute && storeSetting.isWriteComputeEnabled) {
       /*
         If write compute is enabled, we would perform a topic switch from the controller and have the
         controller be in charge of broadcasting start and end messages. We will disable
         sendControlMessagesDirectly to prevent races between the messages sent by the VenicePushJob and
         by the controller for topic switch.
        */
-      setting.sendControlMessagesDirectly = false;
+      jobSetting.sendControlMessagesDirectly = false;
     }
 
-    storeSetting.keySchema = getKeySchemaFromController(controllerClient, setting.controllerRetries, setting.storeName);
+    storeSetting.keySchema =
+        getKeySchemaFromController(controllerClient, jobSetting.controllerRetries, jobSetting.storeName);
 
-    if (setting.isSourceKafka) {
+    if (jobSetting.isSourceKafka) {
       int sourceVersionNumber = Version.parseVersionFromKafkaTopicName(pushJobSetting.kafkaInputTopic);
       Optional<Version> sourceVersion = storeResponse.getStore().getVersion(sourceVersionNumber);
 
@@ -3197,13 +3169,7 @@ public class VenicePushJob implements AutoCloseable {
    * @return
    */
   private Version getStoreVersion(String storeName, int version) {
-    StoreResponse storeResponse = ControllerClient
-        .retryableRequest(controllerClient, pushJobSetting.controllerRetries, c -> c.getStore(storeName));
-    if (storeResponse.isError()) {
-      throw new VeniceException(
-          "Failed to retrieve store response with urls: " + pushJobSetting.veniceControllerUrl + ", error: "
-              + storeResponse.getError());
-    }
+    StoreResponse storeResponse = getStoreResponse(storeName, true);
     Optional<Version> newVersion = storeResponse.getStore().getVersion(version);
     if (!newVersion.isPresent()) {
       throw new VeniceException(
@@ -3212,6 +3178,42 @@ public class VenicePushJob implements AutoCloseable {
     }
 
     return newVersion.get();
+  }
+
+  private StoreResponse getStoreResponse(String storeName) {
+    return getStoreResponse(storeName, false);
+  }
+
+  /**
+   * Get the previously cached {@link StoreResponse} if available, otherwise query the controller.
+   * @param storeName, the store name
+   * @param refresh, if true, query the controller to get the latest store response
+   * @return
+   */
+  private StoreResponse getStoreResponse(String storeName, boolean refresh) {
+    if (storeSetting == null) {
+      storeSetting = new StoreSetting();
+      refresh = true;
+    }
+    if (refresh) {
+      StoreResponse storeResponse = ControllerClient
+          .retryableRequest(controllerClient, pushJobSetting.controllerRetries, c -> c.getStore(storeName));
+      if (storeResponse.isError()) {
+        throw new VeniceException("Can't get store info. " + storeResponse.getError());
+      }
+      storeSetting.storeResponse = storeResponse;
+      storeSetting.storeStorageQuota = storeResponse.getStore().getStorageQuotaInByte();
+      storeSetting.isSchemaAutoRegisterFromPushJobEnabled =
+          storeResponse.getStore().isSchemaAutoRegisterFromPushJobEnabled();
+      storeSetting.isChunkingEnabled = storeResponse.getStore().isChunkingEnabled();
+      storeSetting.isRmdChunkingEnabled = storeResponse.getStore().isRmdChunkingEnabled();
+      storeSetting.compressionStrategy = storeResponse.getStore().getCompressionStrategy();
+      storeSetting.isWriteComputeEnabled = storeResponse.getStore().isWriteComputationEnabled();
+      storeSetting.isIncrementalPushEnabled = storeResponse.getStore().isIncrementalPushEnabled();
+      storeSetting.storeRewindTimeInSeconds = DEFAULT_RE_PUSH_REWIND_IN_SECONDS_OVERRIDE;
+      storeSetting.hybridStoreConfig = storeResponse.getStore().getHybridStoreConfig();
+    }
+    return storeSetting.storeResponse;
   }
 
   private void logPushJobProperties(

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
@@ -860,7 +860,7 @@ public class VenicePushJob implements AutoCloseable {
     }
 
     LOGGER.info("userProvidedStoreName: {}", userProvidedStoreName);
-    StoreResponse storeResponse = getStoreResponse(userProvidedStoreName);
+    StoreResponse storeResponse = getStoreResponse(userProvidedStoreName, true);
     Map<String, Integer> coloToCurrentVersions = getCurrentStoreVersions(storeResponse);
     if (new HashSet<>(coloToCurrentVersions.values()).size() > 1) {
       LOGGER.info(
@@ -3187,7 +3187,7 @@ public class VenicePushJob implements AutoCloseable {
   /**
    * Get the previously cached {@link StoreResponse} if available, otherwise query the controller.
    * @param storeName, the store name
-   * @param refresh, if true, query the controller to get the latest store response
+   * @param refresh, if true, query the controller to get the latest store response. Usually used for up-to-date Version.
    * @return
    */
   private StoreResponse getStoreResponse(String storeName, boolean refresh) {

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
@@ -3194,6 +3194,8 @@ public class VenicePushJob implements AutoCloseable {
    * @param storeName, the store name
    * @param refresh, if true, query the controller to get the latest store response otherwise return the cached one.
    * @return the cached {@link StoreResponse} or the newly fetched {@link StoreResponse} when refresh is true.
+   *
+   * TODO: Need more refactoring to get rid of storeSetting, or even other POJOs in this class so codes can be cleaner.
    */
   private StoreResponse getStoreResponse(String storeName, boolean refresh) {
     if (storeSetting == null) {


### PR DESCRIPTION
## Summary, imperative, start upper case, don't end with a period

In the VPJ, we call the controller 4 times to get the `StoreResponse` which is wasteful. For configurations, they are unlikely to change during a push job and should be cached to reduce the duplicate call. This PR caches the response so we can reduce the duplicate calls by 2.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

GHCI

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x ] No. You can skip the rest of this section.
- [] Yes. Make sure to explain your proposed changes and call out the behavior change.