### PR TITLE
[router] Fetch dictionary in response decompressor

### DIFF
--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/PartialUpdateTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/PartialUpdateTest.java
@@ -612,7 +612,7 @@ public class PartialUpdateTest {
    */
   @Test(timeOut = TEST_TIMEOUT_MS
       * 3, dataProvider = "Compression-Strategies", dataProviderClass = DataProviderUtils.class)
-  public void testActiveAcitvePartialUpdateWithCompression(CompressionStrategy compressionStrategy) throws IOException {
+  public void testActiveActivePartialUpdateWithCompression(CompressionStrategy compressionStrategy) throws IOException {
     final String storeName = Utils.getUniqueString("rmdChunking");
     String parentControllerUrl = parentController.getControllerUrl();
     String keySchemaStr = "{\"type\" : \"string\"}";

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/router/api/TestVeniceDispatcher.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/router/api/TestVeniceDispatcher.java
@@ -420,7 +420,7 @@ public class TestVeniceDispatcher {
       return modifyingCompressor;
     })).when(compressorFactory).getCompressor(any());
 
-    doReturn(new VeniceResponseDecompressor(true, routerStats, mockRequest, "test_store", 1, compressorFactory))
+    doReturn(new VeniceResponseDecompressor(true, routerStats, mockRequest, "test_store", 1, compressorFactory, null))
         .when(mockPath)
         .getResponseDecompressor();
 

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/RouterServer.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/RouterServer.java
@@ -511,7 +511,8 @@ public class RouterServer extends AbstractVeniceService {
         routerStats,
         metadataRepository,
         config,
-        compressorFactory);
+        compressorFactory,
+        dictionaryRetrievalService);
 
     // Setup stat tracking for exceptional case
     RouterExceptionAndTrackingUtils.setRouterStats(routerStats);

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/api/DictionaryRetrievalService.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/api/DictionaryRetrievalService.java
@@ -231,9 +231,9 @@ public class DictionaryRetrievalService extends AbstractVeniceService {
     Instance instance = getOnlineInstance(kafkaTopic);
 
     if (instance == null) {
-      CompletableFuture<byte[]> future = new CompletableFuture<>();
-      future.completeExceptionally(new VeniceException("No online storage instance for resource: " + kafkaTopic));
-      return future;
+      return CompletableFuture.supplyAsync(() -> {
+        throw new VeniceException("No online storage instance for resource: " + kafkaTopic);
+      }, executor);
     }
 
     String instanceUrl = instance.getUrl(sslFactory.isPresent());

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/api/VenicePathParser.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/api/VenicePathParser.java
@@ -95,19 +95,23 @@ public class VenicePathParser<HTTP_REQUEST extends BasicHttpRequest>
   private final VeniceRouterConfig routerConfig;
   private final CompressorFactory compressorFactory;
 
+  private final DictionaryRetrievalService dictionaryRetrievalService;
+
   public VenicePathParser(
       VeniceVersionFinder versionFinder,
       VenicePartitionFinder partitionFinder,
       RouterStats<AggRouterHttpRequestStats> routerStats,
       ReadOnlyStoreRepository storeRepository,
       VeniceRouterConfig routerConfig,
-      CompressorFactory compressorFactory) {
+      CompressorFactory compressorFactory,
+      DictionaryRetrievalService dictionaryRetrievalService) {
     this.versionFinder = versionFinder;
     this.partitionFinder = partitionFinder;
     this.routerStats = routerStats;
     this.storeRepository = storeRepository;
     this.routerConfig = routerConfig;
     this.compressorFactory = compressorFactory;
+    this.dictionaryRetrievalService = dictionaryRetrievalService;
   };
 
   @Override
@@ -260,7 +264,8 @@ public class VenicePathParser<HTTP_REQUEST extends BasicHttpRequest>
           fullHttpRequest,
           storeName,
           version,
-          compressorFactory);
+          compressorFactory,
+          dictionaryRetrievalService);
       path.setResponseDecompressor(responseDecompressor);
 
       AggRouterHttpRequestStats aggRouterHttpRequestStats = routerStats.getStatsByType(requestType);

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/api/VeniceResponseDecompressor.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/api/VeniceResponseDecompressor.java
@@ -185,14 +185,14 @@ public class VeniceResponseDecompressor {
           if (dictionary != null) {
             compressor = compressorFactory
                 .createVersionSpecificCompressorIfNotExist(compressionStrategy, kafkaTopic, dictionary);
-            if (compressor == null) {
-              throw RouterExceptionAndTrackingUtils.newVeniceExceptionAndTracking(
-                  Optional.of(storeName),
-                  Optional.of(requestType),
-                  SERVICE_UNAVAILABLE,
-                  "Compressor not available for resource " + kafkaTopic + ". Dictionary not downloaded.");
-            }
           }
+        }
+        if (compressor == null) {
+          throw RouterExceptionAndTrackingUtils.newVeniceExceptionAndTracking(
+              Optional.of(storeName),
+              Optional.of(requestType),
+              SERVICE_UNAVAILABLE,
+              "Compressor not available for resource " + kafkaTopic + ". Dictionary not downloaded.");
         }
       } else {
         compressor = compressorFactory.getCompressor(compressionStrategy);

--- a/services/venice-router/src/test/java/com/linkedin/venice/router/api/TestDictionaryRetrievalService.java
+++ b/services/venice-router/src/test/java/com/linkedin/venice/router/api/TestDictionaryRetrievalService.java
@@ -129,7 +129,7 @@ public class TestDictionaryRetrievalService {
 
       DictionaryRetrievalService finalDictionaryRetrievalService = dictionaryRetrievalService;
       TestUtils.waitForNonDeterministicAssertion(5, TimeUnit.SECONDS, () -> {
-        assertNotNull(finalDictionaryRetrievalService.getFetchDelayTimeinMsMap().get("test_store_v1"));
+        assertNotNull(finalDictionaryRetrievalService.getFetchDelayTimeMsMap().get("test_store_v1"));
       });
 
       // start at a higher retry time as it will be easy to miss the first couple of retries
@@ -138,7 +138,7 @@ public class TestDictionaryRetrievalService {
         long finalExpectedValue = expectedValue;
         TestUtils.waitForNonDeterministicAssertion(MAX_DICTIONARY_DOWNLOAD_DELAY_TIME_MS, TimeUnit.SECONDS, () -> {
           assertEquals(
-              (long) finalDictionaryRetrievalService.getFetchDelayTimeinMsMap().get("test_store_v1"),
+              (long) finalDictionaryRetrievalService.getFetchDelayTimeMsMap().get("test_store_v1"),
               finalExpectedValue);
         });
         if (expectedValue == MAX_DICTIONARY_DOWNLOAD_DELAY_TIME_MS) {

--- a/services/venice-router/src/test/java/com/linkedin/venice/router/api/TestVenicePathParser.java
+++ b/services/venice-router/src/test/java/com/linkedin/venice/router/api/TestVenicePathParser.java
@@ -125,7 +125,8 @@ public class TestVenicePathParser {
         getMockedStats(),
         storeRepository,
         mock(VeniceRouterConfig.class),
-        mock(CompressorFactory.class));
+        mock(CompressorFactory.class),
+        null);
 
     String storeName = "test-store";
     String uri = "storage/" + storeName;
@@ -185,7 +186,8 @@ public class TestVenicePathParser {
         getMockedStats(),
         mock(ReadOnlyStoreRepository.class),
         MOCK_ROUTER_CONFIG,
-        compressorFactory);
+        compressorFactory,
+        null);
     BasicFullHttpRequest request = new BasicFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, uri, 0, 0);
     VenicePath path = parser.parseResourceUri(uri, request);
     String keyB64 = Base64.getEncoder().encodeToString("key".getBytes());
@@ -214,7 +216,8 @@ public class TestVenicePathParser {
         getMockedStats(),
         mock(ReadOnlyStoreRepository.class),
         MOCK_ROUTER_CONFIG,
-        compressorFactory).parseResourceUri(myUri, request);
+        compressorFactory,
+        null).parseResourceUri(myUri, request);
     ByteBuffer partitionKey = path.getPartitionKey().getKeyBuffer();
     Assert.assertEquals(
         path.getPartitionKey().getKeyBuffer(),
@@ -233,7 +236,8 @@ public class TestVenicePathParser {
         getMockedStats(),
         mock(ReadOnlyStoreRepository.class),
         MOCK_ROUTER_CONFIG,
-        compressorFactory).parseResourceUri("/badAction/storeName/key");
+        compressorFactory,
+        null).parseResourceUri("/badAction/storeName/key");
   }
 
   @Test
