### PR TITLE
[controller] Handle NPE for incremental push reporting

### DIFF
--- a/internal/venice-common/src/main/java/com/linkedin/venice/pushmonitor/OfflinePushStatus.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pushmonitor/OfflinePushStatus.java
@@ -208,6 +208,10 @@ public class OfflinePushStatus {
     for (PartitionStatus partitionStatus: getPartitionStatuses()) {
       Map<CharSequence, Integer> partitionPushStatus = new HashMap<>();
       Partition partition = partitionAssignment.getPartition(partitionStatus.getPartitionId());
+      if (partition == null) {
+        throw new VeniceException(
+            "Partition " + partitionStatus.getPartitionId() + " not found in partition assignment");
+      }
       Set<String> workingInstances =
           partition.getWorkingInstances().stream().map(Instance::getNodeId).collect(Collectors.toSet());
       for (ReplicaStatus replicaStatus: partitionStatus.getReplicaStatuses()) {

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pushmonitor/PartitionStatus.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pushmonitor/PartitionStatus.java
@@ -118,6 +118,7 @@ public class PartitionStatus implements Comparable<PartitionStatus> {
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
+    sb.append("Partition ").append(partitionId).append(": ");
     for (Map.Entry<String, ReplicaStatus> entry: replicaStatusMap.entrySet()) {
       sb.append(entry.getKey()).append(":").append(entry.getValue().getCurrentStatus().name()).append(" ");
     }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pushmonitor/PartitionStatus.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pushmonitor/PartitionStatus.java
@@ -118,7 +118,6 @@ public class PartitionStatus implements Comparable<PartitionStatus> {
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
-    sb.append("Partition ").append(partitionId).append(": ");
     for (Map.Entry<String, ReplicaStatus> entry: replicaStatusMap.entrySet()) {
       sb.append(entry.getKey()).append(":").append(entry.getValue().getCurrentStatus().name()).append(" ");
     }

--- a/internal/venice-common/src/test/java/com/linkedin/venice/pushmonitor/OfflinePushStatusTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/pushmonitor/OfflinePushStatusTest.java
@@ -9,6 +9,7 @@ import static com.linkedin.venice.pushmonitor.ExecutionStatus.STARTED;
 
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.meta.OfflinePushStrategy;
+import com.linkedin.venice.meta.PartitionAssignment;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -161,6 +162,14 @@ public class OfflinePushStatusTest {
     partitionStatus.updateReplicaStatus("i1", COMPLETED);
     offlinePushStatus.setPartitionStatus(partitionStatus);
     Assert.assertNotEquals(clonedPush, offlinePushStatus);
+  }
+
+  @Test(expectedExceptions = VeniceException.class, expectedExceptionsMessageRegExp = "Partition 0 not found in partition assignment")
+  public void testNPECaughtWhenPollingIncPushStatus() {
+    OfflinePushStatus offlinePushStatus =
+        new OfflinePushStatus(kafkaTopic, numberOfPartition, replicationFactor, strategy);
+    PartitionAssignment partitionAssignment = new PartitionAssignment("test-topic", 10);
+    offlinePushStatus.getIncrementalPushStatus(partitionAssignment, "ignore");
   }
 
   private void testValidTargetStatuses(ExecutionStatus from, ExecutionStatus... statuses) {


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Summary
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

We recently find out that NPE would be thrown when polling the incremental push status. This PR adds the NPE handling so we would have more information on which partition couldn't be found. Please note that this PR is NOT for resolving the real problem but attempts to provide more debugging information

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
unit tests
## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.