### PR TITLE
Revert "[server][da-vinci] Bumped RocksDB dep and adopt multiget async io by default (#950)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -118,7 +118,7 @@ ext.libraries = [
     pulsarIoCommon: "${pulsarGroup}:pulsar-io-common:${pulsarVersion}",
     r2: "com.linkedin.pegasus:r2:${pegasusVersion}",
     restliCommon: "com.linkedin.pegasus:restli-common:${pegasusVersion}",
-    rocksdbjni: 'org.rocksdb:rocksdbjni:8.11.4',
+    rocksdbjni: 'org.rocksdb:rocksdbjni:8.8.1',
     samzaApi: 'org.apache.samza:samza-api:1.5.1',
     slf4j: 'org.slf4j:slf4j:1.7.36',
     slf4jApi: 'org.slf4j:slf4j-api:1.7.36',

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/AbstractStorageEngine.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/AbstractStorageEngine.java
@@ -502,13 +502,6 @@ public abstract class AbstractStorageEngine<Partition extends AbstractStoragePar
     });
   }
 
-  public List<byte[]> multiGet(int partitionId, List<byte[]> keys) throws VeniceException {
-    return executeWithSafeGuard(partitionId, () -> {
-      AbstractStoragePartition partition = getPartitionOrThrow(partitionId);
-      return partition.multiGet(keys);
-    });
-  }
-
   public ByteBuffer get(int partitionId, byte[] key, ByteBuffer valueToBePopulated) throws VeniceException {
     return executeWithSafeGuard(partitionId, () -> {
       AbstractStoragePartition partition = getPartitionOrThrow(partitionId);
@@ -549,13 +542,6 @@ public abstract class AbstractStorageEngine<Partition extends AbstractStoragePar
     return executeWithSafeGuard(partitionId, () -> {
       AbstractStoragePartition partition = getPartitionOrThrow(partitionId);
       return partition.getReplicationMetadata(key);
-    });
-  }
-
-  public List<byte[]> multiGetReplicationMetadata(int partitionId, List<byte[]> keys) {
-    return executeWithSafeGuard(partitionId, () -> {
-      AbstractStoragePartition partition = getPartitionOrThrow(partitionId);
-      return partition.multiGetReplicationMetadata(keys);
     });
   }
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/AbstractStoragePartition.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/AbstractStoragePartition.java
@@ -4,8 +4,6 @@ import com.linkedin.davinci.callback.BytesStreamingCallback;
 import com.linkedin.davinci.store.rocksdb.ReplicationMetadataRocksDBStoragePartition;
 import com.linkedin.venice.exceptions.VeniceUnsupportedOperationException;
 import java.nio.ByteBuffer;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Supplier;
@@ -49,12 +47,6 @@ public abstract class AbstractStoragePartition {
   public ByteBuffer get(byte[] key, ByteBuffer valueToBePopulated) {
     // Naive default impl is not optimized... only storage engines that support the optimization implement it.
     return ByteBuffer.wrap(get(key));
-  }
-
-  public List<byte[]> multiGet(List<byte[]> keys) {
-    List<byte[]> values = new ArrayList<>(keys.size());
-    keys.forEach(key -> values.add(get(key)));
-    return values;
   }
 
   /**
@@ -169,10 +161,6 @@ public abstract class AbstractStoragePartition {
    */
   public byte[] getReplicationMetadata(byte[] key) {
     throw new VeniceUnsupportedOperationException("getReplicationMetadata");
-  }
-
-  public List<byte[]> multiGetReplicationMetadata(List<byte[]> keys) {
-    throw new VeniceUnsupportedOperationException("multiGetReplicationMetadata");
   }
 
   /**

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/ReplicationMetadataRocksDBStoragePartition.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/ReplicationMetadataRocksDBStoragePartition.java
@@ -10,15 +10,12 @@ import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.store.rocksdb.RocksDBUtils;
 import com.linkedin.venice.utils.ByteUtils;
 import java.nio.ByteBuffer;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Supplier;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.rocksdb.ColumnFamilyHandle;
 import org.rocksdb.RocksDB;
 import org.rocksdb.RocksDBException;
 import org.rocksdb.WriteBatch;
@@ -140,24 +137,6 @@ public class ReplicationMetadataRocksDBStoragePartition extends RocksDBStoragePa
       makeSureRocksDBIsStillOpen();
       return rocksDB
           .get(columnFamilyHandleList.get(REPLICATION_METADATA_COLUMN_FAMILY_INDEX), READ_OPTIONS_DEFAULT, key);
-    } catch (RocksDBException e) {
-      throw new VeniceException("Failed to get value from RocksDB: " + replicaId, e);
-    } finally {
-      readCloseRWLock.readLock().unlock();
-    }
-  }
-
-  @Override
-  public List<byte[]> multiGetReplicationMetadata(List<byte[]> keys) {
-    readCloseRWLock.readLock().lock();
-    try {
-      makeSureRocksDBIsStillOpen();
-      ColumnFamilyHandle rmdHandle = columnFamilyHandleList.get(REPLICATION_METADATA_COLUMN_FAMILY_INDEX);
-      List cfHandleList = new ArrayList<>(keys.size());
-      for (int i = 0; i < keys.size(); ++i) {
-        cfHandleList.add(rmdHandle);
-      }
-      return rocksDB.multiGetAsList(getReadOptionsForMultiGet(), cfHandleList, keys);
     } catch (RocksDBException e) {
       throw new VeniceException("Failed to get value from RocksDB: " + replicaId, e);
     } finally {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/RocksDBServerConfig.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/RocksDBServerConfig.java
@@ -214,11 +214,6 @@ public class RocksDBServerConfig {
   public static final String ROCKSDB_ATOMIC_FLUSH_ENABLED = "rocksdb.atomic.flush.enabled";
   public static final String ROCKSDB_SEPARATE_RMD_CACHE_ENABLED = "rocksdb.separate.rmd.cache.enabled";
   public static final String ROCKSDB_BLOCK_BASE_FORMAT_VERSION = "rocksdb.block.base.format.version";
-  /**
-   * Whether to enable async io in the read path or not.
-   * https://rocksdb.org/blog/2022/10/07/asynchronous-io-in-rocksdb.html
-   */
-  public static final String ROCKSDB_READ_ASYNC_IO_ENABLED = "rocksdb.read.async.io.enabled";
 
   public static final String ROCKSDB_MAX_LOG_FILE_NUM = "rocksdb.max.log.file.num";
   public static final String ROCKSDB_MAX_LOG_FILE_SIZE = "rocksdb.max.log.file.size";
@@ -289,7 +284,6 @@ public class RocksDBServerConfig {
   private int blockBaseFormatVersion;
   private final int maxLogFileNum;
   private final long maxLogFileSize;
-  private final boolean readAsyncIOEanbled;
   private final String transformerValueSchema;
 
   public RocksDBServerConfig(VeniceProperties props) {
@@ -412,7 +406,6 @@ public class RocksDBServerConfig {
      */
     this.maxLogFileNum = props.getInt(ROCKSDB_MAX_LOG_FILE_NUM, 3);
     this.maxLogFileSize = props.getSizeInBytes(ROCKSDB_MAX_LOG_FILE_SIZE, 10 * 1024 * 1024); // 10MB;
-    this.readAsyncIOEanbled = props.getBoolean(ROCKSDB_READ_ASYNC_IO_ENABLED, true);
     this.transformerValueSchema =
         props.containsKey(RECORD_TRANSFORMER_VALUE_SCHEMA) ? props.getString(RECORD_TRANSFORMER_VALUE_SCHEMA) : "null";
   }
@@ -618,10 +611,6 @@ public class RocksDBServerConfig {
 
   public long getMaxLogFileSize() {
     return maxLogFileSize;
-  }
-
-  public boolean isReadAsyncIOEanbled() {
-    return readAsyncIOEanbled;
   }
 
   public String getTransformerValueSchema() {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/RocksDBStoragePartition.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/RocksDBStoragePartition.java
@@ -67,11 +67,6 @@ public class RocksDBStoragePartition extends AbstractStoragePartition {
   private static final Logger LOGGER = LogManager.getLogger(RocksDBStoragePartition.class);
   private static final String ROCKSDB_ERROR_MESSAGE_FOR_RUNNING_OUT_OF_SPACE_QUOTA = "Max allowed space was reached";
   protected static final ReadOptions READ_OPTIONS_DEFAULT = new ReadOptions();
-  /**
-   * Async IO will speed up the lookup for multi-get with posix file system.
-   * https://rocksdb.org/blog/2022/10/07/asynchronous-io-in-rocksdb.html
-   */
-  protected static final ReadOptions READ_OPTIONS_WITH_ASYNC_IO = new ReadOptions().setAsyncIo(true);
   static final byte[] REPLICATION_METADATA_COLUMN_FAMILY = "timestamp_metadata".getBytes();
 
   private static final FlushOptions WAIT_FOR_FLUSH_OPTIONS = new FlushOptions().setWaitForFlush(true);
@@ -604,19 +599,11 @@ public class RocksDBStoragePartition extends AbstractStoragePartition {
     }
   }
 
-  protected ReadOptions getReadOptionsForMultiGet() {
-    if (rocksDBServerConfig.isRocksDBPlainTableFormatEnabled() || !rocksDBServerConfig.isReadAsyncIOEanbled()) {
-      return READ_OPTIONS_DEFAULT;
-    }
-    return READ_OPTIONS_WITH_ASYNC_IO;
-  }
-
-  @Override
   public List<byte[]> multiGet(List<byte[]> keys) {
     readCloseRWLock.readLock().lock();
     try {
       makeSureRocksDBIsStillOpen();
-      return rocksDB.multiGetAsList(getReadOptionsForMultiGet(), keys);
+      return rocksDB.multiGetAsList(keys);
     } catch (RocksDBException e) {
       throw new VeniceException("Failed to get value from RocksDB: " + replicaId, e);
     } finally {
@@ -629,8 +616,7 @@ public class RocksDBStoragePartition extends AbstractStoragePartition {
 
     try {
       makeSureRocksDBIsStillOpen();
-      List<ByteBufferGetStatus> statusList = rocksDB.multiGetByteBuffers(getReadOptionsForMultiGet(), keys, values);
-
+      List<ByteBufferGetStatus> statusList = rocksDB.multiGetByteBuffers(keys, values);
       int keyCnt = keys.size();
       int statusCnt = statusList.size();
       int valueCnt = values.size();

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTaskTest.java
@@ -92,8 +92,6 @@ import it.unimi.dsi.fastutil.objects.Object2IntArrayMap;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Properties;
@@ -486,12 +484,8 @@ public class ActiveActiveStoreIngestionTaskTest {
     chunkedManifestBytes = ChunkingTestUtils.prependSchemaId(chunkedManifestBytes, manifestSchemaId).array();
     byte[] topLevelKey2 = keyWithChunkingSuffixSerializer.serializeNonChunkedKey(key2);
     byte[] chunkedKey1InKey2 = chunkedKeyWithSuffix1.array();
-
     when(storageEngine.getReplicationMetadata(partition, topLevelKey2)).thenReturn(chunkedManifestBytes);
     when(storageEngine.getReplicationMetadata(partition, chunkedKey1InKey2)).thenReturn(chunkedValue1);
-    List<byte[]> chunkedValues = new ArrayList<>(1);
-    chunkedValues.add(chunkedValue1);
-    when(storageEngine.multiGetReplicationMetadata(eq(partition), any())).thenReturn(chunkedValues);
     byte[] result2 = ingestionTask.getRmdWithValueSchemaByteBufferFromStorage(partition, key2, container, 0L);
     Assert.assertNotNull(result2);
     Assert.assertNotNull(container.getManifest());
@@ -524,12 +518,9 @@ public class ActiveActiveStoreIngestionTaskTest {
     byte[] topLevelKey3 = keyWithChunkingSuffixSerializer.serializeNonChunkedKey(key3);
     byte[] chunkedKey1InKey3 = chunkedKeyWithSuffix1.array();
     byte[] chunkedKey2InKey3 = chunkedKeyWithSuffix2.array();
-
     when(storageEngine.getReplicationMetadata(partition, topLevelKey3)).thenReturn(chunkedManifestBytes);
     when(storageEngine.getReplicationMetadata(partition, chunkedKey1InKey3)).thenReturn(chunkedValue1);
     when(storageEngine.getReplicationMetadata(partition, chunkedKey2InKey3)).thenReturn(chunkedValue2);
-    when(storageEngine.multiGetReplicationMetadata(eq(partition), any()))
-        .thenReturn(Arrays.asList(chunkedValue1, chunkedValue2));
     byte[] result3 = ingestionTask.getRmdWithValueSchemaByteBufferFromStorage(partition, key3, container, 0L);
     Assert.assertNotNull(result3);
     Assert.assertNotNull(container.getManifest());

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/storage/chunking/ChunkingTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/storage/chunking/ChunkingTest.java
@@ -1,6 +1,5 @@
 package com.linkedin.davinci.storage.chunking;
 
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
@@ -23,7 +22,6 @@ import com.linkedin.venice.storage.protocol.ChunkedValueManifest;
 import com.linkedin.venice.utils.ByteUtils;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Random;
 import java.util.concurrent.ThreadLocalRandom;
@@ -215,8 +213,6 @@ public class ChunkingTest {
         .get(eq(partition), eq(ByteBuffer.wrap(serializeNonChunkedKey)));
     doReturn(chunk1Bytes).when(storageEngine).get(eq(partition), eq(firstKey));
     doReturn(chunk2Bytes).when(storageEngine).get(eq(partition), eq(secondKey));
-
-    doReturn(Arrays.asList(chunk1Bytes, chunk2Bytes)).when(storageEngine).multiGet(eq(partition), any());
 
     StoreDeserializerCache storeDeserializerCache = rawBytesStoreDeserializerCache
         ? RawBytesStoreDeserializerCache.getInstance()


### PR DESCRIPTION
## Summary, imperative, start upper case, don't end with a period


This reverts commit 02591a119534377cbd1d993e8276d3548d6d3669.

One important partner discovers some TTL DB issue with this version and that particular feature is not being used by Venice.
In the future, we will roll-forward to pick up RocksDB-9.x, which has the fix and add back this feature during the 9.x version upgrade.

<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->



## How was this PR tested?
CI
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.