### PR TITLE
[Server] Stuck consumer task would kill SITs having issues post online

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
@@ -118,7 +118,6 @@ import static com.linkedin.venice.ConfigKeys.SERVER_STOP_CONSUMPTION_TIMEOUT_IN_
 import static com.linkedin.venice.ConfigKeys.SERVER_STORE_TO_EARLY_TERMINATION_THRESHOLD_MS_MAP;
 import static com.linkedin.venice.ConfigKeys.SERVER_STUCK_CONSUMER_REPAIR_ENABLED;
 import static com.linkedin.venice.ConfigKeys.SERVER_STUCK_CONSUMER_REPAIR_INTERVAL_SECOND;
-import static com.linkedin.venice.ConfigKeys.SERVER_STUCK_CONSUMER_REPAIR_THRESHOLD_SECOND;
 import static com.linkedin.venice.ConfigKeys.SERVER_SYSTEM_STORE_PROMOTION_TO_LEADER_REPLICA_DELAY_SECONDS;
 import static com.linkedin.venice.ConfigKeys.SERVER_UNSUB_AFTER_BATCHPUSH;
 import static com.linkedin.venice.ConfigKeys.SEVER_CALCULATE_QUOTA_USAGE_BASED_ON_PARTITIONS_ASSIGNMENT_ENABLED;
