### PR TITLE
[router][controller] Use SSL port to connect to router

### DIFF
--- a/services/venice-router/src/main/java/com/linkedin/venice/router/RouterServer.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/RouterServer.java
@@ -889,7 +889,7 @@ public class RouterServer extends AbstractVeniceService {
           config.getRefreshAttemptsForZkReconnect(),
           config.getRefreshIntervalForZkReconnectInMs());
       routersClusterManager.refresh();
-      routersClusterManager.registerRouter(Utils.getHelixNodeIdentifier(config.getHostname(), config.getPort()));
+      routersClusterManager.registerRouter(Utils.getHelixNodeIdentifier(config.getHostname(), config.getSslPort()));
       routingDataRepository.refresh();
       hybridStoreQuotaRepository.ifPresent(HelixHybridStoreQuotaRepository::refresh);
 


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Use SSL port to connect to router
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Currently the routers are registered using non-SSL port name on helix zk path, which makes direct to host (non D2) router requests to hit non-SSL port during store backup version cleanup service. This PR registers the routers on SSL port. 

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
GHCI
## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.