### PR TITLE
[dvc] Invoke lifecycle methods in StoreIngestionTask for RecordTransformer

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -1376,6 +1376,10 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
       LOGGER.info("Running {}", ingestionTaskName);
       versionedIngestionStats.resetIngestionTaskPushTimeoutGauge(storeName, versionNumber);
 
+      if (recordTransformer != null) {
+        recordTransformer.onStartIngestionTask();
+      }
+
       while (isRunning()) {
         Store store = storeRepository.getStoreOrThrow(storeName);
         processConsumerActions(store);
@@ -3592,6 +3596,10 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
     // The operation is executed on a single thread in run method.
     // This method signals the run method to end, which closes the
     // resources before exiting.
+
+    if (recordTransformer != null) {
+      recordTransformer.onEndIngestionTask();
+    }
   }
 
   /**

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/AggVersionedIngestionStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/AggVersionedIngestionStats.java
@@ -214,6 +214,20 @@ public class AggVersionedIngestionStats
     recordVersionedAndTotalStat(storeName, version, stat -> stat.recordTransformerLatency(value, timestamp));
   }
 
+  public void recordTransformerLifecycleStartLatency(String storeName, int version, double value, long timestamp) {
+    recordVersionedAndTotalStat(
+        storeName,
+        version,
+        stat -> stat.recordTransformerLifecycleStartLatency(value, timestamp));
+  }
+
+  public void recordTransformerLifecycleEndLatency(String storeName, int version, double value, long timestamp) {
+    recordVersionedAndTotalStat(
+        storeName,
+        version,
+        stat -> stat.recordTransformerLifecycleEndLatency(value, timestamp));
+  }
+
   public void recordTransformerError(String storeName, int version, double value, long timestamp) {
     recordVersionedAndTotalStat(storeName, version, stat -> stat.recordTransformerError(value, timestamp));
   }
@@ -225,6 +239,16 @@ public class AggVersionedIngestionStats
   public void registerTransformerLatencySensor(String storeName, int version) {
     getStats(storeName, version).registerTransformerLatencySensor();
     getTotalStats(storeName).registerTransformerLatencySensor();
+  }
+
+  public void registerTransformerLifecycleStartLatency(String storeName, int version) {
+    getStats(storeName, version).registerTransformerLifecycleStartLatencySensor();
+    getTotalStats(storeName).registerTransformerLifecycleStartLatencySensor();
+  }
+
+  public void registerTransformerLifecycleEndLatency(String storeName, int version) {
+    getStats(storeName, version).registerTransformerLifecycleEndLatencySensor();
+    getTotalStats(storeName).registerTransformerLifecycleEndLatencySensor();
   }
 
   public void registerTransformerErrorSensor(String storeName, int version) {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/IngestionStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/IngestionStats.java
@@ -572,7 +572,6 @@ public class IngestionStats {
   }
 
   public void registerTransformerErrorSensor() {
-    // Check to make sure there isn't already a registered transformerErrorSensor
     if (transformerErrorSensor == null) {
       transformerErrorSensor = localMetricRepository.sensor(TRANSFORMER_ERROR_COUNT);
       transformerErrorSensor.add(TRANSFORMER_ERROR_COUNT, transformerErrorCount);
@@ -591,7 +590,6 @@ public class IngestionStats {
   }
 
   public void registerTransformerLatencySensor() {
-    // Check to make sure there isn't already a registered transformerLatencySensor
     if (transformerLatencySensor == null) {
       transformerLatencySensor = new WritePathLatencySensor(localMetricRepository, METRIC_CONFIG, TRANSFORMER_LATENCY);
     }
@@ -602,7 +600,6 @@ public class IngestionStats {
   }
 
   public void registerTransformerLifecycleStartLatencySensor() {
-    // Check to make sure there isn't already a registered transformerLifecycleStartLatencySensor
     if (transformerLifecycleStartLatencySensor == null) {
       transformerLifecycleStartLatencySensor =
           new WritePathLatencySensor(localMetricRepository, METRIC_CONFIG, TRANSFORMER_LIFECYCLE_START_LATENCY);
@@ -614,7 +611,6 @@ public class IngestionStats {
   }
 
   public void registerTransformerLifecycleEndLatencySensor() {
-    // Check to make sure there isn't already a registered transformerLifecycleEndLatencySensor
     if (transformerLifecycleEndLatencySensor == null) {
       transformerLifecycleEndLatencySensor =
           new WritePathLatencySensor(localMetricRepository, METRIC_CONFIG, TRANSFORMER_LIFECYCLE_END_LATENCY);

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/IngestionStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/IngestionStats.java
@@ -58,6 +58,8 @@ public class IngestionStats {
   public static final String NEARLINE_LOCAL_BROKER_TO_READY_TO_SERVE_LATENCY =
       "nearline_local_broker_to_ready_to_serve_latency";
   public static final String TRANSFORMER_LATENCY = "transformer_latency";
+  public static final String TRANSFORMER_LIFECYCLE_START_LATENCY = "transformer_lifecycle_start_latency";
+  public static final String TRANSFORMER_LIFECYCLE_END_LATENCY = "transformer_lifecycle_end_latency";
   public static final String IDLE_TIME = "idle_time";
   public static final String PRODUCER_CALLBACK_LATENCY = "producer_callback_latency";
   public static final String LEADER_PREPROCESSING_LATENCY = "leader_preprocessing_latency";
@@ -92,6 +94,8 @@ public class IngestionStats {
   private final WritePathLatencySensor nearlineProducerToLocalBrokerLatencySensor;
   private final WritePathLatencySensor nearlineLocalBrokerToReadyToServeLatencySensor;
   private WritePathLatencySensor transformerLatencySensor;
+  private WritePathLatencySensor transformerLifecycleStartLatencySensor;
+  private WritePathLatencySensor transformerLifecycleEndLatencySensor;
   private final WritePathLatencySensor producerCallBackLatency;
   private final WritePathLatencySensor leaderPreprocessingLatency;
   private final WritePathLatencySensor internalPreprocessingLatency;
@@ -590,6 +594,30 @@ public class IngestionStats {
     // Check to make sure there isn't already a registered transformerLatencySensor
     if (transformerLatencySensor == null) {
       transformerLatencySensor = new WritePathLatencySensor(localMetricRepository, METRIC_CONFIG, TRANSFORMER_LATENCY);
+    }
+  }
+
+  public void recordTransformerLifecycleStartLatency(double value, long currentTimeMs) {
+    transformerLifecycleStartLatencySensor.record(value, currentTimeMs);
+  }
+
+  public void registerTransformerLifecycleStartLatencySensor() {
+    // Check to make sure there isn't already a registered transformerLifecycleStartLatencySensor
+    if (transformerLifecycleStartLatencySensor == null) {
+      transformerLifecycleStartLatencySensor =
+          new WritePathLatencySensor(localMetricRepository, METRIC_CONFIG, TRANSFORMER_LIFECYCLE_START_LATENCY);
+    }
+  }
+
+  public void recordTransformerLifecycleEndLatency(double value, long currentTimeMs) {
+    transformerLifecycleEndLatencySensor.record(value, currentTimeMs);
+  }
+
+  public void registerTransformerLifecycleEndLatencySensor() {
+    // Check to make sure there isn't already a registered transformerLifecycleEndLatencySensor
+    if (transformerLifecycleEndLatencySensor == null) {
+      transformerLifecycleEndLatencySensor =
+          new WritePathLatencySensor(localMetricRepository, METRIC_CONFIG, TRANSFORMER_LIFECYCLE_END_LATENCY);
     }
   }
 


### PR DESCRIPTION
## Summary
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

1. When recordTransformer is enabled, `onStartIngestionTask() `and `onEndIngestionTask()` are invoked during the start/end of an IngestionTask.
2. Added sensors to measure the latency of `onStartIngestionTask() `and `onEndIngestionTask()`.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
CI

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.