### PR TITLE
[test] Fix flaky test IngestionHeartBeatTest#testIngestionHeartBeat

### DIFF
--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/ingestionHeartbeat/IngestionHeartBeatTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/ingestionHeartbeat/IngestionHeartBeatTest.java
@@ -1,6 +1,5 @@
 package com.linkedin.venice.ingestionHeartbeat;
 
-import static com.linkedin.venice.ConfigKeys.SERVER_PROMOTION_TO_LEADER_REPLICA_DELAY_SECONDS;
 import static com.linkedin.venice.hadoop.VenicePushJob.DEFAULT_KEY_FIELD_PROP;
 import static com.linkedin.venice.hadoop.VenicePushJob.INCREMENTAL_PUSH;
 import static com.linkedin.venice.message.KafkaKey.HEART_BEAT;
@@ -84,7 +83,6 @@ public class IngestionHeartBeatTest {
   @BeforeClass(alwaysRun = true)
   public void setUp() {
     Properties serverProperties = new Properties();
-    serverProperties.put(SERVER_PROMOTION_TO_LEADER_REPLICA_DELAY_SECONDS, 1L);
     Properties controllerProps = new Properties();
     controllerProps.put(ConfigKeys.CONTROLLER_AUTO_MATERIALIZE_META_SYSTEM_STORE, false);
     this.multiRegionMultiClusterWrapper = ServiceFactory.getVeniceTwoLayerMultiRegionMultiClusterWrapper(
@@ -130,7 +128,7 @@ public class IngestionHeartBeatTest {
               .setCompressionStrategy(CompressionStrategy.NO_OP)
               .setIncrementalPushEnabled(true)
               .setHybridRewindSeconds(500L)
-              .setHybridOffsetLagThreshold(0L)
+              .setHybridOffsetLagThreshold(10L)
               .setPartitionCount(2)
               .setReplicationFactor(2)
               .setNativeReplicationEnabled(true)


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## [test] Fix flaky test IngestionHeartBeatTest#testIngestionHeartBeat
This PR tries to fix the flaky test. 
The cause is: in some cases: when evaluating the lag, the standby replica might already know the leader topic and get the lag == 1, instead of negative max long. This is calculated by local VT end offset - last processed VT. 
In the current test setup, inc push is always enabled in the test, in the non-aggregate mode, it will be subscribing to parent RT, and will not consume HB. Relaxing the requirement is needed for non-AA case.

In the future, let's consider blocking the non-agg mode + inc push
Also, we don't need to test with NR = T / F as NR is always true in prod env for long time.
## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.