### PR TITLE
[server][fast-client] Reject read-compute requests on server when the store is not enabled with the config

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -745,7 +745,7 @@ ext.createDiffFile = { ->
   def file = Files.createTempFile(URLEncoder.encode(project.name, 'UTF-8'), '.diff').toFile()
   def diffBase = "${git.getUpstreamRemote()}/main"
   def command = [
-      'git', 'diff', diffBase, '--no-color', '--minimal', '--', '.'
+      'git', 'diff', "${diffBase}...", '--no-color', '--minimal', '--', '.'
   ]
   command.addAll(exclusionFilter)
   file.withOutputStream { out ->

--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/DispatchingAvroGenericStoreClient.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/DispatchingAvroGenericStoreClient.java
@@ -710,7 +710,13 @@ public class DispatchingAvroGenericStoreClient<K, V> extends InternalAvroStoreCl
       if (!REDUNDANT_LOGGING_FILTER.isRedundantException(COMPUTE_TRANSPORT_EXCEPTION_FILTER_MESSAGE)) {
         LOGGER.error("Exception received from transport. ExMsg: {}", exception.getMessage());
       }
-      decoder.onCompletion(Optional.of(new VeniceClientException("Exception received from transport", exception)));
+      VeniceClientException clientException;
+      if (exception instanceof VeniceClientException) {
+        clientException = (VeniceClientException) exception;
+      } else {
+        clientException = new VeniceClientException("Exception received from transport", exception);
+      }
+      decoder.onCompletion(Optional.of(clientException));
       return;
     }
 

--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/meta/InstanceHealthMonitor.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/meta/InstanceHealthMonitor.java
@@ -1,6 +1,7 @@
 package com.linkedin.venice.fastclient.meta;
 
 import static org.apache.hc.core5.http.HttpStatus.SC_GONE;
+import static org.apache.hc.core5.http.HttpStatus.SC_METHOD_NOT_ALLOWED;
 import static org.apache.hc.core5.http.HttpStatus.SC_NOT_FOUND;
 import static org.apache.hc.core5.http.HttpStatus.SC_OK;
 import static org.apache.hc.core5.http.HttpStatus.SC_SERVICE_UNAVAILABLE;
@@ -143,6 +144,10 @@ public class InstanceHealthMonitor implements Closeable {
         case SC_SERVICE_UNAVAILABLE:
           counterResetDelayMS = clientConfig.getRoutingUnavailableRequestCounterResetDelayMS();
           unhealthyInstance = true;
+          break;
+        case SC_METHOD_NOT_ALLOWED:
+          // Use the same delay as service unavailable without marking the instance as unhealthy
+          counterResetDelayMS = clientConfig.getRoutingUnavailableRequestCounterResetDelayMS();
           break;
         default:
           // All other error statuses

--- a/gradle/helper/git.gradle
+++ b/gradle/helper/git.gradle
@@ -21,7 +21,7 @@ ext.git = [
     def remoteName = ext.git.getUpstreamRemote()
     def stdout = new ByteArrayOutputStream()
     exec {
-      commandLine = ['git', 'diff', '--name-status', "${remoteName}/main"]
+      commandLine = ['git', 'diff', '--name-status', "${remoteName}/main..."]
       standardOutput = stdout
     }
     return "$stdout"

--- a/internal/venice-common/src/main/java/com/linkedin/venice/exceptions/OperationNotAllowedException.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/exceptions/OperationNotAllowedException.java
@@ -1,0 +1,10 @@
+package com.linkedin.venice.exceptions;
+
+import org.apache.http.HttpStatus;
+
+
+public class OperationNotAllowedException extends VeniceHttpException {
+  public OperationNotAllowedException(String message) {
+    super(HttpStatus.SC_METHOD_NOT_ALLOWED, message);
+  }
+}

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/fastclient/AvroStoreClientGzipEndToEndTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/fastclient/AvroStoreClientGzipEndToEndTest.java
@@ -4,6 +4,7 @@ import static com.linkedin.venice.fastclient.utils.ClientTestUtils.REQUEST_TYPES
 import static com.linkedin.venice.fastclient.utils.ClientTestUtils.STORE_METADATA_FETCH_MODES;
 
 import com.linkedin.venice.compression.CompressionStrategy;
+import com.linkedin.venice.controllerapi.UpdateStoreQueryParams;
 import com.linkedin.venice.fastclient.meta.StoreMetadataFetchMode;
 import com.linkedin.venice.helix.HelixReadOnlySchemaRepository;
 import com.linkedin.venice.read.RequestType;
@@ -77,6 +78,7 @@ public class AvroStoreClientGzipEndToEndTest extends AvroStoreClientEndToEndTest
           storeVersionName = topic;
           return null;
         });
+    veniceCluster.updateStore(storeName, new UpdateStoreQueryParams().setReadComputationEnabled(true));
     valueSchemaId = HelixReadOnlySchemaRepository.VALUE_SCHEMA_STARTING_ID;
   }
 

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/fastclient/AvroStoreClientZstdEndToEndTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/fastclient/AvroStoreClientZstdEndToEndTest.java
@@ -7,6 +7,7 @@ import static com.linkedin.venice.utils.ByteUtils.BYTES_PER_MB;
 
 import com.github.luben.zstd.ZstdDictTrainer;
 import com.linkedin.venice.compression.CompressionStrategy;
