### PR TITLE
[controller][dvc] Do not count COMPLETED Da Vinci replicas as offline replicas

### DIFF
--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -1707,8 +1707,13 @@ public class ConfigKeys {
   public static final String DAVINCI_PUSH_STATUS_SCAN_NO_REPORT_RETRY_MAX_ATTEMPTS =
       "davinci.push.status.scan.no.report.retry.max.attempts";
 
-  public static final String DAVINCI_PUSH_STATUS_SCAN_MAX_OFFLINE_INSTANCE =
-      "davinci.push.status.scan.max.offline.instance";
+  // Config to control how many DVC replica instances are allowed to be offline before failing VPJ push.
+  public static final String DAVINCI_PUSH_STATUS_SCAN_MAX_OFFLINE_INSTANCE_COUNT =
+      "davinci.push.status.scan.max.offline.instance.count";
+
+  // Config to control how much percentage of DVC replica instances are allowed to be offline before failing VPJ push.
+  public static final String DAVINCI_PUSH_STATUS_SCAN_MAX_OFFLINE_INSTANCE_RATIO =
+      "davinci.push.status.scan.max.offline.instance.ratio";
 
   public static final String CONTROLLER_ZK_SHARED_DAVINCI_PUSH_STATUS_SYSTEM_SCHEMA_STORE_AUTO_CREATION_ENABLED =
       "controller.zk.shared.davinci.push.status.system.schema.store.auto.creation.enabled";

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerConfig.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerConfig.java
@@ -57,7 +57,8 @@ import static com.linkedin.venice.ConfigKeys.CONTROLLER_ZK_SHARED_DAVINCI_PUSH_S
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_ZK_SHARED_META_SYSTEM_SCHEMA_STORE_AUTO_CREATION_ENABLED;
 import static com.linkedin.venice.ConfigKeys.DAVINCI_PUSH_STATUS_SCAN_ENABLED;
 import static com.linkedin.venice.ConfigKeys.DAVINCI_PUSH_STATUS_SCAN_INTERVAL_IN_SECONDS;
-import static com.linkedin.venice.ConfigKeys.DAVINCI_PUSH_STATUS_SCAN_MAX_OFFLINE_INSTANCE;
+import static com.linkedin.venice.ConfigKeys.DAVINCI_PUSH_STATUS_SCAN_MAX_OFFLINE_INSTANCE_COUNT;
+import static com.linkedin.venice.ConfigKeys.DAVINCI_PUSH_STATUS_SCAN_MAX_OFFLINE_INSTANCE_RATIO;
 import static com.linkedin.venice.ConfigKeys.DAVINCI_PUSH_STATUS_SCAN_NO_REPORT_RETRY_MAX_ATTEMPTS;
 import static com.linkedin.venice.ConfigKeys.DAVINCI_PUSH_STATUS_SCAN_THREAD_NUMBER;
 import static com.linkedin.venice.ConfigKeys.DEPRECATED_TOPIC_MAX_RETENTION_MS;
@@ -229,7 +230,9 @@ public class VeniceControllerConfig extends VeniceControllerClusterConfig {
 
   private final int daVinciPushStatusScanNoReportRetryMaxAttempt;
 
-  private final int daVinciPushStatusScanMaxOfflineInstance;
+  private final int daVinciPushStatusScanMaxOfflineInstanceCount;
+
+  private final double daVinciPushStatusScanMaxOfflineInstanceRatio;
 
   private final boolean zkSharedDaVinciPushStatusSystemSchemaStoreAutoCreationEnabled;
 
@@ -486,7 +489,10 @@ public class VeniceControllerConfig extends VeniceControllerClusterConfig {
     this.daVinciPushStatusScanThreadNumber = props.getInt(DAVINCI_PUSH_STATUS_SCAN_THREAD_NUMBER, 4);
     this.daVinciPushStatusScanNoReportRetryMaxAttempt =
         props.getInt(DAVINCI_PUSH_STATUS_SCAN_NO_REPORT_RETRY_MAX_ATTEMPTS, 6);
-    this.daVinciPushStatusScanMaxOfflineInstance = props.getInt(DAVINCI_PUSH_STATUS_SCAN_MAX_OFFLINE_INSTANCE, 10);
+    this.daVinciPushStatusScanMaxOfflineInstanceCount =
+        props.getInt(DAVINCI_PUSH_STATUS_SCAN_MAX_OFFLINE_INSTANCE_COUNT, 10);
+    this.daVinciPushStatusScanMaxOfflineInstanceRatio =
+        props.getDouble(DAVINCI_PUSH_STATUS_SCAN_MAX_OFFLINE_INSTANCE_RATIO, 0.1d);
 
     this.zkSharedDaVinciPushStatusSystemSchemaStoreAutoCreationEnabled =
         props.getBoolean(CONTROLLER_ZK_SHARED_DAVINCI_PUSH_STATUS_SYSTEM_SCHEMA_STORE_AUTO_CREATION_ENABLED, true);
@@ -639,8 +645,12 @@ public class VeniceControllerConfig extends VeniceControllerClusterConfig {
     return disabledReplicaEnablerServiceIntervalMs;
   }
 
-  public int getDaVinciPushStatusScanMaxOfflineInstance() {
-    return daVinciPushStatusScanMaxOfflineInstance;
+  public int getDaVinciPushStatusScanMaxOfflineInstanceCount() {
+    return daVinciPushStatusScanMaxOfflineInstanceCount;
+  }
+
+  public double getDaVinciPushStatusScanMaxOfflineInstanceRatio() {
+    return daVinciPushStatusScanMaxOfflineInstanceRatio;
   }
 
   public int getTopicCleanupDelayFactor() {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerConfig.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerConfig.java
@@ -492,7 +492,7 @@ public class VeniceControllerConfig extends VeniceControllerClusterConfig {
     this.daVinciPushStatusScanMaxOfflineInstanceCount =
         props.getInt(DAVINCI_PUSH_STATUS_SCAN_MAX_OFFLINE_INSTANCE_COUNT, 10);
     this.daVinciPushStatusScanMaxOfflineInstanceRatio =
-        props.getDouble(DAVINCI_PUSH_STATUS_SCAN_MAX_OFFLINE_INSTANCE_RATIO, 0.1d);
+        props.getDouble(DAVINCI_PUSH_STATUS_SCAN_MAX_OFFLINE_INSTANCE_RATIO, 0.05d);
 
     this.zkSharedDaVinciPushStatusSystemSchemaStoreAutoCreationEnabled =
         props.getBoolean(CONTROLLER_ZK_SHARED_DAVINCI_PUSH_STATUS_SYSTEM_SCHEMA_STORE_AUTO_CREATION_ENABLED, true);

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -5621,7 +5621,8 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
             version.kafkaTopicName(),
             version.getPartitionCount(),
             incrementalPushVersion,
-            multiClusterConfigs.getControllerConfig(clusterName).getDaVinciPushStatusScanMaxOfflineInstance());
+            multiClusterConfigs.getControllerConfig(clusterName).getDaVinciPushStatusScanMaxOfflineInstanceCount(),
+            multiClusterConfigs.getControllerConfig(clusterName).getDaVinciPushStatusScanMaxOfflineInstanceRatio());
         ExecutionStatus daVinciStatus = daVinciStatusAndDetails.getStatus();
         String daVinciDetails = daVinciStatusAndDetails.getDetails();
         executionStatus = getOverallPushStatus(executionStatus, daVinciStatus);

--- a/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/AbstractPushMonitor.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/AbstractPushMonitor.java
@@ -129,7 +129,8 @@ public abstract class AbstractPushMonitor
         controllerConfig.getDaVinciPushStatusScanIntervalInSeconds(),
         controllerConfig.getDaVinciPushStatusScanThreadNumber(),
         controllerConfig.getDaVinciPushStatusScanNoReportRetryMaxAttempt(),
-        controllerConfig.getDaVinciPushStatusScanMaxOfflineInstance());
+        controllerConfig.getDaVinciPushStatusScanMaxOfflineInstanceCount(),
+        controllerConfig.getDaVinciPushStatusScanMaxOfflineInstanceRatio());
     this.isOfflinePushMonitorDaVinciPushStatusEnabled = controllerConfig.isDaVinciPushStatusEnabled();
     pushStatusCollector.start();
   }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/PushMonitorUtils.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/PushMonitorUtils.java
@@ -70,7 +70,7 @@ public class PushMonitorUtils {
         if (!isInstanceAlive) {
           continue;
         }
-        // Derive the partition replica ingestion status based on live replica ingestion status.
+        // Derive the overall partition ingestion status based on all live replica ingestion status.
         liveReplicaCount++;
         if (status == middleStatus) {
           allInstancesCompleted = false;

--- a/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/PushMonitorUtils.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/PushMonitorUtils.java
@@ -60,16 +60,17 @@ public class PushMonitorUtils {
       totalReplicaCount += instances.size();
       for (Map.Entry<CharSequence, Integer> entry: instances.entrySet()) {
         ExecutionStatus status = ExecutionStatus.fromInt(entry.getValue());
+        // We will skip completed replicas, as they have stopped emitting heartbeats and will not be counted as live
+        // replicas.
         if (status == completeStatus) {
           completedReplicaCount++;
           continue;
         }
-        // For live replica change, we will skip completed replicas.
         boolean isInstanceAlive = reader.isInstanceAlive(storeName, entry.getKey().toString());
         if (!isInstanceAlive) {
           continue;
         }
-        // We only compute status based on live instances.
+        // Derive the partition replica ingestion status based on live replica ingestion status.
         liveReplicaCount++;
         if (status == middleStatus) {
           allInstancesCompleted = false;

--- a/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/PushMonitorUtils.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/PushMonitorUtils.java
@@ -32,7 +32,8 @@ public class PushMonitorUtils {
       String topicName,
       int partitionCount,
       Optional<String> incrementalPushVersion,
-      int maxOfflineInstance) {
+      int maxOfflineInstanceCount,
+      double maxOfflineInstanceRatio) {
     if (reader == null) {
       throw new VeniceException("PushStatusStoreReader is null");
     }
@@ -93,7 +94,9 @@ public class PushMonitorUtils {
     boolean noDaVinciStatusReported = totalReplicaCount == 0;
     int offlineReplicaCount = totalReplicaCount - liveReplicaCount - completedReplicaCount;
     // Report error if too many Da Vinci instances are not alive for over 5 minutes.
-    if (offlineReplicaCount > maxOfflineInstance) {
+    int maxOfflineInstanceAllowed =
+        Math.min(maxOfflineInstanceCount, (int) (maxOfflineInstanceRatio * totalReplicaCount));
+    if (offlineReplicaCount > maxOfflineInstanceAllowed) {
       Long lastUpdateTime = storeVersionToDVCDeadInstanceTimeMap.get(topicName);
       if (lastUpdateTime != null) {
         if (lastUpdateTime + TimeUnit.MINUTES.toMillis(daVinciErrorInstanceWaitTime) < System.currentTimeMillis()) {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/PushMonitorUtils.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/PushMonitorUtils.java
@@ -91,11 +91,9 @@ public class PushMonitorUtils {
     }
     boolean noDaVinciStatusReported = totalReplicaCount == 0;
     int offlineReplicaCount = totalReplicaCount - liveReplicaCount - completedReplicaCount;
-    LOGGER.info("DEBUGGING: {} {} {}", totalReplicaCount, liveReplicaCount, completedReplicaCount);
     // Report error if too many Da Vinci instances are not alive for over 5 minutes.
     if (offlineReplicaCount > maxOfflineInstance) {
       Long lastUpdateTime = storeVersionToDVCDeadInstanceTimeMap.get(topicName);
-      LOGGER.info("DEBUGGING ENTER: {} {}", lastUpdateTime, System.currentTimeMillis());
       if (lastUpdateTime != null) {
         if (lastUpdateTime + TimeUnit.MINUTES.toMillis(daVinciErrorInstanceWaitTime) < System.currentTimeMillis()) {
           storeVersionToDVCDeadInstanceTimeMap.remove(topicName);

--- a/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/PushMonitorUtils.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/PushMonitorUtils.java
@@ -103,7 +103,7 @@ public class PushMonitorUtils {
           storeVersionToDVCDeadInstanceTimeMap.remove(topicName);
           return new ExecutionStatusWithDetails(
               ExecutionStatus.ERROR,
-              " Too many dead instances: " + offlineReplicaCount + ", total instances: " + totalReplicaCount,
+              "Too many dead instances: " + offlineReplicaCount + ", total instances: " + totalReplicaCount,
               noDaVinciStatusReported);
         }
       } else {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/PushStatusCollector.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/PushStatusCollector.java
@@ -42,7 +42,8 @@ public class PushStatusCollector {
   private final int daVinciPushStatusScanThreadNumber;
   private final boolean daVinciPushStatusScanEnabled;
   private final int daVinciPushStatusNoReportRetryMaxAttempts;
-  private final int daVinciPushStatusScanMaxOfflineInstance;
+  private final int daVinciPushStatusScanMaxOfflineInstanceCount;
+  private final double daVinciPushStatusScanMaxOfflineInstanceRatio;
   private ScheduledExecutorService offlinePushCheckScheduler;
   private ExecutorService pushStatusStoreScanExecutor;
   private final AtomicBoolean isStarted = new AtomicBoolean(false);
@@ -58,7 +59,8 @@ public class PushStatusCollector {
       int daVinciPushStatusScanIntervalInSeconds,
       int daVinciPushStatusScanThreadNumber,
       int daVinciPushStatusNoReportRetryMaxAttempts,
-      int daVinciPushStatusScanMaxOfflineInstance) {
+      int daVinciPushStatusScanMaxOfflineInstanceCount,
+      double daVinciPushStatusScanMaxOfflineInstanceRatio) {
     this.storeRepository = storeRepository;
     this.pushStatusStoreReader = pushStatusStoreReader;
     this.pushCompletedHandler = pushCompletedHandler;
@@ -67,7 +69,8 @@ public class PushStatusCollector {
     this.daVinciPushStatusScanPeriodInSeconds = daVinciPushStatusScanIntervalInSeconds;
     this.daVinciPushStatusScanThreadNumber = daVinciPushStatusScanThreadNumber;
     this.daVinciPushStatusNoReportRetryMaxAttempts = daVinciPushStatusNoReportRetryMaxAttempts;
-    this.daVinciPushStatusScanMaxOfflineInstance = daVinciPushStatusScanMaxOfflineInstance;
+    this.daVinciPushStatusScanMaxOfflineInstanceCount = daVinciPushStatusScanMaxOfflineInstanceCount;
+    this.daVinciPushStatusScanMaxOfflineInstanceRatio = daVinciPushStatusScanMaxOfflineInstanceRatio;
   }
 
   public void start() {
@@ -131,7 +134,8 @@ public class PushStatusCollector {
               topicName,
               pushStatus.getPartitionCount(),
               Optional.empty(),
-              daVinciPushStatusScanMaxOfflineInstance);
+              daVinciPushStatusScanMaxOfflineInstanceCount,
+              daVinciPushStatusScanMaxOfflineInstanceRatio);
           pushStatus.setDaVinciStatus(statusWithDetails);
           return pushStatus;
         }, pushStatusStoreScanExecutor));

--- a/services/venice-controller/src/test/java/com/linkedin/venice/pushmonitor/PushMonitorUtilsTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/pushmonitor/PushMonitorUtilsTest.java
@@ -25,16 +25,18 @@ public class PushMonitorUtilsTest {
     map.put("c", 3);
     map.put("d", 10);
     doReturn(map).when(reader).getPartitionStatus("store", 1, 0, Optional.empty());
+    doReturn(map).when(reader).getPartitionStatus("store", 2, 0, Optional.empty());
     doReturn(true).when(reader).isInstanceAlive(eq("store"), eq("a"));
     doReturn(false).when(reader).isInstanceAlive(eq("store"), eq("b"));
     doReturn(false).when(reader).isInstanceAlive(eq("store"), eq("c"));
     doReturn(false).when(reader).isInstanceAlive(eq("store"), eq("d"));
 
+    // Testing count-based threshold.
     /**
      * It is still valid, because we have 4 replicas, 1 completed, 2 offline, 1 online, threshold number is 2.
      */
     ExecutionStatusWithDetails executionStatusWithDetails =
-        PushMonitorUtils.getDaVinciPushStatusAndDetails(reader, topicName, 1, Optional.empty(), 2);
+        PushMonitorUtils.getDaVinciPushStatusAndDetails(reader, topicName, 1, Optional.empty(), 2, 1.0);
     Assert.assertEquals(executionStatusWithDetails.getStatus(), ExecutionStatus.STARTED);
 
     /**
@@ -43,7 +45,7 @@ public class PushMonitorUtilsTest {
      */
     Utils.sleep(1);
     executionStatusWithDetails =
-        PushMonitorUtils.getDaVinciPushStatusAndDetails(reader, topicName, 1, Optional.empty(), 1);
+        PushMonitorUtils.getDaVinciPushStatusAndDetails(reader, topicName, 1, Optional.empty(), 1, 1.0);
     Assert.assertEquals(executionStatusWithDetails.getStatus(), ExecutionStatus.STARTED);
 
     /**
@@ -52,7 +54,35 @@ public class PushMonitorUtilsTest {
      */
     Utils.sleep(1);
     executionStatusWithDetails =
-        PushMonitorUtils.getDaVinciPushStatusAndDetails(reader, topicName, 1, Optional.empty(), 1);
+        PushMonitorUtils.getDaVinciPushStatusAndDetails(reader, topicName, 1, Optional.empty(), 1, 1.0);
+    Assert.assertEquals(executionStatusWithDetails.getStatus(), ExecutionStatus.ERROR);
+    Assert.assertEquals(executionStatusWithDetails.getDetails(), " Too many dead instances: 2, total instances: 4");
+
+    // Testing ratio-based threshold.
+    topicName = "store_v2";
+    /**
+     * It is still valid, because we have 4 replicas, 1 completed, 2 offline, 1 online, threshold number is 4 * 0.5 = 2.
+     */
+    executionStatusWithDetails =
+        PushMonitorUtils.getDaVinciPushStatusAndDetails(reader, topicName, 1, Optional.empty(), 100, 0.5);
+    Assert.assertEquals(executionStatusWithDetails.getStatus(), ExecutionStatus.STARTED);
+
+    /**
+     * The offline instances number exceed the max offline threshold count, but it will remain STARTED, as we need to wait
+     * until daVinciErrorInstanceWaitTime has passed since it first occurs.
+     */
+    Utils.sleep(1);
+    executionStatusWithDetails =
+        PushMonitorUtils.getDaVinciPushStatusAndDetails(reader, topicName, 1, Optional.empty(), 100, 0.25);
+    Assert.assertEquals(executionStatusWithDetails.getStatus(), ExecutionStatus.STARTED);
+
+    /**
+     * This time it should fail, as we override the wait time to 0, and after 1ms, the 2nd query should meet the failure
+     * condition check.
+     */
+    Utils.sleep(1);
+    executionStatusWithDetails =
+        PushMonitorUtils.getDaVinciPushStatusAndDetails(reader, topicName, 1, Optional.empty(), 100, 0.25);
     Assert.assertEquals(executionStatusWithDetails.getStatus(), ExecutionStatus.ERROR);
     Assert.assertEquals(executionStatusWithDetails.getDetails(), " Too many dead instances: 2, total instances: 4");
   }

--- a/services/venice-controller/src/test/java/com/linkedin/venice/pushmonitor/PushStatusCollectorTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/pushmonitor/PushStatusCollectorTest.java
@@ -58,7 +58,8 @@ public class PushStatusCollectorTest {
         1,
         4,
         1,
-        20);
+        20,
+        1);
     pushStatusCollector.start();
 
     pushStatusCollector.subscribeTopic(regularStoreTopicV1, 10);
@@ -190,7 +191,8 @@ public class PushStatusCollectorTest {
         1,
         4,
         1,
-        20);
+        20,
+        1);
     pushStatusCollector.start();
 
     pushCompletedCount.set(0);
@@ -272,7 +274,8 @@ public class PushStatusCollectorTest {
         1,
         4,
         0,
-        20);
+        20,
+        1);
     pushStatusCollector.start();
 
     pushCompletedCount.set(0);


### PR DESCRIPTION


<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## [controller][dvc] Do not count COMPLETED Da Vinci replicas as offline replicas
Some Venice Push Job failed with the error stating more than 2k offline replicas in the push. After checking the logic we believe the live replica count check is not accurate. Completed DVC replica will not emit heartbeat to push status store, and will not be counted as live replicas if the ingestion of certain partitions staggers or data skew happens among different partitions.
This PR fix the counting to make sure completed replicas are also considered when calculating offline replicas.
 

## How was this PR tested?
Modify existing unit tests to cover the new logic.
## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.