### PR TITLE
[server] Remove forceClosed check and rely only on message to skip ApacheKafkaProducerCallback processing

### DIFF
--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/adapter/kafka/producer/ApacheKafkaProducerAdapter.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/adapter/kafka/producer/ApacheKafkaProducerAdapter.java
@@ -43,7 +43,6 @@ public class ApacheKafkaProducerAdapter implements PubSubProducerAdapter {
 
   private KafkaProducer<KafkaKey, KafkaMessageEnvelope> producer;
   private final ApacheKafkaProducerConfig producerConfig;
-  private volatile boolean forceClosed = false;
 
   /**
    * @param producerConfig contains producer configs
@@ -99,7 +98,7 @@ public class ApacheKafkaProducerAdapter implements PubSubProducerAdapter {
         key,
         value,
         ApacheKafkaUtils.convertToKafkaSpecificHeaders(pubsubMessageHeaders));
-    ApacheKafkaProducerCallback kafkaCallback = new ApacheKafkaProducerCallback(pubsubProducerCallback, this);
+    ApacheKafkaProducerCallback kafkaCallback = new ApacheKafkaProducerCallback(pubsubProducerCallback);
     try {
       producer.send(record, kafkaCallback);
       return kafkaCallback.getProduceResultFuture();
@@ -155,9 +154,6 @@ public class ApacheKafkaProducerAdapter implements PubSubProducerAdapter {
       producer.flush(closeTimeOutMs, TimeUnit.MILLISECONDS);
       LOGGER.info("Flushed all the messages in producer before closing");
     }
-    if (closeTimeOutMs == 0) {
-      forceClosed = true;
-    }
     producer.close(Duration.ofMillis(closeTimeOutMs));
     // Recycle the internal buffer allocated by KafkaProducer ASAP.
     producer = null;
@@ -188,9 +184,5 @@ public class ApacheKafkaProducerAdapter implements PubSubProducerAdapter {
   @Override
   public String getBrokerAddress() {
     return producerConfig.getBrokerAddress();
-  }
-
-  boolean isForceClosed() {
-    return forceClosed;
   }
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/adapter/kafka/producer/ApacheKafkaProducerCallback.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/adapter/kafka/producer/ApacheKafkaProducerCallback.java
@@ -26,13 +26,9 @@ public class ApacheKafkaProducerCallback implements Callback {
 
   private final PubSubProducerCallback pubsubProducerCallback;
   private final CompletableFuture<PubSubProduceResult> produceResultFuture = new CompletableFuture<>();
-  private final ApacheKafkaProducerAdapter producerAdapter;
 
-  public ApacheKafkaProducerCallback(
-      PubSubProducerCallback pubsubProducerCallback,
-      ApacheKafkaProducerAdapter producerAdapter) {
+  public ApacheKafkaProducerCallback(PubSubProducerCallback pubsubProducerCallback) {
     this.pubsubProducerCallback = pubsubProducerCallback;
-    this.producerAdapter = producerAdapter;
   }
 
   /**
@@ -72,7 +68,7 @@ public class ApacheKafkaProducerCallback implements Callback {
     }
 
     // This is a special case where the producer is closed forcefully. We can skip the callback processing
-    if (kafkaException != null && kafkaException.getMessage() != null && producerAdapter.isForceClosed()
+    if (kafkaException != null && kafkaException.getMessage() != null
         && kafkaException.getMessage().contains("Producer is closed forcefully")) {
       LOGGER.debug("Producer is closed forcefully. Skipping the callback processing.");
       return;

--- a/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/adapter/kafka/producer/ApacheKafkaProducerCallbackTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/adapter/kafka/producer/ApacheKafkaProducerCallbackTest.java
@@ -1,6 +1,5 @@
 package com.linkedin.venice.pubsub.adapter.kafka.producer;
 
-import static org.mockito.Mockito.mock;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
@@ -22,8 +21,7 @@ public class ApacheKafkaProducerCallbackTest {
   @Test
   public void testOnCompletionWithNullExceptionShouldInvokeInternalCallbackWithNullException() {
     PubSubProducerCallbackSimpleImpl internalCallback = new PubSubProducerCallbackSimpleImpl();
-    ApacheKafkaProducerCallback kafkaProducerCallback =
-        new ApacheKafkaProducerCallback(internalCallback, mock(ApacheKafkaProducerAdapter.class));
+    ApacheKafkaProducerCallback kafkaProducerCallback = new ApacheKafkaProducerCallback(internalCallback);
     RecordMetadata recordMetadata = new RecordMetadata(new TopicPartition("topicX", 42), 0, 1, 1676397545, 1L, 11, 12);
 
     kafkaProducerCallback.onCompletion(recordMetadata, null);
@@ -41,8 +39,7 @@ public class ApacheKafkaProducerCallbackTest {
   @Test
   public void testOnCompletionWithNonNullExceptionShouldInvokeInternalCallbackWithNonNullException() {
     PubSubProducerCallbackSimpleImpl internalCallback = new PubSubProducerCallbackSimpleImpl();
-    ApacheKafkaProducerCallback kafkaProducerCallback =
-        new ApacheKafkaProducerCallback(internalCallback, mock(ApacheKafkaProducerAdapter.class));
+    ApacheKafkaProducerCallback kafkaProducerCallback = new ApacheKafkaProducerCallback(internalCallback);
     RecordMetadata recordMetadata = new RecordMetadata(new TopicPartition("topicX", 42), -1, -1, -1, -1L, -1, -1);
 
     UnknownTopicOrPartitionException exception = new UnknownTopicOrPartitionException("Unknown topic: topicX");
@@ -59,8 +56,7 @@ public class ApacheKafkaProducerCallbackTest {
   public void testOnCompletionWithNonNullExceptionShouldCompleteFutureExceptionally()
       throws ExecutionException, InterruptedException {
     PubSubProducerCallbackSimpleImpl internalCallback = new PubSubProducerCallbackSimpleImpl();
-    ApacheKafkaProducerCallback kafkaProducerCallback =
-        new ApacheKafkaProducerCallback(internalCallback, mock(ApacheKafkaProducerAdapter.class));
+    ApacheKafkaProducerCallback kafkaProducerCallback = new ApacheKafkaProducerCallback(internalCallback);
     Future<PubSubProduceResult> produceResultFuture = kafkaProducerCallback.getProduceResultFuture();
     assertFalse(produceResultFuture.isDone());
     assertFalse(produceResultFuture.isCancelled());
@@ -78,8 +74,7 @@ public class ApacheKafkaProducerCallbackTest {
   public void testOnCompletionWithNonNullExceptionShouldCompleteFuture()
       throws ExecutionException, InterruptedException {
     PubSubProducerCallbackSimpleImpl internalCallback = new PubSubProducerCallbackSimpleImpl();
-    ApacheKafkaProducerCallback kafkaProducerCallback =
-        new ApacheKafkaProducerCallback(internalCallback, mock(ApacheKafkaProducerAdapter.class));
+    ApacheKafkaProducerCallback kafkaProducerCallback = new ApacheKafkaProducerCallback(internalCallback);
     Future<PubSubProduceResult> produceResultFuture = kafkaProducerCallback.getProduceResultFuture();
     assertFalse(produceResultFuture.isDone());
     assertFalse(produceResultFuture.isCancelled());


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Remove forceClosed check and rely only on message to skip ApacheKafkaProducerCallback processing
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.