### PR TITLE
[server][test] Allow and skip acl checks for health check uri  from clients to server

### DIFF
--- a/internal/venice-common/src/main/java/com/linkedin/venice/acl/handler/StoreAclHandler.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/acl/handler/StoreAclHandler.java
@@ -93,6 +93,7 @@ public class StoreAclHandler extends SimpleChannelInboundHandler<HttpRequest> im
     String uri = req.uri();
     // Parse resource type and store name
     String[] requestParts = URI.create(uri).getPath().split("/");
+    // invalid request if requestParts.length < 3 except for HEALTH check from venice client
     if (requestParts.length < 3
         && !(requestParts.length == 2 && requestParts[1].toUpperCase().equals(QueryAction.HEALTH.toString()))) {
       NettyUtils.setupResponseAndFlush(
@@ -100,6 +101,7 @@ public class StoreAclHandler extends SimpleChannelInboundHandler<HttpRequest> im
           ("Invalid request uri: " + uri).getBytes(),
           false,
           ctx);
+      return;
     }
 
     /**

--- a/internal/venice-common/src/main/java/com/linkedin/venice/acl/handler/StoreAclHandler.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/acl/handler/StoreAclHandler.java
@@ -93,21 +93,22 @@ public class StoreAclHandler extends SimpleChannelInboundHandler<HttpRequest> im
     String uri = req.uri();
     // Parse resource type and store name
     String[] requestParts = URI.create(uri).getPath().split("/");
-    if (requestParts.length < 3) {
+    if (requestParts.length < 3
+        && !(requestParts.length == 2 && requestParts[1].toUpperCase().equals(QueryAction.HEALTH.toString()))) {
       NettyUtils.setupResponseAndFlush(
           HttpResponseStatus.BAD_REQUEST,
-          ("Invalid request  uri: " + uri).getBytes(),
+          ("Invalid request uri: " + uri).getBytes(),
           false,
           ctx);
-      return;
     }
 
     /**
-     *  Skip ACL for requests to /metadata and /admin as there's no sensitive information in the response.
+     *  Skip ACL for requests to /metadata, /admin and /health as there's no sensitive information in the response.
      */
     try {
       QueryAction queryAction = QueryAction.valueOf(requestParts[1].toUpperCase());
-      if (queryAction.equals(QueryAction.METADATA) || queryAction.equals(QueryAction.ADMIN)) {
+      if (queryAction.equals(QueryAction.METADATA) || queryAction.equals(QueryAction.ADMIN)
+          || queryAction.equals(QueryAction.HEALTH)) {
         ReferenceCountUtil.retain(req);
         ctx.fireChannelRead(req);
         return;

--- a/internal/venice-common/src/main/java/com/linkedin/venice/acl/handler/StoreAclHandler.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/acl/handler/StoreAclHandler.java
@@ -27,7 +27,10 @@ import io.netty.handler.ssl.SslHandler;
 import io.netty.util.ReferenceCountUtil;
 import java.net.URI;
 import java.security.cert.X509Certificate;
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Collectors;
 import javax.net.ssl.SSLPeerUnverifiedException;
 import javax.net.ssl.SSLSession;
@@ -107,10 +110,11 @@ public class StoreAclHandler extends SimpleChannelInboundHandler<HttpRequest> im
     /**
      *  Skip ACL for requests to /metadata, /admin and /health as there's no sensitive information in the response.
      */
+    Set<QueryAction> queriesToSkipAcl =
+        new HashSet<>(Arrays.asList(QueryAction.METADATA, QueryAction.ADMIN, QueryAction.HEALTH));
     try {
       QueryAction queryAction = QueryAction.valueOf(requestParts[1].toUpperCase());
-      if (queryAction.equals(QueryAction.METADATA) || queryAction.equals(QueryAction.ADMIN)
-          || queryAction.equals(QueryAction.HEALTH)) {
+      if (queriesToSkipAcl.contains(queryAction)) {
         ReferenceCountUtil.retain(req);
         ctx.fireChannelRead(req);
         return;


### PR DESCRIPTION
## Summary
Fast client warms up H2 connections by hitting the `/health` endpoint in servers but as uri validation for requests from clients to servers happens in `StoreAclHandler`, added changes to allow the `/heatlh` uri and by-pass acl validation since it is just a health check endpoint without any pii.

## How was this PR tested?
unit tests and GHCI

## Does this PR introduce any user-facing changes?
- [x] No. You can skip the rest of this section.
- [] Yes. Make sure to explain your proposed changes and call out the behavior change.