### PR TITLE
Add bootstrap change capture consumer

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/BootstrappingVeniceChangelogConsumer.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/BootstrappingVeniceChangelogConsumer.java
@@ -1,0 +1,47 @@
+package com.linkedin.davinci.consumer;
+
+import com.linkedin.venice.pubsub.api.PubSubMessage;
+import java.util.Collection;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+
+
+/**
+ * This interface is meant for users where local state must be built off of the entirety of a venice data set
+ * (i.e. Non-idempotent event ingestion), rather than dealing with an event at a time. THIS IS EXPENSIVE.
+ * It's highly recommended that users use the {@link VeniceChangelogConsumer} interface as a means to consume Venice
+ * Change capture data.
+ *
+ * Implementations of this interface rely on access to a compacted view to the data and scanning the entirety of that
+ * compacted view initial calls to poll(). This is the only supported pattern with this interface today. {@link VeniceChangelogConsumer}
+ * enables more fine control.  This interface is intentionally limited as implementors rely on local checkpointing and
+ * maintenance of state which might be easily corrupted with byzantine seek() calls.
+ * @param <K>
+ * @param <V>
+ */
+public interface BootstrappingVeniceChangelogConsumer<K, V> {
+  /**
+   * Start performs both a topic subscription and catch up. The client will look at the latest offset in the server and
+   * sync bootstrap data up to that point in changes. Once that is done for all partitions, the future will complete.
+   *
+   * NOTE: This future may take some time to complete depending on how much data needs to be ingested in order to catch
+   * up with the time that this client started.
+   *
+   * @param partitions which partition id's to catch up with
+   * @return a future that completes once catch up is complete for all passed in partitions.
+   */
+  CompletableFuture<Void> start(Set<Integer> partitions);
+
+  CompletableFuture<Void> start();
+
+  void stop() throws Exception;
+
+  /**
+   * polls for the next batch of change events. The first records returned following calling 'start()' will be from the bootstrap state.
+   * Once this state is consumed, subsequent calls to poll will be based off of recent updates to the Venice store.
+   * @param timeoutInMs
+   * @return
+   */
+  Collection<PubSubMessage<K, ChangeEvent<V>, VeniceChangeCoordinate>> poll(long timeoutInMs);
+
+}

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/BootstrappingVeniceChangelogConsumer.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/BootstrappingVeniceChangelogConsumer.java
@@ -14,7 +14,7 @@ import java.util.concurrent.CompletableFuture;
  *
  * Implementations of this interface rely on access to a compacted view to the data and scanning the entirety of that
  * compacted view initial calls to poll(). This is the only supported pattern with this interface today. {@link VeniceChangelogConsumer}
