### PR TITLE
[vpj] Handle extra null default in ETL+VPJ value schema

### DIFF
--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/recordreader/avro/TestVeniceAvroRecordReader.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/recordreader/avro/TestVeniceAvroRecordReader.java
@@ -1,12 +1,27 @@
 package com.linkedin.venice.hadoop.recordreader.avro;
 
+import static com.linkedin.venice.etl.ETLValueSchemaTransformation.ADD_NULL_TO_UNION;
+import static com.linkedin.venice.etl.ETLValueSchemaTransformation.NONE;
+import static com.linkedin.venice.etl.ETLValueSchemaTransformation.UNIONIZE_WITH_NULL;
+import static com.linkedin.venice.hadoop.VenicePushJobConstants.DEFAULT_KEY_FIELD_PROP;
+import static com.linkedin.venice.hadoop.VenicePushJobConstants.DEFAULT_VALUE_FIELD_PROP;
+import static com.linkedin.venice.utils.DataProviderUtils.BOOLEAN;
+import static com.linkedin.venice.utils.TestWriteUtils.INT_SCHEMA;
 import static com.linkedin.venice.utils.TestWriteUtils.NAME_RECORD_V2_SCHEMA;
+import static com.linkedin.venice.utils.TestWriteUtils.STRING_SCHEMA;
 import static com.linkedin.venice.utils.TestWriteUtils.STRING_TO_NAME_RECORD_V1_SCHEMA;
 
+import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
+import com.linkedin.avroutil1.compatibility.RandomRecordGenerator;
 import com.linkedin.venice.etl.ETLValueSchemaTransformation;
 import com.linkedin.venice.hadoop.input.recordreader.avro.VeniceAvroRecordReader;
 import com.linkedin.venice.schema.writecompute.WriteComputeSchemaConverter;
+import com.linkedin.venice.utils.DataProviderUtils;
+import com.linkedin.venice.utils.RandomGenUtils;
 import com.linkedin.venice.utils.TestWriteUtils;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
