### PR TITLE
[server][da-vinci] reduced DIV warn logging frequency to reduce cpu wait especially during rewind

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -2777,12 +2777,16 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
 
       // TODO: remove this condition check after fixing the bug that drainer in leaders is validating RT DIV info
       if (consumerRecord.getValue().producerMetadata.messageSequenceNumber != 1) {
-        LOGGER.warn(
-            "Data integrity validation problem with: {} offset: {}, "
-                + "but consumption will continue since EOP is already received. Msg: {}",
-            consumerRecord.getTopicPartition(),
-            consumerRecord.getOffset(),
-            warningException.getMessage());
+        String errorMsgIdentifier = consumerRecord.getTopicPartition().getPubSubTopic().getName() + "-"
+            + consumerRecord.getTopicPartition().getPartitionNumber() + "-" + warningException.getClass().getName();
+        if (REDUNDANT_LOGGING_FILTER.isRedundantException(errorMsgIdentifier)) {
+          LOGGER.warn(
+              "Data integrity validation problem with: {} offset: {}, "
+                  + "but consumption will continue since EOP is already received. Msg: {}",
+              consumerRecord.getTopicPartition(),
+              consumerRecord.getOffset(),
+              warningException.getMessage());
+        }
       }
 
       if (!(warningException instanceof ImproperlyStartedSegmentException)) {


### PR DESCRIPTION

<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Summary, imperative, start upper case, don't end with a period
reduced DIV warn logging frequency to reduce cpu wait especially during rewind
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->


## How was this PR tested?
CI
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.