### PR TITLE
[controller] Clear disabled partition metric on server restarts

### DIFF
--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/HelixVeniceClusterResources.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/HelixVeniceClusterResources.java
@@ -167,7 +167,7 @@ public class HelixVeniceClusterResources implements VeniceResource {
         helixAdminClient,
         config,
         admin.getPushStatusStoreReader(),
-        metricsRepository);
+        admin.getDisabledPartitionStats(clusterName));
 
     this.leakedPushStatusCleanUpService = new LeakedPushStatusCleanUpService(
         clusterName,

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -4850,7 +4850,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
         if (entry.getKey().equals(kafkaTopic)) {
           // clean up disabled partition map, so that it does not grow indefinitely with dropped resources
           getHelixAdminClient().enablePartition(true, clusterName, instance, kafkaTopic, entry.getValue());
-          disabledPartitionStatMap.get(clusterName).recordClearDisabledPartition();
+          getDisabledPartitionStats(clusterName).recordClearDisabledPartition();
           LOGGER.info("Cleaning up disabled replica of resource {}, partitions {}", entry.getKey(), entry.getValue());
         }
       }
@@ -5347,7 +5347,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
         Map<String, List<String>> disabledPartitions = helixAdminClient.getDisabledPartitionsMap(clusterName, instance);
         for (Map.Entry<String, List<String>> entry: disabledPartitions.entrySet()) {
           helixAdminClient.enablePartition(true, clusterName, instance, entry.getKey(), entry.getValue());
-          disabledPartitionStatMap.get(clusterName).recordClearDisabledPartition();
+          getDisabledPartitionStats(clusterName).recordClearDisabledPartition();
           LOGGER.info(
               "Enabled disabled replica of resource {}, partitions {} in cluster {}",
               entry.getKey(),

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/stats/DisabledPartitionStats.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/stats/DisabledPartitionStats.java
@@ -3,7 +3,7 @@ package com.linkedin.venice.controller.stats;
 import com.linkedin.venice.stats.AbstractVeniceStats;
 import io.tehuti.metrics.MetricsRepository;
 import io.tehuti.metrics.Sensor;
-import io.tehuti.metrics.stats.Count;
+import io.tehuti.metrics.stats.Total;
 
 
 public class DisabledPartitionStats extends AbstractVeniceStats {
@@ -11,11 +11,14 @@ public class DisabledPartitionStats extends AbstractVeniceStats {
 
   public DisabledPartitionStats(MetricsRepository metricsRepository, String name) {
     super(metricsRepository, name);
-    disabledPartitionCount = registerSensorIfAbsent("disabled_partition_count", new Count());
+    disabledPartitionCount = registerSensorIfAbsent("disabled_partition_count", new Total());
   }
 
   public void recordDisabledPartition() {
-    disabledPartitionCount.record();
+    disabledPartitionCount.record(1);
   }
 
+  public void recordClearDisabledPartition() {
+    disabledPartitionCount.record(-1);
+  }
 }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/AbstractPushMonitor.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/AbstractPushMonitor.java
@@ -34,7 +34,6 @@ import com.linkedin.venice.utils.Time;
 import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
 import com.linkedin.venice.utils.locks.AutoCloseableLock;
 import com.linkedin.venice.utils.locks.ClusterLockManager;
-import io.tehuti.metrics.MetricsRepository;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -85,9 +84,9 @@ public abstract class AbstractPushMonitor
   private final long offlineJobResourceAssignmentWaitTimeInMilliseconds;
 
   private final PushStatusCollector pushStatusCollector;
-  private final DisabledPartitionStats disabledPartitionStats;
-
   private final boolean isOfflinePushMonitorDaVinciPushStatusEnabled;
+
+  private final DisabledPartitionStats disabledPartitionStats;
 
   public AbstractPushMonitor(
       String clusterName,
@@ -103,7 +102,7 @@ public abstract class AbstractPushMonitor
       HelixAdminClient helixAdminClient,
       VeniceControllerConfig controllerConfig,
       PushStatusStoreReader pushStatusStoreReader,
-      MetricsRepository metricsRepository) {
+      DisabledPartitionStats disabledPartitionStats) {
     this.clusterName = clusterName;
     this.offlinePushAccessor = offlinePushAccessor;
     this.storeCleaner = storeCleaner;
@@ -115,7 +114,7 @@ public abstract class AbstractPushMonitor
     this.aggregateRealTimeSourceKafkaUrl = aggregateRealTimeSourceKafkaUrl;
     this.activeActiveRealTimeSourceKafkaURLs = activeActiveRealTimeSourceKafkaURLs;
     this.helixAdminClient = helixAdminClient;
-    this.disabledPartitionStats = new DisabledPartitionStats(metricsRepository, clusterName);
+    this.disabledPartitionStats = disabledPartitionStats;
 
     this.disableErrorLeaderReplica = controllerConfig.isErrorLeaderReplicaFailOverEnabled();
     this.helixClientThrottler =

--- a/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/PartitionStatusBasedPushMonitor.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/PartitionStatusBasedPushMonitor.java
@@ -2,6 +2,7 @@ package com.linkedin.venice.pushmonitor;
 
 import com.linkedin.venice.controller.HelixAdminClient;
 import com.linkedin.venice.controller.VeniceControllerConfig;
+import com.linkedin.venice.controller.stats.DisabledPartitionStats;
 import com.linkedin.venice.ingestion.control.RealTimeTopicSwitcher;
 import com.linkedin.venice.meta.Instance;
 import com.linkedin.venice.meta.PartitionAssignment;
@@ -10,7 +11,6 @@ import com.linkedin.venice.meta.RoutingDataRepository;
 import com.linkedin.venice.meta.StoreCleaner;
 import com.linkedin.venice.pushstatushelper.PushStatusStoreReader;
 import com.linkedin.venice.utils.locks.ClusterLockManager;
-import io.tehuti.metrics.MetricsRepository;
 import java.util.List;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -38,7 +38,7 @@ public class PartitionStatusBasedPushMonitor extends AbstractPushMonitor {
       HelixAdminClient helixAdminClient,
       VeniceControllerConfig controllerConfig,
       PushStatusStoreReader pushStatusStoreReader,
-      MetricsRepository metricsRepository) {
+      DisabledPartitionStats disabledPartitionStats) {
     super(
         clusterName,
         offlinePushAccessor,
@@ -53,7 +53,7 @@ public class PartitionStatusBasedPushMonitor extends AbstractPushMonitor {
         helixAdminClient,
         controllerConfig,
         pushStatusStoreReader,
-        metricsRepository);
+        disabledPartitionStats);
   }
 
   @Override

--- a/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/PushMonitorDelegator.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/PushMonitorDelegator.java
@@ -2,6 +2,7 @@ package com.linkedin.venice.pushmonitor;
 
 import com.linkedin.venice.controller.HelixAdminClient;
 import com.linkedin.venice.controller.VeniceControllerConfig;
+import com.linkedin.venice.controller.stats.DisabledPartitionStats;
 import com.linkedin.venice.exceptions.VeniceNoStoreException;
 import com.linkedin.venice.helix.HelixCustomizedViewOfflinePushRepository;
 import com.linkedin.venice.ingestion.control.RealTimeTopicSwitcher;
@@ -18,7 +19,6 @@ import com.linkedin.venice.pushstatushelper.PushStatusStoreReader;
 import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
 import com.linkedin.venice.utils.locks.AutoCloseableLock;
 import com.linkedin.venice.utils.locks.ClusterLockManager;
-import io.tehuti.metrics.MetricsRepository;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -57,7 +57,7 @@ public class PushMonitorDelegator implements PushMonitor {
       HelixAdminClient helixAdminClient,
       VeniceControllerConfig controllerConfig,
       PushStatusStoreReader pushStatusStoreReader,
-      MetricsRepository metricsRepository) {
+      DisabledPartitionStats disabledPartitionStats) {
     this.clusterName = clusterName;
     this.metadataRepository = metadataRepository;
 
@@ -75,7 +75,7 @@ public class PushMonitorDelegator implements PushMonitor {
         helixAdminClient,
         controllerConfig,
         pushStatusStoreReader,
-        metricsRepository);
+        disabledPartitionStats);
     this.clusterLockManager = clusterLockManager;
 
     this.topicToPushMonitorMap = new VeniceConcurrentHashMap<>();

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceHelixAdmin.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceHelixAdmin.java
@@ -3,6 +3,7 @@ package com.linkedin.venice.controller;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
 
+import com.linkedin.venice.controller.stats.DisabledPartitionStats;
 import com.linkedin.venice.helix.HelixExternalViewRepository;
 import com.linkedin.venice.meta.PartitionAssignment;
 import com.linkedin.venice.meta.ReadWriteStoreRepository;
@@ -44,6 +45,7 @@ public class TestVeniceHelixAdmin {
     doReturn(repository).when(veniceClusterResources).getRoutingDataRepository();
     doReturn(nodes).when(veniceHelixAdmin).getStorageNodes(anyString());
     doReturn(partitionAssignment).when(repository).getPartitionAssignments(anyString());
+    doReturn(mock(DisabledPartitionStats.class)).when(veniceHelixAdmin).getDisabledPartitionStats(anyString());
     doCallRealMethod().when(veniceHelixAdmin).deleteHelixResource(anyString(), anyString());
 
     veniceHelixAdmin.deleteHelixResource(clusterName, kafkaTopic);

--- a/services/venice-controller/src/test/java/com/linkedin/venice/pushmonitor/PartitionStatusBasedPushMonitorTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/pushmonitor/PartitionStatusBasedPushMonitorTest.java
@@ -15,6 +15,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.linkedin.venice.controller.HelixAdminClient;
+import com.linkedin.venice.controller.stats.DisabledPartitionStats;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.helix.CachedReadOnlyStoreRepository;
 import com.linkedin.venice.helix.HelixState;
@@ -62,7 +63,7 @@ public class PartitionStatusBasedPushMonitorTest extends AbstractPushMonitorTest
         helixAdminClient,
         getMockControllerConfig(),
         null,
-        mockMetricRepo);
+        mock(DisabledPartitionStats.class));
   }
 
   @Override
@@ -81,7 +82,7 @@ public class PartitionStatusBasedPushMonitorTest extends AbstractPushMonitorTest
         mock(HelixAdminClient.class),
         getMockControllerConfig(),
         null,
-        mockMetricRepo);
+        mock(DisabledPartitionStats.class));
   }
 
   @Test


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Clear disabled partition metric on server restarts
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

The metric for disabled partition only counts whenever a partition is disabled, but does not count down whenever its reenabled. This PR fixes that.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.