### PR TITLE
[controller] Use the ACTIVE_ACTIVE data replication policy new hybrid AA enabled stores

### DIFF
--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/HybridStoreConfig.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/HybridStoreConfig.java
@@ -22,6 +22,8 @@ public interface HybridStoreConfig extends DataModelBackedStructure<StoreHybridC
 
   DataReplicationPolicy getDataReplicationPolicy();
 
+  void setDataReplicationPolicy(DataReplicationPolicy dataReplicationPolicy);
+
   BufferReplayPolicy getBufferReplayPolicy();
 
   HybridStoreConfig clone();

--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/HybridStoreConfigImpl.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/HybridStoreConfigImpl.java
@@ -74,6 +74,11 @@ public class HybridStoreConfigImpl implements HybridStoreConfig {
   }
 
   @Override
+  public void setDataReplicationPolicy(DataReplicationPolicy dataReplicationPolicy) {
+    this.hybridConfig.dataReplicationPolicy = dataReplicationPolicy.getValue();
+  }
+
+  @Override
   public BufferReplayPolicy getBufferReplayPolicy() {
     return BufferReplayPolicy.valueOf(this.hybridConfig.bufferReplayPolicy);
   }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/ReadOnlyStore.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/ReadOnlyStore.java
@@ -131,6 +131,11 @@ public class ReadOnlyStore implements Store {
     }
 
     @Override
+    public void setDataReplicationPolicy(DataReplicationPolicy dataReplicationPolicy) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
     public BufferReplayPolicy getBufferReplayPolicy() {
       return this.delegate.getBufferReplayPolicy();
     }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestClusterLevelConfigForActiveActiveReplication.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestClusterLevelConfigForActiveActiveReplication.java
@@ -11,11 +11,13 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
 import com.linkedin.venice.common.VeniceSystemStoreUtils;
 import com.linkedin.venice.controllerapi.UpdateStoreQueryParams;
 import com.linkedin.venice.integration.utils.D2TestUtils;
+import com.linkedin.venice.meta.DataReplicationPolicy;
 import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.pubsub.manager.TopicManager;
@@ -87,6 +89,11 @@ public class TestClusterLevelConfigForActiveActiveReplication extends AbstractTe
         storeNameHybrid,
         new UpdateStoreQueryParams().setHybridRewindSeconds(1000L).setHybridOffsetLagThreshold(1000L));
     assertTrue(veniceAdmin.getStore(clusterName, storeNameHybrid).isActiveActiveReplicationEnabled());
+    DataReplicationPolicy drp =
+        veniceAdmin.getStore(clusterName, storeNameHybrid).getHybridStoreConfig().getDataReplicationPolicy();
+    assertNotNull(drp);
+    System.out.println(drp);
+    assertEquals(drp, DataReplicationPolicy.NON_AGGREGATE);
 
     veniceAdmin.updateStore(
         clusterName,

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestClusterLevelConfigForActiveActiveReplication.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestClusterLevelConfigForActiveActiveReplication.java
@@ -11,13 +11,11 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
 import com.linkedin.venice.common.VeniceSystemStoreUtils;
 import com.linkedin.venice.controllerapi.UpdateStoreQueryParams;
 import com.linkedin.venice.integration.utils.D2TestUtils;
-import com.linkedin.venice.meta.DataReplicationPolicy;
 import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.pubsub.manager.TopicManager;
@@ -89,11 +87,6 @@ public class TestClusterLevelConfigForActiveActiveReplication extends AbstractTe
         storeNameHybrid,
         new UpdateStoreQueryParams().setHybridRewindSeconds(1000L).setHybridOffsetLagThreshold(1000L));
     assertTrue(veniceAdmin.getStore(clusterName, storeNameHybrid).isActiveActiveReplicationEnabled());
