### PR TITLE
[dvc][server][vpj][producer][controller] Refactored VeniceWriter's close

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -322,7 +322,7 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
    */
   private void endSegment(int partition) {
     // If the VeniceWriter doesn't exist, then no need to end any segment, and this function becomes a no-op
-    veniceWriter.ifPresent(vw -> vw.endSegment(partition, true));
+    veniceWriter.ifPresent(vw -> vw.closePartition(partition));
   }
 
   @Override

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
@@ -1922,7 +1922,7 @@ public abstract class StoreIngestionTaskTest {
 
     // After the end of push, the venice writer continue puts a corrupt data and end the segment.
     getOffset(veniceWriterCorrupted.put(putKeyFoo, putValueToCorrupt, SCHEMA_ID));
-    veniceWriterCorrupted.endSegment(PARTITION_FOO, true);
+    veniceWriterCorrupted.closePartition(PARTITION_FOO);
 
     // a missing msg
     long fooOffsetToSkip = getOffset(veniceWriterCorrupted.put(putKeyFoo, putValue, SCHEMA_ID));

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/adapter/kafka/producer/ApacheKafkaProducerAdapter.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/adapter/kafka/producer/ApacheKafkaProducerAdapter.java
@@ -20,7 +20,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.Metric;
@@ -145,14 +144,9 @@ public class ApacheKafkaProducerAdapter implements PubSubProducerAdapter {
   }
 
   @Override
-  public void close(int closeTimeOutMs, boolean doFlush) {
+  public void close(long closeTimeOutMs) {
     if (producer == null) {
       return; // producer has been closed already
-    }
-    if (doFlush) {
-      // Flush out all the messages in the producer buffer
-      producer.flush(closeTimeOutMs, TimeUnit.MILLISECONDS);
-      LOGGER.info("Flushed all the messages in producer before closing");
     }
     producer.close(Duration.ofMillis(closeTimeOutMs));
     // Recycle the internal buffer allocated by KafkaProducer ASAP.

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/PubSubProducerAdapter.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/PubSubProducerAdapter.java
@@ -54,10 +54,6 @@ public interface PubSubProducerAdapter {
 
   void close(long closeTimeOutMs);
 
-  default void close(String topic, long closeTimeOutMs) {
-    close(closeTimeOutMs);
-  }
-
   Object2DoubleMap<String> getMeasurableProducerMetrics();
 
   String getBrokerAddress();

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/PubSubProducerAdapter.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/api/PubSubProducerAdapter.java
@@ -52,14 +52,10 @@ public interface PubSubProducerAdapter {
 
   void flush();
 
-  void close(int closeTimeOutMs, boolean doFlush);
+  void close(long closeTimeOutMs);
 
-  default void close(String topic, int closeTimeOutMs, boolean doFlush) {
-    close(closeTimeOutMs, doFlush);
-  }
-
-  default void close(String topic, int closeTimeOutMs) {
-    close(closeTimeOutMs, true);
+  default void close(String topic, long closeTimeOutMs) {
+    close(closeTimeOutMs);
   }
 
   Object2DoubleMap<String> getMeasurableProducerMetrics();

--- a/internal/venice-common/src/main/java/com/linkedin/venice/writer/VeniceWriter.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/writer/VeniceWriter.java
@@ -56,7 +56,6 @@ import com.linkedin.venice.utils.DaemonThreadFactory;
 import com.linkedin.venice.utils.ExceptionUtils;
 import com.linkedin.venice.utils.LatencyUtils;
 import com.linkedin.venice.utils.Time;
-import com.linkedin.venice.utils.Timer;
 import com.linkedin.venice.utils.Utils;
 import com.linkedin.venice.utils.VeniceProperties;
 import com.linkedin.venice.utils.VeniceResourceCloseResult;
@@ -108,8 +107,6 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
       VENICE_WRITER_CONFIG_PREFIX + "replication.metadata.chunking.enabled";
   public static final String MAX_ATTEMPTS_WHEN_TOPIC_MISSING =
       VENICE_WRITER_CONFIG_PREFIX + "max.attemps.when.topic.missing";
-  public static final String SLEEP_TIME_MS_WHEN_TOPIC_MISSING =
-      VENICE_WRITER_CONFIG_PREFIX + "sleep.time.ms.when.topic.missing";
   /**
    * A negative value or 0 will disable the feature.
    */
@@ -150,13 +147,6 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
    * the topic is missing.
    */
   public static final int DEFAULT_MAX_ATTEMPTS_WHEN_TOPIC_MISSING = 30;
-
-  /**
-   * Sleep time in between retry attempts when a topic is missing. Under default settings, the writer will
-   * stall 30 * 10 seconds = 300 seconds = 5 minutes (assuming the failure from Kafka is instantaneous,
-   * which of course it isn't, therefore this is a minimum stall time, not a max).
-   */
-  public static final int DEFAULT_SLEEP_TIME_MS_WHEN_TOPIC_MISSING = 10 * Time.MS_PER_SECOND;
 
   /**
    * The default value of the "upstreamOffset" field in avro record {@link LeaderMetadata}.
@@ -227,7 +217,6 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
   private final CheckSumType checkSumType;
   private final int maxSizeForUserPayloadPerMessageInBytes;
   private final int maxAttemptsWhenTopicMissing;
-  private final long sleepTimeMsWhenTopicMissing;
   private final long maxElapsedTimeForSegmentInMs;
   /**
    * Map of partition to {@link Segment}, which keeps track of all segment-related state.
@@ -249,7 +238,7 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
   private final boolean elapsedTimeForClosingSegmentEnabled;
   private final Object[] partitionLocks;
   private String writerId;
-  private boolean isClosed = false;
+  private volatile boolean isClosed = false;
   private final Object closeLock = new Object();
 
   /**
@@ -312,8 +301,6 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
     this.isChunkingFlagInvoked = false;
     this.maxAttemptsWhenTopicMissing =
         props.getInt(MAX_ATTEMPTS_WHEN_TOPIC_MISSING, DEFAULT_MAX_ATTEMPTS_WHEN_TOPIC_MISSING);
-    this.sleepTimeMsWhenTopicMissing =
-        props.getInt(SLEEP_TIME_MS_WHEN_TOPIC_MISSING, DEFAULT_SLEEP_TIME_MS_WHEN_TOPIC_MISSING);
     this.maxElapsedTimeForSegmentInMs =
         props.getLong(MAX_ELAPSED_TIME_FOR_SEGMENT_IN_MS, DEFAULT_MAX_ELAPSED_TIME_FOR_SEGMENT_IN_MS);
     this.elapsedTimeForClosingSegmentEnabled = maxElapsedTimeForSegmentInMs > 0;
@@ -403,48 +390,6 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
     }
   }
 
-  /**
-   * Close the {@link VeniceWriter}.
-   *
-   * Deprecating this method due to the concern of sending END_OF_SEGMENT control message to a non-existing topic can be
-   * blocked indefinitely as it is calling
-   * {@link #sendMessage(KeyProvider, KafkaMessageEnvelopeProvider, int, PubSubProducerCallback, boolean)}.get()
-   * without timeout.
-   *
-   * @param gracefulClose whether to end the segments and send END_OF_SEGMENT control message.
-   * @param retryOnGracefulCloseFailure whether to retry on graceful close failure.
-   */
-  @Deprecated
-  public void close(boolean gracefulClose, boolean retryOnGracefulCloseFailure) {
-    synchronized (closeLock) {
-      if (isClosed) {
-        return;
-      }
-
-      logger.info("Closing VeniceWriter for topic: {}, gracefulness: {}", topicName, gracefulClose);
-      try (Timer ignore = Timer.run(
-          elapsedTimeInMs -> logger.info("Closed VeniceWriter for topic: {} in {} ms", topicName, elapsedTimeInMs))) {
-        try {
-          // If {@link #broadcastEndOfPush(Map)} was already called, the {@link #endAllSegments(boolean)}
-          // will not do anything (it's idempotent). Segments should not be ended if there are still data missing.
-          if (gracefulClose) {
-            endAllSegments(true);
-          }
-          // DO NOT call the {@link #PubSubProducerAdapter.close(int) version from here.}
-          // For non-shared producer mode gracefulClose will flush the producer
-
-          producerAdapter.close(topicName, closeTimeOutInMs, gracefulClose);
-          OPEN_VENICE_WRITER_COUNT.decrementAndGet();
-        } catch (Exception e) {
-          handleExceptionInClose(e, gracefulClose, retryOnGracefulCloseFailure);
-        } finally {
-          threadPoolExecutor.shutdown();
-          isClosed = true;
-        }
-      }
-    }
-  }
-
   public CompletableFuture<VeniceResourceCloseResult> closeAsync(boolean gracefulClose) {
     return closeAsync(gracefulClose, true);
   }
@@ -460,19 +405,18 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
       if (isClosed) {
         return CompletableFuture.completedFuture(VeniceResourceCloseResult.ALREADY_CLOSED);
       }
-    }
 
-    return CompletableFuture.supplyAsync(() -> {
-      synchronized (closeLock) {
-        if (isClosed) {
-          return VeniceResourceCloseResult.ALREADY_CLOSED;
-        }
-        logger.info("Closing VeniceWriter for topic: {}, gracefulness: {}", topicName, gracefulClose);
-        try (Timer ignore = Timer.run(
-            elapsedTimeInMs -> logger.info("Closed VeniceWriter for topic: {} in {} ms", topicName, elapsedTimeInMs))) {
+      return CompletableFuture.supplyAsync(() -> {
+        synchronized (closeLock) {
+          logger.info("Closing VeniceWriter for topic: {}, gracefulness: {}", topicName, gracefulClose);
+          long timeAtStartOfClose = System.currentTimeMillis();
           try {
-            // try to end all segments before closing the producer.
             if (gracefulClose) {
+              /**
+               * If {@link #broadcastEndOfPush(Map)} was already called, the {@link #endAllSegments(boolean)}
+               * will not do anything (it's idempotent). Segments should not be ended if there are still data missing.
+               * N.B.: This call is run async because it could block indefinitely in case the topic does not exist.
+               */
               CompletableFuture<Void> endSegmentsFuture =
                   CompletableFuture.runAsync(() -> endAllSegments(true), threadPoolExecutor);
               try {
@@ -485,19 +429,32 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
                 logger.warn("Swallowed an exception while trying to end all segments for topic: {}", topicName, e);
               }
             }
-            producerAdapter.close(topicName, closeTimeOutInMs, gracefulClose);
+
+            long timeLeftToClose = 0; // N.B.: 0 indicates an ungraceful close
+            if (gracefulClose) {
+              /** N.B.: We measure the time left to try to adhere strictly to the configured {@link closeTimeOutInMs} */
+              long timeSinceStartOfClose = System.currentTimeMillis() - timeAtStartOfClose;
+              timeLeftToClose = Math.max(0, closeTimeOutInMs - timeSinceStartOfClose);
+            }
+
+            /**
+             * N.B.: We call the overload with a topic name param here for the sake of shared producer...
+             * TODO: Decide whether to keep shared producer or not...
+             */
+            producerAdapter.close(topicName, timeLeftToClose);
             OPEN_VENICE_WRITER_COUNT.decrementAndGet();
           } catch (Exception e) {
             handleExceptionInClose(e, gracefulClose, retryOnGracefulCloseFailure);
           } finally {
-            threadPoolExecutor.shutdown();
             isClosed = true;
+            threadPoolExecutor.shutdown();
+            long elapsedTimeInMs = System.currentTimeMillis() - timeAtStartOfClose;
+            logger.info("Closed VeniceWriter for topic: {} in {} ms", topicName, elapsedTimeInMs);
           }
         }
         return VeniceResourceCloseResult.SUCCESS;
-      }
-
-    }, threadPoolExecutor);
+      }, threadPoolExecutor);
+    }
   }
 
   void handleExceptionInClose(Exception e, boolean gracefulClose, boolean retryOnGracefulCloseFailure) {
@@ -507,11 +464,8 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
     // For graceful close, swallow the exception and give another try to close it ungracefully.
     try {
       if (gracefulClose && retryOnGracefulCloseFailure) {
-        logger.info(
-            "Ungracefully closing the VeniceWriter for topic: {}, closeTimeOut: {} ms",
-            topicName,
-            closeTimeOutInMs);
-        producerAdapter.close(topicName, closeTimeOutInMs, false);
+        logger.info("Ungracefully closing the VeniceWriter for topic: {}, closeTimeOut: 0 ms", topicName);
+        producerAdapter.close(topicName, 0);
         OPEN_VENICE_WRITER_COUNT.decrementAndGet();
       }
     } catch (Exception ex) {
@@ -524,11 +478,6 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
   @Override
   public void close() {
     close(true);
-  }
-
-  /** Used in tests only */
-  PubSubProducerAdapter getProducerAdapter() {
-    return producerAdapter;
   }
 
   /**
@@ -1285,7 +1234,7 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
    */
   public void closePartition(int partition) {
     if (segments[partition] != null) {
-      logger.info("Closing partition: {} in VeniceWriter.", partition);
+      logger.debug("Closing partition: {} in VeniceWriter.", partition);
       endSegment(partition, true);
     }
   }
@@ -1630,7 +1579,12 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
     startOfSegment.checksumType = checkSumType.getValue();
     startOfSegment.upcomingAggregates = new ArrayList<>(); // TODO Add extra aggregates
     controlMessage.controlMessageUnion = startOfSegment;
-    sendControlMessage(controlMessage, partition, debugInfo, null, DEFAULT_LEADER_METADATA_WRAPPER);
+    sendControlMessageWithRetriesForNonExistentTopic(
+        controlMessage,
+        partition,
+        debugInfo,
+        null,
+        DEFAULT_LEADER_METADATA_WRAPPER);
   }
 
   /**
@@ -1641,7 +1595,10 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
    * @param finalSegment a boolean indicating if this is the final segment that this producer will send
    *                     into this partition.
    */
-  private void sendEndOfSegment(int partition, Map<String, String> debugInfo, boolean finalSegment) {
+  private CompletableFuture<PubSubProduceResult> sendEndOfSegment(
+      int partition,
+      Map<String, String> debugInfo,
+      boolean finalSegment) {
     ControlMessage controlMessage = new ControlMessage();
     controlMessage.controlMessageType = ControlMessageType.END_OF_SEGMENT.getValue();
     EndOfSegment endOfSegment = new EndOfSegment();
@@ -1649,7 +1606,7 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
     endOfSegment.computedAggregates = new ArrayList<>(); // TODO Add extra aggregates
     endOfSegment.finalSegment = finalSegment;
     controlMessage.controlMessageUnion = endOfSegment;
-    sendControlMessage(controlMessage, partition, debugInfo, null, DEFAULT_LEADER_METADATA_WRAPPER);
+    return sendControlMessage(controlMessage, partition, debugInfo, null, DEFAULT_LEADER_METADATA_WRAPPER);
   }
 
   /**
@@ -1710,39 +1667,39 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
   /**
    * This function sends a control message into the prescribed partition.
    *
-   * If the Kafka topic does not exist, this function will back off for {@link #sleepTimeMsWhenTopicMissing}
-   * ms and try again for a total of {@link #maxAttemptsWhenTopicMissing} attempts. Note that this back off
-   * and retry behavior does not happen in {@link #sendMessage(KeyProvider, MessageType, Object, int, PubSubProducerCallback, LeaderMetadataWrapper, long)}
+   * If the Kafka topic does not exist, this function will try again for a total of {@link #maxAttemptsWhenTopicMissing}
+   * attempts. Note that this retry behavior does not happen in
+   * {@link #sendMessage(KeyProvider, MessageType, Object, int, PubSubProducerCallback, LeaderMetadataWrapper, long)}
    * because that function returns a {@link Future}, and it is {@link Future#get()} which throws the relevant
    * exception. In any case, the topic should be seeded with a {@link ControlMessageType#START_OF_SEGMENT}
-   * at first, and therefore, there should be no cases where a topic has not been created yet and we attempt
+   * at first, and therefore, there should be no cases where a topic has not been created yet, and we attempt
    * to write a data message first, prior to a control message. If a topic did disappear later on in the
    * {@link VeniceWriter}'s lifecycle, then it would be appropriate to let that {@link Future} fail.
    *
-   * This function is synchronized because if the retries need to be exercised, then it would cause a DIV failure
-   * if another message slipped in after the first attempt and before the eventually successful attempt.
+   * This function has a synchronized block because if the retries need to be exercised, then it would cause a DIV
+   * failure if another message slipped in after the first attempt and before the eventually successful attempt.
    *
    * @param controlMessage a {@link ControlMessage} instance to persist into Kafka.
    * @param partition the Kafka partition to write to.
    * @param debugInfo arbitrary key/value pairs of information that will be propagated alongside the control message.
    * @param callback callback to execute when the record has been acknowledged by the Kafka server (null means no callback)
    */
-  public void sendControlMessage(
+  public void sendControlMessageWithRetriesForNonExistentTopic(
       ControlMessage controlMessage,
       int partition,
       Map<String, String> debugInfo,
       PubSubProducerCallback callback,
       LeaderMetadataWrapper leaderMetadataWrapper) {
+    controlMessage.debugInfo = getDebugInfo(debugInfo);
+    int attempt = 1;
+    boolean updateCheckSum = true;
+    ControlMessageType controlMessageType = ControlMessageType.valueOf(controlMessage);
+    boolean isEndOfSegment = controlMessageType == ControlMessageType.END_OF_SEGMENT;
     synchronized (this.partitionLocks[partition]) {
       // Work around until we upgrade to a more modern Avro version which supports overriding the
       // String implementation.
-      controlMessage.debugInfo = getDebugInfo(debugInfo);
-      int attempt = 1;
-      boolean updateCheckSum = true;
       while (true) {
         try {
-          boolean isEndOfSegment = ControlMessageType.valueOf(controlMessage).equals(ControlMessageType.END_OF_SEGMENT);
-
           sendMessage(
               this::getControlMessageKey,
               MessageType.CONTROL_MESSAGE,
@@ -1760,27 +1717,65 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
              * Not a super clean way to match the exception, but unfortunately, since it is wrapped inside of an
              * {@link ExecutionException}, there may be no other way.
              */
-            String errorMessage =
-                "Caught a UNKNOWN_TOPIC_OR_PARTITION error, attempt " + attempt + "/" + maxAttemptsWhenTopicMissing;
             if (attempt < maxAttemptsWhenTopicMissing) {
               attempt++;
               updateCheckSum = false; // checksum has already been updated, and should not be updated again for retries
-              logger.warn("{}, will sleep {} ms before the next attempt.", errorMessage, sleepTimeMsWhenTopicMissing);
+              logger.warn(
+                  "Caught a UNKNOWN_TOPIC_OR_PARTITION error, attempt {}/{}",
+                  attempt,
+                  maxAttemptsWhenTopicMissing);
             } else {
-              throw new VeniceException(errorMessage + ", will bubble up.");
+              throw new VeniceException(
+                  "Caught a UNKNOWN_TOPIC_OR_PARTITION error, attempt " + attempt + "/" + maxAttemptsWhenTopicMissing
+                      + ", will bubble up.");
             }
-          } else if (ExceptionUtils.recursiveClassEquals(e, PubSubTopicAuthorizationException.class)) {
-            throw new VeniceResourceAccessException(
-                "You do not have permission to write to this store. Please check that ACLs are set correctly.",
-                e);
           } else {
-            throw new VeniceException(
-                "Got an exception while trying to send a control message ("
-                    + ControlMessageType.valueOf(controlMessage).name() + ")",
-                e);
+            handleControlMessageProducingException(e, controlMessageType);
           }
         }
       }
+    }
+  }
+
+  private void handleControlMessageProducingException(Exception e, ControlMessageType controlMessageType) {
+    if (ExceptionUtils.recursiveClassEquals(e, PubSubTopicAuthorizationException.class)) {
+      throw new VeniceResourceAccessException(
+          "You do not have permission to write to this store. Please check that ACLs are set correctly.",
+          e);
+    } else {
+      throw new VeniceException(
+          "Got an exception while trying to send a control message (" + controlMessageType.name() + ")",
+          e);
+    }
+  }
+
+  /**
+   * Main function for sending control messages. Synchronization is most minimal and there is no error checking.
+   *
+   * See also:
+   * {@link #sendControlMessageWithRetriesForNonExistentTopic(ControlMessage, int, Map, PubSubProducerCallback, LeaderMetadataWrapper)}
+   */
+  public CompletableFuture<PubSubProduceResult> sendControlMessage(
+      ControlMessage controlMessage,
+      int partition,
+      Map<String, String> debugInfo,
+      PubSubProducerCallback callback,
+      LeaderMetadataWrapper leaderMetadataWrapper) {
+    // Work around until we upgrade to a more modern Avro version which supports overriding the
+    // String implementation.
+    controlMessage.debugInfo = getDebugInfo(debugInfo);
+    boolean isEndOfSegment = ControlMessageType.valueOf(controlMessage).equals(ControlMessageType.END_OF_SEGMENT);
+    synchronized (this.partitionLocks[partition]) {
+      return sendMessage(
+          this::getControlMessageKey,
+          MessageType.CONTROL_MESSAGE,
+          controlMessage,
+          isEndOfSegment,
+          partition,
+          callback,
+          true,
+          leaderMetadataWrapper,
+          VENICE_DEFAULT_LOGICAL_TS);
     }
   }
 
@@ -1994,18 +1989,25 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
 
   private void endAllSegments(boolean finalSegment) {
     Segment segment;
+    List<CompletableFuture> futures = new ArrayList<>();
     for (int i = 0; i < segments.length; i++) {
       segment = segments[i];
       if (segment != null) {
-        endSegment(i, finalSegment);
+        futures.add(endSegment(i, finalSegment));
       }
+    }
+    try {
+      CompletableFuture.allOf(futures.toArray(new CompletableFuture[futures.size()])).get();
+    } catch (ExecutionException | InterruptedException e) {
+      handleControlMessageProducingException(e, ControlMessageType.END_OF_SEGMENT);
     }
   }
 
   /**
    * @param partition in which to end the current segment
+   * @return A CompletableFuture which either contains a result if a EOS was sent, or null if none needed to be sent.
    */
-  public void endSegment(int partition, boolean finalSegment) {
+  public CompletableFuture<PubSubProduceResult> endSegment(int partition, boolean finalSegment) {
     synchronized (this.partitionLocks[partition]) {
       Segment currentSegment = segments[partition];
       if (currentSegment == null) {
@@ -2016,7 +2018,7 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
         logger.debug("endSegment(partition {}) called but currentSegment.ended == true. Ignoring.", partition);
       } else {
         try {
-          sendEndOfSegment(
+          return sendEndOfSegment(
               partition,
               new HashMap<>(), // TODO: Add extra debugging info
               finalSegment
@@ -2033,6 +2035,7 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
         }
       }
     }
+    return CompletableFuture.completedFuture(null);
   }
 
   public Time getTime() {

--- a/internal/venice-common/src/main/java/com/linkedin/venice/writer/VeniceWriter.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/writer/VeniceWriter.java
@@ -441,10 +441,6 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
               timeLeftToClose = Math.max(0, closeTimeOutInMs - timeSinceStartOfClose);
             }
 
-            /**
-             * N.B.: We call the overload with a topic name param here for the sake of shared producer...
-             * TODO: Decide whether to keep shared producer or not...
-             */
             producerAdapter.close(timeLeftToClose);
             OPEN_VENICE_WRITER_COUNT.decrementAndGet();
           } catch (Exception e) {
@@ -2015,7 +2011,7 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
    * @param partition in which to end the current segment
    * @return A CompletableFuture which either contains a result if a EOS was sent, or null if none needed to be sent.
    */
-  public CompletableFuture<PubSubProduceResult> endSegment(int partition, boolean finalSegment) {
+  private CompletableFuture<PubSubProduceResult> endSegment(int partition, boolean finalSegment) {
     synchronized (this.partitionLocks[partition]) {
       Segment currentSegment = segments[partition];
       if (currentSegment == null) {

--- a/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/adapter/kafka/producer/ApacheKafkaProducerAdapterTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/pubsub/adapter/kafka/producer/ApacheKafkaProducerAdapterTest.java
@@ -1,7 +1,6 @@
 package com.linkedin.venice.pubsub.adapter.kafka.producer;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
@@ -26,14 +25,12 @@ import com.linkedin.venice.pubsub.api.exceptions.PubSubOpTimeoutException;
 import com.linkedin.venice.pubsub.api.exceptions.PubSubTopicAuthorizationException;
 import com.linkedin.venice.pubsub.api.exceptions.PubSubTopicDoesNotExistException;
 import it.unimi.dsi.fastutil.objects.Object2DoubleMap;
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
 import org.apache.kafka.clients.producer.Callback;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerRecord;
@@ -68,7 +65,7 @@ public class ApacheKafkaProducerAdapterTest {
   public void testEnsureProducerIsNotClosedThrowsExceptionWhenProducerIsClosed() {
     ApacheKafkaProducerAdapter producerAdapter = new ApacheKafkaProducerAdapter(producerConfigMock, kafkaProducerMock);
     doNothing().when(kafkaProducerMock).close(any());
-    producerAdapter.close(10, false);
+    producerAdapter.close(10);
     producerAdapter.sendMessage(TOPIC_NAME, 0, testKafkaKey, testKafkaValue, null, null);
   }
 
@@ -139,15 +136,6 @@ public class ApacheKafkaProducerAdapterTest {
   }
 
   @Test
-  public void testCloseInvokesProducerFlushAndClose() {
-    doNothing().when(kafkaProducerMock).flush(anyLong(), any(TimeUnit.class));
-    ApacheKafkaProducerAdapter producerAdapter = new ApacheKafkaProducerAdapter(producerConfigMock, kafkaProducerMock);
-    producerAdapter.close(10, true);
-    verify(kafkaProducerMock, times(1)).flush(anyLong(), any(TimeUnit.class));
-    verify(kafkaProducerMock, times(1)).close(any(Duration.class));
-  }
-
-  @Test
   public void testFlushInvokesInternalProducerFlushIfProducerIsNotClosed() {
     doNothing().when(kafkaProducerMock).flush();
     ApacheKafkaProducerAdapter producerAdapter = new ApacheKafkaProducerAdapter(producerConfigMock, kafkaProducerMock);
@@ -160,7 +148,7 @@ public class ApacheKafkaProducerAdapterTest {
     doNothing().when(kafkaProducerMock).flush();
     doNothing().when(kafkaProducerMock).close();
     ApacheKafkaProducerAdapter producerAdapter = new ApacheKafkaProducerAdapter(producerConfigMock, kafkaProducerMock);
-    producerAdapter.close(10, false); // close without flushing
+    producerAdapter.close(10); // close without flushing
     producerAdapter.flush();
     verify(kafkaProducerMock, never()).flush();
   }
@@ -169,7 +157,7 @@ public class ApacheKafkaProducerAdapterTest {
   public void testGetMeasurableProducerMetricsReturnsEmptyMapWhenProducerIsClosed() {
     doNothing().when(kafkaProducerMock).close();
     ApacheKafkaProducerAdapter producerAdapter = new ApacheKafkaProducerAdapter(producerConfigMock, kafkaProducerMock);
-    producerAdapter.close(10, false); // close without flushing
+    producerAdapter.close(10); // close without flushing
     Object2DoubleMap<String> metrics = producerAdapter.getMeasurableProducerMetrics();
     assertNotNull(metrics, "Returned metrics cannot be null");
     assertEquals(metrics.size(), 0, "Should return empty metrics when producer is closed");

--- a/internal/venice-common/src/test/java/com/linkedin/venice/writer/VeniceWriterUnitTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/writer/VeniceWriterUnitTest.java
@@ -551,7 +551,7 @@ public class VeniceWriterUnitTest {
     Supplier<PubSubProducerAdapter> producerSupplier = () -> {
       PubSubProducerAdapter mockedProducer = mock(PubSubProducerAdapter.class);
       // Only graceful closes (those with a non-zero timeout) will throw a TimeoutException
-      doThrow(new TimeoutException()).when(mockedProducer).close(anyString(), longThat(argument -> argument > 0));
+      doThrow(new TimeoutException()).when(mockedProducer).close(longThat(argument -> argument > 0));
       return mockedProducer;
     };
     Function<PubSubProducerAdapter, VeniceWriter> veniceWriterSupplier = mockedProducer -> {
@@ -567,15 +567,15 @@ public class VeniceWriterUnitTest {
     PubSubProducerAdapter mockedProducer = producerSupplier.get();
     VeniceWriter<Object, Object, Object> writer = veniceWriterSupplier.apply(mockedProducer);
     writer.close(gracefulClose);
-    verify(mockedProducer, times(gracefulClose ? 1 : 0)).close(anyString(), longThat(argument -> argument > 0));
-    verify(mockedProducer, times(1)).close(anyString(), longThat(argument -> argument == 0));
+    verify(mockedProducer, times(gracefulClose ? 1 : 0)).close(longThat(argument -> argument > 0));
+    verify(mockedProducer, times(1)).close(longThat(argument -> argument == 0));
 
     // Same test for asyncClose, after reinitializing everything
     mockedProducer = producerSupplier.get();
     writer = veniceWriterSupplier.apply(mockedProducer);
     writer.closeAsync(gracefulClose).get();
-    verify(mockedProducer, times(gracefulClose ? 1 : 0)).close(anyString(), longThat(argument -> argument > 0));
-    verify(mockedProducer, times(1)).close(anyString(), longThat(argument -> argument == 0));
+    verify(mockedProducer, times(gracefulClose ? 1 : 0)).close(longThat(argument -> argument > 0));
+    verify(mockedProducer, times(1)).close(longThat(argument -> argument == 0));
   }
 
   /**

--- a/internal/venice-common/src/test/java/com/linkedin/venice/writer/VeniceWriterUnitTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/writer/VeniceWriterUnitTest.java
@@ -9,9 +9,9 @@ import static com.linkedin.venice.writer.VeniceWriter.DEFAULT_LEADER_METADATA_WR
 import static com.linkedin.venice.writer.VeniceWriter.DEFAULT_MAX_SIZE_FOR_USER_PAYLOAD_PER_MESSAGE_IN_BYTES;
 import static com.linkedin.venice.writer.VeniceWriter.VENICE_DEFAULT_LOGICAL_TS;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.longThat;
 import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.doThrow;
@@ -61,6 +61,8 @@ import java.util.Arrays;
 import java.util.Properties;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.function.Function;
+import java.util.function.Supplier;
 import org.apache.kafka.common.errors.TimeoutException;
 import org.mockito.ArgumentCaptor;
 import org.testng.Assert;
@@ -69,6 +71,8 @@ import org.testng.annotations.Test;
 
 
 public class VeniceWriterUnitTest {
+  private static final long TIMEOUT = 10 * Time.MS_PER_SECOND;
+
   @Test(dataProvider = "Chunking-And-Partition-Counts", dataProviderClass = DataProviderUtils.class)
   public void testTargetPartitionIsSameForAllOperationsWithTheSameKey(boolean isChunkingEnabled, int partitionCount) {
     PubSubProducerAdapter mockedProducer = mock(PubSubProducerAdapter.class);
@@ -162,7 +166,7 @@ public class VeniceWriterUnitTest {
         WriterChunkingHelper.EMPTY_BYTE_BUFFER);
   }
 
-  @Test(timeOut = 10000)
+  @Test(timeOut = TIMEOUT)
   public void testReplicationMetadataChunking() {
     PubSubProducerAdapter mockedProducer = mock(PubSubProducerAdapter.class);
     CompletableFuture mockedFuture = mock(CompletableFuture.class);
@@ -542,25 +546,36 @@ public class VeniceWriterUnitTest {
   }
 
   // Write a unit test for the retry mechanism in VeniceWriter.close(true) method.
-  @Test(dataProvider = "True-and-False", dataProviderClass = DataProviderUtils.class, timeOut = 10 * Time.MS_PER_SECOND)
+  @Test(dataProvider = "True-and-False", dataProviderClass = DataProviderUtils.class, timeOut = TIMEOUT)
   public void testVeniceWriterCloseRetry(boolean gracefulClose) throws ExecutionException, InterruptedException {
-    PubSubProducerAdapter mockedProducer = mock(PubSubProducerAdapter.class);
-    doThrow(new TimeoutException()).when(mockedProducer).close(anyString(), anyInt(), eq(true));
+    Supplier<PubSubProducerAdapter> producerSupplier = () -> {
+      PubSubProducerAdapter mockedProducer = mock(PubSubProducerAdapter.class);
+      // Only graceful closes (those with a non-zero timeout) will throw a TimeoutException
+      doThrow(new TimeoutException()).when(mockedProducer).close(anyString(), longThat(argument -> argument > 0));
+      return mockedProducer;
+    };
+    Function<PubSubProducerAdapter, VeniceWriter> veniceWriterSupplier = mockedProducer -> {
+      String testTopic = "test";
+      VeniceWriterOptions veniceWriterOptions = new VeniceWriterOptions.Builder(testTopic).setPartitionCount(1).build();
+      return new VeniceWriter(veniceWriterOptions, VeniceProperties.empty(), mockedProducer);
+    };
 
-    String testTopic = "test";
-    VeniceWriterOptions veniceWriterOptions = new VeniceWriterOptions.Builder(testTopic).setPartitionCount(1).build();
-    VeniceWriter<Object, Object, Object> writer =
-        new VeniceWriter(veniceWriterOptions, VeniceProperties.empty(), mockedProducer);
+    // If attempting a graceful close, then the producer should receive an invocation of close with non-zero timeout,
+    // followed by another one with zero timeout. If, on the other hand, we attempt an ungraceful close, then there
+    // should only be a single close invocation, and it should be with zero timeout.
 
-    // Verify that if the producer throws a TimeoutException, the VeniceWriter will retry the close() method
-    // with doFlash = false for both close() and closeAsync() methods.
+    PubSubProducerAdapter mockedProducer = producerSupplier.get();
+    VeniceWriter<Object, Object, Object> writer = veniceWriterSupplier.apply(mockedProducer);
     writer.close(gracefulClose);
+    verify(mockedProducer, times(gracefulClose ? 1 : 0)).close(anyString(), longThat(argument -> argument > 0));
+    verify(mockedProducer, times(1)).close(anyString(), longThat(argument -> argument == 0));
 
-    writer = new VeniceWriter(veniceWriterOptions, VeniceProperties.empty(), mockedProducer);
+    // Same test for asyncClose, after reinitializing everything
+    mockedProducer = producerSupplier.get();
+    writer = veniceWriterSupplier.apply(mockedProducer);
     writer.closeAsync(gracefulClose).get();
-
-    // Verify that the close(false) method will be called twice.
-    verify(mockedProducer, times(2)).close(anyString(), anyInt(), eq(false));
+    verify(mockedProducer, times(gracefulClose ? 1 : 0)).close(anyString(), longThat(argument -> argument > 0));
+    verify(mockedProducer, times(1)).close(anyString(), longThat(argument -> argument == 0));
   }
 
   /**
@@ -571,7 +586,7 @@ public class VeniceWriterUnitTest {
    * 1. The VeniceWriter's cached segment is neither started nor ended.
    * 2. The elapsed time for the segment is greater than MAX_ELAPSED_TIME_FOR_SEGMENT_IN_MS.
    */
-  @Test(timeOut = 10 * Time.MS_PER_SECOND)
+  @Test(timeOut = TIMEOUT)
   public void testVeniceWriterShouldNotCauseStackOverflowError() {
     PubSubProducerAdapter mockedProducer = mock(PubSubProducerAdapter.class);
     CompletableFuture mockedFuture = mock(CompletableFuture.class);
@@ -579,6 +594,7 @@ public class VeniceWriterUnitTest {
 
     Properties writerProperties = new Properties();
     writerProperties.put(VeniceWriter.MAX_ELAPSED_TIME_FOR_SEGMENT_IN_MS, 1);
+    writerProperties.put(VeniceWriter.CLOSE_TIMEOUT_MS, TIMEOUT / 2);
     VeniceWriterOptions veniceWriterOptions = new VeniceWriterOptions.Builder("test").setPartitionCount(1).build();
 
     try (VeniceWriter<Object, Object, Object> writer =

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestFatalDataValidationExceptionHandling.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestFatalDataValidationExceptionHandling.java
@@ -333,7 +333,7 @@ public class TestFatalDataValidationExceptionHandling {
         null,
         new LeaderMetadataWrapper(3, 0));
     vw1.flush();
-    vw1.endSegment(0, true);
+    vw1.closePartition(0);
     vw1.flush();
 
     vw3.broadcastEndOfPush(Collections.emptyMap());

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/pubsub/adapter/kafka/producer/ApacheKafkaProducerAdapterITest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/pubsub/adapter/kafka/producer/ApacheKafkaProducerAdapterITest.java
@@ -99,7 +99,7 @@ public class ApacheKafkaProducerAdapterITest {
   @AfterMethod(alwaysRun = true)
   public void cleanUp() {
     if (producerAdapter != null) {
-      producerAdapter.close(0, false);
+      producerAdapter.close(0);
     }
   }
 
@@ -177,7 +177,7 @@ public class ApacheKafkaProducerAdapterITest {
 
     // Initiate close in another thread as it close() call waits for ioThread to finish.
     // Since we're blocking ioThread in m0's callback calling it from current thread would lead to deadlock.
-    Thread closeProducerThread = new Thread(() -> producerAdapter.close(doFlush ? Integer.MAX_VALUE : 0, doFlush));
+    Thread closeProducerThread = new Thread(() -> producerAdapter.close(doFlush ? Integer.MAX_VALUE : 0));
     closeProducerThread.start();
     // We need to make sure that the Producer::close is always invoked first to ensure the correctness of this test
     waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, () -> {
@@ -313,7 +313,7 @@ public class ApacheKafkaProducerAdapterITest {
       countDownLatch.await();
       // Still wait for some time to make sure blocking sendMessage is inside kafka before closing it.
       Utils.sleep(50);
-      producerAdapter.close(5000, doFlush);
+      producerAdapter.close(5000);
       sendMessageFuture.get(); // this is necessary to check whether expectations in sendMessage thread were met
     } catch (Exception e) {
       fail("Producer closing should have succeeded without an exception", e);

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/pubsub/adapter/kafka/producer/ApacheKafkaProducerAdapterITest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/pubsub/adapter/kafka/producer/ApacheKafkaProducerAdapterITest.java
@@ -287,7 +287,7 @@ public class ApacheKafkaProducerAdapterITest {
    * blocked in Producer::sendMessage() call.
    */
   @Test(timeOut = 30 * MS_PER_SECOND, dataProvider = "True-and-False", dataProviderClass = DataProviderUtils.class)
-  public void testProducerCloseCanUnblockSendMessageCallerThread(boolean doFlush) {
+  public void testProducerCloseCanUnblockSendMessageCallerThread(boolean zeroTimeout) {
     ExecutorService executor = Executors.newCachedThreadPool();
     CountDownLatch countDownLatch = new CountDownLatch(1);
 
@@ -313,7 +313,8 @@ public class ApacheKafkaProducerAdapterITest {
       countDownLatch.await();
       // Still wait for some time to make sure blocking sendMessage is inside kafka before closing it.
       Utils.sleep(50);
-      producerAdapter.close(5000);
+      long timeout = zeroTimeout ? 0 : 5000;
+      producerAdapter.close(timeout);
       sendMessageFuture.get(); // this is necessary to check whether expectations in sendMessage thread were met
     } catch (Exception e) {
       fail("Producer closing should have succeeded without an exception", e);

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/pubsub/api/admin/PubSubAdminAdapterTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/pubsub/api/admin/PubSubAdminAdapterTest.java
@@ -126,7 +126,7 @@ public class PubSubAdminAdapterTest {
   public void tearDownMethod() {
     Utils.closeQuietlyWithErrorLogged(pubSubAdminAdapter);
     if (pubSubProducerAdapterLazy.isPresent()) {
-      pubSubProducerAdapterLazy.get().close(0, false);
+      pubSubProducerAdapterLazy.get().close(0);
     }
     if (pubSubConsumerAdapterLazy.isPresent()) {
       Utils.closeQuietlyWithErrorLogged(pubSubConsumerAdapterLazy.get());

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/pubsub/api/consumer/PubSubConsumerAdapterTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/pubsub/api/consumer/PubSubConsumerAdapterTest.java
@@ -137,7 +137,7 @@ public class PubSubConsumerAdapterTest {
   public void tearDownMethod() {
     Utils.closeQuietlyWithErrorLogged(pubSubConsumerAdapter);
     if (pubSubProducerAdapterLazy.isPresent()) {
-      pubSubProducerAdapterLazy.get().close(0, false);
+      pubSubProducerAdapterLazy.get().close(0);
     }
     if (pubSubAdminAdapterLazy.isPresent()) {
       Utils.closeQuietlyWithErrorLogged(pubSubAdminAdapterLazy.get());

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/pubsub/manager/TopicManagerE2ETest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/pubsub/manager/TopicManagerE2ETest.java
@@ -117,7 +117,7 @@ public class TopicManagerE2ETest {
   @AfterMethod(alwaysRun = true)
   public void tearDownMethod() {
     if (pubSubProducerAdapterLazy.isPresent()) {
-      pubSubProducerAdapterLazy.get().close(0, false);
+      pubSubProducerAdapterLazy.get().close(0);
     }
     if (pubSubAdminAdapterLazy.isPresent()) {
       Utils.closeQuietlyWithErrorLogged(pubSubAdminAdapterLazy.get());

--- a/internal/venice-test-common/src/main/java/com/linkedin/venice/unit/kafka/producer/MockInMemoryProducerAdapter.java
+++ b/internal/venice-test-common/src/main/java/com/linkedin/venice/unit/kafka/producer/MockInMemoryProducerAdapter.java
@@ -12,9 +12,6 @@ import com.linkedin.venice.unit.kafka.InMemoryKafkaMessage;
 import it.unimi.dsi.fastutil.objects.Object2DoubleMap;
 import it.unimi.dsi.fastutil.objects.Object2DoubleMaps;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
 
 /**
@@ -46,33 +43,7 @@ public class MockInMemoryProducerAdapter implements PubSubProducerAdapter {
     if (callback != null) {
       callback.onCompletion(produceResult, null);
     }
-    return new CompletableFuture<PubSubProduceResult>() {
-      @Override
-      public boolean cancel(boolean mayInterruptIfRunning) {
-        return false;
-      }
-
-      @Override
-      public boolean isCancelled() {
-        return false;
-      }
-
-      @Override
-      public boolean isDone() {
-        return false;
-      }
-
-      @Override
-      public PubSubProduceResult get() throws InterruptedException, ExecutionException {
-        return produceResult;
-      }
-
-      @Override
-      public PubSubProduceResult get(long timeout, TimeUnit unit)
-          throws InterruptedException, ExecutionException, TimeoutException {
-        return produceResult;
-      }
-    };
+    return CompletableFuture.completedFuture(produceResult);
   }
 
   @Override
@@ -81,7 +52,7 @@ public class MockInMemoryProducerAdapter implements PubSubProducerAdapter {
   }
 
   @Override
-  public void close(int closeTimeOutMs, boolean flush) {
+  public void close(long closeTimeOutMs) {
     // no-op
   }
 

--- a/internal/venice-test-common/src/main/java/com/linkedin/venice/unit/kafka/producer/TransformingProducerAdapter.java
+++ b/internal/venice-test-common/src/main/java/com/linkedin/venice/unit/kafka/producer/TransformingProducerAdapter.java
@@ -50,8 +50,8 @@ public class TransformingProducerAdapter implements PubSubProducerAdapter {
   }
 
   @Override
-  public void close(int closeTimeOutMs, boolean flush) {
-    baseProducer.close(closeTimeOutMs, flush);
+  public void close(long closeTimeOutMs) {
+    baseProducer.close(closeTimeOutMs);
   }
 
   @Override


### PR DESCRIPTION
The endAllSegments function will now write to all segments in parallel, and wait once at the end, rather than block for each one sequentially.

The close function now honors the venice.writer.close.timeout.ms config strictly. Previously, it could wait longer than this during close.

Deleted the following unused config from the VeniceWriter: venice.writer.sleep.time.ms.when.topic.missing

Deleted unnecessary overloads in ApacheKafkaProducerAdapter. In particular, stopped relying on the flush with timeout API, because it only exists in LinkedIn's fork of Kafka, and thus prevents moving to the Apache fork of Kafka.

Tweaked the synchronization to prevent race conditions when calling close multiple times. It should now be impossible to receive a RejectedExecutionException due to the threadPoolExecutor having been already shutdown.

Miscellaneous:

- TestRestartServerAfterDeletingSstFilesWithActiveActiveIngestion now has more robust resource closing logic.

## How was this PR tested?
GHCI.

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [x] Yes. Make sure to explain your proposed changes and call out the behavior change.

See commit message for deleted config and tweaked config semantic.