### PR TITLE
[thin-client][producer][router] SchemaReader will only fetch single schema for all the APIs

### DIFF
--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/schema/RouterBackedSchemaReader.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/schema/RouterBackedSchemaReader.java
@@ -322,13 +322,8 @@ public class RouterBackedSchemaReader implements SchemaReader {
       }
 
       for (int id: valueSchemaIdSet) {
-        try {
-          maybeFetchValueSchemaEntryById(id, forceRefresh);
-        } catch (VeniceClientException e) {
-          LOGGER.error("Got exception while trying fetch schema id: " + id + " from router for store: " + storeName);
-        }
+        maybeFetchValueSchemaEntryById(id, forceRefresh);
       }
-
     } catch (Exception ex) {
       throw new VeniceClientException(
           "Got exception while trying to fetch all value schemas for store: " + storeName,

--- a/clients/venice-thin-client/src/test/java/com/linkedin/venice/client/schema/RouterBackedSchemaReaderTest.java
+++ b/clients/venice-thin-client/src/test/java/com/linkedin/venice/client/schema/RouterBackedSchemaReaderTest.java
@@ -202,8 +202,11 @@ public class RouterBackedSchemaReaderTest {
 
     try (SchemaReader schemaReader = new RouterBackedSchemaReader(() -> mockClient)) {
       Assert.assertEquals(schemaReader.getLatestValueSchema().toString(), VALUE_SCHEMA_2.toString());
+      Mockito.verify(mockClient, Mockito.timeout(TIMEOUT).times(3)).getRaw(Mockito.anyString());
       Assert.assertEquals(schemaReader.getValueSchema(1).toString(), VALUE_SCHEMA_1.toString());
+      Mockito.verify(mockClient, Mockito.timeout(TIMEOUT).times(3)).getRaw(Mockito.anyString());
       Assert.assertEquals(schemaReader.getValueSchema(2).toString(), VALUE_SCHEMA_2.toString());
+      Mockito.verify(mockClient, Mockito.timeout(TIMEOUT).times(3)).getRaw(Mockito.anyString());
       schemaReader.getLatestValueSchema();
       Mockito.verify(mockClient, Mockito.timeout(TIMEOUT).times(3)).getRaw(Mockito.anyString());
     }

--- a/clients/venice-thin-client/src/test/java/com/linkedin/venice/client/schema/RouterBackedSchemaReaderTest.java
+++ b/clients/venice-thin-client/src/test/java/com/linkedin/venice/client/schema/RouterBackedSchemaReaderTest.java
@@ -550,7 +550,7 @@ public class RouterBackedSchemaReaderTest {
     multiSchemaIdResponse.setSchemaIdSet(schemaIdSet);
     doAnswer(invocation -> getResponseWithDelay(MAPPER.writeValueAsBytes(multiSchemaIdResponse), delayInResponseMs))
         .when(storeClient)
-        .getRaw(eq("value_schema_ids/" + storeName));
+        .getRaw(eq("all_value_schema_ids/" + storeName));
 
     String keySchemaStr = KEY_SCHEMA.toString();
     SchemaResponse keySchemaResponse = new SchemaResponse();

--- a/clients/venice-thin-client/src/test/java/com/linkedin/venice/client/schema/RouterBackedSchemaReaderTest.java
+++ b/clients/venice-thin-client/src/test/java/com/linkedin/venice/client/schema/RouterBackedSchemaReaderTest.java
@@ -392,7 +392,7 @@ public class RouterBackedSchemaReaderTest {
   public void testGetSchemaWithAnExtraFieldInResponse() throws Exception {
     String storeName = "test_store";
     String keySchemaStr = "\"string\"";
-    // Create a repsonse with an extra field.
+    // Create a response with an extra field.
     SchemaResponseWithExtraField schemaResponse = new SchemaResponseWithExtraField();
     schemaResponse.setId(1);
     schemaResponse.setSchemaStr(keySchemaStr);

--- a/clients/venice-thin-client/src/test/java/com/linkedin/venice/client/schema/RouterBackedSchemaReaderTest.java
+++ b/clients/venice-thin-client/src/test/java/com/linkedin/venice/client/schema/RouterBackedSchemaReaderTest.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
 import com.linkedin.venice.client.exceptions.VeniceClientException;
 import com.linkedin.venice.client.store.AbstractAvroStoreClient;
+import com.linkedin.venice.controllerapi.MultiSchemaIdResponse;
 import com.linkedin.venice.controllerapi.MultiSchemaResponse;
 import com.linkedin.venice.controllerapi.SchemaResponse;
 import com.linkedin.venice.controllerapi.VersionCreationResponse;
@@ -38,8 +39,10 @@ import java.io.IOException;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -133,11 +136,12 @@ public class RouterBackedSchemaReaderTest {
       Schema schema = schemaReader.getValueSchema(1);
       Assert.assertEquals(schema.toString(), VALUE_SCHEMA_1.toString());
       Schema cachedSchema = schemaReader.getValueSchema(1);
+      Mockito.verify(mockClient, Mockito.timeout(TIMEOUT).times(1)).getRaw(Mockito.anyString());
       Assert.assertEquals(cachedSchema, schema);
       // Must be the same Schema instance
       Assert.assertSame(schema, cachedSchema);
       Assert.assertEquals(schemaReader.getLatestValueSchema().toString(), VALUE_SCHEMA_2.toString());
-      Mockito.verify(mockClient, Mockito.timeout(TIMEOUT).times(1)).getRaw(Mockito.anyString());
+      Mockito.verify(mockClient, Mockito.timeout(TIMEOUT).times(3)).getRaw(Mockito.anyString());
     }
   }
 
@@ -151,21 +155,24 @@ public class RouterBackedSchemaReaderTest {
       Assert.assertEquals(schema1.toString(), VALUE_SCHEMA_1.toString());
       Mockito.verify(mockClient, Mockito.timeout(TIMEOUT).times(1)).getRaw(Mockito.anyString());
 
-      // If a missing schema is requested, always query routers to try to get it
+      // If a missing schema is requested, we should not query it twice.
       Schema schema = schemaReader.getValueSchema(3);
       Assert.assertNull(schema);
+      Mockito.verify(mockClient, Mockito.timeout(TIMEOUT).times(2)).getRaw(Mockito.anyString());
       Schema cachedSchema = schemaReader.getValueSchema(3);
       Assert.assertNull(cachedSchema);
-      Mockito.verify(mockClient, Mockito.timeout(TIMEOUT).times(3)).getRaw(Mockito.anyString());
+      Mockito.verify(mockClient, Mockito.timeout(TIMEOUT).times(2)).getRaw(Mockito.anyString());
 
       Schema newSchema = schemaReader.getValueSchema(1);
       Assert.assertEquals(newSchema.toString(), VALUE_SCHEMA_1.toString());
+      Mockito.verify(mockClient, Mockito.timeout(TIMEOUT).times(2)).getRaw(Mockito.anyString());
+
       Assert.assertEquals(schemaReader.getLatestValueSchema().toString(), VALUE_SCHEMA_2.toString());
-      Mockito.verify(mockClient, Mockito.timeout(TIMEOUT).times(3)).getRaw(Mockito.anyString());
+      Mockito.verify(mockClient, Mockito.timeout(TIMEOUT).times(4)).getRaw(Mockito.anyString());
     }
   }
 
-  @Test(expectedExceptions = RuntimeException.class)
+  @Test
   public void testGetValueSchemaWhenServerError()
       throws ExecutionException, InterruptedException, VeniceClientException, IOException {
     String storeName = "test_store";
@@ -182,8 +189,9 @@ public class RouterBackedSchemaReaderTest {
     Mockito.doReturn(mockFuture).when(mockClient).getRaw("key_schema/" + storeName);
     Mockito.doThrow(new ExecutionException(new VeniceClientException("Server error"))).when(mockFuture).get();
     Mockito.doReturn(mockFuture).when(mockClient).getRaw("value_schema/" + storeName + "/" + valueSchemaId);
+    // It should not throw error as we catch the exception.
     try (SchemaReader schemaReader = new RouterBackedSchemaReader(() -> mockClient)) {
-      schemaReader.getValueSchema(valueSchemaId);
+      Assert.assertNull(schemaReader.getValueSchema(valueSchemaId));
     }
   }
 
@@ -197,7 +205,7 @@ public class RouterBackedSchemaReaderTest {
       Assert.assertEquals(schemaReader.getValueSchema(1).toString(), VALUE_SCHEMA_1.toString());
       Assert.assertEquals(schemaReader.getValueSchema(2).toString(), VALUE_SCHEMA_2.toString());
       schemaReader.getLatestValueSchema();
-      Mockito.verify(mockClient, Mockito.timeout(TIMEOUT).times(1)).getRaw(Mockito.anyString());
+      Mockito.verify(mockClient, Mockito.timeout(TIMEOUT).times(3)).getRaw(Mockito.anyString());
     }
   }
 
@@ -275,12 +283,11 @@ public class RouterBackedSchemaReaderTest {
       Assert.assertNotNull(future2.get());
 
       /**
-       * 'getRaw' Should be called 3 times:
-       * 1. Fetch value schemas on start up
-       * 2. Fetch value schemas in one of the futures
-       * 3. Fetch update schemas in one of the futures
+       * 'getRaw' Should be called 4 times:
+       * 1. Fetch value schemas on start up, which takes 2 + 1 = 3 individual call.
+       * 2. Fetch update schemas in one of the futures
        */
-      Mockito.verify(storeClient, Mockito.timeout(TIMEOUT).times(3)).getRaw(Mockito.anyString());
+      Mockito.verify(storeClient, Mockito.timeout(TIMEOUT).times(4)).getRaw(Mockito.anyString());
     }
   }
 
@@ -306,7 +313,7 @@ public class RouterBackedSchemaReaderTest {
       // superset schema or the one with the max id
       Assert.assertEquals(schemaReader.getLatestValueSchema().toString(), VALUE_SCHEMA_2.toString());
       schemaReader.getLatestValueSchema();
-      Mockito.verify(mockClient, Mockito.timeout(TIMEOUT).times(1)).getRaw(Mockito.anyString());
+      Mockito.verify(mockClient, Mockito.timeout(TIMEOUT).times(4)).getRaw(Mockito.anyString());
     }
 
     try (SchemaReader schemaReader =
@@ -335,10 +342,10 @@ public class RouterBackedSchemaReaderTest {
     try (SchemaReader schemaReader =
         new RouterBackedSchemaReader(() -> mockClient, Optional.empty(), Optional.empty(), Duration.ofMinutes(2))) {
       // Schemas should be fetched on startup
-      Mockito.verify(mockClient, Mockito.timeout(TIMEOUT).times(1)).getRaw(Mockito.anyString());
+      Mockito.verify(mockClient, Mockito.timeout(TIMEOUT).times(3)).getRaw(Mockito.anyString());
       Assert.assertNotNull(schemaReader.getLatestValueSchema());
       // Should not be checked again
-      Mockito.verify(mockClient, Mockito.timeout(TIMEOUT).times(1)).getRaw(Mockito.anyString());
+      Mockito.verify(mockClient, Mockito.timeout(TIMEOUT).times(3)).getRaw(Mockito.anyString());
     }
   }
 
@@ -397,42 +404,6 @@ public class RouterBackedSchemaReaderTest {
     Mockito.doReturn(MAPPER.writeValueAsBytes(schemaResponse)).when(mockFuture).get();
     Mockito.doReturn(mockFuture).when(mockClient).getRaw(Mockito.anyString());
     try (SchemaReader schemaReader = new RouterBackedSchemaReader(() -> mockClient)) {
-    } catch (VeniceClientException e) {
-      Assert.fail("The unrecognized field should be ignored.");
-    }
-  }
-
-  @Test
-  public void testGetMultiSchemaWithAnExtraFieldInResponse() throws Exception {
-    String storeName = "test_store";
-    String valueSchemaStr = "\"string\"";
-    int valueSchemaId2 = 2;
-    String valueSchemaStr2 = "\"long\"";
-
-    // Create a repsonse with an extra field.
-    MultiSchemaResponseWithExtraField multiSchemaResponse = new MultiSchemaResponseWithExtraField();
-    MultiSchemaResponse.Schema[] schemas = new MultiSchemaResponse.Schema[2];
-    MultiSchemaResponse.Schema schema1 = new MultiSchemaResponse.Schema();
-    schema1.setId(1);
-    schema1.setSchemaStr(valueSchemaStr);
-    MultiSchemaResponse.Schema schema2 = new MultiSchemaResponse.Schema();
-    schema2.setId(valueSchemaId2);
-    schema2.setSchemaStr(valueSchemaStr2);
-    schemas[0] = schema1;
-    schemas[1] = schema2;
-
-    multiSchemaResponse.setSchemas(schemas);
-    multiSchemaResponse.setSuperSetSchemaId(valueSchemaId2);
-    multiSchemaResponse.setExtraField(100);
-
-    AbstractAvroStoreClient mockClient = mock(AbstractAvroStoreClient.class);
-    Mockito.doReturn(storeName).when(mockClient).getStoreName();
-    CompletableFuture<byte[]> mockFuture = mock(CompletableFuture.class);
-    Mockito.doReturn(MAPPER.writeValueAsBytes(multiSchemaResponse)).when(mockFuture).get();
-    Mockito.doReturn(mockFuture).when(mockClient).getRaw(Mockito.anyString());
-    Mockito.doReturn(MAPPER.writeValueAsBytes(multiSchemaResponse)).when(mockFuture).get();
-    try (SchemaReader schemaReader = new RouterBackedSchemaReader(() -> mockClient)) {
-      Assert.assertNotNull(schemaReader.getValueSchema(2));
     } catch (VeniceClientException e) {
       Assert.fail("The unrecognized field should be ignored.");
     }
@@ -565,6 +536,19 @@ public class RouterBackedSchemaReaderTest {
       List<Schema> updateSchemas,
       boolean updateEnabled,
       int delayInResponseMs) {
+    MultiSchemaIdResponse multiSchemaIdResponse = new MultiSchemaIdResponse();
+    if (supersetSchemaId > 0) {
+      multiSchemaIdResponse.setSuperSetSchemaId(supersetSchemaId);
+    }
+    Set<Integer> schemaIdSet = new HashSet<>();
+    for (int i = 1; i <= valueSchemas.size(); i++) {
+      schemaIdSet.add(i);
+    }
+    multiSchemaIdResponse.setSchemaIdSet(schemaIdSet);
+    doAnswer(invocation -> getResponseWithDelay(MAPPER.writeValueAsBytes(multiSchemaIdResponse), delayInResponseMs))
+        .when(storeClient)
+        .getRaw(eq("value_schema_ids/" + storeName));
+
     String keySchemaStr = KEY_SCHEMA.toString();
     SchemaResponse keySchemaResponse = new SchemaResponse();
     keySchemaResponse.setId(1);
@@ -593,6 +577,15 @@ public class RouterBackedSchemaReaderTest {
     doAnswer(invocation -> getResponseWithDelay(MAPPER.writeValueAsBytes(multiSchemaResponse), delayInResponseMs))
         .when(storeClient)
         .getRaw(eq("value_schema/" + storeName));
+
+    for (int i = 0; i < valueSchemas.size(); i++) {
+      SchemaResponse valueSchemaResponse = new SchemaResponse();
+      valueSchemaResponse.setId(i + 1);
+      valueSchemaResponse.setSchemaStr(valueSchemas.get(i).toString());
+      doAnswer(invocation -> getResponseWithDelay(MAPPER.writeValueAsBytes(valueSchemaResponse), delayInResponseMs))
+          .when(storeClient)
+          .getRaw(eq("value_schema/" + storeName + "/" + (i + 1)));
+    }
 
     if (updateEnabled) {
       MultiSchemaResponse allUpdateSchemaResponse = new MultiSchemaResponse();

--- a/clients/venice-thin-client/src/test/java/com/linkedin/venice/client/store/TestAvroStoreClient.java
+++ b/clients/venice-thin-client/src/test/java/com/linkedin/venice/client/store/TestAvroStoreClient.java
@@ -155,10 +155,12 @@ public class TestAvroStoreClient {
   @Test
   public void testDeserializeWriterSchemaMissingReaderNamespace() throws IOException {
     Schema schemaWithoutNamespace = Utils.getSchemaFromResource("testSchemaWithoutNamespace.avsc");
-    Map schemas = new HashMap<>();
-    schemas.put(1, schemaWithoutNamespace.toString());
-    byte[] multiSchemasInBytes = StoreClientTestUtils.constructMultiSchemaResponseInBytes(STORE_NAME, schemas);
-    setupSchemaResponse(multiSchemasInBytes, RouterBackedSchemaReader.TYPE_VALUE_SCHEMA + "/" + STORE_NAME);
+    byte[] singleSchemaResponseInBytes =
+        StoreClientTestUtils.constructSchemaResponseInBytes(STORE_NAME, 1, schemaWithoutNamespace.toString());
+    setupSchemaResponse(
+        singleSchemaResponseInBytes,
+        RouterBackedSchemaReader.TYPE_VALUE_SCHEMA + "/" + STORE_NAME + "/" + 1);
+
     AvroSpecificStoreClientImpl specificStoreClient = new AvroSpecificStoreClientImpl(
         mockTransportClient,
         ClientConfig.defaultSpecificClientConfig(STORE_NAME, NamespaceTest.class));

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/controllerapi/MultiSchemaIdResponse.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/controllerapi/MultiSchemaIdResponse.java
@@ -1,0 +1,28 @@
+package com.linkedin.venice.controllerapi;
+
+import com.linkedin.venice.schema.SchemaData;
+import java.util.HashSet;
+import java.util.Set;
+
+
+public class MultiSchemaIdResponse extends ControllerResponse {
+  /* Uses Json Reflective Serializer, get without set may break things */
+  private int superSetSchemaId = SchemaData.INVALID_VALUE_SCHEMA_ID;
+  private Set<Integer> schemaIdSet = new HashSet<>();
+
+  public void setSuperSetSchemaId(int id) {
+    superSetSchemaId = id;
+  }
+
+  public int getSuperSetSchemaId() {
+    return superSetSchemaId;
+  }
+
+  public void setSchemaIdSet(Set<Integer> schemaIdSet) {
+    this.schemaIdSet = schemaIdSet;
+  }
+
+  public Set<Integer> getSchemaIdSet() {
+    return schemaIdSet;
+  }
+}

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/client/store/AvroGenericStoreClientImplTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/client/store/AvroGenericStoreClientImplTest.java
@@ -173,10 +173,6 @@ public class AvroGenericStoreClientImplTest {
     String valueSchemaPath = "/" + RouterBackedSchemaReader.TYPE_VALUE_SCHEMA + "/" + storeName + "/" + valueSchemaId;
     routerServer.addResponseForUri(valueSchemaPath, valueSchemaResponse);
 
-    FullHttpResponse multiValueSchemaResponse =
-        StoreClientTestUtils.constructHttpMultiSchemaResponse(storeName, valueSchemaEntries);
-    String multiValueSchemaPath = "/" + RouterBackedSchemaReader.TYPE_VALUE_SCHEMA + "/" + storeName;
-
     FullHttpResponse multiValueSchemaIdResponse =
         StoreClientTestUtils.constructHttpMultiSchemaIdResponse(storeName, valueSchemaEntries);
     String multiValueSchemaIdPath = "/" + RouterBackedSchemaReader.TYPE_VALUE_SCHEMA_ID + "/" + storeName;

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/client/store/AvroGenericStoreClientImplTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/client/store/AvroGenericStoreClientImplTest.java
@@ -175,7 +175,7 @@ public class AvroGenericStoreClientImplTest {
 
     FullHttpResponse multiValueSchemaIdResponse =
         StoreClientTestUtils.constructHttpMultiSchemaIdResponse(storeName, valueSchemaEntries);
-    String multiValueSchemaIdPath = "/" + RouterBackedSchemaReader.TYPE_VALUE_SCHEMA_ID + "/" + storeName;
+    String multiValueSchemaIdPath = "/" + RouterBackedSchemaReader.TYPE_ALL_VALUE_SCHEMA_IDS + "/" + storeName;
 
     routerServer.addResponseForUri(multiValueSchemaIdPath, multiValueSchemaIdResponse);
     for (Map.Entry<String, AvroGenericStoreClient<String, Object>> entry: storeClients.entrySet()) {
@@ -237,7 +237,7 @@ public class AvroGenericStoreClientImplTest {
 
     FullHttpResponse multiValueSchemaIdResponse =
         StoreClientTestUtils.constructHttpMultiSchemaIdResponse(storeName, valueSchemaEntries);
-    String multiValueSchemaIdPath = "/" + RouterBackedSchemaReader.TYPE_VALUE_SCHEMA_ID + "/" + storeName;
+    String multiValueSchemaIdPath = "/" + RouterBackedSchemaReader.TYPE_ALL_VALUE_SCHEMA_IDS + "/" + storeName;
     routerServer.addResponseForUri(multiValueSchemaIdPath, multiValueSchemaIdResponse);
 
     String key = "test_key";
@@ -292,7 +292,7 @@ public class AvroGenericStoreClientImplTest {
     routerServer.addResponseForUri(multiValueSchemaPath, multiValueSchemaResponse);
     FullHttpResponse multiValueSchemaIdResponse =
         StoreClientTestUtils.constructHttpMultiSchemaIdResponse(storeName, valueSchemaEntries);
-    String multiValueSchemaIdPath = "/" + RouterBackedSchemaReader.TYPE_VALUE_SCHEMA_ID + "/" + storeName;
+    String multiValueSchemaIdPath = "/" + RouterBackedSchemaReader.TYPE_ALL_VALUE_SCHEMA_IDS + "/" + storeName;
     routerServer.addResponseForUri(multiValueSchemaIdPath, multiValueSchemaIdResponse);
 
     int nonExistingSchemaId = 2;
@@ -418,7 +418,7 @@ public class AvroGenericStoreClientImplTest {
 
     FullHttpResponse multiValueSchemaIdResponse =
         StoreClientTestUtils.constructHttpMultiSchemaIdResponse(storeName, valueSchemaEntries);
-    String multiValueSchemaIdPath = "/" + RouterBackedSchemaReader.TYPE_VALUE_SCHEMA_ID + "/" + storeName;
+    String multiValueSchemaIdPath = "/" + RouterBackedSchemaReader.TYPE_ALL_VALUE_SCHEMA_IDS + "/" + storeName;
     routerServer.addResponseForUri(multiValueSchemaIdPath, multiValueSchemaIdResponse);
 
     String key = "test_key";
@@ -480,7 +480,7 @@ public class AvroGenericStoreClientImplTest {
 
     FullHttpResponse multiValueSchemaIdResponse =
         StoreClientTestUtils.constructHttpMultiSchemaIdResponse(storeName, valueSchemaEntries);
-    String multiValueSchemaIdPath = "/" + RouterBackedSchemaReader.TYPE_VALUE_SCHEMA_ID + "/" + storeName;
+    String multiValueSchemaIdPath = "/" + RouterBackedSchemaReader.TYPE_ALL_VALUE_SCHEMA_IDS + "/" + storeName;
     routerServer.addResponseForUri(multiValueSchemaIdPath, multiValueSchemaIdResponse);
 
     Set<String> keys = new TreeSet<>();

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/client/store/AvroGenericStoreClientImplTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/client/store/AvroGenericStoreClientImplTest.java
@@ -176,7 +176,12 @@ public class AvroGenericStoreClientImplTest {
     FullHttpResponse multiValueSchemaResponse =
         StoreClientTestUtils.constructHttpMultiSchemaResponse(storeName, valueSchemaEntries);
     String multiValueSchemaPath = "/" + RouterBackedSchemaReader.TYPE_VALUE_SCHEMA + "/" + storeName;
-    routerServer.addResponseForUri(multiValueSchemaPath, multiValueSchemaResponse);
+
+    FullHttpResponse multiValueSchemaIdResponse =
+        StoreClientTestUtils.constructHttpMultiSchemaIdResponse(storeName, valueSchemaEntries);
+    String multiValueSchemaIdPath = "/" + RouterBackedSchemaReader.TYPE_VALUE_SCHEMA_ID + "/" + storeName;
+
+    routerServer.addResponseForUri(multiValueSchemaIdPath, multiValueSchemaIdResponse);
     for (Map.Entry<String, AvroGenericStoreClient<String, Object>> entry: storeClients.entrySet()) {
       LOGGER.info("Execute test for transport client: {}", entry.getKey());
       Assert.assertEquals(entry.getValue().getKeySchema(), Schema.parse(defaultKeySchemaStr));
@@ -234,10 +239,15 @@ public class AvroGenericStoreClientImplTest {
     String multiValueSchemaPath = "/" + RouterBackedSchemaReader.TYPE_VALUE_SCHEMA + "/" + storeName;
     routerServer.addResponseForUri(multiValueSchemaPath, multiValueSchemaResponse);
 
+    FullHttpResponse multiValueSchemaIdResponse =
+        StoreClientTestUtils.constructHttpMultiSchemaIdResponse(storeName, valueSchemaEntries);
+    String multiValueSchemaIdPath = "/" + RouterBackedSchemaReader.TYPE_VALUE_SCHEMA_ID + "/" + storeName;
+    routerServer.addResponseForUri(multiValueSchemaIdPath, multiValueSchemaIdResponse);
+
     String key = "test_key";
     Schema valueSchema = Schema.parse(valueSchemaStr);
     GenericData.Record valueRecord = new GenericData.Record(valueSchema);
-    valueRecord.put("a", 100l);
+    valueRecord.put("a", 100L);
     valueRecord.put("b", "test_b_value");
     byte[] valueArray = StoreClientTestUtils.serializeRecord(valueRecord, valueSchema);
     FullHttpResponse valueResponse = StoreClientTestUtils.constructStoreResponse(valueSchemaId, valueArray);
@@ -249,7 +259,7 @@ public class AvroGenericStoreClientImplTest {
       Object value = entry.getValue().get(key).get();
       Assert.assertTrue(value instanceof GenericData.Record);
       GenericData.Record recordValue = (GenericData.Record) value;
-      Assert.assertEquals(recordValue.get("a"), 100l);
+      Assert.assertEquals(recordValue.get("a"), 100L);
       Assert.assertEquals(recordValue.get("b").toString(), "test_b_value");
 
       testMetric(entry.getValue(), RequestType.SINGLE_GET);
@@ -284,6 +294,10 @@ public class AvroGenericStoreClientImplTest {
         StoreClientTestUtils.constructHttpMultiSchemaResponse(storeName, valueSchemaEntries);
     String multiValueSchemaPath = "/" + RouterBackedSchemaReader.TYPE_VALUE_SCHEMA + "/" + storeName;
     routerServer.addResponseForUri(multiValueSchemaPath, multiValueSchemaResponse);
+    FullHttpResponse multiValueSchemaIdResponse =
+        StoreClientTestUtils.constructHttpMultiSchemaIdResponse(storeName, valueSchemaEntries);
+    String multiValueSchemaIdPath = "/" + RouterBackedSchemaReader.TYPE_VALUE_SCHEMA_ID + "/" + storeName;
+    routerServer.addResponseForUri(multiValueSchemaIdPath, multiValueSchemaIdResponse);
 
     int nonExistingSchemaId = 2;
     FullHttpResponse valueResponse =
@@ -406,10 +420,15 @@ public class AvroGenericStoreClientImplTest {
     String multiValueSchemaPath = "/" + RouterBackedSchemaReader.TYPE_VALUE_SCHEMA + "/" + storeName;
     routerServer.addResponseForUri(multiValueSchemaPath, multiValueSchemaResponse);
 
+    FullHttpResponse multiValueSchemaIdResponse =
+        StoreClientTestUtils.constructHttpMultiSchemaIdResponse(storeName, valueSchemaEntries);
+    String multiValueSchemaIdPath = "/" + RouterBackedSchemaReader.TYPE_VALUE_SCHEMA_ID + "/" + storeName;
+    routerServer.addResponseForUri(multiValueSchemaIdPath, multiValueSchemaIdResponse);
+
     String key = "test_key";
     Schema valueSchema = Schema.parse(valueSchemaStr1);
     GenericData.Record valueRecord = new GenericData.Record(valueSchema);
-    valueRecord.put("a", 100l);
+    valueRecord.put("a", 100L);
     valueRecord.put("b", "test_b_value");
     byte[] valueArray = StoreClientTestUtils.serializeRecord(valueRecord, valueSchema);
     FullHttpResponse valueResponse = StoreClientTestUtils.constructStoreResponse(valueSchemaId1, valueArray);
@@ -419,7 +438,7 @@ public class AvroGenericStoreClientImplTest {
     String key2 = "test_key_2";
     Schema valueSchema2 = Schema.parse(valueSchemaStr2);
     GenericData.Record valueRecord2 = new GenericData.Record(valueSchema2);
-    valueRecord2.put("a", 102l);
+    valueRecord2.put("a", 102L);
     valueRecord2.put("b", "test_b_value_2");
     valueRecord2.put("c", "test_c_value_2");
     byte[] valueArray2 = StoreClientTestUtils.serializeRecord(valueRecord2, valueSchema2);
@@ -435,7 +454,7 @@ public class AvroGenericStoreClientImplTest {
       Object value = entry.getValue().get(key).get();
       Assert.assertTrue(value instanceof GenericData.Record);
       GenericData.Record recordValue = (GenericData.Record) value;
-      Assert.assertEquals(recordValue.get("a"), 100l);
+      Assert.assertEquals(recordValue.get("a"), 100L);
       Assert.assertEquals(recordValue.get("b").toString(), "test_b_value");
       Assert.assertEquals(recordValue.get("c").toString(), "c_default_value");
 
@@ -443,13 +462,13 @@ public class AvroGenericStoreClientImplTest {
       Object value2 = entry.getValue().get(key2).get();
       Assert.assertTrue(value2 instanceof GenericData.Record);
       GenericData.Record recordValue2 = (GenericData.Record) value2;
-      Assert.assertEquals(recordValue2.get("a"), 102l);
+      Assert.assertEquals(recordValue2.get("a"), 102L);
       Assert.assertEquals(recordValue2.get("b").toString(), "test_b_value_2");
       Assert.assertEquals(recordValue2.get("c").toString(), "test_c_value_2");
     }
   }
 
-  private Set setupSchemaAndRequest(int valueSchemaId, String valueSchemaStr) throws IOException {
+  private Set<String> setupSchemaAndRequest(int valueSchemaId, String valueSchemaStr) throws IOException {
     Map<Integer, String> valueSchemaEntries = new HashMap<>();
     valueSchemaEntries.put(valueSchemaId, valueSchemaStr);
 
@@ -462,6 +481,11 @@ public class AvroGenericStoreClientImplTest {
         StoreClientTestUtils.constructHttpMultiSchemaResponse(storeName, valueSchemaEntries);
     String multiValueSchemaPath = "/" + RouterBackedSchemaReader.TYPE_VALUE_SCHEMA + "/" + storeName;
     routerServer.addResponseForUri(multiValueSchemaPath, multiValueSchemaResponse);
+
+    FullHttpResponse multiValueSchemaIdResponse =
+        StoreClientTestUtils.constructHttpMultiSchemaIdResponse(storeName, valueSchemaEntries);
+    String multiValueSchemaIdPath = "/" + RouterBackedSchemaReader.TYPE_VALUE_SCHEMA_ID + "/" + storeName;
+    routerServer.addResponseForUri(multiValueSchemaIdPath, multiValueSchemaIdResponse);
 
     Set<String> keys = new TreeSet<>();
     keys.add("key1");

--- a/internal/venice-test-common/src/main/java/com/linkedin/venice/client/utils/StoreClientTestUtils.java
+++ b/internal/venice-test-common/src/main/java/com/linkedin/venice/client/utils/StoreClientTestUtils.java
@@ -5,6 +5,7 @@ import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
 import com.linkedin.venice.HttpConstants;
 import com.linkedin.venice.client.exceptions.VeniceClientException;
 import com.linkedin.venice.controllerapi.D2ServiceDiscoveryResponse;
+import com.linkedin.venice.controllerapi.MultiSchemaIdResponse;
 import com.linkedin.venice.controllerapi.MultiSchemaResponse;
 import com.linkedin.venice.controllerapi.SchemaResponse;
 import com.linkedin.venice.utils.ObjectMapperFactory;
@@ -82,6 +83,29 @@ public class StoreClientTestUtils {
     response.headers().set(HttpHeaderNames.CONTENT_LENGTH, response.content().readableBytes());
 
     return response;
+  }
+
+  public static FullHttpResponse constructHttpMultiSchemaIdResponse(
+      String storeName,
+      Map<Integer, String> valueSchemaEntries) throws IOException {
+    ByteBuf body = Unpooled.wrappedBuffer(constructMultiSchemaIdResponseInBytes(storeName, valueSchemaEntries));
+    FullHttpResponse response = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK, body);
+    response.headers().set(HttpHeaderNames.CONTENT_TYPE, "application/json");
+    // We must specify content_length header, otherwise netty will keep polling, since it
+    // doesn't know when to finish writing the response.
+    response.headers().set(HttpHeaderNames.CONTENT_LENGTH, response.content().readableBytes());
+
+    return response;
+  }
+
+  public static byte[] constructMultiSchemaIdResponseInBytes(String storeName, Map<Integer, String> valueSchemaEntries)
+      throws IOException {
+    MultiSchemaIdResponse responseObject = new MultiSchemaIdResponse();
+    responseObject.setCluster("test_cluster");
+    responseObject.setName(storeName);
+    responseObject.setSchemaIdSet(valueSchemaEntries.keySet());
+    ObjectMapper mapper = ObjectMapperFactory.getInstance();
+    return mapper.writeValueAsBytes(responseObject);
   }
 
   public static byte[] constructMultiSchemaResponseInBytes(String storeName, Map<Integer, String> valueSchemaEntries)

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/MetaDataHandler.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/MetaDataHandler.java
@@ -27,6 +27,7 @@ import com.linkedin.venice.compression.CompressionStrategy;
 import com.linkedin.venice.controllerapi.CurrentVersionResponse;
 import com.linkedin.venice.controllerapi.D2ServiceDiscoveryResponse;
 import com.linkedin.venice.controllerapi.LeaderControllerResponse;
+import com.linkedin.venice.controllerapi.MultiSchemaIdResponse;
 import com.linkedin.venice.controllerapi.MultiSchemaResponse;
 import com.linkedin.venice.controllerapi.SchemaResponse;
 import com.linkedin.venice.controllerapi.VersionCreationResponse;
@@ -73,9 +74,11 @@ import java.security.cert.CertificateExpiredException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import org.apache.commons.lang.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -186,6 +189,11 @@ public class MetaDataHandler extends SimpleChannelInboundHandler<HttpRequest> {
           // The request could fetch the latest value schema for the given store
           // URI: /latest_value_schema/{$storeName} - Get the latest value schema
           handleLatestValueSchemaLookup(ctx, helper);
+          break;
+        case TYPE_VALUE_SCHEMA_IDS:
+          // The request could fetch all the value schema IDs for the given store, also superset schema ID.
+          // URI: /value_schema_ids/{$storeName} - Get all value schema IDs.
+          handleValueSchemaIdsLookup(ctx, helper);
           break;
         case TYPE_GET_UPDATE_SCHEMA:
           // URI: /update_schema/{$storeName} - Get all the update schema
@@ -330,6 +338,28 @@ public class MetaDataHandler extends SimpleChannelInboundHandler<HttpRequest> {
     }
     responseObject.setId(latestValueSchemaEntry.getId());
     responseObject.setSchemaStr(latestValueSchemaEntry.getSchemaStr());
+    setupResponseAndFlush(OK, OBJECT_MAPPER.writeValueAsBytes(responseObject), true, ctx);
+  }
+
+  private void handleValueSchemaIdsLookup(ChannelHandlerContext ctx, VenicePathParserHelper helper) throws IOException {
+    String storeName = helper.getResourceName();
+    checkResourceName(storeName, "/" + TYPE_VALUE_SCHEMA_IDS + "/${storeName}");
+    // URI: /value_schema_ids/{$storeName}
+    // Return all value schema IDs as a set.
+    // If superset schema id exists, also return it.
+    MultiSchemaIdResponse responseObject = new MultiSchemaIdResponse();
+    responseObject.setCluster(clusterName);
+    responseObject.setName(storeName);
+
+    int superSetSchemaId = storeRepository.getStore(storeName).getLatestSuperSetValueSchemaId();
+    if (superSetSchemaId != SchemaData.INVALID_VALUE_SCHEMA_ID) {
+      responseObject.setSuperSetSchemaId(superSetSchemaId);
+    }
+    Set<Integer> schemaIdSet = new HashSet<>();
+    for (SchemaEntry entry: schemaRepo.getValueSchemas(storeName)) {
+      schemaIdSet.add(entry.getId());
+    }
+    responseObject.setSchemaIdSet(schemaIdSet);
     setupResponseAndFlush(OK, OBJECT_MAPPER.writeValueAsBytes(responseObject), true, ctx);
   }
 

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/MetaDataHandler.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/MetaDataHandler.java
@@ -189,9 +189,9 @@ public class MetaDataHandler extends SimpleChannelInboundHandler<HttpRequest> {
           // URI: /latest_value_schema/{$storeName} - Get the latest value schema
           handleLatestValueSchemaLookup(ctx, helper);
           break;
-        case TYPE_VALUE_SCHEMA_IDS:
+        case TYPE_ALL_VALUE_SCHEMA_IDS:
           // The request could fetch all the value schema IDs for the given store, also superset schema ID.
-          // URI: /value_schema_ids/{$storeName} - Get all value schema IDs.
+          // URI: /all_value_schema_ids/{$storeName} - Get all value schema IDs.
           handleValueSchemaIdsLookup(ctx, helper);
           break;
         case TYPE_GET_UPDATE_SCHEMA:
@@ -342,7 +342,7 @@ public class MetaDataHandler extends SimpleChannelInboundHandler<HttpRequest> {
 
   private void handleValueSchemaIdsLookup(ChannelHandlerContext ctx, VenicePathParserHelper helper) throws IOException {
     String storeName = helper.getResourceName();
-    checkResourceName(storeName, "/" + TYPE_VALUE_SCHEMA_IDS + "/${storeName}");
+    checkResourceName(storeName, "/" + TYPE_ALL_VALUE_SCHEMA_IDS + "/${storeName}");
     // URI: /value_schema_ids/{$storeName}
     // Return all value schema IDs as a set.
     // If superset schema id exists, also return it.

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/MetaDataHandler.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/MetaDataHandler.java
@@ -164,7 +164,6 @@ public class MetaDataHandler extends SimpleChannelInboundHandler<HttpRequest> {
   @Override
   public void channelRead0(ChannelHandlerContext ctx, HttpRequest req) throws IOException {
     VenicePathParserHelper helper = parseRequest(req);
-
     RouterResourceType resourceType = helper.getResourceType(); // may be null
 
     try {

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/api/RouterResourceType.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/api/RouterResourceType.java
@@ -8,8 +8,8 @@ public enum RouterResourceType {
   TYPE_LEADER_CONTROLLER("leader_controller"), @Deprecated
   TYPE_LEADER_CONTROLLER_LEGACY("master_controller"), TYPE_KEY_SCHEMA("key_schema"), TYPE_VALUE_SCHEMA("value_schema"),
   TYPE_LATEST_VALUE_SCHEMA("latest_value_schema"), TYPE_GET_UPDATE_SCHEMA("update_schema"),
-  TYPE_CLUSTER_DISCOVERY("discover_cluster"), TYPE_REQUEST_TOPIC("request_topic"),
-  TYPE_STREAM_HYBRID_STORE_QUOTA("stream_hybrid_store_quota"),
+  TYPE_VALUE_SCHEMA_IDS("value_schema_ids"), TYPE_CLUSTER_DISCOVERY("discover_cluster"),
+  TYPE_REQUEST_TOPIC("request_topic"), TYPE_STREAM_HYBRID_STORE_QUOTA("stream_hybrid_store_quota"),
   TYPE_STREAM_REPROCESSING_HYBRID_STORE_QUOTA("stream_reprocessing_hybrid_store_quota"),
   TYPE_STORE_STATE("store_state"), TYPE_PUSH_STATUS("push_status"), TYPE_STORAGE("storage"), TYPE_COMPUTE("compute"),
   TYPE_ADMIN("admin"), TYPE_RESOURCE_STATE("resource_state"), TYPE_CURRENT_VERSION("current_version"),

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/api/RouterResourceType.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/api/RouterResourceType.java
@@ -8,7 +8,7 @@ public enum RouterResourceType {
   TYPE_LEADER_CONTROLLER("leader_controller"), @Deprecated
   TYPE_LEADER_CONTROLLER_LEGACY("master_controller"), TYPE_KEY_SCHEMA("key_schema"), TYPE_VALUE_SCHEMA("value_schema"),
   TYPE_LATEST_VALUE_SCHEMA("latest_value_schema"), TYPE_GET_UPDATE_SCHEMA("update_schema"),
-  TYPE_VALUE_SCHEMA_IDS("value_schema_ids"), TYPE_CLUSTER_DISCOVERY("discover_cluster"),
+  TYPE_ALL_VALUE_SCHEMA_IDS("all_value_schema_ids"), TYPE_CLUSTER_DISCOVERY("discover_cluster"),
   TYPE_REQUEST_TOPIC("request_topic"), TYPE_STREAM_HYBRID_STORE_QUOTA("stream_hybrid_store_quota"),
   TYPE_STREAM_REPROCESSING_HYBRID_STORE_QUOTA("stream_reprocessing_hybrid_store_quota"),
   TYPE_STORE_STATE("store_state"), TYPE_PUSH_STATUS("push_status"), TYPE_STORAGE("storage"), TYPE_COMPUTE("compute"),

--- a/services/venice-router/src/test/java/com/linkedin/venice/router/TestMetaDataHandler.java
+++ b/services/venice-router/src/test/java/com/linkedin/venice/router/TestMetaDataHandler.java
@@ -307,7 +307,7 @@ public class TestMetaDataHandler {
     SchemaEntry valueSchemaEntry2 = new SchemaEntry(valueSchemaId2, valueSchemaStr2);
     Mockito.doReturn(Arrays.asList(valueSchemaEntry1, valueSchemaEntry2)).when(schemaRepo).getValueSchemas(storeName);
     FullHttpResponse response = passRequestToMetadataHandler(
-        "http://myRouterHost:4567/value_schema_ids/" + storeName,
+        "http://myRouterHost:4567/all_value_schema_ids/" + storeName,
         null,
         schemaRepo,
         Mockito.mock(HelixReadOnlyStoreConfigRepository.class),

--- a/services/venice-router/src/test/java/com/linkedin/venice/router/TestMetaDataHandler.java
+++ b/services/venice-router/src/test/java/com/linkedin/venice/router/TestMetaDataHandler.java
@@ -18,6 +18,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.linkedin.venice.common.VeniceSystemStoreType;
 import com.linkedin.venice.controllerapi.D2ServiceDiscoveryResponse;
 import com.linkedin.venice.controllerapi.LeaderControllerResponse;
+import com.linkedin.venice.controllerapi.MultiSchemaIdResponse;
 import com.linkedin.venice.controllerapi.MultiSchemaResponse;
 import com.linkedin.venice.controllerapi.SchemaResponse;
 import com.linkedin.venice.controllerapi.VersionCreationResponse;
@@ -50,6 +51,7 @@ import com.linkedin.venice.pushmonitor.HybridStoreQuotaStatus;
 import com.linkedin.venice.routerapi.HybridStoreQuotaStatusResponse;
 import com.linkedin.venice.routerapi.ReplicaState;
 import com.linkedin.venice.routerapi.ResourceStateResponse;
+import com.linkedin.venice.schema.SchemaData;
 import com.linkedin.venice.schema.SchemaEntry;
 import com.linkedin.venice.schema.writecompute.DerivedSchemaEntry;
 import com.linkedin.venice.serialization.avro.AvroProtocolDefinition;
@@ -289,6 +291,68 @@ public class TestMetaDataHandler {
 
     Assert.assertEquals(response.status(), HttpResponseStatus.NOT_FOUND);
     Assert.assertEquals(response.headers().get(CONTENT_TYPE), "text/plain");
+  }
+
+  @Test
+  public void testAllValueSchemaIdLookup() throws IOException {
+    String storeName = "test_store";
+    String valueSchemaStr1 = "\"string\"";
+    String valueSchemaStr2 = "\"long\"";
+    String clusterName = "test-cluster";
+    int valueSchemaId1 = 1;
+    int valueSchemaId2 = 2;
+    // Mock ReadOnlySchemaRepository
+    ReadOnlySchemaRepository schemaRepo = Mockito.mock(ReadOnlySchemaRepository.class);
+    SchemaEntry valueSchemaEntry1 = new SchemaEntry(valueSchemaId1, valueSchemaStr1);
+    SchemaEntry valueSchemaEntry2 = new SchemaEntry(valueSchemaId2, valueSchemaStr2);
+    Mockito.doReturn(Arrays.asList(valueSchemaEntry1, valueSchemaEntry2)).when(schemaRepo).getValueSchemas(storeName);
+    FullHttpResponse response = passRequestToMetadataHandler(
+        "http://myRouterHost:4567/value_schema_ids/" + storeName,
+        null,
+        schemaRepo,
+        Mockito.mock(HelixReadOnlyStoreConfigRepository.class),
+        Collections.emptyMap(),
+        Collections.emptyMap());
+
+    Assert.assertEquals(response.status(), HttpResponseStatus.OK);
+    Assert.assertEquals(response.headers().get(CONTENT_TYPE), "application/json");
+    MultiSchemaIdResponse multiSchemaIdResponse =
+        OBJECT_MAPPER.readValue(response.content().array(), MultiSchemaIdResponse.class);
+
+    Assert.assertEquals(multiSchemaIdResponse.getName(), storeName);
+    Assert.assertEquals(multiSchemaIdResponse.getCluster(), clusterName);
+    Assert.assertFalse(multiSchemaIdResponse.isError());
+    Assert.assertEquals(multiSchemaIdResponse.getSchemaIdSet().size(), 2);
+    Assert.assertTrue(multiSchemaIdResponse.getSchemaIdSet().contains(1));
+    Assert.assertTrue(multiSchemaIdResponse.getSchemaIdSet().contains(2));
+    Assert.assertEquals(multiSchemaIdResponse.getSuperSetSchemaId(), SchemaData.INVALID_VALUE_SCHEMA_ID);
+
+  }
+
+  @Test
+  public void testAllValueSchemaIdLookupWithNoValueSchema() throws IOException {
+    String storeName = "test_store";
+    String clusterName = "test-cluster";
+
+    FullHttpResponse response = passRequestToMetadataHandler(
+        "http://myRouterHost:4567/value_schema/" + storeName,
+        null,
+        null,
+        Mockito.mock(HelixReadOnlyStoreConfigRepository.class),
+        Collections.emptyMap(),
+        Collections.emptyMap());
+
+    Assert.assertEquals(response.status(), HttpResponseStatus.OK);
+    Assert.assertEquals(response.headers().get(CONTENT_TYPE), "application/json");
+    MultiSchemaIdResponse multiSchemaIdResponse =
+        OBJECT_MAPPER.readValue(response.content().array(), MultiSchemaIdResponse.class);
+
+    Assert.assertEquals(multiSchemaIdResponse.getName(), storeName);
+    Assert.assertEquals(multiSchemaIdResponse.getCluster(), clusterName);
+    Assert.assertFalse(multiSchemaIdResponse.isError());
+    Assert.assertEquals(multiSchemaIdResponse.getSchemaIdSet().size(), 0);
+    Assert.assertEquals(multiSchemaIdResponse.getSuperSetSchemaId(), SchemaData.INVALID_VALUE_SCHEMA_ID);
+
   }
 
   @Test


### PR DESCRIPTION
## [thin-client][producer][router] SchemaReader will only fetch single schema for all the APIs

This PR refactors the RouterBackedSchemaReader implementation to make sure no batch schema fetching under new router endpoint. 

1. It will lazily fetch individual value schema by value schema ID and update schema by value schema ID. 
2. For get value schema id by schema and get latest value schema APIs, we introduced a new router endpoint to /value_schema_ids/schema_name. It will fetch all value schema IDs and then fetch all value schema IDs one by one and derive latest value schema id.
3. For schema refresher thread, it will use the same end point to perform schema refreshing.
4. If new router endpoint is not available, we should fall back to fetch schema by batch.
5. This PR introduces a behavior change: If get value schema / update schema failed router call (throws exception), we will catch it and return null SchemaEntry.


## How was this PR tested?
N/A
## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.