### PR TITLE
[server] Fix edge case in AAWC list element update

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/schema/merge/SortBasedCollectionFieldOpHandler.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/schema/merge/SortBasedCollectionFieldOpHandler.java
@@ -564,11 +564,9 @@ public class SortBasedCollectionFieldOpHandler extends CollectionFieldOperationH
       if (activeTimestamp == null) {
         activeElementToTsMap.put(toAddElement, modifyTimestamp);
         updated = true;
-      } else if (activeTimestamp != modifyTimestamp) {
-        // activeElementToTsMap.remove(toAddElement);
+      } else if (activeTimestamp < modifyTimestamp) {
         activeElementToTsMap.put(toAddElement, modifyTimestamp);
         updated = true;
-
       }
     }
 

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/replication/merge/TestMergeUpdate.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/replication/merge/TestMergeUpdate.java
@@ -486,7 +486,7 @@ public class TestMergeUpdate extends TestMergeBase {
 
     Assert.assertEquals(
         updatedValueRecord.get(STRING_ARRAY_FIELD_NAME),
-        Arrays.asList(new Utf8("key1"), new Utf8("key2"), new Utf8("key3"), new Utf8("key4")));
+        Arrays.asList(new Utf8("key1"), new Utf8("key2"), new Utf8("key4"), new Utf8("key3")));
 
     IndexedHashMap<Utf8, Utf8> expectedMap = new IndexedHashMap<>();
     expectedMap.put(new Utf8("key1"), new Utf8("2"));
@@ -499,7 +499,7 @@ public class TestMergeUpdate extends TestMergeBase {
     GenericRecord updatedRmdTsRecord = (GenericRecord) result.getRmdRecord().get(RmdConstants.TIMESTAMP_FIELD_NAME);
     GenericRecord updatedListTsRecord = (GenericRecord) updatedRmdTsRecord.get(STRING_ARRAY_FIELD_NAME);
     Assert.assertEquals(updatedListTsRecord.get(TOP_LEVEL_TS_FIELD_NAME), 1L);
-    Assert.assertEquals(updatedListTsRecord.get(ACTIVE_ELEM_TS_FIELD_NAME), Arrays.asList(2L, 2L, 2L, 2L));
+    Assert.assertEquals(updatedListTsRecord.get(ACTIVE_ELEM_TS_FIELD_NAME), Arrays.asList(2L, 2L, 2L, 3L));
     Assert.assertEquals(updatedListTsRecord.get(PUT_ONLY_PART_LENGTH_FIELD_NAME), 0);
     Assert.assertEquals(updatedListTsRecord.get(DELETED_ELEM_FIELD_NAME), Arrays.asList("key5", "key6"));
     Assert.assertEquals(updatedListTsRecord.get(DELETED_ELEM_TS_FIELD_NAME), Arrays.asList(2L, 3L));

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/replication/merge/helper/ListCollectionMergeTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/replication/merge/helper/ListCollectionMergeTest.java
@@ -254,4 +254,24 @@ public class ListCollectionMergeTest extends SortBasedCollectionFieldOperationHa
         allCollectionOps,
         ExpectedCollectionResults.createExpectedListResult(LIST_FIELD_NAME, expectedItemsResult));
   }
+
+  @Test
+  public void testHandleListOpsCase11() {
+    /**
+     * Put partially overrides collection-merge-only value:
+     *
+     *  - Event 1, at T1, in DC1, merge 1 to list
+     *  - Event 2, at T2, in DC2, delete 1 from list
+     *  - Event 3, at T3, in DC3, merge 1 to list
+     */
+    List<CollectionOperation> allCollectionOps = Arrays.asList(
+        new MergeListOperation(1L, COLO_ID_1, Collections.singletonList(1), Collections.emptyList(), LIST_FIELD_NAME),
+        new MergeListOperation(2L, COLO_ID_2, Collections.emptyList(), Collections.singletonList(1), LIST_FIELD_NAME),
+        new MergeListOperation(3L, COLO_ID_3, Collections.singletonList(1), Collections.emptyList(), LIST_FIELD_NAME));
+    List<Integer> expectedItemsResult = Collections.singletonList(1);
+    applyAllOperationsOnValue(
+        allCollectionOps,
+        ExpectedCollectionResults.createExpectedListResult(LIST_FIELD_NAME, expectedItemsResult));
+  }
+
 }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/schema/merge/CollectionMergeTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/schema/merge/CollectionMergeTest.java
@@ -309,7 +309,7 @@ public class CollectionMergeTest {
         toRemoveItems);
 
     List<String> updatedMap = (List<String>) currValueRecord.get(LIST_FIELD_NAME);
-    Assert.assertEquals(updatedMap, Arrays.asList("key1", "key2", "key3", "key4"));
+    Assert.assertEquals(updatedMap, Arrays.asList("key1", "key2", "key4", "key3"));
   }
 
   private GenericRecord initiateFieldLevelRmdRecord() {


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## [server] Fix edge case in AAWC list element update
This PR tries to fix a bug in AAWC logic on list element update.
The bug is: when trying to update a pre-existing element in the list field, it only check if the TS is different from the existing element, not greater than the existing element TS. It might lead to update timestamp rewind for the element, and if there is another DELETE that happens between the two updates TS, certain update order can lead to data being deleted - thus data loss.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
Add new unit test.
## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.