### PR TITLE
[dvc] Split large batch-get to execute concurrently

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/client/AvroGenericDaVinciClient.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/client/AvroGenericDaVinciClient.java
@@ -178,11 +178,6 @@ public class AvroGenericDaVinciClient<K, V> implements DaVinciClient<K, V>, Avro
     preValidation.run();
   }
 
-  // For testing
-  void setDaVinciBackend(DaVinciBackend testDaVinciBackend) {
-    daVinciBackend = new ReferenceCounted<>(testDaVinciBackend, (ignored) -> {});
-  }
-
   @Override
   public String getStoreName() {
     return clientConfig.getStoreName();

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/client/AvroGenericDaVinciClient.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/client/AvroGenericDaVinciClient.java
@@ -58,19 +58,25 @@ import com.linkedin.venice.serializer.RecordDeserializer;
 import com.linkedin.venice.serializer.RecordSerializer;
 import com.linkedin.venice.service.ICProvider;
 import com.linkedin.venice.utils.ComplementSet;
+import com.linkedin.venice.utils.DaemonThreadFactory;
 import com.linkedin.venice.utils.PropertyBuilder;
 import com.linkedin.venice.utils.ReferenceCounted;
 import com.linkedin.venice.utils.VeniceProperties;
 import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
 import java.nio.ByteBuffer;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
@@ -99,6 +105,16 @@ public class AvroGenericDaVinciClient<K, V> implements DaVinciClient<K, V>, Avro
   }
 
   private static final ThreadLocal<ReusableObjects> REUSABLE_OBJECTS = ThreadLocal.withInitial(ReusableObjects::new);
+
+  /**
+   * The following two fields are used to speed up the requests with a big number of keys:
+   * 1. Split the big request into smaller chunks.
+   * 2. Execute these chunks concurrently.
+   */
+  private static final ExecutorService READ_CHUNK_EXECUTOR = Executors.newFixedThreadPool(
+      Runtime.getRuntime().availableProcessors(),
+      new DaemonThreadFactory("DaVinci_Read_Chunk_Executor"));
+  public static final int CHUNK_SPLIT_THRESHOLD = 100;
 
   private final DaVinciConfig daVinciConfig;
   private final ClientConfig clientConfig;
@@ -160,6 +176,11 @@ public class AvroGenericDaVinciClient<K, V> implements DaVinciClient<K, V>, Avro
     this.icProvider = icProvider;
     this.chunkingAdapter = chunkingAdapter;
     preValidation.run();
+  }
+
+  // For testing
+  void setDaVinciBackend(DaVinciBackend testDaVinciBackend) {
+    daVinciBackend = new ReferenceCounted<>(testDaVinciBackend, (ignored) -> {});
   }
 
   @Override
@@ -289,43 +310,100 @@ public class AvroGenericDaVinciClient<K, V> implements DaVinciClient<K, V>, Avro
     }
   }
 
