### PR TITLE
[all] Bump avro-util to pick up a fix to disable the annotation processor during compilation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,7 @@ if (project.hasProperty('overrideBuildEnvironment')) {
 }
 
 def avroVersion = '1.10.2'
-def avroUtilVersion = '0.3.17'
+def avroUtilVersion = '0.3.18'
 def grpcVersion = '1.49.2'
 def kafkaGroup = 'com.linkedin.kafka'
 def kafkaVersion = '2.4.1.65'


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Bump `avro-util` to pick up a fix to disable the annotation processor during compilation
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
In one of our use-cases, we noticed this compilation failure:
```
FastSerdeBase [INFO] Starting compilation for the generated source file: <redacted>/MultiGetResponseRecordV1_GenericDeserializer_1339531883776153861_1339531883776153861.java 
warning: Supported source version 'RELEASE_6' from annotation processor 'org.antlr.v4.runtime.misc.NullUsageProcessor' less than -source '1.8'
error: Bad service configuration file, or exception thrown while constructing Processor object: javax.annotation.processing.Processor: Provider lombok.launch.AnnotationProcessorHider$AnnotationProcessor not found
...
Caused by: com.linkedin.venice.exceptions.VeniceException: Failed to generate fast generic de-serializer for Avro schema: {"type":"record","name":"MultiGetResponseRecordV1","namespace":"com.linkedin.venice.read.protocol.response","doc":"This field will store all the related info for one record","fields":[{"name":"keyIndex","type":"int","doc":"The corresponding key index for each record. Venice Client/Router is maintaining a mapping between a unique index and the corresponding key, so that Venice backend doesn't need to return the full key bytes to reduce network overhead"},{"name":"value","type":"bytes","doc":"Avro serialized value"},{"name":"schemaId","type":"int","doc":"Schema id of current store being used when serializing this record"}]}
	at com.linkedin.venice.serializer.FastSerializerDeserializerFactory.verifyWhetherFastGenericDeserializerWorks(FastSerializerDeserializerFactory.java:78) ~[venice-client-common-0.4.111.jar:?]
...
```

It turned out that the user had excluded `lombok` from all configurations and hence, the annotation processor was not found in the classpath. Although this can be attributed as a user error, since fast-avro doesn't use annotations, we disabled annotation processing completely. It could potentially speed up the compilation a bit too since the compiler won't search through the classpath to find all annotation processors. This commit picks up the change made in https://github.com/linkedin/avro-util/pull/518

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
Verified in the user's app that compilation doesn't fail with the new version. GH CI for regression tests.

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.