### PR TITLE
[server] Make sure TransientRecord saves correct value and RMD manifest

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
@@ -650,14 +650,8 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
     if (updatedValueBytes == null) {
       hostLevelIngestionStats.recordTombstoneCreatedDCR();
       aggVersionedIngestionStats.recordTombStoneCreationDCR(storeName, versionNumber);
-      partitionConsumptionState.setTransientRecord(
-          kafkaClusterId,
-          consumerRecord.getOffset(),
-          key,
-          valueSchemaId,
-          rmdRecord,
-          oldValueManifest,
-          oldRmdManifest);
+      partitionConsumptionState
+          .setTransientRecord(kafkaClusterId, consumerRecord.getOffset(), key, valueSchemaId, rmdRecord);
       Delete deletePayload = new Delete();
       deletePayload.schemaId = valueSchemaId;
       deletePayload.replicationMetadataVersionId = rmdProtocolVersionID;
@@ -693,9 +687,7 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
           updatedValueBytes.position(),
           valueLen,
           valueSchemaId,
-          rmdRecord,
-          oldValueManifest,
-          oldRmdManifest);
+          rmdRecord);
 
       Put updatedPut = new Put();
       updatedPut.putValue = ByteUtils

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
@@ -595,6 +595,7 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
           RawBytesStoreDeserializerCache.getInstance(),
           compressor.get(),
           valueManifestContainer);
+      LOGGER.info("DEBUGGING GET OLD MANIFEST FROM STORAGE: {}", valueManifestContainer.getManifest());
       hostLevelIngestionStats.recordIngestionValueBytesLookUpLatency(
           LatencyUtils.getLatencyInMS(lookupStartTimeInNS),
           currentTimeForMetricsMs);
@@ -605,6 +606,10 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
         if (valueManifestContainer != null) {
           valueManifestContainer.setManifest(transientRecord.getValueManifest());
         }
+        LOGGER.info(
+            "DEBUGGING GET OLD MANIFEST FROM CACHE: {} OLD VALUE LENGTH{}",
+            transientRecord.getValueManifest(),
+            transientRecord.getValueLen());
         originalValue = ByteBuffer
             .wrap(transientRecord.getValue(), transientRecord.getValueOffset(), transientRecord.getValueLen());
       }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
@@ -595,7 +595,6 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
           RawBytesStoreDeserializerCache.getInstance(),
           compressor.get(),
           valueManifestContainer);
-      LOGGER.info("DEBUGGING GET OLD MANIFEST FROM STORAGE: {}", valueManifestContainer.getManifest());
       hostLevelIngestionStats.recordIngestionValueBytesLookUpLatency(
           LatencyUtils.getLatencyInMS(lookupStartTimeInNS),
           currentTimeForMetricsMs);
@@ -606,10 +605,6 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
         if (valueManifestContainer != null) {
           valueManifestContainer.setManifest(transientRecord.getValueManifest());
         }
-        LOGGER.info(
-            "DEBUGGING GET OLD MANIFEST FROM CACHE: {} OLD VALUE LENGTH{}",
-            transientRecord.getValueManifest(),
-            transientRecord.getValueLen());
         originalValue = ByteBuffer
             .wrap(transientRecord.getValue(), transientRecord.getValueOffset(), transientRecord.getValueLen());
       }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -2667,8 +2667,6 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
               putValue.position(),
               putValue.remaining(),
               put.schemaId,
-              null,
-              null, // Since we did not perform read, it is not possible to delete old value chunks here.
               null);
         }
 
@@ -2737,8 +2735,7 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
          * For WC enabled stores update the transient record map with the latest {key,null} for similar reason as mentioned in PUT above.
          */
         if (isWriteComputationEnabled && partitionConsumptionState.isEndOfPushReceived()) {
-          partitionConsumptionState
-              .setTransientRecord(kafkaClusterId, consumerRecord.getOffset(), keyBytes, -1, null, null, null);
+          partitionConsumptionState.setTransientRecord(kafkaClusterId, consumerRecord.getOffset(), keyBytes, -1, null);
         }
         leaderProducedRecordContext =
             LeaderProducedRecordContext.newDeleteRecord(kafkaClusterId, consumerRecord.getOffset(), keyBytes, null);
