### PR TITLE
[server] Metric Name fix and math fix for HeartbeatMonitor

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/heartbeat/HeartbeatMonitoringService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/heartbeat/HeartbeatMonitoringService.java
@@ -220,14 +220,15 @@ public class HeartbeatMonitoringService extends AbstractVeniceService {
   }
 
   protected void record() {
+    long currentTime = System.currentTimeMillis();
     recordLags(
         leaderHeartbeatTimeStamps,
         ((storeName, version, region, lag) -> versionStatsReporter
-            .recordLeaderLag(storeName, version, region, System.currentTimeMillis() - lag)));
+            .recordLeaderLag(storeName, version, region, currentTime - lag)));
     recordLags(
         followerHeartbeatTimeStamps,
         ((storeName, version, region, lag) -> versionStatsReporter
-            .recordFollowerLag(storeName, version, region, System.currentTimeMillis() - lag)));
+            .recordFollowerLag(storeName, version, region, currentTime - lag)));
   }
 
   @FunctionalInterface

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/heartbeat/HeartbeatMonitoringService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/heartbeat/HeartbeatMonitoringService.java
@@ -222,10 +222,12 @@ public class HeartbeatMonitoringService extends AbstractVeniceService {
   protected void record() {
     recordLags(
         leaderHeartbeatTimeStamps,
-        ((storeName, version, region, lag) -> versionStatsReporter.recordLeaderLag(storeName, version, region, lag)));
+        ((storeName, version, region, lag) -> versionStatsReporter
+            .recordLeaderLag(storeName, version, region, System.currentTimeMillis() - lag)));
     recordLags(
         followerHeartbeatTimeStamps,
-        ((storeName, version, region, lag) -> versionStatsReporter.recordFollowerLag(storeName, version, region, lag)));
+        ((storeName, version, region, lag) -> versionStatsReporter
+            .recordFollowerLag(storeName, version, region, System.currentTimeMillis() - lag)));
   }
 
   @FunctionalInterface

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/heartbeat/HeartbeatMonitoringService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/heartbeat/HeartbeatMonitoringService.java
@@ -220,20 +220,17 @@ public class HeartbeatMonitoringService extends AbstractVeniceService {
   }
 
   protected void record() {
-    long currentTime = System.currentTimeMillis();
     recordLags(
         leaderHeartbeatTimeStamps,
-        ((storeName, version, region, lag) -> versionStatsReporter
-            .recordLeaderLag(storeName, version, region, currentTime - lag)));
+        ((storeName, version, region, lag) -> versionStatsReporter.recordLeaderLag(storeName, version, region, lag)));
     recordLags(
         followerHeartbeatTimeStamps,
-        ((storeName, version, region, lag) -> versionStatsReporter
-            .recordFollowerLag(storeName, version, region, currentTime - lag)));
+        ((storeName, version, region, lag) -> versionStatsReporter.recordFollowerLag(storeName, version, region, lag)));
   }
 
   @FunctionalInterface
   interface ReportLagFunction {
-    void apply(String storeName, int version, String region, double lag);
+    void apply(String storeName, int version, String region, Long lag);
   }
 
   private class HeartbeatReporterThread extends Thread {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/heartbeat/HeartbeatMonitoringService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/heartbeat/HeartbeatMonitoringService.java
@@ -230,7 +230,7 @@ public class HeartbeatMonitoringService extends AbstractVeniceService {
 
   @FunctionalInterface
   interface ReportLagFunction {
-    void apply(String storeName, int version, String region, Long lag);
+    void apply(String storeName, int version, String region, long lag);
   }
 
   private class HeartbeatReporterThread extends Thread {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/heartbeat/HeartbeatStat.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/heartbeat/HeartbeatStat.java
@@ -29,12 +29,12 @@ public class HeartbeatStat {
     defaultSensor = new WritePathLatencySensor(localRepository, metricConfig, "default-");
   }
 
-  public void recordLeaderLag(String region, Long startTime) {
+  public void recordLeaderLag(String region, long startTime) {
     long endTime = System.currentTimeMillis();
     leaderSensors.computeIfAbsent(region, k -> defaultSensor).record(endTime - startTime, endTime);
   }
 
-  public void recordFollowerLag(String region, Long startTime) {
+  public void recordFollowerLag(String region, long startTime) {
     long endTime = System.currentTimeMillis();
     followerSensors.computeIfAbsent(region, k -> defaultSensor).record(endTime - startTime, endTime);
   }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/heartbeat/HeartbeatStat.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/heartbeat/HeartbeatStat.java
@@ -29,12 +29,14 @@ public class HeartbeatStat {
     defaultSensor = new WritePathLatencySensor(localRepository, metricConfig, "default-");
   }
 
-  public void recordLeaderLag(String region, double lag) {
-    leaderSensors.computeIfAbsent(region, k -> defaultSensor).record(lag, System.currentTimeMillis());
+  public void recordLeaderLag(String region, Long startTime) {
+    long endTime = System.currentTimeMillis();
+    leaderSensors.computeIfAbsent(region, k -> defaultSensor).record(endTime - startTime, endTime);
   }
 
-  public void recordFollowerLag(String region, double lag) {
-    followerSensors.computeIfAbsent(region, k -> defaultSensor).record(lag, System.currentTimeMillis());
+  public void recordFollowerLag(String region, Long startTime) {
+    long endTime = System.currentTimeMillis();
+    followerSensors.computeIfAbsent(region, k -> defaultSensor).record(endTime - startTime, endTime);
   }
 
   public WritePathLatencySensor getLeaderLag(String region) {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/heartbeat/HeartbeatStatReporter.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/heartbeat/HeartbeatStatReporter.java
@@ -7,8 +7,8 @@ import java.util.Set;
 
 
 public class HeartbeatStatReporter extends AbstractVeniceStatsReporter<HeartbeatStat> {
-  private static final String LEADER_METRIC_PREFIX = "--heartbeat_delay_leader-";
-  private static final String FOLLOWER_METRIC_PREFIX = "--heartbeat_delay_follower-";
+  private static final String LEADER_METRIC_PREFIX = "heartbeat_delay_leader-";
+  private static final String FOLLOWER_METRIC_PREFIX = "heartbeat_delay_follower-";
   private static final String MAX = ".Max";
   private static final String AVG = ".Avg";
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/heartbeat/HeartbeatVersionedStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/heartbeat/HeartbeatVersionedStats.java
@@ -16,11 +16,11 @@ public class HeartbeatVersionedStats extends AbstractVeniceAggVersionedStats<Hea
     super(metricsRepository, metadataRepository, statsInitiator, reporterSupplier, true);
   }
 
-  public void recordLeaderLag(String storeName, int version, String region, Long lag) {
+  public void recordLeaderLag(String storeName, int version, String region, long lag) {
     getStats(storeName, version).recordLeaderLag(region, lag);
   }
 
-  public void recordFollowerLag(String storeName, int version, String region, Long lag) {
+  public void recordFollowerLag(String storeName, int version, String region, long lag) {
     getStats(storeName, version).recordFollowerLag(region, lag);
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/heartbeat/HeartbeatVersionedStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/heartbeat/HeartbeatVersionedStats.java
@@ -16,11 +16,11 @@ public class HeartbeatVersionedStats extends AbstractVeniceAggVersionedStats<Hea
     super(metricsRepository, metadataRepository, statsInitiator, reporterSupplier, true);
   }
 
-  public void recordLeaderLag(String storeName, int version, String region, double lag) {
+  public void recordLeaderLag(String storeName, int version, String region, Long lag) {
     getStats(storeName, version).recordLeaderLag(region, lag);
   }
 
-  public void recordFollowerLag(String storeName, int version, String region, double lag) {
+  public void recordFollowerLag(String storeName, int version, String region, Long lag) {
     getStats(storeName, version).recordFollowerLag(region, lag);
   }
 }


### PR DESCRIPTION
## [server] Metric Name fix and math fix for HeartbeatMonitor

The resulting metric name contained an extra set of '--' when being hooked up to the reporter.  Additionally, the metric was reporting the time of the last heartbeat, but not the time SINCE the last heartbeat.

Resolves #XXX

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.