### PR TITLE
[controller] Catch HelixException in deleteHelixResource

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -70,7 +70,7 @@ ext.libraries = [
     failsafe: 'net.jodah:failsafe:2.4.0',
     fastUtil: 'it.unimi.dsi:fastutil:8.3.0',
     hadoopCommon: 'org.apache.hadoop:hadoop-common:2.3.0',
-    helix: 'org.apache.helix:helix-core:1.3.0',
+    helix: 'org.apache.helix:helix-core:1.1.0',
     httpAsyncClient: 'org.apache.httpcomponents:httpasyncclient:4.1.2',
     httpClient5: 'org.apache.httpcomponents.client5:httpclient5:5.2.1',
     httpCore5: 'org.apache.httpcomponents.core5:httpcore5:5.2.2',

--- a/build.gradle
+++ b/build.gradle
@@ -70,7 +70,7 @@ ext.libraries = [
     failsafe: 'net.jodah:failsafe:2.4.0',
     fastUtil: 'it.unimi.dsi:fastutil:8.3.0',
     hadoopCommon: 'org.apache.hadoop:hadoop-common:2.3.0',
-    helix: 'org.apache.helix:helix-core:1.0.4',
+    helix: 'org.apache.helix:helix-core:1.3.0',
     httpAsyncClient: 'org.apache.httpcomponents:httpasyncclient:4.1.2',
     httpClient5: 'org.apache.httpcomponents.client5:httpclient5:5.2.1',
     httpCore5: 'org.apache.httpcomponents.core5:httpcore5:5.2.2',

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -196,6 +196,7 @@ import com.linkedin.venice.utils.KafkaSSLUtils;
 import com.linkedin.venice.utils.LatencyUtils;
 import com.linkedin.venice.utils.Pair;
 import com.linkedin.venice.utils.PartitionUtils;
+import com.linkedin.venice.utils.RedundantExceptionFilter;
 import com.linkedin.venice.utils.RegionUtils;
 import com.linkedin.venice.utils.SslUtils;
 import com.linkedin.venice.utils.Time;
@@ -294,6 +295,9 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
       ExecutionStatus.COMPLETED,
       ExecutionStatus.END_OF_INCREMENTAL_PUSH_RECEIVED,
       ExecutionStatus.ARCHIVED);
+
+  private static final RedundantExceptionFilter EXCEPTION_FILTER =
+      RedundantExceptionFilter.getRedundantExceptionFilter();
 
   private static final Logger LOGGER = LogManager.getLogger(VeniceHelixAdmin.class);
   private static final int RECORD_COUNT = 10;
@@ -4765,11 +4769,10 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
       try {
         disabledPartitions = getHelixAdminClient().getDisabledPartitionsMap(clusterName, instance);
       } catch (HelixException helixException) {
-        LOGGER.warn(
-            "Failed to get disabled partition map in cluster {} for host {} ",
-            clusterName,
-            instance,
-            helixException);
+        String msg = "Failed to get disabled partition map in cluster " + clusterName + " for host " + instance;
+        if (!EXCEPTION_FILTER.isRedundantException(msg)) {
+          LOGGER.warn(msg, helixException);
+        }
         continue;
       }
       for (Map.Entry<String, List<String>> entry: disabledPartitions.entrySet()) {


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

##  Catch HelixException in deleteHelixResource

We see some host contained in  `/CONFIG/PARTICIPANT` path but not in `/INSTANCE` of a cluster .  If queried a list of instances using `ZKHelixAdmin::getInstancesInCluster` and called `getDisabledPartitionsMap` which throws HelixException. This PR tries to skip such exception to continue cleaning the helix resources. Also bumps the Helix dependency to 1.1.0 which would resolve the exception log in zk node deletion code path.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

GHCI

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.