### PR TITLE
[doc] Disable markdowns from "javadoc/legal" dir from showing up on the website

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -4,3 +4,7 @@ nav_external_links:
   - title: Javadoc
     url: ./javadoc/index.html
     hide_icon: false
+
+exclude:
+  # javadoc/legal has some markdowns that get picked up by jekyll/just-the-docs
+  - javadoc/legal


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Disable markdowns from "javadoc/legal" dir from showing up on the website
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
Tested on fork: https://nisargthakkar.github.io/venice/

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.