-    DataReplicationPolicy drp =
-        veniceAdmin.getStore(clusterName, storeNameHybrid).getHybridStoreConfig().getDataReplicationPolicy();
-    assertNotNull(drp);
-    System.out.println(drp);
-    assertEquals(drp, DataReplicationPolicy.NON_AGGREGATE);
 
     veniceAdmin.updateStore(
         clusterName,

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestActiveActiveReplicationForIncPush.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestActiveActiveReplicationForIncPush.java
@@ -35,6 +35,7 @@ import com.linkedin.venice.meta.HybridStoreConfig;
 import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.StoreInfo;
 import com.linkedin.venice.meta.Version;
+import com.linkedin.venice.utils.DataProviderUtils;
 import com.linkedin.venice.utils.IntegrationTestPushUtils;
 import com.linkedin.venice.utils.TestUtils;
 import com.linkedin.venice.utils.TestWriteUtils;
@@ -121,8 +122,8 @@ public class TestActiveActiveReplicationForIncPush {
    * The purpose of this test is to verify that incremental push with RT policy succeeds when A/A is enabled in all
    * regions. And also incremental push can push to the closes kafka cluster from the grid using the SOURCE_GRID_CONFIG.
    */
-  @Test(timeOut = TEST_TIMEOUT)
-  public void testAAReplicationForIncrementalPushToRT() throws Exception {
+  @Test(timeOut = TEST_TIMEOUT, dataProviderClass = DataProviderUtils.class, dataProvider = "True-and-False")
+  public void testAAReplicationForIncrementalPushToRT(boolean overrideDataReplicationPolicy) throws Exception {
     String clusterName = this.clusterNames[0];
     File inputDirBatch = getTempDataDirectory();
     File inputDirInc1 = getTempDataDirectory();
@@ -179,6 +180,12 @@ public class TestActiveActiveReplicationForIncPush {
               .setHybridOffsetLagThreshold(TEST_TIMEOUT / 2)
               .setHybridRewindSeconds(2L)
               .setNativeReplicationSourceFabric("dc-2");
+
+      // Override the data replication policy to be non-aggregate.
+      if (overrideDataReplicationPolicy) {
+        updateStoreParams.setHybridDataReplicationPolicy(DataReplicationPolicy.NON_AGGREGATE);
+      }
+
       TestUtils.assertCommand(parentControllerClient.updateStore(storeName, updateStoreParams));
 
       // Print all the kafka cluster URLs
@@ -198,7 +205,7 @@ public class TestActiveActiveReplicationForIncPush {
           dc2ControllerClient);
       TestUtils.verifyHybridStoreDataReplicationPolicy(
           storeName,
-          DataReplicationPolicy.ACTIVE_ACTIVE,
+          overrideDataReplicationPolicy ? DataReplicationPolicy.NON_AGGREGATE : DataReplicationPolicy.ACTIVE_ACTIVE,
           parentControllerClient,
           dc0ControllerClient,
           dc1ControllerClient,

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestActiveActiveReplicationForIncPush.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestActiveActiveReplicationForIncPush.java
@@ -196,6 +196,13 @@ public class TestActiveActiveReplicationForIncPush {
           dc0ControllerClient,
           dc1ControllerClient,
           dc2ControllerClient);
+      TestUtils.verifyHybridStoreDataReplicationPolicy(
+          storeName,
+          DataReplicationPolicy.ACTIVE_ACTIVE,
+          parentControllerClient,
+          dc0ControllerClient,
+          dc1ControllerClient,
+          dc2ControllerClient);
 
       verifyHybridAndIncPushConfig(
           storeName,

--- a/internal/venice-test-common/src/main/java/com/linkedin/venice/utils/TestUtils.java
+++ b/internal/venice-test-common/src/main/java/com/linkedin/venice/utils/TestUtils.java
@@ -46,6 +46,7 @@ import com.linkedin.venice.helix.HelixReadOnlySchemaRepository;
 import com.linkedin.venice.helix.SafeHelixManager;
 import com.linkedin.venice.helix.VeniceOfflinePushMonitorAccessor;
 import com.linkedin.venice.kafka.protocol.state.PartitionState;
+import com.linkedin.venice.meta.DataReplicationPolicy;
 import com.linkedin.venice.meta.IngestionMode;
 import com.linkedin.venice.meta.Instance;
 import com.linkedin.venice.meta.OfflinePushStrategy;
@@ -681,6 +682,23 @@ public class TestUtils {
             storeResponse.getStore().isActiveActiveReplicationEnabled(),
             enabledAA,
             "The active active replication config does not match.");
+      }
+    });
+  }
+
+  public static void verifyHybridStoreDataReplicationPolicy(
+      String storeName,
+      DataReplicationPolicy dataReplicationPolicy,
+      ControllerClient... controllerClients) {
+    TestUtils.waitForNonDeterministicAssertion(60, TimeUnit.SECONDS, true, () -> {
+      for (ControllerClient controllerClient: controllerClients) {
+        StoreResponse storeResponse = assertCommand(controllerClient.getStore(storeName));
+        Assert.assertNotNull(storeResponse.getStore().getHybridStoreConfig());
+        Assert.assertNotNull(storeResponse.getStore().getHybridStoreConfig());
+        Assert.assertEquals(
+            storeResponse.getStore().getHybridStoreConfig().getDataReplicationPolicy(),
+            dataReplicationPolicy,
+            "The data replication policy does not match.");
       }
     });
   }

--- a/internal/venice-test-common/src/main/java/com/linkedin/venice/utils/TestUtils.java
+++ b/internal/venice-test-common/src/main/java/com/linkedin/venice/utils/TestUtils.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
 import com.github.luben.zstd.Zstd;
@@ -674,11 +675,11 @@ public class TestUtils {
     TestUtils.waitForNonDeterministicAssertion(60, TimeUnit.SECONDS, true, () -> {
       for (ControllerClient controllerClient: controllerClients) {
         StoreResponse storeResponse = assertCommand(controllerClient.getStore(storeName));
-        Assert.assertEquals(
+        assertEquals(
             storeResponse.getStore().isNativeReplicationEnabled(),
             enabledNR,
             "The native replication config does not match.");
-        Assert.assertEquals(
+        assertEquals(
             storeResponse.getStore().isActiveActiveReplicationEnabled(),
             enabledAA,
             "The active active replication config does not match.");
@@ -693,9 +694,9 @@ public class TestUtils {
     TestUtils.waitForNonDeterministicAssertion(60, TimeUnit.SECONDS, true, () -> {
       for (ControllerClient controllerClient: controllerClients) {
         StoreResponse storeResponse = assertCommand(controllerClient.getStore(storeName));
-        Assert.assertNotNull(storeResponse.getStore().getHybridStoreConfig());
-        Assert.assertNotNull(storeResponse.getStore().getHybridStoreConfig());
-        Assert.assertEquals(
+        assertNotNull(storeResponse.getStore(), "Store should not be null");
+        assertNotNull(storeResponse.getStore().getHybridStoreConfig(), "Hybrid store config should not be null");
+        assertEquals(
             storeResponse.getStore().getHybridStoreConfig().getDataReplicationPolicy(),
             dataReplicationPolicy,
             "The data replication policy does not match.");
@@ -893,7 +894,7 @@ public class TestUtils {
       Assert.assertNull(record.get(fieldName));
     } catch (AvroRuntimeException e) {
       // But in Avro 1.10+, it throws instead...
-      Assert.assertEquals(e.getMessage(), "Not a valid schema field: " + fieldName);
+      assertEquals(e.getMessage(), "Not a valid schema field: " + fieldName);
     }
   }
 }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
@@ -2337,6 +2337,15 @@ public class VeniceParentHelixAdmin implements Admin {
           && clusterConfig.isActiveActiveReplicationEnabledAsDefaultForHybrid()) {
         setStore.activeActiveReplicationEnabled = true;
         updatedConfigsList.add(ACTIVE_ACTIVE_REPLICATION_ENABLED);
+        if (!hybridDataReplicationPolicy.isPresent()) {
+          LOGGER.info(
+              "Data replication policy was not explicitly set when converting store to hybrid store: {}."
+                  + " Setting it to active-active replication policy.",
+              storeName);
+
+          updatedHybridStoreConfig.setDataReplicationPolicy(DataReplicationPolicy.ACTIVE_ACTIVE);
+          updatedConfigsList.add(DATA_REPLICATION_POLICY);
+        }
       }
       // When turning off hybrid store, we will also turn off A/A store config.
       if (storeBeingConvertedToBatch && setStore.activeActiveReplicationEnabled) {


### PR DESCRIPTION


## Use the ACTIVE_ACTIVE data replication policy new hybrid AA enabled stores

Use the ACTIVE_ACTIVE data replication policy when converting the store to an active-active  
replication-enabled hybrid store. With this change, lag will be considered caught up only if the  
lag in all regions is less than the threshold.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.