### PR TITLE
[controller] Partial update only allows nullable union pair

### DIFF
--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/schema/rmd/v1/RmdSchemaGeneratorV1.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/schema/rmd/v1/RmdSchemaGeneratorV1.java
@@ -15,7 +15,7 @@ import org.apache.avro.Schema;
 
 
 /**
- * This class helps in generating a active-active metadata schema to hold update timestamps and offsets from a value schema of a store .
+ * This class helps in generating an active-active metadata schema to hold update timestamps and offsets from a value schema of a store.
  *
  * If the value schema is a RECORD then the generated schema will be a RECORD having a UNION field and an array. The UNION will consists
  *   of 1 record to hold a single timestamp field for the entire record. This timestamp indicates when the full record was last update as a whole.
@@ -27,7 +27,7 @@ import org.apache.avro.Schema;
  * If the value schema is not RECORD then the generated schema will be a RECORD to hold a single timestamp field, and the same offset array.
  *   This timestamp indicates when the full record was last update as a whole.
  *
- * Currently nested fields are not supported.
+ * Currently, nested fields are not supported.
  */
 
 public class RmdSchemaGeneratorV1 {

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/schema/TestSchemaUtils.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/schema/TestSchemaUtils.java
@@ -40,6 +40,23 @@ public class TestSchemaUtils {
   private static final String MAP_FIELD_NAME = "IntMapField";
   private static final String NULLABLE_LIST_FIELD_NAME = "NullableStringListField";
   private static final String NULLABLE_MAP_FIELD_NAME = "NullableIntMapField";
+  private static final Schema UNION_VALUE_SCHEMA =
+      AvroSchemaParseUtils.parseSchemaFromJSONStrictValidation(loadSchemaFileAsString("testUnionSchema.avsc"));
+
+  @Test
+  public void testUnionSchemaForPartialUpdate() {
+    Assert.assertTrue(
+        SchemaUtils.isCollectionUnionSchema(UNION_VALUE_SCHEMA.getField("goodNullableCollectionField").schema()));
+    Assert.assertFalse(SchemaUtils.isCollectionUnionSchema(UNION_VALUE_SCHEMA.getField("goodRegularField").schema()));
+    // Union with single type
+    Assert.assertThrows(() -> SchemaUtils.isCollectionUnionSchema(UNION_VALUE_SCHEMA.getField("singleType").schema()));
+    // Union with a regular field and a collection field
+    Assert.assertThrows(() -> SchemaUtils.isCollectionUnionSchema(UNION_VALUE_SCHEMA.getField("mixedType1").schema()));
+    // Union with 2 collection fields
+    Assert.assertThrows(() -> SchemaUtils.isCollectionUnionSchema(UNION_VALUE_SCHEMA.getField("mixedType2").schema()));
+    // Union with 3 fields
+    Assert.assertThrows(() -> SchemaUtils.isCollectionUnionSchema(UNION_VALUE_SCHEMA.getField("mixedType3").schema()));
+  }
 
   @Test
   public void testAnnotateValueSchema() {

--- a/internal/venice-client-common/src/test/resources/testUnionSchema.avsc
+++ b/internal/venice-client-common/src/test/resources/testUnionSchema.avsc
@@ -1,0 +1,76 @@
+{
+  "type": "record",
+  "namespace": "com.linkedin.avro",
+  "name": "TestRecord",
+  "fields": [
+    {
+      "name": "goodNullableCollectionField",
+      "type": [
+        "null",
+        {
+          "type": "array",
+          "items": "string"
+        }
+      ],
+      "default": null
+    },
+    {
+      "name": "goodRegularField",
+      "type": [
+        "null",
+        "string"
+      ],
+      "default": null
+    },
+    {
+      "name": "singleType",
+      "type": [
+        {
+          "type": "array",
+          "items": "string"
+        }
+      ],
+      "default": []
+    },
+    {
+      "name": "mixedType1",
+      "type": [
+        "string",
+        {
+          "type": "array",
+          "items": "string"
+        }
+      ],
+      "default": ""
+    },
+    {
+      "name": "mixedType2",
+      "type": [
+        {
+          "type": "map",
+          "values": "int"
+        },
+        {
+          "type": "array",
+          "items": "string"
+        }
+      ],
+      "default": {}
+    },
+    {
+      "name": "mixedType3",
+      "type": [
+        "null",
+        {
+          "type": "map",
+          "values": "int"
+        },
+        {
+          "type": "array",
+          "items": "string"
+        }
+      ],
+      "default": null
+    }
+  ]
+}


### PR DESCRIPTION
## [controller] Partial update only allows nullable union pair

This PR adds restriction on the UNION field for partial update schema generation.
Previously, any union type can be enabled partial update, except for multiple collection field scenario.
A/A requires null-value pair of union field:
1. [null, regular field] => long RMD timestamp
2. [null, collection field] => complex record RMD timestamp tracking each element in the collection
3. other => not supported, throw exception during schema generation.

In the future, all new hybrid store will by default enable A/A replication, it is good to align the requirement for UNION here so that all partial update stores can transition into A/A replication smoothly.

## How was this PR tested?
new unit test

## Does this PR introduce any user-facing changes?
User won't be able to enable partial update on store schema that contains union field that is not a null-value pair.
This is also the requirement from A/A replication and we are aligning it to make sure they will have a smooth transition into A/A replication.
- [ ] No. You can skip the rest of this section.
- [x] Yes. Make sure to explain your proposed changes and call out the behavior change.