### PR TITLE
[admin-tool] Make end-date arg optional in query-kafka-topic

### DIFF
--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/AdminTool.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/AdminTool.java
@@ -1598,8 +1598,8 @@ public class AdminTool {
 
     String kafkaTopic = getRequiredArgument(cmd, Arg.KAFKA_TOPIC_NAME);
     String startDateInPST = getRequiredArgument(cmd, Arg.START_DATE);
-    String endDateInPST = getRequiredArgument(cmd, Arg.END_DATE);
-    String progressInterval = getRequiredArgument(cmd, Arg.PROGRESS_INTERVAL);
+    String endDateInPST = getOptionalArgument(cmd, Arg.END_DATE);
+    String progressInterval = getOptionalArgument(cmd, Arg.PROGRESS_INTERVAL);
     String keyString = getRequiredArgument(cmd, Arg.KEY);
 
     SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd hh:mm:ss");
@@ -1611,8 +1611,8 @@ public class AdminTool {
           kafkaTopic,
           keyString,
           dateFormat.parse(startDateInPST).getTime(),
-          dateFormat.parse(endDateInPST).getTime(),
-          Long.parseLong(progressInterval));
+          endDateInPST == null ? Long.MAX_VALUE : dateFormat.parse(endDateInPST).getTime(),
+          progressInterval == null ? 1000000 : Long.parseLong(progressInterval));
     }
   }
 

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/Command.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/Command.java
@@ -340,7 +340,8 @@ public enum Command {
   QUERY_KAFKA_TOPIC(
       "query-kafka-topic", "Query some specific keys from the Venice Topic",
       new Arg[] { KAFKA_BOOTSTRAP_SERVERS, KAFKA_CONSUMER_CONFIG_FILE, KAFKA_TOPIC_NAME, CLUSTER, URL, START_DATE,
-          END_DATE, PROGRESS_INTERVAL, KEY }
+          KEY },
+      new Arg[] { END_DATE, PROGRESS_INTERVAL }
   ),
   MIGRATE_STORE(
       "migrate-store", "Migrate store from one cluster to another within the same fabric",

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/TopicMessageFinder.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/TopicMessageFinder.java
@@ -37,8 +37,8 @@ public class TopicMessageFinder {
       PubSubConsumerAdapter consumer,
       String topic,
       String keyString,
-      long startTimestamp,
-      long endTimestamp,
+      long startTimestampEpochMs,
+      long endTimestampEpochMs,
       long progressInterval) {
     String storeName;
     int version = -1;
@@ -83,8 +83,12 @@ public class TopicMessageFinder {
         new PubSubTopicPartitionImpl(pubSubTopicRepository.getTopic(topic), assignedPartition);
 
     // fetch start and end offset
-    startOffset = consumer.offsetForTime(assignedPubSubTopicPartition, startTimestamp);
-    endOffset = consumer.offsetForTime(assignedPubSubTopicPartition, endTimestamp);
+    startOffset = consumer.offsetForTime(assignedPubSubTopicPartition, startTimestampEpochMs);
+    if (endTimestampEpochMs == Long.MAX_VALUE || endTimestampEpochMs > System.currentTimeMillis()) {
+      endOffset = consumer.endOffset(assignedPubSubTopicPartition);
+    } else {
+      endOffset = consumer.offsetForTime(assignedPubSubTopicPartition, endTimestampEpochMs);
+    }
     LOGGER.info("Got start offset: {} and end offset: {} for the specified time range", startOffset, endOffset);
     return consume(consumer, assignedPubSubTopicPartition, startOffset, endOffset, progressInterval, serializedKey);
   }

--- a/clients/venice-admin-tool/src/test/java/com/linkedin/venice/TestAdminToolConsumption.java
+++ b/clients/venice-admin-tool/src/test/java/com/linkedin/venice/TestAdminToolConsumption.java
@@ -112,7 +112,6 @@ public class TestAdminToolConsumption {
 
   @Test
   public void testAdminToolConsumption() {
-
     String topic = Version.composeRealTimeTopic(STORE_NAME);
     ControllerClient controllerClient = mock(ControllerClient.class);
     SchemaResponse schemaResponse = mock(SchemaResponse.class);
@@ -185,19 +184,28 @@ public class TestAdminToolConsumption {
     long endTimestamp = 20;
     when(apacheKafkaConsumer.offsetForTime(pubSubTopicPartition, startTimestamp)).thenReturn(startOffset);
     when(apacheKafkaConsumer.offsetForTime(pubSubTopicPartition, endTimestamp)).thenReturn(endOffset);
-    when(apacheKafkaConsumer.endOffset(pubSubTopicPartition)).thenReturn(endOffset);
     long messageCount = TopicMessageFinder
         .find(controllerClient, apacheKafkaConsumer, topic, keyString, startTimestamp, endTimestamp, progressInterval);
     Assert.assertEquals(messageCount, endOffset - startOffset);
 
-    when(apacheKafkaConsumer.poll(anyLong())).thenReturn(messagesMap, new HashMap<>());
+    when(apacheKafkaConsumer.poll(anyLong())).thenReturn(messagesMap, Collections.EMPTY_MAP);
+    when(apacheKafkaConsumer.endOffset(pubSubTopicPartition)).thenReturn(endOffset);
+    long messageCountNoEndOffset = TopicMessageFinder.find(
+        controllerClient,
+        apacheKafkaConsumer,
+        topic,
+        keyString,
+        startTimestamp,
+        Long.MAX_VALUE,
+        progressInterval);
+    Assert.assertEquals(messageCountNoEndOffset, endOffset - startOffset);
 
-    when(apacheKafkaConsumer.poll(anyLong())).thenReturn(messagesMap, new HashMap<>());
+    when(apacheKafkaConsumer.poll(anyLong())).thenReturn(messagesMap, Collections.EMPTY_MAP);
     ControlMessageDumper controlMessageDumper =
         new ControlMessageDumper(apacheKafkaConsumer, topic, 0, 0, pubSubMessageList.size());
     Assert.assertEquals(controlMessageDumper.fetch().display(), 1);
 
-    when(apacheKafkaConsumer.poll(anyLong())).thenReturn(messagesMap, new HashMap<>());
+    when(apacheKafkaConsumer.poll(anyLong())).thenReturn(messagesMap, Collections.EMPTY_MAP);
     int consumedMessageCount = pubSubMessageList.size() - 1;
     KafkaTopicDumper kafkaTopicDumper = new KafkaTopicDumper(
         controllerClient,


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Make `--end-date` arg optional in `query-kafka-topic` in Admin tool
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
This PR makes the `--end-date` arg optional, and if it is not specified, or if the value is later than the current time, then the end offset of the topic is used to get the offset.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
Tested manually

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.