### PR TITLE
[client][test] Increase socket timeout for HTTP client5

### DIFF
--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/transport/HttpClient5BasedR2Client.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/transport/HttpClient5BasedR2Client.java
@@ -13,6 +13,7 @@ import com.linkedin.venice.httpclient5.HttpClient5Utils;
 import java.util.Arrays;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import javax.net.ssl.SSLContext;
 import org.apache.hc.client5.http.async.methods.SimpleHttpResponse;
 import org.apache.hc.client5.http.async.methods.SimpleRequestBuilder;
@@ -29,6 +30,8 @@ import org.apache.hc.core5.io.CloseMode;
  * TODO: get rid of R2 Client inferface completely from venice-client.
  */
 public class HttpClient5BasedR2Client {
+  private static final long requestTimeOutInMilliseconds = TimeUnit.SECONDS.toMillis(1); // 1s by default
+
   public static final String HTTP_METHOD_GET_LOWER_CASE = "get";
   public static final String HTTP_METHOD_POST_LOWER_CASE = "post";
 
@@ -44,12 +47,17 @@ public class HttpClient5BasedR2Client {
   }
 
   public static Client getR2Client(SSLContext sslContext, int ioThreadCount) throws Exception {
+    return getR2Client(sslContext, ioThreadCount, requestTimeOutInMilliseconds);
+  }
+
+  public static Client getR2Client(SSLContext sslContext, int ioThreadCount, long responseTimeout) throws Exception {
     if (ioThreadCount <= 0) {
       throw new VeniceClientException("ioThreadCount should be greater than 0");
     }
 
     final CloseableHttpAsyncClient client = new HttpClient5Utils.HttpClient5Builder().setIoThreadCount(ioThreadCount)
         .setSslContext(sslContext)
+        .setRequestTimeOutInMilliseconds(responseTimeout)
         // Disable cipher check for now.
         .setSkipCipherCheck(true)
         .buildAndStart();

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/httpclient5/HttpClient5Utils.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/httpclient5/HttpClient5Utils.java
@@ -37,7 +37,7 @@ public class HttpClient5Utils {
     private long requestTimeOutInMilliseconds = TimeUnit.SECONDS.toMillis(1); // 1s by default
     /**
      * We need to use a high connect timeout to avoid reconnect issue, which might result in confusing logging and unhealthy requests.
-     * For now, we remove the functions updating the connect timeout to avoid mistakes.
+     * For now, we remove the functions updating to connect timeout to avoid mistakes.
      */
     private final Timeout CONNECT_TIMEOUT_IN_MILLISECONDS = Timeout.ofMilliseconds(TimeUnit.MINUTES.toMillis(1)); // 1m
                                                                                                                   // by
@@ -54,7 +54,7 @@ public class HttpClient5Utils {
       return this;
     }
 
-    public HttpClient5Builder setRequestTimeOutInMilliseconds(int requestTimeOutInMilliseconds) {
+    public HttpClient5Builder setRequestTimeOutInMilliseconds(long requestTimeOutInMilliseconds) {
       this.requestTimeOutInMilliseconds = requestTimeOutInMilliseconds;
       return this;
     }

--- a/internal/venice-test-common/src/main/java/com/linkedin/venice/fastclient/utils/ClientTestUtils.java
+++ b/internal/venice-test-common/src/main/java/com/linkedin/venice/fastclient/utils/ClientTestUtils.java
@@ -52,7 +52,7 @@ public class ClientTestUtils {
         return setupTransportClientFactory(fastClientHTTPVariant);
 
       case HTTP_2_BASED_HTTPCLIENT5:
-        return HttpClient5BasedR2Client.getR2Client(SslUtils.getVeniceLocalSslFactory().getSSLContext(), 8);
+        return HttpClient5BasedR2Client.getR2Client(SslUtils.getVeniceLocalSslFactory().getSSLContext(), 8, 5000);
 
       default:
         throw new VeniceException("Unsupported Http type: " + fastClientHTTPVariant);


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Increase socket timeout for HTTP client5
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

A bunch of flaky fast-client tests (eg `testFastClientGetWithDifferentHTTPVariants `) fail with the following socket timeout exception. 
Caused by: java.util.concurrent.ExecutionException: com.linkedin.venice.client.exceptions.VeniceClientException: java.net.SocketTimeoutException: 1000 MILLISECONDS
	at java.base/java.util.concurrent.CompletableFuture.reportGet(CompletableFuture.java:395)
	at java.base/java.util.concurrent.CompletableFuture.get(CompletableFuture.java:1999)

This PR tries to increase the timeout to 5s to reduce flakiness.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
GHCI
## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.