### PR TITLE
[fast-client] Long tail retry budget for fast client

### DIFF
--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/ClientConfig.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/ClientConfig.java
@@ -452,7 +452,7 @@ public class ClientConfig<K, V, T extends SpecificRecord> {
 
     private boolean projectionFieldValidation = true;
 
-    private long longTailRetryBudgetEnforcementWindowInMs = 300000; // 5 minutes
+    private long longTailRetryBudgetEnforcementWindowInMs = 60000; // 1 minute
 
     public ClientConfigBuilder<K, V, T> setStoreName(String storeName) {
       this.storeName = storeName;

--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/ClientConfig.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/ClientConfig.java
@@ -85,9 +85,9 @@ public class ClientConfig<K, V, T extends SpecificRecord> {
    */
   private final GrpcClientConfig grpcClientConfig;
   /**
-   * The time window used to calculate user traffic and corresponding long tail retry budget. The default value is 5
-   * minutes. Meaning it will use the average request occurrence rate over the 5 minutes to calculate the corresponding
-   * retry budget for the next 5 minutes and so on.
+   * The time window used to calculate user traffic and corresponding long tail retry budget. The default value is one
+   * minute. Meaning it will use the average request occurrence rate over the one minute to calculate the corresponding
+   * retry budget for the next minute and so on.
    */
   private final long longTailRetryBudgetEnforcementWindowInMs;
 

--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/RetriableAvroGenericStoreClient.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/RetriableAvroGenericStoreClient.java
@@ -9,7 +9,6 @@ import com.linkedin.venice.client.store.streaming.StreamingCallback;
 import com.linkedin.venice.compute.ComputeRequestWrapper;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.fastclient.meta.RetryManager;
-import com.linkedin.venice.fastclient.stats.RetryManagerStats;
 import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
 import java.util.Collections;
 import java.util.Optional;
@@ -41,15 +40,16 @@ public class RetriableAvroGenericStoreClient<K, V> extends DelegatingAvroStoreCl
   private final TimeoutProcessor timeoutProcessor;
   /**
    * The long tail retry budget is only applied to long tail retries. If there were any exception that's not a 429 the
-   * retry will be triggered without going through the long tail {@link RetryManager}. If the retry budget is t
+   * retry will be triggered without going through the long tail {@link RetryManager}. If the retry budget is exhausted
    * then the retry task will do nothing and the request will either complete eventually (original future) or time out.
    */
-  private final RetryManager longTailRetryManager;
-  private final RetryManagerStats retryManagerStats;
+  private RetryManager singleGetLongTailRetryManager = null;
+  private RetryManager multiGetLongTailRetryManager = null;
   private static final Logger LOGGER = LogManager.getLogger(RetriableAvroGenericStoreClient.class);
   // Default value of 0.1 meaning only 10 percent of the user requests are allowed to trigger long tail retry
   private static final double LONG_TAIL_RETRY_BUDGET_PERCENT_DECIMAL = 0.1d;
-  private static final String LONG_TAIL_RETRY_STATS_PREFIX = "long-tail-retry-manager";
+  private static final String SINGLE_GET_LONG_TAIL_RETRY_STATS_PREFIX = "single-get-long-tail-retry-manager";
+  private static final String MULTI_GET_LONG_TAIL_RETRY_STATS_PREFIX = "multi-get-long-tail-retry-manager";
 
   public RetriableAvroGenericStoreClient(
       InternalAvroStoreClient<K, V> delegate,
@@ -70,13 +70,20 @@ public class RetriableAvroGenericStoreClient<K, V> extends DelegatingAvroStoreCl
     this.longTailRetryThresholdForComputeInMicroSeconds =
         clientConfig.getLongTailRetryThresholdForComputeInMicroSeconds();
     this.timeoutProcessor = timeoutProcessor;
-    this.longTailRetryManager = new RetryManager(
-        clientConfig.getLongTailRetryBudgetEnforcementWindowInMs(),
-        LONG_TAIL_RETRY_BUDGET_PERCENT_DECIMAL);
-    this.retryManagerStats = new RetryManagerStats(
-        clientConfig.getClusterStats().getMetricsRepository(),
-        LONG_TAIL_RETRY_STATS_PREFIX,
-        longTailRetryManager);
+    if (longTailRetryEnabledForSingleGet) {
+      this.singleGetLongTailRetryManager = new RetryManager(
+          clientConfig.getClusterStats().getMetricsRepository(),
+          SINGLE_GET_LONG_TAIL_RETRY_STATS_PREFIX,
+          clientConfig.getLongTailRetryBudgetEnforcementWindowInMs(),
+          LONG_TAIL_RETRY_BUDGET_PERCENT_DECIMAL);
+    }
+    if (longTailRetryEnabledForBatchGet) {
+      this.multiGetLongTailRetryManager = new RetryManager(
+          clientConfig.getClusterStats().getMetricsRepository(),
+          MULTI_GET_LONG_TAIL_RETRY_STATS_PREFIX,
+          clientConfig.getLongTailRetryBudgetEnforcementWindowInMs(),
+          LONG_TAIL_RETRY_BUDGET_PERCENT_DECIMAL);
+    }
   }
 
   enum RetryType {
@@ -126,7 +133,7 @@ public class RetriableAvroGenericStoreClient<K, V> extends DelegatingAvroStoreCl
       // if longTailRetry is not enabled for single get, simply return the original future
       return originalRequestFuture;
     }
-    longTailRetryManager.recordRequest();
+    singleGetLongTailRetryManager.recordRequest();
     final CompletableFuture<V> retryFuture = new CompletableFuture<>();
     final CompletableFuture<V> finalFuture = new CompletableFuture<>();
 
@@ -138,7 +145,7 @@ public class RetriableAvroGenericStoreClient<K, V> extends DelegatingAvroStoreCl
         retryFuture.completeExceptionally(savedException.get());
         return;
       }
-      if (savedException.get() != null || longTailRetryManager.isRetryAllowed()) {
+      if (savedException.get() != null || singleGetLongTailRetryManager.isRetryAllowed()) {
         super.get(requestContext, key).whenComplete((value, throwable) -> {
           if (throwable != null) {
             retryFuture.completeExceptionally(throwable);
@@ -254,8 +261,13 @@ public class RetriableAvroGenericStoreClient<K, V> extends DelegatingAvroStoreCl
 
   @Override
   public void close() {
+    if (singleGetLongTailRetryManager != null) {
+      singleGetLongTailRetryManager.close();
+    }
+    if (multiGetLongTailRetryManager != null) {
+      multiGetLongTailRetryManager.close();
+    }
     super.close();
-    longTailRetryManager.close();
   }
 
   private <R extends MultiKeyRequestContext<K, V>, RESPONSE> void retryStreamingMultiKeyRequest(
@@ -297,7 +309,7 @@ public class RetriableAvroGenericStoreClient<K, V> extends DelegatingAvroStoreCl
           finalRequestCompletionFuture.completeExceptionally(throwable);
           return;
         }
-        if (throwable != null || longTailRetryManager.isRetryAllowed()) {
+        if (throwable != null || multiGetLongTailRetryManager.isRetryAllowed()) {
           Set<K> pendingKeys = Collections.unmodifiableSet(pendingKeysFuture.keySet());
           R retryRequestContext =
               requestContextConstructor.construct(pendingKeys.size(), requestContext.isPartialSuccessAllowed);
@@ -345,7 +357,7 @@ public class RetriableAvroGenericStoreClient<K, V> extends DelegatingAvroStoreCl
             savedException,
             pendingKeysFuture,
             scheduledRetryTask));
-    longTailRetryManager.recordRequest();
+    multiGetLongTailRetryManager.recordRequest();
 
     finalRequestCompletionFuture.whenComplete((ignore, finalException) -> {
       if (!scheduledRetryTask.isDone()) {

--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/meta/RetryManager.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/meta/RetryManager.java
@@ -34,7 +34,7 @@ public class RetryManager implements Closeable {
   private final AtomicReference<TokenBucket> retryTokenBucket = new AtomicReference<>(null);
   private final ScheduledExecutorService scheduler;
   private final Clock clock;
-  RetryManagerStats retryManagerStats;
+  private RetryManagerStats retryManagerStats;
   private long lastUpdateTimestamp;
   private long previousQPS = 0;
 

--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/meta/RetryManager.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/meta/RetryManager.java
@@ -108,24 +108,14 @@ public class RetryManager implements Closeable {
     }
   }
 
-  /**
-   * Used for testing only
-   */
-  protected TokenBucket getRetryTokenBucket() {
+  public TokenBucket getRetryTokenBucket() {
     return retryTokenBucket.get();
   }
 
   @Override
   public void close() {
     if (scheduler != null) {
-      scheduler.shutdown();
-      try {
-        if (!scheduler.awaitTermination(60, TimeUnit.SECONDS)) {
-          scheduler.shutdownNow();
-        }
-      } catch (InterruptedException e) {
-        Thread.currentThread().interrupt();
-      }
+      scheduler.shutdownNow();
     }
   }
 }

--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/meta/RetryManager.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/meta/RetryManager.java
@@ -1,0 +1,131 @@
+package com.linkedin.venice.fastclient.meta;
+
+import com.linkedin.venice.throttle.TokenBucket;
+import java.io.Closeable;
+import java.time.Clock;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+
+/**
+ * This class offers advanced client retry behaviors. Specifically enforcing a retry budget and relevant monitoring to
+ * avoid retry storm and alert users when the retry threshold is misconfigured or service is degrading.
+ */
+public class RetryManager implements Closeable {
+  private static final Logger LOGGER = LogManager.getLogger(RetryManager.class);
+  private static final int TOKEN_BUCKET_REFILL_INTERVAL_IN_SECONDS = 1;
+  private static final int TOKEN_BUCKET_CAPACITY_MULTIPLE = 5;
+  private final AtomicBoolean retryBudgetEnabled = new AtomicBoolean();
+  private final long enforcementWindowInMs;
+  private final double retryBudgetInPercentDecimal;
+  private final AtomicLong requestCount = new AtomicLong();
+  private final AtomicReference<TokenBucket> retryTokenBucket = new AtomicReference<>(null);
+  private final ScheduledExecutorService scheduler;
+  private final Clock clock;
+
+  private long lastUpdateTimestamp;
+  private long previousQPS = 0;
+
+  public RetryManager(long enforcementWindowInMs, double retryBudgetInPercentDecimal, Clock clock) {
+    if (enforcementWindowInMs <= 0 || retryBudgetInPercentDecimal <= 0) {
+      scheduler = null;
+      retryBudgetEnabled.set(false);
+    } else {
+      scheduler = Executors.newScheduledThreadPool(1);
+      retryBudgetEnabled.set(true);
+      lastUpdateTimestamp = clock.millis();
+      scheduler.schedule(this::updateRetryTokenBucket, enforcementWindowInMs, TimeUnit.MILLISECONDS);
+    }
+    this.enforcementWindowInMs = enforcementWindowInMs;
+    this.retryBudgetInPercentDecimal = retryBudgetInPercentDecimal;
+    this.clock = clock;
+  }
+
+  public RetryManager(long enforcementWindowInMs, double retryBudgetInPercentDecimal) {
+    this(enforcementWindowInMs, retryBudgetInPercentDecimal, Clock.systemUTC());
+  }
+
+  public void recordRequest() {
+    if (retryBudgetEnabled.get()) {
+      requestCount.incrementAndGet();
+    }
+  }
+
+  public boolean isRetryAllowed() {
+    if (!retryBudgetEnabled.get() || retryTokenBucket.get() == null) {
+      // All retries are allowed when the feature is disabled or during the very first enforcement window when we
+      // haven't collected enough data points yet
+      return true;
+    }
+    return retryTokenBucket.get().tryConsume(1);
+  }
+
+  private void updateRetryTokenBucket() {
+    if (retryBudgetEnabled.get() && requestCount.get() > 0) {
+      try {
+        long elapsedTimeInMs = clock.millis() - lastUpdateTimestamp;
+        long requestCountSinceLastUpdate = requestCount.getAndSet(0);
+        lastUpdateTimestamp = clock.millis();
+        // Minimum user request per second will be 1
+        long newQPS = (long) Math
+            .ceil((double) requestCountSinceLastUpdate / (double) TimeUnit.MILLISECONDS.toSeconds(elapsedTimeInMs));
+        if (previousQPS > 0) {
+          long difference = Math.abs(previousQPS - newQPS);
+          double differenceInPercentDecimal = (double) difference / (double) previousQPS;
+          if (differenceInPercentDecimal > 0.1) {
+            // Only update the retry token bucket if the change in request per seconds is more than 10 percent
+            previousQPS = newQPS;
+            updateTokenBucket(newQPS);
+          }
+        } else {
+          previousQPS = newQPS;
+          updateTokenBucket(newQPS);
+        }
+        scheduler.schedule(this::updateRetryTokenBucket, enforcementWindowInMs, TimeUnit.MILLISECONDS);
+      } catch (Throwable e) {
+        LOGGER.warn("Caught exception when trying to update retry budget, retry budget will be disabled", e);
+        // Once disabled it will not be re-enabled until client is restarted
+        retryBudgetEnabled.set(false);
+      }
+    }
+  }
+
+  private void updateTokenBucket(long newQPS) {
+    // Retry budget QPS should be greater than or equal to 1
+    if (newQPS > 0) {
+      long newRetryBudgetQPS = (long) Math.ceil((double) newQPS * retryBudgetInPercentDecimal);
+      long refillAmount = newRetryBudgetQPS * TOKEN_BUCKET_REFILL_INTERVAL_IN_SECONDS;
+      long capacity = TOKEN_BUCKET_CAPACITY_MULTIPLE * refillAmount;
+      TokenBucket newTokenBucket =
+          new TokenBucket(capacity, refillAmount, TOKEN_BUCKET_REFILL_INTERVAL_IN_SECONDS, TimeUnit.SECONDS, clock);
+      retryTokenBucket.set(newTokenBucket);
+    }
+  }
+
+  /**
+   * Used for testing only
+   */
+  protected TokenBucket getRetryTokenBucket() {
+    return retryTokenBucket.get();
+  }
+
+  @Override
+  public void close() {
+    if (scheduler != null) {
+      scheduler.shutdown();
+      try {
+        if (!scheduler.awaitTermination(60, TimeUnit.SECONDS)) {
+          scheduler.shutdownNow();
+        }
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+      }
+    }
+  }
+}

--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/stats/RetryManagerStats.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/stats/RetryManagerStats.java
@@ -1,0 +1,34 @@
+package com.linkedin.venice.fastclient.stats;
+
+import com.linkedin.venice.fastclient.meta.RetryManager;
+import com.linkedin.venice.stats.AbstractVeniceStats;
+import com.linkedin.venice.throttle.TokenBucket;
+import io.tehuti.metrics.MetricsRepository;
+import io.tehuti.metrics.Sensor;
+import io.tehuti.metrics.stats.AsyncGauge;
+
+
+public class RetryManagerStats extends AbstractVeniceStats {
+  private final Sensor retryLimitPerSeconds;
+  private final Sensor retriesRemaining;
+
+  public RetryManagerStats(MetricsRepository metricsRepository, String name, RetryManager retryManager) {
+    super(metricsRepository, name);
+    retryLimitPerSeconds = registerSensor(new AsyncGauge((ignored, ignored2) -> {
+      TokenBucket bucket = retryManager.getRetryTokenBucket();
+      if (bucket == null) {
+        return -1;
+      } else {
+        return bucket.getAmortizedRefillPerSecond();
+      }
+    }, "retry_limit_per_seconds"));
+    retriesRemaining = registerSensor(new AsyncGauge((ignored, ignored2) -> {
+      TokenBucket bucket = retryManager.getRetryTokenBucket();
+      if (bucket == null) {
+        return -1;
+      } else {
+        return bucket.getStaleTokenCount();
+      }
+    }, "retries_remaining"));
+  }
+}

--- a/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/meta/RetryManagerTest.java
+++ b/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/meta/RetryManagerTest.java
@@ -4,6 +4,7 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 
 import com.linkedin.venice.utils.TestUtils;
+import io.tehuti.metrics.MetricsRepository;
 import java.io.IOException;
 import java.time.Clock;
 import java.util.concurrent.TimeUnit;
@@ -19,12 +20,14 @@ public class RetryManagerTest {
     Clock mockClock = mock(Clock.class);
     long start = System.currentTimeMillis();
     doReturn(start).when(mockClock).millis();
-    RetryManager retryManager = new RetryManager(0, 0.1d, mockClock);
+    MetricsRepository metricsRepository = new MetricsRepository();
+    RetryManager retryManager = new RetryManager(metricsRepository, "test-retry-manager", 0, 0.1d, mockClock);
     retryManager.recordRequest();
     for (int i = 0; i < 10; i++) {
       Assert.assertTrue(retryManager.isRetryAllowed());
     }
     Assert.assertNull(retryManager.getRetryTokenBucket());
+    Assert.assertNull(metricsRepository.getMetric(".test-retry-manager--retry_limit_per_seconds.Gauge"));
     retryManager.close();
   }
 
@@ -33,7 +36,8 @@ public class RetryManagerTest {
     Clock mockClock = mock(Clock.class);
     long start = System.currentTimeMillis();
     doReturn(start).when(mockClock).millis();
-    try (RetryManager retryManager = new RetryManager(1000, 0.1d, mockClock)) {
+    MetricsRepository metricsRepository = new MetricsRepository();
+    try (RetryManager retryManager = new RetryManager(metricsRepository, "test-retry-manager", 1000, 0.1d, mockClock)) {
       doReturn(start + 1000).when(mockClock).millis();
       for (int i = 0; i < 50; i++) {
         retryManager.recordRequest();
@@ -44,10 +48,15 @@ public class RetryManagerTest {
           () -> Assert.assertNotNull(retryManager.getRetryTokenBucket()));
       // The retry budget should be set to 50 * 0.1 = 5
       // With refill interval of 1s and capacity multiple of 5 that makes the token bucket capacity of 25
+      Assert
+          .assertEquals(metricsRepository.getMetric(".test-retry-manager--retry_limit_per_seconds.Gauge").value(), 5d);
+      Assert.assertEquals(metricsRepository.getMetric(".test-retry-manager--retries_remaining.Gauge").value(), 25d);
       for (int i = 0; i < 25; i++) {
         Assert.assertTrue(retryManager.isRetryAllowed());
       }
       Assert.assertFalse(retryManager.isRetryAllowed());
+      Assert.assertEquals(metricsRepository.getMetric(".test-retry-manager--retries_remaining.Gauge").value(), 0d);
+      Assert.assertTrue(metricsRepository.getMetric(".test-retry-manager--rejected_retry.OccurrenceRate").value() > 0);
       doReturn(start + 2001).when(mockClock).millis();
       // We should eventually be able to perform retries again
       TestUtils.waitForNonDeterministicAssertion(

--- a/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/meta/RetryManagerTest.java
+++ b/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/meta/RetryManagerTest.java
@@ -1,0 +1,59 @@
+package com.linkedin.venice.fastclient.meta;
+
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+import com.linkedin.venice.utils.TestUtils;
+import java.io.IOException;
+import java.time.Clock;
+import java.util.concurrent.TimeUnit;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class RetryManagerTest {
+  private static final long TEST_TIMEOUT_IN_MS = 10000;
+
+  @Test(timeOut = TEST_TIMEOUT_IN_MS)
+  public void testRetryManagerDisabled() throws IOException {
+    Clock mockClock = mock(Clock.class);
+    long start = System.currentTimeMillis();
+    doReturn(start).when(mockClock).millis();
+    RetryManager retryManager = new RetryManager(0, 0.1d, mockClock);
+    retryManager.recordRequest();
+    for (int i = 0; i < 10; i++) {
+      Assert.assertTrue(retryManager.isRetryAllowed());
+    }
+    Assert.assertNull(retryManager.getRetryTokenBucket());
+    retryManager.close();
+  }
+
+  @Test(timeOut = TEST_TIMEOUT_IN_MS)
+  public void testRetryManager() throws IOException {
+    Clock mockClock = mock(Clock.class);
+    long start = System.currentTimeMillis();
+    doReturn(start).when(mockClock).millis();
+    try (RetryManager retryManager = new RetryManager(1000, 0.1d, mockClock)) {
+      doReturn(start + 1000).when(mockClock).millis();
+      for (int i = 0; i < 50; i++) {
+        retryManager.recordRequest();
+      }
+      TestUtils.waitForNonDeterministicAssertion(
+          5,
+          TimeUnit.SECONDS,
+          () -> Assert.assertNotNull(retryManager.getRetryTokenBucket()));
+      // The retry budget should be set to 50 * 0.1 = 5
+      // With refill interval of 1s and capacity multiple of 5 that makes the token bucket capacity of 25
+      for (int i = 0; i < 25; i++) {
+        Assert.assertTrue(retryManager.isRetryAllowed());
+      }
+      Assert.assertFalse(retryManager.isRetryAllowed());
+      doReturn(start + 2001).when(mockClock).millis();
+      // We should eventually be able to perform retries again
+      TestUtils.waitForNonDeterministicAssertion(
+          5,
+          TimeUnit.SECONDS,
+          () -> Assert.assertTrue(retryManager.isRetryAllowed()));
+    }
+  }
+}

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/fastclient/FastClientIndividualFeatureConfigurationTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/fastclient/FastClientIndividualFeatureConfigurationTest.java
@@ -27,6 +27,7 @@ import com.linkedin.venice.utils.TestUtils;
 import com.linkedin.venice.writer.VeniceWriter;
 import com.linkedin.venice.writer.VeniceWriterOptions;
 import io.tehuti.metrics.MetricsRepository;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -378,5 +379,40 @@ public class FastClientIndividualFeatureConfigurationTest extends AbstractClient
     }
     assertTrue(nonZeroRequestedKeyCount);
     assertTrue(nonZeroSuccessRequestKeyCount);
+  }
+
+  @Test(timeOut = TIME_OUT)
+  public void testLongTailRetryManagerStats() throws IOException, ExecutionException, InterruptedException {
+    ClientConfig.ClientConfigBuilder clientConfigBuilder =
+        new ClientConfig.ClientConfigBuilder<>().setStoreName(storeName)
+            .setR2Client(r2Client)
+            .setLongTailRetryEnabledForBatchGet(true)
+            .setLongTailRetryThresholdForBatchGetInMicroSeconds(10000)
+            .setLongTailRetryBudgetEnforcementWindowInMs(1000)
+            .setSpeculativeQueryEnabled(false);
+    String longTailRetryManagerStatsPrefix = ".long-tail-retry-manager--";
+    MetricsRepository clientMetric = new MetricsRepository();
+    AvroGenericStoreClient<String, GenericRecord> genericFastClient =
+        getGenericFastClient(clientConfigBuilder, clientMetric, StoreMetadataFetchMode.SERVER_BASED_METADATA);
+    Set<String> keys = new HashSet<>();
+    for (int i = 0; i < recordCnt; ++i) {
+      String key = keyPrefix + i;
+      keys.add(key);
+    }
+    for (int i = 0; i < 10; i++) {
+      genericFastClient.batchGet(keys).get();
+    }
+    TestUtils.waitForNonDeterministicAssertion(
+        10,
+        TimeUnit.SECONDS,
+        () -> assertTrue(
+            clientMetric.getMetric(longTailRetryManagerStatsPrefix + "retry_limit_per_seconds.Gauge").value() > 0,
+            "Current value: "
+                + clientMetric.getMetric(longTailRetryManagerStatsPrefix + "retry_limit_per_seconds.Gauge").value()));
+    TestUtils.waitForNonDeterministicAssertion(
+        10,
+        TimeUnit.SECONDS,
+        () -> assertTrue(
+            clientMetric.getMetric(longTailRetryManagerStatsPrefix + "retries_remaining.Gauge").value() > 0));
   }
 }


### PR DESCRIPTION
## [fast-client] Long tail retry budget for fast client
1. Introduced RetryManager to measure and calculate retry budget based on a percentage of requests.

2. The RetryManager is only applied to long tail retries and currently hard coded to be 10% of the total original request rate. This means if there were any exception that's not a 429 the retry will be triggered without going through the RetryManager. If the retry budget is exhausted then the retry task will do nothing and the request will either complete eventually (original future) or time out.

## How was this PR tested?
Existing and new tests

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.