### PR TITLE
[server] - Fix consumer leaks in TM that occur when the thread owning consumer is interrupted

### DIFF
--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/manager/TopicManagerStats.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/manager/TopicManagerStats.java
@@ -5,6 +5,7 @@ import com.linkedin.venice.stats.TehutiUtils;
 import com.linkedin.venice.utils.LatencyUtils;
 import io.tehuti.metrics.MetricsRepository;
 import io.tehuti.metrics.Sensor;
+import io.tehuti.metrics.stats.AsyncGauge;
 import io.tehuti.metrics.stats.Avg;
 import io.tehuti.metrics.stats.Max;
 import io.tehuti.metrics.stats.Min;
@@ -23,7 +24,7 @@ class TopicManagerStats extends AbstractVeniceStats {
     CREATE_TOPIC, DELETE_TOPIC, LIST_ALL_TOPICS, SET_TOPIC_CONFIG, GET_ALL_TOPIC_RETENTIONS, GET_TOPIC_CONFIG,
     GET_TOPIC_CONFIG_WITH_RETRY, CONTAINS_TOPIC, GET_SOME_TOPIC_CONFIGS, CONTAINS_TOPIC_WITH_RETRY,
     GET_TOPIC_LATEST_OFFSETS, GET_PARTITION_LATEST_OFFSETS, PARTITIONS_FOR, GET_OFFSET_FOR_TIME,
-    GET_PRODUCER_TIMESTAMP_OF_LAST_DATA_MESSAGE
+    GET_PRODUCER_TIMESTAMP_OF_LAST_DATA_MESSAGE, CONSUMER_ACQUISITION_WAIT_TIME
   }
 
   TopicManagerStats(MetricsRepository metricsRepository, String pubSubAddress) {
@@ -56,5 +57,24 @@ class TopicManagerStats extends AbstractVeniceStats {
     }
     // convert ns to us and record
     sensorsByTypes.get(sensorType).record(LatencyUtils.getLatencyInMS(startTimeInNs));
+  }
+
+  void registerTopicMetadataFetcherSensors(TopicMetadataFetcher topicMetadataFetcher) {
+    registerSensorIfAbsent(
+        new AsyncGauge(
+            (ignored, ignored2) -> topicMetadataFetcher.getCurrentConsumerPoolSize(),
+            "available_consumer_count"));
+    registerSensorIfAbsent(
+        new AsyncGauge(
+            (ignored, ignored2) -> topicMetadataFetcher.getAsyncTaskActiveThreadCount(),
+            "async_task_active_thread_count"));
+    registerSensorIfAbsent(
+        new AsyncGauge(
+            (ignored, ignored2) -> topicMetadataFetcher.getAsyncTaskQueueLength(),
+            "async_task_queue_length"));
+    registerSensorIfAbsent(
+        new AsyncGauge(
+            (ignored, ignored2) -> topicMetadataFetcher.getConsumerWaitListSize(),
+            "consumer_wait_list_size"));
   }
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/manager/TopicManagerStats.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/manager/TopicManagerStats.java
@@ -61,7 +61,7 @@ class TopicManagerStats extends AbstractVeniceStats {
     sensorsByTypes.get(sensorType).record(LatencyUtils.getLatencyInMS(startTimeInNs));
   }
 
