### PR TITLE
[server] Fixed union handling in AAWC

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/schema/merge/CollectionTimestampMergeRecordHelper.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/schema/merge/CollectionTimestampMergeRecordHelper.java
@@ -1,8 +1,6 @@
 package com.linkedin.davinci.schema.merge;
 
-import static com.linkedin.davinci.schema.SchemaUtils.isArrayField;
-import static com.linkedin.davinci.schema.SchemaUtils.isMapField;
-
+import com.linkedin.davinci.schema.SchemaUtils;
 import com.linkedin.davinci.utils.IndexedHashMap;
 import com.linkedin.venice.schema.rmd.v1.CollectionRmdTimestamp;
 import java.util.List;
@@ -34,77 +32,36 @@ public class CollectionTimestampMergeRecordHelper extends PerFieldTimestampMerge
       Object newFieldValue,
       final long newPutTimestamp,
       final int putOperationColoID) {
-    if (isMapField(oldRecordField.schema()) || isArrayField(oldRecordField.schema())) {
-      // Collection field must have collection timestamp at this point.
-      Object collectionFieldTimestampObj = oldTimestampRecord.get(oldRecordField.name());
-      if (!(collectionFieldTimestampObj instanceof GenericRecord)) {
-        throw new IllegalStateException(
-            String.format(
-                "Expect field %s to be a generic record from timestamp record %s",
-                oldRecordField.name(),
-                oldTimestampRecord));
-      }
-      GenericRecord collectionFieldTimestamp = (GenericRecord) collectionFieldTimestampObj;
-      return putOnFieldWithCollectionTimestamp(
-          collectionFieldTimestamp,
-          oldRecord,
-          newFieldValue,
-          oldRecordField,
-          newPutTimestamp,
-          putOperationColoID);
+    switch (SchemaUtils.unwrapOptionalUnion(oldRecordField.schema())) {
+      case ARRAY:
+        return collectionFieldOperationHandler.handlePutList(
+            newPutTimestamp,
+            putOperationColoID,
+            (List<Object>) newFieldValue,
+            getCollectionRmdTimestamp(oldTimestampRecord, oldRecordField),
+            oldRecord,
+            oldRecordField);
+      case MAP:
+        if ((newFieldValue != null) && (!(newFieldValue instanceof IndexedHashMap))) {
+          throw new IllegalStateException(
+              "Expect the value to put on the field to be an IndexedHashMap. Got: " + newFieldValue.getClass());
+        }
+        return collectionFieldOperationHandler.handlePutMap(
+            newPutTimestamp,
+            putOperationColoID,
+            (IndexedHashMap<String, Object>) newFieldValue,
+            getCollectionRmdTimestamp(oldTimestampRecord, oldRecordField),
+            oldRecord,
+            oldRecordField);
+      default:
+        return super.putOnField(
+            oldRecord,
+            oldTimestampRecord,
+            oldRecordField,
+            newFieldValue,
+            newPutTimestamp,
+            putOperationColoID);
     }
-    return super.putOnField(
-        oldRecord,
-        oldTimestampRecord,
-        oldRecordField,
-        newFieldValue,
-        newPutTimestamp,
-        putOperationColoID);
-  }
-
-  /**
-   * Put a new collection field value to a collection field with collection timestamp replication metadata.
-   *
-   * @param collectionFieldTimestampRecord Collection timestamp replication metadata.
-   * @param currValueRecord Current record that contains the field.
-   * @param putFieldValue New collection field value to be put.
-   * @param currValueRecordField collection field to be put.
-   * @param putOperationTimestamp Timestamp of the PUT operation.
-   *
-   * @return
-   */
-  private UpdateResultStatus putOnFieldWithCollectionTimestamp(
-      GenericRecord collectionFieldTimestampRecord,
-      GenericRecord currValueRecord,
-      Object putFieldValue,
-      Schema.Field currValueRecordField,
-      final long putOperationTimestamp,
-      final int putOperationColoID) {
-    final CollectionRmdTimestamp collectionRmd = new CollectionRmdTimestamp(collectionFieldTimestampRecord);
-    if (isArrayField(currValueRecordField.schema())) {
-      return collectionFieldOperationHandler.handlePutList(
-          putOperationTimestamp,
-          putOperationColoID,
-          (List<Object>) putFieldValue,
-          collectionRmd,
-          currValueRecord,
-          currValueRecordField);
-    } else if (isMapField(currValueRecordField.schema())) {
-      if ((putFieldValue != null) && (!(putFieldValue instanceof IndexedHashMap))) {
-        throw new IllegalStateException(
-            "Expect the value to put on the field to be an IndexedHashMap. Got: " + putFieldValue.getClass());
-      }
-      return collectionFieldOperationHandler.handlePutMap(
-          putOperationTimestamp,
-          putOperationColoID,
-          (IndexedHashMap<String, Object>) putFieldValue,
-          collectionRmd,
-          currValueRecord,
-          currValueRecordField);
-    }
-    throw new IllegalStateException(
-        "Expect a field that is of a collection type (Map or List). Got: "
-            + currValueRecord.get(currValueRecordField.pos()) + " for field " + currValueRecordField.name());
   }
 
   @Override
@@ -114,40 +71,43 @@ public class CollectionTimestampMergeRecordHelper extends PerFieldTimestampMerge
       Schema.Field currentRecordField,
       final long deleteTimestamp,
       final int coloID) {
-    boolean isMapField = isMapField(currentRecordField.schema());
-    boolean isArrayField = isArrayField(currentRecordField.schema());
-    if (isMapField || isArrayField) {
-      Object timestamp = currentTimestampRecord.get(currentRecordField.name());
-      if (timestamp instanceof Long) {
-        throw new IllegalStateException(
-            String.format(
-                "Expect collection timestamp record for field %s. But got timestamp: %d",
-                currentRecordField.name(),
-                timestamp));
-      }
-      if (isMapField) {
+    switch (SchemaUtils.unwrapOptionalUnion(currentRecordField.schema())) {
+      case MAP:
         return collectionFieldOperationHandler.handleDeleteMap(
             deleteTimestamp,
             coloID,
-            new CollectionRmdTimestamp((GenericRecord) timestamp),
+            getCollectionRmdTimestamp(currentTimestampRecord, currentRecordField),
             currentRecord,
             currentRecordField);
-
-      } else {
+      case ARRAY:
         return collectionFieldOperationHandler.handleDeleteList(
             deleteTimestamp,
             coloID,
-            new CollectionRmdTimestamp((GenericRecord) timestamp),
+            getCollectionRmdTimestamp(currentTimestampRecord, currentRecordField),
             currentRecord,
             currentRecordField);
-      }
-    } else {
-      return super.deleteRecordField(
-          currentRecord,
-          currentTimestampRecord,
-          currentRecordField,
-          deleteTimestamp,
-          coloID);
+      default:
+        return super.deleteRecordField(
+            currentRecord,
+            currentTimestampRecord,
+            currentRecordField,
+            deleteTimestamp,
+            coloID);
     }
+  }
+
+  private CollectionRmdTimestamp getCollectionRmdTimestamp(
+      GenericRecord timestampRecord,
+      Schema.Field valueRecordField) {
+    // Collection field must have collection timestamp at this point.
+    Object collectionFieldTimestampObj = timestampRecord.get(valueRecordField.name());
+    if (!(collectionFieldTimestampObj instanceof GenericRecord)) {
+      throw new IllegalStateException(
+          String.format(
+              "Expect field %s to be a generic record from timestamp record %s",
+              valueRecordField.name(),
+              timestampRecord));
+    }
+    return new CollectionRmdTimestamp((GenericRecord) collectionFieldTimestampObj);
   }
 }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderProducerCallbackTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/LeaderProducerCallbackTest.java
