### PR TITLE
[all] Improve debugging experience

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/ImmutableChangeCapturePubSubMessage.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/ImmutableChangeCapturePubSubMessage.java
@@ -69,4 +69,10 @@ public class ImmutableChangeCapturePubSubMessage<K, V> implements PubSubMessage<
   public boolean isEndOfBootstrap() {
     return isEndOfBootstrap;
   }
+
+  @Override
+  public String toString() {
+    return "PubSubMessage{" + topicPartition + ", offset=" + offset + ", timestamp=" + timestamp + ", isEndOfBootstrap="
+        + isEndOfBootstrap + '}';
+  }
 }

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/utils/DaemonThreadFactory.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/utils/DaemonThreadFactory.java
@@ -13,7 +13,7 @@ public class DaemonThreadFactory implements ThreadFactory {
   private final String namePrefix;
 
   public DaemonThreadFactory(String threadNamePrefix) {
-    this.threadNumber = new AtomicInteger(1);
+    this.threadNumber = new AtomicInteger(0);
     this.namePrefix = threadNamePrefix;
   }
 

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/ImmutablePubSubMessage.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/ImmutablePubSubMessage.java
@@ -82,4 +82,9 @@ public class ImmutablePubSubMessage<K, V> implements PubSubMessage<K, V, Long> {
   public PubSubMessageHeaders getPubSubMessageHeaders() {
     return pubSubMessageHeaders;
   }
+
+  @Override
+  public String toString() {
+    return "PubSubMessage{" + topicPartition + ", offset=" + offset + ", timestamp=" + timestamp + '}';
+  }
 }


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Improve debugging experience

- Adjust the indexes of threads created with DaemonThreadFactory to use
  zero-based indexing. This change simplifies mapping of threads with
  drainer queues and consumers by eliminating the need for additional mental
  calculations.
- Override the `ImmutablePubSubMessage::toString` method to include additional
  information such as topic-partition and offset in the message output.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.