### PR TITLE
[fast-client][server] Throw 403 for metadata request that does not have storage read quota enabled

### DIFF
--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/fastclient/AvroStoreClientGzipEndToEndTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/fastclient/AvroStoreClientGzipEndToEndTest.java
@@ -2,6 +2,7 @@ package com.linkedin.venice.fastclient;
 
 import static com.linkedin.venice.fastclient.utils.ClientTestUtils.REQUEST_TYPES_SMALL;
 import static com.linkedin.venice.fastclient.utils.ClientTestUtils.STORE_METADATA_FETCH_MODES;
+import static org.testng.Assert.assertFalse;
 
 import com.linkedin.venice.compression.CompressionStrategy;
 import com.linkedin.venice.controllerapi.UpdateStoreQueryParams;
@@ -76,7 +77,15 @@ public class AvroStoreClientGzipEndToEndTest extends AvroStoreClientEndToEndTest
           storeVersionName = topic;
           return null;
         });
-    veniceCluster.updateStore(storeName, new UpdateStoreQueryParams().setReadComputationEnabled(true));
+    veniceCluster
+        .useControllerClient(
+            client -> assertFalse(
+                client
+                    .updateStore(
+                        storeName,
+                        new UpdateStoreQueryParams().setStorageNodeReadQuotaEnabled(true)
+                            .setReadComputationEnabled(true))
+                    .isError()));
     valueSchemaId = HelixReadOnlySchemaRepository.VALUE_SCHEMA_STARTING_ID;
   }
 

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/fastclient/AvroStoreClientZstdEndToEndTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/fastclient/AvroStoreClientZstdEndToEndTest.java
@@ -4,6 +4,7 @@ import static com.linkedin.venice.fastclient.utils.ClientTestUtils.REQUEST_TYPES
 import static com.linkedin.venice.fastclient.utils.ClientTestUtils.STORE_METADATA_FETCH_MODES;
 import static com.linkedin.venice.utils.ByteUtils.BYTES_PER_KB;
 import static com.linkedin.venice.utils.ByteUtils.BYTES_PER_MB;
+import static org.testng.Assert.assertFalse;
 
 import com.github.luben.zstd.ZstdDictTrainer;
 import com.linkedin.venice.compression.CompressionStrategy;
@@ -91,7 +92,15 @@ public class AvroStoreClientZstdEndToEndTest extends AvroStoreClientEndToEndTest
           byte[] compressionDictionaryBytes = trainer.trainSamples();
           return ByteBuffer.wrap(compressionDictionaryBytes);
         });
-    veniceCluster.updateStore(storeName, new UpdateStoreQueryParams().setReadComputationEnabled(true));
+    veniceCluster
+        .useControllerClient(
+            client -> assertFalse(
+                client
+                    .updateStore(
+                        storeName,
+                        new UpdateStoreQueryParams().setStorageNodeReadQuotaEnabled(true)
+                            .setReadComputationEnabled(true))
+                    .isError()));
     valueSchemaId = HelixReadOnlySchemaRepository.VALUE_SCHEMA_STARTING_ID;
   }
 }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/fastclient/BatchGetAvroStoreClientGzipTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/fastclient/BatchGetAvroStoreClientGzipTest.java
@@ -1,6 +1,9 @@
 package com.linkedin.venice.fastclient;
 
+import static org.testng.Assert.assertFalse;
+
 import com.linkedin.venice.compression.CompressionStrategy;
+import com.linkedin.venice.controllerapi.UpdateStoreQueryParams;
 import com.linkedin.venice.helix.HelixReadOnlySchemaRepository;
 import com.linkedin.venice.serialization.avro.VeniceAvroKafkaSerializer;
 import java.util.AbstractMap;
@@ -32,6 +35,15 @@ public class BatchGetAvroStoreClientGzipTest extends BatchGetAvroStoreClientTest
           storeVersionName = topic;
           return null;
         });
+    veniceCluster
+        .useControllerClient(
+            client -> assertFalse(
+                client
+                    .updateStore(
+                        storeName,
+                        new UpdateStoreQueryParams().setStorageNodeReadQuotaEnabled(true)
+                            .setReadComputationEnabled(true))
+                    .isError()));
     valueSchemaId = HelixReadOnlySchemaRepository.VALUE_SCHEMA_STARTING_ID;
   }
 

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/fastclient/BatchGetAvroStoreClientZstdTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/fastclient/BatchGetAvroStoreClientZstdTest.java
@@ -2,9 +2,11 @@ package com.linkedin.venice.fastclient;
 
 import static com.linkedin.venice.utils.ByteUtils.BYTES_PER_KB;
 import static com.linkedin.venice.utils.ByteUtils.BYTES_PER_MB;
