### PR TITLE
[common][server][fc] Fix trust store handling for Grpc with SSL

### DIFF
--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/security/SSLConfig.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/security/SSLConfig.java
@@ -6,6 +6,7 @@ import static com.linkedin.venice.CommonConfigKeys.SSL_KEYSTORE_PASSWORD;
 import static com.linkedin.venice.CommonConfigKeys.SSL_KEYSTORE_TYPE;
 import static com.linkedin.venice.CommonConfigKeys.SSL_TRUSTSTORE_LOCATION;
 import static com.linkedin.venice.CommonConfigKeys.SSL_TRUSTSTORE_PASSWORD;
+import static com.linkedin.venice.CommonConfigKeys.SSL_TRUSTSTORE_TYPE;
 
 import java.util.Properties;
 
@@ -15,6 +16,7 @@ public class SSLConfig {
   private String _keyStorePassword = "";
   private String _keyStoreType = "jks";
   private String _keyStoreFilePath = "";
+  private String _trustStoreType = "jks";
   private String _trustStoreFilePath = "";
   private String _trustStoreFilePassword = "";
   private boolean _sslEnabled = false;
@@ -69,6 +71,14 @@ public class SSLConfig {
     return _keyStoreType;
   }
 
+  public void setTrustStoreType(String trustStoreType) {
+    _trustStoreType = trustStoreType;
+  }
+
+  public String getTrustStoreType() {
+    return _trustStoreType;
+  }
+
   public void setSslEnabled(boolean sslEnabled) {
     _sslEnabled = sslEnabled;
   }
@@ -101,6 +111,7 @@ public class SSLConfig {
     config.setSslEnabled(Boolean.valueOf(sslProperties.getProperty(SSL_ENABLED)));
     config.setKeyStoreType(sslProperties.getProperty(SSL_KEYSTORE_TYPE));
     config.setKeyStoreFilePath(sslProperties.getProperty(SSL_KEYSTORE_LOCATION));
+    config.setTrustStoreType(sslProperties.getProperty(SSL_TRUSTSTORE_TYPE));
     config.setTrustStoreFilePath(sslProperties.getProperty(SSL_TRUSTSTORE_LOCATION));
     config.setKeyStorePassword(sslProperties.getProperty(SSL_KEYSTORE_PASSWORD));
     config.setTrustStoreFilePassword(sslProperties.getProperty(SSL_TRUSTSTORE_PASSWORD));

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/utils/SslUtils.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/utils/SslUtils.java
@@ -49,23 +49,6 @@ public class SslUtils {
   /**
    * This function should be used in test cases only.
    *
-   * @return an instance of {@link SSLConfig} with local SSL config.
-   */
-  public static SSLConfig getLocalSslConfig() {
-    String keyStorePath = getPathForResource(LOCAL_KEYSTORE_JKS);
-    SSLConfig sslConfig = new SSLConfig();
-    sslConfig.setKeyStoreFilePath(keyStorePath);
-    sslConfig.setKeyStorePassword(LOCAL_PASSWORD);
-    sslConfig.setKeyStoreType("JKS");
-    sslConfig.setTrustStoreFilePath(keyStorePath);
-    sslConfig.setTrustStoreFilePassword(LOCAL_PASSWORD);
-    sslConfig.setSslEnabled(true);
-    return sslConfig;
-  }
-
-  /**
-   * This function should be used in test cases only.
-   *
    * @return a local SSL factory that uses a self-signed development certificate.
    */
   public static SSLFactory getVeniceLocalSslFactory() {

--- a/internal/venice-common/src/main/java/com/linkedin/venice/SSLConfig.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/SSLConfig.java
@@ -94,6 +94,7 @@ public class SSLConfig {
     config.setKeyStoreType(sslKeyStoreType);
     config.setTrustStoreFilePassword(sslTrustStorePassword);
     config.setTrustStoreFilePath(sslTrustStoreLocation);
+    config.setTrustStoreType(sslTrustStoreType);
 
     return config;
   }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/grpc/GrpcSslUtils.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/grpc/GrpcSslUtils.java
@@ -64,7 +64,7 @@ public class GrpcSslUtils {
 
   public static TrustManager[] getTrustManagers(SSLFactory sslFactory, String algorithm)
       throws CertificateException, KeyStoreException, IOException, NoSuchAlgorithmException {
-    KeyStore trustStore = loadTrustStore(sslFactory, sslFactory.getSSLConfig().getKeyStoreType());
+    KeyStore trustStore = loadTrustStore(sslFactory, sslFactory.getSSLConfig().getTrustStoreType());
     return createTrustManagers(trustStore, algorithm);
   }
 


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Fix trust store handling for Grpc with SSL
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
Currently, `GrpcSslUtils#getTrustManagers` loads the trust store but expects the trust store to be of the same type as the key store. While this is true in our tests, it might not always be true in practice. This PR fixes this by handling trust store types explicitly. 

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
GH CI. Tested in internal jobs.

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.