### PR TITLE
[server] Feature to tune level0 compaction tuning for read-write leader

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -5,6 +5,7 @@ import static com.linkedin.davinci.ingestion.LagType.TIME_LAG;
 import static com.linkedin.davinci.kafka.consumer.ConsumerActionType.RESET_OFFSET;
 import static com.linkedin.davinci.kafka.consumer.ConsumerActionType.SUBSCRIBE;
 import static com.linkedin.davinci.kafka.consumer.ConsumerActionType.UNSUBSCRIBE;
+import static com.linkedin.davinci.kafka.consumer.LeaderFollowerStateType.*;
 import static com.linkedin.davinci.validation.KafkaDataIntegrityValidator.DISABLED;
 import static com.linkedin.venice.ConfigKeys.KAFKA_BOOTSTRAP_SERVERS;
 import static com.linkedin.venice.LogMessages.KILLED_JOB_MESSAGE;
@@ -710,7 +711,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
         returnStatus = storageEngine.checkDatabaseIntegrity(
             partitionId,
             offsetRecord.getDatabaseInfo(),
-            getStoragePartitionConfig(partitionId, storeVersionState.sorted, partitionConsumptionState));
+            getStoragePartitionConfig(storeVersionState.sorted, partitionConsumptionState));
         LOGGER.info(
             "checkDatabaseIntegrity {} for {}, partition: {}",
             returnStatus ? "succeeded" : "failed",
@@ -733,8 +734,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
 
   private void beginBatchWrite(int partitionId, boolean sorted, PartitionConsumptionState partitionConsumptionState) {
     Map<String, String> checkpointedDatabaseInfo = partitionConsumptionState.getOffsetRecord().getDatabaseInfo();
-    StoragePartitionConfig storagePartitionConfig =
-        getStoragePartitionConfig(partitionId, sorted, partitionConsumptionState);
+    StoragePartitionConfig storagePartitionConfig = getStoragePartitionConfig(sorted, partitionConsumptionState);
     partitionConsumptionState.setDeferredWrite(storagePartitionConfig.isDeferredWrite());
 
     Optional<Supplier<byte[]>> partitionChecksumSupplier = Optional.empty();
@@ -761,11 +761,19 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
     }
   }
 
-  private StoragePartitionConfig getStoragePartitionConfig(
-      int partitionId,
+  protected StoragePartitionConfig getStoragePartitionConfig(PartitionConsumptionState partitionConsumptionState) {
+    StoreVersionState storeVersionState = storageEngine.getStoreVersionState();
+    if (storeVersionState == null) {
+      throw new VeniceException("Can't find store version state for store version: " + kafkaVersionTopic);
+    }
+    return getStoragePartitionConfig(storeVersionState.sorted, partitionConsumptionState);
+  }
+
+  protected StoragePartitionConfig getStoragePartitionConfig(
       boolean sorted,
       PartitionConsumptionState partitionConsumptionState) {
-    StoragePartitionConfig storagePartitionConfig = new StoragePartitionConfig(kafkaVersionTopic, partitionId);
+    StoragePartitionConfig storagePartitionConfig =
+        new StoragePartitionConfig(kafkaVersionTopic, partitionConsumptionState.getPartition());
     boolean deferredWrites;
     boolean readOnly = false;
     if (partitionConsumptionState.isEndOfPushReceived()) {
@@ -781,6 +789,25 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
     }
     storagePartitionConfig.setDeferredWrite(deferredWrites);
     storagePartitionConfig.setReadOnly(readOnly);
+
+    if (partitionConsumptionState.isCompletionReported()) {
+      storagePartitionConfig.setWriteOnlyConfig(false);
+    }
+
+    if (partitionConsumptionState.isHybrid()) {
+      if (partitionConsumptionState.getLeaderFollowerState().equals(STANDBY)) {
+        storagePartitionConfig.setReadWriteLeaderForDefaultCF(false);
+        storagePartitionConfig.setReadWriteLeaderForRMDCF(false);
+      } else if (partitionConsumptionState.getLeaderFollowerState().equals(LEADER)) {
+        if (isActiveActiveReplicationEnabled) {
+          storagePartitionConfig.setReadWriteLeaderForRMDCF(true);
+        }
+        if (isWriteComputationEnabled) {
+          storagePartitionConfig.setReadWriteLeaderForDefaultCF(true);
+        }
+      }
+    }
+
     return storagePartitionConfig;
   }
 
@@ -2586,8 +2613,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
      * Right now, we assume there are no sorted message after EndOfPush control message.
      * TODO: if this behavior changes in the future, the logic needs to be adjusted as well.
      */
-    StoragePartitionConfig storagePartitionConfig =
-        getStoragePartitionConfig(partition, false, partitionConsumptionState);
+    StoragePartitionConfig storagePartitionConfig = getStoragePartitionConfig(false, partitionConsumptionState);
 
     /**
      * Update the transactional/deferred mode of the partition.
@@ -3633,19 +3659,26 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
           || (partitionConsumptionState.isEndOfPushReceived() && !partitionConsumptionState.isCompletionReported())) {
         if (isReadyToServe(partitionConsumptionState)) {
           int partition = partitionConsumptionState.getPartition();
-          Store store = storeRepository.getStoreOrThrow(storeName);
 
-          AbstractStorageEngine storageEngineReloadedFromRepo =
-              storageEngineRepository.getLocalStorageEngine(kafkaVersionTopic);
-          if (store.isHybrid()) {
-            if (storageEngineReloadedFromRepo == null) {
-              LOGGER.warn("Storage engine {} was removed before reopening", kafkaVersionTopic);
-            } else {
-              storageEngineReloadedFromRepo.preparePartitionForReading(partition);
-            }
-          }
           if (!partitionConsumptionState.isCompletionReported()) {
+            Store store = storeRepository.getStoreOrThrow(storeName);
             reportCompleted(partitionConsumptionState);
+            AbstractStorageEngine storageEngineReloadedFromRepo =
+                storageEngineRepository.getLocalStorageEngine(kafkaVersionTopic);
+            if (store.isHybrid()) {
+              if (storageEngineReloadedFromRepo == null) {
+                LOGGER.warn("Storage engine {} was removed before reopening", kafkaVersionTopic);
+              } else {
+                /**
+                 * May adjust the underlying storage partition to optimize read perf.
+                 */
+                storageEngineReloadedFromRepo.adjustStoragePartition(
+                    partition,
+                    AbstractStorageEngine.StoragePartitionAdjustmentTrigger.PREPARE_FOR_READ,
+                    getStoragePartitionConfig(partitionConsumptionState));
+              }
+            }
+
             warmupSchemaCache(store);
           }
           if (suppressLiveUpdates) {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/AbstractStorageEngine.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/AbstractStorageEngine.java
@@ -195,10 +195,6 @@ public abstract class AbstractStorageEngine<Partition extends AbstractStoragePar
           "StoragePartitionConfig should contain the right partition id: " + partitionId + ", but got "
               + partitionConfig.getPartitionId());
     }
