### PR TITLE
[server] Do not set data recovery for DaVinci client

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -208,7 +208,8 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
     /**
      * Native replication could also be used to perform data recovery by pointing the source version topic kafka url to
      * a topic with good data in another child fabric.
-     * Do not perform data recovery in DaVinci clients.
+     * During data recovery for DaVinci client running in follower mode does not have the configs needed for data recovery
+     * which leads to DaVinci host ingestion failure, ignore data recovery config for daVinci.
      */
     if (version.getDataRecoveryVersionConfig() == null || isDaVinciClient) {
       this.nativeReplicationSourceVersionTopicKafkaURL = version.getPushStreamSourceAddress();

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -208,6 +208,7 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
     /**
      * Native replication could also be used to perform data recovery by pointing the source version topic kafka url to
      * a topic with good data in another child fabric.
+     * Do not perform data recovery in DaVinci clients.
      */
     if (version.getDataRecoveryVersionConfig() == null || isDaVinciClient) {
       this.nativeReplicationSourceVersionTopicKafkaURL = version.getPushStreamSourceAddress();

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -209,7 +209,7 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
      * Native replication could also be used to perform data recovery by pointing the source version topic kafka url to
      * a topic with good data in another child fabric.
      */
-    if (version.getDataRecoveryVersionConfig() == null) {
+    if (version.getDataRecoveryVersionConfig() == null || isDaVinciClient) {
       this.nativeReplicationSourceVersionTopicKafkaURL = version.getPushStreamSourceAddress();
       isDataRecovery = false;
     } else {


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

##  Do not set data recovery for DaVinci client
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

During target colo push for stores with DaVinci client, or during data recovery,  Venice uses data recovery client endpoints to enable push to rest of the colos, but for DaVinci client running in follower mode does not have the configs needed for data recovery which leads to DaVinci host ingestion failure. 
This PR skip data recovery code path in Davinci clients.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
GHCI
## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.