### PR TITLE
[server] Ignore invalid time stamps for leaderProducerRecordContext.

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/IngestionStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/IngestionStats.java
@@ -488,19 +488,19 @@ public class IngestionStats {
   }
 
   public double getNearlineProducerToLocalBrokerLatencyAvg() {
-    return nearlineProducerToLocalBrokerLatencySensor.getAvg();
+    return unAvailableToZero(nearlineProducerToLocalBrokerLatencySensor.getAvg());
   }
 
   public double getNearlineProducerToLocalBrokerLatencyMax() {
-    return nearlineProducerToLocalBrokerLatencySensor.getMax();
+    return unAvailableToZero(nearlineProducerToLocalBrokerLatencySensor.getMax());
   }
 
   public double getNearlineLocalBrokerToReadyToServeLatencyAvg() {
-    return nearlineLocalBrokerToReadyToServeLatencySensor.getAvg();
+    return unAvailableToZero(nearlineLocalBrokerToReadyToServeLatencySensor.getAvg());
   }
 
   public double getNearlineLocalBrokerToReadyToServeLatencyMax() {
-    return nearlineLocalBrokerToReadyToServeLatencySensor.getMax();
+    return unAvailableToZero(nearlineLocalBrokerToReadyToServeLatencySensor.getMax());
   }
 
   public void recordNearlineProducerToLocalBrokerLatency(double value, long currentTimeMs) {
@@ -511,4 +511,10 @@ public class IngestionStats {
     nearlineLocalBrokerToReadyToServeLatencySensor.record(value, currentTimeMs);
   }
 
+  public static double unAvailableToZero(double value) {
+    /* When data is unavailable, return 0 instead of NaN or Infinity. Some metrics are initialized to -INF.
+     This can cause problems when metrics are aggregated. Use only when zero makes semantic sense.
+    */
+    return Double.isFinite(value) ? value : 0;
+  }
 }


### PR DESCRIPTION


<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Summary, imperative, start upper case, don't end with a period
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
Refactored nearline metrics recording code. Ignore invalid timestamps and don't calculate latency for messages with no upstream.
Filtered out junk metric data and emit zero when latency values are unavailable. This avoids junk values for max latency when they are aggregated across time dimension.

Resolves #XXX
## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.