### PR TITLE
[davinci] PartitionTracker code cleanup

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/validation/PartitionTracker.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/validation/PartitionTracker.java
@@ -566,7 +566,9 @@ public class PartitionTracker {
         logger.error(
             "Encountered missing data message within the log compaction time window. Error msg: {}",
             dataMissingException.getMessage());
-        errorMetricCallback.ifPresent(divErrorMetricCallback -> divErrorMetricCallback.execute(dataMissingException));
+        if (errorMetricCallback.isPresent()) {
+          errorMetricCallback.get().execute(dataMissingException);
+        }
         throw dataMissingException;
       }
       segment.setSequenceNumber(incomingSequenceNumber);
@@ -601,7 +603,9 @@ public class PartitionTracker {
       logger.error(
           "Encountered a missing segment. This is unacceptable even if log compaction kicks in. Error msg: {}",
           missingSegment.getMessage());
-      errorMetricCallback.ifPresent(divErrorMetricCallback -> divErrorMetricCallback.execute(missingSegment));
+      if (errorMetricCallback.isPresent()) {
+        errorMetricCallback.get().execute(missingSegment);
+      }
       throw missingSegment;
     }
 


### PR DESCRIPTION
This change cleans up the code in PartitionTracker based on IDE warnings and there should have no semantics or functionality modifications.

## How was this PR tested?
passed CI tests.

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.