### PR TITLE
[changelog] Make changelog consumer creation parallel in VeniceChangelogConsumerClientFactory

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerClientFactory.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerClientFactory.java
@@ -58,7 +58,7 @@ public class VeniceChangelogConsumerClientFactory {
   /**
    * Default method to create a {@link VeniceChangelogConsumer} given a storeName.
    */
-  public synchronized <K, V> VeniceChangelogConsumer<K, V> getChangelogConsumer(String storeName) {
+  public <K, V> VeniceChangelogConsumer<K, V> getChangelogConsumer(String storeName) {
     return getChangelogConsumer(storeName, null);
   }
 
@@ -66,10 +66,8 @@ public class VeniceChangelogConsumerClientFactory {
    * Creates a VeniceChangelogConsumer with consumer id. This is used to create multiple consumers so that
    * each consumer can only subscribe to certain partitions. Multiple such consumers can work in parallel.
    */
-  public synchronized <K, V> VeniceChangelogConsumer<K, V> getChangelogConsumer(String storeName, String consumerId) {
-
+  public <K, V> VeniceChangelogConsumer<K, V> getChangelogConsumer(String storeName, String consumerId) {
     return storeClientMap.computeIfAbsent(suffixConsumerIdToStore(storeName, consumerId), name -> {
-
       ChangelogClientConfig newStoreChangelogClientConfig = getNewStoreChangelogClientConfig(storeName);
       String viewClass = getViewClass(newStoreChangelogClientConfig, storeName);
       String consumerName = suffixConsumerIdToStore(storeName + "-" + viewClass.getClass().getSimpleName(), consumerId);
@@ -107,11 +105,8 @@ public class VeniceChangelogConsumerClientFactory {
         .computeIfAbsent(suffixConsumerIdToStore(storeName, consumerId), name -> {
           ChangelogClientConfig newStoreChangelogClientConfig = getNewStoreChangelogClientConfig(storeName);
           String viewClass = getViewClass(newStoreChangelogClientConfig, storeName);
-          String consumerName = storeName + "-" + viewClass.getClass().getSimpleName();
-          if (StringUtils.isNotEmpty(consumerId)) {
-            consumerName += "-" + consumerId;
-          }
-
+          String consumerName =
+              suffixConsumerIdToStore(storeName + "-" + viewClass.getClass().getSimpleName(), consumerId);
           return new LocalBootstrappingVeniceChangelogConsumer(
               newStoreChangelogClientConfig,
               consumer != null

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerClientFactory.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerClientFactory.java
@@ -7,15 +7,16 @@ import com.linkedin.venice.controllerapi.StoreResponse;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.kafka.protocol.KafkaMessageEnvelope;
 import com.linkedin.venice.meta.ViewConfig;
+import com.linkedin.venice.pubsub.PubSubConsumerAdapterFactory;
 import com.linkedin.venice.pubsub.adapter.kafka.consumer.ApacheKafkaConsumerAdapterFactory;
 import com.linkedin.venice.pubsub.api.PubSubConsumerAdapter;
 import com.linkedin.venice.pubsub.api.PubSubMessageDeserializer;
 import com.linkedin.venice.serialization.avro.OptimizedKafkaValueSerializer;
 import com.linkedin.venice.utils.VeniceProperties;
+import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
 import com.linkedin.venice.utils.pools.LandFillObjectPool;
 import com.linkedin.venice.views.ChangeCaptureView;
 import io.tehuti.metrics.MetricsRepository;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
@@ -23,9 +24,9 @@ import org.apache.commons.lang.StringUtils;
 
 
 public class VeniceChangelogConsumerClientFactory {
-  private static final ApacheKafkaConsumerAdapterFactory kafkaConsumerAdapterFactory =
+  private static final PubSubConsumerAdapterFactory kafkaConsumerAdapterFactory =
       new ApacheKafkaConsumerAdapterFactory();
-  private final Map<String, VeniceChangelogConsumer> storeClientMap = new HashMap<>();
+  private final Map<String, VeniceChangelogConsumer> storeClientMap = new VeniceConcurrentHashMap<>();
 
   private final MetricsRepository metricsRepository;
 
@@ -91,8 +92,7 @@ public class VeniceChangelogConsumerClientFactory {
     return StringUtils.isEmpty(consumerId) ? storeName : storeName + "-" + consumerId;
   }
 
-  public synchronized <K, V> BootstrappingVeniceChangelogConsumer<K, V> getBootstrappingChangelogConsumer(
-      String storeName) {
+  public <K, V> BootstrappingVeniceChangelogConsumer<K, V> getBootstrappingChangelogConsumer(String storeName) {
     return getBootstrappingChangelogConsumer(storeName, null);
   }
 


### PR DESCRIPTION
## [changelog] Make changelog consumer creation parallel in VeniceChangelogConsumerClientFactory
In user onboarding we noticed that multiple consumer will spent extra time on creation. During log investigation, we found that this factory method is the root cause. 
The synchronized keyword makes consumer creation sequential, including Apache consumer creation and StorageService restoration. Each of them could take 1-2s so in total it took ~11 in practice to complete. 
This change should make it truly parallel in creation and save ~10s during bootstrap.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
N/A
## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.