### PR TITLE
[admin-tool] Let admin tool deal with PubSubClientsFactory to support various type of pub sub system.

### DIFF
--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/AdminTool.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/AdminTool.java
@@ -2,6 +2,9 @@ package com.linkedin.venice;
 
 import static com.linkedin.venice.CommonConfigKeys.SSL_FACTORY_CLASS_NAME;
 import static com.linkedin.venice.ConfigKeys.KAFKA_BOOTSTRAP_SERVERS;
+import static com.linkedin.venice.ConfigKeys.PUB_SUB_ADMIN_ADAPTER_FACTORY_CLASS;
+import static com.linkedin.venice.ConfigKeys.PUB_SUB_CONSUMER_ADAPTER_FACTORY_CLASS;
+import static com.linkedin.venice.ConfigKeys.PUB_SUB_PRODUCER_ADAPTER_FACTORY_CLASS;
 import static com.linkedin.venice.VeniceConstants.DEFAULT_SSL_FACTORY_CLASS_NAME;
 import static com.linkedin.venice.schema.AvroSchemaParseUtils.parseSchemaFromJSONLooseValidation;
 import static com.linkedin.venice.serialization.avro.AvroProtocolDefinition.SERVER_ADMIN_RESPONSE;
@@ -87,7 +90,10 @@ import com.linkedin.venice.meta.StoreInfo;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.meta.VersionStatus;
 import com.linkedin.venice.metadata.response.MetadataResponseRecord;
+import com.linkedin.venice.pubsub.PubSubAdminAdapterFactory;
 import com.linkedin.venice.pubsub.PubSubClientsFactory;
+import com.linkedin.venice.pubsub.PubSubConsumerAdapterFactory;
+import com.linkedin.venice.pubsub.PubSubProducerAdapterFactory;
 import com.linkedin.venice.pubsub.PubSubTopicRepository;
 import com.linkedin.venice.pubsub.adapter.kafka.admin.ApacheKafkaAdminAdapterFactory;
 import com.linkedin.venice.pubsub.adapter.kafka.consumer.ApacheKafkaConsumerAdapterFactory;
