### PR TITLE
[server][dvc] Adopt standard logging format for topic-partition/replica ID to simplify log extraction - PART 1

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/helix/AbstractPartitionStateModel.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/helix/AbstractPartitionStateModel.java
@@ -43,7 +43,6 @@ import org.apache.logging.log4j.Logger;
  */
 public abstract class AbstractPartitionStateModel extends StateModel {
   protected final Logger logger = LogManager.getLogger(getClass());
-  private static final String STORE_PARTITION_DESCRIPTION_FORMAT = "%s-%d";
   private static final int RETRY_COUNT = 5;
   private static final int RETRY_DURATION_MS = 1000;
   private static final int WAIT_PARTITION_ACCESSOR_TIME_OUT_MS = (int) TimeUnit.MINUTES.toMillis(5);
@@ -69,8 +68,7 @@ public abstract class AbstractPartitionStateModel extends StateModel {
     this.storeRepository = storeRepository;
     this.storeAndServerConfigs = storeAndServerConfigs;
     this.partition = partition;
-    this.storePartitionDescription =
-        String.format(STORE_PARTITION_DESCRIPTION_FORMAT, storeAndServerConfigs.getStoreVersionName(), partition);
+    this.storePartitionDescription = Utils.getReplicaId(storeAndServerConfigs.getStoreVersionName(), partition);
     /**
      * We cannot block here because helix manager connection depends on the state model constructing in helix logic.
      * If we block here in the constructor, it will cause deadlocks.

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/helix/LeaderFollowerPartitionStateModel.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/helix/LeaderFollowerPartitionStateModel.java
@@ -16,6 +16,7 @@ import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.meta.VersionImpl;
 import com.linkedin.venice.utils.LatencyUtils;
 import com.linkedin.venice.utils.Pair;
+import com.linkedin.venice.utils.Utils;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
@@ -107,13 +108,9 @@ public class LeaderFollowerPartitionStateModel extends AbstractPartitionStateMod
       try {
         long startTimeForSettingUpNewStorePartitionInNs = System.nanoTime();
         setupNewStorePartition();
-        logger.info(
-            "Completed setting up new store partition for {} partition {}. Total elapsed time: {} ms",
-            resourceName,
-            getPartition(),
-            LatencyUtils.getElapsedTimeFromNSToMS(startTimeForSettingUpNewStorePartitionInNs));
+        logger.info("Completed setting up the replica: {}. Total elapsed time: {} ms", Utils.getReplicaId(resourceName, getPartition()), LatencyUtils.getElapsedTimeFromNSToMS(startTimeForSettingUpNewStorePartitionInNs));
       } catch (Exception e) {
-        logger.error("Failed to set up new store partition for {} partition {}", resourceName, getPartition(), e);
+        logger.error("Failed to set up the new replica: {}", Utils.getReplicaId(resourceName, getPartition()), e);
         if (isRegularStoreCurrentVersion) {
           notifier.stopConsumption(resourceName, getPartition());
         }
@@ -183,7 +180,10 @@ public class LeaderFollowerPartitionStateModel extends AbstractPartitionStateMod
         int version = Version.parseVersionFromKafkaTopicName(resourceName);
         isCurrentVersion = getStoreRepo().getStoreOrThrow(storeName).getCurrentVersion() == version;
       } catch (VeniceNoStoreException e) {
-        logger.warn("Failed to determine if the resource is current version", e);
+        logger.warn(
+            "Failed to determine if the resource is current version. Replica: {}",
+            Utils.getReplicaId(message.getResourceName(), getPartition()),
+            e);
       }
       if (isCurrentVersion) {
         // Only do graceful drop for current version resources that are being queried
@@ -227,16 +227,14 @@ public class LeaderFollowerPartitionStateModel extends AbstractPartitionStateMod
       Version version = res.getSecond();
       if (store == null) {
         logger.error(
-            "Failed to get store for resource: {}-{}. Will not update lag monitor.",
-            resourceName,
-            getPartition());
+            "Failed to get store for resource: {}. Will not update lag monitor.",
+            Utils.getReplicaId(resourceName, getPartition()));
         return;
       }
       if (version == null && !isNullVersionValid) {
         logger.error(
-            "Failed to get version for resource: {}-{} with trigger: {}. Will not update lag monitor.",
-            resourceName,
-            getPartition(),
+            "Failed to get version for resource: {} with trigger: {}. Will not update lag monitor.",
+            Utils.getReplicaId(resourceName, getPartition()),
             trigger);
         return;
       }
@@ -247,7 +245,7 @@ public class LeaderFollowerPartitionStateModel extends AbstractPartitionStateMod
       }
       lagMonFunction.accept(version, getPartition());
     } catch (Exception e) {
-      logger.error("Failed to update lag monitor for resource: {}-{}", resourceName, getPartition(), e);
+      logger.error("Failed to update lag monitor for replica: {}", Utils.getReplicaId(resourceName, getPartition()), e);
     }
   }
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/helix/LeaderFollowerPartitionStateModel.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/helix/LeaderFollowerPartitionStateModel.java
@@ -108,7 +108,10 @@ public class LeaderFollowerPartitionStateModel extends AbstractPartitionStateMod
       try {
         long startTimeForSettingUpNewStorePartitionInNs = System.nanoTime();
         setupNewStorePartition();
-        logger.info("Completed setting up the replica: {}. Total elapsed time: {} ms", Utils.getReplicaId(resourceName, getPartition()), LatencyUtils.getElapsedTimeFromNSToMS(startTimeForSettingUpNewStorePartitionInNs));
+        logger.info(
+            "Completed setting up the replica: {}. Total elapsed time: {} ms",
+            Utils.getReplicaId(resourceName, getPartition()),
+            LatencyUtils.getElapsedTimeFromNSToMS(startTimeForSettingUpNewStorePartitionInNs));
       } catch (Exception e) {
         logger.error("Failed to set up the new replica: {}", Utils.getReplicaId(resourceName, getPartition()), e);
         if (isRegularStoreCurrentVersion) {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ConsumerAction.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ConsumerAction.java
@@ -120,9 +120,8 @@ public class ConsumerAction implements Comparable<ConsumerAction> {
 
   @Override
   public String toString() {
-    return "KafkaTaskMessage{" + "type=" + type + ", topic='" + getTopic() + '\'' + ", partition=" + getPartition()
-        + ", attempts=" + attempts + ", sequenceNumber=" + sequenceNumber + ", createdTimestampInMs="
-        + createTimestampInMs + '}';
+    return "KafkaTaskMessage{" + "type=" + type + ", topicPartition=" + topicPartition + ", attempts=" + attempts
+        + ", sequenceNumber=" + sequenceNumber + ", createdTimestampInMs=" + createTimestampInMs + '}';
   }
 
   @Override

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -899,7 +899,6 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
     }
 
     // leader switch local or remote topic, depending on the sourceKafkaServers specified in TS
-    final int partition = partitionConsumptionState.getPartition();
     final PubSubTopic currentLeaderTopic =
         partitionConsumptionState.getOffsetRecord().getLeaderTopic(pubSubTopicRepository);
     final String newSourceKafkaServer = topicSwitch.sourceKafkaServers.get(0).toString();

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -376,36 +376,36 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
            * so quickly skip this state transition and go straight to the final transition.
            */
           LOGGER.info(
-              "State transition from STANDBY to LEADER is skipped for topic {} partition {}, because Helix has assigned another role to this replica.",
-              topicName,
-              partition);
+              "State transition from STANDBY to LEADER is skipped for replica: {}, because Helix has assigned another role to it.",
+              Utils.getReplicaId(topicName, partition));
           return;
         }
 
         PartitionConsumptionState partitionConsumptionState = partitionConsumptionStateMap.get(partition);
         if (partitionConsumptionState == null) {
           LOGGER.info(
-              "State transition from STANDBY to LEADER is skipped for topic {} partition {}, because partition consumption state is null and the partition may have been unsubscribed.",
-              topicName,
-              partition);
+              "State transition from STANDBY to LEADER is skipped for replica: {}, because PCS is null and the partition may have been unsubscribed.",
+              Utils.getReplicaId(topicName, partition));
           return;
         }
 
         if (partitionConsumptionState.getLeaderFollowerState().equals(LEADER)) {
           LOGGER.info(
-              "State transition from STANDBY to LEADER is skipped for topic {} partition {}, because this replica is the leader already.",
-              topicName,
-              partition);
+              "State transition from STANDBY to LEADER is skipped for replica: {} as it is already the partition leader.",
+              Utils.getReplicaId(topicName, partition));
           return;
         }
         if (store.isMigrationDuplicateStore()) {
           partitionConsumptionState.setLeaderFollowerState(PAUSE_TRANSITION_FROM_STANDBY_TO_LEADER);
-          LOGGER.info("{} for partition {} is paused transition from STANDBY to LEADER", ingestionTaskName, partition);
+          LOGGER.info(
+              "State transition from STANDBY to LEADER is paused for replica: {} as this store is undergoing migration",
+              partitionConsumptionState.getReplicaId());
         } else {
           // Mark this partition in the middle of STANDBY to LEADER transition
           partitionConsumptionState.setLeaderFollowerState(IN_TRANSITION_FROM_STANDBY_TO_LEADER);
-
-          LOGGER.info("{} for partition {} is in transition from STANDBY to LEADER", ingestionTaskName, partition);
+          LOGGER.info(
+              "Replica: {} is in state transition from STANDBY to LEADER",
+              partitionConsumptionState.getReplicaId());
         }
         break;
       case LEADER_TO_STANDBY:
