### PR TITLE
[server] Remove upstream offset calculation and offset record update in processTopicSwitch() for both leader and follower

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
@@ -1086,58 +1086,6 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
     PubSubTopic newSourceTopic = pubSubTopicRepository.getTopic(newSourceTopicName);
     Map<String, Long> upstreamStartOffsetByKafkaURL = new HashMap<>(topicSwitch.sourceKafkaServers.size());
 
-    /*
-    // Calculate the start offset based on start timestamp
-    if (!isDaVinciClient) {
-      final int newSourceTopicPartition = partitionConsumptionState.getSourceTopicPartitionNumber(newSourceTopic);
-      AtomicInteger numberOfContactedBrokers = new AtomicInteger(0);
-      topicSwitch.sourceKafkaServers.forEach(sourceKafkaURL -> {
-        long rewindStartTimestamp;
-        // calculate the rewind start time here if controller asked to do so by using this sentinel value.
-        if (topicSwitch.rewindStartTimestamp == REWIND_TIME_DECIDED_BY_SERVER) {
-          rewindStartTimestamp = calculateRewindStartTime(partitionConsumptionState);
-          LOGGER.info(
-              "{} leader calculated rewindStartTimestamp {} for topic {} partition {}",
-              ingestionTaskName,
-              rewindStartTimestamp,
-              newSourceTopicName,
-              newSourceTopicPartition);
-        } else {
-          rewindStartTimestamp = topicSwitch.rewindStartTimestamp;
-        }
-        if (rewindStartTimestamp > 0) {
-          long upstreamStartOffset = OffsetRecord.LOWEST_OFFSET;
-          try {
-            PubSubTopicPartition newSourceTP = new PubSubTopicPartitionImpl(newSourceTopic, newSourceTopicPartition);
-            upstreamStartOffset =
-                getTopicManager(sourceKafkaURL.toString()).getOffsetByTime(newSourceTP, rewindStartTimestamp);
-            numberOfContactedBrokers.getAndIncrement();
-          } catch (Exception e) {
-            // TODO: Catch more specific Exception?
-            LOGGER.error(
-                "Failed to reach broker {} when trying to get partitionOffsetByTime for topic {} partitions {}",
-                sourceKafkaURL.toString(),
-                newSourceTopicName,
-                newSourceTopicPartition);
-          }
-          if (upstreamStartOffset != OffsetRecord.LOWEST_OFFSET) {
-            upstreamStartOffset -= 1;
-          }
-          upstreamStartOffsetByKafkaURL.put(sourceKafkaURL.toString(), upstreamStartOffset);
-        } else {
-          upstreamStartOffsetByKafkaURL.put(sourceKafkaURL.toString(), OffsetRecord.LOWEST_OFFSET);
-        }
-      });
-    
-      if (numberOfContactedBrokers.get() == 0) {
-        throw new VeniceException("Failed to query any broker for rewind!  Aborting topic switch processing!");
-      }
-    
-      upstreamStartOffsetByKafkaURL.forEach((sourceKafkaURL, upstreamStartOffset) -> {
-        partitionConsumptionState.getOffsetRecord().setLeaderUpstreamOffset(sourceKafkaURL, upstreamStartOffset);
-      });
-    }
-     */
     /**
      * TopicSwitch needs to be persisted locally for both servers and DaVinci clients so that ready-to-serve check
      * can make the correct decision.

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
@@ -1084,13 +1084,12 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
     statusReportAdapter.reportTopicSwitchReceived(partitionConsumptionState);
     final String newSourceTopicName = topicSwitch.sourceTopicName.toString();
     PubSubTopic newSourceTopic = pubSubTopicRepository.getTopic(newSourceTopicName);
-    Map<String, Long> upstreamStartOffsetByKafkaURL = new HashMap<>(topicSwitch.sourceKafkaServers.size());
 
     /**
      * TopicSwitch needs to be persisted locally for both servers and DaVinci clients so that ready-to-serve check
      * can make the correct decision.
      */
