### PR TITLE
[controller] Dont call backup version cleanup service on stores without backup version

### DIFF
--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/StoreBackupVersionCleanupService.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/StoreBackupVersionCleanupService.java
@@ -32,8 +32,10 @@ import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.DefaultConnectionKeepAliveStrategy;
 import org.apache.http.impl.nio.client.CloseableHttpAsyncClient;
 import org.apache.http.impl.nio.client.HttpAsyncClients;
+import org.apache.http.protocol.HttpContext;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -73,7 +75,7 @@ public class StoreBackupVersionCleanupService extends AbstractVeniceService {
   private final MetricsRepository metricsRepository;
 
   private final CloseableHttpAsyncClient httpAsyncClient;
-
+  private final long keepAliveDurationMs = TimeUnit.HOURS.toMillis(1);
   private final Time time;
 
   public StoreBackupVersionCleanupService(
@@ -104,6 +106,12 @@ public class StoreBackupVersionCleanupService extends AbstractVeniceService {
     this.httpAsyncClient = HttpAsyncClients.custom()
         .setDefaultRequestConfig(RequestConfig.custom().setSocketTimeout(10000).build())
         .setSSLContext(sslFactory.map(SSLFactory::getSSLContext).orElse(null))
+        .setKeepAliveStrategy(new DefaultConnectionKeepAliveStrategy() {
+          @Override
+          public long getKeepAliveDuration(HttpResponse response, HttpContext context) {
+            return keepAliveDurationMs;
+          }
+        })
         .build();
   }
 

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestStoreBackupVersionCleanupService.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestStoreBackupVersionCleanupService.java
@@ -87,9 +87,11 @@ public class TestStoreBackupVersionCleanupService {
 
   @Test
   public void testWhetherStoreReadyToBeCleanup() {
+    Map<Integer, VersionStatus> versions = new HashMap<>();
+    versions.put(1, VersionStatus.ONLINE);
+    versions.put(2, VersionStatus.ONLINE);
     long defaultBackupVersionRetentionMs = TimeUnit.DAYS.toMillis(7);
-    Store storeNotReadyForCleanupWithDefaultRetentionPolicy =
-        mockStore(-1, System.currentTimeMillis(), Collections.emptyMap(), -1);
+    Store storeNotReadyForCleanupWithDefaultRetentionPolicy = mockStore(-1, System.currentTimeMillis(), versions, -1);
     Assert.assertFalse(
         StoreBackupVersionCleanupService.whetherStoreReadyToBeCleanup(
             storeNotReadyForCleanupWithDefaultRetentionPolicy,
@@ -97,7 +99,7 @@ public class TestStoreBackupVersionCleanupService {
             new SystemTime()));
 
     Store storeReadyForCleanupWithDefaultRetentionPolicy =
-        mockStore(-1, System.currentTimeMillis() - 2 * defaultBackupVersionRetentionMs, Collections.emptyMap(), -1);
+        mockStore(-1, System.currentTimeMillis() - 2 * defaultBackupVersionRetentionMs, versions, -1);
     Assert.assertTrue(
         StoreBackupVersionCleanupService.whetherStoreReadyToBeCleanup(
             storeReadyForCleanupWithDefaultRetentionPolicy,
@@ -106,18 +108,15 @@ public class TestStoreBackupVersionCleanupService {
 
     long storeBackupRetentionMs = TimeUnit.DAYS.toMillis(3);
     Store storeNotReadyForCleanupWithSpecifiedRetentionPolicy =
-        mockStore(storeBackupRetentionMs, System.currentTimeMillis(), Collections.emptyMap(), -1);
+        mockStore(storeBackupRetentionMs, System.currentTimeMillis(), versions, -1);
     Assert.assertFalse(
         StoreBackupVersionCleanupService.whetherStoreReadyToBeCleanup(
             storeNotReadyForCleanupWithSpecifiedRetentionPolicy,
             defaultBackupVersionRetentionMs,
             new SystemTime()));
 
-    Store storeReadyForCleanupWithSpecifiedRetentionPolicy = mockStore(
-        storeBackupRetentionMs,
-        System.currentTimeMillis() - 2 * storeBackupRetentionMs,
-        Collections.emptyMap(),
-        -1);
+    Store storeReadyForCleanupWithSpecifiedRetentionPolicy =
+        mockStore(storeBackupRetentionMs, System.currentTimeMillis() - 2 * storeBackupRetentionMs, versions, -1);
     Assert.assertTrue(
         StoreBackupVersionCleanupService.whetherStoreReadyToBeCleanup(
             storeReadyForCleanupWithSpecifiedRetentionPolicy,
@@ -126,7 +125,7 @@ public class TestStoreBackupVersionCleanupService {
 
     long storeBackupRetentionMsZero = 0;
     Store storeNotReadyForCleanupWithZeroRetentionPolicy1 =
-        mockStore(storeBackupRetentionMsZero, System.currentTimeMillis(), Collections.emptyMap(), -1);
+        mockStore(storeBackupRetentionMsZero, System.currentTimeMillis(), versions, -1);
     Assert.assertFalse(
         StoreBackupVersionCleanupService.whetherStoreReadyToBeCleanup(
             storeNotReadyForCleanupWithZeroRetentionPolicy1,
@@ -134,18 +133,15 @@ public class TestStoreBackupVersionCleanupService {
             new SystemTime()));
 
     Store storeNotReadyForCleanupWithZeroRetentionPolicy2 =
-        mockStore(storeBackupRetentionMsZero, System.currentTimeMillis() - 10, Collections.emptyMap(), -1);
+        mockStore(storeBackupRetentionMsZero, System.currentTimeMillis() - 10, versions, -1);
     Assert.assertFalse(
         StoreBackupVersionCleanupService.whetherStoreReadyToBeCleanup(
             storeNotReadyForCleanupWithZeroRetentionPolicy2,
             defaultBackupVersionRetentionMs,
             new SystemTime()));
 
-    Store storeReadyForCleanupWithZeroRetentionPolicy = mockStore(
-        storeBackupRetentionMsZero,
-        System.currentTimeMillis() - 2 * storeBackupRetentionMs,
-        Collections.emptyMap(),
-        -1);
+    Store storeReadyForCleanupWithZeroRetentionPolicy =
+        mockStore(storeBackupRetentionMsZero, System.currentTimeMillis() - 2 * storeBackupRetentionMs, versions, -1);
     Assert.assertTrue(
         StoreBackupVersionCleanupService.whetherStoreReadyToBeCleanup(
             storeReadyForCleanupWithZeroRetentionPolicy,


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Dont call backup version cleanup service on stores without backup version
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Since fetching the current version from all router and server is an expensive operation, we should not call backup version cleanup on stores without current version or backup version. Also add a keep-alive period of 1hr to the http client.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
GHCI
## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.