### PR TITLE
[admin-tool] Enable venice-admin-tool to parse JSON map arguments from command line

### DIFF
--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/AdminTool.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/AdminTool.java
@@ -992,7 +992,7 @@ public class AdminTool {
       Arg param,
       Consumer<Map<String, String>> setter,
       Set<Arg> argSet) {
-    genericParam(cmd, param, s -> Utils.parseCommaSeparatedStringMapFromString(s, param.toString()), setter, argSet);
+    genericParam(cmd, param, s -> Utils.parseJsonMapFromString(s, param.toString()), setter, argSet);
   }
 
   private static void stringSetParam(CommandLine cmd, Arg param, Consumer<Set<String>> setter, Set<Arg> argSet) {

--- a/clients/venice-admin-tool/src/test/java/com/linkedin/venice/TestAdminTool.java
+++ b/clients/venice-admin-tool/src/test/java/com/linkedin/venice/TestAdminTool.java
@@ -75,7 +75,7 @@ public class TestAdminTool {
     final String K1 = "k1", V1 = "v1", K2 = "k2", V2 = "v2", K3 = "k3", V3 = "v3";
     String[] args = { "--update-store", "--url", "http://localhost:7036", "--cluster", "test-cluster", "--store",
         "testStore", "--rmd-chunking-enabled", "true", "--partitioner-params",
-        K1 + "=" + V1 + "," + K2 + "=" + V2 + "," + K3 + "=" + V3 };
+        "{\"" + K1 + "\":\"" + V1 + "\",\"" + K2 + "\":\"" + V2 + "\",\"" + K3 + "\":\"" + V3 + "\"}" };
 
     CommandLine commandLine = AdminTool.getCommandLine(args);
     UpdateStoreQueryParams params = AdminTool.getUpdateStoreQueryParams(commandLine);
@@ -293,7 +293,7 @@ public class TestAdminTool {
     // Case 1: Happy path to setup a view.
     String[] args = { "--configure-store-view", "--url", "http://localhost:7036", "--cluster", "test-cluster",
         "--store", "testStore", "--view-name", "testView", "--view-class", ChangeCaptureView.class.getCanonicalName(),
-        "--view-params", K1 + "=" + V1 + "," + K2 + "=" + V2 };
+        "--view-params", "{\"" + K1 + "\":\"" + V1 + "\",\"" + K2 + "\":\"" + V2 + "\"}" };
 
     CommandLine commandLine = AdminTool.getCommandLine(args);
     UpdateStoreQueryParams params = AdminTool.getConfigureStoreViewQueryParams(commandLine);

--- a/internal/venice-common/src/main/java/com/linkedin/venice/utils/Utils.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/utils/Utils.java
@@ -321,8 +321,7 @@ public class Utils {
       }
       return map;
     } catch (IOException jsonException) {
-      throw new VeniceException(
-          fieldName + " must be a valid JSON object or key-value pairs separated by comma, but value: " + value);
+      throw new VeniceException(fieldName + " must be a valid JSON object, but value: " + value);
     }
   }
 

--- a/internal/venice-common/src/main/java/com/linkedin/venice/utils/Utils.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/utils/Utils.java
@@ -2,7 +2,7 @@ package com.linkedin.venice.utils;
 
 import static com.linkedin.venice.HttpConstants.LOCALHOST;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
 import com.linkedin.venice.controllerapi.ControllerResponse;
@@ -308,35 +308,21 @@ public class Utils {
   }
 
   /**
-   * For String-String key-value map config, we expect the command-line interface users to use "key1=value1,key2=value2,..."
+   * For String-String key-value map config, we expect the command-line interface users to use JSON
    * format to represent it. This method deserialize it to String-String map.
    */
