### PR TITLE
Fix BootstrappingVeniceChangelogConsumer no metadata issue

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/InternalLocalBootstrappingVeniceChangelogConsumer.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/InternalLocalBootstrappingVeniceChangelogConsumer.java
@@ -9,7 +9,6 @@ import static com.linkedin.davinci.store.rocksdb.RocksDBServerConfig.ROCKSDB_LEV
 import static com.linkedin.davinci.store.rocksdb.RocksDBServerConfig.ROCKSDB_PLAIN_TABLE_FORMAT_ENABLED;
 import static com.linkedin.venice.ConfigKeys.DATA_BASE_PATH;
 import static com.linkedin.venice.kafka.partitionoffset.PartitionOffsetFetcherImpl.DEFAULT_KAFKA_OFFSET_API_TIMEOUT;
-import static com.linkedin.venice.offsets.OffsetRecord.LOWEST_OFFSET;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.linkedin.davinci.callback.BytesStreamingCallback;
@@ -39,6 +38,7 @@ import com.linkedin.venice.schema.SchemaReader;
 import com.linkedin.venice.serialization.avro.AvroProtocolDefinition;
 import com.linkedin.venice.serialization.avro.InternalAvroSpecificSerializer;
 import com.linkedin.venice.serializer.RecordDeserializer;
+import com.linkedin.venice.service.AbstractVeniceService;
 import com.linkedin.venice.utils.PropertyBuilder;
 import com.linkedin.venice.utils.VeniceProperties;
 import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
@@ -207,7 +207,6 @@ class InternalLocalBootstrappingVeniceChangelogConsumer<K, V> extends VeniceChan
   protected Collection<PubSubMessage<K, ChangeEvent<V>, VeniceChangeCoordinate>> internalPoll(
       long timeoutInMs,
       String topicSuffix) {
-
     if (!isStarted) {
       throw new VeniceException("Client isn't started yet!!");
     }
@@ -308,6 +307,10 @@ class InternalLocalBootstrappingVeniceChangelogConsumer<K, V> extends VeniceChan
       currentPartitionState.currentPubSubPosition = record.getOffset();
       if (currentPartitionState.bootstrapState.equals(PollState.CATCHING_UP)) {
         if (currentPartitionState.isCaughtUp()) {
+          LOGGER.info(
+              "pollAndCatchup completed for partition: {} with offset: {}",
+              record.getPartition(),
+              getOffset(record.getOffset()));
           currentPartitionState.bootstrapState = PollState.BOOTSTRAPPING;
         }
       }
@@ -322,7 +325,8 @@ class InternalLocalBootstrappingVeniceChangelogConsumer<K, V> extends VeniceChan
       byte[] key,
       ByteBuffer value,
       PubSubTopicPartition partition,
-      int readerSchemaId) throws IOException {
+      int readerSchemaId,
+      long recordOffset) throws IOException {
     ByteBuffer decompressedBytes = compressor.decompress(value);
     T deserializedValue = deserializer.deserialize(decompressedBytes);
     if (deserializedValue instanceof RecordChangeEvent) {
@@ -345,6 +349,15 @@ class InternalLocalBootstrappingVeniceChangelogConsumer<K, V> extends VeniceChan
               key,
               ValueRecord.create(readerSchemaId, decompressedBytes.array()).serialize());
     }
+
+    // Update currentPubSubPosition for a partition, this will later be saved in RocksDb by
+    // VeniceChangelogCheckpointThread
+    VeniceChangeCoordinate currentPubSubPosition =
+        bootstrapStateMap.get(partition.getPartitionNumber()).currentPubSubPosition;
+    bootstrapStateMap.get(partition.getPartitionNumber()).currentPubSubPosition = new VeniceChangeCoordinate(
+        currentPubSubPosition.getTopic(),
+        new ApacheKafkaOffsetPosition(recordOffset),
+        currentPubSubPosition.getPartition());
     return deserializedValue;
   }
 