-    if (!containsPartition(partitionId)) {
-      LOGGER.warn("Partition {}_{} was removed before adjusting.", storeVersionName, partitionId);
-      return;
-    }
     LOGGER.info("Storage partition adjustment got triggered by: {} with config: {}", mode, partitionConfig);
     AbstractStoragePartition partition = getPartitionOrThrow(partitionId);
     if (partition.verifyConfig(partitionConfig)) {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/AbstractStorageEngine.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/AbstractStorageEngine.java
@@ -199,7 +199,7 @@ public abstract class AbstractStorageEngine<Partition extends AbstractStoragePar
       LOGGER.warn("Partition {}_{} was removed before adjusting.", storeVersionName, partitionId);
       return;
     }
-    LOGGER.info("Storage partition got triggered by: {} with config: {}", mode, partitionConfig);
+    LOGGER.info("Storage partition adjustment got triggered by: {} with config: {}", mode, partitionConfig);
     AbstractStoragePartition partition = getPartitionOrThrow(partitionId);
     if (partition.verifyConfig(partitionConfig)) {
       LOGGER.info("Store partition adjustment will be skipped as there is no difference");

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/StoragePartitionConfig.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/StoragePartitionConfig.java
@@ -16,6 +16,8 @@ public class StoragePartitionConfig {
   private boolean deferredWrite;
   private boolean readOnly;
   private boolean writeOnlyConfig;
+  private boolean readWriteLeaderForDefaultCF;
+  private boolean readWriteLeaderForRMDCF;
 
   public StoragePartitionConfig(String storeName, int partitionId) {
     this.storeName = storeName;
@@ -23,6 +25,8 @@ public class StoragePartitionConfig {
     this.deferredWrite = false;
     this.readOnly = false;
     this.writeOnlyConfig = true;
+    this.readWriteLeaderForDefaultCF = false;
+    this.readWriteLeaderForRMDCF = false;
   }
 
   public String getStoreName() {
@@ -63,6 +67,22 @@ public class StoragePartitionConfig {
     }
   }
 
+  public boolean isReadWriteLeaderForDefaultCF() {
+    return readWriteLeaderForDefaultCF;
+  }
+
+  public void setReadWriteLeaderForDefaultCF(boolean readWriteLeaderForDefaultCF) {
+    this.readWriteLeaderForDefaultCF = readWriteLeaderForDefaultCF;
+  }
+
+  public boolean isReadWriteLeaderForRMDCF() {
+    return readWriteLeaderForRMDCF;
+  }
+
+  public void setReadWriteLeaderForRMDCF(boolean readWriteLeaderForRMDCF) {
+    this.readWriteLeaderForRMDCF = readWriteLeaderForRMDCF;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -73,17 +93,27 @@ public class StoragePartitionConfig {
     }
     StoragePartitionConfig that = (StoragePartitionConfig) o;
     return partitionId == that.partitionId && deferredWrite == that.deferredWrite && readOnly == that.readOnly
-        && writeOnlyConfig == that.writeOnlyConfig && storeName.equals(that.storeName);
+        && writeOnlyConfig == that.writeOnlyConfig && storeName.equals(that.storeName)
+        && readWriteLeaderForDefaultCF == that.readWriteLeaderForDefaultCF
+        && readWriteLeaderForRMDCF == that.readWriteLeaderForRMDCF;
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(storeName, partitionId, deferredWrite, readOnly, writeOnlyConfig);
+    return Objects.hash(
+        storeName,
+        partitionId,
+        deferredWrite,
+        readOnly,
+        writeOnlyConfig,
+        readWriteLeaderForDefaultCF,
+        readWriteLeaderForRMDCF);
   }
 
   @Override
   public String toString() {
     return "Store: " + storeName + ", partition id: " + partitionId + ", deferred-write: " + deferredWrite
-        + ", read-only: " + readOnly + ", write-only: " + writeOnlyConfig;
+        + ", read-only: " + readOnly + ", write-only: " + writeOnlyConfig + ", read-write leader for default CF: "
+        + readWriteLeaderForDefaultCF + ", read-write leader for RMD CF: " + readWriteLeaderForRMDCF;
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/RocksDBServerConfig.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/RocksDBServerConfig.java
@@ -185,6 +185,15 @@ public class RocksDBServerConfig {
   public static final String ROCKSDB_LEVEL0_STOPS_WRITES_TRIGGER_WRITE_ONLY_VERSION =
       "rocksdb.level0.stops.writes.trigger.write.only.version";
 
+  public static final String ROCKSDB_LEVEL0_FILE_NUM_COMPACTION_TRIGGER_FOR_READ_WRITE_LEADER =
+      "rocksdb.level0.file.num.compaction.trigger.for.read.write.leader";
+  public static final String ROCKSDB_LEVEL0_SLOWDOWN_WRITES_TRIGGER_FOR_READ_WRITE_LEADER =
+      "rocksdb.level0.slowdown.writes.trigger.for.read.write.leader";
+  public static final String ROCKSDB_LEVEL0_STOPS_WRITES_TRIGGER_FOR_READ_WRITE_LEADER =
+      "rocksdb.level0.stops.writes.trigger.for.read.write.leader";
+  public static final String ROCKSDB_LEVEL0_COMPACTION_TUNING_FOR_READ_WRITE_LEADER_ENABLED =
+      "rocksdb.level0.compaction.tuning.for.read.write.leader.enabled";
+
   public static final String ROCKSDB_PUT_REUSE_BYTE_BUFFER = "rocksdb.put.reuse.byte.buffer";
 
   /**
@@ -268,6 +277,12 @@ public class RocksDBServerConfig {
   private final int level0FileNumCompactionTriggerWriteOnlyVersion;
   private final int level0SlowdownWritesTriggerWriteOnlyVersion;
   private final int level0StopWritesTriggerWriteOnlyVersion;
+
+  private final int level0FileNumCompactionTriggerForReadWriteLeader;
+  private final int level0SlowdownWritesTriggerForReadWriteLeader;
+  private final int level0StopWritesTriggerForReadWriteLeader;
+  private final boolean level0CompactionTuningForReadWriteLeaderEnabled;
+
   private final boolean putReuseByteBufferEnabled;
   private final boolean atomicFlushEnabled;
   private final boolean separateRMDCacheEnabled;
@@ -377,6 +392,15 @@ public class RocksDBServerConfig {
     this.level0StopWritesTriggerWriteOnlyVersion =
         props.getInt(ROCKSDB_LEVEL0_STOPS_WRITES_TRIGGER_WRITE_ONLY_VERSION, 160);
 
+    this.level0FileNumCompactionTriggerForReadWriteLeader =
+        props.getInt(ROCKSDB_LEVEL0_FILE_NUM_COMPACTION_TRIGGER_FOR_READ_WRITE_LEADER, 10);
+    this.level0SlowdownWritesTriggerForReadWriteLeader =
+        props.getInt(ROCKSDB_LEVEL0_SLOWDOWN_WRITES_TRIGGER_FOR_READ_WRITE_LEADER, 20);
+    this.level0StopWritesTriggerForReadWriteLeader =
+        props.getInt(ROCKSDB_LEVEL0_STOPS_WRITES_TRIGGER_FOR_READ_WRITE_LEADER, 40);
+    this.level0CompactionTuningForReadWriteLeaderEnabled =
+        props.getBoolean(ROCKSDB_LEVEL0_COMPACTION_TUNING_FOR_READ_WRITE_LEADER_ENABLED, false);
+
     this.putReuseByteBufferEnabled = props.getBoolean(ROCKSDB_PUT_REUSE_BYTE_BUFFER, false);
     this.atomicFlushEnabled = props.getBoolean(ROCKSDB_ATOMIC_FLUSH_ENABLED, true);
     this.separateRMDCacheEnabled = props.getBoolean(ROCKSDB_SEPARATE_RMD_CACHE_ENABLED, false);
@@ -415,6 +439,22 @@ public class RocksDBServerConfig {
 
   public int getLevel0StopWritesTrigger() {
     return level0StopWritesTrigger;
+  }
+
+  public int getLevel0FileNumCompactionTriggerForReadWriteLeader() {
+    return level0FileNumCompactionTriggerForReadWriteLeader;
+  }
+
+  public int getLevel0SlowdownWritesTriggerForReadWriteLeader() {
+    return level0SlowdownWritesTriggerForReadWriteLeader;
+  }
+
+  public int getLevel0StopWritesTriggerForReadWriteLeader() {
+    return level0StopWritesTriggerForReadWriteLeader;
+  }
+
+  public boolean isLevel0CompactionTuningForReadWriteLeaderEnabled() {
+    return level0CompactionTuningForReadWriteLeaderEnabled;
   }
 
   public boolean getRocksDBUseDirectReads() {

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/DeepCopyStorageEngine.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/DeepCopyStorageEngine.java
@@ -165,8 +165,12 @@ public class DeepCopyStorageEngine extends AbstractStorageEngine<AbstractStorage
     this.delegate.delete(logicalPartitionId, key);
   }
 
-  public void preparePartitionForReading(int partition) {
-    delegate.preparePartitionForReading(partition);
+  @Override
+  public synchronized void adjustStoragePartition(
+      int partitionId,
+      StoragePartitionAdjustmentTrigger mode,
+      StoragePartitionConfig partitionConfig) {
+    delegate.adjustStoragePartition(partitionId, mode, partitionConfig);
   }
 
   @Override

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
@@ -10,6 +10,7 @@ import static com.linkedin.davinci.kafka.consumer.StoreIngestionTaskTest.NodeTyp
 import static com.linkedin.davinci.kafka.consumer.StoreIngestionTaskTest.NodeType.FOLLOWER;
 import static com.linkedin.davinci.kafka.consumer.StoreIngestionTaskTest.NodeType.LEADER;
 import static com.linkedin.davinci.kafka.consumer.StoreIngestionTaskTest.SortedInput.SORTED;
+import static com.linkedin.davinci.store.AbstractStorageEngine.StoragePartitionAdjustmentTrigger.PREPARE_FOR_READ;
 import static com.linkedin.venice.ConfigKeys.CLUSTER_NAME;
 import static com.linkedin.venice.ConfigKeys.FREEZE_INGESTION_IF_READY_TO_SERVE_OR_LOCAL_DATA_EXISTS;
 import static com.linkedin.venice.ConfigKeys.HYBRID_QUOTA_ENFORCEMENT_ENABLED;
@@ -1581,14 +1582,22 @@ public abstract class StoreIngestionTaskTest {
       doReturn(storeNameWithoutVersionInfo).when(mockStore).getName();
       doReturn(mockStore).when(mockMetadataRepo).getStoreOrThrow(storeNameWithoutVersionInfo);
     }, () -> {
-      verify(mockAbstractStorageEngine, never()).preparePartitionForReading(PARTITION_BAR);
-      // mockAbstractStorageEngine.preparePartitionForReading will hold the lock, do not use
-      // "verify(mockAbstractStorageEngine, timeout(TEST_TIMEOUT_MS)).preparePartitionForReading(PARTITION_FOO)";
-      // otherwise, the lock will be hold for time "TEST_TIMEOUT_MS"
+      ArgumentCaptor<StoragePartitionConfig> storagePartitionConfigArgumentCaptor =
+          ArgumentCaptor.forClass(StoragePartitionConfig.class);
       TestUtils.waitForNonDeterministicAssertion(
           10,
           TimeUnit.SECONDS,
-          () -> verify(mockAbstractStorageEngine, atLeastOnce()).preparePartitionForReading(PARTITION_FOO));
+          () -> verify(mockAbstractStorageEngine).adjustStoragePartition(
+              eq(PARTITION_FOO),
+              eq(PREPARE_FOR_READ),
+              storagePartitionConfigArgumentCaptor.capture()));
+      StoragePartitionConfig storagePartitionConfigParam = storagePartitionConfigArgumentCaptor.getValue();
+      assertEquals(storagePartitionConfigParam.getPartitionId(), PARTITION_FOO);
+      assertFalse(storagePartitionConfigParam.isWriteOnlyConfig());
+      assertFalse(storagePartitionConfigParam.isReadOnly());
+      assertFalse(storagePartitionConfigParam.isDeferredWrite());
+      assertFalse(storagePartitionConfigParam.isReadWriteLeaderForDefaultCF());
+      assertFalse(storagePartitionConfigParam.isReadWriteLeaderForRMDCF());
     }, aaConfig);
   }
 
@@ -1607,7 +1616,7 @@ public abstract class StoreIngestionTaskTest {
     new StoragePartitionConfig(topic, PARTITION_FOO);
 
     runTest(Utils.setOf(PARTITION_FOO), () -> {
-      verify(mockAbstractStorageEngine, never()).preparePartitionForReading(PARTITION_FOO);
+      verify(mockAbstractStorageEngine, never()).adjustStoragePartition(eq(PARTITION_FOO), eq(PREPARE_FOR_READ), any());
     }, aaConfig);
   }
 
@@ -1627,8 +1636,9 @@ public abstract class StoreIngestionTaskTest {
     new StoragePartitionConfig(topic, PARTITION_BAR);
 
     runTest(Utils.setOf(PARTITION_FOO), () -> {
-      verify(mockAbstractStorageEngine, never()).preparePartitionForReading(PARTITION_FOO);
-      verify(mockAbstractStorageEngine, never()).preparePartitionForReading(PARTITION_BAR);
+      verify(mockAbstractStorageEngine, never()).adjustStoragePartition(eq(PARTITION_FOO), eq(PREPARE_FOR_READ), any());
+      verify(mockAbstractStorageEngine, never()).adjustStoragePartition(eq(PARTITION_BAR), eq(PREPARE_FOR_READ), any());
+
     }, aaConfig);
   }
 

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/store/AbstractStorageEngineTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/store/AbstractStorageEngineTest.java
@@ -218,7 +218,7 @@ public abstract class AbstractStorageEngineTest extends AbstractStoreTest {
         partitionConfig);
   }
 
-  @Test
+  @Test(expectedExceptions = VeniceException.class)
   public void testAdjustStoragePartitionWithUnknownPartitionId() {
     String storeName = testStoreEngine.getStoreVersionName();
     int unknownPartitionId = partitionId + 10000;

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/store/AbstractStorageEngineTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/store/AbstractStorageEngineTest.java
@@ -212,15 +212,21 @@ public abstract class AbstractStorageEngineTest extends AbstractStoreTest {
     String storeName = Utils.getUniqueString("dummy_store_name");
     int partitionId = 1;
     StoragePartitionConfig partitionConfig = new StoragePartitionConfig(storeName, partitionId);
-    testStoreEngine.adjustStoragePartition(partitionConfig);
+    testStoreEngine.adjustStoragePartition(
+        partitionId,
+        AbstractStorageEngine.StoragePartitionAdjustmentTrigger.BEGIN_BATCH_PUSH,
+        partitionConfig);
   }
 
-  @Test(expectedExceptions = VeniceException.class)
+  @Test
   public void testAdjustStoragePartitionWithUnknownPartitionId() {
     String storeName = testStoreEngine.getStoreVersionName();
     int unknownPartitionId = partitionId + 10000;
     StoragePartitionConfig partitionConfig = new StoragePartitionConfig(storeName, unknownPartitionId);
-    testStoreEngine.adjustStoragePartition(partitionConfig);
+    testStoreEngine.adjustStoragePartition(
+        unknownPartitionId,
+        AbstractStorageEngine.StoragePartitionAdjustmentTrigger.BEGIN_BATCH_PUSH,
+        partitionConfig);
   }
 
   @Test
@@ -237,7 +243,10 @@ public abstract class AbstractStorageEngineTest extends AbstractStoreTest {
     Assert.assertTrue(storagePartition.verifyConfig(transactionalPartitionConfig));
     Assert.assertFalse(storagePartition.verifyConfig(deferredWritePartitionConfig));
 
-    testStoreEngine.adjustStoragePartition(deferredWritePartitionConfig);
+    testStoreEngine.adjustStoragePartition(
+        newPartitionId,
+        AbstractStorageEngine.StoragePartitionAdjustmentTrigger.BEGIN_BATCH_PUSH,
+        deferredWritePartitionConfig);
 
     storagePartition = testStoreEngine.getPartitionOrThrow(newPartitionId);
     Assert.assertNotNull(storagePartition);
@@ -261,7 +270,10 @@ public abstract class AbstractStorageEngineTest extends AbstractStoreTest {
     Assert.assertFalse(storagePartition.verifyConfig(transactionalPartitionConfig));
     Assert.assertTrue(storagePartition.verifyConfig(deferredWritePartitionConfig));
 
-    testStoreEngine.adjustStoragePartition(transactionalPartitionConfig);
+    testStoreEngine.adjustStoragePartition(
+        newPartitionId,
+        AbstractStorageEngine.StoragePartitionAdjustmentTrigger.END_BATCH_PUSH,
+        transactionalPartitionConfig);
 
     storagePartition = testStoreEngine.getPartitionOrThrow(newPartitionId);
     Assert.assertNotNull(storagePartition);

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/store/rocksdb/RocksDBStoragePartitionTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/store/rocksdb/RocksDBStoragePartitionTest.java
@@ -1,20 +1,13 @@
 package com.linkedin.davinci.store.rocksdb;
 
-import static com.linkedin.davinci.store.rocksdb.RocksDBServerConfig.ROCKSDB_BLOCK_CACHE_IMPLEMENTATION;
-import static com.linkedin.davinci.store.rocksdb.RocksDBServerConfig.ROCKSDB_LEVEL0_FILE_NUM_COMPACTION_TRIGGER;
-import static com.linkedin.davinci.store.rocksdb.RocksDBServerConfig.ROCKSDB_LEVEL0_FILE_NUM_COMPACTION_TRIGGER_WRITE_ONLY_VERSION;
-import static com.linkedin.davinci.store.rocksdb.RocksDBServerConfig.ROCKSDB_LEVEL0_SLOWDOWN_WRITES_TRIGGER;
-import static com.linkedin.davinci.store.rocksdb.RocksDBServerConfig.ROCKSDB_LEVEL0_SLOWDOWN_WRITES_TRIGGER_WRITE_ONLY_VERSION;
-import static com.linkedin.davinci.store.rocksdb.RocksDBServerConfig.ROCKSDB_LEVEL0_STOPS_WRITES_TRIGGER;
-import static com.linkedin.davinci.store.rocksdb.RocksDBServerConfig.ROCKSDB_LEVEL0_STOPS_WRITES_TRIGGER_WRITE_ONLY_VERSION;
-import static com.linkedin.davinci.store.rocksdb.RocksDBServerConfig.ROCKSDB_MAX_MEMTABLE_COUNT;
-import static com.linkedin.davinci.store.rocksdb.RocksDBServerConfig.ROCKSDB_MEMTABLE_SIZE_IN_BYTES;
-import static com.linkedin.davinci.store.rocksdb.RocksDBServerConfig.ROCKSDB_PLAIN_TABLE_FORMAT_ENABLED;
-import static com.linkedin.davinci.store.rocksdb.RocksDBServerConfig.ROCKSDB_TOTAL_MEMTABLE_USAGE_CAP_IN_BYTES;
+import static com.linkedin.davinci.store.rocksdb.RocksDBServerConfig.*;
 import static com.linkedin.venice.ConfigKeys.INGESTION_MEMORY_LIMIT;
 import static com.linkedin.venice.ConfigKeys.INGESTION_USE_DA_VINCI_CLIENT;
 import static com.linkedin.venice.ConfigKeys.PERSISTENCE_TYPE;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.testng.Assert.assertTrue;
+import static org.testng.AssertJUnit.assertFalse;
 
 import com.linkedin.davinci.config.VeniceServerConfig;
 import com.linkedin.davinci.config.VeniceStoreVersionConfig;
@@ -175,9 +168,7 @@ public class RocksDBStoragePartitionTest {
               checkpointingInfo.get(RocksDBSstFileWriter.ROCKSDB_LAST_FINISHED_SST_FILE_NO),
               String.valueOf(currentFileNo++));
         } else {
-          Assert.assertTrue(
-              checkpointingInfo.isEmpty(),
-              "For non-deferred-write database, sync() should return empty map");
+          assertTrue(checkpointingInfo.isEmpty(), "For non-deferred-write database, sync() should return empty map");
         }
       }
       if (interrupted) {
@@ -227,7 +218,7 @@ public class RocksDBStoragePartitionTest {
     if (sorted) {
       Assert.assertFalse(storagePartition.validateBatchIngestion());
       storagePartition.endBatchWrite();
-      Assert.assertTrue(storagePartition.validateBatchIngestion());
+      assertTrue(storagePartition.validateBatchIngestion());
     }
 
     // Verify all the key/value pairs
@@ -236,7 +227,7 @@ public class RocksDBStoragePartitionTest {
     }
 
     // Verify current ingestion mode is in deferred-write mode
-    Assert.assertTrue(storagePartition.verifyConfig(partitionConfig));
+    assertTrue(storagePartition.verifyConfig(partitionConfig));
 
     // Re-open it in read/write mode
     storagePartition.close();
@@ -257,7 +248,7 @@ public class RocksDBStoragePartitionTest {
     storagePartition.delete(toBeDeletedKey.getBytes());
     Assert.assertNull(storagePartition.get(toBeDeletedKey.getBytes()));
 
-    Assert.assertTrue(storagePartition.getPartitionSizeInBytes() > 0);
+    assertTrue(storagePartition.getPartitionSizeInBytes() > 0);
 
     Options storeOptions = storagePartition.getOptions();
     Assert.assertEquals(storeOptions.level0FileNumCompactionTrigger(), 40);
@@ -316,9 +307,7 @@ public class RocksDBStoragePartitionTest {
               checkpointingInfo.get(RocksDBSstFileWriter.ROCKSDB_LAST_FINISHED_SST_FILE_NO),
               String.valueOf(currentFileNo++));
         } else {
-          Assert.assertTrue(
-              checkpointingInfo.isEmpty(),
-              "For non-deferred-write database, sync() should return empty map");
+          assertTrue(checkpointingInfo.isEmpty(), "For non-deferred-write database, sync() should return empty map");
         }
       }
       if (currentRecordNum == interruptedRecord1 || currentRecordNum == interruptedRecord2) {
@@ -362,7 +351,7 @@ public class RocksDBStoragePartitionTest {
     if (sorted) {
       Assert.assertFalse(storagePartition.validateBatchIngestion());
       storagePartition.endBatchWrite();
-      Assert.assertTrue(storagePartition.validateBatchIngestion());
+      assertTrue(storagePartition.validateBatchIngestion());
     }
 
     // Verify all the key/value pairs
@@ -371,7 +360,7 @@ public class RocksDBStoragePartitionTest {
     }
 
     // Verify current ingestion mode is in deferred-write mode
-    Assert.assertTrue(storagePartition.verifyConfig(partitionConfig));
+    assertTrue(storagePartition.verifyConfig(partitionConfig));
 
     storagePartition.rocksDB.compactRange();
     // Re-open it in read/write mode
@@ -417,7 +406,7 @@ public class RocksDBStoragePartitionTest {
           ByteUtils.copyByteArray(storagePartition.multiGet(keys, byteBufferList).get(0)),
           entry.getValue().getBytes());
       // test it again with the internally enlarged buffer
-      Assert.assertTrue(byteBufferList.get(0).capacity() > 1);
+      assertTrue(byteBufferList.get(0).capacity() > 1);
       Assert.assertEquals(
           ByteUtils.copyByteArray(storagePartition.multiGet(keys, byteBufferList).get(0)),
           entry.getValue().getBytes());
@@ -503,9 +492,7 @@ public class RocksDBStoragePartitionTest {
               checkpointingInfo.get(RocksDBSstFileWriter.ROCKSDB_LAST_FINISHED_SST_FILE_NO),
               String.valueOf(currentFileNo++));
         } else {
-          Assert.assertTrue(
-              checkpointingInfo.isEmpty(),
-              "For non-deferred-write database, sync() should return empty map");
+          assertTrue(checkpointingInfo.isEmpty(), "For non-deferred-write database, sync() should return empty map");
         }
       }
       if (interrupted) {
@@ -554,7 +541,7 @@ public class RocksDBStoragePartitionTest {
     if (sorted) {
       Assert.assertFalse(storagePartition.validateBatchIngestion());
       storagePartition.endBatchWrite();
-      Assert.assertTrue(storagePartition.validateBatchIngestion());
+      assertTrue(storagePartition.validateBatchIngestion());
     }
 
     // Verify all the key/value pairs
@@ -563,7 +550,7 @@ public class RocksDBStoragePartitionTest {
     }
 
     // Verify current ingestion mode is in deferred-write mode
-    Assert.assertTrue(storagePartition.verifyConfig(partitionConfig));
+    assertTrue(storagePartition.verifyConfig(partitionConfig));
 
     // Re-open it in read/write mode
     storagePartition.close();
@@ -620,7 +607,7 @@ public class RocksDBStoragePartitionTest {
       storagePartition.put(entry.getKey().getBytes(), entry.getValue().getBytes());
     }
     VeniceException ex = Assert.expectThrows(VeniceException.class, storagePartition::endBatchWrite);
-    Assert.assertTrue(ex.getMessage().contains("last sstFile checksum didn't match for store"));
+    assertTrue(ex.getMessage().contains("last sstFile checksum didn't match for store"));
 
     storagePartition.drop();
     removeDir(storeDir);
@@ -653,7 +640,7 @@ public class RocksDBStoragePartitionTest {
       storagePartition.get((KEY_PREFIX + "10").getBytes());
       Assert.fail("VeniceException is expected when looking up an already closed DB");
     } catch (VeniceException e) {
-      Assert.assertTrue(e.getMessage().contains("RocksDB has been closed for store"));
+      assertTrue(e.getMessage().contains("RocksDB has been closed for store"));
     }
 
     storagePartition.drop();
@@ -661,7 +648,80 @@ public class RocksDBStoragePartitionTest {
   }
 
   @Test
-  public void testPlainTableCompactionTriggerSetting() {
+  public void testVerifyConfig() {
+    String storeName = Version.composeKafkaTopic(Utils.getUniqueString("test_store"), 1);
+    String storeDir = getTempDatabaseDir(storeName);
+    Properties properties = new Properties();
+    properties.put(PERSISTENCE_TYPE, PersistenceType.ROCKS_DB.toString());
+    properties.put(ROCKSDB_LEVEL0_COMPACTION_TUNING_FOR_READ_WRITE_LEADER_ENABLED, "true");
+
+    VeniceProperties veniceServerProperties =
+        AbstractStorageEngineTest.getServerProperties(PersistenceType.ROCKS_DB, properties);
+    RocksDBServerConfig rocksDBServerConfig =
+        new RocksDBServerConfig(AbstractStorageEngineTest.getServerProperties(PersistenceType.ROCKS_DB, properties));
+    int partitionId = 0;
+    StoragePartitionConfig partitionConfig = new StoragePartitionConfig(storeName, partitionId);
+    partitionConfig.setWriteOnlyConfig(true);
+    VeniceServerConfig serverConfig = new VeniceServerConfig(veniceServerProperties);
+    RocksDBStorageEngineFactory factory = new RocksDBStorageEngineFactory(serverConfig);
+    VeniceStoreVersionConfig storeConfig = new VeniceStoreVersionConfig(storeName, veniceServerProperties);
+    RocksDBStoragePartition storagePartition = new RocksDBStoragePartition(
+        partitionConfig,
+        factory,
+        DATA_BASE_DIR,
+        null,
+        ROCKSDB_THROTTLER,
+        rocksDBServerConfig,
+        storeConfig);
+
+    StoragePartitionConfig testConfig = new StoragePartitionConfig(storeName, partitionId);
+    testConfig.setReadWriteLeaderForRMDCF(true);
+    assertFalse(storagePartition.verifyConfig(testConfig));
+
+    testConfig = new StoragePartitionConfig(storeName, partitionId);
+    testConfig.setReadWriteLeaderForDefaultCF(true);
+    assertFalse(storagePartition.verifyConfig(testConfig));
+
+    testConfig = new StoragePartitionConfig(storeName, partitionId);
+    assertTrue(storagePartition.verifyConfig(testConfig));
+    storagePartition.drop();
+
+    // Create a new storage partition with read-write leader tuning disabled.
+    properties = new Properties();
+    properties.put(PERSISTENCE_TYPE, PersistenceType.ROCKS_DB.toString());
+    properties.put(ROCKSDB_LEVEL0_COMPACTION_TUNING_FOR_READ_WRITE_LEADER_ENABLED, "false");
+    veniceServerProperties = AbstractStorageEngineTest.getServerProperties(PersistenceType.ROCKS_DB, properties);
+    rocksDBServerConfig =
+        new RocksDBServerConfig(AbstractStorageEngineTest.getServerProperties(PersistenceType.ROCKS_DB, properties));
+    serverConfig = new VeniceServerConfig(veniceServerProperties);
+    factory = new RocksDBStorageEngineFactory(serverConfig);
+    storeConfig = new VeniceStoreVersionConfig(storeName, veniceServerProperties);
+    storagePartition = new RocksDBStoragePartition(
+        partitionConfig,
+        factory,
+        DATA_BASE_DIR,
+        null,
+        ROCKSDB_THROTTLER,
+        rocksDBServerConfig,
+        storeConfig);
+
+    testConfig = new StoragePartitionConfig(storeName, partitionId);
+    testConfig.setReadWriteLeaderForRMDCF(true);
+    assertTrue(storagePartition.verifyConfig(testConfig));
+
+    testConfig = new StoragePartitionConfig(storeName, partitionId);
+    testConfig.setReadWriteLeaderForDefaultCF(true);
+    assertTrue(storagePartition.verifyConfig(testConfig));
+
+    testConfig = new StoragePartitionConfig(storeName, partitionId);
+    assertTrue(storagePartition.verifyConfig(testConfig));
+
+    storagePartition.drop();
+    removeDir(storeDir);
+  }
+
+  @Test
+  public void testCompactionTriggerSetting() {
     String storeName = Version.composeKafkaTopic(Utils.getUniqueString("test_store"), 1);
     String storeDir = getTempDatabaseDir(storeName);
     Properties properties = new Properties();
@@ -673,6 +733,10 @@ public class RocksDBStoragePartitionTest {
     properties.put(ROCKSDB_LEVEL0_FILE_NUM_COMPACTION_TRIGGER_WRITE_ONLY_VERSION, 40);
     properties.put(ROCKSDB_LEVEL0_SLOWDOWN_WRITES_TRIGGER_WRITE_ONLY_VERSION, 50);
     properties.put(ROCKSDB_LEVEL0_STOPS_WRITES_TRIGGER_WRITE_ONLY_VERSION, 60);
+    properties.put(ROCKSDB_LEVEL0_COMPACTION_TUNING_FOR_READ_WRITE_LEADER_ENABLED, "true");
+    properties.put(ROCKSDB_LEVEL0_FILE_NUM_COMPACTION_TRIGGER_FOR_READ_WRITE_LEADER, 1);
+    properties.put(ROCKSDB_LEVEL0_SLOWDOWN_WRITES_TRIGGER_FOR_READ_WRITE_LEADER, 2);
+    properties.put(ROCKSDB_LEVEL0_STOPS_WRITES_TRIGGER_FOR_READ_WRITE_LEADER, 4);
     VeniceProperties veniceServerProperties =
         AbstractStorageEngineTest.getServerProperties(PersistenceType.ROCKS_DB, properties);
     RocksDBServerConfig rocksDBServerConfig = new RocksDBServerConfig(veniceServerProperties);
@@ -717,6 +781,34 @@ public class RocksDBStoragePartitionTest {
     Assert.assertEquals(readWriteOptions.level0SlowdownWritesTrigger(), 20);
     Assert.assertEquals(readWriteOptions.level0StopWritesTrigger(), 30);
 
+    // Check compaction setting with read-write leader
+    StoragePartitionConfig storagePartitionConfig = new StoragePartitionConfig(storeName, partitionId);
+    storagePartitionConfig.setReadWriteLeaderForDefaultCF(true);
+    storagePartitionConfig.setReadWriteLeaderForRMDCF(false);
+    // Verify default CF
+    Options readWriterLeaderForDefaultCF = storagePartition.getStoreOptions(storagePartitionConfig, false);
+    Assert.assertEquals(readWriterLeaderForDefaultCF.level0FileNumCompactionTrigger(), 1);
+    Assert.assertEquals(readWriterLeaderForDefaultCF.level0SlowdownWritesTrigger(), 2);
+    Assert.assertEquals(readWriterLeaderForDefaultCF.level0StopWritesTrigger(), 4);
+    // Verify RMD CF
+    Options readWriterLeaderForRMDCF = storagePartition.getStoreOptions(storagePartitionConfig, true);
+    Assert.assertEquals(readWriterLeaderForRMDCF.level0FileNumCompactionTrigger(), 40);
+    Assert.assertEquals(readWriterLeaderForRMDCF.level0SlowdownWritesTrigger(), 50);
+    Assert.assertEquals(readWriterLeaderForRMDCF.level0StopWritesTrigger(), 60);
+
+    storagePartitionConfig.setReadWriteLeaderForDefaultCF(false);
+    storagePartitionConfig.setReadWriteLeaderForRMDCF(true);
+    // Verify default CF
+    readWriterLeaderForDefaultCF = storagePartition.getStoreOptions(storagePartitionConfig, false);
+    Assert.assertEquals(readWriterLeaderForDefaultCF.level0FileNumCompactionTrigger(), 40);
+    Assert.assertEquals(readWriterLeaderForDefaultCF.level0SlowdownWritesTrigger(), 50);
+    Assert.assertEquals(readWriterLeaderForDefaultCF.level0StopWritesTrigger(), 60);
+    // Verify RMD CF
+    readWriterLeaderForRMDCF = storagePartition.getStoreOptions(storagePartitionConfig, true);
+    Assert.assertEquals(readWriterLeaderForRMDCF.level0FileNumCompactionTrigger(), 1);
+    Assert.assertEquals(readWriterLeaderForRMDCF.level0SlowdownWritesTrigger(), 2);
+    Assert.assertEquals(readWriterLeaderForRMDCF.level0StopWritesTrigger(), 4);
+
     storagePartition.drop();
     removeDir(storeDir);
   }
@@ -742,7 +834,7 @@ public class RocksDBStoragePartitionTest {
       int partitionId = 0;
       StoragePartitionConfig partitionConfig = new StoragePartitionConfig(storeName, partitionId);
 
-      RocksDBMemoryStats mockMemoryStats = Mockito.mock(RocksDBMemoryStats.class);
+      RocksDBMemoryStats mockMemoryStats = mock(RocksDBMemoryStats.class);
       VeniceServerConfig serverConfig = new VeniceServerConfig(veniceServerProperties);
       VeniceStoreVersionConfig storeConfig = new VeniceStoreVersionConfig(storeName, veniceServerProperties);
       RocksDBStorageEngineFactory factory = new RocksDBStorageEngineFactory(

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestActiveActiveIngestion.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestActiveActiveIngestion.java
@@ -1,5 +1,6 @@
 package com.linkedin.venice.endToEnd;
 
+import static com.linkedin.davinci.store.rocksdb.RocksDBServerConfig.ROCKSDB_LEVEL0_COMPACTION_TUNING_FOR_READ_WRITE_LEADER_ENABLED;
 import static com.linkedin.davinci.store.rocksdb.RocksDBServerConfig.ROCKSDB_PLAIN_TABLE_FORMAT_ENABLED;
 import static com.linkedin.venice.ConfigKeys.*;
 import static com.linkedin.venice.hadoop.VenicePushJobConstants.DEFAULT_KEY_FIELD_PROP;
@@ -89,6 +90,10 @@ public class TestActiveActiveIngestion {
   private AvroSerializer serializer;
   private ControllerClient parentControllerClient;
 
+  protected boolean isLevel0CompactionTuningForReadWriteLeaderEnabled() {
+    return false;
+  }
+
   @BeforeClass(alwaysRun = true)
   public void setUp() {
     serializer = new AvroSerializer(STRING_SCHEMA);
@@ -96,6 +101,9 @@ public class TestActiveActiveIngestion {
     serverProperties.setProperty(ConfigKeys.SERVER_PROMOTION_TO_LEADER_REPLICA_DELAY_SECONDS, Long.toString(1));
     serverProperties.put(ROCKSDB_PLAIN_TABLE_FORMAT_ENABLED, false);
     serverProperties.put(SERVER_DEDICATED_DRAINER_FOR_SORTED_INPUT_ENABLED, true);
+    serverProperties.put(
+        ROCKSDB_LEVEL0_COMPACTION_TUNING_FOR_READ_WRITE_LEADER_ENABLED,
+        isLevel0CompactionTuningForReadWriteLeaderEnabled());
     serverProperties.put(
         CHILD_DATA_CENTER_KAFKA_URL_PREFIX + "." + DEFAULT_PARENT_DATA_CENTER_REGION_NAME,
         "localhost:" + TestUtils.getFreePort());

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestActiveActiveIngestionWithReadWriteLeaderCompactionTuning.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestActiveActiveIngestionWithReadWriteLeaderCompactionTuning.java
@@ -1,0 +1,11 @@
+package com.linkedin.venice.endToEnd;
+
+/**
+ * Integration test to verify active/active replication when applying read-write leader compaction optimization.
+ */
+public class TestActiveActiveIngestionWithReadWriteLeaderCompactionTuning extends TestActiveActiveIngestion {
+  @Override
+  protected boolean isLevel0CompactionTuningForReadWriteLeaderEnabled() {
+    return true;
+  }
+}


### PR DESCRIPTION
In the ingestion path, we often tune level0 compaction to optimize read/write/space optimization.
When AA/WC is enabled, the leader replica will read the same database while ingesting, which is different from standby replicas. To optimize the read perf of leader replica, this PR exposes the following config:
rocksdb.level0.compaction.tuning.for.read.write.leader.enabled: default false rocksdb.level0.file.num.compaction.trigger.for.read.write.leader: default 10 rocksdb.level0.slowdown.writes.trigger.for.read.write.leader: default 20 rocksdb.level0.stops.writes.trigger.for.read.write.leader: default 40

Essentially, there are 3 sets of level0 compaction tunings:
1. Leader replicas for AA/WC stores.
2. Future version.
3. Current version.

The main reason we would like to only optimize the leader replica for AA/WC stores:
1. Standby replicas don't read at ingestion path.
2. Try to keep the write/space amplication factor for standby replicas as more aggressive level0 compaction tuning is expensive.

<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->


<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->



## How was this PR tested?
CI
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.