@@ -417,26 +417,23 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
            * so quickly skip this state transition and go straight to the final transition.
            */
           LOGGER.info(
-              "State transition from LEADER to STANDBY is skipped for topic {} partition {}, because Helix has assigned another role to this replica.",
-              topicName,
-              partition);
+              "State transition from LEADER to STANDBY is skipped for replica: {}, because Helix has assigned another role to this replica.",
+              Utils.getReplicaId(topicName, partition));
           return;
         }
 
         partitionConsumptionState = partitionConsumptionStateMap.get(partition);
         if (partitionConsumptionState == null) {
           LOGGER.info(
-              "State transition from LEADER to STANDBY is skipped for topic {} partition {}, because partition consumption state is null and the partition may have been unsubscribed.",
-              topicName,
-              partition);
+              "State transition from LEADER to STANDBY is skipped for replica: {}, because PCS is null and the partition may have been unsubscribed.",
+              Utils.getReplicaId(topicName, partition));
           return;
         }
 
         if (partitionConsumptionState.getLeaderFollowerState().equals(STANDBY)) {
           LOGGER.info(
-              "State transition from LEADER to STANDBY is skipped for topic {} partition {}, because this replica is a follower already.",
-              topicName,
-              partition);
+              "State transition from LEADER to STANDBY is skipped for replica: {} as this replica is already a follower.",
+              partitionConsumptionState.getReplicaId());
           return;
         }
 
@@ -459,10 +456,9 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
 
           partitionConsumptionState.setConsumeRemotely(false);
           LOGGER.info(
-              "{} disabled remote consumption from topic {} partition {}",
-              ingestionTaskName,
-              leaderTopic,
-              partition);
+              "Disabled remote consumption from topic-partition: {} for replica: {}",
+              Utils.getReplicaId(leaderTopic, partition),
+              partitionConsumptionState.getReplicaId());
           // Followers always consume local VT and should not skip kafka message
           partitionConsumptionState.setSkipKafkaMessage(false);
           partitionConsumptionState.setLeaderFollowerState(STANDBY);
@@ -472,7 +468,6 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
               partitionConsumptionState.getSourceTopicPartition(topic),
               partitionConsumptionState.getLatestProcessedLocalVersionTopicOffset(),
               localKafkaServer);
