### PR TITLE
[server][da-vinci-client] Restore storage engine if not found

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/DefaultIngestionBackend.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/DefaultIngestionBackend.java
@@ -100,7 +100,6 @@ public class DefaultIngestionBackend implements DaVinciIngestionBackend, VeniceI
     getStoreIngestionService().stopConsumptionAndWait(storeConfig, partition, waitIntervalInSecond, maxRetry, true);
     // Drops corresponding data partition from storage.
     getStorageService().dropStorePartition(storeConfig, partition, removeEmptyStorageEngine);
-
   }
 
   @Override

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/IsolatedIngestionBackend.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/IsolatedIngestionBackend.java
@@ -351,18 +351,15 @@ public class IsolatedIngestionBackend extends DefaultIngestionBackend
       Runnable mainProcessCommandRunnable) {
     boolean isTopicPartitionHosted = isTopicPartitionHosted(topicName, partition);
 
-    // Start consumption for new partition happens in isolated process
-    if (command == START_CONSUMPTION && !isTopicPartitionHosted) {
-      isolatedProcessCommandSupplier.get();
-      return;
-    } else if (command == REMOVE_PARTITION && !isTopicPartitionHosted) {
+    if (command == REMOVE_PARTITION && !isTopicPartitionHosted) {
       mainProcessCommandRunnable.run();
       isolatedProcessCommandSupplier.get();
       return;
     }
 
     do {
-      if (isTopicPartitionHostedInMainProcess(topicName, partition) || !isTopicPartitionHosted) {
+      if (isTopicPartitionHostedInMainProcess(topicName, partition)
+          || !isTopicPartitionHosted && command != START_CONSUMPTION) {
         LOGGER.info("Executing command {} of topic: {}, partition: {} in main process.", command, topicName, partition);
         mainProcessCommandRunnable.run();
         return;

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/IsolatedIngestionBackend.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/IsolatedIngestionBackend.java
@@ -351,9 +351,9 @@ public class IsolatedIngestionBackend extends DefaultIngestionBackend
       Runnable mainProcessCommandRunnable) {
     boolean isTopicPartitionHosted = isTopicPartitionHosted(topicName, partition);
 
+    // drop storage partition in main process if it does not exist
     if (command == REMOVE_PARTITION && !isTopicPartitionHosted) {
       mainProcessCommandRunnable.run();
-      isolatedProcessCommandSupplier.get();
       return;
     }
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/isolated/IsolatedIngestionServer.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/isolated/IsolatedIngestionServer.java
@@ -715,6 +715,8 @@ public class IsolatedIngestionServer extends AbstractVeniceService {
      * automatically open the metadata partitions. Also, during Da Vinci bootstrap, main process will need to open the
      * metadata partition of storage engines in order to perform full cleanup of stale versions.
      */
+    boolean isDaVinciClient = veniceMetadataRepositoryBuilder.isDaVinciClient();
+
     storageService = new StorageService(
         configLoader,
         storageEngineStats,
@@ -722,7 +724,7 @@ public class IsolatedIngestionServer extends AbstractVeniceService {
         storeVersionStateSerializer,
         partitionStateSerializer,
         storeRepository,
-        true,
+        false,
         true);
     storageService.start();
 
@@ -738,7 +740,6 @@ public class IsolatedIngestionServer extends AbstractVeniceService {
     StorageEngineBackedCompressorFactory compressorFactory =
         new StorageEngineBackedCompressorFactory(storageMetadataService);
 
-    boolean isDaVinciClient = veniceMetadataRepositoryBuilder.isDaVinciClient();
     PubSubClientsFactory pubSubClientsFactory = configLoader.getVeniceServerConfig().getPubSubClientsFactory();
 
     // Create KafkaStoreIngestionService

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/isolated/IsolatedIngestionServer.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/isolated/IsolatedIngestionServer.java
@@ -722,7 +722,7 @@ public class IsolatedIngestionServer extends AbstractVeniceService {
         storeVersionStateSerializer,
         partitionStateSerializer,
         storeRepository,
-        false,
+        true,
         true);
     storageService.start();
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/storage/StorageService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/storage/StorageService.java
@@ -398,12 +398,7 @@ public class StorageService extends AbstractVeniceService {
     AbstractStorageEngine<?> storageEngine = getStorageEngineRepository().removeLocalStorageEngine(kafkaTopic);
     if (storageEngine == null) {
       LOGGER.warn("Storage engine {} does not exist, trying to reopen storage for .", kafkaTopic);
-      storageEngine = openStorageEngine(kafkaTopic);
-      if (storageEngine == null) {
-        LOGGER.warn(" Could not retrieve storage engine for {}, ignoring remove request.", kafkaTopic);
-        return;
-      }
-      storageEngine = getStorageEngineRepository().removeLocalStorageEngine(kafkaTopic);
+      return;
     }
     storageEngine.drop();
 
@@ -412,20 +407,6 @@ public class StorageService extends AbstractVeniceService {
 
     StorageEngineFactory factory = getInternalStorageEngineFactory(storeConfig);
     factory.removeStorageEngine(storageEngine);
-  }
-
-  AbstractStorageEngine openStorageEngine(String storeName) {
-    VeniceStoreVersionConfig storeConfig = configLoader.getStoreConfig(storeName);
-    storeConfig.setRestoreDataPartitions(false);
-    storeConfig.setRestoreMetadataPartition(false);
-    AbstractStorageEngine storageEngine;
-
-    try {
-      storageEngine = openStore(storeConfig, () -> null);
-    } catch (Exception e) {
-      return null;
-    }
-    return storageEngine;
   }
 
   /**

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/storage/StorageService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/storage/StorageService.java
@@ -403,6 +403,7 @@ public class StorageService extends AbstractVeniceService {
         LOGGER.warn(" Could not retrieve storage engine for {}, ignoring remove request.", kafkaTopic);
         return;
       }
+      storageEngine = getStorageEngineRepository().removeLocalStorageEngine(kafkaTopic);
     }
     storageEngine.drop();
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/storage/StorageService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/storage/StorageService.java
@@ -361,9 +361,8 @@ public class StorageService extends AbstractVeniceService {
    * @param storeConfig              config of the store version.
    * @param partition                partition ID to be dropped.
    * @param removeEmptyStorageEngine Whether to delete the storage engine when there is no remaining data partition.
-   * @return
    */
-  public synchronized boolean dropStorePartition(
+  public synchronized void dropStorePartition(
       VeniceStoreVersionConfig storeConfig,
       int partition,
       boolean removeEmptyStorageEngine) {
@@ -372,7 +371,7 @@ public class StorageService extends AbstractVeniceService {
     if (storageEngine == null) {
       LOGGER.warn("Storage engine {} does not exist, directly deleting DB files.", kafkaTopic);
       removeStoragePartition(kafkaTopic, partition);
-      return false;
+      return;
     }
     for (int subPartition: getSubPartition(kafkaTopic, partition)) {
       storageEngine.dropPartition(subPartition);
@@ -383,7 +382,6 @@ public class StorageService extends AbstractVeniceService {
     if (remainingPartitions.isEmpty() && removeEmptyStorageEngine) {
       removeStorageEngine(kafkaTopic);
     }
-    return true;
   }
 
   void removeStoragePartition(String kafkaTopic, int partition) {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/StorageEngineFactory.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/StorageEngineFactory.java
@@ -59,6 +59,8 @@ public abstract class StorageEngineFactory {
    */
   public abstract void removeStorageEngine(String storeName);
 
+  public abstract void removeStorageEnginePartition(String storeName, int partition);
+
   /**
    * Close the storage engine from the underlying storage configuration
    *

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/blackhole/BlackHoleStorageEngineFactory.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/blackhole/BlackHoleStorageEngineFactory.java
@@ -37,6 +37,11 @@ public class BlackHoleStorageEngineFactory extends StorageEngineFactory {
   }
 
   @Override
+  public void removeStorageEnginePartition(String storeName, int partition) {
+    // Right away!
+  }
+
+  @Override
   public void closeStorageEngine(AbstractStorageEngine engine) {
     // Right away!
   }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/memory/InMemoryStorageEngineFactory.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/memory/InMemoryStorageEngineFactory.java
@@ -52,6 +52,11 @@ public class InMemoryStorageEngineFactory extends StorageEngineFactory {
   }
 
   @Override
+  public void removeStorageEnginePartition(String storeName, int partition) {
+    // Right away!
+  }
+
+  @Override
   public void closeStorageEngine(AbstractStorageEngine engine) {
     // Nothing to do here since we do not track the created storage engine
   }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/RocksDBServerConfig.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/RocksDBServerConfig.java
@@ -214,7 +214,7 @@ public class RocksDBServerConfig {
   private final int rocksDBEnvFlushPoolSize;
   private final int rocksDBEnvCompactionPoolSize;
 
-  private final CompressionType rocksDBOptionsCompressionType;
+  private CompressionType rocksDBOptionsCompressionType;
   private final CompactionStyle rocksDBOptionsCompactionStyle;
 
   private final long rocksDBBlockCacheSizeInBytes;
@@ -562,6 +562,10 @@ public class RocksDBServerConfig {
   // For test only
   public void setBlockBaseFormatVersion(int version) {
     this.blockBaseFormatVersion = version;
+  }
+
+  public void setRocksdbOptionsCompressionType(String compressionType) {
+    this.rocksDBOptionsCompressionType = CompressionType.valueOf(compressionType);
   }
 
   public int getMaxLogFileNum() {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/RocksDBStorageEngineFactory.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/RocksDBStorageEngineFactory.java
@@ -348,6 +348,7 @@ public class RocksDBStorageEngineFactory extends StorageEngineFactory {
     }
     File dbDir;
 
+    // partitionId -1 means removes all partitions in the DB path.
     if (partitionId == -1) {
       dbDir = new File(rocksDBPath, storeName);
     } else {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/RocksDBStorageEngineFactory.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/RocksDBStorageEngineFactory.java
@@ -16,6 +16,7 @@ import com.linkedin.venice.kafka.protocol.state.StoreVersionState;
 import com.linkedin.venice.meta.PersistenceType;
 import com.linkedin.venice.serialization.avro.AvroProtocolDefinition;
 import com.linkedin.venice.serialization.avro.InternalAvroSpecificSerializer;
+import com.linkedin.venice.store.rocksdb.RocksDBUtils;
 import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
@@ -332,23 +333,36 @@ public class RocksDBStorageEngineFactory extends StorageEngineFactory {
    */
   @Override
   public synchronized void removeStorageEngine(String storeName) {
+    removeStorageEnginePartition(storeName, -1);
+  }
+
+  public String getRocksDBPath(String storeName, int partitionId) {
+    return RocksDBUtils.composePartitionDbDir(rocksDBPath, storeName, partitionId);
+  }
+
+  @Override
+  public synchronized void removeStorageEnginePartition(String storeName, int partitionId) {
     if (storageEngineMap.containsKey(storeName)) {
       throw new VeniceException(
           "Storage engine has already been opened previously, and please use #removeStorageEngine(AbstractStorageEngine) for deletion");
     }
-    File storeDir = new File(rocksDBPath, storeName);
-    if (storeDir.exists()) {
-      LOGGER.info("Started removing RocksDB database folder for store: {}", storeName);
+    File dbDir;
 
+    if (partitionId == -1) {
+      dbDir = new File(rocksDBPath, storeName);
+    } else {
+      dbDir = new File(getRocksDBPath(storeName, partitionId));
+    }
+    if (dbDir.exists()) {
+      LOGGER.info("Started removing RocksDB database folder for store: {}", dbDir.getName());
       try {
-        FileUtils.deleteDirectory(storeDir);
+        FileUtils.deleteDirectory(dbDir);
       } catch (IOException e) {
         throw new VeniceException("Failed to delete RocksDB database folder for store: " + storeName);
       }
-
-      LOGGER.info("Finished removing RocksDB database folder for store: {}", storeName);
+      LOGGER.info("Finished removing RocksDB database folder for store: {}", dbDir.getName());
     } else {
-      LOGGER.warn("RocksDB store: {} doesn't exist", storeName);
+      LOGGER.warn("Trying to delete RocksDB dir: {} which doesn't exist", dbDir.getName());
     }
   }
 

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/storage/StorageServiceTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/storage/StorageServiceTest.java
@@ -1,8 +1,5 @@
 package com.linkedin.davinci.storage;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -42,17 +39,5 @@ public class StorageServiceTest {
 
     StorageService.deleteStorageEngineOnRocksDBError(storageEngineName, storeRepository, factory);
     verify(factory, times(2)).removeStorageEngine(storageEngineName);
-  }
-
-  @Test
-  public void testDeleteStorageEngineOnClosedEngine() {
-    StorageEngineRepository storageEngineRepository = mock(StorageEngineRepository.class);
-    // no store or no version exists, delete the store
-    StorageService storageService = mock(StorageService.class);
-    when(storageEngineRepository.removeLocalStorageEngine(anyString())).thenReturn(null);
-    when(storageService.getStorageEngineRepository()).thenReturn(storageEngineRepository);
-    doCallRealMethod().when(storageService).removeStorageEngine(any());
-    storageService.removeStorageEngine(storageEngineName);
-    verify(storageService, times(1)).openStorageEngine(anyString());
   }
 }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/storage/StorageServiceTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/storage/StorageServiceTest.java
@@ -1,6 +1,12 @@
 package com.linkedin.davinci.storage;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import com.linkedin.davinci.store.StorageEngineFactory;
 import com.linkedin.venice.exceptions.VeniceNoStoreException;
@@ -36,6 +42,17 @@ public class StorageServiceTest {
 
     StorageService.deleteStorageEngineOnRocksDBError(storageEngineName, storeRepository, factory);
     verify(factory, times(2)).removeStorageEngine(storageEngineName);
+  }
 
+  @Test
+  public void testDeleteStorageEngineOnClosedEngine() {
+    StorageEngineRepository storageEngineRepository = mock(StorageEngineRepository.class);
+    // no store or no version exists, delete the store
+    StorageService storageService = mock(StorageService.class);
+    when(storageEngineRepository.removeLocalStorageEngine(anyString())).thenReturn(null);
+    when(storageService.getStorageEngineRepository()).thenReturn(storageEngineRepository);
+    doCallRealMethod().when(storageService).removeStorageEngine(any());
+    storageService.removeStorageEngine(storageEngineName);
+    verify(storageService, times(1)).openStorageEngine(anyString());
   }
 }


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

##  Restore storage engine if not found while executing delete storage engine
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

When bootstrapping server, if II is not enabled, by default all data partitions are restored. So even if there is offline->standby msg sent, storage engine will be created during restore, and if Helix think this resource should be dropped, it will send out a offline->dropped. This should be fine, as it can locate the partition in storage engine and drop it. 
For II, during server bootstrap, we do not do any partition restore at all. When there is any offline > standby message coming in, we will restore it first in II process, ingest it until COMPLETED and then handover to main process. If Helix does not even send offline>standby but send offline->dropped directly, our logic will try to execute it in main process. Since storage engine is not opened, drop will be ignored which leads to version leaks on servers. This PR will try to directly delete DB files if storage engine is not found.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
GHCI
## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.