### PR TITLE
[fc][test] Honor max batch get limit and return proper response for nonExistingKeys

### DIFF
--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/ClientConfig.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/ClientConfig.java
@@ -11,7 +11,6 @@ import com.linkedin.venice.fastclient.meta.StoreMetadataFetchMode;
 import com.linkedin.venice.fastclient.stats.ClusterStats;
 import com.linkedin.venice.fastclient.stats.FastClientStats;
 import com.linkedin.venice.read.RequestType;
-import com.linkedin.venice.router.api.VenicePathParser;
 import com.linkedin.venice.systemstore.schemas.StoreMetaKey;
 import com.linkedin.venice.systemstore.schemas.StoreMetaValue;
 import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
@@ -51,13 +50,9 @@ public class ClientConfig<K, V, T extends SpecificRecord> {
   private final long routingUnavailableRequestCounterResetDelayMS;
   private final int routingPendingRequestCounterInstanceBlockThreshold;
 
-  /**
-   * The max allowed key count in batch-get request.
-   * Right now, the batch-get implementation will leverage single-get, which is inefficient, when there
-   * are many keys, since the requests to the same storage node won't be reused.
-   * But to temporarily unblock the first customer, we will only allow at most two keys in a batch-get request.
-   */
+  // Max allowed key count in batch-get request
   private final int maxAllowedKeyCntInBatchGetReq;
+  protected static final int MAX_ALLOWED_KEY_COUNT_IN_BATCHGET = 150;
   private final DaVinciClient<StoreMetaKey, StoreMetaValue> daVinciClientForMetaStore;
   private final AvroSpecificStoreClient<StoreMetaKey, StoreMetaValue> thinClientForMetaStore;
   private final long metadataRefreshIntervalInSeconds;
@@ -387,16 +382,10 @@ public class ClientConfig<K, V, T extends SpecificRecord> {
     private long routingUnavailableRequestCounterResetDelayMS = -1;
     private int routingPendingRequestCounterInstanceBlockThreshold = -1;
     /**
-     * TODO:
-     * maxAllowedKeyCntInBatchGetReq was set to 2 initially for singleGet based multiGet
-     * for a specific customer ask. This needs to be reevaluated for streamingBatchGet().
-     * Today, the batch-get size for thinclient is enforced in Venice Router via
-     * {@link VenicePathParser#getBatchGetLimit} and it is configurable in store-level.
-     * In Fast-Client, it is still an open question about how to setup the batch-get limit
-     * or whether we need any limit at all. To start with, this can be set similar to routers
-     * global config and evaluate from there.
+     * maxAllowedKeyCntInBatchGetReq is set to {@link #MAX_ALLOWED_KEY_COUNT_IN_BATCHGET}
+     * for fast-client and can be overridden by client config.
      */
-    private int maxAllowedKeyCntInBatchGetReq = 2;
+    private int maxAllowedKeyCntInBatchGetReq = MAX_ALLOWED_KEY_COUNT_IN_BATCHGET;
 
     private DaVinciClient<StoreMetaKey, StoreMetaValue> daVinciClientForMetaStore;
 

--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/RetriableAvroGenericStoreClient.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/RetriableAvroGenericStoreClient.java
@@ -199,8 +199,8 @@ public class RetriableAvroGenericStoreClient<K, V> extends DelegatingAvroStoreCl
         if (exception.isPresent()) {
           streamingResponseFuture.completeExceptionally(exception.get());
         } else {
-          streamingResponseFuture
-              .complete(new VeniceResponseMapImpl<>(valueMap, nonExistingKeys, valueMap.size() == keys.size()));
+          boolean isFullResponse = ((valueMap.size() + nonExistingKeys.size()) == keys.size());
+          streamingResponseFuture.complete(new VeniceResponseMapImpl<>(valueMap, nonExistingKeys, isFullResponse));
         }
       }
     });

--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/RetriableAvroGenericStoreClient.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/RetriableAvroGenericStoreClient.java
@@ -199,7 +199,7 @@ public class RetriableAvroGenericStoreClient<K, V> extends DelegatingAvroStoreCl
         if (exception.isPresent()) {
           streamingResponseFuture.completeExceptionally(exception.get());
         } else {
-          boolean isFullResponse = ((valueMap.size() + nonExistingKeys.size()) == keys.size());
+          boolean isFullResponse = (valueMap.size() + nonExistingKeys.size()) == keys.size();
           streamingResponseFuture.complete(new VeniceResponseMapImpl<>(valueMap, nonExistingKeys, isFullResponse));
         }
       }

--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/StatsAvroGenericStoreClient.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/StatsAvroGenericStoreClient.java
@@ -9,6 +9,7 @@ import com.linkedin.venice.fastclient.meta.InstanceHealthMonitor;
 import com.linkedin.venice.fastclient.stats.ClusterStats;
 import com.linkedin.venice.fastclient.stats.FastClientStats;
 import com.linkedin.venice.read.RequestType;
+import com.linkedin.venice.router.exception.VeniceKeyCountLimitException;
 import com.linkedin.venice.utils.LatencyUtils;
 import com.linkedin.venice.utils.Time;
 import java.util.Collections;
@@ -80,9 +81,11 @@ public class StatsAvroGenericStoreClient<K, V> extends DelegatingAvroStoreClient
     }
     int keyCnt = keys.size();
     if (keyCnt > maxAllowedKeyCntInBatchGetReq) {
-      throw new VeniceClientException(
-          "Currently, the max allowed key count in a batch-get request: " + maxAllowedKeyCntInBatchGetReq
-              + ", but received: " + keyCnt);
+      throw new VeniceKeyCountLimitException(
+          getStoreName(),
+          RequestType.MULTI_GET,
+          keyCnt,
+          maxAllowedKeyCntInBatchGetReq);
     }
     CompletableFuture<Map<K, V>> resultFuture = new CompletableFuture<>();
     Map<K, CompletableFuture<V>> valueFutures = new HashMap<>();

