### PR TITLE
[build] upgraded rocksdb dep to 8.8.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -105,7 +105,7 @@ ext.libraries = [
     pulsarIoCommon: "${pulsarGroup}:pulsar-io-common:${pulsarVersion}",
     r2: "com.linkedin.pegasus:r2:${pegasusVersion}",
     restliCommon: "com.linkedin.pegasus:restli-common:${pegasusVersion}",
-    rocksdbjni: 'org.rocksdb:rocksdbjni:7.9.2',
+    rocksdbjni: 'org.rocksdb:rocksdbjni:8.8.1',
     samzaApi: 'org.apache.samza:samza-api:1.5.1',
     slf4j: 'org.slf4j:slf4j:1.7.36',
     slf4jApi: 'org.slf4j:slf4j-api:1.7.36',

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/RocksDBServerConfig.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/RocksDBServerConfig.java
@@ -219,7 +219,6 @@ public class RocksDBServerConfig {
 
   private final long rocksDBBlockCacheSizeInBytes;
   private final long rocksDBRMDBlockCacheSizeInBytes;
-  private final long rocksDBBlockCacheCompressedSizeInBytes;
   private final boolean rocksDBBlockCacheStrictCapacityLimit;
   private final boolean rocksDBSetCacheIndexAndFilterBlocks;
   private final int rocksDBBlockCacheShardBits;
@@ -296,8 +295,6 @@ public class RocksDBServerConfig {
 
     this.rocksDBBlockCacheSizeInBytes =
         props.getSizeInBytes(ROCKSDB_BLOCK_CACHE_SIZE_IN_BYTES, 16 * 1024 * 1024 * 1024L); // 16GB
-    this.rocksDBBlockCacheCompressedSizeInBytes =
-        props.getSizeInBytes(ROCKSDB_BLOCK_CACHE_COMPRESSED_SIZE_IN_BYTES, 0L); // disable compressed cache
     this.rocksDBRMDBlockCacheSizeInBytes =
         props.getSizeInBytes(ROCKSDB_RMD_BLOCK_CACHE_SIZE_IN_BYTES, 2 * 1024 * 1024 * 1024L); // 2GB
 
@@ -451,10 +448,6 @@ public class RocksDBServerConfig {
 
   public int getRocksDBBlockCacheShardBits() {
     return rocksDBBlockCacheShardBits;
-  }
-
-  public long getRocksDBBlockCacheCompressedSizeInBytes() {
-    return rocksDBBlockCacheCompressedSizeInBytes;
   }
 
   public long getRocksDBSSTFileBlockSizeInBytes() {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/RocksDBStoragePartition.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/RocksDBStoragePartition.java
@@ -376,13 +376,6 @@ public class RocksDBStoragePartition extends AbstractStoragePartition {
       tableConfig.setBlockSize(rocksDBServerConfig.getRocksDBSSTFileBlockSizeInBytes());
       tableConfig.setBlockCache(factory.getSharedCache(isRMD));
       tableConfig.setCacheIndexAndFilterBlocks(rocksDBServerConfig.isRocksDBSetCacheIndexAndFilterBlocks());
-
-      // TODO Consider Adding "cache_index_and_filter_blocks_with_high_priority" to allow for preservation of indexes in
-      // memory.
-      // https://github.com/facebook/rocksdb/wiki/Block-Cache#caching-index-and-filter-blocks
-      // https://github.com/facebook/rocksdb/wiki/Block-Cache#lru-cache
-
-      tableConfig.setBlockCacheCompressedSize(rocksDBServerConfig.getRocksDBBlockCacheCompressedSizeInBytes());
       tableConfig.setFormatVersion(rocksDBServerConfig.getBlockBaseFormatVersion());
       options.setTableFormatConfig(tableConfig);
     }

--- a/services/venice-server/src/main/java/com/linkedin/venice/stats/RocksDBStats.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/stats/RocksDBStats.java
@@ -9,13 +9,11 @@ import static org.rocksdb.TickerType.BLOCK_CACHE_DATA_BYTES_INSERT;
 import static org.rocksdb.TickerType.BLOCK_CACHE_DATA_HIT;
 import static org.rocksdb.TickerType.BLOCK_CACHE_DATA_MISS;
 import static org.rocksdb.TickerType.BLOCK_CACHE_FILTER_ADD;
-import static org.rocksdb.TickerType.BLOCK_CACHE_FILTER_BYTES_EVICT;
 import static org.rocksdb.TickerType.BLOCK_CACHE_FILTER_BYTES_INSERT;
 import static org.rocksdb.TickerType.BLOCK_CACHE_FILTER_HIT;
 import static org.rocksdb.TickerType.BLOCK_CACHE_FILTER_MISS;
 import static org.rocksdb.TickerType.BLOCK_CACHE_HIT;
 import static org.rocksdb.TickerType.BLOCK_CACHE_INDEX_ADD;
-import static org.rocksdb.TickerType.BLOCK_CACHE_INDEX_BYTES_EVICT;
 import static org.rocksdb.TickerType.BLOCK_CACHE_INDEX_BYTES_INSERT;
 import static org.rocksdb.TickerType.BLOCK_CACHE_INDEX_HIT;
 import static org.rocksdb.TickerType.BLOCK_CACHE_INDEX_MISS;
@@ -51,12 +49,10 @@ public class RocksDBStats extends AbstractVeniceStats {
   private final Sensor blockCacheIndexHit;
   private final Sensor blockCacheIndexAdd;
   private final Sensor blockCacheIndexBytesInsert;
-  private final Sensor blockCacheIndexBytesEvict;
   private final Sensor blockCacheFilterMiss;
   private final Sensor blockCacheFilterHit;
   private final Sensor blockCacheFilterAdd;
   private final Sensor blockCacheFilterBytesInsert;
-  private final Sensor blockCacheFilterBytesEvict;
   private final Sensor blockCacheDataMiss;
   private final Sensor blockCacheDataHit;
   private final Sensor blockCacheDataAdd;
@@ -87,15 +83,11 @@ public class RocksDBStats extends AbstractVeniceStats {
     this.blockCacheIndexAdd = registerSensor("rocksdb_block_cache_index_add", BLOCK_CACHE_INDEX_ADD);
     this.blockCacheIndexBytesInsert =
         registerSensor("rocksdb_block_cache_index_bytes_insert", BLOCK_CACHE_INDEX_BYTES_INSERT);
-    this.blockCacheIndexBytesEvict =
-        registerSensor("rocksdb_block_cache_index_bytes_evict", BLOCK_CACHE_INDEX_BYTES_EVICT);
     this.blockCacheFilterMiss = registerSensor("rocksdb_block_cache_filter_miss", BLOCK_CACHE_FILTER_MISS);
     this.blockCacheFilterHit = registerSensor("rocksdb_block_cache_filter_hit", BLOCK_CACHE_FILTER_HIT);
     this.blockCacheFilterAdd = registerSensor("rocksdb_block_cache_filter_add", BLOCK_CACHE_FILTER_ADD);
     this.blockCacheFilterBytesInsert =
         registerSensor("rocksdb_block_cache_filter_bytes_insert", BLOCK_CACHE_FILTER_BYTES_INSERT);
-    this.blockCacheFilterBytesEvict =
-        registerSensor("rocksdb_block_cache_filter_bytes_evict", BLOCK_CACHE_FILTER_BYTES_EVICT);
     this.blockCacheDataMiss = registerSensor("rocksdb_block_cache_data_miss", BLOCK_CACHE_DATA_MISS);
     this.blockCacheDataHit = registerSensor("rocksdb_block_cache_data_hit", BLOCK_CACHE_DATA_HIT);
     this.blockCacheDataAdd = registerSensor("rocksdb_block_cache_data_add", BLOCK_CACHE_DATA_ADD);


### PR DESCRIPTION
## Summary
The latest rocksdb release will enable this feature: `level_compaction_dynamic_level_bytes` by default to reduce the space amplification, and we did some study and we thought this can help us reduce the disk usage for high write throughput stores. Related post for this feature:
https://github.com/facebook/rocksdb/wiki/Leveled-Compaction

<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->


<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->



## How was this PR tested?
CI
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.