### PR TITLE
[controller] get future version for finished pushes

### DIFF
--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestVeniceHelixAdminWithIsolatedEnvironment.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestVeniceHelixAdminWithIsolatedEnvironment.java
@@ -357,6 +357,7 @@ public class TestVeniceHelixAdminWithIsolatedEnvironment extends AbstractTestVen
     ExecutorService asyncExecutor = Executors.newSingleThreadExecutor();
     try {
       String storeName = Utils.getUniqueString("test_store");
+      veniceAdmin.createStore(clusterName, storeName, "test", KEY_SCHEMA, VALUE_SCHEMA);
       asyncExecutor.submit(() -> {
         // A time-consuming store operation that holds cluster-level read lock and store-level write lock.
         HelixVeniceClusterResources resources = veniceAdmin.getHelixVeniceClusterResources(clusterName);

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -3064,19 +3064,23 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
 
   /**
    * @return One future version number of all the ongoing pushes or {@linkplain Store#NON_EXISTING_VERSION} if none exists.
-   * If the push finished successfully it will return the highest store ONLINE version, else returns NON_EXISTING_VERSION
    */
   @Override
   public int getFutureVersion(String clusterName, String storeName) {
     // Find all ongoing offline pushes at first.
     PushMonitor monitor = getHelixVeniceClusterResources(clusterName).getPushMonitor();
-    Optional<String> offlinePush = monitor.getTopicsOfOngoingOfflinePushes()
-        .stream()
-        .filter(topic -> Version.parseStoreFromKafkaTopicName(topic).equals(storeName))
+    List<OfflinePushStatus> offlinePushStatuses = monitor.getOfflinePushStatusForStore(storeName);
+    if (offlinePushStatuses.isEmpty()) {
+      return NON_EXISTING_VERSION;
+    }
+    Optional<String> offlinePush = offlinePushStatuses.stream()
+        .filter(status -> !status.getCurrentStatus().isTerminal())
+        .map(OfflinePushStatus::getKafkaTopic)
         .findFirst();
     if (offlinePush.isPresent()) {
       return Version.parseVersionFromKafkaTopicName(offlinePush.get());
     }
+    // If the push status is finished, then return the largest online version greater than current version
     return getOnlineFutureVersion(clusterName, storeName);
   }
 

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -3064,6 +3064,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
 
   /**
    * @return One future version number of all the ongoing pushes or {@linkplain Store#NON_EXISTING_VERSION} if none exists.
+   * If the push finished successfully it will return the highest store ONLINE version, else returns NON_EXISTING_VERSION
    */
   @Override
   public int getFutureVersion(String clusterName, String storeName) {
@@ -3076,7 +3077,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
     if (offlinePush.isPresent()) {
       return Version.parseVersionFromKafkaTopicName(offlinePush.get());
     }
-    return Store.NON_EXISTING_VERSION;
+    return getOnlineFutureVersion(clusterName, storeName);
   }
 
   @Override

--- a/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/AbstractPushMonitor.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/AbstractPushMonitor.java
@@ -571,6 +571,17 @@ public abstract class AbstractPushMonitor
   }
 
   @Override
+  public List<OfflinePushStatus> getOfflinePushStatusForStore(String storeName) {
+    List<OfflinePushStatus> result = new ArrayList<>();
+    result.addAll(
+        topicToPushMap.values()
+            .stream()
+            .filter(status -> Version.parseStoreFromKafkaTopicName(status.getKafkaTopic()).equals(storeName))
+            .collect(Collectors.toList()));
+    return result;
+  }
+
+  @Override
   public List<UncompletedPartition> getUncompletedPartitions(String topic) {
     OfflinePushStatus pushStatus = getOfflinePush(topic);
     if (pushStatus == null || pushStatus.getCurrentStatus().equals(COMPLETED)) {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/PushMonitor.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/PushMonitor.java
@@ -106,6 +106,8 @@ public interface PushMonitor {
    */
   List<String> getTopicsOfOngoingOfflinePushes();
 
+  List<OfflinePushStatus> getOfflinePushStatusForStore(String storeName);
+
   /**
    * Mark a push to be as error. This is usually called when push is killed.
    */

--- a/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/PushMonitorDelegator.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/pushmonitor/PushMonitorDelegator.java
@@ -189,6 +189,11 @@ public class PushMonitorDelegator implements PushMonitor {
   }
 
   @Override
+  public List<OfflinePushStatus> getOfflinePushStatusForStore(String storeName) {
+    return partitionStatusBasedPushStatusMonitor.getOfflinePushStatusForStore(storeName);
+  }
+
+  @Override
   public void markOfflinePushAsError(String topic, String statusDetails) {
     getPushMonitor(topic).markOfflinePushAsError(topic, statusDetails);
   }


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Get future version for finished pushes.
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Currently list_future_versions works only for ongoing pushes, if the push finishes then it will return invalid version. But in colo-by-colo push workflow, finished pushes not imply that is no future version as current version may not have swapped to it (deferredVersionsSwap = true). This PR will return the largest online version larger than current version as future version.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
CI test.
## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.