### PR TITLE
[fc][test] Make retry work and add proper stats prefix for streamingBatchGet

### DIFF
--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/DispatchingAvroGenericStoreClient.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/DispatchingAvroGenericStoreClient.java
@@ -390,7 +390,8 @@ public class DispatchingAvroGenericStoreClient<K, V> extends InternalAvroStoreCl
      * that exception will be passed to the aggregate future's next stages. */
     CompletableFuture.allOf(requestContext.getAllRouteFutures().toArray(new CompletableFuture[0]))
         .whenComplete((response, throwable) -> {
-          if (throwable != null || (keys.size() > 0 && requestContext.getAllRouteFutures().size() == 0)) {
+          if (throwable != null || (!keys.isEmpty() && requestContext.getAllRouteFutures().isEmpty())) {
+            // If there is an exception or if no partition has a healthy replica.
             // The exception to send to the client might be different. Get from the requestContext
             Throwable clientException = throwable;
             if (requestContext.getPartialResponseException().isPresent()) {

--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/RetriableAvroGenericStoreClient.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/RetriableAvroGenericStoreClient.java
@@ -175,6 +175,30 @@ public class RetriableAvroGenericStoreClient<K, V> extends DelegatingAvroStoreCl
    */
   protected CompletableFuture<Map<K, V>> batchGet(BatchGetRequestContext<K, V> requestContext, Set<K> keys)
       throws VeniceClientException {
+    CompletableFuture<Map<K, V>> responseFuture = new CompletableFuture<>();
+    CompletableFuture<VeniceResponseMap<K, V>> streamingResponseFuture = streamingBatchGet(requestContext, keys);
+    streamingResponseFuture.whenComplete((response, throwable) -> {
+      if (throwable != null) {
+        responseFuture.completeExceptionally(throwable);
+      } else if (!response.isFullResponse()) {
+        if (requestContext.getPartialResponseException().isPresent()) {
+          responseFuture.completeExceptionally(
+              new VeniceClientException(
+                  "Response was not complete",
+                  requestContext.getPartialResponseException().get()));
+        } else {
+          responseFuture.completeExceptionally(new VeniceClientException("Response was not complete"));
+        }
+      } else {
+        responseFuture.complete(response);
+      }
+    });
+    return responseFuture;
+  }
+
+  protected CompletableFuture<VeniceResponseMap<K, V>> streamingBatchGet(
+      BatchGetRequestContext<K, V> requestContext,
+      Set<K> keys) throws VeniceClientException {
     // keys that do not exist in the storage nodes
     Queue<K> nonExistingKeys = new ConcurrentLinkedQueue<>();
     VeniceConcurrentHashMap<K, V> valueMap = new VeniceConcurrentHashMap<>();
@@ -204,24 +228,7 @@ public class RetriableAvroGenericStoreClient<K, V> extends DelegatingAvroStoreCl
         }
       }
     });
-    CompletableFuture<Map<K, V>> responseFuture = new CompletableFuture<>();
-    streamingResponseFuture.whenComplete((response, throwable) -> {
-      if (throwable != null) {
-        responseFuture.completeExceptionally(throwable);
-      } else if (!response.isFullResponse()) {
-        if (requestContext.getPartialResponseException().isPresent()) {
-          responseFuture.completeExceptionally(
-              new VeniceClientException(
-                  "Response was not complete",
-                  requestContext.getPartialResponseException().get()));
-        } else {
-          responseFuture.completeExceptionally(new VeniceClientException("Response was not complete"));
-        }
-      } else {
-        responseFuture.complete(response);
-      }
-    });
-    return responseFuture;
+    return streamingResponseFuture;
   }
 
   @Override
@@ -301,7 +308,7 @@ public class RetriableAvroGenericStoreClient<K, V> extends DelegatingAvroStoreCl
       if (finalException == null) {
         callback.onCompletion(Optional.empty());
       } else {
-        callback.onCompletion(Optional.of(new VeniceClientException("Request failed with exception ", finalException)));
+        callback.onCompletion(Optional.of(new VeniceClientException("Request failed with exception", finalException)));
       }
     });
   }

--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/StatsAvroGenericStoreClient.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/StatsAvroGenericStoreClient.java
@@ -31,6 +31,7 @@ public class StatsAvroGenericStoreClient<K, V> extends DelegatingAvroStoreClient
 
   private final FastClientStats clientStatsForSingleGet;
   private final FastClientStats clientStatsForBatchGet;
+  private final FastClientStats clientStatsForStreamingBatchGet;
   private final ClusterStats clusterStats;
 
   private final int maxAllowedKeyCntInBatchGetReq;