@@ -85,6 +85,8 @@ public class LeaderProducerCallbackTest {
       }
 
       // Message should be logged only three time as there are just 3 unique Topic-Partition
+      // N.B. That assertion seems to be flaky... it sometimes get 4 logs instead of 3.
+      // TODO: Figure out why it's flaky... and maybe remove the assertion entirely if it's expected...
       List<String> logs = inMemoryLogAppender.getLogs();
       long matchedLogs = logs.stream()
           .filter(log -> log.contains("Leader failed to send out message to version topic when consuming "))

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/schema/TestSchemaUtils.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/schema/TestSchemaUtils.java
@@ -13,6 +13,11 @@ import static com.linkedin.venice.schema.writecompute.WriteComputeConstants.MAP_
 import static com.linkedin.venice.schema.writecompute.WriteComputeConstants.MAP_UNION;
 import static com.linkedin.venice.schema.writecompute.WriteComputeConstants.SET_DIFF;
 import static com.linkedin.venice.schema.writecompute.WriteComputeConstants.SET_UNION;
+import static org.apache.avro.Schema.Type.INT;
+import static org.apache.avro.Schema.Type.LONG;
+import static org.apache.avro.Schema.Type.NULL;
+import static org.apache.avro.Schema.Type.UNION;
+import static org.testng.Assert.assertTrue;
 
 import com.linkedin.davinci.serializer.avro.MapOrderPreservingSerDeFactory;
 import com.linkedin.venice.schema.AvroSchemaParseUtils;
