### PR TITLE
Reduce the number of controller requests sent by system store initializer

### DIFF
--- a/internal/venice-common/src/main/java/com/linkedin/venice/system/store/ControllerClientBackedSystemSchemaInitializer.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/system/store/ControllerClientBackedSystemSchemaInitializer.java
@@ -16,6 +16,7 @@ import com.linkedin.venice.controllerapi.UpdateStoreQueryParams;
 import com.linkedin.venice.exceptions.ErrorType;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.schema.avro.DirectionalSchemaCompatibilityType;
+import com.linkedin.venice.schema.writecompute.DerivedSchemaEntry;
 import com.linkedin.venice.schema.writecompute.WriteComputeSchemaConverter;
 import com.linkedin.venice.security.SSLFactory;
 import com.linkedin.venice.serialization.avro.AvroProtocolDefinition;
@@ -23,9 +24,11 @@ import com.linkedin.venice.utils.RetryUtils;
 import com.linkedin.venice.utils.Utils;
 import java.io.Closeable;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import org.apache.avro.Schema;
@@ -134,18 +137,25 @@ public class ControllerClientBackedSystemSchemaInitializer implements Closeable 
     }
 
     MultiSchemaResponse multiSchemaResponse =
-        controllerClient.retryableRequest(DEFAULT_RETRY_TIMES, c -> c.getAllValueSchema(storeName));
+        controllerClient.retryableRequest(DEFAULT_RETRY_TIMES, c -> c.getAllValueAndDerivedSchema(storeName));
     if (multiSchemaResponse.isError()) {
       throw new VeniceException(
           "Error when getting all value schemas from system store " + storeName + " in cluster " + clusterName
               + " after retries. Error: " + multiSchemaResponse.getError());
     }
-    Map<Integer, Schema> schemasInZk = new HashMap<>();
-    Arrays.stream(multiSchemaResponse.getSchemas())
-        .forEach(schema -> schemasInZk.put(schema.getId(), AvroCompatibilityHelper.parse(schema.getSchemaStr())));
+    Map<Integer, Schema> valueSchemasInZk = new HashMap<>();
+    List<DerivedSchemaEntry> partialUpdateSchemasInZk = new ArrayList<>();
+    Arrays.stream(multiSchemaResponse.getSchemas()).forEach(schema -> {
+      if (schema.isDerivedSchema()) {
+        partialUpdateSchemasInZk
+            .add(new DerivedSchemaEntry(schema.getId(), schema.getDerivedSchemaId(), schema.getSchemaStr()));
+      } else {
+        valueSchemasInZk.put(schema.getId(), AvroCompatibilityHelper.parse(schema.getSchemaStr()));
+      }
+    });
 
     if (isSchemaResourceInLocal) {
-      registerLocalSchemaResources(storeName, schemaResources, schemasInZk);
+      registerLocalSchemaResources(storeName, schemaResources, valueSchemasInZk, partialUpdateSchemasInZk);
     } else {
       // For passed in new schemas, its version could be larger than protocolDefinition.getCurrentProtocolVersion(),
       // register schema directly.
@@ -153,7 +163,7 @@ public class ControllerClientBackedSystemSchemaInitializer implements Closeable 
         checkAndMayRegisterValueSchema(
             storeName,
             entry.getKey(),
-            schemasInZk.get(entry.getKey()),
+            valueSchemasInZk.get(entry.getKey()),
             entry.getValue(),
             determineSchemaCompatabilityType());
       }
