### PR TITLE
[server] Fixed rare race condition for TokenBucket tryConsume()

### DIFF
--- a/internal/venice-common/src/main/java/com/linkedin/venice/throttle/TokenBucket.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/throttle/TokenBucket.java
@@ -112,6 +112,7 @@ public class TokenBucket {
   }
 
   public boolean tryConsume(long tokensToConsume) {
+    tokensRequestedSinceLastRefill.getAndAdd(tokensToConsume);
     if (noRetryTryConsume(tokensToConsume)) {
       return true;
     } else {
@@ -121,7 +122,6 @@ public class TokenBucket {
   }
 
   private boolean noRetryTryConsume(long tokensToConsume) {
-    tokensRequestedSinceLastRefill.getAndAdd(tokensToConsume);
     long tokensThatWereAvailable = tokens.getAndAccumulate(tokensToConsume, (existing, toConsume) -> {
       if (toConsume <= existing) { // there are sufficient tokens
         return existing - toConsume;

--- a/internal/venice-common/src/main/java/com/linkedin/venice/throttle/TokenBucket.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/throttle/TokenBucket.java
@@ -71,10 +71,10 @@ public class TokenBucket {
   }
 
   /**
-   *
-   * @return true if tokens may have been added, false if short circuited and no tokens were added
+   * Check and add tokens if conditions are met. Note that token may have been updated by another thread even when the
+   * function is short-circuited. Consumers of the token bucket should always retry.
    */
-  private boolean update() {
+  private void update() {
     if (clock.millis() > nextUpdateTime) {
       synchronized (this) {
         long timeNow = clock.millis();
@@ -99,9 +99,6 @@ public class TokenBucket {
           nextUpdateTime = timeNow + refillIntervalMs;
         }
       }
-      return true;
-    } else {
-      return false;
     }
   }
 
@@ -115,7 +112,12 @@ public class TokenBucket {
   }
 
   public boolean tryConsume(long tokensToConsume) {
-    return noRetryTryConsume(tokensToConsume) || (update() && noRetryTryConsume(tokensToConsume));
+    if (noRetryTryConsume(tokensToConsume)) {
+      return true;
+    } else {
+      update();
+      return noRetryTryConsume(tokensToConsume);
+    }
   }
 
   private boolean noRetryTryConsume(long tokensToConsume) {


### PR DESCRIPTION
## [server] Fixed rare race condition for TokenBucket tryConsume()

TokenBucket relies on consumption itself to update/refill its tokens. There is a rare race condition that could happen and cause very few consumption requests to be rejected even when the token bucket is refilled and has sufficient tokens. The race is caused by the old implementation of tryConsume()

return noRetryTryConsume(tokensToConsume) || (update() && noRetryTryConsume(tokensToConsume));

This is problematic because a small window where token is empty so it enters update() but the bucket just got updated by another thread so the first nextUpdateTime check will be false and hence returning false from update() and causing the tryConsume() to return false when in fact there are plenty of token available and was just refilled.

An alternative fix would be to check the bucket within update() but we might as well always try to consume again.

## How was this PR tested?
Existing unit and integration test, will war drop if needed

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.