### PR TITLE
[server][controller] Support meta system store schema registeration at server start time

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -719,7 +719,6 @@ ext.createDiffFile = { ->
         ':!internal/venice-test-common/*',
         ':!services/venice-server/src/main/java/com/linkedin/venice/server/VeniceServer.java',
         ':!internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerClient.java',
-        ':!services/venice-controller/src/main/java/com/linkedin/venice/controller/init/*',
         ':!services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceController.java',
         ':!services/venice-router/src/main/java/com/linkedin/venice/router/RouterServer.java',
         ':!services/venice-router/src/main/java/com/linkedin/venice/router/streaming/VeniceChunkedResponse.java',

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
@@ -20,6 +20,9 @@ import static com.linkedin.venice.ConfigKeys.KEY_VALUE_PROFILING_ENABLED;
 import static com.linkedin.venice.ConfigKeys.LEADER_FOLLOWER_STATE_TRANSITION_THREAD_POOL_STRATEGY;
 import static com.linkedin.venice.ConfigKeys.LISTENER_HOSTNAME;
 import static com.linkedin.venice.ConfigKeys.LISTENER_PORT;
+import static com.linkedin.venice.ConfigKeys.LOCAL_CONTROLLER_D2_SERVICE_NAME;
+import static com.linkedin.venice.ConfigKeys.LOCAL_CONTROLLER_URL;
+import static com.linkedin.venice.ConfigKeys.LOCAL_D2_ZK_HOST;
 import static com.linkedin.venice.ConfigKeys.MAX_FUTURE_VERSION_LEADER_FOLLOWER_STATE_TRANSITION_THREAD_NUMBER;
 import static com.linkedin.venice.ConfigKeys.MAX_LEADER_FOLLOWER_STATE_TRANSITION_THREAD_NUMBER;
 import static com.linkedin.venice.ConfigKeys.OFFSET_LAG_DELTA_RELAX_FACTOR_FOR_FAST_ONLINE_TRANSITION_IN_RESTART;
@@ -101,6 +104,7 @@ import static com.linkedin.venice.ConfigKeys.STORE_WRITER_BUFFER_MEMORY_CAPACITY
 import static com.linkedin.venice.ConfigKeys.STORE_WRITER_BUFFER_NOTIFY_DELTA;
 import static com.linkedin.venice.ConfigKeys.STORE_WRITER_NUMBER;
 import static com.linkedin.venice.ConfigKeys.SYSTEM_SCHEMA_CLUSTER_NAME;
+import static com.linkedin.venice.ConfigKeys.SYSTEM_SCHEMA_INITIALIZATION_AT_START_TIME_ENABLED;
 import static com.linkedin.venice.ConfigKeys.UNREGISTER_METRIC_FOR_DELETED_STORE_ENABLED;
 import static com.linkedin.venice.ConfigKeys.UNSORTED_INPUT_DRAINER_SIZE;
 
@@ -368,6 +372,10 @@ public class VeniceServerConfig extends VeniceClusterConfig {
   private final long fastClassSchemaWarmupTimeout;
 
   private final boolean schemaPresenceCheckEnabled;
+  private final boolean systemSchemaInitializationAtStartTimeEnabled;
+  private final String localControllerUrl;
+  private final String localControllerD2ServiceName;
+  private final String localD2ZkHost;
 
   private final boolean enableLiveConfigBasedKafkaThrottling;
 
@@ -599,6 +607,11 @@ public class VeniceServerConfig extends VeniceClusterConfig {
     fastClassSchemaWarmupTimeout =
         serverProperties.getLong(SERVER_SCHEMA_FAST_CLASS_WARMUP_TIMEOUT, 2 * Time.MS_PER_MINUTE);
     schemaPresenceCheckEnabled = serverProperties.getBoolean(SERVER_SCHEMA_PRESENCE_CHECK_ENABLED, true);
+    systemSchemaInitializationAtStartTimeEnabled =
+        serverProperties.getBoolean(SYSTEM_SCHEMA_INITIALIZATION_AT_START_TIME_ENABLED, false);
+    localControllerUrl = serverProperties.getString(LOCAL_CONTROLLER_URL, "");
+    localControllerD2ServiceName = serverProperties.getString(LOCAL_CONTROLLER_D2_SERVICE_NAME, "");
+    localD2ZkHost = serverProperties.getString(LOCAL_D2_ZK_HOST, "");
     enableLiveConfigBasedKafkaThrottling =
         serverProperties.getBoolean(SERVER_ENABLE_LIVE_CONFIG_BASED_KAFKA_THROTTLING, false);
     /**
@@ -1060,6 +1073,22 @@ public class VeniceServerConfig extends VeniceClusterConfig {
 
   public boolean isSchemaPresenceCheckEnabled() {
     return schemaPresenceCheckEnabled;
+  }
+
+  public boolean isSystemSchemaInitializationAtStartTimeEnabled() {
+    return systemSchemaInitializationAtStartTimeEnabled;
+  }
+
+  public String getLocalControllerUrl() {
+    return localControllerUrl;
+  }
+
+  public String getLocalControllerD2ServiceName() {
+    return localControllerD2ServiceName;
+  }
+
+  public String getLocalD2ZkHost() {
+    return localD2ZkHost;
   }
 
   public boolean isLiveConfigBasedKafkaThrottlingEnabled() {

--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -772,6 +772,10 @@ public class ConfigKeys {
    */
   public static final String SERVER_SCHEMA_FAST_CLASS_WARMUP_TIMEOUT = "server.schema.fast.class.warmup.timeout";
 
+  /**
+   * The following 3 configs define controller url, d2 service name and d2 zk host in the region that server is located.
+   * Either url or d2 configs must be specified if {@link #SYSTEM_SCHEMA_INITIALIZATION_AT_START_TIME_ENABLED} is true.
+   */
   public static final String LOCAL_CONTROLLER_URL = "local.controller.url";
   public static final String LOCAL_CONTROLLER_D2_SERVICE_NAME = "local.controller.d2.service.name";
   public static final String LOCAL_D2_ZK_HOST = "local.d2.zk.host";

--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -772,6 +772,10 @@ public class ConfigKeys {
    */
   public static final String SERVER_SCHEMA_FAST_CLASS_WARMUP_TIMEOUT = "server.schema.fast.class.warmup.timeout";
 
+  public static final String LOCAL_CONTROLLER_URL = "local.controller.url";
+  public static final String LOCAL_CONTROLLER_D2_SERVICE_NAME = "local.controller.d2.service.name";
+  public static final String LOCAL_D2_ZK_HOST = "local.d2.zk.host";
+
   // Router specific configs
   // TODO the config names are same as the names in application.src, some of them should be changed to keep consistent
   // TODO with controller and server.

--- a/internal/venice-common/src/main/java/com/linkedin/venice/common/VeniceSystemStoreUtils.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/common/VeniceSystemStoreUtils.java
@@ -1,6 +1,8 @@
 package com.linkedin.venice.common;
 
+import com.linkedin.venice.controllerapi.UpdateStoreQueryParams;
 import com.linkedin.venice.meta.Store;
+import java.util.concurrent.TimeUnit;
 
 
 public class VeniceSystemStoreUtils {
@@ -12,6 +14,12 @@ public class VeniceSystemStoreUtils {
   private static final String PUSH_JOB_DETAILS_STORE_NAME =
       String.format(Store.SYSTEM_STORE_FORMAT, PUSH_JOB_DETAILS_STORE);
   public static final String SEPARATOR = "_";
+  public static final UpdateStoreQueryParams DEFAULT_USER_SYSTEM_STORE_UPDATE_QUERY_PARAMS =
+      new UpdateStoreQueryParams().setHybridRewindSeconds(TimeUnit.DAYS.toSeconds(1)) // 1 day rewind
+          .setHybridOffsetLagThreshold(1)
+          .setHybridTimeLagThreshold(-1) // Explicitly disable hybrid time lag measurement on system store
+          .setWriteComputationEnabled(true)
+          .setPartitionCount(1);
 
   public static String getParticipantStoreNameForCluster(String clusterName) {
     return String.format(PARTICIPANT_STORE_FORMAT, clusterName);

--- a/internal/venice-common/src/test/java/com/linkedin/venice/system/store/ControllerClientBackedSystemSchemaInitializerTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/system/store/ControllerClientBackedSystemSchemaInitializerTest.java
@@ -1,0 +1,82 @@
+package com.linkedin.venice.system.store;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.linkedin.venice.controllerapi.ControllerClient;
+import com.linkedin.venice.controllerapi.D2ServiceDiscoveryResponse;
+import com.linkedin.venice.controllerapi.MultiSchemaResponse;
+import com.linkedin.venice.controllerapi.NewStoreResponse;
+import com.linkedin.venice.controllerapi.SchemaResponse;
+import com.linkedin.venice.controllerapi.StoreResponse;
+import com.linkedin.venice.exceptions.ErrorType;
+import com.linkedin.venice.exceptions.VeniceException;
+import com.linkedin.venice.serialization.avro.AvroProtocolDefinition;
+import java.util.Optional;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class ControllerClientBackedSystemSchemaInitializerTest {
+  @Test
+  public void testCreateSystemStoreAndRegisterSchema() {
+    ControllerClientBackedSystemSchemaInitializer initializer;
+    try {
+      initializer = new ControllerClientBackedSystemSchemaInitializer(
+          AvroProtocolDefinition.METADATA_SYSTEM_SCHEMA_STORE,
+          "testCluster",
+          null,
+          null,
+          false,
+          Optional.empty(),
+          "",
+          "",
+          "",
+          false);
+      initializer.execute();
+      Assert.fail("Exception should be thrown when neither controller url nor d2 config is provided");
+    } catch (VeniceException e) {
+      // expected
+    }
+    initializer = new ControllerClientBackedSystemSchemaInitializer(
+        AvroProtocolDefinition.METADATA_SYSTEM_SCHEMA_STORE,
+        "testCluster",
+        null,
+        null,
+        false,
+        Optional.empty(),
+        "",
+        "d2Service",
+        "d2ZkHost",
+        false);
+    ControllerClient controllerClient = mock(ControllerClient.class);
+    doReturn("leaderControllerUrl").when(controllerClient).getLeaderControllerUrl();
+    D2ServiceDiscoveryResponse discoveryResponse = mock(D2ServiceDiscoveryResponse.class);
+    doReturn(true).when(discoveryResponse).isError();
+    doReturn(ErrorType.STORE_NOT_FOUND).when(discoveryResponse).getErrorType();
+    doReturn(discoveryResponse).when(controllerClient).discoverCluster(any());
+    StoreResponse storeResponse = mock(StoreResponse.class);
+    doReturn(true).when(storeResponse).isError();
+    doReturn(ErrorType.STORE_NOT_FOUND).when(storeResponse).getErrorType();
+    doReturn(storeResponse).when(controllerClient).getStore(any());
+    NewStoreResponse newStoreResponse = mock(NewStoreResponse.class);
+    doReturn(newStoreResponse).when(controllerClient).createNewSystemStore(any(), any(), any(), any());
+    MultiSchemaResponse multiSchemaResponse = mock(MultiSchemaResponse.class);
+    doReturn(new MultiSchemaResponse.Schema[0]).when(multiSchemaResponse).getSchemas();
+    doReturn(multiSchemaResponse).when(controllerClient).getAllValueSchema(any());
+    SchemaResponse schemaResponse = mock(SchemaResponse.class);
+    doReturn(schemaResponse).when(controllerClient).addValueSchema(any(), any(), anyInt());
+    doCallRealMethod().when(controllerClient).retryableRequest(anyInt(), any(), any());
+    doCallRealMethod().when(controllerClient).retryableRequest(anyInt(), any());
+    initializer.setControllerClient(controllerClient);
+    initializer.execute();
+    verify(controllerClient, times(1)).createNewSystemStore(any(), any(), any(), any());
+    verify(controllerClient, times(AvroProtocolDefinition.METADATA_SYSTEM_SCHEMA_STORE.getCurrentProtocolVersion()))
+        .addValueSchema(any(), any(), anyInt());
+  }
+}

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceControllerWrapper.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceControllerWrapper.java
@@ -43,6 +43,7 @@ import static com.linkedin.venice.ConfigKeys.PUSH_STATUS_STORE_ENABLED;
 import static com.linkedin.venice.ConfigKeys.SSL_KAFKA_BOOTSTRAP_SERVERS;
 import static com.linkedin.venice.ConfigKeys.SSL_TO_KAFKA_LEGACY;
 import static com.linkedin.venice.ConfigKeys.STORAGE_ENGINE_OVERHEAD_RATIO;
+import static com.linkedin.venice.ConfigKeys.SYSTEM_SCHEMA_INITIALIZATION_AT_START_TIME_ENABLED;
 import static com.linkedin.venice.ConfigKeys.TOPIC_CLEANUP_DELAY_FACTOR;
 import static com.linkedin.venice.ConfigKeys.TOPIC_CLEANUP_SEND_CONCURRENT_DELETES_REQUESTS;
 import static com.linkedin.venice.ConfigKeys.TOPIC_CLEANUP_SLEEP_INTERVAL_BETWEEN_TOPIC_LIST_FETCH_MS;
@@ -209,6 +210,7 @@ public class VeniceControllerWrapper extends ProcessWrapper {
             .put(CONCURRENT_INIT_ROUTINES_ENABLED, true)
             .put(CLUSTER_DISCOVERY_D2_SERVICE, VeniceRouterWrapper.CLUSTER_DISCOVERY_D2_SERVICE_NAME)
             .put(DAVINCI_PUSH_STATUS_SCAN_INTERVAL_IN_SECONDS, 1)
+            .put(SYSTEM_SCHEMA_INITIALIZATION_AT_START_TIME_ENABLED, true)
             .put(extraProps.toProperties());
 
         if (sslEnabled) {

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceServerWrapper.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceServerWrapper.java
@@ -9,6 +9,8 @@ import static com.linkedin.venice.ConfigKeys.ENABLE_SERVER_ALLOW_LIST;
 import static com.linkedin.venice.ConfigKeys.KAFKA_READ_CYCLE_DELAY_MS;
 import static com.linkedin.venice.ConfigKeys.KAFKA_SECURITY_PROTOCOL;
 import static com.linkedin.venice.ConfigKeys.LISTENER_PORT;
+import static com.linkedin.venice.ConfigKeys.LOCAL_CONTROLLER_D2_SERVICE_NAME;
+import static com.linkedin.venice.ConfigKeys.LOCAL_D2_ZK_HOST;
 import static com.linkedin.venice.ConfigKeys.MAX_ONLINE_OFFLINE_STATE_TRANSITION_THREAD_NUMBER;
 import static com.linkedin.venice.ConfigKeys.PARTICIPANT_MESSAGE_CONSUMPTION_DELAY_MS;
 import static com.linkedin.venice.ConfigKeys.PERSISTENCE_TYPE;
@@ -22,6 +24,7 @@ import static com.linkedin.venice.ConfigKeys.SERVER_PROMOTION_TO_LEADER_REPLICA_
 import static com.linkedin.venice.ConfigKeys.SERVER_REST_SERVICE_STORAGE_THREAD_NUM;
 import static com.linkedin.venice.ConfigKeys.SERVER_SSL_HANDSHAKE_THREAD_POOL_SIZE;
 import static com.linkedin.venice.ConfigKeys.SYSTEM_SCHEMA_CLUSTER_NAME;
+import static com.linkedin.venice.ConfigKeys.SYSTEM_SCHEMA_INITIALIZATION_AT_START_TIME_ENABLED;
 import static com.linkedin.venice.meta.PersistenceType.ROCKS_DB;
 
 import com.linkedin.davinci.config.VeniceConfigLoader;
@@ -222,6 +225,9 @@ public class VeniceServerWrapper extends ProcessWrapper implements MetricsAware 
           .put(SERVER_PROMOTION_TO_LEADER_REPLICA_DELAY_SECONDS, Long.toString(1L))
           .put(CLUSTER_DISCOVERY_D2_SERVICE, VeniceRouterWrapper.CLUSTER_DISCOVERY_D2_SERVICE_NAME)
           .put(SERVER_SSL_HANDSHAKE_THREAD_POOL_SIZE, 10)
+          .put(SYSTEM_SCHEMA_INITIALIZATION_AT_START_TIME_ENABLED, true)
+          .put(LOCAL_CONTROLLER_D2_SERVICE_NAME, VeniceControllerWrapper.D2_SERVICE_NAME)
+          .put(LOCAL_D2_ZK_HOST, zkAddress)
           .put(configProperties);
       if (sslToKafka) {
         serverPropsBuilder.put(KAFKA_SECURITY_PROTOCOL, SecurityProtocol.SSL.name);

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/server/VeniceServerTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/server/VeniceServerTest.java
@@ -1,5 +1,6 @@
 package com.linkedin.venice.server;
 
+import static com.linkedin.venice.ConfigKeys.CONTROLLER_ZK_SHARED_META_SYSTEM_SCHEMA_STORE_AUTO_CREATION_ENABLED;
 import static com.linkedin.venice.integration.utils.VeniceServerWrapper.SERVER_ENABLE_SERVER_ALLOW_LIST;
 import static com.linkedin.venice.integration.utils.VeniceServerWrapper.SERVER_IS_AUTO_JOIN;
 
@@ -10,15 +11,19 @@ import com.linkedin.r2.message.rest.RestRequest;
 import com.linkedin.r2.message.rest.RestRequestBuilder;
 import com.linkedin.r2.message.rest.RestResponse;
 import com.linkedin.venice.controllerapi.ControllerClient;
+import com.linkedin.venice.controllerapi.MultiSchemaResponse;
+import com.linkedin.venice.controllerapi.StoreResponse;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.httpclient.HttpClientUtils;
 import com.linkedin.venice.integration.utils.D2TestUtils;
 import com.linkedin.venice.integration.utils.ServiceFactory;
 import com.linkedin.venice.integration.utils.TestVeniceServer;
+import com.linkedin.venice.integration.utils.VeniceClusterCreateOptions;
 import com.linkedin.venice.integration.utils.VeniceClusterWrapper;
 import com.linkedin.venice.integration.utils.VeniceServerWrapper;
 import com.linkedin.venice.meta.QueryAction;
 import com.linkedin.venice.metadata.response.MetadataResponseRecord;
+import com.linkedin.venice.serialization.avro.AvroProtocolDefinition;
 import com.linkedin.venice.serializer.RecordDeserializer;
 import com.linkedin.venice.serializer.SerializerDeserializerFactory;
 import com.linkedin.venice.utils.DataProviderUtils;
@@ -284,6 +289,26 @@ public class VeniceServerTest {
       RestResponse response = d2Client.restRequest(request).get();
 
       Assert.assertEquals(response.getStatus(), HttpStatus.SC_OK);
+    }
+  }
+
+  @Test
+  public void testStartServerWithSystemSchemaInitialization() {
+    Properties controllerProperties = new Properties();
+    // Disable controller meta system store initialization so that server spun up after controller will register schemas
+    controllerProperties.setProperty(CONTROLLER_ZK_SHARED_META_SYSTEM_SCHEMA_STORE_AUTO_CREATION_ENABLED, "false");
+    VeniceClusterCreateOptions options =
+        new VeniceClusterCreateOptions.Builder().extraProperties(controllerProperties).build();
+    try (VeniceClusterWrapper cluster = ServiceFactory.getVeniceCluster(options)) {
+      cluster.useControllerClient(controllerClient -> {
+        String storeName = AvroProtocolDefinition.METADATA_SYSTEM_SCHEMA_STORE.getSystemStoreName();
+        int currentProtocolVersion = AvroProtocolDefinition.METADATA_SYSTEM_SCHEMA_STORE.getCurrentProtocolVersion();
+        StoreResponse storeResponse = controllerClient.getStore(storeName);
+        Assert.assertNotNull(storeResponse.getStore());
+        MultiSchemaResponse schemaResponse = controllerClient.getAllValueAndDerivedSchema(storeName);
+        Assert.assertNotNull(schemaResponse.getSchemas());
+        Assert.assertEquals(schemaResponse.getSchemas().length, currentProtocolVersion * 2);
+      });
     }
   }
 }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerConfig.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerConfig.java
@@ -476,7 +476,7 @@ public class VeniceControllerConfig extends VeniceControllerClusterConfig {
     this.parentExternalSupersetSchemaGenerationEnabled =
         props.getBoolean(CONTROLLER_PARENT_EXTERNAL_SUPERSET_SCHEMA_GENERATION_ENABLED, false);
     this.systemSchemaInitializationAtStartTimeEnabled =
-        props.getBoolean(SYSTEM_SCHEMA_INITIALIZATION_AT_START_TIME_ENABLED, true);
+        props.getBoolean(SYSTEM_SCHEMA_INITIALIZATION_AT_START_TIME_ENABLED, false);
   }
 
   private void validateActiveActiveConfigs() {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -317,13 +317,6 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
 
   static final int VERSION_ID_UNSET = -1;
 
-  static final UpdateStoreQueryParams DEFAULT_USER_SYSTEM_STORE_UPDATE_QUERY_PARAMS =
-      new UpdateStoreQueryParams().setHybridRewindSeconds(TimeUnit.DAYS.toSeconds(1)) // 1 day rewind
-          .setHybridOffsetLagThreshold(1)
-          .setHybridTimeLagThreshold(-1) // Explicitly disable hybrid time lag measurement on system store
-          .setWriteComputationEnabled(true)
-          .setPartitionCount(1);
-
   // TODO remove this field and all invocations once we are fully on HaaS. Use the helixAdminClient instead.
   private final HelixAdmin admin;
   /**
@@ -587,7 +580,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
               multiClusterConfigs,
               this,
               Optional.of(AvroProtocolDefinition.METADATA_SYSTEM_SCHEMA_STORE_KEY.getCurrentProtocolVersionSchema()),
-              Optional.of(DEFAULT_USER_SYSTEM_STORE_UPDATE_QUERY_PARAMS),
+              Optional.of(VeniceSystemStoreUtils.DEFAULT_USER_SYSTEM_STORE_UPDATE_QUERY_PARAMS),
               true));
     }
     if (multiClusterConfigs.isZkSharedDaVinciPushStatusSystemSchemaStoreAutoCreationEnabled()) {
@@ -598,7 +591,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
               multiClusterConfigs,
               this,
               Optional.of(AvroProtocolDefinition.PUSH_STATUS_SYSTEM_SCHEMA_STORE_KEY.getCurrentProtocolVersionSchema()),
-              Optional.of(DEFAULT_USER_SYSTEM_STORE_UPDATE_QUERY_PARAMS),
+              Optional.of(VeniceSystemStoreUtils.DEFAULT_USER_SYSTEM_STORE_UPDATE_QUERY_PARAMS),
               true));
     }
 

--- a/services/venice-server/src/main/java/com/linkedin/venice/server/VeniceServer.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/server/VeniceServer.java
@@ -1,5 +1,7 @@
 package com.linkedin.venice.server;
 
+import static com.linkedin.venice.common.VeniceSystemStoreUtils.DEFAULT_USER_SYSTEM_STORE_UPDATE_QUERY_PARAMS;
+
 import com.linkedin.avro.fastserde.FastDeserializerGeneratorAccessor;
 import com.linkedin.davinci.compression.StorageEngineBackedCompressorFactory;
 import com.linkedin.davinci.config.VeniceClusterConfig;
@@ -60,6 +62,7 @@ import com.linkedin.venice.stats.AggRocksDBStats;
 import com.linkedin.venice.stats.BackupVersionOptimizationServiceStats;
 import com.linkedin.venice.stats.DiskHealthStats;
 import com.linkedin.venice.stats.VeniceJVMStats;
+import com.linkedin.venice.system.store.ControllerClientBackedSystemSchemaInitializer;
 import com.linkedin.venice.utils.CollectionUtils;
 import com.linkedin.venice.utils.LatencyUtils;
 import com.linkedin.venice.utils.Utils;
@@ -209,6 +212,22 @@ public class VeniceServer {
     // Create jvm metrics object
     jvmStats = new VeniceJVMStats(metricsRepository, "VeniceJVMStats");
 
+    if (serverConfig.isSystemSchemaInitializationAtStartTimeEnabled()) {
+      ControllerClientBackedSystemSchemaInitializer metaSystemStoreSchemaInitializer =
+          new ControllerClientBackedSystemSchemaInitializer(
+              AvroProtocolDefinition.METADATA_SYSTEM_SCHEMA_STORE,
+              serverConfig.getSystemSchemaClusterName(),
+              AvroProtocolDefinition.METADATA_SYSTEM_SCHEMA_STORE_KEY.getCurrentProtocolVersionSchema(),
+              DEFAULT_USER_SYSTEM_STORE_UPDATE_QUERY_PARAMS,
+              true,
+              sslFactory,
+              serverConfig.getLocalControllerUrl(),
+              serverConfig.getLocalControllerD2ServiceName(),
+              serverConfig.getLocalD2ZkHost(),
+              false);
+      metaSystemStoreSchemaInitializer.execute();
+    }
+
     Optional<SchemaReader> partitionStateSchemaReader = clientConfigForConsumer.map(
         cc -> ClientFactory
             .getSchemaReader(cc.setStoreName(AvroProtocolDefinition.PARTITION_STATE.getSystemStoreName()), icProvider));
@@ -216,24 +235,40 @@ public class VeniceServer {
         cc -> ClientFactory.getSchemaReader(
             cc.setStoreName(AvroProtocolDefinition.STORE_VERSION_STATE.getSystemStoreName()),
             icProvider));
+    Optional<SchemaReader> kafkaMessageEnvelopeSchemaReader = clientConfigForConsumer.map(
+        cc -> ClientFactory.getSchemaReader(
+            cc.setStoreName(AvroProtocolDefinition.KAFKA_MESSAGE_ENVELOPE.getSystemStoreName()),
+            icProvider));
+
+    // Verify the current version of the system schemas are registered in ZK before moving ahead
+    if (serverConfig.isSchemaPresenceCheckEnabled()) {
+      partitionStateSchemaReader.ifPresent(
+          schemaReader -> new SchemaPresenceChecker(schemaReader, AvroProtocolDefinition.PARTITION_STATE)
+              .verifySchemaVersionPresentOrExit());
+      storeVersionStateSchemaReader.ifPresent(
+          schemaReader -> new SchemaPresenceChecker(schemaReader, AvroProtocolDefinition.STORE_VERSION_STATE)
+              .verifySchemaVersionPresentOrExit());
+      kafkaMessageEnvelopeSchemaReader.ifPresent(
+          schemaReader -> new SchemaPresenceChecker(schemaReader, AvroProtocolDefinition.KAFKA_MESSAGE_ENVELOPE)
+              .verifySchemaVersionPresentOrExit());
+      // For system schemas initialized via controller client, no need to verify again because they should already exist
+      if (!serverConfig.isSystemSchemaInitializationAtStartTimeEnabled()) {
+        Optional<SchemaReader> metaSystemStoreSchemaReader = clientConfigForConsumer.map(
+            cc -> ClientFactory.getSchemaReader(
+                cc.setStoreName(AvroProtocolDefinition.METADATA_SYSTEM_SCHEMA_STORE.getSystemStoreName()),
+                icProvider));
+        metaSystemStoreSchemaReader.ifPresent(
+            schemaReader -> new SchemaPresenceChecker(schemaReader, AvroProtocolDefinition.METADATA_SYSTEM_SCHEMA_STORE)
+                .verifySchemaVersionPresentOrExit());
+      }
+    }
+
     final InternalAvroSpecificSerializer<PartitionState> partitionStateSerializer =
         AvroProtocolDefinition.PARTITION_STATE.getSerializer();
     partitionStateSchemaReader.ifPresent(partitionStateSerializer::setSchemaReader);
     final InternalAvroSpecificSerializer<StoreVersionState> storeVersionStateSerializer =
         AvroProtocolDefinition.STORE_VERSION_STATE.getSerializer();
     storeVersionStateSchemaReader.ifPresent(storeVersionStateSerializer::setSchemaReader);
-
-    // Verify the current version of PARTITION_STATE and STORE_VERSION_STATE schema is registered in ZK before moving
-    // ahead.
-    if (serverConfig.isSchemaPresenceCheckEnabled()) {
-      partitionStateSchemaReader.ifPresent(
-          schemaReader -> new SchemaPresenceChecker(schemaReader, AvroProtocolDefinition.PARTITION_STATE)
-              .verifySchemaVersionPresentOrExit());
-
-      storeVersionStateSchemaReader.ifPresent(
-          schemaReader -> new SchemaPresenceChecker(schemaReader, AvroProtocolDefinition.STORE_VERSION_STATE)
-              .verifySchemaVersionPresentOrExit());
-    }
 
     // Create and add Offset Service.
     VeniceClusterConfig clusterConfig = veniceConfigLoader.getVeniceClusterConfig();
@@ -304,26 +339,6 @@ public class VeniceServer {
 
     // Create stats for RocksDB
     storageService.getRocksDBAggregatedStatistics().ifPresent(stat -> new AggRocksDBStats(metricsRepository, stat));
-
-    Optional<SchemaReader> kafkaMessageEnvelopeSchemaReader = clientConfigForConsumer.map(
-        cc -> ClientFactory.getSchemaReader(
-            cc.setStoreName(AvroProtocolDefinition.KAFKA_MESSAGE_ENVELOPE.getSystemStoreName()),
-            icProvider));
-    Optional<SchemaReader> metaSystemStoreSchemaReader = clientConfigForConsumer.map(
-        cc -> ClientFactory.getSchemaReader(
-            cc.setStoreName(AvroProtocolDefinition.METADATA_SYSTEM_SCHEMA_STORE.getSystemStoreName()),
-            icProvider));
-
-    // verify the current version of the system schemas are registered in ZK before moving ahead
-    if (serverConfig.isSchemaPresenceCheckEnabled()) {
-      kafkaMessageEnvelopeSchemaReader.ifPresent(
-          schemaReader -> new SchemaPresenceChecker(schemaReader, AvroProtocolDefinition.KAFKA_MESSAGE_ENVELOPE)
-              .verifySchemaVersionPresentOrExit());
-
-      metaSystemStoreSchemaReader.ifPresent(
-          schemaReader -> new SchemaPresenceChecker(schemaReader, AvroProtocolDefinition.METADATA_SYSTEM_SCHEMA_STORE)
-              .verifySchemaVersionPresentOrExit());
-    }
 
     compressorFactory = new StorageEngineBackedCompressorFactory(storageMetadataService);
 

--- a/services/venice-server/src/main/java/com/linkedin/venice/server/VeniceServer.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/server/VeniceServer.java
@@ -1,7 +1,5 @@
 package com.linkedin.venice.server;
 
-import static com.linkedin.venice.common.VeniceSystemStoreUtils.DEFAULT_USER_SYSTEM_STORE_UPDATE_QUERY_PARAMS;
-
 import com.linkedin.avro.fastserde.FastDeserializerGeneratorAccessor;
 import com.linkedin.davinci.compression.StorageEngineBackedCompressorFactory;
 import com.linkedin.davinci.config.VeniceClusterConfig;
@@ -29,6 +27,7 @@ import com.linkedin.venice.cleaner.LeakedResourceCleaner;
 import com.linkedin.venice.cleaner.ResourceReadUsageTracker;
 import com.linkedin.venice.client.store.ClientConfig;
 import com.linkedin.venice.client.store.ClientFactory;
+import com.linkedin.venice.common.VeniceSystemStoreUtils;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.helix.AllowlistAccessor;
 import com.linkedin.venice.helix.HelixCustomizedViewOfflinePushRepository;
@@ -218,7 +217,7 @@ public class VeniceServer {
               AvroProtocolDefinition.METADATA_SYSTEM_SCHEMA_STORE,
               serverConfig.getSystemSchemaClusterName(),
               AvroProtocolDefinition.METADATA_SYSTEM_SCHEMA_STORE_KEY.getCurrentProtocolVersionSchema(),
-              DEFAULT_USER_SYSTEM_STORE_UPDATE_QUERY_PARAMS,
+              VeniceSystemStoreUtils.DEFAULT_USER_SYSTEM_STORE_UPDATE_QUERY_PARAMS,
               true,
               sslFactory,
               serverConfig.getLocalControllerUrl(),


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Summary
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

When a server starts, if system schema initialization is enabled, it will call controller to check and register new meta system store schemas. Therefore, servers can be deployed before controllers when meta system store schema is upgraded. Controller url (for open source users who do not want to onboard d2) or d2 configs must be provided to enable system schema initialization at start time.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

Unit test and integration test 

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.