### PR TITLE
[controller] Fix multiple AdminExecutionTasks working on the same store at the same time.

### DIFF
--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/kafka/consumer/AdminExecutionTask.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/kafka/consumer/AdminExecutionTask.java
@@ -84,7 +84,7 @@ public class AdminExecutionTask implements Callable<Void> {
   private final ConcurrentHashMap<String, Long> lastSucceededExecutionIdMap;
   private final long lastPersistedExecutionId;
 
-  private final Set<String> storeSet;
+  private final Map<String, AdminExecutionTask> storeToScheduledTask;
 
   AdminExecutionTask(
       Logger LOGGER,
@@ -98,7 +98,7 @@ public class AdminExecutionTask implements Callable<Void> {
       boolean isParentController,
       AdminConsumptionStats stats,
       String regionName,
-      Set<String> storeSet) {
+      Map<String, AdminExecutionTask> storeToScheduledTask) {
     this.LOGGER = LOGGER;
     this.clusterName = clusterName;
     this.storeName = storeName;
@@ -110,7 +110,7 @@ public class AdminExecutionTask implements Callable<Void> {
     this.isParentController = isParentController;
     this.stats = stats;
     this.regionName = regionName;
-    this.storeSet = storeSet;
+    this.storeToScheduledTask = storeToScheduledTask;
   }
 
   @Override
@@ -160,7 +160,7 @@ public class AdminExecutionTask implements Callable<Void> {
       }
       throw e;
     } finally {
-      storeSet.remove(storeName);
+      storeToScheduledTask.remove(storeName);
     }
     return null;
   }


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Summary, imperative, start upper case, don't end with a period
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Current state: when we create `AdminExecutionTask` , we did not check if there is `AdminExecutionTask` for one store on the fly, so if one `AdminExecutionTask`  is waiting for a lock (e.g. updating  store operation waiting for the store level write lock and that lock is currently unavailable), it is possible that `AdminConsumptionTask` will create multiple `AdminExecutionTask` s for a single store until they occupy all threads from `ExecutorService` 's thread pool, they are all waiting for the same store-level lock.

Besides, `executorService.invokeAll(tasks, processingCycleTimeoutInMs, TimeUnit.MILLISECONDS)`
will cancel every invoked tasks, even the task is emitted by not getting thread from pool to execute.  `ExecutorService` will try to cancel the `AdminExecutionTask`  waiting for a lock after timeout, but that will not terminate that thread (as the acquiring locking operation by `AutoCloseableLock` is not interruptible).   Then that `AdminExecutionTask`  will keep occupying one thread from `ExecutorService` 's thread pool until the lock is released. 


This PR has the following changes to address the issue:
1) Adding check to see if there is `AdminExecutionTask` is running for a store.
2) Integration test to simulate the lock blocking one thread from pool and recover after acquiring the lock.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
CI
## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.