@@ -357,36 +370,34 @@ class InternalLocalBootstrappingVeniceChangelogConsumer<K, V> extends VeniceChan
         throw new VeniceException("Failed to bootstrap change log consumer with exception: ", e);
       }
       for (Integer partition: partitions) {
-        OffsetRecord offsetRecord;
-        try {
-          offsetRecord = storageMetadataService.getLastOffset(localStateTopicName, partition);
-          if (offsetRecord.getLocalVersionTopicOffset() == LOWEST_OFFSET) {
-            storageService.openStoreForNewPartition(
-                configLoader.getStoreConfig(localStateTopicName, PersistenceType.ROCKS_DB),
-                partition,
-                () -> null);
-          }
-        } catch (VeniceException e) {
-          // storageMetadataService will throw exception if there is no local store, it could happen the first
-          // time to run this code or local store has become invalid, we need to re-create the store in this case.
-          storageService.openStoreForNewPartition(
-              configLoader.getStoreConfig(localStateTopicName, PersistenceType.ROCKS_DB),
-              partition,
-              () -> null);
-          offsetRecord = new OffsetRecord(partitionStateSerializer);
-        }
-
+        // We'll always try to open for new partition during bootstrap. If a partition has been restored previously,
+        // it will be skipped in openStoreForNewPartition.
+        storageService.openStoreForNewPartition(
+            configLoader.getStoreConfig(localStateTopicName, PersistenceType.ROCKS_DB),
+            partition,
+            () -> null);
+        OffsetRecord offsetRecord = storageMetadataService.getLastOffset(localStateTopicName, partition);
         // Where we're at now
         String offsetString = offsetRecord.getDatabaseInfo().get(CHANGE_CAPTURE_COORDINATE);
         VeniceChangeCoordinate localCheckpoint;
         try {
           if (StringUtils.isEmpty(offsetString)) {
+            LOGGER.info("No local checkpoint found for partition: {}", partition);
             localCheckpoint = new VeniceChangeCoordinate(
                 getTopicPartition(partition).getPubSubTopic().getName(),
                 new ApacheKafkaOffsetPosition(offsetRecord.getLocalVersionTopicOffset()),
                 partition);
           } else {
             localCheckpoint = VeniceChangeCoordinate.decodeStringAndConvertToVeniceChangeCoordinate(offsetString);
+            if (partition != localCheckpoint.getPartition()) {
+              throw new IllegalStateException(
+                  String.format(
+                      "Local checkpoint partition: %s doesn't match with targeted partition: %s",
+                      localCheckpoint.getPartition(),
+                      partition));
+            }
+
+            LOGGER.info("Got local checkpoint for partition: {}, offset: {}", partition, getOffset(localCheckpoint));
           }
         } catch (IOException | ClassNotFoundException e) {
           throw new VeniceException("Failed to decode local change capture coordinate checkpoint with exception: ", e);
@@ -394,6 +405,7 @@ class InternalLocalBootstrappingVeniceChangelogConsumer<K, V> extends VeniceChan
 
         // Where we need to catch up to
         VeniceChangeCoordinate targetCheckpoint = this.getLatestCoordinate(partition);
+        LOGGER.info("Got latest offset: {} for partition: {}", getOffset(targetCheckpoint), partition);
 
         synchronized (bootstrapStateMap) {
           BootstrapState newState = new BootstrapState();
@@ -415,6 +427,7 @@ class InternalLocalBootstrappingVeniceChangelogConsumer<K, V> extends VeniceChan
         pollAndCatchup(5000L, ChangeCaptureView.CHANGE_CAPTURE_TOPIC_SUFFIX);
       }
 
+      LOGGER.info("Bootstrap completed!");
       this.isStarted = true;
       return null;
     });
@@ -434,7 +447,6 @@ class InternalLocalBootstrappingVeniceChangelogConsumer<K, V> extends VeniceChan
     }
 
     checkpointTask.start();
-
     return seekWithBootStrap(partitions);
   }
 
