### PR TITLE
[controller] Turn off A/A and inc push when turning off hybrid store config

### DIFF
--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
@@ -2315,6 +2315,14 @@ public class VeniceParentHelixAdmin implements Admin {
           && veniceHelixAdmin.isHybrid(updatedHybridStoreConfig);
       // Check if the store is being converted to a batch store
       boolean storeBeingConvertedToBatch = currStore.isHybrid() && !veniceHelixAdmin.isHybrid(updatedHybridStoreConfig);
+      LOGGER.info(
+          "DEBUGGING: {} {} {} {} {} ",
+          storeBeingConvertedToBatch,
+          activeActiveReplicationEnabled,
+          incrementalPushEnabled,
+          currStore.isHybrid(),
+          veniceHelixAdmin.isHybrid(updatedHybridStoreConfig));
+
       if (storeBeingConvertedToBatch && activeActiveReplicationEnabled.orElse(false)) {
         throw new VeniceHttpException(
             HttpStatus.SC_BAD_REQUEST,

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
@@ -2315,14 +2315,6 @@ public class VeniceParentHelixAdmin implements Admin {
           && veniceHelixAdmin.isHybrid(updatedHybridStoreConfig);
       // Check if the store is being converted to a batch store
       boolean storeBeingConvertedToBatch = currStore.isHybrid() && !veniceHelixAdmin.isHybrid(updatedHybridStoreConfig);
-      LOGGER.info(
-          "DEBUGGING: {} {} {} {} {} ",
-          storeBeingConvertedToBatch,
-          activeActiveReplicationEnabled,
-          incrementalPushEnabled,
-          currStore.isHybrid(),
-          veniceHelixAdmin.isHybrid(updatedHybridStoreConfig));
-
       if (storeBeingConvertedToBatch && activeActiveReplicationEnabled.orElse(false)) {
         throw new VeniceHttpException(
             HttpStatus.SC_BAD_REQUEST,

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
@@ -2313,7 +2313,20 @@ public class VeniceParentHelixAdmin implements Admin {
       // Check if the store is being converted to a hybrid store
       boolean storeBeingConvertedToHybrid = !currStore.isHybrid() && updatedHybridStoreConfig != null
           && veniceHelixAdmin.isHybrid(updatedHybridStoreConfig);
-
+      // Check if the store is being converted to a batch store
+      boolean storeBeingConvertedToBatch = currStore.isHybrid() && !veniceHelixAdmin.isHybrid(updatedHybridStoreConfig);
+      if (storeBeingConvertedToBatch && activeActiveReplicationEnabled.orElse(false)) {
+        throw new VeniceHttpException(
+            HttpStatus.SC_BAD_REQUEST,
+            "Cannot convert store to batch-only and enable Active/Active together.",
+            ErrorType.BAD_REQUEST);
+      }
+      if (storeBeingConvertedToBatch && incrementalPushEnabled.orElse(false)) {
+        throw new VeniceHttpException(
+            HttpStatus.SC_BAD_REQUEST,
+            "Cannot convert store to batch-only and enable incremental push together.",
+            ErrorType.BAD_REQUEST);
+      }
       // Update active-active replication config.
       setStore.activeActiveReplicationEnabled = activeActiveReplicationEnabled
           .map(addToUpdatedConfigList(updatedConfigsList, ACTIVE_ACTIVE_REPLICATION_ENABLED))
@@ -2325,6 +2338,12 @@ public class VeniceParentHelixAdmin implements Admin {
         setStore.activeActiveReplicationEnabled = true;
         updatedConfigsList.add(ACTIVE_ACTIVE_REPLICATION_ENABLED);
       }
+      // When turning of hybrid store, we will also turn off A/A store config.
+      if (storeBeingConvertedToBatch && setStore.activeActiveReplicationEnabled) {
+        setStore.activeActiveReplicationEnabled = false;
+        updatedConfigsList.add(ACTIVE_ACTIVE_REPLICATION_ENABLED);
+      }
+
       // Update incremental push config.
       setStore.incrementalPushEnabled =
           incrementalPushEnabled.map(addToUpdatedConfigList(updatedConfigsList, INCREMENTAL_PUSH_ENABLED))
@@ -2337,18 +2356,12 @@ public class VeniceParentHelixAdmin implements Admin {
         setStore.incrementalPushEnabled = true;
         updatedConfigsList.add(INCREMENTAL_PUSH_ENABLED);
       }
-
-      // If store is already hybrid then check to make sure the end state is valid. We do this because we allow enabling
-      // incremental push without enabling hybrid already (we will automatically convert to hybrid store with default
-      // configs).
-      if (veniceHelixAdmin.isHybrid(currStore.getHybridStoreConfig())
-          && !veniceHelixAdmin.isHybrid(updatedHybridStoreConfig) && setStore.incrementalPushEnabled) {
-        throw new VeniceHttpException(
-            HttpStatus.SC_BAD_REQUEST,
-            "Cannot convert store to batch-only, incremental push enabled stores require valid hybrid configs. "
-                + "Please disable incremental push if you'd like to convert the store to batch-only",
-            ErrorType.BAD_REQUEST);
+      // When turning of hybrid store, we will also turn off incremental store config.
+      if (storeBeingConvertedToBatch && setStore.incrementalPushEnabled) {
+        setStore.incrementalPushEnabled = false;
+        updatedConfigsList.add(INCREMENTAL_PUSH_ENABLED);
       }
+
       if (updatedHybridStoreConfig == null) {
         setStore.hybridStoreConfig = null;
       } else {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
@@ -2338,7 +2338,7 @@ public class VeniceParentHelixAdmin implements Admin {
         setStore.activeActiveReplicationEnabled = true;
         updatedConfigsList.add(ACTIVE_ACTIVE_REPLICATION_ENABLED);
       }
-      // When turning of hybrid store, we will also turn off A/A store config.
+      // When turning off hybrid store, we will also turn off A/A store config.
       if (storeBeingConvertedToBatch && setStore.activeActiveReplicationEnabled) {
         setStore.activeActiveReplicationEnabled = false;
         updatedConfigsList.add(ACTIVE_ACTIVE_REPLICATION_ENABLED);
@@ -2356,7 +2356,7 @@ public class VeniceParentHelixAdmin implements Admin {
         setStore.incrementalPushEnabled = true;
         updatedConfigsList.add(INCREMENTAL_PUSH_ENABLED);
       }
-      // When turning of hybrid store, we will also turn off incremental store config.
+      // When turning off hybrid store, we will also turn off incremental store config.
       if (storeBeingConvertedToBatch && setStore.incrementalPushEnabled) {
         setStore.incrementalPushEnabled = false;
         updatedConfigsList.add(INCREMENTAL_PUSH_ENABLED);

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/AbstractTestVeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/AbstractTestVeniceParentHelixAdmin.java
@@ -4,6 +4,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import com.linkedin.venice.authorization.AuthorizerService;
 import com.linkedin.venice.authorization.DefaultIdentityParser;
@@ -22,6 +23,7 @@ import com.linkedin.venice.helix.StoragePersonaRepository;
 import com.linkedin.venice.helix.ZkRoutersClusterManager;
 import com.linkedin.venice.helix.ZkStoreConfigAccessor;
 import com.linkedin.venice.kafka.TopicManager;
+import com.linkedin.venice.meta.HybridStoreConfig;
 import com.linkedin.venice.meta.OfflinePushStrategy;
 import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.pubsub.PubSubTopicRepository;
@@ -84,6 +86,7 @@ public class AbstractTestVeniceParentHelixAdmin {
     doReturn(true).when(topicManager).containsTopicAndAllPartitionsAreOnline(pubSubTopicRepository.getTopic(topicName));
 
     internalAdmin = mock(VeniceHelixAdmin.class);
+    when(internalAdmin.isHybrid((HybridStoreConfig) any())).thenCallRealMethod();
     doReturn(topicManager).when(internalAdmin).getTopicManager();
     SchemaEntry mockEntry = new SchemaEntry(0, TEST_SCHEMA);
     doReturn(mockEntry).when(internalAdmin).getKeySchema(anyString(), anyString());


### PR DESCRIPTION

<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## [controller] Turn off A/A and inc push when turning off hybrid store config
This PR adjusts the existing behavior that throws exception when trying to turn off hybrid on an inc push enabled store. This was added 1.5 year ago as part of tactical fix to prevent store to lose RT right away especially for inc push store. Based on my code reading, we will not delete RT right away, if there is active hybrid version. If that is true, the change should be considered safe.

The new behavior is: When disabling hybrid store config: 
1. If user also try to enable A/A or inc push together, we should fail loudly. 
2. Otherwise, we will disable A/A and inc push store config.


## How was this PR tested?
Added new unit test to confirm the logic is behaving as expected.

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.