### PR TITLE
[server][da-vinci] Remove noise when clearing offsets without metadata partition

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/DaVinciBackend.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/DaVinciBackend.java
@@ -351,7 +351,7 @@ public class DaVinciBackend implements Closeable {
     Map<String, Version> storeNameToBootstrapVersionMap = new HashMap<>();
     Map<String, List<Integer>> storeNameToPartitionListMap = new HashMap<>();
     for (AbstractStorageEngine storageEngine: storageEngines) {
-      String kafkaTopicName = storageEngine.getStoreName();
+      String kafkaTopicName = storageEngine.getStoreVersionName();
       String storeName = Version.parseStoreFromKafkaTopicName(kafkaTopicName);
       if (VeniceSystemStoreType.META_STORE.isSystemStore(storeName)) {
         // Do not bootstrap meta system store via DaVinci backend initialization since the operation is not supported by

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/storage/StorageEngineRepository.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/storage/StorageEngineRepository.java
@@ -31,9 +31,9 @@ public class StorageEngineRepository {
   }
 
   public synchronized void addLocalStorageEngine(AbstractStorageEngine engine) {
-    AbstractStorageEngine found = localStorageEngines.putIfAbsent(engine.getStoreName(), engine);
+    AbstractStorageEngine found = localStorageEngines.putIfAbsent(engine.getStoreVersionName(), engine);
     if (found != null) {
-      String errorMessage = "Storage Engine '" + engine.getStoreName() + "' has already been initialized.";
+      String errorMessage = "Storage Engine '" + engine.getStoreVersionName() + "' has already been initialized.";
       LOGGER.error(errorMessage);
       throw new VeniceException(errorMessage);
     }
@@ -46,7 +46,7 @@ public class StorageEngineRepository {
   public void close() {
     VeniceException lastException = null;
     for (AbstractStorageEngine store: localStorageEngines.values()) {
-      String storeName = store.getStoreName();
+      String storeName = store.getStoreVersionName();
       LOGGER.info("Closing storage engine for store: {}", storeName);
       try {
         store.close();

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/storage/StorageService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/storage/StorageService.java
@@ -476,7 +476,7 @@ public class StorageService extends AbstractVeniceService {
     restoreAllStores(configLoader, true, true, s -> true);
     LOGGER.info("Start cleaning up all the stores persisted previously");
     storageEngineRepository.getAllLocalStorageEngines().stream().forEach(storageEngine -> {
-      String storeName = storageEngine.getStoreName();
+      String storeName = storageEngine.getStoreVersionName();
       LOGGER.info("Start deleting store: {}", storeName);
       Set<Integer> partitionIds = storageEngine.getPartitionIds();
       for (Integer partitionId: partitionIds) {
@@ -502,7 +502,7 @@ public class StorageService extends AbstractVeniceService {
         "Storage service has {} storage engines before cleanup.",
         storageEngineRepository.getAllLocalStorageEngines().size());
     for (AbstractStorageEngine storageEngine: storageEngineRepository.getAllLocalStorageEngines()) {
-      closeStorageEngine(storageEngine.getStoreName());
+      closeStorageEngine(storageEngine.getStoreVersionName());
     }
     LOGGER.info(
         "Storage service has {} storage engines after cleanup.",
@@ -520,7 +520,7 @@ public class StorageService extends AbstractVeniceService {
   public Map<String, Set<Integer>> getStoreAndUserPartitionsMapping() {
     Map<String, Set<Integer>> storePartitionMapping = new HashMap<>();
     for (AbstractStorageEngine engine: storageEngineRepository.getAllLocalStorageEngines()) {
-      String storeName = engine.getStoreName();
+      String storeName = engine.getStoreVersionName();
       int amplificationFactor = PartitionUtils.getAmplificationFactor(storeRepository, storeName);
       Set<Integer> partitionIdSet = new HashSet<>();
       /**

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/storage/chunking/ChunkingUtils.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/storage/chunking/ChunkingUtils.java
@@ -404,7 +404,7 @@ public class ChunkingUtils {
   }
 
   private static String getExceptionMessageDetails(AbstractStorageEngine store, int partition, Integer chunkIndex) {
-    String message = "store: " + store.getStoreName() + ", partition: " + partition;
+    String message = "store: " + store.getStoreVersionName() + ", partition: " + partition;
     if (chunkIndex != null) {
       message += ", chunk index: " + chunkIndex;
     }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/AbstractStorageEngine.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/AbstractStorageEngine.java
@@ -58,7 +58,7 @@ public abstract class AbstractStorageEngine<Partition extends AbstractStoragePar
   // Using a large positive number for metadata partition id instead of -1 can avoid database naming issues.
   public static final int METADATA_PARTITION_ID = 1000_000_000;
 
-  private final String storeName;
+  private final String storeVersionName;
   private final SparseConcurrentList<Partition> partitionList = new SparseConcurrentList<>();
   private Partition metadataPartition;
   private final AtomicReference<StoreVersionState> versionStateCache = new AtomicReference<>();
@@ -81,10 +81,10 @@ public abstract class AbstractStorageEngine<Partition extends AbstractStoragePar
   private final List<ReadWriteLock> rwLockForStoragePartitionAdjustmentList = new SparseConcurrentList<>();
 
   public AbstractStorageEngine(
-      String storeName,
+      String storeVersionName,
       InternalAvroSpecificSerializer<StoreVersionState> storeVersionStateSerializer,
       InternalAvroSpecificSerializer<PartitionState> partitionStateSerializer) {
-    this.storeName = storeName;
+    this.storeVersionName = storeVersionName;
     this.metadataPartition = null;
     this.storeVersionStateSerializer = storeVersionStateSerializer;
     this.partitionStateSerializer = partitionStateSerializer;
@@ -97,18 +97,18 @@ public abstract class AbstractStorageEngine<Partition extends AbstractStoragePar
     ReadWriteLock readWriteLock = rwLockForStoragePartitionAdjustmentList.get(partitionId);
     if (readWriteLock == null) {
       throw new VeniceException(
-          "Failed to get read-write lock for partition: " + partitionId + ", store: " + getStoreName());
+          "Failed to get read-write lock for partition: " + partitionId + ", store: " + getStoreVersionName());
     }
     return readWriteLock;
   }
 
-  public String getStoreName() {
-    return storeName;
+  public String getStoreVersionName() {
+    return storeVersionName;
   }
 
   @Override
   public String toString() {
-    return getStoreName();
+    return getStoreVersionName();
   }
 
   public abstract PersistenceType getType();
@@ -149,7 +149,8 @@ public abstract class AbstractStorageEngine<Partition extends AbstractStoragePar
 
     if (restoreMetadataPartition) {
       LOGGER.info("Metadata partition restore enabled. Restoring metadata partition.");
-      this.metadataPartition = createStoragePartition(new StoragePartitionConfig(storeName, METADATA_PARTITION_ID));
+      this.metadataPartition =
+          createStoragePartition(new StoragePartitionConfig(storeVersionName, METADATA_PARTITION_ID));
     }
 
     if (restoreDataPartitions) {
@@ -172,10 +173,10 @@ public abstract class AbstractStorageEngine<Partition extends AbstractStoragePar
 
   public synchronized void preparePartitionForReading(int partitionId) {
     if (!containsPartition(partitionId)) {
-      LOGGER.warn("Partition {}_{} was removed before reopening.", storeName, partitionId);
+      LOGGER.warn("Partition {}_{} was removed before reopening.", storeVersionName, partitionId);
       return;
     }
-    StoragePartitionConfig partitionConfig = new StoragePartitionConfig(storeName, partitionId);
+    StoragePartitionConfig partitionConfig = new StoragePartitionConfig(storeVersionName, partitionId);
     partitionConfig.setWriteOnlyConfig(false);
 
     adjustStoragePartition(partitionConfig);
@@ -205,7 +206,7 @@ public abstract class AbstractStorageEngine<Partition extends AbstractStoragePar
   }
 
   public void addStoragePartition(int partitionId) {
-    addStoragePartition(new StoragePartitionConfig(storeName, partitionId));
+    addStoragePartition(new StoragePartitionConfig(storeVersionName, partitionId));
   }
 
   public synchronized void addStoragePartition(StoragePartitionConfig storagePartitionConfig) {
@@ -220,9 +221,9 @@ public abstract class AbstractStorageEngine<Partition extends AbstractStoragePar
       LOGGER.error(
           "Failed to add a storage partition for partitionId: {} Store {}. This partition already exists!",
           partitionId,
-          this.getStoreName());
+          this.getStoreVersionName());
       throw new StorageInitializationException(
-          "Partition " + partitionId + " of store " + this.getStoreName() + " already exists.");
+          "Partition " + partitionId + " of store " + this.getStoreVersionName() + " already exists.");
     }
 
     Partition partition = createStoragePartition(storagePartitionConfig);
@@ -242,12 +243,12 @@ public abstract class AbstractStorageEngine<Partition extends AbstractStoragePar
   public synchronized void closePartition(int partitionId) {
     AbstractStoragePartition partition = this.partitionList.remove(partitionId);
     if (partition == null) {
-      LOGGER.error("Failed to close a non existing partition: {} Store {}", partitionId, getStoreName());
+      LOGGER.error("Failed to close a non existing partition: {} Store {}", partitionId, getStoreVersionName());
       return;
     }
     partition.close();
     if (getNumberOfPartitions() == 0) {
-      LOGGER.info("All Partitions closed for store {} ", getStoreName());
+      LOGGER.info("All Partitions closed for store {} ", getStoreVersionName());
     }
   }
 
@@ -272,11 +273,11 @@ public abstract class AbstractStorageEngine<Partition extends AbstractStoragePar
      *    Else there can be situations where the data is consumed from Kafka and not persisted.
      */
     if (!containsPartition(partitionId)) {
-      LOGGER.error("Failed to remove a non existing partition: {} Store {}", partitionId, getStoreName());
+      LOGGER.error("Failed to remove a non existing partition: {} Store {}", partitionId, getStoreVersionName());
       return;
     }
     if (!suppressLogs) {
-      LOGGER.info("Removing Partition: {} Store {}", partitionId, getStoreName());
+      LOGGER.info("Removing Partition: {} Store {}", partitionId, getStoreVersionName());
     }
 
     /**
@@ -293,7 +294,7 @@ public abstract class AbstractStorageEngine<Partition extends AbstractStoragePar
 
     if (getNumberOfPartitions() == 0) {
       if (!suppressLogs) {
-        LOGGER.info("All Partitions deleted for Store {}", getStoreName());
+        LOGGER.info("All Partitions deleted for Store {}", getStoreVersionName());
       }
       /**
        * The reason to invoke {@link #drop} here is that storage engine might need to do some cleanup
@@ -320,7 +321,7 @@ public abstract class AbstractStorageEngine<Partition extends AbstractStoragePar
       return;
     }
     if (!suppressLogs) {
-      LOGGER.info("Started dropping store: {}", getStoreName());
+      LOGGER.info("Started dropping store: {}", getStoreVersionName());
     }
 
     // partitionList is implementation of SparseConcurrentList which sets element to null on `remove`. So its fine
@@ -333,7 +334,7 @@ public abstract class AbstractStorageEngine<Partition extends AbstractStoragePar
     }
     dropMetadataPartition();
     if (!suppressLogs) {
-      LOGGER.info("Finished dropping store: {}", getStoreName());
+      LOGGER.info("Finished dropping store: {}", getStoreVersionName());
     }
   }
 
@@ -356,7 +357,7 @@ public abstract class AbstractStorageEngine<Partition extends AbstractStoragePar
     LOGGER.info(
         "Closing {} rockDB partitions of store {} took {} ms",
         tmpList.size(),
-        storeName,
+        storeVersionName,
         LatencyUtils.getElapsedTimeInMs(startTime));
     partitionList.clear();
     closeMetadataPartition();
@@ -412,7 +413,7 @@ public abstract class AbstractStorageEngine<Partition extends AbstractStoragePar
     adjustStoragePartition(storagePartitionConfig);
 
     if (!partition.validateBatchIngestion()) {
-      throw new VeniceException("Storage temp files not fully ingested for store: " + storeName);
+      throw new VeniceException("Storage temp files not fully ingested for store: " + storeVersionName);
     }
   }
 
@@ -444,7 +445,7 @@ public abstract class AbstractStorageEngine<Partition extends AbstractStoragePar
   public void reopenStoragePartition(int partitionId) {
     executeWithSafeGuard(partitionId, () -> {
       if (!containsPartition(partitionId)) {
-        LOGGER.warn("Partition {}_{} doesn't exist.", storeName, partitionId);
+        LOGGER.warn("Partition {}_{} doesn't exist.", storeVersionName, partitionId);
         return;
       }
       AbstractStoragePartition storagePartition = getPartitionOrThrow(partitionId);
@@ -579,7 +580,10 @@ public abstract class AbstractStorageEngine<Partition extends AbstractStoragePar
    */
   public synchronized void clearPartitionOffset(int partitionId) {
     if (!metadataPartitionCreated()) {
-      LOGGER.info("Metadata partition not created; there is nothing to clear!");
+      LOGGER.info(
+          "Metadata partition not created; there is nothing to clear for {} partition {}",
+          storeVersionName,
+          partitionId);
       return;
     }
     if (partitionId == METADATA_PARTITION_ID) {
@@ -604,7 +608,8 @@ public abstract class AbstractStorageEngine<Partition extends AbstractStoragePar
       throw new StorageInitializationException("Metadata partition not created!");
     }
     versionStateCache.set(versionState);
-    metadataPartition.put(VERSION_METADATA_KEY, storeVersionStateSerializer.serialize(getStoreName(), versionState));
+    metadataPartition
+        .put(VERSION_METADATA_KEY, storeVersionStateSerializer.serialize(getStoreVersionName(), versionState));
   }
 
   /**
@@ -631,7 +636,7 @@ public abstract class AbstractStorageEngine<Partition extends AbstractStoragePar
       if (value == null) {
         return null;
       }
-      versionState = storeVersionStateSerializer.deserialize(storeName, value);
+      versionState = storeVersionStateSerializer.deserialize(storeVersionName, value);
       if (versionStateCache.compareAndSet(null, versionState)) {
         return versionState;
       } // else retry the loop...
@@ -696,7 +701,7 @@ public abstract class AbstractStorageEngine<Partition extends AbstractStoragePar
     }
     if (partition == null) {
       VeniceException e = new PersistenceFailureException(
-          "Partition: " + partitionId + " of store: " + getStoreName() + " does not exist");
+          "Partition: " + partitionId + " of store: " + getStoreVersionName() + " does not exist");
       LOGGER.error("Failed to get the partition with msg: {}", e.getMessage());
       throw e;
     }
@@ -717,10 +722,10 @@ public abstract class AbstractStorageEngine<Partition extends AbstractStoragePar
   }
 
   private void validateStoreName(StoragePartitionConfig storagePartitionConfig) {
-    if (!storagePartitionConfig.getStoreName().equals(getStoreName())) {
+    if (!storagePartitionConfig.getStoreName().equals(getStoreVersionName())) {
       throw new VeniceException(
           "Store name in partition config: " + storagePartitionConfig.getStoreName()
-              + " doesn't match current store engine: " + getStoreName());
+              + " doesn't match current store engine: " + getStoreVersionName());
     }
   }
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/AbstractStorageEngine.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/AbstractStorageEngine.java
@@ -579,7 +579,8 @@ public abstract class AbstractStorageEngine<Partition extends AbstractStoragePar
    */
   public synchronized void clearPartitionOffset(int partitionId) {
     if (!metadataPartitionCreated()) {
-      throw new StorageInitializationException("Metadata partition not created!");
+      LOGGER.info("Metadata partition not created; there is nothing to clear!");
+      return;
     }
     if (partitionId == METADATA_PARTITION_ID) {
       throw new IllegalArgumentException(

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/StorageEngineFactory.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/StorageEngineFactory.java
@@ -86,7 +86,7 @@ public abstract class StorageEngineFactory {
   public void verifyPersistenceType(AbstractStorageEngine engine) {
     if (!engine.getType().equals(getPersistenceType())) {
       throw new VeniceException(
-          "Required store persistence type: " + engine.getType() + " of store: " + engine.getStoreName()
+          "Required store persistence type: " + engine.getType() + " of store: " + engine.getStoreVersionName()
               + " isn't supported in current factory: " + getClass().getName() + " with type: " + getPersistenceType());
     }
   }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/blackhole/BlackHoleStorageEngine.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/blackhole/BlackHoleStorageEngine.java
@@ -9,9 +9,9 @@ import java.util.Set;
 
 
 public class BlackHoleStorageEngine extends AbstractStorageEngine<BlackHoleStorageEnginePartition> {
-  public BlackHoleStorageEngine(String storeName) {
+  public BlackHoleStorageEngine(String storeVersionName) {
     super(
-        storeName,
+        storeVersionName,
         AvroProtocolDefinition.STORE_VERSION_STATE.getSerializer(),
         AvroProtocolDefinition.PARTITION_STATE.getSerializer());
     restoreStoragePartitions();

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/cache/VeniceStoreCacheStorageEngine.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/cache/VeniceStoreCacheStorageEngine.java
@@ -23,12 +23,12 @@ public class VeniceStoreCacheStorageEngine extends AbstractStorageEngine<VeniceS
   private final ReadWriteLock globalRWlock = new ReentrantReadWriteLock();
 
   public VeniceStoreCacheStorageEngine(
-      String storeName,
+      String storeVersionName,
       ObjectCacheConfig config,
       Schema keySchema,
       AsyncCacheLoader asyncCacheLoader) {
     super(
-        storeName,
+        storeVersionName,
         AvroProtocolDefinition.STORE_VERSION_STATE.getSerializer(),
         AvroProtocolDefinition.PARTITION_STATE.getSerializer());
     cacheConfig = config;

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/memory/InMemoryStorageEngine.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/memory/InMemoryStorageEngine.java
@@ -18,9 +18,9 @@ public class InMemoryStorageEngine extends AbstractStorageEngine<InMemoryStorage
     this(storeDef.getStoreVersionName());
   }
 
-  public InMemoryStorageEngine(String versionName) {
+  public InMemoryStorageEngine(String versionVersionName) {
     super(
-        versionName,
+        versionVersionName,
         AvroProtocolDefinition.STORE_VERSION_STATE.getSerializer(),
         AvroProtocolDefinition.PARTITION_STATE.getSerializer());
     restoreStoragePartitions();

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/RocksDBStorageEngine.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/RocksDBStorageEngine.java
@@ -71,11 +71,11 @@ public class RocksDBStorageEngine extends AbstractStorageEngine<RocksDBStoragePa
     this.replicationMetadataEnabled = replicationMetadataEnabled;
 
     // Create store folder if it doesn't exist
-    storeDbPath = RocksDBUtils.composeStoreDbDir(this.rocksDbPath, getStoreName());
+    storeDbPath = RocksDBUtils.composeStoreDbDir(this.rocksDbPath, getStoreVersionName());
     File storeDbDir = new File(storeDbPath);
     if (!storeDbDir.exists()) {
       storeDbDir.mkdirs();
-      LOGGER.info("Created RocksDb dir for store: {}", getStoreName());
+      LOGGER.info("Created RocksDb dir for store: {}", getStoreVersionName());
     } else {
       if (storeConfig.isRocksDbStorageEngineConfigCheckEnabled()) {
         // We only validate it when re-opening the storage engine.
@@ -156,11 +156,11 @@ public class RocksDBStorageEngine extends AbstractStorageEngine<RocksDBStoragePa
       // Remove store db dir
       File storeDbDir = new File(storeDbPath);
       if (storeDbDir.exists()) {
-        LOGGER.info("Started removing database dir: {} for store: {}", storeDbPath, getStoreName());
+        LOGGER.info("Started removing database dir: {} for store: {}", storeDbPath, getStoreVersionName());
         if (!storeDbDir.delete()) {
           LOGGER.warn("Failed to remove dir: {}.", storeDbDir);
         } else {
-          LOGGER.info("Finished removing database dir: {} for store {}", storeDbPath, getStoreName());
+          LOGGER.info("Finished removing database dir: {} for store {}", storeDbPath, getStoreVersionName());
         }
       }
     }
@@ -175,7 +175,7 @@ public class RocksDBStorageEngine extends AbstractStorageEngine<RocksDBStoragePa
       try {
         partition = super.getPartitionOrThrow(i);
       } catch (VeniceException e) {
-        LOGGER.warn("Could not find partition {} for store {}", i, super.getStoreName());
+        LOGGER.warn("Could not find partition {} for store {}", i, super.getStoreVersionName());
         continue;
       }
       diskUsage += partition.getRmdByteUsage();
@@ -244,7 +244,8 @@ public class RocksDBStorageEngine extends AbstractStorageEngine<RocksDBStoragePa
     } else {
       // If no existing config is found, we will by default skip the checking as not enough information is given to
       // enforce the check.
-      LOGGER.warn("RocksDB storage engine config not found for store {} skipping the validation.", getStoreName());
+      LOGGER
+          .warn("RocksDB storage engine config not found for store {} skipping the validation.", getStoreVersionName());
     }
     return false;
   }
@@ -264,7 +265,7 @@ public class RocksDBStorageEngine extends AbstractStorageEngine<RocksDBStoragePa
   }
 
   private String getRocksDbEngineConfigPath() {
-    return RocksDBUtils.composePartitionDbDir(rocksDbPath, getStoreName(), METADATA_PARTITION_ID) + "/"
+    return RocksDBUtils.composePartitionDbDir(rocksDbPath, getStoreVersionName(), METADATA_PARTITION_ID) + "/"
         + SERVER_CONFIG_FILE_NAME;
   }
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/RocksDBStorageEngineFactory.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/RocksDBStorageEngineFactory.java
@@ -316,7 +316,7 @@ public class RocksDBStorageEngineFactory extends StorageEngineFactory {
   @Override
   public synchronized void removeStorageEngine(AbstractStorageEngine engine) {
     verifyPersistenceType(engine);
-    final String storeName = engine.getStoreName();
+    final String storeName = engine.getStoreVersionName();
     if (storageEngineMap.containsKey(storeName)) {
       LOGGER.info("Started removing RocksDB storage engine for store: {}", storeName);
       storageEngineMap.get(storeName).drop();
@@ -370,7 +370,7 @@ public class RocksDBStorageEngineFactory extends StorageEngineFactory {
   @Override
   public synchronized void closeStorageEngine(AbstractStorageEngine engine) {
     verifyPersistenceType(engine);
-    final String storeName = engine.getStoreName();
+    final String storeName = engine.getStoreVersionName();
     if (storageEngineMap.containsKey(storeName)) {
       LOGGER.info("Started closing RocksDB storage engine for store: {}", storeName);
       storageEngineMap.get(storeName).close();

--- a/clients/da-vinci-client/src/main/java/com/linkedin/venice/cleaner/LeakedResourceCleaner.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/venice/cleaner/LeakedResourceCleaner.java
@@ -93,7 +93,7 @@ public class LeakedResourceCleaner extends AbstractVeniceService {
 
         List<AbstractStorageEngine> storageEngines = storageEngineRepository.getAllLocalStorageEngines();
         for (AbstractStorageEngine storageEngine: storageEngines) {
-          String resourceName = storageEngine.getStoreName();
+          String resourceName = storageEngine.getStoreVersionName();
           try {
             Store store;
             String storeName = Version.parseStoreFromKafkaTopicName(resourceName);

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/DeepCopyStorageEngine.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/DeepCopyStorageEngine.java
@@ -32,7 +32,7 @@ public class DeepCopyStorageEngine extends AbstractStorageEngine<AbstractStorage
   private final AbstractStorageEngine delegate;
 
   public DeepCopyStorageEngine(AbstractStorageEngine delegate) {
-    super(delegate.getStoreName(), storeVersionStateSerializer, partitionStateSerializer);
+    super(delegate.getStoreVersionName(), storeVersionStateSerializer, partitionStateSerializer);
     this.delegate = delegate;
     restoreStoragePartitions();
   }
@@ -79,8 +79,8 @@ public class DeepCopyStorageEngine extends AbstractStorageEngine<AbstractStorage
   }
 
   @Override
-  public String getStoreName() {
-    return this.delegate.getStoreName();
+  public String getStoreVersionName() {
+    return this.delegate.getStoreVersionName();
   }
 
   @Override

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/storage/StorageServiceTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/storage/StorageServiceTest.java
@@ -99,7 +99,7 @@ public class StorageServiceTest {
     when(mockStorageEngineFactory.getStorageEngine(storeVersionConfig, false)).thenReturn(mockStorageEngine);
     Set<Integer> partitionSet = new HashSet<>(Arrays.asList(1, 2, 3));
     when(mockStorageEngine.getPersistedPartitionIds()).thenReturn(partitionSet);
-    when(mockStorageEngine.getStoreName()).thenReturn(resourceName);
+    when(mockStorageEngine.getStoreVersionName()).thenReturn(resourceName);
     when(mockStorageEngineFactory.getPersistedStoreNames()).thenReturn(Sets.newSet(resourceName));
     when(mockStorageEngineFactory.getPersistenceType()).thenReturn(PersistenceType.BLACK_HOLE);
 

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/storage/chunking/ChunkingTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/storage/chunking/ChunkingTest.java
@@ -221,7 +221,7 @@ public class ChunkingTest {
     try (StorageEngineBackedCompressorFactory compressorFactory =
         new StorageEngineBackedCompressorFactory(mock(StorageMetadataService.class))) {
       VeniceCompressor compressor =
-          compressorFactory.getCompressor(CompressionStrategy.NO_OP, storageEngine.getStoreName());
+          compressorFactory.getCompressor(CompressionStrategy.NO_OP, storageEngine.getStoreVersionName());
       Object retrievedObject;
       if (getWithSchemaId) {
         retrievedObject = chunkingAdapter.getWithSchemaId(

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/store/AbstractStorageEngineTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/store/AbstractStorageEngineTest.java
@@ -217,7 +217,7 @@ public abstract class AbstractStorageEngineTest extends AbstractStoreTest {
 
   @Test(expectedExceptions = VeniceException.class)
   public void testAdjustStoragePartitionWithUnknownPartitionId() {
-    String storeName = testStoreEngine.getStoreName();
+    String storeName = testStoreEngine.getStoreVersionName();
     int unknownPartitionId = partitionId + 10000;
     StoragePartitionConfig partitionConfig = new StoragePartitionConfig(storeName, unknownPartitionId);
     testStoreEngine.adjustStoragePartition(partitionConfig);
@@ -225,7 +225,7 @@ public abstract class AbstractStorageEngineTest extends AbstractStoreTest {
 
   @Test
   public void testAdjustStoragePartitionFromTransactionalToDeferredWrite() {
-    String storeName = testStoreEngine.getStoreName();
+    String storeName = testStoreEngine.getStoreVersionName();
     int newPartitionId = partitionId + 1;
     StoragePartitionConfig transactionalPartitionConfig = new StoragePartitionConfig(storeName, newPartitionId);
     StoragePartitionConfig deferredWritePartitionConfig = new StoragePartitionConfig(storeName, newPartitionId);
@@ -249,7 +249,7 @@ public abstract class AbstractStorageEngineTest extends AbstractStoreTest {
 
   @Test
   public void testAdjustStoragePartitionFromDeferredWriteToTransactional() {
-    String storeName = testStoreEngine.getStoreName();
+    String storeName = testStoreEngine.getStoreVersionName();
     int newPartitionId = partitionId + 1;
     StoragePartitionConfig transactionalPartitionConfig = new StoragePartitionConfig(storeName, newPartitionId);
     StoragePartitionConfig deferredWritePartitionConfig = new StoragePartitionConfig(storeName, newPartitionId);

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/store/cache/backend/ObjectCacheBackendTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/store/cache/backend/ObjectCacheBackendTest.java
@@ -67,7 +67,7 @@ public class ObjectCacheBackendTest {
     Assert.assertEquals(
         ((VeniceStoreCacheStorageEngine) cachedStorageEngine).getCache().getIfPresent(keyRecord),
         cachedValued);
-    Assert.assertEquals(cachedStorageEngine.getStoreName(), TOPIC_NAME);
+    Assert.assertEquals(cachedStorageEngine.getStoreVersionName(), TOPIC_NAME);
 
     // Make a version push happen that invalidates entries (by triggering the store change event)
     Store mockStore = Mockito.mock(Store.class);

--- a/services/venice-server/src/main/java/com/linkedin/venice/cleaner/BackupVersionOptimizationService.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/cleaner/BackupVersionOptimizationService.java
@@ -116,7 +116,7 @@ public class BackupVersionOptimizationService extends AbstractVeniceService impl
        */
       final Set<String> validResourceSet = new HashSet<>();
       for (AbstractStorageEngine engine: storageEngineRepository.getAllLocalStorageEngines()) {
-        String resourceName = engine.getStoreName();
+        String resourceName = engine.getStoreVersionName();
         validResourceSet.add(resourceName);
         String storeName = Version.parseStoreFromVersionTopic(resourceName);
         int versionNumber = Version.parseVersionFromVersionTopicName(resourceName);

--- a/services/venice-server/src/test/java/com/linkedin/venice/cleaner/BackupVersionOptimizationServiceTest.java
+++ b/services/venice-server/src/test/java/com/linkedin/venice/cleaner/BackupVersionOptimizationServiceTest.java
@@ -42,7 +42,7 @@ public class BackupVersionOptimizationServiceTest {
     for (int version: versions) {
       String resourceName = Version.composeKafkaTopic(storeName, version);
       AbstractStorageEngine storageEngine = mock(AbstractStorageEngine.class);
-      doReturn(resourceName).when(storageEngine).getStoreName();
+      doReturn(resourceName).when(storageEngine).getStoreVersionName();
       doReturn(partitionIdSet).when(storageEngine).getPartitionIds();
       engineList.add(storageEngine);
       doReturn(storageEngine).when(storageEngineRepository).getLocalStorageEngine(resourceName);

--- a/services/venice-server/src/test/java/com/linkedin/venice/cleaner/LeakedResourceCleanerTest.java
+++ b/services/venice-server/src/test/java/com/linkedin/venice/cleaner/LeakedResourceCleanerTest.java
@@ -60,7 +60,7 @@ public class LeakedResourceCleanerTest {
     for (StorageEngineMockConfig config: configs) {
       AbstractStorageEngine storageEngine = mock(AbstractStorageEngine.class);
       String topic = Version.composeKafkaTopic(storeName, config.version);
-      doReturn(topic).when(storageEngine).getStoreName();
+      doReturn(topic).when(storageEngine).getStoreVersionName();
       if (config.existingInZK) {
         Version version = mock(Version.class);
         doReturn(config.version).when(version).getNumber();


### PR DESCRIPTION
## Summary
When a version is retired, both Helix resource and ingestion task will be deleted/killed; when Helix resource is deleted, OFFLINE->DROPPED transition message will be sent to server; and when ingestion task is killed, a kill-job message will be sent to servers; these two deletions are happening independently; if transitions are done before kill-job, and if ingestion task is trying to flush RESET_OFFSET actions, servers will fail to find metadata partition.

If metadata partition doesn't exist when trying to clear offsets, there is nothing left to clear and thus no point throwing exception for it.


## How was this PR tested?
CI

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.