### PR TITLE
[vpj] Allow enabling compression metric collection without using mapper to build dictionary

### DIFF
--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/DefaultInputDataInfoProvider.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/DefaultInputDataInfoProvider.java
@@ -266,7 +266,8 @@ public class DefaultInputDataInfoProvider implements InputDataInfoProvider {
         if (!pushJobSetting.isIncrementalPush) {
           if (!pushJobSetting.useMapperToBuildDict) {
             /** If dictionary compression is enabled for version, read the records to get training samples */
-            if (pushJobSetting.storeCompressionStrategy == CompressionStrategy.ZSTD_WITH_DICT) {
+            if (pushJobSetting.storeCompressionStrategy == CompressionStrategy.ZSTD_WITH_DICT
+                || pushJobSetting.compressionMetricCollectionEnabled) {
               InputDataInfoProvider.loadZstdTrainingSamples(fileIterator, pushJobZstdConfig);
             }
           } else {

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/DefaultInputDataInfoProvider.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/DefaultInputDataInfoProvider.java
@@ -87,8 +87,8 @@ public class DefaultInputDataInfoProvider implements InputDataInfoProvider {
     }
 
     if (!pushJobSetting.isIncrementalPush && !pushJobSetting.useMapperToBuildDict) {
-      if (this.pushJobSetting.storeCompressionStrategy == CompressionStrategy.ZSTD_WITH_DICT) {
-        LOGGER.info("Zstd compression enabled for {}", pushJobSetting.storeName);
+      if (pushJobSetting.storeCompressionStrategy == CompressionStrategy.ZSTD_WITH_DICT
+          || pushJobSetting.compressionMetricCollectionEnabled) {
         initZstdConfig(fileStatuses.length);
       }
     }
@@ -294,7 +294,7 @@ public class DefaultInputDataInfoProvider implements InputDataInfoProvider {
   }
 
   @Override
-  public byte[] getZstdDictTrainSamples() {
+  public byte[] trainZstdDictionary() {
     return pushJobZstdConfig.getZstdDictTrainer().trainSamples();
   }
 
@@ -357,7 +357,8 @@ public class DefaultInputDataInfoProvider implements InputDataInfoProvider {
         if (!pushJobSetting.isIncrementalPush) {
           if (!pushJobSetting.useMapperToBuildDict) {
             /** If dictionary compression is enabled for version, read the records to get training samples */
-            if (pushJobSetting.storeCompressionStrategy == CompressionStrategy.ZSTD_WITH_DICT) {
+            if (pushJobSetting.storeCompressionStrategy == CompressionStrategy.ZSTD_WITH_DICT
+                || pushJobSetting.compressionMetricCollectionEnabled) {
               InputDataInfoProvider.loadZstdTrainingSamples(fileIterator, pushJobZstdConfig);
             }
           } else {

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/DefaultInputDataInfoProvider.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/DefaultInputDataInfoProvider.java
@@ -5,10 +5,11 @@ import static com.linkedin.venice.hadoop.VenicePushJobConstants.DEFAULT_VALUE_FI
 import static com.linkedin.venice.hadoop.VenicePushJobConstants.FILE_KEY_SCHEMA;
 import static com.linkedin.venice.hadoop.VenicePushJobConstants.FILE_VALUE_SCHEMA;
 import static com.linkedin.venice.hadoop.VenicePushJobConstants.KEY_FIELD_PROP;
+import static com.linkedin.venice.hadoop.VenicePushJobConstants.MINIMUM_NUMBER_OF_SAMPLES_REQUIRED_TO_BUILD_ZSTD_DICTIONARY;
 import static com.linkedin.venice.hadoop.VenicePushJobConstants.PATH_FILTER;
 import static com.linkedin.venice.hadoop.VenicePushJobConstants.VALUE_FIELD_PROP;
 
-import com.linkedin.venice.compression.CompressionStrategy;
+import com.linkedin.venice.compression.ZstdWithDictCompressor;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.hadoop.exceptions.VeniceInconsistentSchemaException;
 import com.linkedin.venice.hadoop.exceptions.VeniceSchemaFieldNotFoundException;
@@ -86,11 +87,8 @@ public class DefaultInputDataInfoProvider implements InputDataInfoProvider {
       throw new RuntimeException("No data found at source path: " + srcPath);
     }
 
-    if (!pushJobSetting.isIncrementalPush && !pushJobSetting.useMapperToBuildDict) {
-      if (pushJobSetting.storeCompressionStrategy == CompressionStrategy.ZSTD_WITH_DICT
-          || pushJobSetting.compressionMetricCollectionEnabled) {
-        initZstdConfig(fileStatuses.length);
-      }
+    if (pushJobSetting.isZstdDictCreationRequired && !pushJobSetting.useMapperToBuildDict) {
+      initZstdConfig(fileStatuses.length);
     }
 
     // try reading the file via sequence file reader. It indicates Vson input if it is succeeded.
@@ -119,6 +117,7 @@ public class DefaultInputDataInfoProvider implements InputDataInfoProvider {
       if (!pushJobSetting.useMapperToBuildDict) {
         fileAndOutputValueSchema = checkAvroSchemaConsistency(fs, fileStatuses, inputFileDataSize);
       } else {
+        // ValidateSchemaAndBuildDictMapper will validate all file schemas and build the dictionary
         fileAndOutputValueSchema = getAvroFileHeader(fs, fileStatuses[0].getPath(), false);
       }
 
@@ -137,6 +136,7 @@ public class DefaultInputDataInfoProvider implements InputDataInfoProvider {
       if (!pushJobSetting.useMapperToBuildDict) {
         vsonSchema = checkVsonSchemaConsistency(fs, fileStatuses, inputFileDataSize);
       } else {
+        // ValidateSchemaAndBuildDictMapper will validate all file schemas and build the dictionary
         vsonSchema = getVsonFileHeader(fs, fileStatuses[0].getPath(), false);
       }
 
@@ -195,7 +195,8 @@ public class DefaultInputDataInfoProvider implements InputDataInfoProvider {
                 + fileStatus.getPath().getName());
       }
       inputFileDataSize.addAndGet(fileStatus.getLen());
-      Pair<VsonSchema, VsonSchema> newSchema = getVsonFileHeader(fs, fileStatus.getPath(), true);
+      Pair<VsonSchema, VsonSchema> newSchema =
+          getVsonFileHeader(fs, fileStatus.getPath(), pushJobSetting.isZstdDictCreationRequired);
       if (!vsonSchema.getFirst().equals(newSchema.getFirst())
           || !vsonSchema.getSecond().equals(newSchema.getSecond())) {
         throw new VeniceInconsistentSchemaException(
@@ -259,27 +260,13 @@ public class DefaultInputDataInfoProvider implements InputDataInfoProvider {
       FileSystem fs,
       Path path,
       boolean isZstdDictCreationRequired) {
-    LOGGER.debug("path:{}", path.toUri().getPath());
     VeniceVsonRecordReader recordReader = getVeniceVsonRecordReader(fs, path);
-    try (VeniceVsonFileIterator fileIterator = new VeniceVsonFileIterator(fs, path, recordReader)) {
-      if (isZstdDictCreationRequired) {
-        if (!pushJobSetting.isIncrementalPush) {
-          if (!pushJobSetting.useMapperToBuildDict) {
-            /** If dictionary compression is enabled for version, read the records to get training samples */
-            if (pushJobSetting.storeCompressionStrategy == CompressionStrategy.ZSTD_WITH_DICT
-                || pushJobSetting.compressionMetricCollectionEnabled) {
-              InputDataInfoProvider.loadZstdTrainingSamples(fileIterator, pushJobZstdConfig);
-            }
-          } else {
-            /** If dictionary compression is enabled for version or compression metric collection is enabled,
-             * read the records to get training samples
-             */
-            InputDataInfoProvider.loadZstdTrainingSamples(fileIterator, pushJobZstdConfig);
-          }
-        }
+    if (isZstdDictCreationRequired) {
+      try (VeniceVsonFileIterator fileIterator = new VeniceVsonFileIterator(fs, path, recordReader)) {
+        InputDataInfoProvider.loadZstdTrainingSamples(fileIterator, pushJobZstdConfig);
+      } catch (IOException e) {
+        LOGGER.error(e);
       }
-    } catch (IOException e) {
-      LOGGER.error(e);
     }
     return recordReader.getMetadataMap();
   }
@@ -296,6 +283,17 @@ public class DefaultInputDataInfoProvider implements InputDataInfoProvider {
 
   @Override
   public byte[] trainZstdDictionary() {
+    int collectedNumberOfSamples = pushJobZstdConfig.getCollectedNumberOfSamples();
+    int minNumberOfSamples = MINIMUM_NUMBER_OF_SAMPLES_REQUIRED_TO_BUILD_ZSTD_DICTIONARY;
+    if (collectedNumberOfSamples < minNumberOfSamples) {
+      /** check {@link MINIMUM_NUMBER_OF_SAMPLES_REQUIRED_TO_BUILD_ZSTD_DICTIONARY} */
+      LOGGER.warn(
+          "Training ZSTD compression dictionary on store data skipped. The sample size is too small. "
+              + "Collected number of samples: {}, Minimum number of required samples: {}. Will use synthetic data instead.",
+          collectedNumberOfSamples,
+          minNumberOfSamples);
+      return ZstdWithDictCompressor.buildDictionaryOnSyntheticAvroData();
+    }
     return pushJobZstdConfig.getZstdDictTrainer().trainSamples();
   }
 
@@ -337,7 +335,8 @@ public class DefaultInputDataInfoProvider implements InputDataInfoProvider {
                 + fileStatus.getPath().getName());
       }
       inputFileDataSize.addAndGet(fileStatus.getLen());
-      Pair<Schema, Schema> newSchema = getAvroFileHeader(fs, fileStatus.getPath(), true);
+      Pair<Schema, Schema> newSchema =
+          getAvroFileHeader(fs, fileStatus.getPath(), pushJobSetting.isZstdDictCreationRequired);
       if (!avroSchema.equals(newSchema)) {
         throw new VeniceInconsistentSchemaException(
             String.format(
@@ -351,27 +350,13 @@ public class DefaultInputDataInfoProvider implements InputDataInfoProvider {
   }
 
   protected Pair<Schema, Schema> getAvroFileHeader(FileSystem fs, Path path, boolean isZstdDictCreationRequired) {
-    LOGGER.debug("path:{}", path.toUri().getPath());
     VeniceAvroRecordReader recordReader = getVeniceAvroRecordReader(fs, path);
-    try (VeniceAvroFileIterator fileIterator = new VeniceAvroFileIterator(fs, path, recordReader)) {
-      if (isZstdDictCreationRequired) {
-        if (!pushJobSetting.isIncrementalPush) {
-          if (!pushJobSetting.useMapperToBuildDict) {
-            /** If dictionary compression is enabled for version, read the records to get training samples */
-            if (pushJobSetting.storeCompressionStrategy == CompressionStrategy.ZSTD_WITH_DICT
-                || pushJobSetting.compressionMetricCollectionEnabled) {
-              InputDataInfoProvider.loadZstdTrainingSamples(fileIterator, pushJobZstdConfig);
-            }
-          } else {
-            /** If dictionary compression is enabled for version or compression metric collection is enabled,
-             * read the records to get training samples
-             */
-            InputDataInfoProvider.loadZstdTrainingSamples(fileIterator, pushJobZstdConfig);
-          }
-        }
+    if (isZstdDictCreationRequired) {
+      try (VeniceAvroFileIterator fileIterator = new VeniceAvroFileIterator(fs, path, recordReader)) {
+        InputDataInfoProvider.loadZstdTrainingSamples(fileIterator, pushJobZstdConfig);
+      } catch (IOException e) {
+        LOGGER.error(e);
       }
-    } catch (IOException e) {
-      LOGGER.error(e);
     }
     return new Pair<>(recordReader.getDataSchema(), recordReader.getValueSchema());
   }

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/InputDataInfoProvider.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/InputDataInfoProvider.java
@@ -125,7 +125,7 @@ public interface InputDataInfoProvider extends Closeable {
         ByteUtils.generateHumanReadableByteCountString(fileSampleSize));
   }
 
-  byte[] getZstdDictTrainSamples();
+  byte[] trainZstdDictionary();
 
   Schema extractAvroSubSchema(Schema origin, String fieldName);
 

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/KafkaInputDataInfoProvider.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/KafkaInputDataInfoProvider.java
@@ -35,7 +35,7 @@ public class KafkaInputDataInfoProvider implements InputDataInfoProvider {
   }
 
   @Override
-  public byte[] getZstdDictTrainSamples() {
+  public byte[] trainZstdDictionary() {
     throw new VeniceUnsupportedOperationException("Zstd for KafkaInputDataInfoProvider");
   }
 

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/ValidateSchemaAndBuildDictMapper.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/ValidateSchemaAndBuildDictMapper.java
@@ -214,7 +214,7 @@ public class ValidateSchemaAndBuildDictMapper extends AbstractDataWriterTask
                 inputDataInfoProvider.pushJobZstdConfig.getFilledSize());
             ByteBuffer compressionDictionary;
             try {
-              compressionDictionary = ByteBuffer.wrap(inputDataInfoProvider.getZstdDictTrainSamples());
+              compressionDictionary = ByteBuffer.wrap(inputDataInfoProvider.trainZstdDictionary());
               mapperOutputRecord.put(KEY_ZSTD_COMPRESSION_DICTIONARY, compressionDictionary);
               MRJobCounterHelper.incrMapperZstdDictTrainSuccessCount(reporter, 1);
               LOGGER.info("ZSTD compression dictionary size = {} bytes", compressionDictionary.remaining());

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
@@ -1132,10 +1132,6 @@ public class VenicePushJob implements AutoCloseable {
       return false;
     }
 
-    if (!inputFileHasRecords) {
-      LOGGER.info("No compression dictionary will be generated as there are no records");
-    }
-
     if (pushJobSetting.compressionMetricCollectionEnabled
         || pushJobSetting.storeCompressionStrategy == CompressionStrategy.ZSTD_WITH_DICT) {
       if (!inputFileHasRecords) {
@@ -1186,8 +1182,6 @@ public class VenicePushJob implements AutoCloseable {
     }
 
     if (pushJobSetting.isSourceKafka) {
-      // repush from kafka: This is already checked before calling this function.
-      // This is a defensive check.
       LOGGER.info("No compression related metrics will be generated as the push type is repush");
       return false;
     }

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
@@ -457,15 +457,6 @@ public class VenicePushJob implements AutoCloseable {
         props.getBoolean(COMPRESSION_METRIC_COLLECTION_ENABLED, DEFAULT_COMPRESSION_METRIC_COLLECTION_ENABLED);
     pushJobSettingToReturn.useMapperToBuildDict =
         props.getBoolean(USE_MAPPER_TO_BUILD_DICTIONARY, DEFAULT_USE_MAPPER_TO_BUILD_DICTIONARY);
-    if (pushJobSettingToReturn.compressionMetricCollectionEnabled && !pushJobSettingToReturn.useMapperToBuildDict) {
-      // TODO the idea is to only have compressionMetricCollectionEnabled as a config and remove useMapperToBuildDict
-      // feature flag after its stable.
-      LOGGER.warn(
-          "Force enabling \"{}\" to support \"{}\"",
-          USE_MAPPER_TO_BUILD_DICTIONARY,
-          COMPRESSION_METRIC_COLLECTION_ENABLED);
-      pushJobSettingToReturn.useMapperToBuildDict = true;
-    }
     if (pushJobSettingToReturn.useMapperToBuildDict) {
       pushJobSettingToReturn.useMapperToBuildDictOutputPath = props
           .getString(MAPPER_OUTPUT_DIRECTORY, VALIDATE_SCHEMA_AND_BUILD_DICTIONARY_MAPPER_OUTPUT_PARENT_DIR_DEFAULT);
@@ -1543,7 +1534,7 @@ public class VenicePushJob implements AutoCloseable {
 
         if (!pushJobSetting.useMapperToBuildDict) {
           LOGGER.info("Training Zstd dictionary");
-          compressionDictionary = ByteBuffer.wrap(getInputDataInfoProvider().getZstdDictTrainSamples());
+          compressionDictionary = ByteBuffer.wrap(getInputDataInfoProvider().trainZstdDictionary());
           pushJobSetting.isZstdDictCreationSuccess = true;
         } else {
           if (pushJobSetting.isZstdDictCreationSuccess) {

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJobConstants.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJobConstants.java
@@ -61,8 +61,6 @@ public final class VenicePushJobConstants {
    *
    *  This config also gets evaluated in {@link VenicePushJob#evaluateCompressionMetricCollectionEnabled}
    *  <br><br>
-   *
-   *  Enabling this feature force enables {@link #USE_MAPPER_TO_BUILD_DICTIONARY}.
    */
   public static final String COMPRESSION_METRIC_COLLECTION_ENABLED = "compression.metric.collection.enabled";
   public static final boolean DEFAULT_COMPRESSION_METRIC_COLLECTION_ENABLED = false;
@@ -77,11 +75,8 @@ public final class VenicePushJobConstants {
    * in-memory and to help play around with the sample size and also to support future enhancements
    * if needed. <br><br>
    *
-   * Currently, this will be force enabled if {@link #COMPRESSION_METRIC_COLLECTION_ENABLED} is
-   * enabled and the plan is to make this enabled by default and clean up remaining code once
-   * this becomes stable to make the flow similar for all cases. But needs to be discussed further
-   * on "using a mapper when not really needed (if no dictionary needed or the sample size is small)"
-   * vs "having 2 different flows to manage/test".
+   * Currently, the plan is to only have it available for MapReduce compute engine and remove it eventually as we
+   * remove the MapReduce-related codes.
    */
   public static final String USE_MAPPER_TO_BUILD_DICTIONARY = "use.mapper.to.build.dictionary";
   public static final boolean DEFAULT_USE_MAPPER_TO_BUILD_DICTIONARY = false;


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Allow enabling compression metric collection without using mapper to build dictionary
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
Currently, `use.mapper.to.build.dictionary` is auto enabled when `compression.metric.collection.enabled` is enabled. This commit separates the two configs for migration purposes and `use.mapper.to.build.dictionary` will not be auto-enabled when `compression.metric.collection.enabled` is enabled and it now needs to be explicitly enabled. Eventually, `use.mapper.to.build.dictionary` will be removed along with the `ValidateSchemaAndBuildDict` job.

Operationally, we have noticed that often, the VPJ jobs wait in the queue to acquire resources from Yarn despite the job only requesting a container for one map task and no reduce tasks. When abstracting the compute engines used by VPJ, we decided to not abstract the `ValidateSchemaAndBuildDict` job. We decided this because the initial reasons to add a dedicated job are no longer valid:
1. Zstd dictionary creation would sometimes [crash the JVM](https://github.com/luben/zstd-jni/issues/253)
    * This issue has now been fixed in the library; and
    *  We also have guardrails for this in our code
2. Ability to build larger dictionaries: 
    * We believe the VPJ executors can have enough memory to allow them to build good enough dictionaries
    * At LinkedIn, we have found that dictionaries of size <150 KB and using 200 MB of samples offer great compression ratios. (Upto 40X in some cases). And for this, our executors only need 256 MB of memory.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
Updated unit tests. GH CI runs all tests. Will test on test jobs soon.

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [X] Yes. Make sure to explain your proposed changes and call out the behavior change.
    - `use.mapper.to.build.dictionary` will not be auto-enabled when `compression.metric.collection.enabled` is enabled and it now needs to be explicitly enabled
    - This is okay because this piece only offers analytics around optimization and there are no users of this functionality other than ourselves