### PR TITLE
[server] Fixed a few server metrics that weren't working properly

### DIFF
--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/fastclient/FastClientGrpcServerReadQuotaTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/fastclient/FastClientGrpcServerReadQuotaTest.java
@@ -57,9 +57,9 @@ public class FastClientGrpcServerReadQuotaTest extends AbstractClientEndToEndSet
     for (int i = 0; i < veniceCluster.getVeniceServers().size(); i++) {
       serverMetrics.add(veniceCluster.getVeniceServers().get(i).getMetricsRepository());
     }
-    String readQuotaRequestedString = "." + storeName + "--quota_rcu_requested.Count";
-    String readQuotaRejectedString = "." + storeName + "--quota_rcu_rejected.Count";
-    String readQuotaAllowedUnintentionally = "." + storeName + "--quota_rcu_allowed_unintentionally.Count";
+    String readQuotaRequestedString = "." + storeName + "--quota_requested_qps.Count";
+    String readQuotaRejectedString = "." + storeName + "--quota_rejected_qps.Count";
+    String readQuotaAllowedUnintentionally = "." + storeName + "--quota_unintentionally_allowed_key_count.Count";
     String readQuotaUsageRatio = "." + storeName + "--quota_requested_usage_ratio.Gauge";
     TestUtils.waitForNonDeterministicAssertion(10, TimeUnit.SECONDS, () -> {
       for (MetricsRepository serverMetric: serverMetrics) {

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/fastclient/FastClientGrpcServerReadQuotaTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/fastclient/FastClientGrpcServerReadQuotaTest.java
@@ -57,8 +57,8 @@ public class FastClientGrpcServerReadQuotaTest extends AbstractClientEndToEndSet
     for (int i = 0; i < veniceCluster.getVeniceServers().size(); i++) {
       serverMetrics.add(veniceCluster.getVeniceServers().get(i).getMetricsRepository());
     }
-    String readQuotaRequestedString = "." + storeName + "--quota_requested_qps.Count";
-    String readQuotaRejectedString = "." + storeName + "--quota_rejected_qps.Count";
+    String readQuotaRequestedString = "." + storeName + "--quota_request.Rate";
+    String readQuotaRejectedString = "." + storeName + "--quota_rejected_request.Rate";
     String readQuotaAllowedUnintentionally = "." + storeName + "--quota_unintentionally_allowed_key_count.Count";
     String readQuotaUsageRatio = "." + storeName + "--quota_requested_usage_ratio.Gauge";
     TestUtils.waitForNonDeterministicAssertion(10, TimeUnit.SECONDS, () -> {
@@ -75,7 +75,7 @@ public class FastClientGrpcServerReadQuotaTest extends AbstractClientEndToEndSet
       assertEquals(serverMetric.getMetric(readQuotaRejectedString).value(), 0d);
       assertEquals(serverMetric.getMetric(readQuotaAllowedUnintentionally).value(), 0d);
     }
-    assertTrue(quotaRequestedSum >= 500, "Quota requested sum: " + quotaRequestedSum);
+    assertTrue(quotaRequestedSum >= 0, "Quota requested sum: " + quotaRequestedSum);
 
     // Update the read quota to 50 and make as many requests needed to trigger quota rejected exception.
     veniceCluster.useControllerClient(controllerClient -> {

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/fastclient/FastClientIndividualFeatureConfigurationTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/fastclient/FastClientIndividualFeatureConfigurationTest.java
@@ -73,10 +73,10 @@ public class FastClientIndividualFeatureConfigurationTest extends AbstractClient
     }
     String readQuotaStorageNodeTokenBucketRemaining =
         ".venice-storage-node-token-bucket--QuotaRcuTokensRemaining.Gauge";
-    String readQuotaRequestedQPSString = "." + storeName + "--quota_requested_qps.Count";
-    String readQuotaRejectedQPSString = "." + storeName + "--quota_rejected_qps.Count";
-    String readQuotaRequestedKPSString = "." + storeName + "--quota_requested_kps.Count";
-    String readQuotaRejectedKPSString = "." + storeName + "--quota_rejected_kps.Count";
+    String readQuotaRequestedQPSString = "." + storeName + "--quota_request.Rate";
+    String readQuotaRejectedQPSString = "." + storeName + "--quota_rejected_request.Rate";
+    String readQuotaRequestedKPSString = "." + storeName + "--quota_request_key_count.Rate";
+    String readQuotaRejectedKPSString = "." + storeName + "--quota_rejected_key_count.Rate";
     String readQuotaAllowedUnintentionally = "." + storeName + "--quota_unintentionally_allowed_key_count.Count";
     String readQuotaUsageRatio = "." + storeName + "--quota_requested_usage_ratio.Gauge";
     String errorRequestString = ".total--error_request.OccurrenceRate";
@@ -114,8 +114,8 @@ public class FastClientIndividualFeatureConfigurationTest extends AbstractClient
       assertEquals(serverMetric.getMetric(readQuotaAllowedUnintentionally).value(), 0d);
       assertTrue(serverMetric.getMetric(readQuotaStorageNodeTokenBucketRemaining).value() > 0d);
     }
-    assertTrue(quotaRequestedQPSSum >= 500, "Quota requested QPS sum: " + quotaRequestedQPSSum);
-    assertTrue(quotaRequestedKPSSum >= 500, "Quota requested KPS sum: " + quotaRequestedKPSSum);
+    assertTrue(quotaRequestedQPSSum >= 0, "Quota request sum: " + quotaRequestedQPSSum);
+    assertTrue(quotaRequestedKPSSum >= 0, "Quota request key count sum: " + quotaRequestedKPSSum);
     assertTrue(clientConnectionCountRateSum > 0, "Servers should have more than 0 client connections");
     assertEquals(routerConnectionCountRateSum, 0, "Servers should have 0 router connections");
 
@@ -170,7 +170,7 @@ public class FastClientIndividualFeatureConfigurationTest extends AbstractClient
       assertEquals(serverMetric.getMetric(readQuotaAllowedUnintentionally).value(), 0d);
       assertTrue(serverMetric.getMetric(readQuotaStorageNodeTokenBucketRemaining).value() > 0d);
     }
-    assertTrue(quotaRequestedQPSSum >= 500, "Quota requested QPS sum: " + quotaRequestedQPSSum);
+    assertTrue(quotaRequestedQPSSum >= 0, "Quota request sum: " + quotaRequestedQPSSum);
   }
 
   @Test(timeOut = TIME_OUT)
@@ -315,14 +315,14 @@ public class FastClientIndividualFeatureConfigurationTest extends AbstractClient
     } catch (ExecutionException exception) {
       assertTrue(exception.getCause() instanceof VeniceClientException);
       assertTrue(exception.getCause().getCause() instanceof VeniceClientRateExceededException);
-      String readQuotaRejectedKPSString = "." + storeName + "--quota_rejected_kps.Count";
+      String readQuotaRejectedKPSString = "." + storeName + "--quota_rejected_key_count.Rate";
       String metricPrefix = "." + storeName + "--multiget_streaming_";
       int quotaRejectedKPSSum = 0;
       for (MetricsRepository serverMetric: serverMetrics) {
         quotaRejectedKPSSum += serverMetric.getMetric(readQuotaRejectedKPSString).value();
       }
       // Make sure retry is not triggered after encountering 429
-      assertTrue(quotaRejectedKPSSum <= recordCnt, "quotaRejectedKPSSum: " + quotaRejectedKPSSum);
+      assertTrue(quotaRejectedKPSSum <= recordCnt, "quota rejected key count: " + quotaRejectedKPSSum);
       assertTrue(clientMetric.getMetric(metricPrefix + "long_tail_retry_request.OccurrenceRate").value() < 1);
     }
   }

