### PR TITLE
[server] Best effort to extract optional collection type for type validation before Active/Active partial update collection operation

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/schema/SchemaUtils.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/schema/SchemaUtils.java
@@ -197,4 +197,17 @@ public class SchemaUtils {
         return fieldSchema.getType();
     }
   }
+
+  /**
+   * This method checks if the field contains expected type. It relies on {@link SchemaUtils#unwrapOptionalUnion(Schema)}
+   * to retrieve the type from the field if incoming field is union.
+   * If it could not find expected type, or the incoming union is not valid for processing, it will throw {@link IllegalStateException}
+   */
+  public static void validateFieldSchemaType(String fieldName, Schema fieldSchema, Schema.Type expectedType) {
+    final Schema.Type fieldSchemaType = SchemaUtils.unwrapOptionalUnion(fieldSchema);
+    if (fieldSchemaType != expectedType) {
+      throw new IllegalStateException(
+          String.format("Expect field %s to be of type %s. But got: %s", fieldName, expectedType, fieldSchemaType));
+    }
+  }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/schema/merge/SortBasedCollectionFieldOpHandler.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/schema/merge/SortBasedCollectionFieldOpHandler.java
@@ -2,6 +2,7 @@ package com.linkedin.davinci.schema.merge;
 
 import com.linkedin.avro.api.PrimitiveLongList;
 import com.linkedin.avro.fastserde.primitive.PrimitiveLongArrayList;
+import com.linkedin.davinci.schema.SchemaUtils;
 import com.linkedin.davinci.utils.IndexedHashMap;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.schema.rmd.v1.CollectionRmdTimestamp;
@@ -39,7 +40,7 @@ public class SortBasedCollectionFieldOpHandler extends CollectionFieldOperationH
     if (ignoreIncomingRequest(putTimestamp, coloID, collectionFieldRmd)) {
       return UpdateResultStatus.NOT_UPDATED_AT_ALL;
     }
-    validateFieldSchemaType(currValueRecordField, Schema.Type.ARRAY, true);
+    validateFieldSchemaType(currValueRecordField, Schema.Type.ARRAY);
 
     // Current list will be updated.
     final long currTopLevelTimestamp = collectionFieldRmd.getTopLevelFieldTimestamp();
@@ -170,16 +171,9 @@ public class SortBasedCollectionFieldOpHandler extends CollectionFieldOperationH
     deDupSet.clear(); // Try to be more GC friendly.
   }
 
