### PR TITLE
[server][metrics] Only wire heartbeat monitor at end of follower transition

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/helix/LeaderFollowerPartitionStateModel.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/helix/LeaderFollowerPartitionStateModel.java
@@ -106,7 +106,6 @@ public class LeaderFollowerPartitionStateModel extends AbstractPartitionStateMod
       try {
         long startTimeForSettingUpNewStorePartitionInNs = System.nanoTime();
         setupNewStorePartition();
-        updateLagMonitor(message.getResourceName(), heartbeatMonitoringService::addFollowerLagMonitor);
         logger.info(
             "Completed setting up new store partition for {} partition {}. Total elapsed time: {} ms",
             resourceName,
@@ -122,6 +121,7 @@ public class LeaderFollowerPartitionStateModel extends AbstractPartitionStateMod
       if (isRegularStoreCurrentVersion) {
         waitConsumptionCompleted(resourceName, notifier);
       }
+      updateLagMonitor(message.getResourceName(), heartbeatMonitoringService::addFollowerLagMonitor);
     });
   }
 


### PR DESCRIPTION
## [server][metrics] Only wire heartbeat monitor at end of follower transition
This is to screen out bootstrap time from the metric

Resolves #XXX

## How was this PR tested?
Normal test suite

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.