### PR TITLE
[vpj] Fix regression in partial update + incremental push input schema detection

### DIFF
--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
@@ -2446,7 +2446,8 @@ public class VenicePushJob implements AutoCloseable {
   }
 
   boolean isUpdateSchema(String schemaString) {
-    return schemaString.contains(WriteComputeOperation.NO_OP_ON_FIELD.name());
+    LOGGER.info("DEBUGGING: {}", WriteComputeOperation.NO_OP_ON_FIELD.getName());
+    return schemaString.contains(WriteComputeOperation.NO_OP_ON_FIELD.getName());
   }
 
   private void setSchemaIdPropInSchemaInfo(

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/VenicePushJobTest.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/VenicePushJobTest.java
@@ -17,6 +17,8 @@ import static com.linkedin.venice.hadoop.VenicePushJob.VALUE_FIELD_PROP;
 import static com.linkedin.venice.hadoop.VenicePushJob.VENICE_DISCOVER_URL_PROP;
 import static com.linkedin.venice.hadoop.VenicePushJob.VENICE_STORE_NAME_PROP;
 import static com.linkedin.venice.status.BatchJobHeartbeatConfigs.HEARTBEAT_ENABLED_CONFIG;
+import static com.linkedin.venice.utils.TestWriteUtils.NESTED_SCHEMA_STRING;
+import static com.linkedin.venice.utils.TestWriteUtils.UPDATE_SCHEMA_OF_NESTED_SCHEMA_STRING;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -32,6 +34,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
@@ -93,6 +96,14 @@ public class VenicePushJobTest {
   private static final String PUSH_JOB_ID = "push_job_number_101";
   private static final String DISCOVERY_URL = "d2://d2Clusters/venice-discovery";
   private static final String PARENT_REGION_NAME = "dc-parent";
+
+  @Test
+  public void testVPJcheckInputUpdateSchema() {
+    VenicePushJob vpj = mock(VenicePushJob.class);
+    when(vpj.isUpdateSchema(anyString())).thenCallRealMethod();
+    Assert.assertTrue(vpj.isUpdateSchema(UPDATE_SCHEMA_OF_NESTED_SCHEMA_STRING));
+    Assert.assertFalse(vpj.isUpdateSchema(NESTED_SCHEMA_STRING));
+  }
 
   @Test(expectedExceptions = VeniceException.class, expectedExceptionsMessageRegExp = ".*Repush with TTL is only supported while using Kafka Input Format.*")
   public void testRepushTTLJobWithNonKafkaInput() {

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/PartialUpdateTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/PartialUpdateTest.java
@@ -23,6 +23,7 @@ import static com.linkedin.venice.utils.TestWriteUtils.NESTED_SCHEMA_STRING;
 import static com.linkedin.venice.utils.TestWriteUtils.NESTED_SCHEMA_STRING_V2;
 import static com.linkedin.venice.utils.TestWriteUtils.getTempDataDirectory;
 import static com.linkedin.venice.utils.TestWriteUtils.loadFileAsString;
+import static com.linkedin.venice.utils.TestWriteUtils.writeSimpleAvroFileWithStringToPartialUpdateOpRecordSchema;
 import static com.linkedin.venice.utils.TestWriteUtils.writeSimpleAvroFileWithStringToRecordSchema;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -268,6 +269,68 @@ public class PartialUpdateTest {
           try {
             GenericRecord value = (GenericRecord) storeReader.get(keyRecord).get();
             assertNotNull(value, "key " + keyRecord + " should not be missing!");
+          } catch (Exception e) {
+            throw new VeniceException(e);
+          }
+        });
+      }
+    }
+  }
+
+  @Test(timeOut = 180 * Time.MS_PER_SECOND)
+  public void testIncrementalPushPartialUpdateClassicFormat() throws IOException {
+    final String storeName = Utils.getUniqueString("inc_push_update_classic_format");
+    String parentControllerUrl = parentController.getControllerUrl();
+    File inputDir = getTempDataDirectory();
+    Schema recordSchema = writeSimpleAvroFileWithStringToPartialUpdateOpRecordSchema(inputDir, true);
+    String keySchemaStr = recordSchema.getField(DEFAULT_KEY_FIELD_PROP).schema().toString();
+    String inputDirPath = "file://" + inputDir.getAbsolutePath();
+    Properties vpjProperties =
+        IntegrationTestPushUtils.defaultVPJProps(multiRegionMultiClusterWrapper, inputDirPath, storeName);
+    vpjProperties.put(ENABLE_WRITE_COMPUTE, true);
+    vpjProperties.put(INCREMENTAL_PUSH, true);
+
+    try (ControllerClient parentControllerClient = new ControllerClient(CLUSTER_NAME, parentControllerUrl)) {
+      assertCommand(parentControllerClient.createNewStore(storeName, "test_owner", keySchemaStr, NESTED_SCHEMA_STRING));
+      UpdateStoreQueryParams updateStoreParams =
+          new UpdateStoreQueryParams().setStorageQuotaInByte(Store.UNLIMITED_STORAGE_QUOTA)
+              .setCompressionStrategy(CompressionStrategy.NO_OP)
+              .setWriteComputationEnabled(true)
+              .setChunkingEnabled(true)
+              .setIncrementalPushEnabled(true)
+              .setHybridRewindSeconds(10L)
+              .setHybridOffsetLagThreshold(2L);
+      ControllerResponse updateStoreResponse =
+          parentControllerClient.retryableRequest(5, c -> c.updateStore(storeName, updateStoreParams));
+      assertFalse(updateStoreResponse.isError(), "Update store got error: " + updateStoreResponse.getError());
+
+      VersionCreationResponse response = parentControllerClient.emptyPush(storeName, "test_push_id", 1000);
+      assertEquals(response.getVersion(), 1);
+      assertFalse(response.isError(), "Empty push to parent colo should succeed");
+      TestUtils.waitForNonDeterministicPushCompletion(
+          Version.composeKafkaTopic(storeName, 1),
+          parentControllerClient,
+          30,
+          TimeUnit.SECONDS);
+
+      // VPJ push
+      String childControllerUrl = childDatacenters.get(0).getRandomController().getControllerUrl();
+      try (ControllerClient childControllerClient = new ControllerClient(CLUSTER_NAME, childControllerUrl)) {
+        runVPJ(vpjProperties, 1, childControllerClient);
+      }
+      VeniceClusterWrapper veniceClusterWrapper = childDatacenters.get(0).getClusters().get(CLUSTER_NAME);
+      try (AvroGenericStoreClient<Object, Object> storeReader = ClientFactory.getAndStartGenericAvroClient(
+          ClientConfig.defaultGenericClientConfig(storeName).setVeniceURL(veniceClusterWrapper.getRandomRouterURL()))) {
+        TestUtils.waitForNonDeterministicAssertion(10, TimeUnit.SECONDS, true, () -> {
+          try {
+            for (int i = 1; i < 100; i++) {
+              String key = String.valueOf(i);
+              GenericRecord value = readValue(storeReader, key);
+              assertNotNull(value, "Key " + key + " should not be missing!");
+              assertEquals(value.get("firstName").toString(), "first_name_" + key);
+              assertEquals(value.get("lastName").toString(), "last_name_" + key);
+              // assertEquals(value.get("age"), -1);
+            }
           } catch (Exception e) {
             throw new VeniceException(e);
           }

--- a/internal/venice-test-common/src/main/java/com/linkedin/venice/utils/TestWriteUtils.java
+++ b/internal/venice-test-common/src/main/java/com/linkedin/venice/utils/TestWriteUtils.java
@@ -29,6 +29,7 @@ import com.linkedin.venice.schema.vson.VsonAvroSchemaAdapter;
 import com.linkedin.venice.schema.vson.VsonAvroSerializer;
 import com.linkedin.venice.schema.vson.VsonSchema;
 import com.linkedin.venice.writer.VeniceWriter;
+import com.linkedin.venice.writer.update.UpdateBuilderImpl;
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -137,6 +138,19 @@ public class TestWriteUtils {
           + "  \"name\": \"StringToRecord\",     " + "  \"fields\": [           " + "       { \"name\": \""
           + DEFAULT_KEY_FIELD_PROP + "\", \"type\": \"string\", \"default\": \"\"}, " + "       { \"name\": \""
           + DEFAULT_VALUE_FIELD_PROP + "\", \"type\": " + NESTED_SCHEMA_STRING + " }  " + "  ] " + " } ";
+
+  public static final String UPDATE_SCHEMA_OF_NESTED_SCHEMA_STRING = "{\n" + "  \"type\" : \"record\",\n"
+      + "  \"name\" : \"nameRecordWriteOpRecord\",\n" + "  \"namespace\" : \"example.avro\",\n" + "  \"fields\" : [ {\n"
+      + "    \"name\" : \"firstName\",\n" + "    \"type\" : [ {\n" + "      \"type\" : \"record\",\n"
+      + "      \"name\" : \"NoOp\",\n" + "      \"fields\" : [ ]\n" + "    }, \"string\" ],\n"
+      + "    \"default\" : { }\n" + "  }, {\n" + "    \"name\" : \"lastName\",\n"
+      + "    \"type\" : [ \"NoOp\", \"string\" ],\n" + "    \"default\" : { }\n" + "  } ]\n" + "}";
+
+  public static final String PARTIAL_UPDATE_STRING_RECORD_SCHEMA_STRING = "{" + "  \"namespace\" : \"example.avro\",  "
+      + "  \"type\": \"record\",   " + "  \"name\": \"StringToRecord\",     " + "  \"fields\": [           "
+      + "       { \"name\": \"" + DEFAULT_KEY_FIELD_PROP + "\", \"type\": \"string\", \"default\": \"\"}, "
+      + "       { \"name\": \"" + DEFAULT_VALUE_FIELD_PROP + "\", \"type\": " + UPDATE_SCHEMA_OF_NESTED_SCHEMA_STRING
+      + " }  " + "  ] " + " } ";
 
   public static final String STRING_SCHEMA = "\"string\"";
 
@@ -533,6 +547,31 @@ public class TestWriteUtils {
         GenericRecord valueRecord = new GenericData.Record(valueSchema);
         valueRecord.put("firstName", firstName + i);
         valueRecord.put("lastName", lastName + i);
+        keyValueRecord.put(DEFAULT_VALUE_FIELD_PROP, valueRecord); // Value
+        writer.append(keyValueRecord);
+      }
+    });
+  }
+
+  public static Schema writeSimpleAvroFileWithStringToPartialUpdateOpRecordSchema(
+      File parentDir,
+      boolean fileNameWithAvroSuffix) throws IOException {
+    String fileName;
+    if (fileNameWithAvroSuffix) {
+      fileName = "simple_string2record.avro";
+    } else {
+      fileName = "simple_string2record";
+    }
+    return writeAvroFile(parentDir, fileName, PARTIAL_UPDATE_STRING_RECORD_SCHEMA_STRING, (recordSchema, writer) -> {
+      Schema valueSchema = AvroCompatibilityHelper.parse(UPDATE_SCHEMA_OF_NESTED_SCHEMA_STRING);
+      String firstName = "first_name_";
+      String lastName = "last_name_";
+      for (int i = 1; i <= 100; ++i) {
+        GenericRecord keyValueRecord = new GenericData.Record(recordSchema);
+        keyValueRecord.put(DEFAULT_KEY_FIELD_PROP, String.valueOf(i)); // Key
+        GenericRecord valueRecord = new UpdateBuilderImpl(valueSchema).setNewFieldValue("firstName", firstName + i)
+            .setNewFieldValue("lastName", lastName + i)
+            .build();
         keyValueRecord.put(DEFAULT_VALUE_FIELD_PROP, valueRecord); // Value
         writer.append(keyValueRecord);
       }


### PR DESCRIPTION


<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## [vpj] Fix regression in partial update + incremental push input schema detection
Fix the regression in checking whether input schema is a update schema or not.
Previously it is using NO_OP_ON_FIELD.name(), while it should use .getName() instead to return "NoOp"

## How was this PR tested?
New unit test and new integration test.

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.