### PR TITLE
[server][da-vinci] Delete Unused non NR Metrics

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -1860,13 +1860,6 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
             brokerConsumerLatencyMs,
             producerConsumerLatencyMs);
       }
-    } else {
-      super.recordWriterStats(
-          consumerTimestampMs,
-          producerBrokerLatencyMs,
-          brokerConsumerLatencyMs,
-          producerConsumerLatencyMs,
-          partitionConsumptionState);
     }
   }
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -2802,15 +2802,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
       long brokerConsumerLatencyMs,
       long producerConsumerLatencyMs,
       PartitionConsumptionState partitionConsumptionState) {
-    if (!isUserSystemStore) {
-      versionedDIVStats.recordLatencies(
-          storeName,
-          versionNumber,
-          consumerTimestampMs,
-          producerBrokerLatencyMs,
-          brokerConsumerLatencyMs,
-          producerConsumerLatencyMs);
-    }
+
   }
 
   /**

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/AggVersionedDIVStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/AggVersionedDIVStats.java
@@ -56,20 +56,6 @@ public class AggVersionedDIVStats extends AbstractVeniceAggVersionedStats<DIVSta
     recordVersionedAndTotalStat(storeName, version, DIVStats::recordSuccessMsg);
   }
 
-  public void recordLatencies(
-      String storeName,
-      int version,
-      long currentTimeMs,
-      double producerBrokerLatencyMs,
-      double brokerConsumerLatencyMs,
-      double producerConsumerLatencyMs) {
-    recordVersionedAndTotalStat(storeName, version, stat -> {
-      stat.recordProducerBrokerLatencyMs(producerBrokerLatencyMs, currentTimeMs);
-      stat.recordBrokerConsumerLatencyMs(brokerConsumerLatencyMs, currentTimeMs);
-      stat.recordProducerConsumerLatencyMs(producerConsumerLatencyMs, currentTimeMs);
-    });
-  }
-
   public void recordLeaderLatencies(
       String storeName,
       int version,

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/DIVStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/DIVStats.java
@@ -12,9 +12,6 @@ import java.util.concurrent.atomic.LongAdder;
  */
 public class DIVStats {
   private final MetricConfig metricConfig = new MetricConfig();
-  private final WritePathLatencySensor producerBrokerLatencySensor;
-  private final WritePathLatencySensor brokerConsumerLatencySensor;
-  private final WritePathLatencySensor producerConsumerLatencySensor;
   private final WritePathLatencySensor producerSourceBrokerLatencySensor;
   private final WritePathLatencySensor sourceBrokerLeaderConsumerLatencySensor;
   private final WritePathLatencySensor producerLeaderConsumerLatencySensor;
@@ -43,14 +40,6 @@ public class DIVStats {
      * Creating this separate local metric repository only to utilize the sensor library and not for reporting.
      */
     MetricsRepository localRepository = new MetricsRepository(metricConfig);
-
-    // TODO Remove the three metrics below when NR is fully rolled out, since these metrics only apply to non-NR.
-    producerBrokerLatencySensor =
-        new WritePathLatencySensor(localRepository, metricConfig, "producer_to_broker_latency");
-    brokerConsumerLatencySensor =
-        new WritePathLatencySensor(localRepository, metricConfig, "broker_to_consumer_latency");
-    producerConsumerLatencySensor =
-        new WritePathLatencySensor(localRepository, metricConfig, "producer_to_consumer_latency");
 
     // NR metrics below:
     producerSourceBrokerLatencySensor =
@@ -119,32 +108,8 @@ public class DIVStats {
     this.successMsg.add(count);
   }
 
-  public void recordProducerBrokerLatencyMs(double value, long currentTimeMs) {
-    producerBrokerLatencySensor.record(value, currentTimeMs);
-  }
-
-  public WritePathLatencySensor getProducerBrokerLatencySensor() {
-    return producerBrokerLatencySensor;
-  }
-
   public WritePathLatencySensor getProducerSourceBrokerLatencySensor() {
     return producerSourceBrokerLatencySensor;
-  }
-
-  public void recordBrokerConsumerLatencyMs(double value, long currentTimeMs) {
-    brokerConsumerLatencySensor.record(value, currentTimeMs);
-  }
-
-  public WritePathLatencySensor getBrokerConsumerLatencySensor() {
-    return brokerConsumerLatencySensor;
-  }
-
-  public void recordProducerConsumerLatencyMs(double value, long currentTimeMs) {
-    producerConsumerLatencySensor.record(value, currentTimeMs);
-  }
-
-  public WritePathLatencySensor getProducerConsumerLatencySensor() {
-    return producerConsumerLatencySensor;
   }
 
   public void recordProducerSourceBrokerLatencyMs(double value, long currentTimeMs) {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/DIVStatsReporter.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/DIVStatsReporter.java
@@ -40,9 +40,6 @@ public class DIVStatsReporter extends AbstractVeniceStatsReporter<DIVStats> {
 
     // This prevents user store system store to register latency related DIV metric sensors.
     if (!VeniceSystemStoreUtils.isUserSystemStore(storeName)) {
-      registerLatencySensor("producer_to_broker", DIVStats::getProducerBrokerLatencySensor);
-      registerLatencySensor("broker_to_consumer", DIVStats::getBrokerConsumerLatencySensor);
-      registerLatencySensor("producer_to_consumer", DIVStats::getProducerConsumerLatencySensor);
       registerLatencySensor("producer_to_source_broker", DIVStats::getProducerSourceBrokerLatencySensor);
       registerLatencySensor("source_broker_to_leader_consumer", DIVStats::getSourceBrokerLeaderConsumerLatencySensor);
       registerLatencySensor("producer_to_leader_consumer", DIVStats::getProducerLeaderConsumerLatencySensor);

--- a/services/venice-server/src/test/java/com/linkedin/venice/stats/AggVersionedDIVStatsTest.java
+++ b/services/venice-server/src/test/java/com/linkedin/venice/stats/AggVersionedDIVStatsTest.java
@@ -109,21 +109,6 @@ public class AggVersionedDIVStatsTest {
 
     long consumerTimestampMs = System.currentTimeMillis();
     double v1ProducerBrokerLatencyMs = 801d;
-    double v1BrokerConsumerLatencyMs = 201d;
-    double v1ProducerConsumerLatencyMs = 1001d;
-    stats.recordLatencies(
-        storeName,
-        1,
-        consumerTimestampMs,
-        v1ProducerBrokerLatencyMs,
-        v1BrokerConsumerLatencyMs,
-        v1ProducerConsumerLatencyMs);
-    Assert.assertEquals(
-        reporter.query("." + storeName + "_future--producer_to_consumer_latency_avg_ms.DIVStatsCounter").value(),
-        v1ProducerConsumerLatencyMs);
-    Assert.assertEquals(
-        reporter.query("." + storeName + "_future--producer_to_consumer_latency_max_ms.DIVStatsCounter").value(),
-        v1ProducerConsumerLatencyMs);
 
     double v1ProducerToSourceBrokerLatencyMs = 811d;
     double v1SourceBrokerToLeaderConsumerLatencyMs = 211d;
@@ -168,34 +153,13 @@ public class AggVersionedDIVStatsTest {
     mockStore.addVersion(version2);
 
     stats.recordDuplicateMsg(storeName, 2);
-    double v2ProducerBrokerLatencyMs = 802d;
     double v2BrokerConsumerLatencyMs = 202d;
-    double v2ProducerConsumerLatencyMs = 1002d;
-    stats.recordLatencies(
-        storeName,
-        2,
-        consumerTimestampMs,
-        v2ProducerBrokerLatencyMs,
-        v2BrokerConsumerLatencyMs,
-        v2ProducerConsumerLatencyMs);
     stats.handleStoreChanged(mockStore);
 
     // expect to see v1's stats on current reporter and v2's stats on future reporter
     Assert.assertEquals(reporter.query("." + storeName + "--future_version.VersionStat").value(), 2d);
     Assert.assertEquals(reporter.query("." + storeName + "--current_version.VersionStat").value(), 1d);
     Assert.assertEquals(reporter.query("." + storeName + "_future--duplicate_msg.DIVStatsCounter").value(), 1d);
-    Assert.assertEquals(
-        reporter.query("." + storeName + "_current--producer_to_broker_latency_avg_ms.DIVStatsCounter").value(),
-        v1ProducerBrokerLatencyMs);
-    Assert.assertEquals(
-        reporter.query("." + storeName + "_current--producer_to_broker_latency_max_ms.DIVStatsCounter").value(),
-        v1ProducerBrokerLatencyMs);
-    Assert.assertEquals(
-        reporter.query("." + storeName + "_future--broker_to_consumer_latency_avg_ms.DIVStatsCounter").value(),
-        v2BrokerConsumerLatencyMs);
-    Assert.assertEquals(
-        reporter.query("." + storeName + "_future--broker_to_consumer_latency_max_ms.DIVStatsCounter").value(),
-        v2BrokerConsumerLatencyMs);
 
     double v2ProducerToSourceBrokerLatencyMs = 812d;
     double v2SourceBrokerToLeaderConsumerLatencyMs = 212d;
@@ -263,12 +227,6 @@ public class AggVersionedDIVStatsTest {
 
     // expect to see v2's stats on current reporter and v1's stats on backup reporter
     Assert.assertEquals(reporter.query("." + storeName + "_current--duplicate_msg.DIVStatsCounter").value(), 1d);
-    Assert.assertEquals(
-        reporter.query("." + storeName + "_current--broker_to_consumer_latency_avg_ms.DIVStatsCounter").value(),
-        v2BrokerConsumerLatencyMs);
-    Assert.assertEquals(
-        reporter.query("." + storeName + "_current--broker_to_consumer_latency_max_ms.DIVStatsCounter").value(),
-        v2BrokerConsumerLatencyMs);
 
     // v3 finishes pushing and the status becomes to be online
     Version version3 = new VersionImpl(storeName, 3);


### PR DESCRIPTION
## Delete Unused non NR Metrics

We seem to have a pile of metrics that harken back to pre-NR. This change removes them.

Resolves #XXX

## How was this PR tested?
Ran CI and verified in production hosts these metrics are always blank.

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.