### PR TITLE
[client][internal] Fix tests related to PR#975

### DIFF
--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/fastclient/FastClientGrpcServerReadQuotaTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/fastclient/FastClientGrpcServerReadQuotaTest.java
@@ -43,8 +43,10 @@ public class FastClientGrpcServerReadQuotaTest extends AbstractClientEndToEndSet
         StoreMetadataFetchMode.SERVER_BASED_METADATA);
     // Update the read quota to 1000 and make 500 requests, all requests should be allowed.
     veniceCluster.useControllerClient(controllerClient -> {
-      TestUtils
-          .assertCommand(controllerClient.updateStore(storeName, new UpdateStoreQueryParams().setReadQuotaInCU(1000)));
+      TestUtils.assertCommand(
+          controllerClient.updateStore(
+              storeName,
+              new UpdateStoreQueryParams().setReadQuotaInCU(1000).setStorageNodeReadQuotaEnabled(true)));
     });
     for (int j = 0; j < 5; j++) {
       for (int i = 0; i < recordCnt; i++) {

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/fastclient/FastClientIndividualFeatureConfigurationTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/fastclient/FastClientIndividualFeatureConfigurationTest.java
@@ -60,8 +60,10 @@ public class FastClientIndividualFeatureConfigurationTest extends AbstractClient
         StoreMetadataFetchMode.SERVER_BASED_METADATA);
     // Update the read quota to 1000 and make 500 requests, all requests should be allowed.
     veniceCluster.useControllerClient(controllerClient -> {
-      TestUtils
-          .assertCommand(controllerClient.updateStore(storeName, new UpdateStoreQueryParams().setReadQuotaInCU(1000)));
+      TestUtils.assertCommand(
+          controllerClient.updateStore(
+              storeName,
+              new UpdateStoreQueryParams().setReadQuotaInCU(1000).setStorageNodeReadQuotaEnabled(true)));
     });
     for (int j = 0; j < 5; j++) {
       for (int i = 0; i < recordCnt; i++) {

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/fastclient/FastClientIndividualFeatureConfigurationTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/fastclient/FastClientIndividualFeatureConfigurationTest.java
@@ -42,11 +42,27 @@ import org.apache.avro.generic.GenericRecord;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.testng.Assert;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 
 public class FastClientIndividualFeatureConfigurationTest extends AbstractClientEndToEndSetup {
   private static final Logger LOGGER = LogManager.getLogger();
+
+  /*
+   * @{link AbstractClientEndToEndSetup} enables the read quota for stores as part of prepareData and stores are
+   * typically reused at a class level for tests. However, some tests require flows to disable read quota, and
+   * it is important to reset so that these tests don't step on other tests. For now, we choose to add a before
+   * method to class that validates disabled read quota behavior to reset the state to ensure other tests run
+   * successfully.
+   */
+  @BeforeMethod
+  public void enableStoreReadQuota() {
+    veniceCluster.useControllerClient(controllerClient -> {
+      TestUtils.assertCommand(
+          controllerClient.updateStore(storeName, new UpdateStoreQueryParams().setStorageNodeReadQuotaEnabled(true)));
+    });
+  }
 
   @Test(timeOut = TIME_OUT)
   public void testServerReadQuota() throws Exception {

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/fastclient/utils/AbstractClientEndToEndSetup.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/fastclient/utils/AbstractClientEndToEndSetup.java
@@ -230,6 +230,10 @@ public abstract class AbstractClientEndToEndSetup {
     waitForRouterD2();
   }
 
+  /**
+   * <b>Note:</b> Classes that overrides this method need to ensure the store creation enables the storage
+   * node read quota.
+   */
   protected void prepareData() throws Exception {
     // Create test store
     VersionCreationResponse creationResponse = veniceCluster.getNewStoreVersion(KEY_SCHEMA_STR, VALUE_SCHEMA_STR);

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/fastclient/grpc/VeniceGrpcEndToEndTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/fastclient/grpc/VeniceGrpcEndToEndTest.java
@@ -95,7 +95,8 @@ public class VeniceGrpcEndToEndTest {
   public String writeData(String storeName) throws IOException {
     // 1. Create a new store in Venice
     cluster.getNewStore(storeName);
-    UpdateStoreQueryParams params = new UpdateStoreQueryParams().setStorageQuotaInByte(Store.UNLIMITED_STORAGE_QUOTA);
+    UpdateStoreQueryParams params = new UpdateStoreQueryParams().setStorageQuotaInByte(Store.UNLIMITED_STORAGE_QUOTA)
+        .setStorageNodeReadQuotaEnabled(true);
 
     ControllerResponse updateStoreResponse = cluster.updateStore(storeName, params);
     Assert.assertNull(updateStoreResponse.getError());


### PR DESCRIPTION
## Summary
- Fix tests failures due to #975 
- Extracting the test fixes from #987 
- Reset storage node read quota enabled flag prior to each test in `FastClientIndividualFeatureConfigurationTest`

## How was this PR tested?
ran the failing tests locally in intellij and terminal 

## Does this PR introduce any user-facing changes?
- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.