### PR TITLE
[vpj] Add back public constructor for VeniceAvroRecordReader used in downstream dependency

### DIFF
--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VeniceAvroRecordReader.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VeniceAvroRecordReader.java
@@ -89,9 +89,28 @@ public class VeniceAvroRecordReader extends AbstractVeniceRecordReader<AvroWrapp
   }
 
   /**
+   * This constructor is used in the Dali, please consider evolving it gracefully otherwise it will break downstream dependency.
+   * @param topicName Topic which is to be published to
+   * @param fileSchema Schema of the source files
+   * @param keyFieldStr Field name of the key field
+   * @param valueFieldStr Field name of the value field
+   * @param etlValueSchemaTransformation The type of transformation that was applied to this schema during ETL. When source data set is not an ETL job, use NONE.
+   */
+  public VeniceAvroRecordReader(
+      String topicName,
+      Schema fileSchema,
+      String keyFieldStr,
+      String valueFieldStr,
+      ETLValueSchemaTransformation etlValueSchemaTransformation) {
+    super(topicName);
+    this.fileSchema = fileSchema;
+    this.etlValueSchemaTransformation = etlValueSchemaTransformation;
+    setupSchema(keyFieldStr, valueFieldStr);
+  }
+
+  /**
    * This constructor is used in the Mapper.
    */
-
   public VeniceAvroRecordReader(VeniceProperties props) {
     super(props.getString(TOPIC_PROP));
     this.fileSchema = AvroSchemaParseUtils.parseSchemaFromJSON(


### PR DESCRIPTION
## [vpj] Add back public constructor for VeniceAvroRecordReader used in downstream dependency
Add back constructor method to maintain dependency.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
N/A
## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.