### PR TITLE
[test] Make VeniceProperties overridable in PubSubConsumerAdapterTest

### DIFF
--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/pubsub/api/consumer/PubSubConsumerAdapterTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/pubsub/api/consumer/PubSubConsumerAdapterTest.java
@@ -109,6 +109,19 @@ public class PubSubConsumerAdapterTest {
   @BeforeMethod(alwaysRun = true)
   public void setUpMethod() {
     String clientId = Utils.getUniqueString("test-consumer-");
+    Properties pubSubProperties = getPubSubProperties();
+    pubSubProperties.putAll(pubSubBrokerWrapper.getAdditionalConfig());
+    pubSubProperties.putAll(pubSubBrokerWrapper.getMergeableConfigs());
+    VeniceProperties veniceProperties = new VeniceProperties(pubSubProperties);
+    pubSubConsumerAdapter = pubSubClientsFactory.getConsumerAdapterFactory()
+        .create(veniceProperties, false, pubSubMessageDeserializer, clientId);
+    pubSubProducerAdapterLazy =
+        Lazy.of(() -> pubSubClientsFactory.getProducerAdapterFactory().create(veniceProperties, clientId, null));
+    pubSubAdminAdapterLazy =
+        Lazy.of(() -> pubSubClientsFactory.getAdminAdapterFactory().create(veniceProperties, pubSubTopicRepository));
+  }
+
+  protected Properties getPubSubProperties() {
     Properties properties = new Properties();
     properties.setProperty(ConfigKeys.KAFKA_BOOTSTRAP_SERVERS, pubSubBrokerWrapper.getAddress());
     properties.setProperty(
@@ -117,16 +130,7 @@ public class PubSubConsumerAdapterTest {
     properties.setProperty(PUBSUB_CONSUMER_CHECK_TOPIC_EXISTENCE, "true");
     properties
         .setProperty(PUBSUB_CONSUMER_POSITION_RESET_STRATEGY, PUBSUB_CONSUMER_POSITION_RESET_STRATEGY_DEFAULT_VALUE);
-    properties.putAll(pubSubBrokerWrapper.getAdditionalConfig());
-    properties.putAll(pubSubBrokerWrapper.getMergeableConfigs());
-    VeniceProperties veniceProperties = new VeniceProperties(properties);
-
-    pubSubConsumerAdapter = pubSubClientsFactory.getConsumerAdapterFactory()
-        .create(veniceProperties, false, pubSubMessageDeserializer, clientId);
-    pubSubProducerAdapterLazy =
-        Lazy.of(() -> pubSubClientsFactory.getProducerAdapterFactory().create(veniceProperties, clientId, null));
-    pubSubAdminAdapterLazy =
-        Lazy.of(() -> pubSubClientsFactory.getAdminAdapterFactory().create(veniceProperties, pubSubTopicRepository));
+    return properties;
   }
 
   @AfterMethod(alwaysRun = true)


### PR DESCRIPTION

## Make VeniceProperties overridable in PubSubConsumerAdapterTest
Make VeniceProperties overridable in PubSubConsumerAdapterTest so that different implementations can tune the 
clients as per their requirement to achieve the desired behavior. 

Resolves #XXX

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.