### PR TITLE
[server][dvc] Lag measurement safeguard and logging improvements

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/LagType.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/LagType.java
@@ -1,0 +1,15 @@
+package com.linkedin.davinci.ingestion;
+
+public enum LagType {
+  OFFSET_LAG("Offset"), TIME_LAG("Time");
+
+  private final String prettyString;
+
+  LagType(String prettyString) {
+    this.prettyString = prettyString;
+  }
+
+  public String prettyString() {
+    return this.prettyString;
+  }
+}

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
@@ -9,6 +9,7 @@ import static com.linkedin.venice.writer.VeniceWriter.APP_DEFAULT_LOGICAL_TS;
 import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
 import com.linkedin.davinci.client.DaVinciRecordTransformer;
 import com.linkedin.davinci.config.VeniceStoreVersionConfig;
+import com.linkedin.davinci.ingestion.LagType;
 import com.linkedin.davinci.replication.RmdWithValueSchemaId;
 import com.linkedin.davinci.replication.merge.MergeConflictResolver;
 import com.linkedin.davinci.replication.merge.MergeConflictResolverFactory;
@@ -1307,14 +1308,14 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
       long offsetLag,
       long offsetThreshold,
       boolean shouldLogLag,
-      boolean isOffsetBasedLag,
+      LagType lagType,
       long latestConsumedProducerTimestamp) {
     boolean isLagAcceptable = super.checkAndLogIfLagIsAcceptableForHybridStore(
         pcs,
         offsetLag,
         offsetThreshold,
         false, // We'll take care of logging at the end of this function
-        isOffsetBasedLag,
+        lagType,
         latestConsumedProducerTimestamp);
 
     if (isLagAcceptable && isHybridFollower(pcs)) {
@@ -1343,7 +1344,7 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
         lagLogFooter = "";
       }
       logLag(
-          isOffsetBasedLag,
+          lagType,
           pcs.getPartition(),
           isLagAcceptable,
           latestConsumedProducerTimestamp,

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
@@ -1337,8 +1337,8 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
     if (shouldLogLag) {
       String lagLogFooter;
       if (isHybridFollower(pcs)) {
-        lagLogFooter = ". Leader Complete State: {" + pcs.getLeaderCompleteState().toString()
-            + "}, Last update In Ms: {" + pcs.getLastLeaderCompleteStateUpdateInMs() + "}.";
+        lagLogFooter = "Leader Complete State: {" + pcs.getLeaderCompleteState().toString() + "}, Last update In Ms: {"
+            + pcs.getLastLeaderCompleteStateUpdateInMs() + "}.";
       } else {
         lagLogFooter = "";
       }
@@ -1402,10 +1402,13 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
           }
 
           // Fall back to calculate offset lag in the old way
-          return (cachedPubSubMetadataGetter
-              .getOffset(getTopicManager(kafkaSourceAddress), currentLeaderTopic, pcs.getUserPartition()) - 1)
-              - pcs.getLeaderConsumedUpstreamRTOffset(kafkaSourceAddress);
+          return measureLagWithCallToPubSub(
+              kafkaSourceAddress,
+              currentLeaderTopic,
+              pcs.getUserPartition(),
+              pcs.getLeaderConsumedUpstreamRTOffset(kafkaSourceAddress));
         })
