### PR TITLE
[all] Make VeniceWriter sending EndOfSegment due to timeout best-effort

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/validation/PartitionTracker.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/validation/PartitionTracker.java
@@ -722,7 +722,7 @@ public class PartitionTracker {
       }
       sb.append("; incoming offset: ")
           .append(consumerRecord.getOffset())
-          .append(";previous segment: ")
+          .append("; previous segment: ")
           .append(previousSegment)
           .append("; incoming segment: ")
           .append(producerMetadata.segmentNumber)


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Make `VeniceWriter` sending `EndOfSegment` due to timeout best-effort
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
In `VeniceWriter`, we send `EndOfSegment` messages periodically. However, if there is an exception from the pubsub implementation, it causes future writes in that VeniceWriter instance for that particular partition to be blocked. This commit makes the sending of `EndOfSegment` message best-effort.

The logic to periodically send `EndOfSegment` messages had been added to reduce the state that servers would persist in their state for DIV checks. Given that we now have a way to clean up DIV state older than some configured time, this best-effort behavior is acceptable.
## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
GH CI

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.