### PR TITLE
[router][common][fast-client] Add RetryManager to venice-router

### DIFF
--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/RetriableAvroGenericStoreClient.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/RetriableAvroGenericStoreClient.java
@@ -8,7 +8,7 @@ import com.linkedin.venice.client.store.ComputeGenericRecord;
 import com.linkedin.venice.client.store.streaming.StreamingCallback;
 import com.linkedin.venice.compute.ComputeRequestWrapper;
 import com.linkedin.venice.exceptions.VeniceException;
-import com.linkedin.venice.fastclient.meta.RetryManager;
+import com.linkedin.venice.meta.RetryManager;
 import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
 import java.util.Collections;
 import java.util.Optional;
@@ -40,7 +40,7 @@ public class RetriableAvroGenericStoreClient<K, V> extends DelegatingAvroStoreCl
   private final TimeoutProcessor timeoutProcessor;
   /**
    * The long tail retry budget is only applied to long tail retries. If there were any exception that's not a 429 the
-   * retry will be triggered without going through the long tail {@link RetryManager}. If the retry budget is exhausted
+   * retry will be triggered without going through the long tail {@link com.linkedin.venice.meta.RetryManager}. If the retry budget is exhausted
    * then the retry task will do nothing and the request will either complete eventually (original future) or time out.
    */
   private RetryManager singleGetLongTailRetryManager = null;