@@ -172,11 +178,6 @@ public class AdminTool {
 
   private static final PubSubTopicRepository PUB_SUB_TOPIC_REPOSITORY = new PubSubTopicRepository();
 
-  private static final PubSubClientsFactory PUB_SUB_CLIENTS_FACTORY = new PubSubClientsFactory(
-      new ApacheKafkaProducerAdapterFactory(),
-      new ApacheKafkaConsumerAdapterFactory(),
-      new ApacheKafkaAdminAdapterFactory());
-
   private static final ObjectMapper OBJECT_MAPPER = ObjectMapperFactory.getInstance();
 
   private static ControllerClient controllerClient;
@@ -194,6 +195,31 @@ public class AdminTool {
       "zookeeper.ssl.trustStore.type");
 
   public static void main(String args[]) throws Exception {
+    // Generate PubSubClientsFactory from java system properties, apache kafka adapter is the default one.
+    PubSubClientsFactory pubSubClientsFactory;
+    try {
+      String producerFactoryClassName =
+          System.getProperty(PUB_SUB_PRODUCER_ADAPTER_FACTORY_CLASS, ApacheKafkaProducerAdapterFactory.class.getName());
+      PubSubProducerAdapterFactory pubSubProducerAdapterFactory =
+          (PubSubProducerAdapterFactory) Class.forName(producerFactoryClassName).newInstance();
+      String consumerFactoryClassName =
+          System.getProperty(PUB_SUB_CONSUMER_ADAPTER_FACTORY_CLASS, ApacheKafkaConsumerAdapterFactory.class.getName());
+      PubSubConsumerAdapterFactory pubSubConsumerAdapterFactory =
+          (PubSubConsumerAdapterFactory) Class.forName(consumerFactoryClassName).newInstance();
+      String adminFactoryClassName =
+          System.getProperty(PUB_SUB_ADMIN_ADAPTER_FACTORY_CLASS, ApacheKafkaAdminAdapterFactory.class.getName());
+
+      PubSubAdminAdapterFactory pubSubAdminAdapterFactory =
+          (PubSubAdminAdapterFactory) Class.forName(adminFactoryClassName).newInstance();
+      pubSubClientsFactory = new PubSubClientsFactory(
+          pubSubProducerAdapterFactory,
+          pubSubConsumerAdapterFactory,
+          pubSubAdminAdapterFactory);
+    } catch (ClassNotFoundException | IllegalAccessException | InstantiationException e) {
+      System.out.println("Failed to create an instance of pub sub clients factory with exception: " + e);
+      throw new VeniceException(e);
+    }
+
     CommandLine cmd = getCommandLine(args);
 
     try {
@@ -407,19 +433,19 @@ public class AdminTool {
           listBootstrappingVersions(cmd);
           break;
         case DELETE_KAFKA_TOPIC:
-          deleteKafkaTopic(cmd);
+          deleteKafkaTopic(cmd, pubSubClientsFactory);
           break;
         case DUMP_ADMIN_MESSAGES:
-          dumpAdminMessages(cmd);
+          dumpAdminMessages(cmd, pubSubClientsFactory);
           break;
         case DUMP_CONTROL_MESSAGES:
-          dumpControlMessages(cmd);
+          dumpControlMessages(cmd, pubSubClientsFactory);
           break;
         case DUMP_KAFKA_TOPIC:
-          dumpKafkaTopic(cmd);
+          dumpKafkaTopic(cmd, pubSubClientsFactory);
           break;
         case QUERY_KAFKA_TOPIC:
-          queryKafkaTopic(cmd);
+          queryKafkaTopic(cmd, pubSubClientsFactory);
           break;
         case MIGRATE_STORE:
           migrateStore(cmd);
@@ -554,7 +580,7 @@ public class AdminTool {
           backupStoreMetadataFromGraveyard(cmd);
           break;
         case RECOVER_STORE_METADATA:
-          recoverStoreMetadata(cmd);
+          recoverStoreMetadata(cmd, pubSubClientsFactory);
           break;
         case DUMP_TOPIC_PARTITION_INGESTION_CONTEXT:
           dumpTopicPartitionIngestionContext(cmd);
@@ -1247,7 +1273,8 @@ public class AdminTool {
     }
   }
 
-  private static void recoverStoreMetadata(CommandLine cmd) throws Exception {
+  private static void recoverStoreMetadata(CommandLine cmd, PubSubClientsFactory pubSubClientsFactory)
+      throws Exception {
     String store = getRequiredArgument(cmd, Arg.STORE, Command.RECOVER_STORE_METADATA);
     String url = getRequiredArgument(cmd, Arg.URL, Command.RECOVER_STORE_METADATA);
     boolean skipLastStoreCreation =
@@ -1273,7 +1300,7 @@ public class AdminTool {
         consumerConfigFile.isEmpty() ? new Properties() : loadProperties(cmd, Arg.KAFKA_CONSUMER_CONFIG_FILE);
     String pubSubBrokerUrl = getRequiredArgument(cmd, Arg.KAFKA_BOOTSTRAP_SERVERS, Command.RECOVER_STORE_METADATA);
     consumerProperties = DumpAdminMessages.getPubSubConsumerProperties(pubSubBrokerUrl, consumerProperties);
-    PubSubConsumerAdapter consumer = getConsumer(consumerProperties);
+    PubSubConsumerAdapter consumer = getConsumer(consumerProperties, pubSubClientsFactory);
 
     try {
       RecoverStoreMetadata.recover(
@@ -1499,7 +1526,7 @@ public class AdminTool {
     printObject(response);
   }
 
-  private static void deleteKafkaTopic(CommandLine cmd) throws Exception {
+  private static void deleteKafkaTopic(CommandLine cmd, PubSubClientsFactory pubSubClientsFactory) throws Exception {
     long startTime = System.currentTimeMillis();
     String kafkaBootstrapServer = getRequiredArgument(cmd, Arg.KAFKA_BOOTSTRAP_SERVERS);
     Properties properties = loadProperties(cmd, Arg.KAFKA_CONSUMER_CONFIG_FILE);
@@ -1517,8 +1544,8 @@ public class AdminTool {
             .setPubSubOperationTimeoutMs(kafkaTimeOut)
             .setTopicDeletionStatusPollIntervalMs(topicDeletionStatusPollingInterval)
             .setTopicMinLogCompactionLagMs(0L)
-            .setPubSubConsumerAdapterFactory(PUB_SUB_CLIENTS_FACTORY.getConsumerAdapterFactory())
-            .setPubSubAdminAdapterFactory(PUB_SUB_CLIENTS_FACTORY.getAdminAdapterFactory())
+            .setPubSubConsumerAdapterFactory(pubSubClientsFactory.getConsumerAdapterFactory())
+            .setPubSubAdminAdapterFactory(pubSubClientsFactory.getAdminAdapterFactory())
             .setPubSubTopicRepository(pubSubTopicRepository)
             .setTopicMetadataFetcherConsumerPoolSize(1)
             .setTopicMetadataFetcherThreadPoolSize(1)
@@ -1539,11 +1566,11 @@ public class AdminTool {
     }
   }
 
-  private static void dumpAdminMessages(CommandLine cmd) {
+  private static void dumpAdminMessages(CommandLine cmd, PubSubClientsFactory pubSubClientsFactory) {
     Properties consumerProperties = loadProperties(cmd, Arg.KAFKA_CONSUMER_CONFIG_FILE);
     String pubSubBrokerUrl = getRequiredArgument(cmd, Arg.KAFKA_BOOTSTRAP_SERVERS);
     consumerProperties = DumpAdminMessages.getPubSubConsumerProperties(pubSubBrokerUrl, consumerProperties);
-    PubSubConsumerAdapter consumer = getConsumer(consumerProperties);
+    PubSubConsumerAdapter consumer = getConsumer(consumerProperties, pubSubClientsFactory);
     List<DumpAdminMessages.AdminOperationInfo> adminMessages = DumpAdminMessages.dumpAdminMessages(
         consumer,
         getRequiredArgument(cmd, Arg.CLUSTER),
@@ -1552,7 +1579,7 @@ public class AdminTool {
     printObject(adminMessages);
   }
 
-  private static void dumpControlMessages(CommandLine cmd) {
+  private static void dumpControlMessages(CommandLine cmd, PubSubClientsFactory pubSubClientsFactory) {
     Properties consumerProps = loadProperties(cmd, Arg.KAFKA_CONSUMER_CONFIG_FILE);
     String kafkaUrl = getRequiredArgument(cmd, Arg.KAFKA_BOOTSTRAP_SERVERS);
 
@@ -1569,12 +1596,13 @@ public class AdminTool {
     int partitionNumber = Integer.parseInt(getRequiredArgument(cmd, Arg.KAFKA_TOPIC_PARTITION));
     int startingOffset = Integer.parseInt(getRequiredArgument(cmd, Arg.STARTING_OFFSET));
     int messageCount = Integer.parseInt(getRequiredArgument(cmd, Arg.MESSAGE_COUNT));
-    try (PubSubConsumerAdapter consumer = getConsumer(consumerProps)) {
+    try (PubSubConsumerAdapter consumer = getConsumer(consumerProps, pubSubClientsFactory)) {
       new ControlMessageDumper(consumer, kafkaTopic, partitionNumber, startingOffset, messageCount).fetch().display();
     }
   }
 
-  private static void queryKafkaTopic(CommandLine cmd) throws java.text.ParseException {
+  private static void queryKafkaTopic(CommandLine cmd, PubSubClientsFactory pubSubClientsFactory)
+      throws java.text.ParseException {
     Properties consumerProps = loadProperties(cmd, Arg.KAFKA_CONSUMER_CONFIG_FILE);
     String kafkaUrl = getRequiredArgument(cmd, Arg.KAFKA_BOOTSTRAP_SERVERS);
     consumerProps.setProperty(KAFKA_BOOTSTRAP_SERVERS, kafkaUrl);
@@ -1587,7 +1615,7 @@ public class AdminTool {
 
     SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd hh:mm:ss");
     dateFormat.setTimeZone(TimeZone.getTimeZone("America/Los_Angeles"));
-    try (PubSubConsumerAdapter consumer = getConsumer(consumerProps)) {
+    try (PubSubConsumerAdapter consumer = getConsumer(consumerProps, pubSubClientsFactory)) {
       TopicMessageFinder.find(
           controllerClient,
           consumer,
@@ -1599,7 +1627,7 @@ public class AdminTool {
     }
   }
 
-  private static void dumpKafkaTopic(CommandLine cmd) {
+  private static void dumpKafkaTopic(CommandLine cmd, PubSubClientsFactory pubSubClientsFactory) {
     Properties consumerProps = loadProperties(cmd, Arg.KAFKA_CONSUMER_CONFIG_FILE);
     String kafkaUrl = getRequiredArgument(cmd, Arg.KAFKA_BOOTSTRAP_SERVERS);
 
@@ -1630,7 +1658,7 @@ public class AdminTool {
     boolean logMetadata = cmd.hasOption(Arg.LOG_METADATA.toString());
     boolean logDataRecord = cmd.hasOption(Arg.LOG_DATA_RECORD.toString());
     boolean logRmdRecord = cmd.hasOption(Arg.LOG_RMD_RECORD.toString());
-    try (PubSubConsumerAdapter consumer = getConsumer(consumerProps)) {
+    try (PubSubConsumerAdapter consumer = getConsumer(consumerProps, pubSubClientsFactory)) {
       try (KafkaTopicDumper ktd = new KafkaTopicDumper(
           controllerClient,
           consumer,
@@ -3263,12 +3291,14 @@ public class AdminTool {
     }
   }
 
-  private static PubSubConsumerAdapter getConsumer(Properties consumerProps) {
+  private static PubSubConsumerAdapter getConsumer(
+      Properties consumerProps,
+      PubSubClientsFactory pubSubClientsFactory) {
     PubSubMessageDeserializer pubSubMessageDeserializer = new PubSubMessageDeserializer(
         new OptimizedKafkaValueSerializer(),
         new LandFillObjectPool<>(KafkaMessageEnvelope::new),
         new LandFillObjectPool<>(KafkaMessageEnvelope::new));
-    return PUB_SUB_CLIENTS_FACTORY.getConsumerAdapterFactory()
+    return pubSubClientsFactory.getConsumerAdapterFactory()
         .create(new VeniceProperties(consumerProps), false, pubSubMessageDeserializer, "admin-tool-topic-dumper");
   }
 


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Summary, imperative, start upper case, don't end with a period
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Previously, admin tool only supports apache kafka clients, even it have used `PubSubClientsFactory`. In this change, we let admin tool read from system property to generate a specific implementation of `PubSubClientsFactory`, this will enable admin tool to adopt any implementation of  `PubSubClientsFactory`.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [*] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.