### PR TITLE
[server][da-vinci] Added a configurable delay from OFFLINE to DROPPED transition

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
@@ -101,6 +101,7 @@ import static com.linkedin.venice.ConfigKeys.SERVER_SHUTDOWN_DISK_UNHEALTHY_TIME
 import static com.linkedin.venice.ConfigKeys.SERVER_SOURCE_TOPIC_OFFSET_CHECK_INTERVAL_MS;
 import static com.linkedin.venice.ConfigKeys.SERVER_SSL_HANDSHAKE_QUEUE_CAPACITY;
 import static com.linkedin.venice.ConfigKeys.SERVER_SSL_HANDSHAKE_THREAD_POOL_SIZE;
+import static com.linkedin.venice.ConfigKeys.SERVER_STOP_CONSUMPTION_WAIT_RETRIES_NUM;
 import static com.linkedin.venice.ConfigKeys.SERVER_STORE_TO_EARLY_TERMINATION_THRESHOLD_MS_MAP;
 import static com.linkedin.venice.ConfigKeys.SERVER_SYSTEM_STORE_PROMOTION_TO_LEADER_REPLICA_DELAY_SECONDS;
 import static com.linkedin.venice.ConfigKeys.SERVER_UNSUB_AFTER_BATCHPUSH;
@@ -274,6 +275,7 @@ public class VeniceServerConfig extends VeniceClusterConfig {
 
   private final int partitionGracefulDropDelaySeconds;
 
+  private final int stopConsumptionWaitRetriesNumber;
   private final long leakedResourceCleanUpIntervalInMS;
 
   private final boolean quotaEnforcementEnabled;
@@ -490,6 +492,8 @@ public class VeniceServerConfig extends VeniceClusterConfig {
         serverProperties.getSizeInBytes(SERVER_DATABASE_SYNC_BYTES_INTERNAL_FOR_DEFERRED_WRITE_MODE, 60 * 1024 * 1024);
     diskFullThreshold = serverProperties.getDouble(SERVER_DISK_FULL_THRESHOLD, 0.95);
     partitionGracefulDropDelaySeconds = serverProperties.getInt(SERVER_PARTITION_GRACEFUL_DROP_DELAY_IN_SECONDS, 30);
+    stopConsumptionWaitRetriesNumber =
+        serverProperties.getInt(SERVER_STOP_CONSUMPTION_WAIT_RETRIES_NUM, partitionGracefulDropDelaySeconds);
     leakedResourceCleanUpIntervalInMS =
         TimeUnit.MINUTES.toMillis(serverProperties.getLong(SERVER_LEAKED_RESOURCE_CLEAN_UP_INTERVAL_IN_MINUTES, 10));
     quotaEnforcementEnabled = serverProperties.getBoolean(SERVER_QUOTA_ENFORCEMENT_ENABLED, false);
@@ -881,6 +885,10 @@ public class VeniceServerConfig extends VeniceClusterConfig {
 
   public int getPartitionGracefulDropDelaySeconds() {
     return partitionGracefulDropDelaySeconds;
+  }
+
+  public int getStopConsumptionWaitRetriesNumber() {
+    return stopConsumptionWaitRetriesNumber;
   }
 
   public long getLeakedResourceCleanUpIntervalInMS() {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
@@ -492,8 +492,7 @@ public class VeniceServerConfig extends VeniceClusterConfig {
         serverProperties.getSizeInBytes(SERVER_DATABASE_SYNC_BYTES_INTERNAL_FOR_DEFERRED_WRITE_MODE, 60 * 1024 * 1024);
     diskFullThreshold = serverProperties.getDouble(SERVER_DISK_FULL_THRESHOLD, 0.95);
     partitionGracefulDropDelaySeconds = serverProperties.getInt(SERVER_PARTITION_GRACEFUL_DROP_DELAY_IN_SECONDS, 30);
-    stopConsumptionWaitRetriesNumber =
-        serverProperties.getInt(SERVER_STOP_CONSUMPTION_WAIT_RETRIES_NUM, partitionGracefulDropDelaySeconds);
+    stopConsumptionWaitRetriesNumber = serverProperties.getInt(SERVER_STOP_CONSUMPTION_WAIT_RETRIES_NUM, 180);
     leakedResourceCleanUpIntervalInMS =
         TimeUnit.MINUTES.toMillis(serverProperties.getLong(SERVER_LEAKED_RESOURCE_CLEAN_UP_INTERVAL_IN_MINUTES, 10));
     quotaEnforcementEnabled = serverProperties.getBoolean(SERVER_QUOTA_ENFORCEMENT_ENABLED, false);

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
@@ -101,7 +101,7 @@ import static com.linkedin.venice.ConfigKeys.SERVER_SHUTDOWN_DISK_UNHEALTHY_TIME
 import static com.linkedin.venice.ConfigKeys.SERVER_SOURCE_TOPIC_OFFSET_CHECK_INTERVAL_MS;
 import static com.linkedin.venice.ConfigKeys.SERVER_SSL_HANDSHAKE_QUEUE_CAPACITY;
 import static com.linkedin.venice.ConfigKeys.SERVER_SSL_HANDSHAKE_THREAD_POOL_SIZE;
-import static com.linkedin.venice.ConfigKeys.SERVER_STOP_CONSUMPTION_WAIT_RETRIES_NUM;
+import static com.linkedin.venice.ConfigKeys.SERVER_STOP_CONSUMPTION_TIMEOUT_IN_SECONDS;
 import static com.linkedin.venice.ConfigKeys.SERVER_STORE_TO_EARLY_TERMINATION_THRESHOLD_MS_MAP;
 import static com.linkedin.venice.ConfigKeys.SERVER_SYSTEM_STORE_PROMOTION_TO_LEADER_REPLICA_DELAY_SECONDS;
 import static com.linkedin.venice.ConfigKeys.SERVER_UNSUB_AFTER_BATCHPUSH;
@@ -275,7 +275,7 @@ public class VeniceServerConfig extends VeniceClusterConfig {
 
   private final int partitionGracefulDropDelaySeconds;
 
-  private final int stopConsumptionWaitRetriesNumber;
+  private final int stopConsumptionTimeoutInSeconds;
   private final long leakedResourceCleanUpIntervalInMS;
 
   private final boolean quotaEnforcementEnabled;
@@ -492,7 +492,7 @@ public class VeniceServerConfig extends VeniceClusterConfig {
         serverProperties.getSizeInBytes(SERVER_DATABASE_SYNC_BYTES_INTERNAL_FOR_DEFERRED_WRITE_MODE, 60 * 1024 * 1024);
     diskFullThreshold = serverProperties.getDouble(SERVER_DISK_FULL_THRESHOLD, 0.95);
     partitionGracefulDropDelaySeconds = serverProperties.getInt(SERVER_PARTITION_GRACEFUL_DROP_DELAY_IN_SECONDS, 30);
-    stopConsumptionWaitRetriesNumber = serverProperties.getInt(SERVER_STOP_CONSUMPTION_WAIT_RETRIES_NUM, 180);
+    stopConsumptionTimeoutInSeconds = serverProperties.getInt(SERVER_STOP_CONSUMPTION_TIMEOUT_IN_SECONDS, 180);
     leakedResourceCleanUpIntervalInMS =
         TimeUnit.MINUTES.toMillis(serverProperties.getLong(SERVER_LEAKED_RESOURCE_CLEAN_UP_INTERVAL_IN_MINUTES, 10));
     quotaEnforcementEnabled = serverProperties.getBoolean(SERVER_QUOTA_ENFORCEMENT_ENABLED, false);
@@ -886,8 +886,8 @@ public class VeniceServerConfig extends VeniceClusterConfig {
     return partitionGracefulDropDelaySeconds;
   }
 
-  public int getStopConsumptionWaitRetriesNumber() {
-    return stopConsumptionWaitRetriesNumber;
+  public int getStopConsumptionTimeoutInSeconds() {
+    return stopConsumptionTimeoutInSeconds;
   }
 
   public long getLeakedResourceCleanUpIntervalInMS() {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/helix/AbstractPartitionStateModel.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/helix/AbstractPartitionStateModel.java
@@ -248,10 +248,8 @@ public abstract class AbstractPartitionStateModel extends StateModel {
     // Since this removes the storageEngine from the map not doing an un-subscribe and dropping a partition could
     // lead to NPE and other issues.
     // Adding a topic unsubscribe call for those race conditions as a safeguard before dropping the partition.
-    ingestionBackend.dropStoragePartitionGracefully(
-        storeConfig,
-        partition,
-        getStoreConfig().getPartitionGracefulDropDelaySeconds());
+    ingestionBackend
+        .dropStoragePartitionGracefully(storeConfig, partition, getStoreConfig().getStopConsumptionWaitRetriesNumber());
     removeCustomizedState();
   }
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/helix/AbstractPartitionStateModel.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/helix/AbstractPartitionStateModel.java
@@ -249,7 +249,7 @@ public abstract class AbstractPartitionStateModel extends StateModel {
     // lead to NPE and other issues.
     // Adding a topic unsubscribe call for those race conditions as a safeguard before dropping the partition.
     ingestionBackend
-        .dropStoragePartitionGracefully(storeConfig, partition, getStoreConfig().getStopConsumptionWaitRetriesNumber());
+        .dropStoragePartitionGracefully(storeConfig, partition, getStoreConfig().getStopConsumptionTimeoutInSeconds());
     removeCustomizedState();
   }
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/helix/AbstractStateModelFactory.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/helix/AbstractStateModelFactory.java
@@ -57,6 +57,10 @@ public abstract class AbstractStateModelFactory extends StateModelFactory<StateM
     return executorService;
   }
 
+  /**
+   * Use the right state transition stats for the resource. By default, use the regular one; when
+   * dual state transition thread pool is enabled, use the future version stats for future version resource.
+   */
   public ParticipantStateTransitionStats getStateTransitionStats(String resourceName) {
     return stateTransitionStats;
   }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/helix/AbstractStateModelFactory.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/helix/AbstractStateModelFactory.java
@@ -3,6 +3,7 @@ package com.linkedin.davinci.helix;
 import com.linkedin.davinci.config.VeniceConfigLoader;
 import com.linkedin.davinci.ingestion.VeniceIngestionBackend;
 import com.linkedin.davinci.kafka.consumer.StoreIngestionService;
+import com.linkedin.davinci.stats.ParticipantStateTransitionStats;
 import com.linkedin.davinci.storage.StorageService;
 import com.linkedin.venice.helix.HelixPartitionStatusAccessor;
 import com.linkedin.venice.meta.ReadOnlyStoreRepository;
@@ -29,6 +30,7 @@ public abstract class AbstractStateModelFactory extends StateModelFactory<StateM
   // a dedicated thread pool for state transition execution that all state model created by the
   // same factory would share. If it's null, Helix would use a shared thread pool.
   protected final ExecutorService executorService;
+  protected final ParticipantStateTransitionStats stateTransitionStats;
 
   protected CompletableFuture<HelixPartitionStatusAccessor> partitionPushStatusAccessorFuture;
   protected final String instanceName;
@@ -37,12 +39,14 @@ public abstract class AbstractStateModelFactory extends StateModelFactory<StateM
       VeniceIngestionBackend ingestionBackend,
       VeniceConfigLoader configService,
       ExecutorService executorService,
+      ParticipantStateTransitionStats stateTransitionStats,
       ReadOnlyStoreRepository storeMetadataRepo,
       CompletableFuture<HelixPartitionStatusAccessor> partitionPushStatusAccessorFuture,
       String instanceName) {
     this.ingestionBackend = ingestionBackend;
     this.configService = configService;
     this.executorService = executorService;
+    this.stateTransitionStats = stateTransitionStats;
     this.storeMetadataRepo = storeMetadataRepo;
     this.partitionPushStatusAccessorFuture = partitionPushStatusAccessorFuture;
     this.instanceName = instanceName;
@@ -51,6 +55,10 @@ public abstract class AbstractStateModelFactory extends StateModelFactory<StateM
   @Override
   public ExecutorService getExecutorService(String resourceName) {
     return executorService;
+  }
+
+  public ParticipantStateTransitionStats getStateTransitionStats(String resourceName) {
+    return stateTransitionStats;
   }
 
   /**

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/helix/LeaderFollowerPartitionStateModelFactory.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/helix/LeaderFollowerPartitionStateModelFactory.java
@@ -2,6 +2,7 @@ package com.linkedin.davinci.helix;
 
 import com.linkedin.davinci.config.VeniceConfigLoader;
 import com.linkedin.davinci.ingestion.VeniceIngestionBackend;
+import com.linkedin.davinci.stats.ParticipantStateTransitionStats;
 import com.linkedin.venice.helix.HelixPartitionStatusAccessor;
 import com.linkedin.venice.meta.ReadOnlyStoreRepository;
 import com.linkedin.venice.utils.HelixUtils;
@@ -21,6 +22,7 @@ public class LeaderFollowerPartitionStateModelFactory extends AbstractStateModel
       VeniceIngestionBackend ingestionBackend,
       VeniceConfigLoader configService,
       ExecutorService executorService,
+      ParticipantStateTransitionStats stateTransitionStats,
       ReadOnlyStoreRepository metadataRepo,
       CompletableFuture<HelixPartitionStatusAccessor> partitionPushStatusAccessorFuture,
       String instanceName) {
@@ -28,6 +30,7 @@ public class LeaderFollowerPartitionStateModelFactory extends AbstractStateModel
         ingestionBackend,
         configService,
         executorService,
+        stateTransitionStats,
         metadataRepo,
         partitionPushStatusAccessorFuture,
         instanceName);
@@ -48,7 +51,8 @@ public class LeaderFollowerPartitionStateModelFactory extends AbstractStateModel
         leaderFollowerStateModelNotifier,
         getStoreMetadataRepo(),
         partitionPushStatusAccessorFuture,
-        instanceName);
+        instanceName,
+        getStateTransitionStats(resourceName));
   }
 
   /**

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/DefaultIngestionBackend.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/DefaultIngestionBackend.java
@@ -95,7 +95,9 @@ public class DefaultIngestionBackend implements DaVinciIngestionBackend, VeniceI
     getStoreIngestionService().getMetaSystemStoreReplicaStatusNotifier()
         .ifPresent(systemStoreReplicaStatusNotifier -> systemStoreReplicaStatusNotifier.drop(topicName, partition));
     // Stop consumption of the partition.
-    getStoreIngestionService().stopConsumptionAndWait(storeConfig, partition, 1, timeoutInSeconds, true);
+    final int waitIntervalInSecond = 1;
+    final int maxRetry = timeoutInSeconds / waitIntervalInSecond;
+    getStoreIngestionService().stopConsumptionAndWait(storeConfig, partition, waitIntervalInSecond, maxRetry, true);
     // Drops corresponding data partition from storage.
     getStorageService().dropStorePartition(storeConfig, partition, removeEmptyStorageEngine);
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/isolated/IsolatedIngestionServer.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/isolated/IsolatedIngestionServer.java
@@ -5,7 +5,7 @@ import static com.linkedin.venice.ConfigKeys.D2_ZK_HOSTS_ADDRESS;
 import static com.linkedin.venice.ConfigKeys.SERVER_INGESTION_ISOLATION_CONNECTION_TIMEOUT_SECONDS;
 import static com.linkedin.venice.ConfigKeys.SERVER_INGESTION_ISOLATION_STATS_CLASS_LIST;
 import static com.linkedin.venice.ConfigKeys.SERVER_REMOTE_INGESTION_REPAIR_SLEEP_INTERVAL_SECONDS;
-import static com.linkedin.venice.ConfigKeys.SERVER_STOP_CONSUMPTION_WAIT_RETRIES_NUM;
+import static com.linkedin.venice.ConfigKeys.SERVER_STOP_CONSUMPTION_TIMEOUT_IN_SECONDS;
 import static java.lang.Thread.currentThread;
 
 import com.linkedin.d2.balancer.D2Client;
@@ -148,7 +148,7 @@ public class IsolatedIngestionServer extends AbstractVeniceService {
   private IsolatedIngestionRequestClient reportClient;
   private IsolatedIngestionRequestClient metricClient;
   private volatile long heartbeatTimeInMs = System.currentTimeMillis();
-  private int stopConsumptionWaitRetriesNum;
+  private int stopConsumptionTimeoutInSeconds;
   private DefaultIngestionBackend ingestionBackend;
   private final RemoteIngestionRepairService repairService;
 
@@ -329,8 +329,8 @@ public class IsolatedIngestionServer extends AbstractVeniceService {
     return storeVersionStateSerializer;
   }
 
-  public int getStopConsumptionWaitRetriesNum() {
-    return stopConsumptionWaitRetriesNum;
+  public int getStopConsumptionTimeoutInSeconds() {
+    return stopConsumptionTimeoutInSeconds;
   }
 
   public Map<String, Double> getMetricsMap() {
@@ -531,8 +531,13 @@ public class IsolatedIngestionServer extends AbstractVeniceService {
         VeniceStoreVersionConfig storeConfig = getConfigLoader().getStoreConfig(topicName);
         // Make sure partition is not consuming, so we can safely close the rocksdb partition
         long startTimeInMs = System.currentTimeMillis();
-        getStoreIngestionService()
-            .stopConsumptionAndWait(storeConfig, partitionId, 1, stopConsumptionWaitRetriesNum, false);
+        final int stopConsumptionWaitIntervalInSeconds = 1;
+        getStoreIngestionService().stopConsumptionAndWait(
+            storeConfig,
+            partitionId,
+            stopConsumptionWaitIntervalInSeconds,
+            stopConsumptionTimeoutInSeconds / stopConsumptionWaitIntervalInSeconds,
+            false);
         // Close all RocksDB sub-Partitions in Ingestion Service.
         getStorageService().closeStorePartition(storeConfig, partitionId);
         LOGGER.info(
@@ -622,8 +627,8 @@ public class IsolatedIngestionServer extends AbstractVeniceService {
   }
 
   private void initializeIsolatedIngestionServer() {
-    stopConsumptionWaitRetriesNum =
-        configLoader.getCombinedProperties().getInt(SERVER_STOP_CONSUMPTION_WAIT_RETRIES_NUM, 180);
+    stopConsumptionTimeoutInSeconds =
+        configLoader.getCombinedProperties().getInt(SERVER_STOP_CONSUMPTION_TIMEOUT_IN_SECONDS, 180);
 
     // Initialize D2Client.
     String d2ZkHosts = configLoader.getCombinedProperties().getString(D2_ZK_HOSTS_ADDRESS);

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/isolated/IsolatedIngestionServerHandler.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/isolated/IsolatedIngestionServerHandler.java
@@ -206,7 +206,7 @@ public class IsolatedIngestionServerHandler extends SimpleChannelInboundHandler<
                 .dropStoragePartitionGracefully(
                     storeConfig,
                     partitionId,
-                    isolatedIngestionServer.getStopConsumptionWaitRetriesNum(),
+                    isolatedIngestionServer.getStopConsumptionTimeoutInSeconds(),
                     false);
             isolatedIngestionServer.cleanupTopicPartitionState(topicName, partitionId);
           });

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ConsumerAction.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ConsumerAction.java
@@ -23,6 +23,8 @@ public class ConsumerAction implements Comparable<ConsumerAction> {
 
   private int attempts = 0;
 
+  private long createTimestampInMs = System.currentTimeMillis();
+
   public ConsumerAction(ConsumerActionType type, PubSubTopicPartition topicPartition, int sequenceNumber) {
     this(type, topicPartition, sequenceNumber, null, Optional.empty());
   }
@@ -92,10 +94,15 @@ public class ConsumerAction implements Comparable<ConsumerAction> {
     return leaderState;
   }
 
+  public long getCreateTimestampInMs() {
+    return createTimestampInMs;
+  }
+
   @Override
   public String toString() {
     return "KafkaTaskMessage{" + "type=" + type + ", topic='" + getTopic() + '\'' + ", partition=" + getPartition()
-        + ", attempts=" + attempts + ", sequenceNumber=" + sequenceNumber + '}';
+        + ", attempts=" + attempts + ", sequenceNumber=" + sequenceNumber + ", createdTimestampInMs="
+        + createTimestampInMs + '}';
   }
 
   @Override

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ParticipantStateTransitionStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ParticipantStateTransitionStats.java
@@ -1,0 +1,37 @@
+package com.linkedin.davinci.stats;
+
+import com.linkedin.venice.stats.LambdaStat;
+import com.linkedin.venice.stats.ThreadPoolStats;
+import io.tehuti.metrics.MetricsRepository;
+import io.tehuti.metrics.Sensor;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.atomic.AtomicInteger;
+
+
+/**
+ * This class is used to track the thread pool stats for the state transitions of the participant.
+ * Besides the thread pool stats, it also tracks the number of threads that are blocked on the state transition
+ * from OFFLINE to DROPPED.
+ */
+public class ParticipantStateTransitionStats extends ThreadPoolStats {
+  private Sensor threadBlockedOnOfflineToDroppedTransitionSensor;
+  private AtomicInteger threadBlockedOnOfflineToDroppedTransitionCount = new AtomicInteger(0);
+
+  public ParticipantStateTransitionStats(
+      MetricsRepository metricsRepository,
+      ThreadPoolExecutor threadPoolExecutor,
+      String name) {
+    super(metricsRepository, threadPoolExecutor, name);
+    threadBlockedOnOfflineToDroppedTransitionSensor = registerSensor(
+        "thread_blocked_on_offline_to_dropped_transition",
+        new LambdaStat(() -> this.threadBlockedOnOfflineToDroppedTransitionCount.get()));
+  }
+
+  public void incrementThreadBlockedOnOfflineToDroppedTransitionCount() {
+    threadBlockedOnOfflineToDroppedTransitionCount.incrementAndGet();
+  }
+
+  public void decrementThreadBlockedOnOfflineToDroppedTransitionCount() {
+    threadBlockedOnOfflineToDroppedTransitionCount.decrementAndGet();
+  }
+}

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/helix/AbstractVenicePartitionStateModelTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/helix/AbstractVenicePartitionStateModelTest.java
@@ -4,6 +4,7 @@ import com.linkedin.davinci.config.VeniceStoreVersionConfig;
 import com.linkedin.davinci.ingestion.VeniceIngestionBackend;
 import com.linkedin.davinci.kafka.consumer.KafkaStoreIngestionService;
 import com.linkedin.davinci.stats.AggVersionedIngestionStats;
+import com.linkedin.davinci.stats.ParticipantStateTransitionStats;
 import com.linkedin.davinci.storage.StorageService;
 import com.linkedin.venice.helix.HelixPartitionStatusAccessor;
 import com.linkedin.venice.helix.SafeHelixManager;
@@ -44,6 +45,7 @@ public abstract class AbstractVenicePartitionStateModelTest<MODEL_TYPE extends A
   protected HelixManager mockHelixManager;
   protected HelixPartitionStatusAccessor mockPushStatusAccessor;
   protected CustomizedStateProvider mockCustomizedStateProvider;
+  protected ParticipantStateTransitionStats mockParticipantStateTransitionStats;
 
   @BeforeMethod
   public void setUp() {
@@ -57,6 +59,8 @@ public abstract class AbstractVenicePartitionStateModelTest<MODEL_TYPE extends A
     Mockito.when(mockIngestionBackend.getStorageService()).thenReturn(mockStorageService);
     Mockito.when(mockIngestionBackend.getStoreIngestionService()).thenReturn(mockStoreIngestionService);
     mockStoreConfig = Mockito.mock(VeniceStoreVersionConfig.class);
+    Mockito.when(mockStoreConfig.getPartitionGracefulDropDelaySeconds()).thenReturn(1); // 1 second.
+    mockParticipantStateTransitionStats = Mockito.mock(ParticipantStateTransitionStats.class);
 
     mockAggVersionedIngestionStats = Mockito.mock(AggVersionedIngestionStats.class);
     mockMessage = Mockito.mock(Message.class);

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/helix/LeaderFollowerParticipantModelFactoryTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/helix/LeaderFollowerParticipantModelFactoryTest.java
@@ -4,6 +4,7 @@ import com.linkedin.davinci.config.VeniceConfigLoader;
 import com.linkedin.davinci.config.VeniceServerConfig;
 import com.linkedin.davinci.config.VeniceStoreVersionConfig;
 import com.linkedin.davinci.ingestion.VeniceIngestionBackend;
+import com.linkedin.davinci.stats.ParticipantStateTransitionStats;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.meta.ReadOnlyStoreRepository;
 import com.linkedin.venice.meta.Store;
@@ -68,6 +69,7 @@ public class LeaderFollowerParticipantModelFactoryTest {
         mockIngestionBackend,
         mockConfigLoader,
         this.executorService,
+        Mockito.mock(ParticipantStateTransitionStats.class),
         mockReadOnlyStoreRepository,
         null,
         null);

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/helix/VeniceLeaderFollowerStateModelTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/helix/VeniceLeaderFollowerStateModelTest.java
@@ -5,6 +5,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.linkedin.davinci.stats.ParticipantStateTransitionStats;
 import com.linkedin.venice.meta.Store;
 import java.util.concurrent.CompletableFuture;
 import org.testng.annotations.Test;
@@ -21,7 +22,8 @@ public class VeniceLeaderFollowerStateModelTest extends
         mockNotifier,
         mockReadOnlyStoreRepository,
         CompletableFuture.completedFuture(mockPushStatusAccessor),
-        null);
+        null,
+        mock(ParticipantStateTransitionStats.class));
   }
 
   @Override

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/helix/VeniceLeaderFollowerStateModelTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/helix/VeniceLeaderFollowerStateModelTest.java
@@ -2,10 +2,10 @@ package com.linkedin.davinci.helix;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.linkedin.davinci.stats.ParticipantStateTransitionStats;
 import com.linkedin.venice.meta.Store;
 import java.util.concurrent.CompletableFuture;
 import org.testng.annotations.Test;
@@ -23,7 +23,7 @@ public class VeniceLeaderFollowerStateModelTest extends
         mockReadOnlyStoreRepository,
         CompletableFuture.completedFuture(mockPushStatusAccessor),
         null,
-        mock(ParticipantStateTransitionStats.class));
+        mockParticipantStateTransitionStats);
   }
 
   @Override
@@ -50,5 +50,20 @@ public class VeniceLeaderFollowerStateModelTest extends
         testPartition,
         Store.BOOTSTRAP_TO_ONLINE_TIMEOUT_IN_HOURS,
         mockStoreIngestionService);
+  }
+
+  @Test
+  public void testGracefulDropForCurrentVersionResource() {
+    // if the resource is not the current serving version, state transition thread will not be blocked.
+    when(mockStore.getCurrentVersion()).thenReturn(2);
+    testStateModel.onBecomeDroppedFromOffline(mockMessage, mockContext);
+    verify(mockParticipantStateTransitionStats, never()).incrementThreadBlockedOnOfflineToDroppedTransitionCount();
+    verify(mockParticipantStateTransitionStats, never()).decrementThreadBlockedOnOfflineToDroppedTransitionCount();
+
+    // if the resource is the current serving version, state transition thread will be blocked.
+    when(mockStore.getCurrentVersion()).thenReturn(1);
+    testStateModel.onBecomeDroppedFromOffline(mockMessage, mockContext);
+    verify(mockParticipantStateTransitionStats, times(1)).incrementThreadBlockedOnOfflineToDroppedTransitionCount();
+    verify(mockParticipantStateTransitionStats, times(1)).decrementThreadBlockedOnOfflineToDroppedTransitionCount();
   }
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -608,7 +608,7 @@ public class ConfigKeys {
   /**
    * Number of retries allowed for stopConsumptionAndWait() API in StoreIngestionService.
    */
-  public static final String SERVER_STOP_CONSUMPTION_WAIT_RETRIES_NUM = "server.stop.consumption.wait.retries.num";
+  public static final String SERVER_STOP_CONSUMPTION_TIMEOUT_IN_SECONDS = "server.stop.consumption.timeout.in.seconds";
 
   /**
    * Service listening port number for main ingestion service.


### PR DESCRIPTION
## Summary
Previously in O/B/O mode, there is an explicit delay from OFFLINE to DROPPED transition; we missed this delay when building L/F mode. This PR added the delay back.

## How was this PR tested?
CI ongoing.

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.