### PR TITLE
[vpj] Allow configuring explicit TTL age in VPJ

### DIFF
--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/PushJobSetting.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/PushJobSetting.java
@@ -21,6 +21,7 @@ public class PushJobSetting implements Serializable {
   private static final long serialVersionUID = 1;
 
   // Job-setting inferred from job props
+  public long jobStartTimeMs;
   public String jobId;
   public String jobExecutionId;
   public String jobServerName;
@@ -147,4 +148,9 @@ public class PushJobSetting implements Serializable {
   public transient Version sourceKafkaInputVersionInfo;
   public CompressionStrategy sourceVersionCompressionStrategy;
   public boolean sourceVersionChunkingEnabled;
+
+  public PushJobSetting() {
+    // Default for preserving backward compatibility
+    this.jobStartTimeMs = System.currentTimeMillis();
+  }
 }

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
@@ -2087,6 +2087,8 @@ public class VenicePushJob implements AutoCloseable {
           jobSetting.repushTTLStartTimeMs =
               pushJobSetting.jobStartTimeMs - (storeRewindTimeInSeconds * Time.MS_PER_SECOND);
         }
+
+        LOGGER.info("Will evict records older than epoch time: {} ms", jobSetting.repushTTLStartTimeMs);
       }
     }
 

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
@@ -58,6 +58,7 @@ import static com.linkedin.venice.hadoop.VenicePushJobConstants.POLL_STATUS_RETR
 import static com.linkedin.venice.hadoop.VenicePushJobConstants.POST_VALIDATION_CONSUMPTION_ENABLED;
 import static com.linkedin.venice.hadoop.VenicePushJobConstants.PUSH_JOB_STATUS_UPLOAD_ENABLE;
 import static com.linkedin.venice.hadoop.VenicePushJobConstants.REPUSH_TTL_ENABLE;
+import static com.linkedin.venice.hadoop.VenicePushJobConstants.REPUSH_TTL_SECONDS;
 import static com.linkedin.venice.hadoop.VenicePushJobConstants.REPUSH_TTL_START_TIMESTAMP;
 import static com.linkedin.venice.hadoop.VenicePushJobConstants.REWIND_EPOCH_TIME_BUFFER_IN_SECONDS_OVERRIDE;
 import static com.linkedin.venice.hadoop.VenicePushJobConstants.REWIND_EPOCH_TIME_IN_SECONDS_OVERRIDE;
@@ -144,6 +145,7 @@ import com.linkedin.venice.utils.AvroSupersetSchemaUtils;
 import com.linkedin.venice.utils.ByteUtils;
 import com.linkedin.venice.utils.DictionaryUtils;
 import com.linkedin.venice.utils.EncodingUtils;
+import com.linkedin.venice.utils.LatencyUtils;
 import com.linkedin.venice.utils.PartitionUtils;
 import com.linkedin.venice.utils.ReflectUtils;
 import com.linkedin.venice.utils.RegionUtils;
