### PR TITLE
[Router] Add router count change listner in read quota throttler

### DIFF
--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/RoutersClusterManager.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/RoutersClusterManager.java
@@ -45,20 +45,6 @@ public interface RoutersClusterManager {
    */
   void unSubscribeRouterCountChangedEvent(RouterCountChangedListener listener);
 
-  /**
-   * Listen on the router cluster config, get the notification once the config is changed.
-   *
-   * @param listener
-   */
-  void subscribeRouterClusterConfigChangedEvent(RouterClusterConfigChangedListener listener);
-
-  /**
-   * Stop listening on the router cluster config.
-   *
-   * @param listener
-   */
-  void unSubscribeRouterClusterConfighangedEvent(RouterClusterConfigChangedListener listener);
-
   boolean isThrottlingEnabled();
 
   boolean isMaxCapacityProtectionEnabled();
@@ -80,9 +66,5 @@ public interface RoutersClusterManager {
 
   interface RouterCountChangedListener {
     void handleRouterCountChanged(int newRouterCount);
-  }
-
-  interface RouterClusterConfigChangedListener {
-    void handleRouterClusterConfigChanged(RoutersClusterConfig newConfig);
   }
 }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/helix/ZkRoutersClusterManagerTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/helix/ZkRoutersClusterManagerTest.java
@@ -176,32 +176,6 @@ public class ZkRoutersClusterManagerTest {
         () -> !router.isThrottlingEnabled() && !router.isMaxCapacityProtectionEnabled());
   }
 
