### PR TITLE
Update bootstrappingVeniceChangelogConsumer with sync offset and allow multi-consumers

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/ChangelogClientConfig.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/ChangelogClientConfig.java
@@ -19,8 +19,10 @@ public class ChangelogClientConfig<T extends SpecificRecord> {
   private int controllerRequestRetryCount;
 
   private String bootstrapFileSystemPath;
-
   private long versionSwapDetectionIntervalTimeInMs = 600000L;
+
+  // Default is 32 MB
+  private long databaseSyncBytesInterval = 33554432;
 
   public ChangelogClientConfig(String storeName) {
     this.innerClientConfig = new ClientConfig<>(storeName);
@@ -142,6 +144,15 @@ public class ChangelogClientConfig<T extends SpecificRecord> {
     return this;
   }
 
+  public long getDatabaseSyncBytesInterval() {
+    return databaseSyncBytesInterval;
+  }
+
+  public ChangelogClientConfig setDatabaseSyncBytesInterval(long databaseSyncBytesInterval) {
+    this.databaseSyncBytesInterval = databaseSyncBytesInterval;
+    return this;
+  }
+
   public static <V extends SpecificRecord> ChangelogClientConfig<V> cloneConfig(ChangelogClientConfig<V> config) {
     ChangelogClientConfig<V> newConfig = new ChangelogClientConfig<V>().setStoreName(config.getStoreName())
         .setLocalD2ZkHosts(config.getLocalD2ZkHosts())
@@ -154,7 +165,8 @@ public class ChangelogClientConfig<T extends SpecificRecord> {
         .setD2Client(config.getD2Client())
         .setControllerRequestRetryCount(config.getControllerRequestRetryCount())
         .setBootstrapFileSystemPath(config.getBootstrapFileSystemPath())
-        .setVersionSwapDetectionIntervalTimeInMs(config.getVersionSwapDetectionIntervalTimeInMs());
+        .setVersionSwapDetectionIntervalTimeInMs(config.getVersionSwapDetectionIntervalTimeInMs())
+        .setDatabaseSyncBytesInterval(config.getDatabaseSyncBytesInterval());
     return newConfig;
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/ChangelogClientConfig.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/ChangelogClientConfig.java
@@ -21,7 +21,10 @@ public class ChangelogClientConfig<T extends SpecificRecord> {
   private String bootstrapFileSystemPath;
   private long versionSwapDetectionIntervalTimeInMs = 600000L;
 
-  // Default is 32 MB
+  /**
+   * This will be used in BootstrappingVeniceChangelogConsumer to determine when to sync updates with the underlying
+   * storage engine, e.g. flushes entity and offset data to disk. Default is 32 MB.
+   */
   private long databaseSyncBytesInterval = 33554432;
 
   public ChangelogClientConfig(String storeName) {
@@ -144,10 +147,16 @@ public class ChangelogClientConfig<T extends SpecificRecord> {
     return this;
   }
 
+  /**
+   * Gets the databaseSyncBytesInterval.
+   */
   public long getDatabaseSyncBytesInterval() {
     return databaseSyncBytesInterval;
   }
 
+  /**
+   * Sets the value for databaseSyncBytesInterval.
+   */
   public ChangelogClientConfig setDatabaseSyncBytesInterval(long databaseSyncBytesInterval) {
     this.databaseSyncBytesInterval = databaseSyncBytesInterval;
     return this;

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/InternalLocalBootstrappingVeniceChangelogConsumer.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/InternalLocalBootstrappingVeniceChangelogConsumer.java
@@ -547,14 +547,23 @@ class InternalLocalBootstrappingVeniceChangelogConsumer<K, V> extends VeniceChan
       return currentPubSubPosition.comparePosition(targetPubSubPosition) > -1;
     }
 
+    /**
+     * Resets the processed record size.
+     */
     public void resetProcessedRecordSizeSinceLastSync() {
       this.processedRecordSizeSinceLastSync = 0;
     }
 
+    /**
+     * Gets the current processed record size since last sync.
+     */
     public long getProcessedRecordSizeSinceLastSync() {
       return this.processedRecordSizeSinceLastSync;
     }
 
+    /**
+     * Increases the processed record size since last sync.
+     */
     public void incrementProcessedRecordSizeSinceLastSync(int recordSize) {
       this.processedRecordSizeSinceLastSync += recordSize;
     }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/LocalBootstrappingVeniceChangelogConsumer.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/LocalBootstrappingVeniceChangelogConsumer.java
@@ -15,7 +15,8 @@ public class LocalBootstrappingVeniceChangelogConsumer<K, V>
     extends InternalLocalBootstrappingVeniceChangelogConsumer<K, V> {
   public LocalBootstrappingVeniceChangelogConsumer(
       ChangelogClientConfig changelogClientConfig,
-      PubSubConsumerAdapter pubSubConsumer) {
-    super(changelogClientConfig, pubSubConsumer);
+      PubSubConsumerAdapter pubSubConsumer,
+      String consumerId) {
+    super(changelogClientConfig, pubSubConsumer, consumerId);
   }
 }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/InternalLocalBootstrappingVeniceChangelogConsumerTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/InternalLocalBootstrappingVeniceChangelogConsumerTest.java
@@ -107,7 +107,7 @@ public class InternalLocalBootstrappingVeniceChangelogConsumerTest {
   private static final int TEST_PARTITION_ID_2 = 2;
   private static final long TEST_OFFSET_OLD = 1L;
   private static final long TEST_OFFSET_NEW = 2L;
-  private static final long TEST_DB_SYNC_BYTES_INTERVAL = 10L;
+  private static final long TEST_DB_SYNC_BYTES_INTERVAL = 1000L;
   private String storeName;
   private String localStateTopicName;
   private InternalLocalBootstrappingVeniceChangelogConsumer<Utf8, Utf8> bootstrappingVeniceChangelogConsumer;
@@ -349,7 +349,7 @@ public class InternalLocalBootstrappingVeniceChangelogConsumerTest {
   public void testProcessRecordBytes_SyncOffsetAndUpdatesBootstrapStateMap() throws IOException {
     byte[] key = "key".getBytes();
     // Value size is > TEST_DB_SYNC_BYTES_INTERVAL
-    byte[] valueBytes = "valuevaluevalue".getBytes();
+    byte[] valueBytes = new byte[1001];
     ByteBuffer value = mock(ByteBuffer.class);
     when(value.array()).thenReturn(valueBytes);
     RecordDeserializer deserializer = mock(RecordDeserializer.class);

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestActiveActiveIngestion.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestActiveActiveIngestion.java
@@ -31,6 +31,7 @@ import static com.linkedin.venice.utils.IntegrationTestPushUtils.sendStreamingRe
 import static com.linkedin.venice.utils.TestUtils.generateInput;
 import static com.linkedin.venice.utils.TestWriteUtils.getTempDataDirectory;
 
+import com.google.common.collect.ImmutableSet;
 import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
 import com.linkedin.davinci.consumer.BootstrappingVeniceChangelogConsumer;
 import com.linkedin.davinci.consumer.ChangeEvent;
@@ -1311,6 +1312,146 @@ public class TestActiveActiveIngestion {
       // Since nothing is produced, so no changed events generated.
       TestUtils.waitForNonDeterministicAssertion(5, TimeUnit.SECONDS, true, () -> {
         pollChangeEventsFromChangeCaptureConsumer2(polledChangeEvents, bootstrappingVeniceChangelogConsumer);
+        Assert.assertEquals(polledChangeEvents.size(), 0);
+      });
+
+      // Verify total updates match up
+      TestUtils.waitForNonDeterministicAssertion(
+          5,
+          TimeUnit.SECONDS,
+          () -> Assert.assertEquals(TestView.getInstance().getRecordCountForStore(storeName), 21));
+      parentControllerClient.disableAndDeleteStore(storeName);
+      // Verify that topics and store is cleaned up
+      TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, true, () -> {
+        MultiStoreTopicsResponse storeTopicsResponse = childControllerClient.getDeletableStoreTopics();
+        Assert.assertFalse(storeTopicsResponse.isError());
+        Assert.assertEquals(storeTopicsResponse.getTopics().size(), 0);
+      });
+    }
+  }
+
+  @Test(timeOut = TEST_TIMEOUT, priority = 3)
+  public void testBootstrappingVeniceChangelogConsumer_MultiConsumersWithPollAndCatchUp() throws Exception {
+    ControllerClient childControllerClient =
+        new ControllerClient(clusterName, childDatacenters.get(0).getControllerConnectString());
+    // create a active-active enabled store and run batch push job
+    // batch job contains 100 records
+    File inputDir = getTempDataDirectory();
+    Schema recordSchema = TestWriteUtils.writeSimpleAvroFileWithStringToStringSchema(inputDir);
+    String inputDirPath = "file:" + inputDir.getAbsolutePath();
+    String storeName = Utils.getUniqueString("store");
+    Properties props =
+        TestWriteUtils.defaultVPJProps(parentControllers.get(0).getControllerUrl(), inputDirPath, storeName);
+    String keySchemaStr = recordSchema.getField(DEFAULT_KEY_FIELD_PROP).schema().toString();
+    String valueSchemaStr = recordSchema.getField(DEFAULT_VALUE_FIELD_PROP).schema().toString();
+    Map<String, String> viewConfig = new HashMap<>();
+    viewConfig.put(
+        "testView",
+        "{\"viewClassName\" : \"" + TestView.class.getCanonicalName() + "\", \"viewParameters\" : {}}");
+
+    viewConfig.put(
+        "changeCaptureView",
+        "{\"viewClassName\" : \"" + ChangeCaptureView.class.getCanonicalName() + "\", \"viewParameters\" : {}}");
+    UpdateStoreQueryParams storeParms = new UpdateStoreQueryParams().setActiveActiveReplicationEnabled(true)
+        .setHybridRewindSeconds(500)
+        .setHybridOffsetLagThreshold(8)
+        .setChunkingEnabled(true)
+        .setNativeReplicationEnabled(true)
+        .setPartitionCount(3);
+    MetricsRepository metricsRepository = new MetricsRepository();
+    ControllerClient setupControllerClient =
+        createStoreForJob(clusterName, keySchemaStr, valueSchemaStr, props, storeParms);
+    storeParms.setStoreViews(viewConfig);
+    // IntegrationTestPushUtils.updateStore(clusterName, props, storeParms);
+    setupControllerClient
+        .retryableRequest(5, controllerClient1 -> setupControllerClient.updateStore(storeName, storeParms));
+    // controllerClient.updateStore(storeName, storeParms);
+    TestWriteUtils.runPushJob("Run push job", props);
+    Map<String, String> samzaConfig = getSamzaConfig(storeName);
+    VeniceSystemFactory factory = new VeniceSystemFactory();
+    // Use a unique key for DELETE with RMD validation
+    int deleteWithRmdKeyIndex = 1000;
+
+    TestMockTime testMockTime = new TestMockTime();
+    ZkServerWrapper localZkServer = multiRegionMultiClusterWrapper.getChildRegions().get(0).getZkServerWrapper();
+    try (PubSubBrokerWrapper localKafka = ServiceFactory.getPubSubBroker(
+        new PubSubBrokerConfigs.Builder().setZkWrapper(localZkServer)
+            .setMockTime(testMockTime)
+            .setRegionName("local-pubsub")
+            .build())) {
+      Properties consumerProperties = new Properties();
+      String localKafkaUrl = localKafka.getAddress();
+      consumerProperties.put(KAFKA_BOOTSTRAP_SERVERS, localKafkaUrl);
+      consumerProperties.put(CLUSTER_NAME, clusterName);
+      consumerProperties.put(ZOOKEEPER_ADDRESS, localZkServer.getAddress());
+      ChangelogClientConfig globalChangelogClientConfig = new ChangelogClientConfig().setViewName("changeCaptureView")
+          .setConsumerProperties(consumerProperties)
+          .setControllerD2ServiceName(D2_SERVICE_NAME)
+          .setD2ServiceName(VeniceRouterWrapper.CLUSTER_DISCOVERY_D2_SERVICE_NAME)
+          .setLocalD2ZkHosts(localZkServer.getAddress())
+          .setControllerRequestRetryCount(3)
+          .setBootstrapFileSystemPath(Utils.getUniqueString(inputDirPath))
+          .setDatabaseSyncBytesInterval(100);
+      VeniceChangelogConsumerClientFactory veniceChangelogConsumerClientFactory =
+          new VeniceChangelogConsumerClientFactory(globalChangelogClientConfig, metricsRepository);
+
+      BootstrappingVeniceChangelogConsumer<Utf8, Utf8> bootstrappingVeniceChangelogConsumer_1 =
+          veniceChangelogConsumerClientFactory.getBootstrappingChangelogConsumer(storeName, "1");
+      BootstrappingVeniceChangelogConsumer<Utf8, Utf8> bootstrappingVeniceChangelogConsumer_2 =
+          veniceChangelogConsumerClientFactory.getBootstrappingChangelogConsumer(storeName, "2");
+      BootstrappingVeniceChangelogConsumer<Utf8, Utf8> bootstrappingVeniceChangelogConsumer_3 =
+          veniceChangelogConsumerClientFactory.getBootstrappingChangelogConsumer(storeName, "3");
+      try (VeniceSystemProducer veniceProducer =
+          factory.getClosableProducer("venice", new MapConfig(samzaConfig), null)) {
+        veniceProducer.start();
+        // Run Samza job to send PUT and DELETE requests.
+        runSamzaStreamJob(veniceProducer, storeName, null, 10, 10, 100);
+        // Produce a DELETE record with large timestamp
+        produceRecordWithLogicalTimestamp(veniceProducer, storeName, deleteWithRmdKeyIndex, 1000, true);
+      }
+
+      try (AvroGenericStoreClient<String, Utf8> client = ClientFactory.getAndStartGenericAvroClient(
+          ClientConfig.defaultGenericClientConfig(storeName)
+              .setVeniceURL(clusterWrapper.getRandomRouterURL())
+              .setMetricsRepository(metricsRepository))) {
+        TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, true, () -> {
+          Assert.assertNull(client.get(Integer.toString(deleteWithRmdKeyIndex)).get());
+        });
+      }
+
+      // Wait for 10 seconds so bootstrap can load results from kafka
+      Utils.sleep(10000);
+      bootstrappingVeniceChangelogConsumer_1.start(ImmutableSet.of(0)).get();
+      bootstrappingVeniceChangelogConsumer_2.start(ImmutableSet.of(1)).get();
+      bootstrappingVeniceChangelogConsumer_3.start(ImmutableSet.of(2)).get();
+      Map<String, PubSubMessage<Utf8, ChangeEvent<Utf8>, VeniceChangeCoordinate>> polledChangeEvents = new HashMap<>();
+
+      // 21 changes in nearline. 10 puts, 10 deletes and 1 delete with timestamp will be ignored and 1 end of bootstrap
+      TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, true, () -> {
+        pollChangeEventsFromChangeCaptureConsumer(polledChangeEvents, bootstrappingVeniceChangelogConsumer_1);
+        pollChangeEventsFromChangeCaptureConsumer(polledChangeEvents, bootstrappingVeniceChangelogConsumer_2);
+        pollChangeEventsFromChangeCaptureConsumer(polledChangeEvents, bootstrappingVeniceChangelogConsumer_3);
+        Assert.assertEquals(polledChangeEvents.size(), 11);
+
+        for (int i = 100; i < 110; i++) {
+          String key = Integer.toString(i);
+          ChangeEvent<Utf8> changeEvent = polledChangeEvents.get(key).getValue();
+          Assert.assertNotNull(changeEvent);
+          Assert.assertNull(changeEvent.getPreviousValue());
+          Assert.assertEquals(changeEvent.getCurrentValue().toString(), "stream_" + i);
+        }
+
+        Assert.assertTrue(polledChangeEvents.containsKey(null));
+        Assert.assertTrue(polledChangeEvents.get(null).isEndOfBootstrap());
+      });
+
+      polledChangeEvents.clear();
+
+      // Since nothing is produced, so no changed events generated.
+      TestUtils.waitForNonDeterministicAssertion(5, TimeUnit.SECONDS, true, () -> {
+        pollChangeEventsFromChangeCaptureConsumer2(polledChangeEvents, bootstrappingVeniceChangelogConsumer_1);
+        pollChangeEventsFromChangeCaptureConsumer2(polledChangeEvents, bootstrappingVeniceChangelogConsumer_2);
+        pollChangeEventsFromChangeCaptureConsumer2(polledChangeEvents, bootstrappingVeniceChangelogConsumer_3);
         Assert.assertEquals(polledChangeEvents.size(), 0);
       });
 


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

[changelog][BootstrappingVeniceChangelogConsumer] Update bootstrappingVeniceChangelogConsumer to sync offset during processing and allow multi-consumers with different consumer id.

## Summary, imperative, start upper case, don't end with a period
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

- Update bootstrappingVeniceChangelogConsumer to sync offset during processing when processedRecordSizeSinceLastSync > databaseSyncBytesInterval.
- Add consumerId in the bootstrappingVeniceChangelogConsumer constructor so we can allow multi-consumers creation. Each consumer will have its own state, rocksDB path, etc.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
- unit test
- integration test

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.