### PR TITLE
[router] Check for compressor readiness in version finder

### DIFF
--- a/services/venice-router/src/main/java/com/linkedin/venice/router/api/VeniceVersionFinder.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/api/VeniceVersionFinder.java
@@ -88,8 +88,7 @@ public class VeniceVersionFinder {
 
     int metadataCurrentVersion = store.getCurrentVersion();
     if (!lastCurrentVersionMap.containsKey(storeName)) {
-      if (metadataCurrentVersion != Store.NON_EXISTING_VERSION && store.getVersion(metadataCurrentVersion).isPresent()
-          && !isDecompressorReady(store, metadataCurrentVersion)) {
+      if (metadataCurrentVersion != Store.NON_EXISTING_VERSION && !isDecompressorReady(store, metadataCurrentVersion)) {
         return Store.NON_EXISTING_VERSION;
       } else {
         lastCurrentVersionMap.put(storeName, metadataCurrentVersion);

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/api/VeniceVersionFinder.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/api/VeniceVersionFinder.java
@@ -88,9 +88,13 @@ public class VeniceVersionFinder {
 
     int metadataCurrentVersion = store.getCurrentVersion();
     if (!lastCurrentVersionMap.containsKey(storeName)) {
-      lastCurrentVersionMap.put(storeName, metadataCurrentVersion);
+      if (metadataCurrentVersion != Store.NON_EXISTING_VERSION && !isDecompressorReady(store, metadataCurrentVersion)) {
+        return Store.NON_EXISTING_VERSION;
+      } else {
+        lastCurrentVersionMap.put(storeName, metadataCurrentVersion);
+      }
       if (metadataCurrentVersion == Store.NON_EXISTING_VERSION) {
-        /** This should happen at most once per store, since we are adding the mapping to {@link lastCurrentVersionMap} */
+        // This should happen at most once per store, since we are adding the mapping to {@link lastCurrentVersionMap}
         store = metadataRepository.refreshOneStore(storeName);
         metadataCurrentVersion = store.getCurrentVersion();
       }

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/api/VeniceVersionFinder.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/api/VeniceVersionFinder.java
@@ -88,7 +88,8 @@ public class VeniceVersionFinder {
 
     int metadataCurrentVersion = store.getCurrentVersion();
     if (!lastCurrentVersionMap.containsKey(storeName)) {
-      if (metadataCurrentVersion != Store.NON_EXISTING_VERSION && !isDecompressorReady(store, metadataCurrentVersion)) {
+      if (metadataCurrentVersion != Store.NON_EXISTING_VERSION && store.getVersion(metadataCurrentVersion).isPresent()
+          && !isDecompressorReady(store, metadataCurrentVersion)) {
         return Store.NON_EXISTING_VERSION;
       } else {
         lastCurrentVersionMap.put(storeName, metadataCurrentVersion);

--- a/services/venice-router/src/test/java/com/linkedin/venice/router/api/TestVenicePathParser.java
+++ b/services/venice-router/src/test/java/com/linkedin/venice/router/api/TestVenicePathParser.java
@@ -20,6 +20,7 @@ import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.helix.HelixReadOnlyStoreConfigRepository;
 import com.linkedin.venice.meta.ReadOnlyStoreRepository;
 import com.linkedin.venice.meta.Store;
+import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.partitioner.DefaultVenicePartitioner;
 import com.linkedin.venice.partitioner.VenicePartitioner;
 import com.linkedin.venice.read.RequestType;
@@ -50,6 +51,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 import org.mockito.Mockito;
 import org.testng.Assert;
@@ -70,6 +72,8 @@ public class TestVenicePathParser {
     // Mock objects
     Store mockStore = mock(Store.class);
     doReturn(1).when(mockStore).getCurrentVersion();
+    Version version = mock(Version.class);
+    doReturn(Optional.of(version)).when(mockStore).getVersion(anyInt());
     doReturn(true).when(mockStore).isEnableReads();
     doReturn(CompressionStrategy.NO_OP).when(mockStore).getCompressionStrategy();
     ReadOnlyStoreRepository mockMetadataRepository = mock(ReadOnlyStoreRepository.class);

--- a/services/venice-router/src/test/java/com/linkedin/venice/router/api/TestVeniceVersionFinder.java
+++ b/services/venice-router/src/test/java/com/linkedin/venice/router/api/TestVeniceVersionFinder.java
@@ -96,6 +96,7 @@ public class TestVeniceVersionFinder {
     store.setMigrating(true);
     int currentVersion = 10;
     store.setCurrentVersion(currentVersion);
+    store.addVersion(new VersionImpl(store.getName(), currentVersion, "id1"));
     doReturn(store).when(mockRepo).getStore(anyString());
     StaleVersionStats stats = mock(StaleVersionStats.class);
     HelixReadOnlyStoreConfigRepository storeConfigRepo = mock(HelixReadOnlyStoreConfigRepository.class);
@@ -131,6 +132,7 @@ public class TestVeniceVersionFinder {
     int currentVersion = 10;
     Store store = TestUtils.createTestStore(storeName, "unittest", System.currentTimeMillis());
     store.setCurrentVersion(currentVersion);
+    store.addVersion(new VersionImpl(storeName, currentVersion, "id1"));
     // disable store, should return the number indicates that none of version is avaiable to read.
     store.setEnableReads(false);
     doReturn(store).when(mockRepo).getStore(storeName);

--- a/services/venice-router/src/test/java/com/linkedin/venice/router/api/TestVeniceVersionFinder.java
+++ b/services/venice-router/src/test/java/com/linkedin/venice/router/api/TestVeniceVersionFinder.java
@@ -277,7 +277,7 @@ public class TestVeniceVersionFinder {
     }
   }
 
-  @Test(enabled = false)
+  @Test
   public void returnsCurrentVersionWhenItIsTheOnlyOption() {
     // When the router doesn't know of any other versions, it will return that version even if dictionary is not
     // downloaded.
@@ -320,8 +320,11 @@ public class TestVeniceVersionFinder {
 
     String firstVersionKafkaTopic = Version.composeKafkaTopic(storeName, firstVersion);
 
-    Assert.assertEquals(versionFinder.getVersion(storeName, request), firstVersion);
+    Assert.assertEquals(versionFinder.getVersion(storeName, request), Store.NON_EXISTING_VERSION);
     Assert.assertNull(compressorFactory.getVersionSpecificCompressor(firstVersionKafkaTopic));
+
+    doReturn(true).when(compressorFactory).versionSpecificCompressorExists(firstVersionKafkaTopic);
+    Assert.assertEquals(versionFinder.getVersion(storeName, request), firstVersion);
   }
 
   @Test

--- a/services/venice-router/src/test/java/com/linkedin/venice/router/api/TestVeniceVersionFinder.java
+++ b/services/venice-router/src/test/java/com/linkedin/venice/router/api/TestVeniceVersionFinder.java
@@ -275,7 +275,7 @@ public class TestVeniceVersionFinder {
     }
   }
 
-  @Test
+  @Test(enabled = false)
   public void returnsCurrentVersionWhenItIsTheOnlyOption() {
     // When the router doesn't know of any other versions, it will return that version even if dictionary is not
     // downloaded.


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Check for compressor readiness in version finder
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
During startup of the router if there is no valid store versions, `DictionaryRetrievalService::startInner` will not block the router startup.  During initial reads, `VeniceVersionFinder` might return an online version which still does not have a compressor yet downloaded. That will lead to `Compressor not available for resource. Dictionary not downloaded.` exception. 
This PR will keep returning `NON_EXISTING_VERSION` till the compressor is ready and then add to the current version map. 


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
CI
## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.