### PR TITLE
[controller] Avoid expensive call to TM::getAllTopicRetentions in TopicCleanupService

### DIFF
--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/kafka/TopicCleanupService.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/kafka/TopicCleanupService.java
@@ -278,7 +278,7 @@ public class TopicCleanupService extends AbstractVeniceService {
             continue;
           }
           String pubSubBootstrapServer = multiClusterConfigs.getChildDataCenterKafkaUrlMap().get(childFabric);
-          Set<PubSubTopic> remoteTopics = getTopicManager(pubSubBootstrapServer).getAllTopicRetentions().keySet();
+          Set<PubSubTopic> remoteTopics = getTopicManager(pubSubBootstrapServer).listTopics();
           clearAndPopulateStoreToVersionTopicCountMap(
               remoteTopics,
               multiDataCenterStoreToVersionTopicCount.get(childFabric));

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/kafka/TestTopicCleanupService.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/kafka/TestTopicCleanupService.java
@@ -200,7 +200,7 @@ public class TestTopicCleanupService {
     remoteTopics2.put(getPubSubTopic(storeName3, "_rt"), 1000L);
 
     when(topicManager.getAllTopicRetentions()).thenReturn(storeTopics).thenReturn(storeTopics2);
-    when(remoteTopicManager.getAllTopicRetentions()).thenReturn(remoteTopics).thenReturn(remoteTopics2);
+    when(remoteTopicManager.listTopics()).thenReturn(remoteTopics.keySet()).thenReturn(remoteTopics2.keySet());
     doReturn(false).when(admin).isTopicTruncatedBasedOnRetention(Long.MAX_VALUE);
     doReturn(true).when(admin).isTopicTruncatedBasedOnRetention(1000L);
     doReturn(Optional.of(new StoreConfig(storeName1))).when(storeConfigRepository).getStoreConfig(storeName1);
@@ -410,12 +410,12 @@ public class TestTopicCleanupService {
     doReturn(true).when(admin).isTopicTruncatedBasedOnRetention(1000L);
     doReturn(storeTopics).when(topicManager).getAllTopicRetentions();
     doReturn(Optional.of(new StoreConfig(storeName))).when(storeConfigRepository).getStoreConfig(storeName);
-    when(remoteTopicManager.getAllTopicRetentions()).thenThrow(new VeniceException("test")).thenReturn(storeTopics);
+    when(remoteTopicManager.listTopics()).thenThrow(new VeniceException("test")).thenReturn(storeTopics.keySet());
 
     topicCleanupService.cleanupVeniceTopics();
 
     verify(topicManager, never()).ensureTopicIsDeletedAndBlockWithRetry(getPubSubTopic(storeName, "_rt"));
-    verify(remoteTopicManager, atLeastOnce()).getAllTopicRetentions();
+    verify(remoteTopicManager, atLeastOnce()).listTopics();
     verify(topicCleanupServiceStats, atLeastOnce()).recordDeletableTopicsCount(1);
     verify(topicCleanupServiceStats, atLeastOnce()).recordTopicDeletionError();
 
@@ -445,6 +445,6 @@ public class TestTopicCleanupService {
 
     topicCleanupService.cleanupVeniceTopics();
 
-    verify(remoteTopicManager, atLeastOnce()).getAllTopicRetentions();
+    verify(remoteTopicManager, atLeastOnce()).listTopics();
   }
 }


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Avoid expensive call to TM::getAllTopicRetentions in TopicCleanupService



The call to TopicManager::getAllTopicRetentions is expensive and unnecessary
for non-local region topic queries. We do not use the retention values from
remote version topics to decide whether to delete local real-time (RT) topics.
Replacing it with TM::listTopics, which is sufficient and more cost-effective.



## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
CI

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.