- * enables more fine control.  This interface is intentionally limited as implementors rely on local checkpointing and
+ * enables finer control.  This interface is intentionally limited as implementors rely on local checkpointing and
  * maintenance of state which might be easily corrupted with byzantine seek() calls.
  * @param <K>
  * @param <V>

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/ChangelogClientConfig.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/ChangelogClientConfig.java
@@ -18,6 +18,8 @@ public class ChangelogClientConfig<T extends SpecificRecord> {
   private String controllerD2ServiceName;
   private int controllerRequestRetryCount;
 
+  private String bootstrapFileSystemPath;
+
   public ChangelogClientConfig(String storeName) {
     this.innerClientConfig = new ClientConfig<>(storeName);
   }
@@ -120,6 +122,15 @@ public class ChangelogClientConfig<T extends SpecificRecord> {
     return this.innerClientConfig;
   }
 
+  public ChangelogClientConfig<T> setBootstrapFileSystemPath(String bootstrapFileSystemPath) {
+    this.bootstrapFileSystemPath = bootstrapFileSystemPath;
+    return this;
+  }
+
+  public String getBootstrapFileSystemPath() {
+    return this.bootstrapFileSystemPath;
+  }
+
   public static <V extends SpecificRecord> ChangelogClientConfig<V> cloneConfig(ChangelogClientConfig<V> config) {
     ChangelogClientConfig<V> newConfig = new ChangelogClientConfig<V>().setStoreName(config.getStoreName())
         .setLocalD2ZkHosts(config.getLocalD2ZkHosts())
@@ -130,7 +141,8 @@ public class ChangelogClientConfig<T extends SpecificRecord> {
         .setD2ControllerClient(config.getD2ControllerClient())
         .setControllerD2ServiceName(config.controllerD2ServiceName)
         .setD2Client(config.getD2Client())
-        .setControllerRequestRetryCount(config.getControllerRequestRetryCount());
+        .setControllerRequestRetryCount(config.getControllerRequestRetryCount())
+        .setBootstrapFileSystemPath(config.getBootstrapFileSystemPath());
     return newConfig;
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/ImmutableChangeCapturePubSubMessage.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/ImmutableChangeCapturePubSubMessage.java
@@ -13,6 +13,7 @@ public class ImmutableChangeCapturePubSubMessage<K, V> implements PubSubMessage<
   private final VeniceChangeCoordinate offset;
   private final long timestamp;
   private final int payloadSize;
+  private final boolean isEndOfBootstrap;
 
   public ImmutableChangeCapturePubSubMessage(
       K key,
@@ -20,7 +21,8 @@ public class ImmutableChangeCapturePubSubMessage<K, V> implements PubSubMessage<
       PubSubTopicPartition topicPartition,
       long offset,
       long timestamp,
-      int payloadSize) {
+      int payloadSize,
+      boolean isEndOfBootstrap) {
     this.key = key;
     this.value = value;
     this.topicPartition = Objects.requireNonNull(topicPartition);
@@ -30,6 +32,7 @@ public class ImmutableChangeCapturePubSubMessage<K, V> implements PubSubMessage<
         this.topicPartition.getPubSubTopic().getName(),
         new ApacheKafkaOffsetPosition(offset),
         this.topicPartition.getPartitionNumber());
+    this.isEndOfBootstrap = isEndOfBootstrap;
   }
 
   @Override
@@ -60,5 +63,10 @@ public class ImmutableChangeCapturePubSubMessage<K, V> implements PubSubMessage<
   @Override
   public int getPayloadSize() {
     return payloadSize;
+  }
+
+  @Override
+  public boolean isEndOfBootstrap() {
+    return isEndOfBootstrap;
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/InternalLocalBootstrappingVeniceChangelogConsumer.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/InternalLocalBootstrappingVeniceChangelogConsumer.java
@@ -1,0 +1,505 @@
+package com.linkedin.davinci.consumer;
+
+import static com.linkedin.davinci.store.rocksdb.RocksDBServerConfig.ROCKSDB_LEVEL0_FILE_NUM_COMPACTION_TRIGGER;
+import static com.linkedin.davinci.store.rocksdb.RocksDBServerConfig.ROCKSDB_LEVEL0_FILE_NUM_COMPACTION_TRIGGER_WRITE_ONLY_VERSION;
+import static com.linkedin.davinci.store.rocksdb.RocksDBServerConfig.ROCKSDB_LEVEL0_SLOWDOWN_WRITES_TRIGGER;
+import static com.linkedin.davinci.store.rocksdb.RocksDBServerConfig.ROCKSDB_LEVEL0_SLOWDOWN_WRITES_TRIGGER_WRITE_ONLY_VERSION;
+import static com.linkedin.davinci.store.rocksdb.RocksDBServerConfig.ROCKSDB_LEVEL0_STOPS_WRITES_TRIGGER;
+import static com.linkedin.davinci.store.rocksdb.RocksDBServerConfig.ROCKSDB_LEVEL0_STOPS_WRITES_TRIGGER_WRITE_ONLY_VERSION;
+import static com.linkedin.davinci.store.rocksdb.RocksDBServerConfig.ROCKSDB_PLAIN_TABLE_FORMAT_ENABLED;
+import static com.linkedin.venice.ConfigKeys.DATA_BASE_PATH;
+import static com.linkedin.venice.kafka.partitionoffset.PartitionOffsetFetcherImpl.DEFAULT_KAFKA_OFFSET_API_TIMEOUT;
+import static com.linkedin.venice.offsets.OffsetRecord.LOWEST_OFFSET;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.linkedin.davinci.callback.BytesStreamingCallback;
+import com.linkedin.davinci.config.VeniceConfigLoader;
+import com.linkedin.davinci.stats.AggVersionedStorageEngineStats;
+import com.linkedin.davinci.storage.StorageEngineMetadataService;
+import com.linkedin.davinci.storage.StorageMetadataService;
+import com.linkedin.davinci.storage.StorageService;
+import com.linkedin.davinci.store.record.ValueRecord;
+import com.linkedin.venice.client.change.capture.protocol.RecordChangeEvent;
+import com.linkedin.venice.client.store.ClientConfig;
+import com.linkedin.venice.client.store.ClientFactory;
+import com.linkedin.venice.compression.VeniceCompressor;
+import com.linkedin.venice.exceptions.VeniceException;
+import com.linkedin.venice.kafka.protocol.ControlMessage;
+import com.linkedin.venice.kafka.protocol.VersionSwap;
+import com.linkedin.venice.kafka.protocol.enums.ControlMessageType;
+import com.linkedin.venice.kafka.protocol.state.PartitionState;
+import com.linkedin.venice.kafka.protocol.state.StoreVersionState;
+import com.linkedin.venice.meta.PersistenceType;
+import com.linkedin.venice.offsets.OffsetRecord;
+import com.linkedin.venice.pubsub.adapter.kafka.ApacheKafkaOffsetPosition;
+import com.linkedin.venice.pubsub.api.PubSubConsumerAdapter;
+import com.linkedin.venice.pubsub.api.PubSubMessage;
+import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
+import com.linkedin.venice.schema.SchemaReader;
+import com.linkedin.venice.serialization.avro.AvroProtocolDefinition;
+import com.linkedin.venice.serialization.avro.InternalAvroSpecificSerializer;
+import com.linkedin.venice.serializer.RecordDeserializer;
+import com.linkedin.venice.utils.PropertyBuilder;
+import com.linkedin.venice.utils.VeniceProperties;
+import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
+import com.linkedin.venice.views.ChangeCaptureView;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.apache.commons.lang.StringUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+
+class InternalLocalBootstrappingVeniceChangelogConsumer<K, V> extends VeniceChangelogConsumerImpl<K, V>
+    implements BootstrappingVeniceChangelogConsumer<K, V> {
+  private static final Logger LOGGER = LogManager.getLogger(InternalLocalBootstrappingVeniceChangelogConsumer.class);
+  private StorageService storageService;
+  private StorageMetadataService storageMetadataService;
+
+  private static final String CHANGE_CAPTURE_COORDINATE = "ChangeCaptureCoordinatePosition";
+
+  // This is the name of a non-existent topic. We use it as a handle when interfacing with local storage so we can
+  // make decisions about easily about weather or not to clear out the local state data or not across version for a
+  // store
+  // (we'll keep the local data in the event of a repush, but clear out if a user push comes through)
+  private static final String LOCAL_STATE_TOPIC_NAME = "ChangeCaptureBootstrap_v1";
+
+  private final VeniceConcurrentHashMap<Integer, BootstrapState> bootstrapStateMap = new VeniceConcurrentHashMap<>();
+  private final Thread checkpointTask;
+  private final InternalAvroSpecificSerializer<PartitionState> partitionStateSerializer;
+
+  private VeniceConfigLoader configLoader;
+
+  boolean isStarted = false;
+
+  private int bootstrapCompletedCount = 0;
+
+  public InternalLocalBootstrappingVeniceChangelogConsumer(
+      ChangelogClientConfig changelogClientConfig,
+      PubSubConsumerAdapter pubSubConsumer) {
+    super(changelogClientConfig, pubSubConsumer);
+    configLoader = buildVeniceConfig();
+    AggVersionedStorageEngineStats storageEngineStats = new AggVersionedStorageEngineStats(
+        changelogClientConfig.getInnerClientConfig().getMetricsRepository(),
+        this.storeRepository,
+        true);
+    SchemaReader partitionStateSchemaReader = ClientFactory.getSchemaReader(
+        ClientConfig.cloneConfig(changelogClientConfig.getInnerClientConfig())
+            .setStoreName(AvroProtocolDefinition.PARTITION_STATE.getSystemStoreName()),
+        null);
+    partitionStateSerializer = AvroProtocolDefinition.PARTITION_STATE.getSerializer();
+    partitionStateSerializer.setSchemaReader(partitionStateSchemaReader);
+
+    SchemaReader versionStateSchemaReader = ClientFactory.getSchemaReader(
+        ClientConfig.cloneConfig(changelogClientConfig.getInnerClientConfig())
+            .setStoreName(AvroProtocolDefinition.STORE_VERSION_STATE.getSystemStoreName()),
+        null);
+    InternalAvroSpecificSerializer<StoreVersionState> storeVersionStateSerializer =
+        AvroProtocolDefinition.STORE_VERSION_STATE.getSerializer();
+    storeVersionStateSerializer.setSchemaReader(versionStateSchemaReader);
+
+    storageService = new StorageService(
+        configLoader,
+        storageEngineStats,
+        null,
+        storeVersionStateSerializer,
+        partitionStateSerializer,
+        this.storeRepository,
+        true,
+        true,
+        functionToCheckWhetherStorageEngineShouldBeKeptOrNot());
+    storageMetadataService =
+        new StorageEngineMetadataService(storageService.getStorageEngineRepository(), partitionStateSerializer);
+    checkpointTask = new VeniceChangelogCheckpointThread();
+  }
+
+  private Function<String, Boolean> functionToCheckWhetherStorageEngineShouldBeKeptOrNot() {
+    return storageEngineName -> {
+      // This function needs to determine if the local files need to be cleared out or not. The way it should do
+      // that
+      // is by reading the local storagemetadata bootstrap coordinate, and see if the internal client is able to
+      // subscribe to that position. If it's not able to, that means that the local state is off Venice retention,
+      // and therefore should be completely rebootstrapped.
+      for (Integer partition: bootstrapStateMap.keySet()) {
+        OffsetRecord offsetRecord = storageMetadataService.getLastOffset(LOCAL_STATE_TOPIC_NAME, partition);
+        if (offsetRecord == null) {
+          // No offset info in local, need to bootstrap from beginning.
+          return false;
+        }
+
+        VeniceChangeCoordinate localCheckpoint;
+        try {
+          localCheckpoint = VeniceChangeCoordinate.decodeStringAndConvertToVeniceChangeCoordinate(
+              offsetRecord.getDatabaseInfo().get(CHANGE_CAPTURE_COORDINATE));
+        } catch (IOException | ClassNotFoundException e) {
+          throw new VeniceException("Failed to decode local change capture coordinate checkpoint with exception: ", e);
+        }
+
+        PubSubTopicPartition topicPartition = getTopicPartition(partition);
+        Long earliestOffset = pubSubConsumer.beginningOffset(topicPartition, DEFAULT_KAFKA_OFFSET_API_TIMEOUT);
+        VeniceChangeCoordinate earliestCheckpoint = earliestOffset == null
+            ? null
+            : new VeniceChangeCoordinate(
+                topicPartition.getPubSubTopic().getName(),
+                new ApacheKafkaOffsetPosition(earliestOffset),
+                partition);
+
+        // If earliest offset is larger than the local, we should just bootstrap from beginning.
+        if (earliestCheckpoint != null && earliestCheckpoint.comparePosition(localCheckpoint) > -1) {
+          return false;
+        }
+      }
+
+      return true;
+    };
+  }
+
+  @Override
+  protected boolean handleVersionSwapControlMessage(
+      ControlMessage controlMessage,
+      PubSubTopicPartition pubSubTopicPartition,
+      String topicSuffix) {
+    ControlMessageType controlMessageType = ControlMessageType.valueOf(controlMessage);
+    if (controlMessageType.equals(ControlMessageType.VERSION_SWAP)) {
+      VersionSwap versionSwap = (VersionSwap) controlMessage.controlMessageUnion;
+      if (!versionSwap.isRepush) {
+        // Clean up all local data and seek existing
+        storageMetadataService.clearStoreVersionState(LOCAL_STATE_TOPIC_NAME);
+        this.storageService.cleanupAllStores(this.configLoader);
+        seekToBeginningOfPush(Collections.singleton(pubSubTopicPartition.getPartitionNumber()));
+      }
+    }
+
+    return super.handleControlMessage(controlMessage, pubSubTopicPartition, topicSuffix);
+  }
+
+  private VeniceConfigLoader buildVeniceConfig() {
+    VeniceProperties config = new PropertyBuilder().put(ROCKSDB_LEVEL0_FILE_NUM_COMPACTION_TRIGGER, 4) // RocksDB
+        // default config
+        .put(ROCKSDB_LEVEL0_SLOWDOWN_WRITES_TRIGGER, 20) // RocksDB default config
+        .put(ROCKSDB_LEVEL0_STOPS_WRITES_TRIGGER, 36) // RocksDB default config
+        .put(ROCKSDB_LEVEL0_FILE_NUM_COMPACTION_TRIGGER_WRITE_ONLY_VERSION, 40)
+        .put(ROCKSDB_LEVEL0_SLOWDOWN_WRITES_TRIGGER_WRITE_ONLY_VERSION, 60)
+        .put(ROCKSDB_LEVEL0_STOPS_WRITES_TRIGGER_WRITE_ONLY_VERSION, 80)
+        .put(changelogClientConfig.getConsumerProperties())
+        .put(DATA_BASE_PATH, changelogClientConfig.getBootstrapFileSystemPath())
+        .put(ROCKSDB_PLAIN_TABLE_FORMAT_ENABLED, false)
+        .build();
+    return new VeniceConfigLoader(config, config);
+  }
+
+  @Override
+  protected Collection<PubSubMessage<K, ChangeEvent<V>, VeniceChangeCoordinate>> internalPoll(
+      long timeoutInMs,
+      String topicSuffix) {
+
+    if (!isStarted) {
+      throw new VeniceException("Client isn't started yet!!");
+    }
+    // If there are any partitions which are in BOOTSTRAPPING state, play messages from those partitions first
+    for (Map.Entry<Integer, BootstrapState> state: bootstrapStateMap.entrySet()) {
+      if (state.getValue().bootstrapState.equals(PollState.BOOTSTRAPPING)) {
+        // read from storage engine
+        Collection<PubSubMessage<K, ChangeEvent<V>, VeniceChangeCoordinate>> resultSet = new ArrayList<>();
+        AtomicBoolean completed = new AtomicBoolean(false);
+        storageService.getStorageEngine(LOCAL_STATE_TOPIC_NAME)
+            .getByKeyPrefix(state.getKey(), null, new BytesStreamingCallback() {
+              @Override
+              public void onRecordReceived(byte[] key, byte[] value) {
+                onRecordReceivedForStorage(key, value, state.getKey(), resultSet);
+              }
+
+              @Override
+              public void onCompletion() {
+                onCompletionForStorage(state.getKey(), state.getValue(), resultSet, completed);
+              }
+            });
+        if (!completed.get()) {
+          throw new VeniceException("Interrupted while reading local bootstrap data!");
+        }
+        return resultSet;
+      }
+    }
+    return super.internalPoll(timeoutInMs, topicSuffix);
+  }
+
+  @VisibleForTesting
+  void onRecordReceivedForStorage(
+      byte[] key,
+      byte[] value,
+      int partition,
+      Collection<PubSubMessage<K, ChangeEvent<V>, VeniceChangeCoordinate>> resultSet) {
+    // Transform and populate into the collection that we return.
+    // TODO: this is a shortcoming of both this interface and the change capture client, we need to specify
+    // a user
+    // schema for deserialization
+    ValueRecord valueRecord = ValueRecord.parseAndCreate(value);
+
+    // Create a change event to wrap the record we pulled from disk and deserialize the record
+    ChangeEvent<V> changeEvent = new ChangeEvent<>(
+        null,
+        (V) storeDeserializerCache.getDeserializer(valueRecord.getSchemaId(), valueRecord.getSchemaId())
+            .deserialize(valueRecord.getDataInBytes()));
+
+    PubSubMessage<K, ChangeEvent<V>, VeniceChangeCoordinate> record = new ImmutableChangeCapturePubSubMessage<>(
+        keyDeserializer.deserialize(key),
+        changeEvent,
+        getTopicPartition(partition),
+        0,
+        0,
+        value.length * 8,
+        false);
+    resultSet.add(record);
+  }
+
+  @VisibleForTesting
+  void onCompletionForStorage(
+      int partition,
+      BootstrapState state,
+      Collection<PubSubMessage<K, ChangeEvent<V>, VeniceChangeCoordinate>> resultSet,
+      AtomicBoolean completed) {
+    // Update the map so that we're no longer in bootstrap mode
+    state.bootstrapState = PollState.CONSUMING;
+    bootstrapCompletedCount++;
+    if (bootstrapCompletedCount == bootstrapStateMap.size()) {
+      // Add a dummy record to mark the end of the bootstrap.
+      resultSet.add(new ImmutableChangeCapturePubSubMessage<>(null, null, getTopicPartition(partition), 0, 0, 0, true));
+    }
+
+    // Notify that we've caught up
+    completed.set(true);
+  }
+
+  @VisibleForTesting
+  int getBootstrapCompletedCount() {
+    return bootstrapCompletedCount;
+  }
+
+  /**
+   * Polls change capture client and persist the results to local disk. Also updates the bootstrapStateMap with latest offsets
+   * and if the client has caught up or not.
+   *
+   * @param timeoutInMs timeout on Poll
+   * @param topicSuffix internal topic suffix
+   * @return
+   */
+  private Collection<PubSubMessage<K, ChangeEvent<V>, VeniceChangeCoordinate>> pollAndCatchup(
+      long timeoutInMs,
+      String topicSuffix) {
+    Collection<PubSubMessage<K, ChangeEvent<V>, VeniceChangeCoordinate>> polledResults =
+        super.internalPoll(timeoutInMs, topicSuffix);
+    for (PubSubMessage<K, ChangeEvent<V>, VeniceChangeCoordinate> record: polledResults) {
+      BootstrapState currentPartitionState = bootstrapStateMap.get(record.getPartition());
+      currentPartitionState.currentPubSubPosition = record.getOffset();
+      if (currentPartitionState.bootstrapState.equals(PollState.CATCHING_UP)) {
+        if (currentPartitionState.isCaughtUp()) {
+          currentPartitionState.bootstrapState = PollState.BOOTSTRAPPING;
+        }
+      }
+      bootstrapStateMap.put(record.getPartition(), currentPartitionState);
+    }
+    return polledResults;
+  }
+
+  @Override
+  protected <T> T processRecordBytes(
+      RecordDeserializer<T> deserializer,
+      VeniceCompressor compressor,
+      byte[] key,
+      ByteBuffer value,
+      PubSubTopicPartition partition,
+      int readerSchemaId) throws IOException {
+    ByteBuffer decompressedBytes = compressor.decompress(value);
+    T deserializedValue = deserializer.deserialize(decompressedBytes);
+    if (deserializedValue instanceof RecordChangeEvent) {
+      RecordChangeEvent recordChangeEvent = (RecordChangeEvent) deserializedValue;
+      if (recordChangeEvent.currentValue == null) {
+        storageService.getStorageEngine(LOCAL_STATE_TOPIC_NAME).delete(partition.getPartitionNumber(), key);
+      } else {
+        storageService.getStorageEngine(LOCAL_STATE_TOPIC_NAME)
+            .put(
+                partition.getPartitionNumber(),
+                key,
+                ValueRecord
+                    .create(recordChangeEvent.currentValue.schemaId, recordChangeEvent.currentValue.value.array())
+                    .serialize());
+      }
+    } else {
+      storageService.getStorageEngine(LOCAL_STATE_TOPIC_NAME)
+          .put(
+              partition.getPartitionNumber(),
+              key,
+              ValueRecord.create(readerSchemaId, decompressedBytes.array()).serialize());
+    }
+    return deserializedValue;
+  }
+
+  public CompletableFuture<Void> seekWithBootStrap(Set<Integer> partitions) {
+    return CompletableFuture.supplyAsync(() -> {
+      // Seek everything to tail in order to get the high offset
+      try {
+        this.seekToTail(partitions).get();
+      } catch (InterruptedException | ExecutionException e) {
+        throw new VeniceException("Failed to bootstrap change log consumer with exception: ", e);
+      }
+      for (Integer partition: partitions) {
+        OffsetRecord offsetRecord;
+        try {
+          offsetRecord = storageMetadataService.getLastOffset(LOCAL_STATE_TOPIC_NAME, partition);
+          if (offsetRecord.getLocalVersionTopicOffset() == LOWEST_OFFSET) {
+            storageService.openStoreForNewPartition(
+                configLoader.getStoreConfig(LOCAL_STATE_TOPIC_NAME, PersistenceType.ROCKS_DB),
+                partition,
+                () -> null);
+          }
+        } catch (VeniceException e) {
+          // storageMetadataService will throw exception if there is no local store, it could happen the first
+          // time to run this code or local store has become invalid, we need to re-create the store in this case.
+          storageService.openStoreForNewPartition(
+              configLoader.getStoreConfig(LOCAL_STATE_TOPIC_NAME, PersistenceType.ROCKS_DB),
+              partition,
+              () -> null);
+          offsetRecord = new OffsetRecord(partitionStateSerializer);
+        }
+
+        // Where we're at now
+        String offsetString = offsetRecord.getDatabaseInfo().get(CHANGE_CAPTURE_COORDINATE);
+        VeniceChangeCoordinate localCheckpoint;
+        try {
+          localCheckpoint = StringUtils.isEmpty(offsetString)
+              ? new VeniceChangeCoordinate(
+                  getTopicPartition(partition).getPubSubTopic().getName(),
+                  new ApacheKafkaOffsetPosition(offsetRecord.getLocalVersionTopicOffset()),
+                  partition)
+              : VeniceChangeCoordinate.decodeStringAndConvertToVeniceChangeCoordinate(
+                  offsetRecord.getDatabaseInfo().get(CHANGE_CAPTURE_COORDINATE));
+        } catch (IOException | ClassNotFoundException e) {
+          throw new VeniceException("Failed to decode local hhange capture coordinate chekcpoint with exception: ", e);
+        }
+
+        // Where we need to catch up to
+        VeniceChangeCoordinate targetCheckpoint = this.getLatestCoordinate(partition);
+
+        synchronized (bootstrapStateMap) {
+          BootstrapState newState = new BootstrapState();
+          newState.currentPubSubPosition = localCheckpoint;
+          newState.targetPubSubPosition = targetCheckpoint;
+          newState.bootstrapState = newState.isCaughtUp() ? PollState.BOOTSTRAPPING : PollState.CATCHING_UP;
+          bootstrapStateMap.put(partition, newState);
+        }
+      }
+
+      // Seek to the current position so we can catch up from there to target
+      seekToCheckpoint(
+          bootstrapStateMap.values().stream().map(state -> state.currentPubSubPosition).collect(Collectors.toSet()));
+
+      // Poll until we've caught up completely for all subscribed partitions.
+      while (bootstrapStateMap.entrySet()
+          .stream()
+          .anyMatch(s -> s.getValue().bootstrapState.equals(PollState.CATCHING_UP))) {
+        pollAndCatchup(5000L, ChangeCaptureView.CHANGE_CAPTURE_TOPIC_SUFFIX);
+      }
+
+      this.isStarted = true;
+      return null;
+    });
+  }
+
+  public CompletableFuture<Void> start(Set<Integer> partitions) {
+    if (isStarted) {
+      throw new VeniceException("Bootstrapping Changelog client is already started!");
+    }
+
+    storageService.start();
+    try {
+      storeRepository.start();
+      storeRepository.subscribe(storeName);
+    } catch (InterruptedException e) {
+      throw new RuntimeException(e);
+    }
+
+    checkpointTask.start();
+
+    return seekWithBootStrap(partitions);
+  }
+
+  @Override
+  public CompletableFuture<Void> start() {
+    Set<Integer> allPartitions = new HashSet<>();
+    for (int partition = 0; partition < partitionCount; partition++) {
+      allPartitions.add(partition);
+    }
+    return this.start(allPartitions);
+  }
+
+  @Override
+  public void stop() throws Exception {
+    storageService.stop();
+    checkpointTask.interrupt();
+  }
+
+  @VisibleForTesting
+  void setStorageAndMetadataService(StorageService storageService, StorageMetadataService storageMetadataService) {
+    this.storageService = storageService;
+    this.storageMetadataService = storageMetadataService;
+  }
+
+  enum PollState {
+    CATCHING_UP, BOOTSTRAPPING, CONSUMING
+  }
+
+  static class BootstrapState {
+    PollState bootstrapState;
+    VeniceChangeCoordinate currentPubSubPosition;
+    VeniceChangeCoordinate targetPubSubPosition;
+
+    boolean isCaughtUp() {
+      return currentPubSubPosition.comparePosition(targetPubSubPosition) > -1;
+    }
+  }
+
+  private class VeniceChangelogCheckpointThread extends Thread {
+    VeniceChangelogCheckpointThread() {
+      super("Venice-Changelog-Checkpoint-Thread");
+    }
+
+    @Override
+    public void run() {
+      while (!Thread.interrupted()) {
+        for (Map.Entry<Integer, BootstrapState> state: bootstrapStateMap.entrySet()) {
+          OffsetRecord lastOffset = storageMetadataService.getLastOffset(LOCAL_STATE_TOPIC_NAME, state.getKey());
+          Map<String, String> dbInfo = lastOffset.getDatabaseInfo();
+          try {
+            dbInfo.put(
+                CHANGE_CAPTURE_COORDINATE,
+                VeniceChangeCoordinate
+                    .convertVeniceChangeCoordinateToStringAndEncode(state.getValue().currentPubSubPosition));
+          } catch (IOException e) {
+            LOGGER.error(
+                "Failed to update change capture coordinate position: {}",
+                state.getValue().currentPubSubPosition);
+          }
+          storageMetadataService.put(LOCAL_STATE_TOPIC_NAME, state.getKey(), lastOffset);
+        }
+        try {
+          TimeUnit.SECONDS.sleep(20);
+        } catch (InterruptedException e) {
+          // We've received an interrupt which is to be expected, so we'll just leave the loop and log
+          break;
+        }
+      }
+    }
+  }
+}

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/InternalLocalBootstrappingVeniceChangelogConsumer.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/InternalLocalBootstrappingVeniceChangelogConsumer.java
@@ -378,13 +378,15 @@ class InternalLocalBootstrappingVeniceChangelogConsumer<K, V> extends VeniceChan
         String offsetString = offsetRecord.getDatabaseInfo().get(CHANGE_CAPTURE_COORDINATE);
         VeniceChangeCoordinate localCheckpoint;
         try {
-          localCheckpoint = StringUtils.isEmpty(offsetString)
-              ? new VeniceChangeCoordinate(
-                  getTopicPartition(partition).getPubSubTopic().getName(),
-                  new ApacheKafkaOffsetPosition(offsetRecord.getLocalVersionTopicOffset()),
-                  partition)
-              : VeniceChangeCoordinate.decodeStringAndConvertToVeniceChangeCoordinate(
-                  offsetRecord.getDatabaseInfo().get(CHANGE_CAPTURE_COORDINATE));
+          if (StringUtils.isEmpty(offsetString)) {
+            localCheckpoint = new VeniceChangeCoordinate(
+                getTopicPartition(partition).getPubSubTopic().getName(),
+                new ApacheKafkaOffsetPosition(offsetRecord.getLocalVersionTopicOffset()),
+                partition);
+          } else {
+            localCheckpoint = VeniceChangeCoordinate.decodeStringAndConvertToVeniceChangeCoordinate(
+                offsetRecord.getDatabaseInfo().get(CHANGE_CAPTURE_COORDINATE));
+          }
         } catch (IOException | ClassNotFoundException e) {
           throw new VeniceException("Failed to decode local hhange capture coordinate chekcpoint with exception: ", e);
         }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/LocalBootstrappingVeniceChangelogConsumer.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/LocalBootstrappingVeniceChangelogConsumer.java
@@ -1,0 +1,21 @@
+package com.linkedin.davinci.consumer;
+
+import com.linkedin.venice.pubsub.api.PubSubConsumerAdapter;
+
+
+/**
+ * This is a wrapper class on top of InternalBootstrappingVeniceChangelogConsumerImpl. This confines
+ * the usage of this class for clients to the methods exposed on the interface.  This is meant
+ * to prevent users from doing seek() calls which would render the local state inconsistent.
+ *
+ * @param <K>
+ * @param <V>
+ */
+public class LocalBootstrappingVeniceChangelogConsumer<K, V>
+    extends InternalLocalBootstrappingVeniceChangelogConsumer<K, V> {
+  public LocalBootstrappingVeniceChangelogConsumer(
+      ChangelogClientConfig changelogClientConfig,
+      PubSubConsumerAdapter pubSubConsumer) {
+    super(changelogClientConfig, pubSubConsumer);
+  }
+}

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImpl.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImpl.java
@@ -2,9 +2,11 @@ package com.linkedin.davinci.consumer;
 
 import static com.linkedin.venice.schema.rmd.RmdConstants.*;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.linkedin.davinci.repository.ThinClientMetaStoreBasedRepository;
 import com.linkedin.davinci.storage.chunking.AbstractAvroChunkingAdapter;
 import com.linkedin.davinci.storage.chunking.GenericChunkingAdapter;
+import com.linkedin.davinci.storage.chunking.RawBytesChunkingAdapter;
 import com.linkedin.davinci.storage.chunking.SpecificRecordChunkingAdapter;
 import com.linkedin.davinci.store.memory.InMemoryStorageEngine;
 import com.linkedin.davinci.store.record.ValueRecord;
@@ -39,6 +41,7 @@ import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
 import com.linkedin.venice.schema.SchemaReader;
 import com.linkedin.venice.schema.rmd.RmdUtils;
 import com.linkedin.venice.serialization.AvroStoreDeserializerCache;
+import com.linkedin.venice.serialization.RawBytesStoreDeserializerCache;
 import com.linkedin.venice.serialization.avro.AvroProtocolDefinition;
 import com.linkedin.venice.serializer.FastSerializerDeserializerFactory;
 import com.linkedin.venice.serializer.RecordDeserializer;
@@ -47,6 +50,7 @@ import com.linkedin.venice.utils.DictionaryUtils;
 import com.linkedin.venice.utils.VeniceProperties;
 import com.linkedin.venice.utils.lazy.Lazy;
 import com.linkedin.venice.views.ChangeCaptureView;
+import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -70,14 +74,14 @@ import org.apache.logging.log4j.Logger;
 
 public class VeniceChangelogConsumerImpl<K, V> implements VeniceChangelogConsumer<K, V> {
   private static final Logger LOGGER = LogManager.getLogger(VeniceChangelogConsumerImpl.class);
-  private final int partitionCount;
+  protected final int partitionCount;
 
   protected static final VeniceCompressor NO_OP_COMPRESSOR = new NoopCompressor();
 
   protected final CompressorFactory compressorFactory = new CompressorFactory();
 
   protected final HashMap<Integer, VeniceCompressor> compressorMap = new HashMap<>();
-  private final AvroStoreDeserializerCache<V> storeDeserializerCache;
+  protected AvroStoreDeserializerCache<V> storeDeserializerCache;
   private final AvroStoreDeserializerCache<RecordChangeEvent> recordChangeEventDeserializerCache;
 
   protected ThinClientMetaStoreBasedRepository storeRepository;
@@ -89,7 +93,7 @@ public class VeniceChangelogConsumerImpl<K, V> implements VeniceChangelogConsume
 
   protected final SchemaReader schemaReader;
   private final String viewClassName;
-  private final PubSubTopicRepository pubSubTopicRepository = new PubSubTopicRepository();
+  protected final PubSubTopicRepository pubSubTopicRepository = new PubSubTopicRepository();
 
   protected final RecordDeserializer<K> keyDeserializer;
   private final D2ControllerClient d2ControllerClient;
@@ -139,8 +143,6 @@ public class VeniceChangelogConsumerImpl<K, V> implements VeniceChangelogConsume
     // The in memory storage engine only relies on the name of store and nothing else. We use an unversioned store name
     // here in order to reduce confusion (as this storage engine can be used across version topics).
     this.inMemoryStorageEngine = new InMemoryStorageEngine(storeName);
-    // disable noisy logs
-    this.inMemoryStorageEngine.suppressLogs(true);
     this.storeRepository = new ThinClientMetaStoreBasedRepository(
         changelogClientConfig.getInnerClientConfig(),
         VeniceProperties.empty(),
@@ -588,18 +590,36 @@ public class VeniceChangelogConsumerImpl<K, V> implements VeniceChangelogConsume
           keyBytes,
           ValueRecord.create(schemaId, valueBytes.array()).serialize());
       try {
-        assembledRecord = chunkingAdapter.get(
-            inMemoryStorageEngine,
-            pubSubTopicPartition.getPartitionNumber(),
-            ByteBuffer.wrap(keyBytes),
-            false,
-            null,
-            null,
-            null,
-            readerSchemaId,
-            deserializerCache,
+        assembledRecord = processRecordBytes(
+            recordDeserializer.get(),
             compressor,
-            null);
+            keyBytes,
+            RawBytesChunkingAdapter.INSTANCE.get(
+                inMemoryStorageEngine,
+                pubSubTopicPartition.getPartitionNumber(),
+                ByteBuffer.wrap(keyBytes),
+                false,
+                null,
+                null,
+                null,
+                readerSchemaId,
+                RawBytesStoreDeserializerCache.getInstance(),
+                compressor,
+                null),
+            pubSubTopicPartition,
+            readerSchemaId);
+
+        // assembledRecord = chunkingAdapter.get(
+        // inMemoryStorageEngine,
+        // pubSubTopicPartition.getPartitionNumber(),
+        // ByteBuffer.wrap(keyBytes),
+        // false,
+        // null,
+        // null,
+        // null,
+        // readerSchemaId,
+        // deserializerCache,
+        // compressor, null);
       } catch (Exception ex) {
         // We might get an exception if we haven't persisted all the chunks for a given key. This
         // can actually happen if the client seeks to the middle of a chunked record either by
@@ -613,7 +633,13 @@ public class VeniceChangelogConsumerImpl<K, V> implements VeniceChangelogConsume
     } else {
       // this is a fully specified record, no need to buffer and assemble it, just decompress and deserialize it
       try {
-        assembledRecord = recordDeserializer.get().deserialize(compressor.decompress(valueBytes));
+        assembledRecord = processRecordBytes(
+            recordDeserializer.get(),
+            compressor,
+            keyBytes,
+            valueBytes,
+            pubSubTopicPartition,
+            readerSchemaId);
       } catch (Exception e) {
         throw new RuntimeException(e);
       }
@@ -624,6 +650,21 @@ public class VeniceChangelogConsumerImpl<K, V> implements VeniceChangelogConsume
     // this is safe to do in all such contexts.
     inMemoryStorageEngine.dropPartition(pubSubTopicPartition.getPartitionNumber());
     return assembledRecord;
+  }
+
+  // This function exists for wrappers of this class to be able to do any kind of preprocessing on the raw bytes of the
+  // data consumed
+  // in the change stream so as to avoid having to do any duplicate deserialization/serialization. Wrappers which depend
+  // on solely
+  // on the data post deserialization
+  protected <T> T processRecordBytes(
+      RecordDeserializer<T> deserializer,
+      VeniceCompressor compressor,
+      byte[] key,
+      ByteBuffer value,
+      PubSubTopicPartition partition,
+      int valueSchemaId) throws IOException {
+    return deserializer.deserialize(compressor.decompress(value));
   }
 
   protected Optional<PubSubMessage<K, ChangeEvent<V>, VeniceChangeCoordinate>> convertPubSubMessageToPubSubChangeEventMessage(
@@ -699,7 +740,8 @@ public class VeniceChangelogConsumerImpl<K, V> implements VeniceChangelogConsume
                 pubSubTopicPartition,
                 message.getOffset(),
                 message.getPubSubMessageTime(),
-                payloadSize));
+                payloadSize,
+                false));
       }
 
       // Determine if the event should be filtered or not
