### PR TITLE
[server][da-vinci] Standardize ingestion stats on ready to serve lag check

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
@@ -1297,22 +1297,15 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
     long offsetLagThreshold = hybridStoreConfig.get().getOffsetLagThresholdToGoOnline();
     for (PartitionConsumptionState pcs: partitionConsumptionStateMap.values()) {
       if (pcs.hasLagCaughtUp() && offsetLagThreshold >= 0) {
-        Set<String> sourceRealTimeTopicKafkaURLs = getRealTimeDataSourceKafkaAddress(pcs);
-        if (sourceRealTimeTopicKafkaURLs.isEmpty()) {
-          return true;
-        }
-        int numberOfUnreachableRegions = 0;
-        for (String sourceRealTimeTopicKafkaURL: sourceRealTimeTopicKafkaURLs) {
-          try {
-            // Return true if offset lag in any reachable region is larger than the threshold
-            if (measureRTOffsetLagForSingleRegion(sourceRealTimeTopicKafkaURL, pcs, false) > offsetLagThreshold) {
-              return true;
-            }
-          } catch (Exception e) {
-            if (++numberOfUnreachableRegions > 1) {
-              return true;
-            }
+        // If pcs is marked has having caught up, but we're not ready to serve, that means we're lagging
+        // after having announced that we are ready to serve.
+        try {
+          if (!this.isReadyToServe(pcs)) {
+            return true;
           }
+        } catch (Exception e) {
+          // Something wasn't reachable, we'll report that something is amiss.
+          return true;
         }
       }
     }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
@@ -1297,7 +1297,7 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
     long offsetLagThreshold = hybridStoreConfig.get().getOffsetLagThresholdToGoOnline();
     for (PartitionConsumptionState pcs: partitionConsumptionStateMap.values()) {
       if (pcs.hasLagCaughtUp() && offsetLagThreshold >= 0) {
-        // If pcs is marked has having caught up, but we're not ready to serve, that means we're lagging
+        // If pcs is marked as having caught up, but we're not ready to serve, that means we're lagging
         // after having announced that we are ready to serve.
         try {
           if (!this.isReadyToServe(pcs)) {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -2998,24 +2998,6 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
     return VeniceSystemStoreUtils.isSystemStore(storeName);
   }
 
-  /**
-   * This method fetches/calculates latest leader consumed offset and last offset in RT topic. The method relies on
-   * {@link #getLatestConsumedUpstreamOffsetForHybridOffsetLagMeasurement(PartitionConsumptionState, String)} to fetch
-   * latest leader consumed offset for different data replication policy.
-   * @return the lag (lastOffsetInRealTimeTopic - latestConsumedLeaderOffset)
-   */
-  protected long getLatestLeaderConsumedOffsetAndHybridTopicOffset(
-      String sourceRealTimeTopicKafkaURL,
-      PubSubTopic leaderTopic,
-      PartitionConsumptionState pcs) {
-    return getLatestLeaderOffsetAndHybridTopicOffset(
-        sourceRealTimeTopicKafkaURL,
-        leaderTopic,
-        pcs,
-        this::getLatestConsumedUpstreamOffsetForHybridOffsetLagMeasurement,
-        false);
-  }
-
   private long getLatestLeaderOffsetAndHybridTopicOffset(
       String sourceRealTimeTopicKafkaURL,
       PubSubTopic leaderTopic,

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -2367,7 +2367,6 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
           if (currentLeaderTopic == null) {
             currentLeaderTopic = versionTopic;
           }
-
           final String kafkaSourceAddress = getSourceKafkaUrlForOffsetLagMeasurement(pcs);
           // Consumer might not exist after the consumption state is created, but before attaching the corresponding
           // consumer.
@@ -2378,10 +2377,7 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
 
           // Fall back to calculate offset lag in the original approach
           if (currentLeaderTopic.isRealTime()) {
-            // Since partition count in RT : partition count in VT = 1 : AMP, we will need amplification factor adaptor
-            // to calculate the offset for every subPartitions.
-            long lag = getLatestLeaderConsumedOffsetAndHybridTopicOffset(kafkaSourceAddress, currentLeaderTopic, pcs);
-            return lag - 1;
+            return this.measureHybridOffsetLag(pcs, false);
           } else {
             return (cachedKafkaMetadataGetter
                 .getOffset(getTopicManager(kafkaSourceAddress), currentLeaderTopic, pcs.getPartition()) - 1)

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -3131,4 +3131,9 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
   protected Lazy<VeniceWriter<byte[], byte[], byte[]>> getVeniceWriter() {
     return veniceWriter;
   }
+
+  // test method
+  protected void addPartititionConsumptionState(Integer partition, PartitionConsumptionState pcs) {
+    partitionConsumptionStateMap.put(partition, pcs);
+  }
 }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/TestPubSubTopic.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/TestPubSubTopic.java
@@ -1,0 +1,32 @@
+package com.linkedin.davinci.kafka.consumer;
+
+import com.linkedin.venice.pubsub.api.PubSubTopic;
+import com.linkedin.venice.pubsub.api.PubSubTopicType;
+
+
+public class TestPubSubTopic implements PubSubTopic {
+  String topicName;
+  String storeName;
+  PubSubTopicType topicType;
+
+  public TestPubSubTopic(String topicName, String storeName, PubSubTopicType topicType) {
+    this.topicName = topicName;
+    this.storeName = storeName;
+    this.topicType = topicType;
+  }
+
+  @Override
+  public String getName() {
+    return topicName;
+  }
+
+  @Override
+  public PubSubTopicType getPubSubTopicType() {
+    return topicType;
+  }
+
+  @Override
+  public String getStoreName() {
+    return storeName;
+  }
+}


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Standardize ingestion stats on ready to serve lag check

The old measure is out of the date with what we actually use for ready to serve. So this will remove false alarms and give more transparency in our metrics.

Resolves #XXX

## How was this PR tested?
test suite

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.