### PR TITLE
[server] Add redundant filter on per message logging

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderProducerCallback.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderProducerCallback.java
@@ -261,7 +261,10 @@ public class LeaderProducerCallback implements ChunkAwareCallback {
         record.setValueManifest(chunkedValueManifest);
         record.setRmdManifest(chunkedRmdManifest);
       } else {
-        LOGGER.error("Transient record is missing when trying to update value/RMD manifest.");
+        String msg = "Transient record is missing when trying to update value/RMD manifest.";
+        if (!REDUNDANT_LOGGING_FILTER.isRedundantException(msg)) {
+          LOGGER.error(msg);
+        }
       }
     }
   }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderProducerCallback.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderProducerCallback.java
@@ -260,10 +260,10 @@ public class LeaderProducerCallback implements ChunkAwareCallback {
       if (record != null) {
         record.setValueManifest(chunkedValueManifest);
         record.setRmdManifest(chunkedRmdManifest);
-      } else {
+      } else if (partitionConsumptionState.isEndOfPushReceived()) {
         String msg = "Transient record is missing when trying to update value/RMD manifest for topic "
             + ingestionTask.getKafkaVersionTopic() + " partition: " + subPartition;
-        if (partitionConsumptionState.isEndOfPushReceived() && !REDUNDANT_LOGGING_FILTER.isRedundantException(msg)) {
+        if (!REDUNDANT_LOGGING_FILTER.isRedundantException(msg)) {
           LOGGER.error(msg);
         }
       }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderProducerCallback.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderProducerCallback.java
@@ -262,7 +262,7 @@ public class LeaderProducerCallback implements ChunkAwareCallback {
         record.setRmdManifest(chunkedRmdManifest);
       } else {
         String msg = "Transient record is missing when trying to update value/RMD manifest for topic "
-            + ingestionTask.getKafkaVersionTopic() + " partition:" + subPartition;
+            + ingestionTask.getKafkaVersionTopic() + " partition: " + subPartition;
         if (partitionConsumptionState.isEndOfPushReceived() && !REDUNDANT_LOGGING_FILTER.isRedundantException(msg)) {
           LOGGER.error(msg);
         }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderProducerCallback.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderProducerCallback.java
@@ -261,7 +261,8 @@ public class LeaderProducerCallback implements ChunkAwareCallback {
         record.setValueManifest(chunkedValueManifest);
         record.setRmdManifest(chunkedRmdManifest);
       } else {
-        String msg = "Transient record is missing when trying to update value/RMD manifest.";
+        String msg = "Transient record is missing when trying to update value/RMD manifest for topic "
+            + ingestionTask.getKafkaVersionTopic() + " partition:" + subPartition;
         if (partitionConsumptionState.isEndOfPushReceived() && !REDUNDANT_LOGGING_FILTER.isRedundantException(msg)) {
           LOGGER.error(msg);
         }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderProducerCallback.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderProducerCallback.java
@@ -262,7 +262,7 @@ public class LeaderProducerCallback implements ChunkAwareCallback {
         record.setRmdManifest(chunkedRmdManifest);
       } else {
         String msg = "Transient record is missing when trying to update value/RMD manifest.";
-        if (!REDUNDANT_LOGGING_FILTER.isRedundantException(msg)) {
+        if (partitionConsumptionState.isEndOfPushReceived() && !REDUNDANT_LOGGING_FILTER.isRedundantException(msg)) {
           LOGGER.error(msg);
         }
       }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -1915,20 +1915,20 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
     PartitionConsumptionState partitionConsumptionState = partitionConsumptionStateMap.get(subPartition);
 
     if (partitionConsumptionState == null) {
-      LOGGER.info(
-          "Topic {} Partition {} has been unsubscribed, skip this record that has offset {}",
-          kafkaVersionTopic,
-          subPartition,
-          record.getOffset());
+      String msg = "Topic : " + kafkaVersionTopic + " Partition : " + subPartition
+          + " has been unsubscribed, skip this record that has offset: {}";
+      if (REDUNDANT_LOGGING_FILTER.isRedundantException(msg)) {
+        LOGGER.info(msg, record.getOffset());
+      }
       return false;
     }
 
     if (partitionConsumptionState.isErrorReported()) {
-      LOGGER.info(
-          "Topic {} Partition {} is already errored, skip this record that has offset {}",
-          kafkaVersionTopic,
-          subPartition,
-          record.getOffset());
+      String msg = "Topic : " + kafkaVersionTopic + " Partition : " + subPartition
+          + " is already errored, skip this record that has offset: {}";
+      if (REDUNDANT_LOGGING_FILTER.isRedundantException(msg)) {
+        LOGGER.info(msg, record.getOffset());
+      }
       return false;
     }
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -1917,7 +1917,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
     if (partitionConsumptionState == null) {
       String msg = "Topic : " + kafkaVersionTopic + " Partition : " + subPartition
           + " has been unsubscribed, skip this record that has offset: {}";
-      if (REDUNDANT_LOGGING_FILTER.isRedundantException(msg)) {
+      if (!REDUNDANT_LOGGING_FILTER.isRedundantException(msg)) {
         LOGGER.info(msg, record.getOffset());
       }
       return false;
@@ -1926,7 +1926,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
     if (partitionConsumptionState.isErrorReported()) {
       String msg = "Topic : " + kafkaVersionTopic + " Partition : " + subPartition
           + " is already errored, skip this record that has offset: {}";
-      if (REDUNDANT_LOGGING_FILTER.isRedundantException(msg)) {
+      if (!REDUNDANT_LOGGING_FILTER.isRedundantException(msg)) {
         LOGGER.info(msg, record.getOffset());
       }
       return false;

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderProducerCallbackTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderProducerCallbackTest.java
@@ -4,7 +4,12 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 
 import com.linkedin.davinci.stats.AggVersionedDIVStats;

--- a/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/PushMonitorUtils.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/PushMonitorUtils.java
@@ -117,11 +117,11 @@ public class PushMonitorUtils {
           .append(" Da Vinci replicas.");
     }
     if (erroredReplica.isPresent()) {
-      statusDetailStringBuilder.append("Found a failed partition replica in Da Vinci: ")
+      statusDetailStringBuilder.append("Found a failed partition replica in Da Vinci. ")
           .append("Partition: ")
           .append(erroredPartitionId)
-          .append("Replica: ")
-          .append(erroredReplica)
+          .append(" Replica: ")
+          .append(erroredReplica.get())
           .append(". Live replica count: ")
           .append(liveReplicaCount)
           .append(", total replica count: ")


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Add redundant filter on per message logging
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

If ingestion task errors out or topic got unsubscribed, per message logging floods the log files. This PR adds some redundant checker to it.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
CI
## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.