@@ -221,7 +223,6 @@ public class VenicePushJob implements AutoCloseable {
   // Total input data size, which is used to talk to controller to decide whether we have enough quota or not
   private InputDataInfoProvider.InputDataInfo inputDataInfo;
 
-  private long jobStartTimeMs;
   private Properties veniceWriterProperties;
   private JobClientWrapper jobClientWrapper;
   private SentPushJobDetailsTracker sentPushJobDetailsTracker;
@@ -328,6 +329,7 @@ public class VenicePushJob implements AutoCloseable {
 
   private PushJobSetting getPushJobSetting(VeniceProperties props) {
     PushJobSetting pushJobSettingToReturn = new PushJobSetting();
+    pushJobSettingToReturn.jobStartTimeMs = System.currentTimeMillis();
     pushJobSettingToReturn.jobId = jobId;
     pushJobSettingToReturn.jobExecutionId = props.getString(JOB_EXEC_ID, "unknown_exec_id");
     pushJobSettingToReturn.jobServerName = props.getString(JOB_SERVER_NAME, "unknown_job_server");
@@ -360,6 +362,30 @@ public class VenicePushJob implements AutoCloseable {
     pushJobSettingToReturn.suppressEndOfPushMessage = props.getBoolean(SUPPRESS_END_OF_PUSH_MESSAGE, false);
     pushJobSettingToReturn.deferVersionSwap = props.getBoolean(DEFER_VERSION_SWAP, false);
     pushJobSettingToReturn.repushTTLEnabled = props.getBoolean(REPUSH_TTL_ENABLE, false);
+
+    if (pushJobSettingToReturn.repushTTLEnabled && !pushJobSettingToReturn.isSourceKafka) {
+      throw new VeniceException("Repush with TTL is only supported while using Kafka Input Format");
+    }
+
+    pushJobSettingToReturn.repushTTLStartTimeMs = -1;
+    if (pushJobSettingToReturn.repushTTLEnabled) {
+      long repushTtlSeconds = props.getLong(REPUSH_TTL_SECONDS, -1);
+      long repushTtlStartTimestamp = props.getLong(REPUSH_TTL_START_TIMESTAMP, -1);
+
+      if (repushTtlSeconds >= 0 && repushTtlStartTimestamp >= 0) {
+        String message =
+            "Both " + REPUSH_TTL_SECONDS + " and " + REPUSH_TTL_START_TIMESTAMP + " are set. Please set only one.";
+        throw new VeniceException(message);
+      }
+
+      if (repushTtlSeconds >= 0) {
+        pushJobSettingToReturn.repushTTLStartTimeMs =
+            pushJobSettingToReturn.jobStartTimeMs - (repushTtlSeconds * Time.MS_PER_SECOND);
+      } else if (repushTtlStartTimestamp >= 0) {
+        pushJobSettingToReturn.repushTTLStartTimeMs = repushTtlStartTimestamp;
+      }
+    }
+
     pushJobSettingToReturn.isTargetedRegionPushEnabled = props.getBoolean(TARGETED_REGION_PUSH_ENABLED, false);
     pushJobSettingToReturn.postValidationConsumption = props.getBoolean(POST_VALIDATION_CONSUMPTION_ENABLED, true);
     pushJobSettingToReturn.isSystemSchemaReaderEnabled = props.getBoolean(SYSTEM_SCHEMA_READER_ENABLED, false);
@@ -372,10 +398,6 @@ public class VenicePushJob implements AutoCloseable {
       } else {
         throw new VeniceException("Targeted region push list is only supported when targeted region push is enabled");
       }
-    }
-
-    if (pushJobSettingToReturn.repushTTLEnabled && !pushJobSettingToReturn.isSourceKafka) {
-      throw new VeniceException("Repush with TTL is only supported while using Kafka Input Format");
     }
 
     final String D2_PREFIX = "d2://";
@@ -426,7 +448,7 @@ public class VenicePushJob implements AutoCloseable {
       // But we did specify a rewind time epoch timestamp
       long rewindTimestamp = props.getLong(REWIND_EPOCH_TIME_IN_SECONDS_OVERRIDE, NOT_SET);
       if (rewindTimestamp != NOT_SET) {
-        long nowInSeconds = System.currentTimeMillis() / 1000;
+        long nowInSeconds = pushJobSettingToReturn.jobStartTimeMs / 1000;
         // So long as that rewind time isn't in the future
         if (rewindTimestamp > nowInSeconds) {
           throw new VeniceException(
@@ -635,7 +657,6 @@ public class VenicePushJob implements AutoCloseable {
       }
 
       initPushJobDetails();
-      jobStartTimeMs = System.currentTimeMillis();
       logGreeting();
       sendPushJobDetailsToController();
       validateKafkaMessageEnvelopeSchema(pushJobSetting);
@@ -698,8 +719,8 @@ public class VenicePushJob implements AutoCloseable {
       }
 
       Optional<ByteBuffer> optionalCompressionDictionary = getCompressionDictionary();
-      long pushStartTimeMs = System.currentTimeMillis();
-      String pushId = pushStartTimeMs + "_" + props.getString(JOB_EXEC_URL, "failed_to_obtain_execution_url");
+      String pushId =
+          pushJobSetting.jobStartTimeMs + "_" + props.getString(JOB_EXEC_URL, "failed_to_obtain_execution_url");
       if (pushJobSetting.isSourceKafka) {
         pushId = Version.generateRePushId(pushId);
         if (pushJobSetting.sourceKafkaInputVersionInfo.getHybridStoreConfig() != null
@@ -718,8 +739,9 @@ public class VenicePushJob implements AutoCloseable {
 
           // build the full path for HDFSRmdSchemaSource: the schema path will be suffixed
           // by the store name and time like: <TEMP_DIR_PREFIX>/<store_name>/<timestamp>
-          String rmdSchemaDir = TEMP_DIR_PREFIX + pushJobSetting.storeName + "/rmd_" + System.currentTimeMillis();
-          String valueSchemaDir = TEMP_DIR_PREFIX + pushJobSetting.storeName + "/value_" + System.currentTimeMillis();
+          String rmdSchemaDir = TEMP_DIR_PREFIX + pushJobSetting.storeName + "/rmd_" + pushJobSetting.jobStartTimeMs;
+          String valueSchemaDir =
+              TEMP_DIR_PREFIX + pushJobSetting.storeName + "/value_" + pushJobSetting.jobStartTimeMs;
           try (HDFSSchemaSource schemaSource =
               new HDFSSchemaSource(valueSchemaDir, rmdSchemaDir, pushJobSetting.storeName)) {
             schemaSource.saveSchemasOnDisk(controllerClient);
@@ -759,7 +781,7 @@ public class VenicePushJob implements AutoCloseable {
          * to completely stop using the {@link VeniceWriter} from this class.
          */
         pushJobSetting.incrementalPushVersion =
-            System.currentTimeMillis() + "_" + pushJobSetting.jobServerName + "_" + pushJobSetting.jobExecutionId;
+            pushJobSetting.jobStartTimeMs + "_" + pushJobSetting.jobServerName + "_" + pushJobSetting.jobExecutionId;
         LOGGER.info("Incremental Push Version: {}", pushJobSetting.incrementalPushVersion);
         getVeniceWriter(pushJobSetting)
             .broadcastStartOfIncrementalPush(pushJobSetting.incrementalPushVersion, new HashMap<>());
@@ -813,7 +835,7 @@ public class VenicePushJob implements AutoCloseable {
 
       updatePushJobDetailsWithCheckpoint(PushJobCheckpoints.JOB_STATUS_POLLING_COMPLETED);
       pushJobDetails.overallStatus.add(getPushJobDetailsStatusTuple(PushJobDetailsStatus.COMPLETED.getValue()));
-      pushJobDetails.jobDurationInMs = System.currentTimeMillis() - jobStartTimeMs;
+      pushJobDetails.jobDurationInMs = LatencyUtils.getElapsedTimeInMs(pushJobSetting.jobStartTimeMs);
       updatePushJobDetailsWithConfigs();
       updatePushJobDetailsWithLivenessHeartbeatException(pushJobHeartbeatSender);
       sendPushJobDetailsToController();
@@ -841,7 +863,7 @@ public class VenicePushJob implements AutoCloseable {
         }
         pushJobDetails.overallStatus.add(getPushJobDetailsStatusTuple(PushJobDetailsStatus.ERROR.getValue()));
         pushJobDetails.failureDetails = e.toString();
-        pushJobDetails.jobDurationInMs = System.currentTimeMillis() - jobStartTimeMs;
+        pushJobDetails.jobDurationInMs = LatencyUtils.getElapsedTimeInMs(pushJobSetting.jobStartTimeMs);
         updatePushJobDetailsWithConfigs();
         updatePushJobDetailsWithLivenessHeartbeatException(pushJobHeartbeatSender);
         sendPushJobDetailsToController();
@@ -1605,7 +1627,7 @@ public class VenicePushJob implements AutoCloseable {
 
   private void updatePushJobDetailsWithDataWriterTracker() {
     if (dataWriterComputeJob == null) {
-      LOGGER.info("No running job to update push job details with MR counters");
+      LOGGER.info("No running job found. Skip updating push job details.");
       return;
     }
     DataWriterTaskTracker taskTracker = dataWriterComputeJob.getTaskTracker();
@@ -1626,24 +1648,28 @@ public class VenicePushJob implements AutoCloseable {
       // size of the Zstd with Dict compressed data
       pushJobDetails.totalZstdWithDictCompressedValueBytes = taskTracker.getTotalZstdCompressedValueSize();
       LOGGER.info(
-          "Data writer job summary: " + "\n\tTotal number of records: {} " + "\n\tSize of keys: {} "
-              + "\n\tsize of uncompressed value: {} " + "\n\tConfigured value Compression Strategy: {} "
-              + "\n\tFinal data size stored in Venice based on this compression strategy: {} "
-              + "\n\tCompression Metrics collection is: {} ",
+          "Data writer job summary: " + "\n\tTotal number of records: {}" + "\n\tSize of keys: {}"
+              + "\n\tSize of uncompressed values: {}" + "\n\tConfigured value compression strategy: {}"
+              + "\n\tSize of compressed values: {}" + "\n\tFinal data size stored in Venice: {}"
+              + "\n\tCompression Metrics collection: {}",
           pushJobDetails.totalNumberOfRecords,
           ByteUtils.generateHumanReadableByteCountString(pushJobDetails.totalKeyBytes),
           ByteUtils.generateHumanReadableByteCountString(pushJobDetails.totalRawValueBytes),
-          CompressionStrategy.valueOf(pushJobDetails.valueCompressionStrategy).name(),
+          pushJobSetting.topicCompressionStrategy,
           ByteUtils.generateHumanReadableByteCountString(pushJobDetails.totalCompressedValueBytes),
+          ByteUtils.generateHumanReadableByteCountString(
+              pushJobDetails.totalKeyBytes + pushJobDetails.totalCompressedValueBytes),
           pushJobSetting.compressionMetricCollectionEnabled ? "Enabled" : "Disabled");
       if (pushJobSetting.compressionMetricCollectionEnabled) {
         LOGGER.info(
-            "\tData size if compressed using Gzip: {} ",
-            ByteUtils.generateHumanReadableByteCountString(pushJobDetails.totalGzipCompressedValueBytes));
+            "\tData size if compressed using Gzip: {}",
+            ByteUtils.generateHumanReadableByteCountString(
+                pushJobDetails.totalKeyBytes + pushJobDetails.totalGzipCompressedValueBytes));
         if (pushJobSetting.isZstdDictCreationSuccess) {
           LOGGER.info(
-              "\tData size if compressed using Zstd with Dictionary: {} ",
-              ByteUtils.generateHumanReadableByteCountString(pushJobDetails.totalZstdWithDictCompressedValueBytes));
+              "\tData size if compressed using Zstd with Dictionary: {}",
+              ByteUtils.generateHumanReadableByteCountString(
+                  pushJobDetails.totalKeyBytes + pushJobDetails.totalZstdWithDictCompressedValueBytes));
         } else {
           LOGGER.info("\tZstd Dictionary creation Failed");
         }
@@ -1784,7 +1810,7 @@ public class VenicePushJob implements AutoCloseable {
     }
     try {
       pushJobDetails.reportTimestamp = System.currentTimeMillis();
-      int version = pushJobSetting == null ? UNCREATED_VERSION_NUMBER : pushJobSetting.version;
+      int version = pushJobSetting.version <= 0 ? UNCREATED_VERSION_NUMBER : pushJobSetting.version;
       ControllerResponse response = controllerClient.sendPushJobDetails(
           pushJobSetting.storeName,
           version,
@@ -2056,17 +2082,12 @@ public class VenicePushJob implements AutoCloseable {
       if (hybridStoreConfig == null) {
         throw new VeniceException("Repush TTL is only supported for real-time only store.");
       } else {
-        if (props.containsKey(REPUSH_TTL_START_TIMESTAMP)) {
-          jobSetting.repushTTLStartTimeMs = props.getLong(REPUSH_TTL_START_TIMESTAMP);
-        } else {
+        if (jobSetting.repushTTLStartTimeMs <= 0) {
           long storeRewindTimeInSeconds = hybridStoreConfig.getRewindTimeInSeconds();
           jobSetting.repushTTLStartTimeMs =
-              System.currentTimeMillis() - (storeRewindTimeInSeconds * Time.MS_PER_SECOND);
+              pushJobSetting.jobStartTimeMs - (storeRewindTimeInSeconds * Time.MS_PER_SECOND);
         }
       }
-    } else {
-      jobSetting.repushTTLStartTimeMs =
-          System.currentTimeMillis() - DEFAULT_RE_PUSH_REWIND_IN_SECONDS_OVERRIDE * Time.MS_PER_SECOND;
     }
 
     if (jobSetting.enableWriteCompute && !jobSetting.isStoreWriteComputeEnabled) {
@@ -2425,7 +2446,7 @@ public class VenicePushJob implements AutoCloseable {
       }
       long bootstrapToOnlineTimeoutInHours =
           VenicePushJob.this.pushJobSetting.storeResponse.getStore().getBootstrapToOnlineTimeoutInHours();
-      long durationMs = System.currentTimeMillis() - pollStartTimeMs;
+      long durationMs = LatencyUtils.getElapsedTimeInMs(pollStartTimeMs);
       if (durationMs > TimeUnit.HOURS.toMillis(bootstrapToOnlineTimeoutInHours)) {
         throw new VeniceException(
             "Failing push-job for store " + VenicePushJob.this.pushJobSetting.storeResponse.getName()
@@ -2435,9 +2456,10 @@ public class VenicePushJob implements AutoCloseable {
         unknownStateStartTimeMs = 0;
       } else if (unknownStateStartTimeMs == 0) {
         unknownStateStartTimeMs = System.currentTimeMillis();
-      } else if (System.currentTimeMillis() < unknownStateStartTimeMs
-          + pushJobSetting.jobStatusInUnknownStateTimeoutMs) {
-        double elapsedMinutes = (double) (System.currentTimeMillis() - unknownStateStartTimeMs) / Time.MS_PER_MINUTE;
+      } else if (LatencyUtils
+          .getElapsedTimeInMs(unknownStateStartTimeMs) < pushJobSetting.jobStatusInUnknownStateTimeoutMs) {
+        double elapsedMinutes =
+            ((double) LatencyUtils.getElapsedTimeInMs(unknownStateStartTimeMs)) / Time.MS_PER_MINUTE;
         LOGGER.warn("Some data centers are still in unknown state after waiting for {} minutes", elapsedMinutes);
       } else {
         long timeoutMinutes = pushJobSetting.jobStatusInUnknownStateTimeoutMs / Time.MS_PER_MINUTE;
@@ -2701,12 +2723,12 @@ public class VenicePushJob implements AutoCloseable {
    */
   public void cancel() {
     killJob(pushJobSetting, controllerClient);
-    if (pushJobSetting != null && StringUtils.isEmpty(pushJobSetting.topic)) {
+    if (StringUtils.isEmpty(pushJobSetting.topic)) {
       pushJobDetails.overallStatus.add(getPushJobDetailsStatusTuple(PushJobDetailsStatus.ERROR.getValue()));
     } else {
       pushJobDetails.overallStatus.add(getPushJobDetailsStatusTuple(PushJobDetailsStatus.KILLED.getValue()));
     }
-    pushJobDetails.jobDurationInMs = System.currentTimeMillis() - jobStartTimeMs;
+    pushJobDetails.jobDurationInMs = LatencyUtils.getElapsedTimeInMs(pushJobSetting.jobStartTimeMs);
     updatePushJobDetailsWithConfigs();
     sendPushJobDetailsToController();
   }

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJobConstants.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJobConstants.java
@@ -297,6 +297,7 @@ public final class VenicePushJobConstants {
    */
   public static final String REPUSH_TTL_ENABLE = "repush.ttl.enable";
   public static final String REPUSH_TTL_POLICY = "repush.ttl.policy";
+  public static final String REPUSH_TTL_SECONDS = "repush.ttl.seconds";
   public static final String REPUSH_TTL_START_TIMESTAMP = "repush.ttl.start.timestamp";
   public static final String RMD_SCHEMA_DIR = "rmd.schema.dir";
   public static final String VALUE_SCHEMA_DIR = "value.schema.dir";

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/spark/datawriter/jobs/AbstractDataWriterSparkJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/spark/datawriter/jobs/AbstractDataWriterSparkJob.java
@@ -340,7 +340,7 @@ public abstract class AbstractDataWriterSparkJob extends DataWriterComputeJob {
 
   private Dataset<Row> getInputDataFrame() {
     if (pushJobSetting.isSourceKafka) {
-      throw new VeniceUnsupportedOperationException("Spark push job doesn't support KIF yet");
+      throw new VeniceUnsupportedOperationException("Spark push job for repush workloads");
     } else {
       return getUserInputDataFrame();
     }

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/task/datawriter/AbstractPartitionWriter.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/task/datawriter/AbstractPartitionWriter.java
@@ -342,8 +342,8 @@ public abstract class AbstractPartitionWriter extends AbstractDataWriterTask imp
 
   private VeniceWriter<byte[], byte[], byte[]> createBasicVeniceWriter() {
     Properties writerProps = props.toProperties();
-    // Closing segments based on elapsed time should always be disabled in MR to prevent storage nodes consuming out of
-    // order keys when speculative execution is in play.
+    // Closing segments based on elapsed time should always be disabled in data writer compute jobs to prevent storage
+    // nodes from consuming out of order keys when speculative execution is enabled.
     writerProps.put(VeniceWriter.MAX_ELAPSED_TIME_FOR_SEGMENT_IN_MS, -1);
 
     EngineTaskConfigProvider engineTaskConfigProvider = getEngineTaskConfigProvider();
@@ -378,12 +378,12 @@ public abstract class AbstractPartitionWriter extends AbstractDataWriterTask imp
           (System.nanoTime() - lastTimeThroughputWasLoggedInNS) / (double) Time.NS_PER_SECOND;
 
       // Mapping rate measurement
-      long mrFrameworkRate = (long) (telemetryMessageInterval / timeSinceLastMeasurementInSeconds);
+      long writeThroughput = (long) (telemetryMessageInterval / timeSinceLastMeasurementInSeconds);
       LOGGER.info(
-          "MR Framework records processed: {}, total time spent: {}, current throughput: {} rec/s",
+          "DataWriterComputeJob records processed: {}, total time spent: {}, current throughput: {} rec/s",
           messageSent,
           Utils.makeTimePretty(aggregateTimeOfInBetweenReduceInvocationsInNS),
-          Utils.makeLargeNumberPretty(mrFrameworkRate));
+          Utils.makeLargeNumberPretty(writeThroughput));
 
       // Produce rate measurement
       long newMessageCompletedCount = messageCompleted.get();

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/input/kafka/TestVeniceKafkaInputMapper.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/input/kafka/TestVeniceKafkaInputMapper.java
@@ -17,6 +17,7 @@ import com.linkedin.venice.hadoop.FilterChain;
 import com.linkedin.venice.hadoop.input.kafka.avro.KafkaInputMapperKey;
 import com.linkedin.venice.hadoop.input.kafka.avro.KafkaInputMapperValue;
 import com.linkedin.venice.hadoop.input.kafka.avro.MapperValueType;
+import com.linkedin.venice.hadoop.input.kafka.ttl.TTLResolutionPolicy;
 import com.linkedin.venice.hadoop.mapreduce.datawriter.map.AbstractTestVeniceMapper;
 import com.linkedin.venice.hadoop.task.datawriter.DataWriterTaskTracker;
 import com.linkedin.venice.utils.Time;
@@ -77,7 +78,7 @@ public class TestVeniceKafkaInputMapper extends AbstractTestVeniceMapper<VeniceK
   public void testValidFilterWhenTTLSpecified() {
     Properties props = new Properties();
     props.put(REPUSH_TTL_ENABLE, true);
-    props.put(REPUSH_TTL_POLICY, 0);
+    props.put(REPUSH_TTL_POLICY, TTLResolutionPolicy.RT_WRITE_ONLY.getValue());
     props.put(RMD_SCHEMA_DIR, "tmp");
     props.put(VALUE_SCHEMA_DIR, "tmp2");
     props.put(REPUSH_TTL_START_TIMESTAMP, System.currentTimeMillis() - 10L * Time.MS_PER_SECOND);

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/input/kafka/TestVeniceKafkaInputReducer.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/input/kafka/TestVeniceKafkaInputReducer.java
@@ -26,6 +26,7 @@ import com.linkedin.venice.hadoop.FilterChain;
 import com.linkedin.venice.hadoop.input.kafka.avro.KafkaInputMapperKey;
 import com.linkedin.venice.hadoop.input.kafka.avro.KafkaInputMapperValue;
 import com.linkedin.venice.hadoop.input.kafka.avro.MapperValueType;
+import com.linkedin.venice.hadoop.input.kafka.ttl.TTLResolutionPolicy;
 import com.linkedin.venice.hadoop.mapreduce.datawriter.task.ReporterBackedMapReduceDataWriterTaskTracker;
 import com.linkedin.venice.hadoop.task.datawriter.AbstractPartitionWriter;
 import com.linkedin.venice.serializer.FastSerializerDeserializerFactory;
@@ -196,7 +197,7 @@ public class TestVeniceKafkaInputReducer {
     props.put(COMPRESSION_STRATEGY, CompressionStrategy.NO_OP.name());
     props.put(VALUE_SCHEMA_ID_PROP, 1);
     props.put(REPUSH_TTL_ENABLE, true);
-    props.put(REPUSH_TTL_POLICY, 0);
+    props.put(REPUSH_TTL_POLICY, TTLResolutionPolicy.RT_WRITE_ONLY.getValue());
     props.put(REPUSH_TTL_START_TIMESTAMP, 10000000L - 10L * Time.MS_PER_SECOND);
     props.put(RMD_SCHEMA_DIR, "tmp");
     props.put(VALUE_SCHEMA_DIR, "tmp2");

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/input/kafka/ttl/TestVeniceKafkaInputTTLFilter.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/input/kafka/ttl/TestVeniceKafkaInputTTLFilter.java
@@ -54,7 +54,7 @@ public class TestVeniceKafkaInputTTLFilter {
   public void setUp() throws IOException {
     Properties validProps = new Properties();
     validProps.put(REPUSH_TTL_ENABLE, true);
-    validProps.put(REPUSH_TTL_POLICY, 0);
+    validProps.put(REPUSH_TTL_POLICY, TTLResolutionPolicy.RT_WRITE_ONLY.getValue());
     validProps.put(REPUSH_TTL_START_TIMESTAMP, DUMMY_CURRENT_TIMESTAMP - TTL_IN_SECONDS_DEFAULT * Time.MS_PER_SECOND);
     validProps.put(RMD_SCHEMA_DIR, getTempDataDirectory().getAbsolutePath());
     validProps.put(VALUE_SCHEMA_DIR, getTempDataDirectory().getAbsolutePath());

--- a/docs/ops_guide/repush.md
+++ b/docs/ops_guide/repush.md
@@ -101,11 +101,11 @@ it defaults to false.
 kafka.input.combiner.enabled = true
 ```
 
-To specify whether to enable TTL for the repush job. This is an experimental functionality.
-If unspecified, it defaults to false.
+To specify whether to enable TTL for the repush job. If unspecified, it defaults to false.
 ```
 repush.ttl.enable = true
 ```
+More details on how to configure TTL can be found in the [TTL](../user_guide/ttl) guide.
 
 ## Future Work
 

--- a/docs/user_guide/ttl.md
+++ b/docs/user_guide/ttl.md
@@ -17,11 +17,42 @@ minimum, not maximum, TTL. It is also advisable to schedule the periodic purging
 in case of infra delays or failures.
 
 ## Usage
+There are two ways to achieve TTL compliance, via [Repush with TTL](#repush-with-ttl) or via [empty push](#empty-push).
+The major differences between both approaches is the original data source and how real-time buffer is replayed.
 
-There are two ways to achieve TTL compliance, via [empty push](#empty-push) or via [Repush with TTL](#experimental-repush-with-ttl).
+|                 | Source Data for TTL    | Real-time buffer replay                                               |
+|-----------------|------------------------|-----------------------------------------------------------------------|
+| Empty push      | None                   | Replay real-time buffer with `hybrid-rewind-seconds` config           |
+| Repush with TTL | Existing version topic | Replay real-time buffer with `rewind.time.in.seconds.override` config |
+
+## Repush with TTL
+Repush with TTL runs as a VenicePushJob that reads the data in the existing version of the store,  and writes it back as
+a new version. The TTL is enforced by the VenicePushJob, which only writes records that are younger than the specified
+TTL. Repush with TTL can also be configured and scheduled periodically to enforce TTL.
+
+The store-level rewind time (in hybrid store configs) is used as the default TTL time. A custom TTL time can be
+specified by setting one of the following configs on the VenicePushJob:
+
+| Config                       | TTL behavior                                                         |
+|------------------------------|----------------------------------------------------------------------|
+| `repush.ttl.seconds`         | Records older than the specified value will expire                   |
+| `repush.ttl.start.timestamp` | Records that were written before the specified timestamp will expire |
+
+The `rewind.time.in.seconds.override` is a configurable value in push job (Default: 24 hours).
+
+This brings two major benefits:
+1. The repush job de-dupes writes to the same key, so that the servers need to ingest fewer events.
+2. The repush job sorts the data, thus allowing servers to ingest in a more optimized way.
+
+### How to enable
+In order to enable repush with ttl, a VenicePushJob needs to be configured with the following configs:
+```
+source.kafka = true
+repush.ttl.enable = true
+```
+For more options related to repush, refer to the [Repush](../ops_guide/repush.md) guide.
 
 ## Empty push
-
 For Venice stores that receive nearline writes, it is possible to set up a periodic purge of records that are older than
 some threshold.
 
@@ -36,28 +67,9 @@ between each empty push. For example, if you schedule a daily empty push, and N 
 store will be at least 6 days old, and at most 7 days old.
 
 N can be set up by configuring the `hybrid-rewind-seconds` using venice-admin-tool.
-### How to enable
 
+### How to enable
 At the moment, there are two ways to perform empty pushes:
 1. Via the `empty-push` command in the admin tool.
 2. Via the Venice Push Job, executed from a Hadoop grid, but with an input directory that contains a file with no
    records in it.
-
-## Repush with TTL
-Similarly to empty push, the repush with TTL can also be configured and scheduled periodically to enforce TTL.
-The major differences between this and empty push are original data source and how real-time buffer is replayed.
-
-|                 | Data origin            | Real-time buffer replay                                               |
-|-----------------|------------------------|-----------------------------------------------------------------------|
-| Empty push      | None                   | Replay real-time buffer with `hybrid-rewind-seconds` config           |
-| Repush with TTL | Existing version topic | Replay real-time buffer with `rewind.time.in.seconds.override` config |
-
-The `rewind.time.in.seconds.override` is a configurable value in push job, default to 24 hours.
-
-This brings two major benefits:
-1. The repush job de-dupes writes to the same key, so that the servers need to ingest fewer events.
-2. The repush job sorts the data, thus allowing servers to ingest in a more optimized way.
-
-### How to enable
-
-In order to enable repush with ttl, refer to the [Repush](../ops_guide/repush.md) guide.

--- a/docs/user_guide/write_api/online_producer.md
+++ b/docs/user_guide/write_api/online_producer.md
@@ -1,11 +1,11 @@
 ---
 layout: default
-title: Online Producer (Experimental)
+title: Online Producer
 parent: Write APIs
 grand_parent: User Guides
 permalink: /docs/user_guide/write_api/online_producer
 ---
-# [Experimental] Online Producer
+# Online Producer
 The Online Producer enables online applications to write data to a Venice store directly. All writes are still
 asynchronous, and data is only eventually consistent. However, the APIs guarantee durability of the data if the
 operation is successful.


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Allow configuring explicit TTL age in VPJ
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
Currently, [Repush with TTL](https://venicedb.org/docs/user_guide/ttl#repush-with-ttl) uses the store's `rewindTimeInSeconds` hybrid config  as the TTL time for eviction. Some use-cases might require configurable TTL times through configs on their Venice Push Jobs. This commit adds a new config `repush.ttl.seconds` that can be set to specify such TTL configs.

This commit also improves some unrelated logging in VPJ.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
GHCI

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.