### PR TITLE
[server] Minor improvement of ingestion isolation logging

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/main/MainIngestionReportHandler.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/main/MainIngestionReportHandler.java
@@ -173,7 +173,7 @@ public class MainIngestionReportHandler extends SimpleChannelInboundHandler<Full
         StoreVersionState storeVersionState =
             IsolatedIngestionUtils.deserializeStoreVersionState(topicName, report.storeVersionState.array());
         mainIngestionMonitorService.getStorageMetadataService().putStoreVersionState(topicName, storeVersionState);
-        LOGGER.info("Updated storeVersionState: {} for topic: {}", storeVersionState.toString(), topicName);
+        LOGGER.info("Updated storeVersionState for topic: {}", topicName);
       }
     }
   }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionService.java
@@ -744,7 +744,7 @@ public class KafkaStoreIngestionService extends AbstractVeniceService implements
         }
         sleep(retryIntervalInMs);
       }
-      LOGGER.error(
+      LOGGER.warn(
           "Topic: {}, partition: {} is still having pending ingestion action for it to stop for {} ms.",
           topicName,
           partition,
@@ -888,11 +888,11 @@ public class KafkaStoreIngestionService extends AbstractVeniceService implements
                 partitionId,
                 topicName,
                 LatencyUtils.getElapsedTimeInMs(startTimeInMs));
-            break;
+            return;
           }
           sleep((long) sleepSeconds * Time.MS_PER_SECOND);
         }
-        LOGGER.error(
+        LOGGER.warn(
             "Partition: {} of store: {} is still consuming after waiting for it to stop for {} seconds.",
             partitionId,
             topicName,


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## [server] Minor improvement of ingestion isolation logging
1. Fix a log bug happen during ingestion isolation handover: When the SIT partition is shutdown in time, the old logic still log wrong msg that it does not stop in time and the log is ERROR level. This causes in house deployment tooling to report ERROR logging issues. This PR fixes the logic to only log it when it is actually times out and reduce the log to WARN level.
2. Remove StoreVersionState.toString() logging in handover as this is the underlying SpecificRecord's toString and will print out binary data we store inside SVS. This PR simply remove the logging as we are not interested into the content of the SVS. 

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
Existing tests.
## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.