+        .filter(VALID_LAG)
         .sum();
 
     return minZeroLag(offsetLag);

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
@@ -1309,7 +1309,13 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
       boolean shouldLogLag,
       boolean isOffsetBasedLag,
       long latestConsumedProducerTimestamp) {
-    boolean isLagAcceptable = offsetLag <= offsetThreshold;
+    boolean isLagAcceptable = super.checkAndLogIfLagIsAcceptableForHybridStore(
+        pcs,
+        offsetLag,
+        offsetThreshold,
+        false, // We'll take care of logging at the end of this function
+        isOffsetBasedLag,
+        latestConsumedProducerTimestamp);
 
     if (isLagAcceptable && isHybridFollower(pcs)) {
       if (!getServerConfig().isLeaderCompleteStateCheckInFollowerEnabled()) {
@@ -1336,15 +1342,12 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
       } else {
         lagLogFooter = "";
       }
-      LOGGER.info(
-          "{} [{} lag] partition {} is {}lagging. {}Lag: [{}] {} Threshold [{}]{}",
-          isOffsetBasedLag ? "Offset" : "Time",
-          consumerTaskId,
+      logLag(
+          isOffsetBasedLag,
           pcs.getPartition(),
-          (isLagAcceptable ? "not " : ""),
-          (isOffsetBasedLag ? "" : "The latest producer timestamp is " + latestConsumedProducerTimestamp + ". "),
+          isLagAcceptable,
+          latestConsumedProducerTimestamp,
           offsetLag,
-          (isLagAcceptable ? "<" : ">"),
           offsetThreshold,
           lagLogFooter);
     }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/CachedPubSubMetadataGetter.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/CachedPubSubMetadataGetter.java
@@ -42,6 +42,8 @@ class CachedPubSubMetadataGetter {
    * @return Users of this method should be aware that Kafka will actually
    * return the next available offset rather the latest used offset. Therefore,
    * the value will be 1 offset greater than what's expected.
+   *
+   * TODO: Refactor this using PubSubTopicPartition
    */
   long getOffset(TopicManager topicManager, PubSubTopic pubSubTopic, int partitionId) {
     final String sourcePubSubServer = topicManager.getPubSubBootstrapServers();

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -3271,10 +3271,12 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
             .getOffset(getTopicManager(sourceRealTimeTopicKafkaURL), leaderTopic, partitionToGetLatestOffsetFor);
 
     if (lastOffsetInRealTimeTopic < 0) {
-      LOGGER.warn(
-          "Unexpected! Got a negative lastOffsetInRealTimeTopic ({})! Will return Long.MAX_VALUE as the lag.",
-          lastOffsetInRealTimeTopic,
-          new VeniceException("Exception not thrown, just for logging purposes."));
+      if (!REDUNDANT_LOGGING_FILTER.isRedundantException("Got a negative lastOffsetInRealTimeTopic")) {
+        LOGGER.warn(
+            "Unexpected! Got a negative lastOffsetInRealTimeTopic ({})! Will return Long.MAX_VALUE as the lag.",
+            lastOffsetInRealTimeTopic,
+            new VeniceException("Exception not thrown, just for logging purposes."));
+      }
       return Long.MAX_VALUE;
     }
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -154,7 +154,6 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
   private static final int CONSUMER_ACTION_QUEUE_INIT_CAPACITY = 11;
   protected static final long KILL_WAIT_TIME_MS = 5000L;
   private static final int MAX_KILL_CHECKING_ATTEMPTS = 10;
-  private static final int SLOPPY_OFFSET_CATCHUP_THRESHOLD = 100;
 
   protected static final RedundantExceptionFilter REDUNDANT_LOGGING_FILTER =
       RedundantExceptionFilter.getRedundantExceptionFilter();

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -3488,18 +3488,10 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
             if (storageEngineReloadedFromRepo == null) {
               LOGGER.warn("Storage engine {} was removed before reopening", kafkaVersionTopic);
             } else {
-              LOGGER.info("Reopen partition {}_{} for reading after ready-to-serve.", kafkaVersionTopic, partition);
               storageEngineReloadedFromRepo.preparePartitionForReading(partition);
             }
           }
-          if (partitionConsumptionState.isCompletionReported()) {
-            // Completion has been reported so extraDisjunctionCondition must be true to enter here.
-            LOGGER.info(
-                "{} Partition {} synced offset: {}",
-                consumerTaskId,
-                partition,
-                partitionConsumptionState.getLatestProcessedLocalVersionTopicOffset());
-          } else {
+          if (!partitionConsumptionState.isCompletionReported()) {
             reportCompleted(partitionConsumptionState);
             warmupSchemaCache(store);
           }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -1,5 +1,7 @@
 package com.linkedin.davinci.kafka.consumer;
 
+import static com.linkedin.davinci.ingestion.LagType.OFFSET_LAG;
+import static com.linkedin.davinci.ingestion.LagType.TIME_LAG;
 import static com.linkedin.davinci.kafka.consumer.ConsumerActionType.RESET_OFFSET;
 import static com.linkedin.davinci.kafka.consumer.ConsumerActionType.SUBSCRIBE;
 import static com.linkedin.davinci.kafka.consumer.ConsumerActionType.UNSUBSCRIBE;
@@ -15,6 +17,7 @@ import com.linkedin.davinci.compression.StorageEngineBackedCompressorFactory;
 import com.linkedin.davinci.config.VeniceServerConfig;
 import com.linkedin.davinci.config.VeniceStoreVersionConfig;
 import com.linkedin.davinci.helix.LeaderFollowerPartitionStateModel;
+import com.linkedin.davinci.ingestion.LagType;
 import com.linkedin.davinci.listener.response.AdminResponse;
 import com.linkedin.davinci.notifier.VeniceNotifier;
 import com.linkedin.davinci.stats.AggVersionedDIVStats;
@@ -769,7 +772,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
       long offsetLag,
       long offsetThreshold,
       boolean shouldLogLag,
-      boolean isOffsetBasedLag,
+      LagType lagType,
       long latestConsumedProducerTimestamp);
 
   /**
@@ -828,7 +831,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
               measureHybridOffsetLag(partitionConsumptionState, shouldLogLag),
               offsetThreshold,
               shouldLogLag,
-              true,
+              OFFSET_LAG,
               0);
         }
 
@@ -852,7 +855,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
               LatencyUtils.getElapsedTimeInMs(latestConsumedProducerTimestamp),
               producerTimeLagThresholdInMS,
               shouldLogLag,
-              false,
+              TIME_LAG,
               latestConsumedProducerTimestamp);
           /**
            * If time lag is not acceptable but the producer timestamp of the last message of RT is smaller or equal than

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -2331,7 +2331,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
 
   private void updateOffsetLagInMetadata(PartitionConsumptionState ps) {
     // Measure and save real-time offset lag.
-    long offsetLag = measureHybridOffsetLag(ps, true);
+    long offsetLag = measureHybridOffsetLag(ps, false);
     ps.getOffsetRecord().setOffsetLag(offsetLag);
   }
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/KafkaConsumerServiceStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/KafkaConsumerServiceStats.java
@@ -72,18 +72,15 @@ public class KafkaConsumerServiceStats extends AbstractVeniceStats {
 
     Sensor getOffsetLagSensor = registerSensor("getOffsetLag", new OccurrenceRate());
     Sensor[] offsetLagParent = new Sensor[] { getOffsetLagSensor };
-    this.getOffsetLagIsAbsentSensor =
-        registerSensor("getOffsetLagIsAbsent", null, offsetLagParent, new OccurrenceRate());
-    this.getOffsetLagIsPresentSensor =
-        registerSensor("getOffsetLagIsPresent", null, offsetLagParent, new OccurrenceRate());
+    this.getOffsetLagIsAbsentSensor = registerSensor("getOffsetLagIsAbsent", offsetLagParent, new OccurrenceRate());
+    this.getOffsetLagIsPresentSensor = registerSensor("getOffsetLagIsPresent", offsetLagParent, new OccurrenceRate());
 
     Sensor getLatestOffsetSensor = registerSensor("getLatestOffset", new OccurrenceRate());
     Sensor[] latestOffsetParent = new Sensor[] { getLatestOffsetSensor };
     this.getLatestOffsetIsAbsentSensor =
-        registerSensor("getLatestOffsetIsAbsent", null, latestOffsetParent, new OccurrenceRate());
+        registerSensor("getLatestOffsetIsAbsent", latestOffsetParent, new OccurrenceRate());
     this.getLatestOffsetIsPresentSensor =
-        registerSensor("getLatestOffsetIsPresent", null, latestOffsetParent, new OccurrenceRate());
-
+        registerSensor("getLatestOffsetIsPresent", latestOffsetParent, new OccurrenceRate());
   }
 
   public void recordPollRequestLatency(double latency) {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/AbstractStorageEngine.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/AbstractStorageEngine.java
@@ -190,7 +190,6 @@ public abstract class AbstractStorageEngine<Partition extends AbstractStoragePar
     int partitionId = partitionConfig.getPartitionId();
     AbstractStoragePartition partition = getPartitionOrThrow(partitionId);
     if (partition.verifyConfig(partitionConfig)) {
-      LOGGER.info("No adjustment needed for store name: {}, partition id: {}", getStoreName(), partitionId);
       return;
     }
     // Need to re-open storage partition according to the provided partition config

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/RocksDBSstFileWriter.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/RocksDBSstFileWriter.java
@@ -476,8 +476,11 @@ public class RocksDBSstFileWriter {
       rocksDB.ingestExternalFile(columnFamilyHandle, sstFilePaths, ingestOptions);
 
       LOGGER.info(
-          "Finished ingestion to store: " + storeName + ", partition id: " + partitionId + " from files: "
-              + sstFilePaths);
+          "Finished {} ingestion to store: {}, partition id: {} from files: {}",
+          isRMD ? "RMD" : "data",
+          storeName,
+          partitionId,
+          sstFilePaths);
     } catch (RocksDBException e) {
       throw new VeniceException("Received exception during RocksDB#ingestExternalFile", e);
     }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
@@ -6,7 +6,9 @@ import static com.linkedin.davinci.kafka.consumer.StoreIngestionTaskTest.AAConfi
 import static com.linkedin.davinci.kafka.consumer.StoreIngestionTaskTest.AAConfig.AA_ON;
 import static com.linkedin.davinci.kafka.consumer.StoreIngestionTaskTest.HybridConfig.HYBRID;
 import static com.linkedin.davinci.kafka.consumer.StoreIngestionTaskTest.LeaderCompleteCheck.LEADER_COMPLETE_CHECK_ON;
-import static com.linkedin.davinci.kafka.consumer.StoreIngestionTaskTest.NodeType.*;
+import static com.linkedin.davinci.kafka.consumer.StoreIngestionTaskTest.NodeType.DA_VINCI;
+import static com.linkedin.davinci.kafka.consumer.StoreIngestionTaskTest.NodeType.FOLLOWER;
+import static com.linkedin.davinci.kafka.consumer.StoreIngestionTaskTest.NodeType.LEADER;
 import static com.linkedin.davinci.kafka.consumer.StoreIngestionTaskTest.SortedInput.SORTED;
 import static com.linkedin.venice.ConfigKeys.CLUSTER_NAME;
 import static com.linkedin.venice.ConfigKeys.FREEZE_INGESTION_IF_READY_TO_SERVE_OR_LOCAL_DATA_EXISTS;

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
@@ -3084,6 +3084,7 @@ public abstract class StoreIngestionTaskTest {
     doReturn(150L).when(aggKafkaConsumerService).getLatestOffsetFor(anyString(), any(), any());
     doReturn(0).when(mockPcsMultipleSourceKafkaServers).getPartition();
     doReturn(0).when(mockPcsMultipleSourceKafkaServers).getUserPartition();
+    doReturn(5L).when(mockPcsMultipleSourceKafkaServers).getLatestProcessedLocalVersionTopicOffset();
     if (nodeType == LEADER_SERVER) {
       doReturn(LEADER).when(mockPcsMultipleSourceKafkaServers).getLeaderFollowerState();
     } else {

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
@@ -3,10 +3,13 @@ package com.linkedin.davinci.kafka.consumer;
 import static com.linkedin.davinci.kafka.consumer.LeaderFollowerStateType.IN_TRANSITION_FROM_STANDBY_TO_LEADER;
 import static com.linkedin.davinci.kafka.consumer.LeaderFollowerStateType.LEADER;
 import static com.linkedin.davinci.kafka.consumer.LeaderFollowerStateType.STANDBY;
+import static com.linkedin.davinci.kafka.consumer.StoreIngestionTaskTest.AAConfig.AA_DISABLED;
+import static com.linkedin.davinci.kafka.consumer.StoreIngestionTaskTest.AAConfig.AA_ENABLED;
 import static com.linkedin.davinci.kafka.consumer.StoreIngestionTaskTest.HybridConfig.HYBRID;
 import static com.linkedin.davinci.kafka.consumer.StoreIngestionTaskTest.NodeType.DA_VINCI_CLIENT;
 import static com.linkedin.davinci.kafka.consumer.StoreIngestionTaskTest.NodeType.FOLLOWER_SERVER;
 import static com.linkedin.davinci.kafka.consumer.StoreIngestionTaskTest.NodeType.LEADER_SERVER;
+import static com.linkedin.davinci.kafka.consumer.StoreIngestionTaskTest.SortedInput.SORTED;
 import static com.linkedin.venice.ConfigKeys.CLUSTER_NAME;
 import static com.linkedin.venice.ConfigKeys.FREEZE_INGESTION_IF_READY_TO_SERVE_OR_LOCAL_DATA_EXISTS;
 import static com.linkedin.venice.ConfigKeys.HYBRID_QUOTA_ENFORCEMENT_ENABLED;
@@ -260,7 +263,31 @@ public abstract class StoreIngestionTaskTest {
   }
 
   enum AAConfig {
-    ACTIVE_ACTIVE, NON_ACTIVE_ACTIVE
+    AA_ENABLED, AA_DISABLED
+  }
+
+  enum SortedInput {
+    SORTED, UNSORTED
+  }
+
+  @DataProvider
+  public static Object[][] aaConfigProvider() {
+    return DataProviderUtils.allPermutationGenerator(AAConfig.values());
+  }
+
+  @DataProvider
+  public static Object[][] nodeTypeAndAAConfigProvider() {
+    return DataProviderUtils.allPermutationGenerator(NodeType.values(), AAConfig.values());
+  }
+
+  @DataProvider
+  public static Object[][] hybridConfigAndNodeTypeProvider() {
+    return DataProviderUtils.allPermutationGenerator(HybridConfig.values(), NodeType.values());
+  }
+
+  @DataProvider
+  public static Object[][] sortedInputAndAAConfigProvider() {
+    return DataProviderUtils.allPermutationGenerator(SortedInput.values(), AAConfig.values());
   }
 
   private static final Logger LOGGER = LogManager.getLogger(StoreIngestionTaskTest.class);
@@ -574,16 +601,15 @@ public abstract class StoreIngestionTaskTest {
     return produceResultFuture.get().getOffset();
   }
 
-  private void runTest(Set<Integer> partitions, Runnable assertions, boolean isActiveActiveReplicationEnabled)
-      throws Exception {
-    runTest(partitions, () -> {}, assertions, isActiveActiveReplicationEnabled);
+  private void runTest(Set<Integer> partitions, Runnable assertions, AAConfig aaConfig) throws Exception {
+    runTest(partitions, () -> {}, assertions, aaConfig);
   }
 
   private void runTest(
       Set<Integer> partitions,
       Runnable beforeStartingConsumption,
       Runnable assertions,
-      boolean isActiveActiveReplicationEnabled) throws Exception {
+      AAConfig aaConfig) throws Exception {
     runTest(
         new RandomPollStrategy(),
         partitions,
@@ -592,7 +618,7 @@ public abstract class StoreIngestionTaskTest {
         this.hybridStoreConfig,
         false,
         Optional.empty(),
-        isActiveActiveReplicationEnabled,
+        aaConfig,
         1,
         Collections.emptyMap(),
         storeVersionConfigOverride -> {});
@@ -602,7 +628,7 @@ public abstract class StoreIngestionTaskTest {
       Set<Integer> partitions,
       Runnable beforeStartingConsumption,
       Runnable assertions,
-      boolean isActiveActiveReplicationEnabled,
+      AAConfig aaConfig,
       Consumer<VeniceStoreVersionConfig> storeVersionConfigOverride) throws Exception {
     runTest(
         new RandomPollStrategy(),
@@ -612,7 +638,7 @@ public abstract class StoreIngestionTaskTest {
         this.hybridStoreConfig,
         false,
         Optional.empty(),
-        isActiveActiveReplicationEnabled,
+        aaConfig,
         1,
         Collections.emptyMap(),
         storeVersionConfigOverride);
@@ -623,7 +649,7 @@ public abstract class StoreIngestionTaskTest {
       Set<Integer> partitions,
       Runnable beforeStartingConsumption,
       Runnable assertions,
-      boolean isActiveActiveReplicationEnabled) throws Exception {
+      AAConfig aaConfig) throws Exception {
     runTest(
         pollStrategy,
         partitions,
@@ -632,7 +658,7 @@ public abstract class StoreIngestionTaskTest {
         this.hybridStoreConfig,
         false,
         Optional.empty(),
-        isActiveActiveReplicationEnabled,
+        aaConfig,
         1,
         Collections.emptyMap(),
         storeVersionConfigOverride -> {});
@@ -646,7 +672,7 @@ public abstract class StoreIngestionTaskTest {
       Optional<HybridStoreConfig> hybridStoreConfig,
       boolean incrementalPushEnabled,
       Optional<DiskUsage> diskUsageForTest,
-      boolean isActiveActiveReplicationEnabled,
+      AAConfig aaConfig,
       int amplificationFactor,
       Map<String, Object> extraServerProperties) throws Exception {
     runTest(
@@ -657,7 +683,7 @@ public abstract class StoreIngestionTaskTest {
         hybridStoreConfig,
         incrementalPushEnabled,
         diskUsageForTest,
-        isActiveActiveReplicationEnabled,
+        aaConfig,
         amplificationFactor,
         extraServerProperties,
         storeVersionConfigOverride -> {});
@@ -675,7 +701,7 @@ public abstract class StoreIngestionTaskTest {
    * @param hybridStoreConfig, the config for hybrid store
    * @param incrementalPushEnabled, the flag to turn on incremental push for SIT
    * @param diskUsageForTest, optionally field to mock the disk usage for the test
-   * @param isActiveActiveReplicationEnabled, the flag to turn on ActiveActiveReplication for SIT
+   * @param aaConfig, the flag to turn on ActiveActiveReplication for SIT
    * @param amplificationFactor, the amplificationFactor
    * @param extraServerProperties, the extra config for server
    * @param storeVersionConfigOverride, the override for store version config
@@ -689,7 +715,7 @@ public abstract class StoreIngestionTaskTest {
       Optional<HybridStoreConfig> hybridStoreConfig,
       boolean incrementalPushEnabled,
       Optional<DiskUsage> diskUsageForTest,
-      boolean isActiveActiveReplicationEnabled,
+      AAConfig aaConfig,
       int amplificationFactor,
       Map<String, Object> extraServerProperties,
       Consumer<VeniceStoreVersionConfig> storeVersionConfigOverride) throws Exception {
@@ -706,7 +732,7 @@ public abstract class StoreIngestionTaskTest {
         hybridStoreConfig,
         incrementalPushEnabled,
         false,
-        isActiveActiveReplicationEnabled,
+        aaConfig,
         storeVersionConfigOverride);
     Store mockStore = storeAndVersionConfigs.store;
     Version version = storeAndVersionConfigs.version;
@@ -762,14 +788,14 @@ public abstract class StoreIngestionTaskTest {
       Optional<HybridStoreConfig> hybridStoreConfig,
       boolean incrementalPushEnabled,
       boolean isNativeReplicationEnabled,
-      boolean isActiveActiveReplicationEnabled) {
+      AAConfig aaConfig) {
     return setupStoreAndVersionMocks(
         partitionCount,
         partitionerConfig,
         hybridStoreConfig,
         incrementalPushEnabled,
         isNativeReplicationEnabled,
-        isActiveActiveReplicationEnabled,
+        aaConfig,
         storeVersionConfigOverride -> {});
   }
 
@@ -779,7 +805,7 @@ public abstract class StoreIngestionTaskTest {
       Optional<HybridStoreConfig> hybridStoreConfig,
       boolean incrementalPushEnabled,
       boolean isNativeReplicationEnabled,
-      boolean isActiveActiveReplicationEnabled,
+      AAConfig aaConfig,
       Consumer<VeniceStoreVersionConfig> storeVersionConfigOverride) {
     boolean isHybrid = hybridStoreConfig.isPresent();
     HybridStoreConfig hybridSoreConfigValue = null;
@@ -821,8 +847,8 @@ public abstract class StoreIngestionTaskTest {
     doReturn(-1).when(mockStore).getCurrentVersion();
     doReturn(1).when(mockStore).getBootstrapToOnlineTimeoutInHours();
 
-    version.setActiveActiveReplicationEnabled(isActiveActiveReplicationEnabled);
-    doReturn(isActiveActiveReplicationEnabled).when(mockStore).isActiveActiveReplicationEnabled();
+    version.setActiveActiveReplicationEnabled(aaConfig == AA_ENABLED);
+    doReturn(aaConfig == AA_ENABLED).when(mockStore).isActiveActiveReplicationEnabled();
     version.setRmdVersionId(REPLICATION_METADATA_VERSION_ID);
 
     doReturn(Optional.of(version)).when(mockStore).getVersion(anyInt());
@@ -1142,7 +1168,7 @@ public abstract class StoreIngestionTaskTest {
                 .getMessage()
                 .contains("compression Dictionary should not be empty if CompressionStrategy is ZSTD_WITH_DICT"));
       });
-    }, true);
+    }, AA_ENABLED);
   }
 
   /**
@@ -1151,8 +1177,8 @@ public abstract class StoreIngestionTaskTest {
    * 2. A VeniceMessage with DELETE requests leads to invoking of AbstractStorageEngine#delete.
    * 3. A VeniceMessage with a Kafka offset that was already processed is ignored.
    */
-  @Test(dataProvider = "True-and-False", dataProviderClass = DataProviderUtils.class)
-  public void testVeniceMessagesProcessing(boolean isActiveActiveReplicationEnabled) throws Exception {
+  @Test(dataProvider = "aaConfigProvider")
+  public void testVeniceMessagesProcessing(AAConfig aaConfig) throws Exception {
     localVeniceWriter.broadcastStartOfPush(new HashMap<>());
     PubSubProduceResult putMetadata = (PubSubProduceResult) localVeniceWriter
         .put(putKeyFoo, putValue, EXISTING_SCHEMA_ID, PUT_KEY_FOO_TIMESTAMP, null)
@@ -1173,7 +1199,7 @@ public abstract class StoreIngestionTaskTest {
     runTest(pollStrategy, Utils.setOf(PARTITION_FOO), () -> {}, () -> {
       // Verify it retrieves the offset from the OffSet Manager
       verify(mockStorageMetadataService, timeout(TEST_TIMEOUT_MS)).getLastOffset(topic, PARTITION_FOO);
-      verifyPutAndDelete(1, isActiveActiveReplicationEnabled, true);
+      verifyPutAndDelete(1, aaConfig, true);
       // Verify it commits the offset to Offset Manager
       OffsetRecord expectedOffsetRecordForDeleteMessage = getOffsetRecord(deleteMetadata.getOffset());
       verify(mockStorageMetadataService, timeout(TEST_TIMEOUT_MS))
@@ -1181,14 +1207,14 @@ public abstract class StoreIngestionTaskTest {
 
       verify(mockVersionedStorageIngestionStats, timeout(TEST_TIMEOUT_MS).atLeast(3))
           .recordConsumedRecordEndToEndProcessingLatency(any(), eq(1), anyDouble(), anyLong());
-    }, isActiveActiveReplicationEnabled);
+    }, aaConfig);
 
     // verify the shared consumer should be detached when the ingestion task is closed.
     verify(aggKafkaConsumerService).unsubscribeAll(pubSubTopic);
   }
 
-  @Test(dataProvider = "True-and-False", dataProviderClass = DataProviderUtils.class)
-  public void testAmplificationFactor(boolean isActiveActiveReplicationEnabled) throws Exception {
+  @Test(dataProvider = "aaConfigProvider")
+  public void testAmplificationFactor(AAConfig aaConfig) throws Exception {
     final int amplificationFactor = 2;
     inMemoryLocalKafkaBroker
         .createTopic(Version.composeRealTimeTopic(storeNameWithoutVersionInfo), PARTITION_COUNT / amplificationFactor);
@@ -1236,7 +1262,7 @@ public abstract class StoreIngestionTaskTest {
         rtWriter.put(putKeyFoo, putValue, EXISTING_SCHEMA_ID, PUT_KEY_FOO_TIMESTAMP, null).get();
         rtWriter.delete(deleteKeyFoo, DELETE_KEY_FOO_TIMESTAMP, null).get();
 
-        verifyPutAndDelete(amplificationFactor, isActiveActiveReplicationEnabled, false);
+        verifyPutAndDelete(amplificationFactor, aaConfig, false);
       } catch (Exception e) {
         e.printStackTrace();
       }
@@ -1244,14 +1270,13 @@ public abstract class StoreIngestionTaskTest {
         Optional.of(hybridStoreConfig),
         false,
         Optional.empty(),
-        isActiveActiveReplicationEnabled,
+        aaConfig,
         amplificationFactor,
         Collections.singletonMap(SERVER_PROMOTION_TO_LEADER_REPLICA_DELAY_SECONDS, 3L));
   }
 
-  @Test(dataProvider = "True-and-False", dataProviderClass = DataProviderUtils.class)
-  public void testMissingMessagesForTopicWithLogCompactionEnabled(boolean isActiveActiveReplicationEnabled)
-      throws Exception {
+  @Test(dataProvider = "aaConfigProvider")
+  public void testMissingMessagesForTopicWithLogCompactionEnabled(AAConfig aaConfig) throws Exception {
     // enable log compaction
     when(mockTopicManager.isTopicCompactionEnabled(pubSubTopic)).thenReturn(true);
 
@@ -1295,12 +1320,11 @@ public abstract class StoreIngestionTaskTest {
       OffsetRecord expectedOffsetRecordForLastMessage = getOffsetRecord(putMetadata4.getOffset());
       verify(mockStorageMetadataService, timeout(TEST_TIMEOUT_MS))
           .put(topic, PARTITION_FOO, expectedOffsetRecordForLastMessage);
-    }, isActiveActiveReplicationEnabled);
+    }, aaConfig);
   }
 
-  @Test(dataProvider = "True-and-False", dataProviderClass = DataProviderUtils.class)
-  public void testVeniceMessagesProcessingWithExistingSchemaId(boolean isActiveActiveReplicationEnabled)
-      throws Exception {
+  @Test(dataProvider = "aaConfigProvider")
+  public void testVeniceMessagesProcessingWithExistingSchemaId(AAConfig aaConfig) throws Exception {
     localVeniceWriter.broadcastStartOfPush(new HashMap<>());
     long fooLastOffset = getOffset(localVeniceWriter.put(putKeyFoo, putValue, EXISTING_SCHEMA_ID));
 
@@ -1318,16 +1342,15 @@ public abstract class StoreIngestionTaskTest {
       // Verify it commits the offset to Offset Manager
       OffsetRecord expected = getOffsetRecord(fooLastOffset);
       verify(mockStorageMetadataService, timeout(TEST_TIMEOUT_MS)).put(topic, PARTITION_FOO, expected);
-    }, isActiveActiveReplicationEnabled);
+    }, aaConfig);
   }
 
   /**
    * Test the situation where records arrive faster than the schemas.
    * In this case, Venice would keep polling schemaRepo until schemas arrive.
    */
-  @Test(dataProvider = "True-and-False", dataProviderClass = DataProviderUtils.class)
-  public void testVeniceMessagesProcessingWithTemporarilyNotAvailableSchemaId(boolean isActiveActiveReplicationEnabled)
-      throws Exception {
+  @Test(dataProvider = "aaConfigProvider")
+  public void testVeniceMessagesProcessingWithTemporarilyNotAvailableSchemaId(AAConfig aaConfig) throws Exception {
     localVeniceWriter.broadcastStartOfPush(new HashMap<>());
     localVeniceWriter.put(putKeyFoo, putValue, NON_EXISTING_SCHEMA_ID);
     long existingSchemaOffset = getOffset(localVeniceWriter.put(putKeyFoo, putValue, EXISTING_SCHEMA_ID));
@@ -1355,15 +1378,14 @@ public abstract class StoreIngestionTaskTest {
 
       OffsetRecord expected = getOffsetRecord(existingSchemaOffset);
       verify(mockStorageMetadataService, timeout(TEST_TIMEOUT_MS)).put(topic, PARTITION_FOO, expected);
-    }, isActiveActiveReplicationEnabled);
+    }, aaConfig);
   }
 
   /**
    * Test the situation where records' schemas never arrive. In the case, the StoreIngestionTask will keep being blocked.
    */
-  @Test(dataProvider = "True-and-False", dataProviderClass = DataProviderUtils.class)
-  public void testVeniceMessagesProcessingWithNonExistingSchemaId(boolean isActiveActiveReplicationEnabled)
-      throws Exception {
+  @Test(dataProvider = "aaConfigProvider")
+  public void testVeniceMessagesProcessingWithNonExistingSchemaId(AAConfig aaConfig) throws Exception {
     localVeniceWriter.broadcastStartOfPush(new HashMap<>());
     localVeniceWriter.put(putKeyFoo, putValue, NON_EXISTING_SCHEMA_ID);
     localVeniceWriter.put(putKeyFoo, putValue, EXISTING_SCHEMA_ID);
@@ -1385,11 +1407,11 @@ public abstract class StoreIngestionTaskTest {
       // Only two records(start_of_segment, start_of_push) offset were able to be recorded before
       // 'NON_EXISTING_SCHEMA_ID' blocks #putConsumerRecord
       verify(mockStorageMetadataService, atMost(2)).put(eq(topic), eq(PARTITION_FOO), any(OffsetRecord.class));
-    }, isActiveActiveReplicationEnabled);
+    }, aaConfig);
   }
 
-  @Test(dataProvider = "True-and-False", dataProviderClass = DataProviderUtils.class)
-  public void testReportStartWhenRestarting(boolean isActiveActiveReplicationEnabled) throws Exception {
+  @Test(dataProvider = "aaConfigProvider")
+  public void testReportStartWhenRestarting(AAConfig aaConfig) throws Exception {
     localVeniceWriter.broadcastStartOfPush(new HashMap<>());
     final long STARTING_OFFSET = 2;
     runTest(Utils.setOf(PARTITION_FOO, PARTITION_BAR), () -> {
@@ -1397,11 +1419,11 @@ public abstract class StoreIngestionTaskTest {
     }, () -> {
       // Verify STARTED is NOT reported when offset is 0
       verify(mockLogNotifier, never()).started(topic, PARTITION_BAR);
-    }, isActiveActiveReplicationEnabled);
+    }, aaConfig);
   }
 
-  @Test(dataProvider = "True-and-False", dataProviderClass = DataProviderUtils.class)
-  public void testNotifier(boolean isActiveActiveReplicationEnabled) throws Exception {
+  @Test(dataProvider = "aaConfigProvider")
+  public void testNotifier(AAConfig aaConfig) throws Exception {
     localVeniceWriter.broadcastStartOfPush(new HashMap<>());
     long fooLastOffset = getOffset(localVeniceWriter.put(putKeyFoo, putValue, SCHEMA_ID));
     long barLastOffset = getOffset(localVeniceWriter.put(putKeyBar, putValue, SCHEMA_ID));
@@ -1449,11 +1471,11 @@ public abstract class StoreIngestionTaskTest {
       verify(mockPartitionStatusNotifier, atLeastOnce()).started(topic, PARTITION_BAR);
       verify(mockPartitionStatusNotifier, atLeastOnce()).endOfPushReceived(topic, PARTITION_FOO, fooLastOffset);
       verify(mockPartitionStatusNotifier, atLeastOnce()).endOfPushReceived(topic, PARTITION_BAR, barLastOffset);
-    }, isActiveActiveReplicationEnabled);
+    }, aaConfig);
   }
 
