### PR TITLE
[server][dvc] Inherit ipv6 preference setting from parent process

### DIFF
--- a/internal/venice-common/src/main/java/com/linkedin/venice/utils/ForkedJavaProcess.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/utils/ForkedJavaProcess.java
@@ -313,6 +313,9 @@ public final class ForkedJavaProcess extends Process {
 
     // Inherit Java tmp folder setting from parent process.
     command.add("-Djava.io.tmpdir=" + System.getProperty("java.io.tmpdir"));
+    // Inherit IPv6 preference setting from parent process.
+    command.add("-Djava.net.preferIPv6Addresses=" + System.getProperty("java.net.preferIPv6Addresses", "false"));
+
     /**
      Add log4j2 configuration file and JVM arguments.
      This config will inherit the log4j2 config file from parent process and set up correct logging level and it will


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## [server][dvc] Inherit ipv6 preference setting from parent process
Inherit `-Djava.net.preferIPv6Addresses` config from parent process. If not set, we will default to false.
## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
Existing tests.
## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.