### PR TITLE
[server] Integrated with RocksDB multiget API and benchmark

### DIFF
--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/utils/ByteUtils.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/utils/ByteUtils.java
@@ -213,7 +213,11 @@ public class ByteUtils {
     }
     int size = byteBuffer.remaining();
     byte[] ret = new byte[size];
-    System.arraycopy(byteBuffer.array(), byteBuffer.position(), ret, 0, size);
+    if (byteBuffer.isDirect()) {
+      extractByteArray(byteBuffer, ret, 0, size);
+    } else {
+      System.arraycopy(byteBuffer.array(), byteBuffer.position(), ret, 0, size);
+    }
     return ret;
   }
 

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/utils/ByteUtilsTest.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/utils/ByteUtilsTest.java
@@ -48,5 +48,10 @@ public class ByteUtilsTest {
     byte[] data = "111222333".getBytes();
     ByteBuffer nonEmptyByteBuffer = ByteBuffer.wrap(data, 3, 3);
     Assert.assertTrue(Arrays.equals(ByteUtils.copyByteArray(nonEmptyByteBuffer), "222".getBytes()));
+
+    ByteBuffer directBuffer = ByteBuffer.allocateDirect(data.length);
+    directBuffer.put(data);
+    directBuffer.flip();
+    Assert.assertTrue(Arrays.equals(ByteUtils.copyByteArray(directBuffer), data));
   }
 }

