### PR TITLE
[producer][samza] Reinitalize transport client if a store has moved

### DIFF
--- a/clients/venice-samza/src/main/java/com/linkedin/venice/pushmonitor/RouterBasedHybridStoreQuotaMonitor.java
+++ b/clients/venice-samza/src/main/java/com/linkedin/venice/pushmonitor/RouterBasedHybridStoreQuotaMonitor.java
@@ -132,7 +132,6 @@ public class RouterBasedHybridStoreQuotaMonitor implements Closeable {
           // TODO: It'd make sense to call shutdown on the transport client, but it's a shared object so that's
           // a bit dangerous.
           transportClient = reinitProvider.apply();
-          return;
         }
         LOGGER.error("Router was not able to get hybrid quota status: {}", quotaStatusResponse.getError());
         return;

--- a/clients/venice-samza/src/test/java/com/linkedin/venice/pushmonitor/RouterBasedHybridStoreQuotaMonitorTest.java
+++ b/clients/venice-samza/src/test/java/com/linkedin/venice/pushmonitor/RouterBasedHybridStoreQuotaMonitorTest.java
@@ -22,7 +22,8 @@ public class RouterBasedHybridStoreQuotaMonitorTest {
   private static final String TOPIC_NAME = "fake_Store_v1";
 
   @Test
-  public void testGetCurrentStatus() throws IOException, ExecutionException, InterruptedException, TimeoutException {
+  public void testTransportClientReinit()
+      throws IOException, ExecutionException, InterruptedException, TimeoutException {
     TransportClient mockTransportclient = Mockito.mock(TransportClient.class);
     TransportClientResponse mockResponse = Mockito.mock(TransportClientResponse.class);
     ObjectMapper mockMapper = Mockito.mock(ObjectMapper.class);

--- a/clients/venice-samza/src/test/java/com/linkedin/venice/pushmonitor/RouterBasedHybridStoreQuotaMonitorTest.java
+++ b/clients/venice-samza/src/test/java/com/linkedin/venice/pushmonitor/RouterBasedHybridStoreQuotaMonitorTest.java
@@ -1,0 +1,56 @@
+package com.linkedin.venice.pushmonitor;
+
+import static org.testng.Assert.*;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.linkedin.venice.client.store.transport.TransportClient;
+import com.linkedin.venice.client.store.transport.TransportClientResponse;
+import com.linkedin.venice.exceptions.ErrorType;
+import com.linkedin.venice.meta.Version;
+import com.linkedin.venice.routerapi.HybridStoreQuotaStatusResponse;
+import java.io.IOException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class RouterBasedHybridStoreQuotaMonitorTest {
+  private static final String STORE_NAME = "fake_Store";
+  private static final String TOPIC_NAME = "fake_Store_v1";
+
+  @Test
+  public void testGetCurrentStatus() throws IOException, ExecutionException, InterruptedException, TimeoutException {
+    TransportClient mockTransportclient = Mockito.mock(TransportClient.class);
+    TransportClientResponse mockResponse = Mockito.mock(TransportClientResponse.class);
+    ObjectMapper mockMapper = Mockito.mock(ObjectMapper.class);
+    HybridStoreQuotaStatusResponse mockQuotaStatusResponse = Mockito.mock(HybridStoreQuotaStatusResponse.class);
+    Mockito.when(mockResponse.getBody()).thenReturn(STORE_NAME.getBytes());
+    Mockito.when(mockTransportclient.get(Mockito.anyString()))
+        .thenReturn(CompletableFuture.completedFuture(mockResponse));
+    Mockito
+        .when(mockMapper.readValue(Mockito.eq(STORE_NAME.getBytes()), Mockito.eq(HybridStoreQuotaStatusResponse.class)))
+        .thenReturn(mockQuotaStatusResponse);
+    Mockito.when(mockQuotaStatusResponse.isError()).thenReturn(true);
+    Mockito.when(mockQuotaStatusResponse.getErrorType()).thenReturn(ErrorType.STORE_NOT_FOUND);
+
+    final boolean[] isReinitCalled = { false };
+    RouterBasedHybridStoreQuotaMonitor.TransportClientReinitProvider transportClientReinitProvider = () -> {
+      isReinitCalled[0] = true;
+      return mockTransportclient;
+    };
+    RouterBasedHybridStoreQuotaMonitor routerBasedHybridStoreQuotaMonitor = new RouterBasedHybridStoreQuotaMonitor(
+        mockTransportclient,
+        STORE_NAME,
+        Version.PushType.STREAM,
+        TOPIC_NAME,
+        transportClientReinitProvider);
+
+    routerBasedHybridStoreQuotaMonitor.getHybridQuotaMonitorTask().setMapper(mockMapper);
+    routerBasedHybridStoreQuotaMonitor.getHybridQuotaMonitorTask().checkStatus();
+
+    Assert.assertTrue(isReinitCalled[0]);
+  }
+}

--- a/clients/venice-samza/src/test/java/com/linkedin/venice/pushmonitor/RouterBasedHybridStoreQuotaMonitorTest.java
+++ b/clients/venice-samza/src/test/java/com/linkedin/venice/pushmonitor/RouterBasedHybridStoreQuotaMonitorTest.java
@@ -54,4 +54,38 @@ public class RouterBasedHybridStoreQuotaMonitorTest {
 
     Assert.assertTrue(isReinitCalled[0]);
   }
+
+  @Test
+  public void testStatusChange() throws IOException, ExecutionException, InterruptedException, TimeoutException {
+    TransportClient mockTransportclient = Mockito.mock(TransportClient.class);
+    TransportClientResponse mockResponse = Mockito.mock(TransportClientResponse.class);
+    ObjectMapper mockMapper = Mockito.mock(ObjectMapper.class);
+    HybridStoreQuotaStatusResponse mockQuotaStatusResponse = Mockito.mock(HybridStoreQuotaStatusResponse.class);
+    Mockito.when(mockResponse.getBody()).thenReturn(STORE_NAME.getBytes());
+    Mockito.when(mockTransportclient.get(Mockito.anyString()))
+        .thenReturn(CompletableFuture.completedFuture(mockResponse));
+    Mockito
+        .when(mockMapper.readValue(Mockito.eq(STORE_NAME.getBytes()), Mockito.eq(HybridStoreQuotaStatusResponse.class)))
+        .thenReturn(mockQuotaStatusResponse);
+    Mockito.when(mockQuotaStatusResponse.isError()).thenReturn(false);
+    Mockito.when(mockQuotaStatusResponse.getQuotaStatus()).thenReturn(HybridStoreQuotaStatus.QUOTA_VIOLATED);
+
+    final boolean[] isReinitCalled = { false };
+    RouterBasedHybridStoreQuotaMonitor.TransportClientReinitProvider transportClientReinitProvider = () -> {
+      isReinitCalled[0] = true;
+      return mockTransportclient;
+    };
+    RouterBasedHybridStoreQuotaMonitor routerBasedHybridStoreQuotaMonitor = new RouterBasedHybridStoreQuotaMonitor(
+        mockTransportclient,
+        STORE_NAME,
+        Version.PushType.STREAM,
+        TOPIC_NAME,
+        transportClientReinitProvider);
+
+    routerBasedHybridStoreQuotaMonitor.getHybridQuotaMonitorTask().setMapper(mockMapper);
+    routerBasedHybridStoreQuotaMonitor.getHybridQuotaMonitorTask().checkStatus();
+
+    Assert.assertFalse(isReinitCalled[0]);
+    Assert.assertEquals(routerBasedHybridStoreQuotaMonitor.getCurrentStatus(), HybridStoreQuotaStatus.QUOTA_VIOLATED);
+  }
 }


### PR DESCRIPTION
## [producer][samza] Reinitalize transport client if a store has moved

This is to allow store moves to not break system producers.


Resolves #XXX

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.