### PR TITLE
[server] Forced kill producers when ingestion task is killed

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -648,9 +648,12 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
             new VeniceException("Kill the consumer"));
         /*
          * close can not stop the consumption synchronously, but the status of helix would be set to ERROR after
-         * reportError. The only way to stop it synchronously is interrupt the current running thread, but it's an unsafe
-         * operation, for example it could break the ongoing db operation, so we should avoid that.
+         * reportError. This push is being killed by controller, so this version is abandoned, it will not have
+         * chances to serve traffic; forced kill all resources in this push.
+         * N.B.: if we start seeing alerts from forced killed resource, consider whether we should keep those alerts
+         *       if they are useful, or refactor them.
          */
+        closeVeniceWriters(false);
         close();
       }
     }


### PR DESCRIPTION
## Summary
If StoreIngestionTask receives a kill-job command from Controller or operators, that means this store version is abandoned and it wouldn't have a chance to come online again. In that case, do a forced kill on resources like producer instead of trying to gracefully stop the ingestion task.

## How was this PR tested?
CI

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.