### PR TITLE
[server][controller] Try ungraceful close when the graceful one faile…

### DIFF
--- a/internal/venice-common/src/main/java/com/linkedin/venice/writer/VeniceWriter.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/writer/VeniceWriter.java
@@ -56,6 +56,7 @@ import com.linkedin.venice.utils.DaemonThreadFactory;
 import com.linkedin.venice.utils.ExceptionUtils;
 import com.linkedin.venice.utils.LatencyUtils;
 import com.linkedin.venice.utils.Time;
+import com.linkedin.venice.utils.Timer;
 import com.linkedin.venice.utils.Utils;
 import com.linkedin.venice.utils.VeniceProperties;
 import com.linkedin.venice.utils.VeniceResourceCloseResult;
@@ -399,26 +400,28 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
       if (isClosed) {
         return;
       }
-      long startTime = System.currentTimeMillis();
-      logger.info("Closing VeniceWriter for topic: {}", topicName);
-      try {
-        // If {@link #broadcastEndOfPush(Map)} was already called, the {@link #endAllSegments(boolean)}
-        // will not do anything (it's idempotent). Segments should not be ended if there are still data missing.
-        if (gracefulClose) {
-          endAllSegments(true);
-        }
-        // DO NOT call the {@link #PubSubProducerAdapter.close(int) version from here.}
-        // For non-shared producer mode gracefulClose will flush the producer
 
-        producerAdapter.close(topicName, closeTimeOutInMs, gracefulClose);
-        OPEN_VENICE_WRITER_COUNT.decrementAndGet();
-      } catch (Exception e) {
-        logger.warn("Swallowed an exception while trying to close the VeniceWriter for topic: {}", topicName, e);
-        VENICE_WRITER_CLOSE_FAILED_COUNT.incrementAndGet();
+      logger.info("Closing VeniceWriter for topic: {}, gracefulness: {}", topicName, gracefulClose);
+      try (Timer ignore = Timer.run(
+          elapsedTimeInMs -> logger.info("Closed VeniceWriter for topic: {} in {} ms", topicName, elapsedTimeInMs))) {
+        try {
+          // If {@link #broadcastEndOfPush(Map)} was already called, the {@link #endAllSegments(boolean)}
+          // will not do anything (it's idempotent). Segments should not be ended if there are still data missing.
+          if (gracefulClose) {
+            endAllSegments(true);
+          }
+          // DO NOT call the {@link #PubSubProducerAdapter.close(int) version from here.}
+          // For non-shared producer mode gracefulClose will flush the producer
+
+          producerAdapter.close(topicName, closeTimeOutInMs, gracefulClose);
+          OPEN_VENICE_WRITER_COUNT.decrementAndGet();
+        } catch (Exception e) {
+          handleExceptionInClose(e, gracefulClose);
+        } finally {
+          threadPoolExecutor.shutdown();
+          isClosed = true;
+        }
       }
-      threadPoolExecutor.shutdown();
-      isClosed = true;
-      logger.info("Closed VeniceWriter for topic: {} in {} ms", topicName, System.currentTimeMillis() - startTime);
     }
   }
 
@@ -428,35 +431,54 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
         if (isClosed) {
           return VeniceResourceCloseResult.ALREADY_CLOSED;
         }
