### PR TITLE
[server] Fix NPE in MergeConflictResolver#ignoreNewUpdate()

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/replication/merge/MergeConflictResolver.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/replication/merge/MergeConflictResolver.java
@@ -7,7 +7,7 @@ import static com.linkedin.venice.schema.rmd.v1.CollectionRmdTimestamp.PUT_ONLY_
 import static com.linkedin.venice.schema.rmd.v1.CollectionRmdTimestamp.TOP_LEVEL_COLO_ID_FIELD_POS;
 import static com.linkedin.venice.schema.rmd.v1.CollectionRmdTimestamp.TOP_LEVEL_TS_FIELD_POS;
 import static com.linkedin.venice.schema.writecompute.WriteComputeOperation.NO_OP_ON_FIELD;
-import static com.linkedin.venice.schema.writecompute.WriteComputeSchemaConverter.getFieldOperationType;
+import static com.linkedin.venice.schema.writecompute.WriteComputeOperation.getFieldOperationType;
 
 import com.linkedin.davinci.replication.RmdWithValueSchemaId;
 import com.linkedin.davinci.schema.merge.ValueAndRmd;

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/replication/merge/TestMergeUpdateWithFieldLevelTimestamp.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/replication/merge/TestMergeUpdateWithFieldLevelTimestamp.java
@@ -45,28 +45,32 @@ public class TestMergeUpdateWithFieldLevelTimestamp extends TestMergeConflictRes
     final int incomingWriteComputeSchemaId = 3;
     final int oldValueSchemaId = 3;
     // Set up
-    Schema writeComputeSchema = WriteComputeSchemaConverter.getInstance().convertFromValueRecordSchema(personSchemaV2);
-    GenericRecord updateFieldWriteComputeRecord = AvroSchemaUtils.createGenericRecord(writeComputeSchema);
-    updateFieldWriteComputeRecord.put("age", 66);
-    updateFieldWriteComputeRecord.put("name", "Venice");
+    Schema writeComputeSchema = WriteComputeSchemaConverter.getInstance().convertFromValueRecordSchema(personSchemaV3);
+    GenericRecord updateFieldWriteComputeRecord =
+        new UpdateBuilderImpl(writeComputeSchema).setNewFieldValue("nullableListField", null)
+            .setNewFieldValue("age", 66)
+            .setNewFieldValue("name", "Venice")
+            .build();
     ByteBuffer writeComputeBytes = ByteBuffer.wrap(
         MapOrderPreservingSerDeFactory.getSerializer(writeComputeSchema).serialize(updateFieldWriteComputeRecord));
     final long valueLevelTimestamp = 10L;
     Map<String, Long> fieldNameToTimestampMap = new HashMap<>();
+    fieldNameToTimestampMap.put("nullableListField", 10L);
     fieldNameToTimestampMap.put("age", 10L);
     fieldNameToTimestampMap.put("favoritePet", 10L);
     fieldNameToTimestampMap.put("name", 10L);
     fieldNameToTimestampMap.put("intArray", 10L);
     fieldNameToTimestampMap.put("stringArray", 10L);
+    fieldNameToTimestampMap.put("stringMap", 10L);
 
-    GenericRecord rmdRecord = createRmdWithFieldLevelTimestamp(personRmdSchemaV2, fieldNameToTimestampMap);
+    GenericRecord rmdRecord = createRmdWithFieldLevelTimestamp(personRmdSchemaV3, fieldNameToTimestampMap);
     RmdWithValueSchemaId rmdWithValueSchemaId = new RmdWithValueSchemaId(oldValueSchemaId, RMD_VERSION_ID, rmdRecord);
     ReadOnlySchemaRepository readOnlySchemaRepository = mock(ReadOnlySchemaRepository.class);
     doReturn(new DerivedSchemaEntry(incomingValueSchemaId, 1, writeComputeSchema)).when(readOnlySchemaRepository)
         .getDerivedSchema(storeName, incomingValueSchemaId, incomingWriteComputeSchemaId);
-    doReturn(new SchemaEntry(oldValueSchemaId, personSchemaV2)).when(readOnlySchemaRepository)
+    doReturn(new SchemaEntry(oldValueSchemaId, personSchemaV3)).when(readOnlySchemaRepository)
         .getValueSchema(storeName, oldValueSchemaId);
