### PR TITLE
[controller][server] Add metric to track pub-sub admin operation failures

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/helix/LeaderFollowerPartitionStateModel.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/helix/LeaderFollowerPartitionStateModel.java
@@ -230,8 +230,9 @@ public class LeaderFollowerPartitionStateModel extends AbstractPartitionStateMod
       Version version = res.getSecond();
       if (store == null) {
         logger.error(
-            "Failed to get store for resource: {}. Will not update lag monitor.",
-            Utils.getReplicaId(resourceName, getPartition()));
+            "Failed to get store for resource: {} with trigger: {}. Will not update lag monitor.",
+            Utils.getReplicaId(resourceName, getPartition()),
+            trigger);
         return;
       }
       if (version == null && !isNullVersionValid) {
@@ -248,7 +249,11 @@ public class LeaderFollowerPartitionStateModel extends AbstractPartitionStateMod
       }
       lagMonFunction.accept(version, getPartition());
     } catch (Exception e) {
-      logger.error("Failed to update lag monitor for replica: {}", Utils.getReplicaId(resourceName, getPartition()), e);
+      logger.error(
+          "Failed to update lag monitor for replica: {} with trigger: {}",
+          Utils.getReplicaId(resourceName, getPartition()),
+          trigger,
+          e);
     }
   }
 

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/manager/TopicManager.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/manager/TopicManager.java
@@ -374,6 +374,7 @@ public class TopicManager implements Closeable {
       stats.recordLatency(GET_ALL_TOPIC_RETENTIONS, startTime);
       return topicRetentions;
     } catch (Exception e) {
+      logger.debug("Failed to get all topic retentions", e);
       stats.recordPubSubAdminOpFailure();
       throw e;
     }
@@ -423,6 +424,7 @@ public class TopicManager implements Closeable {
       pubSubAdminAdapter.createTopic(pubSubTopic, numPartitions, replicationFactor, topicConfiguration);
       stats.recordLatency(CREATE_TOPIC, startTime);
     } catch (Exception e) {
+      logger.debug("Failed to create topic: {}", pubSubTopic, e);
       stats.recordPubSubAdminOpFailure();
       throw e;
     }
@@ -434,6 +436,7 @@ public class TopicManager implements Closeable {
       pubSubAdminAdapter.setTopicConfig(pubSubTopic, pubSubTopicConfiguration);
       stats.recordLatency(SET_TOPIC_CONFIG, startTime);
     } catch (Exception e) {
+      logger.debug("Failed to set topic config for topic: {}", pubSubTopic, e);
       stats.recordPubSubAdminOpFailure();
       throw e;
     }
@@ -450,6 +453,7 @@ public class TopicManager implements Closeable {
       stats.recordLatency(GET_TOPIC_CONFIG, startTime);
       return pubSubTopicConfiguration;
     } catch (Exception e) {
+      logger.debug("Failed to get topic config for topic: {}", pubSubTopic, e);
       stats.recordPubSubAdminOpFailure();
       throw e;
     }
@@ -463,6 +467,7 @@ public class TopicManager implements Closeable {
       stats.recordLatency(GET_TOPIC_CONFIG_WITH_RETRY, startTime);
       return pubSubTopicConfiguration;
     } catch (Exception e) {
+      logger.debug("Failed to get topic config for topic: {}", topicName, e);
       stats.recordPubSubAdminOpFailure();
       throw e;
     }
@@ -490,6 +495,7 @@ public class TopicManager implements Closeable {
       stats.recordLatency(GET_SOME_TOPIC_CONFIGS, startTime);
       return topicConfigs;
     } catch (Exception e) {
+      logger.debug("Failed to get topic configs for topics: {}", topicNames, e);
       stats.recordPubSubAdminOpFailure();
       throw e;
     }
@@ -568,6 +574,7 @@ public class TopicManager implements Closeable {
       stats.recordLatency(LIST_ALL_TOPICS, startTime);
       return topics;
     } catch (Exception e) {
+      logger.debug("Failed to list topics", e);
       stats.recordPubSubAdminOpFailure();
       throw e;
     }
@@ -588,6 +595,7 @@ public class TopicManager implements Closeable {
       stats.recordLatency(CONTAINS_TOPIC_WITH_RETRY, startTime);
       return containsTopic;
     } catch (Exception e) {
+      logger.debug("Failed to check if topic: {} exists", topic, e);
       stats.recordPubSubAdminOpFailure();
       throw e;
     }
