### PR TITLE
[controller] Cleanup Helix disabled partition map

### DIFF
--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -4700,8 +4700,11 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
   @Override
   public void deleteHelixResource(String clusterName, String kafkaTopic) {
     checkControllerLeadershipFor(clusterName);
-    List<String> instances = getStorageNodes(clusterName);
 
+    getHelixAdminClient().dropResource(clusterName, kafkaTopic);
+    LOGGER.info("Successfully dropped the resource: {} for cluster: {}", kafkaTopic, clusterName);
+
+    List<String> instances = getStorageNodes(clusterName);
     for (String instance: instances) {
       Map<String, List<String>> disabledPartitions =
           getHelixAdminClient().getDisabledPartitionsMap(clusterName, instance);
@@ -4713,9 +4716,6 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
         }
       }
     }
-
-    getHelixAdminClient().dropResource(clusterName, kafkaTopic);
-    LOGGER.info("Successfully dropped the resource: {} for cluster: {}", kafkaTopic, clusterName);
   }
 
   /**

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceHelixAdmin.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceHelixAdmin.java
@@ -1,0 +1,44 @@
+package com.linkedin.venice.controller;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+import com.linkedin.venice.helix.HelixExternalViewRepository;
+import com.linkedin.venice.meta.PartitionAssignment;
+import com.linkedin.venice.meta.Version;
+import com.linkedin.venice.utils.HelixUtils;
+import java.util.ArrayList;
+import java.util.List;
+import org.testng.annotations.Test;
+
+
+public class TestVeniceHelixAdmin {
+  @Test
+  public void testDropResources() {
+    VeniceHelixAdmin veniceHelixAdmin = mock(VeniceHelixAdmin.class);
+    List<String> nodes = new ArrayList<>();
+    String storeName = "abc";
+    String clusterName = "venice-cluster";
+    nodes.add("node_1");
+    HelixAdminClient adminClient = mock(HelixAdminClient.class);
+    HelixVeniceClusterResources veniceClusterResources = mock(HelixVeniceClusterResources.class);
+    HelixExternalViewRepository repository = mock(HelixExternalViewRepository.class);
+    PartitionAssignment partitionAssignment = mock(PartitionAssignment.class);
+    doReturn(adminClient).when(veniceHelixAdmin).getHelixAdminClient();
+    doReturn(3).when(partitionAssignment).getExpectedNumberOfPartitions();
+    doReturn(veniceClusterResources).when(veniceHelixAdmin).getHelixVeniceClusterResources(anyString());
+    doReturn(repository).when(veniceClusterResources).getRoutingDataRepository();
+    doReturn(nodes).when(veniceHelixAdmin).getStorageNodes(anyString());
+    doReturn(partitionAssignment).when(repository).getPartitionAssignments(anyString());
+    doCallRealMethod().when(veniceHelixAdmin).deleteHelixResource(anyString(), anyString());
+    String kafkaTopic = Version.composeKafkaTopic(storeName, 1);
+    List<String> partitions = new ArrayList<>(3);
+    for (int partitionId = 0; partitionId < 3; partitionId++) {
+      partitions.add(HelixUtils.getPartitionName(kafkaTopic, partitionId));
+    }
+
+    veniceHelixAdmin.deleteHelixResource(clusterName, kafkaTopic);
+    verify(adminClient, times(1)).enablePartition(true, clusterName, "node_1", kafkaTopic, partitions);
+
+  }
+}


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Cleanup Helix disabled partition map during dropping resources
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

During ingestion error in leader, we add  disabled partition map config in helix. But even if those resources are dropped later, the disabled map not cleared, which later might cause znode to blow up. This PR will cleanup disabled partition map (by calling enable, which will clear the node) during dropping of resources.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
unit test
## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.