### PR TITLE
[dvc] Check to clear local data on record transformer value schema change between reinitializations

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/client/AvroGenericDaVinciClient.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/client/AvroGenericDaVinciClient.java
@@ -667,7 +667,11 @@ public class AvroGenericDaVinciClient<K, V> implements DaVinciClient<K, V>, Avro
         .put(KAFKA_BOOTSTRAP_SERVERS, kafkaBootstrapServers)
         .put(ROCKSDB_PLAIN_TABLE_FORMAT_ENABLED, daVinciConfig.getStorageClass() == StorageClass.MEMORY_BACKED_BY_DISK)
         .put(INGESTION_USE_DA_VINCI_CLIENT, true)
-        .put("record.transformer.value.schema", daVinciConfig.getRecordTransformer().getValueOutputSchema().toString())
+        .put(
+            "record.transformer.value.schema",
+            daVinciConfig.getRecordTransformer() != null
+                ? daVinciConfig.getRecordTransformer().getValueOutputSchema().toString()
+                : "null")
         .put(INGESTION_ISOLATION_CONFIG_PREFIX + "." + INGESTION_MEMORY_LIMIT, -1) // Explicitly disable memory limiter
                                                                                    // in Isolated Process
         .build();

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/client/AvroGenericDaVinciClient.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/client/AvroGenericDaVinciClient.java
@@ -667,6 +667,7 @@ public class AvroGenericDaVinciClient<K, V> implements DaVinciClient<K, V>, Avro
         .put(KAFKA_BOOTSTRAP_SERVERS, kafkaBootstrapServers)
         .put(ROCKSDB_PLAIN_TABLE_FORMAT_ENABLED, daVinciConfig.getStorageClass() == StorageClass.MEMORY_BACKED_BY_DISK)
         .put(INGESTION_USE_DA_VINCI_CLIENT, true)
+        .put("record.transformer.value.schema", daVinciConfig.getRecordTransformer().getValueOutputSchema().toString())
         .put(INGESTION_ISOLATION_CONFIG_PREFIX + "." + INGESTION_MEMORY_LIMIT, -1) // Explicitly disable memory limiter
                                                                                    // in Isolated Process
         .build();

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/client/AvroGenericDaVinciClient.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/client/AvroGenericDaVinciClient.java
@@ -1,6 +1,7 @@
 package com.linkedin.davinci.client;
 
 import static com.linkedin.davinci.ingestion.utils.IsolatedIngestionUtils.INGESTION_ISOLATION_CONFIG_PREFIX;
+import static com.linkedin.davinci.store.rocksdb.RocksDBServerConfig.RECORD_TRANSFORMER_VALUE_SCHEMA;
 import static com.linkedin.davinci.store.rocksdb.RocksDBServerConfig.ROCKSDB_LEVEL0_FILE_NUM_COMPACTION_TRIGGER;
 import static com.linkedin.davinci.store.rocksdb.RocksDBServerConfig.ROCKSDB_LEVEL0_FILE_NUM_COMPACTION_TRIGGER_WRITE_ONLY_VERSION;
 import static com.linkedin.davinci.store.rocksdb.RocksDBServerConfig.ROCKSDB_LEVEL0_SLOWDOWN_WRITES_TRIGGER;
