### PR TITLE
[all] Create producer factory based on the runtime configuration

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
@@ -38,9 +38,6 @@ import static com.linkedin.venice.ConfigKeys.OFFSET_LAG_DELTA_RELAX_FACTOR_FOR_F
 import static com.linkedin.venice.ConfigKeys.PARTICIPANT_MESSAGE_CONSUMPTION_DELAY_MS;
 import static com.linkedin.venice.ConfigKeys.PUBSUB_TOPIC_MANAGER_METADATA_FETCHER_CONSUMER_POOL_SIZE;
 import static com.linkedin.venice.ConfigKeys.PUBSUB_TOPIC_MANAGER_METADATA_FETCHER_THREAD_POOL_SIZE;
-import static com.linkedin.venice.ConfigKeys.PUB_SUB_ADMIN_ADAPTER_FACTORY_CLASS;
-import static com.linkedin.venice.ConfigKeys.PUB_SUB_CONSUMER_ADAPTER_FACTORY_CLASS;
-import static com.linkedin.venice.ConfigKeys.PUB_SUB_PRODUCER_ADAPTER_FACTORY_CLASS;
 import static com.linkedin.venice.ConfigKeys.ROUTER_PRINCIPAL_NAME;
 import static com.linkedin.venice.ConfigKeys.SERVER_BLOCKING_QUEUE_TYPE;
 import static com.linkedin.venice.ConfigKeys.SERVER_COMPUTE_FAST_AVRO_ENABLED;
@@ -142,14 +139,8 @@ import com.linkedin.davinci.validation.KafkaDataIntegrityValidator;
 import com.linkedin.venice.exceptions.ConfigurationException;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.meta.IngestionMode;
-import com.linkedin.venice.pubsub.PubSubAdminAdapterFactory;
 import com.linkedin.venice.pubsub.PubSubClientsFactory;
-import com.linkedin.venice.pubsub.PubSubConsumerAdapterFactory;
-import com.linkedin.venice.pubsub.PubSubProducerAdapterFactory;
 import com.linkedin.venice.pubsub.adapter.kafka.admin.ApacheKafkaAdminAdapter;
-import com.linkedin.venice.pubsub.adapter.kafka.admin.ApacheKafkaAdminAdapterFactory;
-import com.linkedin.venice.pubsub.adapter.kafka.consumer.ApacheKafkaConsumerAdapterFactory;
-import com.linkedin.venice.pubsub.adapter.kafka.producer.ApacheKafkaProducerAdapterFactory;
 import com.linkedin.venice.utils.Time;
 import com.linkedin.venice.utils.Utils;
 import com.linkedin.venice.utils.VeniceProperties;
@@ -731,29 +722,9 @@ public class VeniceServerConfig extends VeniceClusterConfig {
       ingestionMemoryLimitStoreSet = Collections.emptySet();
     }
 
-    this.divProducerStateMaxAgeMs =
+    divProducerStateMaxAgeMs =
         serverProperties.getLong(DIV_PRODUCER_STATE_MAX_AGE_MS, KafkaDataIntegrityValidator.DISABLED);
