### PR TITLE
[da-vinci] Added one more config to simplify the DaVinci memory limiter test

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
@@ -669,9 +669,14 @@ public class VeniceServerConfig extends VeniceClusterConfig {
     ingestionMemoryLimit = extractIngestionMemoryLimit(serverProperties, ingestionMode, forkedProcessJvmArgList);
     LOGGER.info("Ingestion memory limit: {} after subtracting other usages", ingestionMemoryLimit);
     ingestionMlockEnabled = serverProperties.getBoolean(INGESTION_MLOCK_ENABLED, false);
-    ingestionMemoryLimitStoreSet = serverProperties.getList(INGESTION_MEMORY_LIMIT_STORE_LIST, Collections.emptyList())
-        .stream()
-        .collect(Collectors.toSet());
+    if (!serverProperties.getString(INGESTION_MEMORY_LIMIT_STORE_LIST, "").isEmpty()) {
+      ingestionMemoryLimitStoreSet =
+          serverProperties.getList(INGESTION_MEMORY_LIMIT_STORE_LIST, Collections.emptyList())
+              .stream()
+              .collect(Collectors.toSet());
+    } else {
+      ingestionMemoryLimitStoreSet = Collections.emptySet();
+    }
 
     this.divProducerStateMaxAgeMs =
         serverProperties.getLong(DIV_PRODUCER_STATE_MAX_AGE_MS, KafkaDataIntegrityValidator.DISABLED);

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
@@ -13,6 +13,7 @@ import static com.linkedin.venice.ConfigKeys.GRPC_READ_SERVER_PORT;
 import static com.linkedin.venice.ConfigKeys.HELIX_HYBRID_STORE_QUOTA_ENABLED;
 import static com.linkedin.venice.ConfigKeys.HYBRID_QUOTA_ENFORCEMENT_ENABLED;
 import static com.linkedin.venice.ConfigKeys.INGESTION_MEMORY_LIMIT;
+import static com.linkedin.venice.ConfigKeys.INGESTION_MEMORY_LIMIT_STORE_LIST;
 import static com.linkedin.venice.ConfigKeys.INGESTION_MLOCK_ENABLED;
 import static com.linkedin.venice.ConfigKeys.INGESTION_USE_DA_VINCI_CLIENT;
 import static com.linkedin.venice.ConfigKeys.KAFKA_ADMIN_CLASS;
@@ -419,6 +420,7 @@ public class VeniceServerConfig extends VeniceClusterConfig {
 
   private final long ingestionMemoryLimit;
   private final boolean ingestionMlockEnabled;
+  private final Set<String> ingestionMemoryLimitStoreSet;
   private final List<String> forkedProcessJvmArgList;
 
   private final long divProducerStateMaxAgeMs;
@@ -667,6 +669,9 @@ public class VeniceServerConfig extends VeniceClusterConfig {
     ingestionMemoryLimit = extractIngestionMemoryLimit(serverProperties, ingestionMode, forkedProcessJvmArgList);
     LOGGER.info("Ingestion memory limit: {} after subtracting other usages", ingestionMemoryLimit);
     ingestionMlockEnabled = serverProperties.getBoolean(INGESTION_MLOCK_ENABLED, false);
+    ingestionMemoryLimitStoreSet = serverProperties.getList(INGESTION_MEMORY_LIMIT_STORE_LIST, Collections.emptyList())
+        .stream()
+        .collect(Collectors.toSet());
 
     this.divProducerStateMaxAgeMs =
         serverProperties.getLong(DIV_PRODUCER_STATE_MAX_AGE_MS, KafkaDataIntegrityValidator.DISABLED);
@@ -1199,6 +1204,10 @@ public class VeniceServerConfig extends VeniceClusterConfig {
 
   public boolean isIngestionMlockEnabled() {
     return ingestionMlockEnabled;
+  }
+
+  public boolean enforceMemoryLimitInStore(String storeName) {
+    return ingestionMemoryLimitStoreSet.isEmpty() || ingestionMemoryLimitStoreSet.contains(storeName);
   }
 
   public long getDivProducerStateMaxAgeMs() {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/RocksDBStorageEngine.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/RocksDBStorageEngine.java
@@ -258,6 +258,10 @@ public class RocksDBStorageEngine extends AbstractStorageEngine<RocksDBStoragePa
   @Override
   public boolean hasMemorySpaceLeft() {
     SstFileManager sstFileManager = factory.getSstFileManagerForMemoryLimiter();
+    if (sstFileManager == null) {
+      // Memory limiter is disabled.
+      return true;
+    }
     if (sstFileManager.isMaxAllowedSpaceReached() || sstFileManager.isMaxAllowedSpaceReachedIncludingCompactions()) {
       return false;
     }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/RocksDBStorageEngine.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/RocksDBStorageEngine.java
@@ -257,7 +257,7 @@ public class RocksDBStorageEngine extends AbstractStorageEngine<RocksDBStoragePa
 
   @Override
   public boolean hasMemorySpaceLeft() {
-    SstFileManager sstFileManager = factory.getSstFileManager();
+    SstFileManager sstFileManager = factory.getSstFileManagerForMemoryLimiter();
     if (sstFileManager.isMaxAllowedSpaceReached() || sstFileManager.isMaxAllowedSpaceReachedIncludingCompactions()) {
       return false;
     }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/store/rocksdb/ReplicationMeadataRocksDBStoragePartitionCFTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/store/rocksdb/ReplicationMeadataRocksDBStoragePartitionCFTest.java
@@ -32,7 +32,7 @@ import org.testng.annotations.BeforeClass;
 public class ReplicationMeadataRocksDBStoragePartitionCFTest extends ReplicationMetadataRocksDBStoragePartitionTest {
   private static final int PARTITION_ID = 0;
 
-  private static final String storeName = Utils.getUniqueString("rocksdb_store_test");
+  private static final String storeName = Version.composeKafkaTopic(Utils.getUniqueString("rocksdb_store_test"), 1);
   private final ReadOnlyStoreRepository mockReadOnlyStoreRepository = mock(ReadOnlyStoreRepository.class);
   private static final int versionNumber = 0;
   private static final String topicName = Version.composeKafkaTopic(storeName, versionNumber);

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/store/rocksdb/ReplicationMetadataRocksDBStoragePartitionTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/store/rocksdb/ReplicationMetadataRocksDBStoragePartitionTest.java
@@ -50,7 +50,7 @@ import org.testng.annotations.Test;
 public class ReplicationMetadataRocksDBStoragePartitionTest extends AbstractStorageEngineTest {
   private static final int PARTITION_ID = 0;
 
-  private static final String storeName = Utils.getUniqueString("rocksdb_store_test");
+  private static final String storeName = Version.composeKafkaTopic(Utils.getUniqueString("rocksdb_store_test"), 1);
   private final ReadOnlyStoreRepository mockReadOnlyStoreRepository = mock(ReadOnlyStoreRepository.class);
   private static final int versionNumber = 0;
   private static final String topicName = Version.composeKafkaTopic(storeName, versionNumber);
@@ -160,7 +160,7 @@ public class ReplicationMetadataRocksDBStoragePartitionTest extends AbstractStor
 
   @Test
   public void testMetadataColumnFamily() {
-    String storeName = "test_store_column1";
+    String storeName = Version.composeKafkaTopic("test_store_column1", 1);
     String storeDir = getTempDatabaseDir(storeName);
     ;
     int valueSchemaId = 1;
@@ -290,7 +290,7 @@ public class ReplicationMetadataRocksDBStoragePartitionTest extends AbstractStor
       boolean reopenDatabaseDuringInterruption,
       boolean verifyChecksum) {
     CheckSum runningChecksum = CheckSum.getInstance(CheckSumType.MD5);
-    String storeName = Utils.getUniqueString("test_store");
+    String storeName = Version.composeKafkaTopic(Utils.getUniqueString("test_store"), 1);
     String storeDir = getTempDatabaseDir(storeName);
     int partitionId = 0;
     StoragePartitionConfig partitionConfig = new StoragePartitionConfig(storeName, partitionId);

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/store/rocksdb/RocksDBStorageEngineFactoryTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/store/rocksdb/RocksDBStorageEngineFactoryTest.java
@@ -5,6 +5,7 @@ import com.linkedin.davinci.config.VeniceStoreVersionConfig;
 import com.linkedin.davinci.store.AbstractStorageEngine;
 import com.linkedin.davinci.store.AbstractStorageEngineTest;
 import com.linkedin.venice.meta.PersistenceType;
+import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.utils.Utils;
 import com.linkedin.venice.utils.VeniceProperties;
 import java.util.Set;
@@ -20,7 +21,7 @@ public class RocksDBStorageEngineFactoryTest {
 
     RocksDBStorageEngineFactory factory = new RocksDBStorageEngineFactory(serverConfig);
 
-    final String testStore = Utils.getUniqueString("test_store");
+    final String testStore = Version.composeKafkaTopic(Utils.getUniqueString("test_store"), 1);
     VeniceStoreVersionConfig testStoreConfig =
         new VeniceStoreVersionConfig(testStore, veniceServerProperties, PersistenceType.ROCKS_DB);
     AbstractStorageEngine storeEngine = factory.getStorageEngine(testStoreConfig);
@@ -37,11 +38,11 @@ public class RocksDBStorageEngineFactoryTest {
 
     RocksDBStorageEngineFactory factory = new RocksDBStorageEngineFactory(serverConfig);
 
-    final String testStore1 = Utils.getUniqueString("test_store");
+    final String testStore1 = Version.composeKafkaTopic(Utils.getUniqueString("test_store"), 1);
     VeniceStoreVersionConfig testStoreConfig1 =
         new VeniceStoreVersionConfig(testStore1, veniceServerProperties, PersistenceType.ROCKS_DB);
     factory.getStorageEngine(testStoreConfig1);
-    final String testStore2 = Utils.getUniqueString("test_store");
+    final String testStore2 = Version.composeKafkaTopic(Utils.getUniqueString("test_store"), 1);
     VeniceStoreVersionConfig testStoreConfig2 =
         new VeniceStoreVersionConfig(testStore2, veniceServerProperties, PersistenceType.ROCKS_DB);
     factory.getStorageEngine(testStoreConfig2);
@@ -61,7 +62,7 @@ public class RocksDBStorageEngineFactoryTest {
 
     RocksDBStorageEngineFactory factory = new RocksDBStorageEngineFactory(serverConfig);
 
-    final String testStore = Utils.getUniqueString("test_store");
+    final String testStore = Version.composeKafkaTopic(Utils.getUniqueString("test_store"), 1);
     VeniceStoreVersionConfig testStoreConfig =
         new VeniceStoreVersionConfig(testStore, veniceServerProperties, PersistenceType.ROCKS_DB);
     AbstractStorageEngine storageEngine = factory.getStorageEngine(testStoreConfig);
@@ -79,7 +80,7 @@ public class RocksDBStorageEngineFactoryTest {
     VeniceServerConfig serverConfig = new VeniceServerConfig(veniceServerProperties);
     RocksDBStorageEngineFactory factory = new RocksDBStorageEngineFactory(serverConfig);
 
-    final String testStore = Utils.getUniqueString("test_store_");
+    final String testStore = Version.composeKafkaTopic(Utils.getUniqueString("test_store_"), 1);
     VeniceStoreVersionConfig testStoreConfig =
         new VeniceStoreVersionConfig(testStore, veniceServerProperties, PersistenceType.ROCKS_DB);
     AbstractStorageEngine storeEngine = factory.getStorageEngine(testStoreConfig);

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/store/rocksdb/RocksDBStoragePartitionTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/store/rocksdb/RocksDBStoragePartitionTest.java
@@ -25,6 +25,7 @@ import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.kafka.validation.checksum.CheckSum;
 import com.linkedin.venice.kafka.validation.checksum.CheckSumType;
 import com.linkedin.venice.meta.PersistenceType;
+import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.serialization.avro.AvroProtocolDefinition;
 import com.linkedin.venice.utils.ByteUtils;
 import com.linkedin.venice.utils.DataProviderUtils;
@@ -120,7 +121,7 @@ public class RocksDBStoragePartitionTest {
       boolean reopenDatabaseDuringInterruption,
       boolean verifyChecksum) {
     CheckSum runningChecksum = CheckSum.getInstance(CheckSumType.MD5);
-    String storeName = Utils.getUniqueString("test_store");
+    String storeName = Version.composeKafkaTopic(Utils.getUniqueString("test_store"), 1);
     String storeDir = getTempDatabaseDir(storeName);
     int partitionId = 0;
     StoragePartitionConfig partitionConfig = new StoragePartitionConfig(storeName, partitionId);
@@ -261,7 +262,7 @@ public class RocksDBStoragePartitionTest {
   @Test(dataProvider = "True-and-False", dataProviderClass = DataProviderUtils.class)
   public void testIngestionFormatVersionChange(boolean sorted) throws RocksDBException {
     CheckSum runningChecksum = CheckSum.getInstance(CheckSumType.MD5);
-    String storeName = Utils.getUniqueString("test_store");
+    String storeName = Version.composeKafkaTopic(Utils.getUniqueString("test_store"), 1);
     String storeDir = getTempDatabaseDir(storeName);
     int partitionId = 0;
     StoragePartitionConfig partitionConfig = new StoragePartitionConfig(storeName, partitionId);
@@ -435,7 +436,7 @@ public class RocksDBStoragePartitionTest {
       boolean reopenDatabaseDuringInterruption,
       boolean verifyChecksum) {
     CheckSum runningChecksum = CheckSum.getInstance(CheckSumType.MD5);
-    String storeName = Utils.getUniqueString("test_store");
+    String storeName = Version.composeKafkaTopic(Utils.getUniqueString("test_store"), 1);
     String storeDir = getTempDatabaseDir(storeName);
     int partitionId = 0;
     StoragePartitionConfig partitionConfig = new StoragePartitionConfig(storeName, partitionId);
@@ -576,7 +577,7 @@ public class RocksDBStoragePartitionTest {
 
   @Test
   public void testChecksumVerificationFailure() {
-    String storeName = "test_store_c1";
+    String storeName = Version.composeKafkaTopic("test_store_c1", 1);
     String storeDir = getTempDatabaseDir(storeName);
     int partitionId = 0;
     StoragePartitionConfig partitionConfig = new StoragePartitionConfig(storeName, partitionId);
@@ -610,7 +611,7 @@ public class RocksDBStoragePartitionTest {
 
   @Test
   public void testRocksDBValidityCheck() {
-    String storeName = Utils.getUniqueString("test_store");
+    String storeName = Version.composeKafkaTopic(Utils.getUniqueString("test_store"), 1);
     String storeDir = getTempDatabaseDir(storeName);
     int partitionId = 0;
     StoragePartitionConfig partitionConfig = new StoragePartitionConfig(storeName, partitionId);
@@ -642,7 +643,7 @@ public class RocksDBStoragePartitionTest {
 
   @Test
   public void testPlainTableCompactionTriggerSetting() {
-    String storeName = Utils.getUniqueString("test_store");
+    String storeName = Version.composeKafkaTopic(Utils.getUniqueString("test_store"), 1);
     String storeDir = getTempDatabaseDir(storeName);
     Properties properties = new Properties();
     properties.put(PERSISTENCE_TYPE, PersistenceType.ROCKS_DB.toString());
@@ -700,7 +701,7 @@ public class RocksDBStoragePartitionTest {
 
   @Test
   public void checkMemoryLimitAtDatabaseOpen() {
-    String storeName = Utils.getUniqueString("test_store");
+    String storeName = Version.composeKafkaTopic(Utils.getUniqueString("test_store"), 1);
     String storeDir = getTempDatabaseDir(storeName);
     RocksDBStoragePartition storagePartition = null;
     try {
@@ -727,7 +728,7 @@ public class RocksDBStoragePartitionTest {
           AvroProtocolDefinition.STORE_VERSION_STATE.getSerializer(),
           AvroProtocolDefinition.PARTITION_STATE.getSerializer());
       Mockito.verify(mockMemoryStats).setMemoryLimit(anyLong());
-      Mockito.verify(mockMemoryStats).setSstFileManager(factory.getSstFileManager());
+      Mockito.verify(mockMemoryStats).setSstFileManager(factory.getSstFileManagerForMemoryLimiter());
       storagePartition = new RocksDBStoragePartition(
           partitionConfig,
           factory,

--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -1920,6 +1920,14 @@ public class ConfigKeys {
   public static final String INGESTION_MLOCK_ENABLED = "ingestion.mlock.enabled";
 
   /**
+   * Only applies the memory limiter to the stores listed in this config.
+   * This is mainly used for testing purpose since ultimately, we want to enforce memory limiter against
+   * all the stores to avoid node crash.
+   * Empty config means ingestion memory limiter will apply to all the stores.
+   */
+  public static final String INGESTION_MEMORY_LIMIT_STORE_LIST = "ingestion.memory.limit.store.list";
+
+  /**
    * The maximum age (in milliseconds) of producer state retained by Data Ingestion Validation. Tuning this
    * can prevent OOMing in cases where there is a lot of historical churn in RT producers. The age of a given
    * producer's state is defined as:

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/DaVinciClientMemoryLimitTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/DaVinciClientMemoryLimitTest.java
@@ -73,7 +73,7 @@ import org.testng.annotations.Test;
 
 
 public class DaVinciClientMemoryLimitTest {
-  private static final int TEST_TIMEOUT = 120_000;
+  private static final int TEST_TIMEOUT = 180_000;
   private VeniceClusterWrapper venice;
   private D2Client d2Client;
 

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/DaVinciClientMemoryLimitTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/DaVinciClientMemoryLimitTest.java
@@ -9,6 +9,7 @@ import static com.linkedin.venice.ConfigKeys.D2_ZK_HOSTS_ADDRESS;
 import static com.linkedin.venice.ConfigKeys.DATA_BASE_PATH;
 import static com.linkedin.venice.ConfigKeys.DAVINCI_PUSH_STATUS_SCAN_NO_REPORT_RETRY_MAX_ATTEMPTS;
 import static com.linkedin.venice.ConfigKeys.INGESTION_MEMORY_LIMIT;
+import static com.linkedin.venice.ConfigKeys.INGESTION_MEMORY_LIMIT_STORE_LIST;
 import static com.linkedin.venice.ConfigKeys.PERSISTENCE_TYPE;
 import static com.linkedin.venice.ConfigKeys.PUSH_STATUS_STORE_ENABLED;
 import static com.linkedin.venice.ConfigKeys.SERVER_FORKED_PROCESS_JVM_ARGUMENT_LIST;
@@ -58,7 +59,11 @@ import com.linkedin.venice.utils.Utils;
 import com.linkedin.venice.utils.VeniceProperties;
 import io.tehuti.metrics.MetricsRepository;
 import java.io.File;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.Properties;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import org.apache.avro.Schema;
 import org.apache.samza.system.SystemProducer;
@@ -96,6 +101,12 @@ public class DaVinciClientMemoryLimitTest {
   }
 
   private VeniceProperties getDaVinciBackendConfig(boolean ingestionIsolationEnabledInDaVinci) {
+    return getDaVinciBackendConfig(ingestionIsolationEnabledInDaVinci, Collections.EMPTY_SET);
+  }
+
+  private VeniceProperties getDaVinciBackendConfig(
+      boolean ingestionIsolationEnabledInDaVinci,
+      Set<String> memoryLimitStores) {
     String baseDataPath = Utils.getTempDataDirectory().getAbsolutePath();
     PropertyBuilder venicePropertyBuilder = new PropertyBuilder();
     venicePropertyBuilder.put(CLIENT_USE_SYSTEM_STORE_REPOSITORY, true)
@@ -106,7 +117,8 @@ public class DaVinciClientMemoryLimitTest {
         .put(D2_ZK_HOSTS_ADDRESS, venice.getZk().getAddress())
         .put(CLUSTER_DISCOVERY_D2_SERVICE, VeniceRouterWrapper.CLUSTER_DISCOVERY_D2_SERVICE_NAME)
         .put(ROCKSDB_MEMTABLE_SIZE_IN_BYTES, "2MB")
-        .put(ROCKSDB_TOTAL_MEMTABLE_USAGE_CAP_IN_BYTES, "10MB");
+        .put(ROCKSDB_TOTAL_MEMTABLE_USAGE_CAP_IN_BYTES, "10MB")
+        .put(INGESTION_MEMORY_LIMIT_STORE_LIST, String.join(",", memoryLimitStores));
     if (ingestionIsolationEnabledInDaVinci) {
       venicePropertyBuilder.put(SERVER_INGESTION_MODE, IngestionMode.ISOLATED);
       venicePropertyBuilder.put(SERVER_INGESTION_ISOLATION_APPLICATION_PORT, TestUtils.getFreePort());
@@ -129,6 +141,8 @@ public class DaVinciClientMemoryLimitTest {
     String inputDirPath = "file://" + inputDir.getAbsolutePath();
     Schema recordSchema = writeSimpleAvroFileWithUserSchema(inputDir, true, 100, 100);
     Properties vpjProperties = defaultVPJProps(venice, inputDirPath, storeName);
+
+    String storeNameWithoutMemoryEnforcement = Utils.getUniqueString("store_without_memory_enforcement");
 
     try (ControllerClient controllerClient = createStoreForJob(venice.getClusterName(), recordSchema, vpjProperties);
         AvroGenericStoreClient client = ClientFactory.getAndStartGenericAvroClient(
@@ -158,7 +172,8 @@ public class DaVinciClientMemoryLimitTest {
       });
 
       // Spin up DaVinci client
-      VeniceProperties backendConfig = getDaVinciBackendConfig(ingestionIsolationEnabledInDaVinci);
+      VeniceProperties backendConfig =
+          getDaVinciBackendConfig(ingestionIsolationEnabledInDaVinci, new HashSet<>(Arrays.asList(storeName)));
       MetricsRepository metricsRepository = new MetricsRepository();
       try (CachingDaVinciClientFactory factory = new CachingDaVinciClientFactory(
           d2Client,
@@ -188,6 +203,32 @@ public class DaVinciClientMemoryLimitTest {
         VeniceException exception =
             expectThrows(VeniceException.class, () -> runVPJ(vpjPropertiesForV2, 2, controllerClient));
         assertTrue(exception.getMessage().contains("Found a failed partition replica in Da Vinci"));
+
+        // Run a bigger push against a non-enforced store should succeed
+        vpjProperties = defaultVPJProps(venice, inputDirPath, storeNameWithoutMemoryEnforcement);
+        try (ControllerClient controllerClient1 =
+            createStoreForJob(venice.getClusterName(), recordSchema, vpjProperties)) {
+          venice.createMetaSystemStore(storeNameWithoutMemoryEnforcement);
+          venice.createPushStatusSystemStore(storeNameWithoutMemoryEnforcement);
+
+          // Make sure DaVinci push status system store is enabled
+          storeResponse = controllerClient1.getStore(storeNameWithoutMemoryEnforcement);
+          assertFalse(storeResponse.isError(), "Store response receives an error: " + storeResponse.getError());
+          assertTrue(storeResponse.getStore().isDaVinciPushStatusStoreEnabled());
+
+          // Run a big VPJ push without DaVinci and it should succeed
+          runVPJ(vpjProperties, 1, controllerClient1);
+
+          // Spin up a DaVinci client for this store
+          DaVinciClient daVinciClientForStoreWithoutMemoryEnforcement = factory.getGenericAvroClient(
+              storeNameWithoutMemoryEnforcement,
+              new DaVinciConfig().setIsolated(true).setStorageClass(StorageClass.MEMORY_BACKED_BY_DISK));
+          daVinciClientForStoreWithoutMemoryEnforcement.start();
+          daVinciClientForStoreWithoutMemoryEnforcement.subscribeAll().get(30, TimeUnit.SECONDS);
+
+          // Another big push should succeed as well
+          runVPJ(vpjProperties, 2, controllerClient1);
+        }
       }
     }
   }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/server/VeniceServerTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/server/VeniceServerTest.java
@@ -22,6 +22,7 @@ import com.linkedin.venice.integration.utils.VeniceClusterCreateOptions;
 import com.linkedin.venice.integration.utils.VeniceClusterWrapper;
 import com.linkedin.venice.integration.utils.VeniceServerWrapper;
 import com.linkedin.venice.meta.QueryAction;
+import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.metadata.response.MetadataResponseRecord;
 import com.linkedin.venice.serialization.avro.AvroProtocolDefinition;
 import com.linkedin.venice.serializer.RecordDeserializer;
@@ -113,7 +114,7 @@ public class VeniceServerTest {
           .assertTrue(repository.getAllLocalStorageEngines().isEmpty(), "New node should not have any storage engine.");
 
       // Create a storage engine.
-      String storeName = Utils.getUniqueString("testCheckBeforeJoinCluster");
+      String storeName = Version.composeKafkaTopic(Utils.getUniqueString("testCheckBeforeJoinCluster"), 1);
       server.getVeniceServer()
           .getStorageService()
           .openStoreForNewPartition(


### PR DESCRIPTION
## Summary
For some DaVinci customers, they want to validate DaVinci memory limiter feature without affecting prod in canary instance, and currently, it is not possible since DaVinci memory limiter will apply globally.
To simplify the test, this code change introduces a new config: 
```
ingestion.memory.limit.store.list : default empty
```
When it is specified, only the stores configured will enforce memory limiter, and if it is not specified (default), all the stores in the same DaVinci instance will enforce memory limiter.

With this way, the customer can specify a test store to test DaVinci memory limiter feature, and when the bootstrapping of test store fails because of memory exhaust, only the push job to the test store will fail.

<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->



## How was this PR tested?
CI
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [x] Yes. Make sure to explain your proposed changes and call out the behavior change.