### PR TITLE
[server][admin-tool] Improve Server Ingestion State Dump

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/listener/response/AdminResponse.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/listener/response/AdminResponse.java
@@ -66,7 +66,7 @@ public class AdminResponse {
     if (storeVersionState.compressionDictionary != null && storeVersionState.compressionDictionary.hasRemaining()) {
       // We don't want to dump compression dictionary since it is not readable
       updatedState = new StoreVersionState();
-      for (Schema.Field field: StoreVersionState.SCHEMA$.getFields()) {
+      for (Schema.Field field: StoreVersionState.getClassSchema().getFields()) {
         if (field.name().equals("compressionDictionary")) {
           updatedState.put(field.pos(), IGNORED_COMPRESSION_DICT);
         } else {

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/listener/response/AdminResponseTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/listener/response/AdminResponseTest.java
@@ -1,0 +1,34 @@
+package com.linkedin.davinci.listener.response;
+
+import static com.linkedin.davinci.listener.response.AdminResponse.IGNORED_COMPRESSION_DICT;
+
+import com.linkedin.davinci.replication.BatchConflictResolutionPolicy;
+import com.linkedin.venice.compression.CompressionStrategy;
+import com.linkedin.venice.kafka.protocol.state.StoreVersionState;
+import com.linkedin.venice.serialization.avro.AvroProtocolDefinition;
+import java.nio.ByteBuffer;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class AdminResponseTest {
+  @Test
+  public void testAddStoreVersionStateToSuppressDict() {
+    StoreVersionState storeVersionState = new StoreVersionState();
+    storeVersionState.compressionDictionary = ByteBuffer.wrap("big_dict".getBytes());
+    storeVersionState.sorted = true;
+    storeVersionState.chunked = false;
+    storeVersionState.compressionStrategy = CompressionStrategy.ZSTD_WITH_DICT.ordinal();
+    storeVersionState.batchConflictResolutionPolicy = BatchConflictResolutionPolicy.BATCH_WRITE_LOSES.getValue();
+    storeVersionState.startOfPushTimestamp = System.currentTimeMillis();
+    storeVersionState.endOfPushTimestamp = System.currentTimeMillis();
+
+    StoreVersionState updatedState = AdminResponse.suppressCompressionDict(storeVersionState);
+
+    Assert.assertEquals(updatedState.compressionDictionary.array(), IGNORED_COMPRESSION_DICT.array());
+
+    Assert.assertEquals(
+        AdminResponse.getResponseSchemaIdHeader(),
+        AvroProtocolDefinition.SERVER_ADMIN_RESPONSE.getCurrentProtocolVersion());
+  }
+}

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/Arg.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/Arg.java
@@ -233,7 +233,7 @@ public enum Arg {
   NON_INTERACTIVE("non-interactive", "nita", false, "non-interactive mode"),
   MIN_COMPACTION_LAG_SECONDS(
       "min-compaction-lag-seconds", "mcls", true, "Min compaction lag seconds for version topic of hybrid stores"
-  ),
+  ), PARTITION("partition", "p", true, "Partition Id"),
   INTERVAL(
       "interval", "itv", true,
       "monitor data recovery progress at seconds close to the number specified by the interval parameter until tasks are finished"

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/Command.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/Command.java
@@ -66,6 +66,7 @@ import static com.linkedin.venice.Arg.NON_INTERACTIVE;
 import static com.linkedin.venice.Arg.NUM_VERSIONS_TO_PRESERVE;
 import static com.linkedin.venice.Arg.OFFSET;
 import static com.linkedin.venice.Arg.OWNER;
+import static com.linkedin.venice.Arg.PARTITION;
 import static com.linkedin.venice.Arg.PARTITIONER_CLASS;
 import static com.linkedin.venice.Arg.PARTITIONER_PARAMS;
 import static com.linkedin.venice.Arg.PARTITION_COUNT;
@@ -468,6 +469,11 @@ public enum Command {
       "request-based-metadata",
       "Get the store's metadata using request based metadata endpoint via a transport client and a server URL",
       new Arg[] { URL, SERVER_URL, STORE }
+  ),
+  DUMP_INGESTION_STATE(
+      "dump-ingestion-state",
+      "Dump the real-time ingestion state for a certain store version in a certain storage node",
+      new Arg[] { SERVER_URL, STORE, VERSION }, new Arg[] { PARTITION }
   );
 
   private final String commandName;

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/utils/SslUtils.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/utils/SslUtils.java
@@ -238,12 +238,13 @@ public class SslUtils {
    * Build an instance of {@link Properties} with a file path to SSL config file.
    *
    * An example of SSL config file:
-   * ssl.enabled=true
-   * keystore.type=PKCS12
-   * keystore.password=local_password
-   * keystore.path=./identity.p12
-   * truststore.password=local_password
-   * truststore.path=/etc/riddler/cacerts
+   * ssl.enabled:true
+   * ssl.key.password:local_password
+   * ssl.keystore.location:./identity.p12
+   * ssl.keystore.password:local_password
+   * ssl.keystore.type:pkcs12
+   * ssl.truststore.location:./cacerts
+   * ssl.truststore.password:local_password
    */
   public static Properties loadSSLConfig(String configFilePath) throws IOException {
     Properties props = new Properties();

--- a/internal/venice-client-common/src/main/java/org/apache/avro/io/ByteBufferToHexFormatJsonEncoder.java
+++ b/internal/venice-client-common/src/main/java/org/apache/avro/io/ByteBufferToHexFormatJsonEncoder.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.charset.CharsetEncoder;
 import java.nio.charset.StandardCharsets;
+import org.apache.avro.AvroTypeException;
 import org.apache.avro.Schema;
 import org.apache.avro.io.parsing.Symbol;
 
@@ -36,6 +37,19 @@ public class ByteBufferToHexFormatJsonEncoder extends JsonEncoder {
      */
     parser.pushSymbol(Symbol.STRING);
     writeString(ByteUtils.toHexString(bytes, start, len));
+  }
+
+  @Override
+  public void writeFixed(byte[] bytes, int start, int len) throws IOException {
+    parser.advance(Symbol.FIXED);
+    Symbol.IntCheckAction top = (Symbol.IntCheckAction) parser.popSymbol();
+    if (len != top.size) {
+      throw new AvroTypeException(
+          "Incorrect length for fixed binary: expected " + top.size + " but received " + len + " bytes.");
+    }
+    // Write human-readable string instead
+    parser.pushSymbol(Symbol.STRING);
+    writeString((ByteUtils.toHexString(bytes, start, len)));
   }
 
   /**

--- a/internal/venice-client-common/src/test/java/org/apache/avro/io/ByteBufferToHexFormatJsonEncoderTest.java
+++ b/internal/venice-client-common/src/test/java/org/apache/avro/io/ByteBufferToHexFormatJsonEncoderTest.java
@@ -1,0 +1,20 @@
+package org.apache.avro.io;
+
+import com.linkedin.venice.kafka.protocol.GUID;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class ByteBufferToHexFormatJsonEncoderTest {
+  @Test
+  public void testWriteFixed() throws IOException {
+    ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+    ByteBufferToHexFormatJsonEncoder encoder = new ByteBufferToHexFormatJsonEncoder(GUID.SCHEMA$, outputStream);
+    GUID guid = new GUID(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 });
+    encoder.writeFixed(guid.bytes());
+    encoder.flush();
+    Assert.assertEquals(new String(outputStream.toByteArray()), "\"0102030405060708090a0b0c0d0e0f10\"");
+  }
+}

--- a/internal/venice-common/src/main/java/com/linkedin/venice/serialization/avro/AvroProtocolDefinition.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/serialization/avro/AvroProtocolDefinition.java
@@ -154,9 +154,9 @@ public enum AvroProtocolDefinition {
   PARTICIPANT_MESSAGE_SYSTEM_STORE_VALUE(1, ParticipantMessageValue.class),
 
   /**
-   * Response record for admin request v1.
+   * Response record for admin request.
    */
-  SERVER_ADMIN_RESPONSE_V1(1, AdminResponseRecord.class),
+  SERVER_ADMIN_RESPONSE(2, AdminResponseRecord.class),
 
   /**
    * Response record for metadata fetch request.
@@ -273,7 +273,10 @@ public enum AvroProtocolDefinition {
   }
 
   public <T extends SpecificRecord> InternalAvroSpecificSerializer<T> getSerializer() {
-    return new InternalAvroSpecificSerializer<>(this);
+    if (magicByte.isPresent() || protocolVersionStoredInHeader) {
+      return new InternalAvroSpecificSerializer<>(this);
+    }
+    return new InternalAvroSpecificSerializer<>(this, 0);
   }
 
   public int getCurrentProtocolVersion() {

--- a/internal/venice-common/src/test/java/com/linkedin/venice/acl/StoreAclHandlerTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/acl/StoreAclHandlerTest.java
@@ -180,7 +180,7 @@ public class StoreAclHandlerTest {
     if (isMetadata[0]) {
       when(req.uri()).thenReturn("/metadata/storename/random");
     } else {
-      when(req.uri()).thenReturn("/random/storename/random");
+      when(req.uri()).thenReturn("/storage/storename/random");
     }
   }
 

--- a/internal/venice-common/src/test/java/com/linkedin/venice/serialization/avro/AvroProtocolDefinitionTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/serialization/avro/AvroProtocolDefinitionTest.java
@@ -1,0 +1,16 @@
+package com.linkedin.venice.serialization.avro;
+
+import static com.linkedin.venice.serialization.avro.AvroProtocolDefinition.KAFKA_MESSAGE_ENVELOPE;
+import static com.linkedin.venice.serialization.avro.AvroProtocolDefinition.SERVER_ADMIN_RESPONSE;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class AvroProtocolDefinitionTest {
+  @Test
+  public void testGetSerializer() {
+    Assert.assertNotNull(KAFKA_MESSAGE_ENVELOPE.getSerializer());
+    Assert.assertNotNull(SERVER_ADMIN_RESPONSE.getSerializer());
+  }
+}

--- a/services/venice-server/src/test/java/com/linkedin/venice/listener/StorageReadRequestHandlerTest.java
+++ b/services/venice-server/src/test/java/com/linkedin/venice/listener/StorageReadRequestHandlerTest.java
@@ -382,7 +382,7 @@ public class StorageReadRequestHandlerTest {
         expectedPartitionId);
     Assert.assertEquals(
         adminResponse.getResponseSchemaIdHeader(),
-        AvroProtocolDefinition.SERVER_ADMIN_RESPONSE_V1.getCurrentProtocolVersion());
+        AvroProtocolDefinition.SERVER_ADMIN_RESPONSE.getCurrentProtocolVersion());
   }
 
   @Test


### PR DESCRIPTION
This code change adds a new command to dump ingestion state, also Venice Server will skip the ACL check for admin request endpoint since there is no PII data.
In the meantime, this code change will skip compression dict in the response since it is not readable and string-format the `Fixed` type.

<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->


<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
CI

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.