@@ -457,9 +456,8 @@ public class VeniceServerConfig extends VeniceClusterConfig {
   private final long leaderCompleteStateCheckInFollowerValidIntervalMs;
   private final boolean stuckConsumerRepairEnabled;
   private final int stuckConsumerRepairIntervalSecond;
-  private final int stuckConsumerDetectionRepairThresholdSecond;
-  private final int nonExistingTopicIngestionTaskKillThresholdSecond;
-  private final int nonExistingTopicCheckRetryIntervalSecond;
+  private final int stuckIngestionTaskKillThresholdMs;
+  private final int stuckIngestionTaskKillRetryIntervalMs;
   private final boolean dedicatedConsumerPoolForAAWCLeaderEnabled;
   private final int dedicatedConsumerPoolSizeForAAWCLeader;
   private final boolean useDaVinciSpecificExecutionStatusForError;
@@ -741,17 +739,9 @@ public class VeniceServerConfig extends VeniceClusterConfig {
 
     stuckConsumerRepairEnabled = serverProperties.getBoolean(SERVER_STUCK_CONSUMER_REPAIR_ENABLED, true);
     stuckConsumerRepairIntervalSecond = serverProperties.getInt(SERVER_STUCK_CONSUMER_REPAIR_INTERVAL_SECOND, 60);
-    stuckConsumerDetectionRepairThresholdSecond =
-        serverProperties.getInt(SERVER_STUCK_CONSUMER_REPAIR_THRESHOLD_SECOND, 5 * 60); // 5 mins
-    if (stuckConsumerRepairEnabled && stuckConsumerDetectionRepairThresholdSecond < stuckConsumerRepairIntervalSecond) {
-      throw new VeniceException(
-          "Config for " + SERVER_STUCK_CONSUMER_REPAIR_THRESHOLD_SECOND + ": "
-              + stuckConsumerDetectionRepairThresholdSecond + " should be equal to or larger than "
-              + SERVER_STUCK_CONSUMER_REPAIR_INTERVAL_SECOND + ": " + stuckConsumerRepairIntervalSecond);
-    }
-    nonExistingTopicIngestionTaskKillThresholdSecond =
+    stuckIngestionTaskKillThresholdMs =
         serverProperties.getInt(SERVER_NON_EXISTING_TOPIC_INGESTION_TASK_KILL_THRESHOLD_SECOND, 15 * 60); // 15 mins
-    nonExistingTopicCheckRetryIntervalSecond =
+    stuckIngestionTaskKillRetryIntervalMs =
         serverProperties.getInt(SERVER_NON_EXISTING_TOPIC_CHECK_RETRY_INTERNAL_SECOND, 60); // 1min
     leaderCompleteStateCheckInFollowerEnabled =
         serverProperties.getBoolean(SERVER_LEADER_COMPLETE_STATE_CHECK_IN_FOLLOWER_ENABLED, false);
@@ -1324,16 +1314,12 @@ public class VeniceServerConfig extends VeniceClusterConfig {
     return stuckConsumerRepairIntervalSecond;
   }
 
-  public int getStuckConsumerDetectionRepairThresholdSecond() {
-    return stuckConsumerDetectionRepairThresholdSecond;
+  public int getStuckIngestionTaskKillThresholdMs() {
+    return stuckIngestionTaskKillThresholdMs;
   }
 
-  public int getNonExistingTopicIngestionTaskKillThresholdSecond() {
-    return nonExistingTopicIngestionTaskKillThresholdSecond;
-  }
-
-  public int getNonExistingTopicCheckRetryIntervalSecond() {
-    return nonExistingTopicCheckRetryIntervalSecond;
+  public int getStuckIngestionTaskKillRetryIntervalMs() {
+    return stuckIngestionTaskKillRetryIntervalMs;
   }
 
   public boolean isDedicatedConsumerPoolForAAWCLeaderEnabled() {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/StuckConsumerRepairStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/StuckConsumerRepairStats.java
@@ -9,14 +9,12 @@ import io.tehuti.metrics.stats.OccurrenceRate;
 public class StuckConsumerRepairStats extends AbstractVeniceStats {
   private Sensor stuckConsumerFound;
   private Sensor ingestionTaskRepair;
-  private Sensor repairFailure;
 
   public StuckConsumerRepairStats(MetricsRepository metricsRepository) {
     super(metricsRepository, "StuckConsumerRepair");
 
     this.stuckConsumerFound = registerSensor("stuck_consumer_found", new OccurrenceRate());
     this.ingestionTaskRepair = registerSensor("ingestion_task_repair", new OccurrenceRate());
-    this.repairFailure = registerSensor("repair_failure", new OccurrenceRate());
   }
 
   public void recordStuckConsumerFound() {
@@ -25,9 +23,5 @@ public class StuckConsumerRepairStats extends AbstractVeniceStats {
 
   public void recordIngestionTaskRepair() {
     ingestionTaskRepair.record();
-  }
-
-  public void recordRepairFailure() {
-    repairFailure.record();
   }
 }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/AggKafkaConsumerServiceTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/AggKafkaConsumerServiceTest.java
@@ -126,16 +126,11 @@ public class AggKafkaConsumerServiceTest {
 
   @Test
   public void testGetStuckConsumerDetectionAndRepairRunnable() {
-    Map<String, AbstractKafkaConsumerService> kafkaServerToConsumerServiceMap = new HashMap<>();
     Map<String, StoreIngestionTask> versionTopicStoreIngestionTaskMapping = new HashMap<>();
-    long stuckConsumerRepairThresholdMs = 100;
-    long nonExistingTopicIngestionTaskKillThresholdMs = 1000;
+    long stuckIngestionTaskKillThresholdMs = 1000;
     StuckConsumerRepairStats stuckConsumerRepairStats = mock(StuckConsumerRepairStats.class);
 
     // Everything is good
-    KafkaConsumerService goodConsumerService = mock(KafkaConsumerService.class);
-    when(goodConsumerService.getMaxElapsedTimeMSSinceLastPollInConsumerPool()).thenReturn(10l);
-    kafkaServerToConsumerServiceMap.put("good", goodConsumerService);
     StoreIngestionTask goodTask = mock(StoreIngestionTask.class);
     when(goodTask.isProducingVersionTopicHealthy()).thenReturn(true);
     versionTopicStoreIngestionTaskMapping.put("good_task", goodTask);
@@ -143,91 +138,93 @@ public class AggKafkaConsumerServiceTest {
     Consumer<String> killIngestionTaskRunnable = mock(Consumer.class);
 
     Runnable repairRunnable = AggKafkaConsumerService.getStuckConsumerDetectionAndRepairRunnable(
-        kafkaServerToConsumerServiceMap,
         versionTopicStoreIngestionTaskMapping,
-        stuckConsumerRepairThresholdMs,
-        nonExistingTopicIngestionTaskKillThresholdMs,
+        stuckIngestionTaskKillThresholdMs,
         200,
         stuckConsumerRepairStats,
         killIngestionTaskRunnable);
     repairRunnable.run();
-    verify(goodConsumerService).getMaxElapsedTimeMSSinceLastPollInConsumerPool();
     verify(stuckConsumerRepairStats, never()).recordStuckConsumerFound();
     verify(stuckConsumerRepairStats, never()).recordIngestionTaskRepair();
-    verify(stuckConsumerRepairStats, never()).recordRepairFailure();
     verify(killIngestionTaskRunnable, never()).accept(any());
   }
 
   @Test
   public void testGetStuckConsumerDetectionAndRepairRunnableForTransientNonExistingTopic() {
-    Map<String, AbstractKafkaConsumerService> kafkaServerToConsumerServiceMap = new HashMap<>();
     Map<String, StoreIngestionTask> versionTopicStoreIngestionTaskMapping = new HashMap<>();
-    long stuckConsumerRepairThresholdMs = 100;
-    long nonExistingTopicIngestionTaskKillThresholdMs = 1000;
+    long stuckIngestionTaskKillThresholdMs = 1000;
     StuckConsumerRepairStats stuckConsumerRepairStats = mock(StuckConsumerRepairStats.class);
 
     Consumer<String> killIngestionTaskRunnable = mock(Consumer.class);
 
     Runnable repairRunnable = AggKafkaConsumerService.getStuckConsumerDetectionAndRepairRunnable(
-        kafkaServerToConsumerServiceMap,
         versionTopicStoreIngestionTaskMapping,
-        stuckConsumerRepairThresholdMs,
-        nonExistingTopicIngestionTaskKillThresholdMs,
+        stuckIngestionTaskKillThresholdMs,
         200,
         stuckConsumerRepairStats,
         killIngestionTaskRunnable);
     // One stuck consumer
-    KafkaConsumerService badConsumerService = mock(KafkaConsumerService.class);
-    when(badConsumerService.getMaxElapsedTimeMSSinceLastPollInConsumerPool()).thenReturn(1000l);
-    kafkaServerToConsumerServiceMap.put("bad", badConsumerService);
-
     StoreIngestionTask transientBadTask = mock(StoreIngestionTask.class);
     when(transientBadTask.isProducingVersionTopicHealthy()).thenReturn(false).thenReturn(true);
+    when(transientBadTask.isIngestionStuckPostOnline()).thenReturn(false);
     versionTopicStoreIngestionTaskMapping.put("transient_bad_task", transientBadTask);
     repairRunnable.run();
-    verify(badConsumerService).getMaxElapsedTimeMSSinceLastPollInConsumerPool();
     verify(stuckConsumerRepairStats).recordStuckConsumerFound();
     verify(stuckConsumerRepairStats, never()).recordIngestionTaskRepair();
-    verify(stuckConsumerRepairStats).recordRepairFailure();
     verify(killIngestionTaskRunnable, never()).accept(any());
   }
 
   @Test
   public void testGetStuckConsumerDetectionAndRepairRunnableForNonExistingTopic() {
-    Map<String, AbstractKafkaConsumerService> kafkaServerToConsumerServiceMap = new HashMap<>();
     Map<String, StoreIngestionTask> versionTopicStoreIngestionTaskMapping = new HashMap<>();
-    long stuckConsumerRepairThresholdMs = 100;
-    long nonExistingTopicIngestionTaskKillThresholdMs = 1000;
+    long stuckIngestionTaskKillThresholdMs = 1000;
     StuckConsumerRepairStats stuckConsumerRepairStats = mock(StuckConsumerRepairStats.class);
 
     Consumer<String> killIngestionTaskRunnable = mock(Consumer.class);
 
     Runnable repairRunnable = AggKafkaConsumerService.getStuckConsumerDetectionAndRepairRunnable(
-        kafkaServerToConsumerServiceMap,
         versionTopicStoreIngestionTaskMapping,
-        stuckConsumerRepairThresholdMs,
-        nonExistingTopicIngestionTaskKillThresholdMs,
+        stuckIngestionTaskKillThresholdMs,
         200,
         stuckConsumerRepairStats,
         killIngestionTaskRunnable);
     // One stuck consumer
-    KafkaConsumerService badConsumerService = mock(KafkaConsumerService.class);
-    when(badConsumerService.getMaxElapsedTimeMSSinceLastPollInConsumerPool()).thenReturn(1000l);
-    kafkaServerToConsumerServiceMap.put("bad", badConsumerService);
     StoreIngestionTask badTask = mock(StoreIngestionTask.class);
     when(badTask.isProducingVersionTopicHealthy()).thenReturn(false);
+    when(badTask.isIngestionStuckPostOnline()).thenReturn(false);
     versionTopicStoreIngestionTaskMapping.put("bad_task", badTask);
     repairRunnable.run();
-    verify(badConsumerService).getMaxElapsedTimeMSSinceLastPollInConsumerPool();
     verify(badTask, times(6)).isProducingVersionTopicHealthy();
     verify(badTask).closeVeniceWriters(false);
     verify(killIngestionTaskRunnable).accept("bad_task");
     verify(stuckConsumerRepairStats).recordStuckConsumerFound();
     verify(stuckConsumerRepairStats).recordIngestionTaskRepair();
+  }
 
-    // One stuck consumer without any problematic ingestion task
-    versionTopicStoreIngestionTaskMapping.remove("bad_task");
+  @Test
+  public void testGetStuckConsumerDetectionAndRepairRunnableForReplicaHavingIssuesPostOnline() {
+    Map<String, StoreIngestionTask> versionTopicStoreIngestionTaskMapping = new HashMap<>();
+    StuckConsumerRepairStats stuckConsumerRepairStats = mock(StuckConsumerRepairStats.class);
+
+    Consumer<String> killIngestionTaskRunnable = mock(Consumer.class);
+
+    Runnable repairRunnable = AggKafkaConsumerService.getStuckConsumerDetectionAndRepairRunnable(
+        versionTopicStoreIngestionTaskMapping,
+        1000,
+        200,
+        stuckConsumerRepairStats,
+        killIngestionTaskRunnable);
+    // One stuck consumer
+    StoreIngestionTask badTask = mock(StoreIngestionTask.class);
+    when(badTask.isProducingVersionTopicHealthy()).thenReturn(true);
+    when(badTask.isIngestionStuckPostOnline()).thenReturn(true);
+    versionTopicStoreIngestionTaskMapping.put("bad_task", badTask);
     repairRunnable.run();
-    verify(stuckConsumerRepairStats).recordRepairFailure();
+    verify(badTask, times(1)).isProducingVersionTopicHealthy();
+    verify(badTask, times(6)).isIngestionStuckPostOnline();
+    verify(badTask).closeVeniceWriters(false);
+    verify(killIngestionTaskRunnable).accept("bad_task");
+    verify(stuckConsumerRepairStats).recordStuckConsumerFound();
+    verify(stuckConsumerRepairStats).recordIngestionTaskRepair();
   }
 }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
@@ -2649,10 +2649,6 @@ public abstract class StoreIngestionTaskTest {
             "Only one partition should be failed");
       });
     }, aaConfig);
-    // for (int i = 0; i < 10000; ++i) {
-    // storeIngestionTaskUnderTest
-    // .setIngestionException(0, new VeniceException("new fake looooooooooooooooong exception"));
-    // }
   }
 
   private VeniceServerConfig buildVeniceServerConfig(Map<String, Object> extraProperties) {


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Summary
### Background
Today if an unrecoverable exception occurs during current version RT ingestion, the ingest task unsubscribes and then sits around.  This is a terminal stale state. That's the state model semantic we have today, that is, we don't put a replica into ERROR state if it's being online.

Recently, we observed that replicas stopped ingestion after being online due to a dependency outage. In order to recover from this, our oncall had to do manual host deployment/fleet-wide restart so these hosts can restart the workflow and ingest data again.

### Goal
In this PR, we are trying to add auto-recovery mechanism for such tasks so oncalls don't have to do it manually 

### Technical details
We have several options to implement this.
* [Implemented by this PR] Relocate the replica to another one by killing the SIT. 
    * The idea is we can piggyback on existing implementation of stuck consumer task to kill the task that's producing to a non-existing topic or is marked as stale after being online. Technically we can consider the stale leaders as its "consumer" being stuck 😃.  The  biggest drawback is when there's an outage, these leader would kill themselves w/o considering other replicas readiness. It potentially also cause some availability issue. It's acceptable given follower still serve the traffic
* Relocate the replica to another one by disabling this replica
    * The idea is we leverage existing logic for disabling replicas for future version and makes it work for current version. However, there are a few potential issues with this approach.
        * It breaks our state transition semantic. In order to leverage the logic, we need to either use `ERROR` or a new state after `COMPLETED` so helix can act on it, but `COMPLETED` will no longer be a terminal state. It’s okay to change it tho but the cost outweighs the gain (unless we foresee we will do this soon), given it's relatively rare to get into unrecoverable state after being online.
        * Need to keep listening more states on ZK. We had scaling challenges on ZK listeners. When the node enters terminal state,  we unsubscribe the listener. With this approach, we have to keep listening to it even though 90% of time there would be no change. That's a waste. 
* Unsubscribe and re-subscribe the topic with a retry with backoff pattern to see if we can recover. This is a workable solution but during outages, it can be just infinite loops and eventually ends up in the same state.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
unit tests


## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.