### PR TITLE
[pubsub] Support passing non-mergeable broker details

### DIFF
--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/PubSubBrokerWrapper.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/PubSubBrokerWrapper.java
@@ -6,6 +6,7 @@ import com.linkedin.venice.pubsub.api.PubSubClientsFactory;
 import com.linkedin.venice.utils.TestUtils;
 import java.io.File;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -35,16 +36,33 @@ public abstract class PubSubBrokerWrapper extends ProcessWrapper {
 
   public abstract String getRegionName();
 
-  Map<String, String> getAdditionalConfig() {
+  public Map<String, String> getAdditionalConfig() {
     return Collections.emptyMap();
   }
 
   /**
-   * Configs that have the same key, will be merged into a single config with individual values separated by commas.
+   * Returns a map of configs that should be merged with other brokers configs to form a single value.
    */
-  public static Map<String, String> combineAdditionalConfigs(List<PubSubBrokerWrapper> pubSubBrokerWrappers) {
-    List<Map<String, String>> additionalConfigs =
-        pubSubBrokerWrappers.stream().map(PubSubBrokerWrapper::getAdditionalConfig).collect(Collectors.toList());
-    return TestUtils.combineConfigs(additionalConfigs);
+  public Map<String, String> getMergeableConfigs() {
+    return Collections.emptyMap();
+  }
+
+  /**
+   * Returns a map of broker details for clients to connect to the broker.
+   *
+   * The values of common key in getMergeableConfigs() will be merged to form a single value.
+   *
+   * @param pubSubBrokerWrappers List of PubSubBrokerWrapper
+   *                             (e.g. KafkaBrokerWrapper, PulsarBrokerWrapper, etc.)
+   * @return Map of broker details for clients to connect to the broker.
+   */
+  public static Map<String, String> getBrokerDetailsForClients(List<PubSubBrokerWrapper> pubSubBrokerWrappers) {
+    Map<String, String> configs = new HashMap<>();
+    pubSubBrokerWrappers.forEach(pubSubBrokerWrapper -> configs.putAll(pubSubBrokerWrapper.getAdditionalConfig()));
+    List<Map<String, String>> toBeMergedList =
+        pubSubBrokerWrappers.stream().map(PubSubBrokerWrapper::getMergeableConfigs).collect(Collectors.toList());
+    configs.putAll(TestUtils.mergeConfigs(toBeMergedList));
+
+    return configs;
   }
 }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceTwoLayerMultiRegionMultiClusterWrapper.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceTwoLayerMultiRegionMultiClusterWrapper.java
@@ -220,7 +220,7 @@ public class VeniceTwoLayerMultiRegionMultiClusterWrapper extends ProcessWrapper
       Map<String, Map<String, String>> kafkaClusterMap =
           addKafkaClusterIDMappingToServerConfigs(serverProperties, childRegionName, allPubSubBrokerWrappers);
 
-      Map<String, String> pubSubBrokerProps = PubSubBrokerWrapper.combineAdditionalConfigs(allPubSubBrokerWrappers);
+      Map<String, String> pubSubBrokerProps = PubSubBrokerWrapper.getBrokerDetailsForClients(allPubSubBrokerWrappers);
       finalParentControllerProperties.putAll(pubSubBrokerProps); // parent controllers
       finalChildControllerProperties.putAll(pubSubBrokerProps); // child controllers
 

--- a/internal/venice-test-common/src/main/java/com/linkedin/venice/utils/TestUtils.java
+++ b/internal/venice-test-common/src/main/java/com/linkedin/venice/utils/TestUtils.java
@@ -841,7 +841,7 @@ public class TestUtils {
     }
   }
 
-  public static Map<String, String> combineConfigs(List<Map<String, String>> configMaps) {
+  public static Map<String, String> mergeConfigs(List<Map<String, String>> configMaps) {
     Map<String, String> aggregateConfigMap = new HashMap<>(2);
 
     for (Map<String, String> configMap: configMaps) {

--- a/internal/venice-test-common/src/test/java/com/linkedin/venice/utils/TestUtilsTest.java
+++ b/internal/venice-test-common/src/test/java/com/linkedin/venice/utils/TestUtilsTest.java
@@ -35,7 +35,7 @@ public class TestUtilsTest {
 
   @Test
   public void testCombineConfigs() {
-    Map<String, String> combinedConfigs = TestUtils.combineConfigs(
+    Map<String, String> combinedConfigs = TestUtils.mergeConfigs(
         Arrays.asList(
             getAdditionalConfigsForRegion(0),
             getAdditionalConfigsForRegion(1),


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Support passing non-mergeable broker details
This commit adds support for passing non-mergeable broker details to the Venice components. This 
means that if there is a key that is present in the broker details for multiple brokers, only the value for 
the last broker will be kept. Previously, all values for the same key would be concatenated together.




## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.