### PR TITLE
[da-vinci] Make chunk assembly a utility

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/InternalLocalBootstrappingVeniceChangelogConsumer.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/InternalLocalBootstrappingVeniceChangelogConsumer.java
@@ -21,7 +21,6 @@ import com.linkedin.davinci.store.record.ValueRecord;
 import com.linkedin.venice.client.change.capture.protocol.RecordChangeEvent;
 import com.linkedin.venice.client.store.ClientConfig;
 import com.linkedin.venice.client.store.ClientFactory;
-import com.linkedin.venice.compression.VeniceCompressor;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.kafka.protocol.ControlMessage;
 import com.linkedin.venice.kafka.protocol.VersionSwap;
@@ -37,7 +36,6 @@ import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
 import com.linkedin.venice.schema.SchemaReader;
 import com.linkedin.venice.serialization.avro.AvroProtocolDefinition;
 import com.linkedin.venice.serialization.avro.InternalAvroSpecificSerializer;
-import com.linkedin.venice.serializer.RecordDeserializer;
 import com.linkedin.venice.service.AbstractVeniceService;
 import com.linkedin.venice.utils.PropertyBuilder;
 import com.linkedin.venice.utils.VeniceProperties;
@@ -325,15 +323,13 @@ class InternalLocalBootstrappingVeniceChangelogConsumer<K, V> extends VeniceChan
 
   @Override
   protected <T> T processRecordBytes(
-      RecordDeserializer<T> deserializer,
-      VeniceCompressor compressor,
+      ByteBuffer decompressedBytes,
+      T deserializedValue,
       byte[] key,
       ByteBuffer value,
       PubSubTopicPartition partition,
       int readerSchemaId,
       long recordOffset) throws IOException {
-    ByteBuffer decompressedBytes = compressor.decompress(value);
-    T deserializedValue = deserializer.deserialize(decompressedBytes);
     if (deserializedValue instanceof RecordChangeEvent) {
       RecordChangeEvent recordChangeEvent = (RecordChangeEvent) deserializedValue;
       if (recordChangeEvent.currentValue == null) {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImpl.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImpl.java
@@ -619,7 +619,14 @@ public class VeniceChangelogConsumerImpl<K, V> implements VeniceChangelogConsume
       }
 
       try {
-        assembledObject = processRecordBytes(null, assembledObject, null, null, null, 0, 0);
+        assembledObject = processRecordBytes(
+            compressor.decompress(put.getPutValue()),
+            assembledObject,
+            keyBytes,
+            put.getPutValue(),
+            pubSubTopicPartition,
+            readerSchemaId,
+            message.getOffset());
       } catch (Exception ex) {
         throw new VeniceException(ex);
       }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImpl.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImpl.java
@@ -541,15 +541,14 @@ public class VeniceChangelogConsumerImpl<K, V> implements VeniceChangelogConsume
   // on solely
   // on the data post deserialization
   protected <T> T processRecordBytes(
-      RecordDeserializer<T> deserializer,
-      VeniceCompressor compressor,
+      ByteBuffer decompressedBytes,
+      T deserializedValue,
       byte[] key,
       ByteBuffer value,
       PubSubTopicPartition partition,
       int valueSchemaId,
       long recordOffset) throws IOException {
-    // NoOp
-    return null;
+    return deserializedValue;
   }
 
   protected Optional<PubSubMessage<K, ChangeEvent<V>, VeniceChangeCoordinate>> convertPubSubMessageToPubSubChangeEventMessage(
@@ -617,6 +616,12 @@ public class VeniceChangelogConsumerImpl<K, V> implements VeniceChangelogConsume
         // bufferAndAssembleRecord may have only buffered records and not returned anything yet because
         // it's waiting for more input. In this case, just return an empty optional for now.
         return Optional.empty();
+      }
+
+      try {
+        assembledObject = processRecordBytes(null, assembledObject, null, null, null, 0, 0);
+      } catch (Exception ex) {
+        throw new VeniceException(ex);
       }
 
       if (assembledObject instanceof RecordChangeEvent) {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImpl.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImpl.java
@@ -553,7 +553,8 @@ public class VeniceChangelogConsumerImpl<K, V> implements VeniceChangelogConsume
       PubSubTopicPartition partition,
       int valueSchemaId,
       long recordOffset) throws IOException {
-    return deserializer.deserialize(compressor.decompress(value));
+    // NoOp
+    return null;
   }
 
   protected Optional<PubSubMessage<K, ChangeEvent<V>, VeniceChangeCoordinate>> convertPubSubMessageToPubSubChangeEventMessage(
@@ -621,9 +622,7 @@ public class VeniceChangelogConsumerImpl<K, V> implements VeniceChangelogConsume
           keyBytes,
           put.getPutValue(),
           message.getOffset(),
-          chunkingAdapter,
           deserializerProvider,
-          deserializerCache,
           readerSchemaId,
           compressor);
       if (assembledObject == null) {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImpl.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImpl.java
@@ -6,10 +6,8 @@ import com.google.common.annotations.VisibleForTesting;
 import com.linkedin.davinci.repository.ThinClientMetaStoreBasedRepository;
 import com.linkedin.davinci.storage.chunking.AbstractAvroChunkingAdapter;
 import com.linkedin.davinci.storage.chunking.GenericChunkingAdapter;
-import com.linkedin.davinci.storage.chunking.RawBytesChunkingAdapter;
 import com.linkedin.davinci.storage.chunking.SpecificRecordChunkingAdapter;
-import com.linkedin.davinci.store.memory.InMemoryStorageEngine;
-import com.linkedin.davinci.store.record.ValueRecord;
+import com.linkedin.davinci.utils.ChunkAssembler;
 import com.linkedin.venice.client.change.capture.protocol.RecordChangeEvent;
 import com.linkedin.venice.compression.CompressionStrategy;
 import com.linkedin.venice.compression.CompressorFactory;
@@ -42,7 +40,6 @@ import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
 import com.linkedin.venice.schema.SchemaReader;
 import com.linkedin.venice.schema.rmd.RmdUtils;
 import com.linkedin.venice.serialization.AvroStoreDeserializerCache;
-import com.linkedin.venice.serialization.RawBytesStoreDeserializerCache;
 import com.linkedin.venice.serialization.StoreDeserializerCache;
 import com.linkedin.venice.serialization.avro.AvroProtocolDefinition;
 import com.linkedin.venice.serialization.avro.AvroSpecificStoreDeserializerCache;
@@ -107,20 +104,13 @@ public class VeniceChangelogConsumerImpl<K, V> implements VeniceChangelogConsume
 
   protected final String storeName;
 
-  // This storage engine serves as a buffer for records which are chunked and have to be buffered before they can
-  // be returned to the client. We leverage the storageEngine interface here in order to take better advantage
-  // of the chunking and decompressing adapters that we've already built (which today are built around this interface)
-  // as chunked records are assembled we will eagerly evict all keys from the storage engine in order to keep the memory
-  // footprint as small as we can. We could use the object cache storage engine here in order to get LRU behavior
-  // but then that runs the risk of a parallel subscription having record chunks getting evicted before we have a chance
-  // to assemble them. So we rely on the simpler and concrete implementation as opposed to the abstraction in order
-  // to control and guarantee the behavior we're expecting.
-  protected final InMemoryStorageEngine inMemoryStorageEngine;
   protected final PubSubConsumerAdapter pubSubConsumer;
   protected final Map<Integer, List<Long>> currentVersionHighWatermarks = new HashMap<>();
   protected final int[] currentValuePayloadSize;
 
   protected final ChangelogClientConfig changelogClientConfig;
+
+  protected final ChunkAssembler chunkAssembler;
 
   public VeniceChangelogConsumerImpl(
       ChangelogClientConfig changelogClientConfig,
@@ -142,11 +132,8 @@ public class VeniceChangelogConsumerImpl<K, V> implements VeniceChangelogConsume
     this.schemaReader = changelogClientConfig.getSchemaReader();
     Schema keySchema = schemaReader.getKeySchema();
     this.keyDeserializer = FastSerializerDeserializerFactory.getFastAvroGenericDeserializer(keySchema, keySchema);
-    // The in memory storage engine only relies on the name of store and nothing else. We use an unversioned store name
-    // here in order to reduce confusion (as this storage engine can be used across version topics).
-    this.inMemoryStorageEngine = new InMemoryStorageEngine(storeName);
-    // disable noisy logs
-    this.inMemoryStorageEngine.suppressLogs(true);
+    this.chunkAssembler = new ChunkAssembler(storeName);
+
     this.storeRepository = new ThinClientMetaStoreBasedRepository(
         changelogClientConfig.getInnerClientConfig(),
         VeniceProperties.empty(),
@@ -553,95 +540,6 @@ public class VeniceChangelogConsumerImpl<K, V> implements VeniceChangelogConsume
     return false;
   }
 
-  protected <T> T bufferAndAssembleRecordChangeEvent(
-      PubSubTopicPartition pubSubTopicPartition,
-      int schemaId,
-      byte[] keyBytes,
-      ByteBuffer valueBytes,
-      long recordOffset,
-      AbstractAvroChunkingAdapter<T> chunkingAdapter,
-      Lazy<RecordDeserializer<T>> recordDeserializer,
-      StoreDeserializerCache<T> deserializerCache,
-      int readerSchemaId) {
-    T assembledRecord = null;
-    // Select compressor. We'll only construct compressors for version topics so this will return null for
-    // events from change capture. This is fine as today they are not compressed.
-    VeniceCompressor compressor;
-    if (pubSubTopicPartition.getPubSubTopic().isVersionTopic()) {
-      compressor = compressorMap.get(pubSubTopicPartition.getPartitionNumber());
-    } else {
-      compressor = NO_OP_COMPRESSOR;
-    }
-
-    if (!inMemoryStorageEngine.containsPartition(pubSubTopicPartition.getPartitionNumber())) {
-      inMemoryStorageEngine.addStoragePartition(pubSubTopicPartition.getPartitionNumber());
-    }
-    // If this is a record chunk, store the chunk and return null for processing this record
-    if (schemaId == AvroProtocolDefinition.CHUNK.getCurrentProtocolVersion()) {
-      inMemoryStorageEngine.put(
-          pubSubTopicPartition.getPartitionNumber(),
-          keyBytes,
-          ValueRecord.create(schemaId, valueBytes.array()).serialize());
-      return null;
-    } else if (schemaId == AvroProtocolDefinition.CHUNKED_VALUE_MANIFEST.getCurrentProtocolVersion()) {
-      // This is the last value. Store it, and now read it from the in memory store as a fully assembled value
-      inMemoryStorageEngine.put(
-          pubSubTopicPartition.getPartitionNumber(),
-          keyBytes,
-          ValueRecord.create(schemaId, valueBytes.array()).serialize());
-      try {
-        assembledRecord = processRecordBytes(
-            recordDeserializer.get(),
-            compressor,
-            keyBytes,
-            RawBytesChunkingAdapter.INSTANCE.get(
-                inMemoryStorageEngine,
-                pubSubTopicPartition.getPartitionNumber(),
-                ByteBuffer.wrap(keyBytes),
-                false,
-                null,
-                null,
-                null,
-                readerSchemaId,
-                RawBytesStoreDeserializerCache.getInstance(),
-                compressor,
-                null),
-            pubSubTopicPartition,
-            readerSchemaId,
-            recordOffset);
-      } catch (Exception ex) {
-        // We might get an exception if we haven't persisted all the chunks for a given key. This
-        // can actually happen if the client seeks to the middle of a chunked record either by
-        // only tailing the records or through direct offset management. This is ok, we just won't
-        // return this record since this is a course grained approach we can drop it.
-        LOGGER.warn(
-            "Encountered error assembling chunked record, this can happen when seeking between chunked records. Skipping offset {} on topic {}",
-            recordOffset,
-            pubSubTopicPartition.getPubSubTopic().getName());
-      }
-    } else {
-      // this is a fully specified record, no need to buffer and assemble it, just decompress and deserialize it
-      try {
-        assembledRecord = processRecordBytes(
-            recordDeserializer.get(),
-            compressor,
-            keyBytes,
-            valueBytes,
-            pubSubTopicPartition,
-            readerSchemaId,
-            recordOffset);
-      } catch (Exception e) {
-        throw new RuntimeException(e);
-      }
-    }
-    // We only buffer one record at a time for a given partition. If we've made it this far
-    // we either just finished assembling a large record, or, didn't specify anything. So we'll clear
-    // the cache. Kafka might give duplicate delivery, but it won't give out of order delivery, so
-    // this is safe to do in all such contexts.
-    inMemoryStorageEngine.dropPartition(pubSubTopicPartition.getPartitionNumber());
-    return assembledRecord;
-  }
-
   // This function exists for wrappers of this class to be able to do any kind of preprocessing on the raw bytes of the
   // data consumed
   // in the change stream so as to avoid having to do any duplicate deserialization/serialization. Wrappers which depend
@@ -707,7 +605,17 @@ public class VeniceChangelogConsumerImpl<K, V> implements VeniceChangelogConsume
         readerSchemaId = this.schemaReader.getLatestValueSchemaId();
         deserializerCache = recordChangeEventDeserializerCache;
       }
-      assembledObject = bufferAndAssembleRecordChangeEvent(
+
+      // Select compressor. We'll only construct compressors for version topics so this will return null for
+      // events from change capture. This is fine as today they are not compressed.
+      VeniceCompressor compressor;
+      if (pubSubTopicPartition.getPubSubTopic().isVersionTopic()) {
+        compressor = compressorMap.get(pubSubTopicPartition.getPartitionNumber());
+      } else {
+        compressor = NO_OP_COMPRESSOR;
+      }
+
+      assembledObject = chunkAssembler.bufferAndAssembleRecord(
           pubSubTopicPartition,
           put.getSchemaId(),
           keyBytes,
@@ -716,9 +624,10 @@ public class VeniceChangelogConsumerImpl<K, V> implements VeniceChangelogConsume
           chunkingAdapter,
           deserializerProvider,
           deserializerCache,
-          readerSchemaId);
+          readerSchemaId,
+          compressor);
       if (assembledObject == null) {
-        // bufferAndAssembleRecordChangeEvent may have only buffered records and not returned anything yet because
+        // bufferAndAssembleRecord may have only buffered records and not returned anything yet because
         // it's waiting for more input. In this case, just return an empty optional for now.
         return Optional.empty();
       }
@@ -814,7 +723,7 @@ public class VeniceChangelogConsumerImpl<K, V> implements VeniceChangelogConsume
             .put(pubSubTopicPartition.getPartitionNumber(), versionSwap.getLocalHighWatermarks());
       }
       switchToNewTopic(newServingVersionTopic, topicSuffix, pubSubTopicPartition.getPartitionNumber());
-      inMemoryStorageEngine.drop();
+      chunkAssembler.clearInMemoryDB();
       return true;
     }
     return false;

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/utils/ChunkAssembler.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/utils/ChunkAssembler.java
@@ -71,7 +71,7 @@ public class ChunkAssembler {
           keyBytes,
           ValueRecord.create(schemaId, valueBytes.array()).serialize());
       try {
-        assembledRecord = deserializeAndDecompressBytes(
+        assembledRecord = decompressAndDeserialize(
             recordDeserializer.get(),
             compressor,
             RawBytesChunkingAdapter.INSTANCE.get(
@@ -99,7 +99,7 @@ public class ChunkAssembler {
     } else {
       // this is a fully specified record, no need to buffer and assemble it, just decompress and deserialize it
       try {
-        assembledRecord = deserializeAndDecompressBytes(recordDeserializer.get(), compressor, valueBytes);
+        assembledRecord = decompressAndDeserialize(recordDeserializer.get(), compressor, valueBytes);
       } catch (Exception e) {
         throw new RuntimeException(e);
       }
@@ -113,7 +113,7 @@ public class ChunkAssembler {
     return assembledRecord;
   }
 
-  protected <T> T deserializeAndDecompressBytes(
+  protected <T> T decompressAndDeserialize(
       RecordDeserializer<T> deserializer,
       VeniceCompressor compressor,
       ByteBuffer value) throws IOException {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/utils/ChunkAssembler.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/utils/ChunkAssembler.java
@@ -1,0 +1,150 @@
+package com.linkedin.davinci.utils;
+
+import com.linkedin.davinci.storage.chunking.AbstractAvroChunkingAdapter;
+import com.linkedin.davinci.storage.chunking.RawBytesChunkingAdapter;
+import com.linkedin.davinci.store.memory.InMemoryStorageEngine;
+import com.linkedin.davinci.store.record.ValueRecord;
+import com.linkedin.venice.compression.NoopCompressor;
+import com.linkedin.venice.compression.VeniceCompressor;
+import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
+import com.linkedin.venice.serialization.RawBytesStoreDeserializerCache;
+import com.linkedin.venice.serialization.StoreDeserializerCache;
+import com.linkedin.venice.serialization.avro.AvroProtocolDefinition;
+import com.linkedin.venice.serializer.RecordDeserializer;
+import com.linkedin.venice.utils.lazy.Lazy;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.HashMap;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+
+/*
+ * This class serves as a utility to deserialize and assemble chunks consumed from a Kafka topic 
+ */
+public class ChunkAssembler {
+  private static final Logger LOGGER = LogManager.getLogger(ChunkAssembler.class);
+
+  protected static final VeniceCompressor NO_OP_COMPRESSOR = new NoopCompressor();
+  protected final HashMap<Integer, VeniceCompressor> compressorMap = new HashMap<>();
+
+  protected final String storeName;
+
+  // This storage engine serves as a buffer for records which are chunked and have to be buffered before they can
+  // be returned to the client. We leverage the storageEngine interface here in order to take better advantage
+  // of the chunking and decompressing adapters that we've already built (which today are built around this interface)
+  // as chunked records are assembled we will eagerly evict all keys from the storage engine in order to keep the memory
+  // footprint as small as we can. We could use the object cache storage engine here in order to get LRU behavior
+  // but then that runs the risk of a parallel subscription having record chunks getting evicted before we have a chance
+  // to assemble them. So we rely on the simpler and concrete implementation as opposed to the abstraction in order
+  // to control and guarantee the behavior we're expecting.
+  protected final InMemoryStorageEngine inMemoryStorageEngine;
+
+  public ChunkAssembler(String storeName) {
+    this.storeName = storeName;
+
+    // The in memory storage engine only relies on the name of store and nothing else. We use an unversioned store name
+    // here in order to reduce confusion (as this storage engine can be used across version topics).
+    this.inMemoryStorageEngine = new InMemoryStorageEngine(storeName);
+    // disable noisy logs
+    this.inMemoryStorageEngine.suppressLogs(true);
+  }
+
+  public <T> T bufferAndAssembleRecord(
+      PubSubTopicPartition pubSubTopicPartition,
+      int schemaId,
+      byte[] keyBytes,
+      ByteBuffer valueBytes,
+      long recordOffset,
+      AbstractAvroChunkingAdapter<T> chunkingAdapter,
+      Lazy<RecordDeserializer<T>> recordDeserializer,
+      StoreDeserializerCache<T> deserializerCache,
+      int readerSchemaId,
+      VeniceCompressor compressor) {
+    T assembledRecord = null;
+
+    if (!inMemoryStorageEngine.containsPartition(pubSubTopicPartition.getPartitionNumber())) {
+      inMemoryStorageEngine.addStoragePartition(pubSubTopicPartition.getPartitionNumber());
+    }
+    // If this is a record chunk, store the chunk and return null for processing this record
+    if (schemaId == AvroProtocolDefinition.CHUNK.getCurrentProtocolVersion()) {
+      inMemoryStorageEngine.put(
+          pubSubTopicPartition.getPartitionNumber(),
+          keyBytes,
+          ValueRecord.create(schemaId, valueBytes.array()).serialize());
+      return null;
+    } else if (schemaId == AvroProtocolDefinition.CHUNKED_VALUE_MANIFEST.getCurrentProtocolVersion()) {
+      // This is the last value. Store it, and now read it from the in memory store as a fully assembled value
+      inMemoryStorageEngine.put(
+          pubSubTopicPartition.getPartitionNumber(),
+          keyBytes,
+          ValueRecord.create(schemaId, valueBytes.array()).serialize());
+      try {
+        assembledRecord = processRecordBytes(
+            recordDeserializer.get(),
+            compressor,
+            keyBytes,
+            RawBytesChunkingAdapter.INSTANCE.get(
+                inMemoryStorageEngine,
+                pubSubTopicPartition.getPartitionNumber(),
+                ByteBuffer.wrap(keyBytes),
+                false,
+                null,
+                null,
+                null,
+                readerSchemaId,
+                RawBytesStoreDeserializerCache.getInstance(),
+                compressor,
+                null),
+            pubSubTopicPartition,
+            readerSchemaId,
+            recordOffset);
+      } catch (Exception ex) {
+        // We might get an exception if we haven't persisted all the chunks for a given key. This
+        // can actually happen if the client seeks to the middle of a chunked record either by
+        // only tailing the records or through direct offset management. This is ok, we just won't
+        // return this record since this is a course grained approach we can drop it.
+        LOGGER.warn(
+            "Encountered error assembling chunked record, this can happen when seeking between chunked records. Skipping offset {} on topic {}",
+            recordOffset,
+            pubSubTopicPartition.getPubSubTopic().getName());
+      }
+    } else {
+      // this is a fully specified record, no need to buffer and assemble it, just decompress and deserialize it
+      try {
+        assembledRecord = processRecordBytes(
+            recordDeserializer.get(),
+            compressor,
+            keyBytes,
+            valueBytes,
+            pubSubTopicPartition,
+            readerSchemaId,
+            recordOffset);
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+    }
+
+    // We only buffer one record at a time for a given partition. If we've made it this far
+    // we either just finished assembling a large record, or, didn't specify anything. So we'll clear
+    // the cache. Kafka might give duplicate delivery, but it won't give out of order delivery, so
+    // this is safe to do in all such contexts.
+    inMemoryStorageEngine.dropPartition(pubSubTopicPartition.getPartitionNumber());
+    return assembledRecord;
+  }
+
+  protected <T> T processRecordBytes(
+      RecordDeserializer<T> deserializer,
+      VeniceCompressor compressor,
+      byte[] key,
+      ByteBuffer value,
+      PubSubTopicPartition partition,
+      int valueSchemaId,
+      long recordOffset) throws IOException {
+    return deserializer.deserialize(compressor.decompress(value));
+  }
+
+  public void clearInMemoryDB() {
+    inMemoryStorageEngine.drop();
+  }
+}

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/utils/ChunkAssembler.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/utils/ChunkAssembler.java
@@ -4,7 +4,6 @@ import com.linkedin.davinci.storage.chunking.AbstractAvroChunkingAdapter;
 import com.linkedin.davinci.storage.chunking.RawBytesChunkingAdapter;
 import com.linkedin.davinci.store.memory.InMemoryStorageEngine;
 import com.linkedin.davinci.store.record.ValueRecord;
-import com.linkedin.venice.compression.NoopCompressor;
 import com.linkedin.venice.compression.VeniceCompressor;
 import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
 import com.linkedin.venice.serialization.RawBytesStoreDeserializerCache;
@@ -14,7 +13,6 @@ import com.linkedin.venice.serializer.RecordDeserializer;
 import com.linkedin.venice.utils.lazy.Lazy;
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.util.HashMap;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -24,9 +22,6 @@ import org.apache.logging.log4j.Logger;
  */
 public class ChunkAssembler {
   private static final Logger LOGGER = LogManager.getLogger(ChunkAssembler.class);
-
-  protected static final VeniceCompressor NO_OP_COMPRESSOR = new NoopCompressor();
-  protected final HashMap<Integer, VeniceCompressor> compressorMap = new HashMap<>();
 
   protected final String storeName;
 

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/InternalLocalBootstrappingVeniceChangelogConsumerTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/InternalLocalBootstrappingVeniceChangelogConsumerTest.java
@@ -4,6 +4,11 @@ import static com.linkedin.venice.ConfigKeys.CLUSTER_NAME;
 import static com.linkedin.venice.ConfigKeys.KAFKA_BOOTSTRAP_SERVERS;
 import static com.linkedin.venice.ConfigKeys.ZOOKEEPER_ADDRESS;
 import static com.linkedin.venice.offsets.OffsetRecord.LOWEST_OFFSET;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyInt;
 import static org.mockito.Mockito.anyLong;
@@ -321,8 +326,15 @@ public class InternalLocalBootstrappingVeniceChangelogConsumerTest {
         new VeniceChangeCoordinate(TEST_TOPIC, new ApacheKafkaOffsetPosition(TEST_OFFSET_OLD), TEST_PARTITION_ID_0);
     bootstrapStateMap.put(TEST_PARTITION_ID_0, bootstrapState);
 
-    bootstrappingVeniceChangelogConsumer
-        .processRecordBytes(deserializer, compressor, key, value, partition, TEST_SCHEMA_ID, TEST_OFFSET_NEW);
+    ByteBuffer decompressedBytes = compressor.decompress(value);
+    bootstrappingVeniceChangelogConsumer.processRecordBytes(
+        decompressedBytes,
+        deserializer.deserialize(decompressedBytes),
+        key,
+        value,
+        partition,
+        TEST_SCHEMA_ID,
+        TEST_OFFSET_NEW);
 
     Assert.assertEquals(
         ((ApacheKafkaOffsetPosition) bootstrapStateMap.get(TEST_PARTITION_ID_0).currentPubSubPosition.getPosition())


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Summary
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

This moves chunk deserialization and assembly to a utility, so it can be used in different areas in da-vinci. This is because other areas face the issue of message sizes being too large to be sent under one message, so they need to be serialized and chunked.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

CI

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.