### PR TITLE
[server] Remove consumer action queue inside StoreIngestionTask

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
@@ -95,6 +95,7 @@ import static com.linkedin.venice.ConfigKeys.SERVER_OPTIMIZE_DATABASE_FOR_BACKUP
 import static com.linkedin.venice.ConfigKeys.SERVER_OPTIMIZE_DATABASE_SERVICE_SCHEDULE_INTERNAL_SECONDS;
 import static com.linkedin.venice.ConfigKeys.SERVER_PARALLEL_BATCH_GET_CHUNK_SIZE;
 import static com.linkedin.venice.ConfigKeys.SERVER_PARTITION_GRACEFUL_DROP_DELAY_IN_SECONDS;
+import static com.linkedin.venice.ConfigKeys.SERVER_PROCESS_CONSUMER_ACTION_WITHOUT_ENQUEUE_ENABLE;
 import static com.linkedin.venice.ConfigKeys.SERVER_PROMOTION_TO_LEADER_REPLICA_DELAY_SECONDS;
 import static com.linkedin.venice.ConfigKeys.SERVER_PUBSUB_CONSUMER_POLL_RETRY_BACKOFF_MS;
 import static com.linkedin.venice.ConfigKeys.SERVER_PUBSUB_CONSUMER_POLL_RETRY_TIMES;
