### PR TITLE
[test][controller] Fix multi-region tests to use VeniceTwoLayerMultiRegionMultiClusterWrapper

### DIFF
--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestClusterLevelConfigForActiveActiveReplication.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestClusterLevelConfigForActiveActiveReplication.java
@@ -3,256 +3,210 @@ package com.linkedin.venice.controller;
 import static com.linkedin.venice.ConfigKeys.ENABLE_ACTIVE_ACTIVE_REPLICATION_AS_DEFAULT_FOR_BATCH_ONLY_STORE;
 import static com.linkedin.venice.ConfigKeys.ENABLE_ACTIVE_ACTIVE_REPLICATION_AS_DEFAULT_FOR_HYBRID_STORE;
 import static com.linkedin.venice.ConfigKeys.ENABLE_NATIVE_REPLICATION_AS_DEFAULT_FOR_BATCH_ONLY;
-import static com.linkedin.venice.ConfigKeys.PARTICIPANT_MESSAGE_STORE_ENABLED;
-import static com.linkedin.venice.controller.VeniceHelixAdmin.VERSION_ID_UNSET;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.mock;
+import static com.linkedin.venice.utils.TestUtils.assertCommand;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
-import com.linkedin.venice.common.VeniceSystemStoreUtils;
+import com.linkedin.venice.controllerapi.ControllerClient;
 import com.linkedin.venice.controllerapi.UpdateStoreQueryParams;
-import com.linkedin.venice.integration.utils.D2TestUtils;
-import com.linkedin.venice.meta.Store;
-import com.linkedin.venice.meta.Version;
-import com.linkedin.venice.pubsub.manager.TopicManager;
-import com.linkedin.venice.pubsub.manager.TopicManagerRepository;
+import com.linkedin.venice.integration.utils.ServiceFactory;
+import com.linkedin.venice.integration.utils.VeniceMultiRegionClusterCreateOptions;
+import com.linkedin.venice.integration.utils.VeniceTwoLayerMultiRegionMultiClusterWrapper;
+import com.linkedin.venice.meta.StoreInfo;
 import com.linkedin.venice.utils.TestUtils;
 import com.linkedin.venice.utils.Time;
 import com.linkedin.venice.utils.Utils;
-import com.linkedin.venice.utils.VeniceProperties;
-import io.tehuti.metrics.MetricsRepository;
 import java.io.IOException;
