### PR TITLE
[server][test] Message header triggered new KME schema registration i…

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/DaVinciBackend.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/DaVinciBackend.java
@@ -242,7 +242,8 @@ public class DaVinciBackend implements Closeable {
           true,
           // TODO: consider how/if a repair task would be valid for Davinci users?
           null,
-          pubSubClientsFactory);
+          pubSubClientsFactory,
+          Optional.empty());
 
       ingestionService.start();
       ingestionService.addIngestionNotifier(ingestionListener);

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
@@ -22,6 +22,7 @@ import static com.linkedin.venice.ConfigKeys.KAFKA_PRODUCER_METRICS;
 import static com.linkedin.venice.ConfigKeys.KAFKA_READ_ONLY_ADMIN_CLASS;
 import static com.linkedin.venice.ConfigKeys.KAFKA_WRITE_ONLY_ADMIN_CLASS;
 import static com.linkedin.venice.ConfigKeys.KEY_VALUE_PROFILING_ENABLED;
+import static com.linkedin.venice.ConfigKeys.KME_REGISTRATION_FROM_MESSAGE_HEADER_ENABLED;
 import static com.linkedin.venice.ConfigKeys.LEADER_FOLLOWER_STATE_TRANSITION_THREAD_POOL_STRATEGY;
 import static com.linkedin.venice.ConfigKeys.LISTENER_HOSTNAME;
 import static com.linkedin.venice.ConfigKeys.LISTENER_PORT;
