### PR TITLE
Add heartbeat lag metrics to change capture client

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/ChangelogClientConfig.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/ChangelogClientConfig.java
@@ -12,6 +12,8 @@ public class ChangelogClientConfig<T extends SpecificRecord> {
   private Properties consumerProperties;
   private SchemaReader schemaReader;
   private String viewName;
+
+  private String consumerName = "";
   private ClientConfig<T> innerClientConfig;
   private D2ControllerClient d2ControllerClient;
 
@@ -72,8 +74,17 @@ public class ChangelogClientConfig<T extends SpecificRecord> {
     return this;
   }
 
+  public ChangelogClientConfig<T> setConsumerName(String consumerName) {
+    this.consumerName = consumerName;
+    return this;
+  }
+
   public String getViewName() {
     return viewName;
+  }
+
+  public String getConsumerName() {
+    return consumerName;
   }
 
   public ChangelogClientConfig<T> setControllerD2ServiceName(String controllerD2ServiceName) {
@@ -190,6 +201,7 @@ public class ChangelogClientConfig<T extends SpecificRecord> {
         .setBootstrapFileSystemPath(config.getBootstrapFileSystemPath())
         .setVersionSwapDetectionIntervalTimeInMs(config.getVersionSwapDetectionIntervalTimeInMs())
         .setRocksDBBlockCacheSizeInBytes(config.getRocksDBBlockCacheSizeInBytes())
+        .setConsumerName(config.consumerName)
         .setDatabaseSyncBytesInterval(config.getDatabaseSyncBytesInterval());
     return newConfig;
   }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerClientFactory.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerClientFactory.java
@@ -69,6 +69,7 @@ public class VeniceChangelogConsumerClientFactory {
   public <K, V> VeniceChangelogConsumer<K, V> getChangelogConsumer(String storeName, String consumerId) {
     return storeClientMap.computeIfAbsent(suffixConsumerIdToStore(storeName, consumerId), name -> {
       ChangelogClientConfig newStoreChangelogClientConfig = getNewStoreChangelogClientConfig(storeName);
+      newStoreChangelogClientConfig.setConsumerName(name);
       String viewClass = getViewClass(newStoreChangelogClientConfig, storeName);
       String consumerName = suffixConsumerIdToStore(storeName + "-" + viewClass.getClass().getSimpleName(), consumerId);
       if (viewClass.equals(ChangeCaptureView.class.getCanonicalName())) {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImpl.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImpl.java
@@ -1,6 +1,6 @@
 package com.linkedin.davinci.consumer;
 
-import static com.linkedin.venice.kafka.protocol.enums.ControlMessageType.*;
+import static com.linkedin.venice.kafka.protocol.enums.ControlMessageType.START_OF_SEGMENT;
 import static com.linkedin.venice.schema.rmd.RmdConstants.REPLICATION_CHECKPOINT_VECTOR_FIELD_POS;
 
 import com.google.common.annotations.VisibleForTesting;

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImpl.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImpl.java
@@ -530,7 +530,9 @@ public class VeniceChangelogConsumerImpl<K, V> implements VeniceChangelogConsume
         }
       }
     }
-    changeCaptureStats.recordRecordsConsumed(pubSubMessages.size());
+    if (changeCaptureStats != null) {
+      changeCaptureStats.recordRecordsConsumed(pubSubMessages.size());
+    }
     return pubSubMessages;
   }
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImpl.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImpl.java
@@ -530,6 +530,7 @@ public class VeniceChangelogConsumerImpl<K, V> implements VeniceChangelogConsume
         }
       }
     }
