### PR TITLE
[server] Avoid creating separate consumer services for broker alias addresses

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/AggKafkaConsumerService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/AggKafkaConsumerService.java
@@ -108,7 +108,7 @@ public class AggKafkaConsumerService extends AbstractVeniceService {
    */
   private KafkaConsumerService getKafkaConsumerService(final String kafkaURL) {
     KafkaConsumerService consumerService = kafkaServerToConsumerServiceMap.get(kafkaURL);
-    if (consumerService == null) {
+    if (consumerService == null && kafkaClusterUrlResolver != null) {
       consumerService = kafkaServerToConsumerServiceMap.get(kafkaClusterUrlResolver.apply(kafkaURL));
     }
     return consumerService;
@@ -128,10 +128,7 @@ public class AggKafkaConsumerService extends AbstractVeniceService {
     if (kafkaUrl == null || kafkaUrl.isEmpty()) {
       throw new IllegalArgumentException("Kafka URL must be set in the consumer properties config. Got: " + kafkaUrl);
     }
-    String resolvedKafkaUrl = kafkaClusterUrlResolver.apply(kafkaUrl);
-    if (resolvedKafkaUrl == null || resolvedKafkaUrl.isEmpty()) {
-      resolvedKafkaUrl = kafkaUrl;
-    }
+    String resolvedKafkaUrl = kafkaClusterUrlResolver == null ? kafkaUrl : kafkaClusterUrlResolver.apply(kafkaUrl);
     final KafkaConsumerService alreadyCreatedConsumerService = getKafkaConsumerService(resolvedKafkaUrl);
     if (alreadyCreatedConsumerService != null) {
       LOGGER.warn("KafkaConsumerService has already been created for Kafka cluster with URL: {}", resolvedKafkaUrl);

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/AggKafkaConsumerService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/AggKafkaConsumerService.java
@@ -115,9 +115,12 @@ public class AggKafkaConsumerService extends AbstractVeniceService {
    * @param consumerProperties consumer properties that are used to create {@link KafkaConsumerService}
    */
   public synchronized KafkaConsumerService createKafkaConsumerService(final Properties consumerProperties) {
-    final String kafkaUrl = consumerProperties.getProperty(KAFKA_BOOTSTRAP_SERVERS);
+    String kafkaUrl = consumerProperties.getProperty(KAFKA_BOOTSTRAP_SERVERS);
     Properties properties = sslPropertiesSupplier.get(kafkaUrl).toProperties();
     consumerProperties.putAll(properties);
+    // sslPropertiesSupplier also does bootstrap address resolution, so we need to update the kafkaUrl to ensure
+    // that we are using the correct kafkaUrl
+    kafkaUrl = consumerProperties.getProperty(KAFKA_BOOTSTRAP_SERVERS);
     if (kafkaUrl == null || kafkaUrl.isEmpty()) {
       throw new IllegalArgumentException("Kafka URL must be set in the consumer properties config. Got: " + kafkaUrl);
     }


### PR DESCRIPTION
## [server] Avoid creating separate consumer services for broker alias addresses


In the current setup, we may inadvertently create a separate KafkaConsumerService for each alias address. 
This change prevents such unnecessary duplication.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
CI

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.