### PR TITLE
[Controller] Implement dual read for Push Status System Store

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/heartbeat/HeartbeatMonitoringService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/heartbeat/HeartbeatMonitoringService.java
@@ -221,6 +221,7 @@ public class HeartbeatMonitoringService extends AbstractVeniceService {
   }
 
   protected void record() {
+
     recordLags(
         leaderHeartbeatTimeStamps,
         ((storeName, version, region, heartbeatTs) -> versionStatsReporter

--- a/internal/venice-common/src/main/java/com/linkedin/venice/common/PushStatusStoreUtils.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/common/PushStatusStoreUtils.java
@@ -30,16 +30,10 @@ public class PushStatusStoreUtils {
     return getFullPushKey(version);
   }
 
-  /**
-   * @deprecated Use {@link #getPushKey(int)} instead. Inc push status report from DaVinci will be removed.
-   */
   public static PushStatusKey getPushKey(int version, int partitionId, Optional<String> incrementalPushVersion) {
     return getPushKey(version, partitionId, incrementalPushVersion, Optional.empty());
   }
 
-  /**
-   * @deprecated
-   */
   public static PushStatusKey getPushKey(
       int version,
       int partitionId,
@@ -65,9 +59,6 @@ public class PushStatusStoreUtils {
     return pushStatusKey;
   }
 
-  /**
-   * @deprecated
-   */
   private static PushStatusKey getFullPushKey(int version, int partitionId) {
     PushStatusKey pushStatusKey = new PushStatusKey();
     pushStatusKey.keyStrings = Arrays.asList(version, partitionId);
@@ -75,9 +66,6 @@ public class PushStatusStoreUtils {
     return pushStatusKey;
   }
 
-  /**
-   * @deprecated
-   */
   private static PushStatusKey getIncrementalPushKey(int version, int partitionId, String incrementalPushVersion) {
     PushStatusKey pushStatusKey = new PushStatusKey();
     pushStatusKey.keyStrings = Arrays.asList(version, partitionId, incrementalPushVersion);
@@ -85,9 +73,6 @@ public class PushStatusStoreUtils {
     return pushStatusKey;
   }
 
-  /**
-   * @deprecated
-   */
   public static PushStatusKey getServerIncrementalPushKey(
       int version,
       int partitionId,
@@ -101,9 +86,6 @@ public class PushStatusStoreUtils {
     return pushStatusKey;
   }
 
-  /**
-   * @deprecated
-   */
   public static PushStatusKey getOngoingIncrementalPushStatusesKey(int version) {
     PushStatusKey pushStatusKey = new PushStatusKey();
     pushStatusKey.keyStrings = Arrays.asList(version, ONGOING_INCREMENTAL_PUSH_STATUSES_KEY);
@@ -111,9 +93,6 @@ public class PushStatusStoreUtils {
     return pushStatusKey;
   }
 
-  /**
-   * @deprecated
-   */
   public static int getPartitionIdFromServerIncrementalPushKey(PushStatusKey key) {
     return (int) key.keyStrings.get(1);
   }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/common/PushStatusStoreUtils.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/common/PushStatusStoreUtils.java
@@ -2,6 +2,7 @@ package com.linkedin.venice.common;
 
 import com.linkedin.venice.pushstatus.PushStatusKey;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Optional;
 
 
@@ -25,10 +26,20 @@ public class PushStatusStoreUtils {
     return pushStatusKey;
   }
 
+  public static PushStatusKey getPushKey(int version) {
+    return getFullPushKey(version);
+  }
+
+  /**
+   * @deprecated Use {@link #getPushKey(int)} instead. Inc push status report from DaVinci will be removed.
+   */
   public static PushStatusKey getPushKey(int version, int partitionId, Optional<String> incrementalPushVersion) {
     return getPushKey(version, partitionId, incrementalPushVersion, Optional.empty());
   }
 
+  /**
+   * @deprecated
+   */
   public static PushStatusKey getPushKey(
       int version,
       int partitionId,
@@ -47,6 +58,16 @@ public class PushStatusStoreUtils {
     return getFullPushKey(version, partitionId);
   }
 
+  public static PushStatusKey getFullPushKey(int version) {
+    PushStatusKey pushStatusKey = new PushStatusKey();
+    pushStatusKey.keyStrings = Collections.singletonList(version);
+    pushStatusKey.messageType = PushStatusKeyType.FULL_PUSH.ordinal();
+    return pushStatusKey;
+  }
+
+  /**
+   * @deprecated
+   */
   public static PushStatusKey getFullPushKey(int version, int partitionId) {
     PushStatusKey pushStatusKey = new PushStatusKey();
     pushStatusKey.keyStrings = Arrays.asList(version, partitionId);
@@ -54,6 +75,9 @@ public class PushStatusStoreUtils {
     return pushStatusKey;
   }
 
+  /**
+   * @deprecated
+   */
   public static PushStatusKey getIncrementalPushKey(int version, int partitionId, String incrementalPushVersion) {
     PushStatusKey pushStatusKey = new PushStatusKey();
     pushStatusKey.keyStrings = Arrays.asList(version, partitionId, incrementalPushVersion);
@@ -61,6 +85,9 @@ public class PushStatusStoreUtils {
     return pushStatusKey;
   }
 
+  /**
+   * @deprecated
+   */
   public static PushStatusKey getServerIncrementalPushKey(
       int version,
       int partitionId,
@@ -74,6 +101,9 @@ public class PushStatusStoreUtils {
     return pushStatusKey;
   }
 
+  /**
+   * @deprecated
+   */
   public static PushStatusKey getOngoingIncrementalPushStatusesKey(int version) {
     PushStatusKey pushStatusKey = new PushStatusKey();
     pushStatusKey.keyStrings = Arrays.asList(version, ONGOING_INCREMENTAL_PUSH_STATUSES_KEY);
@@ -81,6 +111,9 @@ public class PushStatusStoreUtils {
     return pushStatusKey;
   }
 
+  /**
+   * @deprecated
+   */
   public static int getPartitionIdFromServerIncrementalPushKey(PushStatusKey key) {
     return (int) key.keyStrings.get(1);
   }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/common/PushStatusStoreUtils.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/common/PushStatusStoreUtils.java
@@ -58,7 +58,7 @@ public class PushStatusStoreUtils {
     return getFullPushKey(version, partitionId);
   }
 
-  public static PushStatusKey getFullPushKey(int version) {
+  private static PushStatusKey getFullPushKey(int version) {
     PushStatusKey pushStatusKey = new PushStatusKey();
     pushStatusKey.keyStrings = Collections.singletonList(version);
     pushStatusKey.messageType = PushStatusKeyType.FULL_PUSH.ordinal();
@@ -68,7 +68,7 @@ public class PushStatusStoreUtils {
   /**
    * @deprecated
    */
-  public static PushStatusKey getFullPushKey(int version, int partitionId) {
+  private static PushStatusKey getFullPushKey(int version, int partitionId) {
     PushStatusKey pushStatusKey = new PushStatusKey();
     pushStatusKey.keyStrings = Arrays.asList(version, partitionId);
     pushStatusKey.messageType = PushStatusKeyType.FULL_PUSH.ordinal();
@@ -78,7 +78,7 @@ public class PushStatusStoreUtils {
   /**
    * @deprecated
    */
-  public static PushStatusKey getIncrementalPushKey(int version, int partitionId, String incrementalPushVersion) {
+  private static PushStatusKey getIncrementalPushKey(int version, int partitionId, String incrementalPushVersion) {
     PushStatusKey pushStatusKey = new PushStatusKey();
     pushStatusKey.keyStrings = Arrays.asList(version, partitionId, incrementalPushVersion);
     pushStatusKey.messageType = PushStatusKeyType.INCREMENTAL_PUSH.ordinal();

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pushstatushelper/PushStatusStoreReader.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pushstatushelper/PushStatusStoreReader.java
@@ -23,6 +23,7 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.apache.logging.log4j.LogManager;
@@ -57,7 +58,7 @@ public class PushStatusStoreReader implements Closeable {
     AvroSpecificStoreClient<PushStatusKey, PushStatusValue> client = getVeniceClient(storeName);
     PushStatusKey pushStatusKey = PushStatusStoreUtils.getPushKey(version);
     try {
-      PushStatusValue pushStatusValue = client.get(pushStatusKey).get();
+      PushStatusValue pushStatusValue = client.get(pushStatusKey).get(60, TimeUnit.SECONDS);
       if (pushStatusValue == null) {
         // Don't return empty map yet, because caller cannot differentiate between DaVinci not migrated to new mode and
         // DaVinci writing empty map.
@@ -89,7 +90,7 @@ public class PushStatusStoreReader implements Closeable {
     PushStatusKey pushStatusKey =
         PushStatusStoreUtils.getPushKey(version, partitionId, incrementalPushVersion, incrementalPushPrefix);
     try {
-      PushStatusValue pushStatusValue = client.get(pushStatusKey).get();
+      PushStatusValue pushStatusValue = client.get(pushStatusKey).get(60, TimeUnit.SECONDS);
       if (pushStatusValue == null) {
         return Collections.emptyMap();
       } else {
@@ -175,14 +176,14 @@ public class PushStatusStoreReader implements Closeable {
         completableFutures.add(completableFuture);
       }
       for (CompletableFuture<Map<PushStatusKey, PushStatusValue>> completableFuture: completableFutures) {
-        Map<PushStatusKey, PushStatusValue> statuses = completableFuture.get();
+        Map<PushStatusKey, PushStatusValue> statuses = completableFuture.get(60, TimeUnit.SECONDS);
         if (statuses == null) {
           LOGGER.warn("Failed to get incremental push status of some partitions. BatchGet returned null.");
           throw new VeniceException("Failed to get incremental push status of some partitions");
         }
         pushStatusMap.putAll(statuses);
       }
-    } catch (InterruptedException | ExecutionException | VeniceClientException e) {
+    } catch (InterruptedException | ExecutionException | VeniceClientException | TimeoutException e) {
       LOGGER.error(
           "Failed to get statuses of partitions. store:{}, storeVersion:{} incrementalPushVersion:{} "
               + "partitionIds:{} Exception:{}",
@@ -235,8 +236,8 @@ public class PushStatusStoreReader implements Closeable {
     PushStatusKey pushStatusKey = PushStatusStoreUtils.getOngoingIncrementalPushStatusesKey(storeVersion);
     PushStatusValue pushStatusValue;
     try {
-      pushStatusValue = storeClient.get(pushStatusKey).get();
-    } catch (InterruptedException | ExecutionException | VeniceException e) {
+      pushStatusValue = storeClient.get(pushStatusKey).get(60, TimeUnit.SECONDS);
+    } catch (InterruptedException | ExecutionException | VeniceException | TimeoutException e) {
       LOGGER.error("Failed to get ongoing incremental pushes for store:{}.", storeName, e);
       throw new VeniceException(e);
     }

--- a/internal/venice-common/src/test/java/com/linkedin/venice/pushstatushelper/PushStatusStoreReaderTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/pushstatushelper/PushStatusStoreReaderTest.java
@@ -3,6 +3,7 @@ package com.linkedin.venice.pushstatushelper;
 import static com.linkedin.venice.common.PushStatusStoreUtils.SERVER_INCREMENTAL_PUSH_PREFIX;
 import static com.linkedin.venice.common.PushStatusStoreUtils.getServerIncrementalPushKey;
 import static com.linkedin.venice.pushmonitor.ExecutionStatus.END_OF_INCREMENTAL_PUSH_RECEIVED;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anySet;
 import static org.mockito.Mockito.doReturn;
@@ -31,6 +32,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -76,7 +79,7 @@ public class PushStatusStoreReaderTest {
 
   @Test(description = "Expect empty results when push status info is not available for any of the partition")
   public void testGetPartitionStatusesWhenPushStatusesAreNotAvailable()
-      throws ExecutionException, InterruptedException {
+      throws ExecutionException, InterruptedException, TimeoutException {
     Map<PushStatusKey, PushStatusValue> pushStatusMap =
         getPushStatusInstanceData(storeVersion, incPushVersion, partitionCount, replicationFactor);
 
@@ -87,7 +90,7 @@ public class PushStatusStoreReaderTest {
     doReturn(storeClientMock).when(storeReaderSpy).getVeniceClient(any());
     when(storeClientMock.batchGet(pushStatusMap.keySet())).thenReturn(completableFutureMock);
     // simulate store client returns null for given keys
-    when(completableFutureMock.get()).thenReturn(Collections.emptyMap());
+    when(completableFutureMock.get(anyLong(), any())).thenReturn(Collections.emptyMap());
 
     Map<Integer, Map<CharSequence, Integer>> result =
         storeReaderSpy.getPartitionStatuses(storeName, storeVersion, incPushVersion, partitionCount);
@@ -99,7 +102,7 @@ public class PushStatusStoreReaderTest {
 
   @Test(expectedExceptions = VeniceException.class, description = "Expect exception when result when push status read fails for some partitions")
   public void testGetPartitionStatusesWhenPushStatusReadFailsForSomePartitions()
-      throws ExecutionException, InterruptedException {
+      throws ExecutionException, InterruptedException, TimeoutException {
     Map<PushStatusKey, PushStatusValue> pushStatusMap =
         getPushStatusInstanceData(storeVersion, incPushVersion, partitionCount, replicationFactor);
 
@@ -110,7 +113,7 @@ public class PushStatusStoreReaderTest {
     doReturn(storeClientMock).when(storeReaderSpy).getVeniceClient(any());
     when(storeClientMock.batchGet(pushStatusMap.keySet())).thenReturn(completableFutureMock);
     // simulate store client returns null for given keys
-    when(completableFutureMock.get()).thenReturn(null);
+    when(completableFutureMock.get(anyLong(), any())).thenReturn(null);
 
     Map<Integer, Map<CharSequence, Integer>> result =
         storeReaderSpy.getPartitionStatuses(storeName, storeVersion, incPushVersion, partitionCount);
@@ -118,7 +121,8 @@ public class PushStatusStoreReaderTest {
   }
 
   @Test(expectedExceptions = VeniceException.class, description = "Expect an exception when push status store client throws an exception")
-  public void testGetPartitionStatusesWhenStoreClientThrowsException() throws ExecutionException, InterruptedException {
+  public void testGetPartitionStatusesWhenStoreClientThrowsException()
+      throws ExecutionException, InterruptedException, TimeoutException {
     Map<PushStatusKey, PushStatusValue> pushStatusMap =
         getPushStatusInstanceData(storeVersion, incPushVersion, partitionCount, replicationFactor);
 
@@ -129,14 +133,15 @@ public class PushStatusStoreReaderTest {
     doReturn(storeClientMock).when(storeReaderSpy).getVeniceClient(any());
     when(storeClientMock.batchGet(pushStatusMap.keySet())).thenReturn(completableFutureMock);
     // simulate store client returns an exception when fetching status info for given keys
-    when(completableFutureMock.get()).thenThrow(new ExecutionException(new Throwable("Mock execution exception")));
+    when(completableFutureMock.get(anyLong(), any()))
+        .thenThrow(new ExecutionException(new Throwable("Mock execution exception")));
 
     storeReaderSpy.getPartitionStatuses(storeName, storeVersion, incPushVersion, partitionCount);
   }
 
   @Test(description = "Expect statuses of all replicas when store returns all replica statuses")
   public void testGetPartitionStatusesWhenStoreReturnStatusesOfAllReplicas()
-      throws ExecutionException, InterruptedException {
+      throws ExecutionException, InterruptedException, TimeoutException {
     Map<PushStatusKey, PushStatusValue> pushStatusMap =
         getPushStatusInstanceData(storeVersion, incPushVersion, partitionCount, replicationFactor);
 
@@ -146,7 +151,7 @@ public class PushStatusStoreReaderTest {
 
     doReturn(storeClientMock).when(storeReaderSpy).getVeniceClient(any());
     when(storeClientMock.batchGet(pushStatusMap.keySet())).thenReturn(completableFutureMock);
-    when(completableFutureMock.get()).thenReturn(pushStatusMap);
+    when(completableFutureMock.get(anyLong(), any())).thenReturn(pushStatusMap);
 
     Map<Integer, Map<CharSequence, Integer>> result =
         storeReaderSpy.getPartitionStatuses(storeName, storeVersion, incPushVersion, partitionCount);
@@ -159,7 +164,8 @@ public class PushStatusStoreReaderTest {
   }
 
   @Test(description = "Expect empty status when statuses for replicas of a partition is missing")
-  public void testGetPartitionStatusesWhenStatusOfPartitionIsMissing() throws ExecutionException, InterruptedException {
+  public void testGetPartitionStatusesWhenStatusOfPartitionIsMissing()
+      throws ExecutionException, InterruptedException, TimeoutException {
     Map<PushStatusKey, PushStatusValue> pushStatusMap =
         getPushStatusInstanceData(storeVersion, incPushVersion, partitionCount, replicationFactor);
     // erase status of partitionId 0
@@ -174,7 +180,7 @@ public class PushStatusStoreReaderTest {
 
     doReturn(storeClientMock).when(storeReaderSpy).getVeniceClient(any());
     when(storeClientMock.batchGet(pushStatusMap.keySet())).thenReturn(completableFutureMock);
-    when(completableFutureMock.get()).thenReturn(pushStatusMap);
+    when(completableFutureMock.get(anyLong(), any())).thenReturn(pushStatusMap);
 
     Map<Integer, Map<CharSequence, Integer>> result =
         storeReaderSpy.getPartitionStatuses(storeName, storeVersion, incPushVersion, partitionCount);
@@ -190,7 +196,7 @@ public class PushStatusStoreReaderTest {
 
   @Test(description = "Expect empty status when instance info for replicas of a partition is missing")
   public void testGetPartitionStatusesWhenInstanceInfoOfPartitionIsMissing()
-      throws ExecutionException, InterruptedException {
+      throws ExecutionException, InterruptedException, TimeoutException {
     Map<PushStatusKey, PushStatusValue> pushStatusMap =
         getPushStatusInstanceData(storeVersion, incPushVersion, partitionCount, replicationFactor);
     // set empty status for partitionId 0
@@ -205,7 +211,7 @@ public class PushStatusStoreReaderTest {
 
     doReturn(storeClientMock).when(storeReaderSpy).getVeniceClient(any());
     when(storeClientMock.batchGet(pushStatusMap.keySet())).thenReturn(completableFutureMock);
-    when(completableFutureMock.get()).thenReturn(pushStatusMap);
+    when(completableFutureMock.get(anyLong(), any())).thenReturn(pushStatusMap);
 
     Map<Integer, Map<CharSequence, Integer>> result =
         storeReaderSpy.getPartitionStatuses(storeName, storeVersion, incPushVersion, partitionCount);
@@ -222,7 +228,7 @@ public class PushStatusStoreReaderTest {
 
   @Test(description = "Expect all statuses even when number of partitions are greater than the batchGetLimit")
   public void testGetPartitionStatusesWhenNumberOfPartitionsAreGreaterThanBatchGetLimit()
-      throws ExecutionException, InterruptedException {
+      throws ExecutionException, InterruptedException, TimeoutException {
     int partitionCount = 1055;
     int batchGetLimit = 256;
 
@@ -246,7 +252,7 @@ public class PushStatusStoreReaderTest {
       keySets.add(statuses.keySet());
       CompletableFuture<Map<PushStatusKey, PushStatusValue>> completableFutureMock = mock(CompletableFuture.class);
       when(storeClientMock.batchGet(eq(statuses.keySet()))).thenReturn(completableFutureMock);
-      when(completableFutureMock.get()).thenReturn(statuses);
+      when(completableFutureMock.get(anyLong(), any())).thenReturn(statuses);
     }
 
     Map<Integer, Map<CharSequence, Integer>> result =
@@ -281,7 +287,7 @@ public class PushStatusStoreReaderTest {
 
   @Test(description = "Expect an empty result when key-value for ongoing incremental pushes doesn't exist")
   public void testGetSupposedlyOngoingIncrementalPushVersionsWhenIncPushVersionsDoesNotExist()
-      throws ExecutionException, InterruptedException {
+      throws ExecutionException, InterruptedException, TimeoutException {
     PushStatusKey pushStatusKey = PushStatusStoreUtils.getOngoingIncrementalPushStatusesKey(storeVersion);
     PushStatusStoreReader storeReaderSpy =
         spy(new PushStatusStoreReader(d2ClientMock, CLUSTER_DISCOVERY_D2_SERVICE_NAME, 10));
@@ -289,18 +295,18 @@ public class PushStatusStoreReaderTest {
 
     doReturn(storeClientMock).when(storeReaderSpy).getVeniceClient(any());
     when(storeClientMock.get(pushStatusKey)).thenReturn(completableFutureMock);
-    when(completableFutureMock.get()).thenReturn(null);
+    when(completableFutureMock.get(anyLong(), any())).thenReturn(null);
 
     assertEqualsDeep(
         storeReaderSpy.getSupposedlyOngoingIncrementalPushVersions(storeName, storeVersion),
         Collections.emptyMap());
-    verify(completableFutureMock).get();
+    verify(completableFutureMock).get(60, TimeUnit.SECONDS);
     verify(storeClientMock).get(pushStatusKey);
   }
 
   @Test(description = "Expect an empty result when inc push versions are missing in the returned result")
   public void testGetSupposedlyOngoingIncrementalPushVersionsWhenIncPushVersionsAreMissing()
-      throws ExecutionException, InterruptedException {
+      throws ExecutionException, InterruptedException, TimeoutException {
     PushStatusKey pushStatusKey = PushStatusStoreUtils.getOngoingIncrementalPushStatusesKey(storeVersion);
     PushStatusValue pushStatusValue = new PushStatusValue();
     pushStatusValue.instances = null; // to make intentions clear explicitly setting it to null
@@ -310,18 +316,18 @@ public class PushStatusStoreReaderTest {
 
     doReturn(storeClientMock).when(storeReaderSpy).getVeniceClient(any());
     when(storeClientMock.get(pushStatusKey)).thenReturn(completableFutureMock);
-    when(completableFutureMock.get()).thenReturn(pushStatusValue);
+    when(completableFutureMock.get(anyLong(), any())).thenReturn(pushStatusValue);
 
     assertEqualsDeep(
         storeReaderSpy.getSupposedlyOngoingIncrementalPushVersions(storeName, storeVersion),
         Collections.emptyMap());
-    verify(completableFutureMock).get();
+    verify(completableFutureMock).get(60, TimeUnit.SECONDS);
     verify(storeClientMock).get(pushStatusKey);
   }
 
   @Test(description = "Expect all inc push versions when inc push versions are found in push status store")
   public void testGetSupposedlyOngoingIncrementalPushVersionsWhenIncPushVersionsAreAvailable()
-      throws ExecutionException, InterruptedException {
+      throws ExecutionException, InterruptedException, TimeoutException {
     PushStatusKey pushStatusKey = PushStatusStoreUtils.getOngoingIncrementalPushStatusesKey(storeVersion);
     PushStatusValue pushStatusValue = new PushStatusValue();
     pushStatusValue.instances = new HashMap<>();
@@ -334,17 +340,18 @@ public class PushStatusStoreReaderTest {
 
     doReturn(storeClientMock).when(storeReaderSpy).getVeniceClient(any());
     when(storeClientMock.get(pushStatusKey)).thenReturn(completableFutureMock);
-    when(completableFutureMock.get()).thenReturn(pushStatusValue);
+    when(completableFutureMock.get(anyLong(), any())).thenReturn(pushStatusValue);
 
     assertEqualsDeep(
         storeReaderSpy.getSupposedlyOngoingIncrementalPushVersions(storeName, storeVersion),
         pushStatusValue.instances);
-    verify(completableFutureMock).get();
+    verify(completableFutureMock).get(60, TimeUnit.SECONDS);
     verify(storeClientMock).get(pushStatusKey);
   }
 
   @Test
-  public void testNullResponseWhenVersionLevelKeyIsNotWritten() throws ExecutionException, InterruptedException {
+  public void testNullResponseWhenVersionLevelKeyIsNotWritten()
+      throws ExecutionException, InterruptedException, TimeoutException {
     PushStatusKey pushStatusKey = PushStatusStoreUtils.getPushKey(storeVersion);
     PushStatusStoreReader storeReaderSpy =
         spy(new PushStatusStoreReader(d2ClientMock, CLUSTER_DISCOVERY_D2_SERVICE_NAME, 10));
@@ -353,7 +360,7 @@ public class PushStatusStoreReaderTest {
     CompletableFuture<PushStatusValue> completableFutureMock = mock(CompletableFuture.class);
     when(storeClientMock.get(pushStatusKey)).thenReturn(completableFutureMock);
     // simulate store client returns null for given keys
-    when(completableFutureMock.get()).thenReturn(null);
+    when(completableFutureMock.get(anyLong(), any())).thenReturn(null);
 
     // Test that push status store reader will also return null instead of empty map in this case
     Assert.assertNull(storeReaderSpy.getVersionStatus(storeName, storeVersion));

--- a/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/PushMonitorUtils.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/PushMonitorUtils.java
@@ -78,7 +78,6 @@ public class PushMonitorUtils {
         boolean isInstanceAlive = reader.isInstanceAlive(storeName, entry.getKey().toString());
         if (!isInstanceAlive) {
           offlineInstanceCount++;
-          allInstancesCompleted = false;
           // Keep at most 5 offline instances for logging purpose.
           if (offlineInstanceList.size() < 5) {
             offlineInstanceList.add(entry.getKey().toString());
@@ -219,8 +218,6 @@ public class PushMonitorUtils {
         }
         boolean isInstanceAlive = reader.isInstanceAlive(storeName, entry.getKey().toString());
         if (!isInstanceAlive) {
-          allInstancesCompleted = false;
-          allMiddleStatusReceived = false;
           // Keep at most 5 offline instances for logging purpose.
           if (offlineInstanceList.size() < 5) {
             offlineInstanceList.add(entry.getKey().toString());

--- a/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/PushMonitorUtils.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/PushMonitorUtils.java
@@ -24,9 +24,15 @@ public class PushMonitorUtils {
 
   /**
    * This method checks Da Vinci client push status for the target version from push status store and compute a final
-   * status. It will try to get an aggregated status from version level status key first; if not found, it will fall
-   * back to partition level status key.
-   * A Da Vinci instance sent heartbeat to controllers recently is considered active.
+   * status.
+   *
+   * It will try to get an aggregated status from version level status key first; if there is value, it will still try
+   * to query the partition level keys, and combine the result with the old keys, in case DaVinci instances are
+   * partially upgraded and some of them are still populating statuses with old keys.
+   * If no value is found for the new key, it will fall back to partition level status key.
+   *
+   * A Da Vinci instance sent heartbeat to controllers recently is considered active. Only consider the push status
+   * from active Da Vinci instances unless there are too many offline instances which triggers the fail fast mechanism.
    */
   public static ExecutionStatusWithDetails getDaVinciPushStatusAndDetails(
       PushStatusStoreReader reader,

--- a/services/venice-controller/src/test/java/com/linkedin/venice/pushmonitor/PushMonitorUtilsTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/pushmonitor/PushMonitorUtilsTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.mock;
 
 import com.linkedin.venice.pushstatushelper.PushStatusStoreReader;
 import com.linkedin.venice.utils.Utils;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -16,6 +17,40 @@ import org.testng.annotations.Test;
 
 
 public class PushMonitorUtilsTest {
+  @Test
+  public void testCompleteStatusCanBeReportedWithOfflineInstancesBelowFailFastThreshold() {
+    PushMonitorUtils.setDaVinciErrorInstanceWaitTime(0);
+    PushStatusStoreReader reader = mock(PushStatusStoreReader.class);
+    /**
+      * Instance a is offline and its push status is not completed.
+      * Instance b,c,d are online and their push status is completed.
+      * In this case, the overall DaVinci push status can be COMPLETED as long as 1 is below the fail fast threshold.
+      */
+    doReturn(false).when(reader).isInstanceAlive(eq("store"), eq("a"));
+    doReturn(true).when(reader).isInstanceAlive(eq("store"), eq("b"));
+    doReturn(true).when(reader).isInstanceAlive(eq("store"), eq("c"));
+    doReturn(true).when(reader).isInstanceAlive(eq("store"), eq("d"));
+
+    Map<CharSequence, Integer> map = new HashMap<>();
+    map.put("a", 2);
+    map.put("b", 10);
+    map.put("c", 10);
+    map.put("d", 10);
+
+    // Test partition level key first
+    doReturn(null).when(reader).getVersionStatus("store", 1);
+    doReturn(map).when(reader).getPartitionStatus("store", 1, 0, Optional.empty());
+
+    // 1 offline instances is below the fail fast threshold, the overall DaVinci status can be COMPLETED.
+    validatePushStatus(reader, "store_v1", 2, 0.25, ExecutionStatus.COMPLETED);
+
+    // Test version level key
+    doReturn(map).when(reader).getVersionStatus("store", 1);
+    doReturn(Collections.emptyMap()).when(reader).getPartitionStatus("store", 1, 0, Optional.empty());
+    // 1 offline instances is below the fail fast threshold, the overall DaVinci status can be COMPLETED.
+    validatePushStatus(reader, "store_v1", 2, 0.25, ExecutionStatus.COMPLETED);
+  }
+
   @Test
   public void testDaVinciPushStatusScan() {
     PushMonitorUtils.setDaVinciErrorInstanceWaitTime(0);
@@ -42,9 +77,16 @@ public class PushMonitorUtilsTest {
      * Testing count-based threshold.
      */
     // Valid, because we have 4 replicas, 1 completed, 2 offline, 1 online, threshold number is max(2, 0.25*4) = 2.
-    validateOfflineReplicaInPushStatus(reader, "store_v1", 2, 0.25, ExecutionStatus.STARTED, null);
+    validateOfflineReplicaInPushStatusWhenBreachingFailFastThreshold(
+        reader,
+        "store_v1",
+        2,
+        0.25,
+        ExecutionStatus.STARTED,
+        null);
+
     // Expected to fail.
-    validateOfflineReplicaInPushStatus(
+    validateOfflineReplicaInPushStatusWhenBreachingFailFastThreshold(
         reader,
         "store_v1",
         1,
@@ -56,9 +98,15 @@ public class PushMonitorUtilsTest {
      * Testing ratio-based threshold.
      */
     // Valid, because we have 4 replicas, 1 completed, 2 offline, 1 online, threshold number is max(1, 0.5*4) = 2.
-    validateOfflineReplicaInPushStatus(reader, "store_v2", 1, 0.5, ExecutionStatus.STARTED, null);
+    validateOfflineReplicaInPushStatusWhenBreachingFailFastThreshold(
+        reader,
+        "store_v2",
+        1,
+        0.5,
+        ExecutionStatus.STARTED,
+        null);
     // Expected to fail.
-    validateOfflineReplicaInPushStatus(
+    validateOfflineReplicaInPushStatusWhenBreachingFailFastThreshold(
         reader,
         "store_v2",
         1,
@@ -67,7 +115,7 @@ public class PushMonitorUtilsTest {
         "Too many dead instances: 2, total instances: 4, example offline instances: " + offlineInstances);
   }
 
-  private void validateOfflineReplicaInPushStatus(
+  private void validateOfflineReplicaInPushStatusWhenBreachingFailFastThreshold(
       PushStatusStoreReader reader,
       String topicName,
       int maxOfflineInstanceCount,
@@ -99,5 +147,21 @@ public class PushMonitorUtilsTest {
     if (expectedStatus.equals(ExecutionStatus.ERROR)) {
       Assert.assertEquals(executionStatusWithDetails.getDetails(), expectedErrorDetails);
     }
+  }
+
+  private void validatePushStatus(
+      PushStatusStoreReader reader,
+      String topicName,
+      int maxOfflineInstanceCount,
+      double maxOfflineInstanceRatio,
+      ExecutionStatus expectedStatus) {
+    ExecutionStatusWithDetails executionStatusWithDetails = PushMonitorUtils.getDaVinciPushStatusAndDetails(
+        reader,
+        topicName,
+        1,
+        Optional.empty(),
+        maxOfflineInstanceCount,
+        maxOfflineInstanceRatio);
+    Assert.assertEquals(executionStatusWithDetails.getStatus(), expectedStatus);
   }
 }

--- a/services/venice-controller/src/test/java/com/linkedin/venice/pushmonitor/PushMonitorUtilsTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/pushmonitor/PushMonitorUtilsTest.java
@@ -17,43 +17,6 @@ import org.testng.annotations.Test;
 
 public class PushMonitorUtilsTest {
   @Test
-  public void testCompleteStatusCannotBeReportedWithOfflineInstances() {
-    PushMonitorUtils.setDaVinciErrorInstanceWaitTime(0);
-    PushStatusStoreReader reader = mock(PushStatusStoreReader.class);
-    /**
-     * Instance a is offline and its push status is not completed.
-     * Instance b,c,d are online and their push status is completed.
-     * In this case, the overall DaVinci push status shouldn't be reported as COMPLETED, because we want to
-     * wait for all instances to be completed.
-     */
-    doReturn(false).when(reader).isInstanceAlive(eq("store"), eq("a"));
-    doReturn(true).when(reader).isInstanceAlive(eq("store"), eq("b"));
-    doReturn(true).when(reader).isInstanceAlive(eq("store"), eq("c"));
-    doReturn(true).when(reader).isInstanceAlive(eq("store"), eq("d"));
-
-    Map<CharSequence, Integer> map = new HashMap<>();
-    map.put("a", 2);
-    map.put("b", 10);
-    map.put("c", 10);
-    map.put("d", 10);
-
-    // Test partition level key first
-    doReturn(null).when(reader).getVersionStatus("store", 1);
-    doReturn(map).when(reader).getPartitionStatus("store", 1, 0, Optional.empty());
-
-    // With any number of offline instances that haven't reported COMPLETED, the overall DaVinci status cannot be
-    // COMPLETED.
-    validateOfflineReplicaInPushStatus(reader, "store_v1", 2, 0.25, ExecutionStatus.STARTED, null);
-
-    // Test version level key
-    doReturn(map).when(reader).getVersionStatus("store", 1);
-    doReturn(null).when(reader).getPartitionStatus("store", 1, 0, Optional.empty());
-    // With any number of offline instances that haven't reported COMPLETED, the overall DaVinci status cannot be
-    // COMPLETED.
-    validateOfflineReplicaInPushStatus(reader, "store_v1", 2, 0.25, ExecutionStatus.STARTED, null);
-  }
-
-  @Test
   public void testDaVinciPushStatusScan() {
     PushMonitorUtils.setDaVinciErrorInstanceWaitTime(0);
     PushStatusStoreReader reader = mock(PushStatusStoreReader.class);


### PR DESCRIPTION
## Summary
With changes in this PR, controller will try to compose a version level
key and use it to read from push status system store when checking batch
push status on DaVinci side:
{
  keyStrings: {10} // Version 10
  messageType: 1 // 1: Full Push
}
Then controller will always try to query the partition level keys, and combine
the result with the old keys, in case DaVinci instances are partially upgraded
and some of them are still populating statuses with old keys.

If controller gets null response for the new key, it will assume that
DaVinci is not upgraded yet, and fall back to partition level keys:
{
  keyStrings: {10, 0} // Version 10, partition 0
  messageType: 1 // 1: Full Push
}

Roll out steps in order:
1. After the controller changes are rolled out to production and stabilize,
    deprecate all previous backend releases.
2. Release DaVinci changes to start producing a version level batch updates;
    stabilize the client release and deprecate all previous client releases.
3. Clean up tech debts in controller - remove all partition level keys related
    logic.

Other changes:
Previously the entire instance map would be logged whenever a
push status query returns, the log is removed in this PR, because the
map is too big and would flood the log with thousands of instance names.

## How was this PR tested?
New unit test to ensure null is returned when new keys are not populated.

## Does this PR introduce any user-facing changes?
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.