### PR TITLE
[compat][server][fast-client] Use backend store batch-get limit config

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/DaVinciBackend.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/DaVinciBackend.java
@@ -241,8 +241,6 @@ public class DaVinciBackend implements Closeable {
           clusterInfoProvider,
           storeRepository,
           schemaRepository,
-          Optional.empty(),
-          Optional.empty(),
           null,
           metricsRepository,
           Optional.of(kafkaMessageEnvelopeSchemaReader),

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/isolated/IsolatedIngestionServer.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/isolated/IsolatedIngestionServer.java
@@ -766,8 +766,6 @@ public class IsolatedIngestionServer extends AbstractVeniceService {
         clusterInfoProvider,
         storeRepository,
         schemaRepository,
-        Optional.empty(),
-        Optional.empty(),
         liveConfigRepository,
         metricsRepository,
         Optional.of(kafkaMessageEnvelopeSchemaReader),

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionService.java
@@ -1325,6 +1325,11 @@ public class KafkaStoreIngestionService extends AbstractVeniceService implements
       response.setLatestSuperSetValueSchemaId(latestSuperSetValueSchemaId);
       response.setRoutingInfo(routingInfo);
       response.setHelixGroupInfo(helixGroupInfo);
+      if (store.getBatchGetLimit() > 0) {
+        response.setBatchGetLimit(store.getBatchGetLimit());
+      } else {
+        response.setBatchGetLimit(Store.DEFAULT_BATCH_GET_LIMIT);
+      }
     } catch (VeniceException e) {
       LOGGER.warn("Failed to populate request based metadata for store: {}.", storeName);
       response.setMessage("Failed to populate metadata for store: " + storeName + " due to: " + e.getMessage());

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionService.java
@@ -189,8 +189,6 @@ public class KafkaStoreIngestionService extends AbstractVeniceService implements
   private final ResourceAutoClosableLockManager<String> topicLockManager;
 
   private final PubSubTopicRepository pubSubTopicRepository = new PubSubTopicRepository();
-  private Optional<SSLFactory> sslFactory;
-
   private KafkaValueSerializer kafkaValueSerializer;
 
   public KafkaStoreIngestionService(
@@ -227,7 +225,6 @@ public class KafkaStoreIngestionService extends AbstractVeniceService implements
     this.compressorFactory = compressorFactory;
     // Each topic that has any partition ingested by this class has its own lock.
     this.topicLockManager = new ResourceAutoClosableLockManager<>(ReentrantLock::new);
-    this.sslFactory = sslFactory;
 
     VeniceServerConfig serverConfig = veniceConfigLoader.getVeniceServerConfig();
     Properties veniceWriterProperties =

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionService.java
@@ -5,7 +5,7 @@ import com.linkedin.davinci.config.VeniceStoreVersionConfig;
 import com.linkedin.davinci.helix.LeaderFollowerPartitionStateModel;
 import com.linkedin.davinci.notifier.VeniceNotifier;
 import com.linkedin.davinci.stats.AggVersionedIngestionStats;
-import com.linkedin.davinci.storage.MetadataRetriever;
+import com.linkedin.davinci.storage.IngestionMetadataRetriever;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
@@ -14,7 +14,7 @@ import java.util.concurrent.CompletableFuture;
 /**
  * An interface for Store Ingestion Service for Venice.
  */
-public interface StoreIngestionService extends MetadataRetriever {
+public interface StoreIngestionService extends IngestionMetadataRetriever {
   /**
    * Starts consuming messages from Kafka Partition corresponding to Venice Partition.
    * @param veniceStore Venice Store for the partition.

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/listener/response/MetadataResponse.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/listener/response/MetadataResponse.java
@@ -51,6 +51,10 @@ public class MetadataResponse {
     responseRecord.setHelixGroupInfo(helixGroupInfo);
   }
 
+  public void setBatchGetLimit(int batchGetLimit) {
+    responseRecord.setBatchGetLimit(batchGetLimit);
+  }
+
   public ByteBuf getResponseBody() {
     return Unpooled.wrappedBuffer(serializedResponse());
   }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/HostLevelIngestionStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/HostLevelIngestionStats.java
@@ -132,16 +132,6 @@ public class HostLevelIngestionStats extends AbstractVeniceStats {
   private final LongAdderRateGauge totalTombstoneCreationDCRRate;
 
   /**
-   * Measure the number of time request based metadata endpoint was invoked
-   */
-  private final Sensor requestBasedMetadataInvokeCount;
-
-  /**
-   * Measure the number of time request based metadata endpoint failed to respond
-   */
-  private final Sensor requestBasedMetadataFailureCount;
-
-  /**
    * @param totalStats the total stats singleton instance, or null if we are constructing the total stats
    */
   public HostLevelIngestionStats(
@@ -416,18 +406,6 @@ public class HostLevelIngestionStats extends AbstractVeniceStats {
         totalStats,
         () -> totalStats.leaderIngestionActiveActiveDeleteLatencySensor,
         avgAndMax());
-
-    this.requestBasedMetadataInvokeCount = registerPerStoreAndTotalSensor(
-        "request_based_metadata_invoke_count",
-        totalStats,
-        () -> totalStats.requestBasedMetadataInvokeCount,
-        new Rate());
-
-    this.requestBasedMetadataFailureCount = registerPerStoreAndTotalSensor(
-        "request_based_metadata_failure_count",
-        totalStats,
-        () -> totalStats.requestBasedMetadataFailureCount,
-        new Rate());
   }
 
   /** Record a host-level byte consumption rate across all store versions */
@@ -590,13 +568,5 @@ public class HostLevelIngestionStats extends AbstractVeniceStats {
 
   public void recordOffsetRegressionDCRError() {
     totalOffsetRegressionDCRErrorRate.record();
-  }
-
-  public void recordRequestBasedMetadataInvokeCount() {
-    requestBasedMetadataInvokeCount.record();
-  }
-
-  public void recordRequestBasedMetadataFailureCount() {
-    requestBasedMetadataFailureCount.record();
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ServerMetadataServiceStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ServerMetadataServiceStats.java
@@ -1,0 +1,34 @@
+package com.linkedin.davinci.stats;
+
+import com.linkedin.venice.stats.AbstractVeniceStats;
+import io.tehuti.metrics.MetricsRepository;
+import io.tehuti.metrics.Sensor;
+import io.tehuti.metrics.stats.Rate;
+
+
+public class ServerMetadataServiceStats extends AbstractVeniceStats {
+  /**
+   * Measure the number of time request based metadata endpoint was invoked
+   */
+  private final Sensor requestBasedMetadataInvokeCount;
+
+  /**
+   * Measure the number of time request based metadata endpoint failed to respond
+   */
+  private final Sensor requestBasedMetadataFailureCount;
+
+  public ServerMetadataServiceStats(MetricsRepository metricsRepository) {
+    super(metricsRepository, "ServerMetadataStats");
+
+    this.requestBasedMetadataInvokeCount = registerSensorIfAbsent("request_based_metadata_invoke_count", new Rate());
+    this.requestBasedMetadataFailureCount = registerSensorIfAbsent("request_based_metadata_failure_count", new Rate());
+  }
+
+  public void recordRequestBasedMetadataInvokeCount() {
+    requestBasedMetadataInvokeCount.record();
+  }
+
+  public void recordRequestBasedMetadataFailureCount() {
+    requestBasedMetadataFailureCount.record();
+  }
+}

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/storage/IngestionMetadataRetriever.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/storage/IngestionMetadataRetriever.java
@@ -1,21 +1,15 @@
 package com.linkedin.davinci.storage;
 
 import com.linkedin.davinci.listener.response.AdminResponse;
-import com.linkedin.davinci.listener.response.MetadataResponse;
-import com.linkedin.davinci.listener.response.ServerCurrentVersionResponse;
 import com.linkedin.davinci.listener.response.TopicPartitionIngestionContextResponse;
 import com.linkedin.venice.utils.ComplementSet;
 import java.nio.ByteBuffer;
 
 
-public interface MetadataRetriever {
+public interface IngestionMetadataRetriever {
   ByteBuffer getStoreVersionCompressionDictionary(String topicName);
 
   AdminResponse getConsumptionSnapshots(String topicName, ComplementSet<Integer> partitions);
-
-  MetadataResponse getMetadata(String storeName);
-
-  ServerCurrentVersionResponse getCurrentVersionResponse(String storeName);
 
   TopicPartitionIngestionContextResponse getTopicPartitionIngestionContext(
       String versionTopic,

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/storage/ReadMetadataRetriever.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/storage/ReadMetadataRetriever.java
@@ -1,0 +1,11 @@
+package com.linkedin.davinci.storage;
+
+import com.linkedin.davinci.listener.response.MetadataResponse;
+import com.linkedin.davinci.listener.response.ServerCurrentVersionResponse;
+
+
+public interface ReadMetadataRetriever {
+  MetadataResponse getMetadata(String storeName);
+
+  ServerCurrentVersionResponse getCurrentVersionResponse(String storeName);
+}

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionServiceTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionServiceTest.java
@@ -499,7 +499,6 @@ public abstract class KafkaStoreIngestionServiceTest {
         Optional.empty(),
         null);
     String storeName = "test-store";
-    String otherStoreName = "test-store2";
     Store mockStore = new ZKStore(
         storeName,
         "unit-test",
@@ -538,6 +537,8 @@ public abstract class KafkaStoreIngestionServiceTest {
     Assert.assertEquals(versionProperties.getCurrentVersion(), 2);
     Assert.assertEquals(versionProperties.getPartitionCount(), 1);
     Assert.assertEquals(metadataResponse.getResponseRecord().getRoutingInfo().get("0").size(), 1);
+    // If batch get limit is not set should use {@link Store.DEFAULT_BATCH_GET_LIMIT}
+    Assert.assertEquals(metadataResponse.getResponseRecord().getBatchGetLimit(), Store.DEFAULT_BATCH_GET_LIMIT);
     String metadataInvokeMetricName = "." + storeName + "--request_based_metadata_invoke_count.Rate";
     String metadataFailureMetricName = "." + storeName + "--request_based_metadata_failure_count.Rate";
     Assert.assertTrue(metricsRepository.getMetric(metadataInvokeMetricName).value() > 0);
@@ -548,5 +549,8 @@ public abstract class KafkaStoreIngestionServiceTest {
     Assert.assertNotNull(currentVersionResponse);
     Assert.assertEquals(currentVersionResponse.getCurrentVersion(), 2);
 
+    mockStore.setBatchGetLimit(300);
+    metadataResponse = kafkaStoreIngestionService.getMetadata(storeName);
+    Assert.assertEquals(metadataResponse.getResponseRecord().getBatchGetLimit(), 300);
   }
 }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionServiceTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionServiceTest.java
@@ -19,20 +19,13 @@ import com.linkedin.davinci.config.VeniceClusterConfig;
 import com.linkedin.davinci.config.VeniceConfigLoader;
 import com.linkedin.davinci.config.VeniceServerConfig;
 import com.linkedin.davinci.config.VeniceStoreVersionConfig;
-import com.linkedin.davinci.listener.response.MetadataResponse;
-import com.linkedin.davinci.listener.response.ServerCurrentVersionResponse;
 import com.linkedin.davinci.storage.StorageEngineRepository;
 import com.linkedin.davinci.storage.StorageMetadataService;
 import com.linkedin.davinci.store.AbstractStorageEngine;
 import com.linkedin.davinci.store.AbstractStorageEngineTest;
 import com.linkedin.venice.exceptions.VeniceNoStoreException;
-import com.linkedin.venice.helix.HelixCustomizedViewOfflinePushRepository;
-import com.linkedin.venice.helix.HelixInstanceConfigRepository;
 import com.linkedin.venice.meta.ClusterInfoProvider;
-import com.linkedin.venice.meta.Instance;
 import com.linkedin.venice.meta.OfflinePushStrategy;
-import com.linkedin.venice.meta.Partition;
-import com.linkedin.venice.meta.PartitionAssignment;
 import com.linkedin.venice.meta.PersistenceType;
 import com.linkedin.venice.meta.ReadOnlyLiveClusterConfigRepository;
 import com.linkedin.venice.meta.ReadOnlySchemaRepository;
@@ -44,7 +37,6 @@ import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.meta.VersionImpl;
 import com.linkedin.venice.meta.VersionStatus;
 import com.linkedin.venice.meta.ZKStore;
-import com.linkedin.venice.metadata.response.VersionProperties;
 import com.linkedin.venice.pubsub.PubSubAdminAdapterFactory;
 import com.linkedin.venice.pubsub.PubSubClientsFactory;
 import com.linkedin.venice.pubsub.PubSubConsumerAdapterFactory;
@@ -61,13 +53,10 @@ import com.linkedin.venice.utils.VeniceProperties;
 import io.tehuti.metrics.MetricsRepository;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMaps;
 import it.unimi.dsi.fastutil.objects.Object2IntMaps;
-import java.util.Collections;
-import java.util.List;
 import java.util.NavigableMap;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.function.Function;
 import org.apache.avro.Schema;
@@ -86,8 +75,6 @@ public abstract class KafkaStoreIngestionServiceTest {
   private ClusterInfoProvider mockClusterInfoProvider;
   private ReadOnlyStoreRepository mockMetadataRepo;
   private ReadOnlySchemaRepository mockSchemaRepo;
-  private HelixCustomizedViewOfflinePushRepository mockCustomizedViewRepository;
-  private HelixInstanceConfigRepository mockHelixInstanceConfigRepository;
   private ReadOnlyLiveClusterConfigRepository mockLiveClusterConfigRepo;
   private PubSubClientsFactory mockPubSubClientsFactory;
   private StorageEngineBackedCompressorFactory compressorFactory;
@@ -104,8 +91,6 @@ public abstract class KafkaStoreIngestionServiceTest {
     mockClusterInfoProvider = mock(ClusterInfoProvider.class);
     mockMetadataRepo = mock(ReadOnlyStoreRepository.class);
     mockSchemaRepo = mock(ReadOnlySchemaRepository.class);
-    mockCustomizedViewRepository = mock(HelixCustomizedViewOfflinePushRepository.class);
-    mockHelixInstanceConfigRepository = mock(HelixInstanceConfigRepository.class);
     mockLiveClusterConfigRepo = mock(ReadOnlyLiveClusterConfigRepository.class);
     mockPubSubClientsFactory = new PubSubClientsFactory(
         mock(PubSubProducerAdapterFactory.class),
@@ -164,8 +149,6 @@ public abstract class KafkaStoreIngestionServiceTest {
         mockClusterInfoProvider,
         mockMetadataRepo,
         mockSchemaRepo,
-        Optional.empty(),
-        Optional.empty(),
         mockLiveClusterConfigRepo,
         new MetricsRepository(),
         Optional.empty(),
@@ -250,8 +233,6 @@ public abstract class KafkaStoreIngestionServiceTest {
         mockClusterInfoProvider,
         mockMetadataRepo,
         mockSchemaRepo,
-        Optional.empty(),
-        Optional.empty(),
         mockLiveClusterConfigRepo,
         new MetricsRepository(),
         Optional.empty(),
@@ -340,8 +321,6 @@ public abstract class KafkaStoreIngestionServiceTest {
         mockClusterInfoProvider,
         mockMetadataRepo,
         mockSchemaRepo,
-        Optional.empty(),
-        Optional.empty(),
         mockLiveClusterConfigRepo,
         new MetricsRepository(),
         Optional.empty(),
@@ -407,8 +386,6 @@ public abstract class KafkaStoreIngestionServiceTest {
         mockClusterInfoProvider,
         mockMetadataRepo,
         mockSchemaRepo,
-        Optional.empty(),
-        Optional.empty(),
         mockLiveClusterConfigRepo,
         new MetricsRepository(),
         Optional.empty(),
@@ -468,89 +445,5 @@ public abstract class KafkaStoreIngestionServiceTest {
         spy(storeIngestionTask.aggKafkaConsumerService.createKafkaConsumerService(consumerProperties));
     kafkaStoreIngestionService.getTopicPartitionIngestionContext(topicName, topicName, 0);
     verify(kafkaConsumerService, atMostOnce()).getIngestionInfoFromConsumer(pubSubTopic, pubSubTopicPartition);
-  }
-
-  @Test
-  public void testGetMetadata() {
-    MetricsRepository metricsRepository = new MetricsRepository();
-    kafkaStoreIngestionService = new KafkaStoreIngestionService(
-        mockStorageEngineRepository,
-        mockVeniceConfigLoader,
-        storageMetadataService,
-        mockClusterInfoProvider,
-        mockMetadataRepo,
-        mockSchemaRepo,
-        Optional.of(CompletableFuture.completedFuture(mockCustomizedViewRepository)),
-        Optional.of(CompletableFuture.completedFuture(mockHelixInstanceConfigRepository)),
-        mockLiveClusterConfigRepo,
-        metricsRepository,
-        Optional.empty(),
-        Optional.empty(),
-        AvroProtocolDefinition.PARTITION_STATE.getSerializer(),
-        Optional.empty(),
-        null,
-        false,
-        compressorFactory,
-        Optional.empty(),
-        null,
-        false,
-        null,
-        mockPubSubClientsFactory,
-        Optional.empty(),
-        null);
-    String storeName = "test-store";
-    Store mockStore = new ZKStore(
-        storeName,
-        "unit-test",
-        0,
-        PersistenceType.ROCKS_DB,
-        RoutingStrategy.CONSISTENT_HASH,
-        ReadStrategy.ANY_OF_ONLINE,
-        OfflinePushStrategy.WAIT_ALL_REPLICAS,
-        1);
-    mockStore.addVersion(new VersionImpl(storeName, 1, "test-job-id"));
-    mockStore.addVersion(new VersionImpl(storeName, 2, "test-job-id2"));
-    mockStore.setCurrentVersion(2);
-    String topicName = Version.composeKafkaTopic(storeName, 2);
-    PartitionAssignment partitionAssignment = new PartitionAssignment(topicName, 1);
-    Partition partition = mock(Partition.class);
-    doReturn(0).when(partition).getId();
-    List<Instance> readyToServeInstances = Collections.singletonList(new Instance("host1", "host1", 1234));
-    doReturn(readyToServeInstances).when(partition).getReadyToServeInstances();
-    partitionAssignment.addPartition(partition);
-
-    String schema = "\"string\"";
-    doReturn(mockStore).when(mockMetadataRepo).getStoreOrThrow(storeName);
-    Mockito.when(mockSchemaRepo.getKeySchema(storeName)).thenReturn(new SchemaEntry(0, schema));
-    Mockito.when(mockSchemaRepo.getValueSchemas(storeName))
-        .thenReturn(Collections.singletonList(new SchemaEntry(0, schema)));
-    Mockito.when(mockCustomizedViewRepository.getPartitionAssignments(topicName)).thenReturn(partitionAssignment);
-    Mockito.when(mockHelixInstanceConfigRepository.getInstanceGroupIdMapping()).thenReturn(Collections.emptyMap());
-
-    MetadataResponse metadataResponse = kafkaStoreIngestionService.getMetadata(storeName);
-    Assert.assertNotNull(metadataResponse);
-    Assert.assertEquals(metadataResponse.getResponseRecord().getKeySchema().get("0"), "\"string\"");
-    // Verify the metadata
-    Assert.assertEquals(metadataResponse.getResponseRecord().getVersions().size(), 2);
-    VersionProperties versionProperties = metadataResponse.getResponseRecord().getVersionMetadata();
-    Assert.assertNotNull(versionProperties);
-    Assert.assertEquals(versionProperties.getCurrentVersion(), 2);
-    Assert.assertEquals(versionProperties.getPartitionCount(), 1);
-    Assert.assertEquals(metadataResponse.getResponseRecord().getRoutingInfo().get("0").size(), 1);
-    // If batch get limit is not set should use {@link Store.DEFAULT_BATCH_GET_LIMIT}
-    Assert.assertEquals(metadataResponse.getResponseRecord().getBatchGetLimit(), Store.DEFAULT_BATCH_GET_LIMIT);
-    String metadataInvokeMetricName = "." + storeName + "--request_based_metadata_invoke_count.Rate";
-    String metadataFailureMetricName = "." + storeName + "--request_based_metadata_failure_count.Rate";
-    Assert.assertTrue(metricsRepository.getMetric(metadataInvokeMetricName).value() > 0);
-    Assert.assertEquals(metricsRepository.getMetric(metadataFailureMetricName).value(), 0d);
-
-    ServerCurrentVersionResponse currentVersionResponse =
-        kafkaStoreIngestionService.getCurrentVersionResponse(storeName);
-    Assert.assertNotNull(currentVersionResponse);
-    Assert.assertEquals(currentVersionResponse.getCurrentVersion(), 2);
-
-    mockStore.setBatchGetLimit(300);
-    metadataResponse = kafkaStoreIngestionService.getMetadata(storeName);
-    Assert.assertEquals(metadataResponse.getResponseRecord().getBatchGetLimit(), 300);
   }
 }

--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/ClientConfig.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/ClientConfig.java
@@ -50,10 +50,6 @@ public class ClientConfig<K, V, T extends SpecificRecord> {
   private final long routingErrorRequestCounterResetDelayMS;
   private final long routingUnavailableRequestCounterResetDelayMS;
   private final int routingPendingRequestCounterInstanceBlockThreshold;
-
-  // Max allowed key count in batch-get request
-  private final int maxAllowedKeyCntInBatchGetReq;
-  protected static final int MAX_ALLOWED_KEY_COUNT_IN_BATCHGET = 150;
   private final DaVinciClient<StoreMetaKey, StoreMetaValue> daVinciClientForMetaStore;
   private final AvroSpecificStoreClient<StoreMetaKey, StoreMetaValue> thinClientForMetaStore;
   /**
@@ -108,7 +104,6 @@ public class ClientConfig<K, V, T extends SpecificRecord> {
       long routingErrorRequestCounterResetDelayMS,
       long routingUnavailableRequestCounterResetDelayMS,
       int routingPendingRequestCounterInstanceBlockThreshold,
-      int maxAllowedKeyCntInBatchGetReq,
       DaVinciClient<StoreMetaKey, StoreMetaValue> daVinciClientForMetaStore,
       AvroSpecificStoreClient<StoreMetaKey, StoreMetaValue> thinClientForMetaStore,
       boolean isMetadataConnWarmupEnabled,
@@ -191,8 +186,6 @@ public class ClientConfig<K, V, T extends SpecificRecord> {
     this.routingPendingRequestCounterInstanceBlockThreshold = routingPendingRequestCounterInstanceBlockThreshold > 0
         ? routingPendingRequestCounterInstanceBlockThreshold
         : 50;
-
-    this.maxAllowedKeyCntInBatchGetReq = maxAllowedKeyCntInBatchGetReq;
 
     this.daVinciClientForMetaStore = daVinciClientForMetaStore;
     this.thinClientForMetaStore = thinClientForMetaStore;
@@ -317,10 +310,6 @@ public class ClientConfig<K, V, T extends SpecificRecord> {
     return routingPendingRequestCounterInstanceBlockThreshold;
   }
 
-  public int getMaxAllowedKeyCntInBatchGetReq() {
-    return maxAllowedKeyCntInBatchGetReq;
-  }
-
   public DaVinciClient<StoreMetaKey, StoreMetaValue> getDaVinciClientForMetaStore() {
     return daVinciClientForMetaStore;
   }
@@ -425,12 +414,6 @@ public class ClientConfig<K, V, T extends SpecificRecord> {
     private long routingErrorRequestCounterResetDelayMS = -1;
     private long routingUnavailableRequestCounterResetDelayMS = -1;
     private int routingPendingRequestCounterInstanceBlockThreshold = -1;
-    /**
-     * maxAllowedKeyCntInBatchGetReq is set to {@link #MAX_ALLOWED_KEY_COUNT_IN_BATCHGET}
-     * for fast-client and can be overridden by client config.
-     */
-    private int maxAllowedKeyCntInBatchGetReq = MAX_ALLOWED_KEY_COUNT_IN_BATCHGET;
-
     private DaVinciClient<StoreMetaKey, StoreMetaValue> daVinciClientForMetaStore;
 
     private AvroSpecificStoreClient<StoreMetaKey, StoreMetaValue> thinClientForMetaStore;
@@ -570,11 +553,6 @@ public class ClientConfig<K, V, T extends SpecificRecord> {
       return this;
     }
 
-    public ClientConfigBuilder<K, V, T> setMaxAllowedKeyCntInBatchGetReq(int maxAllowedKeyCntInBatchGetReq) {
-      this.maxAllowedKeyCntInBatchGetReq = maxAllowedKeyCntInBatchGetReq;
-      return this;
-    }
-
     public ClientConfigBuilder<K, V, T> setLongTailRetryEnabledForSingleGet(boolean longTailRetryEnabledForSingleGet) {
       this.longTailRetryEnabledForSingleGet = longTailRetryEnabledForSingleGet;
       return this;
@@ -661,7 +639,6 @@ public class ClientConfig<K, V, T extends SpecificRecord> {
           .setRoutingErrorRequestCounterResetDelayMS(routingErrorRequestCounterResetDelayMS)
           .setRoutingUnavailableRequestCounterResetDelayMS(routingUnavailableRequestCounterResetDelayMS)
           .setRoutingPendingRequestCounterInstanceBlockThreshold(routingPendingRequestCounterInstanceBlockThreshold)
-          .setMaxAllowedKeyCntInBatchGetReq(maxAllowedKeyCntInBatchGetReq)
           .setDaVinciClientForMetaStore(daVinciClientForMetaStore)
           .setThinClientForMetaStore(thinClientForMetaStore)
           .setIsMetadataConnWarmupEnabled(isMetadataConnWarmupEnabled)
@@ -700,7 +677,6 @@ public class ClientConfig<K, V, T extends SpecificRecord> {
           routingErrorRequestCounterResetDelayMS,
           routingUnavailableRequestCounterResetDelayMS,
           routingPendingRequestCounterInstanceBlockThreshold,
-          maxAllowedKeyCntInBatchGetReq,
           daVinciClientForMetaStore,
           thinClientForMetaStore,
           isMetadataConnWarmupEnabled,

--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/DispatchingAvroGenericStoreClient.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/DispatchingAvroGenericStoreClient.java
@@ -416,12 +416,11 @@ public class DispatchingAvroGenericStoreClient<K, V> extends InternalAvroStoreCl
       MultiKeyStreamingRouteResponseHandler routeResponseHandler) {
     verifyMetadataInitialized();
     int keyCnt = keys.size();
-    if (keyCnt > this.config.getMaxAllowedKeyCntInBatchGetReq()) {
-      throw new VeniceKeyCountLimitException(
-          getStoreName(),
-          requestType,
-          keyCnt,
-          this.config.getMaxAllowedKeyCntInBatchGetReq());
+    if (keyCnt > metadata.getBatchGetLimit()) {
+      VeniceKeyCountLimitException veniceKeyCountLimitException =
+          new VeniceKeyCountLimitException(getStoreName(), requestType, keyCnt, metadata.getBatchGetLimit());
+      callback.onCompletion(Optional.of(veniceKeyCountLimitException));
+      return;
     }
 
     /* Prepare each of the routes needed to query the keys */

--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/meta/AbstractStoreMetadata.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/meta/AbstractStoreMetadata.java
@@ -6,6 +6,7 @@ import com.linkedin.venice.compression.CompressionStrategy;
 import com.linkedin.venice.compression.CompressorFactory;
 import com.linkedin.venice.compression.VeniceCompressor;
 import com.linkedin.venice.fastclient.ClientConfig;
+import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.utils.Utils;
 import com.linkedin.venice.utils.concurrent.ChainedCompletableFuture;
 import java.io.IOException;
@@ -91,6 +92,11 @@ public abstract class AbstractStoreMetadata implements StoreMetadata {
   @Override
   public InstanceHealthMonitor getInstanceHealthMonitor() {
     return instanceHealthMonitor;
+  }
+
+  @Override
+  public int getBatchGetLimit() {
+    return Store.DEFAULT_BATCH_GET_LIMIT;
   }
 
   @Override

--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/meta/RequestBasedMetadata.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/meta/RequestBasedMetadata.java
@@ -352,7 +352,7 @@ public class RequestBasedMetadata extends AbstractStoreMetadata {
    * @return if the fetched metadata was an updated version
    */
   synchronized void updateCache(boolean onDemandRefresh) throws InterruptedException {
-    LOGGER.info("Metadata fetch operation for store: {} started", storeName);
+    LOGGER.debug("Metadata fetch operation for store: {} started", storeName);
     long currentTimeMs = System.currentTimeMillis();
     // call the METADATA endpoint
     try {
@@ -453,7 +453,7 @@ public class RequestBasedMetadata extends AbstractStoreMetadata {
       routingStrategy.updateHelixGroupInfo(helixGroupInfo);
       // Update the metadata timestamp only if all updates are successful
       clientStats.updateCacheTimestamp(currentTimeMs);
-      LOGGER.info(
+      LOGGER.debug(
           "Metadata fetch operation for store: {} finished successfully with current version {}.",
           storeName,
           fetchedCurrentVersion);
@@ -526,7 +526,7 @@ public class RequestBasedMetadata extends AbstractStoreMetadata {
     CompletableFuture<TransportClientResponse> metadataFuture = new CompletableFuture<>();
     String url = QueryAction.METADATA.toString().toLowerCase() + "/" + storeName;
 
-    LOGGER.info("Fetching metadata for store {} from URL {} ", storeName, url);
+    LOGGER.debug("Fetching metadata for store {} from URL {} ", storeName, url);
     d2TransportClient.get(url).whenComplete((response, throwable) -> {
       if (throwable != null) {
         String message = String.format("Problem fetching metadata from URL:%s for store:%s ", url, storeName);
@@ -543,7 +543,7 @@ public class RequestBasedMetadata extends AbstractStoreMetadata {
     CompletableFuture<TransportClientResponse> compressionDictionaryFuture = new CompletableFuture<>();
     String url = QueryAction.DICTIONARY.toString().toLowerCase() + "/" + storeName + "/" + version;
 
-    LOGGER.info("Fetching compression dictionary for version {} from URL {} ", version, url);
+    LOGGER.debug("Fetching compression dictionary for version {} from URL {} ", version, url);
     d2TransportClient.get(url).whenComplete((response, throwable) -> {
       if (throwable != null) {
         String message = String.format(

--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/meta/RequestBasedMetadata.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/meta/RequestBasedMetadata.java
@@ -104,6 +104,7 @@ public class RequestBasedMetadata extends AbstractStoreMetadata {
   private final String clusterDiscoveryD2ServiceName;
   private final ClusterStats clusterStats;
   private final FastClientStats clientStats;
+  private final AtomicInteger batchGetLimit = new AtomicInteger();
   private RouterBackedSchemaReader metadataResponseSchemaReader;
   private volatile boolean isServiceDiscovered;
   private volatile boolean isReady;
@@ -364,7 +365,7 @@ public class RequestBasedMetadata extends AbstractStoreMetadata {
           FastSerializerDeserializerFactory.getFastAvroSpecificDeserializer(writerSchema, MetadataResponseRecord.class);
       MetadataResponseRecord metadataResponse = metadataResponseDeserializer.deserialize(body);
       VersionProperties versionMetadata = metadataResponse.getVersionMetadata();
-
+      batchGetLimit.set(metadataResponse.getBatchGetLimit());
       int fetchedCurrentVersion = versionMetadata.getCurrentVersion();
 
       // call the DICTIONARY endpoint if needed
@@ -611,6 +612,11 @@ public class RequestBasedMetadata extends AbstractStoreMetadata {
   @Override
   public boolean isReady() {
     return isReady;
+  }
+
+  @Override
+  public int getBatchGetLimit() {
+    return batchGetLimit.get();
   }
 
   /**

--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/meta/StoreMetadata.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/meta/StoreMetadata.java
@@ -56,6 +56,8 @@ public interface StoreMetadata extends SchemaReader {
 
   VeniceCompressor getCompressor(CompressionStrategy compressionStrategy, int version);
 
+  int getBatchGetLimit();
+
   void start();
 
   default boolean isReady() {

--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/meta/VeniceClientBasedMetadata.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/meta/VeniceClientBasedMetadata.java
@@ -385,7 +385,7 @@ public abstract class VeniceClientBasedMetadata extends AbstractStoreMetadata {
     String route = routes.get(ThreadLocalRandom.current().nextInt(routes.size()));
     String url = route + "/" + QueryAction.DICTIONARY.toString().toLowerCase() + "/" + storeName + "/" + version;
 
-    LOGGER.info("Fetching compression dictionary for version {} from URL {} ", version, url);
+    LOGGER.debug("Fetching compression dictionary for version {} from URL {} ", version, url);
     transportClient.get(url).whenComplete((response, throwable) -> {
       if (throwable != null) {
         String message = String.format(

--- a/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/DualReadAvroGenericStoreClientTest.java
+++ b/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/DualReadAvroGenericStoreClientTest.java
@@ -75,7 +75,6 @@ public class DualReadAvroGenericStoreClientTest {
     doReturn(dualClientStats).when(clientConfig).getStats(RequestType.MULTI_GET_STREAMING);
     doReturn(dualClientStats).when(clientConfig).getStats(RequestType.SINGLE_GET);
     doReturn(thinClient).when(clientConfig).getGenericThinClient();
-    doReturn(2).when(clientConfig).getMaxAllowedKeyCntInBatchGetReq();
 
     if (fastClientThrowExceptionWhenSending) {
       String fcRequestFailException = "Mocked VeniceClientException for fast-client while sending out request";

--- a/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/meta/RequestBasedMetadataTestUtils.java
+++ b/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/meta/RequestBasedMetadataTestUtils.java
@@ -155,7 +155,8 @@ public class RequestBasedMetadataTestUtils {
         Collections.singletonMap("1", storeValueSchema.toString()),
         1,
         routeMap,
-        helixGroupMap);
+        helixGroupMap,
+        150);
 
     byte[] metadataBody = SerializerDeserializerFactory.getAvroGenericSerializer(MetadataResponseRecord.SCHEMA$)
         .serialize(metadataResponse);

--- a/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/utils/TestClientSimulator.java
+++ b/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/utils/TestClientSimulator.java
@@ -531,7 +531,6 @@ public class TestClientSimulator implements Client {
     clientConfigBuilder.setR2Client(this);
     clientConfigBuilder.setMetricsRepository(new MetricsRepository());
     clientConfigBuilder.setSpeculativeQueryEnabled(speculativeQueryEnabled);
-    clientConfigBuilder.setMaxAllowedKeyCntInBatchGetReq(1000);
     if (longTailRetryEnabledForBatchGet) {
       clientConfigBuilder.setLongTailRetryEnabledForBatchGet(true);
       clientConfigBuilder
@@ -624,6 +623,11 @@ public class TestClientSimulator implements Client {
       @Override
       public DerivedSchemaEntry getLatestUpdateSchema() {
         return null;
+      }
+
+      @Override
+      public int getBatchGetLimit() {
+        return 1000;
       }
     };
 

--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/Store.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/Store.java
@@ -39,6 +39,8 @@ public interface Store {
 
   long DEFAULT_RT_RETENTION_TIME = TimeUnit.DAYS.toMillis(5);
 
+  int DEFAULT_BATCH_GET_LIMIT = 150;
+
   /**
    * Store name rules:
    *  1.  Only letters, numbers, underscore or dash

--- a/internal/venice-common/src/main/java/com/linkedin/venice/serialization/avro/AvroProtocolDefinition.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/serialization/avro/AvroProtocolDefinition.java
@@ -168,7 +168,7 @@ public enum AvroProtocolDefinition {
   /**
    * Response record for metadata fetch request.
    */
-  SERVER_METADATA_RESPONSE(1, MetadataResponseRecord.class),
+  SERVER_METADATA_RESPONSE(2, MetadataResponseRecord.class),
 
   /**
    * Value schema for change capture event.

--- a/internal/venice-common/src/main/resources/avro/MetadataResponseRecord/v2/MetadataResponseRecord.avsc
+++ b/internal/venice-common/src/main/resources/avro/MetadataResponseRecord/v2/MetadataResponseRecord.avsc
@@ -1,0 +1,132 @@
+{
+  "type": "record",
+  "name": "MetadataResponseRecord",
+  "namespace": "com.linkedin.venice.metadata.response",
+  "doc": "This record will store version properties, key & value schemas, and routing information",
+  "fields": [
+    {
+      "name": "versionMetadata",
+      "doc": "The current version number and other version properties such as the compression strategy",
+      "type": [
+        "null",
+        {
+          "name": "VersionProperties",
+          "type": "record",
+          "fields": [
+            {
+              "name": "currentVersion",
+              "doc": "Current version number",
+              "type": "int"
+            },
+            {
+              "name": "compressionStrategy",
+              "doc": "The current version's compression strategy. 0 -> NO_OP, 1 -> GZIP, 2 -> ZSTD, 3 -> ZSTD_WITH_DICT",
+              "type": {
+                "name": "CompressionStrategy",
+                "type": "int"
+              }
+            },
+            {
+              "name": "partitionCount",
+              "doc": "Partition count of the current version",
+              "type": "int"
+            },
+            {
+              "name": "partitionerClass",
+              "doc": "Partitioner class name",
+              "type": "string"
+            },
+            {
+              "name": "partitionerParams",
+              "doc": "Partitioner parameters",
+              "type": {
+                "type": "map",
+                "values": "string"
+              }
+            },
+            {
+              "name": "amplificationFactor",
+              "doc": "Partitioner amplification factor",
+              "type": "int"
+            }
+          ]
+        }
+      ],
+      "default": null
+    },
+    {
+      "name": "versions",
+      "doc": "List of all version numbers",
+      "type": {
+        "type": "array",
+        "items": "int"
+      }
+    },
+    {
+      "name": "keySchema",
+      "doc": "Key schema",
+      "type": [
+        "null",
+        {
+          "type": "map",
+          "values": "string"
+        }
+      ],
+      "default": null
+    },
+    {
+      "name": "valueSchemas",
+      "doc": "Value schemas",
+      "type": [
+        "null",
+        {
+          "type": "map",
+          "values": "string"
+        }
+      ],
+      "default": null
+    },
+    {
+      "name": "latestSuperSetValueSchemaId",
+      "doc": "Latest super set value schema ID",
+      "type": [
+        "null",
+        "int"
+      ],
+      "default": null
+    },
+    {
+      "name": "routingInfo",
+      "doc": "Routing table information, maps resource to partition ID to a list of replicas",
+      "type": [
+        "null",
+        {
+          "type": "map",
+          "values": {
+            "type": "array",
+            "items": "string"
+          }
+        }
+      ],
+      "default": null
+    },
+    {
+      "name": "helixGroupInfo",
+      "doc": "Helix group information, maps replicas to their respective groups",
+      "type": [
+        "null",
+        {
+          "type": "map",
+          "values": "int"
+        }
+      ],
+      "default": null
+    },
+    {
+      "name": "batchGetLimit",
+      "doc": "The max key number allowed in a batch get request",
+      "type": "int",
+      "default": 150
+    }
+  ]
+}

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/fastclient/AvroStoreClientEndToEndTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/fastclient/AvroStoreClientEndToEndTest.java
@@ -300,10 +300,6 @@ public class AvroStoreClientEndToEndTest extends AbstractClientEndToEndSetup {
             // this needs to be revisited to see how much this should be set. Current default is 50.
             .setRoutingPendingRequestCounterInstanceBlockThreshold(recordCnt);
 
-    if (batchGet || compute) {
-      clientConfigBuilder.setMaxAllowedKeyCntInBatchGetReq(recordCnt);
-    }
-
     if (enableGrpc) {
       setUpGrpcFastClient(clientConfigBuilder);
     }
@@ -450,10 +446,6 @@ public class AvroStoreClientEndToEndTest extends AbstractClientEndToEndSetup {
 
     ClientConfig.ClientConfigBuilder clientConfigBuilder =
         new ClientConfig.ClientConfigBuilder<>().setStoreName(storeName).setR2Client(r2Client);
-
-    if (batchGet || compute) {
-      clientConfigBuilder.setMaxAllowedKeyCntInBatchGetReq(recordCnt);
-    }
 
     Consumer<MetricsRepository> fastClientStatsValidation;
     if (batchGet) {

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/TestVeniceServer.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/TestVeniceServer.java
@@ -3,7 +3,8 @@ package com.linkedin.venice.integration.utils;
 import com.linkedin.davinci.compression.StorageEngineBackedCompressorFactory;
 import com.linkedin.davinci.config.VeniceServerConfig;
 import com.linkedin.davinci.storage.DiskHealthCheckService;
-import com.linkedin.davinci.storage.MetadataRetriever;
+import com.linkedin.davinci.storage.IngestionMetadataRetriever;
+import com.linkedin.davinci.storage.ReadMetadataRetriever;
 import com.linkedin.davinci.storage.StorageEngineRepository;
 import com.linkedin.venice.acl.DynamicAccessController;
 import com.linkedin.venice.acl.StaticAccessController;
@@ -41,7 +42,8 @@ public class TestVeniceServer extends VeniceServer {
       ReadOnlyStoreRepository storeMetadataRepository,
       ReadOnlySchemaRepository schemaRepository,
       CompletableFuture<HelixCustomizedViewOfflinePushRepository> customizedViewRepository,
-      MetadataRetriever metadataRetriever,
+      IngestionMetadataRetriever ingestionMetadataRetriever,
+      ReadMetadataRetriever readMetadataRetriever,
       VeniceServerConfig serverConfig,
       MetricsRepository metricsRepository,
       Optional<SSLFactory> sslFactory,
@@ -56,7 +58,8 @@ public class TestVeniceServer extends VeniceServer {
         storeMetadataRepository,
         schemaRepository,
         customizedViewRepository,
-        metadataRetriever,
+        ingestionMetadataRetriever,
+        readMetadataRetriever,
         serverConfig,
         metricsRepository,
         sslFactory,
@@ -72,7 +75,8 @@ public class TestVeniceServer extends VeniceServer {
           StorageEngineRepository storageEngineRepository,
           ReadOnlyStoreRepository metadataRepository,
           ReadOnlySchemaRepository schemaRepository,
-          MetadataRetriever metadataRetriever,
+          IngestionMetadataRetriever ingestionMetadataRetriever,
+          ReadMetadataRetriever readMetadataRetriever,
           DiskHealthCheckService diskHealthService,
           boolean fastAvroEnabled,
           boolean parallelBatchGetEnabled,
@@ -86,7 +90,8 @@ public class TestVeniceServer extends VeniceServer {
             storageEngineRepository,
             metadataRepository,
             schemaRepository,
-            metadataRetriever,
+            ingestionMetadataRetriever,
+            readMetadataRetriever,
             diskHealthService,
             fastAvroEnabled,
             parallelBatchGetEnabled,

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/fastclient/grpc/VeniceGrpcEndToEndTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/fastclient/grpc/VeniceGrpcEndToEndTest.java
@@ -145,7 +145,6 @@ public class VeniceGrpcEndToEndTest {
     ClientConfigBuilder<Object, Object, SpecificRecord> clientConfigBuilder =
         new com.linkedin.venice.fastclient.ClientConfig.ClientConfigBuilder<>().setStoreName(storeName)
             .setR2Client(r2Client)
-            .setMaxAllowedKeyCntInBatchGetReq(maxAllowedKeys + 1)
             .setRoutingPendingRequestCounterInstanceBlockThreshold(maxAllowedKeys + 1)
             .setSpeculativeQueryEnabled(false);
 
@@ -197,7 +196,6 @@ public class VeniceGrpcEndToEndTest {
     ClientConfigBuilder<Object, Object, SpecificRecord> clientConfigBuilder =
         new com.linkedin.venice.fastclient.ClientConfig.ClientConfigBuilder<>().setStoreName(storeName)
             .setR2Client(r2Client)
-            .setMaxAllowedKeyCntInBatchGetReq(maxAllowedKeys + 1)
             .setRoutingPendingRequestCounterInstanceBlockThreshold(maxAllowedKeys + 1)
             .setSpeculativeQueryEnabled(false);
 
@@ -205,7 +203,6 @@ public class VeniceGrpcEndToEndTest {
         new com.linkedin.venice.fastclient.ClientConfig.ClientConfigBuilder<>().setStoreName(storeName)
             .setUseGrpc(true)
             .setGrpcClientConfig(grpcClientConfig)
-            .setMaxAllowedKeyCntInBatchGetReq(maxAllowedKeys)
             .setRoutingPendingRequestCounterInstanceBlockThreshold(maxAllowedKeys)
             .setSpeculativeQueryEnabled(false);
 
@@ -261,7 +258,6 @@ public class VeniceGrpcEndToEndTest {
     ClientConfigBuilder<Object, Object, SpecificRecord> clientConfigBuilder =
         new com.linkedin.venice.fastclient.ClientConfig.ClientConfigBuilder<>().setStoreName(storeName)
             .setR2Client(r2Client)
-            .setMaxAllowedKeyCntInBatchGetReq(maxAllowedKeys + 1)
             .setRoutingPendingRequestCounterInstanceBlockThreshold(maxAllowedKeys + 1)
             .setSpeculativeQueryEnabled(false);
 
@@ -269,7 +265,6 @@ public class VeniceGrpcEndToEndTest {
         new com.linkedin.venice.fastclient.ClientConfig.ClientConfigBuilder<>().setStoreName(storeName)
             .setUseGrpc(true)
             .setGrpcClientConfig(grpcClientConfig)
-            .setMaxAllowedKeyCntInBatchGetReq(maxAllowedKeys)
             .setRoutingPendingRequestCounterInstanceBlockThreshold(maxAllowedKeys)
             .setSpeculativeQueryEnabled(false);
 
@@ -309,7 +304,6 @@ public class VeniceGrpcEndToEndTest {
     ClientConfigBuilder<Object, Object, SpecificRecord> clientConfigBuilder =
         new com.linkedin.venice.fastclient.ClientConfig.ClientConfigBuilder<>().setStoreName(storeName)
             .setR2Client(fastR2Client)
-            .setMaxAllowedKeyCntInBatchGetReq(maxAllowedKeys + 1)
             .setRoutingPendingRequestCounterInstanceBlockThreshold(maxAllowedKeys + 1)
             .setSpeculativeQueryEnabled(false);
 
@@ -317,7 +311,6 @@ public class VeniceGrpcEndToEndTest {
         new com.linkedin.venice.fastclient.ClientConfig.ClientConfigBuilder<>().setStoreName(storeName)
             .setUseGrpc(true)
             .setGrpcClientConfig(grpcClientConfig)
-            .setMaxAllowedKeyCntInBatchGetReq(maxAllowedKeys + 1)
             .setRoutingPendingRequestCounterInstanceBlockThreshold(maxAllowedKeys + 1)
             .setSpeculativeQueryEnabled(false);
 

--- a/services/venice-server/src/main/java/com/linkedin/venice/listener/ListenerService.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/listener/ListenerService.java
@@ -3,7 +3,8 @@ package com.linkedin.venice.listener;
 import com.linkedin.davinci.compression.StorageEngineBackedCompressorFactory;
 import com.linkedin.davinci.config.VeniceServerConfig;
 import com.linkedin.davinci.storage.DiskHealthCheckService;
-import com.linkedin.davinci.storage.MetadataRetriever;
+import com.linkedin.davinci.storage.IngestionMetadataRetriever;
+import com.linkedin.davinci.storage.ReadMetadataRetriever;
 import com.linkedin.davinci.storage.StorageEngineRepository;
 import com.linkedin.venice.acl.DynamicAccessController;
 import com.linkedin.venice.acl.StaticAccessController;
@@ -71,7 +72,8 @@ public class ListenerService extends AbstractVeniceService {
       ReadOnlyStoreRepository storeMetadataRepository,
       ReadOnlySchemaRepository schemaRepository,
       CompletableFuture<HelixCustomizedViewOfflinePushRepository> customizedViewRepository,
-      MetadataRetriever metadataRetriever,
+      IngestionMetadataRetriever ingestionMetadataRetriever,
+      ReadMetadataRetriever readMetadataRetriever,
       VeniceServerConfig serverConfig,
       MetricsRepository metricsRepository,
       Optional<SSLFactory> sslFactory,
@@ -112,7 +114,8 @@ public class ListenerService extends AbstractVeniceService {
         storageEngineRepository,
         storeMetadataRepository,
         schemaRepository,
-        metadataRetriever,
+        ingestionMetadataRetriever,
+        readMetadataRetriever,
         diskHealthService,
         serverConfig.isComputeFastAvroEnabled(),
         serverConfig.isEnableParallelBatchGet(),
@@ -226,7 +229,8 @@ public class ListenerService extends AbstractVeniceService {
       StorageEngineRepository storageEngineRepository,
       ReadOnlyStoreRepository metadataRepository,
       ReadOnlySchemaRepository schemaRepository,
-      MetadataRetriever metadataRetriever,
+      IngestionMetadataRetriever ingestionMetadataRetriever,
+      ReadMetadataRetriever readMetadataRetriever,
       DiskHealthCheckService diskHealthService,
       boolean fastAvroEnabled,
       boolean parallelBatchGetEnabled,
@@ -239,7 +243,8 @@ public class ListenerService extends AbstractVeniceService {
         storageEngineRepository,
         metadataRepository,
         schemaRepository,
-        metadataRetriever,
+        ingestionMetadataRetriever,
+        readMetadataRetriever,
         diskHealthService,
         fastAvroEnabled,
         parallelBatchGetEnabled,

--- a/services/venice-server/src/main/java/com/linkedin/venice/listener/ServerReadMetadataRepository.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/listener/ServerReadMetadataRepository.java
@@ -1,0 +1,163 @@
+package com.linkedin.venice.listener;
+
+import com.linkedin.davinci.listener.response.MetadataResponse;
+import com.linkedin.davinci.listener.response.ServerCurrentVersionResponse;
+import com.linkedin.davinci.stats.ServerMetadataServiceStats;
+import com.linkedin.davinci.storage.ReadMetadataRetriever;
+import com.linkedin.venice.exceptions.VeniceException;
+import com.linkedin.venice.helix.HelixCustomizedViewOfflinePushRepository;
+import com.linkedin.venice.helix.HelixInstanceConfigRepository;
+import com.linkedin.venice.meta.Instance;
+import com.linkedin.venice.meta.Partition;
+import com.linkedin.venice.meta.ReadOnlySchemaRepository;
+import com.linkedin.venice.meta.ReadOnlyStoreRepository;
+import com.linkedin.venice.meta.Store;
+import com.linkedin.venice.meta.Version;
+import com.linkedin.venice.metadata.response.VersionProperties;
+import com.linkedin.venice.schema.SchemaEntry;
+import com.linkedin.venice.utils.HelixUtils;
+import io.tehuti.metrics.MetricsRepository;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+
+/**
+ * A wrapper that holds reference for various repositories responsible for constructing metadata responses upon request.
+ */
+public class ServerReadMetadataRepository implements ReadMetadataRetriever {
+  private static final Logger LOGGER = LogManager.getLogger(ServerReadMetadataRepository.class);
+  private final ServerMetadataServiceStats serverMetadataServiceStats;
+  private final ReadOnlyStoreRepository storeRepository;
+  private final ReadOnlySchemaRepository schemaRepository;
+  private HelixCustomizedViewOfflinePushRepository customizedViewRepository;
+  private HelixInstanceConfigRepository helixInstanceConfigRepository;
+
+  public ServerReadMetadataRepository(
+      MetricsRepository metricsRepository,
+      ReadOnlyStoreRepository storeRepository,
+      ReadOnlySchemaRepository schemaRepository,
+      Optional<CompletableFuture<HelixCustomizedViewOfflinePushRepository>> customizedViewFuture,
+      Optional<CompletableFuture<HelixInstanceConfigRepository>> helixInstanceFuture) {
+    this.serverMetadataServiceStats = new ServerMetadataServiceStats(metricsRepository);
+    this.storeRepository = storeRepository;
+    this.schemaRepository = schemaRepository;
+
+    customizedViewFuture.ifPresent(future -> future.thenApply(cv -> this.customizedViewRepository = cv));
+    helixInstanceFuture.ifPresent(future -> future.thenApply(helix -> this.helixInstanceConfigRepository = helix));
+  }
+
+  /**
+   * Return the metadata information for the given store. The data is retrieved from its respective repositories which
+   * originate from the VeniceServer.
+   * @param storeName
+   * @return {@link MetadataResponse} object that holds all the information required for answering a server metadata
+   * fetch request.
+   */
+  @Override
+  public MetadataResponse getMetadata(String storeName) {
+    serverMetadataServiceStats.recordRequestBasedMetadataInvokeCount();
+    MetadataResponse response = new MetadataResponse();
+    try {
+      Store store = storeRepository.getStoreOrThrow(storeName);
+      // Version metadata
+      int currentVersionNumber = store.getCurrentVersion();
+      if (currentVersionNumber == Store.NON_EXISTING_VERSION) {
+        throw new VeniceException(
+            "No valid store version available to read for store: " + storeName
+                + ". Please push data to the store before consuming");
+      }
+      Optional<Version> currentVersionOptional = store.getVersion(currentVersionNumber);
+      if (!currentVersionOptional.isPresent()) {
+        throw new VeniceException(
+            String.format("Current version: %d not found in store: %s", currentVersionNumber, storeName));
+      }
+      Version currentVersion = currentVersionOptional.get();
+      Map<CharSequence, CharSequence> partitionerParams =
+          new HashMap<>(currentVersion.getPartitionerConfig().getPartitionerParams());
+      VersionProperties versionProperties = new VersionProperties(
+          currentVersionNumber,
+          currentVersion.getCompressionStrategy().getValue(),
+          currentVersion.getPartitionCount(),
+          currentVersion.getPartitionerConfig().getPartitionerClass(),
+          partitionerParams,
+          currentVersion.getPartitionerConfig().getAmplificationFactor());
+
+      List<Integer> versions = new ArrayList<>();
+      for (Version v: store.getVersions()) {
+        versions.add(v.getNumber());
+      }
+      // Schema metadata
+      Map<CharSequence, CharSequence> keySchema = Collections.singletonMap(
+          String.valueOf(schemaRepository.getKeySchema(storeName).getId()),
+          schemaRepository.getKeySchema(storeName).getSchema().toString());
+      Map<CharSequence, CharSequence> valueSchemas = new HashMap<>();
+      int latestSuperSetValueSchemaId = store.getLatestSuperSetValueSchemaId();
+      for (SchemaEntry schemaEntry: schemaRepository.getValueSchemas(storeName)) {
+        valueSchemas.put(String.valueOf(schemaEntry.getId()), schemaEntry.getSchema().toString());
+      }
+      // Routing metadata
+      Map<CharSequence, List<CharSequence>> routingInfo = new HashMap<>();
+      String currentVersionResource = Version.composeKafkaTopic(storeName, currentVersionNumber);
+      for (Partition partition: customizedViewRepository.getPartitionAssignments(currentVersionResource)
+          .getAllPartitions()) {
+        List<CharSequence> instances = new ArrayList<>();
+        for (Instance instance: partition.getReadyToServeInstances()) {
+          instances.add(instance.getUrl(true));
+        }
+        routingInfo.put(String.valueOf(partition.getId()), instances);
+      }
+
+      // Helix metadata
+      Map<CharSequence, Integer> helixGroupInfo = new HashMap<>();
+      for (Map.Entry<String, Integer> entry: helixInstanceConfigRepository.getInstanceGroupIdMapping().entrySet()) {
+        helixGroupInfo.put(HelixUtils.instanceIdToUrl(entry.getKey()), entry.getValue());
+      }
+
+      response.setVersionMetadata(versionProperties);
+      response.setVersions(versions);
+      response.setKeySchema(keySchema);
+      response.setValueSchemas(valueSchemas);
+      response.setLatestSuperSetValueSchemaId(latestSuperSetValueSchemaId);
+      response.setRoutingInfo(routingInfo);
+      response.setHelixGroupInfo(helixGroupInfo);
+      if (store.getBatchGetLimit() > 0) {
+        response.setBatchGetLimit(store.getBatchGetLimit());
+      } else {
+        response.setBatchGetLimit(Store.DEFAULT_BATCH_GET_LIMIT);
+      }
+    } catch (VeniceException e) {
+      LOGGER.warn("Failed to populate request based metadata for store: {}.", storeName);
+      response.setMessage("Failed to populate metadata for store: " + storeName + " due to: " + e.getMessage());
+      response.setError(true);
+      serverMetadataServiceStats.recordRequestBasedMetadataFailureCount();
+    }
+    return response;
+  }
+
+  @Override
+  public ServerCurrentVersionResponse getCurrentVersionResponse(String storeName) {
+    ServerCurrentVersionResponse response = new ServerCurrentVersionResponse();
+    try {
+      Store store = storeRepository.getStoreOrThrow(storeName);
+      // Version metadata
+      int currentVersionNumber = store.getCurrentVersion();
+      if (currentVersionNumber == Store.NON_EXISTING_VERSION) {
+        throw new VeniceException(
+            "No valid store version available to read for store: " + storeName
+                + ". Please push data to the store before consuming");
+      }
+      response.setCurrentVersion(currentVersionNumber);
+    } catch (VeniceException e) {
+      response.setMessage("Failed to get current version for store: " + storeName + " due to: " + e.getMessage());
+      response.setError(true);
+    }
+    return response;
+  }
+}

--- a/services/venice-server/src/test/java/com/linkedin/venice/listener/ListenerServiceTest.java
+++ b/services/venice-server/src/test/java/com/linkedin/venice/listener/ListenerServiceTest.java
@@ -6,7 +6,8 @@ import static org.mockito.Mockito.mock;
 import com.linkedin.davinci.compression.StorageEngineBackedCompressorFactory;
 import com.linkedin.davinci.config.VeniceServerConfig;
 import com.linkedin.davinci.storage.DiskHealthCheckService;
-import com.linkedin.davinci.storage.MetadataRetriever;
+import com.linkedin.davinci.storage.IngestionMetadataRetriever;
+import com.linkedin.davinci.storage.ReadMetadataRetriever;
 import com.linkedin.davinci.storage.StorageEngineRepository;
 import com.linkedin.venice.acl.DynamicAccessController;
 import com.linkedin.venice.acl.StaticAccessController;
@@ -28,7 +29,8 @@ public class ListenerServiceTest {
   ReadOnlyStoreRepository storeMetadataRepository;
   ReadOnlySchemaRepository schemaRepository;
   CompletableFuture<HelixCustomizedViewOfflinePushRepository> cvRepository;
-  MetadataRetriever metadataRetriever;
+  IngestionMetadataRetriever ingestionMetadataRetriever;
+  ReadMetadataRetriever readMetadataRetriever;
   VeniceServerConfig serverConfig;
   MetricsRepository metricsRepository;
   Optional<SSLFactory> sslFactory;
@@ -44,7 +46,8 @@ public class ListenerServiceTest {
     storeMetadataRepository = mock(ReadOnlyStoreRepository.class);
     schemaRepository = mock(ReadOnlySchemaRepository.class);
     cvRepository = mock(CompletableFuture.class);
-    metadataRetriever = mock(MetadataRetriever.class);
+    ingestionMetadataRetriever = mock(IngestionMetadataRetriever.class);
+    readMetadataRetriever = mock(ReadMetadataRetriever.class);
     serverConfig = mock(VeniceServerConfig.class);
     metricsRepository = new MetricsRepository();
     sslFactory = Optional.of(mock(SSLFactory.class));
@@ -72,7 +75,8 @@ public class ListenerServiceTest {
         storeMetadataRepository,
         schemaRepository,
         cvRepository,
-        metadataRetriever,
+        ingestionMetadataRetriever,
+        readMetadataRetriever,
         serverConfig,
         metricsRepository,
         sslFactory,

--- a/services/venice-server/src/test/java/com/linkedin/venice/listener/ServerReadMetadataRepositoryTest.java
+++ b/services/venice-server/src/test/java/com/linkedin/venice/listener/ServerReadMetadataRepositoryTest.java
@@ -1,0 +1,114 @@
+package com.linkedin.venice.listener;
+
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+import com.linkedin.davinci.listener.response.MetadataResponse;
+import com.linkedin.davinci.listener.response.ServerCurrentVersionResponse;
+import com.linkedin.venice.helix.HelixCustomizedViewOfflinePushRepository;
+import com.linkedin.venice.helix.HelixInstanceConfigRepository;
+import com.linkedin.venice.meta.Instance;
+import com.linkedin.venice.meta.OfflinePushStrategy;
+import com.linkedin.venice.meta.Partition;
+import com.linkedin.venice.meta.PartitionAssignment;
+import com.linkedin.venice.meta.PersistenceType;
+import com.linkedin.venice.meta.ReadOnlySchemaRepository;
+import com.linkedin.venice.meta.ReadOnlyStoreRepository;
+import com.linkedin.venice.meta.ReadStrategy;
+import com.linkedin.venice.meta.RoutingStrategy;
+import com.linkedin.venice.meta.Store;
+import com.linkedin.venice.meta.Version;
+import com.linkedin.venice.meta.VersionImpl;
+import com.linkedin.venice.meta.ZKStore;
+import com.linkedin.venice.metadata.response.VersionProperties;
+import com.linkedin.venice.schema.SchemaEntry;
+import io.tehuti.metrics.MetricsRepository;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+
+public class ServerReadMetadataRepositoryTest {
+  private ReadOnlyStoreRepository mockMetadataRepo;
+  private ReadOnlySchemaRepository mockSchemaRepo;
+  private HelixCustomizedViewOfflinePushRepository mockCustomizedViewRepository;
+  private HelixInstanceConfigRepository mockHelixInstanceConfigRepository;
+
+  @BeforeMethod
+  public void setUp() {
+    mockMetadataRepo = mock(ReadOnlyStoreRepository.class);
+    mockSchemaRepo = mock(ReadOnlySchemaRepository.class);
+    mockCustomizedViewRepository = mock(HelixCustomizedViewOfflinePushRepository.class);
+    mockHelixInstanceConfigRepository = mock(HelixInstanceConfigRepository.class);
+  }
+
+  @Test
+  public void testGetMetadata() {
+    MetricsRepository metricsRepository = new MetricsRepository();
+    ServerReadMetadataRepository serverReadMetadataRepository = new ServerReadMetadataRepository(
+        metricsRepository,
+        mockMetadataRepo,
+        mockSchemaRepo,
+        Optional.of(CompletableFuture.completedFuture(mockCustomizedViewRepository)),
+        Optional.of(CompletableFuture.completedFuture(mockHelixInstanceConfigRepository)));
+    String storeName = "test-store";
+    Store mockStore = new ZKStore(
+        storeName,
+        "unit-test",
+        0,
+        PersistenceType.ROCKS_DB,
+        RoutingStrategy.CONSISTENT_HASH,
+        ReadStrategy.ANY_OF_ONLINE,
+        OfflinePushStrategy.WAIT_ALL_REPLICAS,
+        1);
+    mockStore.addVersion(new VersionImpl(storeName, 1, "test-job-id"));
+    mockStore.addVersion(new VersionImpl(storeName, 2, "test-job-id2"));
+    mockStore.setCurrentVersion(2);
+    String topicName = Version.composeKafkaTopic(storeName, 2);
+    PartitionAssignment partitionAssignment = new PartitionAssignment(topicName, 1);
+    Partition partition = mock(Partition.class);
+    doReturn(0).when(partition).getId();
+    List<Instance> readyToServeInstances = Collections.singletonList(new Instance("host1", "host1", 1234));
+    doReturn(readyToServeInstances).when(partition).getReadyToServeInstances();
+    partitionAssignment.addPartition(partition);
+
+    String schema = "\"string\"";
+    doReturn(mockStore).when(mockMetadataRepo).getStoreOrThrow(storeName);
+    Mockito.when(mockSchemaRepo.getKeySchema(storeName)).thenReturn(new SchemaEntry(0, schema));
+    Mockito.when(mockSchemaRepo.getValueSchemas(storeName))
+        .thenReturn(Collections.singletonList(new SchemaEntry(0, schema)));
+    Mockito.when(mockCustomizedViewRepository.getPartitionAssignments(topicName)).thenReturn(partitionAssignment);
+    Mockito.when(mockHelixInstanceConfigRepository.getInstanceGroupIdMapping()).thenReturn(Collections.emptyMap());
+
+    MetadataResponse metadataResponse = serverReadMetadataRepository.getMetadata(storeName);
+    Assert.assertNotNull(metadataResponse);
+    Assert.assertEquals(metadataResponse.getResponseRecord().getKeySchema().get("0"), "\"string\"");
+    // Verify the metadata
+    Assert.assertEquals(metadataResponse.getResponseRecord().getVersions().size(), 2);
+    VersionProperties versionProperties = metadataResponse.getResponseRecord().getVersionMetadata();
+    Assert.assertNotNull(versionProperties);
+    Assert.assertEquals(versionProperties.getCurrentVersion(), 2);
+    Assert.assertEquals(versionProperties.getPartitionCount(), 1);
+    Assert.assertEquals(metadataResponse.getResponseRecord().getRoutingInfo().get("0").size(), 1);
+    // If batch get limit is not set should use {@link Store.DEFAULT_BATCH_GET_LIMIT}
+    Assert.assertEquals(metadataResponse.getResponseRecord().getBatchGetLimit(), Store.DEFAULT_BATCH_GET_LIMIT);
+    String metadataInvokeMetricName = ".ServerMetadataStats--request_based_metadata_invoke_count.Rate";
+    String metadataFailureMetricName = ".ServerMetadataStats--request_based_metadata_failure_count.Rate";
+    Assert.assertTrue(metricsRepository.getMetric(metadataInvokeMetricName).value() > 0);
+    Assert.assertEquals(metricsRepository.getMetric(metadataFailureMetricName).value(), 0d);
+
+    ServerCurrentVersionResponse currentVersionResponse =
+        serverReadMetadataRepository.getCurrentVersionResponse(storeName);
+    Assert.assertNotNull(currentVersionResponse);
+    Assert.assertEquals(currentVersionResponse.getCurrentVersion(), 2);
+
+    mockStore.setBatchGetLimit(300);
+    metadataResponse = serverReadMetadataRepository.getMetadata(storeName);
+    Assert.assertEquals(metadataResponse.getResponseRecord().getBatchGetLimit(), 300);
+  }
+}

--- a/services/venice-server/src/test/java/com/linkedin/venice/listener/StorageReadRequestHandlerTest.java
+++ b/services/venice-server/src/test/java/com/linkedin/venice/listener/StorageReadRequestHandlerTest.java
@@ -27,7 +27,8 @@ import com.linkedin.davinci.listener.response.AdminResponse;
 import com.linkedin.davinci.listener.response.MetadataResponse;
 import com.linkedin.davinci.listener.response.TopicPartitionIngestionContextResponse;
 import com.linkedin.davinci.storage.DiskHealthCheckService;
-import com.linkedin.davinci.storage.MetadataRetriever;
+import com.linkedin.davinci.storage.IngestionMetadataRetriever;
+import com.linkedin.davinci.storage.ReadMetadataRetriever;
 import com.linkedin.davinci.storage.StorageEngineRepository;
 import com.linkedin.davinci.store.AbstractStorageEngine;
 import com.linkedin.davinci.store.record.ValueRecord;
@@ -149,7 +150,8 @@ public class StorageReadRequestHandlerTest {
   private final StorageEngineBackedCompressorFactory compressorFactory =
       mock(StorageEngineBackedCompressorFactory.class);
   private final DiskHealthCheckService healthCheckService = mock(DiskHealthCheckService.class);
-  private final MetadataRetriever metadataRetriever = mock(MetadataRetriever.class);
+  private final IngestionMetadataRetriever ingestionMetadataRetriever = mock(IngestionMetadataRetriever.class);
+  private final ReadMetadataRetriever readMetadataRetriever = mock(ReadMetadataRetriever.class);
   private final VeniceServerConfig serverConfig = mock(VeniceServerConfig.class);
   private final VenicePartitioner partitioner = new SimplePartitioner();
   private static final int amplificationFactor = 3;
@@ -180,7 +182,8 @@ public class StorageReadRequestHandlerTest {
         schemaRepository,
         compressorFactory,
         healthCheckService,
-        metadataRetriever,
+        ingestionMetadataRetriever,
+        readMetadataRetriever,
         serverConfig,
         context);
   }
@@ -198,7 +201,8 @@ public class StorageReadRequestHandlerTest {
         storageEngineRepository,
         storeRepository,
         schemaRepository,
-        metadataRetriever,
+        ingestionMetadataRetriever,
+        readMetadataRetriever,
         healthCheckService,
         false,
         parallelBatchGetEnabled,
@@ -379,7 +383,7 @@ public class StorageReadRequestHandlerTest {
         new OffsetRecord(AvroProtocolDefinition.PARTITION_STATE.getSerializer()),
         false);
     expectedAdminResponse.addPartitionConsumptionState(state);
-    doReturn(expectedAdminResponse).when(metadataRetriever).getConsumptionSnapshots(eq(topic), any());
+    doReturn(expectedAdminResponse).when(ingestionMetadataRetriever).getConsumptionSnapshots(eq(topic), any());
 
     StorageReadRequestHandler requestHandler = createStorageReadRequestHandler();
     requestHandler.channelRead(context, request);
@@ -413,7 +417,7 @@ public class StorageReadRequestHandlerTest {
         + "      \"elapsedTimeSinceLastPollInMs\" : 7\n" + "    }\n" + "  }\n" + "}";
     byte[] expectedTopicPartitionContext = jsonStr.getBytes();
     expectedTopicPartitionIngestionContextResponse.setTopicPartitionIngestionContext(expectedTopicPartitionContext);
-    doReturn(expectedTopicPartitionIngestionContextResponse).when(metadataRetriever)
+    doReturn(expectedTopicPartitionIngestionContextResponse).when(ingestionMetadataRetriever)
         .getTopicPartitionIngestionContext(eq(topic), eq(topic), eq(expectedPartitionId));
 
     StorageReadRequestHandler requestHandler = createStorageReadRequestHandler();
@@ -454,7 +458,7 @@ public class StorageReadRequestHandlerTest {
     expectedMetadataResponse.setVersionMetadata(versionProperties);
     expectedMetadataResponse.setKeySchema(keySchema);
     expectedMetadataResponse.setValueSchemas(valueSchemas);
-    doReturn(expectedMetadataResponse).when(metadataRetriever).getMetadata(eq(storeName));
+    doReturn(expectedMetadataResponse).when(readMetadataRetriever).getMetadata(eq(storeName));
 
     StorageReadRequestHandler requestHandler = createStorageReadRequestHandler();
     requestHandler.channelRead(context, testRequest);


### PR DESCRIPTION
## [compat][server][fast-client] Use backend store batch-get limit config
1. Removed fast-client side config maxAllowedKeyCntInBatchGetReq. Use the store config value set for batchGetLimit instead to avoid confusion and reduce toil. Default value set to 150.

2. Fast-client will still fail fast for requests that exceeded the limit. However, the exception will now be thrown when the caller calls get() on the future instead of during request construction for better error handling/logging for use cases where venice client is used through another intermediate plateform or library.

3. Evolved MetadataResponseRecord protocol to v2 to include batchGetLimit field. All existing running fast-client uses request based metadata and are on a version that supports forward compatibility so the change should be safe.

4. Split MetadataRetriever into IngestionMetadataRetriever and ReadMetadataRetriever to move read metadata handling out of the already crowded KafkaStoreIngestionService. 

## How was this PR tested?
New and existing unit + integration tests.

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.