@@ -20,6 +25,7 @@ import com.linkedin.venice.schema.rmd.RmdSchemaGenerator;
 import com.linkedin.venice.schema.writecompute.WriteComputeSchemaConverter;
 import com.linkedin.venice.serializer.RecordDeserializer;
 import com.linkedin.venice.serializer.RecordSerializer;
+import com.linkedin.venice.utils.DataProviderUtils;
 import com.linkedin.venice.writer.update.UpdateBuilder;
 import com.linkedin.venice.writer.update.UpdateBuilderImpl;
 import java.util.Arrays;
@@ -152,6 +158,25 @@ public class TestSchemaUtils {
     Assert.assertEquals(mapFieldTsRecord.get(DELETED_ELEM_FIELD_NAME), Collections.singletonList("key2"));
   }
 
+  @Test(dataProviderClass = DataProviderUtils.class, dataProvider = "All-Avro-Schemas-Except-Null-And-Union")
+  public void testUnwrapOptionalUnion(Schema type) {
+    Schema nullAndTypeUnion = Schema.createUnion(Schema.create(NULL), type);
+    assertTrue(SchemaUtils.unwrapOptionalUnion(nullAndTypeUnion) == type.getType());
+
+    Schema typeAndNullUnion = Schema.createUnion(type, Schema.create(NULL));
+    assertTrue(SchemaUtils.unwrapOptionalUnion(typeAndNullUnion) == type.getType());
+
+    Schema singleTypeOnlyUnion = Schema.createUnion(type);
+    assertTrue(SchemaUtils.unwrapOptionalUnion(singleTypeOnlyUnion) == type.getType());
+
+    Schema other = Schema.create(type.getType() == INT ? LONG : INT);
+    Schema typeAndOtherTypeUnion = Schema.createUnion(type, other);
+    assertTrue(SchemaUtils.unwrapOptionalUnion(typeAndOtherTypeUnion) == UNION);
+
+    Schema nullAndTypeAndOtherTypeUnion = Schema.createUnion(Schema.create(NULL), type, other);
+    assertTrue(SchemaUtils.unwrapOptionalUnion(nullAndTypeAndOtherTypeUnion) == UNION);
+  }
+
   protected RecordSerializer<GenericRecord> getSerializer(Schema writerSchema) {
     return MapOrderPreservingSerDeFactory.getAvroGenericSerializer(writerSchema);
   }
@@ -159,5 +184,4 @@ public class TestSchemaUtils {
   protected RecordDeserializer<GenericRecord> getDeserializer(Schema writerSchema, Schema readerSchema) {
     return MapOrderPreservingSerDeFactory.getAvroGenericDeserializer(writerSchema, readerSchema);
   }
-
 }


### PR DESCRIPTION
There was a bug where we assumed unions always used null as the first branch.

Introduced a new SchemaUtils::unwrapOptionalUnion function which replaces several other functions from that class.

Thanks to @sixpluszero for finding that this is the root cause of an issue.

## How was this PR tested?
New existing unit tests.

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.