### PR TITLE
[da-vinci] Added deprecated flag to DaVinciConfig#NonLocalAccessPolicy

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/client/DaVinciConfig.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/client/DaVinciConfig.java
@@ -25,7 +25,16 @@ public class DaVinciConfig {
 
   /**
    * Indicates how to handle access to not-subscribed partitions.
+   *
+   * This feature will be completely removed in a later release.
+   * Here are the reasons this feature doesn't work well:
+   * 1. Remote Venice query is much slower than DaVinci local lookup.
+   * 2. Typically, Venice Backend doesn't provision enough capacity for DaVinci use cases since we normally don't know
+   *    the qps of DaVinci apps and for most of the scenarios, the DaVinci qps can be very high, and we don't want to
+   *    pre-allocate a lot of backend resources for this feature since the remote resources won't be leveraged most of
+   *    the time.
    */
+  @Deprecated
   private NonLocalAccessPolicy nonLocalAccessPolicy = NonLocalAccessPolicy.FAIL_FAST;
 
   /**


### PR DESCRIPTION
This PR is the first step to deprecate NonLocalAccessPolicy#QUERY_VENICE. This feature will be completely removed in a later release. Here are the reasons this feature doesn't work well:
 1. Remote Venice query is much slower than DaVinci local lookup.
 2. Typically, Venice Backend doesn't provision enough capacity for DaVinci use cases since we normally don't know the qps of DaVinci apps and for most of the scenarios, the DaVinci qps can be very high, and we don't want to pre-allocate a lot of backend resources for this feature since the remote resources won't be leveraged most of the time.

In the future, if there are DaVinci use cases, who would like to leverage such capability, we will need to evaluate it properly to make sure such requirement is reasonable or not. From a different perspective, if we can improve DaVinci bootstrapping performance significantly by the blob file transfer, such requirement won't exist IMO.

<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->


## How was this PR tested?
NA
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [x] Yes. Make sure to explain your proposed changes and call out the behavior change.
The current DaVinci applications, which are using this feature to see the deprecated warning.