### PR TITLE
[server] Add read quota enforcement buffer to server to align with router quota

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
@@ -115,6 +115,7 @@ import static com.linkedin.venice.ConfigKeys.SERVER_SOURCE_TOPIC_OFFSET_CHECK_IN
 import static com.linkedin.venice.ConfigKeys.SERVER_SSL_HANDSHAKE_QUEUE_CAPACITY;
 import static com.linkedin.venice.ConfigKeys.SERVER_SSL_HANDSHAKE_THREAD_POOL_SIZE;
 import static com.linkedin.venice.ConfigKeys.SERVER_STOP_CONSUMPTION_TIMEOUT_IN_SECONDS;
+import static com.linkedin.venice.ConfigKeys.SERVER_STORE_READ_QUOTA_BUFFER;
 import static com.linkedin.venice.ConfigKeys.SERVER_STORE_TO_EARLY_TERMINATION_THRESHOLD_MS_MAP;
 import static com.linkedin.venice.ConfigKeys.SERVER_STUCK_CONSUMER_REPAIR_ENABLED;
 import static com.linkedin.venice.ConfigKeys.SERVER_STUCK_CONSUMER_REPAIR_INTERVAL_SECOND;
@@ -296,6 +297,8 @@ public class VeniceServerConfig extends VeniceClusterConfig {
   private final long leakedResourceCleanUpIntervalInMS;
 
   private final boolean quotaEnforcementEnabled;
+
+  private final double readQuotaEnforcementBuffer;
 
   private final boolean serverCalculateQuotaUsageBasedOnPartitionsAssignmentEnabled;
 
@@ -533,6 +536,7 @@ public class VeniceServerConfig extends VeniceClusterConfig {
     leakedResourceCleanUpIntervalInMS =
         TimeUnit.MINUTES.toMillis(serverProperties.getLong(SERVER_LEAKED_RESOURCE_CLEAN_UP_INTERVAL_IN_MINUTES, 10));
     quotaEnforcementEnabled = serverProperties.getBoolean(SERVER_QUOTA_ENFORCEMENT_ENABLED, false);
+    readQuotaEnforcementBuffer = serverProperties.getDouble(SERVER_STORE_READ_QUOTA_BUFFER, 2);
     serverCalculateQuotaUsageBasedOnPartitionsAssignmentEnabled =
         serverProperties.getBoolean(SEVER_CALCULATE_QUOTA_USAGE_BASED_ON_PARTITIONS_ASSIGNMENT_ENABLED, true);
 
@@ -968,6 +972,10 @@ public class VeniceServerConfig extends VeniceClusterConfig {
 
   public boolean isQuotaEnforcementEnabled() {
     return quotaEnforcementEnabled;
+  }
+
+  public double getReadQuotaEnforcementBuffer() {
+    return readQuotaEnforcementBuffer;
   }
 
   public boolean isServerCalculateQuotaUsageBasedOnPartitionsAssignmentEnabled() {

--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -2084,4 +2084,10 @@ public class ConfigKeys {
       "server.dedicated.consumer.pool.for.aa.wc.leader.enabled";
   public static final String SERVER_DEDICATED_CONSUMER_POOL_SIZE_FOR_AA_WC_LEADER =
       "server.dedicated.consumer.pool.size.for.aa.wc.leader";
+
+  /**
+   * The equivalent to {@value ROUTER_PER_STORE_ROUTER_QUOTA_BUFFER} for server read quota. This is to align server
+   * the current solution for hot partitions for server and router read quota enforcement.
+   */
+  public static final String SERVER_STORE_READ_QUOTA_BUFFER = "server.store.read.quota.buffer";
 }

--- a/services/venice-server/src/main/java/com/linkedin/venice/listener/HttpChannelInitializer.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/listener/HttpChannelInitializer.java
@@ -130,7 +130,8 @@ public class HttpChannelInitializer extends ChannelInitializer<SocketChannel> {
           customizedViewRepository,
           nodeId,
           quotaUsageStats,
-          metricsRepository);
+          metricsRepository,
+          serverConfig.getReadQuotaEnforcementBuffer());
 
       // Token Bucket Stats for a store must be initialized when that store is created
       this.quotaTokenBucketStats = new AggServerQuotaTokenBucketStats(metricsRepository, quotaEnforcer);

--- a/services/venice-server/src/test/java/com/linkedin/venice/listener/ReadQuotaEnforcementHandlerTest.java
+++ b/services/venice-server/src/test/java/com/linkedin/venice/listener/ReadQuotaEnforcementHandlerTest.java
@@ -87,6 +87,7 @@ public class ReadQuotaEnforcementHandlerTest {
         thisNodeId,
         stats,
         metricsRepository,
+        1,
         clock);
     grpcQuotaEnforcer = new GrpcReadQuotaEnforcementHandler(quotaEnforcer);
     VeniceServerGrpcHandler mockNextHandler = mock(VeniceServerGrpcHandler.class);


### PR DESCRIPTION
## [server] Add read quota enforcement buffer to server to align with router quota

The current solution in router quota to accommodate traffic skew is via buffer factor. Similar skew can happen in sever quota but for different reasons. Example, we observed hot partition in some SN read quota enabled store where the difference between hot node and cold node traffic could be 2x. 

## How was this PR tested?
Integration and unit tests

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.