-
           /**
            * When switching leader to follower, we may adjust the underlying storage partition to optimize the performance.
            * Only adjust the storage engine after the batch portion as compaction tuning is meaningless for the batch portion.
@@ -483,12 +478,11 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
                 AbstractStorageEngine.StoragePartitionAdjustmentTrigger.DEMOTE_TO_FOLLOWER,
                 getStoragePartitionConfig(partitionConsumptionState));
           }
-
-          LOGGER.info("{} demoted to standby for partition {}", ingestionTaskName, partition);
         } else {
           partitionConsumptionState.setLeaderFollowerState(STANDBY);
           updateLeaderTopicOnFollower(partitionConsumptionState);
         }
+        LOGGER.info("Replica: {} moved to standby/follower state", partitionConsumptionState.getReplicaId());
 
         /**
          * Close the writer to make sure the current segment is closed after the leader is demoted to standby.
@@ -535,18 +529,16 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
           if (!store.isMigrationDuplicateStore()) {
             partitionConsumptionState.setLeaderFollowerState(IN_TRANSITION_FROM_STANDBY_TO_LEADER);
             LOGGER.info(
-                "{} became in transition to leader for partition {}",
-                ingestionTaskName,
-                partitionConsumptionState.getPartition());
+                "Resumed state transition from STANDBY to LEADER for replica: {}",
+                partitionConsumptionState.getReplicaId());
           }
           break;
 
         case IN_TRANSITION_FROM_STANDBY_TO_LEADER:
           if (canSwitchToLeaderTopic(partitionConsumptionState)) {
             LOGGER.info(
-                "{} start promoting to leader for partition {} unsubscribing from current topic: {}",
-                ingestionTaskName,
-                partition,
+                "Initiating promotion of replica: {} to leader for the partition. Unsubscribing from the current topic: {}",
+                partitionConsumptionState.getReplicaId(),
                 kafkaVersionTopic);
             /**
              * There isn't any new message from the old leader for at least {@link newLeaderInactiveTime} minutes,
@@ -556,9 +548,8 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
             consumerUnSubscribe(versionTopic, partitionConsumptionState);
 
             LOGGER.info(
-                "{} start promoting to leader for partition {}, unsubscribed from current topic: {}",
-                ingestionTaskName,
-                partition,
+                "Starting promotion of replica: {} to leader for the partition, unsubscribed from current topic: {}",
+                partitionConsumptionState.getReplicaId(),
                 kafkaVersionTopic);
             OffsetRecord offsetRecord = partitionConsumptionState.getOffsetRecord();
             if (offsetRecord.getLeaderTopic(pubSubTopicRepository) == null) {
@@ -577,7 +568,7 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
 
             if (!amplificationFactorAdapter.isLeaderSubPartition(partition)
                 && partitionConsumptionState.isEndOfPushReceived()) {
-              LOGGER.info("Stop promoting non-leaderSubPartition: {} of store: {}} to leader.", partition, storeName);
+              LOGGER.info("Stop promoting non-leaderSubPartition: {} of store: {} to leader.", partition, storeName);
               partitionConsumptionState.setLeaderFollowerState(STANDBY);
               consumerSubscribe(
                   partitionConsumptionState.getSourceTopicPartition(versionTopic),
@@ -617,8 +608,9 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
           PubSubTopic currentLeaderTopic =
               partitionConsumptionState.getOffsetRecord().getLeaderTopic(pubSubTopicRepository);
           if (currentLeaderTopic == null) {
-            String errorMsg = ingestionTaskName + " Missing leader topic for actual leader. OffsetRecord: "
-                + partitionConsumptionState.getOffsetRecord().toSimplifiedString();
+            String errorMsg =
+                "Missing leader topic for actual leader replica: " + partitionConsumptionState.getReplicaId()
+                    + ". OffsetRecord: " + partitionConsumptionState.getOffsetRecord().toSimplifiedString();
             LOGGER.error(errorMsg);
             throw new VeniceException(errorMsg);
           }
@@ -635,10 +627,9 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
 
             partitionConsumptionState.setConsumeRemotely(false);
             LOGGER.info(
-                "{} disabled remote consumption from topic {} partition {}",
-                ingestionTaskName,
-                currentLeaderTopic,
-                partition);
+                "Disabled remote consumption from topic-partition: {} for replica: {}",
+                Utils.getReplicaId(currentLeaderTopic, partition),
+                partitionConsumptionState.getReplicaId());
             if (isDataRecovery && partitionConsumptionState.isBatchOnly() && !versionTopic.equals(currentLeaderTopic)) {
               partitionConsumptionState.getOffsetRecord().setLeaderTopic(versionTopic);
               currentLeaderTopic = versionTopic;
@@ -785,12 +776,12 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
           newSourceTopicPartition,
           topicSwitch.rewindStartTimestamp);
       LOGGER.info(
-          "{} get upstreamStartOffset: {} for source URL: {}, topic: {}, rewind timestamp: {}",
-          ingestionTaskName,
+          "UpstreamStartOffset: {} for source URL: {}, topic: {}, rewind timestamp: {}. Replica: {}",
           upstreamStartOffset,
-          newSourceTopic,
-          partitionConsumptionState.getPartition(),
-          topicSwitch.rewindStartTimestamp);
+          newSourceKafkaServer,
+          Utils.getReplicaId(newSourceTopic, partitionConsumptionState.getPartition()),
+          topicSwitch.rewindStartTimestamp,
+          partitionConsumptionState.getReplicaId());
     }
     return Collections.singletonMap(OffsetRecord.NON_AA_REPLICATION_UPSTREAM_OFFSET_MAP_KEY, upstreamStartOffset);
   }
@@ -826,10 +817,9 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
       if (shouldNewLeaderSwitchToRemoteConsumption(partitionConsumptionState)) {
         partitionConsumptionState.setConsumeRemotely(true);
         LOGGER.info(
-            "{} enabled remote consumption from topic {} partition {}",
-            ingestionTaskName,
-            offsetRecord.getLeaderTopic(pubSubTopicRepository),
-            partition);
+            "Enabled remote consumption from topic-partition: {} for replica: {}",
+            Utils.getReplicaId(offsetRecord.getLeaderTopic(pubSubTopicRepository), partition),
+            partitionConsumptionState.getReplicaId());
       }
     }
 
@@ -870,14 +860,13 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
 
     // subscribe to the new upstream
     LOGGER.info(
-        "{} is promoted to leader for partition {} and it is going to start consuming from "
-            + "{} at offset {}; source Kafka url: {}; remote consumption flag: {}",
-        ingestionTaskName,
-        partition,
+        "Replica: {} has been promoted to the leader role for the partition. It will start consuming from: {} at offset: {} with the source Kafka URL: {}. Remote consumption flag: {}",
+        partitionConsumptionState.getReplicaId(),
         leaderTopicPartition,
         leaderStartOffset,
         leaderSourceKafkaURL,
         partitionConsumptionState.consumeRemotely());
+
     consumerSubscribe(leaderTopicPartition, leaderStartOffset, leaderSourceKafkaURL);
 
     syncConsumedUpstreamRTOffsetMapIfNeeded(
@@ -885,10 +874,11 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
         Collections.singletonMap(leaderSourceKafkaURL, leaderStartOffset));
 
     LOGGER.info(
-        "{}, as a leader, started consuming from {} at offset {}",
-        ingestionTaskName,
+        "The leader replica: {} started consuming from: {} at offset: {} url: {}",
+        partitionConsumptionState.getReplicaId(),
         leaderTopicPartition,
-        leaderStartOffset);
+        leaderStartOffset,
+        leaderSourceKafkaURL);
   }
 
   private boolean switchAwayFromStreamReprocessingTopic(PubSubTopic currentLeaderTopic, PubSubTopic topicSwitchTopic) {
@@ -938,15 +928,18 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
     waitForLastLeaderPersistFuture(
         partitionConsumptionState,
         String.format(
-            "Leader failed to produce the last message to version topic before switching feed topic from %s to %s on partition %s",
+            "Leader replica: %s failed to produce the last message to version topic before switching feed topic from %s to %s",
+            partitionConsumptionState.getReplicaId(),
             currentLeaderTopic,
-            newSourceTopic,
-            partition));
+            newSourceTopic));
 
     // subscribe to the new upstream
     if (isNativeReplicationEnabled && !newSourceKafkaServer.equals(localKafkaServer)) {
       partitionConsumptionState.setConsumeRemotely(true);
-      LOGGER.info("{} enabled remote consumption from {}", ingestionTaskName, newSourceTopicPartition);
+      LOGGER.info(
+          "Enabled remote consumption from {} for replica: {}",
+          newSourceTopicPartition,
+          partitionConsumptionState.getReplicaId());
     }
     partitionConsumptionState.getOffsetRecord().setLeaderTopic(newSourceTopic);
     partitionConsumptionState.getOffsetRecord()
@@ -964,12 +957,11 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
         Collections.singletonMap(sourceKafkaURL, upstreamStartOffset));
 
     LOGGER.info(
-        "{} leader successfully switch feed topic from {} to {} offset {} partition {}",
-        ingestionTaskName,
+        "Leader replica: {} successfully switched feed topic from: {} to: {} offset: {}",
+        partitionConsumptionState.getReplicaId(),
         currentLeaderTopic,
         newSourceTopic,
-        upstreamStartOffset,
-        partition);
+        upstreamStartOffset);
 
     // In case new topic is empty and leader can never become online
     defaultReadyToServeChecker.apply(partitionConsumptionState);
@@ -1128,10 +1120,9 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
       if (LatencyUtils
           .getElapsedTimeFromMsToMs(latestConsumedProducerTimestamp) < dataRecoveryCompletionTimeLagThresholdInMs) {
         LOGGER.info(
-            "Data recovery completed for topic: {} partition: {} upon consuming records with "
+            "Data recovery completed for replica: {} upon consuming records with "
                 + "producer timestamp of {} which is within the data recovery completion lag threshold of {} ms",
-            kafkaVersionTopic,
-            partitionConsumptionState.getPartition(),
+            partitionConsumptionState.getReplicaId(),
             latestConsumedProducerTimestamp,
             dataRecoveryCompletionTimeLagThresholdInMs);
         isDataRecoveryCompleted = true;
@@ -1151,9 +1142,8 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
       long lastTimestamp = getLastConsumedMessageTimestamp(partitionConsumptionState.getPartition());
       if (isAtEndOfSourceVT && LatencyUtils.getElapsedTimeFromMsToMs(lastTimestamp) > newLeaderInactiveTime) {
         LOGGER.info(
-            "Data recovery completed for topic: {} partition: {} upon exceeding leader inactive time of {} ms",
-            kafkaVersionTopic,
-            partitionConsumptionState.getPartition(),
+            "Data recovery completed for replica: {} upon exceeding leader inactive time of {} ms",
+            partitionConsumptionState.getReplicaId(),
             newLeaderInactiveTime);
         isDataRecoveryCompleted = true;
       }
@@ -1200,17 +1190,17 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
      * Hence, before processing TopicSwitch message, we need to force downgrade other subPartitions into FOLLOWER.
      */
     if (isLeader(partitionConsumptionState) && !amplificationFactorAdapter.isLeaderSubPartition(partition)) {
-      LOGGER.info("SubPartition: {} is demoted from LEADER to STANDBY.", partitionConsumptionState.getPartition());
+      LOGGER.info("SubPartition: {} is demoted from LEADER to STANDBY.", partitionConsumptionState.getReplicaId());
       PubSubTopic currentLeaderTopic =
           partitionConsumptionState.getOffsetRecord().getLeaderTopic(pubSubTopicRepository);
       consumerUnSubscribe(currentLeaderTopic, partitionConsumptionState);
       waitForLastLeaderPersistFuture(
           partitionConsumptionState,
           String.format(
-              "Leader failed to produce the last message to version topic before switching feed topic from %s to %s on partition %s",
+              "Leader replica: %s failed to produce the last message to version topic before switching feed topic from: %s to: %s",
+              partitionConsumptionState.getReplicaId(),
               currentLeaderTopic,
-              kafkaVersionTopic,
-              partition));
+              kafkaVersionTopic));
       partitionConsumptionState.setConsumeRemotely(false);
       partitionConsumptionState.setLeaderFollowerState(STANDBY);
       consumerSubscribe(
@@ -1277,19 +1267,22 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
       if (previousStoreVersionState != null) {
         if (previousStoreVersionState.topicSwitch == null) {
           LOGGER.info(
-              "First time receiving a TopicSwitch message (new source topic: {}; " + "rewind start time: {})",
+              "First time receiving a TopicSwitch message (new source topic: {}; "
+                  + "rewind start time: {}) for replica: {}",
               topicSwitch.sourceTopicName,
-              topicSwitch.rewindStartTimestamp);
+              topicSwitch.rewindStartTimestamp,
+              partitionConsumptionState.getReplicaId());
         } else {
           LOGGER.info(
               "Previous TopicSwitch message in metadata store (source topic: {}; rewind start time: {}; "
-                  + "source kafka servers {}) will be replaced by the new TopicSwitch message (new source topic: {}; "
-                  + "rewind start time: {})",
+                  + "source kafka servers: {}) will be replaced by the new TopicSwitch message (new source topic: {}; "
+                  + "rewind start time: {}) for replica: {}",
               previousStoreVersionState.topicSwitch.sourceTopicName,
               previousStoreVersionState.topicSwitch.rewindStartTimestamp,
               topicSwitch.sourceKafkaServers,
               topicSwitch.sourceTopicName,
-              topicSwitch.rewindStartTimestamp);
+              topicSwitch.rewindStartTimestamp,
+              partitionConsumptionState.getReplicaId());
         }
         previousStoreVersionState.topicSwitch = topicSwitch;
 
