### PR TITLE
[WIP][da-vinci] Allow for custom materialized views in Da-Vinci

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/DaVinciBackend.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/DaVinciBackend.java
@@ -24,6 +24,7 @@ import com.linkedin.davinci.storage.StorageEngineMetadataService;
 import com.linkedin.davinci.storage.StorageMetadataService;
 import com.linkedin.davinci.storage.StorageService;
 import com.linkedin.davinci.store.AbstractStorageEngine;
+import com.linkedin.davinci.store.CustomStorageEngine;
 import com.linkedin.davinci.store.CustomStorageEngineFactory;
 import com.linkedin.davinci.store.cache.backend.ObjectCacheBackend;
 import com.linkedin.davinci.store.cache.backend.ObjectCacheConfig;
@@ -338,6 +339,8 @@ public class DaVinciBackend implements Closeable {
   private synchronized void bootstrap() {
     List<AbstractStorageEngine> storageEngines =
         storageService.getStorageEngineRepository().getAllLocalStorageEngines();
+    List<CustomStorageEngine> customStorageEngines =
+        storageService.getStorageEngineRepository().getAllCustomLocalStorageEngines();
     LOGGER.info("Starting bootstrap, storageEngines: {}", storageEngines);
     Map<String, Version> storeNameToBootstrapVersionMap = new HashMap<>();
     Map<String, List<Integer>> storeNameToPartitionListMap = new HashMap<>();
@@ -376,6 +379,44 @@ public class DaVinciBackend implements Closeable {
           && (storeNameToBootstrapVersionMap.get(storeName).getNumber() < versionNumber))) {
         storeNameToBootstrapVersionMap.put(storeName, version);
         storeNameToPartitionListMap.put(storeName, storageService.getUserPartitions(kafkaTopicName));
+      }
+    }
+
+    for (CustomStorageEngine storageEngine: customStorageEngines) {
+      String kafkaTopicName = storageEngine.getStoreName();
+      String storeName = Version.parseStoreFromKafkaTopicName(kafkaTopicName);
+      if (VeniceSystemStoreType.META_STORE.isSystemStore(storeName)) {
+        // Do not bootstrap meta system store via DaVinci backend initialization since the operation is not supported by
+        // ThinClientMetaStoreBasedRepository. This shouldn't happen normally, but it's possible if the user was using
+        // DVC based metadata for the same store and switched to thin client based metadata.
+        continue;
+      }
+
+      try {
+        getStoreOrThrow(storeName); // throws VeniceNoStoreException
+      } catch (VeniceNoStoreException e) {
+        throw new VeniceException("Unexpected to encounter non-existing store here: " + storeName);
+      }
+
+      int versionNumber = Version.parseVersionFromKafkaTopicName(kafkaTopicName);
+
+      Version version = storeRepository.getStoreOrThrow(storeName)
+          .getVersion(versionNumber)
+          .orElseThrow(
+              () -> new VeniceException(
+                  "Could not find version: " + versionNumber + " for store: " + storeName + " in storeRepository!"));
+
+      /**
+       * Set the target bootstrap version for the store in the below order:
+       * 1. CURRENT_VERSION: store's CURRENT_VERSION exists locally.
+       * 2. FUTURE_VERSION: store's CURRENT_VERSION does not exist locally, but FUTURE_VERSION exists locally.
+       * In most case, we will choose 1, as the CURRENT_VERSION will always exists locally regardless of the FUTURE_VERSION
+       * Case 2 will only exist when store version retention policy is > 2, and rollback happens on Venice side.
+       */
+      if (!(storeNameToBootstrapVersionMap.containsKey(storeName)
+          && (storeNameToBootstrapVersionMap.get(storeName).getNumber() < versionNumber))) {
+        storeNameToBootstrapVersionMap.put(storeName, version);
+        storeNameToPartitionListMap.put(storeName, storageService.getCustomUserPartitions(kafkaTopicName));
       }
     }
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/DaVinciBackend.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/DaVinciBackend.java
@@ -24,6 +24,7 @@ import com.linkedin.davinci.storage.StorageEngineMetadataService;
 import com.linkedin.davinci.storage.StorageMetadataService;
 import com.linkedin.davinci.storage.StorageService;
 import com.linkedin.davinci.store.AbstractStorageEngine;
