### PR TITLE
[dvc] Reduce the number of successful heartbeat info logs

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -1338,7 +1338,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
         processConsumerActions(store);
         checkLongRunningTaskState();
         checkIngestionProgress(store);
-        maybeSendIngestionHeartbeat(Optional.empty());
+        maybeSendIngestionHeartbeat();
       }
 
       List<CompletableFuture<Void>> shutdownFutures = new ArrayList<>(partitionConsumptionStateMap.size());
@@ -3801,9 +3801,11 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
     return kafkaValue.leaderMetadataFooter != null && kafkaValue.leaderMetadataFooter.upstreamOffset >= 0;
   }
 
-  protected void maybeSendIngestionHeartbeat(Optional<Set<String>> failedPartitions) {
-    // No op, heartbeat is only useful for L/F hybrid stores.
-  }
+  /**
+   * For L/F hybrid stores, the leader periodically writes a special SOS message to the RT topic.
+   * Check {@link LeaderFollowerStoreIngestionTask#maybeSendIngestionHeartbeat()} for more details.
+   */
+  protected abstract Set<String> maybeSendIngestionHeartbeat();
 
   /**
    * This function is checking the following conditions:

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -1338,7 +1338,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
         processConsumerActions(store);
         checkLongRunningTaskState();
         checkIngestionProgress(store);
-        maybeSendIngestionHeartbeat();
+        maybeSendIngestionHeartbeat(Optional.empty());
       }
 
       List<CompletableFuture<Void>> shutdownFutures = new ArrayList<>(partitionConsumptionStateMap.size());
@@ -3801,7 +3801,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
     return kafkaValue.leaderMetadataFooter != null && kafkaValue.leaderMetadataFooter.upstreamOffset >= 0;
   }
 
-  protected void maybeSendIngestionHeartbeat() {
+  protected void maybeSendIngestionHeartbeat(Optional<Set<String>> failedPartitions) {
     // No op, heartbeat is only useful for L/F hybrid stores.
   }
 


### PR DESCRIPTION
## Summary
Heartbeat successfully sent is logged per topic partitions leading to a lot of logs per minute if the server hosts a lot of topic partitions.
`maybeSendIngestionHeartbeat()` which sends HB to all RT partitions will generate either 1 error log if there are failures or 1 debug log if everything is successful.
`propagateHeartbeatFromUpstreamTopicToLocalVersionTopic()` which forwards HB from RT to VT sends 1 error/debug log per topic partition if it succeeds/fails respectively. 
Both are protected inside a redundant logging filter (1 min).

## How was this PR tested?
GH CI

## Does this PR introduce any user-facing changes?
- [x] No. You can skip the rest of this section.
- [] Yes. Make sure to explain your proposed changes and call out the behavior change.