### PR TITLE
Fix string cast issue in VeniceProperties

### DIFF
--- a/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/meta/RequestBasedMetadataTestUtils.java
+++ b/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/meta/RequestBasedMetadataTestUtils.java
@@ -69,12 +69,15 @@ public class RequestBasedMetadataTestUtils {
       Schema storeValueSchema) {
     D2TransportClient d2TransportClient = mock(D2TransportClient.class);
 
+    Map<String, String> partitionerParams = new HashMap<>();
+    partitionerParams.put("testKey", "testValue");
+
     VersionProperties versionProperties = new VersionProperties(
         CURRENT_VERSION,
         CompressionStrategy.ZSTD_WITH_DICT.getValue(),
         2,
         "com.linkedin.venice.partitioner.DefaultVenicePartitioner",
-        Collections.emptyMap(),
+        Collections.unmodifiableMap(partitionerParams),
         1);
     Map<CharSequence, List<CharSequence>> routeMap = new HashMap<>();
     routeMap.put("0", Collections.singletonList(REPLICA1_NAME));

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/utils/VeniceProperties.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/utils/VeniceProperties.java
@@ -35,7 +35,7 @@ public class VeniceProperties {
   public VeniceProperties(Properties properties) {
     Map<String, String> tmpProps = new HashMap<>(properties.size());
     for (Map.Entry<Object, Object> e: properties.entrySet()) {
-      tmpProps.put((String) e.getKey(), e.getValue() == null ? null : e.getValue().toString());
+      tmpProps.put(e.getKey().toString(), e.getValue() == null ? null : e.getValue().toString());
     }
     props = Collections.unmodifiableMap(tmpProps);
   }


### PR DESCRIPTION
## Summary
Metadata periodic refresh failed with below for `PartitionerParams`
```
java.lang.ClassCastException: class org.apache.avro.util.Utf8 cannot be cast to class java.lang.String

```
Fix is to use `toString()` in `VeniceProperties` constructor rather than `(String)`

## How was this PR tested?
GH CI

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.