### PR TITLE
[router] Fix NPE in ScatterGatherRequestHandlerImpl

### DIFF
--- a/internal/alpini/router/alpini-router-base/src/main/java/com/linkedin/alpini/router/ScatterGatherRequestHandlerImpl.java
+++ b/internal/alpini/router/alpini-router-base/src/main/java/com/linkedin/alpini/router/ScatterGatherRequestHandlerImpl.java
@@ -936,8 +936,7 @@ public abstract class ScatterGatherRequestHandlerImpl<H, P extends ResourcePath<
       complete = complete.thenCompose(aVoid -> {
         List<CompletableFuture<String>> list = new ArrayList(part.getPartitionKeys().size());
         for (K partitionKey : part.getPartitionKeys()) {
-          list.add(CompletableFuture.completedFuture(pathParser
-                                                     .substitutePartitionKey(basePath, partitionKey))
+          list.add(CompletableFuture.completedFuture(partitionKey)
                    .thenApply(key -> pathParser.substitutePartitionKey(basePath, key))
                    .thenCompose(
                        pathForThisKey -> _scatterGatherHelper

--- a/internal/alpini/router/alpini-router-base/src/main/java/com/linkedin/alpini/router/ScatterGatherRequestHandlerImpl.java
+++ b/internal/alpini/router/alpini-router-base/src/main/java/com/linkedin/alpini/router/ScatterGatherRequestHandlerImpl.java
@@ -956,15 +956,9 @@ public abstract class ScatterGatherRequestHandlerImpl<H, P extends ResourcePath<
                     .forEach(partitionKey -> {
                       contentMsg.append(", PartitionName=").append(partitionKey);
                     }));
-      })
-      .thenAccept(aVoid -> {
-              appendError(
-                  request,
-                  responses,
-                  status,
-                  contentMsg.append(", RoutingPolicy=").append(roles).toString(),
-                  ex);
-            });
+      }).thenAccept(aVoid -> {
+        appendError(request, responses, status, contentMsg.append(", RoutingPolicy=").append(roles).toString(), ex);
+      });
     }
     return complete;
   }

--- a/internal/alpini/router/alpini-router-base/src/main/java/com/linkedin/alpini/router/ScatterGatherRequestHandlerImpl.java
+++ b/internal/alpini/router/alpini-router-base/src/main/java/com/linkedin/alpini/router/ScatterGatherRequestHandlerImpl.java
@@ -43,6 +43,7 @@ import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.function.LongSupplier;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 
 

--- a/internal/alpini/router/alpini-router-base/src/main/java/com/linkedin/alpini/router/ScatterGatherRequestHandlerImpl.java
+++ b/internal/alpini/router/alpini-router-base/src/main/java/com/linkedin/alpini/router/ScatterGatherRequestHandlerImpl.java
@@ -945,7 +945,7 @@ public abstract class ScatterGatherRequestHandlerImpl<H, P extends ResourcePath<
             )
             .collect(Collectors.toList());
         return CompletableFuture.allOf(list.toArray(new CompletableFuture[0]))
