### PR TITLE
[server] Filter out junk metric values for nearline latency sensors 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,7 @@ if (project.hasProperty('overrideBuildEnvironment')) {
 }
 
 def avroVersion = '1.10.2'
-def avroUtilVersion = '0.3.17'
+def avroUtilVersion = '0.3.18'
 def grpcVersion = '1.49.2'
 def kafkaGroup = 'com.linkedin.kafka'
 def kafkaVersion = '2.4.1.65'

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/IngestionStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/IngestionStats.java
@@ -488,19 +488,19 @@ public class IngestionStats {
   }
 
   public double getNearlineProducerToLocalBrokerLatencyAvg() {
-    return nearlineProducerToLocalBrokerLatencySensor.getAvg();
+    return unAvailableToZero(nearlineProducerToLocalBrokerLatencySensor.getAvg());
   }
 
   public double getNearlineProducerToLocalBrokerLatencyMax() {
-    return nearlineProducerToLocalBrokerLatencySensor.getMax();
+    return unAvailableToZero(nearlineProducerToLocalBrokerLatencySensor.getMax());
   }
 
   public double getNearlineLocalBrokerToReadyToServeLatencyAvg() {
-    return nearlineLocalBrokerToReadyToServeLatencySensor.getAvg();
+    return unAvailableToZero(nearlineLocalBrokerToReadyToServeLatencySensor.getAvg());
   }
 
   public double getNearlineLocalBrokerToReadyToServeLatencyMax() {
-    return nearlineLocalBrokerToReadyToServeLatencySensor.getMax();
+    return unAvailableToZero(nearlineLocalBrokerToReadyToServeLatencySensor.getMax());
   }
 
   public void recordNearlineProducerToLocalBrokerLatency(double value, long currentTimeMs) {
@@ -511,4 +511,10 @@ public class IngestionStats {
     nearlineLocalBrokerToReadyToServeLatencySensor.record(value, currentTimeMs);
   }
 
+  public static double unAvailableToZero(double value) {
+    /* When data is unavailable, return 0 instead of NaN or Infinity. Some metrics are initialized to -INF.
+     This can cause problems when metrics are aggregated. Use only when zero makes semantic sense.
+    */
+    return Double.isFinite(value) ? value : 0;
+  }
 }

--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/DispatchingAvroGenericStoreClient.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/DispatchingAvroGenericStoreClient.java
@@ -644,11 +644,11 @@ public class DispatchingAvroGenericStoreClient<K, V> extends InternalAvroStoreCl
     metadata.start();
 
     this.multiGetSerializer =
-        FastSerializerDeserializerFactory.getAvroGenericSerializer(MultiGetRouterRequestKeyV1.SCHEMA$);
+        FastSerializerDeserializerFactory.getFastAvroGenericSerializer(MultiGetRouterRequestKeyV1.SCHEMA$);
   }
 
   protected RecordSerializer getKeySerializer(Schema keySchema) {
-    return FastSerializerDeserializerFactory.getAvroGenericSerializer(keySchema);
+    return FastSerializerDeserializerFactory.getFastAvroGenericSerializer(keySchema);
   }
 
   @Override
@@ -678,10 +678,5 @@ public class DispatchingAvroGenericStoreClient<K, V> extends InternalAvroStoreCl
   // Visible for testing
   public RecordSerializer<K> getKeySerializer() {
     return keySerializer;
-  }
-
-  // Visible for testing
-  public RecordSerializer<MultiGetRouterRequestKeyV1> getMultiGetSerializer() {
-    return multiGetSerializer;
   }
 }

--- a/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/DispatchingAvroGenericStoreClientTest.java
+++ b/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/DispatchingAvroGenericStoreClientTest.java
@@ -24,6 +24,8 @@ import com.linkedin.venice.fastclient.stats.FastClientStats;
 import com.linkedin.venice.fastclient.transport.TransportClientResponseForRoute;
 import com.linkedin.venice.read.RequestType;
 import com.linkedin.venice.read.protocol.response.MultiGetResponseRecordV1;
+import com.linkedin.venice.serializer.FastSerializerDeserializerFactory;
+import com.linkedin.venice.serializer.RecordSerializer;
 import com.linkedin.venice.serializer.SerializerDeserializerFactory;
 import com.linkedin.venice.utils.DataProviderUtils;
 import com.linkedin.venice.utils.TestUtils;
@@ -56,6 +58,9 @@ public class DispatchingAvroGenericStoreClientTest {
   private static final Set<String> BATCH_GET_PARTIAL_KEYS_1 = new HashSet<>();
   private static final Set<String> BATCH_GET_PARTIAL_KEYS_2 = new HashSet<>();
   private static final Map<String, String> BATCH_GET_VALUE_RESPONSE = new HashMap<>();
+  private static final RecordSerializer MULTI_GET_RESPONSE_SERIALIZER =
+      FastSerializerDeserializerFactory.getFastAvroGenericSerializer(MultiGetResponseRecordV1.SCHEMA$);
+
   private ClientConfig.ClientConfigBuilder clientConfigBuilder;
   private GetRequestContext getRequestContext;
   private BatchGetRequestContext batchGetRequestContext;
@@ -387,7 +392,7 @@ public class DispatchingAvroGenericStoreClientTest {
       routerRequestValue.keyIndex = count.getAndIncrement();
       routerRequestValues.add(routerRequestValue);
     });
-    return dispatchingAvroGenericStoreClient.getMultiGetSerializer().serializeObjects(routerRequestValues);
+    return MULTI_GET_RESPONSE_SERIALIZER.serializeObjects(routerRequestValues);
   }
 
   @Test(timeOut = TEST_TIMEOUT)

--- a/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/utils/TestClientSimulator.java
+++ b/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/utils/TestClientSimulator.java
@@ -117,9 +117,9 @@ public class TestClientSimulator implements Client {
 
   public TestClientSimulator() {
     // get()
-    this.keySerializer = FastSerializerDeserializerFactory.getAvroGenericSerializer(KEY_VALUE_SCHEMA);
+    this.keySerializer = FastSerializerDeserializerFactory.getFastAvroGenericSerializer(KEY_VALUE_SCHEMA);
     this.keyDeserializer =
-        FastSerializerDeserializerFactory.getAvroGenericDeserializer(KEY_VALUE_SCHEMA, KEY_VALUE_SCHEMA);
+        FastSerializerDeserializerFactory.getFastAvroGenericDeserializer(KEY_VALUE_SCHEMA, KEY_VALUE_SCHEMA);
     // multiGet()
     this.multiGetResponseSerializer =
         FastSerializerDeserializerFactory.getFastAvroGenericSerializer(MultiGetResponseRecordV1.SCHEMA$);

--- a/clients/venice-producer/src/main/java/com/linkedin/venice/producer/AbstractVeniceProducer.java
+++ b/clients/venice-producer/src/main/java/com/linkedin/venice/producer/AbstractVeniceProducer.java
@@ -149,7 +149,7 @@ public abstract class AbstractVeniceProducer<K, V> implements VeniceProducer<K, 
   }
 
   protected RecordSerializer<Object> getSerializer(Schema schema) {
-    return FastSerializerDeserializerFactory.getAvroGenericSerializer(schema);
+    return FastSerializerDeserializerFactory.getFastAvroGenericSerializer(schema);
   }
 
   private static Schema getSchemaFromObject(Object object) {

--- a/clients/venice-producer/src/main/java/com/linkedin/venice/producer/AbstractVeniceProducer.java
+++ b/clients/venice-producer/src/main/java/com/linkedin/venice/producer/AbstractVeniceProducer.java
@@ -346,7 +346,7 @@ public abstract class AbstractVeniceProducer<K, V> implements VeniceProducer<K, 
                 + ". This might be transient if the schema has been registered recently.");
       }
 
-      UpdateBuilder updateBuilder = new UpdateBuilderImpl(updateSchemaEntry.getSchema());
+      UpdateBuilder updateBuilder = new UpdateBuilderImpl(updateSchema);
       updateFunction.accept(updateBuilder);
       GenericRecord updateRecord = updateBuilder.build();
 