-  public static Map<String, String> parseCommaSeparatedStringMapFromString(String value, String fieldName) {
+  public static Map<String, String> parseJsonMapFromString(String value, String fieldName) {
     try {
       Map<String, String> map = new HashMap<>();
       if (!value.isEmpty()) {
-        ObjectMapper objectMapper = new ObjectMapper();
-        JsonNode rootNode = objectMapper.readTree(value);
-
-        rootNode.fieldNames().forEachRemaining(key -> {
-          JsonNode childNode = rootNode.get(key);
-          if (childNode.isObject()) {
-            map.put(key, childNode.toString());
-          } else {
-            map.put(key, childNode.asText());
-          }
+        ObjectMapper objectMapper = ObjectMapperFactory.getInstance();
+        return objectMapper.readValue(value, new TypeReference<Map<String, String>>() {
         });
       }
       return map;
     } catch (IOException jsonException) {
-      try {
-        Map<String, String> map = new HashMap<>();
-        Arrays.stream(value.split(",")).map(s -> s.split("=")).forEach(strings -> map.put(strings[0], strings[1]));
-        return map;
-      } catch (Exception kvException) {
-        throw new VeniceException(
-            fieldName + " must be a valid JSON object or key-value pairs separated by comma, but value: " + value);
-      }
+      throw new VeniceException(
+          fieldName + " must be a valid JSON object or key-value pairs separated by comma, but value: " + value);
     }
   }
 

--- a/internal/venice-common/src/test/java/com/linkedin/venice/utils/UtilsTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/utils/UtilsTest.java
@@ -1,6 +1,9 @@
 package com.linkedin.venice.utils;
 
-import static org.testng.Assert.*;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.expectThrows;
+import static org.testng.Assert.fail;
 
 import com.linkedin.venice.exceptions.VeniceException;
 import java.nio.file.Files;

--- a/internal/venice-common/src/test/java/com/linkedin/venice/utils/UtilsTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/utils/UtilsTest.java
@@ -1,9 +1,6 @@
 package com.linkedin.venice.utils;
 
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertTrue;
-import static org.testng.Assert.expectThrows;
-import static org.testng.Assert.fail;
+import static org.testng.Assert.*;
 
 import com.linkedin.venice.exceptions.VeniceException;
 import java.nio.file.Files;
@@ -167,36 +164,20 @@ public class UtilsTest {
 
   @Test
   public void testParseMap() {
-    assertEquals(Utils.parseJsonMapFromString("", "test_field").size(), 0);
-    Map nonEmptyMap = Utils.parseJsonMapFromString("a=b", "test_field");
     Map expectedMap = new HashMap<>();
     expectedMap.put("a", "b");
-    assertEquals(nonEmptyMap, expectedMap);
 
-    VeniceException e =
-        expectThrows(VeniceException.class, () -> Utils.parseJsonMapFromString("invalid_value", "test_field"));
-    assertTrue(e.getMessage().contains("must be key value pairs separated by comma"));
+    assertEquals(Utils.parseJsonMapFromString("", "test_field").size(), 0);
+    Map validMap = Utils.parseJsonMapFromString("{\"a\":\"b\"}", "test_field");
+    assertEquals(validMap, expectedMap);
+
+    VeniceException e = expectThrows(VeniceException.class, () -> Utils.parseJsonMapFromString("a=b", "test_field"));
+    assertTrue(e.getMessage().contains("must be a valid JSON object"));
+
   }
 
   @Test
   public void testSanitizingStringForLogger() {
     Assert.assertEquals(Utils.getSanitizedStringForLogger(".abc.123."), "_abc_123_");
-  }
-
-  @Test
-  public void testParseJsonMapFromString() {
-    try {
-      Utils.parseJsonMapFromString(
-          "{\"changeCaptureView\": {\"viewClassName\": \"com.linkedin.venice.views.ChangeCaptureView\",\"params\": {}}}",
-          "someField"); // Method that should not throw an exception
-    } catch (Exception e) {
-      fail("Expected no exception to be thrown, but got: " + e.getMessage());
-    }
-
-    Assert.assertThrows(
-        VeniceException.class,
-        () -> Utils.parseJsonMapFromString(
-            "{\"changeCaptureView\": {\"viewClassName\": \"com.linkedin.venice.views.ChangeCaptureView\",\"params\":",
-            "someField"));
   }
 }

--- a/internal/venice-common/src/test/java/com/linkedin/venice/utils/UtilsTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/utils/UtilsTest.java
@@ -167,15 +167,14 @@ public class UtilsTest {
 
   @Test
   public void testParseMap() {
-    assertEquals(Utils.parseCommaSeparatedStringMapFromString("", "test_field").size(), 0);
-    Map nonEmptyMap = Utils.parseCommaSeparatedStringMapFromString("a=b", "test_field");
+    assertEquals(Utils.parseJsonMapFromString("", "test_field").size(), 0);
+    Map nonEmptyMap = Utils.parseJsonMapFromString("a=b", "test_field");
     Map expectedMap = new HashMap<>();
     expectedMap.put("a", "b");
     assertEquals(nonEmptyMap, expectedMap);
 
-    VeniceException e = expectThrows(
-        VeniceException.class,
-        () -> Utils.parseCommaSeparatedStringMapFromString("invalid_value", "test_field"));
+    VeniceException e =
+        expectThrows(VeniceException.class, () -> Utils.parseJsonMapFromString("invalid_value", "test_field"));
     assertTrue(e.getMessage().contains("must be key value pairs separated by comma"));
   }
 
@@ -185,9 +184,9 @@ public class UtilsTest {
   }
 
   @Test
-  public void testParseCommaSeparatedStringMapFromString() {
+  public void testParseJsonMapFromString() {
     try {
-      Utils.parseCommaSeparatedStringMapFromString(
+      Utils.parseJsonMapFromString(
           "{\"changeCaptureView\": {\"viewClassName\": \"com.linkedin.venice.views.ChangeCaptureView\",\"params\": {}}}",
           "someField"); // Method that should not throw an exception
     } catch (Exception e) {
@@ -196,7 +195,7 @@ public class UtilsTest {
 
     Assert.assertThrows(
         VeniceException.class,
-        () -> Utils.parseCommaSeparatedStringMapFromString(
+        () -> Utils.parseJsonMapFromString(
             "{\"changeCaptureView\": {\"viewClassName\": \"com.linkedin.venice.views.ChangeCaptureView\",\"params\":",
             "someField"));
   }

--- a/internal/venice-common/src/test/java/com/linkedin/venice/utils/UtilsTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/utils/UtilsTest.java
@@ -183,4 +183,21 @@ public class UtilsTest {
   public void testSanitizingStringForLogger() {
     Assert.assertEquals(Utils.getSanitizedStringForLogger(".abc.123."), "_abc_123_");
   }
+
+  @Test
+  public void testParseCommaSeparatedStringMapFromString() {
+    try {
+      Utils.parseCommaSeparatedStringMapFromString(
+          "{\"changeCaptureView\": {\"viewClassName\": \"com.linkedin.venice.views.ChangeCaptureView\",\"params\": {}}}",
+          "someField"); // Method that should not throw an exception
+    } catch (Exception e) {
+      fail("Expected no exception to be thrown, but got: " + e.getMessage());
+    }
+
+    Assert.assertThrows(
+        VeniceException.class,
+        () -> Utils.parseCommaSeparatedStringMapFromString(
+            "{\"changeCaptureView\": {\"viewClassName\": \"com.linkedin.venice.views.ChangeCaptureView\",\"params\":",
+            "someField"));
+  }
 }


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Enable venice-admin-tool to parse JSON map arguments from command line
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
Added correct JSON parsing for command line inputs to admin-tool to read maps as JSON

Resolves #647 

## How was this PR tested?
CI
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.