### PR TITLE
[controller][server] Use only relevant configurations for Kafka client construction

### DIFF
--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/adapter/kafka/admin/ApacheKafkaAdminConfig.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/adapter/kafka/admin/ApacheKafkaAdminConfig.java
@@ -9,8 +9,6 @@ import com.linkedin.venice.utils.VeniceProperties;
 import java.time.Duration;
 import java.util.Properties;
 import org.apache.kafka.clients.admin.AdminClientConfig;
-import org.apache.kafka.clients.consumer.ConsumerConfig;
-import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -26,14 +24,14 @@ public class ApacheKafkaAdminConfig {
     this.brokerAddress = veniceProperties.getString(ApacheKafkaProducerConfig.KAFKA_BOOTSTRAP_SERVERS);
     this.adminProperties = getValidAdminProperties(
         veniceProperties.clipAndFilterNamespace(ApacheKafkaProducerConfig.KAFKA_CONFIG_PREFIX).toProperties());
-    this.adminProperties.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, brokerAddress);
+    this.adminProperties.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, brokerAddress);
     // Setup ssl config if needed.
     if (KafkaSSLUtils.validateAndCopyKafkaSSLConfig(veniceProperties, this.adminProperties)) {
       LOGGER.info("Will initialize an SSL Kafka admin client - bootstrapServers: {}", brokerAddress);
     } else {
       LOGGER.info("Will initialize a non-SSL Kafka admin client - bootstrapServers: {}", brokerAddress);
     }