-  @Test(dataProvider = "True-and-False", dataProviderClass = DataProviderUtils.class)
-  public void testReadyToServePartition(boolean isActiveActiveReplicationEnabled) throws Exception {
+  @Test(dataProvider = "aaConfigProvider")
+  public void testReadyToServePartition(AAConfig aaConfig) throws Exception {
     localVeniceWriter.broadcastStartOfPush(new HashMap<>());
     localVeniceWriter.broadcastEndOfPush(new HashMap<>());
 
@@ -1472,12 +1494,11 @@ public abstract class StoreIngestionTaskTest {
           10,
           TimeUnit.SECONDS,
           () -> verify(mockAbstractStorageEngine, atLeastOnce()).preparePartitionForReading(PARTITION_FOO));
-    }, isActiveActiveReplicationEnabled);
+    }, aaConfig);
   }
 
-  @Test(dataProvider = "True-and-False", dataProviderClass = DataProviderUtils.class)
-  public void testReadyToServePartitionValidateIngestionSuccess(boolean isActiveActiveReplicationEnabled)
-      throws Exception {
+  @Test(dataProvider = "aaConfigProvider")
+  public void testReadyToServePartitionValidateIngestionSuccess(AAConfig aaConfig) throws Exception {
     localVeniceWriter.broadcastStartOfPush(new HashMap<>());
     localVeniceWriter.broadcastEndOfPush(new HashMap<>());
     Store mockStore = mock(Store.class);
@@ -1492,11 +1513,11 @@ public abstract class StoreIngestionTaskTest {
 
     runTest(Utils.setOf(PARTITION_FOO), () -> {
       verify(mockAbstractStorageEngine, never()).preparePartitionForReading(PARTITION_FOO);
-    }, isActiveActiveReplicationEnabled);
+    }, aaConfig);
   }
 
-  @Test(dataProvider = "True-and-False", dataProviderClass = DataProviderUtils.class)
-  public void testReadyToServePartitionWriteOnly(boolean isActiveActiveReplicationEnabled) throws Exception {
+  @Test(dataProvider = "aaConfigProvider")
+  public void testReadyToServePartitionWriteOnly(AAConfig aaConfig) throws Exception {
     localVeniceWriter.broadcastStartOfPush(new HashMap<>());
     localVeniceWriter.broadcastEndOfPush(new HashMap<>());
     Store mockStore = mock(Store.class);
@@ -1513,11 +1534,11 @@ public abstract class StoreIngestionTaskTest {
     runTest(Utils.setOf(PARTITION_FOO), () -> {
       verify(mockAbstractStorageEngine, never()).preparePartitionForReading(PARTITION_FOO);
       verify(mockAbstractStorageEngine, never()).preparePartitionForReading(PARTITION_BAR);
-    }, isActiveActiveReplicationEnabled);
+    }, aaConfig);
   }
 
-  @Test(dataProvider = "True-and-False", dataProviderClass = DataProviderUtils.class)
-  public void testResetPartition(boolean isActiveActiveReplicationEnabled) throws Exception {
+  @Test(dataProvider = "aaConfigProvider")
+  public void testResetPartition(AAConfig aaConfig) throws Exception {
     localVeniceWriter.broadcastStartOfPush(new HashMap<>());
     localVeniceWriter.put(putKeyFoo, putValue, SCHEMA_ID).get();
 
@@ -1530,11 +1551,11 @@ public abstract class StoreIngestionTaskTest {
       verify(mockStorageMetadataService, timeout(TEST_TIMEOUT_MS)).clearOffset(topic, PARTITION_FOO);
       verify(mockAbstractStorageEngine, timeout(TEST_TIMEOUT_MS).times(2))
           .put(PARTITION_FOO, putKeyFoo, ByteBuffer.wrap(ValueRecord.create(SCHEMA_ID, putValue).serialize()));
-    }, isActiveActiveReplicationEnabled);
+    }, aaConfig);
   }
 
-  @Test(dataProvider = "True-and-False", dataProviderClass = DataProviderUtils.class)
-  public void testResetPartitionAfterUnsubscription(boolean isActiveActiveReplicationEnabled) throws Exception {
+  @Test(dataProvider = "aaConfigProvider")
+  public void testResetPartitionAfterUnsubscription(AAConfig aaConfig) throws Exception {
     localVeniceWriter.broadcastStartOfPush(new HashMap<>());
     localVeniceWriter.put(putKeyFoo, putValue, SCHEMA_ID).get();
 
@@ -1551,7 +1572,7 @@ public abstract class StoreIngestionTaskTest {
       // StoreIngestionTask won't invoke consumer.resetOffset() if it already unsubscribe from that topic/partition
       verify(mockLocalKafkaConsumer, timeout(TEST_TIMEOUT_MS).times(0)).resetOffset(fooTopicPartition);
       verify(mockStorageMetadataService, timeout(TEST_TIMEOUT_MS)).clearOffset(topic, PARTITION_FOO);
-    }, isActiveActiveReplicationEnabled);
+    }, aaConfig);
   }
 
   /**
@@ -1559,8 +1580,8 @@ public abstract class StoreIngestionTaskTest {
    *
    * The {@link VeniceNotifier} should see the completion and error reported for the appropriate partitions.
    */
-  @Test(dataProvider = "True-and-False", dataProviderClass = DataProviderUtils.class)
-  public void testDetectionOfMissingRecord(boolean isActiveActiveReplicationEnabled) throws Exception {
+  @Test(dataProvider = "aaConfigProvider")
+  public void testDetectionOfMissingRecord(AAConfig aaConfig) throws Exception {
     localVeniceWriter.broadcastStartOfPush(new HashMap<>());
     long fooLastOffset = getOffset(localVeniceWriter.put(putKeyFoo, putValue, SCHEMA_ID));
     long barOffsetToSkip = getOffset(localVeniceWriter.put(putKeyBar, putValue, SCHEMA_ID));
@@ -1585,15 +1606,15 @@ public abstract class StoreIngestionTaskTest {
 
       verify(mockLogNotifier, atLeastOnce()).started(topic, PARTITION_FOO);
       verify(mockLogNotifier, atLeastOnce()).started(topic, PARTITION_BAR);
-    }, isActiveActiveReplicationEnabled);
+    }, aaConfig);
   }
 
   /**
    * In this test, partition FOO will complete normally, but partition BAR will contain a duplicate record. The
    * {@link VeniceNotifier} should see the completion for both partitions.
    */
-  @Test(dataProvider = "True-and-False", dataProviderClass = DataProviderUtils.class)
-  public void testSkippingOfDuplicateRecord(boolean isActiveActiveReplicationEnabled) throws Exception {
+  @Test(dataProvider = "aaConfigProvider")
+  public void testSkippingOfDuplicateRecord(AAConfig aaConfig) throws Exception {
     localVeniceWriter.broadcastStartOfPush(new HashMap<>());
     long fooLastOffset = getOffset(localVeniceWriter.put(putKeyFoo, putValue, SCHEMA_ID));
     long barOffsetToDupe = getOffset(localVeniceWriter.put(putKeyBar, putValue, SCHEMA_ID));
@@ -1617,11 +1638,11 @@ public abstract class StoreIngestionTaskTest {
 
       verify(mockLogNotifier, atLeastOnce()).started(topic, PARTITION_FOO);
       verify(mockLogNotifier, atLeastOnce()).started(topic, PARTITION_BAR);
-    }, isActiveActiveReplicationEnabled);
+    }, aaConfig);
   }
 
-  @Test(dataProvider = "True-and-False", dataProviderClass = DataProviderUtils.class)
-  public void testThrottling(boolean isActiveActiveReplicationEnabled) throws Exception {
+  @Test(dataProvider = "aaConfigProvider")
+  public void testThrottling(AAConfig aaConfig) throws Exception {
     localVeniceWriter.broadcastStartOfPush(new HashMap<>());
     localVeniceWriter.put(putKeyFoo, putValue, SCHEMA_ID);
     localVeniceWriter.delete(deleteKeyFoo, null);
@@ -1630,7 +1651,7 @@ public abstract class StoreIngestionTaskTest {
       // START_OF_SEGMENT, START_OF_PUSH, PUT, DELETE
       verify(mockRecordsThrottler, timeout(TEST_TIMEOUT_MS).times(4)).maybeThrottle(1);
       verify(mockBandwidthThrottler, timeout(TEST_TIMEOUT_MS).times(4)).maybeThrottle(anyDouble());
-    }, isActiveActiveReplicationEnabled);
+    }, aaConfig);
   }
 
   /**
@@ -1638,8 +1659,8 @@ public abstract class StoreIngestionTaskTest {
    * message in {@link #PARTITION_FOO} will receive a bad message type, whereas the message in {@link #PARTITION_BAR}
    * will receive a bad control message type.
    */
-  @Test(dataProvider = "True-and-False", dataProviderClass = DataProviderUtils.class)
-  public void testBadMessageTypesFailFast(boolean isActiveActiveReplicationEnabled) throws Exception {
+  @Test(dataProvider = "aaConfigProvider")
+  public void testBadMessageTypesFailFast(AAConfig aaConfig) throws Exception {
     int badMessageTypeId = 99; // Venice got 99 problems, but a bad message type ain't one.
 
     // Dear future maintainer,
@@ -1704,7 +1725,7 @@ public abstract class StoreIngestionTaskTest {
 
     runTest(Utils.setOf(PARTITION_FOO, PARTITION_BAR), () -> {
       verify(kafkaConsumerServiceStats, timeout(TEST_TIMEOUT_MS).atLeastOnce()).recordPollError();
-    }, isActiveActiveReplicationEnabled);
+    }, aaConfig);
   }
 
   /**
@@ -1712,8 +1733,8 @@ public abstract class StoreIngestionTaskTest {
    * including a corrupt message followed by a good one. We expect the Notifier to not report any errors after the
    * EOP.
    */
-  @Test(dataProvider = "True-and-False", dataProviderClass = DataProviderUtils.class)
-  public void testCorruptMessagesDoNotFailFastAfterEOP(boolean isActiveActiveReplicationEnabled) throws Exception {
+  @Test(dataProvider = "aaConfigProvider")
+  public void testCorruptMessagesDoNotFailFastAfterEOP(AAConfig aaConfig) throws Exception {
     VeniceWriter veniceWriterForDataDuringPush =
         getVeniceWriter(new MockInMemoryProducerAdapter(inMemoryLocalKafkaBroker));
     VeniceWriter veniceWriterForDataAfterPush = getCorruptedVeniceWriter(putValueToCorrupt, inMemoryLocalKafkaBroker);
@@ -1758,7 +1779,7 @@ public abstract class StoreIngestionTaskTest {
                   && args[3] instanceof CorruptDataException);
         }
 
-      }, isActiveActiveReplicationEnabled);
+      }, aaConfig);
     } catch (VerifyError e) {
       StringBuilder msg = new StringBuilder();
       ClassLoader cl = ClassLoader.getSystemClassLoader();
@@ -1782,8 +1803,8 @@ public abstract class StoreIngestionTaskTest {
    * including a corrupt message followed by a missing message and a good one.
    * We expect the Notifier to not report any errors after the EOP.
    */
-  @Test(dataProvider = "True-and-False", dataProviderClass = DataProviderUtils.class)
-  public void testDIVErrorMessagesNotFailFastAfterEOP(boolean isActiveActiveReplicationEnabled) throws Exception {
+  @Test(dataProvider = "aaConfigProvider")
+  public void testDIVErrorMessagesNotFailFastAfterEOP(AAConfig aaConfig) throws Exception {
     VeniceWriter veniceWriterCorrupted = getCorruptedVeniceWriter(putValueToCorrupt, inMemoryLocalKafkaBroker);
 
     // do a batch push
@@ -1817,7 +1838,7 @@ public abstract class StoreIngestionTaskTest {
             args[0].equals(topic) && args[1].equals(PARTITION_FOO) && ((String) args[2]).length() > 0
                 && args[3] instanceof FatalDataValidationException);
       }
-    }, isActiveActiveReplicationEnabled);
+    }, aaConfig);
   }
 
   /**
@@ -1828,8 +1849,8 @@ public abstract class StoreIngestionTaskTest {
    * should ensure that if this test is ever made flaky again, it will be detected right away. The skipFailedInvocations
    * annotation parameter makes the test skip any invocation after the first failure.
    */
-  @Test(dataProvider = "True-and-False", dataProviderClass = DataProviderUtils.class, invocationCount = 100, skipFailedInvocations = true)
-  public void testCorruptMessagesFailFast(boolean isActiveActiveReplicationEnabled) throws Exception {
+  @Test(dataProvider = "aaConfigProvider", invocationCount = 100, skipFailedInvocations = true)
+  public void testCorruptMessagesFailFast(AAConfig aaConfig) throws Exception {
     VeniceWriter veniceWriterForData = getCorruptedVeniceWriter(putValueToCorrupt, inMemoryLocalKafkaBroker);
 
     localVeniceWriter.broadcastStartOfPush(new HashMap<>());
@@ -1858,11 +1879,11 @@ public abstract class StoreIngestionTaskTest {
        * this test is to detect this edge case.
        */
       verify(mockLogNotifier, never()).completed(eq(topic), eq(PARTITION_BAR), anyLong());
-    }, isActiveActiveReplicationEnabled);
+    }, aaConfig);
   }
 
-  @Test(dataProvider = "True-and-False", dataProviderClass = DataProviderUtils.class)
-  public void testSubscribeCompletedPartition(boolean isActiveActiveReplicationEnabled) throws Exception {
+  @Test(dataProvider = "aaConfigProvider")
+  public void testSubscribeCompletedPartition(AAConfig aaConfig) throws Exception {
     final int offset = 100;
     localVeniceWriter.broadcastStartOfPush(new HashMap<>());
     runTest(
@@ -1872,11 +1893,11 @@ public abstract class StoreIngestionTaskTest {
         () -> {
           verify(mockLogNotifier, timeout(TEST_TIMEOUT_MS)).completed(topic, PARTITION_FOO, offset, "STANDBY");
         },
-        isActiveActiveReplicationEnabled);
+        aaConfig);
   }
 
-  @Test(dataProvider = "True-and-False", dataProviderClass = DataProviderUtils.class)
-  public void testSubscribeCompletedPartitionUnsubscribe(boolean isActiveActiveReplicationEnabled) throws Exception {
+  @Test(dataProvider = "aaConfigProvider")
+  public void testSubscribeCompletedPartitionUnsubscribe(AAConfig aaConfig) throws Exception {
     final int offset = 100;
     final long LONG_TEST_TIMEOUT = 2 * TEST_TIMEOUT_MS;
     localVeniceWriter.broadcastStartOfPush(new HashMap<>());
@@ -1898,12 +1919,11 @@ public abstract class StoreIngestionTaskTest {
       verify(mockLocalKafkaConsumer, timeout(LONG_TEST_TIMEOUT))
           .batchUnsubscribe(Collections.singleton(fooTopicPartition));
       verify(mockLocalKafkaConsumer, never()).unSubscribe(barTopicPartition);
-    }, this.hybridStoreConfig, false, Optional.empty(), isActiveActiveReplicationEnabled, 1, extraServerProperties);
+    }, this.hybridStoreConfig, false, Optional.empty(), aaConfig, 1, extraServerProperties);
   }
 
-  @Test(dataProvider = "True-and-False", dataProviderClass = DataProviderUtils.class)
-  public void testCompleteCalledWhenUnsubscribeAfterBatchPushDisabled(boolean isActiveActiveReplicationEnabled)
-      throws Exception {
+  @Test(dataProvider = "aaConfigProvider")
+  public void testCompleteCalledWhenUnsubscribeAfterBatchPushDisabled(AAConfig aaConfig) throws Exception {
     final int offset = 10;
     localVeniceWriter.broadcastStartOfPush(new HashMap<>());
 
@@ -1917,11 +1937,11 @@ public abstract class StoreIngestionTaskTest {
       doReturn(getOffsetRecord(offset, true)).when(mockStorageMetadataService).getLastOffset(topic, PARTITION_FOO);
     },
         () -> verify(mockLogNotifier, timeout(TEST_TIMEOUT_MS)).completed(topic, PARTITION_FOO, offset, "STANDBY"),
-        isActiveActiveReplicationEnabled);
+        aaConfig);
   }
 
-  @Test(dataProvider = "True-and-False", dataProviderClass = DataProviderUtils.class)
-  public void testUnsubscribeConsumption(boolean isActiveActiveReplicationEnabled) throws Exception {
+  @Test(dataProvider = "aaConfigProvider")
+  public void testUnsubscribeConsumption(AAConfig aaConfig) throws Exception {
     localVeniceWriter.broadcastStartOfPush(new HashMap<>());
     localVeniceWriter.put(putKeyFoo, putValue, SCHEMA_ID);
 
@@ -1930,11 +1950,11 @@ public abstract class StoreIngestionTaskTest {
       // Start of push has already been consumed. Stop consumption
       storeIngestionTaskUnderTest.unSubscribePartition(fooTopicPartition);
       verify(mockLogNotifier, timeout(TEST_TIMEOUT_MS)).stopped(anyString(), anyInt(), anyLong());
-    }, isActiveActiveReplicationEnabled);
+    }, aaConfig);
   }
 
-  @Test(dataProvider = "True-and-False", dataProviderClass = DataProviderUtils.class)
-  public void testKillConsumption(boolean isActiveActiveReplicationEnabled) throws Exception {
+  @Test(dataProvider = "aaConfigProvider")
+  public void testKillConsumption(AAConfig aaConfig) throws Exception {
     final Thread writingThread = new Thread(() -> {
       while (true) {
         localVeniceWriter.put(putKeyFoo, putValue, SCHEMA_ID);
@@ -1971,14 +1991,14 @@ public abstract class StoreIngestionTaskTest {
             TEST_TIMEOUT_MS,
             TimeUnit.MILLISECONDS,
             () -> storeIngestionTaskUnderTest.isRunning() == false);
-      }, isActiveActiveReplicationEnabled);
+      }, aaConfig);
     } finally {
       TestUtils.shutdownThread(writingThread);
     }
   }
 
