### PR TITLE
[build] Bump minor version when patch versions reach 100

### DIFF
--- a/make_tag.py
+++ b/make_tag.py
@@ -54,8 +54,14 @@ def get_next_version(bump_major, bump_minor, remote):
         return format_version(major, minor, 0)
 
     build = version_ints[2]
+    build += 1
 
-    return format_version(major, minor, build + 1)
+    # If build number is 100, increment minor and reset build
+    if build >= 100:
+        minor += 1
+        build = 0
+
+    return format_version(major, minor, build)
 
 
 def get_remote():


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Bump minor version when patch versions reach 100
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
Managing too many patch versions is hard. Bump the minor version when the patch version reaches 100.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
Tested locally:
```shell
$ ./make_tag.py
Using remote: upstream
From github.com:linkedin/venice
 * branch                main       -> FETCH_HEAD
From github.com:linkedin/venice
 * branch                main       -> FETCH_HEAD
From github.com:linkedin/venice
 * branch                main       -> FETCH_HEAD
Current branch tagBumpBuild100 is up to date.
New tag is 0.5.0. Continue? [y/N]:  
```

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.