### PR TITLE
[compat][controller][admintool] Added store-level max compaction lag support

### DIFF
--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/AdminTool.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/AdminTool.java
@@ -1122,6 +1122,7 @@ public class AdminTool {
     genericParam(cmd, Arg.STORAGE_PERSONA, s -> s, p -> params.setStoragePersona(p), argSet);
     integerParam(cmd, Arg.LATEST_SUPERSET_SCHEMA_ID, p -> params.setLatestSupersetSchemaId(p), argSet);
     longParam(cmd, Arg.MIN_COMPACTION_LAG_SECONDS, p -> params.setMinCompactionLagSeconds(p), argSet);
+    longParam(cmd, Arg.MAX_COMPACTION_LAG_SECONDS, p -> params.setMaxCompactionLagSeconds(p), argSet);
 
     /**
      * {@link Arg#REPLICATE_ALL_CONFIGS} doesn't require parameters; once specified, it means true.

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/Arg.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/Arg.java
@@ -236,6 +236,9 @@ public enum Arg {
   NON_INTERACTIVE("non-interactive", "nita", false, "non-interactive mode"),
   MIN_COMPACTION_LAG_SECONDS(
       "min-compaction-lag-seconds", "mcls", true, "Min compaction lag seconds for version topic of hybrid stores"
+  ),
+  MAX_COMPACTION_LAG_SECONDS(
+      "max-compaction-lag-seconds", "mxcls", true, "Max compaction lag seconds for version topic of hybrid stores"
   ), PARTITION("partition", "p", true, "Partition Id"),
   INTERVAL(
       "interval", "itv", true,

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/Command.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/Command.java
@@ -57,6 +57,7 @@ import static com.linkedin.venice.Arg.KEY;
 import static com.linkedin.venice.Arg.KEY_SCHEMA;
 import static com.linkedin.venice.Arg.LARGEST_USED_VERSION_NUMBER;
 import static com.linkedin.venice.Arg.LATEST_SUPERSET_SCHEMA_ID;
+import static com.linkedin.venice.Arg.MAX_COMPACTION_LAG_SECONDS;
 import static com.linkedin.venice.Arg.MESSAGE_COUNT;
 import static com.linkedin.venice.Arg.MIGRATION_PUSH_STRATEGY;
 import static com.linkedin.venice.Arg.MIN_COMPACTION_LAG_SECONDS;
@@ -227,7 +228,8 @@ public enum Command {
           ETLED_PROXY_USER_ACCOUNT, NATIVE_REPLICATION_ENABLED, PUSH_STREAM_SOURCE_ADDRESS,
           BACKUP_VERSION_RETENTION_DAY, REPLICATION_FACTOR, NATIVE_REPLICATION_SOURCE_FABRIC, REPLICATE_ALL_CONFIGS,
           ACTIVE_ACTIVE_REPLICATION_ENABLED, REGIONS_FILTER, DISABLE_META_STORE, DISABLE_DAVINCI_PUSH_STATUS_STORE,
-          STORAGE_PERSONA, STORE_VIEW_CONFIGS, LATEST_SUPERSET_SCHEMA_ID, MIN_COMPACTION_LAG_SECONDS }
+          STORAGE_PERSONA, STORE_VIEW_CONFIGS, LATEST_SUPERSET_SCHEMA_ID, MIN_COMPACTION_LAG_SECONDS,
+          MAX_COMPACTION_LAG_SECONDS }
   ),
   UPDATE_CLUSTER_CONFIG(
       "update-cluster-config", "Update live cluster configs", new Arg[] { URL, CLUSTER },

--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerApiConstants.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerApiConstants.java
@@ -219,5 +219,7 @@ public class ControllerApiConstants {
 
   public static final String MIN_COMPACTION_LAG_SECONDS = "min_compaction_lag_seconds";
 
+  public static final String MAX_COMPACTION_LAG_SECONDS = "max_compaction_lag_seconds";
+
   public static final String HEARTBEAT_TIMESTAMP = "heartbeat_timestamp";
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/UpdateStoreQueryParams.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/UpdateStoreQueryParams.java
@@ -25,6 +25,7 @@ import static com.linkedin.venice.controllerapi.ControllerApiConstants.HYBRID_ST
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.INCREMENTAL_PUSH_ENABLED;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.LARGEST_USED_VERSION_NUMBER;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.LATEST_SUPERSET_SCHEMA_ID;
+import static com.linkedin.venice.controllerapi.ControllerApiConstants.MAX_COMPACTION_LAG_SECONDS;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.MIGRATION_DUPLICATE_STORE;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.MIN_COMPACTION_LAG_SECONDS;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.NATIVE_REPLICATION_ENABLED;
@@ -652,6 +653,14 @@ public class UpdateStoreQueryParams extends QueryParams {
 
   public UpdateStoreQueryParams setDisableStoreView() {
     return (UpdateStoreQueryParams) add(DISABLE_STORE_VIEW, true);
+  }
+
+  public UpdateStoreQueryParams setMaxCompactionLagSeconds(long maxCompactionLagSeconds) {
+    return putLong(MAX_COMPACTION_LAG_SECONDS, maxCompactionLagSeconds);
+  }
+
+  public Optional<Long> getMaxCompactionLagSeconds() {
+    return getLong(MAX_COMPACTION_LAG_SECONDS);
   }
 
   // ***************** above this line are getters and setters *****************

--- a/internal/venice-common/src/main/java/com/linkedin/venice/kafka/TopicManager.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/kafka/TopicManager.java
@@ -2,6 +2,7 @@ package com.linkedin.venice.kafka;
 
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
+import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.kafka.partitionoffset.PartitionOffsetFetcher;
 import com.linkedin.venice.kafka.partitionoffset.PartitionOffsetFetcherFactory;
 import com.linkedin.venice.meta.HybridStoreConfig;
@@ -250,8 +251,12 @@ public class TopicManager implements Closeable {
     long startTime = System.currentTimeMillis();
     long deadlineMs =
         startTime + (useFastKafkaOperationTimeout ? FAST_KAFKA_OPERATION_TIMEOUT_MS : kafkaOperationTimeoutMs);
-    PubSubTopicConfiguration pubSubTopicConfiguration =
-        new PubSubTopicConfiguration(Optional.of(retentionTimeMs), logCompaction, minIsr, topicMinLogCompactionLagMs);
+    PubSubTopicConfiguration pubSubTopicConfiguration = new PubSubTopicConfiguration(
+        Optional.of(retentionTimeMs),
+        logCompaction,
+        minIsr,
+        topicMinLogCompactionLagMs,
+        Optional.empty());
     logger.info(
         "Creating topic: {} partitions: {} replication: {}, configuration: {}",
         topicName,
@@ -339,7 +344,7 @@ public class TopicManager implements Closeable {
   }
 
   public synchronized void updateTopicCompactionPolicy(PubSubTopic topic, boolean expectedLogCompacted) {
-    updateTopicCompactionPolicy(topic, expectedLogCompacted, -1);
+    updateTopicCompactionPolicy(topic, expectedLogCompacted, -1, Optional.empty());
   }
 
   /**
@@ -353,31 +358,49 @@ public class TopicManager implements Closeable {
   public synchronized void updateTopicCompactionPolicy(
       PubSubTopic topic,
       boolean expectedLogCompacted,
-      long minLogCompactionLagMs) throws PubSubTopicDoesNotExistException {
+      long minLogCompactionLagMs,
+      Optional<Long> maxLogCompactionLagMs) throws PubSubTopicDoesNotExistException {
     long expectedMinLogCompactionLagMs = 0l;
+    Optional<Long> expectedMaxLogCompactionLagMs = maxLogCompactionLagMs;
+
     if (expectedLogCompacted) {
       if (minLogCompactionLagMs > 0) {
         expectedMinLogCompactionLagMs = minLogCompactionLagMs;
       } else {
         expectedMinLogCompactionLagMs = topicMinLogCompactionLagMs;
       }
+      expectedMaxLogCompactionLagMs = maxLogCompactionLagMs;
+
+      if (expectedMaxLogCompactionLagMs.isPresent()
+          && expectedMaxLogCompactionLagMs.get() < expectedMinLogCompactionLagMs) {
+        throw new VeniceException(
+            "'expectedMaxLogCompactionLagMs': " + expectedMaxLogCompactionLagMs.get()
+                + " shouldn't be smaller than 'expectedMinLogCompactionLagMs': " + expectedMinLogCompactionLagMs
+                + " when updating compaction policy for topic: " + topic);
+      }
     }
 
     PubSubTopicConfiguration pubSubTopicConfiguration = getTopicConfig(topic);
     boolean currentLogCompacted = pubSubTopicConfiguration.isLogCompacted();
     long currentMinLogCompactionLagMs = pubSubTopicConfiguration.minLogCompactionLagMs();
+    Optional<Long> currentMaxLogCompactionLagMs = pubSubTopicConfiguration.getMaxLogCompactionLagMs();
     if (expectedLogCompacted != currentLogCompacted
-        || expectedLogCompacted && expectedMinLogCompactionLagMs != currentMinLogCompactionLagMs) {
+        || expectedLogCompacted && (expectedMinLogCompactionLagMs != currentMinLogCompactionLagMs
+            || expectedMaxLogCompactionLagMs.equals(currentMaxLogCompactionLagMs))) {
       pubSubTopicConfiguration.setLogCompacted(expectedLogCompacted);
       pubSubTopicConfiguration.setMinLogCompactionLagMs(expectedMinLogCompactionLagMs);
+      pubSubTopicConfiguration.setMaxLogCompactionLagMs(expectedMaxLogCompactionLagMs);
       pubSubWriteOnlyAdminAdapter.get().setTopicConfig(topic, pubSubTopicConfiguration);
       logger.info(
-          "Kafka compaction policy for topic: {} has been updated from {} to {}, min compaction lag updated from {} to {}",
+          "Kafka compaction policy for topic: {} has been updated from {} to {}, min compaction lag updated from"
+              + " {} to {}, max compaction lag updated from {} to {}",
           topic,
           currentLogCompacted,
           expectedLogCompacted,
           currentMinLogCompactionLagMs,
-          expectedMinLogCompactionLagMs);
+          expectedMinLogCompactionLagMs,
+          currentMaxLogCompactionLagMs.isPresent() ? currentMaxLogCompactionLagMs.get() : " not set",
+          expectedMaxLogCompactionLagMs.isPresent() ? expectedMaxLogCompactionLagMs.get() : " not set");
     }
   }
 
@@ -389,6 +412,11 @@ public class TopicManager implements Closeable {
   public long getTopicMinLogCompactionLagMs(PubSubTopic topicName) {
     PubSubTopicConfiguration topicProperties = getCachedTopicConfig(topicName);
     return topicProperties.minLogCompactionLagMs();
+  }
+
+  public Optional<Long> getTopicMaxLogCompactionLagMs(PubSubTopic topicName) {
+    PubSubTopicConfiguration topicProperties = getCachedTopicConfig(topicName);
+    return topicProperties.getMaxLogCompactionLagMs();
   }
 
   public boolean updateTopicMinInSyncReplica(PubSubTopic topicName, int minISR)

--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/ReadOnlyStore.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/ReadOnlyStore.java
@@ -1309,6 +1309,16 @@ public class ReadOnlyStore implements Store {
   }
 
   @Override
+  public long getMaxCompactionLagSeconds() {
+    return this.delegate.getMaxCompactionLagSeconds();
+  }
+
+  @Override
+  public void setMaxCompactionLagSeconds(long maxCompactionLagSeconds) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
   public String toString() {
     return this.delegate.toString();
   }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/Store.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/Store.java
@@ -297,4 +297,8 @@ public interface Store {
   long getMinCompactionLagSeconds();
 
   void setMinCompactionLagSeconds(long minCompactionLagSeconds);
+
+  long getMaxCompactionLagSeconds();
+
+  void setMaxCompactionLagSeconds(long maxCompactionLagSeconds);
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/StoreInfo.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/StoreInfo.java
@@ -66,6 +66,7 @@ public class StoreInfo {
     storeInfo.setViewConfigs(store.getViewConfigs());
     storeInfo.setStorageNodeReadQuotaEnabled(store.isStorageNodeReadQuotaEnabled());
     storeInfo.setMinCompactionLagSeconds(store.getMinCompactionLagSeconds());
+    storeInfo.setMaxCompactionLagSeconds(store.getMaxCompactionLagSeconds());
     return storeInfo;
   }
 
@@ -305,6 +306,8 @@ public class StoreInfo {
   private boolean storageNodeReadQuotaEnabled;
 
   private long minCompactionLagSeconds;
+
+  private long maxCompactionLagSeconds;
 
   public StoreInfo() {
   }
@@ -762,5 +765,13 @@ public class StoreInfo {
 
   public void setMinCompactionLagSeconds(long minCompactionLagSeconds) {
     this.minCompactionLagSeconds = minCompactionLagSeconds;
+  }
+
+  public long getMaxCompactionLagSeconds() {
+    return maxCompactionLagSeconds;
+  }
+
+  public void setMaxCompactionLagSeconds(long maxCompactionLagSeconds) {
+    this.maxCompactionLagSeconds = maxCompactionLagSeconds;
   }
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/SystemStore.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/SystemStore.java
@@ -620,6 +620,16 @@ public class SystemStore extends AbstractStore {
   }
 
   @Override
+  public long getMaxCompactionLagSeconds() {
+    return zkSharedStore.getMaxCompactionLagSeconds();
+  }
+
+  @Override
+  public void setMaxCompactionLagSeconds(long maxCompactionLagSeconds) {
+    throwUnsupportedOperationException("setMaxCompactionLagSeconds");
+  }
+
+  @Override
   public Store cloneStore() {
     return new SystemStore(zkSharedStore.cloneStore(), systemStoreType, veniceStore.cloneStore());
   }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/ZKStore.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/ZKStore.java
@@ -222,6 +222,7 @@ public class ZKStore extends AbstractStore implements DataModelBackedStructure<S
     setViewConfigs(store.getViewConfigs());
     setStorageNodeReadQuotaEnabled(store.isStorageNodeReadQuotaEnabled());
     setMinCompactionLagSeconds(store.getMinCompactionLagSeconds());
+    setMaxCompactionLagSeconds(store.getMaxCompactionLagSeconds());
 
     for (Version storeVersion: store.getVersions()) {
       forceAddVersion(storeVersion.cloneVersion(), true);
@@ -835,6 +836,16 @@ public class ZKStore extends AbstractStore implements DataModelBackedStructure<S
   @Override
   public void setMinCompactionLagSeconds(long minCompactionLagSeconds) {
     this.storeProperties.minCompactionLagSeconds = minCompactionLagSeconds;
+  }
+
+  @Override
+  public long getMaxCompactionLagSeconds() {
+    return this.storeProperties.maxCompactionLagSeconds;
+  }
+
+  @Override
+  public void setMaxCompactionLagSeconds(long maxCompactionLagSeconds) {
+    this.storeProperties.maxCompactionLagSeconds = maxCompactionLagSeconds;
   }
 
   /**

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/PubSubTopicConfiguration.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/PubSubTopicConfiguration.java
@@ -10,17 +10,20 @@ public class PubSubTopicConfiguration {
   Optional<Long> retentionInMs;
   boolean isLogCompacted;
   Long minLogCompactionLagMs;
+  Optional<Long> maxLogCompactionLagMs;
   Optional<Integer> minInSyncReplicas;
 
   public PubSubTopicConfiguration(
       Optional<Long> retentionInMs,
       boolean isLogCompacted,
       Optional<Integer> minInSyncReplicas,
-      Long minLogCompactionLagMs) {
+      Long minLogCompactionLagMs,
+      Optional<Long> maxLogCompactionLagMs) {
     this.retentionInMs = retentionInMs;
     this.isLogCompacted = isLogCompacted;
     this.minInSyncReplicas = minInSyncReplicas;
     this.minLogCompactionLagMs = minLogCompactionLagMs;
+    this.maxLogCompactionLagMs = maxLogCompactionLagMs;
   }
 
   /**
@@ -79,13 +82,25 @@ public class PubSubTopicConfiguration {
     this.minLogCompactionLagMs = minLogCompactionLagMs;
   }
 
+  public Optional<Long> getMaxLogCompactionLagMs() {
+    return maxLogCompactionLagMs;
+  }
+
+  /**
+   * The maximum time a message will remain ineligible for compaction in the log. Only applicable for logs that are being compacted.
+   */
+  public void setMaxLogCompactionLagMs(Optional<Long> maxLogCompactionLagMs) {
+    this.maxLogCompactionLagMs = maxLogCompactionLagMs;
+  }
+
   @Override
   public String toString() {
     return String.format(
-        "TopicConfiguration(retentionInMs = %s, isLogCompacted = %s, minInSyncReplicas = %s, minLogCompactionLagMs = %s)",
-        retentionInMs,
+        "TopicConfiguration(retentionInMs = %s, isLogCompacted = %s, minInSyncReplicas = %s, minLogCompactionLagMs = %s, maxLogCompactionLagMs = %s)",
+        retentionInMs.isPresent() ? retentionInMs.get() : "not set",
         isLogCompacted,
-        minInSyncReplicas,
-        minLogCompactionLagMs);
+        minInSyncReplicas.isPresent() ? minInSyncReplicas.get() : "not set",
+        minLogCompactionLagMs,
+        maxLogCompactionLagMs.isPresent() ? maxLogCompactionLagMs.get() : " not set");
   }
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/adapter/kafka/admin/ApacheKafkaAdminAdapter.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/adapter/kafka/admin/ApacheKafkaAdminAdapter.java
@@ -404,7 +404,15 @@ public class ApacheKafkaAdminAdapter implements PubSubAdminAdapter {
     Long minLogCompactionLagMs = properties.containsKey(TopicConfig.MIN_COMPACTION_LAG_MS_CONFIG)
         ? Long.parseLong((String) properties.get(TopicConfig.MIN_COMPACTION_LAG_MS_CONFIG))
         : 0L;
-    return new PubSubTopicConfiguration(retentionMs, isLogCompacted, minInSyncReplicas, minLogCompactionLagMs);
+    Optional<Long> maxLogCompactionLagMs = properties.containsKey(TopicConfig.MAX_COMPACTION_LAG_MS_CONFIG)
+        ? Optional.of(Long.parseLong(properties.getProperty(TopicConfig.MAX_COMPACTION_LAG_MS_CONFIG)))
+        : Optional.empty();
+    return new PubSubTopicConfiguration(
+        retentionMs,
+        isLogCompacted,
+        minInSyncReplicas,
+        minLogCompactionLagMs,
+        maxLogCompactionLagMs);
   }
 
   private Properties unmarshallProperties(PubSubTopicConfiguration pubSubTopicConfiguration) {
@@ -418,6 +426,11 @@ public class ApacheKafkaAdminAdapter implements PubSubAdminAdapter {
       topicProperties.put(
           TopicConfig.MIN_COMPACTION_LAG_MS_CONFIG,
           Long.toString(pubSubTopicConfiguration.minLogCompactionLagMs()));
+      if (pubSubTopicConfiguration.getMaxLogCompactionLagMs().isPresent()) {
+        topicProperties.put(
+            TopicConfig.MAX_COMPACTION_LAG_MS_CONFIG,
+            Long.toString(pubSubTopicConfiguration.getMaxLogCompactionLagMs().get()));
+      }
     } else {
       topicProperties.put(TopicConfig.CLEANUP_POLICY_CONFIG, TopicConfig.CLEANUP_POLICY_DELETE);
     }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/serialization/avro/AvroProtocolDefinition.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/serialization/avro/AvroProtocolDefinition.java
@@ -136,7 +136,7 @@ public enum AvroProtocolDefinition {
   /**
    * Value schema for metadata system store.
    */
-  METADATA_SYSTEM_SCHEMA_STORE(16, StoreMetaValue.class),
+  METADATA_SYSTEM_SCHEMA_STORE(17, StoreMetaValue.class),
 
   /**
    * Key schema for push status system store.

--- a/internal/venice-common/src/main/java/com/linkedin/venice/serialization/avro/AvroProtocolDefinition.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/serialization/avro/AvroProtocolDefinition.java
@@ -71,7 +71,7 @@ public enum AvroProtocolDefinition {
    *
    * TODO: Move AdminOperation to venice-common module so that we can properly reference it here.
    */
-  ADMIN_OPERATION(73, SpecificData.get().getSchema(ByteBuffer.class), "AdminOperation"),
+  ADMIN_OPERATION(74, SpecificData.get().getSchema(ByteBuffer.class), "AdminOperation"),
 
   /**
    * Single chunk of a large multi-chunk value. Just a bunch of bytes.

--- a/internal/venice-common/src/main/resources/avro/StoreMetaValue/v16/StoreMetaValue.avsc
+++ b/internal/venice-common/src/main/resources/avro/StoreMetaValue/v16/StoreMetaValue.avsc
@@ -157,6 +157,7 @@
             {"name": "activeActiveReplicationEnabled", "type": "boolean", "default": false, "doc": "Whether or not active/active replication is enabled for hybrid stores; eventually this config will replace native replication flag, when all stores are on A/A"},
             {"name": "applyTargetVersionFilterForIncPush", "type": "boolean", "default": false, "doc": "Whether or not the target version field in Kafka messages will be used in increment push to RT policy"},
             {"name": "minCompactionLagSeconds", "type": "long", "default": -1, "doc": "Store level min compaction lag config and if not specified, it will use the global config for version topics"},
+            {"name": "maxCompactionLagSeconds", "type": "long", "default": -1, "doc": "Store level max compaction lag config and if not specified, 'max.compaction.lag.ms' config won't be setup in the corresponding version topics"},
             {
               "name": "versions",
               "doc": "List of non-retired versions. It's currently sorted and there is code run under the assumption that the last element in the list is the largest. Check out {VeniceHelixAdmin#getIncrementalPushVersion}, and please make it in mind if you want to change this logic",

--- a/internal/venice-common/src/main/resources/avro/StoreMetaValue/v17/StoreMetaValue.avsc
+++ b/internal/venice-common/src/main/resources/avro/StoreMetaValue/v17/StoreMetaValue.avsc
@@ -157,6 +157,7 @@
             {"name": "activeActiveReplicationEnabled", "type": "boolean", "default": false, "doc": "Whether or not active/active replication is enabled for hybrid stores; eventually this config will replace native replication flag, when all stores are on A/A"},
             {"name": "applyTargetVersionFilterForIncPush", "type": "boolean", "default": false, "doc": "Whether or not the target version field in Kafka messages will be used in increment push to RT policy"},
             {"name": "minCompactionLagSeconds", "type": "long", "default": -1, "doc": "Store level min compaction lag config and if not specified, it will use the global config for version topics"},
+            {"name": "maxCompactionLagSeconds", "type": "long", "default": -1, "doc": "Store level max compaction lag config and if not specified, 'max.compaction.lag.ms' config won't be setup in the corresponding version topics"},
             {
               "name": "versions",
               "doc": "List of non-retired versions. It's currently sorted and there is code run under the assumption that the last element in the list is the largest. Check out {VeniceHelixAdmin#getIncrementalPushVersion}, and please make it in mind if you want to change this logic",

--- a/internal/venice-common/src/test/java/com/linkedin/venice/kafka/TopicManagerTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/kafka/TopicManagerTest.java
@@ -63,6 +63,7 @@ import java.time.Duration;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
@@ -460,17 +461,19 @@ public class TopicManagerTest {
         "topic: " + topic + " should be with compaction disabled");
     Assert.assertEquals(topicManager.getTopicMinLogCompactionLagMs(topic), 0L);
 
-    topicManager.updateTopicCompactionPolicy(topic, true, 100);
+    topicManager.updateTopicCompactionPolicy(topic, true, 100, Optional.of(Long.valueOf(200l)));
     Assert.assertTrue(
         topicManager.isTopicCompactionEnabled(topic),
         "topic: " + topic + " should be with compaction enabled");
     Assert.assertEquals(topicManager.getTopicMinLogCompactionLagMs(topic), 100L);
+    Assert.assertEquals(topicManager.getTopicMaxLogCompactionLagMs(topic).get(), Long.valueOf(200L));
 
-    topicManager.updateTopicCompactionPolicy(topic, true, 1000);
+    topicManager.updateTopicCompactionPolicy(topic, true, 1000, Optional.of(Long.valueOf(2000L)));
     Assert.assertTrue(
         topicManager.isTopicCompactionEnabled(topic),
         "topic: " + topic + " should be with compaction enabled");
     Assert.assertEquals(topicManager.getTopicMinLogCompactionLagMs(topic), 1000L);
+    Assert.assertEquals(topicManager.getTopicMaxLogCompactionLagMs(topic).get(), Long.valueOf(2000L));
   }
 
   @Test

--- a/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/adapter/kafka/admin/ApacheKafkaAdminAdapterTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/adapter/kafka/admin/ApacheKafkaAdminAdapterTest.java
@@ -84,7 +84,8 @@ public class ApacheKafkaAdminAdapterTest {
         Optional.of(Duration.ofDays(3).toMillis()),
         true,
         Optional.of(2),
-        Duration.ofDays(1).toMillis());
+        Duration.ofDays(1).toMillis(),
+        Optional.empty());
     sampleConfig = new Config(
         Arrays.asList(
             new ConfigEntry("retention.ms", "259200000"),
@@ -361,7 +362,7 @@ public class ApacheKafkaAdminAdapterTest {
   @Test
   public void testSetTopicConfig() {
     PubSubTopicConfiguration topicConfiguration =
-        new PubSubTopicConfiguration(Optional.of(1111L), true, Optional.of(222), 333L);
+        new PubSubTopicConfiguration(Optional.of(1111L), true, Optional.of(222), 333L, Optional.empty());
     AlterConfigsResult alterConfigsResultMock = mock(AlterConfigsResult.class);
     KafkaFuture<Void> alterConfigsKafkaFutureMock = mock(KafkaFuture.class);
 
@@ -390,7 +391,7 @@ public class ApacheKafkaAdminAdapterTest {
   @Test
   public void testSetTopicConfigThrowsException() throws ExecutionException, InterruptedException {
     PubSubTopicConfiguration topicConfiguration =
-        new PubSubTopicConfiguration(Optional.of(1111L), true, Optional.of(222), 333L);
+        new PubSubTopicConfiguration(Optional.of(1111L), true, Optional.of(222), 333L, Optional.empty());
     AlterConfigsResult alterConfigsResultMock = mock(AlterConfigsResult.class);
     KafkaFuture<Void> alterConfigsKafkaFutureMock = mock(KafkaFuture.class);
 

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/VeniceParentHelixAdminTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/VeniceParentHelixAdminTest.java
@@ -608,7 +608,7 @@ public class VeniceParentHelixAdminTest {
         testWriteComputeSchemaAutoGeneration(parentControllerClient);
         testWriteComputeSchemaEnable(parentControllerClient);
         testWriteComputeSchemaAutoGenerationFailure(parentControllerClient);
-        testUpdateMinCompactionLag(parentControllerClient, childControllerClient);
+        testUpdateCompactionLag(parentControllerClient, childControllerClient);
       }
     }
   }
@@ -883,7 +883,7 @@ public class VeniceParentHelixAdminTest {
     Assert.assertEquals(schemaResponse.getSchemas().length, 2);
   }
 
-  private void testUpdateMinCompactionLag(
+  private void testUpdateCompactionLag(
       ControllerClient parentControllerClient,
       ControllerClient childControllerClient) {
     // Adding store
@@ -898,17 +898,21 @@ public class VeniceParentHelixAdminTest {
     parentControllerClient.createNewStore(storeName, owner, keySchemaStr, valueSchema.toString());
 
     final long expectedMinCompactionLagSeconds = 100;
+    final long expectedMaxCompactionLagSeconds = 200;
     UpdateStoreQueryParams params = new UpdateStoreQueryParams();
     params.setMinCompactionLagSeconds(expectedMinCompactionLagSeconds);
+    params.setMaxCompactionLagSeconds(expectedMaxCompactionLagSeconds);
     parentControllerClient.updateStore(storeName, params);
 
     // Validate in parent
     StoreResponse parentStoreResponse = parentControllerClient.getStore(storeName);
     Assert.assertEquals(parentStoreResponse.getStore().getMinCompactionLagSeconds(), expectedMinCompactionLagSeconds);
+    Assert.assertEquals(parentStoreResponse.getStore().getMaxCompactionLagSeconds(), expectedMaxCompactionLagSeconds);
 
     TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, () -> {
       StoreResponse childStoreResponse = parentControllerClient.getStore(storeName);
       Assert.assertEquals(childStoreResponse.getStore().getMinCompactionLagSeconds(), expectedMinCompactionLagSeconds);
+      Assert.assertEquals(childStoreResponse.getStore().getMaxCompactionLagSeconds(), expectedMaxCompactionLagSeconds);
     });
 
   }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -3302,7 +3302,14 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
       long minCompactionLagSeconds = store.getMinCompactionLagSeconds();
       long expectedMinCompactionLagMs =
           minCompactionLagSeconds > 0 ? minCompactionLagSeconds * Time.MS_PER_SECOND : minCompactionLagSeconds;
-      getTopicManager().updateTopicCompactionPolicy(versionTopic, true, expectedMinCompactionLagMs);
+      long maxCompactionLagSeconds = store.getMaxCompactionLagSeconds();
+      long expectedMaxCompactionLagMs =
+          maxCompactionLagSeconds > 0 ? maxCompactionLagSeconds * Time.MS_PER_SECOND : maxCompactionLagSeconds;
+      getTopicManager().updateTopicCompactionPolicy(
+          versionTopic,
+          true,
+          expectedMinCompactionLagMs,
+          expectedMaxCompactionLagMs > 0 ? Optional.of(expectedMaxCompactionLagMs) : Optional.empty());
     }
   }
 
@@ -4236,6 +4243,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
     Optional<Integer> latestSupersetSchemaId = params.getLatestSupersetSchemaId();
     Optional<Boolean> storageNodeReadQuotaEnabled = params.getStorageNodeReadQuotaEnabled();
     Optional<Long> minCompactionLagSeconds = params.getMinCompactionLagSeconds();
+    Optional<Long> maxCompactionLagSeconds = params.getMaxCompactionLagSeconds();
 
     final Optional<HybridStoreConfig> newHybridStoreConfig;
     if (hybridRewindSeconds.isPresent() || hybridOffsetLagThreshold.isPresent() || hybridTimeLagThreshold.isPresent()
@@ -4486,6 +4494,12 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
       if (minCompactionLagSeconds.isPresent()) {
         storeMetadataUpdate(clusterName, storeName, store -> {
           store.setMinCompactionLagSeconds(minCompactionLagSeconds.get());
+          return store;
+        });
+      }
+      if (maxCompactionLagSeconds.isPresent()) {
+        storeMetadataUpdate(clusterName, storeName, store -> {
+          store.setMaxCompactionLagSeconds(maxCompactionLagSeconds.get());
           return store;
         });
       }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/kafka/consumer/AdminExecutionTask.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/kafka/consumer/AdminExecutionTask.java
@@ -520,7 +520,6 @@ public class AdminExecutionTask implements Callable<Void> {
     params.setStorageNodeReadQuotaEnabled(message.storageNodeReadQuotaEnabled);
     params.setMinCompactionLagSeconds(message.minCompactionLagSeconds);
     params.setMaxCompactionLagSeconds(message.maxCompactionLagSeconds);
-    LOGGER.info("max compaction lag ms in AdminExecutionTask: " + message.maxCompactionLagSeconds);
 
     final UpdateStoreQueryParams finalParams;
     if (message.replicateAllConfigs) {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/kafka/consumer/AdminExecutionTask.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/kafka/consumer/AdminExecutionTask.java
@@ -519,6 +519,8 @@ public class AdminExecutionTask implements Callable<Void> {
 
     params.setStorageNodeReadQuotaEnabled(message.storageNodeReadQuotaEnabled);
     params.setMinCompactionLagSeconds(message.minCompactionLagSeconds);
+    params.setMaxCompactionLagSeconds(message.maxCompactionLagSeconds);
+    LOGGER.info("max compaction lag ms in AdminExecutionTask: " + message.maxCompactionLagSeconds);
 
     final UpdateStoreQueryParams finalParams;
     if (message.replicateAllConfigs) {

--- a/services/venice-controller/src/main/resources/avro/AdminOperation/v74/AdminOperation.avsc
+++ b/services/venice-controller/src/main/resources/avro/AdminOperation/v74/AdminOperation.avsc
@@ -1,0 +1,1036 @@
+{
+  "name": "AdminOperation",
+  "namespace": "com.linkedin.venice.controller.kafka.protocol.admin",
+  "type": "record",
+  "fields": [
+    {
+      "name": "operationType",
+      "doc": "0 => StoreCreation, 1 => ValueSchemaCreation, 2 => PauseStore, 3 => ResumeStore, 4 => KillOfflinePushJob, 5 => DisableStoreRead, 6 => EnableStoreRead, 7=> DeleteAllVersions, 8=> SetStoreOwner, 9=> SetStorePartitionCount, 10=> SetStoreCurrentVersion, 11=> UpdateStore, 12=> DeleteStore, 13=> DeleteOldVersion, 14=> MigrateStore, 15=> AbortMigration, 16=>AddVersion, 17=> DerivedSchemaCreation, 18=>SupersetSchemaCreation, 19=>EnableNativeReplicationForCluster, 20=>MetadataSchemaCreation, 21=>EnableActiveActiveReplicationForCluster, 25=>CreatePersona, 26=>DeletePersona, 27=>UpdatePersona",
+      "type": "int"
+    }, {
+      "name": "executionId",
+      "doc": "ID of a command execution which is used to query the status of this command.",
+      "type": "long",
+      "default": 0
+    }, {
+      "name": "payloadUnion",
+      "doc": "This contains the main payload of the admin operation",
+      "type": [
+        {
+          "name": "StoreCreation",
+          "type": "record",
+          "fields": [
+            {
+              "name": "clusterName",
+              "type": "string"
+            },
+            {
+              "name": "storeName",
+              "type": "string"
+            },
+            {
+              "name": "owner",
+              "type": "string"
+            },
+            {
+              "name": "keySchema",
+              "type": {
+                "type": "record",
+                "name": "SchemaMeta",
+                "fields": [
+                  {"name": "schemaType", "type": "int", "doc": "0 => Avro-1.4, and we can add more if necessary"},
+                  {"name": "definition", "type": "string"}
+                ]
+              }
+            },
+            {
+              "name": "valueSchema",
+              "type": "SchemaMeta"
+            }
+          ]
+        },
+        {
+          "name": "ValueSchemaCreation",
+          "type": "record",
+          "fields": [
+            {
+              "name": "clusterName",
+              "type": "string"
+            },
+            {
+              "name": "storeName",
+              "type": "string"
+            },
+            {
+              "name": "schema",
+              "type": "SchemaMeta"
+            },
+            {
+              "name": "schemaId",
+              "type": "int"
+            },
+            {
+              "name": "doUpdateSupersetSchemaID",
+              "type": "boolean",
+              "doc": "Whether this superset schema ID should be updated to be the value schema ID for this store.",
+              "default": false
+            }
+          ]
+        },
+        {
+          "name": "PauseStore",
+          "type": "record",
+          "fields": [
+            {
+              "name": "clusterName",
+              "type": "string"
+            },
+            {
+              "name": "storeName",
+              "type": "string"
+            }
+          ]
+        },
+        {
+          "name": "ResumeStore",
+          "type": "record",
+          "fields": [
+            {
+              "name": "clusterName",
+              "type": "string"
+            },
+            {
+              "name": "storeName",
+              "type": "string"
+            }
+          ]
+        },
+        {
+          "name": "KillOfflinePushJob",
+          "type": "record",
+          "fields": [
+            {
+              "name": "clusterName",
+              "type": "string"
+            },
+            {
+              "name": "kafkaTopic",
+              "type": "string"
+            }
+          ]
+        },
+        {
+          "name": "DisableStoreRead",
+          "type": "record",
+          "fields": [
+            {
+              "name": "clusterName",
+              "type": "string"
+            },
+            {
+              "name": "storeName",
+              "type": "string"
+            }
+          ]
+        },
+        {
+          "name": "EnableStoreRead",
+          "type": "record",
+          "fields": [
+            {
+              "name": "clusterName",
+              "type": "string"
+            },
+            {
+              "name": "storeName",
+              "type": "string"
+            }
+          ]
+        },
+        {
+          "name": "DeleteAllVersions",
+          "type": "record",
+          "fields": [
+            {
+              "name": "clusterName",
+              "type": "string"
+            },
+            {
+              "name": "storeName",
+              "type": "string"
+            }
+          ]
+        },
+        {
+          "name": "SetStoreOwner",
+          "type": "record",
+          "fields": [
+            {
+              "name": "clusterName",
+              "type": "string"
+            },
+            {
+              "name": "storeName",
+              "type": "string"
+            },
+            {
+              "name": "owner",
+              "type": "string"
+            }
+          ]
+        },
+        {
+          "name": "SetStorePartitionCount",
+          "type": "record",
+          "fields": [
+            {
+              "name": "clusterName",
+              "type": "string"
+            },
+            {
+              "name": "storeName",
+              "type": "string"
+            },
+            {
+              "name": "partitionNum",
+              "type": "int"
+            }
+          ]
+        },
+        {
+          "name": "SetStoreCurrentVersion",
+          "type": "record",
+          "fields": [
+            {
+              "name": "clusterName",
+              "type": "string"
+            },
+            {
+              "name": "storeName",
+              "type": "string"
+            },
+            {
+              "name": "currentVersion",
+              "type": "int"
+            }
+          ]
+        },
+        {
+          "name": "UpdateStore",
+          "type": "record",
+          "fields": [
+            {
+              "name": "clusterName",
+              "type": "string"
+            },
+            {
+              "name": "storeName",
+              "type": "string"
+            },
+            {
+              "name": "owner",
+              "type": "string"
+            },
+            {
+              "name": "partitionNum",
+              "type": "int"
+            },
+            {
+              "name": "currentVersion",
+              "type": "int"
+            },
+            {
+              "name": "enableReads",
+              "type": "boolean"
+            },
+            {
+              "name": "enableWrites",
+              "type": "boolean"
+            },
+            {
+              "name": "storageQuotaInByte",
+              "type": "long",
+              "default": 21474836480
+            },
+            {
+              "name": "readQuotaInCU",
+              "type": "long",
+              "default": 1800
+            },
+            {
+              "name": "hybridStoreConfig",
+              "type": [
+                "null",
+                {
+                  "name": "HybridStoreConfigRecord",
+                  "type": "record",
+                  "fields": [
+                    {
+                      "name": "rewindTimeInSeconds",
+                      "type": "long"
+                    },
+                    {
+                      "name": "offsetLagThresholdToGoOnline",
+                      "type": "long"
+                    },
+                    {
+                      "name": "producerTimestampLagThresholdToGoOnlineInSeconds",
+                      "type": "long",
+                      "default": -1
+                    },
+                    {
+                      "name": "dataReplicationPolicy",
+                      "doc": "Real-time Samza job data replication policy. Using int because Avro Enums are not evolvable 0 => NON_AGGREGATE, 1 => AGGREGATE, 2 => NONE, 3 => ACTIVE_ACTIVE",
+                      "type": "int",
+                      "default": 0
+                    },
+                    {
+                      "name": "bufferReplayPolicy",
+                      "type": "int",
+                      "doc": "Policy that will be used during buffer replay. rewindTimeInSeconds defines the delta. 0 => REWIND_FROM_EOP (replay from 'EOP - rewindTimeInSeconds'), 1 => REWIND_FROM_SOP (replay from 'SOP - rewindTimeInSeconds')",
+                      "default": 0
+                    }
+                  ]
+                }
+              ],
+              "default": null
+            },
+            {
+              "name": "accessControlled",
+              "type": "boolean",
+              "default": false
+            },
+            {
+              "name": "compressionStrategy",
+              "doc": "Using int because Avro Enums are not evolvable",
+              "type": "int",
+              "default": 0
+            },
+            {
+              "name": "chunkingEnabled",
+              "type": "boolean",
+              "default": false
+            },
+            {
+              "name": "rmdChunkingEnabled",
+              "type": "boolean",
+              "default": false
+            },
+            {
+              "name": "singleGetRouterCacheEnabled",
+              "aliases": ["routerCacheEnabled"],
+              "type": "boolean",
+              "default": false
+            },
+            {
+              "name": "batchGetRouterCacheEnabled",
+              "type": "boolean",
+              "default": false
+            },
+            {
+              "name": "batchGetLimit",
+              "doc": "The max key number allowed in batch get request, and Venice will use cluster-level config if the limit (not positive) is not valid",
+              "type": "int",
+              "default": -1
+            },
+            {
+              "name": "numVersionsToPreserve",
+              "doc": "The max number of versions the store should preserve. Venice will use cluster-level config if the number is 0 here.",
+              "type": "int",
+              "default": 0
+            },
+            {
+              "name": "incrementalPushEnabled",
+              "doc": "a flag to see if the store supports incremental push or not",
+              "type": "boolean",
+              "default": false
+            },
+            {
+              "name": "isMigrating",
+              "doc": "Whether or not the store is in the process of migration",
+              "type": "boolean",
+              "default": false
+            },
+            {
+              "name": "writeComputationEnabled",
+              "doc": "Whether write-path computation feature is enabled for this store",
+              "type": "boolean",
+              "default": false
+            },
+            {
+              "name": "replicationMetadataVersionID",
+              "doc": "RMD (Replication metadata) version ID on the store-level. Default -1 means NOT_SET and the cluster-level RMD version ID should be used for stores.",
+              "type": "int",
+              "default":  -1
+            },
+            {
+              "name": "readComputationEnabled",
+              "doc": "Whether read-path computation feature is enabled for this store",
+              "type": "boolean",
+              "default": false
+            },
+            {
+              "name": "bootstrapToOnlineTimeoutInHours",
+              "doc": "Maximum number of hours allowed for the store to transition from bootstrap to online state",
+              "type": "int",
+              "default": 24
+            },
+            {
+              "name": "leaderFollowerModelEnabled",
+              "doc":  "Whether or not to use leader follower state transition model for upcoming version",
+              "type": "boolean",
+              "default": false
+            },
+            {
+              "name": "backupStrategy",
+              "doc":  "Strategies to store backup versions.",
+              "type": "int",
+              "default": 0
+            },
+            {
+              "name": "clientDecompressionEnabled",
+              "type": "boolean",
+              "default": true
+            },
+            {
+              "name": "schemaAutoRegisterFromPushJobEnabled",
+              "type": "boolean",
+              "default": false
+            },
+            {
+              "name": "hybridStoreOverheadBypass",
+              "type": "boolean",
+              "default": false
+            },
+            {
+              "name": "hybridStoreDiskQuotaEnabled",
+              "doc":  "Whether or not to enable disk storage quota for a hybrid store",
+              "type": "boolean",
+              "default": false
+            },
+            {
+              "name": "ETLStoreConfig",
+              "type": [
+                "null",
+                {
+                  "name": "ETLStoreConfigRecord",
+                  "type": "record",
+                  "fields": [
+                    {
+                      "name": "etledUserProxyAccount",
+                      "type": ["null", "string"]
+                    },
+                    {
+                      "name": "regularVersionETLEnabled",
+                      "type": "boolean"
+                    },
+                    {
+                      "name": "futureVersionETLEnabled",
+                      "type": "boolean"
+                    }
+                  ]
+                }
+              ],
+              "default": null
+            },
+            {
+              "name": "partitionerConfig",
+              "type": [
+                "null",
+                {
+                  "name": "PartitionerConfigRecord",
+                  "type": "record",
+                  "fields": [
+                    {
+                      "name": "partitionerClass",
+                      "type": "string"
+                    },
+                    {
+                      "name": "partitionerParams",
+                      "type": {
+                        "type": "map",
+                        "values": "string"
+                      }
+                    },
+                    {
+                      "name": "amplificationFactor",
+                      "type": "int"
+                    }
+                  ]
+                }
+              ],
+              "default": null
+            },
+            {
+              "name": "nativeReplicationEnabled",
+              "type": "boolean",
+              "default": false
+            },
+            {
+              "name": "pushStreamSourceAddress",
+              "type": ["null", "string"],
+              "default": null
+            },
+            {
+              "name": "largestUsedVersionNumber",
+              "type": ["null", "int"],
+              "default": null
+            },
+            {
+              "name": "incrementalPushPolicy",
+              "doc": "Incremental Push Policy to reconcile with real time pushes. Using int because Avro Enums are not evolvable 0 => PUSH_TO_VERSION_TOPIC, 1 => INCREMENTAL_PUSH_SAME_AS_REAL_TIME",
+              "type": "int",
+              "default": 0
+            },
+            {
+              "name": "backupVersionRetentionMs",
+              "type": "long",
+              "doc": "Backup version retention time after a new version is promoted to the current version, if not specified, Venice will use the configured retention as the default policy",
+              "default": -1
+            },
+            {
+              "name": "replicationFactor",
+              "doc": "number of replica each store version will have",
+              "type": "int",
+              "default": 3
+            },
+            {
+              "name": "migrationDuplicateStore",
+              "doc": "Whether or not the store is a duplicate store in the process of migration",
+              "type": "boolean",
+              "default": false
+            },
+            {
+              "name": "nativeReplicationSourceFabric",
+              "doc": "The source fabric to be used when the store is running in Native Replication mode.",
+              "type": ["null", "string"],
+              "default": null
+            },
+            {
+              "name": "activeActiveReplicationEnabled",
+              "doc": "A command option to enable/disable Active/Active replication feature for a store",
+              "type": "boolean",
+              "default": false
+            },
+            {
+              "name": "disableMetaStore",
+              "doc": "An UpdateStore command option to disable the companion meta system store",
+              "type": "boolean",
+              "default": false
+            },
+            {
+              "name": "disableDavinciPushStatusStore",
+              "doc": "An UpdateStore command option to disable the companion davinci push status store",
+              "type": "boolean",
+              "default": false
+            },
+            {
+              "name": "applyTargetVersionFilterForIncPush",
+              "doc": "An UpdateStore command option to enable/disable applying the target version filter for incremental pushes",
+              "type": "boolean",
+              "default": false
+            },
+            {
+              "name": "updatedConfigsList",
+              "doc": "The list that contains all updated configs by the UpdateStore command. Most of the fields in UpdateStore are not optional, and changing those fields to Optional (Union) is not a backward compatible change, so we have to add an addition array field to record all updated configs in parent controller.",
+              "type": {
+                "type": "array",
+                "items": "string"
+              },
+              "default": []
+            },
+            {
+              "name": "replicateAllConfigs",
+              "doc": "A flag to indicate whether all store configs in parent cluster will be replicated to child clusters; true by default, so that existing UpdateStore messages in Admin topic will behave the same as before.",
+              "type": "boolean",
+              "default": true
+            },
+            {
+              "name": "regionsFilter",
+              "doc": "A list of regions that will be impacted by the UpdateStore command",
+              "type": ["null", "string"],
+              "default": null
+            },
+            {
+              "name": "storagePersona",
+              "doc": "The name of the StoragePersona to add to the store",
+              "type": ["null", "string"],
+              "default": null
+            },
+            {
+              "name": "views",
+              "doc": "A map of views which describe and configure a downstream view of a venice store. Keys in this map are for convenience of managing configs.",
+              "type": ["null",
+                {
+                  "type":"map",
+                  "java-key-class": "java.lang.String",
+                  "avro.java.string": "String",
+                  "values": {
+                    "name": "StoreViewConfigRecord",
+                    "type": "record",
+                    "doc": "A configuration for a particular view.  This config should inform Venice leaders how to transform and transmit data to destination views.",
+                    "fields": [
+                      {
+                        "name": "viewClassName",
+                        "type": "string",
+                        "doc": "This informs what kind of view we are materializing.  This then informs what kind of parameters are passed to parse this input.  This is expected to be a fully formed class path name for materialization.",
+                        "default": ""
+                      },
+                      {
+                        "name": "viewParameters",
+                        "doc": "Optional parameters to be passed to the given view config.",
+                        "type": ["null",
+                          {
+                            "type": "map",
+                            "java-key-class": "java.lang.String",
+                            "avro.java.string": "String",
+                            "values": { "type": "string", "avro.java.string": "String" }
+                          }
+                        ],
+                        "default": null
+                      }
+                    ]
+                  }
+                }],
+              "default": null
+            },
+            {
+              "name": "latestSuperSetValueSchemaId",
+              "doc": "The schema id for the latest superset schema",
+              "type" : "int",
+              "default": -1
+            },
+            {
+              "name": "storageNodeReadQuotaEnabled",
+              "doc": "Whether storage node read quota is enabled for this store",
+              "type": "boolean",
+              "default": false
+            },
+            {
+              "name": "minCompactionLagSeconds",
+              "doc": "Store-level version topic min compaction lag",
+              "type": "long",
+              "default": -1
+            },
+            {
+              "name": "maxCompactionLagSeconds",
+              "doc": "Store-level version topic max compaction lag",
+              "type": "long",
+              "default": -1
+            }
+          ]
+        },
+        {
+          "name": "DeleteStore",
+          "type": "record",
+          "fields": [
+            {
+              "name": "clusterName",
+              "type": "string"
+            },
+            {
+              "name": "storeName",
+              "type": "string"
+            },
+            {
+              "name": "largestUsedVersionNumber",
+              "type": "int"
+            }
+          ]
+        },
+        {
+          "name": "DeleteOldVersion",
+          "type": "record",
+          "fields": [
+            {
+              "name": "clusterName",
+              "type": "string"
+            },
+            {
+              "name": "storeName",
+              "type": "string"
+            },
+            {
+              "name": "versionNum",
+              "type": "int"
+            }
+          ]
+        },
+        {
+          "name": "MigrateStore",
+          "type": "record",
+          "fields": [
+            {
+              "name": "srcClusterName",
+              "type": "string"
+            },
+            {
+              "name": "destClusterName",
+              "type": "string"
+            },
+            {
+              "name": "storeName",
+              "type": "string"
+            }
+          ]
+        },
+        {
+          "name": "AbortMigration",
+          "type": "record",
+          "fields": [
+            {
+              "name": "srcClusterName",
+              "type": "string"
+            },
+            {
+              "name": "destClusterName",
+              "type": "string"
+            },
+            {
+              "name": "storeName",
+              "type": "string"
+            }
+          ]
+        },
+        {
+          "name": "AddVersion",
+          "type": "record",
+          "fields": [
+            {
+              "name": "clusterName",
+              "type": "string"
+            },
+            {
+              "name": "storeName",
+              "type": "string"
+            },
+            {
+              "name": "pushJobId",
+              "type": "string"
+            },
+            {
+              "name": "versionNum",
+              "type": "int"
+            },
+            {
+              "name": "numberOfPartitions",
+              "type": "int"
+            },
+            {
+              "name": "pushType",
+              "doc": "The push type of the new version, 0 => BATCH, 1 => STREAM_REPROCESSING. Previous add version messages will default to BATCH and this is a safe because they were created when BATCH was the only version type",
+              "type": "int",
+              "default": 0
+            },
+            {
+              "name": "pushStreamSourceAddress",
+              "type": ["null", "string"],
+              "default": null
+            },
+            {
+              "name": "rewindTimeInSecondsOverride",
+              "doc": "The overridable rewind time config for this specific version of a hybrid store, and if it is not specified, the new version will use the store-level rewind time config",
+              "type": "long",
+              "default": -1
+            },
+            {
+              "name": "timestampMetadataVersionId",
+              "doc": "The A/A metadata schema version ID that will be used to deserialize metadataPayload.",
+              "type": "int",
+              "default": -1
+            },
+            {
+              "name": "versionSwapDeferred",
+              "doc": "Indicates if swapping this version to current version after push completion should be initiated or not",
+              "type": "boolean",
+              "default": false
+            },
+            {
+              "name": "targetedRegions",
+              "doc": "The list of regions that is separated by comma for targeted region push. If set, this admin message should only be consumed by the targeted regions",
+              "type": [
+                "null",
+                {
+                  "type": "array",
+                  "items":  "string"
+                }
+              ],
+              "default": null
+            }
+          ]
+        },
+        {
+          "name": "DerivedSchemaCreation",
+          "type": "record",
+          "fields": [
+            {
+              "name": "clusterName",
+              "type": "string"
+            },
+            {
+              "name": "storeName",
+              "type": "string"
+            },
+            {
+              "name": "schema",
+              "type": "SchemaMeta"
+            },
+            {
+              "name": "valueSchemaId",
+              "type": "int"
+            },
+            {
+              "name": "derivedSchemaId",
+              "type": "int"
+            }
+          ]
+        },
+        {
+          "name": "SupersetSchemaCreation",
+          "type": "record",
+          "fields": [
+            {
+              "name": "clusterName",
+              "type": "string"
+            },
+            {
+              "name": "storeName",
+              "type": "string"
+            },
+            {
+              "name": "valueSchema",
+              "type": "SchemaMeta"
+            },
+            {
+              "name": "valueSchemaId",
+              "type": "int"
+            },
+            {
+              "name": "supersetSchema",
+              "type": "SchemaMeta"
+            },
+            {
+              "name": "supersetSchemaId",
+              "type": "int"
+            }
+          ]
+        },
+        {
+          "name": "ConfigureNativeReplicationForCluster",
+          "type": "record",
+          "fields": [
+            {
+              "name": "clusterName",
+              "type": "string"
+            },
+            {
+              "name": "storeType",
+              "type": "string"
+            },
+            {
+              "name": "enabled",
+              "type": "boolean"
+            },
+            {
+              "name": "nativeReplicationSourceRegion",
+              "doc": "The source region to be used when the store is running in Native Replication mode.",
+              "type": ["null", "string"],
+              "default": null
+            },
+            {
+              "name": "regionsFilter",
+              "type": ["null", "string"],
+              "default": null
+            }
+          ]
+        },
+        {
+          "name": "MetadataSchemaCreation",
+          "type": "record",
+          "fields": [
+            {
+              "name": "clusterName",
+              "type": "string"
+            },
+            {
+              "name": "storeName",
+              "type": "string"
+            },
+            {
+              "name": "valueSchemaId",
+              "type": "int"
+            },
+            {
+              "name": "metadataSchema",
+              "type": "SchemaMeta"
+            },
+            {
+              "name": "timestampMetadataVersionId",
+              "type": "int",
+              "aliases": ["metadataVersionId"],
+              "default": -1
+            }
+          ]
+        },
+        {
+          "name": "ConfigureActiveActiveReplicationForCluster",
+          "type": "record",
+          "fields": [
+            {
+              "name": "clusterName",
+              "type": "string"
+            },
+            {
+              "name": "storeType",
+              "type": "string"
+            },
+            {
+              "name": "enabled",
+              "type": "boolean"
+            },
+            {
+              "name": "regionsFilter",
+              "type": ["null", "string"],
+              "default": null
+            }
+          ]
+        }, {
+          "name": "ConfigureIncrementalPushForCluster",
+          "doc": "A command to migrate all incremental push stores in a cluster to a specific incremental push policy.",
+          "type": "record",
+          "fields": [
+            {
+              "name": "clusterName",
+              "type": "string"
+            },
+            {
+              "name": "incrementalPushPolicyToFilter",
+              "doc": "If this batch update command is trying to configure existing incremental push store type, their incremental push policy should also match this filter before the batch update command applies any change to them. Default value is -1, meaning there is no filter.",
+              "type": "int",
+              "default": -1
+            },
+            {
+              "name": "incrementalPushPolicyToApply",
+              "doc": "This field will determine what incremental push policy will be applied to the selected stores. Default value is 1, which is the INCREMENTAL_PUSH_SAME_AS_REAL_TIME policy",
+              "type": "int",
+              "default": 1
+            },
+            {
+              "name": "regionsFilter",
+              "type": ["null", "string"],
+              "default": null
+            }
+          ]
+        }, {
+          "name": "MetaSystemStoreAutoCreationValidation",
+          "type": "record",
+          "fields": [
+            {
+              "name": "clusterName",
+              "type": "string"
+            },
+            {
+              "name": "storeName",
+              "type": "string"
+            }
+          ]
+        }, {
+          "name": "PushStatusSystemStoreAutoCreationValidation",
+          "type": "record",
+          "fields": [
+            {
+              "name": "clusterName",
+              "type": "string"
+            },
+            {
+              "name": "storeName",
+              "type": "string"
+            }
+          ]
+        }, {
+          "name": "CreateStoragePersona",
+          "type": "record",
+          "fields": [
+            {
+              "name": "clusterName",
+              "type": "string"
+            },
+            {
+              "name": "name",
+              "type": "string"
+            },
+            {
+              "name": "quotaNumber",
+              "type": "long"
+            },
+            {
+              "name": "storesToEnforce",
+              "type": {
+                "type": "array",
+                "items": "string",
+                "default": []
+              }
+            },
+            {
+              "name": "owners",
+              "type": {
+                "type": "array",
+                "items": "string",
+                "default": []
+              }
+            }
+          ]
+        }, {
+          "name": "DeleteStoragePersona",
+          "type": "record",
+          "fields": [
+            {
+              "name": "clusterName",
+              "type": "string"
+            },
+            {
+              "name": "name",
+              "type": "string"
+            }
+          ]
+        }, {
+          "name": "UpdateStoragePersona",
+          "type": "record",
+          "fields": [
+            {
+              "name": "clusterName",
+              "type": "string"
+            }, {
+              "name": "name",
+              "type": "string"
+            }, {
+              "name": "quotaNumber",
+              "type": ["null","long"],
+              "default": null
+            }, {
+              "name": "storesToEnforce",
+              "type": [
+                "null",
+                {
+                  "type": "array",
+                  "items": "string"
+                }
+              ],
+              "default": null
+            }, {
+              "name": "owners",
+              "type": [
+                "null",
+                {
+                  "type": "array",
+                  "items":  "string"
+                }
+              ],
+              "default": null
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION

`max.compaction.lag.ms` is used to control the maximum time a message will remain ineligible for compaction. This is the config, which will trigger frequent compaction when there are a lot of duplicated messages in version topic. This config has been proved to help reduce the DaVinci bootstrapping time when the version topic contains many duplicate messages with high write throughput. So far, we will manually adjust this setting for the high-write throughput DaVinci stores.

<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->


## How was this PR tested?
CI
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.