### PR TITLE
[all] Make getValueSchemaId APIs match the canonical schemas

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/client/DelegatingAvroGenericDaVinciClient.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/client/DelegatingAvroGenericDaVinciClient.java
@@ -7,6 +7,7 @@ import com.linkedin.venice.client.store.ComputeGenericRecord;
 import com.linkedin.venice.client.store.ComputeRequestBuilder;
 import com.linkedin.venice.client.store.streaming.StreamingCallback;
 import com.linkedin.venice.compute.ComputeRequestWrapper;
+import com.linkedin.venice.schema.SchemaReader;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -91,9 +92,15 @@ public class DelegatingAvroGenericDaVinciClient<K, V>
     return delegate.getKeySchema();
   }
 
+  @Deprecated
   @Override
   public Schema getLatestValueSchema() {
     return delegate.getLatestValueSchema();
+  }
+
+  @Override
+  public SchemaReader getSchemaReader() {
+    return delegate.getSchemaReader();
   }
 
   @Override

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/repository/DaVinciClientMetaStoreBasedRepository.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/repository/DaVinciClientMetaStoreBasedRepository.java
@@ -16,6 +16,7 @@ import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.StoreConfig;
 import com.linkedin.venice.meta.SystemStore;
 import com.linkedin.venice.meta.ZKStore;
+import com.linkedin.venice.schema.AvroSchemaParseUtils;
 import com.linkedin.venice.schema.SchemaData;
 import com.linkedin.venice.schema.SchemaEntry;
 import com.linkedin.venice.schema.SchemaReader;
