### PR TITLE
[vpj] Fix deterministic GUID generation for VPJ

### DIFF
--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/mapreduce/datawriter/jobs/DataWriterMRJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/mapreduce/datawriter/jobs/DataWriterMRJob.java
@@ -206,7 +206,8 @@ public class DataWriterMRJob extends DataWriterComputeJob {
         props.getString(ZSTD_COMPRESSION_LEVEL, String.valueOf(Zstd.maxCompressionLevel())));
     conf.setBoolean(ZSTD_DICTIONARY_CREATION_SUCCESS, pushJobSetting.isZstdDictCreationSuccess);
 
-    // Deterministic producerGUID generator
+    // We generate a random UUID once, and the tasks of the compute job can use this to build the same producerGUID
+    // deterministically.
     UUID producerGuid = UUID.randomUUID();
     conf.setLong(PUSH_JOB_GUID_MOST_SIGNIFICANT_BITS, producerGuid.getMostSignificantBits());
     conf.setLong(PUSH_JOB_GUID_LEAST_SIGNIFICANT_BITS, producerGuid.getLeastSignificantBits());

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/mapreduce/datawriter/jobs/DataWriterMRJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/mapreduce/datawriter/jobs/DataWriterMRJob.java
@@ -7,6 +7,8 @@ import static com.linkedin.venice.ConfigKeys.KAFKA_PRODUCER_DELIVERY_TIMEOUT_MS;
 import static com.linkedin.venice.ConfigKeys.KAFKA_PRODUCER_REQUEST_TIMEOUT_MS;
 import static com.linkedin.venice.ConfigKeys.KAFKA_PRODUCER_RETRIES_CONFIG;
 import static com.linkedin.venice.ConfigKeys.PARTITIONER_CLASS;
+import static com.linkedin.venice.ConfigKeys.PUSH_JOB_GUID_LEAST_SIGNIFICANT_BITS;
+import static com.linkedin.venice.ConfigKeys.PUSH_JOB_GUID_MOST_SIGNIFICANT_BITS;
 import static com.linkedin.venice.VeniceConstants.DEFAULT_SSL_FACTORY_CLASS_NAME;
 import static com.linkedin.venice.hadoop.VenicePushJobConstants.ALLOW_DUPLICATE_KEY;
 import static com.linkedin.venice.hadoop.VenicePushJobConstants.BATCH_NUM_BYTES_PROP;
@@ -71,6 +73,7 @@ import com.linkedin.venice.hadoop.task.datawriter.DataWriterTaskTracker;
 import com.linkedin.venice.utils.VeniceProperties;
 import com.linkedin.venice.writer.VeniceWriter;
 import java.io.IOException;
+import java.util.UUID;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.mapred.AvroInputFormat;
@@ -202,6 +205,11 @@ public class DataWriterMRJob extends DataWriterComputeJob {
         ZSTD_COMPRESSION_LEVEL,
         props.getString(ZSTD_COMPRESSION_LEVEL, String.valueOf(Zstd.maxCompressionLevel())));
     conf.setBoolean(ZSTD_DICTIONARY_CREATION_SUCCESS, pushJobSetting.isZstdDictCreationSuccess);