-  private void validateFieldSchemaType(
-      Schema.Field currValueRecordField,
-      Schema.Type expectType,
-      boolean nullableAllowed) {
+  private void validateFieldSchemaType(Schema.Field currValueRecordField, Schema.Type expectType) {
     final Schema fieldSchema = currValueRecordField.schema();
-    final Schema.Type fieldSchemaType = fieldSchema.getType();
-    if (nullableAllowed && fieldSchemaType == Schema.Type.UNION) {
-      validateFieldSchemaIsNullableType(fieldSchema, expectType);
-      return;
-    }
+    final Schema.Type fieldSchemaType = SchemaUtils.unwrapOptionalUnion(fieldSchema);
     if (fieldSchemaType != expectType) {
       throw new IllegalStateException(
           String.format(
@@ -187,24 +181,6 @@ public class SortBasedCollectionFieldOpHandler extends CollectionFieldOperationH
               currValueRecordField.name(),
               expectType,
               fieldSchemaType));
-    }
-  }
-
-  private void validateFieldSchemaIsNullableType(Schema fieldSchema, Schema.Type expectType) {
-    // // Expect a nullable type. Expect a union of [null, expected type]
-    if (fieldSchema.getType() != Schema.Type.UNION) {
-      throw new IllegalStateException("Expect a union. Got field schema: " + fieldSchema);
-    }
-    if (fieldSchema.getTypes().size() != 2) {
-      throw new IllegalStateException("Expect a union of size 2. Got field schema: " + fieldSchema);
-    }
-    if (fieldSchema.getTypes().get(0).getType() != Schema.Type.NULL) {
-      throw new IllegalStateException(
-          "Expect the first element in the union to be null. Got field schema: " + fieldSchema);
-    }
-    if (fieldSchema.getTypes().get(1).getType() != expectType) {
-      throw new IllegalStateException(
-          "Expect the second element in the union to be the expected type. Got field schema: " + fieldSchema);
     }
   }
 
@@ -219,7 +195,7 @@ public class SortBasedCollectionFieldOpHandler extends CollectionFieldOperationH
     if (ignoreIncomingRequest(putTimestamp, coloID, collectionFieldRmd)) {
       return UpdateResultStatus.NOT_UPDATED_AT_ALL;
     }
-    validateFieldSchemaType(currValueRecordField, Schema.Type.MAP, true);
+    validateFieldSchemaType(currValueRecordField, Schema.Type.MAP);
     collectionFieldRmd.setTopLevelFieldTimestamp(putTimestamp);
     collectionFieldRmd.setTopLevelColoID(coloID);
     IndexedHashMap<String, Object> toPutMap;
@@ -318,7 +294,7 @@ public class SortBasedCollectionFieldOpHandler extends CollectionFieldOperationH
     if (ignoreIncomingRequest(deleteTimestamp, coloID, collectionFieldRmd)) {
       return UpdateResultStatus.NOT_UPDATED_AT_ALL;
     }
-    validateFieldSchemaType(currValueRecordField, Schema.Type.ARRAY, true);
+    validateFieldSchemaType(currValueRecordField, Schema.Type.ARRAY);
     // Current list will be deleted (partially or completely).
     final int currPutOnlyPartLength = collectionFieldRmd.getPutOnlyPartLength();
     collectionFieldRmd.setTopLevelFieldTimestamp(deleteTimestamp);
@@ -367,7 +343,7 @@ public class SortBasedCollectionFieldOpHandler extends CollectionFieldOperationH
     if (ignoreIncomingRequest(deleteTimestamp, coloID, collectionFieldRmd)) {
       return UpdateResultStatus.NOT_UPDATED_AT_ALL;
     }
-    validateFieldSchemaType(currValueRecordField, Schema.Type.MAP, true);
+    validateFieldSchemaType(currValueRecordField, Schema.Type.MAP);
     // Handle Delete on a map that is in the collection-merge mode.
     final int originalPutOnlyPartLength = collectionFieldRmd.getPutOnlyPartLength();
     final long originalTopLevelFieldTimestamp = collectionFieldRmd.getTopLevelFieldTimestamp();
@@ -419,7 +395,7 @@ public class SortBasedCollectionFieldOpHandler extends CollectionFieldOperationH
     if (ignoreIncomingRequest(modifyTimestamp, Integer.MIN_VALUE, collectionFieldRmd)) {
       return UpdateResultStatus.NOT_UPDATED_AT_ALL;
     }
-    validateFieldSchemaType(currValueRecordField, Schema.Type.ARRAY, true);
+    validateFieldSchemaType(currValueRecordField, Schema.Type.ARRAY);
     Set<Object> toAddElementSet = new HashSet<>(toAddElements);
     Set<Object> toRemoveElementSet = new HashSet<>(toRemoveElements);
     removeIntersectionElements(toAddElementSet, toRemoveElementSet);
@@ -751,7 +727,7 @@ public class SortBasedCollectionFieldOpHandler extends CollectionFieldOperationH
     if (ignoreIncomingRequest(modifyTimestamp, Integer.MIN_VALUE, collectionFieldRmd)) {
       return UpdateResultStatus.NOT_UPDATED_AT_ALL;
     }
-    validateFieldSchemaType(currValueRecordField, Schema.Type.MAP, true);
+    validateFieldSchemaType(currValueRecordField, Schema.Type.MAP);
     if (toRemoveKeys.isEmpty() && newEntries.isEmpty()) {
       return UpdateResultStatus.NOT_UPDATED_AT_ALL;
     }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/schema/merge/SortBasedCollectionFieldOpHandler.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/schema/merge/SortBasedCollectionFieldOpHandler.java
@@ -40,7 +40,7 @@ public class SortBasedCollectionFieldOpHandler extends CollectionFieldOperationH
     if (ignoreIncomingRequest(putTimestamp, coloID, collectionFieldRmd)) {
       return UpdateResultStatus.NOT_UPDATED_AT_ALL;
     }
-    validateFieldSchemaType(currValueRecordField, Schema.Type.ARRAY);
+    SchemaUtils.validateFieldSchemaType(currValueRecordField.name(), currValueRecordField.schema(), Schema.Type.ARRAY);
 
     // Current list will be updated.
     final long currTopLevelTimestamp = collectionFieldRmd.getTopLevelFieldTimestamp();
@@ -171,19 +171,6 @@ public class SortBasedCollectionFieldOpHandler extends CollectionFieldOperationH
     deDupSet.clear(); // Try to be more GC friendly.
   }
 
