### PR TITLE
[server][controller] Close VeniceWriters in MetaStoreWriter concurrently and in bounded time

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
@@ -31,6 +31,8 @@ import static com.linkedin.venice.ConfigKeys.LOCAL_CONTROLLER_URL;
 import static com.linkedin.venice.ConfigKeys.LOCAL_D2_ZK_HOST;
 import static com.linkedin.venice.ConfigKeys.MAX_FUTURE_VERSION_LEADER_FOLLOWER_STATE_TRANSITION_THREAD_NUMBER;
 import static com.linkedin.venice.ConfigKeys.MAX_LEADER_FOLLOWER_STATE_TRANSITION_THREAD_NUMBER;
+import static com.linkedin.venice.ConfigKeys.META_STORE_WRITER_CLOSE_CONCURRENCY;
+import static com.linkedin.venice.ConfigKeys.META_STORE_WRITER_CLOSE_TIMEOUT_MS;
 import static com.linkedin.venice.ConfigKeys.OFFSET_LAG_DELTA_RELAX_FACTOR_FOR_FAST_ONLINE_TRANSITION_IN_RESTART;
 import static com.linkedin.venice.ConfigKeys.PARTICIPANT_MESSAGE_CONSUMPTION_DELAY_MS;
 import static com.linkedin.venice.ConfigKeys.PUB_SUB_ADMIN_ADAPTER_FACTORY_CLASS;