--- a/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/DispatchingAvroGenericStoreClientTest.java
+++ b/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/DispatchingAvroGenericStoreClientTest.java
@@ -24,6 +24,7 @@ import com.linkedin.venice.fastclient.stats.FastClientStats;
 import com.linkedin.venice.fastclient.transport.TransportClientResponseForRoute;
 import com.linkedin.venice.read.RequestType;
 import com.linkedin.venice.read.protocol.response.MultiGetResponseRecordV1;
+import com.linkedin.venice.router.exception.VeniceKeyCountLimitException;
 import com.linkedin.venice.serializer.SerializerDeserializerFactory;
 import com.linkedin.venice.utils.DataProviderUtils;
 import com.linkedin.venice.utils.TestUtils;
@@ -456,6 +457,22 @@ public class DispatchingAvroGenericStoreClientTest {
       }
       metrics = getStats(clientConfig, RequestType.MULTI_GET);
       validateMultiGetMetrics(true, false, useStreamingBatchGetAsDefault, false);
+    } finally {
+      tearDown();
+    }
+  }
+
+  @Test(dataProvider = "True-and-False", dataProviderClass = DataProviderUtils.class, timeOut = TEST_TIMEOUT, expectedExceptions = VeniceKeyCountLimitException.class)
+  public void testBatchGetWithMoreKeysThanMaxSize(boolean useStreamingBatchGetAsDefault)
+      throws ExecutionException, InterruptedException, IOException {
+    try {
+      setUpClient(useStreamingBatchGetAsDefault);
+      batchGetRequestContext = new BatchGetRequestContext<>();
+      Set<String> keys = new HashSet<>();
+      for (int i = 0; i < ClientConfig.MAX_ALLOWED_KEY_COUNT_IN_BATCHGET + 1; ++i) {
+        keys.add("testKey" + i);
+      }
+      statsAvroGenericStoreClient.batchGet(batchGetRequestContext, keys).get();
     } finally {
       tearDown();
     }

--- a/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/utils/TestClientSimulator.java
+++ b/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/utils/TestClientSimulator.java
@@ -523,6 +523,7 @@ public class TestClientSimulator implements Client {
     clientConfigBuilder.setR2Client(this);
     clientConfigBuilder.setMetricsRepository(new MetricsRepository());
     clientConfigBuilder.setSpeculativeQueryEnabled(speculativeQueryEnabled);
+    clientConfigBuilder.setMaxAllowedKeyCntInBatchGetReq(1000);
     if (longTailRetryEnabledForBatchGet) {
       clientConfigBuilder.setLongTailRetryEnabledForBatchGet(true);
       clientConfigBuilder

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/fastclient/utils/AbstractClientEndToEndSetup.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/fastclient/utils/AbstractClientEndToEndSetup.java
@@ -157,28 +157,15 @@ public abstract class AbstractClientEndToEndSetup {
         STORE_METADATA_FETCH_MODES); // storeMetadataFetchMode
   }
 
-  @DataProvider(name = "FastClient-Two-Boolean-Store-Metadata-Fetch-Mode")
-  public Object[][] twoBooleanStoreMetadataFetchMode() {
-    return DataProviderUtils.allPermutationGenerator((permutation) -> {
-      boolean batchGet = (boolean) permutation[0];
-      boolean useStreamingBatchGetAsDefault = (boolean) permutation[1];
-      if (!batchGet) {
-        if (useStreamingBatchGetAsDefault) {
-          // this parameter is related only to batchGet, so just allowing 1 set
-          // to avoid duplicate tests
-          return false;
-        }
-      }
-      return true;
-    },
-        DataProviderUtils.BOOLEAN, // batchGet
-        DataProviderUtils.BOOLEAN, // useStreamingBatchGetAsDefault
-        STORE_METADATA_FETCH_MODES); // storeMetadataFetchMode
-  }
-
   @DataProvider(name = "FastClient-One-Boolean-Store-Metadata-Fetch-Mode")
   public Object[][] oneBooleanStoreMetadataFetchMode() {
     return DataProviderUtils.allPermutationGenerator(DataProviderUtils.BOOLEAN, STORE_METADATA_FETCH_MODES);
+  }
+
+  @DataProvider(name = "FastClient-Two-Boolean-Store-Metadata-Fetch-Mode")
+  public Object[][] twoBooleanStoreMetadataFetchMode() {
+    return DataProviderUtils
+        .allPermutationGenerator(DataProviderUtils.BOOLEAN, DataProviderUtils.BOOLEAN, STORE_METADATA_FETCH_MODES);
   }
 
   @DataProvider(name = "FastClient-Three-Boolean-And-A-Number")


### PR DESCRIPTION
## Summary
1. streaming `batchGet` was not honoring max keys limit in a batch get. Returning `VeniceKeyCountLimitException` now.
2. setting the default max number of keys in a batch get in FC to 150. It was 2 before.
3. When there is a non-existing key in batch get, an exception was returned `Response was not complete`: Changed it to consider non-existing keys as part of response key count. 
4. Added unit tests/integration tests for the above cases.

## How was this PR tested?
GH CI

## Does this PR introduce any user-facing changes?
- [x] No. You can skip the rest of this section.
- [] Yes. Make sure to explain your proposed changes and call out the behavior change.