### PR TITLE
[doc] Fix single-datacenter quickstart guide

### DIFF
--- a/docs/quickstart/quickstart-single-datacenter.md
+++ b/docs/quickstart/quickstart-single-datacenter.md
@@ -61,7 +61,8 @@ value schema:
 
 Let's create a venice store:
 ```
-bash create_store.sh
+./create_store.sh http://venice-controller:5555 venice-cluster0 test-store
+sample-data/schema/keySchema.avsc sample-data/schema/valueSchema.avsc
 ```
 
 #### Step 6: Push data to the store
@@ -69,31 +70,31 @@ Venice supports multiple ways to write data to the store. For more details, plea
 In this example, we will use batch push mode and push 100 records.
 ```
 key: 1 to 100
-value: test_name_1 to test_name_100
+value: val1 to val100
 ```
 
 Let's push the data:
 ```
-bash batch_push_data.sh
+./run-vpj.sh sample-data/single-dc-configs/batch-push-job.properties
 ```
 
 #### Step 7: Read data from the store
 Let's query some data from `venice-store`, using `venice-thin-client` which is included in venice container images. (key: `1 to 100`)
 ```
-bash query_data.sh <key>
+./fetch.sh <router> <store> <key>
 ```
 For example:
 ```bash
-$ bash query_data.sh 1
+$ ./fetch.sh http://venice-router:7777 test-store 1 
 key=1
-value=test_name_1
+value=val1
 
-$ bash query_data.sh 100
+$ ./fetch.sh http://venice-router:7777 test-store 100
 key=100
-value=test_name_100
+value=val100
 
 # Now if we do get on non-existing key, venice will return `null`
-$ bash query_data.sh 101
+$ ./fetch.sh http://venice-router:7777 test-store 101
 key=101
 value=null
 ```
@@ -102,11 +103,11 @@ value=null
 #### Step 8: Update and add some new records using Incremental Push
 Venice supports incremental push which allows us to update values of existing rows or to add new rows in an existing store.
 In this example, we will
-1. update values for keys from `51-100`. For example, the new value of `100` will be `test_name_100_v1`
+1. update values for keys from `51-100`. For example, the new value of `100` will be `val100_v1`
 2. add new rows (key: `101-150`)
 
-```
-bash inc_push_data.sh
+```bash
+./run-vpj.sh sample-data/single-dc-configs/inc-push-job.properties
 ```
 
 #### Step 9: Read data from the store after Incremental Push
@@ -115,19 +116,19 @@ Let's read the data once again.
 
 ```bash
 # Value of 1 changed remains unchanged
-$ bash query_data.sh 1
+$ ./fetch.sh http://venice-router:7777 test-store 1
 key=1
-value=test_name_1
+value=val1
 
 # Value of 100 changed from test_name_100 to test_name_100_v1
-$ bash query_data.sh 100
+$ ./fetch.sh http://venice-router:7777 test-store 100
 key=100
-value=test_name_100_v1
+value=val100_v1
 
 # Incremental Push added value for previously non-existing key 101
-$ bash query_data.sh 101
+$ ./fetch.sh http://venice-router:7777 test-store 101
 key=101
-value=test_name_101_v1
+value=val101
 ```
 
 


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Summary, imperative, start upper case, don't end with a period
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

This pull request fixes the errors in the single-datacenter quickstart guide, e.g., lack of arguments, wrong script names, and wrong sample values.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

I have verified the changes by following the edited guide.

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.