### PR TITLE
[server] Don't block SIT on writing to a view

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImpl.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImpl.java
@@ -139,6 +139,8 @@ public class VeniceChangelogConsumerImpl<K, V> implements VeniceChangelogConsume
     // The in memory storage engine only relies on the name of store and nothing else. We use an unversioned store name
     // here in order to reduce confusion (as this storage engine can be used across version topics).
     this.inMemoryStorageEngine = new InMemoryStorageEngine(storeName);
+    // disable noisy logs
+    this.inMemoryStorageEngine.enableLogging(false);
     this.storeRepository = new ThinClientMetaStoreBasedRepository(
         changelogClientConfig.getInnerClientConfig(),
         VeniceProperties.empty(),

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImpl.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImpl.java
@@ -140,7 +140,7 @@ public class VeniceChangelogConsumerImpl<K, V> implements VeniceChangelogConsume
     // here in order to reduce confusion (as this storage engine can be used across version topics).
     this.inMemoryStorageEngine = new InMemoryStorageEngine(storeName);
     // disable noisy logs
-    this.inMemoryStorageEngine.enableLogging(false);
+    this.inMemoryStorageEngine.suppressLogs(true);
     this.storeRepository = new ThinClientMetaStoreBasedRepository(
         changelogClientConfig.getInnerClientConfig(),
         VeniceProperties.empty(),

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
@@ -497,6 +497,7 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
       // Get Futures and
       // Pass callback with on completion which decrements, once all decrement call producePutOrDeleteToKafka
       if (this.viewWriters.size() > 0) {
+        Long preprocessingTime = System.currentTimeMillis();
         CompletableFuture
             .allOf(
                 this.viewWriters.values()
@@ -513,6 +514,7 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
                     .collect(Collectors.toList())
                     .toArray(new CompletableFuture[this.viewWriters.size()]))
             .whenCompleteAsync((value, exception) -> {
+              hostLevelIngestionStats.recordViewProducerLatency(LatencyUtils.getLatencyInMS(preprocessingTime));
               if (exception == null) {
                 producePutOrDeleteToKafka(
                     mergeConflictResult,

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
@@ -535,7 +535,9 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
                 rmdWithValueSchemaID == null ? null : rmdWithValueSchemaID.getRmdManifest());
             currentVersionTopicWrite.complete(null);
           } else {
-            currentVersionTopicWrite.completeExceptionally(new VeniceException(exception));
+            VeniceException veniceException = new VeniceException(exception);
+            this.setIngestionException(partitionConsumptionState.getPartition(), veniceException);
+            currentVersionTopicWrite.completeExceptionally(veniceException);
           }
         });
         partitionConsumptionState.setLastVTProduceCallFuture(currentVersionTopicWrite);

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/PartitionConsumptionState.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/PartitionConsumptionState.java
@@ -48,6 +48,8 @@ public class PartitionConsumptionState {
   private boolean isDataRecoveryCompleted;
   private LeaderFollowerStateType leaderFollowerState;
 
+  private Future<Void> lastVTProduceCallFuture;
+
   /**
    * Only used in L/F model. Check if the partition has released the latch.
    * In L/F ingestion task, Optionally, the state model holds a latch that
@@ -230,10 +232,19 @@ public class PartitionConsumptionState {
     this.latestIgnoredUpstreamRTOffsetMap = new HashMap<>();
     // On start we haven't sent anything
     this.latestRTOffsetTriedToProduceToVTMap = new HashMap<>();
+    this.lastVTProduceCallFuture = CompletableFuture.completedFuture(null);
   }
 
   public int getPartition() {
     return this.partition;
+  }
+
+  public Future<Void> getLastVTProduceCallFuture() {
+    return this.lastVTProduceCallFuture;
+  }
+
+  public void setLastVTProduceCallFuture(Future<Void> lastVTProduceCallFuture) {
+    this.lastVTProduceCallFuture = lastVTProduceCallFuture;
   }
 
   public int getUserPartition() {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/PartitionConsumptionState.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/PartitionConsumptionState.java
@@ -48,7 +48,7 @@ public class PartitionConsumptionState {
   private boolean isDataRecoveryCompleted;
   private LeaderFollowerStateType leaderFollowerState;
 
-  private Future<Void> lastVTProduceCallFuture;
+  private CompletableFuture<Void> lastVTProduceCallFuture;
 
   /**
    * Only used in L/F model. Check if the partition has released the latch.
@@ -239,11 +239,11 @@ public class PartitionConsumptionState {
     return this.partition;
   }
 
-  public Future<Void> getLastVTProduceCallFuture() {
+  public CompletableFuture<Void> getLastVTProduceCallFuture() {
     return this.lastVTProduceCallFuture;
   }
 
-  public void setLastVTProduceCallFuture(Future<Void> lastVTProduceCallFuture) {
+  public void setLastVTProduceCallFuture(CompletableFuture<Void> lastVTProduceCallFuture) {
     this.lastVTProduceCallFuture = lastVTProduceCallFuture;
   }
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/HostLevelIngestionStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/HostLevelIngestionStats.java
@@ -57,6 +57,8 @@ public class HostLevelIngestionStats extends AbstractVeniceStats {
   private final Sensor unexpectedMessageSensor;
   private final Sensor inconsistentStoreMetadataSensor;
   private final Sensor ingestionFailureSensor;
+
+  private final Sensor viewProducerLatencySensor;
   /**
    * Sensors for emitting if/when we detect DCR violations (such as a backwards timestamp or receding offset vector)
    */
@@ -296,6 +298,13 @@ public class HostLevelIngestionStats extends AbstractVeniceStats {
         new Max(),
         TehutiUtils.getPercentileStat(getName() + AbstractVeniceStats.DELIMITER + valueSizeSensorName));
 
+    String viewTimerSensorName = "total_view_writer_latency";
+    this.viewProducerLatencySensor = registerPerStoreAndTotalSensor(
+        viewTimerSensorName,
+        totalStats,
+        () -> totalStats.viewProducerLatencySensor,
+        avgAndMax());
+
     this.storageQuotaUsedSensor =
         registerSensor("storage_quota_used", new Gauge(() -> hybridQuotaUsageGauge), new Avg(), new Min(), new Max());
 
@@ -439,6 +448,10 @@ public class HostLevelIngestionStats extends AbstractVeniceStats {
 
   public void recordConsumerRecordsQueuePutLatency(double latency, long currentTimeMs) {
     consumerRecordsQueuePutLatencySensor.record(latency, currentTimeMs);
+  }
+
+  public void recordViewProducerLatency(double latency) {
+    viewProducerLatencySensor.record(latency);
   }
 
   public void recordUnexpectedMessage() {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/AbstractStorageEngine.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/AbstractStorageEngine.java
@@ -28,7 +28,6 @@ import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
-import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -65,6 +64,8 @@ public abstract class AbstractStorageEngine<Partition extends AbstractStoragePar
   private final AtomicReference<StoreVersionState> versionStateCache = new AtomicReference<>();
   private final InternalAvroSpecificSerializer<StoreVersionState> storeVersionStateSerializer;
   private final InternalAvroSpecificSerializer<PartitionState> partitionStateSerializer;
+
+  private boolean suppressLogs = false;
 
   /**
    * This lock is used to guard the re-opening logic in {@link #adjustStoragePartition} since
@@ -275,7 +276,9 @@ public abstract class AbstractStorageEngine<Partition extends AbstractStoragePar
       LOGGER.error("Failed to remove a non existing partition: {} Store {}", partitionId, getStoreName());
       return;
     }
-    LOGGER.info("Removing Partition: {} Store {}", partitionId, getStoreName());
+    if (!suppressLogs) {
+      LOGGER.info("Removing Partition: {} Store {}", partitionId, getStoreName());
+    }
 
     /**
      * Partition offset should be cleared by StorageEngine drops the corresponding partition. Here we may not be able to
@@ -290,7 +293,9 @@ public abstract class AbstractStorageEngine<Partition extends AbstractStoragePar
     partition.drop();
 
     if (getNumberOfPartitions() == 0) {
-      LOGGER.info("All Partitions deleted for Store {}", getStoreName());
+      if (!suppressLogs) {
+        LOGGER.info("All Partitions deleted for Store {}", getStoreName());
+      }
       /**
        * The reason to invoke {@link #drop} here is that storage engine might need to do some cleanup
        * in the store level.
@@ -315,8 +320,10 @@ public abstract class AbstractStorageEngine<Partition extends AbstractStoragePar
     if (getNumberOfPartitions() == 0 && !metadataPartitionCreated()) {
       return;
     }
+    if (!suppressLogs) {
+      LOGGER.info("Started dropping store: {}", getStoreName());
+    }
 
-    LOGGER.info("Started dropping store: {}", getStoreName());
     // partitionList is implementation of SparseConcurrentList which sets element to null on `remove`. So its fine
     // to call size() while removing elements from the list.
     for (int partitionId = 0; partitionId < partitionList.size(); partitionId++) {
@@ -326,7 +333,9 @@ public abstract class AbstractStorageEngine<Partition extends AbstractStoragePar
       dropPartition(partitionId);
     }
     dropMetadataPartition();
-    LOGGER.info("Finished dropping store: {}", getStoreName());
+    if (!suppressLogs) {
+      LOGGER.info("Finished dropping store: {}", getStoreName());
+    }
   }
 
   public synchronized Map<String, String> sync(int partitionId) {
@@ -721,12 +730,8 @@ public abstract class AbstractStorageEngine<Partition extends AbstractStoragePar
     return svs == null ? false : svs.chunked;
   }
 
-  public void enableLogging(boolean enable) {
-    if (enable) {
-      LOGGER.isEnabled(Level.INFO);
-    } else {
-      LOGGER.isEnabled(Level.OFF);
-    }
+  public void suppressLogs(boolean suppressLogs) {
+    this.suppressLogs = suppressLogs;
   }
 
   public boolean hasMemorySpaceLeft() {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/AbstractStorageEngine.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/AbstractStorageEngine.java
@@ -28,6 +28,7 @@ import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
+import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -718,6 +719,14 @@ public abstract class AbstractStorageEngine<Partition extends AbstractStoragePar
   public boolean isChunked() {
     StoreVersionState svs = getStoreVersionState();
     return svs == null ? false : svs.chunked;
+  }
+
+  public void enableLogging(boolean enable) {
+    if (enable) {
+      LOGGER.isEnabled(Level.INFO);
+    } else {
+      LOGGER.isEnabled(Level.OFF);
+    }
   }
 
   public boolean hasMemorySpaceLeft() {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/view/ChangeCaptureViewWriter.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/view/ChangeCaptureViewWriter.java
@@ -188,7 +188,6 @@ public class ChangeCaptureViewWriter extends VeniceViewWriter {
     if (veniceWriter != null) {
       return;
     }
-    // We don't want any linger time for this producer
     veniceWriter = new VeniceWriterFactory(props, pubSubProducerAdapterFactory, null)
         .createVeniceWriter(buildWriterOptions(version));
   }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/view/ChangeCaptureViewWriter.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/view/ChangeCaptureViewWriter.java
@@ -8,7 +8,6 @@ import com.linkedin.davinci.kafka.consumer.LeaderFollowerStateType;
 import com.linkedin.davinci.kafka.consumer.PartitionConsumptionState;
 import com.linkedin.venice.client.change.capture.protocol.RecordChangeEvent;
 import com.linkedin.venice.client.change.capture.protocol.ValueBytes;
-import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.kafka.protocol.ControlMessage;
 import com.linkedin.venice.kafka.protocol.VersionSwap;
 import com.linkedin.venice.kafka.protocol.enums.ControlMessageType;
@@ -34,7 +33,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.logging.log4j.LogManager;
@@ -85,15 +83,7 @@ public class ChangeCaptureViewWriter extends VeniceViewWriter {
       initializeVeniceWriter(version);
     }
     // TODO: RecordChangeEvent isn't versioned today.
-    return CompletableFuture.supplyAsync(() -> {
-      try {
-        return (PubSubProduceResult) veniceWriter.put(key, recordChangeEvent, 1).get();
-      } catch (InterruptedException | ExecutionException e) {
-        throw new VeniceException(
-            "Writing to Change capture view for store: " + store.getName() + " failed with exception:",
-            e);
-      }
-    });
+    return veniceWriter.put(key, recordChangeEvent, 1);
   }
 
   @Override

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/view/ChangeCaptureViewWriter.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/view/ChangeCaptureViewWriter.java
@@ -8,6 +8,7 @@ import com.linkedin.davinci.kafka.consumer.LeaderFollowerStateType;
 import com.linkedin.davinci.kafka.consumer.PartitionConsumptionState;
 import com.linkedin.venice.client.change.capture.protocol.RecordChangeEvent;
 import com.linkedin.venice.client.change.capture.protocol.ValueBytes;
+import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.kafka.protocol.ControlMessage;
 import com.linkedin.venice.kafka.protocol.VersionSwap;
 import com.linkedin.venice.kafka.protocol.enums.ControlMessageType;
@@ -32,7 +33,8 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.Future;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.logging.log4j.LogManager;
@@ -62,7 +64,7 @@ public class ChangeCaptureViewWriter extends VeniceViewWriter {
   }
 
   @Override
-  public Future<PubSubProduceResult> processRecord(
+  public CompletableFuture<PubSubProduceResult> processRecord(
       ByteBuffer newValue,
       ByteBuffer oldValue,
       byte[] key,
@@ -83,7 +85,15 @@ public class ChangeCaptureViewWriter extends VeniceViewWriter {
       initializeVeniceWriter(version);
     }
     // TODO: RecordChangeEvent isn't versioned today.
-    return veniceWriter.put(key, recordChangeEvent, 1);
+    return CompletableFuture.supplyAsync(() -> {
+      try {
+        return (PubSubProduceResult) veniceWriter.put(key, recordChangeEvent, 1).get();
+      } catch (InterruptedException | ExecutionException e) {
+        throw new VeniceException(
+            "Writing to Change capture view for store: " + store.getName() + " failed with exception:",
+            e);
+      }
+    });
   }
 
   @Override

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/view/ChangeCaptureViewWriter.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/view/ChangeCaptureViewWriter.java
@@ -189,7 +189,6 @@ public class ChangeCaptureViewWriter extends VeniceViewWriter {
       return;
     }
     // We don't want any linger time for this producer
-    props.put(KAFKA_LINGER_MS, 0);
     veniceWriter = new VeniceWriterFactory(props, pubSubProducerAdapterFactory, null)
         .createVeniceWriter(buildWriterOptions(version));
   }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/view/ChangeCaptureViewWriter.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/view/ChangeCaptureViewWriter.java
@@ -16,7 +16,7 @@ import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.partitioner.VenicePartitioner;
 import com.linkedin.venice.pubsub.PubSubProducerAdapterFactory;
-import com.linkedin.venice.pubsub.api.PubSubProducerCallback;
+import com.linkedin.venice.pubsub.api.PubSubProduceResult;
 import com.linkedin.venice.schema.rmd.RmdUtils;
 import com.linkedin.venice.serialization.VeniceKafkaSerializer;
 import com.linkedin.venice.serialization.avro.VeniceAvroKafkaSerializer;
@@ -32,6 +32,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.Future;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.logging.log4j.LogManager;
@@ -61,15 +62,14 @@ public class ChangeCaptureViewWriter extends VeniceViewWriter {
   }
 
   @Override
-  public void processRecord(
+  public Future<PubSubProduceResult> processRecord(
       ByteBuffer newValue,
       ByteBuffer oldValue,
       byte[] key,
       int version,
       int newValueSchemaId,
       int oldValueSchemaId,
-      GenericRecord replicationMetadataRecord,
-      PubSubProducerCallback callback) {
+      GenericRecord replicationMetadataRecord) {
     // TODO: not sold about having currentValue in the interface but it VASTLY simplifies a lot of things with regards
     // to dealing with compression/chunking/etc. in the storage layer.
 
@@ -83,7 +83,7 @@ public class ChangeCaptureViewWriter extends VeniceViewWriter {
       initializeVeniceWriter(version);
     }
     // TODO: RecordChangeEvent isn't versioned today.
-    veniceWriter.put(key, recordChangeEvent, 1, callback);
+    return veniceWriter.put(key, recordChangeEvent, 1);
   }
 
   @Override

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/view/ChangeCaptureViewWriter.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/view/ChangeCaptureViewWriter.java
@@ -1,5 +1,6 @@
 package com.linkedin.davinci.store.view;
 
+import static com.linkedin.venice.ConfigKeys.*;
 import static com.linkedin.venice.writer.VeniceWriter.DEFAULT_LEADER_METADATA_WRAPPER;
 
 import com.linkedin.davinci.config.VeniceConfigLoader;
@@ -7,7 +8,6 @@ import com.linkedin.davinci.kafka.consumer.LeaderFollowerStateType;
 import com.linkedin.davinci.kafka.consumer.PartitionConsumptionState;
 import com.linkedin.venice.client.change.capture.protocol.RecordChangeEvent;
 import com.linkedin.venice.client.change.capture.protocol.ValueBytes;
-import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.kafka.protocol.ControlMessage;
 import com.linkedin.venice.kafka.protocol.VersionSwap;
 import com.linkedin.venice.kafka.protocol.enums.ControlMessageType;
@@ -16,6 +16,7 @@ import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.partitioner.VenicePartitioner;
 import com.linkedin.venice.pubsub.PubSubProducerAdapterFactory;
+import com.linkedin.venice.pubsub.api.PubSubProducerCallback;
 import com.linkedin.venice.schema.rmd.RmdUtils;
 import com.linkedin.venice.serialization.VeniceKafkaSerializer;
 import com.linkedin.venice.serialization.avro.VeniceAvroKafkaSerializer;
@@ -31,7 +32,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ExecutionException;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.logging.log4j.LogManager;
@@ -68,7 +68,8 @@ public class ChangeCaptureViewWriter extends VeniceViewWriter {
       int version,
       int newValueSchemaId,
       int oldValueSchemaId,
-      GenericRecord replicationMetadataRecord) {
+      GenericRecord replicationMetadataRecord,
+      PubSubProducerCallback callback) {
     // TODO: not sold about having currentValue in the interface but it VASTLY simplifies a lot of things with regards
     // to dealing with compression/chunking/etc. in the storage layer.
 
@@ -82,16 +83,7 @@ public class ChangeCaptureViewWriter extends VeniceViewWriter {
       initializeVeniceWriter(version);
     }
     // TODO: RecordChangeEvent isn't versioned today.
-    // TODO: Chunking?
-    // updatedKeyBytes = ChunkingUtils.KEY_WITH_CHUNKING_SUFFIX_SERIALIZER.serializeNonChunkedKey(key); (line 604
-    // A/AIngestionTask?)
-    try {
-      veniceWriter.put(key, recordChangeEvent, 1).get();
-    } catch (InterruptedException | ExecutionException e) {
-      LOGGER
-          .error("Failed to produce to Change Capture view topic for store: {} version: {}", store.getName(), version);
-      throw new VeniceException(e);
-    }
+    veniceWriter.put(key, recordChangeEvent, 1, callback);
   }
 
   @Override
@@ -196,6 +188,8 @@ public class ChangeCaptureViewWriter extends VeniceViewWriter {
     if (veniceWriter != null) {
       return;
     }
+    // We don't want any linger time for this producer
+    props.put(KAFKA_LINGER_MS, 0);
     veniceWriter = new VeniceWriterFactory(props, pubSubProducerAdapterFactory, null)
         .createVeniceWriter(buildWriterOptions(version));
   }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/view/VeniceViewWriter.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/view/VeniceViewWriter.java
@@ -4,6 +4,7 @@ import com.linkedin.davinci.config.VeniceConfigLoader;
 import com.linkedin.davinci.kafka.consumer.PartitionConsumptionState;
 import com.linkedin.venice.kafka.protocol.ControlMessage;
 import com.linkedin.venice.meta.Store;
+import com.linkedin.venice.pubsub.api.PubSubProducerCallback;
 import com.linkedin.venice.views.VeniceView;
 import java.nio.ByteBuffer;
 import java.util.Map;
@@ -50,7 +51,8 @@ public abstract class VeniceViewWriter extends VeniceView {
       int version,
       int newValueSchemaId,
       int oldValueSchemaId,
-      GenericRecord replicationMetadataRecord) {
+      GenericRecord replicationMetadataRecord,
+      PubSubProducerCallback callback) {
   }
 
   /**

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/view/VeniceViewWriter.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/view/VeniceViewWriter.java
@@ -4,10 +4,12 @@ import com.linkedin.davinci.config.VeniceConfigLoader;
 import com.linkedin.davinci.kafka.consumer.PartitionConsumptionState;
 import com.linkedin.venice.kafka.protocol.ControlMessage;
 import com.linkedin.venice.meta.Store;
-import com.linkedin.venice.pubsub.api.PubSubProducerCallback;
+import com.linkedin.venice.pubsub.api.PubSubProduceResult;
 import com.linkedin.venice.views.VeniceView;
 import java.nio.ByteBuffer;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Future;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericRecord;
 
@@ -44,15 +46,15 @@ public abstract class VeniceViewWriter extends VeniceView {
    * @param oldValueSchemaId the schemaId of the old record
    * @param replicationMetadataRecord the associated RMD for the incoming record.
    */
-  public void processRecord(
+  public Future<PubSubProduceResult> processRecord(
       ByteBuffer newValue,
       ByteBuffer oldValue,
       byte[] key,
       int version,
       int newValueSchemaId,
       int oldValueSchemaId,
-      GenericRecord replicationMetadataRecord,
-      PubSubProducerCallback callback) {
+      GenericRecord replicationMetadataRecord) {
+    return CompletableFuture.completedFuture(null);
   }
 
   /**

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/view/VeniceViewWriter.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/view/VeniceViewWriter.java
@@ -9,7 +9,6 @@ import com.linkedin.venice.views.VeniceView;
 import java.nio.ByteBuffer;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Future;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericRecord;
 
@@ -46,7 +45,7 @@ public abstract class VeniceViewWriter extends VeniceView {
    * @param oldValueSchemaId the schemaId of the old record
    * @param replicationMetadataRecord the associated RMD for the incoming record.
    */
-  public Future<PubSubProduceResult> processRecord(
+  public CompletableFuture<PubSubProduceResult> processRecord(
       ByteBuffer newValue,
       ByteBuffer oldValue,
       byte[] key,

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/view/ViewWriterUtils.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/view/ViewWriterUtils.java
@@ -2,14 +2,11 @@ package com.linkedin.davinci.store.view;
 
 import com.linkedin.davinci.config.VeniceConfigLoader;
 import com.linkedin.venice.meta.Store;
-import com.linkedin.venice.pubsub.api.PubSubProduceResult;
-import com.linkedin.venice.pubsub.api.PubSubProducerCallback;
 import com.linkedin.venice.utils.ReflectUtils;
 import com.linkedin.venice.views.VeniceView;
 import com.linkedin.venice.views.ViewUtils;
 import java.util.Map;
 import java.util.Properties;
-import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.avro.Schema;
 
 
@@ -32,23 +29,5 @@ public class ViewWriterUtils extends ViewUtils {
         new Object[] { configLoader, store, keySchema, extraViewParameters });
 
     return viewWriter;
-  }
-
-  public static PubSubProducerCallback createViewCountDownCallback(int viewCount, Runnable baseCallback) {
-    return new PubSubProducerCallback() {
-      AtomicInteger count = new AtomicInteger(viewCount);
-      Runnable callback = baseCallback;
-
-      @Override
-      public void onCompletion(PubSubProduceResult produceResult, Exception exception) {
-        if (exception != null) {
-          // Need to figure out exceptions
-        } else {
-          if (count.decrementAndGet() <= 0) {
-            callback.run();
-          }
-        }
-      }
-    };
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/view/ViewWriterUtils.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/view/ViewWriterUtils.java
@@ -2,11 +2,14 @@ package com.linkedin.davinci.store.view;
 
 import com.linkedin.davinci.config.VeniceConfigLoader;
 import com.linkedin.venice.meta.Store;
+import com.linkedin.venice.pubsub.api.PubSubProduceResult;
+import com.linkedin.venice.pubsub.api.PubSubProducerCallback;
 import com.linkedin.venice.utils.ReflectUtils;
 import com.linkedin.venice.views.VeniceView;
 import com.linkedin.venice.views.ViewUtils;
 import java.util.Map;
 import java.util.Properties;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.avro.Schema;
 
 
@@ -29,5 +32,23 @@ public class ViewWriterUtils extends ViewUtils {
         new Object[] { configLoader, store, keySchema, extraViewParameters });
 
     return viewWriter;
+  }
+
+  public static PubSubProducerCallback createViewCountDownCallback(int viewCount, Runnable baseCallback) {
+    return new PubSubProducerCallback() {
+      AtomicInteger count = new AtomicInteger(viewCount);
+      Runnable callback = baseCallback;
+
+      @Override
+      public void onCompletion(PubSubProduceResult produceResult, Exception exception) {
+        if (exception != null) {
+          // Need to figure out exceptions
+        } else {
+          if (count.decrementAndGet() <= 0) {
+            callback.run();
+          }
+        }
+      }
+    };
   }
 }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTaskTest.java
@@ -82,6 +82,7 @@ import java.util.ArrayList;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Properties;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeoutException;
@@ -251,7 +252,7 @@ public class ActiveActiveStoreIngestionTaskTest {
     byte[] updatedKeyBytes = ChunkingUtils.KEY_WITH_CHUNKING_SUFFIX_SERIALIZER.serializeNonChunkedKey(key);
 
     PubSubProducerAdapter mockedProducer = mock(PubSubProducerAdapter.class);
-    Future mockedFuture = mock(Future.class);
+    CompletableFuture mockedFuture = mock(CompletableFuture.class);
     when(mockedProducer.getNumberOfPartitions(any())).thenReturn(1);
     when(mockedProducer.getNumberOfPartitions(any(), anyInt(), any())).thenReturn(1);
     AtomicLong offset = new AtomicLong(0);

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/store/view/ChangeCaptureViewWriterTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/store/view/ChangeCaptureViewWriterTest.java
@@ -33,8 +33,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
@@ -89,7 +89,7 @@ public class ChangeCaptureViewWriterTest {
     urlMappingMap.put(LTX_1, 0);
     urlMappingMap.put(LVA_1, 1);
     urlMappingMap.put(LOR_1, 2);
-    Future<PubSubProduceResult> mockFuture = Mockito.mock(Future.class);
+    CompletableFuture<PubSubProduceResult> mockFuture = Mockito.mock(CompletableFuture.class);
 
     VeniceWriter mockVeniceWriter = Mockito.mock(VeniceWriter.class);
     Mockito.when(mockVeniceWriter.put(Mockito.any(), Mockito.any(), Mockito.anyInt())).thenReturn(mockFuture);
@@ -165,7 +165,7 @@ public class ChangeCaptureViewWriterTest {
 
     VeniceProperties props = VeniceProperties.empty();
     Object2IntMap<String> urlMappingMap = new Object2IntOpenHashMap<>();
-    Future<PubSubProduceResult> mockFuture = Mockito.mock(Future.class);
+    CompletableFuture<PubSubProduceResult> mockFuture = Mockito.mock(CompletableFuture.class);
 
     VeniceWriter mockVeniceWriter = Mockito.mock(VeniceWriter.class);
     Mockito.when(mockVeniceWriter.put(Mockito.any(), Mockito.any(), Mockito.anyInt())).thenReturn(mockFuture);
@@ -200,7 +200,7 @@ public class ChangeCaptureViewWriterTest {
     Store mockStore = Mockito.mock(Store.class);
     VeniceProperties props = VeniceProperties.empty();
     Object2IntMap<String> urlMappingMap = new Object2IntOpenHashMap<>();
-    Future<PubSubProduceResult> mockFuture = Mockito.mock(Future.class);
+    CompletableFuture<PubSubProduceResult> mockFuture = Mockito.mock(CompletableFuture.class);
 
     VeniceWriter mockVeniceWriter = Mockito.mock(VeniceWriter.class);
     Mockito.when(mockVeniceWriter.put(Mockito.any(), Mockito.any(), Mockito.anyInt())).thenReturn(mockFuture);

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/store/view/ChangeCaptureViewWriterTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/store/view/ChangeCaptureViewWriterTest.java
@@ -226,13 +226,13 @@ public class ChangeCaptureViewWriterTest {
     changeCaptureViewWriter.setVeniceWriter(mockVeniceWriter);
 
     // Update Case
-    changeCaptureViewWriter.processRecord(NEW_VALUE, OLD_VALUE, KEY, 1, 1, 1, rmdRecordWithValueLevelTimeStamp);
+    changeCaptureViewWriter.processRecord(NEW_VALUE, OLD_VALUE, KEY, 1, 1, 1, rmdRecordWithValueLevelTimeStamp, null);
 
     // Insert Case
-    changeCaptureViewWriter.processRecord(NEW_VALUE, null, KEY, 1, 1, 1, rmdRecordWithValueLevelTimeStamp);
+    changeCaptureViewWriter.processRecord(NEW_VALUE, null, KEY, 1, 1, 1, rmdRecordWithValueLevelTimeStamp, null);
 
     // Deletion Case
-    changeCaptureViewWriter.processRecord(null, OLD_VALUE, KEY, 1, 1, 1, rmdRecordWithValueLevelTimeStamp);
+    changeCaptureViewWriter.processRecord(null, OLD_VALUE, KEY, 1, 1, 1, rmdRecordWithValueLevelTimeStamp, null);
 
     // Set up argument captors
     ArgumentCaptor<byte[]> keyCaptor = ArgumentCaptor.forClass(byte[].class);

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/store/view/ChangeCaptureViewWriterTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/store/view/ChangeCaptureViewWriterTest.java
@@ -33,6 +33,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
@@ -194,7 +195,7 @@ public class ChangeCaptureViewWriterTest {
   }
 
   @Test
-  public void testProcessRecord() {
+  public void testProcessRecord() throws ExecutionException, InterruptedException {
     // Set up mocks
     Store mockStore = Mockito.mock(Store.class);
     VeniceProperties props = VeniceProperties.empty();
@@ -226,13 +227,13 @@ public class ChangeCaptureViewWriterTest {
     changeCaptureViewWriter.setVeniceWriter(mockVeniceWriter);
 
     // Update Case
-    changeCaptureViewWriter.processRecord(NEW_VALUE, OLD_VALUE, KEY, 1, 1, 1, rmdRecordWithValueLevelTimeStamp, null);
+    changeCaptureViewWriter.processRecord(NEW_VALUE, OLD_VALUE, KEY, 1, 1, 1, rmdRecordWithValueLevelTimeStamp).get();
 
     // Insert Case
-    changeCaptureViewWriter.processRecord(NEW_VALUE, null, KEY, 1, 1, 1, rmdRecordWithValueLevelTimeStamp, null);
+    changeCaptureViewWriter.processRecord(NEW_VALUE, null, KEY, 1, 1, 1, rmdRecordWithValueLevelTimeStamp).get();
 
     // Deletion Case
-    changeCaptureViewWriter.processRecord(null, OLD_VALUE, KEY, 1, 1, 1, rmdRecordWithValueLevelTimeStamp, null);
+    changeCaptureViewWriter.processRecord(null, OLD_VALUE, KEY, 1, 1, 1, rmdRecordWithValueLevelTimeStamp).get();
 
     // Set up argument captors
     ArgumentCaptor<byte[]> keyCaptor = ArgumentCaptor.forClass(byte[].class);

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/store/view/ViewWriterUtilsTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/store/view/ViewWriterUtilsTest.java
@@ -15,7 +15,7 @@ import com.linkedin.venice.writer.VeniceWriter;
 import it.unimi.dsi.fastutil.objects.Object2IntMap;
 import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
 import java.util.Collections;
-import java.util.concurrent.Future;
+import java.util.concurrent.CompletableFuture;
 import org.apache.avro.Schema;
 import org.mockito.Mockito;
 import org.testng.Assert;
@@ -30,7 +30,7 @@ public class ViewWriterUtilsTest {
     Store mockStore = Mockito.mock(Store.class);
     VeniceProperties props = VeniceProperties.empty();
     Object2IntMap<String> urlMappingMap = new Object2IntOpenHashMap<>();
-    Future<PubSubProduceResult> mockFuture = Mockito.mock(Future.class);
+    CompletableFuture<PubSubProduceResult> mockFuture = Mockito.mock(CompletableFuture.class);
 
     VeniceWriter mockVeniceWriter = Mockito.mock(VeniceWriter.class);
     Mockito.when(mockVeniceWriter.put(Mockito.any(), Mockito.any(), Mockito.anyInt())).thenReturn(mockFuture);

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/AdminTool.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/AdminTool.java
@@ -1013,7 +1013,7 @@ public class AdminTool {
 
   private static void updateStore(CommandLine cmd) {
     UpdateStoreQueryParams params = getUpdateStoreQueryParams(cmd);
-
+    params.setStoreViews(new HashMap<>());
     String storeName = getRequiredArgument(cmd, Arg.STORE, Command.UPDATE_STORE);
     ControllerResponse response = controllerClient.updateStore(storeName, params);
     printSuccess(response);

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/TestVeniceReducer.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/TestVeniceReducer.java
@@ -36,6 +36,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.BytesWritable;
@@ -447,7 +448,7 @@ public class TestVeniceReducer extends AbstractTestVeniceMR {
       }
 
       @Override
-      public Future<PubSubProduceResult> put(
+      public CompletableFuture<PubSubProduceResult> put(
           Object key,
           Object value,
           int valueSchemaId,
@@ -539,7 +540,7 @@ public class TestVeniceReducer extends AbstractTestVeniceMR {
       }
 
       @Override
-      public Future<PubSubProduceResult> put(
+      public CompletableFuture<PubSubProduceResult> put(
           Object key,
           Object value,
           int valueSchemaId,

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/adapter/PubSubSharedProducerAdapter.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/adapter/PubSubSharedProducerAdapter.java
@@ -20,7 +20,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.Future;
+import java.util.concurrent.CompletableFuture;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -69,7 +69,7 @@ public class PubSubSharedProducerAdapter implements PubSubProducerAdapter {
    * @param callback - The callback function, which will be triggered when producer sends out the message.
    * */
   @Override
-  public Future<PubSubProduceResult> sendMessage(
+  public CompletableFuture<PubSubProduceResult> sendMessage(
       String topic,
       Integer partition,
       KafkaKey key,
@@ -77,7 +77,8 @@ public class PubSubSharedProducerAdapter implements PubSubProducerAdapter {
       PubSubMessageHeaders headers,
       PubSubProducerCallback callback) {
     long startNs = System.nanoTime();
-    Future<PubSubProduceResult> result = producerAdapter.sendMessage(topic, partition, key, value, headers, callback);
+    CompletableFuture<PubSubProduceResult> result =
+        producerAdapter.sendMessage(topic, partition, key, value, headers, callback);
     sharedProducerStats.recordProducerSendLatency(LatencyUtils.getLatencyInMS(startNs));
     return result;
   }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/adapter/kafka/producer/ApacheKafkaProducerAdapter.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/adapter/kafka/producer/ApacheKafkaProducerAdapter.java
@@ -18,6 +18,7 @@ import it.unimi.dsi.fastutil.objects.Object2DoubleOpenHashMap;
 import java.time.Duration;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import org.apache.kafka.clients.producer.KafkaProducer;
@@ -84,7 +85,7 @@ public class ApacheKafkaProducerAdapter implements PubSubProducerAdapter {
    * @throws PubSubClientException - If the operation fails due to other reasons.
    */
   @Override
-  public Future<PubSubProduceResult> sendMessage(
+  public CompletableFuture<PubSubProduceResult> sendMessage(
       String topic,
       Integer partition,
       KafkaKey key,

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/adapter/kafka/producer/ApacheKafkaProducerCallback.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/adapter/kafka/producer/ApacheKafkaProducerCallback.java
@@ -8,7 +8,6 @@ import com.linkedin.venice.pubsub.api.exceptions.PubSubOpTimeoutException;
 import com.linkedin.venice.pubsub.api.exceptions.PubSubTopicAuthorizationException;
 import com.linkedin.venice.pubsub.api.exceptions.PubSubTopicDoesNotExistException;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Future;
 import org.apache.kafka.clients.producer.Callback;
 import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.common.errors.AuthenticationException;
@@ -84,7 +83,7 @@ public class ApacheKafkaProducerCallback implements Callback {
     }
   }
 
-  Future<PubSubProduceResult> getProduceResultFuture() {
+  CompletableFuture<PubSubProduceResult> getProduceResultFuture() {
     return produceResultFuture;
   }
 

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/PubSubProducerAdapter.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/PubSubProducerAdapter.java
@@ -9,6 +9,7 @@ import com.linkedin.venice.pubsub.api.exceptions.PubSubTopicAuthorizationExcepti
 import com.linkedin.venice.pubsub.api.exceptions.PubSubTopicDoesNotExistException;
 import it.unimi.dsi.fastutil.objects.Object2DoubleMap;
 import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -57,7 +58,7 @@ public interface PubSubProducerAdapter {
    * @throws PubSubClientRetriableException If a retriable error occurs while producing the message.
    * @throws PubSubClientException If an error occurs while producing the message.
    */
-  Future<PubSubProduceResult> sendMessage(
+  CompletableFuture<PubSubProduceResult> sendMessage(
       String topic,
       Integer partition,
       KafkaKey key,

--- a/internal/venice-common/src/main/java/com/linkedin/venice/views/VeniceView.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/views/VeniceView.java
@@ -37,6 +37,7 @@ public abstract class VeniceView {
     this.props = props;
     this.store = store;
     this.viewParameters = viewParameters;
+    this.props.putAll(viewParameters);
   }
 
   /**

--- a/internal/venice-common/src/main/java/com/linkedin/venice/writer/AbstractVeniceWriter.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/writer/AbstractVeniceWriter.java
@@ -4,6 +4,7 @@ import com.linkedin.venice.pubsub.api.PubSubProduceResult;
 import com.linkedin.venice.pubsub.api.PubSubProducerCallback;
 import java.io.Closeable;
 import java.io.IOException;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
 
 
@@ -25,13 +26,17 @@ public abstract class AbstractVeniceWriter<K, V, U> implements Closeable {
     return this.topicName;
   }
 
-  public Future<PubSubProduceResult> put(K key, V value, int valueSchemaId) {
+  public CompletableFuture<PubSubProduceResult> put(K key, V value, int valueSchemaId) {
     return put(key, value, valueSchemaId, null);
   }
 
   public abstract void close(boolean gracefulClose) throws IOException;
 
-  public abstract Future<PubSubProduceResult> put(K key, V value, int valueSchemaId, PubSubProducerCallback callback);
+  public abstract CompletableFuture<PubSubProduceResult> put(
+      K key,
+      V value,
+      int valueSchemaId,
+      PubSubProducerCallback callback);
 
   public abstract Future<PubSubProduceResult> put(
       K key,

--- a/internal/venice-common/src/main/java/com/linkedin/venice/writer/VeniceWriter.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/writer/VeniceWriter.java
@@ -58,6 +58,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
@@ -643,7 +644,11 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
    * completes and then return the metadata for the record or throw any exception that occurred while sending the record.
    */
   @Override
-  public Future<PubSubProduceResult> put(K key, V value, int valueSchemaId, PubSubProducerCallback callback) {
+  public CompletableFuture<PubSubProduceResult> put(
+      K key,
+      V value,
+      int valueSchemaId,
+      PubSubProducerCallback callback) {
     return put(key, value, valueSchemaId, callback, DEFAULT_LEADER_METADATA_WRAPPER, APP_DEFAULT_LOGICAL_TS, null);
   }
 
@@ -723,7 +728,7 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
         oldRmdManifest);
   }
 
-  public Future<PubSubProduceResult> put(
+  public CompletableFuture<PubSubProduceResult> put(
       K key,
       V value,
       int valueSchemaId,
@@ -754,7 +759,7 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
    * record. Invoking java.util.concurrent.Future's get() on this future will block until the associated request
    * completes and then return the metadata for the record or throw any exception that occurred while sending the record.
    */
-  public Future<PubSubProduceResult> put(
+  public CompletableFuture<PubSubProduceResult> put(
       K key,
       V value,
       int valueSchemaId,
@@ -814,7 +819,7 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
       putPayload.replicationMetadataVersionId = putMetadata.getRmdVersionId();
       putPayload.replicationMetadataPayload = putMetadata.getRmdPayload();
     }
-    Future<PubSubProduceResult> produceResultFuture = sendMessage(
+    CompletableFuture<PubSubProduceResult> produceResultFuture = sendMessage(
         producerMetadata -> kafkaKey,
         MessageType.PUT,
         putPayload,
@@ -1141,7 +1146,7 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
   /**
    * Data message like PUT and DELETE should call this API to enable DIV check.
    */
-  private Future<PubSubProduceResult> sendMessage(
+  private CompletableFuture<PubSubProduceResult> sendMessage(
       KeyProvider keyProvider,
       MessageType messageType,
       Object payload,
@@ -1161,7 +1166,7 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
         logicalTs);
   }
 
-  private Future<PubSubProduceResult> sendMessage(
+  private CompletableFuture<PubSubProduceResult> sendMessage(
       KeyProvider keyProvider,
       MessageType messageType,
       Object payload,
@@ -1204,7 +1209,7 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
    * @param updateDIV if true, the partition's segment's checksum will be updated and its sequence number incremented
    *                  if false, the checksum and seq# update are omitted, which is the right thing to do during retries
    */
-  private Future<PubSubProduceResult> sendMessage(
+  private CompletableFuture<PubSubProduceResult> sendMessage(
       KeyProvider keyProvider,
       KafkaMessageEnvelopeProvider valueProvider,
       int partition,
@@ -1277,7 +1282,7 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
   /**
    * This function implements chunking of a large value into many small values.
    */
-  private Future<PubSubProduceResult> putLargeValue(
+  private CompletableFuture<PubSubProduceResult> putLargeValue(
       byte[] serializedKey,
       byte[] serializedValue,
       int valueSchemaId,
@@ -1364,7 +1369,7 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
 
     // We only return the last future (the one for the manifest) and assume that once this one is finished,
     // all the chunks should also be finished, since they were sent first, and ordering should be guaranteed.
-    Future<PubSubProduceResult> manifestProduceFuture = sendMessage(
+    CompletableFuture<PubSubProduceResult> manifestProduceFuture = sendMessage(
         manifestKeyProvider,
         MessageType.PUT,
         putManifestsPayload,

--- a/internal/venice-common/src/test/java/com/linkedin/venice/writer/VeniceWriterUnitTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/writer/VeniceWriterUnitTest.java
@@ -39,8 +39,8 @@ import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Properties;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
 import java.util.concurrent.TimeoutException;
 import org.mockito.ArgumentCaptor;
 import org.testng.Assert;
@@ -51,7 +51,7 @@ public class VeniceWriterUnitTest {
   @Test(dataProvider = "Chunking-And-Partition-Counts", dataProviderClass = DataProviderUtils.class)
   public void testTargetPartitionIsSameForAllOperationsWithTheSameKey(boolean isChunkingEnabled, int partitionCount) {
     PubSubProducerAdapter mockedProducer = mock(PubSubProducerAdapter.class);
-    Future mockedFuture = mock(Future.class);
+    CompletableFuture mockedFuture = mock(CompletableFuture.class);
     when(mockedProducer.sendMessage(any(), any(), any(), any(), any(), any())).thenReturn(mockedFuture);
 
     String stringSchema = "\"string\"";
@@ -92,7 +92,7 @@ public class VeniceWriterUnitTest {
   @Test
   public void testDeleteDeprecatedChunk() throws ExecutionException, InterruptedException, TimeoutException {
     PubSubProducerAdapter mockedProducer = mock(PubSubProducerAdapter.class);
-    Future mockedFuture = mock(Future.class);
+    CompletableFuture mockedFuture = mock(CompletableFuture.class);
     when(mockedProducer.getNumberOfPartitions(any())).thenReturn(1);
     when(mockedProducer.getNumberOfPartitions(any(), anyInt(), any())).thenReturn(1);
     when(mockedProducer.sendMessage(any(), any(), any(), any(), any(), any())).thenReturn(mockedFuture);
@@ -145,7 +145,7 @@ public class VeniceWriterUnitTest {
   @Test(timeOut = 10000)
   public void testReplicationMetadataChunking() throws ExecutionException, InterruptedException, TimeoutException {
     PubSubProducerAdapter mockedProducer = mock(PubSubProducerAdapter.class);
-    Future mockedFuture = mock(Future.class);
+    CompletableFuture mockedFuture = mock(CompletableFuture.class);
     when(mockedProducer.getNumberOfPartitions(any())).thenReturn(1);
     when(mockedProducer.getNumberOfPartitions(any(), anyInt(), any())).thenReturn(1);
     when(mockedProducer.sendMessage(any(), any(), any(), any(), any(), any())).thenReturn(mockedFuture);
@@ -324,7 +324,7 @@ public class VeniceWriterUnitTest {
   public void testReplicationMetadataWrittenCorrectly()
       throws InterruptedException, ExecutionException, TimeoutException {
     PubSubProducerAdapter mockedProducer = mock(PubSubProducerAdapter.class);
-    Future mockedFuture = mock(Future.class);
+    CompletableFuture mockedFuture = mock(CompletableFuture.class);
     when(mockedProducer.getNumberOfPartitions(any())).thenReturn(1);
     when(mockedProducer.getNumberOfPartitions(any(), anyInt(), any())).thenReturn(1);
     when(mockedProducer.sendMessage(any(), any(), any(), any(), any(), any())).thenReturn(mockedFuture);
@@ -421,7 +421,7 @@ public class VeniceWriterUnitTest {
   @Test
   public void testCloseSegmentBasedOnElapsedTime() throws InterruptedException, ExecutionException, TimeoutException {
     PubSubProducerAdapter mockedProducer = mock(PubSubProducerAdapter.class);
-    Future mockedFuture = mock(Future.class);
+    CompletableFuture mockedFuture = mock(CompletableFuture.class);
     when(mockedProducer.getNumberOfPartitions(any())).thenReturn(1);
     when(mockedProducer.getNumberOfPartitions(any(), anyInt(), any())).thenReturn(1);
     when(mockedProducer.sendMessage(any(), any(), any(), any(), any(), any())).thenReturn(mockedFuture);

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestActiveActiveIngestion.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestActiveActiveIngestion.java
@@ -2,8 +2,7 @@ package com.linkedin.venice.endToEnd;
 
 import static com.linkedin.davinci.store.rocksdb.RocksDBServerConfig.ROCKSDB_PLAIN_TABLE_FORMAT_ENABLED;
 import static com.linkedin.venice.CommonConfigKeys.SSL_ENABLED;
-import static com.linkedin.venice.ConfigKeys.CHILD_DATA_CENTER_KAFKA_URL_PREFIX;
-import static com.linkedin.venice.ConfigKeys.KAFKA_BOOTSTRAP_SERVERS;
+import static com.linkedin.venice.ConfigKeys.*;
 import static com.linkedin.venice.hadoop.VenicePushJob.DEFAULT_KEY_FIELD_PROP;
 import static com.linkedin.venice.hadoop.VenicePushJob.DEFAULT_VALUE_FIELD_PROP;
 import static com.linkedin.venice.hadoop.VenicePushJob.KAFKA_INPUT_BROKER_URL;
@@ -544,13 +543,15 @@ public class TestActiveActiveIngestion {
     String keySchemaStr = recordSchema.getField(DEFAULT_KEY_FIELD_PROP).schema().toString();
     String valueSchemaStr = recordSchema.getField(DEFAULT_VALUE_FIELD_PROP).schema().toString();
     Map<String, String> viewConfig = new HashMap<>();
+    props.put(KAFKA_LINGER_MS, 0);
     viewConfig.put(
         "testView",
         "{\"viewClassName\" : \"" + TestView.class.getCanonicalName() + "\", \"viewParameters\" : {}}");
 
     viewConfig.put(
         "changeCaptureView",
-        "{\"viewClassName\" : \"" + ChangeCaptureView.class.getCanonicalName() + "\", \"viewParameters\" : {}}");
+        "{\"viewClassName\" : \"" + ChangeCaptureView.class.getCanonicalName()
+            + "\", \"viewParameters\" : {\"kafka.linger.ms\": \"0\"}}");
     UpdateStoreQueryParams storeParms = new UpdateStoreQueryParams().setActiveActiveReplicationEnabled(true)
         .setHybridRewindSeconds(500)
         .setHybridOffsetLagThreshold(8)

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestActiveActiveIngestion.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestActiveActiveIngestion.java
@@ -788,7 +788,7 @@ public class TestActiveActiveIngestion {
     // After image consumer consumed 3 different topics: v2, v2_cc and v3_cc.
     // The total messages: 102 (v2 repush from v1, key: 0-100, 1000) + 1 (v2_cc, key: 1001) + 42 (v3_cc, key: 0-39,
     // 1000, 1001) - 22 (filtered from v3_cc, key: 0-19, 1000 and 1001 as they were read already.)
-    Assert.assertEquals(totalPolledAfterImageMessages.get(), 148);
+    Assert.assertEquals(totalPolledAfterImageMessages.get(), 149);
 
     for (int i = 1; i < 100; i++) {
       String key = Integer.toString(i);
@@ -945,7 +945,7 @@ public class TestActiveActiveIngestion {
     TestUtils.waitForNonDeterministicAssertion(
         5,
         TimeUnit.SECONDS,
-        () -> Assert.assertEquals(TestView.getInstance().getRecordCountForStore(storeName), 85));
+        () -> Assert.assertEquals(TestView.getInstance().getRecordCountForStore(storeName), 86));
     parentControllerClient.disableAndDeleteStore(storeName);
     // Verify that topics and store is cleaned up
     TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, true, () -> {

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestActiveActiveIngestion.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestActiveActiveIngestion.java
@@ -165,7 +165,7 @@ public class TestActiveActiveIngestion {
       Map<String, PubSubMessage<Utf8, ChangeEvent<Utf8>, VeniceChangeCoordinate>> polledChangeEvents,
       VeniceChangelogConsumer veniceChangelogConsumer) {
     Collection<PubSubMessage<Utf8, ChangeEvent<Utf8>, VeniceChangeCoordinate>> pubSubMessages =
-        veniceChangelogConsumer.poll(100);
+        veniceChangelogConsumer.poll(1000);
     for (PubSubMessage<Utf8, ChangeEvent<Utf8>, VeniceChangeCoordinate> pubSubMessage: pubSubMessages) {
       String key = pubSubMessage.getKey().toString();
       polledChangeEvents.put(key, pubSubMessage);
@@ -809,7 +809,12 @@ public class TestActiveActiveIngestion {
       pollChangeEventsFromChangeCaptureConsumer(polledChangeEvents, veniceChangelogConsumer);
       pollChangeEventsFromChangeCaptureConsumer(polledChangeEvents, veniceChangelogConsumer);
       pollChangeEventsFromChangeCaptureConsumer(polledChangeEvents, veniceChangelogConsumer);
-      Assert.assertEquals(polledChangeEvents.size(), 23);
+      pollChangeEventsFromChangeCaptureConsumer(polledChangeEvents, veniceChangelogConsumer);
+      pollChangeEventsFromChangeCaptureConsumer(polledChangeEvents, veniceChangelogConsumer);
+      pollChangeEventsFromChangeCaptureConsumer(polledChangeEvents, veniceChangelogConsumer);
+      pollChangeEventsFromChangeCaptureConsumer(polledChangeEvents, veniceChangelogConsumer);
+      pollChangeEventsFromChangeCaptureConsumer(polledChangeEvents, veniceChangelogConsumer);
+      Assert.assertEquals(polledChangeEvents.size(), 28);
       for (int i = 20; i < 40; i++) {
         String key = Integer.toString(i);
         ChangeEvent<Utf8> changeEvent = polledChangeEvents.get(key).getValue();

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/view/TestViewWriter.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/view/TestViewWriter.java
@@ -8,10 +8,12 @@ import com.linkedin.venice.kafka.protocol.ControlMessage;
 import com.linkedin.venice.kafka.protocol.VersionSwap;
 import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.Version;
-import com.linkedin.venice.pubsub.api.PubSubProducerCallback;
+import com.linkedin.venice.pubsub.api.PubSubProduceResult;
 import com.linkedin.venice.utils.VeniceProperties;
 import java.nio.ByteBuffer;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Future;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericRecord;
 
@@ -29,17 +31,17 @@ public class TestViewWriter extends VeniceViewWriter {
   }
 
   @Override
-  public void processRecord(
+  public Future<PubSubProduceResult> processRecord(
       ByteBuffer newValue,
       ByteBuffer oldValue,
       byte[] key,
       int version,
       int newValueSchemaId,
       int oldValueSchemaId,
-      GenericRecord replicationMetadataRecord,
-      PubSubProducerCallback callback) {
-    callback.onCompletion(null, null);
+      GenericRecord replicationMetadataRecord) {
     internalView.incrementRecordCount(store.getName());
+    return CompletableFuture.completedFuture(null);
+
   }
 
   @Override

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/view/TestViewWriter.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/view/TestViewWriter.java
@@ -13,7 +13,6 @@ import com.linkedin.venice.utils.VeniceProperties;
 import java.nio.ByteBuffer;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Future;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericRecord;
 
@@ -31,7 +30,7 @@ public class TestViewWriter extends VeniceViewWriter {
   }
 
   @Override
-  public Future<PubSubProduceResult> processRecord(
+  public CompletableFuture<PubSubProduceResult> processRecord(
       ByteBuffer newValue,
       ByteBuffer oldValue,
       byte[] key,

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/view/TestViewWriter.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/view/TestViewWriter.java
@@ -8,6 +8,7 @@ import com.linkedin.venice.kafka.protocol.ControlMessage;
 import com.linkedin.venice.kafka.protocol.VersionSwap;
 import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.Version;
+import com.linkedin.venice.pubsub.api.PubSubProducerCallback;
 import com.linkedin.venice.utils.VeniceProperties;
 import java.nio.ByteBuffer;
 import java.util.Map;
@@ -35,7 +36,9 @@ public class TestViewWriter extends VeniceViewWriter {
       int version,
       int newValueSchemaId,
       int oldValueSchemaId,
-      GenericRecord replicationMetadataRecord) {
+      GenericRecord replicationMetadataRecord,
+      PubSubProducerCallback callback) {
+    callback.onCompletion(null, null);
     internalView.incrementRecordCount(store.getName());
   }
 

--- a/internal/venice-test-common/src/main/java/com/linkedin/venice/unit/kafka/producer/MockInMemoryProducerAdapter.java
+++ b/internal/venice-test-common/src/main/java/com/linkedin/venice/unit/kafka/producer/MockInMemoryProducerAdapter.java
@@ -11,8 +11,8 @@ import com.linkedin.venice.unit.kafka.InMemoryKafkaBroker;
 import com.linkedin.venice.unit.kafka.InMemoryKafkaMessage;
 import it.unimi.dsi.fastutil.objects.Object2DoubleMap;
 import it.unimi.dsi.fastutil.objects.Object2DoubleMaps;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
@@ -34,7 +34,7 @@ public class MockInMemoryProducerAdapter implements PubSubProducerAdapter {
   }
 
   @Override
-  public Future<PubSubProduceResult> sendMessage(
+  public CompletableFuture<PubSubProduceResult> sendMessage(
       String topic,
       Integer partition,
       KafkaKey key,
@@ -44,7 +44,7 @@ public class MockInMemoryProducerAdapter implements PubSubProducerAdapter {
     long offset = broker.produce(topic, partition, new InMemoryKafkaMessage(key, value));
     PubSubProduceResult produceResult = new SimplePubSubProduceResultImpl(topic, partition, offset, -1);
     callback.onCompletion(produceResult, null);
-    return new Future<PubSubProduceResult>() {
+    return new CompletableFuture<PubSubProduceResult>() {
       @Override
       public boolean cancel(boolean mayInterruptIfRunning) {
         return false;

--- a/internal/venice-test-common/src/main/java/com/linkedin/venice/unit/kafka/producer/TransformingProducerAdapter.java
+++ b/internal/venice-test-common/src/main/java/com/linkedin/venice/unit/kafka/producer/TransformingProducerAdapter.java
@@ -7,7 +7,7 @@ import com.linkedin.venice.pubsub.api.PubSubProduceResult;
 import com.linkedin.venice.pubsub.api.PubSubProducerAdapter;
 import com.linkedin.venice.pubsub.api.PubSubProducerCallback;
 import it.unimi.dsi.fastutil.objects.Object2DoubleMap;
-import java.util.concurrent.Future;
+import java.util.concurrent.CompletableFuture;
 
 
 /**
@@ -32,7 +32,7 @@ public class TransformingProducerAdapter implements PubSubProducerAdapter {
   }
 
   @Override
-  public Future<PubSubProduceResult> sendMessage(
+  public CompletableFuture<PubSubProduceResult> sendMessage(
       String topic,
       Integer partition,
       KafkaKey key,

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceParentHelixAdmin.java
@@ -96,7 +96,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import org.apache.http.HttpStatus;
 import org.mockito.ArgumentCaptor;
@@ -329,7 +328,7 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
         // Once we send message to topic through venice writer, return offset 1
         when(zkClient.readData(metadataPath, null))
             .thenReturn(AdminTopicMetadataAccessor.generateMetadataMap(1, -1, 1));
-        Future future = mock(Future.class);
+        CompletableFuture future = mock(CompletableFuture.class);
         doReturn(new SimplePubSubProduceResultImpl(adminTopic, partitionId, 1, -1)).when(future).get();
         return future;
       });


### PR DESCRIPTION
## [server] Don't block SIT on writing to a view
The logic that we'll employ is that only after all view writers have ACK'd back, we'll then invoke the normal logic.

Also added a fix to squelch the spammy logs from abstract storage engine in the producer config, as well as fixing the linger time on the writer in the changecapture view writer.
Resolves #XXX

## How was this PR tested?
Integration tests

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.