### PR TITLE
[admin-tool] Improve data recovery task reporting

### DIFF
--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/datarecovery/meta/RepushViabilityInfo.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/datarecovery/meta/RepushViabilityInfo.java
@@ -3,6 +3,7 @@ package com.linkedin.venice.datarecovery.meta;
 public class RepushViabilityInfo {
   private boolean isHybrid;
   private boolean isViable;
+  private boolean isError = false;
   private RepushViabilityInfo.Result result;
 
   public RepushViabilityInfo() {
@@ -27,6 +28,14 @@ public class RepushViabilityInfo {
     isViable = viable;
   }
 
+  public boolean isError() {
+    return isError;
+  }
+
+  public void setError(boolean error) {
+    isError = error;
+  }
+
   public Result getResult() {
     return result;
   }
@@ -35,19 +44,26 @@ public class RepushViabilityInfo {
     this.result = result;
   }
 
-  public RepushViabilityInfo succeedWithResult(Result result) {
+  public RepushViabilityInfo viableWithResult(Result result) {
     setResult(result);
     setViable(true);
     return this;
   }
 
-  public RepushViabilityInfo failWithResult(Result result) {
+  public RepushViabilityInfo inViableWithResult(Result result) {
     setResult(result);
     setViable(false);
     return this;
   }
 
+  public RepushViabilityInfo inViableWithError(Result result) {
+    setResult(result);
+    setViable(false);
+    setError(true);
+    return this;
+  }
+
   public enum Result {
-    NOT_STARTED, SUCCESS, DISCOVERY_ERROR, NO_FUTURE_VERSION, TIMESTAMP_MISMATCH, ONGOING_PUSH, EXCEPTION_THROWN
+    NOT_STARTED, SUCCESS, DISCOVERY_ERROR, NO_CURRENT_VERSION, CURRENT_VERSION_IS_NEWER, ONGOING_PUSH, EXCEPTION_THROWN
   }
 }

--- a/clients/venice-admin-tool/src/test/java/com/linkedin/venice/TestDataRecoveryClient.java
+++ b/clients/venice-admin-tool/src/test/java/com/linkedin/venice/TestDataRecoveryClient.java
@@ -492,7 +492,7 @@ public class TestDataRecoveryClient {
   }
 
   @Test
-  public void TestDataStructure() {
+  public void testDataStructure() {
     RepushViabilityInfo info = new RepushViabilityInfo();
     info.viableWithResult(RepushViabilityInfo.Result.SUCCESS);
     Assert.assertFalse(info.isError());

--- a/clients/venice-admin-tool/src/test/java/com/linkedin/venice/TestDataRecoveryClient.java
+++ b/clients/venice-admin-tool/src/test/java/com/linkedin/venice/TestDataRecoveryClient.java
@@ -492,15 +492,33 @@ public class TestDataRecoveryClient {
   }
 
   @Test
-  public void testDataStructure() {
+  public void testRepushViabilityInfo() {
     RepushViabilityInfo info = new RepushViabilityInfo();
     info.viableWithResult(RepushViabilityInfo.Result.SUCCESS);
     Assert.assertFalse(info.isError());
 
-    info.inViableWithResult(RepushViabilityInfo.Result.NO_CURRENT_VERSION);
+    info.inViableWithResult(RepushViabilityInfo.Result.CURRENT_VERSION_IS_NEWER);
     Assert.assertFalse(info.isError());
 
     info.inViableWithError(RepushViabilityInfo.Result.DISCOVERY_ERROR);
     Assert.assertTrue(info.isError());
   }
+
+  @Test
+  public void testRepushCommandExecute() {
+    StoreRepushCommand repushCommand = spy(StoreRepushCommand.class);
+    RepushViabilityInfo info = new RepushViabilityInfo();
+    info.inViableWithResult(RepushViabilityInfo.Result.CURRENT_VERSION_IS_NEWER);
+    StoreRepushCommand.Params repushParams = new StoreRepushCommand.Params();
+    doReturn(info).when(repushCommand).getRepushViability();
+    doReturn(repushParams).when(repushCommand).getParams();
+
+    repushCommand.execute();
+    Assert.assertFalse(repushCommand.getResult().isError());
+
+    info.inViableWithError(RepushViabilityInfo.Result.DISCOVERY_ERROR);
+    repushCommand.execute();
+    Assert.assertTrue(repushCommand.getResult().isError());
+  }
+
 }

--- a/clients/venice-admin-tool/src/test/java/com/linkedin/venice/TestDataRecoveryClient.java
+++ b/clients/venice-admin-tool/src/test/java/com/linkedin/venice/TestDataRecoveryClient.java
@@ -24,6 +24,7 @@ import com.linkedin.venice.datarecovery.DataRecoveryTask;
 import com.linkedin.venice.datarecovery.EstimateDataRecoveryTimeCommand;
 import com.linkedin.venice.datarecovery.MonitorCommand;
 import com.linkedin.venice.datarecovery.StoreRepushCommand;
+import com.linkedin.venice.datarecovery.meta.RepushViabilityInfo;
 import com.linkedin.venice.meta.HybridStoreConfigImpl;
 import com.linkedin.venice.meta.RegionPushDetails;
 import com.linkedin.venice.meta.StoreInfo;
@@ -488,5 +489,18 @@ public class TestDataRecoveryClient {
       Assert.assertFalse(storeNames.contains(monitor.getTasks().get(i).getTaskParams().getStore()));
       storeNames.add(monitor.getTasks().get(i).getTaskParams().getStore());
     }
+  }
+
+  @Test
+  public void TestDataStructure() {
+    RepushViabilityInfo info = new RepushViabilityInfo();
+    info.viableWithResult(RepushViabilityInfo.Result.SUCCESS);
+    Assert.assertFalse(info.isError());
+
+    info.inViableWithResult(RepushViabilityInfo.Result.NO_CURRENT_VERSION);
+    Assert.assertFalse(info.isError());
+
+    info.inViableWithError(RepushViabilityInfo.Result.DISCOVERY_ERROR);
+    Assert.assertTrue(info.isError());
   }
 }


### PR DESCRIPTION
Today, in data recovery client, `getRepushViability` inaccurately reports certain scenarios as failures, e.g. store's current version is newer than the provided timestamp, or an ongoing push is in-progress. These scenarios are in fact not failures, but cases that a new recovery action is not needed. However, there are other cases that we should consider as errors, e.g. when controller response contains errors.

To report them correctly, this rb introduces a new boolean to `RepushViabilityInfo` data structure to differentiate them and react/report task status differently.

## How was this PR tested?
Manually verified. By giving a very early datetime (so that current version is newer) to the command, the following compares the `before` and `after` reporting.

Before:
```
2023-08-30 15:22:18 INFO [DataRecoveryExecutor] [main] [store: xxxx, status: failed, message: failure: TIMESTAMP_MISMATCH]
2023-08-30 15:22:18 INFO [DataRecoveryWorker] [main] Total: 1, Succeeded: 0, Error: 1, Uncompleted: 0
```
After:
```
2023-08-30 15:13:05 INFO [DataRecoveryExecutor] [main] [store: xxxx, status: started, message: CURRENT_VERSION_IS_NEWER]
2023-08-30 15:13:05 INFO [DataRecoveryWorker] [main] Total: 1, Succeeded: 1, Error: 0, Uncompleted: 0
```





## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.