### PR TITLE
[WIP][compat][server][common] Leader hybrid offset lag fix

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
@@ -105,7 +105,8 @@ import static com.linkedin.venice.ConfigKeys.SERVER_SSL_HANDSHAKE_QUEUE_CAPACITY
 import static com.linkedin.venice.ConfigKeys.SERVER_SSL_HANDSHAKE_THREAD_POOL_SIZE;
 import static com.linkedin.venice.ConfigKeys.SERVER_STOP_CONSUMPTION_TIMEOUT_IN_SECONDS;
 import static com.linkedin.venice.ConfigKeys.SERVER_STORE_TO_EARLY_TERMINATION_THRESHOLD_MS_MAP;
-import static com.linkedin.venice.ConfigKeys.SERVER_SYNC_OFFSET_MIN_INTERVAL_MS;
+import static com.linkedin.venice.ConfigKeys.SERVER_SYNC_OFFSET_ENABLED;
+import static com.linkedin.venice.ConfigKeys.SERVER_SYNC_OFFSET_INTERVAL_MS;
 import static com.linkedin.venice.ConfigKeys.SERVER_SYSTEM_STORE_PROMOTION_TO_LEADER_REPLICA_DELAY_SECONDS;
 import static com.linkedin.venice.ConfigKeys.SERVER_UNSUB_AFTER_BATCHPUSH;
 import static com.linkedin.venice.ConfigKeys.SEVER_CALCULATE_QUOTA_USAGE_BASED_ON_PARTITIONS_ASSIGNMENT_ENABLED;
