### PR TITLE
[server] Move rocksdb compaction cancelled metric under RocksDBStats

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/RocksDBMemoryStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/RocksDBMemoryStats.java
@@ -38,7 +38,6 @@ public class RocksDBMemoryStats extends AbstractVeniceStats {
       "rocksdb.cur-size-all-mem-tables",
       "rocksdb.size-all-mem-tables",
       "rocksdb.num-entries-active-mem-table",
-      "rocksdb.compaction.cancelled",
       "rocksdb.num-entries-imm-mem-tables",
       "rocksdb.num-deletes-active-mem-table",
       "rocksdb.num-deletes-imm-mem-tables",

--- a/services/venice-server/src/main/java/com/linkedin/venice/stats/RocksDBStats.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/stats/RocksDBStats.java
@@ -21,6 +21,7 @@ import static org.rocksdb.TickerType.BLOCK_CACHE_INDEX_HIT;
 import static org.rocksdb.TickerType.BLOCK_CACHE_INDEX_MISS;
 import static org.rocksdb.TickerType.BLOCK_CACHE_MISS;
 import static org.rocksdb.TickerType.BLOOM_FILTER_USEFUL;
+import static org.rocksdb.TickerType.COMPACTION_CANCELLED;
 import static org.rocksdb.TickerType.GET_HIT_L0;
 import static org.rocksdb.TickerType.GET_HIT_L1;
 import static org.rocksdb.TickerType.GET_HIT_L2_AND_UP;
@@ -72,6 +73,7 @@ public class RocksDBStats extends AbstractVeniceStats {
 
   // we'll need to enable read_amp_bytes_per_bit in rocksDB config
   private final Sensor readAmplificationFactor;
+  private final Sensor compactionCancelled;
 
   public RocksDBStats(MetricsRepository metricsRepository, String name) {
     super(metricsRepository, name);
@@ -107,6 +109,7 @@ public class RocksDBStats extends AbstractVeniceStats {
     this.getHitL0 = registerSensor("rocksdb_get_hit_l0", GET_HIT_L0);
     this.getHitL1 = registerSensor("rocksdb_get_hit_l1", GET_HIT_L1);
     this.getHitL2AndUp = registerSensor("rocksdb_get_hit_l2_and_up", GET_HIT_L2_AND_UP);
+    this.compactionCancelled = registerSensor("rocksdb_compaction_cancelled", COMPACTION_CANCELLED);
 
     this.blockCacheHitRatio = registerSensor("rocksdb_block_cache_hit_ratio", new Gauge(() -> {
       if (rocksDBStat != null) {


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Move rocksdb compaction cancelled under aggr stat
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
GHCI
## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.