### PR TITLE
[doc] Standardize and fix links in docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -54,14 +54,14 @@ Venice is a system which straddles the offline, nearline and online worlds, as i
 The Venice write path can be broken down into three granularities: full dataset swap, insertion of many rows into an 
 existing dataset, and updates of some columns of some rows. All three granularities are supported by Hadoop and Samza.
 In addition, any service can asynchronously produce single row inserts and updates as well, using the 
-[Online Producer](user_guide/write_api/online_producer.md) library. The table below summarizes the write operations 
+[Online Producer](./user_guide/write_api/online_producer.md) library. The table below summarizes the write operations 
 supported by each platform:
 
-|                                                  | [Hadoop](user_guide/write_api/push_job.md) | [Samza](user_guide/write_api/stream_processor.md) | [Any Service](user_guide/write_api/online_producer.md) |
-|-------------------------------------------------:|:------------------------------------------:|:-------------------------------------------------:|:------------------------------------------------------:|
-|                                Full dataset swap |                     ✅                      |                         ✅                         |                                                        |
-|  Insertion of some rows into an existing dataset |                     ✅                      |                         ✅                         |                           ✅                            |
-|             Updates to some columns of some rows |                     ✅                      |                         ✅                         |                           ✅                            |
+|                                                  | [Hadoop](./user_guide/write_api/push_job.md) | [Samza](./user_guide/write_api/stream_processor.md) | [Any Service](./user_guide/write_api/online_producer.md) |
+|-------------------------------------------------:|:--------------------------------------------:|:---------------------------------------------------:|:--------------------------------------------------------:|
+|                                Full dataset swap |                      ✅                       |                          ✅                          |                                                          |
+|  Insertion of some rows into an existing dataset |                      ✅                       |                          ✅                          |                            ✅                             |
+|             Updates to some columns of some rows |                      ✅                       |                          ✅                          |                            ✅                             |
 
 ### Hybrid Stores
 Moreover, the three granularities of write operations can all be mixed within a single dataset. A dataset which gets 