@@ -1446,10 +1439,10 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
       }
     } else {
       // Ideally this should never happen.
-      String msg = ingestionTaskName + " UpdateOffset: Produced record should not be null in LEADER for: "
-          + consumerRecord.getTopicPartition();
+      String msg = "UpdateOffset: Produced record should not be null in LEADER for: "
+          + consumerRecord.getTopicPartition() + ". Replica: {}";
       if (!REDUNDANT_LOGGING_FILTER.isRedundantException(msg)) {
-        LOGGER.warn(msg);
+        LOGGER.warn(msg, partitionConsumptionState.getReplicaId());
       }
     }
   }
@@ -1524,12 +1517,11 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
        * otherwise, don't fail the push job, it's streaming ingestion now so it's serving online traffic already.
        */
       String logMsg = String.format(
-          "{} partition {} received message at offset {} with upstreamOffset: {};"
+          "Replica: {} received message at offset: {} with upstreamOffset: {};"
               + " but recorded upstreamOffset is: {}. Received message producer GUID: {}; Recorded producer GUID: {};"
               + " Received message producer host: {}; Recorded producer host: {}."
               + " Multiple leaders are producing. ",
-          ingestionTask.getIngestionTaskName(),
-          consumerRecord.getTopicPartition().getPartitionNumber(),
+          partitionConsumptionState.getReplicaId(),
           consumerRecord.getOffset(),
           newUpstreamOffset,
           previousUpstreamOffset,
@@ -1588,8 +1580,8 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
         }
       } catch (Exception e) {
         LOGGER.warn(
-            "{} failed comparing the rewind message with the actual value in Venice",
-            ingestionTask.getIngestionTaskName(),
+            "Failed comparing the rewind message with the actual value in the database for replica: {}",
+            partitionConsumptionState.getReplicaId(),
             e);
       }
 
