### PR TITLE
[controller] Update superset schema ID after all value schema related operations

### DIFF
--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/consumer/ConsumerIntegrationTestWithSchemaReader.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/consumer/ConsumerIntegrationTestWithSchemaReader.java
@@ -37,8 +37,7 @@ public class ConsumerIntegrationTestWithSchemaReader extends ConsumerIntegration
         systemStoreName,
         NEW_PROTOCOL_SCHEMA.toString(),
         NEW_PROTOCOL_VERSION,
-        DirectionalSchemaCompatibilityType.NONE,
-        false);
+        DirectionalSchemaCompatibilityType.NONE);
   }
 
   @Override

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/Admin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/Admin.java
@@ -347,12 +347,7 @@ public interface Admin extends AutoCloseable, Closeable {
    *
    * TODO: make it private and remove from the interface list
    */
-  SchemaEntry addValueSchema(
-      String clusterName,
-      String storeName,
-      String valueSchemaStr,
-      int schemaId,
-      boolean doUpdateSupersetSchemaID);
+  SchemaEntry addValueSchema(String clusterName, String storeName, String valueSchemaStr, int schemaId);
 
   SchemaEntry addSupersetSchema(
       String clusterName,

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -4843,7 +4843,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
   }
 
   /**
-   * @see #addValueSchema(String, String, String, int, DirectionalSchemaCompatibilityType, boolean)
+   * @see #addValueSchema(String, String, String, int, DirectionalSchemaCompatibilityType)
    */
   @Override
   public SchemaEntry addValueSchema(
@@ -4858,22 +4858,16 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
   }
 
   /**
-   * @see #addValueSchema(String, String, String, int, DirectionalSchemaCompatibilityType, boolean)
+   * @see #addValueSchema(String, String, String, int, DirectionalSchemaCompatibilityType)
    */
   @Override
-  public SchemaEntry addValueSchema(
-      String clusterName,
-      String storeName,
-      String valueSchemaStr,
-      int schemaId,
-      boolean doUpdateSupersetSchemaID) {
+  public SchemaEntry addValueSchema(String clusterName, String storeName, String valueSchemaStr, int schemaId) {
     return addValueSchema(
         clusterName,
         storeName,
         valueSchemaStr,
         schemaId,
-        SchemaEntry.DEFAULT_SCHEMA_CREATION_COMPATIBILITY_TYPE,
-        doUpdateSupersetSchemaID);
+        SchemaEntry.DEFAULT_SCHEMA_CREATION_COMPATIBILITY_TYPE);
   }
 
   /**
@@ -4886,8 +4880,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
       String storeName,
       String valueSchemaStr,
       int schemaId,
-      DirectionalSchemaCompatibilityType compatibilityType,
-      final boolean doUpdateSupersetSchemaID) {
+      DirectionalSchemaCompatibilityType compatibilityType) {
     checkControllerLeadershipFor(clusterName);
     ReadWriteSchemaRepository schemaRepository = getHelixVeniceClusterResources(clusterName).getSchemaRepository();
     int newValueSchemaId =
@@ -4898,15 +4891,6 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
               + " Expected new schema id of " + schemaId + " but the next available id from the local repository is "
               + newValueSchemaId + " for store " + storeName + " in cluster " + clusterName + " Schema: "
               + valueSchemaStr);
-    }
-
-    if (doUpdateSupersetSchemaID) {
-      LOGGER.info(
-          "For store: {} in cluster: {}, value schema is the same as superset schema. Update superset schema ID to {}.",
-          storeName,
-          clusterName,
-          schemaId);
-      updateSupersetSchemaForStore(storeName, clusterName, schemaId);
     }
     return schemaRepository.addValueSchema(storeName, valueSchemaStr, newValueSchemaId);
   }
@@ -5012,11 +4996,6 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
       }
     }
 
-    // Update the store config
-    storeMetadataUpdate(clusterName, storeName, store -> {
-      store.setLatestSuperSetValueSchemaId(supersetSchemaId);
-      return store;
-    });
     // add the value schema
     return schemaRepository.addValueSchema(storeName, valueSchema, valueSchemaId);
   }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -4895,24 +4895,6 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
     return schemaRepository.addValueSchema(storeName, valueSchemaStr, newValueSchemaId);
   }
 
-  private void updateSupersetSchemaForStore(String storeName, String clusterName, int newSupersetSchemaID) {
-    final HelixVeniceClusterResources resources = getHelixVeniceClusterResources(clusterName);
-    try (AutoCloseableLock ignore = resources.getClusterLockManager().createStoreWriteLock(storeName)) {
-      ReadWriteStoreRepository repository = resources.getStoreMetadataRepository();
-      Store store = repository.getStore(storeName);
-      final int existingSupersetSchemaID = store.getLatestSuperSetValueSchemaId();
-      if (existingSupersetSchemaID > newSupersetSchemaID) {
-        throw new VeniceException(
-            "New superset schema ID should not be smaller than existing superset schema ID. "
-                + "Got existing superset schema ID: " + existingSupersetSchemaID + " and new superset schema ID: "
-                + newSupersetSchemaID + " for store " + storeName + " in cluster " + clusterName);
-      }
-      // Update source-of-truth store state.
-      store.setLatestSuperSetValueSchemaId(newSupersetSchemaID);
-      repository.updateStore(store);
-    }
-  }
-
   /**
    * Add a new derived schema for the given store with all specified properties and return a new
    * <code>DerivedSchemaEntry</code> object containing the schema and its id.

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
@@ -2996,6 +2996,10 @@ public class VeniceParentHelixAdmin implements Admin {
           newSupersetSchemaEntry.getId(),
           newSuperSetWriteComputeSchema.toString());
     }
+    updateStore(
+        clusterName,
+        storeName,
+        new UpdateStoreQueryParams().setLatestSupersetSchemaId(newSupersetSchemaEntry.getId()));
     return newValueSchemaEntry;
   }
 
@@ -3041,7 +3045,6 @@ public class VeniceParentHelixAdmin implements Admin {
     schemaMeta.schemaType = SchemaType.AVRO_1_4.getValue();
     valueSchemaCreation.schema = schemaMeta;
     valueSchemaCreation.schemaId = newValueSchemaId;
-    valueSchemaCreation.doUpdateSupersetSchemaID = doUpdateSupersetSchemaID;
 
     AdminOperation message = new AdminOperation();
     message.operationType = AdminMessageType.VALUE_SCHEMA_CREATION.getValue();
@@ -3054,6 +3057,10 @@ public class VeniceParentHelixAdmin implements Admin {
       throw new VeniceException(
           "Something bad happens, the expected new value schema id is: " + newValueSchemaId + ", but got: "
               + actualValueSchemaId);
+    }
+
+    if (doUpdateSupersetSchemaID) {
+      updateStore(clusterName, storeName, new UpdateStoreQueryParams().setLatestSupersetSchemaId(newValueSchemaId));
     }
 
     return new SchemaEntry(actualValueSchemaId, valueSchemaStr);
@@ -3077,12 +3084,7 @@ public class VeniceParentHelixAdmin implements Admin {
    * Unsupported operation in the parent controller.
    */
   @Override
-  public SchemaEntry addValueSchema(
-      String clusterName,
-      String storeName,
-      String valueSchemaStr,
-      int schemaId,
-      boolean doUpdateSupersetSchemaID) {
+  public SchemaEntry addValueSchema(String clusterName, String storeName, String valueSchemaStr, int schemaId) {
     throw new VeniceUnsupportedOperationException("addValueSchema");
   }
 

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/init/SystemSchemaInitializationRoutine.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/init/SystemSchemaInitializationRoutine.java
@@ -168,8 +168,7 @@ public class SystemSchemaInitializationRoutine implements ClusterLeaderInitializ
                 systemStoreName,
                 schemaInLocalResources.toString(),
                 valueSchemaVersion,
-                DirectionalSchemaCompatibilityType.NONE,
-                false);
+                DirectionalSchemaCompatibilityType.NONE);
           } catch (Exception e) {
             LOGGER.error(
                 "Caught Exception when attempting to register '{}' schema version '{}'. Will bubble up.",

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/kafka/consumer/AdminExecutionTask.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/kafka/consumer/AdminExecutionTask.java
@@ -300,18 +300,14 @@ public class AdminExecutionTask implements Callable<Void> {
     String storeName = message.storeName.toString();
     String schemaStr = message.schema.definition.toString();
     final int schemaId = message.schemaId;
-    final boolean doUpdateSupersetSchemaID = message.doUpdateSupersetSchemaID;
 
-    SchemaEntry valueSchemaEntry =
-        admin.addValueSchema(clusterName, storeName, schemaStr, schemaId, doUpdateSupersetSchemaID);
+    SchemaEntry valueSchemaEntry = admin.addValueSchema(clusterName, storeName, schemaStr, schemaId);
     LOGGER.info(
-        "Added value schema {} to store {} in cluster {} with schema ID {} and "
-            + "[update_superset_schema_ID_with_value_schema_ID == {}]",
+        "Added value schema {} to store {} in cluster {} with schema ID {}",
         schemaStr,
         storeName,
         clusterName,
-        valueSchemaEntry.getId(),
-        doUpdateSupersetSchemaID);
+        valueSchemaEntry.getId());
   }
 
   private void handleDerivedSchemaCreation(DerivedSchemaCreation message) {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/SchemaRoutes.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/SchemaRoutes.java
@@ -77,7 +77,7 @@ public class SchemaRoutes extends AbstractRoute {
 
   /**
    * Route to handle adding value schema request.
-   * @see Admin#addValueSchema(String, String, String, int, boolean)
+   * @see Admin#addValueSchema(String, String, String, int)
    */
   public Route addValueSchema(Admin admin) {
     return (request, response) -> {
@@ -102,8 +102,7 @@ public class SchemaRoutes extends AbstractRoute {
               responseObject.getCluster(),
               responseObject.getName(),
               request.queryParams(VALUE_SCHEMA),
-              Integer.parseInt(schemaIdString),
-              false);
+              Integer.parseInt(schemaIdString));
         } else {
           valueSchemaEntry = admin.addValueSchema(
               responseObject.getCluster(),


### PR DESCRIPTION
## [controller] Update superset schema ID after all value schema related operations

Existing implementation updates the superset schema id as soon as we add a new value or superset schema. This is problematic because in parent controller we perform schema addition in the following order:
1. Add new value schema (superset schema id is also updated).
2. Check if A/A is enabled and update RMD schema.
3. Check if WC is enabled and update derived schema.

This execution order allows race to happen when superset schema id is updated but the corresponding RMD schema and derived schema are not available yet. Resulting in failure in downstream consumers like the Venice storage node during ingestion.

The fix is to perform superset schema id as the last step and separate it into its own update store admin message.

## How was this PR tested?
Existing unit and integration tests.

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.