### PR TITLE
[server] apply lossy offset rewind check before data persistence

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
@@ -1151,7 +1151,8 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
       PartitionConsumptionState partitionConsumptionState,
       PubSubMessage<KafkaKey, KafkaMessageEnvelope, Long> consumerRecord,
       LeaderProducedRecordContext leaderProducedRecordContext,
-      String kafkaUrl) {
+      String kafkaUrl,
+      boolean dryRun) {
     updateOffsetsFromConsumerRecord(
         partitionConsumptionState,
         consumerRecord,
@@ -1167,7 +1168,8 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
         (sourceKafkaUrl, upstreamTopic) -> upstreamTopic.isRealTime()
             ? partitionConsumptionState.getLatestProcessedUpstreamRTOffset(sourceKafkaUrl)
             : partitionConsumptionState.getLatestProcessedUpstreamVersionTopicOffset(),
-        () -> getUpstreamKafkaUrl(partitionConsumptionState, consumerRecord, kafkaUrl));
+        () -> getUpstreamKafkaUrl(partitionConsumptionState, consumerRecord, kafkaUrl),
+        dryRun);
   }
 
   /**

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -1274,6 +1274,8 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
    *
    * In LeaderFollowerStoreIngestionTask, "sourceKafkaUrlSupplier" should always return {@link OffsetRecord#NON_AA_REPLICATION_UPSTREAM_OFFSET_MAP_KEY};
    * in ActiveActiveStoreIngestionTask, "sourceKafkaUrlSupplier" should return the actual source Kafka url of the "consumerRecordWrapper"
+   *
+   * Dry-run mode would only check whether the offset rewind is benign or not instead of persisting the processed offset.
    */
   protected void updateOffsetsFromConsumerRecord(
       PartitionConsumptionState partitionConsumptionState,
@@ -1282,7 +1284,8 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
       UpdateVersionTopicOffset updateVersionTopicOffsetFunction,
       UpdateUpstreamTopicOffset updateUpstreamTopicOffsetFunction,
       GetLastKnownUpstreamTopicOffset lastKnownUpstreamTopicOffsetSupplier,
-      Supplier<String> sourceKafkaUrlSupplier) {
+      Supplier<String> sourceKafkaUrlSupplier,
+      boolean dryRun) {
 
     // Only update the metadata if this replica should NOT produce to version topic.
     if (!shouldProduceToVersionTopic(partitionConsumptionState)) {
@@ -1316,26 +1319,32 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
           if (upstreamTopic == null) {
             upstreamTopic = versionTopic;
           }
-          final long previousUpstreamOffset = lastKnownUpstreamTopicOffsetSupplier.apply(sourceKafkaUrl, upstreamTopic);
-          checkAndHandleUpstreamOffsetRewind(
-              partitionConsumptionState,
-              consumerRecord,
-              newUpstreamOffset,
-              previousUpstreamOffset,
-              this);
-          /**
-           * Keep updating the upstream offset no matter whether there is a rewind or not; rewind could happen
-           * to the true leader when the old leader doesn't stop producing.
-           */
-          updateUpstreamTopicOffsetFunction.apply(sourceKafkaUrl, upstreamTopic, newUpstreamOffset);
+          if (dryRun) {
+            final long previousUpstreamOffset =
+                lastKnownUpstreamTopicOffsetSupplier.apply(sourceKafkaUrl, upstreamTopic);
+            checkAndHandleUpstreamOffsetRewind(
+                partitionConsumptionState,
+                consumerRecord,
+                newUpstreamOffset,
+                previousUpstreamOffset,
+                this);
+          } else {
+            /**
+             * Keep updating the upstream offset no matter whether there is a rewind or not; rewind could happen
+             * to the true leader when the old leader doesn't stop producing.
+             */
+            updateUpstreamTopicOffsetFunction.apply(sourceKafkaUrl, upstreamTopic, newUpstreamOffset);
+          }
         }
-        // update leader producer GUID
-        partitionConsumptionState.setLeaderGUID(kafkaValue.producerMetadata.producerGUID);
-        if (kafkaValue.leaderMetadataFooter != null) {
-          partitionConsumptionState.setLeaderHostId(kafkaValue.leaderMetadataFooter.hostName.toString());
+        if (!dryRun) {
+          // update leader producer GUID
+          partitionConsumptionState.setLeaderGUID(kafkaValue.producerMetadata.producerGUID);
+          if (kafkaValue.leaderMetadataFooter != null) {
+            partitionConsumptionState.setLeaderHostId(kafkaValue.leaderMetadataFooter.hostName.toString());
+          }
         }
       }
-    } else {
+    } else if (!dryRun) {
       updateOffsetsAsRemoteConsumeLeader(
           partitionConsumptionState,
           leaderProducedRecordContext,
@@ -1402,7 +1411,8 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
       PartitionConsumptionState partitionConsumptionState,
       PubSubMessage<KafkaKey, KafkaMessageEnvelope, Long> consumerRecordWrapper,
       LeaderProducedRecordContext leaderProducedRecordContext,
-      String kafkaUrl) {
+      String kafkaUrl,
+      boolean dryRun) {
     updateOffsetsFromConsumerRecord(
         partitionConsumptionState,
         consumerRecordWrapper,
@@ -1418,7 +1428,8 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
         (sourceKafkaUrl, upstreamTopic) -> upstreamTopic.isRealTime()
             ? partitionConsumptionState.getLatestProcessedUpstreamRTOffset(sourceKafkaUrl)
             : partitionConsumptionState.getLatestProcessedUpstreamVersionTopicOffset(),
-        () -> OffsetRecord.NON_AA_REPLICATION_UPSTREAM_OFFSET_MAP_KEY);
+        () -> OffsetRecord.NON_AA_REPLICATION_UPSTREAM_OFFSET_MAP_KEY,
+        dryRun);
   }
 
   protected static void checkAndHandleUpstreamOffsetRewind(

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestHybrid.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestHybrid.java
@@ -2,6 +2,7 @@ package com.linkedin.venice.endToEnd;
 
 import static com.linkedin.davinci.store.rocksdb.RocksDBServerConfig.ROCKSDB_PLAIN_TABLE_FORMAT_ENABLED;
 import static com.linkedin.venice.ConfigKeys.DEFAULT_MAX_NUMBER_OF_PARTITIONS;
+import static com.linkedin.venice.ConfigKeys.INSTANCE_ID;
 import static com.linkedin.venice.ConfigKeys.KAFKA_BOOTSTRAP_SERVERS;
 import static com.linkedin.venice.ConfigKeys.PERSISTENCE_TYPE;
 import static com.linkedin.venice.ConfigKeys.SERVER_CONSUMER_POOL_SIZE_PER_KAFKA_CLUSTER;
@@ -49,6 +50,7 @@ import com.linkedin.venice.controllerapi.JobStatusQueryResponse;
 import com.linkedin.venice.controllerapi.StoreResponse;
 import com.linkedin.venice.controllerapi.UpdateStoreQueryParams;
 import com.linkedin.venice.controllerapi.VersionCreationResponse;
+import com.linkedin.venice.controllerapi.VersionResponse;
 import com.linkedin.venice.exceptions.RecordTooLargeException;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.helix.HelixBaseRoutingRepository;
@@ -105,6 +107,7 @@ import com.linkedin.venice.utils.Time;
 import com.linkedin.venice.utils.Utils;
 import com.linkedin.venice.utils.VeniceProperties;
 import com.linkedin.venice.writer.CompletableFutureCallback;
+import com.linkedin.venice.writer.LeaderMetadataWrapper;
 import com.linkedin.venice.writer.VeniceWriter;
 import com.linkedin.venice.writer.VeniceWriterOptions;
 import java.io.File;
@@ -268,6 +271,168 @@ public class TestHybrid {
               sharedVenice.getPubSubTopicRepository().getTopic(Version.composeRealTimeTopic(storeName))),
           TopicManager.getExpectedRetentionTimeInMs(store, hybridStoreConfig),
           "RT retention not updated properly");
