### PR TITLE
[controller] Return null instead of Collections.emptySet()

### DIFF
--- a/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/AbstractPushMonitor.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/AbstractPushMonitor.java
@@ -765,11 +765,10 @@ public abstract class AbstractPushMonitor
           if (helixMap.containsKey(kafkaTopic)) {
             return helixMap.get(kafkaTopic).stream().map(HelixUtils::getPartitionId).collect(Collectors.toSet());
           } else {
-            return Collections.emptySet();
+            return null;
           }
         });
-
-        return disabledPartitions.contains(partitionId);
+        return disabledPartitions != null && disabledPartitions.contains(partitionId);
       }
     };
   }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/AbstractPushMonitor.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/AbstractPushMonitor.java
@@ -762,11 +762,10 @@ public abstract class AbstractPushMonitor
         Set<Integer> disabledPartitions = disabledReplicaMap.computeIfAbsent(instance, k -> {
           helixClientThrottler.maybeThrottle(1);
           Map<String, List<String>> helixMap = helixAdminClient.getDisabledPartitionsMap(clusterName, instance);
-          if (helixMap.containsKey(kafkaTopic)) {
-            return helixMap.get(kafkaTopic).stream().map(HelixUtils::getPartitionId).collect(Collectors.toSet());
-          } else {
-            return null;
-          }
+          List<String> disablePartitionList = helixMap.get(kafkaTopic);
+          return disablePartitionList != null
+              ? disablePartitionList.stream().map(HelixUtils::getPartitionId).collect(Collectors.toSet())
+              : null;
         });
         return disabledPartitions != null && disabledPartitions.contains(partitionId);
       }


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Return null instead of Collections.emptySet() when there is no disable replica found.
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

In `isReplicaDisabled` returning emptySet will cause `java.lang.UnsupportedOperationException: null` exception to be thrown if we try to add any element to it
Instead return null so that it will later create a new HashSet when needed.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
GHCI
## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.