### PR TITLE
Hotfix 0.4.161 stuck consumer metric and repair

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
@@ -83,6 +83,8 @@ import static com.linkedin.venice.ConfigKeys.SERVER_NETTY_GRACEFUL_SHUTDOWN_PERI
 import static com.linkedin.venice.ConfigKeys.SERVER_NETTY_IDLE_TIME_SECONDS;
 import static com.linkedin.venice.ConfigKeys.SERVER_NETTY_WORKER_THREADS;
 import static com.linkedin.venice.ConfigKeys.SERVER_NODE_CAPACITY_RCU;
+import static com.linkedin.venice.ConfigKeys.SERVER_NON_EXISTING_TOPIC_CHECK_RETRY_INTERNAL_SECOND;
+import static com.linkedin.venice.ConfigKeys.SERVER_NON_EXISTING_TOPIC_INGESTION_TASK_KILL_THRESHOLD_SECOND;
 import static com.linkedin.venice.ConfigKeys.SERVER_NUM_SCHEMA_FAST_CLASS_WARMUP;
 import static com.linkedin.venice.ConfigKeys.SERVER_OPTIMIZE_DATABASE_FOR_BACKUP_VERSION_ENABLED;
 import static com.linkedin.venice.ConfigKeys.SERVER_OPTIMIZE_DATABASE_FOR_BACKUP_VERSION_NO_READ_THRESHOLD_SECONDS;
@@ -110,6 +112,9 @@ import static com.linkedin.venice.ConfigKeys.SERVER_SSL_HANDSHAKE_QUEUE_CAPACITY
 import static com.linkedin.venice.ConfigKeys.SERVER_SSL_HANDSHAKE_THREAD_POOL_SIZE;
 import static com.linkedin.venice.ConfigKeys.SERVER_STOP_CONSUMPTION_TIMEOUT_IN_SECONDS;
 import static com.linkedin.venice.ConfigKeys.SERVER_STORE_TO_EARLY_TERMINATION_THRESHOLD_MS_MAP;
+import static com.linkedin.venice.ConfigKeys.SERVER_STUCK_CONSUMER_REPAIR_ENABLED;
+import static com.linkedin.venice.ConfigKeys.SERVER_STUCK_CONSUMER_REPAIR_INTERVAL_SECOND;
+import static com.linkedin.venice.ConfigKeys.SERVER_STUCK_CONSUMER_REPAIR_THRESHOLD_SECOND;
 import static com.linkedin.venice.ConfigKeys.SERVER_SYSTEM_STORE_PROMOTION_TO_LEADER_REPLICA_DELAY_SECONDS;
 import static com.linkedin.venice.ConfigKeys.SERVER_UNSUB_AFTER_BATCHPUSH;
 import static com.linkedin.venice.ConfigKeys.SEVER_CALCULATE_QUOTA_USAGE_BASED_ON_PARTITIONS_ASSIGNMENT_ENABLED;
