### PR TITLE
[router][server][alpini] Add support for IdentityParser in SslInitializer

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
@@ -13,6 +13,7 @@ import static com.linkedin.venice.ConfigKeys.GRPC_READ_SERVER_PORT;
 import static com.linkedin.venice.ConfigKeys.GRPC_SERVER_WORKER_THREAD_COUNT;
 import static com.linkedin.venice.ConfigKeys.HELIX_HYBRID_STORE_QUOTA_ENABLED;
 import static com.linkedin.venice.ConfigKeys.HYBRID_QUOTA_ENFORCEMENT_ENABLED;
+import static com.linkedin.venice.ConfigKeys.IDENTITY_PARSER_CLASS;
 import static com.linkedin.venice.ConfigKeys.INGESTION_MEMORY_LIMIT;
 import static com.linkedin.venice.ConfigKeys.INGESTION_MEMORY_LIMIT_STORE_LIST;
 import static com.linkedin.venice.ConfigKeys.INGESTION_MLOCK_ENABLED;
@@ -138,6 +139,7 @@ import com.linkedin.davinci.kafka.consumer.KafkaConsumerService;
 import com.linkedin.davinci.kafka.consumer.RemoteIngestionRepairService;
 import com.linkedin.davinci.store.rocksdb.RocksDBServerConfig;
 import com.linkedin.davinci.validation.KafkaDataIntegrityValidator;
+import com.linkedin.venice.authorization.DefaultIdentityParser;
 import com.linkedin.venice.exceptions.ConfigurationException;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.meta.IngestionMode;
