### PR TITLE
[producer] Skip metrics for the SchemaReaders inside online producer

### DIFF
--- a/clients/venice-producer/src/main/java/com/linkedin/venice/producer/online/OnlineVeniceProducer.java
+++ b/clients/venice-producer/src/main/java/com/linkedin/venice/producer/online/OnlineVeniceProducer.java
@@ -70,13 +70,15 @@ public class OnlineVeniceProducer<K, V> extends AbstractVeniceProducer<K, V> {
 
       this.storeClient = (InternalAvroStoreClient<K, V>) tempStoreClient;
 
-      ClientConfig clientConfigForSchemaReader =
-          ClientConfig.cloneConfig(storeClientConfig).setSchemaRefreshPeriod(schemaRefreshPeriod);
+      ClientConfig clientConfigForSchemaReader = ClientConfig.cloneConfig(storeClientConfig)
+          .setSchemaRefreshPeriod(schemaRefreshPeriod)
+          .setMetricsRepository(null);
 
       this.schemaReader = ClientFactory.getSchemaReader(clientConfigForSchemaReader, icProvider);
       ClientConfig<KafkaMessageEnvelope> kmeClientConfig = ClientConfig.cloneConfig(storeClientConfig)
           .setStoreName(AvroProtocolDefinition.KAFKA_MESSAGE_ENVELOPE.getSystemStoreName())
-          .setSpecificValueClass(KafkaMessageEnvelope.class);
+          .setSpecificValueClass(KafkaMessageEnvelope.class)
+          .setMetricsRepository(null);
 
       try (SchemaReader kmeSchemaReader = ClientFactory.getSchemaReader(kmeClientConfig, icProvider)) {
         configure(storeName, producerConfigs, metricsRepository, schemaReader, kmeSchemaReader);


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Skip metrics for the `SchemaReader` inside online producer
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
Currently, the clients internal to online producer also registers metrics. While this is not an issue by itself, it could cause issues if online producer and Venice client are used in the same application. This PR disables the metric registration since these metrics are not very useful currently.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
GH CI

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [X] Yes. Make sure to explain your proposed changes and call out the behavior change.
    - Store clients created internal to Online producer will not register and emit any metrics