@@ -278,7 +282,8 @@ public class TestVenicePathParser {
         mockRouterStats,
         storeRepository,
         MOCK_ROUTER_CONFIG,
-        compressorFactory);
+        compressorFactory,
+        null);
     try {
       pathParser.parseResourceUri(myUri, request);
       fail("A RouterException should be thrown here");

--- a/services/venice-router/src/test/java/com/linkedin/venice/router/api/TestVeniceResponseAggregator.java
+++ b/services/venice-router/src/test/java/com/linkedin/venice/router/api/TestVeniceResponseAggregator.java
@@ -66,7 +66,8 @@ public class TestVeniceResponseAggregator {
     doReturn(requestType).when(path).getRequestType();
     doReturn(storeName).when(path).getStoreName();
     doReturn(null).when(path).getChunkedResponse();
-    doReturn(new VeniceResponseDecompressor(false, routerStats, request, storeName, 1, compressorFactory)).when(path)
+    doReturn(new VeniceResponseDecompressor(false, routerStats, request, storeName, 1, compressorFactory, null))
+        .when(path)
         .getResponseDecompressor();
     return path;
   }

--- a/services/venice-router/src/test/java/com/linkedin/venice/router/api/TestVeniceResponseDecompressor.java
+++ b/services/venice-router/src/test/java/com/linkedin/venice/router/api/TestVeniceResponseDecompressor.java
@@ -35,7 +35,7 @@ public class TestVeniceResponseDecompressor {
 
     CompressorFactory compressorFactory = mock(CompressorFactory.class);
     VeniceResponseDecompressor responseDecompressor =
-        new VeniceResponseDecompressor(true, null, request, "test-store", 1, compressorFactory);
+        new VeniceResponseDecompressor(true, null, request, "test-store", 1, compressorFactory, null);
 
     CompositeByteBuf content = Unpooled.compositeBuffer();
 
@@ -73,7 +73,7 @@ public class TestVeniceResponseDecompressor {
           new byte[] {});
 
       VeniceResponseDecompressor responseDecompressor =
-          new VeniceResponseDecompressor(true, routerStats, request, "test-store", 1, compressorFactory);
+          new VeniceResponseDecompressor(true, routerStats, request, "test-store", 1, compressorFactory, null);
 
       CompositeByteBuf content = Unpooled.compositeBuffer();
 
@@ -113,7 +113,7 @@ public class TestVeniceResponseDecompressor {
           new byte[] {});
 
       VeniceResponseDecompressor responseDecompressor =
-          new VeniceResponseDecompressor(true, routerStats, request, "test-store", 1, compressorFactory);
+          new VeniceResponseDecompressor(true, routerStats, request, "test-store", 1, compressorFactory, null);
       CompositeByteBuf content1 = Unpooled.compositeBuffer();
       ContentDecompressResult result =
           responseDecompressor.decompressMultiGetContent(CompressionStrategy.ZSTD_WITH_DICT, content1);


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Fetch dictionary in response decompressor
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

During router startup all current store version's compression dictionary are fetched asynchronously, meanwhile if there is a read request that needs to served it will throw the following 

 `Caused by: com.linkedin.venice.client.exceptions.VeniceClientHttpException: http status: 500, 
   com.linkedin.venice.exceptions.VeniceException: Compressor not available for resource. Dictionary not downloaded.`

This PR will try to fetch the dictionary for the given resource in blocking manner to serve the request in such cases. 
 Many CI tests should also get hardened by this.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

CI

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.