@@ -462,6 +464,7 @@ public class VeniceServerConfig extends VeniceClusterConfig {
   private final int dedicatedConsumerPoolSizeForAAWCLeader;
   private final boolean useDaVinciSpecificExecutionStatusForError;
   private final boolean recordLevelMetricWhenBootstrappingCurrentVersionEnabled;
+  private final String identityParserClassName;
 
   public VeniceServerConfig(VeniceProperties serverProperties) throws ConfigurationException {
     this(serverProperties, Collections.emptyMap());
@@ -762,6 +765,7 @@ public class VeniceServerConfig extends VeniceClusterConfig {
         serverProperties.getBoolean(USE_DA_VINCI_SPECIFIC_EXECUTION_STATUS_FOR_ERROR, false);
     recordLevelMetricWhenBootstrappingCurrentVersionEnabled =
         serverProperties.getBoolean(SERVER_RECORD_LEVEL_METRICS_WHEN_BOOTSTRAPPING_CURRENT_VERSION_ENABLED, true);
+    identityParserClassName = serverProperties.getString(IDENTITY_PARSER_CLASS, DefaultIdentityParser.class.getName());
   }
 
   long extractIngestionMemoryLimit(
@@ -1354,5 +1358,9 @@ public class VeniceServerConfig extends VeniceClusterConfig {
 
   public boolean isRecordLevelMetricWhenBootstrappingCurrentVersionEnabled() {
     return recordLevelMetricWhenBootstrappingCurrentVersionEnabled;
+  }
+
+  public String getIdentityParserClassName() {
+    return identityParserClassName;
   }
 }

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/RouterServer.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/RouterServer.java
@@ -172,7 +172,7 @@ public class RouterServer extends AbstractVeniceService {
   private ExecutorService workerExecutor;
   private EventThrottler routerEarlyThrottler;
 
-  private IdentityParser identityParser;
+  private final IdentityParser identityParser;
 
   // A map of optional ChannelHandlers that retains insertion order to be added at the end of the router pipeline
   private final Map<String, ChannelHandler> optionalChannelHandlers = new LinkedHashMap<>();

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/VeniceRouterConfig.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/VeniceRouterConfig.java
@@ -7,6 +7,7 @@ import static com.linkedin.venice.ConfigKeys.ENFORCE_SECURE_ROUTER;
 import static com.linkedin.venice.ConfigKeys.HEARTBEAT_CYCLE;
 import static com.linkedin.venice.ConfigKeys.HEARTBEAT_TIMEOUT;
 import static com.linkedin.venice.ConfigKeys.HELIX_HYBRID_STORE_QUOTA_ENABLED;
+import static com.linkedin.venice.ConfigKeys.IDENTITY_PARSER_CLASS;
 import static com.linkedin.venice.ConfigKeys.KAFKA_BOOTSTRAP_SERVERS;
 import static com.linkedin.venice.ConfigKeys.KAFKA_OVER_SSL;
 import static com.linkedin.venice.ConfigKeys.KEY_VALUE_PROFILING_ENABLED;
@@ -93,6 +94,7 @@ import static com.linkedin.venice.helix.HelixInstanceConfigRepository.ZONE_FIELD
 import static com.linkedin.venice.router.api.VeniceMultiKeyRoutingStrategy.LEAST_LOADED_ROUTING;
 import static com.linkedin.venice.router.api.routing.helix.HelixGroupSelectionStrategyEnum.LEAST_LOADED;
 
+import com.linkedin.venice.authorization.DefaultIdentityParser;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.router.api.VeniceMultiKeyRoutingStrategy;
 import com.linkedin.venice.router.api.routing.helix.HelixGroupSelectionStrategyEnum;
@@ -203,6 +205,7 @@ public class VeniceRouterConfig {
   private int routerIOWorkerCount;
   private double perStoreRouterQuotaBuffer;
   private boolean httpClientOpensslEnabled;
+  private String identityParserClassName;
 
   public VeniceRouterConfig(VeniceProperties props) {
     try {
@@ -377,6 +380,7 @@ public class VeniceRouterConfig {
     routerIOWorkerCount = props.getInt(ROUTER_IO_WORKER_COUNT, 24);
     perStoreRouterQuotaBuffer = props.getDouble(ROUTER_PER_STORE_ROUTER_QUOTA_BUFFER, 1.5);
     httpClientOpensslEnabled = props.getBoolean(ROUTER_HTTP_CLIENT_OPENSSL_ENABLED, true);
+    identityParserClassName = props.getString(IDENTITY_PARSER_CLASS, DefaultIdentityParser.class.getName());
   }
 
   public double getPerStoreRouterQuotaBuffer() {
@@ -806,5 +810,9 @@ public class VeniceRouterConfig {
 
   public boolean isHttpClientOpensslEnabled() {
     return httpClientOpensslEnabled;
+  }
+
+  public String getIdentityParserClassName() {
+    return identityParserClassName;
   }
 }

--- a/services/venice-server/src/test/java/com/linkedin/venice/listener/HttpChannelInitializerTest.java
+++ b/services/venice-server/src/test/java/com/linkedin/venice/listener/HttpChannelInitializerTest.java
@@ -51,7 +51,6 @@ public class HttpChannelInitializerTest {
     requestHandler = mock(StorageReadRequestHandler.class);
     serverConfig = mock(VeniceServerConfig.class);
     customizedViewRepository = new CompletableFuture<>();
-
     doReturn(DefaultIdentityParser.class.getName()).when(serverConfig).getIdentityParserClassName();
   }
 

--- a/services/venice-server/src/test/java/com/linkedin/venice/listener/HttpChannelInitializerTest.java
+++ b/services/venice-server/src/test/java/com/linkedin/venice/listener/HttpChannelInitializerTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.mock;
 import com.linkedin.davinci.config.VeniceServerConfig;
 import com.linkedin.venice.acl.DynamicAccessController;
 import com.linkedin.venice.acl.StaticAccessController;
+import com.linkedin.venice.authorization.DefaultIdentityParser;
 import com.linkedin.venice.helix.HelixCustomizedViewOfflinePushRepository;
 import com.linkedin.venice.listener.grpc.handlers.VeniceServerGrpcRequestProcessor;
 import com.linkedin.venice.meta.ReadOnlyStoreRepository;
@@ -50,6 +51,8 @@ public class HttpChannelInitializerTest {
     requestHandler = mock(StorageReadRequestHandler.class);
     serverConfig = mock(VeniceServerConfig.class);
     customizedViewRepository = new CompletableFuture<>();
+
+    doReturn(DefaultIdentityParser.class.getName()).when(serverConfig).getIdentityParserClassName();
   }
 
   @Test

--- a/services/venice-server/src/test/java/com/linkedin/venice/listener/ListenerServiceTest.java
+++ b/services/venice-server/src/test/java/com/linkedin/venice/listener/ListenerServiceTest.java
@@ -11,6 +11,7 @@ import com.linkedin.davinci.storage.ReadMetadataRetriever;
 import com.linkedin.davinci.storage.StorageEngineRepository;
 import com.linkedin.venice.acl.DynamicAccessController;
 import com.linkedin.venice.acl.StaticAccessController;
+import com.linkedin.venice.authorization.DefaultIdentityParser;
 import com.linkedin.venice.cleaner.ResourceReadUsageTracker;
 import com.linkedin.venice.helix.HelixCustomizedViewOfflinePushRepository;
 import com.linkedin.venice.meta.ReadOnlySchemaRepository;
@@ -66,6 +67,7 @@ public class ListenerServiceTest {
     doReturn(10).when(serverConfig).getSslHandshakeQueueCapacity();
     doReturn(false).when(serverConfig).isRestServiceEpollEnabled();
     doReturn(10).when(serverConfig).getNettyWorkerThreadCount();
+    doReturn(DefaultIdentityParser.class.getName()).when(serverConfig).getIdentityParserClassName();
   }
 
   @Test


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Add support for IdentityParser in SslInitializer
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
Currently Routers and Servers log the CN to help with investigation of the callers. However, this information is insufficient and we'd like to log the service principal name instead.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
GH CI. Will be tested in staging env

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.