### PR TITLE
[controller][vpj] Revert changes to MultiSchemaResponse/SchemaRoutes that impacts controllerClient#getAllReplicationMetadataSchemas()

### DIFF
--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/schema/HDFSSchemaSource.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/schema/HDFSSchemaSource.java
@@ -92,7 +92,7 @@ public class HDFSSchemaSource implements SchemaSource, AutoCloseable {
       // Path for RMD schema is /<rmdSchemaDir>/<valueSchemaId>_<rmdSchemaId>
       // Path for Value schema is /<valueSchemaDir>/<valueSchemaId>
       String schemaFileName = isRmdSchema
-          ? rmdSchemaDir + SEPARATOR + schema.getId() + UNDERSCORE + schema.getRmdSchemaId()
+          ? rmdSchemaDir + SEPARATOR + schema.getRmdValueSchemaId() + UNDERSCORE + schema.getId()
           : valueSchemaDir + SEPARATOR + schema.getId();
       Path schemaPath = new Path(schemaFileName);
       if (!fs.exists(schemaPath)) {
@@ -107,7 +107,7 @@ public class HDFSSchemaSource implements SchemaSource, AutoCloseable {
         }
         LOGGER.info(
             "Finished writing schema {} onto disk",
-            isRmdSchema ? schema.getId() + "-" + schema.getRmdSchemaId() : schema.getId());
+            isRmdSchema ? schema.getRmdValueSchemaId() + "-" + schema.getId() : schema.getId());
       } else {
         throw new IllegalStateException(String.format("The schema path %s already exists.", schemaPath));
       }

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/input/kafka/ttl/TestVeniceKafkaInputTTLFilter.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/input/kafka/ttl/TestVeniceKafkaInputTTLFilter.java
@@ -84,7 +84,7 @@ public class TestVeniceKafkaInputTTLFilter {
     MultiSchemaResponse.Schema[] response = new MultiSchemaResponse.Schema[n];
     for (int i = 1; i <= n; i++) {
       MultiSchemaResponse.Schema schema = new MultiSchemaResponse.Schema();
-      schema.setRmdSchemaId(i);
+      schema.setRmdValueSchemaId(i);
       schema.setDerivedSchemaId(i);
       schema.setId(i);
       schema.setSchemaStr(RMD_SCHEMA.toString());

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/schema/TestHDFSSchemaSource.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/schema/TestHDFSSchemaSource.java
@@ -79,7 +79,7 @@ public class TestHDFSSchemaSource {
     MultiSchemaResponse.Schema[] response = new MultiSchemaResponse.Schema[n];
     for (int i = 1; i <= n; i++) {
       MultiSchemaResponse.Schema schema = new MultiSchemaResponse.Schema();
-      schema.setRmdSchemaId(i);
+      schema.setRmdValueSchemaId(i);
       schema.setDerivedSchemaId(i);
       schema.setId(i);
       schema.setSchemaStr(RMD_SCHEMA.toString());

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/controllerapi/MultiSchemaResponse.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/controllerapi/MultiSchemaResponse.java
@@ -27,7 +27,7 @@ public class MultiSchemaResponse
      */
     private int derivedSchemaId = SchemaData.INVALID_VALUE_SCHEMA_ID;
 
-    private int rmdSchemaId = SchemaData.INVALID_VALUE_SCHEMA_ID;
+    private int rmdValueSchemaId = SchemaData.INVALID_VALUE_SCHEMA_ID;
 
     private String schemaStr;
 
@@ -60,12 +60,12 @@ public class MultiSchemaResponse
       this.schemaStr = schemaStr;
     }
 
-    public int getRmdSchemaId() {
-      return rmdSchemaId;
+    public int getRmdValueSchemaId() {
+      return rmdValueSchemaId;
     }
 
-    public void setRmdSchemaId(int rmdSchemaId) {
-      this.rmdSchemaId = rmdSchemaId;
+    public void setRmdValueSchemaId(int rmdSchemaId) {
+      this.rmdValueSchemaId = rmdSchemaId;
     }
   }
 

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/utils/AvroSupersetSchemaUtils.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/utils/AvroSupersetSchemaUtils.java
@@ -148,7 +148,7 @@ public class AvroSupersetSchemaUtils {
       if (schema.getDerivedSchemaId() != SchemaData.INVALID_VALUE_SCHEMA_ID) {
         continue;
       }
-      if (schema.getRmdSchemaId() != SchemaData.INVALID_VALUE_SCHEMA_ID) {
+      if (schema.getRmdValueSchemaId() != SchemaData.INVALID_VALUE_SCHEMA_ID) {
         continue;
       }
       return schema;

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/ActiveActiveReplicationForHybridTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/ActiveActiveReplicationForHybridTest.java
@@ -559,7 +559,7 @@ public class ActiveActiveReplicationForHybridTest {
       String expectedSchema =
           "{\"type\":\"record\",\"name\":\"string_MetadataRecord\",\"namespace\":\"com.linkedin.venice\",\"fields\":[{\"name\":\"timestamp\",\"type\":[\"long\"],\"doc\":\"timestamp when the full record was last updated\",\"default\":0},{\"name\":\"replication_checkpoint_vector\",\"type\":{\"type\":\"array\",\"items\":\"long\"},\"doc\":\"high watermark remote checkpoints which touched this record\",\"default\":[]}]}";
       assertEquals(schemaResponse.getSchemas()[0].getSchemaStr(), expectedSchema);
-      assertEquals(schemaResponse.getSchemas()[0].getRmdSchemaId(), 1);
+      assertEquals(schemaResponse.getSchemas()[0].getRmdValueSchemaId(), 1);
       assertEquals(schemaResponse.getSchemas()[0].getId(), 1);
     } finally {
       deleteStores(storeName);

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/SchemaRoutes.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/SchemaRoutes.java
@@ -463,9 +463,9 @@ public class SchemaRoutes extends AbstractRoute {
         int cur = 0;
         for (RmdSchemaEntry entry: valueSchemaEntries) {
           schemas[cur] = new MultiSchemaResponse.Schema();
-          schemas[cur].setId(entry.getValueSchemaID());
+          schemas[cur].setId(entry.getId());
           schemas[cur].setSchemaStr(entry.getSchema().toString());
-          schemas[cur].setRmdSchemaId(entry.getId());
+          schemas[cur].setRmdValueSchemaId(entry.getValueSchemaID());
           ++cur;
         }
         responseObject.setSchemas(schemas);


### PR DESCRIPTION

<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## [controller][vpj] Revert changes to MultiSchemaResponse/SchemaRoutes that impacts controllerClient#getAllReplicationMetadataSchemas()

As a side-effect in PR: #704 I changed the Json property in controller class SchemaRoutes and MultiSchemaResponse to try to clean up API naming to make it makes more sense - ID-RMD_VERSION_ID. This leads to breaking changes in controller, it needs controller deployment to release VPJ and it might have break the API JSON serialization/deserialization. 
To make it easy to release the new TTL repush AAWC feature, this PR reverts the part of the change, so it no longer requires controller deployment. I will try to make another attempt apart from this PR to gracefully deprecate improper naming of JSON property.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
Existing test should pass to make sure it is not a regression.
## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.