### PR TITLE
[server] Make store ingestion task idle counter configurable

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
@@ -67,6 +67,7 @@ import static com.linkedin.venice.ConfigKeys.SERVER_INGESTION_CHECKPOINT_DURING_
 import static com.linkedin.venice.ConfigKeys.SERVER_INGESTION_ISOLATION_APPLICATION_PORT;
 import static com.linkedin.venice.ConfigKeys.SERVER_INGESTION_ISOLATION_SERVICE_PORT;
 import static com.linkedin.venice.ConfigKeys.SERVER_INGESTION_MODE;
+import static com.linkedin.venice.ConfigKeys.SERVER_INGESTION_TASK_MAX_IDLE_COUNT;
 import static com.linkedin.venice.ConfigKeys.SERVER_KAFKA_CONSUMER_OFFSET_COLLECTION_ENABLED;
 import static com.linkedin.venice.ConfigKeys.SERVER_KAFKA_MAX_POLL_RECORDS;
 import static com.linkedin.venice.ConfigKeys.SERVER_KAFKA_POLL_RETRY_BACKOFF_MS;
@@ -432,6 +433,8 @@ public class VeniceServerConfig extends VeniceClusterConfig {
   private final PubSubClientsFactory pubSubClientsFactory;
   private final String routerPrincipalName;
 
+  private final int ingestionTaskMaxIdleCount;
+
   public VeniceServerConfig(VeniceProperties serverProperties) throws ConfigurationException {
     this(serverProperties, Collections.emptyMap());
   }
@@ -711,6 +714,7 @@ public class VeniceServerConfig extends VeniceClusterConfig {
       throw new VeniceException(e);
     }
     routerPrincipalName = serverProperties.getString(ROUTER_PRINCIPAL_NAME, "CN=venice-router");
+    ingestionTaskMaxIdleCount = serverProperties.getInt(SERVER_INGESTION_TASK_MAX_IDLE_COUNT, 10000);
   }
 
   long extractIngestionMemoryLimit(
@@ -1243,5 +1247,9 @@ public class VeniceServerConfig extends VeniceClusterConfig {
 
   public String getRouterPrincipalName() {
     return routerPrincipalName;
+  }
+
+  public int getIngestionTaskMaxIdleCount() {
+    return ingestionTaskMaxIdleCount;
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionService.java
@@ -622,10 +622,6 @@ public class KafkaStoreIngestionService extends AbstractVeniceService implements
       Optional<LeaderFollowerStateType> leaderState) {
 
     final String topic = veniceStore.getStoreVersionName();
-    if (!isRunning()) {
-      LOGGER.info("Ignore start consumption for topic: {}, partition: {} as service is stopping.", topic, partitionId);
-      return;
-    }
 
     try (AutoCloseableLock ignore = topicLockManager.getLockForResource(topic)) {
       StoreIngestionTask storeIngestionTask = topicNameToIngestionTaskMap.get(topic);
@@ -635,6 +631,13 @@ public class KafkaStoreIngestionService extends AbstractVeniceService implements
         storeIngestionTask = createStoreIngestionTask(veniceStore, partitionId);
         topicNameToIngestionTaskMap.put(topic, storeIngestionTask);
         versionedIngestionStats.setIngestionTask(topic, storeIngestionTask);
+        if (!isRunning()) {
+          LOGGER.info(
+              "Ignore start consumption for topic: {}, partition: {} as service is stopping.",
+              topic,
+              partitionId);
+          return;
+        }
         ingestionExecutorService.submit(storeIngestionTask);
       }
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -116,7 +116,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.BooleanSupplier;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -223,7 +222,6 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
   protected final SparseConcurrentList<Object> availableSchemaIds = new SparseConcurrentList<>();
   protected final SparseConcurrentList<Object> deserializedSchemaIds = new SparseConcurrentList<>();
   protected int idleCounter = 0;
-  private final ReentrantLock ingestionTaskActiveCheckLock = new ReentrantLock();
 
   private final StorageUtilizationManager storageUtilizationManager;
 

--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -385,6 +385,8 @@ public class ConfigKeys {
   public static final String UNSORTED_INPUT_DRAINER_SIZE = "unsorted.input.drainer.size";
   public static final String STORE_WRITER_BUFFER_AFTER_LEADER_LOGIC_ENABLED =
       "store.writer.buffer.after.leader.logic.enabled";
+
+  public static final String SERVER_INGESTION_TASK_MAX_IDLE_COUNT = "server.ingestion.task.max.idle.count";
   public static final String STORE_WRITER_BUFFER_MEMORY_CAPACITY = "store.writer.buffer.memory.capacity";
   public static final String STORE_WRITER_BUFFER_NOTIFY_DELTA = "store.writer.buffer.notify.delta";
   public static final String SERVER_REST_SERVICE_STORAGE_THREAD_NUM = "server.rest.service.storage.thread.num";


### PR DESCRIPTION
This PR makes change to resolve race condition between:
(1) new partition ingestion
(2) store ingestion task idle timeout

This PR makes max idle counter configurable and set the default from 100 to 10000, so total timeout would be 1s -> 100s. This should make the race condition very very unlikely to happen. 
Also, to make the logic reliable, this PR makes a change that makes sure the retrieved SIT for startConsumption() is **active** SIT. It will try to reset the idle counter with synchronization guarantee.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
New unit test

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.