### PR TITLE
[common][controller] Delete all version topics before deleting RT topic

### DIFF
--- a/internal/venice-common/src/main/java/com/linkedin/venice/helix/HelixStoreGraveyard.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/helix/HelixStoreGraveyard.java
@@ -62,10 +62,6 @@ public class HelixStoreGraveyard implements StoreGraveyard {
 
     List<Store> stores = getStoreFromAllClusters(storeName);
     if (stores.isEmpty()) {
-      LOGGER.info(
-          "Store: {} does NOT exist in the store graveyard. Will initialize the new store at version: {}.",
-          storeName,
-          Store.NON_EXISTING_VERSION);
       // If store does NOT existing in graveyard, it means store has never been deleted, return 0 which is the default
       // value of largestUsedVersionNumber for a new store.
       return Store.NON_EXISTING_VERSION;
@@ -76,11 +72,6 @@ public class HelixStoreGraveyard implements StoreGraveyard {
         largestUsedVersionNumber = deletedStore.getLargestUsedVersionNumber();
       }
     }
-
-    LOGGER.info(
-        "Found store: {} in the store graveyard. Will initialize the new store at version: {}.",
-        storeName,
-        largestUsedVersionNumber);
     return largestUsedVersionNumber;
   }
 

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/PushStatusStoreTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/PushStatusStoreTest.java
@@ -325,7 +325,7 @@ public class PushStatusStoreTest {
 
     String pushStatusStoreRT =
         Version.composeRealTimeTopic(VeniceSystemStoreUtils.getDaVinciPushStatusStoreName(storeName));
-    admin.truncateKafkaTopic(pushStatusStoreRT);
+    admin.getTopicManager().ensureTopicIsDeletedAndBlock(pubSubTopicRepository.getTopic(pushStatusStoreRT));
     TestUtils.waitForNonDeterministicAssertion(
         30,
         TimeUnit.SECONDS,

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceControllerWrapper.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceControllerWrapper.java
@@ -1,5 +1,6 @@
 package com.linkedin.venice.integration.utils;
 
+import static com.linkedin.venice.ConfigKeys.ACTIVE_ACTIVE_REAL_TIME_SOURCE_FABRIC_LIST;
 import static com.linkedin.venice.ConfigKeys.ADMIN_PORT;
 import static com.linkedin.venice.ConfigKeys.ADMIN_SECURE_PORT;
 import static com.linkedin.venice.ConfigKeys.ADMIN_TOPIC_REPLICATION_FACTOR;
@@ -239,8 +240,14 @@ public class VeniceControllerWrapper extends ProcessWrapper {
           fabricAllowList =
               extraProps.getStringWithAlternative(CHILD_CLUSTER_ALLOWLIST, CHILD_CLUSTER_WHITELIST, StringUtils.EMPTY);
         } else {
-          // child controller should at least know the urls or D2 ZK address of its local region
-          fabricAllowList = options.getExtraProperties().getProperty(LOCAL_REGION_NAME, options.getRegionName());
+          // Use A/A fabric list for fabric allow list in case this controller is used in a multi-region test setup
+          String fabricList = options.getExtraProperties().getProperty(ACTIVE_ACTIVE_REAL_TIME_SOURCE_FABRIC_LIST, "");
+          // Child controller should at least know the urls or D2 ZK address of its local region
+          if (fabricList.isEmpty()) {
+            fabricAllowList = options.getExtraProperties().getProperty(LOCAL_REGION_NAME, options.getRegionName());
+          } else {
+            fabricAllowList = fabricList;
+          }
         }
 
         /**

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceControllerWrapper.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceControllerWrapper.java
@@ -245,6 +245,11 @@ public class VeniceControllerWrapper extends ProcessWrapper {
           // Child controller should at least know the urls or D2 ZK address of its local region
           if (fabricList.isEmpty()) {
             fabricAllowList = options.getExtraProperties().getProperty(LOCAL_REGION_NAME, options.getRegionName());
+            String bootstrapServers = options.isSslToKafka()
+                ? options.getKafkaBroker().getSSLAddress()
+                : options.getKafkaBroker().getAddress();
+            builder.put(CHILD_DATA_CENTER_KAFKA_URL_PREFIX + "." + fabricAllowList, bootstrapServers);
+            builder.put(NATIVE_REPLICATION_FABRIC_ALLOWLIST, fabricAllowList);
           } else {
             fabricAllowList = fabricList;
           }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceController.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceController.java
@@ -11,6 +11,7 @@ import com.linkedin.venice.common.VeniceSystemStoreUtils;
 import com.linkedin.venice.controller.kafka.TopicCleanupService;
 import com.linkedin.venice.controller.kafka.TopicCleanupServiceForParentController;
 import com.linkedin.venice.controller.server.AdminSparkServer;
+import com.linkedin.venice.controller.stats.TopicCleanupServiceStats;
 import com.linkedin.venice.controller.supersetschema.SupersetSchemaGenerator;
 import com.linkedin.venice.controller.systemstore.SystemStoreRepairService;
 import com.linkedin.venice.d2.D2ClientFactory;
@@ -182,8 +183,11 @@ public class VeniceController {
     disabledPartitionEnablerService = Optional.empty();
     Admin admin = controllerService.getVeniceHelixAdmin();
     if (multiClusterConfigs.isParent()) {
-      topicCleanupService =
-          new TopicCleanupServiceForParentController(admin, multiClusterConfigs, pubSubTopicRepository);
+      topicCleanupService = new TopicCleanupServiceForParentController(
+          admin,
+          multiClusterConfigs,
+          pubSubTopicRepository,
+          new TopicCleanupServiceStats(metricsRepository));
       if (!(admin instanceof VeniceParentHelixAdmin)) {
         throw new VeniceException(
             "'VeniceParentHelixAdmin' is expected of the returned 'Admin' from 'VeniceControllerService#getVeniceHelixAdmin' in parent mode");
@@ -197,7 +201,11 @@ public class VeniceController {
         LOGGER.info("SystemStoreRepairServiceEnabled is enabled");
       }
     } else {
-      topicCleanupService = new TopicCleanupService(admin, multiClusterConfigs, pubSubTopicRepository);
+      topicCleanupService = new TopicCleanupService(
+          admin,
+          multiClusterConfigs,
+          pubSubTopicRepository,
+          new TopicCleanupServiceStats(metricsRepository));
       if (!(admin instanceof VeniceHelixAdmin)) {
         throw new VeniceException(
             "'VeniceHelixAdmin' is expected of the returned 'Admin' from 'VeniceControllerService#getVeniceHelixAdmin' in child mode");

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -1032,7 +1032,9 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
         // Delete All versions and push statues
         deleteAllVersionsInStore(clusterName, storeName);
         resources.getPushMonitor().cleanupStoreStatus(storeName);
-        // Clean up topics
+        // Truncate all the version topics, this is a prerequisite to delete the RT topic
+        truncateOldTopics(clusterName, store, true);
+
         if (!store.isMigrating()) {
           // for RT topic block on deletion so that next create store does not see the lingering RT topic which could
           // have different partition count
@@ -1042,7 +1044,6 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
             throw new VeniceRetriableException("Waiting for RT topic deletion for store: " + storeName);
           }
         }
-        truncateOldTopics(clusterName, store, true);
 
         // Cleanup system stores if applicable
         UserSystemStoreLifeCycleHelper.maybeDeleteSystemStoresForUserStore(

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -947,7 +947,19 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
        * Now there is no store exists in the store repository, we will try to retrieve the info from the graveyard.
        * Get the largestUsedVersionNumber from graveyard to avoid resource conflict.
        */
-      configureNewStore(newStore, config, storeGraveyard.getLargestUsedVersionNumber(storeName));
+      int largestUsedStoreVersion = storeGraveyard.getLargestUsedVersionNumber(storeName);
+      if (largestUsedStoreVersion == Store.NON_EXISTING_VERSION) {
+        LOGGER.info(
+            "Store: {} does NOT exist in the store graveyard. Will initialize the new store at version: {}.",
+            storeName,
+            Store.NON_EXISTING_VERSION);
+      } else {
+        LOGGER.info(
+            "Found store: {} in the store graveyard. Will initialize the new store at version: {}.",
+            storeName,
+            largestUsedStoreVersion);
+      }
+      configureNewStore(newStore, config, largestUsedStoreVersion);
 
       storeRepo.addStore(newStore);
       // Create global config for that store.

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/kafka/TopicCleanupService.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/kafka/TopicCleanupService.java
@@ -202,7 +202,7 @@ public class TopicCleanupService extends AbstractVeniceService {
           }
         }
         getTopicManager().ensureTopicIsDeletedAndBlockWithRetry(topic);
-        topicCleanupServiceStats.recordDeletedTopicsCount();
+        topicCleanupServiceStats.recordTopicDeleted();
       } catch (VeniceException e) {
         LOGGER.warn("Caught exception when trying to delete topic: {} - {}", topic.getName(), e.toString());
         topicCleanupServiceStats.recordTopicDeletionError();

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/kafka/TopicCleanupServiceForParentController.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/kafka/TopicCleanupServiceForParentController.java
@@ -42,7 +42,8 @@ public class TopicCleanupServiceForParentController extends TopicCleanupService 
   }
 
   private void cleanupVeniceTopics(TopicManager topicManager) {
-    Map<String, Map<PubSubTopic, Long>> allStoreTopics = getAllVeniceStoreTopicsRetentions(topicManager);
+    Map<PubSubTopic, Long> topicsWithRetention = topicManager.getAllTopicRetentions();
+    Map<String, Map<PubSubTopic, Long>> allStoreTopics = getAllVeniceStoreTopicsRetentions(topicsWithRetention);
     allStoreTopics.forEach((storeName, topics) -> {
       topics.forEach((topic, retention) -> {
         if (getAdmin().isTopicTruncatedBasedOnRetention(retention)) {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/kafka/TopicCleanupServiceForParentController.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/kafka/TopicCleanupServiceForParentController.java
@@ -2,6 +2,7 @@ package com.linkedin.venice.controller.kafka;
 
 import com.linkedin.venice.controller.Admin;
 import com.linkedin.venice.controller.VeniceControllerMultiClusterConfig;
+import com.linkedin.venice.controller.stats.TopicCleanupServiceStats;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.kafka.TopicManager;
 import com.linkedin.venice.pubsub.PubSubTopicRepository;
@@ -24,8 +25,9 @@ public class TopicCleanupServiceForParentController extends TopicCleanupService 
   public TopicCleanupServiceForParentController(
       Admin admin,
       VeniceControllerMultiClusterConfig multiClusterConfigs,
-      PubSubTopicRepository pubSubTopicRepository) {
-    super(admin, multiClusterConfigs, pubSubTopicRepository);
+      PubSubTopicRepository pubSubTopicRepository,
+      TopicCleanupServiceStats topicCleanupServiceStats) {
+    super(admin, multiClusterConfigs, pubSubTopicRepository, topicCleanupServiceStats);
   }
 
   @Override

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/StoresRoutes.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/StoresRoutes.java
@@ -842,8 +842,9 @@ public class StoresRoutes extends AbstractRoute {
       public void internalHandle(Request request, MultiStoreTopicsResponse veniceResponse) {
         AdminSparkServer.validateParams(request, GET_DELETABLE_STORE_TOPICS.getParams(), admin);
         try {
+          Map<PubSubTopic, Long> allTopicRetentions = admin.getTopicManager().getAllTopicRetentions();
           Map<String, Map<PubSubTopic, Long>> allStoreTopics =
-              TopicCleanupService.getAllVeniceStoreTopicsRetentions(admin.getTopicManager());
+              TopicCleanupService.getAllVeniceStoreTopicsRetentions(allTopicRetentions);
           List<String> deletableTopicsList = new ArrayList<>();
           int minNumberOfUnusedKafkaTopicsToPreserve = admin.getMinNumberOfUnusedKafkaTopicsToPreserve();
           allStoreTopics.forEach((storeName, topicsWithRetention) -> {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/stats/TopicCleanupServiceStats.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/stats/TopicCleanupServiceStats.java
@@ -1,0 +1,33 @@
+package com.linkedin.venice.controller.stats;
+
+import com.linkedin.venice.stats.AbstractVeniceStats;
+import com.linkedin.venice.stats.Gauge;
+import io.tehuti.metrics.MetricsRepository;
+import io.tehuti.metrics.Sensor;
+import io.tehuti.metrics.stats.Count;
+
+
+public class TopicCleanupServiceStats extends AbstractVeniceStats {
+  private final Sensor deletableTopicsCountGaugeSensor;
+  private final Sensor deletedTopicsCountSensor;
+  private final Sensor topicDeletionErrorCountSensor;
+
+  public TopicCleanupServiceStats(MetricsRepository metricsRepository) {
+    super(metricsRepository, "TopicCleanupService");
+    deletableTopicsCountGaugeSensor = registerSensorIfAbsent("deletable_topics_count", new Gauge());
+    deletedTopicsCountSensor = registerSensorIfAbsent("deleted_topics_count", new Count());
+    topicDeletionErrorCountSensor = registerSensorIfAbsent("topic_deletion_error_count", new Count());
+  }
+
+  public void recordDeletableTopicsCount(int deletableTopicsCount) {
+    deletableTopicsCountGaugeSensor.record(deletableTopicsCount);
+  }
+
+  public void recordDeletedTopicsCount() {
+    deletedTopicsCountSensor.record();
+  }
+
+  public void recordTopicDeletionError() {
+    topicDeletionErrorCountSensor.record();
+  }
+}

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/stats/TopicCleanupServiceStats.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/stats/TopicCleanupServiceStats.java
@@ -4,30 +4,30 @@ import com.linkedin.venice.stats.AbstractVeniceStats;
 import com.linkedin.venice.stats.Gauge;
 import io.tehuti.metrics.MetricsRepository;
 import io.tehuti.metrics.Sensor;
-import io.tehuti.metrics.stats.Count;
+import io.tehuti.metrics.stats.Rate;
 
 
 public class TopicCleanupServiceStats extends AbstractVeniceStats {
   private final Sensor deletableTopicsCountGaugeSensor;
-  private final Sensor deletedTopicsCountSensor;
-  private final Sensor topicDeletionErrorCountSensor;
+  private final Sensor topicsDeletedRateSensor;
+  private final Sensor topicDeletionErrorRateSensor;
 
   public TopicCleanupServiceStats(MetricsRepository metricsRepository) {
     super(metricsRepository, "TopicCleanupService");
     deletableTopicsCountGaugeSensor = registerSensorIfAbsent("deletable_topics_count", new Gauge());
-    deletedTopicsCountSensor = registerSensorIfAbsent("deleted_topics_count", new Count());
-    topicDeletionErrorCountSensor = registerSensorIfAbsent("topic_deletion_error_count", new Count());
+    topicsDeletedRateSensor = registerSensorIfAbsent("topics_deleted_rate", new Rate());
+    topicDeletionErrorRateSensor = registerSensorIfAbsent("topic_deletion_error_rate", new Rate());
   }
 
   public void recordDeletableTopicsCount(int deletableTopicsCount) {
     deletableTopicsCountGaugeSensor.record(deletableTopicsCount);
   }
 
-  public void recordDeletedTopicsCount() {
-    deletedTopicsCountSensor.record();
+  public void recordTopicDeleted() {
+    topicsDeletedRateSensor.record();
   }
 
   public void recordTopicDeletionError() {
-    topicDeletionErrorCountSensor.record();
+    topicDeletionErrorRateSensor.record();
   }
 }

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/kafka/TestTopicCleanupService.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/kafka/TestTopicCleanupService.java
@@ -266,13 +266,14 @@ public class TestTopicCleanupService {
     verify(topicManager, atLeastOnce()).ensureTopicIsDeletedAndBlockWithRetry(getPubSubTopic(storeName1, "_v1"));
     verify(topicManager, atLeastOnce()).ensureTopicIsDeletedAndBlockWithRetry(getPubSubTopic(storeName1, "_v2"));
     verify(topicManager, atLeastOnce()).ensureTopicIsDeletedAndBlockWithRetry(getPubSubTopic(storeName2, "_v1"));
+    // If we are truncating the RT then all version topics need to be deleted (no min number of version topics to keep)
+    verify(topicManager, atLeastOnce()).ensureTopicIsDeletedAndBlockWithRetry(getPubSubTopic(storeName3, "_v4"));
     verify(topicManager, never()).ensureTopicIsDeletedAndBlockWithRetry(getPubSubTopic(storeName2, "_v2"));
     verify(topicManager, never()).ensureTopicIsDeletedAndBlockWithRetry(getPubSubTopic(storeName3, "_rt"));
     verify(topicManager, never()).ensureTopicIsDeletedAndBlockWithRetry(getPubSubTopic(storeName1, "_v3"));
     verify(topicManager, never()).ensureTopicIsDeletedAndBlockWithRetry(getPubSubTopic(storeName1, "_v4"));
     verify(topicManager, never()).ensureTopicIsDeletedAndBlockWithRetry(getPubSubTopic(storeName1, "_rt"));
     verify(topicManager, never()).ensureTopicIsDeletedAndBlockWithRetry(getPubSubTopic(storeName2, "_v3"));
-    verify(topicManager, never()).ensureTopicIsDeletedAndBlockWithRetry(getPubSubTopic(storeName3, "_v4"));
     verify(topicManager, never()).ensureTopicIsDeletedAndBlockWithRetry(getPubSubTopic("non_venice_topic1_rt", ""));
   }
 

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/kafka/TestTopicCleanupService.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/kafka/TestTopicCleanupService.java
@@ -9,11 +9,10 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
-import com.linkedin.venice.common.VeniceSystemStoreType;
 import com.linkedin.venice.controller.Admin;
+import com.linkedin.venice.controller.VeniceControllerConfig;
 import com.linkedin.venice.controller.VeniceControllerMultiClusterConfig;
 import com.linkedin.venice.helix.HelixReadOnlyStoreConfigRepository;
 import com.linkedin.venice.kafka.TopicManager;
@@ -21,11 +20,10 @@ import com.linkedin.venice.meta.StoreConfig;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.pubsub.PubSubTopicRepository;
 import com.linkedin.venice.pubsub.api.PubSubTopic;
-import com.linkedin.venice.system.store.MetaStoreWriter;
 import com.linkedin.venice.utils.TestUtils;
 import com.linkedin.venice.utils.Utils;
-import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -33,7 +31,6 @@ import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
-import org.apache.kafka.common.PartitionInfo;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
@@ -44,6 +41,7 @@ public class TestTopicCleanupService {
   private Admin admin;
   private HelixReadOnlyStoreConfigRepository storeConfigRepository;
   private TopicManager topicManager;
+  private TopicManager remoteTopicManager;
   private TopicCleanupService topicCleanupService;
   private final PubSubTopicRepository pubSubTopicRepository = new PubSubTopicRepository();
 
@@ -60,6 +58,19 @@ public class TestTopicCleanupService {
     doReturn(0L).when(config).getTopicCleanupSleepIntervalBetweenTopicListFetchMs();
     doReturn(1).when(config).getMinNumberOfUnusedKafkaTopicsToPreserve();
     doReturn(1).when(admin).getMinNumberOfUnusedKafkaTopicsToPreserve();
+
+    VeniceControllerConfig veniceControllerConfig = mock(VeniceControllerConfig.class);
+    doReturn(veniceControllerConfig).when(config).getCommonConfig();
+    doReturn("local,remote").when(veniceControllerConfig).getChildDatacenters();
+    Map<String, String> dataCenterToBootstrapServerMap = new HashMap<>();
+    dataCenterToBootstrapServerMap.put("local", "local");
+    dataCenterToBootstrapServerMap.put("remote", "remote");
+    doReturn(dataCenterToBootstrapServerMap).when(config).getChildDataCenterKafkaUrlMap();
+    doReturn("local").when(topicManager).getPubSubBootstrapServers();
+    remoteTopicManager = mock(TopicManager.class);
+    doReturn(remoteTopicManager).when(admin).getTopicManager("remote");
+    doReturn(Collections.emptyMap()).when(remoteTopicManager).getAllTopicRetentions();
+
     topicCleanupService = new TopicCleanupService(admin, config, pubSubTopicRepository);
   }
 
@@ -78,10 +89,8 @@ public class TestTopicCleanupService {
     storeTopics.put(getPubSubTopic("store2_v10", ""), 5000L);
     storeTopics.put(getPubSubTopic("store2_v11", ""), Long.MAX_VALUE);
 
-    doReturn(storeTopics).when(topicManager).getAllTopicRetentions();
-
     Map<String, Map<PubSubTopic, Long>> filteredStoreTopics =
-        TopicCleanupService.getAllVeniceStoreTopicsRetentions(admin.getTopicManager());
+        TopicCleanupService.getAllVeniceStoreTopicsRetentions(storeTopics);
     Assert.assertEquals(filteredStoreTopics.size(), 2);
     Assert.assertEquals(filteredStoreTopics.get("store1").size(), 4);
     Assert.assertEquals(filteredStoreTopics.get("store2").size(), 2);
@@ -154,14 +163,35 @@ public class TestTopicCleanupService {
   @Test
   public void testCleanupVeniceTopics() throws ExecutionException {
     String storeName1 = Utils.getUniqueString("store1");
+    String storeName2 = Utils.getUniqueString("store2");
+    String storeName3 = Utils.getUniqueString("store3");
     Map<PubSubTopic, Long> storeTopics = new HashMap<>();
     storeTopics.put(getPubSubTopic(storeName1, "_v1"), 1000L);
     storeTopics.put(getPubSubTopic(storeName1, "_v2"), 1000L);
     storeTopics.put(getPubSubTopic(storeName1, "_v3"), Long.MAX_VALUE);
     storeTopics.put(getPubSubTopic(storeName1, "_v4"), 1000L);
     storeTopics.put(getPubSubTopic(storeName1, "_rt"), Long.MAX_VALUE);
+    storeTopics.put(getPubSubTopic(storeName2, "_rt"), 1000L);
+    storeTopics.put(getPubSubTopic(storeName2, "_v1"), 1000L);
+    storeTopics.put(getPubSubTopic(storeName3, "_rt"), 1000L);
 
-    doReturn(storeTopics).when(topicManager).getAllTopicRetentions();
+    Map<PubSubTopic, Long> storeTopics2 = new HashMap<>();
+    storeTopics2.put(getPubSubTopic(storeName1, "_v3"), Long.MAX_VALUE);
+    storeTopics2.put(getPubSubTopic(storeName1, "_rt"), Long.MAX_VALUE);
+    storeTopics2.put(getPubSubTopic(storeName2, "_rt"), 1000L);
+    storeTopics2.put(getPubSubTopic(storeName3, "_rt"), 1000L);
+
+    Map<PubSubTopic, Long> remoteTopics = new HashMap<>();
+    remoteTopics.put(getPubSubTopic(storeName2, "_rt"), 1000L);
+    remoteTopics.put(getPubSubTopic(storeName3, "_rt"), 1000L);
+    remoteTopics.put(getPubSubTopic(storeName3, "_v1"), 1000L);
+
+    Map<PubSubTopic, Long> remoteTopics2 = new HashMap<>();
+    remoteTopics2.put(getPubSubTopic(storeName2, "_rt"), 1000L);
+    remoteTopics2.put(getPubSubTopic(storeName3, "_rt"), 1000L);
+
+    when(topicManager.getAllTopicRetentions()).thenReturn(storeTopics).thenReturn(storeTopics2);
+    when(remoteTopicManager.getAllTopicRetentions()).thenReturn(remoteTopics).thenReturn(remoteTopics2);
     doReturn(false).when(admin).isTopicTruncatedBasedOnRetention(Long.MAX_VALUE);
     doReturn(true).when(admin).isTopicTruncatedBasedOnRetention(1000L);
     doReturn(Optional.of(new StoreConfig(storeName1))).when(storeConfigRepository).getStoreConfig(storeName1);
@@ -173,12 +203,18 @@ public class TestTopicCleanupService {
     verify(topicManager, atLeastOnce()).ensureTopicIsDeletedAndBlockWithRetry(getPubSubTopic(storeName1, "_v2"));
     verify(topicManager, never()).ensureTopicIsDeletedAndBlockWithRetry(getPubSubTopic(storeName1, "_v3"));
     verify(topicManager, never()).ensureTopicIsDeletedAndBlockWithRetry(getPubSubTopic(storeName1, "_v4"));
+    verify(topicManager, atLeastOnce()).ensureTopicIsDeletedAndBlockWithRetry(getPubSubTopic(storeName2, "_v1"));
+    // Delete should be blocked by local VT
+    verify(topicManager, never()).ensureTopicIsDeletedAndBlockWithRetry(getPubSubTopic(storeName2, "_rt"));
+    // Delete should be blocked by remote VT
+    verify(topicManager, never()).ensureTopicIsDeletedAndBlockWithRetry(getPubSubTopic(storeName3, "_rt"));
 
-    // Updated real-time topic to use low retention policy
-    storeTopics.put(getPubSubTopic(storeName1, "_rt"), 1000L);
     topicCleanupService.cleanupVeniceTopics();
 
-    verify(topicManager, atLeastOnce()).ensureTopicIsDeletedAndBlockWithRetry(getPubSubTopic(storeName1, "_rt"));
+    verify(topicManager, never()).ensureTopicIsDeletedAndBlockWithRetry(getPubSubTopic(storeName1, "_v3"));
+    verify(topicManager, never()).ensureTopicIsDeletedAndBlockWithRetry(getPubSubTopic(storeName1, "_rt"));
+    verify(topicManager, atLeastOnce()).ensureTopicIsDeletedAndBlockWithRetry(getPubSubTopic(storeName2, "_rt"));
+    verify(topicManager, atLeastOnce()).ensureTopicIsDeletedAndBlockWithRetry(getPubSubTopic(storeName3, "_rt"));
   }
 
   private PubSubTopic getPubSubTopic(String storeName, String suffix) {
@@ -190,6 +226,7 @@ public class TestTopicCleanupService {
     String storeName1 = Utils.getUniqueString("store1");
     String storeName2 = Utils.getUniqueString("store2");
     String storeName3 = Utils.getUniqueString("store3");
+    String storeName4 = Utils.getUniqueString("store4");
     doReturn(Optional.of(new StoreConfig(storeName1))).when(storeConfigRepository).getStoreConfig(storeName1);
     doReturn(Optional.of(new StoreConfig(storeName2))).when(storeConfigRepository).getStoreConfig(storeName2);
     doReturn(Optional.of(new StoreConfig(storeName3))).when(storeConfigRepository).getStoreConfig(storeName3);
@@ -200,7 +237,7 @@ public class TestTopicCleanupService {
     storeTopics1.put(getPubSubTopic(storeName1, "_v3"), Long.MAX_VALUE);
     storeTopics1.put(getPubSubTopic(storeName1, "_v4"), 1000L);
     storeTopics1.put(getPubSubTopic(storeName1, "_rt"), Long.MAX_VALUE);
-    // storeTopics1.put(getPubSubTopic("non_venice_topic1", ""), Long.MAX_VALUE);
+    storeTopics1.put(getPubSubTopic(storeName4, "_rt"), 1000L);
 
     Map<PubSubTopic, Long> storeTopics2 = new HashMap<>();
     storeTopics2.put(getPubSubTopic(storeName2, "_v1"), 1000L);
@@ -209,11 +246,8 @@ public class TestTopicCleanupService {
     storeTopics2.put(getPubSubTopic(storeName3, "_v4"), 1000L);
     storeTopics2.put(getPubSubTopic(storeName3, "_rt"), 1000L);
 
-    Map<PubSubTopic, Long> storeTopics3 = new HashMap<>();
-
     when(topicManager.getAllTopicRetentions()).thenReturn(storeTopics1)
         .thenReturn(storeTopics2)
-        .thenReturn(storeTopics3)
         .thenReturn(new HashMap<>());
 
     doReturn(false).when(admin).isTopicTruncatedBasedOnRetention(Long.MAX_VALUE);
@@ -233,7 +267,7 @@ public class TestTopicCleanupService {
     verify(topicManager, atLeastOnce()).ensureTopicIsDeletedAndBlockWithRetry(getPubSubTopic(storeName1, "_v2"));
     verify(topicManager, atLeastOnce()).ensureTopicIsDeletedAndBlockWithRetry(getPubSubTopic(storeName2, "_v1"));
     verify(topicManager, never()).ensureTopicIsDeletedAndBlockWithRetry(getPubSubTopic(storeName2, "_v2"));
-    verify(topicManager, atLeastOnce()).ensureTopicIsDeletedAndBlockWithRetry(getPubSubTopic(storeName3, "_rt"));
+    verify(topicManager, never()).ensureTopicIsDeletedAndBlockWithRetry(getPubSubTopic(storeName3, "_rt"));
     verify(topicManager, never()).ensureTopicIsDeletedAndBlockWithRetry(getPubSubTopic(storeName1, "_v3"));
     verify(topicManager, never()).ensureTopicIsDeletedAndBlockWithRetry(getPubSubTopic(storeName1, "_v4"));
     verify(topicManager, never()).ensureTopicIsDeletedAndBlockWithRetry(getPubSubTopic(storeName1, "_rt"));
@@ -303,77 +337,6 @@ public class TestTopicCleanupService {
     verify(topicManager, never()).ensureTopicIsDeletedAndBlockWithRetry(getPubSubTopic(storeName1, "_v4"));
     verify(topicManager, never()).ensureTopicIsDeletedAndBlockWithRetry(getPubSubTopic(storeName1, "_rt"));
     // verify(topicManager, never()).ensureTopicIsDeletedAndBlockWithRetry(getPubSubTopic("non_venice_topic1", ""));
-  }
-
-  @Test
-  public void testCleanupReplicaStatusesFromMetaSystemStoreInParent() {
-    doReturn(true).when(admin).isParent();
-    PubSubTopic versionTopic = pubSubTopicRepository.getTopic(Version.composeKafkaTopic("test", 1));
-    assertFalse(topicCleanupService.cleanupReplicaStatusesFromMetaSystemStore(versionTopic));
-  }
-
-  @Test
-  public void testCleanupReplicaStatusesFromMetaSystemStoreWithRTTopic() {
-    doReturn(false).when(admin).isParent();
-    PubSubTopic rtTopic = pubSubTopicRepository.getTopic(Version.composeRealTimeTopic("test"));
-    assertFalse(topicCleanupService.cleanupReplicaStatusesFromMetaSystemStore(rtTopic));
-  }
-
-  @Test
-  public void testCleanupReplicaStatusesFromMetaSystemStoreWhenMetaSystemStoreRTTopicNotExist() {
-    doReturn(false).when(admin).isParent();
-    String storeName = Utils.getUniqueString("test_store");
-    doReturn(Optional.of(new StoreConfig(storeName))).when(storeConfigRepository).getStoreConfig(storeName);
-    int version = 1;
-    PubSubTopic versionTopic = pubSubTopicRepository.getTopic(Version.composeKafkaTopic(storeName, version));
-    HelixReadOnlyStoreConfigRepository repository = mock(HelixReadOnlyStoreConfigRepository.class);
-    StoreConfig storeConfig = new StoreConfig(storeName);
-    String cluster = "test_cluster";
-    storeConfig.setCluster(cluster);
-    doReturn(Optional.of(storeConfig)).when(repository).getStoreConfig(storeName);
-    doReturn(repository).when(admin).getStoreConfigRepo();
-    PubSubTopic rtTopicForMetaSystemStore = pubSubTopicRepository
-        .getTopic(Version.composeRealTimeTopic(VeniceSystemStoreType.META_STORE.getSystemStoreName(storeName)));
-    TopicManager topicManager = mock(TopicManager.class);
-    doReturn(false).when(topicManager).containsTopic(rtTopicForMetaSystemStore);
-    doReturn(topicManager).when(admin).getTopicManager();
-    assertFalse(topicCleanupService.cleanupReplicaStatusesFromMetaSystemStore(versionTopic));
-  }
-
-  @Test
-  public void testCleanupReplicaStatusesFromMetaSystemStoreWhenMetaSystemStoreRTTopicExist() {
-    doReturn(false).when(admin).isParent();
-    String storeName = Utils.getUniqueString("test_store");
-    doReturn(Optional.of(new StoreConfig(storeName))).when(storeConfigRepository).getStoreConfig(storeName);
-    int version = 1;
-    PubSubTopic versionTopic = pubSubTopicRepository.getTopic(Version.composeKafkaTopic(storeName, version));
-    HelixReadOnlyStoreConfigRepository repository = mock(HelixReadOnlyStoreConfigRepository.class);
-    StoreConfig storeConfig = new StoreConfig(storeName);
-    String cluster = "test_cluster";
-    storeConfig.setCluster(cluster);
-    doReturn(Optional.of(storeConfig)).when(repository).getStoreConfig(storeName);
-    doReturn(repository).when(admin).getStoreConfigRepo();
-    PubSubTopic rtTopicForMetaSystemStore = pubSubTopicRepository
-        .getTopic(Version.composeRealTimeTopic(VeniceSystemStoreType.META_STORE.getSystemStoreName(storeName)));
-    TopicManager topicManager = mock(TopicManager.class);
-    doReturn(true).when(topicManager).containsTopic(rtTopicForMetaSystemStore);
-    doReturn(topicManager).when(admin).getTopicManager();
-
-    // Topic is with partition count: 3
-    int partitionCnt = 3;
-    List<PartitionInfo> partitionInfoList = new ArrayList<>();
-    for (int i = 0; i < partitionCnt; ++i) {
-      partitionInfoList.add(new PartitionInfo(versionTopic.getName(), i, null, null, null));
-    }
-    doReturn(partitionInfoList).when(topicManager).partitionsFor(versionTopic);
-
-    MetaStoreWriter metaStoreWriter = mock(MetaStoreWriter.class);
-    doReturn(metaStoreWriter).when(admin).getMetaStoreWriter();
-
-    assertTrue(topicCleanupService.cleanupReplicaStatusesFromMetaSystemStore(versionTopic));
-    for (int i = 0; i < partitionCnt; ++i) {
-      verify(metaStoreWriter).deleteStoreReplicaStatus(cluster, storeName, version, i);
-    }
   }
 
   @Test

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/kafka/TestTopicCleanupService.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/kafka/TestTopicCleanupService.java
@@ -219,7 +219,7 @@ public class TestTopicCleanupService {
     verify(topicManager, never()).ensureTopicIsDeletedAndBlockWithRetry(getPubSubTopic(storeName3, "_rt"));
     verify(topicCleanupServiceStats, atLeastOnce()).recordDeletableTopicsCount(5);
     verify(topicCleanupServiceStats, never()).recordTopicDeletionError();
-    verify(topicCleanupServiceStats, atLeastOnce()).recordDeletedTopicsCount();
+    verify(topicCleanupServiceStats, atLeastOnce()).recordTopicDeleted();
 
     topicCleanupService.cleanupVeniceTopics();
 

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/kafka/TestTopicCleanupServiceForMultiKafkaClusters.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/kafka/TestTopicCleanupServiceForMultiKafkaClusters.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.verify;
 import com.linkedin.venice.controller.Admin;
 import com.linkedin.venice.controller.VeniceControllerConfig;
 import com.linkedin.venice.controller.VeniceControllerMultiClusterConfig;
+import com.linkedin.venice.controller.stats.TopicCleanupServiceStats;
 import com.linkedin.venice.kafka.TopicManager;
 import com.linkedin.venice.pubsub.PubSubTopicRepository;
 import com.linkedin.venice.pubsub.api.PubSubTopic;
@@ -59,8 +60,10 @@ public class TestTopicCleanupServiceForMultiKafkaClusters {
     topicManager2 = mock(TopicManager.class);
     doReturn(kafkaClusterServerUrl2).when(topicManager2).getPubSubBootstrapServers();
     doReturn(topicManager2).when(admin).getTopicManager(kafkaClusterServerUrl2);
+    TopicCleanupServiceStats topicCleanupServiceStats = mock(TopicCleanupServiceStats.class);
 
-    topicCleanupService = new TopicCleanupServiceForParentController(admin, config, pubSubTopicRepository);
+    topicCleanupService =
+        new TopicCleanupServiceForParentController(admin, config, pubSubTopicRepository, topicCleanupServiceStats);
   }
 
   @Test

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/kafka/TestTopicCleanupServiceForMultiKafkaClusters.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/kafka/TestTopicCleanupServiceForMultiKafkaClusters.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 import com.linkedin.venice.controller.Admin;
+import com.linkedin.venice.controller.VeniceControllerConfig;
 import com.linkedin.venice.controller.VeniceControllerMultiClusterConfig;
 import com.linkedin.venice.kafka.TopicManager;
 import com.linkedin.venice.pubsub.PubSubTopicRepository;
@@ -32,6 +33,9 @@ public class TestTopicCleanupServiceForMultiKafkaClusters {
     VeniceControllerMultiClusterConfig config = mock(VeniceControllerMultiClusterConfig.class);
     doReturn(1000l).when(config).getTopicCleanupSleepIntervalBetweenTopicListFetchMs();
     doReturn(2).when(config).getTopicCleanupDelayFactor();
+    VeniceControllerConfig veniceControllerConfig = mock(VeniceControllerConfig.class);
+    doReturn(veniceControllerConfig).when(config).getCommonConfig();
+    doReturn("fabric1,fabric2").when(veniceControllerConfig).getChildDatacenters();
 
     String kafkaClusterKey1 = "fabric1";
     String kafkaClusterKey2 = "fabric2";

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/kafka/TestTopicCleanupServiceForParentController.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/kafka/TestTopicCleanupServiceForParentController.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.verify;
 import com.linkedin.venice.controller.Admin;
 import com.linkedin.venice.controller.VeniceControllerConfig;
 import com.linkedin.venice.controller.VeniceControllerMultiClusterConfig;
+import com.linkedin.venice.controller.stats.TopicCleanupServiceStats;
 import com.linkedin.venice.kafka.TopicManager;
 import com.linkedin.venice.pubsub.PubSubTopicRepository;
 import com.linkedin.venice.pubsub.api.PubSubTopic;
@@ -35,7 +36,9 @@ public class TestTopicCleanupServiceForParentController {
     VeniceControllerConfig veniceControllerConfig = mock(VeniceControllerConfig.class);
     doReturn(veniceControllerConfig).when(config).getCommonConfig();
     doReturn("dc1").when(veniceControllerConfig).getChildDatacenters();
-    topicCleanupService = new TopicCleanupServiceForParentController(admin, config, pubSubTopicRepository);
+    TopicCleanupServiceStats topicCleanupServiceStats = mock(TopicCleanupServiceStats.class);
+    topicCleanupService =
+        new TopicCleanupServiceForParentController(admin, config, pubSubTopicRepository, topicCleanupServiceStats);
   }
 
   @Test

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/kafka/TestTopicCleanupServiceForParentController.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/kafka/TestTopicCleanupServiceForParentController.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 import com.linkedin.venice.controller.Admin;
+import com.linkedin.venice.controller.VeniceControllerConfig;
 import com.linkedin.venice.controller.VeniceControllerMultiClusterConfig;
 import com.linkedin.venice.kafka.TopicManager;
 import com.linkedin.venice.pubsub.PubSubTopicRepository;
@@ -31,6 +32,9 @@ public class TestTopicCleanupServiceForParentController {
     VeniceControllerMultiClusterConfig config = mock(VeniceControllerMultiClusterConfig.class);
     doReturn(1000l).when(config).getTopicCleanupSleepIntervalBetweenTopicListFetchMs();
     doReturn(2).when(config).getTopicCleanupDelayFactor();
+    VeniceControllerConfig veniceControllerConfig = mock(VeniceControllerConfig.class);
+    doReturn(veniceControllerConfig).when(config).getCommonConfig();
+    doReturn("dc1").when(veniceControllerConfig).getChildDatacenters();
     topicCleanupService = new TopicCleanupServiceForParentController(admin, config, pubSubTopicRepository);
   }
 


### PR DESCRIPTION
## [common][controller] Delete all version topics before deleting RT topic

1. TopicCleanupService in child datacenters will now only delete RT topic if all version topics of the corresponding store is deleted in all child fabrics. This is to ensure there are no ongoing ingestions still polling for these RT topics before deleting them.

2. Cleaned up some excessive logging in store graveyard and FC related meta system store updates in cleanup service that's no longer applicable.

## How was this PR tested?
Existing tests and new unit tests.

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.