### PR TITLE
[thin-client][producer] Handle complex types in query tool and producer tool

### DIFF
--- a/clients/venice-producer/src/main/java/com/linkedin/venice/producer/online/ProducerTool.java
+++ b/clients/venice-producer/src/main/java/com/linkedin/venice/producer/online/ProducerTool.java
@@ -214,16 +214,22 @@ public class ProducerTool {
       case INT:
         data = Integer.parseInt(dataString);
         break;
+      case LONG:
+        data = Long.parseLong(dataString);
+        break;
+      case FLOAT:
+        data = Float.parseFloat(dataString);
+        break;
       case DOUBLE:
         data = Double.parseDouble(dataString);
         break;
-      case LONG:
-        data = Long.parseLong(dataString);
+      case BOOLEAN:
+        data = Boolean.parseBoolean(dataString);
         break;
       case STRING:
         data = dataString;
         break;
-      case RECORD:
+      default:
         try {
           data = new GenericDatumReader<>(dataSchema, dataSchema).read(
               null,
@@ -232,8 +238,6 @@ public class ProducerTool {
           throw new VeniceException("Invalid input:" + dataString, e);
         }
         break;
-      default:
-        throw new VeniceException("Cannot handle type, found schema: " + dataSchema);
     }
     return data;
   }

--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/QueryTool.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/QueryTool.java
@@ -105,16 +105,22 @@ public class QueryTool {
       case INT:
         key = Integer.parseInt(keyString);
         break;
+      case LONG:
+        key = Long.parseLong(keyString);
+        break;
+      case FLOAT:
+        key = Float.parseFloat(keyString);
+        break;
       case DOUBLE:
         key = Double.parseDouble(keyString);
         break;
-      case LONG:
-        key = Long.parseLong(keyString);
+      case BOOLEAN:
+        key = Boolean.parseBoolean(keyString);
         break;
       case STRING:
         key = keyString;
         break;
-      case RECORD:
+      default:
         try {
           key = new GenericDatumReader<>(keySchema, keySchema).read(
               null,
@@ -123,8 +129,6 @@ public class QueryTool {
           throw new VeniceException("Invalid input key:" + keyString, e);
         }
         break;
-      default:
-        throw new VeniceException("Cannot handle key type, found key schema: " + keySchema);
     }
     return key;
   }


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Handle complex types producer tool and query tool
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

The CLI tools to read (`QueryTool`) and write (`ProducerTool`) data to Venice do not handle complex types currently. This commit adds the support to read and write data where the store has complex data types in the schema.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
Tried locally for a user store

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.