### PR TITLE
[server][da-vinci-client] Add log for SharedKafkaConsumer closing duration

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaConsumerService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaConsumerService.java
@@ -68,6 +68,7 @@ import org.apache.logging.log4j.Logger;
  * @see AggKafkaConsumerService which wraps one instance of this class per Kafka cluster.
  */
 public abstract class KafkaConsumerService extends AbstractVeniceService {
+  private static final int SHUTDOWN_TIMEOUT_IN_SECOND = 1;
   private static final RedundantExceptionFilter REDUNDANT_LOGGING_FILTER =
       RedundantExceptionFilter.getRedundantExceptionFilter();
 
@@ -277,11 +278,9 @@ public abstract class KafkaConsumerService extends AbstractVeniceService {
   @Override
   public void stopInner() throws Exception {
     consumerToConsumptionTask.values().forEach(ConsumptionTask::stop);
-
-    int timeOutInSeconds = 1;
-    long gracefulShutdownBeginningTime = System.currentTimeMillis();
-    boolean gracefulShutdownSuccess = consumerExecutor.awaitTermination(timeOutInSeconds, TimeUnit.SECONDS);
-    long gracefulShutdownDuration = System.currentTimeMillis() - gracefulShutdownBeginningTime;
+    long beginningTime = System.currentTimeMillis();
+    boolean gracefulShutdownSuccess = consumerExecutor.awaitTermination(SHUTDOWN_TIMEOUT_IN_SECOND, TimeUnit.SECONDS);
+    long gracefulShutdownDuration = System.currentTimeMillis() - beginningTime;
     if (gracefulShutdownSuccess) {
       LOGGER.info("consumerExecutor terminated gracefully in {} ms.", gracefulShutdownDuration);
     } else {
@@ -290,7 +289,7 @@ public abstract class KafkaConsumerService extends AbstractVeniceService {
           gracefulShutdownDuration);
       long forcefulShutdownBeginningTime = System.currentTimeMillis();
       consumerExecutor.shutdownNow();
-      boolean forcefulShutdownSuccess = consumerExecutor.awaitTermination(timeOutInSeconds, TimeUnit.SECONDS);
+      boolean forcefulShutdownSuccess = consumerExecutor.awaitTermination(SHUTDOWN_TIMEOUT_IN_SECOND, TimeUnit.SECONDS);
       long forcefulShutdownDuration = System.currentTimeMillis() - forcefulShutdownBeginningTime;
       if (forcefulShutdownSuccess) {
         LOGGER.info("consumerExecutor terminated forcefully in {} ms.", forcefulShutdownDuration);
@@ -300,8 +299,9 @@ public abstract class KafkaConsumerService extends AbstractVeniceService {
             forcefulShutdownDuration);
       }
     }
-
+    beginningTime = System.currentTimeMillis();
     consumerToConsumptionTask.keySet().forEach(SharedKafkaConsumer::close);
+    LOGGER.info("SharedKafkaConsumer closed in {} ms.", System.currentTimeMillis() - beginningTime);
   }
 
   public boolean hasAnySubscriptionFor(PubSubTopic versionTopic) {


### PR DESCRIPTION

<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Add log for SharedKafkaConsumer closing duration
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Add log to print how long it takes for SharedKafkaConsumer to close. 

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
GHCI
## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.