### PR TITLE
[vpj] Reuse KafkaConsumer when building dict from an existing topic

### DIFF
--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/input/kafka/KafkaInputDictTrainer.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/input/kafka/KafkaInputDictTrainer.java
@@ -11,8 +11,14 @@ import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.hadoop.PushJobZstdConfig;
 import com.linkedin.venice.hadoop.input.kafka.avro.KafkaInputMapperKey;
 import com.linkedin.venice.hadoop.input.kafka.avro.KafkaInputMapperValue;
+import com.linkedin.venice.kafka.protocol.KafkaMessageEnvelope;
+import com.linkedin.venice.pubsub.adapter.kafka.consumer.ApacheKafkaConsumerAdapterFactory;
+import com.linkedin.venice.pubsub.api.PubSubConsumerAdapter;
+import com.linkedin.venice.pubsub.api.PubSubMessageDeserializer;
+import com.linkedin.venice.serialization.avro.OptimizedKafkaValueSerializer;
 import com.linkedin.venice.utils.ByteUtils;
 import com.linkedin.venice.utils.VeniceProperties;
+import com.linkedin.venice.utils.pools.LandFillObjectPool;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Comparator;
@@ -119,6 +125,9 @@ public class KafkaInputDictTrainer {
   private final CompressionStrategy sourceVersionCompressionStrategy;
   private final CompressorBuilder compressorBuilder;
 
+  // For testing purpose
+  private PubSubConsumerAdapter reusedConsumer;
+
   public KafkaInputDictTrainer(Param param) {
     this(new KafkaInputFormat(), Optional.empty(), param, KafkaInputUtils::getCompressor);
   }
@@ -159,6 +168,10 @@ public class KafkaInputDictTrainer {
     this.compressorBuilder = compressorBuilder;
   }
 
+  synchronized void setReusedConsumer(PubSubConsumerAdapter reusedConsumer) {
+    this.reusedConsumer = reusedConsumer;
+  }
+
   public synchronized byte[] trainDict() {
     if (dict != null) {
       return dict;
@@ -191,12 +204,26 @@ public class KafkaInputDictTrainer {
     int currentPartition = 0;
     long totalSampledRecordCnt = 0;
 
+    // Reuse the same Kafka Consumer across all partitions avoid log flooding
+    if (reusedConsumer == null) {
+      reusedConsumer = new ApacheKafkaConsumerAdapterFactory().create(
+          KafkaInputUtils.getConsumerProperties(jobConf),
+          false,
+          new PubSubMessageDeserializer(
+              new OptimizedKafkaValueSerializer(),
+              new LandFillObjectPool<>(KafkaMessageEnvelope::new),
+              new LandFillObjectPool<>(KafkaMessageEnvelope::new)),
+          null);
+    }
+
     try {
       for (InputSplit split: splits) {
         long currentFilledSize = 0;
         long sampledRecordCnt = 0;
+        // Reset Kafka consumer before using it
+        reusedConsumer.batchUnsubscribe(reusedConsumer.getAssignment());
         RecordReader<KafkaInputMapperKey, KafkaInputMapperValue> recordReader =
-            kafkaInputFormat.getRecordReader(split, jobConf, Reporter.NULL);
+            kafkaInputFormat.getRecordReader(split, jobConf, Reporter.NULL, reusedConsumer);
         try {
           if (mapperKey == null) {
             mapperKey = recordReader.createKey();
@@ -246,6 +273,10 @@ public class KafkaInputDictTrainer {
     } finally {
       if (compressorFactory != null) {
         compressorFactory.close();
+      }
+      if (reusedConsumer != null) {
+        reusedConsumer.close();
+        reusedConsumer = null;
       }
     }
     if (totalSampledRecordCnt == 0) {

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/input/kafka/KafkaInputFormat.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/input/kafka/KafkaInputFormat.java
@@ -11,6 +11,7 @@ import com.linkedin.venice.kafka.TopicManagerRepository;
 import com.linkedin.venice.pubsub.PubSubTopicRepository;
 import com.linkedin.venice.pubsub.adapter.kafka.admin.ApacheKafkaAdminAdapterFactory;
 import com.linkedin.venice.pubsub.adapter.kafka.consumer.ApacheKafkaConsumerAdapterFactory;
+import com.linkedin.venice.pubsub.api.PubSubConsumerAdapter;
 import com.linkedin.venice.utils.VeniceProperties;
 import java.io.IOException;
 import java.util.HashMap;
@@ -104,5 +105,13 @@ public class KafkaInputFormat implements InputFormat<KafkaInputMapperKey, KafkaI
       JobConf job,
       Reporter reporter) {
     return new KafkaInputRecordReader(split, job, reporter);
+  }
+
+  public RecordReader<KafkaInputMapperKey, KafkaInputMapperValue> getRecordReader(
+      InputSplit split,
+      JobConf job,
+      Reporter reporter,
+      PubSubConsumerAdapter consumer) {
+    return new KafkaInputRecordReader(split, job, reporter, consumer);
   }
 }

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/input/kafka/TestKafkaInputDictTrainer.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/input/kafka/TestKafkaInputDictTrainer.java
@@ -63,8 +63,7 @@ public class TestKafkaInputDictTrainer {
         Optional.empty(),
         getParam(100),
         getCompressorBuilder(new NoopCompressor()));
-    trainer.setReusedConsumer(mock(PubSubConsumerAdapter.class));
-    trainer.trainDict();
+    trainer.trainDict(Optional.of(mock(PubSubConsumerAdapter.class)));
   }
 
   interface ResettableRecordReader<K, V> extends RecordReader<K, V> {
@@ -165,8 +164,7 @@ public class TestKafkaInputDictTrainer {
         Optional.of(mockTrainer1),
         getParam(1000),
         getCompressorBuilder(new NoopCompressor()));
-    trainer1.setReusedConsumer(mock(PubSubConsumerAdapter.class));
-    trainer1.trainDict();
+    trainer1.trainDict(Optional.of(mock(PubSubConsumerAdapter.class)));
 
     verify(mockTrainer1).addSample(eq("p0_value0".getBytes()));
     verify(mockTrainer1).addSample(eq("p0_value1".getBytes()));
@@ -184,8 +182,7 @@ public class TestKafkaInputDictTrainer {
         Optional.of(mockTrainer2),
         getParam(20),
         getCompressorBuilder(new NoopCompressor()));
-    trainer2.setReusedConsumer(mock(PubSubConsumerAdapter.class));
-    trainer2.trainDict();
+    trainer2.trainDict(Optional.of(mock(PubSubConsumerAdapter.class)));
     verify(mockTrainer2).addSample(eq("p0_value0".getBytes()));
     verify(mockTrainer2, never()).addSample(eq("p0_value1".getBytes()));
     verify(mockTrainer2, never()).addSample(eq("p0_value2".getBytes()));
@@ -223,8 +220,7 @@ public class TestKafkaInputDictTrainer {
         Optional.of(mockTrainer1),
         getParam(1000, CompressionStrategy.GZIP),
         getCompressorBuilder(mockedCompressor));
-    trainer1.setReusedConsumer(mock(PubSubConsumerAdapter.class));
-    trainer1.trainDict();
+    trainer1.trainDict(Optional.of(mock(PubSubConsumerAdapter.class)));
 
     List<byte[]> allValues = new ArrayList<>(
         Arrays.asList(
@@ -277,8 +273,7 @@ public class TestKafkaInputDictTrainer {
         Optional.of(mockTrainer1),
         getParam(1000, CompressionStrategy.GZIP),
         getCompressorBuilder(mockedCompressor));
-    trainer1.setReusedConsumer(mock(PubSubConsumerAdapter.class));
-    trainer1.trainDict();
+    trainer1.trainDict(Optional.of(mock(PubSubConsumerAdapter.class)));
 
     List<byte[]> allValues = new ArrayList<>(
         Arrays.asList(


### PR DESCRIPTION
## Summary, imperative, start upper case, don't end with a period
Previously, `KafkaInputDictTrainer` would initiate a new KafkaConsumer per partition, which results in ton of KafkaConsumer related logs printed in VPJ log, which would make VPJ log analyzing less efficient. This code change will reuse the same consumer when extracting data messages from different partitions to reduce the total amount of logs produced by KafkaInputDictTrainer.

<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->


<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->


## How was this PR tested?
CI
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.