### PR TITLE
[router] Add router current version metric

### DIFF
--- a/services/venice-router/src/main/java/com/linkedin/venice/router/RouterServer.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/RouterServer.java
@@ -492,7 +492,7 @@ public class RouterServer extends AbstractVeniceService {
         config.getClusterToD2Map(),
         config.getClusterName(),
         compressorFactory,
-        null);
+        metricsRepository);
     VenicePathParser pathParser = new VenicePathParser(
         versionFinder,
         partitionFinder,

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/RouterServer.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/RouterServer.java
@@ -491,7 +491,8 @@ public class RouterServer extends AbstractVeniceService {
         storeConfigRepository,
         config.getClusterToD2Map(),
         config.getClusterName(),
-        compressorFactory);
+        compressorFactory,
+        null);
     VenicePathParser pathParser = new VenicePathParser(
         versionFinder,
         partitionFinder,

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/api/VeniceVersionFinder.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/api/VeniceVersionFinder.java
@@ -16,9 +16,12 @@ import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.StoreConfig;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.meta.VersionStatus;
+import com.linkedin.venice.router.stats.RouterCurrentVersionStats;
 import com.linkedin.venice.router.stats.StaleVersionReason;
 import com.linkedin.venice.router.stats.StaleVersionStats;
 import com.linkedin.venice.utils.RedundantExceptionFilter;
+import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
+import io.tehuti.metrics.MetricsRepository;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -42,8 +45,13 @@ public class VeniceVersionFinder {
   private final Map<String, String> clusterToD2Map;
   private final String clusterName;
   private final ConcurrentMap<String, Integer> lastCurrentVersionMap = new ConcurrentHashMap<>();
+
+  protected final Map<String, RouterCurrentVersionStats> storeStats = new VeniceConcurrentHashMap<>();
+
   private final HelixBaseRoutingRepository routingDataRepository;
   private final CompressorFactory compressorFactory;
+
+  private final MetricsRepository metricsRepository;
 
   public VeniceVersionFinder(
       ReadOnlyStoreRepository metadataRepository,
@@ -52,7 +60,8 @@ public class VeniceVersionFinder {
       HelixReadOnlyStoreConfigRepository storeConfigRepo,
       Map<String, String> clusterToD2Map,
       String clusterName,
-      CompressorFactory compressorFactory) {
+      CompressorFactory compressorFactory,
+      MetricsRepository metricsRepository) {
     this.metadataRepository = metadataRepository;
     this.routingDataRepository = routingDataRepository;
     this.stats = stats;
@@ -60,6 +69,7 @@ public class VeniceVersionFinder {
     this.clusterToD2Map = clusterToD2Map;
     this.clusterName = clusterName;
     this.compressorFactory = compressorFactory;
+    this.metricsRepository = metricsRepository;
   }
 
   public int getVersion(String storeName, BasicFullHttpRequest request) throws VeniceException {
@@ -101,7 +111,11 @@ public class VeniceVersionFinder {
       stats.recordNotStale();
       return metadataCurrentVersion;
     }
-    return maybeServeNewCurrentVersion(store, lastCurrentVersion, metadataCurrentVersion);
+    int currentVersion = maybeServeNewCurrentVersion(store, lastCurrentVersion, metadataCurrentVersion);
+
+    storeStats.computeIfAbsent(storeName, k -> new RouterCurrentVersionStats(metricsRepository, storeName))
+        .updateCurrentVersion(currentVersion);
+    return currentVersion;
   }
 
   private int maybeServeNewCurrentVersion(Store store, int lastCurrentVersion, int newCurrentVersion) {

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/stats/RouterCurrentVersionStats.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/stats/RouterCurrentVersionStats.java
@@ -1,0 +1,21 @@
+package com.linkedin.venice.router.stats;
+
+import com.linkedin.venice.stats.AbstractVeniceStats;
+import com.linkedin.venice.stats.Gauge;
+import io.tehuti.metrics.MetricsRepository;
+import io.tehuti.metrics.Sensor;
+
+
+public class RouterCurrentVersionStats extends AbstractVeniceStats {
+  private final Sensor currentVersionNumberSensor;
+  private int currentVersion = -1;
+
+  public RouterCurrentVersionStats(MetricsRepository metricsRepository, String name) {
+    super(metricsRepository, name);
+    this.currentVersionNumberSensor = registerSensor("current_version", new Gauge(() -> this.currentVersion));
+  }
+
+  public void updateCurrentVersion(int currentVersion) {
+    this.currentVersion = currentVersion;
+  }
+}

--- a/services/venice-router/src/test/java/com/linkedin/venice/router/api/TestVenicePathParser.java
+++ b/services/venice-router/src/test/java/com/linkedin/venice/router/api/TestVenicePathParser.java
@@ -84,7 +84,8 @@ public class TestVenicePathParser {
         storeConfigRepo,
         clusterToD2Map,
         CLUSTER,
-        compressorFactory);
+        compressorFactory,
+        null);
   }
 
   RouterStats<AggRouterHttpRequestStats> getMockedStats() {

--- a/services/venice-router/src/test/java/com/linkedin/venice/router/api/TestVeniceVersionFinder.java
+++ b/services/venice-router/src/test/java/com/linkedin/venice/router/api/TestVeniceVersionFinder.java
@@ -1,5 +1,6 @@
 package com.linkedin.venice.router.api;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.anyInt;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.doReturn;
@@ -31,6 +32,8 @@ import com.linkedin.venice.utils.TestUtils;
 import com.linkedin.venice.utils.Utils;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpVersion;
+import io.tehuti.metrics.MetricsRepository;
+import io.tehuti.metrics.Sensor;
 import java.nio.ByteBuffer;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -71,7 +74,8 @@ public class TestVeniceVersionFinder {
         storeConfigRepo,
         clusterToD2Map,
         CLUSTER,
-        compressorFactory);
+        compressorFactory,
+        mock(MetricsRepository.class));
     try {
       versionFinder.getVersion("", request);
       Assert.fail(
@@ -110,7 +114,8 @@ public class TestVeniceVersionFinder {
         storeConfigRepo,
         clusterToD2Map,
         CLUSTER,
-        compressorFactory);
+        compressorFactory,
+        mock(MetricsRepository.class));
     try {
       request.headers().add(HttpConstants.VENICE_ALLOW_REDIRECT, "1");
       versionFinder.getVersion("store", request);
@@ -144,7 +149,8 @@ public class TestVeniceVersionFinder {
         storeConfigRepo,
         clusterToD2Map,
         CLUSTER,
-        compressorFactory);
+        compressorFactory,
+        mock(MetricsRepository.class));
     try {
       versionFinder.getVersion(storeName, request);
       Assert.fail("Store should be disabled and forbidden to read.");
@@ -184,6 +190,9 @@ public class TestVeniceVersionFinder {
     HelixReadOnlyStoreConfigRepository storeConfigRepo = mock(HelixReadOnlyStoreConfigRepository.class);
 
     CompressorFactory compressorFactory = mock(CompressorFactory.class);
+    MetricsRepository mockMetricsRepository = mock(MetricsRepository.class);
+    final Sensor mockSensor = mock(Sensor.class);
+    doReturn(mockSensor).when(mockMetricsRepository).sensor(anyString(), any());
 
     // Object under test
     VeniceVersionFinder versionFinder = new VeniceVersionFinder(
@@ -193,7 +202,8 @@ public class TestVeniceVersionFinder {
         storeConfigRepo,
         clusterToD2Map,
         CLUSTER,
-        compressorFactory);
+        compressorFactory,
+        mockMetricsRepository);
 
     // for a new store, the versionFinder returns the current version, no matter the online replicas
     Assert.assertEquals(versionFinder.getVersion(storeName, request), firstVersion);
@@ -266,7 +276,8 @@ public class TestVeniceVersionFinder {
           storeConfigRepo,
           clusterToD2Map,
           CLUSTER,
-          compressorFactory);
+          compressorFactory,
+          mock(MetricsRepository.class));
 
       String firstVersionKafkaTopic = Version.composeKafkaTopic(storeName, firstVersion);
 
@@ -314,7 +325,8 @@ public class TestVeniceVersionFinder {
         storeConfigRepo,
         clusterToD2Map,
         CLUSTER,
-        compressorFactory);
+        compressorFactory,
+        mock(MetricsRepository.class));
 
     String firstVersionKafkaTopic = Version.composeKafkaTopic(storeName, firstVersion);
 
@@ -349,6 +361,9 @@ public class TestVeniceVersionFinder {
     doReturn(true).when(routingDataRepo).containsKafkaTopic(anyString());
 
     CompressorFactory compressorFactory = mock(CompressorFactory.class);
+    MetricsRepository mockMetricsRepository = mock(MetricsRepository.class);
+    final Sensor mockSensor = mock(Sensor.class);
+    doReturn(mockSensor).when(mockMetricsRepository).sensor(anyString(), any());
 
     // Object under test
     VeniceVersionFinder versionFinder = new VeniceVersionFinder(
@@ -358,7 +373,8 @@ public class TestVeniceVersionFinder {
         storeConfigRepo,
         clusterToD2Map,
         CLUSTER,
-        compressorFactory);
+        compressorFactory,
+        mockMetricsRepository);
 
     String firstVersionKafkaTopic = Version.composeKafkaTopic(storeName, firstVersion);
     String secondVersionKafkaTopic = Version.composeKafkaTopic(storeName, secondVersion);
@@ -403,6 +419,9 @@ public class TestVeniceVersionFinder {
     doReturn(3).when(routingDataRepo).getNumberOfPartitions(anyString());
     doReturn(instances).when(routingDataRepo).getReadyToServeInstances(anyString(), anyInt());
     doReturn(true).when(routingDataRepo).containsKafkaTopic(anyString());
+    MetricsRepository mockMetricsRepository = mock(MetricsRepository.class);
+    final Sensor mockSensor = mock(Sensor.class);
+    doReturn(mockSensor).when(mockMetricsRepository).sensor(anyString(), any());
 
     try (CompressorFactory compressorFactory = new CompressorFactory()) {
       // Object under test
@@ -413,7 +432,8 @@ public class TestVeniceVersionFinder {
           storeConfigRepo,
           clusterToD2Map,
           CLUSTER,
-          compressorFactory);
+          compressorFactory,
+          mockMetricsRepository);
 
       String firstVersionKafkaTopic = Version.composeKafkaTopic(storeName, firstVersion);
       String secondVersionKafkaTopic = Version.composeKafkaTopic(storeName, secondVersion);


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Add router current version metric
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

This PR adds current version metric in router which gives us visibility of  in-memory vcurrent version being served for a store in the router.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
CI
## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.