### PR TITLE
[controller] Add metric for disabled partition map.

### DIFF
--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/HelixVeniceClusterResources.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/HelixVeniceClusterResources.java
@@ -166,7 +166,8 @@ public class HelixVeniceClusterResources implements VeniceResource {
         getActiveActiveRealTimeSourceKafkaURLs(config),
         helixAdminClient,
         config,
-        admin.getPushStatusStoreReader().orElse(null));
+        admin.getPushStatusStoreReader().orElse(null),
+        metricsRepository);
 
     this.leakedPushStatusCleanUpService = new LeakedPushStatusCleanUpService(
         clusterName,

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/stats/DisabledPartitionStats.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/stats/DisabledPartitionStats.java
@@ -1,0 +1,21 @@
+package com.linkedin.venice.controller.stats;
+
+import com.linkedin.venice.stats.AbstractVeniceStats;
+import io.tehuti.metrics.MetricsRepository;
+import io.tehuti.metrics.Sensor;
+import io.tehuti.metrics.stats.Count;
+
+
+public class DisabledPartitionStats extends AbstractVeniceStats {
+  private final Sensor disabledPartitionCount;
+
+  public DisabledPartitionStats(MetricsRepository metricsRepository, String name) {
+    super(metricsRepository, name);
+    disabledPartitionCount = registerSensorIfAbsent("disabled_partition_count", new Count());
+  }
+
+  public void recordDisabledPartition() {
+    disabledPartitionCount.record();
+  }
+
+}

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/stats/ErrorPartitionStats.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/stats/ErrorPartitionStats.java
@@ -15,6 +15,7 @@ public class ErrorPartitionStats extends AbstractVeniceStats {
   private final Sensor currentVersionErrorPartitionRecoveredFromReset;
   private final Sensor currentVersionErrorPartitionUnrecoverableFromReset;
   private final Sensor errorPartitionProcessingTime;
+  private final Sensor disabledPartitionCount;
 
   public ErrorPartitionStats(MetricsRepository metricsRepository, String name) {
     super(metricsRepository, name);
@@ -28,6 +29,7 @@ public class ErrorPartitionStats extends AbstractVeniceStats {
     currentVersionErrorPartitionUnrecoverableFromReset =
         registerSensorIfAbsent("current_version_error_partition_unrecoverable_from_reset", new Total());
     errorPartitionProcessingTime = registerSensorIfAbsent("error_partition_processing_time", new Avg(), new Max());
+    disabledPartitionCount = registerSensorIfAbsent("disabled_partition_count", new Count());
   }
 
   public void recordErrorPartitionResetAttempt(double value) {
@@ -40,6 +42,10 @@ public class ErrorPartitionStats extends AbstractVeniceStats {
 
   public void recordErrorPartitionRecoveredFromReset() {
     currentVersionErrorPartitionRecoveredFromReset.record();
+  }
+
+  public void recordDisabledPartition() {
+    disabledPartitionCount.record();
   }
 
   public void recordErrorPartitionUnrecoverableFromReset() {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/stats/ErrorPartitionStats.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/stats/ErrorPartitionStats.java
@@ -15,7 +15,6 @@ public class ErrorPartitionStats extends AbstractVeniceStats {
   private final Sensor currentVersionErrorPartitionRecoveredFromReset;
   private final Sensor currentVersionErrorPartitionUnrecoverableFromReset;
   private final Sensor errorPartitionProcessingTime;
-  private final Sensor disabledPartitionCount;
 
   public ErrorPartitionStats(MetricsRepository metricsRepository, String name) {
     super(metricsRepository, name);
@@ -29,7 +28,6 @@ public class ErrorPartitionStats extends AbstractVeniceStats {
     currentVersionErrorPartitionUnrecoverableFromReset =
         registerSensorIfAbsent("current_version_error_partition_unrecoverable_from_reset", new Total());
     errorPartitionProcessingTime = registerSensorIfAbsent("error_partition_processing_time", new Avg(), new Max());
-    disabledPartitionCount = registerSensorIfAbsent("disabled_partition_count", new Count());
   }
 
   public void recordErrorPartitionResetAttempt(double value) {
@@ -42,10 +40,6 @@ public class ErrorPartitionStats extends AbstractVeniceStats {
 
   public void recordErrorPartitionRecoveredFromReset() {
     currentVersionErrorPartitionRecoveredFromReset.record();
-  }
-
-  public void recordDisabledPartition() {
-    disabledPartitionCount.record();
   }
 
   public void recordErrorPartitionUnrecoverableFromReset() {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/AbstractPushMonitor.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/AbstractPushMonitor.java
@@ -10,7 +10,7 @@ import static com.linkedin.venice.pushmonitor.OfflinePushStatus.HELIX_RESOURCE_N
 
 import com.linkedin.venice.controller.HelixAdminClient;
 import com.linkedin.venice.controller.VeniceControllerConfig;
-import com.linkedin.venice.controller.stats.ErrorPartitionStats;
+import com.linkedin.venice.controller.stats.DisabledPartitionStats;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.exceptions.VeniceNoStoreException;
 import com.linkedin.venice.helix.HelixCustomizedViewOfflinePushRepository;
@@ -84,7 +84,7 @@ public abstract class AbstractPushMonitor
   private final long offlineJobResourceAssignmentWaitTimeInMilliseconds;
 
   private final PushStatusCollector pushStatusCollector;
-  private final ErrorPartitionStats errorPartitionStats;
+  private final DisabledPartitionStats disabledPartitionStats;
 
   private final boolean isOfflinePushMonitorDaVinciPushStatusEnabled;
 
@@ -114,7 +114,7 @@ public abstract class AbstractPushMonitor
     this.aggregateRealTimeSourceKafkaUrl = aggregateRealTimeSourceKafkaUrl;
     this.activeActiveRealTimeSourceKafkaURLs = activeActiveRealTimeSourceKafkaURLs;
     this.helixAdminClient = helixAdminClient;
-    this.errorPartitionStats = new ErrorPartitionStats(metricsRepository, clusterName);
+    this.disabledPartitionStats = new DisabledPartitionStats(metricsRepository, clusterName);
 
     this.disableErrorLeaderReplica = controllerConfig.isErrorLeaderReplicaFailOverEnabled();
     this.helixClientThrottler =
@@ -761,7 +761,7 @@ public abstract class AbstractPushMonitor
             kafkaTopic,
             Collections.singletonList(HelixUtils.getPartitionName(kafkaTopic, partitionId)));
         disabledReplicaMap.computeIfAbsent(instance, k -> new HashSet<>()).add(partitionId);
-        errorPartitionStats.recordDisabledPartition();
+        disabledPartitionStats.recordDisabledPartition();
       }
 
       @Override

--- a/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/PartitionStatusBasedPushMonitor.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/PartitionStatusBasedPushMonitor.java
@@ -10,6 +10,7 @@ import com.linkedin.venice.meta.RoutingDataRepository;
 import com.linkedin.venice.meta.StoreCleaner;
 import com.linkedin.venice.pushstatushelper.PushStatusStoreReader;
 import com.linkedin.venice.utils.locks.ClusterLockManager;
+import io.tehuti.metrics.MetricsRepository;
 import java.util.List;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -36,7 +37,8 @@ public class PartitionStatusBasedPushMonitor extends AbstractPushMonitor {
       List<String> childDataCenterKafkaUrls,
       HelixAdminClient helixAdminClient,
       VeniceControllerConfig controllerConfig,
-      PushStatusStoreReader pushStatusStoreReader) {
+      PushStatusStoreReader pushStatusStoreReader,
+      MetricsRepository metricsRepository) {
     super(
         clusterName,
         offlinePushAccessor,
@@ -50,7 +52,8 @@ public class PartitionStatusBasedPushMonitor extends AbstractPushMonitor {
         childDataCenterKafkaUrls,
         helixAdminClient,
         controllerConfig,
-        pushStatusStoreReader);
+        pushStatusStoreReader,
+        metricsRepository);
   }
 
   @Override

--- a/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/PushMonitorDelegator.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/PushMonitorDelegator.java
@@ -18,6 +18,7 @@ import com.linkedin.venice.pushstatushelper.PushStatusStoreReader;
 import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
 import com.linkedin.venice.utils.locks.AutoCloseableLock;
 import com.linkedin.venice.utils.locks.ClusterLockManager;
+import io.tehuti.metrics.MetricsRepository;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -55,7 +56,8 @@ public class PushMonitorDelegator implements PushMonitor {
       List<String> activeActiveRealTimeSourceKafkaURLs,
       HelixAdminClient helixAdminClient,
       VeniceControllerConfig controllerConfig,
-      PushStatusStoreReader pushStatusStoreReader) {
+      PushStatusStoreReader pushStatusStoreReader,
+      MetricsRepository metricsRepository) {
     this.clusterName = clusterName;
     this.metadataRepository = metadataRepository;
 
@@ -72,7 +74,8 @@ public class PushMonitorDelegator implements PushMonitor {
         activeActiveRealTimeSourceKafkaURLs,
         helixAdminClient,
         controllerConfig,
-        pushStatusStoreReader);
+        pushStatusStoreReader,
+        metricsRepository);
     this.clusterLockManager = clusterLockManager;
 
     this.topicToPushMonitorMap = new VeniceConcurrentHashMap<>();

--- a/services/venice-controller/src/test/java/com/linkedin/venice/pushmonitor/AbstractPushMonitorTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/pushmonitor/AbstractPushMonitorTest.java
@@ -43,6 +43,8 @@ import com.linkedin.venice.utils.Time;
 import com.linkedin.venice.utils.Utils;
 import com.linkedin.venice.utils.locks.AutoCloseableLock;
 import com.linkedin.venice.utils.locks.ClusterLockManager;
+import io.tehuti.metrics.MetricsRepository;
+import io.tehuti.metrics.Sensor;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.EnumMap;
@@ -70,6 +72,8 @@ public abstract class AbstractPushMonitorTest {
 
   protected VeniceControllerConfig mockControllerConfig;
 
+  protected MetricsRepository mockMetricRepo;
+
   private final static String clusterName = Utils.getUniqueString("test_cluster");
   private final static String aggregateRealTimeSourceKafkaUrl = "aggregate-real-time-source-kafka-url";
   private String storeName;
@@ -94,10 +98,12 @@ public abstract class AbstractPushMonitorTest {
     mockAccessor = mock(OfflinePushAccessor.class);
     mockStoreCleaner = mock(StoreCleaner.class);
     mockStoreRepo = mock(ReadWriteStoreRepository.class);
+    mockMetricRepo = mock(MetricsRepository.class);
     mockRoutingDataRepo = mock(RoutingDataRepository.class);
     mockPushHealthStats = mock(AggPushHealthStats.class);
     clusterLockManager = new ClusterLockManager(clusterName);
     mockControllerConfig = mock(VeniceControllerConfig.class);
+    when(mockMetricRepo.sensor(anyString(), any())).thenReturn(mock(Sensor.class));
     when(mockControllerConfig.isErrorLeaderReplicaFailOverEnabled()).thenReturn(true);
     when(mockControllerConfig.isDaVinciPushStatusEnabled()).thenReturn(true);
     when(mockControllerConfig.getDaVinciPushStatusScanIntervalInSeconds()).thenReturn(5);

--- a/services/venice-controller/src/test/java/com/linkedin/venice/pushmonitor/PartitionStatusBasedPushMonitorTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/pushmonitor/PartitionStatusBasedPushMonitorTest.java
@@ -30,6 +30,7 @@ import com.linkedin.venice.meta.VersionImpl;
 import com.linkedin.venice.utils.HelixUtils;
 import com.linkedin.venice.utils.TestUtils;
 import com.linkedin.venice.utils.Time;
+import io.tehuti.metrics.MetricsRepository;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -61,6 +62,7 @@ public class PartitionStatusBasedPushMonitorTest extends AbstractPushMonitorTest
         Collections.emptyList(),
         helixAdminClient,
         getMockControllerConfig(),
+        null,
         null);
   }
 
@@ -79,7 +81,8 @@ public class PartitionStatusBasedPushMonitorTest extends AbstractPushMonitorTest
         Collections.emptyList(),
         mock(HelixAdminClient.class),
         getMockControllerConfig(),
-        null);
+        null,
+        mock(MetricsRepository.class));
   }
 
   @Test

--- a/services/venice-controller/src/test/java/com/linkedin/venice/pushmonitor/PartitionStatusBasedPushMonitorTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/pushmonitor/PartitionStatusBasedPushMonitorTest.java
@@ -30,7 +30,6 @@ import com.linkedin.venice.meta.VersionImpl;
 import com.linkedin.venice.utils.HelixUtils;
 import com.linkedin.venice.utils.TestUtils;
 import com.linkedin.venice.utils.Time;
-import io.tehuti.metrics.MetricsRepository;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -63,7 +62,7 @@ public class PartitionStatusBasedPushMonitorTest extends AbstractPushMonitorTest
         helixAdminClient,
         getMockControllerConfig(),
         null,
-        null);
+        mockMetricRepo);
   }
 
   @Override
@@ -82,7 +81,7 @@ public class PartitionStatusBasedPushMonitorTest extends AbstractPushMonitorTest
         mock(HelixAdminClient.class),
         getMockControllerConfig(),
         null,
-        mock(MetricsRepository.class));
+        mockMetricRepo);
   }
 
   @Test


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

##  Add metric for disabled partition map.
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Since disabled metric can cause a cluster to be in undeployable state, this PR is adding an alert to indicate disabled partition per cluster. 
The proposed action would be for oncall to investigate what error caused the alert and mitigate by restarting those hosts.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.