### PR TITLE
[server] Restore data partition in isolated process in Venice Server

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/IsolatedIngestionBackend.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/IsolatedIngestionBackend.java
@@ -390,15 +390,9 @@ public class IsolatedIngestionBackend extends DefaultIngestionBackend
       Runnable mainProcessCommandRunnable) {
     boolean isTopicPartitionHosted = isTopicPartitionHosted(topicName, partition);
 
-    // drop storage partition in main process if it does not exist
-    if (command == REMOVE_PARTITION && !isTopicPartitionHosted) {
-      mainProcessCommandRunnable.run();
-      return;
-    }
-
     do {
       if (isTopicPartitionHostedInMainProcess(topicName, partition)
-          || !isTopicPartitionHosted && command != START_CONSUMPTION) {
+          || (!isTopicPartitionHosted && command != START_CONSUMPTION && command != REMOVE_PARTITION)) {
         LOGGER.info("Executing command {} of topic: {}, partition: {} in main process.", command, topicName, partition);
         mainProcessCommandRunnable.run();
         return;

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/IsolatedIngestionBackend.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/IsolatedIngestionBackend.java
@@ -395,7 +395,9 @@ public class IsolatedIngestionBackend extends DefaultIngestionBackend
        * There are two cases where we execute the command to the main process:
        * (1) The main process metadata tells that the topic partition is hosted in main process.
        * (2) The topic partition has never been associated with the server, and the incoming command is not START_CONSUMPTION
-       * or REMOVE_PARTITION. For these two commands, it should by default be sent to isolated process.
+       * or REMOVE_PARTITION. For these two commands, it should by default be sent to isolated process. Here it needs to
+       * make sure topic partition subscription request has never been issued to the server, so the check "isTopicPartitionHosted"
+       * should be false in this case.
        */
       if (isTopicPartitionHostedInMainProcess(topicName, partition)
           || (!isTopicPartitionHosted && command != START_CONSUMPTION && command != REMOVE_PARTITION)) {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/IsolatedIngestionBackend.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/IsolatedIngestionBackend.java
@@ -391,6 +391,12 @@ public class IsolatedIngestionBackend extends DefaultIngestionBackend
     boolean isTopicPartitionHosted = isTopicPartitionHosted(topicName, partition);
 
     do {
+      /**
+       * There are two cases where we execute the command to the main process:
+       * (1) The main process metadata tells that the topic partition is hosted in main process.
+       * (2) The topic partition has never been associated with the server, and the incoming command is not START_CONSUMPTION
+       * or REMOVE_PARTITION. For these two commands, it should by default be sent to isolated process.
+       */
       if (isTopicPartitionHostedInMainProcess(topicName, partition)
           || (!isTopicPartitionHosted && command != START_CONSUMPTION && command != REMOVE_PARTITION)) {
         LOGGER.info("Executing command {} of topic: {}, partition: {} in main process.", command, topicName, partition);

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/isolated/IsolatedIngestionServer.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/isolated/IsolatedIngestionServer.java
@@ -735,7 +735,7 @@ public class IsolatedIngestionServer extends AbstractVeniceService {
         storeVersionStateSerializer,
         partitionStateSerializer,
         storeRepository,
-        false,
+        !isDaVinciClient,
         true);
     storageService.start();
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/isolated/IsolatedIngestionServer.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/isolated/IsolatedIngestionServer.java
@@ -715,19 +715,22 @@ public class IsolatedIngestionServer extends AbstractVeniceService {
         metricsRepository,
         storeRepository,
         serverConfig.isUnregisterMetricForDeletedStoreEnabled());
-    /**
-     * The reason of not to restore the data partitions during initialization of storage service is:
-     * 1. During first fresh start up with no data on disk, we don't need to restore anything
-     * 2. During fresh start up with data on disk (aka bootstrap), we will receive messages to subscribe to the partition
-     * and it will re-open the partition on demand.
-     * 3. During crash recovery restart, partitions that are already ingestion will be opened by parent process and we
-     * should not try to open it. The remaining ingestion tasks will open the storage engines.
-     * Also, we don't need to restore metadata partition here, as all subscribe requests sent to forked process will
-     * automatically open the metadata partitions. Also, during Da Vinci bootstrap, main process will need to open the
-     * metadata partition of storage engines in order to perform full cleanup of stale versions.
-     */
     boolean isDaVinciClient = veniceMetadataRepositoryBuilder.isDaVinciClient();
 
+    /**
+     * For isolated ingestion server, we always restore metadata partition, but we will only restore data partition in server,
+     * not Da Vinci.
+     * The reason of not to restore the data partitions during initialization of storage service in DVC is:
+     * 1. During fresh start up with data on disk (aka bootstrap), we will receive messages to subscribe to the partition
+     * and it will re-open the partition on demand.
+     * 2. During crash recovery restart, partitions that are already ingestion will be opened by parent process and we
+     * should not try to open it. The remaining ingestion tasks will open the storage engines.
+     * 
+     * The reason to restore data partitions during initialization of storage service in server is:
+     * 1. Helix can issue OFFLINE->DROPPED state transition for stale partition in anytime, including server restart time.
+     * If data partition is not restored here (as well as the main process), it will never be dropped so the RocksDB storage
+     * will be leaking.
+     */
     storageService = new StorageService(
         configLoader,
         storageEngineStats,

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/isolated/IsolatedIngestionServer.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/isolated/IsolatedIngestionServer.java
@@ -472,7 +472,7 @@ public class IsolatedIngestionServer extends AbstractVeniceService {
     return subscription.get();
   }
 
-  public void maybeSubscribeNewResource(String topicName, int partition) {
+  public void maybeInitializeResourceHostingMetadata(String topicName, int partition) {
     getTopicPartitionSubscriptionMap().computeIfAbsent(topicName, s -> new VeniceConcurrentHashMap<>())
         .computeIfAbsent(partition, p -> new AtomicBoolean(true));
   }
@@ -725,7 +725,7 @@ public class IsolatedIngestionServer extends AbstractVeniceService {
      * and it will re-open the partition on demand.
      * 2. During crash recovery restart, partitions that are already ingestion will be opened by parent process and we
      * should not try to open it. The remaining ingestion tasks will open the storage engines.
-     * 
+     *
      * The reason to restore data partitions during initialization of storage service in server is:
      * 1. Helix can issue OFFLINE->DROPPED state transition for stale partition in anytime, including server restart time.
      * If data partition is not restored here (as well as the main process), it will never be dropped so the RocksDB storage

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/isolated/IsolatedIngestionServerHandler.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/isolated/IsolatedIngestionServerHandler.java
@@ -162,7 +162,7 @@ public class IsolatedIngestionServerHandler extends SimpleChannelInboundHandler<
       storeConfig.setRestoreDataPartitions(false);
       switch (ingestionCommandType) {
         case START_CONSUMPTION:
-          isolatedIngestionServer.maybeSubscribeNewResource(topicName, partitionId);
+          isolatedIngestionServer.maybeInitializeResourceHostingMetadata(topicName, partitionId);
           validateAndExecuteCommand(ingestionCommandType, report, () -> {
             ReadOnlyStoreRepository storeRepository = isolatedIngestionServer.getStoreRepository();
             // For subscription based store repository, we will need to subscribe to the store explicitly.
@@ -206,7 +206,7 @@ public class IsolatedIngestionServerHandler extends SimpleChannelInboundHandler<
            * topic partition has never been associated with the server. This is needed as data partition is by default
            * restored in the isolated process, and thus it should be able to be removed by Helix command.
            */
-          isolatedIngestionServer.maybeSubscribeNewResource(topicName, partitionId);
+          isolatedIngestionServer.maybeInitializeResourceHostingMetadata(topicName, partitionId);
           validateAndExecuteCommand(ingestionCommandType, report, () -> {
             /**
              * Here we do not allow storage service to clean up "empty" storage engine. When ingestion isolation is turned on,

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/isolated/IsolatedIngestionServerHandler.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/isolated/IsolatedIngestionServerHandler.java
@@ -201,6 +201,11 @@ public class IsolatedIngestionServerHandler extends SimpleChannelInboundHandler<
           isolatedIngestionServer.cleanupTopicState(topicName);
           break;
         case REMOVE_PARTITION:
+          /**
+           * For this command, we will try to initialize the isolated process metadata for the topic partition, if the
+           * topic partition has never been associated with the server. This is needed as data partition is by default
+           * restored in the isolated process, and thus it should be able to be removed by Helix command.
+           */
           isolatedIngestionServer.maybeSubscribeNewResource(topicName, partitionId);
           validateAndExecuteCommand(ingestionCommandType, report, () -> {
             /**

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/isolated/IsolatedIngestionServerHandler.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/isolated/IsolatedIngestionServerHandler.java
@@ -201,6 +201,7 @@ public class IsolatedIngestionServerHandler extends SimpleChannelInboundHandler<
           isolatedIngestionServer.cleanupTopicState(topicName);
           break;
         case REMOVE_PARTITION:
+          isolatedIngestionServer.maybeSubscribeNewResource(topicName, partitionId);
           validateAndExecuteCommand(ingestionCommandType, report, () -> {
             /**
              * Here we do not allow storage service to clean up "empty" storage engine. When ingestion isolation is turned on,


### PR DESCRIPTION
## [server] Restore data partition in isolated process in Venice Server

This PR tries to address the issue of cleaning up data correctly for ingestion isolation enabled server.
Originally, we observed that certain data partition is not deleted when a OFFLINE -> DROPPED message is issued for stale version upon server restart. The message is not executed as we did not restore all the data partitions upon server start in any of the processes. 
The first fix we implemented is in  #617 , where we added a clean up service in isolated process. However, it is not correct, as the clean up service tries to remove partitions opened in the forked process, which is metadata partition only. This leaves the data partitions still unopened and lingering forever.

This PR tries to fix it thoroughly by adjusting the data restore logic for II. It will by default restore everything in II process. For those partitions to receive OFFLINE->DROPPED message, it will be sent to isolated process and get executed. For old storage engines, it shall also be opened and should be cleaned up eventually, as restore metadata partition will recreate the metadata partition, even if it is deleted before.

## How was this PR tested?
Existing integration tests.
Need to consider adding a new unit test.

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.