### PR TITLE
[admin-tool] Metadata migration from source ZK to destination ZK

### DIFF
--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/AdminTool.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/AdminTool.java
@@ -573,6 +573,9 @@ public class AdminTool {
         case DUMP_TOPIC_PARTITION_INGESTION_CONTEXT:
           dumpTopicPartitionIngestionContext(cmd);
           break;
+        case MIGRATE_VENICE_ZK_PATHS:
+          migrateVeniceZKPaths(cmd);
+          break;
         case EXTRACT_VENICE_ZK_PATHS:
           extractVeniceZKPaths(cmd);
           break;
@@ -3092,6 +3095,15 @@ public class AdminTool {
     } finally {
       Utils.closeQuietlyWithErrorLogged(transportClient);
     }
+  }
+
+  private static void migrateVeniceZKPaths(CommandLine cmd) {
+    Set<String> clusterNames = Utils.parseCommaSeparatedStringToSet(getRequiredArgument(cmd, Arg.CLUSTER_LIST));
+    ZkCopier.migrateVenicePaths(
+        getRequiredArgument(cmd, Arg.SRC_ZOOKEEPER_URL),
+        getRequiredArgument(cmd, Arg.DEST_ZOOKEEPER_URL),
+        clusterNames,
+        getRequiredArgument(cmd, Arg.BASE_PATH));
   }
 
   private static void extractVeniceZKPaths(CommandLine cmd) {

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/AdminTool.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/AdminTool.java
@@ -3097,13 +3097,20 @@ public class AdminTool {
     }
   }
 
