### PR TITLE
[producer] Skip metrics for the store client inside online producer

### DIFF
--- a/clients/venice-producer/src/main/java/com/linkedin/venice/producer/online/OnlineProducerFactory.java
+++ b/clients/venice-producer/src/main/java/com/linkedin/venice/producer/online/OnlineProducerFactory.java
@@ -10,12 +10,10 @@ public class OnlineProducerFactory {
       ClientConfig storeClientConfig,
       VeniceProperties producerConfigs,
       ICProvider icProvider) {
-    OnlineVeniceProducer producer = new OnlineVeniceProducer<>(
+    return new OnlineVeniceProducer<>(
         storeClientConfig,
         producerConfigs,
         storeClientConfig.getMetricsRepository(),
         icProvider);
-
-    return producer;
   }
 }

--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/ClientConfig.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/ClientConfig.java
@@ -458,7 +458,7 @@ public class ClientConfig<T extends SpecificRecord> {
   }
 
   public ClientConfig<T> setSchemaRefreshPeriod(Duration schemaRefreshPeriod) {
-    this.schemaRefreshPeriod = schemaRefreshPeriod;
+    this.schemaRefreshPeriod = schemaRefreshPeriod == null ? DEFAULT_SCHEMA_REFRESH_PERIOD : schemaRefreshPeriod;
     return this;
   }
 


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Skip metrics for the store client inside online producer
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
In #867, we skipped metric emission for `SchemaReader`, but we missed skipping metric emission for the store client that we create to query topic information from routers. This commit addresses this gap.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
GH CI

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.