### PR TITLE
[CI] Correct package name in CI test bucketing logic for accurate bucket allocation

### DIFF
--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/transport/GrpcTransportClient.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/transport/GrpcTransportClient.java
@@ -27,6 +27,7 @@ import io.grpc.Status;
 import io.grpc.TlsChannelCredentials;
 import io.grpc.stub.StreamObserver;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -188,7 +189,7 @@ public class GrpcTransportClient extends InternalTransportClient {
     String[] requestParts = requestPath.split("/");
 
     if (!isValidRequest(requestParts, isSingleGet)) {
-      LOGGER.error("Failed to process request: {}", requestParts);
+      LOGGER.error("Failed to process request: {}", Arrays.toString(requestParts));
       // avoiding CompletableFuture.failedFuture to keep it JDK agnostic
       CompletableFuture<TransportClientResponse> failedFuture = new CompletableFuture<>();
       failedFuture.completeExceptionally(new VeniceClientException("Invalid request"));

--- a/internal/venice-test-common/build.gradle
+++ b/internal/venice-test-common/build.gradle
@@ -144,7 +144,7 @@ def integrationTestBuckets = [
       "com.linkedin.venice.router.*",
       "com.linkedin.venice.fastclient.AvroStoreClientGzipEndToEndTest",
       "com.linkedin.venice.fastclient.AvroStoreClientZstdEndToEndTest",
-      "com.linkedin.venice.ingestionHeartBeat.*"],
+      "com.linkedin.venice.ingestionHeartbeat.*"],
   "H": [
       "com.linkedin.venice.fastclient.BatchGet*",
       "com.linkedin.venice.fastclient.schema.*",

--- a/internal/venice-test-common/build.gradle
+++ b/internal/venice-test-common/build.gradle
@@ -137,21 +137,22 @@ def integrationTestBuckets = [
       "com.linkedin.venice.helix.*",
       "com.linkedin.venice.helixrebalance.*"],
   "F": [
+      "com.linkedin.venice.fastclient.*"],
+  "G": [
+      "com.linkedin.venice.endToEnd.TestEmptyPush",
+      "com.linkedin.venice.router.*",
+      "com.linkedin.venice.ingestionHeartbeat.*"],
+  "H": [
       "com.linkedin.venice.server.*",
       "com.linkedin.venice.storagenode.*",
       "com.linkedin.venice.restart.*"],
-  "G": [
-      "com.linkedin.venice.router.*",
-      "com.linkedin.venice.fastclient.AvroStoreClientGzipEndToEndTest",
-      "com.linkedin.venice.fastclient.AvroStoreClientZstdEndToEndTest",
-      "com.linkedin.venice.ingestionHeartbeat.*"],
-  "H": [
-      "com.linkedin.venice.fastclient.BatchGet*",
-      "com.linkedin.venice.fastclient.schema.*",
-      "com.linkedin.venice.fastclient.meta.*",
-      "com.linkedin.venice.endToEnd.TestEmptyPush"],
   "I": [
-      "com.linkedin.venice.fastclient.AvroStoreClientEndToEndTest"],
+      "com.linkedin.venice.endToEnd.TestStoreMigration",
+      "com.linkedin.venice.endToEnd.TestStuckConsumerRepair",
+      "com.linkedin.venice.endToEnd.TestSuperSetSchemaRegistration",
+      "com.linkedin.venice.endToEnd.TestTopicWiseSharedConsumerPoolResilience",
+      "com.linkedin.venice.endToEnd.TestUnusedValueSchemaCleanup"
+  ],
   "J": [
       "com.linkedin.venice.hadoop.*",
       "com.linkedin.venice.endToEnd.TestVson*",


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Fix package name in CI test bucketing logic for proper bucket allocation
- Fix package name in CI test bucketing logic for proper bucket allocation
- Also rearranged some tests so that overall time to run E2E is below 30mins



Resolves #XXX

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.