@@ -450,13 +462,23 @@ class InternalLocalBootstrappingVeniceChangelogConsumer<K, V> extends VeniceChan
   @Override
   public void stop() throws Exception {
     storageService.stop();
+    ((AbstractVeniceService) storageMetadataService).stop();
+    storeRepository.clear();
     checkpointTask.interrupt();
+    LOGGER.info("Successfully stopped the BootstrappingVeniceChangelogConsumer");
   }
 
   @VisibleForTesting
   void setStorageAndMetadataService(StorageService storageService, StorageMetadataService storageMetadataService) {
     this.storageService = storageService;
     this.storageMetadataService = storageMetadataService;
+  }
+
+  /**
+   * Helper method to get offset in long value from VeniceChangeCoordinate.
+   */
+  private long getOffset(VeniceChangeCoordinate veniceChangeCoordinate) {
+    return ((ApacheKafkaOffsetPosition) (veniceChangeCoordinate.getPosition())).getOffset();
   }
 
   enum PollState {
@@ -489,11 +511,17 @@ class InternalLocalBootstrappingVeniceChangelogConsumer<K, V> extends VeniceChan
                 CHANGE_CAPTURE_COORDINATE,
                 VeniceChangeCoordinate
                     .convertVeniceChangeCoordinateToStringAndEncode(state.getValue().currentPubSubPosition));
+            LOGGER.info(
+                "Update checkpoint for partition: {}, new offset: {}",
+                state.getKey(),
+                getOffset(state.getValue().currentPubSubPosition));
           } catch (IOException e) {
             LOGGER.error(
                 "Failed to update change capture coordinate position: {}",
                 state.getValue().currentPubSubPosition);
           }
+
+          lastOffset.setDatabaseInfo(dbInfo);
           storageMetadataService.put(localStateTopicName, state.getKey(), lastOffset);
         }
         try {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/InternalLocalBootstrappingVeniceChangelogConsumer.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/InternalLocalBootstrappingVeniceChangelogConsumer.java
@@ -289,6 +289,11 @@ class InternalLocalBootstrappingVeniceChangelogConsumer<K, V> extends VeniceChan
     return bootstrapCompletedCount;
   }
 
+  @VisibleForTesting
+  VeniceConcurrentHashMap<Integer, BootstrapState> getBootstrapStateMap() {
+    return bootstrapStateMap;
+  }
+
   /**
    * Polls change capture client and persist the results to local disk. Also updates the bootstrapStateMap with latest offsets
    * and if the client has caught up or not.
@@ -389,7 +394,7 @@ class InternalLocalBootstrappingVeniceChangelogConsumer<K, V> extends VeniceChan
                 partition);
           } else {
             localCheckpoint = VeniceChangeCoordinate.decodeStringAndConvertToVeniceChangeCoordinate(offsetString);
-            if (partition != localCheckpoint.getPartition()) {
+            if (!partition.equals(localCheckpoint.getPartition())) {
               throw new IllegalStateException(
                   String.format(
                       "Local checkpoint partition: %s doesn't match with targeted partition: %s",

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImpl.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImpl.java
@@ -605,7 +605,8 @@ public class VeniceChangelogConsumerImpl<K, V> implements VeniceChangelogConsume
                 compressor,
                 null),
             pubSubTopicPartition,
-            readerSchemaId);
+            readerSchemaId,
+            recordOffset);
       } catch (Exception ex) {
         // We might get an exception if we haven't persisted all the chunks for a given key. This
         // can actually happen if the client seeks to the middle of a chunked record either by
@@ -625,7 +626,8 @@ public class VeniceChangelogConsumerImpl<K, V> implements VeniceChangelogConsume
             keyBytes,
             valueBytes,
             pubSubTopicPartition,
-            readerSchemaId);
+            readerSchemaId,
+            recordOffset);
       } catch (Exception e) {
         throw new RuntimeException(e);
       }
@@ -649,7 +651,8 @@ public class VeniceChangelogConsumerImpl<K, V> implements VeniceChangelogConsume
       byte[] key,
       ByteBuffer value,
       PubSubTopicPartition partition,
-      int valueSchemaId) throws IOException {
+      int valueSchemaId,
+      long recordOffset) throws IOException {
     return deserializer.deserialize(compressor.decompress(value));
   }
 


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Summary, imperative, start upper case, don't end with a period
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Fix BootstrappingVeniceChangelogConsumer no metadata issue. Previously BootstrappingVeniceChangelogConsumer can store the data in local RocksDB. However, it couldn't successfully bootstrap from RocksDB as we didn't save the metadata correctly. This PR is to fix it.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
Tested by running integration test `testBootstrappingVeniceChangelogConsumer_WithPollAndCatchUp` twice with same store name. On the second run, verified the log to show we could load data directly from rocksDB instead of running pollAndCatchUp.

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [X] Yes. Make sure to explain your proposed changes and call out the behavior change.