### PR TITLE
[vpj] Bump Apache Spark version to 3.3.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,10 +50,13 @@ def pulsarGroup = 'org.apache.pulsar'
 def pulsarVersion = '2.10.3'
 def alpnAgentVersion = '2.0.10'
 def hadoopVersion = '2.10.2'
-def apacheSparkVersion = '3.1.3'
+def apacheSparkVersion = '3.3.3'
+def antlrVersion = '4.8'
 
 ext.libraries = [
     alpnAgent: "org.mortbay.jetty.alpn:jetty-alpn-agent:${alpnAgentVersion}",
+    antlr4: "org.antlr:antlr4:${antlrVersion}",
+    antlr4Runtime: "org.antlr:antlr4-runtime:${antlrVersion}",
     apacheSparkAvro: "org.apache.spark:spark-avro_2.12:${apacheSparkVersion}",
     apacheSparkCore: "org.apache.spark:spark-core_2.12:${apacheSparkVersion}",
     apacheSparkSql: "org.apache.spark:spark-sql_2.12:${apacheSparkVersion}",

--- a/clients/venice-push-job/build.gradle
+++ b/clients/venice-push-job/build.gradle
@@ -55,6 +55,11 @@ dependencies {
     exclude group: 'org.apache.hadoop', module: 'hadoop-client-api'
   }
 
+  // Spark versions 3.2.X - 3.3.X are compiled with antlr4 4.8. In our classpath, antlr4 version 4.5 is used. This
+  // discrepancy causes errors at runtime.
+  implementation libraries.antlr4
+  implementation libraries.antlr4Runtime
+
   implementation project(':clients:venice-thin-client') // Needed by the KME SchemaReader
 
   implementation libraries.commonsIo


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Bump Apache Spark version to 3.3.3
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
Apache Spark has a critical vulnerability in versions prior to 3.3.3. ([CVE-2023-22946](https://github.com/advisories/GHSA-329j-jfvr-rhr6)). This PR bumps Spark version to 3.3.3 which has a fix for this vulnerability.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
GH CI. Tested manually on test flows

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.