### PR TITLE
[controller]  Do not lookup RF of existing topics when creating a new topic as it may not be accurate

### DIFF
--- a/internal/venice-common/src/main/java/com/linkedin/venice/kafka/TopicManager.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/kafka/TopicManager.java
@@ -320,10 +320,6 @@ public class TopicManager implements Closeable {
     return kafkaWriteOnlyAdmin.get().deleteTopic(topicName);
   }
 
-  public int getReplicationFactor(PubSubTopic topicName) {
-    return partitionsFor(topicName).iterator().next().replicasNum();
-  }
-
   /**
    * Update retention for the given topic.
    * If the topic doesn't exist, this operation will throw {@link TopicDoesNotExistException}

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/PubSubTopicPartitionInfo.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/PubSubTopicPartitionInfo.java
@@ -6,13 +6,11 @@ import com.linkedin.venice.pubsub.api.PubSubTopic;
 public class PubSubTopicPartitionInfo {
   private final PubSubTopic pubSubTopic;
   private final int partition;
-  private final int replicasNum;
   private final Boolean hasInSyncReplica;
 
-  public PubSubTopicPartitionInfo(PubSubTopic pubSubTopic, int partition, int replicasNum, Boolean hasInSyncReplica) {
+  public PubSubTopicPartitionInfo(PubSubTopic pubSubTopic, int partition, Boolean hasInSyncReplica) {
     this.pubSubTopic = pubSubTopic;
     this.partition = partition;
-    this.replicasNum = replicasNum;
     this.hasInSyncReplica = hasInSyncReplica;
   }
 
@@ -31,17 +29,9 @@ public class PubSubTopicPartitionInfo {
     return hasInSyncReplica;
   }
 
-  public int replicasNum() {
-    return replicasNum;
-  }
-
   @Override
   public String toString() {
-    return String.format(
-        "Partition(topic = %s, partition=%s, replicasInfo = %s, hasInSyncReplica = %s)",
-        pubSubTopic,
-        partition,
-        replicasNum,
-        hasInSyncReplica);
+    return String
+        .format("Partition(topic = %s, partition=%s, hasInSyncReplica = %s)", pubSubTopic, partition, hasInSyncReplica);
   }
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/adapter/kafka/consumer/ApacheKafkaConsumerAdapter.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/adapter/kafka/consumer/ApacheKafkaConsumerAdapter.java
@@ -376,11 +376,7 @@ public class ApacheKafkaConsumerAdapter implements PubSubConsumerAdapter {
     for (PartitionInfo partitionInfo: partitionInfos) {
       if (partitionInfo.topic().equals(topic.getName())) {
         pubSubTopicPartitionInfos.add(
-            new PubSubTopicPartitionInfo(
-                topic,
-                partitionInfo.partition(),
-                partitionInfo.replicas().length,
-                partitionInfo.inSyncReplicas().length > 0));
+            new PubSubTopicPartitionInfo(topic, partitionInfo.partition(), partitionInfo.inSyncReplicas().length > 0));
       }
     }
     return pubSubTopicPartitionInfos;

--- a/internal/venice-common/src/test/java/com/linkedin/venice/kafka/TopicManagerTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/kafka/TopicManagerTest.java
@@ -258,7 +258,6 @@ public class TopicManagerTest {
     Assert.assertEquals(
         topicManager.getTopicRetention(topicNameWithDefaultRetentionPolicy),
         TopicManager.DEFAULT_TOPIC_RETENTION_POLICY_MS);
-    Assert.assertEquals(1, topicManager.getReplicationFactor(topicNameWithDefaultRetentionPolicy));
   }
 
   @Test

--- a/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/PubSubTopicPartitionInfoTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/PubSubTopicPartitionInfoTest.java
@@ -1,0 +1,39 @@
+package com.linkedin.venice.pubsub;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+
+import com.linkedin.venice.pubsub.api.PubSubTopic;
+import org.testng.annotations.Test;
+
+
+/**
+ * Unit tests for {@link PubSubTopicPartitionInfo}.
+ */
+public class PubSubTopicPartitionInfoTest {
+  @Test
+  public void testTopic() {
+    PubSubTopic pubSubTopic = new PubSubTopicImpl("testTopic");
+    PubSubTopicPartitionInfo partitionInfo = new PubSubTopicPartitionInfo(pubSubTopic, 0, true);
+    PubSubTopic result = partitionInfo.topic();
+    assertEquals(result, pubSubTopic);
+  }
+
+  @Test
+  public void testPartition() {
+    PubSubTopicPartitionInfo partitionInfo = new PubSubTopicPartitionInfo(new PubSubTopicImpl("testTopic"), 2, true);
+    assertEquals(partitionInfo.partition(), 2);
+  }
+
+  @Test
+  public void testHasInSyncReplicas() {
+    PubSubTopicPartitionInfo partitionInfo = new PubSubTopicPartitionInfo(new PubSubTopicImpl("testTopic"), 0, false);
+    assertFalse(partitionInfo.hasInSyncReplicas());
+  }
+
+  @Test
+  public void testToString() {
+    PubSubTopicPartitionInfo partitionInfo = new PubSubTopicPartitionInfo(new PubSubTopicImpl("testTopic"), 0, true);
+    assertEquals(partitionInfo.toString(), "Partition(topic = testTopic, partition=0, hasInSyncReplica = true)");
+  }
+}

