### PR TITLE
[dvc][server]Make recordNearlineLocalBrokerToReadyToServeLatency ignore catchup messages after push

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/PartitionConsumptionState.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/PartitionConsumptionState.java
@@ -48,9 +48,11 @@ public class PartitionConsumptionState {
   private boolean deferredWrite;
   private boolean errorReported;
   private boolean lagCaughtUp;
-  // record the time when the lag is caught up to record nearline metrics
-  // for messages produced after this time to ignore the messages that are
-  // getting caught up after a push
+  /**
+   * Save the time when the lag is caught up to record nearline metrics
+   * for messages produced after this time to ignore the old messages that are
+   * getting caught up after a push.
+   */
   private long lagCaughtUpTimeInMs;
   private boolean completionReported;
   private boolean isSubscribed;

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/PartitionConsumptionState.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/PartitionConsumptionState.java
@@ -48,6 +48,10 @@ public class PartitionConsumptionState {
   private boolean deferredWrite;
   private boolean errorReported;
   private boolean lagCaughtUp;
+  // record the time when the lag is caught up to record nearline metrics
+  // for messages produced after this time to ignore the messages that are
+  // getting caught up after a push
+  private long lagCaughtUpTimeInMs;
   private boolean completionReported;
   private boolean isSubscribed;
   private boolean isDataRecoveryCompleted;
@@ -225,6 +229,7 @@ public class PartitionConsumptionState {
     this.offsetRecord = offsetRecord;
     this.errorReported = false;
     this.lagCaughtUp = false;
+    this.lagCaughtUpTimeInMs = 0;
     this.completionReported = false;
     this.isSubscribed = true;
     this.processedRecordSizeSinceLastSync = 0;
@@ -313,11 +318,23 @@ public class PartitionConsumptionState {
   }
 
   public void lagHasCaughtUp() {
-    this.lagCaughtUp = true;
+    if (!this.lagCaughtUp) {
+      this.lagCaughtUp = true;
+      this.lagCaughtUpTimeInMs = System.currentTimeMillis();
+    }
   }
 
   public boolean hasLagCaughtUp() {
     return lagCaughtUp;
+  }
+
+  /**
+   * check to ignore calculating latency from pubsub broker to ready to serve for
+   * messages that are getting caught up from previous pushes.
+   * @param producerTimeStampInMs timestamp of the message
+   */
+  public boolean isNearlineMetricsRecordingValid(long producerTimeStampInMs) {
+    return (lagCaughtUp && lagCaughtUpTimeInMs > 0 && producerTimeStampInMs > lagCaughtUpTimeInMs);
   }
 
   public boolean isCompletionReported() {


### PR DESCRIPTION
## Summary
While measuring nearline latency from local broker to ready to serve, the messages catching up after a push records longer latencies to these metrics. This changes records `lagCaughtUpTimeInMs` and considers the nearline messages that were ingested only after that time to ignore the already ingested messages. 

## How was this PR tested?
GH CI

## Does this PR introduce any user-facing changes?
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.