### PR TITLE
[vpj] Fix file system on spark push job

### DIFF
--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/spark/input/hdfs/VeniceHdfsInputPartitionReader.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/spark/input/hdfs/VeniceHdfsInputPartitionReader.java
@@ -39,11 +39,9 @@ public class VeniceHdfsInputPartitionReader extends VeniceAbstractPartitionReade
       throw new VeniceException("Expected VeniceHdfsInputPartition");
     }
     VeniceHdfsInputPartition inputPartition = (VeniceHdfsInputPartition) partition;
-
-    Configuration configuration = new Configuration();
     FileSystem fs;
     try {
-      fs = FileSystem.get(configuration);
+      fs = inputPartition.getFilePath().getFileSystem(new Configuration());
     } catch (IOException e) {
       throw new VeniceException("Unable to get a FileSystem", e);
     }

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/spark/input/hdfs/VeniceHdfsInputScan.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/spark/input/hdfs/VeniceHdfsInputScan.java
@@ -32,7 +32,7 @@ public class VeniceHdfsInputScan implements Scan, Batch {
   public InputPartition[] planInputPartitions() {
     try {
       Path inputDirPath = new Path(jobConfig.getString(INPUT_PATH_PROP));
-      FileSystem fs = FileSystem.get(new Configuration());
+      FileSystem fs = inputDirPath.getFileSystem(new Configuration());
       List<VeniceHdfsInputPartition> inputPartitionList = new ArrayList<>();
       // For now, we create 1 file as 1 InputPartition. This is not the most ideal, because Avro allows splitting files
       // to a smaller granularity using sync markers. We can explore later if we feel we need that optimization.


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Summary, imperative, start upper case, don't end with a period
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

The current spark job is incapable of reading from other file systems because it takes the default file system. This adds the fixes on such cases enabling to read from any file system. Related to https://github.com/linkedin/venice/pull/711

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

Tested on s3 which fails on the current code with error

```
java.lang.IllegalArgumentException: Wrong FS: s3a://.../.../a.avro, expected: file:///
```

Which now succeeds

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.