### PR TITLE
[dvc][server] Added safeguard in LFSIT::updateOffsetsFromConsumerRecord

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -1270,6 +1270,16 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
 
     // Only update the metadata if this replica should NOT produce to version topic.
     if (!shouldProduceToVersionTopic(partitionConsumptionState)) {
+      PubSubTopic consumedTopic = consumerRecord.getTopicPartition().getPubSubTopic();
+      if (consumedTopic.isRealTime()) {
+        // Does this ever happen?
+        LOGGER.warn(
+            "Will short-circuit updateOffsetsFromConsumerRecord because the consumerRecord is coming from a "
+                + "RT topic ({}), partitionConsumptionState: {}",
+            consumedTopic,
+            partitionConsumptionState);
+        return;
+      }
       /**
        * If either (1) this is a follower replica or (2) this is a leader replica who is consuming from version topic
        * in a local Kafka cluster, we can update the offset metadata in offset record right after consuming a message;


### PR DESCRIPTION
There seems to be a race condition where the RT offset gets persisted into the VT offset field of the PCS. This change guards against this bookkeeping error, and logs information if it happens.

## How was this PR tested?
CI

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.