### PR TITLE
[controller] register meta system store schema before initializing helix manager

### DIFF
--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceControllerWrapper.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceControllerWrapper.java
@@ -4,6 +4,8 @@ import static com.linkedin.venice.ConfigKeys.ADMIN_PORT;
 import static com.linkedin.venice.ConfigKeys.ADMIN_SECURE_PORT;
 import static com.linkedin.venice.ConfigKeys.ADMIN_TOPIC_REPLICATION_FACTOR;
 import static com.linkedin.venice.ConfigKeys.CHILD_CLUSTER_ALLOWLIST;
+import static com.linkedin.venice.ConfigKeys.CHILD_CLUSTER_D2_PREFIX;
+import static com.linkedin.venice.ConfigKeys.CHILD_CLUSTER_D2_SERVICE_NAME;
 import static com.linkedin.venice.ConfigKeys.CHILD_CLUSTER_URL_PREFIX;
 import static com.linkedin.venice.ConfigKeys.CHILD_CLUSTER_WHITELIST;
 import static com.linkedin.venice.ConfigKeys.CHILD_DATA_CENTER_KAFKA_URL_PREFIX;
@@ -30,6 +32,7 @@ import static com.linkedin.venice.ConfigKeys.KAFKA_ADMIN_CLASS;
 import static com.linkedin.venice.ConfigKeys.KAFKA_BOOTSTRAP_SERVERS;
 import static com.linkedin.venice.ConfigKeys.KAFKA_REPLICATION_FACTOR;
 import static com.linkedin.venice.ConfigKeys.KAFKA_SECURITY_PROTOCOL;
+import static com.linkedin.venice.ConfigKeys.LOCAL_REGION_NAME;
 import static com.linkedin.venice.ConfigKeys.MIN_ACTIVE_REPLICA;
 import static com.linkedin.venice.ConfigKeys.NATIVE_REPLICATION_FABRIC_ALLOWLIST;
 import static com.linkedin.venice.ConfigKeys.NATIVE_REPLICATION_SOURCE_FABRIC;
@@ -252,6 +255,11 @@ public class VeniceControllerWrapper extends ProcessWrapper {
                   childController.getKafkaBootstrapServers(options.isSslToKafka()));
             }
           }
+        } else {
+          builder.put(CHILD_CLUSTER_D2_SERVICE_NAME, D2_SERVICE_NAME);
+          String regionName = options.getExtraProperties().getProperty(LOCAL_REGION_NAME, options.getRegionName());
+          builder.put(LOCAL_REGION_NAME, regionName);
+          builder.put(CHILD_CLUSTER_D2_PREFIX + regionName, options.getZkAddress());
         }
         builder.put(CHILD_CLUSTER_ALLOWLIST, fabricAllowList);
 

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceController.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceController.java
@@ -202,6 +202,7 @@ public class VeniceController {
           Optional.of(new StoreBackupVersionCleanupService((VeniceHelixAdmin) admin, multiClusterConfigs));
       LOGGER.info("StoreBackupVersionCleanupService is enabled");
     }
+    // Run before enabling controller in helix so leadership won't hand back to this controller during schema requests.
     initializeSystemSchema(controllerService.getVeniceHelixAdmin());
   }
 

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerConfig.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerConfig.java
@@ -829,6 +829,10 @@ public class VeniceControllerConfig extends VeniceControllerClusterConfig {
     return getProps().getString(CHILD_CLUSTER_URL_PREFIX + fabric, "");
   }
 
+  public String getChildControllerD2ServiceName() {
+    return getProps().getString(CHILD_CLUSTER_D2_SERVICE_NAME, "");
+  }
+
   public String getChildControllerD2ZkHost(String fabric) {
     return getProps().getString(CHILD_CLUSTER_D2_PREFIX + fabric, "");
   }


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Summary
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Current behavior: After helix manager initialization, controller finds system schema cluster leader controller url from helix manager, build controller client using the url, register schemas via the controller client.

Problem: During deployment, when leader controller A stops, helix assigns controller B as leader. When A's controller service starts again, helix wants to hand over leadership to A so it transits B from leader to standby. Before transition completes, B is still the leader and all A's requests are sent to B. But since B clears in-memory store map, it throws no store exception to A's requests. A fails to start.

Fix: Before helix manager initialization, controller builds controller client using url or d2 configs and registers system schemas. Since the controller instance is still disabled in helix, helix won't hand over leadership back to A and won't transit B from leader to standby. B will handle A's requests successfully. Also, in case that leadership transits from B to another controller C, increase the number of retries to cover leader->standby period.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

Ran integration tests and tested in EI

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.