### PR TITLE
[server][da-vinci-client] Add compaction cancelled metric, add details to node_removable 

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/RocksDBMemoryStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/RocksDBMemoryStats.java
@@ -38,6 +38,7 @@ public class RocksDBMemoryStats extends AbstractVeniceStats {
       "rocksdb.cur-size-all-mem-tables",
       "rocksdb.size-all-mem-tables",
       "rocksdb.num-entries-active-mem-table",
+      "rocksdb.compaction.cancelled",
       "rocksdb.num-entries-imm-mem-tables",
       "rocksdb.num-deletes-active-mem-table",
       "rocksdb.num-deletes-imm-mem-tables",

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/InstanceStatusDecider.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/InstanceStatusDecider.java
@@ -112,7 +112,7 @@ public class InstanceStatusDecider {
                   resourceName,
                   clusterName,
                   result.getSecond());
-              return NodeRemovableResult.nonremoveableResult(
+              return NodeRemovableResult.nonRemovableResult(
                   resourceName,
                   NodeRemovableResult.BlockingRemoveReason.WILL_LOSE_DATA,
                   result.getSecond());
@@ -138,7 +138,7 @@ public class InstanceStatusDecider {
                   resourceName,
                   clusterName,
                   result.getSecond());
-              return NodeRemovableResult.nonremoveableResult(
+              return NodeRemovableResult.nonRemovableResult(
                   resourceName,
                   NodeRemovableResult.BlockingRemoveReason.WILL_TRIGGER_LOAD_REBALANCE,
                   result.getSecond());

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/InstanceStatusDecider.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/InstanceStatusDecider.java
@@ -68,7 +68,7 @@ public class InstanceStatusDecider {
       // If instance is not alive, it's removable.
       if (!HelixUtils.isLiveInstance(clusterName, instanceId, resources.getHelixManager())) {
         return NodeRemovableResult
-            .removableResult("Instance " + instanceId + " not found, either dead or wrong instance ID");
+            .removableResult("Instance " + instanceId + " not found in liveinstance set of cluster " + clusterName);
       }
 
       RoutingDataRepository routingDataRepository = resources.getRoutingDataRepository();

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/InstanceStatusDecider.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/InstanceStatusDecider.java
@@ -67,7 +67,8 @@ public class InstanceStatusDecider {
     try {
       // If instance is not alive, it's removable.
       if (!HelixUtils.isLiveInstance(clusterName, instanceId, resources.getHelixManager())) {
-        return NodeRemovableResult.removableResult();
+        return NodeRemovableResult
+            .removableResult("Instance " + instanceId + " not found, either dead or wrong instance ID");
       }
 
       RoutingDataRepository routingDataRepository = resources.getRoutingDataRepository();
@@ -145,7 +146,7 @@ public class InstanceStatusDecider {
           }
         }
       }
-      return NodeRemovableResult.removableResult();
+      return NodeRemovableResult.removableResult("Instance " + instanceId + " can be removed.");
     } catch (Exception e) {
       String errorMsg = "Can not verify whether instance " + instanceId + " is removable.";
       LOGGER.error(errorMsg, e);

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/NodeRemovableResult.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/NodeRemovableResult.java
@@ -10,6 +10,10 @@ public class NodeRemovableResult {
 
   }
 
+  private NodeRemovableResult(String details) {
+    this.details = details;
+  }
+
   public boolean isRemovable() {
     return isRemovable;
   }
@@ -26,8 +30,8 @@ public class NodeRemovableResult {
     return details;
   }
 
-  public static NodeRemovableResult removableResult() {
-    return new NodeRemovableResult();
+  public static NodeRemovableResult removableResult(String blockingReason) {
+    return new NodeRemovableResult(blockingReason);
   }
 
   /**

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/NodeRemovableResult.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/NodeRemovableResult.java
@@ -10,10 +10,6 @@ public class NodeRemovableResult {
 
   }
 
-  private NodeRemovableResult(String details) {
-    this.details = details;
-  }
-
   public boolean isRemovable() {
     return isRemovable;
   }
@@ -30,14 +26,16 @@ public class NodeRemovableResult {
     return details;
   }
 
-  public static NodeRemovableResult removableResult(String blockingReason) {
-    return new NodeRemovableResult(blockingReason);
+  public static NodeRemovableResult removableResult(String details) {
+    NodeRemovableResult result = new NodeRemovableResult();
+    result.details = details;
+    return result;
   }
 
   /**
    * @return a {@link NodeRemovableResult} object with specified parameters.
    */
-  public static NodeRemovableResult nonremoveableResult(
+  public static NodeRemovableResult nonRemovableResult(
       String blockingResource,
       BlockingRemoveReason blockingReason,
       String details) {


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Add compaction cancelled metric, add details to node_removabl
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Added compaction cancellation metric to get more insight on rocksdb SST file size usage. Also adds more details to node removable result to indicate why a node considered removable as passing wrong ID silently tells its removable.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
GHCI
## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.