### PR TITLE
[WIP][fast-client] Add a flag to StoreMetadata to denote if read-computation is enabled for a store

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionService.java
@@ -1296,6 +1296,7 @@ public class KafkaStoreIngestionService extends AbstractVeniceService implements
       response.setLatestSuperSetValueSchemaId(latestSuperSetValueSchemaId);
       response.setRoutingInfo(routingInfo);
       response.setHelixGroupInfo(helixGroupInfo);
+      response.setReadComputationEnabled(store.isReadComputationEnabled());
     } catch (VeniceException e) {
       LOGGER.warn("Failed to populate request based metadata for store: {}.", storeName);
       response.setMessage("Failed to populate metadata for store: " + storeName + " due to: " + e.getMessage());

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/listener/response/MetadataResponse.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/listener/response/MetadataResponse.java
@@ -51,6 +51,10 @@ public class MetadataResponse {
     responseRecord.setHelixGroupInfo(helixGroupInfo);
   }
 
+  public void setReadComputationEnabled(boolean readComputationEnabled) {
+    responseRecord.setReadComputationEnabled(readComputationEnabled);
+  }
+
   public ByteBuf getResponseBody() {
     return Unpooled.wrappedBuffer(serializedResponse());
   }

--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/meta/RequestBasedMetadata.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/meta/RequestBasedMetadata.java
@@ -48,6 +48,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
@@ -71,6 +72,7 @@ public class RequestBasedMetadata extends AbstractStoreMetadata {
   private final AtomicInteger currentVersion = new AtomicInteger();
   private final AtomicInteger latestSuperSetValueSchemaId = new AtomicInteger();
   private final AtomicReference<SchemaData> schemas = new AtomicReference<>();
+  private final AtomicBoolean readComputationEnabled = new AtomicBoolean();
   private final Map<String, List<String>> readyToServeInstancesMap = new VeniceConcurrentHashMap<>();
   private final Map<Integer, VenicePartitioner> versionPartitionerMap = new VeniceConcurrentHashMap<>();
   private final Map<Integer, Integer> versionPartitionCountMap = new VeniceConcurrentHashMap<>();
@@ -256,6 +258,7 @@ public class RequestBasedMetadata extends AbstractStoreMetadata {
       routingStrategy.updateHelixGroupInfo(helixGroupInfo);
 
       latestSuperSetValueSchemaId.set(metadataResponse.getLatestSuperSetValueSchemaId());
+      readComputationEnabled.set(metadataResponse.getReadComputationEnabled());
       // Wait for dictionary fetch to finish if there is one
       try {
         if (dictionaryFetchFuture != null) {
@@ -455,5 +458,10 @@ public class RequestBasedMetadata extends AbstractStoreMetadata {
 
   public long getRefreshIntervalInSeconds() {
     return refreshIntervalInSeconds;
+  }
+
+  @Override
+  public boolean isReadComputationEnabled() {
+    return readComputationEnabled.get();
   }
 }

--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/meta/StoreMetadata.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/meta/StoreMetadata.java
@@ -56,6 +56,8 @@ public interface StoreMetadata extends SchemaReader {
 
   VeniceCompressor getCompressor(CompressionStrategy compressionStrategy, int version);
 
+  boolean isReadComputationEnabled();
+
   void start();
 
   default boolean isReady() {

--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/meta/VeniceClientBasedMetadata.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/meta/VeniceClientBasedMetadata.java
@@ -53,6 +53,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import org.apache.avro.Schema;
@@ -82,6 +83,7 @@ public abstract class VeniceClientBasedMetadata extends AbstractStoreMetadata {
 
   private final AtomicInteger currentVersion = new AtomicInteger();
   private final AtomicInteger latestSuperSetValueSchemaId = new AtomicInteger();
+  private final AtomicBoolean readComputationEnabled = new AtomicBoolean();
   private final AtomicReference<SchemaData> schemas = new AtomicReference<>();
   // A map of version partition string to a list of ready to serve instances.
   private final Map<String, List<String>> readyToServeInstancesMap = new VeniceConcurrentHashMap<>();
@@ -340,6 +342,7 @@ public abstract class VeniceClientBasedMetadata extends AbstractStoreMetadata {
       if (dictionaryFetchFutures.length > 0) {
         CompletableFuture.allOf(dictionaryFetchFutures).get(ZSTD_DICT_FETCH_TIMEOUT, TimeUnit.SECONDS);
       }
+      readComputationEnabled.set(storeProperties.readComputationEnabled);
       currentVersion.set(storeProperties.currentVersion);
       clusterStats.updateCurrentVersion(currentVersion.get());
       latestSuperSetValueSchemaId.set(storeProperties.latestSuperSetValueSchemaId);
@@ -418,4 +421,9 @@ public abstract class VeniceClientBasedMetadata extends AbstractStoreMetadata {
   }
 
   protected abstract StoreMetaValue getStoreMetaValue(StoreMetaKey key);
+
+  @Override
+  public boolean isReadComputationEnabled() {
+    return readComputationEnabled.get();
+  }
 }

--- a/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/meta/RequestBasedMetadataTestUtils.java
+++ b/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/meta/RequestBasedMetadataTestUtils.java
@@ -83,7 +83,8 @@ public class RequestBasedMetadataTestUtils {
         Collections.singletonMap("1", VALUE_SCHEMA),
         1,
         routeMap,
-        helixGroupMap);
+        helixGroupMap,
+        false);
 
     byte[] metadataBody = SerializerDeserializerFactory.getAvroGenericSerializer(MetadataResponseRecord.SCHEMA$)
         .serialize(metadataResponse);

--- a/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/utils/TestClientSimulator.java
+++ b/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/utils/TestClientSimulator.java
@@ -612,6 +612,11 @@ public class TestClientSimulator implements Client {
       public DerivedSchemaEntry getLatestUpdateSchema() {
         return null;
       }
+
+      @Override
+      public boolean isReadComputationEnabled() {
+        return false;
+      }
     };
 
     metadata.setRoutingStrategy(new UnitTestRoutingStrategy());

--- a/internal/venice-common/src/main/java/com/linkedin/venice/serialization/avro/AvroProtocolDefinition.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/serialization/avro/AvroProtocolDefinition.java
@@ -161,7 +161,7 @@ public enum AvroProtocolDefinition {
   /**
    * Response record for metadata fetch request.
    */
-  SERVER_METADATA_RESPONSE(1, MetadataResponseRecord.class),
+  SERVER_METADATA_RESPONSE(2, MetadataResponseRecord.class),
 
   /**
    * Value schema for change capture event.

--- a/internal/venice-common/src/main/resources/avro/MetadataResponseRecord/v2/MetadataResponseRecord.avsc
+++ b/internal/venice-common/src/main/resources/avro/MetadataResponseRecord/v2/MetadataResponseRecord.avsc
@@ -1,0 +1,127 @@
+{
+  "type": "record",
+  "name": "MetadataResponseRecord",
+  "namespace": "com.linkedin.venice.metadata.response",
+  "doc": "This record will store version properties, key & value schemas, and routing information",
+  "fields": [
+    {
+      "name": "versionMetadata",
+      "doc": "The current version number and other version properties such as the compression strategy",
+      "type": [
+        "null",
+        {
+          "name": "VersionProperties",
+          "type": "record",
+          "fields": [
+            {
+              "name": "currentVersion",
+              "doc": "Current version number",
+              "type": "int"
+            },
+            {
+              "name": "compressionStrategy",
+              "doc": "The current version's compression strategy. 0 -> NO_OP, 1 -> GZIP, 2 -> ZSTD, 3 -> ZSTD_WITH_DICT",
+              "type": {
+                "name": "CompressionStrategy",
+                "type": "int"
+              }
+            },
+            {
+              "name": "partitionCount",
+              "doc": "Partition count of the current version",
+              "type": "int"
+            },
+            {
+              "name": "partitionerClass",
+              "doc": "Partitioner class name",
+              "type": "string"
+            },
+            {
+              "name": "partitionerParams",
+              "doc": "Partitioner parameters",
+              "type": {
+                "type": "map",
+                "values": "string"
+              }
+            },
+            {
+              "name": "amplificationFactor",
+              "doc": "Partitioner amplification factor",
+              "type": "int"
+            }
+          ]
+        }
+      ],
+      "default": null
+    },
+    {
+      "name": "versions",
+      "doc": "List of all version numbers",
+      "type": {
+        "type": "array",
+        "items": "int"
+      }
+    },
+    {
+      "name": "keySchema",
+      "doc": "Key schema",
+      "type": [
+        "null",
+        {
+          "type": "map",
+          "values": "string"
+        }
+      ],
+      "default": null
+    },
+    {
+      "name": "valueSchemas",
+      "doc": "Value schemas",
+      "type": [
+        "null",
+        {
+          "type": "map",
+          "values": "string"
+        }
+      ],
+      "default": null
+    },
+    {
+      "name": "latestSuperSetValueSchemaId",
+      "doc": "Latest super set value schema ID",
+      "type": [
+        "null",
+        "int"
+      ],
+      "default": null
+    },
+    {
+      "name": "routingInfo",
+      "doc": "Routing table information, maps resource to partition ID to a list of replicas",
+      "type": [
+        "null",
+        {
+          "type": "map",
+          "values": {
+            "type": "array",
+            "items": "string"
+          }
+        }
+      ],
+      "default": null
+    },
+    {
+      "name": "helixGroupInfo",
+      "doc": "Helix group information, maps replicas to their respective groups",
+      "type": [
+        "null",
+        {
+          "type": "map",
+          "values": "int"
+        }
+      ],
+      "default": null
+    },
+    {"name": "readComputationEnabled", "type": "boolean", "default": false, "doc": "Whether read-path computation is enabled for this store."}
+  ]
+}


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Add a flag to StoreMetadata to denote if read-computation is enabled for a store
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
This commit enables `StoreMetadata` used by fast-client to offer an API to denote if read computation is enabled for a store or not.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
GH CI

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.