### PR TITLE
[server] Remove a global disk quota metric

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/HostLevelIngestionStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/HostLevelIngestionStats.java
@@ -270,12 +270,6 @@ public class HostLevelIngestionStats extends AbstractVeniceStats {
                 .sum(),
             "ingestion_stuck_by_memory_constraint"));
 
-    // Stats which are per-store only:
-    // disk quota allowed for a store without replication. It should be as a straight line unless we bumps the disk
-    // quota
-    // allowed.
-    registerSensor(new AsyncGauge((ignored, ignored2) -> diskQuotaAllowedGauge, "global_store_disk_quota_allowed"));
-
     String keySizeSensorName = "record_key_size_in_bytes";
     this.keySizeSensor = registerSensor(
         keySizeSensorName,

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/HostLevelIngestionStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/HostLevelIngestionStats.java
@@ -270,6 +270,7 @@ public class HostLevelIngestionStats extends AbstractVeniceStats {
                 .sum(),
             "ingestion_stuck_by_memory_constraint"));
 
+    // Stats which are per-store only:
     String keySizeSensorName = "record_key_size_in_bytes";
     this.keySizeSensor = registerSensor(
         keySizeSensorName,

--- a/services/venice-server/src/test/java/com/linkedin/venice/stats/AggHostLevelIngestionStatsTest.java
+++ b/services/venice-server/src/test/java/com/linkedin/venice/stats/AggHostLevelIngestionStatsTest.java
@@ -79,7 +79,6 @@ public class AggHostLevelIngestionStatsTest {
     Assert.assertEquals(
         reporter.query(".total--bytes_read_from_kafka_as_uncompressed_size.Rate").value(),
         300d / LongAdderRateGauge.RATE_GAUGE_CACHE_DURATION_IN_SECONDS);
-    Assert.assertEquals(reporter.query("." + STORE_FOO + "--global_store_disk_quota_allowed.Gauge").value(), 200d);
 
     Assert.assertEquals(
         reporter.query(".total--records_consumed.Rate").value(),


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Summary
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

I noticed we have a `global disk quota` metric which should always be flat when there's no quota change. We have had `disk_usage_in_bytes` to tell us the real-time disk usage and `storage_quota_used` which computes the percentage. The `global disk quota` is useless IMO and we should get rid of it as it's also a store-level metric so can be expensive. 

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

GHCI

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.