### PR TITLE
[controller] DaVinci offline instance wait time is now configurable

### DIFF
--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -1757,6 +1757,13 @@ public class ConfigKeys {
       "push.status.store.heartbeat.expiration.seconds";
 
   /**
+   * Controller will wait for unresponsive DaVinci instances for this amount of time before announcing the push fails
+   * on DaVinci side.
+   */
+  public static final String DA_VINCI_OFFLINE_INSTANCE_WAIT_TIME_IN_MINUTES =
+      "da.vinci.offline.instance.wait.time.in.minutes";
+
+  /**
    * Derived schemaId for push status store write compute.
    */
   public static final String PUSH_STATUS_STORE_DERIVED_SCHEMA_ID = "push.status.store.derived.schema.id";

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerConfig.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerConfig.java
@@ -63,6 +63,7 @@ import static com.linkedin.venice.ConfigKeys.DAVINCI_PUSH_STATUS_SCAN_MAX_OFFLIN
 import static com.linkedin.venice.ConfigKeys.DAVINCI_PUSH_STATUS_SCAN_MAX_OFFLINE_INSTANCE_RATIO;
 import static com.linkedin.venice.ConfigKeys.DAVINCI_PUSH_STATUS_SCAN_NO_REPORT_RETRY_MAX_ATTEMPTS;
 import static com.linkedin.venice.ConfigKeys.DAVINCI_PUSH_STATUS_SCAN_THREAD_NUMBER;
+import static com.linkedin.venice.ConfigKeys.DA_VINCI_OFFLINE_INSTANCE_WAIT_TIME_IN_MINUTES;
 import static com.linkedin.venice.ConfigKeys.DEPRECATED_TOPIC_MAX_RETENTION_MS;
 import static com.linkedin.venice.ConfigKeys.DEPRECATED_TOPIC_RETENTION_MS;
 import static com.linkedin.venice.ConfigKeys.EMERGENCY_SOURCE_REGION;
@@ -248,6 +249,7 @@ public class VeniceControllerConfig extends VeniceControllerClusterConfig {
    * Used to decide if an instance is stale.
    */
   private final long pushStatusStoreHeartbeatExpirationTimeInSeconds;
+  private final long daVinciOfflineInstanceWaitTimeInMinutes;
   private final long systemStoreAclSynchronizationDelayMs;
 
   /**
@@ -500,6 +502,7 @@ public class VeniceControllerConfig extends VeniceControllerClusterConfig {
         props.getBoolean(CONTROLLER_ZK_SHARED_META_SYSTEM_SCHEMA_STORE_AUTO_CREATION_ENABLED, false);
     this.pushStatusStoreHeartbeatExpirationTimeInSeconds =
         props.getLong(PUSH_STATUS_STORE_HEARTBEAT_EXPIRATION_TIME_IN_SECONDS, TimeUnit.MINUTES.toSeconds(10));
+    this.daVinciOfflineInstanceWaitTimeInMinutes = props.getLong(DA_VINCI_OFFLINE_INSTANCE_WAIT_TIME_IN_MINUTES, 15);
     this.isDaVinciPushStatusStoreEnabled = props.getBoolean(PUSH_STATUS_STORE_ENABLED, false);
     this.daVinciPushStatusScanEnabled =
         props.getBoolean(DAVINCI_PUSH_STATUS_SCAN_ENABLED, true) && isDaVinciPushStatusStoreEnabled;
@@ -900,6 +903,10 @@ public class VeniceControllerConfig extends VeniceControllerClusterConfig {
 
   public long getPushStatusStoreHeartbeatExpirationTimeInSeconds() {
     return pushStatusStoreHeartbeatExpirationTimeInSeconds;
+  }
+
+  public long getDaVinciOfflineInstanceWaitTimeInMinutes() {
+    return daVinciOfflineInstanceWaitTimeInMinutes;
   }
 
   public boolean isDaVinciPushStatusStoreEnabled() {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -5819,7 +5819,8 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
             version.getPartitionCount(),
             incrementalPushVersion,
             multiClusterConfigs.getControllerConfig(clusterName).getDaVinciPushStatusScanMaxOfflineInstanceCount(),
-            multiClusterConfigs.getControllerConfig(clusterName).getDaVinciPushStatusScanMaxOfflineInstanceRatio());
+            multiClusterConfigs.getControllerConfig(clusterName).getDaVinciPushStatusScanMaxOfflineInstanceRatio(),
+            multiClusterConfigs.getControllerConfig(clusterName).getDaVinciOfflineInstanceWaitTimeInMinutes());
         ExecutionStatus daVinciStatus = daVinciStatusAndDetails.getStatus();
         String daVinciDetails = daVinciStatusAndDetails.getDetails();
         executionStatus = getOverallPushStatus(executionStatus, daVinciStatus);

--- a/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/AbstractPushMonitor.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/AbstractPushMonitor.java
@@ -130,7 +130,8 @@ public abstract class AbstractPushMonitor
         controllerConfig.getDaVinciPushStatusScanThreadNumber(),
         controllerConfig.getDaVinciPushStatusScanNoReportRetryMaxAttempt(),
         controllerConfig.getDaVinciPushStatusScanMaxOfflineInstanceCount(),
-        controllerConfig.getDaVinciPushStatusScanMaxOfflineInstanceRatio());
+        controllerConfig.getDaVinciPushStatusScanMaxOfflineInstanceRatio(),
+        controllerConfig.getDaVinciOfflineInstanceWaitTimeInMinutes());
     this.isOfflinePushMonitorDaVinciPushStatusEnabled = controllerConfig.isDaVinciPushStatusEnabled();
     pushStatusCollector.start();
   }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/PushMonitorUtils.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/PushMonitorUtils.java
@@ -17,8 +17,6 @@ import org.apache.logging.log4j.Logger;
  * This class contains some common util methods for push monitoring purpose.
  */
 public class PushMonitorUtils {
-  private static long daVinciErrorInstanceWaitTime = 5;
-
   private static final Map<String, Long> storeVersionToDVCDeadInstanceTimeMap = new ConcurrentHashMap<>();
   private static final Logger LOGGER = LogManager.getLogger(PushMonitorUtils.class);
 
@@ -33,7 +31,8 @@ public class PushMonitorUtils {
       int partitionCount,
       Optional<String> incrementalPushVersion,
       int maxOfflineInstanceCount,
-      double maxOfflineInstanceRatio) {
+      double maxOfflineInstanceRatio,
+      long offlineInstanceWaitTimeInMinutes) {
     if (reader == null) {
       throw new VeniceException("PushStatusStoreReader is null");
     }
@@ -104,7 +103,7 @@ public class PushMonitorUtils {
     if (offlineReplicaCount > maxOfflineInstanceAllowed) {
       Long lastUpdateTime = storeVersionToDVCDeadInstanceTimeMap.get(topicName);
       if (lastUpdateTime != null) {
-        if (lastUpdateTime + TimeUnit.MINUTES.toMillis(daVinciErrorInstanceWaitTime) < System.currentTimeMillis()) {
+        if (lastUpdateTime + TimeUnit.MINUTES.toMillis(offlineInstanceWaitTimeInMinutes) < System.currentTimeMillis()) {
           storeVersionToDVCDeadInstanceTimeMap.remove(topicName);
           return new ExecutionStatusWithDetails(
               ExecutionStatus.ERROR,
@@ -165,9 +164,5 @@ public class PushMonitorUtils {
       return new ExecutionStatusWithDetails(ExecutionStatus.ERROR, statusDetail, noDaVinciStatusReported);
     }
     return new ExecutionStatusWithDetails(ExecutionStatus.STARTED, statusDetail, noDaVinciStatusReported);
-  }
-
-  static void setDaVinciErrorInstanceWaitTime(int time) {
-    daVinciErrorInstanceWaitTime = time;
   }
 }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/PushStatusCollector.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/PushStatusCollector.java
@@ -44,6 +44,7 @@ public class PushStatusCollector {
   private final int daVinciPushStatusNoReportRetryMaxAttempts;
   private final int daVinciPushStatusScanMaxOfflineInstanceCount;
   private final double daVinciPushStatusScanMaxOfflineInstanceRatio;
+  private final long daVinciOfflineInstanceWaitTimeInMinutes;
   private ScheduledExecutorService offlinePushCheckScheduler;
   private ExecutorService pushStatusStoreScanExecutor;
   private final AtomicBoolean isStarted = new AtomicBoolean(false);
@@ -60,7 +61,8 @@ public class PushStatusCollector {
       int daVinciPushStatusScanThreadNumber,
       int daVinciPushStatusNoReportRetryMaxAttempts,
       int daVinciPushStatusScanMaxOfflineInstanceCount,
-      double daVinciPushStatusScanMaxOfflineInstanceRatio) {
+      double daVinciPushStatusScanMaxOfflineInstanceRatio,
+      long daVinciOfflineInstanceWaitTimeInMinutes) {
     this.storeRepository = storeRepository;
     this.pushStatusStoreReader = pushStatusStoreReader;
     this.pushCompletedHandler = pushCompletedHandler;
@@ -71,6 +73,20 @@ public class PushStatusCollector {
     this.daVinciPushStatusNoReportRetryMaxAttempts = daVinciPushStatusNoReportRetryMaxAttempts;
     this.daVinciPushStatusScanMaxOfflineInstanceCount = daVinciPushStatusScanMaxOfflineInstanceCount;
     this.daVinciPushStatusScanMaxOfflineInstanceRatio = daVinciPushStatusScanMaxOfflineInstanceRatio;
+    this.daVinciOfflineInstanceWaitTimeInMinutes = daVinciOfflineInstanceWaitTimeInMinutes;
+    LOGGER.info(
+        "Built PushStatusCollector with the following parameters: "
+            + "daVinciPushStatusScanEnabled: {}, daVinciPushStatusScanPeriodInSeconds: {}, "
+            + "daVinciPushStatusScanThreadNumber: {}, daVinciPushStatusNoReportRetryMaxAttempts: {}, "
+            + "daVinciPushStatusScanMaxOfflineInstanceCount: {}, daVinciPushStatusScanMaxOfflineInstanceRatio: {}, "
+            + "daVinciOfflineInstanceWaitTimeInMinutes: {}",
+        daVinciPushStatusScanEnabled,
+        daVinciPushStatusScanPeriodInSeconds,
+        daVinciPushStatusScanThreadNumber,
+        daVinciPushStatusNoReportRetryMaxAttempts,
+        daVinciPushStatusScanMaxOfflineInstanceCount,
+        daVinciPushStatusScanMaxOfflineInstanceRatio,
+        daVinciOfflineInstanceWaitTimeInMinutes);
   }
 
   public void start() {
@@ -135,7 +151,8 @@ public class PushStatusCollector {
               pushStatus.getPartitionCount(),
               Optional.empty(),
               daVinciPushStatusScanMaxOfflineInstanceCount,
-              daVinciPushStatusScanMaxOfflineInstanceRatio);
+              daVinciPushStatusScanMaxOfflineInstanceRatio,
+              daVinciOfflineInstanceWaitTimeInMinutes);
           pushStatus.setDaVinciStatus(statusWithDetails);
           return pushStatus;
         }, pushStatusStoreScanExecutor));

--- a/services/venice-controller/src/test/java/com/linkedin/venice/pushmonitor/PushMonitorUtilsTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/pushmonitor/PushMonitorUtilsTest.java
@@ -93,7 +93,7 @@ public class PushMonitorUtilsTest {
         Optional.empty(),
         maxOfflineInstanceCount,
         maxOfflineInstanceRatio,
-        1);
+        0);
     Assert.assertEquals(executionStatusWithDetails.getStatus(), expectedStatus);
     if (expectedStatus.equals(ExecutionStatus.ERROR)) {
       Assert.assertEquals(executionStatusWithDetails.getDetails(), expectedErrorDetails);

--- a/services/venice-controller/src/test/java/com/linkedin/venice/pushmonitor/PushMonitorUtilsTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/pushmonitor/PushMonitorUtilsTest.java
@@ -18,7 +18,6 @@ import org.testng.annotations.Test;
 public class PushMonitorUtilsTest {
   @Test
   public void testDaVinciPushStatusScan() {
-    PushMonitorUtils.setDaVinciErrorInstanceWaitTime(0);
     PushStatusStoreReader reader = mock(PushStatusStoreReader.class);
     doReturn(true).when(reader).isInstanceAlive(eq("store"), eq("a"));
     doReturn(false).when(reader).isInstanceAlive(eq("store"), eq("b"));
@@ -82,7 +81,8 @@ public class PushMonitorUtilsTest {
         1,
         Optional.empty(),
         maxOfflineInstanceCount,
-        maxOfflineInstanceRatio);
+        maxOfflineInstanceRatio,
+        0);
     Assert.assertEquals(executionStatusWithDetails.getStatus(), ExecutionStatus.STARTED);
     // Sleep 1ms and try again.
     Utils.sleep(1);
@@ -92,7 +92,8 @@ public class PushMonitorUtilsTest {
         1,
         Optional.empty(),
         maxOfflineInstanceCount,
-        maxOfflineInstanceRatio);
+        maxOfflineInstanceRatio,
+        1);
     Assert.assertEquals(executionStatusWithDetails.getStatus(), expectedStatus);
     if (expectedStatus.equals(ExecutionStatus.ERROR)) {
       Assert.assertEquals(executionStatusWithDetails.getDetails(), expectedErrorDetails);

--- a/services/venice-controller/src/test/java/com/linkedin/venice/pushmonitor/PushStatusCollectorTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/pushmonitor/PushStatusCollectorTest.java
@@ -59,6 +59,7 @@ public class PushStatusCollectorTest {
         4,
         1,
         20,
+        1,
         1);
     pushStatusCollector.start();
 
@@ -192,6 +193,7 @@ public class PushStatusCollectorTest {
         4,
         1,
         20,
+        1,
         1);
     pushStatusCollector.start();
 
@@ -275,6 +277,7 @@ public class PushStatusCollectorTest {
         4,
         0,
         20,
+        1,
         1);
     pushStatusCollector.start();
 


### PR DESCRIPTION
## Summary
Previously the offline instance wait time is hardcoded to 5 minutes; this PR makes it configureable with config name:
da.vinci.offline.instance.wait.time.in.minutes

Default value is set to 15 minutes.

## How was this PR tested?
CI

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.