### PR TITLE
[server] Server read quota usage ratio metric improvement

### DIFF
--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/fastclient/FastClientIndividualFeatureConfigurationTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/fastclient/FastClientIndividualFeatureConfigurationTest.java
@@ -118,6 +118,17 @@ public class FastClientIndividualFeatureConfigurationTest extends AbstractClient
     assertTrue(quotaRequestedKPSSum >= 0, "Quota request key count sum: " + quotaRequestedKPSSum);
     assertTrue(clientConnectionCountRateSum > 0, "Servers should have more than 0 client connections");
     assertEquals(routerConnectionCountRateSum, 0, "Servers should have 0 router connections");
+    // At least one server's usage ratio should eventually be a positive decimal
+    TestUtils.waitForNonDeterministicAssertion(5, TimeUnit.SECONDS, () -> {
+      double usageRatio = 0;
+      for (MetricsRepository serverMetric: serverMetrics) {
+        usageRatio = serverMetric.getMetric(readQuotaUsageRatio).value();
+        if (usageRatio > 0) {
+          break;
+        }
+      }
+      assertTrue(usageRatio > 0, "Quota usage ratio: " + usageRatio);
+    });
 
     // Update the read quota to 50 and make as many requests needed to trigger quota rejected exception.
     veniceCluster.useControllerClient(controllerClient -> {

--- a/services/venice-server/src/main/java/com/linkedin/venice/listener/ReadQuotaEnforcementHandler.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/listener/ReadQuotaEnforcementHandler.java
@@ -208,8 +208,6 @@ public class ReadQuotaEnforcementHandler extends SimpleChannelInboundHandler<Rou
      */
     TokenBucket tokenBucket = storeVersionBuckets.get(request.getResourceName());
     if (tokenBucket != null) {
-      // Can always emit the stale usage ratio first because it's using numbers from the previous refill
-      stats.recordReadQuotaUsageRatio(storeName, tokenBucket.getStaleUsageRatio());
       if (!request.isRetryRequest() && !tokenBucket.tryConsume(rcu)
           && handleTooManyRequests(ctx, request, null, store, rcu, false)) {
         // Enforce store version quota for non-retry requests.
@@ -425,6 +423,8 @@ public class ReadQuotaEnforcementHandler extends SimpleChannelInboundHandler<Rou
         return v;
       }
     });
+    String storeName = Version.parseStoreFromVersionTopic(topic);
+    stats.setStoreTokenBucket(storeName, getBucketForStore(storeName));
   }
 
   private long calculateRefillAmount(long totalRcuPerSecond, double thisBucketProportionOfTotalRcu) {
@@ -513,6 +513,7 @@ public class ReadQuotaEnforcementHandler extends SimpleChannelInboundHandler<Rou
       }
     }
     removeTopics(toBeRemovedTopics);
