### PR TITLE
[server][dvc] Fix to RocksDB atomic flush usage

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/RocksDBStoragePartition.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/RocksDBStoragePartition.java
@@ -750,7 +750,7 @@ public class RocksDBStoragePartition extends AbstractStoragePartition {
           // Since Venice RocksDB database disables WAL, flush will be triggered for every 'sync' to avoid data loss
           // during
           // crash recovery
-          rocksDB.flush(WAIT_FOR_FLUSH_OPTIONS);
+          rocksDB.flush(WAIT_FOR_FLUSH_OPTIONS, columnFamilyHandleList);
         } catch (RocksDBException e) {
           checkAndThrowMemoryLimitException(e);
           throw new VeniceException(


### PR DESCRIPTION
Even though we use the DB Options to enable atomic flush, we were not passing the list of column family handles into the flush call, and since our WAL is disabled we did not implicitly get the atomic flush behavior either.

This commit fixes the usage to ensure atomic flushing of the data and RMD column families.

More details: https://github.com/facebook/rocksdb/wiki/Atomic-flush

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.