### PR TITLE
[vpj] Unify shared temp directories for VPJ

### DIFF
--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/PushJobSetting.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/PushJobSetting.java
@@ -25,6 +25,10 @@ public class PushJobSetting implements Serializable {
   public String jobId;
   public String jobExecutionId;
   public String jobServerName;
+  // Path was not serializable till HDFS version 3.0.0, so we use URI instead:
+  // https://issues.apache.org/jira/browse/HADOOP-13519
+  public String sharedTmpDir;
+  public String jobTmpDir;
   public boolean enableSSL;
   public Class<? extends VenicePushJob> vpjEntryClass;
   public String veniceControllerUrl;
@@ -58,7 +62,6 @@ public class PushJobSetting implements Serializable {
   public boolean compressionMetricCollectionEnabled;
   /** Refer {@link VenicePushJobConstants#USE_MAPPER_TO_BUILD_DICTIONARY} **/
   public boolean useMapperToBuildDict;
-  public String useMapperToBuildDictOutputPath;
   public boolean repushTTLEnabled;
   // specify time to drop stale records.
   public long repushTTLStartTimeMs;

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/ValidateSchemaAndBuildDictMapperOutputReader.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/ValidateSchemaAndBuildDictMapperOutputReader.java
@@ -28,18 +28,18 @@ public class ValidateSchemaAndBuildDictMapperOutputReader implements Closeable {
   private final InputStream inputStream;
   private final DataFileStream avroDataFileStream;
   private final FileSystem fs;
-  private final String outputDir;
+  private final Path outputDir;
 
-  public ValidateSchemaAndBuildDictMapperOutputReader(String outputDir, String fileName) throws Exception {
-    Validate.notEmpty(
+  public ValidateSchemaAndBuildDictMapperOutputReader(Path outputDir, String fileName) throws Exception {
+    Validate.notNull(
         outputDir,
-        ValidateSchemaAndBuildDictMapper.class.getSimpleName() + " output directory should not be empty");
+        ValidateSchemaAndBuildDictMapper.class.getSimpleName() + " output directory should not be null");
     Validate.notEmpty(
         fileName,
         ValidateSchemaAndBuildDictMapper.class.getSimpleName() + " output fileName should not be empty");
 
     this.outputDir = outputDir;
-    Path filePath = new Path(String.format("%s/%s", outputDir, fileName));
+    Path filePath = new Path(outputDir, fileName);
 
     LOGGER.info(
         "Reading file {} to retrieve info persisted by {}",
@@ -94,7 +94,7 @@ public class ValidateSchemaAndBuildDictMapperOutputReader implements Closeable {
 
     // delete the output directory: It should not affect other VPJs as this is unique
     try {
-      fs.delete(new Path(outputDir), true);
+      fs.delete(outputDir, true);
     } catch (IOException e) {
       LOGGER.error("Failed to delete directory: {}", outputDir, e);
     }

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/ValidateSchemaAndBuildDictOutputFormat.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/ValidateSchemaAndBuildDictOutputFormat.java
@@ -38,10 +38,6 @@ public class ValidateSchemaAndBuildDictOutputFormat extends AvroOutputFormat {
    * @throws IOException
    */
   protected static void setValidateSchemaAndBuildDictionaryOutputDirPath(JobConf job) {
-    // store+job specific unique directory under parent directory: already derived in VPJ driver
-    // and passed along with the format: {$storeName}-{$JOB_EXEC_ID}-{$randomUniqueString}
-    // this job creates it and VPJ driver deletes it after consuming the data in this directory
-    // in ValidateSchemaAndBuildDictMapperOutputReader. setting 700 permissions for pii.
     String fullOutputDir = job.get(VALIDATE_SCHEMA_AND_BUILD_DICT_MAPPER_OUTPUT_DIRECTORY);
     Path outputPath = new Path(fullOutputDir);
 

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
@@ -30,6 +30,7 @@ import static com.linkedin.venice.hadoop.VenicePushJobConstants.ENABLE_SSL;
 import static com.linkedin.venice.hadoop.VenicePushJobConstants.ENABLE_WRITE_COMPUTE;
 import static com.linkedin.venice.hadoop.VenicePushJobConstants.ETL_VALUE_SCHEMA_TRANSFORMATION;
 import static com.linkedin.venice.hadoop.VenicePushJobConstants.EXTENDED_SCHEMA_VALIDITY_CHECK_ENABLED;
+import static com.linkedin.venice.hadoop.VenicePushJobConstants.HADOOP_TMP_DIR;
 import static com.linkedin.venice.hadoop.VenicePushJobConstants.HADOOP_VALIDATE_SCHEMA_AND_BUILD_DICT_PREFIX;
 import static com.linkedin.venice.hadoop.VenicePushJobConstants.INCREMENTAL_PUSH;
 import static com.linkedin.venice.hadoop.VenicePushJobConstants.INPUT_PATH_LAST_MODIFIED_TIME;
@@ -46,13 +47,14 @@ import static com.linkedin.venice.hadoop.VenicePushJobConstants.KAFKA_INPUT_TOPI
 import static com.linkedin.venice.hadoop.VenicePushJobConstants.KEY_FIELD_PROP;
 import static com.linkedin.venice.hadoop.VenicePushJobConstants.LEGACY_AVRO_KEY_FIELD_PROP;
 import static com.linkedin.venice.hadoop.VenicePushJobConstants.LEGACY_AVRO_VALUE_FIELD_PROP;
-import static com.linkedin.venice.hadoop.VenicePushJobConstants.MAPPER_OUTPUT_DIRECTORY;
 import static com.linkedin.venice.hadoop.VenicePushJobConstants.MULTI_REGION;
 import static com.linkedin.venice.hadoop.VenicePushJobConstants.NON_CRITICAL_EXCEPTION;
 import static com.linkedin.venice.hadoop.VenicePushJobConstants.NOT_SET;
 import static com.linkedin.venice.hadoop.VenicePushJobConstants.PARENT_CONTROLLER_REGION_NAME;
 import static com.linkedin.venice.hadoop.VenicePushJobConstants.PARTITION_COUNT;
 import static com.linkedin.venice.hadoop.VenicePushJobConstants.PATH_FILTER;
+import static com.linkedin.venice.hadoop.VenicePushJobConstants.PERMISSION_700;
+import static com.linkedin.venice.hadoop.VenicePushJobConstants.PERMISSION_777;
 import static com.linkedin.venice.hadoop.VenicePushJobConstants.POLL_JOB_STATUS_INTERVAL_MS;
 import static com.linkedin.venice.hadoop.VenicePushJobConstants.POLL_STATUS_RETRY_ATTEMPTS;
 import static com.linkedin.venice.hadoop.VenicePushJobConstants.PUSH_JOB_STATUS_UPLOAD_ENABLE;
@@ -76,7 +78,6 @@ import static com.linkedin.venice.hadoop.VenicePushJobConstants.UNCREATED_VERSIO
 import static com.linkedin.venice.hadoop.VenicePushJobConstants.USE_MAPPER_TO_BUILD_DICTIONARY;
 import static com.linkedin.venice.hadoop.VenicePushJobConstants.VALIDATE_SCHEMA_AND_BUILD_DICTIONARY_MAPPER_OUTPUT_FILE_EXTENSION;
 import static com.linkedin.venice.hadoop.VenicePushJobConstants.VALIDATE_SCHEMA_AND_BUILD_DICTIONARY_MAPPER_OUTPUT_FILE_PREFIX;
-import static com.linkedin.venice.hadoop.VenicePushJobConstants.VALIDATE_SCHEMA_AND_BUILD_DICTIONARY_MAPPER_OUTPUT_PARENT_DIR_DEFAULT;
 import static com.linkedin.venice.hadoop.VenicePushJobConstants.VALIDATE_SCHEMA_AND_BUILD_DICT_MAPPER_OUTPUT_DIRECTORY;
 import static com.linkedin.venice.hadoop.VenicePushJobConstants.VALUE_FIELD_PROP;
 import static com.linkedin.venice.hadoop.VenicePushJobConstants.VENICE_DISCOVER_URL_PROP;
@@ -84,7 +85,6 @@ import static com.linkedin.venice.hadoop.VenicePushJobConstants.VENICE_STORE_NAM
 import static com.linkedin.venice.status.BatchJobHeartbeatConfigs.HEARTBEAT_ENABLED_CONFIG;
 import static com.linkedin.venice.utils.AvroSupersetSchemaUtils.validateSubsetValueSchema;
 import static com.linkedin.venice.utils.ByteUtils.generateHumanReadableByteCountString;
-import static com.linkedin.venice.utils.Utils.getUniqueString;
 
 import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
 import com.linkedin.venice.compression.CompressionStrategy;
@@ -178,9 +178,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.fs.permission.FsPermission;
 import org.apache.hadoop.mapred.Counters;
-import org.apache.hadoop.mapred.FileOutputFormat;
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.mapred.RunningJob;
 import org.apache.logging.log4j.LogManager;
@@ -198,6 +196,13 @@ public class VenicePushJob implements AutoCloseable {
   // Immutable state
   private final VeniceProperties props;
   private final String jobId;
+
+  // parent directory: Common directory under which all the different push jobs
+  // create their job specific directories.
+  private final Path sharedTmpDir;
+
+  // job specific directory: Unique directory for this VPJ to store intermediate data
+  private final Path jobTmpDir;
 
   // Lazy state
   private final Lazy<Properties> sslProperties;
@@ -225,7 +230,7 @@ public class VenicePushJob implements AutoCloseable {
   private JobClientWrapper jobClientWrapper;
   private SentPushJobDetailsTracker sentPushJobDetailsTracker;
   private ValidateSchemaAndBuildDictMapperOutput validateSchemaAndBuildDictMapperOutput;
-  private String validateSchemaAndBuildDictMapperOutputDirectory;
+  private Path validateSchemaAndBuildDictMapperOutputDirectory;
   private final PushJobSetting pushJobSetting;
 
   private final PushJobDetails pushJobDetails;
@@ -291,6 +296,8 @@ public class VenicePushJob implements AutoCloseable {
     }
     emptyPushZstdDictionary =
         Lazy.of(() -> ByteBuffer.wrap(ZstdWithDictCompressor.buildDictionaryOnSyntheticAvroData()));
+    sharedTmpDir = new Path(pushJobSetting.sharedTmpDir);
+    jobTmpDir = new Path(pushJobSetting.jobTmpDir);
   }
 
   // This is a part of the public API. There is value in exposing this to users of VenicePushJob for reporting purposes
@@ -338,6 +345,10 @@ public class VenicePushJob implements AutoCloseable {
     if (pushJobSettingToReturn.enableSSL) {
       VPJSSLUtils.validateSslProperties(props);
     }
+    String hadoopTempDir = new Configuration().get(HADOOP_TMP_DIR, "/tmp");
+    pushJobSettingToReturn.sharedTmpDir = props.getString(TEMP_DIR_PREFIX, hadoopTempDir + "/venice-push-job");
+    pushJobSettingToReturn.jobTmpDir = pushJobSettingToReturn.sharedTmpDir + "/"
+        + Utils.escapeFilePathComponent(Utils.getUniqueString(pushJobSettingToReturn.jobExecutionId));
     pushJobSettingToReturn.vpjEntryClass = this.getClass();
     if (props.containsKey(SOURCE_GRID_FABRIC)) {
       pushJobSettingToReturn.sourceGridFabric = props.getString(SOURCE_GRID_FABRIC);
@@ -480,11 +491,6 @@ public class VenicePushJob implements AutoCloseable {
           props.getBoolean(USE_MAPPER_TO_BUILD_DICTIONARY, DEFAULT_USE_MAPPER_TO_BUILD_DICTIONARY);
       pushJobSettingToReturn.compressionMetricCollectionEnabled =
           props.getBoolean(COMPRESSION_METRIC_COLLECTION_ENABLED, DEFAULT_COMPRESSION_METRIC_COLLECTION_ENABLED);
-    }
-
-    if (pushJobSettingToReturn.useMapperToBuildDict) {
-      pushJobSettingToReturn.useMapperToBuildDictOutputPath = props
-          .getString(MAPPER_OUTPUT_DIRECTORY, VALIDATE_SCHEMA_AND_BUILD_DICTIONARY_MAPPER_OUTPUT_PARENT_DIR_DEFAULT);
     }
 
     // Compute-engine abstraction related configs
@@ -667,6 +673,8 @@ public class VenicePushJob implements AutoCloseable {
       initPushJobDetails();
       logGreeting();
       sendPushJobDetailsToController();
+      HadoopUtils.createDirectoryWithPermission(sharedTmpDir, PERMISSION_777);
+      HadoopUtils.createDirectoryWithPermission(jobTmpDir, PERMISSION_700);
       validateKafkaMessageEnvelopeSchema(pushJobSetting);
       validateRemoteHybridSettings(pushJobSetting);
       validateStoreSettingAndPopulate(controllerClient, pushJobSetting);
@@ -711,6 +719,9 @@ public class VenicePushJob implements AutoCloseable {
         validateValueSchema(controllerClient, pushJobSetting, pushJobSetting.isSchemaAutoRegisterFromPushJobEnabled);
 
         if (pushJobSetting.useMapperToBuildDict) {
+          validateSchemaAndBuildDictMapperOutputDirectory = new Path(jobTmpDir, "veniceMapperOutput");
+          HadoopUtils.createDirectoryWithPermission(validateSchemaAndBuildDictMapperOutputDirectory, PERMISSION_700);
+
           /**
            * 1. validate whether the remaining file's schema are consistent with the first file
            * 2. calculate {@link inputFileDataSize} during step 1
@@ -737,19 +748,14 @@ public class VenicePushJob implements AutoCloseable {
           LOGGER.info("Overriding re-push rewind time in seconds to: {}", pushJobSetting.rewindTimeInSecondsOverride);
         }
         if (pushJobSetting.repushTTLEnabled) {
-          // make the base directory TEMP_DIR_PREFIX with 777 permissions
-          Path baseSchemaDir = new Path(TEMP_DIR_PREFIX);
-          FileSystem fs = baseSchemaDir.getFileSystem(new Configuration());
-          if (!fs.exists(baseSchemaDir)) {
-            fs.mkdirs(baseSchemaDir);
-            fs.setPermission(baseSchemaDir, new FsPermission("777"));
-          }
-
           // build the full path for HDFSRmdSchemaSource: the schema path will be suffixed
-          // by the store name and time like: <TEMP_DIR_PREFIX>/<store_name>/<timestamp>
-          String rmdSchemaDir = TEMP_DIR_PREFIX + pushJobSetting.storeName + "/rmd_" + pushJobSetting.jobStartTimeMs;
-          String valueSchemaDir =
-              TEMP_DIR_PREFIX + pushJobSetting.storeName + "/value_" + pushJobSetting.jobStartTimeMs;
+          // by the store name and time like:
+          // RMD schemas: <job_temp_dir>/rmd_<timestamp>
+          // Value schemas: <job_temp_dir>/value_<timestamp>
+          Path rmdSchemaDir = new Path(jobTmpDir, "rmd_schemas");
+          HadoopUtils.createDirectoryWithPermission(rmdSchemaDir, PERMISSION_700);
+          Path valueSchemaDir = new Path(jobTmpDir, "value_schemas");
+          HadoopUtils.createDirectoryWithPermission(valueSchemaDir, PERMISSION_700);
           try (HDFSSchemaSource schemaSource =
               new HDFSSchemaSource(valueSchemaDir, rmdSchemaDir, pushJobSetting.storeName)) {
             schemaSource.saveSchemasOnDisk(controllerClient);
@@ -1069,38 +1075,6 @@ public class VenicePushJob implements AutoCloseable {
     updatePushJobDetailsWithCheckpoint(PushJobCheckpoints.VALIDATE_SCHEMA_AND_BUILD_DICT_MAP_JOB_COMPLETED);
   }
 
-  /**
-   * Creating the output file for {@link ValidateSchemaAndBuildDictMapper} to persist data
-   * to be read from VPJ driver.
-   *
-   * Output Directory: {$hadoopTmpDir}/{$storeName}-{$JOB_EXEC_ID}-{$randomUniqueString}
-   * File name: mapper-output-{$MRJobID}.avro
-   *
-   * Why JOB_EXEC_ID and randomUniqueString: This gives uniqueness to the name of the directory whose
-   * permission will be restricted to the current user who started the VPJ only. This helps with 2 issues.
-   * 1. There could be instances where multiple headless accounts are writing to a single Venice store.
-   *    It shouldn't happen in regular cases - but is very likely in case of migrations (technical or organizational)
-   *    => unless we have unique directory for each job, the multiple accounts will have access issues of the directory.
-   *
-   * 2. Multiple push jobs can be started in parallel, but only 1 will continue beyond
-   *    {@link ControllerClient#requestTopicForWrites} as this method will throw CONCURRENT_BATCH_PUSH error
-   *    if there is another push job in progress. As {@link ValidateSchemaAndBuildDictMapper} runs before this method,
-   *    it is prone to concurrent push jobs and thus race conditions. Having unique directories per execution will help here.
-   *
-   * Why can't use MRJobID to achieve randomness: MR's jobID gets populated only after {@link FileOutputFormat#checkOutputSpecs},
-   * which needs {@link FileOutputFormat#setOutputPath} to be set already. so currently unable to use the ID.
-   *
-   * TODO: should try exploring using conf.get("hadoop.tmp.dir") or similar configs to get default
-   *     tmp directory in different HDFS environments rather than hardcoding it to
-   *     VALIDATE_SCHEMA_AND_BUILD_DICTIONARY_MAPPER_OUTPUT_PARENT_DIR_DEFAULT.
-   */
-  protected static String getValidateSchemaAndBuildDictionaryOutputDir(
-      String parentOutputDir,
-      String storeName,
-      String jobExecId) {
-    return parentOutputDir + "/" + storeName + "-" + jobExecId + "-" + getUniqueString();
-  }
-
   protected static String getValidateSchemaAndBuildDictionaryOutputFileNameNoExtension(String mrJobId) {
     return VALIDATE_SCHEMA_AND_BUILD_DICTIONARY_MAPPER_OUTPUT_FILE_PREFIX + mrJobId;
   }
@@ -1111,7 +1085,7 @@ public class VenicePushJob implements AutoCloseable {
   }
 
   private void getValidateSchemaAndBuildDictMapperOutput(String mrJobId) throws Exception {
-    String outputDir = validateSchemaAndBuildDictMapperOutputDirectory;
+    Path outputDir = validateSchemaAndBuildDictMapperOutputDirectory;
     String outputAvroFile = getValidateSchemaAndBuildDictionaryOutputFileName(mrJobId);
     try (ValidateSchemaAndBuildDictMapperOutputReader outputReader =
         getValidateSchemaAndBuildDictMapperOutputReader(outputDir, outputAvroFile)) {
@@ -1341,7 +1315,7 @@ public class VenicePushJob implements AutoCloseable {
   }
 
   protected ValidateSchemaAndBuildDictMapperOutputReader getValidateSchemaAndBuildDictMapperOutputReader(
-      String outputDir,
+      Path outputDir,
       String fileName) throws Exception {
     if (validateSchemaAndBuildDictMapperOutputReader == null) {
       validateSchemaAndBuildDictMapperOutputReader =
@@ -2606,13 +2580,10 @@ public class VenicePushJob implements AutoCloseable {
         props.getInt(COMPRESSION_DICTIONARY_SAMPLE_SIZE, DEFAULT_COMPRESSION_DICTIONARY_SAMPLE_SIZE));
     // USE_MAPPER_TO_BUILD_DICTIONARY is still needed to be passed here for validateInputAndGetInfo
     conf.setBoolean(USE_MAPPER_TO_BUILD_DICTIONARY, pushJobSetting.useMapperToBuildDict);
-    conf.set(MAPPER_OUTPUT_DIRECTORY, pushJobSetting.useMapperToBuildDictOutputPath);
     conf.set(COMPRESSION_STRATEGY, VenicePushJob.this.pushJobSetting.storeCompressionStrategy.toString());
-    validateSchemaAndBuildDictMapperOutputDirectory = getValidateSchemaAndBuildDictionaryOutputDir(
-        pushJobSetting.useMapperToBuildDictOutputPath,
-        pushJobSetting.storeName,
-        pushJobSetting.jobExecutionId);
-    conf.set(VALIDATE_SCHEMA_AND_BUILD_DICT_MAPPER_OUTPUT_DIRECTORY, validateSchemaAndBuildDictMapperOutputDirectory);
+    conf.set(
+        VALIDATE_SCHEMA_AND_BUILD_DICT_MAPPER_OUTPUT_DIRECTORY,
+        validateSchemaAndBuildDictMapperOutputDirectory.toUri().getPath());
 
     /** adding below for {@link AbstractDataWriterTask.configure(EngineTaskConfigProvider)} to not crash: Doesn't affect this flow */
     conf.setBoolean(VeniceWriter.ENABLE_CHUNKING, false);
@@ -2891,6 +2862,11 @@ public class VenicePushJob implements AutoCloseable {
     Utils.closeQuietlyWithErrorLogged(controllerClient);
     Utils.closeQuietlyWithErrorLogged(kmeSchemaSystemStoreControllerClient);
     Utils.closeQuietlyWithErrorLogged(livenessHeartbeatStoreControllerClient);
+    try {
+      jobTmpDir.getFileSystem(new Configuration()).delete(jobTmpDir, true);
+    } catch (IOException e) {
+      LOGGER.warn("Failed to delete temp directory: {}", jobTmpDir);
+    }
   }
 
   public static void main(String[] args) {

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJobConstants.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJobConstants.java
@@ -16,10 +16,6 @@ public final class VenicePushJobConstants {
   private VenicePushJobConstants() {
   }
 
-  public static final String HADOOP_TMP_DIR = "hadoop.tmp.dir";
-  public static final FsPermission PERMISSION_777 = FsPermission.createImmutable((short) 0777);
-  public static final FsPermission PERMISSION_700 = FsPermission.createImmutable((short) 0700);
-
   // Avro input configs
   public static final String LEGACY_AVRO_KEY_FIELD_PROP = "avro.key.field";
   public static final String LEGACY_AVRO_VALUE_FIELD_PROP = "avro.value.field";
@@ -232,6 +228,14 @@ public final class VenicePushJobConstants {
    */
   public static final PathFilter PATH_FILTER = p -> !p.getName().startsWith("_") && !p.getName().startsWith(".");
 
+  // Configs to control temp paths and their permissions
+  public static final String HADOOP_TMP_DIR = "hadoop.tmp.dir";
+  public static final String TEMP_DIR_PREFIX = "tmp.dir.prefix";
+  // World-readable and world-writable
+  public static final FsPermission PERMISSION_777 = FsPermission.createImmutable((short) 0777);
+  // Only readable and writable by the user running VPJ - restricted access
+  public static final FsPermission PERMISSION_700 = FsPermission.createImmutable((short) 0700);
+
   public static final String VALUE_SCHEMA_ID_PROP = "value.schema.id";
   public static final String DERIVED_SCHEMA_ID_PROP = "derived.schema.id";
   public static final String TOPIC_PROP = "venice.kafka.topic";
@@ -300,7 +304,6 @@ public final class VenicePushJobConstants {
   public static final String REPUSH_TTL_START_TIMESTAMP = "repush.ttl.start.timestamp";
   public static final String RMD_SCHEMA_DIR = "rmd.schema.dir";
   public static final String VALUE_SCHEMA_DIR = "value.schema.dir";
-  public static final String TEMP_DIR_PREFIX = "tmp.dir.prefix";
   public static final int NOT_SET = -1;
 
   /**

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJobConstants.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJobConstants.java
@@ -9,11 +9,16 @@ import com.linkedin.venice.hadoop.mapreduce.datawriter.map.AbstractVeniceMapper;
 import com.linkedin.venice.meta.StoreInfo;
 import com.linkedin.venice.utils.Time;
 import org.apache.hadoop.fs.PathFilter;
+import org.apache.hadoop.fs.permission.FsPermission;
 
 
 public final class VenicePushJobConstants {
   private VenicePushJobConstants() {
   }
+
+  public static final String HADOOP_TMP_DIR = "hadoop.tmp.dir";
+  public static final FsPermission PERMISSION_777 = FsPermission.createImmutable((short) 0777);
+  public static final FsPermission PERMISSION_700 = FsPermission.createImmutable((short) 0700);
 
   // Avro input configs
   public static final String LEGACY_AVRO_KEY_FIELD_PROP = "avro.key.field";
@@ -104,12 +109,6 @@ public final class VenicePushJobConstants {
   public static final String VALIDATE_SCHEMA_AND_BUILD_DICT_MAPPER_OUTPUT_DIRECTORY =
       "validate.schema.and.build.dict.mapper.output.directory";
 
-  // used to get parent directory input from Users
-  public static final String MAPPER_OUTPUT_DIRECTORY = "mapper.output.directory";
-
-  // static names used to construct the directory and file name
-  public static final String VALIDATE_SCHEMA_AND_BUILD_DICTIONARY_MAPPER_OUTPUT_PARENT_DIR_DEFAULT =
-      "/tmp/veniceMapperOutput";
   public static final String VALIDATE_SCHEMA_AND_BUILD_DICTIONARY_MAPPER_OUTPUT_FILE_PREFIX = "mapper-output-";
   public static final String VALIDATE_SCHEMA_AND_BUILD_DICTIONARY_MAPPER_OUTPUT_FILE_EXTENSION = ".avro";
 
@@ -301,7 +300,7 @@ public final class VenicePushJobConstants {
   public static final String REPUSH_TTL_START_TIMESTAMP = "repush.ttl.start.timestamp";
   public static final String RMD_SCHEMA_DIR = "rmd.schema.dir";
   public static final String VALUE_SCHEMA_DIR = "value.schema.dir";
-  public static final String TEMP_DIR_PREFIX = "/tmp/veniceSchemas/";
+  public static final String TEMP_DIR_PREFIX = "tmp.dir.prefix";
   public static final int NOT_SET = -1;
 
   /**

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/utils/HadoopUtils.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/utils/HadoopUtils.java
@@ -6,6 +6,7 @@ import java.util.Properties;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.permission.FsPermission;
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -52,6 +53,35 @@ public class HadoopUtils {
       fs.close();
     } catch (IOException e) {
       LOGGER.error("Failed to clean up the HDFS path: {}", path);
+    }
+  }
+
+  /**
+   * Create a temporary directory with the given name under the given path and set the specified permissions.
+   * If the directory already exists, and the permissions are different from ones specified, the permissions will be
+   * updated. If the directory already exists and the permissions are the same, nothing will be done.
+   * @throws IOException
+   */
+  public static void createDirectoryWithPermission(Path path, FsPermission permission) throws IOException {
+    LOGGER.info("Trying to create path {} with permission {}", path.getName(), permission);
+    FileSystem fs = path.getFileSystem(new Configuration());
+    // check if the path needs to be created
+    if (fs.exists(path)) {
+      LOGGER.info("path {} exists already", path);
+      FsPermission currentPermission = fs.getFileStatus(path).getPermission();
+      if (!currentPermission.equals(permission)) {
+        LOGGER.info(
+            "Current permission ({}) differs from expected permission ({}). Updating permissions.",
+            currentPermission,
+            permission);
+        fs.setPermission(path, permission);
+      }
+    } else {
+      LOGGER.info("Creating path {} with permission {}", path.getName(), permission);
+      fs.mkdirs(path);
+      // mkdirs(path,permission) didn't set the right permission when
+      // tested in hdfs, so splitting it like this, it works!
+      fs.setPermission(path, permission);
     }
   }
 }

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/TestValidateSchemaAndBuildDictMapperOutputReader.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/TestValidateSchemaAndBuildDictMapperOutputReader.java
@@ -8,6 +8,7 @@ import com.linkedin.venice.utils.Utils;
 import java.io.File;
 import java.nio.ByteBuffer;
 import org.apache.avro.Schema;
+import org.apache.hadoop.fs.Path;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -16,15 +17,9 @@ public class TestValidateSchemaAndBuildDictMapperOutputReader {
   private static final int TEST_TIMEOUT = 10 * Time.MS_PER_SECOND;
   private static final Schema fileSchema = ValidateSchemaAndBuildDictMapperOutput.getClassSchema();
 
-  @Test(timeOut = TEST_TIMEOUT, expectedExceptions = NullPointerException.class, expectedExceptionsMessageRegExp = ".* output directory should not be empty")
+  @Test(timeOut = TEST_TIMEOUT, expectedExceptions = NullPointerException.class, expectedExceptionsMessageRegExp = ".* output directory should not be null")
   public void testGetWithDirAsNull() throws Exception {
     ValidateSchemaAndBuildDictMapperOutputReader reader = new ValidateSchemaAndBuildDictMapperOutputReader(null, null);
-    reader.close();
-  }
-
-  @Test(timeOut = TEST_TIMEOUT, expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = ".* output directory should not be empty")
-  public void testGetWithDirAsEmpty() throws Exception {
-    ValidateSchemaAndBuildDictMapperOutputReader reader = new ValidateSchemaAndBuildDictMapperOutputReader("", null);
     reader.close();
   }
 
@@ -32,7 +27,7 @@ public class TestValidateSchemaAndBuildDictMapperOutputReader {
   public void testGetWithFileAsNull() throws Exception {
     File inputDir = Utils.getTempDataDirectory();
     ValidateSchemaAndBuildDictMapperOutputReader reader =
-        new ValidateSchemaAndBuildDictMapperOutputReader(inputDir.getAbsolutePath(), null);
+        new ValidateSchemaAndBuildDictMapperOutputReader(new Path(inputDir.getAbsolutePath()), null);
     reader.close();
   }
 
@@ -40,7 +35,7 @@ public class TestValidateSchemaAndBuildDictMapperOutputReader {
   public void testGetWithFileAsEmpty() throws Exception {
     File inputDir = Utils.getTempDataDirectory();
     ValidateSchemaAndBuildDictMapperOutputReader reader =
-        new ValidateSchemaAndBuildDictMapperOutputReader(inputDir.getAbsolutePath(), "");
+        new ValidateSchemaAndBuildDictMapperOutputReader(new Path(inputDir.getAbsolutePath()), "");
     reader.close();
   }
 
@@ -49,7 +44,7 @@ public class TestValidateSchemaAndBuildDictMapperOutputReader {
     File inputDir = Utils.getTempDataDirectory();
     String avroOutputFile = "nofile.avro"; // This file is not present
     ValidateSchemaAndBuildDictMapperOutputReader reader =
-        new ValidateSchemaAndBuildDictMapperOutputReader(inputDir.getAbsolutePath(), avroOutputFile);
+        new ValidateSchemaAndBuildDictMapperOutputReader(new Path(inputDir.getAbsolutePath()), avroOutputFile);
     reader.close();
   }
 
@@ -63,7 +58,7 @@ public class TestValidateSchemaAndBuildDictMapperOutputReader {
     String avroOutputFile = "empty_file.avro";
     TestWriteUtils.writeEmptyAvroFile(inputDir, avroOutputFile, fileSchema);
     ValidateSchemaAndBuildDictMapperOutputReader reader =
-        new ValidateSchemaAndBuildDictMapperOutputReader(inputDir.getAbsolutePath(), avroOutputFile);
+        new ValidateSchemaAndBuildDictMapperOutputReader(new Path(inputDir.getAbsolutePath()), avroOutputFile);
     reader.close();
   }
 
@@ -77,7 +72,7 @@ public class TestValidateSchemaAndBuildDictMapperOutputReader {
     String avroOutputFile = "invalid_file.avro";
     TestWriteUtils.writeInvalidAvroFile(inputDir, avroOutputFile);
     ValidateSchemaAndBuildDictMapperOutputReader reader =
-        new ValidateSchemaAndBuildDictMapperOutputReader(inputDir.getAbsolutePath(), avroOutputFile);
+        new ValidateSchemaAndBuildDictMapperOutputReader(new Path(inputDir.getAbsolutePath()), avroOutputFile);
     reader.close();
   }
 
@@ -96,7 +91,7 @@ public class TestValidateSchemaAndBuildDictMapperOutputReader {
         ByteBuffer.wrap("TestDictionary".getBytes()),
         fileSchema);
     ValidateSchemaAndBuildDictMapperOutputReader reader =
-        new ValidateSchemaAndBuildDictMapperOutputReader(inputDir.getAbsolutePath(), avroOutputFile);
+        new ValidateSchemaAndBuildDictMapperOutputReader(new Path(inputDir.getAbsolutePath()), avroOutputFile);
     reader.close();
   }
 
@@ -111,7 +106,7 @@ public class TestValidateSchemaAndBuildDictMapperOutputReader {
         ByteBuffer.wrap("TestDictionary".getBytes()),
         fileSchema);
     ValidateSchemaAndBuildDictMapperOutputReader reader =
-        new ValidateSchemaAndBuildDictMapperOutputReader(inputDir.getAbsolutePath(), avroOutputFile);
+        new ValidateSchemaAndBuildDictMapperOutputReader(new Path(inputDir.getAbsolutePath()), avroOutputFile);
     ValidateSchemaAndBuildDictMapperOutput output = reader.getOutput();
     reader.close();
 
@@ -131,7 +126,7 @@ public class TestValidateSchemaAndBuildDictMapperOutputReader {
     TestWriteUtils
         .writeSimpleAvroFileForValidateSchemaAndBuildDictMapperOutput(inputDir, avroOutputFile, 1, null, fileSchema);
     ValidateSchemaAndBuildDictMapperOutputReader reader =
-        new ValidateSchemaAndBuildDictMapperOutputReader(inputDir.getAbsolutePath(), avroOutputFile);
+        new ValidateSchemaAndBuildDictMapperOutputReader(new Path(inputDir.getAbsolutePath()), avroOutputFile);
     ValidateSchemaAndBuildDictMapperOutput output = reader.getOutput();
     reader.close();
 

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/utils/TestHadoopUtils.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/utils/TestHadoopUtils.java
@@ -1,9 +1,11 @@
 package com.linkedin.venice.hadoop.utils;
 
+import com.linkedin.venice.utils.Utils;
 import java.io.IOException;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.permission.FsPermission;
 import org.apache.hadoop.mapred.JobConf;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -39,5 +41,43 @@ public class TestHadoopUtils {
 
     // validate the path
     Assert.assertFalse(fs.exists(p));
+  }
+
+  @Test
+  public void testCreateDirectoryWithPermission() throws IOException {
+    FsPermission PERMISSION_777 = FsPermission.createImmutable((short) 0777);
+    FsPermission PERMISSION_700 = FsPermission.createImmutable((short) 0700);
+
+    // create a directory with permissions if not exist
+    Path filePath = new Path(Utils.getUniqueString("/tmp/venice-test"));
+    Assert.assertFalse(filePath.getFileSystem(new Configuration()).exists(filePath));
+    HadoopUtils.createDirectoryWithPermission(filePath, PERMISSION_700);
+    Assert.assertTrue(filePath.getFileSystem(new Configuration()).exists(filePath));
+    Assert.assertEquals(
+        filePath.getFileSystem(new Configuration()).getFileStatus(filePath).getPermission(),
+        PERMISSION_700);
+
+    // Update permission if a directory already exists with a different permission
+    Assert.assertTrue(filePath.getFileSystem(new Configuration()).exists(filePath));
+    HadoopUtils.createDirectoryWithPermission(filePath, PERMISSION_777);
+    Assert.assertTrue(filePath.getFileSystem(new Configuration()).exists(filePath));
+    Assert.assertEquals(
+        filePath.getFileSystem(new Configuration()).getFileStatus(filePath).getPermission(),
+        PERMISSION_777);
+
+    // Update permission if a directory already exists with a different permission
+    Assert.assertTrue(filePath.getFileSystem(new Configuration()).exists(filePath));
+    HadoopUtils.createDirectoryWithPermission(filePath, PERMISSION_777);
+    Assert.assertTrue(filePath.getFileSystem(new Configuration()).exists(filePath));
+    Assert.assertEquals(
+        filePath.getFileSystem(new Configuration()).getFileStatus(filePath).getPermission(),
+        PERMISSION_777);
+
+    // Do nothing if a directory already exists with the same permission
+    HadoopUtils.createDirectoryWithPermission(filePath, PERMISSION_777);
+    Assert.assertTrue(filePath.getFileSystem(new Configuration()).exists(filePath));
+    Assert.assertEquals(
+        filePath.getFileSystem(new Configuration()).getFileStatus(filePath).getPermission(),
+        PERMISSION_777);
   }
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/utils/Utils.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/utils/Utils.java
@@ -919,4 +919,13 @@ public class Utils {
   public static String getReplicaId(PubSubTopic topic, int partition) {
     return topic + "-" + partition;
   }
+
+  /**
+   * Method to escape file path component to make it a valid file path string/substring.
+   * @param component file path component string
+   * @return Escaped file path component string
+   */
+  public static String escapeFilePathComponent(final String component) {
+    return component.replaceAll("[^a-zA-Z0-9-_/\\.]", "_");
+  }
 }


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Unify shared temp directories for VPJ
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
Currently, VPJ uses temp directories for at least two features:
1. To store the output from ValidateSchemaAndBuildDict mapper job to pass the dictionary to the driver
2. To store schemas for TTL repush

In the future, we might add more such cases where data needs to be stored in a temp directory. Currently, each feature that needs a temp space, creates and manages it separately, leading to inconsistencies in the data format, and also facing the same issues each time (like permissions, etc).

For operational reasons, it is desirable to have a temp directory that is shared by all VPJ jobs, and inside this, we can create other feature-specific shared directories that are also shared by all VPJ jobs. These shared directories will have 777 permissions so any user can write to it. If features have private data that need restricted permissions, the feature implementation can create files or subdirectories inside the feature directories and apply the restricted permissions to those.

At the end of the job execution, the temp directory for the job execution is also cleaned up. Previously, this was not always the case, and the cleanup logic was separately written for each feature, or it relied on automatic cleanup of the `/tmp` directory.

After this commit, the the temp directory will be: .
```
|____<hadoop.tmp.dir> (Specified by env, or default /tmp)
| |____venice-push-job (777 permissions) - shared by all VPJ
| | |____<job.execution.id>_<unique-suffix> (700 permissions) - shared by all features in this execution
| | | |____veniceMapperOutput (700 permissions)
| | | |____rmd_schemas (700 permissions)
| | | |____value_schemas (700 permissions)
| | | |____...<features_added_in_the_future> (700 permissions)
```

Since `job.execution.id` is generally provided by fetching from the the execution environment, and it is not clear that it will get used as a path component, we also ensure to scrub out any unsupported characters.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
GH CI

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [X] Yes. Make sure to explain your proposed changes and call out the behavior change.
Previously, the temp directory structore was:
```
|____tmp
| |____veniceSchemas (777 permissions)
| | |____<storeName> (Default permissions (755))
| | | |____value_<timestamp> (Default permissions (755))
| | | |____rmd_<timestamp> (Default permissions (755))
| |____veniceMapperOutput (777 permissions)
| | |____<storeName>-<jobExecutionId>-<abr231asd> (700 permissions)
```