@@ -791,7 +833,8 @@ public class VeniceChangelogConsumerImpl<K, V> implements VeniceChangelogConsume
         pubSubTopicPartition,
         offset,
         timestamp,
-        payloadSize);
+        payloadSize,
+        false);
   }
 
   private V deserializeValueFromBytes(ByteBuffer byteBuffer, int valueSchemaId) {
@@ -841,7 +884,41 @@ public class VeniceChangelogConsumerImpl<K, V> implements VeniceChangelogConsume
     pubSubConsumer.close();
   }
 
+  @VisibleForTesting
   protected void setStoreRepository(ThinClientMetaStoreBasedRepository repository) {
     this.storeRepository = repository;
+    if (changelogClientConfig.getInnerClientConfig().isSpecificClient()) {
+      // If a value class is supplied, we'll use a Specific record adapter
+      Class valueClass = changelogClientConfig.getInnerClientConfig().getSpecificValueClass();
+      this.storeDeserializerCache = new AvroStoreDeserializerCache<>(storeRepository, storeName, valueClass);
+    } else {
+      this.storeDeserializerCache = new AvroStoreDeserializerCache<>(storeRepository, storeName, true);
+    }
+  }
+
+  protected VeniceChangeCoordinate getLatestCoordinate(Integer partition) {
+    Set<PubSubTopicPartition> topicPartitionSet = pubSubConsumer.getAssignment();
+    Optional<PubSubTopicPartition> topicPartition =
+        topicPartitionSet.stream().filter(tp -> tp.getPartitionNumber() == partition).findFirst();
+    if (!topicPartition.isPresent()) {
+      throw new VeniceException(
+          "Cannot get latest coordinate position for partition " + partition + "! Consumer isn't subscribed!");
+    }
+    long offset = pubSubConsumer.endOffset(topicPartition.get()) - 1;
+    return new VeniceChangeCoordinate(
+        topicPartition.get().getPubSubTopic().getName(),
+        new ApacheKafkaOffsetPosition(offset),
+        partition);
+  }
+
+  protected PubSubTopicPartition getTopicPartition(Integer partition) {
+    Set<PubSubTopicPartition> topicPartitionSet = pubSubConsumer.getAssignment();
+    Optional<PubSubTopicPartition> topicPartition =
+        topicPartitionSet.stream().filter(tp -> tp.getPartitionNumber() == partition).findFirst();
+    if (!topicPartition.isPresent()) {
+      throw new VeniceException(
+          "Cannot get latest coordinate position for partition " + partition + "! Consumer isn't subscribed!");
+    }
+    return topicPartition.get();
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImpl.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImpl.java
@@ -143,6 +143,8 @@ public class VeniceChangelogConsumerImpl<K, V> implements VeniceChangelogConsume
     // The in memory storage engine only relies on the name of store and nothing else. We use an unversioned store name
     // here in order to reduce confusion (as this storage engine can be used across version topics).
     this.inMemoryStorageEngine = new InMemoryStorageEngine(storeName);
+    // disable noisy logs
+    this.inMemoryStorageEngine.suppressLogs(true);
     this.storeRepository = new ThinClientMetaStoreBasedRepository(
         changelogClientConfig.getInnerClientConfig(),
         VeniceProperties.empty(),

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreBufferService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreBufferService.java
@@ -643,5 +643,10 @@ public class StoreBufferService extends AbstractStoreBufferService {
     public int getPayloadSize() {
       return 0;
     }
+
+    @Override
+    public boolean isEndOfBootstrap() {
+      return false;
+    }
   }
 }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/InternalLocalBootstrappingVeniceChangelogConsumerTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/InternalLocalBootstrappingVeniceChangelogConsumerTest.java
@@ -1,0 +1,352 @@
+package com.linkedin.davinci.consumer;
+
+import static com.linkedin.venice.ConfigKeys.CLUSTER_NAME;
+import static com.linkedin.venice.ConfigKeys.KAFKA_BOOTSTRAP_SERVERS;
+import static com.linkedin.venice.ConfigKeys.ZOOKEEPER_ADDRESS;
+import static com.linkedin.venice.offsets.OffsetRecord.LOWEST_OFFSET;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyInt;
+import static org.mockito.Mockito.anyLong;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
+import com.linkedin.davinci.repository.ThinClientMetaStoreBasedRepository;
+import com.linkedin.davinci.storage.StorageMetadataService;
+import com.linkedin.davinci.storage.StorageService;
+import com.linkedin.davinci.store.AbstractStorageEngine;
+import com.linkedin.davinci.store.record.ValueRecord;
+import com.linkedin.venice.client.change.capture.protocol.RecordChangeEvent;
+import com.linkedin.venice.client.change.capture.protocol.ValueBytes;
+import com.linkedin.venice.compression.CompressionStrategy;
+import com.linkedin.venice.controllerapi.D2ControllerClient;
+import com.linkedin.venice.controllerapi.StoreResponse;
+import com.linkedin.venice.kafka.protocol.KafkaMessageEnvelope;
+import com.linkedin.venice.kafka.protocol.ProducerMetadata;
+import com.linkedin.venice.kafka.protocol.Put;
+import com.linkedin.venice.kafka.protocol.enums.MessageType;
+import com.linkedin.venice.message.KafkaKey;
+import com.linkedin.venice.meta.Store;
+import com.linkedin.venice.meta.StoreInfo;
+import com.linkedin.venice.meta.Version;
+import com.linkedin.venice.meta.VersionImpl;
+import com.linkedin.venice.offsets.OffsetRecord;
+import com.linkedin.venice.pubsub.ImmutablePubSubMessage;
+import com.linkedin.venice.pubsub.PubSubTopicPartitionImpl;
+import com.linkedin.venice.pubsub.PubSubTopicRepository;
+import com.linkedin.venice.pubsub.api.PubSubConsumerAdapter;
+import com.linkedin.venice.pubsub.api.PubSubMessage;
+import com.linkedin.venice.pubsub.api.PubSubTopic;
+import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
+import com.linkedin.venice.schema.SchemaEntry;
+import com.linkedin.venice.schema.SchemaReader;
+import com.linkedin.venice.serialization.KafkaKeySerializer;
+import com.linkedin.venice.serialization.avro.AvroProtocolDefinition;
+import com.linkedin.venice.serialization.avro.InternalAvroSpecificSerializer;
+import com.linkedin.venice.serialization.avro.KafkaValueSerializer;
+import com.linkedin.venice.serializer.FastSerializerDeserializerFactory;
+import com.linkedin.venice.serializer.RecordSerializer;
+import com.linkedin.venice.utils.Utils;
+import com.linkedin.venice.views.ChangeCaptureView;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.apache.avro.Schema;
+import org.apache.avro.util.Utf8;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+
+public class InternalLocalBootstrappingVeniceChangelogConsumerTest {
+  private static final String TEST_CLUSTER_NAME = "test_cluster";
+  private static final String TEST_ZOOKEEPER_ADDRESS = "test_zookeeper";
+  private static final String TEST_KEY_1 = "key_1";
+  private static final String TEST_KEY_2 = "key_2";
+  private static final String TEST_KEY_3 = "key_3";
+  private static final String TEST_OLD_VALUE_1 = "old_value_1";
+  private static final String TEST_NEW_VALUE_1 = "new_value_1";
+  private static final String TEST_OLD_VALUE_2 = "old_value_2";
+  private static final String TEST_NEW_VALUE_2 = "new_value_2";
+  private static final String TEST_OLD_VALUE_3 = "old_value_3";
+  private static final String TEST_NEW_VALUE_3 = "new_value_3";
+  private static final String TEST_BOOTSTRAP_FILE_SYSTEM_PATH = "/export/content/data/change-capture";
+  private static final int TEST_SCHEMA_ID = 1;
+  private String storeName;
+  private InternalLocalBootstrappingVeniceChangelogConsumer<Utf8, Utf8> bootstrappingVeniceChangelogConsumer;
+  private RecordSerializer<String> keySerializer;
+  private RecordSerializer<String> valueSerializer;
+  private PubSubConsumerAdapter pubSubConsumer;
+  private ThinClientMetaStoreBasedRepository metadataRepository;
+  private PubSubTopic changeCaptureTopic;
+  private SchemaReader schemaReader;
+  private Schema valueSchema;
+  private final PubSubTopicRepository pubSubTopicRepository = new PubSubTopicRepository();
+  private static final Map<String, ChangeEvent<String>> TEST_RECORDS = ImmutableMap.of(
+      TEST_KEY_1,
+      new ChangeEvent<>(TEST_OLD_VALUE_1, TEST_NEW_VALUE_1),
+      TEST_KEY_2,
+      new ChangeEvent<>(TEST_OLD_VALUE_2, TEST_NEW_VALUE_2),
+      TEST_KEY_3,
+      new ChangeEvent<>(TEST_OLD_VALUE_3, TEST_NEW_VALUE_3));
+
+  @BeforeMethod
+  public void setUp() {
+    storeName = Utils.getUniqueString();
+    schemaReader = mock(SchemaReader.class);
+    Schema keySchema = AvroCompatibilityHelper.parse("\"string\"");
+    doReturn(keySchema).when(schemaReader).getKeySchema();
+    valueSchema = AvroCompatibilityHelper.parse("\"string\"");
+    doReturn(valueSchema).when(schemaReader).getValueSchema(1);
+
+    keySerializer = FastSerializerDeserializerFactory.getFastAvroGenericSerializer(keySchema);
+    valueSerializer = FastSerializerDeserializerFactory.getFastAvroGenericSerializer(valueSchema);
+
+    D2ControllerClient d2ControllerClient = mock(D2ControllerClient.class);
+    StoreResponse storeResponse = mock(StoreResponse.class);
+    StoreInfo storeInfo = mock(StoreInfo.class);
+    doReturn(1).when(storeInfo).getCurrentVersion();
+    doReturn(2).when(storeInfo).getPartitionCount();
+    doReturn(storeInfo).when(storeResponse).getStore();
+    doReturn(storeResponse).when(d2ControllerClient).getStore(storeName);
+
+    pubSubConsumer = mock(PubSubConsumerAdapter.class);
+
+    PubSubTopic versionTopic = pubSubTopicRepository.getTopic(Version.composeKafkaTopic(storeName, 1));
+    changeCaptureTopic =
+        pubSubTopicRepository.getTopic(versionTopic.getName() + ChangeCaptureView.CHANGE_CAPTURE_TOPIC_SUFFIX);
+    PubSubTopicPartition topicPartition_0 = new PubSubTopicPartitionImpl(changeCaptureTopic, 0);
+    PubSubTopicPartition topicPartition_1 = new PubSubTopicPartitionImpl(changeCaptureTopic, 1);
+    Set<PubSubTopicPartition> assignments = ImmutableSet.of(topicPartition_0, topicPartition_1);
+    pubSubConsumer = mock(PubSubConsumerAdapter.class);
+    doReturn(assignments).when(pubSubConsumer).getAssignment();
+    doReturn(LOWEST_OFFSET).when(pubSubConsumer).getLatestOffset(topicPartition_0);
+    doReturn(LOWEST_OFFSET).when(pubSubConsumer).getLatestOffset(topicPartition_1);
+    doReturn(0L).when(pubSubConsumer).endOffset(topicPartition_0);
+    doReturn(0L).when(pubSubConsumer).endOffset(topicPartition_1);
+    when(pubSubConsumer.poll(anyLong())).thenReturn(new HashMap<>());
+
+    Properties consumerProperties = new Properties();
+    String localKafkaUrl = "http://www.fooAddress.linkedin.com:16337";
+    consumerProperties.put(KAFKA_BOOTSTRAP_SERVERS, localKafkaUrl);
+    consumerProperties.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, KafkaKeySerializer.class);
+    consumerProperties.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, KafkaValueSerializer.class);
+    consumerProperties.put(ConsumerConfig.RECEIVE_BUFFER_CONFIG, 1024 * 1024);
+    consumerProperties.put(CLUSTER_NAME, TEST_CLUSTER_NAME);
+    consumerProperties.put(ZOOKEEPER_ADDRESS, TEST_ZOOKEEPER_ADDRESS);
+    ChangelogClientConfig changelogClientConfig =
+        new ChangelogClientConfig<>().setD2ControllerClient(d2ControllerClient)
+            .setSchemaReader(schemaReader)
+            .setStoreName(storeName)
+            .setViewName("changeCaptureView")
+            .setBootstrapFileSystemPath(TEST_BOOTSTRAP_FILE_SYSTEM_PATH)
+            .setConsumerProperties(consumerProperties)
+            .setLocalD2ZkHosts(TEST_ZOOKEEPER_ADDRESS);
+    bootstrappingVeniceChangelogConsumer =
+        new InternalLocalBootstrappingVeniceChangelogConsumer<>(changelogClientConfig, pubSubConsumer);
+
+    metadataRepository = mock(ThinClientMetaStoreBasedRepository.class);
+    Store store = mock(Store.class);
+    Version mockVersion = new VersionImpl(storeName, 1, "foo");
+    when(store.getCurrentVersion()).thenReturn(1);
+    when(store.getCompressionStrategy()).thenReturn(CompressionStrategy.NO_OP);
+    when(metadataRepository.getStore(anyString())).thenReturn(store);
+    when(store.getVersion(Mockito.anyInt())).thenReturn(Optional.of(mockVersion));
+    when(metadataRepository.getValueSchema(storeName, TEST_SCHEMA_ID))
+        .thenReturn(new SchemaEntry(TEST_SCHEMA_ID, valueSchema));
+    bootstrappingVeniceChangelogConsumer.setStoreRepository(metadataRepository);
+  }
+
+  @Test
+  public void testStart() throws ExecutionException, InterruptedException {
+    PubSubTopic versionTopic = pubSubTopicRepository.getTopic(Version.composeKafkaTopic(storeName, 1));
+    PubSubTopic changeCaptureTopic =
+        pubSubTopicRepository.getTopic(versionTopic.getName() + ChangeCaptureView.CHANGE_CAPTURE_TOPIC_SUFFIX);
+    PubSubTopicPartition topicPartition_0 = new PubSubTopicPartitionImpl(changeCaptureTopic, 0);
+    PubSubTopicPartition topicPartition_1 = new PubSubTopicPartitionImpl(changeCaptureTopic, 1);
+    Set<PubSubTopicPartition> assignments = ImmutableSet.of(topicPartition_0, topicPartition_1);
+    doReturn(assignments).when(pubSubConsumer).getAssignment();
+    doReturn(0L).when(pubSubConsumer).getLatestOffset(topicPartition_0);
+    doReturn(0L).when(pubSubConsumer).getLatestOffset(topicPartition_1);
+    doReturn(1L).when(pubSubConsumer).endOffset(topicPartition_0);
+    doReturn(1L).when(pubSubConsumer).endOffset(topicPartition_1);
+    when(pubSubConsumer.poll(anyLong())).thenReturn(new HashMap<>());
+
+    StorageService mockStorageService = mock(StorageService.class);
+    AbstractStorageEngine mockStorageEngine = mock(AbstractStorageEngine.class);
+    when(mockStorageService.getStorageEngine(anyString())).thenReturn(mockStorageEngine);
+    StorageMetadataService mockStorageMetadataService = mock(StorageMetadataService.class);
+    when(mockStorageMetadataService.getLastOffset(anyString(), anyInt()))
+        .thenReturn(new OffsetRecord(mock(InternalAvroSpecificSerializer.class)));
+    bootstrappingVeniceChangelogConsumer.setStorageAndMetadataService(mockStorageService, mockStorageMetadataService);
+
+    when(pubSubConsumer.poll(anyLong()))
+        .thenReturn(prepareChangeCaptureRecordsToBePolled(TEST_KEY_1, changeCaptureTopic, 0))
+        .thenReturn(prepareChangeCaptureRecordsToBePolled(TEST_KEY_2, changeCaptureTopic, 1));
+
+    bootstrappingVeniceChangelogConsumer.start().get();
+
+    // verify the consumer start
+    verify(mockStorageService, times(1)).start();
+    verify(mockStorageService, times(1)).openStoreForNewPartition(any(), eq(0), any());
+    verify(mockStorageService, times(1)).openStoreForNewPartition(any(), eq(1), any());
+    verify(metadataRepository, times(1)).start();
+    verify(metadataRepository, times(1)).subscribe(storeName);
+    verify(metadataRepository, times(1)).refresh();
+    verify(pubSubConsumer, times(1)).subscribe(topicPartition_0, LOWEST_OFFSET);
+    verify(pubSubConsumer, times(1)).subscribe(topicPartition_1, LOWEST_OFFSET);
+    verify(pubSubConsumer, times(1)).subscribe(topicPartition_0, 0L);
+    verify(pubSubConsumer, times(1)).subscribe(topicPartition_1, 0L);
+    verify(pubSubConsumer, times(2)).poll(anyLong());
+
+    // Verify onRecordReceivedForStorage for partition 0
+    Collection<PubSubMessage<Utf8, ChangeEvent<Utf8>, VeniceChangeCoordinate>> resultSet = new ArrayList<>();
+    Map<PubSubTopicPartition, List<PubSubMessage<KafkaKey, KafkaMessageEnvelope, Long>>> testRecords =
+        prepareChangeCaptureRecordsToBePolled(TEST_KEY_1, changeCaptureTopic, 0);
+    PubSubMessage<KafkaKey, KafkaMessageEnvelope, Long> testRecord =
+        testRecords.values().stream().findFirst().get().get(0);
+    Map<Integer, String> expectedPartitionToKey = new HashMap<>();
+    expectedPartitionToKey.put(0, TEST_KEY_1);
+    ValueBytes valueBytes = new ValueBytes();
+    valueBytes.schemaId = TEST_SCHEMA_ID;
+    valueBytes.value = ByteBuffer.wrap(valueSerializer.serialize(TEST_NEW_VALUE_1));
+    bootstrappingVeniceChangelogConsumer.onRecordReceivedForStorage(
+        testRecord.getKey().getKey(),
+        ValueRecord.create(TEST_SCHEMA_ID, valueBytes.value.array()).serialize(),
+        0,
+        resultSet);
+
+    verifyPollResult(resultSet, expectedPartitionToKey, true);
+
+    // Verify onCompletionForStorage for partition 0
+    resultSet = new ArrayList<>();
+    InternalLocalBootstrappingVeniceChangelogConsumer.BootstrapState state =
+        new InternalLocalBootstrappingVeniceChangelogConsumer.BootstrapState();
+    AtomicBoolean completed = new AtomicBoolean(false);
+
+    bootstrappingVeniceChangelogConsumer.onCompletionForStorage(0, state, resultSet, completed);
+
+    Assert.assertEquals(resultSet.size(), 0);
+    Assert.assertTrue(completed.get());
+    Assert.assertEquals(state.bootstrapState, InternalLocalBootstrappingVeniceChangelogConsumer.PollState.CONSUMING);
+    Assert.assertEquals(bootstrappingVeniceChangelogConsumer.getBootstrapCompletedCount(), 1);
+
+    // Verify onRecordReceivedForStorage for partition 1
+    resultSet = new ArrayList<>();
+    testRecords = prepareChangeCaptureRecordsToBePolled(TEST_KEY_2, changeCaptureTopic, 1);
+    testRecord = testRecords.values().stream().findFirst().get().get(0);
+    expectedPartitionToKey = new HashMap<>();
+    expectedPartitionToKey.put(1, TEST_KEY_2);
+    valueBytes = new ValueBytes();
+    valueBytes.schemaId = TEST_SCHEMA_ID;
+    valueBytes.value = ByteBuffer.wrap(valueSerializer.serialize(TEST_NEW_VALUE_2));
+
+    bootstrappingVeniceChangelogConsumer.onRecordReceivedForStorage(
+        testRecord.getKey().getKey(),
+        ValueRecord.create(TEST_SCHEMA_ID, valueBytes.value.array()).serialize(),
+        1,
+        resultSet);
+
+    verifyPollResult(resultSet, expectedPartitionToKey, true);
+
+    // Verify onCompletionForStorage for partition 1
+    resultSet = new ArrayList<>();
+    state = new InternalLocalBootstrappingVeniceChangelogConsumer.BootstrapState();
+    completed = new AtomicBoolean(false);
+
+    bootstrappingVeniceChangelogConsumer.onCompletionForStorage(1, state, resultSet, completed);
+
+    Assert.assertEquals(resultSet.size(), 1);
+    Assert.assertTrue(completed.get());
+    Assert.assertEquals(state.bootstrapState, InternalLocalBootstrappingVeniceChangelogConsumer.PollState.CONSUMING);
+    Assert.assertEquals(bootstrappingVeniceChangelogConsumer.getBootstrapCompletedCount(), 2);
+  }
+
+  private void verifyPollResult(
+      Collection<PubSubMessage<Utf8, ChangeEvent<Utf8>, VeniceChangeCoordinate>> bootstrapResult,
+      Map<Integer, String> expectedPartitionToKey,
+      boolean isBootstrap) {
+    Assert.assertEquals(1, bootstrapResult.size());
+    PubSubMessage<Utf8, ChangeEvent<Utf8>, VeniceChangeCoordinate> record = bootstrapResult.stream().findFirst().get();
+    String expectedKey = expectedPartitionToKey.get(record.getPartition());
+    ChangeEvent<String> value = TEST_RECORDS.get(expectedKey);
+    Assert.assertNotNull(value);
+    Assert.assertEquals(expectedKey, record.getKey().toString());
+    if (isBootstrap) {
+      Assert.assertNull(record.getValue().getPreviousValue());
+    } else {
+
+      Assert.assertEquals(value.getPreviousValue(), record.getValue().getPreviousValue().toString());
+    }
+
+    Assert.assertEquals(value.getCurrentValue(), record.getValue().getCurrentValue().toString());
+  }
+
+  private Map<PubSubTopicPartition, List<PubSubMessage<KafkaKey, KafkaMessageEnvelope, Long>>> prepareChangeCaptureRecordsToBePolled(
+      String key,
+      PubSubTopic changeCaptureTopic,
+      int partition) {
+    List<PubSubMessage<KafkaKey, KafkaMessageEnvelope, Long>> pubSubMessageList = new ArrayList<>();
+    pubSubMessageList.add(constructChangeCaptureConsumerRecord(changeCaptureTopic, partition, key));
+    Map<PubSubTopicPartition, List<PubSubMessage<KafkaKey, KafkaMessageEnvelope, Long>>> pubSubMessagesMap =
+        new HashMap<>();
+    PubSubTopicPartition topicPartition = new PubSubTopicPartitionImpl(changeCaptureTopic, partition);
+    pubSubMessagesMap.put(topicPartition, pubSubMessageList);
+    return pubSubMessagesMap;
+  }
+
+  private PubSubMessage<KafkaKey, KafkaMessageEnvelope, Long> constructChangeCaptureConsumerRecord(
+      PubSubTopic changeCaptureVersionTopic,
+      int partition,
+      String key) {
+    ChangeEvent<String> value = TEST_RECORDS.get(key);
+    if (value == null) {
+      throw new IllegalArgumentException("No test value exists for key " + key);
+    }
+
+    ValueBytes oldValueBytes = new ValueBytes();
+    oldValueBytes.schemaId = TEST_SCHEMA_ID;
+    oldValueBytes.value = ByteBuffer.wrap(valueSerializer.serialize(value.getPreviousValue()));
+    ValueBytes newValueBytes = new ValueBytes();
+    newValueBytes.schemaId = TEST_SCHEMA_ID;
+    newValueBytes.value = ByteBuffer.wrap(valueSerializer.serialize(value.getCurrentValue()));
+    RecordChangeEvent recordChangeEvent = new RecordChangeEvent();
+    recordChangeEvent.currentValue = newValueBytes;
+    recordChangeEvent.previousValue = oldValueBytes;
+    recordChangeEvent.key = ByteBuffer.wrap(key.getBytes());
+    recordChangeEvent.replicationCheckpointVector = Arrays.asList(1L, 1L);
+    final RecordSerializer<RecordChangeEvent> recordChangeSerializer = FastSerializerDeserializerFactory
+        .getFastAvroGenericSerializer(AvroProtocolDefinition.RECORD_CHANGE_EVENT.getCurrentProtocolVersionSchema());
+    recordChangeSerializer.serialize(recordChangeEvent);
+    KafkaMessageEnvelope kafkaMessageEnvelope = new KafkaMessageEnvelope(
+        MessageType.PUT.getValue(),
+        new ProducerMetadata(),
+        new Put(
+            ByteBuffer.wrap(recordChangeSerializer.serialize(recordChangeEvent)),
+            TEST_SCHEMA_ID,
+            0,
+            ByteBuffer.allocate(0)),
+        null);
+    KafkaKey kafkaKey = new KafkaKey(MessageType.PUT, keySerializer.serialize(key));
+    PubSubTopicPartition pubSubTopicPartition = new PubSubTopicPartitionImpl(changeCaptureVersionTopic, partition);
+    return new ImmutablePubSubMessage<>(kafkaKey, kafkaMessageEnvelope, pubSubTopicPartition, 0, 0, 0);
+  }
+}

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/TestVeniceChangeCoordinate.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/TestVeniceChangeCoordinate.java
@@ -1,5 +1,6 @@
 package com.linkedin.davinci.consumer;
 
