### PR TITLE
[controller] Avoid NPE in DIV check during kill-job

### DIFF
--- a/internal/venice-common/src/main/java/com/linkedin/venice/pushmonitor/PartitionStatus.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pushmonitor/PartitionStatus.java
@@ -89,7 +89,7 @@ public class PartitionStatus implements Comparable<PartitionStatus> {
 
   public boolean hasFatalDataValidationError() {
     for (ReplicaStatus replicaStatus: replicaStatusMap.values()) {
-      if (ExecutionStatus.isError(replicaStatus.getCurrentStatus())
+      if (ExecutionStatus.isError(replicaStatus.getCurrentStatus()) && replicaStatus.getIncrementalPushVersion() != null
           && replicaStatus.getIncrementalPushVersion().contains(FATAL_DATA_VALIDATION_ERROR)) {
         return true;
       }

--- a/internal/venice-common/src/test/java/com/linkedin/venice/pushmonitor/PartitionStatusTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/pushmonitor/PartitionStatusTest.java
@@ -1,5 +1,6 @@
 package com.linkedin.venice.pushmonitor;
 
+import static com.linkedin.venice.utils.Utils.FATAL_DATA_VALIDATION_ERROR;
 import static org.testng.Assert.assertThrows;
 
 import com.linkedin.venice.exceptions.VeniceException;
@@ -36,5 +37,24 @@ public class PartitionStatusTest {
     assertThrows(
         VeniceException.class,
         () -> readonlyPartitionStatus.updateReplicaStatus(instanceId, ExecutionStatus.COMPLETED, "inc push", 1));
+  }
+
+  @Test
+  public void testHasFatalDataValidationError() {
+    PartitionStatus partitionStatus = new PartitionStatus(partitionId);
+    Assert.assertFalse(partitionStatus.hasFatalDataValidationError());
+
+    partitionStatus.updateReplicaStatus("testInstance1", ExecutionStatus.COMPLETED);
+    Assert.assertFalse(partitionStatus.hasFatalDataValidationError());
+
+    partitionStatus.updateReplicaStatus("testInstance2", ExecutionStatus.ERROR);
+    Assert.assertFalse(partitionStatus.hasFatalDataValidationError());
+
+    partitionStatus.updateReplicaStatus("testInstance3", ExecutionStatus.ERROR, null, 10);
+    Assert.assertFalse(partitionStatus.hasFatalDataValidationError());
+
+    partitionStatus
+        .updateReplicaStatus("testInstance4", ExecutionStatus.ERROR, FATAL_DATA_VALIDATION_ERROR + " for replica", 10);
+    Assert.assertTrue(partitionStatus.hasFatalDataValidationError());
   }
 }


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Avoid NPE in DIV check during kill-job
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
Today, we see NPE during "kill-job" while checking for fatal DIV errors. This commit explicitly checks for a `null` and avoids the NPE

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
GHCI

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.