### PR TITLE
[admin-tool] Add support to dump UPDATE records and RMD records in Kafka Topic Dumper

### DIFF
--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/AdminTool.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/AdminTool.java
@@ -1616,7 +1616,9 @@ public class AdminTool {
       maxConsumeAttempts = Integer.parseInt(getOptionalArgument(cmd, Arg.MAX_POLL_ATTEMPTS));
     }
 
-    boolean logMetadataOnly = cmd.hasOption(Arg.LOG_METADATA.toString());
+    boolean logMetadata = cmd.hasOption(Arg.LOG_METADATA.toString());
+    boolean logDataRecord = cmd.hasOption(Arg.LOG_DATA_RECORD.toString());
+    boolean logRmdRecord = cmd.hasOption(Arg.LOG_RMD_RECORD.toString());
     try (PubSubConsumerAdapter consumer = getConsumer(consumerProps)) {
       try (KafkaTopicDumper ktd = new KafkaTopicDumper(
           controllerClient,
@@ -1627,7 +1629,9 @@ public class AdminTool {
           messageCount,
           parentDir,
           maxConsumeAttempts,
-          logMetadataOnly)) {
+          logMetadata,
+          logDataRecord,
+          logRmdRecord)) {
         ktd.fetchAndProcess();
       } catch (Exception e) {
         System.err.println("Something went wrong during topic dump");

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/Arg.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/Arg.java
@@ -167,7 +167,9 @@ public enum Arg {
   SOURCE_FABRIC("source-fabric", "sf", true, "The fabric where metadata/data copy over starts from"),
   DEST_FABRIC("dest-fabric", "df", true, "The fabric where metadata/data gets copy over into"),
   ACL_PERMS("acl-perms", "ap", true, "Acl permissions for the store"),
-  LOG_METADATA("log-metadata", "lm", false, "Only log the metadata for each kafka message on console"),
+  LOG_METADATA("log-metadata", "lm", false, "Log the metadata for each kafka message on console"),
+  LOG_DATA_RECORD("log-data-record", "ldr", false, "Log the data record for each kafka message on console"),
+  LOG_RMD_RECORD("log-rmd-record", "lrr", false, "Log the RMD record for each kafka message on console"),
   NATIVE_REPLICATION_SOURCE_FABRIC(
       "native-replication-source-fabric", "nrsf", true,
       "The source fabric name to be used in native replication. Remote consumption will happen from kafka in this fabric."

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/KafkaTopicDumper.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/KafkaTopicDumper.java
@@ -341,7 +341,10 @@ public class KafkaTopicDumper implements AutoCloseable {
     }
   }
 
-  void logDataRecord(PubSubMessage<KafkaKey, KafkaMessageEnvelope, Long> record, boolean logReplicationMetadata) {
+  void logDataRecord(
+      PubSubMessage<KafkaKey, KafkaMessageEnvelope, Long> record,
+      boolean logRecordMetadata,
+      boolean logReplicationMetadata) {
     KafkaKey kafkaKey = record.getKey();
     if (kafkaKey.isControlMessage()) {
       return;
@@ -353,6 +356,11 @@ public class KafkaTopicDumper implements AutoCloseable {
         record.getOffset(),
         msgType.toString(),
         buildDataRecordLog(record, logReplicationMetadata));
+
+    // Potentially print the record metadata for data record.
+    if (logRecordMetadata) {
+      logRecordMetadata(record);
+    }
   }
 
   String buildDataRecordLog(
@@ -411,12 +419,11 @@ public class KafkaTopicDumper implements AutoCloseable {
 
   private void processRecord(PubSubMessage<KafkaKey, KafkaMessageEnvelope, Long> record) {
     if (logDataRecord) {
-      logDataRecord(record, logRmdRecord);
-    }
-    if (logMetadata) {
+      logDataRecord(record, logMetadata, logRmdRecord);
+    } else if (logMetadata) {
       logRecordMetadata(record);
-    }
-    if (!(logDataRecord || logMetadata)) {
+    } else {
+      // If no console logging is enabled, we will save data records into local file.
       writeToFile(record);
     }
   }

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/KafkaTopicDumper.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/KafkaTopicDumper.java
@@ -19,21 +19,25 @@ import com.linkedin.venice.kafka.protocol.KafkaMessageEnvelope;
 import com.linkedin.venice.kafka.protocol.LeaderMetadata;
 import com.linkedin.venice.kafka.protocol.ProducerMetadata;
 import com.linkedin.venice.kafka.protocol.Put;
+import com.linkedin.venice.kafka.protocol.Update;
 import com.linkedin.venice.kafka.protocol.enums.ControlMessageType;
 import com.linkedin.venice.kafka.protocol.enums.MessageType;
 import com.linkedin.venice.message.KafkaKey;
+import com.linkedin.venice.meta.StoreInfo;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.pubsub.PubSubTopicPartitionImpl;
 import com.linkedin.venice.pubsub.PubSubTopicRepository;
 import com.linkedin.venice.pubsub.api.PubSubConsumerAdapter;
 import com.linkedin.venice.pubsub.api.PubSubMessage;
 import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
+import com.linkedin.venice.schema.AvroSchemaParseUtils;
 import com.linkedin.venice.serialization.avro.ChunkedValueManifestSerializer;
 import com.linkedin.venice.serializer.AvroSpecificDeserializer;
 import com.linkedin.venice.storage.protocol.ChunkedKeySuffix;
 import com.linkedin.venice.storage.protocol.ChunkedValueManifest;
 import com.linkedin.venice.utils.ByteUtils;
 import com.linkedin.venice.utils.Utils;
+import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
 import com.linkedin.venice.views.ChangeCaptureView;
 import java.io.File;
 import java.io.IOException;
@@ -58,6 +62,13 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 
+/**
+ * This class contains logic to dump Venice Kafka topics.
+ * It has several modes:
+ * (1) Log metadata: Print out Kafka message metadata to console.
+ * (2) Log data record: Print out data record's key/value and optionally RMD to console.
+ * (3) Save data record to file: If both (1)&(2) is not enabled, it will save all the data record value payload to local disk.
+ */
 public class KafkaTopicDumper implements AutoCloseable {
   private static final Logger LOGGER = LogManager.getLogger(KafkaTopicDumper.class);
   private static final String VENICE_ETL_KEY_FIELD = "key";
@@ -69,6 +80,8 @@ public class KafkaTopicDumper implements AutoCloseable {
   private static final String VENICE_ETL_BROKER_TIMESTAMP_FIELD = "brokerTimestamp";
   private static final String VENICE_ETL_PRODUCER_TIMESTAMP_FIELD = "producerTimestamp";
   private static final String VENICE_ETL_PARTITION_FIELD = "partition";
+  private static final String REGULAR_REC = "REG";
+  private static final String CONTROL_REC = "CTRL";
 
   private final String topicName;
   private final int partition;
@@ -76,13 +89,16 @@ public class KafkaTopicDumper implements AutoCloseable {
   private final Schema keySchema;
   private final String latestValueSchemaStr;
   private final Schema[] allValueSchemas;
+  private final Map<Integer, ValueAndDerivedSchemaData> schemaDataMap = new VeniceConcurrentHashMap<>();
   private final boolean isChunkingEnabled;
   private final String parentDirectory;
   private final PubSubConsumerAdapter consumer;
   private final long messageCount;
   private final long endOffset;
   private final int maxConsumeAttempts;
-  private final boolean logMetadataOnly;
+  private final boolean logMetadata;
+  private final boolean logDataRecord;
+  private final boolean logRmdRecord;
 
   private final ChunkKeyValueTransformer chunkKeyValueTransformer;
   private final AvroSpecificDeserializer<ChunkedKeySuffix> chunkedKeySuffixDeserializer;
@@ -104,17 +120,20 @@ public class KafkaTopicDumper implements AutoCloseable {
       int messageCount,
       String parentDir,
       int maxConsumeAttempts,
-      boolean logMetadataOnly) {
+      boolean logMetadata,
+      boolean logDataRecord,
+      boolean logRmdRecord) {
     this.consumer = consumer;
     this.maxConsumeAttempts = maxConsumeAttempts;
-    String storeName;
+    String storeName = Version.parseStoreFromKafkaTopicName(topic);
+    StoreInfo storeInfo = controllerClient.getStore(storeName).getStore();
     if (Version.isATopicThatIsVersioned(topic)) {
-      storeName = Version.parseStoreFromKafkaTopicName(topic);
       int version = Version.parseVersionFromKafkaTopicName(topic);
-      this.isChunkingEnabled =
-          controllerClient.getStore(storeName).getStore().getVersion(version).get().isChunkingEnabled();
+      if (!storeInfo.getVersion(version).isPresent()) {
+        throw new VeniceException("Version: " + version + " does not exist for store: " + storeName);
+      }
+      this.isChunkingEnabled = storeInfo.getVersion(version).get().isChunkingEnabled();
     } else {
-      storeName = Version.parseStoreFromRealTimeTopic(topic);
       this.isChunkingEnabled = false;
     }
     this.keySchemaStr = controllerClient.getKeySchema(storeName).getSchemaStr();
@@ -133,8 +152,11 @@ public class KafkaTopicDumper implements AutoCloseable {
     this.topicName = topic;
     this.partition = partitionNumber;
     this.parentDirectory = parentDir;
-    this.logMetadataOnly = logMetadataOnly;
-    if (logMetadataOnly) {
+    this.logMetadata = logMetadata;
+    this.logDataRecord = logDataRecord;
+    this.logRmdRecord = logRmdRecord;
+
+    if (logMetadata) {
       this.latestValueSchemaStr = null;
       this.allValueSchemas = null;
     } else if (topicName.contains(ChangeCaptureView.CHANGE_CAPTURE_TOPIC_SUFFIX)) {
@@ -148,10 +170,39 @@ public class KafkaTopicDumper implements AutoCloseable {
       this.allValueSchemas = new Schema[schemas.length];
       int i = 0;
       for (MultiSchemaResponse.Schema valueSchema: schemas) {
-        this.allValueSchemas[i] = Schema.parse(valueSchema.getSchemaStr());
+        this.allValueSchemas[i] = AvroSchemaParseUtils.parseSchemaFromJSONLooseValidation(valueSchema.getSchemaStr());
         i++;
+        this.schemaDataMap
+            .put(valueSchema.getId(), new ValueAndDerivedSchemaData(valueSchema.getId(), valueSchema.getSchemaStr()));
+      }
+      if (storeInfo.isWriteComputationEnabled()) {
+        for (MultiSchemaResponse.Schema schema: controllerClient.getAllValueAndDerivedSchema(storeName).getSchemas()) {
+          if (!schema.isDerivedSchema()) {
+            continue;
+          }
+          int valueSchemaId = schema.getId();
+          int protocolId = schema.getDerivedSchemaId();
+          this.schemaDataMap.get(valueSchemaId).setUpdateSchema(protocolId, schema.getSchemaStr());
+        }
+      }
+
+      if (storeInfo.isActiveActiveReplicationEnabled()) {
+        for (MultiSchemaResponse.Schema schema: controllerClient.getAllReplicationMetadataSchemas(storeName)
+            .getSchemas()) {
+          if (!schema.isDerivedSchema()) {
+            continue;
+          }
+          /**
+           * This is intended, as {@link com.linkedin.venice.controller.server.SchemaRoutes} implementation is wrong
+           * for RMD schema entry.
+           */
+          int valueSchemaId = schema.getRmdValueSchemaId();
+          int protocolId = schema.getId();
+          this.schemaDataMap.get(valueSchemaId).setUpdateSchema(protocolId, schema.getSchemaStr());
+        }
       }
     }
+
     PubSubTopicRepository pubSubTopicRepository = new PubSubTopicRepository();
     PubSubTopicPartition partition =
         new PubSubTopicPartitionImpl(pubSubTopicRepository.getTopic(topicName), partitionNumber);
@@ -168,7 +219,7 @@ public class KafkaTopicDumper implements AutoCloseable {
       this.messageCount = messageCount;
     }
 
-    if (!logMetadataOnly) {
+    if (!(logMetadata || logDataRecord)) {
       setupDumpFile();
     }
   }
@@ -214,14 +265,18 @@ public class KafkaTopicDumper implements AutoCloseable {
     List<Schema.Field> outputSchemaFields = new ArrayList<>();
     for (Schema.Field field: VeniceKafkaDecodedRecord.SCHEMA$.getFields()) {
       if (field.name().equals(VENICE_ETL_KEY_FIELD)) {
-        outputSchemaFields
-            .add(AvroCompatibilityHelper.newField(field).setSchema(Schema.parse(this.keySchemaStr)).build());
+        outputSchemaFields.add(
+            AvroCompatibilityHelper.newField(field)
+                .setSchema(AvroSchemaParseUtils.parseSchemaFromJSONLooseValidation(this.keySchemaStr))
+                .build());
       } else if (field.name().equals(VENICE_ETL_VALUE_FIELD)) {
         outputSchemaFields.add(
             AvroCompatibilityHelper.newField(field)
                 .setSchema(
                     Schema.createUnion(
-                        Arrays.asList(Schema.create(Schema.Type.NULL), Schema.parse(this.latestValueSchemaStr))))
+                        Arrays.asList(
+                            Schema.create(Schema.Type.NULL),
+                            AvroSchemaParseUtils.parseSchemaFromJSONLooseValidation(this.latestValueSchemaStr))))
                 .build());
       } else {
         // any fields except key and value will be added using the original schemas, like the offset field and the
@@ -250,9 +305,6 @@ public class KafkaTopicDumper implements AutoCloseable {
     decoderFactory = new DecoderFactory();
   }
 
-  private static final String REGULAR_REC = "REG";
-  private static final String CONTROL_REC = "CTRL";
-
   /**
    * Log the metadata for each kafka message.
    */
@@ -271,10 +323,10 @@ public class KafkaTopicDumper implements AutoCloseable {
       final String chunkMetadata = getChunkMetadataLog(record);
 
       LOGGER.info(
-          "{} {} Offset:{} ProducerMd=(guid:{},seg:{},seq:{},mts:{},lts:{}) LeaderMd=(host:{},uo:{},ukcId:{}){}",
+          "[Record Metadata] Offset:{}; {}; {}; ProducerMd=(guid:{},seg:{},seq:{},mts:{},lts:{}); LeaderMd=(host:{},uo:{},ukcId:{}){}",
+          record.getOffset(),
           kafkaKey.isControlMessage() ? CONTROL_REC : REGULAR_REC,
           msgType,
-          record.getOffset(),
           GuidUtils.getHexFromGuid(producerMetadata.producerGUID),
           producerMetadata.segmentNumber,
           producerMetadata.messageSequenceNumber,
@@ -285,16 +337,88 @@ public class KafkaTopicDumper implements AutoCloseable {
           leaderMetadata == null ? "-" : leaderMetadata.upstreamKafkaClusterId,
           chunkMetadata);
     } catch (Exception e) {
-      LOGGER.error("Failed when building record for offset {}", record.getOffset(), e);
+      LOGGER.error("Encounter exception when processing record for offset {}", record.getOffset(), e);
     }
   }
 
-  private void processRecord(PubSubMessage<KafkaKey, KafkaMessageEnvelope, Long> record) {
-    if (logMetadataOnly) {
-      logRecordMetadata(record);
+  void logDataRecord(PubSubMessage<KafkaKey, KafkaMessageEnvelope, Long> record, boolean logReplicationMetadata) {
+    KafkaKey kafkaKey = record.getKey();
+    if (kafkaKey.isControlMessage()) {
       return;
     }
-    writeToFile(record);
+    KafkaMessageEnvelope kafkaMessageEnvelope = record.getValue();
+    MessageType msgType = MessageType.valueOf(kafkaMessageEnvelope);
+    LOGGER.info(
+        "[Record Data] Offset:{}; {}; {}",
+        record.getOffset(),
+        msgType.toString(),
+        buildDataRecordLog(record, logReplicationMetadata));
+  }
+
+  String buildDataRecordLog(
+      PubSubMessage<KafkaKey, KafkaMessageEnvelope, Long> record,
+      boolean logReplicationMetadata) {
+    KafkaKey kafkaKey = record.getKey();
+    KafkaMessageEnvelope kafkaMessageEnvelope = record.getValue();
+    Object keyRecord = null;
+    Object valueRecord = null;
+    Object rmdRecord = null;
+    try {
+      byte[] keyBytes = kafkaKey.getKey();
+      Decoder keyDecoder = decoderFactory.binaryDecoder(keyBytes, null);
+      keyRecord = keyReader.read(null, keyDecoder);
+      switch (MessageType.valueOf(kafkaMessageEnvelope)) {
+        case PUT:
+          Put put = (Put) kafkaMessageEnvelope.payloadUnion;
+          Decoder valueDecoder = decoderFactory.binaryDecoder(ByteUtils.extractByteArray(put.putValue), null);
+          valueRecord = schemaDataMap.get(put.schemaId).getValueRecordReader().read(null, valueDecoder);
+          if (logReplicationMetadata && put.replicationMetadataPayload != null
+              && put.replicationMetadataPayload.remaining() > 0) {
+            Decoder rmdDecoder =
+                decoderFactory.binaryDecoder(ByteUtils.extractByteArray(put.replicationMetadataPayload), null);
+            rmdRecord = schemaDataMap.get(put.schemaId)
+                .getRmdRecordReader(put.replicationMetadataVersionId)
+                .read(null, rmdDecoder);
+          }
+          break;
+        case DELETE:
+          Delete delete = (Delete) kafkaMessageEnvelope.payloadUnion;
+          if (logReplicationMetadata && delete.replicationMetadataPayload != null
+              && delete.replicationMetadataPayload.remaining() > 0) {
+            Decoder rmdDecoder =
+                decoderFactory.binaryDecoder(ByteUtils.extractByteArray(delete.replicationMetadataPayload), null);
+            rmdRecord = schemaDataMap.get(delete.schemaId)
+                .getRmdRecordReader(delete.replicationMetadataVersionId)
+                .read(null, rmdDecoder);
+          }
+          break;
+        case UPDATE:
+          Update update = (Update) kafkaMessageEnvelope.payloadUnion;
+          Decoder updateDecoder = decoderFactory.binaryDecoder(ByteUtils.extractByteArray(update.updateValue), null);
+          valueRecord =
+              schemaDataMap.get(update.schemaId).getUpdateRecordReader(update.updateSchemaId).read(null, updateDecoder);
+          break;
+        default:
+          throw new VeniceException("Unknown data type.");
+      }
+    } catch (Exception e) {
+      LOGGER.error("Encounter exception when processing record for offset: {}", record.getOffset(), e);
+    }
+    return logReplicationMetadata
+        ? String.format("Key: %s; Value: %s; RMD: %s", keyRecord, valueRecord, rmdRecord)
+        : String.format("Key: %s; Value: %s", keyRecord, valueRecord);
+  }
+
+  private void processRecord(PubSubMessage<KafkaKey, KafkaMessageEnvelope, Long> record) {
+    if (logDataRecord) {
+      logDataRecord(record, logRmdRecord);
+    }
+    if (logMetadata) {
+      logRecordMetadata(record);
+    }
+    if (!(logDataRecord || logMetadata)) {
+      writeToFile(record);
+    }
   }
 
   private void writeToFile(PubSubMessage<KafkaKey, KafkaMessageEnvelope, Long> record) {

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/ValueAndDerivedSchemaData.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/ValueAndDerivedSchemaData.java
@@ -9,29 +9,27 @@ import org.apache.avro.generic.GenericDatumReader;
 
 public class ValueAndDerivedSchemaData {
   private final Schema valueSchema;
-  private final int id;
   private final Map<Integer, Schema> updateSchemaMap = new VeniceConcurrentHashMap<>();
   private final Map<Integer, Schema> rmdSchemaMap = new VeniceConcurrentHashMap<>();
   private final GenericDatumReader<Object> valueRecordReader;
   private final Map<Integer, GenericDatumReader<Object>> updateRecordReaderMap = new VeniceConcurrentHashMap<>();
   private final Map<Integer, GenericDatumReader<Object>> rmdRecordReaderMap = new VeniceConcurrentHashMap<>();
 
-  public ValueAndDerivedSchemaData(int id, String valueSchemaStr) {
+  public ValueAndDerivedSchemaData(String valueSchemaStr) {
     this.valueSchema = AvroSchemaParseUtils.parseSchemaFromJSONLooseValidation(valueSchemaStr);
-    this.id = id;
-    this.valueRecordReader = new GenericDatumReader<>(valueSchema);
+    this.valueRecordReader = new GenericDatumReader<>(valueSchema, valueSchema);
   }
 
   public void setUpdateSchema(int protocolId, String updateSchemaStr) {
     Schema schema = AvroSchemaParseUtils.parseSchemaFromJSONLooseValidation(updateSchemaStr);
     updateSchemaMap.put(protocolId, schema);
-    updateRecordReaderMap.put(protocolId, new GenericDatumReader<>(schema));
+    updateRecordReaderMap.put(protocolId, new GenericDatumReader<>(schema, schema));
   }
 
   public void setRmdSchema(int protocolId, String rmdSchemaStr) {
     Schema schema = AvroSchemaParseUtils.parseSchemaFromJSONLooseValidation(rmdSchemaStr);
     rmdSchemaMap.put(protocolId, schema);
-    rmdRecordReaderMap.put(protocolId, new GenericDatumReader<>(schema));
+    rmdRecordReaderMap.put(protocolId, new GenericDatumReader<>(schema, schema));
   }
 
   GenericDatumReader<Object> getValueRecordReader() {

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/ValueAndDerivedSchemaData.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/ValueAndDerivedSchemaData.java
@@ -1,0 +1,49 @@
+package com.linkedin.venice;
+
+import com.linkedin.venice.schema.AvroSchemaParseUtils;
+import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
+import java.util.Map;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericDatumReader;
+
+
+public class ValueAndDerivedSchemaData {
+  private final Schema valueSchema;
+  private final int id;
+  private final Map<Integer, Schema> updateSchemaMap = new VeniceConcurrentHashMap<>();
+  private final Map<Integer, Schema> rmdSchemaMap = new VeniceConcurrentHashMap<>();
+  private final GenericDatumReader<Object> valueRecordReader;
+  private final Map<Integer, GenericDatumReader<Object>> updateRecordReaderMap = new VeniceConcurrentHashMap<>();
+  private final Map<Integer, GenericDatumReader<Object>> rmdRecordReaderMap = new VeniceConcurrentHashMap<>();
+
+  public ValueAndDerivedSchemaData(int id, String valueSchemaStr) {
+    this.valueSchema = AvroSchemaParseUtils.parseSchemaFromJSONLooseValidation(valueSchemaStr);
+    this.id = id;
+    this.valueRecordReader = new GenericDatumReader<>(valueSchema);
+  }
+
+  public void setUpdateSchema(int protocolId, String updateSchemaStr) {
+    Schema schema = AvroSchemaParseUtils.parseSchemaFromJSONLooseValidation(updateSchemaStr);
+    updateSchemaMap.put(protocolId, schema);
+    updateRecordReaderMap.put(protocolId, new GenericDatumReader<>(schema));
+  }
+
+  public void setRmdSchema(int protocolId, String rmdSchemaStr) {
+    Schema schema = AvroSchemaParseUtils.parseSchemaFromJSONLooseValidation(rmdSchemaStr);
+    rmdSchemaMap.put(protocolId, schema);
+    rmdRecordReaderMap.put(protocolId, new GenericDatumReader<>(schema));
+  }
+
+  GenericDatumReader<Object> getValueRecordReader() {
+    return valueRecordReader;
+  }
+
+  GenericDatumReader<Object> getUpdateRecordReader(int protocolId) {
+    return updateRecordReaderMap.get(protocolId);
+  }
+
+  GenericDatumReader<Object> getRmdRecordReader(int protocolId) {
+    return rmdRecordReaderMap.get(protocolId);
+  }
+
+}

--- a/clients/venice-admin-tool/src/test/java/com/linkedin/venice/TestAdminToolConsumption.java
+++ b/clients/venice-admin-tool/src/test/java/com/linkedin/venice/TestAdminToolConsumption.java
@@ -199,8 +199,18 @@ public class TestAdminToolConsumption {
 
     when(apacheKafkaConsumer.poll(anyLong())).thenReturn(messagesMap, new HashMap<>());
     int consumedMessageCount = pubSubMessageList.size() - 1;
-    KafkaTopicDumper kafkaTopicDumper =
-        new KafkaTopicDumper(controllerClient, apacheKafkaConsumer, topic, assignedPartition, 0, 2, "", 3, true);
+    KafkaTopicDumper kafkaTopicDumper = new KafkaTopicDumper(
+        controllerClient,
+        apacheKafkaConsumer,
+        topic,
+        assignedPartition,
+        0,
+        2,
+        "",
+        3,
+        true,
+        false,
+        false);
     Assert.assertEquals(kafkaTopicDumper.fetchAndProcess(), consumedMessageCount);
   }
 }

--- a/clients/venice-admin-tool/src/test/java/com/linkedin/venice/TestKafkaTopicDumper.java
+++ b/clients/venice-admin-tool/src/test/java/com/linkedin/venice/TestKafkaTopicDumper.java
@@ -75,8 +75,18 @@ public class TestKafkaTopicDumper {
     when(apacheKafkaConsumer.offsetForTime(pubSubTopicPartition, endTimestamp)).thenReturn(endOffset);
     when(apacheKafkaConsumer.endOffset(pubSubTopicPartition)).thenReturn(endOffset);
 
-    KafkaTopicDumper kafkaTopicDumper =
-        new KafkaTopicDumper(controllerClient, apacheKafkaConsumer, topic, assignedPartition, 0, 2, "", 3, true);
+    KafkaTopicDumper kafkaTopicDumper = new KafkaTopicDumper(
+        controllerClient,
+        apacheKafkaConsumer,
+        topic,
+        assignedPartition,
+        0,
+        2,
+        "",
+        3,
+        true,
+        false,
+        false);
 
     int firstChunkSegmentNumber = 1;
     int firstChunkSequenceNumber = 1;

--- a/clients/venice-admin-tool/src/test/java/com/linkedin/venice/TestKafkaTopicDumper.java
+++ b/clients/venice-admin-tool/src/test/java/com/linkedin/venice/TestKafkaTopicDumper.java
@@ -2,11 +2,13 @@ package com.linkedin.venice;
 
 import static com.linkedin.venice.kafka.protocol.enums.MessageType.DELETE;
 import static com.linkedin.venice.kafka.protocol.enums.MessageType.PUT;
+import static com.linkedin.venice.kafka.protocol.enums.MessageType.UPDATE;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.linkedin.venice.chunking.TestChunkingUtils;
 import com.linkedin.venice.controllerapi.ControllerClient;
+import com.linkedin.venice.controllerapi.MultiSchemaResponse;
 import com.linkedin.venice.controllerapi.SchemaResponse;
 import com.linkedin.venice.controllerapi.StoreResponse;
 import com.linkedin.venice.kafka.protocol.Delete;
@@ -14,6 +16,7 @@ import com.linkedin.venice.kafka.protocol.GUID;
 import com.linkedin.venice.kafka.protocol.KafkaMessageEnvelope;
 import com.linkedin.venice.kafka.protocol.ProducerMetadata;
 import com.linkedin.venice.kafka.protocol.Put;
+import com.linkedin.venice.kafka.protocol.Update;
 import com.linkedin.venice.message.KafkaKey;
 import com.linkedin.venice.meta.StoreInfo;
 import com.linkedin.venice.meta.Version;
@@ -23,16 +26,27 @@ import com.linkedin.venice.pubsub.PubSubTopicRepository;
 import com.linkedin.venice.pubsub.adapter.kafka.consumer.ApacheKafkaConsumerAdapter;
 import com.linkedin.venice.pubsub.api.PubSubMessage;
 import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
+import com.linkedin.venice.schema.rmd.RmdSchemaGenerator;
+import com.linkedin.venice.schema.writecompute.WriteComputeSchemaConverter;
 import com.linkedin.venice.serialization.KeyWithChunkingSuffixSerializer;
 import com.linkedin.venice.serialization.avro.AvroProtocolDefinition;
 import com.linkedin.venice.serialization.avro.ChunkedValueManifestSerializer;
+import com.linkedin.venice.serializer.RecordSerializer;
+import com.linkedin.venice.serializer.SerializerDeserializerFactory;
 import com.linkedin.venice.storage.protocol.ChunkedKeySuffix;
 import com.linkedin.venice.storage.protocol.ChunkedValueManifest;
 import com.linkedin.venice.utils.ByteUtils;
+import com.linkedin.venice.utils.TestWriteUtils;
+import com.linkedin.venice.writer.update.UpdateBuilderImpl;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Optional;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.logging.log4j.LogManager;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -119,9 +133,140 @@ public class TestKafkaTopicDumper {
         " ChunkMd=(type:WITH_CHUNK_MANIFEST, FirstChunkMd=(guid:00000000000000000000000000000000,seg:1,seq:1))");
 
     PubSubMessage<KafkaKey, KafkaMessageEnvelope, Long> pubSubMessage5 =
-        getDeleteRecord(serializedKey, 4, pubSubTopicPartition);
+        getDeleteRecord(serializedKey, null, pubSubTopicPartition);
     String deleteChunkMetadataLog = kafkaTopicDumper.getChunkMetadataLog(pubSubMessage5);
     Assert.assertEquals(deleteChunkMetadataLog, " ChunkMd=(type:WITH_FULL_VALUE)");
+  }
+
+  @Test
+  public void testDumpDataRecord() throws IOException {
+    Schema keySchema = TestWriteUtils.STRING_SCHEMA;
+    Schema valueSchema = TestWriteUtils.NAME_RECORD_V1_SCHEMA;
+    Schema updateSchema = WriteComputeSchemaConverter.getInstance().convertFromValueRecordSchema(valueSchema);
+    Schema rmdSchema = RmdSchemaGenerator.generateMetadataSchema(valueSchema);
+    RecordSerializer keySerializer = SerializerDeserializerFactory.getAvroGenericSerializer(keySchema);
+    RecordSerializer valueSerializer = SerializerDeserializerFactory.getAvroGenericSerializer(valueSchema);
+    RecordSerializer updateSerializer = SerializerDeserializerFactory.getAvroGenericSerializer(updateSchema);
+    RecordSerializer rmdSerializer = SerializerDeserializerFactory.getAvroGenericSerializer(rmdSchema);
+
+    String storeName = "test_store";
+    int versionNumber = 1;
+    String topic = Version.composeKafkaTopic(storeName, versionNumber);
+    ControllerClient controllerClient = mock(ControllerClient.class);
+
+    SchemaResponse keySchemaResponse = mock(SchemaResponse.class);
+    when(keySchemaResponse.getSchemaStr()).thenReturn(keySchema.toString());
+    when(controllerClient.getKeySchema(storeName)).thenReturn(keySchemaResponse);
+
+    MultiSchemaResponse valueSchemaResponse = mock(MultiSchemaResponse.class);
+    MultiSchemaResponse.Schema[] valueSchemas = new MultiSchemaResponse.Schema[1];
+    valueSchemas[0] = new MultiSchemaResponse.Schema();
+    valueSchemas[0].setId(1);
+    valueSchemas[0].setSchemaStr(valueSchema.toString());
+    when(valueSchemaResponse.getSchemas()).thenReturn(valueSchemas);
+    when(controllerClient.getAllValueSchema(storeName)).thenReturn(valueSchemaResponse);
+
+    MultiSchemaResponse rmdSchemaResponse = mock(MultiSchemaResponse.class);
+    MultiSchemaResponse.Schema[] rmdSchemas = new MultiSchemaResponse.Schema[1];
+    rmdSchemas[0] = new MultiSchemaResponse.Schema();
+    rmdSchemas[0].setSchemaStr(rmdSchema.toString());
+    rmdSchemas[0].setId(1);
+    rmdSchemas[0].setRmdValueSchemaId(1);
+    when(rmdSchemaResponse.getSchemas()).thenReturn(rmdSchemas);
+    when(controllerClient.getAllReplicationMetadataSchemas(storeName)).thenReturn(rmdSchemaResponse);
+
+    MultiSchemaResponse valueAndDerivedSchemaResponse = mock(MultiSchemaResponse.class);
+    MultiSchemaResponse.Schema[] valueAndDerivedSchema = new MultiSchemaResponse.Schema[2];
+    valueAndDerivedSchema[0] = valueSchemas[0];
+    valueAndDerivedSchema[1] = new MultiSchemaResponse.Schema();
+    valueAndDerivedSchema[1].setDerivedSchemaId(1);
+    valueAndDerivedSchema[1].setId(1);
+    valueAndDerivedSchema[1].setSchemaStr(updateSchema.toString());
+    when(valueAndDerivedSchemaResponse.getSchemas()).thenReturn(valueAndDerivedSchema);
+    when(controllerClient.getAllValueAndDerivedSchema(storeName)).thenReturn(valueAndDerivedSchemaResponse);
+
+    StoreResponse storeResponse = mock(StoreResponse.class);
+    StoreInfo storeInfo = mock(StoreInfo.class);
+    Version version = mock(Version.class);
+    when(version.isChunkingEnabled()).thenReturn(false);
+    when(storeInfo.getPartitionCount()).thenReturn(1);
+    when(storeInfo.isActiveActiveReplicationEnabled()).thenReturn(true);
+    when(storeInfo.isWriteComputationEnabled()).thenReturn(true);
+    when(storeInfo.getVersion(versionNumber)).thenReturn(Optional.of(version));
+    when(controllerClient.getStore(storeName)).thenReturn(storeResponse);
+    when(storeResponse.getStore()).thenReturn(storeInfo);
+
+    PubSubTopicRepository pubSubTopicRepository = new PubSubTopicRepository();
+    int assignedPartition = 0;
+    long startOffset = 0;
+    long endOffset = 4;
+    String keyString = "test";
+    byte[] serializedKey = keySerializer.serialize(keyString);
+    PubSubTopicPartition pubSubTopicPartition =
+        new PubSubTopicPartitionImpl(pubSubTopicRepository.getTopic(topic), assignedPartition);
+
+    ApacheKafkaConsumerAdapter apacheKafkaConsumer = mock(ApacheKafkaConsumerAdapter.class);
+    long startTimestamp = 10;
+    long endTimestamp = 20;
+    when(apacheKafkaConsumer.offsetForTime(pubSubTopicPartition, startTimestamp)).thenReturn(startOffset);
+    when(apacheKafkaConsumer.offsetForTime(pubSubTopicPartition, endTimestamp)).thenReturn(endOffset);
+    when(apacheKafkaConsumer.endOffset(pubSubTopicPartition)).thenReturn(endOffset);
+
+    KafkaTopicDumper kafkaTopicDumper = new KafkaTopicDumper(
+        controllerClient,
+        apacheKafkaConsumer,
+        topic,
+        assignedPartition,
+        0,
+        2,
+        "",
+        3,
+        true,
+        true,
+        false);
+
+    // Test different message type.
+    GenericRecord valueRecord = new GenericData.Record(valueSchema);
+    valueRecord.put("firstName", "f1");
+    valueRecord.put("lastName", "l1");
+    GenericRecord rmdRecord = new GenericData.Record(rmdSchema);
+    rmdRecord.put("timestamp", 1L);
+    rmdRecord.put("replication_checkpoint_vector", Collections.singletonList(1L));
+    GenericRecord updateRecord = new UpdateBuilderImpl(updateSchema).setNewFieldValue("firstName", "f2").build();
+
+    // Test PUT with and without RMD
+    LogManager.getLogger(TestKafkaTopicDumper.class).info("DEBUGGING: {} {}", rmdRecord, rmdSchema);
+    byte[] serializedValue = valueSerializer.serialize(valueRecord);
+    byte[] serializedRmd = rmdSerializer.serialize(rmdRecord);
+    byte[] serializedUpdate = updateSerializer.serialize(updateRecord);
+    PubSubMessage<KafkaKey, KafkaMessageEnvelope, Long> putMessage =
+        getPutRecord(serializedKey, serializedValue, serializedRmd, pubSubTopicPartition);
+    String returnedLog = kafkaTopicDumper.buildDataRecordLog(putMessage, false);
+    String expectedLog = String.format("Key: %s; Value: %s; Schema: %d", keyString, valueRecord, 1);
+    Assert.assertEquals(returnedLog, expectedLog);
+    returnedLog = kafkaTopicDumper.buildDataRecordLog(putMessage, true);
+    expectedLog = String.format("Key: %s; Value: %s; Schema: %d; RMD: %s", keyString, valueRecord, 1, rmdRecord);
+    Assert.assertEquals(returnedLog, expectedLog);
+
+    // Test UPDATE
+    PubSubMessage<KafkaKey, KafkaMessageEnvelope, Long> updateMessage =
+        getUpdateRecord(serializedKey, serializedUpdate, pubSubTopicPartition);
+    returnedLog = kafkaTopicDumper.buildDataRecordLog(updateMessage, false);
+    expectedLog = String.format("Key: %s; Value: %s; Schema: %d-%d", keyString, updateRecord, 1, 1);
+    Assert.assertEquals(returnedLog, expectedLog);
+    returnedLog = kafkaTopicDumper.buildDataRecordLog(updateMessage, true);
+    expectedLog = String.format("Key: %s; Value: %s; Schema: %d-%d; RMD: null", keyString, updateRecord, 1, 1);
+    Assert.assertEquals(returnedLog, expectedLog);
+
+    // Test DELETE with and without RMD
+    PubSubMessage<KafkaKey, KafkaMessageEnvelope, Long> deleteMessage =
+        getDeleteRecord(serializedKey, serializedRmd, pubSubTopicPartition);
+    returnedLog = kafkaTopicDumper.buildDataRecordLog(deleteMessage, false);
+    expectedLog = String.format("Key: %s; Value: %s; Schema: %d", keyString, null, 1);
+    Assert.assertEquals(returnedLog, expectedLog);
+    returnedLog = kafkaTopicDumper.buildDataRecordLog(deleteMessage, true);
+    expectedLog = String.format("Key: %s; Value: %s; Schema: %d; RMD: %s", keyString, null, 1, rmdRecord);
+    Assert.assertEquals(returnedLog, expectedLog);
   }
 
   private PubSubMessage<KafkaKey, KafkaMessageEnvelope, Long> getChunkedRecord(
@@ -200,7 +345,7 @@ public class TestKafkaTopicDumper {
 
   private PubSubMessage<KafkaKey, KafkaMessageEnvelope, Long> getDeleteRecord(
       byte[] serializedKey,
-      int pubSubMessageOffset,
+      byte[] serializedRmd,
       PubSubTopicPartition pubSubTopicPartition) {
     KeyWithChunkingSuffixSerializer keyWithChunkingSuffixSerializer = new KeyWithChunkingSuffixSerializer();
     byte[] chunkKeyWithSuffix = keyWithChunkingSuffixSerializer.serializeNonChunkedKey(serializedKey);
@@ -215,7 +360,60 @@ public class TestKafkaTopicDumper {
 
     Delete delete = new Delete();
     delete.schemaId = 1;
+    if (serializedRmd != null) {
+      delete.replicationMetadataPayload = ByteBuffer.wrap(serializedRmd);
+      delete.replicationMetadataVersionId = 1;
+    }
     messageEnvelope.payloadUnion = delete;
-    return new ImmutablePubSubMessage<>(kafkaKey, messageEnvelope, pubSubTopicPartition, pubSubMessageOffset, 0, 20);
+    return new ImmutablePubSubMessage<>(kafkaKey, messageEnvelope, pubSubTopicPartition, 1, 0, 20);
+  }
+
+  private PubSubMessage<KafkaKey, KafkaMessageEnvelope, Long> getPutRecord(
+      byte[] serializedKey,
+      byte[] serializedValue,
+      byte[] serializedRmd,
+      PubSubTopicPartition pubSubTopicPartition) {
+    KeyWithChunkingSuffixSerializer keyWithChunkingSuffixSerializer = new KeyWithChunkingSuffixSerializer();
+    byte[] chunkKeyWithSuffix = keyWithChunkingSuffixSerializer.serializeNonChunkedKey(serializedKey);
+    KafkaKey kafkaKey = new KafkaKey(PUT, chunkKeyWithSuffix);
+    KafkaMessageEnvelope messageEnvelope = new KafkaMessageEnvelope();
+    messageEnvelope.messageType = PUT.getValue();
+    messageEnvelope.producerMetadata = new ProducerMetadata();
+    messageEnvelope.producerMetadata.messageTimestamp = 0;
+    messageEnvelope.producerMetadata.segmentNumber = 0;
+    messageEnvelope.producerMetadata.messageSequenceNumber = 0;
+    messageEnvelope.producerMetadata.producerGUID = new GUID();
+    Put put = new Put();
+    put.schemaId = 1;
+    put.putValue = ByteBuffer.wrap(serializedValue);
+    if (serializedRmd != null) {
+      put.replicationMetadataPayload = ByteBuffer.wrap(serializedRmd);
+      put.replicationMetadataVersionId = 1;
+    }
+    messageEnvelope.payloadUnion = put;
+    return new ImmutablePubSubMessage<>(kafkaKey, messageEnvelope, pubSubTopicPartition, 1, 0, serializedValue.length);
+  }
+
+  private PubSubMessage<KafkaKey, KafkaMessageEnvelope, Long> getUpdateRecord(
+      byte[] serializedKey,
+      byte[] serializedValue,
+      PubSubTopicPartition pubSubTopicPartition) {
+    KeyWithChunkingSuffixSerializer keyWithChunkingSuffixSerializer = new KeyWithChunkingSuffixSerializer();
+    byte[] chunkKeyWithSuffix = keyWithChunkingSuffixSerializer.serializeNonChunkedKey(serializedKey);
+    KafkaKey kafkaKey = new KafkaKey(UPDATE, chunkKeyWithSuffix);
+    KafkaMessageEnvelope messageEnvelope = new KafkaMessageEnvelope();
+    messageEnvelope.messageType = UPDATE.getValue();
+    messageEnvelope.producerMetadata = new ProducerMetadata();
+    messageEnvelope.producerMetadata.messageTimestamp = 0;
+    messageEnvelope.producerMetadata.segmentNumber = 0;
+    messageEnvelope.producerMetadata.messageSequenceNumber = 0;
+    messageEnvelope.producerMetadata.producerGUID = new GUID();
+    Update update = new Update();
+    update.schemaId = 1;
+    update.updateValue = ByteBuffer.wrap(serializedValue);
+    update.updateSchemaId = 1;
+
+    messageEnvelope.payloadUnion = update;
+    return new ImmutablePubSubMessage<>(kafkaKey, messageEnvelope, pubSubTopicPartition, 1, 0, serializedValue.length);
   }
 }


### PR DESCRIPTION

<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## [admin-tool] Add support to dump UPDATE records and RMD records in Kafka Topic Dumper
This PR adds new mode to print data record (PUT/DELETE/UPDATE) as well as its corresponding RMD record to console, on top of its existing functionality of logging Kafka message metadata to console. It is very useful for debugging feature correctness. 

In the future, we can consider adding a key filter to log specific key only, to better focus on certain key.

## How was this PR tested?
Added new unit test to cover the message build up

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.