### PR TITLE
[all][server][dvc] Fast-avro upgrade, fix meta system store schema update issue and partition size race condition

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,7 @@ if (project.hasProperty('overrideBuildEnvironment')) {
 }
 
 def avroVersion = '1.10.2'
-def avroUtilVersion = '0.3.18'
+def avroUtilVersion = '0.3.19'
 def grpcVersion = '1.49.2'
 def kafkaGroup = 'com.linkedin.kafka'
 def kafkaVersion = '2.4.1.65'

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -50,6 +50,7 @@ import com.linkedin.venice.pubsub.api.PubSubMessage;
 import com.linkedin.venice.pubsub.api.PubSubTopic;
 import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
 import com.linkedin.venice.schema.SchemaEntry;
+import com.linkedin.venice.schema.writecompute.DerivedSchemaEntry;
 import com.linkedin.venice.serialization.AvroStoreDeserializerCache;
 import com.linkedin.venice.stats.StatsErrorCode;
 import com.linkedin.venice.storage.protocol.ChunkedValueManifest;
@@ -2808,8 +2809,9 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
     final int readerValueSchemaId;
     final int readerUpdateProtocolVersion;
     if (isIngestingSystemStore()) {
-      readerValueSchemaId = schemaRepository.getSupersetOrLatestValueSchema(storeName).getId();
-      readerUpdateProtocolVersion = schemaRepository.getLatestDerivedSchema(storeName, readerValueSchemaId).getId();
+      DerivedSchemaEntry latestDerivedSchemaEntry = schemaRepository.getLatestDerivedSchema(storeName);
+      readerValueSchemaId = latestDerivedSchemaEntry.getValueSchemaID();
+      readerUpdateProtocolVersion = latestDerivedSchemaEntry.getId();
     } else {
       SchemaEntry supersetSchemaEntry = schemaRepository.getSupersetSchema(storeName);
       if (supersetSchemaEntry == null) {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/RocksDBStoragePartition.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/RocksDBStoragePartition.java
@@ -931,7 +931,6 @@ public class RocksDBStoragePartition extends AbstractStoragePartition {
     } finally {
       readCloseRWLock.readLock().unlock();
     }
-
   }
 
   protected Options getOptions() {

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/store/rocksdb/RocksDBStoragePartitionTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/store/rocksdb/RocksDBStoragePartitionTest.java
@@ -252,6 +252,8 @@ public class RocksDBStoragePartitionTest {
     storagePartition.delete(toBeDeletedKey.getBytes());
     Assert.assertNull(storagePartition.get(toBeDeletedKey.getBytes()));
 
+    Assert.assertTrue(storagePartition.getPartitionSizeInBytes() > 0);
+
     Options storeOptions = storagePartition.getOptions();
     Assert.assertEquals(storeOptions.level0FileNumCompactionTrigger(), 40);
     storagePartition.drop();

--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/ReadOnlySchemaRepository.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/ReadOnlySchemaRepository.java
@@ -83,8 +83,8 @@ public interface ReadOnlySchemaRepository extends VeniceResource {
       DerivedSchemaEntry latestDerivedSchemaEntry = null;
       for (DerivedSchemaEntry entry: derivedSchemaEntries) {
         if (latestDerivedSchemaEntry == null || entry.getValueSchemaID() > latestDerivedSchemaEntry.getValueSchemaID()
-            || entry.getValueSchemaID() == latestDerivedSchemaEntry.getValueSchemaID()
-                && entry.getId() > latestDerivedSchemaEntry.getId()) {
+            || (entry.getValueSchemaID() == latestDerivedSchemaEntry.getValueSchemaID()
+                && entry.getId() > latestDerivedSchemaEntry.getId())) {
           latestDerivedSchemaEntry = entry;
         }
       }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/ReadOnlySchemaRepository.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/ReadOnlySchemaRepository.java
@@ -1,6 +1,7 @@
 package com.linkedin.venice.meta;
 
 import com.linkedin.venice.VeniceResource;
+import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.schema.GeneratedSchemaID;
 import com.linkedin.venice.schema.SchemaEntry;
 import com.linkedin.venice.schema.rmd.RmdSchemaEntry;
@@ -68,4 +69,29 @@ public interface ReadOnlySchemaRepository extends VeniceResource {
   RmdSchemaEntry getReplicationMetadataSchema(String storeName, int valueSchemaId, int replicationMetadataVersionId);
 
   Collection<RmdSchemaEntry> getReplicationMetadataSchemas(String storeName);
+
+  default DerivedSchemaEntry getLatestDerivedSchema(String storeName) {
+    SchemaEntry valueSchemaEntry = getSupersetOrLatestValueSchema(storeName);
+    try {
+      return getLatestDerivedSchema(storeName, valueSchemaEntry.getId());
+    } catch (Exception e) {
+      /**
+       * Can't find the derived schema for the latest value schema, so it will fall back to find out the latest
+       * value schema, which has a valid derived schema.
+       */
+      Collection<DerivedSchemaEntry> derivedSchemaEntries = getDerivedSchemas(storeName);
+      DerivedSchemaEntry latestDerivedSchemaEntry = null;
+      for (DerivedSchemaEntry entry: derivedSchemaEntries) {
+        if (latestDerivedSchemaEntry == null || entry.getValueSchemaID() > latestDerivedSchemaEntry.getValueSchemaID()
+            || entry.getValueSchemaID() == latestDerivedSchemaEntry.getValueSchemaID()
+                && entry.getId() > latestDerivedSchemaEntry.getId()) {
+          latestDerivedSchemaEntry = entry;
+        }
+      }
+      if (latestDerivedSchemaEntry == null) {
+        throw new VeniceException("Failed to find a valid derived schema for store: " + storeName);
+      }
+      return latestDerivedSchemaEntry;
+    }
+  }
 }

--- a/internal/venice-common/src/test/java/com/linkedin/venice/meta/TestReadOnlySchemaRepository.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/meta/TestReadOnlySchemaRepository.java
@@ -1,0 +1,47 @@
+package com.linkedin.venice.meta;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.linkedin.venice.exceptions.VeniceException;
+import com.linkedin.venice.schema.SchemaEntry;
+import com.linkedin.venice.schema.writecompute.DerivedSchemaEntry;
+import java.util.ArrayList;
+import java.util.List;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class TestReadOnlySchemaRepository {
+  @Test
+  public void testGetLatestDerivedSchema() {
+    String storeName = "test_store";
+    // Latest value schema has a derived schema
+    SchemaEntry latestValueSchema = new SchemaEntry(1, "\"string\"");
+    ReadOnlySchemaRepository repository1 = mock(ReadOnlySchemaRepository.class);
+    when(repository1.getSupersetOrLatestValueSchema(storeName)).thenReturn(latestValueSchema);
+    DerivedSchemaEntry derivedSchemaEntry = new DerivedSchemaEntry(1, 1, "\"string\"");
+    when(repository1.getLatestDerivedSchema(storeName, 1)).thenReturn(derivedSchemaEntry);
+    when(repository1.getLatestDerivedSchema(storeName)).thenCallRealMethod();
+
+    Assert.assertEquals(repository1.getLatestDerivedSchema(storeName), derivedSchemaEntry);
+
+    // Latest value schema doesn't have a corresponding derived schema.
+    SchemaEntry latestSupersetSchema = new SchemaEntry(10, "\"string\"");
+    ReadOnlySchemaRepository repository2 = mock(ReadOnlySchemaRepository.class);
+    when(repository2.getSupersetOrLatestValueSchema(storeName)).thenReturn(latestSupersetSchema);
+    when(repository2.getLatestDerivedSchema(storeName, 10)).thenThrow(new VeniceException("No derived schema"));
+    List<DerivedSchemaEntry> derivedSchemaEntryList = new ArrayList<>();
+    DerivedSchemaEntry latestDerivedSchema = new DerivedSchemaEntry(9, 2, "\"string\"");
+    derivedSchemaEntryList.add(new DerivedSchemaEntry(8, 1, "\"string\""));
+    derivedSchemaEntryList.add(new DerivedSchemaEntry(8, 2, "\"string\""));
+    derivedSchemaEntryList.add(latestDerivedSchema);
+    derivedSchemaEntryList.add(new DerivedSchemaEntry(9, 1, "\"string\""));
+    when(repository2.getDerivedSchemas(storeName)).thenReturn(derivedSchemaEntryList);
+
+    when(repository2.getLatestDerivedSchema(storeName)).thenCallRealMethod();
+
+    Assert.assertEquals(repository2.getLatestDerivedSchema(storeName), latestDerivedSchema);
+  }
+
+}

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestHybridQuota.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestHybridQuota.java
@@ -222,7 +222,7 @@ public class TestHybridQuota {
       // Do a VPJ push
       runVPJ(vpjProperties, 3, controllerClient);
       String topicForStoreVersion3 = Version.composeKafkaTopic(storeName, 3);
-      long storageQuotaInByte = 60000; // A small quota, easily violated.
+      long storageQuotaInByte = 20000; // A small quota, easily violated.
 
       // Need to update store with quota here.
       controllerClient.updateStore(

--- a/services/venice-server/src/main/java/com/linkedin/avro/fastserde/FastDeserializerGeneratorAccessor.java
+++ b/services/venice-server/src/main/java/com/linkedin/avro/fastserde/FastDeserializerGeneratorAccessor.java
@@ -6,5 +6,6 @@ package com.linkedin.avro.fastserde;
 public class FastDeserializerGeneratorAccessor {
   public static void setFieldsPerPopulationMethod(int limit) {
     FastDeserializerGenerator.setFieldsPerPopulationMethod(limit);
+    FastSerializerGenerator.setFieldsPerRecordSerializationMethod(limit);
   }
 }


### PR DESCRIPTION
This code change includes several fixes:
1. Bump up fast-avro lib tot pick up the recent serde optimizations.
2. Fix the meta system store schema race condition issue in Venice Server. Previously, the update schema may not be available for the latest superset schema since there is a delay between registering superset schema and its derived schema. The fix will always retrieve a latest value schema with a valid derived schema.
3. Use RocksDB API to fetch partition size to avoid the following race condition: RocksDB log compaction can delete file in the middle of measuring the directory size.
4. Let 'fast.avro.field.limit.per.method' to control fast serializer size as well.

<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Summary, imperative, start upper case, don't end with a period
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->



## How was this PR tested?
CI
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.