### PR TITLE
[test] fix restartServerByDeletingSSTFiles tests with checksum enabled

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/PartitionConsumptionState.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/PartitionConsumptionState.java
@@ -41,7 +41,10 @@ public class PartitionConsumptionState {
 
   private String leaderHostId;
 
-  /** whether the ingestion of current partition is deferred-write. */
+  /**
+   * whether the ingestion of current partition is deferred-write.
+   * Refer {@link com.linkedin.davinci.store.rocksdb.RocksDBStoragePartition#deferredWrite}
+   */
   private boolean deferredWrite;
   private boolean errorReported;
   private boolean lagCaughtUp;

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/StoragePartitionConfig.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/StoragePartitionConfig.java
@@ -10,6 +10,9 @@ import java.util.Objects;
 public class StoragePartitionConfig {
   private final String storeName;
   private final int partitionId;
+  /**
+   * Refer {@link com.linkedin.davinci.store.rocksdb.RocksDBStoragePartition#deferredWrite}
+   */
   private boolean deferredWrite;
   private boolean readOnly;
   private boolean writeOnlyConfig;

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/RocksDBSstFileWriter.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/RocksDBSstFileWriter.java
@@ -225,6 +225,10 @@ public class RocksDBSstFileWriter {
     }
   }
 
+  /**
+   * Closes currentSSTFileWriter, update lastCheckPointedSSTFileNum with the current SST file number,
+   * validates checksum on this SST file and return updated checkpointingInfo with this lastCheckPointedSSTFileNum.
+   */
   public Map<String, String> sync() {
     try {
       /**
@@ -352,13 +356,13 @@ public class RocksDBSstFileWriter {
    * This function calculates checksum of all the key/value pair stored in the input sstFilePath. It then
    * verifies if the checksum matches with the input checksumToMatch and return the result.
    * A SstFileReader handle is used to perform bulk scan through the entire SST file. fillCache option is
-   * explicitely disabled to not pollute the rocksdb internal block caches. And also implicit checksum verification
+   * explicitly disabled to not pollute the rocksdb internal block caches. And also implicit checksum verification
    * is disabled to reduce latency of the entire operation.
    *
    * @param sstFilePath the full absolute path of the SST file
    * @param expectedRecordNumInSSTFile expected number of key/value pairs in the SST File
    * @param checksumToMatch pre-calculated checksum to match against.
-   * @return true if the the sstFile checksum matches with the provided checksum.
+   * @return true if the sstFile checksum matches with the provided checksum.
    */
   private boolean verifyChecksum(String sstFilePath, long expectedRecordNumInSSTFile, byte[] checksumToMatch) {
     SstFileReader sstFileReader = null;

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/RocksDBStoragePartition.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/RocksDBStoragePartition.java
@@ -114,7 +114,10 @@ public class RocksDBStoragePartition extends AbstractStoragePartition {
   private final RocksDBStorageEngineFactory factory;
   private final RocksDBThrottler rocksDBThrottler;
   /**
-   * Whether the input is sorted or not.
+   * Whether the input is sorted or not. <br>
+   * deferredWrite = sortedInput => ingested via batch push which is sorted in VPJ, can use {@link RocksDBSstFileWriter} to ingest
+   *                                the input data to RocksDB <br>
+   * !deferredWrite = !sortedInput => can not use RocksDBSstFileWriter for ingestion
    */
   protected final boolean deferredWrite;
 
@@ -739,9 +742,8 @@ public class RocksDBStoragePartition extends AbstractStoragePartition {
         LOGGER.debug("Unexpected sync in RocksDB read-only mode");
       } else {
         try {
-          // Since Venice RocksDB database disables WAL, flush will be triggered for every 'sync' to avoid data loss
-          // during
-          // crash recovery
+          // Since Venice RocksDB database disables WAL, flush will be triggered for every 'sync' to
+          // avoid data loss during crash recovery
           rocksDB.flush(WAIT_FOR_FLUSH_OPTIONS, columnFamilyHandleList);
         } catch (RocksDBException e) {
           checkAndThrowMemoryLimitException(e);


### PR DESCRIPTION
## Summary
This test originally had the following flow:
* Delete the SST files.
* Restart the servers to simulate a crash and restart in the midst of SST file move.

However, this flow introduced an issue when checksum was enabled:
Graceful shutdown of the server after SST file deletion triggers a final offset sync, which throws an exception when files are missing during checksum calculations.

Modified the test to:
Stop the server -> Delete the SST files -> Start the server.

## How was this PR tested?
GH CI

## Does this PR introduce any user-facing changes?
- [x] No. You can skip the rest of this section.
- [] Yes. Make sure to explain your proposed changes and call out the behavior change.