### PR TITLE
[controller] Helix resources should be removed after a VPJ kill job

### DIFF
--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -3269,9 +3269,6 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
         return;
       }
       String resourceName = Version.composeKafkaTopic(storeName, versionNumber);
-      LOGGER.info("Deleting helix resource: {} in cluster: {}", resourceName, clusterName);
-      deleteHelixResource(clusterName, resourceName);
-      LOGGER.info("Killing offline push for: {} in cluster: {}", resourceName, clusterName);
       killOfflinePush(clusterName, resourceName, true);
 
       // Check DIV error in the push status before stopping the monitor.
@@ -5192,6 +5189,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
 
   @Override
   public void deleteHelixResource(String clusterName, String kafkaTopic) {
+    LOGGER.info("Deleting helix resource: {} in cluster: {}", kafkaTopic, clusterName);
     checkControllerLeadershipFor(clusterName);
 
     getHelixAdminClient().dropResource(clusterName, kafkaTopic);
@@ -6526,6 +6524,11 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
       LOGGER.info("Resource: {} doesn't exist, kill job will be skipped", kafkaTopic);
       return;
     }
+
+    deleteHelixResource(clusterName, kafkaTopic);
+
+    LOGGER.info("Killing offline push for: {} in cluster: {}", kafkaTopic, clusterName);
+
     checkPreConditionForKillOfflinePush(clusterName, kafkaTopic);
     HelixVeniceClusterResources resources = getHelixVeniceClusterResources(clusterName);
     if (!isForcedKill) {

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceHelixAdmin.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestVeniceHelixAdmin.java
@@ -141,7 +141,11 @@ public class TestVeniceHelixAdmin {
     HelixVeniceClusterResources helixVeniceClusterResources = mock(HelixVeniceClusterResources.class);
     ClusterLockManager clusterLockManager = mock(ClusterLockManager.class);
     AutoCloseableLock autoCloseableLock = mock(AutoCloseableLock.class);
+    ReadWriteStoreRepository repo = mock(ReadWriteStoreRepository.class);
+    Store store = mock(Store.class);
 
+    doReturn(repo).when(helixVeniceClusterResources).getStoreMetadataRepository();
+    doReturn(store).when(repo).getStore(anyString());
     doReturn(adminClient).when(veniceHelixAdmin).getHelixAdminClient();
     doReturn(listMap).when(adminClient).getDisabledPartitionsMap(clusterName, instance);
     doReturn(autoCloseableLock).when(clusterLockManager).createStoreWriteLockOnly(anyString());


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Summary, imperative, start upper case, don't end with a period
When VPJ initiates the kill-job command, the kill-job commands didn't remove the Helix resource. Added logic to include the helix resource deletion whenever a VPJ fails.

Everytime a VPJ runs the `killOfflinePush` job, it does not remove the helix resources. As part of the job, it calls the killOfflinePush but does not call the method to remove the helix resource. 

Changes follow an example of it doing the killOfflinePush & removing helix resource correctly like [here](https://github.com/linkedin/venice/blob/main/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java#L3276) and [here](https://github.com/linkedin/venice/blob/main/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java#L3274). 



## How was this PR tested?
unit tests 

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [X ] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.