### PR TITLE
[server] Fixed stale storage engine reference in server

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/AbstractStorageEngine.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/AbstractStorageEngine.java
@@ -79,6 +79,8 @@ public abstract class AbstractStorageEngine<Partition extends AbstractStoragePar
    */
   private final List<ReadWriteLock> rwLockForStoragePartitionAdjustmentList = new SparseConcurrentList<>();
 
+  private volatile boolean closed = false;
+
   public AbstractStorageEngine(
       String storeName,
       InternalAvroSpecificSerializer<StoreVersionState> storeVersionStateSerializer,
@@ -340,6 +342,7 @@ public abstract class AbstractStorageEngine<Partition extends AbstractStoragePar
 
   @Override
   public synchronized void close() throws VeniceException {
+    this.closed = true;
     long startTime = System.currentTimeMillis();
     List<Partition> tmpList = new ArrayList<>();
     // SparseConcurrentList does not support parallelStream, copy to a tmp list.
@@ -352,6 +355,10 @@ public abstract class AbstractStorageEngine<Partition extends AbstractStoragePar
         LatencyUtils.getElapsedTimeInMs(startTime));
     partitionList.clear();
     closeMetadataPartition();
+  }
+
+  public boolean isClosed() {
+    return this.closed;
   }
 
   /**

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/AbstractStorageEngine.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/AbstractStorageEngine.java
@@ -20,7 +20,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.Callable;
@@ -60,7 +59,7 @@ public abstract class AbstractStorageEngine<Partition extends AbstractStoragePar
   public static final int METADATA_PARTITION_ID = 1000_000_000;
 
   private final String storeName;
-  private final List<Partition> partitionList = new SparseConcurrentList<>();
+  private final SparseConcurrentList<Partition> partitionList = new SparseConcurrentList<>();
   private Partition metadataPartition;
   private final AtomicReference<StoreVersionState> versionStateCache = new AtomicReference<>();
   private final InternalAvroSpecificSerializer<StoreVersionState> storeVersionStateSerializer;
@@ -660,7 +659,7 @@ public abstract class AbstractStorageEngine<Partition extends AbstractStoragePar
    * @return the number of non-null partitions in {@link #partitionList}
    */
   public synchronized long getNumberOfPartitions() {
-    return this.partitionList.stream().filter(Objects::nonNull).count();
+    return this.partitionList.nonNullSize();
   }
 
   /**
@@ -669,10 +668,7 @@ public abstract class AbstractStorageEngine<Partition extends AbstractStoragePar
    * @return partition Ids that are hosted in the current Storage Engine.
    */
   public synchronized Set<Integer> getPartitionIds() {
-    return this.partitionList.stream()
-        .filter(Objects::nonNull)
-        .map(Partition::getPartitionId)
-        .collect(Collectors.toSet());
+    return this.partitionList.values().stream().map(Partition::getPartitionId).collect(Collectors.toSet());
   }
 
   public AbstractStoragePartition getPartitionOrThrow(int partitionId) {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/AbstractStorageEngine.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/AbstractStorageEngine.java
@@ -79,8 +79,6 @@ public abstract class AbstractStorageEngine<Partition extends AbstractStoragePar
    */
   private final List<ReadWriteLock> rwLockForStoragePartitionAdjustmentList = new SparseConcurrentList<>();
 
-  private volatile boolean closed = false;
-
   public AbstractStorageEngine(
       String storeName,
       InternalAvroSpecificSerializer<StoreVersionState> storeVersionStateSerializer,
@@ -342,7 +340,6 @@ public abstract class AbstractStorageEngine<Partition extends AbstractStoragePar
 
   @Override
   public synchronized void close() throws VeniceException {
-    this.closed = true;
     long startTime = System.currentTimeMillis();
     List<Partition> tmpList = new ArrayList<>();
     // SparseConcurrentList does not support parallelStream, copy to a tmp list.
@@ -358,7 +355,7 @@ public abstract class AbstractStorageEngine<Partition extends AbstractStoragePar
   }
 
   public boolean isClosed() {
-    return this.closed;
+    return this.partitionList.isEmpty();
   }
 
   /**

--- a/docker/venice-client/Dockerfile
+++ b/docker/venice-client/Dockerfile
@@ -5,7 +5,7 @@ ENV VENICE_DIR=/opt/venice
 RUN apt-get update
 RUN apt-get install netcat tree wget python3 -y
 RUN mkdir -p "${VENICE_DIR}/bin"
-RUN wget -O ${VENICE_DIR}/bin/avro-tools.jar https://downloads.apache.org/avro/stable/java/avro-tools-1.11.2.jar
+RUN wget -O ${VENICE_DIR}/bin/avro-tools.jar https://repo1.maven.org/maven2/org/apache/avro/avro-tools/1.11.2/avro-tools-1.11.2.jar
 RUN wget -O ${VENICE_DIR}/bin/hadoop-mapreduce-client-core.jar https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-mapreduce-client-core/2.3.0/hadoop-mapreduce-client-core-2.3.0.jar
 RUN wget -O ${VENICE_DIR}/bin/hadoop-mapreduce-client-common.jar https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-mapreduce-client-common/2.3.0/hadoop-mapreduce-client-common-2.3.0.jar
 RUN wget -O ${VENICE_DIR}/bin/hadoop-common.jar https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-common/2.3.0/hadoop-common-2.3.0.jar

--- a/gradle/spotbugs/exclude.xml
+++ b/gradle/spotbugs/exclude.xml
@@ -157,6 +157,9 @@
       <Class name="com.linkedin.davinci.kafka.consumer.SharedKafkaConsumer">
         <Field name="currentAssignment"/>
       </Class>
+      <Class name="com.linkedin.venice.utils.SparseConcurrentList">
+        <Field name="nonNullSize"/>
+      </Class>
     </Or>
   </Match>
   <Match>

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/utils/SparseConcurrentList.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/utils/SparseConcurrentList.java
@@ -18,7 +18,7 @@ import java.util.function.UnaryOperator;
 
 /**
  * A {@link java.util.List} implementation with some usability improvements around resizing. In particular,
- * the list provides {@link Map} semantics in some cases where the regular {@link List} behavior would be
+ * the list provides {@link Map} semantics in some cases where the regular {@link List} behavior would be to
  * throw {@link ArrayIndexOutOfBoundsException}.
  *
  * Note on concurrency and performance characteristics:
@@ -26,7 +26,7 @@ import java.util.function.UnaryOperator;
  * This class extends {@link CopyOnWriteArrayList} and thus mimics its general characteristics: it is
  * threadsafe, very efficient for read operations, but it incurs a locking overhead on mutation operations.
  *
- * Unfortunately, the locking overhead may be up t double that of the parent class, because we cannot get
+ * Unfortunately, the locking overhead may be up to double that of the parent class, because we cannot get
  * access to {@link CopyOnWriteArrayList#lock} since it is package private and Java doesn't allow us to
  * define new classes in the java.* package. So instead we are making every mutation operation synchronized.
  * The end result should be that the inner lock inside the parent class never has any contention, since the
@@ -152,7 +152,7 @@ public class SparseConcurrentList<E> extends CopyOnWriteArrayList<E> {
     return nonNullSize() == 0;
   }
 
-  // Boilerplate code just to add synchronization to mutation operations:
+  // N.B.: All mutation operations add synchronization and maintenance of the nonNullSize.
 
   @Override
   public synchronized boolean add(E e) {
@@ -164,6 +164,15 @@ public class SparseConcurrentList<E> extends CopyOnWriteArrayList<E> {
   public synchronized void add(int index, E element) {
     handleSizeDuringMutation(null, element);
     super.add(index, element);
+  }
+
+  @Override
+  public synchronized boolean remove(Object o) {
+    boolean modified = super.remove(o);
+    if (modified) {
+      this.nonNullSize--;
+    }
+    return modified;
   }
 
   @Override

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/utils/SparseConcurrentListTest.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/utils/SparseConcurrentListTest.java
@@ -1,6 +1,8 @@
 package com.linkedin.venice.utils;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertThrows;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -11,35 +13,48 @@ import org.testng.annotations.Test;
 public class SparseConcurrentListTest {
   @Test
   public void testNonNullSize() {
+    // Initial state: empty list.
     SparseConcurrentList<Object> scl = new SparseConcurrentList<>();
+    assertNull(scl.get(1));
+    assertThrows(() -> scl.get(-1));
     assertEquals(scl.size(), 0);
     assertEquals(scl.nonNullSize(), 0);
-    assertEquals(scl.values().size(), 0);
+    assertEquals(scl.values().size(), scl.nonNullSize()); // This assertion should always be true.
+    Assert.assertTrue(scl.isEmpty());
 
+    // Add a new item at index 5.
     scl.set(5, new Object());
     Assert.assertNotNull(5);
     assertEquals(scl.size(), 6);
     assertEquals(scl.nonNullSize(), 1);
-    assertEquals(scl.values().size(), 1);
+    assertEquals(scl.values().size(), scl.nonNullSize());
+    Assert.assertFalse(scl.isEmpty());
 
+    // Add a new item at an earlier index than the already present item. No resizing expected.
     scl.set(2, new Object());
     Assert.assertNotNull(2);
     assertEquals(scl.size(), 6);
     assertEquals(scl.nonNullSize(), 2);
-    assertEquals(scl.values().size(), 2);
+    assertEquals(scl.values().size(), scl.nonNullSize());
+    Assert.assertFalse(scl.isEmpty());
 
+    // Remove the element at an index that already had nothing.
     scl.remove(3);
     Assert.assertNull(scl.get(3));
     assertEquals(scl.size(), 6);
     assertEquals(scl.nonNullSize(), 2);
-    assertEquals(scl.values().size(), 2);
+    assertEquals(scl.values().size(), scl.nonNullSize());
+    Assert.assertFalse(scl.isEmpty());
 
+    // Remove the element at an index that does contain something.
     scl.remove(2);
     Assert.assertNull(scl.get(2));
     assertEquals(scl.size(), 6);
     assertEquals(scl.nonNullSize(), 1);
-    assertEquals(scl.values().size(), 1);
+    assertEquals(scl.values().size(), scl.nonNullSize());
+    Assert.assertFalse(scl.isEmpty());
 
+    // Append a couple of elements to the end of the list.
     Collection<Object> objectsToAppend = new ArrayList<>();
     objectsToAppend.add(new Object());
     objectsToAppend.add(new Object());
@@ -48,11 +63,31 @@ public class SparseConcurrentListTest {
     Assert.assertNotNull(7);
     assertEquals(scl.size(), 8);
     assertEquals(scl.nonNullSize(), 3);
-    assertEquals(scl.values().size(), 3);
+    assertEquals(scl.values().size(), scl.nonNullSize());
+    Assert.assertFalse(scl.isEmpty());
 
+    // Compute if absent for an already populated index.
+    Object newObject = new Object();
+    scl.computeIfAbsent(5, k -> newObject);
+    Assert.assertNotEquals(scl.get(5), newObject);
+    assertEquals(scl.size(), 8);
+    assertEquals(scl.nonNullSize(), 3);
+    assertEquals(scl.values().size(), scl.nonNullSize());
+    Assert.assertFalse(scl.isEmpty());
+
+    // Compute if absent for an unpopulated index.
+    scl.computeIfAbsent(4, k -> newObject);
+    Assert.assertEquals(scl.get(4), newObject);
+    assertEquals(scl.size(), 8);
+    assertEquals(scl.nonNullSize(), 4);
+    assertEquals(scl.values().size(), scl.nonNullSize());
+    Assert.assertFalse(scl.isEmpty());
+
+    // Go back to the initial state...
     scl.clear();
     assertEquals(scl.size(), 0);
     assertEquals(scl.nonNullSize(), 0);
     assertEquals(scl.values().size(), 0);
+    Assert.assertTrue(scl.isEmpty());
   }
 }

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/utils/SparseConcurrentListTest.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/utils/SparseConcurrentListTest.java
@@ -1,12 +1,15 @@
 package com.linkedin.venice.utils;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotEquals;
+import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertThrows;
+import static org.testng.Assert.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import org.testng.Assert;
 import org.testng.annotations.Test;
 
 
@@ -20,74 +23,74 @@ public class SparseConcurrentListTest {
     assertEquals(scl.size(), 0);
     assertEquals(scl.nonNullSize(), 0);
     assertEquals(scl.values().size(), scl.nonNullSize()); // This assertion should always be true.
-    Assert.assertTrue(scl.isEmpty());
+    assertTrue(scl.isEmpty());
 
     // Add a new item at index 5.
     scl.set(5, new Object());
-    Assert.assertNotNull(5);
+    assertNotNull(5);
     assertEquals(scl.size(), 6);
     assertEquals(scl.nonNullSize(), 1);
     assertEquals(scl.values().size(), scl.nonNullSize());
-    Assert.assertFalse(scl.isEmpty());
+    assertFalse(scl.isEmpty());
 
     // Add a new item at an earlier index than the already present item. No resizing expected.
     scl.set(2, new Object());
-    Assert.assertNotNull(2);
+    assertNotNull(2);
     assertEquals(scl.size(), 6);
     assertEquals(scl.nonNullSize(), 2);
     assertEquals(scl.values().size(), scl.nonNullSize());
-    Assert.assertFalse(scl.isEmpty());
+    assertFalse(scl.isEmpty());
 
     // Remove the element at an index that already had nothing.
     scl.remove(3);
-    Assert.assertNull(scl.get(3));
+    assertNull(scl.get(3));
     assertEquals(scl.size(), 6);
     assertEquals(scl.nonNullSize(), 2);
     assertEquals(scl.values().size(), scl.nonNullSize());
-    Assert.assertFalse(scl.isEmpty());
+    assertFalse(scl.isEmpty());
 
     // Remove the element at an index that does contain something.
     scl.remove(2);
-    Assert.assertNull(scl.get(2));
+    assertNull(scl.get(2));
     assertEquals(scl.size(), 6);
     assertEquals(scl.nonNullSize(), 1);
     assertEquals(scl.values().size(), scl.nonNullSize());
-    Assert.assertFalse(scl.isEmpty());
+    assertFalse(scl.isEmpty());
 
     // Append a couple of elements to the end of the list.
     Collection<Object> objectsToAppend = new ArrayList<>();
     objectsToAppend.add(new Object());
     objectsToAppend.add(new Object());
     scl.addAll(objectsToAppend);
-    Assert.assertNotNull(6);
-    Assert.assertNotNull(7);
+    assertNotNull(6);
+    assertNotNull(7);
     assertEquals(scl.size(), 8);
     assertEquals(scl.nonNullSize(), 3);
     assertEquals(scl.values().size(), scl.nonNullSize());
-    Assert.assertFalse(scl.isEmpty());
+    assertFalse(scl.isEmpty());
 
     // Compute if absent for an already populated index.
     Object newObject = new Object();
     scl.computeIfAbsent(5, k -> newObject);
-    Assert.assertNotEquals(scl.get(5), newObject);
+    assertNotEquals(scl.get(5), newObject);
     assertEquals(scl.size(), 8);
     assertEquals(scl.nonNullSize(), 3);
     assertEquals(scl.values().size(), scl.nonNullSize());
-    Assert.assertFalse(scl.isEmpty());
+    assertFalse(scl.isEmpty());
 
     // Compute if absent for an unpopulated index.
     scl.computeIfAbsent(4, k -> newObject);
-    Assert.assertEquals(scl.get(4), newObject);
+    assertEquals(scl.get(4), newObject);
     assertEquals(scl.size(), 8);
     assertEquals(scl.nonNullSize(), 4);
     assertEquals(scl.values().size(), scl.nonNullSize());
-    Assert.assertFalse(scl.isEmpty());
+    assertFalse(scl.isEmpty());
 
     // Go back to the initial state...
     scl.clear();
     assertEquals(scl.size(), 0);
     assertEquals(scl.nonNullSize(), 0);
     assertEquals(scl.values().size(), 0);
-    Assert.assertTrue(scl.isEmpty());
+    assertTrue(scl.isEmpty());
   }
 }

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/utils/SparseConcurrentListTest.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/utils/SparseConcurrentListTest.java
@@ -1,0 +1,58 @@
+package com.linkedin.venice.utils;
+
+import static org.testng.Assert.assertEquals;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class SparseConcurrentListTest {
+  @Test
+  public void testNonNullSize() {
+    SparseConcurrentList<Object> scl = new SparseConcurrentList<>();
+    assertEquals(scl.size(), 0);
+    assertEquals(scl.nonNullSize(), 0);
+    assertEquals(scl.values().size(), 0);
+
+    scl.set(5, new Object());
+    Assert.assertNotNull(5);
+    assertEquals(scl.size(), 6);
+    assertEquals(scl.nonNullSize(), 1);
+    assertEquals(scl.values().size(), 1);
+
+    scl.set(2, new Object());
+    Assert.assertNotNull(2);
+    assertEquals(scl.size(), 6);
+    assertEquals(scl.nonNullSize(), 2);
+    assertEquals(scl.values().size(), 2);
+
+    scl.remove(3);
+    Assert.assertNull(scl.get(3));
+    assertEquals(scl.size(), 6);
+    assertEquals(scl.nonNullSize(), 2);
+    assertEquals(scl.values().size(), 2);
+
+    scl.remove(2);
+    Assert.assertNull(scl.get(2));
+    assertEquals(scl.size(), 6);
+    assertEquals(scl.nonNullSize(), 1);
+    assertEquals(scl.values().size(), 1);
+
+    Collection<Object> objectsToAppend = new ArrayList<>();
+    objectsToAppend.add(new Object());
+    objectsToAppend.add(new Object());
+    scl.addAll(objectsToAppend);
+    Assert.assertNotNull(6);
+    Assert.assertNotNull(7);
+    assertEquals(scl.size(), 8);
+    assertEquals(scl.nonNullSize(), 3);
+    assertEquals(scl.values().size(), 3);
+
+    scl.clear();
+    assertEquals(scl.size(), 0);
+    assertEquals(scl.nonNullSize(), 0);
+    assertEquals(scl.values().size(), 0);
+  }
+}


### PR DESCRIPTION
The issue could happen in a scenario where the server lost its only partition of a store, the storage engine got closed, and then regained a partition for the store. See the JavaDoc of the new unit test for more details.

## How was this PR tested?
New unit test.

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.