### PR TITLE
[vpj] Use source grid fabric for target region fabric

### DIFF
--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
@@ -2488,7 +2488,7 @@ public class VenicePushJob implements AutoCloseable {
     if (jobSetting.isTargetedRegionPushEnabled && jobSetting.targetedRegions == null) {
       // only override the targeted regions if it is not set and it is a single region push
       // use source grid fabric as target region to reduce data hop, else use default NR source
-      if (StringUtils.isEmpty(jobSetting.sourceGridFabric)) {
+      if (!StringUtils.isEmpty(jobSetting.sourceGridFabric)) {
         jobSetting.targetedRegions = jobSetting.sourceGridFabric;
       } else {
         jobSetting.targetedRegions = storeResponse.getStore().getNativeReplicationSourceFabric();

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
@@ -2487,7 +2487,12 @@ public class VenicePushJob implements AutoCloseable {
 
     if (jobSetting.isTargetedRegionPushEnabled && jobSetting.targetedRegions == null) {
       // only override the targeted regions if it is not set and it is a single region push
-      jobSetting.targetedRegions = storeResponse.getStore().getNativeReplicationSourceFabric();
+      // use source grid fabric as target region to reduce data hop, else use default NR source
+      if (StringUtils.isEmpty(jobSetting.sourceGridFabric)) {
+        jobSetting.targetedRegions = jobSetting.sourceGridFabric;
+      } else {
+        jobSetting.targetedRegions = storeResponse.getStore().getNativeReplicationSourceFabric();
+      }
       if (StringUtils.isEmpty(jobSetting.targetedRegions)) {
         throw new VeniceException(
             "The store either does not have native replication mode enabled or set up default source fabric.");


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## [vpj] Use source grid fabric for target region fabric
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Currently when target region push is enabled, it picks the default NR source fabric as the target region. When source fabric region and default native replication source are different, there would be 2 issues for target region push.

1. The source VT would be created in default NR region which then will be replayed back to the source grid fabric VT, thus data would be making double hop.
2. The SOP for repush will be missing in source grid fabric as it was created only in default NR fabric, thus leading to stuck push.

This PR resolves the above.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.