### PR TITLE
[router] Fix MultiSchemaResponse fetch in metadata handler

### DIFF
--- a/services/venice-router/src/main/java/com/linkedin/venice/router/MetaDataHandler.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/MetaDataHandler.java
@@ -313,11 +313,13 @@ public class MetaDataHandler extends SimpleChannelInboundHandler<HttpRequest> {
       Collection<SchemaEntry> valueSchemaEntries = schemaRepo.getValueSchemas(storeName);
       int schemaNum = valueSchemaEntries.size();
       MultiSchemaResponse.Schema[] schemas = new MultiSchemaResponse.Schema[schemaNum];
+      int index = 0;
       for (SchemaEntry entry: valueSchemaEntries) {
         int schemaId = entry.getId();
-        schemas[schemaId - 1] = new MultiSchemaResponse.Schema();
-        schemas[schemaId - 1].setId(schemaId);
-        schemas[schemaId - 1].setSchemaStr(entry.getSchema().toString());
+        schemas[index] = new MultiSchemaResponse.Schema();
+        schemas[index].setId(schemaId);
+        schemas[index].setSchemaStr(entry.getSchema().toString());
+        index++;
       }
       responseObject.setSchemas(schemas);
       setupResponseAndFlush(OK, OBJECT_MAPPER.writeValueAsBytes(responseObject), true, ctx);


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Fix MultiSchemaResponse fetch in metadata handler
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

In `handleValueSchemaLookup` it allocated the schema response into a array of size number of schemas and sets them using the schema id as index into the array.  But if there are schemas which are deleted then those insertions would throw `java.lang.ArrayIndexOutOfBoundsException`. This PR fixes that.
 
## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
unit test
## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.