### PR TITLE
[controller] Check for bad default during new schema registration

### DIFF
--- a/internal/venice-avro-compatibility-test/src/test/java/com/linkedin/venice/VeniceClusterInitializer.java
+++ b/internal/venice-avro-compatibility-test/src/test/java/com/linkedin/venice/VeniceClusterInitializer.java
@@ -55,7 +55,7 @@ public class VeniceClusterInitializer implements Closeable {
       + "         { \"name\": \"name\", \"type\": \"string\", \"default\": \"default_name\"},           "
       + "         { \"name\": \"boolean_field\", \"type\": \"boolean\", \"default\": false},           "
       + "         { \"name\": \"int_field\", \"type\": \"int\", \"default\": 0},           "
-      + "         { \"name\": \"float_field\", \"type\": \"float\", \"default\": 0},           "
+      + "         { \"name\": \"float_field\", \"type\": \"float\", \"default\": 0.0},           "
       + "         { \"name\": \"namemap\", \"type\":  {\"type\" : \"map\", \"values\" : \"int\" }},           "
       + "         { \"name\": \"member_feature\", \"type\": { \"type\": \"array\", \"items\": \"float\" }, \"default\": []},"
       + "         { \"name\": \"ZookeeperAddress\", \"type\": \"string\"}" + "  ]       " + " }       ";

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestBatch.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestBatch.java
@@ -6,7 +6,6 @@ import static com.linkedin.venice.hadoop.VenicePushJobConstants.COMPRESSION_METR
 import static com.linkedin.venice.hadoop.VenicePushJobConstants.DATA_WRITER_COMPUTE_JOB_CLASS;
 import static com.linkedin.venice.hadoop.VenicePushJobConstants.DEFAULT_KEY_FIELD_PROP;
 import static com.linkedin.venice.hadoop.VenicePushJobConstants.DEFAULT_VALUE_FIELD_PROP;
-import static com.linkedin.venice.hadoop.VenicePushJobConstants.EXTENDED_SCHEMA_VALIDITY_CHECK_ENABLED;
 import static com.linkedin.venice.hadoop.VenicePushJobConstants.INCREMENTAL_PUSH;
 import static com.linkedin.venice.hadoop.VenicePushJobConstants.KAFKA_INPUT_BROKER_URL;
 import static com.linkedin.venice.hadoop.VenicePushJobConstants.KAFKA_INPUT_COMBINER_ENABLED;
@@ -205,16 +204,13 @@ public abstract class TestBatch {
         (avroClient, vsonClient, metricsRepository) -> {});
   }
 
-  @Test(timeOut = TEST_TIMEOUT, dataProvider = "True-and-False", dataProviderClass = DataProviderUtils.class)
-  public void testDataPushWithSchemaWithAWrongDefault(boolean extendedSchemaValidationCheckEnabled) throws Exception {
+  @Test(timeOut = TEST_TIMEOUT)
+  public void testDataPushWithSchemaWithAWrongDefault() {
     final int recordCnt = 100;
-    Exception pushJobException = null;
     try {
       testBatchStore(
           inputDir -> new KeyAndValueSchemas(writeSimpleAvroFileWithASchemaWithAWrongDefaultValue(inputDir, recordCnt)),
-          properties -> properties.setProperty(
-              EXTENDED_SCHEMA_VALIDITY_CHECK_ENABLED,
-              Boolean.toString(extendedSchemaValidationCheckEnabled)),
+          properties -> {},
           (avroClient, vsonClient, metricsRepository) -> {
             for (int i = 0; i < recordCnt; i++) {
               Object valueObject = avroClient.get(Integer.toString(i)).get();
@@ -227,12 +223,7 @@ public abstract class TestBatch {
             }
           });
     } catch (Exception e) {
-      pushJobException = e;
-    }
-    if (extendedSchemaValidationCheckEnabled) {
-      Assert.assertTrue(pushJobException != null && pushJobException.getMessage().contains("Invalid default"));
-    } else {
-      Assert.assertNull(pushJobException);
+      Assert.assertTrue(e.getMessage().contains("Could not create store"));
     }
   }
 

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/utils/IntegrationTestPushUtils.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/utils/IntegrationTestPushUtils.java
@@ -257,9 +257,9 @@ public class IntegrationTestPushUtils {
     NewStoreResponse newStoreResponse = controllerClient
         .createNewStore(props.getProperty(VENICE_STORE_NAME_PROP), "test@linkedin.com", keySchemaStr, valueSchemaStr);
 
-    Assert.assertFalse(
-        newStoreResponse.isError(),
-        "The NewStoreResponse returned an error: " + newStoreResponse.getError());
+    if (newStoreResponse.isError()) {
+      throw new VeniceException("Could not create store " + props.getProperty(VENICE_STORE_NAME_PROP));
+    }
 
     updateStore(veniceClusterName, props, storeParams.setStorageQuotaInByte(Store.UNLIMITED_STORAGE_QUOTA));
     return controllerClient;

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -1695,6 +1695,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
     }
     AvroSchemaUtils.validateAvroSchemaStr(keySchema);
     AvroSchemaUtils.validateAvroSchemaStr(valueSchema);
+    AvroSchemaParseUtils.parseSchemaFromJSONStrictValidation(valueSchema);
     checkControllerLeadershipFor(clusterName);
     checkStoreNameConflict(storeName, allowSystemStore);
     // Before creating store, check the global stores configs at first.
@@ -5385,6 +5386,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
       String valueSchemaStr,
       DirectionalSchemaCompatibilityType expectedCompatibilityType) {
     AvroSchemaUtils.validateAvroSchemaStr(valueSchemaStr);
+    AvroSchemaParseUtils.parseSchemaFromJSONStrictValidation(valueSchemaStr);
     validateValueSchemaUsingRandomGenerator(valueSchemaStr, clusterName, storeName);
     checkControllerLeadershipFor(clusterName);
     return getHelixVeniceClusterResources(clusterName).getSchemaRepository()


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Check for bad default during new schema registration
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

During new store creation and new schema registration Venice does validate the union default for schemas using `AvroSchemaUtils.validateAvroSchemaStr`, but it does not check wrong numeric default types and allows wrong numeric default to be registered. This later causes ingestion error in server as it does strict validation of schemas. 
This PR will make sure controller schema addition code path does a strict validation.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
CI test
## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.