### PR TITLE
[controller] Store Migration Fix: destination cluster will replica version configs from source cluster

### DIFF
--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/AbstractStore.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/AbstractStore.java
@@ -102,6 +102,11 @@ public abstract class AbstractStore implements Store {
   }
 
   @Override
+  public void addVersion(Version version, boolean isClonedVersion) {
+    addVersion(version, true, isClonedVersion);
+  }
+
+  @Override
   public void forceAddVersion(Version version, boolean isClonedVersion) {
     addVersion(version, false, isClonedVersion);
   }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/ReadOnlyStore.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/ReadOnlyStore.java
@@ -1222,6 +1222,11 @@ public class ReadOnlyStore implements Store {
   }
 
   @Override
+  public void addVersion(Version version, boolean isClonedVersion) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
   public void forceAddVersion(Version version, boolean isClonedVersion) {
     throw new UnsupportedOperationException();
   }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/Store.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/Store.java
@@ -266,6 +266,8 @@ public interface Store {
 
   void addVersion(Version version);
 
+  void addVersion(Version version, boolean isClonedVersion);
+
   void forceAddVersion(Version version, boolean isClonedVersion);
 
   void checkDisableStoreWrite(String action, int version);

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceControllerWrapper.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceControllerWrapper.java
@@ -238,6 +238,9 @@ public class VeniceControllerWrapper extends ProcessWrapper {
           // This dummy parent controller won't support such requests until we make this config configurable.
           // go/inclusivecode deferred(Reference will be removed when clients have migrated)
           fabricAllowList = extraProps.getStringWithAlternative(CHILD_CLUSTER_ALLOWLIST, CHILD_CLUSTER_WHITELIST, "");
+        } else {
+          // child controller should at least know the urls or D2 ZK address of its local region
+          fabricAllowList = options.getExtraProperties().getProperty(LOCAL_REGION_NAME, options.getRegionName());
         }
 
         /**

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -2268,6 +2268,55 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
         null);
   }
 
+  private Optional<Version> getVersionFromSourceCluster(
+      ReadWriteStoreRepository repository,
+      String destinationCluster,
+      String storeName,
+      int versionNumber) {
+    Store store = repository.getStore(storeName);
+    if (store == null) {
+      throwStoreDoesNotExist(destinationCluster, storeName);
+    }
+    if (!store.isMigrating()) {
+      return Optional.empty();
+    }
+    ZkStoreConfigAccessor storeConfigAccessor = getStoreConfigAccessor(destinationCluster);
+    StoreConfig storeConfig = storeConfigAccessor.getStoreConfig(storeName);
+    if (!destinationCluster.equals(storeConfig.getMigrationDestCluster())) {
+      // destinationCluster is passed from the add version task, so if the task is not in the destination cluster but in
+      // the source cluster, do not replicate anything from the "source" since this is the source cluster
+      return Optional.empty();
+    }
+    String migrationSourceCluster = storeConfig.getMigrationSrcCluster();
+    ControllerClient srcControllerClient = getControllerClientMap(migrationSourceCluster).get(getRegionName());
+    if (srcControllerClient == null) {
+      throw new VeniceException(
+          "Failed to constructed controller client for cluster " + migrationSourceCluster + " and region "
+              + getRegionName());
+    }
+    StoreResponse srcStoreResponse = srcControllerClient.getStore(storeName);
+    if (srcStoreResponse.isError()) {
+      throw new VeniceException(
+          "Failed to get store " + storeName + " from cluster " + migrationSourceCluster + " and region "
+              + getRegionName() + " with error " + srcStoreResponse.getError());
+    }
+    StoreInfo srcStoreInfo = srcStoreResponse.getStore();
+    // For ongoing new pushes, destination cluster does not need to replicate the exact version configs from the source
+    // cluster; destination cluster can apply its own store configs to the new version.
+    if (versionNumber > srcStoreInfo.getCurrentVersion()) {
+      LOGGER.info(
+          "Version {} is an ongoing new push for store {}, use the store configs to populate new version configs",
+          versionNumber,
+          storeName);
+      return Optional.empty();
+    }
+    LOGGER.info(
+        "During store migration, version configs from source cluster {}: {}",
+        migrationSourceCluster,
+        srcStoreResponse.getStore().getVersion(versionNumber).get());
+    return srcStoreResponse.getStore().getVersion(versionNumber);
+  }
+
   /**
    * Note, versionNumber may be VERSION_ID_UNSET, which must be accounted for.
    * Add version is a multi step process that can be broken down to three main steps:
@@ -2308,7 +2357,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
     checkControllerLeadershipFor(clusterName);
     ReadWriteStoreRepository repository = resources.getStoreMetadataRepository();
     Version version = null;
-    OfflinePushStrategy strategy;
+    OfflinePushStrategy offlinePushStrategy;
     int currentVersionBeforePush = -1;
     VeniceControllerClusterConfig clusterConfig = resources.getConfig();
     BackupStrategy backupStrategy;
@@ -2352,191 +2401,218 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
             return new Pair<>(false, null);
           }
           backupStrategy = store.getBackupStrategy();
-          int amplificationFactor = store.getPartitionerConfig().getAmplificationFactor();
-          int subPartitionCount = numberOfPartitions * amplificationFactor;
-          if (versionNumber == VERSION_ID_UNSET) {
-            // No version supplied, generate a new version. This could happen either in the parent
-            // controller or local Samza jobs.
-            version = new VersionImpl(storeName, store.peekNextVersion().getNumber(), pushJobId, numberOfPartitions);
-          } else {
-            if (store.containsVersion(versionNumber)) {
-              throwVersionAlreadyExists(storeName, versionNumber);
+          offlinePushStrategy = store.getOffLinePushStrategy();
+
+          // Check whether the store is migrating and whether the version is smaller or equal to the current version
+          // in the source cluster. If so, replicate the version configs from the child controllers of the source
+          // cluster;
+          // it's safest to replicate the version configs from the child controller in the same region, because parent
+          // region or other regions could have their own configs.
+          Optional<Version> sourceVersion = (store.isMigrating() && versionNumber != VERSION_ID_UNSET)
+              ? getVersionFromSourceCluster(repository, clusterName, storeName, versionNumber)
+              : Optional.empty();
+          if (sourceVersion.isPresent()) {
+            // Adding an existing version to the destination cluster whose version level resources are already created,
+            // including Kafka topics with data ready, and Helix resource, so skip the steps of recreating these
+            // resources.
+            version = sourceVersion.get().cloneVersion();
+            // Reset version statue; do not make any other config update, version configs are immutable and the version
+            // Configs from the source clusters are source of truth
+            version.setStatus(STARTED);
+
+            if (store.containsVersion(version.getNumber())) {
+              throwVersionAlreadyExists(storeName, version.getNumber());
             }
-            version = new VersionImpl(storeName, versionNumber, pushJobId, numberOfPartitions);
-          }
-
-          topicToCreationTime.computeIfAbsent(version.kafkaTopicName(), topic -> System.currentTimeMillis());
-          createBatchTopics(
-              version,
-              pushType,
-              getTopicManager(),
-              subPartitionCount,
-              clusterConfig,
-              useFastKafkaOperationTimeout);
-
-          ByteBuffer compressionDictionaryBuffer = null;
-          if (compressionDictionary != null) {
-            compressionDictionaryBuffer = ByteBuffer.wrap(EncodingUtils.base64DecodeFromString(compressionDictionary));
-          } else if (store.getCompressionStrategy().equals(CompressionStrategy.ZSTD_WITH_DICT)) {
-            // We can't use dictionary compression with no dictionary, so we generate a basic one
-            // TODO: It would be smarter to query it from the previous version and pass it along. However,
-            // the 'previous' version can mean different things in different colos, and ideally we'd want
-            // a consistent compressed result in all colos so as to make sure we don't confuse our consistency
-            // checking mechanisms. So this needs some (maybe) complicated reworking.
-            compressionDictionaryBuffer = EMPTY_PUSH_ZSTD_DICTIONARY;
-          }
-
-          String sourceKafkaBootstrapServers = null;
-
-          store = repository.getStore(storeName);
-          strategy = store.getOffLinePushStrategy();
-          if (!store.containsVersion(version.getNumber())) {
-            version.setPushType(pushType);
-            store.addVersion(version);
-          }
-
-          // Apply cluster-level native replication configs
-          boolean nativeReplicationEnabled = version.isNativeReplicationEnabled();
-          if (store.isHybrid()) {
-            nativeReplicationEnabled |= clusterConfig.isNativeReplicationEnabledForHybrid();
+            // Update ZK with the new version
+            store.addVersion(version, true);
+            repository.updateStore(store);
           } else {
-            nativeReplicationEnabled |= clusterConfig.isNativeReplicationEnabledForBatchOnly();
-          }
-          version.setNativeReplicationEnabled(nativeReplicationEnabled);
-
-          // Check whether native replication is enabled
-          if (version.isNativeReplicationEnabled()) {
-            if (remoteKafkaBootstrapServers != null) {
-              /**
-               * AddVersion is invoked by {@link com.linkedin.venice.controller.kafka.consumer.AdminExecutionTask}
-               * which is processing an AddVersion message that contains remote Kafka bootstrap servers url.
-               */
-              version.setPushStreamSourceAddress(remoteKafkaBootstrapServers);
+            int amplificationFactor = store.getPartitionerConfig().getAmplificationFactor();
+            int subPartitionCount = numberOfPartitions * amplificationFactor;
+            if (versionNumber == VERSION_ID_UNSET) {
+              // No version supplied, generate a new version. This could happen either in the parent
+              // controller or local Samza jobs.
+              version = new VersionImpl(storeName, store.peekNextVersion().getNumber(), pushJobId, numberOfPartitions);
             } else {
-              /**
-               * AddVersion is invoked by directly querying controllers
-               */
-              String sourceFabric = getNativeReplicationSourceFabric(
-                  clusterName,
-                  store,
-                  sourceGridFabric,
-                  emergencySourceRegion,
-                  targetedRegions);
-              sourceKafkaBootstrapServers = getNativeReplicationKafkaBootstrapServerAddress(sourceFabric);
-              if (sourceKafkaBootstrapServers == null) {
-                sourceKafkaBootstrapServers = getKafkaBootstrapServers(isSslToKafka());
+              if (store.containsVersion(versionNumber)) {
+                throwVersionAlreadyExists(storeName, versionNumber);
               }
-              version.setPushStreamSourceAddress(sourceKafkaBootstrapServers);
-              version.setNativeReplicationSourceFabric(sourceFabric);
+              version = new VersionImpl(storeName, versionNumber, pushJobId, numberOfPartitions);
             }
-            if (isParent() && ((store.isHybrid()
-                && store.getHybridStoreConfig().getDataReplicationPolicy() == DataReplicationPolicy.AGGREGATE)
-                || store.isIncrementalPushEnabled())) {
-              // Create rt topic in parent colo if the store is aggregate mode hybrid store
-              PubSubTopic realTimeTopic = pubSubTopicRepository.getTopic(Version.composeRealTimeTopic(storeName));
-              if (!getTopicManager().containsTopic(realTimeTopic)) {
-                getTopicManager().createTopic(
-                    realTimeTopic,
-                    numberOfPartitions,
-                    clusterConfig.getKafkaReplicationFactorRTTopics(),
-                    TopicManager.getExpectedRetentionTimeInMs(store, store.getHybridStoreConfig()),
-                    false, // Note: do not enable RT compaction! Might make jobs in Online/Offline model stuck
-                    clusterConfig.getMinInSyncReplicasRealTimeTopics(),
-                    false);
+
+            topicToCreationTime.computeIfAbsent(version.kafkaTopicName(), topic -> System.currentTimeMillis());
+            createBatchTopics(
+                version,
+                pushType,
+                getTopicManager(),
+                subPartitionCount,
+                clusterConfig,
+                useFastKafkaOperationTimeout);
+
+            ByteBuffer compressionDictionaryBuffer = null;
+            if (compressionDictionary != null) {
+              compressionDictionaryBuffer =
+                  ByteBuffer.wrap(EncodingUtils.base64DecodeFromString(compressionDictionary));
+            } else if (store.getCompressionStrategy().equals(CompressionStrategy.ZSTD_WITH_DICT)) {
+              // We can't use dictionary compression with no dictionary, so we generate a basic one
+              // TODO: It would be smarter to query it from the previous version and pass it along. However,
+              // the 'previous' version can mean different things in different colos, and ideally we'd want
+              // a consistent compressed result in all colos so as to make sure we don't confuse our consistency
+              // checking mechanisms. So this needs some (maybe) complicated reworking.
+              compressionDictionaryBuffer = EMPTY_PUSH_ZSTD_DICTIONARY;
+            }
+
+            String sourceKafkaBootstrapServers = null;
+
+            store = repository.getStore(storeName);
+            if (!store.containsVersion(version.getNumber())) {
+              version.setPushType(pushType);
+              store.addVersion(version);
+            }
+
+            // Apply cluster-level native replication configs
+            boolean nativeReplicationEnabled = version.isNativeReplicationEnabled();
+            if (store.isHybrid()) {
+              nativeReplicationEnabled |= clusterConfig.isNativeReplicationEnabledForHybrid();
+            } else {
+              nativeReplicationEnabled |= clusterConfig.isNativeReplicationEnabledForBatchOnly();
+            }
+            version.setNativeReplicationEnabled(nativeReplicationEnabled);
+
+            // Check whether native replication is enabled
+            if (version.isNativeReplicationEnabled()) {
+              if (remoteKafkaBootstrapServers != null) {
+                /**
+                 * AddVersion is invoked by {@link com.linkedin.venice.controller.kafka.consumer.AdminExecutionTask}
+                 * which is processing an AddVersion message that contains remote Kafka bootstrap servers url.
+                 */
+                version.setPushStreamSourceAddress(remoteKafkaBootstrapServers);
               } else {
-                // If real-time topic already exists, check whether its retention time is correct.
-                PubSubTopicConfiguration pubSubTopicConfiguration =
-                    getTopicManager().getCachedTopicConfig(realTimeTopic);
-                long topicRetentionTimeInMs = getTopicManager().getTopicRetention(pubSubTopicConfiguration);
-                long expectedRetentionTimeMs =
-                    TopicManager.getExpectedRetentionTimeInMs(store, store.getHybridStoreConfig());
-                if (topicRetentionTimeInMs != expectedRetentionTimeMs) {
-                  getTopicManager()
-                      .updateTopicRetention(realTimeTopic, expectedRetentionTimeMs, pubSubTopicConfiguration);
+                /**
+                 * AddVersion is invoked by directly querying controllers
+                 */
+                String sourceFabric = getNativeReplicationSourceFabric(
+                    clusterName,
+                    store,
+                    sourceGridFabric,
+                    emergencySourceRegion,
+                    targetedRegions);
+                sourceKafkaBootstrapServers = getNativeReplicationKafkaBootstrapServerAddress(sourceFabric);
+                if (sourceKafkaBootstrapServers == null) {
+                  sourceKafkaBootstrapServers = getKafkaBootstrapServers(isSslToKafka());
+                }
+                version.setPushStreamSourceAddress(sourceKafkaBootstrapServers);
+                version.setNativeReplicationSourceFabric(sourceFabric);
+              }
+              if (isParent() && ((store.isHybrid()
+                  && store.getHybridStoreConfig().getDataReplicationPolicy() == DataReplicationPolicy.AGGREGATE)
+                  || store.isIncrementalPushEnabled())) {
+                // Create rt topic in parent colo if the store is aggregate mode hybrid store
+                PubSubTopic realTimeTopic = pubSubTopicRepository.getTopic(Version.composeRealTimeTopic(storeName));
+                if (!getTopicManager().containsTopic(realTimeTopic)) {
+                  getTopicManager().createTopic(
+                      realTimeTopic,
+                      numberOfPartitions,
+                      clusterConfig.getKafkaReplicationFactorRTTopics(),
+                      TopicManager.getExpectedRetentionTimeInMs(store, store.getHybridStoreConfig()),
+                      false,
+                      // Note: do not enable RT compaction! Might make jobs in Online/Offline model stuck
+                      clusterConfig.getMinInSyncReplicasRealTimeTopics(),
+                      false);
+                } else {
+                  // If real-time topic already exists, check whether its retention time is correct.
+                  PubSubTopicConfiguration pubSubTopicConfiguration =
+                      getTopicManager().getCachedTopicConfig(realTimeTopic);
+                  long topicRetentionTimeInMs = getTopicManager().getTopicRetention(pubSubTopicConfiguration);
+                  long expectedRetentionTimeMs =
+                      TopicManager.getExpectedRetentionTimeInMs(store, store.getHybridStoreConfig());
+                  if (topicRetentionTimeInMs != expectedRetentionTimeMs) {
+                    getTopicManager()
+                        .updateTopicRetention(realTimeTopic, expectedRetentionTimeMs, pubSubTopicConfiguration);
+                  }
+                }
+              }
+            }
+            /**
+             * Version-level rewind time override.
+             */
+            handleRewindTimeOverride(store, version, rewindTimeInSecondsOverride);
+            store.setPersistenceType(PersistenceType.ROCKS_DB);
+
+            version.setRmdVersionId(replicationMetadataVersionId);
+
+            version.setVersionSwapDeferred(versionSwapDeferred);
+
+            version.setViewConfigs(store.getViewConfigs());
+
+            Properties veniceViewProperties = new Properties();
+            veniceViewProperties.put(SUB_PARTITION_COUNT, subPartitionCount);
+            veniceViewProperties.put(USE_FAST_KAFKA_OPERATION_TIMEOUT, useFastKafkaOperationTimeout);
+            veniceViewProperties.putAll(clusterConfig.getProps().toProperties());
+            veniceViewProperties.put(LOG_COMPACTION_ENABLED, false);
+            veniceViewProperties.put(KAFKA_REPLICATION_FACTOR, clusterConfig.getKafkaReplicationFactor());
+            veniceViewProperties.put(ETERNAL_TOPIC_RETENTION_ENABLED, true);
+
+            constructViewResources(veniceViewProperties, store, version.getNumber());
+
+            repository.updateStore(store);
+            LOGGER.info("Add version: {} for store: {}", version.getNumber(), storeName);
+
+            /**
+             *  When native replication is enabled and it's in parent controller, directly create the topic in
+             *  the specified source fabric if the source fabric is not the local fabric; the above topic creation
+             *  is still required since child controllers need to create a topic locally, and parent controller uses
+             *  local VT to determine whether there is any ongoing offline push.
+             */
+            if (multiClusterConfigs.isParent() && version.isNativeReplicationEnabled()
+                && !version.getPushStreamSourceAddress().equals(getKafkaBootstrapServers(isSslToKafka()))) {
+              if (sourceKafkaBootstrapServers == null) {
+                throw new VeniceException(
+                    "Parent controller should know the source Kafka bootstrap server url for store: " + storeName
+                        + " and version: " + version.getNumber() + " in cluster: " + clusterName);
+              }
+              createBatchTopics(
+                  version,
+                  pushType,
+                  getTopicManager(sourceKafkaBootstrapServers),
+                  subPartitionCount,
+                  clusterConfig,
+                  useFastKafkaOperationTimeout);
+            }
+
+            if (sendStartOfPush) {
+              final Version finalVersion = version;
+              VeniceWriter veniceWriter = null;
+              try {
+                VeniceWriterOptions.Builder vwOptionsBuilder =
+                    new VeniceWriterOptions.Builder(finalVersion.kafkaTopicName()).setUseKafkaKeySerializer(true)
+                        .setPartitionCount(subPartitionCount);
+                if (multiClusterConfigs.isParent() && finalVersion.isNativeReplicationEnabled()) {
+                  // Produce directly into one of the child fabric
+                  vwOptionsBuilder.setBrokerAddress(finalVersion.getPushStreamSourceAddress());
+                }
+                veniceWriter = getVeniceWriterFactory().createVeniceWriter(vwOptionsBuilder.build());
+                veniceWriter.broadcastStartOfPush(
+                    sorted,
+                    finalVersion.isChunkingEnabled(),
+                    finalVersion.getCompressionStrategy(),
+                    Optional.ofNullable(compressionDictionaryBuffer),
+                    Collections.emptyMap());
+                if (pushType.isStreamReprocessing()) {
+                  // Send TS message to version topic to inform leader to switch to the stream reprocessing topic
+                  veniceWriter.broadcastTopicSwitch(
+                      Collections.singletonList(getKafkaBootstrapServers(isSslToKafka())),
+                      Version.composeStreamReprocessingTopic(finalVersion.getStoreName(), finalVersion.getNumber()),
+                      -1L, // -1 indicates rewinding from the beginning of the source topic
+                      new HashMap<>());
+                }
+              } finally {
+                if (veniceWriter != null) {
+                  veniceWriter.close();
                 }
               }
             }
           }
-          /**
-           * Version-level rewind time override.
-           */
-          handleRewindTimeOverride(store, version, rewindTimeInSecondsOverride);
-          store.setPersistenceType(PersistenceType.ROCKS_DB);
-
-          version.setRmdVersionId(replicationMetadataVersionId);
-
-          version.setVersionSwapDeferred(versionSwapDeferred);
-
-          version.setViewConfigs(store.getViewConfigs());
-
-          Properties veniceViewProperties = new Properties();
-          veniceViewProperties.put(SUB_PARTITION_COUNT, subPartitionCount);
-          veniceViewProperties.put(USE_FAST_KAFKA_OPERATION_TIMEOUT, useFastKafkaOperationTimeout);
-          veniceViewProperties.putAll(clusterConfig.getProps().toProperties());
-          veniceViewProperties.put(LOG_COMPACTION_ENABLED, false);
-          veniceViewProperties.put(KAFKA_REPLICATION_FACTOR, clusterConfig.getKafkaReplicationFactor());
-          veniceViewProperties.put(ETERNAL_TOPIC_RETENTION_ENABLED, true);
-
-          constructViewResources(veniceViewProperties, store, version.getNumber());
-
-          repository.updateStore(store);
-          LOGGER.info("Add version: {} for store: {}", version.getNumber(), storeName);
-
-          /**
-           *  When native replication is enabled and it's in parent controller, directly create the topic in
-           *  the specified source fabric if the source fabric is not the local fabric; the above topic creation
-           *  is still required since child controllers need to create a topic locally, and parent controller uses
-           *  local VT to determine whether there is any ongoing offline push.
-           */
-          if (multiClusterConfigs.isParent() && version.isNativeReplicationEnabled()
-              && !version.getPushStreamSourceAddress().equals(getKafkaBootstrapServers(isSslToKafka()))) {
-            if (sourceKafkaBootstrapServers == null) {
-              throw new VeniceException(
-                  "Parent controller should know the source Kafka bootstrap server url for store: " + storeName
-                      + " and version: " + version.getNumber() + " in cluster: " + clusterName);
-            }
-            createBatchTopics(
-                version,
-                pushType,
-                getTopicManager(sourceKafkaBootstrapServers),
-                subPartitionCount,
-                clusterConfig,
-                useFastKafkaOperationTimeout);
-          }
-
-          if (sendStartOfPush) {
-            final Version finalVersion = version;
-            VeniceWriter veniceWriter = null;
-            try {
-              VeniceWriterOptions.Builder vwOptionsBuilder =
-                  new VeniceWriterOptions.Builder(finalVersion.kafkaTopicName()).setUseKafkaKeySerializer(true)
-                      .setPartitionCount(subPartitionCount);
-              if (multiClusterConfigs.isParent() && finalVersion.isNativeReplicationEnabled()) {
-                // Produce directly into one of the child fabric
-                vwOptionsBuilder.setBrokerAddress(finalVersion.getPushStreamSourceAddress());
-              }
-              veniceWriter = getVeniceWriterFactory().createVeniceWriter(vwOptionsBuilder.build());
-              veniceWriter.broadcastStartOfPush(
-                  sorted,
-                  finalVersion.isChunkingEnabled(),
-                  finalVersion.getCompressionStrategy(),
-                  Optional.ofNullable(compressionDictionaryBuffer),
-                  Collections.emptyMap());
-              if (pushType.isStreamReprocessing()) {
-                // Send TS message to version topic to inform leader to switch to the stream reprocessing topic
-                veniceWriter.broadcastTopicSwitch(
-                    Collections.singletonList(getKafkaBootstrapServers(isSslToKafka())),
-                    Version.composeStreamReprocessingTopic(finalVersion.getStoreName(), finalVersion.getNumber()),
-                    -1L, // -1 indicates rewinding from the beginning of the source topic
-                    new HashMap<>());
-              }
-            } finally {
-              if (veniceWriter != null) {
-                veniceWriter.close();
-              }
-            }
-          }
-
           if (startIngestion) {
             // We need to prepare to monitor before creating helix resource.
             startMonitorOfflinePush(
@@ -2544,7 +2620,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
                 version.kafkaTopicName(),
                 numberOfPartitions,
                 replicationFactor,
-                strategy);
+                offlinePushStrategy);
             helixAdminClient.createVeniceStorageClusterResources(
                 clusterName,
                 version.kafkaTopicName(),
@@ -2577,7 +2653,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
           waitUntilNodesAreAssignedForResource(
               clusterName,
               version.kafkaTopicName(),
-              strategy,
+              offlinePushStrategy,
               clusterConfig.getOffLineJobWaitTimeInMilliseconds(),
               replicationFactor);
         } catch (VeniceNoClusterException e) {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -2413,8 +2413,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
               : Optional.empty();
           if (sourceVersion.isPresent()) {
             // Adding an existing version to the destination cluster whose version level resources are already created,
-            // including Kafka topics with data ready, and Helix resource, so skip the steps of recreating these
-            // resources.
+            // including Kafka topics with data ready, so skip the steps of recreating these resources.
             version = sourceVersion.get().cloneVersion();
             // Reset version statue; do not make any other config update, version configs are immutable and the version
             // Configs from the source clusters are source of truth


### PR DESCRIPTION
## Summary
Bug fixed in this PR: During store migration, versions created in the destination cluster only replicates the hybrid configs, partition count from the version configs in the source cluster; other configs values are from the store configs. However, store configs might change after current version is created; if destination cluster uses those updated store configs, it could conflict with the current version resources like Kafka topics, Helix resource, etc.

Incident due to the above bug: a store didn't have compression enabled when current version was created, and later compression was enabled. After store migration, destination cluster thought compression was enabled and thus trying to leverage ZSTD dictionary in the topic which didn't exist.
Chunking feature would have the same problem, like destination cluster though topic is not chunked because chunking is disable after current version is created.

This PR fixed the bug by replicating version configs from the source cluster - while adding version:
Get version configs from the source cluster in the same region (must copy from the same region) if
1) The store is migrating;
2) the cluster processing the add version message is the destination cluster;
3) the version number being added is smaller or equal to the current version in the source cluster,
   meaning that the immutable version level resources are already created.
Otherwise, apply the store configs to the new version.

The fix requires updating the child.cluster.allowlist config for the child controller too, child controller needs this config in order to construct the region to child controller D2 address.

## How was this PR tested?
An integration test is added to verify that version configs in the destination cluster would be exactly the same as the version configs from the source cluster; configs would be changed before starting the store migration, simulating the incident mentioned above.
Confirmed that the new test can't pass without the fix.

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.