-  @Test
-  public void testTriggerRouterClusterConfigChangedEvent() {
-    int port = 10555;
-    String instanceId = Utils.getHelixNodeIdentifier(Utils.getHostName(), port);
-    ZkRoutersClusterManager manager = createManager(zkClient);
-    manager.registerRouter(instanceId);
-    int expectedNumber = 100;
-
-    boolean[] isUpdated = new boolean[1];
-    isUpdated[0] = false;
-    manager.subscribeRouterClusterConfigChangedEvent(newConfig -> {
-      if (newConfig.getExpectedRouterCount() == expectedNumber || newConfig.isThrottlingEnabled() == false) {
-        isUpdated[0] = true;
-      }
-    });
-
-    manager.updateExpectedRouterCount(expectedNumber);
-
-    TestUtils.waitForNonDeterministicCompletion(1, TimeUnit.SECONDS, () -> isUpdated[0]);
-
-    // Trigger event because throttling feature flag was changed.
-    isUpdated[0] = false;
-    manager.enableThrottling(false);
-    TestUtils.waitForNonDeterministicCompletion(1, TimeUnit.SECONDS, () -> isUpdated[0]);
-  }
-
   private ZkRoutersClusterManager createManager(ZkClient zkClient) {
     ZkRoutersClusterManager manager = new ZkRoutersClusterManager(zkClient, adapter, clusterName, 1, 1000);
     manager.refresh();

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/throttle/ReadRequestThrottler.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/throttle/ReadRequestThrottler.java
@@ -89,6 +89,7 @@ public class ReadRequestThrottler implements RouterThrottler, StoreDataChangedLi
     this.storeQuotaCheckTimeWindow = storeQuotaCheckTimeWindow;
     this.stats = stats;
     this.maxRouterReadCapacity = maxRouterReadCapacity;
+    this.zkRoutersManager.subscribeRouterCountChangedEvent(this);
     this.lastRouterCount = zkRoutersManager.getExpectedRoutersCount();
     this.perStoreRouterQuotaBuffer = perStoreRouterQuotaBuffer;
     this.idealTotalQuotaPerRouter = calculateIdealTotalQuotaPerRouter();

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/throttle/ReadRequestThrottler.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/throttle/ReadRequestThrottler.java
@@ -6,7 +6,6 @@ import com.linkedin.venice.exceptions.QuotaExceededException;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.helix.ZkRoutersClusterManager;
 import com.linkedin.venice.meta.ReadOnlyStoreRepository;
-import com.linkedin.venice.meta.RoutersClusterConfig;
 import com.linkedin.venice.meta.RoutersClusterManager;
 import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.StoreDataChangedListener;
@@ -29,8 +28,8 @@ import org.apache.logging.log4j.Logger;
  * For each read request throttler will ask the related StoreReadThrottler to check both store level quota and storage
  * level quota then accept or reject it.
  */
-public class ReadRequestThrottler implements RouterThrottler, StoreDataChangedListener,
-    RoutersClusterManager.RouterCountChangedListener, RoutersClusterManager.RouterClusterConfigChangedListener {
+public class ReadRequestThrottler
+    implements RouterThrottler, StoreDataChangedListener, RoutersClusterManager.RouterCountChangedListener {
   // We want to give more tight restriction for store-level quota to protect router but more lenient restriction for
   // storage node level quota. Because in some case per-storage node quota is too small to user.
   public static final long DEFAULT_STORE_QUOTA_TIME_WINDOW = TimeUnit.SECONDS.toMillis(10); // 10sec
@@ -303,13 +302,6 @@ public class ReadRequestThrottler implements RouterThrottler, StoreDataChangedLi
 
   private boolean storeHasNoValidVersion(Store store) {
     return store.getCurrentVersion() == NON_EXISTING_VERSION;
-  }
-
-  @Override
-  public void handleRouterClusterConfigChanged(RoutersClusterConfig newConfig) {
-    LOGGER.info("Router cluster config has been changed, reset all throttlers.");
-    resetAllThrottlers();
-    LOGGER.info("All throttlers were reset");
   }
 
   private void resetAllThrottlers() {

--- a/services/venice-router/src/test/java/com/linkedin/venice/router/throttle/ReadRequestThrottlerTest.java
+++ b/services/venice-router/src/test/java/com/linkedin/venice/router/throttle/ReadRequestThrottlerTest.java
@@ -351,34 +351,6 @@ public class ReadRequestThrottlerTest {
     }
   }
 
-  @Test
-  public void testDisableMaxCapacityProtection() {
-    // disable router protection
-    Mockito.doReturn(false).when(zkRoutersClusterManager).isMaxCapacityProtectionEnabled();
-    // Too many router failure, protected the router that guarantee the quota per router will not exceed the max
-    // capacity.
-    routerCount = 1;
-    Mockito.doReturn(routerCount).when(zkRoutersClusterManager).getLiveRoutersCount();
-    throttler.handleRouterClusterConfigChanged(null);
-
-    try {
-      throttler.mayThrottleRead(store.getName(), (int) totalQuota);
-    } catch (QuotaExceededException e) {
-      Assert.fail(
-          "As router protection has been disable. Current usage does not exceed the quota, should not throttle the request.");
-    }
-
-    // enable again
-    Mockito.doReturn(true).when(zkRoutersClusterManager).isMaxCapacityProtectionEnabled();
-    throttler.handleRouterClusterConfigChanged(null);
-    try {
-      throttler.mayThrottleRead(store.getName(), (int) totalQuota * appliedQuotaBuffer);
-      Assert.fail("As router protection has been enabled. Current usage exceeds the quota.");
-    } catch (QuotaExceededException e) {
-      // expected
-    }
-  }
-
   /**
    * We used to get NPEs due to subscribing listeners prior to the end of the constructor. This is a regression test
    * for that issue.


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Add router count change listner in read quota throttler
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Commit https://github.com/linkedin/venice/pull/548/files#diff-a543d0bd2b70372ac582bc358f240ee3507b8c3bf14f9e7c8829fb2e9c0de362 removed the live router count change listener in 'ReadRequestThrottler'  which made router quota susceptible to mismatched quota issues during router instances modifications.
This PR fixes that and add tests to capture this issue.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
integ test.

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.