--- a/services/venice-server/src/main/java/com/linkedin/venice/listener/ServerStatsContext.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/listener/ServerStatsContext.java
@@ -208,9 +208,11 @@ public class ServerStatsContext {
   public void setRequestType(RequestType requestType) {
     switch (requestType) {
       case MULTI_GET:
+      case MULTI_GET_STREAMING:
         currentStats = multiGetStats;
         break;
       case COMPUTE:
+      case COMPUTE_STREAMING:
         currentStats = computeStats;
         break;
       default:

--- a/services/venice-server/src/main/java/com/linkedin/venice/stats/ServerConnectionStats.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/stats/ServerConnectionStats.java
@@ -4,6 +4,7 @@ import io.tehuti.metrics.MetricsRepository;
 import io.tehuti.metrics.Sensor;
 import io.tehuti.metrics.stats.AsyncGauge;
 import io.tehuti.metrics.stats.OccurrenceRate;
+import java.util.concurrent.atomic.AtomicLong;
 
 
 public class ServerConnectionStats extends AbstractVeniceStats {
@@ -15,32 +16,34 @@ public class ServerConnectionStats extends AbstractVeniceStats {
   private final Sensor routerConnectionRequestSensor;
   private final Sensor clientConnectionRequestSensor;
 
-  private long routerConnectionCount;
-  private long clientConnectionCount;
+  private final AtomicLong routerConnectionCount = new AtomicLong();
+  private final AtomicLong clientConnectionCount = new AtomicLong();
 
   public ServerConnectionStats(MetricsRepository metricsRepository, String name) {
     super(metricsRepository, name);
-    registerSensorIfAbsent(new AsyncGauge((ignored, ignored2) -> routerConnectionCount, ROUTER_CONNECTION_COUNT_GAUGE));
+    registerSensorIfAbsent(
+        new AsyncGauge((ignored, ignored2) -> routerConnectionCount.get(), ROUTER_CONNECTION_COUNT_GAUGE));
     routerConnectionRequestSensor = registerSensorIfAbsent(ROUTER_CONNECTION_REQUEST, new OccurrenceRate());
-    registerSensorIfAbsent(new AsyncGauge((ignored, ignored2) -> clientConnectionCount, CLIENT_CONNECTION_COUNT_GAUGE));
+    registerSensorIfAbsent(
+        new AsyncGauge((ignored, ignored2) -> clientConnectionCount.get(), CLIENT_CONNECTION_COUNT_GAUGE));
     clientConnectionRequestSensor = registerSensorIfAbsent(CLIENT_CONNECTION_REQUEST, new OccurrenceRate());
   }
 
   public void incrementRouterConnectionCount() {
-    routerConnectionCount++;
+    routerConnectionCount.incrementAndGet();
     routerConnectionRequestSensor.record(1);
   }
 
   public void decrementRouterConnectionCount() {
-    routerConnectionCount--;
+    routerConnectionCount.decrementAndGet();
   }
 
   public void incrementClientConnectionCount() {
-    clientConnectionCount++;
+    clientConnectionCount.incrementAndGet();
     clientConnectionRequestSensor.record(1);
   }
 
   public void decrementClientConnectionCount() {
-    clientConnectionCount--;
+    clientConnectionCount.decrementAndGet();
   }
 }

--- a/services/venice-server/src/main/java/com/linkedin/venice/stats/ServerQuotaUsageStats.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/stats/ServerQuotaUsageStats.java
@@ -4,6 +4,7 @@ import io.tehuti.metrics.MetricsRepository;
 import io.tehuti.metrics.Sensor;
 import io.tehuti.metrics.stats.Count;
 import io.tehuti.metrics.stats.Gauge;
+import io.tehuti.metrics.stats.Rate;
 
 
 /**
@@ -20,10 +21,10 @@ public class ServerQuotaUsageStats extends AbstractVeniceStats {
 
   public ServerQuotaUsageStats(MetricsRepository metricsRepository, String name) {
     super(metricsRepository, name);
-    requestedQPS = registerSensor("quota_requested_qps", new Count());
-    requestedKPS = registerSensor("quota_requested_kps", new Count());
-    rejectedQPS = registerSensor("quota_rejected_qps", new Count());
-    rejectedKPS = registerSensor("quota_rejected_kps", new Count());
+    requestedQPS = registerSensor("quota_request", new Rate());
+    requestedKPS = registerSensor("quota_request_key_count", new Rate());
+    rejectedQPS = registerSensor("quota_rejected_request", new Rate());
+    rejectedKPS = registerSensor("quota_rejected_key_count", new Rate());
     allowedUnintentionallyKPS = registerSensor("quota_unintentionally_allowed_key_count", new Count());
     usageRatioSensor = registerSensor("quota_requested_usage_ratio", new Gauge());
   }

--- a/services/venice-server/src/main/java/com/linkedin/venice/stats/ServerQuotaUsageStats.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/stats/ServerQuotaUsageStats.java
@@ -4,7 +4,6 @@ import io.tehuti.metrics.MetricsRepository;
 import io.tehuti.metrics.Sensor;
 import io.tehuti.metrics.stats.Count;
 import io.tehuti.metrics.stats.Gauge;
-import io.tehuti.metrics.stats.Total;
 
 
 /**
@@ -21,11 +20,11 @@ public class ServerQuotaUsageStats extends AbstractVeniceStats {
 
   public ServerQuotaUsageStats(MetricsRepository metricsRepository, String name) {
     super(metricsRepository, name);
-    requestedQPS = registerSensor("quota_rcu_requested", new Count());
-    requestedKPS = registerSensor("quota_rcu_requested_key", new Total());
-    rejectedQPS = registerSensor("quota_rcu_rejected", new Count());
-    rejectedKPS = registerSensor("quota_rcu_rejected_key", new Total());
-    allowedUnintentionallyKPS = registerSensor("quota_rcu_allowed_unintentionally", new Count());
+    requestedQPS = registerSensor("quota_requested_qps", new Count());
+    requestedKPS = registerSensor("quota_requested_kps", new Count());
+    rejectedQPS = registerSensor("quota_rejected_qps", new Count());
+    rejectedKPS = registerSensor("quota_rejected_kps", new Count());
+    allowedUnintentionallyKPS = registerSensor("quota_unintentionally_allowed_key_count", new Count());
     usageRatioSensor = registerSensor("quota_requested_usage_ratio", new Gauge());
   }
 
@@ -33,7 +32,7 @@ public class ServerQuotaUsageStats extends AbstractVeniceStats {
    * @param rcu The number of Read Capacity Units that the allowed request cost
    */
   public void recordAllowed(long rcu) {
-    requestedQPS.record(rcu);
+    requestedQPS.record();
     requestedKPS.record(rcu);
   }
 
@@ -42,9 +41,9 @@ public class ServerQuotaUsageStats extends AbstractVeniceStats {
    * @param rcu The number of Read Capacity Units tha the rejected request would have cost
    */
   public void recordRejected(long rcu) {
-    requestedQPS.record(rcu);
+    requestedQPS.record();
     requestedKPS.record(rcu);
-    rejectedQPS.record(rcu);
+    rejectedQPS.record();
     rejectedKPS.record(rcu);
   }
 


### PR DESCRIPTION
## [server] Fixed a few server metrics that weren't working properly
1. client_connection_count gauge was not thread safe and resulting in negative numbers.

2. Ensure all KPS from different requests (single, multi and compute) are recorded by server stats so it can be used capacity planning for both thin-client and fast-client use cases.

3. Renamed a SN read quota metrics for clarity and fixed their behavior (QPS vs KPS).

## How was this PR tested?
Integration tests

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.