### PR TITLE
[server][controller] KME Schema Registration To ZK On Startup

### DIFF
--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceController.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceController.java
@@ -235,25 +235,27 @@ public class VeniceController {
   private void initializeSystemSchema(Admin admin) {
     String systemStoreCluster = multiClusterConfigs.getSystemSchemaClusterName();
     VeniceControllerConfig systemStoreClusterConfig = multiClusterConfigs.getControllerConfig(systemStoreCluster);
-    if (!multiClusterConfigs.isParent() && multiClusterConfigs.isZkSharedMetaSystemSchemaStoreAutoCreationEnabled()
-        && systemStoreClusterConfig.isSystemSchemaInitializationAtStartTimeEnabled()) {
+    if (!multiClusterConfigs.isParent() && systemStoreClusterConfig.isSystemSchemaInitializationAtStartTimeEnabled()) {
       String regionName = systemStoreClusterConfig.getRegionName();
       String childControllerUrl = systemStoreClusterConfig.getChildControllerUrl(regionName);
       String d2ServiceName = systemStoreClusterConfig.getD2ServiceName();
       String d2ZkHost = systemStoreClusterConfig.getChildControllerD2ZkHost(regionName);
       boolean sslOnly = systemStoreClusterConfig.isControllerEnforceSSLOnly();
-      ControllerClientBackedSystemSchemaInitializer metaSystemStoreSchemaInitializer =
-          new ControllerClientBackedSystemSchemaInitializer(
-              AvroProtocolDefinition.METADATA_SYSTEM_SCHEMA_STORE,
-              systemStoreCluster,
-              AvroProtocolDefinition.METADATA_SYSTEM_SCHEMA_STORE_KEY.getCurrentProtocolVersionSchema(),
-              VeniceSystemStoreUtils.DEFAULT_USER_SYSTEM_STORE_UPDATE_QUERY_PARAMS,
-              true,
-              ((VeniceHelixAdmin) admin).getSslFactory(),
-              childControllerUrl,
-              d2ServiceName,
-              d2ZkHost,
-              sslOnly);
+      if (multiClusterConfigs.isZkSharedMetaSystemSchemaStoreAutoCreationEnabled()) {
+        ControllerClientBackedSystemSchemaInitializer metaSystemStoreSchemaInitializer =
+            new ControllerClientBackedSystemSchemaInitializer(
+                AvroProtocolDefinition.METADATA_SYSTEM_SCHEMA_STORE,
+                systemStoreCluster,
+                AvroProtocolDefinition.METADATA_SYSTEM_SCHEMA_STORE_KEY.getCurrentProtocolVersionSchema(),
+                VeniceSystemStoreUtils.DEFAULT_USER_SYSTEM_STORE_UPDATE_QUERY_PARAMS,
+                true,
+                ((VeniceHelixAdmin) admin).getSslFactory(),
+                childControllerUrl,
+                d2ServiceName,
+                d2ZkHost,
+                sslOnly);
+        metaSystemStoreSchemaInitializer.execute();
+      }
       ControllerClientBackedSystemSchemaInitializer kmeSchemaInitializer =
           new ControllerClientBackedSystemSchemaInitializer(
               AvroProtocolDefinition.KAFKA_MESSAGE_ENVELOPE,
@@ -266,7 +268,6 @@ public class VeniceController {
               d2ServiceName,
               d2ZkHost,
               sslOnly);
-      metaSystemStoreSchemaInitializer.execute();
       kmeSchemaInitializer.execute();
     }
   }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceController.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceController.java
@@ -238,6 +238,10 @@ public class VeniceController {
     if (!multiClusterConfigs.isParent() && multiClusterConfigs.isZkSharedMetaSystemSchemaStoreAutoCreationEnabled()
         && systemStoreClusterConfig.isSystemSchemaInitializationAtStartTimeEnabled()) {
       String regionName = systemStoreClusterConfig.getRegionName();
+      String childControllerUrl = systemStoreClusterConfig.getChildControllerUrl(regionName);
+      String d2ServiceName = systemStoreClusterConfig.getD2ServiceName();
+      String d2ZkHost = systemStoreClusterConfig.getChildControllerD2ZkHost(regionName);
+      boolean sslOnly = systemStoreClusterConfig.isControllerEnforceSSLOnly();
       ControllerClientBackedSystemSchemaInitializer metaSystemStoreSchemaInitializer =
           new ControllerClientBackedSystemSchemaInitializer(
               AvroProtocolDefinition.METADATA_SYSTEM_SCHEMA_STORE,
@@ -246,11 +250,24 @@ public class VeniceController {
               VeniceSystemStoreUtils.DEFAULT_USER_SYSTEM_STORE_UPDATE_QUERY_PARAMS,
               true,
               ((VeniceHelixAdmin) admin).getSslFactory(),
-              systemStoreClusterConfig.getChildControllerUrl(regionName),
-              systemStoreClusterConfig.getChildControllerD2ServiceName(),
-              systemStoreClusterConfig.getChildControllerD2ZkHost(regionName),
-              systemStoreClusterConfig.isControllerEnforceSSLOnly());
+              childControllerUrl,
+              d2ServiceName,
+              d2ZkHost,
+              sslOnly);
+      ControllerClientBackedSystemSchemaInitializer kmeSchemaInitializer =
+          new ControllerClientBackedSystemSchemaInitializer(
+              AvroProtocolDefinition.KAFKA_MESSAGE_ENVELOPE,
+              systemStoreCluster,
+              null,
+              null,
+              false,
+              ((VeniceHelixAdmin) admin).getSslFactory(),
+              childControllerUrl,
+              d2ServiceName,
+              d2ZkHost,
+              sslOnly);
       metaSystemStoreSchemaInitializer.execute();
+      kmeSchemaInitializer.execute();
     }
   }
 

--- a/services/venice-server/src/main/java/com/linkedin/venice/server/VeniceServer.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/server/VeniceServer.java
@@ -207,11 +207,11 @@ public class VeniceServer {
       String localControllerUrl = serverConfig.getLocalControllerUrl();
       String d2ServiceName = serverConfig.getLocalControllerD2ServiceName();
       String d2ZkHost = serverConfig.getLocalD2ZkHost();
-      String cluster = serverConfig.getSystemSchemaClusterName();
+      String systemStoreCluster = serverConfig.getSystemSchemaClusterName();
       ControllerClientBackedSystemSchemaInitializer metaSystemStoreSchemaInitializer =
           new ControllerClientBackedSystemSchemaInitializer(
               AvroProtocolDefinition.METADATA_SYSTEM_SCHEMA_STORE,
-              cluster,
+              systemStoreCluster,
               AvroProtocolDefinition.METADATA_SYSTEM_SCHEMA_STORE_KEY.getCurrentProtocolVersionSchema(),
               VeniceSystemStoreUtils.DEFAULT_USER_SYSTEM_STORE_UPDATE_QUERY_PARAMS,
               true,
@@ -223,7 +223,7 @@ public class VeniceServer {
       ControllerClientBackedSystemSchemaInitializer kmeSchemaInitializer =
           new ControllerClientBackedSystemSchemaInitializer(
               AvroProtocolDefinition.KAFKA_MESSAGE_ENVELOPE,
-              cluster,
+              systemStoreCluster,
               null,
               null,
               false,
@@ -256,11 +256,11 @@ public class VeniceServer {
       storeVersionStateSchemaReader.ifPresent(
           schemaReader -> new SchemaPresenceChecker(schemaReader, AvroProtocolDefinition.STORE_VERSION_STATE)
               .verifySchemaVersionPresentOrExit());
-      kafkaMessageEnvelopeSchemaReader.ifPresent(
-          schemaReader -> new SchemaPresenceChecker(schemaReader, AvroProtocolDefinition.KAFKA_MESSAGE_ENVELOPE)
-              .verifySchemaVersionPresentOrExit());
       // For system schemas initialized via controller client, no need to verify again because they should already exist
       if (!serverConfig.isSystemSchemaInitializationAtStartTimeEnabled()) {
+        kafkaMessageEnvelopeSchemaReader.ifPresent(
+            schemaReader -> new SchemaPresenceChecker(schemaReader, AvroProtocolDefinition.KAFKA_MESSAGE_ENVELOPE)
+                .verifySchemaVersionPresentOrExit());
         Optional<SchemaReader> metaSystemStoreSchemaReader = clientConfigForConsumer.map(
             cc -> ClientFactory.getSchemaReader(
                 cc.setStoreName(AvroProtocolDefinition.METADATA_SYSTEM_SCHEMA_STORE.getSystemStoreName()),

--- a/services/venice-server/src/main/java/com/linkedin/venice/server/VeniceServer.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/server/VeniceServer.java
@@ -204,6 +204,9 @@ public class VeniceServer {
     jvmStats = new VeniceJVMStats(metricsRepository, "VeniceJVMStats");
 
     if (serverConfig.isSystemSchemaInitializationAtStartTimeEnabled()) {
+      String childControllerUrl = serverConfig.getLocalControllerUrl();
+      String d2ServiceName = serverConfig.getLocalControllerD2ServiceName();
+      String d2ZkHost = serverConfig.getLocalD2ZkHost();
       ControllerClientBackedSystemSchemaInitializer metaSystemStoreSchemaInitializer =
           new ControllerClientBackedSystemSchemaInitializer(
               AvroProtocolDefinition.METADATA_SYSTEM_SCHEMA_STORE,
@@ -216,7 +219,20 @@ public class VeniceServer {
               serverConfig.getLocalControllerD2ServiceName(),
               serverConfig.getLocalD2ZkHost(),
               false);
+      ControllerClientBackedSystemSchemaInitializer kmeSchemaInitializer =
+          new ControllerClientBackedSystemSchemaInitializer(
+              AvroProtocolDefinition.KAFKA_MESSAGE_ENVELOPE,
+              serverConfig.getSystemSchemaClusterName(),
+              null,
+              null,
+              false,
+              sslFactory,
+              childControllerUrl,
+              d2ServiceName,
+              d2ZkHost,
+              false);
       metaSystemStoreSchemaInitializer.execute();
+      kmeSchemaInitializer.execute();
     }
 
     Optional<SchemaReader> partitionStateSchemaReader = clientConfigForConsumer.map(

--- a/services/venice-server/src/main/java/com/linkedin/venice/server/VeniceServer.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/server/VeniceServer.java
@@ -204,30 +204,31 @@ public class VeniceServer {
     jvmStats = new VeniceJVMStats(metricsRepository, "VeniceJVMStats");
 
     if (serverConfig.isSystemSchemaInitializationAtStartTimeEnabled()) {
-      String childControllerUrl = serverConfig.getLocalControllerUrl();
+      String localControllerUrl = serverConfig.getLocalControllerUrl();
       String d2ServiceName = serverConfig.getLocalControllerD2ServiceName();
       String d2ZkHost = serverConfig.getLocalD2ZkHost();
+      String cluster = serverConfig.getSystemSchemaClusterName();
       ControllerClientBackedSystemSchemaInitializer metaSystemStoreSchemaInitializer =
           new ControllerClientBackedSystemSchemaInitializer(
               AvroProtocolDefinition.METADATA_SYSTEM_SCHEMA_STORE,
-              serverConfig.getSystemSchemaClusterName(),
+              cluster,
               AvroProtocolDefinition.METADATA_SYSTEM_SCHEMA_STORE_KEY.getCurrentProtocolVersionSchema(),
               VeniceSystemStoreUtils.DEFAULT_USER_SYSTEM_STORE_UPDATE_QUERY_PARAMS,
               true,
               sslFactory,
-              serverConfig.getLocalControllerUrl(),
-              serverConfig.getLocalControllerD2ServiceName(),
-              serverConfig.getLocalD2ZkHost(),
+              localControllerUrl,
+              d2ServiceName,
+              d2ZkHost,
               false);
       ControllerClientBackedSystemSchemaInitializer kmeSchemaInitializer =
           new ControllerClientBackedSystemSchemaInitializer(
               AvroProtocolDefinition.KAFKA_MESSAGE_ENVELOPE,
-              serverConfig.getSystemSchemaClusterName(),
+              cluster,
               null,
               null,
               false,
               sslFactory,
-              childControllerUrl,
+              localControllerUrl,
               d2ServiceName,
               d2ZkHost,
               false);


### PR DESCRIPTION
## Summary
Today, only `venice-0` leader controller is allowed to register new KME schema into ZK. This change is intended to allow every other controller and server to register KME schema during startup.

Resolves VENG-10678

## Does this PR introduce any user-facing changes?
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.