### PR TITLE
[server] Fix NPE when collecting heartbeat_delay_ms and QuotaRcuPerSecondAllowed stats

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -717,6 +717,7 @@ ext.createDiffFile = { ->
       // da-vinci-client
       ':!clients/da-vinci-client/src/main/java/com/linkedin/davinci/DaVinciBackend.java',
       ':!clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/isolated/IsolatedIngestionServer.java',
+      ':!clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/heartbeat/HeartbeatStatReporter.java',
 
       // venice-client
       ':!clients/venice-client/src/main/java/com/linkedin/venice/fastclient/factory/ClientFactory.java',

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/heartbeat/HeartbeatMonitoringService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/heartbeat/HeartbeatMonitoringService.java
@@ -63,7 +63,7 @@ public class HeartbeatMonitoringService extends AbstractVeniceService {
         metricsRepository,
         metadataRepository,
         () -> new HeartbeatStat(new MetricConfig(), regionNames),
-        (aMetricsRepository, s) -> new HeartbeatStatReporter(aMetricsRepository, s, regionNames),
+        (aMetricsRepository, storeName) -> new HeartbeatStatReporter(aMetricsRepository, storeName, regionNames),
         leaderHeartbeatTimeStamps,
         followerHeartbeatTimeStamps);
   }
