### PR TITLE
[all] Fix an infinite recursion issue in VeniceWriter (#879)

### DIFF
--- a/internal/venice-common/src/main/java/com/linkedin/venice/kafka/validation/Segment.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/kafka/validation/Segment.java
@@ -407,4 +407,9 @@ public class Segment {
     }
     return deduped;
   }
+
+  // Only for testing.
+  public void setStarted(boolean started) {
+    this.started = started;
+  }
 }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/writer/VeniceWriterTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/writer/VeniceWriterTest.java
@@ -2,6 +2,8 @@ package com.linkedin.venice.writer;
 
 import static com.linkedin.venice.pubsub.PubSubConstants.PUBSUB_OPERATION_TIMEOUT_MS_DEFAULT_VALUE;
 import static com.linkedin.venice.utils.Time.MS_PER_SECOND;
+import static com.linkedin.venice.writer.VeniceWriter.MAX_ELAPSED_TIME_FOR_SEGMENT_IN_MS;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
@@ -13,6 +15,7 @@ import com.linkedin.venice.integration.utils.ServiceFactory;
 import com.linkedin.venice.kafka.protocol.KafkaMessageEnvelope;
 import com.linkedin.venice.kafka.protocol.ProducerMetadata;
 import com.linkedin.venice.kafka.protocol.enums.MessageType;
+import com.linkedin.venice.kafka.validation.Segment;
 import com.linkedin.venice.message.KafkaKey;
 import com.linkedin.venice.partitioner.DefaultVenicePartitioner;
 import com.linkedin.venice.pubsub.PubSubConsumerAdapterFactory;
@@ -225,6 +228,53 @@ public class VeniceWriterTest {
       } finally {
         executor.shutdownNow();
       }
+    }
+  }
+
+  /**
+   * This is a regression test for the VeniceWriter issue where the VeniceWriter could run into
+   * infinite recursions, eventually run out of the stack space and throw StackOverflowError.
+   *
+   * The conditions to trigger this issue are:
+   * 1. The VeniceWriter's cached segment is neither started nor ended.
+   * 2. The elapsed time for the segment is greater than MAX_ELAPSED_TIME_FOR_SEGMENT_IN_MS.
+   */
+  @Test(timeOut = 30 * MS_PER_SECOND)
+  public void testVeniceWriterShouldNotCauseStackOverflow() {
+    String topicName = TestUtils.getUniqueTopicString("topic-for-vw-stack-overflow");
+    int partitionCount = 1;
+    PubSubTopic pubSubTopic = pubSubTopicRepository.getTopic(topicName);
+
+    topicManager.createTopic(pubSubTopic, partitionCount, 1, true);
+    Properties properties = new Properties();
+    properties.put(ConfigKeys.KAFKA_BOOTSTRAP_SERVERS, pubSubBrokerWrapper.getAddress());
+    properties.put(ConfigKeys.PARTITIONER_CLASS, DefaultVenicePartitioner.class.getName());
+
+    // Explicitly set MAX_ELAPSED_TIME_FOR_SEGMENT_IN_MS to 1 second.
+    properties.put(MAX_ELAPSED_TIME_FOR_SEGMENT_IN_MS, 1000);
+    properties.putAll(PubSubBrokerWrapper.getBrokerDetailsForClients(Collections.singletonList(pubSubBrokerWrapper)));
+
+    try (VeniceWriter<KafkaKey, byte[], byte[]> veniceWriter =
+        TestUtils.getVeniceWriterFactory(properties, pubSubProducerAdapterFactory)
+            .createVeniceWriter(
+                new VeniceWriterOptions.Builder(topicName).setUseKafkaKeySerializer(true)
+                    .setPartitionCount(partitionCount)
+                    .build())) {
+      Segment seg = veniceWriter.getSegment(0, false);
+      seg.setStarted(false);
+
+      // Verify that segment is neither started nor ended.
+      assertFalse(seg.isStarted());
+      assertFalse(seg.isEnded());
+
+      // Sleep for 1.1 seconds to make sure the elapsed time for the segment is greater than
+      // MAX_ELAPSED_TIME_FOR_SEGMENT_IN_MS.
+      Thread.sleep(1100);
+
+      // Send an SOS control message to the topic and it should not cause StackOverflowError.
+      veniceWriter.sendStartOfSegment(0, null);
+    } catch (Throwable t) {
+      Assert.fail("VeniceWriter should not cause stack overflow", t);
     }
   }
 }


### PR DESCRIPTION
* [all] Fix an infinite recursion issue in VeniceWriter

Today, VeniceWriter (VW) has a bug to run into an infinite recursion when it sends a message in the VeniceWriter and eventually it throws StackOverflowError. For a particular partition, the conditions to trigger the issue are:

1. VW has a cached Segment
2. The segment is neither started nor ended
3. The elapsed time for the segment is greater than MAX_ELAPSED_TIME_FOR_SEGMENT_IN_MS

To fix it, we break the infinite loop by always recording the new start time. A new integration test, as well as a unit test, is added to capture any regressions.

<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Summary, imperative, start upper case, don't end with a period
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Resolves #XXX

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.