### PR TITLE
[server][dvc] Delete deprecated chunks when processing partial update

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImpl.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImpl.java
@@ -596,7 +596,8 @@ public class VeniceChangelogConsumerImpl<K, V> implements VeniceChangelogConsume
             null,
             readerSchemaId,
             deserializerCache,
-            compressor);
+            compressor,
+            null);
       } catch (Exception ex) {
         // We might get an exception if we haven't persisted all the chunks for a given key. This
         // can actually happen if the client seeks to the middle of a chunked record either by

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
@@ -3,6 +3,7 @@ package com.linkedin.davinci.kafka.consumer;
 import static com.linkedin.davinci.kafka.consumer.LeaderFollowerStateType.LEADER;
 import static com.linkedin.davinci.kafka.consumer.LeaderFollowerStateType.STANDBY;
 import static com.linkedin.venice.VeniceConstants.REWIND_TIME_DECIDED_BY_SERVER;
+import static com.linkedin.venice.writer.VeniceWriter.APP_DEFAULT_LOGICAL_TS;
 
 import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
 import com.linkedin.davinci.config.VeniceStoreVersionConfig;
@@ -52,7 +53,6 @@ import com.linkedin.venice.writer.ChunkAwareCallback;
 import com.linkedin.venice.writer.DeleteMetadata;
 import com.linkedin.venice.writer.LeaderMetadataWrapper;
 import com.linkedin.venice.writer.PutMetadata;
-import com.linkedin.venice.writer.VeniceWriter;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -670,7 +670,10 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
                   key,
                   callback,
                   sourceTopicOffset,
-                  new DeleteMetadata(valueSchemaId, rmdProtocolVersionID, updatedRmdBytes));
+                  APP_DEFAULT_LOGICAL_TS,
+                  new DeleteMetadata(valueSchemaId, rmdProtocolVersionID, updatedRmdBytes),
+                  oldValueManifest,
+                  oldRmdManifest);
       LeaderProducedRecordContext leaderProducedRecordContext =
           LeaderProducedRecordContext.newDeleteRecord(kafkaClusterId, consumerRecord.getOffset(), key, deletePayload);
       produceToLocalKafka(
@@ -1402,7 +1405,7 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
               valueSchemaId,
               callback,
               leaderMetadataWrapper,
-              VeniceWriter.APP_DEFAULT_LOGICAL_TS,
+              APP_DEFAULT_LOGICAL_TS,
               new PutMetadata(getRmdProtocolVersionID(), updatedRmdBytes),
               oldValueManifest,
               oldRmdManifest);

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
@@ -301,6 +301,8 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
       byte[] key,
       int subPartition,
       long currentTimeForMetricsMs) {
+    LOGGER.info("DEBUGGING: {}", key);
+    LOGGER.info("DEBUGGING: {}", partitionConsumptionState);
     PartitionConsumptionState.TransientRecord cachedRecord = partitionConsumptionState.getTransientRecord(key);
     if (cachedRecord != null) {
       getHostLevelIngestionStats().recordIngestionReplicationMetadataCacheHitCount(currentTimeForMetricsMs);
@@ -318,8 +320,13 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
     }
     RmdWithValueSchemaId rmdWithValueSchemaId = new RmdWithValueSchemaId();
     rmdWithValueSchemaId.setRmdManifest(rmdManifestContainer.getManifest());
-    rmdSerDe.deserializeValueSchemaIdPrependedRmdBytes(replicationMetadataWithValueSchemaBytes, rmdWithValueSchemaId);
+    getRmdSerDe()
+        .deserializeValueSchemaIdPrependedRmdBytes(replicationMetadataWithValueSchemaBytes, rmdWithValueSchemaId);
     return rmdWithValueSchemaId;
+  }
+
+  public RmdSerDe getRmdSerDe() {
+    return rmdSerDe;
   }
 
   byte[] getRmdWithValueSchemaByteBufferFromStorage(

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
@@ -301,8 +301,6 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
       byte[] key,
       int subPartition,
       long currentTimeForMetricsMs) {
-    LOGGER.info("DEBUGGING: {}", key);
-    LOGGER.info("DEBUGGING: {}", partitionConsumptionState);
     PartitionConsumptionState.TransientRecord cachedRecord = partitionConsumptionState.getTransientRecord(key);
     if (cachedRecord != null) {
       getHostLevelIngestionStats().recordIngestionReplicationMetadataCacheHitCount(currentTimeForMetricsMs);

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
@@ -718,6 +718,8 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
           key,
           updatedValueBytes,
           updatedRmdBytes,
+          oldValueManifest,
+          oldRmdManifest,
           valueSchemaId,
           mergeConflictResult.doesResultReuseInput());
       produceToLocalKafka(
@@ -1402,6 +1404,8 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
       byte[] key,
       ByteBuffer updatedValueBytes,
       ByteBuffer updatedRmdBytes,
+      ChunkedValueManifest oldValueManifest,
+      ChunkedValueManifest oldRmdManifest,
       int valueSchemaId,
       boolean resultReuseInput) {
     return (callback, leaderMetadataWrapper) -> {
@@ -1422,7 +1426,9 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
               callback,
               leaderMetadataWrapper,
               VeniceWriter.APP_DEFAULT_LOGICAL_TS,
-              new PutMetadata(getRmdProtocolVersionID(), updatedRmdBytes));
+              new PutMetadata(getRmdProtocolVersionID(), updatedRmdBytes),
+              oldValueManifest,
+              oldRmdManifest);
     };
   }
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
@@ -330,7 +330,7 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
     return result.serialize();
   }
 
-  // This function may modify the original record in KME and it is unsafe to use the payload from KME directly after
+  // This function may modify the original record in KME, it is unsafe to use the payload from KME directly after
   // this function.
   protected void processMessageAndMaybeProduceToKafka(
       PubSubMessage<KafkaKey, KafkaMessageEnvelope, Long> consumerRecord,

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
@@ -317,6 +317,7 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
       return null; // No RMD for this key
     }
     RmdWithValueSchemaId rmdWithValueSchemaId = new RmdWithValueSchemaId();
+    // Get old RMD manifest value from RMD Manifest container object.
     rmdWithValueSchemaId.setRmdManifest(rmdManifestContainer.getManifest());
     getRmdSerDe()
         .deserializeValueSchemaIdPrependedRmdBytes(replicationMetadataWithValueSchemaBytes, rmdWithValueSchemaId);
@@ -327,6 +328,10 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
     return rmdSerDe;
   }
 
+  /**
+   * This method tries to retrieve the RMD bytes with prepended value schema ID from storage engine. It will also store
+   * RMD manifest into passed-in {@link ChunkedValueManifestContainer} container object if current RMD value is chunked.
+   */
   byte[] getRmdWithValueSchemaByteBufferFromStorage(
       int subPartition,
       byte[] key,

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -1540,6 +1540,7 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
     LeaderMetadataWrapper leaderMetadataWrapper = new LeaderMetadataWrapper(sourceTopicOffset, kafkaClusterId);
     partitionConsumptionState.setLastLeaderPersistFuture(leaderProducedRecordContext.getPersistedToDBFuture());
     produceFunction.accept(callback, leaderMetadataWrapper);
+    /*
     produceChunkDeletionRequestToLocalKafka(
         consumerRecord,
         partitionConsumptionState,
@@ -1560,6 +1561,8 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
         kafkaUrl,
         leaderMetadataWrapper,
         beforeProcessingRecordTimestampNs);
+    
+     */
   }
 
   protected void produceChunkDeletionRequestToLocalKafka(

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -2941,7 +2941,8 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
             null,
             readerValueSchemaID,
             storeDeserializerCache,
-            compressor.get());
+            compressor.get(),
+            null);
         hostLevelIngestionStats.recordWriteComputeLookUpLatency(LatencyUtils.getLatencyInMS(lookupStartTimeInNS));
       } catch (Exception e) {
         writeComputeFailureCode = StatsErrorCode.WRITE_COMPUTE_DESERIALIZATION_FAILURE.code;

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -32,6 +32,7 @@ import com.linkedin.venice.exceptions.validation.FatalDataValidationException;
 import com.linkedin.venice.guid.GuidUtils;
 import com.linkedin.venice.kafka.TopicManager;
 import com.linkedin.venice.kafka.protocol.ControlMessage;
+import com.linkedin.venice.kafka.protocol.Delete;
 import com.linkedin.venice.kafka.protocol.KafkaMessageEnvelope;
 import com.linkedin.venice.kafka.protocol.Put;
 import com.linkedin.venice.kafka.protocol.TopicSwitch;
@@ -59,6 +60,7 @@ import com.linkedin.venice.utils.PartitionUtils;
 import com.linkedin.venice.utils.Utils;
 import com.linkedin.venice.utils.lazy.Lazy;
 import com.linkedin.venice.writer.ChunkAwareCallback;
+import com.linkedin.venice.writer.DeleteMetadata;
 import com.linkedin.venice.writer.LeaderMetadataWrapper;
 import com.linkedin.venice.writer.VeniceWriter;
 import com.linkedin.venice.writer.VeniceWriterFactory;
@@ -1499,6 +1501,34 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
       String kafkaUrl,
       int kafkaClusterId,
       long beforeProcessingRecordTimestampNs) {
+    produceToLocalKafka(
+        consumerRecord,
+        partitionConsumptionState,
+        leaderProducedRecordContext,
+        produceFunction,
+        null,
+        null,
+        null,
+        null,
+        subPartition,
+        kafkaUrl,
+        kafkaClusterId,
+        beforeProcessingRecordTimestampNs);
+  }
+
+  protected void produceToLocalKafka(
+      PubSubMessage<KafkaKey, KafkaMessageEnvelope, Long> consumerRecord,
+      PartitionConsumptionState partitionConsumptionState,
+      LeaderProducedRecordContext leaderProducedRecordContext,
+      BiConsumer<ChunkAwareCallback, LeaderMetadataWrapper> produceFunction,
+      ChunkedValueManifest oldValueManifest,
+      ChunkedValueManifest oldRmdManifest,
+      Delete chunkDeletePayload,
+      DeleteMetadata chunkDeleteMetadata,
+      int subPartition,
+      String kafkaUrl,
+      int kafkaClusterId,
+      long beforeProcessingRecordTimestampNs) {
     LeaderProducerCallback callback = createProducerCallback(
         consumerRecord,
         partitionConsumptionState,
@@ -1510,6 +1540,55 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
     LeaderMetadataWrapper leaderMetadataWrapper = new LeaderMetadataWrapper(sourceTopicOffset, kafkaClusterId);
     partitionConsumptionState.setLastLeaderPersistFuture(leaderProducedRecordContext.getPersistedToDBFuture());
     produceFunction.accept(callback, leaderMetadataWrapper);
+    produceChunkDeletionRequestToLocalKafka(
+        consumerRecord,
+        partitionConsumptionState,
+        oldValueManifest,
+        chunkDeletePayload,
+        chunkDeleteMetadata,
+        subPartition,
+        kafkaUrl,
+        leaderMetadataWrapper,
+        beforeProcessingRecordTimestampNs);
+    produceChunkDeletionRequestToLocalKafka(
+        consumerRecord,
+        partitionConsumptionState,
+        oldRmdManifest,
+        chunkDeletePayload,
+        chunkDeleteMetadata,
+        subPartition,
+        kafkaUrl,
+        leaderMetadataWrapper,
+        beforeProcessingRecordTimestampNs);
+  }
+
+  protected void produceChunkDeletionRequestToLocalKafka(
+      PubSubMessage<KafkaKey, KafkaMessageEnvelope, Long> consumerRecord,
+      PartitionConsumptionState partitionConsumptionState,
+      ChunkedValueManifest manifest,
+      Delete chunkDeletePayload,
+      DeleteMetadata chunkDeleteMetadata,
+      int subPartition,
+      String kafkaUrl,
+      LeaderMetadataWrapper leaderMetadataWrapper,
+      long beforeProcessingRecordTimestampNs) {
+    if (manifest == null) {
+      return;
+    }
+    for (int i = 0; i < manifest.keysWithChunkIdSuffix.size(); i++) {
+      byte[] chunkKeyBytes = manifest.keysWithChunkIdSuffix.get(i).array();
+      LeaderProducedRecordContext rmdChunkDeleteRecordContext =
+          LeaderProducedRecordContext.newChunkDeleteRecord(chunkKeyBytes, chunkDeletePayload);
+      LeaderProducerCallback callback = createProducerCallback(
+          consumerRecord,
+          partitionConsumptionState,
+          rmdChunkDeleteRecordContext,
+          subPartition,
+          kafkaUrl,
+          beforeProcessingRecordTimestampNs);
+      veniceWriter.get()
+          .deleteDeprecatedChunk(chunkKeyBytes, subPartition, callback, leaderMetadataWrapper, chunkDeleteMetadata);
+    }
   }
 
   @Override
@@ -2891,33 +2970,14 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
           partitionConsumptionState,
           leaderProducedRecordContext,
           produceFunction,
+          oldValueManifest,
+          null,
+          null,
+          null,
           subPartition,
           kafkaUrl,
           kafkaClusterId,
           beforeProcessingRecordTimestampNs);
-    }
-
-    /**
-     * Iterate all chunked keys in old manifest and send DELETE request to version topic.
-     */
-    if (isChunked) {
-      if (oldValueManifest != null) {
-        for (int i = 0; i < oldValueManifest.keysWithChunkIdSuffix.size(); i++) {
-          LeaderProducedRecordContext valueChunkDeleteRecordContext =
-              LeaderProducedRecordContext.newChunkDeleteRecord(updatedKeyBytes, null);
-          byte[] chunkKeyBytes = oldValueManifest.keysWithChunkIdSuffix.get(i).array();
-          produceToLocalKafka(
-              consumerRecord,
-              partitionConsumptionState,
-              valueChunkDeleteRecordContext,
-              (callback, leaderMetadataWrapper) -> veniceWriter.get()
-                  .deleteDeprecatedChunk(chunkKeyBytes, subPartition, callback, leaderMetadataWrapper, null),
-              subPartition,
-              kafkaUrl,
-              kafkaClusterId,
-              beforeProcessingRecordTimestampNs);
-        }
-      }
     }
   }
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -7,6 +7,7 @@ import static com.linkedin.davinci.kafka.consumer.LeaderFollowerStateType.LEADER
 import static com.linkedin.davinci.kafka.consumer.LeaderFollowerStateType.PAUSE_TRANSITION_FROM_STANDBY_TO_LEADER;
 import static com.linkedin.davinci.kafka.consumer.LeaderFollowerStateType.STANDBY;
 import static com.linkedin.venice.kafka.protocol.enums.ControlMessageType.END_OF_PUSH;
+import static com.linkedin.venice.writer.VeniceWriter.APP_DEFAULT_LOGICAL_TS;
 import static com.linkedin.venice.writer.VeniceWriter.DEFAULT_LEADER_METADATA_WRAPPER;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.MINUTES;
@@ -2884,7 +2885,16 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
 
       BiConsumer<ChunkAwareCallback, LeaderMetadataWrapper> produceFunction =
           (callback, leaderMetadataWrapper) -> veniceWriter.get()