@@ -1805,9 +1797,8 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
     PartitionConsumptionState partitionConsumptionState = partitionConsumptionStateMap.get(subPartition);
     if (partitionConsumptionState == null) {
       LOGGER.info(
-          "Skipping message as partition is no longer actively subscribed. Topic: {} Partition Id: {}",
-          kafkaVersionTopic,
-          subPartition);
+          "Skipping message as partition is no longer actively subscribed. Replica: {}",
+          Utils.getReplicaId(versionTopic, subPartition));
       return false;
     }
     switch (partitionConsumptionState.getLeaderFollowerState()) {
@@ -1817,8 +1808,8 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
         if (partitionConsumptionState.consumeRemotely()
             && currentLeaderTopic.isVersionTopicOrStreamReprocessingTopic()) {
           if (partitionConsumptionState.skipKafkaMessage()) {
-            String msg = "Skipping messages after EOP in remote version topic. Topic: " + kafkaVersionTopic
-                + " Partition Id: " + subPartition;
+            String msg = "Skipping messages after EOP in remote version topic. Replica: "
+                + partitionConsumptionState.getReplicaId();
             if (!REDUNDANT_LOGGING_FILTER.isRedundantException(msg)) {
               LOGGER.info(msg);
             }
@@ -1842,12 +1833,12 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
           }
         }
         if (!record.getTopicPartition().getPubSubTopic().equals(currentLeaderTopic)) {
-          String errorMsg = "Leader received a pubsub message that doesn't belong to the leader topic. Store version: "
-              + this.kafkaVersionTopic + ", partition: " + partitionConsumptionState.getPartition() + ", leader topic: "
-              + currentLeaderTopic + ", topic of incoming message: "
-              + record.getTopicPartition().getPubSubTopic().getName();
+          String errorMsg =
+              "Leader replica: {} received a pubsub message that doesn't belong to the leader topic. Leader topic: "
+                  + currentLeaderTopic + ", topic of incoming message: "
+                  + record.getTopicPartition().getPubSubTopic().getName();
           if (!REDUNDANT_LOGGING_FILTER.isRedundantException(errorMsg)) {
-            LOGGER.error(errorMsg);
+            LOGGER.error(errorMsg, partitionConsumptionState.getReplicaId());
           }
           return false;
         }
@@ -1856,9 +1847,8 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
         PubSubTopic pubSubTopic = record.getTopicPartition().getPubSubTopic();
         String topicName = pubSubTopic.getName();
         if (!versionTopic.equals(pubSubTopic)) {
-          String errorMsg =
-              ingestionTaskName + " Current L/F state:" + partitionConsumptionState.getLeaderFollowerState()
-                  + "; partition: " + subPartition + "; Message retrieved from non version topic " + topicName;
+          String errorMsg = partitionConsumptionState.getLeaderFollowerState() + " replica: "
+              + partitionConsumptionState.getReplicaId() + " received message from non version topic: " + topicName;
           if (consumerHasSubscription(pubSubTopic, partitionConsumptionState)) {
             throw new VeniceMessageException(
                 errorMsg + ". Throwing exception as the node still subscribes to " + topicName);
@@ -1871,11 +1861,10 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
 
         long lastOffset = partitionConsumptionState.getLatestProcessedLocalVersionTopicOffset();
         if (lastOffset >= record.getOffset()) {
-          String message =
-              ingestionTaskName + " Current L/F state:" + partitionConsumptionState.getLeaderFollowerState()
-                  + "; The record was already processed partition " + subPartition;
+          String message = partitionConsumptionState.getLeaderFollowerState() + " replica: "
+              + partitionConsumptionState.getReplicaId() + " had already processed the record";
           if (!REDUNDANT_LOGGING_FILTER.isRedundantException(message)) {
-            LOGGER.info("{}; LastKnown {}; Current {}", message, lastOffset, record.getOffset());
+            LOGGER.info("{}; LastKnownOffset: {}; OffsetOfIncomingRecord: {}", message, lastOffset, record.getOffset());
           }
           return false;
         }
@@ -1903,20 +1892,20 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
         PubSubTopic currentLeaderTopic =
             partitionConsumptionState.getOffsetRecord().getLeaderTopic(pubSubTopicRepository);
         if (!incomingMessageTopic.equals(currentLeaderTopic)) {
-          String errorMsg = "Leader received a pubsub message that doesn't belong to the leader topic. Store version: "
-              + this.kafkaVersionTopic + ", partition: " + partitionConsumptionState.getPartition() + ", leader topic: "
-              + currentLeaderTopic + ", topic of incoming message: " + incomingMessageTopic.getName();
+          String errorMsg =
+              "Leader replica: {} received a pubsub message that doesn't belong to the leader topic. Leader topic: "
+                  + currentLeaderTopic + ", topic of incoming message: " + incomingMessageTopic.getName();
           if (!REDUNDANT_LOGGING_FILTER.isRedundantException(errorMsg)) {
-            LOGGER.error(errorMsg);
+            LOGGER.error(errorMsg, partitionConsumptionState.getReplicaId());
           }
           return false;
         }
         break;
       default:
         if (!incomingMessageTopic.equals(this.versionTopic)) {
-          String errorMsg = partitionConsumptionState.getLeaderFollowerState()
-              + " replica received a pubsub message that doesn't belong to version topic: " + this.kafkaVersionTopic
-              + ", partition: " + partitionConsumptionState.getPartition() + ", topic of incoming message: "
+          String errorMsg = partitionConsumptionState.getLeaderFollowerState() + " replica: "
+              + partitionConsumptionState.getReplicaId()
+              + " received a pubsub message that doesn't belong to version topic. Topic of incoming message: "
               + incomingMessageTopic.getName();
           if (!REDUNDANT_LOGGING_FILTER.isRedundantException(errorMsg)) {
             LOGGER.error(errorMsg);
@@ -2043,10 +2032,9 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
             .append("}.");
       }
       LOGGER.info(
-          "{} [{} lag] partition {} is {}. {}Lag: [{}] {} Threshold [{}]. {}",
-          this.ingestionTaskName,
+          "[{} lag] replica: {} is {}. {}Lag: [{}] {} Threshold [{}]. {}",
           lagType.prettyString(),
-          pcs.getPartition(),
+          pcs.getReplicaId(),
           (isLagAcceptable ? "not lagging" : "lagging"),
           (lagType == OFFSET_LAG ? "" : "The latest producer timestamp is " + latestConsumedProducerTimestamp + ". "),
           lag,
@@ -2085,19 +2073,15 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
 
         if (oldState != newState) {
           LOGGER.info(
-              "LeaderCompleteState for store {} version {} partition {} changed from {} to {}",
-              storeName,
-              versionNumber,
-              partitionConsumptionState.getPartition(),
+              "LeaderCompleteState for replica: {} changed from {} to {}",
+              partitionConsumptionState.getReplicaId(),
               oldState,
               newState);
           partitionConsumptionState.setLeaderCompleteState(newState);
         } else {
           LOGGER.debug(
-              "LeaderCompleteState for store {} version {} partition {} received from leader: {} and is unchanged from the previous state",
-              storeName,
-              versionNumber,
-              partitionConsumptionState.getPartition(),
+              "LeaderCompleteState for replica: {} received from leader: {} and is unchanged from the previous state",
+              partitionConsumptionState.getReplicaId(),
               newState);
         }
       }
@@ -2297,7 +2281,11 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
          * messages to disk, and potentially rewind a k/v pair to an old value.
          */
         divErrorMetricCallback.accept(e);
-        LOGGER.debug("{} : Skipping a duplicate record at offset: {}", ingestionTaskName, consumerRecord.getOffset());
+        LOGGER.debug(
+            "Skipping a duplicate record from: {} offset: {} for replica: {}",
+            consumerRecord.getTopicPartition(),
+            consumerRecord.getOffset(),
+            partitionConsumptionState.getReplicaId());
         return DelegateConsumerRecordResult.DUPLICATE_MESSAGE;
       }
 
@@ -2489,8 +2477,8 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
         }
         if (!isSegmentControlMsg(controlMessageType)) {
           LOGGER.info(
-              "{} hasProducedToKafka: {}; ControlMessage: {}; topicPartition: {}; offset: {}",
-              ingestionTaskName,
+              "Replica: {} hasProducedToKafka: {}; ControlMessage: {}; Incoming record topic-partition: {}; offset: {}",
+              partitionConsumptionState.getReplicaId(),
               producedFinally,
               controlMessageType.name(),
               consumerRecord.getTopicPartition(),
@@ -2498,7 +2486,8 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
         }
       } else if (kafkaValue == null) {
         throw new VeniceMessageException(
-            ingestionTaskName + " hasProducedToKafka: Given null Venice Message. TopicPartition: "
+            partitionConsumptionState.getReplicaId()
+                + " hasProducedToKafka: Given null Venice Message. TopicPartition: "
                 + consumerRecord.getTopicPartition() + " Offset " + consumerRecord.getOffset());
       } else {
         // This function may modify the original record in KME and it is unsafe to use the payload from KME directly
@@ -2554,15 +2543,17 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
         }
       } catch (InterruptedException e) {
         LOGGER.warn(
-            "Got interrupted while waiting for the last queued record to be persisted for: {}. "
+            "Got interrupted while waiting for the last queued record to be persisted from: {} for replica: {}"
                 + "Will throw the interrupt exception.",
             topicPartition,
+            partitionConsumptionState.getReplicaId(),
             e);
         throw e;
       } catch (Exception e) {
         LOGGER.error(
-            "Got exception while waiting for the last queued record to be persisted for: {}. Will swallow.",
+            "Got exception while waiting for the last queued record to be persisted from: {} for replica: {}. Will swallow.",
             topicPartition,
+            partitionConsumptionState.getReplicaId(),
             e);
       }
       Future<Void> lastFuture = null;
@@ -2576,23 +2567,25 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
         }
       } catch (InterruptedException e) {
         LOGGER.warn(
-            "Got interrupted while waiting for the last leader producer future for: {}. "
+            "Got interrupted while waiting for the last leader producer future of record from: {} for replica: {}. "
                 + "No data loss. Will throw the interrupt exception.",
             topicPartition,
+            partitionConsumptionState.getReplicaId(),
             e);
         versionedDIVStats.recordBenignLeaderProducerFailure(storeName, versionNumber);
         throw e;
       } catch (TimeoutException e) {
         LOGGER.error(
-            "Timeout on waiting for the last leader producer future for: {}. No data loss. Will swallow.",
+            "Timeout while waiting for the last leader producer future of record from topic-partition: {} for replica: {}. No data loss. Will swallow.",
             topicPartition,
+            partitionConsumptionState.getReplicaId(),
             e);
         lastFuture.cancel(true);
         partitionConsumptionState.setLastLeaderPersistFuture(null);
         versionedDIVStats.recordBenignLeaderProducerFailure(storeName, versionNumber);
       } catch (Exception e) {
         LOGGER.error(
-            "Got exception while waiting for the latest producer future to be completed for: {}. Will swallow.",
+            "Got exception while waiting for the latest producer future to be completed. Will swallow. Topic-partition: {} Replica: {}",
             topicPartition,
             e);
         partitionConsumptionState.setLastLeaderPersistFuture(null);
@@ -3409,9 +3402,10 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
     if (lastOffsetInRealTimeTopic < 0) {
       if (!REDUNDANT_LOGGING_FILTER.isRedundantException("Got a negative lastOffsetInRealTimeTopic")) {
         LOGGER.warn(
-            "Unexpected! Got a negative lastOffsetInRealTimeTopic ({})! Will return Long.MAX_VALUE ({}) as the lag.",
+            "Unexpected! Got a negative lastOffsetInRealTimeTopic ({})! Will return Long.MAX_VALUE ({}) as the lag for replica: {}.",
             lastOffsetInRealTimeTopic,
             Long.MAX_VALUE,
+            pcs.getReplicaId(),
             new VeniceException("Exception not thrown, just for logging purposes."));
       }
       return Long.MAX_VALUE;
@@ -3424,9 +3418,8 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
     long lag = lastOffsetInRealTimeTopic - latestLeaderOffset;
     if (shouldLog) {
       LOGGER.info(
-          "{} partition {} RT lag offset for {} is: Latest RT offset [{}] - persisted offset [{}] = Lag [{}]",
-          ingestionTaskName,
-          pcs.getPartition(),
+          "Replica: {} RT lag offset for {} is: Latest RT offset [{}] - persisted offset [{}] = Lag [{}]",
+          pcs.getReplicaId(),
           sourceRealTimeTopicKafkaURL,
           lastOffsetInRealTimeTopic,
           latestLeaderOffset,
@@ -3482,9 +3475,8 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
     int partitionId = topicPartition.getPartitionNumber();
 
     String logMessage = String.format(
-        "Forward ingestion heartbeat from upstream topic to version topic: %s partition: %s %s.",
-        topicPartitionName,
-        partitionId,
+        "Forward ingestion heartbeat from upstream topic to version topic-partition: %s %s.",
+        Utils.getReplicaId(topicPartitionName, partitionId),
         exception != null ? "failed" : "succeeded");
 
     // using a redundant filter in case if the configured duration to send heartbeat

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/PartitionConsumptionState.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/PartitionConsumptionState.java
@@ -31,6 +31,7 @@ import org.apache.avro.generic.GenericRecord;
  * This class is used to maintain internal state for consumption of each partition.
  */
 public class PartitionConsumptionState {
+  private final String replicaId;
   private final int partition;
   private final int amplificationFactor;
   private final int userPartition;
@@ -217,7 +218,13 @@ public class PartitionConsumptionState {
   private LeaderCompleteState leaderCompleteState;
   private long lastLeaderCompleteStateUpdateInMs;
 
-  public PartitionConsumptionState(int partition, int amplificationFactor, OffsetRecord offsetRecord, boolean hybrid) {
+  public PartitionConsumptionState(
+      String replicaId,
+      int partition,
+      int amplificationFactor,
+      OffsetRecord offsetRecord,
+      boolean hybrid) {
+    this.replicaId = replicaId;
     this.partition = partition;
     this.amplificationFactor = amplificationFactor;
     this.userPartition = PartitionUtils.getUserPartition(partition, amplificationFactor);
@@ -382,9 +389,9 @@ public class PartitionConsumptionState {
 
   @Override
   public String toString() {
-    return new StringBuilder().append("PartitionConsumptionState{")
-        .append("partition=")
-        .append(partition)
+    return new StringBuilder().append("PCS{")
+        .append("replicaId=")
+        .append(replicaId)
         .append(", hybrid=")
         .append(hybrid)
         .append(", latestProcessedLocalVersionTopicOffset=")
@@ -872,5 +879,9 @@ public class PartitionConsumptionState {
 
   public void setLastLeaderCompleteStateUpdateInMs(long lastLeaderCompleteStateUpdateInMs) {
     this.lastLeaderCompleteStateUpdateInMs = lastLeaderCompleteStateUpdateInMs;
+  }
+
+  public String getReplicaId() {
+    return replicaId;
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StatusReportAdapter.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StatusReportAdapter.java
@@ -217,11 +217,12 @@ public class StatusReportAdapter {
         }
       }
       if (updatedCount == amplificationFactor) {
-        maybeReportStatus(status, versionAwareStatus, report, logStatus);
+        maybeReportStatus(partitionConsumptionState.getReplicaId(), status, versionAwareStatus, report, logStatus);
       }
     }
 
     private void maybeReportStatus(
+        String replicaId,
         SubPartitionStatus status,
         String versionAwareStatus,
         Runnable report,
@@ -229,7 +230,11 @@ public class StatusReportAdapter {
       // This is a safeguard to make sure we only report exactly once for each status.
       if (statusReportIndicatorMap.get(versionAwareStatus).compareAndSet(false, true)) {
         if (logStatus) {
-          LOGGER.info("Reporting status {} for user partition: {}.", versionAwareStatus, userPartition);
+          LOGGER.info(
+              "Reporting status {} for user partition: {}. ReplicaId: {}",
+              versionAwareStatus,
+              userPartition,
+              replicaId);
         }
         report.run();
         if (status.equals(COMPLETED)) {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/notifier/LogNotifier.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/notifier/LogNotifier.java
@@ -1,5 +1,6 @@
 package com.linkedin.davinci.notifier;
 
+import com.linkedin.venice.utils.Utils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -11,76 +12,76 @@ public class LogNotifier implements VeniceNotifier {
   private static final Logger LOGGER = LogManager.getLogger(LogNotifier.class);
 
   @Override
-  public void started(String kafkaTopic, int partitionId, String message) {
-    logMessage("Push started", kafkaTopic, partitionId, null, message, null);
+  public void started(String pubSubTopic, int partitionId, String message) {
+    logMessage("Push started", pubSubTopic, partitionId, null, message, null);
   }
 
   @Override
-  public void restarted(String kafkaTopic, int partitionId, long offset, String message) {
-    logMessage("Push restarted", kafkaTopic, partitionId, offset, message, null);
+  public void restarted(String pubSubTopic, int partitionId, long offset, String message) {
+    logMessage("Push restarted", pubSubTopic, partitionId, offset, message, null);
   }
 
   @Override
-  public void completed(String kafkaTopic, int partitionId, long offset, String message) {
-    logMessage("Push completed", kafkaTopic, partitionId, offset, message, null);
+  public void completed(String pubSubTopic, int partitionId, long offset, String message) {
+    logMessage("Push completed", pubSubTopic, partitionId, offset, message, null);
   }
 
   @Override
-  public void progress(String kafkaTopic, int partitionId, long offset, String message) {
-    logMessage("Push progress", kafkaTopic, partitionId, offset, message, null);
+  public void progress(String pubSubTopic, int partitionId, long offset, String message) {
+    logMessage("Push progress", pubSubTopic, partitionId, offset, message, null);
   }
 
   @Override
-  public void endOfPushReceived(String kafkaTopic, int partitionId, long offset, String message) {
-    logMessage("Received END_OF_PUSH", kafkaTopic, partitionId, offset, message, null);
+  public void endOfPushReceived(String pubSubTopic, int partitionId, long offset, String message) {
+    logMessage("Received END_OF_PUSH", pubSubTopic, partitionId, offset, message, null);
   }
 
   @Override
-  public void topicSwitchReceived(String kafkaTopic, int partitionId, long offset, String message) {
-    logMessage("Received TOPIC_SWITCH", kafkaTopic, partitionId, offset, message, null);
+  public void topicSwitchReceived(String pubSubTopic, int partitionId, long offset, String message) {
+    logMessage("Received TOPIC_SWITCH", pubSubTopic, partitionId, offset, message, null);
   }
 
   @Override
-  public void dataRecoveryCompleted(String kafkaTopic, int partitionId, long offset, String message) {
-    logMessage("Data recovery completed", kafkaTopic, partitionId, offset, message, null);
+  public void dataRecoveryCompleted(String pubSubTopic, int partitionId, long offset, String message) {
+    logMessage("Data recovery completed", pubSubTopic, partitionId, offset, message, null);
   }
 
   @Override
-  public void startOfIncrementalPushReceived(String kafkaTopic, int partitionId, long offset, String message) {
-    logMessage("Received START_OF_INCREMENTAL_PUSH", kafkaTopic, partitionId, offset, message, null);
+  public void startOfIncrementalPushReceived(String pubSubTopic, int partitionId, long offset, String message) {
+    logMessage("Received START_OF_INCREMENTAL_PUSH", pubSubTopic, partitionId, offset, message, null);
   }
 
   @Override
-  public void endOfIncrementalPushReceived(String kafkaTopic, int partitionId, long offset, String message) {
-    logMessage("Received END_OF_INCREMENTAL_PUSH", kafkaTopic, partitionId, offset, message, null);
+  public void endOfIncrementalPushReceived(String pubSubTopic, int partitionId, long offset, String message) {
+    logMessage("Received END_OF_INCREMENTAL_PUSH", pubSubTopic, partitionId, offset, message, null);
   }
 
   @Override
-  public void catchUpVersionTopicOffsetLag(String kafkaTopic, int partitionId) {
-    logMessage("Received CATCH_UP_BASE_TOPIC_OFFSET_LAG", kafkaTopic, partitionId, null, "", null);
+  public void catchUpVersionTopicOffsetLag(String pubSubTopic, int partitionId) {
+    logMessage("Received CATCH_UP_BASE_TOPIC_OFFSET_LAG", pubSubTopic, partitionId, null, "", null);
   }
 
   private void logMessage(
       String header,
-      String kafkaTopic,
+      String pubSubTopic,
       int partitionId,
       Long offset,
       String message,
       Exception ex) {
     if (ex == null) {
       LOGGER.info(
-          "{} for store {} user partitionId {}{}{}",
+          "{} for replica: {}{}{}",
           header,
-          kafkaTopic,
+          Utils.getReplicaId(pubSubTopic, partitionId),
+          pubSubTopic,
           partitionId,
           offset == null ? "" : " offset " + offset,
           (message == null || message.isEmpty()) ? "" : " message " + message);
     } else {
       LOGGER.error(
-          "{} for store {} user partitionId {}{}{}",
+          "{} for replica: {}{}{}",
           header,
-          kafkaTopic,
-          partitionId,
+          Utils.getReplicaId(pubSubTopic, partitionId),
           offset == null ? "" : " offset " + offset,
           (message == null || message.isEmpty()) ? "" : " message " + message,
           ex);
@@ -93,12 +94,12 @@ public class LogNotifier implements VeniceNotifier {
   }
 
   @Override
-  public void error(String kafkaTopic, int partitionId, String message, Exception ex) {
-    logMessage("Push errored", kafkaTopic, partitionId, null, message, ex);
+  public void error(String pubSubTopic, int partitionId, String message, Exception ex) {
+    logMessage("Push errored", pubSubTopic, partitionId, null, message, ex);
   }
 
   @Override
-  public void stopped(String kafkaTopic, int partitionId, long offset) {
-    logMessage("Consumption stopped", kafkaTopic, partitionId, offset, null, null);
+  public void stopped(String pubSubTopic, int partitionId, long offset) {
+    logMessage("Consumption stopped", pubSubTopic, partitionId, offset, null, null);
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/StoragePartitionConfig.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/StoragePartitionConfig.java
@@ -1,5 +1,6 @@
 package com.linkedin.davinci.store;
 
+import com.linkedin.venice.utils.Utils;
 import java.util.Objects;
 
 
@@ -112,7 +113,7 @@ public class StoragePartitionConfig {
 
   @Override
   public String toString() {
-    return "Store: " + storeName + ", partition id: " + partitionId + ", deferred-write: " + deferredWrite
+    return "Replica: " + Utils.getReplicaId(storeName, partitionId) + ", deferred-write: " + deferredWrite
         + ", read-only: " + readOnly + ", write-only: " + writeOnlyConfig + ", read-write leader for default CF: "
         + readWriteLeaderForDefaultCF + ", read-write leader for RMD CF: " + readWriteLeaderForRMDCF;
   }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/ReplicationMetadataRocksDBStoragePartition.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/ReplicationMetadataRocksDBStoragePartition.java
@@ -56,7 +56,8 @@ public class ReplicationMetadataRocksDBStoragePartition extends RocksDBStoragePa
         storeConfig);
     this.fullPathForTempSSTFileDir = RocksDBUtils.composeTempRMDSSTFileDir(dbDir, storeNameAndVersion, partitionId);
     if (deferredWrite) {
-      this.rocksDBSstFileWriter = new RocksDBSstFileWriter(storeNameAndVersion,
+      this.rocksDBSstFileWriter = new RocksDBSstFileWriter(
+          storeNameAndVersion,
           partitionId,
           dbDir,
           super.getEnvOptions(),

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/ReplicationMetadataRocksDBStoragePartition.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/ReplicationMetadataRocksDBStoragePartition.java
@@ -54,10 +54,9 @@ public class ReplicationMetadataRocksDBStoragePartition extends RocksDBStoragePa
         rocksDBServerConfig,
         Arrays.asList(RocksDB.DEFAULT_COLUMN_FAMILY, REPLICATION_METADATA_COLUMN_FAMILY),
         storeConfig);
-    this.fullPathForTempSSTFileDir = RocksDBUtils.composeTempRMDSSTFileDir(dbDir, storeName, partitionId);
+    this.fullPathForTempSSTFileDir = RocksDBUtils.composeTempRMDSSTFileDir(dbDir, storeNameAndVersion, partitionId);
     if (deferredWrite) {
-      this.rocksDBSstFileWriter = new RocksDBSstFileWriter(
-          storeName,
+      this.rocksDBSstFileWriter = new RocksDBSstFileWriter(storeNameAndVersion,
           partitionId,
           dbDir,
           super.getEnvOptions(),
@@ -74,8 +73,7 @@ public class ReplicationMetadataRocksDBStoragePartition extends RocksDBStoragePa
     makeSureRocksDBIsStillOpen();
     if (readOnly) {
       throw new VeniceException(
-          "Cannot make writes while partition is opened in read-only mode" + ", partition=" + storeName + "_"
-              + partitionId);
+          "Cannot make writes while database is opened in read-only mode for replica: " + replicaId);
     }
 
     try {
@@ -90,9 +88,7 @@ public class ReplicationMetadataRocksDBStoragePartition extends RocksDBStoragePa
         }
       }
     } catch (RocksDBException e) {
-      throw new VeniceException(
-          "Failed to put key/value pair to store: " + storeName + ", partition id: " + partitionId,
-          e);
+      throw new VeniceException("Failed to put key/value pair to RocksDB: " + replicaId, e);
     }
   }
 
@@ -101,8 +97,7 @@ public class ReplicationMetadataRocksDBStoragePartition extends RocksDBStoragePa
     makeSureRocksDBIsStillOpen();
     if (readOnly) {
       throw new VeniceException(
-          "Cannot make writes while partition is opened in read-only mode" + ", partition=" + storeName + "_"
-              + partitionId);
+          "Cannot make writes while database is opened in read-only mode for replica: " + replicaId);
     }
     try {
       if (deferredWrite) {
@@ -111,9 +106,7 @@ public class ReplicationMetadataRocksDBStoragePartition extends RocksDBStoragePa
         rocksDB.put(columnFamilyHandleList.get(REPLICATION_METADATA_COLUMN_FAMILY_INDEX), writeOptions, key, metadata);
       }
     } catch (RocksDBException e) {
-      throw new VeniceException(
-          "Failed to put key/value pair to store: " + storeName + ", partition id: " + partitionId,
-          e);
+      throw new VeniceException("Failed to put key/value pair to RocksDB: " + replicaId, e);
     }
   }
 
@@ -147,7 +140,7 @@ public class ReplicationMetadataRocksDBStoragePartition extends RocksDBStoragePa
       return rocksDB
           .get(columnFamilyHandleList.get(REPLICATION_METADATA_COLUMN_FAMILY_INDEX), READ_OPTIONS_DEFAULT, key);
     } catch (RocksDBException e) {
-      throw new VeniceException("Failed to get value from store: " + storeName + ", partition id: " + partitionId, e);
+      throw new VeniceException("Failed to get value from RocksDB: " + replicaId, e);
     } finally {
       readCloseRWLock.readLock().unlock();
     }
@@ -165,7 +158,7 @@ public class ReplicationMetadataRocksDBStoragePartition extends RocksDBStoragePa
       }
       return rocksDB.multiGetAsList(getReadOptionsForMultiGet(), cfHandleList, keys);
     } catch (RocksDBException e) {
-      throw new VeniceException("Failed to get value from store: " + storeName + ", partition id: " + partitionId, e);
+      throw new VeniceException("Failed to get value from RocksDB: " + replicaId, e);
     } finally {
       readCloseRWLock.readLock().unlock();
     }
@@ -179,8 +172,7 @@ public class ReplicationMetadataRocksDBStoragePartition extends RocksDBStoragePa
     makeSureRocksDBIsStillOpen();
     if (readOnly) {
       throw new VeniceException(
-          "Cannot make writes while partition is opened in read-only mode" + ", partition=" + storeName + "_"
-              + partitionId);
+          "Cannot make writes while database is opened in read-only mode for replica: " + replicaId);
     }
     try {
       if (deferredWrite) {
@@ -196,8 +188,8 @@ public class ReplicationMetadataRocksDBStoragePartition extends RocksDBStoragePa
       }
     } catch (RocksDBException e) {
       String msg = deferredWrite
-          ? "Failed to put metadata while deleing key for store: " + storeName + ", partition id: " + partitionId
-          : "Failed to delete entry to store: " + storeName + ", partition id: " + partitionId;
+          ? "Failed to put metadata while deleting key from RocksDB: " + replicaId
+          : "Failed to delete entry from the RocksDB: " + replicaId;
       throw new VeniceException(msg, e);
     }
   }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/RocksDBStoragePartition.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/RocksDBStoragePartition.java
@@ -214,7 +214,8 @@ public class RocksDBStoragePartition extends AbstractStoragePartition {
         blobTransferEnabled ? RocksDBUtils.composeSnapshotDir(dbDir, storeNameAndVersion, partitionId) : null;
 
     if (deferredWrite) {
-      this.rocksDBSstFileWriter = new RocksDBSstFileWriter(storeNameAndVersion,
+      this.rocksDBSstFileWriter = new RocksDBSstFileWriter(
+          storeNameAndVersion,
           partitionId,
           dbDir,
           envOptions,
@@ -503,7 +504,8 @@ public class RocksDBStoragePartition extends AbstractStoragePartition {
 
   private void checkAndThrowMemoryLimitException(RocksDBException e) {
     if (e.getMessage().contains(ROCKSDB_ERROR_MESSAGE_FOR_RUNNING_OUT_OF_SPACE_QUOTA)) {
-      throw new MemoryLimitExhaustedException(storeNameAndVersion,
+      throw new MemoryLimitExhaustedException(
+          storeNameAndVersion,
           partitionId,
           factory.getSstFileManagerForMemoryLimiter().getTotalSize());
     }
@@ -878,7 +880,10 @@ public class RocksDBStoragePartition extends AbstractStoragePartition {
     if (writeOptions != null) {
       writeOptions.close();
     }
-    LOGGER.info("RocksDB close for replica: {} took {} ms.", replicaId, LatencyUtils.getElapsedTimeFromMsToMs(startTimeInMs));
+    LOGGER.info(
+        "RocksDB close for replica: {} took {} ms.",
+        replicaId,
+        LatencyUtils.getElapsedTimeFromMsToMs(startTimeInMs));
   }
 
   /**
@@ -890,8 +895,10 @@ public class RocksDBStoragePartition extends AbstractStoragePartition {
     try {
       long startTimeInMs = System.currentTimeMillis();
       rocksDB.close();
-      LOGGER
-          .info("RocksDB close for replica: {} took {} ms.", replicaId, LatencyUtils.getElapsedTimeFromMsToMs(startTimeInMs));
+      LOGGER.info(
+          "RocksDB close for replica: {} took {} ms.",
+          replicaId,
+          LatencyUtils.getElapsedTimeFromMsToMs(startTimeInMs));
       if (this.readOnly) {
         this.rocksDB = rocksDBThrottler
             .openReadOnly(options, fullPathForPartitionDB, columnFamilyDescriptors, columnFamilyHandleList);

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/PartitionConsumptionStateTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/PartitionConsumptionStateTest.java
@@ -11,6 +11,7 @@ import com.linkedin.venice.kafka.validation.checksum.CheckSumType;
 import com.linkedin.venice.offsets.OffsetRecord;
 import com.linkedin.venice.schema.rmd.RmdSchemaGenerator;
 import com.linkedin.venice.serialization.avro.AvroProtocolDefinition;
+import com.linkedin.venice.utils.Utils;
 import com.linkedin.venice.writer.LeaderCompleteState;
 import com.linkedin.venice.writer.WriterChunkingHelper;
 import java.nio.ByteBuffer;
@@ -22,9 +23,11 @@ import org.testng.annotations.Test;
 
 
 public class PartitionConsumptionStateTest {
+  private static final String replicaId = Utils.getReplicaId("topic1", 0);
+
   @Test
   public void testUpdateChecksum() {
-    PartitionConsumptionState pcs = new PartitionConsumptionState(0, 1, mock(OffsetRecord.class), false);
+    PartitionConsumptionState pcs = new PartitionConsumptionState(replicaId, 0, 1, mock(OffsetRecord.class), false);
     pcs.initializeExpectedChecksum();
     byte[] rmdPayload = new byte[] { 127 };
     byte[] key1 = new byte[] { 1 };
@@ -79,7 +82,7 @@ public class PartitionConsumptionStateTest {
    */
   @Test
   public void testTransientRecordMap() {
-    PartitionConsumptionState pcs = new PartitionConsumptionState(0, 1, mock(OffsetRecord.class), false);
+    PartitionConsumptionState pcs = new PartitionConsumptionState(replicaId, 0, 1, mock(OffsetRecord.class), false);
 
     byte[] key1 = new byte[] { 65, 66, 67, 68 };
     byte[] key2 = new byte[] { 65, 66, 67, 68 };
@@ -126,7 +129,7 @@ public class PartitionConsumptionStateTest {
 
   @Test
   public void testIsLeaderCompleted() {
-    PartitionConsumptionState pcs = new PartitionConsumptionState(0, 1, mock(OffsetRecord.class), false);
+    PartitionConsumptionState pcs = new PartitionConsumptionState(replicaId, 0, 1, mock(OffsetRecord.class), false);
     // default is LEADER_NOT_COMPLETED
     assertEquals(pcs.getLeaderCompleteState(), LeaderCompleteState.LEADER_NOT_COMPLETED);
     assertFalse(pcs.isLeaderCompleted());

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StorageUtilizationManagerTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StorageUtilizationManagerTest.java
@@ -12,6 +12,7 @@ import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.meta.VersionStatus;
 import com.linkedin.venice.offsets.OffsetRecord;
+import com.linkedin.venice.utils.Utils;
 import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import org.mockito.ArgumentMatcher;
@@ -50,7 +51,8 @@ public class StorageUtilizationManagerTest {
     partitionConsumptionStateMap = new VeniceConcurrentHashMap<>();
 
     for (int i = 1; i <= storePartitionCount; i++) {
-      PartitionConsumptionState pcs = new PartitionConsumptionState(i, 1, mock(OffsetRecord.class), true);
+      PartitionConsumptionState pcs =
+          new PartitionConsumptionState(Utils.getReplicaId(topic, i), i, 1, mock(OffsetRecord.class), true);
       partitionConsumptionStateMap.put(i, pcs);
     }
 

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
@@ -3437,8 +3437,12 @@ public abstract class StoreIngestionTaskTest {
             null);
 
     OffsetRecord mockOffsetRecord = mock(OffsetRecord.class);
-    PartitionConsumptionState partitionConsumptionState =
-        new PartitionConsumptionState(PARTITION_FOO, amplificationFactor, mockOffsetRecord, true);
+    PartitionConsumptionState partitionConsumptionState = new PartitionConsumptionState(
+        Utils.getReplicaId(topic, PARTITION_FOO),
+        PARTITION_FOO,
+        amplificationFactor,
+        mockOffsetRecord,
+        true);
 
     long producerTimestamp = System.currentTimeMillis();
     LeaderMetadataWrapper mockLeaderMetadataWrapper = mock(LeaderMetadataWrapper.class);
@@ -3722,7 +3726,8 @@ public abstract class StoreIngestionTaskTest {
 
     OffsetRecord offsetRecord = mock(OffsetRecord.class);
     doReturn(pubSubTopicRepository.getTopic(versionTopicName)).when(offsetRecord).getLeaderTopic(any());
-    PartitionConsumptionState partitionConsumptionState = new PartitionConsumptionState(0, 1, offsetRecord, false);
+    PartitionConsumptionState partitionConsumptionState =
+        new PartitionConsumptionState(Utils.getReplicaId(versionTopicName, 0), 0, 1, offsetRecord, false);
 
     long localVersionTopicOffset = 100L;
     long remoteVersionTopicOffset = 200L;
@@ -4064,7 +4069,8 @@ public abstract class StoreIngestionTaskTest {
 
     OffsetRecord offsetRecord = mock(OffsetRecord.class);
     doReturn(pubSubTopic).when(offsetRecord).getLeaderTopic(any());
-    PartitionConsumptionState partitionConsumptionState = new PartitionConsumptionState(0, 1, offsetRecord, false);
+    PartitionConsumptionState partitionConsumptionState =
+        new PartitionConsumptionState(Utils.getReplicaId(pubSubTopic, 0), 0, 1, offsetRecord, false);
 
     storeIngestionTaskUnderTest.updateLeaderTopicOnFollower(partitionConsumptionState);
     storeIngestionTaskUnderTest.startConsumingAsLeader(partitionConsumptionState);

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/store/rocksdb/RocksDBStoragePartitionTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/store/rocksdb/RocksDBStoragePartitionTest.java
@@ -640,7 +640,7 @@ public class RocksDBStoragePartitionTest {
       storagePartition.get((KEY_PREFIX + "10").getBytes());
       Assert.fail("VeniceException is expected when looking up an already closed DB");
     } catch (VeniceException e) {
-      assertTrue(e.getMessage().contains("RocksDB has been closed for store"));
+      Assert.assertTrue(e.getMessage().contains("RocksDB has been closed for replica"));
     }
 
     storagePartition.drop();

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/PubSubTopicPartitionImpl.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/PubSubTopicPartitionImpl.java
@@ -2,6 +2,7 @@ package com.linkedin.venice.pubsub;
 
 import com.linkedin.venice.pubsub.api.PubSubTopic;
 import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
+import com.linkedin.venice.utils.Utils;
 import java.util.Objects;
 
 
@@ -47,7 +48,7 @@ public class PubSubTopicPartitionImpl implements PubSubTopicPartition {
   @Override
   public String toString() {
     if (this.toStringOutput == null) {
-      this.toStringOutput = "TP(topic: '" + topic.getName() + "', partition: " + partitionNumber + ")";
+      this.toStringOutput = Utils.getReplicaId(getTopicName(), getPartitionNumber());
     }
     return this.toStringOutput;
   }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/utils/Utils.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/utils/Utils.java
@@ -20,6 +20,8 @@ import com.linkedin.venice.meta.ReadOnlyStoreRepository;
 import com.linkedin.venice.meta.RoutingDataRepository;
 import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.Version;
+import com.linkedin.venice.pubsub.api.PubSubTopic;
+import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
 import com.linkedin.venice.pushmonitor.ExecutionStatus;
 import com.linkedin.venice.serialization.avro.AvroProtocolDefinition;
 import com.linkedin.venice.serialization.avro.InternalAvroSpecificSerializer;
@@ -901,5 +903,20 @@ public class Utils {
    */
   public static String getSanitizedStringForLogger(String orig) {
     return orig.replace('.', '_');
+  }
+
+  /**
+   * Standard logging format for TopicPartition
+   */
+  public static String getReplicaId(PubSubTopicPartition topicPartition) {
+    return getReplicaId(topicPartition.getPubSubTopic(), topicPartition.getPartitionNumber());
+  }
+
+  public static String getReplicaId(String topic, int partition) {
+    return topic + "-" + partition;
+  }
+
+  public static String getReplicaId(PubSubTopic topic, int partition) {
+    return topic + "-" + partition;
   }
 }

--- a/services/venice-server/src/test/java/com/linkedin/venice/listener/StorageReadRequestHandlerTest.java
+++ b/services/venice-server/src/test/java/com/linkedin/venice/listener/StorageReadRequestHandlerTest.java
@@ -89,6 +89,7 @@ import com.linkedin.venice.serializer.SerializerDeserializerFactory;
 import com.linkedin.venice.streaming.StreamingUtils;
 import com.linkedin.venice.unit.kafka.SimplePartitioner;
 import com.linkedin.venice.utils.DataProviderUtils;
+import com.linkedin.venice.utils.Utils;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http.DefaultFullHttpRequest;
@@ -379,6 +380,7 @@ public class StorageReadRequestHandlerTest {
     // Mock the AdminResponse from ingestion task
     AdminResponse expectedAdminResponse = new AdminResponse();
     PartitionConsumptionState state = new PartitionConsumptionState(
+        Utils.getReplicaId(topic, expectedPartitionId),
         expectedPartitionId,
         1,
         new OffsetRecord(AvroProtocolDefinition.PARTITION_STATE.getSerializer()),


### PR DESCRIPTION
## Adopt standard logging format for topic-partition/replica ID to simplify log extraction
Currently, extracting logs for a specific replica is challenging due to varying log formats
chosen by developers. For instance, consider the complexity of this command:
grep -e " 205 " -e ": 205)" -e "=205," -e "=205 " -e ": 205 " -e "_205" -e "-205-" -e " 205;"
-e ": 205," venice-server-war.log.2023-11-2* | grep -v "205 ms" | grep -v "205 second"
Even with such a command, we might not retrieve all logs for the replica. The aim of this commit
is to adopt a standardized logging format for topic-partition/replica ID, to make log extraction
easier and more straightforward.



## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.