@@ -131,11 +131,11 @@ cost/performance tradeoff without needing to rewrite their applications.
 
 The Open Sourcing Venice [blog](https://engineering.linkedin.com/blog/2022/open-sourcing-venice--linkedin-s-derived-data-platform)
 and [conference talk](https://www.youtube.com/watch?v=pJeg4V3JgYo) are good starting points to get an overview of what
-use cases and scale can Venice support. For more Venice posts, talks and podcasts, see our [Learn More](user_guide/learn_more.md)
+use cases and scale can Venice support. For more Venice posts, talks and podcasts, see our [Learn More](./user_guide/learn_more.md)
 page.
 
 ## Getting Started
-Refer to the [Venice quickstart](quickstart/quickstart.md) to create your own Venice cluster and play around with some 
+Refer to the [Venice quickstart](./quickstart/quickstart.md) to create your own Venice cluster and play around with some 
 features like creating a data store, batch push, incremental push, and single get. We recommend sticking to our latest 
 [stable release](https://blog.venicedb.org/stable-releases).
 

--- a/docs/dev_guide/dev_guide.md
+++ b/docs/dev_guide/dev_guide.md
@@ -6,5 +6,5 @@ permalink: /docs/dev_guide
 ---
 # Developer Guide
 
-This section includes guides for Venice developers. New contributors should visit the [How to Contribute to Venice](how_to/how_to.md)
+This section includes guides for Venice developers. New contributors should visit the [How to Contribute to Venice](./how_to/how_to.md)
 subsection to get started. The rest of the section is to document implementation details.

--- a/docs/dev_guide/how_to/CONTRIBUTING.md
+++ b/docs/dev_guide/how_to/CONTRIBUTING.md
@@ -17,7 +17,7 @@ license.
 
 # Responsible Disclosure of Security Vulnerabilities
 
-Please refer to our [Security Policy](SECURITY.md) for our policy on
+Please refer to our [Security Policy](./SECURITY.md) for our policy on
 responsibly reporting security vulnerabilities.
 
 # Contribution Process
@@ -33,7 +33,7 @@ For any PR, a GitHub issue is required.
 If you want to contribute something new, and it's not tracked in existing GitHub issues, please create a new 
 GitHub issue and the community will help review the idea. Please state `why` in your GitHub issue. 
 If you already have a short design in mind or change is not small please check the 
-[Venice Improvement Proposal](design_doc.md) 
+[Venice Improvement Proposal](./design_doc.md) 
 
 If you have any feature request, please create a new GitHub issue and the community will collect your feature request and work on it.
 
@@ -41,8 +41,8 @@ If you have any user feedback, please create a new GitHub issue and the communit
 
 ## For New Contributors
 
-Please follow [Venice Workspace Setup](workspace_setup.md) and
-[Venice Recommended Development Workflow](recommended_development_workflow.md)
+Please follow [Venice Workspace Setup](./workspace_setup.md) and
+[Venice Recommended Development Workflow](./recommended_development_workflow.md)
 
 ## Tips for Getting Your Pull Request Accepted
 
@@ -68,4 +68,4 @@ Venice does Contributor sync meeting for the contributors to come togather in a 
 
 ## Code of Conduct
 
-This project and everyone who participates in it is governed by the [Venice Code of Conduct](CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code. Please report unacceptable behavior on [Slack](https://venicedb.slack.com/archives/C03SLQWRSLF).
+This project and everyone who participates in it is governed by the [Venice Code of Conduct](./CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code. Please report unacceptable behavior on [Slack](https://venicedb.slack.com/archives/C03SLQWRSLF).

--- a/docs/dev_guide/how_to/design_doc.md
+++ b/docs/dev_guide/how_to/design_doc.md
@@ -50,13 +50,13 @@ The process works in the following way:
 
 1. The author(s) of the proposal will create a file named "VIP-xxx.md" in [proposal](../../proposals) folder
     cloning from the [template for VIP proposals](../../proposals/VIP_TEMPLATE.md). The "xxx" number should 
-    be chosen to be the next number from the existing VIP issues, listed [here](../../docs/proposals/)
+    be chosen to be the next number from the existing VIP issues, listed [here](../../proposals/proposals.md)
 2. The author(s) submit this file as a PR named "VIP-xxx: {short description}" in **DRAFT**/**DISCUSSION** stage.
 3. People discuss using PR comments, each is its own threaded comment. 
    General comments can be made as general comment in the PR. There are two other ways for an interactive
    discussion. 
    1. Venice Community [Slack Channel](http://slack.venicedb.org/), Create a slack channel with #VIP-xxx
-   2. Venice Contributor Sync Meeting, see details [here](CONTRIBUTING.md) at Contributor Sync Meeting
+   2. Venice Contributor Sync Meeting, see details [here](./CONTRIBUTING.md) at Contributor Sync Meeting
 4. Depending on the outcome of the discussion, the status could move to **ACCEPTED** or **REJECTED**, or it could stay 
    in **DISCUSSION** stage (e.g. if we agree tentatively on the broad strokes, but there are still action items to 
    refine certain aspects). At the end of this, the PR gets merged, and at that point the VIP will appear in the 

--- a/docs/dev_guide/how_to/recommended_development_workflow.md
+++ b/docs/dev_guide/how_to/recommended_development_workflow.md
@@ -13,7 +13,7 @@ permalink: /docs/dev_guide/how_to/recommended_development_workflow
 If your change is relatively minor, you can skip this step. If you are adding new major functionality, we suggest that 
 you add a design document and solicit comments from the community before submitting any code.
 
-Please follow the [Design Document Guide](design_doc.md). 
+Please follow the [Design Document Guide](./design_doc.md). 
 
 
 ## Creating GitHub issue

--- a/docs/proposals/VIP_TEMPLATE.md
+++ b/docs/proposals/VIP_TEMPLATE.md
@@ -2,7 +2,7 @@
 layout: default
 title: VIP-`$VIP_Number` `$VIP_Title`
 parent: Proposals
-permalink: /docs/proposals/VIP_TEMPLATE.md
+permalink: /docs/proposals/vip_template
 ---
 
 # VIP-`$VIP_Number`: `$VIP_Title`

--- a/docs/proposals/VIP_TEMPLATE.md
+++ b/docs/proposals/VIP_TEMPLATE.md
@@ -1,7 +1,8 @@
 ---
 layout: default
-title: VIP-`$VIP_Number` `$VIP_Title`
+title: VIP Template # Replace this with "VIP-{VIP_Number} {VIP_Title}"
 parent: Proposals
+
 permalink: /docs/proposals/vip_template
 ---
 

--- a/docs/proposals/proposals.md
+++ b/docs/proposals/proposals.md
@@ -11,9 +11,9 @@ This folder includes all the Venice Improvement Proposals. Click to read further
 
 [VIP process](../dev_guide/how_to/design_doc.md). 
 
-| VIP-#             | Proposal                                                                       | Status           |
-|-------------------|--------------------------------------------------------------------------------|------------------|
-| [VIP-1](vip-1.md) | Authentication Service API                                                     | Accepted         |
-| [VIP-2](vip-2.md) | Removing Per Record Offset Metadata From Venice-Server Storage With Heartbeats | Under Discussion |
-| [VIP-3](vip-3.md) | Rust Server Read Path                                                          | Under Discussion |
-| [VIP-4](vip-4.md) | Store Lifecycle Hooks                                                          | Accepted         |
+| VIP-#               | Proposal                                                                       | Status           |
+|---------------------|--------------------------------------------------------------------------------|------------------|
+| [VIP-1](./vip-1.md) | Authentication Service API                                                     | Accepted         |
+| [VIP-2](./vip-2.md) | Removing Per Record Offset Metadata From Venice-Server Storage With Heartbeats | Under Discussion |
+| [VIP-3](./vip-3.md) | Rust Server Read Path                                                          | Under Discussion |
+| [VIP-4](./vip-4.md) | Store Lifecycle Hooks                                                          | Accepted         |

--- a/docs/user_guide/write_api/stream_processor.md
+++ b/docs/user_guide/write_api/stream_processor.md
@@ -9,7 +9,7 @@ permalink: /docs/user_guide/write_api/stream_processor
 
 Data can be produced to Venice in a nearline fashion, from stream processors. The best supported stream processor is
 Apache Samza though we intend to add first-class support for other stream processors in the future. The difference
-between using a stream processor library and the [Online Producer](online_producer.md) library is that a stream 
+between using a stream processor library and the [Online Producer](./online_producer.md) library is that a stream 
 processor has well-defined semantics around when to ensure that produced data is flushed and a built-in mechanism to 
 checkpoint its progress relative to its consumption progress in upstream data sources, whereas the online producer 
 library is a lower-level building block which leaves these reliability details up to the user.


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Standardize and fix links in docs
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
Some links in our docs were broken. This PR standardizes to use relative paths, and fixes some broken links. These links work well in README and the website. 

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
Tested manually. Deployed here: https://nisargthakkar.github.io/venice/

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.