### PR TITLE
[fc][test] clean up useStreamingBatchGetAsDefault and associated tests

### DIFF
--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/ClientConfig.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/ClientConfig.java
@@ -76,14 +76,6 @@ public class ClientConfig<K, V, T extends SpecificRecord> {
   private final StoreMetadataFetchMode storeMetadataFetchMode;
   private final D2Client d2Client;
   private final String clusterDiscoveryD2Service;
-  /**
-   * The choice of implementation for batch get: single get or streamingBatchget. The first version of batchGet in
-   * FC used single get in a loop to support a customer request for two-key batch-get. This config allows switching
-   * between the two implementations. The current default is single get based batchGet, but once the streamingBatchget
-   * is validated, the default should be changed to streamingBatchget based batchGet, or probably remove the single
-   * get based batchGet support.
-   */
-  private final boolean useStreamingBatchGetAsDefault;
   private final boolean useGrpc;
   /**
    * This is a temporary solution to support gRPC with Venice, we will replace this with retrieving information about
@@ -126,7 +118,6 @@ public class ClientConfig<K, V, T extends SpecificRecord> {
       StoreMetadataFetchMode storeMetadataFetchMode,
       D2Client d2Client,
       String clusterDiscoveryD2Service,
-      boolean useStreamingBatchGetAsDefault,
       boolean useGrpc,
       GrpcClientConfig grpcClientConfig,
       boolean projectionFieldValidation) {
@@ -255,12 +246,6 @@ public class ClientConfig<K, V, T extends SpecificRecord> {
     if (clientRoutingStrategyType == ClientRoutingStrategyType.HELIX_ASSISTED
         && this.storeMetadataFetchMode != StoreMetadataFetchMode.SERVER_BASED_METADATA) {
       throw new VeniceClientException("Helix assisted routing is only available with server based metadata enabled");
-    }
-    this.useStreamingBatchGetAsDefault = useStreamingBatchGetAsDefault;
-    if (this.useStreamingBatchGetAsDefault) {
-      LOGGER.info("Batch get will use streaming batch get implementation");
-    } else {
-      LOGGER.warn("Deprecated: Batch get will use single get implementation");
     }
 
     this.useGrpc = useGrpc;
@@ -394,10 +379,6 @@ public class ClientConfig<K, V, T extends SpecificRecord> {
     return this.clusterDiscoveryD2Service;
   }
 
-  public boolean useStreamingBatchGetAsDefault() {
-    return this.useStreamingBatchGetAsDefault;
-  }
-
   public boolean useGrpc() {
     return useGrpc;
   }
@@ -459,7 +440,6 @@ public class ClientConfig<K, V, T extends SpecificRecord> {
     private StoreMetadataFetchMode storeMetadataFetchMode = StoreMetadataFetchMode.DA_VINCI_CLIENT_BASED_METADATA;
     private D2Client d2Client;
     private String clusterDiscoveryD2Service;
-    private boolean useStreamingBatchGetAsDefault = false;
     private boolean useGrpc = false;
     private GrpcClientConfig grpcClientConfig = null;
 
@@ -632,11 +612,6 @@ public class ClientConfig<K, V, T extends SpecificRecord> {
       return this;
     }
 
-    public ClientConfigBuilder<K, V, T> setUseStreamingBatchGetAsDefault(boolean useStreamingBatchGetAsDefault) {
-      this.useStreamingBatchGetAsDefault = useStreamingBatchGetAsDefault;
-      return this;
-    }
-
     public ClientConfigBuilder<K, V, T> setUseGrpc(boolean useGrpc) {
       this.useGrpc = useGrpc;
       return this;
@@ -684,7 +659,6 @@ public class ClientConfig<K, V, T extends SpecificRecord> {
           .setStoreMetadataFetchMode(storeMetadataFetchMode)
           .setD2Client(d2Client)
           .setClusterDiscoveryD2Service(clusterDiscoveryD2Service)
-          .setUseStreamingBatchGetAsDefault(useStreamingBatchGetAsDefault)
           .setUseGrpc(useGrpc)
           .setGrpcClientConfig(grpcClientConfig)
           .setProjectionFieldValidationEnabled(projectionFieldValidation);
@@ -723,7 +697,6 @@ public class ClientConfig<K, V, T extends SpecificRecord> {
           storeMetadataFetchMode,
           d2Client,
           clusterDiscoveryD2Service,
-          useStreamingBatchGetAsDefault,
           useGrpc,
           grpcClientConfig,
           projectionFieldValidation);

--- a/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/ClientConfigTest.java
+++ b/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/ClientConfigTest.java
@@ -87,19 +87,4 @@ public class ClientConfigTest {
         .setLongTailRetryThresholdForSingleGetInMicroSeconds(1000)
         .build();
   }
-
-  /** Setting useStreamingBatchGetAsDefault, no exceptions thrown */
-  @Test
-  public void testUseStreamingBatchGetAsDefault() {
-    ClientConfig.ClientConfigBuilder clientConfigBuilder = getClientConfigWithMinimumRequiredInputs();
-    ClientConfig clientConfig = clientConfigBuilder.build();
-
-    if (clientConfig.useStreamingBatchGetAsDefault()) {
-      // should be disabled by default
-      throw new VeniceClientException("Batch get using streaming batch get should be disabled by default");
-    }
-
-    clientConfigBuilder.setUseStreamingBatchGetAsDefault(true);
-    clientConfigBuilder.build();
-  }
 }

