### PR TITLE
[controller] Do not delete backup versions for repush

### DIFF
--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/StoreCleaner.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/StoreCleaner.java
@@ -7,7 +7,8 @@ public interface StoreCleaner {
       String clusterName,
       String storeName,
       boolean deleteBackupOnStartPush,
-      int currentVersionBeforePush);
+      int currentVersionBeforePush,
+      boolean isRepush);
 
   /**
    * This purpose of this function is to execute some topic related cleanup when push job is completed.

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestVeniceHelixAdminWithSharedEnvironment.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestVeniceHelixAdminWithSharedEnvironment.java
@@ -343,7 +343,7 @@ public class TestVeniceHelixAdminWithSharedEnvironment extends AbstractTestVenic
     // Store-level write lock is shared between VeniceHelixAdmin and AbstractPushMonitor. It's not guaranteed that the
     // new version is online and old version will be deleted during VeniceHelixAdmin#addVersion early backup deletion.
     // Explicitly run early backup deletion again to make the test deterministic.
-    veniceAdmin.retireOldStoreVersions(clusterName, storeName, true, VERSION_ID_UNSET);
+    veniceAdmin.retireOldStoreVersions(clusterName, storeName, true, VERSION_ID_UNSET, false);
     TestUtils.waitForNonDeterministicCompletion(
         30,
         TimeUnit.SECONDS,
@@ -640,7 +640,7 @@ public class TestVeniceHelixAdminWithSharedEnvironment extends AbstractTestVenic
         30,
         TimeUnit.SECONDS,
         () -> veniceAdmin.getCurrentVersion(clusterName, storeName) == 2);
-    veniceAdmin.retireOldStoreVersions(clusterName, storeName, true, VERSION_ID_UNSET);
+    veniceAdmin.retireOldStoreVersions(clusterName, storeName, true, VERSION_ID_UNSET, false);
     Assert.assertEquals(veniceAdmin.versionsForStore(clusterName, storeName).size(), 1);
 
     veniceAdmin.getHelixAdmin().enableMaintenanceMode(clusterName, false);
@@ -782,7 +782,7 @@ public class TestVeniceHelixAdminWithSharedEnvironment extends AbstractTestVenic
         30,
         TimeUnit.SECONDS,
         () -> veniceAdmin.getCurrentVersion(clusterName, storeName) == 2);
-    veniceAdmin.retireOldStoreVersions(clusterName, storeName, true, VERSION_ID_UNSET);
+    veniceAdmin.retireOldStoreVersions(clusterName, storeName, true, VERSION_ID_UNSET, false);
 
     store = veniceAdmin.getStore(clusterName, storeName);
     // Version 1 and version 2 are added to this store. Version 1 is deleted by early backup deletion
@@ -1079,9 +1079,9 @@ public class TestVeniceHelixAdminWithSharedEnvironment extends AbstractTestVenic
         TOTAL_TIMEOUT_FOR_LONG_TEST_MS,
         TimeUnit.MILLISECONDS,
         () -> veniceAdmin.getStore(clusterName, storeName).getCurrentVersion() == 3);
-    veniceAdmin.retireOldStoreVersions(clusterName, storeName, true, VERSION_ID_UNSET);
+    veniceAdmin.retireOldStoreVersions(clusterName, storeName, true, VERSION_ID_UNSET, false);
     veniceAdmin.setStoreReadability(clusterName, storeName, false);
-    veniceAdmin.retireOldStoreVersions(clusterName, storeName, false, VERSION_ID_UNSET);
+    veniceAdmin.retireOldStoreVersions(clusterName, storeName, false, VERSION_ID_UNSET, false);
     Assert.assertEquals(
         veniceAdmin.getStore(clusterName, storeName).getVersions().size(),
         1,

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -16,6 +16,7 @@ import static com.linkedin.venice.meta.HybridStoreConfigImpl.DEFAULT_HYBRID_TIME
 import static com.linkedin.venice.meta.HybridStoreConfigImpl.DEFAULT_REWIND_TIME_IN_SECONDS;
 import static com.linkedin.venice.meta.Store.NON_EXISTING_VERSION;
 import static com.linkedin.venice.meta.Version.PushType;
+import static com.linkedin.venice.meta.Version.VENICE_RE_PUSH_PUSH_ID_PREFIX;
 import static com.linkedin.venice.meta.VersionStatus.ERROR;
 import static com.linkedin.venice.meta.VersionStatus.NOT_CREATED;
 import static com.linkedin.venice.meta.VersionStatus.ONLINE;
@@ -2642,9 +2643,10 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
         }
 
         if (startIngestion) {
-          // Early delete backup version on start of a push, controlled by store config earlyDeleteBackupEnabled
+          // Early delete backup version on start of a push, except for repush.
           if (backupStrategy == BackupStrategy.DELETE_ON_NEW_PUSH_START
-              && multiClusterConfigs.getControllerConfig(clusterName).isEarlyDeleteBackUpEnabled()) {
+              && multiClusterConfigs.getControllerConfig(clusterName).isEarlyDeleteBackUpEnabled()
+              && !pushJobId.startsWith(VENICE_RE_PUSH_PUSH_ID_PREFIX)) {
             try {
               retireOldStoreVersions(clusterName, storeName, true, currentVersionBeforePush);
             } catch (Throwable t) {

--- a/services/venice-controller/src/test/java/com/linkedin/venice/pushmonitor/AbstractPushMonitorTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/pushmonitor/AbstractPushMonitorTest.java
@@ -792,7 +792,8 @@ public abstract class AbstractPushMonitorTest {
         String clusterName,
         String storeName,
         boolean deleteBackupOnStartPush,
-        int currentVersionBeforePush) {
+        int currentVersionBeforePush,
+        boolean isRepush) {
       try (AutoCloseableLock ignore = clusterLockManager.createStoreWriteLock(storeName)) {
         try {
           Thread.sleep(1000);

--- a/services/venice-controller/src/test/java/com/linkedin/venice/pushmonitor/PartitionStatusBasedPushMonitorTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/pushmonitor/PartitionStatusBasedPushMonitorTest.java
@@ -123,7 +123,8 @@ public class PartitionStatusBasedPushMonitorTest extends AbstractPushMonitorTest
     });
     getMonitor().loadAllPushes();
     verify(getMockStoreRepo(), atLeastOnce()).updateStore(store);
-    verify(getMockStoreCleaner(), atLeastOnce()).retireOldStoreVersions(anyString(), anyString(), eq(false), anyInt());
+    verify(getMockStoreCleaner(), atLeastOnce())
+        .retireOldStoreVersions(anyString(), anyString(), eq(false), anyInt(), false);
     Assert.assertEquals(getMonitor().getOfflinePushOrThrow(topic).getCurrentStatus(), ExecutionStatus.COMPLETED);
     // After offline push completed, bump up the current version of this store.
     Assert.assertEquals(store.getCurrentVersion(), 1);


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Do not delete backup versions for repush
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

At the start of a push, Venice deletes backup versions to save disk space. But for repush, since the current version is same as repush version, the backup version would be the actual backup version and deleting it could cause issues when users would want to rollback. This PR blocks deletion of backup versions for repushes. 
## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
GHCI
## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.