@@ -437,6 +439,9 @@ public class VeniceServerConfig extends VeniceClusterConfig {
 
   private final int ingestionTaskMaxIdleCount;
 
+  private final long metaStoreWriterCloseTimeoutInMS;
+  private final int metaStoreWriterCloseConcurrency;
+
   public VeniceServerConfig(VeniceProperties serverProperties) throws ConfigurationException {
     this(serverProperties, Collections.emptyMap());
   }
@@ -719,6 +724,8 @@ public class VeniceServerConfig extends VeniceClusterConfig {
     }
     routerPrincipalName = serverProperties.getString(ROUTER_PRINCIPAL_NAME, "CN=venice-router");
     ingestionTaskMaxIdleCount = serverProperties.getInt(SERVER_INGESTION_TASK_MAX_IDLE_COUNT, 10000);
+    metaStoreWriterCloseTimeoutInMS = serverProperties.getLong(META_STORE_WRITER_CLOSE_TIMEOUT_MS, 300000L);
+    metaStoreWriterCloseConcurrency = serverProperties.getInt(META_STORE_WRITER_CLOSE_CONCURRENCY, -1);
   }
 
   long extractIngestionMemoryLimit(
@@ -1259,5 +1266,13 @@ public class VeniceServerConfig extends VeniceClusterConfig {
 
   public boolean isKMERegistrationFromMessageHeaderEnabled() {
     return isKMERegistrationFromMessageHeaderEnabled;
+  }
+
+  public long getMetaStoreWriterCloseTimeoutInMS() {
+    return metaStoreWriterCloseTimeoutInMS;
+  }
+
+  public int getMetaStoreWriterCloseConcurrency() {
+    return metaStoreWriterCloseConcurrency;
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionService.java
@@ -341,7 +341,9 @@ public class KafkaStoreIngestionService extends AbstractVeniceService implements
           topicManagerRepository.getTopicManager(),
           veniceWriterFactoryForMetaStoreWriter,
           zkSharedSchemaRepository.get(),
-          pubSubTopicRepository);
+          pubSubTopicRepository,
+          serverConfig.getMetaStoreWriterCloseTimeoutInMS(),
+          serverConfig.getMetaStoreWriterCloseConcurrency());
       this.metaSystemStoreReplicaStatusNotifier = new MetaSystemStoreReplicaStatusNotifier(
           serverConfig.getClusterName(),
           metaStoreWriter,

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTaskTest.java
@@ -254,7 +254,6 @@ public class ActiveActiveStoreIngestionTaskTest {
     PubSubProducerAdapter mockedProducer = mock(PubSubProducerAdapter.class);
     CompletableFuture mockedFuture = mock(CompletableFuture.class);
     when(mockedProducer.getNumberOfPartitions(any())).thenReturn(1);
-    when(mockedProducer.getNumberOfPartitions(any(), anyInt(), any())).thenReturn(1);
     AtomicLong offset = new AtomicLong(0);
 
     ArgumentCaptor<KafkaKey> kafkaKeyArgumentCaptor = ArgumentCaptor.forClass(KafkaKey.class);

--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -1870,6 +1870,16 @@ public class ConfigKeys {
       "controller.server.incremental.push.use.push.status.store";
 
   /**
+   * A config to control the maximum time spent on closing the meta store writer.
+   */
+  public static final String META_STORE_WRITER_CLOSE_TIMEOUT_MS = "meta.store.writer.close.timeout.ms";
+
+  /**
+   * A config to control the maximum number of concurrent meta store writer close operations.
+   */
+  public static final String META_STORE_WRITER_CLOSE_CONCURRENCY = "meta.store.writer.close.concurrency";
+
+  /**
    * A config to control whether VeniceServer will optimize the database for the backup version to
    * free up memory resources occupied.
    * TODO: explore to apply this feature to DVC as well.

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/PubSubProducerAdapter.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/PubSubProducerAdapter.java
@@ -8,14 +8,8 @@ import com.linkedin.venice.pubsub.api.exceptions.PubSubOpTimeoutException;
 import com.linkedin.venice.pubsub.api.exceptions.PubSubTopicAuthorizationException;
 import com.linkedin.venice.pubsub.api.exceptions.PubSubTopicDoesNotExistException;
 import it.unimi.dsi.fastutil.objects.Object2DoubleMap;
-import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
 
 /**
@@ -26,21 +20,11 @@ import java.util.concurrent.TimeoutException;
  *  2. In order delivery (IOD): messages in the same partition should follow the order in which they were sent.
  */
 public interface PubSubProducerAdapter {
-  ExecutorService timeOutExecutor = Executors.newSingleThreadExecutor();
-
   /**
    * The support for the following two getNumberOfPartitions APIs will be removed.
    */
   @Deprecated
   int getNumberOfPartitions(String topic);
-
-  @Deprecated
-  default int getNumberOfPartitions(String topic, int timeout, TimeUnit timeUnit)
-      throws InterruptedException, ExecutionException, TimeoutException {
-    Callable<Integer> task = () -> getNumberOfPartitions(topic);
-    Future<Integer> future = timeOutExecutor.submit(task);
-    return future.get(timeout, timeUnit);
-  }
 
   /**
    * Sends a message to a PubSub topic asynchronously and returns a {@link Future} representing the result of the produce operation.

--- a/internal/venice-common/src/main/java/com/linkedin/venice/system/store/MetaStoreWriter.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/system/store/MetaStoreWriter.java
@@ -84,7 +84,9 @@ public class MetaStoreWriter implements Closeable {
       TopicManager topicManager,
       VeniceWriterFactory writerFactory,
       HelixReadOnlyZKSharedSchemaRepository schemaRepo,
-      PubSubTopicRepository pubSubTopicRepository) {
+      PubSubTopicRepository pubSubTopicRepository,
+      long closeTimeoutMs,
+      int numOfConcurrentVwCloseOps) {
     /**
      * TODO: get the write compute schema from the constructor so that this class does not use {@link WriteComputeSchemaConverter}
      */
@@ -96,8 +98,8 @@ public class MetaStoreWriter implements Closeable {
             .convertFromValueRecordSchema(
                 AvroProtocolDefinition.METADATA_SYSTEM_SCHEMA_STORE.getCurrentProtocolVersionSchema()),
         pubSubTopicRepository,
-        TimeUnit.MINUTES.toMillis(5),
-        -1);
+        closeTimeoutMs,
+        numOfConcurrentVwCloseOps);
   }
 
   MetaStoreWriter(

--- a/internal/venice-common/src/main/java/com/linkedin/venice/system/store/MetaStoreWriter.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/system/store/MetaStoreWriter.java
@@ -78,7 +78,7 @@ public class MetaStoreWriter implements Closeable {
 
   private final PubSubTopicRepository pubSubTopicRepository;
   private final long closeTimeoutMs;
-  private int numOfConcurrentVwCloseOps;
+  private final int numOfConcurrentVwCloseOps;
 
   public MetaStoreWriter(
       TopicManager topicManager,

--- a/internal/venice-common/src/main/java/com/linkedin/venice/system/store/MetaStoreWriter.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/system/store/MetaStoreWriter.java
@@ -97,7 +97,7 @@ public class MetaStoreWriter implements Closeable {
                 AvroProtocolDefinition.METADATA_SYSTEM_SCHEMA_STORE.getCurrentProtocolVersionSchema()),
         pubSubTopicRepository,
         TimeUnit.MINUTES.toMillis(5),
-        256);
+        -1);
   }
 
   MetaStoreWriter(
@@ -580,7 +580,7 @@ public class MetaStoreWriter implements Closeable {
     }
 
     LOGGER.info(
-        "Closed MetaStoreWriter in {} ms - numbOfVeniceWriters: {} - closeResults: {}",
+        "Closed MetaStoreWriter in {} ms - numbOfVeniceWriters: {} veniceWriterCloseResult: {}",
         System.currentTimeMillis() - startTime,
         writersToClose.size(),
         closeResultMap);

--- a/internal/venice-common/src/main/java/com/linkedin/venice/utils/VeniceResourceCloseResult.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/utils/VeniceResourceCloseResult.java
@@ -1,7 +1,7 @@
-package com.linkedin.venice.writer;
+package com.linkedin.venice.utils;
 
 public enum VeniceResourceCloseResult {
-  SUCCESS(0), FAILURE(1), TIMEOUT(2), ALREADY_CLOSED(3);
+  SUCCESS(0), ALREADY_CLOSED(1), FAILED(2);
 
   private final int statusCode;
 

--- a/internal/venice-common/src/main/java/com/linkedin/venice/utils/VeniceResourceCloseResult.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/utils/VeniceResourceCloseResult.java
@@ -1,7 +1,7 @@
 package com.linkedin.venice.utils;
 
 public enum VeniceResourceCloseResult {
-  SUCCESS(0), ALREADY_CLOSED(1), FAILED(2);
+  SUCCESS(0), ALREADY_CLOSED(1), FAILED(2), UNKNOWN(3);
 
   private final int statusCode;
 

--- a/internal/venice-common/src/main/java/com/linkedin/venice/writer/VeniceResourceCloseResult.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/writer/VeniceResourceCloseResult.java
@@ -1,0 +1,15 @@
+package com.linkedin.venice.writer;
+
+public enum VeniceResourceCloseResult {
+  SUCCESS(0), FAILURE(1), TIMEOUT(2), ALREADY_CLOSED(3);
+
+  private final int statusCode;
+
+  VeniceResourceCloseResult(int statusCode) {
+    this.statusCode = statusCode;
+  }
+
+  public int getStatusCode() {
+    return statusCode;
+  }
+}

--- a/internal/venice-common/src/main/java/com/linkedin/venice/writer/VeniceWriter.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/writer/VeniceWriter.java
@@ -46,6 +46,7 @@ import com.linkedin.venice.serialization.avro.ChunkedValueManifestSerializer;
 import com.linkedin.venice.storage.protocol.ChunkedKeySuffix;
 import com.linkedin.venice.storage.protocol.ChunkedValueManifest;
 import com.linkedin.venice.utils.ByteUtils;
+import com.linkedin.venice.utils.DaemonThreadFactory;
 import com.linkedin.venice.utils.ExceptionUtils;
 import com.linkedin.venice.utils.LatencyUtils;
 import com.linkedin.venice.utils.Time;
@@ -61,6 +62,8 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.BiConsumer;
@@ -81,6 +84,9 @@ import org.apache.logging.log4j.Logger;
 public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
   private static final ChunkedPayloadAndManifest EMPTY_CHUNKED_PAYLOAD_AND_MANIFEST =
       new ChunkedPayloadAndManifest(null, null);
+
+  // use for running async close and to fetch number of partitions with timeout from producer
+  private final ThreadPoolExecutor threadPoolExecutor;
 
   // log4j logger
   private final Logger logger;
@@ -238,6 +244,9 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
   private final Object[] partitionLocks;
 
   private String writerId;
+  private boolean isClosed = false;
+  private final Object closeLock = new Object();
+
   /**
    * N.B.: chunking enabled flag is mutable only if this VeniceWriter is currently used in pass-through mode and hasn't
    * been used in non pass-through mode yet; once VW starts referring to the chunking setting in non pass-through mode,
@@ -315,6 +324,16 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
     }
     this.producerGUID = GuidUtils.getGUID(props);
     this.logger = LogManager.getLogger("VeniceWriter [" + GuidUtils.getHexFromGuid(producerGUID) + "]");
+    // Create a thread pool which can have max 2 threads.
+    // Except during VW start and close we expect it to have zero threads to avoid unnecessary resource usage.
+    this.threadPoolExecutor = new ThreadPoolExecutor(
+        2,
+        2,
+        30,
+        TimeUnit.SECONDS,
+        new LinkedBlockingQueue<>(),
+        new DaemonThreadFactory("VW-" + topicName));
+    this.threadPoolExecutor.allowCoreThreadTimeOut(true); // allow core threads to timeout
 
     this.protocolSchemaHeaders = overrideProtocolSchema == null
         ? EMPTY_MSG_HEADERS
@@ -329,7 +348,9 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
       if (params.getPartitionCount() != null) {
         this.numberOfPartitions = params.getPartitionCount();
       } else {
-        this.numberOfPartitions = this.producerAdapter.getNumberOfPartitions(topicName, 30, TimeUnit.SECONDS);
+        this.numberOfPartitions =
+            CompletableFuture.supplyAsync(() -> producerAdapter.getNumberOfPartitions(topicName), threadPoolExecutor)
+                .get(30, TimeUnit.SECONDS);
       }
       if (this.numberOfPartitions <= 0) {
         throw new VeniceException("Invalid number of partitions: " + this.numberOfPartitions);
@@ -357,21 +378,66 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
    */
   @Override
   public void close(boolean gracefulClose) {
-    try {
-      // If {@link #broadcastEndOfPush(Map)} was already called, the {@link #endAllSegments(boolean)}
-      // will not do anything (it's idempotent). Segments should not be ended if there are still data missing.
-      if (gracefulClose) {
-        endAllSegments(true);
+    synchronized (closeLock) {
+      if (isClosed) {
+        return;
       }
-      // DO NOT call the {@link #PubSubProducerAdapter.close(int) version from here.}
-      // For non-shared producer mode gracefulClose will flush the producer
+      long startTime = System.currentTimeMillis();
+      logger.info("Closing VeniceWriter for topic: {}", topicName);
+      try {
+        // If {@link #broadcastEndOfPush(Map)} was already called, the {@link #endAllSegments(boolean)}
+        // will not do anything (it's idempotent). Segments should not be ended if there are still data missing.
+        if (gracefulClose) {
+          endAllSegments(true);
+        }
+        // DO NOT call the {@link #PubSubProducerAdapter.close(int) version from here.}
+        // For non-shared producer mode gracefulClose will flush the producer
 
-      producerAdapter.close(topicName, closeTimeOut, gracefulClose);
-      OPEN_VENICE_WRITER_COUNT.decrementAndGet();
-    } catch (Exception e) {
-      logger.warn("Swallowed an exception while trying to close the VeniceWriter for topic: {}", topicName, e);
-      VENICE_WRITER_CLOSE_FAILED_COUNT.incrementAndGet();
+        producerAdapter.close(topicName, closeTimeOut, gracefulClose);
+        OPEN_VENICE_WRITER_COUNT.decrementAndGet();
+      } catch (Exception e) {
+        logger.warn("Swallowed an exception while trying to close the VeniceWriter for topic: {}", topicName, e);
+        VENICE_WRITER_CLOSE_FAILED_COUNT.incrementAndGet();
+      }
+      isClosed = true;
+      logger.info("Closed VeniceWriter for topic: {} in {} ms", topicName, System.currentTimeMillis() - startTime);
     }
+  }
+
+  public CompletableFuture<VeniceResourceCloseResult> closeAsync(boolean gracefulClose) {
+    return CompletableFuture.supplyAsync(() -> {
+      synchronized (closeLock) {
+        if (isClosed) {
+          return VeniceResourceCloseResult.ALREADY_CLOSED;
+        }
+        long startTime = System.currentTimeMillis();
+        logger.info("Closing VeniceWriter for topic: {}", topicName);
+        try {
+          // try to end all segments before closing the producer
+          if (gracefulClose) {
+            CompletableFuture<Void> endSegmentsFuture =
+                CompletableFuture.runAsync(() -> endAllSegments(true), threadPoolExecutor);
+            try {
+              endSegmentsFuture.get(Math.min(10, closeTimeOut / 2), TimeUnit.SECONDS);
+            } catch (Exception e) {
+              // cancel the endSegmentsFuture if it's not done in time
+              if (!endSegmentsFuture.isDone()) {
+                endSegmentsFuture.cancel(true);
+              }
+              logger.warn("Swallowed an exception while trying to end all segments for topic: {}", topicName, e);
+            }
+          }
+          producerAdapter.close(topicName, closeTimeOut, gracefulClose);
+          OPEN_VENICE_WRITER_COUNT.decrementAndGet();
+        } catch (Exception e) {
+          logger.warn("Swallowed an exception while trying to close the VeniceWriter for topic: {}", topicName, e);
+          VENICE_WRITER_CLOSE_FAILED_COUNT.incrementAndGet();
+        }
+        isClosed = true;
+        logger.info("Closed VeniceWriter for topic: {} in {} ms", topicName, System.currentTimeMillis() - startTime);
+        return VeniceResourceCloseResult.SUCCESS;
+      }
+    }, threadPoolExecutor);
   }
 
   @Override

--- a/internal/venice-common/src/test/java/com/linkedin/venice/system/store/MetaStoreWriterTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/system/store/MetaStoreWriterTest.java
@@ -10,11 +10,20 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.linkedin.venice.exceptions.VeniceException;
+import com.linkedin.venice.helix.HelixReadOnlyZKSharedSchemaRepository;
+import com.linkedin.venice.kafka.TopicManager;
+import com.linkedin.venice.pubsub.PubSubTopicRepository;
 import com.linkedin.venice.systemstore.schemas.StoreMetaKey;
 import com.linkedin.venice.systemstore.schemas.StoreMetaValue;
+import com.linkedin.venice.utils.VeniceResourceCloseResult;
 import com.linkedin.venice.writer.VeniceWriter;
+import com.linkedin.venice.writer.VeniceWriterFactory;
+import java.io.IOException;
 import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.locks.ReentrantLock;
+import org.apache.avro.Schema;
 import org.mockito.ArgumentCaptor;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -64,5 +73,52 @@ public class MetaStoreWriterTest {
     Assert.assertEquals(capturedKey.metadataType, MetaStoreDataType.HEARTBEAT.getValue());
     StoreMetaValue capturedValue = valueArgumentCaptor.getValue();
     Assert.assertEquals(capturedValue.timestamp, timestamp);
+  }
+
+  @Test
+  public void testClose() throws IOException {
+    TopicManager topicManager = mock(TopicManager.class);
+    VeniceWriterFactory writerFactory = mock(VeniceWriterFactory.class);
+    HelixReadOnlyZKSharedSchemaRepository schemaRepo = mock(HelixReadOnlyZKSharedSchemaRepository.class);
+    PubSubTopicRepository pubSubTopicRepository = mock(PubSubTopicRepository.class);
+    Schema derivedComputeSchema = mock(Schema.class);
+
+    long closeTimeoutMs = 60_000L; // 1 minute
+    int numOfConcurrentVwCloseOps = 2;
+
+    MetaStoreWriter metaStoreWriter = new MetaStoreWriter(
+        topicManager,
+        writerFactory,
+        schemaRepo,
+        derivedComputeSchema,
+        pubSubTopicRepository,
+        closeTimeoutMs,
+        numOfConcurrentVwCloseOps);
+    Map<String, VeniceWriter> metaStoreWriters = metaStoreWriter.getMetaStoreWriterMap();
+
+    for (int i = 0; i < 20; i++) {
+      VeniceWriter veniceWriter = mock(VeniceWriter.class);
+      metaStoreWriters.put("topic_" + i, veniceWriter);
+      CompletableFuture<VeniceResourceCloseResult> vwCloseAsyncFuture = mock(CompletableFuture.class);
+      when(veniceWriter.closeAsync(true)).thenReturn(vwCloseAsyncFuture);
+    }
+
+    for (int i = 20; i < 40; i++) {
+      VeniceWriter veniceWriter = mock(VeniceWriter.class);
+      metaStoreWriters.put("topic_" + i, veniceWriter);
+      CompletableFuture<VeniceResourceCloseResult> vwCloseAsyncFuture =
+          CompletableFuture.completedFuture(VeniceResourceCloseResult.ALREADY_CLOSED);
+      when(veniceWriter.closeAsync(true)).thenReturn(vwCloseAsyncFuture);
+    }
+
+    for (int i = 40; i < 50; i++) {
+      VeniceWriter veniceWriter = mock(VeniceWriter.class);
+      metaStoreWriters.put("topic_" + i, veniceWriter);
+      CompletableFuture<VeniceResourceCloseResult> vwCloseAsyncFuture = new CompletableFuture<>();
+      when(veniceWriter.closeAsync(true)).thenReturn(vwCloseAsyncFuture);
+    }
+
+    metaStoreWriter.close();
+    System.out.println(metaStoreWriter);
   }
 }

--- a/internal/venice-common/src/test/java/com/linkedin/venice/writer/VeniceWriterFactoryTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/writer/VeniceWriterFactoryTest.java
@@ -1,7 +1,6 @@
 package com.linkedin.venice.writer;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -18,13 +17,13 @@ import org.testng.annotations.Test;
 
 public class VeniceWriterFactoryTest {
   @Test
-  public void testVeniceWriterFactory() throws Exception {
+  public void testVeniceWriterFactory() {
     PubSubProducerAdapterFactory<PubSubProducerAdapter> producerFactoryMack = mock(PubSubProducerAdapterFactory.class);
     PubSubProducerAdapter producerAdapterMock = mock(PubSubProducerAdapter.class);
     ArgumentCaptor<String> brokerAddrCapture = ArgumentCaptor.forClass(String.class);
     when(producerFactoryMack.create(any(VeniceProperties.class), eq("store_v1"), brokerAddrCapture.capture()))
         .thenReturn(producerAdapterMock);
-    when(producerAdapterMock.getNumberOfPartitions(any(), anyInt(), any())).thenReturn(1);
+    when(producerAdapterMock.getNumberOfPartitions(any())).thenReturn(1);
 
     VeniceWriterFactory veniceWriterFactory = new VeniceWriterFactory(new Properties(), producerFactoryMack, null);
     VeniceWriter veniceWriter = veniceWriterFactory

--- a/internal/venice-common/src/test/java/com/linkedin/venice/writer/VeniceWriterUnitTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/writer/VeniceWriterUnitTest.java
@@ -4,7 +4,6 @@ import static com.linkedin.venice.writer.VeniceWriter.APP_DEFAULT_LOGICAL_TS;
 import static com.linkedin.venice.writer.VeniceWriter.DEFAULT_MAX_SIZE_FOR_USER_PAYLOAD_PER_MESSAGE_IN_BYTES;
 import static com.linkedin.venice.writer.VeniceWriter.VENICE_DEFAULT_LOGICAL_TS;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.doCallRealMethod;
@@ -94,7 +93,6 @@ public class VeniceWriterUnitTest {
     PubSubProducerAdapter mockedProducer = mock(PubSubProducerAdapter.class);
     CompletableFuture mockedFuture = mock(CompletableFuture.class);
     when(mockedProducer.getNumberOfPartitions(any())).thenReturn(1);
-    when(mockedProducer.getNumberOfPartitions(any(), anyInt(), any())).thenReturn(1);
     when(mockedProducer.sendMessage(any(), any(), any(), any(), any(), any())).thenReturn(mockedFuture);
     String stringSchema = "\"string\"";
     VeniceKafkaSerializer serializer = new VeniceAvroKafkaSerializer(stringSchema);
@@ -147,7 +145,6 @@ public class VeniceWriterUnitTest {
     PubSubProducerAdapter mockedProducer = mock(PubSubProducerAdapter.class);
     CompletableFuture mockedFuture = mock(CompletableFuture.class);
     when(mockedProducer.getNumberOfPartitions(any())).thenReturn(1);
-    when(mockedProducer.getNumberOfPartitions(any(), anyInt(), any())).thenReturn(1);
     when(mockedProducer.sendMessage(any(), any(), any(), any(), any(), any())).thenReturn(mockedFuture);
     String stringSchema = "\"string\"";
     VeniceKafkaSerializer serializer = new VeniceAvroKafkaSerializer(stringSchema);
@@ -326,7 +323,6 @@ public class VeniceWriterUnitTest {
     PubSubProducerAdapter mockedProducer = mock(PubSubProducerAdapter.class);
     CompletableFuture mockedFuture = mock(CompletableFuture.class);
     when(mockedProducer.getNumberOfPartitions(any())).thenReturn(1);
-    when(mockedProducer.getNumberOfPartitions(any(), anyInt(), any())).thenReturn(1);
     when(mockedProducer.sendMessage(any(), any(), any(), any(), any(), any())).thenReturn(mockedFuture);
     Properties writerProperties = new Properties();
     String stringSchema = "\"string\"";
@@ -423,7 +419,6 @@ public class VeniceWriterUnitTest {
     PubSubProducerAdapter mockedProducer = mock(PubSubProducerAdapter.class);
     CompletableFuture mockedFuture = mock(CompletableFuture.class);
     when(mockedProducer.getNumberOfPartitions(any())).thenReturn(1);
-    when(mockedProducer.getNumberOfPartitions(any(), anyInt(), any())).thenReturn(1);
     when(mockedProducer.sendMessage(any(), any(), any(), any(), any(), any())).thenReturn(mockedFuture);
     Properties writerProperties = new Properties();
     writerProperties.put(VeniceWriter.MAX_ELAPSED_TIME_FOR_SEGMENT_IN_MS, 0);

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerConfig.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerConfig.java
@@ -67,6 +67,8 @@ import static com.linkedin.venice.ConfigKeys.KAFKA_ADMIN_CLASS;
 import static com.linkedin.venice.ConfigKeys.KAFKA_READ_ONLY_ADMIN_CLASS;
 import static com.linkedin.venice.ConfigKeys.KAFKA_WRITE_ONLY_ADMIN_CLASS;
 import static com.linkedin.venice.ConfigKeys.KME_REGISTRATION_FROM_MESSAGE_HEADER_ENABLED;
+import static com.linkedin.venice.ConfigKeys.META_STORE_WRITER_CLOSE_CONCURRENCY;
+import static com.linkedin.venice.ConfigKeys.META_STORE_WRITER_CLOSE_TIMEOUT_MS;
 import static com.linkedin.venice.ConfigKeys.MIN_NUMBER_OF_STORE_VERSIONS_TO_PRESERVE;
 import static com.linkedin.venice.ConfigKeys.MIN_NUMBER_OF_UNUSED_KAFKA_TOPICS_TO_PRESERVE;
 import static com.linkedin.venice.ConfigKeys.NATIVE_REPLICATION_FABRIC_ALLOWLIST;
@@ -271,6 +273,10 @@ public class VeniceControllerConfig extends VeniceControllerClusterConfig {
   private final boolean controllerInAzureFabric;
 
   private final boolean usePushStatusStoreForIncrementalPush;
+
+  private final long metaStoreWriterCloseTimeoutInMS;
+
+  private final int metaStoreWriterCloseConcurrency;
 
   private final boolean unregisterMetricForDeletedStoreEnabled;
 
@@ -486,6 +492,8 @@ public class VeniceControllerConfig extends VeniceControllerClusterConfig {
     this.isAutoMaterializeDaVinciPushStatusSystemStoreEnabled =
         props.getBoolean(CONTROLLER_AUTO_MATERIALIZE_DAVINCI_PUSH_STATUS_SYSTEM_STORE, false);
     this.usePushStatusStoreForIncrementalPush = props.getBoolean(USE_PUSH_STATUS_STORE_FOR_INCREMENTAL_PUSH, false);
+    this.metaStoreWriterCloseTimeoutInMS = props.getLong(META_STORE_WRITER_CLOSE_TIMEOUT_MS, 300000L);
+    this.metaStoreWriterCloseConcurrency = props.getInt(META_STORE_WRITER_CLOSE_CONCURRENCY, -1);
     this.emergencySourceRegion = props.getString(EMERGENCY_SOURCE_REGION, "");
     this.allowClusterWipe = props.getBoolean(ALLOW_CLUSTER_WIPE, false);
     this.childControllerAdminTopicConsumptionEnabled =
@@ -915,6 +923,14 @@ public class VeniceControllerConfig extends VeniceControllerClusterConfig {
 
   public boolean usePushStatusStoreForIncrementalPush() {
     return usePushStatusStoreForIncrementalPush;
+  }
+
+  public long getMetaStoreWriterCloseTimeoutInMS() {
+    return metaStoreWriterCloseTimeoutInMS;
+  }
+
+  public int getMetaStoreWriterCloseConcurrency() {
+    return metaStoreWriterCloseConcurrency;
   }
 
   public boolean isUnregisterMetricForDeletedStoreEnabled() {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -562,7 +562,9 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
         topicManagerRepository.getTopicManager(),
         veniceWriterFactory,
         zkSharedSchemaRepository,
-        pubSubTopicRepository);
+        pubSubTopicRepository,
+        commonConfig.getMetaStoreWriterCloseTimeoutInMS(),
+        commonConfig.getMetaStoreWriterCloseConcurrency());
     metaStoreReader = new MetaStoreReader(d2Client, commonConfig.getClusterDiscoveryD2ServiceName());
 
     clusterToLiveClusterConfigRepo = new VeniceConcurrentHashMap<>();

--- a/services/venice-server/src/main/java/com/linkedin/venice/server/VeniceServer.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/server/VeniceServer.java
@@ -60,10 +60,10 @@ import com.linkedin.venice.stats.DiskHealthStats;
 import com.linkedin.venice.stats.VeniceJVMStats;
 import com.linkedin.venice.system.store.ControllerClientBackedSystemSchemaInitializer;
 import com.linkedin.venice.utils.CollectionUtils;
-import com.linkedin.venice.utils.LatencyUtils;
 import com.linkedin.venice.utils.Utils;
 import com.linkedin.venice.utils.lazy.Lazy;
 import io.tehuti.metrics.MetricsRepository;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -635,8 +635,11 @@ public class VeniceServer {
         exceptions.add(e);
         LOGGER.error("Exception while closing: {}", zkClient.getClass().getSimpleName(), e);
       }
-
-      LOGGER.info("Shutdown completed in {} ms", LatencyUtils.getLatencyInMS(startTimeMS));
+      long elapsedTimeInMs = System.currentTimeMillis() - startTimeMS;
+      LOGGER.info(
+          "Shutdown completed in {} ms ({} minutes) ",
+          elapsedTimeInMs,
+          Duration.ofMillis(elapsedTimeInMs).toMinutes());
       if (exceptions.size() > 0) {
         throw new VeniceException(exceptions.get(0));
       }

--- a/services/venice-server/src/main/java/com/linkedin/venice/server/VeniceServer.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/server/VeniceServer.java
@@ -63,12 +63,12 @@ import com.linkedin.venice.utils.CollectionUtils;
 import com.linkedin.venice.utils.Utils;
 import com.linkedin.venice.utils.lazy.Lazy;
 import io.tehuti.metrics.MetricsRepository;
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.helix.zookeeper.impl.client.ZkClient;
 import org.apache.logging.log4j.LogManager;
@@ -637,9 +637,9 @@ public class VeniceServer {
       }
       long elapsedTimeInMs = System.currentTimeMillis() - startTimeMS;
       LOGGER.info(
-          "Shutdown completed in {} ms ({} minutes) ",
+          "Shutdown completed in {} ms (or {} minutes) ",
           elapsedTimeInMs,
-          Duration.ofMillis(elapsedTimeInMs).toMinutes());
+          TimeUnit.MILLISECONDS.toMinutes(elapsedTimeInMs));
       if (exceptions.size() > 0) {
         throw new VeniceException(exceptions.get(0));
       }


### PR DESCRIPTION
## Close VeniceWriters in MetaStoreWriter concurrently and within bounded time

This commit addresses the issue in the current `MetaStoreWriter::close` implementation,  
which uses `parallelStream` to close Venice writers. Since no thread pool is specified for   
running `parallelStream`, it uses threads from `ForkJoin.commonPool`. This can lead to   
issues where other parts of the system monopolize the FJ thread pool, causing a lack of   
guaranteed concurrency during the close operation. In other cases, the `MetaStoreWriter`   
itself may monopolize the FJ thread pool, preventing other system components' access to it.  

This PR addresses the issue by eliminating the dependency on the FJ common pool during  
the MetaStore shutdown. It introduces the `VeniceWriter::closeAsync` API to close Venice  
 writers asynchronously. This async operation runs in the Venice writer's dedicated elastic  
 thread pool, which ensures concurrent and predictable behavior during the close process.  




## How was this PR tested?
GHCI


## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.