-  @Test(dataProvider = "True-and-False", dataProviderClass = DataProviderUtils.class)
-  public void testKillActionPriority(boolean isActiveActiveReplicationEnabled) throws Exception {
+  @Test(dataProvider = "aaConfigProvider")
+  public void testKillActionPriority(AAConfig aaConfig) throws Exception {
     runTest(Utils.setOf(PARTITION_FOO), () -> {
       localVeniceWriter.broadcastStartOfPush(new HashMap<>());
       localVeniceWriter.put(putKeyFoo, putValue, SCHEMA_ID);
@@ -2005,7 +2025,7 @@ public abstract class StoreIngestionTaskTest {
           TEST_TIMEOUT_MS,
           TimeUnit.MILLISECONDS,
           () -> storeIngestionTaskUnderTest.isRunning() == false);
-    }, isActiveActiveReplicationEnabled);
+    }, aaConfig);
   }
 
   private byte[] getNumberedKey(int number) {
@@ -2016,17 +2036,16 @@ public abstract class StoreIngestionTaskTest {
     return ByteBuffer.allocate(putValue.length + Integer.BYTES).put(putValue).putInt(number).array();
   }
 
-  @Test(dataProvider = "Two-True-and-False", dataProviderClass = DataProviderUtils.class)
-  public void testDataValidationCheckPointing(boolean sortedInput, boolean isActiveActiveReplicationEnabled)
-      throws Exception {
+  @Test(dataProvider = "sortedInputAndAAConfigProvider")
+  public void testDataValidationCheckPointing(SortedInput sortedInput, AAConfig aaConfig) throws Exception {
     final Map<Integer, Long> maxOffsetPerPartition = new HashMap<>();
     final Map<Pair<Integer, ByteArray>, ByteArray> pushedRecords = new HashMap<>();
     final int totalNumberOfMessages = 1000;
     final int totalNumberOfConsumptionRestarts = 10;
     final long LONG_TEST_TIMEOUT = 2 * TEST_TIMEOUT_MS;
 
-    setStoreVersionStateSupplier(sortedInput);
-    localVeniceWriter.broadcastStartOfPush(sortedInput, new HashMap<>());
+    setStoreVersionStateSupplier(sortedInput == SORTED);
+    localVeniceWriter.broadcastStartOfPush(sortedInput == SORTED, new HashMap<>());
     for (int i = 0; i < totalNumberOfMessages; i++) {
       byte[] key = getNumberedKey(i);
       byte[] value = getNumberedValue(i);
@@ -2102,7 +2121,7 @@ public abstract class StoreIngestionTaskTest {
         verify(mockLocalKafkaConsumer, timeout(LONG_TEST_TIMEOUT).atLeast(totalNumberOfConsumptionRestarts))
             .unSubscribe(eq(pubSubTopicPartition));
 
-        if (sortedInput) {
+        if (sortedInput == SORTED) {
           // Check database mode switches from deferred-write to transactional after EOP control message
           StoragePartitionConfig deferredWritePartitionConfig = new StoragePartitionConfig(topic, partition);
           deferredWritePartitionConfig.setDeferredWrite(true);
@@ -2135,11 +2154,11 @@ public abstract class StoreIngestionTaskTest {
         PartitionConsumptionState pcs = storeIngestionTaskUnderTest.getPartitionConsumptionState(partition);
         Assert.assertTrue(pcs.getLatestProcessedUpstreamRTOffsetMap().isEmpty());
       });
-    }, isActiveActiveReplicationEnabled);
+    }, aaConfig);
   }
 
-  @Test(dataProvider = "True-and-False", dataProviderClass = DataProviderUtils.class)
-  public void testKillAfterPartitionIsCompleted(boolean isActiveActiveReplicationEnabled) throws Exception {
+  @Test(dataProvider = "aaConfigProvider")
+  public void testKillAfterPartitionIsCompleted(AAConfig aaConfig) throws Exception {
     localVeniceWriter.broadcastStartOfPush(new HashMap<>());
     long fooLastOffset = getOffset(localVeniceWriter.put(putKeyFoo, putValue, SCHEMA_ID));
     localVeniceWriter.broadcastEndOfPush(new HashMap<>());
@@ -2151,11 +2170,11 @@ public abstract class StoreIngestionTaskTest {
       storeIngestionTaskUnderTest.kill();
       verify(mockLogNotifier, timeout(TEST_TIMEOUT_MS).atLeastOnce())
           .endOfPushReceived(topic, PARTITION_FOO, fooLastOffset);
-    }, isActiveActiveReplicationEnabled);
+    }, aaConfig);
   }
 
-  @Test(dataProvider = "True-and-False", dataProviderClass = DataProviderUtils.class)
-  public void testNeverReportProgressBeforeStart(boolean isActiveActiveReplicationEnabled) throws Exception {
+  @Test(dataProvider = "aaConfigProvider")
+  public void testNeverReportProgressBeforeStart(AAConfig aaConfig) throws Exception {
     localVeniceWriter.broadcastStartOfPush(new HashMap<>());
     // Read one message for each poll.
     runTest(new RandomPollStrategy(1), Utils.setOf(PARTITION_FOO), () -> {}, () -> {
@@ -2165,11 +2184,11 @@ public abstract class StoreIngestionTaskTest {
       // of messages in bytes, since control message is being counted as 0 bytes (no data persisted in disk),
       // then no progress will be reported during start, but only for processed messages.
       verify(mockLogNotifier, after(TEST_TIMEOUT_MS).never()).progress(any(), anyInt(), anyInt());
-    }, isActiveActiveReplicationEnabled);
+    }, aaConfig);
   }
 
-  @Test(dataProvider = "True-and-False", dataProviderClass = DataProviderUtils.class)
-  public void testOffsetPersistent(boolean isActiveActiveReplicationEnabled) throws Exception {
+  @Test(dataProvider = "aaConfigProvider")
+  public void testOffsetPersistent(AAConfig aaConfig) throws Exception {
     // Do not persist every message.
     List<Long> offsets = new ArrayList<>();
     for (int i = 0; i < PARTITION_COUNT; i++) {
@@ -2198,7 +2217,7 @@ public abstract class StoreIngestionTaskTest {
                   BufferReplayPolicy.REWIND_FROM_EOP)),
           false,
           Optional.empty(),
-          isActiveActiveReplicationEnabled,
+          aaConfig,
           1,
           Collections.emptyMap());
     } finally {
@@ -2207,8 +2226,8 @@ public abstract class StoreIngestionTaskTest {
 
   }
 
-  @Test(dataProvider = "True-and-False", dataProviderClass = DataProviderUtils.class)
-  public void testVeniceMessagesProcessingWithSortedInput(boolean isActiveActiveReplicationEnabled) throws Exception {
+  @Test(dataProvider = "aaConfigProvider")
+  public void testVeniceMessagesProcessingWithSortedInput(AAConfig aaConfig) throws Exception {
     setStoreVersionStateSupplier(true);
     localVeniceWriter.broadcastStartOfPush(true, new HashMap<>());
     PubSubProduceResult putMetadata =
@@ -2220,7 +2239,7 @@ public abstract class StoreIngestionTaskTest {
       // Verify it retrieves the offset from the Offset Manager
       verify(mockStorageMetadataService, timeout(TEST_TIMEOUT_MS)).getLastOffset(topic, PARTITION_FOO);
 
-      verifyPutAndDelete(1, isActiveActiveReplicationEnabled, true);
+      verifyPutAndDelete(1, aaConfig, true);
 
       // Verify it commits the offset to Offset Manager after receiving EOP control message
       OffsetRecord expectedOffsetRecordForDeleteMessage = getOffsetRecord(deleteMetadata.getOffset() + 1, true);
@@ -2238,12 +2257,11 @@ public abstract class StoreIngestionTaskTest {
           .beginBatchWrite(eq(deferredWritePartitionConfig), any(), eq(Optional.empty()));
       StoragePartitionConfig transactionalPartitionConfig = new StoragePartitionConfig(topic, PARTITION_FOO);
       verify(mockAbstractStorageEngine, times(1)).endBatchWrite(transactionalPartitionConfig);
-    }, isActiveActiveReplicationEnabled);
+    }, aaConfig);
   }
 
-  @Test(dataProvider = "True-and-False", dataProviderClass = DataProviderUtils.class)
-  public void testVeniceMessagesProcessingWithSortedInputVerifyChecksum(boolean isActiveActiveReplicationEnabled)
-      throws Exception {
+  @Test(dataProvider = "aaConfigProvider")
+  public void testVeniceMessagesProcessingWithSortedInputVerifyChecksum(AAConfig aaConfig) throws Exception {
     databaseChecksumVerificationEnabled = true;
     doReturn(false).when(rocksDBServerConfig).isRocksDBPlainTableFormatEnabled();
     setStoreVersionStateSupplier(true);
@@ -2275,11 +2293,11 @@ public abstract class StoreIngestionTaskTest {
       Optional<Supplier<byte[]>> checksumSupplier = checksumCaptor.getValue();
       Assert.assertTrue(checksumSupplier.isPresent());
       Assert.assertTrue(Arrays.equals(checksumSupplier.get().get(), checksum.getCheckSum()));
-    }, isActiveActiveReplicationEnabled);
+    }, aaConfig);
   }
 
-  @Test(dataProvider = "True-and-False", dataProviderClass = DataProviderUtils.class)
-  public void testDelayedTransitionToOnlineInHybridMode(boolean isActiveActiveReplicationEnabled) throws Exception {
+  @Test(dataProvider = "aaConfigProvider")
+  public void testDelayedTransitionToOnlineInHybridMode(AAConfig aaConfig) throws Exception {
     final long MESSAGES_BEFORE_EOP = 100;
     final long MESSAGES_AFTER_EOP = 100;
     mockStorageMetadataService = new InMemoryStorageMetadataService();
@@ -2365,7 +2383,7 @@ public abstract class StoreIngestionTaskTest {
       verify(mockLogNotifier, timeout(TEST_TIMEOUT_MS).atLeast(ALL_PARTITIONS.size()))
           .completed(anyString(), anyInt(), anyLong(), anyString());
 
-    }, isActiveActiveReplicationEnabled);
+    }, aaConfig);
   }
 
   /**
@@ -2374,8 +2392,8 @@ public abstract class StoreIngestionTaskTest {
    * the record, it will receive a disk full error.  This test checks for that disk full error on the Notifier object.
    * @throws Exception
    */
-  @Test(dataProvider = "True-and-False", dataProviderClass = DataProviderUtils.class)
-  public void testStoreIngestionTaskRespectsDiskUsage(boolean isActiveActiveReplicationEnabled) throws Exception {
+  @Test(dataProvider = "aaConfigProvider")
+  public void testStoreIngestionTaskRespectsDiskUsage(AAConfig aaConfig) throws Exception {
     localVeniceWriter.broadcastStartOfPush(new HashMap<>());
     localVeniceWriter.put(putKeyFoo, putValue, EXISTING_SCHEMA_ID);
     localVeniceWriter.broadcastEndOfPush(new HashMap<>());
@@ -2408,13 +2426,13 @@ public abstract class StoreIngestionTaskTest {
         Optional.empty(),
         false,
         Optional.of(diskFullUsage),
-        isActiveActiveReplicationEnabled,
+        aaConfig,
         1,
         Collections.emptyMap());
   }
 
-  @Test(dataProvider = "True-and-False", dataProviderClass = DataProviderUtils.class, invocationCount = 10)
-  public void testIncrementalPush(boolean isActiveActiveReplicationEnabled) throws Exception {
+  @Test(dataProvider = "aaConfigProvider")
+  public void testIncrementalPush(AAConfig aaConfig) throws Exception {
     setStoreVersionStateSupplier(true);
     localVeniceWriter.broadcastStartOfPush(true, new HashMap<>());
     long fooOffset = getOffset(localVeniceWriter.put(putKeyFoo, putValue, SCHEMA_ID));
@@ -2451,17 +2469,11 @@ public abstract class StoreIngestionTaskTest {
         verify(mockLogNotifier, atLeastOnce())
             .endOfIncrementalPushReceived(topic, PARTITION_FOO, fooNewOffset, version);
       });
-    },
-        Optional.of(hybridStoreConfig),
-        true,
-        Optional.empty(),
-        isActiveActiveReplicationEnabled,
-        1,
-        Collections.emptyMap());
+    }, Optional.of(hybridStoreConfig), true, Optional.empty(), aaConfig, 1, Collections.emptyMap());
   }
 
