### PR TITLE
[fast-client] IndexOutOfBoundsException in getReplicas due to bad casting

### DIFF
--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/meta/HelixScatterGatherRoutingStrategy.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/meta/HelixScatterGatherRoutingStrategy.java
@@ -29,7 +29,7 @@ public class HelixScatterGatherRoutingStrategy extends AbstractClientRoutingStra
     }
     // select replicas from the selected group, going down the groups if more replicas are needed
     int groupCnt = helixGroupInfo.getGroupIds().size();
-    int startPos = (int) requestId % groupCnt;
+    int startPos = (int) (requestId % groupCnt);
     List<String> selectedReplicas = new ArrayList<>();
     for (int i = 0; i < groupCnt; i++) {
       int groupId = helixGroupInfo.getGroupIds().get((i + startPos) % groupCnt);

--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/meta/LeastLoadedClientRoutingStrategy.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/meta/LeastLoadedClientRoutingStrategy.java
@@ -28,7 +28,7 @@ public class LeastLoadedClientRoutingStrategy extends AbstractClientRoutingStrat
       return Collections.emptyList();
     }
     int replicaCnt = replicas.size();
-    int startPos = (int) requestId % replicaCnt;
+    int startPos = (int) (requestId % replicaCnt);
     List<String> availReplicas = new ArrayList<>();
     for (int i = 0; i < replicaCnt; ++i) {
       String replica = replicas.get((i + startPos) % replicaCnt);

--- a/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/meta/HelixScatterGatherRoutingStrategyTest.java
+++ b/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/meta/HelixScatterGatherRoutingStrategyTest.java
@@ -5,6 +5,7 @@ import static org.mockito.Mockito.mock;
 import static org.testng.Assert.assertEquals;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -74,13 +75,21 @@ public class HelixScatterGatherRoutingStrategyTest {
 
   @Test
   public void testGetReplicasWithoutReachingRequiredCount() {
-    List<String> replicas = Arrays.asList(instance1);
-    runTest(replicas, 0, 2, Arrays.asList(instance1));
+    List<String> replicas = Collections.singletonList(instance1);
+    runTest(replicas, 0, 2, Collections.singletonList(instance1));
   }
 
   @Test
   public void testGetReplicasWithoutAnyFilteredReplicas() {
-    List<String> replicas = Arrays.asList();
-    runTest(replicas, 0, 2, Arrays.asList());
+    List<String> replicas = Collections.emptyList();
+    runTest(replicas, 0, 2, Collections.emptyList());
+  }
+
+  @Test
+  public void testLargeRequestId() {
+    List<String> replicas = Collections.singletonList(instance1);
+    long requestId = Integer.MAX_VALUE;
+    requestId += 100;
+    runTest(replicas, requestId, 1, Collections.singletonList(instance1));
   }
 }

--- a/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/meta/LeastLoadedClientRoutingStrategyTest.java
+++ b/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/meta/LeastLoadedClientRoutingStrategyTest.java
@@ -5,6 +5,7 @@ import static org.mockito.Mockito.mock;
 import static org.testng.Assert.assertEquals;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import org.testng.annotations.Test;
 
@@ -99,5 +100,19 @@ public class LeastLoadedClientRoutingStrategyTest {
         new boolean[] { true, false, true, true, true, true },
         new int[] { 100, 1, 2, 3, 4, 2 });
     runTest(instanceHealthMonitor, replicas, 0, 2, Arrays.asList(instance2, instance3, instance6));
+  }
+
+  @Test
+  public void testLargeRequestId() {
+    String[] instances = new String[] { instance1, instance2, instance3 };
+    List<String> replicas = Arrays.asList(instances);
+    InstanceHealthMonitor instanceHealthMonitor = mockInstanceHealthyMonitor(
+        instances,
+        new boolean[] { false, false, false },
+        new boolean[] { true, true, true },
+        new int[] { 0, 0, 0 });
+    long requestId = Integer.MAX_VALUE;
+    requestId += 100;
+    runTest(instanceHealthMonitor, replicas, requestId, 1, Collections.singletonList(instance3));
   }
 }


### PR DESCRIPTION
## [fast-client] IndexOutOfBoundsException in getReplicas due to bad casting
There is a bug in our getReplicas code for both routing strategies:  HelixScatterGatherRoutingStrategy and LeastLoadedClientRoutingStrategy where we accidentally cast requestId (a long) into an int and this can cause integer overflow and return negative index.

int startPos = (int) requestId % replicaCnt;

instead of 

int startPos = (int) (requestId % replicaCnt);

## How was this PR tested?
New unit tests

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.