### PR TITLE
[server] Fix regression in new push status store write schema retrieval logic

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/helix/HelixParticipationService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/helix/HelixParticipationService.java
@@ -16,7 +16,6 @@ import com.linkedin.davinci.storage.StorageMetadataService;
 import com.linkedin.davinci.storage.StorageService;
 import com.linkedin.venice.common.VeniceSystemStoreType;
 import com.linkedin.venice.exceptions.VeniceException;
-import com.linkedin.venice.exceptions.VeniceNoStoreException;
 import com.linkedin.venice.helix.HelixAdapterSerializer;
 import com.linkedin.venice.helix.HelixInstanceConverter;
 import com.linkedin.venice.helix.HelixPartitionStatusAccessor;
@@ -321,7 +320,7 @@ public class HelixParticipationService extends AbstractVeniceService
       valueSchemaEntry = helixReadOnlySchemaRepository.getSupersetOrLatestValueSchema(dummyPushStatusStoreName);
       updateSchemaEntry =
           helixReadOnlySchemaRepository.getLatestDerivedSchema(dummyPushStatusStoreName, valueSchemaEntry.getId());
-    } catch (VeniceNoStoreException e) {
+    } catch (VeniceException e) {
       LOGGER.warn(
           "ZK-shared system store is not available in current environment, will fall back to last known protocol version instead.");
       int valueSchemaId = AvroProtocolDefinition.PUSH_STATUS_SYSTEM_SCHEMA_STORE.getCurrentProtocolVersion();

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/helix/HelixParticipationService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/helix/HelixParticipationService.java
@@ -16,6 +16,7 @@ import com.linkedin.davinci.storage.StorageMetadataService;
 import com.linkedin.davinci.storage.StorageService;
 import com.linkedin.venice.common.VeniceSystemStoreType;
 import com.linkedin.venice.exceptions.VeniceException;
+import com.linkedin.venice.exceptions.VeniceNoStoreException;
 import com.linkedin.venice.helix.HelixAdapterSerializer;
 import com.linkedin.venice.helix.HelixInstanceConverter;
 import com.linkedin.venice.helix.HelixPartitionStatusAccessor;
@@ -32,6 +33,8 @@ import com.linkedin.venice.pushmonitor.KillOfflinePushMessage;
 import com.linkedin.venice.pushstatushelper.PushStatusStoreWriter;
 import com.linkedin.venice.schema.SchemaEntry;
 import com.linkedin.venice.schema.writecompute.DerivedSchemaEntry;
+import com.linkedin.venice.schema.writecompute.WriteComputeSchemaConverter;
+import com.linkedin.venice.serialization.avro.AvroProtocolDefinition;
 import com.linkedin.venice.service.AbstractVeniceService;
 import com.linkedin.venice.stats.HelixMessageChannelStats;
 import com.linkedin.venice.status.StatusMessageHandler;
@@ -49,6 +52,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import org.apache.avro.Schema;
 import org.apache.helix.HelixAdmin;
 import org.apache.helix.HelixManagerFactory;
 import org.apache.helix.InstanceType;
@@ -310,11 +314,24 @@ public class HelixParticipationService extends AbstractVeniceService
         veniceServerConfig.getPubSubClientsFactory().getProducerAdapterFactory();
     VeniceWriterFactory writerFactory =
         new VeniceWriterFactory(veniceProperties.toProperties(), pubSubProducerAdapterFactory, null);
-    String dummyPushStatusStoreName = VeniceSystemStoreType.DAVINCI_PUSH_STATUS_STORE.getSystemStoreName("dummy");
-    SchemaEntry valueSchemaEntry =
-        helixReadOnlySchemaRepository.getSupersetOrLatestValueSchema(dummyPushStatusStoreName);
-    DerivedSchemaEntry updateSchemaEntry =
-        helixReadOnlySchemaRepository.getLatestDerivedSchema(dummyPushStatusStoreName, valueSchemaEntry.getId());
+    SchemaEntry valueSchemaEntry;
+    DerivedSchemaEntry updateSchemaEntry;
+    try {
+      String dummyPushStatusStoreName = VeniceSystemStoreType.DAVINCI_PUSH_STATUS_STORE.getSystemStoreName("dummy");
+      valueSchemaEntry = helixReadOnlySchemaRepository.getSupersetOrLatestValueSchema(dummyPushStatusStoreName);
+      updateSchemaEntry =
+          helixReadOnlySchemaRepository.getLatestDerivedSchema(dummyPushStatusStoreName, valueSchemaEntry.getId());
+    } catch (VeniceNoStoreException e) {
+      LOGGER.warn(
+          "ZK-shared system store is not available in current environment, will fall back to last known protocol version instead.");
+      int valueSchemaId = AvroProtocolDefinition.PUSH_STATUS_SYSTEM_SCHEMA_STORE.getCurrentProtocolVersion();
+      Schema valueSchema = AvroProtocolDefinition.PUSH_STATUS_SYSTEM_SCHEMA_STORE.getCurrentProtocolVersionSchema();
+      valueSchemaEntry = new SchemaEntry(valueSchemaId, valueSchema);
+      updateSchemaEntry = new DerivedSchemaEntry(
+          valueSchemaId,
+          1,
+          WriteComputeSchemaConverter.getInstance().convertFromValueRecordSchema(valueSchema));
+    }
     // We use push status store for persisting incremental push statuses
     statusStoreWriter =
         new PushStatusStoreWriter(writerFactory, instance.getNodeId(), valueSchemaEntry, updateSchemaEntry);


### PR DESCRIPTION
## [server] Fix regression in new push status store write schema retrieval logic

When server is deployed in a standalone fashion, the cluster does not have 
** venice_system_store_PUSH_STATUS_SYSTEM_SCHEMA_STORE**
So the new push status store writer initialization logic will fail.
This PR adds an exception catch logic and fall back to old fashion.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
Will test in PCL testing.
## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.