### PR TITLE
[admin-tool] Enable decompression in admin tool topic dumper

### DIFF
--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/TopicMessageFinder.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/TopicMessageFinder.java
@@ -55,6 +55,11 @@ public class TopicMessageFinder {
     int partitionCount = storeInfo.getPartitionCount();
     // Parse key string and figure out the right partition
     byte[] serializedKey = serializeKey(keyString, keySchemaStr);
+
+    // Partition assignment is always based on the non-chunked key.
+    int assignedPartition = new DefaultVenicePartitioner().getPartitionId(serializedKey, partitionCount);
+    LOGGER.info("Assigned partition: {} for key: {}", assignedPartition, keyString);
+
     if (version != -1) {
       if (storeInfo.getVersion(version).isPresent()) {
         if (storeInfo.getVersion(version).get().isChunkingEnabled()) {
@@ -69,9 +74,6 @@ public class TopicMessageFinder {
       throw new VeniceException("Invalid partition count: " + partitionCount);
     }
     LOGGER.info("Got partition count: {}", partitionCount);
-
-    int assignedPartition = new DefaultVenicePartitioner().getPartitionId(serializedKey, partitionCount);
-    LOGGER.info("Assigned partition: {} for key: {}", assignedPartition, keyString);
 
     long startOffset;
     long endOffset;

--- a/clients/venice-admin-tool/src/test/java/com/linkedin/venice/TestKafkaTopicDumper.java
+++ b/clients/venice-admin-tool/src/test/java/com/linkedin/venice/TestKafkaTopicDumper.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.linkedin.venice.chunking.TestChunkingUtils;
+import com.linkedin.venice.compression.CompressionStrategy;
 import com.linkedin.venice.controllerapi.ControllerClient;
 import com.linkedin.venice.controllerapi.MultiSchemaResponse;
 import com.linkedin.venice.controllerapi.SchemaResponse;
@@ -66,6 +67,7 @@ public class TestKafkaTopicDumper {
     StoreInfo storeInfo = mock(StoreInfo.class);
 
     Version version = mock(Version.class);
+    when(version.getCompressionStrategy()).thenReturn(CompressionStrategy.NO_OP);
     when(version.isChunkingEnabled()).thenReturn(true);
 
     when(storeInfo.getPartitionCount()).thenReturn(2);
@@ -188,6 +190,7 @@ public class TestKafkaTopicDumper {
     StoreResponse storeResponse = mock(StoreResponse.class);
     StoreInfo storeInfo = mock(StoreInfo.class);
     Version version = mock(Version.class);
+    when(version.getCompressionStrategy()).thenReturn(CompressionStrategy.NO_OP);
     when(version.isChunkingEnabled()).thenReturn(false);
     when(storeInfo.getPartitionCount()).thenReturn(1);
     when(storeInfo.isActiveActiveReplicationEnabled()).thenReturn(true);

--- a/internal/venice-common/src/main/java/com/linkedin/venice/utils/DictionaryUtils.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/utils/DictionaryUtils.java
@@ -54,7 +54,7 @@ public class DictionaryUtils {
    * @return The compression dictionary wrapped in a ByteBuffer, or null if no dictionary was present in the
    * Start Of Push message.
    */
-  static ByteBuffer readDictionaryFromKafka(
+  public static ByteBuffer readDictionaryFromKafka(
       String topicName,
       PubSubConsumerAdapter pubSubConsumer,
       PubSubTopicRepository pubSubTopicRepository) {


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Enable decompression in admin tool topic dumper
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
This PR enables the `KafkaTopicDumper` in Admin tool to dump compressed records. It also fixes `TopicMessageFinder` to use serialized key without the chunking suffix to determine the partition

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
Tested manually.

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.