### PR TITLE
[vpj] Send pushjob details during post-target pushjob

### DIFF
--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
@@ -1294,6 +1294,7 @@ public class VenicePushJob implements AutoCloseable {
           RegionUtils.composeRegionList(candidateRegions),
           false);
     }
+    sendPushJobDetailsToController();
   }
 
   private PushJobHeartbeatSender createPushJobHeartbeatSender(final boolean sslEnabled) {

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestPushJobWithNativeReplication.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestPushJobWithNativeReplication.java
@@ -1063,7 +1063,6 @@ public class TestPushJobWithNativeReplication {
                   .values()) {
                 Assert.assertEquals(version, 2);
               }
-              validatePushJobDetails(clusterName, storeName);
             });
           }
         });

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestPushJobWithNativeReplication.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestPushJobWithNativeReplication.java
@@ -1003,8 +1003,8 @@ public class TestPushJobWithNativeReplication {
         updateStoreQueryParams -> updateStoreQueryParams.setPartitionCount(1),
         100,
         (parentControllerClient, clusterName, storeName, props, inputDir) -> {
-          props.put(TARGETED_REGION_PUSH_ENABLED, true);
-          props.put(POST_VALIDATION_CONSUMPTION_ENABLED, true);
+          props.put(TARGETED_REGION_PUSH_ENABLED, false);
+          props.put(POST_VALIDATION_CONSUMPTION_ENABLED, false);
           try (VenicePushJob job = new VenicePushJob("Test push job 1", props)) {
             job.run(); // the job should succeed
 

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestPushJobWithNativeReplication.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestPushJobWithNativeReplication.java
@@ -1170,12 +1170,17 @@ public class TestPushJobWithNativeReplication {
       key.setStoreName(storeName);
       key.setVersionNumber(1);
       GenericRecord value = (GenericRecord) client.get(key).get();
-      Map<Utf8, List<PushJobDetailsStatusTuple>> map = (HashMap) value.get("coloStatus");
+      HashMap<Utf8, List<PushJobDetailsStatusTuple>> map =
+          (HashMap<Utf8, List<PushJobDetailsStatusTuple>>) value.get("coloStatus");
       Assert.assertEquals(map.size(), 2);
       List<PushJobDetailsStatusTuple> status = map.get(new Utf8("dc-0"));
-      Assert.assertEquals(((GenericRecord) status.get(1)).get("status"), PushJobDetailsStatus.COMPLETED.getValue());
+      Assert.assertEquals(
+          ((GenericRecord) status.get(status.size() - 1)).get("status"),
+          PushJobDetailsStatus.COMPLETED.getValue());
       status = map.get(new Utf8("dc-1"));
-      Assert.assertEquals(((GenericRecord) status.get(1)).get("status"), PushJobDetailsStatus.COMPLETED.getValue());
+      Assert.assertEquals(
+          ((GenericRecord) status.get(status.size() - 1)).get("status"),
+          PushJobDetailsStatus.COMPLETED.getValue());
 
     }
   }


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

##  Send pushjob details during post-target pushjob
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

The push job details are generated and send through controller for various offline tracking of pushjob health. During post canary colo job, it missed to send out pushjob details to the controller, thus it would appear in pushjob detail store that other colo did not finish the pushjob. This PR fixes that issue.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

Integration test.

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.