### PR TITLE
[admin-tool][data-recovery] Added handling for batch stores during store repush.

### DIFF
--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/datarecovery/DataRecoveryClient.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/datarecovery/DataRecoveryClient.java
@@ -3,23 +3,11 @@ package com.linkedin.venice.datarecovery;
 import static com.linkedin.venice.datarecovery.DataRecoveryWorker.INTERVAL_UNSET;
 
 import com.linkedin.venice.controllerapi.ControllerClient;
-import com.linkedin.venice.controllerapi.MultiStoreStatusResponse;
-import com.linkedin.venice.controllerapi.StoreHealthAuditResponse;
-import com.linkedin.venice.exceptions.VeniceException;
-import com.linkedin.venice.meta.RegionPushDetails;
-import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.security.SSLFactory;
 import com.linkedin.venice.utils.Utils;
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
 import java.util.Optional;
 import java.util.Scanner;
 import java.util.Set;
-import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.tuple.Pair;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -60,94 +48,28 @@ public class DataRecoveryClient {
     return monitor;
   }
 
-  public Map<String, Pair<Boolean, String>> getRepushViability(
-      Set<String> storesList,
-      StoreRepushCommand.Params params) {
-    Map<String, Pair<Boolean, String>> ret = new HashMap<>();
-    String url = params.getUrl();
-    ControllerClient cli = params.getPCtrlCliWithoutCluster();
-    LocalDateTime timestamp = params.getTimestamp();
-    String destFabric = params.getDestFabric();
-    for (String s: storesList) {
-      try {
-        String clusterName = cli.discoverCluster(s).getCluster();
-        if (clusterName == null) {
-          ret.put(s, Pair.of(false, "unable to discover cluster for store (likely invalid store name)"));
-          continue;
-        }
-        try (ControllerClient parentCtrlCli = buildControllerClient(clusterName, url, params.getSSLFactory())) {
-          StoreHealthAuditResponse storeHealthInfo = parentCtrlCli.listStorePushInfo(s, false);
-          Map<String, RegionPushDetails> regionPushDetails = storeHealthInfo.getRegionPushDetails();
-          if (!regionPushDetails.containsKey(destFabric)) {
-            ret.put(s, Pair.of(false, "nothing to repush, store version 0"));
-            continue;
-          }
-          String latestTimestamp = regionPushDetails.get(destFabric).getPushStartTimestamp();
-          LocalDateTime latestPushStartTime =
-              LocalDateTime.parse(latestTimestamp, DateTimeFormatter.ISO_LOCAL_DATE_TIME);
-
-          if (latestPushStartTime.isAfter(timestamp)) {
-            ret.put(s, Pair.of(false, "input timestamp earlier than latest push"));
-            continue;
-          }
-
-          MultiStoreStatusResponse response = parentCtrlCli.getFutureVersions(clusterName, s);
-          // No future version status for target region.
-          if (!response.getStoreStatusMap().containsKey(destFabric)) {
-            ret.put(s, Pair.of(true, StringUtils.EMPTY));
-            continue;
-          }
-
-          int futureVersion = Integer.parseInt(response.getStoreStatusMap().get(destFabric));
-          // No ongoing offline pushes detected for target region.
-          if (futureVersion == Store.NON_EXISTING_VERSION) {
-            ret.put(s, Pair.of(true, StringUtils.EMPTY));
-            continue;
-          }
-          // Find ongoing pushes for this store, skip.
-          ret.put(s, Pair.of(false, String.format("find ongoing push, version: %d", futureVersion)));
-        }
-      } catch (VeniceException e) {
-        ret.put(s, Pair.of(false, "VeniceHttpException " + e.getErrorType().toString()));
-      }
-    }
-    return ret;
-  }
-
   public ControllerClient buildControllerClient(String clusterName, String url, Optional<SSLFactory> sslFactory) {
     return new ControllerClient(clusterName, url, sslFactory);
   }
 
   public void execute(DataRecoveryParams drParams, StoreRepushCommand.Params cmdParams) {
     Set<String> storeNames = drParams.getRecoveryStores();
-    Map<String, Pair<Boolean, String>> pushMap = getRepushViability(storeNames, cmdParams);
-    Set<String> filteredStoreNames = new HashSet<>();
 
-    for (Map.Entry<String, Pair<Boolean, String>> e: pushMap.entrySet()) {
-      if (e.getValue().getLeft()) {
-        filteredStoreNames.add(e.getKey());
-      } else {
-        this.getExecutor().getSkippedStores().add(e.getKey());
-      }
-    }
-
-    if (!filteredStoreNames.isEmpty()) {
-      if (!drParams.isNonInteractive && !confirmStores(filteredStoreNames)) {
+    if (!storeNames.isEmpty()) {
+      if (!drParams.isNonInteractive && !confirmStores(storeNames)) {
         return;
       }
-      getExecutor().perform(filteredStoreNames, cmdParams);
+      getExecutor().perform(storeNames, cmdParams);
     } else {
       LOGGER.warn("store list is empty, exit.");
     }
 
     // check if we filtered stores based on push info, report them
-    if (getExecutor().getSkippedStores().size() > 0) {
-      LOGGER.info("================");
-      LOGGER.info("STORES STORES WERE SKIPPED:");
-      for (String store: getExecutor().getSkippedStores()) {
-        LOGGER.info(store + " : " + pushMap.get(store).getRight());
+    for (DataRecoveryTask t: getExecutor().getTasks()) {
+      StoreRepushCommand cmd = (StoreRepushCommand) t.getCommand();
+      if (cmd.getResult().getError() != null) {
+        LOGGER.info("Store " + t.getTaskParams().getStore() + " skipped: " + t.getTaskResult().getError());
       }
-      LOGGER.info("================");
     }
     getExecutor().shutdownAndAwaitTermination();
   }

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/datarecovery/DataRecoveryTask.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/datarecovery/DataRecoveryTask.java
@@ -35,6 +35,10 @@ public class DataRecoveryTask implements Runnable {
     return taskParams;
   }
 
+  public Command getCommand() {
+    return command;
+  }
+
   public static class TaskResult {
     private final Command.Result cmdResult;
 

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/datarecovery/StoreRepushCommand.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/datarecovery/StoreRepushCommand.java
@@ -1,17 +1,26 @@
 package com.linkedin.venice.datarecovery;
 
 import com.linkedin.venice.controllerapi.ControllerClient;
+import com.linkedin.venice.controllerapi.MultiStoreStatusResponse;
+import com.linkedin.venice.controllerapi.StoreHealthAuditResponse;
+import com.linkedin.venice.controllerapi.StoreResponse;
+import com.linkedin.venice.exceptions.VeniceException;
+import com.linkedin.venice.meta.RegionPushDetails;
+import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.security.SSLFactory;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -65,9 +74,9 @@ public class StoreRepushCommand extends Command {
   private List<String> generateRepushCommand() {
     List<String> cmd = new ArrayList<>();
     cmd.add(this.getParams().command);
-    cmd.add(this.params.extraCommandArgs);
-    cmd.add(String.format("--store '%s'", this.params.store));
-    cmd.add(String.format("--fabric '%s'", this.params.sourceFabric));
+    cmd.add(this.getParams().extraCommandArgs);
+    cmd.add(String.format("--store '%s'", this.getParams().store));
+    cmd.add(String.format("--fabric '%s'", this.getParams().sourceFabric));
     return cmd;
   }
 
@@ -88,14 +97,100 @@ public class StoreRepushCommand extends Command {
   }
 
   private void processOutput(String output, int exitCode) {
-    result.setStdOut(output);
-    result.setExitCode(exitCode);
-    result.parseStandardOutput();
-    result.setCoreWorkDone(true);
+    getResult().setStdOut(output);
+    getResult().setExitCode(exitCode);
+    getResult().parseStandardOutput();
+    getResult().setCoreWorkDone(true);
+  }
+
+  public ControllerClient buildControllerClient(String clusterName, String url, Optional<SSLFactory> sslFactory) {
+    return new ControllerClient(clusterName, url, sslFactory);
+  }
+
+  public Pair<Boolean, String> getRepushViability() {
+    String url = getParams().getUrl();
+    ControllerClient cli = getParams().getPCtrlCliWithoutCluster();
+    LocalDateTime timestamp = getParams().getTimestamp();
+    String destFabric = getParams().getDestFabric();
+    String s = getParams().getStore();
+    try {
+      String clusterName = cli.discoverCluster(s).getCluster();
+      if (clusterName == null) {
+        return Pair.of(false, "unable to discover cluster for store (likely invalid store name)");
+      }
+      try (ControllerClient parentCtrlCli = buildControllerClient(clusterName, url, getParams().getSSLFactory())) {
+        StoreHealthAuditResponse storeHealthInfo = parentCtrlCli.listStorePushInfo(s, false);
+        Map<String, RegionPushDetails> regionPushDetails = storeHealthInfo.getRegionPushDetails();
+        if (!regionPushDetails.containsKey(destFabric)) {
+          return Pair.of(false, "nothing to repush, store version 0");
+        }
+        String latestTimestamp = regionPushDetails.get(destFabric).getPushStartTimestamp();
+        LocalDateTime latestPushStartTime = LocalDateTime.parse(latestTimestamp, DateTimeFormatter.ISO_LOCAL_DATE_TIME);
+
+        if (latestPushStartTime.isAfter(timestamp)) {
+          return Pair.of(false, "input timestamp earlier than latest push");
+        }
+
+        boolean isBatch = false;
+        StoreResponse storeResponse = parentCtrlCli.getStore(s);
+        if (storeResponse.getStore().getHybridStoreConfig() != null) {
+          isBatch = true;
+        }
+
+        MultiStoreStatusResponse response = parentCtrlCli.getFutureVersions(clusterName, s);
+        // No future version status for target region.
+        if (!response.getStoreStatusMap().containsKey(destFabric)) {
+          return Pair.of(true, isBatch ? "BATCH" : StringUtils.EMPTY);
+        }
+
+        int futureVersion = Integer.parseInt(response.getStoreStatusMap().get(destFabric));
+        // No ongoing offline pushes detected for target region.
+        if (futureVersion == Store.NON_EXISTING_VERSION) {
+          return Pair.of(true, isBatch ? "BATCH" : StringUtils.EMPTY);
+        }
+        // Find ongoing pushes for this store, skip.
+        return Pair.of(false, String.format("find ongoing push, version: %d", futureVersion));
+      }
+    } catch (VeniceException e) {
+      return Pair.of(false, "VeniceHttpException " + e.getErrorType().toString());
+    }
   }
 
   @Override
   public void execute() {
+    Pair<Boolean, String> repushViability = getRepushViability();
+    StoreRepushCommand.Params repushParams = getParams();
+    ControllerClient cli = repushParams.getPCtrlCliWithoutCluster();
+    if (repushViability.getLeft() == false) {
+      processOutput(repushViability.getRight(), 1);
+      return;
+    }
+    if (repushViability.getRight() == "BATCH") {
+      try {
+        String clusterName = cli.discoverCluster(repushParams.getStore()).getCluster();
+        try (ControllerClient parentCtrlCli =
+            buildControllerClient(clusterName, repushParams.getUrl(), repushParams.getSSLFactory())) {
+          parentCtrlCli.prepareDataRecovery(
+              repushParams.getSourceFabric(),
+              repushParams.getDestFabric(),
+              repushParams.getStore(),
+              -1,
+              Optional.empty());
+          parentCtrlCli.dataRecovery(
+              repushParams.getSourceFabric(),
+              repushParams.getDestFabric(),
+              repushParams.getStore(),
+              -1,
+              false,
+              true,
+              Optional.empty());
+          processOutput("success: (batch store -- no url)", 0);
+        }
+      } catch (VeniceException e) {
+        processOutput(e.getMessage(), 1);
+      }
+      return;
+    }
     ProcessBuilder pb = new ProcessBuilder(getShellCmd());
     // so we can ignore the error stream.
     pb.redirectErrorStream(true);
@@ -131,7 +226,7 @@ public class StoreRepushCommand extends Command {
       }
     }
 
-    if (params.debug) {
+    if (getParams().debug) {
       LOGGER.info("Cmd: {}, StdOut: {}, Exit code: {}", this, stdOut, exitCode);
     }
   }


### PR DESCRIPTION
## Summary
[WORK IN PROGRESS] This set of changes adds additional logic for handling batch stores during a repush request. Additionally, this commit moves some functionality for determining whether or not a store can be repushed to the task execution level, parallelizing a previously introduced single-threaded linear check.

## How was this PR tested?
Currently testing.

## Does this PR introduce any user-facing changes?
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.