### PR TITLE
[server] RocksDB cleanup on bad store/store versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -726,6 +726,7 @@ ext.createDiffFile = { ->
         ':!services/venice-standalone/*', // exclude the entire standalone project
         ':!clients/venice-client/src/main/java/com/linkedin/venice/fastclient/factory/ClientFactory.java',
         ':!clients/da-vinci-client/src/main/java/com/linkedin/davinci/DaVinciBackend.java',
+        ':!clients/da-vinci-client/src/main/java/com/linkedin/davinci/storage/StorageService.java',
         ':!clients/venice-producer/src/main/java/com/linkedin/venice/producer/online/OnlineProducerFactory.java',
         ':!clients/venice-producer/src/main/java/com/linkedin/venice/producer/online/ProducerTool.java',
 

--- a/build.gradle
+++ b/build.gradle
@@ -726,7 +726,6 @@ ext.createDiffFile = { ->
         ':!services/venice-standalone/*', // exclude the entire standalone project
         ':!clients/venice-client/src/main/java/com/linkedin/venice/fastclient/factory/ClientFactory.java',
         ':!clients/da-vinci-client/src/main/java/com/linkedin/davinci/DaVinciBackend.java',
-        ':!clients/da-vinci-client/src/main/java/com/linkedin/davinci/storage/StorageService.java',
         ':!clients/venice-producer/src/main/java/com/linkedin/venice/producer/online/OnlineProducerFactory.java',
         ':!clients/venice-producer/src/main/java/com/linkedin/venice/producer/online/ProducerTool.java',
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/storage/StorageService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/storage/StorageService.java
@@ -191,7 +191,7 @@ public class StorageService extends AbstractVeniceService {
     }
 
     int versionNumber = Version.parseVersionFromKafkaTopicName(storageEngineName);
-    return store.getVersion(versionNumber).isPresent() || versionNumber < store.getCurrentVersion();
+    return !store.getVersion(versionNumber).isPresent() || versionNumber < store.getCurrentVersion();
   }
 
   private void restoreAllStores(

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/storage/StorageService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/storage/StorageService.java
@@ -186,7 +186,6 @@ public class StorageService extends AbstractVeniceService {
       store = storeRepository.getStoreOrThrow(storeName);
     } catch (VeniceNoStoreException e) {
       // The store does not exist in Venice anymore, so it will be deleted.
-      LOGGER.warn("Store {} does not exist, will delete it.", storageEngineName);
       return true;
     }
 
@@ -194,7 +193,7 @@ public class StorageService extends AbstractVeniceService {
     return !store.getVersion(versionNumber).isPresent() || versionNumber < store.getCurrentVersion();
   }
 
-  private void restoreAllStores(
+  void restoreAllStores(
       VeniceConfigLoader configLoader,
       boolean restoreDataPartitions,
       boolean restoreMetadataPartitions,
@@ -223,6 +222,7 @@ public class StorageService extends AbstractVeniceService {
             if (ExceptionUtils.recursiveClassEquals(e, RocksDBException.class)) {
               LOGGER.warn("Encountered RocksDB error while opening store: {}", storeName, e);
               if (deleteStorageEngine(storeName)) {
+                LOGGER.info("Store {} does not exist, will delete it.", storeName);
                 factory.removeStorageEngine(storeName);
               }
               continue;

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/storage/StorageService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/storage/StorageService.java
@@ -15,7 +15,6 @@ import com.linkedin.davinci.store.blackhole.BlackHoleStorageEngineFactory;
 import com.linkedin.davinci.store.memory.InMemoryStorageEngineFactory;
 import com.linkedin.davinci.store.rocksdb.RocksDBStorageEngineFactory;
 import com.linkedin.venice.ConfigKeys;
-import com.linkedin.venice.common.VeniceSystemStoreType;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.exceptions.VeniceNoStoreException;
 import com.linkedin.venice.kafka.protocol.state.PartitionState;
@@ -182,9 +181,6 @@ public class StorageService extends AbstractVeniceService {
 
   private boolean deleteStorageEngine(String storageEngineName) {
     String storeName = Version.parseStoreFromKafkaTopicName(storageEngineName);
-    if (VeniceSystemStoreType.META_STORE.isSystemStore(storeName)) {
-      return true;
-    }
     Store store;
     try {
       store = storeRepository.getStoreOrThrow(storeName);

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/storage/StorageService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/storage/StorageService.java
@@ -186,7 +186,7 @@ public class StorageService extends AbstractVeniceService {
       store = storeRepository.getStoreOrThrow(storeName);
     } catch (VeniceNoStoreException e) {
       // The store does not exist in Venice anymore, so it will be deleted.
-      LOGGER.warn("Store does not exist, will delete invalid local version: {}", storageEngineName);
+      LOGGER.warn("Store {} does not exist, will delete it.", storageEngineName);
       return true;
     }
 
@@ -221,14 +221,14 @@ public class StorageService extends AbstractVeniceService {
             storageEngine = openStore(storeConfig, () -> null);
           } catch (Exception e) {
             if (ExceptionUtils.recursiveClassEquals(e, RocksDBException.class)) {
-              LOGGER.error("Could not load the following store : " + storeName, e);
-              aggVersionedStorageEngineStats.recordRocksDBOpenFailure(storeName);
+              LOGGER.warn("Encountered RocksDB error while opening store: {}", storeName, e);
               if (deleteStorageEngine(storeName)) {
-                LOGGER.info("Error opening store: {}, deleting it", storeName, e);
                 factory.removeStorageEngine(storeName);
               }
               continue;
             }
+            LOGGER.error("Could not load the following store : " + storeName, e);
+            aggVersionedStorageEngineStats.recordRocksDBOpenFailure(storeName);
             throw new VeniceException("Error caught during opening store " + storeName, e);
           }
 

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/storage/StorageServiceTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/storage/StorageServiceTest.java
@@ -1,0 +1,41 @@
+package com.linkedin.davinci.storage;
+
+import static org.mockito.Mockito.*;
+
+import com.linkedin.davinci.store.StorageEngineFactory;
+import com.linkedin.venice.exceptions.VeniceNoStoreException;
+import com.linkedin.venice.meta.ReadOnlyStoreRepository;
+import com.linkedin.venice.meta.Store;
+import com.linkedin.venice.meta.Version;
+import com.linkedin.venice.utils.Utils;
+import java.util.Optional;
+import org.testng.annotations.Test;
+
+
+public class StorageServiceTest {
+  private static final String storeName = Utils.getUniqueString("rocksdb_store_test");
+  private final ReadOnlyStoreRepository storeRepository = mock(ReadOnlyStoreRepository.class);
+  private static final int versionNumber = 0;
+  private static final String storageEngineName = Version.composeKafkaTopic(storeName, versionNumber);
+
+  @Test
+  public void testDeleteStorageEngineOnRocksDBError() {
+    Version mockVersion = mock(Version.class);
+    when(mockVersion.isActiveActiveReplicationEnabled()).thenReturn(false);
+    Store mockStore = mock(Store.class);
+    when(mockStore.getVersion(versionNumber)).thenReturn(Optional.empty()).thenReturn(Optional.of(mockVersion));
+
+    // no store or no version exists, delete the store
+    when(storeRepository.getStoreOrThrow(storeName)).thenThrow(VeniceNoStoreException.class).thenReturn(mockStore);
+    StorageEngineFactory factory = mock(StorageEngineFactory.class);
+    StorageService.deleteStorageEngineOnRocksDBError(storageEngineName, storeRepository, factory);
+    verify(factory, times(1)).removeStorageEngine(storageEngineName);
+
+    StorageService.deleteStorageEngineOnRocksDBError(storageEngineName, storeRepository, factory);
+    verify(factory, times(2)).removeStorageEngine(storageEngineName);
+
+    StorageService.deleteStorageEngineOnRocksDBError(storageEngineName, storeRepository, factory);
+    verify(factory, times(2)).removeStorageEngine(storageEngineName);
+
+  }
+}


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

##  RocksDB cleanup on bad store/store versions
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

If server rocksDB directories have resources which are bad and cannot be opened by rocksdb during restart, they are not loaded into storage engine and none of the background resource cleaner kicks for those directories. This leads to massive disk space waste. This PR if rocksDB open fails, it cleans up unused resources.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
GHCI
## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.