### PR TITLE
[server] Remove excessive logging in leader producer callback when store is not A/A or partial update enabled

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderProducerCallback.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderProducerCallback.java
@@ -259,8 +259,6 @@ public class LeaderProducerCallback implements ChunkAwareCallback {
     if (record != null) {
       record.setValueManifest(chunkedValueManifest);
       record.setRmdManifest(chunkedRmdManifest);
-    } else {
-      LOGGER.error("Transient record is missing when trying to update value/RMD manifest.");
     }
   }
 


### PR DESCRIPTION
## [server] Remove excessive logging in leader producer callback when store is not A/A or partial update enabled
Resolves excessive logging found in internal certification flow. This newly added log line will be logged for store that does not have A/A or partial update enabled. Since it is not easy to check store property inside this LPC callback, this PR removes it.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
Existing unit test.

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.