### PR TITLE
[server][admin-tool] Add server endpoint for topic partition ingestion context.

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/AbstractKafkaConsumerService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/AbstractKafkaConsumerService.java
@@ -36,7 +36,9 @@ public abstract class AbstractKafkaConsumerService extends AbstractVeniceService
 
   public abstract long getOffsetLagBasedOnMetrics(PubSubTopic versionTopic, PubSubTopicPartition pubSubTopicPartition);
 
-  public abstract long getLatestOffsetBasedOnMetrics(PubSubTopic versionTopic, PubSubTopicPartition pubSubTopicPartition);
+  public abstract long getLatestOffsetBasedOnMetrics(
+      PubSubTopic versionTopic,
+      PubSubTopicPartition pubSubTopicPartition);
 
   public abstract Map<PubSubTopicPartition, TopicPartitionIngestionInfo> getIngestionInfoFromConsumer(
       PubSubTopic versionTopic,

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/AbstractKafkaConsumerService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/AbstractKafkaConsumerService.java
@@ -36,6 +36,8 @@ public abstract class AbstractKafkaConsumerService extends AbstractVeniceService
 
   public abstract long getOffsetLagBasedOnMetrics(PubSubTopic versionTopic, PubSubTopicPartition pubSubTopicPartition);
 
+  public abstract long getLatestOffsetBasedOnMetrics(PubSubTopic versionTopic, PubSubTopicPartition pubSubTopicPartition);
+
   public abstract Map<PubSubTopicPartition, TopicPartitionIngestionInfo> getIngestionInfoFromConsumer(
       PubSubTopic versionTopic,
       PubSubTopicPartition pubSubTopicPartition);

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/AbstractKafkaConsumerService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/AbstractKafkaConsumerService.java
@@ -8,6 +8,7 @@ import com.linkedin.venice.pubsub.api.PubSubTopic;
 import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
 import com.linkedin.venice.service.AbstractVeniceService;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 
@@ -35,7 +36,7 @@ public abstract class AbstractKafkaConsumerService extends AbstractVeniceService
 
   public abstract long getOffsetLagBasedOnMetrics(PubSubTopic versionTopic, PubSubTopicPartition pubSubTopicPartition);
 
-  public abstract long getLatestOffsetBasedOnMetrics(
+  public abstract Map<PubSubTopicPartition, TopicPartitionIngestionInfo> getIngestionInfoFromConsumer(
       PubSubTopic versionTopic,
       PubSubTopicPartition pubSubTopicPartition);
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/AggKafkaConsumerService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/AggKafkaConsumerService.java
@@ -2,10 +2,12 @@ package com.linkedin.davinci.kafka.consumer;
 
 import static com.linkedin.venice.ConfigKeys.KAFKA_BOOTSTRAP_SERVERS;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.linkedin.davinci.config.VeniceServerConfig;
 import com.linkedin.davinci.ingestion.consumption.ConsumedDataReceiver;
 import com.linkedin.davinci.stats.StuckConsumerRepairStats;
 import com.linkedin.venice.exceptions.VeniceException;
+import com.linkedin.venice.helix.VeniceJsonSerializer;
 import com.linkedin.venice.kafka.protocol.KafkaMessageEnvelope;
 import com.linkedin.venice.message.KafkaKey;
 import com.linkedin.venice.meta.ReadOnlyStoreRepository;
@@ -26,6 +28,7 @@ import com.linkedin.venice.utils.Utils;
 import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
 import io.tehuti.metrics.MetricsRepository;
 import it.unimi.dsi.fastutil.objects.Object2IntMap;
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -79,6 +82,10 @@ public class AggKafkaConsumerService extends AbstractVeniceService {
 
   private final static String STUCK_CONSUMER_MSG =
       "Didn't find any suspicious ingestion task, and please contact developers to investigate it further";
+
+  private final VeniceJsonSerializer<Map<String, Map<String, TopicPartitionIngestionInfo>>> topicPartitionIngestionContextJsonSerializer =
+      new VeniceJsonSerializer<>(new TypeReference<Map<String, Map<String, TopicPartitionIngestionInfo>>>() {
+      });
 
   public AggKafkaConsumerService(
       final PubSubConsumerAdapterFactory consumerFactory,
@@ -467,33 +474,20 @@ public class AggKafkaConsumerService extends AbstractVeniceService {
     return kafkaUrls;
   }
 
-  String getIngestionInfoFor(PubSubTopic versionTopic, PubSubTopicPartition pubSubTopicPartition) {
-    StringBuilder consumerIngestionInfo = new StringBuilder(
-        String.format("Consumer information for ingestion task of %s with %s\n", versionTopic, pubSubTopicPartition));
+  byte[] getIngestionInfoFor(PubSubTopic versionTopic, PubSubTopicPartition pubSubTopicPartition) throws IOException {
+    Map<String, Map<String, TopicPartitionIngestionInfo>> topicPartitionIngestionContext = new HashMap<>();
     for (String kafkaUrl: kafkaServerToConsumerServiceMap.keySet()) {
-      if (hasConsumerAssignedFor(kafkaUrl, versionTopic, pubSubTopicPartition)) {
-        AbstractKafkaConsumerService consumerService = getKafkaConsumerService(kafkaUrl);
-        Map<PubSubTopicPartition, TopicPartitionIngestionInfo> topicPartitionIngestionInfoMap =
-            consumerService.getIngestionInfoFromConsumer(versionTopic, pubSubTopicPartition);
-        consumerIngestionInfo.append(String.format("\t\tKafka URL: %s: \n", kafkaUrl));
-        for (Map.Entry<PubSubTopicPartition, TopicPartitionIngestionInfo> entry: topicPartitionIngestionInfoMap
-            .entrySet()) {
-          PubSubTopicPartition topicPartition = entry.getKey();
-          TopicPartitionIngestionInfo topicPartitionIngestionInfo = entry.getValue();
-          consumerIngestionInfo.append(
-              String.format(
-                  "\t\t\t\t%s, latestOffset: %s, offsetLag: %s, message rate per second: %f, byte rate per second: %f, "
-                      + "for consumer index: %s (elapsed time since last poll in ms: %s)\n",
-                  topicPartition,
-                  topicPartitionIngestionInfo.latestOffset,
-                  topicPartitionIngestionInfo.offsetLag,
-                  topicPartitionIngestionInfo.msgRate,
-                  topicPartitionIngestionInfo.byteRate,
-                  topicPartitionIngestionInfo.consumerIdx,
-                  topicPartitionIngestionInfo.elapsedTimeSinceLastPollInMs));
-        }
+      AbstractKafkaConsumerService consumerService = getKafkaConsumerService(kafkaUrl);
+      Map<PubSubTopicPartition, TopicPartitionIngestionInfo> topicPartitionIngestionInfoMap =
+          consumerService.getIngestionInfoFromConsumer(versionTopic, pubSubTopicPartition);
+      for (Map.Entry<PubSubTopicPartition, TopicPartitionIngestionInfo> entry: topicPartitionIngestionInfoMap
+          .entrySet()) {
+        PubSubTopicPartition topicPartition = entry.getKey();
+        TopicPartitionIngestionInfo topicPartitionIngestionInfo = entry.getValue();
+        topicPartitionIngestionContext.computeIfAbsent(kafkaUrl, k -> new HashMap<>())
+            .put(topicPartition.toString(), topicPartitionIngestionInfo);
       }
     }
-    return consumerIngestionInfo.toString();
+    return topicPartitionIngestionContextJsonSerializer.serialize(topicPartitionIngestionContext, "");
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/AggKafkaConsumerService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/AggKafkaConsumerService.java
@@ -473,21 +473,8 @@ public class AggKafkaConsumerService extends AbstractVeniceService {
     for (String kafkaUrl: kafkaServerToConsumerServiceMap.keySet()) {
       if (hasConsumerAssignedFor(kafkaUrl, versionTopic, pubSubTopicPartition)) {
         AbstractKafkaConsumerService consumerService = getKafkaConsumerService(kafkaUrl);
-        SharedKafkaConsumer consumer =
-            consumerService.getConsumerAssignedToVersionTopicPartition(versionTopic, pubSubTopicPartition);
-        if (consumer != null) {
-          consumerIngestionInfo
-              .append(String.format("\t\tKafka URL: %s, for consumer index: %s\n", kafkaUrl, consumer.getIndex()));
-          // TODO: Add more ingestion related information accross all topic partitions on this consumer.
-          for (PubSubTopicPartition topicPartition: consumer.getAssignment()) {
-            Long offsetLag = consumer.getOffsetLag(pubSubTopicPartition);
-            Long latestOffset = consumer.getLatestOffset(pubSubTopicPartition);
-            consumerIngestionInfo.append(
-                String.format("\t\t\t\t%s: latestOffset:%s, offsetLag:%s\n", topicPartition, latestOffset, offsetLag));
-          }
-        } else {
-          consumerIngestionInfo.append(String.format("\t\tKafka URL: %s, no consumer found.\n", kafkaUrl));
-        }
+        consumerIngestionInfo
+            .append(consumerService.getTopicPartitionIngestionInfo(versionTopic, pubSubTopicPartition));
       }
     }
     return consumerIngestionInfo.toString();

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ConsumptionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ConsumptionTask.java
@@ -139,6 +139,7 @@ class ConsumptionTask implements Runnable {
           lastSuccessfulPollTimestamp = System.currentTimeMillis();
           aggStats.recordTotalPollRequestLatency(lastSuccessfulPollTimestamp - beforePollingTimeStamp);
           if (!polledPubSubMessages.isEmpty()) {
+            LOGGER.info("Get some messages");
             payloadBytesConsumedInOnePoll = 0;
             polledPubSubMessagesCount = 0;
             beforeProducingToWriteBufferTimestamp = System.currentTimeMillis();

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaConsumerService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaConsumerService.java
@@ -481,14 +481,18 @@ public abstract class KafkaConsumerService extends AbstractKafkaConsumerService 
     Map<PubSubTopicPartition, TopicPartitionIngestionInfo> topicPartitionIngestionInfoMap = new HashMap<>();
     if (consumer != null) {
       ConsumptionTask consumptionTask = consumerToConsumptionTask.get(consumer);
-      long elapsedTimeSinceLastPollInMs =
-          LatencyUtils.getElapsedTimeInMs(consumptionTask.getLastSuccessfulPollTimestamp());
       int consumerIdx = consumptionTask.getTaskId();
       for (PubSubTopicPartition topicPartition: consumer.getAssignment()) {
         long offsetLag = consumer.getOffsetLag(topicPartition);
         long latestOffset = consumer.getLatestOffset(topicPartition);
         double msgRate = consumptionTask.getMessageRate(topicPartition);
-        double byteRate = consumptionTask.getMessageRate(topicPartition);
+        double byteRate = consumptionTask.getByteRate(topicPartition);
+        long lastSuccessfulPollTimestamp = consumptionTask.getLastSuccessfulPollTimestamp(topicPartition);
+        long elapsedTimeSinceLastPollInMs = ConsumptionTask.DEFAULT_TOPIC_PARTITION_NO_POLL_TIMESTAMP;
+        if (lastSuccessfulPollTimestamp != ConsumptionTask.DEFAULT_TOPIC_PARTITION_NO_POLL_TIMESTAMP) {
+          elapsedTimeSinceLastPollInMs =
+              LatencyUtils.getElapsedTimeInMs(consumptionTask.getLastSuccessfulPollTimestamp());
+        }
         TopicPartitionIngestionInfo topicPartitionIngestionInfo = new TopicPartitionIngestionInfo(
             latestOffset,
             offsetLag,

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaConsumerService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaConsumerService.java
@@ -134,7 +134,8 @@ public abstract class KafkaConsumerService extends AbstractKafkaConsumerService 
               null),
           aggStats,
           this::recordPartitionsPerConsumerSensor,
-          this::handleUnsubscription);
+          this::handleUnsubscription,
+          i);
 
       Supplier<Map<PubSubTopicPartition, List<PubSubMessage<KafkaKey, KafkaMessageEnvelope, Long>>>> pollFunction =
           liveConfigBasedKafkaThrottlingEnabled

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaConsumerServiceDelegator.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaConsumerServiceDelegator.java
@@ -9,6 +9,7 @@ import com.linkedin.venice.pubsub.api.PubSubTopic;
 import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
 import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.function.BiFunction;
 import java.util.function.Function;
@@ -140,9 +141,11 @@ public class KafkaConsumerServiceDelegator extends AbstractKafkaConsumerService 
   }
 
   @Override
-  public String getTopicPartitionIngestionInfo(PubSubTopic versionTopic, PubSubTopicPartition pubSubTopicPartition) {
+  public Map<PubSubTopicPartition, TopicPartitionIngestionInfo> getIngestionInfoFromConsumer(
+      PubSubTopic versionTopic,
+      PubSubTopicPartition pubSubTopicPartition) {
     return getKafkaConsumerService(versionTopic, pubSubTopicPartition)
-        .getTopicPartitionIngestionInfo(versionTopic, pubSubTopicPartition);
+        .getIngestionInfoFromConsumer(versionTopic, pubSubTopicPartition);
   }
 
   @Override

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaConsumerServiceDelegator.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaConsumerServiceDelegator.java
@@ -140,6 +140,12 @@ public class KafkaConsumerServiceDelegator extends AbstractKafkaConsumerService 
   }
 
   @Override
+  public String getTopicPartitionIngestionInfo(PubSubTopic versionTopic, PubSubTopicPartition pubSubTopicPartition) {
+    return getKafkaConsumerService(versionTopic, pubSubTopicPartition)
+        .getTopicPartitionIngestionInfo(versionTopic, pubSubTopicPartition);
+  }
+
+  @Override
   public boolean startInner() throws Exception {
     defaultConsumerService.start();
     if (consumerServiceForAAWCLeader != null) {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionService.java
@@ -67,10 +67,10 @@ import com.linkedin.venice.pubsub.adapter.kafka.producer.ApacheKafkaProducerAdap
 import com.linkedin.venice.pubsub.adapter.kafka.producer.ApacheKafkaProducerConfig;
 import com.linkedin.venice.pubsub.adapter.kafka.producer.SharedKafkaProducerAdapterFactory;
 import com.linkedin.venice.pubsub.api.PubSubMessageDeserializer;
-import com.linkedin.venice.pubsub.manager.TopicManagerContext;
-import com.linkedin.venice.pubsub.manager.TopicManagerRepository;
 import com.linkedin.venice.pubsub.api.PubSubTopic;
 import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
+import com.linkedin.venice.pubsub.manager.TopicManagerContext;
+import com.linkedin.venice.pubsub.manager.TopicManagerRepository;
 import com.linkedin.venice.schema.SchemaEntry;
 import com.linkedin.venice.schema.SchemaReader;
 import com.linkedin.venice.security.SSLFactory;

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionService.java
@@ -1214,8 +1214,17 @@ public class KafkaStoreIngestionService extends AbstractVeniceService implements
     PubSubTopic pubSubVersionTopic = pubSubTopicRepository.getTopic(versionTopic);
     PubSubTopic requestTopic = pubSubTopicRepository.getTopic(topicName);
     PubSubTopicPartition pubSubTopicPartition = new PubSubTopicPartitionImpl(requestTopic, partitionNum);
-    String topicPartitionInfo = aggKafkaConsumerService.getIngestionInfoFor(pubSubVersionTopic, pubSubTopicPartition);
-    topicPartitionIngestionContextResponse.setTopicPartitionIngestionContext(topicPartitionInfo);
+    try {
+      byte[] topicPartitionInfo = aggKafkaConsumerService.getIngestionInfoFor(pubSubVersionTopic, pubSubTopicPartition);
+      topicPartitionIngestionContextResponse.setTopicPartitionIngestionContext(topicPartitionInfo);
+    } catch (Exception e) {
+      topicPartitionIngestionContextResponse.setError(true);
+      topicPartitionIngestionContextResponse.setMessage(e.getMessage());
+      LOGGER.error(
+          "Error on get topic partition ingestion context for version topic: " + versionTopic + ", topic name: "
+              + topicName + ", partition number: " + partitionNum,
+          e);
+    }
     return topicPartitionIngestionContextResponse;
   }
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionService.java
@@ -1214,8 +1214,7 @@ public class KafkaStoreIngestionService extends AbstractVeniceService implements
     PubSubTopic pubSubVersionTopic = pubSubTopicRepository.getTopic(versionTopic);
     PubSubTopic requestTopic = pubSubTopicRepository.getTopic(topicName);
     PubSubTopicPartition pubSubTopicPartition = new PubSubTopicPartitionImpl(requestTopic, partitionNum);
-    String topicPartitionInfo =
-        aggKafkaConsumerService.getTopicPartitionIngestionInfo(pubSubVersionTopic, pubSubTopicPartition);
+    String topicPartitionInfo = aggKafkaConsumerService.getIngestionInfoFor(pubSubVersionTopic, pubSubTopicPartition);
     topicPartitionIngestionContextResponse.setTopicPartitionIngestionContext(topicPartitionInfo);
     return topicPartitionIngestionContextResponse;
   }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionService.java
@@ -22,6 +22,7 @@ import com.linkedin.davinci.helix.LeaderFollowerPartitionStateModel;
 import com.linkedin.davinci.listener.response.AdminResponse;
 import com.linkedin.davinci.listener.response.MetadataResponse;
 import com.linkedin.davinci.listener.response.ServerCurrentVersionResponse;
+import com.linkedin.davinci.listener.response.TopicPartitionIngestionContextResponse;
 import com.linkedin.davinci.notifier.LogNotifier;
 import com.linkedin.davinci.notifier.PartitionPushStatusNotifier;
 import com.linkedin.davinci.notifier.VeniceNotifier;
@@ -68,6 +69,8 @@ import com.linkedin.venice.pubsub.adapter.kafka.producer.SharedKafkaProducerAdap
 import com.linkedin.venice.pubsub.api.PubSubMessageDeserializer;
 import com.linkedin.venice.pubsub.manager.TopicManagerContext;
 import com.linkedin.venice.pubsub.manager.TopicManagerRepository;
+import com.linkedin.venice.pubsub.api.PubSubTopic;
+import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
 import com.linkedin.venice.schema.SchemaEntry;
 import com.linkedin.venice.schema.SchemaReader;
 import com.linkedin.venice.security.SSLFactory;
@@ -1200,6 +1203,21 @@ public class KafkaStoreIngestionService extends AbstractVeniceService implements
       response.setMessage(msg);
     }
     return response;
+  }
+
+  public TopicPartitionIngestionContextResponse getTopicPartitionIngestionContext(
+      String versionTopic,
+      String topicName,
+      Integer partitionNum) {
+    TopicPartitionIngestionContextResponse topicPartitionIngestionContextResponse =
+        new TopicPartitionIngestionContextResponse();
+    PubSubTopic pubSubVersionTopic = pubSubTopicRepository.getTopic(versionTopic);
+    PubSubTopic requestTopic = pubSubTopicRepository.getTopic(topicName);
+    PubSubTopicPartition pubSubTopicPartition = new PubSubTopicPartitionImpl(requestTopic, partitionNum);
+    String topicPartitionInfo =
+        aggKafkaConsumerService.getTopicPartitionIngestionInfo(pubSubVersionTopic, pubSubTopicPartition);
+    topicPartitionIngestionContextResponse.setTopicPartitionIngestionContext(topicPartitionInfo);
+    return topicPartitionIngestionContextResponse;
   }
 
   @Override

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/SharedKafkaConsumer.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/SharedKafkaConsumer.java
@@ -82,15 +82,12 @@ class SharedKafkaConsumer implements PubSubConsumerAdapter {
    */
   private volatile long pollTimes = 0;
 
-  private final Integer index;
-
   public SharedKafkaConsumer(
       PubSubConsumerAdapter delegate,
       AggKafkaConsumerServiceStats stats,
       Runnable assignmentChangeListener,
-      UnsubscriptionListener unsubscriptionListener,
-      int index) {
-    this(delegate, stats, assignmentChangeListener, unsubscriptionListener, new SystemTime(), index);
+      UnsubscriptionListener unsubscriptionListener) {
+    this(delegate, stats, assignmentChangeListener, unsubscriptionListener, new SystemTime());
   }
 
   SharedKafkaConsumer(
@@ -98,8 +95,7 @@ class SharedKafkaConsumer implements PubSubConsumerAdapter {
       AggKafkaConsumerServiceStats stats,
       Runnable assignmentChangeListener,
       UnsubscriptionListener unsubscriptionListener,
-      Time time,
-      Integer index) {
+      Time time) {
     this.delegate = delegate;
     this.stats = stats;
     this.assignmentChangeListener = assignmentChangeListener;
@@ -107,7 +103,6 @@ class SharedKafkaConsumer implements PubSubConsumerAdapter {
     this.time = time;
     this.currentAssignment = Collections.emptySet();
     this.currentAssignmentSize = new AtomicInteger(0);
-    this.index = index;
   }
 
   /**
@@ -351,9 +346,5 @@ class SharedKafkaConsumer implements PubSubConsumerAdapter {
   @Override
   public List<PubSubTopicPartitionInfo> partitionsFor(PubSubTopic topic) {
     throw new UnsupportedOperationException("partitionsFor is not supported in SharedKafkaConsumer");
-  }
-
-  public Integer getIndex() {
-    return this.index;
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/SharedKafkaConsumer.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/SharedKafkaConsumer.java
@@ -78,16 +78,19 @@ class SharedKafkaConsumer implements PubSubConsumerAdapter {
   private Set<PubSubTopicPartition> currentAssignment;
 
   /**
-   * an ever increasing count of number of time poll has been invoked.
+   * an ever-increasing count of number of time poll has been invoked.
    */
   private volatile long pollTimes = 0;
+
+  private final Integer index;
 
   public SharedKafkaConsumer(
       PubSubConsumerAdapter delegate,
       AggKafkaConsumerServiceStats stats,
       Runnable assignmentChangeListener,
-      UnsubscriptionListener unsubscriptionListener) {
-    this(delegate, stats, assignmentChangeListener, unsubscriptionListener, new SystemTime());
+      UnsubscriptionListener unsubscriptionListener,
+      int index) {
+    this(delegate, stats, assignmentChangeListener, unsubscriptionListener, new SystemTime(), index);
   }
 
   SharedKafkaConsumer(
@@ -95,7 +98,8 @@ class SharedKafkaConsumer implements PubSubConsumerAdapter {
       AggKafkaConsumerServiceStats stats,
       Runnable assignmentChangeListener,
       UnsubscriptionListener unsubscriptionListener,
-      Time time) {
+      Time time,
+      Integer index) {
     this.delegate = delegate;
     this.stats = stats;
     this.assignmentChangeListener = assignmentChangeListener;
@@ -103,6 +107,7 @@ class SharedKafkaConsumer implements PubSubConsumerAdapter {
     this.time = time;
     this.currentAssignment = Collections.emptySet();
     this.currentAssignmentSize = new AtomicInteger(0);
+    this.index = index;
   }
 
   /**
@@ -346,5 +351,9 @@ class SharedKafkaConsumer implements PubSubConsumerAdapter {
   @Override
   public List<PubSubTopicPartitionInfo> partitionsFor(PubSubTopic topic) {
     throw new UnsupportedOperationException("partitionsFor is not supported in SharedKafkaConsumer");
+  }
+
+  public Integer getIndex() {
+    return this.index;
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/TopicPartitionIngestionInfo.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/TopicPartitionIngestionInfo.java
@@ -1,0 +1,25 @@
+package com.linkedin.davinci.kafka.consumer;
+
+class TopicPartitionIngestionInfo {
+  protected long latestOffset;
+  protected long offsetLag;
+  protected double msgRate;
+  protected double byteRate;
+  protected int consumerIdx;
+  protected long elapsedTimeSinceLastPollInMs;
+
+  TopicPartitionIngestionInfo(
+      long latestOffset,
+      long offsetLag,
+      double msgRate,
+      double byteRate,
+      int consumerIdx,
+      long elapsedTimeSinceLastPollInMs) {
+    this.latestOffset = latestOffset;
+    this.offsetLag = offsetLag;
+    this.msgRate = msgRate;
+    this.byteRate = byteRate;
+    this.consumerIdx = consumerIdx;
+    this.elapsedTimeSinceLastPollInMs = elapsedTimeSinceLastPollInMs;
+  }
+}

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/TopicPartitionIngestionInfo.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/TopicPartitionIngestionInfo.java
@@ -1,25 +1,102 @@
 package com.linkedin.davinci.kafka.consumer;
 
-class TopicPartitionIngestionInfo {
-  protected long latestOffset;
-  protected long offsetLag;
-  protected double msgRate;
-  protected double byteRate;
-  protected int consumerIdx;
-  protected long elapsedTimeSinceLastPollInMs;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
-  TopicPartitionIngestionInfo(
-      long latestOffset,
-      long offsetLag,
-      double msgRate,
-      double byteRate,
-      int consumerIdx,
-      long elapsedTimeSinceLastPollInMs) {
+
+public class TopicPartitionIngestionInfo {
+  private long latestOffset;
+  private long offsetLag;
+  private double msgRate;
+  private double byteRate;
+  private int consumerIdx;
+  private long elapsedTimeSinceLastPollInMs;
+
+  @JsonCreator
+  public TopicPartitionIngestionInfo(
+      @JsonProperty("latestOffset") long latestOffset,
+      @JsonProperty("offsetLag") long offsetLag,
+      @JsonProperty("msgRate") double msgRate,
+      @JsonProperty("byteRate") double byteRate,
+      @JsonProperty("consumerIdx") int consumerIdx,
+      @JsonProperty("elapsedTimeSinceLastPollInMs") long elapsedTimeSinceLastPollInMs) {
     this.latestOffset = latestOffset;
     this.offsetLag = offsetLag;
     this.msgRate = msgRate;
     this.byteRate = byteRate;
     this.consumerIdx = consumerIdx;
     this.elapsedTimeSinceLastPollInMs = elapsedTimeSinceLastPollInMs;
+  }
+
+  public long getLatestOffset() {
+    return latestOffset;
+  }
+
+  public long getOffsetLag() {
+    return offsetLag;
+  }
+
+  public void setOffsetLag(long offsetLag) {
+    this.offsetLag = offsetLag;
+  }
+
+  public double getMsgRate() {
+    return msgRate;
+  }
+
+  public void setMsgRate(double msgRate) {
+    this.msgRate = msgRate;
+  }
+
+  public double getByteRate() {
+    return byteRate;
+  }
+
+  public void setByteRate(double byteRate) {
+    this.byteRate = byteRate;
+  }
+
+  public int getConsumerIdx() {
+    return consumerIdx;
+  }
+
+  public void setConsumerIdx(int consumerIdx) {
+    this.consumerIdx = consumerIdx;
+  }
+
+  public long getElapsedTimeSinceLastPollInMs() {
+    return elapsedTimeSinceLastPollInMs;
+  }
+
+  public void setElapsedTimeSinceLastPollInMs(long elapsedTimeSinceLastPollInMs) {
+    this.elapsedTimeSinceLastPollInMs = elapsedTimeSinceLastPollInMs;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    TopicPartitionIngestionInfo topicPartitionIngestionInfo = (TopicPartitionIngestionInfo) o;
+    return this.latestOffset == topicPartitionIngestionInfo.getLatestOffset()
+        && this.offsetLag == topicPartitionIngestionInfo.getOffsetLag()
+        && this.msgRate == topicPartitionIngestionInfo.getMsgRate()
+        && this.byteRate == topicPartitionIngestionInfo.getByteRate()
+        && this.consumerIdx == topicPartitionIngestionInfo.getConsumerIdx()
+        && this.elapsedTimeSinceLastPollInMs == topicPartitionIngestionInfo.getElapsedTimeSinceLastPollInMs();
+  }
+
+  @Override
+  public int hashCode() {
+    int result = Long.hashCode(latestOffset);
+    result = 31 * result + Long.hashCode(offsetLag);
+    result = 31 * result + Double.hashCode(msgRate);
+    result = 31 * result + Double.hashCode(byteRate);
+    result = 31 * result + consumerIdx;
+    result = 31 * result + Long.hashCode(elapsedTimeSinceLastPollInMs);
+    return result;
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/TopicPartitionIngestionInfo.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/TopicPartitionIngestionInfo.java
@@ -83,8 +83,8 @@ public class TopicPartitionIngestionInfo {
     TopicPartitionIngestionInfo topicPartitionIngestionInfo = (TopicPartitionIngestionInfo) o;
     return this.latestOffset == topicPartitionIngestionInfo.getLatestOffset()
         && this.offsetLag == topicPartitionIngestionInfo.getOffsetLag()
-        && this.msgRate == topicPartitionIngestionInfo.getMsgRate()
-        && this.byteRate == topicPartitionIngestionInfo.getByteRate()
+        && Double.doubleToLongBits(this.msgRate) == Double.doubleToLongBits(topicPartitionIngestionInfo.getMsgRate())
+        && Double.doubleToLongBits(this.byteRate) == Double.doubleToLongBits(topicPartitionIngestionInfo.getByteRate())
         && this.consumerIdx == topicPartitionIngestionInfo.getConsumerIdx()
         && this.elapsedTimeSinceLastPollInMs == topicPartitionIngestionInfo.getElapsedTimeSinceLastPollInMs();
   }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/storage/MetadataRetriever.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/storage/MetadataRetriever.java
@@ -3,6 +3,7 @@ package com.linkedin.davinci.storage;
 import com.linkedin.davinci.listener.response.AdminResponse;
 import com.linkedin.davinci.listener.response.MetadataResponse;
 import com.linkedin.davinci.listener.response.ServerCurrentVersionResponse;
+import com.linkedin.davinci.listener.response.TopicPartitionIngestionContextResponse;
 import com.linkedin.venice.utils.ComplementSet;
 import java.nio.ByteBuffer;
 
@@ -15,4 +16,10 @@ public interface MetadataRetriever {
   MetadataResponse getMetadata(String storeName);
 
   ServerCurrentVersionResponse getCurrentVersionResponse(String storeName);
+
+  TopicPartitionIngestionContextResponse getTopicPartitionIngestionContext(
+      String versionTopic,
+      String topicName,
+      Integer partitionNum);
+
 }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/TopicPartitionIngestionInfoTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/TopicPartitionIngestionInfoTest.java
@@ -1,0 +1,38 @@
+package com.linkedin.davinci.consumer;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.linkedin.davinci.kafka.consumer.TopicPartitionIngestionInfo;
+import com.linkedin.venice.helix.VeniceJsonSerializer;
+import com.linkedin.venice.pubsub.PubSubTopicPartitionImpl;
+import com.linkedin.venice.pubsub.PubSubTopicRepository;
+import com.linkedin.venice.pubsub.api.PubSubTopic;
+import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
+import java.util.HashMap;
+import java.util.Map;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class TopicPartitionIngestionInfoTest {
+  PubSubTopicRepository pubSubTopicRepository = new PubSubTopicRepository();
+
+  @Test
+  public void testJsonParse() throws Exception {
+    TopicPartitionIngestionInfo topicPartitionIngestionInfo = new TopicPartitionIngestionInfo(0, 1, 2.0, 4.0, 5, 7);
+    PubSubTopic pubSubTopic = pubSubTopicRepository.getTopic("test_store_v1");
+    String kafkaUrl = "localhost:1234";
+    PubSubTopicPartition pubSubTopicPartition = new PubSubTopicPartitionImpl(pubSubTopic, 0);
+    Map<String, Map<String, TopicPartitionIngestionInfo>> topicPartitionIngestionContext = new HashMap<>();
+    topicPartitionIngestionContext.computeIfAbsent(kafkaUrl, k -> new HashMap<>())
+        .put(pubSubTopicPartition.toString(), topicPartitionIngestionInfo);
+    VeniceJsonSerializer<Map<String, Map<String, TopicPartitionIngestionInfo>>> veniceJsonSerializer =
+        new VeniceJsonSerializer<>(new TypeReference<Map<String, Map<String, TopicPartitionIngestionInfo>>>() {
+        });
+    byte[] jsonOutput = veniceJsonSerializer.serialize(topicPartitionIngestionContext, "");
+    Map<String, Map<String, TopicPartitionIngestionInfo>> topicPartitionIngestionContexts =
+        veniceJsonSerializer.deserialize(jsonOutput, "");
+    Assert.assertEquals(
+        topicPartitionIngestionContexts.get(kafkaUrl).get(pubSubTopicPartition.toString()),
+        topicPartitionIngestionInfo);
+  }
+}

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/KafkaConsumerServiceTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/KafkaConsumerServiceTest.java
@@ -185,9 +185,9 @@ public class KafkaConsumerServiceTest {
           consumerService.getIngestionInfoFromConsumer(versionTopic, topicPartition);
       Assert.assertEquals(topicPartitionIngestionInfoMap.size(), 1);
       Assert.assertTrue(topicPartitionIngestionInfoMap.containsKey(topicPartition));
-      Assert.assertTrue(topicPartitionIngestionInfoMap.get(topicPartition).consumerIdx == 0);
-      Assert.assertTrue(topicPartitionIngestionInfoMap.get(topicPartition).msgRate > 0);
-      Assert.assertTrue(topicPartitionIngestionInfoMap.get(topicPartition).byteRate > 0);
+      Assert.assertTrue(topicPartitionIngestionInfoMap.get(topicPartition).getConsumerIdx() == 0);
+      Assert.assertTrue(topicPartitionIngestionInfoMap.get(topicPartition).getMsgRate() > 0);
+      Assert.assertTrue(topicPartitionIngestionInfoMap.get(topicPartition).getByteRate() > 0);
     });
     consumerService.stop();
   }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/KafkaConsumerServiceTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/KafkaConsumerServiceTest.java
@@ -1,14 +1,17 @@
 package com.linkedin.davinci.kafka.consumer;
 
 import static com.linkedin.venice.ConfigKeys.KAFKA_BOOTSTRAP_SERVERS;
-import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyBoolean;
+import static org.mockito.Mockito.anyLong;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import com.linkedin.davinci.ingestion.consumption.ConsumedDataReceiver;
 import com.linkedin.venice.kafka.protocol.KafkaMessageEnvelope;
+import com.linkedin.venice.message.KafkaKey;
 import com.linkedin.venice.meta.ReadOnlyStoreRepository;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.pubsub.PubSubConsumerAdapterFactory;
@@ -16,17 +19,23 @@ import com.linkedin.venice.pubsub.PubSubTopicPartitionImpl;
 import com.linkedin.venice.pubsub.PubSubTopicRepository;
 import com.linkedin.venice.pubsub.adapter.kafka.consumer.ApacheKafkaConsumerAdapter;
 import com.linkedin.venice.pubsub.api.PubSubConsumerAdapter;
+import com.linkedin.venice.pubsub.api.PubSubMessage;
 import com.linkedin.venice.pubsub.api.PubSubMessageDeserializer;
 import com.linkedin.venice.pubsub.api.PubSubTopic;
 import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
 import com.linkedin.venice.serialization.avro.OptimizedKafkaValueSerializer;
 import com.linkedin.venice.throttle.EventThrottler;
 import com.linkedin.venice.utils.SystemTime;
+import com.linkedin.venice.utils.TestUtils;
 import com.linkedin.venice.utils.Utils;
 import com.linkedin.venice.utils.pools.LandFillObjectPool;
 import io.tehuti.metrics.MetricsRepository;
 import io.tehuti.metrics.Sensor;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -127,6 +136,93 @@ public class KafkaConsumerServiceTest {
         assignedConsumerForTask2,
         "The assigned consumer should come with least partitions, when no zero loaded consumer available.");
     consumerService.stop();
+  }
+
+  @Test
+  public void testGetTopicPartitionIngestionInformation() throws Exception {
+    ApacheKafkaConsumerAdapter consumer1 = mock(ApacheKafkaConsumerAdapter.class);
+    when(consumer1.hasAnySubscription()).thenReturn(true);
+
+    PubSubConsumerAdapterFactory factory = mock(PubSubConsumerAdapterFactory.class);
+    when(factory.create(any(), anyBoolean(), any(), any())).thenReturn(consumer1);
+
+    Properties properties = new Properties();
+    properties.put(KAFKA_BOOTSTRAP_SERVERS, "test_kafka_url");
+    MetricsRepository mockMetricsRepository = mock(MetricsRepository.class);
+    final Sensor mockSensor = mock(Sensor.class);
+    doReturn(mockSensor).when(mockMetricsRepository).sensor(anyString(), any());
+    KafkaConsumerService consumerService =
+        getKafkaConsumerServiceWithSingleConsumer(factory, properties, mockMetricsRepository);
+    String storeName3 = Utils.getUniqueString("test_consumer_service");
+    PubSubTopic topicForStoreName3 = pubSubTopicRepository.getTopic(Version.composeKafkaTopic(storeName3, 1));
+    StoreIngestionTask task = mock(StoreIngestionTask.class);
+    when(task.getVersionTopic()).thenReturn(topicForStoreName3);
+    when(task.isHybridMode()).thenReturn(true);
+    PubSubTopic versionTopic = task.getVersionTopic();
+    PubSubTopicPartition topicPartition = new PubSubTopicPartitionImpl(versionTopic, 0);
+
+    ConsumedDataReceiver consumedDataReceiver = mock(ConsumedDataReceiver.class);
+    when(consumedDataReceiver.destinationIdentifier()).thenReturn(versionTopic);
+    consumerService.startConsumptionIntoDataReceiver(topicPartition, 0, consumedDataReceiver);
+
+    SharedKafkaConsumer assignedConsumer = consumerService.assignConsumerFor(versionTopic, topicPartition);
+    Set<PubSubTopicPartition> consumerAssignedPartitions = new HashSet<>();
+    consumerAssignedPartitions.add(topicPartition);
+    assignedConsumer.setCurrentAssignment(consumerAssignedPartitions);
+
+    Map<PubSubTopicPartition, List<PubSubMessage<KafkaKey, KafkaMessageEnvelope, Long>>> consumer2MessageMap =
+        new HashMap<>();
+    List<PubSubMessage<KafkaKey, KafkaMessageEnvelope, Long>> pubSubMessages = new ArrayList<>();
+    PubSubMessage pubSubMessage = mock(PubSubMessage.class);
+    when(pubSubMessage.getPayloadSize()).thenReturn(10);
+    pubSubMessages.add(pubSubMessage);
+    consumer2MessageMap.put(topicPartition, pubSubMessages);
+    when(consumer1.poll(anyLong())).thenReturn(consumer2MessageMap);
+    consumerService.start();
+
+    TestUtils.waitForNonDeterministicAssertion(1, TimeUnit.SECONDS, true, true, () -> {
+      Map<PubSubTopicPartition, TopicPartitionIngestionInfo> topicPartitionIngestionInfoMap =
+          consumerService.getIngestionInfoFromConsumer(versionTopic, topicPartition);
+      Assert.assertEquals(topicPartitionIngestionInfoMap.size(), 1);
+      Assert.assertTrue(topicPartitionIngestionInfoMap.containsKey(topicPartition));
+      Assert.assertTrue(topicPartitionIngestionInfoMap.get(topicPartition).consumerIdx == 0);
+      Assert.assertTrue(topicPartitionIngestionInfoMap.get(topicPartition).msgRate > 0);
+      Assert.assertTrue(topicPartitionIngestionInfoMap.get(topicPartition).byteRate > 0);
+    });
+    consumerService.stop();
+  }
+
+  private KafkaConsumerService getKafkaConsumerServiceWithSingleConsumer(
+      PubSubConsumerAdapterFactory factory,
+      Properties properties,
+      MetricsRepository mockMetricsRepository) {
+    KafkaConsumerService consumerService = new KafkaConsumerService(
+        factory,
+        properties,
+        1000l,
+        1,
+        mock(EventThrottler.class),
+        mock(EventThrottler.class),
+        mock(KafkaClusterBasedRecordThrottler.class),
+        mockMetricsRepository,
+        "test_kafka_cluster_alias",
+        TimeUnit.MINUTES.toMillis(1),
+        mock(TopicExistenceChecker.class),
+        false,
+        pubSubDeserializer,
+        SystemTime.INSTANCE,
+        null,
+        false,
+        mock(ReadOnlyStoreRepository.class),
+        false) {
+      @Override
+      protected SharedKafkaConsumer pickConsumerForPartition(
+          PubSubTopic versionTopic,
+          PubSubTopicPartition topicPartition) {
+        return consumerToConsumptionTask.getByIndex(0).getKey();
+      }
+    };
+    return consumerService;
   }
 
   private Set<PubSubTopicPartition> getPubSubTopicPartitionsSet(PubSubTopic pubSubTopic, int partitionNum) {

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionServiceTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionServiceTest.java
@@ -4,10 +4,12 @@ import static com.linkedin.venice.ConfigKeys.KAFKA_BOOTSTRAP_SERVERS;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atMostOnce;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
@@ -47,6 +49,10 @@ import com.linkedin.venice.pubsub.PubSubAdminAdapterFactory;
 import com.linkedin.venice.pubsub.PubSubClientsFactory;
 import com.linkedin.venice.pubsub.PubSubConsumerAdapterFactory;
 import com.linkedin.venice.pubsub.PubSubProducerAdapterFactory;
+import com.linkedin.venice.pubsub.PubSubTopicPartitionImpl;
+import com.linkedin.venice.pubsub.PubSubTopicRepository;
+import com.linkedin.venice.pubsub.api.PubSubTopic;
+import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
 import com.linkedin.venice.schema.SchemaEntry;
 import com.linkedin.venice.serialization.avro.AvroProtocolDefinition;
 import com.linkedin.venice.utils.DataProviderUtils;
@@ -87,6 +93,8 @@ public abstract class KafkaStoreIngestionServiceTest {
   private StorageEngineBackedCompressorFactory compressorFactory;
 
   private KafkaStoreIngestionService kafkaStoreIngestionService;
+
+  private PubSubTopicRepository pubSubTopicRepository = new PubSubTopicRepository();
 
   @BeforeClass
   public void setUp() {
@@ -448,6 +456,14 @@ public abstract class KafkaStoreIngestionServiceTest {
     storeIngestionTask.setPartitionConsumptionState(1, mock(PartitionConsumptionState.class));
     kafkaStoreIngestionService.stopConsumptionAndWait(config, 0, 1, 1, true);
     Assert.assertNotNull(storeIngestionTask);
+    PubSubTopic pubSubTopic = pubSubTopicRepository.getTopic(topicName);
+    PubSubTopicPartition pubSubTopicPartition = new PubSubTopicPartitionImpl(pubSubTopic, 0);
+    Properties consumerProperties = new Properties();
+    consumerProperties.put(KAFKA_BOOTSTRAP_SERVERS, "localhost:16637");
+    AbstractKafkaConsumerService kafkaConsumerService =
+        spy(storeIngestionTask.aggKafkaConsumerService.createKafkaConsumerService(consumerProperties));
+    kafkaStoreIngestionService.getTopicPartitionIngestionContext(topicName, topicName, 0);
+    verify(kafkaConsumerService, atMostOnce()).getIngestionInfoFromConsumer(pubSubTopic, pubSubTopicPartition);
   }
 
   @Test

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/AdminTool.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/AdminTool.java
@@ -3117,7 +3117,7 @@ public class AdminTool {
     responseBody = transportClientResponse.getBody();
     TopicPartitionIngestionContextResponse currentVersionResponse =
         OBJECT_MAPPER.readValue(responseBody, TopicPartitionIngestionContextResponse.class);
-    System.out.println(currentVersionResponse.getTopicPartitionIngestionContext());
+    System.out.println(new String(currentVersionResponse.getTopicPartitionIngestionContext()));
   }
 
   static void getAndPrintRequestBasedMetadata(

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/AdminTool.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/AdminTool.java
@@ -15,6 +15,7 @@ import com.fasterxml.jackson.databind.ObjectWriter;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.linkedin.davinci.listener.response.TopicPartitionIngestionContextResponse;
 import com.linkedin.venice.admin.protocol.response.AdminResponseRecord;
 import com.linkedin.venice.client.exceptions.VeniceClientException;
 import com.linkedin.venice.client.store.ClientConfig;
@@ -175,6 +176,8 @@ public class AdminTool {
       new ApacheKafkaProducerAdapterFactory(),
       new ApacheKafkaConsumerAdapterFactory(),
       new ApacheKafkaAdminAdapterFactory());
+
+  private static final ObjectMapper OBJECT_MAPPER = ObjectMapperFactory.getInstance();
 
   private static ControllerClient controllerClient;
   private static Optional<SSLFactory> sslFactory = Optional.empty();
@@ -552,6 +555,9 @@ public class AdminTool {
           break;
         case RECOVER_STORE_METADATA:
           recoverStoreMetadata(cmd);
+          break;
+        case DUMP_TOPIC_PARTITION_INGESTION_CONTEXT:
+          dumpTopicPartitionIngestionContext(cmd);
           break;
         default:
           StringJoiner availableCommands = new StringJoiner(", ");
@@ -3038,6 +3044,22 @@ public class AdminTool {
     }
   }
 
+  private static void dumpTopicPartitionIngestionContext(CommandLine cmd) throws Exception {
+    TransportClient transportClient = null;
+    try {
+      transportClient =
+          getTransportClientForServer(getRequiredArgument(cmd, Arg.STORE), getRequiredArgument(cmd, Arg.SERVER_URL));
+      dumpTopicPartitionIngestionContext(
+          transportClient,
+          getRequiredArgument(cmd, Arg.STORE),
+          getRequiredArgument(cmd, Arg.VERSION),
+          getRequiredArgument(cmd, Arg.KAFKA_TOPIC_NAME),
+          getRequiredArgument(cmd, Arg.KAFKA_TOPIC_PARTITION));
+    } finally {
+      Utils.closeQuietlyWithErrorLogged(transportClient);
+    }
+  }
+
   private static void configureStoreView(CommandLine cmd) {
     UpdateStoreQueryParams params = getConfigureStoreViewQueryParams(cmd);
     String storeName = getRequiredArgument(cmd, Arg.STORE, Command.CONFIGURE_STORE_VIEW);
@@ -3074,6 +3096,28 @@ public class AdminTool {
     // Use the Avro record's toString() instead and pretty print it.
     Object printObject = ObjectMapperFactory.getInstance().readValue(responseRecord.toString(), Object.class);
     System.out.println(jsonWriter.writeValueAsString(printObject));
+  }
+
+  static void dumpTopicPartitionIngestionContext(
+      TransportClient transportClient,
+      String storeName,
+      String version,
+      String topicName,
+      String partition) throws Exception {
+    StringBuilder sb =
+        new StringBuilder(QueryAction.TOPIC_PARTITION_INGESTION_CONTEXT.toString().toLowerCase()).append("/")
+            .append(Version.composeKafkaTopic(storeName, Integer.parseInt(version)))
+            .append("/")
+            .append(topicName)
+            .append("/")
+            .append(partition);
+    String requestUrl = sb.toString();
+    byte[] responseBody;
+    TransportClientResponse transportClientResponse = transportClient.get(requestUrl).get();
+    responseBody = transportClientResponse.getBody();
+    TopicPartitionIngestionContextResponse currentVersionResponse =
+        OBJECT_MAPPER.readValue(responseBody, TopicPartitionIngestionContextResponse.class);
+    System.out.println(currentVersionResponse.getTopicPartitionIngestionContext());
   }
 
   static void getAndPrintRequestBasedMetadata(

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/Command.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/Command.java
@@ -486,6 +486,11 @@ public enum Command {
       "Dump the real-time ingestion state for a certain store version in a certain storage node",
       new Arg[] { SERVER_URL, STORE, VERSION }, new Arg[] { PARTITION }
   ),
+  DUMP_TOPIC_PARTITION_INGESTION_CONTEXT(
+      "dump-topic-partition-ingestion-context",
+      "Dump the topic partition ingestion context belong to a certain store version in a certain storage node",
+      new Arg[] { SERVER_URL, STORE, VERSION, KAFKA_TOPIC_NAME, KAFKA_TOPIC_PARTITION }
+  ),
   CONFIGURE_STORE_VIEW(
       "configure-store-view", "Configure store view of a certain store", new Arg[] { URL, CLUSTER, STORE, VIEW_NAME },
       new Arg[] { VIEW_CLASS, VIEW_PARAMS, REMOVE_VIEW }

--- a/internal/venice-common/src/main/java/com/linkedin/davinci/listener/response/TopicPartitionIngestionContextResponse.java
+++ b/internal/venice-common/src/main/java/com/linkedin/davinci/listener/response/TopicPartitionIngestionContextResponse.java
@@ -1,0 +1,34 @@
+package com.linkedin.davinci.listener.response;
+
+public class TopicPartitionIngestionContextResponse {
+  private boolean isError;
+  private String topicPartitionIngestionContext;
+  private String message;
+
+  public TopicPartitionIngestionContextResponse() {
+  }
+
+  public void setTopicPartitionIngestionContext(String topicPartitionIngestionContext) {
+    this.topicPartitionIngestionContext = topicPartitionIngestionContext;
+  }
+
+  public void setError(boolean error) {
+    this.isError = error;
+  }
+
+  public boolean isError() {
+    return this.isError;
+  }
+
+  public void setMessage(String message) {
+    this.message = message;
+  }
+
+  public String getMessage() {
+    return this.message;
+  }
+
+  public String getTopicPartitionIngestionContext() {
+    return topicPartitionIngestionContext;
+  }
+}

--- a/internal/venice-common/src/main/java/com/linkedin/davinci/listener/response/TopicPartitionIngestionContextResponse.java
+++ b/internal/venice-common/src/main/java/com/linkedin/davinci/listener/response/TopicPartitionIngestionContextResponse.java
@@ -2,13 +2,13 @@ package com.linkedin.davinci.listener.response;
 
 public class TopicPartitionIngestionContextResponse {
   private boolean isError;
-  private String topicPartitionIngestionContext;
+  private byte[] topicPartitionIngestionContext;
   private String message;
 
   public TopicPartitionIngestionContextResponse() {
   }
 
-  public void setTopicPartitionIngestionContext(String topicPartitionIngestionContext) {
+  public void setTopicPartitionIngestionContext(byte[] topicPartitionIngestionContext) {
     this.topicPartitionIngestionContext = topicPartitionIngestionContext;
   }
 
@@ -28,7 +28,7 @@ public class TopicPartitionIngestionContextResponse {
     return this.message;
   }
 
-  public String getTopicPartitionIngestionContext() {
+  public byte[] getTopicPartitionIngestionContext() {
     return topicPartitionIngestionContext;
   }
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/helix/VeniceJsonSerializer.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/helix/VeniceJsonSerializer.java
@@ -1,5 +1,6 @@
 package com.linkedin.venice.helix;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.linkedin.venice.meta.VeniceSerializer;
@@ -15,11 +16,18 @@ public class VeniceJsonSerializer<T> implements VeniceSerializer<T> {
   private final static int serializedMapSizeLimit = 0xfffff;
   protected static final ObjectMapper OBJECT_MAPPER = ObjectMapperFactory.getInstance();
   private Class<T> type;
+  private TypeReference<T> typeReference;
 
   public VeniceJsonSerializer(Class<T> type) {
     // Ignore unknown properties
     OBJECT_MAPPER.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
     this.type = type;
+  }
+
+  public VeniceJsonSerializer(TypeReference<T> typeReference) {
+    // Ignore unknown properties
+    OBJECT_MAPPER.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+    this.typeReference = typeReference;
   }
 
   @Override
@@ -34,6 +42,9 @@ public class VeniceJsonSerializer<T> implements VeniceSerializer<T> {
 
   @Override
   public T deserialize(byte[] bytes, String path) throws IOException {
+    if (typeReference != null) {
+      return OBJECT_MAPPER.readValue(bytes, typeReference);
+    }
     return OBJECT_MAPPER.readValue(bytes, type);
   }
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/QueryAction.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/QueryAction.java
@@ -25,6 +25,6 @@ public enum QueryAction {
   // that store
   CURRENT_VERSION,
 
-  // TOPIC_PARTITION_INGESTION_CONTEXT request from server admin tool
+  // TOPIC_PARTITION_INGESTION_CONTEXT is a GET request to /version topic/topic/partition from server admin tool
   TOPIC_PARTITION_INGESTION_CONTEXT
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/QueryAction.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/QueryAction.java
@@ -23,5 +23,8 @@ public enum QueryAction {
 
   // CURRENT_VERSION is a GET request to /current_version/storename on the storage node to fetch current version for
   // that store
-  CURRENT_VERSION
+  CURRENT_VERSION,
+
+  // TOPIC_PARTITION_INGESTION_CONTEXT request from server admin tool
+  TOPIC_PARTITION_INGESTION_CONTEXT
 }

--- a/services/venice-server/src/main/java/com/linkedin/venice/listener/RouterRequestHttpHandler.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/listener/RouterRequestHttpHandler.java
@@ -10,8 +10,10 @@ import com.linkedin.venice.listener.request.HealthCheckRequest;
 import com.linkedin.venice.listener.request.MetadataFetchRequest;
 import com.linkedin.venice.listener.request.MultiGetRouterRequestWrapper;
 import com.linkedin.venice.listener.request.RouterRequest;
+import com.linkedin.venice.listener.request.TopicPartitionIngestionContextRequest;
 import com.linkedin.venice.listener.response.HttpShortcutResponse;
 import com.linkedin.venice.meta.QueryAction;
+import com.linkedin.venice.meta.Version;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.handler.codec.http.FullHttpRequest;
@@ -127,6 +129,12 @@ public class RouterRequestHttpHandler extends SimpleChannelInboundHandler<FullHt
           statsHandler.setStoreName(currentVersionRequest.getStoreName());
           ctx.fireChannelRead(currentVersionRequest);
           break;
+        case TOPIC_PARTITION_INGESTION_CONTEXT:
+          TopicPartitionIngestionContextRequest topicPartitionIngestionContextRequest =
+              TopicPartitionIngestionContextRequest.parseGetHttpRequest(req);
+          statsHandler.setStoreName(
+              Version.parseStoreFromVersionTopic(topicPartitionIngestionContextRequest.getVersionTopic()));
+          ctx.fireChannelRead(topicPartitionIngestionContextRequest);
         default:
           throw new VeniceException("Unrecognized query action");
       }

--- a/services/venice-server/src/main/java/com/linkedin/venice/listener/StorageReadRequestHandler.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/listener/StorageReadRequestHandler.java
@@ -7,6 +7,7 @@ import com.linkedin.davinci.listener.response.AdminResponse;
 import com.linkedin.davinci.listener.response.MetadataResponse;
 import com.linkedin.davinci.listener.response.ReadResponse;
 import com.linkedin.davinci.listener.response.ServerCurrentVersionResponse;
+import com.linkedin.davinci.listener.response.TopicPartitionIngestionContextResponse;
 import com.linkedin.davinci.storage.DiskHealthCheckService;
 import com.linkedin.davinci.storage.MetadataRetriever;
 import com.linkedin.davinci.storage.StorageEngineRepository;
@@ -35,6 +36,7 @@ import com.linkedin.venice.listener.request.HealthCheckRequest;
 import com.linkedin.venice.listener.request.MetadataFetchRequest;
 import com.linkedin.venice.listener.request.MultiGetRouterRequestWrapper;
 import com.linkedin.venice.listener.request.RouterRequest;
+import com.linkedin.venice.listener.request.TopicPartitionIngestionContextRequest;
 import com.linkedin.venice.listener.response.BinaryResponse;
 import com.linkedin.venice.listener.response.ComputeResponseWrapper;
 import com.linkedin.venice.listener.response.HttpShortcutResponse;
@@ -368,6 +370,10 @@ public class StorageReadRequestHandler extends ChannelInboundHandlerAdapter {
       context.writeAndFlush(response);
     } else if (message instanceof CurrentVersionRequest) {
       ServerCurrentVersionResponse response = handleCurrentVersionRequest((CurrentVersionRequest) message);
+      context.writeAndFlush(response);
+    } else if (message instanceof TopicPartitionIngestionContextRequest) {
+      TopicPartitionIngestionContextResponse response =
+          handleTopicPartitionIngestionContextRequest((TopicPartitionIngestionContextRequest) message);
       context.writeAndFlush(response);
     } else {
       context.writeAndFlush(
@@ -850,5 +856,13 @@ public class StorageReadRequestHandler extends ChannelInboundHandlerAdapter {
       default:
         throw new VeniceException("Not a valid admin action: " + adminRequest.getServerAdminAction().toString());
     }
+  }
+
+  private TopicPartitionIngestionContextResponse handleTopicPartitionIngestionContextRequest(
+      TopicPartitionIngestionContextRequest topicPartitionIngestionContextRequest) {
+    Integer partition = topicPartitionIngestionContextRequest.getPartition();
+    String versionTopic = topicPartitionIngestionContextRequest.getVersionTopic();
+    String topicName = topicPartitionIngestionContextRequest.getTopic();
+    return metadataRetriever.getTopicPartitionIngestionContext(versionTopic, topicName, partition);
   }
 }

--- a/services/venice-server/src/main/java/com/linkedin/venice/listener/request/TopicPartitionIngestionContextRequest.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/listener/request/TopicPartitionIngestionContextRequest.java
@@ -1,0 +1,45 @@
+package com.linkedin.venice.listener.request;
+
+import com.linkedin.venice.exceptions.VeniceException;
+import com.linkedin.venice.request.RequestHelper;
+import io.netty.handler.codec.http.HttpRequest;
+
+
+public class TopicPartitionIngestionContextRequest {
+  private final String versionTopic;
+  private final String topic;
+  private final Integer partition;
+
+  private TopicPartitionIngestionContextRequest(String versionTopic, String topic, Integer partition) {
+    this.versionTopic = versionTopic;
+    this.topic = topic;
+    this.partition = partition;
+  }
+
+  public static TopicPartitionIngestionContextRequest parseGetHttpRequest(HttpRequest request) {
+    String uri = request.uri();
+    String[] requestParts = RequestHelper.getRequestParts(uri);
+
+    if (requestParts.length == 5) {
+      // [0]""/[1]"action"/[2]"version topic"/[3]"topic name"/[4]"partition number"
+      String versionTopic = requestParts[2];
+      String topic = requestParts[3];
+      Integer partition = Integer.valueOf(requestParts[4]);
+      return new TopicPartitionIngestionContextRequest(versionTopic, topic, partition);
+    } else {
+      throw new VeniceException("not a valid request for a TopicPartitionIngestionContext action: " + uri);
+    }
+  }
+
+  public String getVersionTopic() {
+    return versionTopic;
+  }
+
+  public String getTopic() {
+    return topic;
+  }
+
+  public Integer getPartition() {
+    return partition;
+  }
+}

--- a/services/venice-server/src/test/java/com/linkedin/venice/listener/OutboundHttpWrapperHandlerTest.java
+++ b/services/venice-server/src/test/java/com/linkedin/venice/listener/OutboundHttpWrapperHandlerTest.java
@@ -195,8 +195,13 @@ public class OutboundHttpWrapperHandlerTest {
   @Test
   public void testWriteTopicPartitionIngestionContextResponse() throws JsonProcessingException {
     TopicPartitionIngestionContextResponse msg = new TopicPartitionIngestionContextResponse();
-
-    msg.setTopicPartitionIngestionContext("Ingestion context for expected topic partition.");
+    String topic = "test_store_v1";
+    int expectedPartitionId = 12345;
+    String jsonStr = "{\n" + "\"kafkaUrl\" : {\n" + "  TP(topic: \"" + topic + "\", partition: " + expectedPartitionId
+        + ") : {\n" + "      \"latestOffset\" : 0,\n" + "      \"offsetLag\" : 1,\n" + "      \"msgRate\" : 2.0,\n"
+        + "      \"byteRate\" : 4.0,\n" + "      \"consumerIdx\" : 6,\n"
+        + "      \"elapsedTimeSinceLastPollInMs\" : 7\n" + "    }\n" + "  }\n" + "}";
+    msg.setTopicPartitionIngestionContext(jsonStr.getBytes());
     StatsHandler statsHandler = mock(StatsHandler.class);
     ChannelHandlerContext mockCtx = mock(ChannelHandlerContext.class);
     ByteBuf body = Unpooled.wrappedBuffer(OBJECT_MAPPER.writeValueAsBytes(msg));

--- a/services/venice-server/src/test/java/com/linkedin/venice/listener/OutboundHttpWrapperHandlerTest.java
+++ b/services/venice-server/src/test/java/com/linkedin/venice/listener/OutboundHttpWrapperHandlerTest.java
@@ -14,6 +14,7 @@ import com.google.protobuf.ByteString;
 import com.linkedin.davinci.listener.response.MetadataResponse;
 import com.linkedin.davinci.listener.response.ReadResponse;
 import com.linkedin.davinci.listener.response.ServerCurrentVersionResponse;
+import com.linkedin.davinci.listener.response.TopicPartitionIngestionContextResponse;
 import com.linkedin.venice.HttpConstants;
 import com.linkedin.venice.compression.CompressionStrategy;
 import com.linkedin.venice.listener.grpc.GrpcRequestContext;
@@ -189,6 +190,25 @@ public class OutboundHttpWrapperHandlerTest {
     Assert.assertEquals(ByteString.empty(), responseBuilder.getData());
 
     verify(grpcHandler).processRequest(context);
+  }
+
+  @Test
+  public void testWriteTopicPartitionIngestionContextResponse() throws JsonProcessingException {
+    TopicPartitionIngestionContextResponse msg = new TopicPartitionIngestionContextResponse();
+
+    msg.setTopicPartitionIngestionContext("Ingestion context for expected topic partition.");
+    StatsHandler statsHandler = mock(StatsHandler.class);
+    ChannelHandlerContext mockCtx = mock(ChannelHandlerContext.class);
+    ByteBuf body = Unpooled.wrappedBuffer(OBJECT_MAPPER.writeValueAsBytes(msg));
+    FullHttpResponse response = new DefaultFullHttpResponse(HTTP_1_1, HttpResponseStatus.OK, body);
+    OutboundHttpWrapperHandler outboundHttpWrapperHandler = new OutboundHttpWrapperHandler(statsHandler);
+
+    when(mockCtx.writeAndFlush(any())).then(i -> {
+      FullHttpResponse actualResponse = (DefaultFullHttpResponse) i.getArguments()[0];
+      Assert.assertEquals(actualResponse.content(), response.content());
+      return null;
+    });
+    outboundHttpWrapperHandler.write(mockCtx, msg, null);
   }
 
   private StreamObserver<VeniceServerResponse> getStreamObserver() {

--- a/services/venice-server/src/test/java/com/linkedin/venice/listener/StorageReadRequestHandlerTest.java
+++ b/services/venice-server/src/test/java/com/linkedin/venice/listener/StorageReadRequestHandlerTest.java
@@ -407,9 +407,11 @@ public class StorageReadRequestHandlerTest {
     // Mock the TopicPartitionIngestionContextResponse from ingestion task
     TopicPartitionIngestionContextResponse expectedTopicPartitionIngestionContextResponse =
         new TopicPartitionIngestionContextResponse();
-
-    String expectedTopicPartitionContext =
-        "Ingestion context for topic: " + topic + ", partition: " + expectedPartitionId;
+    String jsonStr = "{\n" + "\"kafkaUrl\" : {\n" + "  TP(topic: \"" + topic + "\", partition: " + expectedPartitionId
+        + ") : {\n" + "      \"latestOffset\" : 0,\n" + "      \"offsetLag\" : 1,\n" + "      \"msgRate\" : 2.0,\n"
+        + "      \"byteRate\" : 4.0,\n" + "      \"consumerIdx\" : 6,\n"
+        + "      \"elapsedTimeSinceLastPollInMs\" : 7\n" + "    }\n" + "  }\n" + "}";
+    byte[] expectedTopicPartitionContext = jsonStr.getBytes();
     expectedTopicPartitionIngestionContextResponse.setTopicPartitionIngestionContext(expectedTopicPartitionContext);
     doReturn(expectedTopicPartitionIngestionContextResponse).when(metadataRetriever)
         .getTopicPartitionIngestionContext(eq(topic), eq(topic), eq(expectedPartitionId));
@@ -419,7 +421,9 @@ public class StorageReadRequestHandlerTest {
     verify(context, times(1)).writeAndFlush(argumentCaptor.capture());
     TopicPartitionIngestionContextResponse topicPartitionIngestionContextResponse =
         (TopicPartitionIngestionContextResponse) argumentCaptor.getValue();
-    assertTrue(topicPartitionIngestionContextResponse.getTopicPartitionIngestionContext().contains(topic));
+    String topicPartitionIngestionContextStr =
+        new String(topicPartitionIngestionContextResponse.getTopicPartitionIngestionContext());
+    assertTrue(topicPartitionIngestionContextStr.contains(topic));
     assertEquals(
         topicPartitionIngestionContextResponse.getTopicPartitionIngestionContext(),
         expectedTopicPartitionContext);


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Summary, imperative, start upper case, don't end with a period
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

This PR introduce an endpoint for obtaining topic partition ingestion information. Essentially, it needs version topic and topic partition information to get exact shared consumer to obtain offset and lag information. It returns to the admin tool a json string including offset related information of all topic partitions sharing one consumer. This will help us to debug stuck or slow ingestion and analyze which topic has the issue hurting. 

Essentially, we will get this information about the consumer thread:

-  Consumer Index
- Elapsed time since last successful poll to help us check if consumer is stuck

For each topic partition within the interested consumer thread, we can get theres information:

- Latest offset and offset lag to check if a specific partition is stuck. 
- record and byte speed for debugging performance issue



Some admin tool query example:

```
sh admin_tool.sh --dump-topic-partition-ingestion-context --server-url localhost:1234 --store test_store --kafka-topic-name  test_store_rt --version 337 --kafka-topic-partition 16
{
  "localhost:1234" : {
    "TP(topic: 'test_store_v337', partition: 21)" : {
      "latestOffset" : -1,
      "offsetLag" : 0,
      "msgRate" : 0.0,
      "byteRate" : 0.0,
      "consumerIdx" : 35,
      "elapsedTimeSinceLastPollInMs" : -1
    },
    "TP(topic: 'test_store_v337_rt', partition: 16)" : {
      "latestOffset" : 5000978,
      "offsetLag" : 0,
      "msgRate" : 0.0,
      "byteRate" : 0.0,
      "consumerIdx" : 35,
      "elapsedTimeSinceLastPollInMs" : 5
    }
  }
}

```


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
CI and frankenwar test on server host machine.
## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.