+import com.linkedin.davinci.store.CustomStorageEngine;
 import com.linkedin.davinci.store.cache.backend.ObjectCacheBackend;
 import com.linkedin.davinci.store.cache.backend.ObjectCacheConfig;
 import com.linkedin.venice.client.store.ClientConfig;
@@ -101,6 +102,7 @@ public class DaVinciBackend implements Closeable {
       VeniceConfigLoader configLoader,
       Optional<Set<String>> managedClients,
       ICProvider icProvider,
+      CustomStorageEngine customStorageEngine,
       Optional<ObjectCacheConfig> cacheConfig) {
     LOGGER.info("Creating Da Vinci backend with managed clients: {}", managedClients);
     try {
@@ -170,6 +172,7 @@ public class DaVinciBackend implements Closeable {
       boolean whetherToRestoreDataPartitions = !isIsolatedIngestion()
           || configLoader.getVeniceServerConfig().freezeIngestionIfReadyToServeOrLocalDataExists();
       LOGGER.info("DaVinci {} restore data partitions.", whetherToRestoreDataPartitions ? "will" : "won't");
+      // TODO: Propagate CustomStorageEngine to storageService
       storageService = new StorageService(
           configLoader,
           aggVersionedStorageEngineStats,

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/DaVinciBackend.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/DaVinciBackend.java
@@ -24,7 +24,7 @@ import com.linkedin.davinci.storage.StorageEngineMetadataService;
 import com.linkedin.davinci.storage.StorageMetadataService;
 import com.linkedin.davinci.storage.StorageService;
 import com.linkedin.davinci.store.AbstractStorageEngine;
-import com.linkedin.davinci.store.CustomStorageEngine;
+import com.linkedin.davinci.store.CustomStorageEngineFactory;
 import com.linkedin.davinci.store.cache.backend.ObjectCacheBackend;
 import com.linkedin.davinci.store.cache.backend.ObjectCacheConfig;
 import com.linkedin.venice.client.store.ClientConfig;
@@ -102,9 +102,12 @@ public class DaVinciBackend implements Closeable {
       VeniceConfigLoader configLoader,
       Optional<Set<String>> managedClients,
       ICProvider icProvider,
-      CustomStorageEngine customStorageEngine,
+      CustomStorageEngineFactory customStorageEngineFactory,
       Optional<ObjectCacheConfig> cacheConfig) {
     LOGGER.info("Creating Da Vinci backend with managed clients: {}", managedClients);
+    if (customStorageEngineFactory != null) {
+      LOGGER.info("Creating Da Vinci backend with custom storage engine");
+    }
     try {
       VeniceServerConfig backendConfig = configLoader.getVeniceServerConfig();
       this.configLoader = configLoader;
@@ -172,7 +175,6 @@ public class DaVinciBackend implements Closeable {
       boolean whetherToRestoreDataPartitions = !isIsolatedIngestion()
           || configLoader.getVeniceServerConfig().freezeIngestionIfReadyToServeOrLocalDataExists();
       LOGGER.info("DaVinci {} restore data partitions.", whetherToRestoreDataPartitions ? "will" : "won't");
-      // TODO: Propagate CustomStorageEngine to storageService
       storageService = new StorageService(
           configLoader,
           aggVersionedStorageEngineStats,

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/client/AvroSpecificDaVinciClient.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/client/AvroSpecificDaVinciClient.java
@@ -1,6 +1,7 @@
 package com.linkedin.davinci.client;
 
 import com.linkedin.davinci.storage.chunking.SpecificRecordChunkingAdapter;
+import com.linkedin.davinci.store.CustomStorageEngine;
 import com.linkedin.venice.client.store.ClientConfig;
 import com.linkedin.venice.serializer.FastSerializerDeserializerFactory;
 import com.linkedin.venice.service.ICProvider;
@@ -22,6 +23,28 @@ public class AvroSpecificDaVinciClient<K, V extends SpecificRecord> extends Avro
         clientConfig,
         backendConfig,
         managedClients,
+        null,
+        icProvider,
+        new SpecificRecordChunkingAdapter<>(),
+        () -> {
+          Class<V> valueClass = clientConfig.getSpecificValueClass();
+          FastSerializerDeserializerFactory.verifyWhetherFastSpecificDeserializerWorks(valueClass);
+        });
+  }
+
+  public AvroSpecificDaVinciClient(
+      DaVinciConfig daVinciConfig,
+      ClientConfig clientConfig,
+      VeniceProperties backendConfig,
+      Optional<Set<String>> managedClients,
+      CustomStorageEngine customStorageEngine,
+      ICProvider icProvider) {
+    super(
+        daVinciConfig,
+        clientConfig,
+        backendConfig,
+        managedClients,
+        customStorageEngine,
         icProvider,
         new SpecificRecordChunkingAdapter<>(),
         () -> {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/client/AvroSpecificDaVinciClient.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/client/AvroSpecificDaVinciClient.java
@@ -1,7 +1,7 @@
 package com.linkedin.davinci.client;
 
 import com.linkedin.davinci.storage.chunking.SpecificRecordChunkingAdapter;
-import com.linkedin.davinci.store.CustomStorageEngine;
+import com.linkedin.davinci.store.CustomStorageEngineFactory;
 import com.linkedin.venice.client.store.ClientConfig;
 import com.linkedin.venice.serializer.FastSerializerDeserializerFactory;
 import com.linkedin.venice.service.ICProvider;
@@ -37,14 +37,14 @@ public class AvroSpecificDaVinciClient<K, V extends SpecificRecord> extends Avro
       ClientConfig clientConfig,
       VeniceProperties backendConfig,
       Optional<Set<String>> managedClients,
-      CustomStorageEngine customStorageEngine,
+      CustomStorageEngineFactory customStorageEngineFactory,
       ICProvider icProvider) {
     super(
         daVinciConfig,
         clientConfig,
         backendConfig,
         managedClients,
-        customStorageEngine,
+        customStorageEngineFactory,
         icProvider,
         new SpecificRecordChunkingAdapter<>(),
         () -> {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/client/DaVinciConfig.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/client/DaVinciConfig.java
@@ -40,6 +40,12 @@ public class DaVinciConfig {
    */
   private boolean readMetricsEnabled = false;
 
+  /**
+   * Whether a CustomStorageEngine is being used
+   * User can pass a CustomStorageEngine for custom materialized views
+   */
+  private boolean hasCustomStorageEngine = false;
+
   public DaVinciConfig() {
   }
 
@@ -91,6 +97,15 @@ public class DaVinciConfig {
   public DaVinciConfig setNonLocalAccessPolicy(NonLocalAccessPolicy nonLocalAccessPolicy) {
     this.nonLocalAccessPolicy = nonLocalAccessPolicy;
     return this;
+  }
+
+  public DaVinciConfig setHasCustomStorageEngine(boolean hasCustomStorageEngine) {
+    this.hasCustomStorageEngine = hasCustomStorageEngine;
+    return this;
+  }
+
+  public boolean getHasCustomStorageEngine() {
+    return hasCustomStorageEngine;
   }
 
   public boolean isCacheEnabled() {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/client/factory/DaVinciClientFactory.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/client/factory/DaVinciClientFactory.java
@@ -2,6 +2,7 @@ package com.linkedin.davinci.client.factory;
 
 import com.linkedin.davinci.client.DaVinciClient;
 import com.linkedin.davinci.client.DaVinciConfig;
+import com.linkedin.davinci.store.CustomStorageEngine;
 import org.apache.avro.specific.SpecificRecord;
 
 
@@ -19,4 +20,26 @@ public interface DaVinciClientFactory {
       String storeName,
       DaVinciConfig config,
       Class<V> valueClass);
+
+  <K, V> DaVinciClient<K, V> getGenericAvroClientWithCustomStorageEngine(
+      String storeName,
+      DaVinciConfig config,
+      CustomStorageEngine customStorageEngine);
+
+  <K, V> DaVinciClient<K, V> getAndStartGenericAvroClientWithCustomStorageEngine(
+      String storeName,
+      DaVinciConfig config,
+      CustomStorageEngine customStorageEngine);
+
+  <K, V extends SpecificRecord> DaVinciClient<K, V> getSpecificAvroClientWithCustomStorageEngine(
+      String storeName,
+      DaVinciConfig config,
+      Class<V> valueClass,
+      CustomStorageEngine customStorageEngine);
+
+  <K, V extends SpecificRecord> DaVinciClient<K, V> getAndStartSpecificAvroClientWithCustomStorageEngine(
+      String storeName,
+      DaVinciConfig config,
+      Class<V> valueClass,
+      CustomStorageEngine customStorageEngine);
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/client/factory/DaVinciClientFactory.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/client/factory/DaVinciClientFactory.java
@@ -2,7 +2,7 @@ package com.linkedin.davinci.client.factory;
 
 import com.linkedin.davinci.client.DaVinciClient;
 import com.linkedin.davinci.client.DaVinciConfig;
-import com.linkedin.davinci.store.CustomStorageEngine;
+import com.linkedin.davinci.store.CustomStorageEngineFactory;
 import org.apache.avro.specific.SpecificRecord;
 
 
@@ -24,22 +24,22 @@ public interface DaVinciClientFactory {
   <K, V> DaVinciClient<K, V> getGenericAvroClientWithCustomStorageEngine(
       String storeName,
       DaVinciConfig config,
-      CustomStorageEngine customStorageEngine);
+      CustomStorageEngineFactory customStorageEngineFactory);
 
   <K, V> DaVinciClient<K, V> getAndStartGenericAvroClientWithCustomStorageEngine(
       String storeName,
       DaVinciConfig config,
-      CustomStorageEngine customStorageEngine);
+      CustomStorageEngineFactory customStorageEngineFactory);
 
   <K, V extends SpecificRecord> DaVinciClient<K, V> getSpecificAvroClientWithCustomStorageEngine(
       String storeName,
       DaVinciConfig config,
       Class<V> valueClass,
-      CustomStorageEngine customStorageEngine);
+      CustomStorageEngineFactory customStorageEngineFactory);
 
   <K, V extends SpecificRecord> DaVinciClient<K, V> getAndStartSpecificAvroClientWithCustomStorageEngine(
       String storeName,
       DaVinciConfig config,
       Class<V> valueClass,
-      CustomStorageEngine customStorageEngine);
+      CustomStorageEngineFactory customStorageEngineFactory);
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/DefaultIngestionBackend.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/DefaultIngestionBackend.java
@@ -13,6 +13,7 @@ import com.linkedin.venice.utils.Utils;
 import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
@@ -24,8 +25,7 @@ import org.apache.logging.log4j.Logger;
  * The default ingestion backend implementation. Ingestion will be done in the same JVM as the application.
  */
 public class DefaultIngestionBackend implements DaVinciIngestionBackend, VeniceIngestionBackend {
-  private static final Logger LOGGER =
-      LogManager.getLogger(com.linkedin.davinci.ingestion.DefaultIngestionBackend.class);
+  private static final Logger LOGGER = LogManager.getLogger(DefaultIngestionBackend.class);
   private final StorageMetadataService storageMetadataService;
   private final StorageService storageService;
   private final KafkaStoreIngestionService storeIngestionService;
@@ -77,7 +77,7 @@ public class DefaultIngestionBackend implements DaVinciIngestionBackend, VeniceI
   }
 
   @Override
-  public void shutdownÏ(String topicName) {
+  public void shutdownIngestionTask(String topicName) {
     getStoreIngestionService().shutdownStoreIngestionTask(topicName);
   }
 
@@ -92,10 +92,6 @@ public class DefaultIngestionBackend implements DaVinciIngestionBackend, VeniceI
       int partition,
       int timeoutInSeconds,
       boolean removeEmptyStorageEngine) {
-    String topicName = storeConfig.getStoreVersionName();
-    // Delete this replica from meta system store if exists.
-    getStoreIngestionService().getMetaSystemStoreReplicaStatusNotifier()
-        .ifPresent(systemStoreReplicaStatusNotifier -> systemStoreReplicaStatusNotifier.drop(topicName, partition));
     // Stop consumption of the partition.
     final int waitIntervalInSecond = 1;
     final int maxRetry = timeoutInSeconds / waitIntervalInSecond;
@@ -161,6 +157,11 @@ public class DefaultIngestionBackend implements DaVinciIngestionBackend, VeniceI
   @Override
   public StorageService getStorageService() {
     return storageService;
+  }
+
+  @Override
+  public Map<String, Set<Integer>> getLoadedStoreUserPartitionsMapping() {
+    return storageService.getStoreAndUserPartitionsMapping();
   }
 
   @Override

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/DefaultIngestionBackend.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/DefaultIngestionBackend.java
@@ -24,7 +24,8 @@ import org.apache.logging.log4j.Logger;
  * The default ingestion backend implementation. Ingestion will be done in the same JVM as the application.
  */
 public class DefaultIngestionBackend implements DaVinciIngestionBackend, VeniceIngestionBackend {
-  private static final Logger LOGGER = LogManager.getLogger(DefaultIngestionBackend.class);
+  private static final Logger LOGGER =
+      LogManager.getLogger(com.linkedin.davinci.ingestion.DefaultIngestionBackend.class);
   private final StorageMetadataService storageMetadataService;
   private final StorageService storageService;
   private final KafkaStoreIngestionService storeIngestionService;
@@ -76,7 +77,7 @@ public class DefaultIngestionBackend implements DaVinciIngestionBackend, VeniceI
   }
 
   @Override
-  public void shutdownIngestionTask(String topicName) {
+  public void shutdownÏ(String topicName) {
     getStoreIngestionService().shutdownStoreIngestionTask(topicName);
   }
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/storage/StorageEngineRepository.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/storage/StorageEngineRepository.java
@@ -58,6 +58,10 @@ public class StorageEngineRepository {
     return new ArrayList<>(localStorageEngines.values());
   }
 
+  public List<CustomStorageEngine> getAllCustomLocalStorageEngines() {
+    return new ArrayList<>(customLocalStorageEngines.values());
+  }
+
   public void close() {
     VeniceException lastException = null;
     for (AbstractStorageEngine store: localStorageEngines.values()) {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/storage/StorageService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/storage/StorageService.java
@@ -117,6 +117,7 @@ public class StorageService extends AbstractVeniceService {
     this.partitionStateSerializer = partitionStateSerializer;
     this.storeRepository = storeRepository;
     this.customStorageEngineFactory = customStorageEngineFactory;
+    this.persistenceTypeToCustomStorageEngineFactoryMap = new HashMap<>();
     if (persistenceTypeToStorageEngineFactoryMapOptional.isPresent()) {
       this.persistenceTypeToStorageEngineFactoryMap = persistenceTypeToStorageEngineFactoryMapOptional.get();
     } else {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/CustomStorageEngine.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/CustomStorageEngine.java
@@ -1,6 +1,7 @@
 package com.linkedin.davinci.store;
 
 import com.linkedin.venice.utils.lazy.Lazy;
+import java.nio.ByteBuffer;
 import java.util.Set;
 
 
@@ -17,11 +18,9 @@ public interface CustomStorageEngine<K, V> {
 
   Set<Integer> getPartitionIds();
 
-  void put(Lazy<K> key, Lazy<V> value, int partition);
+  void put(int partitionId, byte[] key, ByteBuffer value);
 
   void delete(Lazy<K> key, int partition);
-
-  Lazy<V> get(Lazy<K> key, int partition);
 
   void close();
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/CustomStorageEngine.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/CustomStorageEngine.java
@@ -4,6 +4,12 @@ import com.linkedin.venice.utils.lazy.Lazy;
 
 
 public interface CustomStorageEngine<K, V> {
+  String storeName = null;
+
+  String getStoreName();
+
+  void setStoreName();
+
   void put(Lazy<K> key, Lazy<V> value, int partition);
 
   void delete(Lazy<K> key, int partition);

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/CustomStorageEngine.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/CustomStorageEngine.java
@@ -1,0 +1,14 @@
+package com.linkedin.davinci.store;
+
+import com.linkedin.venice.utils.lazy.Lazy;
+
+
+public interface CustomStorageEngine<K, V> {
+  void put(Lazy<K> key, Lazy<V> value, int partition);
+
+  void delete(Lazy<K> key, int partition);
+
+  Lazy<V> get(Lazy<K> key, int partition);
+
+  void close();
+}

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/CustomStorageEngine.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/CustomStorageEngine.java
@@ -1,6 +1,7 @@
 package com.linkedin.davinci.store;
 
 import com.linkedin.venice.utils.lazy.Lazy;
+import java.util.Set;
 
 
 public interface CustomStorageEngine<K, V> {
@@ -9,6 +10,12 @@ public interface CustomStorageEngine<K, V> {
   String getStoreName();
 
   void setStoreName();
+
+  void addStoragePartition(int partitionId);
+
+  boolean containsPartition(int partitionId);
+
+  Set<Integer> getPartitionIds();
 
   void put(Lazy<K> key, Lazy<V> value, int partition);
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/CustomStorageEngineFactory.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/CustomStorageEngineFactory.java
@@ -1,0 +1,13 @@
+package com.linkedin.davinci.store;
+
+public interface CustomStorageEngineFactory<E extends CustomStorageEngine> {
+  E createEngine();
+
+  void setCurrentVersion(E engine);
+
+  void retireVersion(E engine);
+
+  void removeCustomStorageEngine(E engine);
+
+  void close();
+}

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/CustomStoragePartition.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/CustomStoragePartition.java
@@ -1,0 +1,18 @@
+package com.linkedin.davinci.store;
+
+import com.linkedin.venice.utils.lazy.Lazy;
+
+
+public interface CustomStoragePartition<K, V> {
+  Integer partitionId = null;
+
+  Integer getPartitionId();
+
+  void put(Lazy<K> key, Lazy<V> value, int partition);
+
+  void delete(Lazy<K> key, int partition);
+
+  Lazy<V> get(Lazy<K> key, int partition);
+
+  void close();
+}

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/CustomStoragePartition.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/CustomStoragePartition.java
@@ -12,7 +12,5 @@ public interface CustomStoragePartition<K, V> {
 
   void delete(Lazy<K> key, int partition);
 
-  Lazy<V> get(Lazy<K> key, int partition);
-
   void close();
 }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/storage/StorageServiceTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/storage/StorageServiceTest.java
@@ -114,6 +114,7 @@ public class StorageServiceTest {
         storeRepository,
         true,
         true,
+        null,
         (s) -> true,
         Optional.of(persistenceTypeToStorageEngineFactoryMap));
 


### PR DESCRIPTION

## Summary
This is a work in progress to give users the ability to create different ‘views’ of a given Venice data set without having to either reimplement Venice versioning/bootstrapping or push a transformed copy of a dataset which might already exist in Venice.  



## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [x] Yes. Make sure to explain your proposed changes and call out the behavior change.

We would like to give users the ability to set up individual application specific data transformation, storage or filtering to specify what Davinci should do as it ingests every record.
