### PR TITLE
[test] Fix for cross-test interrupt contamination

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -413,7 +413,7 @@ subprojects {
 
     useTestNG {
       excludeGroups 'flaky'
-      listeners = ['com.linkedin.venice.testng.VeniceSuiteListener']
+      listeners = ['com.linkedin.venice.testng.VeniceSuiteListener', 'com.linkedin.venice.testng.VeniceTestListener']
     }
 
     retry {

--- a/internal/venice-test-common/src/main/java/com/linkedin/venice/testng/VeniceTestListener.java
+++ b/internal/venice-test-common/src/main/java/com/linkedin/venice/testng/VeniceTestListener.java
@@ -12,6 +12,8 @@ public class VeniceTestListener extends TestListenerAdapter {
   @Override
   public void onTestStart(ITestResult result) {
     super.onTestStart(result);
+
+    /** N.B.: {@link Thread#interrupted()} not only retrieves, but also clears, the interrupt flag */
     boolean interruptCleared = Thread.interrupted();
     LOGGER.info(
         "\n\n######## TEST ######## {}({}){} - STARTED",

--- a/internal/venice-test-common/src/main/java/com/linkedin/venice/testng/VeniceTestListener.java
+++ b/internal/venice-test-common/src/main/java/com/linkedin/venice/testng/VeniceTestListener.java
@@ -11,14 +11,18 @@ public class VeniceTestListener extends TestListenerAdapter {
 
   @Override
   public void onTestStart(ITestResult result) {
+    super.onTestStart(result);
+    boolean interruptCleared = Thread.interrupted();
     LOGGER.info(
-        "\n\n######## TEST ######## {}({}) - STARTED",
+        "\n\n######## TEST ######## {}({}){} - STARTED",
         result.getMethod().getQualifiedName(),
-        result.getParameters());
+        result.getParameters(),
+        interruptCleared ? " (interrupt cleared)" : "");
   }
 
   @Override
   public void onTestSuccess(ITestResult result) {
+    super.onTestSuccess(result);
     LOGGER.info(
         "######## TEST ######## {}({}) - PASSED\n\n",
         result.getMethod().getQualifiedName(),
@@ -27,6 +31,7 @@ public class VeniceTestListener extends TestListenerAdapter {
 
   @Override
   public void onTestFailure(ITestResult result) {
+    super.onTestFailure(result);
     LOGGER.info(
         "######## TEST ######## {}({}) - FAILED\n\n",
         result.getMethod().getQualifiedName(),
@@ -35,6 +40,7 @@ public class VeniceTestListener extends TestListenerAdapter {
 
   @Override
   public void onTestSkipped(ITestResult result) {
+    super.onTestSkipped(result);
     LOGGER.info(
         "######## TEST ######## {}({}) - SKIPPED\n\n",
         result.getMethod().getQualifiedName(),
@@ -43,6 +49,7 @@ public class VeniceTestListener extends TestListenerAdapter {
 
   @Override
   public void onTestFailedButWithinSuccessPercentage(ITestResult result) {
+    super.onTestFailedButWithinSuccessPercentage(result);
     LOGGER.info(
         "######## TEST ######## {}({}) - FLAKY\n\n",
         result.getMethod().getQualifiedName(),

--- a/internal/venice-test-common/src/test/java/com/linkedin/venice/testng/TestInterruptContaminationClearing.java
+++ b/internal/venice-test-common/src/test/java/com/linkedin/venice/testng/TestInterruptContaminationClearing.java
@@ -9,6 +9,8 @@ import org.testng.annotations.Test;
  * to all unit and integration tests which clears the interrupt state:
  *
  * {@link com.linkedin.venice.testng.VeniceTestListener#onTestStart(ITestResult)}
+ *
+ * N.B.: The naming of the tests is important, as they get executed in lexicographical order.
  */
 public class TestInterruptContaminationClearing {
   @Test

--- a/internal/venice-test-common/src/test/java/com/linkedin/venice/testng/TestInterruptContaminationClearing.java
+++ b/internal/venice-test-common/src/test/java/com/linkedin/venice/testng/TestInterruptContaminationClearing.java
@@ -1,0 +1,23 @@
+package com.linkedin.venice.testng;
+
+import org.testng.ITestResult;
+import org.testng.annotations.Test;
+
+
+/**
+ * This test class reproduces an issue of interrupt contamination across tests. This issue is fixed by a listener added
+ * to all unit and integration tests which clears the interrupt state:
+ *
+ * {@link com.linkedin.venice.testng.VeniceTestListener#onTestStart(ITestResult)}
+ */
+public class TestInterruptContaminationClearing {
+  @Test
+  void test1() {
+    Thread.currentThread().interrupt();
+  }
+
+  @Test
+  void test2() throws InterruptedException {
+    Thread.sleep(1000);
+  }
+}


### PR DESCRIPTION
There is an issue either in Gradle or TestNG where a test which sets the interrupt flag on the current thread can cause a later test to fail, due to checking for the interrupt flag (e.g. in sleep and syncrhonization-related primitives).

This commit fixes this by clearing the interrupt flag via the VeniceTestListener::onTestStart listener. Also registered this listener to unit tests (it was previously used only for integ tests), and added a minimal unit test which deterministically reproduces this issue (in the absence of the listener).

Miscellaneous:

- Added calls to super in all functions of VeniceTestListener, as recommended in the parent class' JavaDoc.

## How was this PR tested?
GHCI, including a new test.

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.