### PR TITLE
[changelog] Use serializer cache to improve changecapture user performance

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImpl.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImpl.java
@@ -110,8 +110,6 @@ public class VeniceChangelogConsumerImpl<K, V> implements VeniceChangelogConsume
 
   protected final ChunkAssembler chunkAssembler;
 
-  protected final AvroStoreDeserializerCache avrostoreDeserializerCache;
-
   public VeniceChangelogConsumerImpl(
       ChangelogClientConfig changelogClientConfig,
       PubSubConsumerAdapter pubSubConsumer) {
@@ -149,7 +147,6 @@ public class VeniceChangelogConsumerImpl<K, V> implements VeniceChangelogConsume
       this.storeDeserializerCache = new AvroStoreDeserializerCache<>(storeRepository, storeName, true);
     }
 
-    avrostoreDeserializerCache = new AvroStoreDeserializerCache(storeRepository, storeName, true);
     LOGGER.info(
         "Start a change log consumer client for store: {}, with partition count: {} and view class: {} ",
         storeName,
@@ -765,7 +762,7 @@ public class VeniceChangelogConsumerImpl<K, V> implements VeniceChangelogConsume
   }
 
   private V deserializeValueFromBytes(ByteBuffer byteBuffer, int valueSchemaId) {
-    RecordDeserializer<V> valueDeserializer = avrostoreDeserializerCache.getDeserializer(valueSchemaId, valueSchemaId);
+    RecordDeserializer<V> valueDeserializer = storeDeserializerCache.getDeserializer(valueSchemaId, valueSchemaId);
     if (byteBuffer != null) {
       return valueDeserializer.deserialize(byteBuffer);
     }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImplTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImplTest.java
@@ -37,6 +37,7 @@ import com.linkedin.venice.pubsub.api.PubSubConsumerAdapter;
 import com.linkedin.venice.pubsub.api.PubSubMessage;
 import com.linkedin.venice.pubsub.api.PubSubTopic;
 import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
+import com.linkedin.venice.schema.SchemaEntry;
 import com.linkedin.venice.schema.SchemaReader;
 import com.linkedin.venice.schema.rmd.RmdConstants;
 import com.linkedin.venice.schema.rmd.RmdSchemaGenerator;
@@ -75,6 +76,7 @@ public class VeniceChangelogConsumerImplTest {
   private Schema rmdSchema;
   private SchemaReader schemaReader;
   private final PubSubTopicRepository pubSubTopicRepository = new PubSubTopicRepository();
+  private final Schema valueSchema = AvroCompatibilityHelper.parse("\"string\"");
 
   @BeforeMethod
   public void setUp() {
@@ -82,7 +84,6 @@ public class VeniceChangelogConsumerImplTest {
     schemaReader = mock(SchemaReader.class);
     Schema keySchema = AvroCompatibilityHelper.parse("\"string\"");
     doReturn(keySchema).when(schemaReader).getKeySchema();
-    Schema valueSchema = AvroCompatibilityHelper.parse("\"string\"");
     doReturn(valueSchema).when(schemaReader).getValueSchema(1);
     rmdSchema = RmdSchemaGenerator.generateMetadataSchema(valueSchema, 1);
 
@@ -134,6 +135,7 @@ public class VeniceChangelogConsumerImplTest {
     Mockito.when(store.getCompressionStrategy()).thenReturn(CompressionStrategy.NO_OP);
     Mockito.when(mockRepository.getStore(anyString())).thenReturn(store);
     Mockito.when(store.getVersion(Mockito.anyInt())).thenReturn(Optional.of(mockVersion));
+    Mockito.when(mockRepository.getValueSchema(storeName, 1)).thenReturn(new SchemaEntry(1, valueSchema));
 
     veniceChangelogConsumer.setStoreRepository(mockRepository);
     veniceChangelogConsumer.subscribe(new HashSet<>(Arrays.asList(0))).get();
@@ -257,6 +259,7 @@ public class VeniceChangelogConsumerImplTest {
     Mockito.when(store.getCurrentVersion()).thenReturn(1);
     Mockito.when(store.getCompressionStrategy()).thenReturn(CompressionStrategy.NO_OP);
     Mockito.when(mockRepository.getStore(anyString())).thenReturn(store);
+    Mockito.when(mockRepository.getValueSchema(storeName, 1)).thenReturn(new SchemaEntry(1, valueSchema));
     Mockito.when(store.getVersion(Mockito.anyInt())).thenReturn(Optional.of(mockVersion));
     veniceChangelogConsumer.setStoreRepository(mockRepository);
     veniceChangelogConsumer.subscribe(new HashSet<>(Arrays.asList(0))).get();


### PR DESCRIPTION
## [changelog] Use serializer cache to improve changecapture user performance

The deserializer lookup is pretty expensive.  This change should speed things up.

Resolves #XXX

## How was this PR tested?
normal test suite

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.