-  private CompletableFuture<Map<K, V>> batchGetFromLocalStorage(Iterable<K> keys) {
+  public static <K> List<List<K>> split(Set<K> keySet, int threshold) {
+    List<List<K>> splits = new ArrayList<>();
+    List<K> currentSplit = new ArrayList<>(threshold);
+    for (K key: keySet) {
+      currentSplit.add(key);
+      if (currentSplit.size() == threshold) {
+        splits.add(currentSplit);
+        currentSplit = new ArrayList<>(threshold);
+      }
+    }
+    if (!currentSplit.isEmpty()) {
+      splits.add(currentSplit);
+    }
+
+    return splits;
+  }
+
+  StoreBackend getStoreBackend() {
+    return this.storeBackend;
+  }
+
+  RecordSerializer<K> getKeySerializer() {
+    return this.keySerializer;
+  }
+
+  StoreDeserializerCache<V> getStoreDeserializerCache() {
+    return this.storeDeserializerCache;
+  }
+
+  CompletableFuture<Map<K, V>> batchGetFromLocalStorage(Iterable<K> keys) {
     // expose underlying getAll functionality.
-    Map<K, V> result = new HashMap<>();
-    try (ReferenceCounted<VersionBackend> versionRef = storeBackend.getDaVinciCurrentVersion()) {
+    Map<K, V> result = new VeniceConcurrentHashMap<>();
+    try (ReferenceCounted<VersionBackend> versionRef = getStoreBackend().getDaVinciCurrentVersion()) {
       VersionBackend versionBackend = versionRef.get();
       if (versionBackend == null) {
-        storeBackend.getStats().recordBadRequest();
+        getStoreBackend().getStats().recordBadRequest();
         throw new VeniceClientException("Da Vinci client is not subscribed, storeName=" + getStoreName());
       }
-      ReusableObjects reusableObjects = REUSABLE_OBJECTS.get();
       int readerSchemaId = versionBackend.getSupersetOrLatestValueSchemaId();
-      for (K key: keys) {
-        byte[] keyBytes = keySerializer.serialize(key);
-        int partition = versionBackend.getPartition(keyBytes);
 
-        if (isPartitionReadyToServe(versionBackend, partition)) {
-          V value = versionBackend.read(
-              partition,
-              keyBytes,
-              getAvroChunkingAdapter(),
-              this.storeDeserializerCache,
-              readerSchemaId,
-              reusableObjects.binaryDecoder,
-              reusableObjects.rawValue,
-              null); // TODO: Consider supporting object re-use for batch get as well.
-          // The result should only contain entries for the keys that have a value associated with them
-          if (value != null) {
-            result.put(key, value);
+      Consumer<Iterable<K>> keyArrayConsumer = keyList -> {
+        ReusableObjects reusableObjects = REUSABLE_OBJECTS.get();
+
+        for (K key: keyList) {
+          byte[] keyBytes = getKeySerializer().serialize(key);
+          int partition = versionBackend.getPartition(keyBytes);
+
+          if (isPartitionReadyToServe(versionBackend, partition)) {
+            V value = versionBackend.read(
+                partition,
+                keyBytes,
+                getAvroChunkingAdapter(),
+                getStoreDeserializerCache(),
+                readerSchemaId,
+                reusableObjects.binaryDecoder,
+                reusableObjects.rawValue,
+                null); // TODO: Consider supporting object re-use for batch get as well.
+            if (value != null) {
+              // The result should only contain entries for the keys that have a value associated with them
+              result.put(key, value);
+            }
+          } else if (!isPartitionSubscribed(versionBackend, partition)) {
+            storeBackend.getStats().recordBadRequest();
+            throw new NonLocalAccessException(versionBackend.toString(), partition);
+          } else {
+            throw new VeniceClientException(
+                "Partition: " + partition + " for store version: " + versionBackend + " is not ready to serve");
           }
-
-        } else if (!isPartitionSubscribed(versionBackend, partition)) {
-          storeBackend.getStats().recordBadRequest();
-          throw new NonLocalAccessException(versionBackend.toString(), partition);
         }
-      }
+      };
 
-      return CompletableFuture.completedFuture(result);
+      if (keys instanceof Set && ((Set) keys).size() > CHUNK_SPLIT_THRESHOLD) {
+        // Execute large request concurrently
+        List<List<K>> splits = split((Set) keys, CHUNK_SPLIT_THRESHOLD);
+        CompletableFuture[] splitFutures = new CompletableFuture[splits.size()];
+        for (int cur = 0; cur < splits.size(); ++cur) {
+          List<K> currentSplit = splits.get(cur);
+          splitFutures[cur] =
+              CompletableFuture.runAsync(() -> keyArrayConsumer.accept(currentSplit), READ_CHUNK_EXECUTOR);
+        }
+        CompletableFuture<Map<K, V>> resultFuture = new CompletableFuture<>();
+        CompletableFuture.allOf(splitFutures).whenComplete((ignored, throwable) -> {
+          if (throwable != null) {
+            resultFuture.completeExceptionally(throwable);
+          } else {
+            resultFuture.complete(result);
+          }
+        });
+
+        return resultFuture;
+      } else {
+        keyArrayConsumer.accept(keys);
+        return CompletableFuture.completedFuture(result);
+      }
     }
   }
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/client/DaVinciConfig.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/client/DaVinciConfig.java
@@ -41,6 +41,13 @@ public class DaVinciConfig {
    */
   private boolean readMetricsEnabled = false;
 
+  /**
+   * When the request key count exceeds the following threshold, it will be split into multiple small
+   * chunks with max size to be the threshold and these chunks will be executed concurrently in a
+   * pre-allocated thread pool.
+   */
+  private int largeBatchRequestSplitThreshold = AvroGenericDaVinciClient.DEFAULT_CHUNK_SPLIT_THRESHOLD;
+
   public DaVinciConfig() {
   }
 
@@ -53,8 +60,19 @@ public class DaVinciConfig {
 
   @Override
   public String toString() {
-    return "DaVinciConfig{" + "managed=" + managed + ", isolated=" + isolated + ", storageClass=" + storageClass
-        + ", cacheConfig=" + cacheConfig + "}";
+    StringBuilder sb = new StringBuilder();
+    sb.append("DaVinciConfig{managed=")
+        .append(managed)
+        .append(", isolated=")
+        .append(isolated)
+        .append(", storageClass=")
+        .append(storageClass)
+        .append(", cacheConfig=")
+        .append(cacheConfig)
+        .append(", largeBatchRequestSplitThreshold=")
+        .append(largeBatchRequestSplitThreshold)
+        .append("}");
+    return sb.toString();
   }
 
   public boolean isManaged() {
@@ -118,7 +136,20 @@ public class DaVinciConfig {
     return readMetricsEnabled;
   }
 
-  public void setReadMetricsEnabled(boolean readMetricsEnabled) {
+  public DaVinciConfig setReadMetricsEnabled(boolean readMetricsEnabled) {
     this.readMetricsEnabled = readMetricsEnabled;
+    return this;
+  }
+
+  public int getLargeBatchRequestSplitThreshold() {
+    return largeBatchRequestSplitThreshold;
+  }
+
+  public DaVinciConfig setLargeBatchRequestSplitThreshold(int largeBatchRequestSplitThreshold) {
+    if (largeBatchRequestSplitThreshold < 1) {
+      throw new IllegalArgumentException("'largeBatchRequestSplitThreshold' param needs to be at least 1");
+    }
+    this.largeBatchRequestSplitThreshold = largeBatchRequestSplitThreshold;
+    return this;
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/client/StorageClass.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/client/StorageClass.java
@@ -1,5 +1,24 @@
 package com.linkedin.davinci.client;
 
 public enum StorageClass {
-  DISK, MEMORY_BACKED_BY_DISK,
+  /**
+   * The mode has the following implications:
+   * 1. Keep all the data on disk.
+   * 2. Use a block cache to keep the hottest entries and internally it is using LRU algorithm. Internally, Block Cache
+   * will try to cache index/bloom filters over data entries if there is a memory pressure.
+   * 3. Block cache size is configurable.
+   * 4. This mode is recommended for the large store use cases that the application doesn't have enough RAM to keep all
+   * the data in memory and the application is using SSD.
+   */
+  DISK,
+  /**
+   * The mode has the following implications:
+   * 1. Keep a snapshot on disk.
+   * 2. Application can use SSD or Hard Drive.
+   * 3. Application needs to have enough RAM to keep DaVinci databases fully in RAM (ideally, it should have enough
+   * RAM to keep two versions since Venice/DaVinci database is versioned.)
+   * 4. At serving time, all the read request will be served out of memory and internally, RocksDB in DaVinci is using
+   * mmap to bring the on-disk data files into RAM.
+   */
+  MEMORY_BACKED_BY_DISK
 }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/client/AvroGenericDaVinciClientTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/client/AvroGenericDaVinciClientTest.java
@@ -86,6 +86,11 @@ public class AvroGenericDaVinciClientTest {
     AvroGenericDaVinciClient<String, String> dvcClient = mock(AvroGenericDaVinciClient.class);
     when(dvcClient.getStoreName()).thenReturn("test_store");
 
+    int largeRequestSplitThreshold = 10;
+    DaVinciConfig daVinciConfig = new DaVinciConfig();
+    daVinciConfig.setLargeBatchRequestSplitThreshold(largeRequestSplitThreshold);
+    when(dvcClient.getDaVinciConfig()).thenReturn(daVinciConfig);
+
     String testValue = "test_value";
     StoreBackend storeBackend = mock(StoreBackend.class);
     VersionBackend versionBackend = mock(VersionBackend.class);
@@ -117,7 +122,7 @@ public class AvroGenericDaVinciClientTest {
 
     // Simulate a large request
     Set<String> largeKeySet = new HashSet<>();
-    int keyCnt = (int) (AvroGenericDaVinciClient.CHUNK_SPLIT_THRESHOLD * 1.5);
+    int keyCnt = (int) (largeRequestSplitThreshold * 1.5);
     String keyPrefix = "key_";
     for (int i = 0; i < keyCnt; ++i) {
       largeKeySet.add(keyPrefix + i);

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/client/AvroGenericDaVinciClientTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/client/AvroGenericDaVinciClientTest.java
@@ -1,14 +1,29 @@
 package com.linkedin.davinci.client;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
 
+import com.linkedin.davinci.StoreBackend;
+import com.linkedin.davinci.VersionBackend;
 import com.linkedin.davinci.store.rocksdb.RocksDBServerConfig;
 import com.linkedin.venice.meta.ReadOnlySchemaRepository;
 import com.linkedin.venice.schema.SchemaEntry;
+import com.linkedin.venice.serializer.AvroSerializer;
 import com.linkedin.venice.utils.PropertyBuilder;
+import com.linkedin.venice.utils.ReferenceCounted;
 import com.linkedin.venice.utils.VeniceProperties;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.concurrent.ExecutionException;
 import org.apache.avro.Schema;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -49,5 +64,68 @@ public class AvroGenericDaVinciClientTest {
     RocksDBServerConfig dbconfig = new RocksDBServerConfig(config);
     Assert.assertEquals(schema, dbconfig.getTransformerValueSchema());
 
+  }
+
+  @Test
+  public void testSplit() {
+    Set<Integer> intSet = new TreeSet<>();
+    intSet.addAll(Arrays.asList(new Integer[] { 1, 2, 3, 4, 5, 6 }));
+    List<List<Integer>> splits = AvroGenericDaVinciClient.split(intSet, 4);
+    Assert.assertEquals(splits.size(), 2);
+    Assert.assertEquals(splits.get(0), Arrays.asList(new Integer[] { 1, 2, 3, 4 }));
+    Assert.assertEquals(splits.get(1), Arrays.asList(new Integer[] { 5, 6 }));
+    splits = AvroGenericDaVinciClient.split(intSet, 2);
+    Assert.assertEquals(splits.size(), 3);
+    Assert.assertEquals(splits.get(0), Arrays.asList(new Integer[] { 1, 2 }));
+    Assert.assertEquals(splits.get(1), Arrays.asList(new Integer[] { 3, 4 }));
+    Assert.assertEquals(splits.get(2), Arrays.asList(new Integer[] { 5, 6 }));
+  }
+
+  @Test
+  public void testBatchGetSplit() throws ExecutionException, InterruptedException {
+    AvroGenericDaVinciClient<String, String> dvcClient = mock(AvroGenericDaVinciClient.class);
+    when(dvcClient.getStoreName()).thenReturn("test_store");
+
+    String testValue = "test_value";
+    StoreBackend storeBackend = mock(StoreBackend.class);
+    VersionBackend versionBackend = mock(VersionBackend.class);
+    when(versionBackend.getSupersetOrLatestValueSchemaId()).thenReturn(1);
+    when(versionBackend.getPartition(any())).thenReturn(1);
+    when(versionBackend.read(anyInt(), any(), any(), any(), anyInt(), any(), any(), any())).thenReturn(testValue);
+    ReferenceCounted<VersionBackend> versionBackendReferenceCounted =
+        new ReferenceCounted<>(versionBackend, ignored -> {});
+    when(storeBackend.getDaVinciCurrentVersion()).thenReturn(versionBackendReferenceCounted);
+    when(dvcClient.getStoreBackend()).thenReturn(storeBackend);
+
+    when(dvcClient.getKeySerializer()).thenReturn(new AvroSerializer<>(Schema.create(Schema.Type.STRING)));
+    when(dvcClient.getStoreDeserializerCache()).thenReturn(null);
+    when(dvcClient.isPartitionReadyToServe(any(), anyInt())).thenReturn(true);
+    when(dvcClient.isPartitionSubscribed(any(), anyInt())).thenReturn(true);
+    when(dvcClient.batchGetFromLocalStorage(any())).thenCallRealMethod();
+
+    Set<String> keySet = new HashSet<>();
+    keySet.add("key_1");
+    keySet.add("key_2");
+    Map<String, String> resultMap = dvcClient.batchGetFromLocalStorage(keySet).get();
+    assertEquals(resultMap.size(), 2);
+    assertEquals(resultMap.get("key_1"), testValue);
+    assertEquals(resultMap.get("key_2"), testValue);
+
+    // Increase the reference to avoid counter underflow as mock object always returns the same referenced counted
+    // object.
+    versionBackendReferenceCounted.retain();
+
+    // Simulate a large request
+    Set<String> largeKeySet = new HashSet<>();
+    int keyCnt = (int) (AvroGenericDaVinciClient.CHUNK_SPLIT_THRESHOLD * 1.5);
+    String keyPrefix = "key_";
+    for (int i = 0; i < keyCnt; ++i) {
+      largeKeySet.add(keyPrefix + i);
+    }
+    resultMap = dvcClient.batchGetFromLocalStorage(largeKeySet).get();
+    assertEquals(resultMap.size(), keyCnt);
+    for (int i = 0; i < keyCnt; ++i) {
+      assertEquals(resultMap.get(keyPrefix + i), testValue);
+    }
   }
 }


### PR DESCRIPTION
Today, for large batch-get request, the latency will be high even the customer is using `MEMORY_BACKED_BY_DISK` mode. For example, in avg, the lookup latency is about 20us and for a request with 3k keys, the latency will be roughly 60ms, which is high and we often recommend customers to break it down into smaller chunks and execute these chunks in parallel. Now, this PR will add such support for batch-get as a default behavior.

TODO: add such support for compute request.

<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->


## How was this PR tested?
CI
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.