### PR TITLE
[venice-server][metrics] Remove period from metric name

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/heartbeat/HeartbeatStatReporter.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/heartbeat/HeartbeatStatReporter.java
@@ -9,8 +9,8 @@ import java.util.Set;
 public class HeartbeatStatReporter extends AbstractVeniceStatsReporter<HeartbeatStat> {
   private static final String LEADER_METRIC_PREFIX = "heartbeat_delay_leader-";
   private static final String FOLLOWER_METRIC_PREFIX = "heartbeat_delay_follower-";
-  private static final String MAX = ".Max";
-  private static final String AVG = ".Avg";
+  private static final String MAX = "-Max";
+  private static final String AVG = "-Avg";
 
   public HeartbeatStatReporter(MetricsRepository metricsRepository, String storeName, Set<String> regions) {
     super(metricsRepository, storeName);


### PR DESCRIPTION
## [venice-server][metrics] Remove period from metric name

This seems to be wreaking some havoc with how Tehuti namespaces metric names.  So replacing it with a '-'.

Resolves #XXX

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.