### PR TITLE
[controller][test] Fix issues in data recovery API

### DIFF
--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/DataRecoveryTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/DataRecoveryTest.java
@@ -281,12 +281,17 @@ public class DataRecoveryTest {
               .dataRecovery(sameFabricName, sameFabricName, storeName, VERSION_ID_UNSET, false, true, Optional.empty())
               .isError());
 
-      // Perform multiple rounds of dc-0 --> dc-1 data recovery.
+      /*
+       * Before data recovery, current version in dc-0 and dc-1 is 1.
+       * With two rounds of dc-0 -> dc-1 data recovery, current version in dc-1 changes to 2 and then 3.
+       * Then with two rounds of dc-1 -> dc-0 data recovery, current version in dc-0 becomes 3 and then 4.
+       */
+
+      // Perform 2 rounds of dc-0 --> dc-1 data recovery.
       performDataRecoveryTest(storeName, parentControllerClient, dc1Client, "dc-0", "dc-1", 2, 2);
 
-      // Perform multiple rounds of dc-1 --> dc-0 data recovery. Now, since src colo's (dc-1) current version is 3, we
-      // should expect
-      // dc-0 starts with dc-1's current version = 3;
+      // Perform 2 rounds of dc-1 --> dc-0 data recovery. Now, since src colo's (dc-1) current version is 3, we
+      // should expect dc-0 current version becomes 3 and then 4.
       performDataRecoveryTest(storeName, parentControllerClient, dc0Client, "dc-1", "dc-0", 2, 3);
     }
   }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/DataRecoveryTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/DataRecoveryTest.java
@@ -286,12 +286,7 @@ public class DataRecoveryTest {
        * With two rounds of dc-0 -> dc-1 data recovery, current version in dc-1 changes to 2 and then 3.
        * Then with two rounds of dc-1 -> dc-0 data recovery, current version in dc-0 becomes 3 and then 4.
        */
-
-      // Perform 2 rounds of dc-0 --> dc-1 data recovery.
       performDataRecoveryTest(storeName, parentControllerClient, dc1Client, "dc-0", "dc-1", 2, 2);
-
-      // Perform 2 rounds of dc-1 --> dc-0 data recovery. Now, since src colo's (dc-1) current version is 3, we
-      // should expect dc-0 current version becomes 3 and then 4.
       performDataRecoveryTest(storeName, parentControllerClient, dc0Client, "dc-1", "dc-0", 2, 3);
     }
   }

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/datarecovery/TestDataRecoveryManager.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/datarecovery/TestDataRecoveryManager.java
@@ -7,7 +7,8 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.testng.Assert.*;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 
 import com.linkedin.d2.balancer.D2Client;
 import com.linkedin.venice.controller.VeniceHelixAdmin;

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/datarecovery/TestDataRecoveryManager.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/datarecovery/TestDataRecoveryManager.java
@@ -7,7 +7,7 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.*;
 
 import com.linkedin.d2.balancer.D2Client;
 import com.linkedin.venice.controller.VeniceHelixAdmin;
@@ -68,6 +68,6 @@ public class TestDataRecoveryManager {
     verify(veniceAdmin).addSpecificVersion(eq(clusterName), eq(storeName), captor.capture());
     assertEquals(captor.getValue().getDataRecoveryVersionConfig().getDataRecoverySourceVersionNumber(), version);
     assertEquals(captor.getValue().getNumber(), 2);
-    assertEquals(captor.getValue().getPushJobId(), "data_recovery_pushJob1");
+    assertTrue(captor.getValue().getPushJobId().startsWith("data-recovery"));
   }
 }


### PR DESCRIPTION
This rb targets several issues in the data recovery API:

1\. Today, during data recovery, only when the version number from the source equals to the current version in the dest fabric, we bump a store's version to LargestUsedVersionNumber+1 in parent and use the increased version for data recovery. So, if the version number from the source is less than the current version in the dest, we simply use it in the dest. As a result, data recovery can not complete successfully, because backup version cleanup thread can kick in, consider it as an expired backup version, and delete it.

As a fix to it, we should extends current condition, and increase the store version for such cases as well.

On the other hand, if the version number from the source fabric is larger than current version in dest fabric, we can use it for the dest fabric without increasing it. This is fine because it is larger than the current, and resources for this version will be deleted during prepareDataRecovery. So, even though the version number is used (created and then deleted) in dest fabric before, it can still be reused.

2\. Users sometimes can put the same fabric name for src and dest which is considered as an error operation. This rb adds guardrail to protect such cases and fails early.

Integration tests are also improved to cover the above two issues to verify the correctness of this fix.

## How was this PR tested?
Improved integration tests.

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.