@@ -433,7 +434,9 @@ public class VeniceServerConfig extends VeniceClusterConfig {
   private final PubSubClientsFactory pubSubClientsFactory;
   private final String routerPrincipalName;
 
-  private final long syncOffsetMinIntervalMs;
+  private final long syncOffsetIntervalMs;
+
+  private final boolean syncOffsetEnabled;
 
   public VeniceServerConfig(VeniceProperties serverProperties) throws ConfigurationException {
     this(serverProperties, Collections.emptyMap());
@@ -714,8 +717,8 @@ public class VeniceServerConfig extends VeniceClusterConfig {
       throw new VeniceException(e);
     }
     routerPrincipalName = serverProperties.getString(ROUTER_PRINCIPAL_NAME, "CN=venice-router");
-    syncOffsetMinIntervalMs =
-        serverProperties.getLong(SERVER_SYNC_OFFSET_MIN_INTERVAL_MS, TimeUnit.MINUTES.toMillis(15));
+    syncOffsetIntervalMs = serverProperties.getLong(SERVER_SYNC_OFFSET_INTERVAL_MS, TimeUnit.MINUTES.toMillis(15));
+    syncOffsetEnabled = serverProperties.getBoolean(SERVER_SYNC_OFFSET_ENABLED, false);
   }
 
   long extractIngestionMemoryLimit(
@@ -1250,7 +1253,11 @@ public class VeniceServerConfig extends VeniceClusterConfig {
     return routerPrincipalName;
   }
 
-  public long getSyncOffsetMinIntervalMs() {
-    return syncOffsetMinIntervalMs;
+  public long getSyncOffsetIntervalMs() {
+    return syncOffsetIntervalMs;
+  }
+
+  public boolean isSyncOffsetEnabled() {
+    return syncOffsetEnabled;
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
@@ -105,6 +105,7 @@ import static com.linkedin.venice.ConfigKeys.SERVER_SSL_HANDSHAKE_QUEUE_CAPACITY
 import static com.linkedin.venice.ConfigKeys.SERVER_SSL_HANDSHAKE_THREAD_POOL_SIZE;
 import static com.linkedin.venice.ConfigKeys.SERVER_STOP_CONSUMPTION_TIMEOUT_IN_SECONDS;
 import static com.linkedin.venice.ConfigKeys.SERVER_STORE_TO_EARLY_TERMINATION_THRESHOLD_MS_MAP;
+import static com.linkedin.venice.ConfigKeys.SERVER_SYNC_OFFSET_MIN_INTERVAL_MS;
 import static com.linkedin.venice.ConfigKeys.SERVER_SYSTEM_STORE_PROMOTION_TO_LEADER_REPLICA_DELAY_SECONDS;
 import static com.linkedin.venice.ConfigKeys.SERVER_UNSUB_AFTER_BATCHPUSH;
 import static com.linkedin.venice.ConfigKeys.SEVER_CALCULATE_QUOTA_USAGE_BASED_ON_PARTITIONS_ASSIGNMENT_ENABLED;
@@ -432,6 +433,8 @@ public class VeniceServerConfig extends VeniceClusterConfig {
   private final PubSubClientsFactory pubSubClientsFactory;
   private final String routerPrincipalName;
 
+  private final long syncOffsetMinIntervalMs;
+
   public VeniceServerConfig(VeniceProperties serverProperties) throws ConfigurationException {
     this(serverProperties, Collections.emptyMap());
   }
@@ -711,6 +714,8 @@ public class VeniceServerConfig extends VeniceClusterConfig {
       throw new VeniceException(e);
     }
     routerPrincipalName = serverProperties.getString(ROUTER_PRINCIPAL_NAME, "CN=venice-router");
+    syncOffsetMinIntervalMs =
+        serverProperties.getLong(SERVER_SYNC_OFFSET_MIN_INTERVAL_MS, TimeUnit.MINUTES.toMillis(15));
   }
 
   long extractIngestionMemoryLimit(
@@ -1243,5 +1248,9 @@ public class VeniceServerConfig extends VeniceClusterConfig {
 
   public String getRouterPrincipalName() {
     return routerPrincipalName;
+  }
+
+  public long getSyncOffsetMinIntervalMs() {
+    return syncOffsetMinIntervalMs;
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/PartitionConsumptionState.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/PartitionConsumptionState.java
@@ -187,13 +187,6 @@ public class PartitionConsumptionState {
    */
   private Map<String, Long> latestProcessedUpstreamRTOffsetMap;
 
-  /**
-   * Key: source Kafka url
-   * Value: The timestamp when the latest consumed offset of a specific source RT is written to VT as a
-   * {@link com.linkedin.venice.kafka.protocol.SyncOffset} control message.
-   */
-  private Map<String, Long> latestRTSyncOffsetTimestampMap;
-
   public PartitionConsumptionState(int partition, int amplificationFactor, OffsetRecord offsetRecord, boolean hybrid) {
     this.partition = partition;
     this.amplificationFactor = amplificationFactor;
@@ -223,7 +216,6 @@ public class PartitionConsumptionState {
     // checkpoint upstream offset map
     consumedUpstreamRTOffsetMap = new VeniceConcurrentHashMap<>();
     latestProcessedUpstreamRTOffsetMap = new VeniceConcurrentHashMap<>();
-    latestRTSyncOffsetTimestampMap = new VeniceConcurrentHashMap<>();
     if (offsetRecord.getLeaderTopic() != null && Version.isRealTimeTopic(offsetRecord.getLeaderTopic())) {
       offsetRecord.cloneUpstreamOffsetMap(consumedUpstreamRTOffsetMap);
       offsetRecord.cloneUpstreamOffsetMap(latestProcessedUpstreamRTOffsetMap);
@@ -787,13 +779,5 @@ public class PartitionConsumptionState {
 
   public void setLeaderHostId(String hostId) {
     this.leaderHostId = hostId;
-  }
-
-  public void setLatestRTSyncOffsetTimestamp(String kafkaURL, long timestamp) {
-    latestRTSyncOffsetTimestampMap.put(kafkaURL, timestamp);
-  }
-
-  public long getLatestRTSyncOffsetTimestamp(String kafkaURL) {
-    return latestRTSyncOffsetTimestampMap.getOrDefault(kafkaURL, 0L);
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/PartitionConsumptionState.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/PartitionConsumptionState.java
@@ -187,6 +187,13 @@ public class PartitionConsumptionState {
    */
   private Map<String, Long> latestProcessedUpstreamRTOffsetMap;
 
+  /**
+   * Key: source Kafka url
+   * Value: The timestamp when the latest consumed offset of a specific source RT is written to VT as a
+   * {@link com.linkedin.venice.kafka.protocol.SyncOffset} control message.
+   */
+  private Map<String, Long> latestRTSyncOffsetTimestampMap;
+
   public PartitionConsumptionState(int partition, int amplificationFactor, OffsetRecord offsetRecord, boolean hybrid) {
     this.partition = partition;
     this.amplificationFactor = amplificationFactor;
@@ -216,6 +223,7 @@ public class PartitionConsumptionState {
     // checkpoint upstream offset map
     consumedUpstreamRTOffsetMap = new VeniceConcurrentHashMap<>();
     latestProcessedUpstreamRTOffsetMap = new VeniceConcurrentHashMap<>();
+    latestRTSyncOffsetTimestampMap = new VeniceConcurrentHashMap<>();
     if (offsetRecord.getLeaderTopic() != null && Version.isRealTimeTopic(offsetRecord.getLeaderTopic())) {
       offsetRecord.cloneUpstreamOffsetMap(consumedUpstreamRTOffsetMap);
       offsetRecord.cloneUpstreamOffsetMap(latestProcessedUpstreamRTOffsetMap);
@@ -779,5 +787,13 @@ public class PartitionConsumptionState {
 
   public void setLeaderHostId(String hostId) {
     this.leaderHostId = hostId;
+  }
+
+  public void setLatestRTSyncOffsetTimestamp(String kafkaURL, long timestamp) {
+    latestRTSyncOffsetTimestampMap.put(kafkaURL, timestamp);
+  }
+
+  public long getLatestRTSyncOffsetTimestamp(String kafkaURL) {
+    return latestRTSyncOffsetTimestampMap.getOrDefault(kafkaURL, 0L);
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -2418,6 +2418,16 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
     statusReportAdapter.reportEndOfIncrementalPushReceived(partitionConsumptionState, endVersion.toString());
   }
 
+  protected void processSyncOffsetMessage(
+      ControlMessage controlMessage,
+      int partition,
+      PartitionConsumptionState partitionConsumptionState) {
+    throw new UnsupportedOperationException(
+        ControlMessageType.SYNC_OFFSET.name()
+            + " control message should not be received in Online/Offline model. Topic: " + kafkaVersionTopic
+            + "partition: " + partition);
+  }
+
   /**
    *  This isn't really used for ingestion outside of A/A, so we NoOp here and rely on the actual implementation in
    *  {@link ActiveActiveStoreIngestionTask}
@@ -2436,7 +2446,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
       PartitionConsumptionState partitionConsumptionState) {
     throw new VeniceException(
         ControlMessageType.TOPIC_SWITCH.name() + " control message should not be received in"
-            + "Online/Offline state model. Topic " + kafkaVersionTopic + " partition " + partition);
+            + "Online/Offline state model. Topic: " + kafkaVersionTopic + " partition: " + partition);
   }
 
   /**
@@ -2494,6 +2504,9 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
         break;
       case VERSION_SWAP:
         processVersionSwapMessage(controlMessage, partition, partitionConsumptionState);
+        break;
+      case SYNC_OFFSET:
+        processSyncOffsetMessage(controlMessage, partition, partitionConsumptionState);
         break;
       default:
         throw new UnsupportedMessageTypeException(

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -3592,4 +3592,10 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
     return kafkaValue.leaderMetadataFooter != null && kafkaValue.leaderMetadataFooter.upstreamOffset >= 0;
   }
 
+  /**
+   * Check and send sync offset control message to local VT for the latest consumed upstream RT topic leader offset.
+   */
+  protected void maybeSendSyncOffsetCM() {
+    // No op
+  }
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -1972,4 +1972,10 @@ public class ConfigKeys {
    * Venice router's principal name used for ssl. Default should contain "venice-router".
    */
   public static final String ROUTER_PRINCIPAL_NAME = "router.principal.name";
+
+  /**
+   * The minimum interval in milliseconds for leader replica to send sync offset control message upon consuming SOS and
+   * EOS messages from RT.
+   */
+  public static final String SERVER_SYNC_OFFSET_MIN_INTERVAL_MS = "server.sync.offset.min.interval.ms";
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -1974,8 +1974,15 @@ public class ConfigKeys {
   public static final String ROUTER_PRINCIPAL_NAME = "router.principal.name";
 
   /**
-   * The minimum interval in milliseconds for leader replica to send sync offset control message upon consuming SOS and
-   * EOS messages from RT.
+   * The time interval in milliseconds for leader replica to send sync offset control message to VT for consumers
+   * (including the leader) to keep its latest processed upstream RT offset up-to-date in case when the RT topic ends
+   * with SOS, EOS or skipped records.
    */
-  public static final String SERVER_SYNC_OFFSET_MIN_INTERVAL_MS = "server.sync.offset.min.interval.ms";
+  public static final String SERVER_SYNC_OFFSET_INTERVAL_MS = "server.sync.offset.interval.ms";
+
+  /**
+   * Whether the leader replica will periodically send sync offset control message to VT for consumers to update its
+   * latest processed upstream RT topic offset.
+   */
+  public static final String SERVER_SYNC_OFFSET_ENABLED = "server.sync.offset.enabled";
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/kafka/protocol/enums/ControlMessageType.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/kafka/protocol/enums/ControlMessageType.java
@@ -9,6 +9,7 @@ import com.linkedin.venice.kafka.protocol.EndOfSegment;
 import com.linkedin.venice.kafka.protocol.StartOfIncrementalPush;
 import com.linkedin.venice.kafka.protocol.StartOfPush;
 import com.linkedin.venice.kafka.protocol.StartOfSegment;
+import com.linkedin.venice.kafka.protocol.SyncOffset;
 import com.linkedin.venice.kafka.protocol.TopicSwitch;
 import com.linkedin.venice.kafka.protocol.VersionSwap;
 import com.linkedin.venice.utils.EnumUtils;
@@ -24,7 +25,8 @@ import com.linkedin.venice.utils.VeniceEnumValue;
  */
 public enum ControlMessageType implements VeniceEnumValue {
   START_OF_PUSH(0), END_OF_PUSH(1), START_OF_SEGMENT(2), END_OF_SEGMENT(3), @Deprecated
-  START_OF_BUFFER_REPLAY(4), START_OF_INCREMENTAL_PUSH(5), END_OF_INCREMENTAL_PUSH(6), TOPIC_SWITCH(7), VERSION_SWAP(8);
+  START_OF_BUFFER_REPLAY(4), START_OF_INCREMENTAL_PUSH(5), END_OF_INCREMENTAL_PUSH(6), TOPIC_SWITCH(7), VERSION_SWAP(8),
+  SYNC_OFFSET(9);
 
   /** The value is the byte used on the wire format */
   private final int value;
@@ -69,7 +71,8 @@ public enum ControlMessageType implements VeniceEnumValue {
         return new TopicSwitch();
       case VERSION_SWAP:
         return new VersionSwap();
-
+      case SYNC_OFFSET:
+        return new SyncOffset();
       default:
         throw new VeniceException("Unsupported " + getClass().getSimpleName() + " value: " + value);
     }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/kafka/validation/Segment.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/kafka/validation/Segment.java
@@ -264,6 +264,7 @@ public class Segment {
           case END_OF_INCREMENTAL_PUSH:
           case TOPIC_SWITCH:
           case VERSION_SWAP:
+          case SYNC_OFFSET:
             // All other control messages are handled the same way.
             updateCheckSum(messageEnvelope.getMessageType());
             updateCheckSum(controlMessage.getControlMessageType());

--- a/internal/venice-common/src/main/java/com/linkedin/venice/serialization/avro/AvroProtocolDefinition.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/serialization/avro/AvroProtocolDefinition.java
@@ -44,7 +44,7 @@ public enum AvroProtocolDefinition {
   /**
    * Used for the Kafka topics, including the main data topics as well as the admin topic.
    */
-  KAFKA_MESSAGE_ENVELOPE(23, 11, KafkaMessageEnvelope.class),
+  KAFKA_MESSAGE_ENVELOPE(23, 12, KafkaMessageEnvelope.class),
 
   /**
    * Used to persist the state of a partition in Storage Nodes, including offset,

--- a/internal/venice-common/src/main/resources/avro/KafkaMessageEnvelope/v12/KafkaMessageEnvelope.avsc
+++ b/internal/venice-common/src/main/resources/avro/KafkaMessageEnvelope/v12/KafkaMessageEnvelope.avsc
@@ -1,0 +1,369 @@
+{
+  "name": "KafkaMessageEnvelope",
+  "namespace": "com.linkedin.venice.kafka.protocol",
+  "type": "record",
+  "fields": [
+    {
+      "name": "messageType",
+      "doc": "Using int because Avro Enums are not evolvable. Readers should always handle the 'unknown' value edge case, to account for future evolutions of this protocol. The mapping is the following: 0 => Put, 1 => Delete, 2 => ControlMessage, 3 => Update.",
+      "type": "int"
+    }, {
+      "name": "producerMetadata",
+      "doc": "ProducerMetadata contains information that the consumer can use to identify an upstream producer. This is common for all MessageType.",
+      "type": {
+        "name": "ProducerMetadata",
+        "type": "record",
+        "fields": [
+          {
+            "name": "producerGUID",
+            "doc": "A unique identifier for this producer.",
+            "type": {
+              "name": "GUID",
+              "type": "fixed",
+              "size": 16
+            }
+          }, {
+            "name": "segmentNumber",
+            "doc": "A number used to disambiguate between sequential segments sent into a given partition by a given producer. An incremented SegmentNumber should only be sent following an EndOfSegment control message. For finite streams (such as those bulk-loaded from Hadoop), it can be acceptable to have a single SegmentNumber per producer/partition combination, though that is not something that the downstream consumer should assume. For infinite streams, segments should be terminated and begun anew periodically. This number begins at 0.",
+            "type": "int"
+          }, {
+            "name": "messageSequenceNumber",
+            "doc": "A monotonically increasing number with no gaps used to distinguish unique messages produced in this segment (i.e.: by this producer into a given partition). This number begins at 0 (with a StartOfSegment ControlMessage) and subsequent messages (such as Put) will have a SequenceNumber of 1 and so forth.",
+            "type": "int"
+          }, {
+            "name": "messageTimestamp",
+            "doc": "The time of the producer's local system clock, at the time the message was submitted for production. This is the number of milliseconds from the unix epoch, 1 January 1970 00:00:00.000 UTC.",
+            "type": "long"
+          }, {
+            "name": "logicalTimestamp",
+            "doc": "This timestamp may be specified by the user. Sentinel value of -1 => apps are not using latest lib, -2 => apps have not specified the time. In case of negative values messageTimestamp field will be used for replication metadata.",
+            "type": "long",
+            "default": -1
+          }
+        ]
+      }
+    }, {
+      "name": "payloadUnion",
+      "doc": "This contains the main payload of the message. Which branch of the union is present is based on the previously-defined MessageType field.",
+      "type": [
+        {
+          "name": "Put",
+          "doc": "Put payloads contain a record value, and information on how to deserialize it.",
+          "type": "record",
+          "fields": [
+            {
+              "name": "putValue",
+              "doc": "The record's value to be persisted in the storage engine.",
+              "type": "bytes"
+            }, {
+              "name": "schemaId",
+              "doc": "An identifier used to determine how the PutValue can be deserialized. Also used, in conjunction with the replicationMetadataVersionId, to deserialize the replicationMetadataPayload.",
+              "type": "int"
+            }, {
+              "name": "replicationMetadataVersionId",
+              "doc": "The A/A replication metadata schema version ID that will be used to deserialize replicationMetadataPayload.",
+              "type": "int",
+              "default": -1
+            }, {
+              "name": "replicationMetadataPayload",
+              "doc": "The serialized value of the replication metadata schema.",
+              "type": "bytes",
+              "default": ""
+            }
+          ]
+        }, {
+          "name": "Update",
+          "doc": "Partial update operation, which merges the update value with the existing value.",
+          "type": "record",
+          "fields": [
+            {
+              "name": "schemaId",
+              "doc": "The original schema ID.",
+              "type": "int"
+            }, {
+              "name": "updateSchemaId",
+              "doc": "The derived schema ID that will be used to deserialize updateValue.",
+              "type": "int"
+            }, {
+              "name": "updateValue",
+              "doc": "New value(s) for parts of the record that need to be updated.",
+              "type": "bytes"
+            }
+          ]
+        }, {
+          "name": "Delete",
+          "doc": "Delete payloads contain fields related to replication metadata of the record.",
+          "type": "record",
+          "fields": [
+            {
+              "name": "schemaId",
+              "doc": "An identifier used, in conjunction with the replicationMetadataVersionId, to deserialize the replicationMetadataPayload.",
+              "type": "int",
+              "default": -1
+            }, {
+              "name": "replicationMetadataVersionId",
+              "doc": "The A/A replication metadata schema version ID that will be used to deserialize replicationMetadataPayload.",
+              "type": "int",
+              "default": -1
+            }, {
+              "name": "replicationMetadataPayload",
+              "doc": "The serialized value of the replication metadata schema.",
+              "type": "bytes",
+              "default": ""
+            }
+          ]
+        }, {
+          "name": "ControlMessage",
+          "doc": "ControlMessage payloads contain metadata about the stream of data, for validation and debuggability purposes.",
+          "type": "record",
+          "fields": [
+            {
+              "name": "controlMessageType",
+              "doc": "Using int because Avro Enums are not evolvable. Readers should always handle the 'unknown' value edge case, to account for future evolutions of this protocol. The mapping is the following: 0 => StartOfPush, 1 => EndOfPush, 2 => StartOfSegment, 3 => EndOfSegment, 4 => StartOfBufferReplay (Deprecated), 5 => StartOfIncrementalPush, 6 => EndOfIncrementalPush, 7 => TopicSwitch, 8 => VersionSwap, 9 => SyncOffset",
+              "type": "int"
+            }, {
+              "name": "debugInfo",
+              "doc": "This metadata is for logging and traceability purposes. It can be used to propagate information about the producer, the environment it runs in, or the source of data being produced into Venice. There should be no assumptions that any of this data will be used (or even looked at) by the downstream consumer in any particular way.",
+              "type": {
+                "type": "map",
+                "values": "string"
+              }
+            }, {
+              "name": "controlMessageUnion",
+              "doc": "This contains the ControlMessage data which is specific to each type of ControlMessage. Which branch of the union is present is based on the previously-defined MessageType field.",
+              "type": [
+                {
+                  "name": "StartOfPush",
+                  "doc": "This ControlMessage is sent once per partition, at the beginning of a bulk load, before any of the data producers come online. This does not contain any data beyond the one which is common to all ControlMessageType.",
+                  "type": "record",
+                  "fields": [
+                    {
+                      "name": "sorted",
+                      "doc": "Whether the messages inside current topic partition between 'StartOfPush' control message and 'EndOfPush' control message is lexicographically sorted by key bytes",
+                      "type": "boolean",
+                      "default": false
+                    }, {
+                      "name": "chunked",
+                      "doc": "Whether the messages inside the current push are encoded with chunking support. If true, this means keys will be prefixed with ChunkId, and values may contain a ChunkedValueManifest (if schema is defined as -20).",
+                      "type": "boolean",
+                      "default": false
+                    }, {
+                      "name": "compressionStrategy",
+                      "doc": "What type of compression strategy the current push uses. Using int because Avro Enums are not evolvable. The mapping is the following: 0 => NO_OP, 1 => GZIP, 2 => ZSTD, 3 => ZSTD_WITH_DICT",
+                      "type": "int",
+                      "default": 0
+                    }, {
+                      "name": "compressionDictionary",
+                      "doc": "The raw bytes of dictionary used to compress/decompress records.",
+                      "type": ["null", "bytes"],
+                      "default": null
+                    }, {
+                      "name": "timestampPolicy",
+                      "doc": "The policy to determine timestamps of batch push records. 0 => no per record replication metadata is stored, hybrid writes always win over batch, 1 => no per record timestamp metadata is stored, Start-Of-Push Control message's logicalTimestamp is treated as last update timestamp for all batch record, and hybrid writes wins only when their own logicalTimestamp are higher, 2 => per record timestamp metadata is provided by the push job and stored for each key, enabling full conflict resolution granularity on a per field basis, just like when merging concurrent update operations.",
+                      "type": "int",
+                      "default": 0
+                    }
+                  ]
+                }, {
+                  "name": "EndOfPush",
+                  "doc": "This ControlMessage is sent once per partition, at the end of a bulk load, after all of the data producers come online. This does not contain any data beyond the one which is common to all ControlMessageType.",
+                  "type": "record",
+                  "fields": []
+                }, {
+                  "name": "StartOfSegment",
+                  "doc": "This ControlMessage is sent at least once per partition per producer. It may be sent more than once per partition/producer, but only after the producer has sent an EndOfSegment into that partition to terminate the previously started segment.",
+                  "type": "record",
+                  "fields": [
+                    {
+                      "name": "checksumType",
+                      "doc": "Using int because Avro Enums are not evolvable. Readers should always handle the 'unknown' value edge case, to account for future evolutions of this protocol. The downstream consumer is expected to compute this checksum and use it to validate the incoming stream of data. The current mapping is the following: 0 => None, 1 => MD5, 2 => Adler32, 3 => CRC32.",
+                      "type": "int"
+                    }, {
+                      "name": "upcomingAggregates",
+                      "doc": "An array of names of aggregate computation strategies for which there will be a value percolated in the corresponding EndOfSegment ControlMessage. The downstream consumer may choose to compute these aggregates on its own and use them as additional validation safeguards, or it may choose to merely log them, or even ignore them altogether.",
+                      "type": {
+                        "type": "array",
+                        "items": "string"
+                      }
+                    }
+                  ]
+                }, {
+                  "name": "EndOfSegment",
+                  "doc": "This ControlMessage is sent at least once per partition per producer. It may be sent more than once per partition/producer, but only after the producer has sent a StartOfSegment into that partition. There should be an equal number of StartOfSegment and EndOfSegment messages in each producer/partition pair.",
+                  "type": "record",
+                  "fields": [
+                    {
+                      "name": "checksumValue",
+                      "doc": "The value of the checksum computed since the last StartOfSegment ControlMessage.",
+                      "type": "bytes"
+                    }, {
+                      "name": "computedAggregates",
+                      "doc": "A map containing the results of the aggregate computation strategies that were promised in the previous StartOfSegment ControlMessage. The downstream consumer may choose to compare the value of these aggregates against those that it computed on its own ir oder to use them as additional validation safeguards, or it may choose to merely log them, or even ignore them altogether.",
+                      "type": {
+                        "type": "array",
+                        "items": "long"
+                      }
+                    }, {
+                      "name": "finalSegment",
+                      "doc": "This field is set to true when the producer knows that there is no more data coming from its data source after this EndOfSegment. This happens at the time the producer is closed.",
+                      "type": "boolean"
+                    }
+                  ]
+                }, {
+                  "name": "StartOfBufferReplay",
+                  "doc": "[Deprecated] This ControlMessage is sent by the Controller, once per partition, after the EndOfPush ControlMessage, in Hybrid Stores that ingest from both offline and nearline sources. It contains information about the the offsets from which the Buffer Replay Service started replaying data from the real-time buffer topic onto the store-version topic. This can be used as a synchronization marker between the real-time buffer topic and the store-version topic, akin to how a clapperboard is used to synchronize sound and image in filmmaking. This synchronization marker can in turn be used by the consumer to compute an offset lag.",
+                  "type": "record",
+                  "fields": [
+                    {
+                      "name": "sourceOffsets",
+                      "doc": "Array of offsets from the real-time buffer topic at which the Buffer Replay Service started replaying data. The index position of the array corresponds to the partition number in the real-time buffer.",
+                      "type": {
+                        "type": "array",
+                        "items": "long"
+                      }
+                    }, {
+                      "name": "sourceKafkaCluster",
+                      "doc": "Kafka bootstrap servers URL of the cluster where the source buffer exists.",
+                      "type": "string"
+                    }, {
+                      "name": "sourceTopicName",
+                      "doc": "Name of the source buffer topic.",
+                      "type": "string"
+                    }
+                  ]
+                }, {
+                  "name": "StartOfIncrementalPush",
+                  "doc": "This ControlMessage is sent per partition by each offline incremental push job, once per partition, at the beginning of a incremental push.",
+                  "type": "record",
+                  "fields": [
+                    {
+                      "name": "version",
+                      "doc": "The version of current incremental push. Each incremental push is associated with a version. Both 'StartOfIncrementalPush' control message and 'EndOfIncrementalPush' contain version info so they can be paired to each other.",
+                      "type": "string"
+                    }
+                  ]
+                }, {
+                  "name": "EndOfIncrementalPush",
+                  "doc": "This ControlMessage is sent per partition by each offline incremental push job, once per partition, at the end of a incremental push",
+                  "type": "record",
+                  "fields": [
+                    {
+                      "name": "version",
+                      "doc": "The version of current incremental push. Each incremental push is associated with a version. Both 'StartOfIncrementalPush' control message and 'EndOfIncrementalPush' contain version info so they can be paired to each other.",
+                      "type": "string"
+                    }
+                  ]
+                }, {
+                  "name": "TopicSwitch",
+                  "doc": "This ControlMessage is sent by the Controller, once per partition; it will only be used in leader/follower state transition model; this control message will indicate the leader to switch to a new source topic and start consuming from offset with a specific timestamp.",
+                  "type": "record",
+                  "fields": [
+                    {
+                      "name": "sourceKafkaServers",
+                      "doc": "A list of Kafka bootstrap servers URLs where the new source topic exists; currently there will be only one URL in the list, but the list opens up the possibility for leader to consume from different fabrics in active-active replication mode.",
+                      "type": {
+                        "type": "array",
+                        "items": "string"
+                      }
+                    }, {
+                      "name": "sourceTopicName",
+                      "doc": "Name of new the source topic.",
+                      "type": "string"
+                    }, {
+                      "name": "rewindStartTimestamp",
+                      "doc": "The creation time of this control message in parent controller minus the rewind time of the corresponding store; leaders in different fabrics will get the offset of the source topic by the same start timestamp and start consuming from there; if timestamp is 0, leader will start consuming from the beginning of the source topic.",
+                      "type": "long"
+                    }
+                  ]
+                }, {
+                  "name": "VersionSwap",
+                  "doc": "This controlMessage is written to the real-time topic by the controller or to the store-version topic by the current version's leader server. It can be used to let current version and future version synchronize on a specific point for all regions' real-time topics, to guarantee there is only one store version producing to change capture topic all the time. It can also be used by the consumer client to switch to another store-version topic and filter messages that have a lower watermark than the one dictated by the leader.",
+                  "type": "record",
+                  "fields": [
+                    {
+                      "name": "oldServingVersionTopic",
+                      "doc": "Name of the old source topic we are switching from.",
+                      "type": "string"
+                    }, {
+                      "name": "newServingVersionTopic",
+                      "doc": "Name of the new source topic we are switching to.",
+                      "type": "string"
+                    }, {
+                      "name": "localHighWatermarks",
+                      "doc": "The latest offsets of all real-time topic has been consumed up until now.",
+                      "type": [
+                        "null",
+                        {
+                          "type": "array",
+                          "items": "long"
+                        }
+                      ],
+                      "default": null
+                    }, {
+                      "name": "isRepush",
+                      "doc": "Flag to indicate this version swap is triggered by repush or not.",
+                      "type": "boolean",
+                      "default": false
+                    }, {
+                      "name": "isLastVersionSwapMessageFromRealTimeTopic",
+                      "doc": "Flag to indicate this version swap message in version topic is triggered by the last version swap in real time topic the leader server has received. With this flag, new leader will be able to recover the full state during leadership handover, when we rely on real-time topics for all regions to achieve version swap synchronization.",
+                      "type": "boolean",
+                      "default": false
+                    }
+                  ]
+                }, {
+                  "name": "SyncOffset",
+                  "doc": "This ControlMessage provide VT consumers on what is the latest processed upstream offset for a given fabric",
+                  "type": "record",
+                  "fields": [
+                    {
+                      "name": "upstreamOffset",
+                      "doc": "The latest processed upstream offset for a given fabric. Leader will produce this CM to VT and consumers of VT will know the leader's progress upon consumption",
+                      "type": "long"
+                    }, {
+                      "name": "kafkaURL",
+                      "doc": "Kafka URL associated with the fabric that the offset belongs to. Default of null to represent the local fabric's kafka URL",
+                      "type": [
+                        "null",
+                        "string"
+                      ],
+                      "default": null
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }, {
+      "name": "leaderMetadataFooter",
+      "doc": "A optional footer that leader SN can use to give extra L/F related mete data",
+      "type": [
+        "null",
+        {
+          "name": "LeaderMetadata",
+          "type": "record",
+          "fields": [
+            {
+              "name": "hostName",
+              "doc": "The identifier of the host which sends the message.This helps detect the 'split brain' scenario in leader SN. Notice that it is different from GUID. GUID represents the one who produces the message. In 'pass-through' mode, the relaying producer will reuse the same GUID from the upstream message.",
+              "type": "string"
+            }, {
+              "name": "upstreamOffset",
+              "doc": "Where this message is located in RT/GF/remote VT topic. This value will be determined and modified by leader SN at runtime.",
+              "type": "long",
+              "default": -1
+            }, {
+              "name": "upstreamKafkaClusterId",
+              "doc": "Kafka bootstrap server URL of the cluster where RT/GF/remote VT topic exists, represented by an integer to reduce the overhead. This value will be determined and modified by leader SN at runtime.",
+              "type": "int",
+              "default": -1
+            }
+          ]
+        }
+      ],
+      "default": null
+    }
+  ]
+}

--- a/internal/venice-common/src/main/resources/avro/KafkaMessageEnvelope/v12/KafkaMessageEnvelope.avsc
+++ b/internal/venice-common/src/main/resources/avro/KafkaMessageEnvelope/v12/KafkaMessageEnvelope.avsc
@@ -317,17 +317,12 @@
                   "type": "record",
                   "fields": [
                     {
-                      "name": "upstreamOffset",
-                      "doc": "The latest processed upstream offset for a given fabric. Leader will produce this CM to VT and consumers of VT will know the leader's progress upon consumption",
-                      "type": "long"
-                    }, {
-                      "name": "kafkaURL",
-                      "doc": "Kafka URL associated with the fabric that the offset belongs to. Default of null to represent the local fabric's kafka URL",
-                      "type": [
-                        "null",
-                        "string"
-                      ],
-                      "default": null
+                      "name": "upstreamLeaderOffsetMap",
+                      "doc": "A map of Kafka URL to the latest consumed leader upstream offset for the given fabric. Leader will produce this CM to VT and consumers of VT (including the leader) will update the leader's latest processed upstream offset upon consumption for proper upstream lag calculation",
+                      "type": {
+                        "type": "map",
+                        "values": "long"
+                      }
                     }
                   ]
                 }


### PR DESCRIPTION
## [WIP][compat][server][common] Leader hybrid offset lag fix
Introduced new control message SyncOffset. The purpose of the new CM is to allow leader replica update its latest processed upstream RT offset and calculate lag correctly when the tail of the RT is filled with SOS and EOS CMs. 

In addition, this will unblock the rollout of A/A lag calculation since it will address the edge case where all the ending
messages of a remote RT topic are ignored due to DCR. Currently this will produce a positive lag when the consumption
of that remote fabric is actually up-to-date.

Here is the new flow, upon consuming SOS, EOS CMs or skipped records from upstream RT as leader the following will
happen:
1. Leader will update the in-memory latest consumed upstream RT offset.
2. The leader will periodically produce the SyncOffset CM containing a map of KafkaURLs and its corresponding latest consumed upstream RT offset (works for both L/F and A/A). 
3. Upon processing the CM in the drainer the consumer will only update its latest processed leader upstream RT offset
if the offset in the CM is greater.

## How was this PR tested?
TODO

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.