-import java.util.Optional;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
-import org.testng.Assert;
-import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 
-public class TestClusterLevelConfigForActiveActiveReplication extends AbstractTestVeniceHelixAdmin {
-  private static final long TEST_TIMEOUT = 30 * Time.MS_PER_SECOND;
+public class TestClusterLevelConfigForActiveActiveReplication {
+  private static final long TEST_TIMEOUT = 120 * Time.MS_PER_SECOND;
 
   @BeforeClass(alwaysRun = true)
-  public void setUp() throws Exception {
-    setupCluster();
-  }
-
-  @AfterClass(alwaysRun = true)
-  public void cleanUp() {
-    cleanupCluster();
+  public void setUp() {
+    Utils.thisIsLocalhost();
   }
 
   @Test(timeOut = TEST_TIMEOUT)
   public void testClusterLevelActiveActiveReplicationConfigForNewHybridStores() throws IOException {
-    TopicManagerRepository originalTopicManagerRepository = prepareCluster(true, false);
-    String storeNameHybrid = Utils.getUniqueString("test-store-hybrid");
-    String pushJobId1 = "test-push-job-id-1";
-    /**
-     * Do not enable any store-level config for leader/follower mode or native replication feature.
-     */
-    veniceAdmin.createStore(clusterName, storeNameHybrid, "test-owner", KEY_SCHEMA, VALUE_SCHEMA);
-    /**
-     * Add a version
-     */
-    veniceAdmin.addVersionAndTopicOnly(
-        clusterName,
-        storeNameHybrid,
-        pushJobId1,
-        VERSION_ID_UNSET,
-        1,
-        1,
-        false,
-        true,
-        Version.PushType.STREAM,
-        null,
-        null,
-        Optional.empty(),
-        -1,
-        1,
-        Optional.empty(),
-        false);
+    Properties parentControllerProps = getActiveActiveControllerProperties(true, false);
+    try (
+        VeniceTwoLayerMultiRegionMultiClusterWrapper multiRegionMultiClusterWrapper =
+            ServiceFactory.getVeniceTwoLayerMultiRegionMultiClusterWrapper(
+                new VeniceMultiRegionClusterCreateOptions.Builder().numberOfRegions(1)
+                    .numberOfParentControllers(1)
+                    .numberOfChildControllers(1)
+                    .numberOfRouters(1)
+                    .numberOfServers(1)
+                    .parentControllerProperties(parentControllerProps)
+                    .build());
+        ControllerClient parentControllerClient = new ControllerClient(
+            multiRegionMultiClusterWrapper.getClusterNames()[0],
+            multiRegionMultiClusterWrapper.getControllerConnectString())) {
+      String storeName = Utils.getUniqueString("test-store-hybrid");
+      String pushJobId1 = "test-push-job-id-1";
+      parentControllerClient.createNewStore(storeName, "test-owner", "\"string\"", "\"string\"");
+      parentControllerClient.emptyPush(storeName, pushJobId1, 1);
 
-    // Version 1 should exist.
-    assertEquals(veniceAdmin.getStore(clusterName, storeNameHybrid).getVersions().size(), 1);
-    // Check store level Active/Active is enabled or not
-    assertFalse(veniceAdmin.getStore(clusterName, storeNameHybrid).isActiveActiveReplicationEnabled());
-    veniceAdmin.updateStore(
-        clusterName,
-        storeNameHybrid,
-        new UpdateStoreQueryParams().setHybridRewindSeconds(1000L).setHybridOffsetLagThreshold(1000L));
-    assertTrue(veniceAdmin.getStore(clusterName, storeNameHybrid).isActiveActiveReplicationEnabled());
+      // Version 1 should exist.
+      StoreInfo store = assertCommand(parentControllerClient.getStore(storeName)).getStore();
+      assertEquals(store.getVersions().size(), 1);
 
-    veniceAdmin.updateStore(
-        clusterName,
-        storeNameHybrid,
-        new UpdateStoreQueryParams().setHybridRewindSeconds(-1).setHybridOffsetLagThreshold(-1));
-    assertTrue(veniceAdmin.getStore(clusterName, storeNameHybrid).isActiveActiveReplicationEnabled());
+      // Check store level Active/Active is enabled or not
+      assertFalse(store.isActiveActiveReplicationEnabled());
 
-    // Set topic original topic manager back
-    veniceAdmin.setTopicManagerRepository(originalTopicManagerRepository);
+      // Convert to hybrid store
+      assertCommand(
+          parentControllerClient.updateStore(
+              storeName,
+              new UpdateStoreQueryParams().setHybridRewindSeconds(1000L).setHybridOffsetLagThreshold(1000L)));
+      TestUtils.waitForNonDeterministicAssertion(TEST_TIMEOUT, TimeUnit.MILLISECONDS, () -> {
+        assertTrue(parentControllerClient.getStore(storeName).getStore().isActiveActiveReplicationEnabled());
+      });
+
+      // Reverting hybrid configs disables A/A mode
+      assertCommand(
+          parentControllerClient.updateStore(
+              storeName,
+              new UpdateStoreQueryParams().setHybridRewindSeconds(-1).setHybridOffsetLagThreshold(-1)));
+      TestUtils.waitForNonDeterministicAssertion(TEST_TIMEOUT, TimeUnit.MILLISECONDS, () -> {
+        assertFalse(parentControllerClient.getStore(storeName).getStore().isActiveActiveReplicationEnabled());
+      });
+    }
   }
 
   @Test(timeOut = TEST_TIMEOUT)
   public void testClusterLevelActiveActiveReplicationConfigForNewIncrementalPushStores() throws IOException {
-    TopicManagerRepository originalTopicManagerRepository = prepareCluster(true, false);
-    String storeNameIncremental = Utils.getUniqueString("test-store-incremental");
-    String pushJobId1 = "test-push-job-id-1";
-    /**
-     * Do not enable any store-level config for leader/follower mode or native replication feature.
-     */
-    veniceAdmin.createStore(clusterName, storeNameIncremental, "test-owner", KEY_SCHEMA, VALUE_SCHEMA);
-    /**
-     * Add a version
-     */
-    veniceAdmin.addVersionAndTopicOnly(
-        clusterName,
-        storeNameIncremental,
-        pushJobId1,
-        VERSION_ID_UNSET,
-        1,
-        1,
-        false,
-        true,
-        Version.PushType.STREAM,
-        null,
-        null,
-        Optional.empty(),
-        -1,
-        1,
-        Optional.empty(),
-        false);
+    Properties parentControllerProps = getActiveActiveControllerProperties(true, false);
+    try (
+        VeniceTwoLayerMultiRegionMultiClusterWrapper multiRegionMultiClusterWrapper =
+            ServiceFactory.getVeniceTwoLayerMultiRegionMultiClusterWrapper(
+                new VeniceMultiRegionClusterCreateOptions.Builder().numberOfRegions(1)
+                    .numberOfParentControllers(1)
+                    .numberOfChildControllers(1)
+                    .numberOfRouters(1)
+                    .numberOfServers(1)
+                    .parentControllerProperties(parentControllerProps)
+                    .build());
+        ControllerClient parentControllerClient = new ControllerClient(
+            multiRegionMultiClusterWrapper.getClusterNames()[0],
+            multiRegionMultiClusterWrapper.getControllerConnectString())) {
+      String storeName = Utils.getUniqueString("test-store-incremental");
+      String pushJobId1 = "test-push-job-id-1";
+      parentControllerClient.createNewStore(storeName, "test-owner", "\"string\"", "\"string\"");
+      parentControllerClient.emptyPush(storeName, pushJobId1, 1);
 
-    // Version 1 should exist.
-    assertEquals(veniceAdmin.getStore(clusterName, storeNameIncremental).getVersions().size(), 1);
+      // Version 1 should exist.
+      StoreInfo store = assertCommand(parentControllerClient.getStore(storeName)).getStore();
+      assertEquals(store.getVersions().size(), 1);
+      assertFalse(store.isIncrementalPushEnabled());
+      assertFalse(store.isActiveActiveReplicationEnabled());
 
-    // Check store level Active/Active is enabled or not
-    veniceAdmin.setIncrementalPushEnabled(clusterName, storeNameIncremental, false);
-    assertFalse(veniceAdmin.getStore(clusterName, storeNameIncremental).isIncrementalPushEnabled());
-    assertFalse(veniceAdmin.getStore(clusterName, storeNameIncremental).isActiveActiveReplicationEnabled());
+      // Disabling incremental push on a store that has inc push disabled should not have any side effects
+      assertCommand(
+          parentControllerClient.updateStore(storeName, new UpdateStoreQueryParams().setIncrementalPushEnabled(false)));
+      TestUtils.waitForNonDeterministicAssertion(TEST_TIMEOUT, TimeUnit.MILLISECONDS, () -> {
+        assertEquals(parentControllerClient.getStore(storeName).getStore().getVersions().size(), 1);
+      });
+      store = parentControllerClient.getStore(storeName).getStore();
+      assertFalse(store.isIncrementalPushEnabled());
+      assertFalse(store.isActiveActiveReplicationEnabled());
 
-    veniceAdmin.setIncrementalPushEnabled(clusterName, storeNameIncremental, true);
-    assertTrue(veniceAdmin.getStore(clusterName, storeNameIncremental).isIncrementalPushEnabled());
-    assertTrue(veniceAdmin.getStore(clusterName, storeNameIncremental).isActiveActiveReplicationEnabled());
+      // Enable inc-push
+      assertCommand(
+          parentControllerClient.updateStore(storeName, new UpdateStoreQueryParams().setIncrementalPushEnabled(true)));
+      TestUtils.waitForNonDeterministicAssertion(TEST_TIMEOUT, TimeUnit.MILLISECONDS, () -> {
+        assertTrue(parentControllerClient.getStore(storeName).getStore().isIncrementalPushEnabled());
+      });
+      store = parentControllerClient.getStore(storeName).getStore();
+      assertTrue(store.isActiveActiveReplicationEnabled());
 
-    // After inc push is disabled, even default A/A config for pure hybrid store is false,
-    // original store A/A config is enabled.
-    veniceAdmin.setIncrementalPushEnabled(clusterName, storeNameIncremental, false);
-    assertFalse(veniceAdmin.getStore(clusterName, storeNameIncremental).isIncrementalPushEnabled());
-    assertTrue(veniceAdmin.getStore(clusterName, storeNameIncremental).isActiveActiveReplicationEnabled());
-
-    // Set topic original topic manager back
-    veniceAdmin.setTopicManagerRepository(originalTopicManagerRepository);
+      // After inc push is disabled, even though default A/A config for pure hybrid store is false,
+      // the store's A/A config is retained.
+      assertCommand(
+          parentControllerClient.updateStore(storeName, new UpdateStoreQueryParams().setIncrementalPushEnabled(false)));
+      TestUtils.waitForNonDeterministicAssertion(TEST_TIMEOUT, TimeUnit.MILLISECONDS, () -> {
+        assertFalse(parentControllerClient.getStore(storeName).getStore().isIncrementalPushEnabled());
+      });
+      store = parentControllerClient.getStore(storeName).getStore();
+      assertTrue(store.isActiveActiveReplicationEnabled());
+    }
   }
 
   @Test(timeOut = TEST_TIMEOUT)
   public void testClusterLevelActiveActiveReplicationConfigForNewBatchOnlyStores() throws IOException {
-    TopicManagerRepository originalTopicManagerRepository = prepareCluster(false, true);
-    String storeNameBatchOnly = Utils.getUniqueString("test-store-batch-only");
-    String pushJobId1 = "test-push-job-id-1";
-    /**
-     * Do not enable any store-level config for leader/follower mode or native replication feature.
-     */
-    veniceAdmin.createStore(clusterName, storeNameBatchOnly, "test-owner", KEY_SCHEMA, VALUE_SCHEMA);
-    /**
-     * Add a version
-     */
-    veniceAdmin.addVersionAndTopicOnly(
-        clusterName,
-        storeNameBatchOnly,
-        pushJobId1,
-        VERSION_ID_UNSET,
-        1,
-        1,
-        false,
-        true,
-        Version.PushType.STREAM,
-        null,
-        null,
-        Optional.empty(),
-        -1,
-        1,
-        Optional.empty(),
-        false);
+    Properties parentControllerProps = getActiveActiveControllerProperties(false, true);
+    try (
+        VeniceTwoLayerMultiRegionMultiClusterWrapper multiRegionMultiClusterWrapper =
+            ServiceFactory.getVeniceTwoLayerMultiRegionMultiClusterWrapper(
+                new VeniceMultiRegionClusterCreateOptions.Builder().numberOfRegions(1)
+                    .numberOfParentControllers(1)
+                    .numberOfChildControllers(1)
+                    .numberOfRouters(1)
+                    .numberOfServers(1)
+                    .parentControllerProperties(parentControllerProps)
+                    .build());
+        ControllerClient parentControllerClient = new ControllerClient(
+            multiRegionMultiClusterWrapper.getClusterNames()[0],
+            multiRegionMultiClusterWrapper.getControllerConnectString())) {
+      String storeName = Utils.getUniqueString("test-store-batch-only");
+      String pushJobId1 = "test-push-job-id-1";
+      parentControllerClient.createNewStore(storeName, "test-owner", "\"string\"", "\"string\"");
+      parentControllerClient.emptyPush(storeName, pushJobId1, 1);
 
-    // Version 1 should exist.
-    assertEquals(veniceAdmin.getStore(clusterName, storeNameBatchOnly).getVersions().size(), 1);
+      // Version 1 should exist.
+      StoreInfo store = assertCommand(parentControllerClient.getStore(storeName)).getStore();
+      assertEquals(store.getVersions().size(), 1);
 
-    // Store level Active/Active replication should be enabled since this store is a batch-only store by default
-    assertTrue(veniceAdmin.getStore(clusterName, storeNameBatchOnly).isActiveActiveReplicationEnabled());
+      // Check store level Active/Active is enabled or not
+      assertTrue(store.isActiveActiveReplicationEnabled());
 
-    // After updating the store to have incremental push enabled, it's A/A is still enabled
-    veniceAdmin.setIncrementalPushEnabled(clusterName, storeNameBatchOnly, true);
-    assertTrue(veniceAdmin.getStore(clusterName, storeNameBatchOnly).isActiveActiveReplicationEnabled());
+      // After updating the store to have incremental push enabled, it's A/A is still enabled
+      assertCommand(
+          parentControllerClient.updateStore(storeName, new UpdateStoreQueryParams().setIncrementalPushEnabled(true)));
+      store = parentControllerClient.getStore(storeName).getStore();
+      assertTrue(parentControllerClient.getStore(storeName).getStore().isIncrementalPushEnabled());
+      assertTrue(store.isActiveActiveReplicationEnabled());
 
-    // Let's disable the A/A config for the store.
-    veniceAdmin.setActiveActiveReplicationEnabled(clusterName, storeNameBatchOnly, false);
-    assertFalse(veniceAdmin.getStore(clusterName, storeNameBatchOnly).isActiveActiveReplicationEnabled());
+      // Let's disable the A/A config for the store.
+      assertCommand(
+          parentControllerClient
+              .updateStore(storeName, new UpdateStoreQueryParams().setActiveActiveReplicationEnabled(false)));
+      TestUtils.waitForNonDeterministicAssertion(TEST_TIMEOUT, TimeUnit.MILLISECONDS, () -> {
+        assertFalse(parentControllerClient.getStore(storeName).getStore().isActiveActiveReplicationEnabled());
+      });
 
-    // After updating the store back to a batch-only store, it's A/A becomes enabled again
-    veniceAdmin.setIncrementalPushEnabled(clusterName, storeNameBatchOnly, false);
-    assertTrue(veniceAdmin.getStore(clusterName, storeNameBatchOnly).isActiveActiveReplicationEnabled());
+      // After updating the store back to a batch-only store, it's A/A becomes enabled again
+      assertCommand(
+          parentControllerClient.updateStore(
+              storeName,
+              new UpdateStoreQueryParams().setIncrementalPushEnabled(false)
+                  .setHybridRewindSeconds(-1)
+                  .setHybridOffsetLagThreshold(-1)));
+      TestUtils.waitForNonDeterministicAssertion(TEST_TIMEOUT, TimeUnit.MILLISECONDS, () -> {
+        assertTrue(parentControllerClient.getStore(storeName).getStore().isActiveActiveReplicationEnabled());
+      });
 
-    // After updating the store to be a hybrid store, it's A/A should still be enabled.
-    veniceAdmin.updateStore(
-        clusterName,
-        storeNameBatchOnly,
-        new UpdateStoreQueryParams().setHybridRewindSeconds(1000L).setHybridOffsetLagThreshold(1000L));
-    assertTrue(veniceAdmin.getStore(clusterName, storeNameBatchOnly).isActiveActiveReplicationEnabled());
-
-    // Set topic original topic manager back
-    veniceAdmin.setTopicManagerRepository(originalTopicManagerRepository);
-  }
-
-  private TopicManagerRepository prepareCluster(
-      boolean enableActiveActiveForHybrid,
-      boolean enableActiveActiveForBatchOnly) throws IOException {
-    veniceAdmin.stop(clusterName);
-    veniceAdmin.close();
-    Properties controllerProperties =
-        getActiveActiveControllerProperties(clusterName, enableActiveActiveForHybrid, enableActiveActiveForBatchOnly);
-    veniceAdmin = new VeniceHelixAdmin(
-        TestUtils.getMultiClusterConfigFromOneCluster(
-            new VeniceControllerConfig(new VeniceProperties(controllerProperties))),
-        new MetricsRepository(),
-        D2TestUtils.getAndStartD2Client(zkAddress),
-        pubSubTopicRepository,
-        pubSubBrokerWrapper.getPubSubClientsFactory());
-
-    veniceAdmin.initStorageCluster(clusterName);
-    TopicManagerRepository originalTopicManagerRepository = veniceAdmin.getTopicManagerRepository();
-
-    TopicManager mockedTopicManager = mock(TopicManager.class);
-    TopicManagerRepository mockedTopicManageRepository = mock(TopicManagerRepository.class);
-    doReturn(mockedTopicManager).when(mockedTopicManageRepository).getLocalTopicManager();
-    doReturn(mockedTopicManager).when(mockedTopicManageRepository).getTopicManager(any(String.class));
-    doReturn(mockedTopicManager).when(mockedTopicManageRepository).getTopicManager(anyString());
-    veniceAdmin.setTopicManagerRepository(mockedTopicManageRepository);
-    TestUtils
-        .waitForNonDeterministicCompletion(5, TimeUnit.SECONDS, () -> veniceAdmin.isLeaderControllerFor(clusterName));
-    Object createParticipantStoreFromProp = controllerProperties.get(PARTICIPANT_MESSAGE_STORE_ENABLED);
-    if (createParticipantStoreFromProp != null && Boolean.parseBoolean(createParticipantStoreFromProp.toString())) {
-      // Wait for participant store to finish materializing
-      TestUtils.waitForNonDeterministicAssertion(10, TimeUnit.SECONDS, () -> {
-        Store store =
-            veniceAdmin.getStore(clusterName, VeniceSystemStoreUtils.getParticipantStoreNameForCluster(clusterName));
-        Assert.assertNotNull(store);
-        assertEquals(store.getCurrentVersion(), 1);
+      // After updating the store to be a hybrid store, it's A/A should still be enabled.
+      assertCommand(
+          parentControllerClient.updateStore(
+              storeName,
+              new UpdateStoreQueryParams().setHybridRewindSeconds(1000L).setHybridOffsetLagThreshold(1000L)));
+      TestUtils.waitForNonDeterministicAssertion(TEST_TIMEOUT, TimeUnit.MILLISECONDS, () -> {
+        assertTrue(parentControllerClient.getStore(storeName).getStore().isActiveActiveReplicationEnabled());
       });
     }
-    return originalTopicManagerRepository;
   }
 
   private Properties getActiveActiveControllerProperties(
-      String clusterName,
       boolean enableActiveActiveForHybrid,
-      boolean enableActiveActiveForBatchOnly) throws IOException {
-    Properties props = super.getControllerProperties(clusterName);
+      boolean enableActiveActiveForBatchOnly) {
+    Properties props = new Properties();
     props.setProperty(ENABLE_NATIVE_REPLICATION_AS_DEFAULT_FOR_BATCH_ONLY, "true");
     // Enable Active/Active replication for hybrid stores through cluster-level config
     props.setProperty(

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestClusterLevelConfigForNativeReplication.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestClusterLevelConfigForNativeReplication.java
@@ -3,108 +3,101 @@ package com.linkedin.venice.controller;
 import static com.linkedin.venice.ConfigKeys.ENABLE_NATIVE_REPLICATION_AS_DEFAULT_FOR_BATCH_ONLY;
 import static com.linkedin.venice.ConfigKeys.NATIVE_REPLICATION_SOURCE_FABRIC_AS_DEFAULT_FOR_BATCH_ONLY_STORES;
 import static com.linkedin.venice.ConfigKeys.NATIVE_REPLICATION_SOURCE_FABRIC_AS_DEFAULT_FOR_HYBRID_STORES;
-import static com.linkedin.venice.controller.VeniceHelixAdmin.VERSION_ID_UNSET;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.mock;
+import static com.linkedin.venice.utils.TestUtils.assertCommand;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 
+import com.linkedin.venice.controllerapi.ControllerClient;
 import com.linkedin.venice.controllerapi.UpdateStoreQueryParams;
-import com.linkedin.venice.meta.Version;
-import com.linkedin.venice.pubsub.manager.TopicManager;
-import com.linkedin.venice.pubsub.manager.TopicManagerRepository;
+import com.linkedin.venice.integration.utils.ServiceFactory;
+import com.linkedin.venice.integration.utils.VeniceMultiRegionClusterCreateOptions;
+import com.linkedin.venice.integration.utils.VeniceTwoLayerMultiRegionMultiClusterWrapper;
+import com.linkedin.venice.meta.StoreInfo;
+import com.linkedin.venice.utils.TestUtils;
+import com.linkedin.venice.utils.Time;
 import com.linkedin.venice.utils.Utils;
-import java.io.IOException;
-import java.util.Optional;
 import java.util.Properties;
+import java.util.concurrent.TimeUnit;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 
-public class TestClusterLevelConfigForNativeReplication extends AbstractTestVeniceHelixAdmin {
+public class TestClusterLevelConfigForNativeReplication {
+  private static final long TEST_TIMEOUT = 60 * Time.MS_PER_SECOND;
+
+  private VeniceTwoLayerMultiRegionMultiClusterWrapper multiRegionMultiClusterWrapper;
+  private ControllerClient parentControllerClient;
+
   @BeforeClass(alwaysRun = true)
-  public void setUp() throws Exception {
-    setupCluster();
+  public void setUp() {
+    Utils.thisIsLocalhost();
+    Properties parentControllerProps = new Properties();
+    // enable native replication for batch-only stores through cluster-level config
+    parentControllerProps.setProperty(ENABLE_NATIVE_REPLICATION_AS_DEFAULT_FOR_BATCH_ONLY, "true");
+    parentControllerProps.setProperty(NATIVE_REPLICATION_SOURCE_FABRIC_AS_DEFAULT_FOR_BATCH_ONLY_STORES, "dc-batch");
+    parentControllerProps.setProperty(NATIVE_REPLICATION_SOURCE_FABRIC_AS_DEFAULT_FOR_HYBRID_STORES, "dc-hybrid");
+    multiRegionMultiClusterWrapper = ServiceFactory.getVeniceTwoLayerMultiRegionMultiClusterWrapper(
+        new VeniceMultiRegionClusterCreateOptions.Builder().numberOfRegions(1)
+            .numberOfParentControllers(1)
+            .numberOfChildControllers(1)
+            .numberOfRouters(1)
+            .numberOfServers(1)
+            .parentControllerProperties(parentControllerProps)
+            .build());
+    parentControllerClient = new ControllerClient(
+        multiRegionMultiClusterWrapper.getClusterNames()[0],
+        multiRegionMultiClusterWrapper.getControllerConnectString());
   }
 
   @AfterClass(alwaysRun = true)
-  public void cleanUp() {
-    cleanupCluster();
+  public void tearDown() {
+    Utils.closeQuietlyWithErrorLogged(parentControllerClient);
+    Utils.closeQuietlyWithErrorLogged(multiRegionMultiClusterWrapper);
   }
 
-  @Override
-  Properties getControllerProperties(String clusterName) throws IOException {
-    Properties props = super.getControllerProperties(clusterName);
-    // enable native replication for batch-only stores through cluster-level config
-    props.setProperty(ENABLE_NATIVE_REPLICATION_AS_DEFAULT_FOR_BATCH_ONLY, "true");
-    props.setProperty(NATIVE_REPLICATION_SOURCE_FABRIC_AS_DEFAULT_FOR_BATCH_ONLY_STORES, "dc-batch");
-    props.setProperty(NATIVE_REPLICATION_SOURCE_FABRIC_AS_DEFAULT_FOR_HYBRID_STORES, "dc-hybrid");
-    return props;
-  }
-
-  @Test
+  @Test(timeOut = TEST_TIMEOUT)
   public void testClusterLevelNativeReplicationConfigForNewStores() {
-    TopicManagerRepository originalTopicManagerRepository = veniceAdmin.getTopicManagerRepository();
-
-    TopicManager mockedTopicManager = mock(TopicManager.class);
-    TopicManagerRepository mockedTopicManageRepository = mock(TopicManagerRepository.class);
-    doReturn(mockedTopicManager).when(mockedTopicManageRepository).getLocalTopicManager();
-    doReturn(mockedTopicManager).when(mockedTopicManageRepository).getTopicManager(any(String.class));
-    doReturn(mockedTopicManager).when(mockedTopicManageRepository).getTopicManager(anyString());
-    veniceAdmin.setTopicManagerRepository(mockedTopicManageRepository);
     String storeName = Utils.getUniqueString("test-store");
     String pushJobId1 = "test-push-job-id-1";
-    /**
-     * Do not enable any store-level config for leader/follower mode or native replication feature.
-     */
-    veniceAdmin.createStore(clusterName, storeName, "test-owner", KEY_SCHEMA, VALUE_SCHEMA);
+    parentControllerClient.createNewStore(storeName, "test-owner", "\"string\"", "\"string\"");
+    parentControllerClient.emptyPush(storeName, pushJobId1, 1);
 
-    /**
-     * Add a version
-     */
-    veniceAdmin.addVersionAndTopicOnly(
-        clusterName,
-        storeName,
-        pushJobId1,
-        VERSION_ID_UNSET,
-        1,
-        1,
-        false,
-        true,
-        Version.PushType.BATCH,
-        null,
-        null,
-        Optional.empty(),
-        -1,
-        1,
-        Optional.empty(),
-        false);
     // Version 1 should exist.
-    Assert.assertEquals(veniceAdmin.getStore(clusterName, storeName).getVersions().size(), 1);
+    StoreInfo store = assertCommand(parentControllerClient.getStore(storeName)).getStore();
+    assertEquals(store.getVersions().size(), 1);
     // native replication should be enabled by cluster-level config
-    Assert.assertEquals(veniceAdmin.getStore(clusterName, storeName).isNativeReplicationEnabled(), true);
-    Assert.assertEquals(veniceAdmin.getStore(clusterName, storeName).getNativeReplicationSourceFabric(), "dc-batch");
-    veniceAdmin.updateStore(
-        clusterName,
-        storeName,
-        new UpdateStoreQueryParams().setHybridRewindSeconds(1L).setHybridOffsetLagThreshold(1L));
-    Assert.assertEquals(veniceAdmin.getStore(clusterName, storeName).getNativeReplicationSourceFabric(), "dc-hybrid");
-    veniceAdmin.updateStore(
-        clusterName,
-        storeName,
-        new UpdateStoreQueryParams().setHybridRewindSeconds(-1L).setHybridOffsetLagThreshold(-1L));
-    Assert.assertEquals(veniceAdmin.getStore(clusterName, storeName).getNativeReplicationSourceFabric(), "dc-batch");
-    veniceAdmin.updateStore(
-        clusterName,
-        storeName,
-        new UpdateStoreQueryParams().setIncrementalPushEnabled(true)
-            .setHybridRewindSeconds(1L)
-            .setHybridOffsetLagThreshold(10));
-    Assert.assertEquals(veniceAdmin.getStore(clusterName, storeName).getNativeReplicationSourceFabric(), "dc-hybrid");
-
-    // Set topic original topic manager back
-    veniceAdmin.setTopicManagerRepository(originalTopicManagerRepository);
+    assertTrue(store.isNativeReplicationEnabled());
+    assertEquals(store.getNativeReplicationSourceFabric(), "dc-batch");
+    assertCommand(
+        parentControllerClient.updateStore(
+            storeName,
+            new UpdateStoreQueryParams().setHybridRewindSeconds(1L).setHybridOffsetLagThreshold(1L)));
+    TestUtils.waitForNonDeterministicAssertion(TEST_TIMEOUT, TimeUnit.MILLISECONDS, () -> {
+      Assert.assertEquals(
+          parentControllerClient.getStore(storeName).getStore().getNativeReplicationSourceFabric(),
+          "dc-hybrid");
+    });
+    assertCommand(
+        parentControllerClient.updateStore(
+            storeName,
+            new UpdateStoreQueryParams().setHybridRewindSeconds(-1L).setHybridOffsetLagThreshold(-1L)));
+    TestUtils.waitForNonDeterministicAssertion(TEST_TIMEOUT, TimeUnit.MILLISECONDS, () -> {
+      Assert.assertEquals(
+          parentControllerClient.getStore(storeName).getStore().getNativeReplicationSourceFabric(),
+          "dc-batch");
+    });
+    assertCommand(
+        parentControllerClient.updateStore(
+            storeName,
+            new UpdateStoreQueryParams().setIncrementalPushEnabled(true)
+                .setHybridRewindSeconds(1L)
+                .setHybridOffsetLagThreshold(10)));
+    TestUtils.waitForNonDeterministicAssertion(TEST_TIMEOUT, TimeUnit.MILLISECONDS, () -> {
+      Assert.assertEquals(
+          parentControllerClient.getStore(storeName).getStore().getNativeReplicationSourceFabric(),
+          "dc-hybrid");
+    });
   }
 }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/kafka/consumer/AdminConsumptionTaskIntegrationTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/kafka/consumer/AdminConsumptionTaskIntegrationTest.java
@@ -190,7 +190,7 @@ public class AdminConsumptionTaskIntegrationTest {
         byte[] storeDeletionMessage = getStoreDeletionMessage(clusterName, storeName, executionId);
         writer.put(new byte[0], storeDeletionMessage, AdminOperationSerializer.LATEST_SCHEMA_ID_FOR_ADMIN_OPERATION);
         TestUtils.waitForNonDeterministicAssertion(TIMEOUT, TimeUnit.MILLISECONDS, () -> {
-          Assert.assertFalse(parentControllerClient.getStore(storeName).isError());
+          Assert.assertTrue(parentControllerClient.getStore(storeName).isError());
         });
       }
     }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/kafka/consumer/AdminConsumptionTaskIntegrationTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/kafka/consumer/AdminConsumptionTaskIntegrationTest.java
@@ -2,10 +2,8 @@ package com.linkedin.venice.controller.kafka.consumer;
 
 import static com.linkedin.venice.ConfigKeys.ADMIN_CONSUMPTION_CYCLE_TIMEOUT_MS;
 import static com.linkedin.venice.ConfigKeys.ADMIN_CONSUMPTION_MAX_WORKER_THREAD_POOL_SIZE;
-import static com.linkedin.venice.integration.utils.VeniceClusterWrapperConstants.STANDALONE_REGION_NAME;
-import static com.linkedin.venice.pubsub.PubSubConstants.PUBSUB_OPERATION_TIMEOUT_MS_DEFAULT_VALUE;
 
-import com.linkedin.venice.controller.VeniceHelixAdmin;
+import com.linkedin.venice.controller.Admin;
 import com.linkedin.venice.controller.kafka.AdminTopicUtils;
 import com.linkedin.venice.controller.kafka.protocol.admin.AdminOperation;
 import com.linkedin.venice.controller.kafka.protocol.admin.DeleteStore;
@@ -17,12 +15,11 @@ import com.linkedin.venice.controller.kafka.protocol.enums.AdminMessageType;
 import com.linkedin.venice.controller.kafka.protocol.enums.SchemaType;
 import com.linkedin.venice.controller.kafka.protocol.serializer.AdminOperationSerializer;
 import com.linkedin.venice.controllerapi.ControllerClient;
-import com.linkedin.venice.integration.utils.PubSubBrokerConfigs;
 import com.linkedin.venice.integration.utils.PubSubBrokerWrapper;
 import com.linkedin.venice.integration.utils.ServiceFactory;
-import com.linkedin.venice.integration.utils.VeniceControllerCreateOptions;
 import com.linkedin.venice.integration.utils.VeniceControllerWrapper;
-import com.linkedin.venice.integration.utils.ZkServerWrapper;
+import com.linkedin.venice.integration.utils.VeniceMultiRegionClusterCreateOptions;
+import com.linkedin.venice.integration.utils.VeniceTwoLayerMultiRegionMultiClusterWrapper;
 import com.linkedin.venice.pubsub.PubSubProducerAdapterFactory;
 import com.linkedin.venice.pubsub.PubSubTopicRepository;
 import com.linkedin.venice.pubsub.api.PubSubTopic;
@@ -50,41 +47,40 @@ import org.testng.annotations.Test;
 public class AdminConsumptionTaskIntegrationTest {
   private static final int TIMEOUT = 1 * Time.MS_PER_MINUTE;
 
-  private String clusterName = Utils.getUniqueString("test-cluster");
   private final AdminOperationSerializer adminOperationSerializer = new AdminOperationSerializer();
 
   private static final String owner = "test_owner";
   private static final String keySchema = "\"string\"";
   private static final String valueSchema = "\"string\"";
 
-  private Properties extraProperties = new Properties();
-  private final PubSubTopicRepository pubSubTopicRepository = new PubSubTopicRepository();
-
   /**
    * This test is flaky on slower hardware, with a short timeout ):
    */
   @Test(timeOut = TIMEOUT)
   public void testSkipMessageEndToEnd() throws ExecutionException, InterruptedException, IOException {
-    try (ZkServerWrapper zkServer = ServiceFactory.getZkServer();
-        PubSubBrokerWrapper pubSubBrokerWrapper = ServiceFactory.getPubSubBroker(
-            new PubSubBrokerConfigs.Builder().setZkWrapper(zkServer).setRegionName(STANDALONE_REGION_NAME).build());
-        TopicManager topicManager =
-            IntegrationTestPushUtils
-                .getTopicManagerRepo(
-                    PUBSUB_OPERATION_TIMEOUT_MS_DEFAULT_VALUE,
-                    100,
-                    0l,
-                    pubSubBrokerWrapper,
-                    pubSubTopicRepository)
-                .getLocalTopicManager()) {
+    try (
+        VeniceTwoLayerMultiRegionMultiClusterWrapper venice =
+            ServiceFactory.getVeniceTwoLayerMultiRegionMultiClusterWrapper(
+                new VeniceMultiRegionClusterCreateOptions.Builder().numberOfRegions(1)
+                    .numberOfClusters(1)
+                    .numberOfParentControllers(1)
+                    .numberOfChildControllers(1)
+                    .numberOfServers(1)
+                    .numberOfRouters(1)
+                    .replicationFactor(1)
+                    .build());
+        ControllerClient parentControllerClient = new ControllerClient(
+            venice.getClusterNames()[0],
+            venice.getParentControllers().get(0).getControllerUrl())) {
+      String clusterName = venice.getClusterNames()[0];
+      Admin admin = venice.getParentControllers().get(0).getVeniceAdmin();
+      PubSubTopicRepository pubSubTopicRepository = admin.getPubSubTopicRepository();
+      TopicManager topicManager = admin.getTopicManager();
       PubSubTopic adminTopic = pubSubTopicRepository.getTopic(AdminTopicUtils.getTopicNameFromClusterName(clusterName));
       topicManager.createTopic(adminTopic, 1, 1, true);
       String storeName = "test-store";
+      PubSubBrokerWrapper pubSubBrokerWrapper = venice.getParentKafkaBrokerWrapper();
       try (
-          VeniceControllerWrapper controller = ServiceFactory.getVeniceController(
-              new VeniceControllerCreateOptions.Builder(clusterName, zkServer, pubSubBrokerWrapper)
-                  .regionName(STANDALONE_REGION_NAME)
-                  .build());
           PubSubProducerAdapterFactory pubSubProducerAdapterFactory =
               pubSubBrokerWrapper.getPubSubClientsFactory().getProducerAdapterFactory();
           VeniceWriter<byte[], byte[], byte[]> writer =
@@ -99,44 +95,48 @@ public class AdminConsumptionTaskIntegrationTest {
         writer.put(new byte[0], goodMessage, AdminOperationSerializer.LATEST_SCHEMA_ID_FOR_ADMIN_OPERATION);
 
         Thread.sleep(5000); // Non-deterministic, but whatever. This should never fail.
-        Assert.assertFalse(controller.getVeniceAdmin().hasStore(clusterName, storeName));
+        Assert.assertTrue(parentControllerClient.getStore(storeName).isError());
 
-        try (ControllerClient controllerClient = new ControllerClient(clusterName, controller.getControllerUrl())) {
-          controllerClient.skipAdminMessage(Long.toString(badOffset), false);
-        }
+        parentControllerClient.skipAdminMessage(Long.toString(badOffset), false);
         TestUtils.waitForNonDeterministicAssertion(TIMEOUT * 3, TimeUnit.MILLISECONDS, () -> {
-          Assert.assertTrue(controller.getVeniceAdmin().hasStore(clusterName, storeName));
+          Assert.assertFalse(parentControllerClient.getStore(storeName).isError());
         });
       }
     }
   }
 
-  @Test(timeOut = TIMEOUT)
+  @Test(timeOut = 2 * TIMEOUT)
   public void testParallelAdminExecutionTasks() throws IOException, InterruptedException {
-    try (ZkServerWrapper zkServer = ServiceFactory.getZkServer();
-        PubSubBrokerWrapper pubSubBrokerWrapper = ServiceFactory.getPubSubBroker(
-            new PubSubBrokerConfigs.Builder().setZkWrapper(zkServer).setRegionName(STANDALONE_REGION_NAME).build());
-        TopicManager topicManager =
-            IntegrationTestPushUtils
-                .getTopicManagerRepo(
-                    PUBSUB_OPERATION_TIMEOUT_MS_DEFAULT_VALUE,
-                    100,
-                    0l,
-                    pubSubBrokerWrapper,
-                    pubSubTopicRepository)
-                .getLocalTopicManager()) {
+    int adminConsumptionMaxWorkerPoolSize = 3;
+
+    Properties parentControllerProps = new Properties();
+    parentControllerProps.put(ADMIN_CONSUMPTION_MAX_WORKER_THREAD_POOL_SIZE, adminConsumptionMaxWorkerPoolSize);
+    parentControllerProps.put(ADMIN_CONSUMPTION_CYCLE_TIMEOUT_MS, 3000);
+
+    try (
+        VeniceTwoLayerMultiRegionMultiClusterWrapper venice =
+            ServiceFactory.getVeniceTwoLayerMultiRegionMultiClusterWrapper(
+                new VeniceMultiRegionClusterCreateOptions.Builder().numberOfRegions(1)
+                    .numberOfClusters(1)
+                    .numberOfParentControllers(1)
+                    .numberOfChildControllers(1)
+                    .numberOfServers(1)
+                    .numberOfRouters(1)
+                    .replicationFactor(1)
+                    .parentControllerProperties(parentControllerProps)
+                    .build());
+        ControllerClient parentControllerClient = new ControllerClient(
+            venice.getClusterNames()[0],
+            venice.getParentControllers().get(0).getControllerUrl())) {
+      String clusterName = venice.getClusterNames()[0];
+      Admin admin = venice.getParentControllers().get(0).getVeniceAdmin();
+      PubSubTopicRepository pubSubTopicRepository = admin.getPubSubTopicRepository();
+      TopicManager topicManager = admin.getTopicManager();
       PubSubTopic adminTopic = pubSubTopicRepository.getTopic(AdminTopicUtils.getTopicNameFromClusterName(clusterName));
       topicManager.createTopic(adminTopic, 1, 1, true);
       String storeName = "test-store";
-      int adminConsumptionMaxWorkerPoolSize = 3;
-      extraProperties.put(ADMIN_CONSUMPTION_MAX_WORKER_THREAD_POOL_SIZE, adminConsumptionMaxWorkerPoolSize);
-      extraProperties.put(ADMIN_CONSUMPTION_CYCLE_TIMEOUT_MS, 3000);
+      PubSubBrokerWrapper pubSubBrokerWrapper = venice.getParentKafkaBrokerWrapper();
       try (
-          VeniceControllerWrapper controller = ServiceFactory.getVeniceController(
-              new VeniceControllerCreateOptions.Builder(clusterName, zkServer, pubSubBrokerWrapper)
-                  .regionName(STANDALONE_REGION_NAME)
-                  .extraProperties(extraProperties)
-                  .build());
           PubSubProducerAdapterFactory pubSubProducerAdapterFactory =
               pubSubBrokerWrapper.getPubSubClientsFactory().getProducerAdapterFactory();
           VeniceWriter<byte[], byte[], byte[]> writer =
@@ -148,12 +148,12 @@ public class AdminConsumptionTaskIntegrationTest {
         writer.put(new byte[0], goodMessage, AdminOperationSerializer.LATEST_SCHEMA_ID_FOR_ADMIN_OPERATION);
 
         TestUtils.waitForNonDeterministicAssertion(TIMEOUT, TimeUnit.MILLISECONDS, () -> {
-          Assert.assertTrue(controller.getVeniceAdmin().hasStore(clusterName, storeName));
+          Assert.assertFalse(parentControllerClient.getStore(storeName).isError());
         });
 
         // Spin up a thread to occupy the store write lock to simulate the blocking admin execution task thread.
         CountDownLatch lockOccupyThreadStartedSignal = new CountDownLatch(1);
-        Runnable infiniteLockOccupy = getRunnable(controller, storeName, lockOccupyThreadStartedSignal);
+        Runnable infiniteLockOccupy = getRunnable(venice, storeName, lockOccupyThreadStartedSignal);
         Thread infiniteLockThread = new Thread(infiniteLockOccupy, "infiniteLockOccupy: " + storeName);
         infiniteLockThread.start();
         Assert.assertTrue(lockOccupyThreadStartedSignal.await(5, TimeUnit.SECONDS));
@@ -181,7 +181,7 @@ public class AdminConsumptionTaskIntegrationTest {
         writer.put(new byte[0], otherStoreMessage, AdminOperationSerializer.LATEST_SCHEMA_ID_FOR_ADMIN_OPERATION);
 
         TestUtils.waitForNonDeterministicAssertion(TIMEOUT, TimeUnit.MILLISECONDS, () -> {
-          Assert.assertTrue(controller.getVeniceAdmin().hasStore(clusterName, otherStoreName));
+          Assert.assertFalse(parentControllerClient.getStore(storeName).isError());
         });
 
         infiniteLockThread.interrupt(); // This will release the lock
@@ -190,14 +190,19 @@ public class AdminConsumptionTaskIntegrationTest {
         byte[] storeDeletionMessage = getStoreDeletionMessage(clusterName, storeName, executionId);
         writer.put(new byte[0], storeDeletionMessage, AdminOperationSerializer.LATEST_SCHEMA_ID_FOR_ADMIN_OPERATION);
         TestUtils.waitForNonDeterministicAssertion(TIMEOUT, TimeUnit.MILLISECONDS, () -> {
-          Assert.assertFalse(controller.getVeniceAdmin().hasStore(clusterName, storeName));
+          Assert.assertFalse(parentControllerClient.getStore(storeName).isError());
         });
       }
     }
   }
 
-  private Runnable getRunnable(VeniceControllerWrapper controller, String storeName, CountDownLatch latch) {
-    VeniceHelixAdmin admin = controller.getVeniceHelixAdmin();
+  private Runnable getRunnable(
+      VeniceTwoLayerMultiRegionMultiClusterWrapper venice,
+      String storeName,
+      CountDownLatch latch) {
+    String clusterName = venice.getClusterNames()[0];
+    VeniceControllerWrapper parentController = venice.getParentControllers().get(0);
+    Admin admin = parentController.getVeniceAdmin();
     return () -> {
       try (AutoCloseableLock ignore =
           admin.getHelixVeniceClusterResources(clusterName).getClusterLockManager().createStoreWriteLock(storeName)) {

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/server/AbstractTestAdminSparkServer.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/server/AbstractTestAdminSparkServer.java
@@ -6,10 +6,9 @@ import static com.linkedin.venice.ConfigKeys.CONTROLLER_AUTO_MATERIALIZE_META_SY
 import com.linkedin.venice.authorization.AuthorizerService;
 import com.linkedin.venice.controllerapi.ControllerClient;
 import com.linkedin.venice.integration.utils.ServiceFactory;
-import com.linkedin.venice.integration.utils.VeniceClusterWrapper;
-import com.linkedin.venice.integration.utils.VeniceControllerCreateOptions;
 import com.linkedin.venice.integration.utils.VeniceControllerWrapper;
-import com.linkedin.venice.integration.utils.ZkServerWrapper;
+import com.linkedin.venice.integration.utils.VeniceMultiRegionClusterCreateOptions;
+import com.linkedin.venice.integration.utils.VeniceTwoLayerMultiRegionMultiClusterWrapper;
 import com.linkedin.venice.utils.TestUtils;
 import com.linkedin.venice.utils.Time;
 import com.linkedin.venice.utils.Utils;
@@ -25,48 +24,60 @@ public class AbstractTestAdminSparkServer {
   protected static final int TEST_TIMEOUT = 300 * Time.MS_PER_SECOND;
   protected static final int STORAGE_NODE_COUNT = 1;
 
-  protected VeniceClusterWrapper cluster;
+  protected VeniceTwoLayerMultiRegionMultiClusterWrapper venice;
   protected ControllerClient controllerClient;
   protected VeniceControllerWrapper parentController;
-  protected ZkServerWrapper parentZk;
+  protected ControllerClient parentControllerClient;
 
   public void setUp(
       boolean useParentRestEndpoint,
       Optional<AuthorizerService> authorizerService,
       Properties extraProperties) {
-    cluster = ServiceFactory.getVeniceCluster(1, STORAGE_NODE_COUNT, 0, 1, 100, false, false, extraProperties);
+    Properties parentControllerProps = new Properties();
+    parentControllerProps.putAll(extraProperties);
+    Properties childControllerProps = new Properties();
+    childControllerProps.putAll(extraProperties);
 
-    parentZk = ServiceFactory.getZkServer();
     // The cluster does not have router setup
-    extraProperties.setProperty(CONTROLLER_AUTO_MATERIALIZE_META_SYSTEM_STORE, "false");
-    extraProperties.setProperty(CONTROLLER_AUTO_MATERIALIZE_DAVINCI_PUSH_STATUS_SYSTEM_STORE, "false");
-    VeniceControllerCreateOptions options =
-        new VeniceControllerCreateOptions.Builder(cluster.getClusterName(), parentZk, cluster.getPubSubBrokerWrapper())
-            .replicationFactor(1)
-            .childControllers(new VeniceControllerWrapper[] { cluster.getLeaderVeniceController() })
-            .extraProperties(extraProperties)
-            .authorizerService(authorizerService.orElse(null))
-            .build();
-    parentController = ServiceFactory.getVeniceController(options);
+    parentControllerProps.setProperty(CONTROLLER_AUTO_MATERIALIZE_META_SYSTEM_STORE, "false");
+    parentControllerProps.setProperty(CONTROLLER_AUTO_MATERIALIZE_DAVINCI_PUSH_STATUS_SYSTEM_STORE, "false");
 
+    childControllerProps.setProperty(CONTROLLER_AUTO_MATERIALIZE_META_SYSTEM_STORE, "false");
+    childControllerProps.setProperty(CONTROLLER_AUTO_MATERIALIZE_DAVINCI_PUSH_STATUS_SYSTEM_STORE, "false");
+
+    venice = ServiceFactory.getVeniceTwoLayerMultiRegionMultiClusterWrapper(
+        new VeniceMultiRegionClusterCreateOptions.Builder().numberOfRegions(1)
+            .numberOfClusters(1)
+            .numberOfParentControllers(1)
+            .numberOfChildControllers(1)
+            .numberOfServers(STORAGE_NODE_COUNT)
+            .numberOfRouters(0)
+            .replicationFactor(1)
+            .parentControllerProperties(parentControllerProps)
+            .childControllerProperties(childControllerProps)
+            .serverProperties(extraProperties)
+            .parentAuthorizerService(authorizerService.orElse(null))
+            .build());
+    parentController = venice.getParentControllers().get(0);
+    parentControllerClient = new ControllerClient(venice.getClusterNames()[0], parentController.getControllerUrl());
+
+    String clusterName = venice.getClusterNames()[0];
     if (!useParentRestEndpoint) {
-      controllerClient =
-          ControllerClient.constructClusterControllerClient(cluster.getClusterName(), cluster.getAllControllersURLs());
-    } else {
       controllerClient = ControllerClient
-          .constructClusterControllerClient(cluster.getClusterName(), parentController.getControllerUrl());
+          .constructClusterControllerClient(clusterName, venice.getChildRegions().get(0).getControllerConnectString());
+    } else {
+      controllerClient =
+          ControllerClient.constructClusterControllerClient(clusterName, parentController.getControllerUrl());
     }
 
     TestUtils.waitForNonDeterministicCompletion(
         TEST_TIMEOUT,
         TimeUnit.MILLISECONDS,
-        () -> parentController.isLeaderController(cluster.getClusterName()));
+        () -> parentController.isLeaderController(clusterName));
   }
 
   public void cleanUp() {
-    Utils.closeQuietlyWithErrorLogged(parentController);
     Utils.closeQuietlyWithErrorLogged(controllerClient);
-    Utils.closeQuietlyWithErrorLogged(cluster);
-    Utils.closeQuietlyWithErrorLogged(parentZk);
+    Utils.closeQuietlyWithErrorLogged(venice);
   }
 }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/server/TestAdminSparkServer.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/server/TestAdminSparkServer.java
@@ -1,5 +1,7 @@
 package com.linkedin.venice.controller.server;
 
+import static com.linkedin.venice.utils.TestUtils.assertCommand;
+
 import com.linkedin.venice.ConfigKeys;
 import com.linkedin.venice.LastSucceedExecutionIdResponse;
 import com.linkedin.venice.common.VeniceSystemStoreType;
@@ -30,8 +32,11 @@ import com.linkedin.venice.controllerapi.routes.AdminCommandExecutionResponse;
 import com.linkedin.venice.exceptions.ErrorType;
 import com.linkedin.venice.exceptions.ExceptionType;
 import com.linkedin.venice.httpclient.HttpClientUtils;
+import com.linkedin.venice.integration.utils.VeniceClusterWrapper;
 import com.linkedin.venice.integration.utils.VeniceControllerWrapper;
+import com.linkedin.venice.integration.utils.VeniceMultiClusterWrapper;
 import com.linkedin.venice.integration.utils.VeniceServerWrapper;
+import com.linkedin.venice.meta.HybridStoreConfig;
 import com.linkedin.venice.meta.InstanceStatus;
 import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.StoreInfo;
@@ -41,6 +46,7 @@ import com.linkedin.venice.utils.ByteUtils;
 import com.linkedin.venice.utils.EncodingUtils;
 import com.linkedin.venice.utils.ObjectMapperFactory;
 import com.linkedin.venice.utils.TestUtils;
+import com.linkedin.venice.utils.Time;
 import com.linkedin.venice.utils.Utils;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -60,6 +66,8 @@ import org.apache.http.client.entity.UrlEncodedFormEntity;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.impl.nio.client.CloseableHttpAsyncClient;
 import org.apache.http.message.BasicNameValuePair;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -67,6 +75,8 @@ import org.testng.annotations.Test;
 
 
 public class TestAdminSparkServer extends AbstractTestAdminSparkServer {
+  private static final Logger LOGGER = LogManager.getLogger(TestAdminSparkServer.class);
+
   /**
    * Seems that Helix has limit on the number of resource each node is able to handle.
    * If the test case needs more than one storage node like testing failover etc, please put it into {@link TestAdminSparkServerWithMultiServers}
@@ -115,7 +125,11 @@ public class TestAdminSparkServer extends AbstractTestAdminSparkServer {
 
   @Test(timeOut = TEST_TIMEOUT)
   public void controllerClientCanQueryReplicasOnAStorageNode() {
-    String storeName = cluster.getNewStoreVersion().getName();
+    String storeName = Utils.getUniqueString("test-store");
+    assertCommand(parentControllerClient.createNewStore(storeName, "owner", "\"string\"", "\"string\""));
+    assertCommand(
+        parentControllerClient
+            .sendEmptyPushAndWait(storeName, Utils.getUniqueString(storeName), 1024, 60 * Time.MS_PER_SECOND));
     try {
       MultiNodeResponse nodeResponse = controllerClient.listStorageNodes();
       String nodeId = nodeResponse.getNodes()[0];
@@ -128,14 +142,16 @@ public class TestAdminSparkServer extends AbstractTestAdminSparkServer {
 
   @Test(timeOut = TEST_TIMEOUT)
   public void controllerClientCanQueryReplicasForTopic() {
-    VersionCreationResponse versionCreationResponse = cluster.getNewStoreVersion();
+    String storeName = Utils.getUniqueString("test-store");
+    assertCommand(parentControllerClient.createNewStore(storeName, "owner", "\"string\"", "\"string\""));
+    VersionCreationResponse versionCreationResponse =
+        parentControllerClient.emptyPush(storeName, Utils.getUniqueString(storeName), 1024);
     Assert.assertFalse(versionCreationResponse.isError(), versionCreationResponse.getError());
-    String storeName = versionCreationResponse.getName();
     try {
-      String kafkaTopic = cluster.getNewStoreVersion().getKafkaTopic();
+      String kafkaTopic = versionCreationResponse.getKafkaTopic();
       Assert.assertNotNull(
           kafkaTopic,
-          "venice.getNewStoreVersion() should not return a null topic name\n" + versionCreationResponse.toString());
+          "parentControllerClient.emptyPush should not return a null topic name\n" + versionCreationResponse);
 
       String store = Version.parseStoreFromKafkaTopicName(kafkaTopic);
       int version = Version.parseVersionFromKafkaTopicName(kafkaTopic);
@@ -155,11 +171,12 @@ public class TestAdminSparkServer extends AbstractTestAdminSparkServer {
     String valueSchema = "\"long\"";
 
     // create Store
-    NewStoreResponse newStoreResponse = controllerClient.createNewStore(storeToCreate, "owner", keySchema, valueSchema);
+    NewStoreResponse newStoreResponse =
+        parentControllerClient.createNewStore(storeToCreate, "owner", keySchema, valueSchema);
     Assert.assertFalse(newStoreResponse.isError(), "create new store should succeed for a store that doesn't exist");
     try {
       NewStoreResponse duplicateNewStoreResponse =
-          controllerClient.createNewStore(storeToCreate, "owner", keySchema, valueSchema);
+          parentControllerClient.createNewStore(storeToCreate, "owner", keySchema, valueSchema);
       Assert
           .assertTrue(duplicateNewStoreResponse.isError(), "create new store should fail for duplicate store creation");
 
@@ -167,12 +184,12 @@ public class TestAdminSparkServer extends AbstractTestAdminSparkServer {
       CloseableHttpAsyncClient httpClient = HttpClientUtils.getMinimalHttpClient(1, 1, Optional.empty());
       httpClient.start();
       List<NameValuePair> params = new ArrayList<>();
-      params.add(new BasicNameValuePair(ControllerApiConstants.CLUSTER, cluster.getClusterName()));
+      params.add(new BasicNameValuePair(ControllerApiConstants.CLUSTER, venice.getClusterNames()[0]));
       params.add(new BasicNameValuePair(ControllerApiConstants.NAME, storeToCreate));
       params.add(new BasicNameValuePair(ControllerApiConstants.OWNER, "owner"));
       params.add(new BasicNameValuePair(ControllerApiConstants.KEY_SCHEMA, keySchema));
       params.add(new BasicNameValuePair(ControllerApiConstants.VALUE_SCHEMA, valueSchema));
-      final HttpPost post = new HttpPost(cluster.getAllControllersURLs() + ControllerRoute.NEW_STORE.getPath());
+      final HttpPost post = new HttpPost(venice.getControllerConnectString() + ControllerRoute.NEW_STORE.getPath());
       post.setEntity(new UrlEncodedFormEntity(params));
       HttpResponse duplicateStoreCreationHttpResponse = httpClient.execute(post, null).get();
       Assert.assertEquals(
@@ -195,13 +212,13 @@ public class TestAdminSparkServer extends AbstractTestAdminSparkServer {
     SchemaResponse sr0 = controllerClient.getKeySchema(storeToCreate);
     Assert.assertTrue(sr0.isError());
     // Create Store
-    NewStoreResponse newStoreResponse =
-        controllerClient.createNewStore(storeToCreate, "owner", keySchemaStr, valueSchemaStr);
+    assertCommand(parentControllerClient.createNewStore(storeToCreate, "owner", keySchemaStr, valueSchemaStr));
     try {
-      Assert.assertFalse(newStoreResponse.isError(), "create new store should succeed for a store that doesn't exist");
-      SchemaResponse sr1 = controllerClient.getKeySchema(storeToCreate);
-      Assert.assertEquals(sr1.getId(), 1);
-      Assert.assertEquals(sr1.getSchemaStr(), keySchemaStr);
+      TestUtils.waitForNonDeterministicAssertion(10, TimeUnit.SECONDS, false, true, () -> {
+        SchemaResponse sr1 = assertCommand(controllerClient.getKeySchema(storeToCreate));
+        Assert.assertEquals(sr1.getId(), 1);
+        Assert.assertEquals(sr1.getSchemaStr(), keySchemaStr);
+      });
     } finally {
       // clear the store since the cluster is shared by other test cases
       deleteStore(storeToCreate);
@@ -238,28 +255,29 @@ public class TestAdminSparkServer extends AbstractTestAdminSparkServer {
     String incompatibleSchema = "\"string\"";
 
     // Add value schema to non-existed store
-    SchemaResponse sr0 = controllerClient.addValueSchema(storeToCreate, schema1);
+    SchemaResponse sr0 = parentControllerClient.addValueSchema(storeToCreate, schema1);
     Assert.assertTrue(sr0.isError());
     // Add value schema to an existing store
-    NewStoreResponse newStoreResponse = controllerClient.createNewStore(storeToCreate, "owner", keySchemaStr, schema1);
+    NewStoreResponse newStoreResponse =
+        parentControllerClient.createNewStore(storeToCreate, "owner", keySchemaStr, schema1);
     Assert.assertFalse(newStoreResponse.isError(), "create new store should succeed for a store that doesn't exist");
     try {
-      SchemaResponse sr1 = controllerClient.addValueSchema(storeToCreate, schema1);
+      SchemaResponse sr1 = parentControllerClient.addValueSchema(storeToCreate, schema1);
       Assert.assertFalse(sr1.isError());
       Assert.assertEquals(sr1.getId(), 1);
       // Add same value schema
-      SchemaResponse sr2 = controllerClient.addValueSchema(storeToCreate, schema1);
+      SchemaResponse sr2 = parentControllerClient.addValueSchema(storeToCreate, schema1);
       Assert.assertFalse(sr2.isError());
       Assert.assertEquals(sr2.getId(), sr1.getId());
       // Add a new value schema
-      SchemaResponse sr3 = controllerClient.addValueSchema(storeToCreate, schema2);
+      SchemaResponse sr3 = parentControllerClient.addValueSchema(storeToCreate, schema2);
       Assert.assertFalse(sr3.isError());
       Assert.assertEquals(sr3.getId(), 2);
       // Add invalid schema
-      SchemaResponse sr4 = controllerClient.addValueSchema(storeToCreate, invalidSchema);
+      SchemaResponse sr4 = parentControllerClient.addValueSchema(storeToCreate, invalidSchema);
       Assert.assertTrue(sr4.isError());
       // Add incompatible schema
-      SchemaResponse sr5 = controllerClient.addValueSchema(storeToCreate, incompatibleSchema);
+      SchemaResponse sr5 = parentControllerClient.addValueSchema(storeToCreate, incompatibleSchema);
       Assert.assertTrue(sr5.isError());
       Assert.assertEquals(sr5.getErrorType(), ErrorType.INVALID_SCHEMA);
       Assert.assertEquals(sr5.getExceptionType(), ExceptionType.INVALID_SCHEMA);
@@ -268,30 +286,30 @@ public class TestAdminSparkServer extends AbstractTestAdminSparkServer {
       String formattedSchemaStr1 = formatSchema(schema1);
       String formattedSchemaStr2 = formatSchema(schema2);
       // Get schema by id
-      SchemaResponse sr6 = controllerClient.getValueSchema(storeToCreate, 1);
+      SchemaResponse sr6 = parentControllerClient.getValueSchema(storeToCreate, 1);
       Assert.assertFalse(sr6.isError());
       Assert.assertEquals(sr6.getSchemaStr(), formattedSchemaStr1);
-      SchemaResponse sr7 = controllerClient.getValueSchema(storeToCreate, 2);
+      SchemaResponse sr7 = parentControllerClient.getValueSchema(storeToCreate, 2);
       Assert.assertFalse(sr7.isError());
       Assert.assertEquals(sr7.getSchemaStr(), formattedSchemaStr2);
       // Get schema by non-existed schema id
-      SchemaResponse sr8 = controllerClient.getValueSchema(storeToCreate, 3);
+      SchemaResponse sr8 = parentControllerClient.getValueSchema(storeToCreate, 3);
       Assert.assertTrue(sr8.isError());
 
       // Get value schema by schema
-      SchemaResponse sr9 = controllerClient.getValueSchemaID(storeToCreate, schema1);
+      SchemaResponse sr9 = parentControllerClient.getValueSchemaID(storeToCreate, schema1);
       Assert.assertFalse(sr9.isError());
       Assert.assertEquals(sr9.getId(), 1);
-      SchemaResponse sr10 = controllerClient.getValueSchemaID(storeToCreate, schema2);
+      SchemaResponse sr10 = parentControllerClient.getValueSchemaID(storeToCreate, schema2);
       Assert.assertFalse(sr10.isError());
       Assert.assertEquals(sr10.getId(), 2);
-      SchemaResponse sr11 = controllerClient.getValueSchemaID(storeToCreate, invalidSchema);
+      SchemaResponse sr11 = parentControllerClient.getValueSchemaID(storeToCreate, invalidSchema);
       Assert.assertTrue(sr11.isError());
-      SchemaResponse sr12 = controllerClient.getValueSchemaID(storeToCreate, incompatibleSchema);
+      SchemaResponse sr12 = parentControllerClient.getValueSchemaID(storeToCreate, incompatibleSchema);
       Assert.assertTrue(sr12.isError());
 
       // Get all value schema
-      MultiSchemaResponse msr = controllerClient.getAllValueSchema(storeToCreate);
+      MultiSchemaResponse msr = parentControllerClient.getAllValueSchema(storeToCreate);
       Assert.assertFalse(msr.isError());
       MultiSchemaResponse.Schema[] schemas = msr.getSchemas();
       Assert.assertEquals(schemas.length, 2);
@@ -307,19 +325,19 @@ public class TestAdminSparkServer extends AbstractTestAdminSparkServer {
       String prefixForLotsOfSchemas = schemaPrefix + salaryFieldWithDefault;
 
       // add incorrect schema
-      sr1 = controllerClient.addValueSchema(storeToCreate, schemaStr);
+      sr1 = parentControllerClient.addValueSchema(storeToCreate, schemaStr);
       Assert.assertTrue(sr1.isError());
       for (int i = 3; i < allSchemas.length; i++) {
         prefixForLotsOfSchemas +=
             "," + "               {\"name\": \"newField" + i + "\", \"type\": \"long\", \"default\": 123 }\n";
         String schema = formatSchema(prefixForLotsOfSchemas + schemaSuffix);
         allSchemas[i - 1] = schema;
-        SchemaResponse sr = controllerClient.addValueSchema(storeToCreate, schema);
+        SchemaResponse sr = parentControllerClient.addValueSchema(storeToCreate, schema);
         Assert.assertFalse(sr.isError());
         Assert.assertEquals(sr.getId(), i);
 
         // At each new schema we create, we test that the ordering is correct
-        MultiSchemaResponse msr2 = controllerClient.getAllValueSchema(storeToCreate);
+        MultiSchemaResponse msr2 = parentControllerClient.getAllValueSchema(storeToCreate);
         Assert.assertFalse(msr2.isError());
         MultiSchemaResponse.Schema[] schemasFromController = msr2.getSchemas();
         Assert.assertEquals(
@@ -361,8 +379,11 @@ public class TestAdminSparkServer extends AbstractTestAdminSparkServer {
 
   @Test(timeOut = TEST_TIMEOUT)
   public void controllerClientCanGetStoreInfo() {
-    String topic = cluster.getNewStoreVersion().getKafkaTopic();
-    String storeName = Version.parseStoreFromKafkaTopicName(topic);
+    String storeName = Utils.getUniqueString("test-store");
+    assertCommand(parentControllerClient.createNewStore(storeName, "owner", "\"string\"", "\"string\""));
+    VersionCreationResponse versionCreationResponse =
+        parentControllerClient.emptyPush(storeName, Utils.getUniqueString(storeName), 1024);
+    Assert.assertFalse(versionCreationResponse.isError(), versionCreationResponse.getError());
     try {
       StoreResponse storeResponse = controllerClient.getStore(storeName);
       Assert.assertFalse(storeResponse.isError(), storeResponse.getError());
@@ -384,8 +405,11 @@ public class TestAdminSparkServer extends AbstractTestAdminSparkServer {
 
   @Test(timeOut = TEST_TIMEOUT)
   public void controllerClientCanDisableStoresWrite() {
-    String topic = cluster.getNewStoreVersion().getKafkaTopic();
-    String storeName = Version.parseStoreFromKafkaTopicName(topic);
+    String storeName = Utils.getUniqueString("test-store");
+    assertCommand(parentControllerClient.createNewStore(storeName, "owner", "\"string\"", "\"string\""));
+    VersionCreationResponse versionCreationResponse =
+        parentControllerClient.emptyPush(storeName, Utils.getUniqueString(storeName), 1024);
+    Assert.assertFalse(versionCreationResponse.isError(), versionCreationResponse.getError());
     try {
       StoreInfo store = controllerClient.getStore(storeName).getStore();
       Assert.assertTrue(store.isEnableStoreWrites(), "Store should NOT be disabled after creating new store-version");
@@ -402,10 +426,11 @@ public class TestAdminSparkServer extends AbstractTestAdminSparkServer {
 
   @Test(timeOut = TEST_TIMEOUT)
   public void controllerClientCanDisableStoresRead() {
-    String topic = cluster.getNewStoreVersion().getKafkaTopic();
-
-    String storeName = Version.parseStoreFromKafkaTopicName(topic);
-
+    String storeName = Utils.getUniqueString("test-store");
+    assertCommand(parentControllerClient.createNewStore(storeName, "owner", "\"string\"", "\"string\""));
+    VersionCreationResponse versionCreationResponse =
+        parentControllerClient.emptyPush(storeName, Utils.getUniqueString(storeName), 1024);
+    Assert.assertFalse(versionCreationResponse.isError(), versionCreationResponse.getError());
     try {
       StoreInfo store = controllerClient.getStore(storeName).getStore();
       Assert.assertTrue(store.isEnableStoreReads(), "Store should NOT be disabled after creating new store-version");
@@ -423,9 +448,11 @@ public class TestAdminSparkServer extends AbstractTestAdminSparkServer {
 
   @Test(timeOut = TEST_TIMEOUT)
   public void controllerClientCanDisableStoresReadWrite() {
-    String topic = cluster.getNewStoreVersion().getKafkaTopic();
-
-    String storeName = Version.parseStoreFromKafkaTopicName(topic);
+    String storeName = Utils.getUniqueString("test-store");
+    assertCommand(parentControllerClient.createNewStore(storeName, "owner", "\"string\"", "\"string\""));
+    VersionCreationResponse versionCreationResponse =
+        parentControllerClient.emptyPush(storeName, Utils.getUniqueString(storeName), 1024);
+    Assert.assertFalse(versionCreationResponse.isError(), versionCreationResponse.getError());
     try {
       StoreInfo store = controllerClient.getStore(storeName).getStore();
       Assert.assertTrue(store.isEnableStoreReads(), "Store should NOT be disabled after creating new store-version");
@@ -448,7 +475,10 @@ public class TestAdminSparkServer extends AbstractTestAdminSparkServer {
     String owner = Utils.getUniqueString("owner");
     int partitionCount = 2;
 
-    cluster.getNewStore(storeName);
+    assertCommand(parentControllerClient.createNewStore(storeName, owner, "\"string\"", "\"string\""));
+    VersionCreationResponse versionCreationResponse =
+        parentControllerClient.emptyPush(storeName, Utils.getUniqueString(storeName), 1024);
+    Assert.assertFalse(versionCreationResponse.isError(), versionCreationResponse.getError());
     try {
       OwnerResponse ownerRes = controllerClient.setStoreOwner(storeName, owner);
       Assert.assertFalse(ownerRes.isError(), ownerRes.getError());
@@ -456,12 +486,14 @@ public class TestAdminSparkServer extends AbstractTestAdminSparkServer {
 
       UpdateStoreQueryParams updateStoreQueryParams =
           new UpdateStoreQueryParams().setPartitionCount(partitionCount).setIncrementalPushEnabled(true);
-      ControllerResponse partitionRes = controllerClient.updateStore(storeName, updateStoreQueryParams);
+      ControllerResponse partitionRes = parentControllerClient.updateStore(storeName, updateStoreQueryParams);
       Assert.assertFalse(partitionRes.isError(), partitionRes.getError());
 
-      StoreResponse storeResponse = controllerClient.getStore(storeName);
-      Assert.assertEquals(storeResponse.getStore().getPartitionCount(), partitionCount);
-      Assert.assertEquals(storeResponse.getStore().isIncrementalPushEnabled(), true);
+      TestUtils.waitForNonDeterministicAssertion(10, TimeUnit.SECONDS, false, true, () -> {
+        StoreResponse storeResponse = controllerClient.getStore(storeName);
+        Assert.assertEquals(storeResponse.getStore().getPartitionCount(), partitionCount);
+        Assert.assertTrue(storeResponse.getStore().isIncrementalPushEnabled());
+      });
     } finally {
       deleteStore(storeName);
     }
@@ -469,7 +501,10 @@ public class TestAdminSparkServer extends AbstractTestAdminSparkServer {
 
   @Test(timeOut = TEST_TIMEOUT)
   public void controllerClientCanQueryRemovability() {
-    VeniceServerWrapper server = cluster.getVeniceServers().get(0);
+    VeniceMultiClusterWrapper multiClusterWrapper = venice.getChildRegions().get(0);
+    String clusterName = multiClusterWrapper.getClusterNames()[0];
+    VeniceClusterWrapper venice = multiClusterWrapper.getClusters().get(clusterName);
+    VeniceServerWrapper server = venice.getVeniceServers().get(0);
     String nodeId = Utils.getHelixNodeIdentifier(Utils.getHostName(), server.getPort());
 
     ControllerResponse response = controllerClient.isNodeRemovable(nodeId);
@@ -478,7 +513,11 @@ public class TestAdminSparkServer extends AbstractTestAdminSparkServer {
 
   @Test(timeOut = TEST_TIMEOUT)
   public void controllerClientCanDeleteAllVersion() {
-    String storeName = cluster.getNewStoreVersion().getName();
+    String storeName = Utils.getUniqueString("test-store");
+    assertCommand(parentControllerClient.createNewStore(storeName, "owner", "\"string\"", "\"string\""));
+    VersionCreationResponse versionCreationResponse =
+        parentControllerClient.emptyPush(storeName, Utils.getUniqueString(storeName), 1024);
+    Assert.assertFalse(versionCreationResponse.isError(), versionCreationResponse.getError());
     try {
       controllerClient.enableStoreReads(storeName, false);
       controllerClient.enableStoreWrites(storeName, false);
@@ -500,7 +539,11 @@ public class TestAdminSparkServer extends AbstractTestAdminSparkServer {
 
   @Test(timeOut = TEST_TIMEOUT)
   public void controllerClientCanDeleteOldVersion() {
-    String storeName = cluster.getNewStoreVersion().getName();
+    String storeName = Utils.getUniqueString("test-store");
+    assertCommand(parentControllerClient.createNewStore(storeName, "owner", "\"string\"", "\"string\""));
+    VersionCreationResponse versionCreationResponse =
+        parentControllerClient.emptyPush(storeName, Utils.getUniqueString(storeName), 1024);
+    Assert.assertFalse(versionCreationResponse.isError(), versionCreationResponse.getError());
     try {
       VersionResponse response = controllerClient.deleteOldVersion(storeName, 1);
       Assert.assertFalse(response.isError(), response.getError());
@@ -522,7 +565,7 @@ public class TestAdminSparkServer extends AbstractTestAdminSparkServer {
 
   @Test(timeOut = TEST_TIMEOUT)
   public void controllerClientCanGetExecutionOfDeleteAllVersions() {
-    String clusterName = cluster.getClusterName();
+    String clusterName = venice.getClusterNames()[0];
     String storeName = Utils.getUniqueString("controllerClientCanDeleteAllVersion");
 
     parentController.getVeniceAdmin().createStore(clusterName, storeName, "test", "\"string\"", "\"string\"");
@@ -551,39 +594,41 @@ public class TestAdminSparkServer extends AbstractTestAdminSparkServer {
     String storePrefix = "controllerClientCanListStoresStatusesTestStore";
     int storeCount = 2;
     for (int i = 0; i < storeCount; i++) {
-      storeNames.add(cluster.getNewStore(storePrefix + i).getName());
+      String storeName = Utils.getUniqueString(storePrefix);
+      assertCommand(parentControllerClient.createNewStore(storeName, "owner", "\"string\"", "\"string\""));
+      storeNames.add(storeName);
     }
 
     try {
-      MultiStoreStatusResponse storeResponse = controllerClient.listStoresStatuses();
-      Assert.assertFalse(storeResponse.isError());
-      // since all test cases share VeniceClusterWrapper, we get the total number of stores from the Wrapper.
-      List<String> storesInCluster =
-          storeResponse.getStoreStatusMap().entrySet().stream().map(e -> e.getKey()).collect(Collectors.toList());
-      for (String storeName: storeNames) {
-        Assert.assertTrue(
-            storesInCluster.contains(storeName),
-            "Result of listing store status should contain all stores we created.");
-      }
-      List<String> storeStatuses = storeResponse.getStoreStatusMap()
-          .entrySet()
-          .stream()
-          .filter(e -> e.getKey().contains(storePrefix))
-          .map(Map.Entry::getValue)
-          .collect(Collectors.toList());
-      Assert.assertTrue(storeStatuses.size() == storeCount);
-      for (String status: storeStatuses) {
-        Assert.assertEquals(
-            status,
-            StoreStatus.UNAVAILABLE.toString(),
-            "Store should be unavailable because we have not created a version for this store. "
-                + storeResponse.getStoreStatusMap());
-      }
-      for (String expectedStore: storeNames) {
-        Assert.assertTrue(
-            storeResponse.getStoreStatusMap().containsKey(expectedStore),
-            "Result of list store status should contain the store we created: " + expectedStore);
-      }
+      TestUtils.waitForNonDeterministicAssertion(10, TimeUnit.SECONDS, false, true, () -> {
+        MultiStoreStatusResponse storeResponse = assertCommand(controllerClient.listStoresStatuses());
+        // since all test cases share VeniceClusterWrapper, we get the total number of stores from the Wrapper.
+        List<String> storesInCluster = new ArrayList<>(storeResponse.getStoreStatusMap().keySet());
+        for (String storeName: storeNames) {
+          Assert.assertTrue(
+              storesInCluster.contains(storeName),
+              "Result of listing store status should contain all stores we created.");
+        }
+        List<String> storeStatuses = storeResponse.getStoreStatusMap()
+            .entrySet()
+            .stream()
+            .filter(e -> e.getKey().contains(storePrefix))
+            .map(Map.Entry::getValue)
+            .collect(Collectors.toList());
+        Assert.assertEquals(storeStatuses.size(), storeCount);
+        for (String status: storeStatuses) {
+          Assert.assertEquals(
+              status,
+              StoreStatus.UNAVAILABLE.toString(),
+              "Store should be unavailable because we have not created a version for this store. "
+                  + storeResponse.getStoreStatusMap());
+        }
+        for (String expectedStore: storeNames) {
+          Assert.assertTrue(
+              storeResponse.getStoreStatusMap().containsKey(expectedStore),
+              "Result of list store status should contain the store we created: " + expectedStore);
+        }
+      });
     } finally {
       storeNames.forEach(this::deleteStore);
     }
@@ -591,13 +636,17 @@ public class TestAdminSparkServer extends AbstractTestAdminSparkServer {
 
   @Test(timeOut = TEST_TIMEOUT)
   public void controllerClientCanListFutureStoreVersions() {
+    String clusterName = venice.getClusterNames()[0];
     List<String> storeNames = new ArrayList<>();
     try {
-      ControllerClient parentControllerClient = ControllerClient
-          .constructClusterControllerClient(cluster.getClusterName(), parentController.getControllerUrl());
-      storeNames.add(parentControllerClient.createNewStore("testStore", "owner", "\"string\"", "\"string\"").getName());
+      ControllerClient parentControllerClient =
+          ControllerClient.constructClusterControllerClient(clusterName, parentController.getControllerUrl());
+      String storeName = Utils.getUniqueString("testStore");
+      NewStoreResponse newStoreResponse =
+          assertCommand(parentControllerClient.createNewStore(storeName, "owner", "\"string\"", "\"string\""));
+      storeNames.add(newStoreResponse.getName());
       MultiStoreStatusResponse storeResponse =
-          parentControllerClient.getFutureVersions(cluster.getClusterName(), storeNames.get(0));
+          assertCommand(parentControllerClient.getFutureVersions(clusterName, storeNames.get(0)));
 
       // There's no version for this store and no future version coming, so we expect an entry with
       // Store.NON_EXISTING_VERSION
@@ -610,20 +659,16 @@ public class TestAdminSparkServer extends AbstractTestAdminSparkServer {
 
   @Test(timeOut = TEST_TIMEOUT)
   public void controllerClientCanUpdateAllowList() {
-    Admin admin = cluster.getLeaderVeniceController().getVeniceAdmin();
+    String clusterName = venice.getClusterNames()[0];
+    Admin admin = venice.getChildRegions().get(0).getLeaderController(clusterName).getVeniceAdmin();
 
     String nodeId = Utils.getHelixNodeIdentifier(Utils.getHostName(), 34567);
-    Assert.assertFalse(
-        admin.getAllowlist(cluster.getClusterName()).contains(nodeId),
-        nodeId + " has not been added into allowlist.");
+    Assert
+        .assertFalse(admin.getAllowlist(clusterName).contains(nodeId), nodeId + " has not been added into allowlist.");
     controllerClient.addNodeIntoAllowList(nodeId);
-    Assert.assertTrue(
-        admin.getAllowlist(cluster.getClusterName()).contains(nodeId),
-        nodeId + " has been added into allowlist.");
+    Assert.assertTrue(admin.getAllowlist(clusterName).contains(nodeId), nodeId + " has been added into allowlist.");
     controllerClient.removeNodeFromAllowList(nodeId);
-    Assert.assertFalse(
-        admin.getAllowlist(cluster.getClusterName()).contains(nodeId),
-        nodeId + " has been removed from allowlist.");
+    Assert.assertFalse(admin.getAllowlist(clusterName).contains(nodeId), nodeId + " has been removed from allowlist.");
   }
 
   @Test(timeOut = TEST_TIMEOUT)
@@ -639,7 +684,11 @@ public class TestAdminSparkServer extends AbstractTestAdminSparkServer {
     long readQuotaInCU = 200l;
     int numVersionToPreserve = 100;
 
-    String storeName = cluster.getNewStoreVersion().getName();
+    String storeName = Utils.getUniqueString("test-store");
+    assertCommand(parentControllerClient.createNewStore(storeName, "owner", "\"string\"", "\"string\""));
+    VersionCreationResponse versionCreationResponse =
+        parentControllerClient.emptyPush(storeName, Utils.getUniqueString(storeName), 1024);
+    Assert.assertFalse(versionCreationResponse.isError(), versionCreationResponse.getError());
     // Disable writes at first and test could we enable writes again through the update store method.
     Assert.assertFalse(
         controllerClient.enableStoreReadWrites(storeName, false).isError(),
@@ -654,6 +703,10 @@ public class TestAdminSparkServer extends AbstractTestAdminSparkServer {
         .setReadQuotaInCU(readQuotaInCU)
         .setAccessControlled(accessControlled)
         .setNumVersionsToPreserve(numVersionToPreserve);
+
+    VeniceMultiClusterWrapper multiClusterWrapper = venice.getChildRegions().get(0);
+    String clusterName = venice.getClusterNames()[0];
+    VeniceClusterWrapper cluster = multiClusterWrapper.getClusters().get(clusterName);
 
     try {
       ControllerResponse response = controllerClient.updateStore(storeName, queryParams);
@@ -691,7 +744,11 @@ public class TestAdminSparkServer extends AbstractTestAdminSparkServer {
       int current = 1;
       boolean enableReads = false;
 
-      storeName = cluster.getNewStoreVersion().getName();
+      storeName = Utils.getUniqueString("test-store");
+      assertCommand(parentControllerClient.createNewStore(storeName, "owner", "\"string\"", "\"string\""));
+      VersionCreationResponse versionCreationResponse =
+          parentControllerClient.emptyPush(storeName, Utils.getUniqueString(storeName), 1024);
+      Assert.assertFalse(versionCreationResponse.isError(), versionCreationResponse.getError());
       ControllerResponse response = controllerClient.updateStore(
           storeName,
           new UpdateStoreQueryParams().setPartitionCount(partitionCount)
@@ -699,10 +756,10 @@ public class TestAdminSparkServer extends AbstractTestAdminSparkServer {
               .setEnableReads(enableReads));
 
       Assert.assertFalse(response.isError(), response.getError());
-      Store store = cluster.getLeaderVeniceController().getVeniceAdmin().getStore(cluster.getClusterName(), storeName);
+      StoreInfo store = controllerClient.getStore(storeName).getStore();
       Assert.assertEquals(store.getPartitionCount(), partitionCount);
       Assert.assertEquals(store.getCurrentVersion(), current);
-      Assert.assertEquals(store.isEnableReads(), enableReads);
+      Assert.assertEquals(store.isEnableStoreReads(), enableReads);
     } finally {
       if (storeName != null) {
         deleteStore(storeName);
@@ -714,14 +771,19 @@ public class TestAdminSparkServer extends AbstractTestAdminSparkServer {
   public void canCreateAHybridStore() {
     String storeName = Utils.getUniqueString("store");
     String owner = Utils.getUniqueString("owner");
-    controllerClient.createNewStore(storeName, owner, "\"string\"", "\"string\"");
+    parentControllerClient.createNewStore(storeName, owner, "\"string\"", "\"string\"");
     try {
-      controllerClient.updateStore(
+      parentControllerClient.updateStore(
           storeName,
           new UpdateStoreQueryParams().setHybridRewindSeconds(123L).setHybridOffsetLagThreshold(1515L));
-      StoreResponse storeResponse = controllerClient.getStore(storeName);
-      Assert.assertEquals(storeResponse.getStore().getHybridStoreConfig().getRewindTimeInSeconds(), 123L);
-      Assert.assertEquals(storeResponse.getStore().getHybridStoreConfig().getOffsetLagThresholdToGoOnline(), 1515L);
+
+      TestUtils.waitForNonDeterministicAssertion(10, TimeUnit.SECONDS, false, true, () -> {
+        StoreResponse storeResponse = controllerClient.getStore(storeName);
+        HybridStoreConfig hybridStoreConfig = storeResponse.getStore().getHybridStoreConfig();
+        Assert.assertNotNull(hybridStoreConfig);
+        Assert.assertEquals(hybridStoreConfig.getRewindTimeInSeconds(), 123L);
+        Assert.assertEquals(hybridStoreConfig.getOffsetLagThresholdToGoOnline(), 1515L);
+      });
     } finally {
       deleteStore(storeName);
     }
@@ -729,7 +791,11 @@ public class TestAdminSparkServer extends AbstractTestAdminSparkServer {
 
   @Test(timeOut = TEST_TIMEOUT)
   public void controllerClientCanGetStorageEngineOverheadRatio() {
-    String storeName = cluster.getNewStoreVersion().getName();
+    String storeName = Utils.getUniqueString("test-store");
+    assertCommand(parentControllerClient.createNewStore(storeName, "owner", "\"string\"", "\"string\""));
+    VersionCreationResponse versionCreationResponse =
+        parentControllerClient.emptyPush(storeName, Utils.getUniqueString(storeName), 1024);
+    Assert.assertFalse(versionCreationResponse.isError(), versionCreationResponse.getError());
     try {
       StorageEngineOverheadRatioResponse response = controllerClient.getStorageEngineOverheadRatio(storeName);
 
@@ -744,7 +810,11 @@ public class TestAdminSparkServer extends AbstractTestAdminSparkServer {
 
   @Test(timeOut = TEST_TIMEOUT)
   public void controllerClientCanDeleteStore() {
-    String storeName = cluster.getNewStoreVersion().getName();
+    String storeName = Utils.getUniqueString("test-store");
+    assertCommand(parentControllerClient.createNewStore(storeName, "owner", "\"string\"", "\"string\""));
+    VersionCreationResponse versionCreationResponse =
+        parentControllerClient.emptyPush(storeName, Utils.getUniqueString(storeName), 1024);
+    Assert.assertFalse(versionCreationResponse.isError(), versionCreationResponse.getError());
     try {
       controllerClient.enableStoreReads(storeName, false);
       controllerClient.enableStoreWrites(storeName, false);
@@ -765,7 +835,7 @@ public class TestAdminSparkServer extends AbstractTestAdminSparkServer {
 
   @Test(timeOut = TEST_TIMEOUT)
   public void controllerClientCanGetExecutionOfDeleteStore() {
-    String clusterName = cluster.getClusterName();
+    String clusterName = venice.getClusterNames()[0];
 
     String storeName = Utils.getUniqueString("controllerClientCanGetExecutionOfDeleteStore");
     parentController.getVeniceAdmin().createStore(clusterName, storeName, "test", "\"string\"", "\"string\"");
@@ -837,7 +907,6 @@ public class TestAdminSparkServer extends AbstractTestAdminSparkServer {
     Assert.assertFalse(controllerClient.getRoutersClusterConfig().getConfig().isThrottlingEnabled());
     controllerClient.enableThrottling(true);
     Assert.assertTrue(controllerClient.getRoutersClusterConfig().getConfig().isThrottlingEnabled());
-
   }
 
   @Test(timeOut = TEST_TIMEOUT)
@@ -852,12 +921,17 @@ public class TestAdminSparkServer extends AbstractTestAdminSparkServer {
   public void controllerClientCanDiscoverCluster() {
     String storeName = Utils.getUniqueString("controllerClientCanDiscoverCluster");
     controllerClient.createNewStore(storeName, "test", "\"string\"", "\"string\"");
+    String clusterName = venice.getClusterNames()[0];
     try {
       Assert.assertEquals(
           ControllerClient
-              .discoverCluster(cluster.getLeaderVeniceController().getControllerUrl(), storeName, Optional.empty(), 1)
+              .discoverCluster(
+                  venice.getChildRegions().get(0).getControllerConnectString(),
+                  storeName,
+                  Optional.empty(),
+                  1)
               .getCluster(),
-          cluster.getClusterName(),
+          clusterName,
           "Should be able to find the cluster which the given store belongs to.");
     } finally {
       deleteStore(storeName);
@@ -874,9 +948,9 @@ public class TestAdminSparkServer extends AbstractTestAdminSparkServer {
 
     String largeDictionary = EncodingUtils.base64EncodeToString(largeDictionaryBytes);
 
-    controllerClient.createNewStore(storeName, "test", "\"string\"", "\"string\"");
+    parentControllerClient.createNewStore(storeName, "test", "\"string\"", "\"string\"");
 
-    VersionCreationResponse vcr = controllerClient.requestTopicForWrites(
+    VersionCreationResponse vcr = parentControllerClient.requestTopicForWrites(
         storeName,
         1L,
         Version.PushType.BATCH,
@@ -896,51 +970,47 @@ public class TestAdminSparkServer extends AbstractTestAdminSparkServer {
 
   @Test(timeOut = TEST_TIMEOUT)
   public void controllerCanGetDeletableStoreTopics() {
-    // The parent controller here is sharing the same kafka as child controllers.
     String storeName = Utils.getUniqueString("canGetDeletableStoreTopics");
-    ControllerClient parentControllerClient =
-        new ControllerClient(cluster.getClusterName(), parentController.getControllerUrl());
+    String clusterName = venice.getClusterNames()[0];
+    ControllerClient parentControllerClient = new ControllerClient(clusterName, parentController.getControllerUrl());
     try {
-      Assert
-          .assertFalse(parentControllerClient.createNewStore(storeName, "test", "\"string\"", "\"string\"").isError());
+      assertCommand(parentControllerClient.createNewStore(storeName, "test", "\"string\"", "\"string\""));
       String metaSystemStoreName = VeniceSystemStoreType.META_STORE.getSystemStoreName(storeName);
       // Add some system store and RT topics in the mix to make sure the request can still return the right values.
-      Assert
-          .assertFalse(parentControllerClient.emptyPush(metaSystemStoreName, "meta-store-push-1", 1024000L).isError());
-      Assert.assertFalse(parentControllerClient.emptyPush(storeName, "push-1", 1024000L).isError());
+      assertCommand(parentControllerClient.emptyPush(metaSystemStoreName, "meta-store-push-1", 1024000L));
+
+      assertCommand(parentControllerClient.emptyPush(storeName, "push-1", 1024000L));
       // Store version topic v1 should be truncated after polling for completion by parent controller.
       TestUtils.waitForNonDeterministicPushCompletion(
           Version.composeKafkaTopic(storeName, 1),
           parentControllerClient,
           10,
           TimeUnit.SECONDS);
-      Assert.assertFalse(parentControllerClient.emptyPush(storeName, "push-2", 1024000L).isError());
+
+      assertCommand(parentControllerClient.emptyPush(storeName, "push-2", 1024000L));
       TestUtils.waitForNonDeterministicPushCompletion(
           Version.composeKafkaTopic(storeName, 2),
-          controllerClient,
+          parentControllerClient,
           10,
           TimeUnit.SECONDS);
-      Assert.assertFalse(parentControllerClient.deleteOldVersion(storeName, 1).isError());
-      MultiStoreTopicsResponse parentMultiStoreTopicResponse = parentControllerClient.getDeletableStoreTopics();
-      Assert.assertFalse(parentMultiStoreTopicResponse.isError());
-      Assert.assertTrue(parentMultiStoreTopicResponse.getTopics().contains(Version.composeKafkaTopic(storeName, 1)));
-      Assert.assertFalse(parentMultiStoreTopicResponse.getTopics().contains(Version.composeKafkaTopic(storeName, 2)));
-      Assert.assertFalse(
-          parentMultiStoreTopicResponse.getTopics().contains(Version.composeKafkaTopic(metaSystemStoreName, 1)));
-      Assert.assertFalse(
-          parentMultiStoreTopicResponse.getTopics().contains(Version.composeRealTimeTopic(metaSystemStoreName)));
-      // Child fabric should return the same result since they are sharing kafka. Wait for resource of v1 to be cleaned
-      // up since for child fabric we only consider a topic is deletable if its resource is deleted.
+      assertCommand(parentControllerClient.deleteOldVersion(storeName, 1));
+      // Wait for resource of v1 to be cleaned up since for child fabric we only consider a topic is deletable if its
+      // resource is deleted.
       TestUtils.waitForNonDeterministicAssertion(10, TimeUnit.SECONDS, () -> {
         Assert.assertFalse(
-            cluster.getLeaderVeniceController()
+            venice.getChildRegions()
+                .get(0)
+                .getLeaderController(clusterName)
                 .getVeniceAdmin()
                 .isResourceStillAlive(Version.composeKafkaTopic(storeName, 1)));
       });
-      MultiStoreTopicsResponse childMultiStoreTopicResponse = controllerClient.getDeletableStoreTopics();
-      Assert.assertFalse(childMultiStoreTopicResponse.isError());
+      MultiStoreTopicsResponse childMultiStoreTopicResponse = assertCommand(controllerClient.getDeletableStoreTopics());
       Assert.assertTrue(childMultiStoreTopicResponse.getTopics().contains(Version.composeKafkaTopic(storeName, 1)));
       Assert.assertFalse(childMultiStoreTopicResponse.getTopics().contains(Version.composeKafkaTopic(storeName, 2)));
+      Assert.assertFalse(
+          childMultiStoreTopicResponse.getTopics().contains(Version.composeKafkaTopic(metaSystemStoreName, 1)));
+      Assert.assertFalse(
+          childMultiStoreTopicResponse.getTopics().contains(Version.composeRealTimeTopic(metaSystemStoreName)));
     } finally {
       deleteStore(parentControllerClient, storeName);
       parentControllerClient.close();
@@ -955,35 +1025,45 @@ public class TestAdminSparkServer extends AbstractTestAdminSparkServer {
 
   @Test(timeOut = TEST_TIMEOUT)
   public void testDeleteKafkaTopic() {
-    String clusterName = cluster.getClusterName();
+    String clusterName = venice.getClusterNames()[0];
     String storeName = Utils.getUniqueString("controllerClientCanDeleteKafkaTopic");
-    VeniceHelixAdmin childControllerAdmin = cluster.getRandomVeniceController().getVeniceHelixAdmin();
-    childControllerAdmin.createStore(clusterName, storeName, "test", "\"string\"", "\"string\"");
-    childControllerAdmin.updateStore(
-        clusterName,
-        storeName,
-        new UpdateStoreQueryParams().setHybridRewindSeconds(1000).setHybridOffsetLagThreshold(1));
-    childControllerAdmin.incrementVersionIdempotent(clusterName, storeName, "test", 1, 1);
+    assertCommand(parentControllerClient.createNewStore(storeName, "owner", "\"string\"", "\"string\""));
+    assertCommand(
+        parentControllerClient.updateStore(
+            storeName,
+            new UpdateStoreQueryParams().setHybridRewindSeconds(1000).setHybridOffsetLagThreshold(1)));
+    assertCommand(parentControllerClient.emptyPush(storeName, Utils.getUniqueString(storeName), 1));
     String topicToDelete = Version.composeKafkaTopic(storeName, 1);
+
+    VeniceHelixAdmin childControllerAdmin =
+        venice.getChildRegions().get(0).getLeaderController(clusterName).getVeniceHelixAdmin();
     TestUtils.waitForNonDeterministicAssertion(30, TimeUnit.SECONDS, () -> {
+      LOGGER.info(
+          "childControllerAdmin.getTopicManager().listTopics(): {}",
+          childControllerAdmin.getTopicManager().listTopics());
       Assert.assertTrue(
           childControllerAdmin.getTopicManager()
-              .containsTopic(cluster.getPubSubTopicRepository().getTopic(topicToDelete)));
+              .containsTopic(
+                  venice.getChildRegions()
+                      .get(0)
+                      .getClusters()
+                      .get(clusterName)
+                      .getPubSubTopicRepository()
+                      .getTopic(topicToDelete)));
       Assert.assertFalse(childControllerAdmin.isTopicTruncated(topicToDelete));
     });
-    controllerClient.deleteKafkaTopic(topicToDelete);
+    assertCommand(controllerClient.deleteKafkaTopic(topicToDelete));
     Assert.assertTrue(childControllerAdmin.isTopicTruncated(topicToDelete));
   }
 
   @Test(timeOut = TEST_TIMEOUT)
   public void testCleanupInstanceCustomizedStates() {
-    String clusterName = cluster.getClusterName();
+    String clusterName = venice.getClusterNames()[0];
     String storeName = Utils.getUniqueString("cleanupInstanceCustomizedStatesTest");
-    VeniceHelixAdmin childControllerAdmin = cluster.getRandomVeniceController().getVeniceHelixAdmin();
+    VeniceHelixAdmin childControllerAdmin = venice.getChildRegions().get(0).getRandomController().getVeniceHelixAdmin();
     childControllerAdmin.createStore(clusterName, storeName, "test", "\"string\"", "\"string\"");
     Version version = childControllerAdmin.incrementVersionIdempotent(clusterName, storeName, "test", 1, 1);
-    MultiStoreTopicsResponse response = controllerClient.cleanupInstanceCustomizedStates();
-    Assert.assertFalse(response.isError());
+    MultiStoreTopicsResponse response = assertCommand(controllerClient.cleanupInstanceCustomizedStates());
     Assert.assertNotNull(response.getTopics());
     for (String topic: response.getTopics()) {
       Assert.assertFalse(topic.endsWith("/" + version.kafkaTopicName()));

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestHybrid.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestHybrid.java
@@ -2,7 +2,6 @@ package com.linkedin.venice.endToEnd;
 
 import static com.linkedin.davinci.store.rocksdb.RocksDBServerConfig.ROCKSDB_PLAIN_TABLE_FORMAT_ENABLED;
 import static com.linkedin.venice.ConfigKeys.DEFAULT_MAX_NUMBER_OF_PARTITIONS;
-import static com.linkedin.venice.ConfigKeys.INSTANCE_ID;
 import static com.linkedin.venice.ConfigKeys.KAFKA_BOOTSTRAP_SERVERS;
 import static com.linkedin.venice.ConfigKeys.PERSISTENCE_TYPE;
 import static com.linkedin.venice.ConfigKeys.SERVER_CONSUMER_POOL_SIZE_PER_KAFKA_CLUSTER;
@@ -30,7 +29,6 @@ import static com.linkedin.venice.utils.TestWriteUtils.STRING_SCHEMA;
 import static com.linkedin.venice.utils.TestWriteUtils.getTempDataDirectory;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
@@ -47,22 +45,16 @@ import com.linkedin.venice.compression.VeniceCompressor;
 import com.linkedin.venice.controller.Admin;
 import com.linkedin.venice.controllerapi.ControllerClient;
 import com.linkedin.venice.controllerapi.ControllerResponse;
-import com.linkedin.venice.controllerapi.JobStatusQueryResponse;
-import com.linkedin.venice.controllerapi.MultiStoreStatusResponse;
 import com.linkedin.venice.controllerapi.StoreResponse;
 import com.linkedin.venice.controllerapi.UpdateStoreQueryParams;
 import com.linkedin.venice.controllerapi.VersionCreationResponse;
-import com.linkedin.venice.controllerapi.VersionResponse;
 import com.linkedin.venice.exceptions.RecordTooLargeException;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.helix.HelixBaseRoutingRepository;
 import com.linkedin.venice.integration.utils.PubSubBrokerWrapper;
 import com.linkedin.venice.integration.utils.ServiceFactory;
 import com.linkedin.venice.integration.utils.VeniceClusterWrapper;
-import com.linkedin.venice.integration.utils.VeniceControllerCreateOptions;
-import com.linkedin.venice.integration.utils.VeniceControllerWrapper;
 import com.linkedin.venice.integration.utils.VeniceServerWrapper;
-import com.linkedin.venice.integration.utils.ZkServerWrapper;
 import com.linkedin.venice.kafka.protocol.GUID;
 import com.linkedin.venice.kafka.protocol.KafkaMessageEnvelope;
 import com.linkedin.venice.kafka.protocol.LeaderMetadata;
@@ -71,9 +63,6 @@ import com.linkedin.venice.kafka.protocol.Put;
 import com.linkedin.venice.kafka.protocol.enums.MessageType;
 import com.linkedin.venice.message.KafkaKey;
 import com.linkedin.venice.meta.BufferReplayPolicy;
-import com.linkedin.venice.meta.DataReplicationPolicy;
-import com.linkedin.venice.meta.HybridStoreConfig;
-import com.linkedin.venice.meta.HybridStoreConfigImpl;
 import com.linkedin.venice.meta.Instance;
 import com.linkedin.venice.meta.InstanceStatus;
 import com.linkedin.venice.meta.PersistenceType;
@@ -81,7 +70,6 @@ import com.linkedin.venice.meta.QueryAction;
 import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.meta.StoreStatus;
 import com.linkedin.venice.meta.Version;
-import com.linkedin.venice.meta.ZKStore;
 import com.linkedin.venice.producer.VeniceProducer;
 import com.linkedin.venice.producer.online.OnlineProducerFactory;
 import com.linkedin.venice.pubsub.PubSubProducerAdapterFactory;
@@ -92,13 +80,10 @@ import com.linkedin.venice.samza.VeniceSystemFactory;
 import com.linkedin.venice.samza.VeniceSystemProducer;
 import com.linkedin.venice.serializer.AvroGenericDeserializer;
 import com.linkedin.venice.serializer.AvroSerializer;
-import com.linkedin.venice.systemstore.schemas.StoreProperties;
-import com.linkedin.venice.utils.AvroRecordUtils;
 import com.linkedin.venice.utils.ByteUtils;
 import com.linkedin.venice.utils.DataProviderUtils;
 import com.linkedin.venice.utils.IntegrationTestPushUtils;
 import com.linkedin.venice.utils.Pair;
-import com.linkedin.venice.utils.StoreUtils;
 import com.linkedin.venice.utils.TestMockTime;
 import com.linkedin.venice.utils.TestUtils;
 import com.linkedin.venice.utils.TestWriteUtils;
@@ -106,7 +91,6 @@ import com.linkedin.venice.utils.Time;
 import com.linkedin.venice.utils.Utils;
 import com.linkedin.venice.utils.VeniceProperties;
 import com.linkedin.venice.writer.CompletableFutureCallback;
-import com.linkedin.venice.writer.LeaderMetadataWrapper;
 import com.linkedin.venice.writer.VeniceWriter;
 import com.linkedin.venice.writer.VeniceWriterOptions;
 import java.io.File;
@@ -170,262 +154,6 @@ public class TestHybrid {
   @AfterClass(alwaysRun = true)
   public void cleanUp() {
     Utils.closeQuietlyWithErrorLogged(sharedVenice);
-  }
-
-  @Test(timeOut = 180 * Time.MS_PER_SECOND)
-  public void testHybridInitializationOnMultiColo() throws IOException {
-    Properties extraProperties = new Properties();
-    extraProperties.setProperty(SERVER_PROMOTION_TO_LEADER_REPLICA_DELAY_SECONDS, Long.toString(3L));
-    extraProperties.setProperty(ROCKSDB_PLAIN_TABLE_FORMAT_ENABLED, "false");
-    extraProperties.setProperty(SERVER_DATABASE_CHECKSUM_VERIFICATION_ENABLED, "true");
-    extraProperties.setProperty(SERVER_DATABASE_SYNC_BYTES_INTERNAL_FOR_DEFERRED_WRITE_MODE, "300");
-    try (
-        VeniceClusterWrapper venice =
-            ServiceFactory.getVeniceCluster(1, 2, 1, 1, 1000000, false, false, extraProperties);
-        ZkServerWrapper parentZk = ServiceFactory.getZkServer();
-        VeniceControllerWrapper parentController = ServiceFactory.getVeniceController(
-            new VeniceControllerCreateOptions.Builder(
-                venice.getClusterName(),
-                parentZk,
-                venice.getPubSubBrokerWrapper())
-                    .childControllers(new VeniceControllerWrapper[] { venice.getLeaderVeniceController() })
-                    .build());
-        ControllerClient controllerClient =
-            new ControllerClient(venice.getClusterName(), parentController.getControllerUrl());
-        TopicManager topicManager =
-            IntegrationTestPushUtils
-                .getTopicManagerRepo(
-                    PUBSUB_OPERATION_TIMEOUT_MS_DEFAULT_VALUE,
-                    100,
-                    0l,
-                    venice.getPubSubBrokerWrapper(),
-                    venice.getPubSubTopicRepository())
-                .getLocalTopicManager()) {
-      long streamingRewindSeconds = 25L;
-      long streamingMessageLag = 2L;
-      final String storeName = Utils.getUniqueString("multi-colo-hybrid-store");
-
-      // Create store at parent, make it a hybrid store
-      controllerClient.createNewStore(storeName, "owner", STRING_SCHEMA.toString(), STRING_SCHEMA.toString());
-      controllerClient.updateStore(
-          storeName,
-          new UpdateStoreQueryParams().setStorageQuotaInByte(Store.UNLIMITED_STORAGE_QUOTA)
-              .setHybridRewindSeconds(streamingRewindSeconds)
-              .setHybridOffsetLagThreshold(streamingMessageLag));
-
-      HybridStoreConfig hybridStoreConfig = new HybridStoreConfigImpl(
-          streamingRewindSeconds,
-          streamingMessageLag,
-          HybridStoreConfigImpl.DEFAULT_HYBRID_TIME_LAG_THRESHOLD,
-          DataReplicationPolicy.NON_AGGREGATE,
-          REWIND_FROM_EOP);
-      // There should be no version on the store yet
-      assertEquals(
-          controllerClient.getStore(storeName).getStore().getCurrentVersion(),
-          0,
-          "The newly created store must have a current version of 0");
-
-      // Create a new version, and do an empty push for that version
-      VersionCreationResponse vcr =
-          controllerClient.emptyPush(storeName, Utils.getUniqueString("empty-hybrid-push"), 1L);
-      int versionNumber = vcr.getVersion();
-      assertNotEquals(versionNumber, 0, "requesting a topic for a push should provide a non zero version number");
-
-      TestUtils.waitForNonDeterministicAssertion(100, TimeUnit.SECONDS, true, () -> {
-        // Now the store should have version 1
-        JobStatusQueryResponse jobStatus =
-            controllerClient.queryJobStatus(Version.composeKafkaTopic(storeName, versionNumber));
-        Assert.assertFalse(jobStatus.isError(), "Error in getting JobStatusResponse: " + jobStatus.getError());
-        assertEquals(jobStatus.getStatus(), "COMPLETED");
-      });
-      vcr = controllerClient.emptyPush(storeName, Utils.getUniqueString("empty-hybrid-push1"), 1L);
-      VersionCreationResponse finalVcr = vcr;
-      TestUtils.waitForNonDeterministicAssertion(100, TimeUnit.SECONDS, true, () -> {
-        // Now the store should have version 2
-        JobStatusQueryResponse jobStatus =
-            controllerClient.queryJobStatus(Version.composeKafkaTopic(storeName, finalVcr.getVersion()));
-        Assert.assertFalse(jobStatus.isError(), "Error in getting JobStatusResponse: " + jobStatus.getError());
-        assertEquals(jobStatus.getStatus(), "COMPLETED");
-      });
-      MultiStoreStatusResponse response = controllerClient.getBackupVersions(venice.getClusterName(), storeName);
-      Assert.assertEquals(response.getStoreStatusMap().get("dc-0"), "1");
-
-      // And real-time topic should exist now.
-      assertTrue(
-          topicManager.containsTopicAndAllPartitionsAreOnline(
-              sharedVenice.getPubSubTopicRepository().getTopic(Version.composeRealTimeTopic(storeName))));
-      // Creating a store object with default values since we're not updating bootstrap to online timeout
-      StoreProperties storeProperties = AvroRecordUtils.prefillAvroRecordWithDefaultValue(new StoreProperties());
-      storeProperties.name = storeName;
-      storeProperties.owner = "owner";
-      storeProperties.createdTime = System.currentTimeMillis();
-      Store store = new ZKStore(storeProperties);
-      assertEquals(
-          topicManager.getTopicRetention(
-              sharedVenice.getPubSubTopicRepository().getTopic(Version.composeRealTimeTopic(storeName))),
-          StoreUtils.getExpectedRetentionTimeInMs(store, hybridStoreConfig),
-          "RT retention not configured properly");
-      // Make sure RT retention is updated when the rewind time is updated
-      long newStreamingRewindSeconds = 600;
-      hybridStoreConfig.setRewindTimeInSeconds(newStreamingRewindSeconds);
-      controllerClient
-          .updateStore(storeName, new UpdateStoreQueryParams().setHybridRewindSeconds(newStreamingRewindSeconds));
-      assertEquals(
-          topicManager.getTopicRetention(
-              sharedVenice.getPubSubTopicRepository().getTopic(Version.composeRealTimeTopic(storeName))),
-          StoreUtils.getExpectedRetentionTimeInMs(store, hybridStoreConfig),
-          "RT retention not updated properly");
-    }
-  }
-
-  @Test(timeOut = 180 * Time.MS_PER_SECOND)
-  public void testHybridSplitBrainIssue() {
-    Properties extraProperties = new Properties();
-    extraProperties.setProperty(SERVER_PROMOTION_TO_LEADER_REPLICA_DELAY_SECONDS, Long.toString(3L));
-    extraProperties.setProperty(ROCKSDB_PLAIN_TABLE_FORMAT_ENABLED, "false");
-    extraProperties.setProperty(SERVER_DATABASE_CHECKSUM_VERIFICATION_ENABLED, "true");
-    extraProperties.setProperty(SERVER_DATABASE_SYNC_BYTES_INTERNAL_FOR_DEFERRED_WRITE_MODE, "300");
-    try (
-        VeniceClusterWrapper venice =
-            ServiceFactory.getVeniceCluster(1, 2, 1, 1, 1000000, false, false, extraProperties);
-        ZkServerWrapper parentZk = ServiceFactory.getZkServer();
-        VeniceControllerWrapper parentController = ServiceFactory.getVeniceController(
-            new VeniceControllerCreateOptions.Builder(
-                venice.getClusterName(),
-                parentZk,
-                venice.getPubSubBrokerWrapper())
-                    .childControllers(new VeniceControllerWrapper[] { venice.getLeaderVeniceController() })
-                    .build());
-        ControllerClient controllerClient =
-            new ControllerClient(venice.getClusterName(), parentController.getControllerUrl())) {
-      long streamingRewindSeconds = 25L;
-      long streamingMessageLag = 2L;
-      final String storeName = Utils.getUniqueString("hybrid-store");
-
-      // Create store at parent, make it a hybrid store
-      controllerClient.createNewStore(storeName, "owner", STRING_SCHEMA.toString(), STRING_SCHEMA.toString());
-      controllerClient.updateStore(
-          storeName,
-          new UpdateStoreQueryParams().setStorageQuotaInByte(Store.UNLIMITED_STORAGE_QUOTA)
-              .setHybridRewindSeconds(streamingRewindSeconds)
-              .setHybridOffsetLagThreshold(streamingMessageLag));
-
-      // There should be no version on the store yet
-      assertEquals(
-          controllerClient.getStore(storeName).getStore().getCurrentVersion(),
-          0,
-          "The newly created store must have a current version of 0");
-
-      VersionResponse versionResponse = controllerClient.addVersionAndStartIngestion(
-          storeName,
-          Utils.getUniqueString("test-hybrid-push"),
-          1,
-          3,
-          Version.PushType.BATCH,
-          null,
-          -1,
-          1);
-      assertFalse(
-          versionResponse.isError(),
-          "Version creation shouldn't return error, but received: " + versionResponse.getError());
-      String versionTopicName = Version.composeKafkaTopic(storeName, 1);
-
-      String writer1 = "writer_1_hostname";
-      String writer2 = "writer_2_hostname";
-      Properties veniceWriterProperties1 = new Properties();
-      veniceWriterProperties1.put(KAFKA_BOOTSTRAP_SERVERS, venice.getPubSubBrokerWrapper().getAddress());
-      veniceWriterProperties1.putAll(
-          PubSubBrokerWrapper.getBrokerDetailsForClients(Collections.singletonList(venice.getPubSubBrokerWrapper())));
-      veniceWriterProperties1.put(INSTANCE_ID, writer1);
-
-      AvroSerializer<String> stringSerializer = new AvroSerializer(STRING_SCHEMA);
-      PubSubProducerAdapterFactory pubSubProducerAdapterFactory =
-          venice.getPubSubBrokerWrapper().getPubSubClientsFactory().getProducerAdapterFactory();
-
-      Properties veniceWriterProperties2 = new Properties();
-      veniceWriterProperties2.put(KAFKA_BOOTSTRAP_SERVERS, venice.getPubSubBrokerWrapper().getAddress());
-      veniceWriterProperties2.putAll(
-          PubSubBrokerWrapper.getBrokerDetailsForClients(Collections.singletonList(venice.getPubSubBrokerWrapper())));
-      veniceWriterProperties2.put(INSTANCE_ID, writer2);
-
-      try (
-          VeniceWriter<byte[], byte[], byte[]> veniceWriter1 =
-              TestUtils.getVeniceWriterFactory(veniceWriterProperties1, pubSubProducerAdapterFactory)
-                  .createVeniceWriter(new VeniceWriterOptions.Builder(versionTopicName).build());
-          VeniceWriter<byte[], byte[], byte[]> veniceWriter2 =
-              TestUtils.getVeniceWriterFactory(veniceWriterProperties2, pubSubProducerAdapterFactory)
-                  .createVeniceWriter(new VeniceWriterOptions.Builder(versionTopicName).build())) {
-        veniceWriter1.broadcastStartOfPush(false, Collections.emptyMap());
-
-        /**
-         * Explicitly simulate split-brain issue.
-         * Writer1:
-         *
-         * key_0: value_0 with upstream offset: 5
-         * key_1: value_1 with upstream offset: 6
-         * key_2: value_2 with upstream offset: 7
-         * key_3: value_3 with upstream offset: 8
-         * key_4: value_4 with upstream offset: 9
-         * Writer2:
-         * key_0: value_x with upstream offset: 3
-         * key_5: value_5 with upstream offset: 10
-         * key_6: value_6 with upstream offset: 11
-         * key_7: value_7 with upstream offset: 12
-         * key_8: value_8 with upstream offset: 13
-         * key_9: value_9 with upstream offset: 14
-         */
-
-        // Sending out dummy records first to push out SOS messages first.
-        veniceWriter1.put(
-            stringSerializer.serialize("key_writer_1"),
-            stringSerializer.serialize("value_writer_1"),
-            1,
-            null,
-            new LeaderMetadataWrapper(0, 0));
-        veniceWriter1.flush();
-        veniceWriter2.put(
-            stringSerializer.serialize("key_writer_2"),
-            stringSerializer.serialize("value_writer_2"),
-            1,
-            null,
-            new LeaderMetadataWrapper(1, 0));
-        veniceWriter2.flush();
-
-        for (int i = 0; i < 5; ++i) {
-          veniceWriter1.put(
-              stringSerializer.serialize("key_" + i),
-              stringSerializer.serialize("value_" + i),
-              1,
-              null,
-              new LeaderMetadataWrapper(i + 5, 0));
-        }
-        veniceWriter1.flush();
-        veniceWriter2.put(
-            stringSerializer.serialize("key_" + 0),
-            stringSerializer.serialize("value_x"),
-            1,
-            null,
-            new LeaderMetadataWrapper(3, 0));
-        for (int i = 5; i < 10; ++i) {
-          veniceWriter2.put(
-              stringSerializer.serialize("key_" + i),
-              stringSerializer.serialize("value_" + i),
-              1,
-              null,
-              new LeaderMetadataWrapper(i + 5, 0));
-        }
-        veniceWriter2.flush();
-        veniceWriter1.broadcastEndOfPush(Collections.emptyMap());
-        veniceWriter1.flush();
-      }
-
-      TestUtils.waitForNonDeterministicAssertion(100, TimeUnit.SECONDS, true, () -> {
-        // Now the store should have version 1
-        JobStatusQueryResponse jobStatus = controllerClient.queryJobStatus(Version.composeKafkaTopic(storeName, 1));
-        Assert.assertFalse(jobStatus.isError(), "Error in getting JobStatusResponse: " + jobStatus.getError());
-        assertEquals(jobStatus.getStatus(), "ERROR");
-      });
-    }
   }
 
   /**

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestHybridMultiRegion.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestHybridMultiRegion.java
@@ -1,0 +1,355 @@
+package com.linkedin.venice.endToEnd;
+
+import static com.linkedin.davinci.store.rocksdb.RocksDBServerConfig.ROCKSDB_PLAIN_TABLE_FORMAT_ENABLED;
+import static com.linkedin.venice.ConfigKeys.DEFAULT_MAX_NUMBER_OF_PARTITIONS;
+import static com.linkedin.venice.ConfigKeys.INSTANCE_ID;
+import static com.linkedin.venice.ConfigKeys.KAFKA_BOOTSTRAP_SERVERS;
+import static com.linkedin.venice.ConfigKeys.PERSISTENCE_TYPE;
+import static com.linkedin.venice.ConfigKeys.SERVER_CONSUMER_POOL_SIZE_PER_KAFKA_CLUSTER;
+import static com.linkedin.venice.ConfigKeys.SERVER_DATABASE_CHECKSUM_VERIFICATION_ENABLED;
+import static com.linkedin.venice.ConfigKeys.SERVER_DATABASE_SYNC_BYTES_INTERNAL_FOR_DEFERRED_WRITE_MODE;
+import static com.linkedin.venice.ConfigKeys.SERVER_DEDICATED_DRAINER_FOR_SORTED_INPUT_ENABLED;
+import static com.linkedin.venice.ConfigKeys.SERVER_PROMOTION_TO_LEADER_REPLICA_DELAY_SECONDS;
+import static com.linkedin.venice.ConfigKeys.SSL_TO_KAFKA_LEGACY;
+import static com.linkedin.venice.meta.BufferReplayPolicy.REWIND_FROM_EOP;
+import static com.linkedin.venice.meta.BufferReplayPolicy.REWIND_FROM_SOP;
+import static com.linkedin.venice.pubsub.PubSubConstants.PUBSUB_OPERATION_TIMEOUT_MS_DEFAULT_VALUE;
+import static com.linkedin.venice.utils.TestWriteUtils.STRING_SCHEMA;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotEquals;
+import static org.testng.Assert.assertTrue;
+
+import com.linkedin.venice.controllerapi.ControllerClient;
+import com.linkedin.venice.controllerapi.JobStatusQueryResponse;
+import com.linkedin.venice.controllerapi.UpdateStoreQueryParams;
+import com.linkedin.venice.controllerapi.VersionCreationResponse;
+import com.linkedin.venice.controllerapi.VersionResponse;
+import com.linkedin.venice.integration.utils.PubSubBrokerWrapper;
+import com.linkedin.venice.integration.utils.ServiceFactory;
+import com.linkedin.venice.integration.utils.VeniceClusterWrapper;
+import com.linkedin.venice.integration.utils.VeniceTwoLayerMultiRegionMultiClusterWrapper;
+import com.linkedin.venice.meta.DataReplicationPolicy;
+import com.linkedin.venice.meta.HybridStoreConfig;
+import com.linkedin.venice.meta.HybridStoreConfigImpl;
+import com.linkedin.venice.meta.PersistenceType;
+import com.linkedin.venice.meta.Store;
+import com.linkedin.venice.meta.Version;
+import com.linkedin.venice.meta.ZKStore;
+import com.linkedin.venice.pubsub.PubSubProducerAdapterFactory;
+import com.linkedin.venice.pubsub.manager.TopicManager;
+import com.linkedin.venice.serializer.AvroSerializer;
+import com.linkedin.venice.systemstore.schemas.StoreProperties;
+import com.linkedin.venice.utils.AvroRecordUtils;
+import com.linkedin.venice.utils.IntegrationTestPushUtils;
+import com.linkedin.venice.utils.StoreUtils;
+import com.linkedin.venice.utils.TestUtils;
+import com.linkedin.venice.utils.Time;
+import com.linkedin.venice.utils.Utils;
+import com.linkedin.venice.writer.LeaderMetadataWrapper;
+import com.linkedin.venice.writer.VeniceWriter;
+import com.linkedin.venice.writer.VeniceWriterOptions;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+
+public class TestHybridMultiRegion {
+  /**
+   * IMPORTANT NOTE: if you use this sharedVenice cluster, please do not close it. The {@link #cleanUp()} function
+   *                 will take care of it. Besides, if any backend component of the shared cluster is stopped in
+   *                 the middle of the test, please restart them at the end of your test.
+   */
+  private VeniceTwoLayerMultiRegionMultiClusterWrapper sharedVenice;
+
+  /**
+   * This cluster is re-used by some of the tests, in order to speed up the suite. Some other tests require
+   * certain specific characteristics which makes it awkward to re-use, though not necessarily impossible.
+   * Further reuse of this shared cluster can be attempted later.
+   */
+  @BeforeClass(alwaysRun = true)
+  public void setUp() {
+    sharedVenice = setUpCluster();
+  }
+
+  @AfterClass(alwaysRun = true)
+  public void cleanUp() {
+    Utils.closeQuietlyWithErrorLogged(sharedVenice);
+  }
+
+  @Test(timeOut = 180 * Time.MS_PER_SECOND)
+  public void testHybridInitializationOnMultiColo() throws IOException {
+    String clusterName = sharedVenice.getClusterNames()[0];
+    VeniceClusterWrapper sharedVeniceClusterWrapper =
+        sharedVenice.getChildRegions().get(0).getClusters().get(clusterName);
+    try (
+        ControllerClient controllerClient =
+            new ControllerClient(clusterName, sharedVenice.getControllerConnectString());
+        TopicManager topicManager =
+            IntegrationTestPushUtils
+                .getTopicManagerRepo(
+                    PUBSUB_OPERATION_TIMEOUT_MS_DEFAULT_VALUE,
+                    100,
+                    0l,
+                    sharedVeniceClusterWrapper.getPubSubBrokerWrapper(),
+                    sharedVeniceClusterWrapper.getPubSubTopicRepository())
+                .getLocalTopicManager()) {
+      long streamingRewindSeconds = 25L;
+      long streamingMessageLag = 2L;
+      final String storeName = Utils.getUniqueString("multi-colo-hybrid-store");
+
+      // Create store at parent, make it a hybrid store
+      controllerClient.createNewStore(storeName, "owner", STRING_SCHEMA.toString(), STRING_SCHEMA.toString());
+      controllerClient.updateStore(
+          storeName,
+          new UpdateStoreQueryParams().setStorageQuotaInByte(Store.UNLIMITED_STORAGE_QUOTA)
+              .setHybridRewindSeconds(streamingRewindSeconds)
+              .setHybridOffsetLagThreshold(streamingMessageLag));
+
+      HybridStoreConfig hybridStoreConfig = new HybridStoreConfigImpl(
+          streamingRewindSeconds,
+          streamingMessageLag,
+          HybridStoreConfigImpl.DEFAULT_HYBRID_TIME_LAG_THRESHOLD,
+          DataReplicationPolicy.NON_AGGREGATE,
+          REWIND_FROM_EOP);
+      // There should be no version on the store yet
+      assertEquals(
+          controllerClient.getStore(storeName).getStore().getCurrentVersion(),
+          0,
+          "The newly created store must have a current version of 0");
+
+      // Create a new version, and do an empty push for that version
+      VersionCreationResponse vcr =
+          controllerClient.emptyPush(storeName, Utils.getUniqueString("empty-hybrid-push"), 1L);
+      int versionNumber = vcr.getVersion();
+      assertNotEquals(versionNumber, 0, "requesting a topic for a push should provide a non zero version number");
+
+      TestUtils.waitForNonDeterministicAssertion(100, TimeUnit.SECONDS, true, () -> {
+        // Now the store should have version 1
+        JobStatusQueryResponse jobStatus =
+            controllerClient.queryJobStatus(Version.composeKafkaTopic(storeName, versionNumber));
+        Assert.assertFalse(jobStatus.isError(), "Error in getting JobStatusResponse: " + jobStatus.getError());
+        assertEquals(jobStatus.getStatus(), "COMPLETED");
+      });
+
+      // And real-time topic should exist now.
+      assertTrue(
+          topicManager.containsTopicAndAllPartitionsAreOnline(
+              sharedVeniceClusterWrapper.getPubSubTopicRepository().getTopic(Version.composeRealTimeTopic(storeName))));
+      // Creating a store object with default values since we're not updating bootstrap to online timeout
+      StoreProperties storeProperties = AvroRecordUtils.prefillAvroRecordWithDefaultValue(new StoreProperties());
+      storeProperties.name = storeName;
+      storeProperties.owner = "owner";
+      storeProperties.createdTime = System.currentTimeMillis();
+      Store store = new ZKStore(storeProperties);
+      assertEquals(
+          topicManager.getTopicRetention(
+              sharedVeniceClusterWrapper.getPubSubTopicRepository().getTopic(Version.composeRealTimeTopic(storeName))),
+          StoreUtils.getExpectedRetentionTimeInMs(store, hybridStoreConfig),
+          "RT retention not configured properly");
+      // Make sure RT retention is updated when the rewind time is updated
+      long newStreamingRewindSeconds = 600;
+      hybridStoreConfig.setRewindTimeInSeconds(newStreamingRewindSeconds);
+      controllerClient
+          .updateStore(storeName, new UpdateStoreQueryParams().setHybridRewindSeconds(newStreamingRewindSeconds));
+      assertEquals(
+          topicManager.getTopicRetention(
+              sharedVeniceClusterWrapper.getPubSubTopicRepository().getTopic(Version.composeRealTimeTopic(storeName))),
+          StoreUtils.getExpectedRetentionTimeInMs(store, hybridStoreConfig),
+          "RT retention not updated properly");
+    }
+  }
+
+  @Test(timeOut = 180 * Time.MS_PER_SECOND)
+  public void testHybridSplitBrainIssue() {
+    String clusterName = sharedVenice.getClusterNames()[0];
+    VeniceClusterWrapper sharedVeniceClusterWrapper =
+        sharedVenice.getChildRegions().get(0).getClusters().get(clusterName);
+    try (ControllerClient controllerClient =
+        new ControllerClient(clusterName, sharedVenice.getControllerConnectString())) {
+      long streamingRewindSeconds = 25L;
+      long streamingMessageLag = 2L;
+      final String storeName = Utils.getUniqueString("hybrid-store");
+
+      // Create store at parent, make it a hybrid store
+      controllerClient.createNewStore(storeName, "owner", STRING_SCHEMA.toString(), STRING_SCHEMA.toString());
+      controllerClient.updateStore(
+          storeName,
+          new UpdateStoreQueryParams().setStorageQuotaInByte(Store.UNLIMITED_STORAGE_QUOTA)
+              .setHybridRewindSeconds(streamingRewindSeconds)
+              .setHybridOffsetLagThreshold(streamingMessageLag));
+
+      // There should be no version on the store yet
+      assertEquals(
+          controllerClient.getStore(storeName).getStore().getCurrentVersion(),
+          0,
+          "The newly created store must have a current version of 0");
+
+      VersionResponse versionResponse = controllerClient.addVersionAndStartIngestion(
+          storeName,
+          Utils.getUniqueString("test-hybrid-push"),
+          1,
+          3,
+          Version.PushType.BATCH,
+          null,
+          -1,
+          1);
+      assertFalse(
+          versionResponse.isError(),
+          "Version creation shouldn't return error, but received: " + versionResponse.getError());
+      String versionTopicName = Version.composeKafkaTopic(storeName, 1);
+
+      String writer1 = "writer_1_hostname";
+      String writer2 = "writer_2_hostname";
+      Properties veniceWriterProperties1 = new Properties();
+      veniceWriterProperties1
+          .put(KAFKA_BOOTSTRAP_SERVERS, sharedVeniceClusterWrapper.getPubSubBrokerWrapper().getAddress());
+      veniceWriterProperties1.putAll(
+          PubSubBrokerWrapper.getBrokerDetailsForClients(
+              Collections.singletonList(sharedVeniceClusterWrapper.getPubSubBrokerWrapper())));
+      veniceWriterProperties1.put(INSTANCE_ID, writer1);
+
+      AvroSerializer<String> stringSerializer = new AvroSerializer(STRING_SCHEMA);
+      PubSubProducerAdapterFactory pubSubProducerAdapterFactory =
+          sharedVeniceClusterWrapper.getPubSubBrokerWrapper().getPubSubClientsFactory().getProducerAdapterFactory();
+
+      Properties veniceWriterProperties2 = new Properties();
+      veniceWriterProperties2
+          .put(KAFKA_BOOTSTRAP_SERVERS, sharedVeniceClusterWrapper.getPubSubBrokerWrapper().getAddress());
+      veniceWriterProperties2.putAll(
+          PubSubBrokerWrapper.getBrokerDetailsForClients(
+              Collections.singletonList(sharedVeniceClusterWrapper.getPubSubBrokerWrapper())));
+      veniceWriterProperties2.put(INSTANCE_ID, writer2);
+
+      try (
+          VeniceWriter<byte[], byte[], byte[]> veniceWriter1 =
+              TestUtils.getVeniceWriterFactory(veniceWriterProperties1, pubSubProducerAdapterFactory)
+                  .createVeniceWriter(new VeniceWriterOptions.Builder(versionTopicName).build());
+          VeniceWriter<byte[], byte[], byte[]> veniceWriter2 =
+              TestUtils.getVeniceWriterFactory(veniceWriterProperties2, pubSubProducerAdapterFactory)
+                  .createVeniceWriter(new VeniceWriterOptions.Builder(versionTopicName).build())) {
+        veniceWriter1.broadcastStartOfPush(false, Collections.emptyMap());
+
+        /**
+         * Explicitly simulate split-brain issue.
+         * Writer1:
+         *
+         * key_0: value_0 with upstream offset: 5
+         * key_1: value_1 with upstream offset: 6
+         * key_2: value_2 with upstream offset: 7
+         * key_3: value_3 with upstream offset: 8
+         * key_4: value_4 with upstream offset: 9
+         * Writer2:
+         * key_0: value_x with upstream offset: 3
+         * key_5: value_5 with upstream offset: 10
+         * key_6: value_6 with upstream offset: 11
+         * key_7: value_7 with upstream offset: 12
+         * key_8: value_8 with upstream offset: 13
+         * key_9: value_9 with upstream offset: 14
+         */
+
+        // Sending out dummy records first to push out SOS messages first.
+        veniceWriter1.put(
+            stringSerializer.serialize("key_writer_1"),
+            stringSerializer.serialize("value_writer_1"),
+            1,
+            null,
+            new LeaderMetadataWrapper(0, 0));
+        veniceWriter1.flush();
+        veniceWriter2.put(
+            stringSerializer.serialize("key_writer_2"),
+            stringSerializer.serialize("value_writer_2"),
+            1,
+            null,
+            new LeaderMetadataWrapper(1, 0));
+        veniceWriter2.flush();
+
+        for (int i = 0; i < 5; ++i) {
+          veniceWriter1.put(
+              stringSerializer.serialize("key_" + i),
+              stringSerializer.serialize("value_" + i),
+              1,
+              null,
+              new LeaderMetadataWrapper(i + 5, 0));
+        }
+        veniceWriter1.flush();
+        veniceWriter2.put(
+            stringSerializer.serialize("key_" + 0),
+            stringSerializer.serialize("value_x"),
+            1,
+            null,
+            new LeaderMetadataWrapper(3, 0));
+        for (int i = 5; i < 10; ++i) {
+          veniceWriter2.put(
+              stringSerializer.serialize("key_" + i),
+              stringSerializer.serialize("value_" + i),
+              1,
+              null,
+              new LeaderMetadataWrapper(i + 5, 0));
+        }
+        veniceWriter2.flush();
+        veniceWriter1.broadcastEndOfPush(Collections.emptyMap());
+        veniceWriter1.flush();
+      }
+
+      TestUtils.waitForNonDeterministicAssertion(100, TimeUnit.SECONDS, true, () -> {
+        // Now the store should have version 1
+        JobStatusQueryResponse jobStatus = controllerClient.queryJobStatus(Version.composeKafkaTopic(storeName, 1));
+        Assert.assertFalse(jobStatus.isError(), "Error in getting JobStatusResponse: " + jobStatus.getError());
+        assertEquals(jobStatus.getStatus(), "ERROR");
+      });
+    }
+  }
+
+  /**
+   * N.B.: Non-L/F does not support chunking, so this permutation is skipped.
+   */
+  @DataProvider(name = "testPermutations", parallel = false)
+  public static Object[][] testPermutations() {
+    return new Object[][] { { false, false, REWIND_FROM_EOP }, { false, true, REWIND_FROM_EOP },
+        { true, false, REWIND_FROM_EOP }, { true, true, REWIND_FROM_EOP }, { false, false, REWIND_FROM_SOP },
+        { false, true, REWIND_FROM_SOP }, { true, false, REWIND_FROM_SOP }, { true, true, REWIND_FROM_SOP } };
+  }
+
+  private static VeniceTwoLayerMultiRegionMultiClusterWrapper setUpCluster() {
+    Properties parentControllerProps = new Properties();
+    parentControllerProps.setProperty(DEFAULT_MAX_NUMBER_OF_PARTITIONS, "5");
+
+    Properties childControllerProperties = new Properties();
+    childControllerProperties.setProperty(DEFAULT_MAX_NUMBER_OF_PARTITIONS, "5");
+
+    Properties serverProperties = new Properties();
+    serverProperties.setProperty(PERSISTENCE_TYPE, PersistenceType.ROCKS_DB.name());
+    serverProperties.setProperty(SERVER_PROMOTION_TO_LEADER_REPLICA_DELAY_SECONDS, Long.toString(3L));
+    serverProperties.setProperty(ROCKSDB_PLAIN_TABLE_FORMAT_ENABLED, "false");
+    serverProperties.setProperty(SERVER_DATABASE_CHECKSUM_VERIFICATION_ENABLED, "true");
+    serverProperties.setProperty(SERVER_DATABASE_SYNC_BYTES_INTERNAL_FOR_DEFERRED_WRITE_MODE, "300");
+
+    serverProperties.setProperty(SSL_TO_KAFKA_LEGACY, "false");
+    serverProperties.setProperty(SERVER_CONSUMER_POOL_SIZE_PER_KAFKA_CLUSTER, "3");
+    serverProperties.setProperty(SERVER_DEDICATED_DRAINER_FOR_SORTED_INPUT_ENABLED, "true");
+
+    VeniceTwoLayerMultiRegionMultiClusterWrapper cluster =
+        ServiceFactory.getVeniceTwoLayerMultiRegionMultiClusterWrapper(
+            1,
+            1,
+            1,
+            1,
+            2,
+            1,
+            1,
+            Optional.of(parentControllerProps),
+            Optional.of(childControllerProperties),
+            Optional.of(serverProperties),
+            false);
+
+    return cluster;
+  }
+}

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestPushJobWithNativeReplication.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestPushJobWithNativeReplication.java
@@ -214,6 +214,7 @@ public class TestPushJobWithNativeReplication {
 
   @AfterClass(alwaysRun = true)
   public void cleanUp() {
+    D2ClientUtils.shutdownClient(d2Client);
     Utils.closeQuietlyWithErrorLogged(multiRegionMultiClusterWrapper);
   }
 

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestWritePathComputation.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestWritePathComputation.java
@@ -31,7 +31,7 @@ public class TestWritePathComputation {
 
   @Test(timeOut = 60 * Time.MS_PER_SECOND)
   public void testFeatureFlagSingleDC() {
-    VeniceMultiClusterCreateOptions options = new VeniceMultiClusterCreateOptions.Builder().setNumberOfClusters(1)
+    VeniceMultiClusterCreateOptions options = new VeniceMultiClusterCreateOptions.Builder().numberOfClusters(1)
         .numberOfControllers(1)
         .numberOfServers(1)
         .numberOfRouters(0)

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestWritePathComputation.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestWritePathComputation.java
@@ -1,5 +1,7 @@
 package com.linkedin.venice.endToEnd;
 
+import static com.linkedin.venice.utils.TestUtils.assertCommand;
+
 import com.linkedin.venice.controller.Admin;
 import com.linkedin.venice.controllerapi.ControllerClient;
 import com.linkedin.venice.controllerapi.ControllerResponse;
@@ -19,37 +21,51 @@ import org.testng.annotations.Test;
 
 public class TestWritePathComputation {
   private static final long GET_LEADER_CONTROLLER_TIMEOUT = 20 * Time.MS_PER_SECOND;
+  private static final String KEY_SCHEMA_STR = "\"string\"";
+  private static final String VALUE_FIELD_NAME = "int_field";
+  private static final String SECOND_VALUE_FIELD_NAME = "opt_int_field";
+  private static final String VALUE_SCHEMA_V2_STR = "{\n" + "\"type\": \"record\",\n"
+      + "\"name\": \"TestValueSchema\",\n" + "\"namespace\": \"com.linkedin.venice.fastclient.schema\",\n"
+      + "\"fields\": [\n" + "  {\"name\": \"" + VALUE_FIELD_NAME + "\", \"type\": \"int\", \"default\": 10},\n"
+      + "{\"name\": \"" + SECOND_VALUE_FIELD_NAME + "\", \"type\": [\"null\", \"int\"], \"default\": null}]\n" + "}";
 
   @Test(timeOut = 60 * Time.MS_PER_SECOND)
   public void testFeatureFlagSingleDC() {
-    VeniceMultiClusterCreateOptions options = new VeniceMultiClusterCreateOptions.Builder(1).numberOfControllers(1)
+    VeniceMultiClusterCreateOptions options = new VeniceMultiClusterCreateOptions.Builder().setNumberOfClusters(1)
+        .numberOfControllers(1)
         .numberOfServers(1)
         .numberOfRouters(0)
         .regionName(VeniceClusterWrapperConstants.STANDALONE_REGION_NAME)
         .build();
     try (VeniceMultiClusterWrapper multiClusterWrapper = ServiceFactory.getVeniceMultiClusterWrapper(options)) {
       String clusterName = multiClusterWrapper.getClusterNames()[0];
+      VeniceControllerWrapper childController = multiClusterWrapper.getLeaderController(clusterName);
       String storeName = "test-store0";
 
       // Create store
-      Admin admin =
+      Admin childAdmin =
           multiClusterWrapper.getLeaderController(clusterName, GET_LEADER_CONTROLLER_TIMEOUT).getVeniceAdmin();
-      admin.createStore(clusterName, storeName, "tester", "\"string\"", "\"string\"");
-      Assert.assertTrue(admin.hasStore(clusterName, storeName));
-      Assert.assertFalse(admin.getStore(clusterName, storeName).isWriteComputationEnabled());
+      childAdmin.createStore(clusterName, storeName, "tester", "\"string\"", "\"string\"");
+      TestUtils.waitForNonDeterministicAssertion(15, TimeUnit.SECONDS, () -> {
+        Assert.assertTrue(childAdmin.hasStore(clusterName, storeName));
+        Assert.assertFalse(childAdmin.getStore(clusterName, storeName).isWriteComputationEnabled());
+      });
 
       // Set flag
-      String controllerUrl =
-          multiClusterWrapper.getLeaderController(clusterName, GET_LEADER_CONTROLLER_TIMEOUT).getControllerUrl();
-      try (ControllerClient controllerClient = new ControllerClient(clusterName, controllerUrl)) {
-        TestUtils.assertCommand(
-            controllerClient.updateStore(storeName, new UpdateStoreQueryParams().setWriteComputationEnabled(true)),
+      String childControllerUrl = childController.getControllerUrl();
+      try (ControllerClient childControllerClient = new ControllerClient(clusterName, childControllerUrl)) {
+        assertCommand(
+            childControllerClient.updateStore(storeName, new UpdateStoreQueryParams().setWriteComputationEnabled(true)),
             "Write Compute should be enabled");
-        Assert.assertTrue(admin.getStore(clusterName, storeName).isWriteComputationEnabled());
+        Assert.assertTrue(childAdmin.getStore(clusterName, storeName).isWriteComputationEnabled());
 
         // Reset flag
-        controllerClient.updateStore(storeName, new UpdateStoreQueryParams().setWriteComputationEnabled(false));
-        Assert.assertFalse(admin.getStore(clusterName, storeName).isWriteComputationEnabled());
+        assertCommand(
+            childControllerClient
+                .updateStore(storeName, new UpdateStoreQueryParams().setWriteComputationEnabled(false)));
+        TestUtils.waitForNonDeterministicAssertion(15, TimeUnit.SECONDS, () -> {
+          Assert.assertFalse(childAdmin.getStore(clusterName, storeName).isWriteComputationEnabled());
+        });
       }
     }
   }
@@ -63,12 +79,14 @@ public class TestWritePathComputation {
       VeniceControllerWrapper parentController = twoLayerMultiRegionMultiClusterWrapper.getParentControllers().get(0);
       String clusterName = multiCluster.getClusterNames()[0];
       String storeName = "test-store0";
+      String storeName2 = "test-store2";
 
       // Create store
       Admin parentAdmin =
           twoLayerMultiRegionMultiClusterWrapper.getLeaderParentControllerWithRetries(clusterName).getVeniceAdmin();
       Admin childAdmin = multiCluster.getLeaderController(clusterName, GET_LEADER_CONTROLLER_TIMEOUT).getVeniceAdmin();
       parentAdmin.createStore(clusterName, storeName, "tester", "\"string\"", "\"string\"");
+      parentAdmin.createStore(clusterName, storeName2, "tester", KEY_SCHEMA_STR, VALUE_SCHEMA_V2_STR);
       TestUtils.waitForNonDeterministicAssertion(15, TimeUnit.SECONDS, () -> {
         Assert.assertTrue(parentAdmin.hasStore(clusterName, storeName));
         Assert.assertTrue(childAdmin.hasStore(clusterName, storeName));
@@ -83,6 +101,15 @@ public class TestWritePathComputation {
             .updateStore(storeName, new UpdateStoreQueryParams().setWriteComputationEnabled(true));
         Assert.assertTrue(response.isError());
         Assert.assertTrue(response.getError().contains("top level field probably missing defaults"));
+
+        ControllerResponse response2 = parentControllerClient.updateStore(
+            storeName,
+            new UpdateStoreQueryParams().setHybridRewindSeconds(1000)
+                .setHybridOffsetLagThreshold(1000)
+                .setWriteComputationEnabled(true));
+        Assert.assertTrue(response2.isError());
+        Assert.assertTrue(response2.getError().contains("top level field probably missing defaults"));
+
         TestUtils.waitForNonDeterministicAssertion(15, TimeUnit.SECONDS, () -> {
           Assert.assertFalse(
               parentAdmin.getStore(clusterName, storeName).isWriteComputationEnabled(),
@@ -92,13 +119,29 @@ public class TestWritePathComputation {
               "Write Compute should not be enabled before the value schema is not a Record.");
         });
 
+        assertCommand(
+            parentControllerClient.updateStore(
+                storeName2,
+                new UpdateStoreQueryParams().setHybridRewindSeconds(1000)
+                    .setHybridOffsetLagThreshold(1000)
+                    .setWriteComputationEnabled(true)));
+        TestUtils.waitForNonDeterministicAssertion(15, TimeUnit.SECONDS, () -> {
+          Assert.assertTrue(parentAdmin.getStore(clusterName, storeName2).isWriteComputationEnabled());
+          Assert.assertTrue(childAdmin.getStore(clusterName, storeName2).isWriteComputationEnabled());
+        });
+
         // Reset flag
-        response = parentControllerClient
-            .updateStore(storeName, new UpdateStoreQueryParams().setWriteComputationEnabled(false));
-        Assert.assertFalse(response.isError(), "No error is expected to disable Write Compute (that was not enabled)");
+        assertCommand(
+            parentControllerClient
+                .updateStore(storeName, new UpdateStoreQueryParams().setWriteComputationEnabled(false)));
+        assertCommand(
+            parentControllerClient
+                .updateStore(storeName2, new UpdateStoreQueryParams().setWriteComputationEnabled(false)));
         TestUtils.waitForNonDeterministicAssertion(15, TimeUnit.SECONDS, () -> {
           Assert.assertFalse(parentAdmin.getStore(clusterName, storeName).isWriteComputationEnabled());
           Assert.assertFalse(childAdmin.getStore(clusterName, storeName).isWriteComputationEnabled());
+          Assert.assertFalse(parentAdmin.getStore(clusterName, storeName2).isWriteComputationEnabled());
+          Assert.assertFalse(childAdmin.getStore(clusterName, storeName2).isWriteComputationEnabled());
         });
       }
     }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/ServiceFactory.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/ServiceFactory.java
@@ -4,7 +4,6 @@ import static com.linkedin.venice.ConfigKeys.CLIENT_USE_SYSTEM_STORE_REPOSITORY;
 import static com.linkedin.venice.ConfigKeys.D2_ZK_HOSTS_ADDRESS;
 import static com.linkedin.venice.ConfigKeys.DATA_BASE_PATH;
 import static com.linkedin.venice.integration.utils.VeniceClusterWrapperConstants.DEFAULT_MAX_ATTEMPT;
-import static com.linkedin.venice.integration.utils.VeniceClusterWrapperConstants.DEFAULT_REPLICATION_FACTOR;
 import static com.linkedin.venice.integration.utils.VeniceClusterWrapperConstants.DEFAULT_WAIT_TIME_FOR_CLUSTER_START_S;
 import static com.linkedin.venice.integration.utils.VeniceClusterWrapperConstants.STANDALONE_REGION_NAME;
 
@@ -408,18 +407,14 @@ public class ServiceFactory {
       int numberOfControllers,
       int numberOfServers,
       int numberOfRouters) {
-    return getService(
-        VeniceTwoLayerMultiRegionMultiClusterWrapper.SERVICE_NAME,
-        VeniceTwoLayerMultiRegionMultiClusterWrapper.generateService(
-            numberOfRegions,
-            numberOfClustersInEachRegion,
-            numberOfParentControllers,
-            numberOfControllers,
-            numberOfServers,
-            numberOfRouters,
-            DEFAULT_REPLICATION_FACTOR,
-            Optional.empty(),
-            Optional.empty()));
+    VeniceMultiRegionClusterCreateOptions.Builder optionsBuilder =
+        new VeniceMultiRegionClusterCreateOptions.Builder().numberOfRegions(numberOfRegions)
+            .numberOfClusters(numberOfClustersInEachRegion)
+            .numberOfParentControllers(numberOfParentControllers)
+            .numberOfChildControllers(numberOfControllers)
+            .numberOfServers(numberOfServers)
+            .numberOfRouters(numberOfRouters);
+    return getVeniceTwoLayerMultiRegionMultiClusterWrapper(optionsBuilder.build());
   }
 
   public static VeniceTwoLayerMultiRegionMultiClusterWrapper getVeniceTwoLayerMultiRegionMultiClusterWrapper(
@@ -433,20 +428,19 @@ public class ServiceFactory {
       Optional<Properties> parentControllerProps,
       Optional<Properties> childControllerProperties,
       Optional<Properties> serverProps) {
-    return getService(
-        VeniceTwoLayerMultiRegionMultiClusterWrapper.SERVICE_NAME,
-        VeniceTwoLayerMultiRegionMultiClusterWrapper.generateService(
-            numberOfRegions,
-            numberOfClustersInEachRegion,
-            numberOfParentControllers,
-            numberOfControllers,
-            numberOfServers,
-            numberOfRouters,
-            replicationFactor,
-            parentControllerProps,
-            childControllerProperties,
-            serverProps,
-            false));
+    VeniceMultiRegionClusterCreateOptions.Builder optionsBuilder =
+        new VeniceMultiRegionClusterCreateOptions.Builder().numberOfRegions(numberOfRegions)
+            .numberOfClusters(numberOfClustersInEachRegion)
+            .numberOfParentControllers(numberOfParentControllers)
+            .numberOfChildControllers(numberOfControllers)
+            .numberOfServers(numberOfServers)
+            .numberOfRouters(numberOfRouters)
+            .replicationFactor(replicationFactor);
+
+    parentControllerProps.ifPresent(optionsBuilder::parentControllerProperties);
+    childControllerProperties.ifPresent(optionsBuilder::childControllerProperties);
+    serverProps.ifPresent(optionsBuilder::serverProperties);
+    return getVeniceTwoLayerMultiRegionMultiClusterWrapper(optionsBuilder.build());
   }
 
   public static VeniceTwoLayerMultiRegionMultiClusterWrapper getVeniceTwoLayerMultiRegionMultiClusterWrapper(
@@ -461,20 +455,27 @@ public class ServiceFactory {
       Optional<Properties> childControllerProperties,
       Optional<Properties> serverProps,
       boolean forkServer) {
+    VeniceMultiRegionClusterCreateOptions.Builder optionsBuilder =
+        new VeniceMultiRegionClusterCreateOptions.Builder().numberOfRegions(numberOfRegions)
+            .numberOfClusters(numberOfClustersInEachRegion)
+            .numberOfParentControllers(numberOfParentControllers)
+            .numberOfChildControllers(numberOfControllers)
+            .numberOfServers(numberOfServers)
+            .numberOfRouters(numberOfRouters)
+            .replicationFactor(replicationFactor)
+            .forkServer(forkServer);
+
+    parentControllerProps.ifPresent(optionsBuilder::parentControllerProperties);
+    childControllerProperties.ifPresent(optionsBuilder::childControllerProperties);
+    serverProps.ifPresent(optionsBuilder::serverProperties);
+    return getVeniceTwoLayerMultiRegionMultiClusterWrapper(optionsBuilder.build());
+  }
+
+  public static VeniceTwoLayerMultiRegionMultiClusterWrapper getVeniceTwoLayerMultiRegionMultiClusterWrapper(
+      VeniceMultiRegionClusterCreateOptions options) {
     return getService(
         VeniceTwoLayerMultiRegionMultiClusterWrapper.SERVICE_NAME,
-        VeniceTwoLayerMultiRegionMultiClusterWrapper.generateService(
-            numberOfRegions,
-            numberOfClustersInEachRegion,
-            numberOfParentControllers,
-            numberOfControllers,
-            numberOfServers,
-            numberOfRouters,
-            replicationFactor,
-            parentControllerProps,
-            childControllerProperties,
-            serverProps,
-            forkServer));
+        VeniceTwoLayerMultiRegionMultiClusterWrapper.generateService(options));
   }
 
   public static HelixAsAServiceWrapper getHelixController(String zkAddress) {

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceMultiClusterCreateOptions.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceMultiClusterCreateOptions.java
@@ -6,6 +6,7 @@ import static com.linkedin.venice.integration.utils.VeniceClusterWrapperConstant
 import static com.linkedin.venice.integration.utils.VeniceClusterWrapperConstants.DEFAULT_NUMBER_OF_SERVERS;
 import static com.linkedin.venice.integration.utils.VeniceClusterWrapperConstants.DEFAULT_PARTITION_SIZE_BYTES;
 import static com.linkedin.venice.integration.utils.VeniceClusterWrapperConstants.DEFAULT_REPLICATION_FACTOR;
+import static com.linkedin.venice.integration.utils.VeniceClusterWrapperConstants.DEFAULT_SSL_TO_KAFKA;
 import static com.linkedin.venice.integration.utils.VeniceClusterWrapperConstants.DEFAULT_SSL_TO_STORAGE_NODES;
 import static com.linkedin.venice.integration.utils.VeniceClusterWrapperConstants.STANDALONE_REGION_NAME;
 
@@ -27,6 +28,7 @@ public class VeniceMultiClusterCreateOptions {
   private final boolean enableAllowlist;
   private final boolean enableAutoJoinAllowlist;
   private final boolean sslToStorageNodes;
+  private final boolean sslToKafka;
   private final boolean randomizeClusterName;
   private final boolean multiRegionSetup;
   private final boolean forkServer;
@@ -82,6 +84,10 @@ public class VeniceMultiClusterCreateOptions {
 
   public boolean isSslToStorageNodes() {
     return sslToStorageNodes;
+  }
+
+  public boolean isSslToKafka() {
+    return sslToKafka;
   }
 
   public boolean isRandomizeClusterName() {
@@ -155,6 +161,9 @@ public class VeniceMultiClusterCreateOptions {
         .append("sslToStorageNodes:")
         .append(sslToStorageNodes)
         .append(", ")
+        .append("sslToKafka:")
+        .append(sslToKafka)
+        .append(", ")
         .append("forkServer:")
         .append(forkServer)
         .append(", ")
@@ -195,6 +204,7 @@ public class VeniceMultiClusterCreateOptions {
     rebalanceDelayMs = builder.rebalanceDelayMs;
     minActiveReplica = builder.minActiveReplica;
     sslToStorageNodes = builder.sslToStorageNodes;
+    sslToKafka = builder.sslToKafka;
     randomizeClusterName = builder.randomizeClusterName;
     multiRegionSetup = builder.multiRegionSetup;
     zkServerWrapper = builder.zkServerWrapper;
@@ -207,7 +217,7 @@ public class VeniceMultiClusterCreateOptions {
 
   public static class Builder {
     private String regionName;
-    private final int numberOfClusters;
+    private int numberOfClusters;
     private int numberOfControllers = DEFAULT_NUMBER_OF_CONTROLLERS;
     private int numberOfServers = DEFAULT_NUMBER_OF_SERVERS;
     private int numberOfRouters = DEFAULT_NUMBER_OF_ROUTERS;
@@ -218,6 +228,7 @@ public class VeniceMultiClusterCreateOptions {
     private boolean enableAllowlist = false;
     private boolean enableAutoJoinAllowlist = false;
     private boolean sslToStorageNodes = DEFAULT_SSL_TO_STORAGE_NODES;
+    private boolean sslToKafka = DEFAULT_SSL_TO_KAFKA;
     private boolean randomizeClusterName = true;
     private boolean multiRegionSetup = false;
     private boolean forkServer = false;
@@ -228,8 +239,9 @@ public class VeniceMultiClusterCreateOptions {
     private Properties childControllerProperties;
     private Properties extraProperties;
 
-    public Builder(int numberOfClusters) {
+    public Builder setNumberOfClusters(int numberOfClusters) {
       this.numberOfClusters = numberOfClusters;
+      return this;
     }
 
     public Builder regionName(String regionName) {
@@ -288,6 +300,11 @@ public class VeniceMultiClusterCreateOptions {
       return this;
     }
 
+    public Builder sslToKafka(boolean sslToKafka) {
+      this.sslToKafka = sslToKafka;
+      return this;
+    }
+
     public Builder randomizeClusterName(boolean randomizeClusterName) {
       this.randomizeClusterName = randomizeClusterName;
       return this;
@@ -329,6 +346,9 @@ public class VeniceMultiClusterCreateOptions {
     }
 
     private void addDefaults() {
+      if (numberOfClusters == 0) {
+        numberOfClusters = 1;
+      }
       if (!isMinActiveReplicaSet) {
         minActiveReplica = replicationFactor - 1;
       }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceMultiClusterCreateOptions.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceMultiClusterCreateOptions.java
@@ -239,7 +239,7 @@ public class VeniceMultiClusterCreateOptions {
     private Properties childControllerProperties;
     private Properties extraProperties;
 
-    public Builder setNumberOfClusters(int numberOfClusters) {
+    public Builder numberOfClusters(int numberOfClusters) {
       this.numberOfClusters = numberOfClusters;
       return this;
     }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceMultiRegionClusterCreateOptions.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceMultiRegionClusterCreateOptions.java
@@ -1,0 +1,256 @@
+package com.linkedin.venice.integration.utils;
+
+import static com.linkedin.venice.integration.utils.VeniceClusterWrapperConstants.DEFAULT_NUMBER_OF_CONTROLLERS;
+import static com.linkedin.venice.integration.utils.VeniceClusterWrapperConstants.DEFAULT_NUMBER_OF_ROUTERS;
+import static com.linkedin.venice.integration.utils.VeniceClusterWrapperConstants.DEFAULT_NUMBER_OF_SERVERS;
+import static com.linkedin.venice.integration.utils.VeniceClusterWrapperConstants.DEFAULT_REPLICATION_FACTOR;
+import static com.linkedin.venice.integration.utils.VeniceClusterWrapperConstants.DEFAULT_SSL_TO_KAFKA;
+import static com.linkedin.venice.integration.utils.VeniceClusterWrapperConstants.DEFAULT_SSL_TO_STORAGE_NODES;
+
+import com.linkedin.venice.authorization.AuthorizerService;
+import java.util.Properties;
+
+
+public class VeniceMultiRegionClusterCreateOptions {
+  private final int numberOfRegions;
+  private final int numberOfClusters;
+  private final int numberOfParentControllers;
+  private final int numberOfChildControllers;
+  private final int numberOfServers;
+  private final int numberOfRouters;
+  private final int replicationFactor;
+  private final boolean sslToStorageNodes;
+  private final boolean sslToKafka;
+  private final boolean forkServer;
+  private final Properties parentControllerProperties;
+  private final Properties childControllerProperties;
+  private final Properties serverProperties;
+  private final AuthorizerService parentAuthorizerService;
+
+  public int getNumberOfRegions() {
+    return numberOfRegions;
+  }
+
+  public int getNumberOfClusters() {
+    return numberOfClusters;
+  }
+
+  public int getNumberOfParentControllers() {
+    return numberOfParentControllers;
+  }
+
+  public int getNumberOfChildControllers() {
+    return numberOfChildControllers;
+  }
+
+  public int getNumberOfServers() {
+    return numberOfServers;
+  }
+
+  public int getNumberOfRouters() {
+    return numberOfRouters;
+  }
+
+  public int getReplicationFactor() {
+    return replicationFactor;
+  }
+
+  public boolean isSslToStorageNodes() {
+    return sslToStorageNodes;
+  }
+
+  public boolean isSslToKafka() {
+    return sslToKafka;
+  }
+
+  public boolean isForkServer() {
+    return forkServer;
+  }
+
+  public Properties getParentControllerProperties() {
+    return parentControllerProperties;
+  }
+
+  public Properties getChildControllerProperties() {
+    return childControllerProperties;
+  }
+
+  public Properties getServerProperties() {
+    return serverProperties;
+  }
+
+  public AuthorizerService getParentAuthorizerService() {
+    return parentAuthorizerService;
+  }
+
+  @Override
+  public String toString() {
+    return new StringBuilder().append("VeniceMultiClusterCreateOptions - ")
+        .append("numberOfRegions:")
+        .append(numberOfRegions)
+        .append(", ")
+        .append("clusters:")
+        .append(numberOfClusters)
+        .append(", ")
+        .append("parent controllers:")
+        .append(numberOfParentControllers)
+        .append(", ")
+        .append("child controllers:")
+        .append(numberOfChildControllers)
+        .append(", ")
+        .append("servers:")
+        .append(numberOfServers)
+        .append(", ")
+        .append("routers:")
+        .append(numberOfRouters)
+        .append(", ")
+        .append("replicationFactor:")
+        .append(replicationFactor)
+        .append(", ")
+        .append("sslToStorageNodes:")
+        .append(sslToStorageNodes)
+        .append(", ")
+        .append("sslToKafka:")
+        .append(sslToKafka)
+        .append(", ")
+        .append("forkServer:")
+        .append(forkServer)
+        .append(", ")
+        .append("childControllerProperties:")
+        .append(childControllerProperties)
+        .append(", ")
+        .append("parentControllerProperties:")
+        .append(parentControllerProperties)
+        .append(", ")
+        .append("serverProperties:")
+        .append(serverProperties)
+        .append(", ")
+        .append("parentAuthorizerService:")
+        .append(parentAuthorizerService)
+        .toString();
+  }
+
+  private VeniceMultiRegionClusterCreateOptions(Builder builder) {
+    numberOfRegions = builder.numberOfRegions;
+    numberOfClusters = builder.numberOfClusters;
+    numberOfParentControllers = builder.numberOfParentControllers;
+    numberOfChildControllers = builder.numberOfChildControllers;
+    numberOfServers = builder.numberOfServers;
+    numberOfRouters = builder.numberOfRouters;
+    replicationFactor = builder.replicationFactor;
+    parentControllerProperties = builder.parentControllerProperties;
+    childControllerProperties = builder.childControllerProperties;
+    serverProperties = builder.serverProperties;
+    sslToStorageNodes = builder.sslToStorageNodes;
+    sslToKafka = builder.sslToKafka;
+    forkServer = builder.forkServer;
+    parentAuthorizerService = builder.parentAuthorizerService;
+  }
+
+  public static class Builder {
+    private int numberOfRegions;
+    private int numberOfClusters;
+    private int numberOfParentControllers = DEFAULT_NUMBER_OF_CONTROLLERS;
+    private int numberOfChildControllers = DEFAULT_NUMBER_OF_CONTROLLERS;
+    private int numberOfServers = DEFAULT_NUMBER_OF_SERVERS;
+    private int numberOfRouters = DEFAULT_NUMBER_OF_ROUTERS;
+    private int replicationFactor = DEFAULT_REPLICATION_FACTOR;
+    private boolean sslToStorageNodes = DEFAULT_SSL_TO_STORAGE_NODES;
+    private boolean sslToKafka = DEFAULT_SSL_TO_KAFKA;
+    private boolean forkServer = false;
+    private Properties parentControllerProperties;
+    private Properties childControllerProperties;
+    private Properties serverProperties;
+    private AuthorizerService parentAuthorizerService;
+
+    public Builder numberOfRegions(int numberOfRegions) {
+      this.numberOfRegions = numberOfRegions;
+      return this;
+    }
+
+    public Builder numberOfClusters(int numberOfClusters) {
+      this.numberOfClusters = numberOfClusters;
+      return this;
+    }
+
+    public Builder numberOfParentControllers(int numberOfParentControllers) {
+      this.numberOfParentControllers = numberOfParentControllers;
+      return this;
+    }
+
+    public Builder numberOfChildControllers(int numberOfChildControllers) {
+      this.numberOfChildControllers = numberOfChildControllers;
+      return this;
+    }
+
+    public Builder numberOfServers(int numberOfServers) {
+      this.numberOfServers = numberOfServers;
+      return this;
+    }
+
+    public Builder numberOfRouters(int numberOfRouters) {
+      this.numberOfRouters = numberOfRouters;
+      return this;
+    }
+
+    public Builder replicationFactor(int replicationFactor) {
+      this.replicationFactor = replicationFactor;
+      return this;
+    }
+
+    public Builder sslToStorageNodes(boolean sslToStorageNodes) {
+      this.sslToStorageNodes = sslToStorageNodes;
+      return this;
+    }
+
+    public Builder sslToKafka(boolean sslToKafka) {
+      this.sslToKafka = sslToKafka;
+      return this;
+    }
+
+    public Builder forkServer(boolean forkServer) {
+      this.forkServer = forkServer;
+      return this;
+    }
+
+    public Builder parentControllerProperties(Properties parentControllerProperties) {
+      this.parentControllerProperties = parentControllerProperties;
+      return this;
+    }
+
+    public Builder childControllerProperties(Properties childControllerProperties) {
+      this.childControllerProperties = childControllerProperties;
+      return this;
+    }
+
+    public Builder serverProperties(Properties serverProperties) {
+      this.serverProperties = serverProperties;
+      return this;
+    }
+
+    public Builder parentAuthorizerService(AuthorizerService parentAuthorizerService) {
+      this.parentAuthorizerService = parentAuthorizerService;
+      return this;
+    }
+
+    private void addDefaults() {
+      if (numberOfRegions == 0) {
+        numberOfRegions = 1;
+      }
+      if (numberOfClusters == 0) {
+        numberOfClusters = 1;
+      }
+      if (parentControllerProperties == null) {
+        parentControllerProperties = new Properties();
+      }
+      if (childControllerProperties == null) {
+        childControllerProperties = new Properties();
+      }
+    }
+
+    public VeniceMultiRegionClusterCreateOptions build() {
+      addDefaults();
+      return new VeniceMultiRegionClusterCreateOptions(this);
+    }
+  }
+}

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceMultiRegionClusterCreateOptions.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceMultiRegionClusterCreateOptions.java
@@ -240,12 +240,6 @@ public class VeniceMultiRegionClusterCreateOptions {
       if (numberOfClusters == 0) {
         numberOfClusters = 1;
       }
-      if (parentControllerProperties == null) {
-        parentControllerProperties = new Properties();
-      }
-      if (childControllerProperties == null) {
-        childControllerProperties = new Properties();
-      }
     }
 
     public VeniceMultiRegionClusterCreateOptions build() {

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceTwoLayerMultiRegionMultiClusterWrapper.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceTwoLayerMultiRegionMultiClusterWrapper.java
@@ -73,45 +73,10 @@ public class VeniceTwoLayerMultiRegionMultiClusterWrapper extends ProcessWrapper
   }
 
   static ServiceProvider<VeniceTwoLayerMultiRegionMultiClusterWrapper> generateService(
-      int numberOfRegions,
-      int numberOfClustersInEachRegion,
-      int numberOfParentControllers,
-      int numberOfControllers,
-      int numberOfServers,
-      int numberOfRouters,
-      int replicationFactor,
-      Optional<Properties> parentControllerProperties,
-      Optional<Properties> serverProperties) {
-    return generateService(
-        numberOfRegions,
-        numberOfClustersInEachRegion,
-        numberOfParentControllers,
-        numberOfControllers,
-        numberOfServers,
-        numberOfRouters,
-        replicationFactor,
-        parentControllerProperties,
-        Optional.empty(),
-        serverProperties,
-        false);
-  }
-
-  static ServiceProvider<VeniceTwoLayerMultiRegionMultiClusterWrapper> generateService(
-      int numberOfRegions,
-      int numberOfClustersInEachRegion,
-      int numberOfParentControllers,
-      int numberOfControllers,
-      int numberOfServers,
-      int numberOfRouters,
-      int replicationFactor,
-      Optional<Properties> parentControllerPropertiesOverride,
-      Optional<Properties> childControllerPropertiesOverride,
-      Optional<Properties> serverProperties,
-      boolean forkServer) {
+      VeniceMultiRegionClusterCreateOptions options) {
     String parentRegionName = DEFAULT_PARENT_DATA_CENTER_REGION_NAME;
-    final List<VeniceControllerWrapper> parentControllers = new ArrayList<>(numberOfParentControllers);
-    final List<VeniceMultiClusterWrapper> multiClusters = new ArrayList<>(numberOfRegions);
-
+    final List<VeniceControllerWrapper> parentControllers = new ArrayList<>(options.getNumberOfParentControllers());
+    final List<VeniceMultiClusterWrapper> multiClusters = new ArrayList<>(options.getNumberOfRegions());
     /**
      * Enable participant system store by default in a two-layer multi-region set-up
      */
@@ -133,8 +98,8 @@ public class VeniceTwoLayerMultiRegionMultiClusterWrapper extends ProcessWrapper
 
       Map<String, String> clusterToD2 = new HashMap<>();
       Map<String, String> clusterToServerD2 = new HashMap<>();
-      String[] clusterNames = new String[numberOfClustersInEachRegion];
-      for (int i = 0; i < numberOfClustersInEachRegion; i++) {
+      String[] clusterNames = new String[options.getNumberOfClusters()];
+      for (int i = 0; i < options.getNumberOfClusters(); i++) {
         String clusterName = "venice-cluster" + i;
         clusterNames[i] = clusterName;
         String routerD2ServiceName = "venice-" + i;
@@ -142,9 +107,9 @@ public class VeniceTwoLayerMultiRegionMultiClusterWrapper extends ProcessWrapper
         String serverD2ServiceName = Utils.getUniqueString(clusterName + "_d2");
         clusterToServerD2.put(clusterName, serverD2ServiceName);
       }
-      List<String> childRegionName = new ArrayList<>(numberOfRegions);
+      List<String> childRegionName = new ArrayList<>(options.getNumberOfRegions());
 
-      for (int i = 0; i < numberOfRegions; i++) {
+      for (int i = 0; i < options.getNumberOfRegions(); i++) {
         childRegionName.add(CHILD_REGION_NAME_PREFIX + i);
       }
 
@@ -171,7 +136,10 @@ public class VeniceTwoLayerMultiRegionMultiClusterWrapper extends ProcessWrapper
 
       final Properties finalParentControllerProperties = new Properties();
       finalParentControllerProperties.putAll(defaultParentControllerProps);
-      parentControllerPropertiesOverride.ifPresent(finalParentControllerProperties::putAll);
+      Properties parentControllerPropsOverride = options.getParentControllerProperties();
+      if (parentControllerPropsOverride != null) {
+        finalParentControllerProperties.putAll(parentControllerPropsOverride);
+      }
 
       Properties nativeReplicationRequiredChildControllerProps = new Properties();
       nativeReplicationRequiredChildControllerProps.put(ADMIN_TOPIC_SOURCE_REGION, parentRegionName);
@@ -200,10 +168,15 @@ public class VeniceTwoLayerMultiRegionMultiClusterWrapper extends ProcessWrapper
 
       final Properties finalChildControllerProperties = new Properties();
       finalChildControllerProperties.putAll(defaultChildControllerProps);
-      childControllerPropertiesOverride.ifPresent(finalChildControllerProperties::putAll);
+      Properties childControllerPropsOverride = options.getChildControllerProperties();
+      if (childControllerPropsOverride != null) {
+        finalChildControllerProperties.putAll(childControllerPropsOverride);
+      }
 
-      Map<String, Map<String, String>> kafkaClusterMap =
-          addKafkaClusterIDMappingToServerConfigs(serverProperties, childRegionName, allPubSubBrokerWrappers);
+      Map<String, Map<String, String>> kafkaClusterMap = addKafkaClusterIDMappingToServerConfigs(
+          Optional.ofNullable(options.getServerProperties()),
+          childRegionName,
+          allPubSubBrokerWrappers);
 
       Map<String, String> pubSubBrokerProps = PubSubBrokerWrapper.getBrokerDetailsForClients(allPubSubBrokerWrappers);
       LOGGER.info("### PubSub broker configs: {}", pubSubBrokerProps);
@@ -211,24 +184,28 @@ public class VeniceTwoLayerMultiRegionMultiClusterWrapper extends ProcessWrapper
       finalChildControllerProperties.putAll(pubSubBrokerProps); // child controllers
 
       Properties additionalServerProps = new Properties();
-      serverProperties.ifPresent(additionalServerProps::putAll);
+      Properties serverPropsOverride = options.getServerProperties();
+      if (serverPropsOverride != null) {
+        additionalServerProps.putAll(serverPropsOverride);
+      }
       additionalServerProps.putAll(pubSubBrokerProps);
-      serverProperties = Optional.of(additionalServerProps);
 
       VeniceMultiClusterCreateOptions.Builder builder =
-          new VeniceMultiClusterCreateOptions.Builder(numberOfClustersInEachRegion)
-              .numberOfControllers(numberOfControllers)
-              .numberOfServers(numberOfServers)
-              .numberOfRouters(numberOfRouters)
-              .replicationFactor(replicationFactor)
+          new VeniceMultiClusterCreateOptions.Builder().setNumberOfClusters(options.getNumberOfClusters())
+              .numberOfControllers(options.getNumberOfChildControllers())
+              .numberOfServers(options.getNumberOfServers())
+              .numberOfRouters(options.getNumberOfRouters())
+              .replicationFactor(options.getReplicationFactor())
               .randomizeClusterName(false)
               .multiRegionSetup(true)
               .childControllerProperties(finalChildControllerProperties)
-              .extraProperties(serverProperties.orElse(null))
-              .forkServer(forkServer)
+              .extraProperties(additionalServerProps)
+              .sslToStorageNodes(options.isSslToStorageNodes())
+              .sslToKafka(options.isSslToKafka())
+              .forkServer(options.isForkServer())
               .kafkaClusterMap(kafkaClusterMap);
       // Create multi-clusters
-      for (int i = 0; i < numberOfRegions; i++) {
+      for (int i = 0; i < options.getNumberOfRegions(); i++) {
         String regionName = childRegionName.get(i);
         builder.regionName(regionName)
             .kafkaBrokerWrapper(pubSubBrokerByRegionName.get(regionName))
@@ -250,15 +227,16 @@ public class VeniceTwoLayerMultiRegionMultiClusterWrapper extends ProcessWrapper
           VeniceControllerWrapper.PARENT_D2_SERVICE_NAME);
       VeniceControllerCreateOptions parentControllerCreateOptions =
           new VeniceControllerCreateOptions.Builder(clusterNames, zkServer, parentPubSubBrokerWrapper)
-              .replicationFactor(replicationFactor)
+              .replicationFactor(options.getReplicationFactor())
               .childControllers(childControllers)
               .extraProperties(finalParentControllerProperties)
               .clusterToD2(clusterToD2)
               .clusterToServerD2(clusterToServerD2)
               .regionName(parentRegionName)
+              .authorizerService(options.getParentAuthorizerService())
               .build();
       // Create parentControllers for multi-cluster
-      for (int i = 0; i < numberOfParentControllers; i++) {
+      for (int i = 0; i < options.getNumberOfParentControllers(); i++) {
         VeniceControllerWrapper parentController = ServiceFactory.getVeniceController(parentControllerCreateOptions);
         parentControllers.add(parentController);
       }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceTwoLayerMultiRegionMultiClusterWrapper.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceTwoLayerMultiRegionMultiClusterWrapper.java
@@ -191,7 +191,7 @@ public class VeniceTwoLayerMultiRegionMultiClusterWrapper extends ProcessWrapper
       additionalServerProps.putAll(pubSubBrokerProps);
 
       VeniceMultiClusterCreateOptions.Builder builder =
-          new VeniceMultiClusterCreateOptions.Builder().setNumberOfClusters(options.getNumberOfClusters())
+          new VeniceMultiClusterCreateOptions.Builder().numberOfClusters(options.getNumberOfClusters())
               .numberOfControllers(options.getNumberOfChildControllers())
               .numberOfServers(options.getNumberOfServers())
               .numberOfRouters(options.getNumberOfRouters())

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/multicluster/TestMetadataOperationInMultiCluster.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/multicluster/TestMetadataOperationInMultiCluster.java
@@ -44,7 +44,8 @@ public class TestMetadataOperationInMultiCluster {
     String keySchema = "\"string\"";
     String valSchema = "\"string\"";
 
-    VeniceMultiClusterCreateOptions options = new VeniceMultiClusterCreateOptions.Builder(2).numberOfControllers(3)
+    VeniceMultiClusterCreateOptions options = new VeniceMultiClusterCreateOptions.Builder().setNumberOfClusters(2)
+        .numberOfControllers(3)
         .numberOfServers(1)
         .numberOfRouters(1)
         .regionName(VeniceClusterWrapperConstants.STANDALONE_REGION_NAME)
@@ -133,7 +134,8 @@ public class TestMetadataOperationInMultiCluster {
 
   @Test
   public void testRunVPJInMultiCluster() throws Exception {
-    VeniceMultiClusterCreateOptions options = new VeniceMultiClusterCreateOptions.Builder(2).numberOfControllers(3)
+    VeniceMultiClusterCreateOptions options = new VeniceMultiClusterCreateOptions.Builder().setNumberOfClusters(2)
+        .numberOfControllers(3)
         .numberOfServers(1)
         .numberOfRouters(1)
         .regionName(VeniceClusterWrapperConstants.STANDALONE_REGION_NAME)

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/multicluster/TestMetadataOperationInMultiCluster.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/multicluster/TestMetadataOperationInMultiCluster.java
@@ -44,7 +44,7 @@ public class TestMetadataOperationInMultiCluster {
     String keySchema = "\"string\"";
     String valSchema = "\"string\"";
 
-    VeniceMultiClusterCreateOptions options = new VeniceMultiClusterCreateOptions.Builder().setNumberOfClusters(2)
+    VeniceMultiClusterCreateOptions options = new VeniceMultiClusterCreateOptions.Builder().numberOfClusters(2)
         .numberOfControllers(3)
         .numberOfServers(1)
         .numberOfRouters(1)
@@ -134,7 +134,7 @@ public class TestMetadataOperationInMultiCluster {
 
   @Test
   public void testRunVPJInMultiCluster() throws Exception {
-    VeniceMultiClusterCreateOptions options = new VeniceMultiClusterCreateOptions.Builder().setNumberOfClusters(2)
+    VeniceMultiClusterCreateOptions options = new VeniceMultiClusterCreateOptions.Builder().numberOfClusters(2)
         .numberOfControllers(3)
         .numberOfServers(1)
         .numberOfRouters(1)

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/router/TestBlobDiscovery.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/router/TestBlobDiscovery.java
@@ -68,10 +68,11 @@ import org.testng.annotations.Test;
 public class TestBlobDiscovery {
   private static final String INT_KEY_SCHEMA = "\"int\"";
   private static final String INT_VALUE_SCHEMA = "\"int\"";
-  String clusterName;
-  String storeName;
+  private String clusterName;
+  private String storeName;
+  private VeniceTwoLayerMultiRegionMultiClusterWrapper multiRegionMultiClusterWrapper;
   private VeniceMultiClusterWrapper multiClusterVenice;
-  D2Client daVinciD2;
+  private D2Client daVinciD2;
 
   /**
    * Set up a multi-cluster Venice environment with meta system store enabled Venice stores.
@@ -84,19 +85,18 @@ public class TestBlobDiscovery {
     Properties parentControllerProps = new Properties();
     parentControllerProps.put(OFFLINE_JOB_START_TIMEOUT_MS, "180000");
 
-    VeniceTwoLayerMultiRegionMultiClusterWrapper multiRegionMultiClusterWrapper =
-        ServiceFactory.getVeniceTwoLayerMultiRegionMultiClusterWrapper(
-            1,
-            2,
-            1,
-            1,
-            3,
-            1,
-            3,
-            Optional.of(parentControllerProps),
-            Optional.empty(),
-            Optional.empty(),
-            false);
+    multiRegionMultiClusterWrapper = ServiceFactory.getVeniceTwoLayerMultiRegionMultiClusterWrapper(
+        1,
+        2,
+        1,
+        1,
+        3,
+        1,
+        3,
+        Optional.of(parentControllerProps),
+        Optional.empty(),
+        Optional.empty(),
+        false);
 
     multiClusterVenice = multiRegionMultiClusterWrapper.getChildRegions().get(0);
     String[] clusterNames = multiClusterVenice.getClusterNames();
@@ -183,9 +183,10 @@ public class TestBlobDiscovery {
     }
   }
 
-  @AfterTest
+  @AfterTest(alwaysRun = true)
   public void tearDown() {
     D2ClientUtils.shutdownClient(daVinciD2);
+    Utils.closeQuietlyWithErrorLogged(multiRegionMultiClusterWrapper);
   }
 
   @Test(timeOut = 60 * Time.MS_PER_SECOND)

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/Admin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/Admin.java
@@ -25,6 +25,7 @@ import com.linkedin.venice.meta.VeniceUserStoreType;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.persona.StoragePersona;
 import com.linkedin.venice.pubsub.PubSubConsumerAdapterFactory;
+import com.linkedin.venice.pubsub.PubSubTopicRepository;
 import com.linkedin.venice.pubsub.manager.TopicManager;
 import com.linkedin.venice.pushmonitor.ExecutionStatus;
 import com.linkedin.venice.pushstatushelper.PushStatusStoreReader;
@@ -1001,4 +1002,11 @@ public interface Admin extends AutoCloseable, Closeable {
    * Read the latest heartbeat timestamp from system store. If it failed to read from system store, this method should return -1.
    */
   long getHeartbeatFromSystemStore(String clusterName, String storeName);
+
+  /**
+   * @return the aggregate resources required by controller to manage a Venice cluster.
+   */
+  HelixVeniceClusterResources getHelixVeniceClusterResources(String cluster);
+
+  PubSubTopicRepository getPubSubTopicRepository();
 }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
@@ -3273,7 +3273,7 @@ public class VeniceParentHelixAdmin implements Admin {
       }
 
       LOGGER.info(
-          "Adding Replication metadata schema: for store: {} in cluster: {} metadataSchema: {} "
+          "Adding Replication metadata schema for store: {} in cluster: {} metadataSchema: {} "
               + "replicationMetadataVersionId: {} valueSchemaId: {}",
           storeName,
           clusterName,
@@ -5441,5 +5441,15 @@ public class VeniceParentHelixAdmin implements Admin {
   @Override
   public long getHeartbeatFromSystemStore(String clusterName, String storeName) {
     throw new VeniceUnsupportedOperationException("getHeartbeatFromSystemStore");
+  }
+
+  @Override
+  public HelixVeniceClusterResources getHelixVeniceClusterResources(String cluster) {
+    return getVeniceHelixAdmin().getHelixVeniceClusterResources(cluster);
+  }
+
+  @Override
+  public PubSubTopicRepository getPubSubTopicRepository() {
+    return pubSubTopicRepository;
   }
 }


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Fix multi-region tests to use `VeniceTwoLayerMultiRegionMultiClusterWrapper`
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
There are several tests that create multi-region clusters through manual, non-standard setups. An example of this is that many tests create a multi-region cluster that shares the same Kafka cluster between them. While this might be valuable for some tests, it is a maintenance overhead for most of them. Our test suite already has `VeniceTwoLayerMultiRegionMultiClusterWrapper` that can be used directly for all current use-cases.

This commit replaces all tests that setup a multi-region test cluster through non-standard means to use `VeniceTwoLayerMultiRegionMultiClusterWrapper` instead. 

This commit also fixes an issue where if the config to enable active active by default for batch-only stores is enabled, new store creation for system stores makes them also active-active. This was masked previously by different configs set on child and parent controllers. So, running this config in parent controller would have been problematic.

This change exposed another bug that storage persona only runs validations when running in a multi-region setups while there is nothing conceptually blocking it from running in a single-region setup. This will be addressed in a follow up PR.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
GH CI

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.