### PR TITLE
[router][server] Return Http status 503 for VeniceNoStoreException

### DIFF
--- a/services/venice-router/src/main/java/com/linkedin/venice/router/api/RouterExceptionAndTrackingUtils.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/api/RouterExceptionAndTrackingUtils.java
@@ -60,7 +60,10 @@ public class RouterExceptionAndTrackingUtils {
     String name = storeName.isPresent() ? storeName.get() : "";
     if (!EXCEPTION_FILTER.isRedundantException(name, String.valueOf(e.code()))) {
       if (responseStatus == BAD_REQUEST) {
-        LOGGER.debug("{} for store: {}", BAD_REQUEST, name, e);
+        String error = "Received bad request for store: " + name;
+        if (!EXCEPTION_FILTER.isRedundantException(error)) {
+          LOGGER.warn(error, e);
+        }
       } else if (failureType == FailureType.RESOURCE_NOT_FOUND) {
         LOGGER.error("Could not find resources for store: {} ", name, e);
       } else {

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/api/VeniceHostHealth.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/api/VeniceHostHealth.java
@@ -58,7 +58,7 @@ public class VeniceHostHealth implements HostHealthMonitor<Instance> {
   public void setHostAsUnhealthy(Instance instance) {
     String identifier = instance.getNodeId();
     unhealthyHosts.add(identifier);
-    LOGGER.info("Marking {} as unhealthy until it passes the next health check.", identifier);
+    LOGGER.warn("Marking {} as unhealthy until it passes the next health check.", identifier);
     aggHostHealthStats.recordUnhealthyHostCountCausedByRouterHeartBeat(unhealthyHosts.size());
   }
 

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/api/path/VeniceMultiKeyPath.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/api/path/VeniceMultiKeyPath.java
@@ -90,7 +90,7 @@ public abstract class VeniceMultiKeyPath<K> extends VenicePath {
       partitionNum = partitionFinder.getNumPartitions(resourceName);
       partitioner = partitionFinder.findPartitioner(getStoreName(), getVersionNumber());
     } catch (VeniceNoHelixResourceException e) {
-      throw RouterExceptionAndTrackingUtils.newRouterExceptionAndTracking(
+      throw RouterExceptionAndTrackingUtils.newRouterExceptionAndTrackingResourceNotFound(
           Optional.of(getStoreName()),
           Optional.of(RequestType.COMPUTE),
           e.getHttpResponseStatus(),

--- a/services/venice-server/src/main/java/com/linkedin/venice/listener/StorageReadRequestHandler.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/listener/StorageReadRequestHandler.java
@@ -359,20 +359,17 @@ public class StorageReadRequestHandler extends ChannelInboundHandlerAdapter {
   }
 
   private HttpResponseStatus getHttpResponseStatus(VeniceNoStoreException e) {
-    HttpResponseStatus status = HttpResponseStatus.BAD_REQUEST;
-
-    // return SERVICE_UNAVAILABLE to kick off error retry in router when store version resource exists
     String topic = e.getStoreName();
     String storeName = Version.parseStoreFromKafkaTopicName(topic);
     int version = Version.parseVersionFromKafkaTopicName(topic);
     Store store = metadataRepository.getStore(storeName);
-    if (store == null) {
-      return status;
+
+    if (store == null || store.getCurrentVersion() != version) {
+      return HttpResponseStatus.BAD_REQUEST;
     }
-    if (store.getCurrentVersion() == version) {
-      status = HttpResponseStatus.SERVICE_UNAVAILABLE;
-    }
-    return status;
+
+    // return SERVICE_UNAVAILABLE to kick off error retry in router when store version resource exists
+    return HttpResponseStatus.SERVICE_UNAVAILABLE;
   }
 
   /**

--- a/services/venice-server/src/main/java/com/linkedin/venice/listener/StorageReadRequestHandler.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/listener/StorageReadRequestHandler.java
@@ -265,10 +265,11 @@ public class StorageReadRequestHandler extends ChannelInboundHandlerAdapter {
                           earlyTerminationException.getMessage(),
                           earlyTerminationException.getHttpResponseStatus()));
                 } else if (e instanceof VeniceNoStoreException) {
+                  // return SERVICE_UNAVAILABLE to kick off error retry in router
                   context.writeAndFlush(
                       new HttpShortcutResponse(
                           "No storage exists for: " + ((VeniceNoStoreException) e).getStoreName(),
-                          HttpResponseStatus.BAD_REQUEST));
+                          HttpResponseStatus.SERVICE_UNAVAILABLE));
                 } else {
                   LOGGER.error("Exception thrown in parallel batch get for {}", request.getResourceName(), e);
                   HttpShortcutResponse shortcutResponse =
@@ -313,8 +314,11 @@ public class StorageReadRequestHandler extends ChannelInboundHandlerAdapter {
           }
           context.writeAndFlush(response);
         } catch (VeniceNoStoreException e) {
+          // return SERVICE_UNAVAILABLE to kick off error retry in router
           context.writeAndFlush(
-              new HttpShortcutResponse("No storage exists for: " + e.getStoreName(), HttpResponseStatus.BAD_REQUEST));
+              new HttpShortcutResponse(
+                  "No storage exists for: " + e.getStoreName(),
+                  HttpResponseStatus.SERVICE_UNAVAILABLE));
         } catch (VeniceRequestEarlyTerminationException e) {
           context.writeAndFlush(new HttpShortcutResponse(e.getMessage(), HttpResponseStatus.REQUEST_TIMEOUT));
         } catch (OperationNotAllowedException e) {

--- a/services/venice-server/src/test/java/com/linkedin/venice/listener/StorageReadRequestHandlerTest.java
+++ b/services/venice-server/src/test/java/com/linkedin/venice/listener/StorageReadRequestHandlerTest.java
@@ -626,7 +626,8 @@ public class StorageReadRequestHandlerTest {
   @Test
   public void testNoStorageEngineReturn503() throws Exception {
     String storeName = "testStore";
-    RouterRequest request = mock(GetRouterRequest.class);
+    String keyString = "key_byte";
+    GetRouterRequest request = mock(GetRouterRequest.class);
     doReturn(false).when(request).shouldRequestBeTerminatedEarly();
     doReturn(SINGLE_GET).when(request).getRequestType();
     doReturn(Version.composeKafkaTopic(storeName, 1)).when(request).getResourceName();
@@ -634,7 +635,10 @@ public class StorageReadRequestHandlerTest {
     Store store = mock(Store.class);
     doReturn(Optional.empty()).when(store).getVersion(anyInt());
     doReturn(store).when(storeRepository).getStore(storeName);
+    doReturn(1).when(store).getCurrentVersion();
+    when(storageEngine.isClosed()).thenReturn(true);
     doReturn(null).when(storageEngineRepository).getLocalStorageEngine(any());
+    doReturn(keyString.getBytes()).when(request).getKeyBytes();
     StorageReadRequestHandler requestHandler = createStorageReadRequestHandler();
     requestHandler.channelRead(context, request);
     ArgumentCaptor<HttpShortcutResponse> shortcutResponseArgumentCaptor =

--- a/services/venice-server/src/test/java/com/linkedin/venice/listener/StorageReadRequestHandlerTest.java
+++ b/services/venice-server/src/test/java/com/linkedin/venice/listener/StorageReadRequestHandlerTest.java
@@ -2,7 +2,8 @@ package com.linkedin.venice.listener;
 
 import static com.linkedin.venice.read.RequestType.SINGLE_GET;
 import static com.linkedin.venice.router.api.VenicePathParser.TYPE_STORAGE;
-import static io.netty.handler.codec.http.HttpResponseStatus.*;
+import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
+import static io.netty.handler.codec.http.HttpResponseStatus.SERVICE_UNAVAILABLE;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyInt;
@@ -645,5 +646,12 @@ public class StorageReadRequestHandlerTest {
         ArgumentCaptor.forClass(HttpShortcutResponse.class);
     verify(context).writeAndFlush(shortcutResponseArgumentCaptor.capture());
     Assert.assertEquals(shortcutResponseArgumentCaptor.getValue().getStatus(), SERVICE_UNAVAILABLE);
+
+    // when current version different from resource, return 400
+    doReturn(10).when(store).getCurrentVersion();
+    requestHandler.channelRead(context, request);
+    verify(context, times(2)).writeAndFlush(shortcutResponseArgumentCaptor.capture());
+
+    Assert.assertEquals(shortcutResponseArgumentCaptor.getValue().getStatus(), BAD_REQUEST);
   }
 }


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Return Http status 503 for VeniceNoStoreException
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Venice routers retry error requests only for 500+ http status codes. But when server returns BAD_REQUEST (400) for VeniceNoStoreException for existing resources, router does not trigger any error retries which causes unhealthy request on the client side. This PR changes the status code to 503 for such cases so that router can initiate error retries.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
CI
## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.