### PR TITLE
[producer] Allow deleting records via the shell producer

### DIFF
--- a/clients/venice-producer/src/main/java/com/linkedin/venice/producer/online/ProducerTool.java
+++ b/clients/venice-producer/src/main/java/com/linkedin/venice/producer/online/ProducerTool.java
@@ -184,10 +184,14 @@ public class ProducerTool {
       RouterBasedStoreSchemaFetcher schemaFetcher = new RouterBasedStoreSchemaFetcher(castClient);
       Schema keySchema = schemaFetcher.getKeySchema();
       Object key = adaptDataToSchema(producerContext.key, keySchema);
-      Object value = getValueObject(producerContext.value, schemaFetcher);
-
-      producer.asyncPut(key, value).get();
-      System.out.println("Data written to Venice!");
+      if (producerContext.value.equals("null")) { // Only allow `null`. Not "null", or 'null', or whatever.
+        producer.asyncDelete(key).get();
+        System.out.println("Record deleted from Venice!");
+      } else {
+        Object value = getValueObject(producerContext.value, schemaFetcher);
+        producer.asyncPut(key, value).get();
+        System.out.println("Data written to Venice!");
+      }
     } catch (Exception e) {
       System.err.println(ExceptionUtils.stackTraceToString(e));
       System.exit(1);


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Allow deleting records via the shell producer
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
The shell producer can allow deleting records by accepting the value `null` regardless of the fact that it is compatible with the store schema or not. Note that other forms of `null` like `"null"`, `'null'`, etc are not allowed.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
Tested locally

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.