### PR TITLE
[controller][server] Reduce logging in controller, server

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/RocksDBSstFileWriter.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/RocksDBSstFileWriter.java
@@ -257,7 +257,7 @@ public class RocksDBSstFileWriter {
                     + recordNumInLastSSTFile + ", latency(ms): " + LatencyUtils.getElapsedTimeInMs(startMs));
           }
         }
-      } else {
+      } else if (!isRMD) {
         LOGGER.warn(
             "Sync gets invoked for store: {}, partition id: {}, but the last sst file: {} is empty",
             storeName,

--- a/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/PushStatusCollector.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/PushStatusCollector.java
@@ -143,7 +143,7 @@ public class PushStatusCollector {
       try {
         pushStatus = future.get();
       } catch (Exception e) {
-        LOGGER.error("Caught exception when getting future result of push status.", e);
+        LOGGER.error("Caught exception when getting future result of push status : " + e.getMessage());
         continue;
       }
       ExecutionStatusWithDetails daVinciStatus = pushStatus.getDaVinciStatus();


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Reduce exception logging in push status collector in controller and SST file ingestion in Server
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

For stores without pushstatus system store, controller logs get flooded with full excception stacktrace. Also in server most of the time RMD file sst writer are empty, so do not print any warn log for it.
## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.