### PR TITLE
[vpj][controller] Fix mismatch in per colo status reporting and overall status priorities to include DVC error codes

### DIFF
--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
@@ -1762,6 +1762,36 @@ public class VenicePushJob implements AutoCloseable {
     return null;
   }
 
+  /** Transform per colo {@link ExecutionStatus} to per colo {@link PushJobDetailsStatus} */
+  protected static PushJobDetailsStatus getPerColoPushJobDetailsStatusFromExecutionStatus(
+      ExecutionStatus executionStatus) {
+    switch (executionStatus.getRootStatus()) {
+      case NOT_CREATED:
+      case NEW:
+      case NOT_STARTED:
+        return PushJobDetailsStatus.NOT_CREATED;
+      case STARTED:
+      case PROGRESS:
+      case CATCH_UP_BASE_TOPIC_OFFSET_LAG:
+        return PushJobDetailsStatus.STARTED;
+      case END_OF_PUSH_RECEIVED:
+        return PushJobDetailsStatus.END_OF_PUSH_RECEIVED;
+      case TOPIC_SWITCH_RECEIVED:
+        return PushJobDetailsStatus.DATA_WRITER_COMPLETED;
+      case START_OF_INCREMENTAL_PUSH_RECEIVED:
+        return PushJobDetailsStatus.START_OF_INCREMENTAL_PUSH_RECEIVED;
+      case END_OF_INCREMENTAL_PUSH_RECEIVED:
+        return PushJobDetailsStatus.END_OF_INCREMENTAL_PUSH_RECEIVED;
+      case COMPLETED:
+      case DATA_RECOVERY_COMPLETED:
+        return PushJobDetailsStatus.COMPLETED;
+      case ERROR:
+        return PushJobDetailsStatus.ERROR;
+      default:
+        return PushJobDetailsStatus.UNKNOWN;
+    }
+  }
+
   private void updatePushJobDetailsWithColoStatus(Map<String, String> coloSpecificInfo, Set<String> completedColos) {
     try {
       if (pushJobDetails.coloStatus == null) {
@@ -1772,16 +1802,17 @@ public class VenicePushJob implements AutoCloseable {
           // Don't bother updating the completed colo's status
           .filter(coloEntry -> !completedColos.contains(coloEntry.getKey()))
           .forEach(coloEntry -> {
-            int status = PushJobDetailsStatus.valueOf(coloEntry.getValue()).getValue();
+            ExecutionStatus executionStatus = ExecutionStatus.valueOf(coloEntry.getValue());
+            int pushJobDetailsStatus = getPerColoPushJobDetailsStatusFromExecutionStatus(executionStatus).getValue();
             if (!pushJobDetails.coloStatus.containsKey(coloEntry.getKey())) {
               List<PushJobDetailsStatusTuple> newList = new ArrayList<>();
-              newList.add(getPushJobDetailsStatusTuple(status));
+              newList.add(getPushJobDetailsStatusTuple(pushJobDetailsStatus));
               pushJobDetails.coloStatus.put(coloEntry.getKey(), newList);
             } else {
               List<PushJobDetailsStatusTuple> statuses = pushJobDetails.coloStatus.get(coloEntry.getKey());
-              if (statuses.get(statuses.size() - 1).status != status) {
-                // Only add the status if there is a change
-                statuses.add(getPushJobDetailsStatusTuple(status));
+              if (statuses.get(statuses.size() - 1).status != pushJobDetailsStatus) {
+                // Only add the pushJobDetailsStatus if there is a change
+                statuses.add(getPushJobDetailsStatusTuple(pushJobDetailsStatus));
               }
             }
           });

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -302,6 +302,10 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
       ExecutionStatus.NEW,
       ExecutionStatus.NOT_CREATED,
       ExecutionStatus.END_OF_PUSH_RECEIVED,
+      ExecutionStatus.DVC_INGESTION_ERROR_OTHER,
+      ExecutionStatus.DVC_INGESTION_ERROR_DISK_FULL,
+      ExecutionStatus.DVC_INGESTION_ERROR_MEMORY_LIMIT_REACHED,
+      ExecutionStatus.DVC_INGESTION_ERROR_TOO_MANY_DEAD_INSTANCES,
       ExecutionStatus.ERROR,
       ExecutionStatus.WARNING,
       ExecutionStatus.COMPLETED,
@@ -5958,8 +5962,8 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
   }
 
   // The method merges push status from Venice Server replicas and online Da Vinci hosts and return the unified status.
-  private ExecutionStatus getOverallPushStatus(ExecutionStatus veniceStatus, ExecutionStatus daVinciStatus) {
-    List<ExecutionStatus> statuses = Arrays.asList(veniceStatus.getRootStatus(), daVinciStatus.getRootStatus());
+  protected static ExecutionStatus getOverallPushStatus(ExecutionStatus veniceStatus, ExecutionStatus daVinciStatus) {
+    List<ExecutionStatus> statuses = Arrays.asList(veniceStatus, daVinciStatus);
     statuses.sort(Comparator.comparingInt(STATUS_PRIORITIES::indexOf));
     return statuses.get(0);
   }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
@@ -3491,7 +3491,7 @@ public class VeniceParentHelixAdmin implements Admin {
     Map<String, String> extraInfo = new HashMap<>();
     Map<String, String> extraDetails = new HashMap<>();
     Map<String, Long> extraInfoUpdateTimestamp = new HashMap<>();
-    int failCount = 0;
+    int numChildRegionsFailedToFetchStatus = 0;
     Set<String> targetedRegionSet = RegionUtils.parseRegionsFilterList(targetedRegions);
 
     for (Map.Entry<String, ControllerClient> entry: controllerClients.entrySet()) {
@@ -3513,7 +3513,7 @@ public class VeniceParentHelixAdmin implements Admin {
       }
       JobStatusQueryResponse response = controllerClient.queryJobStatus(kafkaTopic, incrementalPushVersion);
       if (response.isError()) {
-        failCount += 1;
+        numChildRegionsFailedToFetchStatus += 1;
         LOGGER.warn("Couldn't query {} for job {} status: {}", region, kafkaTopic, response.getError());
         statuses.put(region, ExecutionStatus.UNKNOWN);
         extraInfo.put(region, ExecutionStatus.UNKNOWN.toString());
@@ -3532,18 +3532,8 @@ public class VeniceParentHelixAdmin implements Admin {
 
     StringBuilder currentReturnStatusDetails = new StringBuilder();
 
-    // Sort the per-datacenter status in this order, and return the first one in the list
-    // Edge case example: if one cluster is stuck in NOT_CREATED, then
-    // as another cluster goes from PROGRESS to COMPLETED
-    // the aggregate status will go from PROGRESS back down to NOT_CREATED.
-    List<ExecutionStatus> sortedStatuses = statuses.values()
-        .stream()
-        .map(ExecutionStatus::getRootStatus)
-        .sorted(Comparator.comparingInt(VeniceHelixAdmin.STATUS_PRIORITIES::indexOf))
-        .collect(Collectors.toList());
-
     ExecutionStatus currentReturnStatus =
-        getFinalReturnStatus(sortedStatuses, childRegions, failCount, currentReturnStatusDetails);
+        getFinalReturnStatus(statuses, childRegions, numChildRegionsFailedToFetchStatus, currentReturnStatusDetails);
 
     // Do not delete parent Kafka if its part of targeted colo push to prevent concurrent pushes
     if (currentReturnStatus.isTerminal()) {
@@ -3602,24 +3592,33 @@ public class VeniceParentHelixAdmin implements Admin {
 
   /**
    * Based on the global information, start determining the final status to return
-   * @param sortedStatuses
+   * @param statuses
    * @param childRegions
-   * @param failCount
+   * @param numChildRegionsFailedToFetchStatus
    * @param currentReturnStatusDetails
    * @return
    */
-  private ExecutionStatus getFinalReturnStatus(
-      List<ExecutionStatus> sortedStatuses,
+  protected static ExecutionStatus getFinalReturnStatus(
+      Map<String, ExecutionStatus> statuses,
       Set<String> childRegions,
-      int failCount,
+      int numChildRegionsFailedToFetchStatus,
       StringBuilder currentReturnStatusDetails) {
     ExecutionStatus currentReturnStatus = ExecutionStatus.NEW;
+
+    // Sort the per-datacenter status in this order, and return the first one in the list
+    // Edge case example: if one cluster is stuck in NOT_CREATED, then
+    // as another cluster goes from PROGRESS to COMPLETED
+    // the aggregate status will go from PROGRESS back down to NOT_CREATED.
+    List<ExecutionStatus> sortedStatuses = statuses.values()
+        .stream()
+        .sorted(Comparator.comparingInt(VeniceHelixAdmin.STATUS_PRIORITIES::indexOf))
+        .collect(Collectors.toList());
 
     if (!sortedStatuses.isEmpty()) {
       currentReturnStatus = sortedStatuses.get(0);
     }
 
-    int successCount = childRegions.size() - failCount;
+    int successCount = childRegions.size() - numChildRegionsFailedToFetchStatus;
     if (successCount < (childRegions.size() / 2) + 1) {
       // Strict majority must be reachable, otherwise keep polling
       currentReturnStatus = ExecutionStatus.PROGRESS;
@@ -3628,10 +3627,10 @@ public class VeniceParentHelixAdmin implements Admin {
     if (currentReturnStatus.isTerminal()) {
       // If there is a temporary datacenter connection failure, we want VPJ to report failure while allowing the push
       // to succeed in remaining datacenters. If we want to allow the push to succeed in async in the remaining
-      // datacenter, then put the topic delete into an else block under `if (failCount > 0)`
-      if (failCount > 0) {
+      // datacenter, then put the topic delete into an else block under `if (numChildRegionsFailedToFetchStatus > 0)`
+      if (numChildRegionsFailedToFetchStatus > 0) {
         currentReturnStatus = ExecutionStatus.ERROR;
-        currentReturnStatusDetails.append(failCount)
+        currentReturnStatusDetails.append(numChildRegionsFailedToFetchStatus)
             .append("/")
             .append(childRegions.size())
             .append(" DCs unreachable. ");

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceHelixAdmin.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceHelixAdmin.java
@@ -2,6 +2,7 @@ package com.linkedin.venice.controller;
 
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
+import static org.testng.Assert.*;
 
 import com.linkedin.venice.controller.stats.DisabledPartitionStats;
 import com.linkedin.venice.helix.HelixExternalViewRepository;
@@ -9,6 +10,7 @@ import com.linkedin.venice.meta.PartitionAssignment;
 import com.linkedin.venice.meta.ReadWriteStoreRepository;
 import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.Version;
+import com.linkedin.venice.pushmonitor.ExecutionStatus;
 import com.linkedin.venice.utils.HelixUtils;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -86,5 +88,34 @@ public class TestVeniceHelixAdmin {
     // Enforce that getRealTimeTopic happens before storeMetadataUpdate. See the above comments for the reasons.
     inorder.verify(veniceHelixAdmin).getRealTimeTopic(anyString(), anyString());
     inorder.verify(veniceHelixAdmin).storeMetadataUpdate(anyString(), anyString(), any());
+  }
+
+  @Test
+  public void testGetOverallPushStatus() {
+    ExecutionStatus veniceStatus = ExecutionStatus.COMPLETED;
+    ExecutionStatus daVinciStatus = ExecutionStatus.COMPLETED;
+    ExecutionStatus overallStatus = VeniceHelixAdmin.getOverallPushStatus(veniceStatus, daVinciStatus);
+
+    assertEquals(overallStatus, ExecutionStatus.COMPLETED);
+
+    veniceStatus = ExecutionStatus.ERROR;
+    daVinciStatus = ExecutionStatus.COMPLETED;
+    overallStatus = VeniceHelixAdmin.getOverallPushStatus(veniceStatus, daVinciStatus);
+    assertEquals(overallStatus, ExecutionStatus.ERROR);
+
+    veniceStatus = ExecutionStatus.ERROR;
+    daVinciStatus = ExecutionStatus.ERROR;
+    overallStatus = VeniceHelixAdmin.getOverallPushStatus(veniceStatus, daVinciStatus);
+    assertEquals(overallStatus, ExecutionStatus.ERROR);
+
+    veniceStatus = ExecutionStatus.COMPLETED;
+    daVinciStatus = ExecutionStatus.DVC_INGESTION_ERROR_DISK_FULL;
+    overallStatus = VeniceHelixAdmin.getOverallPushStatus(veniceStatus, daVinciStatus);
+    assertEquals(overallStatus, ExecutionStatus.DVC_INGESTION_ERROR_DISK_FULL);
+
+    veniceStatus = ExecutionStatus.ERROR;
+    daVinciStatus = ExecutionStatus.DVC_INGESTION_ERROR_DISK_FULL;
+    overallStatus = VeniceHelixAdmin.getOverallPushStatus(veniceStatus, daVinciStatus);
+    assertEquals(overallStatus, ExecutionStatus.DVC_INGESTION_ERROR_DISK_FULL);
   }
 }

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceHelixAdmin.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceHelixAdmin.java
@@ -2,7 +2,7 @@ package com.linkedin.venice.controller;
 
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
-import static org.testng.Assert.*;
+import static org.testng.Assert.assertEquals;
 
 import com.linkedin.venice.controller.stats.DisabledPartitionStats;
 import com.linkedin.venice.helix.HelixExternalViewRepository;

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceParentHelixAdmin.java
@@ -18,7 +18,7 @@ import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.testng.Assert.assertThrows;
+import static org.testng.Assert.*;
 
 import com.linkedin.venice.common.VeniceSystemStoreUtils;
 import com.linkedin.venice.compression.CompressionStrategy;
@@ -383,7 +383,7 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
     when(zkClient.readData(zkMetadataNodePath, null)).thenReturn(null);
     parentAdmin.initStorageCluster(clusterName);
 
-    Assert.assertThrows(
+    assertThrows(
         VeniceStoreAlreadyExistsException.class,
         () -> parentAdmin.createStore(clusterName, storeName, owner, keySchemaStr, valueSchemaStr));
   }
@@ -404,7 +404,7 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
     parentAdmin.createStore(clusterName, storeName, owner, keySchemaStr, valueSchemaStr);
 
     // Add store again now with an existing exception
-    Assert.assertThrows(
+    assertThrows(
         VeniceException.class,
         () -> parentAdmin.createStore(clusterName, storeName, owner, keySchemaStr, valueSchemaStr));
   }
@@ -423,12 +423,10 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
     parentAdmin.initStorageCluster(clusterName);
     parentAdmin.createStore(clusterName, storeName, owner, keySchemaStr, valueSchemaStr);
     parentAdmin.setStorePartitionCount(clusterName, storeName, MAX_PARTITION_NUM);
-    Assert.assertThrows(
+    assertThrows(
         ConfigurationException.class,
         () -> parentAdmin.setStorePartitionCount(clusterName, storeName, MAX_PARTITION_NUM + 1));
-    Assert.assertThrows(
-        ConfigurationException.class,
-        () -> parentAdmin.setStorePartitionCount(clusterName, storeName, -1));
+    assertThrows(ConfigurationException.class, () -> parentAdmin.setStorePartitionCount(clusterName, storeName, -1));
   }
 
   @Test
@@ -611,9 +609,7 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
         .thenReturn(AdminTopicMetadataAccessor.generateMetadataMap(1, -1, 1));
 
     parentAdmin.initStorageCluster(clusterName);
-    Assert.assertThrows(
-        VeniceNoStoreException.class,
-        () -> parentAdmin.setStoreWriteability(clusterName, storeName, false));
+    assertThrows(VeniceNoStoreException.class, () -> parentAdmin.setStoreWriteability(clusterName, storeName, false));
   }
 
   @Test
@@ -852,7 +848,7 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
         new PartialMockVeniceParentHelixAdmin(internalAdmin, config)) {
       partialMockParentAdmin.setOfflineJobStatus(ExecutionStatus.PROGRESS);
 
-      Assert.assertThrows(
+      assertThrows(
           VeniceException.class,
           () -> partialMockParentAdmin.incrementVersionIdempotent(clusterName, storeName, pushJobId2, 1, 1));
     }
@@ -1313,7 +1309,7 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
     doReturn(mockHelixVeniceClusterResources).when(mockInternalAdmin).getHelixVeniceClusterResources(clusterName);
     doReturn(mock(VeniceAdminStats.class)).when(mockHelixVeniceClusterResources).getVeniceAdminStats();
 
-    Assert.assertThrows(
+    assertThrows(
         VeniceException.class,
         () -> mockParentAdmin.incrementVersionIdempotent(
             clusterName,
@@ -1542,7 +1538,7 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
         incrementalPushVersion);
 
     doReturn(true).when(internalAdmin).isTopicTruncated(Version.composeRealTimeTopic(storeName));
-    Assert.assertThrows(
+    assertThrows(
         VeniceException.class,
         () -> parentAdmin.getIncrementalPushVersion(incrementalPushVersion, ExecutionStatus.COMPLETED));
   }
@@ -1926,14 +1922,14 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
     parentAdmin.initStorageCluster(clusterName);
     // When user disable hybrid but also try to manually turn on A/A or Incremental Push, update operation should fail
     // loudly.
-    Assert.assertThrows(
+    assertThrows(
         () -> parentAdmin.updateStore(
             clusterName,
             storeName,
             new UpdateStoreQueryParams().setHybridRewindSeconds(-1)
                 .setHybridOffsetLagThreshold(-1)
                 .setActiveActiveReplicationEnabled(true)));
-    Assert.assertThrows(
+    assertThrows(
         () -> parentAdmin.updateStore(
             clusterName,
             storeName,
@@ -2086,21 +2082,21 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
         .thenReturn(AdminTopicMetadataAccessor.generateMetadataMap(1, -1, 1));
     parentAdmin.initStorageCluster(clusterName);
 
-    Assert.assertThrows(
+    assertThrows(
         () -> parentAdmin.updateStore(
             clusterName,
             storeName,
             new UpdateStoreQueryParams().setPartitionerClass("com.linkedin.im.a.bad.man").setAmplificationFactor(-1)));
     verify(veniceWriter, times(0)).put(any(), any(), anyInt());
 
-    Assert.assertThrows(
+    assertThrows(
         () -> parentAdmin.updateStore(
             clusterName,
             storeName,
             new UpdateStoreQueryParams().setWriteComputationEnabled(true).setAmplificationFactor(2)));
     verify(veniceWriter, times(0)).put(any(), any(), anyInt());
 
-    Assert.assertThrows(
+    assertThrows(
         () -> parentAdmin.updateStore(
             clusterName,
             storeName,
@@ -2108,13 +2104,13 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
     verify(veniceWriter, times(0)).put(any(), any(), anyInt());
 
     store.setWriteComputationEnabled(true);
-    Assert.assertThrows(
+    assertThrows(
         () -> parentAdmin.updateStore(clusterName, storeName, new UpdateStoreQueryParams().setAmplificationFactor(2)));
     verify(veniceWriter, times(0)).put(any(), any(), anyInt());
 
     store.setWriteComputationEnabled(false);
     store.setActiveActiveReplicationEnabled(true);
-    Assert.assertThrows(
+    assertThrows(
         () -> parentAdmin.updateStore(clusterName, storeName, new UpdateStoreQueryParams().setAmplificationFactor(2)));
     verify(veniceWriter, times(0)).put(any(), any(), anyInt());
 
@@ -2338,7 +2334,7 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
     // not be called
     doReturn(SystemTime.INSTANCE.getMilliseconds() - Time.MS_PER_MINUTE).when(internalAdmin)
         .getInMemoryTopicCreationTime(Version.composeKafkaTopic(storeName, 1));
-    Assert.assertThrows(
+    assertThrows(
         VeniceException.class,
         () -> mockParentAdmin.getTopicForCurrentPushJob(clusterName, storeName, false, false));
     verify(mockParentAdmin, times(1)).killOfflinePush(clusterName, latestTopic, true);
@@ -2613,13 +2609,11 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
   @Test
   public void testAclException() {
     String storeName = "test-store-authorizer";
-    Assert.assertThrows(
+    assertThrows(
         VeniceUnsupportedOperationException.class,
         () -> parentAdmin.updateAclForStore(clusterName, storeName, ""));
-    Assert.assertThrows(
-        VeniceUnsupportedOperationException.class,
-        () -> parentAdmin.getAclForStore(clusterName, storeName));
-    Assert.assertThrows(
+    assertThrows(VeniceUnsupportedOperationException.class, () -> parentAdmin.getAclForStore(clusterName, storeName));
+    assertThrows(
         VeniceUnsupportedOperationException.class,
         () -> parentAdmin.deleteAclForStore(clusterName, storeName));
   }
@@ -2778,5 +2772,85 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
           e.getMessage(),
           "One of the targeted region invalidRegion is not a valid region in cluster test");
     }
+  }
+
+  @Test
+  public void testGetFinalReturnStatus() {
+    Map<String, ExecutionStatus> statuses = new HashMap<>();
+    Set<String> childRegions = new HashSet<>();
+    childRegions.add("region1");
+    childRegions.add("region2");
+    childRegions.add("region3");
+    ExecutionStatus finalStatus;
+
+    statuses.clear();
+    statuses.put("region1", ExecutionStatus.COMPLETED);
+    statuses.put("region2", ExecutionStatus.COMPLETED);
+    statuses.put("region3", ExecutionStatus.COMPLETED);
+    finalStatus = VeniceParentHelixAdmin.getFinalReturnStatus(statuses, childRegions, 0, new StringBuilder());
+    assertEquals(finalStatus, ExecutionStatus.COMPLETED);
+
+    statuses.clear();
+    statuses.put("region1", ExecutionStatus.COMPLETED);
+    statuses.put("region2", ExecutionStatus.PROGRESS);
+    statuses.put("region3", ExecutionStatus.COMPLETED);
+    finalStatus = VeniceParentHelixAdmin.getFinalReturnStatus(statuses, childRegions, 0, new StringBuilder());
+    assertEquals(finalStatus, ExecutionStatus.PROGRESS);
+
+    statuses.clear();
+    statuses.put("region1", ExecutionStatus.COMPLETED);
+    statuses.put("region2", ExecutionStatus.ERROR);
+    statuses.put("region3", ExecutionStatus.COMPLETED);
+    finalStatus = VeniceParentHelixAdmin.getFinalReturnStatus(statuses, childRegions, 0, new StringBuilder());
+    assertEquals(finalStatus, ExecutionStatus.ERROR);
+
+    statuses.clear();
+    statuses.put("region1", ExecutionStatus.COMPLETED);
+    statuses.put("region2", ExecutionStatus.ERROR);
+    statuses.put("region3", ExecutionStatus.UNKNOWN);
+    finalStatus = VeniceParentHelixAdmin.getFinalReturnStatus(statuses, childRegions, 1, new StringBuilder());
+    assertEquals(finalStatus, ExecutionStatus.UNKNOWN);
+
+    statuses.clear();
+    statuses.put("region1", ExecutionStatus.UNKNOWN);
+    statuses.put("region2", ExecutionStatus.ERROR);
+    statuses.put("region3", ExecutionStatus.UNKNOWN);
+    finalStatus = VeniceParentHelixAdmin.getFinalReturnStatus(statuses, childRegions, 2, new StringBuilder());
+    assertEquals(finalStatus, ExecutionStatus.PROGRESS);
+
+    statuses.clear();
+    statuses.put("region1", ExecutionStatus.COMPLETED);
+    statuses.put("region2", ExecutionStatus.COMPLETED);
+    statuses.put("region3", ExecutionStatus.DVC_INGESTION_ERROR_OTHER);
+    finalStatus = VeniceParentHelixAdmin.getFinalReturnStatus(statuses, childRegions, 0, new StringBuilder());
+    assertEquals(finalStatus, ExecutionStatus.DVC_INGESTION_ERROR_OTHER);
+
+    statuses.clear();
+    statuses.put("region1", ExecutionStatus.COMPLETED);
+    statuses.put("region2", ExecutionStatus.COMPLETED);
+    statuses.put("region3", ExecutionStatus.DVC_INGESTION_ERROR_DISK_FULL);
+    finalStatus = VeniceParentHelixAdmin.getFinalReturnStatus(statuses, childRegions, 0, new StringBuilder());
+    assertEquals(finalStatus, ExecutionStatus.DVC_INGESTION_ERROR_DISK_FULL);
+
+    statuses.clear();
+    statuses.put("region1", ExecutionStatus.COMPLETED);
+    statuses.put("region2", ExecutionStatus.DVC_INGESTION_ERROR_DISK_FULL);
+    statuses.put("region3", ExecutionStatus.DVC_INGESTION_ERROR_DISK_FULL);
+    finalStatus = VeniceParentHelixAdmin.getFinalReturnStatus(statuses, childRegions, 0, new StringBuilder());
+    assertEquals(finalStatus, ExecutionStatus.DVC_INGESTION_ERROR_DISK_FULL);
+
+    statuses.clear();
+    statuses.put("region1", ExecutionStatus.COMPLETED);
+    statuses.put("region2", ExecutionStatus.DVC_INGESTION_ERROR_MEMORY_LIMIT_REACHED);
+    statuses.put("region3", ExecutionStatus.DVC_INGESTION_ERROR_DISK_FULL);
+    finalStatus = VeniceParentHelixAdmin.getFinalReturnStatus(statuses, childRegions, 0, new StringBuilder());
+    assertEquals(finalStatus, ExecutionStatus.DVC_INGESTION_ERROR_DISK_FULL);
+
+    statuses.clear();
+    statuses.put("region1", ExecutionStatus.COMPLETED);
+    statuses.put("region2", ExecutionStatus.DVC_INGESTION_ERROR_MEMORY_LIMIT_REACHED);
+    statuses.put("region3", ExecutionStatus.DVC_INGESTION_ERROR_OTHER);
+    finalStatus = VeniceParentHelixAdmin.getFinalReturnStatus(statuses, childRegions, 0, new StringBuilder());
+    assertEquals(finalStatus, ExecutionStatus.DVC_INGESTION_ERROR_OTHER);
   }
 }

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceParentHelixAdmin.java
@@ -18,7 +18,8 @@ import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.testng.Assert.*;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertThrows;
 
 import com.linkedin.venice.common.VeniceSystemStoreUtils;
 import com.linkedin.venice.compression.CompressionStrategy;
@@ -281,18 +282,18 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
     byte[] keyBytes = keyCaptor.getValue();
     byte[] valueBytes = valueCaptor.getValue();
     int schemaId = schemaCaptor.getValue();
-    Assert.assertEquals(schemaId, AdminOperationSerializer.LATEST_SCHEMA_ID_FOR_ADMIN_OPERATION);
-    Assert.assertEquals(keyBytes.length, 0);
+    assertEquals(schemaId, AdminOperationSerializer.LATEST_SCHEMA_ID_FOR_ADMIN_OPERATION);
+    assertEquals(keyBytes.length, 0);
 
     AdminOperation adminMessage = adminOperationSerializer.deserialize(ByteBuffer.wrap(valueBytes), schemaId);
-    Assert.assertEquals(adminMessage.operationType, AdminMessageType.STORE_CREATION.getValue());
+    assertEquals(adminMessage.operationType, AdminMessageType.STORE_CREATION.getValue());
 
     StoreCreation storeCreationMessage = (StoreCreation) adminMessage.payloadUnion;
-    Assert.assertEquals(storeCreationMessage.clusterName.toString(), clusterName);
-    Assert.assertEquals(storeCreationMessage.storeName.toString(), storeName);
-    Assert.assertEquals(storeCreationMessage.owner.toString(), owner);
-    Assert.assertEquals(storeCreationMessage.keySchema.definition.toString(), keySchemaStr);
-    Assert.assertEquals(storeCreationMessage.valueSchema.definition.toString(), valueSchemaStr);
+    assertEquals(storeCreationMessage.clusterName.toString(), clusterName);
+    assertEquals(storeCreationMessage.storeName.toString(), storeName);
+    assertEquals(storeCreationMessage.owner.toString(), owner);
+    assertEquals(storeCreationMessage.keySchema.definition.toString(), keySchemaStr);
+    assertEquals(storeCreationMessage.valueSchema.definition.toString(), valueSchemaStr);
   }
 
   @Test
@@ -357,16 +358,16 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
       byte[] keyBytes = keyCaptor.getValue();
       byte[] valueBytes = valueCaptor.getValue();
       int schemaId = schemaCaptor.getValue();
-      Assert.assertEquals(schemaId, AdminOperationSerializer.LATEST_SCHEMA_ID_FOR_ADMIN_OPERATION);
-      Assert.assertEquals(keyBytes.length, 0);
+      assertEquals(schemaId, AdminOperationSerializer.LATEST_SCHEMA_ID_FOR_ADMIN_OPERATION);
+      assertEquals(keyBytes.length, 0);
       AdminOperation adminMessage = adminOperationSerializer.deserialize(ByteBuffer.wrap(valueBytes), schemaId);
-      Assert.assertEquals(adminMessage.operationType, AdminMessageType.STORE_CREATION.getValue());
+      assertEquals(adminMessage.operationType, AdminMessageType.STORE_CREATION.getValue());
       StoreCreation storeCreationMessage = (StoreCreation) adminMessage.payloadUnion;
-      Assert.assertEquals(storeCreationMessage.clusterName.toString(), cluster);
-      Assert.assertEquals(storeCreationMessage.storeName.toString(), storeName);
-      Assert.assertEquals(storeCreationMessage.owner.toString(), owner);
-      Assert.assertEquals(storeCreationMessage.keySchema.definition.toString(), keySchemaStr);
-      Assert.assertEquals(storeCreationMessage.valueSchema.definition.toString(), valueSchemaStr);
+      assertEquals(storeCreationMessage.clusterName.toString(), cluster);
+      assertEquals(storeCreationMessage.storeName.toString(), storeName);
+      assertEquals(storeCreationMessage.owner.toString(), owner);
+      assertEquals(storeCreationMessage.keySchema.definition.toString(), keySchemaStr);
+      assertEquals(storeCreationMessage.valueSchema.definition.toString(), valueSchemaStr);
     }
 
   }
@@ -471,17 +472,17 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
     byte[] keyBytes = keyCaptor.getValue();
     byte[] valueBytes = valueCaptor.getValue();
     int schemaId = schemaCaptor.getValue();
-    Assert.assertEquals(schemaId, AdminOperationSerializer.LATEST_SCHEMA_ID_FOR_ADMIN_OPERATION);
-    Assert.assertEquals(keyBytes.length, 0);
+    assertEquals(schemaId, AdminOperationSerializer.LATEST_SCHEMA_ID_FOR_ADMIN_OPERATION);
+    assertEquals(keyBytes.length, 0);
 
     AdminOperation adminMessage = adminOperationSerializer.deserialize(ByteBuffer.wrap(valueBytes), schemaId);
-    Assert.assertEquals(adminMessage.operationType, AdminMessageType.VALUE_SCHEMA_CREATION.getValue());
+    assertEquals(adminMessage.operationType, AdminMessageType.VALUE_SCHEMA_CREATION.getValue());
 
     ValueSchemaCreation valueSchemaCreationMessage = (ValueSchemaCreation) adminMessage.payloadUnion;
-    Assert.assertEquals(valueSchemaCreationMessage.clusterName.toString(), clusterName);
-    Assert.assertEquals(valueSchemaCreationMessage.storeName.toString(), storeName);
-    Assert.assertEquals(valueSchemaCreationMessage.schema.definition.toString(), valueSchemaStr);
-    Assert.assertEquals(valueSchemaCreationMessage.schemaId, valueSchemaId);
+    assertEquals(valueSchemaCreationMessage.clusterName.toString(), clusterName);
+    assertEquals(valueSchemaCreationMessage.storeName.toString(), storeName);
+    assertEquals(valueSchemaCreationMessage.schema.definition.toString(), valueSchemaStr);
+    assertEquals(valueSchemaCreationMessage.schemaId, valueSchemaId);
   }
 
   @Test
@@ -515,11 +516,11 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
         adminOperationSerializer.deserialize(ByteBuffer.wrap(valueCaptor.getValue()), schemaCaptor.getValue());
     DerivedSchemaCreation derivedSchemaCreation = (DerivedSchemaCreation) adminMessage.payloadUnion;
 
-    Assert.assertEquals(derivedSchemaCreation.clusterName.toString(), clusterName);
-    Assert.assertEquals(derivedSchemaCreation.storeName.toString(), storeName);
-    Assert.assertEquals(derivedSchemaCreation.schema.definition.toString(), derivedSchemaStr);
-    Assert.assertEquals(derivedSchemaCreation.valueSchemaId, valueSchemaId);
-    Assert.assertEquals(derivedSchemaCreation.derivedSchemaId, derivedSchemaId);
+    assertEquals(derivedSchemaCreation.clusterName.toString(), clusterName);
+    assertEquals(derivedSchemaCreation.storeName.toString(), storeName);
+    assertEquals(derivedSchemaCreation.schema.definition.toString(), derivedSchemaStr);
+    assertEquals(derivedSchemaCreation.valueSchemaId, valueSchemaId);
+    assertEquals(derivedSchemaCreation.derivedSchemaId, derivedSchemaId);
   }
 
   @Test
@@ -547,15 +548,15 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
     byte[] keyBytes = keyCaptor.getValue();
     byte[] valueBytes = valueCaptor.getValue();
     int schemaId = schemaCaptor.getValue();
-    Assert.assertEquals(schemaId, AdminOperationSerializer.LATEST_SCHEMA_ID_FOR_ADMIN_OPERATION);
-    Assert.assertEquals(keyBytes.length, 0);
+    assertEquals(schemaId, AdminOperationSerializer.LATEST_SCHEMA_ID_FOR_ADMIN_OPERATION);
+    assertEquals(keyBytes.length, 0);
 
     AdminOperation adminMessage = adminOperationSerializer.deserialize(ByteBuffer.wrap(valueBytes), schemaId);
-    Assert.assertEquals(adminMessage.operationType, AdminMessageType.DISABLE_STORE_READ.getValue());
+    assertEquals(adminMessage.operationType, AdminMessageType.DISABLE_STORE_READ.getValue());
 
     DisableStoreRead disableStoreRead = (DisableStoreRead) adminMessage.payloadUnion;
-    Assert.assertEquals(disableStoreRead.clusterName.toString(), clusterName);
-    Assert.assertEquals(disableStoreRead.storeName.toString(), storeName);
+    assertEquals(disableStoreRead.clusterName.toString(), clusterName);
+    assertEquals(disableStoreRead.storeName.toString(), storeName);
   }
 
   @Test
@@ -583,15 +584,15 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
     byte[] keyBytes = keyCaptor.getValue();
     byte[] valueBytes = valueCaptor.getValue();
     int schemaId = schemaCaptor.getValue();
-    Assert.assertEquals(schemaId, AdminOperationSerializer.LATEST_SCHEMA_ID_FOR_ADMIN_OPERATION);
-    Assert.assertEquals(keyBytes.length, 0);
+    assertEquals(schemaId, AdminOperationSerializer.LATEST_SCHEMA_ID_FOR_ADMIN_OPERATION);
+    assertEquals(keyBytes.length, 0);
 
     AdminOperation adminMessage = adminOperationSerializer.deserialize(ByteBuffer.wrap(valueBytes), schemaId);
-    Assert.assertEquals(adminMessage.operationType, AdminMessageType.DISABLE_STORE_WRITE.getValue());
+    assertEquals(adminMessage.operationType, AdminMessageType.DISABLE_STORE_WRITE.getValue());
 
     PauseStore pauseStore = (PauseStore) adminMessage.payloadUnion;
-    Assert.assertEquals(pauseStore.clusterName.toString(), clusterName);
-    Assert.assertEquals(pauseStore.storeName.toString(), storeName);
+    assertEquals(pauseStore.clusterName.toString(), clusterName);
+    assertEquals(pauseStore.storeName.toString(), storeName);
   }
 
   @Test
@@ -637,15 +638,15 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
     byte[] keyBytes = keyCaptor.getValue();
     byte[] valueBytes = valueCaptor.getValue();
     int schemaId = schemaCaptor.getValue();
-    Assert.assertEquals(schemaId, AdminOperationSerializer.LATEST_SCHEMA_ID_FOR_ADMIN_OPERATION);
-    Assert.assertEquals(keyBytes.length, 0);
+    assertEquals(schemaId, AdminOperationSerializer.LATEST_SCHEMA_ID_FOR_ADMIN_OPERATION);
+    assertEquals(keyBytes.length, 0);
 
     AdminOperation adminMessage = adminOperationSerializer.deserialize(ByteBuffer.wrap(valueBytes), schemaId);
-    Assert.assertEquals(adminMessage.operationType, AdminMessageType.ENABLE_STORE_READ.getValue());
+    assertEquals(adminMessage.operationType, AdminMessageType.ENABLE_STORE_READ.getValue());
 
     EnableStoreRead enableStoreRead = (EnableStoreRead) adminMessage.payloadUnion;
-    Assert.assertEquals(enableStoreRead.clusterName.toString(), clusterName);
-    Assert.assertEquals(enableStoreRead.storeName.toString(), storeName);
+    assertEquals(enableStoreRead.clusterName.toString(), clusterName);
+    assertEquals(enableStoreRead.storeName.toString(), storeName);
   }
 
   @Test
@@ -673,15 +674,15 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
     byte[] keyBytes = keyCaptor.getValue();
     byte[] valueBytes = valueCaptor.getValue();
     int schemaId = schemaCaptor.getValue();
-    Assert.assertEquals(schemaId, AdminOperationSerializer.LATEST_SCHEMA_ID_FOR_ADMIN_OPERATION);
-    Assert.assertEquals(keyBytes.length, 0);
+    assertEquals(schemaId, AdminOperationSerializer.LATEST_SCHEMA_ID_FOR_ADMIN_OPERATION);
+    assertEquals(keyBytes.length, 0);
 
     AdminOperation adminMessage = adminOperationSerializer.deserialize(ByteBuffer.wrap(valueBytes), schemaId);
-    Assert.assertEquals(adminMessage.operationType, AdminMessageType.ENABLE_STORE_WRITE.getValue());
+    assertEquals(adminMessage.operationType, AdminMessageType.ENABLE_STORE_WRITE.getValue());
 
     ResumeStore resumeStore = (ResumeStore) adminMessage.payloadUnion;
-    Assert.assertEquals(resumeStore.clusterName.toString(), clusterName);
-    Assert.assertEquals(resumeStore.storeName.toString(), storeName);
+    assertEquals(resumeStore.clusterName.toString(), clusterName);
+    assertEquals(resumeStore.storeName.toString(), storeName);
   }
 
   @Test
@@ -714,15 +715,15 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
     byte[] keyBytes = keyCaptor.getValue();
     byte[] valueBytes = valueCaptor.getValue();
     int schemaId = schemaCaptor.getValue();
-    Assert.assertEquals(schemaId, AdminOperationSerializer.LATEST_SCHEMA_ID_FOR_ADMIN_OPERATION);
-    Assert.assertEquals(keyBytes.length, 0);
+    assertEquals(schemaId, AdminOperationSerializer.LATEST_SCHEMA_ID_FOR_ADMIN_OPERATION);
+    assertEquals(keyBytes.length, 0);
 
     AdminOperation adminMessage = adminOperationSerializer.deserialize(ByteBuffer.wrap(valueBytes), schemaId);
-    Assert.assertEquals(adminMessage.operationType, AdminMessageType.KILL_OFFLINE_PUSH_JOB.getValue());
+    assertEquals(adminMessage.operationType, AdminMessageType.KILL_OFFLINE_PUSH_JOB.getValue());
 
     KillOfflinePushJob killJob = (KillOfflinePushJob) adminMessage.payloadUnion;
-    Assert.assertEquals(killJob.clusterName.toString(), clusterName);
-    Assert.assertEquals(killJob.kafkaTopic.toString(), pubSubTopic.getName());
+    assertEquals(killJob.clusterName.toString(), clusterName);
+    assertEquals(killJob.kafkaTopic.toString(), pubSubTopic.getName());
   }
 
   @Test
@@ -923,7 +924,7 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
           1,
           Optional.empty(),
           false);
-      Assert.assertEquals(newVersion, version);
+      assertEquals(newVersion, version);
     }
   }
 
@@ -1118,7 +1119,7 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
           Version.PushType.BATCH,
           null,
           -1);
-      Assert.assertEquals(newVersion, version);
+      assertEquals(newVersion, version);
     }
   }
 
@@ -1462,7 +1463,7 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
     ArgumentCaptor<Store> storeCaptor = ArgumentCaptor.forClass(Store.class);
     verify(storeRepo).updateStore(storeCaptor.capture());
     Store capturedStore = storeCaptor.getValue();
-    Assert.assertEquals(capturedStore.getVersions().size(), VeniceParentHelixAdmin.STORE_VERSION_RETENTION_COUNT);
+    assertEquals(capturedStore.getVersions().size(), VeniceParentHelixAdmin.STORE_VERSION_RETENTION_COUNT);
 
     for (int i = 1; i <= 3; ++i) {
       Assert.assertFalse(capturedStore.containsVersion(i));
@@ -1516,7 +1517,7 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
   public void testGetIncrementalPushVersion() {
     String storeName = "testStore";
     Version incrementalPushVersion = new VersionImpl(storeName, 1);
-    Assert.assertEquals(
+    assertEquals(
         parentAdmin.getIncrementalPushVersion(incrementalPushVersion, ExecutionStatus.COMPLETED),
         incrementalPushVersion);
 
@@ -1533,7 +1534,7 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
     }
 
     doReturn(false).when(internalAdmin).isTopicTruncated(Version.composeRealTimeTopic(storeName));
-    Assert.assertEquals(
+    assertEquals(
         parentAdmin.getIncrementalPushVersion(incrementalPushVersion, ExecutionStatus.COMPLETED),
         incrementalPushVersion);
 
@@ -1563,8 +1564,7 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
 
     // Verify clients work as expected
     for (ExecutionStatus status: ExecutionStatus.values()) {
-      Assert
-          .assertEquals(clientMap.get(status).queryJobStatus("topic", Optional.empty()).getStatus(), status.toString());
+      assertEquals(clientMap.get(status).queryJobStatus("topic", Optional.empty()).getStatus(), status.toString());
     }
     Assert.assertTrue(clientMap.get(null).queryJobStatus("topic", Optional.empty()).isError());
 
@@ -1593,72 +1593,72 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
     doReturn(Version.PushType.BATCH).when(version).getPushType();
     Admin.OfflinePushStatusInfo offlineJobStatus = parentAdmin.getOffLineJobStatus("IGNORED", "topic1_v1", completeMap);
     Map<String, String> extraInfo = offlineJobStatus.getExtraInfo();
-    Assert.assertEquals(offlineJobStatus.getExecutionStatus(), ExecutionStatus.COMPLETED);
+    assertEquals(offlineJobStatus.getExecutionStatus(), ExecutionStatus.COMPLETED);
     verify(internalAdmin, timeout(TIMEOUT_IN_MS)).truncateKafkaTopic("topic1_v1");
-    Assert.assertEquals(extraInfo.get("cluster"), ExecutionStatus.COMPLETED.toString());
-    Assert.assertEquals(extraInfo.get("cluster2"), ExecutionStatus.COMPLETED.toString());
-    Assert.assertEquals(extraInfo.get("cluster3"), ExecutionStatus.COMPLETED.toString());
+    assertEquals(extraInfo.get("cluster"), ExecutionStatus.COMPLETED.toString());
+    assertEquals(extraInfo.get("cluster2"), ExecutionStatus.COMPLETED.toString());
+    assertEquals(extraInfo.get("cluster3"), ExecutionStatus.COMPLETED.toString());
 
     completeMap.put("cluster-slow", clientMap.get(ExecutionStatus.NOT_CREATED));
     offlineJobStatus = parentAdmin.getOffLineJobStatus("IGNORED", "topic2_v1", completeMap);
     extraInfo = offlineJobStatus.getExtraInfo();
-    Assert.assertEquals(offlineJobStatus.getExecutionStatus(), ExecutionStatus.NOT_CREATED); // Do we want this to be
-                                                                                             // Progress? limitation of
-                                                                                             // ordering used in
-                                                                                             // aggregation code
+    assertEquals(offlineJobStatus.getExecutionStatus(), ExecutionStatus.NOT_CREATED); // Do we want this to be
+                                                                                      // Progress? limitation of
+                                                                                      // ordering used in
+                                                                                      // aggregation code
     verify(internalAdmin, never()).truncateKafkaTopic("topic2_v1");
-    Assert.assertEquals(extraInfo.get("cluster"), ExecutionStatus.COMPLETED.toString());
-    Assert.assertEquals(extraInfo.get("cluster2"), ExecutionStatus.COMPLETED.toString());
-    Assert.assertEquals(extraInfo.get("cluster3"), ExecutionStatus.COMPLETED.toString());
-    Assert.assertEquals(extraInfo.get("cluster-slow"), ExecutionStatus.NOT_CREATED.toString());
+    assertEquals(extraInfo.get("cluster"), ExecutionStatus.COMPLETED.toString());
+    assertEquals(extraInfo.get("cluster2"), ExecutionStatus.COMPLETED.toString());
+    assertEquals(extraInfo.get("cluster3"), ExecutionStatus.COMPLETED.toString());
+    assertEquals(extraInfo.get("cluster-slow"), ExecutionStatus.NOT_CREATED.toString());
 
     Map<String, ControllerClient> progressMap = new HashMap<>();
     progressMap.put("cluster", clientMap.get(ExecutionStatus.NOT_CREATED));
     progressMap.put("cluster3", clientMap.get(ExecutionStatus.NOT_CREATED));
     offlineJobStatus = parentAdmin.getOffLineJobStatus("IGNORED", "topic3_v1", progressMap);
     extraInfo = offlineJobStatus.getExtraInfo();
-    Assert.assertEquals(offlineJobStatus.getExecutionStatus(), ExecutionStatus.NOT_CREATED);
+    assertEquals(offlineJobStatus.getExecutionStatus(), ExecutionStatus.NOT_CREATED);
     verify(internalAdmin, never()).truncateKafkaTopic("topic3_v1");
-    Assert.assertEquals(extraInfo.get("cluster"), ExecutionStatus.NOT_CREATED.toString());
-    Assert.assertEquals(extraInfo.get("cluster3"), ExecutionStatus.NOT_CREATED.toString());
+    assertEquals(extraInfo.get("cluster"), ExecutionStatus.NOT_CREATED.toString());
+    assertEquals(extraInfo.get("cluster3"), ExecutionStatus.NOT_CREATED.toString());
 
     progressMap.put("cluster5", clientMap.get(ExecutionStatus.NEW));
     offlineJobStatus = parentAdmin.getOffLineJobStatus("IGNORED", "topic4_v1", progressMap);
     extraInfo = offlineJobStatus.getExtraInfo();
-    Assert.assertEquals(offlineJobStatus.getExecutionStatus(), ExecutionStatus.NEW);
+    assertEquals(offlineJobStatus.getExecutionStatus(), ExecutionStatus.NEW);
     verify(internalAdmin, never()).truncateKafkaTopic("topic4_v1");
-    Assert.assertEquals(extraInfo.get("cluster"), ExecutionStatus.NOT_CREATED.toString());
-    Assert.assertEquals(extraInfo.get("cluster3"), ExecutionStatus.NOT_CREATED.toString());
-    Assert.assertEquals(extraInfo.get("cluster5"), ExecutionStatus.NEW.toString());
+    assertEquals(extraInfo.get("cluster"), ExecutionStatus.NOT_CREATED.toString());
+    assertEquals(extraInfo.get("cluster3"), ExecutionStatus.NOT_CREATED.toString());
+    assertEquals(extraInfo.get("cluster5"), ExecutionStatus.NEW.toString());
 
     progressMap.put("cluster7", clientMap.get(ExecutionStatus.PROGRESS));
     offlineJobStatus = parentAdmin.getOffLineJobStatus("IGNORED", "topic5_v1", progressMap);
     extraInfo = offlineJobStatus.getExtraInfo();
-    Assert.assertEquals(offlineJobStatus.getExecutionStatus(), ExecutionStatus.PROGRESS);
+    assertEquals(offlineJobStatus.getExecutionStatus(), ExecutionStatus.PROGRESS);
     verify(internalAdmin, never()).truncateKafkaTopic("topic5_v1");
     ;
-    Assert.assertEquals(extraInfo.get("cluster7"), ExecutionStatus.PROGRESS.toString());
+    assertEquals(extraInfo.get("cluster7"), ExecutionStatus.PROGRESS.toString());
 
     progressMap.put("cluster9", clientMap.get(ExecutionStatus.STARTED));
     offlineJobStatus = parentAdmin.getOffLineJobStatus("IGNORED", "topic6_v1", progressMap);
     extraInfo = offlineJobStatus.getExtraInfo();
-    Assert.assertEquals(offlineJobStatus.getExecutionStatus(), ExecutionStatus.PROGRESS);
+    assertEquals(offlineJobStatus.getExecutionStatus(), ExecutionStatus.PROGRESS);
     verify(internalAdmin, never()).truncateKafkaTopic("topic6_v1");
-    Assert.assertEquals(extraInfo.get("cluster9"), ExecutionStatus.STARTED.toString());
+    assertEquals(extraInfo.get("cluster9"), ExecutionStatus.STARTED.toString());
 
     progressMap.put("cluster11", clientMap.get(ExecutionStatus.END_OF_PUSH_RECEIVED));
     offlineJobStatus = parentAdmin.getOffLineJobStatus("IGNORED", "topic7_v1", progressMap);
     extraInfo = offlineJobStatus.getExtraInfo();
-    Assert.assertEquals(offlineJobStatus.getExecutionStatus(), ExecutionStatus.PROGRESS);
+    assertEquals(offlineJobStatus.getExecutionStatus(), ExecutionStatus.PROGRESS);
     verify(internalAdmin, never()).truncateKafkaTopic("topic7_v1");
-    Assert.assertEquals(extraInfo.get("cluster11"), ExecutionStatus.END_OF_PUSH_RECEIVED.toString());
+    assertEquals(extraInfo.get("cluster11"), ExecutionStatus.END_OF_PUSH_RECEIVED.toString());
 
     progressMap.put("cluster13", clientMap.get(ExecutionStatus.COMPLETED));
     offlineJobStatus = parentAdmin.getOffLineJobStatus("IGNORED", "topic8_v1", progressMap);
     extraInfo = offlineJobStatus.getExtraInfo();
-    Assert.assertEquals(offlineJobStatus.getExecutionStatus(), ExecutionStatus.PROGRESS);
+    assertEquals(offlineJobStatus.getExecutionStatus(), ExecutionStatus.PROGRESS);
     verify(internalAdmin, never()).truncateKafkaTopic("topic8_v1");
-    Assert.assertEquals(extraInfo.get("cluster13"), ExecutionStatus.COMPLETED.toString());
+    assertEquals(extraInfo.get("cluster13"), ExecutionStatus.COMPLETED.toString());
 
     // 1 unreachable data center is UNKNOWN; it keeps trying until timeout
     Map<String, ControllerClient> failCompleteMap = new HashMap<>();
@@ -1668,11 +1668,11 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
     failCompleteMap.put("failcluster", clientMap.get(null));
     offlineJobStatus = parentAdmin.getOffLineJobStatus("mycluster", "topic8_v1", failCompleteMap);
     extraInfo = offlineJobStatus.getExtraInfo();
-    Assert.assertEquals(offlineJobStatus.getExecutionStatus(), ExecutionStatus.UNKNOWN);
-    Assert.assertEquals(extraInfo.get("cluster"), ExecutionStatus.COMPLETED.toString());
-    Assert.assertEquals(extraInfo.get("cluster2"), ExecutionStatus.COMPLETED.toString());
-    Assert.assertEquals(extraInfo.get("cluster3"), ExecutionStatus.COMPLETED.toString());
-    Assert.assertEquals(extraInfo.get("failcluster"), ExecutionStatus.UNKNOWN.toString());
+    assertEquals(offlineJobStatus.getExecutionStatus(), ExecutionStatus.UNKNOWN);
+    assertEquals(extraInfo.get("cluster"), ExecutionStatus.COMPLETED.toString());
+    assertEquals(extraInfo.get("cluster2"), ExecutionStatus.COMPLETED.toString());
+    assertEquals(extraInfo.get("cluster3"), ExecutionStatus.COMPLETED.toString());
+    assertEquals(extraInfo.get("failcluster"), ExecutionStatus.UNKNOWN.toString());
 
     // 2 problematic fabrics. One is failing completely and one is returning error response. It should still get the
     // status of other fabrics and return UNKNOWN for the unreachable fabrics.
@@ -1683,10 +1683,10 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
     failCompleteMap.put("completelyFailingFabric", completelyFailingClient);
     offlineJobStatus = parentAdmin.getOffLineJobStatus("mycluster", "topic8_v1", failCompleteMap);
     extraInfo = offlineJobStatus.getExtraInfo();
-    Assert.assertEquals(extraInfo.get("fabric1"), ExecutionStatus.COMPLETED.toString());
-    Assert.assertEquals(extraInfo.get("fabric2"), ExecutionStatus.COMPLETED.toString());
-    Assert.assertEquals(extraInfo.get("failFabric"), ExecutionStatus.UNKNOWN.toString());
-    Assert.assertEquals(extraInfo.get("completelyFailingFabric"), ExecutionStatus.UNKNOWN.toString());
+    assertEquals(extraInfo.get("fabric1"), ExecutionStatus.COMPLETED.toString());
+    assertEquals(extraInfo.get("fabric2"), ExecutionStatus.COMPLETED.toString());
+    assertEquals(extraInfo.get("failFabric"), ExecutionStatus.UNKNOWN.toString());
+    assertEquals(extraInfo.get("completelyFailingFabric"), ExecutionStatus.UNKNOWN.toString());
     Assert.assertTrue(
         offlineJobStatus.getExtraDetails().get("completelyFailingFabric").contains(completelyFailingExceptionMessage));
 
@@ -1695,38 +1695,38 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
     offlineJobStatus = parentAdmin.getOffLineJobStatus("mycluster", "topic10_v1", errorMap);
     extraInfo = offlineJobStatus.getExtraInfo();
     verify(internalAdmin, timeout(TIMEOUT_IN_MS)).truncateKafkaTopic("topic10_v1");
-    Assert.assertEquals(offlineJobStatus.getExecutionStatus(), ExecutionStatus.ERROR);
-    Assert.assertEquals(extraInfo.get("cluster-err"), ExecutionStatus.ERROR.toString());
+    assertEquals(offlineJobStatus.getExecutionStatus(), ExecutionStatus.ERROR);
+    assertEquals(extraInfo.get("cluster-err"), ExecutionStatus.ERROR.toString());
 
     errorMap.put("cluster-complete", clientMap.get(ExecutionStatus.COMPLETED));
     offlineJobStatus = parentAdmin.getOffLineJobStatus("mycluster", "topic11_v1", errorMap);
     extraInfo = offlineJobStatus.getExtraInfo();
     verify(internalAdmin, timeout(TIMEOUT_IN_MS)).truncateKafkaTopic("topic11_v1");
-    Assert.assertEquals(offlineJobStatus.getExecutionStatus(), ExecutionStatus.ERROR);
-    Assert.assertEquals(extraInfo.get("cluster-complete"), ExecutionStatus.COMPLETED.toString());
+    assertEquals(offlineJobStatus.getExecutionStatus(), ExecutionStatus.ERROR);
+    assertEquals(extraInfo.get("cluster-complete"), ExecutionStatus.COMPLETED.toString());
 
     // Test whether errored topics will be truncated or not when 'maxErroredTopicNumToKeep' is > 0.
     parentAdmin.setMaxErroredTopicNumToKeep(2);
     offlineJobStatus = parentAdmin.getOffLineJobStatus("mycluster", "topic12_v1", errorMap);
     extraInfo = offlineJobStatus.getExtraInfo();
     verify(internalAdmin, never()).truncateKafkaTopic("topic12_v1");
-    Assert.assertEquals(offlineJobStatus.getExecutionStatus(), ExecutionStatus.ERROR);
+    assertEquals(offlineJobStatus.getExecutionStatus(), ExecutionStatus.ERROR);
     // Reset
     parentAdmin.setMaxErroredTopicNumToKeep(0);
 
     errorMap.put("cluster-new", clientMap.get(ExecutionStatus.NEW));
     offlineJobStatus = parentAdmin.getOffLineJobStatus("mycluster", "topic13_v1", errorMap);
     extraInfo = offlineJobStatus.getExtraInfo();
-    Assert.assertEquals(offlineJobStatus.getExecutionStatus(), ExecutionStatus.NEW); // Do we want this to be Progress?
-                                                                                     // limitation of ordering used in
-                                                                                     // aggregation code
-    Assert.assertEquals(extraInfo.get("cluster-new"), ExecutionStatus.NEW.toString());
+    assertEquals(offlineJobStatus.getExecutionStatus(), ExecutionStatus.NEW); // Do we want this to be Progress?
+                                                                              // limitation of ordering used in
+                                                                              // aggregation code
+    assertEquals(extraInfo.get("cluster-new"), ExecutionStatus.NEW.toString());
 
     doReturn(true).when(store).isIncrementalPushEnabled();
     doReturn(store).when(internalAdmin).getStore(anyString(), anyString());
     completeMap.remove("cluster-slow");
     offlineJobStatus = parentAdmin.getOffLineJobStatus("IGNORED", "topic2_v1", completeMap);
-    Assert.assertEquals(offlineJobStatus.getExecutionStatus(), ExecutionStatus.COMPLETED);
+    assertEquals(offlineJobStatus.getExecutionStatus(), ExecutionStatus.COMPLETED);
     verify(internalAdmin, timeout(TIMEOUT_IN_MS)).truncateKafkaTopic("topic2_v1");
 
   }
@@ -1758,14 +1758,14 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
     byte[] keyBytes = keyCaptor.getValue();
     byte[] valueBytes = valueCaptor.getValue();
     int schemaId = schemaCaptor.getValue();
-    Assert.assertEquals(schemaId, AdminOperationSerializer.LATEST_SCHEMA_ID_FOR_ADMIN_OPERATION);
-    Assert.assertEquals(keyBytes.length, 0);
+    assertEquals(schemaId, AdminOperationSerializer.LATEST_SCHEMA_ID_FOR_ADMIN_OPERATION);
+    assertEquals(keyBytes.length, 0);
 
     AdminOperation adminMessage = adminOperationSerializer.deserialize(ByteBuffer.wrap(valueBytes), schemaId);
-    Assert.assertEquals(adminMessage.operationType, AdminMessageType.UPDATE_STORE.getValue());
+    assertEquals(adminMessage.operationType, AdminMessageType.UPDATE_STORE.getValue());
 
     UpdateStore updateStore = (UpdateStore) adminMessage.payloadUnion;
-    Assert.assertEquals(updateStore.incrementalPushEnabled, true);
+    assertEquals(updateStore.incrementalPushEnabled, true);
     Assert.assertTrue(updateStore.blobTransferEnabled);
 
     long readQuota = 100L;
@@ -1795,31 +1795,28 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
     schemaId = schemaCaptor.getValue();
     adminMessage = adminOperationSerializer.deserialize(ByteBuffer.wrap(valueBytes), schemaId);
     updateStore = (UpdateStore) adminMessage.payloadUnion;
-    Assert.assertEquals(updateStore.clusterName.toString(), clusterName);
-    Assert.assertEquals(updateStore.storeName.toString(), storeName);
-    Assert.assertEquals(updateStore.readQuotaInCU, readQuota, "New read quota should be written into kafka message.");
-    Assert.assertEquals(
-        updateStore.enableReads,
-        readability,
-        "New read readability should be written into kafka message.");
-    Assert.assertEquals(
+    assertEquals(updateStore.clusterName.toString(), clusterName);
+    assertEquals(updateStore.storeName.toString(), storeName);
+    assertEquals(updateStore.readQuotaInCU, readQuota, "New read quota should be written into kafka message.");
+    assertEquals(updateStore.enableReads, readability, "New read readability should be written into kafka message.");
+    assertEquals(
         updateStore.currentVersion,
         AdminConsumptionTask.IGNORED_CURRENT_VERSION,
         "As we don't pass any current version into updateStore, a magic version number should be used to prevent current version being overrided in prod region.");
     Assert.assertNotNull(
         updateStore.hybridStoreConfig,
         "Hybrid store config should result in something not null in the avro object");
-    Assert.assertEquals(updateStore.hybridStoreConfig.rewindTimeInSeconds, 135L);
-    Assert.assertEquals(updateStore.hybridStoreConfig.offsetLagThresholdToGoOnline, 2000L);
-    Assert.assertEquals(updateStore.hybridStoreConfig.bufferReplayPolicy, REWIND_FROM_SOP.getValue());
-    Assert.assertEquals(updateStore.accessControlled, accessControlled);
-    Assert.assertEquals(updateStore.bootstrapToOnlineTimeoutInHours, 48);
-    Assert.assertEquals(updateStore.partitionerConfig.amplificationFactor, 1);
-    Assert.assertEquals(updateStore.partitionerConfig.partitionerParams.toString(), testPartitionerParams.toString());
-    Assert.assertEquals(
+    assertEquals(updateStore.hybridStoreConfig.rewindTimeInSeconds, 135L);
+    assertEquals(updateStore.hybridStoreConfig.offsetLagThresholdToGoOnline, 2000L);
+    assertEquals(updateStore.hybridStoreConfig.bufferReplayPolicy, REWIND_FROM_SOP.getValue());
+    assertEquals(updateStore.accessControlled, accessControlled);
+    assertEquals(updateStore.bootstrapToOnlineTimeoutInHours, 48);
+    assertEquals(updateStore.partitionerConfig.amplificationFactor, 1);
+    assertEquals(updateStore.partitionerConfig.partitionerParams.toString(), testPartitionerParams.toString());
+    assertEquals(
         updateStore.partitionerConfig.partitionerClass.toString(),
         "com.linkedin.venice.partitioner.DefaultVenicePartitioner");
-    Assert.assertEquals(updateStore.replicationFactor, 2);
+    assertEquals(updateStore.replicationFactor, 2);
     Assert.assertFalse(updateStore.blobTransferEnabled);
     // Disable Access Control
     accessControlled = false;
@@ -1830,7 +1827,7 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
     schemaId = schemaCaptor.getValue();
     adminMessage = adminOperationSerializer.deserialize(ByteBuffer.wrap(valueBytes), schemaId);
     updateStore = (UpdateStore) adminMessage.payloadUnion;
-    Assert.assertEquals(updateStore.accessControlled, accessControlled);
+    assertEquals(updateStore.accessControlled, accessControlled);
 
     // Update the store twice with the same parameter to make sure get methods in UpdateStoreQueryParams class can work
     // properly.
@@ -1857,8 +1854,8 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
       Assert.assertTrue(e.getClass().isAssignableFrom(VeniceHttpException.class));
       Assert.assertTrue(e instanceof VeniceHttpException);
       VeniceHttpException veniceHttpException = (VeniceHttpException) e;
-      Assert.assertEquals(veniceHttpException.getHttpStatusCode(), HttpStatus.SC_BAD_REQUEST);
-      Assert.assertEquals(veniceHttpException.getErrorType(), ErrorType.INVALID_SCHEMA);
+      assertEquals(veniceHttpException.getHttpStatusCode(), HttpStatus.SC_BAD_REQUEST);
+      assertEquals(veniceHttpException.getErrorType(), ErrorType.INVALID_SCHEMA);
     }
   }
 
@@ -1888,7 +1885,7 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
     int schemaId = schemaCaptor.getValue();
     AdminOperation adminMessage = adminOperationSerializer.deserialize(ByteBuffer.wrap(valueBytes), schemaId);
     UpdateStore updateStore = (UpdateStore) adminMessage.payloadUnion;
-    Assert.assertEquals(
+    assertEquals(
         updateStore.nativeReplicationSourceFabric.toString(),
         "dc1",
         "Native replication source fabric does not match after updating the store!");
@@ -2023,9 +2020,9 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
     int schemaId = schemaCaptor.getValue();
     AdminOperation adminMessage = adminOperationSerializer.deserialize(ByteBuffer.wrap(valueBytes), schemaId);
     UpdateStore updateStore = (UpdateStore) adminMessage.payloadUnion;
-    Assert.assertEquals(updateStore.getViews().size(), 2);
+    assertEquals(updateStore.getViews().size(), 2);
     Assert.assertTrue(updateStore.getViews().containsKey("changeCapture"));
-    Assert.assertEquals(
+    assertEquals(
         updateStore.getViews().get("changeCapture").viewClassName.toString(),
         ChangeCaptureView.class.getCanonicalName());
     Assert.assertTrue(updateStore.getViews().get("changeCapture").viewParameters.isEmpty());
@@ -2065,7 +2062,7 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
     int schemaId = schemaCaptor.getValue();
     AdminOperation adminMessage = adminOperationSerializer.deserialize(ByteBuffer.wrap(valueBytes), schemaId);
     UpdateStore updateStore = (UpdateStore) adminMessage.payloadUnion;
-    Assert.assertEquals(updateStore.getViews().size(), 0);
+    assertEquals(updateStore.getViews().size(), 0);
   }
 
   @Test
@@ -2148,16 +2145,16 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
     byte[] keyBytes = keyCaptor.getValue();
     byte[] valueBytes = valueCaptor.getValue();
     int schemaId = schemaCaptor.getValue();
-    Assert.assertEquals(schemaId, AdminOperationSerializer.LATEST_SCHEMA_ID_FOR_ADMIN_OPERATION);
-    Assert.assertEquals(keyBytes.length, 0);
+    assertEquals(schemaId, AdminOperationSerializer.LATEST_SCHEMA_ID_FOR_ADMIN_OPERATION);
+    assertEquals(keyBytes.length, 0);
 
     AdminOperation adminMessage = adminOperationSerializer.deserialize(ByteBuffer.wrap(valueBytes), schemaId);
-    Assert.assertEquals(adminMessage.operationType, AdminMessageType.DELETE_STORE.getValue());
+    assertEquals(adminMessage.operationType, AdminMessageType.DELETE_STORE.getValue());
 
     DeleteStore deleteStore = (DeleteStore) adminMessage.payloadUnion;
-    Assert.assertEquals(deleteStore.clusterName.toString(), clusterName);
-    Assert.assertEquals(deleteStore.storeName.toString(), storeName);
-    Assert.assertEquals(deleteStore.largestUsedVersionNumber, 0);
+    assertEquals(deleteStore.clusterName.toString(), clusterName);
+    assertEquals(deleteStore.storeName.toString(), storeName);
+    assertEquals(deleteStore.largestUsedVersionNumber, 0);
   }
 
   @Test
@@ -2166,9 +2163,9 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
     Map<String, ControllerClient> controllerClientMap = prepareForCurrentVersionTest(regionCount);
     Map<String, Integer> result =
         parentAdmin.getCurrentVersionForMultiRegions(clusterName, "test", controllerClientMap);
-    Assert.assertEquals(result.size(), regionCount, "Should return the current versions for all regions.");
+    assertEquals(result.size(), regionCount, "Should return the current versions for all regions.");
     for (int i = 0; i < regionCount; i++) {
-      Assert.assertEquals(result.get("region" + i).intValue(), i);
+      assertEquals(result.get("region" + i).intValue(), i);
     }
   }
 
@@ -2184,11 +2181,11 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
 
     Map<String, Integer> result =
         parentAdmin.getCurrentVersionForMultiRegions(clusterName, "test", controllerClientMap);
-    Assert.assertEquals(result.size(), regionCount, "Should return the current versions for all regions.");
+    assertEquals(result.size(), regionCount, "Should return the current versions for all regions.");
     for (int i = 0; i < regionCount - 1; i++) {
-      Assert.assertEquals(result.get("region" + i).intValue(), i);
+      assertEquals(result.get("region" + i).intValue(), i);
     }
-    Assert.assertEquals(
+    assertEquals(
         result.get("region4").intValue(),
         AdminConsumptionTask.IGNORED_CURRENT_VERSION,
         "Met an error while querying a current version from a region, should return -1.");
@@ -2223,7 +2220,7 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
     versionTopics = parentAdmin.getKafkaTopicsByAge(storeName);
     Assert.assertFalse(versionTopics.isEmpty());
     PubSubTopic latestTopic = versionTopics.get(0);
-    Assert.assertEquals(latestTopic, pubSubTopicRepository.getTopic(storeName + "_v3"));
+    assertEquals(latestTopic, pubSubTopicRepository.getTopic(storeName + "_v3"));
     Assert.assertTrue(topicList.containsAll(versionTopics));
     Assert.assertTrue(versionTopics.containsAll(topicList));
   }
@@ -2284,7 +2281,7 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
         .getOffLinePushStatus(clusterName, latestTopic);
     Optional<String> currentPush = mockParentAdmin.getTopicForCurrentPushJob(clusterName, storeName, false, false);
     Assert.assertTrue(currentPush.isPresent());
-    Assert.assertEquals(currentPush.get(), latestTopic);
+    assertEquals(currentPush.get(), latestTopic);
     verify(mockParentAdmin, times(2)).getOffLinePushStatus(clusterName, latestTopic);
 
     // When there is a regular topic and the job status is 'UNKNOWN' in some region,
@@ -2305,7 +2302,7 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
         .getOffLinePushStatus(clusterName, latestTopic);
     currentPush = mockParentAdmin.getTopicForCurrentPushJob(clusterName, storeName, false, false);
     Assert.assertTrue(currentPush.isPresent());
-    Assert.assertEquals(currentPush.get(), latestTopic);
+    assertEquals(currentPush.get(), latestTopic);
     verify(mockParentAdmin, times(12)).getOffLinePushStatus(clusterName, latestTopic);
 
     // When there is a regular topic and the job status is 'UNKNOWN' in some region for the first time,
@@ -2317,7 +2314,7 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
         .thenReturn(new Admin.OfflinePushStatusInfo(ExecutionStatus.PROGRESS));
     currentPush = mockParentAdmin.getTopicForCurrentPushJob(clusterName, storeName, false, false);
     Assert.assertTrue(currentPush.isPresent());
-    Assert.assertEquals(currentPush.get(), latestTopic);
+    assertEquals(currentPush.get(), latestTopic);
     verify(mockParentAdmin, times(14)).getOffLinePushStatus(clusterName, latestTopic);
 
     // When there is a regular topic, but there is no corresponding version
@@ -2505,7 +2502,7 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
           Assert.assertFalse(partialMockParentAdmin.isJobKilled(version.kafkaTopicName()));
         }
       } else {
-        Assert.assertEquals(
+        assertEquals(
             partialMockParentAdmin.incrementVersionIdempotent(
                 clusterName,
                 storeName,
@@ -2590,14 +2587,14 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
       Assert.assertTrue(e.getMessage().contains("due to existing exception"));
     }
     // store B should still be able to process admin operations.
-    Assert.assertEquals(
+    assertEquals(
         parentAdmin.incrementVersionIdempotent(clusterName, storeB, "", 3, 3),
         storeBVersion,
         "Unexpected new version returned");
 
     doReturn(null).when(internalAdmin).getLastExceptionForStore(clusterName, storeA);
     // Store A is unblocked and should be able to process admin operations now.
-    Assert.assertEquals(
+    assertEquals(
         parentAdmin.incrementVersionIdempotent(clusterName, storeA, "", 3, 3),
         storeAVersion,
         "Unexpected new version returned");
@@ -2646,15 +2643,15 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
     byte[] keyBytes = keyCaptor.getValue();
     byte[] valueBytes = valueCaptor.getValue();
     int schemaId = schemaCaptor.getValue();
-    Assert.assertEquals(schemaId, AdminOperationSerializer.LATEST_SCHEMA_ID_FOR_ADMIN_OPERATION);
-    Assert.assertEquals(keyBytes.length, 0);
+    assertEquals(schemaId, AdminOperationSerializer.LATEST_SCHEMA_ID_FOR_ADMIN_OPERATION);
+    assertEquals(keyBytes.length, 0);
 
     AdminOperation adminMessage = adminOperationSerializer.deserialize(ByteBuffer.wrap(valueBytes), schemaId);
-    Assert.assertEquals(adminMessage.operationType, AdminMessageType.UPDATE_STORE.getValue());
+    assertEquals(adminMessage.operationType, AdminMessageType.UPDATE_STORE.getValue());
 
     UpdateStore updateStore = (UpdateStore) adminMessage.payloadUnion;
-    Assert.assertEquals(updateStore.hybridStoreConfig.offsetLagThresholdToGoOnline, 20000);
-    Assert.assertEquals(updateStore.hybridStoreConfig.rewindTimeInSeconds, 60);
+    assertEquals(updateStore.hybridStoreConfig.offsetLagThresholdToGoOnline, 20000);
+    assertEquals(updateStore.hybridStoreConfig.rewindTimeInSeconds, 60);
 
     store.setHybridStoreConfig(
         new HybridStoreConfigImpl(
@@ -2734,12 +2731,12 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
     doReturn(s).when(internalAdmin).getStore(anyString(), anyString());
 
     RegionPushDetails details = internalAdmin.getRegionPushDetails(clusterName, storeName, true);
-    Assert.assertEquals(details.getPushEndTimestamp(), now.plusHours(1).toString());
-    Assert.assertEquals(details.getVersions().size(), 1);
-    Assert.assertEquals(details.getCurrentVersion().intValue(), 1);
-    Assert.assertEquals(details.getPartitionDetails().size(), numOfPartition);
+    assertEquals(details.getPushEndTimestamp(), now.plusHours(1).toString());
+    assertEquals(details.getVersions().size(), 1);
+    assertEquals(details.getCurrentVersion().intValue(), 1);
+    assertEquals(details.getPartitionDetails().size(), numOfPartition);
     for (int i = 0; i < numOfPartition; i++) {
-      Assert.assertEquals(details.getPartitionDetails().get(i).getReplicaDetails().size(), replicationFactor);
+      assertEquals(details.getPartitionDetails().get(i).getReplicaDetails().size(), replicationFactor);
     }
 
     doReturn(null).when(internalAdmin).getStore(anyString(), anyString());
@@ -2768,9 +2765,7 @@ public class TestVeniceParentHelixAdmin extends AbstractTestVeniceParentHelixAdm
           -1);
       Assert.fail("Test should fail, but doesn't");
     } catch (VeniceException e) {
-      Assert.assertEquals(
-          e.getMessage(),
-          "One of the targeted region invalidRegion is not a valid region in cluster test");
+      assertEquals(e.getMessage(), "One of the targeted region invalidRegion is not a valid region in cluster test");
     }
   }
 


### PR DESCRIPTION
## Summary
1. per region status returned by controller holds `ExecutionStatus` data, but is read as `PushJobDetailsStatus`. Have been working so far coincidently based on the resulting statuses, but adding new DVC statues uncovered this issue. Added a method to transform `ExecutionStatus` to `PushJobDetailsStatus` after reading in VPJ.
2. `VeniceHelixAdmin.STATUS_PRIORITIES` didn't include the new DVC error status resulting in these returning as ERROR and these new statuses were not getting checkpointed. Added these and added unit tests to check for proper returns.

## How was this PR tested?
GH CI

## Does this PR introduce any user-facing changes?
- [] No. You can skip the rest of this section.
- [] Yes. Make sure to explain your proposed changes and call out the behavior change.