+    stats.setStoreTokenBucket(store.getName(), getBucketForStore(store.getName()));
   }
 
   private Set<String> getStoreTopics(String storeName) {

--- a/services/venice-server/src/main/java/com/linkedin/venice/listener/grpc/handlers/GrpcReadQuotaEnforcementHandler.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/listener/grpc/handlers/GrpcReadQuotaEnforcementHandler.java
@@ -34,7 +34,6 @@ public class GrpcReadQuotaEnforcementHandler extends VeniceServerGrpcHandler {
 
     TokenBucket tokenBucket = readQuota.getStoreVersionBuckets().get(request.getResourceName());
     if (tokenBucket != null) {
-      readQuota.getStats().recordReadQuotaUsageRatio(storeName, tokenBucket.getStaleUsageRatio());
       if (!request.isRetryRequest() && !tokenBucket.tryConsume(rcu)
           && readQuota.handleTooManyRequests(null, request, ctx, store, rcu, true)) {
         invokeNextHandler(ctx);

--- a/services/venice-server/src/main/java/com/linkedin/venice/stats/AggServerQuotaUsageStats.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/stats/AggServerQuotaUsageStats.java
@@ -1,5 +1,6 @@
 package com.linkedin.venice.stats;
 
+import com.linkedin.venice.throttle.TokenBucket;
 import io.tehuti.metrics.MetricsRepository;
 
 
@@ -27,7 +28,7 @@ public class AggServerQuotaUsageStats extends AbstractVeniceAggStats<ServerQuota
     getStoreStats(storeName).recordAllowedUnintentionally(rcu);
   }
 
-  public void recordReadQuotaUsageRatio(String storeName, double usageRatio) {
-    getStoreStats(storeName).recordReadQuotaUsageRatio(usageRatio);
+  public void setStoreTokenBucket(String storeName, TokenBucket tokenBucket) {
+    getStoreStats(storeName).setTokenBucket(tokenBucket);
   }
 }

--- a/services/venice-server/src/main/java/com/linkedin/venice/stats/ServerQuotaUsageStats.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/stats/ServerQuotaUsageStats.java
@@ -1,9 +1,10 @@
 package com.linkedin.venice.stats;
 
+import com.linkedin.venice.throttle.TokenBucket;
 import io.tehuti.metrics.MetricsRepository;
 import io.tehuti.metrics.Sensor;
+import io.tehuti.metrics.stats.AsyncGauge;
 import io.tehuti.metrics.stats.Count;
-import io.tehuti.metrics.stats.Gauge;
 import io.tehuti.metrics.stats.Rate;
 
 
@@ -18,6 +19,7 @@ public class ServerQuotaUsageStats extends AbstractVeniceStats {
   private final Sensor allowedUnintentionallyKPS; // allowed KPS unintentionally due to error or insufficient info
   private final Sensor usageRatioSensor; // requested qps divided by amortized refill per second on this node for a
                                          // store
+  private TokenBucket tokenBucket; // The corresponding store's token bucket that this stats instance is tracking for
 
   public ServerQuotaUsageStats(MetricsRepository metricsRepository, String name) {
     super(metricsRepository, name);
@@ -26,7 +28,8 @@ public class ServerQuotaUsageStats extends AbstractVeniceStats {
     rejectedQPS = registerSensor("quota_rejected_request", new Rate());
     rejectedKPS = registerSensor("quota_rejected_key_count", new Rate());
     allowedUnintentionallyKPS = registerSensor("quota_unintentionally_allowed_key_count", new Count());
-    usageRatioSensor = registerSensor("quota_requested_usage_ratio", new Gauge());
+    usageRatioSensor =
+        registerSensor(new AsyncGauge((ignored, ignored2) -> getReadQuotaUsageRatio(), "quota_requested_usage_ratio"));
   }
 
   /**
@@ -52,7 +55,19 @@ public class ServerQuotaUsageStats extends AbstractVeniceStats {
     allowedUnintentionallyKPS.record(rcu);
   }
 
-  public void recordReadQuotaUsageRatio(double usageRatio) {
-    usageRatioSensor.record(usageRatio);
+  public void setTokenBucket(TokenBucket tokenBucket) {
+    this.tokenBucket = tokenBucket;
+  }
+
+  /**
+   * The usage ratio is calculated within the token bucket based on the number of token requested since last refill
+   * @return usage ratio in decimal or -1 if tokenBucket is not set for this instance
+   */
+  private Double getReadQuotaUsageRatio() {
+    if (tokenBucket == null) {
+      return -1d;
+    } else {
+      return tokenBucket.getStaleUsageRatio();
+    }
   }
 }


### PR DESCRIPTION
## [server] Server read quota usage ratio metric improvement
1. Previously the quota ratio is only updated whenever the token bucket is refilled. This is problematic for stores that have a low KPS relative to their allocated quota since it won't be refilled very often. As a result we could see the old usage ratio for extended periods of time if the token bucket is not refilled frequently.

2. To improve this we will perform the calculation whenever the metric is read by using the requested token since last refill and elasped time since last refill to compute the average KPS and divide by refill KPS.

## How was this PR tested?
existing unit and integration tests

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.