### PR TITLE
[server] Added info to the exception in AASIT::getUpstreamKafkaUrlFromKafkaValue

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
@@ -1252,9 +1252,13 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
       throw new VeniceException(
           String.format(
               "No Kafka cluster ID found in the cluster ID to Kafka URL map. "
-                  + "Got cluster ID %d and ID to cluster URL map %s",
+                  + "Got cluster ID %d and ID to cluster URL map %s. "
+                  + "Message type: %d; ProducerMetadata: %s; LeaderMetadataFooter: %s",
               kafkaValue.leaderMetadataFooter.upstreamKafkaClusterId,
-              kafkaClusterIdToUrlMap));
+              kafkaClusterIdToUrlMap,
+              kafkaValue.messageType,
+              kafkaValue.producerMetadata,
+              kafkaValue.leaderMetadataFooter));
     }
     return upstreamKafkaURL;
   }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
@@ -1196,7 +1196,8 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
          */
         upstreamKafkaURL = localKafkaServer;
       } else {
-        upstreamKafkaURL = getUpstreamKafkaUrlFromKafkaValue(consumerRecord, this.kafkaClusterIdToUrlMap);
+        upstreamKafkaURL =
+            getUpstreamKafkaUrlFromKafkaValue(consumerRecord, recordSourceKafkaUrl, this.kafkaClusterIdToUrlMap);
       }
     }
     return upstreamKafkaURL;
