### PR TITLE
[pubsub][kafka] Skip callback processing when the producer is closed forcefully

### DIFF
--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/adapter/kafka/producer/ApacheKafkaProducerAdapter.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/adapter/kafka/producer/ApacheKafkaProducerAdapter.java
@@ -32,7 +32,7 @@ public class ApacheKafkaProducerAdapter implements PubSubProducerAdapter {
 
   private KafkaProducer<KafkaKey, KafkaMessageEnvelope> producer;
   private final ApacheKafkaProducerConfig producerConfig;
-  private boolean forceClose = false;
+  private boolean forceClosed = false;
 
   /**
    * @param producerConfig contains producer configs
@@ -118,7 +118,7 @@ public class ApacheKafkaProducerAdapter implements PubSubProducerAdapter {
       LOGGER.info("Flushed all the messages in producer before closing");
     }
     if (closeTimeOutMs == 0) {
-      forceClose = true;
+      forceClosed = true;
     }
     producer.close(Duration.ofMillis(closeTimeOutMs));
     // Recycle the internal buffer allocated by KafkaProducer ASAP.
@@ -152,7 +152,7 @@ public class ApacheKafkaProducerAdapter implements PubSubProducerAdapter {
     return producerConfig.getBrokerAddress();
   }
 
-  boolean isForceClose() {
-    return forceClose;
+  boolean isForceClosed() {
+    return forceClosed;
   }
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/adapter/kafka/producer/ApacheKafkaProducerAdapter.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/adapter/kafka/producer/ApacheKafkaProducerAdapter.java
@@ -32,6 +32,7 @@ public class ApacheKafkaProducerAdapter implements PubSubProducerAdapter {
 
   private KafkaProducer<KafkaKey, KafkaMessageEnvelope> producer;
   private final ApacheKafkaProducerConfig producerConfig;
+  private boolean forceClose = false;
 
   /**
    * @param producerConfig contains producer configs
@@ -81,7 +82,7 @@ public class ApacheKafkaProducerAdapter implements PubSubProducerAdapter {
         key,
         value,
         ApacheKafkaUtils.convertToKafkaSpecificHeaders(pubsubMessageHeaders));
-    ApacheKafkaProducerCallback kafkaCallback = new ApacheKafkaProducerCallback(pubsubProducerCallback);
+    ApacheKafkaProducerCallback kafkaCallback = new ApacheKafkaProducerCallback(pubsubProducerCallback, this);
     try {
       producer.send(record, kafkaCallback);
       return kafkaCallback.getProduceResultFuture();
@@ -116,6 +117,9 @@ public class ApacheKafkaProducerAdapter implements PubSubProducerAdapter {
       producer.flush(closeTimeOutMs, TimeUnit.MILLISECONDS);
       LOGGER.info("Flushed all the messages in producer before closing");
     }
+    if (closeTimeOutMs == 0) {
+      forceClose = true;
+    }
     producer.close(Duration.ofMillis(closeTimeOutMs));
     // Recycle the internal buffer allocated by KafkaProducer ASAP.
     producer = null;
@@ -146,5 +150,9 @@ public class ApacheKafkaProducerAdapter implements PubSubProducerAdapter {
   @Override
   public String getBrokerAddress() {
     return producerConfig.getBrokerAddress();
+  }
+
+  boolean isForceClose() {
+    return forceClose;
   }
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/adapter/kafka/producer/ApacheKafkaProducerCallback.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/adapter/kafka/producer/ApacheKafkaProducerCallback.java
@@ -63,7 +63,7 @@ public class ApacheKafkaProducerCallback implements Callback {
     }
 
     // This is a special case where the producer is closed forcefully. We can skip the callback processing
-    if (exception != null && exception.getMessage() != null && producerAdapter.isForceClose()
+    if (exception != null && exception.getMessage() != null && producerAdapter.isForceClosed()
         && exception.getMessage().contains("Producer is closed forcefully")) {
       LOGGER.debug("Producer is closed forcefully. Skipping the callback processing.");
       return;

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/adapter/kafka/producer/ApacheKafkaProducerCallback.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/adapter/kafka/producer/ApacheKafkaProducerCallback.java
@@ -6,17 +6,25 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
 import org.apache.kafka.clients.producer.Callback;
 import org.apache.kafka.clients.producer.RecordMetadata;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 
 /**
  * A Kafka specific callback which wraps generic {@link PubSubProducerCallback}
  */
 public class ApacheKafkaProducerCallback implements Callback {
+  private static final Logger LOGGER = LogManager.getLogger(ApacheKafkaProducerCallback.class);
+
   private final PubSubProducerCallback pubsubProducerCallback;
   private final CompletableFuture<PubSubProduceResult> produceResultFuture = new CompletableFuture<>();
+  private final ApacheKafkaProducerAdapter producerAdapter;
 
-  public ApacheKafkaProducerCallback(PubSubProducerCallback pubsubProducerCallback) {
+  public ApacheKafkaProducerCallback(
+      PubSubProducerCallback pubsubProducerCallback,
+      ApacheKafkaProducerAdapter producerAdapter) {
     this.pubsubProducerCallback = pubsubProducerCallback;
+    this.producerAdapter = producerAdapter;
   }
 
   /**
@@ -53,6 +61,14 @@ public class ApacheKafkaProducerCallback implements Callback {
       produceResult = new ApacheKafkaProduceResult(metadata);
       produceResultFuture.complete(produceResult);
     }
+
+    // This is a special case where the producer is closed forcefully. We can skip the callback processing
+    if (exception != null && exception.getMessage() != null && producerAdapter.isForceClose()
+        && exception.getMessage().contains("Producer is closed forcefully")) {
+      LOGGER.debug("Producer is closed forcefully. Skipping the callback processing.");
+      return;
+    }
+
     if (pubsubProducerCallback != null) {
       pubsubProducerCallback.onCompletion(produceResult, exception);
     }

--- a/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/adapter/kafka/producer/ApacheKafkaProducerCallbackTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/adapter/kafka/producer/ApacheKafkaProducerCallbackTest.java
@@ -1,5 +1,6 @@
 package com.linkedin.venice.pubsub.adapter.kafka.producer;
 
+import static org.mockito.Mockito.mock;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
@@ -20,7 +21,8 @@ public class ApacheKafkaProducerCallbackTest {
   @Test
   public void testOnCompletionWithNullExceptionShouldInvokeInternalCallbackWithNullException() {
     PubSubProducerCallbackSimpleImpl internalCallback = new PubSubProducerCallbackSimpleImpl();
-    ApacheKafkaProducerCallback kafkaProducerCallback = new ApacheKafkaProducerCallback(internalCallback);
+    ApacheKafkaProducerCallback kafkaProducerCallback =
+        new ApacheKafkaProducerCallback(internalCallback, mock(ApacheKafkaProducerAdapter.class));
     RecordMetadata recordMetadata = new RecordMetadata(new TopicPartition("topicX", 42), 0, 1, 1676397545, 1L, 11, 12);
 
     kafkaProducerCallback.onCompletion(recordMetadata, null);
@@ -38,7 +40,8 @@ public class ApacheKafkaProducerCallbackTest {
   @Test
   public void testOnCompletionWithNonNullExceptionShouldInvokeInternalCallbackWithNonNullException() {
     PubSubProducerCallbackSimpleImpl internalCallback = new PubSubProducerCallbackSimpleImpl();
-    ApacheKafkaProducerCallback kafkaProducerCallback = new ApacheKafkaProducerCallback(internalCallback);
+    ApacheKafkaProducerCallback kafkaProducerCallback =
+        new ApacheKafkaProducerCallback(internalCallback, mock(ApacheKafkaProducerAdapter.class));
     RecordMetadata recordMetadata = new RecordMetadata(new TopicPartition("topicX", 42), -1, -1, -1, -1L, -1, -1);
 
     UnknownTopicOrPartitionException exception = new UnknownTopicOrPartitionException("Unknown topic: topicX");
@@ -54,7 +57,8 @@ public class ApacheKafkaProducerCallbackTest {
   public void testOnCompletionWithNonNullExceptionShouldCompleteFutureExceptionally()
       throws ExecutionException, InterruptedException {
     PubSubProducerCallbackSimpleImpl internalCallback = new PubSubProducerCallbackSimpleImpl();
-    ApacheKafkaProducerCallback kafkaProducerCallback = new ApacheKafkaProducerCallback(internalCallback);
+    ApacheKafkaProducerCallback kafkaProducerCallback =
+        new ApacheKafkaProducerCallback(internalCallback, mock(ApacheKafkaProducerAdapter.class));
     Future<PubSubProduceResult> produceResultFuture = kafkaProducerCallback.getProduceResultFuture();
     assertFalse(produceResultFuture.isDone());
     assertFalse(produceResultFuture.isCancelled());
@@ -72,7 +76,8 @@ public class ApacheKafkaProducerCallbackTest {
   public void testOnCompletionWithNonNullExceptionShouldCompleteFuture()
       throws ExecutionException, InterruptedException {
     PubSubProducerCallbackSimpleImpl internalCallback = new PubSubProducerCallbackSimpleImpl();
-    ApacheKafkaProducerCallback kafkaProducerCallback = new ApacheKafkaProducerCallback(internalCallback);
+    ApacheKafkaProducerCallback kafkaProducerCallback =
+        new ApacheKafkaProducerCallback(internalCallback, mock(ApacheKafkaProducerAdapter.class));
     Future<PubSubProduceResult> produceResultFuture = kafkaProducerCallback.getProduceResultFuture();
     assertFalse(produceResultFuture.isDone());
     assertFalse(produceResultFuture.isCancelled());


### PR DESCRIPTION

## Skip callback processing on forceful producer closure

When the producer is closed forcefully, we skip the callback processing. Nevertheless, we  
ensure that any future returned by the producer to the caller is completed, either normally  
or exceptionally.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.