### PR TITLE
[clients][da-vinci-client] Adds getChangelogConsumer with storeName and consumerId

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerClientFactory.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerClientFactory.java
@@ -73,6 +73,14 @@ public class VeniceChangelogConsumerClientFactory {
     });
   }
 
+  /**
+   * Creates a VeniceChangelogConsumer with consumer id. This is used to create multiple consumers so that
+   * each consumer can only subscribe to certain partitions. Multiple such consumers can work in parallel.
+   */
+  public synchronized <K, V> VeniceChangelogConsumer<K, V> getChangelogConsumer(String storeName, String consumerId) {
+    return getChangelogConsumer(storeName + "-" + consumerId);
+  }
+
   public synchronized <K, V> BootstrappingVeniceChangelogConsumer<K, V> getBootstrappingChangelogConsumer(
       String storeName) {
     return getBootstrappingChangelogConsumer(storeName, null);


### PR DESCRIPTION
## Summary
- Adds a new overloaded method getChangelogConsumer with an additional parameter consumerId
- This will be used for having multiple consumers subscribe in parallel to different partitions of the same store
- Added Unit Tests for the new method

## How was this PR tested?
Unit Tests for the new API being added.

## Does this PR introduce any user-facing changes?
- No. It adds a new API