### PR TITLE
[vpj] Fix building or fetching dictionary for repush jobs

### DIFF
--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
@@ -472,10 +472,18 @@ public class VenicePushJob implements AutoCloseable {
 
     pushJobSettingToReturn.extendedSchemaValidityCheckEnabled =
         props.getBoolean(EXTENDED_SCHEMA_VALIDITY_CHECK_ENABLED, DEFAULT_EXTENDED_SCHEMA_VALIDITY_CHECK_ENABLED);
-    pushJobSettingToReturn.compressionMetricCollectionEnabled =
-        props.getBoolean(COMPRESSION_METRIC_COLLECTION_ENABLED, DEFAULT_COMPRESSION_METRIC_COLLECTION_ENABLED);
-    pushJobSettingToReturn.useMapperToBuildDict =
-        props.getBoolean(USE_MAPPER_TO_BUILD_DICTIONARY, DEFAULT_USE_MAPPER_TO_BUILD_DICTIONARY);
+
+    if (pushJobSettingToReturn.isSourceKafka) {
+      // KIF uses a different code-path to build a dictionary, and we also don't need schema validations for KIF
+      pushJobSettingToReturn.useMapperToBuildDict = false;
+      pushJobSettingToReturn.compressionMetricCollectionEnabled = false;
+    } else {
+      pushJobSettingToReturn.useMapperToBuildDict =
+          props.getBoolean(USE_MAPPER_TO_BUILD_DICTIONARY, DEFAULT_USE_MAPPER_TO_BUILD_DICTIONARY);
+      pushJobSettingToReturn.compressionMetricCollectionEnabled =
+          props.getBoolean(COMPRESSION_METRIC_COLLECTION_ENABLED, DEFAULT_COMPRESSION_METRIC_COLLECTION_ENABLED);
+    }
+
     if (pushJobSettingToReturn.useMapperToBuildDict) {
       pushJobSettingToReturn.useMapperToBuildDictOutputPath = props
           .getString(MAPPER_OUTPUT_DIRECTORY, VALIDATE_SCHEMA_AND_BUILD_DICTIONARY_MAPPER_OUTPUT_PARENT_DIR_DEFAULT);
@@ -1136,14 +1144,6 @@ public class VenicePushJob implements AutoCloseable {
   protected static boolean shouldBuildZstdCompressionDictionary(
       PushJobSetting pushJobSetting,
       boolean inputFileHasRecords) {
-    if (pushJobSetting.isSourceKafka) {
-      /**
-       * Currently, KIF repush will use a different code path for dict buid.
-       * If later, we add the support to build the dict in a MR job, we need to revist this logic.
-       */
-      return false;
-    }
-
     if (pushJobSetting.isIncrementalPush) {
       LOGGER.info("No compression dictionary will be generated as the push type is incremental push");
       return false;
@@ -1195,11 +1195,6 @@ public class VenicePushJob implements AutoCloseable {
 
     if (!inputFileHasRecords) {
       LOGGER.info("No compression related metrics will be generated as there are no records");
-      return false;
-    }
-
-    if (pushJobSetting.isSourceKafka) {
-      LOGGER.info("No compression related metrics will be generated as the push type is repush");
       return false;
     }
 

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/VenicePushJobTest.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/VenicePushJobTest.java
@@ -522,21 +522,19 @@ public class VenicePushJobTest {
     new VenicePushJob(PUSH_JOB_ID, props);
   }
 
-  @Test(dataProvider = "Four-True-and-False", dataProviderClass = DataProviderUtils.class)
+  @Test(dataProvider = "Three-True-and-False", dataProviderClass = DataProviderUtils.class)
   public void testShouldBuildZstdCompressionDictionary(
       boolean compressionMetricCollectionEnabled,
-      boolean isSourceKafka,
       boolean isIncrementalPush,
       boolean inputFileHasRecords) {
     PushJobSetting pushJobSetting = new PushJobSetting();
     pushJobSetting.compressionMetricCollectionEnabled = compressionMetricCollectionEnabled;
-    pushJobSetting.isSourceKafka = isSourceKafka;
     pushJobSetting.isIncrementalPush = isIncrementalPush;
 
     for (CompressionStrategy compressionStrategy: CompressionStrategy.values()) {
       pushJobSetting.storeCompressionStrategy = compressionStrategy;
 
-      if (isSourceKafka || isIncrementalPush) {
+      if (isIncrementalPush) {
         assertFalse(VenicePushJob.shouldBuildZstdCompressionDictionary(pushJobSetting, inputFileHasRecords));
       } else if (compressionStrategy == CompressionStrategy.ZSTD_WITH_DICT) {
         assertTrue(VenicePushJob.shouldBuildZstdCompressionDictionary(pushJobSetting, inputFileHasRecords));
@@ -560,14 +558,6 @@ public class VenicePushJobTest {
     // reset settings for the below tests
     pushJobSetting.compressionMetricCollectionEnabled = true;
     assertFalse(VenicePushJob.evaluateCompressionMetricCollectionEnabled(pushJobSetting, false));
-
-    // Test with isSourceKafka == true
-    pushJobSetting.isSourceKafka = true;
-    assertFalse(VenicePushJob.evaluateCompressionMetricCollectionEnabled(pushJobSetting, true));
-    assertFalse(VenicePushJob.evaluateCompressionMetricCollectionEnabled(pushJobSetting, false));
-
-    // reset settings for the below tests
-    pushJobSetting.isSourceKafka = false;
 
     // Test with isIncrementalPush == true
     pushJobSetting.isIncrementalPush = true;

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestBatch.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestBatch.java
@@ -627,6 +627,37 @@ public abstract class TestBatch {
   }
 
   @Test(timeOut = TEST_TIMEOUT)
+  public void testKafkaInputBatchJobWithZstdCompression() throws Exception {
+    VPJValidator validator = (avroClient, vsonClient, metricsRepository) -> {
+      // test single get
+      for (int i = 1; i <= 100; i++) {
+        Assert.assertEquals(avroClient.get(Integer.toString(i)).get().toString(), "test_name_" + i);
+      }
+    };
+    String storeName = testBatchStore(
+        inputDir -> new KeyAndValueSchemas(writeSimpleAvroFileWithStringToStringSchema(inputDir)),
+        properties -> {
+          properties.setProperty(SEND_CONTROL_MESSAGES_DIRECTLY, String.valueOf(true));
+        },
+        validator,
+        new UpdateStoreQueryParams().setCompressionStrategy(CompressionStrategy.ZSTD_WITH_DICT));
+
+    testBatchStore(
+        inputDir -> new KeyAndValueSchemas(Schema.create(Schema.Type.NULL), Schema.create(Schema.Type.NULL)),
+        properties -> {
+          properties.setProperty(SOURCE_KAFKA, "true");
+          properties.setProperty(VENICE_STORE_NAME_PROP, storeName);
+          properties.setProperty(KAFKA_INPUT_BROKER_URL, veniceCluster.getPubSubBrokerWrapper().getAddress());
+          properties.setProperty(KAFKA_INPUT_MAX_RECORDS_PER_MAPPER, "5");
+          properties.setProperty(SEND_CONTROL_MESSAGES_DIRECTLY, String.valueOf(true));
+          properties.setProperty(COMPRESSION_METRIC_COLLECTION_ENABLED, String.valueOf(true));
+        },
+        validator,
+        storeName,
+        new UpdateStoreQueryParams());
+  }
+
+  @Test(timeOut = TEST_TIMEOUT)
   public void testKafkaInputAAStore() throws Exception {
     VPJValidator validator = (avroClient, vsonClient, metricsRepository) -> {
       // test single get

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestBatch.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestBatch.java
@@ -626,8 +626,8 @@ public abstract class TestBatch {
     testRepush(storeName, validator);
   }
 
-  @Test(timeOut = TEST_TIMEOUT)
-  public void testKafkaInputBatchJobWithZstdCompression() throws Exception {
+  @Test(timeOut = TEST_TIMEOUT, dataProvider = "True-and-False", dataProviderClass = DataProviderUtils.class)
+  public void testKafkaInputBatchJobWithZstdCompression(boolean sendDirectControlMessage) throws Exception {
     VPJValidator validator = (avroClient, vsonClient, metricsRepository) -> {
       // test single get
       for (int i = 1; i <= 100; i++) {
@@ -637,7 +637,7 @@ public abstract class TestBatch {
     String storeName = testBatchStore(
         inputDir -> new KeyAndValueSchemas(writeSimpleAvroFileWithStringToStringSchema(inputDir)),
         properties -> {
-          properties.setProperty(SEND_CONTROL_MESSAGES_DIRECTLY, String.valueOf(true));
+          properties.setProperty(SEND_CONTROL_MESSAGES_DIRECTLY, String.valueOf(sendDirectControlMessage));
         },
         validator,
         new UpdateStoreQueryParams().setCompressionStrategy(CompressionStrategy.ZSTD_WITH_DICT));
@@ -649,7 +649,7 @@ public abstract class TestBatch {
           properties.setProperty(VENICE_STORE_NAME_PROP, storeName);
           properties.setProperty(KAFKA_INPUT_BROKER_URL, veniceCluster.getPubSubBrokerWrapper().getAddress());
           properties.setProperty(KAFKA_INPUT_MAX_RECORDS_PER_MAPPER, "5");
-          properties.setProperty(SEND_CONTROL_MESSAGES_DIRECTLY, String.valueOf(true));
+          properties.setProperty(SEND_CONTROL_MESSAGES_DIRECTLY, String.valueOf(sendDirectControlMessage));
           properties.setProperty(COMPRESSION_METRIC_COLLECTION_ENABLED, String.valueOf(true));
         },
         validator,


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Fix building or fetching dictionary for repush jobs
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
Recently, in #886, we refactored some code around compression metric collection and using mapper to build dictionary. This refactoring had a bug where the dictionary building for repush jobs was skipped and if VPJ sends control messages directly, then the push would fail, as the `START_OF_PUSH` would not have any dictionary. This change fixes the issue and reenables a dictionary to be built for KIF repush as well.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
Added an integration test. GH CI will do regression testing

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.