### PR TITLE
[controller] Fixed NPE in StoreInfo::fromStore

### DIFF
--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/StoreInfo.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/StoreInfo.java
@@ -17,6 +17,9 @@ import java.util.Optional;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class StoreInfo {
   public static StoreInfo fromStore(Store store) {
+    if (store == null) {
+      return null;
+    }
     StoreInfo storeInfo = new StoreInfo();
     // Sort the properties alphabetically
     storeInfo.setAccessControlled(store.isAccessControlled());

--- a/internal/venice-common/src/test/java/com/linkedin/venice/meta/TestStoreInfo.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/meta/TestStoreInfo.java
@@ -40,4 +40,9 @@ public class TestStoreInfo {
     StoreInfo storeInfo = StoreInfo.fromStore(store);
     assertTrue(storeInfo.isLeaderFollowerModelEnabled());
   }
+
+  @Test
+  public void nullStore() {
+    assertNull(StoreInfo.fromStore(null)); // should not throw a NPE!
+  }
 }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -7123,7 +7123,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
          * This filtering should not be needed because {@link #getAllStores(String)} should not return any null items,
          * but just in case, we have it here as defensive code...
          */
-        .filter(storeInfo -> storeInfo != null)
+        .filter(Objects::nonNull)
         .map(StoreInfo::fromStore)
         .collect(Collectors.toList());
   }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -1358,6 +1358,33 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
       throw new VeniceException("Source cluster and destination cluster cannot be the same!");
     }
 
+    // Get original store properties
+    StoreInfo srcStore = StoreInfo.fromStore(this.getStore(srcClusterName, storeName));
+    if (srcStore == null) {
+      // Store not found in the source cluster... let's figure out if it's anywhere else...
+
+      StoreConfig storeConfig = storeConfigRepo.getStoreConfigOrThrow(storeName);
+      if (storeConfig == null || StringUtils.isEmpty(storeConfig.getCluster())) {
+        // The store does not exist in any cluster, so we throw.
+        throw new VeniceNoStoreException(storeName);
+      }
+
+      if (storeConfig.getCluster().equals(destClusterName)) {
+        LOGGER.info(
+            "Received command to migrate store '{}' from {} to {}, but that store is already at the destination. Will short-circuit the operation.",
+            storeName,
+            srcClusterName,
+            destClusterName);
+        return;
+      } else {
+        throw new VeniceNoStoreException(
+            storeName,
+            srcClusterName,
+            "Migrate store failed because the store is not in the specified source cluster, but instead in '"
+                + storeConfig.getCluster() + "'.");
+      }
+    }
+
     if (!isParent()) {
       // Update store and storeConfig to support single datacenter store migration
       this.updateStore(srcClusterName, storeName, new UpdateStoreQueryParams().setStoreMigration(true));
@@ -1368,8 +1395,6 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
     ControllerClient destControllerClient =
         ControllerClient.constructClusterControllerClient(destClusterName, destControllerUrl, sslFactory);
 
-    // Get original store properties
-    StoreInfo srcStore = StoreInfo.fromStore(this.getStore(srcClusterName, storeName));
     // Same as StoresRoutes#getStore, set up backup version retention time. Otherwise, parent and child src store
     // info will always be different for stores with negative BackupVersionRetentionMs.
     if (srcStore.getBackupVersionRetentionMs() < 0) {
@@ -7094,6 +7119,11 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
   public ArrayList<StoreInfo> getClusterStores(String clusterName) {
     // Return all stores at this step in the process
     return (ArrayList<StoreInfo>) getAllStores(clusterName).stream()
+        /**
+         * This filtering should not be needed because {@link #getAllStores(String)} should not return any null items,
+         * but just in case, we have it here as defensive code...
+         */
+        .filter(storeInfo -> storeInfo != null)
         .map(StoreInfo::fromStore)
         .collect(Collectors.toList());
   }
@@ -7116,8 +7146,13 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
    */
   @Override
   public RegionPushDetails getRegionPushDetails(String clusterName, String storeName, boolean isPartitionDetailAdded) {
+    StoreInfo store = StoreInfo.fromStore(getStore(clusterName, storeName));
+    if (store == null) {
+      throw new VeniceNoStoreException(storeName, clusterName);
+    }
+
     RegionPushDetails ret = new RegionPushDetails();
-    OfflinePushStatus zkData = retrievePushStatus(clusterName, storeName);
+    OfflinePushStatus zkData = retrievePushStatus(clusterName, store);
 
     for (StatusSnapshot status: zkData.getStatusHistory()) {
       if (shouldUpdateEndTime(ret, status)) {
@@ -7130,7 +7165,6 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
       }
     }
 
-    StoreInfo store = StoreInfo.fromStore(getStore(clusterName, storeName));
     for (Version v: store.getVersions()) {
       ret.addVersion(v.getNumber());
     }
@@ -7141,9 +7175,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
     return ret;
   }
 
-  public OfflinePushStatus retrievePushStatus(String clusterName, String storeName) {
-    StoreInfo store = StoreInfo.fromStore(getStore(clusterName, storeName));
-
+  public OfflinePushStatus retrievePushStatus(String clusterName, StoreInfo store) {
     VeniceOfflinePushMonitorAccessor accessor =
         new VeniceOfflinePushMonitorAccessor(clusterName, getZkClient(), getAdapterSerializer());
 

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceParentHelixAdmin.java
@@ -18,6 +18,7 @@ import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertThrows;
 
 import com.linkedin.venice.common.VeniceSystemStoreUtils;
 import com.linkedin.venice.compression.CompressionStrategy;
@@ -2665,7 +2666,7 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
 
     status.getStatusHistory().add(new StatusSnapshot(ExecutionStatus.STARTED, now.toString()));
     status.getStatusHistory().add(new StatusSnapshot(ExecutionStatus.COMPLETED, now.plusHours(1).toString()));
-    doReturn(status).when(internalAdmin).retrievePushStatus(anyString(), anyString());
+    doReturn(status).when(internalAdmin).retrievePushStatus(anyString(), any());
 
     Store s = TestUtils.createTestStore(storeName, owner, System.currentTimeMillis());
     s.addVersion(new VersionImpl(s.getName(), 1, "pushJobId"));
@@ -2681,6 +2682,9 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
     for (int i = 0; i < numOfPartition; i++) {
       Assert.assertEquals(details.getPartitionDetails().get(i).getReplicaDetails().size(), replicationFactor);
     }
+
+    doReturn(null).when(internalAdmin).getStore(anyString(), anyString());
+    assertThrows(VeniceNoStoreException.class, () -> internalAdmin.getRegionPushDetails(clusterName, storeName, true));
   }
 
   @Test


### PR DESCRIPTION
When this function receives a null Store parameter, it will return null itself.

There are four calls to this function, and they have all been inspected to ensure that they deal properly with nulls.

In the case of VHA::migrateStore, there are some usability improvements so that the VeniceNoStoreException includes the cluster the store is in, if it is in a different one than the supplied source cluster. There is a new short-circuiting logic as well in case the store is already in the desired destination cluster.

## How was this PR tested?
Unit tests.

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.