### PR TITLE
[router] Added config to enable DNS resolution before SSL

### DIFF
--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -1769,6 +1769,28 @@ public class ConfigKeys {
   public static final String ROUTER_CLIENT_SSL_HANDSHAKE_THREADS = "router.client.ssl.handshake.threads";
 
   /**
+   * Config to control if DNS resolution should be done before SSL handshake between clients and a router.
+   * If this is enabled, the above SSL handshake thread pool will be used to perform DNS resolution, because
+   * DNS resolution before SSL and separate SSL handshake thread pool are mutually exclusive features.
+   */
+  public static final String ROUTER_RESOLVE_BEFORE_SSL = "router.resolve.before.ssl";
+
+  /**
+   * Config to control the maximum number of concurrent DNS resolutions that can be done by the router.
+   */
+  public static final String ROUTER_MAX_CONCURRENT_RESOLUTIONS = "router.max.concurrent.resolutions";
+
+  /**
+   * Config to control the maximum number of attempts to resolve a client host name before giving up.
+   */
+  public static final String ROUTER_CLIENT_RESOLUTION_RETRY_ATTEMPTS = "router.client.resolution.retry.attempts";
+
+  /**
+   * Config to control the backoff time between each resolution retry.
+   */
+  public static final String ROUTER_CLIENT_RESOLUTION_RETRY_BACKOFF_MS = "router.client.resolution.retry.backoff.ms";
+
+  /**
    * Config to control the queue capacity for the thread pool executor used for ssl handshake between clients and a router.
    */
   public static final String ROUTER_CLIENT_SSL_HANDSHAKE_QUEUE_CAPACITY = "router.client.ssl.handshake.queue.capacity";

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/MockVeniceRouterWrapper.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/MockVeniceRouterWrapper.java
@@ -8,6 +8,7 @@ import static com.linkedin.venice.ConfigKeys.LISTENER_PORT;
 import static com.linkedin.venice.ConfigKeys.LISTENER_SSL_PORT;
 import static com.linkedin.venice.ConfigKeys.ROUTER_CLIENT_SSL_HANDSHAKE_THREADS;
 import static com.linkedin.venice.ConfigKeys.ROUTER_NETTY_GRACEFUL_SHUTDOWN_PERIOD_SECONDS;
+import static com.linkedin.venice.ConfigKeys.ROUTER_RESOLVE_BEFORE_SSL;
 import static com.linkedin.venice.ConfigKeys.ROUTER_STORAGE_NODE_CLIENT_TYPE;
 import static com.linkedin.venice.ConfigKeys.SSL_TO_STORAGE_NODES;
 import static com.linkedin.venice.ConfigKeys.ZOOKEEPER_ADDRESS;
@@ -138,6 +139,7 @@ public class MockVeniceRouterWrapper extends ProcessWrapper {
               TestUtils.getClusterToD2String(Collections.singletonMap(clusterName, serverD2ServiceName)))
           .put(ROUTER_NETTY_GRACEFUL_SHUTDOWN_PERIOD_SECONDS, 0)
           .put(ROUTER_CLIENT_SSL_HANDSHAKE_THREADS, 10)
+          .put(ROUTER_RESOLVE_BEFORE_SSL, true)
           .put(ROUTER_STORAGE_NODE_CLIENT_TYPE, StorageNodeClientType.APACHE_HTTP_ASYNC_CLIENT.name())
           .put(extraConfigs);
       StoreConfig storeConfig = new StoreConfig("test");

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceRouterWrapper.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceRouterWrapper.java
@@ -15,6 +15,7 @@ import static com.linkedin.venice.ConfigKeys.ROUTER_HTTP_CLIENT_POOL_SIZE;
 import static com.linkedin.venice.ConfigKeys.ROUTER_MAX_OUTGOING_CONNECTION;
 import static com.linkedin.venice.ConfigKeys.ROUTER_MAX_OUTGOING_CONNECTION_PER_ROUTE;
 import static com.linkedin.venice.ConfigKeys.ROUTER_NETTY_GRACEFUL_SHUTDOWN_PERIOD_SECONDS;
+import static com.linkedin.venice.ConfigKeys.ROUTER_RESOLVE_BEFORE_SSL;
 import static com.linkedin.venice.ConfigKeys.ROUTER_STORAGE_NODE_CLIENT_TYPE;
 import static com.linkedin.venice.ConfigKeys.SSL_TO_STORAGE_NODES;
 import static com.linkedin.venice.ConfigKeys.SYSTEM_SCHEMA_CLUSTER_NAME;
@@ -136,6 +137,7 @@ public class VeniceRouterWrapper extends ProcessWrapper implements MetricsAware 
           .put(CLUSTER_TO_D2, TestUtils.getClusterToD2String(finalClusterToD2))
           .put(CLUSTER_TO_SERVER_D2, TestUtils.getClusterToD2String(finalClusterToServerD2))
           .put(ROUTER_CLIENT_SSL_HANDSHAKE_THREADS, 10)
+          .put(ROUTER_RESOLVE_BEFORE_SSL, true)
           // Below configs are to attempt to minimize resource utilization in tests
           .put(ROUTER_CONNECTION_LIMIT, 20)
           .put(ROUTER_HTTP_CLIENT_POOL_SIZE, 2)

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/RouterServer.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/RouterServer.java
@@ -808,6 +808,9 @@ public class RouterServer extends AbstractVeniceService {
     storageNodeClient.close();
     workerEventLoopGroup.shutdownGracefully();
     serverEventLoopGroup.shutdownGracefully();
+    if (sslResolverEventLoopGroup != null) {
+      sslResolverEventLoopGroup.shutdownGracefully();
+    }
 
     dispatcher.stop();
 

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/VeniceRouterConfig.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/VeniceRouterConfig.java
@@ -19,6 +19,8 @@ import static com.linkedin.venice.ConfigKeys.REFRESH_ATTEMPTS_FOR_ZK_RECONNECT;
 import static com.linkedin.venice.ConfigKeys.REFRESH_INTERVAL_FOR_ZK_RECONNECT_MS;
 import static com.linkedin.venice.ConfigKeys.ROUTER_ASYNC_START_ENABLED;
 import static com.linkedin.venice.ConfigKeys.ROUTER_CLIENT_DECOMPRESSION_ENABLED;
+import static com.linkedin.venice.ConfigKeys.ROUTER_CLIENT_RESOLUTION_RETRY_ATTEMPTS;
+import static com.linkedin.venice.ConfigKeys.ROUTER_CLIENT_RESOLUTION_RETRY_BACKOFF_MS;
 import static com.linkedin.venice.ConfigKeys.ROUTER_CLIENT_SSL_HANDSHAKE_QUEUE_CAPACITY;
 import static com.linkedin.venice.ConfigKeys.ROUTER_CLIENT_SSL_HANDSHAKE_THREADS;
 import static com.linkedin.venice.ConfigKeys.ROUTER_COMPUTE_FAST_AVRO_ENABLED;
@@ -61,6 +63,7 @@ import static com.linkedin.venice.ConfigKeys.ROUTER_LEAKED_FUTURE_CLEANUP_THRESH
 import static com.linkedin.venice.ConfigKeys.ROUTER_LONG_TAIL_RETRY_FOR_BATCH_GET_THRESHOLD_MS;
 import static com.linkedin.venice.ConfigKeys.ROUTER_LONG_TAIL_RETRY_FOR_SINGLE_GET_THRESHOLD_MS;
 import static com.linkedin.venice.ConfigKeys.ROUTER_LONG_TAIL_RETRY_MAX_ROUTE_FOR_MULTI_KEYS_REQ;
+import static com.linkedin.venice.ConfigKeys.ROUTER_MAX_CONCURRENT_RESOLUTIONS;
 import static com.linkedin.venice.ConfigKeys.ROUTER_MAX_KEY_COUNT_IN_MULTIGET_REQ;
 import static com.linkedin.venice.ConfigKeys.ROUTER_MAX_OUTGOING_CONNECTION;
 import static com.linkedin.venice.ConfigKeys.ROUTER_MAX_OUTGOING_CONNECTION_PER_ROUTE;
@@ -76,6 +79,7 @@ import static com.linkedin.venice.ConfigKeys.ROUTER_PER_NODE_CLIENT_THREAD_COUNT
 import static com.linkedin.venice.ConfigKeys.ROUTER_PER_STORE_ROUTER_QUOTA_BUFFER;
 import static com.linkedin.venice.ConfigKeys.ROUTER_QUOTA_CHECK_WINDOW;
 import static com.linkedin.venice.ConfigKeys.ROUTER_READ_QUOTA_THROTTLING_LEASE_TIMEOUT_MS;
+import static com.linkedin.venice.ConfigKeys.ROUTER_RESOLVE_BEFORE_SSL;
 import static com.linkedin.venice.ConfigKeys.ROUTER_SINGLEGET_TARDY_LATENCY_MS;
 import static com.linkedin.venice.ConfigKeys.ROUTER_SMART_LONG_TAIL_RETRY_ABORT_THRESHOLD_MS;
 import static com.linkedin.venice.ConfigKeys.ROUTER_SMART_LONG_TAIL_RETRY_ENABLED;
@@ -188,6 +192,10 @@ public class VeniceRouterConfig {
   private HelixGroupSelectionStrategyEnum helixGroupSelectionStrategy;
   private String systemSchemaClusterName;
   private int clientSslHandshakeThreads;
+  private boolean resolveBeforeSSL;
+  private int maxConcurrentResolutions;
+  private int clientResolutionRetryAttempts;
+  private long clientResolutionRetryBackoffMs;
   private int clientSslHandshakeQueueCapacity;
   private long readQuotaThrottlingLeaseTimeoutMs;
   private boolean routerHeartBeatEnabled;
@@ -319,6 +327,10 @@ public class VeniceRouterConfig {
         props.getInt(ROUTER_HTTPASYNCCLIENT_CLIENT_POOL_THREAD_COUNT, Runtime.getRuntime().availableProcessors());
 
     clientSslHandshakeThreads = props.getInt(ROUTER_CLIENT_SSL_HANDSHAKE_THREADS, 0);
+    resolveBeforeSSL = props.getBoolean(ROUTER_RESOLVE_BEFORE_SSL, false);
+    maxConcurrentResolutions = props.getInt(ROUTER_MAX_CONCURRENT_RESOLUTIONS, 100);
+    clientResolutionRetryAttempts = props.getInt(ROUTER_CLIENT_RESOLUTION_RETRY_ATTEMPTS, 3);
+    clientResolutionRetryBackoffMs = props.getLong(ROUTER_CLIENT_RESOLUTION_RETRY_BACKOFF_MS, 5 * Time.MS_PER_SECOND);
     clientSslHandshakeQueueCapacity = props.getInt(ROUTER_CLIENT_SSL_HANDSHAKE_QUEUE_CAPACITY, Integer.MAX_VALUE);
 
     readQuotaThrottlingLeaseTimeoutMs =
@@ -746,6 +758,22 @@ public class VeniceRouterConfig {
 
   public int getClientSslHandshakeThreads() {
     return clientSslHandshakeThreads;
+  }
+
+  public boolean isResolveBeforeSSL() {
+    return resolveBeforeSSL;
+  }
+
+  public int getMaxConcurrentResolutions() {
+    return maxConcurrentResolutions;
+  }
+
+  public int getClientResolutionRetryAttempts() {
+    return clientResolutionRetryAttempts;
+  }
+
+  public long getClientResolutionRetryBackoffMs() {
+    return clientResolutionRetryBackoffMs;
   }
 
   public int getClientSslHandshakeQueueCapacity() {

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/stats/SecurityStats.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/stats/SecurityStats.java
@@ -1,8 +1,10 @@
 package com.linkedin.venice.router.stats;
 
+import com.linkedin.alpini.netty4.ssl.SslInitializer;
 import com.linkedin.venice.stats.AbstractVeniceStats;
 import io.tehuti.metrics.MetricsRepository;
 import io.tehuti.metrics.Sensor;
+import io.tehuti.metrics.stats.AsyncGauge;
 import io.tehuti.metrics.stats.Avg;
 import io.tehuti.metrics.stats.Count;
 import io.tehuti.metrics.stats.Max;
@@ -48,5 +50,17 @@ public class SecurityStats extends AbstractVeniceStats {
    */
   private void recordLiveConnectionCount() {
     this.sslLiveConnectionCount.record(secureConnectionCountSupplier.getAsInt());
+  }
+
+  public void registerSslHandshakeSensors(SslInitializer sslInitializer) {
+    registerSensor(
+        new AsyncGauge(
+            (ignored1, ignored2) -> sslInitializer.getHandshakesStarted()
+                - (sslInitializer.getHandshakesSuccessful() + sslInitializer.getHandshakesFailed()),
+            "pending_ssl_handshake_count"));
+    registerSensor(
+        new AsyncGauge(
+            (ignored1, ignored2) -> sslInitializer.getHandshakesFailed(),
+            "total_failed_ssl_handshake_count"));
   }
 }


### PR DESCRIPTION
## Summary
Config to enable this feature:
router.resolve.before.ssl

When this config is enabled, "SslInitializer#enableSslTaskExecutor" will not be called, and the SSL handshake thread pool count will be used to construct the DNS resolution thread pool.

Besides, added two new SSL related metrics using the API from Netty: pending_ssl_handshake_count
total_failed_ssl_handshake_count

## How was this PR tested?
GHCI

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.