+    }
+  }
+
+  @Test(timeOut = 180 * Time.MS_PER_SECOND)
+  public void testHybridSplitBrainIssue() {
+    Properties extraProperties = new Properties();
+    extraProperties.setProperty(SERVER_PROMOTION_TO_LEADER_REPLICA_DELAY_SECONDS, Long.toString(3L));
+    extraProperties.setProperty(ROCKSDB_PLAIN_TABLE_FORMAT_ENABLED, "false");
+    extraProperties.setProperty(SERVER_DATABASE_CHECKSUM_VERIFICATION_ENABLED, "true");
+    extraProperties.setProperty(SERVER_DATABASE_SYNC_BYTES_INTERNAL_FOR_DEFERRED_WRITE_MODE, "300");
+    try (
+        VeniceClusterWrapper venice =
+            ServiceFactory.getVeniceCluster(1, 2, 1, 1, 1000000, false, false, extraProperties);
+        ZkServerWrapper parentZk = ServiceFactory.getZkServer();
+        VeniceControllerWrapper parentController = ServiceFactory.getVeniceController(
+            new VeniceControllerCreateOptions.Builder(
+                venice.getClusterName(),
+                parentZk,
+                venice.getPubSubBrokerWrapper())
+                    .childControllers(new VeniceControllerWrapper[] { venice.getLeaderVeniceController() })
+                    .build());
+        ControllerClient controllerClient =
+            new ControllerClient(venice.getClusterName(), parentController.getControllerUrl());
+        TopicManager topicManager =
+            IntegrationTestPushUtils
+                .getTopicManagerRepo(
+                    DEFAULT_KAFKA_OPERATION_TIMEOUT_MS,
+                    100,
+                    0l,
+                    venice.getPubSubBrokerWrapper(),
+                    venice.getPubSubTopicRepository())
+                .getTopicManager()) {
+      long streamingRewindSeconds = 25L;
+      long streamingMessageLag = 2L;
+      final String storeName = Utils.getUniqueString("hybrid-store");
+
+      // Create store at parent, make it a hybrid store
+      controllerClient.createNewStore(storeName, "owner", STRING_SCHEMA.toString(), STRING_SCHEMA.toString());
+      controllerClient.updateStore(
+          storeName,
+          new UpdateStoreQueryParams().setStorageQuotaInByte(Store.UNLIMITED_STORAGE_QUOTA)
+              .setHybridRewindSeconds(streamingRewindSeconds)
+              .setHybridOffsetLagThreshold(streamingMessageLag));
+
+      // There should be no version on the store yet
+      assertEquals(
+          controllerClient.getStore(storeName).getStore().getCurrentVersion(),
+          0,
+          "The newly created store must have a current version of 0");
+
+      VersionResponse versionResponse = controllerClient.addVersionAndStartIngestion(
+          storeName,
+          Utils.getUniqueString("test-hybrid-push"),
+          1,
+          3,
+          Version.PushType.BATCH,
+          null,
+          -1,
+          1);
+      assertFalse(
+          versionResponse.isError(),
+          "Version creation shouldn't return error, but received: " + versionResponse.getError());
+      String versionTopicName = Version.composeKafkaTopic(storeName, 1);
+      Utils.sleep(10000);
+      // Enable log compaction
+      topicManager.updateTopicCompactionPolicy(venice.getPubSubTopicRepository().getTopic(versionTopicName), true);
+
+      String writer1 = "writer_1_hostname";
+      String writer2 = "writer_2_hostname";
+      Properties veniceWriterProperties1 = new Properties();
+      veniceWriterProperties1.put(KAFKA_BOOTSTRAP_SERVERS, venice.getPubSubBrokerWrapper().getAddress());
+      veniceWriterProperties1.putAll(
+          PubSubBrokerWrapper.getBrokerDetailsForClients(Collections.singletonList(venice.getPubSubBrokerWrapper())));
+      veniceWriterProperties1.put(INSTANCE_ID, writer1);
+
+      AvroSerializer<String> stringSerializer = new AvroSerializer(STRING_SCHEMA);
+      PubSubProducerAdapterFactory pubSubProducerAdapterFactory =
+          venice.getPubSubBrokerWrapper().getPubSubClientsFactory().getProducerAdapterFactory();
+
+      Properties veniceWriterProperties2 = new Properties();
+      veniceWriterProperties2.put(KAFKA_BOOTSTRAP_SERVERS, venice.getPubSubBrokerWrapper().getAddress());
+      veniceWriterProperties2.putAll(
+          PubSubBrokerWrapper.getBrokerDetailsForClients(Collections.singletonList(venice.getPubSubBrokerWrapper())));
+      veniceWriterProperties2.put(INSTANCE_ID, writer2);
+
+      try (
+          VeniceWriter<byte[], byte[], byte[]> veniceWriter1 =
+              TestUtils.getVeniceWriterFactory(veniceWriterProperties1, pubSubProducerAdapterFactory)
+                  .createVeniceWriter(new VeniceWriterOptions.Builder(versionTopicName).build());
+          VeniceWriter<byte[], byte[], byte[]> veniceWriter2 =
+              TestUtils.getVeniceWriterFactory(veniceWriterProperties2, pubSubProducerAdapterFactory)
+                  .createVeniceWriter(new VeniceWriterOptions.Builder(versionTopicName).build())) {
+        veniceWriter1.broadcastStartOfPush(false, Collections.emptyMap());
+
+        /**
+         * Explicitly simulate split-brain issue.
+         * Writer1:
+         *
+         * key_0: value_0 with upstream offset: 5
+         * key_1: value_1 with upstream offset: 6
+         * key_2: value_2 with upstream offset: 7
+         * key_3: value_3 with upstream offset: 8
+         * key_4: value_4 with upstream offset: 9
+         * Writer2:
+         * key_0: value_x with upstream offset: 3
+         * key_5: value_5 with upstream offset: 10
+         * key_6: value_6 with upstream offset: 11
+         * key_7: value_7 with upstream offset: 12
+         * key_8: value_8 with upstream offset: 13
+         * key_9: value_9 with upstream offset: 14
+         */
+
+        // Sending out dummy records first to push out SOS messages first.
+        veniceWriter1.put(
+            stringSerializer.serialize("key_writer_1"),
+            stringSerializer.serialize("value_writer_1"),
+            1,
+            null,
+            new LeaderMetadataWrapper(0, 0));
+        veniceWriter1.flush();
+        veniceWriter2.put(
+            stringSerializer.serialize("key_writer_2"),
+            stringSerializer.serialize("value_writer_2"),
+            1,
+            null,
+            new LeaderMetadataWrapper(1, 0));
+        veniceWriter2.flush();
+
+        for (int i = 0; i < 5; ++i) {
+          veniceWriter1.put(
+              stringSerializer.serialize("key_" + i),
+              stringSerializer.serialize("value_" + i),
+              1,
+              null,
+              new LeaderMetadataWrapper(i + 5, 0));
+        }
+        veniceWriter1.flush();
+        veniceWriter2.put(
+            stringSerializer.serialize("key_" + 0),
+            stringSerializer.serialize("value_x"),
+            1,
+            null,
+            new LeaderMetadataWrapper(3, 0));
+        for (int i = 5; i < 10; ++i) {
+          veniceWriter2.put(
+              stringSerializer.serialize("key_" + i),
+              stringSerializer.serialize("value_" + i),
+              1,
+              null,
+              new LeaderMetadataWrapper(i + 5, 0));
+        }
+        veniceWriter2.flush();
+        veniceWriter1.broadcastEndOfPush(Collections.emptyMap());
+        veniceWriter1.flush();
+      }
+
+      TestUtils.waitForNonDeterministicAssertion(100, TimeUnit.SECONDS, true, () -> {
+        // Now the store should have version 1
+        JobStatusQueryResponse jobStatus = controllerClient.queryJobStatus(Version.composeKafkaTopic(storeName, 1));
+        Assert.assertFalse(jobStatus.isError(), "Error in getting JobStatusResponse: " + jobStatus.getError());
+        assertEquals(jobStatus.getStatus(), "ERROR");
+      });
     }
   }
 

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestHybrid.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestHybrid.java
@@ -334,9 +334,6 @@ public class TestHybrid {
           versionResponse.isError(),
           "Version creation shouldn't return error, but received: " + versionResponse.getError());
       String versionTopicName = Version.composeKafkaTopic(storeName, 1);
-      Utils.sleep(10000);
-      // Enable log compaction
-      topicManager.updateTopicCompactionPolicy(venice.getPubSubTopicRepository().getTopic(versionTopicName), true);
 
       String writer1 = "writer_1_hostname";
       String writer2 = "writer_2_hostname";


### PR DESCRIPTION
Previously, we discovered that the lossy offset rewind check was applied after data persistence, which made the lossy check useless since the persisted data will be always same as the one just processed. This PR introduced a dry-mode to persisted offset persisting function:
1. Avoid big refactoring.
2. Run the dry-run mode before data persistence to check whether offset rewind is benign or not and run the regular mode after data persistence to persist the processed offset.

This PR also adds an integration test to validate the split brain issue handling logic.

<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->


## How was this PR tested?
CI
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.