--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -2085,4 +2085,25 @@ public class ConfigKeys {
    * Only used in batch push jobs and partial updates.
    */
   public static final String CONTROLLER_DEFAULT_MAX_RECORD_SIZE_BYTES = "controller.default.max.record.size.bytes";
+
+  /**g
+   * Percentage of total single get requests that are allowed for retry in decimal. e.g. 0.1 would mean up to 10% of the
+   * total single get requests are allowed for long tail retry. This is to prevent retry storm and cascading failures.
+   */
+  public static final String ROUTER_SINGLE_GET_LONG_TAIL_RETRY_BUDGET_PERCENT_DECIMAL =
+      "router.single.get.long.tail.retry.budget.percent.decimal";
+
+  /**
+   * Percentage of total multi get requests that are allowed for retry in decimal. e.g. 0.1 would mean up to 10% of the
+   * total multi get requests are allowed for long tail retry. This is to prevent retry storm and cascading failures.
+   */
+  public static final String ROUTER_MULTI_GET_LONG_TAIL_RETRY_BUDGET_PERCENT_DECIMAL =
+      "router.multi.get.long.tail.retry.budget.percent.decimal";
+
+  /**
+   * Enforcement window for router long tail retry budget token bucket. This applies to both single get and multi get
+   * retry managers.
+   */
+  public static final String ROUTER_LONG_TAIL_RETRY_BUDGET_ENFORCEMENT_WINDOW_MS =
+      "router.long.tail.retry.budget.enforcement.window.ms";
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -2090,15 +2090,15 @@ public class ConfigKeys {
    * Percentage of total single get requests that are allowed for retry in decimal. e.g. 0.1 would mean up to 10% of the
    * total single get requests are allowed for long tail retry. This is to prevent retry storm and cascading failures.
    */
-  public static final String ROUTER_SINGLE_GET_LONG_TAIL_RETRY_BUDGET_PERCENT_DECIMAL =
-      "router.single.get.long.tail.retry.budget.percent.decimal";
+  public static final String ROUTER_SINGLE_KEY_LONG_TAIL_RETRY_BUDGET_PERCENT_DECIMAL =
+      "router.single.key.long.tail.retry.budget.percent.decimal";
 
   /**
    * Percentage of total multi get requests that are allowed for retry in decimal. e.g. 0.1 would mean up to 10% of the
    * total multi get requests are allowed for long tail retry. This is to prevent retry storm and cascading failures.
    */
-  public static final String ROUTER_MULTI_GET_LONG_TAIL_RETRY_BUDGET_PERCENT_DECIMAL =
-      "router.multi.get.long.tail.retry.budget.percent.decimal";
+  public static final String ROUTER_MULTI_KEY_LONG_TAIL_RETRY_BUDGET_PERCENT_DECIMAL =
+      "router.multi.key.long.tail.retry.budget.percent.decimal";
 
   /**
    * Enforcement window for router long tail retry budget token bucket. This applies to both single get and multi get
@@ -2106,4 +2106,10 @@ public class ConfigKeys {
    */
   public static final String ROUTER_LONG_TAIL_RETRY_BUDGET_ENFORCEMENT_WINDOW_MS =
       "router.long.tail.retry.budget.enforcement.window.ms";
+
+  /**
+   * The core pool size for the thread pool executor which contains threads responsible for measuring and updating all
+   * retry managers in router periodically to provide retry budget based on a percentage of the original requests.
+   */
+  public static final String ROUTER_RETRY_MANAGER_CORE_POOL_SIZE = "router.retry.manager.core.pool.size";
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/RetryManager.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/RetryManager.java
@@ -75,15 +75,19 @@ public class RetryManager {
   }
 
   public boolean isRetryAllowed() {
+    return this.isRetryAllowed(1);
+  }
+
+  public boolean isRetryAllowed(int numberOfRetries) {
     TokenBucket tokenBucket = retryTokenBucket.get();
     if (!retryBudgetEnabled.get() || tokenBucket == null) {
       // All retries are allowed when the feature is disabled or during the very first enforcement window when we
       // haven't collected enough data points yet
       return true;
     }
-    boolean retryAllowed = retryTokenBucket.get().tryConsume(1);
+    boolean retryAllowed = retryTokenBucket.get().tryConsume(numberOfRetries);
     if (!retryAllowed) {
-      retryManagerStats.recordRejectedRetry();
+      retryManagerStats.recordRejectedRetry(numberOfRetries);
     }
     return retryAllowed;
   }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/RetryManager.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/RetryManager.java
@@ -1,6 +1,6 @@
-package com.linkedin.venice.fastclient.meta;
+package com.linkedin.venice.meta;
 
-import com.linkedin.venice.fastclient.stats.RetryManagerStats;
+import com.linkedin.venice.stats.RetryManagerStats;
 import com.linkedin.venice.throttle.TokenBucket;
 import io.tehuti.metrics.MetricsRepository;
 import java.io.Closeable;
@@ -15,10 +15,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 
-/**
- * This class offers advanced client retry behaviors. Specifically enforcing a retry budget and relevant monitoring to
- * avoid retry storm and alert users when the retry threshold is misconfigured or service is degrading.
- */
 public class RetryManager implements Closeable {
   private static final Logger LOGGER = LogManager.getLogger(RetryManager.class);
   private static final int TOKEN_BUCKET_REFILL_INTERVAL_IN_SECONDS = 1;

--- a/internal/venice-common/src/main/java/com/linkedin/venice/stats/RetryManagerStats.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/stats/RetryManagerStats.java
@@ -1,7 +1,6 @@
-package com.linkedin.venice.fastclient.stats;
+package com.linkedin.venice.stats;
 
-import com.linkedin.venice.fastclient.meta.RetryManager;
-import com.linkedin.venice.stats.AbstractVeniceStats;
+import com.linkedin.venice.meta.RetryManager;
 import com.linkedin.venice.throttle.TokenBucket;
 import io.tehuti.metrics.MetricsRepository;
 import io.tehuti.metrics.Sensor;

--- a/internal/venice-common/src/main/java/com/linkedin/venice/stats/RetryManagerStats.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/stats/RetryManagerStats.java
@@ -34,7 +34,7 @@ public class RetryManagerStats extends AbstractVeniceStats {
     rejectedRetrySensor = registerSensorIfAbsent("rejected_retry", new OccurrenceRate());
   }
 
-  public void recordRejectedRetry() {
-    rejectedRetrySensor.record();
+  public void recordRejectedRetry(int count) {
+    rejectedRetrySensor.record(count);
   }
 }

--- a/internal/venice-common/src/test/java/com/linkedin/venice/meta/RetryManagerTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/meta/RetryManagerTest.java
@@ -6,13 +6,22 @@ import com.linkedin.venice.utils.TestUtils;
 import io.tehuti.metrics.MetricsRepository;
 import java.io.IOException;
 import java.time.Clock;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
 
 
 public class RetryManagerTest {
   private static final long TEST_TIMEOUT_IN_MS = 10000;
+  private final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1);
+
+  @AfterClass
+  public void cleanUp() {
+    scheduler.shutdownNow();
+  }
 
   @Test(timeOut = TEST_TIMEOUT_IN_MS)
   public void testRetryManagerDisabled() throws IOException {
@@ -20,14 +29,14 @@ public class RetryManagerTest {
     long start = System.currentTimeMillis();
     doReturn(start).when(mockClock).millis();
     MetricsRepository metricsRepository = new MetricsRepository();
-    RetryManager retryManager = new RetryManager(metricsRepository, "test-retry-manager", 0, 0.1d, mockClock);
+    RetryManager retryManager =
+        new RetryManager(metricsRepository, "test-retry-manager", 0, 0.1d, mockClock, scheduler);
     retryManager.recordRequest();
     for (int i = 0; i < 10; i++) {
       Assert.assertTrue(retryManager.isRetryAllowed());
     }
     Assert.assertNull(retryManager.getRetryTokenBucket());
     Assert.assertNull(metricsRepository.getMetric(".test-retry-manager--retry_limit_per_seconds.Gauge"));
-    retryManager.close();
   }
 
   @Test(timeOut = TEST_TIMEOUT_IN_MS)
@@ -36,32 +45,29 @@ public class RetryManagerTest {
     long start = System.currentTimeMillis();
     doReturn(start).when(mockClock).millis();
     MetricsRepository metricsRepository = new MetricsRepository();
-    try (RetryManager retryManager = new RetryManager(metricsRepository, "test-retry-manager", 1000, 0.1d, mockClock)) {
-      doReturn(start + 1000).when(mockClock).millis();
-      for (int i = 0; i < 50; i++) {
-        retryManager.recordRequest();
-      }
-      TestUtils.waitForNonDeterministicAssertion(
-          5,
-          TimeUnit.SECONDS,
-          () -> Assert.assertNotNull(retryManager.getRetryTokenBucket()));
-      // The retry budget should be set to 50 * 0.1 = 5
-      // With refill interval of 1s and capacity multiple of 5 that makes the token bucket capacity of 25
-      Assert
-          .assertEquals(metricsRepository.getMetric(".test-retry-manager--retry_limit_per_seconds.Gauge").value(), 5d);
-      Assert.assertEquals(metricsRepository.getMetric(".test-retry-manager--retries_remaining.Gauge").value(), 25d);
-      for (int i = 0; i < 25; i++) {
-        Assert.assertTrue(retryManager.isRetryAllowed());
-      }
-      Assert.assertFalse(retryManager.isRetryAllowed());
-      Assert.assertEquals(metricsRepository.getMetric(".test-retry-manager--retries_remaining.Gauge").value(), 0d);
-      Assert.assertTrue(metricsRepository.getMetric(".test-retry-manager--rejected_retry.OccurrenceRate").value() > 0);
-      doReturn(start + 2001).when(mockClock).millis();
-      // We should eventually be able to perform retries again
-      TestUtils.waitForNonDeterministicAssertion(
-          5,
-          TimeUnit.SECONDS,
-          () -> Assert.assertTrue(retryManager.isRetryAllowed()));
+    RetryManager retryManager =
+        new RetryManager(metricsRepository, "test-retry-manager", 1000, 0.1d, mockClock, scheduler);
+    doReturn(start + 1000).when(mockClock).millis();
+    for (int i = 0; i < 50; i++) {
+      retryManager.recordRequest();
     }
+    TestUtils.waitForNonDeterministicAssertion(
+        5,
+        TimeUnit.SECONDS,
+        () -> Assert.assertNotNull(retryManager.getRetryTokenBucket()));
+    // The retry budget should be set to 50 * 0.1 = 5
+    // With refill interval of 1s and capacity multiple of 5 that makes the token bucket capacity of 25
+    Assert.assertEquals(metricsRepository.getMetric(".test-retry-manager--retry_limit_per_seconds.Gauge").value(), 5d);
+    Assert.assertEquals(metricsRepository.getMetric(".test-retry-manager--retries_remaining.Gauge").value(), 25d);
+    for (int i = 0; i < 25; i++) {
+      Assert.assertTrue(retryManager.isRetryAllowed());
+    }
+    Assert.assertFalse(retryManager.isRetryAllowed());
+    Assert.assertEquals(metricsRepository.getMetric(".test-retry-manager--retries_remaining.Gauge").value(), 0d);
+    Assert.assertTrue(metricsRepository.getMetric(".test-retry-manager--rejected_retry.OccurrenceRate").value() > 0);
+    doReturn(start + 2001).when(mockClock).millis();
+    // We should eventually be able to perform retries again
+    TestUtils
+        .waitForNonDeterministicAssertion(5, TimeUnit.SECONDS, () -> Assert.assertTrue(retryManager.isRetryAllowed()));
   }
 }

--- a/internal/venice-common/src/test/java/com/linkedin/venice/meta/RetryManagerTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/meta/RetryManagerTest.java
@@ -1,7 +1,6 @@
-package com.linkedin.venice.fastclient.meta;
+package com.linkedin.venice.meta;
 
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.*;
 
 import com.linkedin.venice.utils.TestUtils;
 import io.tehuti.metrics.MetricsRepository;

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/fastclient/FastClientIndividualFeatureConfigurationTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/fastclient/FastClientIndividualFeatureConfigurationTest.java
@@ -410,8 +410,8 @@ public class FastClientIndividualFeatureConfigurationTest extends AbstractClient
             .setLongTailRetryThresholdForBatchGetInMicroSeconds(10000)
             .setLongTailRetryBudgetEnforcementWindowInMs(1000)
             .setSpeculativeQueryEnabled(false);
-    String multiGetLongTailRetryManagerStatsPrefix = ".multi-get-long-tail-retry-manager-" + storeName + "--";
-    String singleGetLongTailRetryManagerStatsPrefix = ".single-get-long-tail-retry-manager-" + storeName + "--";
+    String multiKeyLongTailRetryManagerStatsPrefix = ".multi-key-long-tail-retry-manager-" + storeName + "--";
+    String singleKeyLongTailRetryManagerStatsPrefix = ".single-key-long-tail-retry-manager-" + storeName + "--";
     MetricsRepository clientMetric = new MetricsRepository();
     AvroGenericStoreClient<String, GenericRecord> genericFastClient =
         getGenericFastClient(clientConfigBuilder, clientMetric, StoreMetadataFetchMode.SERVER_BASED_METADATA);
@@ -427,19 +427,19 @@ public class FastClientIndividualFeatureConfigurationTest extends AbstractClient
         10,
         TimeUnit.SECONDS,
         () -> assertTrue(
-            clientMetric.getMetric(multiGetLongTailRetryManagerStatsPrefix + "retry_limit_per_seconds.Gauge")
+            clientMetric.getMetric(multiKeyLongTailRetryManagerStatsPrefix + "retry_limit_per_seconds.Gauge")
                 .value() > 0,
             "Current value: "
-                + clientMetric.getMetric(multiGetLongTailRetryManagerStatsPrefix + "retry_limit_per_seconds.Gauge")
+                + clientMetric.getMetric(multiKeyLongTailRetryManagerStatsPrefix + "retry_limit_per_seconds.Gauge")
                     .value()));
-    assertTrue(clientMetric.getMetric(multiGetLongTailRetryManagerStatsPrefix + "retries_remaining.Gauge").value() > 0);
+    assertTrue(clientMetric.getMetric(multiKeyLongTailRetryManagerStatsPrefix + "retries_remaining.Gauge").value() > 0);
     assertEquals(
-        clientMetric.getMetric(multiGetLongTailRetryManagerStatsPrefix + "rejected_retry.OccurrenceRate").value(),
+        clientMetric.getMetric(multiKeyLongTailRetryManagerStatsPrefix + "rejected_retry.OccurrenceRate").value(),
         0d);
     // single get long tail retry manager metrics shouldn't be initialized because it's not enabled
-    assertNull(clientMetric.getMetric(singleGetLongTailRetryManagerStatsPrefix + "retry_limit_per_seconds.Gauge"));
-    assertNull(clientMetric.getMetric(singleGetLongTailRetryManagerStatsPrefix + "retries_remaining.Gauge"));
-    assertNull(clientMetric.getMetric(singleGetLongTailRetryManagerStatsPrefix + "rejected_retry.OccurrenceRate"));
+    assertNull(clientMetric.getMetric(singleKeyLongTailRetryManagerStatsPrefix + "retry_limit_per_seconds.Gauge"));
+    assertNull(clientMetric.getMetric(singleKeyLongTailRetryManagerStatsPrefix + "retries_remaining.Gauge"));
+    assertNull(clientMetric.getMetric(singleKeyLongTailRetryManagerStatsPrefix + "rejected_retry.OccurrenceRate"));
   }
 
   @Test(timeOut = TIME_OUT)

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/fastclient/FastClientIndividualFeatureConfigurationTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/fastclient/FastClientIndividualFeatureConfigurationTest.java
@@ -410,8 +410,8 @@ public class FastClientIndividualFeatureConfigurationTest extends AbstractClient
             .setLongTailRetryThresholdForBatchGetInMicroSeconds(10000)
             .setLongTailRetryBudgetEnforcementWindowInMs(1000)
             .setSpeculativeQueryEnabled(false);
-    String multiGetLongTailRetryManagerStatsPrefix = ".multi-get-long-tail-retry-manager--";
-    String singleGetLongTailRetryManagerStatsPrefix = ".single-get-long-tail-retry-manager--";
+    String multiGetLongTailRetryManagerStatsPrefix = ".multi-get-long-tail-retry-manager-" + storeName + "--";
+    String singleGetLongTailRetryManagerStatsPrefix = ".single-get-long-tail-retry-manager-" + storeName + "--";
     MetricsRepository clientMetric = new MetricsRepository();
     AvroGenericStoreClient<String, GenericRecord> genericFastClient =
         getGenericFastClient(clientConfigBuilder, clientMetric, StoreMetadataFetchMode.SERVER_BASED_METADATA);

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/router/TestRouterRetry.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/router/TestRouterRetry.java
@@ -11,6 +11,7 @@ import com.linkedin.venice.controllerapi.UpdateStoreQueryParams;
 import com.linkedin.venice.controllerapi.VersionCreationResponse;
 import com.linkedin.venice.helix.HelixReadOnlySchemaRepository;
 import com.linkedin.venice.integration.utils.ServiceFactory;
+import com.linkedin.venice.integration.utils.VeniceClusterCreateOptions;
 import com.linkedin.venice.integration.utils.VeniceClusterWrapper;
 import com.linkedin.venice.meta.OfflinePushStrategy;
 import com.linkedin.venice.meta.Version;
@@ -35,8 +36,8 @@ import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
 import org.testng.Assert;
-import org.testng.annotations.AfterClass;
-import org.testng.annotations.BeforeClass;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 
@@ -50,6 +51,9 @@ public class TestRouterRetry {
   private int valueSchemaId;
   private String storeName;
 
+  // default extraProperties
+  private Properties extraProperties;
+
   private static final String KEY_SCHEMA_STR = "\"string\"";
   private static final String VALUE_FIELD_NAME = "int_field";
   private static final String VALUE_SCHEMA_STR =
@@ -58,15 +62,14 @@ public class TestRouterRetry {
   private static final Schema VALUE_SCHEMA = new Schema.Parser().parse(VALUE_SCHEMA_STR);
   private static final String KEY_PREFIX = "key_";
 
-  @BeforeClass(alwaysRun = true)
-  public void setUp() throws VeniceClientException, ExecutionException, InterruptedException {
-    Utils.thisIsLocalhost();
-    Properties extraProperties = new Properties();
+  @BeforeMethod(alwaysRun = true)
+  public void setUp() {
+    extraProperties = new Properties();
     // Add the following specific configs for Router
     // To trigger long-tail retry
     extraProperties.put(ConfigKeys.ROUTER_LONG_TAIL_RETRY_FOR_SINGLE_GET_THRESHOLD_MS, 1);
     extraProperties.put(ConfigKeys.ROUTER_MAX_KEY_COUNT_IN_MULTIGET_REQ, MAX_KEY_LIMIT); // 10 keys at most in a
-                                                                                         // batch-get request
+    // batch-get request
     extraProperties.put(ConfigKeys.ROUTER_LONG_TAIL_RETRY_FOR_BATCH_GET_THRESHOLD_MS, "1-:1");
     extraProperties.put(ConfigKeys.ROUTER_SMART_LONG_TAIL_RETRY_ENABLED, true);
 
@@ -74,8 +77,21 @@ public class TestRouterRetry {
     extraProperties.put(
         ConfigKeys.DEFAULT_OFFLINE_PUSH_STRATEGY,
         OfflinePushStrategy.WAIT_N_MINUS_ONE_REPLCIA_PER_PARTITION.toString());
+  }
 
-    veniceCluster = ServiceFactory.getVeniceCluster(1, 2, 1, 2, 100, true, false, extraProperties);
+  private void initCluster() throws VeniceClientException, ExecutionException, InterruptedException {
+    Utils.thisIsLocalhost();
+    VeniceClusterCreateOptions options = new VeniceClusterCreateOptions.Builder().numberOfControllers(1)
+        .numberOfServers(2)
+        .numberOfRouters(1)
+        .replicationFactor(2)
+        .partitionSize(100)
+        .minActiveReplica(1)
+        .sslToStorageNodes(true)
+        .sslToKafka(false)
+        .extraProperties(extraProperties)
+        .build();
+    veniceCluster = ServiceFactory.getVeniceCluster(options);
     routerAddr = veniceCluster.getRandomRouterSslURL();
 
     // Create test store
@@ -123,7 +139,7 @@ public class TestRouterRetry {
     veniceCluster.stopVeniceServer(veniceCluster.getVeniceServers().get(0).getPort());
   }
 
-  @AfterClass(alwaysRun = true)
+  @AfterMethod(alwaysRun = true)
   public void cleanUp() {
     Utils.closeQuietlyWithErrorLogged(veniceCluster);
     Utils.closeQuietlyWithErrorLogged(veniceWriter);
@@ -139,6 +155,7 @@ public class TestRouterRetry {
 
   @Test(timeOut = 60000)
   public void testRouterRetry() throws ExecutionException, InterruptedException {
+    initCluster();
     try (AvroGenericStoreClient<String, GenericRecord> storeClient = ClientFactory.getAndStartGenericAvroClient(
         ClientConfig.defaultGenericClientConfig(storeName)
             .setVeniceURL(routerAddr)
@@ -213,5 +230,36 @@ public class TestRouterRetry {
         unhealthyRequestMetricForForComputeStreaming,
         0.0,
         "Unhealthy request for compute streaming is unexpected");
+  }
+
+  @Test(timeOut = 60000)
+  public void testRouterRetryManager() throws ExecutionException, InterruptedException {
+    extraProperties.put(ConfigKeys.ROUTER_LONG_TAIL_RETRY_BUDGET_ENFORCEMENT_WINDOW_MS, "1000");
+    initCluster();
+    try (AvroGenericStoreClient<String, GenericRecord> storeClient = ClientFactory.getAndStartGenericAvroClient(
+        ClientConfig.defaultGenericClientConfig(storeName)
+            .setVeniceURL(routerAddr)
+            .setSslFactory(SslUtils.getVeniceLocalSslFactory()))) {
+      Set<String> keySet = new HashSet<>();
+      for (int i = 0; i < MAX_KEY_LIMIT - 1; ++i) {
+        keySet.add(KEY_PREFIX + i);
+      }
+      Map<String, GenericRecord> result = storeClient.batchGet(keySet).get();
+      // Retry manager should eventually be initialized
+      TestUtils.waitForNonDeterministicAssertion(5, TimeUnit.SECONDS, () -> {
+        double multiGetRetryLimit = MetricsUtils.getSum(
+            ".multi-get-long-tail-retry-manager-" + storeName + "--retry_limit_per_seconds.Gauge",
+            veniceCluster.getVeniceRouters());
+        Assert.assertTrue(multiGetRetryLimit > 0);
+      });
+      double multiGetRejectedRetry = MetricsUtils.getSum(
+          ".multi-get-long-tail-retry-manager-" + storeName + "--rejected_retry.OccurrenceRate",
+          veniceCluster.getVeniceRouters());
+      double singleGetRetryLimit = MetricsUtils.getSum(
+          "single-get-long-tail-retry-manager-" + storeName + "--retry_limit_per_seconds.Gauge",
+          veniceCluster.getVeniceRouters());
+      Assert.assertEquals(multiGetRejectedRetry, 0.0, "Rejected retry is unexpected");
+      Assert.assertEquals(singleGetRetryLimit, 0.0, "Single get retry manager shouldn't be initialized");
+    }
   }
 }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/router/TestRouterRetry.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/router/TestRouterRetry.java
@@ -235,8 +235,8 @@ public class TestRouterRetry {
   @Test(timeOut = 60000)
   public void testRouterMultiGetRetryManager() throws ExecutionException, InterruptedException {
     extraProperties.put(ConfigKeys.ROUTER_LONG_TAIL_RETRY_BUDGET_ENFORCEMENT_WINDOW_MS, "1000");
-    extraProperties.put(ConfigKeys.ROUTER_SINGLE_GET_LONG_TAIL_RETRY_BUDGET_PERCENT_DECIMAL, "0.1");
-    extraProperties.put(ConfigKeys.ROUTER_MULTI_GET_LONG_TAIL_RETRY_BUDGET_PERCENT_DECIMAL, "0.1");
+    extraProperties.put(ConfigKeys.ROUTER_SINGLE_KEY_LONG_TAIL_RETRY_BUDGET_PERCENT_DECIMAL, "0.1");
+    extraProperties.put(ConfigKeys.ROUTER_MULTI_KEY_LONG_TAIL_RETRY_BUDGET_PERCENT_DECIMAL, "0.1");
     initCluster();
     try (AvroGenericStoreClient<String, GenericRecord> storeClient = ClientFactory.getAndStartGenericAvroClient(
         ClientConfig.defaultGenericClientConfig(storeName)
@@ -251,26 +251,26 @@ public class TestRouterRetry {
       // Retry manager should eventually be initialized for multi-get
       TestUtils.waitForNonDeterministicAssertion(5, TimeUnit.SECONDS, () -> {
         double multiGetRetryLimit = MetricsUtils.getSum(
-            ".multi-get-long-tail-retry-manager-" + storeName + "--retry_limit_per_seconds.Gauge",
+            ".multi-key-long-tail-retry-manager-" + storeName + "--retry_limit_per_seconds.Gauge",
             veniceCluster.getVeniceRouters());
         Assert.assertTrue(multiGetRetryLimit > 0);
       });
       double multiGetRejectedRetry = MetricsUtils.getSum(
-          ".multi-get-long-tail-retry-manager-" + storeName + "--rejected_retry.OccurrenceRate",
+          ".multi-key-long-tail-retry-manager-" + storeName + "--rejected_retry.OccurrenceRate",
           veniceCluster.getVeniceRouters());
       double singleGetRetryLimit = MetricsUtils.getSum(
-          "single-get-long-tail-retry-manager-" + storeName + "--retry_limit_per_seconds.Gauge",
+          "single-key-long-tail-retry-manager-" + storeName + "--retry_limit_per_seconds.Gauge",
           veniceCluster.getVeniceRouters());
       Assert.assertEquals(multiGetRejectedRetry, 0.0, "Rejected retry is unexpected");
-      Assert.assertEquals(singleGetRetryLimit, 0.0, "Single-get retry manager shouldn't be initialized");
+      Assert.assertEquals(singleGetRetryLimit, 0.0, "Single-key retry manager shouldn't be initialized");
     }
   }
 
   @Test(timeOut = 60000)
   public void testRouterSingleGetRetryManager() throws ExecutionException, InterruptedException {
     extraProperties.put(ConfigKeys.ROUTER_LONG_TAIL_RETRY_BUDGET_ENFORCEMENT_WINDOW_MS, "1000");
-    extraProperties.put(ConfigKeys.ROUTER_SINGLE_GET_LONG_TAIL_RETRY_BUDGET_PERCENT_DECIMAL, "0.1");
-    extraProperties.put(ConfigKeys.ROUTER_MULTI_GET_LONG_TAIL_RETRY_BUDGET_PERCENT_DECIMAL, "0.1");
+    extraProperties.put(ConfigKeys.ROUTER_SINGLE_KEY_LONG_TAIL_RETRY_BUDGET_PERCENT_DECIMAL, "0.1");
+    extraProperties.put(ConfigKeys.ROUTER_MULTI_KEY_LONG_TAIL_RETRY_BUDGET_PERCENT_DECIMAL, "0.1");
     initCluster();
     try (AvroGenericStoreClient<String, GenericRecord> storeClient = ClientFactory.getAndStartGenericAvroClient(
         ClientConfig.defaultGenericClientConfig(storeName)
@@ -282,18 +282,18 @@ public class TestRouterRetry {
       // Retry manager should eventually be initialized for single-get
       TestUtils.waitForNonDeterministicAssertion(5, TimeUnit.SECONDS, () -> {
         double singleGetRetryLimit = MetricsUtils.getSum(
-            ".single-get-long-tail-retry-manager-" + storeName + "--retry_limit_per_seconds.Gauge",
+            ".single-key-long-tail-retry-manager-" + storeName + "--retry_limit_per_seconds.Gauge",
             veniceCluster.getVeniceRouters());
         Assert.assertTrue(singleGetRetryLimit > 0);
       });
       double singleGetRejectedRetry = MetricsUtils.getSum(
-          ".single-get-long-tail-retry-manager-" + storeName + "--rejected_retry.OccurrenceRate",
+          ".single-key-long-tail-retry-manager-" + storeName + "--rejected_retry.OccurrenceRate",
           veniceCluster.getVeniceRouters());
       double multiGetRetryLimit = MetricsUtils.getSum(
-          "multi-get-long-tail-retry-manager-" + storeName + "--retry_limit_per_seconds.Gauge",
+          "multi-key-long-tail-retry-manager-" + storeName + "--retry_limit_per_seconds.Gauge",
           veniceCluster.getVeniceRouters());
       Assert.assertEquals(singleGetRejectedRetry, 0.0, "Rejected retry is unexpected");
-      Assert.assertEquals(multiGetRetryLimit, 0.0, "Multi-get retry manager shouldn't be initialized");
+      Assert.assertEquals(multiGetRetryLimit, 0.0, "Multi-key retry manager shouldn't be initialized");
     }
   }
 }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/router/TestRouterRetry.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/router/TestRouterRetry.java
@@ -86,7 +86,6 @@ public class TestRouterRetry {
         .numberOfRouters(1)
         .replicationFactor(2)
         .partitionSize(100)
-        .minActiveReplica(1)
         .sslToStorageNodes(true)
         .sslToKafka(false)
         .extraProperties(extraProperties)

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/router/TestRouterRetry.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/router/TestRouterRetry.java
@@ -233,8 +233,10 @@ public class TestRouterRetry {
   }
 
   @Test(timeOut = 60000)
-  public void testRouterRetryManager() throws ExecutionException, InterruptedException {
+  public void testRouterMultiGetRetryManager() throws ExecutionException, InterruptedException {
     extraProperties.put(ConfigKeys.ROUTER_LONG_TAIL_RETRY_BUDGET_ENFORCEMENT_WINDOW_MS, "1000");
+    extraProperties.put(ConfigKeys.ROUTER_SINGLE_GET_LONG_TAIL_RETRY_BUDGET_PERCENT_DECIMAL, "0.1");
+    extraProperties.put(ConfigKeys.ROUTER_MULTI_GET_LONG_TAIL_RETRY_BUDGET_PERCENT_DECIMAL, "0.1");
     initCluster();
     try (AvroGenericStoreClient<String, GenericRecord> storeClient = ClientFactory.getAndStartGenericAvroClient(
         ClientConfig.defaultGenericClientConfig(storeName)
@@ -246,7 +248,7 @@ public class TestRouterRetry {
       }
       Map<String, GenericRecord> result = storeClient.batchGet(keySet).get();
       Assert.assertEquals(result.size(), MAX_KEY_LIMIT - 1);
-      // Retry manager should eventually be initialized
+      // Retry manager should eventually be initialized for multi-get
       TestUtils.waitForNonDeterministicAssertion(5, TimeUnit.SECONDS, () -> {
         double multiGetRetryLimit = MetricsUtils.getSum(
             ".multi-get-long-tail-retry-manager-" + storeName + "--retry_limit_per_seconds.Gauge",
@@ -260,7 +262,38 @@ public class TestRouterRetry {
           "single-get-long-tail-retry-manager-" + storeName + "--retry_limit_per_seconds.Gauge",
           veniceCluster.getVeniceRouters());
       Assert.assertEquals(multiGetRejectedRetry, 0.0, "Rejected retry is unexpected");
-      Assert.assertEquals(singleGetRetryLimit, 0.0, "Single get retry manager shouldn't be initialized");
+      Assert.assertEquals(singleGetRetryLimit, 0.0, "Single-get retry manager shouldn't be initialized");
+    }
+  }
+
+  @Test(timeOut = 60000)
+  public void testRouterSingleGetRetryManager() throws ExecutionException, InterruptedException {
+    extraProperties.put(ConfigKeys.ROUTER_LONG_TAIL_RETRY_BUDGET_ENFORCEMENT_WINDOW_MS, "1000");
+    extraProperties.put(ConfigKeys.ROUTER_SINGLE_GET_LONG_TAIL_RETRY_BUDGET_PERCENT_DECIMAL, "0.1");
+    extraProperties.put(ConfigKeys.ROUTER_MULTI_GET_LONG_TAIL_RETRY_BUDGET_PERCENT_DECIMAL, "0.1");
+    initCluster();
+    try (AvroGenericStoreClient<String, GenericRecord> storeClient = ClientFactory.getAndStartGenericAvroClient(
+        ClientConfig.defaultGenericClientConfig(storeName)
+            .setVeniceURL(routerAddr)
+            .setSslFactory(SslUtils.getVeniceLocalSslFactory()))) {
+      String key = KEY_PREFIX + 1;
+      GenericRecord result = storeClient.get(key).get();
+      Assert.assertNotNull(result, "Value should not be null");
+      // Retry manager should eventually be initialized for single-get
+      TestUtils.waitForNonDeterministicAssertion(5, TimeUnit.SECONDS, () -> {
+        double singleGetRetryLimit = MetricsUtils.getSum(
+            ".single-get-long-tail-retry-manager-" + storeName + "--retry_limit_per_seconds.Gauge",
+            veniceCluster.getVeniceRouters());
+        Assert.assertTrue(singleGetRetryLimit > 0);
+      });
+      double singleGetRejectedRetry = MetricsUtils.getSum(
+          ".single-get-long-tail-retry-manager-" + storeName + "--rejected_retry.OccurrenceRate",
+          veniceCluster.getVeniceRouters());
+      double multiGetRetryLimit = MetricsUtils.getSum(
+          "multi-get-long-tail-retry-manager-" + storeName + "--retry_limit_per_seconds.Gauge",
+          veniceCluster.getVeniceRouters());
+      Assert.assertEquals(singleGetRejectedRetry, 0.0, "Rejected retry is unexpected");
+      Assert.assertEquals(multiGetRetryLimit, 0.0, "Multi-get retry manager shouldn't be initialized");
     }
   }
 }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/router/TestRouterRetry.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/router/TestRouterRetry.java
@@ -245,6 +245,7 @@ public class TestRouterRetry {
         keySet.add(KEY_PREFIX + i);
       }
       Map<String, GenericRecord> result = storeClient.batchGet(keySet).get();
+      Assert.assertEquals(result.size(), MAX_KEY_LIMIT - 1);
       // Retry manager should eventually be initialized
       TestUtils.waitForNonDeterministicAssertion(5, TimeUnit.SECONDS, () -> {
         double multiGetRetryLimit = MetricsUtils.getSum(

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/RouterServer.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/RouterServer.java
@@ -526,8 +526,9 @@ public class RouterServer extends AbstractVeniceService {
         compressorFactory,
         metricsRepository);
 
-    retryManagerExecutorService =
-        Executors.newScheduledThreadPool(3, new DaemonThreadFactory(ROUTER_RETRY_MANAGER_THREAD_PREFIX));
+    retryManagerExecutorService = Executors.newScheduledThreadPool(
+        config.getRetryManagerCorePoolSize(),
+        new DaemonThreadFactory(ROUTER_RETRY_MANAGER_THREAD_PREFIX));
 
     VenicePathParser pathParser = new VenicePathParser(
         versionFinder,

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/RouterServer.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/RouterServer.java
@@ -84,6 +84,7 @@ import com.linkedin.venice.stats.ThreadPoolStats;
 import com.linkedin.venice.stats.VeniceJVMStats;
 import com.linkedin.venice.stats.ZkClientStatusStats;
 import com.linkedin.venice.throttle.EventThrottler;
+import com.linkedin.venice.utils.DaemonThreadFactory;
 import com.linkedin.venice.utils.HelixUtils;
 import com.linkedin.venice.utils.ReflectUtils;
 import com.linkedin.venice.utils.SslUtils;
@@ -127,6 +128,8 @@ import org.apache.logging.log4j.Logger;
 
 public class RouterServer extends AbstractVeniceService {
   private static final Logger LOGGER = LogManager.getLogger(RouterServer.class);
+
+  private static final String ROUTER_RETRY_MANAGER_THREAD_PREFIX = "Router-retry-manager-thread";
 
   // Immutable state
   private final List<ServiceDiscoveryAnnouncer> serviceDiscoveryAnnouncers;
@@ -523,7 +526,8 @@ public class RouterServer extends AbstractVeniceService {
         compressorFactory,
         metricsRepository);
 
-    retryManagerExecutorService = Executors.newScheduledThreadPool(3);
+    retryManagerExecutorService =
+        Executors.newScheduledThreadPool(3, new DaemonThreadFactory(ROUTER_RETRY_MANAGER_THREAD_PREFIX));
 
     VenicePathParser pathParser = new VenicePathParser(
         versionFinder,

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/VeniceRouterConfig.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/VeniceRouterConfig.java
@@ -72,7 +72,7 @@ import static com.linkedin.venice.ConfigKeys.ROUTER_MAX_PENDING_REQUEST;
 import static com.linkedin.venice.ConfigKeys.ROUTER_MAX_READ_CAPACITY;
 import static com.linkedin.venice.ConfigKeys.ROUTER_META_STORE_SHADOW_READ_ENABLED;
 import static com.linkedin.venice.ConfigKeys.ROUTER_MULTIGET_TARDY_LATENCY_MS;
-import static com.linkedin.venice.ConfigKeys.ROUTER_MULTI_GET_LONG_TAIL_RETRY_BUDGET_PERCENT_DECIMAL;
+import static com.linkedin.venice.ConfigKeys.ROUTER_MULTI_KEY_LONG_TAIL_RETRY_BUDGET_PERCENT_DECIMAL;
 import static com.linkedin.venice.ConfigKeys.ROUTER_MULTI_KEY_ROUTING_STRATEGY;
 import static com.linkedin.venice.ConfigKeys.ROUTER_NETTY_GRACEFUL_SHUTDOWN_PERIOD_SECONDS;
 import static com.linkedin.venice.ConfigKeys.ROUTER_PENDING_CONNECTION_RESUME_THRESHOLD_PER_ROUTE;
@@ -82,8 +82,9 @@ import static com.linkedin.venice.ConfigKeys.ROUTER_PER_STORE_ROUTER_QUOTA_BUFFE
 import static com.linkedin.venice.ConfigKeys.ROUTER_QUOTA_CHECK_WINDOW;
 import static com.linkedin.venice.ConfigKeys.ROUTER_READ_QUOTA_THROTTLING_LEASE_TIMEOUT_MS;
 import static com.linkedin.venice.ConfigKeys.ROUTER_RESOLVE_BEFORE_SSL;
+import static com.linkedin.venice.ConfigKeys.ROUTER_RETRY_MANAGER_CORE_POOL_SIZE;
 import static com.linkedin.venice.ConfigKeys.ROUTER_SINGLEGET_TARDY_LATENCY_MS;
-import static com.linkedin.venice.ConfigKeys.ROUTER_SINGLE_GET_LONG_TAIL_RETRY_BUDGET_PERCENT_DECIMAL;
+import static com.linkedin.venice.ConfigKeys.ROUTER_SINGLE_KEY_LONG_TAIL_RETRY_BUDGET_PERCENT_DECIMAL;
 import static com.linkedin.venice.ConfigKeys.ROUTER_SMART_LONG_TAIL_RETRY_ABORT_THRESHOLD_MS;
 import static com.linkedin.venice.ConfigKeys.ROUTER_SMART_LONG_TAIL_RETRY_ENABLED;
 import static com.linkedin.venice.ConfigKeys.ROUTER_SOCKET_TIMEOUT;
@@ -218,9 +219,10 @@ public class VeniceRouterConfig {
   private boolean httpClientOpensslEnabled;
   private String identityParserClassName;
 
-  private double singleGetLongTailRetryBudgetPercentDecimal;
-  private double multiGetLongTailRetryBudgetPercentDecimal;
+  private double singleKeyLongTailRetryBudgetPercentDecimal;
+  private double multiKeyLongTailRetryBudgetPercentDecimal;
   private long longTailRetryBudgetEnforcementWindowInMs;
+  private int retryManagerCorePoolSize;
 
   public VeniceRouterConfig(VeniceProperties props) {
     try {
@@ -400,12 +402,13 @@ public class VeniceRouterConfig {
     perStoreRouterQuotaBuffer = props.getDouble(ROUTER_PER_STORE_ROUTER_QUOTA_BUFFER, 1.5);
     httpClientOpensslEnabled = props.getBoolean(ROUTER_HTTP_CLIENT_OPENSSL_ENABLED, true);
     identityParserClassName = props.getString(IDENTITY_PARSER_CLASS, DefaultIdentityParser.class.getName());
-    singleGetLongTailRetryBudgetPercentDecimal =
-        props.getDouble(ROUTER_SINGLE_GET_LONG_TAIL_RETRY_BUDGET_PERCENT_DECIMAL, 0.0);
-    multiGetLongTailRetryBudgetPercentDecimal =
-        props.getDouble(ROUTER_MULTI_GET_LONG_TAIL_RETRY_BUDGET_PERCENT_DECIMAL, 0.0);
+    singleKeyLongTailRetryBudgetPercentDecimal =
+        props.getDouble(ROUTER_SINGLE_KEY_LONG_TAIL_RETRY_BUDGET_PERCENT_DECIMAL, 0.0);
+    multiKeyLongTailRetryBudgetPercentDecimal =
+        props.getDouble(ROUTER_MULTI_KEY_LONG_TAIL_RETRY_BUDGET_PERCENT_DECIMAL, 0.0);
     longTailRetryBudgetEnforcementWindowInMs =
         props.getLong(ROUTER_LONG_TAIL_RETRY_BUDGET_ENFORCEMENT_WINDOW_MS, Time.MS_PER_MINUTE);
+    retryManagerCorePoolSize = props.getInt(ROUTER_RETRY_MANAGER_CORE_POOL_SIZE, 5);
   }
 
   public double getPerStoreRouterQuotaBuffer() {
@@ -857,15 +860,19 @@ public class VeniceRouterConfig {
     return identityParserClassName;
   }
 
-  public double getSingleGetLongTailRetryBudgetPercentDecimal() {
-    return singleGetLongTailRetryBudgetPercentDecimal;
+  public double getSingleKeyLongTailRetryBudgetPercentDecimal() {
+    return singleKeyLongTailRetryBudgetPercentDecimal;
   }
 
-  public double getMultiGetLongTailRetryBudgetPercentDecimal() {
-    return multiGetLongTailRetryBudgetPercentDecimal;
+  public double getMultiKeyLongTailRetryBudgetPercentDecimal() {
+    return multiKeyLongTailRetryBudgetPercentDecimal;
   }
 
   public long getLongTailRetryBudgetEnforcementWindowInMs() {
     return longTailRetryBudgetEnforcementWindowInMs;
+  }
+
+  public int getRetryManagerCorePoolSize() {
+    return retryManagerCorePoolSize;
   }
 }

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/VeniceRouterConfig.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/VeniceRouterConfig.java
@@ -60,6 +60,7 @@ import static com.linkedin.venice.ConfigKeys.ROUTER_IDLE_CONNECTION_TO_SERVER_CL
 import static com.linkedin.venice.ConfigKeys.ROUTER_IO_WORKER_COUNT;
 import static com.linkedin.venice.ConfigKeys.ROUTER_LEAKED_FUTURE_CLEANUP_POLL_INTERVAL_MS;
 import static com.linkedin.venice.ConfigKeys.ROUTER_LEAKED_FUTURE_CLEANUP_THRESHOLD_MS;
+import static com.linkedin.venice.ConfigKeys.ROUTER_LONG_TAIL_RETRY_BUDGET_ENFORCEMENT_WINDOW_MS;
 import static com.linkedin.venice.ConfigKeys.ROUTER_LONG_TAIL_RETRY_FOR_BATCH_GET_THRESHOLD_MS;
 import static com.linkedin.venice.ConfigKeys.ROUTER_LONG_TAIL_RETRY_FOR_SINGLE_GET_THRESHOLD_MS;
 import static com.linkedin.venice.ConfigKeys.ROUTER_LONG_TAIL_RETRY_MAX_ROUTE_FOR_MULTI_KEYS_REQ;
@@ -71,6 +72,7 @@ import static com.linkedin.venice.ConfigKeys.ROUTER_MAX_PENDING_REQUEST;
 import static com.linkedin.venice.ConfigKeys.ROUTER_MAX_READ_CAPACITY;
 import static com.linkedin.venice.ConfigKeys.ROUTER_META_STORE_SHADOW_READ_ENABLED;
 import static com.linkedin.venice.ConfigKeys.ROUTER_MULTIGET_TARDY_LATENCY_MS;
+import static com.linkedin.venice.ConfigKeys.ROUTER_MULTI_GET_LONG_TAIL_RETRY_BUDGET_PERCENT_DECIMAL;
 import static com.linkedin.venice.ConfigKeys.ROUTER_MULTI_KEY_ROUTING_STRATEGY;
 import static com.linkedin.venice.ConfigKeys.ROUTER_NETTY_GRACEFUL_SHUTDOWN_PERIOD_SECONDS;
 import static com.linkedin.venice.ConfigKeys.ROUTER_PENDING_CONNECTION_RESUME_THRESHOLD_PER_ROUTE;
@@ -81,6 +83,7 @@ import static com.linkedin.venice.ConfigKeys.ROUTER_QUOTA_CHECK_WINDOW;
 import static com.linkedin.venice.ConfigKeys.ROUTER_READ_QUOTA_THROTTLING_LEASE_TIMEOUT_MS;
 import static com.linkedin.venice.ConfigKeys.ROUTER_RESOLVE_BEFORE_SSL;
 import static com.linkedin.venice.ConfigKeys.ROUTER_SINGLEGET_TARDY_LATENCY_MS;
+import static com.linkedin.venice.ConfigKeys.ROUTER_SINGLE_GET_LONG_TAIL_RETRY_BUDGET_PERCENT_DECIMAL;
 import static com.linkedin.venice.ConfigKeys.ROUTER_SMART_LONG_TAIL_RETRY_ABORT_THRESHOLD_MS;
 import static com.linkedin.venice.ConfigKeys.ROUTER_SMART_LONG_TAIL_RETRY_ENABLED;
 import static com.linkedin.venice.ConfigKeys.ROUTER_SOCKET_TIMEOUT;
@@ -214,6 +217,10 @@ public class VeniceRouterConfig {
   private double perStoreRouterQuotaBuffer;
   private boolean httpClientOpensslEnabled;
   private String identityParserClassName;
+
+  private double singleGetLongTailRetryBudgetPercentDecimal;
+  private double multiGetLongTailRetryBudgetPercentDecimal;
+  private long longTailRetryBudgetEnforcementWindowInMs;
 
   public VeniceRouterConfig(VeniceProperties props) {
     try {
@@ -393,6 +400,12 @@ public class VeniceRouterConfig {
     perStoreRouterQuotaBuffer = props.getDouble(ROUTER_PER_STORE_ROUTER_QUOTA_BUFFER, 1.5);
     httpClientOpensslEnabled = props.getBoolean(ROUTER_HTTP_CLIENT_OPENSSL_ENABLED, true);
     identityParserClassName = props.getString(IDENTITY_PARSER_CLASS, DefaultIdentityParser.class.getName());
+    singleGetLongTailRetryBudgetPercentDecimal =
+        props.getDouble(ROUTER_SINGLE_GET_LONG_TAIL_RETRY_BUDGET_PERCENT_DECIMAL, 0.1);
+    multiGetLongTailRetryBudgetPercentDecimal =
+        props.getDouble(ROUTER_MULTI_GET_LONG_TAIL_RETRY_BUDGET_PERCENT_DECIMAL, 0.1);
+    longTailRetryBudgetEnforcementWindowInMs =
+        props.getLong(ROUTER_LONG_TAIL_RETRY_BUDGET_ENFORCEMENT_WINDOW_MS, Time.MS_PER_MINUTE);
   }
 
   public double getPerStoreRouterQuotaBuffer() {
@@ -842,5 +855,17 @@ public class VeniceRouterConfig {
 
   public String getIdentityParserClassName() {
     return identityParserClassName;
+  }
+
+  public double getSingleGetLongTailRetryBudgetPercentDecimal() {
+    return singleGetLongTailRetryBudgetPercentDecimal;
+  }
+
+  public double getMultiGetLongTailRetryBudgetPercentDecimal() {
+    return multiGetLongTailRetryBudgetPercentDecimal;
+  }
+
+  public long getLongTailRetryBudgetEnforcementWindowInMs() {
+    return longTailRetryBudgetEnforcementWindowInMs;
   }
 }

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/VeniceRouterConfig.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/VeniceRouterConfig.java
@@ -401,9 +401,9 @@ public class VeniceRouterConfig {
     httpClientOpensslEnabled = props.getBoolean(ROUTER_HTTP_CLIENT_OPENSSL_ENABLED, true);
     identityParserClassName = props.getString(IDENTITY_PARSER_CLASS, DefaultIdentityParser.class.getName());
     singleGetLongTailRetryBudgetPercentDecimal =
-        props.getDouble(ROUTER_SINGLE_GET_LONG_TAIL_RETRY_BUDGET_PERCENT_DECIMAL, 0.1);
+        props.getDouble(ROUTER_SINGLE_GET_LONG_TAIL_RETRY_BUDGET_PERCENT_DECIMAL, 0.0);
     multiGetLongTailRetryBudgetPercentDecimal =
-        props.getDouble(ROUTER_MULTI_GET_LONG_TAIL_RETRY_BUDGET_PERCENT_DECIMAL, 0.1);
+        props.getDouble(ROUTER_MULTI_GET_LONG_TAIL_RETRY_BUDGET_PERCENT_DECIMAL, 0.0);
     longTailRetryBudgetEnforcementWindowInMs =
         props.getLong(ROUTER_LONG_TAIL_RETRY_BUDGET_ENFORCEMENT_WINDOW_MS, Time.MS_PER_MINUTE);
   }

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/api/VeniceDelegateMode.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/api/VeniceDelegateMode.java
@@ -286,6 +286,8 @@ public class VeniceDelegateMode extends ScatterGatherMode {
               "Quota exceeded for '" + storeName + "' while serving a " + venicePath.getRequestType()
                   + " request! msg: " + e.getMessage());
         }
+        // Only record route(s) of the original request for retry manager purposes.
+        venicePath.recordRequest();
       }
     }
 

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/api/VeniceDelegateMode.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/api/VeniceDelegateMode.java
@@ -261,7 +261,6 @@ public class VeniceDelegateMode extends ScatterGatherMode {
             INTERNAL_SERVER_ERROR,
             "Ready-to-serve host must be an 'Instance'");
       }
-      Instance veniceInstance = (Instance) host;
 
       if (!venicePath.isRetryRequest()) {
         /**
@@ -292,8 +291,10 @@ public class VeniceDelegateMode extends ScatterGatherMode {
     }
 
     if (venicePath.isRetryRequest()) {
-      // Check whether the retry request is allowed or not according to the max allowed retry route config
-      if (!venicePath.isLongTailRetryAllowedForNewRoute()) {
+      // Check whether the retry request is allowed or not according to the max allowed retry route config and retry
+      // manager's retry budget. Retry is only allowed if both conditions are true.
+      if (!venicePath.isLongTailRetryAllowedForNewRequest()
+          || !venicePath.isLongTailRetryWithinBudget(onlineRequestNum)) {
         routerStats.getStatsByType(venicePath.getRequestType()).recordDisallowedRetryRequest(storeName);
         throw RouterExceptionAndTrackingUtils.newRouterExceptionAndTracking(
             Optional.of(storeName),

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/api/VenicePathParser.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/api/VenicePathParser.java
@@ -182,7 +182,7 @@ public class VenicePathParser<HTTP_REQUEST extends BasicHttpRequest>
       if (VeniceRouterUtils.isHttpGet(method)) {
         RetryManager singleGetRetryManager = routerSingleGetRetryManagers.computeIfAbsent(
             storeName,
-            k -> new RetryManager(
+            ignored -> new RetryManager(
                 metricsRepository,
                 SINGLE_GET_RETRY_MANAGER_STATS_PREFIX + storeName,
                 routerConfig.getLongTailRetryBudgetEnforcementWindowInMs(),
@@ -198,11 +198,10 @@ public class VenicePathParser<HTTP_REQUEST extends BasicHttpRequest>
             partitionFinder,
             routerStats,
             singleGetRetryManager);
-        singleGetRetryManager.recordRequest();
       } else if (VeniceRouterUtils.isHttpPost(method)) {
         RetryManager multiGetRetryManager = routerMultiGetRetryManagers.computeIfAbsent(
             storeName,
-            k -> new RetryManager(
+            ignored -> new RetryManager(
                 metricsRepository,
                 MULTI_GET_RETRY_MANAGER_STATS_PREFIX + storeName,
                 routerConfig.getLongTailRetryBudgetEnforcementWindowInMs(),
@@ -263,7 +262,6 @@ public class VenicePathParser<HTTP_REQUEST extends BasicHttpRequest>
               "The passed in request must be either a GET or " + "be a POST with a resource type of " + TYPE_STORAGE
                   + " or " + TYPE_COMPUTE + ", but instead it was: " + request.toString());
         }
-        multiGetRetryManager.recordRequest();
       } else {
         throw RouterExceptionAndTrackingUtils.newRouterExceptionAndTracking(
             Optional.empty(),

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/api/path/VeniceComputePath.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/api/path/VeniceComputePath.java
@@ -10,6 +10,7 @@ import com.linkedin.alpini.router.api.RouterException;
 import com.linkedin.venice.HttpConstants;
 import com.linkedin.venice.compute.protocol.request.ComputeRequestV3;
 import com.linkedin.venice.compute.protocol.request.router.ComputeRouterRequestKeyV1;
+import com.linkedin.venice.meta.RetryManager;
 import com.linkedin.venice.read.RequestType;
 import com.linkedin.venice.read.protocol.request.router.MultiGetRouterRequestKeyV1;
 import com.linkedin.venice.router.api.RouterExceptionAndTrackingUtils;
@@ -90,14 +91,16 @@ public class VeniceComputePath extends VeniceMultiKeyPath<ComputeRouterRequestKe
       int maxKeyCount,
       boolean smartLongTailRetryEnabled,
       int smartLongTailRetryAbortThresholdMs,
-      int longTailRetryMaxRouteForMultiKeyReq) throws RouterException {
+      int longTailRetryMaxRouteForMultiKeyReq,
+      RetryManager retryManager) throws RouterException {
     super(
         storeName,
         versionNumber,
         resourceName,
         smartLongTailRetryEnabled,
         smartLongTailRetryAbortThresholdMs,
-        longTailRetryMaxRouteForMultiKeyReq);
+        longTailRetryMaxRouteForMultiKeyReq,
+        retryManager);
 
     this.valueSchemaIdHeader = request.headers().get(VENICE_COMPUTE_VALUE_SCHEMA_ID, "-1");
 
@@ -152,7 +155,8 @@ public class VeniceComputePath extends VeniceMultiKeyPath<ComputeRouterRequestKe
       String computeRequestVersionHeader,
       boolean smartLongTailRetryEnabled,
       int smartLongTailRetryAbortThresholdMs,
-      int longTailRetryMaxRouteForMultiKeyReq) {
+      int longTailRetryMaxRouteForMultiKeyReq,
+      RetryManager retryManager) {
     super(
         storeName,
         versionNumber,
@@ -160,7 +164,8 @@ public class VeniceComputePath extends VeniceMultiKeyPath<ComputeRouterRequestKe
         smartLongTailRetryEnabled,
         smartLongTailRetryAbortThresholdMs,
         routerKeyMap,
-        longTailRetryMaxRouteForMultiKeyReq);
+        longTailRetryMaxRouteForMultiKeyReq,
+        retryManager);
     this.requestContent = requestContent;
     this.valueSchemaIdHeader = valueSchemaIdHeader;
     this.computeRequestLengthInBytes = computeRequestLengthInBytes;
@@ -202,7 +207,8 @@ public class VeniceComputePath extends VeniceMultiKeyPath<ComputeRouterRequestKe
         newRouterKeyMap,
         isSmartLongTailRetryEnabled(),
         getSmartLongTailRetryAbortThresholdMs(),
-        getLongTailRetryMaxRouteForMultiKeyReq());
+        getLongTailRetryMaxRouteForMultiKeyReq(),
+        retryManager);
     newPath.setupRetryRelatedInfo(this);
     return newPath;
   }
@@ -227,7 +233,8 @@ public class VeniceComputePath extends VeniceMultiKeyPath<ComputeRouterRequestKe
         this.computeRequestVersionHeader,
         isSmartLongTailRetryEnabled(),
         getSmartLongTailRetryAbortThresholdMs(),
-        getLongTailRetryMaxRouteForMultiKeyReq());
+        getLongTailRetryMaxRouteForMultiKeyReq(),
+        retryManager);
     subPath.setupRetryRelatedInfo(this);
     return subPath;
   }

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/api/path/VeniceMultiGetPath.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/api/path/VeniceMultiGetPath.java
@@ -6,6 +6,7 @@ import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
 import com.linkedin.alpini.netty4.misc.BasicFullHttpRequest;
 import com.linkedin.alpini.router.api.RouterException;
 import com.linkedin.venice.HttpConstants;
+import com.linkedin.venice.meta.RetryManager;
 import com.linkedin.venice.read.RequestType;
 import com.linkedin.venice.read.protocol.request.router.MultiGetRouterRequestKeyV1;
 import com.linkedin.venice.router.RouterThrottleHandler;
@@ -49,14 +50,16 @@ public class VeniceMultiGetPath extends VeniceMultiKeyPath<MultiGetRouterRequest
       boolean smartLongTailRetryEnabled,
       int smartLongTailRetryAbortThresholdMs,
       RouterStats<AggRouterHttpRequestStats> stats,
-      int longTailRetryMaxRouteForMultiKeyReq) throws RouterException {
+      int longTailRetryMaxRouteForMultiKeyReq,
+      RetryManager retryManager) throws RouterException {
     super(
         storeName,
         versionNumber,
         resourceName,
         smartLongTailRetryEnabled,
         smartLongTailRetryAbortThresholdMs,
-        longTailRetryMaxRouteForMultiKeyReq);
+        longTailRetryMaxRouteForMultiKeyReq,
+        retryManager);
 
     // Validate API version
     int apiVersion = Integer.parseInt(request.headers().get(HttpConstants.VENICE_API_VERSION));
@@ -89,7 +92,8 @@ public class VeniceMultiGetPath extends VeniceMultiKeyPath<MultiGetRouterRequest
       Map<RouterKey, MultiGetRouterRequestKeyV1> routerKeyMap,
       boolean smartLongTailRetryEnabled,
       int smartLongTailRetryAbortThresholdMs,
-      int longTailRetryMaxRouteForMultiKeyReq) {
+      int longTailRetryMaxRouteForMultiKeyReq,
+      RetryManager retryManager) {
     super(
         storeName,
         versionNumber,
@@ -97,7 +101,8 @@ public class VeniceMultiGetPath extends VeniceMultiKeyPath<MultiGetRouterRequest
         smartLongTailRetryEnabled,
         smartLongTailRetryAbortThresholdMs,
         routerKeyMap,
-        longTailRetryMaxRouteForMultiKeyReq);
+        longTailRetryMaxRouteForMultiKeyReq,
+        retryManager);
     setPartitionKeys(routerKeyMap.keySet());
   }
 
@@ -132,7 +137,8 @@ public class VeniceMultiGetPath extends VeniceMultiKeyPath<MultiGetRouterRequest
         routerKeyMap,
         isSmartLongTailRetryEnabled(),
         getSmartLongTailRetryAbortThresholdMs(),
-        getLongTailRetryMaxRouteForMultiKeyReq());
+        getLongTailRetryMaxRouteForMultiKeyReq(),
+        retryManager);
     subPath.setupRetryRelatedInfo(this);
     return subPath;
   }

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/api/path/VeniceMultiKeyPath.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/api/path/VeniceMultiKeyPath.java
@@ -244,7 +244,7 @@ public abstract class VeniceMultiKeyPath<K> extends VenicePath {
     // 1. retry attempts < longTailRetryMaxRouteForMultiKeyReq (if set).
     // 2. we still have retry budget according to retry manager.
     if (longTailRetryMaxRouteForMultiKeyReq == -1) {
-      // feature is disabled
+      // max route feature is disabled
       return retryManager.isRetryAllowed();
     } else if (longTailRetryMaxRouteForMultiKeyReq <= 0) {
       return false;

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/api/path/VeniceMultiKeyPath.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/api/path/VeniceMultiKeyPath.java
@@ -243,16 +243,15 @@ public abstract class VeniceMultiKeyPath<K> extends VenicePath {
     // We are keeping both features for now. Retry is only allowed if both conditions pass:
     // 1. retry attempts < longTailRetryMaxRouteForMultiKeyReq (if set).
     // 2. we still have retry budget according to retry manager.
-    boolean longTailRetryAllowed;
     if (longTailRetryMaxRouteForMultiKeyReq == -1) {
       // feature is disabled
-      longTailRetryAllowed = true;
+      return retryManager.isRetryAllowed();
     } else if (longTailRetryMaxRouteForMultiKeyReq <= 0) {
-      longTailRetryAllowed = false;
+      return false;
     } else {
-      longTailRetryAllowed = currentAllowedRetryRouteCnt.incrementAndGet() <= longTailRetryMaxRouteForMultiKeyReq;
+      return (currentAllowedRetryRouteCnt.incrementAndGet() <= longTailRetryMaxRouteForMultiKeyReq)
+          && retryManager.isRetryAllowed();
     }
-    return longTailRetryAllowed && retryManager.isRetryAllowed();
   }
 
   @Override

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/api/path/VeniceMultiKeyPath.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/api/path/VeniceMultiKeyPath.java
@@ -239,19 +239,15 @@ public abstract class VeniceMultiKeyPath<K> extends VenicePath {
   }
 
   @Override
-  public boolean isLongTailRetryAllowedForNewRoute() {
-    // We are keeping both features for now. Retry is only allowed if both conditions pass:
-    // 1. retry attempts < longTailRetryMaxRouteForMultiKeyReq (if set).
-    // 2. we still have retry budget according to retry manager.
+  public boolean isLongTailRetryAllowedForNewRequest() {
     if (longTailRetryMaxRouteForMultiKeyReq == -1) {
-      // max route feature is disabled
-      return retryManager.isRetryAllowed();
-    } else if (longTailRetryMaxRouteForMultiKeyReq <= 0) {
-      return false;
-    } else {
-      return (currentAllowedRetryRouteCnt.incrementAndGet() <= longTailRetryMaxRouteForMultiKeyReq)
-          && retryManager.isRetryAllowed();
+      // feature is disabled
+      return true;
     }
+    if (longTailRetryMaxRouteForMultiKeyReq <= 0) {
+      return false;
+    }
+    return currentAllowedRetryRouteCnt.incrementAndGet() <= longTailRetryMaxRouteForMultiKeyReq;
   }
 
   @Override

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/api/path/VenicePath.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/api/path/VenicePath.java
@@ -339,8 +339,8 @@ public abstract class VenicePath implements ResourcePath<RouterKey> {
     return getChunkedResponse() != null;
   }
 
-  public boolean isLongTailRetryAllowedForNewRoute() {
-    return retryManager.isRetryAllowed();
+  public boolean isLongTailRetryAllowedForNewRequest() {
+    return true;
   }
 
   public abstract RequestType getRequestType();
@@ -363,5 +363,9 @@ public abstract class VenicePath implements ResourcePath<RouterKey> {
 
   public void recordRequest() {
     retryManager.recordRequest();
+  }
+
+  public boolean isLongTailRetryWithinBudget(int numberOfRoutes) {
+    return retryManager.isRetryAllowed(numberOfRoutes);
   }
 }

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/api/path/VenicePath.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/api/path/VenicePath.java
@@ -3,6 +3,7 @@ package com.linkedin.venice.router.api.path;
 import com.linkedin.alpini.router.api.ResourcePath;
 import com.linkedin.venice.HttpConstants;
 import com.linkedin.venice.exceptions.VeniceException;
+import com.linkedin.venice.meta.RetryManager;
 import com.linkedin.venice.read.RequestType;
 import com.linkedin.venice.router.api.RouterKey;
 import com.linkedin.venice.router.api.VeniceResponseDecompressor;
@@ -33,6 +34,7 @@ public abstract class VenicePath implements ResourcePath<RouterKey> {
   private Collection<RouterKey> partitionKeys;
   protected final String storeName;
   protected final int versionNumber;
+  protected final RetryManager retryManager;
   private final Time time;
   private boolean retryRequest = false;
   private final boolean smartLongTailRetryEnabled;
@@ -65,14 +67,16 @@ public abstract class VenicePath implements ResourcePath<RouterKey> {
       int versionNumber,
       String resourceName,
       boolean smartLongTailRetryEnabled,
-      int smartLongTailRetryAbortThresholdMs) {
+      int smartLongTailRetryAbortThresholdMs,
+      RetryManager retryManager) {
     this(
         storeName,
         versionNumber,
         resourceName,
         smartLongTailRetryEnabled,
         smartLongTailRetryAbortThresholdMs,
-        new SystemTime());
+        new SystemTime(),
+        retryManager);
   }
 
   public VenicePath(
@@ -81,13 +85,15 @@ public abstract class VenicePath implements ResourcePath<RouterKey> {
       String resourceName,
       boolean smartLongTailRetryEnabled,
       int smartLongTailRetryAbortThresholdMs,
-      Time time) {
+      Time time,
+      RetryManager retryManager) {
     this.resourceName = resourceName;
     this.storeName = storeName;
     this.versionNumber = versionNumber;
     this.smartLongTailRetryEnabled = smartLongTailRetryEnabled;
     this.smartLongTailRetryAbortThresholdMs = smartLongTailRetryAbortThresholdMs;
     this.time = time;
+    this.retryManager = retryManager;
   }
 
   public synchronized long getRequestId() {
@@ -334,7 +340,7 @@ public abstract class VenicePath implements ResourcePath<RouterKey> {
   }
 
   public boolean isLongTailRetryAllowedForNewRoute() {
-    return true;
+    return retryManager.isRetryAllowed();
   }
 
   public abstract RequestType getRequestType();

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/api/path/VenicePath.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/api/path/VenicePath.java
@@ -360,4 +360,8 @@ public abstract class VenicePath implements ResourcePath<RouterKey> {
   public abstract byte[] getBody();
 
   public abstract String getVeniceApiVersionHeader();
+
+  public void recordRequest() {
+    retryManager.recordRequest();
+  }
 }

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/api/path/VeniceSingleGetPath.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/api/path/VeniceSingleGetPath.java
@@ -8,6 +8,7 @@ import com.linkedin.alpini.base.misc.QueryStringDecoder;
 import com.linkedin.alpini.router.api.RouterException;
 import com.linkedin.venice.RequestConstants;
 import com.linkedin.venice.exceptions.VeniceNoHelixResourceException;
+import com.linkedin.venice.meta.RetryManager;
 import com.linkedin.venice.read.RequestType;
 import com.linkedin.venice.router.api.RouterExceptionAndTrackingUtils;
 import com.linkedin.venice.router.api.RouterKey;
@@ -41,8 +42,9 @@ public class VeniceSingleGetPath extends VenicePath {
       String key,
       String uri,
       VenicePartitionFinder partitionFinder,
-      RouterStats<AggRouterHttpRequestStats> stats) throws RouterException {
-    super(storeName, versionNumber, resourceName, false, -1);
+      RouterStats<AggRouterHttpRequestStats> stats,
+      RetryManager retryManager) throws RouterException {
+    super(storeName, versionNumber, resourceName, false, -1, retryManager);
     if (StringUtils.isEmpty(key)) {
       throw RouterExceptionAndTrackingUtils.newRouterExceptionAndTracking(
           Optional.empty(),

--- a/services/venice-router/src/test/java/com/linkedin/venice/router/api/TestVeniceDelegateMode.java
+++ b/services/venice-router/src/test/java/com/linkedin/venice/router/api/TestVeniceDelegateMode.java
@@ -26,6 +26,7 @@ import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.helix.HelixInstanceConfigRepository;
 import com.linkedin.venice.meta.Instance;
 import com.linkedin.venice.meta.ReadOnlyStoreRepository;
+import com.linkedin.venice.meta.RetryManager;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.read.RequestType;
 import com.linkedin.venice.router.VeniceRouterConfig;
@@ -76,7 +77,7 @@ public class TestVeniceDelegateMode {
       RequestType requestType,
       List<RouterKey> keys,
       Set<String> slowStorageNodeSet) {
-    return new VenicePath(storeName, version, resourceName, false, -1) {
+    return new VenicePath(storeName, version, resourceName, false, -1, mock(RetryManager.class)) {
       private final String ROUTER_REQUEST_VERSION =
           Integer.toString(ReadAvroProtocolDefinition.SINGLE_GET_ROUTER_REQUEST_V1.getProtocolVersion());
 

--- a/services/venice-router/src/test/java/com/linkedin/venice/router/api/TestVenicePathParser.java
+++ b/services/venice-router/src/test/java/com/linkedin/venice/router/api/TestVenicePathParser.java
@@ -19,7 +19,6 @@ import com.linkedin.venice.compute.ComputeRequestWrapper;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.helix.HelixReadOnlyStoreConfigRepository;
 import com.linkedin.venice.meta.ReadOnlyStoreRepository;
-import com.linkedin.venice.meta.RetryManager;
 import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.partitioner.DefaultVenicePartitioner;
 import com.linkedin.venice.partitioner.VenicePartitioner;
@@ -52,6 +51,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.ScheduledExecutorService;
 import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
@@ -128,8 +128,8 @@ public class TestVenicePathParser {
         storeRepository,
         mock(VeniceRouterConfig.class),
         mock(CompressorFactory.class),
-        mock(RetryManager.class),
-        mock(RetryManager.class));
+        mock(MetricsRepository.class),
+        mock(ScheduledExecutorService.class));
 
     String storeName = "test-store";
     String uri = "storage/" + storeName;
@@ -190,8 +190,8 @@ public class TestVenicePathParser {
         mock(ReadOnlyStoreRepository.class),
         MOCK_ROUTER_CONFIG,
         compressorFactory,
-        mock(RetryManager.class),
-        mock(RetryManager.class));
+        mock(MetricsRepository.class),
+        mock(ScheduledExecutorService.class));
     BasicFullHttpRequest request = new BasicFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, uri, 0, 0);
     VenicePath path = parser.parseResourceUri(uri, request);
     String keyB64 = Base64.getEncoder().encodeToString("key".getBytes());
@@ -221,8 +221,8 @@ public class TestVenicePathParser {
         mock(ReadOnlyStoreRepository.class),
         MOCK_ROUTER_CONFIG,
         compressorFactory,
-        mock(RetryManager.class),
-        mock(RetryManager.class)).parseResourceUri(myUri, request);
+        mock(MetricsRepository.class),
+        mock(ScheduledExecutorService.class)).parseResourceUri(myUri, request);
     ByteBuffer partitionKey = path.getPartitionKey().getKeyBuffer();
     Assert.assertEquals(
         path.getPartitionKey().getKeyBuffer(),
@@ -242,8 +242,8 @@ public class TestVenicePathParser {
         mock(ReadOnlyStoreRepository.class),
         MOCK_ROUTER_CONFIG,
         compressorFactory,
-        mock(RetryManager.class),
-        mock(RetryManager.class)).parseResourceUri("/badAction/storeName/key");
+        mock(MetricsRepository.class),
+        mock(ScheduledExecutorService.class)).parseResourceUri("/badAction/storeName/key");
   }
 
   @Test
@@ -289,8 +289,8 @@ public class TestVenicePathParser {
         storeRepository,
         MOCK_ROUTER_CONFIG,
         compressorFactory,
-        mock(RetryManager.class),
-        mock(RetryManager.class));
+        mock(MetricsRepository.class),
+        mock(ScheduledExecutorService.class));
     try {
       pathParser.parseResourceUri(myUri, request);
       fail("A RouterException should be thrown here");

--- a/services/venice-router/src/test/java/com/linkedin/venice/router/api/TestVenicePathParser.java
+++ b/services/venice-router/src/test/java/com/linkedin/venice/router/api/TestVenicePathParser.java
@@ -19,6 +19,7 @@ import com.linkedin.venice.compute.ComputeRequestWrapper;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.helix.HelixReadOnlyStoreConfigRepository;
 import com.linkedin.venice.meta.ReadOnlyStoreRepository;
+import com.linkedin.venice.meta.RetryManager;
 import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.partitioner.DefaultVenicePartitioner;
 import com.linkedin.venice.partitioner.VenicePartitioner;
@@ -126,7 +127,9 @@ public class TestVenicePathParser {
         getMockedStats(),
         storeRepository,
         mock(VeniceRouterConfig.class),
-        mock(CompressorFactory.class));
+        mock(CompressorFactory.class),
+        mock(RetryManager.class),
+        mock(RetryManager.class));
 
     String storeName = "test-store";
     String uri = "storage/" + storeName;
@@ -186,7 +189,9 @@ public class TestVenicePathParser {
         getMockedStats(),
         mock(ReadOnlyStoreRepository.class),
         MOCK_ROUTER_CONFIG,
-        compressorFactory);
+        compressorFactory,
+        mock(RetryManager.class),
+        mock(RetryManager.class));
     BasicFullHttpRequest request = new BasicFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, uri, 0, 0);
     VenicePath path = parser.parseResourceUri(uri, request);
     String keyB64 = Base64.getEncoder().encodeToString("key".getBytes());
@@ -215,7 +220,9 @@ public class TestVenicePathParser {
         getMockedStats(),
         mock(ReadOnlyStoreRepository.class),
         MOCK_ROUTER_CONFIG,
-        compressorFactory).parseResourceUri(myUri, request);
+        compressorFactory,
+        mock(RetryManager.class),
+        mock(RetryManager.class)).parseResourceUri(myUri, request);
     ByteBuffer partitionKey = path.getPartitionKey().getKeyBuffer();
     Assert.assertEquals(
         path.getPartitionKey().getKeyBuffer(),
@@ -234,7 +241,9 @@ public class TestVenicePathParser {
         getMockedStats(),
         mock(ReadOnlyStoreRepository.class),
         MOCK_ROUTER_CONFIG,
-        compressorFactory).parseResourceUri("/badAction/storeName/key");
+        compressorFactory,
+        mock(RetryManager.class),
+        mock(RetryManager.class)).parseResourceUri("/badAction/storeName/key");
   }
 
   @Test
@@ -279,7 +288,9 @@ public class TestVenicePathParser {
         mockRouterStats,
         storeRepository,
         MOCK_ROUTER_CONFIG,
-        compressorFactory);
+        compressorFactory,
+        mock(RetryManager.class),
+        mock(RetryManager.class));
     try {
       pathParser.parseResourceUri(myUri, request);
       fail("A RouterException should be thrown here");

--- a/services/venice-router/src/test/java/com/linkedin/venice/router/api/path/TestVeniceComputePath.java
+++ b/services/venice-router/src/test/java/com/linkedin/venice/router/api/path/TestVeniceComputePath.java
@@ -16,6 +16,7 @@ import com.linkedin.venice.compute.protocol.request.ComputeRequestV2;
 import com.linkedin.venice.compute.protocol.request.CosineSimilarity;
 import com.linkedin.venice.compute.protocol.request.DotProduct;
 import com.linkedin.venice.compute.protocol.request.enums.ComputeOperationType;
+import com.linkedin.venice.meta.RetryManager;
 import com.linkedin.venice.partitioner.VenicePartitioner;
 import com.linkedin.venice.router.api.VenicePartitionFinder;
 import com.linkedin.venice.schema.avro.ReadAvroProtocolDefinition;
@@ -126,7 +127,8 @@ public class TestVeniceComputePath {
           10,
           false,
           -1,
-          1);
+          1,
+          mock(RetryManager.class));
       Assert.assertEquals(computePath.getComputeRequestLengthInBytes(), expectedLength);
     }
   }
@@ -215,7 +217,8 @@ public class TestVeniceComputePath {
         smartLongTailRetryEnabled,
         smartLongTailRetryAbortThresholdMs,
         null,
-        longTailRetryMaxRouteForMultiKeyReq);
+        longTailRetryMaxRouteForMultiKeyReq,
+        mock(RetryManager.class));
     byte[] serializedMultiGetRequest = multiGetPath.serializeRouterRequest();
 
     VeniceComputePath computePath = new VeniceComputePath(
@@ -227,7 +230,8 @@ public class TestVeniceComputePath {
         maxKeyCount,
         smartLongTailRetryEnabled,
         smartLongTailRetryAbortThresholdMs,
-        longTailRetryMaxRouteForMultiKeyReq);
+        longTailRetryMaxRouteForMultiKeyReq,
+        mock(RetryManager.class));
     VeniceMultiGetPath syntheticMultiGetPath = computePath.toMultiGetPath();
     Assert.assertEquals(syntheticMultiGetPath.serializeRouterRequest(), serializedMultiGetRequest);
     Assert

--- a/services/venice-router/src/test/java/com/linkedin/venice/router/api/path/TestVeniceMultiGetPath.java
+++ b/services/venice-router/src/test/java/com/linkedin/venice/router/api/path/TestVeniceMultiGetPath.java
@@ -36,6 +36,9 @@ import org.testng.annotations.Test;
 
 
 public class TestVeniceMultiGetPath {
+  private final RetryManager disabledRetryManager =
+      new RetryManager(new MetricsRepository(), "test-retry-manager", 0, 0);
+
   @BeforeClass
   public void setUp() {
     RouterExceptionAndTrackingUtils.setRouterStats(
@@ -50,6 +53,7 @@ public class TestVeniceMultiGetPath {
   @AfterClass
   public void cleanUp() {
     RouterExceptionAndTrackingUtils.setRouterStats(null);
+    disabledRetryManager.close();
   }
 
   private static byte[] serializeKeys(Iterable<ByteBuffer> keys) {
@@ -117,7 +121,7 @@ public class TestVeniceMultiGetPath {
         -1,
         null,
         1,
-        mock(RetryManager.class));
+        disabledRetryManager);
   }
 
   @Test(expectedExceptions = RouterException.class, expectedExceptionsMessageRegExp = ".*but received.*")
@@ -146,7 +150,7 @@ public class TestVeniceMultiGetPath {
         -1,
         null,
         1,
-        mock(RetryManager.class));
+        disabledRetryManager);
   }
 
   @Test
@@ -165,7 +169,6 @@ public class TestVeniceMultiGetPath {
     BasicFullHttpRequest request = getMultiGetHttpRequest(resourceName, keys, Optional.empty());
     request.attr(RouterThrottleHandler.THROTTLE_HANDLER_BYTE_ATTRIBUTE_KEY)
         .set(multiGetRequestSerializer.serializeObjects(keys));
-
     VenicePath path = new VeniceMultiGetPath(
         storeName,
         version,
@@ -177,7 +180,7 @@ public class TestVeniceMultiGetPath {
         -1,
         null,
         1,
-        mock(RetryManager.class));
+        disabledRetryManager);
     Assert.assertTrue(path.isLongTailRetryAllowedForNewRoute());
     Assert.assertFalse(path.isLongTailRetryAllowedForNewRoute());
 
@@ -195,7 +198,7 @@ public class TestVeniceMultiGetPath {
         -1,
         null,
         -1,
-        mock(RetryManager.class));
+        disabledRetryManager);
     Assert.assertTrue(path.isLongTailRetryAllowedForNewRoute());
     Assert.assertTrue(path.isLongTailRetryAllowedForNewRoute());
   }

--- a/services/venice-router/src/test/java/com/linkedin/venice/router/api/path/TestVeniceMultiGetPath.java
+++ b/services/venice-router/src/test/java/com/linkedin/venice/router/api/path/TestVeniceMultiGetPath.java
@@ -180,8 +180,8 @@ public class TestVeniceMultiGetPath {
         null,
         1,
         disabledRetryManager);
-    Assert.assertTrue(path.isLongTailRetryAllowedForNewRoute());
-    Assert.assertFalse(path.isLongTailRetryAllowedForNewRoute());
+    Assert.assertTrue(path.isLongTailRetryAllowedForNewRequest());
+    Assert.assertFalse(path.isLongTailRetryAllowedForNewRequest());
 
     request = getMultiGetHttpRequest(resourceName, keys, Optional.empty());
     request.attr(RouterThrottleHandler.THROTTLE_HANDLER_BYTE_ATTRIBUTE_KEY)
@@ -198,7 +198,7 @@ public class TestVeniceMultiGetPath {
         null,
         -1,
         disabledRetryManager);
-    Assert.assertTrue(path.isLongTailRetryAllowedForNewRoute());
-    Assert.assertTrue(path.isLongTailRetryAllowedForNewRoute());
+    Assert.assertTrue(path.isLongTailRetryAllowedForNewRequest());
+    Assert.assertTrue(path.isLongTailRetryAllowedForNewRequest());
   }
 }

--- a/services/venice-router/src/test/java/com/linkedin/venice/router/api/path/TestVeniceMultiGetPath.java
+++ b/services/venice-router/src/test/java/com/linkedin/venice/router/api/path/TestVeniceMultiGetPath.java
@@ -9,6 +9,7 @@ import com.linkedin.alpini.netty4.misc.BasicFullHttpRequest;
 import com.linkedin.alpini.router.api.RouterException;
 import com.linkedin.venice.HttpConstants;
 import com.linkedin.venice.meta.ReadOnlyStoreRepository;
+import com.linkedin.venice.meta.RetryManager;
 import com.linkedin.venice.partitioner.VenicePartitioner;
 import com.linkedin.venice.router.RouterThrottleHandler;
 import com.linkedin.venice.router.api.RouterExceptionAndTrackingUtils;
@@ -115,7 +116,8 @@ public class TestVeniceMultiGetPath {
         false,
         -1,
         null,
-        1);
+        1,
+        mock(RetryManager.class));
   }
 
   @Test(expectedExceptions = RouterException.class, expectedExceptionsMessageRegExp = ".*but received.*")
@@ -143,7 +145,8 @@ public class TestVeniceMultiGetPath {
         false,
         -1,
         null,
-        1);
+        1,
+        mock(RetryManager.class));
   }
 
   @Test
@@ -173,7 +176,8 @@ public class TestVeniceMultiGetPath {
         false,
         -1,
         null,
-        1);
+        1,
+        mock(RetryManager.class));
     Assert.assertTrue(path.isLongTailRetryAllowedForNewRoute());
     Assert.assertFalse(path.isLongTailRetryAllowedForNewRoute());
 
@@ -190,7 +194,8 @@ public class TestVeniceMultiGetPath {
         false,
         -1,
         null,
-        -1);
+        -1,
+        mock(RetryManager.class));
     Assert.assertTrue(path.isLongTailRetryAllowedForNewRoute());
     Assert.assertTrue(path.isLongTailRetryAllowedForNewRoute());
   }

--- a/services/venice-router/src/test/java/com/linkedin/venice/router/api/path/TestVeniceMultiGetPath.java
+++ b/services/venice-router/src/test/java/com/linkedin/venice/router/api/path/TestVeniceMultiGetPath.java
@@ -37,7 +37,7 @@ import org.testng.annotations.Test;
 
 public class TestVeniceMultiGetPath {
   private final RetryManager disabledRetryManager =
-      new RetryManager(new MetricsRepository(), "test-retry-manager", 0, 0);
+      new RetryManager(new MetricsRepository(), "disabled-test-retry-manager", 0, 0, null);
 
   @BeforeClass
   public void setUp() {
@@ -53,7 +53,6 @@ public class TestVeniceMultiGetPath {
   @AfterClass
   public void cleanUp() {
     RouterExceptionAndTrackingUtils.setRouterStats(null);
-    disabledRetryManager.close();
   }
 
   private static byte[] serializeKeys(Iterable<ByteBuffer> keys) {

--- a/services/venice-router/src/test/java/com/linkedin/venice/router/api/path/TestVenicePath.java
+++ b/services/venice-router/src/test/java/com/linkedin/venice/router/api/path/TestVenicePath.java
@@ -1,20 +1,29 @@
 package com.linkedin.venice.router.api.path;
 
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
+import com.linkedin.alpini.base.concurrency.Executors;
 import com.linkedin.venice.meta.RetryManager;
 import com.linkedin.venice.read.RequestType;
 import com.linkedin.venice.router.api.RouterKey;
 import com.linkedin.venice.schema.avro.ReadAvroProtocolDefinition;
 import com.linkedin.venice.utils.TestMockTime;
+import com.linkedin.venice.utils.TestUtils;
 import com.linkedin.venice.utils.Time;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.tehuti.metrics.MetricsRepository;
+import java.time.Clock;
 import java.util.Collection;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 import javax.annotation.Nonnull;
 import org.apache.http.client.methods.HttpUriRequest;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -73,28 +82,36 @@ public class TestVenicePath {
     }
   }
 
-  private RetryManager retryManager;
+  private RetryManager disabledRetryManager;
   private MetricsRepository metricsRepository;
+
+  private final ScheduledExecutorService retryManagerScheduler = Executors.newScheduledThreadPool(1);
 
   @BeforeMethod
   public void setUp() {
     metricsRepository = new MetricsRepository();
     // retry manager is disabled by default
-    retryManager = new RetryManager(metricsRepository, "test-retry-manager", 0, 0);
+    disabledRetryManager =
+        new RetryManager(metricsRepository, "disabled-test-retry-manager", 0, 0, retryManagerScheduler);
+  }
+
+  @AfterClass
+  public void cleanUp() {
+    retryManagerScheduler.shutdownNow();
   }
 
   @Test
   public void testRetryAbortBecauseOfTimeConstraint() {
     TestMockTime time = new TestMockTime();
     time.setTime(1);
-    SmartRetryVenicePath orgPath = new SmartRetryVenicePath(time, retryManager);
+    SmartRetryVenicePath orgPath = new SmartRetryVenicePath(time, disabledRetryManager);
     orgPath.setLongTailRetryThresholdMs(20);
     assertTrue(orgPath.canRequestStorageNode(STORAGE_NODE1));
     assertTrue(orgPath.canRequestStorageNode(STORAGE_NODE2));
     orgPath.recordOriginalRequestStartTimestamp();
     orgPath.markStorageNodeAsFast(STORAGE_NODE1);
 
-    SmartRetryVenicePath retryPath = new SmartRetryVenicePath(time, retryManager);
+    SmartRetryVenicePath retryPath = new SmartRetryVenicePath(time, disabledRetryManager);
     retryPath.setRetryRequest();
     retryPath.setupRetryRelatedInfo(orgPath);
     time.sleep(SMART_LONG_TAIL_RETRY_ABORT_THRESHOLD_MS + orgPath.getLongTailRetryThresholdMs() + 1);
@@ -106,7 +123,7 @@ public class TestVenicePath {
   public void testRetryAbortBecauseOfSlowStorageNode() {
     TestMockTime time = new TestMockTime();
     time.setTime(1);
-    SmartRetryVenicePath orgPath = new SmartRetryVenicePath(time, retryManager);
+    SmartRetryVenicePath orgPath = new SmartRetryVenicePath(time, disabledRetryManager);
     orgPath.setLongTailRetryThresholdMs(20);
     assertTrue(orgPath.canRequestStorageNode(STORAGE_NODE1));
     orgPath.requestStorageNode(STORAGE_NODE1);
@@ -116,7 +133,7 @@ public class TestVenicePath {
     assertTrue(orgPath.canRequestStorageNode(STORAGE_NODE2));
     orgPath.recordOriginalRequestStartTimestamp();
 
-    SmartRetryVenicePath retryPath = new SmartRetryVenicePath(time, retryManager);
+    SmartRetryVenicePath retryPath = new SmartRetryVenicePath(time, disabledRetryManager);
     retryPath.setRetryRequest();
     retryPath.setupRetryRelatedInfo(orgPath);
     time.sleep(1);
@@ -129,12 +146,12 @@ public class TestVenicePath {
   public void testSlowNodeIgnoredWhen5XXcodeReturned() {
     TestMockTime time = new TestMockTime();
     time.setTime(1);
-    SmartRetryVenicePath orgPath = new SmartRetryVenicePath(time, retryManager);
+    SmartRetryVenicePath orgPath = new SmartRetryVenicePath(time, disabledRetryManager);
     orgPath.setLongTailRetryThresholdMs(20);
     assertTrue(orgPath.canRequestStorageNode(STORAGE_NODE1));
     orgPath.requestStorageNode(STORAGE_NODE1);
 
-    SmartRetryVenicePath retryPath = new SmartRetryVenicePath(time, retryManager);
+    SmartRetryVenicePath retryPath = new SmartRetryVenicePath(time, disabledRetryManager);
     retryPath.setupRetryRelatedInfo(orgPath);
     retryPath.setRetryRequest(HttpResponseStatus.BAD_REQUEST);
     time.sleep(1);
@@ -151,14 +168,14 @@ public class TestVenicePath {
   public void testRetryLogicWhenMetBothCriteria() {
     TestMockTime time = new TestMockTime();
     time.setTime(1);
-    SmartRetryVenicePath orgPath = new SmartRetryVenicePath(time, retryManager);
+    SmartRetryVenicePath orgPath = new SmartRetryVenicePath(time, disabledRetryManager);
     orgPath.setLongTailRetryThresholdMs(20);
     assertTrue(orgPath.canRequestStorageNode(STORAGE_NODE1));
     assertTrue(orgPath.canRequestStorageNode(STORAGE_NODE2));
     orgPath.recordOriginalRequestStartTimestamp();
     orgPath.markStorageNodeAsFast(STORAGE_NODE1);
 
-    SmartRetryVenicePath retryPath1 = new SmartRetryVenicePath(time, retryManager);
+    SmartRetryVenicePath retryPath1 = new SmartRetryVenicePath(time, disabledRetryManager);
     retryPath1.setRetryRequest();
     retryPath1.setupRetryRelatedInfo(orgPath);
     time.sleep(1);
@@ -166,10 +183,41 @@ public class TestVenicePath {
     assertTrue(retryPath1.canRequestStorageNode(STORAGE_NODE1));
 
     // Retry to an unknown storage node
-    SmartRetryVenicePath retryPath2 = new SmartRetryVenicePath(time, retryManager);
+    SmartRetryVenicePath retryPath2 = new SmartRetryVenicePath(time, disabledRetryManager);
     retryPath2.setRetryRequest();
     retryPath2.setupRetryRelatedInfo(orgPath);
     assertFalse(retryPath2.isRetryRequestTooLate());
     assertTrue(retryPath2.canRequestStorageNode(STORAGE_NODE1));
+  }
+
+  @Test
+  public void testRetryManager() {
+    Clock mockClock = mock(Clock.class);
+    TestMockTime time = new TestMockTime();
+    long start = System.currentTimeMillis();
+    time.setTime(start);
+    doReturn(start).when(mockClock).millis();
+    RetryManager retryManager =
+        new RetryManager(metricsRepository, "test-retry-manager", 1000, 0.1, mockClock, retryManagerScheduler);
+    retryManager.recordRequest();
+    doReturn(start + 1000).when(mockClock).millis();
+    // The retry budget should be set to: ceiling(1*0.1) = 1 and the token bucket capacity should be
+    // 5 (1 * TOKEN_BUCKET_CAPACITY_MULTIPLE)
+    TestUtils.waitForNonDeterministicAssertion(
+        3,
+        TimeUnit.SECONDS,
+        () -> Assert.assertNotNull(retryManager.getRetryTokenBucket()));
+    SmartRetryVenicePath orgPath = new SmartRetryVenicePath(time, retryManager);
+    orgPath.setLongTailRetryThresholdMs(20);
+    for (int i = 0; i < 6; i++) {
+      SmartRetryVenicePath retryPath = new SmartRetryVenicePath(time, retryManager);
+      retryPath.setRetryRequest();
+      retryPath.setupRetryRelatedInfo(orgPath);
+      if (i < 5) {
+        assertTrue(retryPath.isLongTailRetryAllowedForNewRoute());
+      } else {
+        assertFalse(retryPath.isLongTailRetryAllowedForNewRoute());
+      }
+    }
   }
 }

--- a/services/venice-router/src/test/java/com/linkedin/venice/router/api/path/TestVenicePath.java
+++ b/services/venice-router/src/test/java/com/linkedin/venice/router/api/path/TestVenicePath.java
@@ -214,9 +214,9 @@ public class TestVenicePath {
       retryPath.setRetryRequest();
       retryPath.setupRetryRelatedInfo(orgPath);
       if (i < 5) {
-        assertTrue(retryPath.isLongTailRetryAllowedForNewRoute());
+        assertTrue(retryPath.isLongTailRetryAllowedForNewRequest());
       } else {
-        assertFalse(retryPath.isLongTailRetryAllowedForNewRoute());
+        assertFalse(retryPath.isLongTailRetryAllowedForNewRequest());
       }
     }
   }

--- a/services/venice-router/src/test/java/com/linkedin/venice/router/api/path/TestVenicePath.java
+++ b/services/venice-router/src/test/java/com/linkedin/venice/router/api/path/TestVenicePath.java
@@ -77,7 +77,7 @@ public class TestVenicePath {
   private MetricsRepository metricsRepository;
 
   @BeforeMethod
-  public void setup() {
+  public void setUp() {
     metricsRepository = new MetricsRepository();
     // retry manager is disabled by default
     retryManager = new RetryManager(metricsRepository, "test-retry-manager", 0, 0);

--- a/services/venice-router/src/test/java/com/linkedin/venice/router/api/path/TestVenicePath.java
+++ b/services/venice-router/src/test/java/com/linkedin/venice/router/api/path/TestVenicePath.java
@@ -215,8 +215,10 @@ public class TestVenicePath {
       retryPath.setupRetryRelatedInfo(orgPath);
       if (i < 5) {
         assertTrue(retryPath.isLongTailRetryAllowedForNewRequest());
+        assertTrue(retryPath.isLongTailRetryWithinBudget(1));
       } else {
-        assertFalse(retryPath.isLongTailRetryAllowedForNewRequest());
+        assertTrue(retryPath.isLongTailRetryAllowedForNewRequest());
+        assertFalse(retryPath.isLongTailRetryWithinBudget(1));
       }
     }
   }


### PR DESCRIPTION
## [router][common][fast-client] Add RetryManager to venice-router for long tail retry
1. Move RetryManager to venice-common so it can be used by both fast-client and venice-router. Refactored the constructor a bit so in Venice router we can initialize instances of RetryManager per store (max 2, single-get and multi-get) without  initializing multiple schedulers. 

2. RetryManager for fast-client has store level resource isolation because a fast-client instance is mapped to a single Venice store. RetryManager for venice-router in this change is also made to have store level resource isolation.

3. Updated the fast-client RetryManagerStats with store name in metric prefix to avoid conflict/confusion since a user host could have multiple instances of fast-client for multiple stores. 


## How was this PR tested?
Unit tests and integration tests

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.