### PR TITLE
[server] Tweak logs for better debugging

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ConsumerSubscriptionCleaner.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ConsumerSubscriptionCleaner.java
@@ -127,7 +127,7 @@ public class ConsumerSubscriptionCleaner {
     }
     Set<String> topicsToUnsubscribe = new HashSet<>(nonExistingTopics);
     if (!nonExistingTopics.isEmpty()) {
-      LOGGER.error("Detected the following non-existing topics: {}", nonExistingTopics);
+      LOGGER.warn("Detected the following non-existing topics: {}", nonExistingTopics);
       for (String topic: nonExistingTopics) {
         long firstDetectedTimestamp = nonExistingTopicDiscoverTimestampMap.getLong(topic);
         if (firstDetectedTimestamp == nonExistingTopicDiscoverTimestampMap.defaultReturnValue()) {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/AggVersionedIngestionStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/AggVersionedIngestionStats.java
@@ -47,7 +47,8 @@ public class AggVersionedIngestionStats
         registerConditionalStats(storeName);
       }
     } catch (Exception e) {
-      LOGGER.warn("Failed to set up versioned storage ingestion stats of store: {}, version: {}", storeName, version);
+      LOGGER
+          .warn("Failed to set up versioned storage ingestion stats of store: {}, version: {}", storeName, version, e);
     }
   }
 


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Summary, imperative, start upper case, don't end with a period
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

During my oncall shifts, I find the logging to detect non-existing topics is a bit noisy and doesn't provide much information when we filter by ERROR. It should be WARNING.

Also, sometimes I see stats failed to register but there was no reason. Add that as well.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
ghci.

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.