-    doReturn(new SchemaEntry(oldValueSchemaId, personSchemaV2)).when(readOnlySchemaRepository)
+    doReturn(new SchemaEntry(oldValueSchemaId, personSchemaV3)).when(readOnlySchemaRepository)
         .getSupersetSchema(storeName);
     StringAnnotatedStoreSchemaCache stringAnnotatedStoreSchemaCache =
         new StringAnnotatedStoreSchemaCache(storeName, readOnlySchemaRepository);

--- a/clients/da-vinci-client/src/test/resources/avro/PersonV3.avsc
+++ b/clients/da-vinci-client/src/test/resources/avro/PersonV3.avsc
@@ -3,6 +3,17 @@
   "type": "record",
   "fields": [
     {
+      "name": "nullableListField",
+      "type": [
+        "null",
+        {
+          "type": "array",
+          "items": "int"
+        }
+      ],
+      "default": null
+    },
+    {
       "name": "age",
       "type": "int",
       "default": -1

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/schema/writecompute/WriteComputeSchemaConverter.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/schema/writecompute/WriteComputeSchemaConverter.java
@@ -4,7 +4,6 @@ import static com.linkedin.venice.schema.writecompute.WriteComputeConstants.WRIT
 import static com.linkedin.venice.schema.writecompute.WriteComputeOperation.LIST_OPS;
 import static com.linkedin.venice.schema.writecompute.WriteComputeOperation.MAP_OPS;
 import static com.linkedin.venice.schema.writecompute.WriteComputeOperation.NO_OP_ON_FIELD;
-import static com.linkedin.venice.schema.writecompute.WriteComputeOperation.PUT_NEW_FIELD;
 import static org.apache.avro.Schema.Field;
 import static org.apache.avro.Schema.Type;
 import static org.apache.avro.Schema.Type.RECORD;
@@ -14,7 +13,6 @@ import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.schema.AvroSchemaParseUtils;
 import com.linkedin.venice.utils.AvroSchemaUtils;
-import io.tehuti.utils.Utils;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -22,7 +20,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.apache.avro.Schema;
-import org.apache.avro.generic.IndexedRecord;
 import org.apache.commons.lang.Validate;
 
 
@@ -445,27 +442,5 @@ public class WriteComputeSchemaConverter {
     // will be thrown out during parsing the schema.
     noOpSchema.setFields(Collections.emptyList());
     return noOpSchema;
-  }
-
-  public static WriteComputeOperation getFieldOperationType(Object writeComputeFieldValue) {
-    Utils.notNull(writeComputeFieldValue);
-
-    if (writeComputeFieldValue instanceof IndexedRecord) {
-      IndexedRecord writeComputeFieldRecord = (IndexedRecord) writeComputeFieldValue;
-      String writeComputeFieldSchemaName = writeComputeFieldRecord.getSchema().getName();
-
-      if (writeComputeFieldSchemaName.equals(NO_OP_ON_FIELD.name)) {
-        return NO_OP_ON_FIELD;
-      }
-
-      if (writeComputeFieldSchemaName.endsWith(LIST_OPS.name)) {
-        return LIST_OPS;
-      }
-
-      if (writeComputeFieldSchemaName.endsWith(MAP_OPS.name)) {
-        return MAP_OPS;
-      }
-    }
-    return PUT_NEW_FIELD;
   }
 }

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/schema/writecompute/TestWriteComputeOperation.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/schema/writecompute/TestWriteComputeOperation.java
@@ -1,0 +1,64 @@
+package com.linkedin.venice.schema.writecompute;
+
+import static com.linkedin.venice.utils.TestWriteUtils.loadFileAsString;
+
+import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
+import com.linkedin.venice.writer.update.UpdateBuilderImpl;
+import java.util.Collections;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericRecord;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class TestWriteComputeOperation {
+  @Test
+  public void testGetFieldOperationType() {
+    Schema updateSchemaForList = WriteComputeSchemaConverter.getInstance()
+        .convertFromValueRecordSchema(AvroCompatibilityHelper.parse(loadFileAsString("partialUpdateSchemaV1.avsc")));
+
+    GenericRecord updateRequest = new UpdateBuilderImpl(updateSchemaForList).setNewFieldValue("regularField", "abc")
+        .setNewFieldValue("listField", Collections.emptyList())
+        .setNewFieldValue("nullableListField", null)
+        .setNewFieldValue("mapField", Collections.emptyMap())
+        .setNewFieldValue("nullableMapField", null)
+        .build();
+    Assert.assertEquals(
+        WriteComputeOperation.getFieldOperationType(updateRequest.get("regularField")),
+        WriteComputeOperation.PUT_NEW_FIELD);
+    Assert.assertEquals(
+        WriteComputeOperation.getFieldOperationType(updateRequest.get("listField")),
+        WriteComputeOperation.PUT_NEW_FIELD);
+    Assert.assertEquals(
+        WriteComputeOperation.getFieldOperationType(updateRequest.get("nullableListField")),
+        WriteComputeOperation.PUT_NEW_FIELD);
+    Assert.assertEquals(
+        WriteComputeOperation.getFieldOperationType(updateRequest.get("mapField")),
+        WriteComputeOperation.PUT_NEW_FIELD);
+    Assert.assertEquals(
+        WriteComputeOperation.getFieldOperationType(updateRequest.get("nullableMapField")),
+        WriteComputeOperation.PUT_NEW_FIELD);
+
+    updateRequest = new UpdateBuilderImpl(updateSchemaForList)
+        .setElementsToAddToListField("listField", Collections.singletonList(1))
+        .setElementsToRemoveFromListField("nullableListField", Collections.singletonList(1))
+        .setEntriesToAddToMapField("mapField", Collections.singletonMap("k1", 1))
+        .setKeysToRemoveFromMapField("nullableMapField", Collections.singletonList("k1"))
+        .build();
+    Assert.assertEquals(
+        WriteComputeOperation.getFieldOperationType(updateRequest.get("regularField")),
+        WriteComputeOperation.NO_OP_ON_FIELD);
+    Assert.assertEquals(
+        WriteComputeOperation.getFieldOperationType(updateRequest.get("listField")),
+        WriteComputeOperation.LIST_OPS);
+    Assert.assertEquals(
+        WriteComputeOperation.getFieldOperationType(updateRequest.get("nullableListField")),
+        WriteComputeOperation.LIST_OPS);
+    Assert.assertEquals(
+        WriteComputeOperation.getFieldOperationType(updateRequest.get("mapField")),
+        WriteComputeOperation.MAP_OPS);
+    Assert.assertEquals(
+        WriteComputeOperation.getFieldOperationType(updateRequest.get("nullableMapField")),
+        WriteComputeOperation.MAP_OPS);
+  }
+}

--- a/internal/venice-client-common/src/test/resources/partialUpdateSchemaV1.avsc
+++ b/internal/venice-client-common/src/test/resources/partialUpdateSchemaV1.avsc
@@ -1,0 +1,50 @@
+{
+  "type": "record",
+  "name": "TestRecord",
+  "namespace": "com.linkedin.avro",
+  "fields": [
+    {
+      "name": "regularField",
+      "type": "string",
+      "default": "default_venice"
+    },
+    {
+      "name": "listField",
+      "type": {
+        "type": "array",
+        "items": "int"
+      },
+      "default": []
+    },
+    {
+      "name": "nullableListField",
+      "type": [
+        "null",
+        {
+          "type": "array",
+          "items": "int"
+        }
+      ],
+      "default": null
+    },
+    {
+      "name": "mapField",
+      "type": {
+        "type": "map",
+        "values": "int"
+      },
+      "default": {}
+    },
+    {
+      "name": "nullableMapField",
+      "type": [
+        "null",
+        {
+          "type": "map",
+          "values": "int"
+        }
+      ],
+      "default": null
+    }
+  ]
+}


### PR DESCRIPTION
## [server] Fix NPE in MergeConflictResolver#ignoreNewUpdate()
This PR fixes NPE thrown in MergeConflictResolver#ignoreNewUpdate(): When checking a new UPDATE message, we will first check message timestamp and compared with old value RMD. The existing logic gets all the fields from update record and check operation type for each field. Here it makes a wrong assumption that field value cannot be null, and throw exception when a new field is being set to null.
The PR fixes the issue, removes code duplications in util methods.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
New unit tests in different levels.
## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.