+import static org.testng.Assert.assertFalse;
 
 import com.github.luben.zstd.ZstdDictTrainer;
 import com.linkedin.venice.compression.CompressionStrategy;
+import com.linkedin.venice.controllerapi.UpdateStoreQueryParams;
 import com.linkedin.venice.helix.HelixReadOnlySchemaRepository;
 import com.linkedin.venice.serialization.avro.VeniceAvroKafkaSerializer;
 import java.nio.ByteBuffer;
@@ -48,6 +50,15 @@ public class BatchGetAvroStoreClientZstdTest extends BatchGetAvroStoreClientTest
           byte[] compressionDictionaryBytes = trainer.trainSamples();
           return ByteBuffer.wrap(compressionDictionaryBytes);
         });
+    veniceCluster
+        .useControllerClient(
+            client -> assertFalse(
+                client
+                    .updateStore(
+                        storeName,
+                        new UpdateStoreQueryParams().setStorageNodeReadQuotaEnabled(true)
+                            .setReadComputationEnabled(true))
+                    .isError()));
     valueSchemaId = HelixReadOnlySchemaRepository.VALUE_SCHEMA_STARTING_ID;
   }
 }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/fastclient/meta/RequestBasedMetadataIntegrationTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/fastclient/meta/RequestBasedMetadataIntegrationTest.java
@@ -9,6 +9,7 @@ import com.linkedin.venice.D2.D2ClientUtils;
 import com.linkedin.venice.client.store.transport.D2TransportClient;
 import com.linkedin.venice.compression.CompressionStrategy;
 import com.linkedin.venice.compression.VeniceCompressor;
+import com.linkedin.venice.controllerapi.UpdateStoreQueryParams;
 import com.linkedin.venice.fastclient.ClientConfig;
 import com.linkedin.venice.fastclient.stats.ClusterStats;
 import com.linkedin.venice.fastclient.utils.ClientTestUtils;
