### PR TITLE
[controller][server][client][test] Adds a new checksum type ADHASH for data integrity validation

### DIFF
--- a/internal/venice-common/src/main/java/com/linkedin/venice/kafka/validation/checksum/AdHash.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/kafka/validation/checksum/AdHash.java
@@ -5,7 +5,7 @@ import java.util.zip.CRC32;
 
 
 /**
- * This incremental digest is used to keep track of the checksum of the data incrementally.
+ * This class AdHash is used to keep track of the checksum of the data incrementally.
  * It adopts the idea of AdHash that:
  * " A message x' which I want to hash may be a simple modification of a message x which I previously
  *   hashed. If I have already computed the hash f(x) of x then, rather than re-computing f(x') from
@@ -21,15 +21,15 @@ import java.util.zip.CRC32;
  *   (https://dl.acm.org/doi/abs/10.1145/3578358.3591328)
  */
 
-public class IncDigestCheckSum extends CheckSum {
+public class AdHash extends CheckSum {
   private volatile long incrementalDigest;
   private final CRC32 crc32 = new CRC32();
 
-  public IncDigestCheckSum() {
+  public AdHash() {
     incrementalDigest = 0;
   }
 
-  public IncDigestCheckSum(byte[] encodedState) {
+  public AdHash(byte[] encodedState) {
     incrementalDigest = ByteUtils.readLong(encodedState, 0);
   }
 
@@ -63,7 +63,7 @@ public class IncDigestCheckSum extends CheckSum {
 
   @Override
   public CheckSumType getType() {
-    return CheckSumType.INCDIGEST;
+    return CheckSumType.ADHASH;
   }
 
   @Override

--- a/internal/venice-common/src/main/java/com/linkedin/venice/kafka/validation/checksum/CheckSum.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/kafka/validation/checksum/CheckSum.java
@@ -132,6 +132,8 @@ public abstract class CheckSum {
         return new CRC32CheckSum();
       case MD5:
         return new MD5CheckSum();
+      case INCDIGEST:
+        return new IncDigestCheckSum();
       default:
         return null;
     }
@@ -144,6 +146,8 @@ public abstract class CheckSum {
           return null;
         case MD5:
           return new MD5CheckSum(encodedState);
+        case INCDIGEST:
+          return new IncDigestCheckSum(encodedState);
         default:
           return null;
       }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/kafka/validation/checksum/CheckSum.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/kafka/validation/checksum/CheckSum.java
@@ -132,8 +132,8 @@ public abstract class CheckSum {
         return new CRC32CheckSum();
       case MD5:
         return new MD5CheckSum();
-      case INCDIGEST:
-        return new IncDigestCheckSum();
+      case ADHASH:
+        return new AdHash();
       default:
         return null;
     }
@@ -146,8 +146,8 @@ public abstract class CheckSum {
           return null;
         case MD5:
           return new MD5CheckSum(encodedState);
-        case INCDIGEST:
-          return new IncDigestCheckSum(encodedState);
+        case ADHASH:
+          return new AdHash(encodedState);
         default:
           return null;
       }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/kafka/validation/checksum/CheckSumType.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/kafka/validation/checksum/CheckSumType.java
@@ -11,7 +11,7 @@ import java.util.Map;
 public enum CheckSumType {
   NONE(0, true), MD5(1, true), @Deprecated
   ADLER32(2, false), @Deprecated
-  CRC32(3, false), INCDIGEST(4, true);
+  CRC32(3, false), ADHASH(4, true);
 
   /** The value is the byte used on the wire format */
   private final int value;

--- a/internal/venice-common/src/main/java/com/linkedin/venice/kafka/validation/checksum/CheckSumType.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/kafka/validation/checksum/CheckSumType.java
@@ -11,7 +11,7 @@ import java.util.Map;
 public enum CheckSumType {
   NONE(0, true), MD5(1, true), @Deprecated
   ADLER32(2, false), @Deprecated
-  CRC32(3, false);
+  CRC32(3, false), INCDIGEST(4, true);
 
   /** The value is the byte used on the wire format */
   private final int value;

--- a/internal/venice-common/src/main/java/com/linkedin/venice/kafka/validation/checksum/IncDigestCheckSum.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/kafka/validation/checksum/IncDigestCheckSum.java
@@ -1,0 +1,73 @@
+package com.linkedin.venice.kafka.validation.checksum;
+
+import com.linkedin.venice.utils.ByteUtils;
+import java.util.zip.CRC32;
+
+
+/**
+ * This incremental digest is used to keep track of the checksum of the data incrementally.
+ * It adopts the idea of AdHash that:
+ * " A message x' which I want to hash may be a simple modification of a message x which I previously
+ *   hashed. If I have already computed the hash f(x) of x then, rather than re-computing f(x') from
+ *   scratch, I would like to just quickly 'update' the old hash value f(x) to the new value f(x').
+ *   An incremental hash function is one that permits this. "
+ *
+ * See the paper for details:
+ *   A New Paradigm for Collision-free Hashing: Incrementality at Reduced Cost.
+ *   (https://cseweb.ucsd.edu/~daniele/papers/IncHash.pdf)
+ *
+ * Its adoption in ZooKeeper:
+ *   Verify, And Then Trust: Data Inconsistency Detection in ZooKeeper.
+ *   (https://dl.acm.org/doi/abs/10.1145/3578358.3591328)
+ */
+
+public class IncDigestCheckSum extends CheckSum {
+  private volatile long incrementalDigest;
+  private final CRC32 crc32 = new CRC32();
+
+  public IncDigestCheckSum() {
+    incrementalDigest = 0;
+  }
+
+  public IncDigestCheckSum(byte[] encodedState) {
+    incrementalDigest = ByteUtils.readLong(encodedState, 0);
+  }
+
+  @Override
+  public byte[] getFinalCheckSum() {
+    byte[] finalCheckSum = new byte[ByteUtils.SIZE_OF_LONG];
+    ByteUtils.writeLong(finalCheckSum, incrementalDigest, 0);
+    return finalCheckSum;
+  }
+
+  /**
+   * Update the checksum with the input data. Notice that the internal CRC32 object is
+   * reset everytime before updating the checksum. This is to ensure that the checksum
+   * is always calculated from the beginning of the data and checkpoint-able.
+   * This is not thread-safe, but the caller should ensure that the object is not shared.
+   */
+  @Override
+  public void updateChecksum(byte[] input, int startIndex, int length) {
+    crc32.reset(); // reset the digest.
+    crc32.update(input, startIndex, length);
+
+    // incrementingDigest overflow can happen, but that is fine, we can let the long integer to rotate.
+    incrementalDigest += crc32.getValue();
+  }
+
+  @Override
+  public void resetInternal() {
+    crc32.reset();
+    incrementalDigest = 0;
+  }
+
+  @Override
+  public CheckSumType getType() {
+    return CheckSumType.INCDIGEST;
+  }
+
+  @Override
+  public byte[] getEncodedState() {
+    return getFinalCheckSum();
+  }
+}

--- a/internal/venice-common/src/test/java/com/linkedin/venice/kafka/validation/checksum/TestCheckSum.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/kafka/validation/checksum/TestCheckSum.java
@@ -1,15 +1,16 @@
 package com.linkedin.venice.kafka.validation.checksum;
 
 import com.linkedin.venice.exceptions.VeniceException;
+import com.linkedin.venice.utils.DataProviderUtils;
 import java.util.Arrays;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
 
 public class TestCheckSum {
-  @Test
-  public void testCheckSum() {
-    CheckSum checkSum = CheckSum.getInstance(CheckSumType.MD5);
+  @Test(dataProvider = "CheckpointingSupported-CheckSum-Types", dataProviderClass = DataProviderUtils.class)
+  public void testCheckSum(CheckSumType checkSumType) {
+    CheckSum checkSum = CheckSum.getInstance(checkSumType);
 
     checkSum.update(1);
 

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/CheckSumTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/CheckSumTest.java
@@ -1,0 +1,247 @@
+package com.linkedin.venice.endToEnd;
+
+import static com.linkedin.davinci.store.rocksdb.RocksDBServerConfig.ROCKSDB_PLAIN_TABLE_FORMAT_ENABLED;
+import static com.linkedin.venice.ConfigKeys.*;
+import static com.linkedin.venice.utils.IntegrationTestPushUtils.createStoreForJob;
+import static com.linkedin.venice.utils.IntegrationTestPushUtils.defaultVPJProps;
+import static com.linkedin.venice.utils.IntegrationTestPushUtils.getSamzaProducer;
+import static com.linkedin.venice.utils.IntegrationTestPushUtils.runVPJ;
+import static com.linkedin.venice.utils.IntegrationTestPushUtils.sendCustomSizeStreamingRecord;
+import static com.linkedin.venice.utils.TestWriteUtils.getTempDataDirectory;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+
+import com.linkedin.venice.client.store.AvroGenericStoreClient;
+import com.linkedin.venice.client.store.ClientConfig;
+import com.linkedin.venice.client.store.ClientFactory;
+import com.linkedin.venice.controllerapi.ControllerClient;
+import com.linkedin.venice.controllerapi.ControllerResponse;
+import com.linkedin.venice.controllerapi.UpdateStoreQueryParams;
+import com.linkedin.venice.exceptions.VeniceException;
+import com.linkedin.venice.integration.utils.ServiceFactory;
+import com.linkedin.venice.integration.utils.VeniceClusterWrapper;
+import com.linkedin.venice.integration.utils.VeniceControllerCreateOptions;
+import com.linkedin.venice.integration.utils.VeniceControllerWrapper;
+import com.linkedin.venice.integration.utils.ZkServerWrapper;
+import com.linkedin.venice.kafka.validation.checksum.CheckSumType;
+import com.linkedin.venice.meta.PersistenceType;
+import com.linkedin.venice.meta.Version;
+import com.linkedin.venice.pubsub.PubSubTopicRepository;
+import com.linkedin.venice.utils.Pair;
+import com.linkedin.venice.utils.TestUtils;
+import com.linkedin.venice.utils.TestWriteUtils;
+import com.linkedin.venice.utils.Time;
+import com.linkedin.venice.utils.Utils;
+import com.linkedin.venice.writer.VeniceWriter;
+import java.io.File;
+import java.io.IOException;
+import java.util.Properties;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import org.apache.avro.Schema;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.samza.system.SystemProducer;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+
+public class CheckSumTest {
+  private static final Logger LOGGER = LogManager.getLogger(CheckSumTest.class);
+  public static final int NUMBER_OF_SERVERS = 3;
+  public static final int STREAMING_RECORD_SIZE = 1024;
+
+  private VeniceClusterWrapper veniceCluster;
+  ZkServerWrapper parentZk = null;
+  VeniceControllerWrapper parentController = null;
+  protected final PubSubTopicRepository pubSubTopicRepository = new PubSubTopicRepository();
+
+  @BeforeClass(alwaysRun = true)
+  public void setUp() {
+    veniceCluster = setUpCluster();
+  }
+
+  @AfterClass(alwaysRun = true)
+  public void cleanUp() {
+    parentController.close();
+    parentZk.close();
+    Utils.closeQuietlyWithErrorLogged(veniceCluster);
+  }
+
+  private VeniceClusterWrapper setUpCluster() {
+    Properties extraProperties = new Properties();
+    extraProperties.setProperty(DEFAULT_MAX_NUMBER_OF_PARTITIONS, "5");
+    VeniceClusterWrapper cluster = ServiceFactory.getVeniceCluster(1, 0, 1, 1, 1000000, false, false, extraProperties);
+
+    // Add Venice Router
+    Properties routerProperties = new Properties();
+    cluster.addVeniceRouter(routerProperties);
+
+    // Add Venice Server
+    Properties serverProperties = new Properties();
+    serverProperties.setProperty(PERSISTENCE_TYPE, PersistenceType.ROCKS_DB.name());
+    serverProperties.setProperty(SERVER_PROMOTION_TO_LEADER_REPLICA_DELAY_SECONDS, Long.toString(1L));
+    serverProperties.setProperty(ROCKSDB_PLAIN_TABLE_FORMAT_ENABLED, "false");
+    serverProperties.setProperty(SERVER_DATABASE_CHECKSUM_VERIFICATION_ENABLED, "true");
+    serverProperties.setProperty(SERVER_DATABASE_SYNC_BYTES_INTERNAL_FOR_DEFERRED_WRITE_MODE, "300");
+
+    serverProperties.setProperty(SSL_TO_KAFKA_LEGACY, "false");
+
+    // Set the VeniceWriter to use the ADHASH checksum.
+    serverProperties.setProperty(VeniceWriter.CHECK_SUM_TYPE, CheckSumType.ADHASH.name());
+
+    for (int i = 0; i < NUMBER_OF_SERVERS; i++) {
+      cluster.addVeniceServer(new Properties(), serverProperties);
+    }
+    return cluster;
+  }
+
+  /**
+   * Test the checksum feature by creating two stores with different checksum types and producing records to them.
+   * <ul>
+   * <li> Set CHECK_SUM_TYPE to {@link CheckSumType#ADHASH} in the server properties.
+   * <li> Create two stores with different checksum types in the VPJ.
+   * <li> Verify that records can be read from the both stores.
+   * <li> Produce records to the rt topic of the first store with CheckSumType set to {@link CheckSumType#ADHASH}.
+   * <li> Check that the first store has all the records.
+   * <li> Produce records to the rt topic of the second store with CheckSumType set to {@link CheckSumType#MD5}.
+   * <li> Check that the second store has all the records.
+   * </ul>
+   */
+  @Test(timeOut = 60 * Time.MS_PER_SECOND)
+  public void testCheckSum() throws IOException {
+    parentZk = ServiceFactory.getZkServer();
+    parentController = ServiceFactory.getVeniceController(
+        new VeniceControllerCreateOptions.Builder(
+            veniceCluster.getClusterName(),
+            parentZk,
+            veniceCluster.getPubSubBrokerWrapper())
+                .childControllers(new VeniceControllerWrapper[] { veniceCluster.getLeaderVeniceController() })
+                .build());
+
+    long streamingRewindSeconds = 25;
+    long streamingMessageLag = 2;
+    final String storeNameFirst = Utils.getUniqueString("hybrid-store-for-checksum-first");
+    final String storeNameSecond = Utils.getUniqueString("hybrid-store-for-checksum-second");
+
+    try (
+        AvroGenericStoreClient<Object, Object> clientToFirstStore = ClientFactory.getAndStartGenericAvroClient(
+            ClientConfig.defaultGenericClientConfig(storeNameFirst).setVeniceURL(veniceCluster.getRandomRouterURL()));
+        AvroGenericStoreClient<Object, Object> clientToSecondStore = ClientFactory.getAndStartGenericAvroClient(
+            ClientConfig.defaultGenericClientConfig(storeNameSecond)
+                .setVeniceURL(veniceCluster.getRandomRouterURL()))) {
+
+      LOGGER.info("Creating stores and versions for CheckSumTest");
+      // Create stores and versions for each store.
+      createStoresAndVersion(storeNameFirst, CheckSumType.ADHASH, streamingRewindSeconds, streamingMessageLag);
+      createStoresAndVersion(storeNameSecond, CheckSumType.MD5, streamingRewindSeconds, streamingMessageLag);
+
+      // Produce to the rt topic of the first store with CheckSumType set to ADHASH.
+      produceToStoreRTTopic(storeNameFirst, 10, CheckSumType.ADHASH);
+
+      // Check that the first store has all the records.
+      checkRecords(clientToFirstStore, 10);
+
+      // Produce to the rt topic of the second store with CheckSumType set to MD5.
+      produceToStoreRTTopic(storeNameSecond, 10, CheckSumType.MD5);
+
+      // Check that the second store has all the records.
+      checkRecords(clientToSecondStore, 10);
+    }
+  }
+
+  void checkRecords(AvroGenericStoreClient<Object, Object> client, int numberOfRecords) {
+    TestUtils.waitForNonDeterministicAssertion(10, TimeUnit.SECONDS, true, true, () -> {
+      try {
+        for (int i = 1; i <= numberOfRecords; i++) {
+          checkLargeRecord(client, i);
+          LOGGER.info("Store {}: Checked record {}", client.getStoreName(), i);
+        }
+      } catch (Exception e) {
+        throw new VeniceException(e);
+      }
+    });
+  }
+
+  private void produceToStoreRTTopic(String storeName, int numOfRecords, CheckSumType checkSumType) {
+    LOGGER.info(
+        "Producing {} records to the rt topic of store {} with CheckSumType set to {}",
+        numOfRecords,
+        storeName,
+        checkSumType);
+    SystemProducer veniceProducer = getSamzaProducer(
+        veniceCluster,
+        storeName,
+        Version.PushType.STREAM,
+        Pair.create(VeniceWriter.CHECK_SUM_TYPE, checkSumType.name()));
+    for (int i = 1; i <= numOfRecords; i++) {
+      sendCustomSizeStreamingRecord(veniceProducer, storeName, i, STREAMING_RECORD_SIZE);
+    }
+    veniceProducer.stop();
+  }
+
+  private void createStoresAndVersion(
+      String storeName,
+      CheckSumType type,
+      long streamingRewindSeconds,
+      long streamingMessageLag) throws IOException {
+    // Create store at parent, make it a hybrid store.
+    File inputDir = getTempDataDirectory();
+    String inputDirPath = "file://" + inputDir.getAbsolutePath();
+    Schema recordSchema = TestWriteUtils.writeSimpleAvroFileWithStringToStringSchema(inputDir); // records 1-100
+    Properties vpjProperties = defaultVPJProps(veniceCluster, inputDirPath, storeName);
+    vpjProperties.setProperty(VeniceWriter.CHECK_SUM_TYPE, type.name());
+    LOGGER.info("Creating VPJ {} with CheckSumType set to {}", storeName, type.name());
+    try (
+        ControllerClient controllerClient =
+            createStoreForJob(veniceCluster.getClusterName(), recordSchema, vpjProperties);
+        AvroGenericStoreClient client = ClientFactory.getAndStartGenericAvroClient(
+            ClientConfig.defaultGenericClientConfig(storeName).setVeniceURL(veniceCluster.getRandomRouterURL()))) {
+
+      ControllerResponse response = controllerClient.updateStore(
+          storeName,
+          new UpdateStoreQueryParams().setHybridRewindSeconds(streamingRewindSeconds)
+              .setHybridOffsetLagThreshold(streamingMessageLag)
+              .setPartitionCount(1)
+              .setHybridOffsetLagThreshold(streamingMessageLag));
+
+      Assert.assertFalse(response.isError());
+
+      // Do a VPJ push
+      runVPJ(vpjProperties, 1, controllerClient);
+
+      // Verify some records (note, records 1-100 have been pushed)
+      TestUtils.waitForNonDeterministicAssertion(10, TimeUnit.SECONDS, true, () -> {
+        try {
+          for (int i = 1; i < 100; i++) {
+            String key = Integer.toString(i);
+            Object value = client.get(key).get();
+            assertNotNull(value, "Key " + i + " should not be missing!");
+            assertEquals(value.toString(), "test_name_" + key);
+          }
+        } catch (Exception e) {
+          throw new VeniceException(e);
+        }
+      });
+    }
+  }
+
+  private void checkLargeRecord(AvroGenericStoreClient client, int index)
+      throws ExecutionException, InterruptedException {
+    String key = Integer.toString(index);
+    assert client != null;
+    Object obj = client.get(key).get();
+    String value = obj.toString();
+    assertEquals(
+        value.length(),
+        STREAMING_RECORD_SIZE,
+        "Expected a large record for key '" + key + "' but instead got: '" + value + "'.");
+
+    String expectedChar = Integer.toString(index).substring(0, 1);
+    for (int i = 0; i < value.length(); i++) {
+      assertEquals(value.substring(i, i + 1), expectedChar);
+    }
+  }
+}

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/CheckSumTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/CheckSumTest.java
@@ -105,6 +105,7 @@ public class CheckSumTest {
    * <li> Create two stores with different checksum types in the VPJ.
    * <li> Verify that records can be read from the both stores.
    * <li> Produce records to the rt topic of the first store with CheckSumType set to {@link CheckSumType#ADHASH}.
+   * <li> Produce records to the rt topic of the first store with CheckSumType set to {@link CheckSumType#MD5}.
    * <li> Check that the first store has all the records.
    * <li> Produce records to the rt topic of the second store with CheckSumType set to {@link CheckSumType#MD5}.
    * <li> Check that the second store has all the records.
@@ -139,13 +140,16 @@ public class CheckSumTest {
       createStoresAndVersion(storeNameSecond, CheckSumType.MD5, streamingRewindSeconds, streamingMessageLag);
 
       // Produce to the rt topic of the first store with CheckSumType set to ADHASH.
-      produceToStoreRTTopic(storeNameFirst, 10, CheckSumType.ADHASH);
+      produceToStoreRTTopic(storeNameFirst, 1, 10, CheckSumType.ADHASH);
+
+      // Produce to the rt topic of the first store with CheckSumType set to MD5.
+      produceToStoreRTTopic(storeNameFirst, 11, 20, CheckSumType.MD5);
 
       // Check that the first store has all the records.
-      checkRecords(clientToFirstStore, 10);
+      checkRecords(clientToFirstStore, 20);
 
       // Produce to the rt topic of the second store with CheckSumType set to MD5.
-      produceToStoreRTTopic(storeNameSecond, 10, CheckSumType.MD5);
+      produceToStoreRTTopic(storeNameSecond, 1, 10, CheckSumType.MD5);
 
       // Check that the second store has all the records.
       checkRecords(clientToSecondStore, 10);
@@ -165,10 +169,10 @@ public class CheckSumTest {
     });
   }
 
-  private void produceToStoreRTTopic(String storeName, int numOfRecords, CheckSumType checkSumType) {
+  private void produceToStoreRTTopic(String storeName, int start, int end, CheckSumType checkSumType) {
     LOGGER.info(
         "Producing {} records to the rt topic of store {} with CheckSumType set to {}",
-        numOfRecords,
+        end - start + 1,
         storeName,
         checkSumType);
     SystemProducer veniceProducer = getSamzaProducer(
@@ -176,7 +180,7 @@ public class CheckSumTest {
         storeName,
         Version.PushType.STREAM,
         Pair.create(VeniceWriter.CHECK_SUM_TYPE, checkSumType.name()));
-    for (int i = 1; i <= numOfRecords; i++) {
+    for (int i = start; i <= end; i++) {
       sendCustomSizeStreamingRecord(veniceProducer, storeName, i, STREAMING_RECORD_SIZE);
     }
     veniceProducer.stop();

--- a/internal/venice-test-common/src/main/java/com/linkedin/venice/utils/DataProviderUtils.java
+++ b/internal/venice-test-common/src/main/java/com/linkedin/venice/utils/DataProviderUtils.java
@@ -7,6 +7,7 @@ import static com.linkedin.venice.compression.CompressionStrategy.ZSTD_WITH_DICT
 import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
 import com.linkedin.davinci.client.DaVinciConfig;
 import com.linkedin.davinci.store.cache.backend.ObjectCacheConfig;
+import com.linkedin.venice.kafka.validation.checksum.CheckSumType;
 import com.linkedin.venice.meta.IngestionMode;
 import java.util.Arrays;
 import java.util.Iterator;
@@ -59,6 +60,11 @@ public class DataProviderUtils {
   @DataProvider(name = "Five-True-and-False")
   public static Object[][] fiveBoolean() {
     return allPermutationGenerator(BOOLEAN, BOOLEAN, BOOLEAN, BOOLEAN, BOOLEAN);
+  }
+
+  @DataProvider(name = "CheckpointingSupported-CheckSum-Types")
+  public static Object[][] checkpointingSupportedCheckSumTypes() {
+    return new Object[][] { { CheckSumType.MD5 }, { CheckSumType.INCDIGEST } };
   }
 
   @DataProvider(name = "dv-client-config-provider")

--- a/internal/venice-test-common/src/main/java/com/linkedin/venice/utils/DataProviderUtils.java
+++ b/internal/venice-test-common/src/main/java/com/linkedin/venice/utils/DataProviderUtils.java
@@ -64,7 +64,7 @@ public class DataProviderUtils {
 
   @DataProvider(name = "CheckpointingSupported-CheckSum-Types")
   public static Object[][] checkpointingSupportedCheckSumTypes() {
-    return new Object[][] { { CheckSumType.MD5 }, { CheckSumType.INCDIGEST } };
+    return new Object[][] { { CheckSumType.MD5 }, { CheckSumType.ADHASH } };
   }
 
   @DataProvider(name = "dv-client-config-provider")


### PR DESCRIPTION
[controller][server][client][test] Adds a new checksum type ADHASH for data integrity validation

This PR adds a new checksum type ADHASH for Venice's DIV. ADHASH adopts the
ideal of incremental hash from AdHash and leverages the CRC32 as the underlying
hashing algorithm.

CRC32 is commonly used in networks and storage devices for detecting data corruption.
The purpose of this algorithm is not to protect against intentional
changes (cryptographic hashing), but rather to catch accidents like network errors
and disk write errors, etc. The emphasis of CRC32 is more on speed than on security.

For testing, this PR extends all the existing checksum and DIV tests to include the
new ADHASH type.

## How was this PR tested?
- Extends existing related tests to include the new type.
- Enabled `ADHASH` as the default `DEFAULT_CHECK_SUM_TYPE` in VeniceWriter for testing and all tests were [passed](https://github.com/lluwm/venice/commit/86931b881513a8c05e2f33f5ddb819cf0a115ffb). 

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.