### PR TITLE
[client][server] Emit system store metric only for server

### DIFF
--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/stats/BasicClientStats.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/stats/BasicClientStats.java
@@ -16,6 +16,10 @@ import io.tehuti.metrics.stats.Rate;
  * This class offers very basic metrics for client, and right now, it is directly used by DaVinci.
  */
 public class BasicClientStats extends AbstractVeniceHttpStats {
+  private static final String SYSTEM_STORE_NAME_PREFIX = "venice_system_store_";
+
+  private static final MetricsRepository dummySystemStoreMetricRepo = new MetricsRepository();
+
   private final Sensor requestSensor;
   private final Sensor healthySensor;
   private final Sensor unhealthySensor;
@@ -38,7 +42,10 @@ public class BasicClientStats extends AbstractVeniceHttpStats {
   }
 
   protected BasicClientStats(MetricsRepository metricsRepository, String storeName, RequestType requestType) {
-    super(metricsRepository, storeName, requestType);
+    super(
+        storeName.startsWith(SYSTEM_STORE_NAME_PREFIX) ? dummySystemStoreMetricRepo : metricsRepository,
+        storeName,
+        requestType);
     requestSensor = registerSensor("request", requestRate);
     Rate healthyRequestRate = new OccurrenceRate();
     healthySensor = registerSensor("healthy_request", healthyRequestRate);

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/AbstractVeniceHttpStats.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/AbstractVeniceHttpStats.java
@@ -7,13 +7,10 @@ import io.tehuti.metrics.Sensor;
 
 
 public abstract class AbstractVeniceHttpStats extends AbstractVeniceStats {
-  private static final String SYSTEM_STORE_NAME_PREFIX = "venice_system_store_";
-  private static final MetricsRepository dummySystemStoreMetricRepo = new MetricsRepository();
-
   private final RequestType requestType;
 
   public AbstractVeniceHttpStats(MetricsRepository metricsRepository, String storeName, RequestType requestType) {
-    super(storeName.startsWith(SYSTEM_STORE_NAME_PREFIX) ? dummySystemStoreMetricRepo : metricsRepository, storeName);
+    super(metricsRepository, storeName);
     this.requestType = requestType;
   }
 

--- a/services/venice-server/src/main/java/com/linkedin/venice/listener/HttpChannelInitializer.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/listener/HttpChannelInitializer.java
@@ -63,6 +63,8 @@ public class HttpChannelInitializer extends ChannelInitializer<SocketChannel> {
   AggServerQuotaTokenBucketStats quotaTokenBucketStats;
   List<ServerInterceptor> aclInterceptors;
 
+  private boolean isDaVinciClient;
+
   public HttpChannelInitializer(
       ReadOnlyStoreRepository storeMetadataRepository,
       CompletableFuture<HelixCustomizedViewOfflinePushRepository> customizedViewRepository,
@@ -75,6 +77,7 @@ public class HttpChannelInitializer extends ChannelInitializer<SocketChannel> {
       StorageReadRequestHandler requestHandler) {
     this.serverConfig = serverConfig;
     this.requestHandler = requestHandler;
+    this.isDaVinciClient = serverConfig.isDaVinciClient();
 
     boolean isKeyValueProfilingEnabled = serverConfig.isKeyValueProfilingEnabled();
     boolean isUnregisterMetricForDeletedStoreEnabled = serverConfig.isUnregisterMetricForDeletedStoreEnabled();
@@ -84,19 +87,22 @@ public class HttpChannelInitializer extends ChannelInitializer<SocketChannel> {
         RequestType.SINGLE_GET,
         isKeyValueProfilingEnabled,
         storeMetadataRepository,
-        isUnregisterMetricForDeletedStoreEnabled);
+        isUnregisterMetricForDeletedStoreEnabled,
+        isDaVinciClient);
     this.multiGetStats = new AggServerHttpRequestStats(
         metricsRepository,
         RequestType.MULTI_GET,
         isKeyValueProfilingEnabled,
         storeMetadataRepository,
-        isUnregisterMetricForDeletedStoreEnabled);
+        isUnregisterMetricForDeletedStoreEnabled,
+        isDaVinciClient);
     this.computeStats = new AggServerHttpRequestStats(
         metricsRepository,
         RequestType.COMPUTE,
         isKeyValueProfilingEnabled,
         storeMetadataRepository,
-        isUnregisterMetricForDeletedStoreEnabled);
+        isUnregisterMetricForDeletedStoreEnabled,
+        isDaVinciClient);
 
     if (serverConfig.isComputeFastAvroEnabled()) {
       LOGGER.info("Fast avro for compute is enabled");

--- a/services/venice-server/src/main/java/com/linkedin/venice/listener/ListenerService.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/listener/ListenerService.java
@@ -64,6 +64,8 @@ public class ListenerService extends AbstractVeniceService {
 
   private StorageReadRequestHandler storageReadRequestHandler;
 
+  private boolean isDaVinciClient;
+
   public ListenerService(
       StorageEngineRepository storageEngineRepository,
       ReadOnlyStoreRepository storeMetadataRepository,

--- a/services/venice-server/src/main/java/com/linkedin/venice/stats/AggServerHttpRequestStats.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/stats/AggServerHttpRequestStats.java
@@ -16,10 +16,11 @@ public class AggServerHttpRequestStats extends AbstractVeniceAggStoreStats<Serve
       RequestType requestType,
       boolean isKeyValueProfilingEnabled,
       ReadOnlyStoreRepository metadataRepository,
-      boolean unregisterMetricForDeletedStoreEnabled) {
+      boolean unregisterMetricForDeletedStoreEnabled,
+      boolean isDaVinciClient) {
     super(
         metricsRepository,
-        new ServerHttpRequestStatsSupplier(requestType, isKeyValueProfilingEnabled),
+        new ServerHttpRequestStatsSupplier(requestType, isKeyValueProfilingEnabled, isDaVinciClient),
         metadataRepository,
         unregisterMetricForDeletedStoreEnabled);
   }
@@ -28,9 +29,15 @@ public class AggServerHttpRequestStats extends AbstractVeniceAggStoreStats<Serve
     private final RequestType requestType;
     private final boolean isKeyValueProfilingEnabled;
 
-    ServerHttpRequestStatsSupplier(RequestType requestType, boolean isKeyValueProfilingEnabled) {
+    private boolean isDaVinciClient;
+
+    ServerHttpRequestStatsSupplier(
+        RequestType requestType,
+        boolean isKeyValueProfilingEnabled,
+        boolean isDaVinciClient) {
       this.requestType = requestType;
       this.isKeyValueProfilingEnabled = isKeyValueProfilingEnabled;
+      this.isDaVinciClient = isDaVinciClient;
     }
 
     @Override
@@ -48,7 +55,8 @@ public class AggServerHttpRequestStats extends AbstractVeniceAggStoreStats<Serve
           storeName,
           requestType,
           isKeyValueProfilingEnabled,
-          totalStats);
+          totalStats,
+          isDaVinciClient);
     }
   }
 

--- a/services/venice-server/src/main/java/com/linkedin/venice/stats/ServerHttpRequestStats.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/stats/ServerHttpRequestStats.java
@@ -59,13 +59,16 @@ public class ServerHttpRequestStats extends AbstractVeniceHttpStats {
   private final Sensor successRequestKeyRatioSensor, successRequestRatioSensor;
   private final Sensor misroutedStoreVersionSensor;
 
+  private static final MetricsRepository dummySystemStoreMetricRepo = new MetricsRepository();
+
   public ServerHttpRequestStats(
       MetricsRepository metricsRepository,
       String storeName,
       RequestType requestType,
       boolean isKeyValueProfilingEnabled,
-      ServerHttpRequestStats totalStats) {
-    super(metricsRepository, storeName, requestType);
+      ServerHttpRequestStats totalStats,
+      boolean isDaVinciClient) {
+    super(isDaVinciClient ? dummySystemStoreMetricRepo : metricsRepository, storeName, requestType);
 
     /**
      * Check java doc of function: {@link TehutiUtils.RatioStat} to understand why choosing {@link Rate} instead of

--- a/services/venice-server/src/test/java/com/linkedin/venice/stats/AggServerHttpRequestStatsTest.java
+++ b/services/venice-server/src/test/java/com/linkedin/venice/stats/AggServerHttpRequestStatsTest.java
@@ -34,13 +34,15 @@ public class AggServerHttpRequestStatsTest {
         RequestType.SINGLE_GET,
         false,
         Mockito.mock(ReadOnlyStoreRepository.class),
-        true);
+        true,
+        false);
     this.batchGetStats = new AggServerHttpRequestStats(
         metricsRepository,
         RequestType.MULTI_GET,
         false,
         Mockito.mock(ReadOnlyStoreRepository.class),
-        true);
+        true,
+        false);
   }
 
   @AfterTest


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Emit system store metric only for server, but not thin/fast clients
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

System store metrics are useful only in server side. This PR prevents emission of meta system store metrics in DaVinci/thin clients.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

CI

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.