@@ -445,6 +450,12 @@ public class VeniceServerConfig extends VeniceClusterConfig {
 
   private final long ingestionHeartbeatIntervalMs;
 
+  private final boolean stuckConsumerRepairEnabled;
+  private final int stuckConsumerRepairIntervalSecond;
+  private final int stuckConsumerDetectionRepairThresholdSecond;
+  private final int nonExistingTopicIngestionTaskKillThresholdSecond;
+  private final int nonExistingTopicCheckRetryIntervalSecond;
+
   public VeniceServerConfig(VeniceProperties serverProperties) throws ConfigurationException {
     this(serverProperties, Collections.emptyMap());
   }
@@ -731,6 +742,21 @@ public class VeniceServerConfig extends VeniceClusterConfig {
     metaStoreWriterCloseConcurrency = serverProperties.getInt(META_STORE_WRITER_CLOSE_CONCURRENCY, -1);
     ingestionHeartbeatIntervalMs =
         serverProperties.getLong(SERVER_INGESTION_HEARTBEAT_INTERVAL_MS, TimeUnit.MINUTES.toMillis(1));
+
+    stuckConsumerRepairEnabled = serverProperties.getBoolean(SERVER_STUCK_CONSUMER_REPAIR_ENABLED, true);
+    stuckConsumerRepairIntervalSecond = serverProperties.getInt(SERVER_STUCK_CONSUMER_REPAIR_INTERVAL_SECOND, 60);
+    stuckConsumerDetectionRepairThresholdSecond =
+        serverProperties.getInt(SERVER_STUCK_CONSUMER_REPAIR_THRESHOLD_SECOND, 5 * 60); // 5 mins
+    if (stuckConsumerRepairEnabled && stuckConsumerDetectionRepairThresholdSecond < stuckConsumerRepairIntervalSecond) {
+      throw new VeniceException(
+          "Config for " + SERVER_STUCK_CONSUMER_REPAIR_THRESHOLD_SECOND + ": "
+              + stuckConsumerDetectionRepairThresholdSecond + " should be equal to or larger than "
+              + SERVER_STUCK_CONSUMER_REPAIR_INTERVAL_SECOND + ": " + stuckConsumerRepairIntervalSecond);
+    }
+    nonExistingTopicIngestionTaskKillThresholdSecond =
+        serverProperties.getInt(SERVER_NON_EXISTING_TOPIC_INGESTION_TASK_KILL_THRESHOLD_SECOND, 15 * 60); // 15 mins
+    nonExistingTopicCheckRetryIntervalSecond =
+        serverProperties.getInt(SERVER_NON_EXISTING_TOPIC_CHECK_RETRY_INTERNAL_SECOND, 60); // 1min
   }
 
   long extractIngestionMemoryLimit(
@@ -1283,5 +1309,25 @@ public class VeniceServerConfig extends VeniceClusterConfig {
 
   public long getIngestionHeartbeatIntervalMs() {
     return ingestionHeartbeatIntervalMs;
+  }
+
+  public boolean isStuckConsumerRepairEnabled() {
+    return stuckConsumerRepairEnabled;
+  }
+
+  public int getStuckConsumerRepairIntervalSecond() {
+    return stuckConsumerRepairIntervalSecond;
+  }
+
+  public int getStuckConsumerDetectionRepairThresholdSecond() {
+    return stuckConsumerDetectionRepairThresholdSecond;
+  }
+
+  public int getNonExistingTopicIngestionTaskKillThresholdSecond() {
+    return nonExistingTopicIngestionTaskKillThresholdSecond;
+  }
+
+  public int getNonExistingTopicCheckRetryIntervalSecond() {
+    return nonExistingTopicCheckRetryIntervalSecond;
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaConsumerService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaConsumerService.java
@@ -116,7 +116,7 @@ public abstract class KafkaConsumerService extends AbstractVeniceService {
         : createKafkaConsumerServiceStats(
             metricsRepository,
             kafkaClusterAlias,
-            this::getMaxElapsedTimeSinceLastPollInConsumerPool);
+            this::getMaxElapsedTimeMSSinceLastPollInConsumerPool);
     for (int i = 0; i < numOfConsumersPerKafkaCluster; ++i) {
       /**
        * We need to assign a unique client id across all the storage nodes, otherwise, they will fail into the same throttling bucket.
@@ -324,7 +324,7 @@ public abstract class KafkaConsumerService extends AbstractVeniceService {
         getMaxElapsedTimeSinceLastPollInConsumerPool);
   }
 
-  private long getMaxElapsedTimeSinceLastPollInConsumerPool() {
+  public long getMaxElapsedTimeMSSinceLastPollInConsumerPool() {
     long maxElapsedTimeSinceLastPollInConsumerPool = -1;
     int slowestTaskId = -1;
     long elapsedTimeSinceLastPoll;

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionService.java
@@ -448,7 +448,8 @@ public class KafkaStoreIngestionService extends AbstractVeniceService implements
         kafkaClusterBasedRecordThrottler,
         metricsRepository,
         new MetadataRepoBasedTopicExistingCheckerImpl(this.getMetadataRepo()),
-        pubSubDeserializer);
+        pubSubDeserializer,
+        (topicName) -> this.killConsumptionTask(topicName));
     /**
      * After initializing a {@link AggKafkaConsumerService} service, it doesn't contain KafkaConsumerService yet until
      * a new Kafka cluster is registered; here we explicitly create KafkaConsumerService for the local Kafka cluster.

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -282,7 +282,7 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
   }
 
   @Override
-  protected void closeVeniceWriters(boolean doFlush) {
+  public void closeVeniceWriters(boolean doFlush) {
     if (veniceWriter.isPresent()) {
       veniceWriter.get().close(doFlush);
     }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/KafkaConsumerServiceStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/KafkaConsumerServiceStats.java
@@ -49,7 +49,7 @@ public class KafkaConsumerServiceStats extends AbstractVeniceStats {
      */
     registerSensor(
         "max_elapsed_time_since_last_successful_poll",
-        new Gauge(getMaxElapsedTimeSinceLastPollInConsumerPool.getAsLong()));
+        new Gauge(() -> getMaxElapsedTimeSinceLastPollInConsumerPool.getAsLong()));
     // consumer record number per second returned by Kafka consumer poll.
     pollResultNumSensor = registerSensor("consumer_poll_result_num", new Avg(), new Total());
     pollNonZeroResultNumSensor = registerSensor("consumer_poll_non_zero_result_num", new Avg(), new Total());

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/StuckConsumerRepairStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/StuckConsumerRepairStats.java
@@ -1,0 +1,33 @@
+package com.linkedin.davinci.stats;
+
+import com.linkedin.venice.stats.AbstractVeniceStats;
+import io.tehuti.metrics.MetricsRepository;
+import io.tehuti.metrics.Sensor;
+import io.tehuti.metrics.stats.OccurrenceRate;
+
+
+public class StuckConsumerRepairStats extends AbstractVeniceStats {
+  private Sensor stuckConsumerFound;
+  private Sensor ingestionTaskRepair;
+  private Sensor repairFailure;
+
+  public StuckConsumerRepairStats(MetricsRepository metricsRepository) {
+    super(metricsRepository, "StuckConsumerRepair");
+
+    this.stuckConsumerFound = registerSensor("stuck_consumer_found", new OccurrenceRate());
+    this.ingestionTaskRepair = registerSensor("ingestion_task_repair", new OccurrenceRate());
+    this.repairFailure = registerSensor("repair_failure", new OccurrenceRate());
+  }
+
+  public void recordStuckConsumerFound() {
+    stuckConsumerFound.record();
+  }
+
+  public void recordIngestionTaskRepair() {
+    ingestionTaskRepair.record();
+  }
+
+  public void recordRepairFailure() {
+    repairFailure.record();
+  }
+}

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/AggKafkaConsumerServiceTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/AggKafkaConsumerServiceTest.java
@@ -1,0 +1,124 @@
+package com.linkedin.davinci.kafka.consumer;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.linkedin.davinci.stats.StuckConsumerRepairStats;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Consumer;
+import org.testng.annotations.Test;
+
+
+public class AggKafkaConsumerServiceTest {
+  @Test
+  public void testGetStuckConsumerDetectionAndRepairRunnable() {
+    Map<String, KafkaConsumerService> kafkaServerToConsumerServiceMap = new HashMap<>();
+    Map<String, StoreIngestionTask> versionTopicStoreIngestionTaskMapping = new HashMap<>();
+    long stuckConsumerRepairThresholdMs = 100;
+    long nonExistingTopicIngestionTaskKillThresholdMs = 1000;
+    StuckConsumerRepairStats stuckConsumerRepairStats = mock(StuckConsumerRepairStats.class);
+
+    // Everything is good
+    KafkaConsumerService goodConsumerService = mock(KafkaConsumerService.class);
+    when(goodConsumerService.getMaxElapsedTimeMSSinceLastPollInConsumerPool()).thenReturn(10l);
+    kafkaServerToConsumerServiceMap.put("good", goodConsumerService);
+    StoreIngestionTask goodTask = mock(StoreIngestionTask.class);
+    when(goodTask.isProducingVersionTopicHealthy()).thenReturn(true);
+    versionTopicStoreIngestionTaskMapping.put("good_task", goodTask);
+
+    Consumer<String> killIngestionTaskRunnable = mock(Consumer.class);
+
+    Runnable repairRunnable = AggKafkaConsumerService.getStuckConsumerDetectionAndRepairRunnable(
+        kafkaServerToConsumerServiceMap,
+        versionTopicStoreIngestionTaskMapping,
+        stuckConsumerRepairThresholdMs,
+        nonExistingTopicIngestionTaskKillThresholdMs,
+        200,
+        stuckConsumerRepairStats,
+        killIngestionTaskRunnable);
+    repairRunnable.run();
+    verify(goodConsumerService).getMaxElapsedTimeMSSinceLastPollInConsumerPool();
+    verify(stuckConsumerRepairStats, never()).recordStuckConsumerFound();
+    verify(stuckConsumerRepairStats, never()).recordIngestionTaskRepair();
+    verify(stuckConsumerRepairStats, never()).recordRepairFailure();
+    verify(killIngestionTaskRunnable, never()).accept(any());
+  }
+
+  @Test
+  public void testGetStuckConsumerDetectionAndRepairRunnableForTransientNonExistingTopic() {
+    Map<String, KafkaConsumerService> kafkaServerToConsumerServiceMap = new HashMap<>();
+    Map<String, StoreIngestionTask> versionTopicStoreIngestionTaskMapping = new HashMap<>();
+    long stuckConsumerRepairThresholdMs = 100;
+    long nonExistingTopicIngestionTaskKillThresholdMs = 1000;
+    StuckConsumerRepairStats stuckConsumerRepairStats = mock(StuckConsumerRepairStats.class);
+
+    Consumer<String> killIngestionTaskRunnable = mock(Consumer.class);
+
+    Runnable repairRunnable = AggKafkaConsumerService.getStuckConsumerDetectionAndRepairRunnable(
+        kafkaServerToConsumerServiceMap,
+        versionTopicStoreIngestionTaskMapping,
+        stuckConsumerRepairThresholdMs,
+        nonExistingTopicIngestionTaskKillThresholdMs,
+        200,
+        stuckConsumerRepairStats,
+        killIngestionTaskRunnable);
+    // One stuck consumer
+    KafkaConsumerService badConsumerService = mock(KafkaConsumerService.class);
+    when(badConsumerService.getMaxElapsedTimeMSSinceLastPollInConsumerPool()).thenReturn(1000l);
+    kafkaServerToConsumerServiceMap.put("bad", badConsumerService);
+
+    StoreIngestionTask transientBadTask = mock(StoreIngestionTask.class);
+    when(transientBadTask.isProducingVersionTopicHealthy()).thenReturn(false).thenReturn(true);
+    versionTopicStoreIngestionTaskMapping.put("transient_bad_task", transientBadTask);
+    repairRunnable.run();
+    verify(badConsumerService).getMaxElapsedTimeMSSinceLastPollInConsumerPool();
+    verify(stuckConsumerRepairStats).recordStuckConsumerFound();
+    verify(stuckConsumerRepairStats, never()).recordIngestionTaskRepair();
+    verify(stuckConsumerRepairStats).recordRepairFailure();
+    verify(killIngestionTaskRunnable, never()).accept(any());
+  }
+
+  @Test
+  public void testGetStuckConsumerDetectionAndRepairRunnableForNonExistingTopic() {
+    Map<String, KafkaConsumerService> kafkaServerToConsumerServiceMap = new HashMap<>();
+    Map<String, StoreIngestionTask> versionTopicStoreIngestionTaskMapping = new HashMap<>();
+    long stuckConsumerRepairThresholdMs = 100;
+    long nonExistingTopicIngestionTaskKillThresholdMs = 1000;
+    StuckConsumerRepairStats stuckConsumerRepairStats = mock(StuckConsumerRepairStats.class);
+
+    Consumer<String> killIngestionTaskRunnable = mock(Consumer.class);
+
+    Runnable repairRunnable = AggKafkaConsumerService.getStuckConsumerDetectionAndRepairRunnable(
+        kafkaServerToConsumerServiceMap,
+        versionTopicStoreIngestionTaskMapping,
+        stuckConsumerRepairThresholdMs,
+        nonExistingTopicIngestionTaskKillThresholdMs,
+        200,
+        stuckConsumerRepairStats,
+        killIngestionTaskRunnable);
+    // One stuck consumer
+    KafkaConsumerService badConsumerService = mock(KafkaConsumerService.class);
+    when(badConsumerService.getMaxElapsedTimeMSSinceLastPollInConsumerPool()).thenReturn(1000l);
+    kafkaServerToConsumerServiceMap.put("bad", badConsumerService);
+    StoreIngestionTask badTask = mock(StoreIngestionTask.class);
+    when(badTask.isProducingVersionTopicHealthy()).thenReturn(false);
+    versionTopicStoreIngestionTaskMapping.put("bad_task", badTask);
+    repairRunnable.run();
+    verify(badConsumerService).getMaxElapsedTimeMSSinceLastPollInConsumerPool();
+    verify(badTask, times(6)).isProducingVersionTopicHealthy();
+    verify(badTask).closeVeniceWriters(false);
+    verify(killIngestionTaskRunnable).accept("bad_task");
+    verify(stuckConsumerRepairStats).recordStuckConsumerFound();
+    verify(stuckConsumerRepairStats).recordIngestionTaskRepair();
+
+    // One stuck consumer without any problematic ingestion task
+    versionTopicStoreIngestionTaskMapping.remove("bad_task");
+    repairRunnable.run();
+    verify(stuckConsumerRepairStats).recordRepairFailure();
+  }
+}

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
@@ -3550,7 +3550,6 @@ public abstract class StoreIngestionTaskTest {
     doReturn(veniceWriter).when(veniceWriterFactory).createVeniceWriter(any());
 
     StoreIngestionTaskFactory ingestionTaskFactory = TestUtils.getStoreIngestionTaskBuilder(storeName)
-        .setTopicManagerRepository(mockTopicManagerRepository)
         .setStorageMetadataService(mockStorageMetadataService)
         .setMetadataRepository(mockReadOnlyStoreRepository)
         .setTopicManagerRepository(mockTopicManagerRepository)
@@ -3573,6 +3572,15 @@ public abstract class StoreIngestionTaskTest {
     // Second invocation should be skipped since it shouldn't be time for another heartbeat yet.
     ingestionTask.maybeSendIngestionHeartbeat();
     verify(veniceWriter, times(1)).sendHeartbeat(any(), any(), any());
+
+    /**
+     * Leverage the same test to validate {@link StoreIngestionTask#isProducingVersionTopicHealthy()}
+     */
+    when(mockTopicManager.containsTopic(eq(ingestionTask.getVersionTopic()))).thenReturn(true);
+    Assert.assertTrue(ingestionTask.isProducingVersionTopicHealthy());
+
+    when(mockTopicManager.containsTopic(eq(ingestionTask.getVersionTopic()))).thenReturn(false);
+    Assert.assertFalse(ingestionTask.isProducingVersionTopicHealthy());
   }
 
   private VeniceStoreVersionConfig getDefaultMockVeniceStoreVersionConfig(

--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/stats/BasicClientStats.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/stats/BasicClientStats.java
@@ -16,6 +16,10 @@ import io.tehuti.metrics.stats.Rate;
  * This class offers very basic metrics for client, and right now, it is directly used by DaVinci.
  */
 public class BasicClientStats extends AbstractVeniceHttpStats {
+  private static final String SYSTEM_STORE_NAME_PREFIX = "venice_system_store_";
+
+  private static final MetricsRepository dummySystemStoreMetricRepo = new MetricsRepository();
+
   private final Sensor requestSensor;
   private final Sensor healthySensor;
   private final Sensor unhealthySensor;
@@ -38,7 +42,10 @@ public class BasicClientStats extends AbstractVeniceHttpStats {
   }
 
   protected BasicClientStats(MetricsRepository metricsRepository, String storeName, RequestType requestType) {
-    super(metricsRepository, storeName, requestType);
+    super(
+        storeName.startsWith(SYSTEM_STORE_NAME_PREFIX) ? dummySystemStoreMetricRepo : metricsRepository,
+        storeName,
+        requestType);
     requestSensor = registerSensor("request", requestRate);
     Rate healthyRequestRate = new OccurrenceRate();
     healthySensor = registerSensor("healthy_request", healthyRequestRate);

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/AbstractVeniceHttpStats.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/AbstractVeniceHttpStats.java
@@ -7,13 +7,10 @@ import io.tehuti.metrics.Sensor;
 
 
 public abstract class AbstractVeniceHttpStats extends AbstractVeniceStats {
-  private static final String SYSTEM_STORE_NAME_PREFIX = "venice_system_store_";
-  private static final MetricsRepository dummySystemStoreMetricRepo = new MetricsRepository();
-
   private final RequestType requestType;
 
   public AbstractVeniceHttpStats(MetricsRepository metricsRepository, String storeName, RequestType requestType) {
-    super(storeName.startsWith(SYSTEM_STORE_NAME_PREFIX) ? dummySystemStoreMetricRepo : metricsRepository, storeName);
+    super(metricsRepository, storeName);
     this.requestType = requestType;
   }
 

--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -2015,4 +2015,32 @@ public class ConfigKeys {
    * with SOS, EOS or skipped records.
    */
   public static final String SERVER_INGESTION_HEARTBEAT_INTERVAL_MS = "server.ingestion.heartbeat.interval.ms";
+
+  /**
+   * Whether to enable stuck consumer repair in Server.
+   */
+  public static final String SERVER_STUCK_CONSUMER_REPAIR_ENABLED = "server.stuck.consumer.repair.enabled";
+
+  /**
+   * Server stuck consumer detection interval.
+   */
+  public static final String SERVER_STUCK_CONSUMER_REPAIR_INTERVAL_SECOND = "server.stuck.consumer.repair.second";
+
+  /**
+   * Server stuck consumer repair threshold.
+   */
+  public static final String SERVER_STUCK_CONSUMER_REPAIR_THRESHOLD_SECOND =
+      "server.stuck.consumer.repair.threshold.second";
+
+  /**
+   * When to kill the ingestion task if the topic doesn't exist for the configured period of time.
+   */
+  public static final String SERVER_NON_EXISTING_TOPIC_INGESTION_TASK_KILL_THRESHOLD_SECOND =
+      "server.non.existing.topic.ingestion.task.kill.threshold.second";
+  /**
+   * The config will work together with {@link #SERVER_NON_EXISTING_TOPIC_INGESTION_TASK_KILL_THRESHOLD_SECOND}
+   * to decide whether a certain ingestion task should be killed or not.
+   */
+  public static final String SERVER_NON_EXISTING_TOPIC_CHECK_RETRY_INTERNAL_SECOND =
+      "server.non.existing.topic.check.retry.interval.second";
 }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestStuckConsumerRepair.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestStuckConsumerRepair.java
@@ -1,0 +1,248 @@
+package com.linkedin.venice.endToEnd;
+
+import static com.linkedin.davinci.store.rocksdb.RocksDBServerConfig.ROCKSDB_PLAIN_TABLE_FORMAT_ENABLED;
+import static com.linkedin.venice.ConfigKeys.DEFAULT_MAX_NUMBER_OF_PARTITIONS;
+import static com.linkedin.venice.ConfigKeys.PERSISTENCE_TYPE;
+import static com.linkedin.venice.ConfigKeys.SERVER_CONSUMER_POOL_SIZE_PER_KAFKA_CLUSTER;
+import static com.linkedin.venice.ConfigKeys.SERVER_DATABASE_CHECKSUM_VERIFICATION_ENABLED;
+import static com.linkedin.venice.ConfigKeys.SERVER_DATABASE_SYNC_BYTES_INTERNAL_FOR_DEFERRED_WRITE_MODE;
+import static com.linkedin.venice.ConfigKeys.SERVER_DEDICATED_DRAINER_FOR_SORTED_INPUT_ENABLED;
+import static com.linkedin.venice.ConfigKeys.SERVER_NON_EXISTING_TOPIC_CHECK_RETRY_INTERNAL_SECOND;
+import static com.linkedin.venice.ConfigKeys.SERVER_NON_EXISTING_TOPIC_INGESTION_TASK_KILL_THRESHOLD_SECOND;
+import static com.linkedin.venice.ConfigKeys.SERVER_PROMOTION_TO_LEADER_REPLICA_DELAY_SECONDS;
+import static com.linkedin.venice.ConfigKeys.SERVER_SHARED_CONSUMER_ASSIGNMENT_STRATEGY;
+import static com.linkedin.venice.ConfigKeys.SERVER_STUCK_CONSUMER_REPAIR_ENABLED;
+import static com.linkedin.venice.ConfigKeys.SERVER_STUCK_CONSUMER_REPAIR_INTERVAL_SECOND;
+import static com.linkedin.venice.ConfigKeys.SERVER_STUCK_CONSUMER_REPAIR_THRESHOLD_SECOND;
+import static com.linkedin.venice.ConfigKeys.SSL_TO_KAFKA_LEGACY;
+import static com.linkedin.venice.kafka.TopicManager.DEFAULT_KAFKA_OPERATION_TIMEOUT_MS;
+import static com.linkedin.venice.utils.IntegrationTestPushUtils.createStoreForJob;
+import static com.linkedin.venice.utils.IntegrationTestPushUtils.defaultVPJProps;
+import static com.linkedin.venice.utils.IntegrationTestPushUtils.getSamzaProducer;
+import static com.linkedin.venice.utils.IntegrationTestPushUtils.runVPJ;
+import static com.linkedin.venice.utils.IntegrationTestPushUtils.sendCustomSizeStreamingRecord;
+import static com.linkedin.venice.utils.TestWriteUtils.getTempDataDirectory;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.linkedin.davinci.kafka.consumer.KafkaConsumerService;
+import com.linkedin.venice.client.store.AvroGenericStoreClient;
+import com.linkedin.venice.client.store.ClientConfig;
+import com.linkedin.venice.client.store.ClientFactory;
+import com.linkedin.venice.controllerapi.ControllerClient;
+import com.linkedin.venice.controllerapi.ControllerResponse;
+import com.linkedin.venice.controllerapi.UpdateStoreQueryParams;
+import com.linkedin.venice.exceptions.VeniceException;
+import com.linkedin.venice.integration.utils.ServiceFactory;
+import com.linkedin.venice.integration.utils.VeniceClusterWrapper;
+import com.linkedin.venice.kafka.TopicManager;
+import com.linkedin.venice.meta.PersistenceType;
+import com.linkedin.venice.meta.Version;
+import com.linkedin.venice.utils.IntegrationTestPushUtils;
+import com.linkedin.venice.utils.TestUtils;
+import com.linkedin.venice.utils.TestWriteUtils;
+import com.linkedin.venice.utils.Utils;
+import io.tehuti.metrics.MetricsRepository;
+import java.io.File;
+import java.util.Properties;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import org.apache.avro.Schema;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.samza.system.SystemProducer;
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+
+public class TestStuckConsumerRepair {
+  private static final Logger LOGGER = LogManager.getLogger(TestStuckConsumerRepair.class);
+  public static final int STREAMING_RECORD_SIZE = 1024;
+
+  private VeniceClusterWrapper sharedVenice;
+
+  @BeforeClass(alwaysRun = true)
+  public void setUp() {
+    sharedVenice = setUpCluster();
+  }
+
+  private static VeniceClusterWrapper setUpCluster() {
+    Properties extraProperties = new Properties();
+    extraProperties.setProperty(DEFAULT_MAX_NUMBER_OF_PARTITIONS, "5");
+    VeniceClusterWrapper cluster = ServiceFactory.getVeniceCluster(1, 0, 1, 2, 1000000, false, false, extraProperties);
+
+    // Add Venice Router
+    Properties routerProperties = new Properties();
+    cluster.addVeniceRouter(routerProperties);
+
+    // Add Venice Server
+    Properties serverProperties = new Properties();
+    serverProperties.setProperty(PERSISTENCE_TYPE, PersistenceType.ROCKS_DB.name());
+    serverProperties.setProperty(SERVER_PROMOTION_TO_LEADER_REPLICA_DELAY_SECONDS, Long.toString(1L));
+    serverProperties.setProperty(ROCKSDB_PLAIN_TABLE_FORMAT_ENABLED, "false");
+    serverProperties.setProperty(SERVER_DATABASE_CHECKSUM_VERIFICATION_ENABLED, "true");
+    serverProperties.setProperty(SERVER_DATABASE_SYNC_BYTES_INTERNAL_FOR_DEFERRED_WRITE_MODE, "300");
+
+    serverProperties.setProperty(SSL_TO_KAFKA_LEGACY, "false");
+    serverProperties.setProperty(SERVER_CONSUMER_POOL_SIZE_PER_KAFKA_CLUSTER, "3");
+    serverProperties.setProperty(SERVER_DEDICATED_DRAINER_FOR_SORTED_INPUT_ENABLED, "true");
+    serverProperties.setProperty(SERVER_STUCK_CONSUMER_REPAIR_ENABLED, "true");
+    serverProperties.setProperty(SERVER_STUCK_CONSUMER_REPAIR_INTERVAL_SECOND, "1");
+    serverProperties.setProperty(SERVER_STUCK_CONSUMER_REPAIR_THRESHOLD_SECOND, "2");
+    serverProperties.setProperty(SERVER_NON_EXISTING_TOPIC_INGESTION_TASK_KILL_THRESHOLD_SECOND, "5");
+    serverProperties.setProperty(SERVER_NON_EXISTING_TOPIC_CHECK_RETRY_INTERNAL_SECOND, "1");
+
+    serverProperties.setProperty(DEFAULT_MAX_NUMBER_OF_PARTITIONS, "4");
+    serverProperties.setProperty(
+        SERVER_SHARED_CONSUMER_ASSIGNMENT_STRATEGY,
+        KafkaConsumerService.ConsumerAssignmentStrategy.PARTITION_WISE_SHARED_CONSUMER_ASSIGNMENT_STRATEGY.name());
+    cluster.addVeniceServer(new Properties(), serverProperties);
+    cluster.addVeniceServer(new Properties(), serverProperties);
+
+    return cluster;
+  }
+
+  @AfterClass(alwaysRun = true)
+  public void cleanUp() {
+    Utils.closeQuietlyWithErrorLogged(sharedVenice);
+  }
+
+  private void checkLargeRecord(AvroGenericStoreClient client, int index)
+      throws ExecutionException, InterruptedException {
+    String key = Integer.toString(index);
+    String value = client.get(key).get().toString();
+    assertEquals(
+        value.length(),
+        STREAMING_RECORD_SIZE,
+        "Expected a large record for key '" + key + "' but instead got: '" + value + "'.");
+
+    String expectedChar = Integer.toString(index).substring(0, 1);
+    for (int i = 0; i < value.length(); i++) {
+      assertEquals(value.substring(i, i + 1), expectedChar);
+    }
+  }
+
+  @Test(timeOut = 120 * 000)
+  public void testStuckConsumerRepair() throws Exception {
+    SystemProducer veniceProducer = null;
+
+    VeniceClusterWrapper venice = sharedVenice;
+    try {
+      long streamingMessageLag = 2L;
+
+      String storeName = Utils.getUniqueString("hybrid-store");
+      File inputDir = getTempDataDirectory();
+      String inputDirPath = "file://" + inputDir.getAbsolutePath();
+      Schema recordSchema = TestWriteUtils.writeSimpleAvroFileWithStringToStringSchema(inputDir); // records 1-100
+      Properties vpjProperties = defaultVPJProps(venice, inputDirPath, storeName);
+
+      try (ControllerClient controllerClient = createStoreForJob(venice.getClusterName(), recordSchema, vpjProperties);
+          AvroGenericStoreClient client = ClientFactory.getAndStartGenericAvroClient(
+              ClientConfig.defaultGenericClientConfig(storeName).setVeniceURL(venice.getRandomRouterURL()));
+          TopicManager topicManager =
+              IntegrationTestPushUtils
+                  .getTopicManagerRepo(
+                      DEFAULT_KAFKA_OPERATION_TIMEOUT_MS,
+                      100,
+                      0l,
+                      venice.getPubSubBrokerWrapper(),
+                      sharedVenice.getPubSubTopicRepository())
+                  .getTopicManager()) {
+
+        Cache cacheNothingCache = Mockito.mock(Cache.class);
+        Mockito.when(cacheNothingCache.getIfPresent(Mockito.any())).thenReturn(null);
+        topicManager.setTopicConfigCache(cacheNothingCache);
+
+        ControllerResponse response = controllerClient.updateStore(
+            storeName,
+            new UpdateStoreQueryParams().setHybridRewindSeconds(120).setHybridOffsetLagThreshold(streamingMessageLag));
+
+        Assert.assertFalse(response.isError());
+
+        // Do a VPJ push
+        runVPJ(vpjProperties, 1, controllerClient);
+
+        // Verify some records (note, records 1-100 have been pushed)
+        TestUtils.waitForNonDeterministicAssertion(10, TimeUnit.SECONDS, true, () -> {
+          try {
+            for (int i = 1; i < 100; i++) {
+              String key = Integer.toString(i);
+              Object value = client.get(key).get();
+              assertNotNull(value, "Key " + i + " should not be missing!");
+              assertEquals(value.toString(), "test_name_" + key);
+            }
+          } catch (Exception e) {
+            throw new VeniceException(e);
+          }
+        });
+
+        // write streaming records
+        veniceProducer = getSamzaProducer(venice, storeName, Version.PushType.STREAM);
+        for (int i = 1; i <= 10; i++) {
+          // The batch values are small, but the streaming records are "big" (i.e.: not that big, but bigger than
+          // the server's max configured chunk size). In the scenario where chunking is disabled, the server's
+          // max chunk size is not altered, and thus this will be under threshold.
+          sendCustomSizeStreamingRecord(veniceProducer, storeName, i, STREAMING_RECORD_SIZE);
+        }
+
+        // Run one more VPJ
+        runVPJ(vpjProperties, 2, controllerClient);
+
+        // Verify streaming record in second version
+        checkLargeRecord(client, 2);
+        assertEquals(client.get("19").get().toString(), "test_name_19");
+
+        for (int i = 10; i <= 20; i++) {
+          sendCustomSizeStreamingRecord(veniceProducer, storeName, i, STREAMING_RECORD_SIZE);
+        }
+        TestUtils.waitForNonDeterministicAssertion(15, TimeUnit.SECONDS, () -> {
+          try {
+            checkLargeRecord(client, 19);
+          } catch (Exception e) {
+            throw new VeniceException(e);
+          }
+        });
+
+        // Delete v1 topic to simulate producer stuck issue
+        String topicForV1 = Version.composeKafkaTopic(storeName, 1);
+        topicManager.ensureTopicIsDeletedAndBlock(sharedVenice.getPubSubTopicRepository().getTopic(topicForV1));
+        LOGGER.info("Topic: {} has been deleted", topicForV1);
+        Utils.sleep(10000); // 10 seconds to let Kafka client get the topic deletion signal
+
+        // Start sending more streaming records
+        for (int i = 20; i <= 100; i++) {
+          sendCustomSizeStreamingRecord(veniceProducer, storeName, i, 1024);
+        }
+        // Verify that the stuck consumer repair logic does kick in
+        MetricsRepository serverRepo = venice.getVeniceServers().get(0).getMetricsRepository();
+        TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, () -> {
+          assertTrue(
+              serverRepo.metrics().get(".StuckConsumerRepair--stuck_consumer_found.OccurrenceRate").value() > 0f);
+          assertTrue(
+              serverRepo.metrics().get(".StuckConsumerRepair--ingestion_task_repair.OccurrenceRate").value() > 0f);
+          assertTrue(serverRepo.metrics().get(".StuckConsumerRepair--repair_failure.OccurrenceRate").value() == 0.0f);
+        });
+
+        TestUtils.waitForNonDeterministicAssertion(60, TimeUnit.SECONDS, () -> {
+          try {
+            for (int i = 20; i <= 100; ++i) {
+              checkLargeRecord(client, i);
+            }
+          } catch (Exception e) {
+            throw new VeniceException(e);
+          }
+        });
+      }
+    } finally {
+      if (veniceProducer != null) {
+        veniceProducer.stop();
+      }
+    }
+  }
+
+}

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/kafka/KafkaConsumptionTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/kafka/KafkaConsumptionTest.java
@@ -192,7 +192,8 @@ public class KafkaConsumptionTest {
         kafkaClusterBasedRecordThrottler,
         metricsRepository,
         topicExistenceChecker,
-        pubSubDeserializer);
+        pubSubDeserializer,
+        (ignored) -> {});
 
     versionTopic = getTopic();
     int partition = 0;

--- a/services/venice-server/src/main/java/com/linkedin/venice/listener/HttpChannelInitializer.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/listener/HttpChannelInitializer.java
@@ -63,6 +63,8 @@ public class HttpChannelInitializer extends ChannelInitializer<SocketChannel> {
   AggServerQuotaTokenBucketStats quotaTokenBucketStats;
   List<ServerInterceptor> aclInterceptors;
 
+  private boolean isDaVinciClient;
+
   public HttpChannelInitializer(
       ReadOnlyStoreRepository storeMetadataRepository,
       CompletableFuture<HelixCustomizedViewOfflinePushRepository> customizedViewRepository,
@@ -75,6 +77,7 @@ public class HttpChannelInitializer extends ChannelInitializer<SocketChannel> {
       StorageReadRequestHandler requestHandler) {
     this.serverConfig = serverConfig;
     this.requestHandler = requestHandler;
+    this.isDaVinciClient = serverConfig.isDaVinciClient();
 
     boolean isKeyValueProfilingEnabled = serverConfig.isKeyValueProfilingEnabled();
     boolean isUnregisterMetricForDeletedStoreEnabled = serverConfig.isUnregisterMetricForDeletedStoreEnabled();
@@ -84,19 +87,22 @@ public class HttpChannelInitializer extends ChannelInitializer<SocketChannel> {
         RequestType.SINGLE_GET,
         isKeyValueProfilingEnabled,
         storeMetadataRepository,
-        isUnregisterMetricForDeletedStoreEnabled);
+        isUnregisterMetricForDeletedStoreEnabled,
+        isDaVinciClient);
     this.multiGetStats = new AggServerHttpRequestStats(
         metricsRepository,
         RequestType.MULTI_GET,
         isKeyValueProfilingEnabled,
         storeMetadataRepository,
-        isUnregisterMetricForDeletedStoreEnabled);
+        isUnregisterMetricForDeletedStoreEnabled,
+        isDaVinciClient);
     this.computeStats = new AggServerHttpRequestStats(
         metricsRepository,
         RequestType.COMPUTE,
         isKeyValueProfilingEnabled,
         storeMetadataRepository,
-        isUnregisterMetricForDeletedStoreEnabled);
+        isUnregisterMetricForDeletedStoreEnabled,
+        isDaVinciClient);
 
     if (serverConfig.isComputeFastAvroEnabled()) {
       LOGGER.info("Fast avro for compute is enabled");

--- a/services/venice-server/src/main/java/com/linkedin/venice/listener/ListenerService.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/listener/ListenerService.java
@@ -64,6 +64,8 @@ public class ListenerService extends AbstractVeniceService {
 
   private StorageReadRequestHandler storageReadRequestHandler;
 
+  private boolean isDaVinciClient;
+
   public ListenerService(
       StorageEngineRepository storageEngineRepository,
       ReadOnlyStoreRepository storeMetadataRepository,

--- a/services/venice-server/src/main/java/com/linkedin/venice/stats/AggServerHttpRequestStats.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/stats/AggServerHttpRequestStats.java
@@ -16,10 +16,11 @@ public class AggServerHttpRequestStats extends AbstractVeniceAggStoreStats<Serve
       RequestType requestType,
       boolean isKeyValueProfilingEnabled,
       ReadOnlyStoreRepository metadataRepository,
-      boolean unregisterMetricForDeletedStoreEnabled) {
+      boolean unregisterMetricForDeletedStoreEnabled,
+      boolean isDaVinciClient) {
     super(
         metricsRepository,
-        new ServerHttpRequestStatsSupplier(requestType, isKeyValueProfilingEnabled),
+        new ServerHttpRequestStatsSupplier(requestType, isKeyValueProfilingEnabled, isDaVinciClient),
         metadataRepository,
         unregisterMetricForDeletedStoreEnabled);
   }
@@ -28,9 +29,15 @@ public class AggServerHttpRequestStats extends AbstractVeniceAggStoreStats<Serve
     private final RequestType requestType;
     private final boolean isKeyValueProfilingEnabled;
 
-    ServerHttpRequestStatsSupplier(RequestType requestType, boolean isKeyValueProfilingEnabled) {
+    private boolean isDaVinciClient;
+
+    ServerHttpRequestStatsSupplier(
+        RequestType requestType,
+        boolean isKeyValueProfilingEnabled,
+        boolean isDaVinciClient) {
       this.requestType = requestType;
       this.isKeyValueProfilingEnabled = isKeyValueProfilingEnabled;
+      this.isDaVinciClient = isDaVinciClient;
     }
 
     @Override
@@ -48,7 +55,8 @@ public class AggServerHttpRequestStats extends AbstractVeniceAggStoreStats<Serve
           storeName,
           requestType,
           isKeyValueProfilingEnabled,
-          totalStats);
+          totalStats,
+          isDaVinciClient);
     }
   }
 

--- a/services/venice-server/src/main/java/com/linkedin/venice/stats/ServerHttpRequestStats.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/stats/ServerHttpRequestStats.java
@@ -59,13 +59,16 @@ public class ServerHttpRequestStats extends AbstractVeniceHttpStats {
   private final Sensor successRequestKeyRatioSensor, successRequestRatioSensor;
   private final Sensor misroutedStoreVersionSensor;
 
+  private static final MetricsRepository dummySystemStoreMetricRepo = new MetricsRepository();
+
   public ServerHttpRequestStats(
       MetricsRepository metricsRepository,
       String storeName,
       RequestType requestType,
       boolean isKeyValueProfilingEnabled,
-      ServerHttpRequestStats totalStats) {
-    super(metricsRepository, storeName, requestType);
+      ServerHttpRequestStats totalStats,
+      boolean isDaVinciClient) {
+    super(isDaVinciClient ? dummySystemStoreMetricRepo : metricsRepository, storeName, requestType);
 
     /**
      * Check java doc of function: {@link TehutiUtils.RatioStat} to understand why choosing {@link Rate} instead of

--- a/services/venice-server/src/test/java/com/linkedin/venice/stats/AggServerHttpRequestStatsTest.java
+++ b/services/venice-server/src/test/java/com/linkedin/venice/stats/AggServerHttpRequestStatsTest.java
@@ -34,13 +34,15 @@ public class AggServerHttpRequestStatsTest {
         RequestType.SINGLE_GET,
         false,
         Mockito.mock(ReadOnlyStoreRepository.class),
-        true);
+        true,
+        false);
     this.batchGetStats = new AggServerHttpRequestStats(
         metricsRepository,
         RequestType.MULTI_GET,
         false,
         Mockito.mock(ReadOnlyStoreRepository.class),
-        true);
+        true,
+        false);
   }
 
   @AfterTest


### PR DESCRIPTION


    [server][da-vinci] Construct the MaxElapsedTimeSinceLastPoll Gauge metric with function instead of value (#781)
    
    Constructing Venice Gauge metric with value is pointless; Venice Gauge metric
    can only work with function.

    [server] Introduced a repair service for stuck shared consumer (#757)
    
    * [server] Introduced a repair service for stuck shared consumer
    
    Recently, we noticed that some shared consumers were stuck since they
    were blocked by producing to some non-existing topics, and many other
    store versions got affected since the stuck consumer is being shared
    by many other stores.
    This PR introduces a way to detect and repair stuck consumer for above
    situation.
    In the high level, there will be a thread periodically check whether consumer#poll
    is being invoked regularly or not, and if not, the thread will scan all
    the ingestion tasks to see whether they are producing to any non-existing topics
    or not. And for the store ingestion task, which is talking to some non-existing topic,
    the repair thread will try to close the stuck KafkaProducer and kill the corresponding
    ingestion task.
    This PR also checked the non-existing topics for a configurable duration to tolerate
    tranisent topic metadata propagaton delay.
    
    5 new server configs:
    
    server.stuck.consumer.repair.enabled : default true
    server.stuck.consumer.repair.second : default 1 min
    server.stuck.consumer.repair.threshold.second : default 5 mins
    server.non.existing.topic.ingestion.task.kill.threshold.second: default 15 mins
    server.non.existing.topic.check.retry.interval.second: default 1 min
    
    
    3 new server metrics:
    
    .StuckConsumerRepair--stuck_consumer_found.OccurrenceRate
    .StuckConsumerRepair--ingestion_task_repair.OccurrenceRate
    .StuckConsumerRepair--repair_failure.OccurrenceRate

## How was this PR tested?
CI
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.