### PR TITLE
[changelog] Add isCaughtUp() API to VeniceChangelogConsumer interface

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumer.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumer.java
@@ -198,6 +198,14 @@ public interface VeniceChangelogConsumer<K, V> {
   Collection<PubSubMessage<K, ChangeEvent<V>, VeniceChangeCoordinate>> poll(long timeoutInMs);
 
   /**
+   * Checks whether all subscribed partitions are caught up during bootstrap.
+   * @param offsetThresholdTimestamp Offset timestamp in millisecond. If a partition's (startTimestamp - heartbeatTimestamp)
+   *                                 is smaller or equal to offsetThresholdTimestamp, we consider this partition is caught up.
+   * @return True if all subscribed partitions have caught up.
+   */
+  boolean isCaughtUp(long offsetThresholdTimestamp);
+
+  /**
    * Release the internal resources.
    */
   void close();

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumer.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumer.java
@@ -198,8 +198,8 @@ public interface VeniceChangelogConsumer<K, V> {
   Collection<PubSubMessage<K, ChangeEvent<V>, VeniceChangeCoordinate>> poll(long timeoutInMs);
 
   /**
-   * Checks whether all subscribed partitions are caught up during bootstrap. If a partition's (startTimestamp - heartbeatTimestamp)
-   * is smaller or equal to 1 min (which is 1 Heartbeat stale), we consider this partition is caught up.
+   * Checks whether all subscribed partitions are caught up during bootstrap. If a partition's (currentTimestamp - latestMessageTimestamp)
+   * is smaller or equal to 1 min, we consider this partition is caught up.
    * @return True if all subscribed partitions have caught up.
    */
   boolean isCaughtUp();

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumer.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumer.java
@@ -198,12 +198,11 @@ public interface VeniceChangelogConsumer<K, V> {
   Collection<PubSubMessage<K, ChangeEvent<V>, VeniceChangeCoordinate>> poll(long timeoutInMs);
 
   /**
-   * Checks whether all subscribed partitions are caught up during bootstrap.
-   * @param offsetThresholdTimestamp Offset timestamp in millisecond. If a partition's (startTimestamp - heartbeatTimestamp)
-   *                                 is smaller or equal to offsetThresholdTimestamp, we consider this partition is caught up.
+   * Checks whether all subscribed partitions are caught up during bootstrap. If a partition's (startTimestamp - heartbeatTimestamp)
+   * is smaller or equal to 1 min (which is 1 Heartbeat stale), we consider this partition is caught up.
    * @return True if all subscribed partitions have caught up.
    */
-  boolean isCaughtUp(long offsetThresholdTimestamp);
+  boolean isCaughtUp();
 
   /**
    * Release the internal resources.

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerClientFactory.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerClientFactory.java
@@ -63,7 +63,7 @@ public class VeniceChangelogConsumerClientFactory {
   }
 
   public <K, V> VeniceChangelogConsumer<K, V> getChangelogConsumer(String storeName, String consumerId) {
-    return getChangelogConsumer(storeName, null);
+    return getChangelogConsumer(storeName, consumerId, null);
   }
 
   /**

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerClientFactory.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerClientFactory.java
@@ -62,13 +62,18 @@ public class VeniceChangelogConsumerClientFactory {
     return getChangelogConsumer(storeName, null);
   }
 
+  public <K, V> VeniceChangelogConsumer<K, V> getChangelogConsumer(String storeName, String consumerId) {
+    return getChangelogConsumer(storeName, null);
+  }
+
   /**
    * Creates a VeniceChangelogConsumer with consumer id. This is used to create multiple consumers so that
    * each consumer can only subscribe to certain partitions. Multiple such consumers can work in parallel.
    */
-  public <K, V> VeniceChangelogConsumer<K, V> getChangelogConsumer(String storeName, String consumerId) {
+  public <K, V> VeniceChangelogConsumer<K, V> getChangelogConsumer(String storeName, String consumerId, Class clazz) {
     return storeClientMap.computeIfAbsent(suffixConsumerIdToStore(storeName, consumerId), name -> {
-      ChangelogClientConfig newStoreChangelogClientConfig = getNewStoreChangelogClientConfig(storeName);
+      ChangelogClientConfig newStoreChangelogClientConfig =
+          getNewStoreChangelogClientConfig(storeName).setSpecificValue(clazz);
       newStoreChangelogClientConfig.setConsumerName(name);
       String viewClass = getViewClass(newStoreChangelogClientConfig, storeName);
       String consumerName = suffixConsumerIdToStore(storeName + "-" + viewClass.getClass().getSimpleName(), consumerId);

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImpl.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImpl.java
@@ -444,8 +444,8 @@ public class VeniceChangelogConsumerImpl<K, V> implements VeniceChangelogConsume
   }
 
   @Override
-  public boolean isCaughtUp(long lagThresholdTimestamp) {
-    return partitionToBootstrapHeartbeatLag.values().stream().allMatch(x -> x <= lagThresholdTimestamp);
+  public boolean isCaughtUp() {
+    return partitionToBootstrapHeartbeatLag.values().stream().allMatch(x -> x <= TimeUnit.MINUTES.toMillis(1));
   }
 
   protected CompletableFuture<Void> internalSeek(

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImplTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/VeniceChangelogConsumerImplTest.java
@@ -1,7 +1,10 @@
 package com.linkedin.davinci.consumer;
 
+import static com.linkedin.venice.kafka.protocol.enums.ControlMessageType.START_OF_SEGMENT;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -45,6 +48,7 @@ import com.linkedin.venice.serialization.avro.AvroProtocolDefinition;
 import com.linkedin.venice.serializer.FastSerializerDeserializerFactory;
 import com.linkedin.venice.serializer.RecordSerializer;
 import com.linkedin.venice.utils.Utils;
+import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
 import com.linkedin.venice.utils.lazy.Lazy;
 import com.linkedin.venice.views.ChangeCaptureView;
 import java.nio.ByteBuffer;
@@ -58,6 +62,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
@@ -224,6 +229,31 @@ public class VeniceChangelogConsumerImplTest {
     Mockito.verify(mockInternalSeekConsumer).unsubscribe(partitionSet);
     PubSubTopicPartition pubSubTopicPartition = new PubSubTopicPartitionImpl(oldVersionTopic, 0);
     Mockito.verify(mockPubSubConsumer).subscribe(pubSubTopicPartition, 10);
+  }
+
+  @Test
+  public void testBootstrapState() {
+    VeniceChangelogConsumerImpl veniceChangelogConsumer = mock(VeniceChangelogConsumerImpl.class);
+    Map<Integer, Boolean> bootstrapStateMap = new VeniceConcurrentHashMap<>();
+    bootstrapStateMap.put(0, false);
+    doReturn(bootstrapStateMap).when(veniceChangelogConsumer).getPartitionToBootstrapState();
+    doCallRealMethod().when(veniceChangelogConsumer).maybeUpdatePartitionToBootstrapMap(any(), any(), anyLong());
+    PubSubTopicRepository topicRepository = new PubSubTopicRepository();
+    PubSubTopicPartition pubSubTopicPartition = new PubSubTopicPartitionImpl(topicRepository.getTopic("foo_v1"), 0);
+    ControlMessage controlMessage = new ControlMessage();
+    controlMessage.controlMessageType = START_OF_SEGMENT.getValue();
+    KafkaMessageEnvelope kafkaMessageEnvelope = new KafkaMessageEnvelope();
+    kafkaMessageEnvelope.producerMetadata = new ProducerMetadata();
+    kafkaMessageEnvelope.producerMetadata.messageTimestamp = TimeUnit.MINUTES.toMillis(8);
+    kafkaMessageEnvelope.payloadUnion = controlMessage;
+    PubSubMessage<KafkaKey, KafkaMessageEnvelope, Long> message =
+        new ImmutablePubSubMessage<>(KafkaKey.HEART_BEAT, kafkaMessageEnvelope, pubSubTopicPartition, 0, 0, 0);
+    long startTimestamp = TimeUnit.MINUTES.toMillis(10);
+    veniceChangelogConsumer.maybeUpdatePartitionToBootstrapMap(message, pubSubTopicPartition, startTimestamp);
+    Assert.assertFalse(bootstrapStateMap.get(0));
+    startTimestamp = TimeUnit.MINUTES.toMillis(9);
+    veniceChangelogConsumer.maybeUpdatePartitionToBootstrapMap(message, pubSubTopicPartition, startTimestamp);
+    Assert.assertTrue(bootstrapStateMap.get(0));
   }
 
   @Test

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestChangelogConsumer.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestChangelogConsumer.java
@@ -782,7 +782,7 @@ public class TestChangelogConsumer {
       VeniceChangelogConsumer<Utf8, TestChangelogValue> specificChangelogConsumer =
           veniceChangelogConsumerClientFactory.getChangelogConsumer(storeName, "0", TestChangelogValue.class);
       specificChangelogConsumer.subscribeAll().get();
-      Assert.assertFalse(specificChangelogConsumer.isCaughtUp(0));
+      Assert.assertFalse(specificChangelogConsumer.isCaughtUp());
 
       Map<String, PubSubMessage<Utf8, ChangeEvent<TestChangelogValue>, VeniceChangeCoordinate>> polledChangeEventsMap =
           new HashMap<>();
@@ -794,7 +794,7 @@ public class TestChangelogConsumer {
             polledChangeEventsList,
             specificChangelogConsumer);
         Assert.assertEquals(polledChangeEventsList.size(), 100);
-        Assert.assertTrue(specificChangelogConsumer.isCaughtUp(0));
+        Assert.assertTrue(specificChangelogConsumer.isCaughtUp());
       });
 
       Assert.assertTrue(

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestChangelogConsumer.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestChangelogConsumer.java
@@ -617,7 +617,7 @@ public class TestChangelogConsumer {
   }
 
   @Test(timeOut = TEST_TIMEOUT, priority = 3)
-  public void testSpecificRecordVeniceChangelogConsumer() throws Exception {
+  public void testSpecificRecordBootstrappingVeniceChangelogConsumer() throws Exception {
     ControllerClient childControllerClient =
         new ControllerClient(clusterName, childDatacenters.get(0).getControllerConnectString());
     File inputDir = getTempDataDirectory();
@@ -677,12 +677,126 @@ public class TestChangelogConsumer {
       List<PubSubMessage<Utf8, ChangeEvent<TestChangelogValue>, VeniceChangeCoordinate>> polledChangeEventsList =
           new ArrayList<>();
       TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, true, () -> {
-        pollChangeEventsFromSpecificChangeCaptureConsumer(
+        pollChangeEventsFromSpecificBootstrappingChangeCaptureConsumer(
             polledChangeEventsMap,
             polledChangeEventsList,
             specificChangelogConsumer);
         Assert.assertEquals(polledChangeEventsList.size(), 101);
       });
+      Assert.assertTrue(
+          polledChangeEventsMap.get(Integer.toString(1)).getValue().getCurrentValue() instanceof SpecificRecord);
+      TestChangelogValue value = new TestChangelogValue();
+      value.firstName = "first_name_1";
+      value.lastName = "last_name_1";
+      Assert.assertEquals(polledChangeEventsMap.get(Integer.toString(1)).getValue().getCurrentValue(), value);
+      polledChangeEventsList.clear();
+      polledChangeEventsMap.clear();
+
+      GenericRecord genericRecord = new GenericData.Record(NAME_RECORD_V1_SCHEMA);
+      genericRecord.put("firstName", "Venice");
+      genericRecord.put("lastName", "Italy");
+
+      GenericRecord genericRecordV2 = new GenericData.Record(NAME_RECORD_V1_SCHEMA);
+      genericRecordV2.put("firstName", "Barcelona");
+      genericRecordV2.put("lastName", "Spain");
+
+      VeniceSystemFactory factory = new VeniceSystemFactory();
+      try (VeniceSystemProducer veniceProducer = factory
+          .getClosableProducer("venice", new MapConfig(getSamzaProducerConfig(childDatacenters, 0, storeName)), null)) {
+        veniceProducer.start();
+        // Run Samza job to send PUT and DELETE requests.
+        sendStreamingRecord(veniceProducer, storeName, Integer.toString(10000), genericRecord, null);
+        sendStreamingRecord(veniceProducer, storeName, Integer.toString(10000), genericRecordV2, null);
+      }
+
+      TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, true, () -> {
+        pollChangeEventsFromSpecificBootstrappingChangeCaptureConsumer(
+            polledChangeEventsMap,
+            polledChangeEventsList,
+            specificChangelogConsumer);
+        Assert.assertEquals(polledChangeEventsList.size(), 2);
+      });
+      Assert.assertTrue(
+          polledChangeEventsMap.get(Integer.toString(10000)).getValue().getCurrentValue() instanceof SpecificRecord);
+
+      parentControllerClient.disableAndDeleteStore(storeName);
+      // Verify that topics and store is cleaned up
+      TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, true, () -> {
+        MultiStoreTopicsResponse storeTopicsResponse = childControllerClient.getDeletableStoreTopics();
+        Assert.assertFalse(storeTopicsResponse.isError());
+        Assert.assertEquals(storeTopicsResponse.getTopics().size(), 0);
+      });
+    }
+  }
+
+  @Test(timeOut = TEST_TIMEOUT, priority = 3)
+  public void testSpecificRecordVeniceChangelogConsumer() throws Exception {
+    ControllerClient childControllerClient =
+        new ControllerClient(clusterName, childDatacenters.get(0).getControllerConnectString());
+    File inputDir = getTempDataDirectory();
+    Schema recordSchema = TestWriteUtils.writeSimpleAvroFileWithStringToNameRecordV1Schema(inputDir);
+    String inputDirPath = "file://" + inputDir.getAbsolutePath();
+    String storeName = Utils.getUniqueString("store");
+    Properties props =
+        TestWriteUtils.defaultVPJProps(parentControllers.get(0).getControllerUrl(), inputDirPath, storeName);
+    String keySchemaStr = recordSchema.getField(DEFAULT_KEY_FIELD_PROP).schema().toString();
+    String valueSchemaStr = NAME_RECORD_V2_SCHEMA.toString();
+    UpdateStoreQueryParams storeParms = new UpdateStoreQueryParams().setActiveActiveReplicationEnabled(true)
+        .setHybridRewindSeconds(500)
+        .setHybridOffsetLagThreshold(8)
+        .setChunkingEnabled(true)
+        .setNativeReplicationEnabled(true)
+        .setPartitionCount(3);
+    MetricsRepository metricsRepository = new MetricsRepository();
+    ControllerClient setupControllerClient =
+        createStoreForJob(clusterName, keySchemaStr, valueSchemaStr, props, storeParms);
+    setupControllerClient
+        .retryableRequest(5, controllerClient1 -> setupControllerClient.updateStore(storeName, storeParms));
+    // Registering real data schema as schema v2.
+    setupControllerClient.retryableRequest(
+        5,
+        controllerClient1 -> setupControllerClient.addValueSchema(storeName, NAME_RECORD_V1_SCHEMA.toString()));
+    TestWriteUtils.runPushJob("Run push job", props);
+    TestMockTime testMockTime = new TestMockTime();
+    ZkServerWrapper localZkServer = multiRegionMultiClusterWrapper.getChildRegions().get(0).getZkServerWrapper();
+    try (PubSubBrokerWrapper localKafka = ServiceFactory.getPubSubBroker(
+        new PubSubBrokerConfigs.Builder().setZkWrapper(localZkServer)
+            .setMockTime(testMockTime)
+            .setRegionName("local-pubsub")
+            .build())) {
+      Properties consumerProperties = new Properties();
+      String localKafkaUrl = localKafka.getAddress();
+      consumerProperties.put(KAFKA_BOOTSTRAP_SERVERS, localKafkaUrl);
+      consumerProperties.put(CLUSTER_NAME, clusterName);
+      consumerProperties.put(ZOOKEEPER_ADDRESS, localZkServer.getAddress());
+      ChangelogClientConfig globalChangelogClientConfig =
+          new ChangelogClientConfig().setConsumerProperties(consumerProperties)
+              .setControllerD2ServiceName(D2_SERVICE_NAME)
+              .setD2ServiceName(VeniceRouterWrapper.CLUSTER_DISCOVERY_D2_SERVICE_NAME)
+              .setLocalD2ZkHosts(localZkServer.getAddress())
+              .setControllerRequestRetryCount(3)
+              .setSpecificValue(TestChangelogValue.class)
+              .setBootstrapFileSystemPath(Utils.getUniqueString(inputDirPath));
+      VeniceChangelogConsumerClientFactory veniceChangelogConsumerClientFactory =
+          new VeniceChangelogConsumerClientFactory(globalChangelogClientConfig, metricsRepository);
+      VeniceChangelogConsumer<Utf8, TestChangelogValue> specificChangelogConsumer =
+          veniceChangelogConsumerClientFactory.getChangelogConsumer(storeName, "0", TestChangelogValue.class);
+      specificChangelogConsumer.subscribeAll().get();
+      Assert.assertFalse(specificChangelogConsumer.isCaughtUp(0));
+
+      Map<String, PubSubMessage<Utf8, ChangeEvent<TestChangelogValue>, VeniceChangeCoordinate>> polledChangeEventsMap =
+          new HashMap<>();
+      List<PubSubMessage<Utf8, ChangeEvent<TestChangelogValue>, VeniceChangeCoordinate>> polledChangeEventsList =
+          new ArrayList<>();
+      TestUtils.waitForNonDeterministicAssertion(120, TimeUnit.SECONDS, true, () -> {
+        pollChangeEventsFromSpecificChangeCaptureConsumer(
+            polledChangeEventsMap,
+            polledChangeEventsList,
+            specificChangelogConsumer);
+        Assert.assertEquals(polledChangeEventsList.size(), 100);
+        Assert.assertTrue(specificChangelogConsumer.isCaughtUp(0));
+      });
+
       Assert.assertTrue(
           polledChangeEventsMap.get(Integer.toString(1)).getValue().getCurrentValue() instanceof SpecificRecord);
       TestChangelogValue value = new TestChangelogValue();
@@ -718,7 +832,6 @@ public class TestChangelogConsumer {
       });
       Assert.assertTrue(
           polledChangeEventsMap.get(Integer.toString(10000)).getValue().getCurrentValue() instanceof SpecificRecord);
-
       parentControllerClient.disableAndDeleteStore(storeName);
       // Verify that topics and store is cleaned up
       TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, true, () -> {
@@ -766,10 +879,23 @@ public class TestChangelogConsumer {
     }
   }
 
-  private void pollChangeEventsFromSpecificChangeCaptureConsumer(
+  private void pollChangeEventsFromSpecificBootstrappingChangeCaptureConsumer(
       Map<String, PubSubMessage<Utf8, ChangeEvent<TestChangelogValue>, VeniceChangeCoordinate>> polledChangeEvents,
       List<PubSubMessage<Utf8, ChangeEvent<TestChangelogValue>, VeniceChangeCoordinate>> polledMessageList,
       BootstrappingVeniceChangelogConsumer veniceChangelogConsumer) {
+    Collection<PubSubMessage<Utf8, ChangeEvent<TestChangelogValue>, VeniceChangeCoordinate>> pubSubMessages =
+        veniceChangelogConsumer.poll(1000);
+    for (PubSubMessage<Utf8, ChangeEvent<TestChangelogValue>, VeniceChangeCoordinate> pubSubMessage: pubSubMessages) {
+      String key = pubSubMessage.getKey() == null ? null : pubSubMessage.getKey().toString();
+      polledChangeEvents.put(key, pubSubMessage);
+    }
+    polledMessageList.addAll(pubSubMessages);
+  }
+
+  private void pollChangeEventsFromSpecificChangeCaptureConsumer(
+      Map<String, PubSubMessage<Utf8, ChangeEvent<TestChangelogValue>, VeniceChangeCoordinate>> polledChangeEvents,
+      List<PubSubMessage<Utf8, ChangeEvent<TestChangelogValue>, VeniceChangeCoordinate>> polledMessageList,
+      VeniceChangelogConsumer veniceChangelogConsumer) {
     Collection<PubSubMessage<Utf8, ChangeEvent<TestChangelogValue>, VeniceChangeCoordinate>> pubSubMessages =
         veniceChangelogConsumer.poll(1000);
     for (PubSubMessage<Utf8, ChangeEvent<TestChangelogValue>, VeniceChangeCoordinate> pubSubMessage: pubSubMessages) {


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## [changelog] Add isCaughtUp() API to VeniceChangelogConsumer interface
Instead of implementing a listener as in #1012 , a simpler solution is just to provide an API that user can call to check whether all subscriptions have caught up.
Also, add specific record support for regular consumer

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.