### PR TITLE
[admin-tool][controller] Add new admin tool command to configure/remove particular view for store

### DIFF
--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/AdminTool.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/AdminTool.java
@@ -1033,7 +1033,7 @@ public class AdminTool {
     argSet.addAll(new HashSet<>(Arrays.asList(Command.CONFIGURE_STORE_VIEW.getRequiredArgs())));
     UpdateStoreQueryParams params = new UpdateStoreQueryParams();
     if (cmd.hasOption(Arg.REMOVE_VIEW.toString())) {
-      params.setDisableStoreView(true);
+      params.setDisableStoreView();
     } else {
       // If configuring a view, view class name is required.
       params.setViewClassName(getRequiredArgument(cmd, Arg.VIEW_CLASS));

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/AdminTool.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/AdminTool.java
@@ -1032,6 +1032,7 @@ public class AdminTool {
     Set<Arg> argSet = new HashSet<>(Arrays.asList(Command.CONFIGURE_STORE_VIEW.getOptionalArgs()));
     argSet.addAll(new HashSet<>(Arrays.asList(Command.CONFIGURE_STORE_VIEW.getRequiredArgs())));
     UpdateStoreQueryParams params = new UpdateStoreQueryParams();
+    params.setViewName(getRequiredArgument(cmd, Arg.VIEW_NAME));
     if (cmd.hasOption(Arg.REMOVE_VIEW.toString())) {
       params.setDisableStoreView();
     } else {

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/AdminTool.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/AdminTool.java
@@ -542,6 +542,9 @@ public class AdminTool {
         case DUMP_INGESTION_STATE:
           dumpIngestionState(cmd);
           break;
+        case CONFIGURE_STORE_VIEW:
+          configureStoreView(cmd);
+          break;
         default:
           StringJoiner availableCommands = new StringJoiner(", ");
           for (Command c: Command.values()) {
@@ -1013,7 +1016,6 @@ public class AdminTool {
 
   private static void updateStore(CommandLine cmd) {
     UpdateStoreQueryParams params = getUpdateStoreQueryParams(cmd);
-    params.setStoreViews(new HashMap<>());
     String storeName = getRequiredArgument(cmd, Arg.STORE, Command.UPDATE_STORE);
     ControllerResponse response = controllerClient.updateStore(storeName, params);
     printSuccess(response);
@@ -1024,6 +1026,20 @@ public class AdminTool {
 
     ControllerResponse response = controllerClient.updateClusterConfig(params);
     printSuccess(response);
+  }
+
+  static UpdateStoreQueryParams getConfigureStoreViewQueryParams(CommandLine cmd) {
+    Set<Arg> argSet = new HashSet<>(Arrays.asList(Command.CONFIGURE_STORE_VIEW.getOptionalArgs()));
+    argSet.addAll(new HashSet<>(Arrays.asList(Command.CONFIGURE_STORE_VIEW.getRequiredArgs())));
+    UpdateStoreQueryParams params = new UpdateStoreQueryParams();
+    if (cmd.hasOption(Arg.REMOVE_VIEW.toString())) {
+      params.setDisableStoreView(true);
+    } else {
+      // If configuring a view, view class name is required.
+      params.setViewClassName(getRequiredArgument(cmd, Arg.VIEW_CLASS));
+    }
+    stringMapParam(cmd, Arg.VIEW_PARAMS, p -> params.setViewClassParams(p), argSet);
+    return params;
   }
 
   static UpdateStoreQueryParams getUpdateStoreQueryParams(CommandLine cmd) {
@@ -2879,6 +2895,13 @@ public class AdminTool {
     } finally {
       Utils.closeQuietlyWithErrorLogged(transportClient);
     }
+  }
+
+  private static void configureStoreView(CommandLine cmd) {
+    UpdateStoreQueryParams params = getConfigureStoreViewQueryParams(cmd);
+    String storeName = getRequiredArgument(cmd, Arg.STORE, Command.CONFIGURE_STORE_VIEW);
+    ControllerResponse response = controllerClient.updateStore(storeName, params);
+    printObject(response);
   }
 
   static void dumpIngestionState(TransportClient transportClient, String storeName, String version, String partition)

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/Arg.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/Arg.java
@@ -217,7 +217,10 @@ public enum Arg {
   STORE_VIEW_CONFIGS(
       "storage-view-configs", "svc", true,
       "Config that describes views to be added for a store.  Input is a json map.  Example: {\"ExampleView\": {\"viewClassName\": \"com.linkedin.venice.views.ChangeCaptureView\",\"params\": {}}}"
-  ),
+  ), VIEW_NAME("view-name", "vn", true, "Name of a store view"),
+  VIEW_CLASS("view-class", "vc", true, "Name of a store view class"),
+  VIEW_PARAMS("view-params", "vp", true, "Additional parameter map of a store view class"),
+  REMOVE_VIEW("remove-view", "rv", false, "Optional config to specify to disable certain store view"),
   PARTITION_DETAIL_ENABLED(
       "partition-detail-enabled", "pde", true, "A flag to indicate whether to retrieve partition details"
   ),

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/Command.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/Command.java
@@ -81,6 +81,7 @@ import static com.linkedin.venice.Arg.READ_QUOTA;
 import static com.linkedin.venice.Arg.RECOVERY_COMMAND;
 import static com.linkedin.venice.Arg.REGIONS_FILTER;
 import static com.linkedin.venice.Arg.REGULAR_VERSION_ETL_ENABLED;
+import static com.linkedin.venice.Arg.REMOVE_VIEW;
 import static com.linkedin.venice.Arg.REPLICATE_ALL_CONFIGS;
 import static com.linkedin.venice.Arg.REPLICATION_FACTOR;
 import static com.linkedin.venice.Arg.RETRY;
@@ -107,6 +108,9 @@ import static com.linkedin.venice.Arg.VALUE_SCHEMA_ID;
 import static com.linkedin.venice.Arg.VENICE_CLIENT_SSL_CONFIG_FILE;
 import static com.linkedin.venice.Arg.VENICE_ZOOKEEPER_URL;
 import static com.linkedin.venice.Arg.VERSION;
+import static com.linkedin.venice.Arg.VIEW_CLASS;
+import static com.linkedin.venice.Arg.VIEW_NAME;
+import static com.linkedin.venice.Arg.VIEW_PARAMS;
 import static com.linkedin.venice.Arg.VOLDEMORT_STORE;
 import static com.linkedin.venice.Arg.VSON_STORE;
 import static com.linkedin.venice.Arg.WRITEABILITY;
@@ -474,6 +478,10 @@ public enum Command {
       "dump-ingestion-state",
       "Dump the real-time ingestion state for a certain store version in a certain storage node",
       new Arg[] { SERVER_URL, STORE, VERSION }, new Arg[] { PARTITION }
+  ),
+  CONFIGURE_STORE_VIEW(
+      "configure-store-view", "Configure store view of a certain store", new Arg[] { URL, CLUSTER, STORE, VIEW_NAME },
+      new Arg[] { VIEW_CLASS, VIEW_PARAMS, REMOVE_VIEW }
   );
 
   private final String commandName;

--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerApiConstants.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerApiConstants.java
@@ -89,6 +89,10 @@ public class ControllerApiConstants {
   public static final String INCLUDE_SYSTEM_STORES = "include_system_stores";
 
   public static final String STORE_VIEW = "store_view";
+  public static final String STORE_VIEW_NAME = "store_view_name";
+  public static final String STORE_VIEW_CLASS = "store_view_class";
+  public static final String STORE_VIEW_PARAMS = "store_view_params";
+  public static final String DISABLE_STORE_VIEW = "disable_store_view";
 
   public static final String NATIVE_REPLICATION_ENABLED = "native_replication_enabled";
   public static final String PUSH_STREAM_SOURCE_ADDRESS = "push_stream_source_address";

--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/UpdateStoreQueryParams.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/UpdateStoreQueryParams.java
@@ -15,6 +15,7 @@ import static com.linkedin.venice.controllerapi.ControllerApiConstants.COMPRESSI
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.DATA_REPLICATION_POLICY;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.DISABLE_DAVINCI_PUSH_STATUS_STORE;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.DISABLE_META_STORE;
+import static com.linkedin.venice.controllerapi.ControllerApiConstants.DISABLE_STORE_VIEW;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.ENABLE_READS;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.ENABLE_WRITES;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.ETLED_PROXY_USER_ACCOUNT;
@@ -49,6 +50,9 @@ import static com.linkedin.venice.controllerapi.ControllerApiConstants.STORAGE_N
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.STORAGE_QUOTA_IN_BYTE;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.STORE_MIGRATION;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.STORE_VIEW;
+import static com.linkedin.venice.controllerapi.ControllerApiConstants.STORE_VIEW_CLASS;
+import static com.linkedin.venice.controllerapi.ControllerApiConstants.STORE_VIEW_NAME;
+import static com.linkedin.venice.controllerapi.ControllerApiConstants.STORE_VIEW_PARAMS;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.TIME_LAG_TO_GO_ONLINE;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.UPDATED_CONFIGS_LIST;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.VERSION;
@@ -616,6 +620,38 @@ public class UpdateStoreQueryParams extends QueryParams {
 
   public Optional<Long> getMinCompactionLagSeconds() {
     return getLong(MIN_COMPACTION_LAG_SECONDS);
+  }
+
+  public Optional<String> getViewName() {
+    return getString(STORE_VIEW_NAME);
+  }
+
+  public UpdateStoreQueryParams setViewName(String viewName) {
+    return (UpdateStoreQueryParams) add(STORE_VIEW_NAME, viewName);
+  }
+
+  public Optional<String> getViewClassName() {
+    return getString(STORE_VIEW_CLASS);
+  }
+
+  public UpdateStoreQueryParams setViewClassName(String viewClassName) {
+    return (UpdateStoreQueryParams) add(STORE_VIEW_CLASS, viewClassName);
+  }
+
+  public Optional<Map<String, String>> getViewClassParams() {
+    return getStringMap(STORE_VIEW_PARAMS);
+  }
+
+  public UpdateStoreQueryParams setViewClassParams(Map<String, String> partitionerParams) {
+    return (UpdateStoreQueryParams) putStringMap(STORE_VIEW_PARAMS, partitionerParams);
+  }
+
+  public Optional<Boolean> getDisableStoreView() {
+    return getBoolean(DISABLE_STORE_VIEW);
+  }
+
+  public UpdateStoreQueryParams setDisableStoreView(boolean disableView) {
+    return (UpdateStoreQueryParams) add(DISABLE_STORE_VIEW, disableView);
   }
 
   // ***************** above this line are getters and setters *****************

--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/UpdateStoreQueryParams.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/UpdateStoreQueryParams.java
@@ -650,8 +650,8 @@ public class UpdateStoreQueryParams extends QueryParams {
     return getBoolean(DISABLE_STORE_VIEW);
   }
 
-  public UpdateStoreQueryParams setDisableStoreView(boolean disableView) {
-    return (UpdateStoreQueryParams) add(DISABLE_STORE_VIEW, disableView);
+  public UpdateStoreQueryParams setDisableStoreView() {
+    return (UpdateStoreQueryParams) add(DISABLE_STORE_VIEW, true);
   }
 
   // ***************** above this line are getters and setters *****************

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/StoreViewUtils.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/StoreViewUtils.java
@@ -20,8 +20,8 @@ public class StoreViewUtils {
   private static final VeniceJsonSerializer<ViewConfig> viewConfigVeniceJsonSerializer =
       new VeniceJsonSerializer<>(ViewConfig.class);
 
-  static Map<String, StoreViewConfigRecord> convertStringMapViewToStoreViewConfigRecord(Map<String, String> stringMap)
-      throws VeniceException {
+  static Map<String, StoreViewConfigRecord> convertStringMapViewToStoreViewConfigRecordMap(
+      Map<String, String> stringMap) throws VeniceException {
     Map<String, StoreViewConfigRecord> mergedViewConfigRecords = new HashMap<>();
     if (!stringMap.isEmpty()) {
       for (Map.Entry<String, String> stringViewConfig: stringMap.entrySet()) {
@@ -41,40 +41,41 @@ public class StoreViewUtils {
     return mergedViewConfigRecords;
   }
 
-  static Map<String, StoreViewConfig> convertStringMapViewToStoreViewConfig(Map<String, String> stringMap) {
+  static Map<String, StoreViewConfig> convertStringMapViewToStoreViewConfigMap(Map<String, String> stringMap) {
     Map<String, StoreViewConfig> mergedViewConfigRecords = new HashMap<>();
     if (!stringMap.isEmpty()) {
       for (Map.Entry<String, String> stringViewConfig: stringMap.entrySet()) {
+        StoreViewConfig newViewConfig;
         try {
           ViewConfig viewConfig =
               viewConfigVeniceJsonSerializer.deserialize(stringViewConfig.getValue().getBytes(), "");
-          StoreViewConfig newViewConfig = new StoreViewConfig(
+          newViewConfig = new StoreViewConfig(
               viewConfig.getViewClassName(),
               CollectionUtils.getStringKeyCharSequenceValueMapFromStringMap(viewConfig.getViewParameters()));
-          mergedViewConfigRecords.put(stringViewConfig.getKey(), newViewConfig);
         } catch (IOException e) {
           LOGGER.error("Failed to serialize provided view config: {}", stringViewConfig.getValue());
           throw new VeniceException("Failed to serialize provided view config:" + stringViewConfig.getValue(), e);
         }
+        mergedViewConfigRecords.put(stringViewConfig.getKey(), newViewConfig);
       }
     }
     return mergedViewConfigRecords;
   }
 
-  static Map<String, ViewConfig> convertStringMapViewToViewConfig(Map<String, String> stringMap) {
-    return convertStringMapViewToStoreViewConfig(stringMap).entrySet()
+  static Map<String, ViewConfig> convertStringMapViewToViewConfigMap(Map<String, String> stringMap) {
+    return convertStringMapViewToStoreViewConfigMap(stringMap).entrySet()
         .stream()
         .collect(Collectors.toMap(Map.Entry::getKey, e -> new ViewConfigImpl(e.getValue())));
   }
 
-  static Map<String, StoreViewConfigRecord> convertViewConfigToStoreViewConfig(Map<String, ViewConfig> viewConfigMap) {
+  static Map<String, StoreViewConfigRecord> convertViewConfigMapToStoreViewRecordMap(
+      Map<String, ViewConfig> viewConfigMap) {
     return viewConfigMap.entrySet()
         .stream()
-        .collect(
-            Collectors.toMap(
-                Map.Entry::getKey,
-                e -> new StoreViewConfigRecord(
-                    e.getValue().getViewClassName(),
-                    e.getValue().dataModel().getViewParameters())));
+        .collect(Collectors.toMap(Map.Entry::getKey, e -> convertViewConfigToStoreViewConfigRecord(e.getValue())));
+  }
+
+  static StoreViewConfigRecord convertViewConfigToStoreViewConfigRecord(ViewConfig viewConfig) {
+    return new StoreViewConfigRecord(viewConfig.getViewClassName(), viewConfig.dataModel().getViewParameters());
   }
 }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -4014,7 +4014,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
 
   private void addStoreViews(String clusterName, String storeName, Map<String, String> viewConfigMap) {
     storeMetadataUpdate(clusterName, storeName, store -> {
-      store.setViewConfigs(StoreViewUtils.convertStringMapViewToViewConfig(viewConfigMap));
+      store.setViewConfigs(StoreViewUtils.convertStringMapViewToViewConfigMap(viewConfigMap));
       return store;
     });
   }
@@ -4670,8 +4670,39 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
       oldViewConfigMap = new HashMap<>();
     }
     Map<String, StoreViewConfigRecord> mergedConfigs =
-        StoreViewUtils.convertViewConfigToStoreViewConfig(oldViewConfigMap);
-    mergedConfigs.putAll(StoreViewUtils.convertStringMapViewToStoreViewConfigRecord(viewParameters));
+        StoreViewUtils.convertViewConfigMapToStoreViewRecordMap(oldViewConfigMap);
+    mergedConfigs.putAll(StoreViewUtils.convertStringMapViewToStoreViewConfigRecordMap(viewParameters));
+    return mergedConfigs;
+  }
+
+  static Map<String, StoreViewConfigRecord> addNewViewConfigsIntoOldConfigs(
+      Store oldStore,
+      String viewClass,
+      ViewConfig viewConfig) throws VeniceException {
+    // Add new view config into the existing config map. The new configs will override existing ones which share the
+    // same key.
+    Map<String, ViewConfig> oldViewConfigMap = oldStore.getViewConfigs();
+    if (oldViewConfigMap == null) {
+      oldViewConfigMap = new HashMap<>();
+    }
+    Map<String, StoreViewConfigRecord> mergedConfigs =
+        StoreViewUtils.convertViewConfigMapToStoreViewRecordMap(oldViewConfigMap);
+
+    StoreViewConfigRecord newStoreViewConfigRecord =
+        StoreViewUtils.convertViewConfigToStoreViewConfigRecord(viewConfig);
+    mergedConfigs.put(viewClass, newStoreViewConfigRecord);
+    return mergedConfigs;
+  }
+
+  static Map<String, StoreViewConfigRecord> removeViewConfigFromStoreViewConfigMap(Store oldStore, String viewClass)
+      throws VeniceException {
+    Map<String, ViewConfig> oldViewConfigMap = oldStore.getViewConfigs();
+    if (oldViewConfigMap == null) {
+      oldViewConfigMap = new HashMap<>();
+    }
+    Map<String, StoreViewConfigRecord> mergedConfigs =
+        StoreViewUtils.convertViewConfigMapToStoreViewRecordMap(oldViewConfigMap);
+    mergedConfigs.remove(viewClass);
     return mergedConfigs;
   }
 

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
@@ -2212,11 +2212,12 @@ public class VeniceParentHelixAdmin implements Admin {
         throw new VeniceException("Cannot update a store view and overwrite store view setup together!");
       }
       if (viewName.isPresent()) {
-        if (!viewClassName.isPresent()) {
-          throw new VeniceException("View class name is required when configuring a view.");
-        }
         Map<String, StoreViewConfigRecord> updatedViewSettings;
         if (!removeView.isPresent()) {
+          if (!viewClassName.isPresent()) {
+            throw new VeniceException("View class name is required when configuring a view.");
+          }
+          // If View parameter is not provided, use emtpy map instead. It does not inherit from existing config.
           ViewConfig viewConfig = new ViewConfigImpl(viewClassName.get(), viewParams.orElse(Collections.emptyMap()));
           validateStoreViewConfig(currStore, viewConfig);
           updatedViewSettings = VeniceHelixAdmin.addNewViewConfigsIntoOldConfigs(currStore, viewName.get(), viewConfig);
@@ -2230,9 +2231,7 @@ public class VeniceParentHelixAdmin implements Admin {
       if (storeViewConfig.isPresent()) {
         // Validate and overwrite store views if they're getting set
         validateStoreViewConfigs(storeViewConfig.get(), currStore);
-        Map<String, StoreViewConfigRecord> updatedViewSettings =
-            StoreViewUtils.convertStringMapViewToStoreViewConfigRecordMap(storeViewConfig.get());
-        setStore.views = updatedViewSettings;
+        setStore.views = StoreViewUtils.convertStringMapViewToStoreViewConfigRecordMap(storeViewConfig.get());
         updatedConfigsList.add(STORE_VIEW);
       }
 

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceParentHelixAdmin.java
@@ -64,6 +64,7 @@ import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.StoreInfo;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.meta.VersionImpl;
+import com.linkedin.venice.meta.ViewConfigImpl;
 import com.linkedin.venice.meta.ZKStore;
 import com.linkedin.venice.offsets.OffsetRecord;
 import com.linkedin.venice.partitioner.InvalidKeySchemaPartitioner;
@@ -84,11 +85,13 @@ import com.linkedin.venice.utils.TestUtils;
 import com.linkedin.venice.utils.Time;
 import com.linkedin.venice.utils.Utils;
 import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
+import com.linkedin.venice.views.ChangeCaptureView;
 import com.linkedin.venice.writer.VeniceWriter;
 import java.nio.ByteBuffer;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -1837,9 +1840,122 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
     int schemaId = schemaCaptor.getValue();
     AdminOperation adminMessage = adminOperationSerializer.deserialize(ByteBuffer.wrap(valueBytes), schemaId);
     UpdateStore updateStore = (UpdateStore) adminMessage.payloadUnion;
-    Assert.assertTrue(
-        "dc1".equals(updateStore.nativeReplicationSourceFabric.toString()),
+    Assert.assertEquals(
+        updateStore.nativeReplicationSourceFabric.toString(),
+        "dc1",
         "Native replication source fabric does not match after updating the store!");
+  }
+
+  @Test
+  public void testSetStoreViewConfig() {
+    String storeName = Utils.getUniqueString("testUpdateStore");
+    Store store = TestUtils.createTestStore(storeName, "test", System.currentTimeMillis());
+    store.setActiveActiveReplicationEnabled(true);
+    store.setChunkingEnabled(true);
+    doReturn(store).when(internalAdmin).getStore(clusterName, storeName);
+
+    doReturn(CompletableFuture.completedFuture(new SimplePubSubProduceResultImpl(topicName, partitionId, 1, -1)))
+        .when(veniceWriter)
+        .put(any(), any(), anyInt());
+
+    when(zkClient.readData(zkMetadataNodePath, null)).thenReturn(null)
+        .thenReturn(AdminTopicMetadataAccessor.generateMetadataMap(1, -1, 1));
+
+    parentAdmin.initStorageCluster(clusterName);
+    Map<String, String> viewConfig = new HashMap<>();
+    viewConfig.put(
+        "changeCapture",
+        "{\"viewClassName\" : \"" + ChangeCaptureView.class.getCanonicalName() + "\", \"viewParameters\" : {}}");
+    parentAdmin.updateStore(clusterName, storeName, new UpdateStoreQueryParams().setStoreViews(viewConfig));
+
+    ArgumentCaptor<byte[]> keyCaptor = ArgumentCaptor.forClass(byte[].class);
+    ArgumentCaptor<byte[]> valueCaptor = ArgumentCaptor.forClass(byte[].class);
+    ArgumentCaptor<Integer> schemaCaptor = ArgumentCaptor.forClass(Integer.class);
+
+    verify(veniceWriter, times(1)).put(keyCaptor.capture(), valueCaptor.capture(), schemaCaptor.capture());
+    byte[] valueBytes = valueCaptor.getValue();
+    int schemaId = schemaCaptor.getValue();
+    AdminOperation adminMessage = adminOperationSerializer.deserialize(ByteBuffer.wrap(valueBytes), schemaId);
+    UpdateStore updateStore = (UpdateStore) adminMessage.payloadUnion;
+    Assert.assertTrue(updateStore.getViews().containsKey("changeCapture"));
+  }
+
+  @Test
+  public void testInsertStoreViewConfig() {
+    String storeName = Utils.getUniqueString("testUpdateStore");
+    Store store = TestUtils.createTestStore(storeName, "test", System.currentTimeMillis());
+    store.setActiveActiveReplicationEnabled(true);
+    store.setChunkingEnabled(true);
+    store.setViewConfigs(
+        Collections.singletonMap("testView", new ViewConfigImpl("testViewClassDummyName", Collections.emptyMap())));
+    doReturn(store).when(internalAdmin).getStore(clusterName, storeName);
+
+    doReturn(CompletableFuture.completedFuture(new SimplePubSubProduceResultImpl(topicName, partitionId, 1, -1)))
+        .when(veniceWriter)
+        .put(any(), any(), anyInt());
+
+    when(zkClient.readData(zkMetadataNodePath, null)).thenReturn(null)
+        .thenReturn(AdminTopicMetadataAccessor.generateMetadataMap(1, -1, 1));
+
+    parentAdmin.initStorageCluster(clusterName);
+    parentAdmin.updateStore(
+        clusterName,
+        storeName,
+        new UpdateStoreQueryParams().setViewName("changeCapture")
+            .setViewClassName(ChangeCaptureView.class.getCanonicalName()));
+
+    ArgumentCaptor<byte[]> keyCaptor = ArgumentCaptor.forClass(byte[].class);
+    ArgumentCaptor<byte[]> valueCaptor = ArgumentCaptor.forClass(byte[].class);
+    ArgumentCaptor<Integer> schemaCaptor = ArgumentCaptor.forClass(Integer.class);
+
+    verify(veniceWriter, times(1)).put(keyCaptor.capture(), valueCaptor.capture(), schemaCaptor.capture());
+    byte[] valueBytes = valueCaptor.getValue();
+    int schemaId = schemaCaptor.getValue();
+    AdminOperation adminMessage = adminOperationSerializer.deserialize(ByteBuffer.wrap(valueBytes), schemaId);
+    UpdateStore updateStore = (UpdateStore) adminMessage.payloadUnion;
+    Assert.assertEquals(updateStore.getViews().size(), 2);
+    Assert.assertTrue(updateStore.getViews().containsKey("changeCapture"));
+    Assert.assertEquals(
+        updateStore.getViews().get("changeCapture").viewClassName.toString(),
+        ChangeCaptureView.class.getCanonicalName());
+    Assert.assertTrue(updateStore.getViews().get("changeCapture").viewParameters.isEmpty());
+  }
+
+  @Test
+  public void testRemoveStoreViewConfig() {
+    String storeName = Utils.getUniqueString("testUpdateStore");
+    Store store = TestUtils.createTestStore(storeName, "test", System.currentTimeMillis());
+    store.setActiveActiveReplicationEnabled(true);
+    store.setChunkingEnabled(true);
+    store.setViewConfigs(
+        Collections.singletonMap(
+            "changeCapture",
+            new ViewConfigImpl(ChangeCaptureView.class.getCanonicalName(), Collections.emptyMap())));
+    doReturn(store).when(internalAdmin).getStore(clusterName, storeName);
+
+    doReturn(CompletableFuture.completedFuture(new SimplePubSubProduceResultImpl(topicName, partitionId, 1, -1)))
+        .when(veniceWriter)
+        .put(any(), any(), anyInt());
+
+    when(zkClient.readData(zkMetadataNodePath, null)).thenReturn(null)
+        .thenReturn(AdminTopicMetadataAccessor.generateMetadataMap(1, -1, 1));
+
+    parentAdmin.initStorageCluster(clusterName);
+    parentAdmin.updateStore(
+        clusterName,
+        storeName,
+        new UpdateStoreQueryParams().setViewName("changeCapture").setDisableStoreView(true));
+
+    ArgumentCaptor<byte[]> keyCaptor = ArgumentCaptor.forClass(byte[].class);
+    ArgumentCaptor<byte[]> valueCaptor = ArgumentCaptor.forClass(byte[].class);
+    ArgumentCaptor<Integer> schemaCaptor = ArgumentCaptor.forClass(Integer.class);
+
+    verify(veniceWriter, times(1)).put(keyCaptor.capture(), valueCaptor.capture(), schemaCaptor.capture());
+    byte[] valueBytes = valueCaptor.getValue();
+    int schemaId = schemaCaptor.getValue();
+    AdminOperation adminMessage = adminOperationSerializer.deserialize(ByteBuffer.wrap(valueBytes), schemaId);
+    UpdateStore updateStore = (UpdateStore) adminMessage.payloadUnion;
+    Assert.assertEquals(updateStore.getViews().size(), 0);
   }
 
   @Test

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceParentHelixAdmin.java
@@ -1944,7 +1944,7 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
     parentAdmin.updateStore(
         clusterName,
         storeName,
-        new UpdateStoreQueryParams().setViewName("changeCapture").setDisableStoreView(true));
+        new UpdateStoreQueryParams().setViewName("changeCapture").setDisableStoreView());
 
     ArgumentCaptor<byte[]> keyCaptor = ArgumentCaptor.forClass(byte[].class);
     ArgumentCaptor<byte[]> valueCaptor = ArgumentCaptor.forClass(byte[].class);


### PR DESCRIPTION
## [admin-tool][controller] Add new admin tool command to configure/remove particular view for store

This PR introduces a new AdminTool command to configure (add/update/remove) a view of a store.
The command name is **--configure-store-view**. It takes the following parameter:

1. **--view-name**: Required at all time. Value: Name of the view to act on.
2. **--remove-view**: If present, this action is to remove an existing view from the store config. No Value.
3. **--view-class**: Required when it is not removing a view. Value: View class name of the view.
4. **--view-params**: Optional. Value: Additional parameters for the view in the format of string to string map. If not specified, meaning it is going to use **empty map**, instead of inheriting existing value.

The actual logic is inside update store logic. The reason to separate it into a new command is to make it more user friendly to specify the intention, instead of putting everything into a Json map. 
For the existing setView() API in UpdateStoreQueryParams, this PR **changes the behavior** from merging the input into existing view config to **completely overwrite the old config**, as it is overlapping with the functionality with the new command to some extent.
 
## How was this PR tested?
Added unit tests and integration tests.
## Does this PR introduce any user-facing changes?
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.