@@ -396,6 +397,7 @@ public class VeniceServerConfig extends VeniceClusterConfig {
 
   private final boolean schemaPresenceCheckEnabled;
   private final boolean systemSchemaInitializationAtStartTimeEnabled;
+  private final boolean isKMERegistrationFromMessageHeaderEnabled;
   private final String localControllerUrl;
   private final String localControllerD2ServiceName;
   private final String localD2ZkHost;
@@ -645,6 +647,8 @@ public class VeniceServerConfig extends VeniceClusterConfig {
     schemaPresenceCheckEnabled = serverProperties.getBoolean(SERVER_SCHEMA_PRESENCE_CHECK_ENABLED, true);
     systemSchemaInitializationAtStartTimeEnabled =
         serverProperties.getBoolean(SYSTEM_SCHEMA_INITIALIZATION_AT_START_TIME_ENABLED, false);
+    isKMERegistrationFromMessageHeaderEnabled =
+        serverProperties.getBoolean(KME_REGISTRATION_FROM_MESSAGE_HEADER_ENABLED, false);
     localControllerUrl = serverProperties.getString(LOCAL_CONTROLLER_URL, "");
     localControllerD2ServiceName = serverProperties.getString(LOCAL_CONTROLLER_D2_SERVICE_NAME, "");
     localD2ZkHost = serverProperties.getString(LOCAL_D2_ZK_HOST, "");
@@ -1251,5 +1255,9 @@ public class VeniceServerConfig extends VeniceClusterConfig {
 
   public int getIngestionTaskMaxIdleCount() {
     return ingestionTaskMaxIdleCount;
+  }
+
+  public boolean isKMERegistrationFromMessageHeaderEnabled() {
+    return isKMERegistrationFromMessageHeaderEnabled;
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/isolated/IsolatedIngestionServer.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/isolated/IsolatedIngestionServer.java
@@ -775,7 +775,8 @@ public class IsolatedIngestionServer extends AbstractVeniceService {
         Optional.empty(),
         isDaVinciClient,
         repairService,
-        pubSubClientsFactory);
+        pubSubClientsFactory,
+        sslFactory);
     storeIngestionService.start();
     storeIngestionService.addIngestionNotifier(new IsolatedIngestionNotifier(this));
     ingestionBackend = new DefaultIngestionBackend(storageMetadataService, storeIngestionService, storageService);

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionService.java
@@ -18,6 +18,7 @@ import static com.linkedin.venice.kafka.TopicManager.DEFAULT_KAFKA_OPERATION_TIM
 import static java.lang.Thread.currentThread;
 import static java.lang.Thread.sleep;
 
+import com.google.common.collect.ImmutableMap;
 import com.linkedin.davinci.compression.StorageEngineBackedCompressorFactory;
 import com.linkedin.davinci.config.VeniceConfigLoader;
 import com.linkedin.davinci.config.VeniceServerConfig;
@@ -74,11 +75,14 @@ import com.linkedin.venice.pubsub.adapter.kafka.producer.SharedKafkaProducerAdap
 import com.linkedin.venice.pubsub.api.PubSubMessageDeserializer;
 import com.linkedin.venice.schema.SchemaEntry;
 import com.linkedin.venice.schema.SchemaReader;
+import com.linkedin.venice.security.SSLFactory;
+import com.linkedin.venice.serialization.avro.AvroProtocolDefinition;
 import com.linkedin.venice.serialization.avro.InternalAvroSpecificSerializer;
 import com.linkedin.venice.serialization.avro.KafkaValueSerializer;
 import com.linkedin.venice.serialization.avro.OptimizedKafkaValueSerializer;
 import com.linkedin.venice.service.AbstractVeniceService;
 import com.linkedin.venice.service.ICProvider;
+import com.linkedin.venice.system.store.ControllerClientBackedSystemSchemaInitializer;
 import com.linkedin.venice.system.store.MetaStoreWriter;
 import com.linkedin.venice.throttle.EventThrottler;
 import com.linkedin.venice.utils.ComplementSet;
@@ -119,8 +123,10 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.BiConsumer;
 import java.util.function.BooleanSupplier;
 import java.util.function.Consumer;
+import org.apache.avro.Schema;
 import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.common.protocol.SecurityProtocol;
 import org.apache.logging.log4j.LogManager;
@@ -205,6 +211,9 @@ public class KafkaStoreIngestionService extends AbstractVeniceService implements
   private final ResourceAutoClosableLockManager<String> topicLockManager;
 
   private final PubSubTopicRepository pubSubTopicRepository = new PubSubTopicRepository();
+  private Optional<SSLFactory> sslFactory;
+
+  private KafkaValueSerializer kafkaValueSerializer;
 
   public KafkaStoreIngestionService(
       StorageEngineRepository storageEngineRepository,
@@ -227,7 +236,8 @@ public class KafkaStoreIngestionService extends AbstractVeniceService implements
       Optional<ObjectCacheBackend> cacheBackend,
       boolean isDaVinciClient,
       RemoteIngestionRepairService remoteIngestionRepairService,
-      PubSubClientsFactory pubSubClientsFactory) {
+      PubSubClientsFactory pubSubClientsFactory,
+      Optional<SSLFactory> sslFactory) {
     this.cacheBackend = cacheBackend;
     this.storageMetadataService = storageMetadataService;
     this.metadataRepo = metadataRepo;
@@ -239,6 +249,7 @@ public class KafkaStoreIngestionService extends AbstractVeniceService implements
     this.compressorFactory = compressorFactory;
     // Each topic that has any partition ingested by this class has its own lock.
     this.topicLockManager = new ResourceAutoClosableLockManager<>(ReentrantLock::new);
+    this.sslFactory = sslFactory;
 
     customizedViewFuture.ifPresent(future -> future.thenApply(cv -> this.customizedViewRepository = cv));
     helixInstanceFuture.ifPresent(future -> future.thenApply(helix -> this.helixInstanceConfigRepository = helix));
@@ -399,8 +410,42 @@ public class KafkaStoreIngestionService extends AbstractVeniceService implements
               + "may not be killed if admin helix messaging channel is disabled");
     }
 
-    // TODO: Wire configs into these params
-    KafkaValueSerializer kafkaValueSerializer = new OptimizedKafkaValueSerializer();
+    /**
+     * Register a callback function to handle the case when a new KME value schema is encountered when the server
+     * consumes messages from Kafka.
+     */
+    BiConsumer<Integer, Schema> newSchemaEncountered = (schemaId, schema) -> {
+      LOGGER.info("Encountered a new KME value schema (id = {}), proceed to register", schemaId);
+      try {
+        ControllerClientBackedSystemSchemaInitializer schemaInitializer =
+            new ControllerClientBackedSystemSchemaInitializer(
+                AvroProtocolDefinition.KAFKA_MESSAGE_ENVELOPE,
+                serverConfig.getSystemSchemaClusterName(),
+                null,
+                null,
+                false,
+                sslFactory,
+                serverConfig.getLocalControllerUrl(),
+                serverConfig.getLocalControllerD2ServiceName(),
+                serverConfig.getLocalD2ZkHost(),
+                false);
+
+        schemaInitializer.execute(ImmutableMap.of(schemaId, schema));
+      } catch (VeniceException e) {
+        LOGGER.error(
+            "Exception in registering '{}' schema version '{}'",
+            AvroProtocolDefinition.KAFKA_MESSAGE_ENVELOPE.name(),
+            schemaId,
+            e);
+        throw e;
+      }
+    };
+
+    // Don't apply newSchemaEncountered callbacks for da vinci client.
+    kafkaValueSerializer = (!isDaVinciClient && serverConfig.isKMERegistrationFromMessageHeaderEnabled())
+        ? new OptimizedKafkaValueSerializer(newSchemaEncountered)
+        : new OptimizedKafkaValueSerializer();
+
     kafkaMessageEnvelopeSchemaReader.ifPresent(kafkaValueSerializer::setSchemaReader);
     PubSubMessageDeserializer pubSubDeserializer = new PubSubMessageDeserializer(
         kafkaValueSerializer,
@@ -1357,5 +1402,10 @@ public class KafkaStoreIngestionService extends AbstractVeniceService implements
           new PubSubTopicPartitionImpl(pubSubTopicRepository.getTopic(topic), partitionId));
     }
     LOGGER.info("Offset reset to beginning - Kafka Partition: {}-{}.", topic, partitionId);
+  }
+
+  // For testing purpose only.
+  public KafkaValueSerializer getKafkaValueSerializer() {
+    return kafkaValueSerializer;
   }
 }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionServiceTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionServiceTest.java
