### PR TITLE
[vpj] Remove extra call to PubSub to fetch partition count for data writer job

### DIFF
--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
@@ -199,16 +199,21 @@ public class VenicePushJob implements AutoCloseable {
 
   /**
    * The temp directory structure for VPJ will be: <br/>
-   * |____{@code $hadoop.tmp.dir} (Specified by env, or default {@code /tmp}) <br/>
-   * | |____venice-push-job (777 permissions) - shared temp space for all VPJ executions ({@code $sharedTempDir}) <br/>
-   * | | |____{@code $jobTmpDir} (700 permissions) - temp space for the current execution ({@code $job.execution.id}_{@literal unique-suffix}) <br/>
-   * | | | |____veniceMapperOutput (700 permissions) <br/>
-   * | | | |____rmd_schemas (700 permissions) <br/>
-   * | | | |____value_schemas (700 permissions) <br/>
-   * | | | |____...features_added_in_the_future (700 permissions) <br/>
+   * |____{@code $sharedTmpDir} (777 permissions) - shared temp space for all VPJ executions <br/>
+   * | |____{@code $jobTmpDir} (700 permissions) - temp space for the current execution ({@code $job.execution.id}_{@literal unique-suffix}) <br/>
+   * | | |____veniceMapperOutput (700 permissions) <br/>
+   * | | |____rmd_schemas (700 permissions) <br/>
+   * | | |____value_schemas (700 permissions) <br/>
+   * | | |____...features_added_in_the_future (700 permissions) <br/>
    *  <br/>
    * Common directory under which all the different push jobs create their job specific directories.
-   * The value of {@code sharedTmpDir} is set to {@code ${hadoop.tmp.dir}/venice-push-job} if {@code ${hadoop.tmp.dir}}
+   * The value of {@code sharedTmpDir} is obtained by the following steps:
+   * <ol>
+   *   <li>If {@code tmp.dir.prefix} is configured, that is used.</li>
+   *   <li>Otherwise, if {@code hadoop.tmp.dir} is specified in HDFS configs, then {@code ${hadoop.tmp.dir}/venice-push-job} is used.</li>
+   *   <li>Otherwise, {@code /venice-push-job} is used.</li>
+   * </ol>
+   *   {@code ${hadoop.tmp.dir}/venice-push-job} if {@code ${hadoop.tmp.dir}}
    * is set. Otherwise, the path is set to {@code /tmp/venice-push-job}.
    */
   private final Path sharedTmpDir;
@@ -362,8 +367,10 @@ public class VenicePushJob implements AutoCloseable {
     }
     String hadoopTempDir = new Configuration().get(HADOOP_TMP_DIR, "/tmp");
     pushJobSettingToReturn.sharedTmpDir = props.getString(TEMP_DIR_PREFIX, hadoopTempDir + "/venice-push-job");
+    LOGGER.info("Using {} as shared temp directory", pushJobSettingToReturn.sharedTmpDir);
     pushJobSettingToReturn.jobTmpDir = pushJobSettingToReturn.sharedTmpDir + "/"
         + Utils.escapeFilePathComponent(Utils.getUniqueString(pushJobSettingToReturn.jobExecutionId));
+    LOGGER.info("Using {} as this job's temp directory", pushJobSettingToReturn.sharedTmpDir);
     pushJobSettingToReturn.vpjEntryClass = this.getClass();
     if (props.containsKey(SOURCE_GRID_FABRIC)) {
       pushJobSettingToReturn.sourceGridFabric = props.getString(SOURCE_GRID_FABRIC);

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/task/datawriter/AbstractPartitionWriter.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/task/datawriter/AbstractPartitionWriter.java
@@ -364,6 +364,7 @@ public abstract class AbstractPartitionWriter extends AbstractDataWriterTask imp
             .setChunkingEnabled(chunkingEnabled)
             .setRmdChunkingEnabled(rmdChunkingEnabled)
             .setTime(SystemTime.INSTANCE)
+            .setPartitionCount(getPartitionCount())
             .setPartitioner(partitioner)
             .build();
     return veniceWriterFactoryFactory.createVeniceWriter(options);

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/utils/HadoopUtils.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/utils/HadoopUtils.java
@@ -63,7 +63,7 @@ public class HadoopUtils {
    * @throws IOException
    */
   public static void createDirectoryWithPermission(Path path, FsPermission permission) throws IOException {
-    LOGGER.info("Trying to create path {} with permission {}", path.getName(), permission);
+    LOGGER.info("Trying to create path {} with permission {}", path, permission);
     FileSystem fs = path.getFileSystem(new Configuration());
     // check if the path needs to be created
     if (fs.exists(path)) {
@@ -77,7 +77,7 @@ public class HadoopUtils {
         fs.setPermission(path, permission);
       }
     } else {
-      LOGGER.info("Creating path {} with permission {}", path.getName(), permission);
+      LOGGER.info("Creating path {} with permission {}", path, permission);
       fs.mkdirs(path);
       // mkdirs(path,permission) didn't set the right permission when
       // tested in hdfs, so splitting it like this, it works!


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Summary, imperative, start upper case, don't end with a period
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
Remove extra call to PubSub to fetch partition count for data writer job. There was a job failure in production where the VeniceWriter tried to query PubSub to fetch the partition count during the PartitionWriter phase. Since the partition count is always available before the DataWriter job starts, we can specify it explicitly and reduce one call to the PubSub system.

Also, improve docs and logging for shared temp directory for VPJ

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
GH CI

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.