-            .thenAccept(aVoid -> list.stream()
+            .thenAccept(aVoid2 -> list.stream()
                 .map(CompletableFuture::join)
                 .filter(Objects::nonNull)
                 .distinct()

--- a/internal/alpini/router/alpini-router-base/src/main/java/com/linkedin/alpini/router/ScatterGatherRequestHandlerImpl.java
+++ b/internal/alpini/router/alpini-router-base/src/main/java/com/linkedin/alpini/router/ScatterGatherRequestHandlerImpl.java
@@ -936,7 +936,8 @@ public abstract class ScatterGatherRequestHandlerImpl<H, P extends ResourcePath<
         List<CompletableFuture<String>> list = part.getPartitionKeys().stream()
             .map(CompletableFuture::completedFuture)
             .map(keyFuture -> keyFuture
-                .thenCompose(key -> pathParser.substitutePartitionKey(basePath, key))
+                .thenApply(key -> pathParser.substitutePartitionKey(basePath, key))
+                .thenCompose(pathForThisKey -> _scatterGatherHelper.findPartitionName(pathForThisKey.getResourceName(), keyFuture.join()))
                 .exceptionally(e -> {
                   LOG.info("Exception in appendErrorForEveryKey, key={}", keyFuture.join(), e);
                   return null;    

--- a/internal/alpini/router/alpini-router-base/src/main/java/com/linkedin/alpini/router/ScatterGatherRequestHandlerImpl.java
+++ b/internal/alpini/router/alpini-router-base/src/main/java/com/linkedin/alpini/router/ScatterGatherRequestHandlerImpl.java
@@ -934,25 +934,28 @@ public abstract class ScatterGatherRequestHandlerImpl<H, P extends ResourcePath<
     } else {
       // For requests with keys, send an error for each key. TODO: Consider if we could rip all of that out?
       complete = complete.thenCompose(aVoid -> {
-        List<CompletableFuture<String>> list = part.getPartitionKeys().stream()
+        List<CompletableFuture<String>> list = part.getPartitionKeys()
+            .stream()
             .map(CompletableFuture::completedFuture)
-            .map(keyFuture -> keyFuture
-                .thenApply(key -> pathParser.substitutePartitionKey(basePath, key))
-                .thenCompose(pathForThisKey -> _scatterGatherHelper.findPartitionName(pathForThisKey.getResourceName(),
-                    keyFuture.join()))
-                .exceptionally(e -> {
-                  LOG.info("Exception in appendErrorForEveryKey, key={}", keyFuture.join(), e);
-                  return null;
-                }))
+            .map(
+                keyFuture -> keyFuture.thenApply(key -> pathParser.substitutePartitionKey(basePath, key))
+                    .thenCompose(
+                        pathForThisKey -> _scatterGatherHelper
+                            .findPartitionName(pathForThisKey.getResourceName(), keyFuture.join()))
+                    .exceptionally(e -> {
+                      LOG.info("Exception in appendErrorForEveryKey, key={}", keyFuture.join(), e);
+                      return null;
+                    }))
             .collect(Collectors.toList());
         return CompletableFuture.allOf(list.toArray(new CompletableFuture[0]))
-            .thenAccept(aVoid2 -> list.stream()
-                .map(CompletableFuture::join)
-                .filter(Objects::nonNull)
-                .distinct()
-                .forEach(partitionKey -> {
-                  contentMsg.append(", PartitionName=").append(partitionKey);
-                }));
+            .thenAccept(
+                aVoid2 -> list.stream()
+                    .map(CompletableFuture::join)
+                    .filter(Objects::nonNull)
+                    .distinct()
+                    .forEach(partitionKey -> {
+                      contentMsg.append(", PartitionName=").append(partitionKey);
+                    }));
       })
       .thenAccept(aVoid -> {
               appendError(

--- a/internal/alpini/router/alpini-router-base/src/main/java/com/linkedin/alpini/router/ScatterGatherRequestHandlerImpl.java
+++ b/internal/alpini/router/alpini-router-base/src/main/java/com/linkedin/alpini/router/ScatterGatherRequestHandlerImpl.java
@@ -938,12 +938,12 @@ public abstract class ScatterGatherRequestHandlerImpl<H, P extends ResourcePath<
             .map(CompletableFuture::completedFuture)
             .map(keyFuture -> keyFuture
                 .thenApply(key -> pathParser.substitutePartitionKey(basePath, key))
-                .thenCompose(pathForThisKey -> _scatterGatherHelper.findPartitionName(pathForThisKey.getResourceName(), keyFuture.join()))
+                .thenCompose(pathForThisKey -> _scatterGatherHelper.findPartitionName(pathForThisKey.getResourceName(),
+                    keyFuture.join()))
                 .exceptionally(e -> {
                   LOG.info("Exception in appendErrorForEveryKey, key={}", keyFuture.join(), e);
-                  return null;    
-                })
-            )
+                  return null;
+                }))
             .collect(Collectors.toList());
         return CompletableFuture.allOf(list.toArray(new CompletableFuture[0]))
             .thenAccept(aVoid2 -> list.stream()
@@ -952,8 +952,7 @@ public abstract class ScatterGatherRequestHandlerImpl<H, P extends ResourcePath<
                 .distinct()
                 .forEach(partitionKey -> {
                   contentMsg.append(", PartitionName=").append(partitionKey);
-                })
-            );
+                }));
       })
       .thenAccept(aVoid -> {
               appendError(

--- a/internal/alpini/router/alpini-router-base/src/main/java/com/linkedin/alpini/router/ScatterGatherRequestHandlerImpl.java
+++ b/internal/alpini/router/alpini-router-base/src/main/java/com/linkedin/alpini/router/ScatterGatherRequestHandlerImpl.java
@@ -934,7 +934,7 @@ public abstract class ScatterGatherRequestHandlerImpl<H, P extends ResourcePath<
     } else {
       // For requests with keys, send an error for each key. TODO: Consider if we could rip all of that out?
       complete = complete.thenCompose(aVoid -> {
-        List<CompletableFuture<String>> list = new ArrayList(part.getPartitionKeys().size());
+        List<CompletableFuture<String>> list = new ArrayList<>(part.getPartitionKeys().size());
         for (K partitionKey: part.getPartitionKeys()) {
           list.add(
               CompletableFuture.completedFuture(partitionKey)
@@ -955,10 +955,11 @@ public abstract class ScatterGatherRequestHandlerImpl<H, P extends ResourcePath<
                 distinctSet.add(key);
               }
             });
-            distinctSet.forEach(partitionName -> {
-              contentMsg.append(", PartitionName=").append(partitionName);
-            });
-        }));
+          }
+          distinctSet.forEach(partitionName -> {
+            contentMsg.append(", PartitionName=").append(partitionName);
+          });
+        });
       }).thenAccept(aVoid -> {
         appendError(request, responses, status, contentMsg.append(", RoutingPolicy=").append(roles).toString(), ex);
       });

