### PR TITLE
[dvc][server]Enable leader complete status check for non Active-Active stores

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -10,7 +10,6 @@ import static com.linkedin.davinci.kafka.consumer.LeaderFollowerStateType.STANDB
 import static com.linkedin.venice.kafka.protocol.enums.ControlMessageType.END_OF_PUSH;
 import static com.linkedin.venice.kafka.protocol.enums.ControlMessageType.START_OF_SEGMENT;
 import static com.linkedin.venice.pubsub.api.PubSubMessageHeaders.VENICE_LEADER_COMPLETION_STATE_HEADER;
-import static com.linkedin.venice.writer.LeaderCompleteState.LEADER_COMPLETE_STATE_UNKNOWN;
 import static com.linkedin.venice.writer.VeniceWriter.APP_DEFAULT_LOGICAL_TS;
 import static com.linkedin.venice.writer.VeniceWriter.DEFAULT_LEADER_METADATA_WRAPPER;
 import static java.lang.Long.max;
@@ -1975,11 +1974,10 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
    * Checks whether the lag is acceptable for hybrid stores
    * <p>
    * If the instance is a hybrid standby or DaVinciClient: Also check if <br>
-   * 1. checkLeaderCompleteStateInFollower feature is enabled <br>
-   * 2. first HB SOS is received and[ <br>
-   * 3. leaderCompleteStatus header is in the HB and <br>
-   * 4. leaderCompleteStatus has the leader state=completed and <br>
-   * 5. the last update time was within the configured time interval to not use the stale leader state
+   * 1. checkLeaderCompleteStateInFollower feature is enabled based on configs <br>
+   * 2. leaderCompleteStatus has the leader state=completed and <br>
+   * 3. the last update time was within the configured time interval to not use the stale leader state: check
+   *    {@link com.linkedin.venice.ConfigKeys.SERVER_LEADER_COMPLETE_STATE_CHECK_IN_FOLLOWER_VALID_INTERVAL_MS}
    */
   @Override
   protected boolean checkAndLogIfLagIsAcceptableForHybridStore(
@@ -1990,38 +1988,25 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
       LagType lagType,
       long latestConsumedProducerTimestamp) {
     boolean isLagAcceptable = lag <= threshold;
-    StringBuilder laggingReason = null;
-    if (shouldLogLag) {
-      laggingReason = new StringBuilder();
+    boolean isHybridFollower = isHybridFollower(pcs);
+
+    // if lag is acceptable and is a hybrid standby or DaVinciClient: check and
+    // override it based on leader follower state
+    if (isLagAcceptable && isHybridFollower && shouldCheckLeaderCompleteStateInFollower()) {
+      isLagAcceptable = pcs.isLeaderCompleted()
+          && ((System.currentTimeMillis() - pcs.getLastLeaderCompleteStateUpdateInMs()) <= getServerConfig()
+              .getLeaderCompleteStateCheckInFollowerValidIntervalMs());
     }
 
-    // if lag is acceptable and is a hybrid standby or DaVinciClient: check and override it based on leader follower
-    // state
-    if (isLagAcceptable && isHybridFollower(pcs) && shouldCheckLeaderCompleteStateInFollower()) {
-      if (!pcs.isFirstHeartBeatSOSReceived()) {
-        // wait for the first HB to know if the leader supports sending LeaderCompleteState or not
-        isLagAcceptable = false;
-        if (shouldLogLag) {
-          laggingReason
-              .append("Will wait for the first heart beat to know if the leader supports LeaderCompleteState.");
-        }
-      } else if (!pcs.getLeaderCompleteState().equals(LEADER_COMPLETE_STATE_UNKNOWN)) {
-        // if the first HB is received and the leader supports LeaderCompleteState: check if the
-        // leader is completed and the last update time was within the configured time
-        isLagAcceptable = pcs.isLeaderCompleted()
-            && ((System.currentTimeMillis() - pcs.getLastLeaderCompleteStateUpdateInMs()) <= getServerConfig()
-                .getLeaderCompleteStateCheckInFollowerValidIntervalMs());
-        if (!isLagAcceptable && shouldLogLag) {
-          laggingReason.append("Leader Complete State: {")
-              .append(pcs.getLeaderCompleteState().toString())
-              .append("}, Last update In Ms: {")
-              .append(pcs.getLastLeaderCompleteStateUpdateInMs())
-              .append("}.");
-        }
+    if (shouldLogLag) {
+      StringBuilder leaderCompleteHeaderDetails = new StringBuilder();
+      if (isHybridFollower) {
+        leaderCompleteHeaderDetails.append("Leader Complete State: {")
+            .append(pcs.getLeaderCompleteState().toString())
+            .append("}, Last update In Ms: {")
+            .append(pcs.getLastLeaderCompleteStateUpdateInMs())
+            .append("}.");
       }
-    }
-
-    if (shouldLogLag) {
       LOGGER.info(
           "{} [{} lag] partition {} is {}. {}Lag: [{}] {} Threshold [{}]. {}",
           this.ingestionTaskName,
@@ -2032,7 +2017,7 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
           lag,
           lag <= threshold ? "<=" : ">",
           threshold,
-          laggingReason);
+          leaderCompleteHeaderDetails.toString());
     }
 
     return isLagAcceptable;
@@ -2040,11 +2025,7 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
 
   /**
    * HeartBeat SOS messages carry the leader completion state in the header. This function extracts the leader completion
-   * state from that header and updates the {@param partitionConsumptionState} accordingly. <p>
-   * If there is no leader completion state header, reset the leader completion state to
-   * {@link LeaderCompleteState#LEADER_COMPLETE_STATE_UNKNOWN} as the leader don't know about this header
-   * (using old version of the code) or the leader may have rolled back to a version that doesn't support this header or
-   * this topic partition gets a new leader which doesn't support this header yet.
+   * state from that header and updates the {@param partitionConsumptionState} accordingly.
    */
   protected void getAndUpdateLeaderCompletedState(
       KafkaKey kafkaKey,
@@ -2056,7 +2037,6 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
       ControlMessageType controlMessageType = ControlMessageType.valueOf(controlMessage);
       if (controlMessageType == ControlMessageType.START_OF_SEGMENT
           && Arrays.equals(kafkaKey.getKey(), KafkaKey.HEART_BEAT.getKey())) {
-        boolean isLeaderCompleteHeaderFound = false;
         LeaderCompleteState oldState = partitionConsumptionState.getLeaderCompleteState();
         LeaderCompleteState newState = oldState;
         for (PubSubMessageHeader header: pubSubMessageHeaders.toList()) {
@@ -2064,14 +2044,8 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
             newState = LeaderCompleteState.valueOf(header.value()[0]);
             partitionConsumptionState
                 .setLastLeaderCompleteStateUpdateInMs(kafkaValue.producerMetadata.messageTimestamp);
-            isLeaderCompleteHeaderFound = true;
             break; // only interested in this header here
           }
-        }
-        if (!isLeaderCompleteHeaderFound) {
-          // reset LeaderCompleteState: If a leader originally sent this header but later is rolled back to a version
-          // that doesn't support this header or this TP gets a new leader which doesn't support this header yet.
-          newState = LEADER_COMPLETE_STATE_UNKNOWN;
         }
 
         if (oldState != newState) {
@@ -2091,9 +2065,6 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
               partitionConsumptionState.getPartition(),
               newState);
         }
-        if (!partitionConsumptionState.isFirstHeartBeatSOSReceived()) {
-          partitionConsumptionState.setFirstHeartBeatSOSReceived(true);
-        }
       }
     }
   }
@@ -2104,7 +2075,7 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
    * Adding the headers during this phase instead of adding it to RT directly simplifies the logic
    * of how to identify the HB SOS from the correct version or whether the HB SOS is from the local
    * colo or remote colo, as the header inherited from an incorrect version or remote colos might
-   * provide incorrect information about the support of the header and the leader state.
+   * provide incorrect information about the leader state.
    */
   private void propagateHeartbeatFromUpstreamTopicToLocalVersionTopic(
       PartitionConsumptionState partitionConsumptionState,
@@ -3499,7 +3470,7 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
         leaderMetadataWrapper,
         false, // maybeSendIngestionHeartbeat logs for this case
         false,
-        LeaderCompleteState.LEADER_COMPLETE_STATE_UNKNOWN,
+        LeaderCompleteState.LEADER_NOT_COMPLETED,
         System.currentTimeMillis());
   }
 
