### PR TITLE
[doc] Upgrade github-pages gem to the latest version and fix VIP-1 proposal link

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ internal/venice-test-common/src/jmh/generated
 _site/
 Gemfile.lock
 .bundles_cache
+docs/vendor/

--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -1,5 +1,6 @@
 source "https://rubygems.org"
 
 # do NOT include the jekyll gem !
-gem "github-pages", "~> 219", group: :jekyll_plugins
+gem "github-pages", "~> 228", group: :jekyll_plugins
 gem "kramdown-parser-gfm"
+gem "webrick", "~> 1.8"

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -8,3 +8,4 @@ nav_external_links:
 exclude:
   # javadoc/legal has some markdowns that get picked up by jekyll/just-the-docs
   - javadoc/legal
+  - vendor/

--- a/docs/proposals/proposals.md
+++ b/docs/proposals/proposals.md
@@ -4,13 +4,13 @@ title: Proposals
 has_children: true
 permalink: /docs/proposals
 ---
+
 # Developer Guide
 
 This folder includes all the Venice Improvement Proposals. Click to read further details about
-[VIP process](../dev_guide/design_doc.md). 
+[VIP process](../dev_guide/design_doc.md).
 
-| VIP-#             | Proposal    | Status        |
-|-------------------|-------------|---------------|
-| [VIP-1](VIP-1.md) |  Authentication Service API | Under Discussion |
-|                   |  |  |
-
+| VIP-#               | Proposal                   | Status           |
+| ------------------- | -------------------------- | ---------------- |
+| [VIP-1](./vip-1.md) | Authentication Service API | Under Discussion |
+|                     |                            |                  |

--- a/docs/proposals/vip-1.md
+++ b/docs/proposals/vip-1.md
@@ -2,7 +2,7 @@
 layout: default
 title: Authentication Service API
 parent: Proposals
-permalink: /docs/proposals/vip-1.md
+permalink: /docs/proposals/vip-1
 ---
 
 # Venice Improvement Proposal Template


### PR DESCRIPTION
## Upgrade github-pages gem to the latest version and fix VIP-1 proposal link

This PR upgrades the `github-pages` gem to the latest version. Note that Ruby 2.7+ is needed for using the gem's latest version.

It also fixes currently unreachable VIP-1 proposal page link.

## How was this PR tested?

It was tested locally via Ruby's `bundle` commands, by installing updated dependencies and building the website with Jekyll.

## Does this PR introduce any user-facing changes?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.