### PR TITLE
[CI] bump the code coverage

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -516,19 +516,20 @@ subprojects {
         }
 
         violationRules {
-          minBranches = project.ext.has('diffCoverageThreshold') ? project.ext.diffCoverageThreshold : 0.40
+          minBranches = project.ext.has('diffCoverageThreshold') ? project.ext.diffCoverageThreshold : 0.45
           failOnViolation = true
         }
       }
 
-      task logDiffCoverage {
+      task logCoverage {
         doLast {
+          parseJacocoXml("$buildDir/reports/jacoco/test/jacocoTestReport.xml")
           parseJacocoXml("$buildDir/reports/jacoco/diffCoverage/report.xml")
         }
       }
 
       diffCoverage.dependsOn jacocoTestReport
-      diffCoverage.finalizedBy logDiffCoverage
+      diffCoverage.finalizedBy logCoverage
     }
   }
 
@@ -781,6 +782,7 @@ ext.createDiffFile = { ->
 
 // for a given xml jacoco report, parse it and print out the branch coverage
 ext.parseJacocoXml = { filePath ->
+  println "Parsing Jacoco XML file at: ${filePath}"
   try {
     def jacocoReport = parser.parse(filePath).children()
     def branchCoverage = jacocoReport.find { it.name() == 'counter' && it.@type == 'BRANCH' }


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Summary, imperative, start upper case, don't end with a period
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
This PR bumps the diff code coverage from 40% to 45%.

## Background

We used to have lots of integ tests and few unit tests. Since 2023, we invested some effort to enforce unit test coverage   so people would write more unit tests to catch some bugs that are expensive to test in a integ or cannot be tested by a integ test. The goal was aggressively set to 80% but it hurt devs' velocity to deliver codes since we have too many files that don't have a good test coverage. To get this rolled up slowly, we started with 33% and bumped it to 40% after several months. This PR is a part of effort to continuously raise the bar.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
N/A
## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.