@@ -40,6 +41,7 @@ public class StatsAvroGenericStoreClient<K, V> extends DelegatingAvroStoreClient
     super(delegate);
     this.clientStatsForSingleGet = clientConfig.getStats(RequestType.SINGLE_GET);
     this.clientStatsForBatchGet = clientConfig.getStats(RequestType.MULTI_GET);
+    this.clientStatsForStreamingBatchGet = clientConfig.getStats(RequestType.MULTI_GET_STREAMING);
     this.clusterStats = clientConfig.getClusterStats();
     this.maxAllowedKeyCntInBatchGetReq = clientConfig.getMaxAllowedKeyCntInBatchGetReq();
     this.useStreamingBatchGetAsDefault = clientConfig.useStreamingBatchGetAsDefault();
@@ -121,7 +123,7 @@ public class StatsAvroGenericStoreClient<K, V> extends DelegatingAvroStoreClient
         requestContext,
         keys,
         new StatTrackingStreamingCallBack<>(callback, statFuture, requestContext));
-    recordMetrics(requestContext, keys.size(), statFuture, startTimeInNS, clientStatsForBatchGet);
+    recordMetrics(requestContext, keys.size(), statFuture, startTimeInNS, clientStatsForStreamingBatchGet);
   }
 
   @Override
@@ -130,7 +132,7 @@ public class StatsAvroGenericStoreClient<K, V> extends DelegatingAvroStoreClient
       Set<K> keys) {
     long startTimeInNS = System.nanoTime();
     CompletableFuture<VeniceResponseMap<K, V>> streamingBatchGetFuture = super.streamingBatchGet(requestContext, keys);
-    recordMetrics(requestContext, keys.size(), streamingBatchGetFuture, startTimeInNS, clientStatsForBatchGet);
+    recordMetrics(requestContext, keys.size(), streamingBatchGetFuture, startTimeInNS, clientStatsForStreamingBatchGet);
     return streamingBatchGetFuture;
   }
 