--- a/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/DispatchingAvroGenericStoreClientTest.java
+++ b/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/DispatchingAvroGenericStoreClientTest.java
@@ -125,20 +125,14 @@ public class DispatchingAvroGenericStoreClientTest {
   }
 
   private void setUpClient() throws InterruptedException {
-    setUpClient(false);
-  }
-
-  private void setUpClient(boolean useStreamingBatchGetAsDefault) throws InterruptedException {
-    setUpClient(useStreamingBatchGetAsDefault, false, false, false);
+    setUpClient(false, false, false);
   }
 
   private void setUpClient(
-      boolean useStreamingBatchGetAsDefault,
       boolean transportClientThrowsException,
       boolean transportClientThrowsPartialException,
       boolean transportClientPartialIncomplete) throws InterruptedException {
     setUpClient(
-        useStreamingBatchGetAsDefault,
         transportClientThrowsException,
         transportClientThrowsPartialException,
         transportClientPartialIncomplete,
@@ -147,7 +141,6 @@ public class DispatchingAvroGenericStoreClientTest {
   }
 
   /**
-   * @param useStreamingBatchGetAsDefault use streaming batch get or single get based batch get
    * @param transportClientThrowsException throws exception for both the keys
    * @param transportClientThrowsPartialException responds correct value for the 1st key and throws exception for the 2nd key
    * @param transportClientPartialIncomplete responds correct value for the 1st key and not do anything for 2nd key
@@ -156,16 +149,14 @@ public class DispatchingAvroGenericStoreClientTest {
    * @param routingLeakedRequestCleanupThresholdMS time to set routingLeakedRequestCleanupThresholdMS client config.
    */
   private void setUpClient(
-      boolean useStreamingBatchGetAsDefault,
       boolean transportClientThrowsException,
-      boolean transportClientThrowsPartialException, // only applicable for useStreamingBatchGetAsDefault
-      boolean transportClientPartialIncomplete, // only applicable for useStreamingBatchGetAsDefault
+      boolean transportClientThrowsPartialException,
+      boolean transportClientPartialIncomplete,
       boolean mockTransportClient,
       long routingLeakedRequestCleanupThresholdMS) throws InterruptedException {
 
     clientConfigBuilder = new ClientConfig.ClientConfigBuilder<>().setStoreName(STORE_NAME)
         .setR2Client(getMockR2Client(false))
-        .setUseStreamingBatchGetAsDefault(useStreamingBatchGetAsDefault)
         .setMetadataRefreshIntervalInSeconds(1L)
         .setRoutingLeakedRequestCleanupThresholdMS(routingLeakedRequestCleanupThresholdMS)
         .setRoutingPendingRequestCounterInstanceBlockThreshold(1);
@@ -326,12 +317,9 @@ public class DispatchingAvroGenericStoreClientTest {
       BatchGetRequestContext batchGetRequestContext,
       boolean batchGet,
       boolean computeRequest,
-      String metricPrefix,
-      boolean useStreamingBatchGetAsDefault) {
+      String metricPrefix) {
     if (batchGet) {
-      if (useStreamingBatchGetAsDefault) {
-        assertNull(batchGetRequestContext.retryContext);
-      } // else: locally created single get context will be used internally and not batchGetRequestContext
+      assertNull(batchGetRequestContext.retryContext);
     } else if (computeRequest) {
       // Do nothing since we don't have the ComputeRequestContext to test
     } else {
@@ -346,7 +334,7 @@ public class DispatchingAvroGenericStoreClientTest {
   }
 
   private void validateSingleGetMetrics(GetRequestContext getRequestContext, boolean healthyRequest) {
-    validateMetrics(getRequestContext, null, healthyRequest, false, RequestType.SINGLE_GET, false, false, 1, 0);
+    validateMetrics(getRequestContext, null, healthyRequest, false, RequestType.SINGLE_GET, false, 1, 0);
   }
 
   private void validateMultiGetMetrics(
@@ -354,12 +342,8 @@ public class DispatchingAvroGenericStoreClientTest {
       boolean healthyRequest,
       boolean partialHealthyRequest,
       RequestType requestType,
-      boolean useStreamingBatchGetAsDefault,
       boolean noAvailableReplicas,
       int numKeys) {
-    if (requestType == RequestType.MULTI_GET_STREAMING) {
-      useStreamingBatchGetAsDefault = true;
-    }
 
     validateMetrics(
         null,
@@ -367,7 +351,6 @@ public class DispatchingAvroGenericStoreClientTest {
         healthyRequest,
         partialHealthyRequest,
         requestType,
-        useStreamingBatchGetAsDefault,
         noAvailableReplicas,
         numKeys,
         2);
@@ -378,20 +361,15 @@ public class DispatchingAvroGenericStoreClientTest {
       boolean healthyRequest,
       boolean partialHealthyRequest,
       RequestType requestType,
-      boolean useStreamingBatchGetAsDefault,
       boolean noAvailableReplicas,
       int numKeys,
       double numBlockedReplicas) {
-    if (requestType == RequestType.MULTI_GET_STREAMING) {
-      useStreamingBatchGetAsDefault = true;
-    }
     validateMetrics(
         null,
         batchGetRequestContext,
         healthyRequest,
         partialHealthyRequest,
         requestType,
-        useStreamingBatchGetAsDefault,
         noAvailableReplicas,
         numKeys,
         numBlockedReplicas);
@@ -410,7 +388,6 @@ public class DispatchingAvroGenericStoreClientTest {
         healthyRequest,
         partialHealthyRequest,
         requestType,
-        true,
         noAvailableReplicas,
         numKeys,
         numBlockedReplicas);
@@ -422,11 +399,10 @@ public class DispatchingAvroGenericStoreClientTest {
       boolean healthyRequest,
       boolean partialHealthyRequest,
       RequestType requestType,
-      boolean useStreamingBatchGetAsDefault, // use streaming implementation for batchGet
       boolean noAvailableReplicas,
       int numKeys,
       double numBlockedReplicas) {
-    String metricPrefix = ClientTestUtils.getMetricPrefix(STORE_NAME, requestType, useStreamingBatchGetAsDefault);
+    String metricPrefix = ClientTestUtils.getMetricPrefix(STORE_NAME, requestType);
     boolean batchGet = requestType == RequestType.MULTI_GET || requestType == RequestType.MULTI_GET_STREAMING;
     boolean computeRequest = requestType == RequestType.COMPUTE || requestType == RequestType.COMPUTE_STREAMING;
 
@@ -448,9 +424,7 @@ public class DispatchingAvroGenericStoreClientTest {
       assertFalse(metrics.get(metricPrefix + "unhealthy_request_latency.Avg").value() > 0);
       assertEquals(metrics.get(metricPrefix + "success_request_key_count.Max").value(), successKeyCount);
       if (batchGet) {
-        if (useStreamingBatchGetAsDefault) {
-          assertEquals(batchGetRequestContext.successRequestKeyCount.get(), (int) successKeyCount);
-        } // else: locally created single get context will be used internally and not batchGetRequestContext
+        assertEquals(batchGetRequestContext.successRequestKeyCount.get(), (int) successKeyCount);
       } else if (computeRequest) {
         // Do nothing since we don't have the ComputeRequestContext to test
       } else {
@@ -464,9 +438,7 @@ public class DispatchingAvroGenericStoreClientTest {
       // as partial healthy request is still considered unhealthy, not incrementing the below metric
       assertFalse(metrics.get(metricPrefix + "success_request_key_count.Max").value() > 0);
       if (batchGet) {
-        if (useStreamingBatchGetAsDefault) {
-          assertEquals(batchGetRequestContext.successRequestKeyCount.get(), (int) successKeyCount);
-        } // else: locally created single get context will be used internally and not batchGetRequestContext
+        assertEquals(batchGetRequestContext.successRequestKeyCount.get(), (int) successKeyCount);
       } else if (computeRequest) {
         // Do nothing since we don't have the ComputeRequestContext to test
       } else {
@@ -479,9 +451,7 @@ public class DispatchingAvroGenericStoreClientTest {
       assertTrue(metrics.get(metricPrefix + "unhealthy_request_latency.Avg").value() > 0);
       assertFalse(metrics.get(metricPrefix + "success_request_key_count.Max").value() > 0);
       if (batchGet) {
-        if (useStreamingBatchGetAsDefault) {
-          assertEquals(batchGetRequestContext.successRequestKeyCount.get(), 0);
-        } // else: locally created single get context will be used internally and not batchGetRequestContext
+        assertEquals(batchGetRequestContext.successRequestKeyCount.get(), 0);
       } else if (computeRequest) {
         // Do nothing since we don't have the ComputeRequestContext to test
       } else {
@@ -506,9 +476,7 @@ public class DispatchingAvroGenericStoreClientTest {
       });
       assertEquals(metrics.get(routeMetricsPrefix + "--blocked_instance_count.Max").value(), numBlockedReplicas);
       if (batchGet) {
-        if (useStreamingBatchGetAsDefault) {
-          assertTrue(batchGetRequestContext.noAvailableReplica);
-        } // else: locally created single get context will be used internally and not batchGetRequestContext
+        assertTrue(batchGetRequestContext.noAvailableReplica);
       } else if (computeRequest) {
         // Do nothing since we don't have the ComputeRequestContext to test
       } else {
@@ -517,9 +485,7 @@ public class DispatchingAvroGenericStoreClientTest {
     } else {
       assertFalse(metrics.get(metricPrefix + "no_available_replica_request_count.OccurrenceRate").value() > 0);
       if (batchGet) {
-        if (useStreamingBatchGetAsDefault) {
-          assertFalse(batchGetRequestContext.noAvailableReplica);
-        } // else: locally created single get context will be used internally and not batchGetRequestContext
+        assertFalse(batchGetRequestContext.noAvailableReplica);
       } else if (computeRequest) {
         // Do nothing since we don't have the ComputeRequestContext to test
       } else {
@@ -527,13 +493,7 @@ public class DispatchingAvroGenericStoreClientTest {
       }
     }
 
-    validateRetryMetrics(
-        getRequestContext,
-        batchGetRequestContext,
-        batchGet,
-        computeRequest,
-        metricPrefix,
-        useStreamingBatchGetAsDefault);
+    validateRetryMetrics(getRequestContext, batchGetRequestContext, batchGet, computeRequest, metricPrefix);
   }
 
   private byte[] serializeBatchGetResponse(Set<String> Keys) {
@@ -585,7 +545,7 @@ public class DispatchingAvroGenericStoreClientTest {
   public void testGetWithExceptionFromTransportLayer() throws IOException {
     GetRequestContext getRequestContext = null;
     try {
-      setUpClient(false, true, false, false);
+      setUpClient(true, false, false);
       getRequestContext = new GetRequestContext(false);
       statsAvroGenericStoreClient.get(getRequestContext, "test_key").get().toString();
       fail();
@@ -601,7 +561,7 @@ public class DispatchingAvroGenericStoreClientTest {
   public void testGetToUnreachableClient() throws IOException {
     GetRequestContext getRequestContext = null;
     try {
-      setUpClient(false, false, false, false, false, 2 * Time.MS_PER_SECOND);
+      setUpClient(false, false, false, false, 2 * Time.MS_PER_SECOND);
       getRequestContext = new GetRequestContext(false);
       statsAvroGenericStoreClient.get(getRequestContext, "test_key").get();
       fail();
@@ -613,34 +573,18 @@ public class DispatchingAvroGenericStoreClientTest {
     }
   }
 
-  @Test(dataProvider = "True-and-False", dataProviderClass = DataProviderUtils.class, timeOut = TEST_TIMEOUT)
-  public void testBatchGet(boolean useStreamingBatchGetAsDefault)
-      throws ExecutionException, InterruptedException, IOException {
+  @Test(timeOut = TEST_TIMEOUT)
+  public void testBatchGet() throws ExecutionException, InterruptedException, IOException {
     try {
-      setUpClient(useStreamingBatchGetAsDefault);
+      setUpClient();
       BatchGetRequestContext batchGetRequestContext = new BatchGetRequestContext<>(BATCH_GET_KEYS.size(), false);
       Map<String, GenericRecord> value =
           (Map<String, GenericRecord>) statsAvroGenericStoreClient.batchGet(batchGetRequestContext, BATCH_GET_KEYS)
               .get();
-      if (useStreamingBatchGetAsDefault) {
-        BATCH_GET_KEYS.stream().forEach(key -> {
-          assertTrue(BATCH_GET_VALUE_RESPONSE.get(key).equals(value.get(key)));
-        });
-      } else {
-        // uses single get, so based on the mock, any key will return SINGLE_GET_VALUE_RESPONSE as the value.
-        // also: batchGetRequestContext is not usable anymore
-        BATCH_GET_KEYS.stream().forEach(key -> {
-          assertEquals(SINGLE_GET_VALUE_RESPONSE, value.get(key));
-        });
-      }
-      validateMultiGetMetrics(
-          batchGetRequestContext,
-          true,
-          false,
-          RequestType.MULTI_GET,
-          useStreamingBatchGetAsDefault,
-          false,
-          useStreamingBatchGetAsDefault ? 2 : 1);
+      BATCH_GET_KEYS.stream().forEach(key -> {
+        assertTrue(BATCH_GET_VALUE_RESPONSE.get(key).equals(value.get(key)));
+      });
+      validateMultiGetMetrics(batchGetRequestContext, true, false, RequestType.MULTI_GET, false, 2);
     } finally {
       tearDown();
     }
@@ -650,7 +594,7 @@ public class DispatchingAvroGenericStoreClientTest {
   public void testBatchGetWithEmptyKeys(boolean streamingBatchGet)
       throws ExecutionException, InterruptedException, IOException {
     try {
-      setUpClient(true);
+      setUpClient();
       BatchGetRequestContext batchGetRequestContext;
       Map<String, GenericRecord> value;
       if (streamingBatchGet) {
@@ -677,11 +621,10 @@ public class DispatchingAvroGenericStoreClientTest {
     }
   }
 
-  @Test(dataProvider = "True-and-False", dataProviderClass = DataProviderUtils.class, timeOut = TEST_TIMEOUT, expectedExceptions = VeniceKeyCountLimitException.class)
-  public void testBatchGetWithMoreKeysThanMaxSize(boolean useStreamingBatchGetAsDefault)
-      throws ExecutionException, InterruptedException, IOException {
+  @Test(timeOut = TEST_TIMEOUT, expectedExceptions = VeniceKeyCountLimitException.class)
+  public void testBatchGetWithMoreKeysThanMaxSize() throws ExecutionException, InterruptedException, IOException {
     try {
-      setUpClient(useStreamingBatchGetAsDefault);
+      setUpClient();
       int numKeysInRequest = ClientConfig.MAX_ALLOWED_KEY_COUNT_IN_BATCHGET + 1;
       Set<String> keys = new HashSet<>(numKeysInRequest);
       for (int i = 0; i < numKeysInRequest; ++i) {
@@ -694,74 +637,35 @@ public class DispatchingAvroGenericStoreClientTest {
     }
   }
 
-  @Test(dataProvider = "True-and-False", dataProviderClass = DataProviderUtils.class, timeOut = TEST_TIMEOUT)
-  public void testBatchGetWithExceptionFromTransportLayer(boolean useStreamingBatchGetAsDefault) throws IOException {
+  @Test(timeOut = TEST_TIMEOUT)
+  public void testBatchGetWithExceptionFromTransportLayer() throws IOException {
     BatchGetRequestContext batchGetRequestContext = null;
     try {
-      setUpClient(useStreamingBatchGetAsDefault, true, false, false);
+      setUpClient(true, false, false);
       batchGetRequestContext = new BatchGetRequestContext<>(BATCH_GET_KEYS.size(), false);
       statsAvroGenericStoreClient.batchGet(batchGetRequestContext, BATCH_GET_KEYS).get();
       fail();
     } catch (Exception e) {
-      if (useStreamingBatchGetAsDefault) {
-        assertTrue(e.getMessage().endsWith("At least one route did not complete"), e.getMessage());
-      } else {
-        assertTrue(e.getMessage().endsWith("Exception for client to return 503"), e.getMessage());
-      }
-      validateMultiGetMetrics(
-          batchGetRequestContext,
-          false,
-          false,
-          RequestType.MULTI_GET,
-          useStreamingBatchGetAsDefault,
-          false,
-          useStreamingBatchGetAsDefault ? 2 : 1);
+      assertTrue(e.getMessage().endsWith("At least one route did not complete"), e.getMessage());
+      validateMultiGetMetrics(batchGetRequestContext, false, false, RequestType.MULTI_GET, false, 2);
     } finally {
       tearDown();
     }
   }
 
-  @Test(dataProvider = "True-and-False", dataProviderClass = DataProviderUtils.class, timeOut = TEST_TIMEOUT)
-  public void testBatchGetWithExceptionFromTransportLayerForOneRoute(boolean useStreamingBatchGetAsDefault)
-      throws IOException {
+  @Test(timeOut = TEST_TIMEOUT)
+  public void testBatchGetWithExceptionFromTransportLayerForOneRoute() throws IOException {
     BatchGetRequestContext batchGetRequestContext = null;
     try {
-      setUpClient(useStreamingBatchGetAsDefault, false, true, false);
+      setUpClient(false, true, false);
       batchGetRequestContext = new BatchGetRequestContext<>(BATCH_GET_KEYS.size(), false);
       Map<String, GenericRecord> value =
           (Map<String, GenericRecord>) statsAvroGenericStoreClient.batchGet(batchGetRequestContext, BATCH_GET_KEYS)
               .get();
-      if (useStreamingBatchGetAsDefault) {
-        fail();
-      } else {
-        // uses single get, so based on the mock, any key will return SINGLE_GET_VALUE_RESPONSE as the value.
-        // also: batchGetRequestContext is not usable anymore
-        BATCH_GET_KEYS.stream().forEach(key -> {
-          assertEquals(SINGLE_GET_VALUE_RESPONSE, value.get(key));
-        });
-        validateMultiGetMetrics(
-            batchGetRequestContext,
-            true,
-            false,
-            RequestType.MULTI_GET,
-            useStreamingBatchGetAsDefault,
-            false,
-            1);
-      }
+      fail();
     } catch (Exception e) {
-      if (useStreamingBatchGetAsDefault) {
-        assertTrue(e.getMessage().endsWith("At least one route did not complete"), e.getMessage());
-      } else {
-        fail();
-      }
-      validateMultiGetMetrics(
-          batchGetRequestContext,
-          false,
-          true,
-          RequestType.MULTI_GET,
-          useStreamingBatchGetAsDefault,
-          false,
-          useStreamingBatchGetAsDefault ? 2 : 1);
+      assertTrue(e.getMessage().endsWith("At least one route did not complete"), e.getMessage());
+      validateMultiGetMetrics(batchGetRequestContext, false, true, RequestType.MULTI_GET, false, 2);
     } finally {
       tearDown();
     }
@@ -779,7 +683,7 @@ public class DispatchingAvroGenericStoreClientTest {
     long routingLeakedRequestCleanupThresholdMS = TimeUnit.SECONDS.toMillis(1);
     BatchGetRequestContext batchGetRequestContext = null;
     try {
-      setUpClient(true, false, false, true, true, routingLeakedRequestCleanupThresholdMS);
+      setUpClient(false, false, true, true, routingLeakedRequestCleanupThresholdMS);
       batchGetRequestContext = new BatchGetRequestContext<>(BATCH_GET_KEYS.size(), false);
       statsAvroGenericStoreClient.batchGet(batchGetRequestContext, BATCH_GET_KEYS).get();
       fail();
@@ -791,7 +695,7 @@ public class DispatchingAvroGenericStoreClientTest {
           () -> {
             assertTrue(metrics.get("." + STORE_NAME + "--multiget_streaming_request.OccurrenceRate").value() > 0);
           });
-      validateMultiGetMetrics(batchGetRequestContext, false, true, RequestType.MULTI_GET, true, false, 2);
+      validateMultiGetMetrics(batchGetRequestContext, false, true, RequestType.MULTI_GET, false, 2);
       tearDown();
     }
   }
@@ -809,7 +713,7 @@ public class DispatchingAvroGenericStoreClientTest {
     long routingLeakedRequestCleanupThresholdMS = TimeUnit.SECONDS.toMillis(1);
     BatchGetRequestContext batchGetRequestContext = null;
     try {
-      setUpClient(true, false, false, true, true, routingLeakedRequestCleanupThresholdMS);
+      setUpClient(false, false, true, true, routingLeakedRequestCleanupThresholdMS);
       batchGetRequestContext = new BatchGetRequestContext<>(BATCH_GET_KEYS.size(), false);
       statsAvroGenericStoreClient.batchGet(batchGetRequestContext, BATCH_GET_KEYS).get(2, TimeUnit.SECONDS);
       fail();
@@ -821,7 +725,7 @@ public class DispatchingAvroGenericStoreClientTest {
           () -> {
             assertTrue(metrics.get("." + STORE_NAME + "--multiget_streaming_request.OccurrenceRate").value() > 0);
           });
-      validateMultiGetMetrics(batchGetRequestContext, false, true, RequestType.MULTI_GET, true, false, 2);
+      validateMultiGetMetrics(batchGetRequestContext, false, true, RequestType.MULTI_GET, false, 2);
       tearDown();
     }
   }
@@ -839,7 +743,7 @@ public class DispatchingAvroGenericStoreClientTest {
     long routingLeakedRequestCleanupThresholdMS = TimeUnit.SECONDS.toMillis(2);
     BatchGetRequestContext batchGetRequestContext = null;
     try {
-      setUpClient(true, false, false, true, true, routingLeakedRequestCleanupThresholdMS);
+      setUpClient(false, false, true, true, routingLeakedRequestCleanupThresholdMS);
       batchGetRequestContext = new BatchGetRequestContext<>(BATCH_GET_KEYS.size(), false);
       statsAvroGenericStoreClient.batchGet(batchGetRequestContext, BATCH_GET_KEYS).get(1, TimeUnit.SECONDS);
       fail();
@@ -851,7 +755,7 @@ public class DispatchingAvroGenericStoreClientTest {
           () -> {
             assertTrue(metrics.get("." + STORE_NAME + "--multiget_streaming_request.OccurrenceRate").value() > 0);
           });
-      validateMultiGetMetrics(batchGetRequestContext, false, true, RequestType.MULTI_GET, true, false, 2);
+      validateMultiGetMetrics(batchGetRequestContext, false, true, RequestType.MULTI_GET, false, 2);
       tearDown();
     }
   }
@@ -864,7 +768,7 @@ public class DispatchingAvroGenericStoreClientTest {
   public void testBatchGetWithTimeoutV4() throws IOException {
     long routingLeakedRequestCleanupThresholdMS = TimeUnit.SECONDS.toMillis(1);
     try {
-      setUpClient(true, false, false, true, true, routingLeakedRequestCleanupThresholdMS);
+      setUpClient(false, false, true, true, routingLeakedRequestCleanupThresholdMS);
       BatchGetRequestContext batchGetRequestContext =
           new BatchGetRequestContext<>(BATCH_GET_PARTIAL_KEYS_2.size(), false);
       statsAvroGenericStoreClient.batchGet(batchGetRequestContext, BATCH_GET_PARTIAL_KEYS_2).get();
@@ -888,7 +792,7 @@ public class DispatchingAvroGenericStoreClientTest {
             () -> {
               assertTrue(metrics.get("." + STORE_NAME + "--multiget_streaming_request.OccurrenceRate").value() > 0);
             });
-        validateMultiGetMetrics(batchGetRequestContext, false, true, RequestType.MULTI_GET, true, true, 2, 1);
+        validateMultiGetMetrics(batchGetRequestContext, false, true, RequestType.MULTI_GET, true, 2, 1);
       }
     } finally {
       tearDown();
@@ -905,7 +809,7 @@ public class DispatchingAvroGenericStoreClientTest {
   public void testStreamingBatchGetWithTimeoutV1() throws IOException, ExecutionException, InterruptedException {
     long routingLeakedRequestCleanupThresholdMS = TimeUnit.SECONDS.toMillis(1);
     try {
-      setUpClient(true, false, false, true, true, routingLeakedRequestCleanupThresholdMS);
+      setUpClient(false, false, true, true, routingLeakedRequestCleanupThresholdMS);
       BatchGetRequestContext batchGetRequestContext = new BatchGetRequestContext<>(BATCH_GET_KEYS.size(), true);
       CompletableFuture<VeniceResponseMap<String, GenericRecord>> future =
           statsAvroGenericStoreClient.streamingBatchGet(batchGetRequestContext, BATCH_GET_KEYS);
@@ -920,7 +824,7 @@ public class DispatchingAvroGenericStoreClientTest {
           () -> {
             assertTrue(metrics.get("." + STORE_NAME + "--multiget_streaming_request.OccurrenceRate").value() > 0);
           });
-      validateMultiGetMetrics(batchGetRequestContext, false, true, RequestType.MULTI_GET_STREAMING, true, false, 2);
+      validateMultiGetMetrics(batchGetRequestContext, false, true, RequestType.MULTI_GET_STREAMING, false, 2);
     } finally {
       tearDown();
     }
@@ -937,7 +841,7 @@ public class DispatchingAvroGenericStoreClientTest {
       throws IOException, ExecutionException, InterruptedException, TimeoutException {
     long routingLeakedRequestCleanupThresholdMS = TimeUnit.SECONDS.toMillis(1);
     try {
-      setUpClient(true, false, false, true, true, routingLeakedRequestCleanupThresholdMS);
+      setUpClient(false, false, true, true, routingLeakedRequestCleanupThresholdMS);
       BatchGetRequestContext batchGetRequestContext = new BatchGetRequestContext<>(BATCH_GET_KEYS.size(), true);
       CompletableFuture<VeniceResponseMap<String, GenericRecord>> future =
           statsAvroGenericStoreClient.streamingBatchGet(batchGetRequestContext, BATCH_GET_KEYS);
@@ -952,7 +856,7 @@ public class DispatchingAvroGenericStoreClientTest {
           () -> {
             assertTrue(metrics.get("." + STORE_NAME + "--multiget_streaming_request.OccurrenceRate").value() > 0);
           });
-      validateMultiGetMetrics(batchGetRequestContext, false, true, RequestType.MULTI_GET_STREAMING, true, false, 2);
+      validateMultiGetMetrics(batchGetRequestContext, false, true, RequestType.MULTI_GET_STREAMING, false, 2);
     } finally {
       tearDown();
     }
@@ -969,7 +873,7 @@ public class DispatchingAvroGenericStoreClientTest {
       throws IOException, ExecutionException, InterruptedException, TimeoutException {
     try {
       long routingLeakedRequestCleanupThresholdMS = TimeUnit.SECONDS.toMillis(2);
-      setUpClient(true, false, false, true, true, routingLeakedRequestCleanupThresholdMS);
+      setUpClient(false, false, true, true, routingLeakedRequestCleanupThresholdMS);
       BatchGetRequestContext batchGetRequestContext = new BatchGetRequestContext<>(BATCH_GET_KEYS.size(), true);
       CompletableFuture<VeniceResponseMap<String, GenericRecord>> future =
           statsAvroGenericStoreClient.streamingBatchGet(batchGetRequestContext, BATCH_GET_KEYS);
@@ -984,36 +888,25 @@ public class DispatchingAvroGenericStoreClientTest {
           () -> {
             assertTrue(metrics.get("." + STORE_NAME + "--multiget_streaming_request.OccurrenceRate").value() > 0);
           });
-      validateMultiGetMetrics(batchGetRequestContext, false, true, RequestType.MULTI_GET_STREAMING, true, false, 2);
+      validateMultiGetMetrics(batchGetRequestContext, false, true, RequestType.MULTI_GET_STREAMING, false, 2);
     } finally {
       tearDown();
     }
   }
 
-  @Test(dataProvider = "True-and-False", dataProviderClass = DataProviderUtils.class, timeOut = TEST_TIMEOUT)
-  public void testBatchGetToUnreachableClient(boolean useStreamingBatchGetAsDefault) throws IOException {
+  @Test(timeOut = TEST_TIMEOUT)
+  public void testBatchGetToUnreachableClient() throws IOException {
     BatchGetRequestContext batchGetRequestContext = null;
     try {
-      setUpClient(useStreamingBatchGetAsDefault, false, false, false, false, TimeUnit.SECONDS.toMillis(1));
+      setUpClient(false, false, false, false, TimeUnit.SECONDS.toMillis(1));
       batchGetRequestContext = new BatchGetRequestContext<>(BATCH_GET_KEYS.size(), false);
       statsAvroGenericStoreClient.batchGet(batchGetRequestContext, BATCH_GET_KEYS).get();
       fail();
     } catch (Exception e) {
       // First batchGet fails with unreachable host after timeout and this adds the hosts
       // as blocked due to setRoutingPendingRequestCounterInstanceBlockThreshold(1)
-      if (useStreamingBatchGetAsDefault) {
-        assertTrue(e.getMessage().endsWith("At least one route did not complete"), e.getMessage());
-      } else {
-        assertTrue(e.getMessage().endsWith("http status: 410, Request timed out"), e.getMessage());
-      }
-      validateMultiGetMetrics(
-          batchGetRequestContext,
-          false,
-          false,
-          RequestType.MULTI_GET,
-          useStreamingBatchGetAsDefault,
-          false,
-          useStreamingBatchGetAsDefault ? 2 : 1);
+      assertTrue(e.getMessage().endsWith("At least one route did not complete"), e.getMessage());
+      validateMultiGetMetrics(batchGetRequestContext, false, false, RequestType.MULTI_GET, false, 2);
 
       BatchGetRequestContext batchGetRequestContext2 = null;
       try {
@@ -1023,22 +916,11 @@ public class DispatchingAvroGenericStoreClientTest {
         statsAvroGenericStoreClient.batchGet(batchGetRequestContext2, BATCH_GET_KEYS).get();
         fail();
       } catch (Exception e1) {
-        if (useStreamingBatchGetAsDefault) {
-          assertTrue(e1.getMessage().endsWith("At least one route did not complete"), e1.getMessage());
-          assertTrue(
-              e1.getCause().getCause().getMessage().contains("No available route for store"),
-              e1.getCause().getCause().getMessage());
-        } else {
-          assertTrue(e1.getMessage().contains("No available route for store"), e1.getMessage());
-        }
-        validateMultiGetMetrics(
-            batchGetRequestContext2,
-            false,
-            false,
-            RequestType.MULTI_GET,
-            useStreamingBatchGetAsDefault,
-            true,
-            useStreamingBatchGetAsDefault ? 2 : 1);
+        assertTrue(e1.getMessage().endsWith("At least one route did not complete"), e1.getMessage());
+        assertTrue(
+            e1.getCause().getCause().getMessage().contains("No available route for store"),
+            e1.getCause().getCause().getMessage());
+        validateMultiGetMetrics(batchGetRequestContext2, false, false, RequestType.MULTI_GET, true, 2);
       }
     } finally {
       tearDown();
@@ -1054,7 +936,7 @@ public class DispatchingAvroGenericStoreClientTest {
   @Test(timeOut = TEST_TIMEOUT)
   public void testStreamingBatchGetToUnreachableClient() throws IOException, ExecutionException, InterruptedException {
     try {
-      setUpClient(true, false, false, false, false, TimeUnit.SECONDS.toMillis(1));
+      setUpClient(false, false, false, false, TimeUnit.SECONDS.toMillis(1));
       BatchGetRequestContext batchGetRequestContext = new BatchGetRequestContext<>(BATCH_GET_KEYS.size(), true);
       VeniceResponseMap<String, GenericRecord> response =
           (VeniceResponseMap<String, GenericRecord>) statsAvroGenericStoreClient
@@ -1064,7 +946,7 @@ public class DispatchingAvroGenericStoreClientTest {
       assertEquals(response.getTotalEntryCount(), 0);
       // First batchGet fails with unreachable host after timeout and this adds the hosts
       // as blocked due to setRoutingPendingRequestCounterInstanceBlockThreshold(1)
-      validateMultiGetMetrics(batchGetRequestContext, false, false, RequestType.MULTI_GET_STREAMING, true, false, 2);
+      validateMultiGetMetrics(batchGetRequestContext, false, false, RequestType.MULTI_GET_STREAMING, false, 2);
 
       // the second batchGet is not going to find any routes (as the instances
       // are blocked) and fail instantly
@@ -1075,7 +957,7 @@ public class DispatchingAvroGenericStoreClientTest {
               .get();
       assertFalse(response2.isFullResponse());
       assertEquals(response2.getTotalEntryCount(), 0);
-      validateMultiGetMetrics(batchGetRequestContext2, false, false, RequestType.MULTI_GET_STREAMING, true, true, 2);
+      validateMultiGetMetrics(batchGetRequestContext2, false, false, RequestType.MULTI_GET_STREAMING, true, 2);
     } finally {
       tearDown();
     }
@@ -1091,7 +973,7 @@ public class DispatchingAvroGenericStoreClientTest {
   public void testStreamingBatchGetToUnreachableClientV1()
       throws IOException, ExecutionException, InterruptedException {
     try {
-      setUpClient(true, false, false, false, false, TimeUnit.SECONDS.toMillis(1));
+      setUpClient(false, false, false, false, TimeUnit.SECONDS.toMillis(1));
       BatchGetRequestContext batchGetRequestContext =
           new BatchGetRequestContext<>(BATCH_GET_PARTIAL_KEYS_1.size(), true);
       VeniceResponseMap<String, GenericRecord> response =
@@ -1102,7 +984,7 @@ public class DispatchingAvroGenericStoreClientTest {
       assertEquals(response.getTotalEntryCount(), 0);
       // First batchGet fails with unreachable host after timeout and this adds the hosts
       // as blocked due to setRoutingPendingRequestCounterInstanceBlockThreshold(1)
-      validateMultiGetMetrics(batchGetRequestContext, false, false, RequestType.MULTI_GET_STREAMING, true, false, 1);
+      validateMultiGetMetrics(batchGetRequestContext, false, false, RequestType.MULTI_GET_STREAMING, false, 1);
 
       BatchGetRequestContext batchGetRequestContext2 = new BatchGetRequestContext<>(BATCH_GET_KEYS.size(), true);
       VeniceResponseMap<String, GenericRecord> response2 =
@@ -1111,7 +993,7 @@ public class DispatchingAvroGenericStoreClientTest {
               .get();
       assertFalse(response2.isFullResponse());
       assertEquals(response2.getTotalEntryCount(), 0);
-      validateMultiGetMetrics(batchGetRequestContext2, false, false, RequestType.MULTI_GET_STREAMING, true, true, 2);
+      validateMultiGetMetrics(batchGetRequestContext2, false, false, RequestType.MULTI_GET_STREAMING, true, 2);
     } finally {
       tearDown();
     }
@@ -1127,7 +1009,7 @@ public class DispatchingAvroGenericStoreClientTest {
   public void testStreamingBatchGetToUnreachableClientV2()
       throws IOException, ExecutionException, InterruptedException {
     try {
-      setUpClient(true, false, false, true, true, TimeUnit.SECONDS.toMillis(1));
+      setUpClient(false, false, true, true, TimeUnit.SECONDS.toMillis(1));
       BatchGetRequestContext batchGetRequestContext =
           new BatchGetRequestContext<>(BATCH_GET_PARTIAL_KEYS_2.size(), true);
       VeniceResponseMap<String, GenericRecord> response =
@@ -1138,7 +1020,7 @@ public class DispatchingAvroGenericStoreClientTest {
       assertEquals(response.getTotalEntryCount(), 0);
       // First batchGet fails with unreachable host after timeout and this adds the hosts
       // as blocked due to setRoutingPendingRequestCounterInstanceBlockThreshold(1)
-      validateMultiGetMetrics(batchGetRequestContext, false, false, RequestType.MULTI_GET_STREAMING, true, false, 1);
+      validateMultiGetMetrics(batchGetRequestContext, false, false, RequestType.MULTI_GET_STREAMING, false, 1);
       BatchGetRequestContext batchGetRequestContext2 = new BatchGetRequestContext<>(BATCH_GET_KEYS.size(), true);
       CompletableFuture<VeniceResponseMap<String, GenericRecord>> future =
           statsAvroGenericStoreClient.streamingBatchGet(batchGetRequestContext2, BATCH_GET_KEYS);
@@ -1160,7 +1042,7 @@ public class DispatchingAvroGenericStoreClientTest {
   public void testStreamingBatchGetToUnreachableClientV3()
       throws IOException, ExecutionException, InterruptedException {
     try {
-      setUpClient(true, false, true, false, true, TimeUnit.SECONDS.toMillis(1));
+      setUpClient(false, true, false, true, TimeUnit.SECONDS.toMillis(1));
       BatchGetRequestContext batchGetRequestContext = new BatchGetRequestContext<>(BATCH_GET_KEYS.size(), true);
       VeniceResponseMap<String, GenericRecord> response =
           (VeniceResponseMap<String, GenericRecord>) statsAvroGenericStoreClient
@@ -1171,7 +1053,7 @@ public class DispatchingAvroGenericStoreClientTest {
       assertEquals(response.get("test_key_1"), BATCH_GET_VALUE_RESPONSE.get("test_key_1"));
       // First batchGet fails with unreachable host after timeout and this adds the hosts
       // as blocked due to setRoutingPendingRequestCounterInstanceBlockThreshold(1)
-      validateMultiGetMetrics(batchGetRequestContext, false, true, RequestType.MULTI_GET_STREAMING, true, false, 2);
+      validateMultiGetMetrics(batchGetRequestContext, false, true, RequestType.MULTI_GET_STREAMING, false, 2);
     } finally {
       tearDown();
     }
@@ -1186,7 +1068,7 @@ public class DispatchingAvroGenericStoreClientTest {
       throws IOException, ExecutionException, InterruptedException {
     BatchGetRequestContext batchGetRequestContext = null;
     try {
-      setUpClient(true, true, false, false, true, TimeUnit.SECONDS.toMillis(1));
+      setUpClient(true, false, false, true, TimeUnit.SECONDS.toMillis(1));
       batchGetRequestContext = new BatchGetRequestContext<>(BATCH_GET_KEYS.size(), true);
       VeniceResponseMap<String, GenericRecord> response =
           (VeniceResponseMap<String, GenericRecord>) statsAvroGenericStoreClient
@@ -1196,7 +1078,7 @@ public class DispatchingAvroGenericStoreClientTest {
       assertEquals(response.getTotalEntryCount(), 0);
       // First batchGet fails with unreachable host after timeout and this adds the hosts
       // as blocked due to setRoutingPendingRequestCounterInstanceBlockThreshold(1)
-      validateMultiGetMetrics(batchGetRequestContext, false, false, RequestType.MULTI_GET_STREAMING, true, false, 2);
+      validateMultiGetMetrics(batchGetRequestContext, false, false, RequestType.MULTI_GET_STREAMING, false, 2);
     } finally {
       tearDown();
     }
@@ -1283,7 +1165,7 @@ public class DispatchingAvroGenericStoreClientTest {
   @Test(timeOut = TEST_TIMEOUT)
   public void testComputeWithExceptionFromTransportLayer() throws IOException {
     try {
-      setUpClient(false, true, false, false);
+      setUpClient(true, false, false);
       statsAvroGenericStoreClient.compute().project("name").execute(COMPUTE_REQUEST_KEYS).get();
       fail();
     } catch (Exception e) {
@@ -1297,7 +1179,7 @@ public class DispatchingAvroGenericStoreClientTest {
   @Test(timeOut = TEST_TIMEOUT)
   public void testComputeWithExceptionFromTransportLayerForOneRoute() throws IOException {
     try {
-      setUpClient(false, false, true, false);
+      setUpClient(false, true, false);
       statsAvroGenericStoreClient.compute().project("name").execute(COMPUTE_REQUEST_KEYS).get();
       fail();
     } catch (Exception e) {
@@ -1319,7 +1201,7 @@ public class DispatchingAvroGenericStoreClientTest {
   public void testComputeWithTimeoutV1() throws IOException, ExecutionException, InterruptedException {
     long routingLeakedRequestCleanupThresholdMS = TimeUnit.SECONDS.toMillis(1);
     try {
-      setUpClient(false, false, false, true, true, routingLeakedRequestCleanupThresholdMS);
+      setUpClient(false, false, true, true, routingLeakedRequestCleanupThresholdMS);
       statsAvroGenericStoreClient.compute().project("name").execute(COMPUTE_REQUEST_KEYS).get();
       fail();
     } finally {
@@ -1347,7 +1229,7 @@ public class DispatchingAvroGenericStoreClientTest {
       throws IOException, ExecutionException, InterruptedException, TimeoutException {
     long routingLeakedRequestCleanupThresholdMS = TimeUnit.SECONDS.toMillis(1);
     try {
-      setUpClient(true, false, false, true, true, routingLeakedRequestCleanupThresholdMS);
+      setUpClient(false, false, true, true, routingLeakedRequestCleanupThresholdMS);
       statsAvroGenericStoreClient.compute().project("name").execute(COMPUTE_REQUEST_KEYS).get(2, TimeUnit.SECONDS);
       fail();
     } finally {
@@ -1375,7 +1257,7 @@ public class DispatchingAvroGenericStoreClientTest {
       throws IOException, ExecutionException, InterruptedException, TimeoutException {
     long routingLeakedRequestCleanupThresholdMS = TimeUnit.SECONDS.toMillis(2);
     try {
-      setUpClient(true, false, false, true, true, routingLeakedRequestCleanupThresholdMS);
+      setUpClient(false, false, true, true, routingLeakedRequestCleanupThresholdMS);
       ComputeRequestBuilder requestBuilder = statsAvroGenericStoreClient.compute().project("name");
       requestBuilder.execute(COMPUTE_REQUEST_KEYS).get(1, TimeUnit.SECONDS);
       fail();
@@ -1400,7 +1282,7 @@ public class DispatchingAvroGenericStoreClientTest {
   public void testComputeWithTimeoutV4() throws IOException {
     long routingLeakedRequestCleanupThresholdMS = TimeUnit.SECONDS.toMillis(1);
     try {
-      setUpClient(true, false, false, true, true, routingLeakedRequestCleanupThresholdMS);
+      setUpClient(false, false, true, true, routingLeakedRequestCleanupThresholdMS);
       statsAvroGenericStoreClient.compute().project("name").execute(COMPUTE_REQUEST_PARTIAL_KEYS_2).get();
       fail();
     } catch (Exception e) {
@@ -1436,7 +1318,7 @@ public class DispatchingAvroGenericStoreClientTest {
   @Test(timeOut = TEST_TIMEOUT)
   public void testComputeToUnreachableClient() throws IOException {
     try {
-      setUpClient(false, false, false, false, false, TimeUnit.SECONDS.toMillis(1));
+      setUpClient(false, false, false, false, TimeUnit.SECONDS.toMillis(1));
       statsAvroGenericStoreClient.compute().project("name").execute(COMPUTE_REQUEST_KEYS).get();
       fail();
     } catch (Exception e) {
@@ -1473,7 +1355,7 @@ public class DispatchingAvroGenericStoreClientTest {
   @Test
   public void testStreamingComputeToUnreachableClient() throws IOException, ExecutionException, InterruptedException {
     try {
-      setUpClient(false, false, false, false, false, TimeUnit.SECONDS.toMillis(1));
+      setUpClient(false, false, false, false, TimeUnit.SECONDS.toMillis(1));
       VeniceResponseMap<String, ComputeGenericRecord> response =
           (VeniceResponseMap<String, ComputeGenericRecord>) statsAvroGenericStoreClient.compute()
               .project("name")
@@ -1504,7 +1386,7 @@ public class DispatchingAvroGenericStoreClientTest {
   public void testStreamingComputeWithExceptionFromTransportLayer()
       throws IOException, ExecutionException, InterruptedException {
     try {
-      setUpClient(false, true, false, false);
+      setUpClient(true, false, false);
       VeniceResponseMap<String, ComputeGenericRecord> response =
           (VeniceResponseMap<String, ComputeGenericRecord>) statsAvroGenericStoreClient.compute()
               .project("name")
@@ -1522,7 +1404,7 @@ public class DispatchingAvroGenericStoreClientTest {
   public void testStreamingComputeWithExceptionFromTransportLayerForOneRoute()
       throws IOException, ExecutionException, InterruptedException {
     try {
-      setUpClient(false, false, true, false);
+      setUpClient(false, true, false);
       VeniceResponseMap<String, ComputeGenericRecord> response =
           (VeniceResponseMap<String, ComputeGenericRecord>) statsAvroGenericStoreClient.compute()
               .project("name")
@@ -1550,7 +1432,7 @@ public class DispatchingAvroGenericStoreClientTest {
   public void testStreamingComputeWithTimeoutV1() throws IOException, ExecutionException, InterruptedException {
     long routingLeakedRequestCleanupThresholdMS = TimeUnit.SECONDS.toMillis(1);
     try {
-      setUpClient(false, false, false, true, true, routingLeakedRequestCleanupThresholdMS);
+      setUpClient(false, false, true, true, routingLeakedRequestCleanupThresholdMS);
       VeniceResponseMap<String, ComputeGenericRecord> response =
           (VeniceResponseMap<String, ComputeGenericRecord>) statsAvroGenericStoreClient.compute()
               .project("name")
@@ -1585,7 +1467,7 @@ public class DispatchingAvroGenericStoreClientTest {
       throws IOException, ExecutionException, InterruptedException, TimeoutException {
     long routingLeakedRequestCleanupThresholdMS = TimeUnit.SECONDS.toMillis(1);
     try {
-      setUpClient(true, false, false, true, true, routingLeakedRequestCleanupThresholdMS);
+      setUpClient(false, false, true, true, routingLeakedRequestCleanupThresholdMS);
       VeniceResponseMap<String, ComputeGenericRecord> response =
           (VeniceResponseMap<String, ComputeGenericRecord>) statsAvroGenericStoreClient.compute()
               .project("name")
@@ -1620,7 +1502,7 @@ public class DispatchingAvroGenericStoreClientTest {
       throws IOException, ExecutionException, InterruptedException, TimeoutException {
     try {
       long routingLeakedRequestCleanupThresholdMS = TimeUnit.SECONDS.toMillis(2);
-      setUpClient(true, false, false, true, true, routingLeakedRequestCleanupThresholdMS);
+      setUpClient(false, false, true, true, routingLeakedRequestCleanupThresholdMS);
       ComputeRequestBuilder requestBuilder = statsAvroGenericStoreClient.compute().project("name");
       CompletableFuture<VeniceResponseMap<String, ComputeGenericRecord>> future =
           requestBuilder.streamingExecute(COMPUTE_REQUEST_KEYS);
@@ -1652,7 +1534,7 @@ public class DispatchingAvroGenericStoreClientTest {
   @Test(timeOut = TEST_TIMEOUT)
   public void testStreamingComputeToUnreachableClientV1() throws IOException, ExecutionException, InterruptedException {
     try {
-      setUpClient(true, false, false, false, false, TimeUnit.SECONDS.toMillis(1));
+      setUpClient(false, false, false, false, TimeUnit.SECONDS.toMillis(1));
       VeniceResponseMap<String, ComputeGenericRecord> response =
           (VeniceResponseMap<String, ComputeGenericRecord>) statsAvroGenericStoreClient.compute()
               .project("name")
@@ -1686,7 +1568,7 @@ public class DispatchingAvroGenericStoreClientTest {
   @Test(timeOut = TEST_TIMEOUT)
   public void testStreamingComputeToUnreachableClientV2() throws IOException, ExecutionException, InterruptedException {
     try {
-      setUpClient(true, false, false, true, true, TimeUnit.SECONDS.toMillis(1));
+      setUpClient(false, false, true, true, TimeUnit.SECONDS.toMillis(1));
       VeniceResponseMap<String, ComputeGenericRecord> response =
           (VeniceResponseMap<String, ComputeGenericRecord>) statsAvroGenericStoreClient.compute()
               .project("name")
@@ -1718,7 +1600,7 @@ public class DispatchingAvroGenericStoreClientTest {
   @Test(timeOut = TEST_TIMEOUT)
   public void testStreamingComputeToUnreachableClientV3() throws IOException, ExecutionException, InterruptedException {
     try {
-      setUpClient(true, false, true, false, true, TimeUnit.SECONDS.toMillis(1));
+      setUpClient(false, true, false, true, TimeUnit.SECONDS.toMillis(1));
       VeniceResponseMap<String, ComputeGenericRecord> response =
           (VeniceResponseMap<String, ComputeGenericRecord>) statsAvroGenericStoreClient.compute()
               .project("name")
@@ -1744,7 +1626,7 @@ public class DispatchingAvroGenericStoreClientTest {
   @Test(timeOut = TEST_TIMEOUT)
   public void testStreamingComputeToUnreachableClientV4() throws IOException, ExecutionException, InterruptedException {
     try {
-      setUpClient(true, true, false, false, true, TimeUnit.SECONDS.toMillis(1));
+      setUpClient(true, false, false, true, TimeUnit.SECONDS.toMillis(1));
       VeniceResponseMap<String, ComputeGenericRecord> response =
           (VeniceResponseMap<String, ComputeGenericRecord>) statsAvroGenericStoreClient.compute()
               .project("name")

--- a/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/DispatchingAvroGenericStoreClientTest.java
+++ b/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/DispatchingAvroGenericStoreClientTest.java
@@ -659,9 +659,7 @@ public class DispatchingAvroGenericStoreClientTest {
     try {
       setUpClient(false, true, false);
       batchGetRequestContext = new BatchGetRequestContext<>(BATCH_GET_KEYS.size(), false);
-      Map<String, GenericRecord> value =
-          (Map<String, GenericRecord>) statsAvroGenericStoreClient.batchGet(batchGetRequestContext, BATCH_GET_KEYS)
-              .get();
+      statsAvroGenericStoreClient.batchGet(batchGetRequestContext, BATCH_GET_KEYS).get();
       fail();
     } catch (Exception e) {
       assertTrue(e.getMessage().endsWith("At least one route did not complete"), e.getMessage());

--- a/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/DualReadAvroGenericStoreClientTest.java
+++ b/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/DualReadAvroGenericStoreClientTest.java
@@ -29,9 +29,9 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import org.mockito.AdditionalMatchers;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
-import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 
@@ -68,27 +68,20 @@ public class DualReadAvroGenericStoreClientTest {
       boolean thinClientThrowExceptionWhenSending,
       boolean thinClientSucceed,
       long thinClientDelayMS,
-      FastClientStats dualClientStats,
-      boolean useStreamingBatchGetAsDefault) {
+      FastClientStats dualClientStats) {
     InternalAvroStoreClient<String, String> fastClient = mock(DispatchingAvroGenericStoreClient.class);
     AvroGenericStoreClient<String, String> thinClient = mock(AvroGenericStoreClient.class);
     ClientConfig clientConfig = mock(ClientConfig.class);
     doReturn(dualClientStats).when(clientConfig).getStats(RequestType.MULTI_GET_STREAMING);
     doReturn(dualClientStats).when(clientConfig).getStats(RequestType.SINGLE_GET);
-    doReturn(useStreamingBatchGetAsDefault).when(clientConfig).useStreamingBatchGetAsDefault();
     doReturn(thinClient).when(clientConfig).getGenericThinClient();
     doReturn(2).when(clientConfig).getMaxAllowedKeyCntInBatchGetReq();
 
     if (fastClientThrowExceptionWhenSending) {
       String fcRequestFailException = "Mocked VeniceClientException for fast-client while sending out request";
       if (batchGet) {
-        if (useStreamingBatchGetAsDefault) {
-          doThrow(new VeniceClientException(fcRequestFailException)).when(fastClient)
-              .streamingBatchGet(any(BatchGetRequestContext.class), any(), any());
-        } else {
-          doThrow(new VeniceClientException(fcRequestFailException)).when(fastClient)
-              .get(any(GetRequestContext.class), any());
-        }
+        doThrow(new VeniceClientException(fcRequestFailException)).when(fastClient)
+            .streamingBatchGet(any(BatchGetRequestContext.class), any(), any());
       } else {
         doThrow(new VeniceClientException(fcRequestFailException)).when(fastClient)
             .get(any(GetRequestContext.class), any());
@@ -97,44 +90,26 @@ public class DualReadAvroGenericStoreClientTest {
       if (fastClientSucceed) {
         if (fastClientDelayMS == 0) {
           if (batchGet) {
-            if (useStreamingBatchGetAsDefault) {
-              doAnswer(invocation -> {
-                StreamingCallback callback = invocation.getArgument(2);
-                FAST_CLIENT_BATCH_GET_RESPONSE.forEach((k, v) -> callback.onRecordReceived(k, v));
-                callback.onCompletion(Optional.empty());
-                return null;
-              }).when(fastClient).streamingBatchGet(any(BatchGetRequestContext.class), any(), any());
-            } else {
-              doAnswer(invocation -> {
-                String key = invocation.getArgument(1);
-                return CompletableFuture.completedFuture(FAST_CLIENT_BATCH_GET_RESPONSE.get(key));
-              }).when(fastClient).get(any(GetRequestContext.class), any());
-            }
+            doAnswer(invocation -> {
+              StreamingCallback callback = invocation.getArgument(2);
+              FAST_CLIENT_BATCH_GET_RESPONSE.forEach((k, v) -> callback.onRecordReceived(k, v));
+              callback.onCompletion(Optional.empty());
+              return null;
+            }).when(fastClient).streamingBatchGet(any(BatchGetRequestContext.class), any(), any());
           } else {
             doReturn(CompletableFuture.completedFuture(FAST_CLIENT_SINGLE_GET_RESPONSE)).when(fastClient)
                 .get(any(GetRequestContext.class), any());
           }
         } else {
           if (batchGet) {
-            if (useStreamingBatchGetAsDefault) {
-              doAnswer(invocation -> {
-                maybeDelayExecute(() -> {
-                  StreamingCallback callback = invocation.getArgument(2);
-                  FAST_CLIENT_BATCH_GET_RESPONSE.forEach(callback::onRecordReceived);
-                  callback.onCompletion(Optional.empty());
-                }, fastClientDelayMS);
-                return null;
-              }).when(fastClient).streamingBatchGet(any(BatchGetRequestContext.class), any(), any());
-            } else {
-              doAnswer(invocation -> {
-                CompletableFuture<String> fastClientFuture = new CompletableFuture<>();
-                maybeDelayExecute(() -> {
-                  String key = invocation.getArgument(1);
-                  fastClientFuture.complete(FAST_CLIENT_BATCH_GET_RESPONSE.get(key));
-                }, fastClientDelayMS);
-                return fastClientFuture;
-              }).when(fastClient).get(any(GetRequestContext.class), any());
-            }
+            doAnswer(invocation -> {
+              maybeDelayExecute(() -> {
+                StreamingCallback callback = invocation.getArgument(2);
+                FAST_CLIENT_BATCH_GET_RESPONSE.forEach(callback::onRecordReceived);
+                callback.onCompletion(Optional.empty());
+              }, fastClientDelayMS);
+              return null;
+            }).when(fastClient).streamingBatchGet(any(BatchGetRequestContext.class), any(), any());
           } else {
             doAnswer(invocation -> {
               CompletableFuture<String> fastClientFuture = new CompletableFuture<>();
@@ -148,23 +123,13 @@ public class DualReadAvroGenericStoreClientTest {
       } else {
         String fcException = "Mocked VeniceClientException for fast-client";
         if (batchGet) {
-          if (useStreamingBatchGetAsDefault) {
-            doAnswer(invocation -> {
-              maybeDelayExecute(() -> {
-                StreamingCallback callback = invocation.getArgument(2);
-                callback.onCompletion(Optional.of(new VeniceClientException(fcException)));
-              }, fastClientDelayMS);
-              return null;
-            }).when(fastClient).streamingBatchGet(any(BatchGetRequestContext.class), any(), any());
-          } else {
-            doAnswer(invocation -> {
-              CompletableFuture<Map<String, String>> fastClientFuture = new CompletableFuture<>();
-              maybeDelayExecute(() -> {
-                fastClientFuture.completeExceptionally(new VeniceClientException(fcException));
-              }, fastClientDelayMS);
-              return fastClientFuture;
-            }).when(fastClient).get(any(GetRequestContext.class), any());
-          }
+          doAnswer(invocation -> {
+            maybeDelayExecute(() -> {
+              StreamingCallback callback = invocation.getArgument(2);
+              callback.onCompletion(Optional.of(new VeniceClientException(fcException)));
+            }, fastClientDelayMS);
+            return null;
+          }).when(fastClient).streamingBatchGet(any(BatchGetRequestContext.class), any(), any());
         } else {
           CompletableFuture<String> fastClientFuture = new CompletableFuture<>();
           doAnswer(invocation -> {
@@ -237,30 +202,12 @@ public class DualReadAvroGenericStoreClientTest {
     return new DualReadAvroGenericStoreClient<>(fastClient, clientConfig);
   }
 
-  @DataProvider(name = "FastClient-Two-Booleans")
-  public Object[][] twoBooleans() {
-    return DataProviderUtils.allPermutationGenerator((permutation) -> {
-      boolean batchGet = (boolean) permutation[0];
-      boolean useStreamingBatchGetAsDefault = (boolean) permutation[1];
-      if (!batchGet) {
-        if (useStreamingBatchGetAsDefault) {
-          // avoid duplicate tests for batchGet cases
-          return false;
-        }
-      }
-      return true;
-    },
-        DataProviderUtils.BOOLEAN, // batchGet
-        DataProviderUtils.BOOLEAN); // useStreamingBatchGetAsDefault
-  }
-
   // Both returns, but fast-client is faster
-  @Test(dataProvider = "FastClient-Two-Booleans")
-  public void testGetWithFastClientBeingFaster(boolean batchGet, boolean useStreamingBatchGetAsDefault)
-      throws ExecutionException, InterruptedException {
+  @Test(dataProvider = "True-and-False", dataProviderClass = DataProviderUtils.class)
+  public void testGetWithFastClientBeingFaster(boolean batchGet) throws ExecutionException, InterruptedException {
     FastClientStats dualClientStats = mock(FastClientStats.class);
     AvroGenericStoreClient<String, String> dualReadClient =
-        prepareClient(batchGet, false, true, 0, false, true, 1000, dualClientStats, useStreamingBatchGetAsDefault);
+        prepareClient(batchGet, false, true, 0, false, true, 1000, dualClientStats);
 
     if (batchGet) {
       Map<String, String> batchGetRes = dualReadClient.batchGet(BATCH_GET_KEYS).get();
@@ -279,17 +226,16 @@ public class DualReadAvroGenericStoreClientTest {
     TestUtils.waitForNonDeterministicAssertion(10, TimeUnit.SECONDS, () -> {
       verify(dualClientStats, never()).recordFastClientErrorThinClientSucceedRequest();
       verify(dualClientStats, never()).recordFastClientSlowerRequest();
-      verify(dualClientStats, timeout(2000)).recordThinClientFastClientLatencyDelta(anyDouble());
+      verify(dualClientStats, timeout(2000)).recordThinClientFastClientLatencyDelta(AdditionalMatchers.gt(0.0d));
     });
   }
 
   // Both returns, but thin-client is faster
-  @Test(dataProvider = "FastClient-Two-Booleans")
-  public void testGetWithThinClientBeingFaster(boolean batchGet, boolean useStreamingBatchGetAsDefault)
-      throws ExecutionException, InterruptedException {
+  @Test(dataProvider = "True-and-False", dataProviderClass = DataProviderUtils.class)
+  public void testGetWithThinClientBeingFaster(boolean batchGet) throws ExecutionException, InterruptedException {
     FastClientStats dualClientStats = mock(FastClientStats.class);
     AvroGenericStoreClient<String, String> dualReadClient =
-        prepareClient(batchGet, false, true, 1000, false, true, 0, dualClientStats, useStreamingBatchGetAsDefault);
+        prepareClient(batchGet, false, true, 1000, false, true, 0, dualClientStats);
     if (batchGet) {
       Map<String, String> batchGetRes = dualReadClient.batchGet(BATCH_GET_KEYS).get();
       assertEquals(
@@ -303,20 +249,19 @@ public class DualReadAvroGenericStoreClientTest {
           THIN_CLIENT_SINGLE_GET_RESPONSE,
           "Thin client response should be returned since it is faster");
     }
-    TestUtils.waitForNonDeterministicAssertion(10, TimeUnit.SECONDS, () -> {
+    TestUtils.waitForNonDeterministicAssertion(5, TimeUnit.SECONDS, () -> {
       verify(dualClientStats, never()).recordFastClientErrorThinClientSucceedRequest();
       verify(dualClientStats, timeout(2000)).recordFastClientSlowerRequest();
-      verify(dualClientStats).recordThinClientFastClientLatencyDelta(anyDouble());
+      verify(dualClientStats).recordThinClientFastClientLatencyDelta(AdditionalMatchers.lt(0.0d));
     });
   }
 
   // Fast-client returns ok, but thin-client returns error
-  @Test(dataProvider = "FastClient-Two-Booleans")
-  public void testGetWithThinClientReturnError(boolean batchGet, boolean useStreamingBatchGetAsDefault)
-      throws ExecutionException, InterruptedException {
+  @Test(dataProvider = "True-and-False", dataProviderClass = DataProviderUtils.class)
+  public void testGetWithThinClientReturnError(boolean batchGet) throws ExecutionException, InterruptedException {
     FastClientStats dualClientStats = mock(FastClientStats.class);
     AvroGenericStoreClient<String, String> dualReadClient =
-        prepareClient(batchGet, false, true, 1000, false, false, 0, dualClientStats, useStreamingBatchGetAsDefault);
+        prepareClient(batchGet, false, true, 1000, false, false, 0, dualClientStats);
     if (batchGet) {
       Map<String, String> batchGetRes = dualReadClient.batchGet(BATCH_GET_KEYS).get();
       assertEquals(
@@ -338,12 +283,11 @@ public class DualReadAvroGenericStoreClientTest {
   }
 
   // Fast-client returns error, but thin-client returns ok
-  @Test(dataProvider = "FastClient-Two-Booleans")
-  public void testGetWithFastClientReturnError(boolean batchGet, boolean useStreamingBatchGetAsDefault)
-      throws ExecutionException, InterruptedException {
+  @Test(dataProvider = "True-and-False", dataProviderClass = DataProviderUtils.class)
+  public void testGetWithFastClientReturnError(boolean batchGet) throws ExecutionException, InterruptedException {
     FastClientStats dualClientStats = mock(FastClientStats.class);
     AvroGenericStoreClient<String, String> dualReadClient =
-        prepareClient(batchGet, false, false, 0, false, true, 1000, dualClientStats, useStreamingBatchGetAsDefault);
+        prepareClient(batchGet, false, false, 0, false, true, 1000, dualClientStats);
     if (batchGet) {
       Map<String, String> batchGetRes = dualReadClient.batchGet(BATCH_GET_KEYS).get();
       assertEquals(
@@ -365,11 +309,11 @@ public class DualReadAvroGenericStoreClientTest {
   }
 
   // Both return error
-  @Test(dataProvider = "FastClient-Two-Booleans")
-  public void testGetWithBothClientsReturnError(boolean batchGet, boolean useStreamingBatchGetAsDefault) {
+  @Test(dataProvider = "True-and-False", dataProviderClass = DataProviderUtils.class)
+  public void testGetWithBothClientsReturnError(boolean batchGet) {
     FastClientStats dualClientStats = mock(FastClientStats.class);
     AvroGenericStoreClient<String, String> dualReadClient =
-        prepareClient(batchGet, false, false, 1000, false, false, 0, dualClientStats, useStreamingBatchGetAsDefault);
+        prepareClient(batchGet, false, false, 1000, false, false, 0, dualClientStats);
     try {
       if (batchGet) {
         dualReadClient.batchGet(BATCH_GET_KEYS).get();
@@ -384,12 +328,12 @@ public class DualReadAvroGenericStoreClientTest {
   }
 
   // Fast-client returns ok, but thin-client fails to send out request
-  @Test(dataProvider = "FastClient-Two-Booleans")
-  public void testGetWithThinClientFailsToSendOutRequest(boolean batchGet, boolean useStreamingBatchGetAsDefault)
+  @Test(dataProvider = "True-and-False", dataProviderClass = DataProviderUtils.class)
+  public void testGetWithThinClientFailsToSendOutRequest(boolean batchGet)
       throws ExecutionException, InterruptedException {
     FastClientStats dualClientStats = mock(FastClientStats.class);
     AvroGenericStoreClient<String, String> dualReadClient =
-        prepareClient(batchGet, false, true, 1000, true, true, 0, dualClientStats, useStreamingBatchGetAsDefault);
+        prepareClient(batchGet, false, true, 1000, true, true, 0, dualClientStats);
     if (batchGet) {
       Map<String, String> batchGetRes = dualReadClient.batchGet(BATCH_GET_KEYS).get();
       assertEquals(
@@ -411,12 +355,12 @@ public class DualReadAvroGenericStoreClientTest {
   }
 
   // Fast-client fails to send out request, but thin-client returns ok
-  @Test(dataProvider = "FastClient-Two-Booleans")
-  public void testGetWithFastClientFailsToSendOutRequest(boolean batchGet, boolean useStreamingBatchGetAsDefault)
+  @Test(dataProvider = "True-and-False", dataProviderClass = DataProviderUtils.class)
+  public void testGetWithFastClientFailsToSendOutRequest(boolean batchGet)
       throws ExecutionException, InterruptedException {
     FastClientStats dualClientStats = mock(FastClientStats.class);
     AvroGenericStoreClient<String, String> dualReadClient =
-        prepareClient(batchGet, true, true, 0, false, true, 1000, dualClientStats, useStreamingBatchGetAsDefault);
+        prepareClient(batchGet, true, true, 0, false, true, 1000, dualClientStats);
     if (batchGet) {
       Map<String, String> batchGetRes = dualReadClient.batchGet(BATCH_GET_KEYS).get();
       assertEquals(
@@ -438,11 +382,11 @@ public class DualReadAvroGenericStoreClientTest {
   }
 
   // Both fail to send out request
-  @Test(dataProvider = "FastClient-Two-Booleans")
-  public void testGetWithBothClientsFailsToSendOutRequest(boolean batchGet, boolean useStreamingBatchGetAsDefault) {
+  @Test(dataProvider = "True-and-False", dataProviderClass = DataProviderUtils.class)
+  public void testGetWithBothClientsFailsToSendOutRequest(boolean batchGet) {
     FastClientStats dualClientStats = mock(FastClientStats.class);
     AvroGenericStoreClient<String, String> dualReadClient =
-        prepareClient(batchGet, true, true, 1000, true, true, 0, dualClientStats, useStreamingBatchGetAsDefault);
+        prepareClient(batchGet, true, true, 1000, true, true, 0, dualClientStats);
     try {
       if (batchGet) {
         dualReadClient.batchGet(BATCH_GET_KEYS).get();

--- a/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/RetriableAvroGenericStoreClientTest.java
+++ b/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/RetriableAvroGenericStoreClientTest.java
@@ -103,8 +103,7 @@ public class RetriableAvroGenericStoreClientTest {
             (int) TimeUnit.MILLISECONDS.toMicros(LONG_TAIL_RETRY_THRESHOLD_IN_MS))
         .setLongTailRetryEnabledForCompute(true)
         .setLongTailRetryThresholdForComputeInMicroSeconds(
-            (int) TimeUnit.MILLISECONDS.toMicros(LONG_TAIL_RETRY_THRESHOLD_IN_MS))
-        .setUseStreamingBatchGetAsDefault(true);
+            (int) TimeUnit.MILLISECONDS.toMicros(LONG_TAIL_RETRY_THRESHOLD_IN_MS));
     BATCH_GET_KEYS.add("test_key_1");
     BATCH_GET_KEYS.add("test_key_2");
     GenericRecord value1 = (GenericRecord) rrg.randomGeneric(STORE_VALUE_SCHEMA);
@@ -453,7 +452,7 @@ public class RetriableAvroGenericStoreClientTest {
    * @param retryWin retry request wins
    */
   private void validateMetrics(RequestType requestType, boolean errorRetry, boolean longTailRetry, boolean retryWin) {
-    String metricsPrefix = ClientTestUtils.getMetricPrefix(STORE_NAME, requestType, true);
+    String metricsPrefix = ClientTestUtils.getMetricPrefix(STORE_NAME, requestType);
 
     boolean singleGet = requestType == RequestType.SINGLE_GET;
     boolean batchGet = requestType == RequestType.MULTI_GET || requestType == RequestType.MULTI_GET_STREAMING;

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/fastclient/AvroStoreClientGzipEndToEndTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/fastclient/AvroStoreClientGzipEndToEndTest.java
@@ -31,16 +31,15 @@ public class AvroStoreClientGzipEndToEndTest extends AvroStoreClientEndToEndTest
       if (speculativeQueryEnabled) {
         return false;
       }
-      boolean useStreamingBatchGetAsDefault = (boolean) permutation[2];
-      boolean retryEnabled = (boolean) permutation[4];
+      boolean retryEnabled = (boolean) permutation[3];
       if (retryEnabled) {
         return false;
       }
-      int batchGetKeySize = (int) permutation[5];
-      RequestType requestType = (RequestType) permutation[6];
-      StoreMetadataFetchMode storeMetadataFetchMode = (StoreMetadataFetchMode) permutation[7];
+      int batchGetKeySize = (int) permutation[4];
+      RequestType requestType = (RequestType) permutation[5];
+      StoreMetadataFetchMode storeMetadataFetchMode = (StoreMetadataFetchMode) permutation[6];
       if (requestType != RequestType.MULTI_GET && requestType != RequestType.MULTI_GET_STREAMING) {
-        if (useStreamingBatchGetAsDefault || batchGetKeySize != (int) BATCH_GET_KEY_SIZE.get(0)) {
+        if (batchGetKeySize != (int) BATCH_GET_KEY_SIZE.get(0)) {
           // these parameters are related only to batchGet, so just allowing 1 set
           // to avoid duplicate tests
           return false;
@@ -54,7 +53,6 @@ public class AvroStoreClientGzipEndToEndTest extends AvroStoreClientEndToEndTest
     },
         DataProviderUtils.BOOLEAN_FALSE, // dualRead
         DataProviderUtils.BOOLEAN_FALSE, // speculativeQueryEnabled
-        DataProviderUtils.BOOLEAN_TRUE, // useStreamingBatchGetAsDefault
         DataProviderUtils.BOOLEAN, // enableGrpc
         DataProviderUtils.BOOLEAN, // retryEnabled
         BATCH_GET_KEY_SIZE.toArray(), // batchGetKeySize

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/fastclient/AvroStoreClientZstdEndToEndTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/fastclient/AvroStoreClientZstdEndToEndTest.java
@@ -35,16 +35,15 @@ public class AvroStoreClientZstdEndToEndTest extends AvroStoreClientEndToEndTest
       if (speculativeQueryEnabled) {
         return false;
       }
-      boolean useStreamingBatchGetAsDefault = (boolean) permutation[2];
-      boolean retryEnabled = (boolean) permutation[4];
+      boolean retryEnabled = (boolean) permutation[3];
       if (retryEnabled) {
         return false;
       }
-      int batchGetKeySize = (int) permutation[5];
-      RequestType requestType = (RequestType) permutation[6];
-      StoreMetadataFetchMode storeMetadataFetchMode = (StoreMetadataFetchMode) permutation[7];
+      int batchGetKeySize = (int) permutation[4];
+      RequestType requestType = (RequestType) permutation[5];
+      StoreMetadataFetchMode storeMetadataFetchMode = (StoreMetadataFetchMode) permutation[6];
       if (requestType != RequestType.MULTI_GET && requestType != RequestType.MULTI_GET_STREAMING) {
-        if (useStreamingBatchGetAsDefault || batchGetKeySize != (int) BATCH_GET_KEY_SIZE.get(0)) {
+        if (batchGetKeySize != (int) BATCH_GET_KEY_SIZE.get(0)) {
           // these parameters are related only to batchGet, so just allowing 1 set
           // to avoid duplicate tests
           return false;
@@ -58,7 +57,6 @@ public class AvroStoreClientZstdEndToEndTest extends AvroStoreClientEndToEndTest
     },
         DataProviderUtils.BOOLEAN_FALSE, // dualRead
         DataProviderUtils.BOOLEAN_FALSE, // speculativeQueryEnabled
-        DataProviderUtils.BOOLEAN_TRUE, // useStreamingBatchGetAsDefault
         DataProviderUtils.BOOLEAN, // enableGrpc
         DataProviderUtils.BOOLEAN, // retryEnabled
         BATCH_GET_KEY_SIZE.toArray(), // batchGetKeySize

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/fastclient/FastClientIndividualFeatureConfigurationTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/fastclient/FastClientIndividualFeatureConfigurationTest.java
@@ -202,8 +202,7 @@ public class FastClientIndividualFeatureConfigurationTest extends AbstractClient
     ClientConfig.ClientConfigBuilder clientConfigBuilder =
         new ClientConfig.ClientConfigBuilder<>().setStoreName(storeName)
             .setR2Client(r2Client)
-            .setSpeculativeQueryEnabled(false)
-            .setUseStreamingBatchGetAsDefault(true);
+            .setSpeculativeQueryEnabled(false);
     AvroGenericStoreClient<String, GenericRecord> genericFastClient = getGenericFastClient(
         clientConfigBuilder,
         new MetricsRepository(),

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/fastclient/grpc/VeniceGrpcEndToEndTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/fastclient/grpc/VeniceGrpcEndToEndTest.java
@@ -147,8 +147,7 @@ public class VeniceGrpcEndToEndTest {
             .setR2Client(r2Client)
             .setMaxAllowedKeyCntInBatchGetReq(maxAllowedKeys + 1)
             .setRoutingPendingRequestCounterInstanceBlockThreshold(maxAllowedKeys + 1)
-            .setSpeculativeQueryEnabled(false)
-            .setUseStreamingBatchGetAsDefault(false);
+            .setSpeculativeQueryEnabled(false);
 
     AvroGenericStoreClient<String, GenericRecord> genericFastClient =
         getGenericFastClient(clientConfigBuilder, new MetricsRepository(), d2Client);
@@ -200,8 +199,7 @@ public class VeniceGrpcEndToEndTest {
             .setR2Client(r2Client)
             .setMaxAllowedKeyCntInBatchGetReq(maxAllowedKeys + 1)
             .setRoutingPendingRequestCounterInstanceBlockThreshold(maxAllowedKeys + 1)
-            .setSpeculativeQueryEnabled(false)
-            .setUseStreamingBatchGetAsDefault(true);
+            .setSpeculativeQueryEnabled(false);
 
     ClientConfigBuilder<Object, Object, SpecificRecord> grpcClientConfigBuilder =
         new com.linkedin.venice.fastclient.ClientConfig.ClientConfigBuilder<>().setStoreName(storeName)
@@ -209,8 +207,7 @@ public class VeniceGrpcEndToEndTest {
             .setGrpcClientConfig(grpcClientConfig)
             .setMaxAllowedKeyCntInBatchGetReq(maxAllowedKeys)
             .setRoutingPendingRequestCounterInstanceBlockThreshold(maxAllowedKeys)
-            .setSpeculativeQueryEnabled(false)
-            .setUseStreamingBatchGetAsDefault(true);
+            .setSpeculativeQueryEnabled(false);
 
     AvroGenericStoreClient<String, GenericRecord> genericFastClient =
         getGenericFastClient(clientConfigBuilder, new MetricsRepository(), d2Client);
@@ -266,8 +263,7 @@ public class VeniceGrpcEndToEndTest {
             .setR2Client(r2Client)
             .setMaxAllowedKeyCntInBatchGetReq(maxAllowedKeys + 1)
             .setRoutingPendingRequestCounterInstanceBlockThreshold(maxAllowedKeys + 1)
-            .setSpeculativeQueryEnabled(false)
-            .setUseStreamingBatchGetAsDefault(true);
+            .setSpeculativeQueryEnabled(false);
 
     ClientConfigBuilder<Object, Object, SpecificRecord> grpcClientConfigBuilder =
         new com.linkedin.venice.fastclient.ClientConfig.ClientConfigBuilder<>().setStoreName(storeName)
@@ -275,8 +271,7 @@ public class VeniceGrpcEndToEndTest {
             .setGrpcClientConfig(grpcClientConfig)
             .setMaxAllowedKeyCntInBatchGetReq(maxAllowedKeys)
             .setRoutingPendingRequestCounterInstanceBlockThreshold(maxAllowedKeys)
-            .setSpeculativeQueryEnabled(false)
-            .setUseStreamingBatchGetAsDefault(true);
+            .setSpeculativeQueryEnabled(false);
 
     AvroGenericStoreClient<String, GenericRecord> genericFastClient =
         getGenericFastClient(clientConfigBuilder, new MetricsRepository(), d2Client);
@@ -316,8 +311,7 @@ public class VeniceGrpcEndToEndTest {
             .setR2Client(fastR2Client)
             .setMaxAllowedKeyCntInBatchGetReq(maxAllowedKeys + 1)
             .setRoutingPendingRequestCounterInstanceBlockThreshold(maxAllowedKeys + 1)
-            .setSpeculativeQueryEnabled(false)
-            .setUseStreamingBatchGetAsDefault(true);
+            .setSpeculativeQueryEnabled(false);
 
     ClientConfigBuilder<Object, Object, SpecificRecord> grpcClientConfigBuilder =
         new com.linkedin.venice.fastclient.ClientConfig.ClientConfigBuilder<>().setStoreName(storeName)
@@ -325,8 +319,7 @@ public class VeniceGrpcEndToEndTest {
             .setGrpcClientConfig(grpcClientConfig)
             .setMaxAllowedKeyCntInBatchGetReq(maxAllowedKeys + 1)
             .setRoutingPendingRequestCounterInstanceBlockThreshold(maxAllowedKeys + 1)
-            .setSpeculativeQueryEnabled(false)
-            .setUseStreamingBatchGetAsDefault(true);
+            .setSpeculativeQueryEnabled(false);
 
     AvroGenericStoreClient<String, GenericRecord> genericFastClient =
         getGenericFastClient(clientConfigBuilder, new MetricsRepository(), fastD2Client);

--- a/internal/venice-test-common/src/main/java/com/linkedin/venice/fastclient/utils/ClientTestUtils.java
+++ b/internal/venice-test-common/src/main/java/com/linkedin/venice/fastclient/utils/ClientTestUtils.java
@@ -67,18 +67,11 @@ public class ClientTestUtils {
     }
   }
 
-  public static String getMetricPrefix(
-      String storeName,
-      RequestType requestType,
-      boolean useStreamingBatchGetAsDefault) {
+  public static String getMetricPrefix(String storeName, RequestType requestType) {
     String metricPrefix = "." + storeName;
     switch (requestType) {
       case MULTI_GET:
-        if (useStreamingBatchGetAsDefault) {
-          metricPrefix += "--" + RequestType.MULTI_GET_STREAMING.getMetricPrefix();
-        } else {
-          metricPrefix += "--";
-        }
+        metricPrefix += "--" + RequestType.MULTI_GET_STREAMING.getMetricPrefix();
         break;
       case COMPUTE:
         metricPrefix += "--" + RequestType.COMPUTE_STREAMING.getMetricPrefix();
@@ -98,7 +91,7 @@ public class ClientTestUtils {
     Set<String> allMetricPrefixes = new HashSet<>();
     for (RequestType requestType: RequestType.values()) {
       for (int i = 0; i < 2; i++) {
-        allMetricPrefixes.add(getMetricPrefix(storeName, requestType, i == 0));
+        allMetricPrefixes.add(getMetricPrefix(storeName, requestType));
       }
     }
     return allMetricPrefixes;


### PR DESCRIPTION
## Summary
cleanup `useStreamingBatchGetAsDefault` config which enables using streaming backend for `batchGet` API, its related code and tests to make it the only supported behavior.

## How was this PR tested?
GH CI

## Does this PR introduce any user-facing changes?
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.