### PR TITLE
[server][controller] Disable topic-existence check by default and handle exceptions from KafkaConumer::paritionsFor API

### DIFF
--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/PubSubConstants.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/PubSubConstants.java
@@ -34,4 +34,7 @@ public class PubSubConstants {
   // PubSub admin APIs default timeout
   public static final String PUBSUB_ADMIN_API_DEFAULT_TIMEOUT_MS = "pubsub.admin.api.default.timeout.ms";
   public static final int PUBSUB_ADMIN_API_DEFAULT_TIMEOUT_MS_DEFAULT_VALUE = 120_000; // 2 minutes
+
+  public static final String PUBSUB_CONSUMER_CHECK_TOPIC_EXISTENCE = "pubsub.consumer.check.topic.existence";
+  public static final boolean PUBSUB_CONSUMER_CHECK_TOPIC_EXISTENCE_DEFAULT_VALUE = false;
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/adapter/kafka/consumer/ApacheKafkaConsumerAdapter.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/adapter/kafka/consumer/ApacheKafkaConsumerAdapter.java
@@ -15,6 +15,7 @@ import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
 import com.linkedin.venice.pubsub.api.exceptions.PubSubClientException;
 import com.linkedin.venice.pubsub.api.exceptions.PubSubClientRetriableException;
 import com.linkedin.venice.pubsub.api.exceptions.PubSubOpTimeoutException;
+import com.linkedin.venice.pubsub.api.exceptions.PubSubTopicAuthorizationException;
 import com.linkedin.venice.pubsub.api.exceptions.PubSubTopicDoesNotExistException;
 import com.linkedin.venice.pubsub.api.exceptions.PubSubUnsubscribedTopicPartitionException;
 import java.time.Duration;
@@ -35,6 +36,9 @@ import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.consumer.OffsetAndTimestamp;
 import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.errors.AuthenticationException;
+import org.apache.kafka.common.errors.AuthorizationException;
+import org.apache.kafka.common.errors.InterruptException;
 import org.apache.kafka.common.errors.RetriableException;
 import org.apache.kafka.common.errors.TimeoutException;
 import org.apache.kafka.common.header.Header;
@@ -103,7 +107,7 @@ public class ApacheKafkaConsumerAdapter implements PubSubConsumerAdapter {
     }
 
     // Check if the topic-partition exists
-    if (!isValidTopicPartition(pubSubTopicPartition)) {
+    if (config.shouldCheckTopicExistenceBeforeConsuming() && !isValidTopicPartition(pubSubTopicPartition)) {
       LOGGER.error("Cannot subscribe to topic-partition: {} because it does not exist", pubSubTopicPartition);
       throw new PubSubTopicDoesNotExistException(pubSubTopicPartition.getPubSubTopic());
     }
@@ -125,7 +129,8 @@ public class ApacheKafkaConsumerAdapter implements PubSubConsumerAdapter {
         lastReadOffset);
   }
 
-  private boolean isValidTopicPartition(PubSubTopicPartition pubSubTopicPartition) {
+  // visible for testing
+  boolean isValidTopicPartition(PubSubTopicPartition pubSubTopicPartition) {
     if (pubSubTopicPartition == null) {
       throw new IllegalArgumentException("PubSubTopicPartition cannot be null");
     }
@@ -137,10 +142,19 @@ public class ApacheKafkaConsumerAdapter implements PubSubConsumerAdapter {
     int retries = config.getTopicQueryRetryTimes();
     int attempt = 0;
     while (attempt++ < retries) {
-      topicPartitionInfos = partitionsFor(pubSubTopicPartition.getPubSubTopic());
-      if (topicPartitionInfos != null && !topicPartitionInfos.isEmpty()
-          && pubSubTopicPartition.getPartitionNumber() < topicPartitionInfos.size()) {
-        return true;
+      try {
+        topicPartitionInfos = partitionsFor(pubSubTopicPartition.getPubSubTopic());
+        if (topicPartitionInfos != null && !topicPartitionInfos.isEmpty()
+            && pubSubTopicPartition.getPartitionNumber() < topicPartitionInfos.size()) {
+          return true;
+        }
+      } catch (PubSubClientRetriableException e) {
+        LOGGER.warn(
+            "Exception thrown when attempting to validate topic-partition: {}, attempt {}/{}",
+            pubSubTopicPartition,
+            attempt,
+            retries,
+            e);
       }
       try {
         Thread.sleep(Math.max(1, config.getTopicQueryRetryIntervalMs()));
@@ -468,7 +482,24 @@ public class ApacheKafkaConsumerAdapter implements PubSubConsumerAdapter {
    */
   @Override
   public List<PubSubTopicPartitionInfo> partitionsFor(PubSubTopic topic) {
-    List<PartitionInfo> partitionInfos = this.kafkaConsumer.partitionsFor(topic.getName());
+    List<PartitionInfo> partitionInfos;
+    try {
+      partitionInfos = this.kafkaConsumer.partitionsFor(topic.getName());
+    } catch (RetriableException e) {
+      throw new PubSubClientRetriableException(
+          "Retriable exception thrown when attempting to get partitions for topic: " + topic,
+          e);
+    } catch (AuthorizationException | AuthenticationException e) {
+      throw new PubSubTopicAuthorizationException(
+          "Authorization exception thrown when attempting to get partitions for topic: " + topic,
+          e);
+    } catch (Exception e) {
+      if (e instanceof InterruptException) {
+        Thread.currentThread().interrupt();
+      }
+      throw new PubSubClientException("Exception thrown when attempting to get partitions for topic: " + topic, e);
+    }
+
     if (partitionInfos == null) {
       return null;
     }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/adapter/kafka/consumer/ApacheKafkaConsumerConfig.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/adapter/kafka/consumer/ApacheKafkaConsumerConfig.java
@@ -42,6 +42,7 @@ public class ApacheKafkaConsumerConfig {
   private final int topicQueryRetryTimes;
   private final int topicQueryRetryIntervalMs;
   private final Duration defaultApiTimeout;
+  private final boolean shouldCheckTopicExistenceBeforeConsuming;
 
   ApacheKafkaConsumerConfig(VeniceProperties veniceProperties, String consumerName) {
     this.consumerProperties =
@@ -88,6 +89,10 @@ public class ApacheKafkaConsumerConfig {
         PubSubConstants.PUBSUB_CONSUMER_TOPIC_QUERY_RETRY_INTERVAL_MS,
         PubSubConstants.PUBSUB_CONSUMER_TOPIC_QUERY_RETRY_INTERVAL_MS_DEFAULT_VALUE);
 
+    shouldCheckTopicExistenceBeforeConsuming = veniceProperties.getBoolean(
+        PubSubConstants.PUBSUB_CONSUMER_CHECK_TOPIC_EXISTENCE,
+        PubSubConstants.PUBSUB_CONSUMER_CHECK_TOPIC_EXISTENCE_DEFAULT_VALUE);
+
     LOGGER.debug("Created ApacheKafkaConsumerConfig: {} - consumerProperties: {}", this, consumerProperties);
   }
 
@@ -124,6 +129,10 @@ public class ApacheKafkaConsumerConfig {
 
   int getTopicQueryRetryIntervalMs() {
     return topicQueryRetryIntervalMs;
+  }
+
+  boolean shouldCheckTopicExistenceBeforeConsuming() {
+    return shouldCheckTopicExistenceBeforeConsuming;
   }
 
   public static Properties getValidConsumerProperties(Properties extractedProperties) {

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/pubsub/api/consumer/PubSubConsumerAdapterTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/pubsub/api/consumer/PubSubConsumerAdapterTest.java
@@ -110,6 +110,7 @@ public class PubSubConsumerAdapterTest {
     properties.setProperty(
         PubSubConstants.PUBSUB_CONSUMER_API_DEFAULT_TIMEOUT_MS,
         String.valueOf(PUBSUB_CONSUMER_API_DEFAULT_TIMEOUT_MS));
+    properties.setProperty(PubSubConstants.PUBSUB_CONSUMER_CHECK_TOPIC_EXISTENCE, "true");
     properties.putAll(pubSubBrokerWrapper.getAdditionalConfig());
     properties.putAll(pubSubBrokerWrapper.getMergeableConfigs());
     VeniceProperties veniceProperties = new VeniceProperties(properties);


### PR DESCRIPTION
## Disable topic-existence check by default and handle exceptions from KafkaConumer::paritionsFor API 
-  Catch exceptions from `KafkaConsumer::paritionsFor` API
- Add a config to enable/disable topic-partition check before subscription action


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.