-  private void validateFieldSchemaType(Schema.Field currValueRecordField, Schema.Type expectType) {
-    final Schema fieldSchema = currValueRecordField.schema();
-    final Schema.Type fieldSchemaType = SchemaUtils.unwrapOptionalUnion(fieldSchema);
-    if (fieldSchemaType != expectType) {
-      throw new IllegalStateException(
-          String.format(
-              "Expect field %s to be of type %s. But got: %s",
-              currValueRecordField.name(),
-              expectType,
-              fieldSchemaType));
-    }
-  }
-
   @Override
   public UpdateResultStatus handlePutMap(
       final long putTimestamp,
@@ -195,7 +182,7 @@ public class SortBasedCollectionFieldOpHandler extends CollectionFieldOperationH
     if (ignoreIncomingRequest(putTimestamp, coloID, collectionFieldRmd)) {
       return UpdateResultStatus.NOT_UPDATED_AT_ALL;
     }
-    validateFieldSchemaType(currValueRecordField, Schema.Type.MAP);
+    SchemaUtils.validateFieldSchemaType(currValueRecordField.name(), currValueRecordField.schema(), Schema.Type.MAP);
     collectionFieldRmd.setTopLevelFieldTimestamp(putTimestamp);
     collectionFieldRmd.setTopLevelColoID(coloID);
     IndexedHashMap<String, Object> toPutMap;
@@ -294,7 +281,7 @@ public class SortBasedCollectionFieldOpHandler extends CollectionFieldOperationH
     if (ignoreIncomingRequest(deleteTimestamp, coloID, collectionFieldRmd)) {
       return UpdateResultStatus.NOT_UPDATED_AT_ALL;
     }
-    validateFieldSchemaType(currValueRecordField, Schema.Type.ARRAY);
+    SchemaUtils.validateFieldSchemaType(currValueRecordField.name(), currValueRecordField.schema(), Schema.Type.ARRAY);
     // Current list will be deleted (partially or completely).
     final int currPutOnlyPartLength = collectionFieldRmd.getPutOnlyPartLength();
     collectionFieldRmd.setTopLevelFieldTimestamp(deleteTimestamp);
@@ -343,7 +330,7 @@ public class SortBasedCollectionFieldOpHandler extends CollectionFieldOperationH
     if (ignoreIncomingRequest(deleteTimestamp, coloID, collectionFieldRmd)) {
       return UpdateResultStatus.NOT_UPDATED_AT_ALL;
     }
-    validateFieldSchemaType(currValueRecordField, Schema.Type.MAP);
+    SchemaUtils.validateFieldSchemaType(currValueRecordField.name(), currValueRecordField.schema(), Schema.Type.MAP);
     // Handle Delete on a map that is in the collection-merge mode.
     final int originalPutOnlyPartLength = collectionFieldRmd.getPutOnlyPartLength();
     final long originalTopLevelFieldTimestamp = collectionFieldRmd.getTopLevelFieldTimestamp();
@@ -395,7 +382,7 @@ public class SortBasedCollectionFieldOpHandler extends CollectionFieldOperationH
     if (ignoreIncomingRequest(modifyTimestamp, Integer.MIN_VALUE, collectionFieldRmd)) {
       return UpdateResultStatus.NOT_UPDATED_AT_ALL;
     }
-    validateFieldSchemaType(currValueRecordField, Schema.Type.ARRAY);
+    SchemaUtils.validateFieldSchemaType(currValueRecordField.name(), currValueRecordField.schema(), Schema.Type.ARRAY);
     Set<Object> toAddElementSet = new HashSet<>(toAddElements);
     Set<Object> toRemoveElementSet = new HashSet<>(toRemoveElements);
     removeIntersectionElements(toAddElementSet, toRemoveElementSet);
@@ -727,7 +714,7 @@ public class SortBasedCollectionFieldOpHandler extends CollectionFieldOperationH
     if (ignoreIncomingRequest(modifyTimestamp, Integer.MIN_VALUE, collectionFieldRmd)) {
       return UpdateResultStatus.NOT_UPDATED_AT_ALL;
     }
-    validateFieldSchemaType(currValueRecordField, Schema.Type.MAP);
+    SchemaUtils.validateFieldSchemaType(currValueRecordField.name(), currValueRecordField.schema(), Schema.Type.MAP);
     if (toRemoveKeys.isEmpty() && newEntries.isEmpty()) {
       return UpdateResultStatus.NOT_UPDATED_AT_ALL;
     }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/schema/TestSchemaUtils.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/schema/TestSchemaUtils.java
@@ -177,6 +177,26 @@ public class TestSchemaUtils {
     assertTrue(SchemaUtils.unwrapOptionalUnion(nullAndTypeAndOtherTypeUnion) == UNION);
   }
 
+  @Test(dataProviderClass = DataProviderUtils.class, dataProvider = "All-Avro-Schemas-Except-Null-And-Union")
+  public void testValidateFieldSchemaType(Schema type) {
+    Schema nullAndTypeUnion = Schema.createUnion(Schema.create(NULL), type);
+    SchemaUtils.validateFieldSchemaType("field", nullAndTypeUnion, type.getType());
+
+    Schema typeAndNullUnion = Schema.createUnion(type, Schema.create(NULL));
+    SchemaUtils.validateFieldSchemaType("field", typeAndNullUnion, type.getType());
+
+    Schema singleTypeOnlyUnion = Schema.createUnion(type);
+    SchemaUtils.validateFieldSchemaType("field", singleTypeOnlyUnion, type.getType());
+
+    Schema other = Schema.create(type.getType() == INT ? LONG : INT);
+    Schema typeAndOtherTypeUnion = Schema.createUnion(type, other);
+    Assert.assertThrows(() -> SchemaUtils.validateFieldSchemaType("field", typeAndOtherTypeUnion, type.getType()));
+
+    Schema nullAndTypeAndOtherTypeUnion = Schema.createUnion(Schema.create(NULL), type, other);
+    Assert
+        .assertThrows(() -> SchemaUtils.validateFieldSchemaType("field", nullAndTypeAndOtherTypeUnion, type.getType()));
+  }
+
   protected RecordSerializer<GenericRecord> getSerializer(Schema writerSchema) {
     return MapOrderPreservingSerDeFactory.getAvroGenericSerializer(writerSchema);
   }


### PR DESCRIPTION

<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## [server] Best effort to extract optional collection type for type validation before Active/Active partial update collection operation
This PR removes strict optional collection type check before applying collection partial update in Active/Active store.
Previously it requires [null, collection] to be the union collection schema. This PR uses the SchemaUtils.unwrapOptionalUnion() API to retrieve the collection type.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.