@@ -64,7 +65,10 @@ public class RequestBasedMetadataIntegrationTest {
     r2Client = ClientTestUtils.getR2Client();
     d2Client = D2TestUtils.getAndStartHttpsD2Client(veniceCluster.getZk().getAddress());
     storeName = veniceCluster.createStore(KEY_COUNT);
-
+    veniceCluster.useControllerClient(
+        client -> assertFalse(
+            client.updateStore(storeName, new UpdateStoreQueryParams().setStorageNodeReadQuotaEnabled(true))
+                .isError()));
     keySerializer =
         SerializerDeserializerFactory.getAvroGenericSerializer(Schema.parse(VeniceClusterWrapper.DEFAULT_KEY_SCHEMA));
 
@@ -127,6 +131,10 @@ public class RequestBasedMetadataIntegrationTest {
   @Test(timeOut = TIME_OUT)
   public void testMetadataZstdDictionaryFetch() {
     String zstdStoreName = veniceCluster.createStoreWithZstdDictionary(KEY_COUNT);
+    veniceCluster.useControllerClient(
+        client -> assertFalse(
+            client.updateStore(zstdStoreName, new UpdateStoreQueryParams().setStorageNodeReadQuotaEnabled(true))
+                .isError()));
 
     ClientConfig.ClientConfigBuilder clientConfigBuilder = new ClientConfig.ClientConfigBuilder();
     clientConfigBuilder.setStoreName(zstdStoreName);

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/fastclient/utils/AbstractClientEndToEndSetup.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/fastclient/utils/AbstractClientEndToEndSetup.java
@@ -235,10 +235,15 @@ public abstract class AbstractClientEndToEndSetup {
     VersionCreationResponse creationResponse = veniceCluster.getNewStoreVersion(KEY_SCHEMA_STR, VALUE_SCHEMA_STR);
     storeVersionName = creationResponse.getKafkaTopic();
     storeName = Version.parseStoreFromKafkaTopicName(storeVersionName);
-    veniceCluster.useControllerClient(
-        client -> client.updateStore(
-            storeName,
-            new UpdateStoreQueryParams().setStorageNodeReadQuotaEnabled(true).setReadComputationEnabled(true)));
+    veniceCluster
+        .useControllerClient(
+            client -> assertFalse(
+                client
+                    .updateStore(
+                        storeName,
+                        new UpdateStoreQueryParams().setStorageNodeReadQuotaEnabled(true)
+                            .setReadComputationEnabled(true))
+                    .isError()));
     valueSchemaId = HelixReadOnlySchemaRepository.VALUE_SCHEMA_STARTING_ID;
 
     // TODO: Make serializers parameterized so we test them all.

--- a/services/venice-server/src/main/java/com/linkedin/venice/listener/ServerReadMetadataRepository.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/listener/ServerReadMetadataRepository.java
@@ -66,6 +66,11 @@ public class ServerReadMetadataRepository implements ReadMetadataRetriever {
     MetadataResponse response = new MetadataResponse();
     try {
       Store store = storeRepository.getStoreOrThrow(storeName);
+      if (!store.isStorageNodeReadQuotaEnabled()) {
+        throw new UnsupportedOperationException(
+            String
+                .format("Fast client is not enabled for store: %s, please contact Venice team for support", storeName));
+      }
       // Version metadata
       int currentVersionNumber = store.getCurrentVersion();
       if (currentVersionNumber == Store.NON_EXISTING_VERSION) {

--- a/services/venice-server/src/main/java/com/linkedin/venice/listener/ServerReadMetadataRepository.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/listener/ServerReadMetadataRepository.java
@@ -68,8 +68,9 @@ public class ServerReadMetadataRepository implements ReadMetadataRetriever {
       Store store = storeRepository.getStoreOrThrow(storeName);
       if (!store.isStorageNodeReadQuotaEnabled()) {
         throw new UnsupportedOperationException(
-            String
-                .format("Fast client is not enabled for store: %s, please contact Venice team for support", storeName));
+            String.format(
+                "Fast client is not enabled for store: %s, please ensure storage node read quota is enabled for the given store",
+                storeName));
       }
       // Version metadata
       int currentVersionNumber = store.getCurrentVersion();

--- a/services/venice-server/src/main/java/com/linkedin/venice/listener/StorageReadRequestHandler.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/listener/StorageReadRequestHandler.java
@@ -370,8 +370,15 @@ public class StorageReadRequestHandler extends ChannelInboundHandlerAdapter {
       AdminResponse response = handleServerAdminRequest((AdminRequest) message);
       context.writeAndFlush(response);
     } else if (message instanceof MetadataFetchRequest) {
-      MetadataResponse response = handleMetadataFetchRequest((MetadataFetchRequest) message);
-      context.writeAndFlush(response);
+      try {
+        MetadataResponse response = handleMetadataFetchRequest((MetadataFetchRequest) message);
+        context.writeAndFlush(response);
+      } catch (UnsupportedOperationException e) {
+        LOGGER.warn(
+            "Metadata requested by a storage node read quota not enabled store: {}",
+            ((MetadataFetchRequest) message).getStoreName());
+        context.writeAndFlush(new HttpShortcutResponse(e.getMessage(), HttpResponseStatus.FORBIDDEN));
+      }
     } else if (message instanceof CurrentVersionRequest) {
       ServerCurrentVersionResponse response = handleCurrentVersionRequest((CurrentVersionRequest) message);
       context.writeAndFlush(response);

--- a/services/venice-server/src/test/java/com/linkedin/venice/listener/ServerReadMetadataRepositoryTest.java
+++ b/services/venice-server/src/test/java/com/linkedin/venice/listener/ServerReadMetadataRepositoryTest.java
@@ -69,6 +69,7 @@ public class ServerReadMetadataRepositoryTest {
     mockStore.addVersion(new VersionImpl(storeName, 1, "test-job-id"));
     mockStore.addVersion(new VersionImpl(storeName, 2, "test-job-id2"));
     mockStore.setCurrentVersion(2);
+    mockStore.setStorageNodeReadQuotaEnabled(false);
     String topicName = Version.composeKafkaTopic(storeName, 2);
     PartitionAssignment partitionAssignment = new PartitionAssignment(topicName, 1);
     Partition partition = mock(Partition.class);
@@ -85,6 +86,8 @@ public class ServerReadMetadataRepositoryTest {
     Mockito.when(mockCustomizedViewRepository.getPartitionAssignments(topicName)).thenReturn(partitionAssignment);
     Mockito.when(mockHelixInstanceConfigRepository.getInstanceGroupIdMapping()).thenReturn(Collections.emptyMap());
 
+    Assert.assertThrows(UnsupportedOperationException.class, () -> serverReadMetadataRepository.getMetadata(storeName));
+    mockStore.setStorageNodeReadQuotaEnabled(true);
     MetadataResponse metadataResponse = serverReadMetadataRepository.getMetadata(storeName);
     Assert.assertNotNull(metadataResponse);
     Assert.assertEquals(metadataResponse.getResponseRecord().getKeySchema().get("0"), "\"string\"");


### PR DESCRIPTION
## [fast-client][server] Throw 403 for metadata request that does not have storage read quota enabled
1. The idea is to block new fast-client traffic that do not have storage node read quota enabled. New client version will fail fast and have a clear error message to direct the user on what's missing. Old client versions will keep failing the metadata request and the user will also see the error message once dig deeper into the error trace.

## How was this PR tested?
Unit test and integration test

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.