### PR TITLE
[Controller] Fixed superset schema generation issue

### DIFF
--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/supersetschema/SupersetSchemaGeneratorWithCustomProp.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/supersetschema/SupersetSchemaGeneratorWithCustomProp.java
@@ -41,7 +41,7 @@ public class SupersetSchemaGeneratorWithCustomProp implements SupersetSchemaGene
      * Check whether the latest value schema contains {@link #customProp} or not.
      */
     String customPropInLatestValueSchema = latestValueSchemaEntry.getSchema().getProp(customProp);
-    if (customPropInLatestValueSchema != null) {
+    if (customPropInLatestValueSchema != null && supersetSchemaEntry.getSchema().getProp(customProp) == null) {
       Schema newSupersetSchema = supersetSchemaEntry.clone().getSchema();
       // Not empty, then copy it to the superset schema
       newSupersetSchema.addProp(customProp, customPropInLatestValueSchema);
@@ -74,7 +74,7 @@ public class SupersetSchemaGeneratorWithCustomProp implements SupersetSchemaGene
   public Schema generateSupersetSchema(Schema existingSchema, Schema newSchema) {
     Schema supersetSchema = AvroSupersetSchemaUtils.generateSuperSetSchema(existingSchema, newSchema);
     String customPropInNewSchema = newSchema.getProp(customProp);
-    if (customPropInNewSchema != null) {
+    if (customPropInNewSchema != null) {// && supersetSchema.getProp(customProp) == null) {
       Schema newSupersetSchema = AvroSchemaParseUtils.parseSchemaFromJSONLooseValidation(supersetSchema.toString());
       newSupersetSchema.addProp(customProp, customPropInNewSchema);
       return newSupersetSchema;

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/supersetschema/SupersetSchemaGeneratorWithCustomProp.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/supersetschema/SupersetSchemaGeneratorWithCustomProp.java
@@ -42,6 +42,10 @@ public class SupersetSchemaGeneratorWithCustomProp implements SupersetSchemaGene
      */
     String customPropInLatestValueSchema = latestValueSchemaEntry.getSchema().getProp(customProp);
     if (customPropInLatestValueSchema != null && supersetSchemaEntry.getSchema().getProp(customProp) == null) {
+      /**
+       * The 'supersetSchemaEntry' can contain a different custom prop value than the latest value schema, and
+       * custom prop value is not mutable.
+       */
       Schema newSupersetSchema = supersetSchemaEntry.clone().getSchema();
       // Not empty, then copy it to the superset schema
       newSupersetSchema.addProp(customProp, customPropInLatestValueSchema);
@@ -74,7 +78,7 @@ public class SupersetSchemaGeneratorWithCustomProp implements SupersetSchemaGene
   public Schema generateSupersetSchema(Schema existingSchema, Schema newSchema) {
     Schema supersetSchema = AvroSupersetSchemaUtils.generateSuperSetSchema(existingSchema, newSchema);
     String customPropInNewSchema = newSchema.getProp(customProp);
-    if (customPropInNewSchema != null) {// && supersetSchema.getProp(customProp) == null) {
+    if (customPropInNewSchema != null && supersetSchema.getProp(customProp) == null) {
       Schema newSupersetSchema = AvroSchemaParseUtils.parseSchemaFromJSONLooseValidation(supersetSchema.toString());
       newSupersetSchema.addProp(customProp, customPropInNewSchema);
       return newSupersetSchema;

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/supersetschema/TestSupersetSchemaGeneratorWithCustomProp.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/supersetschema/TestSupersetSchemaGeneratorWithCustomProp.java
@@ -10,8 +10,10 @@ import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
 import com.linkedin.venice.schema.SchemaEntry;
 import com.linkedin.venice.utils.TestWriteUtils;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
 import org.apache.avro.Schema;
 import org.testng.annotations.Test;
 
@@ -105,5 +107,26 @@ public class TestSupersetSchemaGeneratorWithCustomProp {
     assertNotNull(supersetSchema2.getField("f0"));
     assertNotNull(supersetSchema2.getField("f1"));
     assertNotNull(supersetSchema2.getField("f2"));
+  }
+
+  @Test
+  public void testGenerateSupersetSchemaWithExistingCustomProp() {
+    Schema schema1 = Schema.parse(
+        "{\n" + "  \"type\": \"record\",\n" + "  \"name\": \"TestRecord\",\n" + "  \"fields\": [\n"
+            + "    {\"name\": \"int_field\", \"type\": \"int\", \"default\": 0}\n" + "  ],\n"
+            + "  \"custom_prop\": \"custom_prop1\"\n" + "}\n");
+    Schema schema2 = Schema.parse(
+        "{\n" + "  \"type\": \"record\",\n" + "  \"name\": \"TestRecord\",\n" + "  \"fields\": [\n"
+            + "    {\"name\": \"int_field\", \"type\": \"int\", \"default\": 0},\n"
+            + "    {\"name\": \"string_field\", \"type\": \"string\", \"default\": \"\"}\n" + "  ],\n"
+            + "  \"custom_prop\": \"custom_prop2\"\n" + "}");
+    SchemaEntry schemaEntry1 = new SchemaEntry(1, schema1);
+    SchemaEntry schemaEntry2 = new SchemaEntry(2, schema1);
+    List<SchemaEntry> schemaEntryList = new ArrayList<>();
+    schemaEntryList.add(schemaEntry1);
+    schemaEntryList.add(schemaEntry2);
+
+    assertEquals(generator.generateSupersetSchemaFromSchemas(schemaEntryList), schemaEntry2);
+    assertEquals(generator.generateSupersetSchema(schema1, schema2), schema2);
   }
 }

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/supersetschema/TestSupersetSchemaGeneratorWithCustomProp.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/supersetschema/TestSupersetSchemaGeneratorWithCustomProp.java
@@ -111,22 +111,27 @@ public class TestSupersetSchemaGeneratorWithCustomProp {
 
   @Test
   public void testGenerateSupersetSchemaWithExistingCustomProp() {
+    /**
+     * Give a list of schemas and the 2nd schema will remove some optional field.
+     */
     Schema schema1 = Schema.parse(
-        "{\n" + "  \"type\": \"record\",\n" + "  \"name\": \"TestRecord\",\n" + "  \"fields\": [\n"
-            + "    {\"name\": \"int_field\", \"type\": \"int\", \"default\": 0}\n" + "  ],\n"
-            + "  \"custom_prop\": \"custom_prop1\"\n" + "}\n");
-    Schema schema2 = Schema.parse(
         "{\n" + "  \"type\": \"record\",\n" + "  \"name\": \"TestRecord\",\n" + "  \"fields\": [\n"
             + "    {\"name\": \"int_field\", \"type\": \"int\", \"default\": 0},\n"
             + "    {\"name\": \"string_field\", \"type\": \"string\", \"default\": \"\"}\n" + "  ],\n"
-            + "  \"custom_prop\": \"custom_prop2\"\n" + "}");
+            + "  \"custom_prop\": \"custom_prop1\"\n" + "}");
+    Schema schema2 = Schema.parse(
+        "{\n" + "  \"type\": \"record\",\n" + "  \"name\": \"TestRecord\",\n" + "  \"fields\": [\n"
+            + "    {\"name\": \"int_field\", \"type\": \"int\", \"default\": 0}\n" + "  ],\n"
+            + "  \"custom_prop\": \"custom_prop2\"\n" + "}\n");
+
     SchemaEntry schemaEntry1 = new SchemaEntry(1, schema1);
-    SchemaEntry schemaEntry2 = new SchemaEntry(2, schema1);
+    SchemaEntry schemaEntry2 = new SchemaEntry(2, schema2);
     List<SchemaEntry> schemaEntryList = new ArrayList<>();
     schemaEntryList.add(schemaEntry1);
     schemaEntryList.add(schemaEntry2);
 
-    assertEquals(generator.generateSupersetSchemaFromSchemas(schemaEntryList), schemaEntry2);
-    assertEquals(generator.generateSupersetSchema(schema1, schema2), schema2);
+    // Make sure there is no exception thrown
+    generator.generateSupersetSchemaFromSchemas(schemaEntryList);
+    generator.generateSupersetSchema(schema1, schema2);
   }
 }


### PR DESCRIPTION


<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Summary, imperative, start upper case, don't end with a period
This PR fixes two issues:
1. Do the superset schema generation dry-run when first enabling read/write compute.
2. Fixed a bug that when the superset schema already contains custom prop, there is no need to mutate it (mutating an existing prop in Avro schema is not supported).
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->



## How was this PR tested?
CI
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.