### PR TITLE
[controller] Support adding value schema with id and compat type via child controller client

### DIFF
--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerApiConstants.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerApiConstants.java
@@ -29,6 +29,7 @@ public class ControllerApiConstants {
   public static final String VALUE_SCHEMA = "value_schema";
   public static final String DERIVED_SCHEMA = "derived_schema";
   public static final String SCHEMA_ID = "schema_id";
+  public static final String SCHEMA_COMPAT_TYPE = "schema_compat_type";
   public static final String DERIVED_SCHEMA_ID = "derived_schema_id";
   public static final String TOPIC = "topic";
   public static final String OFFSET = "offset";

--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerClient.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerClient.java
@@ -50,6 +50,7 @@ import static com.linkedin.venice.controllerapi.ControllerApiConstants.REGIONS_F
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.REMOTE_KAFKA_BOOTSTRAP_SERVERS;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.REPLICATION_METADATA_VERSION_ID;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.REWIND_TIME_IN_SECONDS_OVERRIDE;
+import static com.linkedin.venice.controllerapi.ControllerApiConstants.SCHEMA_COMPAT_TYPE;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.SCHEMA_ID;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.SEND_START_OF_PUSH;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.SKIP_DIV;
@@ -81,6 +82,7 @@ import com.linkedin.venice.helix.VeniceJsonSerializer;
 import com.linkedin.venice.meta.VeniceUserStoreType;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.pushmonitor.ExecutionStatus;
+import com.linkedin.venice.schema.avro.DirectionalSchemaCompatibilityType;
 import com.linkedin.venice.security.SSLFactory;
 import com.linkedin.venice.utils.ExceptionUtils;
 import com.linkedin.venice.utils.Time;
@@ -908,6 +910,18 @@ public class ControllerClient implements Closeable {
   public SchemaResponse addValueSchema(String storeName, String valueSchemaStr, int valueSchemaId) {
     QueryParams params =
         newParams().add(NAME, storeName).add(VALUE_SCHEMA, valueSchemaStr).add(SCHEMA_ID, valueSchemaId);
+    return request(ControllerRoute.ADD_VALUE_SCHEMA, params, SchemaResponse.class);
+  }
+
+  public SchemaResponse addValueSchema(
+      String storeName,
+      String valueSchemaStr,
+      int valueSchemaId,
+      DirectionalSchemaCompatibilityType schemaCompatType) {
+    QueryParams params = newParams().add(NAME, storeName)
+        .add(VALUE_SCHEMA, valueSchemaStr)
+        .add(SCHEMA_ID, valueSchemaId)
+        .add(SCHEMA_COMPAT_TYPE, schemaCompatType.toString());
     return request(ControllerRoute.ADD_VALUE_SCHEMA, params, SchemaResponse.class);
   }
 

--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerRoute.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerRoute.java
@@ -68,6 +68,7 @@ import static com.linkedin.venice.controllerapi.ControllerApiConstants.REGULAR_V
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.REPLICATION_METADATA_PROTOCOL_VERSION_ID;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.REWIND_TIME_IN_SECONDS;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.RMD_CHUNKING_ENABLED;
+import static com.linkedin.venice.controllerapi.ControllerApiConstants.SCHEMA_COMPAT_TYPE;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.SCHEMA_ID;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.SERVER_KAFKA_FETCH_QUOTA_RECORDS_PER_SECOND;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.SINGLE_GET_ROUTER_CACHE_ENABLED;
@@ -157,7 +158,9 @@ public enum ControllerRoute {
   SKIP_ADMIN("/skip_admin_message", HttpMethod.POST, Collections.singletonList(OFFSET)),
 
   GET_KEY_SCHEMA("/get_key_schema", HttpMethod.GET, Collections.singletonList(NAME)),
-  ADD_VALUE_SCHEMA("/add_value_schema", HttpMethod.POST, Arrays.asList(NAME, VALUE_SCHEMA), SCHEMA_ID),
+  ADD_VALUE_SCHEMA(
+      "/add_value_schema", HttpMethod.POST, Arrays.asList(NAME, VALUE_SCHEMA), SCHEMA_ID, SCHEMA_COMPAT_TYPE
+  ),
   ADD_DERIVED_SCHEMA(
       "/add_derived_schema", HttpMethod.POST, Arrays.asList(NAME, SCHEMA_ID, DERIVED_SCHEMA), DERIVED_SCHEMA_ID
   ), SET_OWNER("/set_owner", HttpMethod.POST, Arrays.asList(NAME, OWNER)),

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/Admin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/Admin.java
@@ -340,14 +340,12 @@ public interface Admin extends AutoCloseable, Closeable {
       String valueSchemaStr,
       DirectionalSchemaCompatibilityType expectedCompatibilityType);
 
-  /**
-   * This method skips most of precondition checks and is intended for only internal use.
-   * Code from outside should call
-   * {@link #addValueSchema(String, String, String, DirectionalSchemaCompatibilityType)} instead.
-   *
-   * TODO: make it private and remove from the interface list
-   */
-  SchemaEntry addValueSchema(String clusterName, String storeName, String valueSchemaStr, int schemaId);
+  SchemaEntry addValueSchema(
+      String clusterName,
+      String storeName,
+      String valueSchemaStr,
+      int schemaId,
+      DirectionalSchemaCompatibilityType expectedCompatibilityType);
 
   SchemaEntry addSupersetSchema(
       String clusterName,

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -4860,7 +4860,6 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
   /**
    * @see #addValueSchema(String, String, String, int, DirectionalSchemaCompatibilityType)
    */
-  @Override
   public SchemaEntry addValueSchema(String clusterName, String storeName, String valueSchemaStr, int schemaId) {
     return addValueSchema(
         clusterName,
@@ -4875,6 +4874,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
    * containing the schema and its id.
    * @return an <code>SchemaEntry</code> object composed of a schema and its corresponding id.
    */
+  @Override
   public SchemaEntry addValueSchema(
       String clusterName,
       String storeName,

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
@@ -3084,7 +3084,12 @@ public class VeniceParentHelixAdmin implements Admin {
    * Unsupported operation in the parent controller.
    */
   @Override
-  public SchemaEntry addValueSchema(String clusterName, String storeName, String valueSchemaStr, int schemaId) {
+  public SchemaEntry addValueSchema(
+      String clusterName,
+      String storeName,
+      String valueSchemaStr,
+      int schemaId,
+      DirectionalSchemaCompatibilityType expectedCompatibilityType) {
     throw new VeniceUnsupportedOperationException("addValueSchema");
   }
 

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/SchemaRoutes.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/SchemaRoutes.java
@@ -4,6 +4,7 @@ import static com.linkedin.venice.controllerapi.ControllerApiConstants.CLUSTER;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.DERIVED_SCHEMA;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.DERIVED_SCHEMA_ID;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.NAME;
+import static com.linkedin.venice.controllerapi.ControllerApiConstants.SCHEMA_COMPAT_TYPE;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.SCHEMA_ID;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.VALUE_SCHEMA;
 import static com.linkedin.venice.controllerapi.ControllerRoute.ADD_DERIVED_SCHEMA;
@@ -30,6 +31,7 @@ import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.schema.GeneratedSchemaID;
 import com.linkedin.venice.schema.SchemaData;
 import com.linkedin.venice.schema.SchemaEntry;
+import com.linkedin.venice.schema.avro.DirectionalSchemaCompatibilityType;
 import com.linkedin.venice.schema.rmd.RmdSchemaEntry;
 import com.linkedin.venice.schema.writecompute.DerivedSchemaEntry;
 import com.linkedin.venice.utils.Utils;
@@ -77,7 +79,8 @@ public class SchemaRoutes extends AbstractRoute {
 
   /**
    * Route to handle adding value schema request.
-   * @see Admin#addValueSchema(String, String, String, int)
+   * @see Admin#addValueSchema(String, String, String, int, DirectionalSchemaCompatibilityType)
+   * @see Admin#addValueSchema(String, String, String, DirectionalSchemaCompatibilityType)
    */
   public Route addValueSchema(Admin admin) {
     return (request, response) -> {
@@ -97,12 +100,18 @@ public class SchemaRoutes extends AbstractRoute {
         String schemaIdString = request.queryParams(SCHEMA_ID);
         SchemaEntry valueSchemaEntry;
         if (schemaIdString != null) {
-          // Schema id is specified which suggests that the request is coming from metadata copy.
+          // Schema id is specified during metadata copy or internal system schema initialization.
+          String schemaCompatTypeString = request.queryParams(SCHEMA_COMPAT_TYPE);
+          DirectionalSchemaCompatibilityType schemaCompatType = SchemaEntry.DEFAULT_SCHEMA_CREATION_COMPATIBILITY_TYPE;
+          if (schemaCompatTypeString != null) {
+            schemaCompatType = DirectionalSchemaCompatibilityType.valueOf(schemaCompatTypeString);
+          }
           valueSchemaEntry = admin.addValueSchema(
               responseObject.getCluster(),
               responseObject.getName(),
               request.queryParams(VALUE_SCHEMA),
-              Integer.parseInt(schemaIdString));
+              Integer.parseInt(schemaIdString),
+              schemaCompatType);
         } else {
           valueSchemaEntry = admin.addValueSchema(
               responseObject.getCluster(),

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/SchemaRoutesTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/SchemaRoutesTest.java
@@ -1,6 +1,15 @@
 package com.linkedin.venice.controller.server;
 
+import static com.linkedin.venice.controllerapi.ControllerApiConstants.CLUSTER;
+import static com.linkedin.venice.controllerapi.ControllerApiConstants.NAME;
+import static com.linkedin.venice.controllerapi.ControllerApiConstants.SCHEMA_COMPAT_TYPE;
+import static com.linkedin.venice.controllerapi.ControllerApiConstants.SCHEMA_ID;
+import static com.linkedin.venice.controllerapi.ControllerApiConstants.VALUE_SCHEMA;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertTrue;
 
@@ -10,8 +19,13 @@ import com.linkedin.venice.exceptions.VeniceNoStoreException;
 import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.schema.GeneratedSchemaID;
 import com.linkedin.venice.schema.SchemaData;
+import com.linkedin.venice.schema.SchemaEntry;
+import com.linkedin.venice.schema.avro.DirectionalSchemaCompatibilityType;
 import java.util.Optional;
 import org.testng.annotations.Test;
+import spark.Request;
+import spark.Response;
+import spark.Route;
 
 
 public class SchemaRoutesTest {
@@ -60,6 +74,34 @@ public class SchemaRoutesTest {
                   "Can not find any registered value schema nor derived schema for the store store_name that matches the schema of data being pushed."),
           "Got this instead: " + e.getMessage());
     }
+  }
+
+  @Test
+  public void testAddValueSchemaWithIdAndCompatType() throws Exception {
+    String cluster = "cluster_name";
+    String store = "store_name";
+    String schemaStr = "\"int\"";
+    int schemaId = 2;
+    DirectionalSchemaCompatibilityType schemaCompatType = DirectionalSchemaCompatibilityType.BACKWARD;
+
+    Admin admin = mock(Admin.class);
+    Request request = mock(Request.class);
+    Response response = mock(Response.class);
+
+    doReturn(cluster).when(request).queryParams(CLUSTER);
+    doReturn(store).when(request).queryParams(NAME);
+    doReturn(schemaStr).when(request).queryParams(VALUE_SCHEMA);
+    doReturn(Integer.toString(schemaId)).when(request).queryParams(SCHEMA_ID);
+    doReturn(schemaCompatType.toString()).when(request).queryParams(SCHEMA_COMPAT_TYPE);
+
+    doReturn(true).when(admin).isLeaderControllerFor("cluster_name");
+    doReturn(new SchemaEntry(schemaId, schemaStr)).when(admin)
+        .addValueSchema(cluster, store, schemaStr, schemaId, schemaCompatType);
+
+    SchemaRoutes schemaRoutes = new SchemaRoutes(false, Optional.empty());
+    Route route = schemaRoutes.addValueSchema(admin);
+    route.handle(request, response);
+    verify(response, times(0)).status(anyInt()); // no error
   }
 
 }


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Summary
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

To resolve KME upgrade deployment order, one action is to make child controllers and servers register KME from the code into local system store at startup time. However, KME is only backward compatible. Adding schema that is not fully compatible via controller client is not supported. This commit supports adding value schema with id and compat type via child controller client.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

New unit test
CI

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.