@@ -163,7 +173,8 @@ public class ControllerClientBackedSystemSchemaInitializer implements Closeable 
   private void registerLocalSchemaResources(
       String storeName,
       Map<Integer, Schema> schemaResources,
-      Map<Integer, Schema> schemasInZk) {
+      Map<Integer, Schema> valueSchemasInZk,
+      List<DerivedSchemaEntry> partialUpdateSchemasInZk) {
     for (int version = 1; version <= protocolDefinition.getCurrentProtocolVersion(); version++) {
       Schema schemaInLocalResources = schemaResources.get(version);
       if (schemaInLocalResources == null) {
@@ -175,22 +186,18 @@ public class ControllerClientBackedSystemSchemaInitializer implements Closeable 
         checkAndMayRegisterValueSchema(
             storeName,
             version,
-            schemasInZk.get(version),
+            valueSchemasInZk.get(version),
             schemaInLocalResources,
             determineSchemaCompatabilityType());
 
         if (autoRegisterPartialUpdateSchema) {
-          checkAndMayRegisterPartialUpdateSchema(storeName, version, schemaInLocalResources);
+          checkAndMayRegisterPartialUpdateSchema(storeName, version, schemaInLocalResources, partialUpdateSchemasInZk);
         }
       }
     }
   }
 
   DirectionalSchemaCompatibilityType determineSchemaCompatabilityType() {
-    if (protocolDefinition == AvroProtocolDefinition.METADATA_SYSTEM_SCHEMA_STORE) {
-      return DirectionalSchemaCompatibilityType.FULL;
-    }
-
     if (protocolDefinition == AvroProtocolDefinition.KAFKA_MESSAGE_ENVELOPE) {
       return DirectionalSchemaCompatibilityType.BACKWARD;
     }
@@ -317,35 +324,35 @@ public class ControllerClientBackedSystemSchemaInitializer implements Closeable 
   private void checkAndMayRegisterPartialUpdateSchema(
       String storeName,
       int valueSchemaId,
-      Schema schemaInLocalResources) {
-    String partialUpdateSchema =
-        WriteComputeSchemaConverter.getInstance().convertFromValueRecordSchema(schemaInLocalResources).toString();
-    SchemaResponse getSchemaResponse = controllerClient.retryableRequest(
-        DEFAULT_RETRY_TIMES,
-        c -> c.getValueOrDerivedSchemaId(storeName, partialUpdateSchema),
-        r -> r.getError().contains("Can not find any registered value schema nor derived schema"));
-    if (getSchemaResponse.isError()) {
-      if (getSchemaResponse.getError().contains("Can not find any registered value schema nor derived schema")) {
-        // The derived schema doesn't exist right now, try to register it.
-        SchemaResponse addDerivedSchemaResponse = controllerClient.retryableRequest(
-            DEFAULT_RETRY_TIMES,
-            c -> c.addDerivedSchema(storeName, valueSchemaId, partialUpdateSchema));
-        if (addDerivedSchemaResponse.isError()) {
-          throw new VeniceException(
-              "Error when adding derived schema for value schema v" + valueSchemaId + " to system store " + storeName
-                  + " in cluster " + clusterName + " after retries. Error: " + addDerivedSchemaResponse.getError());
-        }
+      Schema valueSchemaInLocalResources,
+      List<DerivedSchemaEntry> partialUpdateSchemasInZk) {
+    Schema partialUpdateSchema =
+        WriteComputeSchemaConverter.getInstance().convertFromValueRecordSchema(valueSchemaInLocalResources);
+    String partialUpdateSchemaToFind = AvroCompatibilityHelper.toParsingForm(partialUpdateSchema);
+    for (DerivedSchemaEntry partialUpdateSchemaInZk: partialUpdateSchemasInZk) {
+      if (partialUpdateSchemaToFind.equals(partialUpdateSchemaInZk.getCanonicalSchemaStr())) {
         LOGGER.info(
-            "Added derived schema v{} for value schema v{} to system store {}.",
-            addDerivedSchemaResponse.getDerivedSchemaId(),
-            valueSchemaId,
-            storeName);
-      } else {
-        throw new VeniceException(
-            "Error when getting derived schema from system store " + storeName + " in cluster " + clusterName
-                + " after retries. Error: " + getSchemaResponse.getError());
+            "Partial update schema in system store {} is already registered as version {}-{}.",
+            storeName,
+            partialUpdateSchemaInZk.getValueSchemaID(),
+            partialUpdateSchemaInZk.getId());
+        return;
       }
     }
+    // Partial update schema doesn't exist right now, try to register it.
+    SchemaResponse addDerivedSchemaResponse = controllerClient.retryableRequest(
+        DEFAULT_RETRY_TIMES,
+        c -> c.addDerivedSchema(storeName, valueSchemaId, partialUpdateSchema.toString()));
+    if (addDerivedSchemaResponse.isError()) {
+      throw new VeniceException(
+          "Error when adding derived schema for value schema v" + valueSchemaId + " to system store " + storeName
+              + " in cluster " + clusterName + " after retries. Error: " + addDerivedSchemaResponse.getError());
+    }
+    LOGGER.info(
+        "Added partial update schema v{}-{} to system store {}.",
+        addDerivedSchemaResponse.getDerivedSchemaId(),
+        valueSchemaId,
+        storeName);
   }
 
   @Override

--- a/internal/venice-common/src/main/java/com/linkedin/venice/system/store/ControllerClientBackedSystemSchemaInitializer.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/system/store/ControllerClientBackedSystemSchemaInitializer.java
@@ -345,13 +345,13 @@ public class ControllerClientBackedSystemSchemaInitializer implements Closeable 
         c -> c.addDerivedSchema(storeName, valueSchemaId, partialUpdateSchema.toString()));
     if (addDerivedSchemaResponse.isError()) {
       throw new VeniceException(
-          "Error when adding derived schema for value schema v" + valueSchemaId + " to system store " + storeName
+          "Error when adding partial update schema for value schema v" + valueSchemaId + " to system store " + storeName
               + " in cluster " + clusterName + " after retries. Error: " + addDerivedSchemaResponse.getError());
     }
     LOGGER.info(
         "Added partial update schema v{}-{} to system store {}.",
-        addDerivedSchemaResponse.getDerivedSchemaId(),
         valueSchemaId,
+        addDerivedSchemaResponse.getDerivedSchemaId(),
         storeName);
   }
 


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Summary
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
Today controller client backed initializer sends a get_value_or_derived_schema_id for every meta system store value schema, to check if its partial update schema exists. But actually controller has get_all_value_and_derived_schema api to get all schemas so that we can check if any schema exists. This commit switches to use this api, which helps reduce the number of controller requests from n to 1.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
Updated unit test `testCreateSystemStoreAndRegisterSchema` passed
Existing integ test `testStartServerWithSystemSchemaInitialization` passed

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.