### PR TITLE
Changing ingestion consumption check avoiding race condition.

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionService.java
@@ -1075,7 +1075,8 @@ public class KafkaStoreIngestionService extends AbstractVeniceService implements
   public boolean isPartitionConsuming(String topic, int partitionId) {
     try (AutoCloseableLock ignore = topicLockManager.getLockForResource(topic)) {
       StoreIngestionTask ingestionTask = topicNameToIngestionTaskMap.get(topic);
-      return ingestionTask != null && ingestionTask.isRunning() && ingestionTask.isPartitionConsuming(partitionId);
+      return ingestionTask != null && ingestionTask.isRunning()
+          && ingestionTask.isPartitionConsumingOrHasPendingIngestionAction(partitionId);
     }
   }
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -3321,10 +3321,10 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
   /**
    * To check whether the given partition is still consuming message from Kafka
    */
-  public boolean isPartitionConsuming(int userPartition) {
-    Boolean subPartitionConsumptionStateExist =
+  public boolean isPartitionConsumingOrHasPendingIngestionAction(int userPartition) {
+    boolean subPartitionConsumptionStateExist =
         amplificationFactorAdapter.meetsAny(userPartition, partitionConsumptionStateMap::containsKey);
-    Boolean pendingPartitionIngestionAction = hasPendingPartitionIngestionAction(userPartition);
+    boolean pendingPartitionIngestionAction = hasPendingPartitionIngestionAction(userPartition);
     return pendingPartitionIngestionAction || subPartitionConsumptionStateExist;
   }
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -175,7 +175,6 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
   protected final AtomicInteger consumerActionSequenceNumber = new AtomicInteger(0);
   protected final PriorityBlockingQueue<ConsumerAction> consumerActionsQueue;
   protected final Map<Integer, AtomicInteger> partitionToPendingConsumerActionCountMap;
-  protected final Map<Integer, Boolean> partitionToConsumptionStatusMap;
   protected final StorageMetadataService storageMetadataService;
   protected final TopicManagerRepository topicManagerRepository;
   protected final CachedPubSubMetadataGetter cachedPubSubMetadataGetter;
@@ -339,7 +338,6 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
     this.versionNumber = Version.parseVersionFromKafkaTopicName(kafkaVersionTopic);
     this.consumerActionsQueue = new PriorityBlockingQueue<>(CONSUMER_ACTION_QUEUE_INIT_CAPACITY);
     this.partitionToPendingConsumerActionCountMap = new VeniceConcurrentHashMap<>();
-    this.partitionToConsumptionStatusMap = new VeniceConcurrentHashMap<>();
 
     // partitionConsumptionStateMap could be accessed by multiple threads: consumption thread and the thread handling
     // kill message
@@ -520,7 +518,6 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
     amplificationFactorAdapter.execute(topicPartition.getPartitionNumber(), subPartition -> {
       partitionToPendingConsumerActionCountMap.computeIfAbsent(subPartition, x -> new AtomicInteger(0))
           .incrementAndGet();
-      partitionToConsumptionStatusMap.put(subPartition, true);
       consumerActionsQueue.add(
           new ConsumerAction(
               SUBSCRIBE,
@@ -1779,7 +1776,6 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
         } else {
           LOGGER.info("{} Unsubscribed to: {}", consumerTaskId, topicPartition);
         }
-        partitionToConsumptionStatusMap.put(partition, false);
         break;
       case RESET_OFFSET:
         resetOffset(partition, topicPartition, false);
@@ -3326,8 +3322,10 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
    * To check whether the given partition is still consuming message from Kafka
    */
   public boolean isPartitionConsuming(int userPartition) {
-    return hasPendingPartitionIngestionAction(userPartition)
-        || amplificationFactorAdapter.meetsAny(userPartition, partitionConsumptionStateMap::containsKey);
+    Boolean subPartitionConsumptionStateExist =
+        amplificationFactorAdapter.meetsAny(userPartition, partitionConsumptionStateMap::containsKey);
+    Boolean pendingPartitionIngestionAction = hasPendingPartitionIngestionAction(userPartition);
+    return pendingPartitionIngestionAction || subPartitionConsumptionStateExist;
   }
 
   /**


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Summary, imperative, start upper case, don't end with a period
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Previously, when OFFLINE => DROP transition happen, we will check if we can remove the partition from disk only based on partition consumption state exist or not. However, it is also possible that there are some pending state transitions in consume action queue of the `StoreIngestionTask`.  If we drop the partition and there is a pending SUBSCRIBE action in consumption queue, then it will cause data persistence failure due to partition not existed in disk. To avoid this, we add pending queue checking for the partition about to be deleted during the partition consumption check. 

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
internal CI
## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.