### PR TITLE
[server] Lag monitor should not expect corresponding version always exists in ZK

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/helix/LeaderFollowerPartitionStateModel.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/helix/LeaderFollowerPartitionStateModel.java
@@ -13,6 +13,7 @@ import com.linkedin.venice.helix.HelixState;
 import com.linkedin.venice.meta.ReadOnlyStoreRepository;
 import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.Version;
+import com.linkedin.venice.meta.VersionImpl;
 import com.linkedin.venice.utils.LatencyUtils;
 import com.linkedin.venice.utils.Pair;
 import java.util.concurrent.CompletableFuture;
@@ -121,7 +122,7 @@ public class LeaderFollowerPartitionStateModel extends AbstractPartitionStateMod
       if (isRegularStoreCurrentVersion) {
         waitConsumptionCompleted(resourceName, notifier);
       }
-      updateLagMonitor(message.getResourceName(), heartbeatMonitoringService::addFollowerLagMonitor);
+      updateLagMonitor(message.getResourceName(), heartbeatMonitoringService::addFollowerLagMonitor, false);
     });
   }
 
@@ -133,7 +134,7 @@ public class LeaderFollowerPartitionStateModel extends AbstractPartitionStateMod
      * where a slice doesn't have a replicating leader.  While this state transition executes, there should be no
      * other leader in the slice.
      */
-    updateLagMonitor(message.getResourceName(), heartbeatMonitoringService::addLeaderLagMonitor);
+    updateLagMonitor(message.getResourceName(), heartbeatMonitoringService::addLeaderLagMonitor, false);
     executeStateTransition(
         message,
         context,
@@ -143,7 +144,7 @@ public class LeaderFollowerPartitionStateModel extends AbstractPartitionStateMod
   @Transition(to = HelixState.STANDBY_STATE, from = HelixState.LEADER_STATE)
   public void onBecomeStandbyFromLeader(Message message, NotificationContext context) {
     LeaderSessionIdChecker checker = new LeaderSessionIdChecker(leaderSessionId.incrementAndGet(), leaderSessionId);
-    updateLagMonitor(message.getResourceName(), heartbeatMonitoringService::addFollowerLagMonitor);
+    updateLagMonitor(message.getResourceName(), heartbeatMonitoringService::addFollowerLagMonitor, false);
     executeStateTransition(
         message,
         context,
@@ -152,7 +153,7 @@ public class LeaderFollowerPartitionStateModel extends AbstractPartitionStateMod
 
   @Transition(to = HelixState.OFFLINE_STATE, from = HelixState.STANDBY_STATE)
   public void onBecomeOfflineFromStandby(Message message, NotificationContext context) {
-    updateLagMonitor(message.getResourceName(), heartbeatMonitoringService::removeLagMonitor);
+    updateLagMonitor(message.getResourceName(), heartbeatMonitoringService::removeLagMonitor, true);
     executeStateTransition(message, context, () -> stopConsumption(true));
   }
 
@@ -196,7 +197,7 @@ public class LeaderFollowerPartitionStateModel extends AbstractPartitionStateMod
     logger.warn("unexpected state transition from ERROR to OFFLINE");
   }
 
-  void updateLagMonitor(String resourceName, BiConsumer<Version, Integer> lagMonFunction) {
+  void updateLagMonitor(String resourceName, BiConsumer<Version, Integer> lagMonFunction, boolean isNullVersionValid) {
     try {
       String storeName = Version.parseStoreFromKafkaTopicName(resourceName);
       int storeVersion = Version.parseVersionFromKafkaTopicName(resourceName);
@@ -204,14 +205,24 @@ public class LeaderFollowerPartitionStateModel extends AbstractPartitionStateMod
           .waitVersion(storeName, storeVersion, getStoreAndServerConfigs().getServerMaxWaitForVersionInfo(), 200);
       Store store = res.getFirst();
       Version version = res.getSecond();
-      if (store == null || version == null) {
+      if (store == null) {
         logger.error(
-            "Failed to get store or version for resource: {}-{}. store: {} version: {}. Will not update lag monitor.",
+            "Failed to get store for resource: {}-{}. Will not update lag monitor.",
             resourceName,
-            getPartition(),
-            store,
-            version);
+            getPartition());
         return;
+      }
+      if (version == null) {
+        if (isNullVersionValid) {
+          // During version deletion, the version will be deleted from ZK prior to servers perform resource deletion.
+          // It's valid to have null version when trying to remove lag monitor for the deleted resource.
+          version = new VersionImpl(storeName, storeVersion, "");
+        } else {
+          logger.error(
+              "Failed to get version for resource: {}-{}. Will not update lag monitor.",
+              resourceName,
+              getPartition());
+        }
       }
       lagMonFunction.accept(version, getPartition());
     } catch (Exception e) {


### PR DESCRIPTION
## [server] Lag monitor should not expect corresponding version always exists in ZK
1. updateLagMonitor was implemented to expect the version object to never be null. This assumption is wrong because when we are deleting a version the version object is removed from ZK first before the state transition occurs on the server from STANDBY->OFFLINE. Add the option for updateLagMonitor to accept null version if it's called for removeLagMonitor.

2. Separated the logging for null store and null version to be explicit and not logging store objects.

## How was this PR tested?
New unit test and existing unit+integration tests

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.