### PR TITLE
[server][da-vinci] Replace '.' with '_' in Kafka broker URL when logging

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceClusterConfig.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceClusterConfig.java
@@ -53,7 +53,7 @@ import org.apache.logging.log4j.Logger;
  * class that maintains config very specific to a Venice cluster
  */
 public class VeniceClusterConfig {
-  private static final Logger LOGGER = LogManager.getLogger(VeniceServerConfig.class.getName());
+  private static final Logger LOGGER = LogManager.getLogger(VeniceServerConfig.class);
 
   private final String clusterName;
   private final String zookeeperAddress;

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/helix/AbstractStateModelFactory.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/helix/AbstractStateModelFactory.java
@@ -22,7 +22,7 @@ import org.apache.logging.log4j.Logger;
  * model definition and model factory, each factory could only create 1 type of model.
  */
 public abstract class AbstractStateModelFactory extends StateModelFactory<StateModel> {
-  protected final Logger logger = LogManager.getLogger(getClass().getSimpleName());
+  protected final Logger logger = LogManager.getLogger(getClass());
   private final VeniceIngestionBackend ingestionBackend;
   private final VeniceConfigLoader configService;
   protected final ReadOnlyStoreRepository storeMetadataRepo;

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/helix/StateModelIngestionProgressNotifier.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/helix/StateModelIngestionProgressNotifier.java
@@ -20,7 +20,7 @@ import org.apache.logging.log4j.Logger;
  * need to coordinate with ingestion progress.
  */
 public abstract class StateModelIngestionProgressNotifier implements VeniceNotifier {
-  private final Logger logger = LogManager.getLogger(this.getClass().getSimpleName());
+  private final Logger logger = LogManager.getLogger(this.getClass());
   private final Map<String, CountDownLatch> stateModelToIngestionCompleteFlagMap = new VeniceConcurrentHashMap<>();
   private final Map<String, Boolean> stateModelToSuccessMap = new VeniceConcurrentHashMap<>();
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ConsumptionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ConsumptionTask.java
@@ -8,6 +8,7 @@ import com.linkedin.venice.pubsub.api.PubSubMessage;
 import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
 import com.linkedin.venice.utils.ExceptionUtils;
 import com.linkedin.venice.utils.LatencyUtils;
+import com.linkedin.venice.utils.Utils;
 import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -71,7 +72,7 @@ class ConsumptionTask implements Runnable {
     this.recordsThrottler = recordsThrottler;
     this.stats = stats;
     this.cleaner = cleaner;
-    String kafkaUrlForLogger = kafkaUrl.replace(".", "_");
+    String kafkaUrlForLogger = Utils.getSanitizedStringForLogger(kafkaUrl);
     this.LOGGER = LogManager.getLogger(getClass().getSimpleName() + "[ " + kafkaUrlForLogger + " - " + taskId + " ]");
   }
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ConsumptionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ConsumptionTask.java
@@ -36,7 +36,7 @@ import org.apache.logging.log4j.Logger;
  * 3. Recording some stats.
  */
 class ConsumptionTask implements Runnable {
-  private final Logger logger;
+  private final Logger LOGGER;
   private final int taskId;
   private final Map<PubSubTopicPartition, ConsumedDataReceiver<List<PubSubMessage<KafkaKey, KafkaMessageEnvelope, Long>>>> dataReceiverMap =
       new VeniceConcurrentHashMap<>();
@@ -71,7 +71,8 @@ class ConsumptionTask implements Runnable {
     this.recordsThrottler = recordsThrottler;
     this.stats = stats;
     this.cleaner = cleaner;
-    this.logger = LogManager.getLogger(getClass().getSimpleName() + "[ " + kafkaUrl + " - " + taskId + " ]");
+    String kafkaUrlForLogger = kafkaUrl.replace(".", "_");
+    this.LOGGER = LogManager.getLogger(getClass().getSimpleName() + "[ " + kafkaUrlForLogger + " - " + taskId + " ]");
   }
 
   @Override
@@ -129,7 +130,7 @@ class ConsumptionTask implements Runnable {
             consumedDataReceiver = dataReceiverMap.get(pubSubTopicPartition);
             if (consumedDataReceiver == null) {
               // defensive code
-              logger.error(
+              LOGGER.error(
                   "Couldn't find consumed data receiver for topic partition : {} after receiving records from `poll` request",
                   pubSubTopicPartition);
               topicPartitionsToUnsub.add(pubSubTopicPartition);
@@ -154,15 +155,15 @@ class ConsumptionTask implements Runnable {
       } catch (Exception e) {
         if (ExceptionUtils.recursiveClassEquals(e, InterruptedException.class)) {
           // We sometimes wrap InterruptedExceptions, so not taking any chances...
-          logger.error("Received InterruptedException, will exit");
+          LOGGER.error("Received InterruptedException, will exit");
           break;
         }
-        logger.error("Received exception while polling, will retry", e);
+        LOGGER.error("Received exception while polling, will retry", e);
         addSomeDelay = true;
         stats.recordPollError();
       }
     }
-    logger.info("Shared consumer thread: {} exited", Thread.currentThread().getName());
+    LOGGER.info("Shared consumer thread: {} exited", Thread.currentThread().getName());
   }
 
   void stop() {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaConsumerService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaConsumerService.java
@@ -73,6 +73,7 @@ public abstract class KafkaConsumerService extends AbstractVeniceService {
 
   private final ExecutorService consumerExecutor;
   protected final String kafkaUrl;
+  protected final String kafkaUrlForLogger;
   private final Logger LOGGER;
 
   protected KafkaConsumerServiceStats stats;
@@ -101,7 +102,8 @@ public abstract class KafkaConsumerService extends AbstractVeniceService {
       final KafkaConsumerServiceStats statsOverride,
       final boolean isKafkaConsumerOffsetCollectionEnabled) {
     this.kafkaUrl = consumerProperties.getProperty(KAFKA_BOOTSTRAP_SERVERS);
-    this.LOGGER = LogManager.getLogger(KafkaConsumerService.class.getSimpleName() + " [" + kafkaUrl + "]");
+    this.kafkaUrlForLogger = kafkaUrl.replace(".", "_");
+    this.LOGGER = LogManager.getLogger(KafkaConsumerService.class.getSimpleName() + " [" + kafkaUrlForLogger + "]");
 
     // Initialize consumers and consumerExecutor
     consumerExecutor = Executors.newFixedThreadPool(

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaConsumerService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaConsumerService.java
@@ -102,7 +102,7 @@ public abstract class KafkaConsumerService extends AbstractVeniceService {
       final KafkaConsumerServiceStats statsOverride,
       final boolean isKafkaConsumerOffsetCollectionEnabled) {
     this.kafkaUrl = consumerProperties.getProperty(KAFKA_BOOTSTRAP_SERVERS);
-    this.kafkaUrlForLogger = kafkaUrl.replace(".", "_");
+    this.kafkaUrlForLogger = Utils.getSanitizedStringForLogger(kafkaUrl);
     this.LOGGER = LogManager.getLogger(KafkaConsumerService.class.getSimpleName() + " [" + kafkaUrlForLogger + "]");
 
     // Initialize consumers and consumerExecutor

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/PartitionWiseKafkaConsumerService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/PartitionWiseKafkaConsumerService.java
@@ -35,7 +35,7 @@ public class PartitionWiseKafkaConsumerService extends KafkaConsumerService {
   private final Map<PubSubTopicPartition, Set<PubSubConsumerAdapter>> rtTopicPartitionToConsumerMap =
       new VeniceConcurrentHashMap<>();
 
-  private final Logger logger;
+  private final Logger LOGGER;
 
   private int shareConsumerIndex = 0;
 
@@ -73,7 +73,7 @@ public class PartitionWiseKafkaConsumerService extends KafkaConsumerService {
         time,
         stats,
         isKafkaConsumerOffsetCollectionEnabled);
-    this.logger = LogManager.getLogger(PartitionWiseKafkaConsumerService.class + " [" + kafkaUrl + "]");
+    this.LOGGER = LogManager.getLogger(PartitionWiseKafkaConsumerService.class + " [" + kafkaUrlForLogger + "]");
   }
 
   @Override
@@ -110,7 +110,7 @@ public class PartitionWiseKafkaConsumerService extends KafkaConsumerService {
          * But one consumer cannot consume from several offsets of one partition at the same time.
          */
         if (alreadySubscribedRealtimeTopicPartition(consumer, topicPartition)) {
-          logger.info(
+          LOGGER.info(
               "Current consumer has already subscribed the same real time topic-partition: {} will skip it and try next consumer in consumer pool",
               topicPartition);
           seekNewConsumer = true;
@@ -125,7 +125,7 @@ public class PartitionWiseKafkaConsumerService extends KafkaConsumerService {
       throw new IllegalStateException(
           "Did not find a suitable consumer after checking " + consumersChecked + " instances.");
     }
-    logger.info(
+    LOGGER.info(
         "Get shared consumer for: {} from the ingestion task belonging to version topic: {} with index: {}",
         topicPartition,
         versionTopic,

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StorePartitionDataReceiver.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StorePartitionDataReceiver.java
@@ -19,6 +19,7 @@ public class StorePartitionDataReceiver
   private final StoreIngestionTask storeIngestionTask;
   private final PubSubTopicPartition topicPartition;
   private final String kafkaUrl;
+  private final String kafkaUrlForLogger;
   private final int kafkaClusterId;
   private final Logger LOGGER;
 
@@ -32,8 +33,9 @@ public class StorePartitionDataReceiver
     this.storeIngestionTask = Validate.notNull(storeIngestionTask);
     this.topicPartition = Validate.notNull(topicPartition);
     this.kafkaUrl = Validate.notNull(kafkaUrl);
+    this.kafkaUrlForLogger = kafkaUrl.replace(".", "_");
     this.kafkaClusterId = kafkaClusterId;
-    this.LOGGER = LogManager.getLogger(this.getClass().getSimpleName() + " [" + kafkaUrl + "]");
+    this.LOGGER = LogManager.getLogger(this.getClass().getSimpleName() + " [" + kafkaUrlForLogger + "]");
     this.receivedRecordsCount = 0L;
   }
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StorePartitionDataReceiver.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StorePartitionDataReceiver.java
@@ -9,6 +9,7 @@ import com.linkedin.venice.pubsub.api.PubSubMessage;
 import com.linkedin.venice.pubsub.api.PubSubTopic;
 import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
 import com.linkedin.venice.utils.ExceptionUtils;
+import com.linkedin.venice.utils.Utils;
 import java.util.List;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -33,7 +34,7 @@ public class StorePartitionDataReceiver
     this.storeIngestionTask = Validate.notNull(storeIngestionTask);
     this.topicPartition = Validate.notNull(topicPartition);
     this.kafkaUrl = Validate.notNull(kafkaUrl);
-    this.kafkaUrlForLogger = kafkaUrl.replace(".", "_");
+    this.kafkaUrlForLogger = Utils.getSanitizedStringForLogger(kafkaUrl);
     this.kafkaClusterId = kafkaClusterId;
     this.LOGGER = LogManager.getLogger(this.getClass().getSimpleName() + " [" + kafkaUrlForLogger + "]");
     this.receivedRecordsCount = 0L;

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/TopicWiseKafkaConsumerService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/TopicWiseKafkaConsumerService.java
@@ -68,7 +68,7 @@ public class TopicWiseKafkaConsumerService extends KafkaConsumerService {
         time,
         stats,
         isKafkaConsumerOffsetCollectionEnabled);
-    LOGGER = LogManager.getLogger(TopicWiseKafkaConsumerService.class + " [" + kafkaUrl + "]");
+    LOGGER = LogManager.getLogger(TopicWiseKafkaConsumerService.class + " [" + kafkaUrlForLogger + "]");
   }
 
   /**

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/InputDataInfoProvider.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/InputDataInfoProvider.java
@@ -17,7 +17,7 @@ public interface InputDataInfoProvider extends Closeable {
   /**
    * A POJO that contains input data information (schema information and input data file size)
    */
-  Logger LOGGER = LogManager.getLogger(InputDataInfoProvider.class.getName());
+  Logger LOGGER = LogManager.getLogger(InputDataInfoProvider.class);
 
   class InputDataInfo {
     private final PushJobSchemaInfo pushJobSchemaInfo;

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VsonSequenceFileInputFormat.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VsonSequenceFileInputFormat.java
@@ -20,7 +20,7 @@ import org.apache.logging.log4j.Logger;
  * https://github.com/voldemort/voldemort/blob/master/contrib/hadoop-store-builder/src/java/voldemort/store/readonly/mr/serialization/JsonSequenceFileInputFormat.java
  */
 public class VsonSequenceFileInputFormat extends SequenceFileInputFormat<BytesWritable, BytesWritable> {
-  private static final Logger LOGGER = LogManager.getLogger(VsonSequenceFileInputFormat.class.getName());
+  private static final Logger LOGGER = LogManager.getLogger(VsonSequenceFileInputFormat.class);
 
   @Override
   protected FileStatus[] listStatus(JobConf job) throws IOException {

--- a/internal/venice-common/src/main/java/com/linkedin/venice/kafka/TopicManager.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/kafka/TopicManager.java
@@ -89,7 +89,8 @@ public class TopicManager implements Closeable {
       Caffeine.newBuilder().expireAfterWrite(5, TimeUnit.MINUTES).build();
 
   public TopicManager(TopicManagerRepository.Builder builder, String pubSubBootstrapServers) {
-    this.logger = LogManager.getLogger(this.getClass().getSimpleName() + " [" + pubSubBootstrapServers + "]");
+    String pubSubServersForLogger = Utils.getSanitizedStringForLogger(pubSubBootstrapServers);
+    this.logger = LogManager.getLogger(this.getClass().getSimpleName() + " [" + pubSubServersForLogger + "]");
     this.kafkaOperationTimeoutMs = builder.getKafkaOperationTimeoutMs();
     this.topicMinLogCompactionLagMs = builder.getTopicMinLogCompactionLagMs();
     this.pubSubAdminAdapterFactory = builder.getPubSubAdminAdapterFactory();

--- a/internal/venice-common/src/main/java/com/linkedin/venice/utils/Utils.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/utils/Utils.java
@@ -905,4 +905,15 @@ public class Utils {
       }
     };
   }
+
+  /**
+   * Log4J's class name logging splits at the last "." and assumes it is the class name. In case where custom strings
+   * (e.g. URLs, server addresses, etc.) are added to the logger names, Log4J logs an incomplete string. This function
+   * replaces "." with "_" in the string when setting as the input for the logger.
+   * @param orig The string to sanitize
+   * @return A sanitized string that won't get mutated by Log4J
+   */
+  public static String getSanitizedStringForLogger(String orig) {
+    return orig.replace('.', '_');
+  }
 }

--- a/internal/venice-common/src/test/java/com/linkedin/venice/utils/UtilsTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/utils/UtilsTest.java
@@ -176,4 +176,9 @@ public class UtilsTest {
         () -> Utils.parseCommaSeparatedStringMapFromString("invalid_value", "test_field"));
     assertTrue(e.getMessage().contains("must be key value pairs separated by comma"));
   }
+
+  @Test
+  public void testSanitizingStringForLogger() {
+    Assert.assertEquals(Utils.getSanitizedStringForLogger(".abc.123."), "_abc_123_");
+  }
 }


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Replace `.` with `_` in Kafka broker URL when logging
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
Replace `.` with `_` in Kafka broker URL when logging since Log4J's class name logging splits at the last `.` and logs an incomplete name

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
GH CI

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.