### PR TITLE
[cc] Expose partitionCount from VeniceChangelogConsumer

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumer.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumer.java
@@ -18,6 +18,11 @@ import java.util.concurrent.CompletableFuture;
 @Experimental
 public interface VeniceChangelogConsumer<K, V> {
   /**
+   * @return total number of store partitions
+  */
+  int getPartitionCount();
+
+  /**
    * Subscribe a set of partitions for a store to this VeniceChangelogConsumer. The VeniceChangelogConsumer should try
    * to consume messages from all partitions that are subscribed to it.
    *

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImpl.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImpl.java
@@ -155,6 +155,11 @@ public class VeniceChangelogConsumerImpl<K, V> implements VeniceChangelogConsume
   }
 
   @Override
+  public int getPartitionCount() {
+    return partitionCount;
+  }
+
+  @Override
   public CompletableFuture<Void> subscribe(Set<Integer> partitions) {
     return internalSubscribe(partitions, null);
   }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImplTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImplTest.java
@@ -127,8 +127,9 @@ public class VeniceChangelogConsumerImplTest {
             .setViewName("changeCaptureView");
     VeniceChangelogConsumerImpl<String, Utf8> veniceChangelogConsumer =
         new VeniceChangelogConsumerImpl<>(changelogClientConfig, mockPubSubConsumer);
-    ThinClientMetaStoreBasedRepository mockRepository = mock(ThinClientMetaStoreBasedRepository.class);
+    Assert.assertEquals(veniceChangelogConsumer.getPartitionCount(), 2);
 
+    ThinClientMetaStoreBasedRepository mockRepository = mock(ThinClientMetaStoreBasedRepository.class);
     Store store = mock(Store.class);
     Version mockVersion = new VersionImpl(storeName, 1, "foo");
     Mockito.when(store.getCurrentVersion()).thenReturn(1);
@@ -204,6 +205,8 @@ public class VeniceChangelogConsumerImplTest {
         mockPubSubConsumer,
         Lazy.of(() -> mockInternalSeekConsumer));
     veniceChangelogConsumer.versionSwapDetectionIntervalTimeInMs = 1;
+    Assert.assertEquals(veniceChangelogConsumer.getPartitionCount(), 2);
+
     ThinClientMetaStoreBasedRepository mockRepository = mock(ThinClientMetaStoreBasedRepository.class);
     Store store = mock(Store.class);
     Version mockVersion = new VersionImpl(storeName, 1, "foo");
@@ -253,6 +256,8 @@ public class VeniceChangelogConsumerImplTest {
             .setViewName("");
     VeniceChangelogConsumerImpl<String, Utf8> veniceChangelogConsumer =
         new VeniceAfterImageConsumerImpl<>(changelogClientConfig, mockPubSubConsumer);
+    Assert.assertEquals(veniceChangelogConsumer.getPartitionCount(), 2);
+
     ThinClientMetaStoreBasedRepository mockRepository = mock(ThinClientMetaStoreBasedRepository.class);
     Store store = mock(Store.class);
     Version mockVersion = new VersionImpl(storeName, 1, "foo");


### PR DESCRIPTION
## Summary
Exposed total partition count of store from VeniceChangelogConsumer to programmatically facilitate parallel processing (eg. VeniceIO).

## How was this PR tested?
GH CI

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [X] Yes. Make sure to explain your proposed changes and call out the behavior change.
New method `getPartitionCount` added to experimental `VeniceChangelogConsumer` interface.