### PR TITLE
[vpj] Kill Spark job only when SparkContext is not closed. Handle exceptions gracefully

### DIFF
--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
@@ -2779,7 +2779,7 @@ public class VenicePushJob implements AutoCloseable {
       }
       runningJob.killJob();
     } catch (Exception ex) {
-      // Will try to kill Venice Offline Push Job no matter whether map-reduce job kill throws exception or not.
+      // Will try to kill Venice Offline Push Job no matter whether map-reduce job kill throws an exception or not.
       LOGGER.info(
           "Received exception while killing map-reduce job with name {} and ID {}",
           runningJob.getJobName(),
@@ -2793,7 +2793,17 @@ public class VenicePushJob implements AutoCloseable {
       LOGGER.warn("No op to kill a null data writer job");
       return;
     }
-    dataWriterComputeJob.kill();
+    try {
+      ComputeJob.Status jobStatus = dataWriterComputeJob.getStatus();
+      if (jobStatus.isTerminal()) {
+        LOGGER.warn("No op to kill a compute job in a terminal state: {}", jobStatus);
+        return;
+      }
+      dataWriterComputeJob.kill();
+    } catch (Exception ex) {
+      // Will try to kill Venice Offline Push Job no matter whether the compute job kill throws an exception or not.
+      LOGGER.info("Received exception while killing data writer job", ex);
+    }
   }
 
   // Visible for testing

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/jobs/ComputeJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/jobs/ComputeJob.java
@@ -11,17 +11,27 @@ import java.io.IOException;
 public interface ComputeJob extends Closeable {
   enum Status {
     /** A job that has not started execution yet */
-    NOT_STARTED,
+    NOT_STARTED(false),
     /** A job that is currently executing */
-    RUNNING,
+    RUNNING(false),
     /** A job that has completed execution successfully */
-    SUCCEEDED,
+    SUCCEEDED(true),
     /** A job that failed during it's execution */
-    FAILED,
+    FAILED(true),
     /** A job that has completed execution but failed verification */
-    FAILED_VERIFICATION,
+    FAILED_VERIFICATION(true),
     /** A job that was killed */
-    KILLED
+    KILLED(true);
+
+    private final boolean isTerminal;
+
+    Status(boolean terminal) {
+      this.isTerminal = terminal;
+    }
+
+    public boolean isTerminal() {
+      return isTerminal;
+    }
   }
 
   void configure(VeniceProperties properties);

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/spark/datawriter/jobs/AbstractDataWriterSparkJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/spark/datawriter/jobs/AbstractDataWriterSparkJob.java
@@ -376,7 +376,14 @@ public abstract class AbstractDataWriterSparkJob extends DataWriterComputeJob {
   @Override
   public void kill() {
     super.kill();
-    sparkSession.sparkContext().cancelJobGroup(jobGroupId);
+    if (sparkSession == null) {
+      return;
+    }
+
+    SparkContext sparkContext = sparkSession.sparkContext();
+    if (!sparkContext.isStopped()) {
+      sparkContext.cancelJobGroup(jobGroupId);
+    }
   }
 
   @Override


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Kill Spark job only when `SparkContext` is not closed. Handle exceptions gracefully
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
1. Kill `DataWriterComputeJob` from VPJ only when it is in a non-terminal state.
2. Kill Spark job only when `SparkContext` is not closed. Spark doesn't allow performing operations when the `SparkContext` is not running.
3. Handle exceptions thrown by `DataWriterComputeJob#kill` gracefully.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
GH CI. Tested manually on test flows

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.