### PR TITLE
[controller][server] Pass all properties from server and controller to pub sub adatpers to include special properties we need.

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionService.java
@@ -1069,7 +1069,7 @@ public class KafkaStoreIngestionService extends AbstractVeniceService implements
    * @return
    */
   private Properties getCommonKafkaConsumerProperties(VeniceServerConfig serverConfig) {
-    Properties kafkaConsumerProperties = new Properties();
+    Properties kafkaConsumerProperties = serverConfig.getClusterProperties().getPropertiesCopy();
     ApacheKafkaProducerConfig
         .copyKafkaSASLProperties(serverConfig.getClusterProperties(), kafkaConsumerProperties, false);
     kafkaConsumerProperties.setProperty(KAFKA_BOOTSTRAP_SERVERS, serverConfig.getKafkaBootstrapServers());
@@ -1107,7 +1107,7 @@ public class KafkaStoreIngestionService extends AbstractVeniceService implements
       serverConfig = new VeniceServerConfig(new VeniceProperties(clonedProperties), serverConfig.getKafkaClusterMap());
     }
     VeniceProperties clusterProperties = serverConfig.getClusterProperties();
-    Properties properties = new Properties();
+    Properties properties = serverConfig.getClusterProperties().getPropertiesCopy();
     ApacheKafkaProducerConfig.copyKafkaSASLProperties(clusterProperties, properties, false);
     kafkaBootstrapUrls = serverConfig.getKafkaBootstrapServers();
     String resolvedKafkaUrl = serverConfig.getKafkaClusterUrlResolver().apply(kafkaBootstrapUrls);

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -3243,7 +3243,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
       Properties localConsumerProps,
       String remoteKafkaSourceAddress,
       boolean consumeRemotely) {
-    Properties newConsumerProps = new Properties();
+    Properties newConsumerProps = serverConfig.getClusterProperties().getPropertiesCopy();
     newConsumerProps.putAll(localConsumerProps);
     newConsumerProps.setProperty(KAFKA_BOOTSTRAP_SERVERS, remoteKafkaSourceAddress);
     VeniceProperties customizedConsumerConfigs = consumeRemotely

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
@@ -2982,7 +2982,7 @@ public abstract class StoreIngestionTaskTest {
     doReturn("localhost").when(mockKafkaConsumerProperties).getProperty(eq(KAFKA_BOOTSTRAP_SERVERS));
 
     VeniceServerConfig mockVeniceServerConfig = mock(VeniceServerConfig.class);
-    doReturn(new VeniceProperties(new Properties())).when(mockVeniceServerConfig).getClusterProperties();
+    doReturn(VeniceProperties.empty()).when(mockVeniceServerConfig).getClusterProperties();
     VeniceProperties mockVeniceProperties = mock(VeniceProperties.class);
     doReturn(true).when(mockVeniceProperties).isEmpty();
     doReturn(mockVeniceProperties).when(mockVeniceServerConfig).getKafkaConsumerConfigsForLocalConsumption();
@@ -3085,7 +3085,7 @@ public abstract class StoreIngestionTaskTest {
         .getLocalStorageEngine(anyString());
     doReturn(mockStorageEngineRepository).when(builder).getStorageEngineRepository();
     VeniceServerConfig veniceServerConfig = mock(VeniceServerConfig.class);
-    doReturn(new VeniceProperties(new Properties())).when(veniceServerConfig).getClusterProperties();
+    doReturn(VeniceProperties.empty()).when(veniceServerConfig).getClusterProperties();
     doReturn(VeniceProperties.empty()).when(veniceServerConfig).getKafkaConsumerConfigsForLocalConsumption();
     doReturn(VeniceProperties.empty()).when(veniceServerConfig).getKafkaConsumerConfigsForRemoteConsumption();
     doReturn(Object2IntMaps.emptyMap()).when(veniceServerConfig).getKafkaClusterUrlToIdMap();

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
@@ -2982,6 +2982,7 @@ public abstract class StoreIngestionTaskTest {
     doReturn("localhost").when(mockKafkaConsumerProperties).getProperty(eq(KAFKA_BOOTSTRAP_SERVERS));
 
     VeniceServerConfig mockVeniceServerConfig = mock(VeniceServerConfig.class);
+    doReturn(new VeniceProperties(new Properties())).when(mockVeniceServerConfig).getClusterProperties();
     VeniceProperties mockVeniceProperties = mock(VeniceProperties.class);
     doReturn(true).when(mockVeniceProperties).isEmpty();
     doReturn(mockVeniceProperties).when(mockVeniceServerConfig).getKafkaConsumerConfigsForLocalConsumption();
@@ -3084,6 +3085,7 @@ public abstract class StoreIngestionTaskTest {
         .getLocalStorageEngine(anyString());
     doReturn(mockStorageEngineRepository).when(builder).getStorageEngineRepository();
     VeniceServerConfig veniceServerConfig = mock(VeniceServerConfig.class);
+    doReturn(new VeniceProperties(new Properties())).when(veniceServerConfig).getClusterProperties();
     doReturn(VeniceProperties.empty()).when(veniceServerConfig).getKafkaConsumerConfigsForLocalConsumption();
     doReturn(VeniceProperties.empty()).when(veniceServerConfig).getKafkaConsumerConfigsForRemoteConsumption();
     doReturn(Object2IntMaps.emptyMap()).when(veniceServerConfig).getKafkaClusterUrlToIdMap();

--- a/internal/venice-avro-compatibility-test/src/test/java/com/linkedin/venice/VeniceClientCompatibilityTest.java
+++ b/internal/venice-avro-compatibility-test/src/test/java/com/linkedin/venice/VeniceClientCompatibilityTest.java
@@ -121,11 +121,8 @@ public class VeniceClientCompatibilityTest {
 
     Properties extraBackendConfig = new Properties();
     extraBackendConfig.setProperty(DATA_BASE_PATH, Utils.getTempDataDirectory().getAbsolutePath());
-    daVinciClient = ServiceFactory.getGenericAvroDaVinciClient(
-        storeName,
-        zkAddress[0],
-        new DaVinciConfig(),
-        new VeniceProperties(new Properties()));
+    daVinciClient = ServiceFactory
+        .getGenericAvroDaVinciClient(storeName, zkAddress[0], new DaVinciConfig(), VeniceProperties.empty());
 
     daVinciClient.subscribeAll().get(60, TimeUnit.SECONDS);
   }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/adapter/kafka/admin/ApacheKafkaAdminConfig.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/adapter/kafka/admin/ApacheKafkaAdminConfig.java
@@ -20,7 +20,7 @@ public class ApacheKafkaAdminConfig {
   private final String brokerAddress;
 
   public ApacheKafkaAdminConfig(VeniceProperties veniceProperties) {
-    this.brokerAddress = ApacheKafkaProducerConfig.getPubsubBrokerAddress(veniceProperties);
+    this.brokerAddress = veniceProperties.getString(ApacheKafkaProducerConfig.KAFKA_BOOTSTRAP_SERVERS);
     this.adminProperties =
         veniceProperties.clipAndFilterNamespace(ApacheKafkaProducerConfig.KAFKA_CONFIG_PREFIX).toProperties();
     this.adminProperties.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, brokerAddress);

--- a/internal/venice-common/src/test/java/com/linkedin/venice/kafka/consumer/ApacheKafkaPubSubConsumerAdapterTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/kafka/consumer/ApacheKafkaPubSubConsumerAdapterTest.java
@@ -175,7 +175,7 @@ public class ApacheKafkaPubSubConsumerAdapterTest {
             new TopicPartition("test", 42),
             Collections.singletonList(new ConsumerRecord<>("test", 42, 75, "key".getBytes(), "value".getBytes()))));
     doReturn(consumerRecords).when(consumer).poll(any());
-    new ApacheKafkaConsumerAdapter(consumer, new VeniceProperties(new Properties()), false, pubSubMessageDeserializer)
+    new ApacheKafkaConsumerAdapter(consumer, VeniceProperties.empty(), false, pubSubMessageDeserializer)
         .poll(Long.MAX_VALUE);
   }
 
@@ -193,7 +193,7 @@ public class ApacheKafkaPubSubConsumerAdapterTest {
     ConsumerRecords<byte[], byte[]> records = new ConsumerRecords<>(
         Collections.singletonMap(new TopicPartition("test", 42), Collections.singletonList(record)));
     doReturn(records).when(consumer).poll(any());
-    new ApacheKafkaConsumerAdapter(consumer, new VeniceProperties(new Properties()), false, pubSubMessageDeserializer)
+    new ApacheKafkaConsumerAdapter(consumer, VeniceProperties.empty(), false, pubSubMessageDeserializer)
         .poll(Long.MAX_VALUE);
   }
 
@@ -229,11 +229,8 @@ public class ApacheKafkaPubSubConsumerAdapterTest {
         Collections.singletonMap(new TopicPartition("test", 42), Collections.singletonList(record)));
     doReturn(records).when(consumer).poll(any());
 
-    ApacheKafkaConsumerAdapter consumerAdapter = new ApacheKafkaConsumerAdapter(
-        consumer,
-        new VeniceProperties(new Properties()),
-        false,
-        pubSubMessageDeserializer);
+    ApacheKafkaConsumerAdapter consumerAdapter =
+        new ApacheKafkaConsumerAdapter(consumer, VeniceProperties.empty(), false, pubSubMessageDeserializer);
     PubSubTopicPartition pubSubTopicPartition =
         new PubSubTopicPartitionImpl(pubSubTopicRepository.getTopic("test"), 42);
     // add partition to assignments

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceClusterWrapper.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceClusterWrapper.java
@@ -187,7 +187,8 @@ public class VeniceClusterWrapper extends ProcessWrapper {
             "PubSubBrokerWrapper region name " + pubSubBrokerWrapper.getRegionName()
                 + " does not match with the region name " + options.getRegionName() + " in the options");
       }
-      pubSubBrokerWrapper.getAdditionalConfig().forEach((k, v) -> options.getExtraProperties().putIfAbsent(k, v));
+      PubSubBrokerWrapper.getBrokerDetailsForClients(Collections.singletonList(pubSubBrokerWrapper))
+          .forEach((k, v) -> options.getExtraProperties().putIfAbsent(k, v));
       // Setup D2 for controller
       String zkAddress = zkServerWrapper.getAddress();
       D2TestUtils.setupD2Config(
@@ -766,6 +767,7 @@ public class VeniceClusterWrapper extends ProcessWrapper {
    */
   public VeniceWriter<String, String, byte[]> getVeniceWriter(String storeVersionName) {
     Properties properties = new Properties();
+    properties.putAll(PubSubBrokerWrapper.getBrokerDetailsForClients(Collections.singletonList(pubSubBrokerWrapper)));
     properties.put(KAFKA_BOOTSTRAP_SERVERS, pubSubBrokerWrapper.getAddress());
     properties.put(ZOOKEEPER_ADDRESS, zkServerWrapper.getAddress());
     VeniceWriterFactory factory = TestUtils.getVeniceWriterFactory(properties, pubSubProducerAdapterFactory);
@@ -781,6 +783,7 @@ public class VeniceClusterWrapper extends ProcessWrapper {
 
   public VeniceWriter<String, String, byte[]> getSslVeniceWriter(String storeVersionName) {
     Properties properties = new Properties();
+    properties.putAll(PubSubBrokerWrapper.getBrokerDetailsForClients(Collections.singletonList(pubSubBrokerWrapper)));
     properties.put(KAFKA_BOOTSTRAP_SERVERS, pubSubBrokerWrapper.getSSLAddress());
     properties.put(ZOOKEEPER_ADDRESS, zkServerWrapper.getAddress());
     properties.putAll(KafkaTestUtils.getLocalKafkaClientSSLConfig());

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceControllerWrapper.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceControllerWrapper.java
@@ -79,6 +79,7 @@ import io.tehuti.metrics.MetricsRepository;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -314,7 +315,8 @@ public class VeniceControllerWrapper extends ProcessWrapper {
         }
 
         // Add additional config from PubSubBrokerWrapper to server.properties iff the key is not already present
-        Map<String, String> brokerDetails = options.getKafkaBroker().getAdditionalConfig();
+        Map<String, String> brokerDetails =
+            PubSubBrokerWrapper.getBrokerDetailsForClients(Collections.singletonList(options.getKafkaBroker()));
         for (Map.Entry<String, String> entry: brokerDetails.entrySet()) {
           builder.putIfAbsent(entry.getKey(), entry.getValue());
         }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceMultiClusterWrapper.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceMultiClusterWrapper.java
@@ -12,6 +12,7 @@ import com.linkedin.venice.utils.SslUtils;
 import com.linkedin.venice.utils.Time;
 import com.linkedin.venice.utils.Utils;
 import java.io.File;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
@@ -69,7 +70,8 @@ public class VeniceMultiClusterWrapper extends ProcessWrapper {
             "PubSubBrokerWrapper region name " + pubSubBrokerWrapper.getRegionName()
                 + " does not match with the region name " + options.getRegionName() + " in the options");
       }
-      Map<String, String> pubBrokerDetails = pubSubBrokerWrapper.getAdditionalConfig();
+      Map<String, String> pubBrokerDetails =
+          PubSubBrokerWrapper.getBrokerDetailsForClients(Collections.singletonList(pubSubBrokerWrapper));
       String[] clusterNames = new String[options.getNumberOfClusters()];
       Map<String, String> clusterToD2 = new HashMap<>();
       Map<String, String> clusterToServerD2 = new HashMap<>();

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceServerWrapper.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceServerWrapper.java
@@ -52,6 +52,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -247,7 +248,8 @@ public class VeniceServerWrapper extends ProcessWrapper implements MetricsAware 
       }
 
       // Add additional config from PubSubBrokerWrapper to server.properties iff the key is not already present
-      Map<String, String> brokerDetails = pubSubBrokerWrapper.getAdditionalConfig();
+      Map<String, String> brokerDetails =
+          PubSubBrokerWrapper.getBrokerDetailsForClients(Collections.singletonList(pubSubBrokerWrapper));
       for (Map.Entry<String, String> entry: brokerDetails.entrySet()) {
         if (clusterProps.containsKey(entry.getKey())) {
           // skip if the key is already present in cluster.properties

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/kafka/KafkaConsumptionTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/kafka/KafkaConsumptionTest.java
@@ -276,7 +276,7 @@ public class KafkaConsumptionTest {
       PubSubBrokerWrapper pubSubBrokerWrapper) throws ExecutionException, InterruptedException {
     PubSubProducerAdapter producerAdapter = pubSubBrokerWrapper.getPubSubClientsFactory()
         .getProducerAdapterFactory()
-        .create(new VeniceProperties(new Properties()), "test-producer", pubSubBrokerWrapper.getAddress());
+        .create(VeniceProperties.empty(), "test-producer", pubSubBrokerWrapper.getAddress());
 
     final byte[] randomBytes = new byte[] { 0, 1 };
 

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/kafka/TopicManagerIntegrationTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/kafka/TopicManagerIntegrationTest.java
@@ -13,7 +13,6 @@ import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
 import com.linkedin.venice.utils.IntegrationTestPushUtils;
 import com.linkedin.venice.utils.TestMockTime;
 import com.linkedin.venice.utils.VeniceProperties;
-import java.util.Properties;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -45,7 +44,7 @@ public class TopicManagerIntegrationTest extends TopicManagerTest {
   protected PubSubProducerAdapter createPubSubProducerAdapter() {
     return pubSubBrokerWrapper.getPubSubClientsFactory()
         .getProducerAdapterFactory()
-        .create(new VeniceProperties(new Properties()), "topicManagerTestProducer", pubSubBrokerWrapper.getAddress());
+        .create(VeniceProperties.empty(), "topicManagerTestProducer", pubSubBrokerWrapper.getAddress());
   }
 
   @Test

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -671,8 +671,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
       clonedProperties.setProperty(KAFKA_BOOTSTRAP_SERVERS, pubSubBootstrapServers);
     }
     controllerConfig = new VeniceControllerConfig(new VeniceProperties(clonedProperties));
-
-    Properties properties = new Properties();
+    Properties properties = multiClusterConfigs.getCommonConfig().getProps().getPropertiesCopy();
     ApacheKafkaProducerConfig.copyKafkaSASLProperties(originalPros, properties, false);
     if (KafkaSSLUtils.isKafkaSSLProtocol(controllerConfig.getKafkaSecurityProtocol())) {
       Optional<SSLConfig> sslConfig = controllerConfig.getSslConfig();


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Summary, imperative, start upper case, don't end with a period
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Previous server and controller prepare specific properties map with only kafka related properties from server config and controller config, respectively. To support other type of pub sub system, we may need to pass additionally properties to pub sub adapters. Instead of creating new empty properties, we just use copied properties of server configs and controller configs and the overriding logic is still the same. 

Besides, fix some additional configs merge logic issues inside test utils. 

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
internal CI
## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.