### PR TITLE
[server] Extend retry for new superset schema fetching.

### DIFF
--- a/internal/venice-common/src/test/java/com/linkedin/venice/helix/HelixReadOnlySchemaRepositoryTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/helix/HelixReadOnlySchemaRepositoryTest.java
@@ -135,7 +135,7 @@ public class HelixReadOnlySchemaRepositoryTest {
     // 3 times force refresh still won't get the schema, exception should be thrown.
     when(store.getLatestSuperSetValueSchemaId()).thenReturn(2);
     Assert.assertThrows(InvalidVeniceSchemaException.class, () -> schemaRepository.getSupersetSchema(storeName));
-    verify(schemaRepository, times(7)).forceRefreshSchemaData(any(), any());
+    verify(schemaRepository, times(14)).forceRefreshSchemaData(any(), any());
 
     when(store.getLatestSuperSetValueSchemaId()).thenReturn(SchemaData.INVALID_VALUE_SCHEMA_ID);
     Assert.assertNull(schemaRepository.getSupersetSchema(storeName));


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Summary, imperative, start upper case, don't end with a period
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Previous when user updates a new value schema to the AAWC store, the ongoing ingestion will get acknowledged by ZK store to refresh the schema. Previous retry for fetching the new schema from zk is 3 times with a fixed 100ms, which is very short. Without fetching new schema, the store ingestion could fail.  For a real-prod system, usually server need to wait for 3~5 seconds to fetch this schema after new schema registered.  Here we use exponential back off retry.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
Test in prod system by update test store's value schema.
## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ *] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.