### PR TITLE
[controller] Support dangling topic check and deletion in topic cleanup service.

### DIFF
--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -2142,4 +2142,10 @@ public class ConfigKeys {
    */
   public static final String SERVER_RECORD_LEVEL_METRICS_WHEN_BOOTSTRAPPING_CURRENT_VERSION_ENABLED =
       "server.record.level.metrics.when.bootstrapping.current.version.enabled";
+
+  /**
+   * Time interval for checking dangling topics between 2 different types of pub sub backends.
+   */
+  public static final String CONTROLLER_DANGLING_TOPIC_CLEAN_UP_INTERVAL_SECOND =
+      "controller.dangling.topic.clean.up.interval.second";
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -2065,6 +2065,12 @@ public class ConfigKeys {
   public static final String PUB_SUB_CONSUMER_ADAPTER_FACTORY_CLASS = "pub.sub.consumer.adapter.factory.class";
 
   /**
+   * Source of truth admin adapter type, mainly for avoiding topic discrepancy between multiple pub sub systems.
+   */
+  public static final String PUB_SUB_SOURCE_OF_TRUTH_ADMIN_ADAPTER_FACTORY_CLASS =
+      "pub.sub.of.source.of.truth.admin.adapter.factory.class";
+
+  /**
    * Venice router's principal name used for ssl. Default should contain "venice-router".
    */
   public static final String ROUTER_PRINCIPAL_NAME = "router.principal.name";

--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -2154,4 +2154,11 @@ public class ConfigKeys {
    */
   public static final String CONTROLLER_DANGLING_TOPIC_CLEAN_UP_INTERVAL_SECOND =
       "controller.dangling.topic.clean.up.interval.second";
+
+  /**
+   * To avoid potential risk of race condition, if a topic is identified as dangling topic in number of times beyond
+   * this defined threshold, then this topic could be deleted.
+   */
+  public static final String CONTROLLER_DANGLING_TOPIC_OCCURRENCE_THRESHOLD_FOR_CLEANUP =
+      "controller.dangling.topic.occurrence.threshold.for.cleanup";
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/PubSubClientsFactory.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/PubSubClientsFactory.java
@@ -3,6 +3,7 @@ package com.linkedin.venice.pubsub;
 import static com.linkedin.venice.ConfigKeys.PUB_SUB_ADMIN_ADAPTER_FACTORY_CLASS;
 import static com.linkedin.venice.ConfigKeys.PUB_SUB_CONSUMER_ADAPTER_FACTORY_CLASS;
 import static com.linkedin.venice.ConfigKeys.PUB_SUB_PRODUCER_ADAPTER_FACTORY_CLASS;
+import static com.linkedin.venice.ConfigKeys.PUB_SUB_SOURCE_OF_TRUTH_ADMIN_ADAPTER_FACTORY_CLASS;
 
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.pubsub.adapter.kafka.admin.ApacheKafkaAdminAdapterFactory;
@@ -84,6 +85,15 @@ public class PubSubClientsFactory {
     return createFactory(
         veniceProperties,
         PUB_SUB_ADMIN_ADAPTER_FACTORY_CLASS,
+        ApacheKafkaAdminAdapterFactory.class.getName(),
+        FactoryType.ADMIN);
+  }
+
+  public static PubSubAdminAdapterFactory<PubSubAdminAdapter> createSourceOfTruthAdminFactory(
+      VeniceProperties veniceProperties) {
+    return createFactory(
+        veniceProperties,
+        PUB_SUB_SOURCE_OF_TRUTH_ADMIN_ADAPTER_FACTORY_CLASS,
         ApacheKafkaAdminAdapterFactory.class.getName(),
         FactoryType.ADMIN);
   }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceController.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceController.java
@@ -190,7 +190,8 @@ public class VeniceController {
           admin,
           multiClusterConfigs,
           pubSubTopicRepository,
-          new TopicCleanupServiceStats(metricsRepository));
+          new TopicCleanupServiceStats(metricsRepository),
+          pubSubClientsFactory);
       if (!(admin instanceof VeniceParentHelixAdmin)) {
         throw new VeniceException(
             "'VeniceParentHelixAdmin' is expected of the returned 'Admin' from 'VeniceControllerService#getVeniceHelixAdmin' in parent mode");
@@ -210,7 +211,8 @@ public class VeniceController {
           admin,
           multiClusterConfigs,
           pubSubTopicRepository,
-          new TopicCleanupServiceStats(metricsRepository));
+          new TopicCleanupServiceStats(metricsRepository),
+          pubSubClientsFactory);
       if (!(admin instanceof VeniceHelixAdmin)) {
         throw new VeniceException(
             "'VeniceHelixAdmin' is expected of the returned 'Admin' from 'VeniceControllerService#getVeniceHelixAdmin' in child mode");

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerConfig.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerConfig.java
@@ -33,6 +33,7 @@ import static com.linkedin.venice.ConfigKeys.CONTROLLER_CLUSTER;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_CLUSTER_LEADER_HAAS;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_CLUSTER_REPLICA;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_CLUSTER_ZK_ADDRESSS;
+import static com.linkedin.venice.ConfigKeys.CONTROLLER_DANGLING_TOPIC_CLEAN_UP_INTERVAL_SECOND;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_DISABLED_REPLICA_ENABLER_INTERVAL_MS;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_DISABLED_ROUTES;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_DISABLE_PARENT_TOPIC_TRUNCATION_UPON_COMPLETION;
@@ -328,6 +329,8 @@ public class VeniceControllerConfig extends VeniceControllerClusterConfig {
   private final boolean useDaVinciSpecificExecutionStatusForError;
   private final PubSubClientsFactory pubSubClientsFactory;
 
+  private final long danglingTopicCleanupIntervalSeconds;
+
   public VeniceControllerConfig(VeniceProperties props) {
     super(props);
     this.adminPort = props.getInt(ADMIN_PORT);
@@ -572,6 +575,7 @@ public class VeniceControllerConfig extends VeniceControllerClusterConfig {
     this.useDaVinciSpecificExecutionStatusForError =
         props.getBoolean(USE_DA_VINCI_SPECIFIC_EXECUTION_STATUS_FOR_ERROR, false);
     this.pubSubClientsFactory = new PubSubClientsFactory(props);
+    this.danglingTopicCleanupIntervalSeconds = props.getLong(CONTROLLER_DANGLING_TOPIC_CLEAN_UP_INTERVAL_SECOND, 3600);
   }
 
   private void validateActiveActiveConfigs() {
@@ -1151,6 +1155,10 @@ public class VeniceControllerConfig extends VeniceControllerClusterConfig {
     }
 
     return outputMap;
+  }
+
+  public long getDanglingTopicCleanupIntervalSeconds() {
+    return danglingTopicCleanupIntervalSeconds;
   }
 
   /**

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerConfig.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerConfig.java
@@ -112,6 +112,7 @@ import com.linkedin.venice.authorization.DefaultIdentityParser;
 import com.linkedin.venice.client.store.ClientConfig;
 import com.linkedin.venice.controllerapi.ControllerRoute;
 import com.linkedin.venice.exceptions.VeniceException;
+import com.linkedin.venice.pubsub.PubSubAdminAdapterFactory;
 import com.linkedin.venice.pubsub.PubSubClientsFactory;
 import com.linkedin.venice.pubsub.adapter.kafka.admin.ApacheKafkaAdminAdapter;
 import com.linkedin.venice.status.BatchJobHeartbeatConfigs;
@@ -328,6 +329,8 @@ public class VeniceControllerConfig extends VeniceControllerClusterConfig {
   private final int minSchemaCountToKeep;
   private final boolean useDaVinciSpecificExecutionStatusForError;
   private final PubSubClientsFactory pubSubClientsFactory;
+
+  private final PubSubAdminAdapterFactory sourceOfTruthAdminAdapterFactory;
 
   private final long danglingTopicCleanupIntervalSeconds;
 
@@ -575,6 +578,7 @@ public class VeniceControllerConfig extends VeniceControllerClusterConfig {
     this.useDaVinciSpecificExecutionStatusForError =
         props.getBoolean(USE_DA_VINCI_SPECIFIC_EXECUTION_STATUS_FOR_ERROR, false);
     this.pubSubClientsFactory = new PubSubClientsFactory(props);
+    this.sourceOfTruthAdminAdapterFactory = PubSubClientsFactory.createSourceOfTruthAdminFactory(props);
     this.danglingTopicCleanupIntervalSeconds = props.getLong(CONTROLLER_DANGLING_TOPIC_CLEAN_UP_INTERVAL_SECOND, 3600);
   }
 
@@ -1062,6 +1066,10 @@ public class VeniceControllerConfig extends VeniceControllerClusterConfig {
 
   public PubSubClientsFactory getPubSubClientsFactory() {
     return pubSubClientsFactory;
+  }
+
+  public PubSubAdminAdapterFactory getSourceOfTruthAdminAdapterFactory() {
+    return sourceOfTruthAdminAdapterFactory;
   }
 
   /**

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerConfig.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerConfig.java
@@ -34,6 +34,7 @@ import static com.linkedin.venice.ConfigKeys.CONTROLLER_CLUSTER_LEADER_HAAS;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_CLUSTER_REPLICA;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_CLUSTER_ZK_ADDRESSS;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_DANGLING_TOPIC_CLEAN_UP_INTERVAL_SECOND;
+import static com.linkedin.venice.ConfigKeys.CONTROLLER_DANGLING_TOPIC_OCCURRENCE_THRESHOLD_FOR_CLEANUP;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_DISABLED_REPLICA_ENABLER_INTERVAL_MS;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_DISABLED_ROUTES;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_DISABLE_PARENT_TOPIC_TRUNCATION_UPON_COMPLETION;
@@ -333,6 +334,7 @@ public class VeniceControllerConfig extends VeniceControllerClusterConfig {
   private final PubSubAdminAdapterFactory sourceOfTruthAdminAdapterFactory;
 
   private final long danglingTopicCleanupIntervalSeconds;
+  private final int danglingTopicOccurrenceThresholdForCleanup;
 
   public VeniceControllerConfig(VeniceProperties props) {
     super(props);
@@ -579,7 +581,9 @@ public class VeniceControllerConfig extends VeniceControllerClusterConfig {
         props.getBoolean(USE_DA_VINCI_SPECIFIC_EXECUTION_STATUS_FOR_ERROR, false);
     this.pubSubClientsFactory = new PubSubClientsFactory(props);
     this.sourceOfTruthAdminAdapterFactory = PubSubClientsFactory.createSourceOfTruthAdminFactory(props);
-    this.danglingTopicCleanupIntervalSeconds = props.getLong(CONTROLLER_DANGLING_TOPIC_CLEAN_UP_INTERVAL_SECOND, 3600);
+    this.danglingTopicCleanupIntervalSeconds = props.getLong(CONTROLLER_DANGLING_TOPIC_CLEAN_UP_INTERVAL_SECOND, -1);
+    this.danglingTopicOccurrenceThresholdForCleanup =
+        props.getInt(CONTROLLER_DANGLING_TOPIC_OCCURRENCE_THRESHOLD_FOR_CLEANUP, 3);
   }
 
   private void validateActiveActiveConfigs() {
@@ -1167,6 +1171,10 @@ public class VeniceControllerConfig extends VeniceControllerClusterConfig {
 
   public long getDanglingTopicCleanupIntervalSeconds() {
     return danglingTopicCleanupIntervalSeconds;
+  }
+
+  public int getDanglingTopicOccurrenceThresholdForCleanup() {
+    return danglingTopicOccurrenceThresholdForCleanup;
   }
 
   /**

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerMultiClusterConfig.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerMultiClusterConfig.java
@@ -3,6 +3,7 @@ package com.linkedin.venice.controller;
 import com.linkedin.venice.SSLConfig;
 import com.linkedin.venice.controllerapi.ControllerRoute;
 import com.linkedin.venice.exceptions.VeniceNoClusterException;
+import com.linkedin.venice.pubsub.PubSubAdminAdapterFactory;
 import com.linkedin.venice.pubsub.PubSubClientsFactory;
 import com.linkedin.venice.utils.VeniceProperties;
 import java.time.Duration;
@@ -280,6 +281,10 @@ public class VeniceControllerMultiClusterConfig {
 
   public PubSubClientsFactory getPubSubClientsFactory() {
     return getCommonConfig().getPubSubClientsFactory();
+  }
+
+  public PubSubAdminAdapterFactory getSourceOfTruthAdminAdapterFactory() {
+    return getCommonConfig().getSourceOfTruthAdminAdapterFactory();
   }
 
   public long getDanglingTopicCleanupIntervalSeconds() {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerMultiClusterConfig.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerMultiClusterConfig.java
@@ -278,8 +278,11 @@ public class VeniceControllerMultiClusterConfig {
     return getCommonConfig().getStoreGraveyardCleanupSleepIntervalBetweenListFetchMinutes();
   }
 
-  // TODO: Remove this method once we fully support cluster-level pub sub adapter configuration.
   public PubSubClientsFactory getPubSubClientsFactory() {
     return getCommonConfig().getPubSubClientsFactory();
+  }
+
+  public long getDanglingTopicCleanupIntervalSeconds() {
+    return getCommonConfig().getDanglingTopicCleanupIntervalSeconds();
   }
 }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerMultiClusterConfig.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerMultiClusterConfig.java
@@ -290,4 +290,8 @@ public class VeniceControllerMultiClusterConfig {
   public long getDanglingTopicCleanupIntervalSeconds() {
     return getCommonConfig().getDanglingTopicCleanupIntervalSeconds();
   }
+
+  public int getDanglingTopicOccurrenceThresholdForCleanup() {
+    return getCommonConfig().getDanglingTopicOccurrenceThresholdForCleanup();
+  }
 }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/kafka/TopicCleanupServiceForParentController.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/kafka/TopicCleanupServiceForParentController.java
@@ -4,6 +4,7 @@ import com.linkedin.venice.controller.Admin;
 import com.linkedin.venice.controller.VeniceControllerMultiClusterConfig;
 import com.linkedin.venice.controller.stats.TopicCleanupServiceStats;
 import com.linkedin.venice.exceptions.VeniceException;
+import com.linkedin.venice.pubsub.PubSubClientsFactory;
 import com.linkedin.venice.pubsub.PubSubTopicRepository;
 import com.linkedin.venice.pubsub.api.PubSubTopic;
 import com.linkedin.venice.pubsub.manager.TopicManager;
@@ -26,8 +27,9 @@ public class TopicCleanupServiceForParentController extends TopicCleanupService 
       Admin admin,
       VeniceControllerMultiClusterConfig multiClusterConfigs,
       PubSubTopicRepository pubSubTopicRepository,
-      TopicCleanupServiceStats topicCleanupServiceStats) {
-    super(admin, multiClusterConfigs, pubSubTopicRepository, topicCleanupServiceStats);
+      TopicCleanupServiceStats topicCleanupServiceStats,
+      PubSubClientsFactory pubSubClientsFactory) {
+    super(admin, multiClusterConfigs, pubSubTopicRepository, topicCleanupServiceStats, pubSubClientsFactory);
   }
 
   @Override

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/kafka/TestTopicCleanupService.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/kafka/TestTopicCleanupService.java
@@ -1,10 +1,12 @@
 package com.linkedin.venice.controller.kafka;
 
-import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -17,20 +19,28 @@ import com.linkedin.venice.controller.VeniceControllerConfig;
 import com.linkedin.venice.controller.VeniceControllerMultiClusterConfig;
 import com.linkedin.venice.controller.stats.TopicCleanupServiceStats;
 import com.linkedin.venice.exceptions.VeniceException;
+import com.linkedin.venice.exceptions.VeniceNoStoreException;
 import com.linkedin.venice.helix.HelixReadOnlyStoreConfigRepository;
+import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.StoreConfig;
 import com.linkedin.venice.meta.Version;
+import com.linkedin.venice.pubsub.PubSubClientsFactory;
 import com.linkedin.venice.pubsub.PubSubTopicRepository;
+import com.linkedin.venice.pubsub.adapter.kafka.admin.ApacheKafkaAdminAdapter;
+import com.linkedin.venice.pubsub.adapter.kafka.admin.ApacheKafkaAdminAdapterFactory;
 import com.linkedin.venice.pubsub.api.PubSubTopic;
 import com.linkedin.venice.pubsub.manager.TopicManager;
+import com.linkedin.venice.utils.Pair;
 import com.linkedin.venice.utils.TestUtils;
 import com.linkedin.venice.utils.Utils;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
@@ -49,6 +59,7 @@ public class TestTopicCleanupService {
   private VeniceControllerMultiClusterConfig veniceControllerMultiClusterConfig;
   private TopicCleanupServiceStats topicCleanupServiceStats;
   private final PubSubTopicRepository pubSubTopicRepository = new PubSubTopicRepository();
+  private final PubSubClientsFactory pubSubClientsFactory = mock(PubSubClientsFactory.class);
 
   @BeforeMethod
   public void setUp() {
@@ -77,11 +88,13 @@ public class TestTopicCleanupService {
     doReturn(Collections.emptyMap()).when(remoteTopicManager).getAllTopicRetentions();
     topicCleanupServiceStats = mock(TopicCleanupServiceStats.class);
 
+    doReturn(new ApacheKafkaAdminAdapterFactory()).when(pubSubClientsFactory).getAdminAdapterFactory();
     topicCleanupService = new TopicCleanupService(
         admin,
         veniceControllerMultiClusterConfig,
         pubSubTopicRepository,
-        topicCleanupServiceStats);
+        topicCleanupServiceStats,
+        pubSubClientsFactory);
   }
 
   @AfterMethod
@@ -175,6 +188,8 @@ public class TestTopicCleanupService {
     String storeName1 = Utils.getUniqueString("store1");
     String storeName2 = Utils.getUniqueString("store2");
     String storeName3 = Utils.getUniqueString("store3");
+    String storeName4 = Utils.getUniqueString("store4");
+    String storeName5 = Utils.getUniqueString("store5");
     Map<PubSubTopic, Long> storeTopics = new HashMap<>();
     storeTopics.put(getPubSubTopic(storeName1, "_v1"), 1000L);
     storeTopics.put(getPubSubTopic(storeName1, "_v2"), 1000L);
@@ -184,6 +199,9 @@ public class TestTopicCleanupService {
     storeTopics.put(getPubSubTopic(storeName2, "_rt"), 1000L);
     storeTopics.put(getPubSubTopic(storeName2, "_v1"), 1000L);
     storeTopics.put(getPubSubTopic(storeName3, "_rt"), 1000L);
+    storeTopics.put(getPubSubTopic(storeName3, "_v100"), Long.MAX_VALUE);
+    storeTopics.put(getPubSubTopic(storeName4, "_rt"), Long.MAX_VALUE);
+    storeTopics.put(getPubSubTopic(storeName5, "_v1"), Long.MAX_VALUE);
 
     Map<PubSubTopic, Long> storeTopics2 = new HashMap<>();
     storeTopics2.put(getPubSubTopic(storeName1, "_v3"), Long.MAX_VALUE);
@@ -208,6 +226,35 @@ public class TestTopicCleanupService {
     doReturn(true).when(admin).isTopicTruncatedBasedOnRetention(any(), eq(1000L));
     doReturn(Optional.of(new StoreConfig(storeName1))).when(storeConfigRepository).getStoreConfig(storeName1);
 
+    Set<PubSubTopic> pubSubTopicSet = new HashSet<>();
+    pubSubTopicSet.addAll(storeTopics.keySet());
+    pubSubTopicSet.remove(getPubSubTopic(storeName3, "_v100"));
+    pubSubTopicSet.remove(getPubSubTopic(storeName4, "_rt"));
+    pubSubTopicSet.remove(getPubSubTopic(storeName5, "_v1"));
+
+    ApacheKafkaAdminAdapterFactory apacheKafkaAdminAdapterFactory = mock(ApacheKafkaAdminAdapterFactory.class);
+    ApacheKafkaAdminAdapter apacheKafkaAdminAdapter = mock(ApacheKafkaAdminAdapter.class);
+    doReturn(apacheKafkaAdminAdapter).when(apacheKafkaAdminAdapterFactory).create(any(), eq(pubSubTopicRepository));
+
+    topicCleanupService.setApacheKafkaAdminAdapter(apacheKafkaAdminAdapter);
+    String clusterName = "clusterName";
+    Pair<String, String> pair = new Pair<>(clusterName, "");
+    doReturn(pair).when(admin).discoverCluster(storeName3);
+    doReturn(pair).when(admin).discoverCluster(storeName4);
+    doThrow(new VeniceNoStoreException(storeName5)).when(admin).discoverCluster(storeName5);
+
+    Store store3 = mock(Store.class);
+    doReturn(false).when(store3).containsVersion(100);
+
+    Store store4 = mock(Store.class);
+    doReturn(false).when(store4).isHybrid();
+    Version version = mock(Version.class);
+    doReturn(null).when(version).getHybridStoreConfig();
+
+    doReturn(store3).when(admin).getStore(clusterName, storeName3);
+    doReturn(store4).when(admin).getStore(clusterName, storeName4);
+    doReturn(pubSubTopicSet).when(apacheKafkaAdminAdapter).listAllTopics();
+
     topicCleanupService.cleanupVeniceTopics();
 
     verify(topicManager, never()).ensureTopicIsDeletedAndBlockWithRetry(getPubSubTopic(storeName1, "_rt"));
@@ -220,10 +267,13 @@ public class TestTopicCleanupService {
     verify(topicManager, never()).ensureTopicIsDeletedAndBlockWithRetry(getPubSubTopic(storeName2, "_rt"));
     // Delete should be blocked by remote VT
     verify(topicManager, never()).ensureTopicIsDeletedAndBlockWithRetry(getPubSubTopic(storeName3, "_rt"));
-    verify(topicCleanupServiceStats, atLeastOnce()).recordDeletableTopicsCount(5);
+    verify(topicCleanupServiceStats, atLeastOnce()).recordDeletableTopicsCount(8);
     verify(topicCleanupServiceStats, never()).recordTopicDeletionError();
     verify(topicCleanupServiceStats, atLeastOnce()).recordTopicDeleted();
 
+    verify(topicManager, atLeastOnce()).ensureTopicIsDeletedAndBlockWithRetry(getPubSubTopic(storeName3, "_v100"));
+    verify(topicManager, atLeastOnce()).ensureTopicIsDeletedAndBlockWithRetry(getPubSubTopic(storeName4, "_rt"));
+    verify(topicManager, atLeastOnce()).ensureTopicIsDeletedAndBlockWithRetry(getPubSubTopic(storeName5, "_v1"));
     topicCleanupService.cleanupVeniceTopics();
 
     verify(topicManager, never()).ensureTopicIsDeletedAndBlockWithRetry(getPubSubTopic(storeName1, "_v3"));
@@ -394,7 +444,8 @@ public class TestTopicCleanupService {
         admin,
         veniceControllerMultiClusterConfig,
         pubSubTopicRepository,
-        topicCleanupServiceStats);
+        topicCleanupServiceStats,
+        pubSubClientsFactory);
     String storeName = Utils.getUniqueString("testStore");
     Map<PubSubTopic, Long> storeTopics = new HashMap<>();
     storeTopics.put(getPubSubTopic(storeName, "_rt"), 1000L);

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/kafka/TestTopicCleanupService.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/kafka/TestTopicCleanupService.java
@@ -29,6 +29,7 @@ import com.linkedin.venice.pubsub.PubSubTopicRepository;
 import com.linkedin.venice.pubsub.adapter.kafka.admin.ApacheKafkaAdminAdapter;
 import com.linkedin.venice.pubsub.adapter.kafka.admin.ApacheKafkaAdminAdapterFactory;
 import com.linkedin.venice.pubsub.api.PubSubTopic;
+import com.linkedin.venice.pubsub.api.PubSubTopicType;
 import com.linkedin.venice.pubsub.manager.TopicManager;
 import com.linkedin.venice.utils.Pair;
 import com.linkedin.venice.utils.TestUtils;
@@ -202,6 +203,7 @@ public class TestTopicCleanupService {
     storeTopics.put(getPubSubTopic(storeName3, "_v100"), Long.MAX_VALUE);
     storeTopics.put(getPubSubTopic(storeName4, "_rt"), Long.MAX_VALUE);
     storeTopics.put(getPubSubTopic(storeName5, "_v1"), Long.MAX_VALUE);
+    storeTopics.put(getPubSubTopic(PubSubTopicType.ADMIN_TOPIC_PREFIX, "_cluster"), Long.MAX_VALUE);
 
     Map<PubSubTopic, Long> storeTopics2 = new HashMap<>();
     storeTopics2.put(getPubSubTopic(storeName1, "_v3"), Long.MAX_VALUE);
@@ -231,6 +233,7 @@ public class TestTopicCleanupService {
     pubSubTopicSet.remove(getPubSubTopic(storeName3, "_v100"));
     pubSubTopicSet.remove(getPubSubTopic(storeName4, "_rt"));
     pubSubTopicSet.remove(getPubSubTopic(storeName5, "_v1"));
+    pubSubTopicSet.remove(getPubSubTopic(PubSubTopicType.ADMIN_TOPIC_PREFIX, "_cluster"));
 
     ApacheKafkaAdminAdapterFactory apacheKafkaAdminAdapterFactory = mock(ApacheKafkaAdminAdapterFactory.class);
     ApacheKafkaAdminAdapter apacheKafkaAdminAdapter = mock(ApacheKafkaAdminAdapter.class);

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/kafka/TestTopicCleanupService.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/kafka/TestTopicCleanupService.java
@@ -74,6 +74,8 @@ public class TestTopicCleanupService {
     veniceControllerMultiClusterConfig = mock(VeniceControllerMultiClusterConfig.class);
     doReturn(0L).when(veniceControllerMultiClusterConfig).getTopicCleanupSleepIntervalBetweenTopicListFetchMs();
     doReturn(1).when(veniceControllerMultiClusterConfig).getMinNumberOfUnusedKafkaTopicsToPreserve();
+    doReturn(new ApacheKafkaAdminAdapterFactory()).when(veniceControllerMultiClusterConfig)
+        .getSourceOfTruthAdminAdapterFactory();
     doReturn(1).when(admin).getMinNumberOfUnusedKafkaTopicsToPreserve();
 
     VeniceControllerConfig veniceControllerConfig = mock(VeniceControllerConfig.class);
@@ -239,7 +241,7 @@ public class TestTopicCleanupService {
     ApacheKafkaAdminAdapter apacheKafkaAdminAdapter = mock(ApacheKafkaAdminAdapter.class);
     doReturn(apacheKafkaAdminAdapter).when(apacheKafkaAdminAdapterFactory).create(any(), eq(pubSubTopicRepository));
 
-    topicCleanupService.setApacheKafkaAdminAdapter(apacheKafkaAdminAdapter);
+    topicCleanupService.setSourceOfTruthPubSubAdminAdapter(apacheKafkaAdminAdapter);
     String clusterName = "clusterName";
     Pair<String, String> pair = new Pair<>(clusterName, "");
     doReturn(pair).when(admin).discoverCluster(storeName3);

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/kafka/TestTopicCleanupService.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/kafka/TestTopicCleanupService.java
@@ -85,6 +85,7 @@ public class TestTopicCleanupService {
     dataCenterToBootstrapServerMap.put("local", "local");
     dataCenterToBootstrapServerMap.put("remote", "remote");
     doReturn(dataCenterToBootstrapServerMap).when(veniceControllerMultiClusterConfig).getChildDataCenterKafkaUrlMap();
+    doReturn(1).when(veniceControllerMultiClusterConfig).getDanglingTopicOccurrenceThresholdForCleanup();
     doReturn("local").when(topicManager).getPubSubClusterAddress();
     remoteTopicManager = mock(TopicManager.class);
     doReturn(remoteTopicManager).when(admin).getTopicManager("remote");

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/kafka/TestTopicCleanupServiceForMultiKafkaClusters.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/kafka/TestTopicCleanupServiceForMultiKafkaClusters.java
@@ -39,6 +39,7 @@ public class TestTopicCleanupServiceForMultiKafkaClusters {
     doReturn(2).when(config).getTopicCleanupDelayFactor();
     VeniceControllerConfig veniceControllerConfig = mock(VeniceControllerConfig.class);
     doReturn(veniceControllerConfig).when(config).getCommonConfig();
+    doReturn(new ApacheKafkaAdminAdapterFactory()).when(config).getSourceOfTruthAdminAdapterFactory();
     doReturn("fabric1,fabric2").when(veniceControllerConfig).getChildDatacenters();
 
     String kafkaClusterKey1 = "fabric1";

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/kafka/TestTopicCleanupServiceForMultiKafkaClusters.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/kafka/TestTopicCleanupServiceForMultiKafkaClusters.java
@@ -9,7 +9,9 @@ import com.linkedin.venice.controller.Admin;
 import com.linkedin.venice.controller.VeniceControllerConfig;
 import com.linkedin.venice.controller.VeniceControllerMultiClusterConfig;
 import com.linkedin.venice.controller.stats.TopicCleanupServiceStats;
+import com.linkedin.venice.pubsub.PubSubClientsFactory;
 import com.linkedin.venice.pubsub.PubSubTopicRepository;
+import com.linkedin.venice.pubsub.adapter.kafka.admin.ApacheKafkaAdminAdapterFactory;
 import com.linkedin.venice.pubsub.api.PubSubTopic;
 import com.linkedin.venice.pubsub.manager.TopicManager;
 import java.util.HashMap;
@@ -28,6 +30,7 @@ public class TestTopicCleanupServiceForMultiKafkaClusters {
   private TopicCleanupServiceForParentController topicCleanupService;
 
   private PubSubTopicRepository pubSubTopicRepository = new PubSubTopicRepository();
+  private final PubSubClientsFactory pubSubClientsFactory = mock(PubSubClientsFactory.class);
 
   @BeforeTest
   public void setUp() {
@@ -61,9 +64,13 @@ public class TestTopicCleanupServiceForMultiKafkaClusters {
     doReturn(kafkaClusterServerUrl2).when(topicManager2).getPubSubClusterAddress();
     doReturn(topicManager2).when(admin).getTopicManager(kafkaClusterServerUrl2);
     TopicCleanupServiceStats topicCleanupServiceStats = mock(TopicCleanupServiceStats.class);
-
-    topicCleanupService =
-        new TopicCleanupServiceForParentController(admin, config, pubSubTopicRepository, topicCleanupServiceStats);
+    doReturn(new ApacheKafkaAdminAdapterFactory()).when(pubSubClientsFactory).getAdminAdapterFactory();
+    topicCleanupService = new TopicCleanupServiceForParentController(
+        admin,
+        config,
+        pubSubTopicRepository,
+        topicCleanupServiceStats,
+        pubSubClientsFactory);
   }
 
   @Test

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/kafka/TestTopicCleanupServiceForParentController.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/kafka/TestTopicCleanupServiceForParentController.java
@@ -9,7 +9,9 @@ import com.linkedin.venice.controller.Admin;
 import com.linkedin.venice.controller.VeniceControllerConfig;
 import com.linkedin.venice.controller.VeniceControllerMultiClusterConfig;
 import com.linkedin.venice.controller.stats.TopicCleanupServiceStats;
+import com.linkedin.venice.pubsub.PubSubClientsFactory;
 import com.linkedin.venice.pubsub.PubSubTopicRepository;
+import com.linkedin.venice.pubsub.adapter.kafka.admin.ApacheKafkaAdminAdapterFactory;
 import com.linkedin.venice.pubsub.api.PubSubTopic;
 import com.linkedin.venice.pubsub.manager.TopicManager;
 import java.util.HashMap;
@@ -24,6 +26,7 @@ public class TestTopicCleanupServiceForParentController {
   private TopicManager topicManager;
   private TopicCleanupService topicCleanupService;
   private final PubSubTopicRepository pubSubTopicRepository = new PubSubTopicRepository();
+  private final PubSubClientsFactory pubSubClientsFactory = mock(PubSubClientsFactory.class);
 
   @BeforeTest
   public void setUp() {
@@ -37,8 +40,13 @@ public class TestTopicCleanupServiceForParentController {
     doReturn(veniceControllerConfig).when(config).getCommonConfig();
     doReturn("dc1").when(veniceControllerConfig).getChildDatacenters();
     TopicCleanupServiceStats topicCleanupServiceStats = mock(TopicCleanupServiceStats.class);
-    topicCleanupService =
-        new TopicCleanupServiceForParentController(admin, config, pubSubTopicRepository, topicCleanupServiceStats);
+    doReturn(new ApacheKafkaAdminAdapterFactory()).when(pubSubClientsFactory).getAdminAdapterFactory();
+    topicCleanupService = new TopicCleanupServiceForParentController(
+        admin,
+        config,
+        pubSubTopicRepository,
+        topicCleanupServiceStats,
+        pubSubClientsFactory);
   }
 
   @Test

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/kafka/TestTopicCleanupServiceForParentController.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/kafka/TestTopicCleanupServiceForParentController.java
@@ -41,6 +41,7 @@ public class TestTopicCleanupServiceForParentController {
     doReturn("dc1").when(veniceControllerConfig).getChildDatacenters();
     TopicCleanupServiceStats topicCleanupServiceStats = mock(TopicCleanupServiceStats.class);
     doReturn(new ApacheKafkaAdminAdapterFactory()).when(pubSubClientsFactory).getAdminAdapterFactory();
+    doReturn(new ApacheKafkaAdminAdapterFactory()).when(config).getSourceOfTruthAdminAdapterFactory();
     topicCleanupService = new TopicCleanupServiceForParentController(
         admin,
         config,


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Summary, imperative, start upper case, don't end with a period
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Add dangling topic checking functionality,  `TopicCleanupService` will compare topics listed from source of truth pub sub system and topics from other type of pub sub client, if there is topic could not be found by source of truth pub sub system client but can be founded by other type of pub sub client, topic will be deleted if met by times more than `CONTROLLER_DANGLING_TOPIC_OCCURRENCE_THRESHOLD_FOR_CLEANUP` by such cases:

1.  Real-time topic, if store is not hybrid and no store version carries hybrid config,  that topic is not valid. 
2. Version topic, if store does not contain that version, the topic is not valid. 
3. If there is no store available for that topic, the topic is not valid. 

Add a config for source of truth admin client class: `PUB_SUB_SOURCE_OF_TRUTH_ADMIN_ADAPTER_FACTORY_CLASS`
Add a config for consistently decide a topic is dangling: `CONTROLLER_DANGLING_TOPIC_OCCURRENCE_THRESHOLD_FOR_CLEANUP`
Add a new config to enable this feature: `CONTROLLER_DANGLING_TOPIC_CLEAN_UP_INTERVAL_SECOND`. If its value is >0 and `PUB_SUB_SOURCE_OF_TRUTH_ADMIN_ADAPTER_FACTORY_CLASS` is not the same as `PUB_SUB_ADMIN_ADAPTER_FACTORY_CLASS`,  the feature will be turned on. Otherwise, it will be disabled. 




## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
CI, integration test will be in internal repo with other type of pub sub system. 
## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [*] No. You can skip the rest of this section.
- [] Yes. Make sure to explain your proposed changes and call out the behavior change.