### PR TITLE
[metrics][server] Remove large sentinal value for default hearbteat lag

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/helix/LeaderFollowerPartitionStateModel.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/helix/LeaderFollowerPartitionStateModel.java
@@ -128,6 +128,11 @@ public class LeaderFollowerPartitionStateModel extends AbstractPartitionStateMod
   @Transition(to = HelixState.LEADER_STATE, from = HelixState.STANDBY_STATE)
   public void onBecomeLeaderFromStandby(Message message, NotificationContext context) {
     LeaderSessionIdChecker checker = new LeaderSessionIdChecker(leaderSessionId.incrementAndGet(), leaderSessionId);
+    /**
+     * We set up the lag monitor first for leader transitions because we want to monitor the amount of time
+     * where a slice doesn't have a replicating leader.  While this state transition executes, there should be no
+     * other leader in the slice.
+     */
     updateLagMonitor(message.getResourceName(), heartbeatMonitoringService::addLeaderLagMonitor);
     executeStateTransition(
         message,

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/heartbeat/HeartbeatMonitoringService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/heartbeat/HeartbeatMonitoringService.java
@@ -37,10 +37,6 @@ public class HeartbeatMonitoringService extends AbstractVeniceService {
   private static final Logger LOGGER = LogManager.getLogger(HeartbeatMonitoringService.class);
   public static final int DEFAULT_REPORTER_THREAD_SLEEP_INTERVAL_SECONDS = 60;
 
-  // This default value SHOULD be a number that will trip an alert. Alerting on this should be duration based,
-  // so starting off with a large value is fine that is cleared once we get the next heartbeat
-  public long DEFAULT_SENTINEL_HEARTBEAT_TIMESTAMP = System.currentTimeMillis() - 21600000; // 6 hours ago
-
   private final Set<String> regionNames;
   private final String localRegionName;
 
@@ -83,10 +79,10 @@ public class HeartbeatMonitoringService extends AbstractVeniceService {
           Map<String, Long> regionTimestamps = new VeniceConcurrentHashMap<>();
           if (version.isActiveActiveReplicationEnabled() && !isFollower) {
             for (String region: regionNames) {
-              regionTimestamps.put(region, DEFAULT_SENTINEL_HEARTBEAT_TIMESTAMP);
+              regionTimestamps.put(region, System.currentTimeMillis());
             }
           } else {
-            regionTimestamps.put(localRegionName, DEFAULT_SENTINEL_HEARTBEAT_TIMESTAMP);
+            regionTimestamps.put(localRegionName, System.currentTimeMillis());
           }
           return regionTimestamps;
         });


### PR DESCRIPTION
## [metrics][server] Remove large sentinal value for default hearbteat lag

This seems to be making graphs hard to read and causing some deployment noise.  After thinking on it more, this is probably ok since we would expect the alert to trip within 10's of minutes anyway even with a window of monitoring.

Resolves #XXX

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.