### PR TITLE
[controller] Do not call metadata store in parent controller

### DIFF
--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestUnusedValueSchemaCleanup.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestUnusedValueSchemaCleanup.java
@@ -111,7 +111,8 @@ public class TestUnusedValueSchemaCleanup {
       TestUtils.waitForNonDeterministicCompletion(
           20,
           TimeUnit.SECONDS,
-          () -> veniceHelixAdmin.getValueSchemas(CLUSTER_NAMES[0], storeName).size() == 1);
+          () -> veniceHelixAdmin.getValueSchemas(CLUSTER_NAMES[0], storeName).size() == 1
+              && parentControllerClient.getAllValueSchema(storeName).getSchemas().length == 1);
     }
   }
 

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -3925,6 +3925,11 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
       }
       int previousVersion = store.getCurrentVersion();
       store.setCurrentVersion(futureVersion);
+      LOGGER.info(
+          "Rolling forward current version {} to version {} in store {}",
+          previousVersion,
+          futureVersion,
+          storeName);
       realTimeTopicSwitcher.transmitVersionSwapMessage(store, previousVersion, futureVersion);
       return store;
     });
@@ -3960,6 +3965,8 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
       }
       int previousVersion = store.getCurrentVersion();
       store.setCurrentVersion(backupVersion);
+      LOGGER
+          .info("Rolling back current version {} to version {} in store {}", previousVersion, backupVersion, storeName);
       realTimeTopicSwitcher.transmitVersionSwapMessage(store, previousVersion, backupVersion);
       return store;
     });
@@ -4168,6 +4175,10 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
 
   @Override
   public Set<Integer> getInUseValueSchemaIds(String clusterName, String storeName) {
+    if (isParent()) {
+      return Collections.emptySet();
+    }
+
     Store store = getStore(clusterName, storeName);
     Set<Integer> schemaIds = new HashSet<>();
 

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
@@ -664,7 +664,7 @@ public class VeniceParentHelixAdmin implements Admin {
       String region = entry.getKey();
       ControllerClient controllerClient = entry.getValue();
       SchemaUsageResponse response = controllerClient.getInUseSchemaIds(storeName);
-      if (response.isError() || response.getInUseValueSchemaIds().isEmpty()) {
+      if (response.isError()) {
         if (response.isError()) {
           LOGGER.error(
               "Could not query store from region: " + region + " for cluster: " + clusterName + ". "
@@ -2010,7 +2010,7 @@ public class VeniceParentHelixAdmin implements Admin {
         }
       }
       sendAdminMessageAndWaitForConsumed(clusterName, storeName, message);
-
+      LOGGER.info("Truncating topic {} after rollforward", Version.composeKafkaTopic(storeName, futureVersion));
       truncateKafkaTopic(Version.composeKafkaTopic(storeName, futureVersion));
     } finally {
       releaseAdminMessageLock(clusterName, storeName);


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Do not call metadata store in parent controller for value schema query
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

During unused schema cleanup, parent controller sends admin message to all admin including parent admin as well. Since the unused schema info is stored in meta store which is not available in parent cluster it would fail the admin message. This PR skips the query for parent colo and queries the schema set only from child controller.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
integ test.
## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.