### PR TITLE
[server][metrics] Add filtering to heartbeat versioned stats for hybrid stores

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/AbstractVeniceAggVersionedStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/AbstractVeniceAggVersionedStats.java
@@ -50,7 +50,7 @@ public abstract class AbstractVeniceAggVersionedStats<STATS, STATS_REPORTER exte
     loadAllStats();
   }
 
-  public final synchronized void loadAllStats() {
+  public synchronized void loadAllStats() {
     metadataRepository.getAllStores().forEach(store -> {
       addStore(store.getName());
       updateStatsVersionInfo(store.getName(), store.getVersions(), store.getCurrentVersion());
@@ -85,7 +85,7 @@ public abstract class AbstractVeniceAggVersionedStats<STATS, STATS_REPORTER exte
     return stats;
   }
 
-  private VeniceVersionedStats<STATS, STATS_REPORTER> addStore(String storeName) {
+  protected VeniceVersionedStats<STATS, STATS_REPORTER> addStore(String storeName) {
     return aggStats.computeIfAbsent(
         storeName,
         s -> new VeniceVersionedStats<>(metricsRepository, storeName, statsInitiator, reporterSupplier));

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/heartbeat/HeartbeatMonitoringService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/heartbeat/HeartbeatMonitoringService.java
@@ -65,7 +65,7 @@ public class HeartbeatMonitoringService extends AbstractVeniceService {
         () -> new HeartbeatStat(new MetricConfig(), regionNames),
         (aMetricsRepository, s) -> new HeartbeatStatReporter(aMetricsRepository, s, regionNames),
         leaderHeartbeatTimeStamps,
-        leaderHeartbeatTimeStamps);
+        followerHeartbeatTimeStamps);
   }
 
   private synchronized void initializeEntry(

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/heartbeat/HeartbeatMonitoringService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/heartbeat/HeartbeatMonitoringService.java
@@ -63,7 +63,8 @@ public class HeartbeatMonitoringService extends AbstractVeniceService {
         metricsRepository,
         metadataRepository,
         () -> new HeartbeatStat(new MetricConfig(), regionNames),
-        (aMetricsRepository, s) -> new HeartbeatStatReporter(aMetricsRepository, s, regionNames));
+        (aMetricsRepository, s) -> new HeartbeatStatReporter(aMetricsRepository, s, regionNames),
+        this);
   }
 
   private synchronized void initializeEntry(
@@ -231,6 +232,12 @@ public class HeartbeatMonitoringService extends AbstractVeniceService {
   @FunctionalInterface
   interface ReportLagFunction {
     void apply(String storeName, int version, String region, long lag);
+  }
+
+  Set<String> getReportedStores() {
+    Set<String> monitoredStores = leaderHeartbeatTimeStamps.keySet();
+    monitoredStores.addAll(followerHeartbeatTimeStamps.keySet());
+    return monitoredStores;
   }
 
   private class HeartbeatReporterThread extends Thread {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/heartbeat/HeartbeatMonitoringService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/heartbeat/HeartbeatMonitoringService.java
@@ -95,12 +95,12 @@ public class HeartbeatMonitoringService extends AbstractVeniceService {
       Map<String, Map<Integer, Map<Integer, Map<String, Long>>>> heartbeatTimestamps,
       Version version,
       int partition) {
-    heartbeatTimestamps.computeIfPresent(version.getStoreName(), (storeKey, map1) -> {
-      map1.computeIfPresent(version.getNumber(), (versionKey, map2) -> {
-        map2.remove(partition);
-        return map2;
+    heartbeatTimestamps.computeIfPresent(version.getStoreName(), (storeKey, versionMap) -> {
+      versionMap.computeIfPresent(version.getNumber(), (versionKey, partitionMap) -> {
+        partitionMap.remove(partition);
+        return partitionMap;
       });
-      return map1;
+      return versionMap;
     });
   }
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/heartbeat/HeartbeatMonitoringService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/heartbeat/HeartbeatMonitoringService.java
@@ -64,7 +64,8 @@ public class HeartbeatMonitoringService extends AbstractVeniceService {
         metadataRepository,
         () -> new HeartbeatStat(new MetricConfig(), regionNames),
         (aMetricsRepository, s) -> new HeartbeatStatReporter(aMetricsRepository, s, regionNames),
-        this);
+        leaderHeartbeatTimeStamps,
+        leaderHeartbeatTimeStamps);
   }
 
   private synchronized void initializeEntry(
@@ -231,12 +232,6 @@ public class HeartbeatMonitoringService extends AbstractVeniceService {
   @FunctionalInterface
   interface ReportLagFunction {
     void apply(String storeName, int version, String region, long lag);
-  }
-
-  Set<String> getReportedStores() {
-    Set<String> monitoredStores = leaderHeartbeatTimeStamps.keySet();
-    monitoredStores.addAll(followerHeartbeatTimeStamps.keySet());
-    return monitoredStores;
   }
 
   private class HeartbeatReporterThread extends Thread {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/heartbeat/HeartbeatStatReporter.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/heartbeat/HeartbeatStatReporter.java
@@ -7,8 +7,8 @@ import java.util.Set;
 
 
 public class HeartbeatStatReporter extends AbstractVeniceStatsReporter<HeartbeatStat> {
-  private static final String LEADER_METRIC_PREFIX = "heartbeat_delay_leader-";
-  private static final String FOLLOWER_METRIC_PREFIX = "heartbeat_delay_follower-";
+  private static final String LEADER_METRIC_PREFIX = "heartbeat_delay_ms_leader-";
+  private static final String FOLLOWER_METRIC_PREFIX = "heartbeat_delay_ms_follower-";
   private static final String MAX = ".Max";
   private static final String AVG = ".Avg";
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/heartbeat/HeartbeatVersionedStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/heartbeat/HeartbeatVersionedStats.java
@@ -12,8 +12,8 @@ import java.util.function.Supplier;
 
 
 public class HeartbeatVersionedStats extends AbstractVeniceAggVersionedStats<HeartbeatStat, HeartbeatStatReporter> {
-  private Map<String, Map<Integer, Map<Integer, Map<String, Long>>>> leaderMonitors;
-  private Map<String, Map<Integer, Map<Integer, Map<String, Long>>>> followerMonitors;
+  private final Map<String, Map<Integer, Map<Integer, Map<String, Long>>>> leaderMonitors;
+  private final Map<String, Map<Integer, Map<Integer, Map<String, Long>>>> followerMonitors;
 
   public HeartbeatVersionedStats(
       MetricsRepository metricsRepository,

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/heartbeat/HeartbeatVersionedStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/heartbeat/HeartbeatVersionedStats.java
@@ -40,9 +40,7 @@ public class HeartbeatVersionedStats extends AbstractVeniceAggVersionedStats<Hea
 
   @Override
   public void handleStoreCreated(Store store) {
-    if (isStoreAssignedToThisNode(store.getName())) {
-      addStore(store.getName());
-    }
+    // No-op
   }
 
   @Override

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/heartbeat/HeartbeatVersionedStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/heartbeat/HeartbeatVersionedStats.java
@@ -35,12 +35,7 @@ public class HeartbeatVersionedStats extends AbstractVeniceAggVersionedStats<Hea
 
   @Override
   public synchronized void loadAllStats() {
-    metadataRepository.getAllStores().forEach(store -> {
-      if (isStoreAssignedToThisNode(store.getName())) {
-        addStore(store.getName());
-        updateStatsVersionInfo(store.getName(), store.getVersions(), store.getCurrentVersion());
-      }
-    });
+    // No-op
   }
 
   @Override

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/heartbeat/HeartbeatVersionedStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/heartbeat/HeartbeatVersionedStats.java
@@ -5,6 +5,7 @@ import com.linkedin.venice.meta.ReadOnlyStoreRepository;
 import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.stats.StatsSupplier;
 import io.tehuti.metrics.MetricsRepository;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Supplier;
@@ -62,6 +63,11 @@ public class HeartbeatVersionedStats extends AbstractVeniceAggVersionedStats<Hea
   }
 
   Set<String> getReportedStores() {
+    if (leaderMonitors == null || followerMonitors == null) {
+      // TODO: We have to do this because theres a self call in the constructor
+      // of the superclass of this class. We shouldn't have to do this
+      return Collections.EMPTY_SET;
+    }
     Set<String> monitoredStores = leaderMonitors.keySet();
     monitoredStores.addAll(followerMonitors.keySet());
     return monitoredStores;

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/heartbeat/HeartbeatVersionedStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/heartbeat/HeartbeatVersionedStats.java
@@ -2,18 +2,24 @@ package com.linkedin.davinci.stats.ingestion.heartbeat;
 
 import com.linkedin.davinci.stats.AbstractVeniceAggVersionedStats;
 import com.linkedin.venice.meta.ReadOnlyStoreRepository;
+import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.stats.StatsSupplier;
 import io.tehuti.metrics.MetricsRepository;
+import java.util.Set;
 import java.util.function.Supplier;
 
 
 public class HeartbeatVersionedStats extends AbstractVeniceAggVersionedStats<HeartbeatStat, HeartbeatStatReporter> {
+  private HeartbeatMonitoringService monitoringService;
+
   public HeartbeatVersionedStats(
       MetricsRepository metricsRepository,
       ReadOnlyStoreRepository metadataRepository,
       Supplier<HeartbeatStat> statsInitiator,
-      StatsSupplier<HeartbeatStatReporter> reporterSupplier) {
+      StatsSupplier<HeartbeatStatReporter> reporterSupplier,
+      HeartbeatMonitoringService monitoringService) {
     super(metricsRepository, metadataRepository, statsInitiator, reporterSupplier, true);
+    this.monitoringService = monitoringService;
   }
 
   public void recordLeaderLag(String storeName, int version, String region, long lag) {
@@ -22,5 +28,32 @@ public class HeartbeatVersionedStats extends AbstractVeniceAggVersionedStats<Hea
 
   public void recordFollowerLag(String storeName, int version, String region, long lag) {
     getStats(storeName, version).recordFollowerLag(region, lag);
+  }
+
+  @Override
+  public synchronized void loadAllStats() {
+    Set<String> stores = monitoringService.getReportedStores();
+    metadataRepository.getAllStores().forEach(store -> {
+      if (stores.contains(store.getName())) {
+        addStore(store.getName());
+        updateStatsVersionInfo(store.getName(), store.getVersions(), store.getCurrentVersion());
+      }
+    });
+  }
+
+  @Override
+  public void handleStoreCreated(Store store) {
+    Set<String> stores = monitoringService.getReportedStores();
+    if (stores.contains(store.getName())) {
+      addStore(store.getName());
+    }
+  }
+
+  @Override
+  public void handleStoreChanged(Store store) {
+    Set<String> stores = monitoringService.getReportedStores();
+    if (stores.contains(store)) {
+      updateStatsVersionInfo(store.getName(), store.getVersions(), store.getCurrentVersion());
+    }
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/heartbeat/HeartbeatVersionedStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/heartbeat/HeartbeatVersionedStats.java
@@ -5,21 +5,25 @@ import com.linkedin.venice.meta.ReadOnlyStoreRepository;
 import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.stats.StatsSupplier;
 import io.tehuti.metrics.MetricsRepository;
+import java.util.Map;
 import java.util.Set;
 import java.util.function.Supplier;
 
 
 public class HeartbeatVersionedStats extends AbstractVeniceAggVersionedStats<HeartbeatStat, HeartbeatStatReporter> {
-  private HeartbeatMonitoringService monitoringService;
+  private Map<String, Map<Integer, Map<Integer, Map<String, Long>>>> leaderMonitors;
+  private Map<String, Map<Integer, Map<Integer, Map<String, Long>>>> followerMonitors;
 
   public HeartbeatVersionedStats(
       MetricsRepository metricsRepository,
       ReadOnlyStoreRepository metadataRepository,
       Supplier<HeartbeatStat> statsInitiator,
       StatsSupplier<HeartbeatStatReporter> reporterSupplier,
-      HeartbeatMonitoringService monitoringService) {
+      Map<String, Map<Integer, Map<Integer, Map<String, Long>>>> leaderMonitors,
+      Map<String, Map<Integer, Map<Integer, Map<String, Long>>>> followerMonitors) {
     super(metricsRepository, metadataRepository, statsInitiator, reporterSupplier, true);
-    this.monitoringService = monitoringService;
+    this.leaderMonitors = leaderMonitors;
+    this.followerMonitors = followerMonitors;
   }
 
   public void recordLeaderLag(String storeName, int version, String region, long lag) {
@@ -32,7 +36,7 @@ public class HeartbeatVersionedStats extends AbstractVeniceAggVersionedStats<Hea
 
   @Override
   public synchronized void loadAllStats() {
-    Set<String> stores = monitoringService.getReportedStores();
+    Set<String> stores = getReportedStores();
     metadataRepository.getAllStores().forEach(store -> {
       if (stores.contains(store.getName())) {
         addStore(store.getName());
@@ -43,7 +47,7 @@ public class HeartbeatVersionedStats extends AbstractVeniceAggVersionedStats<Hea
 
   @Override
   public void handleStoreCreated(Store store) {
-    Set<String> stores = monitoringService.getReportedStores();
+    Set<String> stores = getReportedStores();
     if (stores.contains(store.getName())) {
       addStore(store.getName());
     }
@@ -51,9 +55,15 @@ public class HeartbeatVersionedStats extends AbstractVeniceAggVersionedStats<Hea
 
   @Override
   public void handleStoreChanged(Store store) {
-    Set<String> stores = monitoringService.getReportedStores();
-    if (stores.contains(store)) {
+    Set<String> stores = getReportedStores();
+    if (stores.contains(store.getName())) {
       updateStatsVersionInfo(store.getName(), store.getVersions(), store.getCurrentVersion());
     }
+  }
+
+  Set<String> getReportedStores() {
+    Set<String> monitoredStores = leaderMonitors.keySet();
+    monitoredStores.addAll(followerMonitors.keySet());
+    return monitoredStores;
   }
 }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/ingestion/heartbeat/HeartbeatMonitoringServiceTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/ingestion/heartbeat/HeartbeatMonitoringServiceTest.java
@@ -60,6 +60,8 @@ public class HeartbeatMonitoringServiceTest {
     // Let's emit some heartbeats that don't exist in the registry yet
     heartbeatMonitoringService.recordLeaderHeartbeat(TEST_STORE, 1, 0, LOCAL_FABRIC, 1000L);
     heartbeatMonitoringService.recordFollowerHeartbeat(TEST_STORE, 2, 0, LOCAL_FABRIC, 1000L);
+    // and throw a null at it too for good measure
+    heartbeatMonitoringService.recordFollowerHeartbeat(TEST_STORE, 2, 0, null, 1000L);
 
     // Since we haven't gotten a signal to handle these heartbeats, we discard them.
     Assert.assertNull(heartbeatMonitoringService.getLeaderHeartbeatTimeStamps().get(TEST_STORE));


### PR DESCRIPTION
## [server][metrics] Add filtering to heartbeat versioned stats for hybrid stores

VersionedStats assumes all metrics should be applied for all stores.  This change overrides methods which add stats to check to see if the node should report metrics for the store getting added or not.

Resolves #XXX

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.