### PR TITLE
[vpj] Fix user-friendly partial update mode in Spark

### DIFF
--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/spark/input/hdfs/VeniceHdfsInputPartitionReader.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/spark/input/hdfs/VeniceHdfsInputPartitionReader.java
@@ -1,17 +1,7 @@
 package com.linkedin.venice.hadoop.spark.input.hdfs;
 
-import static com.linkedin.venice.hadoop.VenicePushJobConstants.DEFAULT_KEY_FIELD_PROP;
-import static com.linkedin.venice.hadoop.VenicePushJobConstants.DEFAULT_VALUE_FIELD_PROP;
-import static com.linkedin.venice.hadoop.VenicePushJobConstants.ETL_VALUE_SCHEMA_TRANSFORMATION;
-import static com.linkedin.venice.hadoop.VenicePushJobConstants.FILE_KEY_SCHEMA;
-import static com.linkedin.venice.hadoop.VenicePushJobConstants.FILE_VALUE_SCHEMA;
-import static com.linkedin.venice.hadoop.VenicePushJobConstants.KEY_FIELD_PROP;
-import static com.linkedin.venice.hadoop.VenicePushJobConstants.SCHEMA_STRING_PROP;
-import static com.linkedin.venice.hadoop.VenicePushJobConstants.VALUE_FIELD_PROP;
 import static com.linkedin.venice.hadoop.VenicePushJobConstants.VSON_PUSH;
 
-import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
-import com.linkedin.venice.etl.ETLValueSchemaTransformation;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.hadoop.input.recordreader.VeniceRecordIterator;
 import com.linkedin.venice.hadoop.input.recordreader.avro.VeniceAvroFileIterator;
@@ -21,7 +11,6 @@ import com.linkedin.venice.hadoop.input.recordreader.vson.VeniceVsonRecordReader
 import com.linkedin.venice.hadoop.spark.input.VeniceAbstractPartitionReader;
 import com.linkedin.venice.utils.VeniceProperties;
 import java.io.IOException;
-import org.apache.avro.Schema;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -46,25 +35,15 @@ public class VeniceHdfsInputPartitionReader extends VeniceAbstractPartitionReade
       throw new VeniceException("Unable to get a FileSystem", e);
     }
 
-    String keyFieldStr = jobConfig.getString(KEY_FIELD_PROP, DEFAULT_KEY_FIELD_PROP);
-    String valueFieldStr = jobConfig.getString(VALUE_FIELD_PROP, DEFAULT_VALUE_FIELD_PROP);
-    ETLValueSchemaTransformation etlValueSchemaTransformation = ETLValueSchemaTransformation
-        .valueOf(jobConfig.getString(ETL_VALUE_SCHEMA_TRANSFORMATION, ETLValueSchemaTransformation.NONE.name()));
     boolean vsonPush = jobConfig.getBoolean(VSON_PUSH, false);
     Path filePath = inputPartition.getFilePath();
 
     if (vsonPush) {
-      String fileKeySchema = jobConfig.getString(FILE_KEY_SCHEMA);
-      String fileValueSchema = jobConfig.getString(FILE_VALUE_SCHEMA);
-      VeniceVsonRecordReader recordReader =
-          new VeniceVsonRecordReader(fileKeySchema, fileValueSchema, keyFieldStr, valueFieldStr);
+      VeniceVsonRecordReader recordReader = new VeniceVsonRecordReader(jobConfig);
       return new VeniceVsonFileIterator(fs, filePath, recordReader);
     }
 
-    // Input data is not in Vson format. It must be Avro.
-    Schema fileSchema = AvroCompatibilityHelper.parse(jobConfig.getString(SCHEMA_STRING_PROP));
-    VeniceAvroRecordReader recordReader =
-        new VeniceAvroRecordReader(fileSchema, keyFieldStr, valueFieldStr, etlValueSchemaTransformation, null);
+    VeniceAvroRecordReader recordReader = VeniceAvroRecordReader.fromProps(jobConfig);
     return new VeniceAvroFileIterator(fs, filePath, recordReader);
   }
 }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/PartialUpdateTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/PartialUpdateTest.java
@@ -1,5 +1,6 @@
 package com.linkedin.venice.endToEnd;
 
+import static com.linkedin.venice.hadoop.VenicePushJobConstants.DATA_WRITER_COMPUTE_JOB_CLASS;
 import static com.linkedin.venice.hadoop.VenicePushJobConstants.DEFAULT_KEY_FIELD_PROP;
 import static com.linkedin.venice.hadoop.VenicePushJobConstants.DEFAULT_VALUE_FIELD_PROP;
 import static com.linkedin.venice.hadoop.VenicePushJobConstants.ENABLE_WRITE_COMPUTE;
@@ -61,6 +62,7 @@ import com.linkedin.venice.controllerapi.UpdateStoreQueryParams;
 import com.linkedin.venice.controllerapi.VersionCreationResponse;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.hadoop.VenicePushJob;
+import com.linkedin.venice.hadoop.spark.datawriter.jobs.DataWriterSparkJob;
 import com.linkedin.venice.integration.utils.ServiceFactory;
 import com.linkedin.venice.integration.utils.VeniceClusterWrapper;
 import com.linkedin.venice.integration.utils.VeniceControllerWrapper;
@@ -349,8 +351,8 @@ public class PartialUpdateTest {
     }
   }
 
-  @Test(timeOut = TEST_TIMEOUT_MS)
-  public void testIncrementalPushPartialUpdateNewFormat() throws IOException {
+  @Test(timeOut = TEST_TIMEOUT_MS, dataProvider = "True-and-False", dataProviderClass = DataProviderUtils.class)
+  public void testIncrementalPushPartialUpdateNewFormat(boolean useSparkCompute) throws IOException {
     final String storeName = Utils.getUniqueString("inc_push_update_new_format");
     String parentControllerUrl = parentController.getControllerUrl();
     File inputDir = getTempDataDirectory();
@@ -361,6 +363,9 @@ public class PartialUpdateTest {
         IntegrationTestPushUtils.defaultVPJProps(multiRegionMultiClusterWrapper, inputDirPath, storeName);
     vpjProperties.put(ENABLE_WRITE_COMPUTE, true);
     vpjProperties.put(INCREMENTAL_PUSH, true);
+    if (useSparkCompute) {
+      vpjProperties.setProperty(DATA_WRITER_COMPUTE_JOB_CLASS, DataWriterSparkJob.class.getCanonicalName());
+    }
 
     try (ControllerClient parentControllerClient = new ControllerClient(CLUSTER_NAME, parentControllerUrl)) {
       assertCommand(


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Fix user-friendly partial update mode in Spark
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Incremental push has a user-friendly mode for partial update so users don't have to know the full update schema. VPJ would generate the full update request based on the input data's schema and the fields in that schema.

This feature is not implemented properly in Spark and causes deserialization exception in servers. This is quite critical because the Server cannot recover from this anymore without the RT data being truncated. This is also a data-loss.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
Added a new unit test. Updated `PartialUpdateTest`. GH CI for regression tests.

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.