### PR TITLE
[server] Skip success request metric tracking for /health request

### DIFF
--- a/services/venice-server/src/main/java/com/linkedin/venice/listener/StatsHandler.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/listener/StatsHandler.java
@@ -208,7 +208,10 @@ public class StatsHandler extends ChannelDuplexHandler {
         // records a successRequest in stats. Otherwise, records a errorRequest in stats;
         if (result.isSuccess() && (serverStatsContext.getResponseStatus().equals(OK)
             || serverStatsContext.getResponseStatus().equals(NOT_FOUND))) {
-          serverStatsContext.successRequest(serverHttpRequestStats, elapsedTime);
+          if (serverHttpRequestStats != null) {
+            // For /health request, there is no store name
+            serverStatsContext.successRequest(serverHttpRequestStats, elapsedTime);
+          }
         } else {
           serverStatsContext.errorRequest(serverHttpRequestStats, elapsedTime);
         }


### PR DESCRIPTION
/health request from Router doesn't have a store name, so the store-level tracking would break with a gaint log stacktrace, which is bloating log file, and this is a regression happened a few months ago.

<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->


<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->


## How was this PR tested?
CI
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.