### PR TITLE
[admin][producer] Disable partial matching for Apache Commons CLI

### DIFF
--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/AdminTool.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/AdminTool.java
@@ -599,7 +599,7 @@ public class AdminTool {
 
     options.addOptionGroup(commandGroup);
 
-    CommandLineParser parser = new DefaultParser();
+    CommandLineParser parser = new DefaultParser(false);
     CommandLine cmd = parser.parse(options, args);
 
     if (cmd.hasOption(Arg.HELP.first())) {
@@ -626,7 +626,7 @@ public class AdminTool {
         if (foundCommand == null) {
           foundCommand = c.toString();
         } else {
-          throw new VeniceException("Can only specify one of --" + foundCommand + " and --" + c.toString());
+          throw new VeniceException("Can only specify one of --" + foundCommand + " and --" + c);
         }
       }
     }

--- a/clients/venice-producer/src/main/java/com/linkedin/venice/producer/online/ProducerTool.java
+++ b/clients/venice-producer/src/main/java/com/linkedin/venice/producer/online/ProducerTool.java
@@ -86,7 +86,7 @@ public class ProducerTool {
 
     CommandLine cmd = null;
     try {
-      cmd = new DefaultParser().parse(CLI_OPTIONS, args);
+      cmd = new DefaultParser(false).parse(CLI_OPTIONS, args);
     } catch (ParseException e) {
       System.out.println("[ERROR] " + e.getMessage());
       printHelp();

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceServerWrapper.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceServerWrapper.java
@@ -505,7 +505,7 @@ public class VeniceServerWrapper extends ProcessWrapper implements MetricsAware 
     options.addOption(new Option("iaj", "isAutoJoin", false, "automatically join the venice cluster"));
     options.addOption(new Option("vu", "veniceUrl", true, "ZK url for venice d2 service"));
     options.addOption(new Option("dsn", "d2ServiceName", true, "d2 service name"));
-    CommandLineParser parser = new DefaultParser();
+    CommandLineParser parser = new DefaultParser(false);
     CommandLine cmd = parser.parse(options, args);
 
     String clusterName = cmd.getOptionValue("cn");


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Disable partial matching for Apache Commons CLI
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
Commons CLI enables partial matching for CLI options. We do not wish to use this as it can lead to unintended commands in `AdminTool`. For example, Since there is no `--get-store` command, `--get-store` matches `--get-store-acl`. While this is benign, there could be other cases where it becomes critical

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
Tested locally

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.