+import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.pubsub.adapter.kafka.ApacheKafkaOffsetPosition;
 import com.linkedin.venice.pubsub.api.PubSubPosition;
 import java.io.ByteArrayInputStream;
@@ -41,5 +42,30 @@ public class TestVeniceChangeCoordinate {
     Assert.assertEquals(restoredCoordinate.getPartition(), TEST_PARTITION);
     Assert.assertEquals(restoredCoordinate.getPosition(), position);
 
+  }
+
+  @Test
+  public void testComparePosition() {
+    VeniceChangeCoordinate veniceChangeCoordinate =
+        new VeniceChangeCoordinate(TEST_STORE_TOPIC, new ApacheKafkaOffsetPosition(TEST_OFFSET), TEST_PARTITION);
+    VeniceChangeCoordinate veniceChangeCoordinate_1 =
+        new VeniceChangeCoordinate(TEST_STORE_TOPIC, new ApacheKafkaOffsetPosition(TEST_OFFSET), TEST_PARTITION);
+    Assert.assertEquals(veniceChangeCoordinate.comparePosition(veniceChangeCoordinate_1), 0);
+
+    VeniceChangeCoordinate veniceChangeCoordinate_2 =
+        new VeniceChangeCoordinate(TEST_STORE_TOPIC, new ApacheKafkaOffsetPosition(TEST_OFFSET), TEST_PARTITION + 1);
+    Assert.assertThrows(VeniceException.class, () -> veniceChangeCoordinate.comparePosition(veniceChangeCoordinate_2));
+
+    VeniceChangeCoordinate veniceChangeCoordinate_3 =
+        new VeniceChangeCoordinate(TEST_STORE_TOPIC, new ApacheKafkaOffsetPosition(TEST_OFFSET - 1), TEST_PARTITION);
+    Assert.assertTrue(veniceChangeCoordinate.comparePosition(veniceChangeCoordinate_3) > 0);
+
+    VeniceChangeCoordinate veniceChangeCoordinate_4 =
+        new VeniceChangeCoordinate(TEST_STORE_TOPIC, new ApacheKafkaOffsetPosition(TEST_OFFSET + 1), TEST_PARTITION);
+    Assert.assertTrue(veniceChangeCoordinate.comparePosition(veniceChangeCoordinate_4) < 0);
+
+    VeniceChangeCoordinate veniceChangeCoordinate_5 =
+        new VeniceChangeCoordinate(TEST_STORE_TOPIC + "v2", new ApacheKafkaOffsetPosition(TEST_OFFSET), TEST_PARTITION);
+    Assert.assertTrue(veniceChangeCoordinate.comparePosition(veniceChangeCoordinate_5) < 0);
   }
 }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerClientFactoryTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerClientFactoryTest.java
