### PR TITLE
[tc][dvc][router][server] Cleaned up some read compute tech debt

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/VersionBackend.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/VersionBackend.java
@@ -234,7 +234,6 @@ public class VersionBackend {
         compressor.get());
 
     return ComputeUtils.computeResult(
-        computeRequestWrapper.getComputeRequestVersion(),
         computeRequestWrapper.getOperations(),
         computeRequestWrapper.getOperationResultFields(),
         sharedContext,
@@ -259,7 +258,6 @@ public class VersionBackend {
           @Override
           public void onRecordReceived(GenericRecord key, GenericRecord value) {
             GenericRecord computeResult = ComputeUtils.computeResult(
-                computeRequestWrapper.getComputeRequestVersion(),
                 computeRequestWrapper.getOperations(),
                 computeRequestWrapper.getOperationResultFields(),
                 sharedContext,

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/client/AvroGenericDaVinciClient.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/client/AvroGenericDaVinciClient.java
@@ -389,7 +389,6 @@ public class AvroGenericDaVinciClient<K, V> implements DaVinciClient<K, V>, Avro
       ComputeUtils.checkResultSchema(
           computeResultSchema,
           computeRequestWrapper.getValueSchema(),
-          computeRequestWrapper.getComputeRequestVersion(),
           computeRequestWrapper.getOperations());
       computeResultSchemaCache.putIfAbsent(computeResultSchemaStr, computeResultSchema);
     }
@@ -430,7 +429,6 @@ public class AvroGenericDaVinciClient<K, V> implements DaVinciClient<K, V>, Avro
 
       Map<String, Object> globalContext = new HashMap<>();
       Schema computeResultSchema = getComputeResultSchema(computeRequestWrapper);
-      computeRequestWrapper.initializeOperationResultFields(computeResultSchema);
 
       int readerSchemaId = versionBackend.getSupersetOrLatestValueSchemaId();
       for (K key: keys) {
@@ -505,7 +503,6 @@ public class AvroGenericDaVinciClient<K, V> implements DaVinciClient<K, V>, Avro
 
       Map<String, Object> globalContext = new HashMap<>();
       Schema computeResultSchema = getComputeResultSchema(computeRequestWrapper);
-      computeRequestWrapper.initializeOperationResultFields(computeResultSchema);
 
       int partitionCount = versionBackend.getPartitionCount();
       for (int currPartition = 0; currPartition < partitionCount; currPartition++) {

--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/schema/SchemaAndToString.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/schema/SchemaAndToString.java
@@ -1,0 +1,25 @@
+package com.linkedin.venice.client.schema;
+
+import org.apache.avro.Schema;
+
+
+/**
+ * Used to cache the toString of a given schema, since it is expensive to compute.
+ */
+public class SchemaAndToString {
+  private final Schema schema;
+  private final String toString;
+
+  public SchemaAndToString(Schema schema) {
+    this.schema = schema;
+    this.toString = schema.toString();
+  }
+
+  public Schema getSchema() {
+    return schema;
+  }
+
+  public String getToString() {
+    return toString;
+  }
+}

--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/AvroBlackHoleResponseStoreClientImpl.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/AvroBlackHoleResponseStoreClientImpl.java
@@ -1,7 +1,5 @@
 package com.linkedin.venice.client.store;
 
-import static com.linkedin.venice.VeniceConstants.COMPUTE_REQUEST_VERSION_V2;
-
 import com.linkedin.venice.client.exceptions.VeniceClientException;
 import com.linkedin.venice.client.store.streaming.DelegatingTrackingCallback;
 import com.linkedin.venice.client.store.streaming.StreamingCallback;
@@ -45,9 +43,7 @@ public class AvroBlackHoleResponseStoreClientImpl<K, V> extends AvroGenericStore
 
     byte[] serializedComputeRequest = serializeComputeRequest(computeRequestWrapper, keys);
 
-    Map<String, String> headerMap = (computeRequestWrapper.getComputeRequestVersion() == COMPUTE_REQUEST_VERSION_V2)
-        ? COMPUTE_HEADER_MAP_FOR_STREAMING_V2
-        : COMPUTE_HEADER_MAP_FOR_STREAMING_V3;
+    Map<String, String> headerMap = COMPUTE_HEADER_MAP_FOR_STREAMING_V3;
 
     getTransportClient().streamPost(
         getComputeRequestPath(),

--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/AvroComputeRequestBuilderV3.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/AvroComputeRequestBuilderV3.java
@@ -4,6 +4,7 @@ import static com.linkedin.venice.VeniceConstants.COMPUTE_REQUEST_VERSION_V3;
 import static com.linkedin.venice.compute.protocol.request.enums.ComputeOperationType.COUNT;
 
 import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
+import com.linkedin.venice.client.schema.SchemaAndToString;
 import com.linkedin.venice.client.store.predicate.Predicate;
 import com.linkedin.venice.client.store.streaming.StreamingCallback;
 import com.linkedin.venice.compute.ComputeRequestWrapper;
@@ -40,7 +41,7 @@ public class AvroComputeRequestBuilderV3<K> extends AbstractAvroComputeRequestBu
   }
 
   @Override
-  protected Pair<Schema, String> getResultSchema() {
+  protected SchemaAndToString getResultSchema() {
     Map<String, Object> computeSpec = getCommonComputeSpec();
 
     List<Pair<CharSequence, CharSequence>> countPairs = new LinkedList<>();
@@ -74,22 +75,12 @@ public class AvroComputeRequestBuilderV3<K> extends AbstractAvroComputeRequestBu
 
       Schema generatedResultSchema = Schema.createRecord(resultSchemaName, "", "", false);
       generatedResultSchema.setFields(resultSchemaFields);
-      return Pair.create(generatedResultSchema, generatedResultSchema.toString());
+      return new SchemaAndToString(generatedResultSchema);
     });
   }
 
-  @Override
-  protected ComputeRequestWrapper generateComputeRequest(String resultSchemaStr) {
-    // Generate ComputeRequestWrapper object
-    ComputeRequestWrapper computeRequestWrapper = new ComputeRequestWrapper(COMPUTE_REQUEST_VERSION);
-    computeRequestWrapper.setResultSchemaStr(resultSchemaStr);
-    computeRequestWrapper.setOperations(getComputeRequestOperations());
-    computeRequestWrapper.setValueSchema(latestValueSchema);
-    return computeRequestWrapper;
-  }
-
   protected List<ComputeOperation> getComputeRequestOperations() {
-    List<ComputeOperation> operations = getCommonComputeOperations();
+    List<ComputeOperation> operations = super.getComputeRequestOperations();
 
     countOperations.forEach(count -> {
       ComputeOperation computeOperation = new ComputeOperation();

--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/AvroComputeRequestBuilderV4.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/AvroComputeRequestBuilderV4.java
@@ -5,6 +5,7 @@ import static org.apache.avro.Schema.Type.RECORD;
 
 import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
 import com.linkedin.venice.client.exceptions.VeniceClientException;
+import com.linkedin.venice.client.schema.SchemaAndToString;
 import com.linkedin.venice.client.store.predicate.AndPredicate;
 import com.linkedin.venice.client.store.predicate.EqualsRelationalOperator;
 import com.linkedin.venice.client.store.predicate.Predicate;
@@ -13,7 +14,6 @@ import com.linkedin.venice.compute.ComputeRequestWrapper;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.serializer.FastSerializerDeserializerFactory;
 import com.linkedin.venice.serializer.RecordSerializer;
-import com.linkedin.venice.utils.Pair;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -32,22 +32,12 @@ public class AvroComputeRequestBuilderV4<K> extends AvroComputeRequestBuilderV3<
   }
 
   @Override
-  protected ComputeRequestWrapper generateComputeRequest(String resultSchemaStr) {
-    // Generate ComputeRequestWrapper object
-    ComputeRequestWrapper computeRequestWrapper = new ComputeRequestWrapper(COMPUTE_REQUEST_VERSION);
-    computeRequestWrapper.setResultSchemaStr(resultSchemaStr);
-    computeRequestWrapper.setOperations(getComputeRequestOperations());
-    computeRequestWrapper.setValueSchema(latestValueSchema);
-    return computeRequestWrapper;
-  }
-
-  @Override
   public void executeWithFilter(
       Predicate requiredPrefixFields,
       StreamingCallback<GenericRecord, GenericRecord> callback) {
     byte[] prefixBytes = extractKeyPrefixBytesFromPredicate(requiredPrefixFields, storeClient.getKeySchema());
-    Pair<Schema, String> resultSchema = getResultSchema();
-    ComputeRequestWrapper computeRequestWrapper = generateComputeRequest(resultSchema.getSecond());
+    SchemaAndToString resultSchema = getResultSchema();
+    ComputeRequestWrapper computeRequestWrapper = generateComputeRequest(resultSchema);
     storeClient.computeWithKeyPrefixFilter(prefixBytes, computeRequestWrapper, callback);
   }
 

--- a/clients/venice-thin-client/src/test/java/com/linkedin/venice/client/store/AvroComputeRequestBuilderTest.java
+++ b/clients/venice-thin-client/src/test/java/com/linkedin/venice/client/store/AvroComputeRequestBuilderTest.java
@@ -1,11 +1,8 @@
 package com.linkedin.venice.client.store;
 
-import static com.linkedin.venice.VeniceConstants.COMPUTE_REQUEST_VERSION_V3;
-import static com.linkedin.venice.VeniceConstants.COMPUTE_REQUEST_VERSION_V4;
 import static com.linkedin.venice.VeniceConstants.VENICE_COMPUTATION_ERROR_MAP_FIELD_NAME;
 import static com.linkedin.venice.client.store.predicate.PredicateBuilder.and;
 import static com.linkedin.venice.client.store.predicate.PredicateBuilder.equalTo;
-import static com.linkedin.venice.compute.ComputeRequestWrapper.LATEST_SCHEMA_VERSION_FOR_COMPUTE_REQUEST;
 import static com.linkedin.venice.compute.protocol.request.enums.ComputeOperationType.COSINE_SIMILARITY;
 import static com.linkedin.venice.compute.protocol.request.enums.ComputeOperationType.DOT_PRODUCT;
 import static com.linkedin.venice.compute.protocol.request.enums.ComputeOperationType.HADAMARD_PRODUCT;
@@ -117,7 +114,6 @@ public class AvroComputeRequestBuilderTest {
     Assert.assertEquals(capturedComputeRequest.getValueSchema(), VALID_RECORD_SCHEMA);
     Assert.assertEquals(capturedComputeRequest.getResultSchemaStr().toString(), expectedSchema);
     Assert.assertEquals(capturedComputeRequest.getOperations().size(), 6);
-    Assert.assertEquals(capturedComputeRequest.getComputeRequestVersion(), COMPUTE_REQUEST_VERSION_V3);
 
     List<Float> expectedDotProductParam = new ArrayList<>();
     for (Float f: dotProductParam) {
@@ -217,11 +213,6 @@ public class AvroComputeRequestBuilderTest {
     Assert.assertEquals(capturedComputeRequest.getValueSchema(), VALID_RECORD_SCHEMA);
     Assert.assertEquals(capturedComputeRequest.getResultSchemaStr().toString(), expectedSchema);
     Assert.assertEquals(capturedComputeRequest.getOperations().size(), 3);
-    /**
-     * Compute request version should be {@link LATEST_SCHEMA_VERSION_FOR_COMPUTE_REQUEST}
-     * if {@link AvroComputeRequestBuilderV3#hadamardProduct(String, List, String)} is invoked.
-     */
-    Assert.assertEquals(capturedComputeRequest.getComputeRequestVersion(), LATEST_SCHEMA_VERSION_FOR_COMPUTE_REQUEST);
 
     // Verify hadamard-product parameter
     List<Float> expectedHadamardProductParam = new ArrayList<>();
@@ -437,7 +428,6 @@ public class AvroComputeRequestBuilderTest {
     Assert.assertTrue(Arrays.equals(prefixByteCaptor.getValue(), expectedPrefixBytes));
     ComputeRequestWrapper capturedComputeRequest = computeRequestCaptor.getValue();
     Assert.assertEquals(capturedComputeRequest.getOperations().size(), 0);
-    Assert.assertEquals(capturedComputeRequest.getComputeRequestVersion(), COMPUTE_REQUEST_VERSION_V4);
     Assert.assertEquals(streamingCallbackCaptor.getValue(), callback);
   }
 

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/compute/CosineSimilarityOperator.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/compute/CosineSimilarityOperator.java
@@ -14,7 +14,6 @@ import org.apache.avro.generic.GenericRecord;
 public class CosineSimilarityOperator implements ReadComputeOperator {
   @Override
   public void compute(
-      int computeRequestVersion,
       ComputeOperation op,
       Schema.Field operatorInputField,
       Schema.Field resultField,

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/compute/CountOperator.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/compute/CountOperator.java
@@ -12,7 +12,6 @@ import org.apache.avro.generic.GenericRecord;
 public class CountOperator implements ReadComputeOperator {
   @Override
   public void compute(
-      int computeRequestVersion,
       ComputeOperation op,
       Schema.Field operatorInputField,
       Schema.Field resultField,

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/compute/DotProductOperator.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/compute/DotProductOperator.java
@@ -11,7 +11,6 @@ import org.apache.avro.generic.GenericRecord;
 public class DotProductOperator implements ReadComputeOperator {
   @Override
   public void compute(
-      int computeRequestVersion,
       ComputeOperation op,
       Schema.Field operatorInputField,
       Schema.Field resultField,

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/compute/HadamardProductOperator.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/compute/HadamardProductOperator.java
@@ -11,7 +11,6 @@ import org.apache.avro.generic.GenericRecord;
 public class HadamardProductOperator implements ReadComputeOperator {
   @Override
   public void compute(
-      int computeRequestVersion,
       ComputeOperation op,
       Schema.Field operatorInputField,
       Schema.Field resultField,

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/compute/ReadComputeOperator.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/compute/ReadComputeOperator.java
@@ -8,7 +8,6 @@ import org.apache.avro.generic.GenericRecord;
 
 public interface ReadComputeOperator {
   void compute(
-      int computeRequestVersion,
       ComputeOperation op,
       Schema.Field operatorField,
       Schema.Field resultField,

--- a/internal/venice-client-common/src/main/resources/avro/ComputeRequest.avsc
+++ b/internal/venice-client-common/src/main/resources/avro/ComputeRequest.avsc
@@ -1,0 +1,123 @@
+{
+  "type": "record",
+  "name": "ComputeRequest",
+  "namespace": "com.linkedin.venice.compute.protocol.request",
+  "doc": "This record only contains the operations and result schema, and keys will be appended after during serialization",
+  "fields": [
+    {
+      "name": "operations",
+      "type": {
+        "type": "array",
+        "items": {
+          "name": "ComputeOperation",
+          "type": "record",
+          "fields": [
+            {
+              "name": "operationType",
+              "type": "int",
+              "doc": "Supported operation type: 0 -> DotProduct"
+            },
+            {
+              "name": "operation",
+              "type": [
+                {
+                  "name": "DotProduct",
+                  "type": "record",
+                  "fields": [
+                    {
+                      "name": "field",
+                      "type": "string",
+                      "doc": "The field in the original value record, which will used to execute dot-product calculation"
+                    },
+                    {
+                      "name": "dotProductParam",
+                      "type": {
+                        "type": "array",
+                        "items": "float"
+                      },
+                      "doc": "The passed feature vector, which will be used to execute dot-product calculation against the field in the original value record"
+                    },
+                    {
+                      "name": "resultFieldName",
+                      "type": "string",
+                      "doc": "The field name used to store the calculated result"
+                    }
+                  ]
+                },
+                {
+                  "name": "CosineSimilarity",
+                  "type": "record",
+                  "fields": [
+                    {
+                      "name": "field",
+                      "type": "string",
+                      "doc": "The field in the original value record, which will used to execute cosine-similarity calculation"
+                    },
+                    {
+                      "name": "cosSimilarityParam",
+                      "type": {
+                        "type": "array",
+                        "items": "float"
+                      },
+                      "doc": "The passed feature vector, which will be used to execute cosine-similarity calculation against the field in the original value record"
+                    },
+                    {
+                      "name": "resultFieldName",
+                      "type": "string",
+                      "doc": "The field name used to store the calculated result"
+                    }
+                  ]
+                },
+                {
+                  "name": "HadamardProduct",
+                  "type": "record",
+                  "fields": [
+                    {
+                      "name": "field",
+                      "type": "string",
+                      "doc": "The field in the original value record, which will used to execute hadamard-product calculation"
+                    },
+                    {
+                      "name": "hadamardProductParam",
+                      "type": {
+                        "type": "array",
+                        "items": "float"
+                      },
+                      "doc": "The passed feature vector, which will be used to execute hadamard-product calculation against the field in the original value record"
+                    },
+                    {
+                      "name": "resultFieldName",
+                      "type": "string",
+                      "doc": "The field name used to store the calculated result"
+                    }
+                  ]
+                },
+                {
+                  "name": "Count",
+                  "type": "record",
+                  "fields": [
+                    {
+                      "name": "field",
+                      "type": "string",
+                      "doc": "The field name in the original value record of type array or map, which will used to execute count operation on"
+                    },
+                    {
+                      "name": "resultFieldName",
+                      "type": "string",
+                      "doc": "The field name used to store the count operation result"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      }
+    },
+    {
+      "name": "resultSchemaStr",
+      "type": "string",
+      "doc": "The field contains the serialized result schema, which will be used to de-serialize the response returned by Venice"
+    }
+  ]
+}

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/compute/ComputeUtilsTest.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/compute/ComputeUtilsTest.java
@@ -57,18 +57,14 @@ public class ComputeUtilsTest {
     count.setResultFieldName("StringListFieldCount");
     op1.setOperation(count);
     operations.add(op1);
-    ComputeRequestWrapper computeRequestWrapper = new ComputeRequestWrapper(computeVersion);
-    computeRequestWrapper.setOperations(operations);
-    computeRequestWrapper.initializeOperationResultFields(resultSchema);
-    List<Schema.Field> operationResultFields = computeRequestWrapper.getOperationResultFields();
+    List<Schema.Field> operationResultFields = ComputeUtils.getOperationResultFields(operations, resultSchema);
     Map<String, Object> sharedContext = new HashMap<>();
     GenericRecord inputRecord = new GenericData.Record(valueSchema);
     inputRecord.put("StringListField", new ArrayList<>());
     GenericRecord outputRecord = new GenericData.Record(resultSchema);
 
     // Code under test
-    ComputeUtils
-        .computeResult(computeVersion, operations, operationResultFields, sharedContext, inputRecord, outputRecord);
+    ComputeUtils.computeResult(operations, operationResultFields, sharedContext, inputRecord, outputRecord);
 
     assertNull(outputRecord.get("IntMapField"));
     assertEquals(outputRecord.get("StringListFieldCount"), 0);
@@ -264,7 +260,6 @@ public class ComputeUtilsTest {
 
     @Override
     public void compute(
-        int computeVersion,
         ComputeOperation operation,
         Schema.Field operatorInputField,
         Schema.Field resultField,

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/client/store/StoreClientPerfTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/client/store/StoreClientPerfTest.java
@@ -3,6 +3,7 @@ package com.linkedin.venice.client.store;
 import com.linkedin.d2.balancer.D2Client;
 import com.linkedin.venice.VeniceConstants;
 import com.linkedin.venice.client.schema.RouterBackedSchemaReader;
+import com.linkedin.venice.client.schema.SchemaAndToString;
 import com.linkedin.venice.client.utils.StoreClientTestUtils;
 import com.linkedin.venice.compute.protocol.response.ComputeResponseRecordV1;
 import com.linkedin.venice.integration.utils.D2TestUtils;
@@ -13,7 +14,6 @@ import com.linkedin.venice.read.protocol.response.MultiGetResponseRecordV1;
 import com.linkedin.venice.serializer.RecordDeserializer;
 import com.linkedin.venice.serializer.RecordSerializer;
 import com.linkedin.venice.serializer.SerializerDeserializerFactory;
-import com.linkedin.venice.utils.Pair;
 import com.linkedin.venice.utils.TestWriteUtils;
 import com.linkedin.venice.utils.Utils;
 import io.netty.handler.codec.http.FullHttpResponse;
@@ -204,7 +204,7 @@ public class StoreClientPerfTest {
       super(storeClient, latestValueSchema);
     }
 
-    public Pair<Schema, String> getResultSchema() {
+    public SchemaAndToString getResultSchema() {
       return super.getResultSchema();
     }
   }
@@ -234,8 +234,7 @@ public class StoreClientPerfTest {
       Collection<String> fieldNames =
           valueSchema.getFields().stream().map(field -> field.name()).collect(Collectors.toList());
       testComputeRequestBuilder.project(fieldNames);
-      Pair<Schema, String> computeResultSchemaPair = testComputeRequestBuilder.getResultSchema();
-      Schema computeResultSchema = computeResultSchemaPair.getFirst();
+      Schema computeResultSchema = testComputeRequestBuilder.getResultSchema().getSchema();
       RecordSerializer<Object> computeResultSerializer =
           SerializerDeserializerFactory.getAvroGenericSerializer(computeResultSchema);
       RecordDeserializer<Object> computeResultDeserializer =

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/api/path/VeniceComputePath.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/api/path/VeniceComputePath.java
@@ -8,7 +8,7 @@ import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
 import com.linkedin.alpini.netty4.misc.BasicFullHttpRequest;
 import com.linkedin.alpini.router.api.RouterException;
 import com.linkedin.venice.HttpConstants;
-import com.linkedin.venice.compute.ComputeRequestWrapper;
+import com.linkedin.venice.compute.protocol.request.ComputeRequestV3;
 import com.linkedin.venice.compute.protocol.request.router.ComputeRouterRequestKeyV1;
 import com.linkedin.venice.read.RequestType;
 import com.linkedin.venice.read.protocol.request.router.MultiGetRouterRequestKeyV1;
@@ -22,30 +22,63 @@ import com.linkedin.venice.serializer.RecordDeserializer;
 import com.linkedin.venice.serializer.RecordSerializer;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.BiConsumer;
 import javax.annotation.Nonnull;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.io.BinaryDecoder;
 import org.apache.avro.io.OptimizedBinaryDecoderFactory;
 
 
 public class VeniceComputePath extends VeniceMultiKeyPath<ComputeRouterRequestKeyV1> {
+  private static final Schema EMPTY_RECORD_SCHEMA = Schema.createRecord(
+      ComputeRequestV3.class.getSimpleName(),
+      "no-op",
+      ComputeRequestV3.class.getPackage().getName(),
+      false,
+      Collections.emptyList());
+  private static final ThreadLocal<GenericRecord> EMPTY_COMPUTE_REQUEST_RECORD =
+      ThreadLocal.withInitial(() -> new GenericData.Record(EMPTY_RECORD_SCHEMA));
+
+  /**
+   * N.B. This deserializer takes V3 as the writer schema, but the reader schema is just an empty record.
+   *
+   * There are a few important details here:
+   *
+   * 1. The router need not actually read the compute request, but rather merely skip over it. That is why we use an
+   *    empty record. It cannot be any empty record though, it has to be one with the same FQCN, which is why we build
+   *    it the way we do in {@link #EMPTY_RECORD_SCHEMA}.
+   *
+   * 2. Historically, we've had three versions of the compute request used over the wire (V1 through V3), but in fact,
+   *    V3 is capable of deserializing the previous two as well. This is because these schemas have only ever added new
+   *    branches to the {@link com.linkedin.venice.compute.protocol.request.ComputeRequest#operations} union, and thus
+   *    the schema with all the branches can deserialize those with fewer branches. For this reason, it is not necessary
+   *    here to take the schema the client used to encode as the writer schema the router uses to decode. If, however,
+   *    in the future, we keep evolving the compute request protocol, we need to reevaluate if the evolution will
+   *    require passing in the precise writer schema used. For example, if adding a new field, we would need to start
+   *    using the correct writer schema (either V3 or the newer one).
+   */
+  private static final RecordDeserializer<GenericRecord> COMPUTE_REQUEST_NO_OP_DESERIALIZER =
+      FastSerializerDeserializerFactory.getFastAvroGenericDeserializer(ComputeRequestV3.SCHEMA$, EMPTY_RECORD_SCHEMA);
   private static final RecordDeserializer<ByteBuffer> COMPUTE_REQUEST_CLIENT_KEY_V1_DESERIALIZER =
       FastSerializerDeserializerFactory
           .getAvroGenericDeserializer(ReadAvroProtocolDefinition.COMPUTE_REQUEST_CLIENT_KEY_V1.getSchema());
-
   private static final RecordSerializer<ComputeRouterRequestKeyV1> COMPUTE_ROUTER_REQUEST_KEY_V1_SERIALIZER =
       FastSerializerDeserializerFactory.getAvroGenericSerializer(ComputeRouterRequestKeyV1.getClassSchema());
 
-  // Compute request is useless for now in router, until we support ranking in the future.
-  private final ComputeRequestWrapper computeRequestWrapper;
+  public static void skipOverComputeRequest(BinaryDecoder decoder) {
+    COMPUTE_REQUEST_NO_OP_DESERIALIZER.deserialize(EMPTY_COMPUTE_REQUEST_RECORD.get(), decoder);
+  }
+
   private final byte[] requestContent;
   private final int computeRequestLengthInBytes;
-  private int valueSchemaId;
-
-  private final int computeRequestVersion;
+  private final String valueSchemaIdHeader;
+  private final String computeRequestVersionHeader;
 
   public VeniceComputePath(
       String storeName,
@@ -65,11 +98,11 @@ public class VeniceComputePath extends VeniceMultiKeyPath<ComputeRouterRequestKe
         smartLongTailRetryAbortThresholdMs,
         longTailRetryMaxRouteForMultiKeyReq);
 
-    // Get API version
-    computeRequestVersion = Integer.parseInt(request.headers().get(HttpConstants.VENICE_API_VERSION));
-    CharSequence schemaHeader = request.getRequestHeaders().get(VENICE_COMPUTE_VALUE_SCHEMA_ID);
-    valueSchemaId = schemaHeader == null ? -1 : Integer.parseInt((String) schemaHeader);
+    this.valueSchemaIdHeader = request.headers().get(VENICE_COMPUTE_VALUE_SCHEMA_ID, "-1");
 
+    // Get API version
+    this.computeRequestVersionHeader = request.headers().get(HttpConstants.VENICE_API_VERSION);
+    int computeRequestVersion = Integer.parseInt(this.computeRequestVersionHeader);
     if (computeRequestVersion <= 0 || computeRequestVersion > LATEST_SCHEMA_VERSION_FOR_COMPUTE_REQUEST) {
       throw RouterExceptionAndTrackingUtils.newRouterExceptionAndTracking(
           Optional.of(getStoreName()),
@@ -84,12 +117,12 @@ public class VeniceComputePath extends VeniceMultiKeyPath<ComputeRouterRequestKe
 
     /**
      * The first part of the request content from client is the ComputeRequest which contains an array of operations
-     * and the result schema string for now; deserialize the first part and record the length of the first part
+     * and the result schema string. Here, we deserialize the first part (but throw it away, as it is only to advance
+     * the internal state of the decoder) and record the length of the first part.
      */
-    computeRequestWrapper = new ComputeRequestWrapper(computeRequestVersion);
     BinaryDecoder decoder = OptimizedBinaryDecoderFactory.defaultFactory()
         .createOptimizedBinaryDecoder(requestContent, 0, requestContent.length);
-    computeRequestWrapper.deserialize(decoder);
+    skipOverComputeRequest(decoder);
     try {
       // record the length of the serialized ComputeRequest
       computeRequestLengthInBytes = requestContent.length - decoder.inputStream().available();
@@ -112,10 +145,10 @@ public class VeniceComputePath extends VeniceMultiKeyPath<ComputeRouterRequestKe
       int versionNumber,
       String resourceName,
       Map<RouterKey, ComputeRouterRequestKeyV1> routerKeyMap,
-      ComputeRequestWrapper computeRequestWrapper,
       byte[] requestContent,
       int computeRequestLengthInBytes,
-      int computeRequestVersion,
+      String valueSchemaIdHeader,
+      String computeRequestVersionHeader,
       boolean smartLongTailRetryEnabled,
       int smartLongTailRetryAbortThresholdMs,
       int longTailRetryMaxRouteForMultiKeyReq) {
@@ -127,10 +160,10 @@ public class VeniceComputePath extends VeniceMultiKeyPath<ComputeRouterRequestKe
         smartLongTailRetryAbortThresholdMs,
         routerKeyMap,
         longTailRetryMaxRouteForMultiKeyReq);
-    this.computeRequestWrapper = computeRequestWrapper;
     this.requestContent = requestContent;
+    this.valueSchemaIdHeader = valueSchemaIdHeader;
     this.computeRequestLengthInBytes = computeRequestLengthInBytes;
-    this.computeRequestVersion = computeRequestVersion;
+    this.computeRequestVersionHeader = computeRequestVersionHeader;
     setPartitionKeys(routerKeyMap.keySet());
   }
 
@@ -187,15 +220,14 @@ public class VeniceComputePath extends VeniceMultiKeyPath<ComputeRouterRequestKe
         versionNumber,
         getResourceName(),
         routerKeyMap,
-        this.computeRequestWrapper,
         this.requestContent,
         this.computeRequestLengthInBytes,
-        this.computeRequestVersion,
+        this.valueSchemaIdHeader,
+        this.computeRequestVersionHeader,
         isSmartLongTailRetryEnabled(),
         getSmartLongTailRetryAbortThresholdMs(),
         getLongTailRetryMaxRouteForMultiKeyReq());
     subPath.setupRetryRelatedInfo(this);
-    subPath.setValueSchemaId(this.getValueSchemaId());
     return subPath;
   }
 
@@ -214,28 +246,15 @@ public class VeniceComputePath extends VeniceMultiKeyPath<ComputeRouterRequestKe
         .serializeObjects(routerKeyMap.values(), ByteBuffer.wrap(requestContent, 0, computeRequestLengthInBytes));
   }
 
-  public int getValueSchemaId() {
-    return valueSchemaId;
-  }
-
-  public void setValueSchemaId(int id) {
-    this.valueSchemaId = id;
-  }
-
   @Override
   public void setupVeniceHeaders(BiConsumer<String, String> setupHeaderFunc) {
     super.setupVeniceHeaders(setupHeaderFunc);
-    setupHeaderFunc.accept(VENICE_COMPUTE_VALUE_SCHEMA_ID, Integer.toString(getValueSchemaId()));
+    setupHeaderFunc.accept(VENICE_COMPUTE_VALUE_SCHEMA_ID, this.valueSchemaIdHeader);
   }
 
   @Override
   public String getVeniceApiVersionHeader() {
-    return String.valueOf(computeRequestVersion);
-  }
-
-  // for testing
-  protected ComputeRequestWrapper getComputeRequest() {
-    return computeRequestWrapper;
+    return computeRequestVersionHeader;
   }
 
   // for testing

--- a/services/venice-router/src/test/java/com/linkedin/venice/router/api/path/TestVeniceComputePath.java
+++ b/services/venice-router/src/test/java/com/linkedin/venice/router/api/path/TestVeniceComputePath.java
@@ -10,7 +10,6 @@ import static org.mockito.Mockito.when;
 import com.linkedin.alpini.netty4.misc.BasicFullHttpRequest;
 import com.linkedin.alpini.router.api.RouterException;
 import com.linkedin.venice.HttpConstants;
-import com.linkedin.venice.compute.ComputeRequestWrapper;
 import com.linkedin.venice.compute.protocol.request.ComputeOperation;
 import com.linkedin.venice.compute.protocol.request.ComputeRequestV1;
 import com.linkedin.venice.compute.protocol.request.ComputeRequestV2;
@@ -32,7 +31,6 @@ import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
-import org.apache.avro.Schema;
 import org.apache.commons.lang.ArrayUtils;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -130,13 +128,6 @@ public class TestVeniceComputePath {
           -1,
           1);
       Assert.assertEquals(computePath.getComputeRequestLengthInBytes(), expectedLength);
-
-      ComputeRequestWrapper requestInPath = computePath.getComputeRequest();
-      Schema resultSchemaInPath = Schema.parse(requestInPath.getResultSchemaStr().toString());
-      Schema expectedResultSchema = Schema.parse(computeRequest.resultSchemaStr.toString());
-
-      Assert.assertTrue(resultSchemaInPath.equals(expectedResultSchema));
-      Assert.assertEquals(requestInPath.getOperations(), computeRequest.operations);
     }
   }
 

--- a/services/venice-server/src/test/java/com/linkedin/venice/listener/StorageReadRequestHandlerTest.java
+++ b/services/venice-server/src/test/java/com/linkedin/venice/listener/StorageReadRequestHandlerTest.java
@@ -28,6 +28,8 @@ import com.linkedin.venice.client.store.AvroGenericReadComputeStoreClient;
 import com.linkedin.venice.compression.CompressionStrategy;
 import com.linkedin.venice.compression.NoopCompressor;
 import com.linkedin.venice.compute.ComputeRequestWrapper;
+import com.linkedin.venice.compute.ComputeUtils;
+import com.linkedin.venice.compute.protocol.request.ComputeRequest;
 import com.linkedin.venice.compute.protocol.request.router.ComputeRouterRequestKeyV1;
 import com.linkedin.venice.compute.protocol.response.ComputeResponseRecordV1;
 import com.linkedin.venice.exceptions.VeniceException;
@@ -458,13 +460,11 @@ public class StorageReadRequestHandlerTest {
         .execute(keySet);
     ArgumentCaptor<ComputeRequestWrapper> requestCaptor = ArgumentCaptor.forClass(ComputeRequestWrapper.class);
     verify(storeClient, times(1)).compute(requestCaptor.capture(), any(), any(), any(), anyLong());
-    ComputeRequestWrapper computeRequest = requestCaptor.getValue();
-    // During normal operation, StorageReadRequestHandler gets a request after Avro deserialization,
-    // which as a side effect converts String to Utf8.
-    // Here we simulate this by serializing the request and then deserializing it back.
-    computeRequest.deserialize(
+    ComputeRequestWrapper computeRequestWrapper = requestCaptor.getValue();
+    ComputeRequest computeRequest = ComputeUtils.deserializeComputeRequest(
         OptimizedBinaryDecoderFactory.defaultFactory()
-            .createOptimizedBinaryDecoder(ByteBuffer.wrap(computeRequest.serialize())));
+            .createOptimizedBinaryDecoder(ByteBuffer.wrap(computeRequestWrapper.serialize())),
+        null);
 
     ComputeRouterRequestWrapper request = mock(ComputeRouterRequestWrapper.class);
     doReturn(RequestType.COMPUTE).when(request).getRequestType();


### PR DESCRIPTION
Prior to this commit, the ComputeRequestWrapper class was used across client, router and server, but these components all had different needs and the end result was a bit awkward, as it led to the class needing to be constructed in a way that was not fully initialized, only to have the rest of the init happen later by mutating its internal state. This seemed error-prone.

Furthermore, the class attempted to serve as a way to evolve the read compute wire protocol, and although we did evolve read compute, the way we evolved it was already compatible anyway, and if we had evolved it in less compatible ways, it's not clear that the original structure of this class would have been good enough to support such evolution.

In this commit, we are cleaning all of that up and simplifying many aspects of the code in the process. Notably:

- ComputeRequestWrapper is now only used in the client, and it is fully initialized at construction-time, with all internal state final.

- The read compute protocol version passed in a header is still checked when parsing an incoming request, but then it's not carried into deeper code paths, where it was essentially ignored and useless.

- Created a SchemaAndToString container class to replace some usages of Pair<Schema, String>.

- Added a ComputeRequest specific record, which is the same as ComputeRequestV[1-4] except that the items inside the list of operations are strongly-typed, rather than objects. We do still need to keep (at least one of) the other schemas around since those are the ones the clients use on the wire, but we can cheaply convert between those and the new one, and so the server code need not do as much casting as before.

- In the router, the VeniceComputePath does not hang on to a ComputeRequestWrapper anymore, which it didn't need to. It merely skips over the bytes represented by the compute request, with as little allocation as possible. It also hangs on to the raw String headers it needs rather than convert them to int and then back to strings moments later. Made all state final.

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.