### PR TITLE
[server] Fix storage node read quota enforcement

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
@@ -508,7 +508,7 @@ public class VeniceServerConfig extends VeniceClusterConfig {
     serverCalculateQuotaUsageBasedOnPartitionsAssignmentEnabled =
         serverProperties.getBoolean(SEVER_CALCULATE_QUOTA_USAGE_BASED_ON_PARTITIONS_ASSIGNMENT_ENABLED, true);
 
-    nodeCapacityInRcu = serverProperties.getLong(SERVER_NODE_CAPACITY_RCU, 50000);
+    nodeCapacityInRcu = serverProperties.getLong(SERVER_NODE_CAPACITY_RCU, 100000);
     kafkaMaxPollRecords = serverProperties.getInt(SERVER_KAFKA_MAX_POLL_RECORDS, 100);
     kafkaPollRetryTimes = serverProperties.getInt(SERVER_KAFKA_POLL_RETRY_TIMES, 100);
     kafkaPollRetryBackoffMs = serverProperties.getInt(SERVER_KAFKA_POLL_RETRY_BACKOFF_MS, 0);

--- a/docker/venice-client/Dockerfile
+++ b/docker/venice-client/Dockerfile
@@ -5,7 +5,7 @@ ENV VENICE_DIR=/opt/venice
 RUN apt-get update
 RUN apt-get install netcat tree wget python3 -y
 RUN mkdir -p "${VENICE_DIR}/bin"
-RUN wget -O ${VENICE_DIR}/bin/avro-tools.jar https://downloads.apache.org/avro/stable/java/avro-tools-1.11.2.jar
+RUN wget -O ${VENICE_DIR}/bin/avro-tools.jar https://repo1.maven.org/maven2/org/apache/avro/avro-tools/1.11.2/avro-tools-1.11.2.jar
 RUN wget -O ${VENICE_DIR}/bin/hadoop-mapreduce-client-core.jar https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-mapreduce-client-core/2.3.0/hadoop-mapreduce-client-core-2.3.0.jar
 RUN wget -O ${VENICE_DIR}/bin/hadoop-mapreduce-client-common.jar https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-mapreduce-client-common/2.3.0/hadoop-mapreduce-client-common-2.3.0.jar
 RUN wget -O ${VENICE_DIR}/bin/hadoop-common.jar https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-common/2.3.0/hadoop-common-2.3.0.jar

--- a/internal/venice-common/src/main/java/com/linkedin/venice/throttle/TokenBucket.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/throttle/TokenBucket.java
@@ -54,8 +54,7 @@ public class TokenBucket {
     tokensConsumedSinceLastRefill = new AtomicLong(0);
     nextUpdateTime = clock.millis() + refillIntervalMs;
 
-    float refillIntervalSeconds = refillIntervalMs / (float) 1000;
-    refillPerSecond = refillAmount / refillIntervalSeconds;
+    refillPerSecond = refillAmount / (float) refillInterval;
   }
 
   /**
@@ -106,14 +105,6 @@ public class TokenBucket {
   public long getStaleTokenCount() {
     // TODO: maybe update the token after getting the stale token count
     return tokens.get();
-  }
-
-  /**
-   * This method does not call #update(), so it is only accurate as of the last time #tryConsume() and update() was called
-   * @return ratio between number of tokens consumed since last refill over the total token count after the last refill
-   */
-  public double getStaleUsageRatio() {
-    return (double) tokensConsumedSinceLastRefill.get() / (double) tokensCountAfterLastRefill.get();
   }
 
   public boolean tryConsume(long tokensToConsume) {

--- a/internal/venice-common/src/main/java/com/linkedin/venice/throttle/TokenBucket.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/throttle/TokenBucket.java
@@ -54,7 +54,7 @@ public class TokenBucket {
     tokensConsumedSinceLastRefill = new AtomicLong(0);
     nextUpdateTime = clock.millis() + refillIntervalMs;
 
-    refillPerSecond = refillAmount / (float) refillInterval;
+    refillPerSecond = refillAmount / (float) refillUnit.toSeconds(refillInterval);
   }
 
   /**

--- a/internal/venice-common/src/test/java/com/linkedin/venice/throttle/TokenBucketTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/throttle/TokenBucketTest.java
@@ -33,9 +33,13 @@ public class TokenBucketTest {
         tokenBucket.getStaleTokenCount(),
         20,
         "After failing to consume tokens, the remaining tokens in the bucket must be unchanged");
+    assertEquals(tokenBucket.getStaleUsageRatio(), 0d, "Stale usage ratio should be zero before any refill");
     doReturn(start + 3500).when(mockClock).millis(); // 3 refills of 10 each puts bucket at 50.
 
     assertTrue(tokenBucket.tryConsume(40), "After refill, bucket must support consumption");
     assertEquals(tokenBucket.getStaleTokenCount(), 10, "After refill and consumption, bucket must have correct tokens");
+    double expectedRatio =
+        ((double) 160 / (double) TimeUnit.MILLISECONDS.toSeconds(3500)) / tokenBucket.getAmortizedRefillPerSecond();
+    assertEquals(tokenBucket.getStaleUsageRatio(), expectedRatio);
   }
 }

--- a/internal/venice-common/src/test/java/com/linkedin/venice/throttle/TokenBucketTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/throttle/TokenBucketTest.java
@@ -28,26 +28,14 @@ public class TokenBucketTest {
         tokenBucket.getStaleTokenCount(),
         20,
         "After consuming tokens, the remaining tokens in the bucket must be reduced");
-    assertEquals(
-        tokenBucket.getStaleUsageRatio(),
-        (double) 80 / (double) 100,
-        "No new consumption or refill since last consumption of 80, usage ratio should be 80/100");
     assertFalse(tokenBucket.tryConsume(40), "TokenBucket must not allow consuming more tokens than available");
     assertEquals(
         tokenBucket.getStaleTokenCount(),
         20,
         "After failing to consume tokens, the remaining tokens in the bucket must be unchanged");
-    assertEquals(
-        tokenBucket.getStaleUsageRatio(),
-        (double) 80 / (double) 100,
-        "After failing to consume tokens, the usage ratio should remain to be 80/100");
     doReturn(start + 3500).when(mockClock).millis(); // 3 refills of 10 each puts bucket at 50.
 
     assertTrue(tokenBucket.tryConsume(40), "After refill, bucket must support consumption");
     assertEquals(tokenBucket.getStaleTokenCount(), 10, "After refill and consumption, bucket must have correct tokens");
-    assertEquals(
-        tokenBucket.getStaleUsageRatio(),
-        (double) 40 / (double) 50,
-        "After 3 refills and the most recent consumption of 40 the usage ratio should be 40/50");
   }
 }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/fastclient/FastClientGrpcServerReadQuotaTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/fastclient/FastClientGrpcServerReadQuotaTest.java
@@ -60,11 +60,13 @@ public class FastClientGrpcServerReadQuotaTest extends AbstractClientEndToEndSet
     String readQuotaRequestedString = "." + storeName + "--quota_rcu_requested.Count";
     String readQuotaRejectedString = "." + storeName + "--quota_rcu_rejected.Count";
     String readQuotaAllowedUnintentionally = "." + storeName + "--quota_rcu_allowed_unintentionally.Count";
+    String readQuotaUsageRatio = "." + storeName + "--quota_requested_usage_ratio.Gauge";
     TestUtils.waitForNonDeterministicAssertion(10, TimeUnit.SECONDS, () -> {
       for (MetricsRepository serverMetric: serverMetrics) {
         assertNotNull(serverMetric.getMetric(readQuotaRequestedString));
         assertNotNull(serverMetric.getMetric(readQuotaRejectedString));
         assertNotNull(serverMetric.getMetric(readQuotaAllowedUnintentionally));
+        assertNotNull(serverMetric.getMetric(readQuotaUsageRatio));
       }
     });
     int quotaRequestedSum = 0;

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/fastclient/FastClientGrpcServerReadQuotaTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/fastclient/FastClientGrpcServerReadQuotaTest.java
@@ -59,19 +59,19 @@ public class FastClientGrpcServerReadQuotaTest extends AbstractClientEndToEndSet
     }
     String readQuotaRequestedString = "." + storeName + "--quota_rcu_requested.Count";
     String readQuotaRejectedString = "." + storeName + "--quota_rcu_rejected.Count";
-    String readQuotaUsageRatio = "." + storeName + "--read_quota_usage_ratio.Gauge";
+    String readQuotaAllowedUnintentionally = "." + storeName + "--quota_rcu_allowed_unintentionally.Count";
     TestUtils.waitForNonDeterministicAssertion(10, TimeUnit.SECONDS, () -> {
       for (MetricsRepository serverMetric: serverMetrics) {
         assertNotNull(serverMetric.getMetric(readQuotaRequestedString));
         assertNotNull(serverMetric.getMetric(readQuotaRejectedString));
-        assertNotNull(serverMetric.getMetric(readQuotaUsageRatio));
+        assertNotNull(serverMetric.getMetric(readQuotaAllowedUnintentionally));
       }
     });
     int quotaRequestedSum = 0;
     for (MetricsRepository serverMetric: serverMetrics) {
       quotaRequestedSum += serverMetric.getMetric(readQuotaRequestedString).value();
       assertEquals(serverMetric.getMetric(readQuotaRejectedString).value(), 0d);
-      assertTrue(serverMetric.getMetric(readQuotaUsageRatio).value() > 0);
+      assertEquals(serverMetric.getMetric(readQuotaAllowedUnintentionally).value(), 0d);
     }
     assertTrue(quotaRequestedSum >= 500, "Quota requested sum: " + quotaRequestedSum);
 

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/fastclient/FastClientServerReadQuotaTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/fastclient/FastClientServerReadQuotaTest.java
@@ -49,6 +49,7 @@ public class FastClientServerReadQuotaTest extends AbstractClientEndToEndSetup {
     String readQuotaRequestedString = "." + storeName + "--quota_rcu_requested.Count";
     String readQuotaRejectedString = "." + storeName + "--quota_rcu_rejected.Count";
     String readQuotaAllowedUnintentionally = "." + storeName + "--quota_rcu_allowed_unintentionally.Count";
+    String readQuotaUsageRatio = "." + storeName + "--quota_requested_usage_ratio.Gauge";
     String clientConnectionCountGaugeString = ".server_connection_stats--client_connection_count.Gauge";
     String routerConnectionCountGaugeString = ".server_connection_stats--router_connection_count.Gauge";
     String clientConnectionCountRateString = ".server_connection_stats--client_connection_count.OccurrenceRate";
@@ -58,6 +59,7 @@ public class FastClientServerReadQuotaTest extends AbstractClientEndToEndSetup {
         assertNotNull(serverMetric.getMetric(readQuotaStorageNodeTokenBucketRemaining));
         assertNotNull(serverMetric.getMetric(readQuotaRequestedString));
         assertNotNull(serverMetric.getMetric(readQuotaRejectedString));
+        assertNotNull(serverMetric.getMetric(readQuotaUsageRatio));
         assertNotNull(serverMetric.getMetric(readQuotaAllowedUnintentionally));
         assertNotNull(serverMetric.getMetric(clientConnectionCountGaugeString));
         assertNotNull(serverMetric.getMetric(routerConnectionCountGaugeString));
@@ -103,7 +105,6 @@ public class FastClientServerReadQuotaTest extends AbstractClientEndToEndSetup {
     for (MetricsRepository serverMetric: serverMetrics) {
       if (serverMetric.getMetric(readQuotaRejectedString).value() > 0) {
         readQuotaRejected = true;
-        break;
       }
     }
     assertTrue(readQuotaRejected);

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/fastclient/FastClientServerReadQuotaTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/fastclient/FastClientServerReadQuotaTest.java
@@ -44,18 +44,21 @@ public class FastClientServerReadQuotaTest extends AbstractClientEndToEndSetup {
     for (int i = 0; i < veniceCluster.getVeniceServers().size(); i++) {
       serverMetrics.add(veniceCluster.getVeniceServers().get(i).getMetricsRepository());
     }
+    String readQuotaStorageNodeTokenBucketRemaining =
+        "." + "venice-storage-node-token-bucket--QuotaRcuTokensRemaining.Gauge";
     String readQuotaRequestedString = "." + storeName + "--quota_rcu_requested.Count";
     String readQuotaRejectedString = "." + storeName + "--quota_rcu_rejected.Count";
-    String readQuotaUsageRatio = "." + storeName + "--read_quota_usage_ratio.Gauge";
+    String readQuotaAllowedUnintentionally = "." + storeName + "--quota_rcu_allowed_unintentionally.Count";
     String clientConnectionCountGaugeString = ".server_connection_stats--client_connection_count.Gauge";
     String routerConnectionCountGaugeString = ".server_connection_stats--router_connection_count.Gauge";
     String clientConnectionCountRateString = ".server_connection_stats--client_connection_count.OccurrenceRate";
     String routerConnectionCountRateString = ".server_connection_stats--router_connection_count.OccurrenceRate";
     TestUtils.waitForNonDeterministicAssertion(10, TimeUnit.SECONDS, () -> {
       for (MetricsRepository serverMetric: serverMetrics) {
+        assertNotNull(serverMetric.getMetric(readQuotaStorageNodeTokenBucketRemaining));
         assertNotNull(serverMetric.getMetric(readQuotaRequestedString));
         assertNotNull(serverMetric.getMetric(readQuotaRejectedString));
-        assertNotNull(serverMetric.getMetric(readQuotaUsageRatio));
+        assertNotNull(serverMetric.getMetric(readQuotaAllowedUnintentionally));
         assertNotNull(serverMetric.getMetric(clientConnectionCountGaugeString));
         assertNotNull(serverMetric.getMetric(routerConnectionCountGaugeString));
         assertNotNull(serverMetric.getMetric(clientConnectionCountRateString));
@@ -70,7 +73,8 @@ public class FastClientServerReadQuotaTest extends AbstractClientEndToEndSetup {
       clientConnectionCountRateSum += serverMetric.getMetric(clientConnectionCountRateString).value();
       routerConnectionCountRateSum += serverMetric.getMetric(routerConnectionCountRateString).value();
       assertEquals(serverMetric.getMetric(readQuotaRejectedString).value(), 0d);
-      assertTrue(serverMetric.getMetric(readQuotaUsageRatio).value() > 0);
+      assertEquals(serverMetric.getMetric(readQuotaAllowedUnintentionally).value(), 0d);
+      assertTrue(serverMetric.getMetric(readQuotaStorageNodeTokenBucketRemaining).value() > 0d);
     }
     assertTrue(quotaRequestedSum >= 500, "Quota requested sum: " + quotaRequestedSum);
     assertTrue(clientConnectionCountRateSum > 0, "Servers should have more than 0 client connections");

--- a/services/venice-server/src/main/java/com/linkedin/venice/listener/HttpChannelInitializer.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/listener/HttpChannelInitializer.java
@@ -123,7 +123,8 @@ public class HttpChannelInitializer extends ChannelInitializer<SocketChannel> {
           storeMetadataRepository,
           customizedViewRepository,
           nodeId,
-          quotaUsageStats);
+          quotaUsageStats,
+          metricsRepository);
 
       // Token Bucket Stats for a store must be initialized when that store is created
       this.quotaTokenBucketStats = new AggServerQuotaTokenBucketStats(metricsRepository, quotaEnforcer);

--- a/services/venice-server/src/main/java/com/linkedin/venice/listener/ReadQuotaEnforcementHandler.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/listener/ReadQuotaEnforcementHandler.java
@@ -388,7 +388,7 @@ public class ReadQuotaEnforcementHandler extends SimpleChannelInboundHandler<Rou
 
   @Override
   public void onExternalViewChange(PartitionAssignment partitionAssignment) {
-    updateQuota(partitionAssignment);
+    // Ignore this event since the partition assignment triggered by EV won't contain the right states.
   }
 
   @Override

--- a/services/venice-server/src/main/java/com/linkedin/venice/listener/ReadQuotaEnforcementHandler.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/listener/ReadQuotaEnforcementHandler.java
@@ -22,6 +22,7 @@ import com.linkedin.venice.pushmonitor.ReadOnlyPartitionStatus;
 import com.linkedin.venice.routerapi.ReplicaState;
 import com.linkedin.venice.stats.AbstractVeniceAggStats;
 import com.linkedin.venice.stats.AggServerQuotaUsageStats;
+import com.linkedin.venice.stats.ServerQuotaTokenBucketStats;
 import com.linkedin.venice.throttle.TokenBucket;
 import com.linkedin.venice.utils.ExpiringSet;
 import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
@@ -30,6 +31,7 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.util.ReferenceCountUtil;
+import io.tehuti.metrics.MetricsRepository;
 import java.time.Clock;
 import java.util.ArrayList;
 import java.util.List;
@@ -47,8 +49,10 @@ import org.apache.logging.log4j.Logger;
 public class ReadQuotaEnforcementHandler extends SimpleChannelInboundHandler<RouterRequest>
     implements RoutingDataRepository.RoutingDataChangedListener, StoreDataChangedListener {
   private static final Logger LOGGER = LogManager.getLogger(ReadQuotaEnforcementHandler.class);
+  private static final String SERVER_BUCKET_STATS_NAME = "venice-storage-node-token-bucket";
   private final ConcurrentMap<String, TokenBucket> storeVersionBuckets = new VeniceConcurrentHashMap<>();
   private final TokenBucket storageNodeBucket;
+  private final ServerQuotaTokenBucketStats storageNodeTokenBucketStats;
   private final ReadOnlyStoreRepository storeRepository;
   private final String thisNodeId;
   private final AggServerQuotaUsageStats stats;
@@ -67,8 +71,16 @@ public class ReadQuotaEnforcementHandler extends SimpleChannelInboundHandler<Rou
       ReadOnlyStoreRepository storeRepository,
       CompletableFuture<HelixCustomizedViewOfflinePushRepository> customizedViewRepository,
       String nodeId,
-      AggServerQuotaUsageStats stats) {
-    this(storageNodeRcuCapacity, storeRepository, customizedViewRepository, nodeId, stats, Clock.systemUTC());
+      AggServerQuotaUsageStats stats,
+      MetricsRepository metricsRepository) {
+    this(
+        storageNodeRcuCapacity,
+        storeRepository,
+        customizedViewRepository,
+        nodeId,
+        stats,
+        metricsRepository,
+        Clock.systemUTC());
   }
 
   public ReadQuotaEnforcementHandler(
@@ -77,9 +89,12 @@ public class ReadQuotaEnforcementHandler extends SimpleChannelInboundHandler<Rou
       CompletableFuture<HelixCustomizedViewOfflinePushRepository> customizedViewRepository,
       String nodeId,
       AggServerQuotaUsageStats stats,
+      MetricsRepository metricsRepository,
       Clock clock) {
     this.clock = clock;
     this.storageNodeBucket = tokenBucketfromRcuPerSecond(storageNodeRcuCapacity, 1);
+    this.storageNodeTokenBucketStats =
+        new ServerQuotaTokenBucketStats(metricsRepository, SERVER_BUCKET_STATS_NAME, () -> storageNodeBucket);
     this.storeRepository = storeRepository;
     this.thisNodeId = nodeId;
     this.stats = stats;
@@ -100,9 +115,10 @@ public class ReadQuotaEnforcementHandler extends SimpleChannelInboundHandler<Rou
       case SINGLE_GET:
         return 1;
       case MULTI_GET:
-        return request.getKeyCount();
+      case MULTI_GET_STREAMING:
       case COMPUTE:
-        // Eventually, we'll want to add some extra cost beyond the look up cost for compute operations.
+      case COMPUTE_STREAMING:
+        // Eventually, we'll want to add some extra cost beyond the lookup cost for compute operations.
         return request.getKeyCount();
       default:
         LOGGER.error(
@@ -159,8 +175,8 @@ public class ReadQuotaEnforcementHandler extends SimpleChannelInboundHandler<Rou
       LOGGER.error(
           "Null resource assignment from HelixCustomizedViewOfflinePushRepository in ReadQuotaEnforcementHandler");
     } else {
-      for (String resource: customizedViewRepository.getResourceAssignment().getAssignedResources()) {
-        this.onExternalViewChange(customizedViewRepository.getPartitionAssignments(resource));
+      for (String resource: resourceAssignment.getAssignedResources()) {
+        this.onExternalViewChange(resourceAssignment.getPartitionAssignment(resource));
       }
     }
     this.initializedVolatile = true;
@@ -188,30 +204,34 @@ public class ReadQuotaEnforcementHandler extends SimpleChannelInboundHandler<Rou
     String storeName = request.getStoreName();
     Store store = storeRepository.getStore(storeName);
 
-    if (checkStoreNull(ctx, request, null, false, store)) {
+    if (!enforcing || checkStoreNull(ctx, request, null, false, store)) {
       return;
     }
 
-    if (checkInitAndQuotaEnabled(ctx, request, store, false)) {
+    if (checkInitAndQuotaEnabledToSkipQuotaEnforcement(ctx, request, store, false)) {
       return;
     }
 
     int rcu = getRcu(request); // read capacity units
 
     /**
-     * First check store bucket for capacity; don't throttle retried request at store version level
+     * First check store bucket for capacity don't throttle retried request at store version level
      */
     TokenBucket tokenBucket = storeVersionBuckets.get(request.getResourceName());
-    if (tokenBucket != null && !request.isRetryRequest()) {
-      if (!tokenBucket.tryConsume(rcu)) {
+    if (tokenBucket != null) {
+      if (!request.isRetryRequest() && !tokenBucket.tryConsume(rcu)
+          && handleTooManyRequests(ctx, request, null, store, rcu, false)) {
+        // Enforce store version quota for non-retry requests.
         // TODO: check if extra node capacity and can still process this request out of quota
-        if (handleTooManyRequests(ctx, request, null, store, rcu, false))
-          return;
+        return;
       }
-    } else if (enforcing && !noBucketStores.contains(request.getResourceName())) {
-      // If this happens it is probably due to a short-lived race condition
-      // of the resource being allocated before the bucket is allocated.
-      handleEnforcingAndNoBucket(request);
+    } else {
+      // If this happens it is probably due to a short-lived race condition where the resource is being accessed before
+      // the bucket is allocated. The request will be allowed based on node/server capacity so emit metrics accordingly.
+      stats.recordAllowedUnintentionally(storeName, rcu);
+      if (!noBucketStores.contains(request.getResourceName())) {
+        handleEnforcingAndNoBucket(request.getResourceName());
+      }
     }
 
     /**
@@ -249,7 +269,7 @@ public class ReadQuotaEnforcementHandler extends SimpleChannelInboundHandler<Rou
     return true;
   }
 
-  public boolean checkInitAndQuotaEnabled(
+  public boolean checkInitAndQuotaEnabledToSkipQuotaEnforcement(
       ChannelHandlerContext ctx,
       RouterRequest request,
       Store store,
@@ -300,12 +320,13 @@ public class ReadQuotaEnforcementHandler extends SimpleChannelInboundHandler<Rou
     return true;
   }
 
-  public void handleEnforcingAndNoBucket(RouterRequest request) {
-    LOGGER.warn(
-        "Request for resource: {} but no TokenBucket for that resource. Not yet enforcing quota",
-        request.getResourceName());
+  /**
+   * This method and the expiring set noBucketStores is only used to throttle the logging of such event
+   */
+  public void handleEnforcingAndNoBucket(String resourceName) {
+    LOGGER.warn("Request for resource: {} but no TokenBucket for that resource. Not yet enforcing quota", resourceName);
     // TODO: we could consider initializing a bucket. Would need to carefully consider this case.
-    noBucketStores.add(request.getResourceName()); // So that we only log this once every 30 seconds
+    noBucketStores.add(resourceName); // So that we only log this once every 30 seconds
   }
 
   public boolean handleServerOverCapacity(
@@ -342,7 +363,6 @@ public class ReadQuotaEnforcementHandler extends SimpleChannelInboundHandler<Rou
       ctx.fireChannelRead(request);
     }
     stats.recordAllowed(storeName, rcu);
-    stats.recordReadQuotaUsage(storeName, storageNodeBucket.getStaleUsageRatio());
   }
 
   /**
@@ -366,7 +386,7 @@ public class ReadQuotaEnforcementHandler extends SimpleChannelInboundHandler<Rou
   private TokenBucket tokenBucketfromRcuPerSecond(long totalRcuPerSecond, double thisBucketProportionOfTotalRcu) {
     long totalRefillAmount = totalRcuPerSecond * enforcementIntervalSeconds;
     long totalCapacity = totalRefillAmount * enforcementCapacityMultiple;
-    long thisRefillAmount = (long) Math.ceil(totalRefillAmount * thisBucketProportionOfTotalRcu);
+    long thisRefillAmount = calculateRefillAmount(totalRcuPerSecond, thisBucketProportionOfTotalRcu);
     long thisCapacity = (long) Math.ceil(totalCapacity * thisBucketProportionOfTotalRcu);
     return new TokenBucket(thisCapacity, thisRefillAmount, enforcementIntervalSeconds, SECONDS, clock);
   }
@@ -407,8 +427,20 @@ public class ReadQuotaEnforcementHandler extends SimpleChannelInboundHandler<Rou
     }
     long quotaInRcu = storeRepository.getStore(Version.parseStoreFromKafkaTopicName(partitionAssignment.getTopic()))
         .getReadQuotaInCU();
-    TokenBucket newStoreBucket = tokenBucketfromRcuPerSecond(quotaInRcu, thisNodeQuotaResponsibility);
-    storeVersionBuckets.put(topic, newStoreBucket); // put is atomic, so this method is thread-safe
+    storeVersionBuckets.compute(topic, (k, v) -> {
+      long newRefillAmount = calculateRefillAmount(quotaInRcu, thisNodeQuotaResponsibility);
+      if (v == null || v.getAmortizedRefillPerSecond() * enforcementIntervalSeconds != newRefillAmount) {
+        // only replace the existing bucket if the difference is greater than 1
+        return tokenBucketfromRcuPerSecond(quotaInRcu, thisNodeQuotaResponsibility);
+      } else {
+        return v;
+      }
+    }); // put is atomic, so this method is thread-safe
+  }
+
+  private long calculateRefillAmount(long totalRcuPerSecond, double thisBucketProportionOfTotalRcu) {
+    long totalRefillAmount = totalRcuPerSecond * enforcementIntervalSeconds;
+    return (long) Math.ceil(totalRefillAmount * thisBucketProportionOfTotalRcu);
   }
 
   @Override
@@ -432,18 +464,19 @@ public class ReadQuotaEnforcementHandler extends SimpleChannelInboundHandler<Rou
     removeTopics(topics);
   }
 
+  /**
+   * This is where we add new {@link TokenBucket} for new store version and remove irrelevant ones. We should keep the
+   * same number of token buckets as the number of active versions. This is because readers like FC might be lagging
+   * behind or vice versa. This way quota will still be enforced properly during the version swap or transition period.
+   */
   @Override
   public void handleStoreChanged(Store store) {
-    Set<String> oldTopics = getStoreTopics(store.getName());
+    Set<String> toBeRemovedTopics = getStoreTopics(store.getName());
 
     List<String> topics =
         store.getVersions().stream().map((version) -> version.kafkaTopicName()).collect(Collectors.toList());
     for (String topic: topics) {
-      int topicVersion = Version.parseVersionFromKafkaTopicName(topic);
-      // No need to subscribe StorageQuotaHandler on versions other than current version.
-      if (store.getCurrentVersion() != topicVersion) {
-        continue;
-      }
+      toBeRemovedTopics.remove(topic);
       customizedViewRepository.subscribeRoutingDataChange(topic, this);
       try {
         /**
@@ -479,7 +512,7 @@ public class ReadQuotaEnforcementHandler extends SimpleChannelInboundHandler<Rou
           /**
            * For future version, it's possible that store metadata update callback is invoked faster than
            * the external view change callback; but for any other versions between future version and the
-           * oldest version that should be retire, they should exist on external view if they are online.
+           * oldest version that should be retired, they should exist on external view if they are online.
            */
           if (!isLatestVersion(Version.parseVersionFromKafkaTopicName(topic), topics)) {
             throw new VeniceException(
@@ -489,10 +522,8 @@ public class ReadQuotaEnforcementHandler extends SimpleChannelInboundHandler<Rou
           }
         }
       }
-      oldTopics.remove(topic);
     }
-
-    removeTopics(oldTopics);
+    removeTopics(toBeRemovedTopics);
   }
 
   private Set<String> getStoreTopics(String storeName) {
@@ -562,8 +593,8 @@ public class ReadQuotaEnforcementHandler extends SimpleChannelInboundHandler<Rou
     return storeVersionBuckets;
   }
 
-  public boolean isEnforcingAndNoBucketStoreContainsResource(String resourceName) {
-    return enforcing && noBucketStores.contains(resourceName);
+  public boolean isNoBucketStoreContainsResource(String resourceName) {
+    return noBucketStores.contains(resourceName);
   }
 
   public boolean storageConsumeRcu(int rcu) {
@@ -572,9 +603,5 @@ public class ReadQuotaEnforcementHandler extends SimpleChannelInboundHandler<Rou
 
   public AggServerQuotaUsageStats getStats() {
     return stats;
-  }
-
-  public double getStaleUsageRatio() {
-    return storageNodeBucket.getStaleUsageRatio();
   }
 }

--- a/services/venice-server/src/main/java/com/linkedin/venice/listener/grpc/handlers/GrpcReadQuotaEnforcementHandler.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/listener/grpc/handlers/GrpcReadQuotaEnforcementHandler.java
@@ -34,6 +34,7 @@ public class GrpcReadQuotaEnforcementHandler extends VeniceServerGrpcHandler {
 
     TokenBucket tokenBucket = readQuota.getStoreVersionBuckets().get(request.getResourceName());
     if (tokenBucket != null) {
+      readQuota.getStats().recordReadQuotaUsageRatio(storeName, tokenBucket.getStaleUsageRatio());
       if (!request.isRetryRequest() && !tokenBucket.tryConsume(rcu)
           && readQuota.handleTooManyRequests(null, request, ctx, store, rcu, true)) {
         invokeNextHandler(ctx);

--- a/services/venice-server/src/main/java/com/linkedin/venice/listener/grpc/handlers/GrpcReadQuotaEnforcementHandler.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/listener/grpc/handlers/GrpcReadQuotaEnforcementHandler.java
@@ -41,8 +41,8 @@ public class GrpcReadQuotaEnforcementHandler extends VeniceServerGrpcHandler {
       }
     } else {
       readQuota.getStats().recordAllowedUnintentionally(storeName, rcu);
-      if (!readQuota.isNoBucketStoreContainsResource(request.getResourceName())) {
-        readQuota.handleEnforcingAndNoBucket(request.getResourceName());
+      if (readQuota.isNewNoBucketResource(request.getResourceName())) {
+        readQuota.handleResourceNoBucket(request.getResourceName());
       }
     }
 

--- a/services/venice-server/src/main/java/com/linkedin/venice/stats/AggServerQuotaUsageStats.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/stats/AggServerQuotaUsageStats.java
@@ -26,4 +26,8 @@ public class AggServerQuotaUsageStats extends AbstractVeniceAggStats<ServerQuota
     totalStats.recordAllowedUnintentionally(rcu);
     getStoreStats(storeName).recordAllowedUnintentionally(rcu);
   }
+
+  public void recordReadQuotaUsageRatio(String storeName, double usageRatio) {
+    getStoreStats(storeName).recordReadQuotaUsageRatio(usageRatio);
+  }
 }

--- a/services/venice-server/src/main/java/com/linkedin/venice/stats/AggServerQuotaUsageStats.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/stats/AggServerQuotaUsageStats.java
@@ -22,7 +22,8 @@ public class AggServerQuotaUsageStats extends AbstractVeniceAggStats<ServerQuota
     getStoreStats(storeName).recordRejected(rcu);
   }
 
-  public void recordReadQuotaUsage(String storeName, double ratio) {
-    getStoreStats(storeName).recordReadQuotaUsage(ratio);
+  public void recordAllowedUnintentionally(String storeName, long rcu) {
+    totalStats.recordAllowedUnintentionally(rcu);
+    getStoreStats(storeName).recordAllowedUnintentionally(rcu);
   }
 }

--- a/services/venice-server/src/main/java/com/linkedin/venice/stats/ServerQuotaUsageStats.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/stats/ServerQuotaUsageStats.java
@@ -3,7 +3,6 @@ package com.linkedin.venice.stats;
 import io.tehuti.metrics.MetricsRepository;
 import io.tehuti.metrics.Sensor;
 import io.tehuti.metrics.stats.Count;
-import io.tehuti.metrics.stats.Gauge;
 import io.tehuti.metrics.stats.Total;
 
 
@@ -15,7 +14,7 @@ public class ServerQuotaUsageStats extends AbstractVeniceStats {
   private final Sensor requestedKPS; // requested key per second
   private final Sensor rejectedQPS; // rejected query per second
   private final Sensor rejectedKPS; // rejected key per second
-  private final Sensor quotaUsageRatio; // quota usage key per second
+  private final Sensor allowedUnintentionallyKPS; // allowed KPS unintentionally due to error or insufficient info
 
   public ServerQuotaUsageStats(MetricsRepository metricsRepository, String name) {
     super(metricsRepository, name);
@@ -23,7 +22,7 @@ public class ServerQuotaUsageStats extends AbstractVeniceStats {
     requestedKPS = registerSensor("quota_rcu_requested_key", new Total());
     rejectedQPS = registerSensor("quota_rcu_rejected", new Count());
     rejectedKPS = registerSensor("quota_rcu_rejected_key", new Total());
-    quotaUsageRatio = registerSensor("read_quota_usage_ratio", new Gauge());
+    allowedUnintentionallyKPS = registerSensor("quota_rcu_allowed_unintentionally", new Count());
   }
 
   /**
@@ -45,10 +44,7 @@ public class ServerQuotaUsageStats extends AbstractVeniceStats {
     rejectedKPS.record(rcu);
   }
 
-  /**
-   * @param ratio The number of Read Capacity Units (KPS) used divided by total capacity
-   */
-  public void recordReadQuotaUsage(double ratio) {
-    quotaUsageRatio.record(ratio);
+  public void recordAllowedUnintentionally(long rcu) {
+    allowedUnintentionallyKPS.record(rcu);
   }
 }

--- a/services/venice-server/src/main/java/com/linkedin/venice/stats/ServerQuotaUsageStats.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/stats/ServerQuotaUsageStats.java
@@ -3,6 +3,7 @@ package com.linkedin.venice.stats;
 import io.tehuti.metrics.MetricsRepository;
 import io.tehuti.metrics.Sensor;
 import io.tehuti.metrics.stats.Count;
+import io.tehuti.metrics.stats.Gauge;
 import io.tehuti.metrics.stats.Total;
 
 
@@ -15,6 +16,8 @@ public class ServerQuotaUsageStats extends AbstractVeniceStats {
   private final Sensor rejectedQPS; // rejected query per second
   private final Sensor rejectedKPS; // rejected key per second
   private final Sensor allowedUnintentionallyKPS; // allowed KPS unintentionally due to error or insufficient info
+  private final Sensor usageRatioSensor; // requested qps divided by amortized refill per second on this node for a
+                                         // store
 
   public ServerQuotaUsageStats(MetricsRepository metricsRepository, String name) {
     super(metricsRepository, name);
@@ -23,6 +26,7 @@ public class ServerQuotaUsageStats extends AbstractVeniceStats {
     rejectedQPS = registerSensor("quota_rcu_rejected", new Count());
     rejectedKPS = registerSensor("quota_rcu_rejected_key", new Total());
     allowedUnintentionallyKPS = registerSensor("quota_rcu_allowed_unintentionally", new Count());
+    usageRatioSensor = registerSensor("quota_requested_usage_ratio", new Gauge());
   }
 
   /**
@@ -46,5 +50,9 @@ public class ServerQuotaUsageStats extends AbstractVeniceStats {
 
   public void recordAllowedUnintentionally(long rcu) {
     allowedUnintentionallyKPS.record(rcu);
+  }
+
+  public void recordReadQuotaUsageRatio(double usageRatio) {
+    usageRatioSensor.record(usageRatio);
   }
 }

--- a/services/venice-server/src/test/java/com/linkedin/venice/listener/ReadQuotaEnforcementHandlerListenerTest.java
+++ b/services/venice-server/src/test/java/com/linkedin/venice/listener/ReadQuotaEnforcementHandlerListenerTest.java
@@ -25,6 +25,7 @@ import com.linkedin.venice.meta.VersionImpl;
 import com.linkedin.venice.meta.ZKStore;
 import com.linkedin.venice.routerapi.ReplicaState;
 import com.linkedin.venice.stats.AggServerQuotaUsageStats;
+import io.tehuti.metrics.MetricsRepository;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -50,6 +51,7 @@ public class ReadQuotaEnforcementHandlerListenerTest {
         mock(HelixCustomizedViewOfflinePushRepository.class);
     ReadOnlyStoreRepository storeRepository = mock(ReadOnlyStoreRepository.class);
     AggServerQuotaUsageStats stats = mock(AggServerQuotaUsageStats.class);
+    MetricsRepository metricsRepository = new MetricsRepository();
 
     List<StoreDataChangedListener> listeners = new ArrayList<>();
     doAnswer((invocation) -> {
@@ -63,7 +65,8 @@ public class ReadQuotaEnforcementHandlerListenerTest {
         storeRepository,
         CompletableFuture.completedFuture(customizedViewRepository),
         nodeId,
-        stats);
+        stats,
+        metricsRepository);
 
     Assert.assertEquals(listeners.get(0), quotaEnforcer);
   }
@@ -100,6 +103,7 @@ public class ReadQuotaEnforcementHandlerListenerTest {
     }).when(customizedViewRepository).getPartitionAssignments(anyString());
 
     AggServerQuotaUsageStats stats = mock(AggServerQuotaUsageStats.class);
+    MetricsRepository metricsRepository = new MetricsRepository();
 
     // Object under test
     ReadQuotaEnforcementHandler quotaEnforcer = new ReadQuotaEnforcementHandler(
@@ -107,7 +111,8 @@ public class ReadQuotaEnforcementHandlerListenerTest {
         storeRepository,
         CompletableFuture.completedFuture(customizedViewRepository),
         nodeId,
-        stats);
+        stats,
+        metricsRepository);
 
     // Add a store (call store created) verify all versions in buckets and in subscriptions
     Store store1 = getDummyStore("store1", Arrays.asList(new Integer[] { 1 }), 10);

--- a/services/venice-server/src/test/java/com/linkedin/venice/listener/ReadQuotaEnforcementHandlerTest.java
+++ b/services/venice-server/src/test/java/com/linkedin/venice/listener/ReadQuotaEnforcementHandlerTest.java
@@ -2,12 +2,15 @@ package com.linkedin.venice.listener;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
@@ -34,13 +37,16 @@ import com.linkedin.venice.stats.AggServerQuotaUsageStats;
 import com.linkedin.venice.utils.Utils;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http.HttpResponseStatus;
+import io.tehuti.metrics.MetricsRepository;
 import java.time.Clock;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.mockito.ArgumentCaptor;
+import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -60,6 +66,8 @@ public class ReadQuotaEnforcementHandlerTest {
   GrpcReadQuotaEnforcementHandler grpcQuotaEnforcer;
   AggServerQuotaUsageStats stats;
 
+  MetricsRepository metricsRepository;
+
   @BeforeMethod
   public void setUp() {
     nodeCapacity = 10; // rcu per second that a single node can support
@@ -70,12 +78,14 @@ public class ReadQuotaEnforcementHandlerTest {
     storeRepository = mock(ReadOnlyStoreRepository.class);
     customizedViewRepository = mock(HelixCustomizedViewOfflinePushRepository.class);
     stats = mock(AggServerQuotaUsageStats.class);
+    metricsRepository = new MetricsRepository();
     quotaEnforcer = new ReadQuotaEnforcementHandler(
         nodeCapacity,
         storeRepository,
         CompletableFuture.completedFuture(customizedViewRepository),
         thisNodeId,
         stats,
+        metricsRepository,
         clock);
     grpcQuotaEnforcer = new GrpcReadQuotaEnforcementHandler(quotaEnforcer);
     VeniceServerGrpcHandler mockNextHandler = mock(VeniceServerGrpcHandler.class);
@@ -86,6 +96,23 @@ public class ReadQuotaEnforcementHandlerTest {
   @DataProvider(name = "Test-Quota-EnforcementHandler-Enable-Grpc")
   public Object[][] testQuotaEnforcementHandlerEnableGrpc() {
     return new Object[][] { { true }, { false } };
+  }
+
+  @Test
+  public void testGetRCU() {
+    for (RequestType requestType: RequestType.values()) {
+      RouterRequest request = mock(RouterRequest.class);
+      int keyCount = 10;
+      doReturn(keyCount).when(request).getKeyCount();
+      doReturn(requestType).when(request).getRequestType();
+
+      int rcu = ReadQuotaEnforcementHandler.getRcu(request);
+      if (requestType == RequestType.SINGLE_GET) {
+        assertEquals(rcu, 1, "Single get rcu count should be 1");
+      } else {
+        assertEquals(rcu, keyCount, "Non-single get rcu count should be: " + keyCount);
+      }
+    }
   }
 
   /**
@@ -115,19 +142,10 @@ public class ReadQuotaEnforcementHandlerTest {
     Instance thisInstance = mock(Instance.class);
     doReturn(thisNodeId).when(thisInstance).getNodeId();
 
-    Partition partition = mock(Partition.class);
+    Partition partition = setUpPartitionMock(topic, thisInstance, true, 0);
     doReturn(0).when(partition).getId();
 
-    List<ReplicaState> replicaStates = new ArrayList<>();
-    ReplicaState thisReplicaState = mock(ReplicaState.class);
-    doReturn(thisInstance.getNodeId()).when(thisReplicaState).getParticipantId();
-    doReturn(true).when(thisReplicaState).isReadyToServe();
-    replicaStates.add(thisReplicaState);
-    when(customizedViewRepository.getReplicaStates(topic, partition.getId())).thenReturn(replicaStates);
-
-    PartitionAssignment pa = mock(PartitionAssignment.class);
-    doReturn(topic).when(pa).getTopic();
-    doReturn(Collections.singletonList(partition)).when(pa).getAllPartitions();
+    PartitionAssignment pa = setUpPartitionAssignmentMock(topic, Collections.singletonList(partition));
 
     long storeReadQuota = 5; // rcu per second
     Store store = mock(Store.class);
@@ -217,6 +235,89 @@ public class ReadQuotaEnforcementHandlerTest {
     assertNotNull(builder.getErrorMessage());
   }
 
+  @Test
+  public void testReadQuotaOnVersionChange() {
+    String storeName = Utils.getUniqueString("test-store");
+    int currentVersion = 1;
+    String topic = Version.composeKafkaTopic(storeName, currentVersion);
+    String nextTopic = Version.composeKafkaTopic(storeName, currentVersion + 1);
+    Version version = mock(Version.class);
+    doReturn(topic).when(version).kafkaTopicName();
+    Version nextVersion = mock(Version.class);
+    doReturn(nextTopic).when(nextVersion).kafkaTopicName();
+    Instance thisInstance = mock(Instance.class);
+    doReturn(thisNodeId).when(thisInstance).getNodeId();
+
+    Partition partition = setUpPartitionMock(topic, thisInstance, true, 0);
+    PartitionAssignment pa = setUpPartitionAssignmentMock(topic, Collections.singletonList(partition));
+    doReturn(pa).when(customizedViewRepository).getPartitionAssignments(topic);
+    Partition nextPartition = setUpPartitionMock(nextTopic, thisInstance, true, 0);
+    PartitionAssignment nextPa = setUpPartitionAssignmentMock(nextTopic, Collections.singletonList(nextPartition));
+    doReturn(nextPa).when(customizedViewRepository).getPartitionAssignments(nextTopic);
+
+    long storeReadQuota = 1;
+    long newStoreReadQuota = storeReadQuota * 2;
+    Store store = setUpStoreMock(storeName, currentVersion, Arrays.asList(version, nextVersion), storeReadQuota, true);
+    Store storeAfterVersionBump =
+        setUpStoreMock(storeName, currentVersion + 1, Collections.singletonList(nextVersion), storeReadQuota, true);
+    Store storeAfterQuotaBump =
+        setUpStoreMock(storeName, currentVersion + 1, Collections.singletonList(nextVersion), newStoreReadQuota, true);
+    // The store repository is called to initialize/update the token buckets, we need to make sure it doesn't return the
+    // store state with higher quota prior to the test to verify quota change.
+    when(storeRepository.getStore(eq(storeName))).thenReturn(store, store, storeAfterVersionBump, storeAfterQuotaBump);
+
+    quotaEnforcer.handleStoreChanged(store);
+    Assert.assertTrue(quotaEnforcer.listTopics().contains(topic));
+    Assert.assertTrue(quotaEnforcer.listTopics().contains(nextTopic));
+
+    quotaEnforcer.handleStoreChanged(storeAfterVersionBump);
+    Assert.assertFalse(quotaEnforcer.listTopics().contains(topic));
+    Assert.assertTrue(quotaEnforcer.listTopics().contains(nextTopic));
+
+    AtomicInteger allowed = new AtomicInteger(0);
+    AtomicInteger blocked = new AtomicInteger(0);
+    RouterRequest request = mock(RouterRequest.class);
+    RouterRequest oldVersionRequest = mock(RouterRequest.class);
+    ChannelHandlerContext ctx = mock(ChannelHandlerContext.class);
+    setUpRequestMocks(ctx, request, allowed, blocked, nextTopic);
+    setUpRequestMocks(ctx, oldVersionRequest, allowed, blocked, topic);
+    long capacity = storeReadQuota * 5 * 10;
+    for (int i = 0; i < capacity; i++) {
+      quotaEnforcer.channelRead0(ctx, request);
+    }
+    assertEquals(allowed.get(), capacity);
+    assertEquals(blocked.get(), 0);
+    verify(stats, times((int) capacity)).recordAllowed(eq(storeName), anyLong());
+    verify(stats, never()).recordAllowedUnintentionally(eq(storeName), anyLong());
+    verify(stats, never()).recordRejected(eq(storeName), anyLong());
+
+    quotaEnforcer.channelRead0(ctx, request);
+    assertEquals(allowed.get(), capacity);
+    assertEquals(blocked.get(), 1);
+    verify(stats, times((int) capacity)).recordAllowed(eq(storeName), anyLong());
+    verify(stats, never()).recordAllowedUnintentionally(eq(storeName), anyLong());
+    verify(stats, times(1)).recordRejected(eq(storeName), anyLong());
+
+    quotaEnforcer.channelRead0(ctx, oldVersionRequest);
+    assertEquals(allowed.get(), capacity + 1);
+    assertEquals(blocked.get(), 1);
+    verify(stats, times((int) capacity + 1)).recordAllowed(eq(storeName), anyLong());
+    verify(stats, times(1)).recordAllowedUnintentionally(eq(storeName), anyLong());
+    verify(stats, times(1)).recordRejected(eq(storeName), anyLong());
+
+    quotaEnforcer.handleStoreChanged(storeAfterQuotaBump);
+    long newCapacity = newStoreReadQuota * 5 * 10;
+    for (int i = 0; i < newCapacity; i++) {
+      quotaEnforcer.channelRead0(ctx, request);
+    }
+    int expectedAllowedCount = (int) capacity + 1 + (int) newCapacity;
+    assertEquals(allowed.get(), expectedAllowedCount);
+    assertEquals(blocked.get(), 1);
+    verify(stats, times(expectedAllowedCount)).recordAllowed(eq(storeName), anyLong());
+    verify(stats, times(1)).recordAllowedUnintentionally(eq(storeName), anyLong());
+    verify(stats, times(1)).recordRejected(eq(storeName), anyLong());
+  }
+
   @DataProvider(name = "Enable-Grpc-Test-Boolean")
   public Object[][] enableGrpcTestBoolean() {
     return new Object[][] { { false }, { true } };
@@ -237,27 +338,14 @@ public class ReadQuotaEnforcementHandlerTest {
     Instance thisInstance = mock(Instance.class);
     doReturn(thisNodeId).when(thisInstance).getNodeId();
 
-    Partition partition = mock(Partition.class);
-    doReturn(0).when(partition).getId();
-
-    List<ReplicaState> replicaStates = new ArrayList<>();
-    ReplicaState thisReplicaState = mock(ReplicaState.class);
-    doReturn(thisInstance.getNodeId()).when(thisReplicaState).getParticipantId();
-    doReturn(true).when(thisReplicaState).isReadyToServe();
-    replicaStates.add(thisReplicaState);
-    when(customizedViewRepository.getReplicaStates(quotaEnabledTopic, partition.getId())).thenReturn(replicaStates);
-
-    PartitionAssignment pa = mock(PartitionAssignment.class);
-    doReturn(quotaEnabledTopic).when(pa).getTopic();
-    doReturn(Collections.singletonList(partition)).when(pa).getAllPartitions();
+    Partition partition = setUpPartitionMock(quotaEnabledTopic, thisInstance, true, 0);
+    PartitionAssignment pa = setUpPartitionAssignmentMock(quotaEnabledTopic, Collections.singletonList(partition));
 
     long storeReadQuota = 1;
-    Store store = mock(Store.class);
-    Store quotaDisabledStore = mock(Store.class);
-    doReturn(true).when(store).isStorageNodeReadQuotaEnabled();
-    doReturn(storeReadQuota).when(store).getReadQuotaInCU();
+    Store store = setUpStoreMock(quotaEnabledStoreName, 1, Collections.emptyList(), storeReadQuota, true);
+    Store quotaDisabledStore =
+        setUpStoreMock(quotaDisabledStoreName, 1, Collections.emptyList(), storeReadQuota, false);
     doReturn(store).when(storeRepository).getStore(eq(quotaEnabledStoreName));
-    doReturn(storeReadQuota).when(quotaDisabledStore).getReadQuotaInCU();
     doReturn(quotaDisabledStore).when(storeRepository).getStore(eq(quotaDisabledStoreName));
 
     quotaEnforcer.onExternalViewChange(pa);
@@ -306,27 +394,15 @@ public class ReadQuotaEnforcementHandlerTest {
     Instance thisInstance = mock(Instance.class);
     doReturn(thisNodeId).when(thisInstance).getNodeId();
 
-    Partition partition = mock(Partition.class);
-    doReturn(0).when(partition).getId();
+    Partition partition = setUpPartitionMock(quotaEnabledTopic, thisInstance, true, 0);
 
-    List<ReplicaState> replicaStates = new ArrayList<>();
-    ReplicaState thisReplicaState = mock(ReplicaState.class);
-    doReturn(thisInstance.getNodeId()).when(thisReplicaState).getParticipantId();
-    doReturn(true).when(thisReplicaState).isReadyToServe();
-    replicaStates.add(thisReplicaState);
-    when(customizedViewRepository.getReplicaStates(quotaEnabledTopic, partition.getId())).thenReturn(replicaStates);
-
-    PartitionAssignment pa = mock(PartitionAssignment.class);
-    doReturn(quotaEnabledTopic).when(pa).getTopic();
-    doReturn(Collections.singletonList(partition)).when(pa).getAllPartitions();
+    PartitionAssignment pa = setUpPartitionAssignmentMock(quotaEnabledTopic, Collections.singletonList(partition));
 
     long storeReadQuota = 1;
-    Store store = mock(Store.class);
-    Store quotaDisabledStore = mock(Store.class);
-    doReturn(true).when(store).isStorageNodeReadQuotaEnabled();
-    doReturn(storeReadQuota).when(store).getReadQuotaInCU();
+    Store store = setUpStoreMock(quotaEnabledStoreName, 1, Collections.emptyList(), storeReadQuota, true);
+    Store quotaDisabledStore =
+        setUpStoreMock(quotaDisabledStoreName, 1, Collections.emptyList(), storeReadQuota, false);
     doReturn(store).when(storeRepository).getStore(eq(quotaEnabledStoreName));
-    doReturn(storeReadQuota).when(quotaDisabledStore).getReadQuotaInCU();
     doReturn(quotaDisabledStore).when(storeRepository).getStore(eq(quotaDisabledStoreName));
 
     quotaEnforcer.onExternalViewChange(pa);
@@ -456,5 +532,39 @@ public class ReadQuotaEnforcementHandlerTest {
       blocked.incrementAndGet();
       return null;
     }).when(grpcCtx).setError();
+  }
+
+  private PartitionAssignment setUpPartitionAssignmentMock(String topic, List<Partition> partitions) {
+    PartitionAssignment pa = mock(PartitionAssignment.class);
+    doReturn(topic).when(pa).getTopic();
+    doReturn(partitions).when(pa).getAllPartitions();
+    return pa;
+  }
+
+  private Partition setUpPartitionMock(String topic, Instance instance, boolean isReadyToServe, int partitionId) {
+    Partition partition = mock(Partition.class);
+    doReturn(partitionId).when(partition).getId();
+    List<ReplicaState> replicaStates = new ArrayList<>();
+    ReplicaState thisReplicaState = mock(ReplicaState.class);
+    doReturn(instance.getNodeId()).when(thisReplicaState).getParticipantId();
+    doReturn(isReadyToServe).when(thisReplicaState).isReadyToServe();
+    replicaStates.add(thisReplicaState);
+    when(customizedViewRepository.getReplicaStates(topic, partition.getId())).thenReturn(replicaStates);
+    return partition;
+  }
+
+  private Store setUpStoreMock(
+      String storeName,
+      int currentVersion,
+      List<Version> versionList,
+      long readQuota,
+      boolean readQuotaEnabled) {
+    Store store = mock(Store.class);
+    doReturn(storeName).when(store).getName();
+    doReturn(currentVersion).when(store).getCurrentVersion();
+    doReturn(versionList).when(store).getVersions();
+    doReturn(readQuota).when(store).getReadQuotaInCU();
+    doReturn(readQuotaEnabled).when(store).isStorageNodeReadQuotaEnabled();
+    return store;
   }
 }

--- a/services/venice-server/src/test/java/com/linkedin/venice/listener/ReadQuotaEnforcementHandlerTest.java
+++ b/services/venice-server/src/test/java/com/linkedin/venice/listener/ReadQuotaEnforcementHandlerTest.java
@@ -153,7 +153,7 @@ public class ReadQuotaEnforcementHandlerTest {
     doReturn(storeReadQuota).when(store).getReadQuotaInCU();
     doReturn(store).when(storeRepository).getStore(any());
 
-    quotaEnforcer.onExternalViewChange(pa);
+    quotaEnforcer.onCustomizedViewChange(pa);
 
     runTest(topic, storeReadQuota * 5 * 10, storeReadQuota * 10, 10000);
   }
@@ -348,7 +348,7 @@ public class ReadQuotaEnforcementHandlerTest {
     doReturn(store).when(storeRepository).getStore(eq(quotaEnabledStoreName));
     doReturn(quotaDisabledStore).when(storeRepository).getStore(eq(quotaDisabledStoreName));
 
-    quotaEnforcer.onExternalViewChange(pa);
+    quotaEnforcer.onCustomizedViewChange(pa);
 
     AtomicInteger allowed = new AtomicInteger(0);
     AtomicInteger blocked = new AtomicInteger(0);
@@ -405,7 +405,7 @@ public class ReadQuotaEnforcementHandlerTest {
     doReturn(store).when(storeRepository).getStore(eq(quotaEnabledStoreName));
     doReturn(quotaDisabledStore).when(storeRepository).getStore(eq(quotaDisabledStoreName));
 
-    quotaEnforcer.onExternalViewChange(pa);
+    quotaEnforcer.onCustomizedViewChange(pa);
 
     AtomicInteger allowed = new AtomicInteger(0);
     AtomicInteger blocked = new AtomicInteger(0);


### PR DESCRIPTION
## [server] Fix storage node read quota enforcement
The PR fixed several issues in the `ReadQuotaEnforcementHandler.java`:

1. The `ReadQuotaEnforcementHandler` used to only keep the token bucket of the current version. As a result when FC metadata is updated asynchronously it's possible that it will query the server for a different "current" version. During this transition period we don't have the corresponding token bucket and quota is not enforced.

2. In the old `channelRead0` there is a bug when handling retry requests. Retry request will not enter the if block but enter the else if unintentionally and trigger `handleEnforcingAndNoBucket` on the request.

3. `updateQuota` used to blindly replace existing token bucket with a new one even if they are identical. Now it checks if it's different and only replace it if it's different to avoid unnecessary initialization of new token buckets.

4. Modified the old usage ratio metric since it's not very useful due to the bucket's large headroom for spike handling and we can get a more useful ratio by looking at the token requested and amortized refill per second. Added a new `quota_rcu_allowed_unintentionally` metric to track requests allowed due to missing token bucket.

5. Initialize `ServerQuotaTokenBucketStats` for the server node's token bucket to gain visibility on the storage level quota enforcement. 

## How was this PR tested?
Existing and new tests

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.