### PR TITLE
[changelog] Add RocksDB block cache metric to changeLogClientConfig; Expose RocksDBMemoryStats to changelogConsumer

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/ChangelogClientConfig.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/ChangelogClientConfig.java
@@ -28,9 +28,9 @@ public class ChangelogClientConfig<T extends SpecificRecord> {
   private long databaseSyncBytesInterval = 32 * 1024 * 1024L;
 
   /**
-   * RocksDB block cache size per BootstrappingVeniceChangelogConsumer. Default is 1 GB.
+   * RocksDB block cache size per BootstrappingVeniceChangelogConsumer. Default is 1 MB.
    */
-  private long rocksDBBlockCacheSizeInBytes = 1024 * 1024 * 1024L;
+  private long rocksDBBlockCacheSizeInBytes = 1024 * 1024L;
 
   public ChangelogClientConfig(String storeName) {
     this.innerClientConfig = new ClientConfig<>(storeName);

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/ChangelogClientConfig.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/ChangelogClientConfig.java
@@ -28,9 +28,9 @@ public class ChangelogClientConfig<T extends SpecificRecord> {
   private long databaseSyncBytesInterval = 32 * 1024 * 1024L;
 
   /**
-   * RocksDB block cache size per BootstrappingVeniceChangelogConsumer. Default is 16 GB.
+   * RocksDB block cache size per BootstrappingVeniceChangelogConsumer. Default is 1 GB.
    */
-  private long rocksDBBlockCacheSizeInBytes = 16 * 1024 * 1024 * 1024L;
+  private long rocksDBBlockCacheSizeInBytes = 1024 * 1024 * 1024L;
 
   public ChangelogClientConfig(String storeName) {
     this.innerClientConfig = new ClientConfig<>(storeName);

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/ChangelogClientConfig.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/ChangelogClientConfig.java
@@ -25,7 +25,12 @@ public class ChangelogClientConfig<T extends SpecificRecord> {
    * This will be used in BootstrappingVeniceChangelogConsumer to determine when to sync updates with the underlying
    * storage engine, e.g. flushes entity and offset data to disk. Default is 32 MB.
    */
-  private long databaseSyncBytesInterval = 33554432;
+  private long databaseSyncBytesInterval = 32 * 1024 * 1024L;
+
+  /**
+   * RocksDB block cache size per BootstrappingVeniceChangelogConsumer. Default is 16 GB.
+   */
+  private long rocksDBBlockCacheSizeInBytes = 16 * 1024 * 1024 * 1024L;
 
   public ChangelogClientConfig(String storeName) {
     this.innerClientConfig = new ClientConfig<>(storeName);
@@ -162,6 +167,15 @@ public class ChangelogClientConfig<T extends SpecificRecord> {
     return this;
   }
 
+  public long getRocksDBBlockCacheSizeInBytes() {
+    return rocksDBBlockCacheSizeInBytes;
+  }
+
+  public ChangelogClientConfig setRocksDBBlockCacheSizeInBytes(long rocksDBBlockCacheSizeInBytes) {
+    this.rocksDBBlockCacheSizeInBytes = rocksDBBlockCacheSizeInBytes;
+    return this;
+  }
+
   public static <V extends SpecificRecord> ChangelogClientConfig<V> cloneConfig(ChangelogClientConfig<V> config) {
     ChangelogClientConfig<V> newConfig = new ChangelogClientConfig<V>().setStoreName(config.getStoreName())
         .setLocalD2ZkHosts(config.getLocalD2ZkHosts())
@@ -175,6 +189,7 @@ public class ChangelogClientConfig<T extends SpecificRecord> {
         .setControllerRequestRetryCount(config.getControllerRequestRetryCount())
         .setBootstrapFileSystemPath(config.getBootstrapFileSystemPath())
         .setVersionSwapDetectionIntervalTimeInMs(config.getVersionSwapDetectionIntervalTimeInMs())
+        .setRocksDBBlockCacheSizeInBytes(config.getRocksDBBlockCacheSizeInBytes())
         .setDatabaseSyncBytesInterval(config.getDatabaseSyncBytesInterval());
     return newConfig;
   }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/InternalLocalBootstrappingVeniceChangelogConsumer.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/InternalLocalBootstrappingVeniceChangelogConsumer.java
@@ -67,28 +67,22 @@ class InternalLocalBootstrappingVeniceChangelogConsumer<K, V> extends VeniceChan
     implements BootstrappingVeniceChangelogConsumer<K, V> {
   private static final Logger LOGGER = LogManager.getLogger(InternalLocalBootstrappingVeniceChangelogConsumer.class);
   private static final String CHANGE_CAPTURE_COORDINATE = "ChangeCaptureCoordinatePosition";
-  // This is the name of a non-existent topic. We use it as a handle when interfacing with local storage so we can
+  // This is the name of a non-existent topic. We use it as a handle when interfacing with local storage, so we can
   // make decisions about easily about weather or not to clear out the local state data or not across version for a
-  // store
-  // (we'll keep the local data in the event of a repush, but clear out if a user push comes through)
+  // store (we'll keep the local data in the event of a repush, but clear out if a user push comes through)
   private static final String LOCAL_STATE_TOPIC_SUFFIX = "_Bootstrap_v1";
 
-  private StorageService storageService;
-  private StorageMetadataService storageMetadataService;
-
   private final MetricsRepository metricsRepository;
-
   private final String localStateTopicName;
   private final VeniceConcurrentHashMap<Integer, BootstrapState> bootstrapStateMap;
   private final InternalAvroSpecificSerializer<PartitionState> partitionStateSerializer;
-
   private final VeniceConfigLoader configLoader;
-
-  boolean isStarted = false;
-
-  private int bootstrapCompletedCount = 0;
-
   private final long syncBytesInterval;
+
+  private StorageService storageService;
+  private StorageMetadataService storageMetadataService;
+  private boolean isStarted = false;
+  private int bootstrapCompletedCount = 0;
 
   public InternalLocalBootstrappingVeniceChangelogConsumer(
       ChangelogClientConfig changelogClientConfig,
@@ -127,7 +121,9 @@ class InternalLocalBootstrappingVeniceChangelogConsumer<K, V> extends VeniceChan
     storageService = new StorageService(
         configLoader,
         storageEngineStats,
-        new RocksDBMemoryStats(metricsRepository, "RocksDBMemoryStats-" + consumerId, false),
+        metricsRepository == null
+            ? null
+            : new RocksDBMemoryStats(metricsRepository, "RocksDBMemoryStats-" + consumerId, false),
         storeVersionStateSerializer,
         partitionStateSerializer,
         storeRepository,

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImpl.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImpl.java
@@ -848,4 +848,8 @@ public class VeniceChangelogConsumerImpl<K, V> implements VeniceChangelogConsume
   protected PubSubConsumerAdapter getPubSubConsumer() {
     return pubSubConsumer;
   }
+
+  protected ChangelogClientConfig getChangelogClientConfig() {
+    return changelogClientConfig;
+  }
 }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/InternalLocalBootstrappingVeniceChangelogConsumerTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/InternalLocalBootstrappingVeniceChangelogConsumerTest.java
@@ -108,6 +108,7 @@ public class InternalLocalBootstrappingVeniceChangelogConsumerTest {
   private static final long TEST_OFFSET_OLD = 1L;
   private static final long TEST_OFFSET_NEW = 2L;
   private static final long TEST_DB_SYNC_BYTES_INTERVAL = 1000L;
+  private static final long TEST_ROCKSDB_BLOCK_CACHE_SIZE_IN_BYTES = 1024L;
   private String storeName;
   private String localStateTopicName;
   private InternalLocalBootstrappingVeniceChangelogConsumer<Utf8, Utf8> bootstrappingVeniceChangelogConsumer;
@@ -180,6 +181,7 @@ public class InternalLocalBootstrappingVeniceChangelogConsumerTest {
             .setBootstrapFileSystemPath(TEST_BOOTSTRAP_FILE_SYSTEM_PATH)
             .setConsumerProperties(consumerProperties)
             .setLocalD2ZkHosts(TEST_ZOOKEEPER_ADDRESS)
+            .setRocksDBBlockCacheSizeInBytes(TEST_ROCKSDB_BLOCK_CACHE_SIZE_IN_BYTES)
             .setDatabaseSyncBytesInterval(TEST_DB_SYNC_BYTES_INTERVAL);
     bootstrappingVeniceChangelogConsumer =
         new InternalLocalBootstrappingVeniceChangelogConsumer<>(changelogClientConfig, pubSubConsumer, null);
@@ -299,6 +301,9 @@ public class InternalLocalBootstrappingVeniceChangelogConsumerTest {
     Assert.assertTrue(completed.get());
     Assert.assertEquals(state.bootstrapState, InternalLocalBootstrappingVeniceChangelogConsumer.PollState.CONSUMING);
     Assert.assertEquals(bootstrappingVeniceChangelogConsumer.getBootstrapCompletedCount(), 2);
+    Assert.assertEquals(
+        bootstrappingVeniceChangelogConsumer.getChangelogClientConfig().getRocksDBBlockCacheSizeInBytes(),
+        TEST_ROCKSDB_BLOCK_CACHE_SIZE_IN_BYTES);
   }
 
   @Test


### PR DESCRIPTION

<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## [changelog] Add RocksDB block cache metric to changeLogClientConfig; Expose RocksDBMemoryStats to changelogConsumer
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

After customer adopts multiple changelog consumer, we encounter OOM and application killed by consumer. Based on current config setup, we suspect it is caused by multiple RocksDB instance opening 16GB block cache and eventually it use more memory than it should. Since we don't expose RocksDBMemoryStats today, we cannot make sure this is 100% the root cause, but from the behavior change from 1 consumer to 8 consumer with the same dataset, it is likely the cause.

Personally I think it will be great if multiple consumer can share same RocksDB instance without performance impact during bootstrap and consumption. Based on current implementation it would be hard to do so, so we will put this PR as an incremental improvement.

This PR opens up the config for user to set per consumer cache size limit. We will verify from the new metrics in the new client release.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
Existing test.
## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.