### PR TITLE
[changelog] Multiple fixes to changelog consumer logic

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/InternalLocalBootstrappingVeniceChangelogConsumer.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/InternalLocalBootstrappingVeniceChangelogConsumer.java
@@ -56,6 +56,7 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.apache.commons.lang.StringUtils;
@@ -307,6 +308,17 @@ class InternalLocalBootstrappingVeniceChangelogConsumer<K, V> extends VeniceAfte
         0,
         value.length * 8,
         false);
+    /*
+    if (partition == 459) {
+      LOGGER.info(
+          "DEBUG Partition: 459 bootstrap. key={}, value={}, offset={} schema={}",
+          keyDeserializer.deserialize(key),
+          changeEvent.getCurrentValue(),
+          record.getOffset().getPosition(),
+          valueRecord.getSchemaId());
+    }
+    
+     */
     resultSet.add(record);
   }
 
@@ -354,9 +366,11 @@ class InternalLocalBootstrappingVeniceChangelogConsumer<K, V> extends VeniceAfte
       if (currentPartitionState.bootstrapState.equals(PollState.CATCHING_UP)) {
         if (currentPartitionState.isCaughtUp()) {
           LOGGER.info(
-              "pollAndCatchup completed for partition: {} with offset: {}",
+              "pollAndCatchup completed for partition: {} with offset: {}, put message: {}, delete message: {}",
               record.getPartition(),
-              getOffset(record.getOffset()));
+              getOffset(record.getOffset()),
+              partitionToPutMessageCount.getOrDefault(record.getPartition(), new AtomicLong(0)).get(),
+              partitionToDeleteMessageCount.getOrDefault(record.getPartition(), new AtomicLong(0)).get());
           currentPartitionState.bootstrapState = PollState.BOOTSTRAPPING;
         }
       }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/InternalLocalBootstrappingVeniceChangelogConsumer.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/InternalLocalBootstrappingVeniceChangelogConsumer.java
@@ -308,17 +308,6 @@ class InternalLocalBootstrappingVeniceChangelogConsumer<K, V> extends VeniceAfte
         0,
         value.length * 8,
         false);
-    /*
-    if (partition == 459) {
-      LOGGER.info(
-          "DEBUG Partition: 459 bootstrap. key={}, value={}, offset={} schema={}",
-          keyDeserializer.deserialize(key),
-          changeEvent.getCurrentValue(),
-          record.getOffset().getPosition(),
-          valueRecord.getSchemaId());
-    }
-    
-     */
     resultSet.add(record);
   }
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/ReplicationMetadataSchemaRepository.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/ReplicationMetadataSchemaRepository.java
@@ -2,8 +2,8 @@ package com.linkedin.davinci.consumer;
 
 import com.linkedin.venice.controllerapi.ControllerClient;
 import com.linkedin.venice.controllerapi.MultiSchemaResponse;
-import com.linkedin.venice.controllerapi.MultiSchemaResponse.Schema;
 import com.linkedin.venice.exceptions.VeniceException;