@@ -2863,8 +2860,6 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
           0,
           updatedValueBytes.length,
           readerValueSchemaId,
-          null,
-          oldValueManifest,
           null);
 
       ByteBuffer updateValueWithSchemaId =

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderProducerCallback.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderProducerCallback.java
@@ -250,6 +250,7 @@ public class LeaderProducerCallback implements ChunkAwareCallback {
     this.oldValueManifest = oldValueManifest;
     this.oldRmdManifest = oldRmdManifest;
     if (getPartitionConsumptionState() == null) {
+      LOGGER.error("PartitionConsumptionState is missing in chunk producer callback");
       return;
     }
     // TransientRecord map is indexed by non-chunked key.
@@ -258,6 +259,8 @@ public class LeaderProducerCallback implements ChunkAwareCallback {
     if (record != null) {
       record.setValueManifest(chunkedValueManifest);
       record.setRmdManifest(chunkedRmdManifest);
+    } else {
+      LOGGER.error("Transient record is missing when trying to update value/RMD manifest.");
     }
   }
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderProducerCallback.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderProducerCallback.java
@@ -23,7 +23,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 
-class LeaderProducerCallback implements ChunkAwareCallback {
+public class LeaderProducerCallback implements ChunkAwareCallback {
   private static final Logger LOGGER = LogManager.getLogger(LeaderFollowerStoreIngestionTask.class);
   private static final RedundantExceptionFilter REDUNDANT_LOGGING_FILTER =
       RedundantExceptionFilter.getRedundantExceptionFilter();
@@ -249,12 +249,12 @@ class LeaderProducerCallback implements ChunkAwareCallback {
     this.rmdChunks = rmdChunks;
     this.oldValueManifest = oldValueManifest;
     this.oldRmdManifest = oldRmdManifest;
-    if (partitionConsumptionState == null) {
+    if (getPartitionConsumptionState() == null) {
       return;
     }
     // TransientRecord map is indexed by non-chunked key.
     PartitionConsumptionState.TransientRecord record =
-        partitionConsumptionState.getTransientRecord(sourceConsumerRecord.getKey().getKey());
+        getPartitionConsumptionState().getTransientRecord(getSourceConsumerRecord().getKey().getKey());
     if (record != null) {
       record.setValueManifest(chunkedValueManifest);
       record.setRmdManifest(chunkedRmdManifest);
@@ -339,5 +339,14 @@ class LeaderProducerCallback implements ChunkAwareCallback {
           beforeProcessingRecordTimestampNs,
           currentTimeForMetricsMs);
     }
+  }
+
+  // Visible for VeniceWriter unit test.
+  public PartitionConsumptionState getPartitionConsumptionState() {
+    return partitionConsumptionState;
+  }
+
+  public PubSubMessage<KafkaKey, KafkaMessageEnvelope, Long> getSourceConsumerRecord() {
+    return sourceConsumerRecord;
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderProducerCallback.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderProducerCallback.java
@@ -249,6 +249,16 @@ class LeaderProducerCallback implements ChunkAwareCallback {
     this.rmdChunks = rmdChunks;
     this.oldValueManifest = oldValueManifest;
     this.oldRmdManifest = oldRmdManifest;
+    if (partitionConsumptionState == null) {
+      return;
+    }
+    // TransientRecord map is indexed by non-chunked key.
+    PartitionConsumptionState.TransientRecord record =
+        partitionConsumptionState.getTransientRecord(sourceConsumerRecord.getKey().getKey());
+    if (record != null) {
+      record.setValueManifest(chunkedValueManifest);
+      record.setRmdManifest(chunkedRmdManifest);
+    }
   }
 
   private void recordProducerStats(int producedRecordSize, int producedRecordNum) {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/PartitionConsumptionState.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/PartitionConsumptionState.java
@@ -503,6 +503,7 @@ public class PartitionConsumptionState {
     if (replicationMetadataRecord != null) {
       transientRecord.setReplicationMetadataRecord(replicationMetadataRecord);
     }
+
     transientRecordMap.put(ByteArrayKey.wrap(key), transientRecord);
   }
 
@@ -603,8 +604,16 @@ public class PartitionConsumptionState {
       return rmdManifest;
     }
 
+    public void setRmdManifest(ChunkedValueManifest rmdManifest) {
+      this.rmdManifest = rmdManifest;
+    }
+
     public ChunkedValueManifest getValueManifest() {
       return valueManifest;
+    }
+
+    public void setValueManifest(ChunkedValueManifest valueManifest) {
+      this.valueManifest = valueManifest;
     }
 
     public void setReplicationMetadataRecord(GenericRecord replicationMetadataRecord) {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/PartitionConsumptionState.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/PartitionConsumptionState.java
@@ -568,7 +568,7 @@ public class PartitionConsumptionState {
     private ChunkedValueManifest valueManifest;
     private ChunkedValueManifest rmdManifest;
 
-    TransientRecord(
+    public TransientRecord(
         byte[] value,
         int valueOffset,
         int valueLen,

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/PartitionConsumptionState.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/PartitionConsumptionState.java
@@ -464,9 +464,7 @@ public class PartitionConsumptionState {
       long kafkaConsumedOffset,
       byte[] key,
       int valueSchemaId,
-      GenericRecord replicationMetadataRecord,
-      ChunkedValueManifest valueManifest,
-      ChunkedValueManifest rmdManifest) {
+      GenericRecord replicationMetadataRecord) {
     setTransientRecord(
         kafkaClusterId,
         kafkaConsumedOffset,
@@ -475,9 +473,7 @@ public class PartitionConsumptionState {
         -1,
         -1,
         valueSchemaId,
-        replicationMetadataRecord,
-        valueManifest,
-        rmdManifest);
+        replicationMetadataRecord);
   }
 
   public void setTransientRecord(
@@ -488,18 +484,9 @@ public class PartitionConsumptionState {
       int valueOffset,
       int valueLen,
       int valueSchemaId,
-      GenericRecord replicationMetadataRecord,
-      ChunkedValueManifest valueManifest,
-      ChunkedValueManifest rmdManifest) {
-    TransientRecord transientRecord = new TransientRecord(
-        value,
-        valueOffset,
-        valueLen,
-        valueSchemaId,
-        kafkaClusterId,
-        kafkaConsumedOffset,
-        valueManifest,
-        rmdManifest);
+      GenericRecord replicationMetadataRecord) {
+    TransientRecord transientRecord =
+        new TransientRecord(value, valueOffset, valueLen, valueSchemaId, kafkaClusterId, kafkaConsumedOffset);
     if (replicationMetadataRecord != null) {
       transientRecord.setReplicationMetadataRecord(replicationMetadataRecord);
     }
@@ -587,17 +574,13 @@ public class PartitionConsumptionState {
         int valueLen,
         int valueSchemaId,
         int kafkaClusterId,
-        long kafkaConsumedOffset,
-        ChunkedValueManifest valueManifest,
-        ChunkedValueManifest rmdManifest) {
+        long kafkaConsumedOffset) {
       this.value = value;
       this.valueOffset = valueOffset;
       this.valueLen = valueLen;
       this.valueSchemaId = valueSchemaId;
       this.kafkaClusterId = kafkaClusterId;
       this.kafkaConsumedOffset = kafkaConsumedOffset;
-      this.valueManifest = valueManifest;
-      this.rmdManifest = rmdManifest;
     }
 
     public ChunkedValueManifest getRmdManifest() {

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/PartitionConsumptionStateTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/PartitionConsumptionStateTest.java
@@ -29,7 +29,7 @@ public class PartitionConsumptionStateTest {
     Schema aaSchema = RmdSchemaGenerator.generateMetadataSchema(schema, 1);
     GenericRecord record = new GenericData.Record(aaSchema);
     // Test removal succeeds if the key is specified with same kafkaConsumedOffset
-    pcs.setTransientRecord(-1, 1, key1, 5, record, null, null);
+    pcs.setTransientRecord(-1, 1, key1, 5, record);
     PartitionConsumptionState.TransientRecord tr1 = pcs.getTransientRecord(key2);
     Assert.assertEquals(tr1.getValue(), null);
     Assert.assertEquals(tr1.getValueLen(), -1);
@@ -43,10 +43,10 @@ public class PartitionConsumptionStateTest {
     Assert.assertEquals(pcs.getTransientRecordMapSize(), 0);
 
     // Test removal fails if the key is specified with same kafkaConsumedOffset
-    pcs.setTransientRecord(-1, 1, key1, value1, 100, value1.length, 5, null, null, null);
-    pcs.setTransientRecord(-1, 2, key3, 5, null, null, null);
+    pcs.setTransientRecord(-1, 1, key1, value1, 100, value1.length, 5, null);
+    pcs.setTransientRecord(-1, 2, key3, 5, null);
     Assert.assertEquals(pcs.getTransientRecordMapSize(), 2);
-    pcs.setTransientRecord(-1, 3, key1, value2, 100, value2.length, 5, null, null, null);
+    pcs.setTransientRecord(-1, 3, key1, value2, 100, value2.length, 5, null);
 
     tr2 = pcs.mayRemoveTransientRecord(-1, 1, key1);
     Assert.assertNotNull(tr2);

--- a/internal/venice-common/src/main/java/com/linkedin/venice/writer/VeniceWriter.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/writer/VeniceWriter.java
@@ -1350,7 +1350,6 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
           "This message cannot be chunked, because even its manifest is too big to go through. "
               + "Please reconsider your life choices. " + reportSizeGenerator.get());
     }
-
     if (callback instanceof ChunkAwareCallback) {
       /** We leave a handle to the key, chunks and manifests so that the {@link ChunkAwareCallback} can act on them */
       ((ChunkAwareCallback) callback).setChunkingInfo(

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/PartialUpdateTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/PartialUpdateTest.java
@@ -100,7 +100,6 @@ import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.io.BinaryEncoder;
 import org.apache.avro.io.DatumWriter;
 import org.apache.avro.util.Utf8;
-import org.apache.logging.log4j.LogManager;
 import org.apache.samza.config.MapConfig;
 import org.apache.samza.system.SystemProducer;
 import org.testng.Assert;
@@ -215,7 +214,6 @@ public class PartialUpdateTest {
           try {
             GenericRecord value = (GenericRecord) storeReader.get(keyRecord).get();
             assertNotNull(value, "key " + keyRecord + " should not be missing!");
-            LogManager.getLogger().info("DEBUGGING: " + value);
           } catch (Exception e) {
             throw new VeniceException(e);
           }


### PR DESCRIPTION
## [server] Make sure TransientRecord saves correct value and RMD manifest

This PR fixes the bug that TransientRecord is not saving correct value/RMD manifest when updating a key. In the current code, it will try to save the old value/RMD manifest and it will be fetching the same value/RMD manifest until cache expires. This mean chunk is still leaking. 
This PR fixes it by updating the TransientRecord cache's manifests when VeniceWriter invokes ChunkAwareCallback#setChunkingInfo() API. This is prior to the next value record processing so it will be processed correctly.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
Will add unit test to make sure LPC API is called.
## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.