### PR TITLE
[controller] Muted exception from a log in VHA::hasFatalDataValidationError

### DIFF
--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -3325,7 +3325,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
       OfflinePushStatus offlinePushStatus = pushMonitor.getOfflinePushOrThrow(topicName);
       return offlinePushStatus.hasFatalDataValidationError();
     } catch (VeniceException e) {
-      LOGGER.warn("Failed to get offline push status for topic: {}", topicName, e);
+      LOGGER.warn("Failed to get offline push status for topic: {}. It might not exist anymore.", topicName);
       return false;
     }
   }


### PR DESCRIPTION
There is only one code path calling this function and it is part of deleting a store-version. Therefore, it is expected that a store-version would not be found and there is no point in logging an exception for it.

## How was this PR tested?
GHCI.

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.