### PR TITLE
[dvc] Do not throw DIV segment MISSING when a host regains leadership after EOP

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/validation/PartitionTracker.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/validation/PartitionTracker.java
@@ -22,6 +22,7 @@ import com.linkedin.venice.kafka.protocol.state.ProducerPartitionState;
 import com.linkedin.venice.kafka.validation.Segment;
 import com.linkedin.venice.kafka.validation.checksum.CheckSumType;
 import com.linkedin.venice.message.KafkaKey;
+import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.offsets.OffsetRecord;
 import com.linkedin.venice.pubsub.api.PubSubMessage;
 import com.linkedin.venice.utils.CollectionUtils;
@@ -275,7 +276,8 @@ public class PartitionTracker {
        * So, when a host regains its leadership and re-consumes RT, DIV tolerates the segment gap for very first message
        * it meets and creates a new unregistered segment (based on the contents fo the impending message) to replace it.
        */
-      if (endOfPushReceived && previousSegment.isCreatedFromCheckPoint()) {
+      if (endOfPushReceived && previousSegment.isCreatedFromCheckPoint()
+          && Version.isRealTimeTopic(consumerRecord.getTopicName())) {
         return initializeNewSegment(consumerRecord, true, true);
       }
 
@@ -369,7 +371,7 @@ public class PartitionTracker {
       String errorMsgIdentifier = consumerRecord.getTopicPartition().getPubSubTopic().getName() + "-"
           + consumerRecord.getTopicPartition().getPartitionNumber() + "-" + DataFaultType.UNREGISTERED_PRODUCER;
       if (!REDUNDANT_LOGGING_FILTER.isRedundantException(errorMsgIdentifier)) {
-        logger.warn("Will {}, endOfPushReceived=true, tolerateAnyMessageType=true", scenario);
+        logger.info("Will {}, endOfPushReceived=true, tolerateAnyMessageType=true", scenario);
       }
     } else {
       throw DataFaultType.UNREGISTERED_PRODUCER.getNewException(

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/validation/TestPartitionTracker.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/validation/TestPartitionTracker.java
@@ -18,6 +18,7 @@ import com.linkedin.venice.kafka.protocol.state.ProducerPartitionState;
 import com.linkedin.venice.kafka.validation.Segment;
 import com.linkedin.venice.kafka.validation.checksum.CheckSumType;
 import com.linkedin.venice.message.KafkaKey;
+import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.offsets.OffsetRecord;
 import com.linkedin.venice.pubsub.ImmutablePubSubMessage;
 import com.linkedin.venice.pubsub.PubSubTopicPartitionImpl;
@@ -44,6 +45,8 @@ public class TestPartitionTracker {
   private PartitionTracker partitionTracker;
   private GUID guid;
   private String topic;
+
+  private String rtTopic;
   int partitionId = 0;
   private final PubSubTopicRepository pubSubTopicRepository = new PubSubTopicRepository();
 
@@ -53,7 +56,9 @@ public class TestPartitionTracker {
     this.guid = new GUID();
     guid.bytes(testGuid.getBytes());
     this.topic = "test_topic_" + System.currentTimeMillis() + "_v1";
+    this.rtTopic = Version.composeRealTimeTopic(Version.parseStoreFromKafkaTopicName(topic));
     this.partitionTracker = new PartitionTracker(topic, partitionId);
+
   }
 
   private KafkaMessageEnvelope getKafkaMessageEnvelope(
@@ -245,7 +250,7 @@ public class TestPartitionTracker {
   @Test(timeOut = 5 * Time.MS_PER_SECOND)
   public void testHandleFirstMessageAfterLoadingFromCheckPoint() {
     PubSubTopicPartition pubSubTopicPartition =
-        new PubSubTopicPartitionImpl(pubSubTopicRepository.getTopic(topic), partitionId);
+        new PubSubTopicPartitionImpl(pubSubTopicRepository.getTopic(this.rtTopic), partitionId);
     int segmentNum = 1;
     int sequenceNum = 1;
     int firstNewSegmentNumber = 5;

--- a/internal/venice-common/src/main/java/com/linkedin/venice/kafka/validation/Segment.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/kafka/validation/Segment.java
@@ -76,6 +76,13 @@ public class Segment {
   // record the last producer message time stamp passed within the ConsumerRecord
   private long lastRecordProducerTimestamp = -1;
 
+  /**
+   * Indicate if a segment is constructed from a check point. When a host regains its leadership and consume RT,
+   * DIV tolerates the segment gap for very first message it meets and creates a new unregistered segment to replace it.
+   * Only set to true when a segment is created from a check point or copy constructed into the leader DIV.
+   */
+  private final boolean isCreatedFromCheckPoint;
+
   public Segment(
       int partition,
       int segmentNumber,
@@ -93,6 +100,7 @@ public class Segment {
     this.newSegment = true;
     this.debugInfo = getDedupedDebugInfo(debugInfo);
     this.aggregates = aggregates;
+    this.isCreatedFromCheckPoint = false;
   }
 
   public Segment(int partition, int segmentNumber, CheckSumType checkSumType) {
@@ -118,6 +126,7 @@ public class Segment {
     this.aggregates = CollectionUtils.substituteEmptyMap(state.getAggregates());
     this.registered = state.isRegistered;
     this.lastRecordProducerTimestamp = state.messageTimestamp;
+    this.isCreatedFromCheckPoint = true;
   }
 
   public Segment(Segment segment) {
@@ -138,6 +147,11 @@ public class Segment {
     this.aggregates = segment.aggregates;
     this.registered = segment.registered;
     this.lastRecordProducerTimestamp = segment.lastRecordProducerTimestamp;
+    this.isCreatedFromCheckPoint = segment.isCreatedFromCheckPoint;
+  }
+
+  public boolean isCreatedFromCheckPoint() {
+    return isCreatedFromCheckPoint;
   }
 
   public int getSegmentNumber() {


### PR DESCRIPTION
…ip after EOP

DIV dumps its segments information into offset record periodically or before server shut down and loads the contents back during Helix state transition (OFFLINE->STANDBY) when the host is transitioned to follower and, when it becomes the leader, copied into the leader DIV.

For hybrid store partitions (after EOP), if a host went through a LEADER -> (OFFLINE ->) FOLLOWER -> LEADER transition, e.g. because of host shutdown, its DIV dumps and reloads segments as above described. However, today, if another host became the new leader (when it was offline or follower), did its leadershipduty by consuming messages from RT topic, producing to local VT etc, then when the previous host became the leader for the 2nd time, its DIV, after loading segment info from checkpoint, only contains the stale segment info in terms of the segment number for the RT topic, thus when it starts to consume, it will throw DIV MISSING error, which in most cases a false alarm.

This false alarm can happen very often as long as for a hybrid store partition, a host shuts down, rt topic keeps getting new data and consumed by new leader, old host starts again and regains the leadership for the same rt topic.

This rb introduces a flag to indicate if a segment is constructed from a check point. When a host regains its leadership and re-consumes RT, DIV tolerates the segment gap for very first message it meets and creates a new unregistered segment (based on the contents of the impending message) to replace it.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

- Frankenwar test
- Added new unit test
- passed GHA

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.