### PR TITLE
[internal][client] Support GRPC port discovery for non-local environment

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -110,7 +110,7 @@ ext.libraries = [
     mail: 'javax.mail:mail:1.4.4',
     mapreduceClientCore: "org.apache.hadoop:hadoop-mapreduce-client-core:${hadoopVersion}",
     mapreduceClientJobClient: "org.apache.hadoop:hadoop-mapreduce-client-jobclient:${hadoopVersion}",
-    mockito: 'org.mockito:mockito-inline:4.11.0',
+    mockito: 'org.mockito:mockito-core:5.2.0',
     netty: 'io.netty:netty-all:4.1.74.Final',
     oss: 'org.sonatype.oss:oss-parent:7',
     pulsarClient: "${pulsarGroup}:pulsar-client:${pulsarVersion}",

--- a/build.gradle
+++ b/build.gradle
@@ -110,7 +110,7 @@ ext.libraries = [
     mail: 'javax.mail:mail:1.4.4',
     mapreduceClientCore: "org.apache.hadoop:hadoop-mapreduce-client-core:${hadoopVersion}",
     mapreduceClientJobClient: "org.apache.hadoop:hadoop-mapreduce-client-jobclient:${hadoopVersion}",
-    mockito: 'org.mockito:mockito-core:4.11.0',
+    mockito: 'org.mockito:mockito-inline:4.11.0',
     netty: 'io.netty:netty-all:4.1.74.Final',
     oss: 'org.sonatype.oss:oss-parent:7',
     pulsarClient: "${pulsarGroup}:pulsar-client:${pulsarVersion}",

--- a/build.gradle
+++ b/build.gradle
@@ -110,7 +110,7 @@ ext.libraries = [
     mail: 'javax.mail:mail:1.4.4',
     mapreduceClientCore: "org.apache.hadoop:hadoop-mapreduce-client-core:${hadoopVersion}",
     mapreduceClientJobClient: "org.apache.hadoop:hadoop-mapreduce-client-jobclient:${hadoopVersion}",
-    mockito: 'org.mockito:mockito-core:5.2.0',
+    mockito: 'org.mockito:mockito-core:4.11.0',
     netty: 'io.netty:netty-all:4.1.74.Final',
     oss: 'org.sonatype.oss:oss-parent:7',
     pulsarClient: "${pulsarGroup}:pulsar-client:${pulsarVersion}",

--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/GrpcClientConfig.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/GrpcClientConfig.java
@@ -9,6 +9,8 @@ import java.util.Map;
 public class GrpcClientConfig {
   // Use r2Client for non-storage related requests (not implemented in gRPC yet)
   private final Client r2Client;
+
+  private final int port;
   // require a map from netty server to grpc address due to lack of gRPC service discovery
   private final Map<String, String> nettyServerToGrpcAddress;
   // SSL Factory required if using SSL
@@ -16,12 +18,17 @@ public class GrpcClientConfig {
 
   GrpcClientConfig(Builder builder) {
     this.r2Client = builder.r2Client;
+    this.port = builder.port;
     this.nettyServerToGrpcAddress = builder.nettyServerToGrpcAddress;
     this.sslFactory = builder.sslFactory;
   }
 
   public Client getR2Client() {
     return r2Client;
+  }
+
+  public int getPort() {
+    return this.port;
   }
 
   public Map<String, String> getNettyServerToGrpcAddress() {
@@ -34,11 +41,18 @@ public class GrpcClientConfig {
 
   public static class Builder {
     private Client r2Client = null;
+
+    private int port;
     private Map<String, String> nettyServerToGrpcAddress = null;
     private SSLFactory sslFactory = null;
 
     public Builder setR2Client(Client r2Client) {
       this.r2Client = r2Client;
+      return this;
+    }
+
+    public Builder setPort(int port) {
+      this.port = port;
       return this;
     }
 
@@ -55,6 +69,7 @@ public class GrpcClientConfig {
     public GrpcClientConfig build() {
       Preconditions.checkNotNull(r2Client);
       Preconditions.checkNotNull(nettyServerToGrpcAddress);
+      Preconditions.checkState(port != -1 || nettyServerToGrpcAddress.isEmpty());
       return new GrpcClientConfig(this);
     }
   }

--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/GrpcClientConfig.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/GrpcClientConfig.java
@@ -69,7 +69,7 @@ public class GrpcClientConfig {
     public GrpcClientConfig build() {
       Preconditions.checkNotNull(r2Client);
       Preconditions.checkNotNull(nettyServerToGrpcAddress);
-      Preconditions.checkState(port != -1 || nettyServerToGrpcAddress.isEmpty());
+      Preconditions.checkState(port != 0 || !nettyServerToGrpcAddress.isEmpty());
       return new GrpcClientConfig(this);
     }
   }

--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/GrpcClientConfig.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/GrpcClientConfig.java
@@ -1,5 +1,6 @@
 package com.linkedin.venice.fastclient;
 
+import com.google.common.base.Preconditions;
 import com.linkedin.r2.transport.common.Client;
 import com.linkedin.venice.security.SSLFactory;
 import java.util.Map;
@@ -9,13 +10,13 @@ public class GrpcClientConfig {
   // Use r2Client for non-storage related requests (not implemented in gRPC yet)
   private final Client r2Client;
   // require a map from netty server to grpc address due to lack of gRPC service discovery
-  private final Map<String, String> nettyServerToGrpcAddressMap;
+  private final Map<String, String> nettyServerToGrpcAddress;
   // SSL Factory required if using SSL
   private final SSLFactory sslFactory;
 
-  public GrpcClientConfig(Builder builder) {
+  GrpcClientConfig(Builder builder) {
     this.r2Client = builder.r2Client;
-    this.nettyServerToGrpcAddressMap = builder.nettyServerToGrpcAddressMap;
+    this.nettyServerToGrpcAddress = builder.nettyServerToGrpcAddress;
     this.sslFactory = builder.sslFactory;
   }
 
@@ -23,8 +24,8 @@ public class GrpcClientConfig {
     return r2Client;
   }
 
-  public Map<String, String> getNettyServerToGrpcAddressMap() {
-    return nettyServerToGrpcAddressMap;
+  public Map<String, String> getNettyServerToGrpcAddress() {
+    return nettyServerToGrpcAddress;
   }
 
   public SSLFactory getSslFactory() {
@@ -33,7 +34,7 @@ public class GrpcClientConfig {
 
   public static class Builder {
     private Client r2Client = null;
-    private Map<String, String> nettyServerToGrpcAddressMap = null;
+    private Map<String, String> nettyServerToGrpcAddress = null;
     private SSLFactory sslFactory = null;
 
     public Builder setR2Client(Client r2Client) {
@@ -41,8 +42,8 @@ public class GrpcClientConfig {
       return this;
     }
 
-    public Builder setNettyServerToGrpcAddressMap(Map<String, String> nettyServerToGrpcAddressMap) {
-      this.nettyServerToGrpcAddressMap = nettyServerToGrpcAddressMap;
+    public Builder setNettyServerToGrpcAddress(Map<String, String> nettyServerToGrpcAddress) {
+      this.nettyServerToGrpcAddress = nettyServerToGrpcAddress;
       return this;
     }
 
@@ -52,20 +53,9 @@ public class GrpcClientConfig {
     }
 
     public GrpcClientConfig build() {
-      verify();
+      Preconditions.checkNotNull(r2Client);
+      Preconditions.checkNotNull(nettyServerToGrpcAddress);
       return new GrpcClientConfig(this);
-    }
-
-    private void verify() {
-      if (r2Client == null) {
-        throw new IllegalArgumentException("R2 client must be set when enabling gRPC on FC");
-      }
-      if (nettyServerToGrpcAddressMap == null) {
-        throw new IllegalArgumentException("Netty server to grpc address map must be set");
-      }
-      if (nettyServerToGrpcAddressMap.size() == 0) {
-        throw new IllegalArgumentException("Netty server to grpc address map must not be empty");
-      }
     }
   }
 }

--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/transport/GrpcTransportClient.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/transport/GrpcTransportClient.java
@@ -178,7 +178,7 @@ public class GrpcTransportClient extends InternalTransportClient {
       boolean isSingleGet) {
     String[] requestParts = requestPath.split("/");
 
-    if (isValidRequest(requestParts, isSingleGet)) {
+    if (!isValidRequest(requestParts, isSingleGet)) {
       LOGGER.error("Failed to process request: {}", requestParts);
       // avoiding CompletableFuture.failedFuture to keep it JDK agnostic
       CompletableFuture<TransportClientResponse> failedFuture = new CompletableFuture<>();

--- a/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/GrpcClientConfigTest.java
+++ b/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/GrpcClientConfigTest.java
@@ -29,14 +29,14 @@ public class GrpcClientConfigTest {
     assertEquals(config.getSslFactory(), sslFactory);
   }
 
-  @Test(expectedExceptions = IllegalArgumentException.class)
+  @Test(expectedExceptions = NullPointerException.class)
   public void testMissingR2Client() {
     new GrpcClientConfig.Builder().setNettyServerToGrpcAddress(new HashMap<>())
         .setSSLFactory(mock(SSLFactory.class))
         .build();
   }
 
-  @Test(expectedExceptions = IllegalArgumentException.class)
+  @Test(expectedExceptions = NullPointerException.class)
   public void testMissingAddressMap() {
     new GrpcClientConfig.Builder().setR2Client(mock(Client.class)).setSSLFactory(mock(SSLFactory.class)).build();
   }

--- a/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/GrpcClientConfigTest.java
+++ b/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/GrpcClientConfigTest.java
@@ -3,30 +3,37 @@ package com.linkedin.venice.fastclient;
 import static org.mockito.Mockito.mock;
 import static org.testng.Assert.assertEquals;
 
+import com.google.common.collect.ImmutableMap;
 import com.linkedin.r2.transport.common.Client;
 import com.linkedin.venice.security.SSLFactory;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 
 public class GrpcClientConfigTest {
+  private static final Map<String, String> NETTY_SERVER_TO_GRPC_SERVER_ADDRESS =
+      ImmutableMap.of("testserver:1690", "localhost:23900");
+
+  private static final int PORT = 23900;
+
   @Test
   public void testBuilder() {
     Client r2Client = mock(Client.class);
-    Map<String, String> nettyServerToGrpcAddress = new HashMap<>();
-    nettyServerToGrpcAddress.put("server1", "localhost:5000");
-
     SSLFactory sslFactory = mock(SSLFactory.class);
 
     GrpcClientConfig config = new GrpcClientConfig.Builder().setR2Client(r2Client)
-        .setNettyServerToGrpcAddress(nettyServerToGrpcAddress)
+        .setNettyServerToGrpcAddress(NETTY_SERVER_TO_GRPC_SERVER_ADDRESS)
         .setSSLFactory(sslFactory)
+        .setPort(PORT)
         .build();
 
     assertEquals(config.getR2Client(), r2Client);
-    assertEquals(config.getNettyServerToGrpcAddress(), nettyServerToGrpcAddress);
+    assertEquals(config.getNettyServerToGrpcAddress(), NETTY_SERVER_TO_GRPC_SERVER_ADDRESS);
     assertEquals(config.getSslFactory(), sslFactory);
+    assertEquals(config.getPort(), PORT);
   }
 
   @Test(expectedExceptions = NullPointerException.class)
@@ -39,5 +46,31 @@ public class GrpcClientConfigTest {
   @Test(expectedExceptions = NullPointerException.class)
   public void testMissingAddressMap() {
     new GrpcClientConfig.Builder().setR2Client(mock(Client.class)).setSSLFactory(mock(SSLFactory.class)).build();
+  }
+
+  @Test(expectedExceptions = IllegalStateException.class)
+  public void testBuildWithNoPortOrMap() {
+    new GrpcClientConfig.Builder().setR2Client(mock(Client.class))
+        .setSSLFactory(mock(SSLFactory.class))
+        .setNettyServerToGrpcAddress(Collections.emptyMap())
+        .build();
+  }
+
+  @Test(dataProvider = "port-address-combination")
+  public void testBuildSucceedsWithEitherPortOrMap(int port, Map<String, String> nettyServerToGrpcAddress) {
+    GrpcClientConfig config = new GrpcClientConfig.Builder().setR2Client(mock(Client.class))
+        .setSSLFactory(mock(SSLFactory.class))
+        .setNettyServerToGrpcAddress(nettyServerToGrpcAddress)
+        .setPort(port)
+        .build();
+
+    assertEquals(config.getPort(), port);
+    assertEquals(config.getNettyServerToGrpcAddress(), nettyServerToGrpcAddress);
+  }
+
+  @DataProvider(name = "port-address-combination")
+  public static Object[][] generatePortAddressForClientConfig() {
+    return new Object[][] { { 0, NETTY_SERVER_TO_GRPC_SERVER_ADDRESS }, { PORT, Collections.emptyMap() },
+        { PORT, NETTY_SERVER_TO_GRPC_SERVER_ADDRESS } };
   }
 }

--- a/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/GrpcClientConfigTest.java
+++ b/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/GrpcClientConfigTest.java
@@ -14,24 +14,24 @@ public class GrpcClientConfigTest {
   @Test
   public void testBuilder() {
     Client r2Client = mock(Client.class);
-    Map<String, String> addressMap = new HashMap<>();
-    addressMap.put("server1", "localhost:5000");
+    Map<String, String> nettyServerToGrpcAddress = new HashMap<>();
+    nettyServerToGrpcAddress.put("server1", "localhost:5000");
 
     SSLFactory sslFactory = mock(SSLFactory.class);
 
     GrpcClientConfig config = new GrpcClientConfig.Builder().setR2Client(r2Client)
-        .setNettyServerToGrpcAddressMap(addressMap)
+        .setNettyServerToGrpcAddress(nettyServerToGrpcAddress)
         .setSSLFactory(sslFactory)
         .build();
 
     assertEquals(config.getR2Client(), r2Client);
-    assertEquals(config.getNettyServerToGrpcAddressMap(), addressMap);
+    assertEquals(config.getNettyServerToGrpcAddress(), nettyServerToGrpcAddress);
     assertEquals(config.getSslFactory(), sslFactory);
   }
 
   @Test(expectedExceptions = IllegalArgumentException.class)
   public void testMissingR2Client() {
-    new GrpcClientConfig.Builder().setNettyServerToGrpcAddressMap(new HashMap<>())
+    new GrpcClientConfig.Builder().setNettyServerToGrpcAddress(new HashMap<>())
         .setSSLFactory(mock(SSLFactory.class))
         .build();
   }
@@ -40,13 +40,4 @@ public class GrpcClientConfigTest {
   public void testMissingAddressMap() {
     new GrpcClientConfig.Builder().setR2Client(mock(Client.class)).setSSLFactory(mock(SSLFactory.class)).build();
   }
-
-  @Test(expectedExceptions = IllegalArgumentException.class)
-  public void testEmptyAddressMap() {
-    new GrpcClientConfig.Builder().setR2Client(mock(Client.class))
-        .setNettyServerToGrpcAddressMap(new HashMap<>())
-        .setSSLFactory(mock(SSLFactory.class))
-        .build();
-  }
-
 }

--- a/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/transport/GrpcTransportClientTest.java
+++ b/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/transport/GrpcTransportClientTest.java
@@ -1,0 +1,218 @@
+package com.linkedin.venice.fastclient.transport;
+
+import static org.mockito.Mockito.*;
+import static org.testng.Assert.*;
+
+import com.google.common.collect.ImmutableMap;
+import com.linkedin.r2.transport.common.Client;
+import com.linkedin.venice.HttpMethod;
+import com.linkedin.venice.client.exceptions.VeniceClientException;
+import com.linkedin.venice.client.store.transport.TransportClient;
+import com.linkedin.venice.client.store.transport.TransportClientResponse;
+import com.linkedin.venice.fastclient.GrpcClientConfig;
+import com.linkedin.venice.protocols.VeniceClientRequest;
+import com.linkedin.venice.protocols.VeniceReadServiceGrpc;
+import com.linkedin.venice.protocols.VeniceServerResponse;
+import com.linkedin.venice.security.SSLFactory;
+import io.grpc.ChannelCredentials;
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+
+public class GrpcTransportClientTest {
+  private static final int PARTITION = 1;
+  private static final String URI = "localhost:1690";
+
+  private static final String GRPC_URI = "localhost:1691";
+  private static final String STORAGE = "storage";
+  private static final String RESOURCE_NAME = "test_store_v1";
+
+  private static final String PROTOCOL = "https";
+  private static final String PARTITION_STRING = String.valueOf(PARTITION);
+
+  private static final String KEY_STRING = "test_key";
+
+  private static final String[] DEFAULT_REQUEST_PATH =
+      { PROTOCOL, ":", URI, STORAGE, RESOURCE_NAME, PARTITION_STRING, KEY_STRING };
+
+  @Mock
+  private GrpcClientConfig mockClientConfig;
+
+  @Mock
+  private Client mockClient;
+
+  private Map<String, String> nettyServerToGrpcAddress = Collections.emptyMap();
+
+  private GrpcTransportClient grpcTransportClient;
+
+  @BeforeTest
+  public void setup() {
+    MockitoAnnotations.openMocks(this);
+    when(mockClientConfig.getR2Client()).thenReturn(mockClient);
+    when(mockClientConfig.getNettyServerToGrpcAddress()).thenReturn(nettyServerToGrpcAddress);
+
+    grpcTransportClient = new GrpcTransportClient(mockClientConfig);
+  }
+
+  @Test(expectedExceptions = VeniceClientException.class)
+  public void testBuildChannelCredentials() {
+    ChannelCredentials actualChannelCredentials = grpcTransportClient.buildChannelCredentials(null);
+    assertNotNull(actualChannelCredentials, "Null ssl factory should default to insecure channel credentials");
+
+    grpcTransportClient.buildChannelCredentials(mock(SSLFactory.class));
+  }
+
+  @Test
+  public void testBuildVeniceClientRequestForSingleGet() {
+    VeniceClientRequest clientRequest =
+        grpcTransportClient.buildVeniceClientRequest(DEFAULT_REQUEST_PATH, new byte[0], true);
+
+    assertFalse(clientRequest.getIsBatchRequest());
+    assertEquals(clientRequest.getKeyString(), KEY_STRING);
+    assertEquals(clientRequest.getPartition(), PARTITION);
+    assertEquals(clientRequest.getResourceName(), RESOURCE_NAME);
+    assertEquals(clientRequest.getMethod(), HttpMethod.GET.name());
+  }
+
+  @Test
+  public void testBuildVeniceClientRequestForBatchGet() {
+    VeniceClientRequest clientRequest =
+        grpcTransportClient.buildVeniceClientRequest(DEFAULT_REQUEST_PATH, new byte[0], false);
+
+    assertTrue(clientRequest.getIsBatchRequest());
+    assertEquals(clientRequest.getResourceName(), RESOURCE_NAME);
+    assertEquals(clientRequest.getMethod(), HttpMethod.POST.name());
+    assertNotNull(clientRequest.getKeyBytes());
+  }
+
+  @Test
+  public void testGetGrpcAddressFromServerAddress() {
+    when(mockClientConfig.getNettyServerToGrpcAddress()).thenReturn(ImmutableMap.of(URI, GRPC_URI));
+    grpcTransportClient = new GrpcTransportClient(mockClientConfig);
+
+    // Entry found in the mapping should be returned and is validated by checking port which is not the default GRPC
+    // port
+    assertEquals(grpcTransportClient.getGrpcAddressFromServerAddress(URI), GRPC_URI);
+
+    final String TEST_URI = "localhost:1234";
+    final String FALLBACK_URI = "localhost:23900";
+    // No entry in the map should result in generating GRPC address with default port
+    assertEquals(grpcTransportClient.getGrpcAddressFromServerAddress(TEST_URI), FALLBACK_URI);
+
+    // Ensure subsequent mapping leverages cache and doesn't run the logic to compute grpc fallback address
+    Map<String, String> nettyToGrpcAddress = grpcTransportClient.getNettyServerToGrpcAddress();
+    assertEquals(nettyToGrpcAddress.get(TEST_URI), FALLBACK_URI);
+  }
+
+  @Test(expectedExceptions = IllegalStateException.class)
+  public void testGetGrpcAddressFromServerAddressWithInvalidServerAddress() {
+    grpcTransportClient.getGrpcAddressFromServerAddress("");
+  }
+
+  @Test
+  public void testNonStorageQueries() {
+    String[] nonStorageValidRequestPath = { PROTOCOL, ":", URI, "metadata" };
+    // type of method should not impact the validation
+    assertTrue(grpcTransportClient.isValidRequest(nonStorageValidRequestPath, false));
+    assertTrue(grpcTransportClient.isValidRequest(nonStorageValidRequestPath, true));
+
+    // valid non storage query parts with greater than 4 parts
+    String[] nonStorageValidRequestPath1 = { PROTOCOL, ":", URI, "metadata", "junk_field" };
+    assertTrue(grpcTransportClient.isValidRequest(nonStorageValidRequestPath1, false));
+    assertTrue(grpcTransportClient.isValidRequest(nonStorageValidRequestPath1, true));
+
+    // invalid request path
+    assertFalse(grpcTransportClient.isValidRequest(new String[0], true));
+    assertFalse(grpcTransportClient.isValidRequest(new String[0], false));
+  }
+
+  @Test
+  public void testInvalidStorageQueriesRequest() {
+    String[] invalidStorageRequestPath = { PROTOCOL, ":", URI, STORAGE, RESOURCE_NAME, PARTITION_STRING };
+    assertFalse(grpcTransportClient.isValidRequest(invalidStorageRequestPath, false));
+
+    assertFalse(grpcTransportClient.isValidRequest(invalidStorageRequestPath, true));
+    assertFalse(grpcTransportClient.isValidRequest(DEFAULT_REQUEST_PATH, false));
+  }
+
+  @Test
+  public void testValidStorageQueriesRequest() {
+    // single get validation
+    assertTrue(grpcTransportClient.isValidRequest(DEFAULT_REQUEST_PATH, true));
+
+    // batch get validation
+    String[] validBatchRequestPath = { PROTOCOL, ":", URI, STORAGE, RESOURCE_NAME };
+    assertTrue(grpcTransportClient.isValidRequest(validBatchRequestPath, false));
+  }
+
+  @Test
+  public void testHandleStorageGetQuery() {
+    final VeniceClientRequest mockClientRequest = mock(VeniceClientRequest.class);
+    final VeniceReadServiceGrpc.VeniceReadServiceStub mockClientStub =
+        mock(VeniceReadServiceGrpc.VeniceReadServiceStub.class);
+
+    grpcTransportClient = spy(new GrpcTransportClient(mockClientConfig));
+    doReturn(mockClientRequest).when(grpcTransportClient).buildVeniceClientRequest(any(), any(), anyBoolean());
+    doReturn(mockClientStub).when(grpcTransportClient).getOrCreateStub(any());
+
+    grpcTransportClient.handleStorageQueries(DEFAULT_REQUEST_PATH, new byte[0], true);
+    verify(mockClientStub).get(eq(mockClientRequest), any());
+  }
+
+  @Test
+  public void testHandleStorageBatchQuery() {
+    final VeniceClientRequest mockClientRequest = mock(VeniceClientRequest.class);
+    final VeniceReadServiceGrpc.VeniceReadServiceStub mockClientStub =
+        mock(VeniceReadServiceGrpc.VeniceReadServiceStub.class);
+
+    grpcTransportClient = spy(new GrpcTransportClient(mockClientConfig));
+    doReturn(mockClientRequest).when(grpcTransportClient).buildVeniceClientRequest(any(), any(), anyBoolean());
+    doReturn(mockClientStub).when(grpcTransportClient).getOrCreateStub(any());
+
+    grpcTransportClient.handleStorageQueries(DEFAULT_REQUEST_PATH, new byte[0], false);
+    verify(mockClientStub).batchGet(eq(mockClientRequest), any());
+  }
+
+  @Test
+  public void testHandleNonStorageQueries() {
+    TransportClient mockTransportClient = mock(TransportClient.class);
+    GrpcTransportClient transportClient = spy(new GrpcTransportClient(mockTransportClient, ImmutableMap.of(), null));
+
+    Map<String, String> headers = Collections.emptyMap();
+    transportClient.handleNonStorageQueries(URI, headers, new byte[0], true);
+    verify(mockTransportClient).get(eq(URI), eq(headers));
+
+    byte[] body = new byte[0];
+    transportClient.handleNonStorageQueries(URI, headers, body, false);
+    verify(mockTransportClient).post(eq(URI), eq(headers), eq(body));
+  }
+
+  @Test(dataProvider = "error-code-error-message")
+  public void testHandleResponseError(int errorCode, String errorMessage) {
+    CompletableFuture<TransportClientResponse> responseFuture = new CompletableFuture<>();
+    GrpcTransportClient.VeniceGrpcStreamObserver veniceGrpcStreamObserver =
+        new GrpcTransportClient.VeniceGrpcStreamObserver(responseFuture);
+
+    VeniceServerResponse mockResponse = mock(VeniceServerResponse.class);
+
+    when(mockResponse.getErrorCode()).thenReturn(errorCode);
+    when(mockResponse.getErrorMessage()).thenReturn(errorMessage);
+    veniceGrpcStreamObserver.handleResponseError(mockResponse);
+
+    assertTrue(responseFuture.isDone());
+    if (errorCode != 101) {
+      assertTrue(responseFuture.isCompletedExceptionally());
+    }
+  }
+
+  @DataProvider(name = "error-code-error-message")
+  public static Object[][] generateErrorCode() {
+    return new Object[][] { { 400, "bad request" }, { 501, "too many request" }, { 101, "key not found" } };
+  }
+}

--- a/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/transport/GrpcTransportClientTest.java
+++ b/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/transport/GrpcTransportClientTest.java
@@ -182,7 +182,8 @@ public class GrpcTransportClientTest {
   @Test
   public void testHandleNonStorageQueries() {
     TransportClient mockTransportClient = mock(TransportClient.class);
-    GrpcTransportClient transportClient = spy(new GrpcTransportClient(mockTransportClient, ImmutableMap.of(), null));
+    GrpcTransportClient transportClient =
+        spy(new GrpcTransportClient(mockTransportClient, ImmutableMap.of(), 23900, null));
 
     Map<String, String> headers = Collections.emptyMap();
     transportClient.handleNonStorageQueries(URI, headers, new byte[0], true);

--- a/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/transport/GrpcTransportClientTest.java
+++ b/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/transport/GrpcTransportClientTest.java
@@ -52,7 +52,7 @@ public class GrpcTransportClientTest {
   private GrpcTransportClient grpcTransportClient;
 
   @BeforeTest
-  public void setup() {
+  public void setUp() {
     MockitoAnnotations.openMocks(this);
     when(mockClientConfig.getR2Client()).thenReturn(mockClient);
     when(mockClientConfig.getNettyServerToGrpcAddress()).thenReturn(nettyServerToGrpcAddress);

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/fastclient/FastClientGrpcServerReadQuotaTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/fastclient/FastClientGrpcServerReadQuotaTest.java
@@ -26,7 +26,7 @@ public class FastClientGrpcServerReadQuotaTest extends AbstractClientEndToEndSet
   @Test(timeOut = TIME_OUT)
   public void testGrpcServerReadQuota() throws Exception {
     GrpcClientConfig grpcClientConfig = new GrpcClientConfig.Builder().setR2Client(r2Client)
-        .setNettyServerToGrpcAddressMap(veniceCluster.getNettyToGrpcServerMap())
+        .setNettyServerToGrpcAddress(veniceCluster.getNettyServerToGrpcAddress())
         .setSSLFactory(SslUtils.getVeniceLocalSslFactory())
         .build();
 

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/fastclient/utils/AbstractClientEndToEndSetup.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/fastclient/utils/AbstractClientEndToEndSetup.java
@@ -405,7 +405,7 @@ public abstract class AbstractClientEndToEndSetup {
   protected void setUpGrpcFastClient(ClientConfig.ClientConfigBuilder clientConfigBuilder) {
     GrpcClientConfig grpcClientConfig = new GrpcClientConfig.Builder().setR2Client(r2Client)
         .setSSLFactory(SslUtils.getVeniceLocalSslFactory())
-        .setNettyServerToGrpcAddressMap(veniceCluster.getNettyToGrpcServerMap())
+        .setNettyServerToGrpcAddress(veniceCluster.getNettyServerToGrpcAddress())
         .build();
 
     clientConfigBuilder.setGrpcClientConfig(grpcClientConfig).setUseGrpc(true);

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/fastclient/grpc/VeniceGrpcEndToEndTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/fastclient/grpc/VeniceGrpcEndToEndTest.java
@@ -83,7 +83,7 @@ public class VeniceGrpcEndToEndTest {
             .extraProperties(props)
             .build());
 
-    nettyToGrpcPortMap = cluster.getNettyToGrpcServerMap();
+    nettyToGrpcPortMap = cluster.getNettyServerToGrpcAddress();
     storeName = writeData(Utils.getUniqueString("testStore"));
   }
 
@@ -191,7 +191,7 @@ public class VeniceGrpcEndToEndTest {
     GrpcClientConfig grpcClientConfig =
         new GrpcClientConfig.Builder().setSSLFactory(SslUtils.getVeniceLocalSslFactory())
             .setR2Client(grpcR2ClientPassthrough)
-            .setNettyServerToGrpcAddressMap(nettyToGrpcPortMap)
+            .setNettyServerToGrpcAddress(nettyToGrpcPortMap)
             .build();
 
     ClientConfigBuilder<Object, Object, SpecificRecord> clientConfigBuilder =
@@ -253,7 +253,7 @@ public class VeniceGrpcEndToEndTest {
     GrpcClientConfig grpcClientConfig =
         new GrpcClientConfig.Builder().setSSLFactory(SslUtils.getVeniceLocalSslFactory())
             .setR2Client(r2Client)
-            .setNettyServerToGrpcAddressMap(nettyToGrpcPortMap)
+            .setNettyServerToGrpcAddress(nettyToGrpcPortMap)
             .build();
 
     ClientConfigBuilder<Object, Object, SpecificRecord> clientConfigBuilder =
@@ -299,7 +299,7 @@ public class VeniceGrpcEndToEndTest {
     GrpcClientConfig grpcClientConfig =
         new GrpcClientConfig.Builder().setSSLFactory(SslUtils.getVeniceLocalSslFactory())
             .setR2Client(grpcR2Client)
-            .setNettyServerToGrpcAddressMap(nettyToGrpcPortMap)
+            .setNettyServerToGrpcAddress(nettyToGrpcPortMap)
             .build();
 
     ClientConfigBuilder<Object, Object, SpecificRecord> clientConfigBuilder =


### PR DESCRIPTION
## Summary
- [Functional] Introduce logic to use fallback Grpc port for netty server address -> Grpc server mapping
- [Refactor] Modularize request handling and remove boiler plate in `GrpcTransportClient`
- [Bug fix] Fix integration tests that was failing due to #975 
- [Clean up] Remove some validations, added few invariants check and reorganize some depending on the mode (local vs integration/production)
- [Clean up] Rename fields to remove type information
- [Test] Add unit tests for `GrpcTransportClient` class


## How was this PR tested?
- Unit test and integration tests
- Deployed client changes locally with test application

## Does this PR introduce any user-facing changes?
- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.