### PR TITLE
[all][tc] Create a new internal store client for schema reader

### DIFF
--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/AbstractAvroStoreClient.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/AbstractAvroStoreClient.java
@@ -721,7 +721,7 @@ public abstract class AbstractAvroStoreClient<K, V> extends InternalAvroStoreCli
   public void start() throws VeniceClientException {
     if (needSchemaReader) {
       this.schemaReader = new RouterBackedSchemaReader(
-          this,
+          this::getStoreClientForSchemaReader,
           getReaderSchema(),
           clientConfig.getPreferredSchemaFilter(),
           clientConfig.getSchemaRefreshPeriod(),
@@ -746,6 +746,13 @@ public abstract class AbstractAvroStoreClient<K, V> extends InternalAvroStoreCli
   protected Optional<Schema> getReaderSchema() {
     return Optional.empty();
   }
+
+  /**
+   * To avoid cycle dependency, we need to initialize another store client for schema reader.
+   * @return
+   * @throws VeniceClientException
+   */
+  protected abstract AbstractAvroStoreClient<K, V> getStoreClientForSchemaReader();
 
   public abstract RecordDeserializer<V> getDataRecordDeserializer(int schemaId) throws VeniceClientException;
 

--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/AvroGenericStoreClientImpl.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/AvroGenericStoreClientImpl.java
@@ -28,6 +28,17 @@ public class AvroGenericStoreClientImpl<K, V> extends AbstractAvroStoreClient<K,
     }
   }
 
+  /**
+   * To avoid cycle dependency, we need to initialize another store client for schema reader.
+   */
+  @Override
+  protected AbstractAvroStoreClient<K, V> getStoreClientForSchemaReader() {
+    return new AvroGenericStoreClientImpl<K, V>(
+        getTransportClient().getCopyIfNotUsableInCallback(),
+        false,
+        ClientConfig.defaultGenericClientConfig(getStoreName()));
+  }
+
   @Override
   public RecordDeserializer<V> getDataRecordDeserializer(int writerSchemaId) throws VeniceClientException {
     SchemaReader schemaReader = getSchemaReader();

--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/AvroSpecificStoreClientImpl.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/AvroSpecificStoreClientImpl.java
@@ -41,6 +41,19 @@ public class AvroSpecificStoreClientImpl<K, V extends SpecificRecord> extends Ab
     super.start();
   }
 
+  /**
+   * To avoid cycle dependency, we need to initialize another store client for schema reader.
+   * @return
+   * @throws VeniceClientException
+   */
+  @Override
+  protected AbstractAvroStoreClient<K, V> getStoreClientForSchemaReader() {
+    return new AvroSpecificStoreClientImpl<K, V>(
+        getTransportClient().getCopyIfNotUsableInCallback(),
+        false,
+        ClientConfig.defaultSpecificClientConfig(getStoreName(), valueClass));
+  }
+
   @Override
   public RecordDeserializer<V> getDataRecordDeserializer(int schemaId) throws VeniceClientException {
     SchemaReader schemaReader = getSchemaReader();

--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/VsonGenericStoreClientImpl.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/VsonGenericStoreClientImpl.java
@@ -22,6 +22,14 @@ public class VsonGenericStoreClientImpl<K, V> extends AvroGenericStoreClientImpl
   }
 
   @Override
+  protected AbstractAvroStoreClient<K, V> getStoreClientForSchemaReader() {
+    return new VsonGenericStoreClientImpl<K, V>(
+        getTransportClient().getCopyIfNotUsableInCallback(),
+        false,
+        ClientConfig.defaultVsonGenericClientConfig(getStoreName()));
+  }
+
+  @Override
   protected RecordDeserializer<V> getDeserializerFromFactory(Schema writer, Schema reader) {
     return SerializerDeserializerFactory.getVsonDeserializer(writer, reader);
   }

--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/transport/HttpTransportClient.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/transport/HttpTransportClient.java
@@ -177,6 +177,15 @@ public class HttpTransportClient extends TransportClient {
     }
   }
 