+import com.linkedin.venice.schema.rmd.RmdSchemaEntry;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -11,15 +11,15 @@ import java.util.stream.Collectors;
 
 
 public class ReplicationMetadataSchemaRepository {
-  private ControllerClient controllerClient;
+  private final ControllerClient controllerClient;
 
-  private List<Schema> cachedReplicationMetadataSchemas = new ArrayList<>();
+  private List<RmdSchemaEntry> cachedReplicationMetadataSchemas = new ArrayList<>();
 
   public ReplicationMetadataSchemaRepository(ControllerClient controllerClient) {
     this.controllerClient = controllerClient;
   }
 
-  public Schema getReplicationMetadataSchemaById(String storeName, int replicationMetadataSchemaId) {
+  public RmdSchemaEntry getReplicationMetadataSchemaById(String storeName, int replicationMetadataSchemaId) {
     if (cachedReplicationMetadataSchemas.size() < replicationMetadataSchemaId) {
       MultiSchemaResponse multiReplicationSchemaResponse = controllerClient.getAllReplicationMetadataSchemas(storeName);
       if (multiReplicationSchemaResponse.isError()) {
@@ -27,8 +27,9 @@ public class ReplicationMetadataSchemaRepository {
             "Failed to get store replication info for store: " + storeName + " with error: "
                 + multiReplicationSchemaResponse.getError());
       }
-      cachedReplicationMetadataSchemas =
-          Arrays.stream(multiReplicationSchemaResponse.getSchemas()).collect(Collectors.toList());
+      cachedReplicationMetadataSchemas = Arrays.stream(multiReplicationSchemaResponse.getSchemas())
+          .map(schema -> new RmdSchemaEntry(schema.getRmdValueSchemaId(), schema.getId(), schema.getSchemaStr()))
+          .collect(Collectors.toList());
       if (cachedReplicationMetadataSchemas.size() < replicationMetadataSchemaId) {
         throw new VeniceException("No available store replication metadata schema for store: " + storeName);
       }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/RmdDeserializerCache.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/RmdDeserializerCache.java
@@ -1,0 +1,47 @@
+package com.linkedin.davinci.consumer;
+
+import com.linkedin.venice.serialization.StoreDeserializerCache;
+import com.linkedin.venice.serializer.FastSerializerDeserializerFactory;
+import com.linkedin.venice.serializer.RecordDeserializer;
+import com.linkedin.venice.serializer.SerializerDeserializerFactory;
+import com.linkedin.venice.utils.collections.BiIntKeyCache;
+import java.util.function.BiFunction;
+import java.util.function.IntFunction;
+import org.apache.avro.Schema;
+
+
+/**
+ * Container for the deserializers of a single store.
+ */
+public class RmdDeserializerCache<T> implements StoreDeserializerCache<T> {
+  private final BiIntKeyCache<RecordDeserializer<T>> cache;
+
+  public RmdDeserializerCache(
+      ReplicationMetadataSchemaRepository rmdSchemaRepo,
+      String storeName,
+      int protocolId,
+      boolean fastAvroEnabled) {
+    this(
+        (valueSchemaId) -> rmdSchemaRepo.getReplicationMetadataSchemaById(storeName, valueSchemaId).getSchema(),
+        fastAvroEnabled
+            ? FastSerializerDeserializerFactory::getFastAvroGenericDeserializer
+            : SerializerDeserializerFactory::getAvroGenericDeserializer);
+  }
+
+  private RmdDeserializerCache(
+      IntFunction<Schema> schemaGetter,
+      BiFunction<Schema, Schema, RecordDeserializer<T>> deserializerGetter) {
+    this.cache = new BiIntKeyCache<>(
+        (writerId, readerId) -> deserializerGetter.apply(schemaGetter.apply(writerId), schemaGetter.apply(readerId)));
+  }
+
+  public RecordDeserializer<T> getDeserializer(int writerSchemaId, int readerSchemaId) {
+    return this.cache.get(writerSchemaId, readerSchemaId);
+  }
+
+  @Override
+  public RecordDeserializer<T> getDeserializer(int writerSchemaId) {
+    throw new UnsupportedOperationException(
+        "getDeserializer by only writeSchemaId is not supported by " + this.getClass().getSimpleName());
+  }
+}

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangeCoordinate.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangeCoordinate.java
@@ -73,7 +73,7 @@ public class VeniceChangeCoordinate implements Externalizable {
     return topic;
   }
 
-  public PubSubPosition getPosition() {
+  protected PubSubPosition getPosition() {
     return pubSubPosition;
   }
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangeCoordinate.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangeCoordinate.java
@@ -73,7 +73,7 @@ public class VeniceChangeCoordinate implements Externalizable {
     return topic;
   }
 
-  protected PubSubPosition getPosition() {
+  public PubSubPosition getPosition() {
     return pubSubPosition;
   }
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImpl.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImpl.java
@@ -16,7 +16,6 @@ import com.linkedin.venice.compression.CompressorFactory;
 import com.linkedin.venice.compression.NoopCompressor;
 import com.linkedin.venice.compression.VeniceCompressor;
 import com.linkedin.venice.controllerapi.D2ControllerClient;
-import com.linkedin.venice.controllerapi.MultiSchemaResponse;
 import com.linkedin.venice.controllerapi.StoreResponse;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.kafka.protocol.ControlMessage;
@@ -39,6 +38,7 @@ import com.linkedin.venice.pubsub.api.PubSubMessage;
 import com.linkedin.venice.pubsub.api.PubSubTopic;
 import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
 import com.linkedin.venice.schema.SchemaReader;
+import com.linkedin.venice.schema.rmd.RmdSchemaEntry;
 import com.linkedin.venice.schema.rmd.RmdUtils;
 import com.linkedin.venice.serialization.AvroStoreDeserializerCache;
 import com.linkedin.venice.serialization.StoreDeserializerCache;
@@ -46,9 +46,9 @@ import com.linkedin.venice.serialization.avro.AvroProtocolDefinition;
 import com.linkedin.venice.serialization.avro.AvroSpecificStoreDeserializerCache;
 import com.linkedin.venice.serializer.FastSerializerDeserializerFactory;
 import com.linkedin.venice.serializer.RecordDeserializer;
-import com.linkedin.venice.serializer.SerializerDeserializerFactory;
 import com.linkedin.venice.utils.DictionaryUtils;
 import com.linkedin.venice.utils.VeniceProperties;
+import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
 import com.linkedin.venice.utils.lazy.Lazy;
 import com.linkedin.venice.views.ChangeCaptureView;
 import java.io.IOException;
@@ -66,6 +66,7 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
@@ -84,6 +85,8 @@ public class VeniceChangelogConsumerImpl<K, V> implements VeniceChangelogConsume
 
   protected final HashMap<Integer, VeniceCompressor> compressorMap = new HashMap<>();
   protected StoreDeserializerCache<V> storeDeserializerCache;
+  protected StoreDeserializerCache<GenericRecord> rmdDeserializerCache;
+  protected Class specificValueClass;
 
   protected ThinClientMetaStoreBasedRepository storeRepository;
 
@@ -92,6 +95,9 @@ public class VeniceChangelogConsumerImpl<K, V> implements VeniceChangelogConsume
   protected final SchemaReader schemaReader;
   private final String viewClassName;
   protected final PubSubTopicRepository pubSubTopicRepository = new PubSubTopicRepository();
+
+  protected final Map<Integer, AtomicLong> partitionToPutMessageCount = new VeniceConcurrentHashMap<>();
+  protected final Map<Integer, AtomicLong> partitionToDeleteMessageCount = new VeniceConcurrentHashMap<>();
 
   protected final RecordDeserializer<K> keyDeserializer;
   private final D2ControllerClient d2ControllerClient;
@@ -149,15 +155,20 @@ public class VeniceChangelogConsumerImpl<K, V> implements VeniceChangelogConsume
         changelogClientConfig.getInnerClientConfig(),
         VeniceProperties.empty(),
         null);
-
+    this.rmdDeserializerCache = new RmdDeserializerCache<>(replicationMetadataSchemaRepository, storeName, 1, false);
     if (changelogClientConfig.getInnerClientConfig().isSpecificClient()) {
       // If a value class is supplied, we'll use a Specific record adapter
       Class valueClass = changelogClientConfig.getInnerClientConfig().getSpecificValueClass();
       this.userEventChunkingAdapter = new SpecificRecordChunkingAdapter();
       this.storeDeserializerCache = new AvroSpecificStoreDeserializerCache<>(storeRepository, storeName, valueClass);
+      this.specificValueClass = valueClass;
+      LOGGER.info("Using specific value deserializer: {}", valueClass.getName());
     } else {
       this.userEventChunkingAdapter = GenericChunkingAdapter.INSTANCE;
       this.storeDeserializerCache = new AvroStoreDeserializerCache<>(storeRepository, storeName, true);
+      this.specificValueClass = null;
+      LOGGER.info("Using generic value deserializer");
+
     }
 
     LOGGER.info(
@@ -354,7 +365,7 @@ public class VeniceChangelogConsumerImpl<K, V> implements VeniceChangelogConsume
     return seekToTail(
         pubSubConsumer.getAssignment()
             .stream()
-            .map(topicPartition -> topicPartition.getPartitionNumber())
+            .map(PubSubTopicPartition::getPartitionNumber)
             .collect(Collectors.toSet()));
   }
 
@@ -634,9 +645,36 @@ public class VeniceChangelogConsumerImpl<K, V> implements VeniceChangelogConsume
               message.getPayloadSize(),
               false));
 
-      replicationCheckpoint = extractOffsetVectorFromMessage(
-          delete.getReplicationMetadataVersionId(),
-          delete.getReplicationMetadataPayload());
+      try {
+        replicationCheckpoint = extractOffsetVectorFromMessage(
+            delete.getSchemaId(),
+            delete.getReplicationMetadataVersionId(),
+            delete.getReplicationMetadataPayload());
+      } catch (Exception e) {
+        LOGGER.info(
+            "Encounter RMD extraction exception for delete OP. partition={}, offset={}, key={}, rmd={}, rmd_id={}",
+            message.getPartition(),
+            message.getOffset(),
+            keyDeserializer.deserialize(keyBytes),
+            delete.getReplicationMetadataPayload(),
+            delete.getReplicationMetadataVersionId(),
+            e);
+        RmdSchemaEntry rmdSchema =
+            replicationMetadataSchemaRepository.getReplicationMetadataSchemaById(storeName, delete.getSchemaId());
+        LOGGER.info("Using: {} {} {}", rmdSchema.getId(), rmdSchema.getValueSchemaID(), rmdSchema.getSchemaStr());
+        throw e;
+      }
+      /*
+      if (message.getPartition() == 459) {
+        LOGGER.info(
+            "DEBUG Partition: 459 consume DELETE key={}, offset={}",
+            keyDeserializer.deserialize(keyBytes),
+            message.getOffset());
+      }
+      
+       */
+
+      partitionToDeleteMessageCount.computeIfAbsent(message.getPartition(), x -> new AtomicLong(0)).incrementAndGet();
     }
     if (messageType.equals(MessageType.PUT)) {
       Put put = (Put) message.getValue().payloadUnion;
@@ -645,9 +683,11 @@ public class VeniceChangelogConsumerImpl<K, V> implements VeniceChangelogConsume
       int readerSchemaId;
       if (pubSubTopicPartition.getPubSubTopic().isVersionTopic()) {
         Schema valueSchema = schemaReader.getValueSchema(put.schemaId);
-        deserializerProvider =
-            Lazy.of(() -> FastSerializerDeserializerFactory.getFastAvroGenericDeserializer(valueSchema, valueSchema));
-        readerSchemaId = AvroProtocolDefinition.RECORD_CHANGE_EVENT.getCurrentProtocolVersion();
+        // deserializerProvider = Lazy.of(() ->
+        // FastSerializerDeserializerFactory.getFastAvroGenericDeserializer(valueSchema, valueSchema));
+        deserializerProvider = Lazy.of(() -> storeDeserializerCache.getDeserializer(put.schemaId, put.schemaId));
+        // readerSchemaId = AvroProtocolDefinition.RECORD_CHANGE_EVENT.getCurrentProtocolVersion();
+        readerSchemaId = put.schemaId;
       } else {
         deserializerProvider = Lazy.of(() -> recordChangeDeserializer);
         readerSchemaId = this.schemaReader.getLatestValueSchemaId();
@@ -692,8 +732,26 @@ public class VeniceChangelogConsumerImpl<K, V> implements VeniceChangelogConsume
         recordChangeEvent = (RecordChangeEvent) assembledObject;
         replicationCheckpoint = recordChangeEvent.replicationCheckpointVector;
       } else {
-        replicationCheckpoint =
-            extractOffsetVectorFromMessage(put.getReplicationMetadataVersionId(), put.getReplicationMetadataPayload());
+        try {
+          replicationCheckpoint = extractOffsetVectorFromMessage(
+              put.getSchemaId(),
+              put.getReplicationMetadataVersionId(),
+              put.getReplicationMetadataPayload());
+        } catch (Exception e) {
+          LOGGER.info(
+              "Encounter RMD extraction exception for PUT OP. partition={}, offset={}, key={}, value={}, rmd={}, rmd_id={}",
+              message.getPartition(),
+              message.getOffset(),
+              keyDeserializer.deserialize(keyBytes),
+              assembledObject,
+              put.getReplicationMetadataPayload(),
+              put.getReplicationMetadataVersionId(),
+              e);
+          RmdSchemaEntry rmdSchema =
+              replicationMetadataSchemaRepository.getReplicationMetadataSchemaById(storeName, put.getSchemaId());
+          LOGGER.info("Using: {} {} {}", rmdSchema.getId(), rmdSchema.getValueSchemaID(), rmdSchema.getSchemaStr());
+          throw e;
+        }
       }
 
       // Now that we've assembled the object, we need to extract the replication vector depending on if it's from VT
@@ -722,6 +780,18 @@ public class VeniceChangelogConsumerImpl<K, V> implements VeniceChangelogConsume
                 payloadSize,
                 false));
       }