-        long startTime = System.currentTimeMillis();
-        logger.info("Closing VeniceWriter for topic: {}", topicName);
-        try {
-          // try to end all segments before closing the producer
-          if (gracefulClose) {
-            CompletableFuture<Void> endSegmentsFuture =
-                CompletableFuture.runAsync(() -> endAllSegments(true), threadPoolExecutor);
-            try {
-              endSegmentsFuture.get(Math.max(100, closeTimeOutInMs / 2), TimeUnit.MILLISECONDS);
-            } catch (Exception e) {
-              // cancel the endSegmentsFuture if it's not done in time
-              if (!endSegmentsFuture.isDone()) {
-                endSegmentsFuture.cancel(true);
+        logger.info("Closing VeniceWriter for topic: {}, gracefulness: {}", topicName, gracefulClose);
+        try (Timer ignore = Timer.run(
+            elapsedTimeInMs -> logger.info("Closed VeniceWriter for topic: {} in {} ms", topicName, elapsedTimeInMs))) {
+          try {
+            // try to end all segments before closing the producer.
+            if (gracefulClose) {
+              CompletableFuture<Void> endSegmentsFuture =
+                  CompletableFuture.runAsync(() -> endAllSegments(true), threadPoolExecutor);
+              try {
+                endSegmentsFuture.get(Math.max(100, closeTimeOutInMs / 2), TimeUnit.MILLISECONDS);
+              } catch (Exception e) {
+                // cancel the endSegmentsFuture if it's not done in time.
+                if (!endSegmentsFuture.isDone()) {
+                  endSegmentsFuture.cancel(true);
+                }
+                logger.warn("Swallowed an exception while trying to end all segments for topic: {}", topicName, e);
               }
-              logger.warn("Swallowed an exception while trying to end all segments for topic: {}", topicName, e);
             }
+            producerAdapter.close(topicName, closeTimeOutInMs, gracefulClose);
+            OPEN_VENICE_WRITER_COUNT.decrementAndGet();
+          } catch (Exception e) {
+            handleExceptionInClose(e, gracefulClose);
+          } finally {
+            threadPoolExecutor.shutdown();
+            isClosed = true;
           }
-          producerAdapter.close(topicName, closeTimeOutInMs, gracefulClose);
-          OPEN_VENICE_WRITER_COUNT.decrementAndGet();
-        } catch (Exception e) {
-          logger.warn("Swallowed an exception while trying to close the VeniceWriter for topic: {}", topicName, e);
-          VENICE_WRITER_CLOSE_FAILED_COUNT.incrementAndGet();
         }
-        threadPoolExecutor.shutdown();
-        isClosed = true;
-        logger.info("Closed VeniceWriter for topic: {} in {} ms", topicName, System.currentTimeMillis() - startTime);
         return VeniceResourceCloseResult.SUCCESS;
       }
+
     }, threadPoolExecutor);
+  }
+
+  void handleExceptionInClose(Exception e, boolean gracefulClose) {
+    logger.warn("Swallowed an exception while trying to close the VeniceWriter for topic: {}", topicName, e);
+    VENICE_WRITER_CLOSE_FAILED_COUNT.incrementAndGet();
+
+    // For graceful close, swallow the exception and give another try to close it ungracefully.
+    try {
+      if (gracefulClose) {
+        producerAdapter.close(topicName, closeTimeOutInMs, false);
+        OPEN_VENICE_WRITER_COUNT.decrementAndGet();
+      }
+    } catch (Exception ex) {
+      // Even ungraceful close fails, give up, swallow exception and move on.
+      logger.warn("Exception in ungraceful close for topic: {}", topicName, ex);
+      VENICE_WRITER_CLOSE_FAILED_COUNT.incrementAndGet();
+    }
   }
 
   @Override

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/pubsub/adapter/kafka/producer/ApacheKafkaProducerAdapterITest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/pubsub/adapter/kafka/producer/ApacheKafkaProducerAdapterITest.java
@@ -114,11 +114,11 @@ public class ApacheKafkaProducerAdapterITest {
     }
   }
 