@@ -1,5 +1,8 @@
 package com.linkedin.davinci.consumer;
 
+import static com.linkedin.venice.ConfigKeys.CLUSTER_NAME;
+import static com.linkedin.venice.ConfigKeys.KAFKA_BOOTSTRAP_SERVERS;
+import static com.linkedin.venice.ConfigKeys.ZOOKEEPER_ADDRESS;
 import static org.mockito.Mockito.*;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -37,6 +40,9 @@ public class VeniceChangelogConsumerClientFactoryTest {
   private static final String STORE_NAME = "dybbuk_store";
   private static final String VIEW_NAME = "mazzikim_view";
   private static final String TEST_CLUSTER = "golem_cluster";
+  private static final String TEST_CLUSTER_NAME = "test_cluster";
+  private static final String TEST_ZOOKEEPER_ADDRESS = "test_zookeeper";
+  private static final String TEST_BOOTSTRAP_FILE_SYSTEM_PATH = "/export/content/data/change-capture";
 
   @Test
   public void testGetChangelogConsumer() throws ExecutionException, InterruptedException, JsonProcessingException {
@@ -148,5 +154,128 @@ public class VeniceChangelogConsumerClientFactoryTest {
     Mockito.when(mockControllerClient.getStore(STORE_NAME)).thenReturn(mockStoreResponse);
     globalChangelogClientConfig.setViewName(VIEW_NAME);
     Assert.assertThrows(() -> veniceChangelogConsumerClientFactory.getChangelogConsumer(STORE_NAME));
+  }
+
+  @Test
+  public void testGetBootstrappingChangelogConsumer()
+      throws ExecutionException, InterruptedException, JsonProcessingException {
+    Properties consumerProperties = new Properties();
+    String localKafkaUrl = "http://www.fooAddress.linkedin.com:16337";
+    consumerProperties.put(KAFKA_BOOTSTRAP_SERVERS, localKafkaUrl);
+    consumerProperties.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, KafkaKeySerializer.class);
+    consumerProperties.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, KafkaValueSerializer.class);
+    consumerProperties.put(ConsumerConfig.RECEIVE_BUFFER_CONFIG, 1024 * 1024);
+    consumerProperties.put(CLUSTER_NAME, TEST_CLUSTER_NAME);
+    consumerProperties.put(ZOOKEEPER_ADDRESS, TEST_ZOOKEEPER_ADDRESS);
+
+    SchemaReader mockSchemaReader = Mockito.mock(SchemaReader.class);
+    Mockito.when(mockSchemaReader.getKeySchema()).thenReturn(TestKeyRecord.SCHEMA$);
+    PubSubConsumerAdapter mockKafkaConsumer = Mockito.mock(PubSubConsumerAdapter.class);
+
+    ChangelogClientConfig globalChangelogClientConfig =
+        new ChangelogClientConfig().setConsumerProperties(consumerProperties)
+            .setSchemaReader(mockSchemaReader)
+            .setBootstrapFileSystemPath(TEST_BOOTSTRAP_FILE_SYSTEM_PATH)
+            .setLocalD2ZkHosts(TEST_ZOOKEEPER_ADDRESS);
+    VeniceChangelogConsumerClientFactory veniceChangelogConsumerClientFactory =
+        new VeniceChangelogConsumerClientFactory(globalChangelogClientConfig, new MetricsRepository());
+    D2ControllerClient mockControllerClient = Mockito.mock(D2ControllerClient.class);
+
+    veniceChangelogConsumerClientFactory.setD2ControllerClient(mockControllerClient);
+    veniceChangelogConsumerClientFactory.setConsumer(mockKafkaConsumer);
+
+    StoreResponse mockStoreResponse = Mockito.mock(StoreResponse.class);
+    Mockito.when(mockStoreResponse.isError()).thenReturn(false);
+    StoreInfo mockStoreInfo = new StoreInfo();
+    mockStoreInfo.setPartitionCount(1);
+    mockStoreInfo.setCurrentVersion(1);
+    ViewConfig viewConfig = new ViewConfigImpl(ChangeCaptureView.class.getCanonicalName(), new HashMap<>());
+    Map<String, ViewConfig> viewConfigMap = new HashMap<>();
+    viewConfigMap.put(VIEW_NAME, viewConfig);
+    mockStoreInfo.setViewConfigs(viewConfigMap);
+    Mockito.when(mockStoreResponse.getStore()).thenReturn(mockStoreInfo);
+    Mockito.when(mockControllerClient.getStore(STORE_NAME)).thenReturn(mockStoreResponse);
+    BootstrappingVeniceChangelogConsumer consumer =
+        veniceChangelogConsumerClientFactory.getBootstrappingChangelogConsumer(STORE_NAME);
+
+    Assert.assertTrue(consumer instanceof LocalBootstrappingVeniceChangelogConsumer);
+
+    globalChangelogClientConfig.setViewName(VIEW_NAME);
+    consumer = veniceChangelogConsumerClientFactory.getBootstrappingChangelogConsumer(STORE_NAME);
+    Assert.assertTrue(consumer instanceof LocalBootstrappingVeniceChangelogConsumer);
+
+    D2ServiceDiscoveryResponse serviceDiscoveryResponse = new D2ServiceDiscoveryResponse();
+    serviceDiscoveryResponse.setCluster(TEST_CLUSTER);
+    serviceDiscoveryResponse.setD2Service("TEST_ROUTER_D2_SERVICE");
+    serviceDiscoveryResponse.setServerD2Service("TEST_SERVER_D2_SERVICE");
+    serviceDiscoveryResponse.setName(STORE_NAME);
+    String discoverClusterResponse = ObjectMapperFactory.getInstance().writeValueAsString(serviceDiscoveryResponse);
+
+    RestResponse discoverClusterRestResponse = mock(RestResponse.class);
+    doReturn(ByteString.unsafeWrap(discoverClusterResponse.getBytes(StandardCharsets.UTF_8)))
+        .when(discoverClusterRestResponse)
+        .getEntity();
+
+    // Verify branches which have a managed D2Client passed in for the controller client
+    D2Client mockD2Client = Mockito.mock(D2Client.class);
+    Future mockClusterDiscoveryFuture = Mockito.mock(Future.class);
+    Mockito.when(mockClusterDiscoveryFuture.get()).thenReturn(discoverClusterRestResponse);
+    Mockito.when(mockD2Client.restRequest(Mockito.any())).thenReturn(mockClusterDiscoveryFuture);
+
+    globalChangelogClientConfig.setD2Client(mockD2Client).setD2ControllerClient(null).setControllerRequestRetryCount(1);
+
+    VeniceChangelogConsumerClientFactory.ViewClassGetter mockViewGetter = (
+        String storeName,
+        String viewName,
+        D2ControllerClient d2ControllerClient,
+        int retries) -> ChangeCaptureView.class.getCanonicalName();
+
+    veniceChangelogConsumerClientFactory =
+        new VeniceChangelogConsumerClientFactory(globalChangelogClientConfig, new MetricsRepository());
+    veniceChangelogConsumerClientFactory.setViewClassGetter(mockViewGetter);
+    veniceChangelogConsumerClientFactory.setD2ControllerClient(mockControllerClient);
+    veniceChangelogConsumerClientFactory.setConsumer(mockKafkaConsumer);
+
+    consumer = veniceChangelogConsumerClientFactory.getBootstrappingChangelogConsumer(STORE_NAME);
+    Assert.assertTrue(consumer instanceof LocalBootstrappingVeniceChangelogConsumer);
+  }
+
+  @Test
+  public void testGetBootstrappingChangelogConsumerThrowsException() {
+    Properties consumerProperties = new Properties();
+    String localKafkaUrl = "http://www.fooAddress.linkedin.com:16337";
+    consumerProperties.put(KAFKA_BOOTSTRAP_SERVERS, localKafkaUrl);
+    consumerProperties.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, KafkaKeySerializer.class);
+    consumerProperties.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, KafkaValueSerializer.class);
+    consumerProperties.put(ConsumerConfig.RECEIVE_BUFFER_CONFIG, 1024 * 1024);
+    consumerProperties.put(CLUSTER_NAME, TEST_CLUSTER_NAME);
+    consumerProperties.put(ZOOKEEPER_ADDRESS, TEST_ZOOKEEPER_ADDRESS);
+
+    SchemaReader mockSchemaReader = Mockito.mock(SchemaReader.class);
+    Mockito.when(mockSchemaReader.getKeySchema()).thenReturn(TestKeyRecord.SCHEMA$);
+    PubSubConsumerAdapter mockKafkaConsumer = Mockito.mock(PubSubConsumerAdapter.class);
+
+    ChangelogClientConfig globalChangelogClientConfig =
+        new ChangelogClientConfig().setConsumerProperties(consumerProperties)
+            .setSchemaReader(mockSchemaReader)
+            .setBootstrapFileSystemPath(TEST_BOOTSTRAP_FILE_SYSTEM_PATH)
+            .setLocalD2ZkHosts(TEST_ZOOKEEPER_ADDRESS);
+    VeniceChangelogConsumerClientFactory veniceChangelogConsumerClientFactory =
+        new VeniceChangelogConsumerClientFactory(globalChangelogClientConfig, new MetricsRepository());
+    D2ControllerClient mockControllerClient = Mockito.mock(D2ControllerClient.class);
+
+    veniceChangelogConsumerClientFactory.setConsumer(mockKafkaConsumer);
+
+    StoreResponse mockStoreResponse = Mockito.mock(StoreResponse.class);
+    Mockito.when(mockStoreResponse.isError()).thenReturn(false);
+    StoreInfo mockStoreInfo = new StoreInfo();
+    mockStoreInfo.setPartitionCount(1);
+    mockStoreInfo.setCurrentVersion(1);
+    Map<String, ViewConfig> viewConfigMap = new HashMap<>();
+    mockStoreInfo.setViewConfigs(viewConfigMap);
+    Mockito.when(mockStoreResponse.getStore()).thenReturn(mockStoreInfo);
+    Mockito.when(mockControllerClient.getStore(STORE_NAME)).thenReturn(mockStoreResponse);
+    globalChangelogClientConfig.setViewName(VIEW_NAME);
+    Assert.assertThrows(() -> veniceChangelogConsumerClientFactory.getBootstrappingChangelogConsumer(STORE_NAME));
   }
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/ImmutablePubSubMessage.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/ImmutablePubSubMessage.java
@@ -57,4 +57,9 @@ public class ImmutablePubSubMessage<K, V> implements PubSubMessage<K, V, Long> {
   public int getPayloadSize() {
     return payloadSize;
   }
+
+  @Override
+  public boolean isEndOfBootstrap() {
+    return false;
+  }
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/PubSubMessage.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/PubSubMessage.java
@@ -7,8 +7,8 @@ public interface PubSubMessage<K, V, OFFSET> {
   K getKey();
 
   /**
-  * @return the value part of this message
-  */
+   * @return the value part of this message
+   */
   V getValue();
 
   /**
@@ -38,4 +38,9 @@ public interface PubSubMessage<K, V, OFFSET> {
   default int getPartition() {
     return getTopicPartition().getPartitionNumber();
   }
+
+  /**
+   * @return whether this message marks the end of bootstrap.
+   */
+  boolean isEndOfBootstrap();
 }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestActiveActiveIngestion.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestActiveActiveIngestion.java
@@ -30,6 +30,7 @@ import static com.linkedin.venice.utils.TestUtils.generateInput;
 import static com.linkedin.venice.utils.TestWriteUtils.getTempDataDirectory;
 
 import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
+import com.linkedin.davinci.consumer.BootstrappingVeniceChangelogConsumer;
 import com.linkedin.davinci.consumer.ChangeEvent;
 import com.linkedin.davinci.consumer.ChangelogClientConfig;
 import com.linkedin.davinci.consumer.VeniceChangeCoordinate;
@@ -171,6 +172,17 @@ public class TestActiveActiveIngestion {
     }
   }
 