+  /**
+   * The same {@link CloseableHttpAsyncClient} could not be used to send out another request in its own callback function.
+   * @return
+   */
+  @Override
+  public TransportClient getCopyIfNotUsableInCallback() {
+    return new HttpTransportClient(routerUrl, maxConnectionsTotal, maxConnectionsPerRoute);
+  }
+
   private static class HttpTransportClientCallback extends TransportClientCallback
       implements FutureCallback<SimpleHttpResponse> {
     public HttpTransportClientCallback(CompletableFuture<TransportClientResponse> valueFuture) {

--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/transport/HttpsTransportClient.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/transport/HttpsTransportClient.java
@@ -7,6 +7,7 @@ import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient;
 
 public class HttpsTransportClient extends HttpTransportClient {
   private boolean requireHTTP2;
+  private SSLFactory sslFactory;
 
   public HttpsTransportClient(
       String routerUrl,
@@ -18,6 +19,7 @@ public class HttpsTransportClient extends HttpTransportClient {
     this.maxConnectionsTotal = maxConnectionsTotal;
     this.maxConnectionsPerRoute = maxConnectionsPerRoute;
     this.requireHTTP2 = requireHTTP2;
+    this.sslFactory = sslFactory;
   }
 
   public HttpsTransportClient(String routerUrl, CloseableHttpAsyncClient client) {
@@ -29,5 +31,14 @@ public class HttpsTransportClient extends HttpTransportClient {
 
   public boolean isRequireHTTP2() {
     return requireHTTP2;
+  }
+
+  /**
+   * The same {@link CloseableHttpAsyncClient} could not be used to send out another request in its own callback function.
+   * @return
+   */
+  @Override
+  public TransportClient getCopyIfNotUsableInCallback() {
+    return new HttpsTransportClient(routerUrl, maxConnectionsTotal, maxConnectionsPerRoute, requireHTTP2, sslFactory);
   }
 }

--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/transport/TransportClient.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/transport/TransportClient.java
@@ -34,4 +34,14 @@ public abstract class TransportClient implements Closeable {
       byte[] requestBody,
       TransportClientStreamingCallback callback,
       int keyCount);
+
+  /**
+   * If the internal client could not be used by its callback function,
+   * implementation of this function should return a new copy.
+   * The default implementation is to return itself.
+   * @return
+   */
+  public TransportClient getCopyIfNotUsableInCallback() {
+    return this;
+  }
 }

--- a/clients/venice-thin-client/src/test/java/com/linkedin/venice/client/store/AbstractAvroStoreClientTest.java
+++ b/clients/venice-thin-client/src/test/java/com/linkedin/venice/client/store/AbstractAvroStoreClientTest.java
@@ -1,8 +1,7 @@
 package com.linkedin.venice.client.store;
 
-import static com.linkedin.venice.client.schema.RouterBackedSchemaReader.*;
-import static com.linkedin.venice.client.store.AbstractAvroStoreClient.*;
-import static com.linkedin.venice.client.store.D2ServiceDiscovery.*;
+import static com.linkedin.venice.client.schema.RouterBackedSchemaReader.TYPE_KEY_SCHEMA;
+import static com.linkedin.venice.client.store.AbstractAvroStoreClient.TYPE_STORAGE;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 
@@ -50,6 +49,8 @@ import org.testng.annotations.Test;
 
 public class AbstractAvroStoreClientTest {
   private static class SimpleStoreClient<K, V> extends AbstractAvroStoreClient<K, V> {
+    private final TransportClient transportClient;
+    private final String storeName;
     private final boolean overrideGetSchemaReader;
 
     public SimpleStoreClient(
@@ -70,7 +71,18 @@ public class AbstractAvroStoreClientTest {
           transportClient,
           needSchemaReader,
           ClientConfig.defaultGenericClientConfig(storeName).setDeserializationExecutor(deserializationExecutor));
+      this.transportClient = transportClient;
+      this.storeName = storeName;
       this.overrideGetSchemaReader = overrideGetSchemaReader;
+    }
+
+    @Override
+    protected AbstractAvroStoreClient<K, V> getStoreClientForSchemaReader() {
+      return new SimpleStoreClient<>(
+          transportClient,
+          storeName,
+          false,
+          AbstractAvroStoreClient.getDefaultDeserializationExecutor());
     }
 
     @Override

--- a/clients/venice-thin-client/src/test/java/com/linkedin/venice/client/store/StatTrackingStoreClientTest.java
+++ b/clients/venice-thin-client/src/test/java/com/linkedin/venice/client/store/StatTrackingStoreClientTest.java
@@ -67,6 +67,11 @@ public class StatTrackingStoreClientTest {
     }
 
     @Override
+    protected AbstractAvroStoreClient<K, V> getStoreClientForSchemaReader() {
+      return this;
+    }
+
+    @Override
     public RecordDeserializer<V> getDataRecordDeserializer(int schemaId) throws VeniceClientException {
       return null;
     }

--- a/clients/venice-thin-client/src/test/java/com/linkedin/venice/client/store/TestAvroStoreClient.java
+++ b/clients/venice-thin-client/src/test/java/com/linkedin/venice/client/store/TestAvroStoreClient.java
@@ -46,6 +46,7 @@ public class TestAvroStoreClient {
   @BeforeClass
   public void setUp() throws VeniceClientException, IOException {
     mockTransportClient = mock(TransportClient.class);
+    doReturn(mockTransportClient).when(mockTransportClient).getCopyIfNotUsableInCallback();
 
     byte[] schemaResponseInBytes = StoreClientTestUtils.constructSchemaResponseInBytes(STORE_NAME, 1, KEY_SCHEMA_STR);
     setupSchemaResponse(schemaResponseInBytes, RouterBackedSchemaReader.TYPE_KEY_SCHEMA + "/" + STORE_NAME);


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Create a new internal store client for schema reader
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
This change reverts a bunch of changes that were made in PR #472.
There was a deadlock in production that had the following stacktraces in the threaddump
Thread 1:
```
"veniceClient.WarmUpExecutorService-22-4":
	at com.linkedin.venice.client.store.AbstractAvroStoreClient.discoverD2Service(AbstractAvroStoreClient.java:352)
	- waiting to lock <0x00007f1f2e518070> (a com.linkedin.venice.client.store.VsonGenericStoreClientImpl)
	at com.linkedin.venice.client.store.AbstractAvroStoreClient.getRaw(AbstractAvroStoreClient.java:459)
	at com.linkedin.venice.client.store.InternalAvroStoreClient.getRaw(InternalAvroStoreClient.java:24)
	at com.linkedin.venice.client.schema.RouterBackedSchemaReader.executeRouterRequest(RouterBackedSchemaReader.java:349)
	at com.linkedin.venice.client.schema.RouterBackedSchemaReader.fetchSingleSchemaResponse(RouterBackedSchemaReader.java:299)
	at com.linkedin.venice.client.schema.RouterBackedSchemaReader.fetchSingleSchema(RouterBackedSchemaReader.java:281)
	at com.linkedin.venice.client.schema.RouterBackedSchemaReader.fetchKeySchema(RouterBackedSchemaReader.java:375)
	at com.linkedin.venice.client.schema.RouterBackedSchemaReader.getKeySchema(RouterBackedSchemaReader.java:161)
	- locked <0x00007f1f2e5183e0> (a com.linkedin.venice.client.schema.RouterBackedSchemaReader)
	at com.linkedin.venice.client.store.AbstractAvroStoreClient.getKeySchema(AbstractAvroStoreClient.java:799)
	at com.linkedin.venice.client.store.DelegatingStoreClient.getKeySchema(DelegatingStoreClient.java:102)
	...
```

Thread 2:
```
"ForkJoinPool.commonPool-worker-15":
	at com.linkedin.venice.client.schema.RouterBackedSchemaReader.getKeySchema(RouterBackedSchemaReader.java:158)
	- waiting to lock <0x00007f1f2e5183e0> (a com.linkedin.venice.client.schema.RouterBackedSchemaReader)
	at com.linkedin.venice.client.store.AbstractAvroStoreClient.getKeySchema(AbstractAvroStoreClient.java:799)
	at com.linkedin.venice.client.store.VsonGenericStoreClientImpl.initSerializer(VsonGenericStoreClientImpl.java:33)
	at com.linkedin.venice.client.store.AbstractAvroStoreClient.init(AbstractAvroStoreClient.java:345)
	at com.linkedin.venice.client.store.AbstractAvroStoreClient.getKeySerializerWithRetry(AbstractAvroStoreClient.java:321)
	- locked <0x00007f1f2e518070> (a com.linkedin.venice.client.store.VsonGenericStoreClientImpl)
	at com.linkedin.venice.client.store.AbstractAvroStoreClient.getKeySerializerWithRetryWithLongInterval(AbstractAvroStoreClient.java:294)
	at com.linkedin.venice.client.store.AbstractAvroStoreClient$$Lambda$1276/0x00007efacfec7458.run(Unknown Source)
	at java.util.concurrent.CompletableFuture$AsyncRun.run(java.base@11.0.13/CompletableFuture.java:1736)
	at java.util.concurrent.CompletableFuture$AsyncRun.exec(java.base@11.0.13/CompletableFuture.java:1728)
	at java.util.concurrent.ForkJoinTask.doExec(java.base@11.0.13/ForkJoinTask.java:290)
	at java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(java.base@11.0.13/ForkJoinPool.java:1020)
	at java.util.concurrent.ForkJoinPool.scan(java.base@11.0.13/ForkJoinPool.java:1656)
	at java.util.concurrent.ForkJoinPool.runWorker(java.base@11.0.13/ForkJoinPool.java:1594)
	at java.util.concurrent.ForkJoinWorkerThread.run(java.base@11.0.13/ForkJoinWorkerThread.java:183)
```

So, the users used the `getKeySchema` method on the client when initial client warm up failed and an async warm up was executing. 

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
GH CI

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.