### PR TITLE
[server] Add a new option to allocate dedicated consumer pool for leader replicas of AA/WC stores

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
@@ -51,6 +51,8 @@ import static com.linkedin.venice.ConfigKeys.SERVER_DATABASE_SYNC_BYTES_INTERNAL
 import static com.linkedin.venice.ConfigKeys.SERVER_DATABASE_SYNC_BYTES_INTERNAL_FOR_TRANSACTIONAL_MODE;
 import static com.linkedin.venice.ConfigKeys.SERVER_DB_READ_ONLY_FOR_BATCH_ONLY_STORE_ENABLED;
 import static com.linkedin.venice.ConfigKeys.SERVER_DEBUG_LOGGING_ENABLED;
+import static com.linkedin.venice.ConfigKeys.SERVER_DEDICATED_CONSUMER_POOL_FOR_AA_WC_LEADER_ENABLED;
+import static com.linkedin.venice.ConfigKeys.SERVER_DEDICATED_CONSUMER_POOL_SIZE_FOR_AA_WC_LEADER;
 import static com.linkedin.venice.ConfigKeys.SERVER_DEDICATED_DRAINER_FOR_SORTED_INPUT_ENABLED;
 import static com.linkedin.venice.ConfigKeys.SERVER_DELAY_REPORT_READY_TO_SERVE_MS;
 import static com.linkedin.venice.ConfigKeys.SERVER_DISK_FULL_THRESHOLD;