+  private void pollChangeEventsFromChangeCaptureConsumer(
+      Map<String, PubSubMessage<Utf8, ChangeEvent<Utf8>, VeniceChangeCoordinate>> polledChangeEvents,
+      BootstrappingVeniceChangelogConsumer bootstrappingVeniceChangelogConsumer) {
+    Collection<PubSubMessage<Utf8, ChangeEvent<Utf8>, VeniceChangeCoordinate>> pubSubMessages =
+        bootstrappingVeniceChangelogConsumer.poll(1000);
+    for (PubSubMessage<Utf8, ChangeEvent<Utf8>, VeniceChangeCoordinate> pubSubMessage: pubSubMessages) {
+      String key = pubSubMessage.getKey() == null ? null : pubSubMessage.getKey().toString();
+      polledChangeEvents.put(key, pubSubMessage);
+    }
+  }
+
   private void pollChangeEventsFromChangeCaptureConsumer2(
       Map<String, PubSubMessage<Utf8, ChangeEvent<Utf8>, VeniceChangeCoordinate>> polledChangeEvents,
       VeniceChangelogConsumer veniceChangelogConsumer) {
@@ -178,6 +190,19 @@ public class TestActiveActiveIngestion {
         veniceChangelogConsumer.poll(1000);
     pubSubMessages.addAll(veniceChangelogConsumer.poll(1000));
     pubSubMessages.addAll(veniceChangelogConsumer.poll(1000));
+    for (PubSubMessage<Utf8, ChangeEvent<Utf8>, VeniceChangeCoordinate> pubSubMessage: pubSubMessages) {
+      String key = pubSubMessage.getKey().toString();
+      polledChangeEvents.put(key, pubSubMessage);
+    }
+  }
+
+  private void pollChangeEventsFromChangeCaptureConsumer2(
+      Map<String, PubSubMessage<Utf8, ChangeEvent<Utf8>, VeniceChangeCoordinate>> polledChangeEvents,
+      BootstrappingVeniceChangelogConsumer bootstrappingVeniceChangelogConsumer) {
+    Collection<PubSubMessage<Utf8, ChangeEvent<Utf8>, VeniceChangeCoordinate>> pubSubMessages =
+        bootstrappingVeniceChangelogConsumer.poll(1000);
+    pubSubMessages.addAll(bootstrappingVeniceChangelogConsumer.poll(1000));
+    pubSubMessages.addAll(bootstrappingVeniceChangelogConsumer.poll(1000));
     for (PubSubMessage<Utf8, ChangeEvent<Utf8>, VeniceChangeCoordinate> pubSubMessage: pubSubMessages) {
       String key = pubSubMessage.getKey().toString();
       polledChangeEvents.put(key, pubSubMessage);
@@ -964,6 +989,266 @@ public class TestActiveActiveIngestion {
       Assert.assertEquals(storeTopicsResponse.getTopics().size(), 0);
     });
 
+  }
+
+  @Test(timeOut = TEST_TIMEOUT, priority = 3)
+  public void testBootstrappingVeniceChangelogConsumer_WithoutPollAndCatchUp() throws Exception {
+    ControllerClient childControllerClient =
+        new ControllerClient(clusterName, childDatacenters.get(0).getControllerConnectString());
+    // create a active-active enabled store and run batch push job
+    // batch job contains 100 records
+    File inputDir = getTempDataDirectory();
+    Schema recordSchema = TestWriteUtils.writeSimpleAvroFileWithStringToStringSchema(inputDir);
+    String inputDirPath = "file:" + inputDir.getAbsolutePath();
+    String storeName = Utils.getUniqueString("store");
+    Properties props =
+        TestWriteUtils.defaultVPJProps(parentControllers.get(0).getControllerUrl(), inputDirPath, storeName);
+    String keySchemaStr = recordSchema.getField(DEFAULT_KEY_FIELD_PROP).schema().toString();
+    String valueSchemaStr = recordSchema.getField(DEFAULT_VALUE_FIELD_PROP).schema().toString();
+    Map<String, String> viewConfig = new HashMap<>();
+    viewConfig.put(
+        "testView",
+        "{\"viewClassName\" : \"" + TestView.class.getCanonicalName() + "\", \"viewParameters\" : {}}");
+
+    viewConfig.put(
+        "changeCaptureView",
+        "{\"viewClassName\" : \"" + ChangeCaptureView.class.getCanonicalName() + "\", \"viewParameters\" : {}}");
+    UpdateStoreQueryParams storeParms = new UpdateStoreQueryParams().setActiveActiveReplicationEnabled(true)
+        .setHybridRewindSeconds(500)
+        .setHybridOffsetLagThreshold(8)
+        .setChunkingEnabled(true)
+        .setNativeReplicationEnabled(true)
+        .setPartitionCount(3);
+    MetricsRepository metricsRepository = new MetricsRepository();
+    ControllerClient setupControllerClient =
+        createStoreForJob(clusterName, keySchemaStr, valueSchemaStr, props, storeParms);
+    storeParms.setStoreViews(viewConfig);
+    // IntegrationTestPushUtils.updateStore(clusterName, props, storeParms);
+    setupControllerClient
+        .retryableRequest(5, controllerClient1 -> setupControllerClient.updateStore(storeName, storeParms));
+    // controllerClient.updateStore(storeName, storeParms);
+    TestWriteUtils.runPushJob("Run push job", props);
+    Map<String, String> samzaConfig = getSamzaConfig(storeName);
+    VeniceSystemFactory factory = new VeniceSystemFactory();
+    // Use a unique key for DELETE with RMD validation
+    int deleteWithRmdKeyIndex = 1000;
+
+    TestMockTime testMockTime = new TestMockTime();
+    ZkServerWrapper localZkServer = multiRegionMultiClusterWrapper.getChildRegions().get(0).getZkServerWrapper();
+    PubSubBrokerWrapper localKafka = ServiceFactory.getPubSubBroker(
+        new PubSubBrokerConfigs.Builder().setZkWrapper(localZkServer)
+            .setMockTime(testMockTime)
+            .setRegionName("local-pubsub")
+            .build());
+    Properties consumerProperties = new Properties();
+    String localKafkaUrl = localKafka.getAddress();
+    consumerProperties.put(KAFKA_BOOTSTRAP_SERVERS, localKafkaUrl);
+    consumerProperties.put(CLUSTER_NAME, clusterName);
+    consumerProperties.put(ZOOKEEPER_ADDRESS, localZkServer.getAddress());
+    ChangelogClientConfig globalChangelogClientConfig = new ChangelogClientConfig().setViewName("changeCaptureView")
+        .setConsumerProperties(consumerProperties)
+        .setControllerD2ServiceName(D2_SERVICE_NAME)
+        .setD2ServiceName(VeniceRouterWrapper.CLUSTER_DISCOVERY_D2_SERVICE_NAME)
+        .setLocalD2ZkHosts(localZkServer.getAddress())
+        .setControllerRequestRetryCount(3)
+        .setBootstrapFileSystemPath(Utils.getUniqueString(inputDirPath));
+    VeniceChangelogConsumerClientFactory veniceChangelogConsumerClientFactory =
+        new VeniceChangelogConsumerClientFactory(globalChangelogClientConfig, metricsRepository);
+
+    BootstrappingVeniceChangelogConsumer<Utf8, Utf8> bootstrappingVeniceChangelogConsumer =
+        veniceChangelogConsumerClientFactory.getBootstrappingChangelogConsumer(storeName);
+    bootstrappingVeniceChangelogConsumer.start().get();
+    try (
+        VeniceSystemProducer veniceProducer = factory.getClosableProducer("venice", new MapConfig(samzaConfig), null)) {
+      veniceProducer.start();
+      // Run Samza job to send PUT and DELETE requests.
+      runSamzaStreamJob(veniceProducer, storeName, null, 10, 10, 100);
+      // Produce a DELETE record with large timestamp
+      produceRecordWithLogicalTimestamp(veniceProducer, storeName, deleteWithRmdKeyIndex, 1000, true);
+    }
+
+    try (AvroGenericStoreClient<String, Utf8> client = ClientFactory.getAndStartGenericAvroClient(
+        ClientConfig.defaultGenericClientConfig(storeName)
+            .setVeniceURL(clusterWrapper.getRandomRouterURL())
+            .setMetricsRepository(metricsRepository))) {
+      TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, true, () -> {
+        Assert.assertNull(client.get(Integer.toString(deleteWithRmdKeyIndex)).get());
+      });
+    }
+
+    Map<String, PubSubMessage<Utf8, ChangeEvent<Utf8>, VeniceChangeCoordinate>> polledChangeEvents = new HashMap<>();
+
+    // 21 changes in nearline. 10 puts, 10 deletes, and 1 record with a producer timestamp
+    TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, true, () -> {
+      pollChangeEventsFromChangeCaptureConsumer(polledChangeEvents, bootstrappingVeniceChangelogConsumer);
+      // 21 events for nearline events
+      Assert.assertEquals(polledChangeEvents.size(), 22);
+      for (int i = 100; i < 110; i++) {
+        String key = Integer.toString(i);
+        ChangeEvent<Utf8> changeEvent = polledChangeEvents.get(key).getValue();
+        Assert.assertNotNull(changeEvent);
+        if (i != 100) {
+          Assert.assertNull(changeEvent.getPreviousValue());
+        } else {
+          Assert.assertTrue(changeEvent.getPreviousValue().toString().contains(key));
+        }
+        Assert.assertEquals(changeEvent.getCurrentValue().toString(), "stream_" + i);
+      }
+      for (int i = 110; i < 120; i++) {
+        String key = Integer.toString(i);
+        ChangeEvent<Utf8> changeEvent = polledChangeEvents.get(key).getValue();
+        Assert.assertNotNull(changeEvent);
+        Assert.assertNull(changeEvent.getPreviousValue()); // schema id is negative, so we did not parse.
+        Assert.assertNull(changeEvent.getCurrentValue());
+      }
+    });
+
+    polledChangeEvents.clear();
+
+    // Since nothing is produced, so no changed events generated.
+    TestUtils.waitForNonDeterministicAssertion(5, TimeUnit.SECONDS, true, () -> {
+      pollChangeEventsFromChangeCaptureConsumer2(polledChangeEvents, bootstrappingVeniceChangelogConsumer);
+      Assert.assertEquals(polledChangeEvents.size(), 0);
+    });
+
+    // Verify total updates match up
+    TestUtils.waitForNonDeterministicAssertion(
+        5,
+        TimeUnit.SECONDS,
+        () -> Assert.assertEquals(TestView.getInstance().getRecordCountForStore(storeName), 21));
+    parentControllerClient.disableAndDeleteStore(storeName);
+    // Verify that topics and store is cleaned up
+    TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, true, () -> {
+      MultiStoreTopicsResponse storeTopicsResponse = childControllerClient.getDeletableStoreTopics();
+      Assert.assertFalse(storeTopicsResponse.isError());
+      Assert.assertEquals(storeTopicsResponse.getTopics().size(), 0);
+    });
+  }
+
+  @Test(timeOut = TEST_TIMEOUT, priority = 3)
+  public void testBootstrappingVeniceChangelogConsumer_WithPollAndCatchUp() throws Exception {
+    ControllerClient childControllerClient =
+        new ControllerClient(clusterName, childDatacenters.get(0).getControllerConnectString());
+    // create a active-active enabled store and run batch push job
+    // batch job contains 100 records
+    File inputDir = getTempDataDirectory();
+    Schema recordSchema = TestWriteUtils.writeSimpleAvroFileWithStringToStringSchema(inputDir);
+    String inputDirPath = "file:" + inputDir.getAbsolutePath();
+    String storeName = Utils.getUniqueString("store");
+    Properties props =
+        TestWriteUtils.defaultVPJProps(parentControllers.get(0).getControllerUrl(), inputDirPath, storeName);
+    String keySchemaStr = recordSchema.getField(DEFAULT_KEY_FIELD_PROP).schema().toString();
+    String valueSchemaStr = recordSchema.getField(DEFAULT_VALUE_FIELD_PROP).schema().toString();
+    Map<String, String> viewConfig = new HashMap<>();
+    viewConfig.put(
+        "testView",
+        "{\"viewClassName\" : \"" + TestView.class.getCanonicalName() + "\", \"viewParameters\" : {}}");
+
+    viewConfig.put(
+        "changeCaptureView",
+        "{\"viewClassName\" : \"" + ChangeCaptureView.class.getCanonicalName() + "\", \"viewParameters\" : {}}");
+    UpdateStoreQueryParams storeParms = new UpdateStoreQueryParams().setActiveActiveReplicationEnabled(true)
+        .setHybridRewindSeconds(500)
+        .setHybridOffsetLagThreshold(8)
+        .setChunkingEnabled(true)
+        .setNativeReplicationEnabled(true)
+        .setPartitionCount(3);
+    MetricsRepository metricsRepository = new MetricsRepository();
+    ControllerClient setupControllerClient =
+        createStoreForJob(clusterName, keySchemaStr, valueSchemaStr, props, storeParms);
+    storeParms.setStoreViews(viewConfig);
+    // IntegrationTestPushUtils.updateStore(clusterName, props, storeParms);
+    setupControllerClient
+        .retryableRequest(5, controllerClient1 -> setupControllerClient.updateStore(storeName, storeParms));
+    // controllerClient.updateStore(storeName, storeParms);
+    TestWriteUtils.runPushJob("Run push job", props);
+    Map<String, String> samzaConfig = getSamzaConfig(storeName);
+    VeniceSystemFactory factory = new VeniceSystemFactory();
+    // Use a unique key for DELETE with RMD validation
+    int deleteWithRmdKeyIndex = 1000;
+
+    TestMockTime testMockTime = new TestMockTime();
+    ZkServerWrapper localZkServer = multiRegionMultiClusterWrapper.getChildRegions().get(0).getZkServerWrapper();
+    PubSubBrokerWrapper localKafka = ServiceFactory.getPubSubBroker(
+        new PubSubBrokerConfigs.Builder().setZkWrapper(localZkServer)
+            .setMockTime(testMockTime)
+            .setRegionName("local-pubsub")
+            .build());
+    Properties consumerProperties = new Properties();
+    String localKafkaUrl = localKafka.getAddress();
+    consumerProperties.put(KAFKA_BOOTSTRAP_SERVERS, localKafkaUrl);
+    consumerProperties.put(CLUSTER_NAME, clusterName);
+    consumerProperties.put(ZOOKEEPER_ADDRESS, localZkServer.getAddress());
+    ChangelogClientConfig globalChangelogClientConfig = new ChangelogClientConfig().setViewName("changeCaptureView")
+        .setConsumerProperties(consumerProperties)
+        .setControllerD2ServiceName(D2_SERVICE_NAME)
+        .setD2ServiceName(VeniceRouterWrapper.CLUSTER_DISCOVERY_D2_SERVICE_NAME)
+        .setLocalD2ZkHosts(localZkServer.getAddress())
+        .setControllerRequestRetryCount(3)
+        .setBootstrapFileSystemPath(Utils.getUniqueString(inputDirPath));
+    VeniceChangelogConsumerClientFactory veniceChangelogConsumerClientFactory =
+        new VeniceChangelogConsumerClientFactory(globalChangelogClientConfig, metricsRepository);
+
+    BootstrappingVeniceChangelogConsumer<Utf8, Utf8> bootstrappingVeniceChangelogConsumer =
+        veniceChangelogConsumerClientFactory.getBootstrappingChangelogConsumer(storeName);
+    try (
+        VeniceSystemProducer veniceProducer = factory.getClosableProducer("venice", new MapConfig(samzaConfig), null)) {
+      veniceProducer.start();
+      // Run Samza job to send PUT and DELETE requests.
+      runSamzaStreamJob(veniceProducer, storeName, null, 10, 10, 100);
+      // Produce a DELETE record with large timestamp
+      produceRecordWithLogicalTimestamp(veniceProducer, storeName, deleteWithRmdKeyIndex, 1000, true);
+    }
+
+    try (AvroGenericStoreClient<String, Utf8> client = ClientFactory.getAndStartGenericAvroClient(
+        ClientConfig.defaultGenericClientConfig(storeName)
+            .setVeniceURL(clusterWrapper.getRandomRouterURL())
+            .setMetricsRepository(metricsRepository))) {
+      TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, true, () -> {
+        Assert.assertNull(client.get(Integer.toString(deleteWithRmdKeyIndex)).get());
+      });
+    }
+
+    bootstrappingVeniceChangelogConsumer.start().get();
+    Map<String, PubSubMessage<Utf8, ChangeEvent<Utf8>, VeniceChangeCoordinate>> polledChangeEvents = new HashMap<>();
+
+    // 21 changes in nearline. 10 puts, 10 deletes and 1 delete with timestamp will be ignored and 1 end of bootstrap
+    TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, true, () -> {
+      pollChangeEventsFromChangeCaptureConsumer(polledChangeEvents, bootstrappingVeniceChangelogConsumer);
+      Assert.assertEquals(polledChangeEvents.size(), 11);
+
+      for (int i = 100; i < 110; i++) {
+        String key = Integer.toString(i);
+        ChangeEvent<Utf8> changeEvent = polledChangeEvents.get(key).getValue();
+        Assert.assertNotNull(changeEvent);
+        Assert.assertNull(changeEvent.getPreviousValue());
+        Assert.assertEquals(changeEvent.getCurrentValue().toString(), "stream_" + i);
+      }
+
+      Assert.assertTrue(polledChangeEvents.containsKey(null));
+      Assert.assertTrue(polledChangeEvents.get(null).isEndOfBootstrap());
+    });
+
+    polledChangeEvents.clear();
+
+    // Since nothing is produced, so no changed events generated.
+    TestUtils.waitForNonDeterministicAssertion(5, TimeUnit.SECONDS, true, () -> {
+      pollChangeEventsFromChangeCaptureConsumer2(polledChangeEvents, bootstrappingVeniceChangelogConsumer);
+      Assert.assertEquals(polledChangeEvents.size(), 0);
+    });
+
+    // Verify total updates match up
+    TestUtils.waitForNonDeterministicAssertion(
+        5,
+        TimeUnit.SECONDS,
+        () -> Assert.assertEquals(TestView.getInstance().getRecordCountForStore(storeName), 21));
+    parentControllerClient.disableAndDeleteStore(storeName);
+    // Verify that topics and store is cleaned up
+    TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, true, () -> {
+      MultiStoreTopicsResponse storeTopicsResponse = childControllerClient.getDeletableStoreTopics();
+      Assert.assertFalse(storeTopicsResponse.isError());
+      Assert.assertEquals(storeTopicsResponse.getTopics().size(), 0);
+    });
   }
 
   private void runSamzaStreamJob(

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestActiveActiveIngestion.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestActiveActiveIngestion.java
@@ -1209,6 +1209,8 @@ public class TestActiveActiveIngestion {
       });
     }
 