-              .put(keyBytes, updatedValueBytes, readerValueSchemaId, callback, leaderMetadataWrapper);
+              .put(
+                  keyBytes,
+                  updatedValueBytes,
+                  readerValueSchemaId,
+                  callback,
+                  leaderMetadataWrapper,
+                  APP_DEFAULT_LOGICAL_TS,
+                  null,
+                  oldValueManifest,
+                  null);
 
       produceToLocalKafka(
           consumerRecord,

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderProducedRecordContext.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderProducedRecordContext.java
@@ -103,6 +103,10 @@ public class LeaderProducedRecordContext {
     return new LeaderProducedRecordContext(NO_UPSTREAM, NO_UPSTREAM, PUT, keyBytes, valueUnion);
   }
 
+  public static LeaderProducedRecordContext newChunkDeleteRecord(byte[] keyBytes, Delete valueUnion) {
+    return new LeaderProducedRecordContext(NO_UPSTREAM, NO_UPSTREAM, DELETE, keyBytes, valueUnion);
+  }
+
   public static LeaderProducedRecordContext newPutRecordWithFuture(
       int consumedKafkaClusterId,
       long consumedOffset,

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderProducerCallback.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderProducerCallback.java
@@ -143,7 +143,7 @@ class LeaderProducerCallback implements ChunkAwareCallback {
       try {
         /**
          * queue the leaderProducedRecordContext to drainer service as is in case the value was not chunked.
-         * Otherwise queue the chunks and manifest individually to drainer service.
+         * Otherwise, queue the chunks and manifest individually to drainer service.
          */
         if (chunkedValueManifest == null) {
           // update the keyBytes for the ProducedRecord in case it was changed due to isChunkingEnabled flag in

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderProducerCallback.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderProducerCallback.java
@@ -308,9 +308,8 @@ class LeaderProducerCallback implements ChunkAwareCallback {
     return totalChunkSize;
   }
 
-  private void produceDeprecatedChunkDeletionToStoreBufferService(
-      ChunkedValueManifest manifest,
-      long currentTimeForMetricsMs) throws InterruptedException {
+  void produceDeprecatedChunkDeletionToStoreBufferService(ChunkedValueManifest manifest, long currentTimeForMetricsMs)
+      throws InterruptedException {
     if (manifest == null) {
       return;
     }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderProducerCallback.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderProducerCallback.java
@@ -204,9 +204,9 @@ class LeaderProducerCallback implements ChunkAwareCallback {
               currentTimeForMetricsMs);
           producedRecordNum++;
           producedRecordSize += key.length + manifest.remaining();
-          produceDeprecatedChunkDeletionToStoreBufferService(oldValueManifest, currentTimeForMetricsMs);
-          produceDeprecatedChunkDeletionToStoreBufferService(oldRmdManifest, currentTimeForMetricsMs);
         }
+        produceDeprecatedChunkDeletionToStoreBufferService(oldValueManifest, currentTimeForMetricsMs);
+        produceDeprecatedChunkDeletionToStoreBufferService(oldRmdManifest, currentTimeForMetricsMs);
         recordProducerStats(producedRecordSize, producedRecordNum);
 
       } catch (Exception oe) {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderProducerCallback.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderProducerCallback.java
@@ -141,7 +141,11 @@ class LeaderProducerCallback implements ChunkAwareCallback {
                   currentTimeForMetricsMs);
         }
       }
-
+      // update the keyBytes for the ProducedRecord in case it was changed due to isChunkingEnabled flag in
+      // VeniceWriter.
+      if (key != null) {
+        leaderProducedRecordContext.setKeyBytes(key);
+      }
       int producedRecordNum = 0;
       int producedRecordSize = 0;
       // produce to drainer buffer service for further processing.
@@ -151,11 +155,6 @@ class LeaderProducerCallback implements ChunkAwareCallback {
          * Otherwise, queue the chunks and manifest individually to drainer service.
          */
         if (chunkedValueManifest == null) {
-          // update the keyBytes for the ProducedRecord in case it was changed due to isChunkingEnabled flag in
-          // VeniceWriter.
-          if (key != null) {
-            leaderProducedRecordContext.setKeyBytes(key);
-          }
           leaderProducedRecordContext.setProducedOffset(produceResult.getOffset());
           ingestionTask.produceToStoreBufferService(
               sourceConsumerRecord,

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/PartitionConsumptionState.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/PartitionConsumptionState.java
@@ -464,7 +464,9 @@ public class PartitionConsumptionState {
       long kafkaConsumedOffset,
       byte[] key,
       int valueSchemaId,
-      GenericRecord replicationMetadataRecord) {
+      GenericRecord replicationMetadataRecord,
+      ChunkedValueManifest valueManifest,
+      ChunkedValueManifest rmdManifest) {
     setTransientRecord(
         kafkaClusterId,
         kafkaConsumedOffset,
@@ -473,7 +475,9 @@ public class PartitionConsumptionState {
         -1,
         -1,
         valueSchemaId,
-        replicationMetadataRecord);
+        replicationMetadataRecord,
+        valueManifest,
+        rmdManifest);
   }
 
   public void setTransientRecord(
@@ -484,9 +488,18 @@ public class PartitionConsumptionState {
       int valueOffset,
       int valueLen,
       int valueSchemaId,
-      GenericRecord replicationMetadataRecord) {
-    TransientRecord transientRecord =
-        new TransientRecord(value, valueOffset, valueLen, valueSchemaId, kafkaClusterId, kafkaConsumedOffset);
+      GenericRecord replicationMetadataRecord,
+      ChunkedValueManifest valueManifest,
+      ChunkedValueManifest rmdManifest) {
+    TransientRecord transientRecord = new TransientRecord(
+        value,
+        valueOffset,
+        valueLen,
+        valueSchemaId,
+        kafkaClusterId,
+        kafkaConsumedOffset,
+        valueManifest,
+        rmdManifest);
     if (replicationMetadataRecord != null) {
       transientRecord.setReplicationMetadataRecord(replicationMetadataRecord);
     }
@@ -565,7 +578,7 @@ public class PartitionConsumptionState {
     private GenericRecord replicationMetadataRecord;
 
     private ChunkedValueManifest valueManifest;
-    private ChunkedValueManifest replicationMetadataManifest;
+    private ChunkedValueManifest rmdManifest;
 
     TransientRecord(
         byte[] value,
@@ -573,13 +586,25 @@ public class PartitionConsumptionState {
         int valueLen,
         int valueSchemaId,
         int kafkaClusterId,
-        long kafkaConsumedOffset) {
+        long kafkaConsumedOffset,
+        ChunkedValueManifest valueManifest,
+        ChunkedValueManifest rmdManifest) {
       this.value = value;
       this.valueOffset = valueOffset;
       this.valueLen = valueLen;
       this.valueSchemaId = valueSchemaId;
       this.kafkaClusterId = kafkaClusterId;
       this.kafkaConsumedOffset = kafkaConsumedOffset;
+      this.valueManifest = valueManifest;
+      this.rmdManifest = rmdManifest;
+    }
+
+    public ChunkedValueManifest getRmdManifest() {
+      return rmdManifest;
+    }
+
+    public ChunkedValueManifest getValueManifest() {
+      return valueManifest;
     }
 
     public void setReplicationMetadataRecord(GenericRecord replicationMetadataRecord) {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/PartitionConsumptionState.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/PartitionConsumptionState.java
@@ -12,6 +12,7 @@ import com.linkedin.venice.pubsub.PubSubTopicPartitionImpl;
 import com.linkedin.venice.pubsub.PubSubTopicRepository;
 import com.linkedin.venice.pubsub.api.PubSubTopic;
 import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
+import com.linkedin.venice.storage.protocol.ChunkedValueManifest;
 import com.linkedin.venice.utils.PartitionUtils;
 import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
 import java.nio.ByteBuffer;
@@ -562,6 +563,9 @@ public class PartitionConsumptionState {
     private final int kafkaClusterId;
     private final long kafkaConsumedOffset;
     private GenericRecord replicationMetadataRecord;
+
+    private ChunkedValueManifest valueManifest;
+    private ChunkedValueManifest replicationMetadataManifest;
 
     TransientRecord(
         byte[] value,

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -2924,7 +2924,6 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
     MessageType messageType = (leaderProducedRecordContext == null
         ? MessageType.valueOf(kafkaValue)
         : leaderProducedRecordContext.getMessageType());
-
     switch (messageType) {
       case PUT:
         // If single-threaded, we can re-use (and clobber) the same Put instance. // TODO: explore GC tuning later.

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/replication/RmdWithValueSchemaId.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/replication/RmdWithValueSchemaId.java
@@ -1,5 +1,6 @@
 package com.linkedin.davinci.replication;
 
+import com.linkedin.venice.storage.protocol.ChunkedValueManifest;
 import org.apache.avro.generic.GenericRecord;
 
 
@@ -10,14 +11,40 @@ import org.apache.avro.generic.GenericRecord;
  *    3. Value schema ID used to generate the RMD schema.
  */
 public class RmdWithValueSchemaId {
-  private final int valueSchemaID;
-  private final int rmdProtocolVersionID;
-  private final GenericRecord rmdRecord;
+  private int valueSchemaID;
+  private int rmdProtocolVersionID;
+  private GenericRecord rmdRecord;
 
-  public RmdWithValueSchemaId(int valueSchemaID, int rmdProtocolVersionID, GenericRecord rmdRecord) {
+  private ChunkedValueManifest rmdManifest;
+
+  public RmdWithValueSchemaId(
+      int valueSchemaID,
+      int rmdProtocolVersionID,
+      GenericRecord rmdRecord,
+      ChunkedValueManifest rmdManifest) {
     this.valueSchemaID = valueSchemaID;
     this.rmdRecord = rmdRecord;
     this.rmdProtocolVersionID = rmdProtocolVersionID;
+    this.rmdManifest = rmdManifest;
+  }
+
+  public RmdWithValueSchemaId() {
+  }
+
+  public void setValueSchemaID(int valueSchemaID) {
+    this.valueSchemaID = valueSchemaID;
+  }
+
+  public void setRmdProtocolVersionID(int rmdProtocolVersionID) {
+    this.rmdProtocolVersionID = rmdProtocolVersionID;
+  }
+
+  public void setRmdRecord(GenericRecord rmdRecord) {
+    this.rmdRecord = rmdRecord;
+  }
+
+  public void setRmdManifest(ChunkedValueManifest rmdManifest) {
+    this.rmdManifest = rmdManifest;
   }
 
   public GenericRecord getRmdRecord() {
@@ -30,5 +57,9 @@ public class RmdWithValueSchemaId {
 
   public int getRmdProtocolVersionID() {
     return rmdProtocolVersionID;
+  }
+
+  public ChunkedValueManifest getRmdManifest() {
+    return rmdManifest;
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/replication/RmdWithValueSchemaId.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/replication/RmdWithValueSchemaId.java
@@ -28,6 +28,12 @@ public class RmdWithValueSchemaId {
     this.rmdManifest = rmdManifest;
   }
 
+  public RmdWithValueSchemaId(int valueSchemaID, int rmdProtocolVersionID, GenericRecord rmdRecord) {
+    this.valueSchemaID = valueSchemaID;
+    this.rmdRecord = rmdRecord;
+    this.rmdProtocolVersionID = rmdProtocolVersionID;
+  }
+
   public RmdWithValueSchemaId() {
   }
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/replication/merge/RmdSerDe.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/replication/merge/RmdSerDe.java
@@ -48,7 +48,9 @@ public class RmdSerDe {
    * @return A {@link RmdWithValueSchemaId} object composed by extracting the value schema ID from the
    *    * header of the replication metadata.
    */
-  public RmdWithValueSchemaId deserializeValueSchemaIdPrependedRmdBytes(byte[] valueSchemaIdPrependedBytes) {
+  public void deserializeValueSchemaIdPrependedRmdBytes(
+      byte[] valueSchemaIdPrependedBytes,
+      RmdWithValueSchemaId rmdWithValueSchemaId) {
     Validate.notNull(valueSchemaIdPrependedBytes);
     ByteBuffer rmdWithValueSchemaID = ByteBuffer.wrap(valueSchemaIdPrependedBytes);
     final int valueSchemaId = rmdWithValueSchemaID.getInt();
@@ -58,7 +60,10 @@ public class RmdSerDe {
             rmdWithValueSchemaID.position(),
             rmdWithValueSchemaID.remaining());
     GenericRecord rmdRecord = getRmdDeserializer(valueSchemaId, valueSchemaId).deserialize(binaryDecoder);
-    return new RmdWithValueSchemaId(valueSchemaId, rmdVersionId, rmdRecord);
+    rmdWithValueSchemaId.setValueSchemaID(valueSchemaId);
+    rmdWithValueSchemaId.setRmdProtocolVersionID(rmdVersionId);
+    rmdWithValueSchemaId.setRmdRecord(rmdRecord);
+    // return new RmdWithValueSchemaId(valueSchemaId, rmdVersionId, rmdRecord);
   }
 
   /**

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/replication/merge/RmdSerDe.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/replication/merge/RmdSerDe.java
@@ -63,7 +63,6 @@ public class RmdSerDe {
     rmdWithValueSchemaId.setValueSchemaID(valueSchemaId);
     rmdWithValueSchemaId.setRmdProtocolVersionID(rmdVersionId);
     rmdWithValueSchemaId.setRmdRecord(rmdRecord);
-    // return new RmdWithValueSchemaId(valueSchemaId, rmdVersionId, rmdRecord);
   }
 
   /**

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/replication/merge/RmdSerDe.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/replication/merge/RmdSerDe.java
@@ -44,9 +44,8 @@ public class RmdSerDe {
   }
 
   /**
-   * @param valueSchemaIdPrependedBytes The raw bytes with value schema ID prepended.
-   * @return A {@link RmdWithValueSchemaId} object composed by extracting the value schema ID from the
-   *    * header of the replication metadata.
+   * This method takes in the RMD bytes with prepended value schema ID and a {@link RmdWithValueSchemaId} container object.
+   * It will deserialize the RMD bytes into RMD record and fill the passed-in container.
    */
   public void deserializeValueSchemaIdPrependedRmdBytes(
       byte[] valueSchemaIdPrependedBytes,

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/storage/chunking/AbstractAvroChunkingAdapter.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/storage/chunking/AbstractAvroChunkingAdapter.java
@@ -121,7 +121,8 @@ public abstract class AbstractAvroChunkingAdapter<T> implements ChunkingAdapter<
         readerSchemaId,
         storeDeserializerCache,
         compressor,
-        false);
+        false,
+        null);
   }
 
   public T get(

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/storage/chunking/AbstractAvroChunkingAdapter.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/storage/chunking/AbstractAvroChunkingAdapter.java
@@ -106,7 +106,8 @@ public abstract class AbstractAvroChunkingAdapter<T> implements ChunkingAdapter<
       ReadResponse response,
       int readerSchemaId,
       StoreDeserializerCache<T> storeDeserializerCache,
-      VeniceCompressor compressor) {
+      VeniceCompressor compressor,
+      ChunkedValueManifestContainer manifestContainer) {
     if (isChunked) {
       key = ChunkingUtils.KEY_WITH_CHUNKING_SUFFIX_SERIALIZER.serializeNonChunkedKey(key);
     }
@@ -122,7 +123,7 @@ public abstract class AbstractAvroChunkingAdapter<T> implements ChunkingAdapter<
         storeDeserializerCache,
         compressor,
         false,
-        null);
+        manifestContainer);
   }
 
   public T get(

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/storage/chunking/ChunkedValueManifestContainer.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/storage/chunking/ChunkedValueManifestContainer.java
@@ -1,0 +1,19 @@
+package com.linkedin.davinci.storage.chunking;
+
+import com.linkedin.venice.storage.protocol.ChunkedValueManifest;
+
+
+public class ChunkedValueManifestContainer {
+  private ChunkedValueManifest manifest;
+
+  public ChunkedValueManifestContainer() {
+  }
+
+  public void setManifest(ChunkedValueManifest manifest) {
+    this.manifest = manifest;
+  }
+
+  public ChunkedValueManifest getManifest() {
+    return manifest;
+  }
+}

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/storage/chunking/ChunkingUtils.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/storage/chunking/ChunkingUtils.java
@@ -227,11 +227,11 @@ public class ChunkingUtils {
   }
 
   public static ChunkedValueManifest getChunkValueManifestFromStorage(
-      ByteBuffer key,
+      byte[] key,
       int partition,
       boolean isRmd,
       AbstractStorageEngine store) {
-    byte[] value = store.get(partition, key);
+    byte[] value = isRmd ? store.getReplicationMetadata(partition, key) : store.get(partition, key);
     if (value == null) {
       return null;
     }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/storage/chunking/ChunkingUtils.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/storage/chunking/ChunkingUtils.java
@@ -226,6 +226,22 @@ public class ChunkingUtils {
         isRmdValue);
   }
 
+  public static ChunkedValueManifest getChunkValueManifestFromStorage(
+      ByteBuffer key,
+      int partition,
+      boolean isRmd,
+      AbstractStorageEngine store) {
+    byte[] value = store.get(partition, key);
+    if (value == null) {
+      return null;
+    }
+    int writerSchemaId = ValueRecord.parseSchemaId(value);
+    if (writerSchemaId > 0) {
+      return null;
+    }
+    return CHUNKED_VALUE_MANIFEST_SERIALIZER.deserialize(value, writerSchemaId);
+  }
+
   /**
    * Fetches the value associated with the given key, and potentially re-assembles it, if it is
    * a chunked value.

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/storage/chunking/ChunkingUtils.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/storage/chunking/ChunkingUtils.java
@@ -73,7 +73,7 @@ public class ChunkingUtils {
       int partition,
       ByteBuffer keyBuffer,
       ReadResponse response) {
-    return getFromStorage(adapter, store, partition, keyBuffer, response, null, null, -1, null, null, false);
+    return getFromStorage(adapter, store, partition, keyBuffer, response, null, null, -1, null, null, false, null);
   }
 
   static <VALUE, ASSEMBLED_VALUE_CONTAINER> VALUE getReplicationMetadataFromStorage(
@@ -81,8 +81,21 @@ public class ChunkingUtils {
       AbstractStorageEngine store,
       int partition,
       ByteBuffer keyBuffer,
-      ReadResponse response) {
-    return getFromStorage(adapter, store, partition, keyBuffer, response, null, null, -1, null, null, true);
+      ReadResponse response,
+      ChunkedValueManifestContainer manifestContainer) {
+    return getFromStorage(
+        adapter,
+        store,
+        partition,
+        keyBuffer,
+        response,
+        null,
+        null,
+        -1,
+        null,
+        null,
+        true,
+        manifestContainer);
   }
 
   static <VALUE, CHUNKS_CONTAINER> VALUE getFromStorage(
@@ -115,7 +128,8 @@ public class ChunkingUtils {
         readerSchemaId,
         storeDeserializerCache,
         compressor,
-        false);
+        false,
+        null);
   }
 
   static <CHUNKS_CONTAINER, VALUE> void getFromStorageByPartialKey(
@@ -205,7 +219,8 @@ public class ChunkingUtils {
       int readerSchemaID,
       StoreDeserializerCache<VALUE> storeDeserializerCache,
       VeniceCompressor compressor,
-      boolean isRmdValue) {
+      boolean isRmdValue,
+      ChunkedValueManifestContainer manifestContainer) {
     long databaseLookupStartTimeInNS = (response != null) ? System.nanoTime() : 0;
     byte[] value =
         isRmdValue ? store.getReplicationMetadata(partition, keyBuffer.array()) : store.get(partition, keyBuffer);
@@ -223,7 +238,8 @@ public class ChunkingUtils {
         readerSchemaID,
         storeDeserializerCache,
         compressor,
-        isRmdValue);
+        isRmdValue,
+        manifestContainer);
   }
 
   public static ChunkedValueManifest getChunkValueManifestFromStorage(
@@ -267,7 +283,8 @@ public class ChunkingUtils {
       int readerSchemaId,
       StoreDeserializerCache<VALUE> storeDeserializerCache,
       VeniceCompressor compressor,
-      boolean isRmdValue) {
+      boolean isRmdValue,
+      ChunkedValueManifestContainer manifestContainer) {
 
     if (value == null) {
       return null;
@@ -297,6 +314,9 @@ public class ChunkingUtils {
     // End of initial sanity checks. We have a chunked value, so we need to fetch all chunks
 
     ChunkedValueManifest chunkedValueManifest = CHUNKED_VALUE_MANIFEST_SERIALIZER.deserialize(value, writerSchemaId);
+    if (manifestContainer != null) {
+      manifestContainer.setManifest(chunkedValueManifest);
+    }
     CHUNKS_CONTAINER assembledValueContainer = adapter.constructChunksContainer(chunkedValueManifest);
     int actualSize = 0;
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/storage/chunking/SingleGetChunkingAdapter.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/storage/chunking/SingleGetChunkingAdapter.java
@@ -56,11 +56,17 @@ public class SingleGetChunkingAdapter implements ChunkingAdapter<CompositeByteBu
       int partition,
       byte[] key,
       boolean isChunked,
-      ReadResponse response) {
+      ReadResponse response,
+      ChunkedValueManifestContainer manifestContainer) {
     ByteBuffer keyBuffer = isChunked
         ? ChunkingUtils.KEY_WITH_CHUNKING_SUFFIX_SERIALIZER.serializeNonChunkedKeyAsByteBuffer(key)
         : ByteBuffer.wrap(key);
-    return ChunkingUtils
-        .getReplicationMetadataFromStorage(SINGLE_GET_CHUNKING_ADAPTER, store, partition, keyBuffer, response);
+    return ChunkingUtils.getReplicationMetadataFromStorage(
+        SINGLE_GET_CHUNKING_ADAPTER,
+        store,
+        partition,
+        keyBuffer,
+        response,
+        manifestContainer);
   }
 }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTaskTest.java
@@ -165,7 +165,7 @@ public class ActiveActiveStoreIngestionTaskTest {
     when(badPartitionConsumptionState.hasLagCaughtUp()).thenReturn(true);
     // short circuit isReadyToServe
     when(badPartitionConsumptionState.isEndOfPushReceived()).thenReturn(false);
-    ingestionTask.addPartititionConsumptionState(1, badPartitionConsumptionState);
+    ingestionTask.addPartitionConsumptionState(1, badPartitionConsumptionState);
 
     Assert.assertTrue(ingestionTask.isReadyToServeAnnouncedWithRTLag());
 
@@ -173,11 +173,11 @@ public class ActiveActiveStoreIngestionTaskTest {
     when(goodPartitionConsumptionState.hasLagCaughtUp()).thenReturn(true);
     when(goodPartitionConsumptionState.isEndOfPushReceived()).thenReturn(true);
     when(goodPartitionConsumptionState.isWaitingForReplicationLag()).thenReturn(false);
-    ingestionTask.addPartititionConsumptionState(1, goodPartitionConsumptionState);
+    ingestionTask.addPartitionConsumptionState(1, goodPartitionConsumptionState);
 
     Assert.assertFalse(ingestionTask.isReadyToServeAnnouncedWithRTLag());
 
-    ingestionTask.addPartititionConsumptionState(2, badPartitionConsumptionState);
+    ingestionTask.addPartitionConsumptionState(2, badPartitionConsumptionState);
 
     Assert.assertTrue(ingestionTask.isReadyToServeAnnouncedWithRTLag());
   }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTaskTest.java
@@ -201,7 +201,8 @@ public class ActiveActiveStoreIngestionTaskTest {
     when(ingestionTask.getKafkaVersionTopic()).thenReturn(testTopic);
     when(ingestionTask.createProducerCallback(any(), any(), any(), anyInt(), anyString(), anyLong()))
         .thenCallRealMethod();
-    when(ingestionTask.getProduceToTopicFunction(any(), any(), any(), anyInt(), anyBoolean())).thenCallRealMethod();
+    when(ingestionTask.getProduceToTopicFunction(any(), any(), any(), any(), any(), anyInt(), anyBoolean()))
+        .thenCallRealMethod();
     when(ingestionTask.getRmdProtocolVersionID()).thenReturn(rmdProtocolVersionID);
     doCallRealMethod().when(ingestionTask)
         .produceToLocalKafka(any(), any(), any(), any(), anyInt(), anyString(), anyInt(), anyLong());
@@ -277,6 +278,8 @@ public class ActiveActiveStoreIngestionTaskTest {
             updatedKeyBytes,
             updatedValueBytes,
             updatedRmdBytes,
+            null,
+            null,
             valueSchemaId,
             resultReuseInput),
         subPartition,

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTaskTest.java
@@ -376,12 +376,13 @@ public class ActiveActiveStoreIngestionTaskTest {
     when(ingestionTask.getStorageEngine()).thenReturn(storageEngine);
     when(ingestionTask.getSchemaRepo()).thenReturn(schemaRepository);
     when(ingestionTask.getServerConfig()).thenReturn(serverConfig);
-    when(ingestionTask.getRmdWithValueSchemaByteBufferFromStorage(anyInt(), any(), anyLong())).thenCallRealMethod();
+    when(ingestionTask.getRmdWithValueSchemaByteBufferFromStorage(anyInt(), any(), any(), anyLong()))
+        .thenCallRealMethod();
     when(ingestionTask.isChunked()).thenReturn(true);
     when(ingestionTask.getHostLevelIngestionStats()).thenReturn(mock(HostLevelIngestionStats.class));
 
     when(storageEngine.getReplicationMetadata(subPartition, topLevelKey1)).thenReturn(expectedNonChunkedValue);
-    byte[] result = ingestionTask.getRmdWithValueSchemaByteBufferFromStorage(subPartition, key1, 0L);
+    byte[] result = ingestionTask.getRmdWithValueSchemaByteBufferFromStorage(subPartition, key1, null, 0L);
     Assert.assertNotNull(result);
     Assert.assertEquals(result, expectedNonChunkedValue);
 
@@ -414,7 +415,7 @@ public class ActiveActiveStoreIngestionTaskTest {
 
     when(storageEngine.getReplicationMetadata(subPartition, topLevelKey2)).thenReturn(chunkedManifestWithSchemaBytes);
     when(storageEngine.getReplicationMetadata(subPartition, chunkedKey1InKey2)).thenReturn(chunkedValue1);
-    byte[] result2 = ingestionTask.getRmdWithValueSchemaByteBufferFromStorage(subPartition, key2, 0L);
+    byte[] result2 = ingestionTask.getRmdWithValueSchemaByteBufferFromStorage(subPartition, key2, null, 0L);
     Assert.assertNotNull(result2);
     Assert.assertEquals(result2, expectedChunkedValue1);
 
@@ -453,7 +454,7 @@ public class ActiveActiveStoreIngestionTaskTest {
     when(storageEngine.getReplicationMetadata(subPartition, topLevelKey3)).thenReturn(chunkedManifestWithSchemaBytes);
     when(storageEngine.getReplicationMetadata(subPartition, chunkedKey1InKey3)).thenReturn(chunkedValue1);
     when(storageEngine.getReplicationMetadata(subPartition, chunkedKey2InKey3)).thenReturn(chunkedValue2);
-    byte[] result3 = ingestionTask.getRmdWithValueSchemaByteBufferFromStorage(subPartition, key3, 0L);
+    byte[] result3 = ingestionTask.getRmdWithValueSchemaByteBufferFromStorage(subPartition, key3, null, 0L);
     Assert.assertNotNull(result3);
     Assert.assertEquals(result3, expectedChunkedValue2);
   }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/PartitionConsumptionStateTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/PartitionConsumptionStateTest.java
@@ -29,7 +29,7 @@ public class PartitionConsumptionStateTest {
     Schema aaSchema = RmdSchemaGenerator.generateMetadataSchema(schema, 1);
     GenericRecord record = new GenericData.Record(aaSchema);
     // Test removal succeeds if the key is specified with same kafkaConsumedOffset
-    pcs.setTransientRecord(-1, 1, key1, 5, record);
+    pcs.setTransientRecord(-1, 1, key1, 5, record, null, null);
     PartitionConsumptionState.TransientRecord tr1 = pcs.getTransientRecord(key2);
     Assert.assertEquals(tr1.getValue(), null);
     Assert.assertEquals(tr1.getValueLen(), -1);
@@ -43,10 +43,10 @@ public class PartitionConsumptionStateTest {
     Assert.assertEquals(pcs.getTransientRecordMapSize(), 0);
 
     // Test removal fails if the key is specified with same kafkaConsumedOffset
-    pcs.setTransientRecord(-1, 1, key1, value1, 100, value1.length, 5, null);
-    pcs.setTransientRecord(-1, 2, key3, 5, null);
+    pcs.setTransientRecord(-1, 1, key1, value1, 100, value1.length, 5, null, null, null);
+    pcs.setTransientRecord(-1, 2, key3, 5, null, null, null);
     Assert.assertEquals(pcs.getTransientRecordMapSize(), 2);
-    pcs.setTransientRecord(-1, 3, key1, value2, 100, value2.length, 5, null);
+    pcs.setTransientRecord(-1, 3, key1, value2, 100, value2.length, 5, null, null, null);
 
     tr2 = pcs.mayRemoveTransientRecord(-1, 1, key1);
     Assert.assertNotNull(tr2);

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/replication/merge/RmdSerDeTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/replication/merge/RmdSerDeTest.java
@@ -64,8 +64,8 @@ public class RmdSerDeTest {
     rmdAndValueSchemaIDBytes.put(rmdBytes.array());
 
     // Deserialize all bytes and expect to get value schema ID and RMD record back.
-    RmdWithValueSchemaId rmdAndValueID =
-        rmdSerDe.deserializeValueSchemaIdPrependedRmdBytes(rmdAndValueSchemaIDBytes.array());
+    RmdWithValueSchemaId rmdAndValueID = new RmdWithValueSchemaId();
+    rmdSerDe.deserializeValueSchemaIdPrependedRmdBytes(rmdAndValueSchemaIDBytes.array(), rmdAndValueID);
     Assert.assertEquals(rmdAndValueID.getValueSchemaId(), valueSchemaID);
     Assert.assertEquals(rmdAndValueID.getRmdRecord(), rmd);
   }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/storage/chunking/ChunkingTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/storage/chunking/ChunkingTest.java
@@ -231,7 +231,8 @@ public class ChunkingTest {
               null,
               readerSchemaId,
               storeDeserializerCache,
-              compressor));
+              compressor,
+              null));
     }
   }
 

--- a/internal/venice-common/src/main/java/com/linkedin/venice/writer/ChunkAwareCallback.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/writer/ChunkAwareCallback.java
@@ -19,7 +19,11 @@ public interface ChunkAwareCallback extends PubSubProducerCallback {
    *
    * @param key A byte[] corresponding to the top-level key written to Kafka, potentially including a chunking suffix
    * @param valueChunks An array of {@link ByteBuffer} where the backing array has sufficient headroom to prepend Venice's header
-   * @param chunkedValueManifest The {@link ChunkedValueManifest} of the chunked value
+   * @param chunkedValueManifest The {@link ChunkedValueManifest} of the new chunked value
+   * @param rmdChunks An array of {@link ByteBuffer} where the backing array has sufficient headroom to prepend Venice's header
+   * @param chunkedRmdManifest The {@link ChunkedValueManifest} of the new chunked RMD
+   * @param oldValueManifest The {@link ChunkedValueManifest} of the previous chunked value
+   * @param oldRmdManifest The {@link ChunkedValueManifest} of the previous chunked RMD
    */
   void setChunkingInfo(
       byte[] key,

--- a/internal/venice-common/src/main/java/com/linkedin/venice/writer/ChunkAwareCallback.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/writer/ChunkAwareCallback.java
@@ -8,7 +8,7 @@ import java.nio.ByteBuffer;
 
 /**
  *  The {@link VeniceWriter}, upon detecting an instance of this class being passed to it, will always call
- *  {@link #setChunkingInfo(byte[], ByteBuffer[], ChunkedValueManifest, ByteBuffer[], ChunkedValueManifest)} whenever
+ *  {@link #setChunkingInfo(byte[], ByteBuffer[], ChunkedValueManifest, ByteBuffer[], ChunkedValueManifest, ChunkedValueManifest, ChunkedValueManifest)} whenever
  *  processing a {@link MessageType#PUT}, whether it is chunked or not.
  */
 public interface ChunkAwareCallback extends PubSubProducerCallback {
@@ -26,5 +26,7 @@ public interface ChunkAwareCallback extends PubSubProducerCallback {
       ByteBuffer[] valueChunks,
       ChunkedValueManifest chunkedValueManifest,
       ByteBuffer[] rmdChunks,
-      ChunkedValueManifest chunkedRmdManifest);
+      ChunkedValueManifest chunkedRmdManifest,
+      ChunkedValueManifest oldValueManifest,
+      ChunkedValueManifest oldRmdManifest);
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/writer/VeniceWriter.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/writer/VeniceWriter.java
@@ -251,8 +251,6 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
 
   private final boolean isRmdChunkingEnabled;
 
-  private final int rmdProtocolVersionId;
-
   public VeniceWriter(VeniceWriterOptions params, VeniceProperties props, PubSubProducerAdapter producerAdapter) {
     this(params, props, producerAdapter, KafkaMessageEnvelope.SCHEMA$);
   }
@@ -280,8 +278,6 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
     this.isChunkingEnabled = params.isChunkingEnabled();
     this.isChunkingSet = true;
     this.isRmdChunkingEnabled = params.isRmdChunkingEnabled();
-    // TODO: Add VWOption support to change it.
-    this.rmdProtocolVersionId = 1;
     this.maxSizeForUserPayloadPerMessageInBytes = props
         .getInt(MAX_SIZE_FOR_USER_PAYLOAD_PER_MESSAGE_IN_BYTES, DEFAULT_MAX_SIZE_FOR_USER_PAYLOAD_PER_MESSAGE_IN_BYTES);
     if (maxSizeForUserPayloadPerMessageInBytes > DEFAULT_MAX_SIZE_FOR_USER_PAYLOAD_PER_MESSAGE_IN_BYTES) {

--- a/internal/venice-common/src/main/java/com/linkedin/venice/writer/VeniceWriter.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/writer/VeniceWriter.java
@@ -520,12 +520,11 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
     }
     KafkaKey kafkaKey = new KafkaKey(MessageType.DELETE, serializedKey);
     Delete delete = new Delete();
+    delete.schemaId = AvroProtocolDefinition.CHUNK.getCurrentProtocolVersion();
     if (deleteMetadata == null) {
-      delete.schemaId = VENICE_DEFAULT_VALUE_SCHEMA_ID;
       delete.replicationMetadataVersionId = VENICE_DEFAULT_TIMESTAMP_METADATA_VERSION_ID;
       delete.replicationMetadataPayload = EMPTY_BYTE_BUFFER;
     } else {
-      delete.schemaId = deleteMetadata.getValueSchemaId();
       delete.replicationMetadataVersionId = deleteMetadata.getRmdVersionId();
       delete.replicationMetadataPayload = deleteMetadata.getRmdPayload();
     }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/writer/VeniceWriter.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/writer/VeniceWriter.java
@@ -508,6 +508,9 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
     return delete(key, callback, DEFAULT_LEADER_METADATA_WRAPPER, APP_DEFAULT_LOGICAL_TS, deleteMetadata);
   }
 
+  /**
+   * This method produces a DELETE request to a deprecated chunk key.
+   */
   public void deleteDeprecatedChunk(
       byte[] serializedKey,
       int partition,
@@ -1386,6 +1389,10 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
     return manifestProduceFuture;
   }
 
+  /**
+   * This method iterates over a {@link ChunkedValueManifest} object's chunk key list and issue DELETE request for each
+   * chunk.
+   */
   private void deleteDeprecatedChunksFromManifest(
       ChunkedValueManifest manifest,
       int partition,

--- a/internal/venice-common/src/main/java/com/linkedin/venice/writer/VeniceWriter.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/writer/VeniceWriter.java
@@ -508,17 +508,6 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
     return delete(key, callback, DEFAULT_LEADER_METADATA_WRAPPER, APP_DEFAULT_LOGICAL_TS, deleteMetadata);
   }
 
-  public void deleteDeprecatedChunksFromManifest(
-      ChunkedValueManifest manifest,
-      int partition,
-      PubSubProducerCallback callback,
-      LeaderMetadataWrapper leaderMetadataWrapper,
-      DeleteMetadata deleteMetadata) {
-    for (ByteBuffer chunkedKeyByteBuffer: manifest.keysWithChunkIdSuffix) {
-      deleteDeprecatedChunk(chunkedKeyByteBuffer.array(), partition, callback, leaderMetadataWrapper, deleteMetadata);
-    }
-  }
-
   public void deleteDeprecatedChunk(
       byte[] serializedKey,
       int partition,

--- a/internal/venice-common/src/main/java/com/linkedin/venice/writer/WriterChunkingHelper.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/writer/WriterChunkingHelper.java
@@ -22,7 +22,7 @@ import java.util.function.Supplier;
  * This class is a helper class that contains writer side chunking logics.
  */
 public class WriterChunkingHelper {
-  private static final ByteBuffer EMPTY_BYTE_BUFFER = ByteBuffer.allocate(0);
+  public static final ByteBuffer EMPTY_BYTE_BUFFER = ByteBuffer.allocate(0);
 
   /**
    * This method chunks payload and send each chunk out.

--- a/internal/venice-common/src/test/java/com/linkedin/venice/writer/VeniceWriterUnitTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/writer/VeniceWriterUnitTest.java
@@ -1,19 +1,42 @@
 package com.linkedin.venice.writer;
 
+import static com.linkedin.venice.writer.VeniceWriter.APP_DEFAULT_LOGICAL_TS;
+import static com.linkedin.venice.writer.VeniceWriter.DEFAULT_MAX_SIZE_FOR_USER_PAYLOAD_PER_MESSAGE_IN_BYTES;
+import static com.linkedin.venice.writer.VeniceWriter.VENICE_DEFAULT_LOGICAL_TS;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.linkedin.venice.kafka.protocol.Delete;
+import com.linkedin.venice.kafka.protocol.KafkaMessageEnvelope;
+import com.linkedin.venice.kafka.protocol.ProducerMetadata;
+import com.linkedin.venice.kafka.protocol.Put;
+import com.linkedin.venice.kafka.protocol.enums.MessageType;
+import com.linkedin.venice.message.KafkaKey;
 import com.linkedin.venice.partitioner.DefaultVenicePartitioner;
 import com.linkedin.venice.pubsub.api.PubSubProducerAdapter;
+import com.linkedin.venice.serialization.KeyWithChunkingSuffixSerializer;
 import com.linkedin.venice.serialization.VeniceKafkaSerializer;
+import com.linkedin.venice.serialization.avro.AvroProtocolDefinition;
+import com.linkedin.venice.serialization.avro.ChunkedValueManifestSerializer;
 import com.linkedin.venice.serialization.avro.VeniceAvroKafkaSerializer;
+import com.linkedin.venice.storage.protocol.ChunkId;
+import com.linkedin.venice.storage.protocol.ChunkedKeySuffix;
+import com.linkedin.venice.storage.protocol.ChunkedValueManifest;
 import com.linkedin.venice.utils.DataProviderUtils;
+import com.linkedin.venice.utils.SystemTime;
 import com.linkedin.venice.utils.VeniceProperties;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Properties;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeoutException;
 import org.mockito.ArgumentCaptor;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -60,4 +83,349 @@ public class VeniceWriterUnitTest {
     Assert.assertEquals(putPartitionArgumentCaptor.getValue(), deletePartitionArgumentCaptor.getValue());
     Assert.assertEquals(putPartitionArgumentCaptor.getValue(), updatePartitionArgumentCaptor.getValue());
   }
+
+  @Test
+  public void testDeleteDeprecatedChunk() throws ExecutionException, InterruptedException, TimeoutException {
+    PubSubProducerAdapter mockedProducer = mock(PubSubProducerAdapter.class);
+    Future mockedFuture = mock(Future.class);
+    when(mockedProducer.getNumberOfPartitions(any())).thenReturn(1);
+    when(mockedProducer.getNumberOfPartitions(any(), anyInt(), any())).thenReturn(1);
+    when(mockedProducer.sendMessage(any(), any(), any(), any(), any(), any())).thenReturn(mockedFuture);
+    String stringSchema = "\"string\"";
+    VeniceKafkaSerializer serializer = new VeniceAvroKafkaSerializer(stringSchema);
+    String testTopic = "test";
+    VeniceWriterOptions veniceWriterOptions = new VeniceWriterOptions.Builder(testTopic).setKeySerializer(serializer)
+        .setValueSerializer(serializer)
+        .setWriteComputeSerializer(serializer)
+        .setPartitioner(new DefaultVenicePartitioner())
+        .setTime(SystemTime.INSTANCE)
+        .setChunkingEnabled(true)
+        .setRmdChunkingEnabled(true)
+        .build();
+    VeniceWriter<Object, Object, Object> writer =
+        new VeniceWriter(veniceWriterOptions, VeniceProperties.empty(), mockedProducer);
+    byte[] serializedKeyBytes = new byte[] { 0xa, 0xb };
+    writer.deleteDeprecatedChunk(serializedKeyBytes, 0, null, VeniceWriter.DEFAULT_LEADER_METADATA_WRAPPER, null);
+    writer.deleteDeprecatedChunk(
+        serializedKeyBytes,
+        0,
+        null,
+        VeniceWriter.DEFAULT_LEADER_METADATA_WRAPPER,
+        new DeleteMetadata(
+            AvroProtocolDefinition.CHUNK.getCurrentProtocolVersion(),
+            1,
+            WriterChunkingHelper.EMPTY_BYTE_BUFFER));
+
+    ArgumentCaptor<KafkaKey> keyArgumentCaptor = ArgumentCaptor.forClass(KafkaKey.class);
+    ArgumentCaptor<KafkaMessageEnvelope> kmeArgumentCaptor = ArgumentCaptor.forClass(KafkaMessageEnvelope.class);
+    verify(mockedProducer, atLeast(3))
+        .sendMessage(any(), any(), keyArgumentCaptor.capture(), kmeArgumentCaptor.capture(), any(), any());
+    Assert.assertEquals(kmeArgumentCaptor.getAllValues().size(), 3);
+    KafkaMessageEnvelope actualValue1 = kmeArgumentCaptor.getAllValues().get(1);
+    Assert.assertEquals(actualValue1.messageType, MessageType.DELETE.getValue());
+    Assert.assertEquals(((Delete) actualValue1.payloadUnion).schemaId, -10);
+    Assert.assertEquals(((Delete) actualValue1.payloadUnion).replicationMetadataVersionId, -1);
+    Assert.assertEquals(
+        ((Delete) actualValue1.payloadUnion).replicationMetadataPayload,
+        WriterChunkingHelper.EMPTY_BYTE_BUFFER);
+    KafkaMessageEnvelope actualValue2 = kmeArgumentCaptor.getAllValues().get(2);
+    Assert.assertEquals(actualValue2.messageType, MessageType.DELETE.getValue());
+    Assert.assertEquals(((Delete) actualValue2.payloadUnion).schemaId, -10);
+    Assert.assertEquals(((Delete) actualValue2.payloadUnion).replicationMetadataVersionId, 1);
+    Assert.assertEquals(
+        ((Delete) actualValue2.payloadUnion).replicationMetadataPayload,
+        WriterChunkingHelper.EMPTY_BYTE_BUFFER);
+  }
+
+  @Test(timeOut = 10000)
+  public void testReplicationMetadataChunking() throws ExecutionException, InterruptedException, TimeoutException {
+    PubSubProducerAdapter mockedProducer = mock(PubSubProducerAdapter.class);
+    Future mockedFuture = mock(Future.class);
+    when(mockedProducer.getNumberOfPartitions(any())).thenReturn(1);
+    when(mockedProducer.getNumberOfPartitions(any(), anyInt(), any())).thenReturn(1);
+    when(mockedProducer.sendMessage(any(), any(), any(), any(), any(), any())).thenReturn(mockedFuture);
+    String stringSchema = "\"string\"";
+    VeniceKafkaSerializer serializer = new VeniceAvroKafkaSerializer(stringSchema);
+    String testTopic = "test";
+    VeniceWriterOptions veniceWriterOptions = new VeniceWriterOptions.Builder(testTopic).setKeySerializer(serializer)
+        .setValueSerializer(serializer)
+        .setWriteComputeSerializer(serializer)
+        .setPartitioner(new DefaultVenicePartitioner())
+        .setTime(SystemTime.INSTANCE)
+        .setChunkingEnabled(true)
+        .setRmdChunkingEnabled(true)
+        .build();
+    VeniceWriter<Object, Object, Object> writer =
+        new VeniceWriter(veniceWriterOptions, VeniceProperties.empty(), mockedProducer);
+
+    ByteBuffer replicationMetadata = ByteBuffer.wrap(new byte[] { 0xa, 0xb });
+    PutMetadata putMetadata = new PutMetadata(1, replicationMetadata);
+
+    StringBuilder stringBuilder = new StringBuilder();
+    for (int i = 0; i < 50000; i++) {
+      stringBuilder.append("abcdefghabcdefghabcdefghabcdefgh");
+    }
+    String valueString = stringBuilder.toString();
+
+    writer.put(
+        Integer.toString(1),
+        valueString,
+        1,
+        null,
+        VeniceWriter.DEFAULT_LEADER_METADATA_WRAPPER,
+        APP_DEFAULT_LOGICAL_TS,
+        putMetadata);
+    ArgumentCaptor<KafkaKey> keyArgumentCaptor = ArgumentCaptor.forClass(KafkaKey.class);
+    ArgumentCaptor<KafkaMessageEnvelope> kmeArgumentCaptor = ArgumentCaptor.forClass(KafkaMessageEnvelope.class);
+    verify(mockedProducer, atLeast(2))
+        .sendMessage(any(), any(), keyArgumentCaptor.capture(), kmeArgumentCaptor.capture(), any(), any());
+    KeyWithChunkingSuffixSerializer keyWithChunkingSuffixSerializer = new KeyWithChunkingSuffixSerializer();
+    byte[] serializedKey = serializer.serialize(testTopic, Integer.toString(1));
+    byte[] serializedValue = serializer.serialize(testTopic, valueString);
+    byte[] serializedRmd = replicationMetadata.array();
+    int availableMessageSize = DEFAULT_MAX_SIZE_FOR_USER_PAYLOAD_PER_MESSAGE_IN_BYTES - serializedKey.length;
+
+    // The order should be SOS, valueChunk1, valueChunk2, replicationMetadataChunk1, manifest for value and RMD.
+    Assert.assertEquals(kmeArgumentCaptor.getAllValues().size(), 5);
+
+    // Verify value of the 1st chunk.
+    KafkaMessageEnvelope actualValue1 = kmeArgumentCaptor.getAllValues().get(1);
+    Assert.assertEquals(actualValue1.messageType, MessageType.PUT.getValue());
+    Assert.assertEquals(((Put) actualValue1.payloadUnion).schemaId, -10);
+    Assert.assertEquals(((Put) actualValue1.payloadUnion).replicationMetadataVersionId, -1);
+    Assert.assertEquals(((Put) actualValue1.payloadUnion).replicationMetadataPayload, ByteBuffer.allocate(0));
+    Assert.assertEquals(((Put) actualValue1.payloadUnion).putValue.array().length, availableMessageSize + 4);
+    Assert.assertEquals(actualValue1.producerMetadata.logicalTimestamp, VENICE_DEFAULT_LOGICAL_TS);
+
+    // Verify value of the 2nd chunk.
+    KafkaMessageEnvelope actualValue2 = kmeArgumentCaptor.getAllValues().get(2);
+    Assert.assertEquals(actualValue2.messageType, MessageType.PUT.getValue());
+    Assert.assertEquals(((Put) actualValue2.payloadUnion).schemaId, -10);
+    Assert.assertEquals(((Put) actualValue2.payloadUnion).replicationMetadataVersionId, -1);
+    Assert.assertEquals(((Put) actualValue2.payloadUnion).replicationMetadataPayload, ByteBuffer.allocate(0));
+    Assert.assertEquals(
+        ((Put) actualValue2.payloadUnion).putValue.array().length,
+        (serializedValue.length - availableMessageSize) + 4);
+    Assert.assertEquals(actualValue2.producerMetadata.logicalTimestamp, VENICE_DEFAULT_LOGICAL_TS);
+
+    ChunkedValueManifestSerializer chunkedValueManifestSerializer = new ChunkedValueManifestSerializer(true);
+
+    final ChunkedValueManifest chunkedValueManifest = new ChunkedValueManifest();
+    chunkedValueManifest.schemaId = 1;
+    chunkedValueManifest.keysWithChunkIdSuffix = new ArrayList<>(2);
+    chunkedValueManifest.size = serializedValue.length;
+
+    // Verify key of the 1st value chunk.
+    ChunkedKeySuffix chunkedKeySuffix = new ChunkedKeySuffix();
+    chunkedKeySuffix.isChunk = true;
+    chunkedKeySuffix.chunkId = new ChunkId();
+    chunkedKeySuffix.chunkId.chunkIndex = 0;
+    ProducerMetadata producerMetadata = actualValue1.producerMetadata;
+    chunkedKeySuffix.chunkId.producerGUID = producerMetadata.producerGUID;
+    chunkedKeySuffix.chunkId.segmentNumber = producerMetadata.segmentNumber;
+    chunkedKeySuffix.chunkId.messageSequenceNumber = producerMetadata.messageSequenceNumber;
+
+    ByteBuffer keyWithSuffix = keyWithChunkingSuffixSerializer.serializeChunkedKey(serializedKey, chunkedKeySuffix);
+    chunkedValueManifest.keysWithChunkIdSuffix.add(keyWithSuffix);
+    KafkaKey expectedKey1 = new KafkaKey(MessageType.PUT, keyWithSuffix.array());
+    KafkaKey actualKey1 = keyArgumentCaptor.getAllValues().get(1);
+    Assert.assertEquals(actualKey1.getKey(), expectedKey1.getKey());
+
+    // Verify key of the 2nd value chunk.
+    chunkedKeySuffix.chunkId.chunkIndex = 1;
+    keyWithSuffix = keyWithChunkingSuffixSerializer.serializeChunkedKey(serializedKey, chunkedKeySuffix);
+    chunkedValueManifest.keysWithChunkIdSuffix.add(keyWithSuffix);
+    KafkaKey expectedKey2 = new KafkaKey(MessageType.PUT, keyWithSuffix.array());
+    KafkaKey actualKey2 = keyArgumentCaptor.getAllValues().get(2);
+    Assert.assertEquals(actualKey2.getKey(), expectedKey2.getKey());
+
+    // Check value of the 1st RMD chunk.
+    KafkaMessageEnvelope actualValue3 = kmeArgumentCaptor.getAllValues().get(3);
+    Assert.assertEquals(actualValue3.messageType, MessageType.PUT.getValue());
+    Assert.assertEquals(((Put) actualValue3.payloadUnion).schemaId, -10);
+    Assert.assertEquals(((Put) actualValue3.payloadUnion).replicationMetadataVersionId, -1);
+    Assert.assertEquals(((Put) actualValue3.payloadUnion).putValue, ByteBuffer.allocate(0));
+    Assert.assertEquals(
+        ((Put) actualValue3.payloadUnion).replicationMetadataPayload.array().length,
+        serializedRmd.length + 4);
+    Assert.assertEquals(actualValue3.producerMetadata.logicalTimestamp, VENICE_DEFAULT_LOGICAL_TS);
+
+    // Check key of the 1st RMD chunk.
+    ChunkedValueManifest chunkedRmdManifest = new ChunkedValueManifest();
+    chunkedRmdManifest.schemaId = 1;
+    chunkedRmdManifest.keysWithChunkIdSuffix = new ArrayList<>(1);
+    chunkedRmdManifest.size = serializedRmd.length;
+    chunkedKeySuffix = new ChunkedKeySuffix();
+    chunkedKeySuffix.isChunk = true;
+    chunkedKeySuffix.chunkId = new ChunkId();
+    producerMetadata = actualValue3.producerMetadata;
+    chunkedKeySuffix.chunkId.producerGUID = producerMetadata.producerGUID;
+    chunkedKeySuffix.chunkId.segmentNumber = producerMetadata.segmentNumber;
+    chunkedKeySuffix.chunkId.messageSequenceNumber = producerMetadata.messageSequenceNumber;
+    // The chunkIndex of the first RMD should be the number of value chunks so that key space of value chunk and RMD
+    // chunk will not collide.
+    chunkedKeySuffix.chunkId.chunkIndex = 2;
+    keyWithSuffix = keyWithChunkingSuffixSerializer.serializeChunkedKey(serializedKey, chunkedKeySuffix);
+    chunkedRmdManifest.keysWithChunkIdSuffix.add(keyWithSuffix);
+    KafkaKey expectedKey3 = new KafkaKey(MessageType.PUT, keyWithSuffix.array());
+    KafkaKey actualKey3 = keyArgumentCaptor.getAllValues().get(3);
+    Assert.assertEquals(actualKey3.getKey(), expectedKey3.getKey());
+
+    // Check key of the manifest.
+    byte[] topLevelKey = keyWithChunkingSuffixSerializer.serializeNonChunkedKey(serializedKey);
+    KafkaKey expectedKey4 = new KafkaKey(MessageType.PUT, topLevelKey);
+    KafkaKey actualKey4 = keyArgumentCaptor.getAllValues().get(4);
+    Assert.assertEquals(actualKey4.getKey(), expectedKey4.getKey());
+
+    // Check manifest for both value and rmd.
+    KafkaMessageEnvelope actualValue4 = kmeArgumentCaptor.getAllValues().get(4);
+    Assert.assertEquals(actualValue4.messageType, MessageType.PUT.getValue());
+    Assert.assertEquals(
+        ((Put) actualValue4.payloadUnion).schemaId,
+        AvroProtocolDefinition.CHUNKED_VALUE_MANIFEST.getCurrentProtocolVersion());
+    Assert.assertEquals(((Put) actualValue4.payloadUnion).replicationMetadataVersionId, putMetadata.getRmdVersionId());
+    Assert.assertEquals(
+        ((Put) actualValue4.payloadUnion).replicationMetadataPayload,
+        ByteBuffer.wrap(chunkedValueManifestSerializer.serialize(testTopic, chunkedRmdManifest)));
+    Assert.assertEquals(
+        ((Put) actualValue4.payloadUnion).putValue,
+        ByteBuffer.wrap(chunkedValueManifestSerializer.serialize(testTopic, chunkedValueManifest)));
+    Assert.assertEquals(actualValue4.producerMetadata.logicalTimestamp, APP_DEFAULT_LOGICAL_TS);
+
+  }
+
+  @Test
+  public void testReplicationMetadataWrittenCorrectly()
+      throws InterruptedException, ExecutionException, TimeoutException {
+    PubSubProducerAdapter mockedProducer = mock(PubSubProducerAdapter.class);
+    Future mockedFuture = mock(Future.class);
+    when(mockedProducer.getNumberOfPartitions(any())).thenReturn(1);
+    when(mockedProducer.getNumberOfPartitions(any(), anyInt(), any())).thenReturn(1);
+    when(mockedProducer.sendMessage(any(), any(), any(), any(), any(), any())).thenReturn(mockedFuture);
+    Properties writerProperties = new Properties();
+    String stringSchema = "\"string\"";
+    VeniceKafkaSerializer serializer = new VeniceAvroKafkaSerializer(stringSchema);
+    String testTopic = "test";
+    VeniceWriterOptions veniceWriterOptions = new VeniceWriterOptions.Builder(testTopic).setKeySerializer(serializer)
+        .setValueSerializer(serializer)
+        .setWriteComputeSerializer(serializer)
+        .setPartitioner(new DefaultVenicePartitioner())
+        .setTime(SystemTime.INSTANCE)
+        .build();
+    VeniceWriter<Object, Object, Object> writer =
+        new VeniceWriter(veniceWriterOptions, new VeniceProperties(writerProperties), mockedProducer);
+
+    // verify the new veniceWriter API's are able to encode the A/A metadat info correctly.
+    long ctime = System.currentTimeMillis();
+    ByteBuffer replicationMetadata = ByteBuffer.wrap(new byte[] { 0xa, 0xb });
+    PutMetadata putMetadata = new PutMetadata(1, replicationMetadata);
+    DeleteMetadata deleteMetadata = new DeleteMetadata(1, 1, replicationMetadata);
+
+    writer.put(
+        Integer.toString(1),
+        Integer.toString(1),
+        1,
+        null,
+        VeniceWriter.DEFAULT_LEADER_METADATA_WRAPPER,
+        ctime,
+        null);
+    writer.put(
+        Integer.toString(2),
+        Integer.toString(2),
+        1,
+        null,
+        VeniceWriter.DEFAULT_LEADER_METADATA_WRAPPER,
+        APP_DEFAULT_LOGICAL_TS,
+        putMetadata);
+    writer.update(Integer.toString(3), Integer.toString(2), 1, 1, null, ctime);
+    writer.delete(Integer.toString(4), null, VeniceWriter.DEFAULT_LEADER_METADATA_WRAPPER, ctime);
+    writer.delete(Integer.toString(5), null, VeniceWriter.DEFAULT_LEADER_METADATA_WRAPPER, deleteMetadata);
+    writer.put(Integer.toString(6), Integer.toString(1), 1, null, VeniceWriter.DEFAULT_LEADER_METADATA_WRAPPER);
+
+    ArgumentCaptor<KafkaMessageEnvelope> kmeArgumentCaptor = ArgumentCaptor.forClass(KafkaMessageEnvelope.class);
+    verify(mockedProducer, atLeast(2)).sendMessage(any(), any(), any(), kmeArgumentCaptor.capture(), any(), any());
+
+    // first one will be control message SOS, there should not be any aa metadata.
+    KafkaMessageEnvelope value0 = kmeArgumentCaptor.getAllValues().get(0);
+    Assert.assertEquals(value0.producerMetadata.logicalTimestamp, VENICE_DEFAULT_LOGICAL_TS);
+
+    // verify timestamp is encoded correctly.
+    KafkaMessageEnvelope value1 = kmeArgumentCaptor.getAllValues().get(1);
+    KafkaMessageEnvelope value3 = kmeArgumentCaptor.getAllValues().get(3);
+    KafkaMessageEnvelope value4 = kmeArgumentCaptor.getAllValues().get(4);
+    for (KafkaMessageEnvelope kme: Arrays.asList(value1, value3, value4)) {
+      Assert.assertEquals(kme.producerMetadata.logicalTimestamp, ctime);
+    }
+
+    // verify default values for replicationMetadata are written correctly
+    Put put = (Put) value1.payloadUnion;
+    Assert.assertEquals(put.schemaId, 1);
+    Assert.assertEquals(put.replicationMetadataVersionId, VeniceWriter.VENICE_DEFAULT_TIMESTAMP_METADATA_VERSION_ID);
+    Assert.assertEquals(put.replicationMetadataPayload, ByteBuffer.wrap(new byte[0]));
+
+    Delete delete = (Delete) value4.payloadUnion;
+    Assert.assertEquals(delete.schemaId, VeniceWriter.VENICE_DEFAULT_VALUE_SCHEMA_ID);
+    Assert.assertEquals(delete.replicationMetadataVersionId, VeniceWriter.VENICE_DEFAULT_TIMESTAMP_METADATA_VERSION_ID);
+    Assert.assertEquals(delete.replicationMetadataPayload, ByteBuffer.wrap(new byte[0]));
+
+    // verify replicationMetadata is encoded correctly for Put.
+    KafkaMessageEnvelope value2 = kmeArgumentCaptor.getAllValues().get(2);
+    Assert.assertEquals(value2.messageType, MessageType.PUT.getValue());
+    put = (Put) value2.payloadUnion;
+    Assert.assertEquals(put.schemaId, 1);
+    Assert.assertEquals(put.replicationMetadataVersionId, 1);
+    Assert.assertEquals(put.replicationMetadataPayload, ByteBuffer.wrap(new byte[] { 0xa, 0xb }));
+    Assert.assertEquals(value2.producerMetadata.logicalTimestamp, APP_DEFAULT_LOGICAL_TS);
+
+    // verify replicationMetadata is encoded correctly for Delete.
+    KafkaMessageEnvelope value5 = kmeArgumentCaptor.getAllValues().get(5);
+    Assert.assertEquals(value5.messageType, MessageType.DELETE.getValue());
+    delete = (Delete) value5.payloadUnion;
+    Assert.assertEquals(delete.schemaId, 1);
+    Assert.assertEquals(delete.replicationMetadataVersionId, 1);
+    Assert.assertEquals(delete.replicationMetadataPayload, ByteBuffer.wrap(new byte[] { 0xa, 0xb }));
+    Assert.assertEquals(value5.producerMetadata.logicalTimestamp, APP_DEFAULT_LOGICAL_TS);
+
+    // verify default logical_ts is encoded correctly
+    KafkaMessageEnvelope value6 = kmeArgumentCaptor.getAllValues().get(6);
+    Assert.assertEquals(value6.messageType, MessageType.PUT.getValue());
+    Assert.assertEquals(value6.producerMetadata.logicalTimestamp, APP_DEFAULT_LOGICAL_TS);
+  }
+
+  @Test
+  public void testCloseSegmentBasedOnElapsedTime() throws InterruptedException, ExecutionException, TimeoutException {
+    PubSubProducerAdapter mockedProducer = mock(PubSubProducerAdapter.class);
+    Future mockedFuture = mock(Future.class);
+    when(mockedProducer.getNumberOfPartitions(any())).thenReturn(1);
+    when(mockedProducer.getNumberOfPartitions(any(), anyInt(), any())).thenReturn(1);
+    when(mockedProducer.sendMessage(any(), any(), any(), any(), any(), any())).thenReturn(mockedFuture);
+    Properties writerProperties = new Properties();
+    writerProperties.put(VeniceWriter.MAX_ELAPSED_TIME_FOR_SEGMENT_IN_MS, 0);
+    String stringSchema = "\"string\"";
+    VeniceKafkaSerializer serializer = new VeniceAvroKafkaSerializer(stringSchema);
+    String testTopic = "test";
+    VeniceWriterOptions veniceWriterOptions = new VeniceWriterOptions.Builder(testTopic).setKeySerializer(serializer)
+        .setValueSerializer(serializer)
+        .setWriteComputeSerializer(serializer)
+        .setPartitioner(new DefaultVenicePartitioner())
+        .setTime(SystemTime.INSTANCE)
+        .build();
+    VeniceWriter<Object, Object, Object> writer =
+        new VeniceWriter(veniceWriterOptions, new VeniceProperties(writerProperties), mockedProducer);
+    for (int i = 0; i < 1000; i++) {
+      writer.put(Integer.toString(i), Integer.toString(i), 1, null);
+    }
+    ArgumentCaptor<KafkaMessageEnvelope> kmeArgumentCaptor = ArgumentCaptor.forClass(KafkaMessageEnvelope.class);
+    verify(mockedProducer, atLeast(1000)).sendMessage(any(), any(), any(), kmeArgumentCaptor.capture(), any(), any());
+    int segmentNumber = -1;
+    for (KafkaMessageEnvelope envelope: kmeArgumentCaptor.getAllValues()) {
+      if (segmentNumber == -1) {
+        segmentNumber = envelope.producerMetadata.segmentNumber;
+      } else {
+        // Segment number should not change since we disabled closing segment based on elapsed time.
+        Assert.assertEquals(envelope.producerMetadata.segmentNumber, segmentNumber);
+      }
+    }
+  }
+
 }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/PartialUpdateTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/PartialUpdateTest.java
@@ -592,12 +592,13 @@ public class PartialUpdateTest {
           serverWrapper.getVeniceServer().getStorageService().getStorageEngine(kafkaTopic);
       assertNotNull(storageEngine);
       ValueRecord result = SingleGetChunkingAdapter
-          .getReplicationMetadata(storageEngine, 0, serializeStringKeyToByteArray(key), true, null);
+          .getReplicationMetadata(storageEngine, 0, serializeStringKeyToByteArray(key), true, null, null);
       // Avoid assertion failure logging massive RMD record.
       boolean nullRmd = (result == null);
       assertFalse(nullRmd);
       byte[] value = result.serialize();
-      RmdWithValueSchemaId rmdWithValueSchemaId = rmdSerDe.deserializeValueSchemaIdPrependedRmdBytes(value);
+      RmdWithValueSchemaId rmdWithValueSchemaId = new RmdWithValueSchemaId();
+      rmdSerDe.deserializeValueSchemaIdPrependedRmdBytes(value, rmdWithValueSchemaId);
       rmdDataValidationFlow.accept(rmdWithValueSchemaId);
     }
   }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/PartialUpdateTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/PartialUpdateTest.java
@@ -35,6 +35,7 @@ import com.linkedin.davinci.kafka.consumer.StoreIngestionTaskBackdoor;
 import com.linkedin.davinci.replication.RmdWithValueSchemaId;
 import com.linkedin.davinci.replication.merge.RmdSerDe;
 import com.linkedin.davinci.replication.merge.StringAnnotatedStoreSchemaCache;
+import com.linkedin.davinci.storage.chunking.ChunkingUtils;
 import com.linkedin.davinci.storage.chunking.SingleGetChunkingAdapter;
 import com.linkedin.davinci.store.AbstractStorageEngine;
 import com.linkedin.davinci.store.record.ValueRecord;
@@ -66,6 +67,9 @@ import com.linkedin.venice.schema.rmd.RmdSchemaEntry;
 import com.linkedin.venice.schema.rmd.RmdSchemaGenerator;
 import com.linkedin.venice.schema.writecompute.DerivedSchemaEntry;
 import com.linkedin.venice.schema.writecompute.WriteComputeSchemaConverter;
+import com.linkedin.venice.serialization.avro.AvroProtocolDefinition;
+import com.linkedin.venice.serialization.avro.ChunkedValueManifestSerializer;
+import com.linkedin.venice.storage.protocol.ChunkedValueManifest;
 import com.linkedin.venice.utils.DataProviderUtils;
 import com.linkedin.venice.utils.IntegrationTestPushUtils;
 import com.linkedin.venice.utils.TestUtils;
@@ -78,6 +82,7 @@ import com.linkedin.venice.writer.update.UpdateBuilderImpl;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -87,6 +92,7 @@ import java.util.Optional;
 import java.util.Properties;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
@@ -112,6 +118,9 @@ public class PartialUpdateTest {
   private static final int NUMBER_OF_CLUSTERS = 1;
   private static final int TEST_TIMEOUT_MS = 120_000;
   private static final String CLUSTER_NAME = "venice-cluster0";
+
+  private static final ChunkedValueManifestSerializer CHUNKED_VALUE_MANIFEST_SERIALIZER =
+      new ChunkedValueManifestSerializer(false);
 
   private VeniceTwoLayerMultiRegionMultiClusterWrapper multiRegionMultiClusterWrapper;
   private VeniceControllerWrapper parentController;
@@ -353,10 +362,10 @@ public class PartialUpdateTest {
     String keySchemaStr = "{\"type\" : \"string\"}";
     Schema valueSchema = AvroCompatibilityHelper.parse(loadFileAsString("CollectionRecordV1.avsc"));
     Schema rmdSchema = RmdSchemaGenerator.generateMetadataSchema(valueSchema);
-    Schema writeComputeSchema = WriteComputeSchemaConverter.getInstance().convertFromValueRecordSchema(valueSchema);
+    Schema partialUpdateSchema = WriteComputeSchemaConverter.getInstance().convertFromValueRecordSchema(valueSchema);
     ReadOnlySchemaRepository schemaRepo = mock(ReadOnlySchemaRepository.class);
     when(schemaRepo.getReplicationMetadataSchema(storeName, 1, 1)).thenReturn(new RmdSchemaEntry(1, 1, rmdSchema));
-    when(schemaRepo.getDerivedSchema(storeName, 1, 1)).thenReturn(new DerivedSchemaEntry(1, 1, writeComputeSchema));
+    when(schemaRepo.getDerivedSchema(storeName, 1, 1)).thenReturn(new DerivedSchemaEntry(1, 1, partialUpdateSchema));
     when(schemaRepo.getValueSchema(storeName, 1)).thenReturn(new SchemaEntry(1, valueSchema));
     StringAnnotatedStoreSchemaCache stringAnnotatedStoreSchemaCache =
         new StringAnnotatedStoreSchemaCache(storeName, schemaRepo);
@@ -398,23 +407,60 @@ public class PartialUpdateTest {
     String mapFieldName = "stringMap";
 
     // Insert large amount of Map entries to trigger RMD chunking.
-    int updateCount = 30;
+    int oldUpdateCount = 29;
     int singleUpdateEntryCount = 10000;
     try (AvroGenericStoreClient<Object, Object> storeReader = ClientFactory.getAndStartGenericAvroClient(
         ClientConfig.defaultGenericClientConfig(storeName).setVeniceURL(veniceCluster.getRandomRouterURL()))) {
-      Map<String, String> newEntries = new HashMap<>();
-      for (int i = 0; i < updateCount; i++) {
-        UpdateBuilder updateBuilder = new UpdateBuilderImpl(writeComputeSchema);
-        updateBuilder.setNewFieldValue(primitiveFieldName, "Tottenham");
-        newEntries.clear();
-        for (int j = 0; j < singleUpdateEntryCount; j++) {
-          String idx = String.valueOf(i * singleUpdateEntryCount + j);
-          newEntries.put("key_" + idx, "value_" + idx);
-        }
-        updateBuilder.setEntriesToAddToMapField(mapFieldName, newEntries);
-        GenericRecord partialUpdateRecord = updateBuilder.build();
-        sendStreamingRecord(veniceProducer, storeName, key, partialUpdateRecord, i * 10L + 1);
+      for (int i = 0; i < oldUpdateCount; i++) {
+        producePartialUpdate(
+            storeName,
+            veniceProducer,
+            partialUpdateSchema,
+            key,
+            primitiveFieldName,
+            mapFieldName,
+            singleUpdateEntryCount,
+            i);
       }
+      // Verify the value record has been partially updated.
+      TestUtils.waitForNonDeterministicAssertion(TEST_TIMEOUT_MS * 2, TimeUnit.MILLISECONDS, true, () -> {
+        try {
+          GenericRecord valueRecord = readValue(storeReader, key);
+          boolean nullRecord = (valueRecord == null);
+          assertFalse(nullRecord);
+          assertEquals(valueRecord.get(primitiveFieldName).toString(), "Tottenham"); // Updated field
+          Map<String, String> mapFieldResult = new HashMap<>();
+          ((Map<Utf8, Utf8>) valueRecord.get(mapFieldName))
+              .forEach((x, y) -> mapFieldResult.put(x.toString(), y.toString()));
+          assertEquals(mapFieldResult.size(), oldUpdateCount * singleUpdateEntryCount);
+        } catch (Exception e) {
+          throw new VeniceException(e);
+        }
+      });
+
+      String kafkaTopic_v1 = Version.composeKafkaTopic(storeName, 1);
+      validateValueChunks(kafkaTopic_v1, key, Assert::assertNotNull);
+      VeniceServerWrapper serverWrapper = multiRegionMultiClusterWrapper.getChildRegions()
+          .get(0)
+          .getClusters()
+          .get("venice-cluster0")
+          .getVeniceServers()
+          .get(0);
+      AbstractStorageEngine storageEngine =
+          serverWrapper.getVeniceServer().getStorageService().getStorageEngine(kafkaTopic_v1);
+      ChunkedValueManifest valueManifest = getChunkValueManifest(storageEngine, 0, key, false);
+      ChunkedValueManifest rmdManifest = getChunkValueManifest(storageEngine, 0, key, true);
+
+      int updateCount = 30;
+      producePartialUpdate(
+          storeName,
+          veniceProducer,
+          partialUpdateSchema,
+          key,
+          primitiveFieldName,
+          mapFieldName,
+          singleUpdateEntryCount,
+          updateCount - 1);
 
       // Verify the value record has been partially updated.
       TestUtils.waitForNonDeterministicAssertion(TEST_TIMEOUT_MS * 2, TimeUnit.MILLISECONDS, true, () -> {
@@ -432,15 +478,22 @@ public class PartialUpdateTest {
         }
       });
       // Validate RMD bytes after PUT requests.
-      String kafkaTopic = Version.composeKafkaTopic(storeName, 1);
-      validateRmdData(rmdSerDe, kafkaTopic, key, rmdWithValueSchemaId -> {
+      validateRmdData(rmdSerDe, kafkaTopic_v1, key, rmdWithValueSchemaId -> {
         GenericRecord timestampRecord = (GenericRecord) rmdWithValueSchemaId.getRmdRecord().get("timestamp");
         GenericRecord stringMapTimestampRecord = (GenericRecord) timestampRecord.get("stringMap");
         List<Long> activeElementsTimestamps = (List<Long>) stringMapTimestampRecord.get("activeElementsTimestamps");
         assertEquals(activeElementsTimestamps.size(), updateCount * singleUpdateEntryCount);
       });
 
-      // Perform one time repush to make sure repush can handle RMD chunks data correctly.
+      TestUtils.waitForNonDeterministicAssertion(TEST_TIMEOUT_MS, TimeUnit.MILLISECONDS, true, () -> {
+        validateChunksFromManifests(kafkaTopic_v1, 0, valueManifest, rmdManifest, (valueChunkBytes, rmdChunkBytes) -> {
+          Assert.assertNull(valueChunkBytes);
+          Assert.assertNotNull(rmdChunkBytes);
+          Assert.assertEquals(rmdChunkBytes.length, 4);
+        });
+      });
+
+      // <!--- Perform one time repush to make sure repush can handle RMD chunks data correctly -->
       Properties props =
           IntegrationTestPushUtils.defaultVPJProps(multiRegionMultiClusterWrapper, "dummyInputPath", storeName);
       props.setProperty(SOURCE_KAFKA, "true");
@@ -474,8 +527,8 @@ public class PartialUpdateTest {
       });
 
       // Validate RMD bytes after PUT requests.
-      kafkaTopic = Version.composeKafkaTopic(storeName, 2);
-      validateRmdData(rmdSerDe, kafkaTopic, key, rmdWithValueSchemaId -> {
+      String kafkaTopic_v2 = Version.composeKafkaTopic(storeName, 2);
+      validateRmdData(rmdSerDe, kafkaTopic_v2, key, rmdWithValueSchemaId -> {
         GenericRecord timestampRecord = (GenericRecord) rmdWithValueSchemaId.getRmdRecord().get("timestamp");
         GenericRecord stringMapTimestampRecord = (GenericRecord) timestampRecord.get("stringMap");
         List<Long> activeElementsTimestamps = (List<Long>) stringMapTimestampRecord.get("activeElementsTimestamps");
@@ -496,7 +549,7 @@ public class PartialUpdateTest {
         assertEquals(mapFieldResult.size(), singleUpdateEntryCount);
       });
 
-      validateRmdData(rmdSerDe, kafkaTopic, key, rmdWithValueSchemaId -> {
+      validateRmdData(rmdSerDe, kafkaTopic_v2, key, rmdWithValueSchemaId -> {
         GenericRecord timestampRecord = (GenericRecord) rmdWithValueSchemaId.getRmdRecord().get("timestamp");
         GenericRecord stringMapTimestampRecord = (GenericRecord) timestampRecord.get("stringMap");
         List<Long> activeElementsTimestamps = (List<Long>) stringMapTimestampRecord.get("activeElementsTimestamps");
@@ -512,7 +565,7 @@ public class PartialUpdateTest {
         boolean nullRecord = (valueRecord == null);
         assertTrue(nullRecord);
       });
-      validateRmdData(rmdSerDe, kafkaTopic, key, rmdWithValueSchemaId -> {
+      validateRmdData(rmdSerDe, kafkaTopic_v2, key, rmdWithValueSchemaId -> {
         Assert.assertTrue(
             rmdWithValueSchemaId.getRmdRecord().get(RmdConstants.TIMESTAMP_FIELD_NAME) instanceof GenericRecord);
         GenericRecord timestampRecord =
@@ -1013,4 +1066,97 @@ public class PartialUpdateTest {
     }
     return out.toByteArray();
   }
+
+  private void producePartialUpdate(
+      String storeName,
+      SystemProducer veniceProducer,
+      Schema partialUpdateSchema,
+      String key,
+      String primitiveFieldName,
+      String mapFieldName,
+      int singleUpdateEntryCount,
+      int updateCount) {
+    UpdateBuilder updateBuilder = new UpdateBuilderImpl(partialUpdateSchema);
+    updateBuilder.setNewFieldValue(primitiveFieldName, "Tottenham");
+    Map<String, String> newEntries = new HashMap<>();
+    for (int j = 0; j < singleUpdateEntryCount; j++) {
+      String idx = String.valueOf(updateCount * singleUpdateEntryCount + j);
+      newEntries.put("key_" + idx, "value_" + idx);
+    }
+    updateBuilder.setEntriesToAddToMapField(mapFieldName, newEntries);
+    GenericRecord partialUpdateRecord = updateBuilder.build();
+    sendStreamingRecord(veniceProducer, storeName, key, partialUpdateRecord, updateCount * 10L + 1);
+  }
+
+  private void validateValueChunks(String kafkaTopic, String key, Consumer<byte[]> validationFlow) {
+    for (VeniceServerWrapper serverWrapper: multiRegionMultiClusterWrapper.getChildRegions()
+        .get(0)
+        .getClusters()
+        .get("venice-cluster0")
+        .getVeniceServers()) {
+      AbstractStorageEngine storageEngine =
+          serverWrapper.getVeniceServer().getStorageService().getStorageEngine(kafkaTopic);
+      assertNotNull(storageEngine);
+
+      ChunkedValueManifest manifest = getChunkValueManifest(storageEngine, 0, key, false);
+      Assert.assertNotNull(manifest);
+
+      for (ByteBuffer chunkedKey: manifest.keysWithChunkIdSuffix) {
+        byte[] chunkValueBytes = storageEngine.get(0, chunkedKey.array());
+        validationFlow.accept(chunkValueBytes);
+      }
+    }
+  }
+
+  private void validateChunksFromManifests(
+      String kafkaTopic,
+      int partition,
+      ChunkedValueManifest valueManifest,
+      ChunkedValueManifest rmdManifest,
+      BiConsumer<byte[], byte[]> validationFlow) {
+    for (VeniceServerWrapper serverWrapper: multiRegionMultiClusterWrapper.getChildRegions()
+        .get(0)
+        .getClusters()
+        .get("venice-cluster0")
+        .getVeniceServers()) {
+      AbstractStorageEngine storageEngine =
+          serverWrapper.getVeniceServer().getStorageService().getStorageEngine(kafkaTopic);
+      assertNotNull(storageEngine);
+
+      validateChunkDataFromManifest(storageEngine, 0, valueManifest, validationFlow);
+      validateChunkDataFromManifest(storageEngine, 0, rmdManifest, validationFlow);
+    }
+  }
+
+  private ChunkedValueManifest getChunkValueManifest(
+      AbstractStorageEngine storageEngine,
+      int partition,
+      String key,
+      boolean isRmd) {
+    byte[] serializedKeyBytes =
+        ChunkingUtils.KEY_WITH_CHUNKING_SUFFIX_SERIALIZER.serializeNonChunkedKey(serializeStringKeyToByteArray(key));
+    byte[] manifestValueBytes = isRmd
+        ? storageEngine.getReplicationMetadata(partition, serializedKeyBytes)
+        : storageEngine.get(partition, serializedKeyBytes);
+    if (manifestValueBytes == null) {
+      return null;
+    }
+    int schemaId = ValueRecord.parseSchemaId(manifestValueBytes);
+    Assert.assertEquals(schemaId, AvroProtocolDefinition.CHUNKED_VALUE_MANIFEST.getCurrentProtocolVersion());
+    return CHUNKED_VALUE_MANIFEST_SERIALIZER.deserialize(manifestValueBytes, schemaId);
+  }
+
+  private void validateChunkDataFromManifest(
+      AbstractStorageEngine storageEngine,
+      int partition,
+      ChunkedValueManifest manifest,
+      BiConsumer<byte[], byte[]> validationFlow) {
+    for (int i = 0; i < manifest.keysWithChunkIdSuffix.size(); i++) {
+      byte[] chunkKeyBytes = manifest.keysWithChunkIdSuffix.get(i).array();
+      byte[] valueBytes = storageEngine.get(partition, chunkKeyBytes);
+      byte[] rmdBytes = storageEngine.getReplicationMetadata(partition, chunkKeyBytes);
+      validationFlow.accept(valueBytes, rmdBytes);
+    }
+  }
+
 }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/PartialUpdateTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/PartialUpdateTest.java
@@ -353,15 +353,10 @@ public class PartialUpdateTest {
     String parentControllerUrl = parentController.getControllerUrl();
     String keySchemaStr = "{\"type\" : \"string\"}";
     Schema valueSchema = AvroCompatibilityHelper.parse(loadFileAsString("CollectionRecordV1.avsc"));
-    Schema rmdSchema = RmdSchemaGenerator.generateMetadataSchema(valueSchema);
     Schema partialUpdateSchema = WriteComputeSchemaConverter.getInstance().convertFromValueRecordSchema(valueSchema);
     ReadOnlySchemaRepository schemaRepo = mock(ReadOnlySchemaRepository.class);
-    // when(schemaRepo.getReplicationMetadataSchema(storeName, 1, 1)).thenReturn(new RmdSchemaEntry(1, 1, rmdSchema));
     when(schemaRepo.getDerivedSchema(storeName, 1, 1)).thenReturn(new DerivedSchemaEntry(1, 1, partialUpdateSchema));
     when(schemaRepo.getValueSchema(storeName, 1)).thenReturn(new SchemaEntry(1, valueSchema));
-    StringAnnotatedStoreSchemaCache stringAnnotatedStoreSchemaCache =
-        new StringAnnotatedStoreSchemaCache(storeName, schemaRepo);
-    // RmdSerDe rmdSerDe = new RmdSerDe(stringAnnotatedStoreSchemaCache, 1);
 
     try (ControllerClient parentControllerClient = new ControllerClient(CLUSTER_NAME, parentControllerUrl)) {
       assertCommand(

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/writer/VeniceWriterTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/writer/VeniceWriterTest.java
@@ -1,24 +1,13 @@
 package com.linkedin.venice.writer;
 
 import static com.linkedin.venice.kafka.TopicManager.DEFAULT_KAFKA_OPERATION_TIMEOUT_MS;
-import static com.linkedin.venice.writer.VeniceWriter.APP_DEFAULT_LOGICAL_TS;
-import static com.linkedin.venice.writer.VeniceWriter.DEFAULT_MAX_SIZE_FOR_USER_PAYLOAD_PER_MESSAGE_IN_BYTES;
-import static com.linkedin.venice.writer.VeniceWriter.VENICE_DEFAULT_LOGICAL_TS;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.anyInt;
-import static org.mockito.Mockito.atLeast;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 import com.linkedin.venice.ConfigKeys;
 import com.linkedin.venice.integration.utils.PubSubBrokerWrapper;
 import com.linkedin.venice.integration.utils.ServiceFactory;
 import com.linkedin.venice.kafka.TopicManager;
-import com.linkedin.venice.kafka.protocol.Delete;
 import com.linkedin.venice.kafka.protocol.KafkaMessageEnvelope;
 import com.linkedin.venice.kafka.protocol.ProducerMetadata;
-import com.linkedin.venice.kafka.protocol.Put;
 import com.linkedin.venice.kafka.protocol.enums.MessageType;
 import com.linkedin.venice.message.KafkaKey;
 import com.linkedin.venice.partitioner.DefaultVenicePartitioner;
@@ -28,30 +17,17 @@ import com.linkedin.venice.pubsub.api.PubSubConsumerAdapter;
 import com.linkedin.venice.pubsub.api.PubSubConsumerAdapterFactory;
 import com.linkedin.venice.pubsub.api.PubSubMessage;
 import com.linkedin.venice.pubsub.api.PubSubMessageDeserializer;
-import com.linkedin.venice.pubsub.api.PubSubProducerAdapter;
 import com.linkedin.venice.pubsub.api.PubSubTopic;
 import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
-import com.linkedin.venice.serialization.KeyWithChunkingSuffixSerializer;
-import com.linkedin.venice.serialization.VeniceKafkaSerializer;
-import com.linkedin.venice.serialization.avro.AvroProtocolDefinition;
-import com.linkedin.venice.serialization.avro.ChunkedValueManifestSerializer;
 import com.linkedin.venice.serialization.avro.KafkaValueSerializer;
 import com.linkedin.venice.serialization.avro.OptimizedKafkaValueSerializer;
-import com.linkedin.venice.serialization.avro.VeniceAvroKafkaSerializer;
-import com.linkedin.venice.storage.protocol.ChunkId;
-import com.linkedin.venice.storage.protocol.ChunkedKeySuffix;
-import com.linkedin.venice.storage.protocol.ChunkedValueManifest;
 import com.linkedin.venice.utils.IntegrationTestPushUtils;
-import com.linkedin.venice.utils.SystemTime;
 import com.linkedin.venice.utils.TestUtils;
 import com.linkedin.venice.utils.Time;
 import com.linkedin.venice.utils.Utils;
 import com.linkedin.venice.utils.VeniceProperties;
 import com.linkedin.venice.utils.pools.LandFillObjectPool;
 import java.io.IOException;
-import java.nio.ByteBuffer;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -59,8 +35,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
-import java.util.concurrent.TimeoutException;
-import org.mockito.ArgumentCaptor;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -166,296 +140,5 @@ public class VeniceWriterTest {
     testThreadSafety(
         100,
         veniceWriter -> veniceWriter.put(new KafkaKey(MessageType.PUT, "blah".getBytes()), "blah".getBytes(), 1, null));
-  }
-
-  @Test
-  public void testCloseSegmentBasedOnElapsedTime() throws InterruptedException, ExecutionException, TimeoutException {
-    PubSubProducerAdapter mockedProducer = mock(PubSubProducerAdapter.class);
-    Future mockedFuture = mock(Future.class);
-    when(mockedProducer.getNumberOfPartitions(any())).thenReturn(1);
-    when(mockedProducer.getNumberOfPartitions(any(), anyInt(), any())).thenReturn(1);
-    when(mockedProducer.sendMessage(any(), any(), any(), any(), any(), any())).thenReturn(mockedFuture);
-    Properties writerProperties = new Properties();
-    writerProperties.put(VeniceWriter.MAX_ELAPSED_TIME_FOR_SEGMENT_IN_MS, 0);
-    String stringSchema = "\"string\"";
-    VeniceKafkaSerializer serializer = new VeniceAvroKafkaSerializer(stringSchema);
-    String testTopic = "test";
-    VeniceWriterOptions veniceWriterOptions = new VeniceWriterOptions.Builder(testTopic).setKeySerializer(serializer)
-        .setValueSerializer(serializer)
-        .setWriteComputeSerializer(serializer)
-        .setPartitioner(new DefaultVenicePartitioner())
-        .setTime(SystemTime.INSTANCE)
-        .build();
-    VeniceWriter<Object, Object, Object> writer =
-        new VeniceWriter(veniceWriterOptions, new VeniceProperties(writerProperties), mockedProducer);
-    for (int i = 0; i < 1000; i++) {
-      writer.put(Integer.toString(i), Integer.toString(i), 1, null);
-    }
-    ArgumentCaptor<KafkaMessageEnvelope> kmeArgumentCaptor = ArgumentCaptor.forClass(KafkaMessageEnvelope.class);
-    verify(mockedProducer, atLeast(1000)).sendMessage(any(), any(), any(), kmeArgumentCaptor.capture(), any(), any());
-    int segmentNumber = -1;
-    for (KafkaMessageEnvelope envelope: kmeArgumentCaptor.getAllValues()) {
-      if (segmentNumber == -1) {
-        segmentNumber = envelope.producerMetadata.segmentNumber;
-      } else {
-        // Segment number should not change since we disabled closing segment based on elapsed time.
-        Assert.assertEquals(envelope.producerMetadata.segmentNumber, segmentNumber);
-      }
-    }
-  }
-
-  @Test
-  public void testReplicationMetadataWrittenCorrectly()
-      throws InterruptedException, ExecutionException, TimeoutException {
-    PubSubProducerAdapter mockedProducer = mock(PubSubProducerAdapter.class);
-    Future mockedFuture = mock(Future.class);
-    when(mockedProducer.getNumberOfPartitions(any())).thenReturn(1);
-    when(mockedProducer.getNumberOfPartitions(any(), anyInt(), any())).thenReturn(1);
-    when(mockedProducer.sendMessage(any(), any(), any(), any(), any(), any())).thenReturn(mockedFuture);
-    Properties writerProperties = new Properties();
-    String stringSchema = "\"string\"";
-    VeniceKafkaSerializer serializer = new VeniceAvroKafkaSerializer(stringSchema);
-    String testTopic = "test";
-    VeniceWriterOptions veniceWriterOptions = new VeniceWriterOptions.Builder(testTopic).setKeySerializer(serializer)
-        .setValueSerializer(serializer)
-        .setWriteComputeSerializer(serializer)
-        .setPartitioner(new DefaultVenicePartitioner())
-        .setTime(SystemTime.INSTANCE)
-        .build();
-    VeniceWriter<Object, Object, Object> writer =
-        new VeniceWriter(veniceWriterOptions, new VeniceProperties(writerProperties), mockedProducer);
-
-    // verify the new veniceWriter API's are able to encode the A/A metadat info correctly.
-    long ctime = System.currentTimeMillis();
-    ByteBuffer replicationMetadata = ByteBuffer.wrap(new byte[] { 0xa, 0xb });
-    PutMetadata putMetadata = new PutMetadata(1, replicationMetadata);
-    DeleteMetadata deleteMetadata = new DeleteMetadata(1, 1, replicationMetadata);
-
-    writer.put(
-        Integer.toString(1),
-        Integer.toString(1),
-        1,
-        null,
-        VeniceWriter.DEFAULT_LEADER_METADATA_WRAPPER,
-        ctime,
-        null);
-    writer.put(
-        Integer.toString(2),
-        Integer.toString(2),
-        1,
-        null,
-        VeniceWriter.DEFAULT_LEADER_METADATA_WRAPPER,
-        APP_DEFAULT_LOGICAL_TS,
-        putMetadata);
-    writer.update(Integer.toString(3), Integer.toString(2), 1, 1, null, ctime);
-    writer.delete(Integer.toString(4), null, VeniceWriter.DEFAULT_LEADER_METADATA_WRAPPER, ctime);
-    writer.delete(Integer.toString(5), null, VeniceWriter.DEFAULT_LEADER_METADATA_WRAPPER, deleteMetadata);
-    writer.put(Integer.toString(6), Integer.toString(1), 1, null, VeniceWriter.DEFAULT_LEADER_METADATA_WRAPPER);
-
-    ArgumentCaptor<KafkaMessageEnvelope> kmeArgumentCaptor = ArgumentCaptor.forClass(KafkaMessageEnvelope.class);
-    verify(mockedProducer, atLeast(2)).sendMessage(any(), any(), any(), kmeArgumentCaptor.capture(), any(), any());
-
-    // first one will be control message SOS, there should not be any aa metadata.
-    KafkaMessageEnvelope value0 = kmeArgumentCaptor.getAllValues().get(0);
-    Assert.assertEquals(value0.producerMetadata.logicalTimestamp, VENICE_DEFAULT_LOGICAL_TS);
-
-    // verify timestamp is encoded correctly.
-    KafkaMessageEnvelope value1 = kmeArgumentCaptor.getAllValues().get(1);
-    KafkaMessageEnvelope value3 = kmeArgumentCaptor.getAllValues().get(3);
-    KafkaMessageEnvelope value4 = kmeArgumentCaptor.getAllValues().get(4);
-    for (KafkaMessageEnvelope kme: Arrays.asList(value1, value3, value4)) {
-      Assert.assertEquals(kme.producerMetadata.logicalTimestamp, ctime);
-    }
-
-    // verify default values for replicationMetadata are written correctly
-    Put put = (Put) value1.payloadUnion;
-    Assert.assertEquals(put.schemaId, 1);
-    Assert.assertEquals(put.replicationMetadataVersionId, VeniceWriter.VENICE_DEFAULT_TIMESTAMP_METADATA_VERSION_ID);
-    Assert.assertEquals(put.replicationMetadataPayload, ByteBuffer.wrap(new byte[0]));
-
-    Delete delete = (Delete) value4.payloadUnion;
-    Assert.assertEquals(delete.schemaId, VeniceWriter.VENICE_DEFAULT_VALUE_SCHEMA_ID);
-    Assert.assertEquals(delete.replicationMetadataVersionId, VeniceWriter.VENICE_DEFAULT_TIMESTAMP_METADATA_VERSION_ID);
-    Assert.assertEquals(delete.replicationMetadataPayload, ByteBuffer.wrap(new byte[0]));
-
-    // verify replicationMetadata is encoded correctly for Put.
-    KafkaMessageEnvelope value2 = kmeArgumentCaptor.getAllValues().get(2);
-    Assert.assertEquals(value2.messageType, MessageType.PUT.getValue());
-    put = (Put) value2.payloadUnion;
-    Assert.assertEquals(put.schemaId, 1);
-    Assert.assertEquals(put.replicationMetadataVersionId, 1);
-    Assert.assertEquals(put.replicationMetadataPayload, ByteBuffer.wrap(new byte[] { 0xa, 0xb }));
-    Assert.assertEquals(value2.producerMetadata.logicalTimestamp, APP_DEFAULT_LOGICAL_TS);
-
-    // verify replicationMetadata is encoded correctly for Delete.
-    KafkaMessageEnvelope value5 = kmeArgumentCaptor.getAllValues().get(5);
-    Assert.assertEquals(value5.messageType, MessageType.DELETE.getValue());
-    delete = (Delete) value5.payloadUnion;
-    Assert.assertEquals(delete.schemaId, 1);
-    Assert.assertEquals(delete.replicationMetadataVersionId, 1);
-    Assert.assertEquals(delete.replicationMetadataPayload, ByteBuffer.wrap(new byte[] { 0xa, 0xb }));
-    Assert.assertEquals(value5.producerMetadata.logicalTimestamp, APP_DEFAULT_LOGICAL_TS);
-
-    // verify default logical_ts is encoded correctly
-    KafkaMessageEnvelope value6 = kmeArgumentCaptor.getAllValues().get(6);
-    Assert.assertEquals(value6.messageType, MessageType.PUT.getValue());
-    Assert.assertEquals(value6.producerMetadata.logicalTimestamp, APP_DEFAULT_LOGICAL_TS);
-  }
-
-  @Test(timeOut = 10000)
-  public void testReplicationMetadataChunking() throws ExecutionException, InterruptedException, TimeoutException {
-    PubSubProducerAdapter mockedProducer = mock(PubSubProducerAdapter.class);
-    Future mockedFuture = mock(Future.class);
-    when(mockedProducer.getNumberOfPartitions(any())).thenReturn(1);
-    when(mockedProducer.getNumberOfPartitions(any(), anyInt(), any())).thenReturn(1);
-    when(mockedProducer.sendMessage(any(), any(), any(), any(), any(), any())).thenReturn(mockedFuture);
-    String stringSchema = "\"string\"";
-    VeniceKafkaSerializer serializer = new VeniceAvroKafkaSerializer(stringSchema);
-    String testTopic = "test";
-    VeniceWriterOptions veniceWriterOptions = new VeniceWriterOptions.Builder(testTopic).setKeySerializer(serializer)
-        .setValueSerializer(serializer)
-        .setWriteComputeSerializer(serializer)
-        .setPartitioner(new DefaultVenicePartitioner())
-        .setTime(SystemTime.INSTANCE)
-        .setChunkingEnabled(true)
-        .setRmdChunkingEnabled(true)
-        .build();
-    VeniceWriter<Object, Object, Object> writer =
-        new VeniceWriter(veniceWriterOptions, VeniceProperties.empty(), mockedProducer);
-
-    ByteBuffer replicationMetadata = ByteBuffer.wrap(new byte[] { 0xa, 0xb });
-    PutMetadata putMetadata = new PutMetadata(1, replicationMetadata);
-
-    StringBuilder stringBuilder = new StringBuilder();
-    for (int i = 0; i < 50000; i++) {
-      stringBuilder.append("abcdefghabcdefghabcdefghabcdefgh");
-    }
-    String valueString = stringBuilder.toString();
-
-    writer.put(
-        Integer.toString(1),
-        valueString,
-        1,
-        null,
-        VeniceWriter.DEFAULT_LEADER_METADATA_WRAPPER,
-        APP_DEFAULT_LOGICAL_TS,
-        putMetadata);
-    ArgumentCaptor<KafkaKey> keyArgumentCaptor = ArgumentCaptor.forClass(KafkaKey.class);
-    ArgumentCaptor<KafkaMessageEnvelope> kmeArgumentCaptor = ArgumentCaptor.forClass(KafkaMessageEnvelope.class);
-    verify(mockedProducer, atLeast(2))
-        .sendMessage(any(), any(), keyArgumentCaptor.capture(), kmeArgumentCaptor.capture(), any(), any());
-    KeyWithChunkingSuffixSerializer keyWithChunkingSuffixSerializer = new KeyWithChunkingSuffixSerializer();
-    byte[] serializedKey = serializer.serialize(testTopic, Integer.toString(1));
-    byte[] serializedValue = serializer.serialize(testTopic, valueString);
-    byte[] serializedRmd = replicationMetadata.array();
-    int availableMessageSize = DEFAULT_MAX_SIZE_FOR_USER_PAYLOAD_PER_MESSAGE_IN_BYTES - serializedKey.length;
-
-    // The order should be SOS, valueChunk1, valueChunk2, replicationMetadataChunk1, manifest for value and RMD.
-    Assert.assertEquals(kmeArgumentCaptor.getAllValues().size(), 5);
-
-    // Verify value of the 1st chunk.
-    KafkaMessageEnvelope actualValue1 = kmeArgumentCaptor.getAllValues().get(1);
-    Assert.assertEquals(actualValue1.messageType, MessageType.PUT.getValue());
-    Assert.assertEquals(((Put) actualValue1.payloadUnion).schemaId, -10);
-    Assert.assertEquals(((Put) actualValue1.payloadUnion).replicationMetadataVersionId, -1);
-    Assert.assertEquals(((Put) actualValue1.payloadUnion).replicationMetadataPayload, ByteBuffer.allocate(0));
-    Assert.assertEquals(((Put) actualValue1.payloadUnion).putValue.array().length, availableMessageSize + 4);
-    Assert.assertEquals(actualValue1.producerMetadata.logicalTimestamp, VENICE_DEFAULT_LOGICAL_TS);
-
-    // Verify value of the 2nd chunk.
-    KafkaMessageEnvelope actualValue2 = kmeArgumentCaptor.getAllValues().get(2);
-    Assert.assertEquals(actualValue2.messageType, MessageType.PUT.getValue());
-    Assert.assertEquals(((Put) actualValue2.payloadUnion).schemaId, -10);
-    Assert.assertEquals(((Put) actualValue2.payloadUnion).replicationMetadataVersionId, -1);
-    Assert.assertEquals(((Put) actualValue2.payloadUnion).replicationMetadataPayload, ByteBuffer.allocate(0));
-    Assert.assertEquals(
-        ((Put) actualValue2.payloadUnion).putValue.array().length,
-        (serializedValue.length - availableMessageSize) + 4);
-    Assert.assertEquals(actualValue2.producerMetadata.logicalTimestamp, VENICE_DEFAULT_LOGICAL_TS);
-
-    ChunkedValueManifestSerializer chunkedValueManifestSerializer = new ChunkedValueManifestSerializer(true);
-
-    final ChunkedValueManifest chunkedValueManifest = new ChunkedValueManifest();
-    chunkedValueManifest.schemaId = 1;
-    chunkedValueManifest.keysWithChunkIdSuffix = new ArrayList<>(2);
-    chunkedValueManifest.size = serializedValue.length;
-
-    // Verify key of the 1st value chunk.
-    ChunkedKeySuffix chunkedKeySuffix = new ChunkedKeySuffix();
-    chunkedKeySuffix.isChunk = true;
-    chunkedKeySuffix.chunkId = new ChunkId();
-    chunkedKeySuffix.chunkId.chunkIndex = 0;
-    ProducerMetadata producerMetadata = actualValue1.producerMetadata;
-    chunkedKeySuffix.chunkId.producerGUID = producerMetadata.producerGUID;
-    chunkedKeySuffix.chunkId.segmentNumber = producerMetadata.segmentNumber;
-    chunkedKeySuffix.chunkId.messageSequenceNumber = producerMetadata.messageSequenceNumber;
-
-    ByteBuffer keyWithSuffix = keyWithChunkingSuffixSerializer.serializeChunkedKey(serializedKey, chunkedKeySuffix);
-    chunkedValueManifest.keysWithChunkIdSuffix.add(keyWithSuffix);
-    KafkaKey expectedKey1 = new KafkaKey(MessageType.PUT, keyWithSuffix.array());
-    KafkaKey actualKey1 = keyArgumentCaptor.getAllValues().get(1);
-    Assert.assertEquals(actualKey1.getKey(), expectedKey1.getKey());
-
-    // Verify key of the 2nd value chunk.
-    chunkedKeySuffix.chunkId.chunkIndex = 1;
-    keyWithSuffix = keyWithChunkingSuffixSerializer.serializeChunkedKey(serializedKey, chunkedKeySuffix);
-    chunkedValueManifest.keysWithChunkIdSuffix.add(keyWithSuffix);
-    KafkaKey expectedKey2 = new KafkaKey(MessageType.PUT, keyWithSuffix.array());
-    KafkaKey actualKey2 = keyArgumentCaptor.getAllValues().get(2);
-    Assert.assertEquals(actualKey2.getKey(), expectedKey2.getKey());
-
-    // Check value of the 1st RMD chunk.
-    KafkaMessageEnvelope actualValue3 = kmeArgumentCaptor.getAllValues().get(3);
-    Assert.assertEquals(actualValue3.messageType, MessageType.PUT.getValue());
-    Assert.assertEquals(((Put) actualValue3.payloadUnion).schemaId, -10);
-    Assert.assertEquals(((Put) actualValue3.payloadUnion).replicationMetadataVersionId, -1);
-    Assert.assertEquals(((Put) actualValue3.payloadUnion).putValue, ByteBuffer.allocate(0));
-    Assert.assertEquals(
-        ((Put) actualValue3.payloadUnion).replicationMetadataPayload.array().length,
-        serializedRmd.length + 4);
-    Assert.assertEquals(actualValue3.producerMetadata.logicalTimestamp, VENICE_DEFAULT_LOGICAL_TS);
-
-    // Check key of the 1st RMD chunk.
-    ChunkedValueManifest chunkedRmdManifest = new ChunkedValueManifest();
-    chunkedRmdManifest.schemaId = 1;
-    chunkedRmdManifest.keysWithChunkIdSuffix = new ArrayList<>(1);
-    chunkedRmdManifest.size = serializedRmd.length;
-    chunkedKeySuffix = new ChunkedKeySuffix();
-    chunkedKeySuffix.isChunk = true;
-    chunkedKeySuffix.chunkId = new ChunkId();
-    producerMetadata = actualValue3.producerMetadata;
-    chunkedKeySuffix.chunkId.producerGUID = producerMetadata.producerGUID;
-    chunkedKeySuffix.chunkId.segmentNumber = producerMetadata.segmentNumber;
-    chunkedKeySuffix.chunkId.messageSequenceNumber = producerMetadata.messageSequenceNumber;
-    // The chunkIndex of the first RMD should be the number of value chunks so that key space of value chunk and RMD
-    // chunk will not collide.
-    chunkedKeySuffix.chunkId.chunkIndex = 2;
-    keyWithSuffix = keyWithChunkingSuffixSerializer.serializeChunkedKey(serializedKey, chunkedKeySuffix);
-    chunkedRmdManifest.keysWithChunkIdSuffix.add(keyWithSuffix);
-    KafkaKey expectedKey3 = new KafkaKey(MessageType.PUT, keyWithSuffix.array());
-    KafkaKey actualKey3 = keyArgumentCaptor.getAllValues().get(3);
-    Assert.assertEquals(actualKey3.getKey(), expectedKey3.getKey());
-
-    // Check key of the manifest.
-    byte[] topLevelKey = keyWithChunkingSuffixSerializer.serializeNonChunkedKey(serializedKey);
-    KafkaKey expectedKey4 = new KafkaKey(MessageType.PUT, topLevelKey);
-    KafkaKey actualKey4 = keyArgumentCaptor.getAllValues().get(4);
-    Assert.assertEquals(actualKey4.getKey(), expectedKey4.getKey());
-
-    // Check manifest for both value and rmd.
-    KafkaMessageEnvelope actualValue4 = kmeArgumentCaptor.getAllValues().get(4);
-    Assert.assertEquals(actualValue4.messageType, MessageType.PUT.getValue());
-    Assert.assertEquals(
-        ((Put) actualValue4.payloadUnion).schemaId,
-        AvroProtocolDefinition.CHUNKED_VALUE_MANIFEST.getCurrentProtocolVersion());
-    Assert.assertEquals(((Put) actualValue4.payloadUnion).replicationMetadataVersionId, putMetadata.getRmdVersionId());
-    Assert.assertEquals(
-        ((Put) actualValue4.payloadUnion).replicationMetadataPayload,
-        ByteBuffer.wrap(chunkedValueManifestSerializer.serialize(testTopic, chunkedRmdManifest)));
-    Assert.assertEquals(
-        ((Put) actualValue4.payloadUnion).putValue,
-        ByteBuffer.wrap(chunkedValueManifestSerializer.serialize(testTopic, chunkedValueManifest)));
-    Assert.assertEquals(actualValue4.producerMetadata.logicalTimestamp, APP_DEFAULT_LOGICAL_TS);
-
   }
 }


### PR DESCRIPTION
## [server][dvc] Delete deprecated chunks when processing partial update
This PR aims to clean up deprecated value and RMD chunks to avoid storage engine chunking leaks. When we processed a partial update request, it will also try to look up old value and RMD manifest and will produce DELETE messages to old value and RMD chunks to remove them.
Note:
1. As discussed offline, this solution will be a short term solution to clean up disk space, but it will not clean up Kafka version topic garbage chunks as even after log compression there will be one DELETE message left per deprecated chunk key, but we think this is acceptable at this stage as DELETE message is considered small and we can work on long term complete solution later.
2. Based on current implementation, we could not fully delete a RMD of a key. We can only insert an empty RMD into it. (If this is not acceptable, we will need to add new implementations to execute real RocksDB delete on RMD Column Family.
3. We refactor the chunking get method to store the retrieved value's manifest if it is chunked. That means for AASIT, we will always delete old RMD chunks (as it is always fetched for every operation) and we will do best effort to delete old value's RMD (in theory, we will always do it for UPDATE). For LFSIT, we will always delete value chunks for UPDATE operation.


## How was this PR tested?
Added new integration test logic to validate existing value and RMD chunks are deleted after a new UPDATE request.

## Does this PR introduce any user-facing changes?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.