### PR TITLE
[router] Skip registering router metrics for system stores

### DIFF
--- a/internal/venice-common/src/main/java/com/linkedin/venice/common/VeniceSystemStoreType.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/common/VeniceSystemStoreType.java
@@ -26,16 +26,15 @@ import java.util.List;
  */
 public enum VeniceSystemStoreType {
   DAVINCI_PUSH_STATUS_STORE(
-      String.format(Store.SYSTEM_STORE_FORMAT, "davinci_push_status_store"), true, PushStatusKey.SCHEMA$.toString(),
+      VeniceSystemStoreUtils.DAVINCI_PUSH_STATUS_STORE_STR, true, PushStatusKey.SCHEMA$.toString(),
       PushStatusValue.SCHEMA$.toString(), AvroProtocolDefinition.PUSH_STATUS_SYSTEM_SCHEMA_STORE.getSystemStoreName(),
       true, Method.WRITE_SYSTEM_STORE
   ),
 
   // New Metadata system store
   META_STORE(
-      String.format(Store.SYSTEM_STORE_FORMAT, "meta_store"), true, StoreMetaKey.SCHEMA$.toString(),
-      StoreMetaValue.SCHEMA$.toString(), AvroProtocolDefinition.METADATA_SYSTEM_SCHEMA_STORE.getSystemStoreName(), true,
-      Method.READ_SYSTEM_STORE
+      VeniceSystemStoreUtils.META_STORE_STR, true, StoreMetaKey.SCHEMA$.toString(), StoreMetaValue.SCHEMA$.toString(),
+      AvroProtocolDefinition.METADATA_SYSTEM_SCHEMA_STORE.getSystemStoreName(), true, Method.READ_SYSTEM_STORE
   ),
 
   // This system store's prefix is used as its full name since it is not a per-user-store system store

--- a/internal/venice-common/src/main/java/com/linkedin/venice/common/VeniceSystemStoreUtils.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/common/VeniceSystemStoreUtils.java
@@ -1,5 +1,6 @@
 package com.linkedin.venice.common;
 
+import com.linkedin.avroutil1.compatibility.StringUtils;
 import com.linkedin.venice.controllerapi.UpdateStoreQueryParams;
 import com.linkedin.venice.meta.Store;
 import java.util.concurrent.TimeUnit;
@@ -8,6 +9,9 @@ import java.util.concurrent.TimeUnit;
 public class VeniceSystemStoreUtils {
   public static final String PARTICIPANT_STORE = "participant_store";
   public static final String PUSH_JOB_DETAILS_STORE = "push_job_details_store";
+  public static final String DAVINCI_PUSH_STATUS_STORE_STR =
+      String.format(Store.SYSTEM_STORE_FORMAT, "davinci_push_status_store");
+  public static final String META_STORE_STR = String.format(Store.SYSTEM_STORE_FORMAT, "meta_store");
 
   private static final String PARTICIPANT_STORE_PREFIX = String.format(Store.SYSTEM_STORE_FORMAT, PARTICIPANT_STORE);
   private static final String PARTICIPANT_STORE_FORMAT = PARTICIPANT_STORE_PREFIX + "_cluster_%s";
@@ -52,4 +56,14 @@ public class VeniceSystemStoreUtils {
     VeniceSystemStoreType veniceSystemStoreType = VeniceSystemStoreType.getSystemStoreType(storeName);
     return veniceSystemStoreType != null && veniceSystemStoreType.isStoreZkShared();
   }
+
+  public static String extractSystemStoreType(String systemStoreName) {
+    if (systemStoreName.startsWith(DAVINCI_PUSH_STATUS_STORE_STR)) {
+      return DAVINCI_PUSH_STATUS_STORE_STR;
+    } else if (systemStoreName.startsWith(META_STORE_STR)) {
+      return META_STORE_STR;
+    }
+    return StringUtils.EMPTY_STRING;
+  }
+
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/common/VeniceSystemStoreUtils.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/common/VeniceSystemStoreUtils.java
@@ -1,6 +1,5 @@
 package com.linkedin.venice.common;
 
-import com.linkedin.avroutil1.compatibility.StringUtils;
 import com.linkedin.venice.controllerapi.UpdateStoreQueryParams;
 import com.linkedin.venice.meta.Store;
 import java.util.concurrent.TimeUnit;
@@ -63,7 +62,6 @@ public class VeniceSystemStoreUtils {
     } else if (systemStoreName.startsWith(META_STORE_STR)) {
       return META_STORE_STR;
     }
-    return StringUtils.EMPTY_STRING;
+    return null;
   }
-
 }

--- a/internal/venice-common/src/test/java/com/linkedin/venice/common/TestVeniceSystemStoreType.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/common/TestVeniceSystemStoreType.java
@@ -45,4 +45,17 @@ public class TestVeniceSystemStoreType {
     Assert.assertTrue(systemStoreSet.contains(VeniceSystemStoreType.META_STORE));
     Assert.assertTrue(systemStoreSet.contains(VeniceSystemStoreType.DAVINCI_PUSH_STATUS_STORE));
   }
