### PR TITLE
[client] Reset user token in httpclient5

### DIFF
--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/httpclient5/HttpClient5Utils.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/httpclient5/HttpClient5Utils.java
@@ -128,6 +128,7 @@ public class HttpClient5Utils {
                 RequestConfig.custom()
                     .setResponseTimeout(Timeout.ofMilliseconds(requestTimeOutInMilliseconds))
                     .setConnectionRequestTimeout(CONNECT_TIMEOUT_IN_MILLISECONDS)
+                    .setDefaultKeepAlive(1, TimeUnit.HOURS)
                     .build())
             .setUserTokenHandler((route, context) -> null)
             .build();

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/httpclient5/HttpClient5Utils.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/httpclient5/HttpClient5Utils.java
@@ -8,6 +8,7 @@ import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient;
 import org.apache.hc.client5.http.impl.async.HttpAsyncClients;
 import org.apache.hc.client5.http.impl.nio.PoolingAsyncClientConnectionManagerBuilder;
 import org.apache.hc.client5.http.ssl.ClientTlsStrategyBuilder;
+import org.apache.hc.core5.http.impl.DefaultConnectionReuseStrategy;
 import org.apache.hc.core5.http.nio.ssl.TlsStrategy;
 import org.apache.hc.core5.http.ssl.TLS;
 import org.apache.hc.core5.http2.HttpVersionPolicy;
@@ -111,6 +112,7 @@ public class HttpClient5Utils {
         return HttpAsyncClients.custom()
             .setVersionPolicy(HttpVersionPolicy.FORCE_HTTP_1)
             .setIOReactorConfig(ioReactorConfig)
+            .setConnectionReuseStrategy(new DefaultConnectionReuseStrategy())
             .setConnectionManager(
                 PoolingAsyncClientConnectionManagerBuilder.create()
                     .setMaxConnTotal(http1MaxConnectionsTotal)
@@ -127,6 +129,7 @@ public class HttpClient5Utils {
                     .setResponseTimeout(Timeout.ofMilliseconds(requestTimeOutInMilliseconds))
                     .setConnectionRequestTimeout(CONNECT_TIMEOUT_IN_MILLISECONDS)
                     .build())
+            .setUserTokenHandler((route, context) -> null)
             .build();
       } else {
         return HttpAsyncClients.customHttp2()


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Reset user token in httpclient5
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

When a connection lease attempt is made the state requested is null. However when the connection is put back into the pool the state is set to the X500Principal object of the SSL peer. This happens in the DefaultUserTokenHandler class. This PR overrides while creating the HttpClient class so that it will reuse the connections.

Before using httpclient5 using SSL.

client->router delay ~300ms from local mac to ltx1 due to SSL/TLS handshake while creating conn on every requests.

After this change

client->router delay ~100ms from local mac to ltx1.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
testing using venice-thin-client.

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.