### PR TITLE
[admin-tool] Handle DELETE messages for deprecated chunks in KafkaTopicDumper

### DIFF
--- a/clients/venice-admin-tool/src/test/java/com/linkedin/venice/TestKafkaTopicDumper.java
+++ b/clients/venice-admin-tool/src/test/java/com/linkedin/venice/TestKafkaTopicDumper.java
@@ -82,24 +82,24 @@ public class TestKafkaTopicDumper {
     int firstChunkSequenceNumber = 1;
     PubSubMessage<KafkaKey, KafkaMessageEnvelope, Long> pubSubMessage1 =
         getChunkedRecord(serializedKey, firstChunkSegmentNumber, firstChunkSequenceNumber, 0, 0, pubSubTopicPartition);
-    String dirstChunkMetadataLog = kafkaTopicDumper.getChunkMetadataLog(pubSubMessage1);
+    String firstChunkMetadataLog = kafkaTopicDumper.getChunkMetadataLog(pubSubMessage1);
     Assert.assertEquals(
-        dirstChunkMetadataLog,
-        " ChunkMd=(type:WITH_VALUE_CHUNK, FirstChunkMd=(guid:00000000000000000000000000000000,seg:1,seq:1))");
+        firstChunkMetadataLog,
+        " ChunkMd=(type:WITH_VALUE_CHUNK, ChunkIndex: 0, FirstChunkMd=(guid:00000000000000000000000000000000,seg:1,seq:1))");
 
     PubSubMessage<KafkaKey, KafkaMessageEnvelope, Long> pubSubMessage2 =
         getChunkedRecord(serializedKey, firstChunkSegmentNumber, firstChunkSequenceNumber, 1, 0, pubSubTopicPartition);
     String secondChunkMetadataLog = kafkaTopicDumper.getChunkMetadataLog(pubSubMessage2);
     Assert.assertEquals(
         secondChunkMetadataLog,
-        " ChunkMd=(type:WITH_VALUE_CHUNK, FirstChunkMd=(guid:00000000000000000000000000000000,seg:1,seq:1))");
+        " ChunkMd=(type:WITH_VALUE_CHUNK, ChunkIndex: 1, FirstChunkMd=(guid:00000000000000000000000000000000,seg:1,seq:1))");
 
     PubSubMessage<KafkaKey, KafkaMessageEnvelope, Long> pubSubMessage3 =
         getChunkedRecord(serializedKey, firstChunkSegmentNumber, firstChunkSequenceNumber, 2, 0, pubSubTopicPartition);
     String thirdChunkMetadataLog = kafkaTopicDumper.getChunkMetadataLog(pubSubMessage3);
     Assert.assertEquals(
         thirdChunkMetadataLog,
-        " ChunkMd=(type:WITH_VALUE_CHUNK, FirstChunkMd=(guid:00000000000000000000000000000000,seg:1,seq:1))");
+        " ChunkMd=(type:WITH_VALUE_CHUNK, ChunkIndex: 2, FirstChunkMd=(guid:00000000000000000000000000000000,seg:1,seq:1))");
 
     PubSubMessage<KafkaKey, KafkaMessageEnvelope, Long> pubSubMessage4 =
         getChunkValueManifestRecord(serializedKey, pubSubMessage1, firstChunkSequenceNumber, pubSubTopicPartition);


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Handle `DELETE` messages for deprecated chunks in `KafkaTopicDumper`
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
Recently, we've added support to emit `DELETE` messages to clean up leaked chunks (#535) but we hadn't handled this in the topic dumper tool.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
Tested by dumping data from an actual topic

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.