--- a/clients/venice-producer/src/main/java/com/linkedin/venice/producer/online/ProducerTool.java
+++ b/clients/venice-producer/src/main/java/com/linkedin/venice/producer/online/ProducerTool.java
@@ -184,10 +184,14 @@ public class ProducerTool {
       RouterBasedStoreSchemaFetcher schemaFetcher = new RouterBasedStoreSchemaFetcher(castClient);
       Schema keySchema = schemaFetcher.getKeySchema();
       Object key = adaptDataToSchema(producerContext.key, keySchema);
-      Object value = getValueObject(producerContext.value, schemaFetcher);
-
-      producer.asyncPut(key, value).get();
-      System.out.println("Data written to Venice!");
+      if (producerContext.value.equals("null")) { // Only allow `null`. Not "null", or 'null', or whatever.
+        producer.asyncDelete(key).get();
+        System.out.println("Record deleted from Venice!");
+      } else {
+        Object value = getValueObject(producerContext.value, schemaFetcher);
+        producer.asyncPut(key, value).get();
+        System.out.println("Data written to Venice!");
+      }
     } catch (Exception e) {
       System.err.println(ExceptionUtils.stackTraceToString(e));
       System.exit(1);

--- a/clients/venice-producer/src/test/java/com/linkedin/venice/producer/online/OnlineVeniceProducerTest.java
+++ b/clients/venice-producer/src/test/java/com/linkedin/venice/producer/online/OnlineVeniceProducerTest.java
@@ -1082,7 +1082,7 @@ public class OnlineVeniceProducerTest {
   }
 
   private static RecordSerializer<Object> getSerializer(Schema schema) {
-    return FastSerializerDeserializerFactory.getAvroGenericSerializer(schema);
+    return FastSerializerDeserializerFactory.getFastAvroGenericSerializer(schema);
   }
 
   private void assertThrowsExceptionFromFuture(Class throwableClass, Assert.ThrowingRunnable runnable) {

--- a/clients/venice-producer/src/test/java/com/linkedin/venice/producer/online/OnlineVeniceProducerTest.java
+++ b/clients/venice-producer/src/test/java/com/linkedin/venice/producer/online/OnlineVeniceProducerTest.java
@@ -12,7 +12,6 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doCallRealMethod;
-import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -49,6 +48,7 @@ import com.linkedin.venice.meta.RoutingStrategy;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.meta.VersionImpl;
 import com.linkedin.venice.meta.ZKStore;
+import com.linkedin.venice.producer.DurableWrite;
 import com.linkedin.venice.producer.VeniceProducer;
 import com.linkedin.venice.pubsub.api.PubSubProducerCallback;
 import com.linkedin.venice.schema.writecompute.WriteComputeSchemaConverter;
@@ -56,6 +56,7 @@ import com.linkedin.venice.serializer.FastSerializerDeserializerFactory;
 import com.linkedin.venice.serializer.RecordSerializer;
 import com.linkedin.venice.utils.ObjectMapperFactory;
 import com.linkedin.venice.utils.TestUtils;
+import com.linkedin.venice.utils.Time;
 import com.linkedin.venice.utils.Utils;
 import com.linkedin.venice.utils.VeniceProperties;
 import com.linkedin.venice.writer.VeniceWriter;
@@ -708,6 +709,41 @@ public class OnlineVeniceProducerTest {
   }
 
   @Test
+  public void testConcurrentEnsureSchemaRefreshed() throws IOException, ExecutionException, InterruptedException {
+    boolean updateEnabled = true;
+    ClientConfig storeClientConfig = configureMocksAndGetStoreConfig(storeName, updateEnabled);
+    TransportClient mockTransportClient = ClientFactory.getTransportClient(storeClientConfig);
+    configureMockTransportClient(mockTransportClient, updateEnabled, null, 500);
+
+    MetricsRepository metricsRepository = new MetricsRepository();
+    Properties backendConfigs = new Properties();
+
+    // Should be high enough to not get triggered during the test as it might end up fetching the schemas instead
+    backendConfigs.put(CLIENT_PRODUCER_SCHEMA_REFRESH_INTERVAL_SECONDS, 2 * Time.MS_PER_MINUTE);
+    try (VeniceProducer producer =
+        new TestOnlineVeniceProducer(storeClientConfig, new VeniceProperties(backendConfigs), metricsRepository)) {
+      CompletableFuture<DurableWrite> future1 = producer.asyncUpdate(1000, "KEY1", updateBuilderObj -> {
+        UpdateBuilder updateBuilder = ((UpdateBuilder) updateBuilderObj);
+        updateBuilder.setNewFieldValue(FIELD_COLOR, "green");
+        Assert.assertEquals(updateBuilder.build().getSchema().toString(), UPDATE_SCHEMA_2.toString());
+      });
+
+      CompletableFuture<DurableWrite> future2 = producer.asyncUpdate(1000, "KEY2", updateBuilderObj -> {
+        UpdateBuilder updateBuilder = ((UpdateBuilder) updateBuilderObj);
+        updateBuilder.setNewFieldValue(FIELD_COLOR, "red");
+      });
+
+      /**
+       * Before this fix, one of these {@code asyncUpdate} call would think that update schemas had already been fetched
+       * and because it wouldn't find the update schemas themselves, the future would return exceptionally with:
+       * {@literal Update schema not found. Check if partial update is enabled for the store...}
+       */
+      future1.get();
+      future2.get();
+    }
+  }
+
+  @Test
   public void testFetchLatestValueAndUpdateSchemas() throws IOException, ExecutionException, InterruptedException {
     ClientConfig storeClientConfig = configureMocksAndGetStoreConfig(storeName, true);
 
@@ -728,8 +764,9 @@ public class OnlineVeniceProducerTest {
           Arrays.asList(VALUE_SCHEMA_1, VALUE_SCHEMA_2, VALUE_SCHEMA_3, VALUE_SCHEMA_4),
           3,
           Arrays.asList(UPDATE_SCHEMA_1, UPDATE_SCHEMA_2, UPDATE_SCHEMA_3, UPDATE_SCHEMA_4),
-          true);
-      TestUtils.waitForNonDeterministicAssertion(10, TimeUnit.MINUTES, () -> {
+          true,
+          0);
+      TestUtils.waitForNonDeterministicAssertion(1, TimeUnit.MINUTES, () -> {
         try {
           producer.asyncUpdate(1000, "KEY1", updateBuilderObj -> {
             UpdateBuilder updateBuilder = ((UpdateBuilder) updateBuilderObj);
@@ -763,9 +800,8 @@ public class OnlineVeniceProducerTest {
     multiSchemaResponse.setSchemas(valueSchemaArr);
     multiSchemaResponse.setCluster(clusterName);
 
-    CompletableFuture<TransportClientResponse> requestTopicFuture =
-        getTransportClientFuture(MAPPER.writeValueAsBytes(multiSchemaResponse));
-    doReturn(requestTopicFuture).when(transportClient)
+    doAnswer(invocation -> getTransportClientFuture(MAPPER.writeValueAsBytes(multiSchemaResponse), 0))
+        .when(transportClient)
         .get(eq("value_schema/" + KAFKA_MESSAGE_ENVELOPE.getSystemStoreName()), anyMap());
   }
 
@@ -802,6 +838,14 @@ public class OnlineVeniceProducerTest {
       TransportClient transportClient,
       boolean updateEnabled,
       byte[] requestTopicResponse) throws IOException {
+    configureMockTransportClient(transportClient, updateEnabled, requestTopicResponse, 0);
+  }
+
+  private void configureMockTransportClient(
+      TransportClient transportClient,
+      boolean updateEnabled,
+      byte[] requestTopicResponse,
+      int delayInResponseMs) throws IOException {
     doCallRealMethod().when(transportClient).getCopyIfNotUsableInCallback();
     doCallRealMethod().when(transportClient).get(anyString());
     doCallRealMethod().when(transportClient).post(anyString(), any());
@@ -836,33 +880,34 @@ public class OnlineVeniceProducerTest {
     store.setVersions(Collections.singletonList(version));
     store.setWriteComputationEnabled(updateEnabled);
 
-    CompletableFuture<TransportClientResponse> requestTopicFuture;
-    if (requestTopicResponse == null) {
-      VersionCreationResponse versionCreationResponse = new VersionCreationResponse();
-      versionCreationResponse.setPartitions(partitionCount);
-      versionCreationResponse.setPartitionerClass(partitionerConfig.getPartitionerClass());
-      versionCreationResponse.setPartitionerParams(partitionerConfig.getPartitionerParams());
-      versionCreationResponse.setKafkaBootstrapServers("localhost:9092");
-      versionCreationResponse.setKafkaTopic(Version.composeRealTimeTopic(storeName));
-      versionCreationResponse.setAmplificationFactor(1);
-      versionCreationResponse.setEnableSSL(false);
+    doAnswer(invocation -> {
+      if (requestTopicResponse == null) {
+        VersionCreationResponse versionCreationResponse = new VersionCreationResponse();
+        versionCreationResponse.setPartitions(partitionCount);
+        versionCreationResponse.setPartitionerClass(partitionerConfig.getPartitionerClass());
+        versionCreationResponse.setPartitionerParams(partitionerConfig.getPartitionerParams());
+        versionCreationResponse.setKafkaBootstrapServers("localhost:9092");
+        versionCreationResponse.setKafkaTopic(Version.composeRealTimeTopic(storeName));
+        versionCreationResponse.setAmplificationFactor(1);
+        versionCreationResponse.setEnableSSL(false);
 
-      requestTopicFuture = getTransportClientFuture(MAPPER.writeValueAsBytes(versionCreationResponse));
-    } else {
-      requestTopicFuture = getTransportClientFuture(requestTopicResponse);
-    }
-    doReturn(requestTopicFuture).when(transportClient).get(eq("request_topic/" + storeName), anyMap());
+        return getTransportClientFuture(MAPPER.writeValueAsBytes(versionCreationResponse), delayInResponseMs);
+      } else {
+        return getTransportClientFuture(requestTopicResponse, delayInResponseMs);
+      }
+    }).when(transportClient).get(eq("request_topic/" + storeName), anyMap());
 
-    CompletableFuture<TransportClientResponse> storeStateFuture =
-        getTransportClientFuture(STORE_SERIALIZER.serialize(store, null));
-    doReturn(storeStateFuture).when(transportClient).get(eq("store_state/" + storeName), anyMap());
+    doAnswer(invocation -> getTransportClientFuture(STORE_SERIALIZER.serialize(store, null), delayInResponseMs))
+        .when(transportClient)
+        .get(eq("store_state/" + storeName), anyMap());
 
     configureSchemaResponseMocks(
         transportClient,
         Arrays.asList(VALUE_SCHEMA_1, VALUE_SCHEMA_2),
         2,
         Arrays.asList(UPDATE_SCHEMA_1, UPDATE_SCHEMA_2),
-        updateEnabled);
+        updateEnabled,
+        delayInResponseMs);
   }
 
   private void configureSchemaResponseMocks(
@@ -870,15 +915,16 @@ public class OnlineVeniceProducerTest {
       List<Schema> valueSchemas,
       int supersetSchemaId,
       List<Schema> updateSchemas,
-      boolean updateEnabled) throws JsonProcessingException {
+      boolean updateEnabled,
+      int delayInResponseMs) {
     String keySchemaStr = KEY_SCHEMA.toString();
     SchemaResponse keySchemaResponse = new SchemaResponse();
     keySchemaResponse.setId(1);
     keySchemaResponse.setSchemaStr(keySchemaStr);
 
-    CompletableFuture<TransportClientResponse> keySchemaFuture =
-        getTransportClientFuture(MAPPER.writeValueAsBytes(keySchemaResponse));
-    doReturn(keySchemaFuture).when(transportClient).get(eq("key_schema/" + storeName), anyMap());
+    doAnswer(invocation -> getTransportClientFuture(MAPPER.writeValueAsBytes(keySchemaResponse), delayInResponseMs))
+        .when(transportClient)
+        .get(eq("key_schema/" + storeName), anyMap());
 
     MultiSchemaResponse.Schema[] valueSchemaArr = new MultiSchemaResponse.Schema[valueSchemas.size()];
     for (int i = 0; i < valueSchemas.size(); i++) {
@@ -896,9 +942,9 @@ public class OnlineVeniceProducerTest {
       multiSchemaResponse.setSuperSetSchemaId(supersetSchemaId);
     }
 
-    CompletableFuture<TransportClientResponse> valueSchemasFuture =
-        getTransportClientFuture(MAPPER.writeValueAsBytes(multiSchemaResponse));
-    doReturn(valueSchemasFuture).when(transportClient).get(eq("value_schema/" + storeName), anyMap());
+    doAnswer(invocation -> getTransportClientFuture(MAPPER.writeValueAsBytes(multiSchemaResponse), delayInResponseMs))
+        .when(transportClient)
+        .get(eq("value_schema/" + storeName), anyMap());
 
     if (updateEnabled) {
       MultiSchemaResponse allUpdateSchemaResponse = new MultiSchemaResponse();
@@ -914,10 +960,10 @@ public class OnlineVeniceProducerTest {
         updateSchemaResponse.setDerivedSchemaId(1);
         updateSchemaResponse.setSchemaStr(updateSchemas.get(i).toString());
 
-        CompletableFuture<TransportClientResponse> updateSchemaFuture =
-            getTransportClientFuture(MAPPER.writeValueAsBytes(updateSchemaResponse));
-        doReturn(updateSchemaFuture).when(transportClient)
-            .get(eq("update_schema/" + storeName + "/" + (i + 1)), anyMap());
+        doAnswer(
+            invocation -> getTransportClientFuture(MAPPER.writeValueAsBytes(updateSchemaResponse), delayInResponseMs))
+                .when(transportClient)
+                .get(eq("update_schema/" + storeName + "/" + (i + 1)), anyMap());
 
         MultiSchemaResponse.Schema schema = new MultiSchemaResponse.Schema();
         schema.setId(i + 1);
@@ -927,19 +973,20 @@ public class OnlineVeniceProducerTest {
       }
       allUpdateSchemaResponse.setSchemas(multiSchemas);
 
-      CompletableFuture<TransportClientResponse> allUpdateSchemaFuture =
-          getTransportClientFuture(MAPPER.writeValueAsBytes(allUpdateSchemaResponse));
-      doReturn(allUpdateSchemaFuture).when(transportClient).get(eq("update_schema/" + storeName), anyMap());
+      doAnswer(
+          invocation -> getTransportClientFuture(MAPPER.writeValueAsBytes(allUpdateSchemaResponse), delayInResponseMs))
+              .when(transportClient)
+              .get(eq("update_schema/" + storeName), anyMap());
     } else {
       for (int i = 0; i < updateSchemas.size(); i++) {
         SchemaResponse noUpdateSchemaResponse = new SchemaResponse();
         noUpdateSchemaResponse
             .setError("Update schema doesn't exist for value schema id: " + (i + 1) + " of store: " + storeName);
 
-        CompletableFuture<TransportClientResponse> updateSchemaFuture =
-            getTransportClientFuture(MAPPER.writeValueAsBytes(noUpdateSchemaResponse));
-        doReturn(updateSchemaFuture).when(transportClient)
-            .get(eq("update_schema/" + storeName + "/" + (i + 1)), anyMap());
+        doAnswer(
+            invocation -> getTransportClientFuture(MAPPER.writeValueAsBytes(noUpdateSchemaResponse), delayInResponseMs))
+                .when(transportClient)
+                .get(eq("update_schema/" + storeName + "/" + (i + 1)), anyMap());
       }
 
       MultiSchemaResponse allUpdateSchemaResponse = new MultiSchemaResponse();
@@ -949,9 +996,10 @@ public class OnlineVeniceProducerTest {
       MultiSchemaResponse.Schema[] multiSchemas = new MultiSchemaResponse.Schema[0];
       allUpdateSchemaResponse.setSchemas(multiSchemas);
 
-      CompletableFuture<TransportClientResponse> allUpdateSchemaFuture =
-          getTransportClientFuture(MAPPER.writeValueAsBytes(allUpdateSchemaResponse));
-      doReturn(allUpdateSchemaFuture).when(transportClient).get(eq("update_schema/" + storeName), anyMap());
+      doAnswer(
+          invocation -> getTransportClientFuture(MAPPER.writeValueAsBytes(allUpdateSchemaResponse), delayInResponseMs))
+              .when(transportClient)
+              .get(eq("update_schema/" + storeName), anyMap());
     }
   }
 
@@ -1058,9 +1106,12 @@ public class OnlineVeniceProducerTest {
     throw new AssertionError(thrown.getMessage(), thrown);
   }
 
-  private CompletableFuture<TransportClientResponse> getTransportClientFuture(byte[] body) {
+  private CompletableFuture<TransportClientResponse> getTransportClientFuture(byte[] body, long delayInResponseMs) {
     return CompletableFuture.supplyAsync(() -> {
       try {
+        if (delayInResponseMs > 0) {
+          Utils.sleep(delayInResponseMs);
+        }
         return new TransportClientResponse(1, CompressionStrategy.NO_OP, body);
       } catch (Throwable t) {
         return null;

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/input/kafka/TestKafkaInputKeyComparator.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/input/kafka/TestKafkaInputKeyComparator.java
@@ -14,7 +14,7 @@ import org.testng.annotations.Test;
 
 public class TestKafkaInputKeyComparator {
   private static RecordSerializer<KafkaInputMapperKey> KAFKA_INPUT_MAPPER_KEY_SERIALIZER =
-      FastSerializerDeserializerFactory.getAvroGenericSerializer(KafkaInputMapperKey.SCHEMA$);
+      FastSerializerDeserializerFactory.getFastAvroGenericSerializer(KafkaInputMapperKey.SCHEMA$);
   private static KafkaInputKeyComparator KAFKA_INPUT_KEY_COMPARATOR = new KafkaInputKeyComparator();
 
   private static final ByteBuffer SERIALIZED_EMPTY_BYTES_WRITABLE;

--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/AbstractAvroStoreClient.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/AbstractAvroStoreClient.java
@@ -358,7 +358,7 @@ public abstract class AbstractAvroStoreClient<K, V> extends InternalAvroStoreCli
    */
   protected RecordSerializer<K> createKeySerializer() {
     return getClientConfig().isUseFastAvro()
-        ? FastSerializerDeserializerFactory.getAvroGenericSerializer(getKeySchema())
+        ? FastSerializerDeserializerFactory.getFastAvroGenericSerializer(getKeySchema())
         : SerializerDeserializerFactory.getAvroGenericSerializer(getKeySchema());
   }
 
@@ -369,13 +369,13 @@ public abstract class AbstractAvroStoreClient<K, V> extends InternalAvroStoreCli
         // init multi-get request serializer
         this.multiGetRequestSerializer = getClientConfig().isUseFastAvro()
             ? FastSerializerDeserializerFactory
-                .getAvroGenericSerializer(ReadAvroProtocolDefinition.MULTI_GET_CLIENT_REQUEST_V1.getSchema())
+                .getFastAvroGenericSerializer(ReadAvroProtocolDefinition.MULTI_GET_CLIENT_REQUEST_V1.getSchema())
             : SerializerDeserializerFactory
                 .getAvroGenericSerializer(ReadAvroProtocolDefinition.MULTI_GET_CLIENT_REQUEST_V1.getSchema());
         // init compute request serializer
         this.computeRequestClientKeySerializer = getClientConfig().isUseFastAvro()
             ? FastSerializerDeserializerFactory
-                .getAvroGenericSerializer(ReadAvroProtocolDefinition.COMPUTE_REQUEST_CLIENT_KEY_V1.getSchema())
+                .getFastAvroGenericSerializer(ReadAvroProtocolDefinition.COMPUTE_REQUEST_CLIENT_KEY_V1.getSchema())
             : SerializerDeserializerFactory
                 .getAvroGenericSerializer(ReadAvroProtocolDefinition.COMPUTE_REQUEST_CLIENT_KEY_V1.getSchema());
         this.streamingFooterRecordDeserializer = getClientConfig().isUseFastAvro()

--- a/clients/venice-thin-client/src/test/java/com/linkedin/venice/client/schema/RouterBackedSchemaReaderTest.java
+++ b/clients/venice-thin-client/src/test/java/com/linkedin/venice/client/schema/RouterBackedSchemaReaderTest.java
@@ -1,9 +1,10 @@
 package com.linkedin.venice.client.schema;
 
 import static com.linkedin.venice.utils.TestWriteUtils.loadFileAsStringQuietlyWithErrorLogged;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
 import com.linkedin.venice.client.exceptions.VeniceClientException;
@@ -27,10 +28,12 @@ import com.linkedin.venice.meta.VersionImpl;
 import com.linkedin.venice.meta.ZKStore;
 import com.linkedin.venice.schema.SchemaData;
 import com.linkedin.venice.schema.SchemaReader;
+import com.linkedin.venice.schema.writecompute.DerivedSchemaEntry;
 import com.linkedin.venice.schema.writecompute.WriteComputeSchemaConverter;
 import com.linkedin.venice.service.ICProvider;
 import com.linkedin.venice.utils.ObjectMapperFactory;
 import com.linkedin.venice.utils.TestUtils;
+import com.linkedin.venice.utils.Utils;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.Arrays;
@@ -236,7 +239,8 @@ public class RouterBackedSchemaReaderTest {
           Arrays.asList(VALUE_SCHEMA_1, VALUE_SCHEMA_2, VALUE_SCHEMA_3, VALUE_SCHEMA_4),
           3,
           Arrays.asList(UPDATE_SCHEMA_1, UPDATE_SCHEMA_2, UPDATE_SCHEMA_3, UPDATE_SCHEMA_4),
-          true);
+          true,
+          0);
       TestUtils.waitForNonDeterministicAssertion(10, TimeUnit.SECONDS, () -> {
         Assert.assertEquals(schemaReader.getValueSchema(1), VALUE_SCHEMA_1);
         Assert.assertEquals(schemaReader.getValueSchema(2), VALUE_SCHEMA_2);
@@ -254,6 +258,33 @@ public class RouterBackedSchemaReaderTest {
   }
 
   @Test
+  public void testConcurrentRefreshValueAndUpdateSchemas()
+      throws IOException, ExecutionException, InterruptedException {
+    AbstractAvroStoreClient storeClient = getMockStoreClient(true, 500);
+
+    try (SchemaReader schemaReader =
+        new RouterBackedSchemaReader(() -> storeClient, Optional.empty(), Optional.empty(), Duration.ofMinutes(2))) {
+      // This will create 2 threads that will try to refresh the schemas concurrently. When querying Venice backend for
+      // schemas, one thread will sleep for 500 ms. In that time, we expect the other thread to also start waiting to
+      // acquire the lock.
+      CompletableFuture<DerivedSchemaEntry> future1 =
+          CompletableFuture.supplyAsync(() -> schemaReader.getLatestUpdateSchema());
+      CompletableFuture<DerivedSchemaEntry> future2 =
+          CompletableFuture.supplyAsync(() -> schemaReader.getLatestUpdateSchema());
+      Assert.assertNotNull(future1.get());
+      Assert.assertNotNull(future2.get());
+
+      /**
+       * 'getRaw' Should be called 3 times:
+       * 1. Fetch value schemas on start up
+       * 2. Fetch value schemas in one of the futures
+       * 3. Fetch update schemas in one of the futures
+       */
+      Mockito.verify(storeClient, Mockito.timeout(TIMEOUT).times(3)).getRaw(Mockito.anyString());
+    }
+  }
+
+  @Test
   public void testGetLatestValueSchemaWithSupersetSchema() throws Exception {
     AbstractAvroStoreClient mockClient = getMockStoreClient(false);
     configureSchemaResponseMocks(
@@ -261,7 +292,8 @@ public class RouterBackedSchemaReaderTest {
         Arrays.asList(VALUE_SCHEMA_1, VALUE_SCHEMA_2, VALUE_SCHEMA_3),
         1,
         Collections.emptyList(),
-        false);
+        false,
+        0);
 
     try (SchemaReader schemaReader = new RouterBackedSchemaReader(
         () -> mockClient,
@@ -296,6 +328,21 @@ public class RouterBackedSchemaReaderTest {
   }
 
   @Test
+  public void testGetSchemasOnStartup()
+      throws IOException, ExecutionException, InterruptedException, VeniceClientException {
+    AbstractAvroStoreClient mockClient = getMockStoreClient(false);
+
+    try (SchemaReader schemaReader =
+        new RouterBackedSchemaReader(() -> mockClient, Optional.empty(), Optional.empty(), Duration.ofMinutes(2))) {
+      // Schemas should be fetched on startup
+      Mockito.verify(mockClient, Mockito.timeout(TIMEOUT).times(1)).getRaw(Mockito.anyString());
+      Assert.assertNotNull(schemaReader.getLatestValueSchema());
+      // Should not be checked again
+      Mockito.verify(mockClient, Mockito.timeout(TIMEOUT).times(1)).getRaw(Mockito.anyString());
+    }
+  }
+
+  @Test
   public void testGetLatestValueSchemaWhenNoValueSchema()
       throws IOException, ExecutionException, InterruptedException, VeniceClientException {
     AbstractAvroStoreClient mockClient = getMockStoreClient(false);
@@ -304,7 +351,8 @@ public class RouterBackedSchemaReaderTest {
         Collections.emptyList(),
         SchemaData.INVALID_VALUE_SCHEMA_ID,
         Collections.emptyList(),
-        false);
+        false,
+        0);
 
     try (SchemaReader schemaReader = new RouterBackedSchemaReader(() -> mockClient)) {
       Assert.assertNull(schemaReader.getLatestValueSchema());
@@ -444,6 +492,11 @@ public class RouterBackedSchemaReaderTest {
 
   private AbstractAvroStoreClient getMockStoreClient(boolean updateEnabled)
       throws IOException, ExecutionException, InterruptedException {
+    return getMockStoreClient(updateEnabled, 0);
+  }
+
+  private AbstractAvroStoreClient getMockStoreClient(boolean updateEnabled, int delayInResponseMs)
+      throws IOException, ExecutionException, InterruptedException {
     int partitionCount = 10;
     PartitionerConfig partitionerConfig = new PartitionerConfigImpl();
     Version version = new VersionImpl(storeName, 1, "test-job-id");
@@ -499,7 +552,8 @@ public class RouterBackedSchemaReaderTest {
         Arrays.asList(VALUE_SCHEMA_1, VALUE_SCHEMA_2),
         2,
         Arrays.asList(UPDATE_SCHEMA_1, UPDATE_SCHEMA_2),
-        updateEnabled);
+        updateEnabled,
+        delayInResponseMs);
 
     return storeClient;
   }
@@ -509,15 +563,16 @@ public class RouterBackedSchemaReaderTest {
       List<Schema> valueSchemas,
       int supersetSchemaId,
       List<Schema> updateSchemas,
-      boolean updateEnabled) throws JsonProcessingException, ExecutionException, InterruptedException {
+      boolean updateEnabled,
+      int delayInResponseMs) {
     String keySchemaStr = KEY_SCHEMA.toString();
     SchemaResponse keySchemaResponse = new SchemaResponse();
     keySchemaResponse.setId(1);
     keySchemaResponse.setSchemaStr(keySchemaStr);
 
-    CompletableFuture<byte[]> keySchemaFuture = mock(CompletableFuture.class);
-    Mockito.doReturn(MAPPER.writeValueAsBytes(keySchemaResponse)).when(keySchemaFuture).get();
-    Mockito.doReturn(keySchemaFuture).when(storeClient).getRaw("key_schema/" + storeName);
+    doAnswer(invocation -> getResponseWithDelay(MAPPER.writeValueAsBytes(keySchemaResponse), delayInResponseMs))
+        .when(storeClient)
+        .getRaw(eq("key_schema/" + storeName));
 
     MultiSchemaResponse.Schema[] valueSchemaArr = new MultiSchemaResponse.Schema[valueSchemas.size()];
     for (int i = 0; i < valueSchemas.size(); i++) {
@@ -535,9 +590,9 @@ public class RouterBackedSchemaReaderTest {
       multiSchemaResponse.setSuperSetSchemaId(supersetSchemaId);
     }
 
-    CompletableFuture<byte[]> valueSchemasFuture = mock(CompletableFuture.class);
-    Mockito.doReturn(MAPPER.writeValueAsBytes(multiSchemaResponse)).when(valueSchemasFuture).get();
-    Mockito.doReturn(valueSchemasFuture).when(storeClient).getRaw("value_schema/" + storeName);
+    doAnswer(invocation -> getResponseWithDelay(MAPPER.writeValueAsBytes(multiSchemaResponse), delayInResponseMs))
+        .when(storeClient)
+        .getRaw(eq("value_schema/" + storeName));
 
     if (updateEnabled) {
       MultiSchemaResponse allUpdateSchemaResponse = new MultiSchemaResponse();
@@ -553,9 +608,9 @@ public class RouterBackedSchemaReaderTest {
         updateSchemaResponse.setDerivedSchemaId(1);
         updateSchemaResponse.setSchemaStr(updateSchemas.get(i).toString());
 
-        CompletableFuture<byte[]> updateSchemaFuture = mock(CompletableFuture.class);
-        Mockito.doReturn(MAPPER.writeValueAsBytes(updateSchemaResponse)).when(updateSchemaFuture).get();
-        Mockito.doReturn(updateSchemaFuture).when(storeClient).getRaw("update_schema/" + storeName + "/" + (i + 1));
+        doAnswer(invocation -> getResponseWithDelay(MAPPER.writeValueAsBytes(updateSchemaResponse), delayInResponseMs))
+            .when(storeClient)
+            .getRaw(eq("update_schema/" + storeName + "/" + (i + 1)));
 
         MultiSchemaResponse.Schema schema = new MultiSchemaResponse.Schema();
         schema.setId(i + 1);
@@ -563,20 +618,21 @@ public class RouterBackedSchemaReaderTest {
         schema.setSchemaStr(updateSchemas.get(i).toString());
         multiSchemas[i] = schema;
       }
-
       allUpdateSchemaResponse.setSchemas(multiSchemas);
-      CompletableFuture<byte[]> allUpdateSchemaFuture = mock(CompletableFuture.class);
-      Mockito.doReturn(MAPPER.writeValueAsBytes(allUpdateSchemaResponse)).when(allUpdateSchemaFuture).get();
-      Mockito.doReturn(allUpdateSchemaFuture).when(storeClient).getRaw("update_schema/" + storeName);
+
+      doAnswer(invocation -> getResponseWithDelay(MAPPER.writeValueAsBytes(allUpdateSchemaResponse), delayInResponseMs))
+          .when(storeClient)
+          .getRaw(eq("update_schema/" + storeName));
     } else {
       for (int i = 0; i < updateSchemas.size(); i++) {
         SchemaResponse noUpdateSchemaResponse = new SchemaResponse();
         noUpdateSchemaResponse
             .setError("Update schema doesn't exist for value schema id: " + (i + 1) + " of store: " + storeName);
 
-        CompletableFuture<byte[]> updateSchemaFuture = mock(CompletableFuture.class);
-        Mockito.doReturn(MAPPER.writeValueAsBytes(noUpdateSchemaResponse)).when(updateSchemaFuture).get();
-        Mockito.doReturn(updateSchemaFuture).when(storeClient).getRaw("update_schema/" + storeName + "/" + (i + 1));
+        doAnswer(
+            invocation -> getResponseWithDelay(MAPPER.writeValueAsBytes(noUpdateSchemaResponse), delayInResponseMs))
+                .when(storeClient)
+                .getRaw(eq("update_schema/" + storeName + "/" + (i + 1)));
       }
 
       MultiSchemaResponse allUpdateSchemaResponse = new MultiSchemaResponse();
@@ -585,9 +641,23 @@ public class RouterBackedSchemaReaderTest {
 
       MultiSchemaResponse.Schema[] multiSchemas = new MultiSchemaResponse.Schema[0];
       allUpdateSchemaResponse.setSchemas(multiSchemas);
-      CompletableFuture<byte[]> allUpdateSchemaFuture = mock(CompletableFuture.class);
-      Mockito.doReturn(MAPPER.writeValueAsBytes(allUpdateSchemaResponse)).when(allUpdateSchemaFuture).get();
-      Mockito.doReturn(allUpdateSchemaFuture).when(storeClient).getRaw("update_schema/" + storeName);
+
+      doAnswer(invocation -> getResponseWithDelay(MAPPER.writeValueAsBytes(allUpdateSchemaResponse), delayInResponseMs))
+          .when(storeClient)
+          .getRaw(eq("update_schema/" + storeName));
     }
+  }
+
+  private CompletableFuture<byte[]> getResponseWithDelay(byte[] body, long delayInResponseMs) {
+    return CompletableFuture.supplyAsync(() -> {
+      try {
+        if (delayInResponseMs > 0) {
+          Utils.sleep(delayInResponseMs);
+        }
+        return body;
+      } catch (Throwable t) {
+        return null;
+      }
+    });
   }
 }

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/compute/ComputeRequestWrapper.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/compute/ComputeRequestWrapper.java
@@ -1,6 +1,6 @@
 package com.linkedin.venice.compute;
 
-import static com.linkedin.venice.serializer.SerializerDeserializerFactory.getAvroGenericSerializer;
+import static com.linkedin.venice.serializer.FastSerializerDeserializerFactory.getFastAvroGenericSerializer;
 
 import com.linkedin.venice.compute.protocol.request.ComputeOperation;
 import com.linkedin.venice.compute.protocol.request.ComputeRequestV3;
@@ -21,7 +21,7 @@ public class ComputeRequestWrapper {
   public static final int LATEST_SCHEMA_VERSION_FOR_COMPUTE_REQUEST = 3;
 
   private static final RecordSerializer<ComputeRequestV3> SERIALIZER =
-      getAvroGenericSerializer(ComputeRequestV3.SCHEMA$);
+      getFastAvroGenericSerializer(ComputeRequestV3.SCHEMA$);
 
   private final ComputeRequestV3 computeRequest;
   private final Schema valueSchema;

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/compute/ComputeUtils.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/compute/ComputeUtils.java
@@ -1,6 +1,6 @@
 package com.linkedin.venice.compute;
 
-import static com.linkedin.venice.serializer.FastSerializerDeserializerFactory.*;
+import static com.linkedin.venice.serializer.FastSerializerDeserializerFactory.getFastAvroSpecificDeserializer;
 
 import com.linkedin.avro.api.PrimitiveFloatList;
 import com.linkedin.venice.VeniceConstants;

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/serializer/AvroGenericDeserializer.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/serializer/AvroGenericDeserializer.java
@@ -87,14 +87,14 @@ public class AvroGenericDeserializer<V> implements RecordDeserializer<V> {
   }
 
   @Override
-  public Iterable<V> deserializeObjects(byte[] bytes) throws VeniceSerializationException {
+  public List<V> deserializeObjects(byte[] bytes) throws VeniceSerializationException {
     InputStream in = new ByteArrayInputStream(bytes);
     BinaryDecoder decoder = AvroCompatibilityHelper.newBinaryDecoder(in, BUFFERED_AVRO_DECODER, null);
     return deserializeObjects(decoder);
   }
 
   @Override
-  public Iterable<V> deserializeObjects(BinaryDecoder decoder) throws VeniceSerializationException {
+  public List<V> deserializeObjects(BinaryDecoder decoder) throws VeniceSerializationException {
     List<V> objects = new ArrayList();
     try {
       while (!decoder.isEnd()) {

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/serializer/RecordDeserializer.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/serializer/RecordDeserializer.java
@@ -2,6 +2,7 @@ package com.linkedin.venice.serializer;
 
 import java.io.InputStream;
 import java.nio.ByteBuffer;
+import java.util.List;
 import org.apache.avro.io.BinaryDecoder;
 
 
@@ -20,7 +21,7 @@ public interface RecordDeserializer<T> {
 
   T deserialize(T reuse, InputStream in, BinaryDecoder reusedDecoder) throws VeniceSerializationException;
 
-  Iterable<T> deserializeObjects(byte[] bytes) throws VeniceSerializationException;
+  List<T> deserializeObjects(byte[] bytes) throws VeniceSerializationException;
 
-  Iterable<T> deserializeObjects(BinaryDecoder binaryDecoder) throws VeniceSerializationException;
+  List<T> deserializeObjects(BinaryDecoder binaryDecoder) throws VeniceSerializationException;
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/chunking/ChunkKeyValueTransformerImpl.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/chunking/ChunkKeyValueTransformerImpl.java
@@ -3,8 +3,8 @@ package com.linkedin.venice.chunking;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.serialization.KeyWithChunkingSuffixSerializer;
 import com.linkedin.venice.serialization.avro.ChunkedKeySuffixSerializer;
+import com.linkedin.venice.serializer.FastSerializerDeserializerFactory;
 import com.linkedin.venice.serializer.RecordDeserializer;
-import com.linkedin.venice.serializer.SerializerDeserializerFactory;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import javax.annotation.Nonnull;
@@ -27,7 +27,7 @@ public class ChunkKeyValueTransformerImpl implements ChunkKeyValueTransformer {
 
   public ChunkKeyValueTransformerImpl(@Nonnull Schema keySchema) {
     Validate.notNull(keySchema);
-    this.keyDeserializer = SerializerDeserializerFactory.getAvroGenericDeserializer(keySchema);
+    this.keyDeserializer = FastSerializerDeserializerFactory.getFastAvroGenericDeserializer(keySchema, keySchema);
   }
 
   @Override

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/adapter/kafka/consumer/ApacheKafkaConsumerConfig.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/adapter/kafka/consumer/ApacheKafkaConsumerConfig.java
@@ -32,6 +32,7 @@ public class ApacheKafkaConsumerConfig {
       KAFKA_CONFIG_PREFIX + ApacheKafkaConsumerAdapter.CONSUMER_POLL_RETRY_BACKOFF_MS_CONFIG;
   public static final String KAFKA_CLIENT_ID_CONFIG = KAFKA_CONFIG_PREFIX + ConsumerConfig.CLIENT_ID_CONFIG;
   public static final String KAFKA_GROUP_ID_CONFIG = KAFKA_CONFIG_PREFIX + ConsumerConfig.GROUP_ID_CONFIG;
+  public static final int DEFAULT_RECEIVE_BUFFER_SIZE = 1024 * 1024;
 
   private final Properties consumerProperties;
 
@@ -48,8 +49,10 @@ public class ApacheKafkaConsumerConfig {
       LOGGER.info("Will initialize a non-SSL Kafka consumer client");
     }
 
-    // Copied from KafkaClientFactory
-    consumerProperties.put(ConsumerConfig.RECEIVE_BUFFER_CONFIG, 1024 * 1024);
+    if (!consumerProperties.containsKey(ConsumerConfig.RECEIVE_BUFFER_CONFIG)) {
+      consumerProperties.put(ConsumerConfig.RECEIVE_BUFFER_CONFIG, DEFAULT_RECEIVE_BUFFER_SIZE);
+    }
+
     consumerProperties.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class);
     consumerProperties.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class);
   }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/schema/RecordSchemaAdapter.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/schema/RecordSchemaAdapter.java
@@ -33,9 +33,9 @@ class RecordSchemaAdapter implements SchemaAdapter {
     }
 
     RecordDeserializer<IndexedRecord> deserializer =
-        FastSerializerDeserializerFactory.getAvroGenericDeserializer(datumSchema, expectedSchema);
+        FastSerializerDeserializerFactory.getFastAvroGenericDeserializer(datumSchema, expectedSchema);
     RecordSerializer<IndexedRecord> serializer =
-        FastSerializerDeserializerFactory.getAvroGenericSerializer(datumSchema);
+        FastSerializerDeserializerFactory.getFastAvroGenericSerializer(datumSchema);
 
     try {
       return deserializer.deserialize(serializer.serialize(datumRecord));

--- a/internal/venice-common/src/main/java/com/linkedin/venice/serialization/IdentityRecordDeserializer.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/serialization/IdentityRecordDeserializer.java
@@ -6,6 +6,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.util.Collections;
+import java.util.List;
 import org.apache.avro.io.BinaryDecoder;
 import org.apache.avro.io.OptimizedBinaryDecoder;
 import org.apache.commons.io.IOUtils;
@@ -74,12 +75,12 @@ public class IdentityRecordDeserializer implements RecordDeserializer<ByteBuffer
   }
 
   @Override
-  public Iterable<ByteBuffer> deserializeObjects(byte[] bytes) throws VeniceSerializationException {
-    return Collections.singleton(deserialize(bytes));
+  public List<ByteBuffer> deserializeObjects(byte[] bytes) throws VeniceSerializationException {
+    return Collections.singletonList(deserialize(bytes));
   }
 
   @Override
-  public Iterable<ByteBuffer> deserializeObjects(BinaryDecoder binaryDecoder) throws VeniceSerializationException {
-    return Collections.singleton(deserialize(binaryDecoder));
+  public List<ByteBuffer> deserializeObjects(BinaryDecoder binaryDecoder) throws VeniceSerializationException {
+    return Collections.singletonList(deserialize(binaryDecoder));
   }
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/writer/update/UpdateBuilderImpl.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/writer/update/UpdateBuilderImpl.java
@@ -32,7 +32,7 @@ public class UpdateBuilderImpl implements UpdateBuilder {
   public UpdateBuilderImpl(Schema updateSchema) {
     validateUpdateSchema(updateSchema);
     this.updateRecord = new GenericData.Record(updateSchema);
-    this.serializer = FastSerializerDeserializerFactory.getAvroGenericSerializer(updateSchema);
+    this.serializer = FastSerializerDeserializerFactory.getFastAvroGenericSerializer(updateSchema);
     this.updateFieldNameSet = new HashSet<>();
     this.collectionMergeFieldNameSet = new HashSet<>();
   }

--- a/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/adapter/kafka/consumer/ApacheKafkaConsumerConfigTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/adapter/kafka/consumer/ApacheKafkaConsumerConfigTest.java
@@ -4,8 +4,11 @@ import static com.linkedin.venice.pubsub.adapter.kafka.producer.ApacheKafkaProdu
 import static com.linkedin.venice.pubsub.adapter.kafka.producer.ApacheKafkaProducerConfig.SSL_KAFKA_BOOTSTRAP_SERVERS;
 import static com.linkedin.venice.pubsub.adapter.kafka.producer.ApacheKafkaProducerConfig.SSL_TO_KAFKA_LEGACY;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
 
 import com.linkedin.venice.pubsub.adapter.kafka.producer.ApacheKafkaProducerConfig;
+import com.linkedin.venice.utils.VeniceProperties;
 import java.util.Properties;
 import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
@@ -49,5 +52,25 @@ public class ApacheKafkaConsumerConfigTest {
     assertEquals(validProps.size(), 2);
     assertEquals(validProps.get(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG), "localhost:9092");
     assertEquals(validProps.get(ConsumerConfig.MAX_PARTITION_FETCH_BYTES_CONFIG), "2000");
+  }
+
+  @Test
+  public void testDefaultsValuesAreUsedIfConfigIsNotProvided() {
+    Properties props = new Properties();
+    ApacheKafkaConsumerConfig apacheKafkaConsumerConfig =
+        new ApacheKafkaConsumerConfig(new VeniceProperties(props), "test");
+    Properties consumerProps = apacheKafkaConsumerConfig.getConsumerProperties();
+    assertNotNull(consumerProps);
+    assertTrue(consumerProps.containsKey(ConsumerConfig.RECEIVE_BUFFER_CONFIG));
+    assertEquals(
+        consumerProps.get(ConsumerConfig.RECEIVE_BUFFER_CONFIG),
+        ApacheKafkaConsumerConfig.DEFAULT_RECEIVE_BUFFER_SIZE);
+
+    props.put(ApacheKafkaProducerConfig.KAFKA_CONFIG_PREFIX + ConsumerConfig.RECEIVE_BUFFER_CONFIG, "98765");
+    apacheKafkaConsumerConfig = new ApacheKafkaConsumerConfig(new VeniceProperties(props), "test");
+    consumerProps = apacheKafkaConsumerConfig.getConsumerProperties();
+    assertNotNull(consumerProps);
+    assertTrue(consumerProps.containsKey(ConsumerConfig.RECEIVE_BUFFER_CONFIG));
+    assertEquals(consumerProps.get(ConsumerConfig.RECEIVE_BUFFER_CONFIG), "98765");
   }
 }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestWritePathComputation.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestWritePathComputation.java
@@ -54,7 +54,7 @@ public class TestWritePathComputation {
     }
   }
 
-  @Test(timeOut = 60 * Time.MS_PER_SECOND)
+  @Test(timeOut = 90 * Time.MS_PER_SECOND)
   public void testFeatureFlagMultipleDC() {
     try (VeniceTwoLayerMultiRegionMultiClusterWrapper twoLayerMultiRegionMultiClusterWrapper =
         ServiceFactory.getVeniceTwoLayerMultiRegionMultiClusterWrapper(1, 1, 1, 1, 1, 0)) {

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/api/MetaStoreShadowReader.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/api/MetaStoreShadowReader.java
@@ -42,11 +42,12 @@ public class MetaStoreShadowReader {
   private static final Logger LOGGER = LogManager.getLogger(MetaStoreShadowReader.class);
   private final ReadOnlySchemaRepository schemaRepo;
   private final RecordDeserializer<StoreMetaKey> keyDeserializer =
-      FastSerializerDeserializerFactory.getAvroSpecificDeserializer(StoreMetaKey.class);
+      FastSerializerDeserializerFactory.getFastAvroSpecificDeserializer(StoreMetaKey.SCHEMA$, StoreMetaKey.class);
   private final int metaSystemStoreSchemaId =
       AvroProtocolDefinition.METADATA_SYSTEM_SCHEMA_STORE.getCurrentProtocolVersion();
-  private final RecordSerializer<StoreMetaValue> valueSerializer = FastSerializerDeserializerFactory
-      .getAvroGenericSerializer(AvroProtocolDefinition.METADATA_SYSTEM_SCHEMA_STORE.getCurrentProtocolVersionSchema());
+  private final RecordSerializer<StoreMetaValue> valueSerializer =
+      FastSerializerDeserializerFactory.getFastAvroGenericSerializer(
+          AvroProtocolDefinition.METADATA_SYSTEM_SCHEMA_STORE.getCurrentProtocolVersionSchema());
   private final RedundantExceptionFilter filter = RedundantExceptionFilter.getRedundantExceptionFilter();
 
   public MetaStoreShadowReader(ReadOnlySchemaRepository readOnlySchemaRepository) {

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/api/path/VeniceComputePath.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/api/path/VeniceComputePath.java
@@ -66,10 +66,11 @@ public class VeniceComputePath extends VeniceMultiKeyPath<ComputeRouterRequestKe
   private static final RecordDeserializer<GenericRecord> COMPUTE_REQUEST_NO_OP_DESERIALIZER =
       FastSerializerDeserializerFactory.getFastAvroGenericDeserializer(ComputeRequestV3.SCHEMA$, EMPTY_RECORD_SCHEMA);
   private static final RecordDeserializer<ByteBuffer> COMPUTE_REQUEST_CLIENT_KEY_V1_DESERIALIZER =
-      FastSerializerDeserializerFactory
-          .getAvroGenericDeserializer(ReadAvroProtocolDefinition.COMPUTE_REQUEST_CLIENT_KEY_V1.getSchema());
+      FastSerializerDeserializerFactory.getFastAvroGenericDeserializer(
+          ReadAvroProtocolDefinition.COMPUTE_REQUEST_CLIENT_KEY_V1.getSchema(),
+          ReadAvroProtocolDefinition.COMPUTE_REQUEST_CLIENT_KEY_V1.getSchema());
   private static final RecordSerializer<ComputeRouterRequestKeyV1> COMPUTE_ROUTER_REQUEST_KEY_V1_SERIALIZER =
-      FastSerializerDeserializerFactory.getAvroGenericSerializer(ComputeRouterRequestKeyV1.getClassSchema());
+      FastSerializerDeserializerFactory.getFastAvroGenericSerializer(ComputeRouterRequestKeyV1.getClassSchema());
 
   public static void skipOverComputeRequest(BinaryDecoder decoder) {
     COMPUTE_REQUEST_NO_OP_DESERIALIZER.deserialize(EMPTY_COMPUTE_REQUEST_RECORD.get(), decoder);

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/api/path/VeniceMultiGetPath.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/api/path/VeniceMultiGetPath.java
@@ -31,13 +31,13 @@ public class VeniceMultiGetPath extends VeniceMultiKeyPath<MultiGetRouterRequest
       Integer.toString(ReadAvroProtocolDefinition.MULTI_GET_ROUTER_REQUEST_V1.getProtocolVersion());
 
   private static final RecordSerializer<MultiGetRouterRequestKeyV1> MULTI_GET_ROUTER_REQUEST_KEY_V1_SERIALIZER =
-      FastSerializerDeserializerFactory.getAvroGenericSerializer(MultiGetRouterRequestKeyV1.getClassSchema());
+      FastSerializerDeserializerFactory.getFastAvroGenericSerializer(MultiGetRouterRequestKeyV1.getClassSchema());
 
   protected static final ReadAvroProtocolDefinition EXPECTED_PROTOCOL =
       ReadAvroProtocolDefinition.MULTI_GET_CLIENT_REQUEST_V1;
 
-  private static final RecordDeserializer<ByteBuffer> EXPECTED_PROTOCOL_DESERIALIZER =
-      FastSerializerDeserializerFactory.getAvroGenericDeserializer(EXPECTED_PROTOCOL.getSchema());
+  private static final RecordDeserializer<ByteBuffer> EXPECTED_PROTOCOL_DESERIALIZER = FastSerializerDeserializerFactory
+      .getFastAvroGenericDeserializer(EXPECTED_PROTOCOL.getSchema(), EXPECTED_PROTOCOL.getSchema());
 
   public VeniceMultiGetPath(
       String storeName,

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/streaming/VeniceChunkedResponse.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/streaming/VeniceChunkedResponse.java
@@ -86,12 +86,12 @@ public class VeniceChunkedResponse {
    * to include meta data info, which are only available after processing the full request.
    */
   private static final RecordSerializer<StreamingFooterRecordV1> STREAMING_FOOTER_SERIALIZER =
-      FastSerializerDeserializerFactory.getAvroGenericSerializer(StreamingFooterRecordV1.getClassSchema());
+      FastSerializerDeserializerFactory.getFastAvroGenericSerializer(StreamingFooterRecordV1.getClassSchema());
   private static final Map<CharSequence, CharSequence> EMPTY_MAP = new HashMap<>();
   private static final RecordSerializer<MultiGetResponseRecordV1> MULTI_GET_RESPONSE_SERIALIZER =
-      FastSerializerDeserializerFactory.getAvroGenericSerializer(MultiGetResponseRecordV1.getClassSchema());
+      FastSerializerDeserializerFactory.getFastAvroGenericSerializer(MultiGetResponseRecordV1.getClassSchema());
   private static final RecordSerializer<ComputeResponseRecordV1> COMPUTE_RESPONSE_SERIALIZER =
-      FastSerializerDeserializerFactory.getAvroGenericSerializer(ComputeResponseRecordV1.getClassSchema());
+      FastSerializerDeserializerFactory.getFastAvroGenericSerializer(ComputeResponseRecordV1.getClassSchema());
 
   private final String storeName;
   private final RequestType requestType;

--- a/services/venice-server/src/main/java/com/linkedin/venice/listener/request/ComputeRouterRequestWrapper.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/listener/request/ComputeRouterRequestWrapper.java
@@ -13,6 +13,7 @@ import com.linkedin.venice.serializer.RecordDeserializer;
 import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http.HttpRequest;
 import java.net.URI;
+import java.util.List;
 import org.apache.avro.io.BinaryDecoder;
 import org.apache.avro.io.OptimizedBinaryDecoderFactory;
 
@@ -21,8 +22,8 @@ import org.apache.avro.io.OptimizedBinaryDecoderFactory;
  * {@code ComputeRouterRequestWrapper} encapsulates a POST request for read-compute from routers.
  */
 public class ComputeRouterRequestWrapper extends MultiKeyRouterRequestWrapper<ComputeRouterRequestKeyV1> {
-  private static final RecordDeserializer<ComputeRouterRequestKeyV1> DESERIALIZER =
-      FastSerializerDeserializerFactory.getAvroSpecificDeserializer(ComputeRouterRequestKeyV1.class);
+  private static final RecordDeserializer<ComputeRouterRequestKeyV1> DESERIALIZER = FastSerializerDeserializerFactory
+      .getFastAvroSpecificDeserializer(ComputeRouterRequestKeyV1.SCHEMA$, ComputeRouterRequestKeyV1.class);
 
   private final ComputeRequest computeRequest;
   private int valueSchemaId = -1;
@@ -30,7 +31,7 @@ public class ComputeRouterRequestWrapper extends MultiKeyRouterRequestWrapper<Co
   private ComputeRouterRequestWrapper(
       String resourceName,
       ComputeRequest computeRequest,
-      Iterable<ComputeRouterRequestKeyV1> keys,
+      List<ComputeRouterRequestKeyV1> keys,
       HttpRequest request,
       String schemaId) {
     super(resourceName, keys, request);
@@ -70,7 +71,7 @@ public class ComputeRouterRequestWrapper extends MultiKeyRouterRequestWrapper<Co
         .createOptimizedBinaryDecoder(requestContent, 0, requestContent.length);
     ComputeRequest computeRequest = ComputeUtils.deserializeComputeRequest(decoder, null);
 
-    Iterable<ComputeRouterRequestKeyV1> keys = DESERIALIZER.deserializeObjects(decoder);
+    List<ComputeRouterRequestKeyV1> keys = DESERIALIZER.deserializeObjects(decoder);
     String schemaId = httpRequest.headers().get(HttpConstants.VENICE_COMPUTE_VALUE_SCHEMA_ID);
     return new ComputeRouterRequestWrapper(resourceName, computeRequest, keys, httpRequest, schemaId);
   }
@@ -84,7 +85,7 @@ public class ComputeRouterRequestWrapper extends MultiKeyRouterRequestWrapper<Co
   }
 
   public String toString() {
-    return "ComputeRouterRequestWrapper(storeName: " + getStoreName() + ", key count: " + keyCount + ")";
+    return "ComputeRouterRequestWrapper(storeName: " + getStoreName() + ", key count: " + getKeyCount() + ")";
   }
 
   @Override

--- a/services/venice-server/src/main/java/com/linkedin/venice/listener/request/MultiKeyRouterRequestWrapper.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/listener/request/MultiKeyRouterRequestWrapper.java
@@ -1,32 +1,27 @@
 package com.linkedin.venice.listener.request;
 
 import io.netty.handler.codec.http.HttpRequest;
+import java.util.List;
 
 
 /**
  * {@code MultiKeyRouterRequestWrapper} is a base class for a multi-key operation.
  */
 public abstract class MultiKeyRouterRequestWrapper<K> extends RouterRequest {
-  private final Iterable<K> keys;
-  protected int keyCount = 0;
+  private final List<K> keys;
 
-  protected MultiKeyRouterRequestWrapper(String resourceName, Iterable<K> keys, HttpRequest request) {
+  protected MultiKeyRouterRequestWrapper(String resourceName, List<K> keys, HttpRequest request) {
     super(resourceName, request);
-
     this.keys = keys;
-    // TODO: looping through all keys at the beginning would prevent us from using lazy deserializer; refactor this
-    this.keys.forEach(key -> ++keyCount);
   }
 
   protected MultiKeyRouterRequestWrapper(
       String resourceName,
-      Iterable<K> keys,
+      List<K> keys,
       boolean isRetryRequest,
       boolean isStreamingRequest) {
     super(resourceName, isRetryRequest, isStreamingRequest);
-
     this.keys = keys;
-    this.keys.forEach(key -> ++keyCount);
   }
 
   public Iterable<K> getKeys() {
@@ -35,7 +30,7 @@ public abstract class MultiKeyRouterRequestWrapper<K> extends RouterRequest {
 
   @Override
   public int getKeyCount() {
-    return this.keyCount;
+    return this.keys.size();
   }
 
 }

--- a/services/venice-server/src/main/java/com/linkedin/venice/listener/response/ComputeResponseWrapper.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/listener/response/ComputeResponseWrapper.java
@@ -9,7 +9,7 @@ import com.linkedin.venice.serializer.RecordSerializer;
 
 public class ComputeResponseWrapper extends MultiKeyResponseWrapper<ComputeResponseRecordV1> {
   private static final RecordSerializer<ComputeResponseRecordV1> SERIALIZER =
-      FastSerializerDeserializerFactory.getAvroGenericSerializer(ComputeResponseRecordV1.getClassSchema());
+      FastSerializerDeserializerFactory.getFastAvroGenericSerializer(ComputeResponseRecordV1.getClassSchema());
 
   public ComputeResponseWrapper(int maxKeyCount) {
     super(maxKeyCount);

--- a/services/venice-server/src/main/java/com/linkedin/venice/listener/response/MultiGetResponseWrapper.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/listener/response/MultiGetResponseWrapper.java
@@ -8,7 +8,7 @@ import com.linkedin.venice.serializer.RecordSerializer;
 
 public class MultiGetResponseWrapper extends MultiKeyResponseWrapper<MultiGetResponseRecordV1> {
   private static final RecordSerializer<MultiGetResponseRecordV1> SERIALIZER =
-      FastSerializerDeserializerFactory.getAvroGenericSerializer(MultiGetResponseRecordV1.getClassSchema());
+      FastSerializerDeserializerFactory.getFastAvroGenericSerializer(MultiGetResponseRecordV1.getClassSchema());
 
   public MultiGetResponseWrapper(int maxKeyCount) {
     super(maxKeyCount);


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[server] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Filter out junk metric values for nearline latency sensors  
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
Nearline latency sensors will emit -INF values when no data is present for a partition. This is a problem when aggregating data across time and instane dimensions. Emitting zero is safe for this metric as long as it is not used to detect inactivity.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
Unit tests
## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.