@@ -123,7 +124,8 @@ public class DaVinciClientMetaStoreBasedRepository extends NativeMetadataReposit
   @Override
   public int getValueSchemaId(String storeName, String valueSchemaStr) {
     if (VeniceSystemStoreType.getSystemStoreType(storeName) == VeniceSystemStoreType.META_STORE) {
-      return metaStoreSchemaReader.getValueSchemaId(Schema.parse(valueSchemaStr));
+      return metaStoreSchemaReader
+          .getValueSchemaId(AvroSchemaParseUtils.parseSchemaFromJSONLooseValidation(valueSchemaStr));
     } else {
       return super.getValueSchemaId(storeName, valueSchemaStr);
     }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/client/AvroGenericDaVinciClientTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/client/AvroGenericDaVinciClientTest.java
@@ -2,17 +2,13 @@ package com.linkedin.davinci.client;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 
 import com.linkedin.davinci.StoreBackend;
 import com.linkedin.davinci.VersionBackend;
 import com.linkedin.davinci.store.rocksdb.RocksDBServerConfig;
-import com.linkedin.venice.meta.ReadOnlySchemaRepository;
-import com.linkedin.venice.schema.SchemaEntry;
 import com.linkedin.venice.serializer.AvroSerializer;
 import com.linkedin.venice.utils.PropertyBuilder;
 import com.linkedin.venice.utils.ReferenceCounted;
@@ -30,32 +26,6 @@ import org.testng.annotations.Test;
 
 
 public class AvroGenericDaVinciClientTest {
-  @Test
-  public void testGetValueSchemaIdForComputeRequest() {
-    String storeName = "test_store";
-    ReadOnlySchemaRepository repo = mock(ReadOnlySchemaRepository.class);
-
-    Schema computeValueSchema = mock(Schema.class);
-    String computeValueSchemaString = "compute_value_schema";
-    doReturn(computeValueSchemaString).when(computeValueSchema).toString();
-    int valueSchemaId = 1;
-    doReturn(new SchemaEntry(valueSchemaId, computeValueSchema)).when(repo).getSupersetOrLatestValueSchema(storeName);
-    Assert.assertEquals(
-        AvroGenericDaVinciClient.getValueSchemaIdForComputeRequest(storeName, computeValueSchema, repo),
-        1);
-
-    // mismatch scenario
-    Schema latestValueSchema = mock(Schema.class);
-    int latestValueSchemaId = 2;
-    doReturn(new SchemaEntry(latestValueSchemaId, latestValueSchema)).when(repo)
-        .getSupersetOrLatestValueSchema(storeName);
-    doReturn(valueSchemaId).when(repo).getValueSchemaId(storeName, computeValueSchemaString);
-    Assert.assertEquals(
-        AvroGenericDaVinciClient.getValueSchemaIdForComputeRequest(storeName, computeValueSchema, repo),
-        1);
-    verify(repo).getValueSchemaId(storeName, computeValueSchemaString);
-  }
-
   @Test
   public void testPropertyBuilderWithRecordTransformer() {
     String schema = "{\n" + "  \"type\": \"string\"\n" + "}\n";

--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/DelegatingAvroStoreClient.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/DelegatingAvroStoreClient.java
@@ -9,6 +9,7 @@ import com.linkedin.venice.client.store.ComputeRequestBuilder;
 import com.linkedin.venice.client.store.streaming.StreamingCallback;
 import com.linkedin.venice.compute.ComputeRequestWrapper;
 import com.linkedin.venice.fastclient.factory.ClientFactory;
+import com.linkedin.venice.schema.SchemaReader;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
@@ -81,6 +82,11 @@ public class DelegatingAvroStoreClient<K, V> extends InternalAvroStoreClient<K, 
   }
 
   @Override
+  public SchemaReader getSchemaReader() {
+    return delegate.getSchemaReader();
+  }
+
+  @Override
   protected CompletableFuture<V> get(GetRequestContext requestContext, K key) throws VeniceClientException {
     return delegate.get(requestContext, key);
   }
@@ -124,6 +130,7 @@ public class DelegatingAvroStoreClient<K, V> extends InternalAvroStoreClient<K, 
     return delegate.getKeySchema();
   }
 
+  @Deprecated
   @Override
   public Schema getLatestValueSchema() {
     return delegate.getLatestValueSchema();

--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/DispatchingAvroGenericStoreClient.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/DispatchingAvroGenericStoreClient.java
@@ -31,6 +31,7 @@ import com.linkedin.venice.read.protocol.request.router.MultiGetRouterRequestKey
 import com.linkedin.venice.read.protocol.response.MultiGetResponseRecordV1;
 import com.linkedin.venice.read.protocol.response.streaming.StreamingFooterRecordV1;
 import com.linkedin.venice.router.exception.VeniceKeyCountLimitException;
+import com.linkedin.venice.schema.SchemaReader;
 import com.linkedin.venice.schema.avro.ReadAvroProtocolDefinition;
 import com.linkedin.venice.serialization.AvroStoreDeserializerCache;
 import com.linkedin.venice.serialization.StoreDeserializerCache;
@@ -618,9 +619,7 @@ public class DispatchingAvroGenericStoreClient<K, V> extends InternalAvroStoreCl
     headers.put(
         HttpConstants.VENICE_API_VERSION,
         Integer.toString(ReadAvroProtocolDefinition.COMPUTE_REQUEST_V3.getProtocolVersion()));
-    headers.put(
-        VENICE_COMPUTE_VALUE_SCHEMA_ID,
-        Integer.toString(metadata.getValueSchemaId(computeRequest.getValueSchema())));
+    headers.put(VENICE_COMPUTE_VALUE_SCHEMA_ID, Integer.toString(computeRequest.getValueSchemaID()));
 
     RecordDeserializer<GenericRecord> computeResultRecordDeserializer =
         getComputeResultRecordDeserializer(resultSchema);
@@ -869,8 +868,14 @@ public class DispatchingAvroGenericStoreClient<K, V> extends InternalAvroStoreCl
     return metadata.getKeySchema();
   }
 
+  @Deprecated
   @Override
   public Schema getLatestValueSchema() {
     return metadata.getLatestValueSchema();
+  }
+
+  @Override
+  public SchemaReader getSchemaReader() {
+    return metadata;
   }
 }

