### PR TITLE
[test] Slight tweaks to ExceptionUtils

### DIFF
--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/utils/ExceptionUtils.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/utils/ExceptionUtils.java
@@ -28,54 +28,36 @@ public class ExceptionUtils {
    * @return true if the throwableToInspect corresponds to or is caused by any of the throwableClassesToLookFor
    */
   public static boolean recursiveClassEquals(Throwable throwableToInspect, Class... throwableClassesToLookFor) {
-    return getRecursiveCause(throwableToInspect, throwableClassesToLookFor) != null;
-  }
-
-  /**
-   * Inspects a given {@link Throwable} as well as its nested causes, in order to look
-   * for a specific set of exception classes. The function also detects if the throwable
-   * to inspect is a subclass of one of the classes you look for, but not the other way
-   * around (i.e.: if you're looking for the subclass but the throwableToInspect is the
-   * parent class, then this function returns false).
-   *
-   * @return true if the throwableToInspect corresponds to or is caused by any of the throwableClassesToLookFor
-   */
-  public static Throwable getRecursiveCause(Throwable throwableToInspect, Class... throwableClassesToLookFor) {
-    if (throwableToInspect == null) {
-      return null;
-    }
-    for (Class clazz: throwableClassesToLookFor) {
-      Class classToInspect = throwableToInspect.getClass();
-      while (classToInspect != null) {
-        if (classToInspect.equals(clazz)) {
-          return throwableToInspect;
+    while (throwableToInspect != null) {
+      for (Class clazz: throwableClassesToLookFor) {
+        Class classToInspect = throwableToInspect.getClass();
+        while (classToInspect != null) {
+          if (classToInspect.equals(clazz)) {
+            return true;
+          }
+          classToInspect = classToInspect.getSuperclass();
         }
-        classToInspect = classToInspect.getSuperclass();
       }
+      throwableToInspect = throwableToInspect.getCause();
     }
-    Throwable cause = throwableToInspect.getCause();
-    return getRecursiveCause(cause, throwableClassesToLookFor);
+    return false;
   }
 
   /**
    * Inspects a given {@link Throwable} as well as its nested causes, in order to look
    * for a specific message.
    *
-   * @return true if a the throwableToInspect contains the message parameter
+   * @return true if the throwableToInspect contains the message parameter
    */
   public static boolean recursiveMessageContains(Throwable throwableToInspect, String message) {
-    if (throwableToInspect == null) {
-      return false;
+    while (throwableToInspect != null) {
+      String throwableToInspectMessage = throwableToInspect.getMessage();
+      if (throwableToInspectMessage != null && throwableToInspectMessage.contains(message)) {
+        return true;
+      }
+      throwableToInspect = throwableToInspect.getCause();
     }
-    String throwableToInspectMessage = throwableToInspect.getMessage();
-    if (throwableToInspectMessage == null) {
-      return false;
-    }
-    if (throwableToInspectMessage.contains(message)) {
-      return true;
-    }
-    Throwable cause = throwableToInspect.getCause();
-    return recursiveMessageContains(cause, message);
+    return false;
   }
 
   /**

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/utils/TestExceptionUtils.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/utils/TestExceptionUtils.java
@@ -14,6 +14,24 @@ public class TestExceptionUtils {
     Throwable vio = new VeniceException("test venice exception wrapping io exception", io);
     Assert.assertTrue(ExceptionUtils.recursiveClassEquals(io, IOException.class));
     Assert.assertTrue(ExceptionUtils.recursiveClassEquals(vio, IOException.class));
+    Assert.assertTrue(
+        ExceptionUtils.recursiveClassEquals(vio, IOException.class, IllegalArgumentException.class),
+        "If any of the classes match the exception, the function should return true.");
     Assert.assertFalse(ExceptionUtils.recursiveClassEquals(v, IOException.class));
+    Assert.assertFalse(
+        ExceptionUtils.recursiveClassEquals(v, IOException.class, IllegalArgumentException.class),
+        "If none of the classes match the exception, the function should return false.");
+  }
+
+  @Test
+  public void testRecursiveMessageContains() {
+    Throwable io = new IOException("test io exception");
+    Throwable v = new VeniceException("test venice exception");
+    Throwable vio = new VeniceException("test venice exception wrapping io exception", io);
+    Throwable vioWithNullMessage = new VeniceException(null, io);
+    Assert.assertTrue(ExceptionUtils.recursiveMessageContains(io, "test io exception"));
+    Assert.assertTrue(ExceptionUtils.recursiveMessageContains(vio, "test io exception"));
+    Assert.assertTrue(ExceptionUtils.recursiveMessageContains(vioWithNullMessage, "test io exception"));
+    Assert.assertFalse(ExceptionUtils.recursiveMessageContains(v, "test io exception"));
   }
 }


### PR DESCRIPTION
Made recursiveMessageContains work even in an edge case where the message is null but a cause has the message we're looking for. Added a unit test for this. Note that this is the only functional change of this commit, but the recursiveMessageContains function is only used in tests, hence the tag of the commit is just [test]... The motivation for this change is that this function is being used in another project that depends on Venice.

Reduced code size (without functional changes) of recursiveClassEquals.

## How was this PR tested?
New unit test.

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.