### PR TITLE
[changelog] Tweak after image consumer to not consume view topic

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/ChangelogClientConfig.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/ChangelogClientConfig.java
@@ -20,6 +20,8 @@ public class ChangelogClientConfig<T extends SpecificRecord> {
 
   private String bootstrapFileSystemPath;
 
+  private long versionSwapDetectionIntervalTimeInMs = 600000L;
+
   public ChangelogClientConfig(String storeName) {
     this.innerClientConfig = new ClientConfig<>(storeName);
   }
@@ -131,6 +133,15 @@ public class ChangelogClientConfig<T extends SpecificRecord> {
     return this.bootstrapFileSystemPath;
   }
 
+  public long getVersionSwapDetectionIntervalTimeInMs() {
+    return versionSwapDetectionIntervalTimeInMs;
+  }
+
+  public ChangelogClientConfig setVersionSwapDetectionIntervalTimeInMs(long intervalTimeInMs) {
+    this.versionSwapDetectionIntervalTimeInMs = intervalTimeInMs;
+    return this;
+  }
+
   public static <V extends SpecificRecord> ChangelogClientConfig<V> cloneConfig(ChangelogClientConfig<V> config) {
     ChangelogClientConfig<V> newConfig = new ChangelogClientConfig<V>().setStoreName(config.getStoreName())
         .setLocalD2ZkHosts(config.getLocalD2ZkHosts())
@@ -142,7 +153,8 @@ public class ChangelogClientConfig<T extends SpecificRecord> {
         .setControllerD2ServiceName(config.controllerD2ServiceName)
         .setD2Client(config.getD2Client())
         .setControllerRequestRetryCount(config.getControllerRequestRetryCount())
-        .setBootstrapFileSystemPath(config.getBootstrapFileSystemPath());
+        .setBootstrapFileSystemPath(config.getBootstrapFileSystemPath())
+        .setVersionSwapDetectionIntervalTimeInMs(config.getVersionSwapDetectionIntervalTimeInMs());
     return newConfig;
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/InternalLocalBootstrappingVeniceChangelogConsumer.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/InternalLocalBootstrappingVeniceChangelogConsumer.java
@@ -389,7 +389,7 @@ class InternalLocalBootstrappingVeniceChangelogConsumer<K, V> extends VeniceChan
             localCheckpoint = VeniceChangeCoordinate.decodeStringAndConvertToVeniceChangeCoordinate(offsetString);
           }
         } catch (IOException | ClassNotFoundException e) {
-          throw new VeniceException("Failed to decode local hhange capture coordinate chekcpoint with exception: ", e);
+          throw new VeniceException("Failed to decode local change capture coordinate checkpoint with exception: ", e);
         }
 
         // Where we need to catch up to

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceAfterImageConsumerImpl.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceAfterImageConsumerImpl.java
@@ -196,15 +196,19 @@ public class VeniceAfterImageConsumerImpl<K, V> extends VeniceChangelogConsumerI
             partitions.add(partitionSubscription.getPartitionNumber());
           }
           try {
+            LOGGER.info(
+                "New Version detected!  Seeking consumer to version: " + currentVersion
+                    + " in VersionSwaDetectionThread: " + this.getId());
             seekToEndOfPush(partitions).get();
           } catch (InterruptedException | ExecutionException e) {
             LOGGER.error(
-                "Seek to End of Push Failed for store: " + storeName + " partitions: " + partitions + " will retry...",
+                "Seek to End of Push Failed for store: " + storeName + " partitions: " + partitions
+                    + " on VersionSwapDetectionThread: " + this.getId() + "will retry...",
                 e);
           }
         }
       }
-      LOGGER.info("VersionSwapDetectionThread thread interrupted!  Shutting down...");
+      LOGGER.info("VersionSwapDetectionThread thread #" + this.getId() + "interrupted!  Shutting down...");
     }
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceAfterImageConsumerImpl.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceAfterImageConsumerImpl.java
@@ -1,17 +1,205 @@
 package com.linkedin.davinci.consumer;
 
+import com.linkedin.venice.exceptions.VeniceException;
+import com.linkedin.venice.kafka.protocol.ControlMessage;
+import com.linkedin.venice.kafka.protocol.KafkaMessageEnvelope;
+import com.linkedin.venice.kafka.protocol.enums.ControlMessageType;
+import com.linkedin.venice.message.KafkaKey;
+import com.linkedin.venice.meta.Version;
+import com.linkedin.venice.pubsub.adapter.kafka.ApacheKafkaOffsetPosition;
 import com.linkedin.venice.pubsub.api.PubSubConsumerAdapter;
 import com.linkedin.venice.pubsub.api.PubSubMessage;