@@ -612,6 +620,7 @@ public class TopicManager implements Closeable {
       stats.recordLatency(CONTAINS_TOPIC_WITH_RETRY, startTime);
       return containsTopic;
     } catch (Exception e) {
+      logger.debug("Failed to check if topic: {} exists", topic, e);
       stats.recordPubSubAdminOpFailure();
       throw e;
     }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/manager/TopicManagerStats.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/manager/TopicManagerStats.java
@@ -50,7 +50,6 @@ class TopicManagerStats extends AbstractVeniceStats {
               TehutiUtils.getPercentileStat(getName() + AbstractVeniceStats.DELIMITER + sensorName)));
     }
 
-    // register pubSubAdminOpFailureCount sensor
     registerSensorIfAbsent(
         new AsyncGauge(
             (ignored, ignored2) -> pubSubAdminOpFailureCount.getAndSet(0),
@@ -69,7 +68,6 @@ class TopicManagerStats extends AbstractVeniceStats {
     sensorsByTypes.get(sensorType).record(LatencyUtils.getElapsedTimeFromNSToMS(startTimeInNs));
   }
 
-  // pubSubAdminOpFailureCount
   void recordPubSubAdminOpFailure() {
     pubSubAdminOpFailureCount.incrementAndGet();
   }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/manager/TopicManagerStats.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/manager/TopicManagerStats.java
@@ -11,6 +11,7 @@ import io.tehuti.metrics.stats.Max;
 import io.tehuti.metrics.stats.Min;
 import io.tehuti.metrics.stats.OccurrenceRate;
 import java.util.EnumMap;
+import java.util.concurrent.atomic.AtomicLong;
 
 
 /**
@@ -20,6 +21,7 @@ class TopicManagerStats extends AbstractVeniceStats {
   private static final String TOPIC_MANAGER_STATS_PREFIX = "TopicManagerStats_";
   private EnumMap<SENSOR_TYPE, Sensor> sensorsByTypes = null;
   private final MetricsRepository metricsRepository;
+  private AtomicLong pubSubAdminOpFailureCount = new AtomicLong(0);
 
   enum SENSOR_TYPE {
     CREATE_TOPIC, DELETE_TOPIC, LIST_ALL_TOPICS, SET_TOPIC_CONFIG, GET_ALL_TOPIC_RETENTIONS, GET_TOPIC_CONFIG,
@@ -61,6 +63,11 @@ class TopicManagerStats extends AbstractVeniceStats {
     sensorsByTypes.get(sensorType).record(LatencyUtils.getElapsedTimeFromNSToMS(startTimeInNs));
   }
 
+  // pubSubAdminOpFailureCount
+  void recordPubSubAdminOpFailure() {
+    pubSubAdminOpFailureCount.incrementAndGet();
+  }
+
   final void registerTopicMetadataFetcherSensors(TopicMetadataFetcher topicMetadataFetcher) {
     if (metricsRepository == null) {
       return;
@@ -81,5 +88,9 @@ class TopicManagerStats extends AbstractVeniceStats {
         new AsyncGauge(
             (ignored, ignored2) -> topicMetadataFetcher.getConsumerWaitListSize(),
             "consumer_wait_list_size"));
+    registerSensorIfAbsent(
+        new AsyncGauge(
+            (ignored, ignored2) -> pubSubAdminOpFailureCount.getAndSet(0),
+            "pub_sub_admin_op_failure_count"));
   }
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/manager/TopicMetadataFetcher.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/manager/TopicMetadataFetcher.java
@@ -250,7 +250,7 @@ class TopicMetadataFetcher implements Closeable {
       return containsTopic;
     } catch (Exception e) {
       LOGGER.error("Failed to check if topic exists: {}", topic, e);
-      return false;
+      throw e;
     }
   }
 

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/manager/TopicMetadataFetcher.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/manager/TopicMetadataFetcher.java
@@ -249,7 +249,7 @@ class TopicMetadataFetcher implements Closeable {
       stats.recordLatency(CONTAINS_TOPIC, startTime);
       return containsTopic;
     } catch (Exception e) {
-      LOGGER.error("Failed to check if topic exists: {}", topic, e);
+      stats.recordPubSubAdminOpFailure();
       throw e;
     }
   }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/manager/TopicMetadataFetcher.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/manager/TopicMetadataFetcher.java
@@ -249,6 +249,7 @@ class TopicMetadataFetcher implements Closeable {
       stats.recordLatency(CONTAINS_TOPIC, startTime);
       return containsTopic;
     } catch (Exception e) {
+      LOGGER.debug("Failed to check if topic exists: {}", topic, e);
       stats.recordPubSubAdminOpFailure();
       throw e;
     }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/manager/TopicMetadataFetcher.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/manager/TopicMetadataFetcher.java
@@ -243,10 +243,15 @@ class TopicMetadataFetcher implements Closeable {
    * @return true if the topic exists, false otherwise
    */
   boolean containsTopic(PubSubTopic topic) {
-    long startTime = System.nanoTime();
-    boolean containsTopic = pubSubAdminAdapter.containsTopic(topic);
-    stats.recordLatency(CONTAINS_TOPIC, startTime);
-    return containsTopic;
+    try {
+      long startTime = System.nanoTime();
+      boolean containsTopic = pubSubAdminAdapter.containsTopic(topic);
+      stats.recordLatency(CONTAINS_TOPIC, startTime);
+      return containsTopic;
+    } catch (Exception e) {
+      LOGGER.error("Failed to check if topic exists: {}", topic, e);
+      return false;
+    }
   }
 
   CompletableFuture<Boolean> containsTopicAsync(PubSubTopic topic) {

--- a/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/manager/TopicManagerStatsTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/manager/TopicManagerStatsTest.java
@@ -47,4 +47,35 @@ public class TopicManagerStatsTest {
             .value() > 0);
     assertTrue(metrics.get(".TopicManagerStats_venice_kafka_dc-1_linkedin_com_12345--create_topic.Avg").value() > 0);
   }
+
+  @Test
+  public void testPubSubFailedAdminOpCount() {
+    MetricsRepository metricsRepository = new MetricsRepository();
+    String pubSubClusterAddress = "venice.kafka.dc-1.linkedin.com:12345";
+    TopicManagerStats stats = new TopicManagerStats(metricsRepository, pubSubClusterAddress);
+    assertEquals(stats.getPubSubAdminOpFailureCount(), 0);
+    System.out.println(metricsRepository.metrics());
+    assertEquals(
+        metricsRepository
+            .getMetric(".TopicManagerStats_venice_kafka_dc-1_linkedin_com_12345--pub_sub_admin_op_failure_count.Gauge")
+            .value(),
+        0.0);
+
+    stats.recordPubSubAdminOpFailure();
+    stats.recordPubSubAdminOpFailure();
+    assertEquals(stats.getPubSubAdminOpFailureCount(), 2);
+    assertEquals(
+        metricsRepository
+            .getMetric(".TopicManagerStats_venice_kafka_dc-1_linkedin_com_12345--pub_sub_admin_op_failure_count.Gauge")
+            .value(),
+        2.0);
+
+    // should reset the count after reading
+    assertEquals(stats.getPubSubAdminOpFailureCount(), 0);
+    assertEquals(
+        metricsRepository
+            .getMetric(".TopicManagerStats_venice_kafka_dc-1_linkedin_com_12345--pub_sub_admin_op_failure_count.Gauge")
+            .value(),
+        0.0);
+  }
 }

--- a/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/manager/TopicManagerTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/manager/TopicManagerTest.java
@@ -42,6 +42,7 @@ import com.linkedin.venice.pubsub.api.PubSubProducerAdapter;
 import com.linkedin.venice.pubsub.api.PubSubProducerCallback;
 import com.linkedin.venice.pubsub.api.PubSubTopic;
 import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
+import com.linkedin.venice.pubsub.api.exceptions.PubSubClientRetriableException;
 import com.linkedin.venice.pubsub.api.exceptions.PubSubOpTimeoutException;
 import com.linkedin.venice.pubsub.api.exceptions.PubSubTopicDoesNotExistException;
 import com.linkedin.venice.systemstore.schemas.StoreProperties;
@@ -407,8 +408,7 @@ public class TopicManagerTest {
     Set<PubSubTopic> topics = new HashSet<>();
     topics.add(topic1);
     topics.add(topic2);
-    Map<PubSubTopic, PubSubTopicConfiguration> topicProperties = topicManager.getSomeTopicConfigs(topics);
-    Assert.assertTrue(topicProperties.isEmpty());
+    Assert.expectThrows(PubSubClientRetriableException.class, () -> topicManager.getSomeTopicConfigs(topics));
   }
 
   @Test

--- a/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/manager/TopicManagerTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/manager/TopicManagerTest.java
@@ -377,6 +377,41 @@ public class TopicManagerTest {
   }
 
   @Test
+  public void testGetSomeTopicConfigs() {
+    PubSubTopic topic1 = pubSubTopicRepository.getTopic(TestUtils.getUniqueTopicString("topic"));
+    PubSubTopic topic2 = pubSubTopicRepository.getTopic(TestUtils.getUniqueTopicString("topic"));
+    topicManager.createTopic(topic1, 1, 1, true);
+    topicManager.createTopic(topic2, 1, 1, true);
+    Set<PubSubTopic> topics = topicManager.listTopics();
+    Assert.assertTrue(topics.contains(topic1));
+    Assert.assertTrue(topics.contains(topic2));
+
+    Map<PubSubTopic, PubSubTopicConfiguration> topicProperties = topicManager.getSomeTopicConfigs(topics);
+    topicProperties.forEach((k, v) -> {
+      Assert.assertTrue(v.retentionInMs().isPresent());
+      Assert.assertTrue(v.retentionInMs().get() > 0, "retention.ms should be positive");
+    });
+  }
+
+  @Test
+  public void testGetSomeTopicConfigsForEmptyTopics() {
+    Set<PubSubTopic> topics = new HashSet<>();
+    Map<PubSubTopic, PubSubTopicConfiguration> topicProperties = topicManager.getSomeTopicConfigs(topics);
+    Assert.assertTrue(topicProperties.isEmpty());
+  }
+
+  @Test
+  public void testGetSomeTopicConfigsForUnknownTopics() {
+    PubSubTopic topic1 = pubSubTopicRepository.getTopic(TestUtils.getUniqueTopicString("topic"));
+    PubSubTopic topic2 = pubSubTopicRepository.getTopic(TestUtils.getUniqueTopicString("topic"));
+    Set<PubSubTopic> topics = new HashSet<>();
+    topics.add(topic1);
+    topics.add(topic2);
+    Map<PubSubTopic, PubSubTopicConfiguration> topicProperties = topicManager.getSomeTopicConfigs(topics);
+    Assert.assertTrue(topicProperties.isEmpty());
+  }
+
+  @Test
   public void testUpdateTopicRetention() {
     PubSubTopic topic = pubSubTopicRepository.getTopic(TestUtils.getUniqueTopicString("topic"));
     topicManager.createTopic(topic, 1, 1, true);

--- a/internal/venice-test-common/src/main/java/com/linkedin/venice/unit/kafka/MockInMemoryAdminAdapter.java
+++ b/internal/venice-test-common/src/main/java/com/linkedin/venice/unit/kafka/MockInMemoryAdminAdapter.java
@@ -148,6 +148,8 @@ public class MockInMemoryAdminAdapter implements PubSubAdminAdapter {
     for (PubSubTopic topic: topicNames) {
       if (topicPubSubTopicConfigurationMap.containsKey(topic)) {
         topicConfigs.put(topic, topicPubSubTopicConfigurationMap.get(topic));
+      } else {
+        throw new PubSubTopicDoesNotExistException("Topic " + topic + " does not exist");
       }
     }
     return topicConfigs;

--- a/internal/venice-test-common/src/main/java/com/linkedin/venice/unit/kafka/MockInMemoryAdminAdapter.java
+++ b/internal/venice-test-common/src/main/java/com/linkedin/venice/unit/kafka/MockInMemoryAdminAdapter.java
@@ -149,7 +149,7 @@ public class MockInMemoryAdminAdapter implements PubSubAdminAdapter {
       if (topicPubSubTopicConfigurationMap.containsKey(topic)) {
         topicConfigs.put(topic, topicPubSubTopicConfigurationMap.get(topic));
       } else {
-        throw new PubSubTopicDoesNotExistException("Topic " + topic + " does not exist");
+        throw new PubSubTopicDoesNotExistException(topic);
       }
     }
     return topicConfigs;


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Add metric to track pub-sub admin operation failures

Added a metric: `pub_sub_admin_op_failure_count` to track the count of failed admin operations. This will allow us to monitor these failures and set up alerts.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.