### PR TITLE
[controller][server] Allow current_version request server endpoint in acl handler

### DIFF
--- a/internal/venice-common/src/main/java/com/linkedin/venice/acl/handler/StoreAclHandler.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/acl/handler/StoreAclHandler.java
@@ -109,10 +109,10 @@ public class StoreAclHandler extends SimpleChannelInboundHandler<HttpRequest> im
     }
 
     /**
-     *  Skip ACL for requests to /metadata, /admin and /health as there's no sensitive information in the response.
+     *  Skip ACL for requests to /metadata, /admin /current_version and /health as there's no sensitive information in the response.
      */
-    Set<QueryAction> queriesToSkipAcl =
-        new HashSet<>(Arrays.asList(QueryAction.METADATA, QueryAction.ADMIN, QueryAction.HEALTH));
+    Set<QueryAction> queriesToSkipAcl = new HashSet<>(
+        Arrays.asList(QueryAction.METADATA, QueryAction.ADMIN, QueryAction.HEALTH, QueryAction.CURRENT_VERSION));
     try {
       QueryAction queryAction = QueryAction.valueOf(requestParts[1].toUpperCase());
       if (queriesToSkipAcl.contains(queryAction)) {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/StoreBackupVersionCleanupService.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/StoreBackupVersionCleanupService.java
@@ -157,7 +157,7 @@ public class StoreBackupVersionCleanupService extends AbstractVeniceService {
           LOGGER.warn(
               "Got status code {} from host {} while querying router current version for store {}",
               response.getStatusLine().getStatusCode(),
-              routerRequest,
+              routerInstance,
               store.getName());
           return false;
         }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/StoreBackupVersionCleanupService.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/StoreBackupVersionCleanupService.java
@@ -151,13 +151,13 @@ public class StoreBackupVersionCleanupService extends AbstractVeniceService {
     for (Instance routerInstance: liveRouterInstances) {
       try {
         HttpGet routerRequest =
-            new HttpGet(routerInstance.getHostUrl(true) + "/" + TYPE_CURRENT_VERSION + "/" + store.getName());
+            new HttpGet(routerInstance.getHostUrl(true) + TYPE_CURRENT_VERSION + "/" + store.getName());
         HttpResponse response = getHttpAsyncClient().execute(routerRequest, null).get(500, TimeUnit.MILLISECONDS);
         if (response.getStatusLine().getStatusCode() != HttpStatus.SC_OK) {
           LOGGER.warn(
               "Got status code {} from host {} while querying router current version for store {}",
               response.getStatusLine().getStatusCode(),
-              routerInstance,
+              routerRequest,
               store.getName());
           return false;
         }
@@ -188,8 +188,7 @@ public class StoreBackupVersionCleanupService extends AbstractVeniceService {
     for (Instance instance: instances) {
       try {
         HttpGet serverRequest = new HttpGet(
-            instance.getHostUrl(true) + "/" + QueryAction.CURRENT_VERSION.toString().toLowerCase() + "/"
-                + store.getName());
+            instance.getHostUrl(true) + QueryAction.CURRENT_VERSION.toString().toLowerCase() + "/" + store.getName());
         HttpResponse response = getHttpAsyncClient().execute(serverRequest, null).get(500, TimeUnit.MILLISECONDS);
         if (response.getStatusLine().getStatusCode() != HttpStatus.SC_OK) {
           LOGGER.warn(


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Allow current_version request server endpoint in acl handler
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Server metadata fetch backup version deletion calls server current version endpoint to validate the backup version.
 But in server Acl handler check fails for QueryAction.CURRENT_VERSION as its not authorized such request. This PR allows such metadata calls in server.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.