### PR TITLE
[all] Fix an infinite recursion issue in VeniceWriter

### DIFF
--- a/internal/venice-common/src/main/java/com/linkedin/venice/kafka/validation/Segment.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/kafka/validation/Segment.java
@@ -407,4 +407,9 @@ public class Segment {
     }
     return deduped;
   }
+
+  // Only for testing.
+  public void setStarted(boolean started) {
+    this.started = started;
+  }
 }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/writer/VeniceWriterTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/writer/VeniceWriterTest.java
@@ -260,23 +260,21 @@ public class VeniceWriterTest {
                 new VeniceWriterOptions.Builder(topicName).setUseKafkaKeySerializer(true)
                     .setPartitionCount(partitionCount)
                     .build())) {
-      try {
-        Segment seg = veniceWriter.getSegment(0, false);
-        seg.setStarted(false);
+      Segment seg = veniceWriter.getSegment(0, false);
+      seg.setStarted(false);
 
-        // Verify that segment is neither started nor ended.
-        assertFalse(seg.isStarted());
-        assertFalse(seg.isEnded());
+      // Verify that segment is neither started nor ended.
+      assertFalse(seg.isStarted());
+      assertFalse(seg.isEnded());
 
-        // Sleep for 1.1 seconds to make sure the elapsed time for the segment is greater than
-        // MAX_ELAPSED_TIME_FOR_SEGMENT_IN_MS.
-        Thread.sleep(1100);
+      // Sleep for 1.1 seconds to make sure the elapsed time for the segment is greater than
+      // MAX_ELAPSED_TIME_FOR_SEGMENT_IN_MS.
+      Thread.sleep(1100);
 
-        // Send an SOS control message to the topic and it should not cause StackOverflowError.
-        veniceWriter.sendStartOfSegment(0, null);
-      } catch (Throwable t) {
-        Assert.fail("VeniceWriter should not cause stack overflow", t);
-      }
+      // Send an SOS control message to the topic and it should not cause StackOverflowError.
+      veniceWriter.sendStartOfSegment(0, null);
+    } catch (Throwable t) {
+      Assert.fail("VeniceWriter should not cause stack overflow", t);
     }
   }
 }


### PR DESCRIPTION
Today, VeniceWriter (VW) has a bug to run into an infinite recursion when it sends a message in the VeniceWriter and eventually it throws StackOverflowError. For a particular partition, the conditions to trigger the issue are:

1. VW has a cached Segment
2. The segment is neither started nor ended
3. The elapsed time for the segment is greater than MAX_ELAPSED_TIME_FOR_SEGMENT_IN_MS

To fix it, we can break the infinite loop by always recording the new start time.

## How was this PR tested?
GH action

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.