### PR TITLE
[dvc] Add config to return Da Vinci specific ExecutionStatus for Errors

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
@@ -129,6 +129,7 @@ import static com.linkedin.venice.ConfigKeys.SYSTEM_SCHEMA_CLUSTER_NAME;
 import static com.linkedin.venice.ConfigKeys.SYSTEM_SCHEMA_INITIALIZATION_AT_START_TIME_ENABLED;
 import static com.linkedin.venice.ConfigKeys.UNREGISTER_METRIC_FOR_DELETED_STORE_ENABLED;
 import static com.linkedin.venice.ConfigKeys.UNSORTED_INPUT_DRAINER_SIZE;
+import static com.linkedin.venice.ConfigKeys.USE_DA_VINCI_SPECIFIC_EXECUTION_STATUS_FOR_ERROR;
 import static com.linkedin.venice.pubsub.PubSubConstants.PUBSUB_TOPIC_MANAGER_METADATA_FETCHER_CONSUMER_POOL_SIZE_DEFAULT_VALUE;
 
 import com.linkedin.davinci.helix.LeaderFollowerPartitionStateModelFactory;
@@ -458,6 +459,7 @@ public class VeniceServerConfig extends VeniceClusterConfig {
   private final int nonExistingTopicCheckRetryIntervalSecond;
   private final boolean dedicatedConsumerPoolForAAWCLeaderEnabled;
   private final int dedicatedConsumerPoolSizeForAAWCLeader;
+  private final boolean useDaVinciSpecificExecutionStatusForError;
 
   public VeniceServerConfig(VeniceProperties serverProperties) throws ConfigurationException {
     this(serverProperties, Collections.emptyMap());
@@ -754,6 +756,8 @@ public class VeniceServerConfig extends VeniceClusterConfig {
         serverProperties.getBoolean(SERVER_DEDICATED_CONSUMER_POOL_FOR_AA_WC_LEADER_ENABLED, false);
     dedicatedConsumerPoolSizeForAAWCLeader =
         serverProperties.getInt(SERVER_DEDICATED_CONSUMER_POOL_SIZE_FOR_AA_WC_LEADER, 5);
+    useDaVinciSpecificExecutionStatusForError =
+        serverProperties.getBoolean(USE_DA_VINCI_SPECIFIC_EXECUTION_STATUS_FOR_ERROR, false);
   }
 
   long extractIngestionMemoryLimit(
@@ -1338,5 +1342,9 @@ public class VeniceServerConfig extends VeniceClusterConfig {
 
   public int getTopicManagerMetadataFetcherThreadPoolSize() {
     return topicManagerMetadataFetcherThreadPoolSize;
+  }
+
+  public boolean useDaVinciSpecificExecutionStatusForError() {
+    return useDaVinciSpecificExecutionStatusForError;
   }
 }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/DaVinciBackendTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/DaVinciBackendTest.java
@@ -1,6 +1,8 @@
 package com.linkedin.davinci;
 
 import static com.linkedin.venice.pushmonitor.ExecutionStatus.DVC_INGESTION_ERROR_OTHER;
+import static com.linkedin.venice.pushmonitor.ExecutionStatus.ERROR;
+import static com.linkedin.venice.utils.DataProviderUtils.BOOLEAN;
 import static com.linkedin.venice.utils.DataProviderUtils.allPermutationGenerator;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.fail;
@@ -14,16 +16,18 @@ import org.testng.annotations.Test;
 
 
 public class DaVinciBackendTest {
-  @DataProvider(name = "DvcErrorExecutionStatus")
-  public static Object[][] dvcErrorExecutionStatus() {
+  @DataProvider(name = "DvcErrorExecutionStatusAndBoolean")
+  public static Object[][] dvcErrorExecutionStatusAndBoolean() {
     return allPermutationGenerator((permutation) -> {
       ExecutionStatus status = (ExecutionStatus) permutation[0];
       return status.isDVCIngestionError();
-    }, ExecutionStatus.values());
+    }, ExecutionStatus.values(), BOOLEAN);
   }
 
-  @Test(dataProvider = "DvcErrorExecutionStatus")
-  public void testGetDaVinciErrorStatus(ExecutionStatus executionStatus) {
+  @Test(dataProvider = "DvcErrorExecutionStatusAndBoolean")
+  public void testGetDaVinciErrorStatus(
+      ExecutionStatus executionStatus,
+      boolean useDaVinciSpecificExecutionStatusForError) {
     VeniceException veniceException;
     switch (executionStatus) {
       case DVC_INGESTION_ERROR_DISK_FULL:
@@ -40,15 +44,23 @@ public class DaVinciBackendTest {
         fail("Unexpected execution status: " + executionStatus);
         return;
     }
-    assertEquals(
-        DaVinciBackend.getDaVinciErrorStatus(veniceException),
-        executionStatus.equals(ExecutionStatus.DVC_INGESTION_ERROR_TOO_MANY_DEAD_INSTANCES)
-            ? DVC_INGESTION_ERROR_OTHER
-            : executionStatus);
+    if (useDaVinciSpecificExecutionStatusForError) {
+      assertEquals(
+          DaVinciBackend.getDaVinciErrorStatus(veniceException, useDaVinciSpecificExecutionStatusForError),
+          executionStatus.equals(ExecutionStatus.DVC_INGESTION_ERROR_TOO_MANY_DEAD_INSTANCES)
+              ? DVC_INGESTION_ERROR_OTHER
+              : executionStatus);
+    } else {
+      assertEquals(
+          DaVinciBackend.getDaVinciErrorStatus(veniceException, useDaVinciSpecificExecutionStatusForError),
+          ERROR);
+    }
   }
 
-  @Test(dataProvider = "DvcErrorExecutionStatus")
-  public void testGetDaVinciErrorStatusNested(ExecutionStatus executionStatus) {
+  @Test(dataProvider = "DvcErrorExecutionStatusAndBoolean")
+  public void testGetDaVinciErrorStatusNested(
+      ExecutionStatus executionStatus,
+      boolean useDaVinciSpecificExecutionStatusForError) {
     VeniceException veniceException;
     switch (executionStatus) {
       case DVC_INGESTION_ERROR_DISK_FULL:
@@ -65,15 +77,23 @@ public class DaVinciBackendTest {
         fail("Unexpected execution status: " + executionStatus);
         return;
     }
-    assertEquals(
-        DaVinciBackend.getDaVinciErrorStatus(veniceException),
-        executionStatus.equals(ExecutionStatus.DVC_INGESTION_ERROR_TOO_MANY_DEAD_INSTANCES)
-            ? DVC_INGESTION_ERROR_OTHER
-            : executionStatus);
+    if (useDaVinciSpecificExecutionStatusForError) {
+      assertEquals(
+          DaVinciBackend.getDaVinciErrorStatus(veniceException, useDaVinciSpecificExecutionStatusForError),
+          executionStatus.equals(ExecutionStatus.DVC_INGESTION_ERROR_TOO_MANY_DEAD_INSTANCES)
+              ? DVC_INGESTION_ERROR_OTHER
+              : executionStatus);
+    } else {
+      assertEquals(
+          DaVinciBackend.getDaVinciErrorStatus(veniceException, useDaVinciSpecificExecutionStatusForError),
+          ERROR);
+    }
   }
 
-  @Test(dataProvider = "DvcErrorExecutionStatus")
-  public void testGetDaVinciErrorStatusWithInvalidCases(ExecutionStatus executionStatus) {
+  @Test(dataProvider = "DvcErrorExecutionStatusAndBoolean")
+  public void testGetDaVinciErrorStatusWithInvalidCases(
+      ExecutionStatus executionStatus,
+      boolean useDaVinciSpecificExecutionStatusForError) {
     VeniceException veniceException;
     switch (executionStatus) {
       case DVC_INGESTION_ERROR_DISK_FULL:
@@ -87,7 +107,16 @@ public class DaVinciBackendTest {
         return;
     }
 
-    assertEquals(DaVinciBackend.getDaVinciErrorStatus(veniceException), DVC_INGESTION_ERROR_OTHER);
+    if (useDaVinciSpecificExecutionStatusForError) {
+      assertEquals(
+          DaVinciBackend.getDaVinciErrorStatus(veniceException, useDaVinciSpecificExecutionStatusForError),
+          DVC_INGESTION_ERROR_OTHER);
+
+    } else {
+      assertEquals(
+          DaVinciBackend.getDaVinciErrorStatus(veniceException, useDaVinciSpecificExecutionStatusForError),
+          ERROR);
+    }
   }
 
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -1757,6 +1757,13 @@ public class ConfigKeys {
       "push.status.store.heartbeat.expiration.seconds";
 
   /**
+   * when enabled, Da Vinci Clients returns specific status codes to indicate the type of ingestion failure
+   * rather than a generic {@link com.linkedin.venice.pushmonitor.ExecutionStatus.ERROR}
+   */
+  public static final String USE_DA_VINCI_SPECIFIC_EXECUTION_STATUS_FOR_ERROR =
+      "use.da.vinci.specific.execution.status.for.error";
+
+  /**
    * Whether to throttle SSL connections between router and client.
    */
   public static final String ROUTER_THROTTLE_CLIENT_SSL_HANDSHAKES = "router.throttle.client.ssl.handshakes";


### PR DESCRIPTION
## Summary
* Added a config `use.da.vinci.specific.execution.status.for.error` to enable/disable returning newly added Da Vinci specific `ExecutionStatus` for Errors in Da VInci clients.
* Its disabled by default and can be enabled back again after the new code is in all components

## How was this PR tested?
GH CI

## Does this PR introduce any user-facing changes?
- [] No. You can skip the rest of this section.
- [x] Yes. Make sure to explain your proposed changes and call out the behavior change.
New config `use.da.vinci.specific.execution.status.for.error` to enable/disable the new statuses.