@@ -14,19 +29,24 @@ import org.apache.avro.generic.IndexedRecord;
 import org.apache.avro.mapred.AvroWrapper;
 import org.apache.hadoop.io.NullWritable;
 import org.testng.Assert;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 
 public class TestVeniceAvroRecordReader {
+  private static final RandomRecordGenerator RANDOM_RECORD_GENERATOR = new RandomRecordGenerator();
+  private static final Object[] ETL_TRANSFORMATIONS = { NONE, ADD_NULL_TO_UNION, UNIONIZE_WITH_NULL };
+
+  @DataProvider(name = "Boolean-and-EtlTransformations")
+  public static Object[][] booleanAndEtlTransformations() {
+    return DataProviderUtils.allPermutationGenerator(BOOLEAN, ETL_TRANSFORMATIONS);
+  }
+
   @Test
   public void testGeneratePartialUpdate() {
     Schema updateSchema = WriteComputeSchemaConverter.getInstance().convertFromValueRecordSchema(NAME_RECORD_V2_SCHEMA);
-    VeniceAvroRecordReader recordReader = new VeniceAvroRecordReader(
-        STRING_TO_NAME_RECORD_V1_SCHEMA,
-        "key",
-        "value",
-        ETLValueSchemaTransformation.NONE,
-        updateSchema);
+    VeniceAvroRecordReader recordReader =
+        new VeniceAvroRecordReader(STRING_TO_NAME_RECORD_V1_SCHEMA, "key", "value", NONE, updateSchema);
 
     GenericRecord record = new GenericData.Record(STRING_TO_NAME_RECORD_V1_SCHEMA);
     record.put("key", "123");
@@ -42,5 +62,79 @@ public class TestVeniceAvroRecordReader {
     Assert.assertEquals(
         ((IndexedRecord) result).get(updateSchema.getField("age").pos()),
         new GenericData.Record(updateSchema.getField("age").schema().getTypes().get(0)));
+  }
+
+  @Test(dataProvider = "Boolean-and-EtlTransformations")
+  public void testRecordReaderForETLInput(
+      boolean nullDefaultValue,
+      ETLValueSchemaTransformation etlValueSchemaTransformation) {
+    Schema keySchema = STRING_SCHEMA;
+
+    Schema valueSchema;
+    switch (etlValueSchemaTransformation) {
+      case NONE:
+        valueSchema = Schema.createUnion(Arrays.asList(INT_SCHEMA, STRING_SCHEMA, Schema.create(Schema.Type.NULL)));
+        break;
+      case ADD_NULL_TO_UNION:
+        valueSchema = Schema.createUnion(Arrays.asList(INT_SCHEMA, STRING_SCHEMA));
+        break;
+      case UNIONIZE_WITH_NULL:
+        valueSchema = INT_SCHEMA;
+        break;
+      default:
+        throw new IllegalArgumentException("Invalid ETL Value schema transformation: " + etlValueSchemaTransformation);
+    }
+
+    Schema fileSchema;
+    if (nullDefaultValue) {
+      fileSchema = TestWriteUtils.getETLFileSchemaWithNullDefaultValue(keySchema, valueSchema);
+    } else {
+      fileSchema = TestWriteUtils.getETLFileSchema(keySchema, valueSchema);
+    }
+    ETLValueSchemaTransformation inferredEtlTransformation = ETLValueSchemaTransformation.fromSchema(valueSchema);
+    Assert.assertEquals(inferredEtlTransformation, etlValueSchemaTransformation);
+
+    VeniceAvroRecordReader recordReader = new VeniceAvroRecordReader(
+        fileSchema,
+        DEFAULT_KEY_FIELD_PROP,
+        DEFAULT_VALUE_FIELD_PROP,
+        etlValueSchemaTransformation,
+        null);
+
+    Schema dummyValueRecordSchema = Schema.createRecord(
+        "valueWrapper",
+        null,
+        null,
+        false,
+        Collections.singletonList(
+            AvroCompatibilityHelper.newField(null).setName(DEFAULT_VALUE_FIELD_PROP).setSchema(valueSchema).build()));
+    for (int i = 0; i < 10; i++) {
+      Object key = RANDOM_RECORD_GENERATOR.randomGeneric(keySchema);
+      Object value;
+      if (i == 0) {
+        value = null;
+      } else {
+        // RandomRecordGenerator cannot handle union schemas. So, we need to create a dummy record to generate a value.
+        value = ((GenericRecord) RANDOM_RECORD_GENERATOR.randomGeneric(dummyValueRecordSchema))
+            .get(DEFAULT_VALUE_FIELD_PROP);
+      }
+
+      GenericRecord record = generateRandomEtlRecord(fileSchema, key, value);
+      Object extractedValue = recordReader.getAvroValue(new AvroWrapper<>(record), NullWritable.get());
+
+      Assert.assertEquals(value, extractedValue);
+    }
+  }
+
+  private GenericRecord generateRandomEtlRecord(Schema fileSchema, Object key, Object value) {
+    GenericRecord record = new GenericData.Record(fileSchema);
+    record.put(DEFAULT_KEY_FIELD_PROP, key);
+    record.put(DEFAULT_VALUE_FIELD_PROP, value);
+
+    record.put("offset", (long) RandomGenUtils.getRandomIntWithin(Integer.MAX_VALUE));
+    record.put("DELETED_TS", null);
+    record.put("metadata", new HashMap<>());
+
+    return record;
   }
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/etl/ETLUtils.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/etl/ETLUtils.java
@@ -50,26 +50,19 @@ public class ETLUtils {
   public static Schema getValueSchemaFromETLValueSchema(
       Schema etlValueSchema,
       ETLValueSchemaTransformation transformation) {
-    Schema pushValueSchema;
-
     switch (transformation) {
       case UNIONIZE_WITH_NULL:
-        pushValueSchema = VsonAvroSchemaAdapter.stripFromUnion(etlValueSchema);
-        break;
+        return VsonAvroSchemaAdapter.stripFromUnion(etlValueSchema);
       case ADD_NULL_TO_UNION:
         List<Schema> schemasInUnion = etlValueSchema.getTypes();
         List<Schema> nullStrippedUnionSchema = schemasInUnion.stream()
             .filter(schema -> !schema.getType().equals(Schema.Type.NULL))
             .collect(Collectors.toList());
-        pushValueSchema = Schema.createUnion(nullStrippedUnionSchema);
-        break;
+        return Schema.createUnion(nullStrippedUnionSchema);
       case NONE:
-        pushValueSchema = etlValueSchema;
-        break;
+        return etlValueSchema;
       default:
         throw new VeniceException("Invalid ETL Value schema transformation: " + transformation);
     }
-
-    return pushValueSchema;
   }
 }

--- a/internal/venice-test-common/src/main/java/com/linkedin/venice/utils/TestWriteUtils.java
+++ b/internal/venice-test-common/src/main/java/com/linkedin/venice/utils/TestWriteUtils.java
@@ -65,7 +65,7 @@ import org.testng.Assert;
 
 
 public class TestWriteUtils {
-  public static final Logger LOGGER = LogManager.getLogger(TestWriteUtils.class);
+  private static final Logger LOGGER = LogManager.getLogger(TestWriteUtils.class);
   public static final int DEFAULT_USER_DATA_RECORD_COUNT = 100;
   public static final String DEFAULT_USER_DATA_VALUE_PREFIX = "test_name_";
 
@@ -716,7 +716,7 @@ public class TestWriteUtils {
     return writeAvroFile(
         parentDir,
         fileName,
-        getETLStoreSchemaString(ETL_KEY_SCHEMA.toString(), ETL_VALUE_SCHEMA.toString()),
+        getETLFileSchema(ETL_KEY_SCHEMA, ETL_VALUE_SCHEMA),
         (recordSchema, writer) -> {
           for (int i = 1; i <= 50; ++i) {
             GenericRecord user = new GenericData.Record(recordSchema);
@@ -727,9 +727,6 @@ public class TestWriteUtils {
             key.put(DEFAULT_KEY_FIELD_PROP, Integer.toString(i));
             value.put(DEFAULT_VALUE_FIELD_PROP, DEFAULT_USER_DATA_VALUE_PREFIX + i);
 
-            user.put("opalSegmentIdPart", 0);
-            user.put("opalSegmentIdSeq", 0);
-            user.put("opalSegmentOffset", (long) 0);
             user.put("metadata", new HashMap<>());
 
             user.put("key", key);
@@ -747,9 +744,6 @@ public class TestWriteUtils {
 
             key.put(DEFAULT_KEY_FIELD_PROP, Integer.toString(i));
 
-            user.put("opalSegmentIdPart", 0);
-            user.put("opalSegmentIdSeq", 0);
-            user.put("opalSegmentOffset", (long) 0);
             user.put("metadata", new HashMap<>());
 
             user.put("key", key);
@@ -762,11 +756,54 @@ public class TestWriteUtils {
         });
   }
 
+  public static Schema writeETLFileWithUserSchemaAndNullDefaultValue(File parentDir) throws IOException {
+    String fileName = "simple_etl_user_with_default.avro";
+    Schema schema = getETLFileSchemaWithNullDefaultValue(ETL_KEY_SCHEMA, ETL_VALUE_SCHEMA);
+    AvroCompatibilityHelper.parse(schema.toString());
+    return writeAvroFile(parentDir, fileName, schema, (recordSchema, writer) -> {
+      for (int i = 1; i <= 50; ++i) {
+        GenericRecord user = new GenericData.Record(recordSchema);
+
+        GenericRecord key = new GenericData.Record(ETL_KEY_SCHEMA);
+        GenericRecord value = new GenericData.Record(ETL_VALUE_SCHEMA);
+
+        key.put(DEFAULT_KEY_FIELD_PROP, Integer.toString(i));
+        value.put(DEFAULT_VALUE_FIELD_PROP, DEFAULT_USER_DATA_VALUE_PREFIX + i);
+
+        user.put("metadata", new HashMap<>());
+
+        user.put("key", key);
+        user.put("value", value);
+        user.put("offset", (long) i);
+        user.put("DELETED_TS", null);
+
+        writer.append(user);
+      }
+
+      for (int i = 51; i <= 100; ++i) {
+        GenericRecord user = new GenericData.Record(recordSchema);
+
+        GenericRecord key = new GenericData.Record(ETL_KEY_SCHEMA);
+
+        key.put(DEFAULT_KEY_FIELD_PROP, Integer.toString(i));
+
+        user.put("metadata", new HashMap<>());
+
+        user.put("key", key);
+        user.put("value", null);
+        user.put("offset", (long) i);
+        user.put("DELETED_TS", (long) i);
+
+        writer.append(user);
+      }
+    });
+  }
+
   public static Schema writeETLFileWithUnionWithNullSchema(File parentDir) throws IOException {
     return writeAvroFile(
         parentDir,
         "simple_etl_union_with_null.avro",
-        getETLStoreSchemaString(ETL_KEY_SCHEMA.toString(), ETL_UNION_VALUE_WITH_NULL_SCHEMA.toString()),
+        getETLFileSchema(ETL_KEY_SCHEMA, ETL_UNION_VALUE_WITH_NULL_SCHEMA),
         (recordSchema, writer) -> {
           for (int i = 1; i <= 25; ++i) {
             GenericRecord user = new GenericData.Record(recordSchema);
@@ -775,9 +812,6 @@ public class TestWriteUtils {
 
             key.put(DEFAULT_KEY_FIELD_PROP, Integer.toString(i));
 
-            user.put("opalSegmentIdPart", 0);
-            user.put("opalSegmentIdSeq", 0);
-            user.put("opalSegmentOffset", (long) 0);
             user.put("metadata", new HashMap<>());
 
             user.put("key", key);
@@ -795,9 +829,6 @@ public class TestWriteUtils {
 
             key.put(DEFAULT_KEY_FIELD_PROP, Integer.toString(i));
 
-            user.put("opalSegmentIdPart", 0);
-            user.put("opalSegmentIdSeq", 0);
-            user.put("opalSegmentOffset", (long) 0);
             user.put("metadata", new HashMap<>());
 
             user.put("key", key);
@@ -815,9 +846,6 @@ public class TestWriteUtils {
 
             key.put(DEFAULT_KEY_FIELD_PROP, Integer.toString(i));
 
-            user.put("opalSegmentIdPart", 0);
-            user.put("opalSegmentIdSeq", 0);
-            user.put("opalSegmentOffset", (long) 0);
             user.put("metadata", new HashMap<>());
 
             user.put("key", key);
@@ -835,7 +863,7 @@ public class TestWriteUtils {
     return writeAvroFile(
         parentDir,
         "simple_etl_union_without_null.avro",
-        getETLStoreSchemaString(ETL_KEY_SCHEMA.toString(), ETL_UNION_VALUE_WITHOUT_NULL_SCHEMA.toString()),
+        getETLFileSchema(ETL_KEY_SCHEMA, ETL_UNION_VALUE_WITHOUT_NULL_SCHEMA),
         (recordSchema, writer) -> {
           for (int i = 1; i <= 25; ++i) {
             GenericRecord user = new GenericData.Record(recordSchema);
@@ -844,9 +872,6 @@ public class TestWriteUtils {
 
             key.put(DEFAULT_KEY_FIELD_PROP, Integer.toString(i));
 
-            user.put("opalSegmentIdPart", 0);
-            user.put("opalSegmentIdSeq", 0);
-            user.put("opalSegmentOffset", (long) 0);
             user.put("metadata", new HashMap<>());
 
             user.put("key", key);
@@ -864,9 +889,6 @@ public class TestWriteUtils {
 
             key.put(DEFAULT_KEY_FIELD_PROP, Integer.toString(i));
 
-            user.put("opalSegmentIdPart", 0);
-            user.put("opalSegmentIdSeq", 0);
-            user.put("opalSegmentOffset", (long) 0);
             user.put("metadata", new HashMap<>());
 
             user.put("key", key);
@@ -884,9 +906,6 @@ public class TestWriteUtils {
 
             key.put(DEFAULT_KEY_FIELD_PROP, Integer.toString(i));
 
-            user.put("opalSegmentIdPart", 0);
-            user.put("opalSegmentIdSeq", 0);
-            user.put("opalSegmentOffset", (long) 0);
             user.put("metadata", new HashMap<>());
 
             user.put("key", key);
@@ -899,31 +918,53 @@ public class TestWriteUtils {
         });
   }
 
-  public static Schema getETLStoreSchemaString(String keySchema, String valueSchema) {
-    String finalValueSchema =
-        ETLUtils.transformValueSchemaForETL(AvroCompatibilityHelper.parse(valueSchema)).toString();
-    String fileSchema = "{\n" + "  \"type\": \"record\",\n" + "  \"name\": \"storeName_v1\",\n"
-        + "  \"namespace\": \"com.linkedin.gobblin.venice.model\",\n" + "  \"fields\": [\n" + "    {\n"
-        + "      \"name\": \"opalSegmentIdPart\",\n" + "      \"type\": \"int\",\n"
-        + "      \"doc\": \"Opal segment id partition\"\n" + "    },\n" + "    {\n"
-        + "      \"name\": \"opalSegmentIdSeq\",\n" + "      \"type\": \"int\",\n"
-        + "      \"doc\": \"Opal segment id sequence\"\n" + "    },\n" + "    {\n"
-        + "      \"name\": \"opalSegmentOffset\",\n" + "      \"type\": \"long\",\n"
-        + "      \"doc\": \"Opal segment offset\"\n" + "    },\n" + "    {\n" + "      \"name\": \"key\",\n"
-        + "      \"type\":" + keySchema + ",\n" + "      \"doc\": \"Raw bytes of the key\"\n" + "    },\n" + "    {\n"
-        + "      \"name\": \"value\",\n" + "      \"type\":" + finalValueSchema + ",\n"
-        + "      \"doc\": \"Raw bytes of the value\"\n" + "    },\n" + "    {\n" + "      \"name\": \"offset\",\n"
-        + "      \"type\": \"long\",\n" + "      \"doc\": \"The offset of this record in Kafka\"\n" + "    },\n"
-        + "    {\n" + "      \"name\": \"DELETED_TS\",\n" + "      \"type\": [\n" + "        \"null\",\n"
-        + "        \"long\"\n" + "      ],\n"
-        + "      \"doc\": \"If the current record is a PUT, this field will be null; if it's a DELETE, this field will be the offset of the record in Kafka\",\n"
-        + "      \"default\": null\n" + "    },\n" + "    {\n" + "      \"name\": \"metadata\",\n"
-        + "      \"type\": {\n" + "        \"type\": \"map\",\n" + "        \"values\": {\n"
-        + "          \"type\": \"string\",\n" + "          \"avro.java.string\": \"String\"\n" + "        },\n"
-        + "        \"avro.java.string\": \"String\"\n" + "      },\n"
-        + "      \"doc\": \"Metadata of the record; currently it contains the schemaId of the record\",\n"
-        + "      \"default\": {}\n" + "    }\n" + "  ]\n" + "}";
-    return AvroCompatibilityHelper.parse(fileSchema);
+  public static Schema getETLFileSchema(Schema keySchema, Schema valueSchema) {
+    Schema finalValueSchema = ETLUtils.transformValueSchemaForETL(valueSchema);
+    return Schema.createRecord(
+        "storeName_v1",
+        "",
+        "",
+        false,
+        Arrays.asList(
+            AvroCompatibilityHelper.newField(null).setName(DEFAULT_KEY_FIELD_PROP).setSchema(keySchema).build(),
+            AvroCompatibilityHelper.newField(null)
+                .setName(DEFAULT_VALUE_FIELD_PROP)
+                .setSchema(finalValueSchema)
+                .build(),
+            AvroCompatibilityHelper.newField(null).setName("offset").setSchema(Schema.create(Schema.Type.LONG)).build(),
+            AvroCompatibilityHelper.newField(null)
+                .setName("DELETED_TS")
+                .setSchema(Schema.createUnion(Schema.create(Schema.Type.NULL), Schema.create(Schema.Type.LONG)))
+                .build(),
+            AvroCompatibilityHelper.newField(null)
+                .setName("metadata")
+                .setSchema(Schema.createMap(Schema.create(Schema.Type.STRING)))
+                .build()));
+  }
+
+  public static Schema getETLFileSchemaWithNullDefaultValue(Schema keySchema, Schema valueSchema) {
+    Schema finalValueSchema = ETLUtils.transformValueSchemaForETL(valueSchema);
+    return Schema.createRecord(
+        "storeName_v1",
+        "",
+        "",
+        false,
+        Arrays.asList(
+            AvroCompatibilityHelper.newField(null).setName(DEFAULT_KEY_FIELD_PROP).setSchema(keySchema).build(),
+            AvroCompatibilityHelper.newField(null)
+                .setName(DEFAULT_VALUE_FIELD_PROP)
+                .setSchema(finalValueSchema)
+                .setDefault(null)
+                .build(),
+            AvroCompatibilityHelper.newField(null).setName("offset").setSchema(Schema.create(Schema.Type.LONG)).build(),
+            AvroCompatibilityHelper.newField(null)
+                .setName("DELETED_TS")
+                .setSchema(Schema.createUnion(Schema.create(Schema.Type.NULL), Schema.create(Schema.Type.LONG)))
+                .build(),
+            AvroCompatibilityHelper.newField(null)
+                .setName("metadata")
+                .setSchema(Schema.createMap(Schema.create(Schema.Type.STRING)))
+                .build()));
   }
 
   public static void runPushJob(String jobId, Properties props) {


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Handle extra `null` default in ETL+VPJ value schema
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
Currently, ETL+VPJ flow makes strict assumptions about schema. It doesn't allow the value schema to have `null` as a default value if the original value schema didn't have a `null` default. This commit allows schemas where the `value` field has a `null` default.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
Added unit tests, integration tests

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.