--- a/internal/venice-test-common/src/jmh/java/com/linkedin/venice/benchmark/RocksDBLookupApiBenchmark.java
+++ b/internal/venice-test-common/src/jmh/java/com/linkedin/venice/benchmark/RocksDBLookupApiBenchmark.java
@@ -1,0 +1,187 @@
+package com.linkedin.venice.benchmark;
+
+import static com.linkedin.davinci.store.rocksdb.RocksDBServerConfig.ROCKSDB_LEVEL0_FILE_NUM_COMPACTION_TRIGGER;
+import static com.linkedin.davinci.store.rocksdb.RocksDBServerConfig.ROCKSDB_LEVEL0_SLOWDOWN_WRITES_TRIGGER;
+import static com.linkedin.davinci.store.rocksdb.RocksDBServerConfig.ROCKSDB_LEVEL0_STOPS_WRITES_TRIGGER;
+import static com.linkedin.davinci.store.rocksdb.RocksDBServerConfig.ROCKSDB_PLAIN_TABLE_FORMAT_ENABLED;
+import static com.linkedin.venice.ConfigKeys.ADMIN_PORT;
+import static com.linkedin.venice.ConfigKeys.CLUSTER_NAME;
+import static com.linkedin.venice.ConfigKeys.DATA_BASE_PATH;
+import static com.linkedin.venice.ConfigKeys.KAFKA_BOOTSTRAP_SERVERS;
+import static com.linkedin.venice.ConfigKeys.LISTENER_PORT;
+import static com.linkedin.venice.ConfigKeys.PERSISTENCE_TYPE;
+import static com.linkedin.venice.ConfigKeys.ZOOKEEPER_ADDRESS;
+
+import com.linkedin.davinci.config.VeniceServerConfig;
+import com.linkedin.davinci.store.StoragePartitionConfig;
+import com.linkedin.davinci.store.rocksdb.RocksDBServerConfig;
+import com.linkedin.davinci.store.rocksdb.RocksDBStorageEngineFactory;
+import com.linkedin.davinci.store.rocksdb.RocksDBStoragePartition;
+import com.linkedin.davinci.store.rocksdb.RocksDBThrottler;
+import com.linkedin.venice.exceptions.VeniceException;
+import com.linkedin.venice.meta.PersistenceType;
+import com.linkedin.venice.utils.PropertyBuilder;
+import com.linkedin.venice.utils.Utils;
+import com.linkedin.venice.utils.VeniceProperties;
+import java.io.File;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.rocksdb.RocksDB;
+
+
+@Fork(value = 2, jvmArgs = { "-Xms4G", "-Xmx4G" })
+@Warmup(iterations = 2)
+@Measurement(iterations = 5)
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+public class RocksDBLookupApiBenchmark {
+  private static String getRandomStr(int length) {
+    byte[] str = new byte[length];
+    ThreadLocalRandom.current().nextBytes(str);
+    return new String(str);
+  }
+
+  private static final String DATA_BASE_DIR = Utils.getUniqueTempPath();
+
+  private static final String KEY_PREFIX = getRandomStr(10);
+  private static final String VALUE_PREFIX = getRandomStr(100);
+  private static final int ROW_CNT = 5_000_000;
+
+  private RocksDBStoragePartition storagePartition;
+  private String storeDir;
+
+  @Param({ "1", "2", "5", "10", "50" })
+  private static int BATCH_SIZE;
+
+  private String getTempDatabaseDir(String storeName) {
+    File storeDir = new File(DATA_BASE_DIR, storeName).getAbsoluteFile();
+    if (!storeDir.mkdirs()) {
+      throw new VeniceException("Failed to mkdirs for path: " + storeDir.getPath());
+    }
+    storeDir.deleteOnExit();
+    return storeDir.getPath();
+  }
+
+  public static VeniceProperties getServerProperties(PersistenceType persistenceType, Properties properties) {
+    return new PropertyBuilder().put(CLUSTER_NAME, "test_offset_manager")
+        .put(ZOOKEEPER_ADDRESS, "localhost:2181")
+        .put(PERSISTENCE_TYPE, persistenceType.toString())
+        .put(KAFKA_BOOTSTRAP_SERVERS, "127.0.0.1:9092")
+        .put(LISTENER_PORT, 7072)
+        .put(ADMIN_PORT, 7073)
+        .put(DATA_BASE_PATH, DATA_BASE_DIR)
+        .put(properties)
+        .build();
+  }
+
+  @Setup
+  public void setUp() throws Exception {
+    RocksDB.loadLibrary();
+    String storeName = Utils.getUniqueString("test_store");
+    storeDir = getTempDatabaseDir(storeName);
+    Properties properties = new Properties();
+    properties.put(PERSISTENCE_TYPE, PersistenceType.ROCKS_DB.toString());
+    properties.put(ROCKSDB_PLAIN_TABLE_FORMAT_ENABLED, "true");
+    properties.put(ROCKSDB_LEVEL0_FILE_NUM_COMPACTION_TRIGGER, 2);
+    properties.put(ROCKSDB_LEVEL0_SLOWDOWN_WRITES_TRIGGER, 4);
+    properties.put(ROCKSDB_LEVEL0_STOPS_WRITES_TRIGGER, 6);
+    VeniceProperties veniceServerProperties = getServerProperties(PersistenceType.ROCKS_DB, properties);
+    storagePartition = new RocksDBStoragePartition(
+        new StoragePartitionConfig(storeName, 0),
+        new RocksDBStorageEngineFactory(new VeniceServerConfig(veniceServerProperties)),
+        DATA_BASE_DIR,
+        null,
+        new RocksDBThrottler(3),
+        new RocksDBServerConfig(veniceServerProperties));
+
+    // Populate the database
+    for (int i = 0; i < ROW_CNT; ++i) {
+      byte[] key = (KEY_PREFIX + i).getBytes();
+      byte[] value = (VALUE_PREFIX + i).getBytes();
+      storagePartition.put(key, value);
+    }
+    System.out.println("Finished populating the database, path: " + storagePartition.getFullPathForTempSSTFileDir());
+  }
+
+  @TearDown
+  public void tearDown() {
+    storagePartition.drop();
+    File file = new File(storeDir);
+    if (file.exists() && !file.delete()) {
+      throw new VeniceException("Failed to remove path: " + storeDir);
+    }
+  }
+
+  @Benchmark
+  public void measureSingleGetAPI(org.openjdk.jmh.infra.Blackhole bh) {
+    if (BATCH_SIZE != 1) {
+      // Only execute this function once.
+      return;
+    }
+    for (int cur = 0; cur < ROW_CNT; ++cur) {
+      bh.consume(storagePartition.get((KEY_PREFIX + cur).getBytes()));
+    }
+  }
+
+  @Benchmark
+  public void measureMultiGetAPI(org.openjdk.jmh.infra.Blackhole bh) {
+    List<byte[]> keys = new ArrayList<>(BATCH_SIZE);
+    // populate with dummy elements
+    for (int i = 0; i < BATCH_SIZE; ++i) {
+      keys.add(null);
+    }
+    for (int cur = 0; cur < ROW_CNT; cur += BATCH_SIZE) {
+      for (int b = 0; b < BATCH_SIZE; ++b) {
+        keys.set(b, (KEY_PREFIX + cur + b).getBytes());
+      }
+      bh.consume(storagePartition.multiGet(keys));
+    }
+  }
+
+  @Benchmark
+  public void measureMultiGetAPIWithByteBuffer(org.openjdk.jmh.infra.Blackhole bh) {
+    List<ByteBuffer> keys = new ArrayList<>(BATCH_SIZE);
+    List<ByteBuffer> values = new ArrayList<>(BATCH_SIZE);
+    // populate with dummy elements
+    for (int i = 0; i < BATCH_SIZE; ++i) {
+      keys.add(ByteBuffer.allocateDirect(50)); // make sure it is large enough
+      values.add(ByteBuffer.allocateDirect(200));
+    }
+
+    for (int cur = 0; cur < ROW_CNT; cur += BATCH_SIZE) {
+      for (int b = 0; b < BATCH_SIZE; ++b) {
+        ByteBuffer keyBuffer = keys.get(b);
+        keyBuffer.clear();
+        keyBuffer.put((KEY_PREFIX + cur + b).getBytes());
+        keyBuffer.flip();
+        values.get(b).clear();
+      }
+      bh.consume(storagePartition.multiGet(keys, values));
+    }
+  }
+
+  public static void main(String[] args) throws Exception {
+    Options opt = new OptionsBuilder().include(RocksDBLookupApiBenchmark.class.getSimpleName()).build();
+    new Runner(opt).run();
+  }
+}


