### PR TITLE
[server] Skip lag monitor setup if the version info is not found in the store metadata

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
@@ -85,6 +85,7 @@ import static com.linkedin.venice.ConfigKeys.SERVER_LEAKED_RESOURCE_CLEANUP_ENAB
 import static com.linkedin.venice.ConfigKeys.SERVER_LEAKED_RESOURCE_CLEAN_UP_INTERVAL_IN_MINUTES;
 import static com.linkedin.venice.ConfigKeys.SERVER_LOCAL_CONSUMER_CONFIG_PREFIX;
 import static com.linkedin.venice.ConfigKeys.SERVER_MAX_REQUEST_SIZE;
+import static com.linkedin.venice.ConfigKeys.SERVER_MAX_WAIT_FOR_VERSION_INFO_MS_CONFIG;
 import static com.linkedin.venice.ConfigKeys.SERVER_NETTY_GRACEFUL_SHUTDOWN_PERIOD_SECONDS;
 import static com.linkedin.venice.ConfigKeys.SERVER_NETTY_IDLE_TIME_SECONDS;
 import static com.linkedin.venice.ConfigKeys.SERVER_NETTY_WORKER_THREADS;
@@ -156,6 +157,7 @@ import com.linkedin.venice.utils.Utils;
 import com.linkedin.venice.utils.VeniceProperties;
 import com.linkedin.venice.utils.concurrent.BlockingQueueType;
 import java.nio.file.Paths;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -329,6 +331,8 @@ public class VeniceServerConfig extends VeniceClusterConfig {
   private final long diskHealthCheckTimeoutInMs;
 
   private final boolean diskHealthCheckServiceEnabled;
+
+  private final Duration serverMaxWaitForVersionInfo;
 
   private final boolean computeFastAvroEnabled;
 
@@ -555,6 +559,8 @@ public class VeniceServerConfig extends VeniceClusterConfig {
     diskHealthCheckTimeoutInMs =
         TimeUnit.SECONDS.toMillis(serverProperties.getLong(SERVER_DISK_HEALTH_CHECK_TIMEOUT_IN_SECONDS, 30));
     diskHealthCheckServiceEnabled = serverProperties.getBoolean(SERVER_DISK_HEALTH_CHECK_SERVICE_ENABLED, true);
+    serverMaxWaitForVersionInfo =
+        Duration.ofMillis(serverProperties.getLong(SERVER_MAX_WAIT_FOR_VERSION_INFO_MS_CONFIG, 5000));
     computeFastAvroEnabled = serverProperties.getBoolean(SERVER_COMPUTE_FAST_AVRO_ENABLED, true);
     participantMessageConsumptionDelayMs = serverProperties.getLong(PARTICIPANT_MESSAGE_CONSUMPTION_DELAY_MS, 60000);
     serverPromotionToLeaderReplicaDelayMs =
@@ -1012,6 +1018,10 @@ public class VeniceServerConfig extends VeniceClusterConfig {
 
   public boolean isDiskHealthCheckServiceEnabled() {
     return diskHealthCheckServiceEnabled;
+  }
+
+  public Duration getServerMaxWaitForVersionInfo() {
+    return serverMaxWaitForVersionInfo;
   }
 
   public BlockingQueueType getBlockingQueueType() {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/helix/LeaderFollowerPartitionStateModel.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/helix/LeaderFollowerPartitionStateModel.java
@@ -15,7 +15,6 @@ import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.utils.LatencyUtils;
 import com.linkedin.venice.utils.Pair;
-import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
@@ -196,7 +195,8 @@ public class LeaderFollowerPartitionStateModel extends AbstractPartitionStateMod
     try {
       String storeName = Version.parseStoreFromKafkaTopicName(resourceName);
       int storeVersion = Version.parseVersionFromKafkaTopicName(resourceName);
-      Pair<Store, Version> res = getStoreRepo().waitVersion(storeName, storeVersion, Duration.ofSeconds(30));
+      Pair<Store, Version> res = getStoreRepo()
+          .waitVersion(storeName, storeVersion, getStoreAndServerConfigs().getServerMaxWaitForVersionInfo(), 200);
       Store store = res.getFirst();
       Version version = res.getSecond();
       if (store == null || version == null) {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/helix/LeaderFollowerPartitionStateModel.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/helix/LeaderFollowerPartitionStateModel.java
@@ -104,7 +104,7 @@ public class LeaderFollowerPartitionStateModel extends AbstractPartitionStateMod
       try {
         long startTimeForSettingUpNewStorePartitionInNs = System.nanoTime();
         setupNewStorePartition();
-        heartbeatMonitoringService.addFollowerLagMonitor(store.getVersion(version).get(), getPartition());
+        store.getVersion(version).ifPresent(v -> heartbeatMonitoringService.addFollowerLagMonitor(v, getPartition()));
         logger.info(
             "Completed setting up new store partition for {} partition {}. Total elapsed time: {} ms",
             resourceName,
@@ -130,7 +130,7 @@ public class LeaderFollowerPartitionStateModel extends AbstractPartitionStateMod
     String storeName = Version.parseStoreFromKafkaTopicName(resourceName);
     int version = Version.parseVersionFromKafkaTopicName(resourceName);
     Store store = getStoreRepo().getStoreOrThrow(storeName);
-    heartbeatMonitoringService.addLeaderLagMonitor(store.getVersion(version).get(), getPartition());
+    store.getVersion(version).ifPresent(v -> heartbeatMonitoringService.addLeaderLagMonitor(v, getPartition()));
     executeStateTransition(
         message,
         context,
@@ -144,7 +144,7 @@ public class LeaderFollowerPartitionStateModel extends AbstractPartitionStateMod
     String storeName = Version.parseStoreFromKafkaTopicName(resourceName);
     int version = Version.parseVersionFromKafkaTopicName(resourceName);
     Store store = getStoreRepo().getStoreOrThrow(storeName);
-    heartbeatMonitoringService.addFollowerLagMonitor(store.getVersion(version).get(), getPartition());
+    store.getVersion(version).ifPresent(v -> heartbeatMonitoringService.addFollowerLagMonitor(v, getPartition()));
     executeStateTransition(
         message,
         context,
@@ -157,7 +157,7 @@ public class LeaderFollowerPartitionStateModel extends AbstractPartitionStateMod
     String storeName = Version.parseStoreFromKafkaTopicName(resourceName);
     int version = Version.parseVersionFromKafkaTopicName(resourceName);
     Store store = getStoreRepo().getStoreOrThrow(storeName);
-    heartbeatMonitoringService.removeLagMonitor(store.getVersion(version).get(), getPartition());
+    store.getVersion(version).ifPresent(v -> heartbeatMonitoringService.removeLagMonitor(v, getPartition()));
     executeStateTransition(message, context, () -> stopConsumption(true));
   }
 

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/helix/LeaderFollowerPartitionStateModelTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/helix/LeaderFollowerPartitionStateModelTest.java
@@ -1,0 +1,98 @@
+package com.linkedin.davinci.helix;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.linkedin.davinci.config.VeniceStoreVersionConfig;
+import com.linkedin.davinci.ingestion.VeniceIngestionBackend;
+import com.linkedin.davinci.stats.ParticipantStateTransitionStats;
+import com.linkedin.davinci.stats.ingestion.heartbeat.HeartbeatMonitoringService;
+import com.linkedin.venice.helix.HelixPartitionStatusAccessor;
+import com.linkedin.venice.meta.ReadOnlyStoreRepository;
+import com.linkedin.venice.meta.Store;
+import com.linkedin.venice.meta.Version;
+import com.linkedin.venice.utils.Pair;
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import org.apache.helix.NotificationContext;
+import org.apache.helix.model.Message;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+
+public class LeaderFollowerPartitionStateModelTest {
+  private VeniceIngestionBackend ingestionBackend;
+  private VeniceStoreVersionConfig storeAndServerConfigs;
+  private LeaderFollowerIngestionProgressNotifier notifier;
+  private ReadOnlyStoreRepository metadataRepo;
+  private CompletableFuture<HelixPartitionStatusAccessor> partitionPushStatusAccessorFuture;
+  private ParticipantStateTransitionStats threadPoolStats;
+  private HeartbeatMonitoringService heartbeatMonitoringService;
+  private LeaderFollowerPartitionStateModel leaderFollowerPartitionStateModel;
+  private static final String storeName = "store_85c9234588_1cce12d5";
+  private static final int storeVersion = 3;
+  private static final int partition = 0;
+  private static final String resourceName = storeName + "_v" + storeVersion;
+
+  @BeforeMethod
+  public void setUp() {
+    ingestionBackend = mock(VeniceIngestionBackend.class);
+    storeAndServerConfigs = mock(VeniceStoreVersionConfig.class);
+    notifier = mock(LeaderFollowerIngestionProgressNotifier.class);
+    metadataRepo = mock(ReadOnlyStoreRepository.class);
+    partitionPushStatusAccessorFuture = mock(CompletableFuture.class);
+    threadPoolStats = mock(ParticipantStateTransitionStats.class);
+    heartbeatMonitoringService = mock(HeartbeatMonitoringService.class);
+    leaderFollowerPartitionStateModel = new LeaderFollowerPartitionStateModel(
+        ingestionBackend,
+        storeAndServerConfigs,
+        partition,
+        notifier,
+        metadataRepo,
+        partitionPushStatusAccessorFuture,
+        "instanceName",
+        threadPoolStats,
+        heartbeatMonitoringService);
+  }
+
+  @Test
+  public void testUpdateLagMonitor() {
+    Message message = mock(Message.class);
+    NotificationContext context = mock(NotificationContext.class);
+    Store store = mock(Store.class);
+    Version version = mock(Version.class);
+    when(message.getResourceName()).thenReturn(resourceName);
+
+    LeaderFollowerPartitionStateModel leaderFollowerPartitionStateModelSpy = spy(leaderFollowerPartitionStateModel);
+
+    // test when both store and version are null
+    when(metadataRepo.waitVersion(eq(storeName), eq(storeVersion), any(Duration.class)))
+        .thenReturn(Pair.create(null, null));
+    leaderFollowerPartitionStateModelSpy.onBecomeLeaderFromStandby(message, context);
+    verify(metadataRepo).waitVersion(eq(storeName), eq(storeVersion), any(Duration.class));
+    verify(heartbeatMonitoringService, never()).addLeaderLagMonitor(any(Version.class), anyInt());
+
+    // test when store is not null and version is null
+    when(metadataRepo.waitVersion(eq(storeName), eq(storeVersion), any(Duration.class)))
+        .thenReturn(Pair.create(store, null));
+    leaderFollowerPartitionStateModelSpy.onBecomeLeaderFromStandby(message, context);
+    verify(metadataRepo, times(2)).waitVersion(eq(storeName), eq(storeVersion), any(Duration.class));
+    verify(heartbeatMonitoringService, never()).addLeaderLagMonitor(any(Version.class), anyInt());
+
+    // test both store and version are not null
+    when(metadataRepo.waitVersion(eq(storeName), eq(storeVersion), any(Duration.class)))
+        .thenReturn(Pair.create(store, version));
+    doNothing().when(leaderFollowerPartitionStateModelSpy).executeStateTransition(any(), any(), any());
+    leaderFollowerPartitionStateModelSpy.onBecomeLeaderFromStandby(message, context);
+    verify(metadataRepo, times(3)).waitVersion(eq(storeName), eq(storeVersion), any(Duration.class));
+    verify(heartbeatMonitoringService).addLeaderLagMonitor(version, partition);
+  }
+}

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/helix/LeaderFollowerPartitionStateModelTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/helix/LeaderFollowerPartitionStateModelTest.java
@@ -2,6 +2,7 @@ package com.linkedin.davinci.helix;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
@@ -74,25 +75,25 @@ public class LeaderFollowerPartitionStateModelTest {
     LeaderFollowerPartitionStateModel leaderFollowerPartitionStateModelSpy = spy(leaderFollowerPartitionStateModel);
 
     // test when both store and version are null
-    when(metadataRepo.waitVersion(eq(storeName), eq(storeVersion), any(Duration.class)))
+    when(metadataRepo.waitVersion(eq(storeName), eq(storeVersion), any(Duration.class), anyLong()))
         .thenReturn(Pair.create(null, null));
     leaderFollowerPartitionStateModelSpy.onBecomeLeaderFromStandby(message, context);
-    verify(metadataRepo).waitVersion(eq(storeName), eq(storeVersion), any(Duration.class));
+    verify(metadataRepo).waitVersion(eq(storeName), eq(storeVersion), any(Duration.class), anyLong());
     verify(heartbeatMonitoringService, never()).addLeaderLagMonitor(any(Version.class), anyInt());
 
     // test when store is not null and version is null
-    when(metadataRepo.waitVersion(eq(storeName), eq(storeVersion), any(Duration.class)))
+    when(metadataRepo.waitVersion(eq(storeName), eq(storeVersion), any(Duration.class), anyLong()))
         .thenReturn(Pair.create(store, null));
     leaderFollowerPartitionStateModelSpy.onBecomeLeaderFromStandby(message, context);
-    verify(metadataRepo, times(2)).waitVersion(eq(storeName), eq(storeVersion), any(Duration.class));
+    verify(metadataRepo, times(2)).waitVersion(eq(storeName), eq(storeVersion), any(Duration.class), anyLong());
     verify(heartbeatMonitoringService, never()).addLeaderLagMonitor(any(Version.class), anyInt());
 
     // test both store and version are not null
-    when(metadataRepo.waitVersion(eq(storeName), eq(storeVersion), any(Duration.class)))
+    when(metadataRepo.waitVersion(eq(storeName), eq(storeVersion), any(Duration.class), anyLong()))
         .thenReturn(Pair.create(store, version));
     doNothing().when(leaderFollowerPartitionStateModelSpy).executeStateTransition(any(), any(), any());
     leaderFollowerPartitionStateModelSpy.onBecomeLeaderFromStandby(message, context);
-    verify(metadataRepo, times(3)).waitVersion(eq(storeName), eq(storeVersion), any(Duration.class));
+    verify(metadataRepo, times(3)).waitVersion(eq(storeName), eq(storeVersion), any(Duration.class), anyLong());
     verify(heartbeatMonitoringService).addLeaderLagMonitor(version, partition);
   }
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -548,6 +548,12 @@ public class ConfigKeys {
       "server." + PubSubConstants.PUBSUB_CONSUMER_POLL_RETRY_BACKOFF_MS;
 
   /**
+   * Maximum duration (in milliseconds) to wait for the version information to become available in the store metadata
+   * repository before skipping Heartbeat (HB) lag monitor setup activity during state transition.
+   */
+  public static final String SERVER_MAX_WAIT_FOR_VERSION_INFO_MS_CONFIG = "server.max.wait.for.version.info.ms";
+
+  /**
    * This config decides the frequency of the disk health check; the disk health check service writes
    * 64KB data to a temporary file in the database directory and read from the file for each health check.
    */

--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/ReadOnlyStoreRepository.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/ReadOnlyStoreRepository.java
@@ -36,8 +36,11 @@ public interface ReadOnlyStoreRepository extends VeniceResource {
    *         (null, null) if store still doesn't exit after waiting for allowed time.
    */
   default Pair<Store, Version> waitVersion(String storeName, int versionNumber, Duration timeout) {
-    long delay = TimeUnit.SECONDS.toMillis(1);
-    long expirationTime = System.currentTimeMillis() + timeout.toMillis() - delay;
+    return waitVersion(storeName, versionNumber, timeout, TimeUnit.SECONDS.toMillis(1));
+  }
+
+  default Pair<Store, Version> waitVersion(String storeName, int versionNumber, Duration timeout, long delayMs) {
+    long expirationTime = System.currentTimeMillis() + timeout.toMillis() - delayMs;
     Store store = getStore(storeName);
     for (;;) {
       if (store != null) {
@@ -46,7 +49,7 @@ public interface ReadOnlyStoreRepository extends VeniceResource {
           return new Pair<>(store, version.get());
         }
       }
-      if (expirationTime < System.currentTimeMillis() || !Utils.sleep(delay)) {
+      if (expirationTime < System.currentTimeMillis() || !Utils.sleep(delayMs)) {
         return new Pair<>(store, null);
       }
       store = refreshOneStore(storeName);

--- a/internal/venice-common/src/test/java/com/linkedin/venice/meta/ReadOnlyStoreRepositoryTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/meta/ReadOnlyStoreRepositoryTest.java
@@ -1,0 +1,52 @@
+package com.linkedin.venice.meta;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+
+import com.linkedin.venice.utils.Pair;
+import java.time.Duration;
+import java.util.Optional;
+import org.testng.annotations.Test;
+
+
+public class ReadOnlyStoreRepositoryTest {
+  @Test
+  public void testWaitVersion() {
+    Store store = mock(Store.class);
+
+    ReadOnlyStoreRepository readOnlyStoreRepository = mock(ReadOnlyStoreRepository.class);
+    doReturn(store).when(readOnlyStoreRepository).getStore(anyString());
+    doCallRealMethod().when(readOnlyStoreRepository).waitVersion(anyString(), anyInt(), any());
+    doCallRealMethod().when(readOnlyStoreRepository).waitVersion(anyString(), anyInt(), any(), anyLong());
+    doReturn(store).when(readOnlyStoreRepository).refreshOneStore(anyString());
+
+    Pair<Store, Version> res = readOnlyStoreRepository.waitVersion("test", 1, Duration.ofMillis(5000));
+    assertNotNull(res);
+    assertNotNull(res.getFirst(), "Store should not be null");
+    assertEquals(res.getFirst(), store, "Store should be the same");
+    assertNull(res.getSecond(), "Version should be null");
+    verify(readOnlyStoreRepository).getStore("test");
+    verify(readOnlyStoreRepository, atLeast(3)).refreshOneStore("test");
+    verify(store, atLeast(3)).getVersion(1);
+
+    Version version = mock(Version.class);
+    doReturn(Optional.of(version)).when(store).getVersion(1);
+
+    res = readOnlyStoreRepository.waitVersion("test", 1, Duration.ofMillis(5000), 10);
+    assertNotNull(res);
+    assertNotNull(res.getFirst(), "Store should not be null");
+    assertEquals(res.getFirst(), store, "Store should be the same");
+    assertNotNull(res.getSecond(), "Version should not be null");
+    assertEquals(res.getSecond(), version, "Version should be the same");
+  }
+}

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceServerWrapper.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceServerWrapper.java
@@ -27,6 +27,7 @@ import static com.linkedin.venice.ConfigKeys.SERVER_INGESTION_HEARTBEAT_INTERVAL
 import static com.linkedin.venice.ConfigKeys.SERVER_INGESTION_ISOLATION_APPLICATION_PORT;
 import static com.linkedin.venice.ConfigKeys.SERVER_INGESTION_ISOLATION_SERVICE_PORT;
 import static com.linkedin.venice.ConfigKeys.SERVER_LEADER_COMPLETE_STATE_CHECK_IN_FOLLOWER_VALID_INTERVAL_MS;
+import static com.linkedin.venice.ConfigKeys.SERVER_MAX_WAIT_FOR_VERSION_INFO_MS_CONFIG;
 import static com.linkedin.venice.ConfigKeys.SERVER_NETTY_GRACEFUL_SHUTDOWN_PERIOD_SECONDS;
 import static com.linkedin.venice.ConfigKeys.SERVER_PARTITION_GRACEFUL_DROP_DELAY_IN_SECONDS;
 import static com.linkedin.venice.ConfigKeys.SERVER_PROMOTION_TO_LEADER_REPLICA_DELAY_SECONDS;
@@ -233,6 +234,7 @@ public class VeniceServerWrapper extends ProcessWrapper implements MetricsAware 
           .put(SERVER_DATABASE_CHECKSUM_VERIFICATION_ENABLED, true)
           .put(SERVER_PARTITION_GRACEFUL_DROP_DELAY_IN_SECONDS, 0)
           .put(PARTICIPANT_MESSAGE_CONSUMPTION_DELAY_MS, 1000)
+          .put(SERVER_MAX_WAIT_FOR_VERSION_INFO_MS_CONFIG, 1000)
           .put(KAFKA_READ_CYCLE_DELAY_MS, 50)
           .put(SERVER_DISK_FULL_THRESHOLD, 0.99) // Minimum free space is required in tests
           .put(SYSTEM_SCHEMA_CLUSTER_NAME, clusterName)


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Skip lag monitor setup if the version info is not found in the store metadata
Previously, if version info for a store wasn't available in the metadata repo,
the HB lag monitor would throw an exception, causing state transitions to fail.
This change adds a configurable wait for version info to become available. If it
doesn't, we skip the lag monitor setup and log the failure.

New config:
`server.max.wait.for.version.info.ms (default: 5000 milliseconds)`
A config to control the maximum duration to wait for the version  
information to become available in the store metadata repository  
before skipping Heartbeat (HB) lag monitor setup activity during  
state transition.




## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.