@@ -3561,7 +3532,7 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
    * its latest processed upstream RT topic offset. At this point, the offset reflects the correct position, regardless of trailing
    * CMs or skippable data records due to DCR.
    * <p>
-   * This heartbeat message does not include a leader completion header. This maintains the leader completion states only in VTs and not
+   * This heartbeat message does not send a leader completion header. This results in having the leader completion states only in VTs and not
    * in the RT, avoiding the need to differentiate between heartbeats from leaders of different versions (backup/current/future) and colos.
    *
    * @return the set of partitions that failed to send heartbeat (used for tests)

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/PartitionConsumptionState.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/PartitionConsumptionState.java
@@ -216,12 +216,6 @@ public class PartitionConsumptionState {
 
   private LeaderCompleteState leaderCompleteState;
   private long lastLeaderCompleteStateUpdateInMs;
-  /**
-   * In case of hybrid store, wait until the first HB is received, which might have the leader completed header and base the
-   * decision on that. Check {@link com.linkedin.venice.ConfigKeys#SERVER_LEADER_COMPLETE_STATE_CHECK_IN_FOLLOWER_ENABLED} for
-   * more details.
-   */
-  private boolean firstHeartBeatSOSReceived;
 
   public PartitionConsumptionState(int partition, int amplificationFactor, OffsetRecord offsetRecord, boolean hybrid) {
     this.partition = partition;
@@ -270,9 +264,8 @@ public class PartitionConsumptionState {
     // On start we haven't sent anything
     this.latestRTOffsetTriedToProduceToVTMap = new HashMap<>();
     this.lastVTProduceCallFuture = CompletableFuture.completedFuture(null);
-    this.leaderCompleteState = LeaderCompleteState.LEADER_COMPLETE_STATE_UNKNOWN;
+    this.leaderCompleteState = LeaderCompleteState.LEADER_NOT_COMPLETED;
     this.lastLeaderCompleteStateUpdateInMs = 0;
-    this.firstHeartBeatSOSReceived = false;
   }
 
   public int getPartition() {
@@ -879,13 +872,5 @@ public class PartitionConsumptionState {
 
   public void setLastLeaderCompleteStateUpdateInMs(long lastLeaderCompleteStateUpdateInMs) {
     this.lastLeaderCompleteStateUpdateInMs = lastLeaderCompleteStateUpdateInMs;
-  }
-
-  public boolean isFirstHeartBeatSOSReceived() {
-    return firstHeartBeatSOSReceived;
-  }
-
-  public void setFirstHeartBeatSOSReceived(boolean firstHeartBeatSOSReceived) {
-    this.firstHeartBeatSOSReceived = firstHeartBeatSOSReceived;
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -781,13 +781,15 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
 
   protected abstract boolean isHybridFollower(PartitionConsumptionState partitionConsumptionState);
 
+  protected abstract boolean shouldCheckLeaderCompleteStateInFollower();
+
   /**
    * Checks whether the lag is acceptable for hybrid stores
    */
   protected abstract boolean checkAndLogIfLagIsAcceptableForHybridStore(
       PartitionConsumptionState partitionConsumptionState,
-      long offsetLag,
-      long offsetThreshold,
+      long lag,
+      long threshold,
       boolean shouldLogLag,
       LagType lagType,
       long latestConsumedProducerTimestamp);

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/PartitionConsumptionStateTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/PartitionConsumptionStateTest.java
@@ -127,12 +127,8 @@ public class PartitionConsumptionStateTest {
   @Test
   public void testIsLeaderCompleted() {
     PartitionConsumptionState pcs = new PartitionConsumptionState(0, 1, mock(OffsetRecord.class), false);
-    // default is LEADER_COMPLETE_STATE_UNKNOWN
-    assertEquals(pcs.getLeaderCompleteState(), LeaderCompleteState.LEADER_COMPLETE_STATE_UNKNOWN);
-    assertFalse(pcs.isLeaderCompleted());
-
-    // test with LEADER_NOT_COMPLETED
-    pcs.setLeaderCompleteState(LeaderCompleteState.LEADER_NOT_COMPLETED);
+    // default is LEADER_NOT_COMPLETED
+    assertEquals(pcs.getLeaderCompleteState(), LeaderCompleteState.LEADER_NOT_COMPLETED);
     assertFalse(pcs.isLeaderCompleted());
 
     // test with LEADER_COMPLETED

--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -2065,7 +2065,10 @@ public class ConfigKeys {
    * Follower replicas and DavinciClient will only consider heartbeats received within
    * this time window to mark themselves as completed. This is to avoid the cases that
    * the follower replica is marked completed based on the old heartbeat messages from
-   * a previous leader replica.
+   * a previous leader replica. Note that the leader replica keeps sending the leader
+   * completed headers in every heartbeat messages which allows the follower replica
+   * the liberty to decide based on the freshness of the heartbeat messages to avoid
+   * stale data from some edge cases scenarios.
    */
   public static final String SERVER_LEADER_COMPLETE_STATE_CHECK_IN_FOLLOWER_VALID_INTERVAL_MS =
       "server.leader.complete.state.check.in.follower.valid.interval.ms";

--- a/internal/venice-common/src/main/java/com/linkedin/venice/writer/LeaderCompleteState.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/writer/LeaderCompleteState.java
@@ -10,20 +10,13 @@ import com.linkedin.venice.utils.VeniceEnumValue;
  */
 public enum LeaderCompleteState implements VeniceEnumValue {
   /**
-   * Leader partition is not completed yet
+   * Leader partition is not completed yet: Default state
    */
   LEADER_NOT_COMPLETED(0),
   /**
    * Leader partition is completed
    */
-  LEADER_COMPLETED(1),
-  /**
-   * Default state for the partition until VENICE_LEADER_COMPLETION_STATE_HEADER is received from leader partition
-   * and the state is updated. This works in conjunction with PartitionConsumptionState#isFirstHeartBeatSOSReceived
-   * to decide whether to use this state or not. This will be used only during the transition phase to avoid 2 phase
-   * deployment and once all servers are running the latest code, this can be removed.
-   */
-  LEADER_COMPLETE_STATE_UNKNOWN(2);
+  LEADER_COMPLETED(1);
 
   private final int value;
   private static final LeaderCompleteState[] TYPES_ARRAY = EnumUtils.getEnumValuesArray(LeaderCompleteState.class);


### PR DESCRIPTION
## Summary
PR [775](https://github.com/linkedin/venice/pull/775) introduced a feature for hybrid stores' followers to go ready to serve only after leader is marked completed. But it was disabled for non-AA stores as the Heartbeats (which this feature piggybacks on) are written only to local RT's but certain non-AA cases' LFSIT consumes only from parent RT.  One fix considered for these non-AA stores to get onboard to this feature was to write HB to parent RT as well. But as Parent RT is soon to be deprecated and we don't want to add more to it, this PR works around that considering the below aspects and enabling this feature for all stores except non-AA and `DRP=AGGREGATE` stores.
1. All incremental push stores should be Active-active by default.
2. All stores not on AA without incremental push except `DRP=AGGREGATE` will be reading from local RT. 

the long-term goal is to remove `DRP` completely and make all existing hybrid stores either:
1. AA: If cross region replication needed
2. non-AA: If cross region replication not needed

Also removed `LEADER_COMPLETE_STATE_UNKNOWN` and `firstHeartBeatSOSReceived` as it was introduced for deployment transition phase to start using this header. Config `SERVER_LEADER_COMPLETE_STATE_CHECK_IN_FOLLOWER_ENABLED` should be used to enable this feature after deployment.

## How was this PR tested?
GH CI

## Does this PR introduce any user-facing changes?
- [x] No. You can skip the rest of this section.
- [] Yes. Make sure to explain your proposed changes and call out the behavior change.