### PR DESCRIPTION
## Summary, imperative, start upper case, don't end with a period
RocksDB offers a set of multiget API besides single-get API, and it claims that it should improve the performance by parallelizing the IO operations with linux kernal 5.1 or later.
We also want to benchmark these APIs for PT format since in theory, it should reduce the cost of JNI because of less JNI calls.

Based on the benchmarking, the performance of multiget API is performing worse than single-get API (which is weird), and we would like to keep these benchmarks and code, so that we can evaluate BT format in the future.

PT benchmark result (subset):
Benchmark                                                   (BATCH_SIZE)  Mode  Cnt      Score      Error  Units
RocksDBLookupApiBenchmark.measureMultiGetAPI                           1  avgt    5  18195.987 ± 1484.887  ms/op
RocksDBLookupApiBenchmark.measureMultiGetAPI                           2  avgt    5  16774.263 ±  212.736  ms/op
RocksDBLookupApiBenchmark.measureMultiGetAPI                          10  avgt    5  18206.964 ± 3331.436  ms/op
RocksDBLookupApiBenchmark.measureMultiGetAPIWithByteBuffer             1  avgt    5  27395.865 ±  688.723  ms/op
RocksDBLookupApiBenchmark.measureMultiGetAPIWithByteBuffer             2  avgt    5  23750.618 ± 4607.772  ms/op
RocksDBLookupApiBenchmark.measureMultiGetAPIWithByteBuffer            10  avgt    5  15060.939 ±  941.485  ms/op
RocksDBLookupApiBenchmark.measureSingleGetAPI                          1  avgt    5   8542.114 ±  378.653  ms/op

<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->


<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->



## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
CI

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.