### PR TITLE
[venice-thin-client] Allow refresh while fetching value from router

### DIFF
--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/schema/RouterBackedSchemaReader.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/schema/RouterBackedSchemaReader.java
@@ -187,7 +187,9 @@ public class RouterBackedSchemaReader implements SchemaReader {
 
   @Override
   public Schema getValueSchema(int id) {
-    SchemaEntry valueSchemaEntry = maybeFetchValueSchemaEntryById(id, false);
+    // Should call with refresh as any router transient error can lead to null schema stored in the map
+    // `valueSchemaEntryMap`
+    SchemaEntry valueSchemaEntry = maybeFetchValueSchemaEntryById(id, true);
     if (!isValidSchemaEntry(valueSchemaEntry)) {
       LOGGER.warn("Got null value schema from Venice for store: {} and id: {}", storeName, id);
       return null;
@@ -663,8 +665,8 @@ public class RouterBackedSchemaReader implements SchemaReader {
 
       response = RetryUtils.executeWithMaxAttempt(
           () -> (responseFuture.get()),
-          3,
-          Duration.ofNanos(1),
+          5,
+          Duration.ofMillis(100),
           Collections.singletonList(ExecutionException.class));
     } catch (Exception e) {
       throw new VeniceClientException(

--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/schema/RouterBackedSchemaReader.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/schema/RouterBackedSchemaReader.java
@@ -238,7 +238,7 @@ public class RouterBackedSchemaReader implements SchemaReader {
 
   @Override
   public Schema getUpdateSchema(int valueSchemaId) {
-    DerivedSchemaEntry updateSchemaEntry = maybeUpdateAndFetchUpdateSchemaEntryById(valueSchemaId, false);
+    DerivedSchemaEntry updateSchemaEntry = maybeUpdateAndFetchUpdateSchemaEntryById(valueSchemaId, true);
     if (isValidSchemaEntry(updateSchemaEntry)) {
       return updateSchemaEntry.getSchema();
     }

--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/schema/RouterBackedSchemaReader.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/schema/RouterBackedSchemaReader.java
@@ -477,6 +477,7 @@ public class RouterBackedSchemaReader implements SchemaReader {
         return NOT_EXIST_VALUE_SCHEMA_ENTRY;
       } else {
         valueSchemaEntryMap.put(valueSchemaId, entry);
+        shouldRefreshLatestValueSchemaEntry.compareAndSet(false, true);
         cacheValueAndCanonicalSchemas(entry.getSchema(), valueSchemaId);
         return entry;
       }

--- a/clients/venice-thin-client/src/test/java/com/linkedin/venice/client/schema/RouterBackedSchemaReaderTest.java
+++ b/clients/venice-thin-client/src/test/java/com/linkedin/venice/client/schema/RouterBackedSchemaReaderTest.java
@@ -311,7 +311,7 @@ public class RouterBackedSchemaReaderTest {
        * 1. Fetch value schemas on start up, which takes 2 + 1 = 3 individual call.
        * 2. Fetch update schemas in one of the futures
        */
-      Mockito.verify(storeClient, Mockito.timeout(TIMEOUT).times(4)).getRaw(Mockito.anyString());
+      Mockito.verify(storeClient, Mockito.timeout(TIMEOUT).times(5)).getRaw(Mockito.anyString());
     }
   }
 
@@ -369,7 +369,7 @@ public class RouterBackedSchemaReaderTest {
       Mockito.verify(mockClient, Mockito.timeout(TIMEOUT).times(3)).getRaw(Mockito.anyString());
       Assert.assertNotNull(schemaReader.getLatestValueSchema());
       // Should not be checked again
-      Mockito.verify(mockClient, Mockito.timeout(TIMEOUT).times(3)).getRaw(Mockito.anyString());
+      Mockito.verify(mockClient, Mockito.timeout(TIMEOUT).times(4)).getRaw(Mockito.anyString());
     }
   }
 

--- a/clients/venice-thin-client/src/test/java/com/linkedin/venice/client/schema/RouterBackedSchemaReaderTest.java
+++ b/clients/venice-thin-client/src/test/java/com/linkedin/venice/client/schema/RouterBackedSchemaReaderTest.java
@@ -161,14 +161,14 @@ public class RouterBackedSchemaReaderTest {
       Mockito.verify(mockClient, Mockito.timeout(TIMEOUT).times(2)).getRaw(Mockito.anyString());
       Schema cachedSchema = schemaReader.getValueSchema(3);
       Assert.assertNull(cachedSchema);
-      Mockito.verify(mockClient, Mockito.timeout(TIMEOUT).times(2)).getRaw(Mockito.anyString());
+      Mockito.verify(mockClient, Mockito.timeout(TIMEOUT).times(3)).getRaw(Mockito.anyString());
 
       Schema newSchema = schemaReader.getValueSchema(1);
       Assert.assertEquals(newSchema.toString(), VALUE_SCHEMA_1.toString());
-      Mockito.verify(mockClient, Mockito.timeout(TIMEOUT).times(2)).getRaw(Mockito.anyString());
+      Mockito.verify(mockClient, Mockito.timeout(TIMEOUT).times(3)).getRaw(Mockito.anyString());
 
       Assert.assertEquals(schemaReader.getLatestValueSchema().toString(), VALUE_SCHEMA_2.toString());
-      Mockito.verify(mockClient, Mockito.timeout(TIMEOUT).times(4)).getRaw(Mockito.anyString());
+      Mockito.verify(mockClient, Mockito.timeout(TIMEOUT).times(5)).getRaw(Mockito.anyString());
     }
   }
 


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Allow refresh while fetching value from router
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

When fetching schemas from routers in a thin client, any transient issues can cause requests to fail, leading the client to save a null schema for the schema ID, which results in further request failures. This PR addresses the issue by forcing a refresh during schema fetches and increasing both the retry count and delay for router requests.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
unit test
## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.