### PR TITLE
[server] Add metric for poll count only if it returns non-zero record count

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ConsumptionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ConsumptionTask.java
@@ -119,11 +119,11 @@ class ConsumptionTask implements Runnable {
         polledPubSubMessages = pollFunction.get();
         lastSuccessfulPollTimestamp = System.currentTimeMillis();
         stats.recordPollRequestLatency(lastSuccessfulPollTimestamp - beforePollingTimeStamp);
+        stats.recordPollResultNum(polledPubSubMessagesCount);
         payloadBytesConsumedInOnePoll = 0;
         polledPubSubMessagesCount = 0;
         if (!polledPubSubMessages.isEmpty()) {
           beforeProducingToWriteBufferTimestamp = System.currentTimeMillis();
-          stats.recordPollResultNum(polledPubSubMessagesCount);
           for (Map.Entry<PubSubTopicPartition, List<PubSubMessage<KafkaKey, KafkaMessageEnvelope, Long>>> entry: polledPubSubMessages
               .entrySet()) {
             PubSubTopicPartition pubSubTopicPartition = entry.getKey();
@@ -145,6 +145,7 @@ class ConsumptionTask implements Runnable {
           }
           stats.recordConsumerRecordsProducingToWriterBufferLatency(
               LatencyUtils.getElapsedTimeInMs(beforeProducingToWriteBufferTimestamp));
+          stats.recordNonZeroPollResultNum(polledPubSubMessagesCount);
           bandwidthThrottler.accept(payloadBytesConsumedInOnePoll);
           recordsThrottler.accept(polledPubSubMessagesCount);
           cleaner.unsubscribe(topicPartitionsToUnsub);

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ConsumptionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ConsumptionTask.java
@@ -119,11 +119,11 @@ class ConsumptionTask implements Runnable {
         polledPubSubMessages = pollFunction.get();
         lastSuccessfulPollTimestamp = System.currentTimeMillis();
         stats.recordPollRequestLatency(lastSuccessfulPollTimestamp - beforePollingTimeStamp);
-        stats.recordPollResultNum(polledPubSubMessagesCount);
         payloadBytesConsumedInOnePoll = 0;
         polledPubSubMessagesCount = 0;
         if (!polledPubSubMessages.isEmpty()) {
           beforeProducingToWriteBufferTimestamp = System.currentTimeMillis();
+          stats.recordPollResultNum(polledPubSubMessagesCount);
           for (Map.Entry<PubSubTopicPartition, List<PubSubMessage<KafkaKey, KafkaMessageEnvelope, Long>>> entry: polledPubSubMessages
               .entrySet()) {
             PubSubTopicPartition pubSubTopicPartition = entry.getKey();

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/KafkaConsumerServiceStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/KafkaConsumerServiceStats.java
@@ -16,6 +16,8 @@ public class KafkaConsumerServiceStats extends AbstractVeniceStats {
   private final Sensor pollRequestSensor;
   private final Sensor pollRequestLatencySensor;
   private final Sensor pollResultNumSensor;
+  private final Sensor pollNonZeroResultNumSensor;
+
   private final Sensor pollRequestError;
   private final Sensor consumerRecordsProducingToWriterBufferLatencySensor;
   private final Sensor detectedDeletedTopicNumSensor;
@@ -50,6 +52,7 @@ public class KafkaConsumerServiceStats extends AbstractVeniceStats {
         new Gauge(getMaxElapsedTimeSinceLastPollInConsumerPool.getAsLong()));
     // consumer record number per second returned by Kafka consumer poll.
     pollResultNumSensor = registerSensor("consumer_poll_result_num", new Avg(), new Total());
+    pollNonZeroResultNumSensor = registerSensor("consumer_poll_non_zero_result_num", new Avg(), new Total());
     pollRequestError = registerSensor("consumer_poll_error", new OccurrenceRate());
     // To measure 'put' latency of consumer records blocking queue
     consumerRecordsProducingToWriterBufferLatencySensor =
@@ -90,6 +93,10 @@ public class KafkaConsumerServiceStats extends AbstractVeniceStats {
 
   public void recordPollResultNum(int count) {
     pollResultNumSensor.record(count);
+  }
+
+  public void recordNonZeroPollResultNum(int count) {
+    pollNonZeroResultNumSensor.record(count);
   }
 
   public void recordConsumerRecordsProducingToWriterBufferLatency(double latency) {


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Add metric for poll count only if it returns non-zero record count
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
If some consumer poll returns empty record count, the metric will record 0 which will affect the avg count for consumers which are actually polling non-zero records. For a clearer view of the poll result, this PR will add another metric which will record only when there is a non-zero results from the poll

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
CI
## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.