+
+    // Deterministic producerGUID generator
+    UUID producerGuid = UUID.randomUUID();
+    conf.setLong(PUSH_JOB_GUID_MOST_SIGNIFICANT_BITS, producerGuid.getMostSignificantBits());
+    conf.setLong(PUSH_JOB_GUID_LEAST_SIGNIFICANT_BITS, producerGuid.getLeastSignificantBits());
 
     /**
      * Override the configs following the rules:

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/spark/datawriter/jobs/AbstractDataWriterSparkJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/spark/datawriter/jobs/AbstractDataWriterSparkJob.java
@@ -292,7 +292,8 @@ public abstract class AbstractDataWriterSparkJob extends DataWriterComputeJob {
         props.getString(ZSTD_COMPRESSION_LEVEL, String.valueOf(Zstd.maxCompressionLevel())));
     jobConf.set(ZSTD_DICTIONARY_CREATION_SUCCESS, pushJobSetting.isZstdDictCreationSuccess);
 
-    // Deterministic producerGUID generator
+    // We generate a random UUID once, and the tasks of the compute job can use this to build the same producerGUID
+    // deterministically.
     UUID producerGuid = UUID.randomUUID();
     jobConf.set(PUSH_JOB_GUID_MOST_SIGNIFICANT_BITS, producerGuid.getMostSignificantBits());
     jobConf.set(PUSH_JOB_GUID_LEAST_SIGNIFICANT_BITS, producerGuid.getLeastSignificantBits());

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/spark/datawriter/jobs/AbstractDataWriterSparkJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/spark/datawriter/jobs/AbstractDataWriterSparkJob.java
@@ -6,6 +6,8 @@ import static com.linkedin.venice.ConfigKeys.KAFKA_PRODUCER_DELIVERY_TIMEOUT_MS;
 import static com.linkedin.venice.ConfigKeys.KAFKA_PRODUCER_REQUEST_TIMEOUT_MS;
 import static com.linkedin.venice.ConfigKeys.KAFKA_PRODUCER_RETRIES_CONFIG;
 import static com.linkedin.venice.ConfigKeys.PARTITIONER_CLASS;
+import static com.linkedin.venice.ConfigKeys.PUSH_JOB_GUID_LEAST_SIGNIFICANT_BITS;
+import static com.linkedin.venice.ConfigKeys.PUSH_JOB_GUID_MOST_SIGNIFICANT_BITS;
 import static com.linkedin.venice.hadoop.VenicePushJobConstants.ALLOW_DUPLICATE_KEY;
 import static com.linkedin.venice.hadoop.VenicePushJobConstants.BATCH_NUM_BYTES_PROP;
 import static com.linkedin.venice.hadoop.VenicePushJobConstants.COMPRESSION_METRIC_COLLECTION_ENABLED;
@@ -70,6 +72,7 @@ import com.linkedin.venice.writer.VeniceWriter;
 import java.io.IOException;
 import java.util.Objects;
 import java.util.Properties;
+import java.util.UUID;
 import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -288,6 +291,11 @@ public abstract class AbstractDataWriterSparkJob extends DataWriterComputeJob {
         ZSTD_COMPRESSION_LEVEL,
         props.getString(ZSTD_COMPRESSION_LEVEL, String.valueOf(Zstd.maxCompressionLevel())));
     jobConf.set(ZSTD_DICTIONARY_CREATION_SUCCESS, pushJobSetting.isZstdDictCreationSuccess);
+
+    // Deterministic producerGUID generator
+    UUID producerGuid = UUID.randomUUID();
+    jobConf.set(PUSH_JOB_GUID_MOST_SIGNIFICANT_BITS, producerGuid.getMostSignificantBits());
+    jobConf.set(PUSH_JOB_GUID_LEAST_SIGNIFICANT_BITS, producerGuid.getLeastSignificantBits());
 
     /**
      * Override the configs following the rules:

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/task/datawriter/AbstractPartitionWriter.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/task/datawriter/AbstractPartitionWriter.java
@@ -349,7 +349,7 @@ public abstract class AbstractPartitionWriter extends AbstractDataWriterTask imp
     EngineTaskConfigProvider engineTaskConfigProvider = getEngineTaskConfigProvider();
     Properties jobProps = engineTaskConfigProvider.getJobProps();
 
-    // Use a deterministic GUID generator for VPJ
+    // Use the UUID bits created by the VPJ driver to build a producerGUID deterministically
     writerProps.put(GuidUtils.GUID_GENERATOR_IMPLEMENTATION, GuidUtils.DETERMINISTIC_GUID_GENERATOR_IMPLEMENTATION);
     writerProps.put(PUSH_JOB_GUID_MOST_SIGNIFICANT_BITS, jobProps.getProperty(PUSH_JOB_GUID_MOST_SIGNIFICANT_BITS));
     writerProps.put(PUSH_JOB_GUID_LEAST_SIGNIFICANT_BITS, jobProps.getProperty(PUSH_JOB_GUID_LEAST_SIGNIFICANT_BITS));

--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -1375,14 +1375,14 @@ public class ConfigKeys {
   public static final String PUSH_JOB_STATUS_STORE_CLUSTER_NAME = "controller.push.job.status.store.cluster.name";
 
   /**
-   * The job tracker identifier as part of a map reduce job id.
+   * The most-significant-bits of the producer GUID used by {@code VenicePushJob} encoded as a {@code long}.
    */
-  public static final String PUSH_JOB_COMPUTE_JOB_ID = "push.job.compute.job.id";
+  public static final String PUSH_JOB_GUID_MOST_SIGNIFICANT_BITS = "push.job.guid.most.significant.bits";
 
   /**
-   * The job identifier as part of a map reduce job id.
+   * The least-significant-bits of the producer GUID used by {@code VenicePushJob} encoded as a {@code long}.
    */
