### PR TITLE
[admin-tool][data-recovery] Added handling for batch stores during store repush.

### DIFF
--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/datarecovery/Command.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/datarecovery/Command.java
@@ -1,11 +1,20 @@
 package com.linkedin.venice.datarecovery;
 
+import com.linkedin.venice.controllerapi.ControllerClient;
+import com.linkedin.venice.security.SSLFactory;
+import java.util.Optional;
+
+
 public abstract class Command {
   public abstract void execute();
 
   public abstract Result getResult();
 
   public abstract boolean needWaitForFirstTaskToComplete();
+
+  public ControllerClient buildControllerClient(String clusterName, String url, Optional<SSLFactory> sslFactory) {
+    return new ControllerClient(clusterName, url, sslFactory);
+  }
 
   public abstract static class Params {
     // Store name.

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/datarecovery/Command.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/datarecovery/Command.java
@@ -21,10 +21,10 @@ public abstract class Command {
   }
 
   public abstract static class Result {
-    private String cluster;
-    private String store;
-    protected String error;
-    protected String message;
+    private String cluster = null;
+    private String store = null;
+    protected String error = null;
+    protected String message = null;
 
     // isCoreWorkDone indicates if the core task is finished when an interval is specified.
     protected boolean isCoreWorkDone = false;

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/datarecovery/DataRecoveryClient.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/datarecovery/DataRecoveryClient.java
@@ -2,6 +2,7 @@ package com.linkedin.venice.datarecovery;
 
 import static com.linkedin.venice.datarecovery.DataRecoveryWorker.INTERVAL_UNSET;
 
+import com.linkedin.venice.datarecovery.meta.RepushViabilityInfo;
 import java.util.Scanner;
 import java.util.Set;
 import org.apache.logging.log4j.LogManager;
@@ -59,7 +60,15 @@ public class DataRecoveryClient {
     for (DataRecoveryTask t: getExecutor().getTasks()) {
       StoreRepushCommand cmd = (StoreRepushCommand) t.getCommand();
       if (cmd.getResult().isError()) {
-        LOGGER.info("Store " + t.getTaskParams().getStore() + " skipped: " + t.getTaskResult().getError());
+        if (cmd.getViabilityResult() != RepushViabilityInfo.Result.SUCCESS) {
+          // unsuccessful viability check
+          LOGGER.info("Store " + t.getTaskParams().getStore() + " skipped: " + cmd.getViabilityResult().toString());
+        } else {
+          // successful viability check, error in execution
+          LOGGER.info(
+              "Store " + t.getTaskParams().getStore() + " encountered an error during execution: "
+                  + cmd.getResult().getError());
+        }
       }
     }
 

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/datarecovery/DataRecoveryClient.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/datarecovery/DataRecoveryClient.java
@@ -3,22 +3,10 @@ package com.linkedin.venice.datarecovery;
 import static com.linkedin.venice.datarecovery.DataRecoveryWorker.INTERVAL_UNSET;
 
 import com.linkedin.venice.controllerapi.ControllerClient;
-import com.linkedin.venice.controllerapi.MultiStoreStatusResponse;
-import com.linkedin.venice.controllerapi.StoreHealthAuditResponse;
-import com.linkedin.venice.exceptions.VeniceException;
-import com.linkedin.venice.meta.RegionPushDetails;
-import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.security.SSLFactory;
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
 import java.util.Optional;
 import java.util.Scanner;
 import java.util.Set;
-import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.tuple.Pair;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -59,60 +47,6 @@ public class DataRecoveryClient {
     return monitor;
   }
 
-  public Map<String, Pair<Boolean, String>> getRepushViability(
-      Set<String> storesList,
-      StoreRepushCommand.Params params) {
-    Map<String, Pair<Boolean, String>> ret = new HashMap<>();
-    String url = params.getUrl();
-    ControllerClient cli = params.getPCtrlCliWithoutCluster();
-    LocalDateTime timestamp = params.getTimestamp();
-    String destFabric = params.getDestFabric();
-    for (String s: storesList) {
-      try {
-        String clusterName = cli.discoverCluster(s).getCluster();
-        if (clusterName == null) {
-          ret.put(s, Pair.of(false, "unable to discover cluster for store (likely invalid store name)"));
-          continue;
-        }
-        try (ControllerClient parentCtrlCli = buildControllerClient(clusterName, url, params.getSSLFactory())) {
-          StoreHealthAuditResponse storeHealthInfo = parentCtrlCli.listStorePushInfo(s, false);
-          Map<String, RegionPushDetails> regionPushDetails = storeHealthInfo.getRegionPushDetails();
-          if (!regionPushDetails.containsKey(destFabric)) {
-            ret.put(s, Pair.of(false, "nothing to repush, store version 0"));
-            continue;
-          }
-          String latestTimestamp = regionPushDetails.get(destFabric).getPushStartTimestamp();
-          LocalDateTime latestPushStartTime =
-              LocalDateTime.parse(latestTimestamp, DateTimeFormatter.ISO_LOCAL_DATE_TIME);
-
-          if (latestPushStartTime.isAfter(timestamp)) {
-            ret.put(s, Pair.of(false, "input timestamp earlier than latest push"));
-            continue;
-          }
-
-          MultiStoreStatusResponse response = parentCtrlCli.getFutureVersions(clusterName, s);
-          // No future version status for target region.
-          if (!response.getStoreStatusMap().containsKey(destFabric)) {
-            ret.put(s, Pair.of(true, StringUtils.EMPTY));
-            continue;
-          }
-
-          int futureVersion = Integer.parseInt(response.getStoreStatusMap().get(destFabric));
-          // No ongoing offline pushes detected for target region.
-          if (futureVersion == Store.NON_EXISTING_VERSION) {
-            ret.put(s, Pair.of(true, StringUtils.EMPTY));
-            continue;
-          }
-          // Find ongoing pushes for this store, skip.
-          ret.put(s, Pair.of(false, String.format("find ongoing push, version: %d", futureVersion)));
-        }
-      } catch (VeniceException e) {
-        ret.put(s, Pair.of(false, "VeniceHttpException " + e.getErrorType().toString()));
-      }
-    }
-    return ret;
-  }
-
   public ControllerClient buildControllerClient(String clusterName, String url, Optional<SSLFactory> sslFactory) {
     return new ControllerClient(clusterName, url, sslFactory);
   }
@@ -124,35 +58,18 @@ public class DataRecoveryClient {
       return;
     }
 
-    Map<String, Pair<Boolean, String>> pushMap = getRepushViability(storeNames, cmdParams);
-    Set<String> filteredStoreNames = new HashSet<>();
+    if (!drParams.isNonInteractive && !confirmStores(storeNames)) {
+      return;
+    }
+    getExecutor().perform(storeNames, cmdParams);
 
-    for (Map.Entry<String, Pair<Boolean, String>> e: pushMap.entrySet()) {
-      if (e.getValue().getLeft()) {
-        filteredStoreNames.add(e.getKey());
-      } else {
-        this.getExecutor().getSkippedStores().add(e.getKey());
+    for (DataRecoveryTask t: getExecutor().getTasks()) {
+      StoreRepushCommand cmd = (StoreRepushCommand) t.getCommand();
+      if (cmd.getResult().isError()) {
+        LOGGER.info("Store " + t.getTaskParams().getStore() + " skipped: " + t.getTaskResult().getError());
       }
     }
 
-    if (!filteredStoreNames.isEmpty()) {
-      if (!drParams.isNonInteractive && !confirmStores(filteredStoreNames)) {
-        return;
-      }
-      getExecutor().perform(filteredStoreNames, cmdParams);
-    } else {
-      LOGGER.warn("store list is empty, exit.");
-    }
-
-    // check if we filtered stores based on push info, report them
-    if (getExecutor().getSkippedStores().size() > 0) {
-      LOGGER.info("================");
-      LOGGER.info("STORES STORES WERE SKIPPED:");
-      for (String store: getExecutor().getSkippedStores()) {
-        LOGGER.info(store + " : " + pushMap.get(store).getRight());
-      }
-      LOGGER.info("================");
-    }
     getExecutor().shutdownAndAwaitTermination();
   }
 

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/datarecovery/DataRecoveryClient.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/datarecovery/DataRecoveryClient.java
@@ -2,9 +2,6 @@ package com.linkedin.venice.datarecovery;
 
 import static com.linkedin.venice.datarecovery.DataRecoveryWorker.INTERVAL_UNSET;
 
-import com.linkedin.venice.controllerapi.ControllerClient;
-import com.linkedin.venice.security.SSLFactory;
-import java.util.Optional;
 import java.util.Scanner;
 import java.util.Set;
 import org.apache.logging.log4j.LogManager;
@@ -45,10 +42,6 @@ public class DataRecoveryClient {
 
   public DataRecoveryMonitor getMonitor() {
     return monitor;
-  }
-
-  public ControllerClient buildControllerClient(String clusterName, String url, Optional<SSLFactory> sslFactory) {
-    return new ControllerClient(clusterName, url, sslFactory);
   }
 
   public void execute(DataRecoveryParams drParams, StoreRepushCommand.Params cmdParams) {

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/datarecovery/DataRecoveryExecutor.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/datarecovery/DataRecoveryExecutor.java
@@ -1,7 +1,6 @@
 package com.linkedin.venice.datarecovery;
 
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import org.apache.logging.log4j.LogManager;
@@ -13,11 +12,9 @@ import org.apache.logging.log4j.Logger;
  */
 public class DataRecoveryExecutor extends DataRecoveryWorker {
   private final Logger LOGGER = LogManager.getLogger(DataRecoveryExecutor.class);
-  private Set<String> skippedStores;
 
   public DataRecoveryExecutor() {
     super();
-    this.skippedStores = new HashSet<>();
   }
 
   @Override
@@ -32,12 +29,6 @@ public class DataRecoveryExecutor extends DataRecoveryWorker {
       tasks.add(new DataRecoveryTask(new StoreRepushCommand(p), taskParams));
     }
     return tasks;
-  }
-
-  // for testing
-
-  public Set<String> getSkippedStores() {
-    return skippedStores;
   }
 
   @Override

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/datarecovery/DataRecoveryTask.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/datarecovery/DataRecoveryTask.java
@@ -16,7 +16,7 @@ public class DataRecoveryTask implements Runnable {
   @Override
   public void run() {
     command.execute();
-    taskResult = new DataRecoveryTask.TaskResult(command.getResult());
+    taskResult = new DataRecoveryTask.TaskResult(getCommand().getResult());
   }
 
   /**
@@ -29,6 +29,10 @@ public class DataRecoveryTask implements Runnable {
 
   public TaskResult getTaskResult() {
     return taskResult;
+  }
+
+  public Command getCommand() {
+    return command;
   }
 
   public TaskParams getTaskParams() {

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/datarecovery/EstimateDataRecoveryTimeCommand.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/datarecovery/EstimateDataRecoveryTimeCommand.java
@@ -45,13 +45,6 @@ public class EstimateDataRecoveryTimeCommand extends Command {
     this.result = result;
   }
 
-  public ControllerClient buildControllerClient(
-      String clusterName,
-      String discoveryUrls,
-      Optional<SSLFactory> sslFactory) {
-    return new ControllerClient(clusterName, discoveryUrls, sslFactory);
-  }
-
   @Override
   public void execute() {
     // get store's push + partition info

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/datarecovery/MonitorCommand.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/datarecovery/MonitorCommand.java
@@ -161,13 +161,6 @@ public class MonitorCommand extends Command {
     result.setCoreWorkDone(true);
   }
 
-  public ControllerClient buildControllerClient(
-      String clusterName,
-      String discoveryUrls,
-      Optional<SSLFactory> sslFactory) {
-    return new ControllerClient(clusterName, discoveryUrls, sslFactory);
-  }
-
   public static class Params extends Command.Params {
     // Target region.
     private String targetRegion;

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/datarecovery/StoreRepushCommand.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/datarecovery/StoreRepushCommand.java
@@ -168,7 +168,7 @@ public class StoreRepushCommand extends Command {
         // Find ongoing pushes for this store, skip.
         return Pair.of(false, String.format("find ongoing push, version: %d", futureVersion));
       }
-    } catch (Exception e) {
+    } catch (VeniceException e) {
       return Pair.of(false, "Exception Thrown: " + e.toString());
     }
   }

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/datarecovery/StoreRepushCommand.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/datarecovery/StoreRepushCommand.java
@@ -197,6 +197,7 @@ public class StoreRepushCommand extends Command {
               Optional.empty());
           if (prepareResponse.isError()) {
             completeCoreWorkWithError("failure: " + prepareResponse.getError());
+            return;
           }
           ControllerResponse dataRecoveryResponse = parentCtrlCli.dataRecovery(
               repushParams.getSourceFabric(),
@@ -208,6 +209,7 @@ public class StoreRepushCommand extends Command {
               Optional.empty());
           if (dataRecoveryResponse.isError()) {
             completeCoreWorkWithError("failure: " + dataRecoveryResponse.getError());
+            return;
           }
           completeCoreWorkWithMessage("success: (batch store -- no url)");
         }

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/datarecovery/StoreRepushCommand.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/datarecovery/StoreRepushCommand.java
@@ -182,7 +182,7 @@ public class StoreRepushCommand extends Command {
       completeCoreWorkWithError("failure: " + repushViability.getRight());
       return;
     }
-    if (repushViability.getRight() == "BATCH") {
+    if (repushViability.getRight().equals("BATCH")) {
       try {
         String clusterName = cli.discoverCluster(repushParams.getStore()).getCluster();
         try (ControllerClient parentCtrlCli =

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/datarecovery/StoreRepushCommand.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/datarecovery/StoreRepushCommand.java
@@ -180,11 +180,11 @@ public class StoreRepushCommand extends Command {
     this.repushViabilityResult = repushViability.getResult();
     StoreRepushCommand.Params repushParams = getParams();
     ControllerClient cli = repushParams.getPCtrlCliWithoutCluster();
-    if (repushViability.isViable() == false) {
+    if (!repushViability.isViable()) {
       completeCoreWorkWithError("failure: " + repushViability.getResult().toString());
       return;
     }
-    if (repushViability.isHybrid() == false) {
+    if (!repushViability.isHybrid()) {
       try {
         String clusterName = cli.discoverCluster(repushParams.getStore()).getCluster();
         try (ControllerClient parentCtrlCli =

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/datarecovery/meta/RepushViabilityInfo.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/datarecovery/meta/RepushViabilityInfo.java
@@ -1,0 +1,53 @@
+package com.linkedin.venice.datarecovery.meta;
+
+public class RepushViabilityInfo {
+  private boolean isHybrid;
+  private boolean isViable;
+  private RepushViabilityInfo.Result result;
+
+  public RepushViabilityInfo() {
+    setHybrid(false);
+    setViable(false);
+    setResult(Result.NOT_STARTED);
+  }
+
+  public boolean isHybrid() {
+    return isHybrid;
+  }
+
+  public void setHybrid(boolean hybrid) {
+    isHybrid = hybrid;
+  }
+
+  public boolean isViable() {
+    return isViable;
+  }
+
+  public void setViable(boolean viable) {
+    isViable = viable;
+  }
+
+  public Result getResult() {
+    return result;
+  }
+
+  public void setResult(Result result) {
+    this.result = result;
+  }
+
+  public RepushViabilityInfo succeedWithResult(Result result) {
+    setResult(result);
+    setViable(true);
+    return this;
+  }
+
+  public RepushViabilityInfo failWithResult(Result result) {
+    setResult(result);
+    setViable(false);
+    return this;
+  }
+
+  public enum Result {
+    NOT_STARTED, SUCCESS, DISCOVERY_ERROR, NO_FUTURE_VERSION, TIMESTAMP_MISMATCH, ONGOING_PUSH, EXCEPTION_THROWN
+  }
+}


### PR DESCRIPTION
## Summary
This set of changes adds additional logic for handling batch stores during a repush request. Additionally, this commit moves some functionality for determining whether or not a store can be repushed to the task execution level, parallelizing a previously introduced single-threaded linear check.

## How was this PR tested?
Tested on a couple EI stores.

```
$ java -jar venice-admin-tool-all.jar --execute-data-recovery --recovery-command venice-tools --stores akozma_test_store_EI,HB_VPJtarget_ei-venice-0,cert-histogram-dataset-copy --source-fabric ei-ltx1 --dest-fabric ei-ltx1 --extra-command-args 'repush kafka --force --format' --datetime "2023-07-24T20:00:00" --url "http://ltx1-app5774.stg.linkedin.com:1576"
2023-07-19 14:14:36 INFO [DataRecoveryExecutor] [main] [store: akozma_test_store_EI, status: started, message: failure: find ongoing push, version: 5]
2023-07-19 14:14:36 INFO [DataRecoveryExecutor] [main] [store: cert-histogram-dataset-copy, status: started, message: failure: find ongoing push, version: 20]
2023-07-19 14:14:36 INFO [DataRecoveryExecutor] [main] [store: HB_VPJtarget_ei-venice-0, status: started, message: failure: find ongoing push, version: 17085]
2023-07-19 14:14:36 INFO [DataRecoveryExecutor] [main] [store: akozma_test_store_EI, status: started, message: failure: find ongoing push, version: 5]
2023-07-19 14:14:36 INFO [DataRecoveryWorker] [main] Total: 3, Succeeded: 3, Error: 0, Uncompleted: 0
```

## Does this PR introduce any user-facing changes?
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.

I am opening this one and closing PR # 529 ( https://github.com/linkedin/venice/pull/529 )