### PR TITLE
[controller] Delete da-vinci push status asynchronously

### DIFF
--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -3177,6 +3177,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
                 storeName,
                 versionNumber,
                 e);
+            future.cancel(true);
             Thread.currentThread().interrupt();
           } catch (ExecutionException e) {
             LOGGER.error("Exception thrown when deleting da-vinci push status of {}_v{}", storeName, versionNumber, e);
@@ -3184,7 +3185,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
             LOGGER.error("Timed out when deleting da-vinci push status of {}_v{}", storeName, versionNumber);
             future.cancel(true);
           } finally {
-            executor.shutdown();
+            executor.shutdownNow();
           }
         }
       }


### PR DESCRIPTION

<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Summary
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

When controller zk listener thread handles error push and deletes user store version, it will produce a delete message to davinci push status system store RT. If RT does not exist, zk listener thread will wait infinitely. Since the thread holds the store write lock forever, admin execution task threads will be blocked when processing the store's admin operations. What's worse, as admin execution tasks are shared, other stores' admin operations cannot be processed either.

This commit submits a task to delete davinci push status, wait for up to 30s to get the result, and cancel the task after timeout.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
New integ test

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.