--- a/internal/alpini/router/alpini-router-base/src/main/java/com/linkedin/alpini/router/ScatterGatherRequestHandlerImpl.java
+++ b/internal/alpini/router/alpini-router-base/src/main/java/com/linkedin/alpini/router/ScatterGatherRequestHandlerImpl.java
@@ -946,6 +946,7 @@ public abstract class ScatterGatherRequestHandlerImpl<H, P extends ResourcePath<
                        LOG.info("Exception in appendErrorForEveryKey, key={}", partitionKey, e);
                        return null;
                     }));
+        }
         return CompletableFuture.allOf(list.toArray(new CompletableFuture[0]))
             .thenAccept(
                 aVoid2 -> {

--- a/internal/alpini/router/alpini-router-base/src/main/java/com/linkedin/alpini/router/ScatterGatherRequestHandlerImpl.java
+++ b/internal/alpini/router/alpini-router-base/src/main/java/com/linkedin/alpini/router/ScatterGatherRequestHandlerImpl.java
@@ -44,7 +44,6 @@ import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.function.LongSupplier;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 
 

--- a/internal/alpini/router/alpini-router-base/src/main/java/com/linkedin/alpini/router/ScatterGatherRequestHandlerImpl.java
+++ b/internal/alpini/router/alpini-router-base/src/main/java/com/linkedin/alpini/router/ScatterGatherRequestHandlerImpl.java
@@ -941,9 +941,9 @@ public abstract class ScatterGatherRequestHandlerImpl<H, P extends ResourcePath<
                    .thenApply(key -> pathParser.substitutePartitionKey(basePath, key))
                    .thenCompose(
                        pathForThisKey -> _scatterGatherHelper
-                           .findPartitionName(pathForThisKey.getResourceName(), keyFuture.join()))
+                           .findPartitionName(pathForThisKey.getResourceName(), partitionKey))
                    .exceptionally(e -> {
-                       LOG.info("Exception in appendErrorForEveryKey, key={}", keyFuture.join(), e);
+                       LOG.info("Exception in appendErrorForEveryKey, key={}", partitionKey, e);
                        return null;
                     }));
         return CompletableFuture.allOf(list.toArray(new CompletableFuture[0]))

--- a/internal/alpini/router/alpini-router-base/src/main/java/com/linkedin/alpini/router/ScatterGatherRequestHandlerImpl.java
+++ b/internal/alpini/router/alpini-router-base/src/main/java/com/linkedin/alpini/router/ScatterGatherRequestHandlerImpl.java
@@ -958,7 +958,7 @@ public abstract class ScatterGatherRequestHandlerImpl<H, P extends ResourcePath<
             distinctSet.forEach(partitionName -> {
               contentMsg.append(", PartitionName=").append(partitionName);
             });
-        });
+        }));
       }).thenAccept(aVoid -> {
         appendError(request, responses, status, contentMsg.append(", RoutingPolicy=").append(roles).toString(), ex);
       });

--- a/internal/alpini/router/alpini-router-base/src/main/java/com/linkedin/alpini/router/ScatterGatherRequestHandlerImpl.java
+++ b/internal/alpini/router/alpini-router-base/src/main/java/com/linkedin/alpini/router/ScatterGatherRequestHandlerImpl.java
@@ -31,6 +31,7 @@ import io.netty.util.concurrent.EventExecutor;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Summary, imperative, start upper case, don't end with a period

- CompletableFuture.thenCompose requires functions that do not return null.
- The return from findPartitionName is a CompletionStage (async).
- dedup partition names after retrieving partition names for each key.
- only call appendError once when there are multiple partition keys.

<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Resolves #XXX

## How was this PR tested?
Not yet tested ;-)

<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.