+import com.linkedin.venice.controllerapi.UpdateStoreQueryParams;
 import com.linkedin.venice.fastclient.meta.StoreMetadataFetchMode;
 import com.linkedin.venice.helix.HelixReadOnlySchemaRepository;
 import com.linkedin.venice.read.RequestType;
@@ -92,6 +93,7 @@ public class AvroStoreClientZstdEndToEndTest extends AvroStoreClientEndToEndTest
           byte[] compressionDictionaryBytes = trainer.trainSamples();
           return ByteBuffer.wrap(compressionDictionaryBytes);
         });
+    veniceCluster.updateStore(storeName, new UpdateStoreQueryParams().setReadComputationEnabled(true));
     valueSchemaId = HelixReadOnlySchemaRepository.VALUE_SCHEMA_STARTING_ID;
   }
 }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/fastclient/FastClientGrpcServerReadQuotaTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/fastclient/FastClientGrpcServerReadQuotaTest.java
@@ -20,7 +20,7 @@ import org.testng.annotations.Test;
 
 public class FastClientGrpcServerReadQuotaTest extends AbstractClientEndToEndSetup {
   /**
-   * test is copied from {@link FastClientServerReadQuotaTest}, we need to reset server-side stats before each test class
+   * test is copied from {@link FastClientIndividualFeatureConfigurationTest}, we need to reset server-side stats before each test class
    * @throws Exception
    */
   @Test(timeOut = TIME_OUT)

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/fastclient/utils/AbstractClientEndToEndSetup.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/fastclient/utils/AbstractClientEndToEndSetup.java
@@ -566,30 +566,30 @@ public abstract class AbstractClientEndToEndSetup {
       assertTrue(
           metrics.get(metricPrefix + "success_request_key_count.Max").value() >= successKeyCount,
           "Respective success_request_key_count should have been incremented");
+
+      Set<String> allMetricPrefixes = ClientTestUtils.getAllMetricPrefixes(storeName);
+      Set<String> allIncorrectMetricPrefixes = new HashSet<>(allMetricPrefixes);
+      allIncorrectMetricPrefixes.remove(metricPrefix);
+
+      for (String incorrectMetricPrefix: allIncorrectMetricPrefixes) {
+        // incorrect metric should not be incremented
+        assertFalse(
+            metrics.get(incorrectMetricPrefix + "request_key_count.Rate").value() > 0,
+            "Incorrect request_key_count should not be incremented");
+      }
+
+      if (retryEnabled) {
+        assertTrue(
+            metrics.get(metricPrefix + "long_tail_retry_request.OccurrenceRate").value() > 0,
+            "Long tail retry should be triggered");
+      } else {
+        metrics.forEach((mName, metric) -> {
+          if (mName.contains("long_tail_retry_request")) {
+            assertTrue(metric.value() == 0, "Long tail retry should not be triggered");
+          }
+        });
+      }
     });
-
-    Set<String> allMetricPrefixes = ClientTestUtils.getAllMetricPrefixes(storeName);
-    Set<String> allIncorrectMetricPrefixes = new HashSet<>(allMetricPrefixes);
-    allIncorrectMetricPrefixes.remove(metricPrefix);
-
-    for (String incorrectMetricPrefix: allIncorrectMetricPrefixes) {
-      // incorrect metric should not be incremented
-      assertFalse(
-          metrics.get(incorrectMetricPrefix + "request_key_count.Rate").value() > 0,
-          "Incorrect request_key_count should not be incremented");
-    }
-
-    if (retryEnabled) {
-      assertTrue(
-          metrics.get(metricPrefix + "long_tail_retry_request.OccurrenceRate").value() > 0,
-          "Long tail retry should be triggered");
-    } else {
-      metrics.forEach((mName, metric) -> {
-        if (mName.contains("long_tail_retry_request")) {
-          assertTrue(metric.value() == 0, "Long tail retry should not be triggered");
-        }
-      });
-    }
   }
 
   @AfterClass(alwaysRun = true)


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Reject read-compute requests on server when the store is not enabled with the config
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
Currently, servers will perform read-compute on compute requests for any store. This commit adds a check on servers to reject such requests so that servers don't spend resources for stores that aren't allowed to use read-compute

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
Added UT, Integration tests. GHCI for regression testing

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [X] Yes. Make sure to explain your proposed changes and call out the behavior change.
    - Servers will reject read-compute requests for stores that do not have read-compute enabled