### PR TITLE
[server] Revert lossy rewind criterion to EOP from completion reporting

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -1570,9 +1570,9 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
       }
 
       if (lossy) {
-        if (!partitionConsumptionState.isCompletionReported()) {
+        if (!partitionConsumptionState.isEndOfPushReceived()) {
           logMsg += Utils.NEW_LINE_CHAR;
-          logMsg += "Failing the job because lossy rewind happens before reporting completed";
+          logMsg += "Failing the job because lossy rewind happens before receiving EndOfPush.";
           LOGGER.error(logMsg);
           ingestionTask.getVersionedDIVStats()
               .recordPotentiallyLossyLeaderOffsetRewind(ingestionTask.getStoreName(), ingestionTask.getVersionNumber());

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
@@ -4544,7 +4544,7 @@ public abstract class StoreIngestionTaskTest {
         () -> LeaderFollowerStoreIngestionTask
             .checkAndHandleUpstreamOffsetRewind(mockState2, consumedRecord, 10, 11, mockTask2));
     assertTrue(
-        exception.getMessage().contains("Failing the job because lossy rewind happens before reporting completed"));
+        exception.getMessage().contains("Failing the job because lossy rewind happens before receiving EndOfPush."));
     verify(mockStats2).recordPotentiallyLossyLeaderOffsetRewind(storeName, version);
   }
 


### PR DESCRIPTION
## Revert lossy rewind criterion to EOP from completion reporting
The PR: #846 modified the method responsible for handling lossy rewind checks: it updated
the function to suppress the lossy rewind issue only after reporting completion, rather
than upon receiving the EOP. It is important to note that the status of reported completion
is not permanent and can change during state transitions. As a result of this change, there
is an increased likelihood of ingestion stalls / failures due to lossy rewinds, compared
to the previous method based on the EOP signal.

This PR reverts the check function to its original state, where the lossy rewind issue is
suppressed after reporting the EOP signal, as it was before pull request #846.
This fix is intended to avoid serving stale data. The only downside is that data
for a few keys might be inconsistent, but this issue also exists with the completion-based
check. Since this is a short-term solution, this is okay. We're working on a solution
that allows us to ignore data from illegitimate topic writers.



## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.