### PR TITLE
[producer] Log details if input doesn't match any value schema in ProducerTool

### DIFF
--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/schema/RouterBasedStoreSchemaFetcher.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/schema/RouterBasedStoreSchemaFetcher.java
@@ -16,8 +16,8 @@ import com.linkedin.venice.utils.RetryUtils;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.Collections;
-import java.util.HashSet;
-import java.util.Set;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import org.apache.avro.Schema;
@@ -104,12 +104,12 @@ public class RouterBasedStoreSchemaFetcher implements StoreSchemaFetcher {
   }
 
   @Override
-  public Set<Schema> getAllValueSchemas() {
+  public Map<Integer, Schema> getAllValueSchemasWithId() {
     MultiSchemaResponse multiSchemaResponse = fetchAllValueSchemas();
-    Set<Schema> schemaSet = new HashSet<>();
+    Map<Integer, Schema> schemaSet = new HashMap<>();
     try {
       for (MultiSchemaResponse.Schema schema: multiSchemaResponse.getSchemas()) {
-        schemaSet.add(parseSchemaFromJSONLooseValidation(schema.getSchemaStr()));
+        schemaSet.put(schema.getId(), parseSchemaFromJSONLooseValidation(schema.getSchemaStr()));
       }
     } catch (Exception e) {
       throw new VeniceException("Got exception while parsing value schema", e);

--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/schema/StoreSchemaFetcher.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/schema/StoreSchemaFetcher.java
@@ -3,6 +3,8 @@ package com.linkedin.venice.client.schema;
 import com.linkedin.venice.exceptions.InvalidVeniceSchemaException;
 import com.linkedin.venice.exceptions.VeniceException;
 import java.io.Closeable;
+import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericRecord;
@@ -30,7 +32,14 @@ public interface StoreSchemaFetcher extends Closeable {
   /**
    * Returns all value schemas of the store.
    */
-  Set<Schema> getAllValueSchemas();
+  default Set<Schema> getAllValueSchemas() {
+    return new HashSet<>(getAllValueSchemasWithId().values());
+  }
+
+  /**
+   * Returns all value schemas of the store as a map with schema id as the key.
+   */
+  Map<Integer, Schema> getAllValueSchemasWithId();
 
   /**
    * Returns the Update (Write Compute) schema of the provided Value schema. The returned schema is used to construct


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Log details if input doesn't match any value schema in ProducerTool
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
It will give users more context about the errors. New output format:
```
[ERROR] Value schema not found. Is a schema that is compatible with the specified data already registered?
Exception messages for each schema:
	Schema Id: 1. Exception: org.apache.avro.AvroTypeException: Expected start-union. Got START_ARRAY
	Schema Id: 2. Exception: org.apache.avro.AvroTypeException: Expected start-union. Got START_ARRAY
```

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
Tested locally. GH CI for the rest

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.