### PR TITLE
[doc] Fix create-store command

### DIFF
--- a/docs/quickstart/quickstart-single-datacenter.md
+++ b/docs/quickstart/quickstart-single-datacenter.md
@@ -61,7 +61,7 @@ value schema:
 
 Let's create a venice store:
 ```
-./create_store.sh http://venice-controller:5555 venice-cluster0 test-store sample-data/schema/keySchema.avsc sample-data/schema/valueSchema.avsc
+./create-store.sh http://venice-controller:5555 venice-cluster0 test-store sample-data/schema/keySchema.avsc sample-data/schema/valueSchema.avsc
 ```
 
 #### Step 6: Push data to the store


### PR DESCRIPTION
## [doc] Fix create-store command

Fixes erroneous `create-store` command mentioned in "Single-Datacenter Docker Quickstart" page.

## How was this PR tested?

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.