@@ -466,6 +467,8 @@ public class VeniceServerConfig extends VeniceClusterConfig {
   private final boolean recordLevelMetricWhenBootstrappingCurrentVersionEnabled;
   private final String identityParserClassName;
 
+  private final boolean processConsumerActionWithoutEnqueueEnabled;
+
   public VeniceServerConfig(VeniceProperties serverProperties) throws ConfigurationException {
     this(serverProperties, Collections.emptyMap());
   }
@@ -766,6 +769,8 @@ public class VeniceServerConfig extends VeniceClusterConfig {
     recordLevelMetricWhenBootstrappingCurrentVersionEnabled =
         serverProperties.getBoolean(SERVER_RECORD_LEVEL_METRICS_WHEN_BOOTSTRAPPING_CURRENT_VERSION_ENABLED, true);
     identityParserClassName = serverProperties.getString(IDENTITY_PARSER_CLASS, DefaultIdentityParser.class.getName());
+    processConsumerActionWithoutEnqueueEnabled =
+        serverProperties.getBoolean(SERVER_PROCESS_CONSUMER_ACTION_WITHOUT_ENQUEUE_ENABLE, true);
   }
 
   long extractIngestionMemoryLimit(
@@ -1362,5 +1367,9 @@ public class VeniceServerConfig extends VeniceClusterConfig {
 
   public String getIdentityParserClassName() {
     return identityParserClassName;
+  }
+
+  public boolean isProcessConsumerActionWithoutEnqueueEnabled() {
+    return processConsumerActionWithoutEnqueueEnabled;
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -328,10 +328,7 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
       PubSubTopicPartition topicPartition,
       LeaderFollowerPartitionStateModel.LeaderSessionIdChecker checker) {
     throwIfNotRunning();
-    partitionToPendingConsumerActionCountMap
-        .computeIfAbsent(topicPartition.getPartitionNumber(), x -> new AtomicInteger(0))
-        .incrementAndGet();
-    consumerActionsQueue.add(new ConsumerAction(STANDBY_TO_LEADER, topicPartition, nextSeqNum(), checker, true));
+    processConsumerActionOrEnqueue(new ConsumerAction(STANDBY_TO_LEADER, topicPartition, nextSeqNum(), checker, true));
   }
 
   @Override
@@ -339,10 +336,7 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
       PubSubTopicPartition topicPartition,
       LeaderFollowerPartitionStateModel.LeaderSessionIdChecker checker) {
     throwIfNotRunning();
-    partitionToPendingConsumerActionCountMap
-        .computeIfAbsent(topicPartition.getPartitionNumber(), x -> new AtomicInteger(0))
-        .incrementAndGet();
-    consumerActionsQueue.add(new ConsumerAction(LEADER_TO_STANDBY, topicPartition, nextSeqNum(), checker, true));
+    processConsumerActionOrEnqueue(new ConsumerAction(LEADER_TO_STANDBY, topicPartition, nextSeqNum(), checker, true));
   }
 
   @Override

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/PartitionConsumptionState.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/PartitionConsumptionState.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.avro.generic.GenericRecord;
 
 
@@ -203,6 +204,8 @@ public class PartitionConsumptionState {
   private LeaderCompleteState leaderCompleteState;
   private long lastLeaderCompleteStateUpdateInMs;
 
+  private AtomicInteger lastConsumerActionSeqNum;
+
   public PartitionConsumptionState(String replicaId, int partition, OffsetRecord offsetRecord, boolean hybrid) {
     this.replicaId = replicaId;
     this.partition = partition;
@@ -246,6 +249,7 @@ public class PartitionConsumptionState {
     this.lastVTProduceCallFuture = CompletableFuture.completedFuture(null);
     this.leaderCompleteState = LeaderCompleteState.LEADER_NOT_COMPLETED;
     this.lastLeaderCompleteStateUpdateInMs = 0;
+    this.lastConsumerActionSeqNum = new AtomicInteger(0);
   }
 
   public int getPartition() {
@@ -832,5 +836,13 @@ public class PartitionConsumptionState {
 
   public String getReplicaId() {
     return replicaId;
+  }
+
+  public void setLastConsumerActionSeqNum(Integer processedConsumerActionSeqNum) {
+    this.lastConsumerActionSeqNum.set(processedConsumerActionSeqNum);
+  }
+
+  public Integer getLastConsumerActionSeqNum() {
+    return this.lastConsumerActionSeqNum.get();
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/HostLevelIngestionStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/HostLevelIngestionStats.java
@@ -61,6 +61,11 @@ public class HostLevelIngestionStats extends AbstractVeniceStats {
   private final LongAdderRateGauge totalTimestampRegressionDCRErrorRate;
   private final LongAdderRateGauge totalOffsetRegressionDCRErrorRate;
   /**
+   * Sensors for emitting if/when we detect out of order consumer action execution as not only {@link StoreIngestionTask}
+   * thread executing the consumer action.
+   */
+  private final LongAdderRateGauge totalOutOfOrderConsumerActionExecutionErrorRate;
+  /**
    * A gauge reporting the total the percentage of hybrid quota used.
    */
   private double hybridQuotaUsageGauge;
@@ -207,6 +212,12 @@ public class HostLevelIngestionStats extends AbstractVeniceStats {
         "offset_regression_dcr_error",
         totalStats,
         () -> totalStats.totalOffsetRegressionDCRErrorRate,
+        time);
+
+    this.totalOutOfOrderConsumerActionExecutionErrorRate = registerOnlyTotalRate(
+        "out_of_order_consumer_action_execution_error_rate",
+        totalStats,
+        () -> totalStats.totalOutOfOrderConsumerActionExecutionErrorRate,
         time);
 
     Int2ObjectMap<String> kafkaClusterIdToAliasMap = serverConfig.getKafkaClusterIdToAliasMap();
@@ -591,5 +602,9 @@ public class HostLevelIngestionStats extends AbstractVeniceStats {
 
   public void recordOffsetRegressionDCRError() {
     totalOffsetRegressionDCRErrorRate.record();
+  }
+
+  public void recordTotalOutOfOrderConsumerActionExecutionError() {
+    totalOutOfOrderConsumerActionExecutionErrorRate.record();
   }
 }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/SITWithPWiseAndProcessConsumerActionWithoutEnqueueDisabled.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/SITWithPWiseAndProcessConsumerActionWithoutEnqueueDisabled.java
@@ -1,11 +1,11 @@
 package com.linkedin.davinci.kafka.consumer;
 
-public class SITWithPWiseWithoutBufferAfterLeaderTest extends StoreIngestionTaskTest {
+public class SITWithPWiseAndProcessConsumerActionWithoutEnqueueDisabled extends StoreIngestionTaskTest {
   protected KafkaConsumerService.ConsumerAssignmentStrategy getConsumerAssignmentStrategy() {
     return KafkaConsumerService.ConsumerAssignmentStrategy.PARTITION_WISE_SHARED_CONSUMER_ASSIGNMENT_STRATEGY;
   }
 
-  protected boolean isStoreWriterBufferAfterLeaderLogicEnabled() {
+  protected boolean isProcessConsumerActionWithoutEnqueueEnabled() {
     return false;
   }
 }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/SITWithPWiseAndProcessConsumerActionWithoutEnqueueEnabled.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/SITWithPWiseAndProcessConsumerActionWithoutEnqueueEnabled.java
@@ -1,11 +1,11 @@
 package com.linkedin.davinci.kafka.consumer;
 
-public class SITWithPWiseAndBufferAfterLeaderTest extends StoreIngestionTaskTest {
+public class SITWithPWiseAndProcessConsumerActionWithoutEnqueueEnabled extends StoreIngestionTaskTest {
   protected KafkaConsumerService.ConsumerAssignmentStrategy getConsumerAssignmentStrategy() {
     return KafkaConsumerService.ConsumerAssignmentStrategy.PARTITION_WISE_SHARED_CONSUMER_ASSIGNMENT_STRATEGY;
   }
 
-  protected boolean isStoreWriterBufferAfterLeaderLogicEnabled() {
+  protected boolean isProcessConsumerActionWithoutEnqueueEnabled() {
     return true;
   }
 }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/SITWithTWiseAndProcessConsumerActionWithoutEnqueueEnabled.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/SITWithTWiseAndProcessConsumerActionWithoutEnqueueEnabled.java
@@ -1,11 +1,11 @@
 package com.linkedin.davinci.kafka.consumer;
 
-public class SITWithTWiseAndBufferAfterLeaderTest extends StoreIngestionTaskTest {
+public class SITWithTWiseAndProcessConsumerActionWithoutEnqueueEnabled extends StoreIngestionTaskTest {
   protected KafkaConsumerService.ConsumerAssignmentStrategy getConsumerAssignmentStrategy() {
     return KafkaConsumerService.ConsumerAssignmentStrategy.TOPIC_WISE_SHARED_CONSUMER_ASSIGNMENT_STRATEGY;
   }
 
-  protected boolean isStoreWriterBufferAfterLeaderLogicEnabled() {
+  protected boolean isProcessConsumerActionWithoutEnqueueEnabled() {
     return true;
   }
 }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/SITWithTWiseWithoutProcessConsumerActionWithoutEnqueueDisabled.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/SITWithTWiseWithoutProcessConsumerActionWithoutEnqueueDisabled.java
@@ -1,11 +1,11 @@
 package com.linkedin.davinci.kafka.consumer;
 
-public class SITWithTWiseWithoutBufferAfterLeaderTest extends StoreIngestionTaskTest {
+public class SITWithTWiseWithoutProcessConsumerActionWithoutEnqueueDisabled extends StoreIngestionTaskTest {
   protected KafkaConsumerService.ConsumerAssignmentStrategy getConsumerAssignmentStrategy() {
     return KafkaConsumerService.ConsumerAssignmentStrategy.TOPIC_WISE_SHARED_CONSUMER_ASSIGNMENT_STRATEGY;
   }
 
-  protected boolean isStoreWriterBufferAfterLeaderLogicEnabled() {
+  protected boolean isProcessConsumerActionWithoutEnqueueEnabled() {
     return false;
   }
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -2161,4 +2161,11 @@ public class ConfigKeys {
    */
   public static final String CONTROLLER_DANGLING_TOPIC_OCCURRENCE_THRESHOLD_FOR_CLEANUP =
       "controller.dangling.topic.occurrence.threshold.for.cleanup";
+  /**
+   * Whether to bypass the consumer action queue. If true, {@link StoreIngestionTask} thread is responsible for executing
+   * consumer action.
+   */
+  public static final String SERVER_PROCESS_CONSUMER_ACTION_WITHOUT_ENQUEUE_ENABLE =
+      "server.process.consumer.action.without.enqueue.enable";
+
 }


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->
This change is for removing the consumer action queue inside `StoreIngestionTask`. Previously other thread will enqueue the consumer actions, and then `StoreIngestionTask` thread will process these consumer actions. 

-  `SUBSCRIBE` : triggered by helix transition from OFFLINE to STANDBY, `StoreIngestionTask` thread for processIngestionException.
- `UNSUBSCRIBE`: triggered by helix transition from STANDBY to OFFLINE,  `StoreBufferDrainer` thread (ready to serve check and div error handling), `StoreIngestionTask` thread for processIngestionException.
- `STANDBY_TO_LEADER`:  triggered by helix transition from STANDBY to LEADER
- `LEADER_TO_STANDBY`: triggered by helix transition from LEADER to STANDBY
- `KILL`:  `missingSOPCheckExecutor` thread. 
-  `RESET_OFFSET`:  triggered by helix transition from OFFLINE to DROPPED.

By removing the queue, each thread will be responsible for execution of the action and handling exceptions. Except for `KILL` Operation,  KILL operation will still be processed by `StoreIngestionTask` thread.  There are benefits:
1. State transition thread will be blocked until these operations finished: `standby_to_leader`, `leader_to_standby`. So that means there will only be one helix thread interacting with `StoreIngestionTask` for a specific version topic partition. So it is not possible a `standby_to_leader` considered to be finished, but subscribe operation as leader is not finished. 
2. Parallel execution of consumer action execution will improve the speed. 

Introduce a new config for enabling this feature so that we can roll back safely. 
Besides, `UNSUBSCRIBE` operation called from `StoreBufferService#Drainer` would cause problem as it will need to wait drainer to finish remain records.  Without introducing a new thread for executing the unsub operation, the drainer will be stuck. 


## Summary, imperative, start upper case, don't end with a period
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Resolves #XXX

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.