@@ -162,7 +162,6 @@ public class HeartbeatMonitoringService extends AbstractVeniceService {
    */
   public void recordLeaderHeartbeat(String store, int version, int partition, String region, Long timestamp) {
     recordHeartbeat(store, version, partition, region, timestamp, leaderHeartbeatTimeStamps);
-
   }
 
   /**

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/heartbeat/HeartbeatMonitoringService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/heartbeat/HeartbeatMonitoringService.java
@@ -223,10 +223,12 @@ public class HeartbeatMonitoringService extends AbstractVeniceService {
   protected void record() {
     recordLags(
         leaderHeartbeatTimeStamps,
-        ((storeName, version, region, lag) -> versionStatsReporter.recordLeaderLag(storeName, version, region, lag)));
+        ((storeName, version, region, heartbeatTs) -> versionStatsReporter
+            .recordLeaderLag(storeName, version, region, heartbeatTs)));
     recordLags(
         followerHeartbeatTimeStamps,
-        ((storeName, version, region, lag) -> versionStatsReporter.recordFollowerLag(storeName, version, region, lag)));
+        ((storeName, version, region, heartbeatTs) -> versionStatsReporter
+            .recordFollowerLag(storeName, version, region, heartbeatTs)));
   }
 
   @FunctionalInterface

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/heartbeat/HeartbeatStatReporter.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/heartbeat/HeartbeatStatReporter.java
@@ -1,5 +1,7 @@
 package com.linkedin.davinci.stats.ingestion.heartbeat;
 
+import static com.linkedin.venice.stats.StatsErrorCode.NULL_INGESTION_STATS;
+
 import com.linkedin.davinci.stats.AbstractVeniceStatsReporter;
 import io.tehuti.metrics.MetricsRepository;
 import io.tehuti.metrics.stats.AsyncGauge;
@@ -15,22 +17,36 @@ public class HeartbeatStatReporter extends AbstractVeniceStatsReporter<Heartbeat
   public HeartbeatStatReporter(MetricsRepository metricsRepository, String storeName, Set<String> regions) {
     super(metricsRepository, storeName);
     for (String region: regions) {
-      registerSensor(
-          new AsyncGauge(
-              (ignored, ignored2) -> getStats().getLeaderLag(region).getMax(),
-              LEADER_METRIC_PREFIX + region + MAX));
-      registerSensor(
-          new AsyncGauge(
-              (ignored, ignored2) -> getStats().getFollowerLag(region).getMax(),
-              FOLLOWER_METRIC_PREFIX + region + MAX));
-      registerSensor(
-          new AsyncGauge(
-              (ignored, ignored2) -> getStats().getLeaderLag(region).getAvg(),
-              LEADER_METRIC_PREFIX + region + AVG));
-      registerSensor(
-          new AsyncGauge(
-              (ignored, ignored2) -> getStats().getFollowerLag(region).getAvg(),
-              FOLLOWER_METRIC_PREFIX + region + AVG));
+      registerSensor(new AsyncGauge((ignored, ignored2) -> {
+        if (getStats() == null) {
+          return NULL_INGESTION_STATS.code;
+        }
+        return getStats().getLeaderLag(region).getMax();
+      }, LEADER_METRIC_PREFIX + region + MAX));
+
+      registerSensor(new AsyncGauge((ignored, ignored2) -> {
+        if (getStats() == null) {
+          return NULL_INGESTION_STATS.code;
+        }
+
+        return getStats().getFollowerLag(region).getMax();
+      }, FOLLOWER_METRIC_PREFIX + region + MAX));
+
+      registerSensor(new AsyncGauge((ignored, ignored2) -> {
+        if (getStats() == null) {
+          return NULL_INGESTION_STATS.code;
+        }
+
+        return getStats().getLeaderLag(region).getAvg();
+      }, LEADER_METRIC_PREFIX + region + AVG));
+
+      registerSensor(new AsyncGauge((ignored, ignored2) -> {
+        if (getStats() == null) {
+          return NULL_INGESTION_STATS.code;
+        }
+
+        return getStats().getFollowerLag(region).getAvg();
+      }, FOLLOWER_METRIC_PREFIX + region + AVG));
     }
   }
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/heartbeat/HeartbeatVersionedStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/heartbeat/HeartbeatVersionedStats.java
@@ -25,12 +25,12 @@ public class HeartbeatVersionedStats extends AbstractVeniceAggVersionedStats<Hea
     this.followerMonitors = followerMonitors;
   }
 
-  public void recordLeaderLag(String storeName, int version, String region, long lag) {
-    getStats(storeName, version).recordLeaderLag(region, lag);
+  public void recordLeaderLag(String storeName, int version, String region, long heartbeatTs) {
+    getStats(storeName, version).recordLeaderLag(region, heartbeatTs);
   }
 
-  public void recordFollowerLag(String storeName, int version, String region, long lag) {
-    getStats(storeName, version).recordFollowerLag(region, lag);
+  public void recordFollowerLag(String storeName, int version, String region, long heartbeatTs) {
+    getStats(storeName, version).recordFollowerLag(region, heartbeatTs);
   }
 
   @Override

--- a/services/venice-server/src/main/java/com/linkedin/venice/listener/ReadQuotaEnforcementHandler.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/listener/ReadQuotaEnforcementHandler.java
@@ -561,7 +561,12 @@ public class ReadQuotaEnforcementHandler extends SimpleChannelInboundHandler<Rou
     if (storeName.equals(AbstractVeniceAggStats.STORE_NAME_FOR_TOTAL_STAT)) {
       return storageNodeBucket;
     } else {
-      int currentVersion = storeRepository.getStore(storeName).getCurrentVersion();
+      Store store = storeRepository.getStore(storeName);
+      if (store == null) {
+        return null;
+      }
+
+      int currentVersion = store.getCurrentVersion();
       String topic = Version.composeKafkaTopic(storeName, currentVersion);
       return storeVersionBuckets.get(topic);
     }

--- a/services/venice-server/src/test/java/com/linkedin/venice/listener/ReadQuotaEnforcementHandlerTest.java
+++ b/services/venice-server/src/test/java/com/linkedin/venice/listener/ReadQuotaEnforcementHandlerTest.java
@@ -16,6 +16,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 
 import com.linkedin.venice.grpc.GrpcErrorCodes;
@@ -34,7 +35,9 @@ import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.protocols.VeniceServerResponse;
 import com.linkedin.venice.read.RequestType;
 import com.linkedin.venice.routerapi.ReplicaState;
+import com.linkedin.venice.stats.AbstractVeniceAggStats;
 import com.linkedin.venice.stats.AggServerQuotaUsageStats;
+import com.linkedin.venice.throttle.TokenBucket;
 import com.linkedin.venice.utils.Utils;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http.HttpResponseStatus;
@@ -458,6 +461,38 @@ public class ReadQuotaEnforcementHandlerTest {
     // Store that have storage node read quota disabled should not be blocked
     assertEquals(allowed.get(), capacity * 2);
     assertEquals(blocked.get(), 0);
+  }
+
+  @Test
+  public void testGetBucketForStore() {
+    String storeName = "testStore";
+    String topic = Version.composeKafkaTopic(storeName, 1);
+    Version version = mock(Version.class);
+    doReturn(topic).when(version).kafkaTopicName();
+    Store store = setUpStoreMock(storeName, 1, Collections.singletonList(version), 100, true);
+    doReturn(store).when(storeRepository).getStore(storeName);
+    doReturn(Collections.singletonList(store)).when(storeRepository).getAllStores();
+
+    Instance thisInstance = mock(Instance.class);
+    doReturn(thisNodeId).when(thisInstance).getNodeId();
+
+    Partition partition = setUpPartitionMock(topic, thisInstance, true, 0);
+    doReturn(0).when(partition).getId();
+
+    PartitionAssignment pa = setUpPartitionAssignmentMock(topic, Collections.singletonList(partition));
+
+    quotaEnforcer.onCustomizedViewChange(pa);
+    TokenBucket bucketForStore = quotaEnforcer.getBucketForStore(storeName);
+    // Actual stale buckets = quota (100) * enforcementCapacityMultiple (5) * enforcementInterval (10)
+    assertEquals(bucketForStore.getStaleTokenCount(), 100 * 5 * 10);
+
+    // Total buckets = node capacity (10) * enforcementCapacityMultiple (5) * enforcementInterval (10)
+    TokenBucket totalBuckets = quotaEnforcer.getBucketForStore(AbstractVeniceAggStats.STORE_NAME_FOR_TOTAL_STAT);
+    assertEquals(totalBuckets.getStaleTokenCount(), nodeCapacity * 5 * 10);
+
+    // Non-existent store should return "null" TokenBucket object
+    TokenBucket bucketForInvalidStore = quotaEnforcer.getBucketForStore("incorrect_store");
+    assertNull(bucketForInvalidStore);
   }
 
   /**


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Fix NPE when collecting `heartbeat_delay_ms` and `QuotaRcuPerSecondAllowed` stats
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
We noticed NPE exceptions in deployed instances in the metric collection code paths. This commit handles `null` gracefully and prevents these NPEs.

`AbstractVeniceAggVersionedStats#updateStatsVersionInfo` has the following code:
```
    if (newCurrentVersion != versionedStats.getCurrentVersion()) {
      versionedStats.setCurrentVersion(newCurrentVersion);
    }
...
    if (futureVersion != versionedStats.getFutureVersion()) {
      versionedStats.setFutureVersion(futureVersion);
    }
```

If there is no future version, the `if` block will never get executed. The `setFutureVersion` is what sets the `stat` object. However, the `heartbeat_delay_ms` metric already got registered like:
```
(ignored, ignored2) -> getStats().getFollowerLag(region).getMax()
```
So, `getStats()` would return `null` in such a case.

For `QuotaRcuPerSecondAllowed`, this code just avoids an NPE. I have not done much analysis into why `storeRepository.getStore(storeName)` could be `null`. We can investigate this more if we see a degradation in the metrics.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
GH CI

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.