### PR TITLE
[test] Fix flaky TopicManagerE2ETest::testMetadataApisForExistingTopics

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -411,7 +411,6 @@ subprojects {
     }
 
     useTestNG {
-      includeGroups 'smokyBear'
       excludeGroups 'flaky'
       listeners = ['com.linkedin.venice.testng.VeniceSuiteListener']
     }

--- a/build.gradle
+++ b/build.gradle
@@ -411,6 +411,7 @@ subprojects {
     }
 
     useTestNG {
+      includeGroups 'smokyBear'
       excludeGroups 'flaky'
       listeners = ['com.linkedin.venice.testng.VeniceSuiteListener']
     }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/pubsub/manager/TopicManagerE2ETest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/pubsub/manager/TopicManagerE2ETest.java
@@ -270,7 +270,7 @@ public class TopicManagerE2ETest {
     assertEquals(topicManager.getLatestOffsetCached(nonExistentTopic, 1), StatsErrorCode.LAG_MEASUREMENT_FAILURE.code);
   }
 
-  @Test(timeOut = 3 * Time.MS_PER_MINUTE, invocationCount = 50)
+  @Test(timeOut = 3 * Time.MS_PER_MINUTE, invocationCount = 100, groups = "smokyBear")
   public void testMetadataApisForExistingTopics() throws ExecutionException, InterruptedException, TimeoutException {
     int numPartitions = 35;
     int replicationFactor = 1;

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/pubsub/manager/TopicManagerE2ETest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/pubsub/manager/TopicManagerE2ETest.java
@@ -270,7 +270,7 @@ public class TopicManagerE2ETest {
     assertEquals(topicManager.getLatestOffsetCached(nonExistentTopic, 1), StatsErrorCode.LAG_MEASUREMENT_FAILURE.code);
   }
 
-  @Test(timeOut = 3 * Time.MS_PER_MINUTE, invocationCount = 50)
+  @Test(timeOut = 3 * Time.MS_PER_MINUTE)
   public void testMetadataApisForExistingTopics() throws ExecutionException, InterruptedException, TimeoutException {
     int numPartitions = 35;
     int replicationFactor = 1;

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/pubsub/manager/TopicManagerE2ETest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/pubsub/manager/TopicManagerE2ETest.java
@@ -270,7 +270,7 @@ public class TopicManagerE2ETest {
     assertEquals(topicManager.getLatestOffsetCached(nonExistentTopic, 1), StatsErrorCode.LAG_MEASUREMENT_FAILURE.code);
   }
 
-  @Test(timeOut = 3 * Time.MS_PER_MINUTE, invocationCount = 100, groups = "smokyBear")
+  @Test(timeOut = 3 * Time.MS_PER_MINUTE, invocationCount = 50)
   public void testMetadataApisForExistingTopics() throws ExecutionException, InterruptedException, TimeoutException {
     int numPartitions = 35;
     int replicationFactor = 1;

--- a/internal/venice-test-common/src/main/java/com/linkedin/venice/utils/PubSubHelper.java
+++ b/internal/venice-test-common/src/main/java/com/linkedin/venice/utils/PubSubHelper.java
@@ -72,13 +72,15 @@ public class PubSubHelper {
               null)
           .whenComplete((result, throwable) -> {
             if (throwable == null) {
-              message.setOffset(result.getOffset());
-              message.setTimestampAfterProduce(System.currentTimeMillis());
               try {
                 TimeUnit.MILLISECONDS.sleep(delayBetweenMessagesInMs);
               } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
                 throw new RuntimeException(e);
+              } finally {
+                // update the offset and timestamp after produce (and delay) so that each message has a unique timestamp
+                message.setOffset(result.getOffset());
+                message.setTimestampAfterProduce(System.currentTimeMillis());
               }
             }
           })


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Fix flaky TopicManagerE2ETest::testMetadataApisForExistingTopics
This fix ensures that the timestamp used to retrieve `TM::getOffsetByTime`
distinctly identifies messages, preventing collisions that could cause this
test to become flaky.



## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.