### PR TITLE
[dvc] Add a new config to replace pid as instance name suffix

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/DaVinciBackend.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/DaVinciBackend.java
@@ -1,5 +1,6 @@
 package com.linkedin.davinci;
 
+import static com.linkedin.venice.ConfigKeys.DAVINCI_PUSH_STATUS_INSTANCE_SUFFIX;
 import static com.linkedin.venice.ConfigKeys.VALIDATE_VENICE_INTERNAL_SCHEMA_VERSION;
 import static java.lang.Thread.currentThread;
 
@@ -190,7 +191,9 @@ public class DaVinciBackend implements Closeable {
       VeniceWriterFactory writerFactory =
           new VeniceWriterFactory(backendProps.toProperties(), pubSubClientsFactory.getProducerAdapterFactory(), null);
       String pid = Utils.getPid();
-      String instanceName = Utils.getHostName() + "_" + (pid == null ? "NA" : pid);
+      String instanceSuffix = configLoader.getCombinedProperties()
+          .getString(DAVINCI_PUSH_STATUS_INSTANCE_SUFFIX, (pid == null ? "NA" : pid));
+      String instanceName = Utils.getHostName() + "_" + instanceSuffix;
 
       // Fetch latest update schema's protocol ID for Push Status Store from Router.
       ClientConfig pushStatusStoreClientConfig = ClientConfig.cloneConfig(clientConfig)

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/DaVinciBackend.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/DaVinciBackend.java
@@ -1,6 +1,6 @@
 package com.linkedin.davinci;
 
-import static com.linkedin.venice.ConfigKeys.DAVINCI_PUSH_STATUS_INSTANCE_SUFFIX;
+import static com.linkedin.venice.ConfigKeys.PUSH_STATUS_INSTANCE_SUFFIX;
 import static com.linkedin.venice.ConfigKeys.VALIDATE_VENICE_INTERNAL_SCHEMA_VERSION;
 import static java.lang.Thread.currentThread;
 
@@ -191,8 +191,8 @@ public class DaVinciBackend implements Closeable {
       VeniceWriterFactory writerFactory =
           new VeniceWriterFactory(backendProps.toProperties(), pubSubClientsFactory.getProducerAdapterFactory(), null);
       String pid = Utils.getPid();
-      String instanceSuffix = configLoader.getCombinedProperties()
-          .getString(DAVINCI_PUSH_STATUS_INSTANCE_SUFFIX, (pid == null ? "NA" : pid));
+      String instanceSuffix =
+          configLoader.getCombinedProperties().getString(PUSH_STATUS_INSTANCE_SUFFIX, (pid == null ? "NA" : pid));
       String instanceName = Utils.getHostName() + "_" + instanceSuffix;
 
       // Fetch latest update schema's protocol ID for Push Status Store from Router.

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/DaVinciBackend.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/DaVinciBackend.java
@@ -1,6 +1,6 @@
 package com.linkedin.davinci;
 
-import static com.linkedin.venice.ConfigKeys.PUSH_STATUS_INSTANCE_SUFFIX;
+import static com.linkedin.venice.ConfigKeys.PUSH_STATUS_INSTANCE_NAME_SUFFIX;
 import static com.linkedin.venice.ConfigKeys.VALIDATE_VENICE_INTERNAL_SCHEMA_VERSION;
 import static java.lang.Thread.currentThread;
 
@@ -192,7 +192,7 @@ public class DaVinciBackend implements Closeable {
           new VeniceWriterFactory(backendProps.toProperties(), pubSubClientsFactory.getProducerAdapterFactory(), null);
       String pid = Utils.getPid();
       String instanceSuffix =
-          configLoader.getCombinedProperties().getString(PUSH_STATUS_INSTANCE_SUFFIX, (pid == null ? "NA" : pid));
+          configLoader.getCombinedProperties().getString(PUSH_STATUS_INSTANCE_NAME_SUFFIX, (pid == null ? "NA" : pid));
       String instanceName = Utils.getHostName() + "_" + instanceSuffix;
 
       // Fetch latest update schema's protocol ID for Push Status Store from Router.

--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -1753,7 +1753,7 @@ public class ConfigKeys {
    * Config to control what's the suffix for Da Vinci instance which is reporting push status and heartbeats. By default,
    * it is process PID if not specified, but note that PID is subject to change upon instance restart.
    */
-  public static final String DAVINCI_PUSH_STATUS_INSTANCE_SUFFIX = "davinci.push.status.instance.suffix";
+  public static final String PUSH_STATUS_INSTANCE_SUFFIX = "push.status.instance.suffix";
 
   /**
    * The expiration timeout. If an instance not sending heartbeats for over the expiration

--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -1753,7 +1753,7 @@ public class ConfigKeys {
    * Config to control what's the suffix for Da Vinci instance which is reporting push status and heartbeats. By default,
    * it is process PID if not specified, but note that PID is subject to change upon instance restart.
    */
-  public static final String PUSH_STATUS_INSTANCE_SUFFIX = "push.status.instance.suffix";
+  public static final String PUSH_STATUS_INSTANCE_NAME_SUFFIX = "push.status.instance.name.suffix";
 
   /**
    * The expiration timeout. If an instance not sending heartbeats for over the expiration

--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -1750,16 +1750,17 @@ public class ConfigKeys {
       "push.status.store.heartbeat.interval.seconds";
 
   /**
+   * Config to control what's the suffix for Da Vinci instance which is reporting push status and heartbeats. By default,
+   * it is process PID if not specified, but note that PID is subject to change upon instance restart.
+   */
+  public static final String DAVINCI_PUSH_STATUS_INSTANCE_SUFFIX = "davinci.push.status.instance.suffix";
+
+  /**
    * The expiration timeout. If an instance not sending heartbeats for over the expiration
    * time, it will be considered as stale.
    */
   public static final String PUSH_STATUS_STORE_HEARTBEAT_EXPIRATION_TIME_IN_SECONDS =
       "push.status.store.heartbeat.expiration.seconds";
-
-  /**
-   * Derived schemaId for push status store write compute.
-   */
-  public static final String PUSH_STATUS_STORE_DERIVED_SCHEMA_ID = "push.status.store.derived.schema.id";
 
   /**
    * Whether to throttle SSL connections between router and client.

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/PushStatusStoreTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/PushStatusStoreTest.java
@@ -145,7 +145,7 @@ public class PushStatusStoreTest {
     extraBackendConfigMap.put(CLIENT_SYSTEM_STORE_REPOSITORY_REFRESH_INTERVAL_SECONDS, 10);
     extraBackendConfigMap.put(PUSH_STATUS_STORE_ENABLED, true);
     extraBackendConfigMap.put(DAVINCI_PUSH_STATUS_SCAN_INTERVAL_IN_SECONDS, 5);
-    String expectedInstanceSuffix = "i015";
+    String expectedInstanceSuffix = "sampleApp_i015";
     extraBackendConfigMap.put(PUSH_STATUS_INSTANCE_NAME_SUFFIX, expectedInstanceSuffix);
 
     try (DaVinciClient<Integer, Integer> daVinciClient = ServiceFactory.getGenericAvroDaVinciClientWithRetries(

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/PushStatusStoreTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/PushStatusStoreTest.java
@@ -3,7 +3,7 @@ package com.linkedin.venice.endToEnd;
 import static com.linkedin.venice.ConfigKeys.CLIENT_SYSTEM_STORE_REPOSITORY_REFRESH_INTERVAL_SECONDS;
 import static com.linkedin.venice.ConfigKeys.CLIENT_USE_SYSTEM_STORE_REPOSITORY;
 import static com.linkedin.venice.ConfigKeys.DAVINCI_PUSH_STATUS_SCAN_INTERVAL_IN_SECONDS;
-import static com.linkedin.venice.ConfigKeys.PUSH_STATUS_INSTANCE_SUFFIX;
+import static com.linkedin.venice.ConfigKeys.PUSH_STATUS_INSTANCE_NAME_SUFFIX;
 import static com.linkedin.venice.ConfigKeys.PUSH_STATUS_STORE_ENABLED;
 import static com.linkedin.venice.ConfigKeys.SERVER_PROMOTION_TO_LEADER_REPLICA_DELAY_SECONDS;
 import static com.linkedin.venice.ConfigKeys.USE_PUSH_STATUS_STORE_FOR_INCREMENTAL_PUSH;
@@ -146,7 +146,7 @@ public class PushStatusStoreTest {
     extraBackendConfigMap.put(PUSH_STATUS_STORE_ENABLED, true);
     extraBackendConfigMap.put(DAVINCI_PUSH_STATUS_SCAN_INTERVAL_IN_SECONDS, 5);
     String expectedInstanceSuffix = "i015";
-    extraBackendConfigMap.put(PUSH_STATUS_INSTANCE_SUFFIX, expectedInstanceSuffix);
+    extraBackendConfigMap.put(PUSH_STATUS_INSTANCE_NAME_SUFFIX, expectedInstanceSuffix);
 
     try (DaVinciClient<Integer, Integer> daVinciClient = ServiceFactory.getGenericAvroDaVinciClientWithRetries(
         storeName,

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/PushStatusStoreTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/PushStatusStoreTest.java
@@ -2,8 +2,8 @@ package com.linkedin.venice.endToEnd;
 
 import static com.linkedin.venice.ConfigKeys.CLIENT_SYSTEM_STORE_REPOSITORY_REFRESH_INTERVAL_SECONDS;
 import static com.linkedin.venice.ConfigKeys.CLIENT_USE_SYSTEM_STORE_REPOSITORY;
-import static com.linkedin.venice.ConfigKeys.DAVINCI_PUSH_STATUS_INSTANCE_SUFFIX;
 import static com.linkedin.venice.ConfigKeys.DAVINCI_PUSH_STATUS_SCAN_INTERVAL_IN_SECONDS;
+import static com.linkedin.venice.ConfigKeys.PUSH_STATUS_INSTANCE_SUFFIX;
 import static com.linkedin.venice.ConfigKeys.PUSH_STATUS_STORE_ENABLED;
 import static com.linkedin.venice.ConfigKeys.SERVER_PROMOTION_TO_LEADER_REPLICA_DELAY_SECONDS;
 import static com.linkedin.venice.ConfigKeys.USE_PUSH_STATUS_STORE_FOR_INCREMENTAL_PUSH;
@@ -146,7 +146,7 @@ public class PushStatusStoreTest {
     extraBackendConfigMap.put(PUSH_STATUS_STORE_ENABLED, true);
     extraBackendConfigMap.put(DAVINCI_PUSH_STATUS_SCAN_INTERVAL_IN_SECONDS, 5);
     String expectedInstanceSuffix = "i015";
-    extraBackendConfigMap.put(DAVINCI_PUSH_STATUS_INSTANCE_SUFFIX, expectedInstanceSuffix);
+    extraBackendConfigMap.put(PUSH_STATUS_INSTANCE_SUFFIX, expectedInstanceSuffix);
 
     try (DaVinciClient<Integer, Integer> daVinciClient = ServiceFactory.getGenericAvroDaVinciClientWithRetries(
         storeName,

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/PushStatusStoreTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/PushStatusStoreTest.java
@@ -2,6 +2,7 @@ package com.linkedin.venice.endToEnd;
 
 import static com.linkedin.venice.ConfigKeys.CLIENT_SYSTEM_STORE_REPOSITORY_REFRESH_INTERVAL_SECONDS;
 import static com.linkedin.venice.ConfigKeys.CLIENT_USE_SYSTEM_STORE_REPOSITORY;
+import static com.linkedin.venice.ConfigKeys.DAVINCI_PUSH_STATUS_INSTANCE_SUFFIX;
 import static com.linkedin.venice.ConfigKeys.DAVINCI_PUSH_STATUS_SCAN_INTERVAL_IN_SECONDS;
 import static com.linkedin.venice.ConfigKeys.PUSH_STATUS_STORE_ENABLED;
 import static com.linkedin.venice.ConfigKeys.SERVER_PROMOTION_TO_LEADER_REPLICA_DELAY_SECONDS;
@@ -144,6 +145,8 @@ public class PushStatusStoreTest {
     extraBackendConfigMap.put(CLIENT_SYSTEM_STORE_REPOSITORY_REFRESH_INTERVAL_SECONDS, 10);
     extraBackendConfigMap.put(PUSH_STATUS_STORE_ENABLED, true);
     extraBackendConfigMap.put(DAVINCI_PUSH_STATUS_SCAN_INTERVAL_IN_SECONDS, 5);
+    String expectedInstanceSuffix = "i015";
+    extraBackendConfigMap.put(DAVINCI_PUSH_STATUS_INSTANCE_SUFFIX, expectedInstanceSuffix);
 
     try (DaVinciClient<Integer, Integer> daVinciClient = ServiceFactory.getGenericAvroDaVinciClientWithRetries(
         storeName,
@@ -152,8 +155,11 @@ public class PushStatusStoreTest {
         extraBackendConfigMap)) {
       daVinciClient.subscribeAll().get();
       runVPJ(vpjProperties, 2, cluster);
-      TestUtils.waitForNonDeterministicAssertion(TEST_TIMEOUT_MS, TimeUnit.MILLISECONDS, () -> {
-        assertEquals(reader.getPartitionStatus(storeName, 2, 0, Optional.empty()).size(), 1);
+      TestUtils.waitForNonDeterministicAssertion(TEST_TIMEOUT_MS, TimeUnit.MILLISECONDS, true, () -> {
+        Map<CharSequence, Integer> partitionStatus = reader.getPartitionStatus(storeName, 2, 0, Optional.empty());
+        assertEquals(partitionStatus.size(), 1);
+        String expectedHostName = Utils.getHostName() + "_" + expectedInstanceSuffix;
+        assertTrue(partitionStatus.containsKey(new Utf8(expectedHostName)));
       });
     }
     Admin admin = cluster.getVeniceControllers().get(0).getVeniceAdmin();


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## [dvc] Add a new config to replace pid as instance name suffix
Using process pid as instance name suffix will not work for VPJ when application slice is performing large scale restart.
This PR introduces a new config as instance suffix to replace PID. And if the config is not specified, we will still use PID as fall back (but not recommended)
## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
Modified existing integration test to verify the new config is adopted.
## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.