-    try {
-      String producerFactoryClassName = serverProperties
-          .getString(PUB_SUB_PRODUCER_ADAPTER_FACTORY_CLASS, ApacheKafkaProducerAdapterFactory.class.getName());
-      PubSubProducerAdapterFactory pubSubProducerAdapterFactory =
-          (PubSubProducerAdapterFactory) Class.forName(producerFactoryClassName).newInstance();
-      String consumerFactoryClassName = serverProperties
-          .getString(PUB_SUB_CONSUMER_ADAPTER_FACTORY_CLASS, ApacheKafkaConsumerAdapterFactory.class.getName());
-      PubSubConsumerAdapterFactory pubSubConsumerAdapterFactory =
-          (PubSubConsumerAdapterFactory) Class.forName(consumerFactoryClassName).newInstance();
-      String adminFactoryClassName = serverProperties
-          .getString(PUB_SUB_ADMIN_ADAPTER_FACTORY_CLASS, ApacheKafkaAdminAdapterFactory.class.getName());
-      PubSubAdminAdapterFactory pubSubAdminAdapterFactory =
-          (PubSubAdminAdapterFactory) Class.forName(adminFactoryClassName).newInstance();
-      pubSubClientsFactory = new PubSubClientsFactory(
-          pubSubProducerAdapterFactory,
-          pubSubConsumerAdapterFactory,
-          pubSubAdminAdapterFactory);
-    } catch (ClassNotFoundException | IllegalAccessException | InstantiationException e) {
-      LOGGER.error("Failed to create an instance of pub sub clients factory", e);
-      throw new VeniceException(e);
-    }
+    pubSubClientsFactory = new PubSubClientsFactory(serverProperties);
     routerPrincipalName = serverProperties.getString(ROUTER_PRINCIPAL_NAME, "CN=venice-router");
     ingestionTaskMaxIdleCount = serverProperties.getInt(SERVER_INGESTION_TASK_MAX_IDLE_COUNT, 10000);
     metaStoreWriterCloseTimeoutInMS = serverProperties.getLong(META_STORE_WRITER_CLOSE_TIMEOUT_MS, 300000L);

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/view/ChangeCaptureViewWriter.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/view/ChangeCaptureViewWriter.java
@@ -57,7 +57,6 @@ public class ChangeCaptureViewWriter extends VeniceViewWriter {
     kafkaClusterUrlToIdMap = props.getVeniceServerConfig().getKafkaClusterUrlToIdMap();
     pubSubProducerAdapterFactory = props.getVeniceServerConfig().getPubSubClientsFactory().getProducerAdapterFactory();
     maxColoIdValue = kafkaClusterUrlToIdMap.values().stream().max(Integer::compareTo).orElse(-1);
-
   }
 
   @Override

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/AdminTool.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/AdminTool.java
@@ -2,9 +2,6 @@ package com.linkedin.venice;
 
 import static com.linkedin.venice.CommonConfigKeys.SSL_FACTORY_CLASS_NAME;
 import static com.linkedin.venice.ConfigKeys.KAFKA_BOOTSTRAP_SERVERS;
-import static com.linkedin.venice.ConfigKeys.PUB_SUB_ADMIN_ADAPTER_FACTORY_CLASS;
-import static com.linkedin.venice.ConfigKeys.PUB_SUB_CONSUMER_ADAPTER_FACTORY_CLASS;
-import static com.linkedin.venice.ConfigKeys.PUB_SUB_PRODUCER_ADAPTER_FACTORY_CLASS;
 import static com.linkedin.venice.VeniceConstants.DEFAULT_SSL_FACTORY_CLASS_NAME;
 import static com.linkedin.venice.schema.AvroSchemaParseUtils.parseSchemaFromJSONLooseValidation;
 import static com.linkedin.venice.serialization.avro.AvroProtocolDefinition.SERVER_ADMIN_RESPONSE;
@@ -90,14 +87,8 @@ import com.linkedin.venice.meta.StoreInfo;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.meta.VersionStatus;
 import com.linkedin.venice.metadata.response.MetadataResponseRecord;
-import com.linkedin.venice.pubsub.PubSubAdminAdapterFactory;
 import com.linkedin.venice.pubsub.PubSubClientsFactory;
-import com.linkedin.venice.pubsub.PubSubConsumerAdapterFactory;
-import com.linkedin.venice.pubsub.PubSubProducerAdapterFactory;
 import com.linkedin.venice.pubsub.PubSubTopicRepository;
-import com.linkedin.venice.pubsub.adapter.kafka.admin.ApacheKafkaAdminAdapterFactory;
-import com.linkedin.venice.pubsub.adapter.kafka.consumer.ApacheKafkaConsumerAdapterFactory;
-import com.linkedin.venice.pubsub.adapter.kafka.producer.ApacheKafkaProducerAdapterFactory;
 import com.linkedin.venice.pubsub.api.PubSubConsumerAdapter;
 import com.linkedin.venice.pubsub.api.PubSubMessageDeserializer;
 import com.linkedin.venice.pubsub.api.exceptions.PubSubOpTimeoutException;