@@ -1250,6 +1251,7 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
    */
   static String getUpstreamKafkaUrlFromKafkaValue(
       PubSubMessage<KafkaKey, KafkaMessageEnvelope, Long> consumerRecord,
+      String recordSourceKafkaUrl,
       Int2ObjectMap<String> kafkaClusterIdToUrlMap) {
     KafkaMessageEnvelope kafkaValue = consumerRecord.getValue();
     if (kafkaValue.leaderMetadataFooter == null) {
@@ -1261,10 +1263,11 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
       throw new VeniceException(
           String.format(
               "No Kafka cluster ID found in the cluster ID to Kafka URL map. "
-                  + "Got cluster ID %d and ID to cluster URL map %s. "
+                  + "Got cluster ID %d and ID to cluster URL map %s. Source Kafka: %s; "
                   + "%s; Offset: %d; Message type: %s; ProducerMetadata: %s; LeaderMetadataFooter: %s",
               kafkaValue.leaderMetadataFooter.upstreamKafkaClusterId,
               kafkaClusterIdToUrlMap,
+              recordSourceKafkaUrl,
               consumerRecord.getTopicPartition(),
               consumerRecord.getOffset(),
               type.toString() + (type == MessageType.CONTROL_MESSAGE

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTaskTest.java
@@ -561,6 +561,7 @@ public class ActiveActiveStoreIngestionTaskTest {
     long offset = 100;
     long timestamp = System.currentTimeMillis();
     int payloadSize = 200;
+    String sourceKafka = "sourceKafkaURL";
 
     Int2ObjectMap<String> kafkaClusterIdToUrlMap = new Int2ObjectArrayMap<>(2);
     kafkaClusterIdToUrlMap.put(0, "url0");
@@ -577,7 +578,7 @@ public class ActiveActiveStoreIngestionTaskTest {
             payloadSize);
     try {
       ActiveActiveStoreIngestionTask
-          .getUpstreamKafkaUrlFromKafkaValue(pubSubMessageWithNullLeaderMetadata, kafkaClusterIdToUrlMap);
+          .getUpstreamKafkaUrlFromKafkaValue(pubSubMessageWithNullLeaderMetadata, sourceKafka, kafkaClusterIdToUrlMap);
     } catch (VeniceException e) {
       LOGGER.info("kmeWithNullLeaderMetadata", e);
       assertEquals(e.getMessage(), "leaderMetadataFooter field in KME should have been set.");
@@ -597,7 +598,7 @@ public class ActiveActiveStoreIngestionTaskTest {
         payloadSize);
     try {
       ActiveActiveStoreIngestionTask
-          .getUpstreamKafkaUrlFromKafkaValue(msgWithAbsentUpstreamCluster, kafkaClusterIdToUrlMap);
+          .getUpstreamKafkaUrlFromKafkaValue(msgWithAbsentUpstreamCluster, sourceKafka, kafkaClusterIdToUrlMap);
     } catch (VeniceException e) {
       LOGGER.info("kmeWithAbsentUpstreamCluster", e);
       assertTrue(e.getMessage().startsWith("No Kafka cluster ID found in the cluster ID to Kafka URL map."));
@@ -620,7 +621,8 @@ public class ActiveActiveStoreIngestionTaskTest {
         timestamp,
         payloadSize);
     try {
-      ActiveActiveStoreIngestionTask.getUpstreamKafkaUrlFromKafkaValue(msgForControlMessage, kafkaClusterIdToUrlMap);
+      ActiveActiveStoreIngestionTask
+          .getUpstreamKafkaUrlFromKafkaValue(msgForControlMessage, sourceKafka, kafkaClusterIdToUrlMap);
     } catch (VeniceException e) {
       LOGGER.info("kmeForControlMessage", e);
       assertTrue(e.getMessage().startsWith("No Kafka cluster ID found in the cluster ID to Kafka URL map."));
@@ -641,7 +643,7 @@ public class ActiveActiveStoreIngestionTaskTest {
         timestamp,
         payloadSize);
     assertEquals(
-        ActiveActiveStoreIngestionTask.getUpstreamKafkaUrlFromKafkaValue(validMsg, kafkaClusterIdToUrlMap),
+        ActiveActiveStoreIngestionTask.getUpstreamKafkaUrlFromKafkaValue(validMsg, sourceKafka, kafkaClusterIdToUrlMap),
         "url0");
   }
 

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTaskTest.java
@@ -15,8 +15,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.testng.Assert.assertNotNull;
-import static org.testng.Assert.assertNull;
+import static org.testng.Assert.*;
 
 import com.github.luben.zstd.Zstd;
 import com.linkedin.davinci.config.VeniceServerConfig;
@@ -36,10 +35,14 @@ import com.linkedin.venice.compression.CompressorFactory;
 import com.linkedin.venice.compression.NoopCompressor;
 import com.linkedin.venice.compression.VeniceCompressor;
 import com.linkedin.venice.compression.ZstdWithDictCompressor;
+import com.linkedin.venice.exceptions.VeniceException;
+import com.linkedin.venice.kafka.protocol.ControlMessage;
 import com.linkedin.venice.kafka.protocol.GUID;
 import com.linkedin.venice.kafka.protocol.KafkaMessageEnvelope;
+import com.linkedin.venice.kafka.protocol.LeaderMetadata;
 import com.linkedin.venice.kafka.protocol.ProducerMetadata;
 import com.linkedin.venice.kafka.protocol.Put;
+import com.linkedin.venice.kafka.protocol.enums.ControlMessageType;
 import com.linkedin.venice.kafka.protocol.enums.MessageType;
 import com.linkedin.venice.message.KafkaKey;
 import com.linkedin.venice.meta.BufferReplayPolicy;
@@ -57,12 +60,15 @@ import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.meta.VersionImpl;
 import com.linkedin.venice.meta.ZKStore;
 import com.linkedin.venice.partitioner.DefaultVenicePartitioner;
+import com.linkedin.venice.pubsub.ImmutablePubSubMessage;
+import com.linkedin.venice.pubsub.PubSubTopicPartitionImpl;
 import com.linkedin.venice.pubsub.PubSubTopicRepository;
 import com.linkedin.venice.pubsub.api.PubSubMessage;
 import com.linkedin.venice.pubsub.api.PubSubProduceResult;
 import com.linkedin.venice.pubsub.api.PubSubProducerAdapter;
 import com.linkedin.venice.pubsub.api.PubSubProducerCallback;
 import com.linkedin.venice.pubsub.api.PubSubTopic;
+import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
 import com.linkedin.venice.pubsub.api.PubSubTopicType;
 import com.linkedin.venice.schema.SchemaEntry;
 import com.linkedin.venice.serialization.KeyWithChunkingSuffixSerializer;
@@ -78,6 +84,7 @@ import com.linkedin.venice.utils.lazy.Lazy;
 import com.linkedin.venice.writer.VeniceWriter;
 import com.linkedin.venice.writer.VeniceWriterOptions;
 import it.unimi.dsi.fastutil.ints.Int2ObjectArrayMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import it.unimi.dsi.fastutil.objects.Object2IntArrayMap;
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -90,6 +97,8 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicLong;
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
 import org.mockito.ArgumentCaptor;
 import org.mockito.stubbing.Answer;
 import org.testng.Assert;
@@ -98,6 +107,7 @@ import org.testng.annotations.Test;
 
 
 public class ActiveActiveStoreIngestionTaskTest {
+  private static final Logger LOGGER = LogManager.getLogger(ActiveActiveStoreIngestionTaskTest.class);
   String STORE_NAME = "Thvorusleikir_store";
   String PUSH_JOB_ID = "yule";
   String BOOTSTRAP_SERVER = "Stekkjastaur";
@@ -539,6 +549,97 @@ public class ActiveActiveStoreIngestionTaskTest {
         Lazy.of(() -> new ByteBufferValueRecord<>(ByteBuffer.wrap(new byte[1]), 1)));
     assertNotNull(lazyBB);
     assertNotNull(lazyBB.get());
+  }
+
+  @Test
+  public void testGetUpstreamKafkaUrlFromKafkaValue() {
+    PubSubTopicRepository pubSubTopicRepository = new PubSubTopicRepository();
+    PubSubTopicPartition partition = new PubSubTopicPartitionImpl(pubSubTopicRepository.getTopic("topic"), 0);
+    long offset = 100;
+    long timestamp = System.currentTimeMillis();
+    int payloadSize = 200;
+
+    Int2ObjectMap<String> kafkaClusterIdToUrlMap = new Int2ObjectArrayMap<>(2);
+    kafkaClusterIdToUrlMap.put(0, "url0");
+    kafkaClusterIdToUrlMap.put(1, "url1");
+
+    KafkaMessageEnvelope kmeWithNullLeaderMetadata = new KafkaMessageEnvelope();
+    PubSubMessage<KafkaKey, KafkaMessageEnvelope, Long> pubSubMessageWithNullLeaderMetadata =
+        new ImmutablePubSubMessage<>(
+            new KafkaKey(MessageType.PUT, new byte[] { 1 }),
+            kmeWithNullLeaderMetadata,
+            partition,
+            offset,
+            timestamp,
+            payloadSize);
+    try {
+      ActiveActiveStoreIngestionTask
+          .getUpstreamKafkaUrlFromKafkaValue(pubSubMessageWithNullLeaderMetadata, kafkaClusterIdToUrlMap);
+    } catch (VeniceException e) {
+      LOGGER.info("kmeWithNullLeaderMetadata", e);
+      assertEquals(e.getMessage(), "leaderMetadataFooter field in KME should have been set.");
+    }
+
+    KafkaMessageEnvelope kmeWithAbsentUpstreamCluster = new KafkaMessageEnvelope();
+    kmeWithAbsentUpstreamCluster.setLeaderMetadataFooter(new LeaderMetadata());
+    kmeWithAbsentUpstreamCluster.getLeaderMetadataFooter().upstreamKafkaClusterId = -1;
+    kmeWithAbsentUpstreamCluster.setMessageType(MessageType.PUT.getValue());
+    kmeWithAbsentUpstreamCluster.setProducerMetadata(new ProducerMetadata());
+    PubSubMessage<KafkaKey, KafkaMessageEnvelope, Long> msgWithAbsentUpstreamCluster = new ImmutablePubSubMessage<>(
+        new KafkaKey(MessageType.PUT, new byte[] { 1 }),
+        kmeWithAbsentUpstreamCluster,
+        partition,
+        offset,
+        timestamp,
+        payloadSize);
+    try {
+      ActiveActiveStoreIngestionTask
+          .getUpstreamKafkaUrlFromKafkaValue(msgWithAbsentUpstreamCluster, kafkaClusterIdToUrlMap);
+    } catch (VeniceException e) {
+      LOGGER.info("kmeWithAbsentUpstreamCluster", e);
+      assertTrue(e.getMessage().startsWith("No Kafka cluster ID found in the cluster ID to Kafka URL map."));
+      assertTrue(e.getMessage().contains("Message type: " + MessageType.PUT));
+    }
+
+    KafkaMessageEnvelope kmeForControlMessage = new KafkaMessageEnvelope();
+    kmeForControlMessage.setLeaderMetadataFooter(new LeaderMetadata());
+    kmeForControlMessage.getLeaderMetadataFooter().upstreamKafkaClusterId = -1;
+    kmeForControlMessage.setMessageType(MessageType.CONTROL_MESSAGE.getValue());
+    ControlMessage controlMessage = new ControlMessage();
+    controlMessage.setControlMessageType(ControlMessageType.TOPIC_SWITCH.getValue());
+    kmeForControlMessage.setPayloadUnion(controlMessage);
+    kmeForControlMessage.setProducerMetadata(new ProducerMetadata());
+    PubSubMessage<KafkaKey, KafkaMessageEnvelope, Long> msgForControlMessage = new ImmutablePubSubMessage<>(
+        new KafkaKey(MessageType.CONTROL_MESSAGE, new byte[] { 1 }),
+        kmeForControlMessage,
+        partition,
+        offset,
+        timestamp,
+        payloadSize);
+    try {
+      ActiveActiveStoreIngestionTask.getUpstreamKafkaUrlFromKafkaValue(msgForControlMessage, kafkaClusterIdToUrlMap);
+    } catch (VeniceException e) {
+      LOGGER.info("kmeForControlMessage", e);
+      assertTrue(e.getMessage().startsWith("No Kafka cluster ID found in the cluster ID to Kafka URL map."));
+      assertTrue(
+          e.getMessage()
+              .contains("Message type: " + MessageType.CONTROL_MESSAGE + "/" + ControlMessageType.TOPIC_SWITCH));
+    }
+
+    KafkaMessageEnvelope validKME = new KafkaMessageEnvelope();
+    validKME.setLeaderMetadataFooter(new LeaderMetadata());
+    validKME.getLeaderMetadataFooter().upstreamKafkaClusterId = 0;
+    validKME.setProducerMetadata(new ProducerMetadata());
+    PubSubMessage<KafkaKey, KafkaMessageEnvelope, Long> validMsg = new ImmutablePubSubMessage<>(
+        new KafkaKey(MessageType.PUT, new byte[] { 1 }),
+        validKME,
+        partition,
+        offset,
+        timestamp,
+        payloadSize);
+    assertEquals(
+        ActiveActiveStoreIngestionTask.getUpstreamKafkaUrlFromKafkaValue(validMsg, kafkaClusterIdToUrlMap),
+        "url0");
   }
 
   private VeniceCompressor getCompressor(CompressionStrategy strategy) {

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTaskTest.java
@@ -15,7 +15,10 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.testng.Assert.*;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
 
 import com.github.luben.zstd.Zstd;
 import com.linkedin.davinci.config.VeniceServerConfig;


### PR DESCRIPTION
The exception now looks like this:

com.linkedin.venice.exceptions.VeniceException: No Kafka cluster ID found in the cluster ID to Kafka URL map. Got cluster ID -1 and ID to cluster URL map {0=>url0, 1=>url1}. Source Kafka: sourceKafkaURL; TP(topic: 'topic', partition: 0); Offset: 100; Message type: CONTROL_MESSAGE/TOPIC_SWITCH; ProducerMetadata: {"producerGUID": null, "segmentNumber": 0, "messageSequenceNumber": 0, "messageTimestamp": 0, "logicalTimestamp": 0}; LeaderMetadataFooter: {"hostName": null, "upstreamOffset": 0, "upstreamKafkaClusterId": -1}

## How was this PR tested?
New unit test.

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.