-    syncTopicSwitchToIngestionMetadataService(topicSwitch, partitionConsumptionState, upstreamStartOffsetByKafkaURL);
+    syncTopicSwitchToIngestionMetadataService(topicSwitch, partitionConsumptionState);
     if (!isLeader(partitionConsumptionState)) {
       partitionConsumptionState.getOffsetRecord().setLeaderTopic(newSourceTopic);
       return true;

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -1174,6 +1174,7 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
     String newSourceTopicName = topicSwitch.sourceTopicName.toString();
     PubSubTopic newSourceTopic = pubSubTopicRepository.getTopic(newSourceTopicName);
     long upstreamStartOffset = OffsetRecord.LOWEST_OFFSET;
+    /*
     // Since DaVinci clients might not have network ACLs to remote RT, they will skip upstream start offset calculation.
     if (!isDaVinciClient && topicSwitch.rewindStartTimestamp > 0) {
       int newSourceTopicPartitionId = partitionConsumptionState.getSourceTopicPartitionNumber(newSourceTopic);
@@ -1185,6 +1186,7 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
         upstreamStartOffset -= 1;
       }
     }
+     */
 
     syncTopicSwitchToIngestionMetadataService(
         topicSwitch,
@@ -1201,15 +1203,15 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
        * don't update the consumption state like leader topic until actually switching topic. The leaderTopic field
        * should be used to track the topic that leader is actually consuming.
        */
-      partitionConsumptionState.getOffsetRecord()
-          .setLeaderUpstreamOffset(OffsetRecord.NON_AA_REPLICATION_UPSTREAM_OFFSET_MAP_KEY, upstreamStartOffset);
+      // partitionConsumptionState.getOffsetRecord().setLeaderUpstreamOffset(OffsetRecord.NON_AA_REPLICATION_UPSTREAM_OFFSET_MAP_KEY,
+      // upstreamStartOffset);
     } else {
       /**
        * For follower, just keep track of what leader is doing now.
        */
       partitionConsumptionState.getOffsetRecord().setLeaderTopic(newSourceTopic);
-      partitionConsumptionState.getOffsetRecord()
-          .setLeaderUpstreamOffset(OffsetRecord.NON_AA_REPLICATION_UPSTREAM_OFFSET_MAP_KEY, upstreamStartOffset);
+      // partitionConsumptionState.getOffsetRecord().setLeaderUpstreamOffset(OffsetRecord.NON_AA_REPLICATION_UPSTREAM_OFFSET_MAP_KEY,
+      // upstreamStartOffset);
       /**
        * We need to measure offset lag after processing TopicSwitch for follower; if real-time topic is empty and never
        * gets any new message, follower replica will never become online.

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
@@ -3512,8 +3512,8 @@ public abstract class StoreIngestionTaskTest {
     doReturn(PARTITION_FOO).when(mockPcs).getPartition();
     storeIngestionTaskUnderTest.getStatusReportAdapter().initializePartitionReportStatus(PARTITION_FOO);
     storeIngestionTaskUnderTest.processTopicSwitch(controlMessage, PARTITION_FOO, 10, mockPcs);
-
-    verify(mockTopicManagerRemoteKafka, nodeType == DA_VINCI ? never() : times(1)).getOffsetByTime(any(), anyLong());
+    verify(mockTopicManagerRemoteKafka, never()).getOffsetByTime(any(), anyLong());
+    verify(mockOffsetRecord, never()).setLeaderUpstreamOffset(anyString(), anyLong());
   }
 
   @Test(dataProvider = "aaConfigProvider")


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## [server] Remove upstream offset calculation and offset record update in processTopicSwitch() for both leader and follower
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
The original issue is, when re-bootstrapping a current/backup version partition, when hitting proessTopicSwitch, it will calculate rewind and get the offset by rewind. It will persist the offset to the OffsetRecord. However, due to RT message retention, old messages got removed, and the newly calculated offset is pointing to newer message's offset. When it is processing the message in VT (which was consumed by leader from RT), the old message's offset < persisted offset, and SIT will throw exception, thinking multiple leader is consuming.

After checking the code, I think we do such logic in current code:
**Leader**

1.  processTopicSwitch(drainer): Calculate offset, persist.
2.  leaderExecuteTopicSwitch(consumer long running task thread): Calculate offset, persist, subscribe

**Follower**

1.  processTopicSwitch(drainer): Calculate offset, persist, set leader topic.

I think for both leader and follower, processTopicSwitch does not need to perform extra calculation, as follower should trust what leader produce into VT. For leader, that's also redundant calculation.

This PR removes two rewind calculation from both LFSIT and AASIT in API processTopicSwitch().


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
Tweak unit test to make sure no such persist API call in both L & F.

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.