### PR TITLE
[davinci][server] Add more write-path metrics for observability

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
@@ -163,8 +163,8 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
       int subPartition,
       String kafkaUrl,
       int kafkaClusterId,
-      long beforeProcessingRecordTimestampNs,
-      long currentTimeForMetricsMs) {
+      long beforeProcessingPerRecordTimestampNs,
+      long beforeProcessingBatchRecordsTimestampMs) {
     if (!consumerRecord.getTopicPartition().getPubSubTopic().isRealTime()) {
       /**
        * We don't need to lock the partition here because during VT consumption there is only one consumption source.
@@ -174,8 +174,8 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
           subPartition,
           kafkaUrl,
           kafkaClusterId,
-          beforeProcessingRecordTimestampNs,
-          currentTimeForMetricsMs);
+          beforeProcessingPerRecordTimestampNs,
+          beforeProcessingBatchRecordsTimestampMs);
     } else {
       /**
        * The below flow must be executed in a critical session for the same key:
@@ -197,8 +197,8 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
             subPartition,
             kafkaUrl,
             kafkaClusterId,
-            beforeProcessingRecordTimestampNs,
-            currentTimeForMetricsMs);
+            beforeProcessingPerRecordTimestampNs,
+            beforeProcessingBatchRecordsTimestampMs);
       } finally {
         keyLevelLock.unlock();
         this.keyLevelLocksManager.get().releaseLock(byteArrayKey);

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -1878,7 +1878,6 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
       long consumerTimestampMs,
       long producerBrokerLatencyMs,
       long brokerConsumerLatencyMs,
-      long producerConsumerLatencyMs,
       PartitionConsumptionState partitionConsumptionState) {
     if (isUserSystemStore()) {
       return;
@@ -1892,16 +1891,14 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
             versionNumber,
             consumerTimestampMs,
             producerBrokerLatencyMs,
-            brokerConsumerLatencyMs,
-            producerConsumerLatencyMs);
+            brokerConsumerLatencyMs);
       } else {
         versionedDIVStats.recordFollowerLatencies(
             storeName,
             versionNumber,
             consumerTimestampMs,
             producerBrokerLatencyMs,
-            brokerConsumerLatencyMs,
-            producerConsumerLatencyMs);
+            brokerConsumerLatencyMs);
       }
     }
   }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -2239,7 +2239,7 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
         versionedDIVStats.recordLeaderDIVCompletionTime(
             storeName,
             versionNumber,
-            LatencyUtils.getElapsedTimeInMs(beforeProcessingBatchRecordsTimestampMs),
+            LatencyUtils.getElapsedTimeInMs(beforeProcessingPerRecordTimestampNs),
             beforeProcessingBatchRecordsTimestampMs);
         versionedDIVStats.recordSuccessMsg(storeName, versionNumber);
       } catch (FatalDataValidationException e) {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -2236,6 +2236,11 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
             consumerRecord,
             isEndOfPushReceived,
             partitionConsumptionState);
+        versionedDIVStats.recordLeaderDIVCompletionTime(
+            storeName,
+            versionNumber,
+            LatencyUtils.getElapsedTimeInMs(currentTimeForMetricsMs),
+            currentTimeForMetricsMs);
         versionedDIVStats.recordSuccessMsg(storeName, versionNumber);
       } catch (FatalDataValidationException e) {
         if (!isEndOfPushReceived) {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -2163,8 +2163,8 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
       int subPartition,
       String kafkaUrl,
       int kafkaClusterId,
-      long beforeProcessingRecordTimestampNs,
-      long currentTimeForMetricsMs) {
+      long beforeProcessingPerRecordTimestampNs,
+      long beforeProcessingBatchRecordsTimestampMs) {
     boolean produceToLocalKafka = false;
     try {
       KafkaKey kafkaKey = consumerRecord.getKey();
@@ -2218,7 +2218,7 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
             kafkaClusterId,
             consumerRecord.getPayloadSize(),
             consumerRecord.getOffset(),
-            currentTimeForMetricsMs);
+            beforeProcessingBatchRecordsTimestampMs);
         updateLatestInMemoryLeaderConsumedRTOffset(partitionConsumptionState, kafkaUrl, consumerRecord.getOffset());
       }
 
@@ -2239,8 +2239,8 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
         versionedDIVStats.recordLeaderDIVCompletionTime(
             storeName,
             versionNumber,
-            LatencyUtils.getElapsedTimeInMs(currentTimeForMetricsMs),
-            currentTimeForMetricsMs);
+            LatencyUtils.getElapsedTimeInMs(beforeProcessingBatchRecordsTimestampMs),
+            beforeProcessingBatchRecordsTimestampMs);
         versionedDIVStats.recordSuccessMsg(storeName, versionNumber);
       } catch (FatalDataValidationException e) {
         if (!isEndOfPushReceived) {
@@ -2302,7 +2302,7 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
                 subPartition,
                 kafkaUrl,
                 kafkaClusterId,
-                beforeProcessingRecordTimestampNs);
+                beforeProcessingPerRecordTimestampNs);
             break;
           case START_OF_SEGMENT:
           case END_OF_SEGMENT:
@@ -2336,7 +2336,7 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
                   subPartition,
                   kafkaUrl,
                   kafkaClusterId,
-                  beforeProcessingRecordTimestampNs);
+                  beforeProcessingPerRecordTimestampNs);
             } else {
               if (controlMessageType == START_OF_SEGMENT
                   && Arrays.equals(consumerRecord.getKey().getKey(), KafkaKey.HEART_BEAT.getKey())) {
@@ -2347,7 +2347,7 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
                     subPartition,
                     kafkaUrl,
                     kafkaClusterId,
-                    beforeProcessingRecordTimestampNs);
+                    beforeProcessingPerRecordTimestampNs);
               } else {
                 /**
                  * Based on current design handling this case (specially EOS) is tricky as we don't produce the SOS/EOS
@@ -2398,7 +2398,7 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
                 subPartition,
                 kafkaUrl,
                 kafkaClusterId,
-                beforeProcessingRecordTimestampNs);
+                beforeProcessingPerRecordTimestampNs);
             break;
           case TOPIC_SWITCH:
             /**
@@ -2428,7 +2428,7 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
                 subPartition,
                 kafkaUrl,
                 kafkaClusterId,
-                beforeProcessingRecordTimestampNs);
+                beforeProcessingPerRecordTimestampNs);
             break;
           case VERSION_SWAP:
             return DelegateConsumerRecordResult.QUEUED_TO_DRAINER;
@@ -2458,8 +2458,8 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
             subPartition,
             kafkaUrl,
             kafkaClusterId,
-            beforeProcessingRecordTimestampNs,
-            currentTimeForMetricsMs);
+            beforeProcessingPerRecordTimestampNs,
+            beforeProcessingBatchRecordsTimestampMs);
       }
       return DelegateConsumerRecordResult.PRODUCED_TO_KAFKA;
     } catch (Exception e) {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderProducerCallback.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderProducerCallback.java
@@ -207,7 +207,14 @@ public class LeaderProducerCallback implements ChunkAwareCallback {
         produceDeprecatedChunkDeletionToStoreBufferService(oldValueManifest, currentTimeForMetricsMs);
         produceDeprecatedChunkDeletionToStoreBufferService(oldRmdManifest, currentTimeForMetricsMs);
         recordProducerStats(producedRecordSize, producedRecordNum);
-
+        if (!ingestionTask.isUserSystemStore()) {
+          ingestionTask.getVersionIngestionStats()
+              .recordProducerCallBackLatency(
+                  ingestionTask.getStoreName(),
+                  ingestionTask.versionNumber,
+                  LatencyUtils.getLatencyInMS(produceTimeNs),
+                  currentTimeForMetricsMs);
+        }
       } catch (Exception oe) {
         boolean endOfPushReceived = partitionConsumptionState.isEndOfPushReceived();
         LOGGER.error(

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/SeparatedStoreBufferService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/SeparatedStoreBufferService.java
@@ -8,6 +8,7 @@ import com.linkedin.venice.pubsub.api.PubSubMessage;
 import com.linkedin.venice.pubsub.api.PubSubTopic;
 import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
 import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
+import io.tehuti.metrics.MetricsRepository;
 import java.util.Map;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -27,7 +28,7 @@ public class SeparatedStoreBufferService extends AbstractStoreBufferService {
   private final int unsortedPoolSize;
   private final Map<PubSubTopic, Boolean> topicToSortedIngestionMode = new VeniceConcurrentHashMap<>();
 
-  SeparatedStoreBufferService(VeniceServerConfig serverConfig) {
+  SeparatedStoreBufferService(VeniceServerConfig serverConfig, MetricsRepository metricsRepository) {
     this(
         serverConfig.getDrainerPoolSizeSortedInput(),
         serverConfig.getDrainerPoolSizeUnsortedInput(),
@@ -35,12 +36,14 @@ public class SeparatedStoreBufferService extends AbstractStoreBufferService {
             serverConfig.getDrainerPoolSizeSortedInput(),
             serverConfig.getStoreWriterBufferMemoryCapacity(),
             serverConfig.getStoreWriterBufferNotifyDelta(),
-            serverConfig.isStoreWriterBufferAfterLeaderLogicEnabled()),
+            serverConfig.isStoreWriterBufferAfterLeaderLogicEnabled(),
+            metricsRepository),
         new StoreBufferService(
             serverConfig.getDrainerPoolSizeUnsortedInput(),
             serverConfig.getStoreWriterBufferMemoryCapacity(),
             serverConfig.getStoreWriterBufferNotifyDelta(),
-            serverConfig.isStoreWriterBufferAfterLeaderLogicEnabled()));
+            serverConfig.isStoreWriterBufferAfterLeaderLogicEnabled(),
+            metricsRepository));
     LOGGER.info(
         "Created separated store buffer service with {} sorted drainers and {} unsorted drainers queues with capacity of {}",
         sortedPoolSize,

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreBufferService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreBufferService.java
@@ -4,6 +4,7 @@ import static java.util.Collections.reverseOrder;
 import static java.util.Comparator.comparing;
 import static java.util.stream.Collectors.toList;
 
+import com.linkedin.davinci.stats.StoreBufferServiceStats;
 import com.linkedin.venice.common.Measurable;
 import com.linkedin.venice.exceptions.VeniceChecksumException;
 import com.linkedin.venice.exceptions.VeniceException;
@@ -16,6 +17,7 @@ import com.linkedin.venice.pubsub.api.PubSubMessage;
 import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
 import com.linkedin.venice.utils.DaemonThreadFactory;
 import com.linkedin.venice.utils.PartitionUtils;
+import io.tehuti.metrics.MetricsRepository;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -50,6 +52,289 @@ import org.apache.logging.log4j.Logger;
  * thread pool to speed up polling from local Kafka brokers.
  */
 public class StoreBufferService extends AbstractStoreBufferService {
+  private static final Logger LOGGER = LogManager.getLogger(StoreBufferService.class);
+  private final int drainerNum;
+  private final ArrayList<MemoryBoundBlockingQueue<QueueNode>> blockingQueueArr;
+  private ExecutorService executorService;
+  private final List<StoreBufferDrainer> drainerList = new ArrayList<>();
+  private final long bufferCapacityPerDrainer;
+
+  private final RecordHandler leaderRecordHandler;
+  private final StoreBufferServiceStats storeBufferServiceStats;
+
+  public StoreBufferService(
+      int drainerNum,
+      long bufferCapacityPerDrainer,
+      long bufferNotifyDelta,
+      boolean queueLeaderWrites,
+      MetricsRepository metricsRepository) {
+    this.drainerNum = drainerNum;
+    this.blockingQueueArr = new ArrayList<>();
+    this.bufferCapacityPerDrainer = bufferCapacityPerDrainer;
+    for (int cur = 0; cur < drainerNum; ++cur) {
+      this.blockingQueueArr.add(new MemoryBoundBlockingQueue<>(bufferCapacityPerDrainer, bufferNotifyDelta));
+    }
+    this.leaderRecordHandler = queueLeaderWrites ? this::queueLeaderRecord : StoreBufferService::processRecord;
+    this.storeBufferServiceStats = new StoreBufferServiceStats(
+        metricsRepository,
+        this::getTotalMemoryUsage,
+        this::getTotalRemainingMemory,
+        this::getMaxMemoryUsagePerDrainer,
+        this::getMinMemoryUsagePerDrainer);
+  }
+
+  protected MemoryBoundBlockingQueue<QueueNode> getDrainerForConsumerRecord(
+      PubSubMessage<KafkaKey, KafkaMessageEnvelope, Long> consumerRecord,
+      int subPartition) {
+    int drainerIndex = getDrainerIndexForConsumerRecord(consumerRecord, subPartition);
+    return blockingQueueArr.get(drainerIndex);
+  }
+
+  protected int getDrainerIndexForConsumerRecord(
+      PubSubMessage<KafkaKey, KafkaMessageEnvelope, Long> consumerRecord,
+      int subPartition) {
+    /**
+     * This will guarantee that 'topicHash' will be a positive integer, whose maximum value is
+     * {@link Integer.MAX_VALUE} / 2 + 1, which could make sure 'topicHash + consumerRecord.partition()' should be
+     * positive for most of time to guarantee even partition assignment.
+     */
+    int topicHash = Math.abs(consumerRecord.getTopicPartition().getPubSubTopic().hashCode() / 2);
+    return Math.abs((topicHash + subPartition) % this.drainerNum);
+  }
+
+  @Override
+  public void putConsumerRecord(
+      PubSubMessage<KafkaKey, KafkaMessageEnvelope, Long> consumerRecord,
+      StoreIngestionTask ingestionTask,
+      LeaderProducedRecordContext leaderProducedRecordContext,
+      int subPartition,
+      String kafkaUrl,
+      long beforeProcessingRecordTimestampNs) throws InterruptedException {
+    if (leaderProducedRecordContext == null) {
+      /**
+       * The last queued record persisted future will only be setup when {@param leaderProducedRecordContext} is 'null',
+       * since {@link LeaderProducedRecordContext#persistedToDBFuture} is a superset of this, which is tracking the
+       * end-to-end completeness when producing to local Kafka is needed.
+       */
+      CompletableFuture<Void> recordFuture = new CompletableFuture<>();
+      getDrainerForConsumerRecord(consumerRecord, subPartition).put(
+          new FollowerQueueNode(
+              consumerRecord,
+              ingestionTask,
+              kafkaUrl,
+              beforeProcessingRecordTimestampNs,
+              recordFuture));
+
+      // Setup the last queued record's future
+      PartitionConsumptionState partitionConsumptionState =
+          ingestionTask.getPartitionConsumptionState(consumerRecord.getTopicPartition().getPartitionNumber());
+      if (partitionConsumptionState != null) {
+        partitionConsumptionState.setLastQueuedRecordPersistedFuture(recordFuture);
+      }
+    } else {
+      leaderRecordHandler.handle(
+          consumerRecord,
+          ingestionTask,
+          leaderProducedRecordContext,
+          subPartition,
+          kafkaUrl,
+          beforeProcessingRecordTimestampNs);
+    }
+  }
+
+  private interface RecordHandler {
+    void handle(
+        PubSubMessage<KafkaKey, KafkaMessageEnvelope, Long> consumerRecord,
+        StoreIngestionTask ingestionTask,
+        LeaderProducedRecordContext leaderProducedRecordContext,
+        int subPartition,
+        String kafkaUrl,
+        long beforeProcessingRecordTimestamp) throws InterruptedException;
+  }
+
+  private void queueLeaderRecord(
+      PubSubMessage<KafkaKey, KafkaMessageEnvelope, Long> consumerRecord,
+      StoreIngestionTask ingestionTask,
+      LeaderProducedRecordContext leaderProducedRecordContext,
+      int subPartition,
+      String kafkaUrl,
+      long beforeProcessingRecordTimestamp) throws InterruptedException {
+    getDrainerForConsumerRecord(consumerRecord, subPartition).put(
+        new LeaderQueueNode(
+            consumerRecord,
+            ingestionTask,
+            kafkaUrl,
+            beforeProcessingRecordTimestamp,
+            leaderProducedRecordContext));
+  }
+
+  private static void processRecord(
+      PubSubMessage<KafkaKey, KafkaMessageEnvelope, Long> consumerRecord,
+      StoreIngestionTask ingestionTask,
+      LeaderProducedRecordContext leaderProducedRecordContext,
+      int subPartition,
+      String kafkaUrl,
+      long beforeProcessingRecordTimestampNs) {
+    ingestionTask.processConsumerRecord(
+        consumerRecord,
+        leaderProducedRecordContext,
+        subPartition,
+        kafkaUrl,
+        beforeProcessingRecordTimestampNs);
+
+    // complete the leaderProducedRecordContext future as processing for this leaderProducedRecordContext is done here.
+    if (leaderProducedRecordContext != null) {
+      leaderProducedRecordContext.completePersistedToDBFuture(null);
+    }
+  }
+
+  /**
+   * This function is used to drain all the records for the specified topic + partition.
+   * The reason is that we don't want overlap Kafka messages between two different subscriptions,
+   * which could introduce complicate dependencies in {@link StoreIngestionTask}.
+   * @param topicPartition for which to drain buffer
+   * @throws InterruptedException
+   */
+  public void drainBufferedRecordsFromTopicPartition(PubSubTopicPartition topicPartition) throws InterruptedException {
+    int retryNum = 1000;
+    int sleepIntervalInMS = 50;
+    internalDrainBufferedRecordsFromTopicPartition(topicPartition, retryNum, sleepIntervalInMS);
+  }
+
+  protected void internalDrainBufferedRecordsFromTopicPartition(
+      PubSubTopicPartition topicPartition,
+      int retryNum,
+      int sleepIntervalInMS) throws InterruptedException {
+    PubSubMessage<KafkaKey, KafkaMessageEnvelope, Long> fakeRecord = new FakePubSubMessage(topicPartition);
+    int workerIndex = getDrainerIndexForConsumerRecord(fakeRecord, topicPartition.getPartitionNumber());
+    BlockingQueue<QueueNode> blockingQueue = blockingQueueArr.get(workerIndex);
+    if (!drainerList.get(workerIndex).isRunning.get()) {
+      throw new VeniceException(
+          "Drainer thread " + workerIndex + " has stopped running, cannot drain the topic "
+              + topicPartition.getPubSubTopic().getName());
+    }
+
+    QueueNode fakeNode = new QueueNode(fakeRecord, null, "dummyKafkaUrl", 0);
+
+    int cur = 0;
+    while (cur++ < retryNum) {
+      if (!blockingQueue.contains(fakeNode)) {
+        LOGGER.info(
+            "The blocking queue of store writer thread: {} doesn't contain any record for: {}",
+            workerIndex,
+            topicPartition);
+        return;
+      }
+      Thread.sleep(sleepIntervalInMS);
+    }
+    String errorMessage = "There are still some records left in the blocking queue of store writer thread: "
+        + workerIndex + " for topic: " + topicPartition.getPubSubTopic().getName() + " partition after retry for "
+        + retryNum + " times";
+    LOGGER.error(errorMessage);
+    throw new VeniceException(errorMessage);
+  }
+
+  @Override
+  public boolean startInner() {
+    this.executorService = Executors.newFixedThreadPool(drainerNum, new DaemonThreadFactory("Store-writer"));
+
+    // Submit all the buffer drainers
+    for (int cur = 0; cur < drainerNum; ++cur) {
+      StoreBufferDrainer drainer = new StoreBufferDrainer(this.blockingQueueArr.get(cur), cur, storeBufferServiceStats);
+      this.executorService.submit(drainer);
+      drainerList.add(drainer);
+    }
+    this.executorService.shutdown();
+    return true;
+  }
+
+  @Override
+  public void stopInner() throws Exception {
+    // Graceful shutdown
+    drainerList.forEach(drainer -> drainer.stop());
+    if (this.executorService != null) {
+      this.executorService.shutdownNow();
+      this.executorService.awaitTermination(10, TimeUnit.SECONDS);
+    }
+  }
+
+  @Override
+  public int getDrainerCount() {
+    return blockingQueueArr.size();
+  }
+
+  @Override
+  public long getDrainerQueueMemoryUsage(int index) {
+    return blockingQueueArr.get(index).getMemoryUsage();
+  }
+
+  @Override
+  public long getTotalMemoryUsage() {
+    long totalUsage = 0;
+    for (MemoryBoundBlockingQueue<QueueNode> queue: blockingQueueArr) {
+      totalUsage += queue.getMemoryUsage();
+    }
+    return totalUsage;
+  }
+
+  @Override
+  public long getTotalRemainingMemory() {
+    long totalRemaining = 0;
+    for (MemoryBoundBlockingQueue<QueueNode> queue: blockingQueueArr) {
+      totalRemaining += queue.remainingMemoryCapacityInByte();
+    }
+    return totalRemaining;
+  }
+
+  @Override
+  public long getMaxMemoryUsagePerDrainer() {
+    long maxUsage = 0;
+    boolean slowDrainerExists = false;
+
+    for (MemoryBoundBlockingQueue<QueueNode> queue: blockingQueueArr) {
+      maxUsage = Math.max(maxUsage, queue.getMemoryUsage());
+      if (queue.getMemoryUsage() > 0.8 * bufferCapacityPerDrainer) {
+        slowDrainerExists = true;
+      }
+    }
+
+    for (int index = 0; index < blockingQueueArr.size(); index++) {
+      StoreBufferDrainer drainer = drainerList.get(index);
+      // print drainer info when there is a slow drainer.
+      if (slowDrainerExists) {
+        MemoryBoundBlockingQueue<QueueNode> queue = blockingQueueArr.get(index);
+        int count = queue.getMemoryUsage() > 0.8 * bufferCapacityPerDrainer ? 5 : 1;
+        List<Map.Entry<PubSubTopicPartition, Long>> slowestEntries = drainer.topicToTimeSpent.entrySet()
+            .stream()
+            .sorted(comparing(Map.Entry::getValue, reverseOrder()))
+            .limit(count)
+            .collect(toList());
+        // TODO: break this done so we can let it emit latency metrics too.
+        int finalIndex = index;
+        slowestEntries.forEach(
+            entry -> LOGGER
+                .info("In drainer number {}, time spent on {} : {} ms", finalIndex, entry.getKey(), entry.getValue()));
+      }
+      drainer.topicToTimeSpent.clear();
+    }
+
+    return maxUsage;
+  }
+
+  /** Used for testing */
+  Map<PubSubTopicPartition, Long> getTopicToTimeSpentMap(int i) {
+    return drainerList.get(i).topicToTimeSpent;
+  }
+
+  @Override
+  public long getMinMemoryUsagePerDrainer() {
+    long minUsage = Long.MAX_VALUE;
+    for (MemoryBoundBlockingQueue<QueueNode> queue: blockingQueueArr) {
+      minUsage = Math.min(minUsage, queue.getMemoryUsage());
+    }
+    return minUsage;
+  }
+
   /**
    * Queue node type in {@link BlockingQueue} of each drainer thread.
    */
@@ -227,10 +512,12 @@ public class StoreBufferService extends AbstractStoreBufferService {
     private final AtomicBoolean isRunning = new AtomicBoolean(true);
     private final int drainerIndex;
     private final ConcurrentMap<PubSubTopicPartition, Long> topicToTimeSpent = new ConcurrentHashMap<>();
+    private final StoreBufferServiceStats stats;
 
-    public StoreBufferDrainer(BlockingQueue<QueueNode> blockingQueue, int drainerIndex) {
+    public StoreBufferDrainer(BlockingQueue<QueueNode> blockingQueue, int drainerIndex, StoreBufferServiceStats stats) {
       this.blockingQueue = blockingQueue;
       this.drainerIndex = drainerIndex;
+      this.stats = stats;
     }
 
     public void stop() {
@@ -273,10 +560,9 @@ public class StoreBufferService extends AbstractStoreBufferService {
           if (recordPersistedFuture != null) {
             recordPersistedFuture.complete(null);
           }
-
-          topicToTimeSpent.compute(
-              consumerRecord.getTopicPartition(),
-              (K, V) -> (V == null ? 0 : V) + System.currentTimeMillis() - startTime);
+          long latencyInMS = System.currentTimeMillis() - startTime;
+          this.stats.recordInternalProcessingLatency(latencyInMS);
+          topicToTimeSpent.compute(consumerRecord.getTopicPartition(), (K, V) -> (V == null ? 0 : V) + latencyInMS);
         } catch (Throwable e) {
           if (e instanceof InterruptedException) {
             LOGGER.error("Drainer {} received InterruptedException, will exit", drainerIndex);
@@ -298,6 +584,7 @@ public class StoreBufferService extends AbstractStoreBufferService {
             logBuilder.append(consumerRecordString);
           }
           LOGGER.error(logBuilder.toString(), e);
+          stats.recordInternalProcessingError();
 
           /**
            * Catch all the thrown exception and store it in {@link StoreIngestionTask#lastWorkerException}.
@@ -329,281 +616,6 @@ public class StoreBufferService extends AbstractStoreBufferService {
       }
       LOGGER.info("Current StoreBufferDrainer {} stopped", drainerIndex);
     }
-  }
-
-  private static final Logger LOGGER = LogManager.getLogger(StoreBufferService.class);
-  private final int drainerNum;
-  private final ArrayList<MemoryBoundBlockingQueue<QueueNode>> blockingQueueArr;
-  private ExecutorService executorService;
-  private final List<StoreBufferDrainer> drainerList = new ArrayList<>();
-  private final long bufferCapacityPerDrainer;
-
-  private final RecordHandler leaderRecordHandler;
-
-  public StoreBufferService(
-      int drainerNum,
-      long bufferCapacityPerDrainer,
-      long bufferNotifyDelta,
-      boolean queueLeaderWrites) {
-    this.drainerNum = drainerNum;
-    this.blockingQueueArr = new ArrayList<>();
-    this.bufferCapacityPerDrainer = bufferCapacityPerDrainer;
-    for (int cur = 0; cur < drainerNum; ++cur) {
-      this.blockingQueueArr.add(new MemoryBoundBlockingQueue<>(bufferCapacityPerDrainer, bufferNotifyDelta));
-    }
-    this.leaderRecordHandler = queueLeaderWrites ? this::queueLeaderRecord : StoreBufferService::processRecord;
-  }
-
-  protected MemoryBoundBlockingQueue<QueueNode> getDrainerForConsumerRecord(
-      PubSubMessage<KafkaKey, KafkaMessageEnvelope, Long> consumerRecord,
-      int subPartition) {
-    int drainerIndex = getDrainerIndexForConsumerRecord(consumerRecord, subPartition);
-    return blockingQueueArr.get(drainerIndex);
-  }
-
-  protected int getDrainerIndexForConsumerRecord(
-      PubSubMessage<KafkaKey, KafkaMessageEnvelope, Long> consumerRecord,
-      int subPartition) {
-    /**
-     * This will guarantee that 'topicHash' will be a positive integer, whose maximum value is
-     * {@link Integer.MAX_VALUE} / 2 + 1, which could make sure 'topicHash + consumerRecord.partition()' should be
-     * positive for most of time to guarantee even partition assignment.
-     */
-    int topicHash = Math.abs(consumerRecord.getTopicPartition().getPubSubTopic().hashCode() / 2);
-    return Math.abs((topicHash + subPartition) % this.drainerNum);
-  }
-
-  @Override
-  public void putConsumerRecord(
-      PubSubMessage<KafkaKey, KafkaMessageEnvelope, Long> consumerRecord,
-      StoreIngestionTask ingestionTask,
-      LeaderProducedRecordContext leaderProducedRecordContext,
-      int subPartition,
-      String kafkaUrl,
-      long beforeProcessingRecordTimestampNs) throws InterruptedException {
-    if (leaderProducedRecordContext == null) {
-      /**
-       * The last queued record persisted future will only be setup when {@param leaderProducedRecordContext} is 'null',
-       * since {@link LeaderProducedRecordContext#persistedToDBFuture} is a superset of this, which is tracking the
-       * end-to-end completeness when producing to local Kafka is needed.
-       */
-      CompletableFuture<Void> recordFuture = new CompletableFuture<>();
-      getDrainerForConsumerRecord(consumerRecord, subPartition).put(
-          new FollowerQueueNode(
-              consumerRecord,
-              ingestionTask,
-              kafkaUrl,
-              beforeProcessingRecordTimestampNs,
-              recordFuture));
-
-      // Setup the last queued record's future
-      PartitionConsumptionState partitionConsumptionState =
-          ingestionTask.getPartitionConsumptionState(consumerRecord.getTopicPartition().getPartitionNumber());
-      if (partitionConsumptionState != null) {
-        partitionConsumptionState.setLastQueuedRecordPersistedFuture(recordFuture);
-      }
-    } else {
-      leaderRecordHandler.handle(
-          consumerRecord,
-          ingestionTask,
-          leaderProducedRecordContext,
-          subPartition,
-          kafkaUrl,
-          beforeProcessingRecordTimestampNs);
-    }
-  }
-
-  private interface RecordHandler {
-    void handle(
-        PubSubMessage<KafkaKey, KafkaMessageEnvelope, Long> consumerRecord,
-        StoreIngestionTask ingestionTask,
-        LeaderProducedRecordContext leaderProducedRecordContext,
-        int subPartition,
-        String kafkaUrl,
-        long beforeProcessingRecordTimestamp) throws InterruptedException;
-  }
-
-  private void queueLeaderRecord(
-      PubSubMessage<KafkaKey, KafkaMessageEnvelope, Long> consumerRecord,
-      StoreIngestionTask ingestionTask,
-      LeaderProducedRecordContext leaderProducedRecordContext,
-      int subPartition,
-      String kafkaUrl,
-      long beforeProcessingRecordTimestamp) throws InterruptedException {
-    getDrainerForConsumerRecord(consumerRecord, subPartition).put(
-        new LeaderQueueNode(
-            consumerRecord,
-            ingestionTask,
-            kafkaUrl,
-            beforeProcessingRecordTimestamp,
-            leaderProducedRecordContext));
-  }
-
-  private static void processRecord(
-      PubSubMessage<KafkaKey, KafkaMessageEnvelope, Long> consumerRecord,
-      StoreIngestionTask ingestionTask,
-      LeaderProducedRecordContext leaderProducedRecordContext,
-      int subPartition,
-      String kafkaUrl,
-      long beforeProcessingRecordTimestampNs) {
-    ingestionTask.processConsumerRecord(
-        consumerRecord,
-        leaderProducedRecordContext,
-        subPartition,
-        kafkaUrl,
-        beforeProcessingRecordTimestampNs);
-
-    // complete the leaderProducedRecordContext future as processing for this leaderProducedRecordContext is done here.
-    if (leaderProducedRecordContext != null) {
-      leaderProducedRecordContext.completePersistedToDBFuture(null);
-    }
-  }
-
-  /**
-   * This function is used to drain all the records for the specified topic + partition.
-   * The reason is that we don't want overlap Kafka messages between two different subscriptions,
-   * which could introduce complicate dependencies in {@link StoreIngestionTask}.
-   * @param topicPartition for which to drain buffer
-   * @throws InterruptedException
-   */
-  public void drainBufferedRecordsFromTopicPartition(PubSubTopicPartition topicPartition) throws InterruptedException {
-    int retryNum = 1000;
-    int sleepIntervalInMS = 50;
-    internalDrainBufferedRecordsFromTopicPartition(topicPartition, retryNum, sleepIntervalInMS);
-  }
-
-  protected void internalDrainBufferedRecordsFromTopicPartition(
-      PubSubTopicPartition topicPartition,
-      int retryNum,
-      int sleepIntervalInMS) throws InterruptedException {
-    PubSubMessage<KafkaKey, KafkaMessageEnvelope, Long> fakeRecord = new FakePubSubMessage(topicPartition);
-    int workerIndex = getDrainerIndexForConsumerRecord(fakeRecord, topicPartition.getPartitionNumber());
-    BlockingQueue<QueueNode> blockingQueue = blockingQueueArr.get(workerIndex);
-    if (!drainerList.get(workerIndex).isRunning.get()) {
-      throw new VeniceException(
-          "Drainer thread " + workerIndex + " has stopped running, cannot drain the topic "
-              + topicPartition.getPubSubTopic().getName());
-    }
-
-    QueueNode fakeNode = new QueueNode(fakeRecord, null, "dummyKafkaUrl", 0);
-
-    int cur = 0;
-    while (cur++ < retryNum) {
-      if (!blockingQueue.contains(fakeNode)) {
-        LOGGER.info(
-            "The blocking queue of store writer thread: {} doesn't contain any record for: {}",
-            workerIndex,
-            topicPartition);
-        return;
-      }
-      Thread.sleep(sleepIntervalInMS);
-    }
-    String errorMessage = "There are still some records left in the blocking queue of store writer thread: "
-        + workerIndex + " for topic: " + topicPartition.getPubSubTopic().getName() + " partition after retry for "
-        + retryNum + " times";
-    LOGGER.error(errorMessage);
-    throw new VeniceException(errorMessage);
-  }
-
-  @Override
-  public boolean startInner() {
-    this.executorService = Executors.newFixedThreadPool(drainerNum, new DaemonThreadFactory("Store-writer"));
-
-    // Submit all the buffer drainers
-    for (int cur = 0; cur < drainerNum; ++cur) {
-      StoreBufferDrainer drainer = new StoreBufferDrainer(this.blockingQueueArr.get(cur), cur);
-      this.executorService.submit(drainer);
-      drainerList.add(drainer);
-    }
-    this.executorService.shutdown();
-    return true;
-  }
-
-  @Override
-  public void stopInner() throws Exception {
-    // Graceful shutdown
-    drainerList.forEach(drainer -> drainer.stop());
-    if (this.executorService != null) {
-      this.executorService.shutdownNow();
-      this.executorService.awaitTermination(10, TimeUnit.SECONDS);
-    }
-  }
-
-  @Override
-  public int getDrainerCount() {
-    return blockingQueueArr.size();
-  }
-
-  @Override
-  public long getDrainerQueueMemoryUsage(int index) {
-    return blockingQueueArr.get(index).getMemoryUsage();
-  }
-
-  @Override
-  public long getTotalMemoryUsage() {
-    long totalUsage = 0;
-    for (MemoryBoundBlockingQueue<QueueNode> queue: blockingQueueArr) {
-      totalUsage += queue.getMemoryUsage();
-    }
-    return totalUsage;
-  }
-
-  @Override
-  public long getTotalRemainingMemory() {
-    long totalRemaining = 0;
-    for (MemoryBoundBlockingQueue<QueueNode> queue: blockingQueueArr) {
-      totalRemaining += queue.remainingMemoryCapacityInByte();
-    }
-    return totalRemaining;
-  }
-
-  @Override
-  public long getMaxMemoryUsagePerDrainer() {
-    long maxUsage = 0;
-    boolean slowDrainerExists = false;
-
-    for (MemoryBoundBlockingQueue<QueueNode> queue: blockingQueueArr) {
-      maxUsage = Math.max(maxUsage, queue.getMemoryUsage());
-      if (queue.getMemoryUsage() > 0.8 * bufferCapacityPerDrainer) {
-        slowDrainerExists = true;
-      }
-    }
-
-    for (int index = 0; index < blockingQueueArr.size(); index++) {
-      StoreBufferDrainer drainer = drainerList.get(index);
-      // print drainer info when there is a slow drainer.
-      if (slowDrainerExists) {
-        MemoryBoundBlockingQueue<QueueNode> queue = blockingQueueArr.get(index);
-        int count = queue.getMemoryUsage() > 0.8 * bufferCapacityPerDrainer ? 5 : 1;
-        List<Map.Entry<PubSubTopicPartition, Long>> slowestEntries = drainer.topicToTimeSpent.entrySet()
-            .stream()
-            .sorted(comparing(Map.Entry::getValue, reverseOrder()))
-            .limit(count)
-            .collect(toList());
-
-        int finalIndex = index;
-        slowestEntries.forEach(
-            entry -> LOGGER
-                .info("In drainer number {}, time spent on {} : {} ms", finalIndex, entry.getKey(), entry.getValue()));
-      }
-      drainer.topicToTimeSpent.clear();
-    }
-
-    return maxUsage;
-  }
-
-  /** Used for testing */
-  Map<PubSubTopicPartition, Long> getTopicToTimeSpentMap(int i) {
-    return drainerList.get(i).topicToTimeSpent;
-  }
-
-  @Override
-  public long getMinMemoryUsagePerDrainer() {
-    long minUsage = Long.MAX_VALUE;
-    for (MemoryBoundBlockingQueue<QueueNode> queue: blockingQueueArr) {
-      minUsage = Math.min(minUsage, queue.getMemoryUsage());
-    }
-    return minUsage;
   }
 
   private static class FakePubSubMessage implements PubSubMessage {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -2733,13 +2733,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
       long producerBrokerLatencyMs =
           Math.max(consumerRecord.getPubSubMessageTime() - kafkaValue.producerMetadata.messageTimestamp, 0);
       long brokerConsumerLatencyMs = Math.max(currentTimeMs - consumerRecord.getPubSubMessageTime(), 0);
-      long producerConsumerLatencyMs = Math.max(currentTimeMs - kafkaValue.producerMetadata.messageTimestamp, 0);
-      recordWriterStats(
-          currentTimeMs,
-          producerBrokerLatencyMs,
-          brokerConsumerLatencyMs,
-          producerConsumerLatencyMs,
-          partitionConsumptionState);
+      recordWriterStats(currentTimeMs, producerBrokerLatencyMs, brokerConsumerLatencyMs, partitionConsumptionState);
       boolean endOfPushReceived = partitionConsumptionState.isEndOfPushReceived();
       /**
        * DIV check will happen for every single message in drainer queues.
@@ -2874,7 +2868,6 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
       long consumerTimestampMs,
       long producerBrokerLatencyMs,
       long brokerConsumerLatencyMs,
-      long producerConsumerLatencyMs,
       PartitionConsumptionState partitionConsumptionState) {
 
   }
@@ -3783,6 +3776,11 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
     SKIPPED_MESSAGE
   }
 
+  /**
+   * The method measures the time between receiving the message from the local VT and when the message is committed in
+   * the local db and ready to serve.
+   * For a leader, it's the time when the callback to the version topic write returns.
+   */
   private void recordNearlineLocalBrokerToReadyToServerLatency(
       String storeName,
       int versionNumber,

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -2955,12 +2955,12 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
    * in order to insert the {@param schemaId} there. This avoids a byte array copy, which can be beneficial in terms
    * of GC.
    */
-  private void prependHeaderAndWriteToStorageEngine(int partition, byte[] keyBytes, Put put, long currentTimeMs) {
+  private void prependHeaderAndWriteToStorageEngine(int partition, byte[] keyBytes, Put put) {
     ByteBuffer putValue = put.putValue;
 
     if ((putValue.remaining() == 0) && (put.replicationMetadataPayload.remaining() > 0)) {
       // For RMD chunk, it is already prepended with the schema ID, so we will just put to storage engine.
-      writeToStorageEngine(partition, keyBytes, put, currentTimeMs);
+      writeToStorageEngine(partition, keyBytes, put);
     } else if (putValue.position() < ValueRecord.SCHEMA_HEADER_LENGTH) {
       throw new VeniceException(
           "Start position of 'putValue' ByteBuffer shouldn't be less than " + ValueRecord.SCHEMA_HEADER_LENGTH);
@@ -2977,7 +2977,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
       putValue.position(putValue.position() - ValueRecord.SCHEMA_HEADER_LENGTH);
       ByteUtils.writeInt(putValue.array(), put.schemaId, putValue.position());
       try {
-        writeToStorageEngine(partition, keyBytes, put, currentTimeMs);
+        writeToStorageEngine(partition, keyBytes, put);
       } finally {
         /* We still want to recover the original position to make this function idempotent. */
         putValue.putInt(backupBytes);
@@ -2985,26 +2985,21 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
     }
   }
 
-  private void writeToStorageEngine(int partition, byte[] keyBytes, Put put, long currentTimeMs) {
-    boolean metricsEnabled = emitMetrics.get();
-    boolean traceEnabled = LOGGER.isTraceEnabled();
-    long putStartTimeNs = (metricsEnabled || traceEnabled) ? System.nanoTime() : 0;
+  private void writeToStorageEngine(int partition, byte[] keyBytes, Put put) {
     putInStorageEngine(partition, keyBytes, put);
     if (cacheBackend.isPresent()) {
       if (cacheBackend.get().getStorageEngine(kafkaVersionTopic) != null) {
         cacheBackend.get().getStorageEngine(kafkaVersionTopic).put(partition, keyBytes, put.putValue);
       }
     }
-    if (traceEnabled) {
-      LOGGER.trace(
-          "{} : Completed PUT to Store: {} in {} ns at {}",
-          ingestionTaskName,
-          kafkaVersionTopic,
-          System.nanoTime() - putStartTimeNs,
-          System.currentTimeMillis());
-    }
-    if (metricsEnabled) {
-      hostLevelIngestionStats.recordStorageEnginePutLatency(LatencyUtils.getLatencyInMS(putStartTimeNs), currentTimeMs);
+  }
+
+  private void deleteFromStorageEngine(int partition, byte[] keyBytes, Delete delete) {
+    removeFromStorageEngine(partition, keyBytes, delete);
+    if (cacheBackend.isPresent()) {
+      if (cacheBackend.get().getStorageEngine(kafkaVersionTopic) != null) {
+        cacheBackend.get().getStorageEngine(kafkaVersionTopic).delete(partition, keyBytes);
+      }
     }
   }
 
@@ -3131,6 +3126,11 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
     MessageType messageType = (leaderProducedRecordContext == null
         ? MessageType.valueOf(kafkaValue)
         : leaderProducedRecordContext.getMessageType());
+
+    boolean metricsEnabled = emitMetrics.get();
+    boolean traceEnabled = LOGGER.isTraceEnabled();
+    long startTimeNs = (metricsEnabled || traceEnabled) ? System.nanoTime() : 0;
+
     switch (messageType) {
       case PUT:
         // If single-threaded, we can re-use (and clobber) the same Put instance. // TODO: explore GC tuning later.
@@ -3184,22 +3184,24 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
               versionNumber,
               LatencyUtils.getElapsedTimeInMs(recordTransformStartTime),
               currentTimeMs);
-          writeToStorageEngine(producedPartition, keyBytes, put, currentTimeMs);
+          writeToStorageEngine(producedPartition, keyBytes, put);
         } else {
-
           prependHeaderAndWriteToStorageEngine(
               // Leaders might consume from a RT topic and immediately write into StorageEngine,
               // so we need to re-calculate partition.
               // Followers are not affected since they are always consuming from VTs.
               producedPartition,
               keyBytes,
-              put,
-              currentTimeMs);
+              put);
         }
         // grab the positive schema id (actual value schema id) to be used in schema warm-up value schema id.
         // for hybrid use case in read compute store in future we need revisit this as we can have multiple schemas.
         if (putSchemaId > 0) {
           valueSchemaId = putSchemaId;
+        }
+        if (metricsEnabled) {
+          hostLevelIngestionStats
+              .recordStorageEnginePutLatency(LatencyUtils.getLatencyInMS(startTimeNs), currentTimeMs);
         }
         break;
 
@@ -3213,11 +3215,10 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
           delete = ((Delete) leaderProducedRecordContext.getValueUnion());
         }
         keyLen = keyBytes.length;
-        removeFromStorageEngine(producedPartition, keyBytes, delete);
-        if (cacheBackend.isPresent()) {
-          if (cacheBackend.get().getStorageEngine(kafkaVersionTopic) != null) {
-            cacheBackend.get().getStorageEngine(kafkaVersionTopic).delete(producedPartition, keyBytes);
-          }
+        deleteFromStorageEngine(producedPartition, keyBytes, delete);
+        if (metricsEnabled) {
+          hostLevelIngestionStats
+              .recordStorageEngineDeleteLatency(LatencyUtils.getLatencyInMS(startTimeNs), currentTimeMs);
         }
         break;
 
@@ -3230,6 +3231,15 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
             ingestionTaskName + " : Invalid/Unrecognized operation type submitted: " + kafkaValue.messageType);
     }
 
+    if (traceEnabled) {
+      LOGGER.trace(
+          "{} : Completed {} to Store: {} in {} ns at {}",
+          ingestionTaskName,
+          messageType,
+          kafkaVersionTopic,
+          System.nanoTime() - startTimeNs,
+          System.currentTimeMillis());
+    }
     /*
      * Potentially clean the mapping from transient record map. consumedOffset may be -1 when individual chunks are getting
      * produced to drainer queue from kafka callback thread {@link LeaderFollowerStoreIngestionTask#LeaderProducerMessageCallback}

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/AggVersionedDIVStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/AggVersionedDIVStats.java
@@ -91,6 +91,13 @@ public class AggVersionedDIVStats extends AbstractVeniceAggVersionedStats<DIVSta
         stat -> stat.recordLeaderProducerCompletionLatencyMs(value, currentTimeMs));
   }
 
+  public void recordLeaderDIVCompletionTime(String storeName, int version, double value, long currentTimeMs) {
+    recordVersionedAndTotalStat(
+        storeName,
+        version,
+        stat -> stat.recordLeaderDIVCompletionLatencyMs(value, currentTimeMs));
+  }
+
   public void recordBenignLeaderOffsetRewind(String storeName, int version) {
     recordVersionedAndTotalStat(storeName, version, DIVStats::recordBenignLeaderOffsetRewind);
   }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/AggVersionedDIVStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/AggVersionedDIVStats.java
@@ -61,12 +61,10 @@ public class AggVersionedDIVStats extends AbstractVeniceAggVersionedStats<DIVSta
       int version,
       long currentTimeMs,
       double producerBrokerLatencyMs,
-      double brokerConsumerLatencyMs,
-      double producerConsumerLatencyMs) {
+      double brokerConsumerLatencyMs) {
     recordVersionedAndTotalStat(storeName, version, stat -> {
       stat.recordProducerSourceBrokerLatencyMs(producerBrokerLatencyMs, currentTimeMs);
       stat.recordSourceBrokerLeaderConsumerLatencyMs(brokerConsumerLatencyMs, currentTimeMs);
-      stat.recordProducerLeaderConsumerLatencyMs(producerConsumerLatencyMs, currentTimeMs);
     });
   }
 
@@ -75,12 +73,10 @@ public class AggVersionedDIVStats extends AbstractVeniceAggVersionedStats<DIVSta
       int version,
       long currentTimeMs,
       double producerBrokerLatencyMs,
-      double brokerConsumerLatencyMs,
-      double producerConsumerLatencyMs) {
+      double brokerConsumerLatencyMs) {
     recordVersionedAndTotalStat(storeName, version, stat -> {
       stat.recordProducerLocalBrokerLatencyMs(producerBrokerLatencyMs, currentTimeMs);
       stat.recordLocalBrokerFollowerConsumerLatencyMs(brokerConsumerLatencyMs, currentTimeMs);
-      stat.recordProducerFollowerConsumerLatencyMs(producerConsumerLatencyMs, currentTimeMs);
     });
   }
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/AggVersionedIngestionStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/AggVersionedIngestionStats.java
@@ -128,6 +128,10 @@ public class AggVersionedIngestionStats
     recordVersionedAndTotalStat(storeName, version, stat -> stat.recordSubscribePrepLatency(value, currentTimeMs));
   }
 
+  public void recordProducerCallBackLatency(String storeName, int version, double value, long currentTimeMs) {
+    recordVersionedAndTotalStat(storeName, version, stat -> stat.recordProducerCallBackLatency(value, currentTimeMs));
+  }
+
   public void recordConsumedRecordEndToEndProcessingLatency(
       String storeName,
       int version,

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/DIVStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/DIVStats.java
@@ -14,10 +14,8 @@ public class DIVStats {
   private final MetricConfig metricConfig = new MetricConfig();
   private final WritePathLatencySensor producerSourceBrokerLatencySensor;
   private final WritePathLatencySensor sourceBrokerLeaderConsumerLatencySensor;
-  private final WritePathLatencySensor producerLeaderConsumerLatencySensor;
   private final WritePathLatencySensor producerLocalBrokerLatencySensor;
   private final WritePathLatencySensor localBrokerFollowerConsumerLatencySensor;
-  private final WritePathLatencySensor producerFollowerConsumerLatencySensor;
   private final WritePathLatencySensor leaderProducerCompletionLatencySensor;
   private final WritePathLatencySensor leaderDIVCompletionLatencySensor;
   private final LongAdder duplicateMsg = new LongAdder();
@@ -47,14 +45,10 @@ public class DIVStats {
         new WritePathLatencySensor(localRepository, metricConfig, "producer_to_source_broker_latency");
     sourceBrokerLeaderConsumerLatencySensor =
         new WritePathLatencySensor(localRepository, metricConfig, "source_broker_to_leader_consumer_latency");
-    producerLeaderConsumerLatencySensor =
-        new WritePathLatencySensor(localRepository, metricConfig, "producer_to_leader_consumer_latency");
     producerLocalBrokerLatencySensor =
         new WritePathLatencySensor(localRepository, metricConfig, "producer_to_local_broker_latency");
     localBrokerFollowerConsumerLatencySensor =
         new WritePathLatencySensor(localRepository, metricConfig, "local_broker_to_follower_consumer_latency");
-    producerFollowerConsumerLatencySensor =
-        new WritePathLatencySensor(localRepository, metricConfig, "producer_to_follower_consumer_latency");
     leaderProducerCompletionLatencySensor =
         new WritePathLatencySensor(localRepository, metricConfig, "leader_producer_completion_latency");
     leaderDIVCompletionLatencySensor =
@@ -127,14 +121,6 @@ public class DIVStats {
     return sourceBrokerLeaderConsumerLatencySensor;
   }
 
-  public void recordProducerLeaderConsumerLatencyMs(double value, long currentTimeMs) {
-    producerLeaderConsumerLatencySensor.record(value, currentTimeMs);
-  }
-
-  public WritePathLatencySensor getProducerLeaderConsumerLatencySensor() {
-    return producerLeaderConsumerLatencySensor;
-  }
-
   public void recordProducerLocalBrokerLatencyMs(double value, long currentTimeMs) {
     producerLocalBrokerLatencySensor.record(value, currentTimeMs);
   }
@@ -149,14 +135,6 @@ public class DIVStats {
 
   public WritePathLatencySensor getLocalBrokerFollowerConsumerLatencySensor() {
     return localBrokerFollowerConsumerLatencySensor;
-  }
-
-  public void recordProducerFollowerConsumerLatencyMs(double value, long currentTimeMs) {
-    producerFollowerConsumerLatencySensor.record(value, currentTimeMs);
-  }
-
-  public WritePathLatencySensor getProducerFollowerConsumerLatencySensor() {
-    return producerFollowerConsumerLatencySensor;
   }
 
   public void recordLeaderProducerCompletionLatencyMs(double value, long currentTimeMs) {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/DIVStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/DIVStats.java
@@ -19,6 +19,7 @@ public class DIVStats {
   private final WritePathLatencySensor localBrokerFollowerConsumerLatencySensor;
   private final WritePathLatencySensor producerFollowerConsumerLatencySensor;
   private final WritePathLatencySensor leaderProducerCompletionLatencySensor;
+  private final WritePathLatencySensor leaderDIVCompletionLatencySensor;
   private final LongAdder duplicateMsg = new LongAdder();
   private final LongAdder successMsg = new LongAdder();
 
@@ -56,6 +57,8 @@ public class DIVStats {
         new WritePathLatencySensor(localRepository, metricConfig, "producer_to_follower_consumer_latency");
     leaderProducerCompletionLatencySensor =
         new WritePathLatencySensor(localRepository, metricConfig, "leader_producer_completion_latency");
+    leaderDIVCompletionLatencySensor =
+        new WritePathLatencySensor(localRepository, metricConfig, "leader_div_completion_latency");
   }
 
   public long getDuplicateMsg() {
@@ -162,6 +165,14 @@ public class DIVStats {
 
   public WritePathLatencySensor getLeaderProducerCompletionLatencySensor() {
     return leaderProducerCompletionLatencySensor;
+  }
+
+  public WritePathLatencySensor getLeaderDIVCompletionLatencySensor() {
+    return leaderDIVCompletionLatencySensor;
+  }
+
+  public void recordLeaderDIVCompletionLatencyMs(double value, long currentTimeMs) {
+    leaderDIVCompletionLatencySensor.record(value, currentTimeMs);
   }
 
   public synchronized void recordBenignLeaderOffsetRewind() {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/DIVStatsReporter.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/DIVStatsReporter.java
@@ -55,6 +55,7 @@ public class DIVStatsReporter extends AbstractVeniceStatsReporter<DIVStats> {
       registerLatencySensor("local_broker_to_follower_consumer", DIVStats::getLocalBrokerFollowerConsumerLatencySensor);
       registerLatencySensor("producer_to_follower_consumer", DIVStats::getProducerFollowerConsumerLatencySensor);
       registerLatencySensor("leader_producer_completion", DIVStats::getLeaderProducerCompletionLatencySensor);
+      registerLatencySensor("leader_div_completion", DIVStats::getLeaderDIVCompletionLatencySensor);
     }
   }
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/DIVStatsReporter.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/DIVStatsReporter.java
@@ -50,10 +50,8 @@ public class DIVStatsReporter extends AbstractVeniceStatsReporter<DIVStats> {
     if (!VeniceSystemStoreUtils.isUserSystemStore(storeName)) {
       registerLatencySensor("producer_to_source_broker", DIVStats::getProducerSourceBrokerLatencySensor);
       registerLatencySensor("source_broker_to_leader_consumer", DIVStats::getSourceBrokerLeaderConsumerLatencySensor);
-      registerLatencySensor("producer_to_leader_consumer", DIVStats::getProducerLeaderConsumerLatencySensor);
       registerLatencySensor("producer_to_local_broker", DIVStats::getProducerLocalBrokerLatencySensor);
       registerLatencySensor("local_broker_to_follower_consumer", DIVStats::getLocalBrokerFollowerConsumerLatencySensor);
-      registerLatencySensor("producer_to_follower_consumer", DIVStats::getProducerFollowerConsumerLatencySensor);
       registerLatencySensor("leader_producer_completion", DIVStats::getLeaderProducerCompletionLatencySensor);
       registerLatencySensor("leader_div_completion", DIVStats::getLeaderDIVCompletionLatencySensor);
     }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/HostLevelIngestionStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/HostLevelIngestionStats.java
@@ -77,6 +77,8 @@ public class HostLevelIngestionStats extends AbstractVeniceStats {
   private final Sensor checkLongRunningTasksLatencySensor;
   // Measure the latency in putting data into storage engine
   private final Sensor storageEnginePutLatencySensor;
+  // Measure the latency in deleting data from storage engine
+  private final Sensor storageEngineDeleteLatencySensor;
 
   /**
    * Measure the number of times a record was found in {@link PartitionConsumptionState#transientRecordMap} during UPDATE
@@ -344,7 +346,8 @@ public class HostLevelIngestionStats extends AbstractVeniceStats {
         () -> totalStats.checkLongRunningTasksLatencySensor,
         avgAndMax());
 
-    String storageEnginePutLatencySensorName = "storage_engine_put_latency";
+    String storageEnginePutLatencySensorName = "storage_engine_put_latency",
+        storageEngineDeleteLatencySensorName = "storage_engine_delete_latency";
     this.storageEnginePutLatencySensor = registerPerStoreAndTotalSensor(
         storageEnginePutLatencySensorName,
         totalStats,
@@ -352,6 +355,15 @@ public class HostLevelIngestionStats extends AbstractVeniceStats {
         new Avg(),
         new Max(),
         TehutiUtils.getPercentileStat(getName() + AbstractVeniceStats.DELIMITER + storageEnginePutLatencySensorName));
+
+    this.storageEngineDeleteLatencySensor = registerPerStoreAndTotalSensor(
+        storageEngineDeleteLatencySensorName,
+        totalStats,
+        () -> totalStats.storageEngineDeleteLatencySensor,
+        new Avg(),
+        new Max(),
+        TehutiUtils
+            .getPercentileStat(getName() + AbstractVeniceStats.DELIMITER + storageEngineDeleteLatencySensorName));
 
     this.writeComputeCacheHitCount = registerPerStoreAndTotalSensor(
         "write_compute_cache_hit_count",
@@ -504,6 +516,10 @@ public class HostLevelIngestionStats extends AbstractVeniceStats {
 
   public void recordStorageEnginePutLatency(double latency, long currentTimeMs) {
     storageEnginePutLatencySensor.record(latency, currentTimeMs);
+  }
+
+  public void recordStorageEngineDeleteLatency(double latency, long currentTimeMs) {
+    storageEngineDeleteLatencySensor.record(latency, currentTimeMs);
   }
 
   public void recordWriteComputeCacheHitCount() {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/IngestionStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/IngestionStats.java
@@ -58,6 +58,7 @@ public class IngestionStats {
       "nearline_local_broker_to_ready_to_serve_latency";
   public static final String TRANSFORMER_LATENCY = "transformer_latency";
   public static final String IDLE_TIME = "idle_time";
+  public static final String PRODUCER_CALLBACK_LATENCY = "producer_callback_latency";
 
   private static final MetricConfig METRIC_CONFIG = new MetricConfig();
   private StoreIngestionTask ingestionTask;
@@ -81,6 +82,7 @@ public class IngestionStats {
   private final WritePathLatencySensor nearlineProducerToLocalBrokerLatencySensor;
   private final WritePathLatencySensor nearlineLocalBrokerToReadyToServeLatencySensor;
   private WritePathLatencySensor transformerLatencySensor;
+  private final WritePathLatencySensor producerCallBackLatency;
   // Measure the count of ignored updates due to conflict resolution
   private final LongAdderRateGauge conflictResolutionUpdateIgnoredSensor = new LongAdderRateGauge();
   // Measure the total number of incoming conflict resolutions
@@ -163,6 +165,8 @@ public class IngestionStats {
         localMetricRepository,
         METRIC_CONFIG,
         NEARLINE_LOCAL_BROKER_TO_READY_TO_SERVE_LATENCY);
+    producerCallBackLatency =
+        new WritePathLatencySensor(localMetricRepository, METRIC_CONFIG, PRODUCER_CALLBACK_LATENCY);
 
     registerSensor(localMetricRepository, UPDATE_IGNORED_DCR, conflictResolutionUpdateIgnoredSensor);
     registerSensor(localMetricRepository, TOTAL_DCR, totalConflictResolutionCountSensor);
@@ -304,6 +308,14 @@ public class IngestionStats {
 
   public void recordSubscribePrepLatency(double value, long currentTimeMs) {
     subscribePrepLatencySensor.record(value, currentTimeMs);
+  }
+
+  public double getProducerCallBackLatencyMax() {
+    return producerCallBackLatency.getMax();
+  }
+
+  public void recordProducerCallBackLatency(double value, long currentTimeMs) {
+    producerCallBackLatency.record(value, currentTimeMs);
   }
 
   public void recordVersionTopicEndOffsetRewind() {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/IngestionStatsReporter.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/IngestionStatsReporter.java
@@ -22,6 +22,7 @@ import static com.linkedin.davinci.stats.IngestionStats.LEADER_STALLED_HYBRID_IN
 import static com.linkedin.davinci.stats.IngestionStats.NEARLINE_LOCAL_BROKER_TO_READY_TO_SERVE_LATENCY;
 import static com.linkedin.davinci.stats.IngestionStats.NEARLINE_PRODUCER_TO_LOCAL_BROKER_LATENCY;
 import static com.linkedin.davinci.stats.IngestionStats.OFFSET_REGRESSION_DCR_ERROR;
+import static com.linkedin.davinci.stats.IngestionStats.PRODUCER_CALLBACK_LATENCY;
 import static com.linkedin.davinci.stats.IngestionStats.READY_TO_SERVE_WITH_RT_LAG_METRIC_NAME;
 import static com.linkedin.davinci.stats.IngestionStats.RECORDS_CONSUMED_METRIC_NAME;
 import static com.linkedin.davinci.stats.IngestionStats.SUBSCRIBE_ACTION_PREP_LATENCY;
@@ -181,6 +182,12 @@ public class IngestionStatsReporter extends AbstractVeniceStatsReporter<Ingestio
               0,
               CONSUMED_RECORD_END_TO_END_PROCESSING_LATENCY + "_max"));
       registerSensor(new IngestionStatsGauge(this, () -> getStats().getIdleTime(), 0, IDLE_TIME + "_max"));
+      registerSensor(
+          new IngestionStatsGauge(
+              this,
+              () -> getStats().getProducerCallBackLatencyMax(),
+              0,
+              PRODUCER_CALLBACK_LATENCY + "_max"));
     }
   }
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/KafkaConsumerServiceStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/KafkaConsumerServiceStats.java
@@ -64,7 +64,6 @@ public class KafkaConsumerServiceStats extends AbstractVeniceStats {
         totalStats,
         () -> totalStats.pollResultNumSensor,
         new Avg(),
-        new Total(),
         new Min());
 
     /**

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/StoreBufferServiceStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/StoreBufferServiceStats.java
@@ -1,45 +1,52 @@
 package com.linkedin.davinci.stats;
 
-import com.linkedin.davinci.kafka.consumer.AbstractStoreBufferService;
 import com.linkedin.venice.stats.AbstractVeniceStats;
 import io.tehuti.metrics.MetricsRepository;
 import io.tehuti.metrics.Sensor;
 import io.tehuti.metrics.stats.AsyncGauge;
-import java.util.ArrayList;
-import java.util.List;
+import io.tehuti.metrics.stats.Avg;
+import io.tehuti.metrics.stats.Max;
+import io.tehuti.metrics.stats.OccurrenceRate;
+import java.util.function.LongSupplier;
 
 
 public class StoreBufferServiceStats extends AbstractVeniceStats {
-  private AbstractStoreBufferService workerService = null;
+  private final Sensor totalMemoryUsageSensor;
+  private final Sensor totalRemainingMemorySensor;
+  private final Sensor maxMemoryUsagePerWriterSensor;
+  private final Sensor minMemoryUsagePerWriterSensor;
+  private final Sensor internalProcessingLatencySensor;
+  private final Sensor internalProcessingErrorSensor;
 
-  private Sensor totalMemoryUsageSensor;
-  private Sensor totalRemainingMemorySensor;
-  private Sensor maxMemoryUsagePerWriterSensor;
-  private Sensor minMemoryUsagePerWriterSensor;
-  private List<Sensor> preDrainerSensors = new ArrayList<>(2);
-
-  public StoreBufferServiceStats(MetricsRepository metricsRepository, AbstractStoreBufferService workerService) {
+  public StoreBufferServiceStats(
+      MetricsRepository metricsRepository,
+      LongSupplier totalMemoryUsageSupplier,
+      LongSupplier totalRemainingMemorySupplier,
+      LongSupplier maxMemoryUsagePerDrainerSupplier,
+      LongSupplier minMemoryUsagePerDrainerSupplier) {
     super(metricsRepository, "StoreBufferService");
-    this.workerService = workerService;
     totalMemoryUsageSensor = registerSensor(
-        new AsyncGauge((ignored, ignored2) -> this.workerService.getTotalMemoryUsage(), "total_memory_usage"));
+        new AsyncGauge((ignored, ignored2) -> totalMemoryUsageSupplier.getAsLong(), "total_memory_usage"));
     totalRemainingMemorySensor = registerSensor(
-        new AsyncGauge((ignored, ignored2) -> this.workerService.getTotalRemainingMemory(), "total_remaining_memory"));
+        new AsyncGauge((ignored, ignored2) -> totalRemainingMemorySupplier.getAsLong(), "total_remaining_memory"));
     maxMemoryUsagePerWriterSensor = registerSensor(
         new AsyncGauge(
-            (ignored, ignored2) -> this.workerService.getMaxMemoryUsagePerDrainer(),
+            (ignored, ignored2) -> maxMemoryUsagePerDrainerSupplier.getAsLong(),
             "max_memory_usage_per_writer"));
     minMemoryUsagePerWriterSensor = registerSensor(
         new AsyncGauge(
-            (ignored, ignored2) -> this.workerService.getMinMemoryUsagePerDrainer(),
+            (ignored, ignored2) -> minMemoryUsagePerDrainerSupplier.getAsLong(),
             "min_memory_usage_per_writer"));
 
-    for (int i = 0; i < this.workerService.getDrainerCount(); i++) {
-      int finalIndex = i;
-      registerSensor(
-          new AsyncGauge(
-              (ignored, ignored2) -> this.workerService.getDrainerQueueMemoryUsage(finalIndex),
-              "memory_usage_for_writer_num_" + i));
-    }
+    internalProcessingLatencySensor = registerSensor("internal_processing_latency", new Avg(), new Max());
+    internalProcessingErrorSensor = registerSensor("internal_processing_error", new OccurrenceRate());
+  }
+
+  public void recordInternalProcessingError() {
+    internalProcessingErrorSensor.record();
+  }
+
+  public void recordInternalProcessingLatency(long latency) {
+    internalProcessingLatencySensor.record(latency);
   }
 }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreBufferServiceTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreBufferServiceTest.java
@@ -1,6 +1,7 @@
 package com.linkedin.davinci.kafka.consumer;
 
-import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;

--- a/gradle/spotbugs/exclude.xml
+++ b/gradle/spotbugs/exclude.xml
@@ -430,6 +430,7 @@
       <Class name="com.linkedin.venice.controller.VeniceParentHelixAdmin"/>
       <Class name="com.linkedin.venice.controller.VeniceHelixAdmin"/>
       <Class name="com.linkedin.davinci.kafka.consumer.ActiveActiveStoreIngestionTask"/>
+      <Class name="com.linkedin.davinci.kafka.consumer.StoreBufferService"/>
     </Or>
   </Match>
   <Match>

--- a/services/venice-server/src/test/java/com/linkedin/venice/stats/AggVersionedDIVStatsTest.java
+++ b/services/venice-server/src/test/java/com/linkedin/venice/stats/AggVersionedDIVStatsTest.java
@@ -108,43 +108,24 @@ public class AggVersionedDIVStatsTest {
     Assert.assertEquals(reporter.query("." + storeName + "--future_version.Gauge").value(), 1d);
 
     long consumerTimestampMs = System.currentTimeMillis();
-    double v1ProducerBrokerLatencyMs = 801d;
 
     double v1ProducerToSourceBrokerLatencyMs = 811d;
     double v1SourceBrokerToLeaderConsumerLatencyMs = 211d;
-    double v1ProducerToLeaderConsumerLatencyMs = 1011d;
     stats.recordLeaderLatencies(
         storeName,
         1,
         consumerTimestampMs,
         v1ProducerToSourceBrokerLatencyMs,
-        v1SourceBrokerToLeaderConsumerLatencyMs,
-        v1ProducerToLeaderConsumerLatencyMs);
-    Assert.assertEquals(
-        reporter.query("." + storeName + "_future--producer_to_leader_consumer_latency_avg_ms.DIVStatsCounter").value(),
-        v1ProducerToLeaderConsumerLatencyMs);
-    Assert.assertEquals(
-        reporter.query("." + storeName + "_future--producer_to_leader_consumer_latency_max_ms.DIVStatsCounter").value(),
-        v1ProducerToLeaderConsumerLatencyMs);
+        v1SourceBrokerToLeaderConsumerLatencyMs);
 
     double v1ProducerToLocalBrokerLatencyMs = 821d;
     double v1LocalBrokerToFollowerConsumerLatencyMs = 221d;
-    double v1ProducerToFollowerConsumerLatencyMs = 1021d;
     stats.recordFollowerLatencies(
         storeName,
         1,
         consumerTimestampMs,
         v1ProducerToLocalBrokerLatencyMs,
-        v1LocalBrokerToFollowerConsumerLatencyMs,
-        v1ProducerToFollowerConsumerLatencyMs);
-    Assert.assertEquals(
-        reporter.query("." + storeName + "_future--producer_to_follower_consumer_latency_avg_ms.DIVStatsCounter")
-            .value(),
-        v1ProducerToFollowerConsumerLatencyMs);
-    Assert.assertEquals(
-        reporter.query("." + storeName + "_future--producer_to_follower_consumer_latency_max_ms.DIVStatsCounter")
-            .value(),
-        v1ProducerToFollowerConsumerLatencyMs);
+        v1LocalBrokerToFollowerConsumerLatencyMs);
 
     // v1 becomes the current version and v2 starts pushing
     version.setStatus(VersionStatus.ONLINE);
@@ -153,7 +134,6 @@ public class AggVersionedDIVStatsTest {
     mockStore.addVersion(version2);
 
     stats.recordDuplicateMsg(storeName, 2);
-    double v2BrokerConsumerLatencyMs = 202d;
     stats.handleStoreChanged(mockStore);
 
     // expect to see v1's stats on current reporter and v2's stats on future reporter
@@ -163,14 +143,12 @@ public class AggVersionedDIVStatsTest {
 
     double v2ProducerToSourceBrokerLatencyMs = 812d;
     double v2SourceBrokerToLeaderConsumerLatencyMs = 212d;
-    double v2ProducerToLeaderConsumerLatencyMs = 1012d;
     stats.recordLeaderLatencies(
         storeName,
         2,
         consumerTimestampMs,
         v2ProducerToSourceBrokerLatencyMs,
-        v2SourceBrokerToLeaderConsumerLatencyMs,
-        v2ProducerToLeaderConsumerLatencyMs);
+        v2SourceBrokerToLeaderConsumerLatencyMs);
 
     Assert.assertEquals(
         reporter.query("." + storeName + "_current--producer_to_source_broker_latency_avg_ms.DIVStatsCounter").value(),
@@ -189,14 +167,12 @@ public class AggVersionedDIVStatsTest {
 
     double v2ProducerToLocalBrokerLatencyMs = 822d;
     double v2LocalBrokerToFollowerConsumerLatencyMs = 222d;
-    double v2ProducerToFollowerConsumerLatencyMs = 1022d;
     stats.recordFollowerLatencies(
         storeName,
         2,
         consumerTimestampMs,
         v2ProducerToLocalBrokerLatencyMs,
-        v2LocalBrokerToFollowerConsumerLatencyMs,
-        v2ProducerToFollowerConsumerLatencyMs);
+        v2LocalBrokerToFollowerConsumerLatencyMs);
 
     Assert.assertEquals(
         reporter.query("." + storeName + "_current--producer_to_local_broker_latency_avg_ms.DIVStatsCounter").value(),


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Summary, imperative, start upper case, don't end with a period
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

This PR adds some metrics on the write path to provide fine-granular view, specifically:
1. Add `leader_div_completion_latency` to measure how long it takes for a leader node begins to process each record pulled from pubsub system, e.g. kafka, to the time it finishes DIV(date ingestion validation).
2. Add `internal_process_latency`, which measures how long for a drainer to process a record internally and `process_record_error`, which count the number of errors happen for internal processing in `StoreBufferService`(SBS). The term "internal process" refers to the process nodes persist records on the local disk.
3. Add `storage_engine_delete_latency`, which measures the long to delete a record from store engine.
4. Remove `memory_usage_for_writer_num_` metrics for SBS since they are not particularly helpful for debugging. We used to use them to identify drainer skew issue tho.
5. Remove `producer_to_follower_consumer_latency` and `producer_to_leader_consumer_latency` since they can be deduced using existing metrics
6. Removed `Total` for `consumer_poll_result_num`
7. Added `producer_callback_latency` to measure the total time spent in the producer callback.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
GHCI

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [x] Yes. Make sure to explain your proposed changes and call out the behavior change.