-  public static final String PUSH_JOB_COMPUTE_TASK_ID = "push.job.compute.task.id";
+  public static final String PUSH_JOB_GUID_LEAST_SIGNIFICANT_BITS = "push.job.guid.least.significant.bits";
 
   /**
    * Flag to indicate whether to perform add version and start of ingestion via the admin protocol.

--- a/internal/venice-common/src/main/java/com/linkedin/venice/guid/GuidUtils.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/guid/GuidUtils.java
@@ -1,11 +1,14 @@
 package com.linkedin.venice.guid;
 
-import com.linkedin.venice.ConfigKeys;
+import static com.linkedin.venice.ConfigKeys.PUSH_JOB_GUID_LEAST_SIGNIFICANT_BITS;
+import static com.linkedin.venice.ConfigKeys.PUSH_JOB_GUID_MOST_SIGNIFICANT_BITS;
+
 import com.linkedin.venice.kafka.protocol.GUID;
 import com.linkedin.venice.utils.ByteUtils;
 import com.linkedin.venice.utils.ReflectUtils;
 import com.linkedin.venice.utils.VeniceProperties;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.UUID;
 import org.apache.avro.specific.FixedSize;
 
@@ -31,17 +34,9 @@ public class GuidUtils {
     if (implName.equals(JavaUtilGuidV4Generator.class.getName())) {
       guidGenerator = new JavaUtilGuidV4Generator();
     } else if (implName.equals(DeterministicGuidGenerator.class.getName())) {
-      String jobId = properties.getString(ConfigKeys.PUSH_JOB_COMPUTE_JOB_ID, (String) null);
-      long guidGeneratorPrefix;
-      if (jobId == null) {
-        guidGeneratorPrefix = 0;
-      } else {
-        guidGeneratorPrefix = jobId.hashCode();
-      }
-
       guidGenerator = new DeterministicGuidGenerator(
-          guidGeneratorPrefix,
-          properties.getLong(ConfigKeys.PUSH_JOB_COMPUTE_TASK_ID, 0L));
+          properties.getLong(PUSH_JOB_GUID_MOST_SIGNIFICANT_BITS, 0L),
+          properties.getLong(PUSH_JOB_GUID_LEAST_SIGNIFICANT_BITS, 0L));
     } else {
       Class<? extends GuidGenerator> implClass = ReflectUtils.loadClass(implName);
       guidGenerator = ReflectUtils.callConstructor(implClass, new Class[0], new Object[0]);
@@ -49,7 +44,7 @@ public class GuidUtils {
     return guidGenerator;
   }
 
-  static final Charset CHARSET = Charset.forName("ISO-8859-1");
+  static final Charset CHARSET = StandardCharsets.ISO_8859_1;
 
   public static GUID getGuidFromCharSequence(CharSequence charSequence) {
     GUID guid = new GUID();

--- a/internal/venice-common/src/main/java/com/linkedin/venice/guid/GuidUtils.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/guid/GuidUtils.java
@@ -35,8 +35,8 @@ public class GuidUtils {
       guidGenerator = new JavaUtilGuidV4Generator();
     } else if (implName.equals(DeterministicGuidGenerator.class.getName())) {
       guidGenerator = new DeterministicGuidGenerator(
-          properties.getLong(PUSH_JOB_GUID_MOST_SIGNIFICANT_BITS, 0L),
-          properties.getLong(PUSH_JOB_GUID_LEAST_SIGNIFICANT_BITS, 0L));
+          properties.getLong(PUSH_JOB_GUID_MOST_SIGNIFICANT_BITS),
+          properties.getLong(PUSH_JOB_GUID_LEAST_SIGNIFICANT_BITS));
     } else {
       Class<? extends GuidGenerator> implClass = ReflectUtils.loadClass(implName);
       guidGenerator = ReflectUtils.callConstructor(implClass, new Class[0], new Object[0]);

--- a/internal/venice-common/src/test/java/com/linkedin/venice/guid/GuidUtilsTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/guid/GuidUtilsTest.java
@@ -1,7 +1,7 @@
 package com.linkedin.venice.guid;
 
-import static com.linkedin.venice.ConfigKeys.PUSH_JOB_COMPUTE_JOB_ID;
-import static com.linkedin.venice.ConfigKeys.PUSH_JOB_COMPUTE_TASK_ID;
+import static com.linkedin.venice.ConfigKeys.PUSH_JOB_GUID_LEAST_SIGNIFICANT_BITS;
+import static com.linkedin.venice.ConfigKeys.PUSH_JOB_GUID_MOST_SIGNIFICANT_BITS;
 import static com.linkedin.venice.guid.GuidUtils.GUID_GENERATOR_IMPLEMENTATION;
 
 import com.linkedin.venice.kafka.protocol.GUID;
@@ -88,7 +88,7 @@ public class GuidUtilsTest {
     // When a job id is provided but no compute task id is provided, a default compute task id will be used
     Properties properties2 = new Properties();
     properties2.put(GUID_GENERATOR_IMPLEMENTATION, DeterministicGuidGenerator.class.getName());
-    properties2.put(PUSH_JOB_COMPUTE_JOB_ID, "Test_JOB_ID_2");
+    properties2.put(PUSH_JOB_GUID_MOST_SIGNIFICANT_BITS, "2");
     VeniceProperties props2 = new VeniceProperties(properties2);
     GUID guid2 = GuidUtils.getGUID(props2);
     Assert.assertEquals(
@@ -99,8 +99,8 @@ public class GuidUtilsTest {
     // When job id and compute task id are provided, they will be used to generate the guid
     Properties properties3 = new Properties();
     properties3.put(GUID_GENERATOR_IMPLEMENTATION, DeterministicGuidGenerator.class.getName());
-    properties3.put(PUSH_JOB_COMPUTE_JOB_ID, "Test_JOB_ID_3");
-    properties3.put(PUSH_JOB_COMPUTE_TASK_ID, "100");
+    properties3.put(PUSH_JOB_GUID_MOST_SIGNIFICANT_BITS, "3");
+    properties3.put(PUSH_JOB_GUID_LEAST_SIGNIFICANT_BITS, "100");
     VeniceProperties props3 = new VeniceProperties(properties3);
     GUID guid3 = GuidUtils.getGUID(props3);
     Assert.assertEquals(

--- a/internal/venice-common/src/test/java/com/linkedin/venice/guid/GuidUtilsTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/guid/GuidUtilsTest.java
@@ -78,6 +78,8 @@ public class GuidUtilsTest {
     // When no job ID and compute task id is provided, a default value will be used
     Properties properties1 = new Properties();
     properties1.put(GUID_GENERATOR_IMPLEMENTATION, DeterministicGuidGenerator.class.getName());
+    properties1.put(PUSH_JOB_GUID_MOST_SIGNIFICANT_BITS, "10");
+    properties1.put(PUSH_JOB_GUID_LEAST_SIGNIFICANT_BITS, "1200");
     VeniceProperties props1 = new VeniceProperties(properties1);
     GUID guid1 = GuidUtils.getGUID(props1);
     Assert.assertEquals(
@@ -88,7 +90,8 @@ public class GuidUtilsTest {
     // When a job id is provided but no compute task id is provided, a default compute task id will be used
     Properties properties2 = new Properties();
     properties2.put(GUID_GENERATOR_IMPLEMENTATION, DeterministicGuidGenerator.class.getName());
-    properties2.put(PUSH_JOB_GUID_MOST_SIGNIFICANT_BITS, "2");
+    properties2.put(PUSH_JOB_GUID_MOST_SIGNIFICANT_BITS, "120");
+    properties2.put(PUSH_JOB_GUID_LEAST_SIGNIFICANT_BITS, "170");
     VeniceProperties props2 = new VeniceProperties(properties2);
     GUID guid2 = GuidUtils.getGUID(props2);
     Assert.assertEquals(

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestBatch.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestBatch.java
@@ -42,6 +42,7 @@ import static com.linkedin.venice.utils.TestWriteUtils.writeSchemaWithUnknownFie
 import static com.linkedin.venice.utils.TestWriteUtils.writeSimpleAvroFileWithASchemaWithAWrongDefaultValue;
 import static com.linkedin.venice.utils.TestWriteUtils.writeSimpleAvroFileWithCustomSize;
 import static com.linkedin.venice.utils.TestWriteUtils.writeSimpleAvroFileWithDuplicateKey;
+import static com.linkedin.venice.utils.TestWriteUtils.writeSimpleAvroFileWithStringToStringSchema;
 import static com.linkedin.venice.utils.TestWriteUtils.writeSimpleAvroFileWithStringToStringSchema2;
 
 import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
@@ -260,7 +261,7 @@ public abstract class TestBatch {
       }
     };
     String storeName = testBatchStore(
-        inputDir -> new KeyAndValueSchemas(TestWriteUtils.writeSimpleAvroFileWithStringToStringSchema(inputDir)),
+        inputDir -> new KeyAndValueSchemas(writeSimpleAvroFileWithStringToStringSchema(inputDir)),
         properties -> {
           properties
               .setProperty(COMPRESSION_METRIC_COLLECTION_ENABLED, String.valueOf(compressionMetricCollectionEnabled));
@@ -276,7 +277,7 @@ public abstract class TestBatch {
   @Test(timeOut = TEST_TIMEOUT)
   public void testZstdCompressingAvroRecordCanFailWhenNoFallbackAvailable() throws Exception {
     testBatchStore(
-        inputDir -> new KeyAndValueSchemas(TestWriteUtils.writeSimpleAvroFileWithStringToStringSchema(inputDir)),
+        inputDir -> new KeyAndValueSchemas(writeSimpleAvroFileWithStringToStringSchema(inputDir)),
         properties -> {},
         (avroClient, vsonClient, metricsRepository) -> {
           // test single get. Can throw exception since no fallback available
@@ -333,7 +334,7 @@ public abstract class TestBatch {
   @Test(timeOut = TEST_TIMEOUT)
   public void testZstdCompressingAvroRecordWhenNoFallbackAvailableWithSleep() throws Exception {
     testBatchStore(
-        inputDir -> new KeyAndValueSchemas(TestWriteUtils.writeSimpleAvroFileWithStringToStringSchema(inputDir)),
+        inputDir -> new KeyAndValueSchemas(writeSimpleAvroFileWithStringToStringSchema(inputDir)),
         properties -> properties.setProperty(ZSTD_COMPRESSION_LEVEL, String.valueOf(17)),
         getSimpleFileWithUserSchemaValidatorForZstd(),
         new UpdateStoreQueryParams().setCompressionStrategy(CompressionStrategy.ZSTD_WITH_DICT));
@@ -345,7 +346,7 @@ public abstract class TestBatch {
       boolean useMapperToBuildDict) throws Exception {
     // Running a batch push first.
     String storeName = testBatchStore(
-        inputDir -> new KeyAndValueSchemas(TestWriteUtils.writeSimpleAvroFileWithStringToStringSchema(inputDir)),
+        inputDir -> new KeyAndValueSchemas(writeSimpleAvroFileWithStringToStringSchema(inputDir)),
         properties -> {
           properties
               .setProperty(COMPRESSION_METRIC_COLLECTION_ENABLED, String.valueOf(compressionMetricCollectionEnabled));
@@ -414,7 +415,7 @@ public abstract class TestBatch {
   @Test(timeOut = TEST_TIMEOUT)
   public void testEarlyDeleteBackupStore() throws Exception {
     String storeName = testBatchStoreMultiVersionPush(
-        inputDir -> new KeyAndValueSchemas(TestWriteUtils.writeSimpleAvroFileWithStringToStringSchema(inputDir)),
+        inputDir -> new KeyAndValueSchemas(writeSimpleAvroFileWithStringToStringSchema(inputDir)),
         properties -> {},
         (avroClient, vsonClient, metricsRepository) -> {
           // test single get
@@ -443,7 +444,7 @@ public abstract class TestBatch {
   @Test(timeOut = TEST_TIMEOUT)
   public void testIncrementalPush() throws Exception {
     String storeName = testBatchStore(
-        inputDir -> new KeyAndValueSchemas(TestWriteUtils.writeSimpleAvroFileWithStringToStringSchema(inputDir)),
+        inputDir -> new KeyAndValueSchemas(writeSimpleAvroFileWithStringToStringSchema(inputDir)),
         properties -> {},
         (avroClient, vsonClient, metricsRepository) -> {
           for (int i = 1; i <= 100; i++) {
@@ -467,6 +468,18 @@ public abstract class TestBatch {
         },
         storeName,
         new UpdateStoreQueryParams().setIncrementalPushEnabled(true));
+
+    testBatchStore(
+        inputDir -> new KeyAndValueSchemas(writeSimpleAvroFileWithStringToStringSchema(inputDir)),
+        properties -> properties.setProperty(INCREMENTAL_PUSH, "true"),
+        (avroClient, vsonClient, metricsRepository) -> {
+          // Original data from the 2nd inc push
+          for (int i = 1; i <= 100; i++) {
+            Assert.assertEquals(avroClient.get(Integer.toString(i)).get().toString(), "test_name_" + i);
+          }
+        },
+        storeName,
+        new UpdateStoreQueryParams().setIncrementalPushEnabled(true));
   }
 
   @Test(timeOut = TEST_TIMEOUT, dataProvider = "Two-True-and-False", dataProviderClass = DataProviderUtils.class)
@@ -474,7 +487,7 @@ public abstract class TestBatch {
       boolean compressionMetricCollectionEnabled,
       boolean useMapperToBuildDict) throws Exception {
     String storeName = testBatchStore(
-        inputDir -> new KeyAndValueSchemas(TestWriteUtils.writeSimpleAvroFileWithStringToStringSchema(inputDir)),
+        inputDir -> new KeyAndValueSchemas(writeSimpleAvroFileWithStringToStringSchema(inputDir)),
         properties -> {
           properties
               .setProperty(COMPRESSION_METRIC_COLLECTION_ENABLED, String.valueOf(compressionMetricCollectionEnabled));
@@ -516,7 +529,7 @@ public abstract class TestBatch {
     LOGGER.info("Start of {}", uniqueTestId);
     try {
       String storeName = testBatchStore(
-          inputDir -> new KeyAndValueSchemas(TestWriteUtils.writeSimpleAvroFileWithStringToStringSchema(inputDir)),
+          inputDir -> new KeyAndValueSchemas(writeSimpleAvroFileWithStringToStringSchema(inputDir)),
           properties -> {},
           (avroClient, vsonClient, metricsRepository) -> {
             for (int i = 1; i <= 100; i++) {
@@ -541,7 +554,7 @@ public abstract class TestBatch {
           null);
 
       testBatchStore(
-          inputDir -> new KeyAndValueSchemas(TestWriteUtils.writeSimpleAvroFileWithStringToStringSchema(inputDir)),
+          inputDir -> new KeyAndValueSchemas(writeSimpleAvroFileWithStringToStringSchema(inputDir)),
           properties -> {},
           (avroClient, vsonClient, metricsRepository) -> {
             TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, true, () -> {
@@ -565,7 +578,7 @@ public abstract class TestBatch {
   @Test(timeOut = TEST_TIMEOUT)
   public void testMetaStoreSchemaValidation() throws Exception {
     String storeName = testBatchStore(
-        inputDir -> new KeyAndValueSchemas(TestWriteUtils.writeSimpleAvroFileWithStringToStringSchema(inputDir)),
+        inputDir -> new KeyAndValueSchemas(writeSimpleAvroFileWithStringToStringSchema(inputDir)),
         properties -> {},
         (avroClient, vsonClient, metricsRepository) -> {
           // test single get
@@ -610,7 +623,7 @@ public abstract class TestBatch {
       }
     };
     String storeName = testBatchStore(
-        inputDir -> new KeyAndValueSchemas(TestWriteUtils.writeSimpleAvroFileWithStringToStringSchema(inputDir)),
+        inputDir -> new KeyAndValueSchemas(writeSimpleAvroFileWithStringToStringSchema(inputDir)),
         properties -> {},
         validator);
     // Re-push with Kafka Input
@@ -626,7 +639,7 @@ public abstract class TestBatch {
       }
     };
     String storeName = testBatchStore(
-        inputDir -> new KeyAndValueSchemas(TestWriteUtils.writeSimpleAvroFileWithStringToStringSchema(inputDir)),
+        inputDir -> new KeyAndValueSchemas(writeSimpleAvroFileWithStringToStringSchema(inputDir)),
         properties -> {},
         validator,
         new UpdateStoreQueryParams().setActiveActiveReplicationEnabled(true)
@@ -646,7 +659,7 @@ public abstract class TestBatch {
       }
     };
     String storeName = testBatchStore(
-        inputDir -> new KeyAndValueSchemas(TestWriteUtils.writeSimpleAvroFileWithStringToStringSchema(inputDir, 1)),
+        inputDir -> new KeyAndValueSchemas(writeSimpleAvroFileWithStringToStringSchema(inputDir, 1)),
         properties -> {},
         validator,
         new UpdateStoreQueryParams().setPartitionCount(3));


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## [vpj] Fix deterministic GUID generation for VPJ
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
Recently, when abstracting compute engines, the logic to compute a deterministic GUID was changed to be less reliant on the underlying compute engine. However, this change had a bug where the uniqueness of the GUID was tied to the uniqueness of the `jobId` used to trigger the `VenicePushJob`. This commit generates a unique GUID per VPJ job.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
GH CI. Updated an integration test

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.