@@ -196,32 +187,8 @@ public class AdminTool {
 
   public static void main(String args[]) throws Exception {
     // Generate PubSubClientsFactory from java system properties, apache kafka adapter is the default one.
-    PubSubClientsFactory pubSubClientsFactory;
-    try {
-      String producerFactoryClassName =
-          System.getProperty(PUB_SUB_PRODUCER_ADAPTER_FACTORY_CLASS, ApacheKafkaProducerAdapterFactory.class.getName());
-      PubSubProducerAdapterFactory pubSubProducerAdapterFactory =
-          (PubSubProducerAdapterFactory) Class.forName(producerFactoryClassName).newInstance();
-      String consumerFactoryClassName =
-          System.getProperty(PUB_SUB_CONSUMER_ADAPTER_FACTORY_CLASS, ApacheKafkaConsumerAdapterFactory.class.getName());
-      PubSubConsumerAdapterFactory pubSubConsumerAdapterFactory =
-          (PubSubConsumerAdapterFactory) Class.forName(consumerFactoryClassName).newInstance();
-      String adminFactoryClassName =
-          System.getProperty(PUB_SUB_ADMIN_ADAPTER_FACTORY_CLASS, ApacheKafkaAdminAdapterFactory.class.getName());
-
-      PubSubAdminAdapterFactory pubSubAdminAdapterFactory =
-          (PubSubAdminAdapterFactory) Class.forName(adminFactoryClassName).newInstance();
-      pubSubClientsFactory = new PubSubClientsFactory(
-          pubSubProducerAdapterFactory,
-          pubSubConsumerAdapterFactory,
-          pubSubAdminAdapterFactory);
-    } catch (ClassNotFoundException | IllegalAccessException | InstantiationException e) {
-      System.out.println("Failed to create an instance of pub sub clients factory with exception: " + e);
-      throw new VeniceException(e);
-    }
-
+    PubSubClientsFactory pubSubClientsFactory = new PubSubClientsFactory(new VeniceProperties(System.getProperties()));
     CommandLine cmd = getCommandLine(args);
-
     try {
       Command foundCommand = ensureOnlyOneCommand(cmd);
 

--- a/clients/venice-producer/src/main/java/com/linkedin/venice/producer/AbstractVeniceProducer.java
+++ b/clients/venice-producer/src/main/java/com/linkedin/venice/producer/AbstractVeniceProducer.java
@@ -9,7 +9,6 @@ import static com.linkedin.venice.writer.VeniceWriter.APP_DEFAULT_LOGICAL_TS;
 import com.linkedin.venice.controllerapi.VersionCreationResponse;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.partitioner.VenicePartitioner;
-import com.linkedin.venice.pubsub.adapter.kafka.producer.ApacheKafkaProducerAdapterFactory;
 import com.linkedin.venice.pubsub.api.PubSubProduceResult;
 import com.linkedin.venice.pubsub.api.PubSubProducerCallback;
 import com.linkedin.venice.schema.SchemaData;
@@ -145,8 +144,7 @@ public abstract class AbstractVeniceProducer<K, V> implements VeniceProducer<K, 
   protected VeniceWriter<byte[], byte[], byte[]> constructVeniceWriter(
       Properties properties,
       VeniceWriterOptions writerOptions) {
-    return new VeniceWriterFactory(properties, new ApacheKafkaProducerAdapterFactory(), null)
-        .createVeniceWriter(writerOptions);
+    return new VeniceWriterFactory(properties).createVeniceWriter(writerOptions);
   }
 
   protected RecordSerializer<Object> getSerializer(Schema schema) {

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
@@ -131,7 +131,6 @@ import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.partitioner.DefaultVenicePartitioner;
 import com.linkedin.venice.partitioner.VenicePartitioner;
-import com.linkedin.venice.pubsub.adapter.kafka.producer.ApacheKafkaProducerAdapterFactory;
 import com.linkedin.venice.pushmonitor.ExecutionStatus;
 import com.linkedin.venice.schema.AvroSchemaParseUtils;
 import com.linkedin.venice.schema.writecompute.WriteComputeOperation;
@@ -2273,10 +2272,7 @@ public class VenicePushJob implements AutoCloseable {
   private synchronized VeniceWriter<KafkaKey, byte[], byte[]> getVeniceWriter(PushJobSetting pushJobSetting) {
     if (veniceWriter == null) {
       // Initialize VeniceWriter, TODO: passing configurable PubSubProducerAdapter
-      VeniceWriterFactory veniceWriterFactory = new VeniceWriterFactory(
-          getVeniceWriterProperties(pushJobSetting),
-          new ApacheKafkaProducerAdapterFactory(),
-          null);
+      VeniceWriterFactory veniceWriterFactory = new VeniceWriterFactory(getVeniceWriterProperties(pushJobSetting));
 
       Properties partitionerProperties = new Properties();
       partitionerProperties.putAll(pushJobSetting.partitionerParams);

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
@@ -2271,9 +2271,7 @@ public class VenicePushJob implements AutoCloseable {
 
   private synchronized VeniceWriter<KafkaKey, byte[], byte[]> getVeniceWriter(PushJobSetting pushJobSetting) {
     if (veniceWriter == null) {
-      // Initialize VeniceWriter, TODO: passing configurable PubSubProducerAdapter
       VeniceWriterFactory veniceWriterFactory = new VeniceWriterFactory(getVeniceWriterProperties(pushJobSetting));
-
       Properties partitionerProperties = new Properties();
       partitionerProperties.putAll(pushJobSetting.partitionerParams);
       VenicePartitioner partitioner = PartitionUtils.getVenicePartitioner(

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/heartbeat/DefaultPushJobHeartbeatSenderFactory.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/heartbeat/DefaultPushJobHeartbeatSenderFactory.java
@@ -15,7 +15,6 @@ import com.linkedin.venice.meta.PartitionerConfig;
 import com.linkedin.venice.meta.StoreInfo;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.partitioner.VenicePartitioner;
-import com.linkedin.venice.pubsub.adapter.kafka.producer.ApacheKafkaProducerAdapterFactory;
 import com.linkedin.venice.serialization.avro.AvroProtocolDefinition;
 import com.linkedin.venice.utils.PartitionUtils;
 import com.linkedin.venice.utils.VeniceProperties;
@@ -132,10 +131,9 @@ public class DefaultPushJobHeartbeatSenderFactory implements PushJobHeartbeatSen
         partitionerConfig.getPartitionerClass(),
         partitionerConfig.getAmplificationFactor(),
         new VeniceProperties(partitionerProperties));
-    return new VeniceWriterFactory(veniceWriterProperties, new ApacheKafkaProducerAdapterFactory(), null)
-        .createVeniceWriter(
-            new VeniceWriterOptions.Builder(heartbeatKafkaTopicName).setPartitioner(venicePartitioner)
-                .setPartitionCount(partitionNum)
-                .build());
+    return new VeniceWriterFactory(veniceWriterProperties).createVeniceWriter(
+        new VeniceWriterOptions.Builder(heartbeatKafkaTopicName).setPartitioner(venicePartitioner)
+            .setPartitionCount(partitionNum)
+            .build());
   }
 }

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/task/datawriter/AbstractPartitionWriter.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/task/datawriter/AbstractPartitionWriter.java
@@ -27,7 +27,6 @@ import com.linkedin.venice.hadoop.input.recordreader.vson.VeniceVsonRecordReader
 import com.linkedin.venice.hadoop.task.TaskTracker;
 import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.partitioner.VenicePartitioner;
-import com.linkedin.venice.pubsub.adapter.kafka.producer.ApacheKafkaProducerAdapterFactory;
 import com.linkedin.venice.pubsub.api.PubSubProduceResult;
 import com.linkedin.venice.pubsub.api.PubSubProducerCallback;
 import com.linkedin.venice.serialization.DefaultSerializer;
@@ -353,9 +352,7 @@ public abstract class AbstractPartitionWriter extends AbstractDataWriterTask imp
     writerProps.put(GuidUtils.GUID_GENERATOR_IMPLEMENTATION, GuidUtils.DETERMINISTIC_GUID_GENERATOR_IMPLEMENTATION);
     writerProps.put(PUSH_JOB_GUID_MOST_SIGNIFICANT_BITS, jobProps.getProperty(PUSH_JOB_GUID_MOST_SIGNIFICANT_BITS));
     writerProps.put(PUSH_JOB_GUID_LEAST_SIGNIFICANT_BITS, jobProps.getProperty(PUSH_JOB_GUID_LEAST_SIGNIFICANT_BITS));
-
-    VeniceWriterFactory veniceWriterFactoryFactory =
-        new VeniceWriterFactory(writerProps, new ApacheKafkaProducerAdapterFactory(), null);
+    VeniceWriterFactory veniceWriterFactoryFactory = new VeniceWriterFactory(writerProps);
     boolean chunkingEnabled = props.getBoolean(VeniceWriter.ENABLE_CHUNKING, false);
     boolean rmdChunkingEnabled = props.getBoolean(VeniceWriter.ENABLE_RMD_CHUNKING, false);
     VenicePartitioner partitioner = PartitionUtils.getVenicePartitioner(props);

--- a/clients/venice-samza/src/main/java/com/linkedin/venice/samza/VeniceSystemProducer.java
+++ b/clients/venice-samza/src/main/java/com/linkedin/venice/samza/VeniceSystemProducer.java
@@ -26,7 +26,6 @@ import com.linkedin.venice.controllerapi.VersionCreationResponse;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.partitioner.VenicePartitioner;
-import com.linkedin.venice.pubsub.adapter.kafka.producer.ApacheKafkaProducerAdapterFactory;
 import com.linkedin.venice.pubsub.api.PubSubProducerCallback;
 import com.linkedin.venice.pushmonitor.ExecutionStatus;
 import com.linkedin.venice.pushmonitor.HybridStoreQuotaStatus;
@@ -410,8 +409,7 @@ public class VeniceSystemProducer implements SystemProducer, Closeable {
     Properties finalWriterConfigs = new Properties();
     finalWriterConfigs.putAll(properties);
     finalWriterConfigs.putAll(additionalWriterConfigs);
-    return new VeniceWriterFactory(finalWriterConfigs, new ApacheKafkaProducerAdapterFactory(), null)
-        .createVeniceWriter(writerOptions);
+    return new VeniceWriterFactory(finalWriterConfigs).createVeniceWriter(writerOptions);
   }
 
   @Override

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/PubSubClientsFactory.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/PubSubClientsFactory.java
@@ -1,11 +1,34 @@
 package com.linkedin.venice.pubsub;
 
+import static com.linkedin.venice.ConfigKeys.PUB_SUB_ADMIN_ADAPTER_FACTORY_CLASS;
+import static com.linkedin.venice.ConfigKeys.PUB_SUB_CONSUMER_ADAPTER_FACTORY_CLASS;
+import static com.linkedin.venice.ConfigKeys.PUB_SUB_PRODUCER_ADAPTER_FACTORY_CLASS;
+
+import com.linkedin.venice.exceptions.VeniceException;
+import com.linkedin.venice.pubsub.adapter.kafka.admin.ApacheKafkaAdminAdapterFactory;
+import com.linkedin.venice.pubsub.adapter.kafka.consumer.ApacheKafkaConsumerAdapterFactory;
+import com.linkedin.venice.pubsub.adapter.kafka.producer.ApacheKafkaProducerAdapterFactory;
+import com.linkedin.venice.pubsub.api.PubSubAdminAdapter;
+import com.linkedin.venice.pubsub.api.PubSubConsumerAdapter;
+import com.linkedin.venice.pubsub.api.PubSubProducerAdapter;
+import com.linkedin.venice.utils.VeniceProperties;
+import java.util.Properties;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+
 /**
  * A wrapper around pub-sub producer, consumer, and admin adapter factories
  *
  * This will be passed as one of the arguments to the component which depends on the pub-sub APIs.
  */
 public class PubSubClientsFactory {
+  private static final Logger LOGGER = LogManager.getLogger(PubSubClientsFactory.class);
+
+  private enum FactoryType {
+    PRODUCER, CONSUMER, ADMIN
+  }
+
   private final PubSubProducerAdapterFactory producerAdapterFactory;
   private final PubSubConsumerAdapterFactory consumerAdapterFactory;
   private final PubSubAdminAdapterFactory adminAdapterFactory;
@@ -19,6 +42,10 @@ public class PubSubClientsFactory {
     this.adminAdapterFactory = adminAdapterFactory;
   }
 
+  public PubSubClientsFactory(VeniceProperties properties) {
+    this(createProducerFactory(properties), createConsumerFactory(properties), createAdminFactory(properties));
+  }
+
   public PubSubProducerAdapterFactory getProducerAdapterFactory() {
     return producerAdapterFactory;
   }
@@ -29,5 +56,61 @@ public class PubSubClientsFactory {
 
   public PubSubAdminAdapterFactory getAdminAdapterFactory() {
     return adminAdapterFactory;
+  }
+
+  public static PubSubProducerAdapterFactory<PubSubProducerAdapter> createProducerFactory(Properties properties) {
+    return createProducerFactory(new VeniceProperties(properties));
+  }
+
+  public static PubSubProducerAdapterFactory<PubSubProducerAdapter> createProducerFactory(
+      VeniceProperties veniceProperties) {
+    return createFactory(
+        veniceProperties,
+        PUB_SUB_PRODUCER_ADAPTER_FACTORY_CLASS,
+        ApacheKafkaProducerAdapterFactory.class.getName(),
+        FactoryType.PRODUCER);
+  }
+
+  public static PubSubConsumerAdapterFactory<PubSubConsumerAdapter> createConsumerFactory(
+      VeniceProperties veniceProperties) {
+    return createFactory(
+        veniceProperties,
+        PUB_SUB_CONSUMER_ADAPTER_FACTORY_CLASS,
+        ApacheKafkaConsumerAdapterFactory.class.getName(),
+        FactoryType.CONSUMER);
+  }
+
+  public static PubSubAdminAdapterFactory<PubSubAdminAdapter> createAdminFactory(VeniceProperties veniceProperties) {
+    return createFactory(
+        veniceProperties,
+        PUB_SUB_ADMIN_ADAPTER_FACTORY_CLASS,
+        ApacheKafkaAdminAdapterFactory.class.getName(),
+        FactoryType.ADMIN);
+  }
+
+  private static <T> T createFactory(
+      VeniceProperties properties,
+      String configKey,
+      String defaultClassName,
+      FactoryType factoryType) {
+    String className;
+    if (properties.containsKey(configKey)) {
+      className = properties.getString(configKey);
+      LOGGER.info("Creating pub-sub {} adapter factory instance for class: {}", factoryType, className);
+    } else {
+      className = defaultClassName;
+      LOGGER.info("Creating pub-sub {} adapter factory instance with default class: {}", factoryType, className);
+    }
+
+    return createInstance(className);
+  }
+
+  public static <T> T createInstance(String className) {
+    try {
+      return (T) Class.forName(className).getDeclaredConstructor().newInstance();
+    } catch (Exception e) {
+      LOGGER.error("Failed to create instance of class: {}", className, e);
+      throw new VeniceException("Failed to create instance of class: " + className, e);
+    }
   }
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/PubSubClientsFactory.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/PubSubClientsFactory.java
@@ -109,7 +109,6 @@ public class PubSubClientsFactory {
     try {
       return (T) Class.forName(className).getDeclaredConstructor().newInstance();
     } catch (Exception e) {
-      LOGGER.error("Failed to create instance of class: {}", className, e);
       throw new VeniceException("Failed to create instance of class: " + className, e);
     }
   }

--- a/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/PubSubClientsFactoryTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/PubSubClientsFactoryTest.java
@@ -1,0 +1,69 @@
+package com.linkedin.venice.pubsub;
+
+import static com.linkedin.venice.ConfigKeys.PUB_SUB_ADMIN_ADAPTER_FACTORY_CLASS;
+import static com.linkedin.venice.ConfigKeys.PUB_SUB_CONSUMER_ADAPTER_FACTORY_CLASS;
+import static com.linkedin.venice.ConfigKeys.PUB_SUB_PRODUCER_ADAPTER_FACTORY_CLASS;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.expectThrows;
+
+import com.linkedin.venice.exceptions.VeniceException;
+import com.linkedin.venice.pubsub.adapter.kafka.admin.ApacheKafkaAdminAdapterFactory;
+import com.linkedin.venice.pubsub.adapter.kafka.consumer.ApacheKafkaConsumerAdapterFactory;
+import com.linkedin.venice.pubsub.adapter.kafka.producer.ApacheKafkaProducerAdapterFactory;
+import com.linkedin.venice.utils.VeniceProperties;
+import java.util.Properties;
+import org.testng.annotations.Test;
+
+
+public class PubSubClientsFactoryTest {
+  @Test
+  public void testCreateInstanceSuccess() {
+    // default
+    VeniceProperties veniceProps = new VeniceProperties(new Properties());
+    PubSubClientsFactory factory = new PubSubClientsFactory(veniceProps);
+
+    PubSubProducerAdapterFactory producerFactory = factory.getProducerAdapterFactory();
+    assertNotNull(producerFactory);
+    assertEquals(producerFactory.getClass().getName(), ApacheKafkaProducerAdapterFactory.class.getName());
+
+    PubSubConsumerAdapterFactory consumerFactory = factory.getConsumerAdapterFactory();
+    assertNotNull(consumerFactory);
+    assertEquals(consumerFactory.getClass().getName(), ApacheKafkaConsumerAdapterFactory.class.getName());
+
+    PubSubAdminAdapterFactory adminFactory = factory.getAdminAdapterFactory();
+    assertNotNull(adminFactory);
+    assertEquals(adminFactory.getClass().getName(), ApacheKafkaAdminAdapterFactory.class.getName());
+
+    // with factory class name
+    Properties properties = new Properties();
+    properties.put(PUB_SUB_PRODUCER_ADAPTER_FACTORY_CLASS, ApacheKafkaProducerAdapterFactory.class.getName());
+    properties.put(PUB_SUB_CONSUMER_ADAPTER_FACTORY_CLASS, ApacheKafkaConsumerAdapterFactory.class.getName());
+    properties.put(PUB_SUB_ADMIN_ADAPTER_FACTORY_CLASS, ApacheKafkaAdminAdapterFactory.class.getName());
+    veniceProps = new VeniceProperties(properties);
+    factory = new PubSubClientsFactory(veniceProps);
+
+    producerFactory = factory.getProducerAdapterFactory();
+    assertNotNull(producerFactory);
+    assertEquals(producerFactory.getClass().getName(), ApacheKafkaProducerAdapterFactory.class.getName());
+
+    consumerFactory = factory.getConsumerAdapterFactory();
+    assertNotNull(consumerFactory);
+    assertEquals(consumerFactory.getClass().getName(), ApacheKafkaConsumerAdapterFactory.class.getName());
+
+    adminFactory = factory.getAdminAdapterFactory();
+    assertNotNull(adminFactory);
+    assertEquals(adminFactory.getClass().getName(), ApacheKafkaAdminAdapterFactory.class.getName());
+  }
+
+  @Test
+  public void testCreateInstanceFailure() {
+    String className = "com.example.bogus.NonExistentClass";
+    Properties properties = new Properties();
+    properties.put(PUB_SUB_PRODUCER_ADAPTER_FACTORY_CLASS, className);
+    Throwable t = expectThrows(
+        VeniceException.class,
+        () -> PubSubClientsFactory.createProducerFactory(new VeniceProperties(properties)));
+    assertEquals(t.getMessage(), "Failed to create instance of class: " + className);
+  }
+}

--- a/internal/venice-common/src/test/java/com/linkedin/venice/writer/VeniceWriterFactoryTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/writer/VeniceWriterFactoryTest.java
@@ -8,6 +8,7 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 
 import com.linkedin.venice.pubsub.PubSubProducerAdapterFactory;
+import com.linkedin.venice.pubsub.adapter.kafka.producer.ApacheKafkaProducerAdapterFactory;
 import com.linkedin.venice.pubsub.api.PubSubProducerAdapter;
 import com.linkedin.venice.utils.VeniceProperties;
 import java.util.Properties;
@@ -34,5 +35,23 @@ public class VeniceWriterFactoryTest {
     String capturedBrokerAddr = veniceWriter.getDestination();
     assertNotNull(capturedBrokerAddr);
     assertEquals(capturedBrokerAddr, "store_v1@kafka:9898");
+  }
+
+  @Test
+  public void testVeniceWriterFactoryCreatesProducerAdapterFactory() {
+    VeniceWriterFactory veniceWriterFactory = new VeniceWriterFactory(new Properties(), null, null);
+    assertNotNull(veniceWriterFactory.getProducerAdapterFactory());
+
+    veniceWriterFactory = new VeniceWriterFactory(new Properties(), null);
+    assertNotNull(veniceWriterFactory.getProducerAdapterFactory());
+    assertEquals(veniceWriterFactory.getProducerAdapterFactory().getClass(), ApacheKafkaProducerAdapterFactory.class);
+
+    veniceWriterFactory = new VeniceWriterFactory(new Properties());
+    assertNotNull(veniceWriterFactory.getProducerAdapterFactory());
+    assertEquals(veniceWriterFactory.getProducerAdapterFactory().getClass(), ApacheKafkaProducerAdapterFactory.class);
+
+    veniceWriterFactory = new VeniceWriterFactory(new Properties(), new ApacheKafkaProducerAdapterFactory(), null);
+    assertNotNull(veniceWriterFactory.getProducerAdapterFactory());
+    assertEquals(veniceWriterFactory.getProducerAdapterFactory().getClass(), ApacheKafkaProducerAdapterFactory.class);
   }
 }


### PR DESCRIPTION
##  Create producer factory based on the runtime configuration 

This change removes hardcoded references to ApacheKafkaProducerAdapterFactory and
 introduces dynamic creation of pub-sub client factories based on runtime configurations.  
 



## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.