### PR TITLE
[all][build] Force dependency versions that were upgraded transitively by Spark and are known to be bad

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -245,6 +245,17 @@ subprojects {
     }
     all {
       resolutionStrategy.force libraries.zookeeper
+      resolutionStrategy.eachDependency { details ->
+        // Spark pulls in Avro 1.11 which is known to be susceptible to a deadlock bug (AVRO-3243)
+        if (details.requested.group == 'org.apache.avro') {
+          details.useVersion "${avroVersion}"
+        }
+
+        // Spark pulls in log4j 2.17.2 which has a performance regression (LOG4J2-3487)
+        if (details.requested.group == 'org.apache.logging.log4j') {
+          details.useVersion "${log4j2Version}"
+        }
+      }
     }
     avroCompiler {
     }


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Force dependency versions that were upgraded transitively by Spark and are known to be bad
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
In the PR that added Apache Spark, a few dependencies were bumped transitively and some of them are known to have critical issues:
1. Avro 1.11 is known to be susceptible to a deadlock bug ([AVRO-3243](https://issues.apache.org/jira/browse/AVRO-3243))
2. log4j 2.17.2 has a performance regression ([LOG4J2-3487](https://issues.apache.org/jira/browse/LOG4J2-3487))

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
Relying on GH CI

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.