### PR TITLE
[vpj][samza][controller][tc][fc] Increase timeout for D2Client startup

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/utils/IsolatedIngestionUtils.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/utils/IsolatedIngestionUtils.java
@@ -16,9 +16,6 @@ import static com.linkedin.venice.ingestion.protocol.enums.IngestionAction.REPOR
 import static com.linkedin.venice.ingestion.protocol.enums.IngestionAction.SHUTDOWN_COMPONENT;
 import static com.linkedin.venice.ingestion.protocol.enums.IngestionAction.UPDATE_METADATA;
 
-import com.linkedin.common.callback.Callback;
-import com.linkedin.common.util.None;
-import com.linkedin.d2.balancer.D2Client;
 import com.linkedin.davinci.config.VeniceConfigLoader;
 import com.linkedin.davinci.ingestion.isolated.IsolatedIngestionServer;
 import com.linkedin.davinci.ingestion.isolated.IsolatedIngestionServerAclHandler;
@@ -80,8 +77,6 @@ import java.util.AbstractMap;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.avro.specific.SpecificRecordBase;
@@ -223,31 +218,6 @@ public class IsolatedIngestionUtils {
       throw new VeniceException(
           "Only able to parse POST requests for IngestionActions. Cannot support action: " + requestParts[1],
           e);
-    }
-  }
-
-  public static void startD2Client(D2Client d2Client) {
-    CountDownLatch latch = new CountDownLatch(1);
-    d2Client.start(new Callback<None>() {
-      @Override
-      public void onSuccess(None result) {
-        latch.countDown();
-        LOGGER.info("D2 client started successfully");
-      }
-
-      @Override
-      public void onError(Throwable e) {
-        latch.countDown();
-        LOGGER.error("D2 client failed to startup", e);
-      }
-    });
-    try {
-      if (!latch.await(D2_STARTUP_TIMEOUT, TimeUnit.MILLISECONDS)) {
-        throw new VeniceException("Time out after " + D2_STARTUP_TIMEOUT + "ms waiting for D2 client to startup");
-      }
-    } catch (InterruptedException e) {
-      Thread.currentThread().interrupt();
-      throw new VeniceException("latch wait was interrupted, d2 client may not have had enough time to startup", e);
     }
   }
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/utils/IsolatedIngestionUtils.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/utils/IsolatedIngestionUtils.java
@@ -98,7 +98,6 @@ public class IsolatedIngestionUtils {
   public static final String PID = "pid";
 
   private static final Logger LOGGER = LogManager.getLogger(IsolatedIngestionUtils.class);
-  private static final int D2_STARTUP_TIMEOUT = 60000;
   private static final int SHELL_COMMAND_WAIT_TIME = 1000;
 
   private static final InternalAvroSpecificSerializer<IngestionTaskCommand> ingestionTaskCommandSerializer =

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/D2/D2ClientUtils.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/D2/D2ClientUtils.java
@@ -26,7 +26,7 @@ import org.apache.logging.log4j.Logger;
 
 public class D2ClientUtils {
   private static final Logger LOGGER = LogManager.getLogger(D2ClientUtils.class);
-  private static long DEFAULT_D2_STARTUP_TIMEOUT_MS = 5_000;
+  private static long DEFAULT_D2_STARTUP_TIMEOUT_MS = 60_000;
   private static long DEFAULT_D2_SHUTDOWN_TIMEOUT_MS = 60_000;
 
   public static void startClient(D2Client client) {

--- a/internal/venice-common/src/main/java/com/linkedin/venice/d2/D2ClientFactory.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/d2/D2ClientFactory.java
@@ -41,7 +41,6 @@ public class D2ClientFactory {
           .setSSLContext(sslFactoryOptional.map(SSLFactory::getSSLContext).orElse(null))
           .setIsSSLEnabled(sslFactoryOptional.isPresent())
           .setSSLParameters(sslFactoryOptional.map(SSLFactory::getSSLParameters).orElse(null))
-          .setRetry(true)
           .build();
       if (!unitTestMode) {
         try {

--- a/internal/venice-common/src/main/java/com/linkedin/venice/d2/D2ClientFactory.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/d2/D2ClientFactory.java
@@ -41,6 +41,7 @@ public class D2ClientFactory {
           .setSSLContext(sslFactoryOptional.map(SSLFactory::getSSLContext).orElse(null))
           .setIsSSLEnabled(sslFactoryOptional.isPresent())
           .setSSLParameters(sslFactoryOptional.map(SSLFactory::getSSLParameters).orElse(null))
+          .setRetry(true)
           .build();
       if (!unitTestMode) {
         try {


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Increase timeout for D2Client startup
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
Currently, when creating a D2 client via `D2ClientFactory`, the code only waits for 5 seconds. This commit increases the timeout to 60 seconds.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
GH CI

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.