--- a/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/RetriableAvroGenericStoreClientTest.java
+++ b/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/RetriableAvroGenericStoreClientTest.java
@@ -151,7 +151,8 @@ public class RetriableAvroGenericStoreClientTest {
       ClientConfig clientConfig) {
     StoreMetadata mockMetadata = mock(StoreMetadata.class);
     doReturn(STORE_NAME).when(mockMetadata).getStoreName();
-    doReturn(STORE_VALUE_SCHEMA).when(mockMetadata).getLatestValueSchema();
+    doReturn(1).when(mockMetadata).getLatestValueSchemaId();
+    doReturn(STORE_VALUE_SCHEMA).when(mockMetadata).getValueSchema(1);
     return new DispatchingAvroGenericStoreClient(mockMetadata, clientConfig) {
       private int requestCnt = 0;
 

--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/schema/RouterBackedSchemaReader.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/schema/RouterBackedSchemaReader.java
@@ -748,6 +748,8 @@ public class RouterBackedSchemaReader implements SchemaReader {
     valueSchemaToCanonicalSchemaId.put(valueSchema, valueSchemaId);
 
     Integer cachedCanonicalSchemaId = canonicalValueSchemaMapR.getIfPresent(canonicalSchema);
+    // Cache schemas if they're previously unseen or have a higher schema ID than the current cached one. This will
+    // ensure that the later schemas are preferred over old schemas
     if (cachedCanonicalSchemaId == null || cachedCanonicalSchemaId < valueSchemaId) {
       canonicalValueSchemaMapR.put(canonicalSchema, valueSchemaId);
     }

--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/AbstractAvroStoreClient.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/AbstractAvroStoreClient.java
@@ -196,7 +196,8 @@ public abstract class AbstractAvroStoreClient<K, V> extends InternalAvroStoreCli
     return transportClient;
   }
 
-  protected SchemaReader getSchemaReader() {
+  @Override
+  public SchemaReader getSchemaReader() {
     return schemaReader;
   }
 
@@ -677,7 +678,7 @@ public abstract class AbstractAvroStoreClient<K, V> extends InternalAvroStoreCli
       TransportClientStreamingCallback callback,
       Optional<ClientStats> stats) throws VeniceClientException {
     Map<String, String> headers = new HashMap<>(COMPUTE_HEADER_MAP_FOR_STREAMING_V3);
-    int schemaId = getSchemaReader().getValueSchemaId(computeRequest.getValueSchema());
+    int schemaId = computeRequest.getValueSchemaID();
     headers.put(VENICE_KEY_COUNT, Integer.toString(keyList.size()));
     headers.put(VENICE_COMPUTE_VALUE_SCHEMA_ID, Integer.toString(schemaId));
     if (!clientConfig.isRemoteComputationOnly()) {
@@ -790,6 +791,7 @@ public abstract class AbstractAvroStoreClient<K, V> extends InternalAvroStoreCli
     return getSchemaReader().getKeySchema();
   }
 
+  @Deprecated
   @Override
   public Schema getLatestValueSchema() {
     return getSchemaReader().getLatestValueSchema();

--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/AvroComputeRequestBuilderV3.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/AvroComputeRequestBuilderV3.java
@@ -1,6 +1,5 @@
 package com.linkedin.venice.client.store;
 
-import static com.linkedin.venice.VeniceConstants.COMPUTE_REQUEST_VERSION_V3;
 import static com.linkedin.venice.compute.protocol.request.enums.ComputeOperationType.COUNT;
 
 import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
@@ -11,6 +10,7 @@ import com.linkedin.venice.compute.ComputeRequestWrapper;
 import com.linkedin.venice.compute.protocol.request.ComputeOperation;
 import com.linkedin.venice.compute.protocol.request.Count;
 import com.linkedin.venice.exceptions.VeniceException;
+import com.linkedin.venice.schema.SchemaReader;
 import com.linkedin.venice.utils.Pair;
 import java.util.Arrays;
 import java.util.LinkedList;
@@ -30,14 +30,13 @@ import org.apache.avro.generic.GenericRecord;
  * @param <K>
  */
 public class AvroComputeRequestBuilderV3<K> extends AbstractAvroComputeRequestBuilder<K> {
-  private static final int COMPUTE_REQUEST_VERSION = COMPUTE_REQUEST_VERSION_V3;
   private static final String COUNT_SPEC = "count_spec";
   private static final Schema COUNT_RESULT_SCHEMA =
       Schema.createUnion(Arrays.asList(Schema.create(Schema.Type.NULL), Schema.create(Schema.Type.INT)));
   private final List<Count> countOperations = new LinkedList<>();
 
-  public AvroComputeRequestBuilderV3(AvroGenericReadComputeStoreClient storeClient, Schema latestValueSchema) {
-    super(storeClient, latestValueSchema);
+  public AvroComputeRequestBuilderV3(AvroGenericReadComputeStoreClient storeClient, SchemaReader schemaReader) {
+    super(storeClient, schemaReader);
   }
 
   @Override

--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/AvroComputeRequestBuilderV4.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/AvroComputeRequestBuilderV4.java
@@ -1,6 +1,5 @@
 package com.linkedin.venice.client.store;
 
-import static com.linkedin.venice.VeniceConstants.COMPUTE_REQUEST_VERSION_V4;
 import static org.apache.avro.Schema.Type.RECORD;
 
 import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
@@ -12,6 +11,7 @@ import com.linkedin.venice.client.store.predicate.Predicate;
 import com.linkedin.venice.client.store.streaming.StreamingCallback;
 import com.linkedin.venice.compute.ComputeRequestWrapper;
 import com.linkedin.venice.exceptions.VeniceException;
+import com.linkedin.venice.schema.SchemaReader;
 import com.linkedin.venice.serializer.FastSerializerDeserializerFactory;
 import com.linkedin.venice.serializer.RecordSerializer;
 import java.util.ArrayList;
@@ -25,10 +25,8 @@ import org.apache.avro.generic.GenericRecord;
 
 
 public class AvroComputeRequestBuilderV4<K> extends AvroComputeRequestBuilderV3<K> {
-  private static final int COMPUTE_REQUEST_VERSION = COMPUTE_REQUEST_VERSION_V4;
-
-  public AvroComputeRequestBuilderV4(AvroGenericReadComputeStoreClient storeClient, Schema latestValueSchema) {
-    super(storeClient, latestValueSchema);
+  public AvroComputeRequestBuilderV4(AvroGenericReadComputeStoreClient storeClient, SchemaReader schemaReader) {
+    super(storeClient, schemaReader);
   }
 
   @Override

--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/AvroGenericReadComputeStoreClient.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/AvroGenericReadComputeStoreClient.java
@@ -4,6 +4,7 @@ import com.linkedin.venice.client.exceptions.VeniceClientException;
 import com.linkedin.venice.client.stats.ClientStats;
 import com.linkedin.venice.client.store.streaming.StreamingCallback;
 import com.linkedin.venice.compute.ComputeRequestWrapper;
+import com.linkedin.venice.schema.SchemaReader;
 import java.util.Optional;
 import java.util.Set;
 import org.apache.avro.Schema;
@@ -11,11 +12,13 @@ import org.apache.avro.generic.GenericRecord;
 
 
 /**
- * Venice avro generic client to provide read compute operations
+ * Venice avro generic client to provide read compute operations. This interface is internal and is subject to change.
  * @param <K>
  * @param <V>
  */
 public interface AvroGenericReadComputeStoreClient<K, V> extends AvroGenericStoreClient<K, V> {
+  SchemaReader getSchemaReader();
+
   boolean isProjectionFieldValidationEnabled();
 
   @Override
@@ -43,7 +46,7 @@ public interface AvroGenericReadComputeStoreClient<K, V> extends AvroGenericStor
   default ComputeRequestBuilder<K> compute(
       Optional<ClientStats> stats,
       AvroGenericReadComputeStoreClient computeStoreClient) throws VeniceClientException {
-    return new AvroComputeRequestBuilderV3<K>(computeStoreClient, getLatestValueSchema()).setStats(stats)
+    return new AvroComputeRequestBuilderV3<K>(computeStoreClient, getSchemaReader()).setStats(stats)
         .setValidateProjectionFields(isProjectionFieldValidationEnabled());
   }
 

--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/DelegatingStoreClient.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/DelegatingStoreClient.java
@@ -4,6 +4,7 @@ import com.linkedin.venice.client.exceptions.VeniceClientException;
 import com.linkedin.venice.client.stats.ClientStats;
 import com.linkedin.venice.client.store.streaming.StreamingCallback;
 import com.linkedin.venice.compute.ComputeRequestWrapper;
+import com.linkedin.venice.schema.SchemaReader;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -23,6 +24,11 @@ public class DelegatingStoreClient<K, V> extends InternalAvroStoreClient<K, V> {
   // for testing
   public InternalAvroStoreClient<K, V> getInnerStoreClient() {
     return innerStoreClient;
+  }
+
+  @Override
+  public SchemaReader getSchemaReader() {
+    return innerStoreClient.getSchemaReader();
   }
 
   @Override

--- a/clients/venice-thin-client/src/test/java/com/linkedin/venice/client/schema/RouterBackedSchemaReaderTest.java
+++ b/clients/venice-thin-client/src/test/java/com/linkedin/venice/client/schema/RouterBackedSchemaReaderTest.java
@@ -213,6 +213,27 @@ public class RouterBackedSchemaReaderTest {
   }
 
   @Test
+  public void testGetValueSchemaId()
+      throws IOException, ExecutionException, InterruptedException, VeniceClientException {
+    AbstractAvroStoreClient mockClient = getMockStoreClient(false);
+
+    final Schema sameCanonicalSchemaAsValueSchema2 =
+        AvroCompatibilityHelper.parse(loadFileAsStringQuietlyWithErrorLogged("SameCanonicalAsRecordValueSchema2.avsc"));
+
+    final Schema invalidValueSchema =
+        AvroCompatibilityHelper.parse(loadFileAsStringQuietlyWithErrorLogged("testSchemaWithNamespace.avsc"));
+
+    try (SchemaReader schemaReader = new RouterBackedSchemaReader(() -> mockClient)) {
+      Assert.assertEquals(schemaReader.getValueSchemaId(VALUE_SCHEMA_1), 1);
+      Assert.assertEquals(schemaReader.getValueSchemaId(VALUE_SCHEMA_2), 2);
+      Assert.assertEquals(schemaReader.getValueSchemaId(sameCanonicalSchemaAsValueSchema2), 2);
+      VeniceClientException e =
+          Assert.expectThrows(VeniceClientException.class, () -> schemaReader.getValueSchemaId(invalidValueSchema));
+      Assert.assertTrue(e.getMessage().contains("Could not find schema"));
+    }
+  }
+
+  @Test
   public void testGetUpdateSchema()
       throws IOException, ExecutionException, InterruptedException, VeniceClientException {
     AbstractAvroStoreClient storeClient = getMockStoreClient(true);

--- a/clients/venice-thin-client/src/test/java/com/linkedin/venice/client/store/AbstractAvroStoreClientTest.java
+++ b/clients/venice-thin-client/src/test/java/com/linkedin/venice/client/store/AbstractAvroStoreClientTest.java
@@ -98,19 +98,16 @@ public class AbstractAvroStoreClientTest {
     }
 
     @Override
-    protected SchemaReader getSchemaReader() {
+    public SchemaReader getSchemaReader() {
       if (overrideGetSchemaReader) {
         SchemaReader mockSchemaReader = mock(SchemaReader.class);
         doReturn(Schema.create(Schema.Type.STRING)).when(mockSchemaReader).getKeySchema();
+        doReturn(1).when(mockSchemaReader).getLatestValueSchemaId();
+        doReturn(VALUE_SCHEMA).when(mockSchemaReader).getValueSchema(1);
         return mockSchemaReader;
       } else {
         return super.getSchemaReader();
       }
-    }
-
-    @Override
-    public Schema getLatestValueSchema() {
-      return VALUE_SCHEMA;
     }
   }
 

--- a/clients/venice-thin-client/src/test/java/com/linkedin/venice/client/store/StatTrackingStoreClientTest.java
+++ b/clients/venice-thin-client/src/test/java/com/linkedin/venice/client/store/StatTrackingStoreClientTest.java
@@ -17,6 +17,7 @@ import com.linkedin.venice.client.store.transport.TransportClientResponse;
 import com.linkedin.venice.compression.CompressionStrategy;
 import com.linkedin.venice.compute.ComputeRequestWrapper;
 import com.linkedin.venice.compute.protocol.response.ComputeResponseRecordV1;
+import com.linkedin.venice.schema.AvroSchemaParseUtils;
 import com.linkedin.venice.schema.SchemaReader;
 import com.linkedin.venice.schema.avro.ReadAvroProtocolDefinition;
 import com.linkedin.venice.serializer.RecordDeserializer;
@@ -79,29 +80,28 @@ public class StatTrackingStoreClientTest {
     }
 
     @Override
-    protected SchemaReader getSchemaReader() {
+    public SchemaReader getSchemaReader() {
       SchemaReader mockSchemaReader = mock(SchemaReader.class);
       doReturn(Schema.create(Schema.Type.STRING)).when(mockSchemaReader).getKeySchema();
+      doReturn(1).when(mockSchemaReader).getLatestValueSchemaId();
+      doReturn(VALUE_SCHEMA).when(mockSchemaReader).getValueSchema(1);
       return mockSchemaReader;
-    }
-
-    @Override
-    public Schema getLatestValueSchema() {
-      return Schema.parse(VALUE_SCHEMA);
     }
   }
 
-  private static final String VALUE_SCHEMA = "{\n" + "\t\"type\": \"record\",\n" + "\t\"name\": \"record_schema\",\n"
-      + "\t\"fields\": [\n"
-      + "\t\t{\"name\": \"int_field\", \"type\": \"int\", \"default\": 0, \"doc\": \"doc for int_field\"},\n"
-      + "\t\t{\"name\": \"float_field\", \"type\": \"float\", \"doc\": \"doc for float_field\"},\n" + "\t\t{\n"
-      + "\t\t\t\"name\": \"record_field\",\n" + "\t\t\t\"namespace\": \"com.linkedin.test\",\n" + "\t\t\t\"type\": {\n"
-      + "\t\t\t\t\"name\": \"Record1\",\n" + "\t\t\t\t\"type\": \"record\",\n" + "\t\t\t\t\"fields\": [\n"
-      + "\t\t\t\t\t{\"name\": \"nested_field1\", \"type\": \"double\", \"doc\": \"doc for nested field\"}\n"
-      + "\t\t\t\t]\n" + "\t\t\t}\n" + "\t\t},\n"
-      + "\t\t{\"name\": \"float_array_field1\", \"type\": {\"type\": \"array\", \"items\": \"float\"}},\n"
-      + "\t\t{\"name\": \"float_array_field2\", \"type\": {\"type\": \"array\", \"items\": \"float\"}},\n"
-      + "\t\t{\"name\": \"int_array_field2\", \"type\": {\"type\": \"array\", \"items\": \"int\"}}\n" + "\t]\n" + "}";
+  private static final Schema VALUE_SCHEMA = AvroSchemaParseUtils.parseSchemaFromJSONLooseValidation(
+      "{\n" + "\t\"type\": \"record\",\n" + "\t\"name\": \"record_schema\",\n" + "\t\"fields\": [\n"
+          + "\t\t{\"name\": \"int_field\", \"type\": \"int\", \"default\": 0, \"doc\": \"doc for int_field\"},\n"
+          + "\t\t{\"name\": \"float_field\", \"type\": \"float\", \"doc\": \"doc for float_field\"},\n" + "\t\t{\n"
+          + "\t\t\t\"name\": \"record_field\",\n" + "\t\t\t\"namespace\": \"com.linkedin.test\",\n"
+          + "\t\t\t\"type\": {\n" + "\t\t\t\t\"name\": \"Record1\",\n" + "\t\t\t\t\"type\": \"record\",\n"
+          + "\t\t\t\t\"fields\": [\n"
+          + "\t\t\t\t\t{\"name\": \"nested_field1\", \"type\": \"double\", \"doc\": \"doc for nested field\"}\n"
+          + "\t\t\t\t]\n" + "\t\t\t}\n" + "\t\t},\n"
+          + "\t\t{\"name\": \"float_array_field1\", \"type\": {\"type\": \"array\", \"items\": \"float\"}},\n"
+          + "\t\t{\"name\": \"float_array_field2\", \"type\": {\"type\": \"array\", \"items\": \"float\"}},\n"
+          + "\t\t{\"name\": \"int_array_field2\", \"type\": {\"type\": \"array\", \"items\": \"int\"}}\n" + "\t]\n"
+          + "}");
 
   private static final Set<String> keys = new HashSet<>();
   static {

--- a/clients/venice-thin-client/src/test/resources/SameCanonicalAsRecordValueSchema2.avsc
+++ b/clients/venice-thin-client/src/test/resources/SameCanonicalAsRecordValueSchema2.avsc
@@ -1,0 +1,24 @@
+{
+  "type": "record",
+  "name": "ValueRecord",
+  "doc": "This schema has the same parsing canonical form as RecordValueSchema2",
+  "fields": [
+    {
+      "name": "favorite_number",
+      "type": "long",
+      "default": 0,
+      "doc": "Doc for favorite_number"
+    },
+    {
+      "name": "favorite_color",
+      "type": "string",
+      "default": "blue",
+      "arbitrary_attribute": "arbitrary attribute value"
+    },
+    {
+      "name": "favorite_company",
+      "type": "string",
+      "default": "COMPANY_1"
+    }
+  ]
+}

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/compute/ComputeRequestWrapper.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/compute/ComputeRequestWrapper.java
@@ -24,11 +24,13 @@ public class ComputeRequestWrapper {
       getFastAvroGenericSerializer(ComputeRequestV3.SCHEMA$);
 
   private final ComputeRequestV3 computeRequest;
+  private final int valueSchemaId;
   private final Schema valueSchema;
   private final List<Schema.Field> operationResultFields;
   private final boolean originallyStreaming;
 
   public ComputeRequestWrapper(
+      int valueSchemaId,
       Schema valueSchema,
       Schema resultSchema,
       String resultSchemaString,
@@ -37,6 +39,7 @@ public class ComputeRequestWrapper {
     this.computeRequest = new ComputeRequestV3();
     this.computeRequest.setResultSchemaStr(resultSchemaString);
     this.computeRequest.setOperations((List) operations);
+    this.valueSchemaId = valueSchemaId;
     this.valueSchema = valueSchema;
     this.operationResultFields = ComputeUtils.getOperationResultFields(operations, resultSchema);
     this.originallyStreaming = originallyStreaming;
@@ -48,6 +51,10 @@ public class ComputeRequestWrapper {
 
   public CharSequence getResultSchemaStr() {
     return this.computeRequest.getResultSchemaStr();
+  }
+
+  public int getValueSchemaID() {
+    return this.valueSchemaId;
   }
 
   public Schema getValueSchema() {

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/schema/SchemaReader.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/schema/SchemaReader.java
@@ -14,6 +14,11 @@ public interface SchemaReader extends Closeable {
 
   Schema getValueSchema(int id);
 
+  /**
+   * Return the schema ID of any schema that has the same parsing canonical form as the schema provided.
+   * @param schema The schema for which the schema ID is needed
+   * @return The ID of the schema that has the same parsing canonical form as the schema provided
+   */
   int getValueSchemaId(Schema schema);
 
   Schema getLatestValueSchema();

--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/ReadOnlySchemaRepository.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/ReadOnlySchemaRepository.java
@@ -26,7 +26,7 @@ public interface ReadOnlySchemaRepository extends VeniceResource {
   boolean hasValueSchema(String storeName, int id);
 
   /**
-   * Look up the schema id by store name and value schema.
+   * Return the schema ID of any schema for the store that has the same parsing canonical form as the schema provided.
    */
   int getValueSchemaId(String storeName, String valueSchemaStr);
 

--- a/internal/venice-common/src/test/java/com/linkedin/venice/schema/TestAvroSchema.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/schema/TestAvroSchema.java
@@ -1,6 +1,7 @@
 package com.linkedin.venice.schema;
 
 import static com.linkedin.venice.serializer.SerializerDeserializerFactory.getAvroGenericSerializer;
+import static org.testng.Assert.assertFalse;
 
 import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
 import com.linkedin.venice.exceptions.VeniceException;
@@ -156,7 +157,7 @@ public class TestAvroSchema {
     if (AvroSchemaUtils.schemaResolveHasErrors(schemaWithoutNamespace, schemaWithNamespace)) {
       Schema massagedWriterSchema = AvroSchemaUtils
           .generateSchemaWithNamespace(schemaWithoutNamespace.toString(), schemaWithNamespace.getNamespace());
-      Assert.assertFalse(
+      assertFalse(
           AvroSchemaUtils.schemaResolveHasErrors(massagedWriterSchema, schemaWithNamespace),
           "Resolve error should go away after the writer schema fix");
       deserializer =

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/client/store/StoreClientPerfTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/client/store/StoreClientPerfTest.java
@@ -11,6 +11,7 @@ import com.linkedin.venice.integration.utils.MockD2ServerWrapper;
 import com.linkedin.venice.integration.utils.ServiceFactory;
 import com.linkedin.venice.read.RequestType;
 import com.linkedin.venice.read.protocol.response.MultiGetResponseRecordV1;
+import com.linkedin.venice.schema.SchemaReader;
 import com.linkedin.venice.serializer.RecordDeserializer;
 import com.linkedin.venice.serializer.RecordSerializer;
 import com.linkedin.venice.serializer.SerializerDeserializerFactory;
@@ -200,8 +201,8 @@ public class StoreClientPerfTest {
   }
 
   private static class TestComputeRequestBuilder extends AvroComputeRequestBuilderV3<String> {
-    public TestComputeRequestBuilder(InternalAvroStoreClient storeClient, Schema latestValueSchema) {
-      super(storeClient, latestValueSchema);
+    public TestComputeRequestBuilder(InternalAvroStoreClient storeClient, SchemaReader schemaReader) {
+      super(storeClient, schemaReader);
     }
 
     public SchemaAndToString getResultSchema() {
@@ -229,8 +230,10 @@ public class StoreClientPerfTest {
           SerializerDeserializerFactory.getAvroGenericSerializer(Schema.parse(valueSchemaStr));
       List<MultiGetResponseRecordV1> records = new ArrayList<>();
 
+      InternalAvroStoreClient internalAvroStoreClient = (InternalAvroStoreClient) client;
+
       TestComputeRequestBuilder testComputeRequestBuilder =
-          new TestComputeRequestBuilder((InternalAvroStoreClient) client, client.getLatestValueSchema());
+          new TestComputeRequestBuilder(internalAvroStoreClient, internalAvroStoreClient.getSchemaReader());
       Collection<String> fieldNames =
           valueSchema.getFields().stream().map(field -> field.name()).collect(Collectors.toList());
       testComputeRequestBuilder.project(fieldNames);

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/VeniceParentHelixAdminTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/VeniceParentHelixAdminTest.java
@@ -608,7 +608,7 @@ public class VeniceParentHelixAdminTest {
         testWriteComputeSchemaAutoGeneration(parentControllerClient);
         testWriteComputeSchemaEnable(parentControllerClient);
         testWriteComputeSchemaAutoGenerationFailure(parentControllerClient);
-        testUpdateCompactionLag(parentControllerClient, childControllerClient);
+        testUpdateCompactionLag(parentControllerClient);
       }
     }
   }
@@ -907,17 +907,13 @@ public class VeniceParentHelixAdminTest {
     Assert.assertEquals(schemaResponse.getSchemas().length, 2);
   }
 
-  private void testUpdateCompactionLag(
-      ControllerClient parentControllerClient,
-      ControllerClient childControllerClient) {
+  private void testUpdateCompactionLag(ControllerClient parentControllerClient) {
     // Adding store
     String storeName = Utils.getUniqueString("test_store");
     String owner = "test_owner";
     String keySchemaStr = "\"long\"";
     String schemaStr =
         "{\"type\":\"record\",\"name\":\"KeyRecord\",\"fields\":[{\"name\":\"name\",\"type\":\"string\",\"doc\":\"name field\"},{\"name\":\"id1\",\"type\":\"double\", \"default\": 0.0}]}";
-    String schemaStrDoc =
-        "{\"type\":\"record\",\"name\":\"KeyRecord\",\"fields\":[{\"name\":\"name\",\"type\":\"string\",\"doc\":\"name field updated\", \"default\": \"default name\"},{\"name\":\"id1\",\"type\":\"double\",\"default\": 0.0}]}";
     Schema valueSchema = AvroSchemaParseUtils.parseSchemaFromJSONStrictValidation(schemaStr);
     parentControllerClient.createNewStore(storeName, owner, keySchemaStr, valueSchema.toString());
 


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Make `getValueSchemaId` APIs match the canonical schemas
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
Today, `getValueSchemaId` APIs in `SchemaReader`, `SchemaData` and `ReadOnlySchemaRepository` match the schemas exactly (with the exception of `HelixReadWriteSchemaRepository`). These APIs are generally used to get a schema id to write along with the data. In such cases, we only care about canonical schemas.

The exception is where we want to register a schema with a doc change. In our codebase, this schema check is not handled via `getValueSchemaId` APIs and happens in the `VeniceHelixAdmin#addValueSchema` code paths which handle this case explicitly.

This PR makes `getValueSchemaId` use canonical schema match in all places.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
Updated tests. GH CI

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.