### PR TITLE
[test] Increase test timeout for FC tests after adding compute to them

### DIFF
--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/fastclient/AvroStoreClientEndToEndTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/fastclient/AvroStoreClientEndToEndTest.java
@@ -396,7 +396,7 @@ public class AvroStoreClientEndToEndTest extends AbstractClientEndToEndSetup {
     }
   }
 
-  @Test(dataProvider = "fastClientHTTPVariantsAndStoreMetadataFetchModes", timeOut = TIME_OUT)
+  @Test(dataProvider = "fastClientHTTPVariantsAndStoreMetadataFetchModes", timeOut = 2 * TIME_OUT)
   public void testFastClientGetWithDifferentHTTPVariants(
       ClientTestUtils.FastClientHTTPVariant fastClientHTTPVariant,
       StoreMetadataFetchMode storeMetadataFetchMode) throws Exception {

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/fastclient/utils/AbstractClientEndToEndSetup.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/fastclient/utils/AbstractClientEndToEndSetup.java
@@ -467,14 +467,11 @@ public abstract class AbstractClientEndToEndSetup {
    * TODO: Explore to see if we can reuse these for all the tests rather than cleaning it up everytime.
    * */
   protected void cleanupDaVinciClientForMetaStore() {
-    if (daVinciClientForMetaStore != null) {
-      daVinciClientForMetaStore.close();
-      daVinciClientForMetaStore = null;
-    }
-    if (daVinciClientFactory != null) {
-      daVinciClientFactory.close();
-      daVinciClientFactory = null;
-    }
+    Utils.closeQuietlyWithErrorLogged(daVinciClientForMetaStore);
+    daVinciClientForMetaStore = null;
+
+    Utils.closeQuietlyWithErrorLogged(daVinciClientFactory);
+    daVinciClientFactory = null;
   }
 
   protected AvroGenericStoreClient<String, GenericRecord> getGenericThinClient(MetricsRepository metricsRepository) {


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Increase test timeout for FC tests after adding compute to them
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
After adding read-compute support to fast-client (#664) , some FC tests added a "compute" test to them and this caused tests that were close to hitting the timeout now start getting timed out. This commit increases the timeout for one such test that we notice on our internal CI

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
CI

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.