-  @Test(dataProvider = "True-and-False", dataProviderClass = DataProviderUtils.class)
-  public void testSchemaCacheWarming(boolean isActiveActiveReplicationEnabled) throws Exception {
+  @Test(dataProvider = "aaConfigProvider")
+  public void testSchemaCacheWarming(AAConfig aaConfig) throws Exception {
     setStoreVersionStateSupplier(true);
     localVeniceWriter.broadcastStartOfPush(true, new HashMap<>());
     long fooOffset = getOffset(localVeniceWriter.put(putKeyFoo, putValue, SCHEMA_ID));
@@ -2490,13 +2502,13 @@ public abstract class StoreIngestionTaskTest {
         Optional.empty(),
         false,
         Optional.empty(),
-        isActiveActiveReplicationEnabled,
+        aaConfig,
         1,
         Collections.singletonMap(SERVER_NUM_SCHEMA_FAST_CLASS_WARMUP, 1));
   }
 
-  @Test(dataProvider = "True-and-False", dataProviderClass = DataProviderUtils.class)
-  public void testReportErrorWithEmptyPcsMap(boolean isActiveActiveReplicationEnabled) throws Exception {
+  @Test(dataProvider = "aaConfigProvider")
+  public void testReportErrorWithEmptyPcsMap(AAConfig aaConfig) throws Exception {
     localVeniceWriter.broadcastStartOfPush(new HashMap<>());
     localVeniceWriter.put(putKeyFoo, putValue, EXISTING_SCHEMA_ID);
     // Dummy exception to put ingestion task into ERROR state
@@ -2505,11 +2517,11 @@ public abstract class StoreIngestionTaskTest {
 
     runTest(Utils.setOf(PARTITION_FOO), () -> {
       verify(mockLogNotifier, timeout(TEST_TIMEOUT_MS)).error(eq(topic), eq(PARTITION_FOO), anyString(), any());
-    }, isActiveActiveReplicationEnabled);
+    }, aaConfig);
   }
 
-  @Test(dataProvider = "True-and-False", dataProviderClass = DataProviderUtils.class, timeOut = TEST_TIMEOUT_MS * 5)
-  public void testPartitionExceptionIsolation(boolean isActiveActiveReplicationEnabled) throws Exception {
+  @Test(dataProvider = "aaConfigProvider")
+  public void testPartitionExceptionIsolation(AAConfig aaConfig) throws Exception {
     localVeniceWriter.broadcastStartOfPush(new HashMap<>());
     getOffset(localVeniceWriter.put(putKeyFoo, putValue, SCHEMA_ID));
     long barLastOffset = getOffset(localVeniceWriter.put(putKeyBar, putValue, SCHEMA_ID));
@@ -2532,7 +2544,7 @@ public abstract class StoreIngestionTaskTest {
           storeIngestionTaskUnderTest.getPartitionIngestionExceptionList().get(PARTITION_FOO),
           "Exception for the errored partition should be cleared after unsubscription");
       assertEquals(storeIngestionTaskUnderTest.getFailedPartitions().size(), 1, "Only one partition should be failed");
-    }, isActiveActiveReplicationEnabled);
+    }, aaConfig);
     for (int i = 0; i < 10000; ++i) {
       storeIngestionTaskUnderTest
           .setIngestionException(0, new VeniceException("new fake looooooooooooooooong exception"));
@@ -2567,16 +2579,13 @@ public abstract class StoreIngestionTaskTest {
     return new VeniceServerConfig(propertyBuilder.build(), kafkaClusterMap);
   }
 
-  private void verifyPutAndDelete(
-      int amplificationFactor,
-      boolean isActiveActiveReplicationEnabled,
-      boolean recordsInBatchPush) {
+  private void verifyPutAndDelete(int amplificationFactor, AAConfig aaConfig, boolean recordsInBatchPush) {
     VenicePartitioner partitioner = getVenicePartitioner(amplificationFactor);
     int targetPartitionPutKeyFoo = partitioner.getPartitionId(putKeyFoo, PARTITION_COUNT);
     int targetPartitionDeleteKeyFoo = partitioner.getPartitionId(deleteKeyFoo, PARTITION_COUNT);
 
     // Batch push records for Active/Active do not persist replication metadata.
-    if (isActiveActiveReplicationEnabled && !recordsInBatchPush) {
+    if (aaConfig == AA_ENABLED && !recordsInBatchPush) {
       // Verify StorageEngine#putWithReplicationMetadata is invoked only once and with appropriate key & value.
       verify(mockAbstractStorageEngine, timeout(100000)).putWithReplicationMetadata(
           targetPartitionPutKeyFoo,
@@ -2640,7 +2649,7 @@ public abstract class StoreIngestionTaskTest {
         Optional.of(hybridStoreConfig),
         false,
         false,
-        true);
+        AA_ENABLED);
     Store mockStore = storeAndVersionConfigs.store;
     Version version = storeAndVersionConfigs.version;
     VeniceStoreVersionConfig storeConfig = storeAndVersionConfigs.storeVersionConfig;
@@ -2755,13 +2764,8 @@ public abstract class StoreIngestionTaskTest {
         "Remote consumer should not poll for new records but return previously cached records");
   }
 
-  @Test(dataProvider = "Three-True-and-False", dataProviderClass = DataProviderUtils.class)
-  public void testIsReadyToServe(boolean isDaVinciClient, boolean isLeader, boolean isActiveActiveReplicationEnabled) {
-    if (isDaVinciClient && isLeader) {
-      // DaVinci client can't be leader
-      return;
-    }
-
+  @Test(dataProvider = "nodeTypeAndAAConfigProvider")
+  public void testIsReadyToServe(NodeType nodeType, AAConfig aaConfig) {
     int partitionCount = 2;
     int amplificationFactor = 1;
 
@@ -2783,7 +2787,7 @@ public abstract class StoreIngestionTaskTest {
         Optional.of(hybridStoreConfig),
         false,
         true,
-        isActiveActiveReplicationEnabled);
+        aaConfig);
     Store mockStore = storeAndVersionConfigs.store;
     Version version = storeAndVersionConfigs.version;
     VeniceStoreVersionConfig storeConfig = storeAndVersionConfigs.storeVersionConfig;
@@ -2799,7 +2803,9 @@ public abstract class StoreIngestionTaskTest {
         Optional.empty(),
         1,
         extraServerProperties,
-        false).setIsDaVinciClient(isDaVinciClient).setAggKafkaConsumerService(aggKafkaConsumerService).build();
+        false).setIsDaVinciClient(nodeType == DA_VINCI_CLIENT)
+            .setAggKafkaConsumerService(aggKafkaConsumerService)
+            .build();
 
     TopicManager mockTopicManagerRemoteKafka = mock(TopicManager.class);
 
@@ -2896,7 +2902,7 @@ public abstract class StoreIngestionTaskTest {
     doReturn(0).when(mockPcsBufferReplayStartedLagCaughtUp).getPartition();
     doReturn(0).when(mockPcsBufferReplayStartedLagCaughtUp).getUserPartition();
     storeIngestionTaskUnderTest.setPartitionConsumptionState(0, mockPcsBufferReplayStartedLagCaughtUp);
-    if (isLeader) {
+    if (nodeType == LEADER_SERVER) {
       // case 5a: leader replica => partition is ready to serve
       doReturn(LEADER).when(mockPcsBufferReplayStartedLagCaughtUp).getLeaderFollowerState();
       assertTrue(storeIngestionTaskUnderTest.isReadyToServe(mockPcsBufferReplayStartedLagCaughtUp));
@@ -2906,7 +2912,7 @@ public abstract class StoreIngestionTaskTest {
       doReturn(LEADER_NOT_COMPLETED).when(mockPcsBufferReplayStartedLagCaughtUp).getLeaderCompleteState();
       assertEquals(
           storeIngestionTaskUnderTest.isReadyToServe(mockPcsBufferReplayStartedLagCaughtUp),
-          !isActiveActiveReplicationEnabled);
+          aaConfig == AA_DISABLED);
       // case 5c: standby replica and LEADER_COMPLETED => partition is ready to serve
       doReturn(LEADER_COMPLETED).when(mockPcsBufferReplayStartedLagCaughtUp).getLeaderCompleteState();
       doCallRealMethod().when(mockPcsBufferReplayStartedLagCaughtUp).isLeaderCompleted();
@@ -2930,7 +2936,7 @@ public abstract class StoreIngestionTaskTest {
     doReturn(5L).when(mockTopicManager).getPartitionLatestOffsetAndRetry(any(), anyInt());
     doReturn(150L).when(mockTopicManagerRemoteKafka).getPartitionLatestOffsetAndRetry(any(), anyInt());
     doReturn(150L).when(aggKafkaConsumerService).getLatestOffsetFor(anyString(), any(), any());
-    if (isLeader) {
+    if (nodeType == LEADER_SERVER) {
       // case 6a: leader replica => partition is not ready to serve
       doReturn(LEADER).when(mockPcsBufferReplayStartedRemoteLagging).getLeaderFollowerState();
       assertFalse(storeIngestionTaskUnderTest.isReadyToServe(mockPcsBufferReplayStartedRemoteLagging));
@@ -2940,7 +2946,7 @@ public abstract class StoreIngestionTaskTest {
       doReturn(LEADER_NOT_COMPLETED).when(mockPcsBufferReplayStartedRemoteLagging).getLeaderCompleteState();
       assertEquals(
           storeIngestionTaskUnderTest.isReadyToServe(mockPcsBufferReplayStartedRemoteLagging),
-          !isActiveActiveReplicationEnabled);
+          aaConfig == AA_DISABLED);
       // case 6c: standby replica and LEADER_COMPLETED => partition is ready to serve
       doReturn(LEADER_COMPLETED).when(mockPcsBufferReplayStartedRemoteLagging).getLeaderCompleteState();
       doCallRealMethod().when(mockPcsBufferReplayStartedRemoteLagging).isLeaderCompleted();
@@ -2966,7 +2972,7 @@ public abstract class StoreIngestionTaskTest {
         .getProducerTimestampOfLastDataRecord(any(), anyInt());
     doReturn(System.currentTimeMillis()).when(mockTopicManagerRemoteKafka)
         .getProducerTimestampOfLastDataRecord(any(), anyInt());
-    if (isLeader) {
+    if (nodeType == LEADER_SERVER) {
       // case 7a: leader replica => partition is not ready to serve
       doReturn(LEADER).when(mockPcsOffsetLagCaughtUpTimestampLagging).getLeaderFollowerState();
       assertFalse(storeIngestionTaskUnderTest.isReadyToServe(mockPcsOffsetLagCaughtUpTimestampLagging));
@@ -2976,7 +2982,7 @@ public abstract class StoreIngestionTaskTest {
       doReturn(LEADER_NOT_COMPLETED).when(mockPcsOffsetLagCaughtUpTimestampLagging).getLeaderCompleteState();
       assertEquals(
           storeIngestionTaskUnderTest.isReadyToServe(mockPcsOffsetLagCaughtUpTimestampLagging),
-          !isActiveActiveReplicationEnabled);
+          aaConfig == AA_DISABLED);
       // case 7c: standby replica and LEADER_COMPLETED => partition is ready to serve
       doReturn(LEADER_COMPLETED).when(mockPcsOffsetLagCaughtUpTimestampLagging).getLeaderCompleteState();
       doCallRealMethod().when(mockPcsOffsetLagCaughtUpTimestampLagging).isLeaderCompleted();
@@ -2987,18 +2993,7 @@ public abstract class StoreIngestionTaskTest {
     }
   }
 
-  @DataProvider
-  public static Object[][] testActiveActiveStoreIsReadyToServeProvider() {
-    List<Object[]> params = new ArrayList<>();
-    for (HybridConfig hybridConfig: HybridConfig.values()) {
-      for (NodeType nodeType: NodeType.values()) {
-        params.add(new Object[] { hybridConfig, nodeType });
-      }
-    }
-    return params.toArray(new Object[0][]);
-  }
-
-  @Test(dataProvider = "testActiveActiveStoreIsReadyToServeProvider")
+  @Test(dataProvider = "hybridConfigAndNodeTypeProvider")
   public void testActiveActiveStoreIsReadyToServe(HybridConfig hybridConfig, NodeType nodeType) {
     int partitionCount = 2;
     int amplificationFactor = 1;
@@ -3022,7 +3017,7 @@ public abstract class StoreIngestionTaskTest {
         Optional.ofNullable(hybridStoreConfig),
         false,
         true,
-        true);
+        AA_ENABLED);
     Store mockStore = storeAndVersionConfigs.store;
     Version version = storeAndVersionConfigs.version;
     VeniceStoreVersionConfig storeConfig = storeAndVersionConfigs.storeVersionConfig;
@@ -3111,11 +3106,20 @@ public abstract class StoreIngestionTaskTest {
     }
   }
 
-  @Test(dataProvider = "Four-True-and-False", dataProviderClass = DataProviderUtils.class)
+  @DataProvider
+  public static Object[][] testCheckAndLogIfLagIsAcceptableForHybridStoreProvider() {
+    return DataProviderUtils.allPermutationGenerator(
+        DataProviderUtils.BOOLEAN,
+        new NodeType[] { DA_VINCI_CLIENT, FOLLOWER_SERVER },
+        AAConfig.values(),
+        DataProviderUtils.BOOLEAN);
+  }
+
+  @Test(dataProvider = "testCheckAndLogIfLagIsAcceptableForHybridStoreProvider")
   public void testCheckAndLogIfLagIsAcceptableForHybridStore(
       boolean isOffsetBasedLag,
-      boolean isDaVinciClient,
-      boolean isActiveActiveReplicationEnabled,
+      NodeType nodeType,
+      AAConfig aaConfig,
       boolean leaderCompleteStateCheckEnabled) {
     int partitionCount = 2;
     int amplificationFactor = 1;
@@ -3137,7 +3141,7 @@ public abstract class StoreIngestionTaskTest {
         Optional.of(hybridStoreConfig),
         false,
         true,
-        isActiveActiveReplicationEnabled);
+        aaConfig);
     Store mockStore = storeAndVersionConfigs.store;
     Version version = storeAndVersionConfigs.version;
     VeniceStoreVersionConfig storeConfig = storeAndVersionConfigs.storeVersionConfig;
@@ -3153,7 +3157,9 @@ public abstract class StoreIngestionTaskTest {
         Optional.empty(),
         1,
         serverProperties,
-        false).setIsDaVinciClient(isDaVinciClient).setAggKafkaConsumerService(aggKafkaConsumerService).build();
+        false).setIsDaVinciClient(nodeType == DA_VINCI_CLIENT)
+            .setAggKafkaConsumerService(aggKafkaConsumerService)
+            .build();
 
     TopicManager mockTopicManagerRemoteKafka = mock(TopicManager.class);
     doReturn(mockTopicManager).when(mockTopicManagerRepository)
@@ -3182,7 +3188,7 @@ public abstract class StoreIngestionTaskTest {
     // Case 1: offsetLag > offsetThreshold and instance is leader
     long offsetLag = 100;
     long offsetThreshold = 50;
-    if (!isDaVinciClient) {
+    if (nodeType != DA_VINCI_CLIENT) {
       doReturn(LEADER).when(mockPartitionConsumptionState).getLeaderFollowerState();
       assertFalse(
           storeIngestionTaskUnderTest.checkAndLogIfLagIsAcceptableForHybridStore(
@@ -3208,7 +3214,7 @@ public abstract class StoreIngestionTaskTest {
     // Case 3: offsetLag <= offsetThreshold and instance is not a standby or DaVinciClient
     offsetLag = 50;
     offsetThreshold = 100;
-    if (!isDaVinciClient) {
+    if (nodeType != DA_VINCI_CLIENT) {
       doReturn(LEADER).when(mockPartitionConsumptionState).getLeaderFollowerState();
       assertTrue(
           storeIngestionTaskUnderTest.checkAndLogIfLagIsAcceptableForHybridStore(
@@ -3232,7 +3238,7 @@ public abstract class StoreIngestionTaskTest {
             false,
             isOffsetBasedLag,
             0),
-        !(leaderCompleteStateCheckEnabled && isActiveActiveReplicationEnabled));
+        !(leaderCompleteStateCheckEnabled && aaConfig == AA_ENABLED));
 
     // Case 5: offsetLag <= offsetThreshold and instance is a standby or DaVinciClient
     // and first heart beat SOS has been received and leaderCompleteState is unknown
@@ -3276,7 +3282,7 @@ public abstract class StoreIngestionTaskTest {
             false,
             isOffsetBasedLag,
             0),
-        !(leaderCompleteStateCheckEnabled && isActiveActiveReplicationEnabled));
+        !(leaderCompleteStateCheckEnabled && aaConfig == AA_ENABLED));
 
     // Case 8: offsetLag <= offsetThreshold and instance is a standby or DaVinciClient
     // and first heart beat SOS has been received and leaderCompleteState is LEADER_NOT_COMPLETED
@@ -3290,20 +3296,15 @@ public abstract class StoreIngestionTaskTest {
             false,
             isOffsetBasedLag,
             0),
-        !(leaderCompleteStateCheckEnabled && isActiveActiveReplicationEnabled));
+        !(leaderCompleteStateCheckEnabled && aaConfig == AA_ENABLED));
   }
 
   @DataProvider
   public static Object[][] testGetAndUpdateLeaderCompletedStateProvider() {
-    List<Object[]> params = new ArrayList<>();
-    for (HybridConfig hybridConfig: HybridConfig.values()) {
-      for (NodeType nodeType: new NodeType[] { DA_VINCI_CLIENT, FOLLOWER_SERVER }) {
-        for (boolean leaderCompletedHeaderFound: new boolean[] { false, true }) {
-          params.add(new Object[] { hybridConfig, nodeType, leaderCompletedHeaderFound });
-        }
-      }
-    }
-    return params.toArray(new Object[0][]);
+    return DataProviderUtils.allPermutationGenerator(
+        HybridConfig.values(),
+        new NodeType[] { DA_VINCI_CLIENT, FOLLOWER_SERVER },
+        DataProviderUtils.BOOLEAN);
   }
 
   @Test(dataProvider = "testGetAndUpdateLeaderCompletedStateProvider")
@@ -3330,7 +3331,7 @@ public abstract class StoreIngestionTaskTest {
         Optional.ofNullable(hybridStoreConfig),
         false,
         true,
-        true);
+        AA_ENABLED);
     Store mockStore = storeAndVersionConfigs.store;
     Version version = storeAndVersionConfigs.version;
     VeniceStoreVersionConfig storeConfig = storeAndVersionConfigs.storeVersionConfig;
@@ -3434,7 +3435,7 @@ public abstract class StoreIngestionTaskTest {
     HybridStoreConfig hybridStoreConfig =
         new HybridStoreConfigImpl(100, 100, 100, DataReplicationPolicy.AGGREGATE, BufferReplayPolicy.REWIND_FROM_EOP);
     MockStoreVersionConfigs storeAndVersionConfigs =
-        setupStoreAndVersionMocks(2, partitionerConfig, Optional.of(hybridStoreConfig), false, true, false);
+        setupStoreAndVersionMocks(2, partitionerConfig, Optional.of(hybridStoreConfig), false, true, AA_DISABLED);
     Store mockStore = storeAndVersionConfigs.store;
     Version version = storeAndVersionConfigs.version;
     VeniceStoreVersionConfig storeConfig = storeAndVersionConfigs.storeVersionConfig;
@@ -3485,8 +3486,8 @@ public abstract class StoreIngestionTaskTest {
         .getPartitionOffsetByTime(any(), anyLong());
   }
 
-  @Test(dataProvider = "True-and-False", dataProviderClass = DataProviderUtils.class)
-  public void testUpdateConsumedUpstreamRTOffsetMapDuringRTSubscription(boolean activeActive) {
+  @Test(dataProvider = "aaConfigProvider")
+  public void testUpdateConsumedUpstreamRTOffsetMapDuringRTSubscription(AAConfig aaConfig) {
     String storeName = Utils.getUniqueString("store");
     String versionTopic = Version.composeKafkaTopic(storeName, 1);
 
@@ -3502,7 +3503,7 @@ public abstract class StoreIngestionTaskTest {
     doReturn(mockStore).when(mockReadOnlyStoreRepository).getStoreOrThrow(eq(storeName));
     doReturn(false).when(mockStore).isHybridStoreDiskQuotaEnabled();
     doReturn(Optional.of(mockVersion)).when(mockStore).getVersion(1);
-    doReturn(activeActive).when(mockVersion).isActiveActiveReplicationEnabled();
+    doReturn(aaConfig == AA_ENABLED).when(mockVersion).isActiveActiveReplicationEnabled();
 
     Properties mockKafkaConsumerProperties = mock(Properties.class);
     doReturn("localhost").when(mockKafkaConsumerProperties).getProperty(eq(KAFKA_BOOTSTRAP_SERVERS));
@@ -3553,7 +3554,7 @@ public abstract class StoreIngestionTaskTest {
     // Test whether consumedUpstreamRTOffsetMap is updated when leader subscribes to RT after state transition
     ingestionTask.startConsumingAsLeaderInTransitionFromStandby(mockPcs);
     verify(mockPcs, times(1)).updateLeaderConsumedUpstreamRTOffset(
-        eq(activeActive ? "localhost" : OffsetRecord.NON_AA_REPLICATION_UPSTREAM_OFFSET_MAP_KEY),
+        eq(aaConfig == AA_ENABLED ? "localhost" : OffsetRecord.NON_AA_REPLICATION_UPSTREAM_OFFSET_MAP_KEY),
         eq(1000L));
 
     PubSubTopic rtTopic = pubSubTopicRepository.getTopic("test_rt");
@@ -3565,7 +3566,7 @@ public abstract class StoreIngestionTaskTest {
       doReturn(rtTopic).when(mockOR).getLeaderTopic(any());
       System.out.println(mockOR.getLeaderTopic(null));
       doReturn(1000L).when(mockOR).getUpstreamOffset(anyString());
-      if (activeActive) {
+      if (aaConfig == AA_ENABLED) {
         doReturn(1000L).when(mock).getLatestProcessedUpstreamRTOffsetWithNoDefault(anyString());
       } else {
         doReturn(1000L).when(mock).getLatestProcessedUpstreamRTOffset(anyString());
@@ -3579,13 +3580,13 @@ public abstract class StoreIngestionTaskTest {
     // Test whether consumedUpstreamRTOffsetMap is updated when leader subscribes to RT after executing TS
     ingestionTask.leaderExecuteTopicSwitch(mockPcs, topicSwitch, newSourceTopic);
     verify(mockPcs, times(1)).updateLeaderConsumedUpstreamRTOffset(
-        eq(activeActive ? "localhost" : OffsetRecord.NON_AA_REPLICATION_UPSTREAM_OFFSET_MAP_KEY),
+        eq(aaConfig == AA_ENABLED ? "localhost" : OffsetRecord.NON_AA_REPLICATION_UPSTREAM_OFFSET_MAP_KEY),
         eq(1000L));
 
     // Test alternative branch of the code
     Supplier<PartitionConsumptionState> mockPcsSupplier2 = () -> {
       PartitionConsumptionState mock = mockPcsSupplier.get();
-      if (activeActive) {
+      if (aaConfig == AA_ENABLED) {
         doReturn(-1L).when(mock).getLatestProcessedUpstreamRTOffsetWithNoDefault(anyString());
       } else {
         doReturn(-1L).when(mock).getLatestProcessedUpstreamRTOffset(anyString());
@@ -3678,9 +3679,8 @@ public abstract class StoreIngestionTaskTest {
         .consumerSubscribe(any(), eq(remoteVersionTopicOffset), anyString());
   }
 
-  @Test(dataProvider = "True-and-False", dataProviderClass = DataProviderUtils.class)
-  public void testWrappedInterruptExceptionDuringGracefulShutdown(boolean isActiveActiveReplicationEnabled)
-      throws Exception {
+  @Test(dataProvider = "aaConfigProvider")
+  public void testWrappedInterruptExceptionDuringGracefulShutdown(AAConfig aaConfig) throws Exception {
     hybridStoreConfig = Optional.of(
         new HybridStoreConfigImpl(
             10,
@@ -3696,7 +3696,7 @@ public abstract class StoreIngestionTaskTest {
       verify(mockLogNotifier, timeout(TEST_TIMEOUT_MS)).restarted(eq(topic), eq(PARTITION_FOO), anyLong());
       storeIngestionTaskUnderTest.close();
       verify(aggKafkaConsumerService, timeout(TEST_TIMEOUT_MS)).unsubscribeConsumerFor(eq(pubSubTopic), any());
-    }, isActiveActiveReplicationEnabled);
+    }, aaConfig);
     Assert.assertEquals(mockNotifierError.size(), 0);
   }
 
@@ -3707,11 +3707,9 @@ public abstract class StoreIngestionTaskTest {
    * 1. offsetRecord and pcs has the same state at the beginning
    * 2. pcs consumes 2 records and offsetRecords doesn't sync up with pcs due to high sync interval.
    * 3. enforce to gracefully shutdown and validate offsetRecord has been synced up with pcs once.
-   * @param isActiveActiveReplicationEnabled
-   * @throws Exception
    */
-  @Test(dataProvider = "True-and-False", dataProviderClass = DataProviderUtils.class)
-  public void testOffsetSyncBeforeGracefulShutDown(boolean isActiveActiveReplicationEnabled) throws Exception {
+  @Test(dataProvider = "aaConfigProvider")
+  public void testOffsetSyncBeforeGracefulShutDown(AAConfig aaConfig) throws Exception {
     // prepare to send 2 messages
     localVeniceWriter.put(putKeyFoo, putValue, SCHEMA_ID);
     localVeniceWriter.put(putKeyFoo2, putValue, SCHEMA_ID);
@@ -3731,12 +3729,26 @@ public abstract class StoreIngestionTaskTest {
 
       // Verify offsetRecord hasn't been synced yet
       PartitionConsumptionState pcs = storeIngestionTaskUnderTest.getPartitionConsumptionState(PARTITION_FOO);
-      OffsetRecord offsetRecord = pcs.getOffsetRecord();
-      Assert.assertEquals(pcs.getLatestProcessedLocalVersionTopicOffset(), 0L);
-      Assert.assertEquals(offsetRecord.getLocalVersionTopicOffset(), 0L);
+      if (pcs == null) {
+        LOGGER.info(
+            "pcs for PARTITION_FOO is null, which is an indication that it was never synced before, so we carry on.");
+      } else {
+        // If the pcs is non-null, then we perform additional checks to ensure that it was not synced
+        Assert.assertEquals(
+            pcs.getLatestProcessedLocalVersionTopicOffset(),
+            0L,
+            "pcs.getLatestProcessedLocalVersionTopicOffset() for PARTITION_FOO is expected to be zero!");
+        OffsetRecord offsetRecord = pcs.getOffsetRecord();
+        assertNotNull(offsetRecord);
+        Assert.assertEquals(offsetRecord.getLocalVersionTopicOffset(), 0L);
+      }
 
       // verify 2 messages were processed
       verify(mockStoreIngestionStats, timeout(TEST_TIMEOUT_MS).times(2)).recordTotalRecordsConsumed();
+      pcs = storeIngestionTaskUnderTest.getPartitionConsumptionState(PARTITION_FOO); // We re-fetch in case it was null
+      assertNotNull(pcs, "pcs for PARTITION_FOO is null!");
+      OffsetRecord offsetRecord = pcs.getOffsetRecord();
+      assertNotNull(offsetRecord);
       Assert.assertEquals(pcs.getLatestProcessedLocalVersionTopicOffset(), 2L); // PCS updated
       Assert.assertEquals(offsetRecord.getLocalVersionTopicOffset(), 0L); // offsetRecord hasn't been updated yet
 
@@ -3746,15 +3758,15 @@ public abstract class StoreIngestionTaskTest {
       verify(mockStorageMetadataService, timeout(TEST_TIMEOUT_MS).times(1)).put(eq(topic), eq(PARTITION_FOO), any());
       Assert.assertEquals(offsetRecord.getLocalVersionTopicOffset(), 2L);
 
-    }, isActiveActiveReplicationEnabled, configOverride -> {
+    }, aaConfig, configOverride -> {
       // set very high threshold so offsetRecord isn't be synced during regular consumption
       doReturn(100_000L).when(configOverride).getDatabaseSyncBytesIntervalForTransactionalMode();
     });
     Assert.assertEquals(mockNotifierError.size(), 0);
   }
 
-  @Test(dataProvider = "True-and-False", dataProviderClass = DataProviderUtils.class)
-  public void testProduceToStoreBufferService(boolean activeActiveEnabled) throws Exception {
+  @Test(dataProvider = "aaConfigProvider")
+  public void testProduceToStoreBufferService(AAConfig aaConfig) throws Exception {
     byte[] keyBytes = new byte[1];
     KafkaKey kafkaKey = new KafkaKey(MessageType.PUT, keyBytes);
     KafkaMessageEnvelope kafkaMessageEnvelope = new KafkaMessageEnvelope();
@@ -3823,7 +3835,7 @@ public abstract class StoreIngestionTaskTest {
               ArgumentMatchers.doubleThat(argument -> argument >= 0 && argument < 1000),
               ArgumentMatchers.longThat(
                   argument -> argument > currentTimeMs - errorMargin && argument < currentTimeMs + errorMargin));
-    }, activeActiveEnabled);
+    }, aaConfig);
   }
 
   private void verifyStats(
@@ -3848,7 +3860,7 @@ public abstract class StoreIngestionTaskTest {
 
     runTest(Collections.singleton(PARTITION_FOO), () -> {
       assertFalse(storeIngestionTaskUnderTest.shouldPersistRecord(pubSubMessage, null));
-    }, false);
+    }, AA_DISABLED);
 
     Map<String, Object> serverProperties = new HashMap<>();
     serverProperties.put(FREEZE_INGESTION_IF_READY_TO_SERVE_OR_LOCAL_DATA_EXISTS, true);
@@ -3864,7 +3876,7 @@ public abstract class StoreIngestionTaskTest {
     runTest(new RandomPollStrategy(), Collections.singleton(PARTITION_FOO), () -> {}, () -> {
       PartitionConsumptionState partitionConsumptionState = partitionConsumptionStateSupplier.get();
       assertFalse(storeIngestionTaskUnderTest.shouldPersistRecord(pubSubMessage, partitionConsumptionState));
-    }, this.hybridStoreConfig, false, Optional.empty(), false, 1, serverProperties);
+    }, this.hybridStoreConfig, false, Optional.empty(), AA_DISABLED, 1, serverProperties);
 
     runTest(Collections.singleton(PARTITION_FOO), () -> {
       PartitionConsumptionState partitionConsumptionState = partitionConsumptionStateSupplier.get();
@@ -3875,7 +3887,7 @@ public abstract class StoreIngestionTaskTest {
 
       when(partitionConsumptionState.getLeaderFollowerState()).thenReturn(LEADER);
       assertFalse(storeIngestionTaskUnderTest.shouldPersistRecord(pubSubMessage, partitionConsumptionState));
-    }, false);
+    }, AA_DISABLED);
 
     runTest(Collections.singleton(PARTITION_FOO), () -> {
       PartitionConsumptionState partitionConsumptionState = partitionConsumptionStateSupplier.get();
@@ -3886,7 +3898,7 @@ public abstract class StoreIngestionTaskTest {
 
       when(partitionConsumptionState.getLeaderFollowerState()).thenReturn(STANDBY);
       assertFalse(storeIngestionTaskUnderTest.shouldPersistRecord(pubSubMessage2, partitionConsumptionState));
-    }, false);
+    }, AA_DISABLED);
   }
 
   @Test
@@ -3900,7 +3912,7 @@ public abstract class StoreIngestionTaskTest {
       verify(mockAbstractStorageEngine, timeout(1000)).put(eq(PARTITION_FOO), any(), (ByteBuffer) any());
       verify(mockLogNotifier, timeout(1000)).error(any(), eq(PARTITION_FOO), any(), isA(VeniceException.class));
       verify(runnableForKillNonCurrentVersion, never()).run();
-    }, false);
+    }, AA_DISABLED);
   }
 
   @Test
@@ -3921,7 +3933,7 @@ public abstract class StoreIngestionTaskTest {
       verify(mockAbstractStorageEngine, timeout(1000)).reopenStoragePartition(PARTITION_FOO);
       verify(mockLogNotifier, timeout(1000)).completed(anyString(), eq(PARTITION_FOO), anyLong(), anyString());
       verify(runnableForKillNonCurrentVersion, times(1)).run();
-    }, false);
+    }, AA_DISABLED);
   }
 
   @Test
@@ -3944,7 +3956,7 @@ public abstract class StoreIngestionTaskTest {
       when(offsetRecord.getLeaderTopic(any())).thenReturn(pubSubTopic);
       when(partitionConsumptionState.consumeRemotely()).thenReturn(true);
       assertTrue(lfsit.shouldProduceToVersionTopic(partitionConsumptionState));
-    }, false);
+    }, AA_DISABLED);
   }
 
   @Test
@@ -4013,12 +4025,21 @@ public abstract class StoreIngestionTaskTest {
     Assert.assertTrue(storeIngestionTask.maybeSetIngestionTaskActiveState(false));
   }
 
-  @Test(dataProvider = "Four-True-and-False", dataProviderClass = DataProviderUtils.class)
+  @DataProvider
+  public static Object[][] testMaybeSendIngestionHeartbeatProvider() {
+    return DataProviderUtils.allPermutationGenerator(
+        AAConfig.values(),
+        DataProviderUtils.BOOLEAN,
+        new NodeType[] { FOLLOWER_SERVER, LEADER_SERVER },
+        HybridConfig.values());
+  }
+
+  @Test(dataProvider = "testMaybeSendIngestionHeartbeatProvider")
   public void testMaybeSendIngestionHeartbeat(
-      boolean isActiveActive,
+      AAConfig aaConfig,
       boolean isRealTimeTopic,
-      boolean isLeader,
-      boolean isHybridStore) {
+      NodeType nodeType,
+      HybridConfig hybridConfig) {
     String storeName = Utils.getUniqueString("store");
     Store mockStore = mock(Store.class);
     String versionTopic = Version.composeKafkaTopic(storeName, 1);
@@ -4028,7 +4049,7 @@ public abstract class StoreIngestionTaskTest {
     doReturn(1).when(mockVersion).getPartitionCount();
     doReturn(VersionStatus.STARTED).when(mockVersion).getStatus();
     doReturn(true).when(mockVersion).isUseVersionLevelHybridConfig();
-    if (isHybridStore) {
+    if (hybridConfig == HYBRID) {
       HybridStoreConfig mockHybridConfig = mock(HybridStoreConfig.class);
       doReturn(mockHybridConfig).when(mockVersion).getHybridStoreConfig();
     } else {
@@ -4040,7 +4061,7 @@ public abstract class StoreIngestionTaskTest {
     doReturn(mockStore).when(mockReadOnlyStoreRepository).getStoreOrThrow(eq(storeName));
     doReturn(false).when(mockStore).isHybridStoreDiskQuotaEnabled();
     doReturn(Optional.of(mockVersion)).when(mockStore).getVersion(1);
-    doReturn(isActiveActive).when(mockVersion).isActiveActiveReplicationEnabled();
+    doReturn(aaConfig == AA_ENABLED).when(mockVersion).isActiveActiveReplicationEnabled();
     VeniceServerConfig mockVeniceServerConfig = mock(VeniceServerConfig.class);
     VeniceProperties mockVeniceProperties = mock(VeniceProperties.class);
     doReturn(true).when(mockVeniceProperties).isEmpty();
@@ -4051,7 +4072,7 @@ public abstract class StoreIngestionTaskTest {
     PartitionConsumptionState pcs = mock(PartitionConsumptionState.class);
     OffsetRecord offsetRecord = mock(OffsetRecord.class);
     doReturn(offsetRecord).when(pcs).getOffsetRecord();
-    doReturn(isLeader ? LEADER : STANDBY).when(pcs).getLeaderFollowerState();
+    doReturn(nodeType == LEADER_SERVER ? LEADER : STANDBY).when(pcs).getLeaderFollowerState();
     PubSubTopic pubsubTopic = mock(PubSubTopic.class);
     doReturn(pubsubTopic).when(offsetRecord).getLeaderTopic(any());
     doReturn(isRealTimeTopic).when(pubsubTopic).isRealTime();
@@ -4086,7 +4107,7 @@ public abstract class StoreIngestionTaskTest {
     ingestionTask.maybeSendIngestionHeartbeat();
     // Second invocation should be skipped since it shouldn't be time for another heartbeat yet.
     ingestionTask.maybeSendIngestionHeartbeat();
-    if (isHybridStore && isRealTimeTopic && isLeader) {
+    if (hybridConfig == HYBRID && isRealTimeTopic && nodeType == LEADER_SERVER) {
       verify(veniceWriter, times(1)).sendHeartbeat(any(), any(), any(), anyBoolean(), any(), anyLong());
     } else {
       verify(veniceWriter, never()).sendHeartbeat(any(), any(), any(), anyBoolean(), any(), anyLong());

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
@@ -1407,6 +1407,14 @@ public abstract class StoreIngestionTaskTest {
     long barLastOffset = getOffset(localVeniceWriter.put(putKeyBar, putValue, SCHEMA_ID));
     localVeniceWriter.broadcastEndOfPush(new HashMap<>());
     localVeniceWriter.broadcastEndOfPush(new HashMap<>());
+    doReturn(fooLastOffset + 1).when(mockTopicManager)
+        .getPartitionLatestOffsetAndRetry(
+            argThat(argument -> argument.getPartitionNumber() == PARTITION_FOO),
+            anyInt());
+    doReturn(barLastOffset + 1).when(mockTopicManager)
+        .getPartitionLatestOffsetAndRetry(
+            argThat(argument -> argument.getPartitionNumber() == PARTITION_BAR),
+            anyInt());
 
     runTest(Utils.setOf(PARTITION_FOO, PARTITION_BAR), () -> {
       /**

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
@@ -2266,16 +2266,34 @@ public abstract class StoreIngestionTaskTest {
             HybridStoreConfigImpl.DEFAULT_HYBRID_TIME_LAG_THRESHOLD,
             DataReplicationPolicy.NON_AGGREGATE,
             BufferReplayPolicy.REWIND_FROM_EOP));
+    long[] messageCountPerPartition = new long[PARTITION_COUNT];
+    when(mockTopicManager.getPartitionLatestOffsetAndRetry(any(), anyInt())).thenAnswer(invocation -> {
+      PubSubTopicPartition pt = invocation.getArgument(0);
+      return messageCountPerPartition[pt.getPartitionNumber()];
+    });
+
     runTest(ALL_PARTITIONS, () -> {
       localVeniceWriter.broadcastStartOfPush(Collections.emptyMap());
+      for (int partition: ALL_PARTITIONS) {
+        // Taking into account both the initial SOS and the SOP
+        messageCountPerPartition[partition] = messageCountPerPartition[partition] + 2;
+      }
       for (int i = 0; i < MESSAGES_BEFORE_EOP; i++) {
         try {
-          localVeniceWriter.put(getNumberedKey(i), getNumberedValue(i), SCHEMA_ID).get();
+          CompletableFuture<PubSubProduceResult> future =
+              localVeniceWriter.put(getNumberedKey(i), getNumberedValue(i), SCHEMA_ID);
+          PubSubProduceResult result = future.get();
+          int partition = result.getPartition();
+          long offset = messageCountPerPartition[partition];
+          messageCountPerPartition[partition] = ++offset;
         } catch (InterruptedException | ExecutionException e) {
           throw new VeniceException(e);
         }
       }
       localVeniceWriter.broadcastEndOfPush(Collections.emptyMap());
+      for (int partition: ALL_PARTITIONS) {
+        messageCountPerPartition[partition] = ++messageCountPerPartition[partition];
+      }
 
     }, () -> {
       verify(mockLogNotifier, timeout(TEST_TIMEOUT_MS).atLeast(ALL_PARTITIONS.size())).started(eq(topic), anyInt());
@@ -2286,10 +2304,18 @@ public abstract class StoreIngestionTaskTest {
           Version.composeRealTimeTopic(storeNameWithoutVersionInfo),
           System.currentTimeMillis() - TimeUnit.SECONDS.toMillis(10),
           Collections.emptyMap());
+      for (int partition: ALL_PARTITIONS) {
+        messageCountPerPartition[partition] = ++messageCountPerPartition[partition];
+      }
 
       for (int i = 0; i < MESSAGES_AFTER_EOP; i++) {
         try {
-          localVeniceWriter.put(getNumberedKey(i), getNumberedValue(i), SCHEMA_ID).get();
+          CompletableFuture<PubSubProduceResult> future =
+              localVeniceWriter.put(getNumberedKey(i), getNumberedValue(i), SCHEMA_ID);
+          PubSubProduceResult result = future.get();
+          int partition = result.getPartition();
+          long offset = messageCountPerPartition[partition];
+          messageCountPerPartition[partition] = ++offset;
         } catch (InterruptedException | ExecutionException e) {
           throw new VeniceException(e);
         }
@@ -2310,6 +2336,7 @@ public abstract class StoreIngestionTaskTest {
             true,
             LeaderCompleteState.getLeaderCompleteState(true),
             System.currentTimeMillis());
+        messageCountPerPartition[partition] = ++messageCountPerPartition[partition];
       }
 
       verify(mockLogNotifier, timeout(TEST_TIMEOUT_MS).atLeast(ALL_PARTITIONS.size()))
@@ -3136,7 +3163,7 @@ public abstract class StoreIngestionTaskTest {
               mockPartitionConsumptionState,
               offsetLag,
               offsetThreshold,
-              false,
+              true,
               isOffsetBasedLag,
               0));
     }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/KafkaConsumerServiceStatsTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/KafkaConsumerServiceStatsTest.java
@@ -1,0 +1,92 @@
+package com.linkedin.davinci.stats;
+
+import static com.linkedin.venice.stats.AbstractVeniceStats.getSensorFullName;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
+import io.tehuti.Metric;
+import io.tehuti.metrics.MetricsRepository;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.testng.annotations.Test;
+
+
+public class KafkaConsumerServiceStatsTest {
+  private static final Logger LOGGER = LogManager.getLogger(KafkaConsumerServiceStatsTest.class);
+
+  @Test
+  public void testParentStats() {
+    MetricsRepository metricsRepository = new MetricsRepository();
+    String nameWithKafkaClusterAlias = "moon-east-1";
+    String getLatestOffsetIsPresentName =
+        getSensorFullName(nameWithKafkaClusterAlias, "getLatestOffsetIsPresent.OccurrenceRate");
+    String getLatestOffsetIsAbsentName =
+        getSensorFullName(nameWithKafkaClusterAlias, "getLatestOffsetIsAbsent.OccurrenceRate");
+    String getLatestOffsetName = getSensorFullName(nameWithKafkaClusterAlias, "getLatestOffset.OccurrenceRate");
+    String getOffsetLagIsPresentName =
+        getSensorFullName(nameWithKafkaClusterAlias, "getOffsetLagIsPresent.OccurrenceRate");
+    String getOffsetLagIsAbsentName =
+        getSensorFullName(nameWithKafkaClusterAlias, "getOffsetLagIsAbsent.OccurrenceRate");
+    String getOffsetLagName = getSensorFullName(nameWithKafkaClusterAlias, "getOffsetLag.OccurrenceRate");
+    Metric getLatestOffsetIsPresent = metricsRepository.getMetric(getLatestOffsetIsPresentName);
+    Metric getLatestOffsetIsAbsent = metricsRepository.getMetric(getLatestOffsetIsAbsentName);
+    Metric getLatestOffset = metricsRepository.getMetric(getLatestOffsetName);
+    Metric getOffsetLagIsPresent = metricsRepository.getMetric(getOffsetLagIsPresentName);
+    Metric getOffsetLagIsAbsent = metricsRepository.getMetric(getOffsetLagIsAbsentName);
+    Metric getOffsetLag = metricsRepository.getMetric(getOffsetLagName);
+    Metric[] allMetrics = new Metric[] { getLatestOffsetIsPresent, getLatestOffsetIsAbsent, getLatestOffset,
+        getOffsetLagIsPresent, getOffsetLagIsAbsent, getOffsetLag };
+
+    // Verify initial state
+    for (Metric metric: allMetrics) {
+      assertNull(metric);
+    }
+
+    // Create objects under test
+    KafkaConsumerServiceStats stats =
+        new KafkaConsumerServiceStats(metricsRepository, nameWithKafkaClusterAlias, () -> 1);
+    LOGGER.info(metricsRepository.metrics().keySet().toString().replace(", ", ",\n"));
+    getLatestOffsetIsPresent = metricsRepository.getMetric(getLatestOffsetIsPresentName);
+    getLatestOffsetIsAbsent = metricsRepository.getMetric(getLatestOffsetIsAbsentName);
+    getLatestOffset = metricsRepository.getMetric(getLatestOffsetName);
+    getOffsetLagIsPresent = metricsRepository.getMetric(getOffsetLagIsPresentName);
+    getOffsetLagIsAbsent = metricsRepository.getMetric(getOffsetLagIsAbsentName);
+    getOffsetLag = metricsRepository.getMetric(getOffsetLagName);
+    allMetrics = new Metric[] { getLatestOffsetIsPresent, getLatestOffsetIsAbsent, getLatestOffset,
+        getOffsetLagIsPresent, getOffsetLagIsAbsent, getOffsetLag };
+
+    // Verify that metrics exist but are empty
+    for (Metric metric: allMetrics) {
+      assertNotNull(metric);
+      assertEquals(metric.value(), 0.0);
+    }
+
+    // Record into one of two children stats
+    stats.recordLatestOffsetIsPresent();
+    stats.recordOffsetLagIsPresent();
+
+    // Verify that the parent is incremented but not the other child
+    assertTrue(getLatestOffsetIsPresent.value() > 0.0);
+    assertEquals(getLatestOffsetIsAbsent.value(), 0.0);
+    assertTrue(getLatestOffset.value() > 0.0);
+    assertTrue(getOffsetLagIsPresent.value() > 0.0);
+    assertEquals(getOffsetLagIsAbsent.value(), 0.0);
+    assertTrue(getOffsetLag.value() > 0.0);
+
+    // Record into the second child
+    stats.recordLatestOffsetIsAbsent();
+    stats.recordOffsetLagIsAbsent();
+
+    // Verify that the parent is larger than both children
+    assertTrue(getLatestOffsetIsPresent.value() > 0.0);
+    assertTrue(getLatestOffsetIsAbsent.value() > 0.0);
+    assertTrue(getLatestOffset.value() > getLatestOffsetIsPresent.value());
+    assertTrue(getLatestOffset.value() > getLatestOffsetIsAbsent.value());
+    assertTrue(getOffsetLagIsPresent.value() > 0.0);
+    assertTrue(getOffsetLagIsAbsent.value() > 0.0);
+    assertTrue(getOffsetLag.value() > getLatestOffsetIsPresent.value());
+    assertTrue(getOffsetLag.value() > getLatestOffsetIsAbsent.value());
+  }
+}

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/AbstractVeniceStats.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/AbstractVeniceStats.java
@@ -63,12 +63,13 @@ public class AbstractVeniceStats {
     return registerSensor(getSensorFullName(getName(), sensorName), null, parents, stats);
   }
 
+  /**
+   * N.B.: This function is private because it requires the full sensor name, which should be generated from
+   *       {@link #getSensorFullName(String)}, and is therefore less user-friendly for developers of subclasses.
+   *       The other functions which call this one require just the partial sensor name, which is less error-prone.
+   */
   @SuppressWarnings("SynchronizationOnLocalVariableOrMethodParameter")
-  protected Sensor registerSensor(
-      String sensorFullName,
-      MetricConfig config,
-      Sensor[] parents,
-      MeasurableStat... stats) {
+  private Sensor registerSensor(String sensorFullName, MetricConfig config, Sensor[] parents, MeasurableStat... stats) {
     return sensors.computeIfAbsent(sensorFullName, key -> {
       /**
        * The sensors concurrentmap will not prevent other objects working on the same metrics repository to execute
@@ -155,7 +156,7 @@ public class AbstractVeniceStats {
     return getSensorFullName(getName(), sensorName);
   }
 
-  protected String getSensorFullName(String resourceName, String sensorName) {
+  public static String getSensorFullName(String resourceName, String sensorName) {
     if (resourceName.charAt(0) != '.') {
       resourceName = "." + resourceName;
     }

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/LambdaStat.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/stats/LambdaStat.java
@@ -1,13 +1,15 @@
 package com.linkedin.venice.stats;
 
 import io.tehuti.metrics.Measurable;
+import io.tehuti.metrics.MeasurableStat;
+import io.tehuti.metrics.Sensor;
 
 
 /**
  * @deprecated, use {@link Gauge} instead.
  *
  * The reason to deprecate {@link LambdaStat} is that {@link Gauge} is a better name when appending the class name
- * as the suffix of metric name here: {@link AbstractVeniceStats#registerSensor}.
+ * as the suffix of metric name here: {@link AbstractVeniceStats#registerSensor(String, Sensor[], MeasurableStat...)}.
  */
 @Deprecated
 public class LambdaStat extends Gauge {

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/AbstractVeniceStatsTest.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/AbstractVeniceStatsTest.java
@@ -38,7 +38,7 @@ public class AbstractVeniceStatsTest {
 
   /**
    * This test creates the same metric via many objects using multiple threads.
-   * Without the synchronization in {@link AbstractVeniceStats#registerSensor(String, MetricConfig, Sensor[], MeasurableStat...)}
+   * Without the synchronization in {@link AbstractVeniceStats#registerSensor(String, Sensor[], MeasurableStat...)}
    * this test fails consistently. With the synchronization added the test passes.
    * @throws InterruptedException
    */

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/AbstractVeniceStatsTest.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/stats/AbstractVeniceStatsTest.java
@@ -1,6 +1,12 @@
 package com.linkedin.venice.stats;
 
-import static org.testng.AssertJUnit.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.argThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 
 import com.linkedin.venice.client.stats.BasicClientStats;
 import com.linkedin.venice.client.stats.ClientStats;
@@ -9,13 +15,16 @@ import com.linkedin.venice.read.RequestType;
 import io.tehuti.Metric;
 import io.tehuti.metrics.MeasurableStat;
 import io.tehuti.metrics.MetricConfig;
+import io.tehuti.metrics.MetricsReporter;
 import io.tehuti.metrics.MetricsRepository;
 import io.tehuti.metrics.Sensor;
-import java.util.Optional;
+import io.tehuti.metrics.stats.Count;
+import io.tehuti.metrics.stats.OccurrenceRate;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -29,7 +38,7 @@ public class AbstractVeniceStatsTest {
 
   /**
    * This test creates the same metric via many objects using multiple threads.
-   * Without the synchronization in {@link AbstractVeniceStats#registerSensor(String, Optional, MetricConfig, Sensor[], MeasurableStat...)}
+   * Without the synchronization in {@link AbstractVeniceStats#registerSensor(String, MetricConfig, Sensor[], MeasurableStat...)}
    * this test fails consistently. With the synchronization added the test passes.
    * @throws InterruptedException
    */
@@ -107,4 +116,62 @@ public class AbstractVeniceStatsTest {
     clientStats.recordRequestRetryCount();
   }
 
+  @Test
+  public void testParentStats() {
+    MetricsRepository metricsRepository = new MetricsRepository();
+    MetricsReporter reporter = mock(MetricsReporter.class);
+    metricsRepository.addReporter(reporter);
+    AbstractVeniceStats avs = new AbstractVeniceStats(metricsRepository, "AVS");
+    Count parentCount = new Count(), childCount1 = new Count(), childCount2 = new Count();
+    OccurrenceRate parentOccurrenceRate = new OccurrenceRate(), childOccurrenceRate1 = new OccurrenceRate(),
+        childOccurrenceRate2 = new OccurrenceRate();
+    long now = System.currentTimeMillis();
+    MetricConfig metricConfig = new MetricConfig();
+
+    // Test initial state
+    assertEquals(childCount1.measure(metricConfig, now), 0.0);
+    assertEquals(childCount2.measure(metricConfig, now), 0.0);
+    assertEquals(parentCount.measure(metricConfig, now), 0.0);
+    assertEquals(childOccurrenceRate1.measure(metricConfig, now), 0.0);
+    assertEquals(childOccurrenceRate2.measure(metricConfig, now), 0.0);
+    assertEquals(parentOccurrenceRate.measure(metricConfig, now), 0.0);
+    Mockito.verify(reporter).init(argThat(argument -> argument.size() == 0));
+    Mockito.verify(reporter, never()).addMetric(any());
+
+    // Register metrics
+    Sensor parentSensor = avs.registerSensor("parent", parentCount, parentOccurrenceRate);
+    Sensor[] parentSensorArray = new Sensor[] { parentSensor };
+    Sensor childSensor1 = avs.registerSensor("child1", parentSensorArray, childCount1, childOccurrenceRate1);
+    Sensor childSensor2 = avs.registerSensor("child2", parentSensorArray, childCount2, childOccurrenceRate2);
+
+    // Test reporter
+    Mockito.verify(reporter).init(argThat(argument -> argument.size() == 0));
+    Mockito.verify(reporter, times(6)).addMetric(any());
+
+    // Test that recording propagates from child to parent
+    childSensor1.record(1);
+    assertEquals(childCount1.measure(metricConfig, now), 1.0);
+    assertEquals(childCount2.measure(metricConfig, now), 0.0);
+    assertEquals(parentCount.measure(metricConfig, now), 1.0);
+    assertTrue(childOccurrenceRate1.measure(metricConfig, now) > 0.0);
+    assertEquals(childOccurrenceRate2.measure(metricConfig, now), 0.0);
+    assertTrue(parentOccurrenceRate.measure(metricConfig, now) > 0.0);
+
+    childSensor2.record(1);
+    assertEquals(childCount1.measure(metricConfig, now), 1.0);
+    assertEquals(childCount2.measure(metricConfig, now), 1.0);
+    assertEquals(parentCount.measure(metricConfig, now), 2.0);
+    assertTrue(childOccurrenceRate1.measure(metricConfig, now) > 0.0);
+    assertTrue(childOccurrenceRate2.measure(metricConfig, now) > 0.0);
+    assertTrue(parentOccurrenceRate.measure(metricConfig, now) > 0.0);
+
+    // Test that recording does not propagate from parent to child
+    parentSensor.record(1);
+    assertEquals(childCount1.measure(metricConfig, now), 1.0);
+    assertEquals(childCount2.measure(metricConfig, now), 1.0);
+    assertEquals(parentCount.measure(metricConfig, now), 3.0);
+    assertTrue(childOccurrenceRate1.measure(metricConfig, now) > 0.0);
+    assertTrue(childOccurrenceRate2.measure(metricConfig, now) > 0.0);
+    assertTrue(parentOccurrenceRate.measure(metricConfig, now) > 0.0);
+  }
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/kafka/partitionoffset/PartitionOffsetFetcherImpl.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/kafka/partitionoffset/PartitionOffsetFetcherImpl.java
@@ -506,7 +506,9 @@ public class PartitionOffsetFetcherImpl implements PartitionOffsetFetcher {
       IOUtils.closeQuietly(kafkaAdminWrapper.get(), logger::error);
     }
     if (pubSubConsumer.isPresent()) {
-      IOUtils.closeQuietly(pubSubConsumer.get(), logger::error);
+      try (AutoCloseableLock ignore = AutoCloseableLock.of(adminConsumerLock)) {
+        IOUtils.closeQuietly(pubSubConsumer.get(), logger::error);
+      }
     }
   }
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/kafka/partitionoffset/PartitionOffsetFetcherStats.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/kafka/partitionoffset/PartitionOffsetFetcherStats.java
@@ -9,7 +9,7 @@ import io.tehuti.metrics.stats.Max;
 import io.tehuti.metrics.stats.Min;
 import io.tehuti.metrics.stats.OccurrenceRate;
 import java.util.Collections;
-import java.util.HashMap;
+import java.util.EnumMap;
 import java.util.Map;
 
 
@@ -21,11 +21,12 @@ public class PartitionOffsetFetcherStats extends AbstractVeniceStats {
   }
 
   private final Map<OCCURRENCE_LATENCY_SENSOR_TYPE, Sensor> sensorsByTypes;
+  private Sensor getPartitionLatestOffsetError;
 
   public PartitionOffsetFetcherStats(MetricsRepository metricsRepository, String name) {
     super(metricsRepository, name);
     Map<OCCURRENCE_LATENCY_SENSOR_TYPE, Sensor> tmpRateSensorsByTypes =
-        new HashMap<>(OCCURRENCE_LATENCY_SENSOR_TYPE.values().length);
+        new EnumMap<>(OCCURRENCE_LATENCY_SENSOR_TYPE.class);
     for (OCCURRENCE_LATENCY_SENSOR_TYPE sensorType: OCCURRENCE_LATENCY_SENSOR_TYPE.values()) {
       final String sensorName = sensorType.name().toLowerCase();
       tmpRateSensorsByTypes.put(
@@ -40,9 +41,15 @@ public class PartitionOffsetFetcherStats extends AbstractVeniceStats {
     }
 
     this.sensorsByTypes = Collections.unmodifiableMap(tmpRateSensorsByTypes);
+    this.getPartitionLatestOffsetError =
+        registerSensorIfAbsent("get_partition_latest_offset_with_retry_error", new OccurrenceRate());
   }
 
   public void recordLatency(OCCURRENCE_LATENCY_SENSOR_TYPE sensor_type, long requestLatencyMs) {
     sensorsByTypes.get(sensor_type).record(requestLatencyMs);
+  }
+
+  public void recordGetLatestOffsetError() {
+    this.getPartitionLatestOffsetError.record();
   }
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/adapter/kafka/KafkaPartitionTopicOffsetMetrics.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/adapter/kafka/KafkaPartitionTopicOffsetMetrics.java
@@ -1,0 +1,50 @@
+package com.linkedin.venice.pubsub.adapter.kafka;
+
+import static com.linkedin.venice.pubsub.adapter.kafka.TopicPartitionsOffsetsTracker.INVALID;
+
+import org.apache.kafka.common.Metric;
+
+
+/**
+ * A wrapper for a Kafka {@link Metric} object representing a topic-partition's lag. We also carry the
+ * current offset so that we can calculate the end offset.
+ */
+class KafkaPartitionTopicOffsetMetrics {
+  private long currentOffset = INVALID;
+  private Metric lagMetric = null;
+
+  void setCurrentOffset(long currentOffset) {
+    this.currentOffset = currentOffset;
+  }
+
+  void setLagMetric(Metric lagMetric) {
+    this.lagMetric = lagMetric;
+  }
+
+  boolean isLagMetricMissing() {
+    return this.lagMetric == null;
+  }
+
+  long getLag() {
+    if (this.lagMetric != null) {
+      Object metricValue = this.lagMetric.metricValue();
+      if (metricValue instanceof Double) {
+        // Double is the way all metrics are internally represented in Kafka, but since we are dealing with lag, we
+        // want an integral type, so we cast it.
+        return ((Double) metricValue).longValue();
+      }
+    }
+    return INVALID;
+  }
+
+  long getEndOffset() {
+    if (this.currentOffset == INVALID) {
+      return INVALID;
+    }
+    long lag = getLag();
+    if (lag == INVALID) {
+      return INVALID;
+    }
+    return this.currentOffset + lag;
+  }
+}

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/adapter/kafka/TopicPartitionsOffsetsTracker.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/adapter/kafka/TopicPartitionsOffsetsTracker.java
@@ -11,19 +11,16 @@ import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.common.Metric;
 import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.TopicPartition;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 
 /**
  * This class tracks consumed topic partitions' offsets
  */
 public class TopicPartitionsOffsetsTracker {
-  private static final Logger LOGGER = LogManager.getLogger(TopicPartitionsOffsetsTracker.class);
-  private static final long INVALID = -1;
+  static final long INVALID = -1;
   private static final long DEFAULT_OFFSETS_UPDATE_INTERVAL_MS = 30 * Time.MS_PER_SECOND;
 
-  private final Map<TopicPartition, OffsetInfo> topicPartitionOffsetInfo;
+  private final Map<TopicPartition, KafkaPartitionTopicOffsetMetrics> topicPartitionOffsetInfo;
   private volatile long lastMetricsCollectedTime;
   private final long offsetsUpdateIntervalMs;
 
@@ -60,76 +57,42 @@ public class TopicPartitionsOffsetsTracker {
   public void updateEndAndCurrentOffsets(
       ConsumerRecords<byte[], byte[]> records,
       Consumer<byte[], byte[]> kafkaConsumer) {
-    long lastMetricsCollectedTimeSnapshot = lastMetricsCollectedTime;
-    long currentTime = System.currentTimeMillis();
-    long elapsedTime = currentTime - lastMetricsCollectedTimeSnapshot;
-    if (elapsedTime < offsetsUpdateIntervalMs) {
-      return; // Not yet
-    }
-    synchronized (this) {
-      /**
-       * N.B.: This race condition check could be defeated if we allowed the {@link offsetsUpdateIntervalMs} to be zero.
-       *       This is why the {@link #validateInterval(long)} function protects against this at construction-time.
-       *       We do allow an interval of zero in tests, via the package-private constructor, because these are not
-       *       multi-threaded.
-       */
-      if (lastMetricsCollectedTimeSnapshot == lastMetricsCollectedTime) {
-        lastMetricsCollectedTime = currentTime;
-      } else {
-        return; // Another thread got in first.
-      }
-    }
+
+    boolean lagMetricMissing = false;
 
     // Update current offset cache for all topics partition.
     List<ConsumerRecord<byte[], byte[]>> listOfRecordsForOnePartition;
     ConsumerRecord<byte[], byte[]> lastConsumerRecordOfPartition;
+    KafkaPartitionTopicOffsetMetrics offsetInfo;
     for (TopicPartition tp: records.partitions()) {
       listOfRecordsForOnePartition = records.records(tp);
       lastConsumerRecordOfPartition = listOfRecordsForOnePartition.get(listOfRecordsForOnePartition.size() - 1);
-      topicPartitionOffsetInfo.computeIfAbsent(tp, k -> new OffsetInfo()).currentOffset =
-          lastConsumerRecordOfPartition.offset();
+      offsetInfo = topicPartitionOffsetInfo.computeIfAbsent(tp, k -> new KafkaPartitionTopicOffsetMetrics());
+      offsetInfo.setCurrentOffset(lastConsumerRecordOfPartition.offset());
+      if (offsetInfo.isLagMetricMissing()) {
+        lagMetricMissing = true;
+      }
     }
 
+    long currentTime = System.currentTimeMillis();
+    long elapsedTime = currentTime - lastMetricsCollectedTime;
+    if (elapsedTime < offsetsUpdateIntervalMs && !lagMetricMissing) {
+      return; // Not yet
+    }
+
+    lastMetricsCollectedTime = currentTime;
     MetricName metricName;
     Metric metric;
     TopicPartition tp;
-    OffsetInfo offsetInfo;
-    long metricValue;
     for (Map.Entry<MetricName, ? extends Metric> entry: kafkaConsumer.metrics().entrySet()) {
       metricName = entry.getKey();
       metric = entry.getValue();
-      metricValue = getMetricEntryRecordsLag(metricName, metric);
 
-      if (metricValue != INVALID) {
-        tp = new TopicPartition(metricName.tags().get("topic"), Integer.parseInt(metricName.tags().get("partition")));
-        offsetInfo = topicPartitionOffsetInfo.computeIfAbsent(tp, k -> new OffsetInfo());
-        offsetInfo.lag = metricValue;
-        if (offsetInfo.currentOffset != INVALID) {
-          offsetInfo.endOffset = offsetInfo.currentOffset + metricValue;
-        }
-      }
-    }
-  }
-
-  /**
-   * @return the lag value if the metric is for lag, or {@link #INVALID} otherwise.
-   */
-  private long getMetricEntryRecordsLag(MetricName metricName, Metric metric) {
-    try {
       if (Objects.equals(metricName.name(), "records-lag")) {
-        Object metricValue = metric.metricValue();
-        if (metricValue instanceof Double) {
-          // Double is the way all metrics are internally represented in Kafka, but since we are dealing with lag, we
-          // want an integral type, so we cast it.
-          return ((Double) metricValue).longValue();
-        }
+        tp = new TopicPartition(metricName.tags().get("topic"), Integer.parseInt(metricName.tags().get("partition")));
+        offsetInfo = topicPartitionOffsetInfo.computeIfAbsent(tp, k -> new KafkaPartitionTopicOffsetMetrics());
+        offsetInfo.setLagMetric(metric);
       }
-      return INVALID;
-    } catch (Exception e) {
-      LOGGER.warn(
-          "Caught exception: {} when attempting to get consumer metrics. Incomplete metrics might be returned.",
-          e.getMessage());
-      return INVALID;
     }
   }
 
@@ -156,8 +119,8 @@ public class TopicPartitionsOffsetsTracker {
    * @return end offset of a topic partition if there is any.
    */
   public long getEndOffset(String topic, int partition) {
-    OffsetInfo offsetInfo = topicPartitionOffsetInfo.get(new TopicPartition(topic, partition));
-    return offsetInfo == null ? INVALID : offsetInfo.endOffset;
+    KafkaPartitionTopicOffsetMetrics offsetInfo = topicPartitionOffsetInfo.get(new TopicPartition(topic, partition));
+    return offsetInfo == null ? INVALID : offsetInfo.getEndOffset();
   }
 
   /**
@@ -167,13 +130,7 @@ public class TopicPartitionsOffsetsTracker {
    * @return end offset of a topic partition if there is any.
    */
   public long getOffsetLag(String topic, int partition) {
-    OffsetInfo offsetInfo = topicPartitionOffsetInfo.get(new TopicPartition(topic, partition));
-    return offsetInfo == null ? INVALID : offsetInfo.lag;
-  }
-
-  private static class OffsetInfo {
-    long currentOffset = INVALID;
-    long endOffset = INVALID;
-    long lag = INVALID;
+    KafkaPartitionTopicOffsetMetrics offsetInfo = topicPartitionOffsetInfo.get(new TopicPartition(topic, partition));
+    return offsetInfo == null ? INVALID : offsetInfo.getLag();
   }
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/adapter/kafka/consumer/ApacheKafkaConsumerAdapter.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/adapter/kafka/consumer/ApacheKafkaConsumerAdapter.java
@@ -275,7 +275,7 @@ public class ApacheKafkaConsumerAdapter implements PubSubConsumerAdapter {
     }
 
     if (topicPartitionsOffsetsTracker != null) {
-      topicPartitionsOffsetsTracker.updateEndAndCurrentOffsets(records, kafkaConsumer.metrics());
+      topicPartitionsOffsetsTracker.updateEndAndCurrentOffsets(records, kafkaConsumer);
     }
     return polledPubSubMessages;
   }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/EmptyPubSubMessageHeaders.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/EmptyPubSubMessageHeaders.java
@@ -1,0 +1,34 @@
+package com.linkedin.venice.pubsub.api;
+
+import java.util.Collections;
+import java.util.List;
+
+
+public class EmptyPubSubMessageHeaders extends PubSubMessageHeaders {
+  public static final PubSubMessageHeaders SINGLETON = new EmptyPubSubMessageHeaders();
+
+  private static final String EX_MSG = EmptyPubSubMessageHeaders.class.getSimpleName() + " is immutable.";
+
+  private EmptyPubSubMessageHeaders() {
+  }
+
+  @Override
+  public PubSubMessageHeaders add(PubSubMessageHeader header) {
+    throw new UnsupportedOperationException(EX_MSG);
+  }
+
+  @Override
+  public PubSubMessageHeaders add(String key, byte[] value) {
+    throw new UnsupportedOperationException(EX_MSG);
+  }
+
+  @Override
+  public PubSubMessageHeaders remove(String key) {
+    throw new UnsupportedOperationException(EX_MSG);
+  }
+
+  @Override
+  public List<PubSubMessageHeader> toList() {
+    return Collections.emptyList();
+  }
+}

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/PubSubMessage.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/PubSubMessage.java
@@ -1,8 +1,5 @@
 package com.linkedin.venice.pubsub.api;
 
-import static com.linkedin.venice.writer.VeniceWriter.EMPTY_MSG_HEADERS;
-
-
 public interface PubSubMessage<K, V, OFFSET> {
   /**
    * @return the key part of this message
@@ -48,6 +45,6 @@ public interface PubSubMessage<K, V, OFFSET> {
   boolean isEndOfBootstrap();
 
   default PubSubMessageHeaders getPubSubMessageHeaders() {
-    return EMPTY_MSG_HEADERS;
+    return EmptyPubSubMessageHeaders.SINGLETON;
   }
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/PubSubMessageHeaders.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/PubSubMessageHeaders.java
@@ -11,10 +11,10 @@ import java.util.Map;
  * In case of headers with the same key, only the most recently added headers value will be kept.
  */
 public class PubSubMessageHeaders {
-
-  // Kafka allows duplicate keys in the headers but some pubsub systems may not
-  // allow it. Hence, it would be good to enforce uniqueness of keys in headers
-  // from the beginning.
+  /**
+   * N.B.: Kafka allows duplicate keys in the headers but some pubsub systems may not
+   * allow it. Hence, we will enforce uniqueness of keys in headers from the beginning.
+   */
   private final Map<String, PubSubMessageHeader> headers = new LinkedHashMap<>();
 
   public static final String VENICE_TRANSPORT_PROTOCOL_HEADER = "vtp";

--- a/internal/venice-common/src/main/java/com/linkedin/venice/writer/VeniceWriter.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/writer/VeniceWriter.java
@@ -36,6 +36,7 @@ import com.linkedin.venice.kafka.validation.checksum.CheckSumType;
 import com.linkedin.venice.message.KafkaKey;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.partitioner.VenicePartitioner;
+import com.linkedin.venice.pubsub.api.EmptyPubSubMessageHeaders;
 import com.linkedin.venice.pubsub.api.PubSubMessageHeader;
 import com.linkedin.venice.pubsub.api.PubSubMessageHeaders;
 import com.linkedin.venice.pubsub.api.PubSubProduceResult;
@@ -210,8 +211,6 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
   public static final LeaderMetadataWrapper DEFAULT_LEADER_METADATA_WRAPPER =
       new LeaderMetadataWrapper(DEFAULT_UPSTREAM_OFFSET, DEFAULT_UPSTREAM_KAFKA_CLUSTER_ID);
 
-  public static final PubSubMessageHeaders EMPTY_MSG_HEADERS = new PubSubMessageHeaders();
-
   // Immutable state
   private final PubSubMessageHeaders protocolSchemaHeaders;
 
@@ -343,7 +342,7 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
     this.threadPoolExecutor.allowCoreThreadTimeOut(true); // allow core threads to timeout
 
     this.protocolSchemaHeaders = overrideProtocolSchema == null
-        ? EMPTY_MSG_HEADERS
+        ? EmptyPubSubMessageHeaders.SINGLETON
         : new PubSubMessageHeaders()
             .add(VENICE_TRANSPORT_PROTOCOL_HEADER, overrideProtocolSchema.toString().getBytes(StandardCharsets.UTF_8));
     try {
@@ -1357,7 +1356,7 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
   }
 
   /**
-   * {@link PubSubMessageHeaders#VENICE_TRANSPORT_PROTOCOL_HEADER} or {@link VeniceWriter#EMPTY_MSG_HEADERS} is used for
+   * {@link PubSubMessageHeaders#VENICE_TRANSPORT_PROTOCOL_HEADER} or {@link EmptyPubSubMessageHeaders} is used for
    * all messages to a partition based on {@link VeniceWriter} param overrideProtocolSchema and whether it's a first message.
    * {@link PubSubMessageHeaders#VENICE_LEADER_COMPLETION_STATE_HEADER} is added to the above headers for HB SOS message.
    *
@@ -1378,7 +1377,7 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
     PubSubMessageHeaders pubSubMessageHeaders =
         producerMetadata.getSegmentNumber() == 0 && producerMetadata.getMessageSequenceNumber() == 0
             ? protocolSchemaHeaders
-            : EMPTY_MSG_HEADERS;
+            : EmptyPubSubMessageHeaders.SINGLETON;
 
     if (addLeaderCompleteState) {
       // copy protocolSchemaHeaders locally and add extra header for leaderCompleteState


### PR DESCRIPTION
[server][dvc] Lag measurement safeguard and logging improvements

It seems that sometimes the offset lag used in lag measurement can
be negative, which results in the lag being considered acceptable
and the replica becoming ready to serve (prematurely).

It seems that negative lag is a somewhat normal phenomenon since
the formula is basically max_offset - consumed_offset, and the
former is cached, so if stale it could be smaller than the latter
(which of course doesn't make sense, but is an artifact of the
caching). This is a benign case.

However, there is also a case where the max_offset retrieval can
fail, in which case a negative error code would be returned. This
also leads to negative lag, but it is a mistake.

This commit adds safeguards to prevent prematurely declaring
ready-to-serve. There are a bunch of code paths interacting with
offset retrieval, which makes this commit a bit big. In order to
improve maintainability, the tricky bits are centralized as much
as possible into a new SIT::measureLagWithCallToPubSub function.

Miscellaneous:

- Added a get_partition_latest_offset_with_retry_error metric.

- Deleted the SLOPPY_OFFSET_CATCHUP_THRESHOLD in SIT, which is
  not necessary and is, well, sloppy.

- Introduced a new EmptyPubSubMessageHeaders which is immutable
  (the previous EMPTY_MSG_HEADERS in VeniceWriter was mutable).

- Fixed a NPE in AbstractVeniceStatsReporter.

- Fixed a concurrency issue about closing the non-threadsafe
  Kafka consumer in PartitionOffsetFetcher.

- Fixed the sensor name of KafkaConsumerServiceStats's offset 
  present/absent metrics. Added a test for this as well.

- Tweaked the API in AbstractVeniceStats so that it is less
  error-prone. The registerSensor function with sensorFullName
  parameter is now private, to avoid misuse.

There are also various log tweaks to make logs less voluminous:

- Deleted two log lines from SIT::getDefaultReadyToServeChecker
  - "Reopen partition {}_{} for reading after ready-to-serve."
  - "Partition {} synced offset"

- Passed shouldLogLag false in SIT::updateOffsetLagInMetadata.

- Deleted two functions from LFSIT which were used only to 
  specify default values to some parameters in a deeper 
  function. Kept only measureRTOffsetLagForSingleRegion, which 
  is the first function of the call chain.

- Rewrote the TopicPartitionsOffsetsTracker so that it is a bit 
  more efficient, cannot have invalid lag, doesn't needlessly 
  log a bunch of lines every minute or so, and uses less code.

Test changes:

- Overhauled DataProviders in StoreIngestionTaskTest. Rather
  than using a bunch of booleans which are hard reason about
  in test logs, we now use enums, which makes it easy to read
  which test permutations passed or failed. In one case, this 
  allows squashing 2 booleans (of which 1 of 4 permutations is
  invalid) into a single 3 items enum, thus reducing the test 
  permutations count.

- Fixed testOffsetSyncBeforeGracefulShutDown flakiness in 
  StoreIngestionTaskTest.

- SITTest::testGetAndUpdateLeaderCompletedState which was 
  mutating the static instance of VW.EMPTY_MSG_HEADERS, thus 
  contaminating subsequent tests (when running in the same JVM,
  as is the case in IntelliJ, but not in Gradle).

- Added a unit test for parent stats.

## How was this PR tested?
Existing tests. Broke them a few times before finding a way that the safeguard doesn't cause failures.

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.