+    // Wait for 10 seconds so bootstrap can load results from kafka
+    Utils.sleep(10000);
     bootstrappingVeniceChangelogConsumer.start().get();
     Map<String, PubSubMessage<Utf8, ChangeEvent<Utf8>, VeniceChangeCoordinate>> polledChangeEvents = new HashMap<>();
 


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Add bootstrap change capture consumer
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

This change adds the BootstrappingVeniceChangelogConsumer interface and an implementation.

### BootstrappingVeniceChangelogConsumer
This interface is meant for users where local state must be built off of the entirety of a venice data set (i.e. Non-idempotent event ingestion), rather than dealing with an event at a time. THIS IS EXPENSIVE. It's highly recommended that users use the VeniceChangelogConsumer interface as a means to consume Venice Change capture data.

BootstrappingVeniceChangelogConsumerImpl works by maintaining a local rocksdb instance to store records as they are consumed from change capture.

### A Note about davinci (and why this isn't using davinci for now)
This is like davinci, and potentially a future refactor should be davinci based, but an expeditious delivery was required, and it seemed that this would not have been a straightforward refactor. The way to think about the data that is kept locally (and how it deviates significantly for the guarantees davinci gives) is that this is a state which is meant to be snapshotted to a specific point in time as perceived by an instance consumer of change capture, and this is data which isn't tied to a specific store version across all partitions (rather, it's spread across versions as data is consumed by the instance). An excellent analogy would be to think of this as a wrapper interface to the change capture interface that a client might implement when persisting and keeping some local state.

### Version Push
The behavior of this client deviates from the VeniceChangeLogConsumer. The VeniceChangeLogConsumer when encountering a version push filters events between the two versions and tries to only play a single message for every real time update. This new client instead is trying to support a non-idempotent consumer, which means that if a version push occurs which is not a repush, data must be rebootstrapped and replayed. As a result when a new data push is detected the client will purge local data and seek to the beginning of the new push. Davinci today behaves based on signals from Venice itself when data for all local partitions should be recycled and consumed. This implementation instead relies on the user reading and handling events for moving the state.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

unit test and integration test added.

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [X] Yes. The changes are added in the description section.