--- a/internal/venice-test-common/src/main/java/com/linkedin/venice/unit/kafka/MockInMemoryAdminAdapter.java
+++ b/internal/venice-test-common/src/main/java/com/linkedin/venice/unit/kafka/MockInMemoryAdminAdapter.java
@@ -52,7 +52,7 @@ public class MockInMemoryAdminAdapter implements PubSubAdminAdapter {
     topicPubSubTopicConfigurationMap.put(topic, topicPubSubTopicConfiguration);
     topicPartitionNumMap.put(topic, new ArrayList<>());
     for (int i = 0; i < numPartitions; i++) {
-      topicPartitionNumMap.get(topic).add(new PubSubTopicPartitionInfo(topic, i, replication, true));
+      topicPartitionNumMap.get(topic).add(new PubSubTopicPartitionInfo(topic, i, true));
     }
   }
 

--- a/services/venice-controller/src/main/java/com/linkedin/venice/ingestion/control/RealTimeTopicSwitcher.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/ingestion/control/RealTimeTopicSwitcher.java
@@ -46,8 +46,8 @@ public class RealTimeTopicSwitcher {
   private final String destKafkaBootstrapServers;
   private final VeniceWriterFactory veniceWriterFactory;
   private final Time timer;
-  private final Integer kafkaReplicationFactorForRTTopics;
-  private final Integer kafkaReplicationFactor;
+  private final int kafkaReplicationFactorForRTTopics;
+  private final int kafkaReplicationFactor;
   private final Optional<Integer> minSyncReplicasForRTTopics;
 
   private final PubSubTopicRepository pubSubTopicRepository;

--- a/services/venice-controller/src/main/java/com/linkedin/venice/ingestion/control/RealTimeTopicSwitcher.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/ingestion/control/RealTimeTopicSwitcher.java
@@ -47,6 +47,7 @@ public class RealTimeTopicSwitcher {
   private final VeniceWriterFactory veniceWriterFactory;
   private final Time timer;
   private final Integer kafkaReplicationFactorForRTTopics;
+  private final Integer kafkaReplicationFactor;
   private final Optional<Integer> minSyncReplicasForRTTopics;
 
   private final PubSubTopicRepository pubSubTopicRepository;
@@ -64,7 +65,7 @@ public class RealTimeTopicSwitcher {
         veniceProperties.getBooleanWithAlternative(ConfigKeys.KAFKA_OVER_SSL, ConfigKeys.SSL_TO_KAFKA_LEGACY, false)
             ? veniceProperties.getString(ConfigKeys.SSL_KAFKA_BOOTSTRAP_SERVERS)
             : veniceProperties.getString(ConfigKeys.KAFKA_BOOTSTRAP_SERVERS);
-    int kafkaReplicationFactor = veniceProperties.getInt(KAFKA_REPLICATION_FACTOR, DEFAULT_KAFKA_REPLICATION_FACTOR);
+    this.kafkaReplicationFactor = veniceProperties.getInt(KAFKA_REPLICATION_FACTOR, DEFAULT_KAFKA_REPLICATION_FACTOR);
     this.kafkaReplicationFactorForRTTopics =
         veniceProperties.getInt(KAFKA_REPLICATION_FACTOR_RT_TOPICS, kafkaReplicationFactor);
     this.minSyncReplicasForRTTopics = veniceProperties.getOptionalInt(KAFKA_MIN_IN_SYNC_REPLICAS_RT_TOPICS);
@@ -154,9 +155,7 @@ public class RealTimeTopicSwitcher {
       } else {
         partitionCount = store.getPartitionCount();
       }
-      int replicationFactor = srcTopicName.isRealTime()
-          ? kafkaReplicationFactorForRTTopics
-          : getTopicManager().getReplicationFactor(topicWhereToSendTheTopicSwitch);
+      int replicationFactor = srcTopicName.isRealTime() ? kafkaReplicationFactorForRTTopics : kafkaReplicationFactor;
       Optional<Integer> minISR = srcTopicName.isRealTime() ? minSyncReplicasForRTTopics : Optional.empty();
       getTopicManager().createTopic(
           srcTopicName,


### PR DESCRIPTION
##  Do not lookup the replication factor of existing topics when creating a new topic as it may not be accurate
The way we get the replication factor for VTs is not reliable since `partitionInfo.replicas().length != RF` in some  
cases (e.g., offline replicas,  partition reassignment). Besides Kafka doesn't offer an API to get RF at the moment.   
Hence use `kafka.replication.factor` config value as it is a safer option. 



## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.