### PR TITLE
[vpj] Force collect at least 1 sample per input file for zstd dict

### DIFF
--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/InputDataInfoProvider.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/InputDataInfoProvider.java
@@ -101,13 +101,16 @@ public interface InputDataInfoProvider extends Closeable {
         continue;
       }
 
-      if (fileSampleSize + data.length > pushJobZstdConfig.getMaxBytesPerFile()) {
-        String perFileLimitErrorMsg = String.format(
-            "Read %s to build dictionary. Reached limit per file of %s.",
-            ByteUtils.generateHumanReadableByteCountString(fileSampleSize),
-            ByteUtils.generateHumanReadableByteCountString(pushJobZstdConfig.getMaxBytesPerFile()));
-        LOGGER.debug(perFileLimitErrorMsg);
-        return;
+      // At least 1 sample per file should be added until the max sample size is reached
+      if (fileSampleSize > 0) {
+        if (fileSampleSize + data.length > pushJobZstdConfig.getMaxBytesPerFile()) {
+          String perFileLimitErrorMsg = String.format(
+              "Read %s to build dictionary. Reached limit per file of %s.",
+              ByteUtils.generateHumanReadableByteCountString(fileSampleSize),
+              ByteUtils.generateHumanReadableByteCountString(pushJobZstdConfig.getMaxBytesPerFile()));
+          LOGGER.debug(perFileLimitErrorMsg);
+          return;
+        }
       }
 
       // addSample returns false when the data read no longer fits in the 'sample' buffer limit

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/InputDataInfoProvider.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/InputDataInfoProvider.java
@@ -104,22 +104,20 @@ public interface InputDataInfoProvider extends Closeable {
       // At least 1 sample per file should be added until the max sample size is reached
       if (fileSampleSize > 0) {
         if (fileSampleSize + data.length > pushJobZstdConfig.getMaxBytesPerFile()) {
-          String perFileLimitErrorMsg = String.format(
-              "Read %s to build dictionary. Reached limit per file of %s.",
+          LOGGER.debug(
+              "Read {} to build dictionary. Reached limit per file of {}.",
               ByteUtils.generateHumanReadableByteCountString(fileSampleSize),
               ByteUtils.generateHumanReadableByteCountString(pushJobZstdConfig.getMaxBytesPerFile()));
-          LOGGER.debug(perFileLimitErrorMsg);
           return;
         }
       }
 
       // addSample returns false when the data read no longer fits in the 'sample' buffer limit
       if (!pushJobZstdConfig.getZstdDictTrainer().addSample(data)) {
-        String maxSamplesReadErrorMsg = String.format(
-            "Read %s to build dictionary. Reached sample limit of %s.",
+        LOGGER.debug(
+            "Read {} to build dictionary. Reached sample limit of {}.",
             ByteUtils.generateHumanReadableByteCountString(fileSampleSize),
             ByteUtils.generateHumanReadableByteCountString(pushJobZstdConfig.getMaxSampleSize()));
-        LOGGER.debug(maxSamplesReadErrorMsg);
         return;
       }
       fileSampleSize += data.length;

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
@@ -72,6 +72,7 @@ import com.linkedin.venice.serialization.avro.InternalAvroSpecificSerializer;
 import com.linkedin.venice.status.PushJobDetailsStatus;
 import com.linkedin.venice.status.protocol.PushJobDetails;
 import com.linkedin.venice.status.protocol.PushJobDetailsStatusTuple;
+import com.linkedin.venice.utils.ByteUtils;
 import com.linkedin.venice.utils.DictionaryUtils;
 import com.linkedin.venice.utils.EncodingUtils;
 import com.linkedin.venice.utils.PartitionUtils;
@@ -2023,22 +2024,24 @@ public class VenicePushJob implements AutoCloseable {
       pushJobDetails.totalZstdWithDictCompressedValueBytes =
           MRJobCounterHelper.getTotalZstdWithDictCompressedValueSize(runningJob.getCounters());
       LOGGER.info(
-          "pushJobDetails MR Counters: " + "\n\tTotal number of records: {} " + "\n\tSize of keys: {} Bytes "
-              + "\n\tsize of uncompressed value: {} Bytes " + "\n\tConfigured value Compression Strategy: {} "
-              + "\n\tFinal data size stored in Venice based on this compression strategy: {} Bytes "
+          "pushJobDetails MR Counters: " + "\n\tTotal number of records: {} " + "\n\tSize of keys: {} "
+              + "\n\tsize of uncompressed value: {} " + "\n\tConfigured value Compression Strategy: {} "
+              + "\n\tFinal data size stored in Venice based on this compression strategy: {} "
               + "\n\tCompression Metrics collection is: {} ",
           pushJobDetails.totalNumberOfRecords,
-          pushJobDetails.totalKeyBytes,
-          pushJobDetails.totalRawValueBytes,
+          ByteUtils.generateHumanReadableByteCountString(pushJobDetails.totalKeyBytes),
+          ByteUtils.generateHumanReadableByteCountString(pushJobDetails.totalRawValueBytes),
           CompressionStrategy.valueOf(pushJobDetails.valueCompressionStrategy).name(),
-          pushJobDetails.totalCompressedValueBytes,
+          ByteUtils.generateHumanReadableByteCountString(pushJobDetails.totalCompressedValueBytes),
           pushJobSetting.compressionMetricCollectionEnabled ? "Enabled" : "Disabled");
       if (pushJobSetting.compressionMetricCollectionEnabled) {
-        LOGGER.info("\tData size if compressed using Gzip: {} Bytes ", pushJobDetails.totalGzipCompressedValueBytes);
+        LOGGER.info(
+            "\tData size if compressed using Gzip: {} ",
+            ByteUtils.generateHumanReadableByteCountString(pushJobDetails.totalGzipCompressedValueBytes));
         if (isZstdDictCreationSuccess) {
           LOGGER.info(
-              "\tData size if compressed using Zstd with Dictionary: {} Bytes",
-              pushJobDetails.totalZstdWithDictCompressedValueBytes);
+              "\tData size if compressed using Zstd with Dictionary: {} ",
+              ByteUtils.generateHumanReadableByteCountString(pushJobDetails.totalZstdWithDictCompressedValueBytes));
         } else {
           LOGGER.info("\tZstd Dictionary creation Failed");
         }


### PR DESCRIPTION
## Summary
In VPJ, `PushJobZstdConfig` calculates number of bytes to be collected per input file baed on the configurable sample size(default `200MB`). If that ends up being less than size of first value in file, no samples get collected from that file potentially leading to skipping zstd dictionary creation. Changing this to add an extra check to add at least 1 sample per input file(until reaching 200MB).

## How was this PR tested?
github ci

## Does this PR introduce any user-facing changes?
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.