### PR TITLE
[server] Fixed SN read quota not initialized properly for pre-existing resources

### DIFF
--- a/internal/venice-common/src/main/java/com/linkedin/venice/helix/HelixCustomizedViewOfflinePushRepository.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/helix/HelixCustomizedViewOfflinePushRepository.java
@@ -220,6 +220,13 @@ public class HelixCustomizedViewOfflinePushRepository extends HelixBaseRoutingRe
       for (String kafkaTopic: updates.getDeletedResource()) {
         listenerManager.trigger(kafkaTopic, listener -> listener.onRoutingDataDeleted(kafkaTopic));
       }
+      for (String kafkaTopic: updates.getNewResources()) {
+        PartitionAssignment partitionAssignment;
+        try (AutoCloseableLock ignored = AutoCloseableLock.of(resourceAssignmentRWLock.readLock())) {
+          partitionAssignment = resourceAssignment.getPartitionAssignment(kafkaTopic);
+        }
+        listenerManager.trigger(kafkaTopic, listener -> listener.onCustomizedViewAdded(partitionAssignment));
+      }
     }
   }
 

--- a/internal/venice-common/src/main/java/com/linkedin/venice/helix/ResourceAssignment.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/helix/ResourceAssignment.java
@@ -58,9 +58,17 @@ public class ResourceAssignment {
   public ResourceAssignmentChanges updateResourceAssignment(ResourceAssignment newAssignment) {
     Set<String> deletedResources = compareAndGetDeletedResources(newAssignment);
     Set<String> updatedResources = compareAndGetUpdatedResources(newAssignment);
+    Set<String> newResources = compareAndGetNewResources(newAssignment);
 
     this.resourceToAssignmentsMap = newAssignment.resourceToAssignmentsMap;
-    return new ResourceAssignmentChanges(deletedResources, updatedResources);
+    return new ResourceAssignmentChanges(deletedResources, updatedResources, newResources);
+  }
+
+  Set<String> compareAndGetNewResources(ResourceAssignment newAssignment) {
+    return newAssignment.getAssignedResources()
+        .stream()
+        .filter(newResource -> !containsResource(newResource))
+        .collect(Collectors.toSet());
   }
 
   Set<String> compareAndGetDeletedResources(ResourceAssignment newAssignment) {
@@ -82,10 +90,12 @@ public class ResourceAssignment {
   public static class ResourceAssignmentChanges {
     Set<String> deletedResources;
     Set<String> updatedResources;
+    Set<String> newResources;
 
-    ResourceAssignmentChanges(Set<String> deletedResources, Set<String> updatedResources) {
+    ResourceAssignmentChanges(Set<String> deletedResources, Set<String> updatedResources, Set<String> newResources) {
       this.deletedResources = deletedResources;
       this.updatedResources = updatedResources;
+      this.newResources = newResources;
     }
 
     public Set<String> getDeletedResource() {
@@ -94,6 +104,10 @@ public class ResourceAssignment {
 
     public Set<String> getUpdatedResources() {
       return updatedResources;
+    }
+
+    public Set<String> getNewResources() {
+      return newResources;
     }
   }
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/RoutingDataRepository.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/RoutingDataRepository.java
@@ -70,6 +70,8 @@ public interface RoutingDataRepository extends VeniceResource, OnlineInstanceFin
 
     void onCustomizedViewChange(PartitionAssignment partitionAssignment);
 
+    void onCustomizedViewAdded(PartitionAssignment partitionAssignment);
+
     void onPartitionStatusChange(String topic, ReadOnlyPartitionStatus partitionStatus);
 
     void onRoutingDataDeleted(String kafkaTopic);

--- a/internal/venice-common/src/test/java/com/linkedin/venice/listener/TestListenerManager.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/listener/TestListenerManager.java
@@ -67,6 +67,11 @@ public class TestListenerManager {
     }
 
     @Override
+    public void onCustomizedViewAdded(PartitionAssignment partitionAssignment) {
+      isExecuted = true;
+    }
+
+    @Override
     public void onPartitionStatusChange(String topic, ReadOnlyPartitionStatus partitionStatus) {
       isExecuted = true;
     }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/helix/TestHelixCustomizedViewOfflinePushRepository.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/helix/TestHelixCustomizedViewOfflinePushRepository.java
@@ -354,7 +354,7 @@ public class TestHelixCustomizedViewOfflinePushRepository {
 
   @Test
   public void testListeners() throws Exception {
-    final boolean[] isNoticed = { false, false, false, false };
+    final boolean[] isNoticed = { false, false, false, false, false };
     RoutingDataRepository.RoutingDataChangedListener listener = new RoutingDataRepository.RoutingDataChangedListener() {
       @Override
       public void onExternalViewChange(PartitionAssignment partitionAssignment) {
@@ -364,6 +364,11 @@ public class TestHelixCustomizedViewOfflinePushRepository {
       @Override
       public void onCustomizedViewChange(PartitionAssignment partitionAssignment) {
         isNoticed[1] = true;
+      }
+
+      @Override
+      public void onCustomizedViewAdded(PartitionAssignment partitionAssignment) {
+        isNoticed[4] = true;
       }
 
       @Override
@@ -384,6 +389,7 @@ public class TestHelixCustomizedViewOfflinePushRepository {
     Assert.assertFalse(isNoticed[1], "Should not get notification after un-registering.");
     Assert.assertFalse(isNoticed[2], "Should not get notification after un-registering.");
     Assert.assertFalse(isNoticed[3], "Should not get notification after un-registering.");
+    Assert.assertFalse(isNoticed[4], "Should not get notification after un-registering.");
 
     offlinePushOnlyRepository.subscribeRoutingDataChange(resourceName, listener);
 

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/helix/TestHelixExternalViewRepository.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/helix/TestHelixExternalViewRepository.java
@@ -207,6 +207,11 @@ public class TestHelixExternalViewRepository {
       }
 
       @Override
+      public void onCustomizedViewAdded(PartitionAssignment partitionAssignment) {
+        isNoticed[0] = true;
+      }
+
+      @Override
       public void onPartitionStatusChange(String topic, ReadOnlyPartitionStatus partitionStatus) {
         isNoticed[0] = true;
       }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/stats/AggPartitionHealthStats.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/stats/AggPartitionHealthStats.java
@@ -84,6 +84,11 @@ public class AggPartitionHealthStats extends AbstractVeniceAggStats<PartitionHea
   }
 
   @Override
+  public void onCustomizedViewAdded(PartitionAssignment partitionAssignment) {
+    // Ignore this event
+  }
+
+  @Override
   public void onPartitionStatusChange(String topic, ReadOnlyPartitionStatus partitionStatus) {
     // Ignore this event
   }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/AbstractPushMonitor.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/AbstractPushMonitor.java
@@ -816,6 +816,11 @@ public abstract class AbstractPushMonitor
   }
 
   @Override
+  public void onCustomizedViewAdded(PartitionAssignment partitionAssignment) {
+    // Ignore this event
+  }
+
+  @Override
   public void onRoutingDataDeleted(String kafkaTopic) {
     // Beside the external view, we also care about the ideal state here. If the resource was deleted from the
     // externalview by mistake,

--- a/services/venice-server/src/test/java/com/linkedin/venice/listener/ReadQuotaEnforcementHandlerCalculationTest.java
+++ b/services/venice-server/src/test/java/com/linkedin/venice/listener/ReadQuotaEnforcementHandlerCalculationTest.java
@@ -2,13 +2,10 @@ package com.linkedin.venice.listener;
 
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
-import com.linkedin.venice.helix.HelixCustomizedViewOfflinePushRepository;
 import com.linkedin.venice.meta.Instance;
 import com.linkedin.venice.meta.Partition;
 import com.linkedin.venice.meta.PartitionAssignment;
-import com.linkedin.venice.routerapi.ReplicaState;
 import com.linkedin.venice.utils.Utils;
 import java.util.ArrayList;
 import java.util.List;
@@ -23,58 +20,55 @@ public class ReadQuotaEnforcementHandlerCalculationTest {
   public void onePartitionFourReplicas() {
     // one partition, four replicas, one replica on this host. Portion should be 1/4
     PartitionAssignment pa = getPartitionAssignment("topic", nodeId, new int[] { 4 }, new int[] { 1 });
-    HelixCustomizedViewOfflinePushRepository cvRepository = getCVRepository("topic", nodeId, pa, new int[] { 4 });
-    double portion = ReadQuotaEnforcementHandler.getNodeResponsibilityForQuota(cvRepository, pa, nodeId);
+    double portion = ReadQuotaEnforcementHandler.getNodeResponsibilityForQuota(pa, nodeId);
     Assert.assertEquals(portion, 0.25d);
   }
 
   @Test
   void twoPartitionsTwoAndThreeReplicas() {
-    PartitionAssignment pa = getPartitionAssignment("topic", nodeId, new int[] { 3, 3 }, new int[] { 1, 1 });
-    HelixCustomizedViewOfflinePushRepository cvRepository = getCVRepository("topic", nodeId, pa, new int[] { 2, 3 });
-    double portion = ReadQuotaEnforcementHandler.getNodeResponsibilityForQuota(cvRepository, pa, nodeId);
+    PartitionAssignment pa = getPartitionAssignment("topic", nodeId, new int[] { 2, 3 }, new int[] { 1, 1 });
+    double portion = ReadQuotaEnforcementHandler.getNodeResponsibilityForQuota(pa, nodeId);
     Assert.assertEquals(portion, 0.41666666666666663d); // (1/2 + 1/3)/2
   }
 
   @Test
   void twoPartitionsTwoAndThreeReplicasOnlyTwoReplicasLocally() {
-    PartitionAssignment pa = getPartitionAssignment("topic", nodeId, new int[] { 3, 3, 3 }, new int[] { 1, 1, 0 });
-    HelixCustomizedViewOfflinePushRepository cvRepository = getCVRepository("topic", nodeId, pa, new int[] { 2, 3, 3 });
-    double portion = ReadQuotaEnforcementHandler.getNodeResponsibilityForQuota(cvRepository, pa, nodeId);
+    PartitionAssignment pa = getPartitionAssignment("topic", nodeId, new int[] { 2, 3, 3 }, new int[] { 1, 1, 0 });
+    double portion = ReadQuotaEnforcementHandler.getNodeResponsibilityForQuota(pa, nodeId);
     Assert.assertEquals(portion, 0.27777777777777773d); // (1/2 + 1/3 + 0/3)/3
   }
 
   /**
    * If a store as 3 partitions,
-   *   partitions 0 and 1 have 3 online replicas,
+   *   partitions 0 and 1 have 3 ready to serve replicas,
    *   partition 2 has 2 online replicas,
    *   and this node has a replica for partitions 0 and 2, then
-   *   onlineReplicaCounts = [3,3,2]
+   *   readyToServeReplicaCounts = [3,3,2]
    *   replicasOnThisNode = [1,0,1]
    *
    * @param topic
    * @param thisNodeId
-   * @param onlineReplicaCounts
+   * @param readyToServeReplicaCounts
    * @param replicasOnThisNode
    * @return
    */
   public static PartitionAssignment getPartitionAssignment(
       String topic,
       String thisNodeId,
-      int[] onlineReplicaCounts,
+      int[] readyToServeReplicaCounts,
       int[] replicasOnThisNode) {
-    if (onlineReplicaCounts.length != replicasOnThisNode.length) {
+    if (readyToServeReplicaCounts.length != replicasOnThisNode.length) {
       throw new RuntimeException(
-          "onlineReplicaCounts and replicasOnThisNode must have the same number of elements.  This is the number of partitions");
+          "readyToServeReplicaCounts and replicasOnThisNode must have the same number of elements.  This is the number of partitions");
     }
     PartitionAssignment partitionAssignment = mock(PartitionAssignment.class);
     doReturn(topic).when(partitionAssignment).getTopic();
     Instance thisInstance = new Instance(thisNodeId, "dummyHost", 1234);
     List<Partition> partitions = new ArrayList<>();
-    for (int p = 0; p < onlineReplicaCounts.length; p++) {
+    for (int p = 0; p < readyToServeReplicaCounts.length; p++) {
       Partition partition = mock(Partition.class);
       List<Instance> instances = new ArrayList<>();
-      for (int i = 0; i < onlineReplicaCounts[p]; i++) {
+      for (int i = 0; i < readyToServeReplicaCounts[p]; i++) {
         if (i == 0 && replicasOnThisNode[p] > 0) {
           instances.add(thisInstance);
         } else {
@@ -82,42 +76,10 @@ public class ReadQuotaEnforcementHandlerCalculationTest {
         }
       }
       doReturn(p).when(partition).getId();
-      doReturn(instances).when(partition).getWorkingInstances();
+      doReturn(instances).when(partition).getReadyToServeInstances();
       partitions.add(partition);
     }
     doReturn(partitions).when(partitionAssignment).getAllPartitions();
     return partitionAssignment;
-  }
-
-  public static HelixCustomizedViewOfflinePushRepository getCVRepository(
-      String topic,
-      String thisNodeId,
-      PartitionAssignment partitionAssignment,
-      int[] readyToServeReplicas) {
-    HelixCustomizedViewOfflinePushRepository customizedViewOfflinePushRepository =
-        mock(HelixCustomizedViewOfflinePushRepository.class);
-    for (Partition p: partitionAssignment.getAllPartitions()) {
-      List<ReplicaState> replicaStates = new ArrayList<>();
-      int readyToServeReplicaCount = readyToServeReplicas[p.getId()];
-      for (Instance i: p.getWorkingInstances()) {
-        ReplicaState thisReplicaState = mock(ReplicaState.class);
-        doReturn(i.getNodeId()).when(thisReplicaState).getParticipantId();
-        if (thisNodeId.equals(i.getNodeId())) {
-          doReturn(true).when(thisReplicaState).isReadyToServe();
-          replicaStates.add(thisReplicaState);
-          readyToServeReplicaCount -= 1;
-          continue;
-        }
-        if (readyToServeReplicaCount > 0) {
-          doReturn(true).when(thisReplicaState).isReadyToServe();
-          readyToServeReplicaCount -= 1;
-        } else {
-          doReturn(false).when(thisReplicaState).isReadyToServe();
-        }
-        replicaStates.add(thisReplicaState);
-      }
-      when(customizedViewOfflinePushRepository.getReplicaStates(topic, p.getId())).thenReturn(replicaStates);
-    }
-    return customizedViewOfflinePushRepository;
   }
 }

--- a/services/venice-server/src/test/java/com/linkedin/venice/listener/ReadQuotaEnforcementHandlerListenerTest.java
+++ b/services/venice-server/src/test/java/com/linkedin/venice/listener/ReadQuotaEnforcementHandlerListenerTest.java
@@ -5,7 +5,6 @@ import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
@@ -23,7 +22,6 @@ import com.linkedin.venice.meta.StoreDataChangedListener;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.meta.VersionImpl;
 import com.linkedin.venice.meta.ZKStore;
-import com.linkedin.venice.routerapi.ReplicaState;
 import com.linkedin.venice.stats.AggServerQuotaUsageStats;
 import io.tehuti.metrics.MetricsRepository;
 import java.util.ArrayList;
@@ -204,13 +202,7 @@ public class ReadQuotaEnforcementHandlerListenerTest {
     Partition partition = mock(Partition.class);
     doReturn(0).when(partition).getId();
     doReturn(Collections.singletonList(partition)).when(partitionAssignment).getAllPartitions();
-
-    List<ReplicaState> replicaStates = new ArrayList<>();
-    ReplicaState thisReplicaState = mock(ReplicaState.class);
-    doReturn(thisInstance.getNodeId()).when(thisReplicaState).getParticipantId();
-    doReturn(true).when(thisReplicaState).isReadyToServe();
-    replicaStates.add(thisReplicaState);
-    when(customizedViewRepository.getReplicaStates(topic, partition.getId())).thenReturn(replicaStates);
+    doReturn(Collections.singletonList(thisInstance)).when(partition).getReadyToServeInstances();
 
     return partitionAssignment;
   }

--- a/services/venice-server/src/test/java/com/linkedin/venice/listener/ReadQuotaEnforcementHandlerTest.java
+++ b/services/venice-server/src/test/java/com/linkedin/venice/listener/ReadQuotaEnforcementHandlerTest.java
@@ -20,7 +20,6 @@ import static org.testng.Assert.assertTrue;
 
 import com.linkedin.venice.grpc.GrpcErrorCodes;
 import com.linkedin.venice.helix.HelixCustomizedViewOfflinePushRepository;
-import com.linkedin.venice.helix.ResourceAssignment;
 import com.linkedin.venice.listener.grpc.GrpcRequestContext;
 import com.linkedin.venice.listener.grpc.handlers.GrpcReadQuotaEnforcementHandler;
 import com.linkedin.venice.listener.grpc.handlers.VeniceServerGrpcHandler;
@@ -44,9 +43,7 @@ import java.time.Clock;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.mockito.ArgumentCaptor;
@@ -127,19 +124,10 @@ public class ReadQuotaEnforcementHandlerTest {
     doReturn(topic).when(version).kafkaTopicName();
     Store store = setUpStoreMock(storeName, 1, Collections.singletonList(version), 100, true);
     doReturn(store).when(storeRepository).getStore(storeName);
-    ResourceAssignment resourceAssignment = mock(ResourceAssignment.class);
-    doReturn(resourceAssignment).when(customizedViewRepository).getResourceAssignment();
-    Set<String> resources = new HashSet<>(Collections.singletonList(topic));
-    doReturn(resources).when(resourceAssignment).getAssignedResources();
-    Instance instance = mock(Instance.class);
-    doReturn(thisNodeId).when(instance).getNodeId();
-    Partition partition = setUpPartitionMock(topic, instance, true, 0);
-    PartitionAssignment pa = setUpPartitionAssignmentMock(topic, Collections.singletonList(partition));
-    doReturn(pa).when(resourceAssignment).getPartitionAssignment(topic);
+    doReturn(Collections.singletonList(store)).when(storeRepository).getAllStores();
 
     quotaEnforcer.init();
 
-    assertTrue(quotaEnforcer.listTopics().contains(topic), "resource: " + topic + " should be initialized");
     verify(storeRepository, atLeastOnce()).registerStoreDataChangedListener(any());
     verify(customizedViewRepository, atLeastOnce()).subscribeRoutingDataChange(eq(topic), any());
   }


### PR DESCRIPTION
## [server] Fixed SN read quota not initialized properly for pre-existing resources
This PR intend to address two issues:
1. During init the pre-existing resources did not get subscribed to the routing data change listener. This means the corresponding quota calculation won't be accurate if there was a rebalance before the store was changed (we used subscribe to routing data change for  existing and new resources on store change).

2. We discovered that the customized view repository does not return the complete resource list right after server is started even after the future is completed. We are working with Helix to investigate and solve this issue but in the meantime we can add a new event onCustomizedViewAdded to be notified when the CV repository receives new resources. The read quota handler will respond to the event by initializing the corresponding token bucket. This issue is not reproducible in integration test but can be reporduced consistently in PROD environment. Added a restart test to read quota to verify this.

## How was this PR tested?
Existing and new integration test. Verified the fix via frankenwar in cert cluster.

## Does this PR introduce any user-facing changes?
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.