### PR TITLE
[server] Added metrics to track Active/Active perf

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/HostLevelIngestionStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/HostLevelIngestionStats.java
@@ -122,6 +122,12 @@ public class HostLevelIngestionStats extends AbstractVeniceStats {
    */
   private final Sensor leaderIngestionReplicationMetadataLookUpLatencySensor;
 
+  private final Sensor leaderIngestionActiveActivePutLatencySensor;
+
+  private final Sensor leaderIngestionActiveActiveUpdateLatencySensor;
+
+  private final Sensor leaderIngestionActiveActiveDeleteLatencySensor;
+
   /**
    * Measure the count of ignored updates due to conflict resolution
    */
@@ -409,6 +415,24 @@ public class HostLevelIngestionStats extends AbstractVeniceStats {
         () -> totalStats.leaderIngestionReplicationMetadataLookUpLatencySensor,
         avgAndMax());
 
+    this.leaderIngestionActiveActivePutLatencySensor = registerPerStoreAndTotalSensor(
+        "leader_ingestion_active_active_put_latency",
+        totalStats,
+        () -> totalStats.leaderIngestionActiveActivePutLatencySensor,
+        avgAndMax());
+
+    this.leaderIngestionActiveActiveUpdateLatencySensor = registerPerStoreAndTotalSensor(
+        "leader_ingestion_active_active_update_latency",
+        totalStats,
+        () -> totalStats.leaderIngestionActiveActiveUpdateLatencySensor,
+        avgAndMax());
+
+    this.leaderIngestionActiveActiveDeleteLatencySensor = registerPerStoreAndTotalSensor(
+        "leader_ingestion_active_active_delete_latency",
+        totalStats,
+        () -> totalStats.leaderIngestionActiveActiveDeleteLatencySensor,
+        avgAndMax());
+
     this.requestBasedMetadataInvokeCount = registerPerStoreAndTotalSensor(
         "request_based_metadata_invoke_count",
         totalStats,
@@ -492,6 +516,18 @@ public class HostLevelIngestionStats extends AbstractVeniceStats {
 
   public void recordIngestionReplicationMetadataLookUpLatency(double latency, long currentTimeMs) {
     leaderIngestionReplicationMetadataLookUpLatencySensor.record(latency, currentTimeMs);
+  }
+
+  public void recordIngestionActiveActivePutLatency(double latency) {
+    leaderIngestionActiveActivePutLatencySensor.record(latency);
+  }
+
+  public void recordIngestionActiveActiveUpdateLatency(double latency) {
+    leaderIngestionActiveActiveUpdateLatencySensor.record(latency);
+  }
+
+  public void recordIngestionActiveActiveDeleteLatency(double latency) {
+    leaderIngestionActiveActiveDeleteLatencySensor.record(latency);
   }
 
   public void recordWriteComputeUpdateLatency(double latency) {

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestStuckConsumerRepair.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestStuckConsumerRepair.java
@@ -218,15 +218,6 @@ public class TestStuckConsumerRepair {
         for (int i = 20; i <= 100; i++) {
           sendCustomSizeStreamingRecord(veniceProducer, storeName, i, 1024);
         }
-        // Verify that the stuck consumer repair logic does kick in
-        MetricsRepository serverRepo = venice.getVeniceServers().get(0).getMetricsRepository();
-        TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, () -> {
-          assertTrue(
-              serverRepo.metrics().get(".StuckConsumerRepair--stuck_consumer_found.OccurrenceRate").value() > 0f);
-          assertTrue(
-              serverRepo.metrics().get(".StuckConsumerRepair--ingestion_task_repair.OccurrenceRate").value() > 0f);
-          assertTrue(serverRepo.metrics().get(".StuckConsumerRepair--repair_failure.OccurrenceRate").value() == 0.0f);
-        });
 
         TestUtils.waitForNonDeterministicAssertion(60, TimeUnit.SECONDS, () -> {
           try {
@@ -236,6 +227,15 @@ public class TestStuckConsumerRepair {
           } catch (Exception e) {
             throw new VeniceException(e);
           }
+        });
+        // Verify that the stuck consumer repair logic does kick in
+        MetricsRepository serverRepo = venice.getVeniceServers().get(0).getMetricsRepository();
+        TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, () -> {
+          assertTrue(
+              serverRepo.metrics().get(".StuckConsumerRepair--stuck_consumer_found.OccurrenceRate").value() > 0f);
+          assertTrue(
+              serverRepo.metrics().get(".StuckConsumerRepair--ingestion_task_repair.OccurrenceRate").value() > 0f);
+          assertTrue(serverRepo.metrics().get(".StuckConsumerRepair--repair_failure.OccurrenceRate").value() == 0.0f);
         });
       }
     } finally {


### PR DESCRIPTION
This code change made a few fixes:
1. Added 3 new metrics to track Active/Active perf in store-level: 
```
leader_ingestion_active_active_put_latency
leader_ingestion_active_active_update_latency
leader_ingestion_active_active_delete_latency
```
2. Removed one existing metric from `ActiveActiveStoreIngestionTask#processMessageAndMaybeProduceToKafka`: consumed_record_end_to_end_processing_latency, which is supposed to be triggered in drainer.
3. Reduced flakiness of test: `TestStuckConsumerRepair`.

<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->


## How was this PR tested?
CI
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.