### PR TITLE
[vpj] [controller] Enforce Record Size Limit on Batch Push Jobs

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -282,6 +282,7 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
             .setChunkingEnabled(isChunked)
             .setRmdChunkingEnabled(version.isRmdChunkingEnabled())
             .setPartitionCount(storeVersionPartitionCount)
+            .setMaxRecordSizeBytes(store.getMaxRecordSizeBytes())
             .build();
     this.veniceWriter = Lazy.of(() -> veniceWriterFactory.createVeniceWriter(writerOptions));
     this.kafkaClusterIdToUrlMap = serverConfig.getKafkaClusterIdToUrlMap();

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -282,7 +282,6 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
             .setChunkingEnabled(isChunked)
             .setRmdChunkingEnabled(version.isRmdChunkingEnabled())
             .setPartitionCount(storeVersionPartitionCount)
-            .setMaxRecordSizeBytes(store.getMaxRecordSizeBytes())
             .build();
     this.veniceWriter = Lazy.of(() -> veniceWriterFactory.createVeniceWriter(writerOptions));
     this.kafkaClusterIdToUrlMap = serverConfig.getKafkaClusterIdToUrlMap();

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
@@ -882,7 +882,7 @@ public abstract class StoreIngestionTaskTest {
 
     doReturn(1).when(mockStore).getPartitionCount();
 
-    doReturn(-1).when(mockStore).getMaxRecordSizeBytes();
+    doReturn(VeniceWriter.UNLIMITED_MAX_RECORD_SIZE).when(mockStore).getMaxRecordSizeBytes();
 
     doReturn(false).when(mockStore).isHybridStoreDiskQuotaEnabled();
     doReturn(-1).when(mockStore).getCurrentVersion();

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/Arg.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/Arg.java
@@ -246,7 +246,7 @@ public enum Arg {
   ),
   MAX_RECORD_SIZE_BYTES(
       "max-record-size-bytes", "mrsb", true,
-      "Store-level max record size in bytes. Used by VeniceWriter to fail batch push jobs and pause consumption on nearline jobs."
+      "Store-level max record size in bytes. Used by VeniceWriter to fail batch push jobs and pause consumption on nearline jobs with partial update."
   ), UNUSED_SCHEMA_DELETION_ENABLED("enable-unused-schema-deletion", "usde", true, "Enable unused schema deletion"),
   PARTITION("partition", "p", true, "Partition Id"),
   INTERVAL(

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/PushJobSetting.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/PushJobSetting.java
@@ -114,7 +114,6 @@ public class PushJobSetting implements Serializable {
   public Map<String, String> partitionerParams;
   public boolean chunkingEnabled;
   public boolean rmdChunkingEnabled;
-  public boolean largeRecordsAllowed;
   public int maxRecordSizeBytes;
   public String kafkaSourceRegion;
   public transient RepushInfoResponse repushInfoResponse;

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/PushJobSetting.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/PushJobSetting.java
@@ -114,6 +114,8 @@ public class PushJobSetting implements Serializable {
   public Map<String, String> partitionerParams;
   public boolean chunkingEnabled;
   public boolean rmdChunkingEnabled;
+  public boolean largeRecordsAllowed;
+  public int maxRecordSizeBytes;
   public String kafkaSourceRegion;
   public transient RepushInfoResponse repushInfoResponse;
 

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
@@ -2716,8 +2716,8 @@ public class VenicePushJob implements AutoCloseable {
       pushJobSetting.hybridStoreConfig = storeResponse.getStore().getHybridStoreConfig();
       pushJobSetting.maxRecordSizeBytes = storeResponse.getStore().getMaxRecordSizeBytes();
       final boolean isRepush = pushJobSetting.isSourceKafka || pushJobSetting.isSourceETL;
-      if (pushJobSetting.maxRecordSizeBytes != VeniceWriter.DEFAULT_MAX_RECORD_SIZE_BYTES && isRepush) {
-        pushJobSetting.maxRecordSizeBytes = VeniceWriter.DEFAULT_MAX_RECORD_SIZE_BYTES; // safer to allow on repush
+      if (isRepush && pushJobSetting.maxRecordSizeBytes != VeniceWriter.UNLIMITED_MAX_RECORD_SIZE) {
+        pushJobSetting.maxRecordSizeBytes = VeniceWriter.UNLIMITED_MAX_RECORD_SIZE; // safer to allow on repush
         final String repushJobType = (pushJobSetting.isSourceKafka) ? "Kafka" : "ETL";
         LOGGER.info("Setting max record size to unlimited for {} repush job", repushJobType);
       }

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/VenicePushJob.java
@@ -2714,8 +2714,12 @@ public class VenicePushJob implements AutoCloseable {
       pushJobSetting.isStoreWriteComputeEnabled = storeResponse.getStore().isWriteComputationEnabled();
       pushJobSetting.isStoreIncrementalPushEnabled = storeResponse.getStore().isIncrementalPushEnabled();
       pushJobSetting.hybridStoreConfig = storeResponse.getStore().getHybridStoreConfig();
-      final boolean isRepush = pushJobSetting.isSourceKafka || pushJobSetting.isSourceETL; // safer to simply allow them
-      pushJobSetting.maxRecordSizeBytes = (isRepush) ? -1 : storeResponse.getStore().getMaxRecordSizeBytes();
+      pushJobSetting.maxRecordSizeBytes = storeResponse.getStore().getMaxRecordSizeBytes();
+      if (pushJobSetting.maxRecordSizeBytes != -1 && (pushJobSetting.isSourceKafka || pushJobSetting.isSourceETL)) {
+        pushJobSetting.maxRecordSizeBytes = -1; // safer to simply allow large records on repush
+        final String repushJobType = (pushJobSetting.isSourceKafka) ? "Kafka" : "ETL";
+        LOGGER.info("Setting max record size to unlimited for {} repush job", repushJobType);
+      }
     }
     return pushJobSetting.storeResponse;
   }

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/mapreduce/datawriter/jobs/DataWriterMRJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/mapreduce/datawriter/jobs/DataWriterMRJob.java
@@ -144,6 +144,8 @@ public class DataWriterMRJob extends DataWriterComputeJob {
     conf.setBoolean(ALLOW_DUPLICATE_KEY, pushJobSetting.isDuplicateKeyAllowed);
     conf.setBoolean(VeniceWriter.ENABLE_CHUNKING, pushJobSetting.chunkingEnabled);
     conf.setBoolean(VeniceWriter.ENABLE_RMD_CHUNKING, pushJobSetting.rmdChunkingEnabled);
+    conf.setBoolean(VeniceWriter.LARGE_RECORDS_ALLOWED, pushJobSetting.largeRecordsAllowed);
+    conf.setInt(VeniceWriter.MAX_RECORD_SIZE_BYTES, pushJobSetting.maxRecordSizeBytes);
 
     conf.set(STORAGE_QUOTA_PROP, Long.toString(pushJobSetting.storeStorageQuota));
 

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/mapreduce/datawriter/jobs/DataWriterMRJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/mapreduce/datawriter/jobs/DataWriterMRJob.java
@@ -144,7 +144,6 @@ public class DataWriterMRJob extends DataWriterComputeJob {
     conf.setBoolean(ALLOW_DUPLICATE_KEY, pushJobSetting.isDuplicateKeyAllowed);
     conf.setBoolean(VeniceWriter.ENABLE_CHUNKING, pushJobSetting.chunkingEnabled);
     conf.setBoolean(VeniceWriter.ENABLE_RMD_CHUNKING, pushJobSetting.rmdChunkingEnabled);
-    conf.setBoolean(VeniceWriter.LARGE_RECORDS_ALLOWED, pushJobSetting.largeRecordsAllowed);
     conf.setInt(VeniceWriter.MAX_RECORD_SIZE_BYTES, pushJobSetting.maxRecordSizeBytes);
 
     conf.set(STORAGE_QUOTA_PROP, Long.toString(pushJobSetting.storeStorageQuota));

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/spark/datawriter/jobs/AbstractDataWriterSparkJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/spark/datawriter/jobs/AbstractDataWriterSparkJob.java
@@ -227,7 +227,6 @@ public abstract class AbstractDataWriterSparkJob extends DataWriterComputeJob {
     jobConf.set(ALLOW_DUPLICATE_KEY, pushJobSetting.isDuplicateKeyAllowed);
     jobConf.set(VeniceWriter.ENABLE_CHUNKING, pushJobSetting.chunkingEnabled);
     jobConf.set(VeniceWriter.ENABLE_RMD_CHUNKING, pushJobSetting.rmdChunkingEnabled);
-    jobConf.set(VeniceWriter.LARGE_RECORDS_ALLOWED, pushJobSetting.largeRecordsAllowed);
     jobConf.set(VeniceWriter.MAX_RECORD_SIZE_BYTES, pushJobSetting.maxRecordSizeBytes);
 
     jobConf.set(STORAGE_QUOTA_PROP, pushJobSetting.storeStorageQuota);

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/spark/datawriter/jobs/AbstractDataWriterSparkJob.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/spark/datawriter/jobs/AbstractDataWriterSparkJob.java
@@ -227,6 +227,8 @@ public abstract class AbstractDataWriterSparkJob extends DataWriterComputeJob {
     jobConf.set(ALLOW_DUPLICATE_KEY, pushJobSetting.isDuplicateKeyAllowed);
     jobConf.set(VeniceWriter.ENABLE_CHUNKING, pushJobSetting.chunkingEnabled);
     jobConf.set(VeniceWriter.ENABLE_RMD_CHUNKING, pushJobSetting.rmdChunkingEnabled);
+    jobConf.set(VeniceWriter.LARGE_RECORDS_ALLOWED, pushJobSetting.largeRecordsAllowed);
+    jobConf.set(VeniceWriter.MAX_RECORD_SIZE_BYTES, pushJobSetting.maxRecordSizeBytes);
 
     jobConf.set(STORAGE_QUOTA_PROP, pushJobSetting.storeStorageQuota);
 

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/task/datawriter/AbstractPartitionWriter.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/task/datawriter/AbstractPartitionWriter.java
@@ -355,6 +355,8 @@ public abstract class AbstractPartitionWriter extends AbstractDataWriterTask imp
     VeniceWriterFactory veniceWriterFactoryFactory = new VeniceWriterFactory(writerProps);
     boolean chunkingEnabled = props.getBoolean(VeniceWriter.ENABLE_CHUNKING, false);
     boolean rmdChunkingEnabled = props.getBoolean(VeniceWriter.ENABLE_RMD_CHUNKING, false);
+    String maxRecordSizeBytesStr = (String) jobProps
+        .getOrDefault(VeniceWriter.MAX_RECORD_SIZE_BYTES, String.valueOf(VeniceWriter.DEFAULT_MAX_RECORD_SIZE_BYTES));
     VenicePartitioner partitioner = PartitionUtils.getVenicePartitioner(props);
 
     VeniceWriterOptions options =
@@ -366,6 +368,7 @@ public abstract class AbstractPartitionWriter extends AbstractDataWriterTask imp
             .setTime(SystemTime.INSTANCE)
             .setPartitionCount(getPartitionCount())
             .setPartitioner(partitioner)
+            .setMaxRecordSizeBytes(Integer.parseInt(maxRecordSizeBytesStr))
             .build();
     return veniceWriterFactoryFactory.createVeniceWriter(options);
   }

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/task/datawriter/AbstractPartitionWriter.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/task/datawriter/AbstractPartitionWriter.java
@@ -356,7 +356,7 @@ public abstract class AbstractPartitionWriter extends AbstractDataWriterTask imp
     boolean chunkingEnabled = props.getBoolean(VeniceWriter.ENABLE_CHUNKING, false);
     boolean rmdChunkingEnabled = props.getBoolean(VeniceWriter.ENABLE_RMD_CHUNKING, false);
     String maxRecordSizeBytesStr = (String) jobProps
-        .getOrDefault(VeniceWriter.MAX_RECORD_SIZE_BYTES, String.valueOf(VeniceWriter.DEFAULT_MAX_RECORD_SIZE_BYTES));
+        .getOrDefault(VeniceWriter.MAX_RECORD_SIZE_BYTES, String.valueOf(VeniceWriter.UNLIMITED_MAX_RECORD_SIZE));
     VenicePartitioner partitioner = PartitionUtils.getVenicePartitioner(props);
 
     VeniceWriterOptions options =

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/VenicePushJobTest.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/VenicePushJobTest.java
@@ -27,6 +27,7 @@ import static com.linkedin.venice.hadoop.VenicePushJobConstants.VALUE_FIELD_PROP
 import static com.linkedin.venice.hadoop.VenicePushJobConstants.VENICE_DISCOVER_URL_PROP;
 import static com.linkedin.venice.hadoop.VenicePushJobConstants.VENICE_STORE_NAME_PROP;
 import static com.linkedin.venice.status.BatchJobHeartbeatConfigs.HEARTBEAT_ENABLED_CONFIG;
+import static com.linkedin.venice.utils.ByteUtils.BYTES_PER_MB;
 import static com.linkedin.venice.utils.TestWriteUtils.NAME_RECORD_V1_SCHEMA;
 import static com.linkedin.venice.utils.TestWriteUtils.NAME_RECORD_V1_UPDATE_SCHEMA;
 import static org.mockito.ArgumentMatchers.any;
@@ -1007,6 +1008,6 @@ public class VenicePushJobTest {
     setting.partitionerClass = DefaultVenicePartitioner.class.getCanonicalName();
     setting.topic = Version.composeKafkaTopic(setting.storeName, 7);
     setting.partitionCount = 1;
-    setting.maxRecordSizeBytes = 100 * 1024 * 1024;
+    setting.maxRecordSizeBytes = 100 * BYTES_PER_MB;
   }
 }

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/VenicePushJobTest.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/VenicePushJobTest.java
@@ -899,7 +899,7 @@ public class VenicePushJobTest {
       // The value of chunkingEnabled should dictate the error message returned
       final String errorMessage = vpj.updatePushJobDetailsWithJobDetails(dataWriterTaskTracker);
       final int latestCheckpoint = pushJobDetails.pushJobLatestCheckpoint;
-      Assert.assertTrue(errorMessage.contains((chunkingEnabled) ? "10.0 MiB" : "950.0 KiB"), errorMessage);
+      Assert.assertTrue(errorMessage.contains((chunkingEnabled) ? "100.0 MiB" : "950.0 KiB"), errorMessage);
       Assert.assertEquals(latestCheckpoint, VenicePushJob.PushJobCheckpoints.RECORD_TOO_LARGE_FAILED.getValue());
     }
   }
@@ -999,9 +999,7 @@ public class VenicePushJobTest {
     doNothing().when(pushJob).runJobAndUpdateStatus();
   }
 
-  /**
-   * Sets basic values for the given {@link PushJobSetting} object in order for VeniceWriter to be constructed.
-   */
+  /** Sets basic values for the given {@link PushJobSetting} object in order for VeniceWriter to be constructed. */
   private void setPushJobSettingDefaults(PushJobSetting setting) {
     setting.storeName = TEST_STORE;
     setting.kafkaUrl = "localhost:9092";
@@ -1009,6 +1007,6 @@ public class VenicePushJobTest {
     setting.partitionerClass = DefaultVenicePartitioner.class.getCanonicalName();
     setting.topic = Version.composeKafkaTopic(setting.storeName, 7);
     setting.partitionCount = 1;
-    setting.maxRecordSizeBytes = -1;
+    setting.maxRecordSizeBytes = 100 * 1024 * 1024;
   }
 }

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/VenicePushJobTest.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/VenicePushJobTest.java
@@ -1,5 +1,6 @@
 package com.linkedin.venice.hadoop;
 
+import static com.linkedin.venice.ConfigKeys.LARGE_RECORDS_ALLOWED;
 import static com.linkedin.venice.hadoop.VenicePushJob.getExecutionStatusFromControllerResponse;
 import static com.linkedin.venice.hadoop.VenicePushJobConstants.CONTROLLER_REQUEST_RETRY_ATTEMPTS;
 import static com.linkedin.venice.hadoop.VenicePushJobConstants.D2_ZK_HOSTS_PREFIX;
@@ -66,6 +67,8 @@ import com.linkedin.venice.controllerapi.VersionCreationResponse;
 import com.linkedin.venice.exceptions.UndefinedPropertyException;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.hadoop.exceptions.VeniceValidationException;
+import com.linkedin.venice.hadoop.task.datawriter.DataWriterTaskTracker;
+import com.linkedin.venice.message.KafkaKey;
 import com.linkedin.venice.meta.HybridStoreConfigImpl;
 import com.linkedin.venice.meta.StoreInfo;
 import com.linkedin.venice.meta.Version;
@@ -74,10 +77,12 @@ import com.linkedin.venice.partitioner.DefaultVenicePartitioner;
 import com.linkedin.venice.pushmonitor.ExecutionStatus;
 import com.linkedin.venice.schema.AvroSchemaParseUtils;
 import com.linkedin.venice.status.PushJobDetailsStatus;
+import com.linkedin.venice.status.protocol.PushJobDetails;
 import com.linkedin.venice.utils.DataProviderUtils;
 import com.linkedin.venice.utils.TestWriteUtils;
 import com.linkedin.venice.utils.Time;
 import com.linkedin.venice.utils.VeniceProperties;
+import com.linkedin.venice.writer.VeniceWriter;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -877,6 +882,66 @@ public class VenicePushJobTest {
     }
   }
 
+  /**
+   * Tests that the error message for the {@link VenicePushJob.PushJobCheckpoints#RECORD_TOO_LARGE_FAILED} code path of
+   * {@link VenicePushJob#updatePushJobDetailsWithJobDetails(DataWriterTaskTracker)} uses maxRecordSizeBytes.
+   */
+  @Test(dataProvider = "True-and-False", dataProviderClass = DataProviderUtils.class)
+  public void testUpdatePushJobDetailsWithJobDetailsRecordTooLarge(boolean chunkingEnabled) {
+    try (final VenicePushJob vpj = getSpyVenicePushJob(getVpjRequiredProperties(), getClient())) {
+      // Setup push job settings and mocks
+      PushJobDetails pushJobDetails = vpj.getPushJobDetails();
+      pushJobDetails.chunkingEnabled = chunkingEnabled;
+      setPushJobSettingDefaults(vpj.getPushJobSetting());
+      vpj.setInputStorageQuotaTracker(mock(InputStorageQuotaTracker.class));
+      final DataWriterTaskTracker dataWriterTaskTracker = mock(DataWriterTaskTracker.class);
+      doReturn(1L).when(dataWriterTaskTracker).getRecordTooLargeFailureCount();
+
+      // The value of chunkingEnabled should dictate the error message returned
+      final String errorMessage = vpj.updatePushJobDetailsWithJobDetails(dataWriterTaskTracker);
+      final int latestCheckpoint = pushJobDetails.pushJobLatestCheckpoint;
+      Assert.assertTrue(errorMessage.contains((chunkingEnabled) ? "10.0 MiB" : "950.0 KiB"), errorMessage);
+      Assert.assertEquals(latestCheckpoint, VenicePushJob.PushJobCheckpoints.RECORD_TOO_LARGE_FAILED.getValue());
+    }
+  }
+
+  /**
+   * Tests that when {@link PushJobSetting#isSourceKafka}=true, {@link VenicePushJob} will override the value of
+   * {@link PushJobSetting#largeRecordsAllowed} and set it to true.
+   */
+  @Test(dataProvider = "Three-True-and-False", dataProviderClass = DataProviderUtils.class)
+  public void testLargeRecordsAllowedRepush(boolean largeRecordsAllowed, boolean isSourceKafka, boolean isSourceETL) {
+    Properties props = getVpjRequiredProperties();
+    props.put(SOURCE_ETL, isSourceETL);
+    props.put(SOURCE_KAFKA, isSourceKafka);
+    props.put(LARGE_RECORDS_ALLOWED, largeRecordsAllowed);
+    final boolean isRepush = isSourceKafka || isSourceETL;
+    if (!(isSourceKafka && isSourceETL)) { // both true is an invalid test case that will cause validation error
+      try (final VenicePushJob vpj = getSpyVenicePushJob(props, getClient())) {
+        PushJobSetting pushJobSetting = vpj.getPushJobSetting();
+        Assert.assertEquals(pushJobSetting.largeRecordsAllowed, largeRecordsAllowed || isRepush);
+      }
+    }
+  }
+
+  /**
+   * These are mainly for code coverage for the code paths of {@link VenicePushJob#getVeniceWriter(PushJobSetting)} and
+   * {@link VenicePushJob#getVeniceWriterProperties(PushJobSetting)}.
+   */
+  @Test
+  public void testGetVeniceWriter() {
+    Properties props = getVpjRequiredProperties();
+    props.put(VeniceWriter.CLOSE_TIMEOUT_MS, 1000);
+    props.put(VeniceWriter.LARGE_RECORDS_ALLOWED, true);
+    try (final VenicePushJob vpj = getSpyVenicePushJob(props, getClient())) {
+      PushJobSetting pushJobSetting = vpj.getPushJobSetting();
+      setPushJobSettingDefaults(pushJobSetting);
+      final VeniceWriter<KafkaKey, byte[], byte[]> veniceWriter = vpj.getVeniceWriter(pushJobSetting);
+      Assert.assertNotNull(veniceWriter, "VeniceWriter should've been constructed and returned");
+      Assert.assertEquals(veniceWriter, vpj.getVeniceWriter(pushJobSetting), "Second get() should return same object");
+    }
+  }
+
   private JobStatusQueryResponse mockJobStatusQuery() {
     JobStatusQueryResponse response = new JobStatusQueryResponse();
     response.setStatus(ExecutionStatus.COMPLETED.toString());
@@ -953,5 +1018,18 @@ public class VenicePushJobTest {
     doNothing().when(pushJob).validateKeySchema(any());
     doNothing().when(pushJob).validateValueSchema(any(), any(), anyBoolean());
     doNothing().when(pushJob).runJobAndUpdateStatus();
+  }
+
+  /**
+   * Sets basic values for the given {@link PushJobSetting} object in order for VeniceWriter to be constructed.
+   */
+  private void setPushJobSettingDefaults(PushJobSetting setting) {
+    setting.storeName = TEST_STORE;
+    setting.kafkaUrl = "localhost:9092";
+    setting.partitionerParams = new HashMap<>();
+    setting.partitionerClass = DefaultVenicePartitioner.class.getCanonicalName();
+    setting.topic = Version.composeKafkaTopic(setting.storeName, 7);
+    setting.partitionCount = 1;
+    setting.maxRecordSizeBytes = -1;
   }
 }

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/VenicePushJobTest.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/VenicePushJobTest.java
@@ -1,6 +1,5 @@
 package com.linkedin.venice.hadoop;
 
-import static com.linkedin.venice.ConfigKeys.LARGE_RECORDS_ALLOWED;
 import static com.linkedin.venice.hadoop.VenicePushJob.getExecutionStatusFromControllerResponse;
 import static com.linkedin.venice.hadoop.VenicePushJobConstants.CONTROLLER_REQUEST_RETRY_ATTEMPTS;
 import static com.linkedin.venice.hadoop.VenicePushJobConstants.D2_ZK_HOSTS_PREFIX;
@@ -906,25 +905,6 @@ public class VenicePushJobTest {
   }
 
   /**
-   * Tests that when {@link PushJobSetting#isSourceKafka}=true, {@link VenicePushJob} will override the value of
-   * {@link PushJobSetting#largeRecordsAllowed} and set it to true.
-   */
-  @Test(dataProvider = "Three-True-and-False", dataProviderClass = DataProviderUtils.class)
-  public void testLargeRecordsAllowedRepush(boolean largeRecordsAllowed, boolean isSourceKafka, boolean isSourceETL) {
-    Properties props = getVpjRequiredProperties();
-    props.put(SOURCE_ETL, isSourceETL);
-    props.put(SOURCE_KAFKA, isSourceKafka);
-    props.put(LARGE_RECORDS_ALLOWED, largeRecordsAllowed);
-    final boolean isRepush = isSourceKafka || isSourceETL;
-    if (!(isSourceKafka && isSourceETL)) { // both true is an invalid test case that will cause validation error
-      try (final VenicePushJob vpj = getSpyVenicePushJob(props, getClient())) {
-        PushJobSetting pushJobSetting = vpj.getPushJobSetting();
-        Assert.assertEquals(pushJobSetting.largeRecordsAllowed, largeRecordsAllowed || isRepush);
-      }
-    }
-  }
-
-  /**
    * These are mainly for code coverage for the code paths of {@link VenicePushJob#getVeniceWriter(PushJobSetting)} and
    * {@link VenicePushJob#getVeniceWriterProperties(PushJobSetting)}.
    */
@@ -932,7 +912,6 @@ public class VenicePushJobTest {
   public void testGetVeniceWriter() {
     Properties props = getVpjRequiredProperties();
     props.put(VeniceWriter.CLOSE_TIMEOUT_MS, 1000);
-    props.put(VeniceWriter.LARGE_RECORDS_ALLOWED, true);
     try (final VenicePushJob vpj = getSpyVenicePushJob(props, getClient())) {
       PushJobSetting pushJobSetting = vpj.getPushJobSetting();
       setPushJobSettingDefaults(pushJobSetting);

--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -2162,4 +2162,10 @@ public class ConfigKeys {
    */
   public static final String CONTROLLER_DANGLING_TOPIC_OCCURRENCE_THRESHOLD_FOR_CLEANUP =
       "controller.dangling.topic.occurrence.threshold.for.cleanup";
+
+  /**
+   * Whether to allow large records (which violate the specified store-level setting `maxRecordSizeBytes` in
+   * {@link com.linkedin.venice.meta.Store}). This feature flag will be read in the VenicePushJob and consumer pool.
+   */
+  public static final String LARGE_RECORDS_ALLOWED = "large.records.allowed";
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -2162,10 +2162,4 @@ public class ConfigKeys {
    */
   public static final String CONTROLLER_DANGLING_TOPIC_OCCURRENCE_THRESHOLD_FOR_CLEANUP =
       "controller.dangling.topic.occurrence.threshold.for.cleanup";
-
-  /**
-   * Whether to allow large records (which violate the specified store-level setting `maxRecordSizeBytes` in
-   * {@link com.linkedin.venice.meta.Store}). This feature flag will be read in the VenicePushJob and consumer pool.
-   */
-  public static final String LARGE_RECORDS_ALLOWED = "large.records.allowed";
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -2165,7 +2165,7 @@ public class ConfigKeys {
 
   /**
    * Controller config for the default value of {@link com.linkedin.venice.writer.VeniceWriter#maxRecordSizeBytes}.
-   * Only used in batch push and nearline jobs.
+   * Only used in batch push jobs and partial updates.
    */
   public static final String CONTROLLER_DEFAULT_MAX_RECORD_SIZE_BYTES = "controller.default.max.record.size.bytes";
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -2162,4 +2162,10 @@ public class ConfigKeys {
    */
   public static final String CONTROLLER_DANGLING_TOPIC_OCCURRENCE_THRESHOLD_FOR_CLEANUP =
       "controller.dangling.topic.occurrence.threshold.for.cleanup";
+
+  /**
+   * Controller config for the default value of {@link com.linkedin.venice.writer.VeniceWriter#maxRecordSizeBytes}.
+   * Only used in batch push and nearline jobs.
+   */
+  public static final String CONTROLLER_DEFAULT_MAX_RECORD_SIZE_BYTES = "controller.default.max.record.size.bytes";
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/StoreInfo.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/StoreInfo.java
@@ -779,6 +779,7 @@ public class StoreInfo {
     return this.maxRecordSizeBytes;
   }
 
+  // TODO: this code running on VPJ should set default value, even for controllers running on older versions right?
   public void setMaxRecordSizeBytes(int maxRecordSizeBytes) {
     this.maxRecordSizeBytes = maxRecordSizeBytes;
   }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/StoreInfo.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/StoreInfo.java
@@ -5,6 +5,7 @@ import static com.linkedin.venice.meta.Store.NUM_VERSION_PRESERVE_NOT_SET;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.linkedin.venice.compression.CompressionStrategy;
+import com.linkedin.venice.writer.VeniceWriter;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -312,7 +313,7 @@ public class StoreInfo {
 
   private long maxCompactionLagSeconds;
 
-  private int maxRecordSizeBytes;
+  private int maxRecordSizeBytes = VeniceWriter.UNLIMITED_MAX_RECORD_SIZE;
 
   private boolean unusedSchemaDeletionEnabled;
 

--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/StoreInfo.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/StoreInfo.java
@@ -779,7 +779,6 @@ public class StoreInfo {
     return this.maxRecordSizeBytes;
   }
 
-  // TODO: this code running on VPJ should set default value, even for controllers running on older versions right?
   public void setMaxRecordSizeBytes(int maxRecordSizeBytes) {
     this.maxRecordSizeBytes = maxRecordSizeBytes;
   }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/writer/VeniceWriter.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/writer/VeniceWriter.java
@@ -126,7 +126,7 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
       VENICE_WRITER_CONFIG_PREFIX + "max.size.for.user.payload.per.message.in.bytes";
 
   /**
-   * Maximum Venice record size. Default: {@value DEFAULT_MAX_RECORD_SIZE_BYTES}
+   * Maximum Venice record size. Default: {@value UNLIMITED_MAX_RECORD_SIZE}
    *
    * Large records can cause performance issues, so this setting is used to detect and prevent them. Not to be confused
    * with Kafka record size (which is the ~1MB limit {@link VeniceWriter#MAX_SIZE_FOR_USER_PAYLOAD_PER_MESSAGE_IN_BYTES}
@@ -147,10 +147,11 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
   public static final int DEFAULT_MAX_SIZE_FOR_USER_PAYLOAD_PER_MESSAGE_IN_BYTES = 950 * 1024;
 
   /**
-   * Unlimited / unset (-1) just to be safe. An actual value should be set for batch push jobs and partial updates
-   * using the controller config {@link com.linkedin.venice.ConfigKeys#CONTROLLER_DEFAULT_MAX_RECORD_SIZE_BYTES}.
+   * The default for {@link #maxRecordSizeBytes} is unlimited / unset (-1) just to be safe. A more specific default value
+   * should be set using {@link com.linkedin.venice.ConfigKeys#CONTROLLER_DEFAULT_MAX_RECORD_SIZE_BYTES} the controller
+   * config on the cluster level.
    */
-  public static final int DEFAULT_MAX_RECORD_SIZE_BYTES = -1;
+  public static final int UNLIMITED_MAX_RECORD_SIZE = -1;
 
   /**
    * This controls the Kafka producer's close timeout.
@@ -320,7 +321,7 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
                 + " is true and the topic is Version Topic");
       }
     }
-    if (maxRecordSizeBytes != DEFAULT_MAX_RECORD_SIZE_BYTES
+    if (maxRecordSizeBytes != UNLIMITED_MAX_RECORD_SIZE
         && maxSizeForUserPayloadPerMessageInBytes > maxRecordSizeBytes) {
       throw new VeniceException(
           MAX_SIZE_FOR_USER_PAYLOAD_PER_MESSAGE_IN_BYTES + '=' + maxSizeForUserPayloadPerMessageInBytes
@@ -1601,7 +1602,7 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
         + "Replication Metadata size: " + replicationMetadataPayloadSize + " bytes, " + "Total payload size: "
         + (serializedKeySize + serializedValueSize + replicationMetadataPayloadSize) + " bytes, "
         + "Max available payload size: " + maxSizeForUserPayloadPerMessageInBytes + " bytes"
-        + ((maxRecordSizeBytes == DEFAULT_MAX_RECORD_SIZE_BYTES)
+        + ((maxRecordSizeBytes == UNLIMITED_MAX_RECORD_SIZE)
             ? ""
             : ", Max Venice record size: " + maxRecordSizeBytes + " bytes")
         + ".";
@@ -2088,7 +2089,7 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
   }
 
   public boolean isRecordTooLarge(int recordSize) {
-    return maxRecordSizeBytes != DEFAULT_MAX_RECORD_SIZE_BYTES && recordSize > maxRecordSizeBytes;
+    return maxRecordSizeBytes != UNLIMITED_MAX_RECORD_SIZE && recordSize > maxRecordSizeBytes;
   }
 
   public boolean isChunkingNeededForRecord(int recordSize) {

--- a/internal/venice-common/src/main/java/com/linkedin/venice/writer/VeniceWriter.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/writer/VeniceWriter.java
@@ -312,20 +312,21 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
     if (maxSizeForUserPayloadPerMessageInBytes > DEFAULT_MAX_SIZE_FOR_USER_PAYLOAD_PER_MESSAGE_IN_BYTES) {
       if (!isChunkingEnabled) {
         throw new VeniceException(
-            MAX_SIZE_FOR_USER_PAYLOAD_PER_MESSAGE_IN_BYTES + " cannot be set higher than "
-                + DEFAULT_MAX_SIZE_FOR_USER_PAYLOAD_PER_MESSAGE_IN_BYTES + " unless " + ENABLE_CHUNKING + " is true");
+            MAX_SIZE_FOR_USER_PAYLOAD_PER_MESSAGE_IN_BYTES + " (" + maxSizeForUserPayloadPerMessageInBytes
+                + ") cannot be set higher than " + DEFAULT_MAX_SIZE_FOR_USER_PAYLOAD_PER_MESSAGE_IN_BYTES + " unless "
+                + ENABLE_CHUNKING + " is true");
       } else if (isChunkingEnabled && !Version.isVersionTopic(topicName)) {
         throw new VeniceException(
-            MAX_SIZE_FOR_USER_PAYLOAD_PER_MESSAGE_IN_BYTES + " cannot be set higher than "
-                + DEFAULT_MAX_SIZE_FOR_USER_PAYLOAD_PER_MESSAGE_IN_BYTES + " unless " + ENABLE_CHUNKING
-                + " is true and the topic is Version Topic");
+            MAX_SIZE_FOR_USER_PAYLOAD_PER_MESSAGE_IN_BYTES + " (" + maxSizeForUserPayloadPerMessageInBytes
+                + ") cannot be set higher than " + DEFAULT_MAX_SIZE_FOR_USER_PAYLOAD_PER_MESSAGE_IN_BYTES + " unless "
+                + ENABLE_CHUNKING + " is true and the topic is Version Topic");
       }
     }
     if (maxRecordSizeBytes != UNLIMITED_MAX_RECORD_SIZE
         && maxSizeForUserPayloadPerMessageInBytes > maxRecordSizeBytes) {
       throw new VeniceException(
-          MAX_SIZE_FOR_USER_PAYLOAD_PER_MESSAGE_IN_BYTES + '=' + maxSizeForUserPayloadPerMessageInBytes
-              + " cannot be set higher than " + MAX_RECORD_SIZE_BYTES + '=' + maxRecordSizeBytes);
+          MAX_SIZE_FOR_USER_PAYLOAD_PER_MESSAGE_IN_BYTES + " (" + maxSizeForUserPayloadPerMessageInBytes
+              + ") cannot be set higher than " + MAX_RECORD_SIZE_BYTES + " (" + maxRecordSizeBytes + ')');
     }
     this.isChunkingFlagInvoked = false;
     this.maxAttemptsWhenTopicMissing =
@@ -1601,11 +1602,8 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
     return "Key size: " + serializedKeySize + " bytes, " + "Value size: " + serializedValueSize + " bytes, "
         + "Replication Metadata size: " + replicationMetadataPayloadSize + " bytes, " + "Total payload size: "
         + (serializedKeySize + serializedValueSize + replicationMetadataPayloadSize) + " bytes, "
-        + "Max available payload size: " + maxSizeForUserPayloadPerMessageInBytes + " bytes"
-        + ((maxRecordSizeBytes == UNLIMITED_MAX_RECORD_SIZE)
-            ? ""
-            : ", Max Venice record size: " + maxRecordSizeBytes + " bytes")
-        + ".";
+        + "Max available payload size: " + maxSizeForUserPayloadPerMessageInBytes + " bytes, " + ", Max record size: "
+        + ((maxRecordSizeBytes == UNLIMITED_MAX_RECORD_SIZE) ? "unlimited" : maxRecordSizeBytes) + " bytes.";
   }
 
   /**

--- a/internal/venice-common/src/main/java/com/linkedin/venice/writer/VeniceWriter.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/writer/VeniceWriter.java
@@ -305,7 +305,7 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
     this.isChunkingEnabled = params.isChunkingEnabled();
     this.isChunkingSet = true;
     this.isRmdChunkingEnabled = params.isRmdChunkingEnabled();
-    this.maxRecordSizeBytes = props.getInt(MAX_RECORD_SIZE_BYTES, DEFAULT_MAX_RECORD_SIZE_BYTES);
+    this.maxRecordSizeBytes = params.getMaxRecordSizeBytes();
     this.maxSizeForUserPayloadPerMessageInBytes = props
         .getInt(MAX_SIZE_FOR_USER_PAYLOAD_PER_MESSAGE_IN_BYTES, DEFAULT_MAX_SIZE_FOR_USER_PAYLOAD_PER_MESSAGE_IN_BYTES);
     if (maxSizeForUserPayloadPerMessageInBytes > DEFAULT_MAX_SIZE_FOR_USER_PAYLOAD_PER_MESSAGE_IN_BYTES) {
@@ -320,7 +320,8 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
                 + " is true and the topic is Version Topic");
       }
     }
-    if (maxRecordSizeBytes != -1 && maxSizeForUserPayloadPerMessageInBytes > maxRecordSizeBytes) {
+    if (maxRecordSizeBytes != DEFAULT_MAX_RECORD_SIZE_BYTES
+        && maxSizeForUserPayloadPerMessageInBytes > maxRecordSizeBytes) {
       throw new VeniceException(
           MAX_SIZE_FOR_USER_PAYLOAD_PER_MESSAGE_IN_BYTES + '=' + maxSizeForUserPayloadPerMessageInBytes
               + " cannot be set higher than " + MAX_RECORD_SIZE_BYTES + '=' + maxRecordSizeBytes);
@@ -1600,7 +1601,10 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
         + "Replication Metadata size: " + replicationMetadataPayloadSize + " bytes, " + "Total payload size: "
         + (serializedKeySize + serializedValueSize + replicationMetadataPayloadSize) + " bytes, "
         + "Max available payload size: " + maxSizeForUserPayloadPerMessageInBytes + " bytes"
-        + ((maxRecordSizeBytes == -1) ? "" : ", Max Venice record size: " + maxRecordSizeBytes + " bytes") + ".";
+        + ((maxRecordSizeBytes == DEFAULT_MAX_RECORD_SIZE_BYTES)
+            ? ""
+            : ", Max Venice record size: " + maxRecordSizeBytes + " bytes")
+        + ".";
   }
 
   /**
@@ -2084,7 +2088,7 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
   }
 
   public boolean isRecordTooLarge(int recordSize) {
-    return maxRecordSizeBytes != -1 && recordSize > maxRecordSizeBytes; // -1 means no limit / maximum size
+    return maxRecordSizeBytes != DEFAULT_MAX_RECORD_SIZE_BYTES && recordSize > maxRecordSizeBytes;
   }
 
   public boolean isChunkingNeededForRecord(int recordSize) {

--- a/internal/venice-common/src/main/java/com/linkedin/venice/writer/VeniceWriterOptions.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/writer/VeniceWriterOptions.java
@@ -144,7 +144,7 @@ public class VeniceWriterOptions {
         time = SystemTime.INSTANCE;
       }
       if (maxRecordSizeBytes == null) {
-        maxRecordSizeBytes = -1;
+        maxRecordSizeBytes = VeniceWriter.UNLIMITED_MAX_RECORD_SIZE;
       }
     }
 

--- a/internal/venice-common/src/main/java/com/linkedin/venice/writer/VeniceWriterOptions.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/writer/VeniceWriterOptions.java
@@ -26,6 +26,7 @@ public class VeniceWriterOptions {
   private final Integer partitionCount;
   private final boolean chunkingEnabled;
   private final boolean rmdChunkingEnabled;
+  private final Integer maxRecordSizeBytes;
   // Set this field if you want to use different broker address than the local broker address
   private final String brokerAddress;
 
@@ -69,6 +70,10 @@ public class VeniceWriterOptions {
     return rmdChunkingEnabled;
   }
 
+  public Integer getMaxRecordSizeBytes() {
+    return maxRecordSizeBytes;
+  }
+
   private VeniceWriterOptions(Builder builder) {
     topicName = builder.topicName;
     keySerializer = builder.keySerializer;
@@ -79,6 +84,7 @@ public class VeniceWriterOptions {
     partitionCount = builder.partitionCount;
     chunkingEnabled = builder.chunkingEnabled;
     rmdChunkingEnabled = builder.rmdChunkingEnabled;
+    maxRecordSizeBytes = builder.maxRecordSizeBytes;
     brokerAddress = builder.brokerAddress;
   }
 
@@ -95,6 +101,15 @@ public class VeniceWriterOptions {
         .append(", ")
         .append("partitionCount:")
         .append(partitionCount != null ? partitionCount : "-")
+        .append(", ")
+        .append("chunkingEnabled:")
+        .append(chunkingEnabled)
+        .append(", ")
+        .append("rmdChunkingEnabled:")
+        .append(rmdChunkingEnabled)
+        .append(", ")
+        .append("maxRecordSizeBytes:")
+        .append(maxRecordSizeBytes != null ? maxRecordSizeBytes : -1)
         .append("}")
         .toString();
   }
@@ -109,6 +124,7 @@ public class VeniceWriterOptions {
     private Integer partitionCount = null; // default null
     private boolean chunkingEnabled; // default false
     private boolean rmdChunkingEnabled; // default false
+    private Integer maxRecordSizeBytes = null; // default null
     private String brokerAddress = null; // default null
 
     private void addDefaults() {
@@ -126,6 +142,9 @@ public class VeniceWriterOptions {
       }
       if (time == null) {
         time = SystemTime.INSTANCE;
+      }
+      if (maxRecordSizeBytes == null) {
+        maxRecordSizeBytes = -1;
       }
     }
 
@@ -187,6 +206,11 @@ public class VeniceWriterOptions {
 
     public Builder setPartitionCount(Integer partitionCount) {
       this.partitionCount = partitionCount;
+      return this;
+    }
+
+    public Builder setMaxRecordSizeBytes(Integer maxRecordSizeBytes) {
+      this.maxRecordSizeBytes = maxRecordSizeBytes;
       return this;
     }
   }

--- a/internal/venice-common/src/test/java/com/linkedin/venice/meta/TestSystemStore.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/meta/TestSystemStore.java
@@ -9,6 +9,7 @@ import static org.testng.Assert.assertTrue;
 import com.linkedin.venice.common.VeniceSystemStoreType;
 import com.linkedin.venice.compression.CompressionStrategy;
 import com.linkedin.venice.partitioner.DefaultVenicePartitioner;
+import com.linkedin.venice.writer.VeniceWriter;
 import org.testng.annotations.Test;
 
 
@@ -105,7 +106,7 @@ public class TestSystemStore {
     assertEquals(systemStore.getNativeReplicationSourceFabric(), "");
     assertFalse(systemStore.isDaVinciPushStatusStoreEnabled());
     assertFalse(systemStore.isBlobTransferEnabled());
-    assertEquals(systemStore.getMaxRecordSizeBytes(), -1);
+    assertEquals(systemStore.getMaxRecordSizeBytes(), VeniceWriter.UNLIMITED_MAX_RECORD_SIZE);
 
     // All the shared store-level property update should throw exception
     assertThrows(() -> systemStore.setOwner("test"));

--- a/internal/venice-common/src/test/java/com/linkedin/venice/writer/VeniceWriterFactoryTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/writer/VeniceWriterFactoryTest.java
@@ -35,7 +35,7 @@ public class VeniceWriterFactoryTest {
       assertNotNull(capturedBrokerAddr);
       assertEquals(capturedBrokerAddr, "store_v1@kafka:9898");
 
-      assertEquals(veniceWriter.getMaxRecordSizeBytes(), VeniceWriter.DEFAULT_MAX_RECORD_SIZE_BYTES);
+      assertEquals(veniceWriter.getMaxRecordSizeBytes(), VeniceWriter.UNLIMITED_MAX_RECORD_SIZE);
     }
   }
 

--- a/internal/venice-common/src/test/java/com/linkedin/venice/writer/VeniceWriterFactoryTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/writer/VeniceWriterFactoryTest.java
@@ -34,6 +34,8 @@ public class VeniceWriterFactoryTest {
       String capturedBrokerAddr = veniceWriter.getDestination();
       assertNotNull(capturedBrokerAddr);
       assertEquals(capturedBrokerAddr, "store_v1@kafka:9898");
+
+      assertEquals(veniceWriter.getMaxRecordSizeBytes(), VeniceWriter.DEFAULT_MAX_RECORD_SIZE_BYTES);
     }
   }
 

--- a/internal/venice-common/src/test/java/com/linkedin/venice/writer/VeniceWriterUnitTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/writer/VeniceWriterUnitTest.java
@@ -2,6 +2,8 @@ package com.linkedin.venice.writer;
 
 import static com.linkedin.venice.message.KafkaKey.HEART_BEAT;
 import static com.linkedin.venice.pubsub.api.PubSubMessageHeaders.VENICE_LEADER_COMPLETION_STATE_HEADER;
+import static com.linkedin.venice.utils.ByteUtils.BYTES_PER_KB;
+import static com.linkedin.venice.utils.ByteUtils.BYTES_PER_MB;
 import static com.linkedin.venice.writer.LeaderCompleteState.LEADER_COMPLETED;
 import static com.linkedin.venice.writer.LeaderCompleteState.LEADER_NOT_COMPLETED;
 import static com.linkedin.venice.writer.VeniceWriter.APP_DEFAULT_LOGICAL_TS;
@@ -628,7 +630,7 @@ public class VeniceWriterUnitTest {
    */
   @Test(dataProvider = "True-and-False", dataProviderClass = DataProviderUtils.class, timeOut = TIMEOUT)
   public void testPutTooLargeRecord(boolean isChunkingEnabled) {
-    final int maxRecordSizeBytes = 1024 * 1024; // 1MB
+    final int maxRecordSizeBytes = BYTES_PER_MB; // 1MB
     CompletableFuture mockedFuture = mock(CompletableFuture.class);
     PubSubProducerAdapter mockedProducer = mock(PubSubProducerAdapter.class);
     when(mockedProducer.sendMessage(any(), any(), any(), any(), any(), any())).thenReturn(mockedFuture);
@@ -644,7 +646,7 @@ public class VeniceWriterUnitTest {
 
     // "small" < maxSizeForUserPayloadPerMessageInBytes < "large" < maxRecordSizeBytes < "too large"
     final int SMALL_VALUE_SIZE = maxRecordSizeBytes / 2;
-    final int LARGE_VALUE_SIZE = maxRecordSizeBytes - 1024; // offset to account for the size of the key
+    final int LARGE_VALUE_SIZE = maxRecordSizeBytes - BYTES_PER_KB; // offset to account for the size of the key
     final int TOO_LARGE_VALUE_SIZE = maxRecordSizeBytes * 2;
 
     for (int size: Arrays.asList(SMALL_VALUE_SIZE, LARGE_VALUE_SIZE, TOO_LARGE_VALUE_SIZE)) {

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/VeniceParentHelixAdminTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/VeniceParentHelixAdminTest.java
@@ -10,6 +10,7 @@ import static com.linkedin.venice.controller.SchemaConstants.VALUE_SCHEMA_FOR_WR
 import static com.linkedin.venice.controller.SchemaConstants.VALUE_SCHEMA_FOR_WRITE_COMPUTE_V3;
 import static com.linkedin.venice.controller.SchemaConstants.VALUE_SCHEMA_FOR_WRITE_COMPUTE_V4;
 import static com.linkedin.venice.controller.SchemaConstants.VALUE_SCHEMA_FOR_WRITE_COMPUTE_V5;
+import static com.linkedin.venice.utils.ByteUtils.BYTES_PER_MB;
 import static com.linkedin.venice.utils.TestUtils.assertCommand;
 import static com.linkedin.venice.utils.TestUtils.waitForNonDeterministicAssertion;
 import static com.linkedin.venice.utils.TestUtils.waitForNonDeterministicPushCompletion;
@@ -952,7 +953,7 @@ public class VeniceParentHelixAdminTest {
   }
 
   private void testUpdateMaxRecordSize(ControllerClient parentClient, ControllerClient childClient) {
-    final int expectedMaxRecordSizeBytes = 7 * 1024 * 1024;
+    final int expectedMaxRecordSizeBytes = 7 * BYTES_PER_MB;
     testUpdateConfig(
         parentClient,
         childClient,

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/server/TestAdminSparkServer.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/server/TestAdminSparkServer.java
@@ -1,5 +1,6 @@
 package com.linkedin.venice.controller.server;
 
+import static com.linkedin.venice.utils.ByteUtils.BYTES_PER_MB;
 import static com.linkedin.venice.utils.TestUtils.assertCommand;
 
 import com.linkedin.venice.ConfigKeys;
@@ -84,7 +85,7 @@ public class TestAdminSparkServer extends AbstractTestAdminSparkServer {
    * And please collect the store and version you created in the end of your test case.
    */
 
-  private static final int TEST_MAX_RECORD_SIZE_BYTES = 16 * 1024 * 1024; // arbitrary 16MB
+  private static final int TEST_MAX_RECORD_SIZE_BYTES = 16 * BYTES_PER_MB; // arbitrary 16MB
 
   @BeforeClass
   public void setUp() {
@@ -92,7 +93,7 @@ public class TestAdminSparkServer extends AbstractTestAdminSparkServer {
 
     extraProperties.put(
         ConfigKeys.CONTROLLER_JETTY_CONFIG_OVERRIDE_PREFIX + "org.eclipse.jetty.server.Request.maxFormContentSize",
-        ByteUtils.BYTES_PER_MB);
+        BYTES_PER_MB);
     // Set topic cleanup interval to a large number and min number of unused topic to preserve to 1 to test
     // getDeletableStoreTopics deterministically.
     extraProperties.put(

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/server/TestAdminSparkServer.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/server/TestAdminSparkServer.java
@@ -84,6 +84,8 @@ public class TestAdminSparkServer extends AbstractTestAdminSparkServer {
    * And please collect the store and version you created in the end of your test case.
    */
 
+  private static final int TEST_MAX_RECORD_SIZE_BYTES = 16 * 1024 * 1024; // arbitrary 16MB
+
   @BeforeClass
   public void setUp() {
     Properties extraProperties = new Properties();
@@ -96,6 +98,8 @@ public class TestAdminSparkServer extends AbstractTestAdminSparkServer {
     extraProperties.put(
         ConfigKeys.TOPIC_CLEANUP_SLEEP_INTERVAL_BETWEEN_TOPIC_LIST_FETCH_MS,
         Long.toString(TimeUnit.DAYS.toMillis(7)));
+    extraProperties
+        .put(ConfigKeys.CONTROLLER_DEFAULT_MAX_RECORD_SIZE_BYTES, Integer.toString(TEST_MAX_RECORD_SIZE_BYTES));
     extraProperties.put(ConfigKeys.MIN_NUMBER_OF_UNUSED_KAFKA_TOPICS_TO_PRESERVE, Integer.toString(1));
     super.setUp(false, Optional.empty(), extraProperties);
   }
@@ -393,6 +397,14 @@ public class TestAdminSparkServer extends AbstractTestAdminSparkServer {
           parentController.getVeniceAdmin().getBackupVersionDefaultRetentionMs(),
           store.getBackupVersionRetentionMs(),
           "Store Info should have correct default retention time in ms.");
+      Assert.assertEquals(
+          parentController.getVeniceAdmin().getDefaultMaxRecordSizeBytes(),
+          TEST_MAX_RECORD_SIZE_BYTES,
+          "Default max record size bytes setting should've been correctly set by the test.");
+      Assert.assertEquals(
+          store.getMaxRecordSizeBytes(),
+          TEST_MAX_RECORD_SIZE_BYTES,
+          "Store Info should have the same default max record size in bytes.");
       Assert.assertEquals(store.getName(), storeName, "Store Info should have same store name as request");
       Assert.assertTrue(store.isEnableStoreWrites(), "New store should not be disabled");
       Assert.assertTrue(store.isEnableStoreReads(), "New store should not be disabled");

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/PushJobDetailsTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/PushJobDetailsTest.java
@@ -10,7 +10,6 @@ import static com.linkedin.venice.hadoop.VenicePushJobConstants.DEFAULT_VALUE_FI
 import static com.linkedin.venice.hadoop.VenicePushJobConstants.PUSH_JOB_STATUS_UPLOAD_ENABLE;
 import static com.linkedin.venice.utils.IntegrationTestPushUtils.defaultVPJProps;
 import static com.linkedin.venice.utils.TestWriteUtils.getTempDataDirectory;
-import static com.linkedin.venice.writer.VeniceWriter.LARGE_RECORDS_ALLOWED;
 import static com.linkedin.venice.writer.VeniceWriter.MAX_SIZE_FOR_USER_PAYLOAD_PER_MESSAGE_IN_BYTES;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
@@ -254,8 +253,8 @@ public class PushJobDetailsTest {
 
   /**
    * Test that the push job details are correctly updated when a large record is pushed.
-   * The settings `LARGE_RECORDS_ALLOWED`, `MAX_RECORD_SIZE_BYTES`, and `MAX_SIZE_FOR_USER_PAYLOAD_PER_MESSAGE_IN_BYTES`
-   * are set to extremely low values, so that regular records will trigger the "large" condition and fail to be pushed.
+   * The settings `MAX_RECORD_SIZE_BYTES` and `MAX_SIZE_FOR_USER_PAYLOAD_PER_MESSAGE_IN_BYTES` are set to
+   * extremely low values, so that regular records will trigger the "large" condition and fail to be pushed.
    */
   @Test(timeOut = 60 * Time.MS_PER_SECOND)
   public void testPushJobDetailsRecordTooLarge() throws ExecutionException, InterruptedException {
@@ -274,7 +273,6 @@ public class PushJobDetailsTest {
 
     Properties pushJobProps = defaultVPJProps(multiRegionMultiClusterWrapper, inputDirPath, testStoreName);
     pushJobProps.setProperty(PUSH_JOB_STATUS_UPLOAD_ENABLE, String.valueOf(true));
-    pushJobProps.setProperty(LARGE_RECORDS_ALLOWED, String.valueOf(false));
     pushJobProps.setProperty(MAX_SIZE_FOR_USER_PAYLOAD_PER_MESSAGE_IN_BYTES, "0");
     try (final VenicePushJob testPushJob = new VenicePushJob("test-push-job-details-job", pushJobProps)) {
       assertThrows(VeniceException.class, testPushJob::run); // Push job should fail due to large record

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/PushJobDetailsTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/PushJobDetailsTest.java
@@ -3,12 +3,15 @@ package com.linkedin.venice.endToEnd;
 import static com.linkedin.davinci.store.rocksdb.RocksDBServerConfig.ROCKSDB_PLAIN_TABLE_FORMAT_ENABLED;
 import static com.linkedin.venice.ConfigKeys.SERVER_DATABASE_CHECKSUM_VERIFICATION_ENABLED;
 import static com.linkedin.venice.ConfigKeys.SERVER_DATABASE_SYNC_BYTES_INTERNAL_FOR_DEFERRED_WRITE_MODE;
+import static com.linkedin.venice.hadoop.VenicePushJob.PushJobCheckpoints.RECORD_TOO_LARGE_FAILED;
 import static com.linkedin.venice.hadoop.VenicePushJob.PushJobCheckpoints.START_DATA_WRITER_JOB;
 import static com.linkedin.venice.hadoop.VenicePushJobConstants.DEFAULT_KEY_FIELD_PROP;
 import static com.linkedin.venice.hadoop.VenicePushJobConstants.DEFAULT_VALUE_FIELD_PROP;
 import static com.linkedin.venice.hadoop.VenicePushJobConstants.PUSH_JOB_STATUS_UPLOAD_ENABLE;
 import static com.linkedin.venice.utils.IntegrationTestPushUtils.defaultVPJProps;
 import static com.linkedin.venice.utils.TestWriteUtils.getTempDataDirectory;
+import static com.linkedin.venice.writer.VeniceWriter.LARGE_RECORDS_ALLOWED;
+import static com.linkedin.venice.writer.VeniceWriter.MAX_SIZE_FOR_USER_PAYLOAD_PER_MESSAGE_IN_BYTES;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
@@ -208,7 +211,6 @@ public class PushJobDetailsTest {
         }
       });
     }
-
   }
 
   @Test(timeOut = 60 * Time.MS_PER_SECOND)
@@ -247,6 +249,48 @@ public class PushJobDetailsTest {
           START_DATA_WRITER_JOB.getValue(),
           "Unexpected latest push job checkpoint reported");
       assertFalse(value.failureDetails.toString().isEmpty());
+    }
+  }
+
+  /**
+   * Test that the push job details are correctly updated when a large record is pushed.
+   * The settings `LARGE_RECORDS_ALLOWED`, `MAX_RECORD_SIZE_BYTES`, and `MAX_SIZE_FOR_USER_PAYLOAD_PER_MESSAGE_IN_BYTES`
+   * are set to extremely low values, so that regular records will trigger the "large" condition and fail to be pushed.
+   */
+  @Test(timeOut = 60 * Time.MS_PER_SECOND)
+  public void testPushJobDetailsRecordTooLarge() throws ExecutionException, InterruptedException {
+    String testStoreName = "test-push-store";
+    parentControllerClient.createNewStore(
+        testStoreName,
+        "test-user",
+        recordSchema.getField(DEFAULT_KEY_FIELD_PROP).schema().toString(),
+        recordSchema.getField(DEFAULT_VALUE_FIELD_PROP).schema().toString());
+    // Set store quota to unlimited else local VPJ jobs will fail due to quota enforcement NullPointerException
+    final UpdateStoreQueryParams queryParams = new UpdateStoreQueryParams().setStorageQuotaInByte(-1)
+        .setPartitionCount(2)
+        .setChunkingEnabled(true)
+        .setMaxRecordSizeBytes(0);
+    parentControllerClient.updateStore(testStoreName, queryParams);
+
+    Properties pushJobProps = defaultVPJProps(multiRegionMultiClusterWrapper, inputDirPath, testStoreName);
+    pushJobProps.setProperty(PUSH_JOB_STATUS_UPLOAD_ENABLE, String.valueOf(true));
+    pushJobProps.setProperty(LARGE_RECORDS_ALLOWED, String.valueOf(false));
+    pushJobProps.setProperty(MAX_SIZE_FOR_USER_PAYLOAD_PER_MESSAGE_IN_BYTES, "0");
+    try (final VenicePushJob testPushJob = new VenicePushJob("test-push-job-details-job", pushJobProps)) {
+      assertThrows(VeniceException.class, testPushJob::run); // Push job should fail due to large record
+    }
+    try (final AvroSpecificStoreClient<PushJobStatusRecordKey, PushJobDetails> client =
+        ClientFactory.getAndStartSpecificAvroClient(
+            ClientConfig
+                .defaultSpecificClientConfig(VeniceSystemStoreUtils.getPushJobDetailsStoreName(), PushJobDetails.class)
+                .setVeniceURL(childRegionClusterWrapper.getRandomRouterURL()))) {
+      final PushJobStatusRecordKey key = new PushJobStatusRecordKey(testStoreName, 1);
+      TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, true, () -> {
+        assertNotNull(client.get(key).get(), "RT writes are not reflected in store yet");
+      });
+      final PushJobDetails value = client.get(key).get();
+      assertEquals(value.pushJobLatestCheckpoint.intValue(), RECORD_TOO_LARGE_FAILED.getValue());
+      assertFalse(value.failureDetails.toString().isEmpty(), "Assert failure recorded in PushJobDetails");
     }
   }
 }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestBatch.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestBatch.java
@@ -990,20 +990,19 @@ public abstract class TestBatch {
     validatePerStoreMetricsRange(storeName, ASSEMBLED_RECORD_VALUE_SIZE_IN_BYTES, minSize, LARGE_RECORD_VALUE_SIZE);
   }
 
-  /**
-   * Test that values that are too large will fail the push job only when the limit is enforced.
-   */
+  /** Test that values that are too large will fail the push job only when the limit is enforced. */
   @Test(dataProvider = "True-and-False", dataProviderClass = DataProviderUtils.class, timeOut = TEST_TIMEOUT)
-  public void testValuesThatAreTooLarge(boolean enforceLimit) throws Exception {
+  public void testStoreWithTooLargeValues(boolean enforceLimit) throws Exception {
     final int wayTooLargeRecordValueSize = 11 * 1024 * 1024; // 11 MB
-    final int maxRecordSizeBytesForTest = (enforceLimit) ? -1 : 15 * 1024 * 1024; // -1 means use default
+    final int maxRecordSizeBytesForTest = (enforceLimit) ? 10 * 1024 * 1024 : -1; // -1 means no limit
     try {
       testStoreWithLargeValues(true, properties -> {
         properties.setProperty(MAX_RECORD_SIZE_BYTES, String.valueOf(maxRecordSizeBytesForTest));
       }, null, wayTooLargeRecordValueSize);
       Assert.assertFalse(enforceLimit, "Too large values should fail only when not allowed");
     } catch (VeniceException e) {
-      Assert.assertTrue(e.getMessage().contains("exceed the maximum record limit of 10.0 MiB"));
+      // 100.0 MiB comes from controller config VeniceControllerConfig.defaultMaxRecordSizeBytes
+      Assert.assertTrue(e.getMessage().contains("exceed the maximum record limit of 100.0 MiB"), e.getMessage());
     }
   }
 

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestBatch.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestBatch.java
@@ -995,8 +995,7 @@ public abstract class TestBatch {
   @Test(dataProvider = "True-and-False", dataProviderClass = DataProviderUtils.class, timeOut = TEST_TIMEOUT)
   public void testStoreWithTooLargeValues(boolean enforceLimit) throws Exception {
     final int wayTooLargeRecordValueSize = 11 * 1024 * 1024; // 11 MB
-    final int maxRecordSizeBytesForTest =
-        (enforceLimit) ? 10 * 1024 * 1024 : VeniceWriter.DEFAULT_MAX_RECORD_SIZE_BYTES;
+    final int maxRecordSizeBytesForTest = (enforceLimit) ? 10 * 1024 * 1024 : VeniceWriter.UNLIMITED_MAX_RECORD_SIZE;
     try {
       testStoreWithLargeValues(true, properties -> {
         properties.setProperty(MAX_RECORD_SIZE_BYTES, String.valueOf(maxRecordSizeBytesForTest));

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestBatch.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestBatch.java
@@ -78,6 +78,7 @@ import com.linkedin.venice.utils.TestWriteUtils;
 import com.linkedin.venice.utils.Time;
 import com.linkedin.venice.utils.Utils;
 import com.linkedin.venice.utils.VeniceProperties;
+import com.linkedin.venice.writer.VeniceWriter;
 import io.tehuti.Metric;
 import io.tehuti.metrics.MetricsRepository;
 import java.io.File;
@@ -994,7 +995,8 @@ public abstract class TestBatch {
   @Test(dataProvider = "True-and-False", dataProviderClass = DataProviderUtils.class, timeOut = TEST_TIMEOUT)
   public void testStoreWithTooLargeValues(boolean enforceLimit) throws Exception {
     final int wayTooLargeRecordValueSize = 11 * 1024 * 1024; // 11 MB
-    final int maxRecordSizeBytesForTest = (enforceLimit) ? 10 * 1024 * 1024 : -1; // -1 means no limit
+    final int maxRecordSizeBytesForTest =
+        (enforceLimit) ? 10 * 1024 * 1024 : VeniceWriter.DEFAULT_MAX_RECORD_SIZE_BYTES;
     try {
       testStoreWithLargeValues(true, properties -> {
         properties.setProperty(MAX_RECORD_SIZE_BYTES, String.valueOf(maxRecordSizeBytesForTest));

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/Admin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/Admin.java
@@ -853,6 +853,12 @@ public interface Admin extends AutoCloseable, Closeable {
    */
   long getBackupVersionDefaultRetentionMs();
 
+  /**
+   * @return The default value of {@link com.linkedin.venice.writer.VeniceWriter#maxRecordSizeBytes} which is
+   * provided to the VPJ and Consumer as a controller config to dynamically control the setting per cluster.
+   */
+  int getDefaultMaxRecordSizeBytes();
+
   void wipeCluster(String clusterName, String fabric, Optional<String> storeName, Optional<Integer> versionNum);
 
   StoreInfo copyOverStoreSchemasAndConfigs(String clusterName, String srcFabric, String destFabric, String storeName);

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerMultiClusterConfig.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerMultiClusterConfig.java
@@ -294,4 +294,8 @@ public class VeniceControllerMultiClusterConfig {
   public int getDanglingTopicOccurrenceThresholdForCleanup() {
     return getCommonConfig().getDanglingTopicOccurrenceThresholdForCleanup();
   }
+
+  public int getDefaultMaxRecordSizeBytes() {
+    return getCommonConfig().getDefaultMaxRecordSizeBytes();
+  }
 }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -414,6 +414,8 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
 
   private long backupVersionDefaultRetentionMs;
 
+  private int defaultMaxRecordSizeBytes;
+
   private DataRecoveryManager dataRecoveryManager;
 
   protected final PubSubTopicRepository pubSubTopicRepository;
@@ -470,6 +472,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
     this.fatalDataValidationFailureRetentionMs = multiClusterConfigs.getFatalDataValidationFailureRetentionMs();
     this.deprecatedJobTopicMaxRetentionMs = multiClusterConfigs.getDeprecatedJobTopicMaxRetentionMs();
     this.backupVersionDefaultRetentionMs = multiClusterConfigs.getBackupVersionDefaultRetentionMs();
+    this.defaultMaxRecordSizeBytes = multiClusterConfigs.getDefaultMaxRecordSizeBytes();
 
     this.minNumberOfStoreVersionsToPreserve = multiClusterConfigs.getMinNumberOfStoreVersionsToPreserve();
     this.d2Client = d2Client;
@@ -7946,6 +7949,14 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
   @Override
   public long getBackupVersionDefaultRetentionMs() {
     return backupVersionDefaultRetentionMs;
+  }
+
+  /**
+   * @see Admin#getDefaultMaxRecordSizeBytes()
+   */
+  @Override
+  public int getDefaultMaxRecordSizeBytes() {
+    return defaultMaxRecordSizeBytes;
   }
 
   private Pair<NodeReplicasReadinessState, List<Replica>> areAllCurrentVersionReplicasReady(

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -7951,9 +7951,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
     return backupVersionDefaultRetentionMs;
   }
 
-  /**
-   * @see Admin#getDefaultMaxRecordSizeBytes()
-   */
+  /** @see Admin#getDefaultMaxRecordSizeBytes() */
   @Override
   public int getDefaultMaxRecordSizeBytes() {
     return defaultMaxRecordSizeBytes;

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
@@ -5008,6 +5008,14 @@ public class VeniceParentHelixAdmin implements Admin {
   }
 
   /**
+   * @see Admin#getDefaultMaxRecordSizeBytes()
+   */
+  @Override
+  public int getDefaultMaxRecordSizeBytes() {
+    return getVeniceHelixAdmin().getDefaultMaxRecordSizeBytes();
+  }
+
+  /**
    * Delete stores from the cluster by sending a {@link ControllerClient#wipeCluster(String, Optional, Optional)} request.
    */
   @Override

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
@@ -5007,9 +5007,7 @@ public class VeniceParentHelixAdmin implements Admin {
     return getVeniceHelixAdmin().getBackupVersionDefaultRetentionMs();
   }
 
-  /**
-   * @see Admin#getDefaultMaxRecordSizeBytes()
-   */
+  /** @see Admin#getDefaultMaxRecordSizeBytes() */
   @Override
   public int getDefaultMaxRecordSizeBytes() {
     return getVeniceHelixAdmin().getDefaultMaxRecordSizeBytes();

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/StoresRoutes.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/StoresRoutes.java
@@ -327,6 +327,10 @@ public class StoresRoutes extends AbstractRoute {
         if (storeInfo.getBackupVersionRetentionMs() < 0) {
           storeInfo.setBackupVersionRetentionMs(admin.getBackupVersionDefaultRetentionMs());
         }
+        // This is the only place the default value of maxRecordSizeBytes is set for StoreResponse for VPJ and Consumer
+        if (storeInfo.getMaxRecordSizeBytes() < 0) {
+          storeInfo.setMaxRecordSizeBytes(admin.getDefaultMaxRecordSizeBytes());
+        }
         storeInfo.setColoToCurrentVersions(admin.getCurrentVersionsForMultiColos(clusterName, storeName));
         boolean isSSL = admin.isSSLEnabledForPush(clusterName, storeName);
         storeInfo.setKafkaBrokerUrl(admin.getKafkaBootstrapServers(isSSL));

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/StoreRoutesTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/StoreRoutesTest.java
@@ -12,7 +12,13 @@ import com.linkedin.venice.controller.VeniceHelixAdmin;
 import com.linkedin.venice.controller.VeniceParentHelixAdmin;
 import com.linkedin.venice.controllerapi.ControllerApiConstants;
 import com.linkedin.venice.controllerapi.MultiStoreStatusResponse;
+import com.linkedin.venice.controllerapi.StoreResponse;
+import com.linkedin.venice.meta.OfflinePushStrategy;
+import com.linkedin.venice.meta.PersistenceType;
+import com.linkedin.venice.meta.ReadStrategy;
+import com.linkedin.venice.meta.RoutingStrategy;
 import com.linkedin.venice.meta.Store;
+import com.linkedin.venice.meta.ZKStore;
 import com.linkedin.venice.pubsub.PubSubTopicRepository;
 import com.linkedin.venice.utils.ObjectMapperFactory;
 import java.util.Collections;
@@ -178,5 +184,38 @@ public class StoreRoutesTest {
             MultiStoreStatusResponse.class);
     Assert.assertTrue(multiStoreStatusResponse.isError());
     Assert.assertEquals(multiStoreStatusResponse.getErrorType(), STORE_NOT_FOUND);
+  }
+
+  /**
+   * Testing getStore API code paths for code coverage purposes
+   */
+  @Test
+  public void testGetStore() throws Exception {
+    final Store testStore = new ZKStore(
+        TEST_STORE_NAME,
+        "owner",
+        System.currentTimeMillis(),
+        PersistenceType.IN_MEMORY,
+        RoutingStrategy.CONSISTENT_HASH,
+        ReadStrategy.ANY_OF_ONLINE,
+        OfflinePushStrategy.WAIT_N_MINUS_ONE_REPLCIA_PER_PARTITION,
+        1);
+
+    final int testMaxRecordSizeBytesValue = 33333;
+    final Admin mockAdmin = mock(VeniceParentHelixAdmin.class);
+    doReturn(true).when(mockAdmin).isLeaderControllerFor(TEST_CLUSTER);
+    doReturn(testStore).when(mockAdmin).getStore(TEST_CLUSTER, TEST_STORE_NAME);
+    doReturn(testMaxRecordSizeBytesValue).when(mockAdmin).getDefaultMaxRecordSizeBytes();
+
+    final Request request = mock(Request.class);
+    doReturn(TEST_CLUSTER).when(request).queryParams(eq(ControllerApiConstants.CLUSTER));
+    doReturn(TEST_STORE_NAME).when(request).queryParams(eq(ControllerApiConstants.NAME));
+
+    final StoresRoutes storesRoutes = new StoresRoutes(false, Optional.empty(), pubSubTopicRepository);
+    final StoreResponse response = ObjectMapperFactory.getInstance()
+        .readValue(
+            storesRoutes.getStore(mockAdmin).handle(request, mock(Response.class)).toString(),
+            StoreResponse.class);
+    Assert.assertEquals(response.getStore().getMaxRecordSizeBytes(), testMaxRecordSizeBytesValue);
   }
 }

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/StoreRoutesTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/StoreRoutesTest.java
@@ -186,9 +186,7 @@ public class StoreRoutesTest {
     Assert.assertEquals(multiStoreStatusResponse.getErrorType(), STORE_NOT_FOUND);
   }
 
-  /**
-   * Testing getStore API code paths for code coverage purposes
-   */
+  /** Testing getStore API code paths for code coverage purposes */
   @Test
   public void testGetStore() throws Exception {
     final Store testStore = new ZKStore(


### PR DESCRIPTION
## Summary

**NOTE:** This PR adds the code for enforcing record size limits, but no push jobs will fail by default until the controller config `controller.default.max.record.size.bytes` is adjusted and deployed for each cluster.

1. When users try to push Venice records larger than `maxRecordSizeBytes` (introduced in #1027), the Batch Push Job will fail, reporting a `RecordSizeTooLarge` error. This is the same error that is emitted when `chunkingEnabled=false` and a user tries to push a record surpassing the `1MB` Kafka record size limit (handled by `maxSizeForUserPayloadPerMessageInBytes`).
2. The default is unlimited / unset (`-1`), but the store-level config `maxRecordSizeBytes` can be adjusted on the store itself.
3. The intended way of changing the setting fleetwide is by modifying the controller config `controller.default.max.record.size.bytes` per cluster. The controller will backfill the `maxRecordSizeBytes` if the store-level config is absent (`-1`) ([link](https://github.com/linkedin/venice/pull/1052#discussion_r1669466912)).
    1. The default value for this controller backfill will be `100MB`, which is an arbitrary high number that will not be reached.

### Changes

1. **[Functional]** `VeniceWriter` will now throw `RecordTooLargeException` if `largeRecordsAllowed=false` and it tries to `put()` a record which has a size that is larger than the store-level setting `maxRecordSizeBytes`. Currently, only batch push jobs should set the value to an actual value.
2. **[Functional]** `VenicePushJob` added support for the `maxRecordSizeBytes` and `largeRecordsAllowed` settings and will pass these settings down to the `DataWriterJob` who is the one that actually touches the data.
3. **[Functional]** Venice Controller will backfill the value of `maxRecordSizeBytes` with a controller config `defaultMaxRecordSizeBytes` (set by `controller.default.max.record.size.bytes`) when the `getStore()` API is called. The intended use case is for us to be able to set it on the controller-side to control the value fleetwide. The default is set to `100MB` by default which should never be hit.
4. **[Unit Test]** Added unit tests for test coverage:
    1. `testGetVeniceWriter()` and `testUpdatePushJobDetailsWithJobDetailsRecordTooLarge()` in `VenicePushJobTest`
    2. `testPutTooLargeRecord()` in `VeniceWriterUnitTest`
    3. `testGetStore()` in `StoreRoutesTest`
5. **[Integration Test]**  Added integration tests which should hopefully mean that the changes are working:
    1. `testStoreWithTooLargeValues()` in `TestBatch`
    2. `testPushJobDetailsRecordTooLarge()` in `PushJobDetailsTest`

## How was this PR tested?
Added integration tests and unit tests.

## Does this PR introduce any user-facing changes?
- [X] Yes. Make sure to explain your proposed changes and call out the behavior change.

See the **Summary** section.