### PR TITLE
[server][common] Periodically produce SOS heartbeat from leader replicas of hybrid store

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
@@ -730,7 +730,7 @@ public class VeniceServerConfig extends VeniceClusterConfig {
     metaStoreWriterCloseTimeoutInMS = serverProperties.getLong(META_STORE_WRITER_CLOSE_TIMEOUT_MS, 300000L);
     metaStoreWriterCloseConcurrency = serverProperties.getInt(META_STORE_WRITER_CLOSE_CONCURRENCY, -1);
     ingestionHeartbeatIntervalMs =
-        serverProperties.getLong(SERVER_INGESTION_HEARTBEAT_INTERVAL_MS, TimeUnit.MINUTES.toMillis(15));
+        serverProperties.getLong(SERVER_INGESTION_HEARTBEAT_INTERVAL_MS, TimeUnit.MINUTES.toMillis(1));
   }
 
   long extractIngestionMemoryLimit(

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
@@ -67,6 +67,7 @@ import static com.linkedin.venice.ConfigKeys.SERVER_HTTP2_MAX_CONCURRENT_STREAMS
 import static com.linkedin.venice.ConfigKeys.SERVER_HTTP2_MAX_FRAME_SIZE;
 import static com.linkedin.venice.ConfigKeys.SERVER_HTTP2_MAX_HEADER_LIST_SIZE;
 import static com.linkedin.venice.ConfigKeys.SERVER_INGESTION_CHECKPOINT_DURING_GRACEFUL_SHUTDOWN_ENABLED;
+import static com.linkedin.venice.ConfigKeys.SERVER_INGESTION_HEARTBEAT_INTERVAL_MS;
 import static com.linkedin.venice.ConfigKeys.SERVER_INGESTION_ISOLATION_APPLICATION_PORT;
 import static com.linkedin.venice.ConfigKeys.SERVER_INGESTION_ISOLATION_SERVICE_PORT;
 import static com.linkedin.venice.ConfigKeys.SERVER_INGESTION_MODE;
@@ -442,6 +443,8 @@ public class VeniceServerConfig extends VeniceClusterConfig {
   private final long metaStoreWriterCloseTimeoutInMS;
   private final int metaStoreWriterCloseConcurrency;
 
+  private final long ingestionHeartbeatIntervalMs;
+
   public VeniceServerConfig(VeniceProperties serverProperties) throws ConfigurationException {
     this(serverProperties, Collections.emptyMap());
   }
@@ -726,6 +729,8 @@ public class VeniceServerConfig extends VeniceClusterConfig {
     ingestionTaskMaxIdleCount = serverProperties.getInt(SERVER_INGESTION_TASK_MAX_IDLE_COUNT, 10000);
     metaStoreWriterCloseTimeoutInMS = serverProperties.getLong(META_STORE_WRITER_CLOSE_TIMEOUT_MS, 300000L);
     metaStoreWriterCloseConcurrency = serverProperties.getInt(META_STORE_WRITER_CLOSE_CONCURRENCY, -1);
+    ingestionHeartbeatIntervalMs =
+        serverProperties.getLong(SERVER_INGESTION_HEARTBEAT_INTERVAL_MS, TimeUnit.MINUTES.toMillis(15));
   }
 
   long extractIngestionMemoryLimit(
@@ -1274,5 +1279,9 @@ public class VeniceServerConfig extends VeniceClusterConfig {
 
   public int getMetaStoreWriterCloseConcurrency() {
     return metaStoreWriterCloseConcurrency;
+  }
+
+  public long getIngestionHeartbeatIntervalMs() {
+    return ingestionHeartbeatIntervalMs;
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -823,8 +823,15 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
     final String newSourceKafkaServer = topicSwitch.sourceKafkaServers.get(0).toString();
     final PubSubTopicPartition newSourceTopicPartition =
         partitionConsumptionState.getSourceTopicPartition(newSourceTopic);
-    long upstreamStartOffset = partitionConsumptionState
-        .getLatestProcessedUpstreamRTOffset(OffsetRecord.NON_AA_REPLICATION_UPSTREAM_OFFSET_MAP_KEY);
+
+    // Only use the latestProcessedUpstreamRTOffset if we are switching to the new topic from a VT topic or if we are
+    // switching to the same RT topic. The upstreamStartOffset won't be correct if we are already consuming from a RT
+    // topic. e.g. If we are already consuming from RT and would like to switch to some arbitrary topic.
+    boolean switchingToSameTopic = currentLeaderTopic.getName().equals(newSourceTopic.getName());
+    long upstreamStartOffset = switchingToSameTopic || currentLeaderTopic.isVersionTopic()
+        ? partitionConsumptionState
+            .getLatestProcessedUpstreamRTOffset(OffsetRecord.NON_AA_REPLICATION_UPSTREAM_OFFSET_MAP_KEY)
+        : OffsetRecord.LOWEST_OFFSET;
 
     if (upstreamStartOffset < 0) {
       if (topicSwitch.rewindStartTimestamp > 0) {
@@ -2044,8 +2051,7 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
              * 2. SOS and EOS are from version topics in local fabric, which has 2 different scenarios:
              *    i.  native replication is enabled, but the current fabric is the source fabric (use cases: native repl for source fabric)
              *    ii. native replication is not enabled; it doesn't matter whether current replica is leader or follower,
-             *        messages from local VT doesn't need to be reproduced into local VT again (use cases: local batch consumption,
-             *        incremental push to VT)
+             *        messages from local VT doesn't need to be reproduced into local VT again (use case: local batch consumption)
              *
              * There is one exception that overrules the above conditions. i.e. if the SOS is a heartbeat from the RT topic.
              * In such case the heartbeat is produced to VT with updated {@link LeaderMetadataWrapper}.
@@ -3108,7 +3114,6 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
     if (earliestOffset == lastOffsetInRealTimeTopic - 1) {
       lag = 0;
     }
-
     if (shouldLog) {
       LOGGER.info(
           "{} partition {} RT lag offset for {} is: Latest RT offset [{}] - persisted offset [{}] = Lag [{}]",
@@ -3177,6 +3182,11 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
       PubSubTopic leaderTopic = pcs.getOffsetRecord().getLeaderTopic(pubSubTopicRepository);
       if (isLeader(pcs) && leaderTopic != null && leaderTopic.isRealTime()) {
         // Only leader replica consuming from RT topic may send sync offset control message.
+        if (pcs.getTopicSwitch() != null
+            && !leaderTopic.getName().equals(pcs.getTopicSwitch().getNewSourceTopic().getName())) {
+          // Do not send heartbeat if we detected a topic switch is happening since TS requires the leader to be idle.
+          continue;
+        }
         PubSubTopicPartition topicPartition = new PubSubTopicPartitionImpl(leaderTopic, pcs.getPartition());
         try {
           veniceWriter.get().sendHeartbeat(topicPartition, null, DEFAULT_LEADER_METADATA_WRAPPER);

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -7,6 +7,7 @@ import static com.linkedin.davinci.kafka.consumer.LeaderFollowerStateType.LEADER
 import static com.linkedin.davinci.kafka.consumer.LeaderFollowerStateType.PAUSE_TRANSITION_FROM_STANDBY_TO_LEADER;
 import static com.linkedin.davinci.kafka.consumer.LeaderFollowerStateType.STANDBY;
 import static com.linkedin.venice.kafka.protocol.enums.ControlMessageType.END_OF_PUSH;
+import static com.linkedin.venice.kafka.protocol.enums.ControlMessageType.START_OF_SEGMENT;
 import static com.linkedin.venice.writer.VeniceWriter.APP_DEFAULT_LOGICAL_TS;
 import static com.linkedin.venice.writer.VeniceWriter.DEFAULT_LEADER_METADATA_WRAPPER;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
@@ -68,6 +69,7 @@ import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import it.unimi.dsi.fastutil.ints.IntList;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -166,6 +168,8 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
   protected final Map<String, VeniceViewWriter> viewWriters;
 
   protected final AvroStoreDeserializerCache storeDeserializerCache;
+
+  private long lastSendIngestionHeartbeatTimestamp;
 
   public LeaderFollowerStoreIngestionTask(
       StoreIngestionTaskFactory.Builder builder,
@@ -2042,6 +2046,9 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
              *    ii. native replication is not enabled; it doesn't matter whether current replica is leader or follower,
              *        messages from local VT doesn't need to be reproduced into local VT again (use cases: local batch consumption,
              *        incremental push to VT)
+             *
+             * There is one exception that overrules the above conditions. i.e. if the SOS is a heartbeat from the RT topic.
+             * In such case the heartbeat is produced to VT with updated {@link LeaderMetadataWrapper}.
              */
             if (!consumerRecord.getTopicPartition().getPubSubTopic().isRealTime()) {
               produceToLocalKafka(
@@ -2060,26 +2067,41 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
                   kafkaClusterId,
                   beforeProcessingRecordTimestampNs);
             } else {
-              /**
-               * Based on current design handling this case (specially EOS) is tricky as we don't produce the SOS/EOS
-               * received from RT to local VT. But ideally EOS must be queued in-order (after all previous data message
-               * PUT/UPDATE/DELETE) to drainer. But since the queueing of data message to drainer
-               * happens in Kafka producer callback there is no way to queue this EOS to drainer in-order.
-               *
-               * Usually following processing in Leader for other control message.
-               *    1. DIV:
-               *    2. updateOffset:
-               *    3. stats maintenance as in {@link StoreIngestionTask#processKafkaDataMessage(PubSubMessage, PartitionConsumptionState, LeaderProducedRecordContext)}
-               *
-               * For #1 Since we have moved the DIV validation in this function, We are good with DIV part which is the most critical one.
-               * For #2 Leader will not update the offset for SOS/EOS. From Server restart point of view this is tolerable. This was the case in previous design also. So there is no change in behaviour.
-               * For #3 stat counter update will not happen for SOS/EOS message. This should not be a big issue. If needed we can copy some of the stats maintenance
-               *   work here.
-               *
-               * So in summary NO further processing is needed SOS/EOS received from RT topics. Just silently drop the message here.
-               * We should not return false here.
-               */
-              producedFinally = false;
+              if (controlMessageType == START_OF_SEGMENT
+                  && Arrays.equals(consumerRecord.getKey().getKey(), KafkaKey.HEART_BEAT.getKey())) {
+                LeaderProducerCallback callback = createProducerCallback(
+                    consumerRecord,
+                    partitionConsumptionState,
+                    leaderProducedRecordContext,
+                    subPartition,
+                    kafkaUrl,
+                    beforeProcessingRecordTimestampNs);
+                LeaderMetadataWrapper leaderMetadataWrapper =
+                    new LeaderMetadataWrapper(consumerRecord.getOffset(), kafkaClusterId);
+                PubSubTopicPartition topicPartition = new PubSubTopicPartitionImpl(getVersionTopic(), subPartition);
+                veniceWriter.get().sendHeartbeat(topicPartition, callback, leaderMetadataWrapper);
+              } else {
+                /**
+                 * Based on current design handling this case (specially EOS) is tricky as we don't produce the SOS/EOS
+                 * received from RT to local VT. But ideally EOS must be queued in-order (after all previous data message
+                 * PUT/UPDATE/DELETE) to drainer. But since the queueing of data message to drainer
+                 * happens in Kafka producer callback there is no way to queue this EOS to drainer in-order.
+                 *
+                 * Usually following processing in Leader for other control message.
+                 *    1. DIV:
+                 *    2. updateOffset:
+                 *    3. stats maintenance as in {@link StoreIngestionTask#processKafkaDataMessage(PubSubMessage, PartitionConsumptionState, LeaderProducedRecordContext)}
+                 *
+                 * For #1 Since we have moved the DIV validation in this function, We are good with DIV part which is the most critical one.
+                 * For #2 Leader will not update the offset for SOS/EOS. From Server restart point of view this is tolerable. This was the case in previous design also. So there is no change in behaviour.
+                 * For #3 stat counter update will not happen for SOS/EOS message. This should not be a big issue. If needed we can copy some of the stats maintenance
+                 *   work here.
+                 *
+                 * So in summary NO further processing is needed SOS/EOS received from RT topics. Just silently drop the message here.
+                 * We should not return false here.
+                 */
+                producedFinally = false;
+              }
             }
             break;
           case START_OF_INCREMENTAL_PUSH:
@@ -3078,20 +3100,13 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
     }
     long lag = lastOffsetInRealTimeTopic - latestLeaderOffset;
 
-    // Here we handle the case where the topic is actually empty,
-    // if consumerLag is a positive number then that means there is an existing offset that we've consumed to and a
-    // bigger offset out there somewhere. Meaning that there are at least two messages in the topic and it's not empty
-    long consumerLag = getPartitionOffsetLag(sourceRealTimeTopicKafkaURL, leaderTopic, partitionToGetLatestOffsetFor);
-    if (consumerLag <= 0) {
-      // We don't have a positive consumer lag, but this could be because we haven't polled.
-      // So as a final check to determine if the topic is empty, we check
-      // if the end offset is the same as the beginning
-      long earliestOffset = cachedPubSubMetadataGetter.getEarliestOffset(
-          getTopicManager(sourceRealTimeTopicKafkaURL),
-          new PubSubTopicPartitionImpl(leaderTopic, partitionToGetLatestOffsetFor));
-      if (earliestOffset == lastOffsetInRealTimeTopic - 1) {
-        lag = 0;
-      }
+    // Here we handle the case where the topic is actually empty, we check if the end offset is the same as the
+    // beginning
+    long earliestOffset = cachedPubSubMetadataGetter.getEarliestOffset(
+        getTopicManager(sourceRealTimeTopicKafkaURL),
+        new PubSubTopicPartitionImpl(leaderTopic, partitionToGetLatestOffsetFor));
+    if (earliestOffset == lastOffsetInRealTimeTopic - 1) {
+      lag = 0;
     }
 
     if (shouldLog) {
@@ -3144,5 +3159,36 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
   // test method
   protected void addPartitionConsumptionState(Integer partition, PartitionConsumptionState pcs) {
     partitionConsumptionStateMap.put(partition, pcs);
+  }
+
+  @Override
+  protected void maybeSendIngestionHeartbeat() {
+    if (!isHybridMode() || isDaVinciClient) {
+      // Skip if the store version is not hybrid or if this is a DaVinci client.
+      return;
+    }
+    long currentTimestamp = System.currentTimeMillis();
+    if (lastSendIngestionHeartbeatTimestamp + serverConfig.getIngestionHeartbeatIntervalMs() > currentTimestamp) {
+      // Not time for another heartbeat yet.
+      return;
+    }
+
+    for (PartitionConsumptionState pcs: partitionConsumptionStateMap.values()) {
+      PubSubTopic leaderTopic = pcs.getOffsetRecord().getLeaderTopic(pubSubTopicRepository);
+      if (isLeader(pcs) && leaderTopic != null && leaderTopic.isRealTime()) {
+        // Only leader replica consuming from RT topic may send sync offset control message.
+        PubSubTopicPartition topicPartition = new PubSubTopicPartitionImpl(leaderTopic, pcs.getPartition());
+        try {
+          veniceWriter.get().sendHeartbeat(topicPartition, null, DEFAULT_LEADER_METADATA_WRAPPER);
+        } catch (Exception e) {
+          String errorMessage = String.format(
+              "Failed to send ingestion heartbeat for topic: %s, partition: %s",
+              topicPartition.getPubSubTopic().getName(),
+              topicPartition.getPartitionNumber());
+          LOGGER.error(errorMessage, e);
+        }
+      }
+    }
+    lastSendIngestionHeartbeatTimestamp = currentTimestamp;
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -1296,6 +1296,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
         processConsumerActions(store);
         checkLongRunningTaskState();
         checkIngestionProgress(store);
+        maybeSendIngestionHeartbeat();
       }
 
       // If the ingestion task is stopped gracefully (server stops), persist processed offset to disk

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -100,6 +100,7 @@ import java.nio.ByteBuffer;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -2742,6 +2743,11 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
       PubSubMessage<KafkaKey, KafkaMessageEnvelope, Long> consumerRecord,
       boolean endOfPushReceived,
       PartitionConsumptionState partitionConsumptionState) {
+    KafkaKey key = consumerRecord.getKey();
+    if (key.isControlMessage() && Arrays.equals(KafkaKey.HEART_BEAT.getKey(), key.getKey())) {
+      // Skip DIV for ingestion heartbeat records.
+      return;
+    }
     Lazy<Boolean> tolerateMissingMsgs = Lazy.of(() -> {
       TopicManager topicManager = topicManagerRepository.getTopicManager();
       // Tolerate missing message if store version is data recovery + hybrid and TS not received yet (due to source
@@ -3686,4 +3692,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
     return kafkaValue.leaderMetadataFooter != null && kafkaValue.leaderMetadataFooter.upstreamOffset >= 0;
   }
 
+  protected void maybeSendIngestionHeartbeat() {
+    // No op, heartbeat is only useful for L/F hybrid stores.
+  }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/view/ChangeCaptureViewWriter.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/view/ChangeCaptureViewWriter.java
@@ -1,6 +1,5 @@
 package com.linkedin.davinci.store.view;
 
-import static com.linkedin.venice.ConfigKeys.*;
 import static com.linkedin.venice.writer.VeniceWriter.DEFAULT_LEADER_METADATA_WRAPPER;
 
 import com.linkedin.davinci.config.VeniceConfigLoader;

--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -2009,4 +2009,11 @@ public class ConfigKeys {
    * Venice router's principal name used for ssl. Default should contain "venice-router".
    */
   public static final String ROUTER_PRINCIPAL_NAME = "router.principal.name";
+
+  /**
+   * The time interval in milliseconds for leader replica to send heartbeat to RT topic for consumers
+   * (including the leader) to keep its latest processed upstream RT offset up-to-date in case when the RT topic ends
+   * with SOS, EOS or skipped records.
+   */
+  public static final String SERVER_INGESTION_HEARTBEAT_INTERVAL_MS = "server.ingestion.heartbeat.interval.ms";
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/guid/HeartbeatGuidV3Generator.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/guid/HeartbeatGuidV3Generator.java
@@ -1,0 +1,36 @@
+package com.linkedin.venice.guid;
+
+import com.linkedin.venice.kafka.protocol.GUID;
+import java.nio.ByteBuffer;
+import java.util.UUID;
+
+
+/**
+ * A Guid generator which uses the {@link java.util.UUID#nameUUIDFromBytes(byte[])}. Which is a type 3 Guid that will
+ * not collide with our type 4 Guid generated for user data using {@link JavaUtilGuidV4Generator}
+ */
+public class HeartbeatGuidV3Generator implements GuidGenerator {
+  private static HeartbeatGuidV3Generator instance;
+
+  private HeartbeatGuidV3Generator() {
+  }
+
+  public static synchronized HeartbeatGuidV3Generator getInstance() {
+    if (instance == null) {
+      instance = new HeartbeatGuidV3Generator();
+    }
+    return instance;
+  }
+
+  @Override
+  public GUID getGuid() {
+    UUID javaUtilUuid = UUID.nameUUIDFromBytes("heartbeatControlMessage".getBytes());
+    GUID guid = new GUID();
+    byte[] guidBytes = ByteBuffer.allocate(16)
+        .putLong(javaUtilUuid.getMostSignificantBits())
+        .putLong(javaUtilUuid.getLeastSignificantBits())
+        .array();
+    guid.bytes(guidBytes);
+    return guid;
+  }
+}

--- a/internal/venice-common/src/main/java/com/linkedin/venice/message/KafkaKey.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/message/KafkaKey.java
@@ -1,8 +1,12 @@
 package com.linkedin.venice.message;
 
+import com.linkedin.venice.kafka.protocol.GUID;
 import com.linkedin.venice.kafka.protocol.enums.MessageType;
 import com.linkedin.venice.utils.ByteUtils;
+import com.linkedin.venice.writer.VeniceWriter;
+import java.nio.ByteBuffer;
 import javax.annotation.Nonnull;
+import org.apache.avro.specific.FixedSize;
 
 
 /**
@@ -10,6 +14,13 @@ import javax.annotation.Nonnull;
  * {@link com.linkedin.venice.serialization.KafkaKeySerializer}.
  */
 public class KafkaKey {
+  public static final KafkaKey HEART_BEAT = new KafkaKey(
+      MessageType.CONTROL_MESSAGE,
+      ByteBuffer.allocate(GUID.class.getAnnotation(FixedSize.class).value() + Integer.BYTES * 2)
+          .put(VeniceWriter.HEART_BEAT_GUID.bytes())
+          .putInt(0)
+          .putInt(0)
+          .array());
   private final byte keyHeaderByte;
   private final byte[] key; // TODO: Consider whether we may want to use a ByteBuffer here
 

--- a/internal/venice-common/src/test/java/com/linkedin/venice/writer/VeniceWriterUnitTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/writer/VeniceWriterUnitTest.java
@@ -3,7 +3,6 @@ package com.linkedin.venice.writer;
 import static com.linkedin.venice.writer.VeniceWriter.APP_DEFAULT_LOGICAL_TS;
 import static com.linkedin.venice.writer.VeniceWriter.DEFAULT_LEADER_METADATA_WRAPPER;
 import static com.linkedin.venice.writer.VeniceWriter.DEFAULT_MAX_SIZE_FOR_USER_PAYLOAD_PER_MESSAGE_IN_BYTES;
-import static com.linkedin.venice.writer.VeniceWriter.HEART_BEAT_GUID;
 import static com.linkedin.venice.writer.VeniceWriter.VENICE_DEFAULT_LOGICAL_TS;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -17,6 +16,7 @@ import static org.mockito.Mockito.when;
 import com.linkedin.davinci.kafka.consumer.LeaderFollowerStoreIngestionTask;
 import com.linkedin.davinci.kafka.consumer.LeaderProducerCallback;
 import com.linkedin.davinci.kafka.consumer.PartitionConsumptionState;
+import com.linkedin.venice.guid.HeartbeatGuidV3Generator;
 import com.linkedin.venice.kafka.protocol.ControlMessage;
 import com.linkedin.venice.kafka.protocol.Delete;
 import com.linkedin.venice.kafka.protocol.KafkaMessageEnvelope;
@@ -459,9 +459,9 @@ public class VeniceWriterUnitTest {
   @Test
   public void testSendHeartbeat() throws ExecutionException, InterruptedException, TimeoutException {
     PubSubProducerAdapter mockedProducer = mock(PubSubProducerAdapter.class);
-    Future mockedFuture = mock(Future.class);
+    CompletableFuture mockedFuture = mock(CompletableFuture.class);
     when(mockedProducer.getNumberOfPartitions(any())).thenReturn(1);
-    when(mockedProducer.getNumberOfPartitions(any(), anyInt(), any())).thenReturn(1);
+    when(mockedProducer.getNumberOfPartitions(any())).thenReturn(1);
     when(mockedProducer.sendMessage(any(), any(), any(), any(), any(), any())).thenReturn(mockedFuture);
     Properties writerProperties = new Properties();
     String stringSchema = "\"string\"";
@@ -495,7 +495,7 @@ public class VeniceWriterUnitTest {
       ControlMessage controlMessage = (ControlMessage) kme.payloadUnion;
       Assert.assertEquals(controlMessage.controlMessageType, ControlMessageType.START_OF_SEGMENT.getValue());
       ProducerMetadata producerMetadata = kme.producerMetadata;
-      Assert.assertEquals(producerMetadata.producerGUID, HEART_BEAT_GUID);
+      Assert.assertEquals(producerMetadata.producerGUID, HeartbeatGuidV3Generator.getInstance().getGuid());
       Assert.assertEquals(producerMetadata.segmentNumber, 0);
       Assert.assertEquals(producerMetadata.messageSequenceNumber, 0);
     }

--- a/internal/venice-common/src/test/java/com/linkedin/venice/writer/VeniceWriterUnitTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/writer/VeniceWriterUnitTest.java
@@ -1,10 +1,13 @@
 package com.linkedin.venice.writer;
 
 import static com.linkedin.venice.writer.VeniceWriter.APP_DEFAULT_LOGICAL_TS;
+import static com.linkedin.venice.writer.VeniceWriter.DEFAULT_LEADER_METADATA_WRAPPER;
 import static com.linkedin.venice.writer.VeniceWriter.DEFAULT_MAX_SIZE_FOR_USER_PAYLOAD_PER_MESSAGE_IN_BYTES;
+import static com.linkedin.venice.writer.VeniceWriter.HEART_BEAT_GUID;
 import static com.linkedin.venice.writer.VeniceWriter.VENICE_DEFAULT_LOGICAL_TS;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.mock;
@@ -14,15 +17,19 @@ import static org.mockito.Mockito.when;
 import com.linkedin.davinci.kafka.consumer.LeaderFollowerStoreIngestionTask;
 import com.linkedin.davinci.kafka.consumer.LeaderProducerCallback;
 import com.linkedin.davinci.kafka.consumer.PartitionConsumptionState;
+import com.linkedin.venice.kafka.protocol.ControlMessage;
 import com.linkedin.venice.kafka.protocol.Delete;
 import com.linkedin.venice.kafka.protocol.KafkaMessageEnvelope;
 import com.linkedin.venice.kafka.protocol.ProducerMetadata;
 import com.linkedin.venice.kafka.protocol.Put;
+import com.linkedin.venice.kafka.protocol.enums.ControlMessageType;
 import com.linkedin.venice.kafka.protocol.enums.MessageType;
 import com.linkedin.venice.message.KafkaKey;
 import com.linkedin.venice.partitioner.DefaultVenicePartitioner;
 import com.linkedin.venice.pubsub.api.PubSubMessage;
 import com.linkedin.venice.pubsub.api.PubSubProducerAdapter;
+import com.linkedin.venice.pubsub.api.PubSubTopic;
+import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
 import com.linkedin.venice.serialization.KeyWithChunkingSuffixSerializer;
 import com.linkedin.venice.serialization.VeniceKafkaSerializer;
 import com.linkedin.venice.serialization.avro.AvroProtocolDefinition;
@@ -449,4 +456,48 @@ public class VeniceWriterUnitTest {
     }
   }
 
+  @Test
+  public void testSendHeartbeat() throws ExecutionException, InterruptedException, TimeoutException {
+    PubSubProducerAdapter mockedProducer = mock(PubSubProducerAdapter.class);
+    Future mockedFuture = mock(Future.class);
+    when(mockedProducer.getNumberOfPartitions(any())).thenReturn(1);
+    when(mockedProducer.getNumberOfPartitions(any(), anyInt(), any())).thenReturn(1);
+    when(mockedProducer.sendMessage(any(), any(), any(), any(), any(), any())).thenReturn(mockedFuture);
+    Properties writerProperties = new Properties();
+    String stringSchema = "\"string\"";
+    VeniceKafkaSerializer serializer = new VeniceAvroKafkaSerializer(stringSchema);
+    String testTopic = "test_rt";
+    VeniceWriterOptions veniceWriterOptions = new VeniceWriterOptions.Builder(testTopic).setKeySerializer(serializer)
+        .setValueSerializer(serializer)
+        .setWriteComputeSerializer(serializer)
+        .setPartitioner(new DefaultVenicePartitioner())
+        .setTime(SystemTime.INSTANCE)
+        .build();
+    VeniceWriter<Object, Object, Object> writer =
+        new VeniceWriter(veniceWriterOptions, new VeniceProperties(writerProperties), mockedProducer);
+    PubSubTopicPartition topicPartition = mock(PubSubTopicPartition.class);
+    PubSubTopic topic = mock(PubSubTopic.class);
+    when(topic.getName()).thenReturn(testTopic);
+    when(topicPartition.getPubSubTopic()).thenReturn(topic);
+    when(topicPartition.getPartitionNumber()).thenReturn(0);
+    for (int i = 0; i < 10; i++) {
+      writer.sendHeartbeat(topicPartition, null, DEFAULT_LEADER_METADATA_WRAPPER);
+    }
+    ArgumentCaptor<KafkaMessageEnvelope> kmeArgumentCaptor = ArgumentCaptor.forClass(KafkaMessageEnvelope.class);
+    ArgumentCaptor<KafkaKey> kafkaKeyArgumentCaptor = ArgumentCaptor.forClass(KafkaKey.class);
+    verify(mockedProducer, atLeast(10))
+        .sendMessage(eq(testTopic), eq(0), kafkaKeyArgumentCaptor.capture(), kmeArgumentCaptor.capture(), any(), any());
+    for (KafkaKey key: kafkaKeyArgumentCaptor.getAllValues()) {
+      Assert.assertTrue(Arrays.equals(KafkaKey.HEART_BEAT.getKey(), key.getKey()));
+    }
+    for (KafkaMessageEnvelope kme: kmeArgumentCaptor.getAllValues()) {
+      Assert.assertEquals(kme.messageType, MessageType.CONTROL_MESSAGE.getValue());
+      ControlMessage controlMessage = (ControlMessage) kme.payloadUnion;
+      Assert.assertEquals(controlMessage.controlMessageType, ControlMessageType.START_OF_SEGMENT.getValue());
+      ProducerMetadata producerMetadata = kme.producerMetadata;
+      Assert.assertEquals(producerMetadata.producerGUID, HEART_BEAT_GUID);
+      Assert.assertEquals(producerMetadata.segmentNumber, 0);
+      Assert.assertEquals(producerMetadata.messageSequenceNumber, 0);
+    }
+  }
 }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/ServiceFactory.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/ServiceFactory.java
@@ -175,6 +175,10 @@ public class ServiceFactory {
     });
   }
 
+  /**
+   * @deprecated Future use should use {@link #getVeniceServer(String, String, PubSubBrokerWrapper, String, Properties, Properties, boolean, String, Map, String)}
+   * to have the correct kafka cluster map in multi-fabric environment for essential features like A/A and heartbeat to work.
+   */
   public static VeniceServerWrapper getVeniceServer(
       String regionName,
       String clusterName,

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceClusterWrapper.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceClusterWrapper.java
@@ -630,13 +630,18 @@ public class VeniceClusterWrapper extends ProcessWrapper {
   }
 
   public VeniceServerWrapper addVeniceServer(Properties featureProperties, Properties configProperties) {
+    Properties mergedProperties = options.getExtraProperties();
+    mergedProperties.putAll(configProperties);
     VeniceServerWrapper veniceServerWrapper = ServiceFactory.getVeniceServer(
         options.getRegionName(),
         getClusterName(),
         pubSubBrokerWrapper,
         zkServerWrapper.getAddress(),
         featureProperties,
-        configProperties,
+        mergedProperties,
+        options.isForkServer(),
+        "",
+        options.getKafkaClusterMap(),
         clusterToServerD2.get(getClusterName()));
     synchronized (this) {
       veniceServerWrappers.put(veniceServerWrapper.getPort(), veniceServerWrapper);

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceServerWrapper.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceServerWrapper.java
@@ -22,6 +22,7 @@ import static com.linkedin.venice.ConfigKeys.PUB_SUB_CONSUMER_ADAPTER_FACTORY_CL
 import static com.linkedin.venice.ConfigKeys.PUB_SUB_PRODUCER_ADAPTER_FACTORY_CLASS;
 import static com.linkedin.venice.ConfigKeys.SERVER_DISK_FULL_THRESHOLD;
 import static com.linkedin.venice.ConfigKeys.SERVER_HTTP2_INBOUND_ENABLED;
+import static com.linkedin.venice.ConfigKeys.SERVER_INGESTION_HEARTBEAT_INTERVAL_MS;
 import static com.linkedin.venice.ConfigKeys.SERVER_INGESTION_ISOLATION_APPLICATION_PORT;
 import static com.linkedin.venice.ConfigKeys.SERVER_INGESTION_ISOLATION_SERVICE_PORT;
 import static com.linkedin.venice.ConfigKeys.SERVER_NETTY_GRACEFUL_SHUTDOWN_PERIOD_SECONDS;

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceServerWrapper.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceServerWrapper.java
@@ -247,6 +247,7 @@ public class VeniceServerWrapper extends ProcessWrapper implements MetricsAware 
           .put(
               PUB_SUB_ADMIN_ADAPTER_FACTORY_CLASS,
               pubSubBrokerWrapper.getPubSubClientsFactory().getAdminAdapterFactory().getClass().getName())
+          .put(SERVER_INGESTION_HEARTBEAT_INTERVAL_MS, 1000)
           .put(configProperties);
       if (sslToKafka) {
         serverPropsBuilder.put(KAFKA_SECURITY_PROTOCOL, SecurityProtocol.SSL.name);

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceServerWrapper.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceServerWrapper.java
@@ -247,7 +247,7 @@ public class VeniceServerWrapper extends ProcessWrapper implements MetricsAware 
           .put(
               PUB_SUB_ADMIN_ADAPTER_FACTORY_CLASS,
               pubSubBrokerWrapper.getPubSubClientsFactory().getAdminAdapterFactory().getClass().getName())
-          .put(SERVER_INGESTION_HEARTBEAT_INTERVAL_MS, 1000)
+          .put(SERVER_INGESTION_HEARTBEAT_INTERVAL_MS, 5000)
           .put(configProperties);
       if (sslToKafka) {
         serverPropsBuilder.put(KAFKA_SECURITY_PROTOCOL, SecurityProtocol.SSL.name);


### PR DESCRIPTION
## [server][common] Periodically produce SOS heartbeat from leader replicas of hybrid store

For hybrid store only, periodically have the leader write a special SOS to the RT topic with the following properties:

- Special key with constant bytes so it will be compacted.

- A fixed/known producer GUID dedicated to heartbeats so DIV won’t break.

- The special segment will never contain any data so no EOS needed.

Upon consuming the new CM the leader will write it to its local VT. Once the record is processed in the drainer the leader can update its latest processed upstream RT topic offset accordingly. At this point the latest processed upstream RT topic offset will be correct regardless if the RT had trailing CMs or skippable data records due to DCR.


## How was this PR tested?

- Made sure existing unit and integration tests pass with heartbeat enabled by default at a 5 seconds interval.
- Modified an existing A/A test that enforced a tight lag requirement with DCR skipped messages at the end of the RT that couldn't become online after rewind by lag check without the heartbeat message.

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.