-    this.adminProperties.put(ConsumerConfig.RECEIVE_BUFFER_CONFIG, 1024 * 1024);
+    this.adminProperties.put(AdminClientConfig.RECEIVE_BUFFER_CONFIG, 1024 * 1024);
     this.topicConfigMaxRetryInMs =
         Duration
             .ofSeconds(

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/adapter/kafka/admin/ApacheKafkaAdminConfig.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/adapter/kafka/admin/ApacheKafkaAdminConfig.java
@@ -8,6 +8,7 @@ import com.linkedin.venice.utils.KafkaSSLUtils;
 import com.linkedin.venice.utils.VeniceProperties;
 import java.time.Duration;
 import java.util.Properties;
+import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.logging.log4j.LogManager;
@@ -23,8 +24,8 @@ public class ApacheKafkaAdminConfig {
 
   public ApacheKafkaAdminConfig(VeniceProperties veniceProperties) {
     this.brokerAddress = veniceProperties.getString(ApacheKafkaProducerConfig.KAFKA_BOOTSTRAP_SERVERS);
-    this.adminProperties =
-        veniceProperties.clipAndFilterNamespace(ApacheKafkaProducerConfig.KAFKA_CONFIG_PREFIX).toProperties();
+    this.adminProperties = getValidAdminProperties(
+        veniceProperties.clipAndFilterNamespace(ApacheKafkaProducerConfig.KAFKA_CONFIG_PREFIX).toProperties());
     this.adminProperties.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, brokerAddress);
     // Setup ssl config if needed.
     if (KafkaSSLUtils.validateAndCopyKafkaSSLConfig(veniceProperties, this.adminProperties)) {
@@ -54,4 +55,13 @@ public class ApacheKafkaAdminConfig {
     return brokerAddress;
   }
 
+  public static Properties getValidAdminProperties(Properties extractedProperties) {
+    Properties validProperties = new Properties();
+    extractedProperties.forEach((configKey, configVal) -> {
+      if (AdminClientConfig.configNames().contains(configKey)) {
+        validProperties.put(configKey, configVal);
+      }
+    });
+    return validProperties;
+  }
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/adapter/kafka/consumer/ApacheKafkaConsumerConfig.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/adapter/kafka/consumer/ApacheKafkaConsumerConfig.java
@@ -36,7 +36,8 @@ public class ApacheKafkaConsumerConfig {
   private final Properties consumerProperties;
 
   public ApacheKafkaConsumerConfig(VeniceProperties veniceProperties, String consumerName) {
-    this.consumerProperties = veniceProperties.clipAndFilterNamespace(KAFKA_CONFIG_PREFIX).toProperties();
+    this.consumerProperties =
+        getValidConsumerProperties(veniceProperties.clipAndFilterNamespace(KAFKA_CONFIG_PREFIX).toProperties());
     if (consumerName != null) {
       consumerProperties.put(ConsumerConfig.CLIENT_ID_CONFIG, consumerName);
     }
@@ -55,5 +56,15 @@ public class ApacheKafkaConsumerConfig {
 
   public Properties getConsumerProperties() {
     return consumerProperties;
+  }
+
+  public static Properties getValidConsumerProperties(Properties extractedProperties) {
+    Properties validProperties = new Properties();
+    extractedProperties.forEach((configKey, configVal) -> {
+      if (ConsumerConfig.configNames().contains(configKey)) {
+        validProperties.put(configKey, configVal);
+      }
+    });
+    return validProperties;
   }
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/adapter/kafka/producer/ApacheKafkaProducerConfig.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/adapter/kafka/producer/ApacheKafkaProducerConfig.java
@@ -65,7 +65,8 @@ public class ApacheKafkaProducerConfig {
       boolean strictConfigs) {
     String brokerAddress =
         brokerAddressToOverride != null ? brokerAddressToOverride : getPubsubBrokerAddress(allVeniceProperties);
-    this.producerProperties = allVeniceProperties.clipAndFilterNamespace(KAFKA_CONFIG_PREFIX).toProperties();
+    this.producerProperties =
+        getValidProducerProperties(allVeniceProperties.clipAndFilterNamespace(KAFKA_CONFIG_PREFIX).toProperties());
     this.producerProperties.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, brokerAddress);
     validateAndUpdateProperties(this.producerProperties, strictConfigs);
     if (producerName != null) {
@@ -201,6 +202,16 @@ public class ApacheKafkaProducerConfig {
               + "requiredConfigKey: '" + requiredConfigKey + "', requiredConfigValue: '" + requiredConfigValue
               + "', actualConfigValue: '" + actualConfigValue + "'.");
     }
+  }
+
+  public static Properties getValidProducerProperties(Properties extractedProperties) {
+    Properties validProperties = new Properties();
+    extractedProperties.forEach((configKey, configVal) -> {
+      if (ProducerConfig.configNames().contains(configKey)) {
+        validProperties.put(configKey, configVal);
+      }
+    });
+    return validProperties;
   }
 
   /**

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/adapter/kafka/producer/ApacheKafkaProducerConfig.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/adapter/kafka/producer/ApacheKafkaProducerConfig.java
@@ -276,6 +276,5 @@ public class ApacheKafkaProducerConfig {
         properties.put("kafka.security.protocol", securityProtocol);
       }
     }
-
   }
 }

--- a/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/adapter/kafka/admin/ApacheKafkaAdminConfigTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/adapter/kafka/admin/ApacheKafkaAdminConfigTest.java
@@ -4,6 +4,9 @@ import static org.testng.Assert.*;
 
 import com.linkedin.venice.utils.VeniceProperties;
 import java.util.Properties;
+import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.config.SslConfigs;
 import org.apache.kafka.common.protocol.SecurityProtocol;
 import org.testng.annotations.Test;
@@ -47,5 +50,17 @@ public class ApacheKafkaAdminConfigTest {
     assertEquals(SASL_JAAS_CONFIG, adminProperties.get("sasl.jaas.config"));
     assertEquals(SASL_MECHANISM, adminProperties.get("sasl.mechanism"));
     assertEquals(securityProtocol.name, adminProperties.get("security.protocol"));
+  }
+
+  @Test
+  public void testGetValidAdminProperties() {
+    Properties allProps = new Properties();
+    allProps.put(ProducerConfig.MAX_BLOCK_MS_CONFIG, "1000");
+    allProps.put(ConsumerConfig.MAX_PARTITION_FETCH_BYTES_CONFIG, "2000");
+    allProps.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+
+    Properties validProps = ApacheKafkaAdminConfig.getValidAdminProperties(allProps);
+    assertEquals(validProps.size(), 1);
+    assertEquals(validProps.get(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG), "localhost:9092");
   }
 }

--- a/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/adapter/kafka/admin/ApacheKafkaAdminConfigTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/adapter/kafka/admin/ApacheKafkaAdminConfigTest.java
@@ -58,6 +58,7 @@ public class ApacheKafkaAdminConfigTest {
     allProps.put(ProducerConfig.MAX_BLOCK_MS_CONFIG, "1000");
     allProps.put(ConsumerConfig.MAX_PARTITION_FETCH_BYTES_CONFIG, "2000");
     allProps.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+    allProps.put("bogus.kafka.config", "bogusValue");
 
     Properties validProps = ApacheKafkaAdminConfig.getValidAdminProperties(allProps);
     assertEquals(validProps.size(), 1);

--- a/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/adapter/kafka/consumer/ApacheKafkaConsumerConfigTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/adapter/kafka/consumer/ApacheKafkaConsumerConfigTest.java
@@ -7,6 +7,9 @@ import static org.testng.Assert.assertEquals;
 
 import com.linkedin.venice.pubsub.adapter.kafka.producer.ApacheKafkaProducerConfig;
 import java.util.Properties;
+import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.ProducerConfig;
 import org.testng.annotations.Test;
 
 
@@ -31,5 +34,19 @@ public class ApacheKafkaConsumerConfigTest {
     assertEquals(SASL_JAAS_CONFIG, producerProperties.get("sasl.jaas.config"));
     assertEquals(SASL_MECHANISM, producerProperties.get("sasl.mechanism"));
     assertEquals("SASL_SSL", producerProperties.get("security.protocol"));
+  }
+
+  @Test
+  public void testGetValidConsumerProperties() {
+    Properties allProps = new Properties();
+    allProps.put(ProducerConfig.MAX_BLOCK_MS_CONFIG, "1000");
+    allProps.put(ConsumerConfig.MAX_PARTITION_FETCH_BYTES_CONFIG, "2000");
+    // this is common config; there are no admin specific configs
+    allProps.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+
+    Properties validProps = ApacheKafkaConsumerConfig.getValidConsumerProperties(allProps);
+    assertEquals(validProps.size(), 2);
+    assertEquals(validProps.get(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG), "localhost:9092");
+    assertEquals(validProps.get(ConsumerConfig.MAX_PARTITION_FETCH_BYTES_CONFIG), "2000");
   }
 }

--- a/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/adapter/kafka/consumer/ApacheKafkaConsumerConfigTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/adapter/kafka/consumer/ApacheKafkaConsumerConfigTest.java
@@ -43,6 +43,7 @@ public class ApacheKafkaConsumerConfigTest {
     allProps.put(ConsumerConfig.MAX_PARTITION_FETCH_BYTES_CONFIG, "2000");
     // this is common config; there are no admin specific configs
     allProps.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+    allProps.put("bogus.kafka.config", "bogusValue");
 
     Properties validProps = ApacheKafkaConsumerConfig.getValidConsumerProperties(allProps);
     assertEquals(validProps.size(), 2);

--- a/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/adapter/kafka/producer/ApacheKafkaProducerConfigTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/adapter/kafka/producer/ApacheKafkaProducerConfigTest.java
@@ -16,6 +16,8 @@ import com.linkedin.venice.serialization.KafkaKeySerializer;
 import com.linkedin.venice.utils.VeniceProperties;
 import java.util.Properties;
 import java.util.function.BiConsumer;
+import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -184,5 +186,19 @@ public class ApacheKafkaProducerConfigTest {
     assertEquals(actualProps2.get(ProducerConfig.BATCH_SIZE_CONFIG), "55");
     assertTrue(actualProps2.containsKey(ProducerConfig.LINGER_MS_CONFIG));
     assertEquals(actualProps2.get(ProducerConfig.LINGER_MS_CONFIG), "66");
+  }
+
+  @Test
+  public void testGetValidProducerProperties() {
+    Properties allProps = new Properties();
+    allProps.put(ProducerConfig.MAX_BLOCK_MS_CONFIG, "1000");
+    allProps.put(ConsumerConfig.MAX_PARTITION_FETCH_BYTES_CONFIG, "2000");
+    // this is common config; there are no admin specific configs
+    allProps.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+
+    Properties validProps = ApacheKafkaProducerConfig.getValidProducerProperties(allProps);
+    assertEquals(validProps.size(), 2);
+    assertEquals(validProps.get(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG), "localhost:9092");
+    assertEquals(validProps.get(ProducerConfig.MAX_BLOCK_MS_CONFIG), "1000");
   }
 }

--- a/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/adapter/kafka/producer/ApacheKafkaProducerConfigTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/adapter/kafka/producer/ApacheKafkaProducerConfigTest.java
@@ -195,6 +195,7 @@ public class ApacheKafkaProducerConfigTest {
     allProps.put(ConsumerConfig.MAX_PARTITION_FETCH_BYTES_CONFIG, "2000");
     // this is common config; there are no admin specific configs
     allProps.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+    allProps.put("bogus.kafka.config", "bogusValue");
 
     Properties validProps = ApacheKafkaProducerConfig.getValidProducerProperties(allProps);
     assertEquals(validProps.size(), 2);


### PR DESCRIPTION
## Use only relevant configurations for Kafka client construction
Currently we extract Kafka client properties from VeniceProperties based on prefixes. However, this approach  
sometimes  leads to passing irrelevant properties to clients, as these properties may contain settings intended  
for other client types. When irrelevant properties are passed to Kafka clients they log a message which ends up
polluting logs and can cause confusion.  

Fixed this issue by adding an additional property check to ensure their validity for the specific client being constructed.  


Resolves #XXX

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.