+    changeCaptureStats.recordRecordsConsumed(pubSubMessages.size());
     return pubSubMessages;
   }
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImpl.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImpl.java
@@ -896,7 +896,7 @@ public class VeniceChangelogConsumerImpl<K, V> implements VeniceChangelogConsume
           changeCaptureStats.recordLag(System.currentTimeMillis() - lastHeartbeat);
         }
         try {
-          TimeUnit.SECONDS.sleep(60000L);
+          TimeUnit.SECONDS.sleep(60L);
         } catch (InterruptedException e) {
           // We've received an interrupt which is to be expected, so we'll just leave the loop and log
           break;

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/stats/BasicConsumerStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/stats/BasicConsumerStats.java
@@ -1,0 +1,20 @@
+package com.linkedin.davinci.consumer.stats;
+
+import com.linkedin.venice.stats.AbstractVeniceStats;
+import io.tehuti.metrics.MetricsRepository;
+import io.tehuti.metrics.Sensor;
+import io.tehuti.metrics.stats.Max;
+
+
+public class BasicConsumerStats extends AbstractVeniceStats {
+  public BasicConsumerStats(MetricsRepository metricsRepository, String name) {
+    super(metricsRepository, name);
+    maxLagSensor = registerSensor("max_partition_lag", new Max());
+  }
+
+  private final Sensor maxLagSensor;
+
+  public void recordLag(Long lag) {
+    maxLagSensor.record(lag);
+  }
+}

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/stats/BasicConsumerStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/stats/BasicConsumerStats.java
@@ -3,18 +3,25 @@ package com.linkedin.davinci.consumer.stats;
 import com.linkedin.venice.stats.AbstractVeniceStats;
 import io.tehuti.metrics.MetricsRepository;
 import io.tehuti.metrics.Sensor;
+import io.tehuti.metrics.stats.Avg;
 import io.tehuti.metrics.stats.Max;
 
 
 public class BasicConsumerStats extends AbstractVeniceStats {
+  private final Sensor maxLagSensor;
+  private final Sensor recordsConsumed;
+
   public BasicConsumerStats(MetricsRepository metricsRepository, String name) {
     super(metricsRepository, name);
     maxLagSensor = registerSensor("max_partition_lag", new Max());
+    recordsConsumed = registerSensor("records_consumed", new Avg(), new Max());
   }
-
-  private final Sensor maxLagSensor;
 
   public void recordLag(Long lag) {
     maxLagSensor.record(lag);
+  }
+
+  public void recordRecordsConsumed(int count) {
+    recordsConsumed.record(count);
   }
 }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImplTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImplTest.java
@@ -377,6 +377,9 @@ public class VeniceChangelogConsumerImplTest {
     versionSwapMessage.localHighWatermarks = localHighWatermarks;
 
     KafkaMessageEnvelope kafkaMessageEnvelope = new KafkaMessageEnvelope();
+    ProducerMetadata producerMetadata = new ProducerMetadata();
+    producerMetadata.setMessageTimestamp(1000L);
+    kafkaMessageEnvelope.setProducerMetadata(producerMetadata);
     ControlMessage controlMessage = new ControlMessage();
     controlMessage.controlMessageUnion = versionSwapMessage;
     controlMessage.controlMessageType = ControlMessageType.VERSION_SWAP.getValue();
@@ -406,11 +409,14 @@ public class VeniceChangelogConsumerImplTest {
     final RecordSerializer<RecordChangeEvent> recordChangeSerializer = FastSerializerDeserializerFactory
         .getFastAvroGenericSerializer(AvroProtocolDefinition.RECORD_CHANGE_EVENT.getCurrentProtocolVersionSchema());
     recordChangeSerializer.serialize(recordChangeEvent);
+    ProducerMetadata producerMetadata = new ProducerMetadata();
+    producerMetadata.setMessageTimestamp(1000L);
     KafkaMessageEnvelope kafkaMessageEnvelope = new KafkaMessageEnvelope(
         MessageType.PUT.getValue(),
-        new ProducerMetadata(),
+        producerMetadata,
         new Put(ByteBuffer.wrap(recordChangeSerializer.serialize(recordChangeEvent)), 0, 0, ByteBuffer.allocate(0)),
         null);
+    kafkaMessageEnvelope.setProducerMetadata(producerMetadata);
     KafkaKey kafkaKey = new KafkaKey(MessageType.PUT, keySerializer.serialize(key));
     PubSubTopicPartition pubSubTopicPartition = new PubSubTopicPartitionImpl(changeCaptureVersionTopic, partition);
     return new ImmutablePubSubMessage<>(kafkaKey, kafkaMessageEnvelope, pubSubTopicPartition, 0, 0, 0);
@@ -427,9 +433,11 @@ public class VeniceChangelogConsumerImplTest {
     rmdRecord.put(RmdConstants.REPLICATION_CHECKPOINT_VECTOR_FIELD_NAME, replicationCheckpointVector);
     ByteBuffer bytes =
         ByteBuffer.wrap(FastSerializerDeserializerFactory.getFastAvroGenericSerializer(rmdSchema).serialize(rmdRecord));
+    ProducerMetadata producerMetadata = new ProducerMetadata();
+    producerMetadata.messageTimestamp = 10000L;
     KafkaMessageEnvelope kafkaMessageEnvelope = new KafkaMessageEnvelope(
         MessageType.PUT.getValue(),
-        new ProducerMetadata(),
+        producerMetadata,
         new Put(ByteBuffer.wrap(valueSerializer.serialize(newValue)), 1, 1, bytes),
         null);
     KafkaKey kafkaKey = new KafkaKey(MessageType.PUT, keySerializer.serialize(key));
@@ -444,6 +452,9 @@ public class VeniceChangelogConsumerImplTest {
     KafkaKey kafkaKey = new KafkaKey(MessageType.CONTROL_MESSAGE, null);
     EndOfPush endOfPush = new EndOfPush();
     KafkaMessageEnvelope kafkaMessageEnvelope = new KafkaMessageEnvelope();
+    ProducerMetadata producerMetadata = new ProducerMetadata();
+    producerMetadata.setMessageTimestamp(1000L);
+    kafkaMessageEnvelope.setProducerMetadata(producerMetadata);
     ControlMessage controlMessage = new ControlMessage();
     controlMessage.controlMessageUnion = endOfPush;
     controlMessage.controlMessageType = ControlMessageType.END_OF_PUSH.getValue();
@@ -459,6 +470,9 @@ public class VeniceChangelogConsumerImplTest {
     StartOfPush startOfPush = new StartOfPush();
     startOfPush.compressionStrategy = CompressionStrategy.NO_OP.getValue();
     KafkaMessageEnvelope kafkaMessageEnvelope = new KafkaMessageEnvelope();
+    ProducerMetadata producerMetadata = new ProducerMetadata();
+    producerMetadata.setMessageTimestamp(1000L);
+    kafkaMessageEnvelope.setProducerMetadata(producerMetadata);
     ControlMessage controlMessage = new ControlMessage();
     controlMessage.controlMessageUnion = startOfPush;
     controlMessage.controlMessageType = ControlMessageType.START_OF_PUSH.getValue();


### PR DESCRIPTION
## Add heartbeat lag metrics to change capture client

This works similar to the heartbeat lag measure done in server.  This tracks the time of last consumed heartbeat from the version topic.

Resolves #XXX

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.