### PR TITLE
[controller] Add new controller cluster config to enable partial update by default when converting new store from batch to hybrid

### DIFF
--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -1149,10 +1149,19 @@ public class ConfigKeys {
    */
   public static final String ENABLE_INCREMENTAL_PUSH_FOR_HYBRID_ACTIVE_ACTIVE_USER_STORES =
       "enable.incremental.push.for.hybrid.active.active.user.stores";
-
+  /**
+   * We will use this config to determine whether we should enable partial update for hybrid active-active user stores.
+   * If this config is set to true, we will enable partial update for hybrid active-active user stores whose latest value
+   * schema meets partial update feature requirement.
+   */
   public static final String ENABLE_PARTIAL_UPDATE_FOR_HYBRID_ACTIVE_ACTIVE_USER_STORES =
       "enable.partial.update.for.hybrid.active.active.user.stores";
 
+  /**
+   * We will use this config to determine whether we should enable partial update for hybrid non-active-active user stores.
+   * If this config is set to true, we will enable partial update for hybrid active-active user stores whose latest value
+   * schema meets partial update feature requirement.
+   */
   public static final String ENABLE_PARTIAL_UPDATE_FOR_HYBRID_NON_ACTIVE_ACTIVE_USER_STORES =
       "enable.partial.update.for.hybrid.non.active.active.user.stores";
 

--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -1150,6 +1150,12 @@ public class ConfigKeys {
   public static final String ENABLE_INCREMENTAL_PUSH_FOR_HYBRID_ACTIVE_ACTIVE_USER_STORES =
       "enable.incremental.push.for.hybrid.active.active.user.stores";
 
+  public static final String ENABLE_PARTIAL_UPDATE_FOR_HYBRID_ACTIVE_ACTIVE_USER_STORES =
+      "enable.partial.update.for.hybrid.active.active.user.stores";
+
+  public static final String ENABLE_PARTIAL_UPDATE_FOR_HYBRID_NON_ACTIVE_ACTIVE_USER_STORES =
+      "enable.partial.update.for.hybrid.non.active.active.user.stores";
+
   /**
    * The highest priority source fabric selection config, specified in parent controller.
    */

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/PartialUpdateClusterConfigTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/PartialUpdateClusterConfigTest.java
@@ -40,7 +40,6 @@ public class PartialUpdateClusterConfigTest {
 
   @BeforeClass(alwaysRun = true)
   public void setUp() {
-    Utils.thisIsLocalhost();
     Properties serverProperties = new Properties();
     Properties controllerProps = new Properties();
     controllerProps.put(ConfigKeys.CONTROLLER_AUTO_MATERIALIZE_META_SYSTEM_STORE, false);

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/PartialUpdateClusterConfigTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/PartialUpdateClusterConfigTest.java
@@ -1,0 +1,110 @@
+package com.linkedin.venice.endToEnd;
+
+import static com.linkedin.venice.utils.TestUtils.assertCommand;
+import static com.linkedin.venice.utils.TestWriteUtils.NAME_RECORD_V2_SCHEMA;
+import static com.linkedin.venice.utils.TestWriteUtils.STRING_SCHEMA;
+import static org.testng.Assert.assertFalse;
+
+import com.linkedin.venice.ConfigKeys;
+import com.linkedin.venice.compression.CompressionStrategy;
+import com.linkedin.venice.controllerapi.ControllerClient;
+import com.linkedin.venice.controllerapi.ControllerResponse;
+import com.linkedin.venice.controllerapi.StoreResponse;
+import com.linkedin.venice.controllerapi.UpdateStoreQueryParams;
+import com.linkedin.venice.integration.utils.ServiceFactory;
+import com.linkedin.venice.integration.utils.VeniceControllerWrapper;
+import com.linkedin.venice.integration.utils.VeniceMultiClusterWrapper;
+import com.linkedin.venice.integration.utils.VeniceTwoLayerMultiRegionMultiClusterWrapper;
+import com.linkedin.venice.meta.Store;
+import com.linkedin.venice.meta.StoreInfo;
+import com.linkedin.venice.utils.DataProviderUtils;
+import com.linkedin.venice.utils.TestUtils;
+import com.linkedin.venice.utils.Utils;
+import java.util.List;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+
+public class PartialUpdateClusterConfigTest {
+  private static final int NUMBER_OF_CHILD_DATACENTERS = 1;
+  private static final int NUMBER_OF_CLUSTERS = 1;
+  private static final int TEST_TIMEOUT_MS = 180_000;
+  private static final String CLUSTER_NAME = "venice-cluster0";
+  private VeniceTwoLayerMultiRegionMultiClusterWrapper multiRegionMultiClusterWrapper;
+  private VeniceControllerWrapper parentController;
+  private List<VeniceMultiClusterWrapper> childDatacenters;
+
+  @BeforeClass(alwaysRun = true)
+  public void setUp() {
+    Properties serverProperties = new Properties();
+    Properties controllerProps = new Properties();
+    controllerProps.put(ConfigKeys.CONTROLLER_AUTO_MATERIALIZE_META_SYSTEM_STORE, false);
+    controllerProps.put(ConfigKeys.ENABLE_PARTIAL_UPDATE_FOR_HYBRID_ACTIVE_ACTIVE_USER_STORES, true);
+    controllerProps.put(ConfigKeys.ENABLE_PARTIAL_UPDATE_FOR_HYBRID_NON_ACTIVE_ACTIVE_USER_STORES, true);
+    this.multiRegionMultiClusterWrapper = ServiceFactory.getVeniceTwoLayerMultiRegionMultiClusterWrapper(
+        NUMBER_OF_CHILD_DATACENTERS,
+        NUMBER_OF_CLUSTERS,
+        1,
+        1,
+        2,
+        1,
+        2,
+        Optional.of(controllerProps),
+        Optional.of(controllerProps),
+        Optional.of(serverProperties),
+        false);
+    this.childDatacenters = multiRegionMultiClusterWrapper.getChildRegions();
+    List<VeniceControllerWrapper> parentControllers = multiRegionMultiClusterWrapper.getParentControllers();
+    if (parentControllers.size() != 1) {
+      throw new IllegalStateException("Expect only one parent controller. Got: " + parentControllers.size());
+    }
+    this.parentController = parentControllers.get(0);
+  }
+
+  @Test(timeOut = TEST_TIMEOUT_MS, dataProvider = "True-and-False", dataProviderClass = DataProviderUtils.class)
+  public void testPartialUpdateAutoEnable(boolean activeActiveEnabled) {
+    final String storeName = Utils.getUniqueString();
+    String parentControllerUrl = parentController.getControllerUrl();
+
+    try (ControllerClient parentControllerClient = new ControllerClient(CLUSTER_NAME, parentControllerUrl)) {
+      ControllerClient[] controllerClients = new ControllerClient[childDatacenters.size() + 1];
+      controllerClients[0] = parentControllerClient;
+      for (int i = 0; i < childDatacenters.size(); i++) {
+        controllerClients[i + 1] =
+            new ControllerClient(CLUSTER_NAME, childDatacenters.get(i).getControllerConnectString());
+      }
+      assertCommand(
+          parentControllerClient
+              .createNewStore(storeName, "test_owner", STRING_SCHEMA.toString(), NAME_RECORD_V2_SCHEMA.toString()));
+      UpdateStoreQueryParams updateStoreParams =
+          new UpdateStoreQueryParams().setStorageQuotaInByte(Store.UNLIMITED_STORAGE_QUOTA)
+              .setCompressionStrategy(CompressionStrategy.NO_OP)
+              .setActiveActiveReplicationEnabled(activeActiveEnabled)
+              .setHybridRewindSeconds(10L)
+              .setHybridOffsetLagThreshold(2L);
+      ControllerResponse updateStoreResponse =
+          parentControllerClient.retryableRequest(5, c -> c.updateStore(storeName, updateStoreParams));
+      assertFalse(updateStoreResponse.isError(), "Update store got error: " + updateStoreResponse.getError());
+
+      TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, false, true, () -> {
+        for (ControllerClient controllerClient: controllerClients) {
+          StoreResponse storeResponse = controllerClient.getStore(storeName);
+          Assert.assertFalse(storeResponse.isError());
+          StoreInfo storeInfo = storeResponse.getStore();
+
+          Assert.assertNotNull(storeInfo.getHybridStoreConfig());
+          Assert.assertTrue(storeInfo.isWriteComputationEnabled());
+          Assert.assertTrue(storeInfo.isChunkingEnabled());
+          if (activeActiveEnabled) {
+            Assert.assertTrue(storeInfo.isRmdChunkingEnabled());
+            Assert.assertTrue(storeInfo.isActiveActiveReplicationEnabled());
+          }
+        }
+      });
+    }
+  }
+}

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/PartialUpdateClusterConfigTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/PartialUpdateClusterConfigTest.java
@@ -40,6 +40,7 @@ public class PartialUpdateClusterConfigTest {
 
   @BeforeClass(alwaysRun = true)
   public void setUp() {
+    Utils.thisIsLocalhost();
     Properties serverProperties = new Properties();
     Properties controllerProps = new Properties();
     controllerProps.put(ConfigKeys.CONTROLLER_AUTO_MATERIALIZE_META_SYSTEM_STORE, false);

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerClusterConfig.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerClusterConfig.java
@@ -169,6 +169,9 @@ public class VeniceControllerClusterConfig {
    */
   private boolean enabledIncrementalPushForHybridActiveActiveUserStores;
 
+  private boolean enablePartialUpdateForHybridActiveActiveUserStores;
+  private boolean enablePartialUpdateForHybridNonActiveActiveUserStores;
+
   /**
    * When this option is enabled, all new batch-only stores will have active-active replication enabled in store config so long
    * as the store has leader follower also enabled.
@@ -636,5 +639,13 @@ public class VeniceControllerClusterConfig {
 
   public boolean enabledIncrementalPushForHybridActiveActiveUserStores() {
     return enabledIncrementalPushForHybridActiveActiveUserStores;
+  }
+
+  public boolean isEnablePartialUpdateForHybridActiveActiveUserStores() {
+    return enablePartialUpdateForHybridActiveActiveUserStores;
+  }
+
+  public boolean isEnablePartialUpdateForHybridNonActiveActiveUserStores() {
+    return enablePartialUpdateForHybridNonActiveActiveUserStores;
   }
 }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerClusterConfig.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerClusterConfig.java
@@ -32,6 +32,8 @@ import static com.linkedin.venice.ConfigKeys.ENABLE_NATIVE_REPLICATION_FOR_BATCH
 import static com.linkedin.venice.ConfigKeys.ENABLE_NATIVE_REPLICATION_FOR_HYBRID;
 import static com.linkedin.venice.ConfigKeys.ENABLE_OFFLINE_PUSH_SSL_ALLOWLIST;
 import static com.linkedin.venice.ConfigKeys.ENABLE_OFFLINE_PUSH_SSL_WHITELIST;
+import static com.linkedin.venice.ConfigKeys.ENABLE_PARTIAL_UPDATE_FOR_HYBRID_ACTIVE_ACTIVE_USER_STORES;
+import static com.linkedin.venice.ConfigKeys.ENABLE_PARTIAL_UPDATE_FOR_HYBRID_NON_ACTIVE_ACTIVE_USER_STORES;
 import static com.linkedin.venice.ConfigKeys.ENABLE_PARTITION_COUNT_ROUND_UP;
 import static com.linkedin.venice.ConfigKeys.FORCE_LEADER_ERROR_REPLICA_FAIL_OVER_ENABLED;
 import static com.linkedin.venice.ConfigKeys.HELIX_REBALANCE_ALG;
@@ -333,6 +335,10 @@ public class VeniceControllerClusterConfig {
     controllerSchemaValidationEnabled = props.getBoolean(CONTROLLER_SCHEMA_VALIDATION_ENABLED, true);
     enabledIncrementalPushForHybridActiveActiveUserStores =
         props.getBoolean(ENABLE_INCREMENTAL_PUSH_FOR_HYBRID_ACTIVE_ACTIVE_USER_STORES, false);
+    enablePartialUpdateForHybridActiveActiveUserStores =
+        props.getBoolean(ENABLE_PARTIAL_UPDATE_FOR_HYBRID_ACTIVE_ACTIVE_USER_STORES, false);
+    enablePartialUpdateForHybridNonActiveActiveUserStores =
+        props.getBoolean(ENABLE_PARTIAL_UPDATE_FOR_HYBRID_NON_ACTIVE_ACTIVE_USER_STORES, false);
 
     clusterToD2Map = props.getMap(CLUSTER_TO_D2);
     clusterToServerD2Map = props.getMap(CLUSTER_TO_SERVER_D2, Collections.emptyMap());

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
@@ -2491,7 +2491,7 @@ public class VeniceParentHelixAdmin implements Admin {
           this,
           clusterName,
           storeName,
-          params.getWriteComputationEnabled(),
+          writeComputationEnabled,
           setStore,
           storeBeingConvertedToHybrid);
       if (partialUpdateConfigUpdated) {
@@ -2501,27 +2501,24 @@ public class VeniceParentHelixAdmin implements Admin {
 
       // Update Chunking config.
       boolean chunkingConfigUpdated = ParentControllerConfigUpdateUtils
-          .checkAndMaybeApplyChunkingConfigChange(this, clusterName, storeName, params.getChunkingEnabled(), setStore);
+          .checkAndMaybeApplyChunkingConfigChange(this, clusterName, storeName, chunkingEnabled, setStore);
       if (chunkingConfigUpdated) {
         updatedConfigsList.add(CHUNKING_ENABLED);
       }
 
       // Update RMD Chunking config.
-      boolean rmdChunkingConfigUpdated = ParentControllerConfigUpdateUtils.checkAndMaybeApplyRmdChunkingConfigChange(
-          this,
-          clusterName,
-          storeName,
-          params.getRmdChunkingEnabled(),
-          setStore);
+      boolean rmdChunkingConfigUpdated = ParentControllerConfigUpdateUtils
+          .checkAndMaybeApplyRmdChunkingConfigChange(this, clusterName, storeName, rmdChunkingEnabled, setStore);
       if (rmdChunkingConfigUpdated) {
         updatedConfigsList.add(RMD_CHUNKING_ENABLED);
       }
 
+      // Validate Amplification Factor config based on latest A/A and partial update status.
       if ((setStore.getActiveActiveReplicationEnabled() || setStore.getWriteComputationEnabled())
           && updatedPartitionerConfig.getAmplificationFactor() > 1) {
         throw new VeniceHttpException(
             HttpStatus.SC_BAD_REQUEST,
-            "Non-default amplification factor is not compatible with active-active replication and/or write compute.",
+            "Non-default amplification factor is not compatible with active-active replication and/or partial update.",
             ErrorType.BAD_REQUEST);
       }
 

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
@@ -2377,11 +2377,6 @@ public class VeniceParentHelixAdmin implements Admin {
               .orElseGet(currStore::getNumVersionsToPreserve);
       setStore.isMigrating = storeMigration.map(addToUpdatedConfigList(updatedConfigsList, STORE_MIGRATION))
           .orElseGet(currStore::isMigrating);
-      /*
-      setStore.writeComputationEnabled =
-          writeComputationEnabled.map(addToUpdatedConfigList(updatedConfigsList, WRITE_COMPUTATION_ENABLED))
-              .orElseGet(currStore::isWriteComputationEnabled);
-       */
       setStore.replicationMetadataVersionID = replicationMetadataVersionID
           .map(addToUpdatedConfigList(updatedConfigsList, REPLICATION_METADATA_PROTOCOL_VERSION_ID))
           .orElse(currStore.getRmdVersion());
@@ -2498,7 +2493,6 @@ public class VeniceParentHelixAdmin implements Admin {
         updatedConfigsList.add(WRITE_COMPUTATION_ENABLED);
       }
       boolean partialUpdateJustEnabled = setStore.writeComputationEnabled && !currStore.isWriteComputationEnabled();
-
       // Update Chunking config.
       boolean chunkingConfigUpdated = ParentControllerConfigUpdateUtils
           .checkAndMaybeApplyChunkingConfigChange(this, clusterName, storeName, chunkingEnabled, setStore);

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/util/ParentControllerConfigUpdateUtils.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/util/ParentControllerConfigUpdateUtils.java
@@ -17,6 +17,11 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 
+/**
+ * This class is a utility class for Parent Controller store update logics.
+ * The method here aims to take in current status and request params to determine if certain feature is updated / should
+ * be updated based on some customized logics.
+ */
 public class ParentControllerConfigUpdateUtils {
   public static final Logger LOGGER = LogManager.getLogger(ParentControllerConfigUpdateUtils.class);
   public static final WriteComputeSchemaConverter updateSchemaConverter = WriteComputeSchemaConverter.getInstance();
@@ -129,7 +134,7 @@ public class ParentControllerConfigUpdateUtils {
         Schema updateSchema = updateSchemaConverter.convertFromValueRecordSchema(valueSchemaEntry.getSchema());
         updateSchemaEntries.add(new SchemaEntry(valueSchemaEntry.getId(), updateSchema));
       } catch (Exception e) {
-        // Allow failure in write-compute schema generation in all schema except the latest value schema
+        // Allow failure in update schema generation in all schema except the latest value schema
         if (valueSchemaEntry.getId() == maxId) {
           throw new VeniceException(
               "For store " + storeName + " cannot generate update schema for value schema ID :"

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/util/ParentControllerConfigUpdateUtils.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/util/ParentControllerConfigUpdateUtils.java
@@ -50,17 +50,14 @@ public class ParentControllerConfigUpdateUtils {
     boolean partialUpdateConfigChanged = false;
     setStore.writeComputationEnabled = currentStore.isWriteComputationEnabled();
     if (partialUpdateRequest.isPresent()) {
-      if (partialUpdateRequest.get() != currentStore.isWriteComputationEnabled()) {
-        partialUpdateConfigChanged = true;
-        setStore.writeComputationEnabled = partialUpdateRequest.get();
-        if (partialUpdateRequest.get()) {
-          // Dry-run generating update schemas before sending admin messages to enable partial update because
-          // update schema generation may fail due to some reasons. If that happens, abort the store update process.
-          addUpdateSchemaForStore(parentHelixAdmin, clusterName, storeName, true);
-        }
+      setStore.writeComputationEnabled = partialUpdateRequest.get();
+      if (partialUpdateRequest.get() && !currentStore.isWriteComputationEnabled()) {
+        // Dry-run generating update schemas before sending admin messages to enable partial update because
+        // update schema generation may fail due to some reasons. If that happens, abort the store update process.
+        addUpdateSchemaForStore(parentHelixAdmin, clusterName, storeName, true);
       }
       // Explicit request to change partial update config has the highest priority.
-      return partialUpdateConfigChanged;
+      return true;
     }
     /**
      * If a store:
@@ -102,14 +99,10 @@ public class ParentControllerConfigUpdateUtils {
       UpdateStore setStore) {
     Store currentStore = parentHelixAdmin.getVeniceHelixAdmin().getStore(clusterName, storeName);
     setStore.chunkingEnabled = currentStore.isChunkingEnabled();
-    boolean chunkingConfigChanged = false;
     if (chunkingRequest.isPresent()) {
-      if (chunkingRequest.get() != currentStore.isChunkingEnabled()) {
-        chunkingConfigChanged = true;
-        setStore.chunkingEnabled = chunkingRequest.get();
-      }
+      setStore.chunkingEnabled = chunkingRequest.get();
       // Explicit request to change chunking config has the highest priority.
-      return chunkingConfigChanged;
+      return true;
     }
     // If partial update is just enabled, we will by default enable chunking, if no explict request to update chunking
     // config.
@@ -129,14 +122,10 @@ public class ParentControllerConfigUpdateUtils {
       UpdateStore setStore) {
     Store currentStore = parentHelixAdmin.getVeniceHelixAdmin().getStore(clusterName, storeName);
     setStore.rmdChunkingEnabled = currentStore.isRmdChunkingEnabled();
-    boolean rmdChunkingConfigChanged = false;
     if (rmdChunkingRequest.isPresent()) {
-      if (rmdChunkingRequest.get() != currentStore.isChunkingEnabled()) {
-        rmdChunkingConfigChanged = true;
-        setStore.rmdChunkingEnabled = rmdChunkingRequest.get();
-      }
+      setStore.rmdChunkingEnabled = rmdChunkingRequest.get();
       // Explicit request to change RMD chunking config has the highest priority.
-      return rmdChunkingConfigChanged;
+      return true;
     }
     // If partial update is just enabled and A/A is enabled, we will by default enable RMD chunking, if no explict
     // request to update RMD chunking config.

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/util/ParentControllerConfigUpdateUtils.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/util/ParentControllerConfigUpdateUtils.java
@@ -111,8 +111,12 @@ public class ParentControllerConfigUpdateUtils {
     }
     // If partial update is just enabled, we will by default enable chunking, if no explict request to update chunking
     // config.
-    return !currentStore.isWriteComputationEnabled() && setStore.writeComputationEnabled
-        && !currentStore.isChunkingEnabled();
+    if (!currentStore.isWriteComputationEnabled() && setStore.writeComputationEnabled
+        && !currentStore.isChunkingEnabled()) {
+      setStore.chunkingEnabled = true;
+      return true;
+    }
+    return false;
   }
 
   public static boolean checkAndMaybeApplyRmdChunkingConfigChange(
@@ -133,8 +137,12 @@ public class ParentControllerConfigUpdateUtils {
     }
     // If partial update is just enabled and A/A is enabled, we will by default enable RMD chunking, if no explict
     // request to update RMD chunking config.
-    return !currentStore.isWriteComputationEnabled() && setStore.writeComputationEnabled
-        && setStore.activeActiveReplicationEnabled && !currentStore.isRmdChunkingEnabled();
+    if (!currentStore.isWriteComputationEnabled() && setStore.writeComputationEnabled
+        && setStore.activeActiveReplicationEnabled && !currentStore.isRmdChunkingEnabled()) {
+      setStore.rmdChunkingEnabled = true;
+      return true;
+    }
+    return false;
   }
 
   public static void addUpdateSchemaForStore(

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/util/ParentControllerConfigUpdateUtils.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/util/ParentControllerConfigUpdateUtils.java
@@ -96,7 +96,8 @@ public class ParentControllerConfigUpdateUtils {
     }
     // If partial update is just enabled, we will by default enable chunking, if no explict request to update chunking
     // config.
-    return !currentStore.isWriteComputationEnabled() && setStore.writeComputationEnabled;
+    return !currentStore.isWriteComputationEnabled() && setStore.writeComputationEnabled
+        && !currentStore.isChunkingEnabled();
   }
 
   public static boolean checkAndMaybeApplyRmdChunkingConfigChange(
@@ -118,7 +119,7 @@ public class ParentControllerConfigUpdateUtils {
     // If partial update is just enabled and A/A is enabled, we will by default enable RMD chunking, if no explict
     // request to update RMD chunking config.
     return !currentStore.isWriteComputationEnabled() && setStore.writeComputationEnabled
-        && setStore.activeActiveReplicationEnabled;
+        && setStore.activeActiveReplicationEnabled && !currentStore.isRmdChunkingEnabled();
   }
 
   public static void addUpdateSchemaForStore(

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/util/ParentControllerConfigUpdateUtils.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/util/ParentControllerConfigUpdateUtils.java
@@ -48,6 +48,7 @@ public class ParentControllerConfigUpdateUtils {
     VeniceControllerClusterConfig clusterConfig =
         parentHelixAdmin.getVeniceHelixAdmin().getHelixVeniceClusterResources(clusterName).getConfig();
     boolean partialUpdateConfigChanged = false;
+    setStore.writeComputationEnabled = currentStore.isWriteComputationEnabled();
     if (partialUpdateRequest.isPresent()) {
       if (partialUpdateRequest.get() != currentStore.isWriteComputationEnabled()) {
         partialUpdateConfigChanged = true;
@@ -100,6 +101,7 @@ public class ParentControllerConfigUpdateUtils {
       Optional<Boolean> chunkingRequest,
       UpdateStore setStore) {
     Store currentStore = parentHelixAdmin.getVeniceHelixAdmin().getStore(clusterName, storeName);
+    setStore.chunkingEnabled = currentStore.isChunkingEnabled();
     boolean chunkingConfigChanged = false;
     if (chunkingRequest.isPresent()) {
       if (chunkingRequest.get() != currentStore.isChunkingEnabled()) {
@@ -126,6 +128,7 @@ public class ParentControllerConfigUpdateUtils {
       Optional<Boolean> rmdChunkingRequest,
       UpdateStore setStore) {
     Store currentStore = parentHelixAdmin.getVeniceHelixAdmin().getStore(clusterName, storeName);
+    setStore.rmdChunkingEnabled = currentStore.isRmdChunkingEnabled();
     boolean rmdChunkingConfigChanged = false;
     if (rmdChunkingRequest.isPresent()) {
       if (rmdChunkingRequest.get() != currentStore.isChunkingEnabled()) {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/util/ParentControllerConfigUpdateUtils.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/util/ParentControllerConfigUpdateUtils.java
@@ -1,0 +1,110 @@
+package com.linkedin.venice.controller.util;
+
+import com.linkedin.venice.controller.VeniceControllerClusterConfig;
+import com.linkedin.venice.controller.VeniceParentHelixAdmin;
+import com.linkedin.venice.controller.kafka.protocol.admin.UpdateStore;
+import com.linkedin.venice.exceptions.VeniceException;
+import com.linkedin.venice.meta.Store;
+import com.linkedin.venice.schema.SchemaEntry;
+import com.linkedin.venice.schema.writecompute.WriteComputeSchemaConverter;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+import org.apache.avro.Schema;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+
+public class ParentControllerConfigUpdateUtils {
+  public static final Logger LOGGER = LogManager.getLogger(ParentControllerConfigUpdateUtils.class);
+  public static final WriteComputeSchemaConverter updateSchemaConverter = WriteComputeSchemaConverter.getInstance();
+
+  public static boolean checkAndMaybeApplyPartialUpdateConfig(
+      VeniceParentHelixAdmin parentHelixAdmin,
+      String clusterName,
+      String storeName,
+      Optional<Boolean> partialUpdateRequest,
+      UpdateStore setStore,
+      boolean storeBeingConvertedToHybrid) {
+    Store currentStore = parentHelixAdmin.getVeniceHelixAdmin().getStore(clusterName, storeName);
+    VeniceControllerClusterConfig clusterConfig =
+        parentHelixAdmin.getVeniceHelixAdmin().getHelixVeniceClusterResources(clusterName).getConfig();
+    boolean partialUpdateConfigChanged = false;
+    if (partialUpdateRequest.isPresent()) {
+      if (partialUpdateRequest.get() != currentStore.isWriteComputationEnabled()) {
+        partialUpdateConfigChanged = true;
+        setStore.writeComputationEnabled = partialUpdateRequest.get();
+        if (partialUpdateRequest.get()) {
+          // Dry-run generating Write Compute schemas before sending admin messages to enable Write Compute because
+          // Write
+          // Compute schema generation may fail due to some reasons. If that happens, abort the store update process.
+          addUpdateSchemaForStore(parentHelixAdmin, clusterName, storeName, true);
+        }
+      }
+    }
+    /**
+     * Explicit request to change partial update config has the highest priority.
+     */
+    if (partialUpdateConfigChanged) {
+      return true;
+    }
+    /**
+     * If a store: (1) Is being converted to hybrid (2) Is not partial update enabled for now. (3) Does not change
+     * partial update config in this request.
+     * It means partial update is not enabled, and there is no explict intention to change it. In this case, we will
+     * look up cluster config and based on the replication policy to enable partial update implicitly.
+     */
+    final boolean shouldEnablePartialUpdateBasedOnClusterConfig =
+        storeBeingConvertedToHybrid && (setStore.activeActiveReplicationEnabled
+            ? clusterConfig.isEnablePartialUpdateForHybridActiveActiveUserStores()
+            : clusterConfig.isEnablePartialUpdateForHybridNonActiveActiveUserStores());
+    if (!currentStore.isWriteComputationEnabled() && shouldEnablePartialUpdateBasedOnClusterConfig) {
+      LOGGER.info("Controller will try to enable partial update based on cluster config for store: " + storeName);
+      try {
+        addUpdateSchemaForStore(parentHelixAdmin, clusterName, storeName, true);
+        setStore.writeComputationEnabled = true;
+        partialUpdateConfigChanged = true;
+      } catch (Exception e) {
+        LOGGER.warn(
+            "Caught exception when trying to enable partial update base on cluster config, will not enable partial update for store: "
+                + storeName,
+            e);
+      }
+    }
+    return partialUpdateConfigChanged;
+  }
+
+  public static void addUpdateSchemaForStore(
+      VeniceParentHelixAdmin parentHelixAdmin,
+      String clusterName,
+      String storeName,
+      boolean dryRun) {
+    Collection<SchemaEntry> valueSchemaEntries = parentHelixAdmin.getValueSchemas(clusterName, storeName);
+    List<SchemaEntry> updateSchemaEntries = new ArrayList<>(valueSchemaEntries.size());
+    int maxId = valueSchemaEntries.stream().map(SchemaEntry::getId).max(Comparator.naturalOrder()).get();
+    for (SchemaEntry valueSchemaEntry: valueSchemaEntries) {
+      try {
+        Schema updateSchema = updateSchemaConverter.convertFromValueRecordSchema(valueSchemaEntry.getSchema());
+        updateSchemaEntries.add(new SchemaEntry(valueSchemaEntry.getId(), updateSchema));
+      } catch (Exception e) {
+        // Allow failure in write-compute schema generation in all schema except the latest value schema
+        if (valueSchemaEntry.getId() == maxId) {
+          throw new VeniceException(
+              "For store " + storeName + " cannot generate update schema for value schema ID :"
+                  + valueSchemaEntry.getId() + ", top level field probably missing defaults.",
+              e);
+        }
+      }
+    }
+    // Add update schemas only after all update schema generation succeeded.
+    if (dryRun) {
+      return;
+    }
+    for (SchemaEntry updateSchemaEntry: updateSchemaEntries) {
+      parentHelixAdmin
+          .addDerivedSchema(clusterName, storeName, updateSchemaEntry.getId(), updateSchemaEntry.getSchemaStr());
+    }
+  }
+}

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/utils/ParentControllerConfigUpdateUtilsTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/utils/ParentControllerConfigUpdateUtilsTest.java
@@ -51,10 +51,10 @@ public class ParentControllerConfigUpdateUtilsTest {
             partialUpdateRequest,
             setStore,
             true));
-    // Case 2: partial update config not updated.
+    // Case 2: partial update config updated.
     setStore = new UpdateStore();
     when(store.isWriteComputationEnabled()).thenReturn(true);
-    Assert.assertFalse(
+    Assert.assertTrue(
         ParentControllerConfigUpdateUtils.checkAndMaybeApplyPartialUpdateConfig(
             parentHelixAdmin,
             cluster,
@@ -73,10 +73,10 @@ public class ParentControllerConfigUpdateUtilsTest {
             partialUpdateRequest,
             setStore,
             true));
-    // Case 4: partial update config not updated.
+    // Case 4: partial update config updated.
     setStore = new UpdateStore();
     when(store.isWriteComputationEnabled()).thenReturn(false);
-    Assert.assertFalse(
+    Assert.assertTrue(
         ParentControllerConfigUpdateUtils.checkAndMaybeApplyPartialUpdateConfig(
             parentHelixAdmin,
             cluster,
@@ -154,11 +154,11 @@ public class ParentControllerConfigUpdateUtilsTest {
     Assert.assertTrue(
         ParentControllerConfigUpdateUtils
             .checkAndMaybeApplyChunkingConfigChange(parentHelixAdmin, cluster, storeName, chunkingRequest, setStore));
-    // Case 2: chunking config not updated.
+    // Case 2: chunking config updated.
     setStore = new UpdateStore();
     setStore.chunkingEnabled = false;
     when(store.isChunkingEnabled()).thenReturn(true);
-    Assert.assertFalse(
+    Assert.assertTrue(
         ParentControllerConfigUpdateUtils
             .checkAndMaybeApplyChunkingConfigChange(parentHelixAdmin, cluster, storeName, chunkingRequest, setStore));
     // Case 3: chunking config updated.
@@ -167,10 +167,10 @@ public class ParentControllerConfigUpdateUtilsTest {
     Assert.assertTrue(
         ParentControllerConfigUpdateUtils
             .checkAndMaybeApplyChunkingConfigChange(parentHelixAdmin, cluster, storeName, chunkingRequest, setStore));
-    // Case 4: chunking config not updated.
+    // Case 4: chunking config updated.
     setStore = new UpdateStore();
     when(store.isChunkingEnabled()).thenReturn(false);
-    Assert.assertFalse(
+    Assert.assertTrue(
         ParentControllerConfigUpdateUtils
             .checkAndMaybeApplyChunkingConfigChange(parentHelixAdmin, cluster, storeName, chunkingRequest, setStore));
     /**
@@ -219,11 +219,11 @@ public class ParentControllerConfigUpdateUtilsTest {
             storeName,
             chunkingRequest,
             setStore));
-    // Case 2: chunking config not updated.
+    // Case 2: chunking config updated.
     setStore = new UpdateStore();
     setStore.chunkingEnabled = false;
     when(store.isChunkingEnabled()).thenReturn(true);
-    Assert.assertFalse(
+    Assert.assertTrue(
         ParentControllerConfigUpdateUtils.checkAndMaybeApplyRmdChunkingConfigChange(
             parentHelixAdmin,
             cluster,
@@ -240,10 +240,10 @@ public class ParentControllerConfigUpdateUtilsTest {
             storeName,
             chunkingRequest,
             setStore));
-    // Case 4: chunking config not updated.
+    // Case 4: chunking config updated.
     setStore = new UpdateStore();
     when(store.isChunkingEnabled()).thenReturn(false);
-    Assert.assertFalse(
+    Assert.assertTrue(
         ParentControllerConfigUpdateUtils.checkAndMaybeApplyRmdChunkingConfigChange(
             parentHelixAdmin,
             cluster,

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/utils/ParentControllerConfigUpdateUtilsTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/utils/ParentControllerConfigUpdateUtilsTest.java
@@ -1,0 +1,308 @@
+package com.linkedin.venice.controller.utils;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.linkedin.venice.controller.HelixVeniceClusterResources;
+import com.linkedin.venice.controller.VeniceControllerClusterConfig;
+import com.linkedin.venice.controller.VeniceHelixAdmin;
+import com.linkedin.venice.controller.VeniceParentHelixAdmin;
+import com.linkedin.venice.controller.kafka.protocol.admin.UpdateStore;
+import com.linkedin.venice.controller.util.ParentControllerConfigUpdateUtils;
+import com.linkedin.venice.meta.Store;
+import com.linkedin.venice.schema.SchemaEntry;
+import com.linkedin.venice.utils.TestWriteUtils;
+import java.util.Collections;
+import java.util.Optional;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class ParentControllerConfigUpdateUtilsTest {
+  @Test
+  public void testPartialUpdateConfigUpdate() {
+    VeniceParentHelixAdmin parentHelixAdmin = mock(VeniceParentHelixAdmin.class);
+    VeniceHelixAdmin veniceHelixAdmin = mock(VeniceHelixAdmin.class);
+    String cluster = "foo";
+    String storeName = "bar";
+    Store store = mock(Store.class);
+    when(parentHelixAdmin.getVeniceHelixAdmin()).thenReturn(veniceHelixAdmin);
+    when(veniceHelixAdmin.getStore(anyString(), anyString())).thenReturn(store);
+    HelixVeniceClusterResources helixVeniceClusterResources = mock(HelixVeniceClusterResources.class);
+    VeniceControllerClusterConfig veniceControllerClusterConfig = mock(VeniceControllerClusterConfig.class);
+    when(helixVeniceClusterResources.getConfig()).thenReturn(veniceControllerClusterConfig);
+    when(veniceHelixAdmin.getHelixVeniceClusterResources(anyString())).thenReturn(helixVeniceClusterResources);
+    SchemaEntry schemaEntry = new SchemaEntry(1, TestWriteUtils.USER_WITH_DEFAULT_SCHEMA);
+    when(veniceHelixAdmin.getValueSchemas(anyString(), anyString())).thenReturn(Collections.singletonList(schemaEntry));
+    when(parentHelixAdmin.getValueSchemas(anyString(), anyString())).thenReturn(Collections.singletonList(schemaEntry));
+
+    /**
+     * Explicit request.
+     */
+    Optional<Boolean> partialUpdateRequest = Optional.of(true);
+    // Case 1: partial update config updated.
+    UpdateStore setStore = new UpdateStore();
+    Assert.assertTrue(
+        ParentControllerConfigUpdateUtils.checkAndMaybeApplyPartialUpdateConfig(
+            parentHelixAdmin,
+            cluster,
+            storeName,
+            partialUpdateRequest,
+            setStore,
+            true));
+    // Case 2: partial update config not updated.
+    setStore = new UpdateStore();
+    when(store.isWriteComputationEnabled()).thenReturn(true);
+    Assert.assertFalse(
+        ParentControllerConfigUpdateUtils.checkAndMaybeApplyPartialUpdateConfig(
+            parentHelixAdmin,
+            cluster,
+            storeName,
+            partialUpdateRequest,
+            setStore,
+            true));
+    // Case 3: partial update config updated.
+    partialUpdateRequest = Optional.of(false);
+    when(store.isWriteComputationEnabled()).thenReturn(true);
+    Assert.assertTrue(
+        ParentControllerConfigUpdateUtils.checkAndMaybeApplyPartialUpdateConfig(
+            parentHelixAdmin,
+            cluster,
+            storeName,
+            partialUpdateRequest,
+            setStore,
+            true));
+    // Case 4: partial update config not updated.
+    setStore = new UpdateStore();
+    when(store.isWriteComputationEnabled()).thenReturn(false);
+    Assert.assertFalse(
+        ParentControllerConfigUpdateUtils.checkAndMaybeApplyPartialUpdateConfig(
+            parentHelixAdmin,
+            cluster,
+            storeName,
+            partialUpdateRequest,
+            setStore,
+            true));
+
+    /**
+     * No request.
+     */
+    partialUpdateRequest = Optional.empty();
+    when(veniceControllerClusterConfig.isEnablePartialUpdateForHybridActiveActiveUserStores()).thenReturn(false);
+    when(veniceControllerClusterConfig.isEnablePartialUpdateForHybridNonActiveActiveUserStores()).thenReturn(false);
+    // Case 1: partial update config not updated.
+    setStore = new UpdateStore();
+    Assert.assertFalse(
+        ParentControllerConfigUpdateUtils.checkAndMaybeApplyPartialUpdateConfig(
+            parentHelixAdmin,
+            cluster,
+            storeName,
+            partialUpdateRequest,
+            setStore,
+            true));
+    setStore.activeActiveReplicationEnabled = true;
+    Assert.assertFalse(
+        ParentControllerConfigUpdateUtils.checkAndMaybeApplyPartialUpdateConfig(
+            parentHelixAdmin,
+            cluster,
+            storeName,
+            partialUpdateRequest,
+            setStore,
+            true));
+    // Case 2: partial update config updated.
+    when(veniceControllerClusterConfig.isEnablePartialUpdateForHybridActiveActiveUserStores()).thenReturn(true);
+    when(veniceControllerClusterConfig.isEnablePartialUpdateForHybridNonActiveActiveUserStores()).thenReturn(true);
+    setStore = new UpdateStore();
+    Assert.assertTrue(
+        ParentControllerConfigUpdateUtils.checkAndMaybeApplyPartialUpdateConfig(
+            parentHelixAdmin,
+            cluster,
+            storeName,
+            partialUpdateRequest,
+            setStore,
+            true));
+    setStore.activeActiveReplicationEnabled = true;
+    Assert.assertTrue(
+        ParentControllerConfigUpdateUtils.checkAndMaybeApplyPartialUpdateConfig(
+            parentHelixAdmin,
+            cluster,
+            storeName,
+            partialUpdateRequest,
+            setStore,
+            true));
+  }
+
+  @Test
+  public void testChunkingConfigUpdate() {
+    VeniceParentHelixAdmin parentHelixAdmin = mock(VeniceParentHelixAdmin.class);
+    VeniceHelixAdmin veniceHelixAdmin = mock(VeniceHelixAdmin.class);
+    String cluster = "foo";
+    String storeName = "bar";
+    Store store = mock(Store.class);
+    when(parentHelixAdmin.getVeniceHelixAdmin()).thenReturn(veniceHelixAdmin);
+    when(veniceHelixAdmin.getStore(anyString(), anyString())).thenReturn(store);
+
+    /**
+     * Explicit request.
+     */
+    Optional<Boolean> chunkingRequest = Optional.of(true);
+    when(store.isChunkingEnabled()).thenReturn(false);
+    // Case 1: chunking config updated.
+    UpdateStore setStore = new UpdateStore();
+    setStore.chunkingEnabled = false;
+    Assert.assertTrue(
+        ParentControllerConfigUpdateUtils
+            .checkAndMaybeApplyChunkingConfigChange(parentHelixAdmin, cluster, storeName, chunkingRequest, setStore));
+    // Case 2: chunking config not updated.
+    setStore = new UpdateStore();
+    setStore.chunkingEnabled = false;
+    when(store.isChunkingEnabled()).thenReturn(true);
+    Assert.assertFalse(
+        ParentControllerConfigUpdateUtils
+            .checkAndMaybeApplyChunkingConfigChange(parentHelixAdmin, cluster, storeName, chunkingRequest, setStore));
+    // Case 3: chunking config updated.
+    chunkingRequest = Optional.of(false);
+    when(store.isChunkingEnabled()).thenReturn(true);
+    Assert.assertTrue(
+        ParentControllerConfigUpdateUtils
+            .checkAndMaybeApplyChunkingConfigChange(parentHelixAdmin, cluster, storeName, chunkingRequest, setStore));
+    // Case 4: chunking config not updated.
+    setStore = new UpdateStore();
+    when(store.isChunkingEnabled()).thenReturn(false);
+    Assert.assertFalse(
+        ParentControllerConfigUpdateUtils
+            .checkAndMaybeApplyChunkingConfigChange(parentHelixAdmin, cluster, storeName, chunkingRequest, setStore));
+    /**
+     * No request.
+     */
+    chunkingRequest = Optional.empty();
+    when(store.isWriteComputationEnabled()).thenReturn(false);
+    // Case 1: already enabled, chunking config not updated.
+    when(store.isChunkingEnabled()).thenReturn(true);
+    setStore = new UpdateStore();
+    setStore.writeComputationEnabled = true;
+    Assert.assertFalse(
+        ParentControllerConfigUpdateUtils
+            .checkAndMaybeApplyChunkingConfigChange(parentHelixAdmin, cluster, storeName, chunkingRequest, setStore));
+    // Case 2: chunking config updated.
+    when(store.isChunkingEnabled()).thenReturn(false);
+    setStore = new UpdateStore();
+    setStore.writeComputationEnabled = true;
+    Assert.assertTrue(
+        ParentControllerConfigUpdateUtils
+            .checkAndMaybeApplyChunkingConfigChange(parentHelixAdmin, cluster, storeName, chunkingRequest, setStore));
+  }
+
+  @Test
+  public void testRmdChunkingConfigUpdate() {
+    VeniceParentHelixAdmin parentHelixAdmin = mock(VeniceParentHelixAdmin.class);
+    VeniceHelixAdmin veniceHelixAdmin = mock(VeniceHelixAdmin.class);
+    String cluster = "foo";
+    String storeName = "bar";
+    Store store = mock(Store.class);
+    when(parentHelixAdmin.getVeniceHelixAdmin()).thenReturn(veniceHelixAdmin);
+    when(veniceHelixAdmin.getStore(anyString(), anyString())).thenReturn(store);
+
+    /**
+     * Explicit request.
+     */
+    Optional<Boolean> chunkingRequest = Optional.of(true);
+    when(store.isChunkingEnabled()).thenReturn(false);
+    // Case 1: chunking config updated.
+    UpdateStore setStore = new UpdateStore();
+    setStore.chunkingEnabled = false;
+    Assert.assertTrue(
+        ParentControllerConfigUpdateUtils.checkAndMaybeApplyRmdChunkingConfigChange(
+            parentHelixAdmin,
+            cluster,
+            storeName,
+            chunkingRequest,
+            setStore));
+    // Case 2: chunking config not updated.
+    setStore = new UpdateStore();
+    setStore.chunkingEnabled = false;
+    when(store.isChunkingEnabled()).thenReturn(true);
+    Assert.assertFalse(
+        ParentControllerConfigUpdateUtils.checkAndMaybeApplyRmdChunkingConfigChange(
+            parentHelixAdmin,
+            cluster,
+            storeName,
+            chunkingRequest,
+            setStore));
+    // Case 3: chunking config updated.
+    chunkingRequest = Optional.of(false);
+    when(store.isChunkingEnabled()).thenReturn(true);
+    Assert.assertTrue(
+        ParentControllerConfigUpdateUtils.checkAndMaybeApplyRmdChunkingConfigChange(
+            parentHelixAdmin,
+            cluster,
+            storeName,
+            chunkingRequest,
+            setStore));
+    // Case 4: chunking config not updated.
+    setStore = new UpdateStore();
+    when(store.isChunkingEnabled()).thenReturn(false);
+    Assert.assertFalse(
+        ParentControllerConfigUpdateUtils.checkAndMaybeApplyRmdChunkingConfigChange(
+            parentHelixAdmin,
+            cluster,
+            storeName,
+            chunkingRequest,
+            setStore));
+
+    /**
+     * No request.
+     */
+    chunkingRequest = Optional.empty();
+    when(store.isWriteComputationEnabled()).thenReturn(false);
+    // Case 1: already enabled, chunking config not updated.
+    when(store.isChunkingEnabled()).thenReturn(true);
+    setStore = new UpdateStore();
+    setStore.writeComputationEnabled = true;
+    Assert.assertFalse(
+        ParentControllerConfigUpdateUtils.checkAndMaybeApplyRmdChunkingConfigChange(
+            parentHelixAdmin,
+            cluster,
+            storeName,
+            chunkingRequest,
+            setStore));
+    // Case 2: chunking config not updated.
+    when(store.isChunkingEnabled()).thenReturn(false);
+    setStore = new UpdateStore();
+    setStore.writeComputationEnabled = true;
+    setStore.activeActiveReplicationEnabled = false;
+    Assert.assertFalse(
+        ParentControllerConfigUpdateUtils.checkAndMaybeApplyRmdChunkingConfigChange(
+            parentHelixAdmin,
+            cluster,
+            storeName,
+            chunkingRequest,
+            setStore));
+    // Case 3: chunking config not updated.
+    when(store.isChunkingEnabled()).thenReturn(false);
+    setStore = new UpdateStore();
+    setStore.writeComputationEnabled = false;
+    setStore.activeActiveReplicationEnabled = true;
+    Assert.assertFalse(
+        ParentControllerConfigUpdateUtils.checkAndMaybeApplyRmdChunkingConfigChange(
+            parentHelixAdmin,
+            cluster,
+            storeName,
+            chunkingRequest,
+            setStore));
+    // Case 4: chunking config updated.
+    when(store.isChunkingEnabled()).thenReturn(false);
+    setStore = new UpdateStore();
+    setStore.writeComputationEnabled = true;
+    setStore.activeActiveReplicationEnabled = true;
+    Assert.assertTrue(
+        ParentControllerConfigUpdateUtils.checkAndMaybeApplyRmdChunkingConfigChange(
+            parentHelixAdmin,
+            cluster,
+            storeName,
+            chunkingRequest,
+            setStore));
+
+  }
+}


### PR DESCRIPTION
## [controller] Add new controller cluster config to enable partial update by default when converting new store from batch to hybrid
This PR adds two new config to enable partial update by default when converting a store from batch to hybrid:
"enable.partial.update.for.hybrid.active.active.user.stores"
"enable.partial.update.for.hybrid.non.active.active.user.stores"

If the update request does not explicitly enable/disable partial update, then it will rely on the above 2 configs to determine if a store should enable partial update. If the resolution determines it needs partial update, it will also enable chunking (and RMD chunking, if A/A is enabled).

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
Add a new integration test to validate the cluster level config.

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.