### PR TITLE
[vpj] Clean up PushJobSetting to remove DataWriterMRJob specific fields

### DIFF
--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/PushJobSetting.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/PushJobSetting.java
@@ -5,7 +5,6 @@ import com.linkedin.venice.controllerapi.RepushInfoResponse;
 import com.linkedin.venice.controllerapi.StoreResponse;
 import com.linkedin.venice.etl.ETLValueSchemaTransformation;
 import com.linkedin.venice.hadoop.jobs.DataWriterComputeJob;
-import com.linkedin.venice.hadoop.mapreduce.datawriter.partition.VeniceMRPartitioner;
 import com.linkedin.venice.meta.BufferReplayPolicy;
 import com.linkedin.venice.meta.HybridStoreConfig;
 import com.linkedin.venice.meta.Version;
@@ -13,7 +12,6 @@ import com.linkedin.venice.schema.vson.VsonSchema;
 import java.io.Serializable;
 import java.util.Map;
 import org.apache.avro.Schema;
-import org.apache.hadoop.mapred.Partitioner;
 
 
 /**
@@ -37,7 +35,6 @@ public class PushJobSetting implements Serializable {
   public String incrementalPushVersion;
   public boolean isDuplicateKeyAllowed;
   public boolean enablePushJobStatusUpload;
-  public boolean enableReducerSpeculativeExecution;
   public int controllerRetries;
   public int controllerStatusPollRetries;
   public long pollJobStatusIntervalMs;
@@ -150,7 +147,4 @@ public class PushJobSetting implements Serializable {
   public transient Version sourceKafkaInputVersionInfo;
   public CompressionStrategy sourceVersionCompressionStrategy;
   public boolean sourceVersionChunkingEnabled;
-
-  // Configs to help with testing
-  public Class<? extends Partitioner> mapReducePartitionerClass = VeniceMRPartitioner.class;
 }

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
@@ -47,7 +47,6 @@ import static com.linkedin.venice.hadoop.VenicePushJobConstants.KEY_FIELD_PROP;
 import static com.linkedin.venice.hadoop.VenicePushJobConstants.LEGACY_AVRO_KEY_FIELD_PROP;
 import static com.linkedin.venice.hadoop.VenicePushJobConstants.LEGACY_AVRO_VALUE_FIELD_PROP;
 import static com.linkedin.venice.hadoop.VenicePushJobConstants.MAPPER_OUTPUT_DIRECTORY;
-import static com.linkedin.venice.hadoop.VenicePushJobConstants.MAP_REDUCE_PARTITIONER_CLASS_CONFIG;
 import static com.linkedin.venice.hadoop.VenicePushJobConstants.MULTI_REGION;
 import static com.linkedin.venice.hadoop.VenicePushJobConstants.NON_CRITICAL_EXCEPTION;
 import static com.linkedin.venice.hadoop.VenicePushJobConstants.NOT_SET;
@@ -58,7 +57,6 @@ import static com.linkedin.venice.hadoop.VenicePushJobConstants.POLL_JOB_STATUS_
 import static com.linkedin.venice.hadoop.VenicePushJobConstants.POLL_STATUS_RETRY_ATTEMPTS;
 import static com.linkedin.venice.hadoop.VenicePushJobConstants.POST_VALIDATION_CONSUMPTION_ENABLED;
 import static com.linkedin.venice.hadoop.VenicePushJobConstants.PUSH_JOB_STATUS_UPLOAD_ENABLE;
-import static com.linkedin.venice.hadoop.VenicePushJobConstants.REDUCER_SPECULATIVE_EXECUTION_ENABLE;
 import static com.linkedin.venice.hadoop.VenicePushJobConstants.REPUSH_TTL_ENABLE;
 import static com.linkedin.venice.hadoop.VenicePushJobConstants.REPUSH_TTL_START_TIMESTAMP;
 import static com.linkedin.venice.hadoop.VenicePushJobConstants.REWIND_EPOCH_TIME_BUFFER_IN_SECONDS_OVERRIDE;
@@ -346,8 +344,6 @@ public class VenicePushJob implements AutoCloseable {
     pushJobSettingToReturn.isIncrementalPush = props.getBoolean(INCREMENTAL_PUSH, false);
     pushJobSettingToReturn.isDuplicateKeyAllowed = props.getBoolean(ALLOW_DUPLICATE_KEY, false);
     pushJobSettingToReturn.enablePushJobStatusUpload = props.getBoolean(PUSH_JOB_STATUS_UPLOAD_ENABLE, false);
-    pushJobSettingToReturn.enableReducerSpeculativeExecution =
-        props.getBoolean(REDUCER_SPECULATIVE_EXECUTION_ENABLE, false);
     pushJobSettingToReturn.controllerRetries = props.getInt(CONTROLLER_REQUEST_RETRY_ATTEMPTS, 1);
     pushJobSettingToReturn.controllerStatusPollRetries = props.getInt(POLL_STATUS_RETRY_ATTEMPTS, 15);
     pushJobSettingToReturn.pollJobStatusIntervalMs =
@@ -472,12 +468,6 @@ public class VenicePushJob implements AutoCloseable {
       Class objectClass = ReflectUtils.loadClass(dataWriterComputeJobClass);
       Validate.isAssignableFrom(DataWriterComputeJob.class, objectClass);
       pushJobSettingToReturn.dataWriterComputeJobClass = objectClass;
-    }
-
-    // Test related configs
-    if (props.containsKey(MAP_REDUCE_PARTITIONER_CLASS_CONFIG)) {
-      pushJobSettingToReturn.mapReducePartitionerClass =
-          ReflectUtils.loadClass(props.getString(MAP_REDUCE_PARTITIONER_CLASS_CONFIG));
     }
 
     return pushJobSettingToReturn;

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/spark/datawriter/jobs/AbstractDataWriterSparkJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/spark/datawriter/jobs/AbstractDataWriterSparkJob.java
@@ -405,6 +405,7 @@ public abstract class AbstractDataWriterSparkJob extends DataWriterComputeJob {
     logAccumulatorValue(accumulatorsForDataWriterJob.outputRecordCounter);
     logAccumulatorValue(accumulatorsForDataWriterJob.emptyRecordCounter);
     logAccumulatorValue(accumulatorsForDataWriterJob.totalKeySizeCounter);
+    logAccumulatorValue(accumulatorsForDataWriterJob.uncompressedValueSizeCounter);
     logAccumulatorValue(accumulatorsForDataWriterJob.compressedValueSizeCounter);
     logAccumulatorValue(accumulatorsForDataWriterJob.gzipCompressedValueSizeCounter);
     logAccumulatorValue(accumulatorsForDataWriterJob.zstdCompressedValueSizeCounter);


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Clean up `PushJobSetting` and remove `DataWriterMRJob` specific fields
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
`PushJobSetting` has two configs that are specific to `DataWriterMRJob`. This is an anti-pattern and this commit moves them into `DataWriterMRJob`

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
GH CI

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.