### PR TITLE
[server] Do not collect stats for metadata requests

### DIFF
--- a/services/venice-server/src/main/java/com/linkedin/venice/listener/RouterRequestHttpHandler.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/listener/RouterRequestHttpHandler.java
@@ -105,7 +105,7 @@ public class RouterRequestHttpHandler extends SimpleChannelInboundHandler<FullHt
           }
           break;
         case HEALTH:
-          statsHandler.setHealthCheck(true);
+          statsHandler.setMetadataRequest(true);
           HealthCheckRequest healthCheckRequest = new HealthCheckRequest();
           ctx.fireChannelRead(healthCheckRequest);
           break;
@@ -120,11 +120,13 @@ public class RouterRequestHttpHandler extends SimpleChannelInboundHandler<FullHt
           ctx.fireChannelRead(adminRequest);
           break;
         case METADATA:
+          statsHandler.setMetadataRequest(true);
           MetadataFetchRequest metadataFetchRequest = MetadataFetchRequest.parseGetHttpRequest(req);
           statsHandler.setStoreName(metadataFetchRequest.getStoreName());
           ctx.fireChannelRead(metadataFetchRequest);
           break;
         case CURRENT_VERSION:
+          statsHandler.setMetadataRequest(true);
           CurrentVersionRequest currentVersionRequest = CurrentVersionRequest.parseGetHttpRequest(req);
           statsHandler.setStoreName(currentVersionRequest.getStoreName());
           ctx.fireChannelRead(currentVersionRequest);

--- a/services/venice-server/src/main/java/com/linkedin/venice/listener/ServerStatsContext.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/listener/ServerStatsContext.java
@@ -22,7 +22,7 @@ public class ServerStatsContext {
   private long startTimeInNS;
   private HttpResponseStatus responseStatus;
   private String storeName = null;
-  private boolean isHealthCheck;
+  private boolean isMetadataRequest;
   private double databaseLookupLatency = -1;
   private int multiChunkLargeValueCount = -1;
   private int requestKeyCount = -1;
@@ -138,7 +138,7 @@ public class ServerStatsContext {
     partsInvokeDelayLatency = -1;
     secondPartLatency = -1;
     requestPartCount = 1;
-    isHealthCheck = false;
+    isMetadataRequest = false;
     responseStatus = null;
     statCallbackExecuted = false;
     databaseLookupLatency = -1;
@@ -169,8 +169,8 @@ public class ServerStatsContext {
     this.newRequest = true;
   }
 
-  public boolean isHealthCheck() {
-    return isHealthCheck;
+  public boolean isMetadataRequest() {
+    return isMetadataRequest;
   }
 
   public boolean isStatCallBackExecuted() {
@@ -193,8 +193,8 @@ public class ServerStatsContext {
     this.storeName = name;
   }
 
-  public void setHealthCheck(boolean healthCheck) {
-    this.isHealthCheck = healthCheck;
+  public void setMetadataRequest(boolean metadataRequest) {
+    this.isMetadataRequest = metadataRequest;
   }
 
   public void setRequestTerminatedEarly() {

--- a/services/venice-server/src/main/java/com/linkedin/venice/listener/StatsHandler.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/listener/StatsHandler.java
@@ -47,8 +47,8 @@ public class StatsHandler extends ChannelDuplexHandler {
     serverStatsContext.setStoreName(name);
   }
 
-  public void setHealthCheck(boolean healthCheck) {
-    serverStatsContext.setHealthCheck(healthCheck);
+  public void setMetadataRequest(boolean metadataRequest) {
+    serverStatsContext.setMetadataRequest(metadataRequest);
   }
 
   public void setRequestTerminatedEarly() {
@@ -190,8 +190,8 @@ public class StatsHandler extends ChannelDuplexHandler {
         throw new VeniceException("request status could not be null");
       }
 
-      // we don't record if it is a health check request
-      if (serverStatsContext.isHealthCheck()) {
+      // we don't record if it is a metatadata request
+      if (serverStatsContext.isMetadataRequest()) {
         return;
       }
 


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Do not collect stats for metadata requests
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Metadata requests for otherwise unused stores triggers metric collection, which for clusters with high number of stores creates memory pressure. This PR skips metric recording for metadata requests which includes `current_version/health and metatdata` calls.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
GHCI
## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.