-  void registerTopicMetadataFetcherSensors(TopicMetadataFetcher topicMetadataFetcher) {
+  final void registerTopicMetadataFetcherSensors(TopicMetadataFetcher topicMetadataFetcher) {
     if (metricsRepository == null) {
       return;
     }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/manager/TopicManagerStats.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/manager/TopicManagerStats.java
@@ -19,6 +19,7 @@ import java.util.EnumMap;
 class TopicManagerStats extends AbstractVeniceStats {
   private static final String TOPIC_MANAGER_STATS_PREFIX = "TopicManagerStats_";
   private EnumMap<SENSOR_TYPE, Sensor> sensorsByTypes = null;
+  private final MetricsRepository metricsRepository;
 
   enum SENSOR_TYPE {
     CREATE_TOPIC, DELETE_TOPIC, LIST_ALL_TOPICS, SET_TOPIC_CONFIG, GET_ALL_TOPIC_RETENTIONS, GET_TOPIC_CONFIG,
@@ -29,6 +30,7 @@ class TopicManagerStats extends AbstractVeniceStats {
 
   TopicManagerStats(MetricsRepository metricsRepository, String pubSubAddress) {
     super(metricsRepository, TOPIC_MANAGER_STATS_PREFIX + TehutiUtils.fixMalformedMetricName(pubSubAddress));
+    this.metricsRepository = metricsRepository;
     if (metricsRepository == null) {
       return;
     }
@@ -60,6 +62,9 @@ class TopicManagerStats extends AbstractVeniceStats {
   }
 
   void registerTopicMetadataFetcherSensors(TopicMetadataFetcher topicMetadataFetcher) {
+    if (metricsRepository == null) {
+      return;
+    }
     registerSensorIfAbsent(
         new AsyncGauge(
             (ignored, ignored2) -> topicMetadataFetcher.getCurrentConsumerPoolSize(),

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/manager/TopicMetadataFetcher.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/manager/TopicMetadataFetcher.java
@@ -1,6 +1,7 @@
 package com.linkedin.venice.pubsub.manager;
 
 import static com.linkedin.venice.pubsub.PubSubConstants.PUBSUB_OFFSET_API_TIMEOUT_DURATION_DEFAULT_VALUE;
+import static com.linkedin.venice.pubsub.manager.TopicManagerStats.SENSOR_TYPE.CONSUMER_ACQUISITION_WAIT_TIME;
 import static com.linkedin.venice.pubsub.manager.TopicManagerStats.SENSOR_TYPE.CONTAINS_TOPIC;
 import static com.linkedin.venice.pubsub.manager.TopicManagerStats.SENSOR_TYPE.GET_OFFSET_FOR_TIME;
 import static com.linkedin.venice.pubsub.manager.TopicManagerStats.SENSOR_TYPE.GET_PARTITION_LATEST_OFFSETS;
@@ -49,6 +50,7 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -86,6 +88,7 @@ class TopicMetadataFetcher implements Closeable {
   private final Map<PubSubTopicPartition, ValueAndExpiryTime<Long>> lastProducerTimestampCache =
       new VeniceConcurrentHashMap<>();
   private final long cachedEntryTtlInNs;
+  private final AtomicInteger consumerWaitListSize = new AtomicInteger(0);
 
   TopicMetadataFetcher(
       String pubSubClusterAddress,
@@ -125,6 +128,8 @@ class TopicMetadataFetcher implements Closeable {
         new DaemonThreadFactory("TopicMetadataFetcherThreadPool"));
     threadPoolExecutor.allowCoreThreadTimeOut(true);
 
+    stats.registerTopicMetadataFetcherSensors(this);
+
     LOGGER.info(
         "Initialized TopicMetadataFetcher for pubSubClusterAddress: {} with consumer pool size: {} and thread pool size: {}",
         pubSubClusterAddress,
@@ -152,10 +157,16 @@ class TopicMetadataFetcher implements Closeable {
   // acquire the consumer from the pool
   private PubSubConsumerAdapter acquireConsumer() {
     try {
-      return pubSubConsumerPool.take();
+      consumerWaitListSize.incrementAndGet();
+      long startTime = System.nanoTime();
+      PubSubConsumerAdapter consumerAdapter = pubSubConsumerPool.take();
+      stats.recordLatency(CONSUMER_ACQUISITION_WAIT_TIME, startTime);
+      return consumerAdapter;
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
       throw new VeniceException("Interrupted while acquiring pubSubConsumerAdapter", e);
+    } finally {
+      consumerWaitListSize.decrementAndGet();
     }
   }
 
@@ -749,6 +760,22 @@ class TopicMetadataFetcher implements Closeable {
     void setUpdateInProgressStatus(boolean status) {
       this.isUpdateInProgress.set(status);
     }
+  }
+
+  int getCurrentConsumerPoolSize() {
+    return pubSubConsumerPool.size();
+  }
+
+  int getAsyncTaskActiveThreadCount() {
+    return threadPoolExecutor.getActiveCount();
+  }
+
+  int getAsyncTaskQueueLength() {
+    return threadPoolExecutor.getQueue().size();
+  }
+
+  int getConsumerWaitListSize() {
+    return consumerWaitListSize.get();
   }
 
   @Override

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/manager/TopicMetadataFetcher.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/manager/TopicMetadataFetcher.java
@@ -155,7 +155,7 @@ class TopicMetadataFetcher implements Closeable {
   }
 
   // acquire the consumer from the pool
-  private PubSubConsumerAdapter acquireConsumer() {
+  PubSubConsumerAdapter acquireConsumer() {
     try {
       consumerWaitListSize.incrementAndGet();
       long startTime = System.nanoTime();
@@ -171,7 +171,7 @@ class TopicMetadataFetcher implements Closeable {
   }
 
   // release the consumer back to the pool
-  private void releaseConsumer(PubSubConsumerAdapter pubSubConsumerAdapter) {
+  void releaseConsumer(PubSubConsumerAdapter pubSubConsumerAdapter) {
     if (!pubSubConsumerPool.offer(pubSubConsumerAdapter)) {
       LOGGER.error("Failed to release pubSubConsumerAdapter back to the pool. Closing the consumer.");
     }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/manager/TopicMetadataFetcher.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/manager/TopicMetadataFetcher.java
@@ -161,11 +161,8 @@ class TopicMetadataFetcher implements Closeable {
 
   // release the consumer back to the pool
   private void releaseConsumer(PubSubConsumerAdapter pubSubConsumerAdapter) {
-    try {
-      pubSubConsumerPool.put(pubSubConsumerAdapter);
-    } catch (InterruptedException e) {
-      Thread.currentThread().interrupt();
-      throw new VeniceException("Interrupted while releasing pubSubConsumerAdapter", e);
+    if (!pubSubConsumerPool.offer(pubSubConsumerAdapter)) {
+      LOGGER.error("Failed to release pubSubConsumerAdapter back to the pool. Closing the consumer.");
     }
   }
 

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/manager/TopicMetadataFetcher.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/manager/TopicMetadataFetcher.java
@@ -173,7 +173,7 @@ class TopicMetadataFetcher implements Closeable {
   // release the consumer back to the pool
   void releaseConsumer(PubSubConsumerAdapter pubSubConsumerAdapter) {
     if (!pubSubConsumerPool.offer(pubSubConsumerAdapter)) {
-      LOGGER.error("Failed to release pubSubConsumerAdapter back to the pool. Closing the consumer.");
+      LOGGER.error("Failed to release pubSubConsumerAdapter back to the pool.");
     }
   }
 

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/manager/TopicMetadataFetcher.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/manager/TopicMetadataFetcher.java
@@ -212,11 +212,6 @@ class TopicMetadataFetcher implements Closeable {
     }
     long waitUntil = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(30);
     while (System.currentTimeMillis() <= waitUntil && !closeables.isEmpty()) {
-      LOGGER.info(
-          "Waiting for {} consumers to be closed for pubSubClusterAddress: {} remainingTime: {} ms",
-          closeables.size(),
-          pubSubClusterAddress,
-          waitUntil - System.currentTimeMillis());
       PubSubConsumerAdapter pubSubConsumerAdapter = null;
       try {
         pubSubConsumerAdapter = pubSubConsumerPool.poll(5, MILLISECONDS);


### PR DESCRIPTION
## Fix topic manager consumer leaks that occur when the thread owning it is interrupted
Currently, if a thread owning a consumer is interrupted, the consumer is not 
returned to the consumer pool. This occurs because the blocking calls throw an 
interrupted exception when invoked by a thread with the interrupt status set. 
In this case, it is the `LBQ::put` call in `TMDF::releaseConsumer`.

As a result, we eventually run out of consumers to execute metadata requests. 
This situation typically arises when non-blocking metrics collection threads 
cancel active executions to terminate slow queries.


## How was this PR tested?
CI

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.