-  private static void migrateVeniceZKPaths(CommandLine cmd) {
+  private static void migrateVeniceZKPaths(CommandLine cmd) throws Exception {
     Set<String> clusterNames = Utils.parseCommaSeparatedStringToSet(getRequiredArgument(cmd, Arg.CLUSTER_LIST));
-    ZkCopier.migrateVenicePaths(
-        getRequiredArgument(cmd, Arg.SRC_ZOOKEEPER_URL),
-        getRequiredArgument(cmd, Arg.DEST_ZOOKEEPER_URL),
-        clusterNames,
-        getRequiredArgument(cmd, Arg.BASE_PATH));
+    String srcZKUrl = getRequiredArgument(cmd, Arg.SRC_ZOOKEEPER_URL);
+    String srcZKSSLConfigs = getOptionalArgument(cmd, Arg.SRC_ZK_SSL_CONFIG_FILE, "");
+    String destZKUrl = getRequiredArgument(cmd, Arg.DEST_ZOOKEEPER_URL);
+    String destZKSSLConfigs = getOptionalArgument(cmd, Arg.DEST_ZK_SSL_CONFIG_FILE, "");
+    ZkClient srcZkClient = readZKConfigAndBuildZKClient(srcZKUrl, srcZKSSLConfigs);
+    ZkClient destZkClient = readZKConfigAndBuildZKClient(destZKUrl, destZKSSLConfigs);
+    try {
+      ZkCopier.migrateVenicePaths(srcZkClient, destZkClient, clusterNames, getRequiredArgument(cmd, Arg.BASE_PATH));
+    } finally {
+      srcZkClient.close();
+      destZkClient.close();
+    }
   }
 
   private static void extractVeniceZKPaths(CommandLine cmd) {

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/AdminTool.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/AdminTool.java
@@ -3100,9 +3100,9 @@ public class AdminTool {
   private static void migrateVeniceZKPaths(CommandLine cmd) throws Exception {
     Set<String> clusterNames = Utils.parseCommaSeparatedStringToSet(getRequiredArgument(cmd, Arg.CLUSTER_LIST));
     String srcZKUrl = getRequiredArgument(cmd, Arg.SRC_ZOOKEEPER_URL);
-    String srcZKSSLConfigs = getOptionalArgument(cmd, Arg.SRC_ZK_SSL_CONFIG_FILE, "");
+    String srcZKSSLConfigs = getRequiredArgument(cmd, Arg.SRC_ZK_SSL_CONFIG_FILE);
     String destZKUrl = getRequiredArgument(cmd, Arg.DEST_ZOOKEEPER_URL);
-    String destZKSSLConfigs = getOptionalArgument(cmd, Arg.DEST_ZK_SSL_CONFIG_FILE, "");
+    String destZKSSLConfigs = getRequiredArgument(cmd, Arg.DEST_ZK_SSL_CONFIG_FILE);
     ZkClient srcZkClient = readZKConfigAndBuildZKClient(srcZKUrl, srcZKSSLConfigs);
     ZkClient destZkClient = readZKConfigAndBuildZKClient(destZKUrl, destZKSSLConfigs);
     try {

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/Arg.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/Arg.java
@@ -11,6 +11,8 @@ public enum Arg {
   URL("url", "u", true, "Venice url, eg. http://localhost:1689  This can be a router or a controller"),
   SERVER_URL("server-url", "su", true, "Venice server url, eg. http://localhost:1690  This has to be a storage node"),
   VENICE_ZOOKEEPER_URL("venice-zookeeper-url", "vzu", true, "Venice Zookeeper url, eg. localhost:2622"),
+  SRC_ZOOKEEPER_URL("src-zookeeper-url", "szu", true, "Source Zookeeper url, eg. localhost:2181"),
+  DEST_ZOOKEEPER_URL("dest-zookeeper-url", "dzu", true, "Destination Zookeeper url, eg. localhost:2182"),
   INFILE("infile", "if", true, "Path to input text file"), OUTFILE("outfile", "of", true, "Path to output text file"),
   BASE_PATH("base-path", "bp", true, "Base path for ZK, eg. /venice-parent"),
   CLUSTER("cluster", "c", true, "Name of Venice cluster"),

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/Arg.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/Arg.java
@@ -29,7 +29,10 @@ public enum Arg {
   VALUE_SCHEMA_ID("value-schema-id", "vid", true, "value schema id"),
   VALUE_SCHEMA("value-schema-file", "vs", true, "Path to text file with value schema"),
   ZK_SSL_CONFIG_FILE("zk-ssl-config-file", "zscf", true, "Path to text file with ZK SSL configs"),
-  DERIVED_SCHEMA_ID("derived-schema-id", "did", true, "derived schema id"),
+  SRC_ZK_SSL_CONFIG_FILE("src-zk-ssl-config-file", "szscf", true, "Path to text file with source ZK SSL configs"),
+  DEST_ZK_SSL_CONFIG_FILE(
+      "dest-zk-ssl-config-file", "dzscf", true, "Path to text file with destination ZK SSL configs"
+  ), DERIVED_SCHEMA_ID("derived-schema-id", "did", true, "derived schema id"),
   DERIVED_SCHEMA("derived-schema-file", "ds", true, "Path to text file with derived schema"),
   OWNER("owner", "o", true, "Owner email for new store creation"),
   STORAGE_NODE("storage-node", "n", true, "Helix instance ID for a storage node, eg. lva1-app1234_1690"),

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/Command.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/Command.java
@@ -25,6 +25,7 @@ import static com.linkedin.venice.Arg.DEBUG;
 import static com.linkedin.venice.Arg.DERIVED_SCHEMA;
 import static com.linkedin.venice.Arg.DERIVED_SCHEMA_ID;
 import static com.linkedin.venice.Arg.DEST_FABRIC;
+import static com.linkedin.venice.Arg.DEST_ZK_SSL_CONFIG_FILE;
 import static com.linkedin.venice.Arg.DEST_ZOOKEEPER_URL;
 import static com.linkedin.venice.Arg.DISABLE_DAVINCI_PUSH_STATUS_STORE;
 import static com.linkedin.venice.Arg.DISABLE_META_STORE;
@@ -102,6 +103,7 @@ import static com.linkedin.venice.Arg.SERVER_URL;
 import static com.linkedin.venice.Arg.SKIP_DIV;
 import static com.linkedin.venice.Arg.SKIP_LAST_STORE_CREATION;
 import static com.linkedin.venice.Arg.SOURCE_FABRIC;
+import static com.linkedin.venice.Arg.SRC_ZK_SSL_CONFIG_FILE;
 import static com.linkedin.venice.Arg.SRC_ZOOKEEPER_URL;
 import static com.linkedin.venice.Arg.STARTING_OFFSET;
 import static com.linkedin.venice.Arg.START_DATE;
@@ -538,7 +540,8 @@ public enum Command {
   ),
   MIGRATE_VENICE_ZK_PATHS(
       "migrate-venice-zk-paths", "Migrate Venice-specific metadata from a source ZK to a destination ZK",
-      new Arg[] { SRC_ZOOKEEPER_URL, DEST_ZOOKEEPER_URL, CLUSTER_LIST, BASE_PATH }
+      new Arg[] { SRC_ZOOKEEPER_URL, DEST_ZOOKEEPER_URL, CLUSTER_LIST, BASE_PATH },
+      new Arg[] { SRC_ZK_SSL_CONFIG_FILE, DEST_ZK_SSL_CONFIG_FILE }
   ),
   EXTRACT_VENICE_ZK_PATHS(
       "extract-venice-zk-paths",

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/Command.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/Command.java
@@ -25,6 +25,7 @@ import static com.linkedin.venice.Arg.DEBUG;
 import static com.linkedin.venice.Arg.DERIVED_SCHEMA;
 import static com.linkedin.venice.Arg.DERIVED_SCHEMA_ID;
 import static com.linkedin.venice.Arg.DEST_FABRIC;
+import static com.linkedin.venice.Arg.DEST_ZOOKEEPER_URL;
 import static com.linkedin.venice.Arg.DISABLE_DAVINCI_PUSH_STATUS_STORE;
 import static com.linkedin.venice.Arg.DISABLE_META_STORE;
 import static com.linkedin.venice.Arg.ENABLE_DISABLED_REPLICA;
@@ -101,6 +102,7 @@ import static com.linkedin.venice.Arg.SERVER_URL;
 import static com.linkedin.venice.Arg.SKIP_DIV;
 import static com.linkedin.venice.Arg.SKIP_LAST_STORE_CREATION;
 import static com.linkedin.venice.Arg.SOURCE_FABRIC;
+import static com.linkedin.venice.Arg.SRC_ZOOKEEPER_URL;
 import static com.linkedin.venice.Arg.STARTING_OFFSET;
 import static com.linkedin.venice.Arg.START_DATE;
 import static com.linkedin.venice.Arg.STORAGE_NODE;
@@ -533,6 +535,10 @@ public enum Command {
   BACKUP_STORE_METADATA_FROM_GRAVEYARD(
       "backup-store-metadata-from-graveyard", "Backup store metadata from graveyard in EI",
       new Arg[] { VENICE_ZOOKEEPER_URL, ZK_SSL_CONFIG_FILE, BACKUP_FOLDER }
+  ),
+  MIGRATE_VENICE_ZK_PATHS(
+      "migrate-venice-zk-paths", "Migrate Venice-specific metadata from a source ZK to a destination ZK",
+      new Arg[] { SRC_ZOOKEEPER_URL, DEST_ZOOKEEPER_URL, CLUSTER_LIST, BASE_PATH }
   ),
   EXTRACT_VENICE_ZK_PATHS(
       "extract-venice-zk-paths",

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/Command.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/Command.java
@@ -540,8 +540,8 @@ public enum Command {
   ),
   MIGRATE_VENICE_ZK_PATHS(
       "migrate-venice-zk-paths", "Migrate Venice-specific metadata from a source ZK to a destination ZK",
-      new Arg[] { SRC_ZOOKEEPER_URL, DEST_ZOOKEEPER_URL, CLUSTER_LIST, BASE_PATH },
-      new Arg[] { SRC_ZK_SSL_CONFIG_FILE, DEST_ZK_SSL_CONFIG_FILE }
+      new Arg[] { SRC_ZOOKEEPER_URL, SRC_ZK_SSL_CONFIG_FILE, DEST_ZOOKEEPER_URL, DEST_ZK_SSL_CONFIG_FILE, CLUSTER_LIST,
+          BASE_PATH }
   ),
   EXTRACT_VENICE_ZK_PATHS(
       "extract-venice-zk-paths",

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/ZkCopier.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/ZkCopier.java
@@ -1,22 +1,15 @@
 package com.linkedin.venice;
 
-import static com.linkedin.venice.zk.VeniceZkPaths.ADMIN_TOPIC_METADATA;
-import static com.linkedin.venice.zk.VeniceZkPaths.EXECUTION_IDS;
-import static com.linkedin.venice.zk.VeniceZkPaths.PARENT_OFFLINE_PUSHES;
-import static com.linkedin.venice.zk.VeniceZkPaths.ROUTERS;
-import static com.linkedin.venice.zk.VeniceZkPaths.STORES;
+import static com.linkedin.venice.zk.VeniceZkPaths.CLUSTER_ZK_PATHS;
 import static com.linkedin.venice.zk.VeniceZkPaths.STORE_CONFIGS;
-import static com.linkedin.venice.zk.VeniceZkPaths.STORE_GRAVEYARD;
 
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.helix.ZkClientFactory;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -26,10 +19,15 @@ import org.apache.helix.zookeeper.impl.client.ZkClient;
 import org.apache.zookeeper.CreateMode;
 
 
+/**
+ * <p>
+ *   This class contains methods to 1)migrate Venice-specific metadata from a source ZooKeeper (ZK) to a destination ZK
+ *   and 2)extract Venice-specific paths from an input text file containing ZK paths to an output text file.
+ *   We implement a tree data structure to represent ZK paths as nested children and use it to filter out Venice-specific
+ *   paths efficiently.
+ * </p>
+ */
 public class ZkCopier {
-  private static final Set<String> CLUSTER_ZK_PATHS = new HashSet<>(
-      Arrays.asList(ADMIN_TOPIC_METADATA, EXECUTION_IDS, PARENT_OFFLINE_PUSHES, ROUTERS, STORE_GRAVEYARD, STORES));
-
   /**
    * Migrate Venice-specific metadata from a source ZK to a destination ZK.
    * @param srcZkAddress source ZK address

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/ZkCopier.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/ZkCopier.java
@@ -38,6 +38,8 @@ public class ZkCopier {
    * @param destZkClient destination ZK client
    * @param clusterNames set of cluster names
    * @param basePath base path for ZK
+   * @Note: {@code destZkClient} should be a fresh ZK server or must not contain any Venice-specific metadata that needs to be migrated,
+   * otherwise a {@code ZkNodeExistsException} will be thrown
    */
   public static void migrateVenicePaths(
       ZkClient srcZkClient,

--- a/clients/venice-admin-tool/src/test/java/com/linkedin/venice/TestZkCopier.java
+++ b/clients/venice-admin-tool/src/test/java/com/linkedin/venice/TestZkCopier.java
@@ -53,9 +53,6 @@ public class TestZkCopier {
     }
   }
 
-  /**
-   * Test ZkCopier.getVenicePathsFromList() and ZkCopier.getVenicePathsFromTree()
-   */
   @Test
   public void testGetVenicePathsFromList() {
     List<String> zkPaths = getPaths();
@@ -68,35 +65,27 @@ public class TestZkCopier {
     Assert.assertFalse(venicePaths.contains("/venice/cluster1/adminTopicMetadata"));
     Assert.assertFalse(venicePaths.contains("/venice/cluster1/adminTopicMetadata/file1"));
     Assert.assertFalse(venicePaths.contains("/venice/cluster1/adminTopicMetadata/file2/file3"));
-    Assert.assertTrue(venicePaths.contains("/venice-parent"));
-    Assert.assertTrue(venicePaths.contains("/venice-parent/storeConfigs"));
-    Assert.assertTrue(venicePaths.contains("/venice-parent/cluster1"));
     Assert.assertFalse(venicePaths.contains("/venice-parent/cluster1/storeConfigs"));
-    Assert.assertTrue(venicePaths.contains("/venice-parent/cluster1/adminTopicMetadata"));
     Assert.assertTrue(venicePaths.contains("/venice-parent/cluster1/adminTopicMetadata/file1"));
     Assert.assertTrue(venicePaths.contains("/venice-parent/cluster1/adminTopicMetadata/file2"));
     Assert.assertTrue(venicePaths.contains("/venice-parent/cluster1/adminTopicMetadata/file2/file3"));
-    Assert.assertTrue(venicePaths.contains("/venice-parent/cluster1/executionids"));
-    Assert.assertTrue(venicePaths.contains("/venice-parent/cluster1/ParentOfflinePushes"));
-    Assert.assertTrue(venicePaths.contains("/venice-parent/cluster1/routers"));
-    Assert.assertTrue(venicePaths.contains("/venice-parent/cluster1/StoreGraveyard"));
-    Assert.assertTrue(venicePaths.contains("/venice-parent/cluster1/Stores"));
-    Assert.assertTrue(venicePaths.contains("/venice-parent/cluster2"));
     Assert.assertFalse(venicePaths.contains("/venice-parent/cluster2/storeConfigs"));
-    Assert.assertTrue(venicePaths.contains("/venice-parent/cluster2/adminTopicMetadata"));
-    Assert.assertTrue(venicePaths.contains("/venice-parent/cluster2/executionids"));
     Assert.assertTrue(venicePaths.contains("/venice-parent/cluster2/executionids/file1"));
     Assert.assertTrue(venicePaths.contains("/venice-parent/cluster2/executionids/file2"));
     Assert.assertTrue(venicePaths.contains("/venice-parent/cluster2/executionids/file2/file3"));
-    Assert.assertTrue(venicePaths.contains("/venice-parent/cluster2/ParentOfflinePushes"));
-    Assert.assertTrue(venicePaths.contains("/venice-parent/cluster2/routers"));
-    Assert.assertTrue(venicePaths.contains("/venice-parent/cluster2/StoreGraveyard"));
-    Assert.assertTrue(venicePaths.contains("/venice-parent/cluster2/Stores"));
     Assert.assertFalse(venicePaths.contains("/venice-parent/helix-cluster"));
     Assert.assertFalse(venicePaths.contains("/venice-parent/helix-cluster/storeConfigs"));
     Assert.assertFalse(venicePaths.contains("/venice-parent/helix-cluster/adminTopicMetadata"));
     Assert.assertFalse(venicePaths.contains("/venice-parent/helix-cluster/adminTopicMetadata/file1"));
     Assert.assertFalse(venicePaths.contains("/venice-parent/helix-cluster/adminTopicMetadata/file2/file3"));
+    testVenicePathsContainsAsserts(venicePaths);
+  }
+
+  @Test
+  public void testGetVenicePathsFromTree() {
+    TreeNode root = ZkCopier.buildRequiredPathsTree(CLUSTERS, BASE_PATH);
+    List<String> venicePaths = ZkCopier.getVenicePathsFromTree(root, CLUSTERS, BASE_PATH);
+    testVenicePathsContainsAsserts(venicePaths);
   }
 
   @Test
@@ -121,6 +110,25 @@ public class TestZkCopier {
           break;
       }
     }
+  }
+
+  private void testVenicePathsContainsAsserts(List<String> venicePaths) {
+    Assert.assertTrue(venicePaths.contains("/venice-parent"));
+    Assert.assertTrue(venicePaths.contains("/venice-parent/storeConfigs"));
+    Assert.assertTrue(venicePaths.contains("/venice-parent/cluster1"));
+    Assert.assertTrue(venicePaths.contains("/venice-parent/cluster1/adminTopicMetadata"));
+    Assert.assertTrue(venicePaths.contains("/venice-parent/cluster1/executionids"));
+    Assert.assertTrue(venicePaths.contains("/venice-parent/cluster1/ParentOfflinePushes"));
+    Assert.assertTrue(venicePaths.contains("/venice-parent/cluster1/routers"));
+    Assert.assertTrue(venicePaths.contains("/venice-parent/cluster1/StoreGraveyard"));
+    Assert.assertTrue(venicePaths.contains("/venice-parent/cluster1/Stores"));
+    Assert.assertTrue(venicePaths.contains("/venice-parent/cluster2"));
+    Assert.assertTrue(venicePaths.contains("/venice-parent/cluster2/adminTopicMetadata"));
+    Assert.assertTrue(venicePaths.contains("/venice-parent/cluster2/executionids"));
+    Assert.assertTrue(venicePaths.contains("/venice-parent/cluster2/ParentOfflinePushes"));
+    Assert.assertTrue(venicePaths.contains("/venice-parent/cluster2/routers"));
+    Assert.assertTrue(venicePaths.contains("/venice-parent/cluster2/StoreGraveyard"));
+    Assert.assertTrue(venicePaths.contains("/venice-parent/cluster2/Stores"));
   }
 
   private void testContainsChildAsserts(TreeNode child) {

--- a/clients/venice-admin-tool/src/test/java/com/linkedin/venice/TestZkCopier.java
+++ b/clients/venice-admin-tool/src/test/java/com/linkedin/venice/TestZkCopier.java
@@ -53,10 +53,13 @@ public class TestZkCopier {
     }
   }
 
+  /**
+   * Test ZkCopier.getVenicePathsFromList() and ZkCopier.getVenicePathsFromTree()
+   */
   @Test
-  public void testGetVenicePaths() {
+  public void testGetVenicePathsFromList() {
     List<String> zkPaths = getPaths();
-    List<String> venicePaths = ZkCopier.getVenicePaths(zkPaths, CLUSTERS, BASE_PATH);
+    List<String> venicePaths = ZkCopier.getVenicePathsFromList(zkPaths, CLUSTERS, BASE_PATH);
     Assert.assertEquals(venicePaths.size(), 22);
     Assert.assertFalse(venicePaths.contains("/venice"));
     Assert.assertFalse(venicePaths.contains("/venice/storeConfigs"));

--- a/internal/venice-common/src/main/java/com/linkedin/venice/zk/VeniceZkPaths.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/zk/VeniceZkPaths.java
@@ -1,5 +1,11 @@
 package com.linkedin.venice.zk;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+
 /**
  * This class contains constants that represent Venice-managed ZooKeeper paths.
  */
@@ -13,4 +19,8 @@ public class VeniceZkPaths {
   public static final String STORES = "Stores";
   public static final String STORE_CONFIGS = "storeConfigs";
   public static final String STORE_GRAVEYARD = "StoreGraveyard";
+  private static final Set<String> CLUSTER_ZK_PATHS_MODIFIABLE = new HashSet<>(
+      Arrays.asList(ADMIN_TOPIC_METADATA, EXECUTION_IDS, PARENT_OFFLINE_PUSHES, ROUTERS, STORE_GRAVEYARD, STORES));
+  /** Set of all Venice-managed ZooKeeper cluster paths */
+  public static final Set<String> CLUSTER_ZK_PATHS = Collections.unmodifiableSet(CLUSTER_ZK_PATHS_MODIFIABLE);
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/zk/VeniceZkPaths.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/zk/VeniceZkPaths.java
@@ -19,8 +19,10 @@ public class VeniceZkPaths {
   public static final String STORES = "Stores";
   public static final String STORE_CONFIGS = "storeConfigs";
   public static final String STORE_GRAVEYARD = "StoreGraveyard";
+
+  /** Set of all Venice-managed ZooKeeper cluster paths */
   private static final Set<String> CLUSTER_ZK_PATHS_MODIFIABLE = new HashSet<>(
       Arrays.asList(ADMIN_TOPIC_METADATA, EXECUTION_IDS, PARENT_OFFLINE_PUSHES, ROUTERS, STORE_GRAVEYARD, STORES));
-  /** Set of all Venice-managed ZooKeeper cluster paths */
+  /** @see #CLUSTER_ZK_PATHS_MODIFIABLE */
   public static final Set<String> CLUSTER_ZK_PATHS = Collections.unmodifiableSet(CLUSTER_ZK_PATHS_MODIFIABLE);
 }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/zk/TestMigrateVeniceZKPaths.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/zk/TestMigrateVeniceZKPaths.java
@@ -1,0 +1,111 @@
+package com.linkedin.venice.zk;
+
+import static com.linkedin.venice.zk.VeniceZkPaths.ADMIN_TOPIC_METADATA;
+import static com.linkedin.venice.zk.VeniceZkPaths.EXECUTION_IDS;
+import static com.linkedin.venice.zk.VeniceZkPaths.PARENT_OFFLINE_PUSHES;
+import static com.linkedin.venice.zk.VeniceZkPaths.ROUTERS;
+import static com.linkedin.venice.zk.VeniceZkPaths.STORES;
+import static com.linkedin.venice.zk.VeniceZkPaths.STORE_CONFIGS;
+import static com.linkedin.venice.zk.VeniceZkPaths.STORE_GRAVEYARD;
+
+import com.linkedin.venice.AdminTool;
+import com.linkedin.venice.helix.ZkClientFactory;
+import com.linkedin.venice.integration.utils.ServiceFactory;
+import com.linkedin.venice.integration.utils.ZkServerWrapper;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import org.apache.helix.zookeeper.impl.client.ZkClient;
+import org.apache.zookeeper.CreateMode;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+
+public class TestMigrateVeniceZKPaths {
+  private String srcZkAddress;
+  private ZkClient srcZkClient;
+  private ZkServerWrapper srcZkServerWrapper;
+  private String destZkAddress;
+  private ZkClient destZkClient;
+  private ZkServerWrapper destZkServerWrapper;
+  private final String CLUSTER_1 = "cluster1";
+  private final String CLUSTER_2 = "cluster2";
+  private final Set<String> CLUSTERS = new HashSet<>(Arrays.asList(CLUSTER_1, CLUSTER_2));
+  private final String BASE_PATH = "/venice-parent";
+  private final Set<String> CLUSTER_ZK_PATHS = new HashSet<>(
+      Arrays.asList(ADMIN_TOPIC_METADATA, EXECUTION_IDS, PARENT_OFFLINE_PUSHES, ROUTERS, STORE_GRAVEYARD, STORES));
+
+  @BeforeClass
+  public void zkSetup() {
+    srcZkServerWrapper = ServiceFactory.getZkServer();
+    srcZkAddress = srcZkServerWrapper.getAddress();
+    srcZkClient = ZkClientFactory.newZkClient(srcZkAddress);
+    destZkServerWrapper = ServiceFactory.getZkServer();
+    destZkAddress = destZkServerWrapper.getAddress();
+    destZkClient = ZkClientFactory.newZkClient(destZkAddress);
+    createZkClientPaths(srcZkClient);
+  }
+
+  @AfterClass
+  public void zkCleanup() {
+    srcZkClient.deleteRecursively(BASE_PATH);
+    srcZkClient.close();
+    srcZkServerWrapper.close();
+    destZkClient.deleteRecursively(BASE_PATH);
+    destZkClient.close();
+    destZkServerWrapper.close();
+  }
+
+  @Test
+  public void testMigrateVeniceZKPaths() {
+    String[] args = { "--migrate-venice-zk-paths", "--src-zookeeper-url", srcZkAddress, "--dest-zookeeper-url",
+        destZkAddress, "--cluster-list", "cluster1, cluster2", "--base-path", BASE_PATH };
+    try {
+      AdminTool.main(args);
+      testZkClientPathsAsserts(destZkClient);
+    } catch (Exception e) {
+      e.printStackTrace();
+    }
+  }
+
+  private void createZkClientPaths(ZkClient zkClient) {
+    zkClient.create(BASE_PATH, BASE_PATH, CreateMode.PERSISTENT);
+    zkClient.create(BASE_PATH + "/" + STORE_CONFIGS, STORE_CONFIGS, CreateMode.PERSISTENT);
+    zkClient.create(BASE_PATH + "/" + STORE_CONFIGS + "/file", "file", CreateMode.PERSISTENT);
+    for (String cluster: CLUSTERS) {
+      String clusterPath = BASE_PATH + "/" + cluster;
+      zkClient.create(clusterPath, cluster, CreateMode.PERSISTENT);
+      for (String zkPath: CLUSTER_ZK_PATHS) {
+        zkClient.create(clusterPath + "/" + zkPath, zkPath, CreateMode.PERSISTENT);
+        if (zkPath.equals(STORES)) {
+          zkClient.create(clusterPath + "/" + zkPath + "/testStore", "testStore", CreateMode.PERSISTENT);
+        }
+      }
+    }
+  }
+
+  private void testZkClientPathsAsserts(ZkClient zkClient) {
+    Assert.assertTrue(zkClient.exists(BASE_PATH));
+    Assert.assertEquals(zkClient.readData(BASE_PATH), BASE_PATH);
+    Assert.assertTrue(zkClient.exists(BASE_PATH + "/" + STORE_CONFIGS));
+    Assert.assertEquals(zkClient.readData(BASE_PATH + "/" + STORE_CONFIGS), STORE_CONFIGS);
+    Assert.assertTrue(zkClient.exists(BASE_PATH + "/" + STORE_CONFIGS + "/file"));
+    Assert.assertEquals(zkClient.readData(BASE_PATH + "/" + STORE_CONFIGS + "/file"), "file");
+    for (String cluster: CLUSTERS) {
+      String clusterPath = BASE_PATH + "/" + cluster;
+      Assert.assertTrue(zkClient.exists(clusterPath));
+      Assert.assertEquals(zkClient.readData(clusterPath), cluster);
+      for (String zkPath: CLUSTER_ZK_PATHS) {
+        Assert.assertTrue(zkClient.exists(clusterPath + "/" + zkPath));
+        Assert.assertEquals(zkClient.readData(clusterPath + "/" + zkPath), zkPath);
+        if (zkPath.equals(STORES)) {
+          Assert.assertFalse(zkClient.exists(clusterPath + "/" + zkPath + "/assertFalse"));
+          Assert.assertTrue(zkClient.exists(clusterPath + "/" + zkPath + "/testStore"));
+          Assert.assertEquals(zkClient.readData(clusterPath + "/" + zkPath + "/testStore"), "testStore");
+        }
+      }
+    }
+  }
+}

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/zk/TestMigrateVeniceZKPaths.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/zk/TestMigrateVeniceZKPaths.java
@@ -1,13 +1,8 @@
 package com.linkedin.venice.zk;
 
-import static com.linkedin.venice.zk.VeniceZkPaths.ADMIN_TOPIC_METADATA;
 import static com.linkedin.venice.zk.VeniceZkPaths.CLUSTER_ZK_PATHS;
-import static com.linkedin.venice.zk.VeniceZkPaths.EXECUTION_IDS;
-import static com.linkedin.venice.zk.VeniceZkPaths.PARENT_OFFLINE_PUSHES;
-import static com.linkedin.venice.zk.VeniceZkPaths.ROUTERS;
 import static com.linkedin.venice.zk.VeniceZkPaths.STORES;
 import static com.linkedin.venice.zk.VeniceZkPaths.STORE_CONFIGS;
-import static com.linkedin.venice.zk.VeniceZkPaths.STORE_GRAVEYARD;
 
 import com.linkedin.venice.ZkCopier;
 import com.linkedin.venice.helix.ZkClientFactory;
@@ -15,7 +10,6 @@ import com.linkedin.venice.integration.utils.ServiceFactory;
 import com.linkedin.venice.integration.utils.ZkServerWrapper;
 import java.util.Arrays;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 import org.apache.helix.zookeeper.impl.client.ZkClient;
 import org.apache.zookeeper.CreateMode;
@@ -62,9 +56,8 @@ public class TestMigrateVeniceZKPaths {
   /** Test migrating metadata from local source ZK to local destination ZK using ZkCopier.migrateVenicePaths()*/
   @Test
   public void testMigrateVenicePaths() {
-    List<String> destZkClientVenicePaths = ZkCopier.migrateVenicePaths(srcZkClient, destZkClient, CLUSTERS, BASE_PATH);
+    ZkCopier.migrateVenicePaths(srcZkClient, destZkClient, CLUSTERS, BASE_PATH);
     testZkClientPathsAsserts(destZkClient);
-    testVenicePathsAsserts(destZkClientVenicePaths);
   }
 
   private void createZkClientPaths(ZkClient zkClient) {
@@ -108,28 +101,5 @@ public class TestMigrateVeniceZKPaths {
         }
       }
     }
-  }
-
-  private void testVenicePathsAsserts(List<String> venicePaths) {
-    Assert.assertEquals(venicePaths.size(), 19);
-    Assert.assertTrue(venicePaths.contains(BASE_PATH));
-    Assert.assertTrue(venicePaths.contains(BASE_PATH + "/" + STORE_CONFIGS));
-    Assert.assertTrue(venicePaths.contains(BASE_PATH + "/" + STORE_CONFIGS + "/file"));
-    Assert.assertTrue(venicePaths.contains(BASE_PATH + "/" + CLUSTER_1));
-    Assert.assertTrue(venicePaths.contains(BASE_PATH + "/" + CLUSTER_1 + "/" + ADMIN_TOPIC_METADATA));
-    Assert.assertTrue(venicePaths.contains(BASE_PATH + "/" + CLUSTER_1 + "/" + EXECUTION_IDS));
-    Assert.assertTrue(venicePaths.contains(BASE_PATH + "/" + CLUSTER_1 + "/" + PARENT_OFFLINE_PUSHES));
-    Assert.assertTrue(venicePaths.contains(BASE_PATH + "/" + CLUSTER_1 + "/" + ROUTERS));
-    Assert.assertTrue(venicePaths.contains(BASE_PATH + "/" + CLUSTER_1 + "/" + STORE_GRAVEYARD));
-    Assert.assertTrue(venicePaths.contains(BASE_PATH + "/" + CLUSTER_1 + "/" + STORES));
-    Assert.assertTrue(venicePaths.contains(BASE_PATH + "/" + CLUSTER_1 + "/" + STORES + "/testStore"));
-    Assert.assertTrue(venicePaths.contains(BASE_PATH + "/" + CLUSTER_2));
-    Assert.assertTrue(venicePaths.contains(BASE_PATH + "/" + CLUSTER_2 + "/" + ADMIN_TOPIC_METADATA));
-    Assert.assertTrue(venicePaths.contains(BASE_PATH + "/" + CLUSTER_2 + "/" + EXECUTION_IDS));
-    Assert.assertTrue(venicePaths.contains(BASE_PATH + "/" + CLUSTER_2 + "/" + PARENT_OFFLINE_PUSHES));
-    Assert.assertTrue(venicePaths.contains(BASE_PATH + "/" + CLUSTER_2 + "/" + ROUTERS));
-    Assert.assertTrue(venicePaths.contains(BASE_PATH + "/" + CLUSTER_2 + "/" + STORE_GRAVEYARD));
-    Assert.assertTrue(venicePaths.contains(BASE_PATH + "/" + CLUSTER_2 + "/" + STORES));
-    Assert.assertTrue(venicePaths.contains(BASE_PATH + "/" + CLUSTER_2 + "/" + STORES + "/testStore"));
   }
 }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/zk/TestMigrateVeniceZKPaths.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/zk/TestMigrateVeniceZKPaths.java
@@ -1,15 +1,21 @@
 package com.linkedin.venice.zk;
 
+import static com.linkedin.venice.zk.VeniceZkPaths.ADMIN_TOPIC_METADATA;
 import static com.linkedin.venice.zk.VeniceZkPaths.CLUSTER_ZK_PATHS;
+import static com.linkedin.venice.zk.VeniceZkPaths.EXECUTION_IDS;
+import static com.linkedin.venice.zk.VeniceZkPaths.PARENT_OFFLINE_PUSHES;
+import static com.linkedin.venice.zk.VeniceZkPaths.ROUTERS;
 import static com.linkedin.venice.zk.VeniceZkPaths.STORES;
 import static com.linkedin.venice.zk.VeniceZkPaths.STORE_CONFIGS;
+import static com.linkedin.venice.zk.VeniceZkPaths.STORE_GRAVEYARD;
 
-import com.linkedin.venice.AdminTool;
+import com.linkedin.venice.ZkCopier;
 import com.linkedin.venice.helix.ZkClientFactory;
 import com.linkedin.venice.integration.utils.ServiceFactory;
 import com.linkedin.venice.integration.utils.ZkServerWrapper;
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import org.apache.helix.zookeeper.impl.client.ZkClient;
 import org.apache.zookeeper.CreateMode;
@@ -39,6 +45,7 @@ public class TestMigrateVeniceZKPaths {
     destZkServerWrapper = ServiceFactory.getZkServer();
     destZkAddress = destZkServerWrapper.getAddress();
     destZkClient = ZkClientFactory.newZkClient(destZkAddress);
+    Assert.assertNotEquals(srcZkAddress, destZkAddress);
     createZkClientPaths(srcZkClient);
   }
 
@@ -52,16 +59,12 @@ public class TestMigrateVeniceZKPaths {
     destZkServerWrapper.close();
   }
 
+  /** Test migrating metadata from local source ZK to local destination ZK using ZkCopier.migrateVenicePaths()*/
   @Test
-  public void testMigrateVeniceZKPaths() {
-    String[] args = { "--migrate-venice-zk-paths", "--src-zookeeper-url", srcZkAddress, "--dest-zookeeper-url",
-        destZkAddress, "--cluster-list", "cluster1, cluster2", "--base-path", BASE_PATH };
-    try {
-      AdminTool.main(args);
-      testZkClientPathsAsserts(destZkClient);
-    } catch (Exception e) {
-      e.printStackTrace();
-    }
+  public void testMigrateVenicePaths() {
+    List<String> destZkClientVenicePaths = ZkCopier.migrateVenicePaths(srcZkClient, destZkClient, CLUSTERS, BASE_PATH);
+    testZkClientPathsAsserts(destZkClient);
+    testVenicePathsAsserts(destZkClientVenicePaths);
   }
 
   private void createZkClientPaths(ZkClient zkClient) {
@@ -105,5 +108,28 @@ public class TestMigrateVeniceZKPaths {
         }
       }
     }
+  }
+
+  private void testVenicePathsAsserts(List<String> venicePaths) {
+    Assert.assertEquals(venicePaths.size(), 19);
+    Assert.assertTrue(venicePaths.contains(BASE_PATH));
+    Assert.assertTrue(venicePaths.contains(BASE_PATH + "/" + STORE_CONFIGS));
+    Assert.assertTrue(venicePaths.contains(BASE_PATH + "/" + STORE_CONFIGS + "/file"));
+    Assert.assertTrue(venicePaths.contains(BASE_PATH + "/" + CLUSTER_1));
+    Assert.assertTrue(venicePaths.contains(BASE_PATH + "/" + CLUSTER_1 + "/" + ADMIN_TOPIC_METADATA));
+    Assert.assertTrue(venicePaths.contains(BASE_PATH + "/" + CLUSTER_1 + "/" + EXECUTION_IDS));
+    Assert.assertTrue(venicePaths.contains(BASE_PATH + "/" + CLUSTER_1 + "/" + PARENT_OFFLINE_PUSHES));
+    Assert.assertTrue(venicePaths.contains(BASE_PATH + "/" + CLUSTER_1 + "/" + ROUTERS));
+    Assert.assertTrue(venicePaths.contains(BASE_PATH + "/" + CLUSTER_1 + "/" + STORE_GRAVEYARD));
+    Assert.assertTrue(venicePaths.contains(BASE_PATH + "/" + CLUSTER_1 + "/" + STORES));
+    Assert.assertTrue(venicePaths.contains(BASE_PATH + "/" + CLUSTER_1 + "/" + STORES + "/testStore"));
+    Assert.assertTrue(venicePaths.contains(BASE_PATH + "/" + CLUSTER_2));
+    Assert.assertTrue(venicePaths.contains(BASE_PATH + "/" + CLUSTER_2 + "/" + ADMIN_TOPIC_METADATA));
+    Assert.assertTrue(venicePaths.contains(BASE_PATH + "/" + CLUSTER_2 + "/" + EXECUTION_IDS));
+    Assert.assertTrue(venicePaths.contains(BASE_PATH + "/" + CLUSTER_2 + "/" + PARENT_OFFLINE_PUSHES));
+    Assert.assertTrue(venicePaths.contains(BASE_PATH + "/" + CLUSTER_2 + "/" + ROUTERS));
+    Assert.assertTrue(venicePaths.contains(BASE_PATH + "/" + CLUSTER_2 + "/" + STORE_GRAVEYARD));
+    Assert.assertTrue(venicePaths.contains(BASE_PATH + "/" + CLUSTER_2 + "/" + STORES));
+    Assert.assertTrue(venicePaths.contains(BASE_PATH + "/" + CLUSTER_2 + "/" + STORES + "/testStore"));
   }
 }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/zk/TestMigrateVeniceZKPaths.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/zk/TestMigrateVeniceZKPaths.java
@@ -1,12 +1,8 @@
 package com.linkedin.venice.zk;
 
-import static com.linkedin.venice.zk.VeniceZkPaths.ADMIN_TOPIC_METADATA;
-import static com.linkedin.venice.zk.VeniceZkPaths.EXECUTION_IDS;
-import static com.linkedin.venice.zk.VeniceZkPaths.PARENT_OFFLINE_PUSHES;
-import static com.linkedin.venice.zk.VeniceZkPaths.ROUTERS;
+import static com.linkedin.venice.zk.VeniceZkPaths.CLUSTER_ZK_PATHS;
 import static com.linkedin.venice.zk.VeniceZkPaths.STORES;
 import static com.linkedin.venice.zk.VeniceZkPaths.STORE_CONFIGS;
-import static com.linkedin.venice.zk.VeniceZkPaths.STORE_GRAVEYARD;
 
 import com.linkedin.venice.AdminTool;
 import com.linkedin.venice.helix.ZkClientFactory;
@@ -34,8 +30,6 @@ public class TestMigrateVeniceZKPaths {
   private static final String CLUSTER_2 = "cluster2";
   private final Set<String> CLUSTERS = new HashSet<>(Arrays.asList(CLUSTER_1, CLUSTER_2));
   private static final String BASE_PATH = "/venice-parent";
-  private final Set<String> CLUSTER_ZK_PATHS = new HashSet<>(
-      Arrays.asList(ADMIN_TOPIC_METADATA, EXECUTION_IDS, PARENT_OFFLINE_PUSHES, ROUTERS, STORE_GRAVEYARD, STORES));
 
   @BeforeClass
   public void zkSetup() {


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Metadata migration from source ZK to destination ZK
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

- Implemented AdminTool command to migrate Venice-specific metadata from a source ZooKeeper to a destination ZooKeeper.
- Completed manual testing with ei-ltx1 ZooKeeper server and migrated some of its metadata to a local Apache ZooKeeper server in standalone mode.
- Reading and writing `data` for ZNode works!

**Future steps:**
- Folders on ZooKeeper contain `ACLs`, `Stat`, and `Context` so we should look into migrating this information as well.
- We tested migration from a live ZooKeeper server -> local Apache ZooKeeper server. We will test migrating metadata from local Apache ZooKeeper server -> live ZooKeeper server in future end-to-end testing.
- Currently, we are building a tree of paths that we want to migrate from the source ZK, then converting it to a list. We will refactor this into one step in future iterations without having duplicate functionality.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

Unit Tests, Integration Tests, Manual Testing

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.