### PR TITLE
[server][dvc] Lag arithmetic fix

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -2431,13 +2431,19 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
       // A negative value means there was a problem in measuring the end offset, and therefore we return "infinite lag"
       return Long.MAX_VALUE;
     } else if (endOffset == 0) {
-      // The topic is empty and therefore, by definition, there cannot be any lag
+      /**
+       * Topics which were never produced to have an end offset of zero. Such topics are empty and therefore, by
+       * definition, there cannot be any lag.
+       *
+       * Note that the reverse is not true: a topic can be currently empty and have an end offset above zero, if it had
+       * messages produced to it before, which have since then disappeared (e.g. due to time-based retention).
+       */
       return 0;
     }
 
     /**
-     * An empty topic should have an end offset of zero. A topic with a single message in it will have an end offset of
-     * 1, while that single message will have offset 0. In such single message topic, a consumer which fully scans the
+     * A topic with an end offset of zero is empty. A topic with a single message in it will have an end offset of 1,
+     * while that single message will have offset 0. In such single message topic, a consumer which fully scans the
      * topic would have a current offset of 0, while the topic has an end offset of 1, and therefore we need to subtract
      * 1 from the end offset in order to arrive at the correct lag of 0.
      */

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -2416,11 +2416,18 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
       return Long.MAX_VALUE;
     }
     TopicManager tm = getTopicManager(pubSubServerName);
-    long endOffset = tm.getLatestOffsetCached(topic, partition) - 1;
+    long endOffset = tm.getLatestOffsetCached(topic, partition);
     if (endOffset < 0) {
       return Long.MAX_VALUE;
     }
-    return endOffset - currentOffset;
+
+    /**
+     * An empty topic should have an end offset of zero. A topic with a single message in it will have an end offset of
+     * 1, while that single message will have offset 0. In such single message topic, a consumer which fully scans the
+     * topic would have a current offset of 0, while the topic has an end offset of 1, and therefore we need to subtract
+     * 1 from the end offset in order to arrive at the correct lag of 0.
+     */
+    return endOffset - 1 - currentOffset;
   }
 
   /**

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
@@ -166,6 +166,7 @@ import com.linkedin.venice.serialization.avro.OptimizedKafkaValueSerializer;
 import com.linkedin.venice.serialization.avro.VeniceAvroKafkaSerializer;
 import com.linkedin.venice.serializer.FastSerializerDeserializerFactory;
 import com.linkedin.venice.serializer.RecordSerializer;
+import com.linkedin.venice.stats.StatsErrorCode;
 import com.linkedin.venice.throttle.EventThrottler;
 import com.linkedin.venice.unit.kafka.InMemoryKafkaBroker;
 import com.linkedin.venice.unit.kafka.SimplePartitioner;
@@ -4356,6 +4357,7 @@ public abstract class StoreIngestionTaskTest {
         10l);
   }
 
+  @Test
   public void testCheckAndHandleUpstreamOffsetRewind() {
     String storeName = "test_store";
     int version = 1;
@@ -4446,6 +4448,73 @@ public abstract class StoreIngestionTaskTest {
     assertTrue(
         exception.getMessage().contains("Failing the job because lossy rewind happens before reporting completed"));
     verify(mockStats2).recordPotentiallyLossyLeaderOffsetRewind(storeName, version);
+  }
+
+  @Test
+  public void testMeasureLagWithCallToPubSub() {
+    final int PARTITION_UNABLE_TO_GET_END_OFFSET = 0;
+    final int EMPTY_PARTITION = 1;
+    final int PARTITION_WITH_SOME_MESSAGES_IN_IT = 2;
+    final long MESSAGE_COUNT = 10;
+    final long INVALID_CURRENT_OFFSET = -2;
+    final long CURRENT_OFFSET_NOTHING_CONSUMED = OffsetRecord.LOWEST_OFFSET;
+    final long CURRENT_OFFSET_SOME_CONSUMED = 3;
+    final String PUB_SUB_SERVER_NAME = "blah";
+    doReturn((long) StatsErrorCode.LAG_MEASUREMENT_FAILURE.code).when(mockTopicManager)
+        .getLatestOffsetCached(pubSubTopic, PARTITION_UNABLE_TO_GET_END_OFFSET);
+    doReturn(0L).when(mockTopicManager).getLatestOffsetCached(pubSubTopic, EMPTY_PARTITION);
+    doReturn(MESSAGE_COUNT).when(mockTopicManager)
+        .getLatestOffsetCached(pubSubTopic, PARTITION_WITH_SOME_MESSAGES_IN_IT);
+
+    assertEquals(
+        StoreIngestionTask.measureLagWithCallToPubSub(
+            PUB_SUB_SERVER_NAME,
+            pubSubTopic,
+            PARTITION_UNABLE_TO_GET_END_OFFSET,
+            CURRENT_OFFSET_NOTHING_CONSUMED,
+            s -> mockTopicManager),
+        Long.MAX_VALUE,
+        "If unable to get the end offset, we expect Long.MAX_VALUE (infinite lag).");
+
+    assertEquals(
+        StoreIngestionTask.measureLagWithCallToPubSub(
+            PUB_SUB_SERVER_NAME,
+            pubSubTopic,
+            EMPTY_PARTITION,
+            INVALID_CURRENT_OFFSET,
+            s -> mockTopicManager),
+        Long.MAX_VALUE,
+        "If the current offset is invalid (less than -1), we expect Long.MAX_VALUE (infinite lag).");
+
+    assertEquals(
+        StoreIngestionTask.measureLagWithCallToPubSub(
+            PUB_SUB_SERVER_NAME,
+            pubSubTopic,
+            EMPTY_PARTITION,
+            CURRENT_OFFSET_NOTHING_CONSUMED,
+            s -> mockTopicManager),
+        0,
+        "If the partition is empty, we expect no lag.");
+
+    assertEquals(
+        StoreIngestionTask.measureLagWithCallToPubSub(
+            PUB_SUB_SERVER_NAME,
+            pubSubTopic,
+            PARTITION_WITH_SOME_MESSAGES_IN_IT,
+            CURRENT_OFFSET_NOTHING_CONSUMED,
+            s -> mockTopicManager),
+        MESSAGE_COUNT,
+        "If the partition has messages in it, but we consumed nothing, we expect lag to equal the message count.");
+
+    assertEquals(
+        StoreIngestionTask.measureLagWithCallToPubSub(
+            PUB_SUB_SERVER_NAME,
+            pubSubTopic,
+            PARTITION_WITH_SOME_MESSAGES_IN_IT,
+            CURRENT_OFFSET_SOME_CONSUMED,
+            s -> mockTopicManager),
+        MESSAGE_COUNT - 1 - CURRENT_OFFSET_SOME_CONSUMED,
+        "If the partition has messages in it, and we consumed some of them, we expect lag to equal the unconsumed message count.");
   }
 
   private VeniceStoreVersionConfig getDefaultMockVeniceStoreVersionConfig(


### PR DESCRIPTION
There is an edge case where an empty topic with an end offset of zero gets mistaken for an error code, and results in returning Long.MAX_VALUE as the lag instead.

## How was this PR tested?
It was not... tests should be added.

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.