### PR TITLE
[da-vinci][server] Alert on failed ingestions for both incomplete and completed partitions

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ConsumerAction.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ConsumerAction.java
@@ -26,26 +26,33 @@ public class ConsumerAction implements Comparable<ConsumerAction> {
 
   private long createTimestampInMs = System.currentTimeMillis();
 
+  private boolean isHelixTriggeredAction = true;
   private CompletableFuture<Void> future = new CompletableFuture<>();
 
-  public ConsumerAction(ConsumerActionType type, PubSubTopicPartition topicPartition, int sequenceNumber) {
-    this(type, topicPartition, sequenceNumber, null, Optional.empty());
+  public ConsumerAction(
+      ConsumerActionType type,
+      PubSubTopicPartition topicPartition,
+      int sequenceNumber,
+      boolean isHelixTriggeredAction) {
+    this(type, topicPartition, sequenceNumber, null, Optional.empty(), isHelixTriggeredAction);
   }
 
   public ConsumerAction(
       ConsumerActionType type,
       PubSubTopicPartition topicPartition,
       int sequenceNumber,
-      LeaderFollowerPartitionStateModel.LeaderSessionIdChecker checker) {
-    this(type, topicPartition, sequenceNumber, checker, Optional.empty());
+      LeaderFollowerPartitionStateModel.LeaderSessionIdChecker checker,
+      boolean isHelixTriggeredAction) {
+    this(type, topicPartition, sequenceNumber, checker, Optional.empty(), isHelixTriggeredAction);
   }
 
   public ConsumerAction(
       ConsumerActionType type,
       PubSubTopicPartition topicPartition,
       int sequenceNumber,
-      Optional<LeaderFollowerStateType> leaderState) {
-    this(type, topicPartition, sequenceNumber, null, leaderState);
+      Optional<LeaderFollowerStateType> leaderState,
+      boolean isHelixTriggeredAction) {
+    this(type, topicPartition, sequenceNumber, null, leaderState, isHelixTriggeredAction);
   }
 
   private ConsumerAction(
@@ -53,12 +60,14 @@ public class ConsumerAction implements Comparable<ConsumerAction> {
       PubSubTopicPartition topicPartition,
       int sequenceNumber,
       LeaderFollowerPartitionStateModel.LeaderSessionIdChecker checker,
-      Optional<LeaderFollowerStateType> leaderState) {
+      Optional<LeaderFollowerStateType> leaderState,
+      boolean isHelixTriggeredAction) {
     this.type = type;
     this.topicPartition = Utils.notNull(topicPartition);
     this.sequenceNumber = sequenceNumber;
     this.checker = checker;
     this.leaderState = leaderState.orElse(LeaderFollowerStateType.STANDBY);
+    this.isHelixTriggeredAction = isHelixTriggeredAction;
   }
 
   public ConsumerActionType getType() {
@@ -103,6 +112,10 @@ public class ConsumerAction implements Comparable<ConsumerAction> {
 
   public CompletableFuture<Void> getFuture() {
     return future;
+  }
+
+  public boolean isHelixTriggeredAction() {
+    return isHelixTriggeredAction;
   }
 
   @Override
@@ -161,6 +174,12 @@ public class ConsumerAction implements Comparable<ConsumerAction> {
    * value for no meaning.
    */
   public static ConsumerAction createKillAction(PubSubTopic topic, int sequenceNumber) {
-    return new ConsumerAction(ConsumerActionType.KILL, new PubSubTopicPartitionImpl(topic, 0), sequenceNumber);
+    return new ConsumerAction(
+        ConsumerActionType.KILL,
+        new PubSubTopicPartitionImpl(topic, 0),
+        sequenceNumber,
+        null,
+        Optional.empty(),
+        false);
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -316,7 +316,8 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
               STANDBY_TO_LEADER,
               new PubSubTopicPartitionImpl(topicPartition.getPubSubTopic(), subPartition),
               nextSeqNum(),
-              checker));
+              checker,
+              true));
     });
   }
 
@@ -333,7 +334,8 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
               LEADER_TO_STANDBY,
               new PubSubTopicPartitionImpl(topicPartition.getPubSubTopic(), subPartition),
               nextSeqNum(),
-              checker));
+              checker,
+              true));
     });
   }
 
@@ -461,7 +463,7 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
         endSegment(partition);
         break;
       default:
-        processCommonConsumerAction(operation, message.getTopicPartition(), message.getLeaderState());
+        processCommonConsumerAction(message);
     }
   }
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/IngestionStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/IngestionStats.java
@@ -199,10 +199,9 @@ public class IngestionStats {
     if (!hasActiveIngestionTask()) {
       return 0;
     }
-    boolean anyErrorReported =
-        ingestionTask.hasAnyPartitionConsumptionState(PartitionConsumptionState::isErrorReported);
+    int totalFailedIngestionPartitions = ingestionTask.getFailedIngestionPartitionCount();
     boolean anyCompleted = ingestionTask.hasAnyPartitionConsumptionState(PartitionConsumptionState::isComplete);
-    return anyCompleted && anyErrorReported ? 1 : 0;
+    return anyCompleted ? totalFailedIngestionPartitions : 0;
   }
 
   public long getBatchReplicationLag() {

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/ConsumerActionTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/ConsumerActionTest.java
@@ -81,11 +81,11 @@ public class ConsumerActionTest {
   public void testEqualsAndHashCode() {
     PubSubTopicPartition pubSubTopicPartition1 =
         new PubSubTopicPartitionImpl(pubSubTopicRepository.getTopic("blah_rt"), 0);
-    ConsumerAction ca1 = new ConsumerAction(ConsumerActionType.RESUME, pubSubTopicPartition1, 0);
+    ConsumerAction ca1 = new ConsumerAction(ConsumerActionType.RESUME, pubSubTopicPartition1, 0, false);
 
     PubSubTopicPartition pubSubTopicPartition2 =
         new PubSubTopicPartitionImpl(pubSubTopicRepository.getTopic("blah_rt"), 1);
-    ConsumerAction ca2 = new ConsumerAction(ConsumerActionType.RESUME, pubSubTopicPartition2, 0);
+    ConsumerAction ca2 = new ConsumerAction(ConsumerActionType.RESUME, pubSubTopicPartition2, 0, false);
 
     assertNotEquals(ca1, ca2);
     assertNotEquals(ca1.hashCode(), ca2.hashCode());
@@ -93,21 +93,22 @@ public class ConsumerActionTest {
 
     PubSubTopicPartition pubSubTopicPartition3 =
         new PubSubTopicPartitionImpl(pubSubTopicRepository.getTopic("blah_rt"), 1);
-    ConsumerAction ca3 = new ConsumerAction(ConsumerActionType.RESUME, pubSubTopicPartition3, 0);
+    ConsumerAction ca3 = new ConsumerAction(ConsumerActionType.RESUME, pubSubTopicPartition3, 0, false);
 
     assertEquals(ca2, ca3);
     assertEquals(ca2.hashCode(), ca3.hashCode());
 
-    ConsumerAction ca4 = new ConsumerAction(ConsumerActionType.RESUME, pubSubTopicPartition3, 1);
+    ConsumerAction ca4 = new ConsumerAction(ConsumerActionType.RESUME, pubSubTopicPartition3, 1, false);
     assertNotEquals(ca2, ca4);
     assertNotEquals(ca3, ca4);
 
-    ConsumerAction ca5 = new ConsumerAction(ConsumerActionType.KILL, pubSubTopicPartition3, 0);
+    ConsumerAction ca5 = new ConsumerAction(ConsumerActionType.KILL, pubSubTopicPartition3, 0, false);
     assertNotEquals(ca2, ca5);
     assertNotEquals(ca3, ca5);
     assertNotEquals(ca4, ca5);
 
-    ConsumerAction ca6 = new ConsumerAction(ConsumerActionType.KILL, pubSubTopicPartition3, 0, Optional.of(LEADER));
+    ConsumerAction ca6 =
+        new ConsumerAction(ConsumerActionType.KILL, pubSubTopicPartition3, 0, Optional.of(LEADER), false);
     assertNotEquals(ca2, ca6);
     assertNotEquals(ca3, ca6);
     assertNotEquals(ca4, ca6);
@@ -122,7 +123,8 @@ public class ConsumerActionTest {
         return new ConsumerAction(
             actionTypes[index],
             new PubSubTopicPartitionImpl(pubSubTopicRepository.getTopic(topic), partition),
-            sequenceNumber);
+            sequenceNumber,
+            false);
       }
     }
   }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
@@ -2446,6 +2446,7 @@ public abstract class StoreIngestionTaskTest {
       assertNull(
           storeIngestionTaskUnderTest.getPartitionIngestionExceptionList().get(PARTITION_FOO),
           "Exception for the errored partition should be cleared after unsubscription");
+      assertEquals(storeIngestionTaskUnderTest.getFailedPartitions().size(), 1, "Only one partition should be failed");
     }, isActiveActiveReplicationEnabled);
     for (int i = 0; i < 10000; ++i) {
       storeIngestionTaskUnderTest


### PR DESCRIPTION
## Summary
Problem:
The "ingestion_task_errored_gauge" metric checks ingestion errors for partitions which explicitly reports ERROR to ZK. However, for COMPLETED partition, ERROR will not be reported in order to protect read path, but ingestion will stop without any alerts until we see a high lag after rolling bounce or users notice data staleness/inconsistency.

Fix:
Added a new set to track the partition IDs whose ingestion has failed and stopped. Life cycles of the partitions IDs in the set:
1. When a partition encounters exceptions, update both the partition-to-exception list and failed-partitions set;
2. When an unsubscribe action is triggered by Helix for the failed partition, remove it from both the partition-to-exception list and failed-partitions set;
3. When an unsubscribe action is triggered by internal logic, remove the partition from the partition-to-exception list (stop logging) but keep it in the failed-partitions set (keep alerting);
4. When an subscribe action happens for the failed partition, regardless of who triggers it, remove it from both trackings, since ingestion will start over again.

Resolves VENG-10930

## How was this PR tested?
Added unit test to verify that when partition-to-exception list is updated, failed-ingestion set would keep the failed partition.

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.