### PR TITLE
[router] Fixed order of checks in compressed batch gets

### DIFF
--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestHAASController.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestHAASController.java
@@ -158,7 +158,7 @@ public class TestHAASController {
     }
   }
 
-  @Test(timeOut = 120 * Time.MS_PER_SECOND)
+  @Test(timeOut = 180 * Time.MS_PER_SECOND)
   public void testTransitionToHAASControllerAsStorageClusterLeader() {
     try (VeniceClusterWrapper venice = ServiceFactory.getVeniceCluster(3, 1, 0, 1);
         HelixAsAServiceWrapper helixAsAServiceWrapper = startAndWaitForHAASToBeAvailable(venice.getZk().getAddress())) {

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestHAASController.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestHAASController.java
@@ -259,14 +259,19 @@ public class TestHAASController {
   }
 
   private HelixAsAServiceWrapper startAndWaitForHAASToBeAvailable(String zkAddress) {
-    HelixAsAServiceWrapper helixAsAServiceWrapper = ServiceFactory.getHelixController(zkAddress);
-    waitForNonDeterministicAssertion(
-        30,
-        TimeUnit.SECONDS,
-        true,
-        () -> assertNotNull(
-            helixAsAServiceWrapper.getSuperClusterLeader(),
-            "Helix super cluster doesn't have a leader yet"));
-    return helixAsAServiceWrapper;
+    HelixAsAServiceWrapper helixAsAServiceWrapper = null;
+    try {
+      helixAsAServiceWrapper = ServiceFactory.getHelixController(zkAddress);
+      final HelixAsAServiceWrapper finalHaas = helixAsAServiceWrapper;
+      waitForNonDeterministicAssertion(
+          30,
+          TimeUnit.SECONDS,
+          true,
+          () -> assertNotNull(finalHaas.getSuperClusterLeader(), "Helix super cluster doesn't have a leader yet"));
+      return helixAsAServiceWrapper;
+    } catch (Exception e) {
+      Utils.closeQuietlyWithErrorLogged(helixAsAServiceWrapper);
+      throw e;
+    }
   }
 }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceClusterWrapper.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceClusterWrapper.java
@@ -516,25 +516,31 @@ public class VeniceClusterWrapper extends ProcessWrapper {
   }
 
   public VeniceControllerWrapper addVeniceController(Properties properties) {
-    VeniceControllerWrapper veniceControllerWrapper = ServiceFactory.getVeniceController(
-        new VeniceControllerCreateOptions.Builder(getClusterName(), zkServerWrapper, pubSubBrokerWrapper)
-            .regionName(options.getRegionName())
-            .replicationFactor(options.getReplicationFactor())
-            .partitionSize(options.getPartitionSize())
-            .numberOfPartitions(options.getNumberOfPartitions())
-            .maxNumberOfPartitions(options.getMaxNumberOfPartitions())
-            .rebalanceDelayMs(options.getRebalanceDelayMs())
-            .minActiveReplica(options.getMinActiveReplica())
-            .sslToKafka(options.isSslToKafka())
-            .clusterToD2(clusterToD2)
-            .clusterToServerD2(clusterToServerD2)
-            .extraProperties(properties)
-            .build());
-    synchronized (this) {
-      veniceControllerWrappers.put(veniceControllerWrapper.getPort(), veniceControllerWrapper);
-      setExternalControllerDiscoveryURL(getAllControllersURLs());
+    VeniceControllerWrapper veniceControllerWrapper = null;
+    try {
+      veniceControllerWrapper = ServiceFactory.getVeniceController(
+          new VeniceControllerCreateOptions.Builder(getClusterName(), zkServerWrapper, pubSubBrokerWrapper)
+              .regionName(options.getRegionName())
+              .replicationFactor(options.getReplicationFactor())
+              .partitionSize(options.getPartitionSize())
+              .numberOfPartitions(options.getNumberOfPartitions())
+              .maxNumberOfPartitions(options.getMaxNumberOfPartitions())
+              .rebalanceDelayMs(options.getRebalanceDelayMs())
+              .minActiveReplica(options.getMinActiveReplica())
+              .sslToKafka(options.isSslToKafka())
+              .clusterToD2(clusterToD2)
+              .clusterToServerD2(clusterToServerD2)
+              .extraProperties(properties)
+              .build());
+      synchronized (this) {
+        veniceControllerWrappers.put(veniceControllerWrapper.getPort(), veniceControllerWrapper);
+        setExternalControllerDiscoveryURL(getAllControllersURLs());
+      }
+      return veniceControllerWrapper;
+    } catch (Exception e) {
+      Utils.closeQuietlyWithErrorLogged(veniceControllerWrapper);
+      throw e;
     }
-    return veniceControllerWrapper;
   }
 
   public void addVeniceControllerWrapper(VeniceControllerWrapper veniceControllerWrapper) {


### PR DESCRIPTION
In the VeniceResponseAggregator, the router used to check that all responses from servers had a consistent compression scheme, and then if they were 200 OK. This leads to misleading logs about inconsistent compression in cases where servers return an error, since the error itself may be missing the compression header.

This commit flips the order of the checks to avoid the misleading logs.

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.