--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/StatsAvroGenericStoreClient.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/StatsAvroGenericStoreClient.java
@@ -167,12 +167,6 @@ public class StatsAvroGenericStoreClient<K, V> extends DelegatingAvroStoreClient
 
     return innerFuture.handle((value, throwable) -> {
       double latency = LatencyUtils.getLatencyInMS(startTimeInNS);
-      if (numberOfKeys == 0) {
-        clientStats.recordHealthyRequest();
-        clientStats.recordHealthyLatency(latency);
-        return value;
-      }
-
       clientStats.recordRequestKeyCount(numberOfKeys);
 
       boolean exceptionReceived = false;

--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/StatsAvroGenericStoreClient.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/StatsAvroGenericStoreClient.java
@@ -167,6 +167,12 @@ public class StatsAvroGenericStoreClient<K, V> extends DelegatingAvroStoreClient
 
     return innerFuture.handle((value, throwable) -> {
       double latency = LatencyUtils.getLatencyInMS(startTimeInNS);
+      if (numberOfKeys == 0) {
+        clientStats.recordHealthyRequest();
+        clientStats.recordHealthyLatency(latency);
+        return value;
+      }
+
       clientStats.recordRequestKeyCount(numberOfKeys);
 
       boolean exceptionReceived = false;

--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/StatsAvroGenericStoreClient.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/StatsAvroGenericStoreClient.java
@@ -148,6 +148,14 @@ public class StatsAvroGenericStoreClient<K, V> extends DelegatingAvroStoreClient
     return AppTimeOutTrackingCompletableFuture.track(statFuture, clientStats);
   }
 
+  /**
+   * Metrics are incremented after one of the below cases
+   * 1. request is complete or
+   * 2. exception is thrown or
+   * 3. routingLeakedRequestCleanupThresholdMS is elapsed: In case of streamingBatchGet.get(timeout) returning
+   *            partial response and this timeout happens after than and before the full response is returned,
+   *            it will still raise a silent exception leading to the request being considered an unhealthy request.
+   */
   private <R> CompletableFuture<R> recordRequestMetrics(
       RequestContext requestContext,
       int numberOfKeys,

--- a/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/BatchGetAvroStoreClientUnitTest.java
+++ b/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/BatchGetAvroStoreClientUnitTest.java
@@ -709,7 +709,7 @@ public class BatchGetAvroStoreClientUnitTest {
       double expectedNumberOfKeysToBeRetried,
       double expectedNumberOfKeysToBeRetriedSuccessfully) {
     Map<String, ? extends Metric> metrics = getStats(client.getClientConfig());
-    String metricPrefix = "." + client.UNIT_TEST_STORE_NAME + "--multiget_";
+    String metricPrefix = "." + client.UNIT_TEST_STORE_NAME + "--multiget_streaming_";
     if (totalNumberOfKeys > 0) {
       assertTrue(metrics.get(metricPrefix + "request.OccurrenceRate").value() > 0);
       assertEquals(metrics.get(metricPrefix + "request_key_count.Max").value(), totalNumberOfKeys);

--- a/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/DispatchingAvroGenericStoreClientTest.java
+++ b/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/DispatchingAvroGenericStoreClientTest.java
@@ -588,13 +588,7 @@ public class DispatchingAvroGenericStoreClientTest {
         BATCH_GET_KEYS.stream().forEach(key -> {
           assertTrue(SINGLE_GET_VALUE_RESPONSE.contentEquals(value.get(key)));
         });
-        validateMultiGetMetrics(
-            true,
-            false,
-            useStreamingBatchGetAsDefault,
-            false,
-            false,
-            useStreamingBatchGetAsDefault ? 2 : 1);
+        validateMultiGetMetrics(true, false, useStreamingBatchGetAsDefault, false, false, 1);
       }
     } catch (Exception e) {
       if (useStreamingBatchGetAsDefault) {

--- a/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/RetriableAvroGenericStoreClientTest.java
+++ b/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/RetriableAvroGenericStoreClientTest.java
@@ -244,7 +244,7 @@ public class RetriableAvroGenericStoreClientTest {
       }
     }
 
-    validateMetrics(false, errorRetry, longTailRetry, retryWin);
+    validateMetrics(false, false, errorRetry, longTailRetry, retryWin);
   }
 
   private void testBatchGetAndValidateMetrics(
@@ -272,7 +272,7 @@ public class RetriableAvroGenericStoreClientTest {
       }
     }
 
-    validateMetrics(true, false, longTailRetry, retryWin);
+    validateMetrics(true, false, false, longTailRetry, retryWin);
   }
 
   private void testStreamingBatchGetAndValidateMetrics(
@@ -301,7 +301,7 @@ public class RetriableAvroGenericStoreClientTest {
       }
     }
 
-    validateMetrics(true, false, longTailRetry, retryWin);
+    validateMetrics(true, true, false, longTailRetry, retryWin);
   }
 
   /**
@@ -311,9 +311,15 @@ public class RetriableAvroGenericStoreClientTest {
    * @param longTailRetry request is retried because the original request is taking more time
    * @param retryWin retry request wins
    */
-  private void validateMetrics(boolean batchGet, boolean errorRetry, boolean longTailRetry, boolean retryWin) {
+  private void validateMetrics(
+      boolean batchGet,
+      boolean streamingBatchGet,
+      boolean errorRetry,
+      boolean longTailRetry,
+      boolean retryWin) {
     metrics = getStats(clientConfig);
-    String metricsPrefix = "." + STORE_NAME + (batchGet ? "--multiget_" : "--");
+    String metricsPrefix =
+        "." + STORE_NAME + (batchGet ? (streamingBatchGet ? "--multiget_streaming_" : "--multiget_") : "--");
     double expectedKeyCount = batchGet ? 2.0 : 1.0;
 
     TestUtils.waitForNonDeterministicAssertion(5, TimeUnit.SECONDS, () -> {

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/fastclient/AvroStoreClientEndToEndTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/fastclient/AvroStoreClientEndToEndTest.java
@@ -306,6 +306,7 @@ public class AvroStoreClientEndToEndTest extends AbstractClientEndToEndSetup {
         fastClientStatsValidation = metricsRepository -> validateBatchGetMetrics(
             metricsRepository,
             useStreamingBatchGetAsDefault,
+            false,
             batchGetKeySize,
             batchGetKeySize,
             false);
@@ -418,6 +419,7 @@ public class AvroStoreClientEndToEndTest extends AbstractClientEndToEndSetup {
     fastClientStatsValidation = metricsRepository -> validateBatchGetMetrics(
         metricsRepository,
         true, // testing batch get with useStreamingBatchGetAsDefault as true
+        false,
         recordCnt,
         recordCnt,
         false);
@@ -449,7 +451,7 @@ public class AvroStoreClientEndToEndTest extends AbstractClientEndToEndSetup {
       clientConfigBuilder.setLongTailRetryEnabledForBatchGet(true)
           .setLongTailRetryThresholdForBatchGetInMicroSeconds(1);
       fastClientStatsValidation =
-          metricsRepository -> validateBatchGetMetrics(metricsRepository, true, recordCnt, recordCnt, true);
+          metricsRepository -> validateBatchGetMetrics(metricsRepository, true, false, recordCnt, recordCnt, true);
     } else {
       clientConfigBuilder.setLongTailRetryEnabledForSingleGet(true)
           .setLongTailRetryThresholdForSingleGetInMicroSeconds(1);

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/fastclient/AvroStoreClientEndToEndTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/fastclient/AvroStoreClientEndToEndTest.java
@@ -1,5 +1,6 @@
 package com.linkedin.venice.fastclient;
 
+import static com.linkedin.venice.utils.Time.MS_PER_SECOND;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
@@ -228,13 +229,14 @@ public class AvroStoreClientEndToEndTest extends AbstractClientEndToEndSetup {
     }
   }
 
-  @Test(dataProvider = "FastClient-Five-Boolean-A-Number-Store-Metadata-Fetch-Mode", timeOut = TIME_OUT)
+  @Test(dataProvider = "FastClient-Six-Boolean-A-Number-Store-Metadata-Fetch-Mode", timeOut = TIME_OUT)
   public void testFastClientGet(
       boolean dualRead,
       boolean speculativeQueryEnabled,
       boolean batchGet,
       boolean useStreamingBatchGetAsDefault,
       boolean enableGrpc,
+      boolean retryEnabled,
       int batchGetKeySize,
       StoreMetadataFetchMode storeMetadataFetchMode) throws Exception {
     ClientConfig.ClientConfigBuilder clientConfigBuilder =
@@ -254,6 +256,13 @@ public class AvroStoreClientEndToEndTest extends AbstractClientEndToEndSetup {
 
     if (enableGrpc) {
       setUpGrpcFastClient(clientConfigBuilder);
+    }
+
+    if (retryEnabled) {
+      clientConfigBuilder.setLongTailRetryEnabledForSingleGet(true)
+          .setLongTailRetryThresholdForSingleGetInMicroSeconds(TIME_OUT * MS_PER_SECOND)
+          .setLongTailRetryEnabledForBatchGet(true)
+          .setLongTailRetryThresholdForBatchGetInMicroSeconds(TIME_OUT * MS_PER_SECOND);
     }
 
     // dualRead needs thinClient

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/fastclient/AvroStoreClientEndToEndTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/fastclient/AvroStoreClientEndToEndTest.java
@@ -259,6 +259,8 @@ public class AvroStoreClientEndToEndTest extends AbstractClientEndToEndSetup {
     }
 
     if (retryEnabled) {
+      // enable retry to test the code path: to mimic retry in integration tests
+      // can be non-deterministic, so setting big retry threshold to not actually retry
       clientConfigBuilder.setLongTailRetryEnabledForSingleGet(true)
           .setLongTailRetryThresholdForSingleGetInMicroSeconds(TIME_OUT * MS_PER_SECOND)
           .setLongTailRetryEnabledForBatchGet(true)

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/fastclient/AvroStoreClientGzipEndToEndTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/fastclient/AvroStoreClientGzipEndToEndTest.java
@@ -18,13 +18,21 @@ import org.testng.annotations.DataProvider;
 
 public class AvroStoreClientGzipEndToEndTest extends AvroStoreClientEndToEndTest {
   @Override
-  @DataProvider(name = "FastClient-Five-Boolean-A-Number-Store-Metadata-Fetch-Mode")
-  public Object[][] fiveBooleanANumberStoreMetadataFetchMode() {
+  @DataProvider(name = "FastClient-Six-Boolean-A-Number-Store-Metadata-Fetch-Mode")
+  public Object[][] sixBooleanANumberStoreMetadataFetchMode() {
     return DataProviderUtils.allPermutationGenerator((permutation) -> {
+      boolean speculativeQueryEnabled = (boolean) permutation[1];
+      if (speculativeQueryEnabled) {
+        return false;
+      }
       boolean batchGet = (boolean) permutation[2];
       boolean useStreamingBatchGetAsDefault = (boolean) permutation[3];
-      int batchGetKeySize = (int) permutation[5];
-      StoreMetadataFetchMode storeMetadataFetchMode = (StoreMetadataFetchMode) permutation[6];
+      boolean retryEnabled = (boolean) permutation[5];
+      if (retryEnabled) {
+        return false;
+      }
+      int batchGetKeySize = (int) permutation[6];
+      StoreMetadataFetchMode storeMetadataFetchMode = (StoreMetadataFetchMode) permutation[7];
       if (!batchGet) {
         if (useStreamingBatchGetAsDefault || batchGetKeySize != (int) BATCH_GET_KEY_SIZE.get(0)) {
           // these parameters are related only to batchGet, so just allowing 1 set
@@ -32,7 +40,8 @@ public class AvroStoreClientGzipEndToEndTest extends AvroStoreClientEndToEndTest
           return false;
         }
       }
-      if (storeMetadataFetchMode == StoreMetadataFetchMode.DA_VINCI_CLIENT_BASED_METADATA) {
+
+      if (storeMetadataFetchMode != StoreMetadataFetchMode.SERVER_BASED_METADATA) {
         return false;
       }
       return true;
@@ -42,6 +51,7 @@ public class AvroStoreClientGzipEndToEndTest extends AvroStoreClientEndToEndTest
         DataProviderUtils.BOOLEAN, // batchGet
         DataProviderUtils.BOOLEAN_TRUE, // useStreamingBatchGetAsDefault
         DataProviderUtils.BOOLEAN, // enableGrpc
+        DataProviderUtils.BOOLEAN, // retryEnabled
         BATCH_GET_KEY_SIZE.toArray(), // batchGetKeySize
         STORE_METADATA_FETCH_MODES); // storeMetadataFetchMode
   }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/fastclient/AvroStoreClientZstdEndToEndTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/fastclient/AvroStoreClientZstdEndToEndTest.java
@@ -22,13 +22,21 @@ import org.testng.annotations.DataProvider;
 
 public class AvroStoreClientZstdEndToEndTest extends AvroStoreClientEndToEndTest {
   @Override
-  @DataProvider(name = "FastClient-Five-Boolean-A-Number-Store-Metadata-Fetch-Mode")
-  public Object[][] fiveBooleanANumberStoreMetadataFetchMode() {
+  @DataProvider(name = "FastClient-Six-Boolean-A-Number-Store-Metadata-Fetch-Mode")
+  public Object[][] sixBooleanANumberStoreMetadataFetchMode() {
     return DataProviderUtils.allPermutationGenerator((permutation) -> {
+      boolean speculativeQueryEnabled = (boolean) permutation[1];
+      if (speculativeQueryEnabled) {
+        return false;
+      }
       boolean batchGet = (boolean) permutation[2];
       boolean useStreamingBatchGetAsDefault = (boolean) permutation[3];
-      int batchGetKeySize = (int) permutation[5];
-      StoreMetadataFetchMode storeMetadataFetchMode = (StoreMetadataFetchMode) permutation[6];
+      boolean retryEnabled = (boolean) permutation[5];
+      if (retryEnabled) {
+        return false;
+      }
+      int batchGetKeySize = (int) permutation[6];
+      StoreMetadataFetchMode storeMetadataFetchMode = (StoreMetadataFetchMode) permutation[7];
       if (!batchGet) {
         if (useStreamingBatchGetAsDefault || batchGetKeySize != (int) BATCH_GET_KEY_SIZE.get(0)) {
           // these parameters are related only to batchGet, so just allowing 1 set
@@ -36,7 +44,7 @@ public class AvroStoreClientZstdEndToEndTest extends AvroStoreClientEndToEndTest
           return false;
         }
       }
-      if (storeMetadataFetchMode == StoreMetadataFetchMode.DA_VINCI_CLIENT_BASED_METADATA) {
+      if (storeMetadataFetchMode != StoreMetadataFetchMode.SERVER_BASED_METADATA) {
         return false;
       }
       return true;
@@ -46,6 +54,7 @@ public class AvroStoreClientZstdEndToEndTest extends AvroStoreClientEndToEndTest
         DataProviderUtils.BOOLEAN, // batchGet
         DataProviderUtils.BOOLEAN_TRUE, // useStreamingBatchGetAsDefault
         DataProviderUtils.BOOLEAN, // enableGrpc
+        DataProviderUtils.BOOLEAN, // retryEnabled
         BATCH_GET_KEY_SIZE.toArray(), // batchGetKeySize
         STORE_METADATA_FETCH_MODES); // storeMetadataFetchMode
   }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/fastclient/BatchGetAvroStoreClientTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/fastclient/BatchGetAvroStoreClientTest.java
@@ -135,8 +135,8 @@ public class BatchGetAvroStoreClientTest extends AbstractClientEndToEndSetup {
             .setUseStreamingBatchGetAsDefault(useStreamingBatchGetAsDefault);
 
     if (retryEnabled) {
-      // enable retry to test the code path: mimic retry in integration tests
-      // be non-deterministic, so setting big retry threshold to not actually retry
+      // enable retry to test the code path: to mimic retry in integration tests
+      // can be non-deterministic, so setting big retry threshold to not actually retry
       clientConfigBuilder.setLongTailRetryEnabledForBatchGet(true)
           .setLongTailRetryThresholdForBatchGetInMicroSeconds(10 * US_PER_SECOND);
     }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/fastclient/BatchGetAvroStoreClientTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/fastclient/BatchGetAvroStoreClientTest.java
@@ -158,7 +158,7 @@ public class BatchGetAvroStoreClientTest extends AbstractClientEndToEndSetup {
       assertEquals(value.get(VALUE_FIELD_NAME), i);
     }
 
-    validateBatchGetMetrics(metricsRepository, useStreamingBatchGetAsDefault, recordCnt + 1, recordCnt, false);
+    validateBatchGetMetrics(metricsRepository, useStreamingBatchGetAsDefault, false, recordCnt + 1, recordCnt, false);
 
     FastClientStats stats = clientConfig.getStats(RequestType.MULTI_GET);
     LOGGER.info("STATS: {}", stats.buildSensorStatSummary("multiget_healthy_request_latency"));
@@ -195,7 +195,7 @@ public class BatchGetAvroStoreClientTest extends AbstractClientEndToEndSetup {
       assertEquals(value.get(VALUE_FIELD_NAME), i);
     }
 
-    validateBatchGetMetrics(metricsRepository, useStreamingBatchGetAsDefault, recordCnt, recordCnt, false);
+    validateBatchGetMetrics(metricsRepository, useStreamingBatchGetAsDefault, false, recordCnt, recordCnt, false);
 
     specificFastClient.close();
     printAllStats();
@@ -247,7 +247,7 @@ public class BatchGetAvroStoreClientTest extends AbstractClientEndToEndSetup {
         1,
         "Incorrect non existing key size . Expected  1 got " + veniceResponseMap.getNonExistingKeys().size());
 
-    validateBatchGetMetrics(metricsRepository, true, recordCnt + 1, recordCnt, false);
+    validateBatchGetMetrics(metricsRepository, true, true, recordCnt + 1, recordCnt, false);
   }
 
   @Test(dataProvider = "StoreMetadataFetchModes", timeOut = TIME_OUT)
@@ -323,7 +323,7 @@ public class BatchGetAvroStoreClientTest extends AbstractClientEndToEndSetup {
         "STATS: latency -> {}",
         stats.buildSensorStatSummary("multiget_healthy_request_latency", "99thPercentile"));
 
-    validateBatchGetMetrics(metricsRepository, true, recordCnt + 1, recordCnt, false);
+    validateBatchGetMetrics(metricsRepository, true, true, recordCnt + 1, recordCnt, false);
     printAllStats();
   }
 }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/fastclient/BatchGetAvroStoreClientTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/fastclient/BatchGetAvroStoreClientTest.java
@@ -1,6 +1,6 @@
 package com.linkedin.venice.fastclient;
 
-import static com.linkedin.venice.utils.Time.US_PER_SECOND;
+import static com.linkedin.venice.utils.Time.MS_PER_SECOND;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
@@ -138,7 +138,7 @@ public class BatchGetAvroStoreClientTest extends AbstractClientEndToEndSetup {
       // enable retry to test the code path: to mimic retry in integration tests
       // can be non-deterministic, so setting big retry threshold to not actually retry
       clientConfigBuilder.setLongTailRetryEnabledForBatchGet(true)
-          .setLongTailRetryThresholdForBatchGetInMicroSeconds(10 * US_PER_SECOND);
+          .setLongTailRetryThresholdForBatchGetInMicroSeconds(TIME_OUT * MS_PER_SECOND);
     }
 
     MetricsRepository metricsRepository = new MetricsRepository();

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/fastclient/BatchGetAvroStoreClientTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/fastclient/BatchGetAvroStoreClientTest.java
@@ -201,13 +201,21 @@ public class BatchGetAvroStoreClientTest extends AbstractClientEndToEndSetup {
     printAllStats();
   }
 
-  @Test(dataProvider = "StoreMetadataFetchModes", timeOut = TIME_OUT)
-  public void testStreamingBatchGetGenericClient(StoreMetadataFetchMode storeMetadataFetchMode) throws Exception {
+  @Test(dataProvider = "Boolean-And-StoreMetadataFetchModes", timeOut = TIME_OUT)
+  public void testStreamingBatchGetGenericClient(boolean retryEnabled, StoreMetadataFetchMode storeMetadataFetchMode)
+      throws Exception {
     ClientConfig.ClientConfigBuilder clientConfigBuilder =
         new ClientConfig.ClientConfigBuilder<>().setStoreName(storeName)
             .setR2Client(r2Client)
-            .setSpeculativeQueryEnabled(true)
+            .setSpeculativeQueryEnabled(false)
             .setDualReadEnabled(false);
+
+    if (retryEnabled) {
+      // enable retry to test the code path: to mimic retry in integration tests
+      // can be non-deterministic, so setting big retry threshold to not actually retry
+      clientConfigBuilder.setLongTailRetryEnabledForBatchGet(true)
+          .setLongTailRetryThresholdForBatchGetInMicroSeconds(TIME_OUT * MS_PER_SECOND);
+    }
 
     MetricsRepository metricsRepository = new MetricsRepository();
     AvroGenericStoreClient<String, GenericRecord> genericFastClient =
@@ -250,14 +258,22 @@ public class BatchGetAvroStoreClientTest extends AbstractClientEndToEndSetup {
     validateBatchGetMetrics(metricsRepository, true, true, recordCnt + 1, recordCnt, false);
   }
 
-  @Test(dataProvider = "StoreMetadataFetchModes", timeOut = TIME_OUT)
-  public void testStreamingBatchGetWithCallbackGenericClient(StoreMetadataFetchMode storeMetadataFetchMode)
-      throws Exception {
+  @Test(dataProvider = "Boolean-And-StoreMetadataFetchModes", timeOut = TIME_OUT)
+  public void testStreamingBatchGetWithCallbackGenericClient(
+      boolean retryEnabled,
+      StoreMetadataFetchMode storeMetadataFetchMode) throws Exception {
     ClientConfig.ClientConfigBuilder clientConfigBuilder =
         new ClientConfig.ClientConfigBuilder<>().setStoreName(storeName)
             .setR2Client(r2Client)
-            .setSpeculativeQueryEnabled(true)
+            .setSpeculativeQueryEnabled(false)
             .setDualReadEnabled(false);
+
+    if (retryEnabled) {
+      // enable retry to test the code path: to mimic retry in integration tests
+      // can be non-deterministic, so setting big retry threshold to not actually retry
+      clientConfigBuilder.setLongTailRetryEnabledForBatchGet(true)
+          .setLongTailRetryThresholdForBatchGetInMicroSeconds(TIME_OUT * MS_PER_SECOND);
+    }
 
     MetricsRepository metricsRepository = new MetricsRepository();
     AvroGenericStoreClient<String, GenericRecord> genericFastClient =

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/fastclient/utils/AbstractClientEndToEndSetup.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/fastclient/utils/AbstractClientEndToEndSetup.java
@@ -215,6 +215,11 @@ public abstract class AbstractClientEndToEndSetup {
     return DataProviderUtils.allPermutationGenerator(STORE_METADATA_FETCH_MODES);
   }
 
+  @DataProvider(name = "Boolean-And-StoreMetadataFetchModes")
+  public static Object[][] booleanAndstoreMetadataFetchModes() {
+    return DataProviderUtils.allPermutationGenerator(DataProviderUtils.BOOLEAN, STORE_METADATA_FETCH_MODES);
+  }
+
   @BeforeClass(alwaysRun = true)
   public void setUp() throws Exception {
     Utils.thisIsLocalhost();

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/fastclient/utils/AbstractClientEndToEndSetup.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/fastclient/utils/AbstractClientEndToEndSetup.java
@@ -109,7 +109,7 @@ public abstract class AbstractClientEndToEndSetup {
 
   protected ClientConfig clientConfig;
 
-  protected static final long TIME_OUT = 60 * Time.MS_PER_SECOND;
+  protected static final int TIME_OUT = 60 * Time.MS_PER_SECOND;
   protected static final String KEY_SCHEMA_STR = "\"string\"";
   protected static final String VALUE_FIELD_NAME = "int_field";
   protected static final String VALUE_SCHEMA_STR = "{\n" + "\"type\": \"record\",\n"
@@ -133,18 +133,29 @@ public abstract class AbstractClientEndToEndSetup {
    */
   protected static final ImmutableList<Object> BATCH_GET_KEY_SIZE = ImmutableList.of(2, recordCnt);
 
-  @DataProvider(name = "FastClient-Five-Boolean-A-Number-Store-Metadata-Fetch-Mode")
-  public Object[][] fiveBooleanANumberStoreMetadataFetchMode() {
+  @DataProvider(name = "FastClient-Six-Boolean-A-Number-Store-Metadata-Fetch-Mode")
+  public Object[][] sixBooleanANumberStoreMetadataFetchMode() {
     return DataProviderUtils.allPermutationGenerator((permutation) -> {
+      boolean speculativeQueryEnabled = (boolean) permutation[1];
       boolean batchGet = (boolean) permutation[2];
       boolean useStreamingBatchGetAsDefault = (boolean) permutation[3];
-      int batchGetKeySize = (int) permutation[5];
+      boolean retryEnabled = (boolean) permutation[5];
+      int batchGetKeySize = (int) permutation[6];
+      StoreMetadataFetchMode storeMetadataFetchMode = (StoreMetadataFetchMode) permutation[7];
       if (!batchGet) {
         if (useStreamingBatchGetAsDefault || batchGetKeySize != (int) BATCH_GET_KEY_SIZE.get(0)) {
           // these parameters are related only to batchGet, so just allowing 1 set
           // to avoid duplicate tests
           return false;
         }
+      }
+      if (storeMetadataFetchMode != StoreMetadataFetchMode.SERVER_BASED_METADATA) {
+        if (retryEnabled || speculativeQueryEnabled) {
+          return false;
+        }
+      }
+      if (retryEnabled && speculativeQueryEnabled) {
+        return false;
       }
       return true;
     },
@@ -153,6 +164,7 @@ public abstract class AbstractClientEndToEndSetup {
         DataProviderUtils.BOOLEAN, // batchGet
         DataProviderUtils.BOOLEAN, // useStreamingBatchGetAsDefault
         DataProviderUtils.BOOLEAN, // enableGrpc
+        DataProviderUtils.BOOLEAN, // retryEnabled
         BATCH_GET_KEY_SIZE.toArray(), // batchGetKeySize
         STORE_METADATA_FETCH_MODES); // storeMetadataFetchMode
   }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/fastclient/utils/AbstractClientEndToEndSetup.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/fastclient/utils/AbstractClientEndToEndSetup.java
@@ -512,16 +512,18 @@ public abstract class AbstractClientEndToEndSetup {
   }
 
   protected void validateSingleGetMetrics(MetricsRepository metricsRepository, boolean retryEnabled) {
-    validateBatchGetMetrics(metricsRepository, false, 0, 0, retryEnabled);
+    validateBatchGetMetrics(metricsRepository, false, false, 0, 0, retryEnabled);
   }
 
   protected void validateBatchGetMetrics(
       MetricsRepository metricsRepository,
       boolean useStreamingBatchGetAsDefault,
+      boolean streamingBatchGetApi,
       int expectedBatchGetKeySizeMetricsCount,
       int expectedBatchGetKeySizeSuccessMetricsCount,
       boolean retryEnabled) {
-    String metricPrefix = "." + storeName + (useStreamingBatchGetAsDefault ? "--multiget_" : "--");
+    String metricPrefix = "." + storeName
+        + (streamingBatchGetApi ? "--multiget_streaming_" : (useStreamingBatchGetAsDefault ? "--multiget_" : "--"));
     double keyCount = useStreamingBatchGetAsDefault ? expectedBatchGetKeySizeMetricsCount : 1;
     double successKeyCount = useStreamingBatchGetAsDefault ? expectedBatchGetKeySizeSuccessMetricsCount : 1;
     Map<String, ? extends Metric> metrics = metricsRepository.metrics();


### PR DESCRIPTION
## Summary
1. Retry was not working for `streamingBatchGet(keys)` as the proper delegation was not happening in `RetriableAvroGenericStoreClient.java`. This change fixes this problem.
2. make streamingBatchGet use `--multiget_streaming_` rather than `--multiget_` as prefix for metrics.
    - `batchGet()` using single get uses single get metrics
    - `batchGet()` using streaming implementation uses `--multiget_`
    - `streamingBatchGet` uses `--multiget_streaming_`
3. return an exception if every key hits no replica found issue. Before this change, even though this case didn't increment successful key count metric and increment no replica found metric, it was still considering the request to healthy. After this change, this is considered unhealthy metric. Even after this change, if at least one of the routes find a replica and is successful, `streamingBatchGet` considers this a healthy request as this is a partial API.
4. Add additional unit and integration tests for `streamingBatchGet` and retry cases.

## How was this PR tested?
GH CI

## Does this PR introduce any user-facing changes?
- [x] No. You can skip the rest of this section.
- [] Yes. Make sure to explain your proposed changes and call out the behavior change.