+      /*
+      if (message.getPartition() == 459) {
+        LOGGER.info(
+            "DEBUG Partition: 459 consume PUT key={}, value={}, offset={}, schema={}",
+            keyDeserializer.deserialize(keyBytes),
+            assembledObject,
+            message.getOffset(),
+            readerSchemaId);
+      }
+      
+       */
+      partitionToPutMessageCount.computeIfAbsent(message.getPartition(), x -> new AtomicLong(0)).incrementAndGet();
     }
 
     // Determine if the event should be filtered or not
@@ -733,14 +803,20 @@ public class VeniceChangelogConsumerImpl<K, V> implements VeniceChangelogConsume
   }
 
   protected List<Long> extractOffsetVectorFromMessage(
-      int replicationMetadataVersionId,
+      int valueSchemaId,
+      int rmdProtocolId,
       ByteBuffer replicationMetadataPayload) {
-    if (replicationMetadataVersionId > 0) {
-      MultiSchemaResponse.Schema replicationMetadataSchema =
-          replicationMetadataSchemaRepository.getReplicationMetadataSchemaById(storeName, replicationMetadataVersionId);
-      RecordDeserializer<GenericRecord> deserializer = SerializerDeserializerFactory
-          .getAvroGenericDeserializer(Schema.parse(replicationMetadataSchema.getSchemaStr()));
+    // LOGGER.info("DEBUGGING: {} {} {}", valueSchemaId, rmdProtocolId, replicationMetadataPayload.remaining());
+    if (rmdProtocolId > 0 && replicationMetadataPayload.remaining() > 0) {
+      // Schema replicationMetadataSchema =
+      // replicationMetadataSchemaRepository.getReplicationMetadataSchemaById(storeName, valueSchemaId);
+      // RecordDeserializer<GenericRecord> deserializer =
+      // SerializerDeserializerFactory.getAvroGenericDeserializer(Schema.parse(replicationMetadataSchema.getSchemaStr()));
+      RecordDeserializer<GenericRecord> deserializer =
+          rmdDeserializerCache.getDeserializer(valueSchemaId, valueSchemaId);
       GenericRecord replicationMetadataRecord = deserializer.deserialize(replicationMetadataPayload);
+      // LOGGER.info("DEBUGGING: {} {}", replicationMetadataRecord.get(REPLICATION_CHECKPOINT_VECTOR_FIELD_POS),
+      // replicationMetadataRecord.get(REPLICATION_CHECKPOINT_VECTOR_FIELD_POS) instanceof PrimitiveLongArrayList);
       GenericData.Array replicationCheckpointVector =
           (GenericData.Array) replicationMetadataRecord.get(REPLICATION_CHECKPOINT_VECTOR_FIELD_POS);
       List<Long> offsetVector = new ArrayList<>();

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/PartialUpdateTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/PartialUpdateTest.java
@@ -30,8 +30,8 @@ import static com.linkedin.venice.utils.TestWriteUtils.NAME_RECORD_V2_SCHEMA;
 import static com.linkedin.venice.utils.TestWriteUtils.STRING_SCHEMA;
 import static com.linkedin.venice.utils.TestWriteUtils.getTempDataDirectory;
 import static com.linkedin.venice.utils.TestWriteUtils.loadFileAsString;
+import static com.linkedin.venice.utils.TestWriteUtils.writeSimpleAvroFileWithStringToNameRecordV1Schema;
 import static com.linkedin.venice.utils.TestWriteUtils.writeSimpleAvroFileWithStringToPartialUpdateOpRecordSchema;
-import static com.linkedin.venice.utils.TestWriteUtils.writeSimpleAvroFileWithStringToRecordSchema;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
@@ -354,7 +354,7 @@ public class PartialUpdateTest {
     final String storeName = Utils.getUniqueString("inc_push_update_new_format");
     String parentControllerUrl = parentController.getControllerUrl();
     File inputDir = getTempDataDirectory();
-    Schema recordSchema = writeSimpleAvroFileWithStringToRecordSchema(inputDir);
+    Schema recordSchema = writeSimpleAvroFileWithStringToNameRecordV1Schema(inputDir);
     String keySchemaStr = recordSchema.getField(DEFAULT_KEY_FIELD_PROP).schema().toString();
     String inputDirPath = "file://" + inputDir.getAbsolutePath();
     Properties vpjProperties =
@@ -425,7 +425,7 @@ public class PartialUpdateTest {
     final String storeName = Utils.getUniqueString("updateBatch");
     String parentControllerUrl = parentController.getControllerUrl();
     File inputDir = getTempDataDirectory();
-    Schema recordSchema = writeSimpleAvroFileWithStringToRecordSchema(inputDir);
+    Schema recordSchema = writeSimpleAvroFileWithStringToNameRecordV1Schema(inputDir);
     String keySchemaStr = recordSchema.getField(DEFAULT_KEY_FIELD_PROP).schema().toString();
     String valueSchemaStr = recordSchema.getField(DEFAULT_VALUE_FIELD_PROP).schema().toString();
     String inputDirPath = "file://" + inputDir.getAbsolutePath();
@@ -1192,7 +1192,7 @@ public class PartialUpdateTest {
       String inputDirPath = "file://" + inputDir.getAbsolutePath();
       String parentControllerURL = parentController.getControllerUrl();
       // Records 1-100, id string to name record
-      Schema recordSchema = writeSimpleAvroFileWithStringToRecordSchema(inputDir);
+      Schema recordSchema = writeSimpleAvroFileWithStringToNameRecordV1Schema(inputDir);
       VeniceClusterWrapper veniceClusterWrapper = childDatacenters.get(0).getClusters().get(CLUSTER_NAME);
       Properties vpjProperties =
           IntegrationTestPushUtils.defaultVPJProps(multiRegionMultiClusterWrapper, inputDirPath, storeName);
@@ -1409,7 +1409,7 @@ public class PartialUpdateTest {
     File inputDir = getTempDataDirectory();
     String parentControllerURL = parentController.getControllerUrl();
     // Records 1-100, id string to name record
-    Schema recordSchema = writeSimpleAvroFileWithStringToRecordSchema(inputDir);
+    Schema recordSchema = writeSimpleAvroFileWithStringToNameRecordV1Schema(inputDir);
     VeniceClusterWrapper veniceClusterWrapper = childDatacenters.get(0).getClusters().get(CLUSTER_NAME);
     try (ControllerClient controllerClient = new ControllerClient(CLUSTER_NAME, parentControllerURL)) {
 

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestChangelogConsumer.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestChangelogConsumer.java
@@ -779,19 +779,6 @@ public class TestChangelogConsumer {
     polledMessageList.addAll(pubSubMessages);
   }
 
-  private void pollChangeEventsFromSpecificChangeCaptureConsumerV2(
-      Map<TestChangelogValue, PubSubMessage<TestChangelogValue, ChangeEvent<TestChangelogValue>, VeniceChangeCoordinate>> polledChangeEvents,
-      List<PubSubMessage<TestChangelogValue, ChangeEvent<TestChangelogValue>, VeniceChangeCoordinate>> polledMessageList,
-      BootstrappingVeniceChangelogConsumer veniceChangelogConsumer) {
-    Collection<PubSubMessage<TestChangelogValue, ChangeEvent<TestChangelogValue>, VeniceChangeCoordinate>> pubSubMessages =
-        veniceChangelogConsumer.poll(1000);
-    for (PubSubMessage<TestChangelogValue, ChangeEvent<TestChangelogValue>, VeniceChangeCoordinate> pubSubMessage: pubSubMessages) {
-      TestChangelogValue key = pubSubMessage.getKey() == null ? null : pubSubMessage.getKey();
-      polledChangeEvents.put(key, pubSubMessage);
-    }
-    polledMessageList.addAll(pubSubMessages);
-  }
-
   private void pollChangeEventsFromChangeCaptureConsumer2(
       Map<String, PubSubMessage<Utf8, ChangeEvent<Utf8>, VeniceChangeCoordinate>> polledChangeEvents,
       VeniceChangelogConsumer veniceChangelogConsumer) {

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestChangelogConsumer.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestChangelogConsumer.java
@@ -20,6 +20,7 @@ import static com.linkedin.venice.utils.IntegrationTestPushUtils.getSamzaProduce
 import static com.linkedin.venice.utils.IntegrationTestPushUtils.sendStreamingDeleteRecord;
 import static com.linkedin.venice.utils.IntegrationTestPushUtils.sendStreamingRecord;
 import static com.linkedin.venice.utils.IntegrationTestPushUtils.sendStreamingRecordWithLogicalTimestamp;
+import static com.linkedin.venice.utils.TestWriteUtils.NAME_RECORD_V1_SCHEMA;
 import static com.linkedin.venice.utils.TestWriteUtils.getTempDataDirectory;
 
 import com.linkedin.davinci.consumer.BootstrappingVeniceChangelogConsumer;
@@ -77,6 +78,9 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.specific.SpecificRecord;
 import org.apache.avro.util.Utf8;
 import org.apache.samza.config.MapConfig;
 import org.testng.Assert;
@@ -648,14 +652,14 @@ public class TestChangelogConsumer {
       consumerProperties.put(KAFKA_BOOTSTRAP_SERVERS, localKafkaUrl);
       consumerProperties.put(CLUSTER_NAME, clusterName);
       consumerProperties.put(ZOOKEEPER_ADDRESS, localZkServer.getAddress());
-      ChangelogClientConfig globalChangelogClientConfig = new ChangelogClientConfig()// .setViewName("changeCaptureView")
-          .setConsumerProperties(consumerProperties)
-          .setControllerD2ServiceName(D2_SERVICE_NAME)
-          .setD2ServiceName(VeniceRouterWrapper.CLUSTER_DISCOVERY_D2_SERVICE_NAME)
-          .setLocalD2ZkHosts(localZkServer.getAddress())
-          .setControllerRequestRetryCount(3)
-          .setSpecificValue(TestChangelogValue.class)
-          .setBootstrapFileSystemPath(Utils.getUniqueString(inputDirPath));
+      ChangelogClientConfig globalChangelogClientConfig =
+          new ChangelogClientConfig().setConsumerProperties(consumerProperties)
+              .setControllerD2ServiceName(D2_SERVICE_NAME)
+              .setD2ServiceName(VeniceRouterWrapper.CLUSTER_DISCOVERY_D2_SERVICE_NAME)
+              .setLocalD2ZkHosts(localZkServer.getAddress())
+              .setControllerRequestRetryCount(3)
+              .setSpecificValue(TestChangelogValue.class)
+              .setBootstrapFileSystemPath(Utils.getUniqueString(inputDirPath));
       VeniceChangelogConsumerClientFactory veniceChangelogConsumerClientFactory =
           new VeniceChangelogConsumerClientFactory(globalChangelogClientConfig, metricsRepository);
       BootstrappingVeniceChangelogConsumer<Utf8, TestChangelogValue> specificChangelogConsumer =
@@ -674,6 +678,125 @@ public class TestChangelogConsumer {
             specificChangelogConsumer);
         Assert.assertEquals(polledChangeEventsList.size(), 101);
       });
+      Assert.assertTrue(
+          polledChangeEventsMap.get(Integer.toString(1)).getValue().getCurrentValue() instanceof SpecificRecord);
+      TestChangelogValue value = new TestChangelogValue();
+      value.firstName = "first_name_1";
+      value.lastName = "last_name_1";
+      Assert.assertEquals(polledChangeEventsMap.get(Integer.toString(1)).getValue().getCurrentValue(), value);
+      polledChangeEventsList.clear();
+      polledChangeEventsMap.clear();
+
+      GenericRecord genericRecord = new GenericData.Record(NAME_RECORD_V1_SCHEMA);
+      genericRecord.put("firstName", "Jialin");
+      genericRecord.put("lastName", "Liu");
+
+      GenericRecord genericRecordV2 = new GenericData.Record(NAME_RECORD_V1_SCHEMA);
+      genericRecordV2.put("firstName", "Jason");
+      genericRecordV2.put("lastName", "Liu");
+
+      VeniceSystemFactory factory = new VeniceSystemFactory();
+      try (VeniceSystemProducer veniceProducer = factory
+          .getClosableProducer("venice", new MapConfig(getSamzaProducerConfig(childDatacenters, 0, storeName)), null)) {
+        veniceProducer.start();
+        // Run Samza job to send PUT and DELETE requests.
+        sendStreamingRecord(veniceProducer, storeName, Integer.toString(10000), genericRecord, null);
+        sendStreamingRecord(veniceProducer, storeName, Integer.toString(10000), genericRecordV2, null);
+        // runSamzaStreamJob(veniceProducer, storeName, null, 1, 0, 10000);
+      }
+
+      TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, true, () -> {
+        pollChangeEventsFromSpecificChangeCaptureConsumer(
+            polledChangeEventsMap,
+            polledChangeEventsList,
+            specificChangelogConsumer);
+        Assert.assertEquals(polledChangeEventsList.size(), 2);
+      });
+      Assert.assertTrue(
+          polledChangeEventsMap.get(Integer.toString(10000)).getValue().getCurrentValue() instanceof SpecificRecord);
+
+      parentControllerClient.disableAndDeleteStore(storeName);
+      // Verify that topics and store is cleaned up
+      TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, true, () -> {
+        MultiStoreTopicsResponse storeTopicsResponse = childControllerClient.getDeletableStoreTopics();
+        Assert.assertFalse(storeTopicsResponse.isError());
+        Assert.assertEquals(storeTopicsResponse.getTopics().size(), 0);
+      });
+    }
+  }
+
+  @Test(timeOut = TEST_TIMEOUT, priority = 3)
+  public void testSpecificRecordVeniceChangelogConsumerWithRecordKey() throws Exception {
+    ControllerClient childControllerClient =
+        new ControllerClient(clusterName, childDatacenters.get(0).getControllerConnectString());
+    File inputDir = getTempDataDirectory();
+    Schema recordSchema = TestWriteUtils.writeSimpleAvroFileWithRecordToRecordSchema(inputDir);
+    String inputDirPath = "file://" + inputDir.getAbsolutePath();
+    String storeName = Utils.getUniqueString("store");
+    Properties props =
+        TestWriteUtils.defaultVPJProps(parentControllers.get(0).getControllerUrl(), inputDirPath, storeName);
+    String keySchemaStr = recordSchema.getField(DEFAULT_KEY_FIELD_PROP).schema().toString();
+    String valueSchemaStr = recordSchema.getField(DEFAULT_VALUE_FIELD_PROP).schema().toString();
+    UpdateStoreQueryParams storeParms = new UpdateStoreQueryParams().setActiveActiveReplicationEnabled(true)
+        .setHybridRewindSeconds(500)
+        .setHybridOffsetLagThreshold(8)
+        .setChunkingEnabled(true)
+        .setNativeReplicationEnabled(true)
+        .setPartitionCount(3);
+    MetricsRepository metricsRepository = new MetricsRepository();
+    ControllerClient setupControllerClient =
+        createStoreForJob(clusterName, keySchemaStr, valueSchemaStr, props, storeParms);
+    setupControllerClient
+        .retryableRequest(5, controllerClient1 -> setupControllerClient.updateStore(storeName, storeParms));
+    TestWriteUtils.runPushJob("Run push job", props);
+
+    TestMockTime testMockTime = new TestMockTime();
+    ZkServerWrapper localZkServer = multiRegionMultiClusterWrapper.getChildRegions().get(0).getZkServerWrapper();
+    try (PubSubBrokerWrapper localKafka = ServiceFactory.getPubSubBroker(
+        new PubSubBrokerConfigs.Builder().setZkWrapper(localZkServer)
+            .setMockTime(testMockTime)
+            .setRegionName("local-pubsub")
+            .build())) {
+      Properties consumerProperties = new Properties();
+      String localKafkaUrl = localKafka.getAddress();
+      consumerProperties.put(KAFKA_BOOTSTRAP_SERVERS, localKafkaUrl);
+      consumerProperties.put(CLUSTER_NAME, clusterName);
+      consumerProperties.put(ZOOKEEPER_ADDRESS, localZkServer.getAddress());
+      ChangelogClientConfig globalChangelogClientConfig = new ChangelogClientConfig()// .setViewName("changeCaptureView")
+          .setConsumerProperties(consumerProperties)
+          .setControllerD2ServiceName(D2_SERVICE_NAME)
+          .setD2ServiceName(VeniceRouterWrapper.CLUSTER_DISCOVERY_D2_SERVICE_NAME)
+          .setLocalD2ZkHosts(localZkServer.getAddress())
+          .setControllerRequestRetryCount(3)
+          .setSpecificValue(TestChangelogValue.class)
+          .setBootstrapFileSystemPath(Utils.getUniqueString(inputDirPath));
+      VeniceChangelogConsumerClientFactory veniceChangelogConsumerClientFactory =
+          new VeniceChangelogConsumerClientFactory(globalChangelogClientConfig, metricsRepository);
+      BootstrappingVeniceChangelogConsumer<TestChangelogValue, TestChangelogValue> specificChangelogConsumer =
+          veniceChangelogConsumerClientFactory
+              .getBootstrappingChangelogConsumer(storeName, "0", TestChangelogValue.class);
+      specificChangelogConsumer.start().get();
+
+      Map<TestChangelogValue, PubSubMessage<TestChangelogValue, ChangeEvent<TestChangelogValue>, VeniceChangeCoordinate>> polledChangeEventsMap =
+          new HashMap<>();
+      List<PubSubMessage<TestChangelogValue, ChangeEvent<TestChangelogValue>, VeniceChangeCoordinate>> polledChangeEventsList =
+          new ArrayList<>();
+      TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, true, () -> {
+        pollChangeEventsFromSpecificChangeCaptureConsumerV2(
+            polledChangeEventsMap,
+            polledChangeEventsList,
+            specificChangelogConsumer);
+        Assert.assertEquals(polledChangeEventsList.size(), 101);
+      });
+      TestChangelogValue key = new TestChangelogValue();
+      key.firstName = "first_name_1";
+      key.lastName = "last_name_1";
+
+      Assert.assertTrue(polledChangeEventsMap.get(key).getValue().getCurrentValue() instanceof SpecificRecord);
+      TestChangelogValue value = new TestChangelogValue();
+      value.firstName = "first_name_1";
+      value.lastName = "last_name_1";
+      Assert.assertEquals(polledChangeEventsMap.get(key).getValue().getCurrentValue(), value);
       polledChangeEventsList.clear();
       polledChangeEventsMap.clear();
 
@@ -732,6 +855,19 @@ public class TestChangelogConsumer {
         veniceChangelogConsumer.poll(1000);
     for (PubSubMessage<Utf8, ChangeEvent<TestChangelogValue>, VeniceChangeCoordinate> pubSubMessage: pubSubMessages) {
       String key = pubSubMessage.getKey() == null ? null : pubSubMessage.getKey().toString();
+      polledChangeEvents.put(key, pubSubMessage);
+    }
+    polledMessageList.addAll(pubSubMessages);
+  }
+
+  private void pollChangeEventsFromSpecificChangeCaptureConsumerV2(
+      Map<TestChangelogValue, PubSubMessage<TestChangelogValue, ChangeEvent<TestChangelogValue>, VeniceChangeCoordinate>> polledChangeEvents,
+      List<PubSubMessage<TestChangelogValue, ChangeEvent<TestChangelogValue>, VeniceChangeCoordinate>> polledMessageList,
+      BootstrappingVeniceChangelogConsumer veniceChangelogConsumer) {
+    Collection<PubSubMessage<TestChangelogValue, ChangeEvent<TestChangelogValue>, VeniceChangeCoordinate>> pubSubMessages =
+        veniceChangelogConsumer.poll(1000);
+    for (PubSubMessage<TestChangelogValue, ChangeEvent<TestChangelogValue>, VeniceChangeCoordinate> pubSubMessage: pubSubMessages) {
+      TestChangelogValue key = pubSubMessage.getKey() == null ? null : pubSubMessage.getKey();
       polledChangeEvents.put(key, pubSubMessage);
     }
     polledMessageList.addAll(pubSubMessages);

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/ingestionHeartbeat/IngestionHeartBeatTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/ingestionHeartbeat/IngestionHeartBeatTest.java
@@ -9,7 +9,7 @@ import static com.linkedin.venice.pubsub.api.PubSubMessageHeaders.VENICE_LEADER_
 import static com.linkedin.venice.utils.TestUtils.assertCommand;
 import static com.linkedin.venice.utils.TestWriteUtils.NAME_RECORD_V1_SCHEMA;
 import static com.linkedin.venice.utils.TestWriteUtils.getTempDataDirectory;
-import static com.linkedin.venice.utils.TestWriteUtils.writeSimpleAvroFileWithStringToRecordSchema;
+import static com.linkedin.venice.utils.TestWriteUtils.writeSimpleAvroFileWithStringToNameRecordV1Schema;
 import static com.linkedin.venice.writer.LeaderCompleteState.LEADER_COMPLETED;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
@@ -141,7 +141,7 @@ public class IngestionHeartBeatTest {
     storeName = Utils.getUniqueString("ingestionHeartBeatTest");
     String parentControllerUrl = parentController.getControllerUrl();
     File inputDir = getTempDataDirectory();
-    Schema recordSchema = writeSimpleAvroFileWithStringToRecordSchema(inputDir);
+    Schema recordSchema = writeSimpleAvroFileWithStringToNameRecordV1Schema(inputDir);
     String keySchemaStr = recordSchema.getField(DEFAULT_KEY_FIELD_PROP).schema().toString();
     String inputDirPath = "file://" + inputDir.getAbsolutePath();
     Properties vpjProperties =

--- a/internal/venice-test-common/src/main/java/com/linkedin/venice/utils/TestWriteUtils.java
+++ b/internal/venice-test-common/src/main/java/com/linkedin/venice/utils/TestWriteUtils.java
@@ -111,6 +111,8 @@ public class TestWriteUtils {
       new PushInputSchemaBuilder().setKeySchema(INT_SCHEMA).setValueSchema(STRING_SCHEMA).build();
   public static final Schema STRING_TO_STRING_SCHEMA =
       new PushInputSchemaBuilder().setKeySchema(STRING_SCHEMA).setValueSchema(STRING_SCHEMA).build();
+  public static final Schema NAME_RECORD_V1_TO_NAME_RECORD_V1_SCHEMA =
+      new PushInputSchemaBuilder().setKeySchema(NAME_RECORD_V1_SCHEMA).setValueSchema(NAME_RECORD_V1_SCHEMA).build();
   public static final Schema STRING_TO_NAME_RECORD_V1_SCHEMA =
       new PushInputSchemaBuilder().setKeySchema(STRING_SCHEMA).setValueSchema(NAME_RECORD_V1_SCHEMA).build();
 
@@ -318,6 +320,32 @@ public class TestWriteUtils {
         writer.append(keyValueRecord);
       }
     });
+  }
+
+  public static Schema writeSimpleAvroFileWithRecordToRecordSchema(File parentDir) throws IOException {
+    return writeAvroFile(
+        parentDir,
+        "string2record.avro",
+        NAME_RECORD_V1_TO_NAME_RECORD_V1_SCHEMA,
+        (recordSchema, writer) -> {
+          String firstName = "first_name_";
+          String lastName = "last_name_";
+          for (int i = 1; i <= DEFAULT_USER_DATA_RECORD_COUNT; ++i) {
+            GenericRecord keyValueRecord = new GenericData.Record(recordSchema);
+
+            GenericRecord keyRecord = new GenericData.Record(NAME_RECORD_V1_SCHEMA);
+            keyRecord.put("firstName", firstName + i);
+            keyRecord.put("lastName", lastName + i);
+            keyValueRecord.put(DEFAULT_KEY_FIELD_PROP, keyRecord); // Key
+
+            GenericRecord valueRecord = new GenericData.Record(NAME_RECORD_V1_SCHEMA);
+            valueRecord.put("firstName", firstName + i);
+            valueRecord.put("lastName", lastName + i);
+            keyValueRecord.put(DEFAULT_VALUE_FIELD_PROP, valueRecord); // Value
+
+            writer.append(keyValueRecord);
+          }
+        });
   }
 
   public static Schema writeSimpleAvroFileWithStringToPartialUpdateOpRecordSchema(File parentDir) throws IOException {

--- a/internal/venice-test-common/src/main/java/com/linkedin/venice/utils/TestWriteUtils.java
+++ b/internal/venice-test-common/src/main/java/com/linkedin/venice/utils/TestWriteUtils.java
@@ -111,10 +111,10 @@ public class TestWriteUtils {
       new PushInputSchemaBuilder().setKeySchema(INT_SCHEMA).setValueSchema(STRING_SCHEMA).build();
   public static final Schema STRING_TO_STRING_SCHEMA =
       new PushInputSchemaBuilder().setKeySchema(STRING_SCHEMA).setValueSchema(STRING_SCHEMA).build();
-  public static final Schema NAME_RECORD_V1_TO_NAME_RECORD_V1_SCHEMA =
-      new PushInputSchemaBuilder().setKeySchema(NAME_RECORD_V1_SCHEMA).setValueSchema(NAME_RECORD_V1_SCHEMA).build();
   public static final Schema STRING_TO_NAME_RECORD_V1_SCHEMA =
       new PushInputSchemaBuilder().setKeySchema(STRING_SCHEMA).setValueSchema(NAME_RECORD_V1_SCHEMA).build();
+  public static final Schema STRING_TO_NAME_RECORD_V2_SCHEMA =
+      new PushInputSchemaBuilder().setKeySchema(STRING_SCHEMA).setValueSchema(NAME_RECORD_V2_SCHEMA).build();
 
   public static final Schema STRING_TO_NAME_RECORD_V3_SCHEMA =
       new PushInputSchemaBuilder().setKeySchema(STRING_SCHEMA).setValueSchema(NAME_RECORD_V3_SCHEMA).build();
@@ -306,7 +306,7 @@ public class TestWriteUtils {
     });
   }
 
-  public static Schema writeSimpleAvroFileWithStringToRecordSchema(File parentDir) throws IOException {
+  public static Schema writeSimpleAvroFileWithStringToNameRecordV1Schema(File parentDir) throws IOException {
     return writeAvroFile(parentDir, "string2record.avro", STRING_TO_NAME_RECORD_V1_SCHEMA, (recordSchema, writer) -> {
       String firstName = "first_name_";
       String lastName = "last_name_";
@@ -320,32 +320,6 @@ public class TestWriteUtils {
         writer.append(keyValueRecord);
       }
     });
-  }
-
-  public static Schema writeSimpleAvroFileWithRecordToRecordSchema(File parentDir) throws IOException {
-    return writeAvroFile(
-        parentDir,
-        "string2record.avro",
-        NAME_RECORD_V1_TO_NAME_RECORD_V1_SCHEMA,
-        (recordSchema, writer) -> {
-          String firstName = "first_name_";
-          String lastName = "last_name_";
-          for (int i = 1; i <= DEFAULT_USER_DATA_RECORD_COUNT; ++i) {
-            GenericRecord keyValueRecord = new GenericData.Record(recordSchema);
-
-            GenericRecord keyRecord = new GenericData.Record(NAME_RECORD_V1_SCHEMA);
-            keyRecord.put("firstName", firstName + i);
-            keyRecord.put("lastName", lastName + i);
-            keyValueRecord.put(DEFAULT_KEY_FIELD_PROP, keyRecord); // Key
-
-            GenericRecord valueRecord = new GenericData.Record(NAME_RECORD_V1_SCHEMA);
-            valueRecord.put("firstName", firstName + i);
-            valueRecord.put("lastName", lastName + i);
-            keyValueRecord.put(DEFAULT_VALUE_FIELD_PROP, valueRecord); // Value
-
-            writer.append(keyValueRecord);
-          }
-        });
   }
 
   public static Schema writeSimpleAvroFileWithStringToPartialUpdateOpRecordSchema(File parentDir) throws IOException {


### PR DESCRIPTION
## [changelog] Multiple fixes to changelog consumer logic
Fix a few places in the code that use RMD protocol ID instead of value schema id to deserialize value. 
Also, introduce a RMD schema cache to cache the schema.

## How was this PR tested?
Adjust existing integration tests to cover schema id > 1 cases.

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.