### PR TITLE
[changelog] Add bootstrap listener implementation to after image changelog consumer

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/ChangelogClientConfig.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/ChangelogClientConfig.java
@@ -1,6 +1,7 @@
 package com.linkedin.davinci.consumer;
 
 import com.linkedin.d2.balancer.D2Client;
+import com.linkedin.davinci.notifier.VeniceChangelogBootstrapListener;
 import com.linkedin.venice.client.store.ClientConfig;
 import com.linkedin.venice.controllerapi.D2ControllerClient;
 import com.linkedin.venice.schema.SchemaReader;
@@ -9,12 +10,13 @@ import org.apache.avro.specific.SpecificRecord;
 
 
 public class ChangelogClientConfig<T extends SpecificRecord> {
+  private final ClientConfig<T> innerClientConfig;
+
   private Properties consumerProperties;
   private SchemaReader schemaReader;
   private String viewName;
 
   private String consumerName = "";
-  private ClientConfig<T> innerClientConfig;
   private D2ControllerClient d2ControllerClient;
 
   private String controllerD2ServiceName;
@@ -22,6 +24,7 @@ public class ChangelogClientConfig<T extends SpecificRecord> {
 
   private String bootstrapFileSystemPath;
   private long versionSwapDetectionIntervalTimeInMs = 600000L;
+  private VeniceChangelogBootstrapListener changelogBootstrapListener = null;
 
   /**
    * This will be used in BootstrappingVeniceChangelogConsumer to determine when to sync updates with the underlying
@@ -192,6 +195,16 @@ public class ChangelogClientConfig<T extends SpecificRecord> {
     return this;
   }
 
+  public ChangelogClientConfig setChangelogBootstrapListener(
+      VeniceChangelogBootstrapListener changelogBootstrapListener) {
+    this.changelogBootstrapListener = changelogBootstrapListener;
+    return this;
+  }
+
+  public VeniceChangelogBootstrapListener getChangelogBootstrapListener() {
+    return changelogBootstrapListener;
+  }
+
   public static <V extends SpecificRecord> ChangelogClientConfig<V> cloneConfig(ChangelogClientConfig<V> config) {
     ChangelogClientConfig<V> newConfig = new ChangelogClientConfig<V>().setStoreName(config.getStoreName())
         .setLocalD2ZkHosts(config.getLocalD2ZkHosts())
@@ -207,7 +220,8 @@ public class ChangelogClientConfig<T extends SpecificRecord> {
         .setVersionSwapDetectionIntervalTimeInMs(config.getVersionSwapDetectionIntervalTimeInMs())
         .setRocksDBBlockCacheSizeInBytes(config.getRocksDBBlockCacheSizeInBytes())
         .setConsumerName(config.consumerName)
-        .setDatabaseSyncBytesInterval(config.getDatabaseSyncBytesInterval());
+        .setDatabaseSyncBytesInterval(config.getDatabaseSyncBytesInterval())
+        .setChangelogBootstrapListener(config.getChangelogBootstrapListener());
     return newConfig;
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerClientFactory.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerClientFactory.java
@@ -62,13 +62,18 @@ public class VeniceChangelogConsumerClientFactory {
     return getChangelogConsumer(storeName, null);
   }
 
+  public <K, V> VeniceChangelogConsumer<K, V> getChangelogConsumer(String storeName, String consumerId) {
+    return getChangelogConsumer(storeName, consumerId, null);
+  }
+
   /**
    * Creates a VeniceChangelogConsumer with consumer id. This is used to create multiple consumers so that
    * each consumer can only subscribe to certain partitions. Multiple such consumers can work in parallel.
    */
-  public <K, V> VeniceChangelogConsumer<K, V> getChangelogConsumer(String storeName, String consumerId) {
+  public <K, V> VeniceChangelogConsumer<K, V> getChangelogConsumer(String storeName, String consumerId, Class clazz) {
     return storeClientMap.computeIfAbsent(suffixConsumerIdToStore(storeName, consumerId), name -> {
-      ChangelogClientConfig newStoreChangelogClientConfig = getNewStoreChangelogClientConfig(storeName);
+      ChangelogClientConfig newStoreChangelogClientConfig =
+          getNewStoreChangelogClientConfig(storeName).setSpecificValue(clazz);
       newStoreChangelogClientConfig.setConsumerName(name);
       String viewClass = getViewClass(newStoreChangelogClientConfig, storeName);
       String consumerName = suffixConsumerIdToStore(storeName + "-" + viewClass.getClass().getSimpleName(), consumerId);

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/notifier/VeniceChangelogBootstrapListener.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/notifier/VeniceChangelogBootstrapListener.java
@@ -1,0 +1,19 @@
+package com.linkedin.davinci.notifier;
+
+public class VeniceChangelogBootstrapListener {
+  private int bootstrapTimestampDeltaInSeconds = 0;
+
+  public VeniceChangelogBootstrapListener() {
+  }
+
+  public void handleBootstrapCompleted() {
+  }
+
+  public void setBootstrapTimestampDeltaInSeconds(int seconds) {
+    bootstrapTimestampDeltaInSeconds = seconds;
+  }
+
+  public long getBootstrapTimestampDeltaInSeconds() {
+    return bootstrapTimestampDeltaInSeconds;
+  }
+}


### PR DESCRIPTION


<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## [changelog] Add bootstrap listener implementation to after image changelog consumer
This PR adds bootstrap listener on regular changelog consumer and as well as specific record support.
User can override the listener bootstrap completed notification behavior to perform any action

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
Added an integration test to verify the listener is working.
## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.