### PR TITLE
[server] Code change for server connection count metrics

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
@@ -710,7 +710,7 @@ public class VeniceServerConfig extends VeniceClusterConfig {
       LOGGER.error("Failed to create an instance of pub sub clients factory", e);
       throw new VeniceException(e);
     }
-    routerPrincipalName = serverProperties.getString(ROUTER_PRINCIPAL_NAME, "venice-router");
+    routerPrincipalName = serverProperties.getString(ROUTER_PRINCIPAL_NAME, "CN=venice-router");
   }
 
   long extractIngestionMemoryLimit(

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
@@ -35,6 +35,7 @@ import static com.linkedin.venice.ConfigKeys.PARTICIPANT_MESSAGE_CONSUMPTION_DEL
 import static com.linkedin.venice.ConfigKeys.PUB_SUB_ADMIN_ADAPTER_FACTORY_CLASS;
 import static com.linkedin.venice.ConfigKeys.PUB_SUB_CONSUMER_ADAPTER_FACTORY_CLASS;
 import static com.linkedin.venice.ConfigKeys.PUB_SUB_PRODUCER_ADAPTER_FACTORY_CLASS;
+import static com.linkedin.venice.ConfigKeys.ROUTER_PRINCIPAL_NAME;
 import static com.linkedin.venice.ConfigKeys.SERVER_BLOCKING_QUEUE_TYPE;
 import static com.linkedin.venice.ConfigKeys.SERVER_COMPUTE_FAST_AVRO_ENABLED;
 import static com.linkedin.venice.ConfigKeys.SERVER_COMPUTE_QUEUE_CAPACITY;
@@ -429,6 +430,7 @@ public class VeniceServerConfig extends VeniceClusterConfig {
 
   private final long divProducerStateMaxAgeMs;
   private final PubSubClientsFactory pubSubClientsFactory;
+  private final String routerPrincipalName;
 
   public VeniceServerConfig(VeniceProperties serverProperties) throws ConfigurationException {
     this(serverProperties, Collections.emptyMap());
@@ -708,6 +710,7 @@ public class VeniceServerConfig extends VeniceClusterConfig {
       LOGGER.error("Failed to create an instance of pub sub clients factory", e);
       throw new VeniceException(e);
     }
+    routerPrincipalName = serverProperties.getString(ROUTER_PRINCIPAL_NAME, "venice-router");
   }
 
   long extractIngestionMemoryLimit(
@@ -1236,5 +1239,9 @@ public class VeniceServerConfig extends VeniceClusterConfig {
 
   public PubSubClientsFactory getPubSubClientsFactory() {
     return pubSubClientsFactory;
+  }
+
+  public String getRouterPrincipalName() {
+    return routerPrincipalName;
   }
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -1948,4 +1948,9 @@ public class ConfigKeys {
   public static final String PUB_SUB_PRODUCER_ADAPTER_FACTORY_CLASS = "pub.sub.producer.adapter.factory.class";
 
   public static final String PUB_SUB_CONSUMER_ADAPTER_FACTORY_CLASS = "pub.sub.consumer.adapter.factory.class";
+
+  /**
+   * Venice router's principal name used for ssl. Default should contain "venice-router".
+   */
+  public static final String ROUTER_PRINCIPAL_NAME = "router.principal.name";
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/listener/response/HttpShortcutResponse.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/listener/response/HttpShortcutResponse.java
@@ -10,6 +10,8 @@ public class HttpShortcutResponse {
   private final String message;
   private final HttpResponseStatus status;
 
+  private boolean misroutedStoreVersion = false;
+
   public HttpShortcutResponse(String message, HttpResponseStatus status) {
     this.message = message;
     this.status = status;
@@ -21,5 +23,13 @@ public class HttpShortcutResponse {
 
   public HttpResponseStatus getStatus() {
     return status;
+  }
+
+  public boolean isMisroutedStoreVersion() {
+    return misroutedStoreVersion;
+  }
+
+  public void setMisroutedStoreVersion(boolean misroutedStoreVersion) {
+    this.misroutedStoreVersion = misroutedStoreVersion;
   }
 }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/fastclient/FastClientServerReadQuotaTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/fastclient/FastClientServerReadQuotaTest.java
@@ -47,25 +47,34 @@ public class FastClientServerReadQuotaTest extends AbstractClientEndToEndSetup {
     String readQuotaRequestedString = "." + storeName + "--quota_rcu_requested.Count";
     String readQuotaRejectedString = "." + storeName + "--quota_rcu_rejected.Count";
     String readQuotaUsageRatio = "." + storeName + "--read_quota_usage_ratio.Gauge";
-    String clientConnectionCountString = ".server_connection_stats--client_connection_count_gauge.Max";
+    String clientConnectionCountGaugeString = ".server_connection_stats--client_connection_count.Gauge";
+    String routerConnectionCountGaugeString = ".server_connection_stats--router_connection_count.Gauge";
+    String clientConnectionCountRateString = ".server_connection_stats--client_connection_count.OccurrenceRate";
+    String routerConnectionCountRateString = ".server_connection_stats--router_connection_count.OccurrenceRate";
     TestUtils.waitForNonDeterministicAssertion(10, TimeUnit.SECONDS, () -> {
       for (MetricsRepository serverMetric: serverMetrics) {
         assertNotNull(serverMetric.getMetric(readQuotaRequestedString));
         assertNotNull(serverMetric.getMetric(readQuotaRejectedString));
         assertNotNull(serverMetric.getMetric(readQuotaUsageRatio));
-        assertNotNull(serverMetric.getMetric(clientConnectionCountString));
+        assertNotNull(serverMetric.getMetric(clientConnectionCountGaugeString));
+        assertNotNull(serverMetric.getMetric(routerConnectionCountGaugeString));
+        assertNotNull(serverMetric.getMetric(clientConnectionCountRateString));
+        assertNotNull(serverMetric.getMetric(routerConnectionCountRateString));
       }
     });
     int quotaRequestedSum = 0;
-    int clientConnectionCountSum = 0;
+    int clientConnectionCountRateSum = 0;
+    int routerConnectionCountRateSum = 0;
     for (MetricsRepository serverMetric: serverMetrics) {
       quotaRequestedSum += serverMetric.getMetric(readQuotaRequestedString).value();
-      clientConnectionCountSum += serverMetric.getMetric(clientConnectionCountString).value();
+      clientConnectionCountRateSum += serverMetric.getMetric(clientConnectionCountRateString).value();
+      routerConnectionCountRateSum += serverMetric.getMetric(routerConnectionCountRateString).value();
       assertEquals(serverMetric.getMetric(readQuotaRejectedString).value(), 0d);
       assertTrue(serverMetric.getMetric(readQuotaUsageRatio).value() > 0);
     }
     assertTrue(quotaRequestedSum >= 500, "Quota requested sum: " + quotaRequestedSum);
-    assertTrue(clientConnectionCountSum > 0, "Servers should have more than 0 client connections");
+    assertTrue(clientConnectionCountRateSum > 0, "Servers should have more than 0 client connections");
+    assertEquals(routerConnectionCountRateSum, 0, "Servers should have 0 router connections");
 
     // Update the read quota to 50 and make as many requests needed to trigger quota rejected exception.
     veniceCluster.useControllerClient(controllerClient -> {

--- a/services/venice-server/src/main/java/com/linkedin/venice/listener/HttpChannelInitializer.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/listener/HttpChannelInitializer.java
@@ -169,6 +169,9 @@ public class HttpChannelInitializer extends ChannelInitializer<SocketChannel> {
       ch.pipeline().addLast(sslInitializer);
     }
     ChannelPipelineConsumer httpPipelineInitializer = (pipeline, whetherNeedServerCodec) -> {
+      ServerConnectionStatsHandler serverConnectionStatsHandler =
+          new ServerConnectionStatsHandler(serverConnectionStats, serverConfig.getRouterPrincipalName());
+      pipeline.addLast(serverConnectionStatsHandler);
       StatsHandler statsHandler = new StatsHandler(singleGetStats, multiGetStats, computeStats);
       pipeline.addLast(statsHandler);
       if (whetherNeedServerCodec) {
@@ -208,9 +211,6 @@ public class HttpChannelInitializer extends ChannelInitializer<SocketChannel> {
           pipeline.addLast(storeAclHandler.get());
         }
       }
-      ServerConnectionStatsHandler serverConnectionStatsHandler =
-          new ServerConnectionStatsHandler(serverConnectionStats, serverConfig.getRouterPrincipalName());
-      pipeline.addLast(serverConnectionStatsHandler);
       pipeline
           .addLast(new RouterRequestHttpHandler(statsHandler, serverConfig.getStoreToEarlyTerminationThresholdMSMap()));
       if (quotaEnforcer != null) {

--- a/services/venice-server/src/main/java/com/linkedin/venice/listener/OutboundHttpWrapperHandler.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/listener/OutboundHttpWrapperHandler.java
@@ -79,6 +79,7 @@ public class OutboundHttpWrapperHandler extends ChannelOutboundHandlerAdapter {
         if (shortcutResponse.getStatus().equals(VeniceRequestEarlyTerminationException.getHttpResponseStatus())) {
           statsHandler.setRequestTerminatedEarly();
         }
+        statsHandler.setMisroutedStoreVersionRequest(shortcutResponse.isMisroutedStoreVersion());
       } else if (msg instanceof BinaryResponse) {
         // For dictionary Fetch requests
         body = ((BinaryResponse) msg).getBody();

--- a/services/venice-server/src/main/java/com/linkedin/venice/listener/ServerConnectionStatsHandler.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/listener/ServerConnectionStatsHandler.java
@@ -1,0 +1,61 @@
+package com.linkedin.venice.listener;
+
+import com.linkedin.venice.stats.ServerConnectionStats;
+import com.linkedin.venice.utils.SslUtils;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.handler.ssl.SslHandler;
+import java.security.cert.X509Certificate;
+import javax.net.ssl.SSLPeerUnverifiedException;
+
+
+public class ServerConnectionStatsHandler extends ChannelInboundHandlerAdapter {
+  private final ServerConnectionStats serverConnectionStats;
+  private final String routerPrincialName;
+
+  public ServerConnectionStatsHandler(ServerConnectionStats serverConnectionStats, String routerPrincipalName) {
+    this.serverConnectionStats = serverConnectionStats;
+    this.routerPrincialName = routerPrincipalName;
+  }
+
+  @Override
+  public void channelRegistered(ChannelHandlerContext ctx) throws Exception {
+    SslHandler sslHandler = extractSslHandler(ctx);
+    if (sslHandler == null) {
+      // No ssl enabled, record all connections as client connections
+      serverConnectionStats.incrementClientConnectionCount();
+      return;
+    }
+    String principalName = getPrincipal(sslHandler);
+    if (principalName.contains(routerPrincialName)) {
+      serverConnectionStats.incrementRouterConnectionCount();
+    } else {
+      serverConnectionStats.incrementClientConnectionCount();
+    }
+  }
+
+  @Override
+  public void channelUnregistered(ChannelHandlerContext ctx) throws Exception {
+    SslHandler sslHandler = extractSslHandler(ctx);
+    if (sslHandler == null) {
+      // No ssl enabled, record all connections as client connections
+      serverConnectionStats.decrementClientConnectionCount();
+      return;
+    }
+    String principalName = getPrincipal(sslHandler);
+    if (principalName.contains(routerPrincialName)) {
+      serverConnectionStats.incrementRouterConnectionCount();
+    } else {
+      serverConnectionStats.incrementClientConnectionCount();
+    }
+  }
+
+  protected SslHandler extractSslHandler(ChannelHandlerContext ctx) {
+    return ServerHandlerUtils.extractSslHandler(ctx);
+  }
+
+  private String getPrincipal(SslHandler sslHandler) throws SSLPeerUnverifiedException {
+    X509Certificate clientCert = SslUtils.getX509Certificate(sslHandler.engine().getSession().getPeerCertificates()[0]);
+    return clientCert.getSubjectX500Principal().getName();
+  }
+}

--- a/services/venice-server/src/main/java/com/linkedin/venice/listener/ServerConnectionStatsHandler.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/listener/ServerConnectionStatsHandler.java
@@ -11,11 +11,11 @@ import javax.net.ssl.SSLPeerUnverifiedException;
 
 public class ServerConnectionStatsHandler extends ChannelInboundHandlerAdapter {
   private final ServerConnectionStats serverConnectionStats;
-  private final String routerPrincialName;
+  private final String routerPrincipalName;
 
   public ServerConnectionStatsHandler(ServerConnectionStats serverConnectionStats, String routerPrincipalName) {
     this.serverConnectionStats = serverConnectionStats;
-    this.routerPrincialName = routerPrincipalName;
+    this.routerPrincipalName = routerPrincipalName;
   }
 
   @Override
@@ -27,7 +27,7 @@ public class ServerConnectionStatsHandler extends ChannelInboundHandlerAdapter {
       return;
     }
     String principalName = getPrincipal(sslHandler);
-    if (principalName.contains(routerPrincialName)) {
+    if (principalName.contains(routerPrincipalName)) {
       serverConnectionStats.incrementRouterConnectionCount();
     } else {
       serverConnectionStats.incrementClientConnectionCount();
@@ -43,10 +43,10 @@ public class ServerConnectionStatsHandler extends ChannelInboundHandlerAdapter {
       return;
     }
     String principalName = getPrincipal(sslHandler);
-    if (principalName.contains(routerPrincialName)) {
-      serverConnectionStats.incrementRouterConnectionCount();
+    if (principalName.contains(routerPrincipalName)) {
+      serverConnectionStats.decrementRouterConnectionCount();
     } else {
-      serverConnectionStats.incrementClientConnectionCount();
+      serverConnectionStats.decrementClientConnectionCount();
     }
   }
 

--- a/services/venice-server/src/main/java/com/linkedin/venice/listener/ServerConnectionStatsHandler.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/listener/ServerConnectionStatsHandler.java
@@ -27,7 +27,7 @@ public class ServerConnectionStatsHandler extends ChannelInboundHandlerAdapter {
       return;
     }
     String principalName = getPrincipal(sslHandler);
-    if (principalName.contains(routerPrincipalName)) {
+    if (principalName.equals(routerPrincipalName)) {
       serverConnectionStats.incrementRouterConnectionCount();
     } else {
       serverConnectionStats.incrementClientConnectionCount();
@@ -43,7 +43,7 @@ public class ServerConnectionStatsHandler extends ChannelInboundHandlerAdapter {
       return;
     }
     String principalName = getPrincipal(sslHandler);
-    if (principalName.contains(routerPrincipalName)) {
+    if (principalName.equals(routerPrincipalName)) {
       serverConnectionStats.decrementRouterConnectionCount();
     } else {
       serverConnectionStats.decrementClientConnectionCount();

--- a/services/venice-server/src/main/java/com/linkedin/venice/listener/StatsHandler.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/listener/StatsHandler.java
@@ -1,5 +1,8 @@
 package com.linkedin.venice.listener;
 
+import static io.netty.handler.codec.http.HttpResponseStatus.NOT_FOUND;
+import static io.netty.handler.codec.http.HttpResponseStatus.OK;
+
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.listener.request.RouterRequest;
 import com.linkedin.venice.read.RequestType;
@@ -12,9 +15,6 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import it.unimi.dsi.fastutil.ints.IntList;
-
-import static io.netty.handler.codec.http.HttpResponseStatus.NOT_FOUND;
-import static io.netty.handler.codec.http.HttpResponseStatus.OK;
 
 
 public class StatsHandler extends ChannelDuplexHandler {
@@ -146,6 +146,10 @@ public class StatsHandler extends ChannelDuplexHandler {
     return serverStatsContext;
   }
 
+  public void setMisroutedStoreVersionRequest(boolean misroutedStoreVersionRequest) {
+    serverStatsContext.setMisroutedStoreVersion(misroutedStoreVersionRequest);
+  }
+
   @Override
   public void channelRead(ChannelHandlerContext ctx, Object msg) {
     if (serverStatsContext.isNewRequest()) {
@@ -195,10 +199,10 @@ public class StatsHandler extends ChannelDuplexHandler {
        * multiple times for a single request
        */
       if (!serverStatsContext.isStatCallBackExecuted()) {
-        ServerHttpRequestStats serverHttpRequestStats =
-            serverStatsContext.getCurrentStats().getStoreStats(serverStatsContext.getStoreName());
+        ServerHttpRequestStats serverHttpRequestStats = serverStatsContext.getStoreName() == null
+            ? null
+            : serverStatsContext.getCurrentStats().getStoreStats(serverStatsContext.getStoreName());
         serverStatsContext.recordBasicMetrics(serverHttpRequestStats);
-
         double elapsedTime = LatencyUtils.getLatencyInMS(serverStatsContext.getRequestStartTimeInNS());
         // if ResponseStatus is either OK or NOT_FOUND and the channel write is succeed,
         // records a successRequest in stats. Otherwise, records a errorRequest in stats;

--- a/services/venice-server/src/main/java/com/linkedin/venice/listener/StatsHandler.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/listener/StatsHandler.java
@@ -1,7 +1,5 @@
 package com.linkedin.venice.listener;
 
-import static io.netty.handler.codec.http.HttpResponseStatus.*;
-
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.listener.request.RouterRequest;
 import com.linkedin.venice.read.RequestType;
@@ -14,6 +12,9 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import it.unimi.dsi.fastutil.ints.IntList;
+
+import static io.netty.handler.codec.http.HttpResponseStatus.NOT_FOUND;
+import static io.netty.handler.codec.http.HttpResponseStatus.OK;
 
 
 public class StatsHandler extends ChannelDuplexHandler {

--- a/services/venice-server/src/main/java/com/linkedin/venice/listener/grpc/handlers/GrpcOutboundStatsHandler.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/listener/grpc/handlers/GrpcOutboundStatsHandler.java
@@ -32,8 +32,9 @@ public class GrpcOutboundStatsHandler extends VeniceServerGrpcHandler {
       throw new VeniceException("store name could not be null");
     }
 
-    ServerHttpRequestStats serverHttpRequestStats =
-        statsContext.getCurrentStats().getStoreStats(statsContext.getStoreName());
+    ServerHttpRequestStats serverHttpRequestStats = statsContext.getStoreName() == null
+        ? null
+        : statsContext.getCurrentStats().getStoreStats(statsContext.getStoreName());
 
     statsContext.recordBasicMetrics(serverHttpRequestStats);
 

--- a/services/venice-server/src/main/java/com/linkedin/venice/stats/AggServerHttpRequestStats.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/stats/AggServerHttpRequestStats.java
@@ -67,4 +67,8 @@ public class AggServerHttpRequestStats extends AbstractVeniceAggStoreStats<Serve
   public void recordStorageExecutionQueueLen(int len) {
     totalStats.recordStorageExecutionQueueLen(len);
   }
+
+  public void recordMisroutedStoreVersionRequest() {
+    totalStats.recordMisroutedStoreVersionRequest();
+  }
 }

--- a/services/venice-server/src/main/java/com/linkedin/venice/stats/ServerConnectionStats.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/stats/ServerConnectionStats.java
@@ -2,6 +2,7 @@ package com.linkedin.venice.stats;
 
 import io.tehuti.metrics.MetricsRepository;
 import io.tehuti.metrics.Sensor;
+import io.tehuti.metrics.stats.Max;
 
 
 public class ServerConnectionStats extends AbstractVeniceStats {
@@ -16,8 +17,8 @@ public class ServerConnectionStats extends AbstractVeniceStats {
 
   public ServerConnectionStats(MetricsRepository metricsRepository, String name) {
     super(metricsRepository, name);
-    routerConnectionCountSensor = registerSensorIfAbsent(ROUTER_CONNECTION_COUNT_GAUGE, new Gauge());
-    clientConnectionCountSensor = registerSensorIfAbsent(CLIENT_CONNECTION_COUNT_GAUGE, new Gauge());
+    routerConnectionCountSensor = registerSensorIfAbsent(ROUTER_CONNECTION_COUNT_GAUGE, new Gauge(), new Max());
+    clientConnectionCountSensor = registerSensorIfAbsent(CLIENT_CONNECTION_COUNT_GAUGE, new Gauge(), new Max());
   }
 
   public void incrementRouterConnectionCount() {

--- a/services/venice-server/src/main/java/com/linkedin/venice/stats/ServerConnectionStats.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/stats/ServerConnectionStats.java
@@ -1,0 +1,42 @@
+package com.linkedin.venice.stats;
+
+import io.tehuti.metrics.MetricsRepository;
+import io.tehuti.metrics.Sensor;
+
+
+public class ServerConnectionStats extends AbstractVeniceStats {
+  public static final String ROUTER_CONNECTION_COUNT_GAUGE = "router_connection_count_gauge";
+  public static final String CLIENT_CONNECTION_COUNT_GAUGE = "client_connection_count_gauge";
+
+  private final Sensor routerConnectionCountSensor;
+  private final Sensor clientConnectionCountSensor;
+
+  private int routerConnectionCount;
+  private int clientConnectionCount;
+
+  public ServerConnectionStats(MetricsRepository metricsRepository, String name) {
+    super(metricsRepository, name);
+    routerConnectionCountSensor = registerSensorIfAbsent(ROUTER_CONNECTION_COUNT_GAUGE, new Gauge());
+    clientConnectionCountSensor = registerSensorIfAbsent(CLIENT_CONNECTION_COUNT_GAUGE, new Gauge());
+  }
+
+  public void incrementRouterConnectionCount() {
+    routerConnectionCount++;
+    routerConnectionCountSensor.record(routerConnectionCount);
+  }
+
+  public void decrementRouterConnectionCount() {
+    routerConnectionCount--;
+    routerConnectionCountSensor.record(routerConnectionCount);
+  }
+
+  public void incrementClientConnectionCount() {
+    clientConnectionCount++;
+    clientConnectionCountSensor.record(clientConnectionCount);
+  }
+
+  public void decrementClientConnectionCount() {
+    clientConnectionCount--;
+    clientConnectionCountSensor.record(clientConnectionCount);
+  }
+}

--- a/services/venice-server/src/main/java/com/linkedin/venice/stats/ServerConnectionStats.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/stats/ServerConnectionStats.java
@@ -2,23 +2,29 @@ package com.linkedin.venice.stats;
 
 import io.tehuti.metrics.MetricsRepository;
 import io.tehuti.metrics.Sensor;
-import io.tehuti.metrics.stats.Max;
+import io.tehuti.metrics.stats.OccurrenceRate;
 
 
 public class ServerConnectionStats extends AbstractVeniceStats {
-  public static final String ROUTER_CONNECTION_COUNT_GAUGE = "router_connection_count_gauge";
-  public static final String CLIENT_CONNECTION_COUNT_GAUGE = "client_connection_count_gauge";
+  public static final String ROUTER_CONNECTION_COUNT_GAUGE = "router_connection_count";
+  public static final String CLIENT_CONNECTION_COUNT_GAUGE = "client_connection_count";
 
   private final Sensor routerConnectionCountSensor;
   private final Sensor clientConnectionCountSensor;
 
-  private int routerConnectionCount;
-  private int clientConnectionCount;
+  private long routerConnectionCount;
+  private long clientConnectionCount;
 
   public ServerConnectionStats(MetricsRepository metricsRepository, String name) {
     super(metricsRepository, name);
-    routerConnectionCountSensor = registerSensorIfAbsent(ROUTER_CONNECTION_COUNT_GAUGE, new Gauge(), new Max());
-    clientConnectionCountSensor = registerSensorIfAbsent(CLIENT_CONNECTION_COUNT_GAUGE, new Gauge(), new Max());
+    routerConnectionCountSensor = registerSensorIfAbsent(
+        ROUTER_CONNECTION_COUNT_GAUGE,
+        new Gauge(() -> routerConnectionCount),
+        new OccurrenceRate());
+    clientConnectionCountSensor = registerSensorIfAbsent(
+        CLIENT_CONNECTION_COUNT_GAUGE,
+        new Gauge(() -> clientConnectionCount),
+        new OccurrenceRate());
   }
 
   public void incrementRouterConnectionCount() {

--- a/services/venice-server/src/main/java/com/linkedin/venice/stats/ServerHttpRequestStats.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/stats/ServerHttpRequestStats.java
@@ -57,6 +57,7 @@ public class ServerHttpRequestStats extends AbstractVeniceHttpStats {
   // Ratio sensors are not directly written to, but they still get their state updated indirectly
   @SuppressWarnings("unused")
   private final Sensor successRequestKeyRatioSensor, successRequestRatioSensor;
+  private final Sensor misroutedStoreVersionSensor;
 
   public ServerHttpRequestStats(
       MetricsRepository metricsRepository,
@@ -305,6 +306,11 @@ public class ServerHttpRequestStats extends AbstractVeniceHttpStats {
           TehutiUtils
               .getFineGrainedPercentileStatWithAvgAndMax(getName(), getFullMetricName(requestKeySizeSensorName)));
     }
+    misroutedStoreVersionSensor = registerPerStoreAndTotal(
+        "misrouted_store_version_request_count",
+        totalStats,
+        () -> totalStats.misroutedStoreVersionSensor,
+        new OccurrenceRate());
   }
 
   private Sensor registerPerStoreAndTotal(
@@ -428,5 +434,9 @@ public class ServerHttpRequestStats extends AbstractVeniceHttpStats {
 
   public void recordValueSizeInByte(long valueSize) {
     requestValueSizeSensor.record(valueSize);
+  }
+
+  public void recordMisroutedStoreVersionRequest() {
+    misroutedStoreVersionSensor.record();
   }
 }

--- a/services/venice-server/src/test/java/com/linkedin/venice/grpc/ServerStatsContextTest.java
+++ b/services/venice-server/src/test/java/com/linkedin/venice/grpc/ServerStatsContextTest.java
@@ -67,10 +67,17 @@ public class ServerStatsContextTest {
 
     ServerHttpRequestStats stats = mock(ServerHttpRequestStats.class);
     context.setRequestType(RequestType.SINGLE_GET);
+    context.setMisroutedStoreVersion(true);
     context.errorRequest(stats, 12.3);
 
+    verify(stats).recordErrorRequest();
+    verify(stats).recordErrorRequestLatency(12.3);
+    verify(stats).recordMisroutedStoreVersionRequest();
+
+    context.errorRequest(null, 12.3);
     verify(singleGetStats).recordErrorRequest();
     verify(singleGetStats).recordErrorRequestLatency(12.3);
+    verify(singleGetStats).recordMisroutedStoreVersionRequest();
   }
 
   @Test

--- a/services/venice-server/src/test/java/com/linkedin/venice/listener/ServerConnectionStatsHandlerTest.java
+++ b/services/venice-server/src/test/java/com/linkedin/venice/listener/ServerConnectionStatsHandlerTest.java
@@ -1,0 +1,85 @@
+package com.linkedin.venice.listener;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.linkedin.venice.stats.ServerConnectionStats;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPipeline;
+import io.netty.handler.ssl.SslHandler;
+import java.security.cert.Certificate;
+import java.security.cert.X509Certificate;
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLSession;
+import javax.security.auth.x500.X500Principal;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+
+public class ServerConnectionStatsHandlerTest {
+  private ChannelHandlerContext context;
+  private ChannelPipeline pipeline;
+  private Channel channel;
+
+  @BeforeMethod
+  public void setUp() {
+    context = mock(ChannelHandlerContext.class);
+    pipeline = mock(ChannelPipeline.class);
+    doReturn(pipeline).when(context).pipeline();
+    channel = mock(Channel.class);
+    doReturn(channel).when(context).channel();
+  }
+
+  @Test
+  public void testChannelRegisteredUnregisteredWithNoSslHandler() throws Exception {
+    ServerConnectionStats serverConnectionStats = mock(ServerConnectionStats.class);
+    ServerConnectionStatsHandler serverConnectionStatsHandler =
+        new ServerConnectionStatsHandler(serverConnectionStats, "venice-router");
+    serverConnectionStatsHandler.channelRegistered(context);
+    verify(serverConnectionStats, times(1)).incrementClientConnectionCount();
+    verify(serverConnectionStats, never()).decrementClientConnectionCount();
+    serverConnectionStatsHandler.channelUnregistered(context);
+    verify(serverConnectionStats, times(1)).incrementClientConnectionCount();
+    verify(serverConnectionStats, times(1)).decrementClientConnectionCount();
+    verify(serverConnectionStats, never()).incrementRouterConnectionCount();
+    verify(serverConnectionStats, never()).decrementRouterConnectionCount();
+  }
+
+  @Test
+  public void testChannelRegisteredUnregisteredWithSslHandler() throws Exception {
+    String veniceRouterPrincipalString = "CN=venice-router";
+    SslHandler sslHandler = mock(SslHandler.class);
+    doReturn(sslHandler).when(pipeline).get(eq(SslHandler.class));
+    X509Certificate cert = mock(X509Certificate.class);
+    X500Principal routerPrincipal = new X500Principal(veniceRouterPrincipalString);
+    X500Principal clientPrincipal = new X500Principal("CN=test-client");
+    when(cert.getSubjectX500Principal()).thenReturn(routerPrincipal, routerPrincipal, clientPrincipal);
+    SSLEngine engine = mock(SSLEngine.class);
+    SSLSession session = mock(SSLSession.class);
+    Certificate[] certificates = { cert };
+    doReturn(certificates).when(session).getPeerCertificates();
+    doReturn(session).when(engine).getSession();
+    doReturn(engine).when(sslHandler).engine();
+    ServerConnectionStats serverConnectionStats = mock(ServerConnectionStats.class);
+    ServerConnectionStatsHandler serverConnectionStatsHandler =
+        new ServerConnectionStatsHandler(serverConnectionStats, veniceRouterPrincipalString);
+    serverConnectionStatsHandler.channelRegistered(context);
+    serverConnectionStatsHandler.channelUnregistered(context);
+    verify(serverConnectionStats, times(1)).incrementRouterConnectionCount();
+    verify(serverConnectionStats, times(1)).decrementRouterConnectionCount();
+    verify(serverConnectionStats, never()).incrementClientConnectionCount();
+    verify(serverConnectionStats, never()).decrementClientConnectionCount();
+    serverConnectionStatsHandler.channelRegistered(context);
+    serverConnectionStatsHandler.channelUnregistered(context);
+    verify(serverConnectionStats, times(1)).incrementRouterConnectionCount();
+    verify(serverConnectionStats, times(1)).decrementRouterConnectionCount();
+    verify(serverConnectionStats, times(1)).incrementClientConnectionCount();
+    verify(serverConnectionStats, times(1)).decrementClientConnectionCount();
+  }
+}


### PR DESCRIPTION
## Add Venice server connection and misrouted metrics
Two gauges (and its max) to show server's live connections count from routers and servers.
- router_connection_count (Gauge and OccurrenceRate)
- client_connection_count (Gauge and OccurrenceRate)
These metrics are collected by a new `ChannelInboundHandlerAdapter`, the `ServerConnectionStatsHandler` that will collect stats accordingly on `channelRegistered` and `channelUnregistered.

Additional per store and total metric for misrouted requests based on invalid store version.
- misrouted_store_version_request_count
The check only occurs on error requests, the corresponding flag is set on the `HttpShortcutResponse` if it's determined that the request had a misrouted store version. `StatsHandler` will emit the corresponding metric on its. `ServerStatsContext.errorRequest`

## How was this PR tested?
TODO will have unit and integration test to verify the metrics
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.