### PR TITLE
[server][dvc][tc] Avro fixes, optimizations and 1.10.2 upgrade

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,7 @@ if (project.hasProperty('overrideBuildEnvironment')) {
   }
 }
 
-def avroVersion = '1.9.2'
+def avroVersion = '1.10.2'
 def avroUtilVersion = '0.2.150'
 def grpcVersion = '1.54.1'
 def kafkaGroup = 'com.linkedin.kafka'

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/VersionBackend.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/VersionBackend.java
@@ -236,6 +236,7 @@ public class VersionBackend {
     return ComputeUtils.computeResult(
         computeRequestWrapper.getComputeRequestVersion(),
         computeRequestWrapper.getOperations(),
+        computeRequestWrapper.getOperationResultFields(),
         sharedContext,
         reusableValueRecord,
         computeResultSchema);
@@ -260,6 +261,7 @@ public class VersionBackend {
             GenericRecord computeResult = ComputeUtils.computeResult(
                 computeRequestWrapper.getComputeRequestVersion(),
                 computeRequestWrapper.getOperations(),
+                computeRequestWrapper.getOperationResultFields(),
                 sharedContext,
                 value,
                 computeResultSchema);

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/client/AvroGenericDaVinciClient.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/client/AvroGenericDaVinciClient.java
@@ -430,6 +430,7 @@ public class AvroGenericDaVinciClient<K, V> implements DaVinciClient<K, V>, Avro
 
       Map<String, Object> globalContext = new HashMap<>();
       Schema computeResultSchema = getComputeResultSchema(computeRequestWrapper);
+      computeRequestWrapper.initializeOperationResultFields(computeResultSchema);
 
       int readerSchemaId = versionBackend.getSupersetOrLatestValueSchemaId();
       for (K key: keys) {
@@ -504,6 +505,7 @@ public class AvroGenericDaVinciClient<K, V> implements DaVinciClient<K, V>, Avro
 
       Map<String, Object> globalContext = new HashMap<>();
       Schema computeResultSchema = getComputeResultSchema(computeRequestWrapper);
+      computeRequestWrapper.initializeOperationResultFields(computeResultSchema);
 
       int partitionCount = versionBackend.getPartitionCount();
       for (int currPartition = 0; currPartition < partitionCount; currPartition++) {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/listener/response/ReadResponse.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/listener/response/ReadResponse.java
@@ -112,20 +112,20 @@ public abstract class ReadResponse {
     return readComputeOutputSize;
   }
 
-  public void incrementDotProductCount() {
-    dotProductCount++;
+  public void incrementDotProductCount(int count) {
+    dotProductCount += count;
   }
 
-  public void incrementCountOperatorCount() {
-    countOperatorCount++;
+  public void incrementCountOperatorCount(int count) {
+    countOperatorCount += count;
   }
 
-  public void incrementCosineSimilarityCount() {
-    cosineSimilarityCount++;
+  public void incrementCosineSimilarityCount(int count) {
+    cosineSimilarityCount += count;
   }
 
-  public void incrementHadamardProductCount() {
-    hadamardProductCount++;
+  public void incrementHadamardProductCount(int count) {
+    hadamardProductCount += count;
   }
 
   public double getReadComputeSerializationLatency() {

--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/AbstractAvroStoreClient.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/AbstractAvroStoreClient.java
@@ -635,6 +635,7 @@ public abstract class AbstractAvroStoreClient<K, V> extends InternalAvroStoreCli
       return;
     }
 
+    computeRequest.initializeOperationResultFields(resultSchema);
     ClientComputeRecordStreamDecoder.Callback<K, GenericRecord> decoderCallback =
         new ClientComputeRecordStreamDecoder.Callback<K, GenericRecord>(
             DelegatingTrackingCallback.wrap((StreamingCallback) callback)) {
@@ -646,6 +647,7 @@ public abstract class AbstractAvroStoreClient<K, V> extends InternalAvroStoreCli
               value = ComputeUtils.computeResult(
                   computeRequest.getComputeRequestVersion(),
                   computeRequest.getOperations(),
+                  computeRequest.getOperationResultFields(),
                   sharedContext,
                   value,
                   resultSchema);

--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/predicate/EqualsRelationalOperator.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/predicate/EqualsRelationalOperator.java
@@ -3,6 +3,7 @@ package com.linkedin.venice.client.store.predicate;
 import com.linkedin.venice.annotation.Experimental;
 import com.linkedin.venice.client.exceptions.VeniceClientException;
 import java.util.Objects;
+import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericRecord;
 
 
@@ -23,7 +24,11 @@ public class EqualsRelationalOperator implements Predicate {
     if (dataRecord == null) {
       return false;
     } else {
-      return Objects.deepEquals(dataRecord.get(fieldName), expectedValue);
+      Schema.Field field = dataRecord.getSchema().getField(fieldName);
+      if (field == null) {
+        return this.expectedValue == null;
+      }
+      return Objects.deepEquals(dataRecord.get(field.pos()), expectedValue);
     }
   }
 

--- a/internal/venice-avro-compatibility-test/build.gradle
+++ b/internal/venice-avro-compatibility-test/build.gradle
@@ -14,7 +14,7 @@ def AVRO_1_6 = 'org.apache.avro:avro:1.6.3'
 def AVRO_1_7 = 'org.apache.avro:avro:1.7.7'
 def AVRO_1_8 = 'org.apache.avro:avro:1.8.2'
 def AVRO_1_9 = 'org.apache.avro:avro:1.9.2'
-def AVRO_1_10 = 'org.apache.avro:avro:1.10.0'
+def AVRO_1_10 = 'org.apache.avro:avro:1.10.2'
 
 dependencies {
   testImplementation project(':clients:da-vinci-client')

--- a/internal/venice-avro-compatibility-test/src/test/java/com/linkedin/venice/VeniceClusterInitializer.java
+++ b/internal/venice-avro-compatibility-test/src/test/java/com/linkedin/venice/VeniceClusterInitializer.java
@@ -233,7 +233,7 @@ public class VeniceClusterInitializer implements Closeable {
    */
   public static void main(String[] args) {
     LOGGER.info("Avro version in VeniceClusterInitializer: {}", AvroCompatibilityHelperCommon.getRuntimeAvroVersion());
-    Assert.assertEquals(AvroCompatibilityHelperCommon.getRuntimeAvroVersion(), AvroVersion.AVRO_1_9);
+    Assert.assertEquals(AvroCompatibilityHelperCommon.getRuntimeAvroVersion(), AvroVersion.AVRO_1_10);
     Assert.assertEquals(args.length, 2, "Store name and router port arguments are expected");
 
     String storeName = args[0];

--- a/internal/venice-avro-compatibility-test/src/test/java/com/linkedin/venice/utils/ClassPathSupplierForVeniceCluster.java
+++ b/internal/venice-avro-compatibility-test/src/test/java/com/linkedin/venice/utils/ClassPathSupplierForVeniceCluster.java
@@ -23,7 +23,7 @@ import org.apache.logging.log4j.Logger;
 public class ClassPathSupplierForVeniceCluster implements Supplier<String> {
   private static final Logger LOGGER = LogManager.getLogger(ClassPathSupplierForVeniceCluster.class);
 
-  private static final String AVRO_192_JAR_FILE = "avro-1.9.2.jar";
+  private static final String AVRO_JAR_FILE = "avro-1.10.2.jar";
 
   @Override
   public String get() {
@@ -67,7 +67,7 @@ public class ClassPathSupplierForVeniceCluster implements Supplier<String> {
 
   private File extractAvro192JarFileBasedOnExistingAvroJarFile(File existingAvroJarFile) {
     LOGGER.info("Existing avro jar file: {}", existingAvroJarFile.getAbsolutePath());
-    if (existingAvroJarFile.getName().equals(AVRO_192_JAR_FILE)) {
+    if (existingAvroJarFile.getName().equals(AVRO_JAR_FILE)) {
       return existingAvroJarFile;
     }
     /**
@@ -79,11 +79,11 @@ public class ClassPathSupplierForVeniceCluster implements Supplier<String> {
     File avroRootDir = existingAvroJarFile.getParentFile().getParentFile().getParentFile();
     Collection<File> jarFiles = FileUtils.listFiles(avroRootDir, new String[] { "jar" }, true);
     for (File jarFile: jarFiles) {
-      if (jarFile.getName().equals(AVRO_192_JAR_FILE)) {
-        LOGGER.info("Found the jar file: {} for {}", jarFile.getAbsolutePath(), AVRO_192_JAR_FILE);
+      if (jarFile.getName().equals(AVRO_JAR_FILE)) {
+        LOGGER.info("Found the jar file: {} for {}", jarFile.getAbsolutePath(), AVRO_JAR_FILE);
         return jarFile;
       }
     }
-    throw new VeniceException("Failed to find out " + AVRO_192_JAR_FILE + " in the existing class path");
+    throw new VeniceException("Failed to find out " + AVRO_JAR_FILE + " in the existing class path");
   }
 }

--- a/internal/venice-avro-compatibility-test/src/test/java/com/linkedin/venice/utils/ClassPathSupplierForVeniceCluster.java
+++ b/internal/venice-avro-compatibility-test/src/test/java/com/linkedin/venice/utils/ClassPathSupplierForVeniceCluster.java
@@ -17,8 +17,8 @@ import org.apache.logging.log4j.Logger;
 
 
 /**
- * This utility is used to remove the existing Avro jars and prepend avro-1.9 to make sure the Venice Cluster
- * is always using avro-1.9.
+ * This utility is used to remove the existing Avro jars and prepend a specific Avro jar version to the classpath,
+ * to control which version the Venice Cluster will use. The version used is controlled by {@link #AVRO_JAR_FILE}.
  */
 public class ClassPathSupplierForVeniceCluster implements Supplier<String> {
   private static final Logger LOGGER = LogManager.getLogger(ClassPathSupplierForVeniceCluster.class);
@@ -54,10 +54,7 @@ public class ClassPathSupplierForVeniceCluster implements Supplier<String> {
         if (existingAvroJarFile == null) {
           throw new VeniceException("There should be some existing Avro lib in the class path");
         }
-        /**
-         * Append avro-1.9 jar to the classpath, which is the one being used by the backend.
-         */
-        paths.add(extractAvro192JarFileBasedOnExistingAvroJarFile(existingAvroJarFile));
+        paths.add(extractAvroJarFileBasedOnExistingAvroJarFile(existingAvroJarFile));
       } catch (Exception e) {
         throw new VeniceException("Failed to compose class path", e);
       }
@@ -65,7 +62,10 @@ public class ClassPathSupplierForVeniceCluster implements Supplier<String> {
     }
   }
 
-  private File extractAvro192JarFileBasedOnExistingAvroJarFile(File existingAvroJarFile) {
+  /**
+   * Append {@link #AVRO_JAR_FILE} to the classpath, which is the one being used by the backend.
+   */
+  private File extractAvroJarFileBasedOnExistingAvroJarFile(File existingAvroJarFile) {
     LOGGER.info("Existing avro jar file: {}", existingAvroJarFile.getAbsolutePath());
     if (existingAvroJarFile.getName().equals(AVRO_JAR_FILE)) {
       return existingAvroJarFile;
@@ -74,7 +74,7 @@ public class ClassPathSupplierForVeniceCluster implements Supplier<String> {
      * The file path should be in the following way:
      * .../org.apache.avro/avro/1.4.1/3548c0bc136e71006f3fc34e22d34a29e5069e50/avro-1.4.1.jar
      * And the target file should be here:
-     * /org.apache.avro/avro/1.9.2/.../avro-1.9.2.jar
+     * /org.apache.avro/avro/1.10.2/.../avro-1.10.2.jar
      */
     File avroRootDir = existingAvroJarFile.getParentFile().getParentFile().getParentFile();
     Collection<File> jarFiles = FileUtils.listFiles(avroRootDir, new String[] { "jar" }, true);

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/compute/ComputeUtils.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/compute/ComputeUtils.java
@@ -17,7 +17,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -245,20 +244,20 @@ public class ComputeUtils {
   /**
    *
    * @param record the record from which the value of the given field is extracted
-   * @param fieldName name of the file which is used to extract the value from the given record
+   * @param field field which is used to extract the value from the given record
    * @param <T> Type of the list element to cast the extracted value to
    *
    * @return An unmodifiable empty list if the extracted value is null. Otherwise return a list that may or may not be
    *         modifiable depending on specified type of the list as a field in the record.
    */
-  public static <T> List<T> getNullableFieldValueAsList(final GenericRecord record, final String fieldName) {
-    Object value = record.get(fieldName);
+  public static <T> List<T> getNullableFieldValueAsList(final GenericRecord record, Schema.Field field) {
+    Object value = record.get(field.pos());
     if (value == null) {
       return Collections.emptyList();
     }
     if (!(value instanceof List)) {
       throw new IllegalArgumentException(
-          String.format("Field %s in the record is not of the type list. Value: %s", fieldName, record));
+          String.format("Field %s in the record is not of the type list. Value: %s", field.name(), record));
     }
     return (List<T>) value;
   }
@@ -266,27 +265,26 @@ public class ComputeUtils {
   /**
    * @return Error message if the nullable field validation failed or Optional.empty() otherwise.
    */
-  public static Optional<String> validateNullableFieldAndGetErrorMsg(
+  public static String validateNullableFieldAndGetErrorMsg(
       ReadComputeOperator operator,
       GenericRecord valueRecord,
+      Schema.Field operatorField,
       String operatorFieldName) {
-    if (valueRecord.get(operatorFieldName) != null) {
-      return Optional.empty();
+    if (operatorField == null) {
+      return "Failed to execute compute request as the field " + operatorFieldName
+          + " does not exist in the value record. " + "Fields present in the value record are: "
+          + getStringOfSchemaFieldNames(valueRecord);
     }
-    if (valueRecord.getSchema().getField(operatorFieldName) == null) {
-      return Optional.of(
-          "Failed to execute compute request as the field " + operatorFieldName
-              + " does not exist in the value record. " + "Fields present in the value record are: "
-              + getStringOfSchemaFieldNames(valueRecord));
+    if (valueRecord.get(operatorField.pos()) != null) {
+      return null;
     }
 
     // Field exist and the value is null. That means the field is nullable.
     if (operator.allowFieldValueToBeNull()) {
-      return Optional.empty();
+      return null;
     }
-    return Optional.of(
-        "Failed to execute compute request as the field " + operatorFieldName + " is not allowed to be null for "
-            + operator + " in value record.");
+    return "Failed to execute compute request as the field " + operatorFieldName + " is not allowed to be null for "
+        + operator + " in value record.";
   }
 
   private static String getStringOfSchemaFieldNames(GenericRecord valueRecord) {
@@ -298,15 +296,23 @@ public class ComputeUtils {
   public static GenericRecord computeResult(
       int computeVersion,
       List<ComputeOperation> operations,
+      List<Schema.Field> operationResultFields,
       Map<String, Object> sharedContext,
       GenericRecord inputRecord,
       Schema outputSchema) {
-    return computeResult(computeVersion, operations, sharedContext, inputRecord, new GenericData.Record(outputSchema));
+    return computeResult(
+        computeVersion,
+        operations,
+        operationResultFields,
+        sharedContext,
+        inputRecord,
+        new GenericData.Record(outputSchema));
   }
 
   public static GenericRecord computeResult(
       int computeVersion,
       List<ComputeOperation> operations,
+      List<Schema.Field> operationResultFields,
       Map<String, Object> sharedContext,
       GenericRecord inputRecord,
       GenericRecord outputRecord) {
@@ -315,17 +321,32 @@ public class ComputeUtils {
     }
 
     Map<String, String> errorMap = new HashMap<>();
-    for (ComputeOperation computeOperation: operations) {
-      ReadComputeOperator operator = ComputeOperationType.valueOf(computeOperation).getOperator();
-      String errorMessage =
-          validateNullableFieldAndGetErrorMsg(operator, inputRecord, operator.getOperatorFieldName(computeOperation))
-              .orElse(null);
+    ComputeOperation computeOperation;
+    ReadComputeOperator operator;
+    String operatorFieldName, errorMessage;
+    Schema.Field operatorField, resultField;
+    for (int i = 0; i < operations.size(); i++) {
+      computeOperation = operations.get(i);
+      operator = ComputeOperationType.valueOf(computeOperation).getOperator();
+      operatorFieldName = operator.getOperatorFieldName(computeOperation);
+      operatorField = inputRecord.getSchema().getField(operatorFieldName);
+      resultField = operationResultFields.get(i);
+      errorMessage = validateNullableFieldAndGetErrorMsg(operator, inputRecord, operatorField, operatorFieldName);
       if (errorMessage != null) {
-        operator.putDefaultResult(outputRecord, operator.getResultFieldName(computeOperation));
+        operator.putDefaultResult(outputRecord, resultField);
         errorMap.put(operator.getResultFieldName(computeOperation), errorMessage);
         continue;
       }
-      operator.compute(computeVersion, computeOperation, inputRecord, outputRecord, errorMap, sharedContext);
+
+      operator.compute(
+          computeVersion,
+          computeOperation,
+          operatorField,
+          resultField,
+          inputRecord,
+          outputRecord,
+          errorMap,
+          sharedContext);
     }
 
     Schema outputSchema = outputRecord.getSchema();
@@ -334,9 +355,19 @@ public class ComputeUtils {
       outputRecord.put(errorMapField.pos(), errorMap);
     }
 
+    Schema.Field inputRecordField;
     for (Schema.Field field: outputSchema.getFields()) {
       if (outputRecord.get(field.pos()) == null) {
-        outputRecord.put(field.pos(), inputRecord.get(field.name()));
+        /**
+         * N.B. Up until Avro 1.9, we could directly do {@code inputRecord.get(field.name())}, and it would work
+         * even if that field name didn't exist in the {@link inputRecord} (merely returning null in that case),
+         * but later versions of Avro throw instead, so we need to get the field and manually check whether it's
+         * null (which is the same work that {@link GenericData.Record#get(String)} would do anyway).
+         */
+        inputRecordField = inputRecord.getSchema().getField(field.name());
+        if (inputRecordField != null) {
+          outputRecord.put(field.pos(), inputRecord.get(inputRecordField.pos()));
+        }
       }
     }
     return outputRecord;

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/compute/ComputeUtils.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/compute/ComputeUtils.java
@@ -263,7 +263,7 @@ public class ComputeUtils {
   }
 
   /**
-   * @return Error message if the nullable field validation failed or Optional.empty() otherwise.
+   * @return Error message if the nullable field validation failed or null otherwise.
    */
   public static String validateNullableFieldAndGetErrorMsg(
       ReadComputeOperator operator,

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/compute/ReadComputeOperator.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/compute/ReadComputeOperator.java
@@ -2,6 +2,7 @@ package com.linkedin.venice.compute;
 
 import com.linkedin.venice.compute.protocol.request.ComputeOperation;
 import java.util.Map;
+import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericRecord;
 
 
@@ -9,16 +10,18 @@ public interface ReadComputeOperator {
   void compute(
       int computeRequestVersion,
       ComputeOperation op,
+      Schema.Field operatorField,
+      Schema.Field resultField,
       GenericRecord valueRecord,
       GenericRecord resultRecord,
       Map<String, String> computationErrorMap,
       Map<String, Object> context);
 
-  default void putResult(GenericRecord record, String field, Object result) {
-    record.put(field, result);
+  default void putResult(GenericRecord record, Schema.Field field, Object result) {
+    record.put(field.pos(), result);
   }
 
-  default void putDefaultResult(GenericRecord record, String field) {
+  default void putDefaultResult(GenericRecord record, Schema.Field field) {
     putResult(record, field, 0.0f);
   }
 

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/compute/protocol/request/enums/ComputeOperationType.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/compute/protocol/request/enums/ComputeOperationType.java
@@ -11,17 +11,17 @@ import com.linkedin.venice.compute.protocol.request.Count;
 import com.linkedin.venice.compute.protocol.request.DotProduct;
 import com.linkedin.venice.compute.protocol.request.HadamardProduct;
 import com.linkedin.venice.exceptions.VeniceException;
-import java.util.HashMap;
-import java.util.Map;
+import com.linkedin.venice.utils.EnumUtils;
+import com.linkedin.venice.utils.VeniceEnumValue;
 
 
-public enum ComputeOperationType {
+public enum ComputeOperationType implements VeniceEnumValue {
   DOT_PRODUCT(0, new DotProductOperator()), COSINE_SIMILARITY(1, new CosineSimilarityOperator()),
   HADAMARD_PRODUCT(2, new HadamardProductOperator()), COUNT(3, new CountOperator());
 
   private final ReadComputeOperator operator;
   private final int value;
-  private static final Map<Integer, ComputeOperationType> OPERATION_TYPE_MAP = getOperationTypeMap();
+  private static final ComputeOperationType[] TYPES_ARRAY = EnumUtils.getEnumValuesArray(ComputeOperationType.class);
 
   ComputeOperationType(int value, ReadComputeOperator operator) {
     this.value = value;
@@ -43,24 +43,16 @@ public enum ComputeOperationType {
     }
   }
 
-  private static ComputeOperationType valueOf(int value) {
-    ComputeOperationType type = OPERATION_TYPE_MAP.get(value);
-    if (type == null) {
+  public static ComputeOperationType valueOf(int value) {
+    try {
+      return TYPES_ARRAY[value];
+    } catch (IndexOutOfBoundsException e) {
       throw new VeniceException("Invalid compute operation type: " + value);
     }
-    return type;
   }
 
   public static ComputeOperationType valueOf(ComputeOperation operation) {
     return valueOf(operation.operationType);
-  }
-
-  private static Map<Integer, ComputeOperationType> getOperationTypeMap() {
-    Map<Integer, ComputeOperationType> intToTypeMap = new HashMap<>();
-    for (ComputeOperationType type: ComputeOperationType.values()) {
-      intToTypeMap.put(type.value, type);
-    }
-    return intToTypeMap;
   }
 
   public int getValue() {

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/compute/ComputeUtilsTest.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/compute/ComputeUtilsTest.java
@@ -1,15 +1,22 @@
 package com.linkedin.venice.compute;
 
-import static org.testng.Assert.assertThrows;
+import static com.linkedin.venice.utils.TestWriteUtils.*;
+import static org.testng.Assert.*;
 
 import com.linkedin.avro.api.PrimitiveFloatList;
 import com.linkedin.avro.fastserde.primitive.PrimitiveFloatArrayList;
+import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
+import com.linkedin.venice.VeniceConstants;
 import com.linkedin.venice.compute.protocol.request.ComputeOperation;
+import com.linkedin.venice.compute.protocol.request.Count;
+import com.linkedin.venice.compute.protocol.request.enums.ComputeOperationType;
+import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import org.apache.avro.Schema;
 import org.apache.avro.SchemaBuilder;
 import org.apache.avro.generic.GenericData;
@@ -20,11 +27,62 @@ import org.testng.annotations.Test;
 
 public class ComputeUtilsTest {
   @Test
+  public void testComputeResult() throws IOException {
+    // Input/output schemas
+    Schema valueSchema = AvroCompatibilityHelper.parse(loadFileAsString("testMergeSchema.avsc"));
+    List<Schema.Field> resultSchemaFields = new ArrayList<>();
+    resultSchemaFields.add(
+        AvroCompatibilityHelper.createSchemaField(
+            "IntMapField",
+            Schema.createMap(Schema.create(Schema.Type.INT)),
+            "doc",
+            new HashMap<>()));
+    resultSchemaFields.add(
+        AvroCompatibilityHelper.createSchemaField("StringListFieldCount", Schema.create(Schema.Type.INT), "doc", -1));
+    resultSchemaFields.add(
+        AvroCompatibilityHelper.createSchemaField(
+            VeniceConstants.VENICE_COMPUTATION_ERROR_MAP_FIELD_NAME,
+            Schema.createMap(Schema.create(Schema.Type.STRING)),
+            "doc",
+            new HashMap<>()));
+    Schema resultSchema = Schema.createRecord("Result", "doc", "com.acme", false, resultSchemaFields);
+
+    // Other boilerplate
+    int computeVersion = 4;
+    List<ComputeOperation> operations = new ArrayList<>();
+    ComputeOperation op1 = new ComputeOperation();
+    op1.setOperationType(ComputeOperationType.COUNT.getValue());
+    Count count = new Count();
+    count.setField("StringListField");
+    count.setResultFieldName("StringListFieldCount");
+    op1.setOperation(count);
+    operations.add(op1);
+    ComputeRequestWrapper computeRequestWrapper = new ComputeRequestWrapper(computeVersion);
+    computeRequestWrapper.setOperations(operations);
+    computeRequestWrapper.initializeOperationResultFields(resultSchema);
+    List<Schema.Field> operationResultFields = computeRequestWrapper.getOperationResultFields();
+    Map<String, Object> sharedContext = new HashMap<>();
+    GenericRecord inputRecord = new GenericData.Record(valueSchema);
+    inputRecord.put("StringListField", new ArrayList<>());
+    GenericRecord outputRecord = new GenericData.Record(resultSchema);
+
+    // Code under test
+    ComputeUtils
+        .computeResult(computeVersion, operations, operationResultFields, sharedContext, inputRecord, outputRecord);
+
+    assertNull(outputRecord.get("IntMapField"));
+    assertEquals(outputRecord.get("StringListFieldCount"), 0);
+    assertTrue(
+        ((Map<String, String>) outputRecord.get(VeniceConstants.VENICE_COMPUTATION_ERROR_MAP_FIELD_NAME)).isEmpty());
+  }
+
+  @Test
   public void testGetNullableFieldValueAsList_NonNullValue() {
     GenericRecord record = createGetNullableFieldValueAsListRecord();
     List<Integer> expectedList = Arrays.asList(1, 2, 3);
     record.put("listField", expectedList);
-    List<Integer> resultList = ComputeUtils.getNullableFieldValueAsList(record, "listField");
+    Schema.Field field = record.getSchema().getField("listField");
+    List<Integer> resultList = ComputeUtils.getNullableFieldValueAsList(record, field);
     Assert.assertEquals(resultList, expectedList);
   }
 
@@ -32,7 +90,8 @@ public class ComputeUtilsTest {
   public void testGetNullableFieldValueAsList_NullValue() {
     GenericRecord record = createGetNullableFieldValueAsListRecord();
     record.put("listField", null);
-    List<Integer> resultList = ComputeUtils.getNullableFieldValueAsList(record, "listField");
+    Schema.Field field = record.getSchema().getField("listField");
+    List<Integer> resultList = ComputeUtils.getNullableFieldValueAsList(record, field);
     Assert.assertEquals(resultList, Collections.emptyList());
   }
 
@@ -40,9 +99,8 @@ public class ComputeUtilsTest {
   public void testGetNullableFieldValueAsList_FieldNotList() {
     GenericRecord record = createGetNullableFieldValueAsListRecord();
     record.put("nonListField", 123);
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> ComputeUtils.getNullableFieldValueAsList(record, "nonListField"));
+    Schema.Field field = record.getSchema().getField("nonListField");
+    assertThrows(IllegalArgumentException.class, () -> ComputeUtils.getNullableFieldValueAsList(record, field));
   }
 
   @Test
@@ -135,8 +193,9 @@ public class ComputeUtilsTest {
         SchemaBuilder.record("SampleSchema").fields().name("field").type().nullable().intType().noDefault().endRecord();
     GenericRecord valueRecord = new GenericData.Record(schema);
 
-    Optional<String> errorMsg = ComputeUtils.validateNullableFieldAndGetErrorMsg(operator, valueRecord, "field");
-    Assert.assertFalse(errorMsg.isPresent());
+    Schema.Field field = valueRecord.getSchema().getField("field");
+    String errorMsg = ComputeUtils.validateNullableFieldAndGetErrorMsg(operator, valueRecord, field, "field");
+    Assert.assertNull(errorMsg);
   }
 
   @Test
@@ -147,10 +206,11 @@ public class ComputeUtilsTest {
         SchemaBuilder.record("SampleSchema").fields().name("field").type().nullable().intType().noDefault().endRecord();
     GenericRecord valueRecord = new GenericData.Record(schema);
 
-    Optional<String> errorMsg = ComputeUtils.validateNullableFieldAndGetErrorMsg(operator, valueRecord, "field");
-    Assert.assertTrue(errorMsg.isPresent());
+    Schema.Field field = valueRecord.getSchema().getField("field");
+    String errorMsg = ComputeUtils.validateNullableFieldAndGetErrorMsg(operator, valueRecord, field, "field");
+    Assert.assertNotNull(errorMsg);
     Assert.assertEquals(
-        errorMsg.get(),
+        errorMsg,
         "Failed to execute compute request as the field field is not allowed to be null for " + operator
             + " in value record.");
   }
@@ -163,8 +223,9 @@ public class ComputeUtilsTest {
     GenericRecord valueRecord = new GenericData.Record(schema);
     valueRecord.put("field", 123);
 
-    Optional<String> errorMsg = ComputeUtils.validateNullableFieldAndGetErrorMsg(operator, valueRecord, "field");
-    Assert.assertFalse(errorMsg.isPresent());
+    Schema.Field field = valueRecord.getSchema().getField("field");
+    String errorMsg = ComputeUtils.validateNullableFieldAndGetErrorMsg(operator, valueRecord, field, "field");
+    Assert.assertNull(errorMsg);
   }
 
   @Test
@@ -175,8 +236,9 @@ public class ComputeUtilsTest {
     GenericRecord valueRecord = new GenericData.Record(schema);
     valueRecord.put("field", 123);
 
-    Optional<String> errorMsg = ComputeUtils.validateNullableFieldAndGetErrorMsg(operator, valueRecord, "field");
-    Assert.assertFalse(errorMsg.isPresent());
+    Schema.Field field = valueRecord.getSchema().getField("field");
+    String errorMsg = ComputeUtils.validateNullableFieldAndGetErrorMsg(operator, valueRecord, field, "field");
+    Assert.assertNull(errorMsg);
   }
 
   private static class TestReadComputeOperator implements ReadComputeOperator {
@@ -204,7 +266,9 @@ public class ComputeUtilsTest {
     public void compute(
         int computeVersion,
         ComputeOperation operation,
-        GenericRecord inputRecord,
+        Schema.Field operatorInputField,
+        Schema.Field resultField,
+        GenericRecord inputValueRecord,
         GenericRecord outputRecord,
         Map<String, String> errorMap,
         Map<String, Object> sharedContext) {
@@ -216,7 +280,7 @@ public class ComputeUtilsTest {
     }
 
     @Override
-    public void putDefaultResult(GenericRecord outputRecord, String resultFieldName) {
+    public void putDefaultResult(GenericRecord outputRecord, Schema.Field field) {
     }
 
     @Override

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/schema/vson/TestVsonAvroDatumWriter.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/schema/vson/TestVsonAvroDatumWriter.java
@@ -2,6 +2,7 @@ package com.linkedin.venice.schema.vson;
 
 import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
 import com.linkedin.venice.serializer.AvroGenericDeserializer;
+import com.linkedin.venice.utils.TestUtils;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -63,9 +64,7 @@ public class TestVsonAvroDatumWriter {
     testWriter(vsonSchemaStr, () -> record, (avroObject) -> {
       Assert.assertEquals(((GenericData.Record) avroObject).get("member_id"), 1);
       Assert.assertEquals(((GenericData.Record) avroObject).get("score"), 2f);
-
-      // test querying an invalid field. By default, Avro is gonna return null.
-      Assert.assertNull(((GenericData.Record) avroObject).get("unknown field"));
+      TestUtils.checkMissingFieldInAvroRecord((GenericData.Record) avroObject, "unknown field");
     });
 
     // record with null field

--- a/internal/venice-common/src/test/java/com/linkedin/venice/schema/SchemaAdapterTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/schema/SchemaAdapterTest.java
@@ -1,6 +1,7 @@
 package com.linkedin.venice.schema;
 
 import com.linkedin.alpini.io.IOUtils;
+import com.linkedin.venice.utils.TestUtils;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.LinkedHashMap;
@@ -77,8 +78,8 @@ public class SchemaAdapterTest {
     Assert.assertEquals(adaptedGenericRecord.getSchema(), OLD_RECORD_SCHEMA);
     Assert.assertTrue(adaptedGenericRecord.get("field1") instanceof GenericRecord);
     Assert.assertEquals(((GenericRecord) adaptedGenericRecord.get("field1")).get("field1_1"), 1);
-    Assert.assertNull(((GenericRecord) adaptedGenericRecord.get("field1")).get("field1_2"));
-    Assert.assertNull(adaptedGenericRecord.get("field2"));
+    TestUtils.checkMissingFieldInAvroRecord((GenericRecord) adaptedGenericRecord.get("field1"), "field1_2");
+    TestUtils.checkMissingFieldInAvroRecord(adaptedGenericRecord, "field2");
   }
 
   @Test

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/consumer/ConsumerTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/consumer/ConsumerTest.java
@@ -10,6 +10,7 @@ import com.linkedin.venice.kafka.protocol.Put;
 import com.linkedin.venice.kafka.protocol.enums.MessageType;
 import com.linkedin.venice.schema.SchemaReader;
 import com.linkedin.venice.serialization.avro.KafkaValueSerializer;
+import com.linkedin.venice.utils.TestUtils;
 import com.linkedin.venice.utils.VeniceProperties;
 import com.linkedin.venice.writer.VeniceWriter;
 import java.nio.ByteBuffer;
@@ -80,13 +81,7 @@ public class ConsumerTest {
                 "Field '" + f + "' is not equal pre- and post-serialization."));
 
     // The new field should be absent in order to be fully compliant with the reader's compiled schema
-    try {
-      messageFromObliviousDeserializer.get(NEW_FIELD);
-      Assert.fail("The new field name should not be available because the reader does not want it.");
-    } catch (Exception e) {
-      // Expected
-      Assert.assertEquals(e.getClass(), NullPointerException.class);
-    }
+    TestUtils.checkMissingFieldInAvroRecord(messageFromObliviousDeserializer, NEW_FIELD);
     Assert.assertNotEquals(
         messageFromObliviousDeserializer,
         messageFromNewProtocol,

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/DaVinciComputeTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/DaVinciComputeTest.java
@@ -302,12 +302,9 @@ public class DaVinciComputeTest {
 
     int numRecords = 100;
     Map<Integer, ComputeGenericRecord> computeResult;
-    Set<Integer> keySetForCompute = new HashSet<Integer>() {
-      {
-        add(1);
-        add(2);
-      }
-    };
+    Set<Integer> keySetForCompute = new HashSet<>();
+    keySetForCompute.add(1);
+    keySetForCompute.add(2);
 
     DaVinciTestContext<Integer, Integer> daVinciTestContext =
         ServiceFactory.getGenericAvroDaVinciFactoryAndClientWithRetries(
@@ -883,7 +880,7 @@ public class DaVinciComputeTest {
       String key = KEY_PREFIX + i;
       GenericRecord record = resultMap.get(key);
       Assert.assertEquals(record.get("int_field"), i);
-      Assert.assertNull(record.get("float_field"));
+      TestUtils.checkMissingFieldInAvroRecord(record, "float_field");
     }
   }
 

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestPartialUpdateWithActiveActiveReplication.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestPartialUpdateWithActiveActiveReplication.java
@@ -403,6 +403,8 @@ public class TestPartialUpdateWithActiveActiveReplication {
       if (expectedField3 == null) {
         assertNull(retrievedValue.get(PERSON_F3_NAME));
       } else {
+        Schema.Field field3 = retrievedValue.getSchema().getField(PERSON_F3_NAME);
+        assertNotNull(field3);
         assertNotNull(retrievedValue.get(PERSON_F3_NAME));
         assertEquals(retrievedValue.get(PERSON_F3_NAME).toString(), expectedField3);
       }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/router/TestRead.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/router/TestRead.java
@@ -306,8 +306,8 @@ public abstract class TestRead {
             record.put(UNUSED_FIELD_NAME, -i);
             Assert.assertEquals(result.get(KEY_PREFIX + i), record);
             Assert.assertEquals(computeResult.get(KEY_PREFIX + i).get(VALUE_FIELD_NAME), i);
-            Assert.assertNull(computeResult.get(KEY_PREFIX + i).get(UNUSED_FIELD_NAME));
-            Assert.assertNull(computeResult.get(KEY_PREFIX + i).get(UNKNOWN_FIELD_NAME));
+            TestUtils.checkMissingFieldInAvroRecord(computeResult.get(KEY_PREFIX + i), UNUSED_FIELD_NAME);
+            TestUtils.checkMissingFieldInAvroRecord(computeResult.get(KEY_PREFIX + i), UNKNOWN_FIELD_NAME);
           }
 
           // Test simple get

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/router/TestStreaming.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/router/TestStreaming.java
@@ -413,7 +413,7 @@ public class TestStreaming {
       String key = KEY_PREFIX + i;
       GenericRecord record = resultMap.get(key);
       Assert.assertEquals(record.get("int_field"), i);
-      Assert.assertNull(record.get("float_field"));
+      TestUtils.checkMissingFieldInAvroRecord(record, "float_field");
       if (i <= LAST_KEY_INDEX_WITH_NON_NULL_VALUE) {
         Assert.assertEquals("nullable_string_field" + i, record.get("nullable_string_field").toString());
       } else {

--- a/internal/venice-test-common/src/main/java/com/linkedin/venice/utils/TestUtils.java
+++ b/internal/venice-test-common/src/main/java/com/linkedin/venice/utils/TestUtils.java
@@ -104,6 +104,8 @@ import java.util.function.BooleanSupplier;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import org.apache.avro.AvroRuntimeException;
+import org.apache.avro.generic.GenericRecord;
 import org.apache.helix.HelixManagerFactory;
 import org.apache.helix.InstanceType;
 import org.apache.helix.participant.statemachine.StateModel;
@@ -868,5 +870,14 @@ public class TestUtils {
       }
     }
     return aggregateConfigMap;
+  }
+
+  public static void checkMissingFieldInAvroRecord(GenericRecord record, String fieldName) {
+    try {
+      Assert.assertNull(record.get(fieldName));
+    } catch (AvroRuntimeException e) {
+      // But in Avro 1.10+, it throws instead...
+      Assert.assertEquals(e.getMessage(), "Not a valid schema field: " + fieldName);
+    }
   }
 }

--- a/services/venice-server/src/main/java/com/linkedin/venice/listener/request/ComputeRouterRequestWrapper.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/listener/request/ComputeRouterRequestWrapper.java
@@ -20,6 +20,9 @@ import org.apache.avro.io.OptimizedBinaryDecoderFactory;
  * {@code ComputeRouterRequestWrapper} encapsulates a POST request for read-compute from routers.
  */
 public class ComputeRouterRequestWrapper extends MultiKeyRouterRequestWrapper<ComputeRouterRequestKeyV1> {
+  private static final RecordDeserializer<ComputeRouterRequestKeyV1> DESERIALIZER =
+      FastSerializerDeserializerFactory.getAvroSpecificDeserializer(ComputeRouterRequestKeyV1.class);
+
   private final ComputeRequestWrapper computeRequestWrapper;
   private int valueSchemaId = -1;
 
@@ -67,16 +70,9 @@ public class ComputeRouterRequestWrapper extends MultiKeyRouterRequestWrapper<Co
         .createOptimizedBinaryDecoder(requestContent, 0, requestContent.length);
     computeRequestWrapper.deserialize(decoder);
 
-    Iterable<ComputeRouterRequestKeyV1> keys = parseKeys(decoder);
+    Iterable<ComputeRouterRequestKeyV1> keys = DESERIALIZER.deserializeObjects(decoder);
     String schemaId = httpRequest.headers().get(HttpConstants.VENICE_COMPUTE_VALUE_SCHEMA_ID);
     return new ComputeRouterRequestWrapper(resourceName, computeRequestWrapper, keys, httpRequest, schemaId);
-  }
-
-  private static Iterable<ComputeRouterRequestKeyV1> parseKeys(BinaryDecoder decoder) {
-    RecordDeserializer<ComputeRouterRequestKeyV1> deserializer =
-        FastSerializerDeserializerFactory.getAvroSpecificDeserializer(ComputeRouterRequestKeyV1.class);
-
-    return deserializer.deserializeObjects(decoder);
   }
 
   public ComputeRequestWrapper getComputeRequest() {


### PR DESCRIPTION
The upgrade of Avro from 1.9 to 1.10 carries one major change which is that GenericRecords no longer return null for fields they do not have, but rather throw AvroRuntimeException. This makes the read compute code fail.

This commit also optimizes various usages of Avro in the read compute hot path, including:

- The ComputeRequestWrapper now carries a list of operation result fields, which is looked up once at the start of the query, rather than redundantly during each processed key. This reduces map lookups from 1/op/key to 1/op/query.

- The getNullableFieldValueAsList function removes 1/op/key map lookups.

- The validateNullableFieldAndGetErrorMsg function removes 1 to 2/op/key map lookups.

- The ComputeRouterRequestWrapper now uses a static final deserializer rather than looking it up on each query.

And other non-Avro optimizations:

- The stats for each read compute op are now incremented once at the end of the query by the amount of keys that found a hit in the storage engine, rather than piecemeal, while processing each key.

- The validateNullableFieldAndGetErrorMsg does not return an Optional anymore.

- ComputeOperationType::valueOf now uses EnumUtils to remove a map lookup. This removes 2/op/key map lookups.

## How was this PR tested?
CI

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.

The user does not have to bump Avro, and the client libraries will continue to work with older Avro versions. However, if the user does adopt Avro 1.10 in its client app, then the change of semantics mentioned at the beginning will apply to the GenericRecords returned by the client libs.