### PR TITLE
[router] Fixed NPE in ReadRequestThrottler

### DIFF
--- a/services/venice-router/src/main/java/com/linkedin/venice/router/RouterServer.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/RouterServer.java
@@ -896,7 +896,6 @@ public class RouterServer extends AbstractVeniceService {
       readRequestThrottler = new ReadRequestThrottler(
           routersClusterManager,
           metadataRepository,
-          routingDataRepository,
           routerStats.getStatsByType(RequestType.SINGLE_GET),
           config);
 

--- a/services/venice-router/src/test/java/com/linkedin/venice/router/throttle/ReadRequestThrottlerTest.java
+++ b/services/venice-router/src/test/java/com/linkedin/venice/router/throttle/ReadRequestThrottlerTest.java
@@ -425,6 +425,7 @@ public class ReadRequestThrottlerTest {
           listener.handleStoreDeleted("testStore");
         } catch (Throwable t) {
           LOGGER.error("Caught a throwable when calling the listener immediately after subscription", t);
+          listenerThrewException.set(true);
         }
       }
 

--- a/services/venice-router/src/test/java/com/linkedin/venice/router/throttle/RouterRequestThrottlingTest.java
+++ b/services/venice-router/src/test/java/com/linkedin/venice/router/throttle/RouterRequestThrottlingTest.java
@@ -13,7 +13,6 @@ import com.linkedin.alpini.router.api.ScatterGatherRequest;
 import com.linkedin.venice.helix.ZkRoutersClusterManager;
 import com.linkedin.venice.meta.Instance;
 import com.linkedin.venice.meta.ReadOnlyStoreRepository;
-import com.linkedin.venice.meta.RoutingDataRepository;
 import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.read.RequestType;
 import com.linkedin.venice.router.VeniceRouterConfig;
@@ -65,15 +64,7 @@ public class RouterRequestThrottlingTest {
     doReturn(1).when(zkRoutersClusterManager).getLiveRoutersCount();
     doReturn(true).when(zkRoutersClusterManager).isThrottlingEnabled();
     doReturn(true).when(zkRoutersClusterManager).isMaxCapacityProtectionEnabled();
-    RoutingDataRepository routingDataRepository = mock(RoutingDataRepository.class);
-    throttler = new ReadRequestThrottler(
-        zkRoutersClusterManager,
-        storeRepository,
-        routingDataRepository,
-        2000,
-        stats,
-        1.5,
-        1000);
+    throttler = new ReadRequestThrottler(zkRoutersClusterManager, storeRepository, 2000, stats, 1.5, 1000);
   }
 
   @DataProvider(name = "multiGet_compute")


### PR DESCRIPTION
There could be a race condition where a listener of the ReadRequestThrottler got called while the constructor was not fully done executing, leading to a NPE for accessing a field that was not yet initialized. The fix is to register listeners at the very end.

Also eliminated the RoutingDataRepository constructor param and class property since it was unused.

## How was this PR tested?
New unit test.

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.