@@ -668,7 +669,7 @@ public class AvroGenericDaVinciClient<K, V> implements DaVinciClient<K, V>, Avro
         .put(ROCKSDB_PLAIN_TABLE_FORMAT_ENABLED, daVinciConfig.getStorageClass() == StorageClass.MEMORY_BACKED_BY_DISK)
         .put(INGESTION_USE_DA_VINCI_CLIENT, true)
         .put(
-            "record.transformer.value.schema",
+            RECORD_TRANSFORMER_VALUE_SCHEMA,
             daVinciConfig.getRecordTransformer() != null
                 ? daVinciConfig.getRecordTransformer().getValueOutputSchema().toString()
                 : "null")

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/RocksDBServerConfig.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/RocksDBServerConfig.java
@@ -208,6 +208,7 @@ public class RocksDBServerConfig {
 
   public static final String ROCKSDB_MAX_LOG_FILE_NUM = "rocksdb.max.log.file.num";
   public static final String ROCKSDB_MAX_LOG_FILE_SIZE = "rocksdb.max.log.file.size";
+  public static final String RECORD_TRANSFORMER_VALUE_SCHEMA = "record.transformer.value.schema";
 
   private final boolean rocksDBUseDirectReads;
 
@@ -381,7 +382,8 @@ public class RocksDBServerConfig {
      */
     this.maxLogFileNum = props.getInt(ROCKSDB_MAX_LOG_FILE_NUM, 3);
     this.maxLogFileSize = props.getSizeInBytes(ROCKSDB_MAX_LOG_FILE_SIZE, 10 * 1024 * 1024); // 10MB;
-    this.transformerValueSchema = props.getString("record.transformer.value.schema", "null");
+    this.transformerValueSchema =
+        props.containsKey(RECORD_TRANSFORMER_VALUE_SCHEMA) ? props.getString(RECORD_TRANSFORMER_VALUE_SCHEMA) : "null";
   }
 
   public int getLevel0FileNumCompactionTriggerWriteOnlyVersion() {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/RocksDBServerConfig.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/RocksDBServerConfig.java
@@ -381,7 +381,7 @@ public class RocksDBServerConfig {
      */
     this.maxLogFileNum = props.getInt(ROCKSDB_MAX_LOG_FILE_NUM, 3);
     this.maxLogFileSize = props.getSizeInBytes(ROCKSDB_MAX_LOG_FILE_SIZE, 10 * 1024 * 1024); // 10MB;
-    this.transformerValueSchema = props.getString("record.transformer.value.schema");
+    this.transformerValueSchema = props.getString("record.transformer.value.schema", "null");
   }
 
   public int getLevel0FileNumCompactionTriggerWriteOnlyVersion() {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/RocksDBServerConfig.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/RocksDBServerConfig.java
@@ -268,6 +268,7 @@ public class RocksDBServerConfig {
   private int blockBaseFormatVersion;
   private final int maxLogFileNum;
   private final long maxLogFileSize;
+  private final String transformerValueSchema;
 
   public RocksDBServerConfig(VeniceProperties props) {
     // Do not use Direct IO for reads by default
@@ -380,6 +381,7 @@ public class RocksDBServerConfig {
      */
     this.maxLogFileNum = props.getInt(ROCKSDB_MAX_LOG_FILE_NUM, 3);
     this.maxLogFileSize = props.getSizeInBytes(ROCKSDB_MAX_LOG_FILE_SIZE, 10 * 1024 * 1024); // 10MB;
+    this.transformerValueSchema = props.getString("record.transformer.value.schema");
   }
 
   public int getLevel0FileNumCompactionTriggerWriteOnlyVersion() {
@@ -568,4 +570,9 @@ public class RocksDBServerConfig {
   public long getMaxLogFileSize() {
     return maxLogFileSize;
   }
+
+  public String getTransformerValueSchema() {
+    return transformerValueSchema;
+  }
+
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/RocksDBStorageEngine.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/RocksDBStorageEngine.java
@@ -215,6 +215,7 @@ public class RocksDBStorageEngine extends AbstractStorageEngine<RocksDBStoragePa
         VeniceProperties persistedStorageEngineConfig = Utils.parseProperties(storeEngineConfig);
         LOGGER.info("Found storage engine configs: {}", persistedStorageEngineConfig.toString(true));
         boolean usePlainTableFormat = persistedStorageEngineConfig.getBoolean(ROCKSDB_PLAIN_TABLE_FORMAT_ENABLED, true);
+        String transformerValueSchema = persistedStorageEngineConfig.getString("record.transformer.value.schema");
         if (usePlainTableFormat != rocksDBServerConfig.isRocksDBPlainTableFormatEnabled()) {
           String existingTableFormat = usePlainTableFormat ? "PlainTable" : "BlockBasedTable";
           String newTableFormat =
@@ -223,6 +224,13 @@ public class RocksDBStorageEngine extends AbstractStorageEngine<RocksDBStoragePa
               "Tried to open an existing {} RocksDB format engine with table format option: {}. Will remove the content and recreate the folder.",
               existingTableFormat,
               newTableFormat);
+          return true;
+        }
+        if (!transformerValueSchema.equals(rocksDBServerConfig.getTransformerValueSchema())) {
+          LOGGER.warn(
+              "Tried to open an existing RocksDB engine with transformer schema: {} but already exists with schema {}. Will remove the content and recreate the folder.",
+              rocksDBServerConfig.getTransformerValueSchema(),
+              transformerValueSchema);
           return true;
         }
       } catch (IOException e) {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/RocksDBStorageEngine.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/RocksDBStorageEngine.java
@@ -36,7 +36,8 @@ public class RocksDBStorageEngine extends AbstractStorageEngine<RocksDBStoragePa
   private final String storeDbPath;
   private final RocksDBMemoryStats memoryStats;
   private final RocksDBThrottler rocksDbThrottler;
-  private final RocksDBServerConfig rocksDBServerConfig;
+  // Made non-final only for testing purposes
+  private RocksDBServerConfig rocksDBServerConfig;
   private final RocksDBStorageEngineFactory factory;
   private final VeniceStoreVersionConfig storeConfig;
   private final boolean replicationMetadataEnabled;
@@ -207,7 +208,8 @@ public class RocksDBStorageEngine extends AbstractStorageEngine<RocksDBStoragePa
     return cachedDiskUsage;
   }
 
-  private boolean hasConflictPersistedStoreEngineConfig() {
+  // package-private for testing purposes
+  boolean hasConflictPersistedStoreEngineConfig() {
     String configPath = getRocksDbEngineConfigPath();
     File storeEngineConfig = new File(configPath);
     if (storeEngineConfig.exists()) {
@@ -281,5 +283,10 @@ public class RocksDBStorageEngine extends AbstractStorageEngine<RocksDBStoragePa
       return true;
     }
     return false;
+  }
+
+  // Only used for testing purposes
+  public void setRocksDBServerConfig(RocksDBServerConfig rocksDBServerConfig) {
+    this.rocksDBServerConfig = rocksDBServerConfig;
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/RocksDBStorageEngine.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/RocksDBStorageEngine.java
@@ -1,5 +1,6 @@
 package com.linkedin.davinci.store.rocksdb;
 
+import static com.linkedin.davinci.store.rocksdb.RocksDBServerConfig.RECORD_TRANSFORMER_VALUE_SCHEMA;
 import static com.linkedin.davinci.store.rocksdb.RocksDBServerConfig.ROCKSDB_PLAIN_TABLE_FORMAT_ENABLED;
 
 import com.linkedin.davinci.config.VeniceStoreVersionConfig;
@@ -215,7 +216,9 @@ public class RocksDBStorageEngine extends AbstractStorageEngine<RocksDBStoragePa
         VeniceProperties persistedStorageEngineConfig = Utils.parseProperties(storeEngineConfig);
         LOGGER.info("Found storage engine configs: {}", persistedStorageEngineConfig.toString(true));
         boolean usePlainTableFormat = persistedStorageEngineConfig.getBoolean(ROCKSDB_PLAIN_TABLE_FORMAT_ENABLED, true);
-        String transformerValueSchema = persistedStorageEngineConfig.getString("record.transformer.value.schema");
+        String transformerValueSchema = persistedStorageEngineConfig.containsKey(RECORD_TRANSFORMER_VALUE_SCHEMA)
+            ? persistedStorageEngineConfig.getString(RECORD_TRANSFORMER_VALUE_SCHEMA)
+            : "null";
         if (usePlainTableFormat != rocksDBServerConfig.isRocksDBPlainTableFormatEnabled()) {
           String existingTableFormat = usePlainTableFormat ? "PlainTable" : "BlockBasedTable";
           String newTableFormat =

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/client/AvroGenericDaVinciClientTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/client/AvroGenericDaVinciClientTest.java
@@ -4,8 +4,11 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
+import com.linkedin.davinci.store.rocksdb.RocksDBServerConfig;
 import com.linkedin.venice.meta.ReadOnlySchemaRepository;
 import com.linkedin.venice.schema.SchemaEntry;
+import com.linkedin.venice.utils.PropertyBuilder;
+import com.linkedin.venice.utils.VeniceProperties;
 import org.apache.avro.Schema;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -36,5 +39,15 @@ public class AvroGenericDaVinciClientTest {
         AvroGenericDaVinciClient.getValueSchemaIdForComputeRequest(storeName, computeValueSchema, repo),
         1);
     verify(repo).getValueSchemaId(storeName, computeValueSchemaString);
+  }
+
+  @Test
+  public void testPropertyBuilderWithRecordTransformer() {
+    String schema = "{\n" + "  \"type\": \"string\"\n" + "}\n";
+    VeniceProperties config =
+        new PropertyBuilder().put("kafka.admin.class", "name").put("record.transformer.value.schema", schema).build();
+    RocksDBServerConfig dbconfig = new RocksDBServerConfig(config);
+    Assert.assertEquals(schema, dbconfig.getTransformerValueSchema());
+
   }
 }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/store/rocksdb/RocksDBStorageEngineTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/store/rocksdb/RocksDBStorageEngineTest.java
@@ -193,4 +193,19 @@ public class RocksDBStorageEngineTest extends AbstractStorageEngineTest {
     Assert.assertFalse(testStoreEngine.getMetadataPartition() instanceof ReplicationMetadataRocksDBStoragePartition);
     Assert.assertTrue(testStoreEngine.getMetadataPartition() instanceof RocksDBStoragePartition);
   }
+
+  @Test
+  public void testHasConflictPersistedStoreEngineConfig() {
+    AbstractStorageEngine testStorageEngine = getTestStoreEngine();
+    RocksDBStorageEngine rocksDBStorageEngine = (RocksDBStorageEngine) testStorageEngine;
+    RocksDBServerConfig rocksDBServerConfigMock = mock(RocksDBServerConfig.class);
+    when(rocksDBServerConfigMock.getTransformerValueSchema()).thenReturn("not_null");
+    when(rocksDBServerConfigMock.isRocksDBPlainTableFormatEnabled()).thenReturn(false);
+    rocksDBStorageEngine.setRocksDBServerConfig(rocksDBServerConfigMock);
+
+    boolean result = rocksDBStorageEngine.hasConflictPersistedStoreEngineConfig();
+
+    Assert.assertTrue(result);
+
+  }
 }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/DaVinciClientTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/DaVinciClientTest.java
@@ -210,9 +210,9 @@ public class DaVinciClientTest {
         VeniceRouterWrapper.CLUSTER_DISCOVERY_D2_SERVICE_NAME,
         metricsRepository,
         backendConfig)) {
+      recordTransformer.setOriginalSchema(Schema.parse(DEFAULT_VALUE_SCHEMA));
       DaVinciClient<Integer, Object> clientWithRecordTransformer =
           factory.getAndStartGenericAvroClient(storeName1, clientConfig.setRecordTransformer(recordTransformer));
-      recordTransformer.setOriginalSchema(Schema.parse(DEFAULT_VALUE_SCHEMA));
 
       // Test non-existent key access
       clientWithRecordTransformer.subscribeAll().get();


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

In order to make sure that data is always ingested and transformed with the most up to date value output schema, we need to add an additional check in  `hasConflictPersistedStoreEngineConfig() ` to compare the new schema and the current schema. If there is a conflict in the schema, this function will return true.
Describe


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.