@@ -458,6 +460,8 @@ public class VeniceServerConfig extends VeniceClusterConfig {
   private final int stuckConsumerDetectionRepairThresholdSecond;
   private final int nonExistingTopicIngestionTaskKillThresholdSecond;
   private final int nonExistingTopicCheckRetryIntervalSecond;
+  private final boolean dedicatedConsumerPoolForAAWCLeaderEnabled;
+  private final int dedicatedConsumerPoolSizeForAAWCLeader;
 
   public VeniceServerConfig(VeniceProperties serverProperties) throws ConfigurationException {
     this(serverProperties, Collections.emptyMap());
@@ -764,6 +768,10 @@ public class VeniceServerConfig extends VeniceClusterConfig {
         serverProperties.getBoolean(SERVER_LEADER_COMPLETE_STATE_CHECK_IN_FOLLOWER_ENABLED, false);
     leaderCompleteStateCheckInFollowerValidIntervalMs = serverProperties
         .getLong(SERVER_LEADER_COMPLETE_STATE_CHECK_IN_FOLLOWER_VALID_INTERVAL_MS, TimeUnit.MINUTES.toMillis(5));
+    dedicatedConsumerPoolForAAWCLeaderEnabled =
+        serverProperties.getBoolean(SERVER_DEDICATED_CONSUMER_POOL_FOR_AA_WC_LEADER_ENABLED, false);
+    dedicatedConsumerPoolSizeForAAWCLeader =
+        serverProperties.getInt(SERVER_DEDICATED_CONSUMER_POOL_SIZE_FOR_AA_WC_LEADER, 5);
   }
 
   long extractIngestionMemoryLimit(
@@ -1344,5 +1352,13 @@ public class VeniceServerConfig extends VeniceClusterConfig {
 
   public int getNonExistingTopicCheckRetryIntervalSecond() {
     return nonExistingTopicCheckRetryIntervalSecond;
+  }
+
+  public boolean isDedicatedConsumerPoolForAAWCLeaderEnabled() {
+    return dedicatedConsumerPoolForAAWCLeaderEnabled;
+  }
+
+  public int getDedicatedConsumerPoolSizeForAAWCLeader() {
+    return dedicatedConsumerPoolSizeForAAWCLeader;
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/AbstractKafkaConsumerService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/AbstractKafkaConsumerService.java
@@ -1,0 +1,39 @@
+package com.linkedin.davinci.kafka.consumer;
+
+import com.linkedin.davinci.ingestion.consumption.ConsumedDataReceiver;
+import com.linkedin.venice.kafka.protocol.KafkaMessageEnvelope;
+import com.linkedin.venice.message.KafkaKey;
+import com.linkedin.venice.pubsub.api.PubSubMessage;
+import com.linkedin.venice.pubsub.api.PubSubTopic;
+import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
+import com.linkedin.venice.service.AbstractVeniceService;
+import java.util.List;
+import java.util.Set;
+
+
+public abstract class AbstractKafkaConsumerService extends AbstractVeniceService {
+  public abstract SharedKafkaConsumer getConsumerAssignedToVersionTopicPartition(
+      PubSubTopic versionTopic,
+      PubSubTopicPartition topicPartition);
+
+  public abstract SharedKafkaConsumer assignConsumerFor(PubSubTopic versionTopic, PubSubTopicPartition topicPartition);
+
+  public abstract void unsubscribeAll(PubSubTopic versionTopic);
+
+  public abstract void unSubscribe(PubSubTopic versionTopic, PubSubTopicPartition pubSubTopicPartition);
+
+  public abstract void batchUnsubscribe(PubSubTopic versionTopic, Set<PubSubTopicPartition> topicPartitionsToUnSub);
+
+  public abstract boolean hasAnySubscriptionFor(PubSubTopic versionTopic);
+
+  public abstract long getMaxElapsedTimeMSSinceLastPollInConsumerPool();
+
+  public abstract void startConsumptionIntoDataReceiver(
+      PubSubTopicPartition topicPartition,
+      long lastReadOffset,
+      ConsumedDataReceiver<List<PubSubMessage<KafkaKey, KafkaMessageEnvelope, Long>>> consumedDataReceiver);
+
+  public abstract long getOffsetLagFor(PubSubTopic versionTopic, PubSubTopicPartition pubSubTopicPartition);
+
+  public abstract long getLatestOffsetFor(PubSubTopic versionTopic, PubSubTopicPartition pubSubTopicPartition);
+}

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/AggKafkaConsumerService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/AggKafkaConsumerService.java
@@ -48,7 +48,8 @@ public class AggKafkaConsumerService extends AbstractVeniceService {
   private static final Logger LOGGER = LogManager.getLogger(AggKafkaConsumerService.class);
 
   private final PubSubConsumerAdapterFactory consumerFactory;
-  private final int numOfConsumersPerKafkaCluster;
+  // private final int numOfConsumersPerKafkaCluster;
+  private final VeniceServerConfig serverConfig;
   private final long readCycleDelayMs;
   private final long sharedConsumerNonExistingTopicCleanupDelayMS;
   private final EventThrottler bandwidthThrottler;
@@ -59,7 +60,8 @@ public class AggKafkaConsumerService extends AbstractVeniceService {
   private final boolean liveConfigBasedKafkaThrottlingEnabled;
   private final boolean isKafkaConsumerOffsetCollectionEnabled;
   private final KafkaConsumerService.ConsumerAssignmentStrategy sharedConsumerAssignmentStrategy;
-  private final Map<String, KafkaConsumerService> kafkaServerToConsumerServiceMap = new VeniceConcurrentHashMap<>();
+  private final Map<String, AbstractKafkaConsumerService> kafkaServerToConsumerServiceMap =
+      new VeniceConcurrentHashMap<>();
   private final Map<String, String> kafkaClusterUrlToAliasMap;
   private final Object2IntMap<String> kafkaClusterUrlToIdMap;
   private final PubSubMessageDeserializer pubSubDeserializer;
@@ -68,6 +70,7 @@ public class AggKafkaConsumerService extends AbstractVeniceService {
 
   private final Map<String, StoreIngestionTask> versionTopicStoreIngestionTaskMapping = new VeniceConcurrentHashMap<>();
   private ScheduledExecutorService stuckConsumerRepairExecutorService;
+  private final Function<String, Boolean> isAAOrWCEnabledFunc;
 
   public AggKafkaConsumerService(
       final PubSubConsumerAdapterFactory consumerFactory,
@@ -79,10 +82,11 @@ public class AggKafkaConsumerService extends AbstractVeniceService {
       final MetricsRepository metricsRepository,
       TopicExistenceChecker topicExistenceChecker,
       final PubSubMessageDeserializer pubSubDeserializer,
-      Consumer<String> killIngestionTaskRunnable) {
+      Consumer<String> killIngestionTaskRunnable,
+      Function<String, Boolean> isAAOrWCEnabledFunc) {
+    this.serverConfig = serverConfig;
     this.consumerFactory = consumerFactory;
     this.readCycleDelayMs = serverConfig.getKafkaReadCycleDelayMs();
-    this.numOfConsumersPerKafkaCluster = serverConfig.getConsumerPoolSizePerKafkaCluster();
     this.sharedConsumerNonExistingTopicCleanupDelayMS = serverConfig.getSharedConsumerNonExistingTopicCleanupDelayMS();
     this.bandwidthThrottler = bandwidthThrottler;
     this.recordsThrottler = recordsThrottler;
@@ -116,6 +120,7 @@ public class AggKafkaConsumerService extends AbstractVeniceService {
           TimeUnit.SECONDS);
       LOGGER.info("Started stuck consumer repair service with checking interval: {} seconds", intervalInSeconds);
     }
+    this.isAAOrWCEnabledFunc = isAAOrWCEnabledFunc;
 
     LOGGER.info("Successfully initialized AggKafkaConsumerService");
   }
@@ -131,7 +136,7 @@ public class AggKafkaConsumerService extends AbstractVeniceService {
 
   @Override
   public void stopInner() throws Exception {
-    for (KafkaConsumerService consumerService: kafkaServerToConsumerServiceMap.values()) {
+    for (AbstractKafkaConsumerService consumerService: kafkaServerToConsumerServiceMap.values()) {
       consumerService.stop();
     }
     if (this.stuckConsumerRepairExecutorService != null) {
@@ -140,7 +145,7 @@ public class AggKafkaConsumerService extends AbstractVeniceService {
   }
 
   protected static Runnable getStuckConsumerDetectionAndRepairRunnable(
-      Map<String, KafkaConsumerService> kafkaServerToConsumerServiceMap,
+      Map<String, AbstractKafkaConsumerService> kafkaServerToConsumerServiceMap,
       Map<String, StoreIngestionTask> versionTopicStoreIngestionTaskMapping,
       long stuckConsumerRepairThresholdMs,
       long nonExistingTopicIngestionTaskKillThresholdMs,
@@ -159,7 +164,7 @@ public class AggKafkaConsumerService extends AbstractVeniceService {
        * 3. The check is cheap when there is no stuck consumer.
        */
       boolean scanStoreIngestionTaskToFixStuckConsumer = false;
-      for (KafkaConsumerService consumerService: kafkaServerToConsumerServiceMap.values()) {
+      for (AbstractKafkaConsumerService consumerService: kafkaServerToConsumerServiceMap.values()) {
         long maxDelayMs = consumerService.getMaxElapsedTimeMSSinceLastPollInConsumerPool();
         if (maxDelayMs >= stuckConsumerRepairThresholdMs) {
           scanStoreIngestionTaskToFixStuckConsumer = true;
@@ -244,8 +249,8 @@ public class AggKafkaConsumerService extends AbstractVeniceService {
    * @return the {@link KafkaConsumerService} for a specific Kafka bootstrap url,
    *         or null if there isn't any.
    */
-  private KafkaConsumerService getKafkaConsumerService(final String kafkaURL) {
-    KafkaConsumerService consumerService = kafkaServerToConsumerServiceMap.get(kafkaURL);
+  private AbstractKafkaConsumerService getKafkaConsumerService(final String kafkaURL) {
+    AbstractKafkaConsumerService consumerService = kafkaServerToConsumerServiceMap.get(kafkaURL);
     if (consumerService == null && kafkaClusterUrlResolver != null) {
       consumerService = kafkaServerToConsumerServiceMap.get(kafkaClusterUrlResolver.apply(kafkaURL));
     }
@@ -259,7 +264,7 @@ public class AggKafkaConsumerService extends AbstractVeniceService {
    *
    * @param consumerProperties consumer properties that are used to create {@link KafkaConsumerService}
    */
-  public synchronized KafkaConsumerService createKafkaConsumerService(final Properties consumerProperties) {
+  public synchronized AbstractKafkaConsumerService createKafkaConsumerService(final Properties consumerProperties) {
     String kafkaUrl = consumerProperties.getProperty(KAFKA_BOOTSTRAP_SERVERS);
     Properties properties = sslPropertiesSupplier.get(kafkaUrl).toProperties();
     consumerProperties.putAll(properties);
@@ -267,31 +272,34 @@ public class AggKafkaConsumerService extends AbstractVeniceService {
       throw new IllegalArgumentException("Kafka URL must be set in the consumer properties config. Got: " + kafkaUrl);
     }
     String resolvedKafkaUrl = kafkaClusterUrlResolver == null ? kafkaUrl : kafkaClusterUrlResolver.apply(kafkaUrl);
-    final KafkaConsumerService alreadyCreatedConsumerService = getKafkaConsumerService(resolvedKafkaUrl);
+    final AbstractKafkaConsumerService alreadyCreatedConsumerService = getKafkaConsumerService(resolvedKafkaUrl);
     if (alreadyCreatedConsumerService != null) {
       LOGGER.warn("KafkaConsumerService has already been created for Kafka cluster with URL: {}", resolvedKafkaUrl);
       return alreadyCreatedConsumerService;
     }
 
-    KafkaConsumerService consumerService = kafkaServerToConsumerServiceMap.computeIfAbsent(
+    AbstractKafkaConsumerService consumerService = kafkaServerToConsumerServiceMap.computeIfAbsent(
         resolvedKafkaUrl,
-        url -> sharedConsumerAssignmentStrategy.constructor.construct(
-            consumerFactory,
-            consumerProperties,
-            readCycleDelayMs,
-            numOfConsumersPerKafkaCluster,
-            bandwidthThrottler,
-            recordsThrottler,
-            kafkaClusterBasedRecordThrottler,
-            metricsRepository,
-            kafkaClusterUrlToAliasMap.getOrDefault(url, url),
-            sharedConsumerNonExistingTopicCleanupDelayMS,
-            topicExistenceChecker,
-            liveConfigBasedKafkaThrottlingEnabled,
-            pubSubDeserializer,
-            SystemTime.INSTANCE,
-            null,
-            isKafkaConsumerOffsetCollectionEnabled));
+        url -> new KafkaConsumerServiceDelegator(
+            serverConfig,
+            (consumerPoolSize, statsSuffix) -> sharedConsumerAssignmentStrategy.constructor.construct(
+                consumerFactory,
+                consumerProperties,
+                readCycleDelayMs,
+                consumerPoolSize,
+                bandwidthThrottler,
+                recordsThrottler,
+                kafkaClusterBasedRecordThrottler,
+                metricsRepository,
+                kafkaClusterUrlToAliasMap.getOrDefault(url, url) + statsSuffix,
+                sharedConsumerNonExistingTopicCleanupDelayMS,
+                topicExistenceChecker,
+                liveConfigBasedKafkaThrottlingEnabled,
+                pubSubDeserializer,
+                SystemTime.INSTANCE,
+                null,
+                isKafkaConsumerOffsetCollectionEnabled),
+            isAAOrWCEnabledFunc));
 
     if (!consumerService.isRunning()) {
       consumerService.start();
@@ -303,7 +311,7 @@ public class AggKafkaConsumerService extends AbstractVeniceService {
       final String kafkaURL,
       PubSubTopic versionTopic,
       PubSubTopicPartition pubSubTopicPartition) {
-    KafkaConsumerService consumerService = getKafkaConsumerService(kafkaURL);
+    AbstractKafkaConsumerService consumerService = getKafkaConsumerService(kafkaURL);
     if (consumerService == null) {
       return false;
     }
@@ -322,7 +330,7 @@ public class AggKafkaConsumerService extends AbstractVeniceService {
   }
 
   boolean hasAnyConsumerAssignedForVersionTopic(PubSubTopic versionTopic) {
-    for (KafkaConsumerService consumerService: kafkaServerToConsumerServiceMap.values()) {
+    for (AbstractKafkaConsumerService consumerService: kafkaServerToConsumerServiceMap.values()) {
       if (consumerService.hasAnySubscriptionFor(versionTopic)) {
         return true;
       }
@@ -332,7 +340,7 @@ public class AggKafkaConsumerService extends AbstractVeniceService {
 
   void resetOffsetFor(PubSubTopic versionTopic, PubSubTopicPartition pubSubTopicPartition) {
     PubSubConsumerAdapter consumer;
-    for (KafkaConsumerService consumerService: kafkaServerToConsumerServiceMap.values()) {
+    for (AbstractKafkaConsumerService consumerService: kafkaServerToConsumerServiceMap.values()) {
       consumer = consumerService.getConsumerAssignedToVersionTopicPartition(versionTopic, pubSubTopicPartition);
       if (consumer != null) {
         consumer.resetOffset(pubSubTopicPartition);
@@ -341,13 +349,13 @@ public class AggKafkaConsumerService extends AbstractVeniceService {
   }
 
   public void unsubscribeConsumerFor(PubSubTopic versionTopic, PubSubTopicPartition pubSubTopicPartition) {
-    for (KafkaConsumerService consumerService: kafkaServerToConsumerServiceMap.values()) {
+    for (AbstractKafkaConsumerService consumerService: kafkaServerToConsumerServiceMap.values()) {
       consumerService.unSubscribe(versionTopic, pubSubTopicPartition);
     }
   }
 
   void batchUnsubscribeConsumerFor(PubSubTopic versionTopic, Set<PubSubTopicPartition> topicPartitionSet) {
-    for (KafkaConsumerService consumerService: kafkaServerToConsumerServiceMap.values()) {
+    for (AbstractKafkaConsumerService consumerService: kafkaServerToConsumerServiceMap.values()) {
       consumerService.batchUnsubscribe(versionTopic, topicPartitionSet);
     }
   }
@@ -358,7 +366,7 @@ public class AggKafkaConsumerService extends AbstractVeniceService {
       PubSubTopicPartition pubSubTopicPartition,
       long lastOffset) {
     PubSubTopic versionTopic = storeIngestionTask.getVersionTopic();
-    KafkaConsumerService consumerService = getKafkaConsumerService(kafkaURL);
+    AbstractKafkaConsumerService consumerService = getKafkaConsumerService(kafkaURL);
     if (consumerService == null) {
       throw new VeniceException(
           "Kafka consumer service must exist for version topic: " + versionTopic + " in Kafka cluster: " + kafkaURL);
@@ -371,9 +379,8 @@ public class AggKafkaConsumerService extends AbstractVeniceService {
             kafkaURL,
             kafkaClusterUrlToIdMap.getOrDefault(kafkaURL, -1));
 
-    consumerService.startConsumptionIntoDataReceiver(pubSubTopicPartition, lastOffset, dataReceiver);
-
     versionTopicStoreIngestionTaskMapping.put(storeIngestionTask.getVersionTopic().getName(), storeIngestionTask);
+    consumerService.startConsumptionIntoDataReceiver(pubSubTopicPartition, lastOffset, dataReceiver);
 
     return dataReceiver;
   }
@@ -382,7 +389,7 @@ public class AggKafkaConsumerService extends AbstractVeniceService {
       final String kafkaURL,
       PubSubTopic versionTopic,
       PubSubTopicPartition pubSubTopicPartition) {
-    KafkaConsumerService consumerService = getKafkaConsumerService(kafkaURL);
+    AbstractKafkaConsumerService consumerService = getKafkaConsumerService(kafkaURL);
     return consumerService == null ? -1 : consumerService.getOffsetLagFor(versionTopic, pubSubTopicPartition);
   }
 
@@ -390,7 +397,7 @@ public class AggKafkaConsumerService extends AbstractVeniceService {
       final String kafkaURL,
       PubSubTopic versionTopic,
       PubSubTopicPartition pubSubTopicPartition) {
-    KafkaConsumerService consumerService = getKafkaConsumerService(kafkaURL);
+    AbstractKafkaConsumerService consumerService = getKafkaConsumerService(kafkaURL);
     return consumerService == null ? -1 : consumerService.getLatestOffsetFor(versionTopic, pubSubTopicPartition);
   }
 
@@ -405,7 +412,7 @@ public class AggKafkaConsumerService extends AbstractVeniceService {
 
   void pauseConsumerFor(PubSubTopic versionTopic, PubSubTopicPartition pubSubTopicPartition) {
     PubSubConsumerAdapter consumer;
-    for (KafkaConsumerService consumerService: kafkaServerToConsumerServiceMap.values()) {
+    for (AbstractKafkaConsumerService consumerService: kafkaServerToConsumerServiceMap.values()) {
       consumer = consumerService.getConsumerAssignedToVersionTopicPartition(versionTopic, pubSubTopicPartition);
       if (consumer != null) {
         consumer.pause(pubSubTopicPartition);
@@ -415,7 +422,7 @@ public class AggKafkaConsumerService extends AbstractVeniceService {
 
   void resumeConsumerFor(PubSubTopic versionTopic, PubSubTopicPartition pubSubTopicPartition) {
     PubSubConsumerAdapter consumer;
-    for (KafkaConsumerService consumerService: kafkaServerToConsumerServiceMap.values()) {
+    for (AbstractKafkaConsumerService consumerService: kafkaServerToConsumerServiceMap.values()) {
       consumer = consumerService.getConsumerAssignedToVersionTopicPartition(versionTopic, pubSubTopicPartition);
       if (consumer != null) {
         consumer.resume(pubSubTopicPartition);
@@ -428,7 +435,7 @@ public class AggKafkaConsumerService extends AbstractVeniceService {
    */
   Set<String> getKafkaUrlsFor(PubSubTopic versionTopic) {
     Set<String> kafkaUrls = new HashSet<>(kafkaServerToConsumerServiceMap.size());
-    for (Map.Entry<String, KafkaConsumerService> entry: kafkaServerToConsumerServiceMap.entrySet()) {
+    for (Map.Entry<String, AbstractKafkaConsumerService> entry: kafkaServerToConsumerServiceMap.entrySet()) {
       if (entry.getValue().hasAnySubscriptionFor(versionTopic)) {
         kafkaUrls.add(entry.getKey());
       }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/AggKafkaConsumerService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/AggKafkaConsumerService.java
@@ -48,7 +48,6 @@ public class AggKafkaConsumerService extends AbstractVeniceService {
   private static final Logger LOGGER = LogManager.getLogger(AggKafkaConsumerService.class);
 
   private final PubSubConsumerAdapterFactory consumerFactory;
-  // private final int numOfConsumersPerKafkaCluster;
   private final VeniceServerConfig serverConfig;
   private final long readCycleDelayMs;
   private final long sharedConsumerNonExistingTopicCleanupDelayMS;

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaConsumerService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaConsumerService.java
@@ -16,7 +16,6 @@ import com.linkedin.venice.pubsub.api.PubSubMessage;
 import com.linkedin.venice.pubsub.api.PubSubMessageDeserializer;
 import com.linkedin.venice.pubsub.api.PubSubTopic;
 import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
-import com.linkedin.venice.service.AbstractVeniceService;
 import com.linkedin.venice.throttle.EventThrottler;
 import com.linkedin.venice.utils.DaemonThreadFactory;
 import com.linkedin.venice.utils.LatencyUtils;
@@ -67,7 +66,7 @@ import org.apache.logging.log4j.Logger;
  *
  * @see AggKafkaConsumerService which wraps one instance of this class per Kafka cluster.
  */
-public abstract class KafkaConsumerService extends AbstractVeniceService {
+public abstract class KafkaConsumerService extends AbstractKafkaConsumerService {
   private static final int SHUTDOWN_TIMEOUT_IN_SECOND = 1;
   private static final RedundantExceptionFilter REDUNDANT_LOGGING_FILTER =
       RedundantExceptionFilter.getRedundantExceptionFilter();
@@ -170,6 +169,7 @@ public abstract class KafkaConsumerService extends AbstractVeniceService {
     return Utils.getHostName() + "_" + kafkaUrl + "_" + suffix;
   }
 
+  @Override
   public SharedKafkaConsumer getConsumerAssignedToVersionTopicPartition(
       PubSubTopic versionTopic,
       PubSubTopicPartition topicPartition) {
@@ -185,6 +185,7 @@ public abstract class KafkaConsumerService extends AbstractVeniceService {
    *
    * Must be idempotent and thus return previously a assigned consumer (for the same params) if any exists.
    */
+  @Override
   public SharedKafkaConsumer assignConsumerFor(PubSubTopic versionTopic, PubSubTopicPartition topicPartition) {
     Map<PubSubTopicPartition, SharedKafkaConsumer> topicPartitionToConsumerMap =
         versionTopicToTopicPartitionToConsumer.computeIfAbsent(versionTopic, k -> new VeniceConcurrentHashMap<>());
@@ -205,6 +206,7 @@ public abstract class KafkaConsumerService extends AbstractVeniceService {
   /**
    * Stop all subscription associated with the given version topic.
    */
+  @Override
   public void unsubscribeAll(PubSubTopic versionTopic) {
     versionTopicToTopicPartitionToConsumer.compute(versionTopic, (k, topicPartitionToConsumerMap) -> {
       if (topicPartitionToConsumerMap != null) {
@@ -220,7 +222,8 @@ public abstract class KafkaConsumerService extends AbstractVeniceService {
   /**
    * Stop specific subscription associated with the given version topic.
    */
-  void unSubscribe(PubSubTopic versionTopic, PubSubTopicPartition pubSubTopicPartition) {
+  @Override
+  public void unSubscribe(PubSubTopic versionTopic, PubSubTopicPartition pubSubTopicPartition) {
     PubSubConsumerAdapter consumer = getConsumerAssignedToVersionTopicPartition(versionTopic, pubSubTopicPartition);
     if (consumer != null) {
       consumer.unSubscribe(pubSubTopicPartition);
@@ -236,7 +239,8 @@ public abstract class KafkaConsumerService extends AbstractVeniceService {
     }
   }
 
-  void batchUnsubscribe(PubSubTopic versionTopic, Set<PubSubTopicPartition> topicPartitionsToUnSub) {
+  @Override
+  public void batchUnsubscribe(PubSubTopic versionTopic, Set<PubSubTopicPartition> topicPartitionsToUnSub) {
     Map<PubSubConsumerAdapter, Set<PubSubTopicPartition>> consumerUnSubTopicPartitionSet = new HashMap<>();
     PubSubConsumerAdapter consumer;
     for (PubSubTopicPartition topicPartition: topicPartitionsToUnSub) {
@@ -304,6 +308,7 @@ public abstract class KafkaConsumerService extends AbstractVeniceService {
     LOGGER.info("SharedKafkaConsumer closed in {} ms.", System.currentTimeMillis() - beginningTime);
   }
 
+  @Override
   public boolean hasAnySubscriptionFor(PubSubTopic versionTopic) {
     Map<PubSubTopicPartition, SharedKafkaConsumer> subscriptions =
         versionTopicToTopicPartitionToConsumer.get(versionTopic);
@@ -324,6 +329,7 @@ public abstract class KafkaConsumerService extends AbstractVeniceService {
         getMaxElapsedTimeSinceLastPollInConsumerPool);
   }
 
+  @Override
   public long getMaxElapsedTimeMSSinceLastPollInConsumerPool() {
     long maxElapsedTimeSinceLastPollInConsumerPool = -1;
     int slowestTaskId = -1;
@@ -349,6 +355,7 @@ public abstract class KafkaConsumerService extends AbstractVeniceService {
     return maxElapsedTimeSinceLastPollInConsumerPool;
   }
 
+  @Override
   public void startConsumptionIntoDataReceiver(
       PubSubTopicPartition topicPartition,
       long lastReadOffset,

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaConsumerServiceDelegator.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaConsumerServiceDelegator.java
@@ -1,0 +1,144 @@
+package com.linkedin.davinci.kafka.consumer;
+
+import com.linkedin.davinci.config.VeniceServerConfig;
+import com.linkedin.davinci.ingestion.consumption.ConsumedDataReceiver;
+import com.linkedin.venice.kafka.protocol.KafkaMessageEnvelope;
+import com.linkedin.venice.message.KafkaKey;
+import com.linkedin.venice.pubsub.api.PubSubMessage;
+import com.linkedin.venice.pubsub.api.PubSubTopic;
+import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
+import java.util.List;
+import java.util.Set;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+
+/**
+ * This delegator impl is used to distribute different partition requests into different consumer service.
+ * When {@text ConfigKeys#SERVER_DEDICATED_CONSUMER_POOL_FOR_AA_WC_LEADER_ENABLED} is off, this class
+ * will always return the default consumer service.
+ * When the option is on, it will return the dedicated consumer service when the topic partition belongs
+ * to a Real-time topic and the corresponding store has active/active or write compute enabled.
+ * The reason to use dedicated consumer pool for leader replicas of active/active or write compute stores is
+ * that handling the writes before putting into the drainer queue is too expensive comparing to others.
+ */
+public class KafkaConsumerServiceDelegator extends AbstractKafkaConsumerService {
+  private final KafkaConsumerService defaultConsumerService;
+  private final KafkaConsumerService consumerServiceForAAWCLeader;
+  private final Function<String, Boolean> isAAWCStoreFunc;
+
+  public KafkaConsumerServiceDelegator(
+      VeniceServerConfig serverConfig,
+      BiFunction<Integer, String, KafkaConsumerService> consumerServiceConstructor,
+      Function<String, Boolean> isAAWCStoreFunc) {
+
+    this.defaultConsumerService =
+        consumerServiceConstructor.apply(serverConfig.getConsumerPoolSizePerKafkaCluster(), ""); // Empty stats suffix
+    if (serverConfig.isDedicatedConsumerPoolForAAWCLeaderEnabled()) {
+      this.consumerServiceForAAWCLeader = consumerServiceConstructor
+          .apply(serverConfig.getDedicatedConsumerPoolSizeForAAWCLeader(), "_for_aa_wc_leader");
+    } else {
+      this.consumerServiceForAAWCLeader = null;
+    }
+    this.isAAWCStoreFunc = isAAWCStoreFunc;
+  }
+
+  private KafkaConsumerService getKafkaConsumerService(PubSubTopic versionTopic, PubSubTopicPartition topicPartition) {
+    if (this.consumerServiceForAAWCLeader != null && isAAWCStoreFunc.apply(versionTopic.getName())
+        && topicPartition.getPubSubTopic().isRealTime()) {
+      /**
+       * For AAWC leader replica, this function will return the dedicated consumer pool.
+       */
+      return consumerServiceForAAWCLeader;
+    }
+    return defaultConsumerService;
+  }
+
+  @Override
+  public SharedKafkaConsumer getConsumerAssignedToVersionTopicPartition(
+      PubSubTopic versionTopic,
+      PubSubTopicPartition topicPartition) {
+    return getKafkaConsumerService(versionTopic, topicPartition)
+        .getConsumerAssignedToVersionTopicPartition(versionTopic, topicPartition);
+  }
+
+  @Override
+  public SharedKafkaConsumer assignConsumerFor(PubSubTopic versionTopic, PubSubTopicPartition topicPartition) {
+    return getKafkaConsumerService(versionTopic, topicPartition).assignConsumerFor(versionTopic, topicPartition);
+  }
+
+  @Override
+  public void unsubscribeAll(PubSubTopic versionTopic) {
+    defaultConsumerService.unsubscribeAll(versionTopic);
+    if (consumerServiceForAAWCLeader != null) {
+      consumerServiceForAAWCLeader.unsubscribeAll(versionTopic);
+    }
+  }
+
+  @Override
+  public void unSubscribe(PubSubTopic versionTopic, PubSubTopicPartition pubSubTopicPartition) {
+    getKafkaConsumerService(versionTopic, pubSubTopicPartition).unSubscribe(versionTopic, pubSubTopicPartition);
+  }
+
+  @Override
+  public void batchUnsubscribe(PubSubTopic versionTopic, Set<PubSubTopicPartition> topicPartitionsToUnSub) {
+    defaultConsumerService.batchUnsubscribe(versionTopic, topicPartitionsToUnSub);
+    if (consumerServiceForAAWCLeader != null) {
+      consumerServiceForAAWCLeader.batchUnsubscribe(versionTopic, topicPartitionsToUnSub);
+    }
+  }
+
+  @Override
+  public boolean hasAnySubscriptionFor(PubSubTopic versionTopic) {
+    return defaultConsumerService.hasAnySubscriptionFor(versionTopic)
+        || consumerServiceForAAWCLeader != null && consumerServiceForAAWCLeader.hasAnySubscriptionFor(versionTopic);
+  }
+
+  @Override
+  public long getMaxElapsedTimeMSSinceLastPollInConsumerPool() {
+    return Math.max(
+        defaultConsumerService.getMaxElapsedTimeMSSinceLastPollInConsumerPool(),
+        consumerServiceForAAWCLeader == null
+            ? 0
+            : consumerServiceForAAWCLeader.getMaxElapsedTimeMSSinceLastPollInConsumerPool());
+  }
+
+  @Override
+  public void startConsumptionIntoDataReceiver(
+      PubSubTopicPartition topicPartition,
+      long lastReadOffset,
+      ConsumedDataReceiver<List<PubSubMessage<KafkaKey, KafkaMessageEnvelope, Long>>> consumedDataReceiver) {
+    PubSubTopic versionTopic = consumedDataReceiver.destinationIdentifier();
+    getKafkaConsumerService(versionTopic, topicPartition)
+        .startConsumptionIntoDataReceiver(topicPartition, lastReadOffset, consumedDataReceiver);
+  }
+
+  @Override
+  public long getOffsetLagFor(PubSubTopic versionTopic, PubSubTopicPartition pubSubTopicPartition) {
+    return getKafkaConsumerService(versionTopic, pubSubTopicPartition)
+        .getOffsetLagFor(versionTopic, pubSubTopicPartition);
+  }
+
+  @Override
+  public long getLatestOffsetFor(PubSubTopic versionTopic, PubSubTopicPartition pubSubTopicPartition) {
+    return getKafkaConsumerService(versionTopic, pubSubTopicPartition)
+        .getLatestOffsetFor(versionTopic, pubSubTopicPartition);
+  }
+
+  @Override
+  public boolean startInner() throws Exception {
+    defaultConsumerService.start();
+    if (consumerServiceForAAWCLeader != null) {
+      consumerServiceForAAWCLeader.start();
+    }
+    return true;
+  }
+
+  @Override
+  public void stopInner() throws Exception {
+    defaultConsumerService.stop();
+    if (consumerServiceForAAWCLeader != null) {
+      consumerServiceForAAWCLeader.stop();
+    }
+  }
+}

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/AggKafkaConsumerServiceTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/AggKafkaConsumerServiceTest.java
@@ -17,7 +17,7 @@ import org.testng.annotations.Test;
 public class AggKafkaConsumerServiceTest {
   @Test
   public void testGetStuckConsumerDetectionAndRepairRunnable() {
-    Map<String, KafkaConsumerService> kafkaServerToConsumerServiceMap = new HashMap<>();
+    Map<String, AbstractKafkaConsumerService> kafkaServerToConsumerServiceMap = new HashMap<>();
     Map<String, StoreIngestionTask> versionTopicStoreIngestionTaskMapping = new HashMap<>();
     long stuckConsumerRepairThresholdMs = 100;
     long nonExistingTopicIngestionTaskKillThresholdMs = 1000;
@@ -51,7 +51,7 @@ public class AggKafkaConsumerServiceTest {
 
   @Test
   public void testGetStuckConsumerDetectionAndRepairRunnableForTransientNonExistingTopic() {
-    Map<String, KafkaConsumerService> kafkaServerToConsumerServiceMap = new HashMap<>();
+    Map<String, AbstractKafkaConsumerService> kafkaServerToConsumerServiceMap = new HashMap<>();
     Map<String, StoreIngestionTask> versionTopicStoreIngestionTaskMapping = new HashMap<>();
     long stuckConsumerRepairThresholdMs = 100;
     long nonExistingTopicIngestionTaskKillThresholdMs = 1000;
@@ -85,7 +85,7 @@ public class AggKafkaConsumerServiceTest {
 
   @Test
   public void testGetStuckConsumerDetectionAndRepairRunnableForNonExistingTopic() {
-    Map<String, KafkaConsumerService> kafkaServerToConsumerServiceMap = new HashMap<>();
+    Map<String, AbstractKafkaConsumerService> kafkaServerToConsumerServiceMap = new HashMap<>();
     Map<String, StoreIngestionTask> versionTopicStoreIngestionTaskMapping = new HashMap<>();
     long stuckConsumerRepairThresholdMs = 100;
     long nonExistingTopicIngestionTaskKillThresholdMs = 1000;

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/KafkaConsumerServiceDelegatorTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/KafkaConsumerServiceDelegatorTest.java
@@ -1,0 +1,192 @@
+package com.linkedin.davinci.kafka.consumer;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+import static org.testng.Assert.assertTrue;
+
+import com.linkedin.davinci.config.VeniceServerConfig;
+import com.linkedin.davinci.ingestion.consumption.ConsumedDataReceiver;
+import com.linkedin.venice.pubsub.PubSubTopicPartitionImpl;
+import com.linkedin.venice.pubsub.PubSubTopicRepository;
+import com.linkedin.venice.pubsub.api.PubSubTopic;
+import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+
+public class KafkaConsumerServiceDelegatorTest {
+  private static final PubSubTopicRepository TOPIC_REPOSITORY = new PubSubTopicRepository();
+  private static final String VERSION_TOPIC_NAME = "test_store_v1";
+  private static final String RT_TOPIC_NAME = "test_store_rt";
+  private static final int PARTITION_ID = 1;
+
+  @DataProvider(name = "Method-List")
+  public static Object[][] methodList() {
+    return new Object[][] { { "getConsumerAssignedToVersionTopicPartition" }, { "assignConsumerFor" },
+        { "unSubscribe" }, { "getOffsetLagFor" }, { "getLatestOffsetFor" } };
+  }
+
+  @Test(dataProvider = "Method-List")
+  public void chooseConsumerServiceTest(String methodName)
+      throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+    KafkaConsumerService mockDefaultConsumerService = mock(KafkaConsumerService.class);
+    KafkaConsumerService mockDedicatedConsumerService = mock(KafkaConsumerService.class);
+    VeniceServerConfig mockConfig = mock(VeniceServerConfig.class);
+    doReturn(true).when(mockConfig).isDedicatedConsumerPoolForAAWCLeaderEnabled();
+
+    Function<String, Boolean> isAAWCStoreFunc = vt -> true;
+    BiFunction<Integer, String, KafkaConsumerService> consumerServiceConstructor =
+        (ignored, statSuffix) -> statSuffix.isEmpty() ? mockDefaultConsumerService : mockDedicatedConsumerService;
+
+    KafkaConsumerServiceDelegator delegator =
+        new KafkaConsumerServiceDelegator(mockConfig, consumerServiceConstructor, isAAWCStoreFunc);
+
+    PubSubTopic versionTopic = TOPIC_REPOSITORY.getTopic(VERSION_TOPIC_NAME);
+    PubSubTopic rtTopic = TOPIC_REPOSITORY.getTopic(RT_TOPIC_NAME);
+    PubSubTopicPartition topicPartitionForVT = new PubSubTopicPartitionImpl(versionTopic, PARTITION_ID);
+    PubSubTopicPartition topicPartitionForRT = new PubSubTopicPartitionImpl(rtTopic, PARTITION_ID);
+
+    Method testMethod =
+        KafkaConsumerServiceDelegator.class.getMethod(methodName, PubSubTopic.class, PubSubTopicPartition.class);
+    Method verifyMethod =
+        KafkaConsumerService.class.getMethod(methodName, PubSubTopic.class, PubSubTopicPartition.class);
+
+    testMethod.invoke(delegator, versionTopic, topicPartitionForVT);
+    verifyMethod.invoke(verify(mockDefaultConsumerService), versionTopic, topicPartitionForVT);
+    verifyMethod.invoke(verify(mockDedicatedConsumerService, never()), versionTopic, topicPartitionForVT);
+    reset(mockDefaultConsumerService);
+    reset(mockDedicatedConsumerService);
+    testMethod.invoke(delegator, versionTopic, topicPartitionForRT);
+    verifyMethod.invoke(verify(mockDedicatedConsumerService), versionTopic, topicPartitionForRT);
+    verifyMethod.invoke(verify(mockDefaultConsumerService, never()), versionTopic, topicPartitionForRT);
+    reset(mockDefaultConsumerService);
+    reset(mockDedicatedConsumerService);
+
+    isAAWCStoreFunc = vt -> false;
+    delegator = new KafkaConsumerServiceDelegator(mockConfig, consumerServiceConstructor, isAAWCStoreFunc);
+
+    testMethod.invoke(delegator, versionTopic, topicPartitionForVT);
+    verifyMethod.invoke(verify(mockDefaultConsumerService), versionTopic, topicPartitionForVT);
+    verifyMethod.invoke(verify(mockDedicatedConsumerService, never()), versionTopic, topicPartitionForVT);
+    reset(mockDefaultConsumerService);
+    reset(mockDedicatedConsumerService);
+    testMethod.invoke(delegator, versionTopic, topicPartitionForRT);
+    verifyMethod.invoke(verify(mockDefaultConsumerService), versionTopic, topicPartitionForRT);
+    verifyMethod.invoke(verify(mockDedicatedConsumerService, never()), versionTopic, topicPartitionForRT);
+  }
+
+  @Test
+  public void unsubscribeAllTest() {
+    KafkaConsumerService mockDefaultConsumerService = mock(KafkaConsumerService.class);
+    KafkaConsumerService mockDedicatedConsumerService = mock(KafkaConsumerService.class);
+    VeniceServerConfig mockConfig = mock(VeniceServerConfig.class);
+    doReturn(true).when(mockConfig).isDedicatedConsumerPoolForAAWCLeaderEnabled();
+
+    Function<String, Boolean> isAAWCStoreFunc = vt -> true;
+    BiFunction<Integer, String, KafkaConsumerService> consumerServiceConstructor =
+        (ignored, statSuffix) -> statSuffix.isEmpty() ? mockDefaultConsumerService : mockDedicatedConsumerService;
+
+    KafkaConsumerServiceDelegator delegator =
+        new KafkaConsumerServiceDelegator(mockConfig, consumerServiceConstructor, isAAWCStoreFunc);
+    PubSubTopic versionTopic = TOPIC_REPOSITORY.getTopic(VERSION_TOPIC_NAME);
+    delegator.unsubscribeAll(versionTopic);
+    verify(mockDefaultConsumerService).unsubscribeAll(versionTopic);
+    verify(mockDedicatedConsumerService).unsubscribeAll(versionTopic);
+  }
+
+  @Test
+  public void batchUnsubscribe_start_stop_getMaxElapsedTimeMSSinceLastPollInConsumerPool_hasAnySubscriptionFor_Test()
+      throws Exception {
+    KafkaConsumerService mockDefaultConsumerService = mock(KafkaConsumerService.class);
+    KafkaConsumerService mockDedicatedConsumerService = mock(KafkaConsumerService.class);
+    VeniceServerConfig mockConfig = mock(VeniceServerConfig.class);
+    doReturn(true).when(mockConfig).isDedicatedConsumerPoolForAAWCLeaderEnabled();
+
+    Function<String, Boolean> isAAWCStoreFunc = vt -> true;
+    BiFunction<Integer, String, KafkaConsumerService> consumerServiceConstructor =
+        (ignored, statSuffix) -> statSuffix.isEmpty() ? mockDefaultConsumerService : mockDedicatedConsumerService;
+
+    KafkaConsumerServiceDelegator delegator =
+        new KafkaConsumerServiceDelegator(mockConfig, consumerServiceConstructor, isAAWCStoreFunc);
+    PubSubTopic versionTopic = TOPIC_REPOSITORY.getTopic(VERSION_TOPIC_NAME);
+    PubSubTopic rtTopic = TOPIC_REPOSITORY.getTopic(RT_TOPIC_NAME);
+    PubSubTopicPartition topicPartitionForVT = new PubSubTopicPartitionImpl(versionTopic, PARTITION_ID);
+    PubSubTopicPartition topicPartitionForRT = new PubSubTopicPartitionImpl(rtTopic, PARTITION_ID);
+    Set<PubSubTopicPartition> partitionSet = new HashSet<>();
+    partitionSet.add(topicPartitionForVT);
+    partitionSet.add(topicPartitionForRT);
+
+    delegator.batchUnsubscribe(versionTopic, partitionSet);
+    verify(mockDefaultConsumerService).batchUnsubscribe(versionTopic, partitionSet);
+    verify(mockDedicatedConsumerService).batchUnsubscribe(versionTopic, partitionSet);
+
+    reset(mockDefaultConsumerService);
+    reset(mockDedicatedConsumerService);
+    delegator.startInner();
+    verify(mockDefaultConsumerService).start();
+    verify(mockDedicatedConsumerService).start();
+
+    reset(mockDefaultConsumerService);
+    reset(mockDedicatedConsumerService);
+    delegator.stopInner();
+    verify(mockDefaultConsumerService).stop();
+    verify(mockDedicatedConsumerService).stop();
+
+    reset(mockDefaultConsumerService);
+    reset(mockDedicatedConsumerService);
+    delegator.getMaxElapsedTimeMSSinceLastPollInConsumerPool();
+    verify(mockDedicatedConsumerService).getMaxElapsedTimeMSSinceLastPollInConsumerPool();
+    verify(mockDefaultConsumerService).getMaxElapsedTimeMSSinceLastPollInConsumerPool();
+
+    reset(mockDefaultConsumerService);
+    reset(mockDedicatedConsumerService);
+    doReturn(false).when(mockDefaultConsumerService).hasAnySubscriptionFor(any());
+    doReturn(true).when(mockDedicatedConsumerService).hasAnySubscriptionFor(any());
+    assertTrue(delegator.hasAnySubscriptionFor(versionTopic));
+    verify(mockDedicatedConsumerService).hasAnySubscriptionFor(versionTopic);
+    verify(mockDefaultConsumerService).hasAnySubscriptionFor(versionTopic);
+  }
+
+  @Test
+  public void startConsumptionIntoDataReceiverTest() {
+    KafkaConsumerService mockDefaultConsumerService = mock(KafkaConsumerService.class);
+    KafkaConsumerService mockDedicatedConsumerService = mock(KafkaConsumerService.class);
+    VeniceServerConfig mockConfig = mock(VeniceServerConfig.class);
+    doReturn(true).when(mockConfig).isDedicatedConsumerPoolForAAWCLeaderEnabled();
+
+    Function<String, Boolean> isAAWCStoreFunc = vt -> true;
+    BiFunction<Integer, String, KafkaConsumerService> consumerServiceConstructor =
+        (ignored, statSuffix) -> statSuffix.isEmpty() ? mockDefaultConsumerService : mockDedicatedConsumerService;
+
+    KafkaConsumerServiceDelegator delegator =
+        new KafkaConsumerServiceDelegator(mockConfig, consumerServiceConstructor, isAAWCStoreFunc);
+    PubSubTopic versionTopic = TOPIC_REPOSITORY.getTopic(VERSION_TOPIC_NAME);
+    PubSubTopic rtTopic = TOPIC_REPOSITORY.getTopic(RT_TOPIC_NAME);
+    PubSubTopicPartition topicPartitionForVT = new PubSubTopicPartitionImpl(versionTopic, PARTITION_ID);
+    PubSubTopicPartition topicPartitionForRT = new PubSubTopicPartitionImpl(rtTopic, PARTITION_ID);
+
+    ConsumedDataReceiver dataReceiver = mock(ConsumedDataReceiver.class);
+    doReturn(versionTopic).when(dataReceiver).destinationIdentifier();
+
+    delegator.startConsumptionIntoDataReceiver(topicPartitionForVT, 0, dataReceiver);
+    verify(mockDefaultConsumerService).startConsumptionIntoDataReceiver(topicPartitionForVT, 0, dataReceiver);
+    verify(mockDedicatedConsumerService, never())
+        .startConsumptionIntoDataReceiver(topicPartitionForVT, 0, dataReceiver);
+
+    reset(mockDefaultConsumerService);
+    reset(mockDedicatedConsumerService);
+    delegator.startConsumptionIntoDataReceiver(topicPartitionForRT, 0, dataReceiver);
+    verify(mockDefaultConsumerService, never()).startConsumptionIntoDataReceiver(topicPartitionForRT, 0, dataReceiver);
+    verify(mockDedicatedConsumerService).startConsumptionIntoDataReceiver(topicPartitionForRT, 0, dataReceiver);
+  }
+}

--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -2069,4 +2069,14 @@ public class ConfigKeys {
    */
   public static final String SERVER_NON_EXISTING_TOPIC_CHECK_RETRY_INTERNAL_SECOND =
       "server.non.existing.topic.check.retry.interval.second";
+
+  /**
+   * Handling AA or WC stores is expensive because of RocksDB lookup, and this following
+   * feature will handle these writes in dedicated consumer pool, so that the full
+   * updates won't be affected by the heavy writes to these AA/WC stores.
+   */
+  public static final String SERVER_DEDICATED_CONSUMER_POOL_FOR_AA_WC_LEADER_ENABLED =
+      "server.dedicated.consumer.pool.for.aa.wc.leader.enabled";
+  public static final String SERVER_DEDICATED_CONSUMER_POOL_SIZE_FOR_AA_WC_LEADER =
+      "server.dedicated.consumer.pool.size.for.aa.wc.leader";
 }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestActiveActiveReplicationForIncPush.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestActiveActiveReplicationForIncPush.java
@@ -6,6 +6,7 @@ import static com.linkedin.venice.ConfigKeys.ENABLE_ACTIVE_ACTIVE_REPLICATION_AS
 import static com.linkedin.venice.ConfigKeys.ENABLE_INCREMENTAL_PUSH_FOR_HYBRID_ACTIVE_ACTIVE_USER_STORES;
 import static com.linkedin.venice.ConfigKeys.SERVER_DATABASE_CHECKSUM_VERIFICATION_ENABLED;
 import static com.linkedin.venice.ConfigKeys.SERVER_DATABASE_SYNC_BYTES_INTERNAL_FOR_DEFERRED_WRITE_MODE;
+import static com.linkedin.venice.ConfigKeys.SERVER_DEDICATED_CONSUMER_POOL_FOR_AA_WC_LEADER_ENABLED;
 import static com.linkedin.venice.ConfigKeys.SERVER_KAFKA_PRODUCER_POOL_SIZE_PER_KAFKA_CLUSTER;
 import static com.linkedin.venice.ConfigKeys.SERVER_PROMOTION_TO_LEADER_REPLICA_DELAY_SECONDS;
 import static com.linkedin.venice.ConfigKeys.SERVER_SHARED_KAFKA_PRODUCER_ENABLED;
@@ -82,6 +83,7 @@ public class TestActiveActiveReplicationForIncPush {
     serverProperties.setProperty(SERVER_DATABASE_SYNC_BYTES_INTERNAL_FOR_DEFERRED_WRITE_MODE, "300");
     serverProperties.put(SERVER_SHARED_KAFKA_PRODUCER_ENABLED, "true");
     serverProperties.put(SERVER_KAFKA_PRODUCER_POOL_SIZE_PER_KAFKA_CLUSTER, "1");
+    serverProperties.put(SERVER_DEDICATED_CONSUMER_POOL_FOR_AA_WC_LEADER_ENABLED, "true");
 
     Properties controllerProps = new Properties();
     controllerProps.put(CONTROLLER_AUTO_MATERIALIZE_DAVINCI_PUSH_STATUS_SYSTEM_STORE, "true");

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/kafka/KafkaConsumptionTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/kafka/KafkaConsumptionTest.java
@@ -193,7 +193,8 @@ public class KafkaConsumptionTest {
         metricsRepository,
         topicExistenceChecker,
         pubSubDeserializer,
-        (ignored) -> {});
+        (ignored) -> {},
+        (ignored) -> false);
 
     versionTopic = getTopic();
     int partition = 0;


### PR DESCRIPTION
## Summary
Based on the offline analysis, the logic to handle writes from Active/Active or Write-compute stores in consumer threads is much heavier than other stores, which would slow down the ingestion speed of regular stores significantly when there are some high write throughput to AA or WC stores.
This code change introduces an option to assign the leader replicas of AA or WC stores to a dedicated consumer pool, so that the regular store ingestion won't be affected by the above combination.

The write compute flag is store-level config, so it can change in the lifetime of a particular version, and this code change won't react of write compute flag change until a restart.

New configs:
server.dedicated.consumer.pool.for.aa.wc.leader.enabled: default false server.dedicated.consumer.pool.size.for.aa.wc.leader: default 5

This code change will introduce a new set of consumer service metrics with suffix: `_for_aa_wc_leader` when this feature is enabled.

<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->


## How was this PR tested?
CI
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.