+
+  @Test
+  public void testExtractSystemStoreName() {
+    String dvcpushStatusStore = "venice_system_store_davinci_push_status_store_abc";
+    String metaStore = "venice_system_store_meta_store_abc";
+    String userStore = "userStore";
+    Assert.assertEquals(
+        VeniceSystemStoreUtils.extractSystemStoreType(dvcpushStatusStore),
+        VeniceSystemStoreUtils.DAVINCI_PUSH_STATUS_STORE_STR);
+    Assert
+        .assertEquals(VeniceSystemStoreUtils.extractSystemStoreType(metaStore), VeniceSystemStoreUtils.META_STORE_STR);
+    Assert.assertNull(VeniceSystemStoreUtils.extractSystemStoreType(userStore));
+  }
 }

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/stats/RouterHttpRequestStats.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/stats/RouterHttpRequestStats.java
@@ -67,8 +67,6 @@ public class RouterHttpRequestStats extends AbstractVeniceHttpStats {
   private final Sensor multiGetFallbackSensor;
   private final Sensor metaStoreShadowReadSensor;
   private Sensor keySizeSensor;
-  private final boolean isSystemStore;
-
   private Sensor systemStoreSensor = null;
 
   // QPS metrics
@@ -79,8 +77,7 @@ public class RouterHttpRequestStats extends AbstractVeniceHttpStats {
       ScatterGatherStats scatterGatherStats,
       boolean isKeyValueProfilingEnabled) {
     super(metricsRepository, storeName, requestType);
-    this.isSystemStore = VeniceSystemStoreUtils.isSystemStore(storeName);
-    if (isSystemStore) {
+    if (VeniceSystemStoreUtils.isSystemStore(storeName)) {
       MetricsRepository dummyMetricRepo = new MetricsRepository();
       this.systemStoreSensor = dummyMetricRepo.sensor("dummy_system_store_sensor");
     }
@@ -374,7 +371,7 @@ public class RouterHttpRequestStats extends AbstractVeniceHttpStats {
 
   @Override
   protected Sensor registerSensor(String sensorName, MeasurableStat... stats) {
-    if (isSystemStore) {
+    if (systemStoreSensor != null) {
       return systemStoreSensor;
     }
     return super.registerSensor(getFullMetricName(sensorName), null, stats);

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/stats/RouterHttpRequestStats.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/stats/RouterHttpRequestStats.java
@@ -3,6 +3,7 @@ package com.linkedin.venice.router.stats;
 import static com.linkedin.venice.stats.AbstractVeniceAggStats.*;
 
 import com.linkedin.alpini.router.monitoring.ScatterGatherStats;
+import com.linkedin.venice.common.VeniceSystemStoreUtils;
 import com.linkedin.venice.read.RequestType;
 import com.linkedin.venice.stats.AbstractVeniceHttpStats;
 import com.linkedin.venice.stats.LambdaStat;
@@ -21,50 +22,52 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 
 public class RouterHttpRequestStats extends AbstractVeniceHttpStats {
-  private final Sensor requestSensor;
-  private final Sensor healthySensor;
-  private final Sensor unhealthySensor;
-  private final Sensor tardySensor;
-  private final Sensor healthyRequestRateSensor;
-  private final Sensor tardyRequestRatioSensor;
-  private final Sensor throttleSensor;
-  private final Sensor latencySensor;
-  private final Sensor healthyRequestLatencySensor;
-  private final Sensor unhealthyRequestLatencySensor;
-  private final Sensor tardyRequestLatencySensor;
-  private final Sensor throttledRequestLatencySensor;
-  private final Sensor requestSizeSensor;
-  private final Sensor compressedResponseSizeSensor;
-  private final Sensor responseSizeSensor;
-  private final Sensor badRequestSensor;
-  private final Sensor badRequestKeyCountSensor;
-  private final Sensor requestThrottledByRouterCapacitySensor;
-  private final Sensor decompressionTimeSensor;
-  private final Sensor routerResponseWaitingTimeSensor;
-  private final Sensor fanoutRequestCountSensor;
-  private final Sensor quotaSensor;
-  private final Sensor findUnhealthyHostRequestSensor;
-  private final Sensor keyNumSensor;
+  private Sensor requestSensor = null;
+  private Sensor healthySensor = null;
+  private Sensor unhealthySensor = null;
+  private Sensor tardySensor = null;
+  private Sensor healthyRequestRateSensor = null;
+  private Sensor tardyRequestRatioSensor = null;
+  private Sensor throttleSensor = null;
+  private Sensor latencySensor = null;
+  private Sensor healthyRequestLatencySensor = null;
+  private Sensor unhealthyRequestLatencySensor = null;
+  private Sensor tardyRequestLatencySensor = null;
+  private Sensor throttledRequestLatencySensor = null;
+  private Sensor requestSizeSensor = null;
+  private Sensor compressedResponseSizeSensor = null;
+  private Sensor responseSizeSensor = null;
+  private Sensor badRequestSensor = null;
+  private Sensor badRequestKeyCountSensor = null;
+  private Sensor requestThrottledByRouterCapacitySensor = null;
+  private Sensor decompressionTimeSensor = null;
+  private Sensor routerResponseWaitingTimeSensor = null;
+  private Sensor fanoutRequestCountSensor = null;
+  private Sensor quotaSensor = null;
+  private Sensor findUnhealthyHostRequestSensor = null;
+  private Sensor keyNumSensor = null;
   // Reflect the real request usage, e.g count each key as an unit of request usage.
-  private final Sensor requestUsageSensor;
-  private final Sensor requestParsingLatencySensor;
-  private final Sensor requestRoutingLatencySensor;
-  private final Sensor unAvailableRequestSensor;
-  private final Sensor delayConstraintAbortedRetryRequest;
-  private final Sensor slowRouteAbortedRetryRequest;
-  private final Sensor retryRouteLimitAbortedRetryRequest;
-  private final Sensor noAvailableReplicaAbortedRetryRequest;
-  private final Sensor readQuotaUsageSensor;
-  private final Sensor inFlightRequestSensor;
-  private final AtomicInteger currentInFlightRequest;
-  private final Sensor unavailableReplicaStreamingRequestSensor;
-  private final Sensor allowedRetryRequestSensor;
-  private final Sensor disallowedRetryRequestSensor;
-  private final Sensor errorRetryAttemptTriggeredByPendingRequestCheckSensor;
-  private final Sensor retryDelaySensor;
-  private final Sensor multiGetFallbackSensor;
-  private final Sensor metaStoreShadowReadSensor;
+  private Sensor requestUsageSensor = null;
+  private Sensor requestParsingLatencySensor = null;
+  private Sensor requestRoutingLatencySensor = null;
+  private Sensor unAvailableRequestSensor = null;
+  private Sensor delayConstraintAbortedRetryRequest = null;
+  private Sensor slowRouteAbortedRetryRequest = null;
+  private Sensor retryRouteLimitAbortedRetryRequest = null;
+  private Sensor noAvailableReplicaAbortedRetryRequest = null;
+  private Sensor readQuotaUsageSensor = null;
+  private Sensor inFlightRequestSensor = null;
+  private AtomicInteger currentInFlightRequest = null;
+  private Sensor unavailableReplicaStreamingRequestSensor = null;
+  private Sensor allowedRetryRequestSensor = null;
+  private Sensor disallowedRetryRequestSensor = null;
+  private Sensor errorRetryAttemptTriggeredByPendingRequestCheckSensor = null;
+  private Sensor retryDelaySensor = null;
+  private Sensor multiGetFallbackSensor = null;
+  private Sensor metaStoreShadowReadSensor = null;
   private Sensor keySizeSensor;
+
+  private boolean isSystemStore;
 
   // QPS metrics
   public RouterHttpRequestStats(
@@ -74,111 +77,114 @@ public class RouterHttpRequestStats extends AbstractVeniceHttpStats {
       ScatterGatherStats scatterGatherStats,
       boolean isKeyValueProfilingEnabled) {
     super(metricsRepository, storeName, requestType);
+    this.isSystemStore = VeniceSystemStoreUtils.isSystemStore(storeName);
 
-    Rate requestRate = new OccurrenceRate();
-    Rate healthyRequestRate = new OccurrenceRate();
-    Rate tardyRequestRate = new OccurrenceRate();
-    requestSensor = registerSensor("request", new Count(), requestRate);
-    healthySensor = registerSensor("healthy_request", new Count(), healthyRequestRate);
-    unhealthySensor = registerSensor("unhealthy_request", new Count());
-    unavailableReplicaStreamingRequestSensor = registerSensor("unavailable_replica_streaming_request", new Count());
-    tardySensor = registerSensor("tardy_request", new Count(), tardyRequestRate);
-    healthyRequestRateSensor =
-        registerSensor("healthy_request_ratio", new TehutiUtils.SimpleRatioStat(healthyRequestRate, requestRate));
-    tardyRequestRatioSensor =
-        registerSensor("tardy_request_ratio", new TehutiUtils.SimpleRatioStat(tardyRequestRate, requestRate));
-    throttleSensor = registerSensor("throttled_request", new Count());
-    badRequestSensor = registerSensor("bad_request", new Count());
-    badRequestKeyCountSensor = registerSensor("bad_request_key_count", new OccurrenceRate(), new Avg(), new Max());
-    requestThrottledByRouterCapacitySensor = registerSensor("request_throttled_by_router_capacity", new Count());
-    fanoutRequestCountSensor = registerSensor("fanout_request_count", new Avg(), new Max(0));
-    latencySensor = registerSensorWithDetailedPercentiles("latency", new Avg(), new Max(0));
-    healthyRequestLatencySensor =
-        registerSensorWithDetailedPercentiles("healthy_request_latency", new Avg(), new Max(0));
-    unhealthyRequestLatencySensor =
-        registerSensorWithDetailedPercentiles("unhealthy_request_latency", new Avg(), new Max(0));
-    tardyRequestLatencySensor = registerSensorWithDetailedPercentiles("tardy_request_latency", new Avg(), new Max(0));
-    throttledRequestLatencySensor =
-        registerSensorWithDetailedPercentiles("throttled_request_latency", new Avg(), new Max(0));
-    routerResponseWaitingTimeSensor = registerSensor(
-        "response_waiting_time",
-        TehutiUtils.getPercentileStat(getName(), getFullMetricName("response_waiting_time")));
-    requestSizeSensor = registerSensor(
-        "request_size",
-        TehutiUtils.getPercentileStat(getName(), getFullMetricName("request_size")),
-        new Avg());
-    compressedResponseSizeSensor = registerSensor(
-        "compressed_response_size",
-        TehutiUtils.getPercentileStat(getName(), getFullMetricName("compressed_response_size")),
-        new Avg(),
-        new Max());
-
-    decompressionTimeSensor = registerSensor(
-        "decompression_time",
-        TehutiUtils.getPercentileStat(getName(), getFullMetricName("decompression_time")),
-        new Avg());
-    quotaSensor = registerSensor("read_quota_per_router", new Gauge());
-    findUnhealthyHostRequestSensor = registerSensor("find_unhealthy_host_request", new OccurrenceRate());
-
-    registerSensor("retry_count", new LambdaStat(() -> scatterGatherStats.getTotalRetries()));
-    registerSensor("retry_key_count", new LambdaStat(() -> scatterGatherStats.getTotalRetriedKeys()));
-    registerSensor(
-        "retry_slower_than_original_count",
-        new LambdaStat(() -> scatterGatherStats.getTotalRetriesDiscarded()));
-    registerSensor("retry_error_count", new LambdaStat(() -> scatterGatherStats.getTotalRetriesError()));
-    registerSensor(
-        "retry_faster_than_original_count",
-        new LambdaStat(() -> scatterGatherStats.getTotalRetriesWinner()));
-
-    keyNumSensor = registerSensor("key_num", new Avg(), new Max(0));
-    /**
-     * request_usage.Total is incoming KPS while request_usage.OccurrenceRate is QPS
-     */
-    requestUsageSensor = registerSensor("request_usage", new Total(), new OccurrenceRate());
-    multiGetFallbackSensor = registerSensor("multiget_fallback", new Total(), new OccurrenceRate());
-
-    requestParsingLatencySensor = registerSensor("request_parse_latency", new Avg());
-    requestRoutingLatencySensor = registerSensor("request_route_latency", new Avg());
-
-    unAvailableRequestSensor = registerSensor("unavailable_request", new Count());
-
-    delayConstraintAbortedRetryRequest = registerSensor("delay_constraint_aborted_retry_request", new Count());
-    slowRouteAbortedRetryRequest = registerSensor("slow_route_aborted_retry_request", new Count());
-    retryRouteLimitAbortedRetryRequest = registerSensor("retry_route_limit_aborted_retry_request", new Count());
-    noAvailableReplicaAbortedRetryRequest = registerSensor("no_available_replica_aborted_retry_request", new Count());
-
-    readQuotaUsageSensor = registerSensor("read_quota_usage_kps", new Total());
-
-    inFlightRequestSensor = registerSensor("in_flight_request_count", new Min(), new Max(0), new Avg());
-
-    String responseSizeSensorName = "response_size";
-    if (isKeyValueProfilingEnabled && storeName.equals(STORE_NAME_FOR_TOTAL_STAT)) {
-      String keySizeSensorName = "key_size_in_byte";
-      keySizeSensor = registerSensor(
-          keySizeSensorName,
+    if (!isSystemStore) {
+      Rate requestRate = new OccurrenceRate();
+      Rate healthyRequestRate = new OccurrenceRate();
+      Rate tardyRequestRate = new OccurrenceRate();
+      requestSensor = registerSensor("request", new Count(), requestRate);
+      healthySensor = registerSensor("healthy_request", new Count(), healthyRequestRate);
+      unhealthySensor = registerSensor("unhealthy_request", new Count());
+      unavailableReplicaStreamingRequestSensor = registerSensor("unavailable_replica_streaming_request", new Count());
+      tardySensor = registerSensor("tardy_request", new Count(), tardyRequestRate);
+      healthyRequestRateSensor =
+          registerSensor("healthy_request_ratio", new TehutiUtils.SimpleRatioStat(healthyRequestRate, requestRate));
+      tardyRequestRatioSensor =
+          registerSensor("tardy_request_ratio", new TehutiUtils.SimpleRatioStat(tardyRequestRate, requestRate));
+      throttleSensor = registerSensor("throttled_request", new Count());
+      badRequestSensor = registerSensor("bad_request", new Count());
+      badRequestKeyCountSensor = registerSensor("bad_request_key_count", new OccurrenceRate(), new Avg(), new Max());
+      requestThrottledByRouterCapacitySensor = registerSensor("request_throttled_by_router_capacity", new Count());
+      fanoutRequestCountSensor = registerSensor("fanout_request_count", new Avg(), new Max(0));
+      latencySensor = registerSensorWithDetailedPercentiles("latency", new Avg(), new Max(0));
+      healthyRequestLatencySensor =
+          registerSensorWithDetailedPercentiles("healthy_request_latency", new Avg(), new Max(0));
+      unhealthyRequestLatencySensor =
+          registerSensorWithDetailedPercentiles("unhealthy_request_latency", new Avg(), new Max(0));
+      tardyRequestLatencySensor = registerSensorWithDetailedPercentiles("tardy_request_latency", new Avg(), new Max(0));
+      throttledRequestLatencySensor =
+          registerSensorWithDetailedPercentiles("throttled_request_latency", new Avg(), new Max(0));
+      routerResponseWaitingTimeSensor = registerSensor(
+          "response_waiting_time",
+          TehutiUtils.getPercentileStat(getName(), getFullMetricName("response_waiting_time")));
+      requestSizeSensor = registerSensor(
+          "request_size",
+          TehutiUtils.getPercentileStat(getName(), getFullMetricName("request_size")),
+          new Avg());
+      compressedResponseSizeSensor = registerSensor(
+          "compressed_response_size",
+          TehutiUtils.getPercentileStat(getName(), getFullMetricName("compressed_response_size")),
           new Avg(),
-          new Max(),
-          TehutiUtils.getFineGrainedPercentileStat(getName(), getFullMetricName(keySizeSensorName)));
-      responseSizeSensor = registerSensor(
-          responseSizeSensorName,
-          new Avg(),
-          new Max(),
-          TehutiUtils.getFineGrainedPercentileStat(getName(), getFullMetricName(responseSizeSensorName)));
-    } else {
-      responseSizeSensor = registerSensor(
-          responseSizeSensorName,
-          new Avg(),
-          new Max(),
-          TehutiUtils.getPercentileStat(getName(), getFullMetricName(responseSizeSensorName)));
+          new Max());
+
+      decompressionTimeSensor = registerSensor(
+          "decompression_time",
+          TehutiUtils.getPercentileStat(getName(), getFullMetricName("decompression_time")),
+          new Avg());
+      quotaSensor = registerSensor("read_quota_per_router", new Gauge());
+      findUnhealthyHostRequestSensor = registerSensor("find_unhealthy_host_request", new OccurrenceRate());
+
+      registerSensor("retry_count", new LambdaStat(() -> scatterGatherStats.getTotalRetries()));
+      registerSensor("retry_key_count", new LambdaStat(() -> scatterGatherStats.getTotalRetriedKeys()));
+      registerSensor(
+          "retry_slower_than_original_count",
+          new LambdaStat(() -> scatterGatherStats.getTotalRetriesDiscarded()));
+      registerSensor("retry_error_count", new LambdaStat(() -> scatterGatherStats.getTotalRetriesError()));
+      registerSensor(
+          "retry_faster_than_original_count",
+          new LambdaStat(() -> scatterGatherStats.getTotalRetriesWinner()));
+
+      keyNumSensor = registerSensor("key_num", new Avg(), new Max(0));
+      /**
+       * request_usage.Total is incoming KPS while request_usage.OccurrenceRate is QPS
+       */
+      requestUsageSensor = registerSensor("request_usage", new Total(), new OccurrenceRate());
+      multiGetFallbackSensor = registerSensor("multiget_fallback", new Total(), new OccurrenceRate());
+
+      requestParsingLatencySensor = registerSensor("request_parse_latency", new Avg());
+      requestRoutingLatencySensor = registerSensor("request_route_latency", new Avg());
+
+      unAvailableRequestSensor = registerSensor("unavailable_request", new Count());
+
+      delayConstraintAbortedRetryRequest = registerSensor("delay_constraint_aborted_retry_request", new Count());
+      slowRouteAbortedRetryRequest = registerSensor("slow_route_aborted_retry_request", new Count());
+      retryRouteLimitAbortedRetryRequest = registerSensor("retry_route_limit_aborted_retry_request", new Count());
+      noAvailableReplicaAbortedRetryRequest = registerSensor("no_available_replica_aborted_retry_request", new Count());
+
+      readQuotaUsageSensor = registerSensor("read_quota_usage_kps", new Total());
+
+      inFlightRequestSensor = registerSensor("in_flight_request_count", new Min(), new Max(0), new Avg());
+
+      String responseSizeSensorName = "response_size";
+      if (isKeyValueProfilingEnabled && storeName.equals(STORE_NAME_FOR_TOTAL_STAT)) {
+        String keySizeSensorName = "key_size_in_byte";
+        keySizeSensor = registerSensor(
+            keySizeSensorName,
+            new Avg(),
+            new Max(),
+            TehutiUtils.getFineGrainedPercentileStat(getName(), getFullMetricName(keySizeSensorName)));
+        responseSizeSensor = registerSensor(
+            responseSizeSensorName,
+            new Avg(),
+            new Max(),
+            TehutiUtils.getFineGrainedPercentileStat(getName(), getFullMetricName(responseSizeSensorName)));
+      } else {
+        responseSizeSensor = registerSensor(
+            responseSizeSensorName,
+            new Avg(),
+            new Max(),
+            TehutiUtils.getPercentileStat(getName(), getFullMetricName(responseSizeSensorName)));
+      }
+      currentInFlightRequest = new AtomicInteger();
+
+      allowedRetryRequestSensor = registerSensor("allowed_retry_request_count", new OccurrenceRate());
+      disallowedRetryRequestSensor = registerSensor("disallowed_retry_request_count", new OccurrenceRate());
+      errorRetryAttemptTriggeredByPendingRequestCheckSensor =
+          registerSensor("error_retry_attempt_triggered_by_pending_request_check", new OccurrenceRate());
+      retryDelaySensor = registerSensor("retry_delay", new Avg(), new Max());
+      metaStoreShadowReadSensor = registerSensor("meta_store_shadow_read", new OccurrenceRate());
     }
-    currentInFlightRequest = new AtomicInteger();
-
-    allowedRetryRequestSensor = registerSensor("allowed_retry_request_count", new OccurrenceRate());
-    disallowedRetryRequestSensor = registerSensor("disallowed_retry_request_count", new OccurrenceRate());
-    errorRetryAttemptTriggeredByPendingRequestCheckSensor =
-        registerSensor("error_retry_attempt_triggered_by_pending_request_check", new OccurrenceRate());
-    retryDelaySensor = registerSensor("retry_delay", new Avg(), new Max());
-    metaStoreShadowReadSensor = registerSensor("meta_store_shadow_read", new OccurrenceRate());
   }
 
   /**
@@ -186,11 +192,17 @@ public class RouterHttpRequestStats extends AbstractVeniceHttpStats {
    * types of requests also have their latencies logged at the same time.
    */
   public void recordRequest() {
+    if (isSystemStore) {
+      return;
+    }
     requestSensor.record();
     inFlightRequestSensor.record(currentInFlightRequest.incrementAndGet());
   }
 
   public void recordHealthyRequest(Double latency) {
+    if (isSystemStore) {
+      return;
+    }
     healthySensor.record();
     if (latency != null) {
       healthyRequestLatencySensor.record(latency);
@@ -198,14 +210,23 @@ public class RouterHttpRequestStats extends AbstractVeniceHttpStats {
   }
 
   public void recordUnhealthyRequest() {
+    if (isSystemStore) {
+      return;
+    }
     unhealthySensor.record();
   }
 
   public void recordUnavailableReplicaStreamingRequest() {
+    if (isSystemStore) {
+      return;
+    }
     unavailableReplicaStreamingRequestSensor.record();
   }
 
   public void recordUnhealthyRequest(double latency) {
+    if (isSystemStore) {
+      return;
+    }
     recordUnhealthyRequest();
     unhealthyRequestLatencySensor.record(latency);
   }
@@ -215,15 +236,24 @@ public class RouterHttpRequestStats extends AbstractVeniceHttpStats {
    * @param quotaUsage
    */
   public void recordReadQuotaUsage(int quotaUsage) {
+    if (isSystemStore) {
+      return;
+    }
     readQuotaUsageSensor.record(quotaUsage);
   }
 
   public void recordTardyRequest(double latency) {
+    if (isSystemStore) {
+      return;
+    }
     tardySensor.record();
     tardyRequestLatencySensor.record(latency);
   }
 
   public void recordThrottledRequest(double latency) {
+    if (isSystemStore) {
+      return;
+    }
     recordThrottledRequest();
     throttledRequestLatencySensor.record(latency);
   }
@@ -236,106 +266,181 @@ public class RouterHttpRequestStats extends AbstractVeniceHttpStats {
    * TODO: Remove this overload after fixing the above.
    */
   public void recordThrottledRequest() {
+    if (isSystemStore) {
+      return;
+    }
     throttleSensor.record();
   }
 
   public void recordBadRequest() {
+    if (isSystemStore) {
+      return;
+    }
     badRequestSensor.record();
   }
 
   public void recordBadRequestKeyCount(int keyCount) {
+    if (isSystemStore) {
+      return;
+    }
     badRequestKeyCountSensor.record(keyCount);
   }
 
   public void recordRequestThrottledByRouterCapacity() {
+    if (isSystemStore) {
+      return;
+    }
     requestThrottledByRouterCapacitySensor.record();
   }
 
   public void recordFanoutRequestCount(int count) {
+    if (isSystemStore) {
+      return;
+    }
     if (!getRequestType().equals(RequestType.SINGLE_GET)) {
       fanoutRequestCountSensor.record(count);
     }
   }
 
   public void recordLatency(double latency) {
+    if (isSystemStore) {
+      return;
+    }
     latencySensor.record(latency);
   }
 
   public void recordResponseWaitingTime(double waitingTime) {
+    if (isSystemStore) {
+      return;
+    }
     routerResponseWaitingTimeSensor.record(waitingTime);
   }
 
   public void recordRequestSize(double requestSize) {
+    if (isSystemStore) {
+      return;
+    }
     requestSizeSensor.record(requestSize);
   }
 
   public void recordCompressedResponseSize(double compressedResponseSize) {
+    if (isSystemStore) {
+      return;
+    }
     compressedResponseSizeSensor.record(compressedResponseSize);
   }
 
   public void recordResponseSize(double responseSize) {
+    if (isSystemStore) {
+      return;
+    }
     responseSizeSensor.record(responseSize);
   }
 
   public void recordDecompressionTime(double decompressionTime) {
+    if (isSystemStore) {
+      return;
+    }
     decompressionTimeSensor.record(decompressionTime);
   }
 
   public void recordQuota(double quota) {
+    if (isSystemStore) {
+      return;
+    }
     quotaSensor.record(quota);
   }
 
   public void recordFindUnhealthyHostRequest() {
+    if (isSystemStore) {
+      return;
+    }
     findUnhealthyHostRequestSensor.record();
   }
 
   public void recordKeyNum(int keyNum) {
+    if (isSystemStore) {
+      return;
+    }
     keyNumSensor.record(keyNum);
   }
 
   public void recordRequestUsage(int usage) {
+    if (isSystemStore) {
+      return;
+    }
     requestUsageSensor.record(usage);
   }
 
   public void recordMultiGetFallback(int keyCount) {
+    if (isSystemStore) {
+      return;
+    }
     multiGetFallbackSensor.record(keyCount);
   }
 
   public void recordRequestParsingLatency(double latency) {
+    if (isSystemStore) {
+      return;
+    }
     requestParsingLatencySensor.record(latency);
   }
 
   public void recordRequestRoutingLatency(double latency) {
+    if (isSystemStore) {
+      return;
+    }
     requestRoutingLatencySensor.record(latency);
   }
 
   public void recordUnavailableRequest() {
+    if (isSystemStore) {
+      return;
+    }
     unAvailableRequestSensor.record();
   }
 
   public void recordDelayConstraintAbortedRetryRequest() {
+    if (isSystemStore) {
+      return;
+    }
     delayConstraintAbortedRetryRequest.record();
   }
 
   public void recordSlowRouteAbortedRetryRequest() {
+    if (isSystemStore) {
+      return;
+    }
     slowRouteAbortedRetryRequest.record();
   }
 
   public void recordRetryRouteLimitAbortedRetryRequest() {
+    if (isSystemStore) {
+      return;
+    }
     retryRouteLimitAbortedRetryRequest.record();
   }
 
   public void recordNoAvailableReplicaAbortedRetryRequest() {
+    if (isSystemStore) {
+      return;
+    }
     noAvailableReplicaAbortedRetryRequest.record();
   }
 
   public void recordKeySizeInByte(long keySize) {
+    if (isSystemStore) {
+      return;
+    }
     if (keySizeSensor != null) {
       keySizeSensor.record(keySize);
     }
   }
 
   public void recordResponse() {
+    if (isSystemStore) {
+      return;
+    }
     /**
      * We already report into the sensor when the request starts, in {@link #recordRequest()}, so at response time
      * there is no need to record into the sensor again. We just want to maintain the bookkeeping.
@@ -344,22 +449,37 @@ public class RouterHttpRequestStats extends AbstractVeniceHttpStats {
   }
 
   public void recordAllowedRetryRequest() {
+    if (isSystemStore) {
+      return;
+    }
     allowedRetryRequestSensor.record();
   }
 
   public void recordDisallowedRetryRequest() {
+    if (isSystemStore) {
+      return;
+    }
     disallowedRetryRequestSensor.record();
   }
 
   public void recordErrorRetryAttemptTriggeredByPendingRequestCheck() {
+    if (isSystemStore) {
+      return;
+    }
     errorRetryAttemptTriggeredByPendingRequestCheckSensor.record();
   }
 
   public void recordRetryDelay(double delay) {
+    if (isSystemStore) {
+      return;
+    }
     retryDelaySensor.record(delay);
   }
 
   public void recordMetaStoreShadowRead() {
+    if (isSystemStore) {
+      return;
+    }
     metaStoreShadowReadSensor.record();
   }
 }

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/stats/RouterHttpRequestStats.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/stats/RouterHttpRequestStats.java
@@ -67,7 +67,7 @@ public class RouterHttpRequestStats extends AbstractVeniceHttpStats {
   private final Sensor multiGetFallbackSensor;
   private final Sensor metaStoreShadowReadSensor;
   private Sensor keySizeSensor;
-  private Sensor systemStoreSensor = null;
+  private final String systemStoreName;
 
   // QPS metrics
   public RouterHttpRequestStats(
@@ -77,12 +77,7 @@ public class RouterHttpRequestStats extends AbstractVeniceHttpStats {
       ScatterGatherStats scatterGatherStats,
       boolean isKeyValueProfilingEnabled) {
     super(metricsRepository, storeName, requestType);
-    if (VeniceSystemStoreUtils.isSystemStore(storeName)) {
-      String systemStoreName = VeniceSystemStoreUtils.extractSystemStoreType(storeName);
-      if (!systemStoreName.isEmpty()) {
-        this.systemStoreSensor = metricsRepository.sensor(systemStoreName);
-      }
-    }
+    this.systemStoreName = VeniceSystemStoreUtils.extractSystemStoreType(storeName);
     Rate requestRate = new OccurrenceRate();
     Rate healthyRequestRate = new OccurrenceRate();
     Rate tardyRequestRate = new OccurrenceRate();
@@ -373,9 +368,6 @@ public class RouterHttpRequestStats extends AbstractVeniceHttpStats {
 
   @Override
   protected Sensor registerSensor(String sensorName, MeasurableStat... stats) {
-    if (systemStoreSensor != null) {
-      return systemStoreSensor;
-    }
-    return super.registerSensor(getFullMetricName(sensorName), null, stats);
+    return super.registerSensor(systemStoreName == null ? sensorName : systemStoreName, null, stats);
   }
 }

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/stats/RouterHttpRequestStats.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/stats/RouterHttpRequestStats.java
@@ -8,6 +8,7 @@ import com.linkedin.venice.read.RequestType;
 import com.linkedin.venice.stats.AbstractVeniceHttpStats;
 import com.linkedin.venice.stats.LambdaStat;
 import com.linkedin.venice.stats.TehutiUtils;
+import io.tehuti.metrics.MeasurableStat;
 import io.tehuti.metrics.MetricsRepository;
 import io.tehuti.metrics.Sensor;
 import io.tehuti.metrics.stats.Avg;
@@ -22,52 +23,53 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 
 public class RouterHttpRequestStats extends AbstractVeniceHttpStats {
-  private Sensor requestSensor = null;
-  private Sensor healthySensor = null;
-  private Sensor unhealthySensor = null;
-  private Sensor tardySensor = null;
-  private Sensor healthyRequestRateSensor = null;
-  private Sensor tardyRequestRatioSensor = null;
-  private Sensor throttleSensor = null;
-  private Sensor latencySensor = null;
-  private Sensor healthyRequestLatencySensor = null;
-  private Sensor unhealthyRequestLatencySensor = null;
-  private Sensor tardyRequestLatencySensor = null;
-  private Sensor throttledRequestLatencySensor = null;
-  private Sensor requestSizeSensor = null;
-  private Sensor compressedResponseSizeSensor = null;
-  private Sensor responseSizeSensor = null;
-  private Sensor badRequestSensor = null;
-  private Sensor badRequestKeyCountSensor = null;
-  private Sensor requestThrottledByRouterCapacitySensor = null;
-  private Sensor decompressionTimeSensor = null;
-  private Sensor routerResponseWaitingTimeSensor = null;
-  private Sensor fanoutRequestCountSensor = null;
-  private Sensor quotaSensor = null;
-  private Sensor findUnhealthyHostRequestSensor = null;
-  private Sensor keyNumSensor = null;
+  private final Sensor requestSensor;
+  private final Sensor healthySensor;
+  private final Sensor unhealthySensor;
+  private final Sensor tardySensor;
+  private final Sensor healthyRequestRateSensor;
+  private final Sensor tardyRequestRatioSensor;
+  private final Sensor throttleSensor;
+  private final Sensor latencySensor;
+  private final Sensor healthyRequestLatencySensor;
+  private final Sensor unhealthyRequestLatencySensor;
+  private final Sensor tardyRequestLatencySensor;
+  private final Sensor throttledRequestLatencySensor;
+  private final Sensor requestSizeSensor;
+  private final Sensor compressedResponseSizeSensor;
+  private final Sensor responseSizeSensor;
+  private final Sensor badRequestSensor;
+  private final Sensor badRequestKeyCountSensor;
+  private final Sensor requestThrottledByRouterCapacitySensor;
+  private final Sensor decompressionTimeSensor;
+  private final Sensor routerResponseWaitingTimeSensor;
+  private final Sensor fanoutRequestCountSensor;
+  private final Sensor quotaSensor;
+  private final Sensor findUnhealthyHostRequestSensor;
+  private final Sensor keyNumSensor;
   // Reflect the real request usage, e.g count each key as an unit of request usage.
-  private Sensor requestUsageSensor = null;
-  private Sensor requestParsingLatencySensor = null;
-  private Sensor requestRoutingLatencySensor = null;
-  private Sensor unAvailableRequestSensor = null;
-  private Sensor delayConstraintAbortedRetryRequest = null;
-  private Sensor slowRouteAbortedRetryRequest = null;
-  private Sensor retryRouteLimitAbortedRetryRequest = null;
-  private Sensor noAvailableReplicaAbortedRetryRequest = null;
-  private Sensor readQuotaUsageSensor = null;
-  private Sensor inFlightRequestSensor = null;
-  private AtomicInteger currentInFlightRequest = null;
-  private Sensor unavailableReplicaStreamingRequestSensor = null;
-  private Sensor allowedRetryRequestSensor = null;
-  private Sensor disallowedRetryRequestSensor = null;
-  private Sensor errorRetryAttemptTriggeredByPendingRequestCheckSensor = null;
-  private Sensor retryDelaySensor = null;
-  private Sensor multiGetFallbackSensor = null;
-  private Sensor metaStoreShadowReadSensor = null;
+  private final Sensor requestUsageSensor;
+  private final Sensor requestParsingLatencySensor;
+  private final Sensor requestRoutingLatencySensor;
+  private final Sensor unAvailableRequestSensor;
+  private final Sensor delayConstraintAbortedRetryRequest;
+  private final Sensor slowRouteAbortedRetryRequest;
+  private final Sensor retryRouteLimitAbortedRetryRequest;
+  private final Sensor noAvailableReplicaAbortedRetryRequest;
+  private final Sensor readQuotaUsageSensor;
+  private final Sensor inFlightRequestSensor;
+  private final AtomicInteger currentInFlightRequest;
+  private final Sensor unavailableReplicaStreamingRequestSensor;
+  private final Sensor allowedRetryRequestSensor;
+  private final Sensor disallowedRetryRequestSensor;
+  private final Sensor errorRetryAttemptTriggeredByPendingRequestCheckSensor;
+  private final Sensor retryDelaySensor;
+  private final Sensor multiGetFallbackSensor;
+  private final Sensor metaStoreShadowReadSensor;
   private Sensor keySizeSensor;
+  private final boolean isSystemStore;
 
-  private boolean isSystemStore;
+  private Sensor systemStoreSensor = null;
 
   // QPS metrics
   public RouterHttpRequestStats(
@@ -78,113 +80,114 @@ public class RouterHttpRequestStats extends AbstractVeniceHttpStats {
       boolean isKeyValueProfilingEnabled) {
     super(metricsRepository, storeName, requestType);
     this.isSystemStore = VeniceSystemStoreUtils.isSystemStore(storeName);
-
-    if (!isSystemStore) {
-      Rate requestRate = new OccurrenceRate();
-      Rate healthyRequestRate = new OccurrenceRate();
-      Rate tardyRequestRate = new OccurrenceRate();
-      requestSensor = registerSensor("request", new Count(), requestRate);
-      healthySensor = registerSensor("healthy_request", new Count(), healthyRequestRate);
-      unhealthySensor = registerSensor("unhealthy_request", new Count());
-      unavailableReplicaStreamingRequestSensor = registerSensor("unavailable_replica_streaming_request", new Count());
-      tardySensor = registerSensor("tardy_request", new Count(), tardyRequestRate);
-      healthyRequestRateSensor =
-          registerSensor("healthy_request_ratio", new TehutiUtils.SimpleRatioStat(healthyRequestRate, requestRate));
-      tardyRequestRatioSensor =
-          registerSensor("tardy_request_ratio", new TehutiUtils.SimpleRatioStat(tardyRequestRate, requestRate));
-      throttleSensor = registerSensor("throttled_request", new Count());
-      badRequestSensor = registerSensor("bad_request", new Count());
-      badRequestKeyCountSensor = registerSensor("bad_request_key_count", new OccurrenceRate(), new Avg(), new Max());
-      requestThrottledByRouterCapacitySensor = registerSensor("request_throttled_by_router_capacity", new Count());
-      fanoutRequestCountSensor = registerSensor("fanout_request_count", new Avg(), new Max(0));
-      latencySensor = registerSensorWithDetailedPercentiles("latency", new Avg(), new Max(0));
-      healthyRequestLatencySensor =
-          registerSensorWithDetailedPercentiles("healthy_request_latency", new Avg(), new Max(0));
-      unhealthyRequestLatencySensor =
-          registerSensorWithDetailedPercentiles("unhealthy_request_latency", new Avg(), new Max(0));
-      tardyRequestLatencySensor = registerSensorWithDetailedPercentiles("tardy_request_latency", new Avg(), new Max(0));
-      throttledRequestLatencySensor =
-          registerSensorWithDetailedPercentiles("throttled_request_latency", new Avg(), new Max(0));
-      routerResponseWaitingTimeSensor = registerSensor(
-          "response_waiting_time",
-          TehutiUtils.getPercentileStat(getName(), getFullMetricName("response_waiting_time")));
-      requestSizeSensor = registerSensor(
-          "request_size",
-          TehutiUtils.getPercentileStat(getName(), getFullMetricName("request_size")),
-          new Avg());
-      compressedResponseSizeSensor = registerSensor(
-          "compressed_response_size",
-          TehutiUtils.getPercentileStat(getName(), getFullMetricName("compressed_response_size")),
-          new Avg(),
-          new Max());
-
-      decompressionTimeSensor = registerSensor(
-          "decompression_time",
-          TehutiUtils.getPercentileStat(getName(), getFullMetricName("decompression_time")),
-          new Avg());
-      quotaSensor = registerSensor("read_quota_per_router", new Gauge());
-      findUnhealthyHostRequestSensor = registerSensor("find_unhealthy_host_request", new OccurrenceRate());
-
-      registerSensor("retry_count", new LambdaStat(() -> scatterGatherStats.getTotalRetries()));
-      registerSensor("retry_key_count", new LambdaStat(() -> scatterGatherStats.getTotalRetriedKeys()));
-      registerSensor(
-          "retry_slower_than_original_count",
-          new LambdaStat(() -> scatterGatherStats.getTotalRetriesDiscarded()));
-      registerSensor("retry_error_count", new LambdaStat(() -> scatterGatherStats.getTotalRetriesError()));
-      registerSensor(
-          "retry_faster_than_original_count",
-          new LambdaStat(() -> scatterGatherStats.getTotalRetriesWinner()));
-
-      keyNumSensor = registerSensor("key_num", new Avg(), new Max(0));
-      /**
-       * request_usage.Total is incoming KPS while request_usage.OccurrenceRate is QPS
-       */
-      requestUsageSensor = registerSensor("request_usage", new Total(), new OccurrenceRate());
-      multiGetFallbackSensor = registerSensor("multiget_fallback", new Total(), new OccurrenceRate());
-
-      requestParsingLatencySensor = registerSensor("request_parse_latency", new Avg());
-      requestRoutingLatencySensor = registerSensor("request_route_latency", new Avg());
-
-      unAvailableRequestSensor = registerSensor("unavailable_request", new Count());
-
-      delayConstraintAbortedRetryRequest = registerSensor("delay_constraint_aborted_retry_request", new Count());
-      slowRouteAbortedRetryRequest = registerSensor("slow_route_aborted_retry_request", new Count());
-      retryRouteLimitAbortedRetryRequest = registerSensor("retry_route_limit_aborted_retry_request", new Count());
-      noAvailableReplicaAbortedRetryRequest = registerSensor("no_available_replica_aborted_retry_request", new Count());
-
-      readQuotaUsageSensor = registerSensor("read_quota_usage_kps", new Total());
-
-      inFlightRequestSensor = registerSensor("in_flight_request_count", new Min(), new Max(0), new Avg());
-
-      String responseSizeSensorName = "response_size";
-      if (isKeyValueProfilingEnabled && storeName.equals(STORE_NAME_FOR_TOTAL_STAT)) {
-        String keySizeSensorName = "key_size_in_byte";
-        keySizeSensor = registerSensor(
-            keySizeSensorName,
-            new Avg(),
-            new Max(),
-            TehutiUtils.getFineGrainedPercentileStat(getName(), getFullMetricName(keySizeSensorName)));
-        responseSizeSensor = registerSensor(
-            responseSizeSensorName,
-            new Avg(),
-            new Max(),
-            TehutiUtils.getFineGrainedPercentileStat(getName(), getFullMetricName(responseSizeSensorName)));
-      } else {
-        responseSizeSensor = registerSensor(
-            responseSizeSensorName,
-            new Avg(),
-            new Max(),
-            TehutiUtils.getPercentileStat(getName(), getFullMetricName(responseSizeSensorName)));
-      }
-      currentInFlightRequest = new AtomicInteger();
-
-      allowedRetryRequestSensor = registerSensor("allowed_retry_request_count", new OccurrenceRate());
-      disallowedRetryRequestSensor = registerSensor("disallowed_retry_request_count", new OccurrenceRate());
-      errorRetryAttemptTriggeredByPendingRequestCheckSensor =
-          registerSensor("error_retry_attempt_triggered_by_pending_request_check", new OccurrenceRate());
-      retryDelaySensor = registerSensor("retry_delay", new Avg(), new Max());
-      metaStoreShadowReadSensor = registerSensor("meta_store_shadow_read", new OccurrenceRate());
+    if (isSystemStore) {
+      MetricsRepository dummyMetricRepo = new MetricsRepository();
+      this.systemStoreSensor = dummyMetricRepo.sensor("dummy_system_store_sensor");
     }
+    Rate requestRate = new OccurrenceRate();
+    Rate healthyRequestRate = new OccurrenceRate();
+    Rate tardyRequestRate = new OccurrenceRate();
+    requestSensor = registerSensor("request", new Count(), requestRate);
+    healthySensor = registerSensor("healthy_request", new Count(), healthyRequestRate);
+    unhealthySensor = registerSensor("unhealthy_request", new Count());
+    unavailableReplicaStreamingRequestSensor = registerSensor("unavailable_replica_streaming_request", new Count());
+    tardySensor = registerSensor("tardy_request", new Count(), tardyRequestRate);
+    healthyRequestRateSensor =
+        registerSensor("healthy_request_ratio", new TehutiUtils.SimpleRatioStat(healthyRequestRate, requestRate));
+    tardyRequestRatioSensor =
+        registerSensor("tardy_request_ratio", new TehutiUtils.SimpleRatioStat(tardyRequestRate, requestRate));
+    throttleSensor = registerSensor("throttled_request", new Count());
+    badRequestSensor = registerSensor("bad_request", new Count());
+    badRequestKeyCountSensor = registerSensor("bad_request_key_count", new OccurrenceRate(), new Avg(), new Max());
+    requestThrottledByRouterCapacitySensor = registerSensor("request_throttled_by_router_capacity", new Count());
+    fanoutRequestCountSensor = registerSensor("fanout_request_count", new Avg(), new Max(0));
+    latencySensor = registerSensorWithDetailedPercentiles("latency", new Avg(), new Max(0));
+    healthyRequestLatencySensor =
+        registerSensorWithDetailedPercentiles("healthy_request_latency", new Avg(), new Max(0));
+    unhealthyRequestLatencySensor =
+        registerSensorWithDetailedPercentiles("unhealthy_request_latency", new Avg(), new Max(0));
+    tardyRequestLatencySensor = registerSensorWithDetailedPercentiles("tardy_request_latency", new Avg(), new Max(0));
+    throttledRequestLatencySensor =
+        registerSensorWithDetailedPercentiles("throttled_request_latency", new Avg(), new Max(0));
+    routerResponseWaitingTimeSensor = registerSensor(
+        "response_waiting_time",
+        TehutiUtils.getPercentileStat(getName(), getFullMetricName("response_waiting_time")));
+    requestSizeSensor = registerSensor(
+        "request_size",
+        TehutiUtils.getPercentileStat(getName(), getFullMetricName("request_size")),
+        new Avg());
+    compressedResponseSizeSensor = registerSensor(
+        "compressed_response_size",
+        TehutiUtils.getPercentileStat(getName(), getFullMetricName("compressed_response_size")),
+        new Avg(),
+        new Max());
+
+    decompressionTimeSensor = registerSensor(
+        "decompression_time",
+        TehutiUtils.getPercentileStat(getName(), getFullMetricName("decompression_time")),
+        new Avg());
+    quotaSensor = registerSensor("read_quota_per_router", new Gauge());
+    findUnhealthyHostRequestSensor = registerSensor("find_unhealthy_host_request", new OccurrenceRate());
+
+    registerSensor("retry_count", new LambdaStat(() -> scatterGatherStats.getTotalRetries()));
+    registerSensor("retry_key_count", new LambdaStat(() -> scatterGatherStats.getTotalRetriedKeys()));
+    registerSensor(
+        "retry_slower_than_original_count",
+        new LambdaStat(() -> scatterGatherStats.getTotalRetriesDiscarded()));
+    registerSensor("retry_error_count", new LambdaStat(() -> scatterGatherStats.getTotalRetriesError()));
+    registerSensor(
+        "retry_faster_than_original_count",
+        new LambdaStat(() -> scatterGatherStats.getTotalRetriesWinner()));
+
+    keyNumSensor = registerSensor("key_num", new Avg(), new Max(0));
+    /**
+     * request_usage.Total is incoming KPS while request_usage.OccurrenceRate is QPS
+     */
+    requestUsageSensor = registerSensor("request_usage", new Total(), new OccurrenceRate());
+    multiGetFallbackSensor = registerSensor("multiget_fallback", new Total(), new OccurrenceRate());
+
+    requestParsingLatencySensor = registerSensor("request_parse_latency", new Avg());
+    requestRoutingLatencySensor = registerSensor("request_route_latency", new Avg());
+
+    unAvailableRequestSensor = registerSensor("unavailable_request", new Count());
+
+    delayConstraintAbortedRetryRequest = registerSensor("delay_constraint_aborted_retry_request", new Count());
+    slowRouteAbortedRetryRequest = registerSensor("slow_route_aborted_retry_request", new Count());
+    retryRouteLimitAbortedRetryRequest = registerSensor("retry_route_limit_aborted_retry_request", new Count());
+    noAvailableReplicaAbortedRetryRequest = registerSensor("no_available_replica_aborted_retry_request", new Count());
+
+    readQuotaUsageSensor = registerSensor("read_quota_usage_kps", new Total());
+
+    inFlightRequestSensor = registerSensor("in_flight_request_count", new Min(), new Max(0), new Avg());
+
+    String responseSizeSensorName = "response_size";
+    if (isKeyValueProfilingEnabled && storeName.equals(STORE_NAME_FOR_TOTAL_STAT)) {
+      String keySizeSensorName = "key_size_in_byte";
+      keySizeSensor = registerSensor(
+          keySizeSensorName,
+          new Avg(),
+          new Max(),
+          TehutiUtils.getFineGrainedPercentileStat(getName(), getFullMetricName(keySizeSensorName)));
+      responseSizeSensor = registerSensor(
+          responseSizeSensorName,
+          new Avg(),
+          new Max(),
+          TehutiUtils.getFineGrainedPercentileStat(getName(), getFullMetricName(responseSizeSensorName)));
+    } else {
+      responseSizeSensor = registerSensor(
+          responseSizeSensorName,
+          new Avg(),
+          new Max(),
+          TehutiUtils.getPercentileStat(getName(), getFullMetricName(responseSizeSensorName)));
+    }
+    currentInFlightRequest = new AtomicInteger();
+
+    allowedRetryRequestSensor = registerSensor("allowed_retry_request_count", new OccurrenceRate());
+    disallowedRetryRequestSensor = registerSensor("disallowed_retry_request_count", new OccurrenceRate());
+    errorRetryAttemptTriggeredByPendingRequestCheckSensor =
+        registerSensor("error_retry_attempt_triggered_by_pending_request_check", new OccurrenceRate());
+    retryDelaySensor = registerSensor("retry_delay", new Avg(), new Max());
+    metaStoreShadowReadSensor = registerSensor("meta_store_shadow_read", new OccurrenceRate());
   }
 
   /**
@@ -192,17 +195,11 @@ public class RouterHttpRequestStats extends AbstractVeniceHttpStats {
    * types of requests also have their latencies logged at the same time.
    */
   public void recordRequest() {
-    if (isSystemStore) {
-      return;
-    }
     requestSensor.record();
     inFlightRequestSensor.record(currentInFlightRequest.incrementAndGet());
   }
 
   public void recordHealthyRequest(Double latency) {
-    if (isSystemStore) {
-      return;
-    }
     healthySensor.record();
     if (latency != null) {
       healthyRequestLatencySensor.record(latency);
@@ -210,23 +207,14 @@ public class RouterHttpRequestStats extends AbstractVeniceHttpStats {
   }
 
   public void recordUnhealthyRequest() {
-    if (isSystemStore) {
-      return;
-    }
     unhealthySensor.record();
   }
 
   public void recordUnavailableReplicaStreamingRequest() {
-    if (isSystemStore) {
-      return;
-    }
     unavailableReplicaStreamingRequestSensor.record();
   }
 
   public void recordUnhealthyRequest(double latency) {
-    if (isSystemStore) {
-      return;
-    }
     recordUnhealthyRequest();
     unhealthyRequestLatencySensor.record(latency);
   }
@@ -236,24 +224,15 @@ public class RouterHttpRequestStats extends AbstractVeniceHttpStats {
    * @param quotaUsage
    */
   public void recordReadQuotaUsage(int quotaUsage) {
-    if (isSystemStore) {
-      return;
-    }
     readQuotaUsageSensor.record(quotaUsage);
   }
 
   public void recordTardyRequest(double latency) {
-    if (isSystemStore) {
-      return;
-    }
     tardySensor.record();
     tardyRequestLatencySensor.record(latency);
   }
 
   public void recordThrottledRequest(double latency) {
-    if (isSystemStore) {
-      return;
-    }
     recordThrottledRequest();
     throttledRequestLatencySensor.record(latency);
   }
@@ -266,181 +245,106 @@ public class RouterHttpRequestStats extends AbstractVeniceHttpStats {
    * TODO: Remove this overload after fixing the above.
    */
   public void recordThrottledRequest() {
-    if (isSystemStore) {
-      return;
-    }
     throttleSensor.record();
   }
 
   public void recordBadRequest() {
-    if (isSystemStore) {
-      return;
-    }
     badRequestSensor.record();
   }
 
   public void recordBadRequestKeyCount(int keyCount) {
-    if (isSystemStore) {
-      return;
-    }
     badRequestKeyCountSensor.record(keyCount);
   }
 
   public void recordRequestThrottledByRouterCapacity() {
-    if (isSystemStore) {
-      return;
-    }
     requestThrottledByRouterCapacitySensor.record();
   }
 
   public void recordFanoutRequestCount(int count) {
-    if (isSystemStore) {
-      return;
-    }
     if (!getRequestType().equals(RequestType.SINGLE_GET)) {
       fanoutRequestCountSensor.record(count);
     }
   }
 
   public void recordLatency(double latency) {
-    if (isSystemStore) {
-      return;
-    }
     latencySensor.record(latency);
   }
 
   public void recordResponseWaitingTime(double waitingTime) {
-    if (isSystemStore) {
-      return;
-    }
     routerResponseWaitingTimeSensor.record(waitingTime);
   }
 
   public void recordRequestSize(double requestSize) {
-    if (isSystemStore) {
-      return;
-    }
     requestSizeSensor.record(requestSize);
   }
 
   public void recordCompressedResponseSize(double compressedResponseSize) {
-    if (isSystemStore) {
-      return;
-    }
     compressedResponseSizeSensor.record(compressedResponseSize);
   }
 
   public void recordResponseSize(double responseSize) {
-    if (isSystemStore) {
-      return;
-    }
     responseSizeSensor.record(responseSize);
   }
 
   public void recordDecompressionTime(double decompressionTime) {
-    if (isSystemStore) {
-      return;
-    }
     decompressionTimeSensor.record(decompressionTime);
   }
 
   public void recordQuota(double quota) {
-    if (isSystemStore) {
-      return;
-    }
     quotaSensor.record(quota);
   }
 
   public void recordFindUnhealthyHostRequest() {
-    if (isSystemStore) {
-      return;
-    }
     findUnhealthyHostRequestSensor.record();
   }
 
   public void recordKeyNum(int keyNum) {
-    if (isSystemStore) {
-      return;
-    }
     keyNumSensor.record(keyNum);
   }
 
   public void recordRequestUsage(int usage) {
-    if (isSystemStore) {
-      return;
-    }
     requestUsageSensor.record(usage);
   }
 
   public void recordMultiGetFallback(int keyCount) {
-    if (isSystemStore) {
-      return;
-    }
     multiGetFallbackSensor.record(keyCount);
   }
 
   public void recordRequestParsingLatency(double latency) {
-    if (isSystemStore) {
-      return;
-    }
     requestParsingLatencySensor.record(latency);
   }
 
   public void recordRequestRoutingLatency(double latency) {
-    if (isSystemStore) {
-      return;
-    }
     requestRoutingLatencySensor.record(latency);
   }
 
   public void recordUnavailableRequest() {
-    if (isSystemStore) {
-      return;
-    }
     unAvailableRequestSensor.record();
   }
 
   public void recordDelayConstraintAbortedRetryRequest() {
-    if (isSystemStore) {
-      return;
-    }
     delayConstraintAbortedRetryRequest.record();
   }
 
   public void recordSlowRouteAbortedRetryRequest() {
-    if (isSystemStore) {
-      return;
-    }
     slowRouteAbortedRetryRequest.record();
   }
 
   public void recordRetryRouteLimitAbortedRetryRequest() {
-    if (isSystemStore) {
-      return;
-    }
     retryRouteLimitAbortedRetryRequest.record();
   }
 
   public void recordNoAvailableReplicaAbortedRetryRequest() {
-    if (isSystemStore) {
-      return;
-    }
     noAvailableReplicaAbortedRetryRequest.record();
   }
 
   public void recordKeySizeInByte(long keySize) {
-    if (isSystemStore) {
-      return;
-    }
     if (keySizeSensor != null) {
       keySizeSensor.record(keySize);
     }
   }
 
   public void recordResponse() {
-    if (isSystemStore) {
-      return;
-    }
     /**
      * We already report into the sensor when the request starts, in {@link #recordRequest()}, so at response time
      * there is no need to record into the sensor again. We just want to maintain the bookkeeping.
@@ -449,37 +353,30 @@ public class RouterHttpRequestStats extends AbstractVeniceHttpStats {
   }
 
   public void recordAllowedRetryRequest() {
-    if (isSystemStore) {
-      return;
-    }
     allowedRetryRequestSensor.record();
   }
 
   public void recordDisallowedRetryRequest() {
-    if (isSystemStore) {
-      return;
-    }
     disallowedRetryRequestSensor.record();
   }
 
   public void recordErrorRetryAttemptTriggeredByPendingRequestCheck() {
-    if (isSystemStore) {
-      return;
-    }
     errorRetryAttemptTriggeredByPendingRequestCheckSensor.record();
   }
 
   public void recordRetryDelay(double delay) {
-    if (isSystemStore) {
-      return;
-    }
     retryDelaySensor.record(delay);
   }
 
   public void recordMetaStoreShadowRead() {
-    if (isSystemStore) {
-      return;
-    }
     metaStoreShadowReadSensor.record();
+  }
+
+  @Override
+  protected Sensor registerSensor(String sensorName, MeasurableStat... stats) {
+    if (isSystemStore) {
+      return systemStoreSensor;
+    }
+    return super.registerSensor(getFullMetricName(sensorName), null, stats);
   }
 }

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/stats/RouterHttpRequestStats.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/stats/RouterHttpRequestStats.java
@@ -78,8 +78,10 @@ public class RouterHttpRequestStats extends AbstractVeniceHttpStats {
       boolean isKeyValueProfilingEnabled) {
     super(metricsRepository, storeName, requestType);
     if (VeniceSystemStoreUtils.isSystemStore(storeName)) {
-      MetricsRepository dummyMetricRepo = new MetricsRepository();
-      this.systemStoreSensor = dummyMetricRepo.sensor("dummy_system_store_sensor");
+      String systemStoreName = VeniceSystemStoreUtils.extractSystemStoreType(storeName);
+      if (!systemStoreName.isEmpty()) {
+        this.systemStoreSensor = metricsRepository.sensor(systemStoreName);
+      }
     }
     Rate requestRate = new OccurrenceRate();
     Rate healthyRequestRate = new OccurrenceRate();


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Do not register router metrics for system stores
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

The system stores are mostly read from controller and their router metrics are hardly useful for debugging system store issues as most of the time system store issues stems from write path to them. But nonetheless for each user store router emits 2x the number of system store metrics, one for its DVC push status and one for meta store system stores. This PR will stop emitting system store router metrics thus cutting down router metric count by 1/3.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

GHCI

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.