### PR TITLE
[controller][server][test] Support cluster by cluster pub sub clients for controller.

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/DaVinciBackend.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/DaVinciBackend.java
@@ -186,7 +186,11 @@ public class DaVinciBackend implements Closeable {
           new VeniceWriterFactory(backendProps.toProperties(), pubSubClientsFactory.getProducerAdapterFactory(), null);
       String instanceName = Utils.getHostName() + "_" + Utils.getPid();
       int derivedSchemaID = backendProps.getInt(PUSH_STATUS_STORE_DERIVED_SCHEMA_ID, 1);
-      pushStatusStoreWriter = new PushStatusStoreWriter(writerFactory, instanceName, derivedSchemaID);
+      Map<String, VeniceWriterFactory> writerFactoryMap = new HashMap<>(1);
+      String clusterName = backendConfig.getClusterName();
+      writerFactoryMap.put(clusterName, writerFactory);
+      pushStatusStoreWriter =
+          new PushStatusStoreWriter(writerFactoryMap, instanceName, derivedSchemaID, s -> clusterName);
 
       SchemaReader kafkaMessageEnvelopeSchemaReader = ClientFactory.getSchemaReader(
           ClientConfig.cloneConfig(clientConfig)

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/DaVinciBackend.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/DaVinciBackend.java
@@ -190,7 +190,7 @@ public class DaVinciBackend implements Closeable {
       String clusterName = backendConfig.getClusterName();
       writerFactoryMap.put(clusterName, writerFactory);
       pushStatusStoreWriter =
-          new PushStatusStoreWriter(writerFactoryMap, instanceName, derivedSchemaID, s -> clusterName);
+          new PushStatusStoreWriter(writerFactoryMap, instanceName, derivedSchemaID, s -> Optional.of(clusterName));
 
       SchemaReader kafkaMessageEnvelopeSchemaReader = ClientFactory.getSchemaReader(
           ClientConfig.cloneConfig(clientConfig)

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/helix/HelixParticipationService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/helix/HelixParticipationService.java
@@ -43,6 +43,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
@@ -307,7 +308,7 @@ public class HelixParticipationService extends AbstractVeniceService
         veniceWriterFactoryMap,
         instance.getNodeId(),
         veniceProperties.getInt(PUSH_STATUS_STORE_DERIVED_SCHEMA_ID, 1),
-        s -> clusterName);
+        s -> Optional.of(clusterName));
 
     // Record replica status in Zookeeper.
     // Need to be started before connecting to ZK, otherwise some notification will not be sent by this notifier.

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/helix/HelixParticipationService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/helix/HelixParticipationService.java
@@ -40,7 +40,9 @@ import com.linkedin.venice.utils.VeniceProperties;
 import com.linkedin.venice.writer.VeniceWriterFactory;
 import io.tehuti.metrics.MetricsRepository;
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
@@ -299,10 +301,13 @@ public class HelixParticipationService extends AbstractVeniceService
         veniceServerConfig.getPubSubClientsFactory().getProducerAdapterFactory();
     VeniceWriterFactory writerFactory =
         new VeniceWriterFactory(veniceProperties.toProperties(), pubSubProducerAdapterFactory, null);
+    Map<String, VeniceWriterFactory> veniceWriterFactoryMap = new HashMap<>();
+    veniceWriterFactoryMap.put(clusterName, writerFactory);
     statusStoreWriter = new PushStatusStoreWriter(
-        writerFactory,
+        veniceWriterFactoryMap,
         instance.getNodeId(),
-        veniceProperties.getInt(PUSH_STATUS_STORE_DERIVED_SCHEMA_ID, 1));
+        veniceProperties.getInt(PUSH_STATUS_STORE_DERIVED_SCHEMA_ID, 1),
+        s -> clusterName);
 
     // Record replica status in Zookeeper.
     // Need to be started before connecting to ZK, otherwise some notification will not be sent by this notifier.

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/helix/HelixParticipationService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/helix/HelixParticipationService.java
@@ -302,7 +302,7 @@ public class HelixParticipationService extends AbstractVeniceService
         veniceServerConfig.getPubSubClientsFactory().getProducerAdapterFactory();
     VeniceWriterFactory writerFactory =
         new VeniceWriterFactory(veniceProperties.toProperties(), pubSubProducerAdapterFactory, null);
-    Map<String, VeniceWriterFactory> veniceWriterFactoryMap = new HashMap<>();
+    Map<String, VeniceWriterFactory> veniceWriterFactoryMap = new HashMap<>(1);
     veniceWriterFactoryMap.put(clusterName, writerFactory);
     statusStoreWriter = new PushStatusStoreWriter(
         veniceWriterFactoryMap,

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -308,6 +308,8 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
   private final String[] msgForLagMeasurement;
   private final Runnable runnableForKillIngestionTasksForNonCurrentVersions;
 
+  protected final String clusterName;
+
   public StoreIngestionTask(
       StoreIngestionTaskFactory.Builder builder,
       Store store,
@@ -321,6 +323,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
       Queue<VeniceNotifier> notifiers) {
     this.readCycleDelayMs = storeConfig.getKafkaReadCycleDelayMs();
     this.emptyPollSleepMs = storeConfig.getKafkaEmptyPollSleepMs();
+    this.clusterName = storeConfig.getClusterName();
     this.databaseSyncBytesIntervalForTransactionalMode = storeConfig.getDatabaseSyncBytesIntervalForTransactionalMode();
     this.databaseSyncBytesIntervalForDeferredWriteMode = storeConfig.getDatabaseSyncBytesIntervalForDeferredWriteMode();
     this.kafkaProps = kafkaConsumerProperties;

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -308,8 +308,6 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
   private final String[] msgForLagMeasurement;
   private final Runnable runnableForKillIngestionTasksForNonCurrentVersions;
 
-  protected final String clusterName;
-
   public StoreIngestionTask(
       StoreIngestionTaskFactory.Builder builder,
       Store store,
@@ -323,7 +321,6 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
       Queue<VeniceNotifier> notifiers) {
     this.readCycleDelayMs = storeConfig.getKafkaReadCycleDelayMs();
     this.emptyPollSleepMs = storeConfig.getKafkaEmptyPollSleepMs();
-    this.clusterName = storeConfig.getClusterName();
     this.databaseSyncBytesIntervalForTransactionalMode = storeConfig.getDatabaseSyncBytesIntervalForTransactionalMode();
     this.databaseSyncBytesIntervalForDeferredWriteMode = storeConfig.getDatabaseSyncBytesIntervalForDeferredWriteMode();
     this.kafkaProps = kafkaConsumerProperties;

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/CachedPubSubMetadataGetterTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/CachedPubSubMetadataGetterTest.java
@@ -23,7 +23,6 @@ import org.testng.annotations.Test;
 
 public class CachedPubSubMetadataGetterTest {
   private final PubSubTopicRepository pubSubTopicRepository = new PubSubTopicRepository();
-  private final String clusterName = "testCluster";
 
   @Test
   public void testGetEarliestOffset() {

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/CachedPubSubMetadataGetterTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/CachedPubSubMetadataGetterTest.java
@@ -23,6 +23,7 @@ import org.testng.annotations.Test;
 
 public class CachedPubSubMetadataGetterTest {
   private final PubSubTopicRepository pubSubTopicRepository = new PubSubTopicRepository();
+  private final String clusterName = "testCluster";
 
   @Test
   public void testGetEarliestOffset() {

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
@@ -3522,6 +3522,7 @@ public abstract class StoreIngestionTaskTest {
     doReturn(databaseSyncBytesIntervalForDeferredWriteMode).when(storeConfig)
         .getDatabaseSyncBytesIntervalForDeferredWriteMode();
     doReturn(false).when(storeConfig).isReadOnlyForBatchOnlyStoreEnabled();
+    // doReturn(clusterName).when(storeConfig).getClusterName();
     storeVersionConfigOverride.accept(storeConfig);
     return storeConfig;
   }

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/AdminTool.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/AdminTool.java
@@ -1410,8 +1410,7 @@ public class AdminTool {
         .setTopicDeletionStatusPollIntervalMs(topicDeletionStatusPollingInterval)
         .setTopicMinLogCompactionLagMs(0L)
         .setLocalKafkaBootstrapServers(kafkaBootstrapServer)
-        .setPubSubConsumerAdapterFactory(PUB_SUB_CLIENTS_FACTORY.getConsumerAdapterFactory())
-        .setPubSubAdminAdapterFactory(PUB_SUB_CLIENTS_FACTORY.getAdminAdapterFactory())
+        .setDefaultPubSubClientsFactory(PUB_SUB_CLIENTS_FACTORY)
         .setPubSubTopicRepository(pubSubTopicRepository)
         .build()) {
       TopicManager topicManager = topicManagerRepository.getTopicManager();

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/input/kafka/KafkaInputDictTrainer.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/input/kafka/KafkaInputDictTrainer.java
@@ -45,7 +45,6 @@ public class KafkaInputDictTrainer {
     private final int compressionDictSize;
     private final int dictSampleSize;
     private final CompressionStrategy sourceVersionCompressionStrategy;
-
     private final boolean sourceVersionChunkingEnabled;
 
     Param(ParamBuilder builder) {

--- a/internal/venice-common/src/main/java/com/linkedin/venice/helix/HelixSchemaAccessor.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/helix/HelixSchemaAccessor.java
@@ -68,6 +68,10 @@ public class HelixSchemaAccessor {
     replicationMetadataSchemaAccessor = new ZkBaseDataAccessor<>(zkClient);
   }
 
+  public String getClusterName() {
+    return clusterName;
+  }
+
   private void registerSerializerForSchema(ZkClient zkClient, HelixAdapterSerializer adapter) {
     // Register schema serializer
     String keySchemaPath = getKeySchemaPath(PathResourceRegistry.WILDCARD_MATCH_ANY);

--- a/internal/venice-common/src/main/java/com/linkedin/venice/kafka/TopicManagerRepository.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/kafka/TopicManagerRepository.java
@@ -6,10 +6,12 @@ import static com.linkedin.venice.kafka.TopicManager.DEFAULT_KAFKA_OPERATION_TIM
 
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.pubsub.PubSubAdminAdapterFactory;
+import com.linkedin.venice.pubsub.PubSubClientsFactory;
 import com.linkedin.venice.pubsub.PubSubConsumerAdapterFactory;
 import com.linkedin.venice.pubsub.PubSubTopicRepository;
 import com.linkedin.venice.pubsub.api.PubSubAdminAdapter;
 import com.linkedin.venice.pubsub.api.PubSubConsumerAdapter;
+import com.linkedin.venice.pubsub.api.PubSubTopic;
 import com.linkedin.venice.utils.VeniceProperties;
 import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
 import com.linkedin.venice.utils.lazy.Lazy;
@@ -82,9 +84,11 @@ public class TopicManagerRepository implements Closeable {
     private long topicMinLogCompactionLagMs = DEFAULT_KAFKA_MIN_LOG_COMPACTION_LAG_MS;
     private PubSubAdminAdapterFactory<PubSubAdminAdapter> pubSubAdminAdapterFactory;
     private PubSubConsumerAdapterFactory<PubSubConsumerAdapter> pubSubConsumerAdapterFactory;
+    private Map<String, PubSubClientsFactory> pubSubClientsFactoryMap;
     private PubSubTopicRepository pubSubTopicRepository;
     private MetricsRepository metricsRepository;
     private SSLPropertiesSupplier pubSubProperties;
+    private ClusterNameSupplier clusterNameSupplier;
 
     private interface Setter {
       void apply();
@@ -135,8 +139,16 @@ public class TopicManagerRepository implements Closeable {
       return pubSubConsumerAdapterFactory;
     }
 
+    public Map<String, PubSubClientsFactory> getPubSubClientsFactoryMap() {
+      return pubSubClientsFactoryMap;
+    }
+
     public SSLPropertiesSupplier getPubSubProperties() {
       return pubSubProperties;
+    }
+
+    public ClusterNameSupplier getClusterNameSupplier() {
+      return clusterNameSupplier;
     }
 
     public Builder setLocalKafkaBootstrapServers(String localKafkaBootstrapServers) {
@@ -173,12 +185,24 @@ public class TopicManagerRepository implements Closeable {
       return set(() -> this.pubSubConsumerAdapterFactory = pubSubConsumerAdapterFactory);
     }
 
+    public Builder setPubSubClientsFactoryMap(Map<String, PubSubClientsFactory> pubSubClientsFactoryMap) {
+      return set(() -> this.pubSubClientsFactoryMap = pubSubClientsFactoryMap);
+    }
+
     public Builder setPubSubProperties(SSLPropertiesSupplier pubSubProperties) {
       return set(() -> this.pubSubProperties = pubSubProperties);
+    }
+
+    public Builder setClusterNameSupplier(ClusterNameSupplier clusterNameSupplier) {
+      return set(() -> this.clusterNameSupplier = clusterNameSupplier);
     }
   }
 
   public interface SSLPropertiesSupplier {
     VeniceProperties get(String pubSubBootstrapServers);
+  }
+
+  public interface ClusterNameSupplier {
+    String get(PubSubTopic pubSubTopic);
   }
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/kafka/TopicManagerRepository.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/kafka/TopicManagerRepository.java
@@ -5,12 +5,8 @@ import static com.linkedin.venice.kafka.TopicManager.DEFAULT_KAFKA_MIN_LOG_COMPA
 import static com.linkedin.venice.kafka.TopicManager.DEFAULT_KAFKA_OPERATION_TIMEOUT_MS;
 
 import com.linkedin.venice.exceptions.VeniceException;
-import com.linkedin.venice.pubsub.PubSubAdminAdapterFactory;
 import com.linkedin.venice.pubsub.PubSubClientsFactory;
-import com.linkedin.venice.pubsub.PubSubConsumerAdapterFactory;
 import com.linkedin.venice.pubsub.PubSubTopicRepository;
-import com.linkedin.venice.pubsub.api.PubSubAdminAdapter;
-import com.linkedin.venice.pubsub.api.PubSubConsumerAdapter;
 import com.linkedin.venice.pubsub.api.PubSubTopic;
 import com.linkedin.venice.utils.VeniceProperties;
 import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
@@ -18,6 +14,7 @@ import com.linkedin.venice.utils.lazy.Lazy;
 import io.tehuti.metrics.MetricsRepository;
 import java.io.Closeable;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import org.apache.logging.log4j.LogManager;
@@ -82,8 +79,7 @@ public class TopicManagerRepository implements Closeable {
     private long kafkaOperationTimeoutMs = DEFAULT_KAFKA_OPERATION_TIMEOUT_MS;
     private long topicDeletionStatusPollIntervalMs = DEFAULT_TOPIC_DELETION_STATUS_POLL_INTERVAL_MS;
     private long topicMinLogCompactionLagMs = DEFAULT_KAFKA_MIN_LOG_COMPACTION_LAG_MS;
-    private PubSubAdminAdapterFactory<PubSubAdminAdapter> pubSubAdminAdapterFactory;
-    private PubSubConsumerAdapterFactory<PubSubConsumerAdapter> pubSubConsumerAdapterFactory;
+    private PubSubClientsFactory defaultPubSubClientsFactory;
     private Map<String, PubSubClientsFactory> pubSubClientsFactoryMap;
     private PubSubTopicRepository pubSubTopicRepository;
     private MetricsRepository metricsRepository;
@@ -131,16 +127,12 @@ public class TopicManagerRepository implements Closeable {
       return pubSubTopicRepository;
     }
 
-    public PubSubAdminAdapterFactory<PubSubAdminAdapter> getPubSubAdminAdapterFactory() {
-      return pubSubAdminAdapterFactory;
-    }
-
-    public PubSubConsumerAdapterFactory<PubSubConsumerAdapter> getPubSubConsumerAdapterFactory() {
-      return pubSubConsumerAdapterFactory;
-    }
-
     public Map<String, PubSubClientsFactory> getPubSubClientsFactoryMap() {
       return pubSubClientsFactoryMap;
+    }
+
+    public PubSubClientsFactory getPubSubClientsFactory() {
+      return defaultPubSubClientsFactory;
     }
 
     public SSLPropertiesSupplier getPubSubProperties() {
@@ -175,14 +167,8 @@ public class TopicManagerRepository implements Closeable {
       return set(() -> this.pubSubTopicRepository = pubSubTopicRepository);
     }
 
-    public Builder setPubSubAdminAdapterFactory(
-        PubSubAdminAdapterFactory<PubSubAdminAdapter> pubSubAdminAdapterFactory) {
-      return set(() -> this.pubSubAdminAdapterFactory = pubSubAdminAdapterFactory);
-    }
-
-    public Builder setPubSubConsumerAdapterFactory(
-        PubSubConsumerAdapterFactory<PubSubConsumerAdapter> pubSubConsumerAdapterFactory) {
-      return set(() -> this.pubSubConsumerAdapterFactory = pubSubConsumerAdapterFactory);
+    public Builder setDefaultPubSubClientsFactory(PubSubClientsFactory pubSubClientsFactory) {
+      return set(() -> this.defaultPubSubClientsFactory = pubSubClientsFactory);
     }
 
     public Builder setPubSubClientsFactoryMap(Map<String, PubSubClientsFactory> pubSubClientsFactoryMap) {
@@ -203,6 +189,6 @@ public class TopicManagerRepository implements Closeable {
   }
 
   public interface ClusterNameSupplier {
-    String get(PubSubTopic pubSubTopic);
+    Optional<String> get(PubSubTopic pubSubTopic);
   }
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/kafka/partitionoffset/PartitionOffsetFetcherFactory.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/kafka/partitionoffset/PartitionOffsetFetcherFactory.java
@@ -1,6 +1,8 @@
 package com.linkedin.venice.kafka.partitionoffset;
 
-import com.linkedin.venice.kafka.TopicManager;
+import com.linkedin.venice.pubsub.api.PubSubAdminAdapter;
+import com.linkedin.venice.pubsub.api.PubSubConsumerAdapter;
+import com.linkedin.venice.pubsub.api.PubSubTopic;
 import com.linkedin.venice.utils.SystemTime;
 import io.tehuti.metrics.MetricsRepository;
 import java.util.Optional;
@@ -8,8 +10,8 @@ import java.util.Optional;
 
 public class PartitionOffsetFetcherFactory {
   public static PartitionOffsetFetcher createDefaultPartitionOffsetFetcher(
-      TopicManager.ConsumerSupplier consumerSupplier,
-      TopicManager.AdminSupplier adminSupplier,
+      ConsumerSupplier consumerSupplier,
+      AdminSupplier adminSupplier,
       String pubSubBootstrapServers,
       long kafkaOperationTimeoutMs,
       Optional<MetricsRepository> optionalMetricsRepository) {
@@ -28,5 +30,13 @@ public class PartitionOffsetFetcherFactory {
     } else {
       return partitionOffsetFetcher;
     }
+  }
+
+  public interface AdminSupplier {
+    PubSubAdminAdapter get(PubSubTopic pubSubTopic);
+  }
+
+  public interface ConsumerSupplier {
+    PubSubConsumerAdapter get(PubSubTopic pubSubTopic);
   }
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/kafka/partitionoffset/PartitionOffsetFetcherFactory.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/kafka/partitionoffset/PartitionOffsetFetcherFactory.java
@@ -1,35 +1,21 @@
 package com.linkedin.venice.kafka.partitionoffset;
 
-import com.linkedin.venice.kafka.protocol.KafkaMessageEnvelope;
-import com.linkedin.venice.pubsub.PubSubConsumerAdapterFactory;
-import com.linkedin.venice.pubsub.api.PubSubAdminAdapter;
-import com.linkedin.venice.pubsub.api.PubSubMessageDeserializer;
-import com.linkedin.venice.serialization.avro.KafkaValueSerializer;
+import com.linkedin.venice.kafka.TopicManager;
 import com.linkedin.venice.utils.SystemTime;
-import com.linkedin.venice.utils.VeniceProperties;
-import com.linkedin.venice.utils.lazy.Lazy;
-import com.linkedin.venice.utils.pools.LandFillObjectPool;
 import io.tehuti.metrics.MetricsRepository;
 import java.util.Optional;
 
 
 public class PartitionOffsetFetcherFactory {
   public static PartitionOffsetFetcher createDefaultPartitionOffsetFetcher(
-      PubSubConsumerAdapterFactory pubSubConsumerAdapterFactory,
-      VeniceProperties veniceProperties,
+      TopicManager.ConsumerSupplier consumerSupplier,
+      TopicManager.AdminSupplier adminSupplier,
       String pubSubBootstrapServers,
-      Lazy<PubSubAdminAdapter> kafkaAdminWrapper,
       long kafkaOperationTimeoutMs,
       Optional<MetricsRepository> optionalMetricsRepository) {
-    PubSubMessageDeserializer pubSubMessageDeserializer = new PubSubMessageDeserializer(
-        new KafkaValueSerializer(),
-        new LandFillObjectPool<>(KafkaMessageEnvelope::new),
-        new LandFillObjectPool<>(KafkaMessageEnvelope::new));
     PartitionOffsetFetcher partitionOffsetFetcher = new PartitionOffsetFetcherImpl(
-        kafkaAdminWrapper,
-        Lazy.of(
-            () -> pubSubConsumerAdapterFactory
-                .create(veniceProperties, false, pubSubMessageDeserializer, pubSubBootstrapServers)),
+        consumerSupplier,
+        adminSupplier,
         kafkaOperationTimeoutMs,
         pubSubBootstrapServers);
     if (optionalMetricsRepository.isPresent()) {

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pushstatushelper/PushStatusStoreRecordDeleter.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pushstatushelper/PushStatusStoreRecordDeleter.java
@@ -6,6 +6,7 @@ import com.linkedin.venice.pushstatus.PushStatusKey;
 import com.linkedin.venice.utils.LatencyUtils;
 import com.linkedin.venice.writer.VeniceWriter;
 import com.linkedin.venice.writer.VeniceWriterFactory;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.Future;
 import org.apache.logging.log4j.LogManager;
@@ -19,8 +20,10 @@ public class PushStatusStoreRecordDeleter implements AutoCloseable {
   private static final Logger LOGGER = LogManager.getLogger(PushStatusStoreRecordDeleter.class);
   private final PushStatusStoreVeniceWriterCache veniceWriterCache;
 
-  public PushStatusStoreRecordDeleter(VeniceWriterFactory veniceWriterFactory) {
-    this.veniceWriterCache = new PushStatusStoreVeniceWriterCache(veniceWriterFactory);
+  public PushStatusStoreRecordDeleter(
+      Map<String, VeniceWriterFactory> writerFactoryMap,
+      PushStatusStoreWriter.ClusterNameSupplier clusterNameSupplier) {
+    this.veniceWriterCache = new PushStatusStoreVeniceWriterCache(writerFactoryMap, clusterNameSupplier);
   }
 
   public void deletePushStatus(

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pushstatushelper/PushStatusStoreWriter.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pushstatushelper/PushStatusStoreWriter.java
@@ -176,6 +176,6 @@ public class PushStatusStoreWriter implements AutoCloseable {
   }
 
   public interface ClusterNameSupplier {
-    String get(PubSubTopic pubSubTopic);
+    Optional<String> get(PubSubTopic pubSubTopic);
   }
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pushstatushelper/PushStatusStoreWriter.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pushstatushelper/PushStatusStoreWriter.java
@@ -1,6 +1,7 @@
 package com.linkedin.venice.pushstatushelper;
 
 import com.linkedin.venice.common.PushStatusStoreUtils;
+import com.linkedin.venice.pubsub.api.PubSubTopic;
 import com.linkedin.venice.pushmonitor.ExecutionStatus;
 import com.linkedin.venice.pushstatus.NoOp;
 import com.linkedin.venice.pushstatus.PushStatusKey;
@@ -11,6 +12,7 @@ import com.linkedin.venice.serialization.avro.AvroProtocolDefinition;
 import com.linkedin.venice.writer.VeniceWriter;
 import com.linkedin.venice.writer.VeniceWriterFactory;
 import java.util.Collections;
+import java.util.Map;
 import java.util.Optional;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -29,12 +31,16 @@ public class PushStatusStoreWriter implements AutoCloseable {
   private final int derivedSchemaId;
 
   /**
-   * @param writerFactory Used for instantiate veniceWriterCache
+   * @param writerFactoryMap Used for instantiate veniceWriterCache
    * @param instanceName format = hostAddress,appName
    * @param derivedSchemaId writeCompute schema for updating push status
    */
-  public PushStatusStoreWriter(VeniceWriterFactory writerFactory, String instanceName, int derivedSchemaId) {
-    this(new PushStatusStoreVeniceWriterCache(writerFactory), instanceName, derivedSchemaId);
+  public PushStatusStoreWriter(
+      Map<String, VeniceWriterFactory> writerFactoryMap,
+      String instanceName,
+      int derivedSchemaId,
+      ClusterNameSupplier clusterNameSupplier) {
+    this(new PushStatusStoreVeniceWriterCache(writerFactoryMap, clusterNameSupplier), instanceName, derivedSchemaId);
   }
 
   PushStatusStoreWriter(PushStatusStoreVeniceWriterCache veniceWriterCache, String instanceName, int derivedSchemaId) {
@@ -167,5 +173,9 @@ public class PushStatusStoreWriter implements AutoCloseable {
   @Override
   public void close() {
     veniceWriterCache.close();
+  }
+
+  public interface ClusterNameSupplier {
+    String get(PubSubTopic pubSubTopic);
   }
 }

--- a/internal/venice-common/src/test/java/com/linkedin/venice/system/store/MetaStoreWriterTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/system/store/MetaStoreWriterTest.java
@@ -25,6 +25,7 @@ public class MetaStoreWriterTest {
   public void testMetaStoreWriterWillRestartUponProduceFailure() {
     MetaStoreWriter metaStoreWriter = mock(MetaStoreWriter.class);
     String metaStoreName = "testStore";
+    String clusterName = "test_cluster";
     ReentrantLock reentrantLock = new ReentrantLock();
     when(metaStoreWriter.getOrCreateMetaStoreWriterLock(metaStoreName)).thenReturn(reentrantLock);
     VeniceWriter badWriter = mock(VeniceWriter.class);

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/AbstractTestVeniceHelixAdmin.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/AbstractTestVeniceHelixAdmin.java
@@ -110,8 +110,7 @@ class AbstractTestVeniceHelixAdmin {
         multiClusterConfig,
         metricsRepository,
         D2TestUtils.getAndStartD2Client(zkAddress),
-        pubSubTopicRepository,
-        pubSubBrokerWrapper.getPubSubClientsFactory());
+        pubSubTopicRepository);
     veniceAdmin.initStorageCluster(clusterName);
     startParticipant();
     waitUntilIsLeader(veniceAdmin, clusterName, LEADER_CHANGE_TIMEOUT_MS);

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestClusterLevelConfigForActiveActiveReplication.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestClusterLevelConfigForActiveActiveReplication.java
@@ -221,8 +221,7 @@ public class TestClusterLevelConfigForActiveActiveReplication extends AbstractTe
             new VeniceControllerConfig(new VeniceProperties(controllerProperties))),
         new MetricsRepository(),
         D2TestUtils.getAndStartD2Client(zkAddress),
-        pubSubTopicRepository,
-        pubSubBrokerWrapper.getPubSubClientsFactory());
+        pubSubTopicRepository);
 
     veniceAdmin.initStorageCluster(clusterName);
     TopicManagerRepository originalTopicManagerRepository = veniceAdmin.getTopicManagerRepository();

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestDeleteStoreDeletesRealtimeTopic.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestDeleteStoreDeletesRealtimeTopic.java
@@ -46,6 +46,7 @@ public class TestDeleteStoreDeletesRealtimeTopic {
   private String storeName = null;
 
   private PubSubTopicRepository pubSubTopicRepository = new PubSubTopicRepository();
+  private String clusterName;
 
   @BeforeClass
   public void setUp() {
@@ -53,12 +54,15 @@ public class TestDeleteStoreDeletesRealtimeTopic {
     controllerClient =
         ControllerClient.constructClusterControllerClient(venice.getClusterName(), venice.getRandomRouterURL());
 
+    clusterName = venice.getClusterName();
+
     try (TopicManagerRepository topicManagerRepository = IntegrationTestPushUtils.getTopicManagerRepo(
         DEFAULT_KAFKA_OPERATION_TIMEOUT_MS,
         100,
         0l,
         venice.getPubSubBrokerWrapper(),
-        pubSubTopicRepository)) {
+        pubSubTopicRepository,
+        clusterName)) {
       topicManager = topicManagerRepository.getTopicManager();
     }
 

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestTopicRequestOnHybridDelete.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestTopicRequestOnHybridDelete.java
@@ -190,7 +190,8 @@ public class TestTopicRequestOnHybridDelete {
         100,
         0l,
         venice.getPubSubBrokerWrapper(),
-        pubSubTopicRepository)) {
+        pubSubTopicRepository,
+        venice.getClusterName())) {
 
       TopicManager topicManager = topicManagerRepository.getTopicManager();
 

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestVeniceHelixAdminWithIsolatedEnvironment.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestVeniceHelixAdminWithIsolatedEnvironment.java
@@ -64,8 +64,7 @@ public class TestVeniceHelixAdminWithIsolatedEnvironment extends AbstractTestVen
         TestUtils.getMultiClusterConfigFromOneCluster(newConfig),
         new MetricsRepository(),
         D2TestUtils.getAndStartD2Client(zkAddress),
-        pubSubTopicRepository,
-        pubSubBrokerWrapper.getPubSubClientsFactory());
+        pubSubTopicRepository);
     // Start stand by controller
     newAdmin.initStorageCluster(clusterName);
     List<VeniceHelixAdmin> allAdmins = new ArrayList<>();
@@ -318,8 +317,7 @@ public class TestVeniceHelixAdminWithIsolatedEnvironment extends AbstractTestVen
         TestUtils.getMultiClusterConfigFromOneCluster(newConfig),
         new MetricsRepository(),
         D2TestUtils.getAndStartD2Client(zkAddress),
-        pubSubTopicRepository,
-        pubSubBrokerWrapper.getPubSubClientsFactory());
+        pubSubTopicRepository);
     newLeaderAdmin.initStorageCluster(clusterName);
     List<VeniceHelixAdmin> admins = new ArrayList<>();
     admins.add(veniceAdmin);

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestVeniceHelixAdminWithSharedEnvironment.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestVeniceHelixAdminWithSharedEnvironment.java
@@ -148,8 +148,7 @@ public class TestVeniceHelixAdminWithSharedEnvironment extends AbstractTestVenic
         TestUtils.getMultiClusterConfigFromOneCluster(newConfig),
         new MetricsRepository(),
         D2TestUtils.getAndStartD2Client(zkAddress),
-        pubSubTopicRepository,
-        pubSubBrokerWrapper.getPubSubClientsFactory());
+        pubSubTopicRepository);
     // Start stand by controller
     newLeaderAdmin.initStorageCluster(clusterName);
     Assert.assertFalse(

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/kafka/consumer/AdminConsumptionTaskIntegrationTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/kafka/consumer/AdminConsumptionTaskIntegrationTest.java
@@ -65,7 +65,8 @@ public class AdminConsumptionTaskIntegrationTest {
                     100,
                     0l,
                     pubSubBrokerWrapper,
-                    pubSubTopicRepository)
+                    pubSubTopicRepository,
+                    clusterName)
                 .getTopicManager()) {
       PubSubTopic adminTopic = pubSubTopicRepository.getTopic(AdminTopicUtils.getTopicNameFromClusterName(clusterName));
       topicManager.createTopic(adminTopic, 1, 1, true);

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/PushStatusStoreTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/PushStatusStoreTest.java
@@ -271,7 +271,7 @@ public class PushStatusStoreTest {
 
         Map<String, VeniceWriterFactory> writerFactoryMap = Collections.singletonMap(
             clusterName,
-            cluster.getLeaderVeniceController().getVeniceHelixAdmin().getVeniceWriterFactory());
+            cluster.getLeaderVeniceController().getVeniceHelixAdmin().getVeniceWriterFactory(clusterName));
         PushStatusStoreRecordDeleter statusStoreDeleter =
             new PushStatusStoreRecordDeleter(writerFactoryMap, s -> Optional.of(clusterName));
 

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/PushStatusStoreTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/PushStatusStoreTest.java
@@ -273,7 +273,7 @@ public class PushStatusStoreTest {
             clusterName,
             cluster.getLeaderVeniceController().getVeniceHelixAdmin().getVeniceWriterFactory());
         PushStatusStoreRecordDeleter statusStoreDeleter =
-            new PushStatusStoreRecordDeleter(writerFactoryMap, s -> clusterName);
+            new PushStatusStoreRecordDeleter(writerFactoryMap, s -> Optional.of(clusterName));
 
         // After deleting the inc push status belonging to just one partition we should expect
         // SOIP from the controller since other partition has replicas with EOIP status

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestEmptyPush.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestEmptyPush.java
@@ -111,7 +111,8 @@ public class TestEmptyPush {
                     100,
                     0l,
                     venice.getPubSubBrokerWrapper(),
-                    venice.getPubSubTopicRepository())
+                    venice.getPubSubTopicRepository(),
+                    venice.getClusterName())
                 .getTopicManager()) {
       controllerClient.createNewStore(storeName, "owner", STRING_SCHEMA, STRING_SCHEMA);
       controllerClient.updateStore(

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestHybrid.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestHybrid.java
@@ -202,7 +202,8 @@ public class TestHybrid {
                     100,
                     0l,
                     venice.getPubSubBrokerWrapper(),
-                    venice.getPubSubTopicRepository())
+                    venice.getPubSubTopicRepository(),
+                    venice.getClusterName())
                 .getTopicManager()) {
       long streamingRewindSeconds = 25L;
       long streamingMessageLag = 2L;
@@ -335,7 +336,8 @@ public class TestHybrid {
                       100,
                       0l,
                       venice.getPubSubBrokerWrapper(),
-                      sharedVenice.getPubSubTopicRepository())
+                      sharedVenice.getPubSubTopicRepository(),
+                      venice.getClusterName())
                   .getTopicManager()) {
 
         Cache cacheNothingCache = Mockito.mock(Cache.class);
@@ -1169,7 +1171,8 @@ public class TestHybrid {
                       100L,
                       MIN_COMPACTION_LAG,
                       venice.getPubSubBrokerWrapper(),
-                      sharedVenice.getPubSubTopicRepository())
+                      sharedVenice.getPubSubTopicRepository(),
+                      venice.getClusterName())
                   .getTopicManager()) {
 
         ControllerResponse response = controllerClient.updateStore(

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestHybridQuota.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestHybridQuota.java
@@ -138,7 +138,8 @@ public class TestHybridQuota {
                     100L,
                     0L,
                     sharedVenice.getPubSubBrokerWrapper(),
-                    sharedVenice.getPubSubTopicRepository())
+                    sharedVenice.getPubSubTopicRepository(),
+                    sharedVenice.getClusterName())
                 .getTopicManager()) {
 
       // Setting the hybrid store quota here will cause the VPJ push failed.

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestMultiDataCenterAdminOperations.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestMultiDataCenterAdminOperations.java
@@ -144,7 +144,7 @@ public class TestMultiDataCenterAdminOperations {
     VeniceControllerWrapper parentController =
         multiRegionMultiClusterWrapper.getLeaderParentControllerWithRetries(clusterName);
     Admin admin = parentController.getVeniceAdmin();
-    VeniceWriterFactory veniceWriterFactory = admin.getVeniceWriterFactory();
+    VeniceWriterFactory veniceWriterFactory = admin.getVeniceWriterFactory(clusterName);
     VeniceWriter<byte[], byte[], byte[]> veniceWriter = veniceWriterFactory.createVeniceWriter(
         new VeniceWriterOptions.Builder(AdminTopicUtils.getTopicNameFromClusterName(clusterName)).build());
     AdminOperationSerializer adminOperationSerializer = new AdminOperationSerializer();

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestPushJobWithNativeReplication.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestPushJobWithNativeReplication.java
@@ -781,7 +781,7 @@ public class TestPushJobWithNativeReplication {
             incPushToRTWriter = startIncrementalPush(
                 parentControllerClient,
                 storeName,
-                parentController.getVeniceAdmin().getVeniceWriterFactory(),
+                parentController.getVeniceAdmin().getVeniceWriterFactory(clusterName),
                 incPushToRTVersion);
             final String newVersionTopic = Version.composeKafkaTopic(
                 storeName,

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/hadoop/input/kafka/TestKafkaInputFormat.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/hadoop/input/kafka/TestKafkaInputFormat.java
@@ -37,6 +37,7 @@ public class TestKafkaInputFormat {
   private PubSubBrokerWrapper pubSubBrokerWrapper;
   private TopicManager manager;
   private PubSubTopicRepository pubSubTopicRepository = new PubSubTopicRepository();
+  private String clusterName = "test_cluster";
 
   @BeforeClass
   public void setUp() {
@@ -48,7 +49,8 @@ public class TestKafkaInputFormat {
                 100L,
                 24 * Time.MS_PER_HOUR,
                 pubSubBrokerWrapper,
-                pubSubTopicRepository)
+                pubSubTopicRepository,
+                clusterName)
             .getTopicManager();
   }
 

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/hadoop/input/kafka/TestKafkaInputRecordReader.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/hadoop/input/kafka/TestKafkaInputRecordReader.java
@@ -37,6 +37,8 @@ public class TestKafkaInputRecordReader {
   private TopicManager manager;
   private PubSubTopicRepository pubSubTopicRepository = new PubSubTopicRepository();
 
+  private String clusterName = "test_cluster";
+
   @BeforeClass
   public void setUp() {
     pubSubBrokerWrapper = ServiceFactory.getPubSubBroker();
@@ -47,7 +49,8 @@ public class TestKafkaInputRecordReader {
                 100L,
                 24 * Time.MS_PER_HOUR,
                 pubSubBrokerWrapper,
-                pubSubTopicRepository)
+                pubSubTopicRepository,
+                clusterName)
             .getTopicManager();
   }
 

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/kafka/KafkaConsumptionTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/kafka/KafkaConsumptionTest.java
@@ -78,6 +78,8 @@ public class KafkaConsumptionTest {
   private TestMockTime remoteMockTime;
   private PubSubTopic versionTopic;
 
+  private String clusterName = "test_cluster";
+
   private PubSubTopic getTopic() {
     String callingFunction = Thread.currentThread().getStackTrace()[2].getMethodName();
     PubSubTopic versionTopic = pubSubTopicRepository.getTopic(TestUtils.getUniqueTopicString(callingFunction));
@@ -108,7 +110,8 @@ public class KafkaConsumptionTest {
                 100L,
                 MIN_COMPACTION_LAG,
                 localPubSubBroker,
-                pubSubTopicRepository)
+                pubSubTopicRepository,
+                clusterName)
             .getTopicManager();
     Cache cacheNothingCache = mock(Cache.class);
     Mockito.when(cacheNothingCache.getIfPresent(Mockito.any())).thenReturn(null);
@@ -124,7 +127,8 @@ public class KafkaConsumptionTest {
                 100L,
                 MIN_COMPACTION_LAG,
                 remotePubSubBroker,
-                pubSubTopicRepository)
+                pubSubTopicRepository,
+                clusterName)
             .getTopicManager();
     Cache remoteCacheNothingCache = mock(Cache.class);
     Mockito.when(remoteCacheNothingCache.getIfPresent(Mockito.any())).thenReturn(null);

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/kafka/TopicManagerIntegrationTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/kafka/TopicManagerIntegrationTest.java
@@ -39,7 +39,7 @@ public class TopicManagerIntegrationTest extends TopicManagerTest {
     topicManager =
         IntegrationTestPushUtils
             .getTopicManagerRepo(
-                500L,
+                1000L,
                 100L,
                 MIN_COMPACTION_LAG,
                 pubSubBrokerWrapper,

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/kafka/TopicManagerIntegrationTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/kafka/TopicManagerIntegrationTest.java
@@ -36,9 +36,16 @@ public class TopicManagerIntegrationTest extends TopicManagerTest {
     TestMockTime mockTime = new TestMockTime();
     pubSubBrokerWrapper = ServiceFactory.getPubSubBroker(
         new PubSubBrokerConfigs.Builder().setMockTime(mockTime).setRegionName(STANDALONE_REGION_NAME).build());
-    topicManager = IntegrationTestPushUtils
-        .getTopicManagerRepo(500L, 100L, MIN_COMPACTION_LAG, pubSubBrokerWrapper, new PubSubTopicRepository())
-        .getTopicManager();
+    topicManager =
+        IntegrationTestPushUtils
+            .getTopicManagerRepo(
+                500L,
+                100L,
+                MIN_COMPACTION_LAG,
+                pubSubBrokerWrapper,
+                new PubSubTopicRepository(),
+                clusterName)
+            .getTopicManager();
   }
 
   protected PubSubProducerAdapter createPubSubProducerAdapter() {

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/utils/IntegrationTestPushUtils.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/utils/IntegrationTestPushUtils.java
@@ -376,20 +376,19 @@ public class IntegrationTestPushUtils {
     String pubSubBootstrapServers = pubSubBrokerWrapper.getAddress();
     properties.putAll(PubSubBrokerWrapper.getBrokerDetailsForClients(Collections.singletonList(pubSubBrokerWrapper)));
     properties.put(KAFKA_BOOTSTRAP_SERVERS, pubSubBootstrapServers);
-    Map<String, PubSubClientsFactory> pubSubClientsFactoryMap = new HashMap<>();
-    pubSubClientsFactoryMap.put(clusterName, pubSubBrokerWrapper.getPubSubClientsFactory());
+    Map<String, PubSubClientsFactory> pubSubClientsFactoryMap =
+        Collections.singletonMap(clusterName, pubSubBrokerWrapper.getPubSubClientsFactory());
 
     return TopicManagerRepository.builder()
         .setPubSubProperties(k -> new VeniceProperties(properties))
         .setPubSubTopicRepository(pubSubTopicRepository)
         .setLocalKafkaBootstrapServers(pubSubBootstrapServers)
-        .setPubSubConsumerAdapterFactory(pubSubBrokerWrapper.getPubSubClientsFactory().getConsumerAdapterFactory())
-        .setPubSubAdminAdapterFactory(pubSubBrokerWrapper.getPubSubClientsFactory().getAdminAdapterFactory())
+        .setDefaultPubSubClientsFactory(pubSubBrokerWrapper.getPubSubClientsFactory())
         .setPubSubClientsFactoryMap(pubSubClientsFactoryMap)
         .setKafkaOperationTimeoutMs(kafkaOperationTimeoutMs)
         .setTopicDeletionStatusPollIntervalMs(topicDeletionStatusPollIntervalMs)
         .setTopicMinLogCompactionLagMs(topicMinLogCompactionLagMs)
-        .setClusterNameSupplier(s -> clusterName)
+        .setClusterNameSupplier(s -> Optional.of(clusterName))
         .build();
   }
 

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/utils/IntegrationTestPushUtils.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/utils/IntegrationTestPushUtils.java
@@ -40,8 +40,8 @@ import com.linkedin.venice.integration.utils.VeniceTwoLayerMultiRegionMultiClust
 import com.linkedin.venice.kafka.TopicManagerRepository;
 import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.Version;
-import com.linkedin.venice.pubsub.PubSubProducerAdapterFactory;
 import com.linkedin.venice.pubsub.PubSubClientsFactory;
+import com.linkedin.venice.pubsub.PubSubProducerAdapterFactory;
 import com.linkedin.venice.pubsub.PubSubTopicRepository;
 import com.linkedin.venice.samza.VeniceObjectWithTimestamp;
 import com.linkedin.venice.samza.VeniceSystemFactory;

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/utils/IntegrationTestPushUtils.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/utils/IntegrationTestPushUtils.java
@@ -41,6 +41,7 @@ import com.linkedin.venice.kafka.TopicManagerRepository;
 import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.pubsub.PubSubProducerAdapterFactory;
+import com.linkedin.venice.pubsub.PubSubClientsFactory;
 import com.linkedin.venice.pubsub.PubSubTopicRepository;
 import com.linkedin.venice.samza.VeniceObjectWithTimestamp;
 import com.linkedin.venice.samza.VeniceSystemFactory;
@@ -369,20 +370,26 @@ public class IntegrationTestPushUtils {
       long topicDeletionStatusPollIntervalMs,
       long topicMinLogCompactionLagMs,
       PubSubBrokerWrapper pubSubBrokerWrapper,
-      PubSubTopicRepository pubSubTopicRepository) {
+      PubSubTopicRepository pubSubTopicRepository,
+      String clusterName) {
     Properties properties = new Properties();
     String pubSubBootstrapServers = pubSubBrokerWrapper.getAddress();
     properties.putAll(PubSubBrokerWrapper.getBrokerDetailsForClients(Collections.singletonList(pubSubBrokerWrapper)));
     properties.put(KAFKA_BOOTSTRAP_SERVERS, pubSubBootstrapServers);
+    Map<String, PubSubClientsFactory> pubSubClientsFactoryMap = new HashMap<>();
+    pubSubClientsFactoryMap.put(clusterName, pubSubBrokerWrapper.getPubSubClientsFactory());
+
     return TopicManagerRepository.builder()
         .setPubSubProperties(k -> new VeniceProperties(properties))
         .setPubSubTopicRepository(pubSubTopicRepository)
         .setLocalKafkaBootstrapServers(pubSubBootstrapServers)
         .setPubSubConsumerAdapterFactory(pubSubBrokerWrapper.getPubSubClientsFactory().getConsumerAdapterFactory())
         .setPubSubAdminAdapterFactory(pubSubBrokerWrapper.getPubSubClientsFactory().getAdminAdapterFactory())
+        .setPubSubClientsFactoryMap(pubSubClientsFactoryMap)
         .setKafkaOperationTimeoutMs(kafkaOperationTimeoutMs)
         .setTopicDeletionStatusPollIntervalMs(topicDeletionStatusPollIntervalMs)
         .setTopicMinLogCompactionLagMs(topicMinLogCompactionLagMs)
+        .setClusterNameSupplier(s -> clusterName)
         .build();
   }
 

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/utils/TestDictionaryUtils.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/utils/TestDictionaryUtils.java
@@ -41,6 +41,8 @@ public class TestDictionaryUtils {
   private PubSubProducerAdapterFactory pubSubProducerAdapterFactory;
   private final PubSubTopicRepository pubSubTopicRepository = new PubSubTopicRepository();
 
+  private final String clusterName = "test_cluster";
+
   private String getTopic() {
     String callingFunction = Thread.currentThread().getStackTrace()[2].getMethodName();
     PubSubTopic pubSubTopic =
@@ -73,7 +75,8 @@ public class TestDictionaryUtils {
                 100,
                 MIN_COMPACTION_LAG,
                 pubSubBrokerWrapper,
-                pubSubTopicRepository)
+                pubSubTopicRepository,
+                clusterName)
             .getTopicManager();
     pubSubProducerAdapterFactory = pubSubBrokerWrapper.getPubSubClientsFactory().getProducerAdapterFactory();
   }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/utils/TestDictionaryUtils.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/utils/TestDictionaryUtils.java
@@ -41,8 +41,6 @@ public class TestDictionaryUtils {
   private PubSubProducerAdapterFactory pubSubProducerAdapterFactory;
   private final PubSubTopicRepository pubSubTopicRepository = new PubSubTopicRepository();
 
-  private final String clusterName = "test_cluster";
-
   private String getTopic() {
     String callingFunction = Thread.currentThread().getStackTrace()[2].getMethodName();
     PubSubTopic pubSubTopic =
@@ -68,6 +66,7 @@ public class TestDictionaryUtils {
     mockTime = new TestMockTime();
     pubSubBrokerWrapper = ServiceFactory.getPubSubBroker(
         new PubSubBrokerConfigs.Builder().setMockTime(mockTime).setRegionName(STANDALONE_REGION_NAME).build());
+    String clusterName = "test_cluster";
     manager =
         IntegrationTestPushUtils
             .getTopicManagerRepo(

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/writer/PubSubSharedProducerAdapterFactoryTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/writer/PubSubSharedProducerAdapterFactoryTest.java
@@ -50,14 +50,22 @@ public class PubSubSharedProducerAdapterFactoryTest {
   private TopicManager topicManager;
   private PubSubConsumerAdapterFactory pubSubConsumerAdapterFactory;
   private PubSubTopicRepository pubSubTopicRepository = new PubSubTopicRepository();
+  private final String clusterName = "test_cluster";
 
   @BeforeClass
   public void setUp() {
     pubSubBrokerWrapper = ServiceFactory.getPubSubBroker();
     pubSubConsumerAdapterFactory = pubSubBrokerWrapper.getPubSubClientsFactory().getConsumerAdapterFactory();
-    topicManager = IntegrationTestPushUtils
-        .getTopicManagerRepo(DEFAULT_KAFKA_OPERATION_TIMEOUT_MS, 100, 0L, pubSubBrokerWrapper, pubSubTopicRepository)
-        .getTopicManager();
+    topicManager =
+        IntegrationTestPushUtils
+            .getTopicManagerRepo(
+                DEFAULT_KAFKA_OPERATION_TIMEOUT_MS,
+                100,
+                0L,
+                pubSubBrokerWrapper,
+                pubSubTopicRepository,
+                clusterName)
+            .getTopicManager();
   }
 
   @AfterClass

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/writer/VeniceWriterTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/writer/VeniceWriterTest.java
@@ -48,8 +48,8 @@ public class VeniceWriterTest {
   private PubSubBrokerWrapper pubSubBrokerWrapper;
   private TopicManager topicManager;
   private PubSubConsumerAdapterFactory pubSubConsumerAdapterFactory;
-
   private PubSubProducerAdapterFactory pubSubProducerAdapterFactory;
+  private final String clusterName = "test_cluster";
 
   private final PubSubTopicRepository pubSubTopicRepository = new PubSubTopicRepository();
 
@@ -58,9 +58,16 @@ public class VeniceWriterTest {
     pubSubBrokerWrapper = ServiceFactory.getPubSubBroker();
     pubSubConsumerAdapterFactory = pubSubBrokerWrapper.getPubSubClientsFactory().getConsumerAdapterFactory();
     pubSubProducerAdapterFactory = pubSubBrokerWrapper.getPubSubClientsFactory().getProducerAdapterFactory();
-    topicManager = IntegrationTestPushUtils
-        .getTopicManagerRepo(DEFAULT_KAFKA_OPERATION_TIMEOUT_MS, 100L, 0L, pubSubBrokerWrapper, pubSubTopicRepository)
-        .getTopicManager();
+    topicManager =
+        IntegrationTestPushUtils
+            .getTopicManagerRepo(
+                DEFAULT_KAFKA_OPERATION_TIMEOUT_MS,
+                100L,
+                0L,
+                pubSubBrokerWrapper,
+                pubSubTopicRepository,
+                clusterName)
+            .getTopicManager();
   }
 
   @AfterClass

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/writer/VeniceWriterTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/writer/VeniceWriterTest.java
@@ -49,12 +49,12 @@ public class VeniceWriterTest {
   private TopicManager topicManager;
   private PubSubConsumerAdapterFactory pubSubConsumerAdapterFactory;
   private PubSubProducerAdapterFactory pubSubProducerAdapterFactory;
-  private final String clusterName = "test_cluster";
 
   private final PubSubTopicRepository pubSubTopicRepository = new PubSubTopicRepository();
 
   @BeforeClass
   public void setUp() {
+    String clusterName = "test_cluster";
     pubSubBrokerWrapper = ServiceFactory.getPubSubBroker();
     pubSubConsumerAdapterFactory = pubSubBrokerWrapper.getPubSubClientsFactory().getConsumerAdapterFactory();
     pubSubProducerAdapterFactory = pubSubBrokerWrapper.getPubSubClientsFactory().getProducerAdapterFactory();

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/Admin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/Admin.java
@@ -634,7 +634,7 @@ public interface Admin extends AutoCloseable, Closeable {
    */
   Map<String, String> findAllBootstrappingVersions(String clusterName);
 
-  VeniceWriterFactory getVeniceWriterFactory();
+  VeniceWriterFactory getVeniceWriterFactory(String clusterName);
 
   Map<String, PubSubConsumerAdapterFactory> getVeniceConsumerFactoryMap();
 

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/Admin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/Admin.java
@@ -636,7 +636,7 @@ public interface Admin extends AutoCloseable, Closeable {
 
   VeniceWriterFactory getVeniceWriterFactory();
 
-  PubSubConsumerAdapterFactory getVeniceConsumerFactory();
+  Map<String, PubSubConsumerAdapterFactory> getVeniceConsumerFactoryMap();
 
   VeniceProperties getPubSubSSLProperties(String pubSubBrokerAddress);
 

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceController.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceController.java
@@ -15,7 +15,6 @@ import com.linkedin.venice.controller.supersetschema.SupersetSchemaGenerator;
 import com.linkedin.venice.controller.systemstore.SystemStoreRepairService;
 import com.linkedin.venice.d2.D2ClientFactory;
 import com.linkedin.venice.exceptions.VeniceException;
-import com.linkedin.venice.pubsub.PubSubClientsFactory;
 import com.linkedin.venice.pubsub.PubSubTopicRepository;
 import com.linkedin.venice.serialization.avro.AvroProtocolDefinition;
 import com.linkedin.venice.service.AbstractVeniceService;
@@ -60,7 +59,6 @@ public class VeniceController {
   private final Optional<ICProvider> icProvider;
   private final Optional<SupersetSchemaGenerator> externalSupersetSchemaGenerator;
   private final PubSubTopicRepository pubSubTopicRepository = new PubSubTopicRepository();
-  private final PubSubClientsFactory pubSubClientsFactory;
   static final String CONTROLLER_SERVICE_NAME = "venice-controller";
 
   /**
@@ -121,7 +119,6 @@ public class VeniceController {
     this.routerClientConfig = Optional.ofNullable(ctx.getRouterClientConfig());
     this.icProvider = Optional.ofNullable(ctx.getIcProvider());
     this.externalSupersetSchemaGenerator = Optional.ofNullable(ctx.getExternalSupersetSchemaGenerator());
-    this.pubSubClientsFactory = multiClusterConfigs.getPubSubClientsFactory();
     createServices();
   }
 
@@ -137,8 +134,7 @@ public class VeniceController {
         routerClientConfig,
         icProvider,
         externalSupersetSchemaGenerator,
-        pubSubTopicRepository,
-        pubSubClientsFactory);
+        pubSubTopicRepository);
 
     adminServer = new AdminSparkServer(
         // no need to pass the hostname, we are binding to all the addresses

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerService.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerService.java
@@ -15,7 +15,6 @@ import com.linkedin.venice.controller.lingeringjob.HeartbeatBasedLingeringStoreV
 import com.linkedin.venice.controller.lingeringjob.LingeringStoreVersionChecker;
 import com.linkedin.venice.controller.supersetschema.SupersetSchemaGenerator;
 import com.linkedin.venice.kafka.protocol.KafkaMessageEnvelope;
-import com.linkedin.venice.pubsub.PubSubClientsFactory;
 import com.linkedin.venice.pubsub.PubSubTopicRepository;
 import com.linkedin.venice.pubsub.api.PubSubMessageDeserializer;
 import com.linkedin.venice.schema.SchemaReader;
@@ -56,8 +55,7 @@ public class VeniceControllerService extends AbstractVeniceService {
       Optional<ClientConfig> routerClientConfig,
       Optional<ICProvider> icProvider,
       Optional<SupersetSchemaGenerator> externalSupersetSchemaGenerator,
-      PubSubTopicRepository pubSubTopicRepository,
-      PubSubClientsFactory pubSubClientsFactory) {
+      PubSubTopicRepository pubSubTopicRepository) {
     this.multiClusterConfigs = multiClusterConfigs;
 
     DelegatingClusterLeaderInitializationRoutine initRoutineForPushJobDetailsSystemStore =
@@ -84,7 +82,6 @@ public class VeniceControllerService extends AbstractVeniceService {
         accessController,
         icProvider,
         pubSubTopicRepository,
-        pubSubClientsFactory,
         Arrays.asList(initRoutineForPushJobDetailsSystemStore, initRoutineForHeartbeatSystemStore));
 
     if (multiClusterConfigs.isParent()) {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
@@ -4016,11 +4016,11 @@ public class VeniceParentHelixAdmin implements Admin {
   }
 
   /**
-   * @see VeniceHelixAdmin#getVeniceConsumerFactory()
+   * @see VeniceHelixAdmin#getVeniceConsumerFactoryMap() ()
    */
   @Override
-  public PubSubConsumerAdapterFactory getVeniceConsumerFactory() {
-    return getVeniceHelixAdmin().getVeniceConsumerFactory();
+  public Map<String, PubSubConsumerAdapterFactory> getVeniceConsumerFactoryMap() {
+    return getVeniceHelixAdmin().getVeniceConsumerFactoryMap();
   }
 
   @Override
@@ -4089,7 +4089,7 @@ public class VeniceParentHelixAdmin implements Admin {
   }
 
   /**
-   * @see VeniceHelixAdmin#isTopicTruncated(String)
+   * @see VeniceHelixAdmin#isTopicTruncated( String)
    */
   @Override
   public boolean isTopicTruncated(String kafkaTopicName) {
@@ -4113,7 +4113,7 @@ public class VeniceParentHelixAdmin implements Admin {
   }
 
   /**
-   * @see VeniceHelixAdmin#truncateKafkaTopic(String)
+   * @see VeniceHelixAdmin#truncateKafkaTopic( String)
    */
   @Override
   public boolean truncateKafkaTopic(String kafkaTopicName) {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
@@ -566,7 +566,7 @@ public class VeniceParentHelixAdmin implements Admin {
        * 2. Data out of order;
        * 3. Data duplication;
        */
-      return getVeniceWriterFactory().createVeniceWriter(
+      return getVeniceWriterFactory(clusterName).createVeniceWriter(
           new VeniceWriterOptions.Builder(topicName.getName()).setTime(getTimer())
               .setPartitionCount(AdminTopicUtils.PARTITION_NUM_FOR_ADMIN_TOPIC)
               .build());
@@ -4011,8 +4011,8 @@ public class VeniceParentHelixAdmin implements Admin {
    * @return a <code>VeniceWriterFactory</code> object used by the Venice controller to create the venice writer.
    */
   @Override
-  public VeniceWriterFactory getVeniceWriterFactory() {
-    return getVeniceHelixAdmin().getVeniceWriterFactory();
+  public VeniceWriterFactory getVeniceWriterFactory(String clusterName) {
+    return getVeniceHelixAdmin().getVeniceWriterFactory(clusterName);
   }
 
   /**

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/kafka/consumer/AdminConsumerService.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/kafka/consumer/AdminConsumerService.java
@@ -33,7 +33,7 @@ public class AdminConsumerService extends AbstractVeniceService {
   private final VeniceControllerConfig config;
   private final VeniceHelixAdmin admin;
   private final ZkAdminTopicMetadataAccessor adminTopicMetadataAccessor;
-  private final PubSubConsumerAdapterFactory consumerFactory;
+  private final Map<String, PubSubConsumerAdapterFactory> consumerFactoryMap;
   private final MetricsRepository metricsRepository;
   private final boolean remoteConsumptionEnabled;
   private final Optional<String> remoteKafkaServerUrl;
@@ -67,7 +67,7 @@ public class AdminConsumerService extends AbstractVeniceService {
       remoteKafkaServerUrl = Optional.empty();
     }
     this.localKafkaServerUrl = admin.getKafkaBootstrapServers(admin.isSslToKafka());
-    this.consumerFactory = admin.getVeniceConsumerFactory();
+    this.consumerFactoryMap = admin.getVeniceConsumerFactoryMap();
   }
 
   @Override
@@ -210,7 +210,7 @@ public class AdminConsumerService extends AbstractVeniceService {
      * 1. {@link AdminConsumptionTask} is persisting {@link com.linkedin.venice.offsets.OffsetRecord} in Zookeeper.
      */
     kafkaConsumerProperties.setProperty(KAFKA_ENABLE_AUTO_COMMIT_CONFIG, "false");
-    return consumerFactory
+    return consumerFactoryMap.get(clusterName)
         .create(new VeniceProperties(kafkaConsumerProperties), false, pubSubMessageDeserializer, clusterName);
   }
 }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/AbstractPushMonitor.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/AbstractPushMonitor.java
@@ -863,6 +863,7 @@ public abstract class AbstractPushMonitor
         try {
           String newStatusDetails;
           realTimeTopicSwitcher.switchToRealTimeTopic(
+              clusterName,
               Version.composeRealTimeTopic(storeName),
               offlinePushStatus.getKafkaTopic(),
               store,
@@ -1050,7 +1051,7 @@ public abstract class AbstractPushMonitor
           } else {
             int previousVersion = store.getCurrentVersion();
             store.setCurrentVersion(versionNumber);
-            realTimeTopicSwitcher.transmitVersionSwapMessage(store, previousVersion, versionNumber);
+            realTimeTopicSwitcher.transmitVersionSwapMessage(clusterName, store, previousVersion, versionNumber);
           }
         } else {
           LOGGER.info(

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/kafka/consumer/TestAdminConsumerService.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/kafka/consumer/TestAdminConsumerService.java
@@ -30,6 +30,7 @@ import com.linkedin.venice.utils.VeniceProperties;
 import com.linkedin.venice.utils.pools.LandFillObjectPool;
 import io.tehuti.metrics.MetricsRepository;
 import java.util.Collections;
+import java.util.Map;
 import org.apache.helix.zookeeper.impl.client.ZkClient;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -62,11 +63,13 @@ public class TestAdminConsumerService {
     VeniceControllerConfig controllerConfig = new VeniceControllerConfig(props);
 
     PubSubConsumerAdapterFactory consumerFactory = mock(PubSubConsumerAdapterFactory.class);
+    Map<String, PubSubConsumerAdapterFactory> consumerFactoryMap =
+        Collections.singletonMap(someClusterName, consumerFactory);
 
     VeniceHelixAdmin admin = mock(VeniceHelixAdmin.class);
     doReturn(mock(ZkClient.class)).when(admin).getZkClient();
     doReturn(mock(HelixAdapterSerializer.class)).when(admin).getAdapterSerializer();
-    doReturn(consumerFactory).when(admin).getVeniceConsumerFactory();
+    doReturn(consumerFactoryMap).when(admin).getVeniceConsumerFactoryMap();
     doReturn("localhost:1234").when(admin).getKafkaBootstrapServers(true);
     doReturn(true).when(admin).isSslToKafka();
 

--- a/services/venice-controller/src/test/java/com/linkedin/venice/ingestion/control/RealTimeTopicSwitcherRewindTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/ingestion/control/RealTimeTopicSwitcherRewindTest.java
@@ -39,6 +39,8 @@ public class RealTimeTopicSwitcherRewindTest {
   private RealTimeTopicSwitcher topicReplicator;
   private TestMockTime mockTime;
 
+  private String clusterName = "test_cluster";
+
   private final PubSubTopicRepository pubSubTopicRepository = new PubSubTopicRepository();
 
   @BeforeTest
@@ -57,15 +59,15 @@ public class RealTimeTopicSwitcherRewindTest {
     mockTime = new TestMockTime();
 
     when(topicReplicator.getTopicManager()).thenReturn(topicManager);
-    when(topicReplicator.getVeniceWriterFactory()).thenReturn(veniceWriterFactory);
+    when(topicReplicator.getVeniceWriterFactory(clusterName)).thenReturn(veniceWriterFactory);
     when(topicReplicator.getTimer()).thenReturn(mockTime);
-    when(topicManager.containsTopicAndAllPartitionsAreOnline(any())).thenReturn(true);
+    when(topicManager.containsTopicAndAllPartitionsAreOnline(any(), any())).thenReturn(true);
     when(veniceWriterFactory.<byte[], byte[], byte[]>createVeniceWriter(any())).thenReturn(veniceWriter);
 
     // Methods under test
-    doCallRealMethod().when(topicReplicator).ensurePreconditions(any(), any(), any(), any());
+    doCallRealMethod().when(topicReplicator).ensurePreconditions(any(), any(), any(), any(), any());
     doCallRealMethod().when(topicReplicator).getRewindStartTime(any(), any(), anyLong());
-    doCallRealMethod().when(topicReplicator).sendTopicSwitch(any(), any(), anyLong(), anyList());
+    doCallRealMethod().when(topicReplicator).sendTopicSwitch(any(), any(), any(), anyLong(), anyList());
   }
 
   @Test
@@ -83,19 +85,19 @@ public class RealTimeTopicSwitcherRewindTest {
     final PubSubTopic sourceTopicName = pubSubTopicRepository.getTopic("source topic name_v1");
     final PubSubTopic destinationTopicName = pubSubTopicRepository.getTopic("destination topic name_v1");
 
-    topicReplicator.ensurePreconditions(sourceTopicName, destinationTopicName, store, hybridStoreConfig);
+    topicReplicator.ensurePreconditions(clusterName, sourceTopicName, destinationTopicName, store, hybridStoreConfig);
     long rewindStartTime =
         topicReplicator.getRewindStartTime(mock(Version.class), hybridStoreConfig, VERSION_CREATION_TIME_MS);
     assertEquals(
         rewindStartTime,
         mockTime.getMilliseconds() - Time.MS_PER_SECOND * REWIND_TIME_IN_SECONDS,
         "Rewind start timestamp is not calculated properly");
-    topicReplicator.sendTopicSwitch(sourceTopicName, destinationTopicName, rewindStartTime, null);
+    topicReplicator.sendTopicSwitch(clusterName, sourceTopicName, destinationTopicName, rewindStartTime, null);
 
-    verify(topicReplicator).sendTopicSwitch(sourceTopicName, destinationTopicName, rewindStartTime, null);
+    verify(topicReplicator).sendTopicSwitch(clusterName, sourceTopicName, destinationTopicName, rewindStartTime, null);
 
     try {
-      topicReplicator.ensurePreconditions(sourceTopicName, destinationTopicName, store, Optional.empty());
+      topicReplicator.ensurePreconditions(clusterName, sourceTopicName, destinationTopicName, store, Optional.empty());
       fail("topicReplicator.startBufferReplay should fail (FOR NOW) for non-Hybrid stores.");
     } catch (VeniceException e) {
       // expected
@@ -117,19 +119,19 @@ public class RealTimeTopicSwitcherRewindTest {
     final PubSubTopic sourceTopicName = pubSubTopicRepository.getTopic("source topic name_v1");
     final PubSubTopic destinationTopicName = pubSubTopicRepository.getTopic("destination topic name_v1");
 
-    topicReplicator.ensurePreconditions(sourceTopicName, destinationTopicName, store, hybridStoreConfig);
+    topicReplicator.ensurePreconditions(clusterName, sourceTopicName, destinationTopicName, store, hybridStoreConfig);
     long rewindStartTime =
         topicReplicator.getRewindStartTime(mock(Version.class), hybridStoreConfig, VERSION_CREATION_TIME_MS);
     assertEquals(
         rewindStartTime,
         VERSION_CREATION_TIME_MS - Time.MS_PER_SECOND * REWIND_TIME_IN_SECONDS,
         "Rewind start timestamp is not calculated properly");
-    topicReplicator.sendTopicSwitch(sourceTopicName, destinationTopicName, rewindStartTime, null);
+    topicReplicator.sendTopicSwitch(clusterName, sourceTopicName, destinationTopicName, rewindStartTime, null);
 
-    verify(topicReplicator).sendTopicSwitch(sourceTopicName, destinationTopicName, rewindStartTime, null);
+    verify(topicReplicator).sendTopicSwitch(clusterName, sourceTopicName, destinationTopicName, rewindStartTime, null);
 
     try {
-      topicReplicator.ensurePreconditions(sourceTopicName, destinationTopicName, store, Optional.empty());
+      topicReplicator.ensurePreconditions(clusterName, sourceTopicName, destinationTopicName, store, Optional.empty());
       fail("topicReplicator.startBufferReplay should fail (FOR NOW) for non-Hybrid stores.");
     } catch (VeniceException e) {
       // expected

--- a/services/venice-controller/src/test/java/com/linkedin/venice/pushmonitor/AbstractPushMonitorTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/pushmonitor/AbstractPushMonitorTest.java
@@ -679,7 +679,7 @@ public abstract class AbstractPushMonitorTest {
     // Check hybrid push status
     monitor.onPartitionStatusChange(topic, partitionStatus);
     // Not ready to send SOBR
-    verify(realTimeTopicSwitcher, never()).switchToRealTimeTopic(any(), any(), any(), any(), anyList());
+    verify(realTimeTopicSwitcher, never()).switchToRealTimeTopic(any(), any(), any(), any(), any(), anyList());
     Assert.assertEquals(
         monitor.getOfflinePushOrThrow(topic).getCurrentStatus(),
         ExecutionStatus.STARTED,
@@ -689,6 +689,7 @@ public abstract class AbstractPushMonitorTest {
     replicaStatuses.get(0).updateStatus(ExecutionStatus.END_OF_PUSH_RECEIVED);
     monitor.onPartitionStatusChange(topic, partitionStatus);
     verify(realTimeTopicSwitcher, times(1)).switchToRealTimeTopic(
+        eq(clusterName),
         eq(Version.composeRealTimeTopic(store.getName())),
         eq(topic),
         eq(store),
@@ -705,7 +706,7 @@ public abstract class AbstractPushMonitorTest {
     monitor.setRealTimeTopicSwitcher(realTimeTopicSwitcher);
     monitor.onPartitionStatusChange(topic, partitionStatus);
     // Should not send SOBR again
-    verify(realTimeTopicSwitcher, never()).switchToRealTimeTopic(any(), any(), any(), any(), anyList());
+    verify(realTimeTopicSwitcher, never()).switchToRealTimeTopic(any(), any(), any(), any(), any(), anyList());
   }
 
   @Test
@@ -758,6 +759,7 @@ public abstract class AbstractPushMonitorTest {
     }
     // Only send one SOBR
     verify(realTimeTopicSwitcher, only()).switchToRealTimeTopic(
+        eq(clusterName),
         eq(Version.composeRealTimeTopic(store.getName())),
         eq(topic),
         eq(store),


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Summary, imperative, start upper case, don't end with a period
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Previously, different venice cluster for controller share the same pub sub admin, consumer and producer clients, especially for `TopicManager`. As venice is going to support different pub sub clients, we need to add support for different pub sub clients for different cluster running in the same controller host. 

In current controller's pub sub client usage in common class (e.g `TopicManager`) used by controller, there is no cluster name information in API. To avoid changing the interface, a cluster discovery supplier function is added to `TopicManagerRepository` and other utility class. For controller, this cluster discovery logic will rely on `HelixReadOnlyStoreConfigRepository` to resolve cluster name from topic. For server, it just uses the default cluster name for that host. 

It is possible that `HelixReadOnlyStoreConfigRepository` based logic cannot resolve cluster name from topic and some pub sub client usage is not for specific cluster (e.g. listing all topics inside `TopicManager`), we will rely on default pub sub clients factory to do this. 


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.