### PR TITLE
[server][da-vinci] Construct the MaxElapsedTimeSinceLastPoll Gauge metric with function instead of value

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/KafkaConsumerServiceStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/KafkaConsumerServiceStats.java
@@ -49,7 +49,7 @@ public class KafkaConsumerServiceStats extends AbstractVeniceStats {
      */
     registerSensor(
         "max_elapsed_time_since_last_successful_poll",
-        new Gauge(getMaxElapsedTimeSinceLastPollInConsumerPool.getAsLong()));
+        new Gauge(() -> getMaxElapsedTimeSinceLastPollInConsumerPool.getAsLong()));
     // consumer record number per second returned by Kafka consumer poll.
     pollResultNumSensor = registerSensor("consumer_poll_result_num", new Avg(), new Total());
     pollNonZeroResultNumSensor = registerSensor("consumer_poll_non_zero_result_num", new Avg(), new Total());


### PR DESCRIPTION
## Summary
Constructing Venice Gauge metric with value is pointless; Venice Gauge metric can only work with function.

## How was this PR tested?
Tested in PR#756

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.