### PR TITLE
[DRAFT] Reduce consumer lock contention in PartitionOffsetFetcherImpl

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/CachedPubSubMetadataGetter.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/CachedPubSubMetadataGetter.java
@@ -109,7 +109,7 @@ class CachedPubSubMetadataGetter {
       Map<PubSubMetadataCacheKey, ValueAndExpiryTime<T>> metadataCache,
       Supplier<T> valueSupplier) {
     final long now = System.nanoTime();
-    final ValueAndExpiryTime<T> cachedValue =
+    ValueAndExpiryTime<T> cachedValue =
         metadataCache.computeIfAbsent(key, k -> new ValueAndExpiryTime<>(valueSupplier.get(), now + ttlNs));
 
     // For a given key in the given cache, we will only issue one async request at the same time.

--- a/internal/venice-common/src/main/java/com/linkedin/venice/kafka/partitionoffset/PartitionOffsetFetcherFactory.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/kafka/partitionoffset/PartitionOffsetFetcherFactory.java
@@ -3,11 +3,11 @@ package com.linkedin.venice.kafka.partitionoffset;
 import com.linkedin.venice.kafka.protocol.KafkaMessageEnvelope;
 import com.linkedin.venice.pubsub.PubSubConsumerAdapterFactory;
 import com.linkedin.venice.pubsub.api.PubSubAdminAdapter;
+import com.linkedin.venice.pubsub.api.PubSubConsumerAdapter;
 import com.linkedin.venice.pubsub.api.PubSubMessageDeserializer;
 import com.linkedin.venice.serialization.avro.KafkaValueSerializer;
 import com.linkedin.venice.utils.SystemTime;
 import com.linkedin.venice.utils.VeniceProperties;
-import com.linkedin.venice.utils.lazy.Lazy;
 import com.linkedin.venice.utils.pools.LandFillObjectPool;
 import io.tehuti.metrics.MetricsRepository;
 import java.util.Optional;
@@ -18,18 +18,18 @@ public class PartitionOffsetFetcherFactory {
       PubSubConsumerAdapterFactory pubSubConsumerAdapterFactory,
       VeniceProperties veniceProperties,
       String pubSubBootstrapServers,
-      Lazy<PubSubAdminAdapter> kafkaAdminWrapper,
+      PubSubAdminAdapter pubSubAdminAdapter,
       long kafkaOperationTimeoutMs,
       Optional<MetricsRepository> optionalMetricsRepository) {
     PubSubMessageDeserializer pubSubMessageDeserializer = new PubSubMessageDeserializer(
         new KafkaValueSerializer(),
         new LandFillObjectPool<>(KafkaMessageEnvelope::new),
         new LandFillObjectPool<>(KafkaMessageEnvelope::new));
+    PubSubConsumerAdapter pubSubConsumerAdapter =
+        pubSubConsumerAdapterFactory.create(veniceProperties, false, pubSubMessageDeserializer, pubSubBootstrapServers);
     PartitionOffsetFetcher partitionOffsetFetcher = new PartitionOffsetFetcherImpl(
-        kafkaAdminWrapper,
-        Lazy.of(
-            () -> pubSubConsumerAdapterFactory
-                .create(veniceProperties, false, pubSubMessageDeserializer, pubSubBootstrapServers)),
+        pubSubAdminAdapter,
+        pubSubConsumerAdapter,
         kafkaOperationTimeoutMs,
         pubSubBootstrapServers);
     if (optionalMetricsRepository.isPresent()) {

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/adapter/kafka/admin/ApacheKafkaAdminAdapter.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/adapter/kafka/admin/ApacheKafkaAdminAdapter.java
@@ -78,7 +78,7 @@ public class ApacheKafkaAdminAdapter implements PubSubAdminAdapter {
     this.internalKafkaAdminClient =
         Objects.requireNonNull(internalKafkaAdminClient, "Kafka admin client cannot be null!");
     this.pubSubTopicRepository = pubSubTopicRepository;
-    LOGGER.debug("Created KafkaAdminClient with properties: {}", apacheKafkaAdminConfig.getAdminProperties());
+    LOGGER.info("Created KafkaAdminClient with properties: {}", apacheKafkaAdminConfig.getAdminProperties());
   }
 
   /**
@@ -528,6 +528,7 @@ public class ApacheKafkaAdminAdapter implements PubSubAdminAdapter {
 
   @Override
   public void close() throws IOException {
+    LOGGER.info("Closing KafkaAdminClient: ", Thread.currentThread().getStackTrace());
     if (this.internalKafkaAdminClient != null) {
       try {
         this.internalKafkaAdminClient.close(Duration.ofSeconds(60));

--- a/internal/venice-common/src/test/java/com/linkedin/venice/kafka/TopicManagerTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/kafka/TopicManagerTest.java
@@ -518,8 +518,7 @@ public class TopicManagerTest {
     PubSubTopicPartition pubSubTopicPartition = new PubSubTopicPartitionImpl(topic, 0);
     // Mock an admin client to pass topic existence check
     PubSubAdminAdapter mockPubSubAdminAdapter = mock(PubSubAdminAdapter.class);
-    doReturn(true).when(mockPubSubAdminAdapter)
-        .containsTopicWithPartitionCheckExpectationAndRetry(eq(pubSubTopicPartition), anyInt(), eq(true));
+    doReturn(true).when(mockPubSubAdminAdapter).containsTopicWithExpectationAndRetry(eq(topic), anyInt(), eq(true));
     PubSubConsumerAdapter mockPubSubConsumer = mock(PubSubConsumerAdapter.class);
     doThrow(new PubSubOpTimeoutException("Timed out while fetching end offsets")).when(mockPubSubConsumer)
         .endOffsets(any(), any());

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/kafka/partitionoffset/PartitionOffsetFetcherTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/kafka/partitionoffset/PartitionOffsetFetcherTest.java
@@ -13,7 +13,6 @@ import com.linkedin.venice.pubsub.api.exceptions.PubSubTopicDoesNotExistExceptio
 import com.linkedin.venice.utils.Time;
 import com.linkedin.venice.utils.Utils;
 import com.linkedin.venice.utils.VeniceProperties;
-import com.linkedin.venice.utils.lazy.Lazy;
 import java.util.Optional;
 import java.util.Properties;
 import org.testng.Assert;
@@ -50,7 +49,7 @@ public class PartitionOffsetFetcherTest {
         pubSubConsumerAdapterFactory,
         new VeniceProperties(properties),
         pubSubBrokerWrapper.getAddress(),
-        Lazy.of(() -> pubSubAdminAdapterFactory.create(new VeniceProperties(properties), pubSubTopicRepository)),
+        pubSubAdminAdapterFactory.create(new VeniceProperties(properties), pubSubTopicRepository),
         Time.MS_PER_SECOND,
         Optional.empty())) {
       String topic = Utils.getUniqueString("topic") + "_v1";


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## [DRAFT] Reduce consumer lock contention in PartitionOffsetFetcherImpl
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Resolves #XXX

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
WIP

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.