-  private KafkaKey getDummyKey() {
+  public static KafkaKey getDummyKey() {
     return new KafkaKey(MessageType.PUT, Utils.getUniqueString("key-").getBytes());
   }
 
-  private KafkaMessageEnvelope getDummyVal() {
+  public static KafkaMessageEnvelope getDummyVal() {
     KafkaMessageEnvelope messageEnvelope = new KafkaMessageEnvelope();
     messageEnvelope.producerMetadata = new ProducerMetadata();
     messageEnvelope.producerMetadata.messageTimestamp = 0;

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/writer/VeniceWriterTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/writer/VeniceWriterTest.java
@@ -1,8 +1,13 @@
 package com.linkedin.venice.writer;
 
 import static com.linkedin.venice.kafka.TopicManager.DEFAULT_KAFKA_OPERATION_TIMEOUT_MS;
+import static com.linkedin.venice.utils.Time.MS_PER_SECOND;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
 
 import com.linkedin.venice.ConfigKeys;
+import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.integration.utils.PubSubBrokerWrapper;
 import com.linkedin.venice.integration.utils.ServiceFactory;
 import com.linkedin.venice.kafka.TopicManager;
@@ -22,6 +27,8 @@ import com.linkedin.venice.pubsub.api.PubSubTopic;
 import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
 import com.linkedin.venice.serialization.avro.KafkaValueSerializer;
 import com.linkedin.venice.serialization.avro.OptimizedKafkaValueSerializer;
+import com.linkedin.venice.utils.DataProviderUtils;
+import com.linkedin.venice.utils.ExceptionUtils;
 import com.linkedin.venice.utils.IntegrationTestPushUtils;
 import com.linkedin.venice.utils.TestUtils;
 import com.linkedin.venice.utils.Time;
@@ -33,10 +40,13 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -45,6 +55,7 @@ import org.testng.annotations.Test;
 
 @Test
 public class VeniceWriterTest {
+  private static final Logger LOGGER = LogManager.getLogger(VeniceWriterTest.class);
   private PubSubBrokerWrapper pubSubBrokerWrapper;
   private TopicManager topicManager;
   private PubSubConsumerAdapterFactory pubSubConsumerAdapterFactory;
@@ -141,5 +152,73 @@ public class VeniceWriterTest {
     testThreadSafety(
         100,
         veniceWriter -> veniceWriter.put(new KafkaKey(MessageType.PUT, "blah".getBytes()), "blah".getBytes(), 1, null));
+  }
+
+  /**
+   * This test does the following steps:
+   * 1. Creates a VeniceWriter with a topic that does not exist.
+   * 2. Create a new thread to send a SOS control message to this non-existent topic.
+   * 3. The new thread should block on sendMessage() call.
+   * 4. Main thread closes the VeniceWriter (no matter 'doFlush' flag is true or false) and
+   *    expect the 'sendMessageThread' to unblock.
+   */
+  @Test(timeOut = 60 * MS_PER_SECOND, dataProvider = "True-and-False", dataProviderClass = DataProviderUtils.class)
+  public void testVeniceWriterClose(boolean doFlush) {
+    String topicName = Utils.getUniqueString("version-topic");
+    int partitionCount = 1;
+
+    // Intentionally not create the topic: "version-topic", so that the control message send will also be blocked.
+    // topicManager.createTopic(pubSubTopic, partitionCount, 1, true);
+
+    CountDownLatch countDownLatch = new CountDownLatch(1);
+
+    Properties properties = new Properties();
+    properties.put(ConfigKeys.KAFKA_BOOTSTRAP_SERVERS, pubSubBrokerWrapper.getAddress());
+    properties.put(ConfigKeys.PARTITIONER_CLASS, DefaultVenicePartitioner.class.getName());
+
+    try (VeniceWriter<KafkaKey, byte[], byte[]> veniceWriter =
+        TestUtils.getVeniceWriterFactory(properties, pubSubProducerAdapterFactory)
+            .createVeniceWriter(
+                new VeniceWriterOptions.Builder(topicName).setUseKafkaKeySerializer(true)
+                    .setPartitionCount(partitionCount)
+                    .build())) {
+      ExecutorService executor = Executors.newSingleThreadExecutor();
+
+      Future<?> sendMessageFuture = executor.submit(() -> {
+        Thread.currentThread().setName("sendMessageThread");
+        countDownLatch.countDown();
+        try {
+          // send to non-existent topic and block.
+          veniceWriter.sendStartOfSegment(0, null);
+          fail("sendMessage on non-existent topic should have blocked the executing thread");
+        } catch (VeniceException e) {
+          LOGGER.info("As expected an exception has been received from sendMessage()", e);
+          assertNotNull(e.getMessage(), "Exception thrown by sendMessage does not have a message");
+          assertTrue(
+              e.getMessage()
+                  .contains(
+                      String.format(
+                          "Got an error while trying to produce message into Kafka. Topic: '%s'",
+                          veniceWriter.getTopicName())));
+          assertTrue(ExceptionUtils.recursiveMessageContains(e, "Producer closed while send in progress"));
+          assertTrue(ExceptionUtils.recursiveMessageContains(e, "Requested metadata update after close"));
+          LOGGER.info("All expectations were met in thread: {}", Thread.currentThread().getName());
+        }
+      });
+
+      try {
+        countDownLatch.await();
+        // Still wait for some time to make sure blocking sendMessage is inside kafka before closing it.
+        Utils.sleep(5000);
+        veniceWriter.close(doFlush);
+
+        // this is necessary to check whether expectations in sendMessage thread were met.
+        sendMessageFuture.get();
+      } catch (Exception e) {
+        fail("Producer closing should have succeeded without an exception", e);
+      } finally {
+        executor.shutdownNow();
+      }
+    }
   }
 }


### PR DESCRIPTION
…d in VeniceWriter

In VeniceWriter.close(), when gracefulClose is set to true, Kafka producer call the underlining method, which tries to flush the buffered data before closing it (see ApacheKafkaProducerAdapter.close). However, when exception happens (e.g. timeout), today, VeniceWriter only logs the exception, moves on, and consider the VeniceWriter being closed while it is actually not. (A leaking Venicewriter can cause several issues, e.g. a stuck consumer thread etc.)

This change adds a retry of ungraceful close if gracefulClose flag is set to true and it failed. In this case, ungraceful close will skip the flushing step and it should always succeed (e.g. StoreIngestionTask.kill()). For cases where gracefulClose is set to false, this change doesn't change anything.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

Unit test.
CI.

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.