### PR TITLE
[test] Fix Flaky testAssembledValueSizeSensor Unit Test

### DIFF
--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
@@ -4419,15 +4419,12 @@ public abstract class StoreIngestionTaskTest {
             System.currentTimeMillis());
       } catch (Exception e) {
         e.printStackTrace();
-        // Verify transformer error was recorded
-        verify(mockVersionedStorageIngestionStats)
-            .recordTransformerError(eq(storeNameWithoutVersionInfo), anyInt(), anyDouble(), anyLong());
       }
-    }, aaConfig, (storeVersion) -> new TestStringRecordTransformer(storeVersion));
 
-    // Verify transformer error was recorded
-    verify(mockVersionedStorageIngestionStats)
-        .recordTransformerError(eq(storeNameWithoutVersionInfo), anyInt(), anyDouble(), anyLong());
+      // Verify transformer error was recorded
+      verify(mockVersionedStorageIngestionStats, timeout(1000))
+          .recordTransformerError(eq(storeNameWithoutVersionInfo), anyInt(), anyDouble(), anyLong());
+    }, aaConfig, TestStringRecordTransformer::new);
   }
 
   @DataProvider
@@ -4489,16 +4486,16 @@ public abstract class StoreIngestionTaskTest {
           throw new VeniceException(e);
         }
       }
-    }, aaConfig);
 
-    // Verify that the size of the assembled record was recorded in the metrics only if schemaId=-20
-    HostLevelIngestionStats hostLevelIngestionStats = storeIngestionTaskUnderTest.hostLevelIngestionStats;
-    if (useRealSchemaId) {
-      verify(hostLevelIngestionStats).recordAssembledValueSize(eq(expectedRecordSize), anyLong());
-      verify(hostLevelIngestionStats, times(1)).recordAssembledValueSize(anyLong(), anyLong());
-    } else {
-      verify(hostLevelIngestionStats, times(0)).recordAssembledValueSize(anyLong(), anyLong());
-    }
+      // Verify that the size of the assembled record was recorded in the metrics only if schemaId=-20
+      HostLevelIngestionStats hostLevelIngestionStats = storeIngestionTaskUnderTest.hostLevelIngestionStats;
+      if (useRealSchemaId) {
+        verify(hostLevelIngestionStats, timeout(1000)).recordAssembledValueSize(eq(expectedRecordSize), anyLong());
+        verify(hostLevelIngestionStats, timeout(1000).times(1)).recordAssembledValueSize(anyLong(), anyLong());
+      } else {
+        verify(hostLevelIngestionStats, times(0)).recordAssembledValueSize(anyLong(), anyLong());
+      }
+    }, aaConfig);
   }
 
   @Test


### PR DESCRIPTION
## Summary

The `testAssembledValueSizeSensor()` unit test from #1009 is flaky and fails very frequently on GHCI runs. The turns out to be due to the `verify()` assertions being outside the `runTest()` function, which causes the `StoreIngestionTask` to be prematurely closed before all messages have been processed. Moving the `verify()` lines solves the problem.

Thanks to @sixpluszero for the help.

## How was this PR tested?
GHCI

## Does this PR introduce any user-facing changes?
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.