### PR TITLE
[controller][h2v][common][router] Improve resiliency in ZSTD dictionary retrieval

### DIFF
--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
@@ -203,6 +203,7 @@ public class VenicePushJob implements AutoCloseable {
 
   // Lazy state
   private final Lazy<Properties> sslProperties;
+  private final Lazy<ByteBuffer> emptyPushZSTDDictionary;
   private VeniceWriter<KafkaKey, byte[], byte[]> veniceWriter;
   /** TODO: refactor to use {@link Lazy} */
 
@@ -289,6 +290,8 @@ public class VenicePushJob implements AutoCloseable {
       LOGGER.info("Push job heartbeat is NOT enabled.");
       this.pushJobHeartbeatSenderFactory = new NoOpPushJobHeartbeatSenderFactory();
     }
+    emptyPushZSTDDictionary =
+        Lazy.of(() -> ByteBuffer.wrap(ZstdWithDictCompressor.buildDictionaryOnSyntheticAvroData()));
   }
 
   // This is a part of the public API. There is value in exposing this to users of VenicePushJob for reporting purposes
@@ -1530,7 +1533,7 @@ public class VenicePushJob implements AutoCloseable {
           LOGGER.info(
               "compression strategy is {} with no input records: Generating dictionary from synthetic data",
               pushJobSetting.storeCompressionStrategy);
-          compressionDictionary = ZstdWithDictCompressor.EMPTY_PUSH_ZSTD_DICTIONARY;
+          compressionDictionary = emptyPushZSTDDictionary.get();
           return Optional.of(compressionDictionary);
         }
 

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/compression/ZstdWithDictCompressor.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/compression/ZstdWithDictCompressor.java
@@ -33,9 +33,6 @@ public class ZstdWithDictCompressor extends VeniceCompressor {
   private final byte[] dictionary;
   private final int level;
 
-  public static final ByteBuffer EMPTY_PUSH_ZSTD_DICTIONARY =
-      ByteBuffer.wrap(ZstdWithDictCompressor.buildDictionaryOnSyntheticAvroData());
-
   public ZstdWithDictCompressor(final byte[] dictionary, int level) {
     super(CompressionStrategy.ZSTD_WITH_DICT);
     this.dictionary = dictionary;

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestStoreMigration.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestStoreMigration.java
@@ -472,7 +472,8 @@ public class TestStoreMigration {
     UpdateStoreQueryParams updateStoreQueryParams =
         new UpdateStoreQueryParams().setStorageQuotaInByte(Store.UNLIMITED_STORAGE_QUOTA)
             .setHybridRewindSeconds(TEST_TIMEOUT)
-            .setHybridOffsetLagThreshold(2L);
+            .setHybridOffsetLagThreshold(2L)
+            .setCompressionStrategy(CompressionStrategy.ZSTD_WITH_DICT);
     IntegrationTestPushUtils.createStoreForJob(clusterName, keySchemaStr, valueSchemaStr, props, updateStoreQueryParams)
         .close();
 

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/api/DictionaryRetrievalService.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/api/DictionaryRetrievalService.java
@@ -28,8 +28,8 @@ import io.tehuti.utils.Time;
 import java.io.IOException;
 import java.util.AbstractMap;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -209,7 +209,15 @@ public class DictionaryRetrievalService extends AbstractVeniceService {
           continue;
         }
 
-        downloadDictionaries(Arrays.asList(kafkaTopic));
+        try {
+          downloadDictionaries(Collections.singletonList(kafkaTopic));
+        } catch (Throwable throwable) {
+          // Catch throwable so the thread don't die when encountering issues with one store/dictionary.
+          LOGGER.error(
+              "Caught a throwable while trying to fetch dictionary for store version: {}. Will not retry",
+              kafkaTopic,
+              throwable);
+        }
       }
     };
 


### PR DESCRIPTION
## [controller][h2v][common][router] Improve resiliency in ZSTD dictionary retrieval
1. Catch throwable in router dictionary fetching thread so the thread doesn't die when encountering issues fetching dictionary for one store.

2. Replaced static final field for empty push dictionary in ZstdWithDictCompressor to Lazy wrapped final fields in corresponding classes. This way it doesn't get initialized if it's not used. This is the case for routers since it was initialized but never used. Failure to initialize the field will render the entire ZstdWithDictCompressor class unable to initialize.

## How was this PR tested?
Existing unit and integration tests

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.