### PR TITLE
[controller] Deprecate ACTIVE_ACTIVE and NONE data replication policies 

### DIFF
--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTaskTest.java
@@ -215,8 +215,12 @@ public class ActiveActiveStoreIngestionTaskTest {
     builder.setStorageEngineRepository(storageEngineRepository);
 
     // Set up version config and store config
-    HybridStoreConfig hybridStoreConfig =
-        new HybridStoreConfigImpl(100L, 100L, 100L, DataReplicationPolicy.NONE, BufferReplayPolicy.REWIND_FROM_EOP);
+    HybridStoreConfig hybridStoreConfig = new HybridStoreConfigImpl(
+        100L,
+        100L,
+        100L,
+        DataReplicationPolicy.NON_AGGREGATE,
+        BufferReplayPolicy.REWIND_FROM_EOP);
     Version mockVersion = new VersionImpl(STORE_NAME, 1, PUSH_JOB_ID);
     mockVersion.setHybridStoreConfig(hybridStoreConfig);
 

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTaskTest.java
@@ -215,12 +215,8 @@ public class ActiveActiveStoreIngestionTaskTest {
     builder.setStorageEngineRepository(storageEngineRepository);
 
     // Set up version config and store config
-    HybridStoreConfig hybridStoreConfig = new HybridStoreConfigImpl(
-        100L,
-        100L,
-        100L,
-        DataReplicationPolicy.ACTIVE_ACTIVE,
-        BufferReplayPolicy.REWIND_FROM_EOP);
+    HybridStoreConfig hybridStoreConfig =
+        new HybridStoreConfigImpl(100L, 100L, 100L, DataReplicationPolicy.NONE, BufferReplayPolicy.REWIND_FROM_EOP);
     Version mockVersion = new VersionImpl(STORE_NAME, 1, PUSH_JOB_ID);
     mockVersion.setHybridStoreConfig(hybridStoreConfig);
 

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
@@ -3025,8 +3025,12 @@ public abstract class StoreIngestionTaskTest {
     partitionerConfig.setPartitionerClass(partitioner.getClass().getName());
     HybridStoreConfig hybridStoreConfig = null;
     if (hybridConfig == HYBRID) {
-      hybridStoreConfig =
-          new HybridStoreConfigImpl(100, 100, -1, DataReplicationPolicy.NONE, BufferReplayPolicy.REWIND_FROM_EOP);
+      hybridStoreConfig = new HybridStoreConfigImpl(
+          100,
+          100,
+          -1,
+          DataReplicationPolicy.NON_AGGREGATE,
+          BufferReplayPolicy.REWIND_FROM_EOP);
     }
 
     MockStoreVersionConfigs storeAndVersionConfigs = setupStoreAndVersionMocks(

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
@@ -3025,12 +3025,8 @@ public abstract class StoreIngestionTaskTest {
     partitionerConfig.setPartitionerClass(partitioner.getClass().getName());
     HybridStoreConfig hybridStoreConfig = null;
     if (hybridConfig == HYBRID) {
-      hybridStoreConfig = new HybridStoreConfigImpl(
-          100,
-          100,
-          -1,
-          DataReplicationPolicy.ACTIVE_ACTIVE,
-          BufferReplayPolicy.REWIND_FROM_EOP);
+      hybridStoreConfig =
+          new HybridStoreConfigImpl(100, 100, -1, DataReplicationPolicy.NONE, BufferReplayPolicy.REWIND_FROM_EOP);
     }
 
     MockStoreVersionConfigs storeAndVersionConfigs = setupStoreAndVersionMocks(

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/ingestion/heartbeat/HeartbeatMonitoringServiceTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/ingestion/heartbeat/HeartbeatMonitoringServiceTest.java
@@ -27,7 +27,7 @@ public class HeartbeatMonitoringServiceTest {
 
     // Default hybrid store config
     HybridStoreConfig hybridStoreConfig =
-        new HybridStoreConfigImpl(1L, 1L, 1L, DataReplicationPolicy.NONE, BufferReplayPolicy.REWIND_FROM_SOP);
+        new HybridStoreConfigImpl(1L, 1L, 1L, DataReplicationPolicy.NON_AGGREGATE, BufferReplayPolicy.REWIND_FROM_SOP);
 
     // Version configs
     Version backupVersion = new VersionImpl(TEST_STORE, 1, "1"); // Non hybrid version

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/ingestion/heartbeat/HeartbeatMonitoringServiceTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/ingestion/heartbeat/HeartbeatMonitoringServiceTest.java
@@ -27,7 +27,7 @@ public class HeartbeatMonitoringServiceTest {
 
     // Default hybrid store config
     HybridStoreConfig hybridStoreConfig =
-        new HybridStoreConfigImpl(1L, 1L, 1L, DataReplicationPolicy.ACTIVE_ACTIVE, BufferReplayPolicy.REWIND_FROM_SOP);
+        new HybridStoreConfigImpl(1L, 1L, 1L, DataReplicationPolicy.NONE, BufferReplayPolicy.REWIND_FROM_SOP);
 
     // Version configs
     Version backupVersion = new VersionImpl(TEST_STORE, 1, "1"); // Non hybrid version

--- a/clients/venice-producer/src/test/java/com/linkedin/venice/producer/online/OnlineVeniceProducerTest.java
+++ b/clients/venice-producer/src/test/java/com/linkedin/venice/producer/online/OnlineVeniceProducerTest.java
@@ -877,12 +877,8 @@ public class OnlineVeniceProducerTest {
     Version version = new VersionImpl(storeName, 1, "test-job-id");
     version.setPartitionCount(partitionCount);
 
-    HybridStoreConfig hybridStoreConfig = new HybridStoreConfigImpl(
-        1000,
-        1000,
-        -1,
-        DataReplicationPolicy.ACTIVE_ACTIVE,
-        BufferReplayPolicy.REWIND_FROM_EOP);
+    HybridStoreConfig hybridStoreConfig =
+        new HybridStoreConfigImpl(1000, 1000, -1, DataReplicationPolicy.NONE, BufferReplayPolicy.REWIND_FROM_EOP);
 
     ZKStore store = new ZKStore(
         storeName,

--- a/clients/venice-producer/src/test/java/com/linkedin/venice/producer/online/OnlineVeniceProducerTest.java
+++ b/clients/venice-producer/src/test/java/com/linkedin/venice/producer/online/OnlineVeniceProducerTest.java
@@ -877,8 +877,12 @@ public class OnlineVeniceProducerTest {
     Version version = new VersionImpl(storeName, 1, "test-job-id");
     version.setPartitionCount(partitionCount);
 
-    HybridStoreConfig hybridStoreConfig =
-        new HybridStoreConfigImpl(1000, 1000, -1, DataReplicationPolicy.NONE, BufferReplayPolicy.REWIND_FROM_EOP);
+    HybridStoreConfig hybridStoreConfig = new HybridStoreConfigImpl(
+        1000,
+        1000,
+        -1,
+        DataReplicationPolicy.NON_AGGREGATE,
+        BufferReplayPolicy.REWIND_FROM_EOP);
 
     ZKStore store = new ZKStore(
         storeName,

--- a/clients/venice-thin-client/src/test/java/com/linkedin/venice/client/schema/RouterBackedSchemaReaderTest.java
+++ b/clients/venice-thin-client/src/test/java/com/linkedin/venice/client/schema/RouterBackedSchemaReaderTest.java
@@ -497,12 +497,8 @@ public class RouterBackedSchemaReaderTest {
     Version version = new VersionImpl(storeName, 1, "test-job-id");
     version.setPartitionCount(partitionCount);
 
-    HybridStoreConfig hybridStoreConfig = new HybridStoreConfigImpl(
-        1000,
-        1000,
-        -1,
-        DataReplicationPolicy.ACTIVE_ACTIVE,
-        BufferReplayPolicy.REWIND_FROM_EOP);
+    HybridStoreConfig hybridStoreConfig =
+        new HybridStoreConfigImpl(1000, 1000, -1, DataReplicationPolicy.NONE, BufferReplayPolicy.REWIND_FROM_EOP);
 
     ZKStore store = new ZKStore(
         storeName,

--- a/clients/venice-thin-client/src/test/java/com/linkedin/venice/client/schema/RouterBackedSchemaReaderTest.java
+++ b/clients/venice-thin-client/src/test/java/com/linkedin/venice/client/schema/RouterBackedSchemaReaderTest.java
@@ -497,8 +497,12 @@ public class RouterBackedSchemaReaderTest {
     Version version = new VersionImpl(storeName, 1, "test-job-id");
     version.setPartitionCount(partitionCount);
 
-    HybridStoreConfig hybridStoreConfig =
-        new HybridStoreConfigImpl(1000, 1000, -1, DataReplicationPolicy.NONE, BufferReplayPolicy.REWIND_FROM_EOP);
+    HybridStoreConfig hybridStoreConfig = new HybridStoreConfigImpl(
+        1000,
+        1000,
+        -1,
+        DataReplicationPolicy.NON_AGGREGATE,
+        BufferReplayPolicy.REWIND_FROM_EOP);
 
     ZKStore store = new ZKStore(
         storeName,

--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/DataReplicationPolicy.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/DataReplicationPolicy.java
@@ -6,8 +6,9 @@ import java.util.Map;
 
 
 /**
- * Enums of the policies used to decide how real-time samza data is replicated.
- * Note: Data replication policy does not play any role for AA enabled hybrid stores.
+ * The data replication policy determines which fabric to use for sending real-time writes from clients and
+ * where to direct servers for real-time data consumption. If active-active replication is enabled,
+ * the data replication policy is bypassed, as writes are sent to the local fabric.
  */
 public enum DataReplicationPolicy {
   /**

--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/DataReplicationPolicy.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/DataReplicationPolicy.java
@@ -30,6 +30,7 @@ public enum DataReplicationPolicy {
    * Samza job per colo pushes to local real-time topic. Leader SNs replicate data from real-time topic in all colos to
    * local version topic.
    */
+  @Deprecated
   ACTIVE_ACTIVE(3);
 
   private final int value;

--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/DataReplicationPolicy.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/DataReplicationPolicy.java
@@ -7,6 +7,7 @@ import java.util.Map;
 
 /**
  * Enums of the policies used to decide how real-time samza data is replicated.
+ * Note: Data replication policy does not play any role for AA enabled hybrid stores.
  */
 public enum DataReplicationPolicy {
   /**
@@ -19,17 +20,9 @@ public enum DataReplicationPolicy {
    */
   AGGREGATE(1),
 
-  /**
-   * This enum value is used in 2 cases:
-   *   1. batch-only stores since it has no real-time data replication.
-   *   2. incremental push stores that do not have Samza jobs.
-   */
+  @Deprecated
   NONE(2),
 
-  /**
-   * Samza job per colo pushes to local real-time topic. Leader SNs replicate data from real-time topic in all colos to
-   * local version topic.
-   */
   @Deprecated
   ACTIVE_ACTIVE(3);
 

--- a/internal/venice-common/src/test/java/com/linkedin/venice/store/StoreStateReaderTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/store/StoreStateReaderTest.java
@@ -70,8 +70,12 @@ public class StoreStateReaderTest {
     Version version = new VersionImpl(storeName, 1, "test-job-id");
     version.setPartitionCount(partitionCount);
 
-    HybridStoreConfig hybridStoreConfig =
-        new HybridStoreConfigImpl(1000, 1000, -1, DataReplicationPolicy.NONE, BufferReplayPolicy.REWIND_FROM_EOP);
+    HybridStoreConfig hybridStoreConfig = new HybridStoreConfigImpl(
+        1000,
+        1000,
+        -1,
+        DataReplicationPolicy.NON_AGGREGATE,
+        BufferReplayPolicy.REWIND_FROM_EOP);
 
     ZKStore store = new ZKStore(
         storeName,

--- a/internal/venice-common/src/test/java/com/linkedin/venice/store/StoreStateReaderTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/store/StoreStateReaderTest.java
@@ -70,12 +70,8 @@ public class StoreStateReaderTest {
     Version version = new VersionImpl(storeName, 1, "test-job-id");
     version.setPartitionCount(partitionCount);
 
-    HybridStoreConfig hybridStoreConfig = new HybridStoreConfigImpl(
-        1000,
-        1000,
-        -1,
-        DataReplicationPolicy.ACTIVE_ACTIVE,
-        BufferReplayPolicy.REWIND_FROM_EOP);
+    HybridStoreConfig hybridStoreConfig =
+        new HybridStoreConfigImpl(1000, 1000, -1, DataReplicationPolicy.NONE, BufferReplayPolicy.REWIND_FROM_EOP);
 
     ZKStore store = new ZKStore(
         storeName,

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/DataRecoveryTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/DataRecoveryTest.java
@@ -311,7 +311,6 @@ public class DataRecoveryTest {
                   storeName,
                   new UpdateStoreQueryParams().setHybridRewindSeconds(10)
                       .setHybridOffsetLagThreshold(2)
-                      .setHybridDataReplicationPolicy(DataReplicationPolicy.NON_AGGREGATE)
                       .setNativeReplicationEnabled(true)
                       .setActiveActiveReplicationEnabled(true)
                       .setPartitionCount(1))

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/DataRecoveryTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/DataRecoveryTest.java
@@ -311,7 +311,7 @@ public class DataRecoveryTest {
                   storeName,
                   new UpdateStoreQueryParams().setHybridRewindSeconds(10)
                       .setHybridOffsetLagThreshold(2)
-                      .setHybridDataReplicationPolicy(DataReplicationPolicy.ACTIVE_ACTIVE)
+                      .setHybridDataReplicationPolicy(DataReplicationPolicy.NON_AGGREGATE)
                       .setNativeReplicationEnabled(true)
                       .setActiveActiveReplicationEnabled(true)
                       .setPartitionCount(1))

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestActiveActiveReplicationForIncPush.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestActiveActiveReplicationForIncPush.java
@@ -33,7 +33,6 @@ import com.linkedin.venice.meta.HybridStoreConfig;
 import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.StoreInfo;
 import com.linkedin.venice.meta.Version;
-import com.linkedin.venice.utils.DataProviderUtils;
 import com.linkedin.venice.utils.IntegrationTestPushUtils;
 import com.linkedin.venice.utils.TestUtils;
 import com.linkedin.venice.utils.TestWriteUtils;
@@ -118,8 +117,8 @@ public class TestActiveActiveReplicationForIncPush {
    * The purpose of this test is to verify that incremental push with RT policy succeeds when A/A is enabled in all
    * regions. And also incremental push can push to the closes kafka cluster from the grid using the SOURCE_GRID_CONFIG.
    */
-  @Test(timeOut = TEST_TIMEOUT, dataProviderClass = DataProviderUtils.class, dataProvider = "True-and-False")
-  public void testAAReplicationForIncrementalPushToRT(boolean overrideDataReplicationPolicy) throws Exception {
+  @Test(timeOut = TEST_TIMEOUT)
+  public void testAAReplicationForIncrementalPushToRT() throws Exception {
     String clusterName = this.clusterNames[0];
     File inputDirBatch = getTempDataDirectory();
     File inputDirInc1 = getTempDataDirectory();
@@ -177,11 +176,6 @@ public class TestActiveActiveReplicationForIncPush {
               .setHybridRewindSeconds(2L)
               .setNativeReplicationSourceFabric("dc-2");
 
-      // Override the data replication policy to be non-aggregate.
-      if (overrideDataReplicationPolicy) {
-        updateStoreParams.setHybridDataReplicationPolicy(DataReplicationPolicy.NON_AGGREGATE);
-      }
-
       TestUtils.assertCommand(parentControllerClient.updateStore(storeName, updateStoreParams));
 
       // Print all the kafka cluster URLs
@@ -195,13 +189,6 @@ public class TestActiveActiveReplicationForIncPush {
           storeName,
           true,
           true,
-          parentControllerClient,
-          dc0ControllerClient,
-          dc1ControllerClient,
-          dc2ControllerClient);
-      TestUtils.verifyHybridStoreDataReplicationPolicy(
-          storeName,
-          overrideDataReplicationPolicy ? DataReplicationPolicy.NON_AGGREGATE : DataReplicationPolicy.ACTIVE_ACTIVE,
           parentControllerClient,
           dc0ControllerClient,
           dc1ControllerClient,

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/ingestionHeartbeat/IngestionHeartBeatTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/ingestionHeartbeat/IngestionHeartBeatTest.java
@@ -120,11 +120,8 @@ public class IngestionHeartBeatTest {
 
   @DataProvider
   public static Object[][] AAConfigAndIncPushAndDRPProvider() {
-    return DataProviderUtils.allPermutationGenerator(
-        (permutation) -> true,
-        DataProviderUtils.BOOLEAN,
-        DataProviderUtils.BOOLEAN,
-        DataReplicationPolicy.values());
+    return DataProviderUtils
+        .allPermutationGenerator(DataProviderUtils.BOOLEAN, DataProviderUtils.BOOLEAN, DataReplicationPolicy.values());
   }
 
   @Test(dataProvider = "AAConfigAndIncPushAndDRPProvider", timeOut = TEST_TIMEOUT_MS)

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/ingestionHeartbeat/IngestionHeartBeatTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/ingestionHeartbeat/IngestionHeartBeatTest.java
@@ -4,7 +4,6 @@ import static com.linkedin.venice.hadoop.VenicePushJobConstants.DEFAULT_KEY_FIEL
 import static com.linkedin.venice.hadoop.VenicePushJobConstants.INCREMENTAL_PUSH;
 import static com.linkedin.venice.hadoop.VenicePushJobConstants.VENICE_STORE_NAME_PROP;
 import static com.linkedin.venice.message.KafkaKey.HEART_BEAT;
-import static com.linkedin.venice.meta.DataReplicationPolicy.ACTIVE_ACTIVE;
 import static com.linkedin.venice.pubsub.api.PubSubMessageHeaders.VENICE_LEADER_COMPLETION_STATE_HEADER;
 import static com.linkedin.venice.utils.TestUtils.assertCommand;
 import static com.linkedin.venice.utils.TestWriteUtils.NAME_RECORD_V1_SCHEMA;
@@ -121,14 +120,11 @@ public class IngestionHeartBeatTest {
 
   @DataProvider
   public static Object[][] AAConfigAndIncPushAndDRPProvider() {
-    return DataProviderUtils.allPermutationGenerator((permutation) -> {
-      boolean isActiveActiveEnabled = (boolean) permutation[1];
-      DataReplicationPolicy dataReplicationPolicy = (DataReplicationPolicy) permutation[3];
-      if (isActiveActiveEnabled && dataReplicationPolicy != ACTIVE_ACTIVE) {
-        return false;
-      }
-      return true;
-    }, DataProviderUtils.BOOLEAN, DataProviderUtils.BOOLEAN, DataReplicationPolicy.values());
+    return DataProviderUtils.allPermutationGenerator(
+        (permutation) -> true,
+        DataProviderUtils.BOOLEAN,
+        DataProviderUtils.BOOLEAN,
+        DataReplicationPolicy.values());
   }
 
   @Test(dataProvider = "AAConfigAndIncPushAndDRPProvider", timeOut = TEST_TIMEOUT_MS)

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -4886,7 +4886,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
                 DEFAULT_REWIND_TIME_IN_SECONDS,
                 DEFAULT_HYBRID_OFFSET_LAG_THRESHOLD,
                 DEFAULT_HYBRID_TIME_LAG_THRESHOLD,
-                DataReplicationPolicy.NONE,
+                DataReplicationPolicy.NON_AGGREGATE,
                 null));
       } else if (hybridStoreConfig.getDataReplicationPolicy() == null) {
         store.setHybridStoreConfig(
@@ -4894,7 +4894,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
                 hybridStoreConfig.getRewindTimeInSeconds(),
                 hybridStoreConfig.getOffsetLagThresholdToGoOnline(),
                 hybridStoreConfig.getProducerTimestampLagThresholdToGoOnlineInSeconds(),
-                DataReplicationPolicy.NONE,
+                DataReplicationPolicy.NON_AGGREGATE,
                 hybridStoreConfig.getBufferReplayPolicy()));
       }
       return store;

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
@@ -502,8 +502,7 @@ public class VeniceParentHelixAdmin implements Admin {
     if (initRoutineForHeartbeatSystemStore != null) {
       if (initializeBatchJobHeartbeatStore) {
         UpdateStoreQueryParams updateStoreQueryParamsForHeartbeatSystemStore =
-            new UpdateStoreQueryParams().setHybridDataReplicationPolicy(DataReplicationPolicy.ACTIVE_ACTIVE)
-                .setActiveActiveReplicationEnabled(true);
+            new UpdateStoreQueryParams().setActiveActiveReplicationEnabled(true);
         initRoutineForHeartbeatSystemStore.setDelegate(
             new SharedInternalRTStoreInitializationRoutine(
                 batchJobHeartbeatStoreClusterName,
@@ -2429,15 +2428,6 @@ public class VeniceParentHelixAdmin implements Admin {
           && controllerConfig.isActiveActiveReplicationEnabledAsDefaultForHybrid()) {
         setStore.activeActiveReplicationEnabled = true;
         updatedConfigsList.add(ACTIVE_ACTIVE_REPLICATION_ENABLED);
-        if (!hybridDataReplicationPolicy.isPresent()) {
-          LOGGER.info(
-              "Data replication policy was not explicitly set when converting store to hybrid store: {}."
-                  + " Setting it to active-active replication policy.",
-              storeName);
-
-          updatedHybridStoreConfig.setDataReplicationPolicy(DataReplicationPolicy.ACTIVE_ACTIVE);
-          updatedConfigsList.add(DATA_REPLICATION_POLICY);
-        }
       }
       // When turning off hybrid store, we will also turn off A/A store config.
       if (storeBeingConvertedToBatch && setStore.activeActiveReplicationEnabled) {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
@@ -2480,7 +2480,7 @@ public class VeniceParentHelixAdmin implements Admin {
         updatedConfigsList.add(OFFSET_LAG_TO_GO_ONLINE);
         hybridStoreConfigRecord.producerTimestampLagThresholdToGoOnlineInSeconds = DEFAULT_HYBRID_TIME_LAG_THRESHOLD;
         updatedConfigsList.add(TIME_LAG_TO_GO_ONLINE);
-        hybridStoreConfigRecord.dataReplicationPolicy = DataReplicationPolicy.NONE.getValue();
+        hybridStoreConfigRecord.dataReplicationPolicy = DataReplicationPolicy.NON_AGGREGATE.getValue();
         updatedConfigsList.add(DATA_REPLICATION_POLICY);
         hybridStoreConfigRecord.bufferReplayPolicy = BufferReplayPolicy.REWIND_FROM_EOP.getValue();
         updatedConfigsList.add(BUFFER_REPLAY_POLICY);

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/CreateVersion.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/CreateVersion.java
@@ -465,8 +465,13 @@ public class CreateVersion extends AbstractRoute {
               + " which is not configured to be a hybrid store",
           ErrorType.BAD_REQUEST);
     }
-    if (pushType.equals(PushType.STREAM)
-        && store.getHybridStoreConfig().getDataReplicationPolicy().equals(DataReplicationPolicy.NONE)) {
+    /**
+     * Allow STREAM push type if one of the following conditions is true
+     * 1. AA is enabled for the store
+     * 2. AA is not enabled for the store but the store is configured with NON_AGGREGATE data replication policy
+     */
+    if (pushType.equals(PushType.STREAM) && !(store.isActiveActiveReplicationEnabled()
+        || store.getHybridStoreConfig().getDataReplicationPolicy().equals(DataReplicationPolicy.NON_AGGREGATE))) {
       throw new VeniceHttpException(
           HttpStatus.SC_BAD_REQUEST,
           "requesting topic for streaming writes to store " + store.getName()

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/CreateVersion.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/CreateVersion.java
@@ -457,7 +457,7 @@ public class CreateVersion extends AbstractRoute {
     response.setKafkaBootstrapServers(bootstrapServerAddress);
   }
 
-  private void validatePushType(PushType pushType, Store store) {
+  void validatePushType(PushType pushType, Store store) {
     if (pushType.equals(PushType.STREAM) && !store.isHybrid()) {
       throw new VeniceHttpException(
           HttpStatus.SC_BAD_REQUEST,
@@ -481,20 +481,19 @@ public class CreateVersion extends AbstractRoute {
               + store.getHybridStoreConfig().getDataReplicationPolicy(),
           ErrorType.BAD_REQUEST);
     }
-    if (pushType.isIncremental()) {
-      if (!store.isIncrementalPushEnabled()) {
-        throw new VeniceHttpException(
-            HttpStatus.SC_BAD_REQUEST,
-            "requesting topic for incremental push to store: " + store.getName()
-                + " which does not have incremental push enabled.",
-            ErrorType.BAD_REQUEST);
-      } else if (!store.isHybrid()) {
-        throw new VeniceHttpException(
-            HttpStatus.SC_BAD_REQUEST,
-            "requesting topic for incremental push to store: " + store.getName()
-                + " which does not have hybrid mode enabled.",
-            ErrorType.BAD_REQUEST);
-      }
+    if (pushType.isIncremental() && !store.isHybrid()) {
+      throw new VeniceHttpException(
+          HttpStatus.SC_BAD_REQUEST,
+          "requesting topic for incremental push to store: " + store.getName()
+              + " which does not have hybrid mode enabled.",
+          ErrorType.BAD_REQUEST);
+    }
+    if (pushType.isIncremental() && !store.isIncrementalPushEnabled()) {
+      throw new VeniceHttpException(
+          HttpStatus.SC_BAD_REQUEST,
+          "requesting topic for incremental push to store: " + store.getName()
+              + " which does not have incremental push enabled.",
+          ErrorType.BAD_REQUEST);
     }
   }
 

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/CreateVersion.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/CreateVersion.java
@@ -469,9 +469,11 @@ public class CreateVersion extends AbstractRoute {
      * Allow STREAM push type if one of the following conditions is true
      * 1. AA is enabled for the store
      * 2. AA is not enabled for the store but the store is configured with NON_AGGREGATE data replication policy
+     * 3. AA is not enabled for the store but the store is configured with AGGREGATE data replication policy
      */
     if (pushType.equals(PushType.STREAM) && !(store.isActiveActiveReplicationEnabled()
-        || store.getHybridStoreConfig().getDataReplicationPolicy().equals(DataReplicationPolicy.NON_AGGREGATE))) {
+        || store.getHybridStoreConfig().getDataReplicationPolicy().equals(DataReplicationPolicy.NON_AGGREGATE)
+        || store.getHybridStoreConfig().getDataReplicationPolicy().equals(DataReplicationPolicy.AGGREGATE))) {
       throw new VeniceHttpException(
           HttpStatus.SC_BAD_REQUEST,
           "requesting topic for streaming writes to store " + store.getName()

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/MetaDataHandler.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/MetaDataHandler.java
@@ -138,8 +138,8 @@ public class MetaDataHandler extends SimpleChannelInboundHandler<HttpRequest> {
   static final String REQUEST_TOPIC_ERROR_CURRENT_VERSION_NOT_HYBRID =
       "Online writes are only supported for stores with a current version capable of receiving hybrid writes.";
   static final String REQUEST_TOPIC_ERROR_UNSUPPORTED_REPLICATION_POLICY =
-      "Online writes are only supported for hybrid stores that either have AA enabled or AA disabled with the "
-          + NON_AGGREGATE + " data replication policy.";
+      "Online writes are only supported for hybrid stores that either have Active-Active replication enabled or "
+          + NON_AGGREGATE + " data replication policy when Active-Active replication is disabled.";
   static final String REQUEST_TOPIC_ERROR_FORMAT_UNSUPPORTED_PARTITIONER =
       "Expected partitioner class %s cannot be found.";
 

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/MetaDataHandler.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/MetaDataHandler.java
@@ -8,7 +8,6 @@ import static com.linkedin.venice.controllerapi.ControllerApiConstants.NAME;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.PARTITIONERS;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.STORE_PARTITION;
 import static com.linkedin.venice.controllerapi.ControllerApiConstants.STORE_VERSION;
-import static com.linkedin.venice.meta.DataReplicationPolicy.ACTIVE_ACTIVE;
 import static com.linkedin.venice.meta.DataReplicationPolicy.NON_AGGREGATE;
 import static com.linkedin.venice.router.api.RouterResourceType.TYPE_ALL_VALUE_SCHEMA_IDS;
 import static com.linkedin.venice.router.api.RouterResourceType.TYPE_CURRENT_VERSION;
@@ -139,8 +138,8 @@ public class MetaDataHandler extends SimpleChannelInboundHandler<HttpRequest> {
   static final String REQUEST_TOPIC_ERROR_CURRENT_VERSION_NOT_HYBRID =
       "Online writes are only supported for stores with a current version capable of receiving hybrid writes.";
   static final String REQUEST_TOPIC_ERROR_UNSUPPORTED_REPLICATION_POLICY =
-      "Online writes are only supported for hybrid stores that have " + ACTIVE_ACTIVE + " or " + NON_AGGREGATE
-          + " data replication policy.";
+      "Online writes are only supported for hybrid stores that either have AA enabled or AA disabled with the "
+          + NON_AGGREGATE + " data replication policy.";
   static final String REQUEST_TOPIC_ERROR_FORMAT_UNSUPPORTED_PARTITIONER =
       "Expected partitioner class %s cannot be found.";
 
@@ -764,12 +763,12 @@ public class MetaDataHandler extends SimpleChannelInboundHandler<HttpRequest> {
     }
 
     /**
-     * Only allow router request_topic for hybrid stores that have data replication policy:
-     * 1. NON_AGGREGATE
-     * 2. ACTIVE_ACTIVE
+     * Only allow router request_topic for hybrid stores that have either
+     * 1. AA enabled
+     * 2. AA disabled and data replication policy is NON_AGGREGATE
      */
     DataReplicationPolicy dataReplicationPolicy = hybridStoreConfig.getDataReplicationPolicy();
-    if (!dataReplicationPolicy.equals(NON_AGGREGATE) && !dataReplicationPolicy.equals(ACTIVE_ACTIVE)) {
+    if (!currentVersion.isActiveActiveReplicationEnabled() && !dataReplicationPolicy.equals(NON_AGGREGATE)) {
       setupResponseAndFlush(BAD_REQUEST, REQUEST_TOPIC_ERROR_UNSUPPORTED_REPLICATION_POLICY.getBytes(), false, ctx);
       return;
     }

--- a/services/venice-router/src/test/java/com/linkedin/venice/router/TestMetaDataHandler.java
+++ b/services/venice-router/src/test/java/com/linkedin/venice/router/TestMetaDataHandler.java
@@ -1309,7 +1309,7 @@ public class TestMetaDataHandler {
         Time.SECONDS_PER_DAY,
         1,
         TimeUnit.MINUTES.toSeconds(1),
-        DataReplicationPolicy.NONE,
+        DataReplicationPolicy.NON_AGGREGATE,
         BufferReplayPolicy.REWIND_FROM_EOP);
     Mockito.doReturn(true).when(store).isHybrid();
     Mockito.doReturn(nonAggStoreConfig).when(store).getHybridStoreConfig();

--- a/services/venice-router/src/test/java/com/linkedin/venice/router/TestMetaDataHandler.java
+++ b/services/venice-router/src/test/java/com/linkedin/venice/router/TestMetaDataHandler.java
@@ -1296,7 +1296,7 @@ public class TestMetaDataHandler {
   }
 
   @Test
-  public void testRequestTopicForStoreWithActiveActiveReplicationPolicy() throws IOException {
+  public void testRequestTopicForStoreWithActiveActiveStore() throws IOException {
     String clusterName = "test-cluster";
     HelixReadOnlyStoreRepository storeRepository = Mockito.mock(HelixReadOnlyStoreRepository.class);
     HelixReadOnlyStoreConfigRepository storeConfigRepository = Mockito.mock(HelixReadOnlyStoreConfigRepository.class);
@@ -1309,7 +1309,7 @@ public class TestMetaDataHandler {
         Time.SECONDS_PER_DAY,
         1,
         TimeUnit.MINUTES.toSeconds(1),
-        DataReplicationPolicy.ACTIVE_ACTIVE,
+        DataReplicationPolicy.NONE,
         BufferReplayPolicy.REWIND_FROM_EOP);
     Mockito.doReturn(true).when(store).isHybrid();
     Mockito.doReturn(nonAggStoreConfig).when(store).getHybridStoreConfig();
@@ -1321,6 +1321,7 @@ public class TestMetaDataHandler {
     Mockito.doReturn(nonAggStoreConfig).when(currentVersion).getHybridStoreConfig();
     Mockito.doReturn(1).when(currentVersion).getNumber();
     Mockito.doReturn(10).when(currentVersion).getPartitionCount();
+    Mockito.doReturn(true).when(currentVersion).isActiveActiveReplicationEnabled();
 
     Mockito.doReturn(1).when(store).getCurrentVersion();
     Mockito.doReturn(currentVersion).when(store).getVersion(1);
@@ -1361,7 +1362,7 @@ public class TestMetaDataHandler {
         Time.SECONDS_PER_DAY,
         1,
         TimeUnit.MINUTES.toSeconds(1),
-        DataReplicationPolicy.ACTIVE_ACTIVE,
+        DataReplicationPolicy.NON_AGGREGATE,
         BufferReplayPolicy.REWIND_FROM_EOP);
     Mockito.doReturn(true).when(store).isHybrid();
     Mockito.doReturn(nonAggStoreConfig).when(store).getHybridStoreConfig();
@@ -1415,7 +1416,7 @@ public class TestMetaDataHandler {
         Time.SECONDS_PER_DAY,
         1,
         TimeUnit.MINUTES.toSeconds(1),
-        DataReplicationPolicy.ACTIVE_ACTIVE,
+        DataReplicationPolicy.NON_AGGREGATE,
         BufferReplayPolicy.REWIND_FROM_EOP);
     Mockito.doReturn(true).when(store).isHybrid();
     Mockito.doReturn(nonAggStoreConfig).when(store).getHybridStoreConfig();


### PR DESCRIPTION
# Deprecate ACTIVE_ACTIVE data replication policy

Deprecate the ACTIVE_ACTIVE data replication policy, as it is no longer necessary  
for lag measurements. Additionally, deprecate the NONE data replication policy.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
CI

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.