@@ -167,7 +167,8 @@ public abstract class KafkaStoreIngestionServiceTest {
         Optional.empty(),
         false,
         null,
-        mockPubSubClientsFactory);
+        mockPubSubClientsFactory,
+        Optional.empty());
 
     String mockStoreName = "test";
     String mockSimilarStoreName = "testTest";
@@ -250,7 +251,8 @@ public abstract class KafkaStoreIngestionServiceTest {
         Optional.empty(),
         false,
         null,
-        mockPubSubClientsFactory);
+        mockPubSubClientsFactory,
+        Optional.empty());
     String topic1 = "test-store_v1";
     String topic2 = "test-store_v2";
     String invalidTopic = "invalid-store_v1";
@@ -337,7 +339,8 @@ public abstract class KafkaStoreIngestionServiceTest {
         Optional.empty(),
         false,
         null,
-        mockPubSubClientsFactory);
+        mockPubSubClientsFactory,
+        Optional.empty());
     String topicName = "test-store_v1";
     String storeName = Version.parseStoreFromKafkaTopicName(topicName);
     Store mockStore = new ZKStore(
@@ -401,7 +404,8 @@ public abstract class KafkaStoreIngestionServiceTest {
         Optional.empty(),
         false,
         null,
-        mockPubSubClientsFactory);
+        mockPubSubClientsFactory,
+        Optional.empty());
     String topicName = "test-store_v1";
     String storeName = Version.parseStoreFromKafkaTopicName(topicName);
     Store mockStore = new ZKStore(
@@ -463,7 +467,8 @@ public abstract class KafkaStoreIngestionServiceTest {
         Optional.empty(),
         false,
         null,
-        mockPubSubClientsFactory);
+        mockPubSubClientsFactory,
+        Optional.empty());
     String storeName = "test-store";
     String otherStoreName = "test-store2";
     Store mockStore = new ZKStore(

--- a/internal/venice-common/src/main/java/com/linkedin/venice/serialization/avro/InternalAvroSpecificSerializer.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/serialization/avro/InternalAvroSpecificSerializer.java
@@ -374,9 +374,11 @@ public class InternalAvroSpecificSerializer<SPECIFIC_RECORD extends SpecificReco
     VeniceSpecificDatumReader<SPECIFIC_RECORD> specificDatumReader =
         protocolVersionToReader.computeIfAbsent(protocolVersion, index -> {
           newSchemaEncountered.accept(protocolVersion, providedProtocolSchema);
+
+          // Add a new datum reader for the protocol version. Notice that in that case that newSchemaEncountered is
+          // an empty lambda, the reader will still be added locally.
           return cacheDatumReader(protocolVersion, providedProtocolSchema);
         });
-
     return deserialize(bytes, specificDatumReader, reuse);
   }
 

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/helix/TestServerKMERegistrationFromMessageHeader.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/helix/TestServerKMERegistrationFromMessageHeader.java
@@ -1,0 +1,139 @@
+package com.linkedin.venice.helix;
+
+import static com.linkedin.venice.ConfigKeys.KME_REGISTRATION_FROM_MESSAGE_HEADER_ENABLED;
+
+import com.linkedin.venice.compression.CompressionStrategy;
+import com.linkedin.venice.controllerapi.ControllerClient;
+import com.linkedin.venice.controllerapi.VersionCreationResponse;
+import com.linkedin.venice.integration.utils.ServiceFactory;
+import com.linkedin.venice.integration.utils.VeniceClusterWrapper;
+import com.linkedin.venice.integration.utils.VeniceControllerWrapper;
+import com.linkedin.venice.integration.utils.VeniceServerWrapper;
+import com.linkedin.venice.meta.Version;
+import com.linkedin.venice.pubsub.PubSubProducerAdapterFactory;
+import com.linkedin.venice.serialization.VeniceKafkaSerializer;
+import com.linkedin.venice.serialization.avro.AvroProtocolDefinition;
+import com.linkedin.venice.serialization.avro.KafkaValueSerializer;
+import com.linkedin.venice.serialization.avro.VeniceAvroKafkaSerializer;
+import com.linkedin.venice.utils.IntegrationTestPushUtils;
+import com.linkedin.venice.utils.TestUtils;
+import com.linkedin.venice.utils.Utils;
+import com.linkedin.venice.writer.VeniceWriter;
+import com.linkedin.venice.writer.VeniceWriterOptions;
+import java.util.HashMap;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+
+public class TestServerKMERegistrationFromMessageHeader {
+  private static final Logger LOGGER = LogManager.getLogger(TestServerKMERegistrationFromMessageHeader.class);
+
+  private VeniceClusterWrapper cluster;
+  protected ControllerClient controllerClient;
+  int replicaFactor = 1;
+  int numOfController = 1;
+  int numOfRouters = 1;
+  int partitionSize = 1000;
+  private static final int TEST_TIMEOUT = 90_000; // ms
+  private String storeName;
+  private String storeVersion;
+  private static final String KEY_SCHEMA = "\"string\"";
+  private static final String VALUE_SCHEMA = "\"string\"";
+  private VeniceWriter<Object, Object, Object> veniceWriter;
+  private VeniceKafkaSerializer keySerializer;
+  private VeniceServerWrapper server;
+  private String clusterName;
+
+  @BeforeClass
+  public void setUp() {
+    cluster =
+        ServiceFactory.getVeniceCluster(numOfController, 0, numOfRouters, replicaFactor, partitionSize, false, false);
+    clusterName = cluster.getClusterName();
+
+    Properties serverProperties = new Properties();
+    Properties serverFeatureProperties = new Properties();
+    serverProperties.put(KME_REGISTRATION_FROM_MESSAGE_HEADER_ENABLED, true);
+    server = cluster.addVeniceServer(serverFeatureProperties, serverProperties);
+  }
+
+  @AfterClass(alwaysRun = true)
+  public void cleanUp() {
+    Utils.closeQuietlyWithErrorLogged(cluster);
+  }
+
+  @Test(timeOut = TEST_TIMEOUT)
+  public void testServerKMERegistrationFromMessageHeader() {
+    storeName = Utils.getUniqueString("venice-store");
+    cluster.getNewStore(storeName, KEY_SCHEMA, VALUE_SCHEMA);
+    VersionCreationResponse creationResponse = cluster.getNewVersion(storeName, false);
+
+    storeVersion = creationResponse.getKafkaTopic();
+    int pushVersion = Version.parseVersionFromKafkaTopicName(storeVersion);
+    PubSubProducerAdapterFactory pubSubProducerAdapterFactory =
+        cluster.getPubSubBrokerWrapper().getPubSubClientsFactory().getProducerAdapterFactory();
+    keySerializer = new VeniceAvroKafkaSerializer(KEY_SCHEMA);
+
+    veniceWriter =
+        IntegrationTestPushUtils.getVeniceWriterFactory(cluster.getPubSubBrokerWrapper(), pubSubProducerAdapterFactory)
+            .createVeniceWriter(new VeniceWriterOptions.Builder(storeVersion).setKeySerializer(keySerializer).build());
+
+    VeniceControllerWrapper leaderController = cluster.getLeaderVeniceController();
+    KafkaValueSerializer valueSerializer =
+        server.getVeniceServer().getKafkaStoreIngestionService().getKafkaValueSerializer();
+
+    HelixReadWriteSchemaRepositoryAdapter adapter =
+        (HelixReadWriteSchemaRepositoryAdapter) (leaderController.getVeniceHelixAdmin()
+            .getHelixVeniceClusterResources(clusterName)
+            .getSchemaRepository());
+    HelixReadWriteSchemaRepository repo =
+        (HelixReadWriteSchemaRepository) adapter.getReadWriteRegularStoreSchemaRepository();
+
+    // Wait until the latest schema appears in child colo's schema repository (ZK).
+    TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, true, true, () -> {
+      Assert.assertEquals(
+          repo.getValueSchema(
+              AvroProtocolDefinition.KAFKA_MESSAGE_ENVELOPE.getSystemStoreName(),
+              AvroProtocolDefinition.KAFKA_MESSAGE_ENVELOPE.getCurrentProtocolVersion()).getId(),
+          AvroProtocolDefinition.KAFKA_MESSAGE_ENVELOPE.getCurrentProtocolVersion());
+    });
+
+    // Remove the latest schema from child controller's local value serializer and remove it from child colo's schema
+    // repository (ZK).
+    repo.removeValueSchema(
+        AvroProtocolDefinition.KAFKA_MESSAGE_ENVELOPE.getSystemStoreName(),
+        AvroProtocolDefinition.KAFKA_MESSAGE_ENVELOPE.getCurrentProtocolVersion());
+    valueSerializer.removeAllSchemas();
+    LOGGER.info("all schemas are removed");
+
+    /*
+     * Sending a start of segment control message will the latest schema in its header.
+     * Venice server, when it encounters the new schema in the message header and when KME_REGISTRATION_FROM_MESSAGE_HEADER_ENABLED
+     * is enabled, registers the new schema into the child colo's schema repo as well as add to its local serializer.
+     */
+    veniceWriter.broadcastStartOfPush(false, false, CompressionStrategy.NO_OP, new HashMap<>());
+    veniceWriter.broadcastEndOfPush(new HashMap<>());
+
+    // Verify that new schema is registered in the child colo's schema repo.
+    TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, true, true, () -> {
+      Assert.assertEquals(
+          repo.getValueSchema(
+              AvroProtocolDefinition.KAFKA_MESSAGE_ENVELOPE.getSystemStoreName(),
+              AvroProtocolDefinition.KAFKA_MESSAGE_ENVELOPE.getCurrentProtocolVersion()).getId(),
+          AvroProtocolDefinition.KAFKA_MESSAGE_ENVELOPE.getCurrentProtocolVersion());
+    });
+
+    // Verify that empty push can be finished successfully and a new version is created.
+    String controllerUrl = cluster.getAllControllersURLs();
+    TestUtils.waitForNonDeterministicCompletion(30, TimeUnit.SECONDS, () -> {
+      int currentVersion =
+          ControllerClient.getStore(controllerUrl, cluster.getClusterName(), storeName).getStore().getCurrentVersion();
+      return currentVersion == pushVersion;
+    });
+  }
+}

--- a/services/venice-server/src/main/java/com/linkedin/venice/server/VeniceServer.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/server/VeniceServer.java
@@ -381,7 +381,8 @@ public class VeniceServer {
         Optional.empty(),
         false,
         remoteIngestionRepairService,
-        pubSubClientsFactory);
+        pubSubClientsFactory,
+        sslFactory);
     this.kafkaStoreIngestionService.addMetaSystemStoreReplicaStatusNotifier();
 
     this.diskHealthCheckService = new DiskHealthCheckService(


### PR DESCRIPTION
…n venice server

This is a follow-up change to 0b5af23 and it is also part of the solution to remove deployment order for KafkaMessageEnvelope (KME) value schema. For Venice servers, by design, we apply the same strategy as controllers, i.e., when servers find an unknown KME schema from the message header, they need to request the system cluster leader controller to register the new schema into local region system store.

This change enables Venice servers to perform the unknown KME schemas registration work when it discovers. At its core, it leverages the existing functionalities from the ControllerClientBackedSystemSchemaInitializer class for the implementation. A new server config is introduced and a new integration test is added to verify its correctness.


## How was this PR tested?

CI passed.
Add a new integration test.

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.