### PR TITLE
[WIP][server] Calculate upstream offset from TopicSwitch if needed when transitioning into LEADER

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -745,6 +745,30 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
     startConsumingAsLeader(partitionConsumptionState);
   }
 
+  protected Map<String, Long> calculateLeaderUpstreamOffsetWithTopicSwitch(
+      PartitionConsumptionState partitionConsumptionState,
+      TopicSwitch topicSwitch,
+      PubSubTopic newSourceTopic,
+      List<CharSequence> unreachableBrokerList) {
+    final String newSourceKafkaServer = topicSwitch.sourceKafkaServers.get(0).toString();
+    final PubSubTopicPartition newSourceTopicPartition =
+        partitionConsumptionState.getSourceTopicPartition(newSourceTopic);
+
+    long upstreamStartOffset = OffsetRecord.LOWEST_OFFSET;
+    if (topicSwitch.rewindStartTimestamp > 0) {
+      upstreamStartOffset = getTopicPartitionOffsetByKafkaURL(
+          newSourceKafkaServer,
+          newSourceTopicPartition,
+          topicSwitch.rewindStartTimestamp);
+      LOGGER.info(
+          "Calculated upstream from TopicSwitch rewind TS with {} offset {} partition {}",
+          newSourceTopic,
+          upstreamStartOffset,
+          partitionConsumptionState.getPartition());
+    }
+    return Collections.singletonMap(OffsetRecord.NON_AA_REPLICATION_UPSTREAM_OFFSET_MAP_KEY, upstreamStartOffset);
+  }
+
   @Override
   protected void startConsumingAsLeader(PartitionConsumptionState partitionConsumptionState) {
     /**
@@ -796,11 +820,26 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
     }
     final PubSubTopic leaderTopic = offsetRecord.getLeaderTopic(pubSubTopicRepository);
     final PubSubTopicPartition leaderTopicPartition = partitionConsumptionState.getSourceTopicPartition(leaderTopic);
-    final long leaderStartOffset = partitionConsumptionState
+    long leaderStartOffset = partitionConsumptionState
         .getLeaderOffset(OffsetRecord.NON_AA_REPLICATION_UPSTREAM_OFFSET_MAP_KEY, pubSubTopicRepository);
+    String leaderSourceKafkaURL = leaderSourceKafkaURLs.iterator().next();
+    if (leaderStartOffset < 0) {
+      // TODO: Add description.
+      TopicSwitch topicSwitch = partitionConsumptionState.getTopicSwitch().getTopicSwitch();
+      if (topicSwitch == null && leaderTopic.isRealTime()) {
+        throw new VeniceException(
+            "New leader does not have topic switch, unable to switch to realtime leader topic: "
+                + leaderTopicPartition);
+      }
+      leaderStartOffset = calculateLeaderUpstreamOffsetWithTopicSwitch(
+          partitionConsumptionState,
+          topicSwitch,
+          leaderTopic,
+          Collections.emptyList())
+              .getOrDefault(OffsetRecord.NON_AA_REPLICATION_UPSTREAM_OFFSET_MAP_KEY, OffsetRecord.LOWEST_OFFSET);
+    }
 
     // subscribe to the new upstream
-    String leaderSourceKafkaURL = leaderSourceKafkaURLs.iterator().next();
     LOGGER.info(
         "{} is promoted to leader for partition {} and it is going to start consuming from "
             + "{} at offset {}; source Kafka url: {}; remote consumption flag: {}",
@@ -856,16 +895,13 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
         ? partitionConsumptionState
             .getLatestProcessedUpstreamRTOffset(OffsetRecord.NON_AA_REPLICATION_UPSTREAM_OFFSET_MAP_KEY)
         : OffsetRecord.LOWEST_OFFSET;
-
-    if (upstreamStartOffset < 0) {
-      if (topicSwitch.rewindStartTimestamp > 0) {
-        upstreamStartOffset = getTopicPartitionOffsetByKafkaURL(
-            newSourceKafkaServer,
-            newSourceTopicPartition,
-            topicSwitch.rewindStartTimestamp);
-      } else {
-        upstreamStartOffset = OffsetRecord.LOWEST_OFFSET;
-      }
+    if (upstreamStartOffset < 0 && newSourceTopic.isRealTime()) {
+      upstreamStartOffset = calculateLeaderUpstreamOffsetWithTopicSwitch(
+          partitionConsumptionState,
+          topicSwitch,
+          newSourceTopic,
+          Collections.emptyList())
+              .getOrDefault(OffsetRecord.NON_AA_REPLICATION_UPSTREAM_OFFSET_MAP_KEY, OffsetRecord.LOWEST_OFFSET);
     }
 
     // unsubscribe the old source and subscribe to the new source


### PR DESCRIPTION
## [server] Calculate upstream offset from TopicSwitch if needed when transitioning into LEADER

PR #908 fixed the bug that follower may calculate and store wrong rewind offset if some RT messages are gone because of message retention.
However, the fix is not complete. It missed the case during leader transition: The to-be-leader will store TS (if it sees one), it will update the leader topic, but it will not calculate the rewind and persist it after the PR change. The result is that: when it becomes leader after 5 min inactive time, it will start from -1, as no upstream offset has been computed. 

This PR proposes to fix the case by adding the same offset calculation logic to API startConsumingAsLeader.

It happens to improve the resiliency of AA subscription as well by reusing the same code. As in the past, the to-be-leader will not re-try calculating offset for unreachable broker via repair task.

## How was this PR tested?

Not yet. I am planning to add an integration test to attack this scenario.
## Does this PR introduce any user-facing changes?
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.