+import com.linkedin.venice.pubsub.api.PubSubTopic;
+import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
+import com.linkedin.venice.utils.lazy.Lazy;
 import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 
 public class VeniceAfterImageConsumerImpl<K, V> extends VeniceChangelogConsumerImpl<K, V> {
+  private static final Logger LOGGER = LogManager.getLogger(VeniceAfterImageConsumerImpl.class);
+  // 10 Minute default
+  protected long versionSwapDetectionIntervalTimeInMs = 600000L;
+  // This consumer is used to find EOP messages without impacting consumption by other subscriptions. It's only used
+  // in the context of seeking to EOP in the event of the user calling that seek or a version push.
+  // TODO: We shouldn't use this in the long run. Once the EOP position is queryable from venice and version
+  // swap is produced to VT, then we should remove this as it's no longer needed.
+  final private Lazy<VeniceChangelogConsumerImpl<K, V>> internalSeekConsumer;
+  private Thread versionSwapDetectionThread;
+
   public VeniceAfterImageConsumerImpl(ChangelogClientConfig changelogClientConfig, PubSubConsumerAdapter consumer) {
+    this(
+        changelogClientConfig,
+        consumer,
+        Lazy.of(
+            () -> new VeniceChangelogConsumerImpl<K, V>(
+                changelogClientConfig,
+                VeniceChangelogConsumerClientFactory.getConsumer(
+                    changelogClientConfig.getConsumerProperties(),
+                    changelogClientConfig.getStoreName() + "-" + "internal"))));
+  }
+
+  protected VeniceAfterImageConsumerImpl(
+      ChangelogClientConfig changelogClientConfig,
+      PubSubConsumerAdapter consumer,
+      Lazy<VeniceChangelogConsumerImpl<K, V>> seekConsumer) {
     super(changelogClientConfig, consumer);
+    versionSwapDetectionThread = new VersionSwapDetectionThread();
+    internalSeekConsumer = seekConsumer;
   }
 
   @Override
   public Collection<PubSubMessage<K, ChangeEvent<V>, VeniceChangeCoordinate>> poll(long timeoutInMs) {
     return internalPoll(timeoutInMs, "");
+  }
+
+  @Override
+  public CompletableFuture<Void> seekToTimestamps(Map<Integer, Long> timestamps) {
+    return internalSeekToTimestamps(timestamps, "");
+  }
+
+  @Override
+  public CompletableFuture<Void> seekToTail(Set<Integer> partitions) {
+    return internalSeekToTail(partitions, "");
+  }
+
+  @Override
+  public CompletableFuture<Void> seekToEndOfPush(Set<Integer> partitions) {
+    return CompletableFuture.supplyAsync(() -> {
+      synchronized (internalSeekConsumer) {
+        try {
+          // TODO: This implementation basically just scans the version topic until it finds the EOP message. The
+          // approach
+          // we'd like to do is instead add the offset of the EOP message in the VT, and then just seek to that offset.
+          // We'll do that in a future patch.
+          internalSeekConsumer.get().subscribe(partitions).get();
+
+          // We need to get the internal consumer as we have to intercept the control messages that we would normally
+          // filter out from the user
+          PubSubConsumerAdapter consumerAdapter = internalSeekConsumer.get().pubSubConsumer;
+
+          Map<PubSubTopicPartition, List<PubSubMessage<KafkaKey, KafkaMessageEnvelope, Long>>> polledResults;
+          Map<Integer, Boolean> endOfPushConsumedPerPartitionMap = new HashMap<>();
+          Set<VeniceChangeCoordinate> checkpoints = new HashSet<>();
+
+          // Initialize map with all false entries for each partition
+          for (Integer partition: partitions) {
+            endOfPushConsumedPerPartitionMap.put(partition, false);
+          }
+
+          // poll until we get EOP for all partitions
+          while (true) {
+            polledResults = consumerAdapter.poll(5000L);
+            // Loop through all polled messages
+            for (Map.Entry<PubSubTopicPartition, List<PubSubMessage<KafkaKey, KafkaMessageEnvelope, Long>>> entry: polledResults
+                .entrySet()) {
+              PubSubTopicPartition pubSubTopicPartition = entry.getKey();
+              List<PubSubMessage<KafkaKey, KafkaMessageEnvelope, Long>> messageList = entry.getValue();
+              for (PubSubMessage<KafkaKey, KafkaMessageEnvelope, Long> message: messageList) {
+                if (message.getKey().isControlMessage()) {
+                  ControlMessage controlMessage = (ControlMessage) message.getValue().getPayloadUnion();
+                  ControlMessageType controlMessageType = ControlMessageType.valueOf(controlMessage);
+                  if (controlMessageType.equals(ControlMessageType.END_OF_PUSH)) {
+                    // note down the partition and offset and mark that we've got the thing
+                    endOfPushConsumedPerPartitionMap.put(pubSubTopicPartition.getPartitionNumber(), true);
+                    VeniceChangeCoordinate coordinate = new VeniceChangeCoordinate(
+                        pubSubTopicPartition.getPubSubTopic().getName(),
+                        new ApacheKafkaOffsetPosition(message.getOffset()),
+                        pubSubTopicPartition.getPartitionNumber());
+                    checkpoints.add(coordinate);
+                    Set<Integer> unsubSet = new HashSet<>();
+                    unsubSet.add(pubSubTopicPartition.getPartitionNumber());
+                    internalSeekConsumer.get().unsubscribe(unsubSet);
+                    // No need to look at the rest of the messages for this partition that we might have polled
+                    break;
+                  }
+                }
+              }
+            }
+            if (endOfPushConsumedPerPartitionMap.values().stream().allMatch(e -> e)) {
+              // We polled all EOP messages, stop polling!
+              break;
+            }
+            this.seekToCheckpoint(checkpoints).get();
+          }
+        } catch (InterruptedException | ExecutionException e) {
+          throw new VeniceException(
+              "Seek to End of Push Failed for store: " + storeName + " partitions: " + partitions.toString(),
+              e);
+        }
+      }
+      return null;
+    });
+  }
+
+  public CompletableFuture<Void> internalSeek(
+      Set<Integer> partitions,
+      PubSubTopic targetTopic,
+      SeekFunction seekAction) {
+    if (!versionSwapDetectionThread.isAlive()) {
+      versionSwapDetectionThread.start();
+    }
+    return super.internalSeek(partitions, targetTopic, seekAction);
+  }
+
+  private class VersionSwapDetectionThread extends Thread {
+    VersionSwapDetectionThread() {
+      super("Version-Swap-Detection-Thread");
+    }
+
+    @Override
+    public void run() {
+      while (!Thread.interrupted()) {
+        try {
+          TimeUnit.MILLISECONDS.sleep(versionSwapDetectionIntervalTimeInMs);
+        } catch (InterruptedException e) {
+          // We've received an interrupt which is to be expected, so we'll just leave the loop and log
+          break;
+        }
+
+        // Check the current version of the server
+        storeRepository.refresh();
+        int currentVersion = storeRepository.getStore(storeName).getCurrentVersion();
+
+        // Check the current ingested version
+        Set<PubSubTopicPartition> subscriptions = pubSubConsumer.getAssignment();
+        if (subscriptions.isEmpty()) {
+          continue;
+        }
+        int maxVersion = -1;
+        for (PubSubTopicPartition topicPartition: subscriptions) {
+          int version = Version.parseVersionFromVersionTopicName(topicPartition.getPubSubTopic().getName());
+          if (version >= maxVersion) {
+            maxVersion = version;
+          }
+        }
+
+        // Seek to end of push
+        if (currentVersion != maxVersion) {
+          // get current subscriptions and seek to endOfPus
+          Set<Integer> partitions = new HashSet<>();
+          for (PubSubTopicPartition partitionSubscription: subscriptions) {
+            partitions.add(partitionSubscription.getPartitionNumber());
+          }
+          try {
+            seekToEndOfPush(partitions).get();
+          } catch (InterruptedException | ExecutionException e) {
+            LOGGER.error(
+                "Seek to End of Push Failed for store: " + storeName + " partitions: " + partitions + " will retry...",
+                e);
+          }
+        }
+      }
+      LOGGER.info("VersionSwapDetectionThread thread interrupted!  Shutting down...");
+    }
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceAfterImageConsumerImpl.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceAfterImageConsumerImpl.java
@@ -28,7 +28,7 @@ import org.apache.logging.log4j.Logger;
 public class VeniceAfterImageConsumerImpl<K, V> extends VeniceChangelogConsumerImpl<K, V> {
   private static final Logger LOGGER = LogManager.getLogger(VeniceAfterImageConsumerImpl.class);
   // 10 Minute default
-  protected long versionSwapDetectionIntervalTimeInMs = 600000L;
+  protected long versionSwapDetectionIntervalTimeInMs;
   // This consumer is used to find EOP messages without impacting consumption by other subscriptions. It's only used
   // in the context of seeking to EOP in the event of the user calling that seek or a version push.
   // TODO: We shouldn't use this in the long run. Once the EOP position is queryable from venice and version

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerClientFactory.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerClientFactory.java
@@ -134,7 +134,7 @@ public class VeniceChangelogConsumerClientFactory {
     return viewClass;
   }
 
-  private PubSubConsumerAdapter getConsumer(Properties consumerProps, String consumerName) {
+  static PubSubConsumerAdapter getConsumer(Properties consumerProps, String consumerName) {
     PubSubMessageDeserializer pubSubMessageDeserializer = new PubSubMessageDeserializer(
         new OptimizedKafkaValueSerializer(),
         new LandFillObjectPool<>(KafkaMessageEnvelope::new),

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImpl.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImpl.java
@@ -888,7 +888,7 @@ public class VeniceChangelogConsumerImpl<K, V> implements VeniceChangelogConsume
     Set<Integer> partitions = Collections.singleton(partition);
     for (PubSubTopicPartition currentSubscribedPartition: pubSubConsumer.getAssignment()) {
       if (partition.equals(currentSubscribedPartition.getPartitionNumber())) {
-        if (mergedTopicName.getName() == currentSubscribedPartition.getPubSubTopic().getName()) {
+        if (mergedTopicName.getName().equals(currentSubscribedPartition.getPubSubTopic().getName())) {
           // We're being asked to switch to a topic that we're already subscribed to, NoOp this
           return;
         }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImplTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImplTest.java
@@ -142,8 +142,6 @@ public class VeniceChangelogConsumerImplTest {
     verify(mockPubSubConsumer).subscribe(oldVersionTopicPartition, OffsetRecord.LOWEST_OFFSET);
 
     veniceChangelogConsumer.subscribe(new HashSet<>(Arrays.asList(0))).get();
-    // veniceChangelogConsumer.seekToEndOfPush();
-    // verify(mockPubSubConsumer, times(2)).subscribe(oldVersionTopicPartition, OffsetRecord.LOWEST_OFFSET);
 
     List<PubSubMessage<String, ChangeEvent<Utf8>, VeniceChangeCoordinate>> pubSubMessages =
         (List<PubSubMessage<String, ChangeEvent<Utf8>, VeniceChangeCoordinate>>) veniceChangelogConsumer.poll(100);

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImplTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImplTest.java
@@ -138,8 +138,8 @@ public class VeniceChangelogConsumerImplTest {
     verify(mockPubSubConsumer).subscribe(oldVersionTopicPartition, OffsetRecord.LOWEST_OFFSET);
 
     veniceChangelogConsumer.subscribe(new HashSet<>(Arrays.asList(0))).get();
-    veniceChangelogConsumer.seekToEndOfPush();
-    verify(mockPubSubConsumer, times(2)).subscribe(oldVersionTopicPartition, OffsetRecord.LOWEST_OFFSET);
+    // veniceChangelogConsumer.seekToEndOfPush();
+    // verify(mockPubSubConsumer, times(2)).subscribe(oldVersionTopicPartition, OffsetRecord.LOWEST_OFFSET);
 
     List<PubSubMessage<String, ChangeEvent<Utf8>, VeniceChangeCoordinate>> pubSubMessages =
         (List<PubSubMessage<String, ChangeEvent<Utf8>, VeniceChangeCoordinate>>) veniceChangelogConsumer.poll(100);
@@ -213,7 +213,8 @@ public class VeniceChangelogConsumerImplTest {
       Assert.assertEquals(messageStr.toString(), "newValue" + i);
     }
     // Verify version swap from version topic to its corresponding change capture topic happened.
-    verify(mockPubSubConsumer).subscribe(new PubSubTopicPartitionImpl(oldVersionTopic, 0), OffsetRecord.LOWEST_OFFSET);
+    // verify(mockPubSubConsumer).subscribe(new PubSubTopicPartitionImpl(oldVersionTopic, 0),
+    // OffsetRecord.LOWEST_OFFSET);
     prepareChangeCaptureRecordsToBePolled(0L, 10L, mockPubSubConsumer, oldChangeCaptureTopic, 0, oldVersionTopic, null);
     pubSubMessages =
         (List<PubSubMessage<String, ChangeEvent<Utf8>, VeniceChangeCoordinate>>) veniceChangelogConsumer.poll(100);

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImplTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImplTest.java
@@ -44,6 +44,7 @@ import com.linkedin.venice.serialization.avro.AvroProtocolDefinition;
 import com.linkedin.venice.serializer.FastSerializerDeserializerFactory;
 import com.linkedin.venice.serializer.RecordSerializer;
 import com.linkedin.venice.utils.Utils;
+import com.linkedin.venice.utils.lazy.Lazy;
 import com.linkedin.venice.views.ChangeCaptureView;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
@@ -54,6 +55,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
@@ -114,7 +117,8 @@ public class VeniceChangelogConsumerImplTest {
         oldChangeCaptureTopic,
         partition,
         oldVersionTopic,
-        newVersionTopic);
+        newVersionTopic,
+        false);
     ChangelogClientConfig changelogClientConfig =
         new ChangelogClientConfig<>().setD2ControllerClient(d2ControllerClient)
             .setSchemaReader(schemaReader)
@@ -166,6 +170,61 @@ public class VeniceChangelogConsumerImplTest {
   }
 
   @Test
+  public void testAfterImageConsumerSeek() throws ExecutionException, InterruptedException {
+    D2ControllerClient d2ControllerClient = mock(D2ControllerClient.class);
+    StoreResponse storeResponse = mock(StoreResponse.class);
+    StoreInfo storeInfo = mock(StoreInfo.class);
+    doReturn(1).when(storeInfo).getCurrentVersion();
+    doReturn(2).when(storeInfo).getPartitionCount();
+    doReturn(storeInfo).when(storeResponse).getStore();
+    doReturn(storeResponse).when(d2ControllerClient).getStore(storeName);
+    MultiSchemaResponse multiRMDSchemaResponse = mock(MultiSchemaResponse.class);
+    MultiSchemaResponse.Schema rmdSchemaFromMultiSchemaResponse = mock(MultiSchemaResponse.Schema.class);
+    doReturn(rmdSchema.toString()).when(rmdSchemaFromMultiSchemaResponse).getSchemaStr();
+    doReturn(new MultiSchemaResponse.Schema[] { rmdSchemaFromMultiSchemaResponse }).when(multiRMDSchemaResponse)
+        .getSchemas();
+    doReturn(multiRMDSchemaResponse).when(d2ControllerClient).getAllReplicationMetadataSchemas(storeName);
+
+    PubSubConsumerAdapter mockPubSubConsumer = mock(PubSubConsumerAdapter.class);
+    PubSubTopic oldVersionTopic = pubSubTopicRepository.getTopic(Version.composeKafkaTopic(storeName, 1));
+
+    prepareVersionTopicRecordsToBePolled(0L, 5L, mockPubSubConsumer, oldVersionTopic, 0, true);
+    ChangelogClientConfig changelogClientConfig =
+        new ChangelogClientConfig<>().setD2ControllerClient(d2ControllerClient)
+            .setSchemaReader(schemaReader)
+            .setStoreName(storeName)
+            .setViewName("");
+
+    VeniceChangelogConsumerImpl mockInternalSeekConsumer = Mockito.mock(VeniceChangelogConsumerImpl.class);
+    Mockito.when(mockInternalSeekConsumer.subscribe(any())).thenReturn(CompletableFuture.completedFuture(null));
+    Mockito.when(mockInternalSeekConsumer.getPubSubConsumer()).thenReturn(mockPubSubConsumer);
+    prepareChangeCaptureRecordsToBePolled(0L, 10L, mockPubSubConsumer, oldVersionTopic, 0, oldVersionTopic, null, true);
+    VeniceAfterImageConsumerImpl<String, Utf8> veniceChangelogConsumer = new VeniceAfterImageConsumerImpl<>(
+        changelogClientConfig,
+        mockPubSubConsumer,
+        Lazy.of(() -> mockInternalSeekConsumer));
+    veniceChangelogConsumer.versionSwapDetectionIntervalTimeInMs = 1;
+    ThinClientMetaStoreBasedRepository mockRepository = mock(ThinClientMetaStoreBasedRepository.class);
+    Store store = mock(Store.class);
+    Version mockVersion = new VersionImpl(storeName, 1, "foo");
+    Mockito.when(store.getCurrentVersion()).thenReturn(1);
+    Mockito.when(store.getCompressionStrategy()).thenReturn(CompressionStrategy.NO_OP);
+    Mockito.when(mockRepository.getStore(anyString())).thenReturn(store);
+    Mockito.when(store.getVersion(Mockito.anyInt())).thenReturn(Optional.of(mockVersion));
+    veniceChangelogConsumer.setStoreRepository(mockRepository);
+    veniceChangelogConsumer.subscribe(new HashSet<>(Arrays.asList(0))).get();
+
+    Set<Integer> partitionSet = new HashSet<>();
+    partitionSet.add(0);
+    veniceChangelogConsumer.seekToEndOfPush(partitionSet).get();
+
+    Mockito.verify(mockInternalSeekConsumer).subscribe(partitionSet);
+    Mockito.verify(mockInternalSeekConsumer).unsubscribe(partitionSet);
+    PubSubTopicPartition pubSubTopicPartition = new PubSubTopicPartitionImpl(oldVersionTopic, 0);
+    Mockito.verify(mockPubSubConsumer).subscribe(pubSubTopicPartition, 10);
+  }
+
+  @Test
   public void testConsumeAfterImage() throws ExecutionException, InterruptedException {
     D2ControllerClient d2ControllerClient = mock(D2ControllerClient.class);
     StoreResponse storeResponse = mock(StoreResponse.class);
@@ -212,10 +271,15 @@ public class VeniceChangelogConsumerImplTest {
       Utf8 messageStr = pubSubMessage.getValue().getCurrentValue();
       Assert.assertEquals(messageStr.toString(), "newValue" + i);
     }
-    // Verify version swap from version topic to its corresponding change capture topic happened.
-    // verify(mockPubSubConsumer).subscribe(new PubSubTopicPartitionImpl(oldVersionTopic, 0),
-    // OffsetRecord.LOWEST_OFFSET);
-    prepareChangeCaptureRecordsToBePolled(0L, 10L, mockPubSubConsumer, oldChangeCaptureTopic, 0, oldVersionTopic, null);
+    prepareChangeCaptureRecordsToBePolled(
+        0L,
+        10L,
+        mockPubSubConsumer,
+        oldChangeCaptureTopic,
+        0,
+        oldVersionTopic,
+        null,
+        false);
     pubSubMessages =
         (List<PubSubMessage<String, ChangeEvent<Utf8>, VeniceChangeCoordinate>>) veniceChangelogConsumer.poll(100);
     Assert.assertFalse(pubSubMessages.isEmpty());
@@ -238,7 +302,8 @@ public class VeniceChangelogConsumerImplTest {
       PubSubTopic changeCaptureTopic,
       int partition,
       PubSubTopic oldVersionTopic,
-      PubSubTopic newVersionTopic) {
+      PubSubTopic newVersionTopic,
+      boolean addEndOfPushMessage) {
     List<PubSubMessage<KafkaKey, KafkaMessageEnvelope, Long>> pubSubMessageList = new ArrayList<>();
 
     // Add a start of push message
@@ -256,6 +321,11 @@ public class VeniceChangelogConsumerImplTest {
           Arrays.asList(i, i));
       pubSubMessageList.add(pubSubMessage);
     }
+
+    if (addEndOfPushMessage) {
+      pubSubMessageList.add(constructEndOfPushMessage(changeCaptureTopic, partition, endIdx + 1));
+    }
+
     if (newVersionTopic != null) {
       pubSubMessageList.add(
           constructVersionSwapMessage(
@@ -267,7 +337,7 @@ public class VeniceChangelogConsumerImplTest {
     }
     PubSubTopicPartition topicPartition = new PubSubTopicPartitionImpl(changeCaptureTopic, partition);
     pubSubMessagesMap.put(topicPartition, pubSubMessageList);
-    doReturn(pubSubMessagesMap).when(pubSubConsumer).poll(100);
+    doReturn(pubSubMessagesMap).when(pubSubConsumer).poll(Mockito.anyLong());
   }
 
   private void prepareVersionTopicRecordsToBePolled(
@@ -286,7 +356,7 @@ public class VeniceChangelogConsumerImplTest {
       consumerRecordList.add(pubSubMessage);
     }
     if (prepareEndOfPush) {
-      consumerRecordList.add(constructEndOfPushMessage(versionTopic, partition));
+      consumerRecordList.add(constructEndOfPushMessage(versionTopic, partition, 0L));
     }
     PubSubTopicPartition pubSubTopicPartition = new PubSubTopicPartitionImpl(versionTopic, partition);
     consumerRecordsMap.put(pubSubTopicPartition, consumerRecordList);
@@ -368,7 +438,8 @@ public class VeniceChangelogConsumerImplTest {
 
   private PubSubMessage<KafkaKey, KafkaMessageEnvelope, Long> constructEndOfPushMessage(
       PubSubTopic versionTopic,
-      int partition) {
+      int partition,
+      Long offset) {
     KafkaKey kafkaKey = new KafkaKey(MessageType.CONTROL_MESSAGE, null);
     EndOfPush endOfPush = new EndOfPush();
     KafkaMessageEnvelope kafkaMessageEnvelope = new KafkaMessageEnvelope();
@@ -377,7 +448,7 @@ public class VeniceChangelogConsumerImplTest {
     controlMessage.controlMessageType = ControlMessageType.END_OF_PUSH.getValue();
     kafkaMessageEnvelope.payloadUnion = controlMessage;
     PubSubTopicPartition pubSubTopicPartition = new PubSubTopicPartitionImpl(versionTopic, partition);
-    return new ImmutablePubSubMessage<>(kafkaKey, kafkaMessageEnvelope, pubSubTopicPartition, 0, 0, 0);
+    return new ImmutablePubSubMessage<>(kafkaKey, kafkaMessageEnvelope, pubSubTopicPartition, offset, 0, 0);
   }
 
   private PubSubMessage<KafkaKey, KafkaMessageEnvelope, Long> constructStartOfPushMessage(

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestActiveActiveIngestion.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestActiveActiveIngestion.java
@@ -652,7 +652,7 @@ public class TestActiveActiveIngestion {
 
       VeniceChangelogConsumer<Utf8, Utf8> versionTopicConsumer =
           veniceAfterImageConsumerClientFactory.getChangelogConsumer(storeName);
-      Assert.assertTrue(versionTopicConsumer instanceof VeniceAfterImageConsumerImpl<Utf8, Utf8>);
+      Assert.assertTrue(versionTopicConsumer instanceof VeniceAfterImageConsumerImpl);
       versionTopicConsumer.subscribeAll().get();
 
       // Let's consume those 100 records off of version 1

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestActiveActiveIngestion.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestActiveActiveIngestion.java
@@ -33,6 +33,7 @@ import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
 import com.linkedin.davinci.consumer.BootstrappingVeniceChangelogConsumer;
 import com.linkedin.davinci.consumer.ChangeEvent;
 import com.linkedin.davinci.consumer.ChangelogClientConfig;
+import com.linkedin.davinci.consumer.VeniceAfterImageConsumerImpl;
 import com.linkedin.davinci.consumer.VeniceChangeCoordinate;
 import com.linkedin.davinci.consumer.VeniceChangelogConsumer;
 import com.linkedin.davinci.consumer.VeniceChangelogConsumerClientFactory;
@@ -209,11 +210,11 @@ public class TestActiveActiveIngestion {
     }
   }
 
-  /*  private int pollAfterImageEventsFromChangeCaptureConsumer(
+  private int pollAfterImageEventsFromChangeCaptureConsumer(
       Map<String, Utf8> polledChangeEvents,
       VeniceChangelogConsumer veniceChangelogConsumer) {
     int polledMessagesNum = 0;
-    Collection<PubSubMessage<Utf8, ChangeEvent<Utf8>, Long>> pubSubMessages = veniceChangelogConsumer.poll(100);
+    Collection<PubSubMessage<Utf8, ChangeEvent<Utf8>, Long>> pubSubMessages = veniceChangelogConsumer.poll(1000);
     for (PubSubMessage<Utf8, ChangeEvent<Utf8>, Long> pubSubMessage: pubSubMessages) {
       Utf8 afterImageEvent = pubSubMessage.getValue().getCurrentValue();
       String key = pubSubMessage.getKey().toString();
@@ -221,7 +222,7 @@ public class TestActiveActiveIngestion {
       polledMessagesNum++;
     }
     return polledMessagesNum;
-  }*/
+  }
 
   @Test(timeOut = TEST_TIMEOUT, dataProviderClass = DataProviderUtils.class)
   public void testLeaderLagWithIgnoredData() throws Exception {
@@ -554,6 +555,7 @@ public class TestActiveActiveIngestion {
 
   @Test(timeOut = TEST_TIMEOUT, priority = 3)
   public void testAAIngestionWithStoreView() throws Exception {
+    // Set up the store
     Long timestamp = System.currentTimeMillis();
     ControllerClient childControllerClient =
         new ControllerClient(clusterName, childDatacenters.get(0).getControllerConnectString());
@@ -614,7 +616,10 @@ public class TestActiveActiveIngestion {
       Assert.assertEquals(viewConfigMap.get("changeCaptureView").getViewParameters().size(), 1);
     });
 
+    // Write Records to the store for version v1, the push job will contain 100 records.
     TestWriteUtils.runPushJob("Run push job", props);
+
+    // Write Records from nearline
     Map<String, String> samzaConfig = getSamzaConfig(storeName);
     VeniceSystemFactory factory = new VeniceSystemFactory();
     // Use a unique key for DELETE with RMD validation
@@ -635,14 +640,25 @@ public class TestActiveActiveIngestion {
           .setControllerD2ServiceName(D2_SERVICE_NAME)
           .setD2ServiceName(VeniceRouterWrapper.CLUSTER_DISCOVERY_D2_SERVICE_NAME)
           .setLocalD2ZkHosts(localZkServer.getAddress())
-          .setControllerRequestRetryCount(3);
+          .setControllerRequestRetryCount(3)
+          .setVersionSwapDetectionIntervalTimeInMs(10L);
       VeniceChangelogConsumerClientFactory veniceChangelogConsumerClientFactory =
           new VeniceChangelogConsumerClientFactory(globalChangelogClientConfig, metricsRepository);
 
-      // ChangelogClientConfig globalAfterImageClientConfig =
-      // ChangelogClientConfig.cloneConfig(globalChangelogClientConfig).setViewName("");
-      // VeniceChangelogConsumerClientFactory veniceAfterImageConsumerClientFactory =
-      // new VeniceChangelogConsumerClientFactory(globalAfterImageClientConfig, metricsRepository);
+      ChangelogClientConfig globalAfterImageClientConfig =
+          ChangelogClientConfig.cloneConfig(globalChangelogClientConfig).setViewName("");
+      VeniceChangelogConsumerClientFactory veniceAfterImageConsumerClientFactory =
+          new VeniceChangelogConsumerClientFactory(globalAfterImageClientConfig, metricsRepository);
+
+      VeniceChangelogConsumer<Utf8, Utf8> versionTopicConsumer =
+          veniceAfterImageConsumerClientFactory.getChangelogConsumer(storeName);
+      Assert.assertTrue(versionTopicConsumer instanceof VeniceAfterImageConsumerImpl<Utf8, Utf8>);
+      versionTopicConsumer.subscribeAll().get();
+
+      // Let's consume those 100 records off of version 1
+      Map<String, Utf8> versionTopicEvents = new HashMap<>();
+      pollAfterImageEventsFromChangeCaptureConsumer(versionTopicEvents, versionTopicConsumer);
+      Assert.assertEquals(versionTopicEvents.size(), 100);
 
       VeniceChangelogConsumer<Utf8, Utf8> veniceChangelogConsumer =
           veniceChangelogConsumerClientFactory.getChangelogConsumer(storeName);
@@ -700,7 +716,14 @@ public class TestActiveActiveIngestion {
           Assert.assertNull(changeEvent.getCurrentValue());
         }
       });
-      // run repush
+
+      versionTopicEvents.clear();
+      TestUtils.waitForNonDeterministicAssertion(10, TimeUnit.SECONDS, true, () -> {
+        pollAfterImageEventsFromChangeCaptureConsumer(versionTopicEvents, versionTopicConsumer);
+        Assert.assertEquals(versionTopicEvents.size(), 21);
+      });
+
+      // run repush. Repush will reapply all existing events to the new store and trim all events from the RT
       props.setProperty(SOURCE_KAFKA, "true");
       props.setProperty(KAFKA_INPUT_BROKER_URL, clusterWrapper.getPubSubBrokerWrapper().getAddress());
       props.setProperty(KAFKA_INPUT_MAX_RECORDS_PER_MAPPER, "5");
@@ -763,10 +786,7 @@ public class TestActiveActiveIngestion {
           Assert.assertNull(client.get(Integer.toString(deleteWithRmdKeyIndex)).get());
         });
       }
-      // TODO disabling verification of veniceAfterImageConsumer until its behavior is defined/fixed.
-      // VeniceChangelogConsumer<Utf8, Utf8> veniceAfterImageConsumer =
-      // veniceAfterImageConsumerClientFactory.getChangelogConsumer(storeName);
-      // veniceAfterImageConsumer.subscribeAll().get();
+
       // Validate changed events for version 2.
       allChangeEvents.putAll(polledChangeEvents);
       polledChangeEvents.clear();
@@ -785,6 +805,7 @@ public class TestActiveActiveIngestion {
             polledChangeEvents.get(persistWithRmdKey).getValue().getCurrentValue().toString(),
             "stream_" + persistWithRmdKey);
       });
+
       /**
        * Test Repush with TTL
        */
@@ -858,7 +879,8 @@ public class TestActiveActiveIngestion {
       // }
 
       // Drain the remaining events on version 3 and verify that we got everything. We don't verify the count
-      // because at this stage, the total events which will get polled
+      // because at this stage, the total events which will get polled will be determined by how far back the rewind
+      // managed to get (and test run duration might be variable)
       TestUtils.waitForNonDeterministicAssertion(10, TimeUnit.SECONDS, true, () -> {
         pollChangeEventsFromChangeCaptureConsumer(polledChangeEvents, veniceChangelogConsumer);
         pollChangeEventsFromChangeCaptureConsumer(polledChangeEvents, veniceChangelogConsumer);
@@ -947,7 +969,7 @@ public class TestActiveActiveIngestion {
       veniceChangelogConsumer.seekToBeginningOfPush().join();
       TestUtils.waitForNonDeterministicAssertion(5, TimeUnit.SECONDS, () -> {
         pollChangeEventsFromChangeCaptureConsumer(polledChangeEvents, veniceChangelogConsumer);
-        Assert.assertEquals(polledChangeEvents.size(), 15);
+        Assert.assertEquals(polledChangeEvents.size(), 30);
       });
 
       // Save a checkpoint and clear the map
@@ -964,7 +986,8 @@ public class TestActiveActiveIngestion {
       // Poll Change events again, verify we get everything
       TestUtils.waitForNonDeterministicAssertion(5, TimeUnit.SECONDS, () -> {
         pollChangeEventsFromChangeCaptureConsumer(polledChangeEvents, veniceChangelogConsumer);
-        Assert.assertEquals(polledChangeEvents.size(), 8);
+        // Repush with TTL will include delete events in the topic
+        Assert.assertEquals(polledChangeEvents.size(), 16);
       });
       allChangeEvents.putAll(polledChangeEvents);
       polledChangeEvents.clear();
@@ -992,6 +1015,29 @@ public class TestActiveActiveIngestion {
         Assert.assertEquals(polledChangeEvents.size(), 0);
       });
 
+      versionTopicEvents.clear();
+      TestUtils.waitForNonDeterministicAssertion(10, TimeUnit.SECONDS, true, () -> {
+        pollAfterImageEventsFromChangeCaptureConsumer(versionTopicEvents, versionTopicConsumer);
+        // At this point, the consumer should have auto tracked to version 4, and since we didn't apply any nearline
+        // writes to version 4, there should be no events to consume at this point
+        Assert.assertEquals(versionTopicEvents.size(), 0);
+      });
+
+      versionTopicConsumer.seekToEndOfPush().get();
+      TestUtils.waitForNonDeterministicAssertion(10, TimeUnit.SECONDS, true, () -> {
+        pollAfterImageEventsFromChangeCaptureConsumer(versionTopicEvents, versionTopicConsumer);
+        // Again, no events to consume here.
+        Assert.assertEquals(versionTopicEvents.size(), 0);
+      });
+
+      versionTopicConsumer.seekToBeginningOfPush().get();
+      TestUtils.waitForNonDeterministicAssertion(10, TimeUnit.SECONDS, true, () -> {
+        pollAfterImageEventsFromChangeCaptureConsumer(versionTopicEvents, versionTopicConsumer);
+        // Reconsuming the events from the version topic, which at this point should just contain the same 16
+        // events we consumed with the before/after image consumer ealier.
+        Assert.assertEquals(versionTopicEvents.size(), 16);
+      });
+
       // Verify version swap count matches with version count - 1 (since we don't transmit from version 0 to version 1).
       // This will include messages for all partitions, so (4 version -1)*3 partitions=9 messages
       TestUtils.waitForNonDeterministicAssertion(
@@ -1002,7 +1048,7 @@ public class TestActiveActiveIngestion {
       // are
       // applied to a version)
       TestUtils.waitForNonDeterministicAssertion(
-          5,
+          8,
           TimeUnit.SECONDS,
           () -> Assert.assertEquals(TestView.getInstance().getRecordCountForStore(storeName), 86));
       parentControllerClient.disableAndDeleteStore(storeName);


### PR DESCRIPTION
## [changelog] Tweak after image consumer to not consume view topic
This changes the behavior of the after image consumer so that it consumes the version topic instead of consuming the change capture topic.  In order to fully accomodate this, a few changes had to be applied, including:

- Seek API's for the After image consumer had to supply a topic suffix so as to always stay on version topics.
- seek to EOP for now has to basically consume the version topic and then find the coordinates of the EOP message.  Because this has to be done also when we detect that a new version is available, we use a second consumer which is doing the search/seek for the EOP message.  Once it finds it, it then resubscribes the client to the appropriate coordinate.
- Tweak message processing so that it returns deletes that are found on the version topic (tweaks to tests reflect this).  To my knowledge, deletes in the version topic should only happen in the case of TTL repushes, and this isn't really done in production yet.
- The after image consumer uses a background thread to detect if a version swap has happened.  This is a temporary measure until we publish version swaps to version topics.  Once we have that, we should delete this logic, as this implementation is a little fraught in terms of possible edge cases.

## How was this PR tested?
Added new integration and unit tests to verify the behavior

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [x] Yes. Make sure to explain your proposed changes and call out the behavior change.