### PR TITLE
[vpj] Skip closing the SparkSession and let it be closed at app shutdown

### DIFF
--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/spark/datawriter/jobs/AbstractDataWriterSparkJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/spark/datawriter/jobs/AbstractDataWriterSparkJob.java
@@ -66,7 +66,6 @@ import com.linkedin.venice.hadoop.spark.utils.SparkPartitionUtils;
 import com.linkedin.venice.hadoop.spark.utils.SparkScalaUtils;
 import com.linkedin.venice.hadoop.ssl.TempFileSSLConfigurator;
 import com.linkedin.venice.hadoop.task.datawriter.DataWriterTaskTracker;
-import com.linkedin.venice.utils.Utils;
 import com.linkedin.venice.utils.VeniceProperties;
 import com.linkedin.venice.writer.VeniceWriter;
 import java.io.IOException;
@@ -397,7 +396,8 @@ public abstract class AbstractDataWriterSparkJob extends DataWriterComputeJob {
 
   @Override
   public void close() throws IOException {
-    Utils.closeQuietlyWithErrorLogged(sparkSession);
+    // We don't close the SparkSession to help with reusability across multiple Spark jobs, and it will eventually be
+    // closed by SparkContext's ShutdownHook
   }
 
   private void logAccumulatorValues() {


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Skip closing the SparkSession and let it be closed at app shutdown
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
In `AbstractDataWriterSparkJob`, we need a `SparkSession` and to get one, we use `SparkSession.Builder()...getOrCreate()`. This either provides an existing `SparkSession`, or creates a new one if one doesn't exist already. `SparkContext` has a `ShutdownHook` that closes the session at the end of the JVM. When VPJ is executed via `spark-submit`, it executes in the Spark driver. In this case, we do not wish to close the `SparkSession` and instead let the `ShutdownHook` take care of it. This is also okay for client-mode of Spark execution as those can be expected to be short lived. If someone needs a way to explicitly close a `SparkSession`, we can add a new function that helps achieve that. We don't have such a need right now.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
GH CI. Tested manually as well

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.