### PR TITLE
[server] Ratio Metric for Max Record Size

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
@@ -2,6 +2,7 @@ package com.linkedin.davinci.config;
 
 import static com.linkedin.davinci.ingestion.utils.IsolatedIngestionUtils.INGESTION_ISOLATION_CONFIG_PREFIX;
 import static com.linkedin.davinci.store.rocksdb.RocksDBServerConfig.ROCKSDB_TOTAL_MEMTABLE_USAGE_CAP_IN_BYTES;
+import static com.linkedin.venice.ConfigConstants.DEFAULT_MAX_RECORD_SIZE_BYTES_BACKFILL;
 import static com.linkedin.venice.ConfigKeys.AUTOCREATE_DATA_PATH;
 import static com.linkedin.venice.ConfigKeys.BLOB_TRANSFER_MANAGER_ENABLED;
 import static com.linkedin.venice.ConfigKeys.DATA_BASE_PATH;
@@ -798,7 +799,8 @@ public class VeniceServerConfig extends VeniceClusterConfig {
         serverProperties.getSizeInBytes(DA_VINCI_CURRENT_VERSION_BOOTSTRAPPING_QUOTA_BYTES_PER_SECOND, -1);
     resubscriptionTriggeredByVersionIngestionContextChangeEnabled =
         serverProperties.getBoolean(SERVER_RESUBSCRIPTION_TRIGGERED_BY_VERSION_INGESTION_CONTEXT_CHANGE_ENABLED, false);
-    defaultMaxRecordSizeBytes = serverProperties.getInt(DEFAULT_MAX_RECORD_SIZE_BYTES, 100 * BYTES_PER_MB);
+    defaultMaxRecordSizeBytes =
+        serverProperties.getInt(DEFAULT_MAX_RECORD_SIZE_BYTES, DEFAULT_MAX_RECORD_SIZE_BYTES_BACKFILL);
     if (defaultMaxRecordSizeBytes < BYTES_PER_MB) {
       throw new VeniceException(
           DEFAULT_MAX_RECORD_SIZE_BYTES + ": " + defaultMaxRecordSizeBytes + " must be at least "

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -287,7 +287,9 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
             // .setMaxRecordSizeBytes(store.getMaxRecordSizeBytes()) // TODO: allow when nearline jobs are enforced
             .build();
     this.veniceWriter = Lazy.of(() -> veniceWriterFactory.createVeniceWriter(writerOptions));
-    this.maxRecordSizeBytes = store.getMaxRecordSizeBytes(); // TODO: move to VeniceWriter when nearline jobs enforce
+    this.maxRecordSizeBytes = (store.getMaxRecordSizeBytes() < 0) // TODO: move to VeniceWriter when nearline supported
+        ? serverConfig.getDefaultMaxRecordSizeBytes()
+        : store.getMaxRecordSizeBytes();
     this.kafkaClusterIdToUrlMap = serverConfig.getKafkaClusterIdToUrlMap();
     this.kafkaDataIntegrityValidatorForLeaders = new KafkaDataIntegrityValidator(kafkaVersionTopic);
     if (builder.getVeniceViewWriterFactory() != null && !store.getViewConfigs().isEmpty()) {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -1901,9 +1901,14 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
   }
 
   @Override
-  protected final void recordAssembledRecordSizeRatio(long size, long currentTimeMs) {
+  protected final double calculateAssembledRecordSizeRatio(long recordSize) {
+    return (double) recordSize / maxRecordSizeBytes;
+  }
+
+  @Override
+  protected final void recordAssembledRecordSizeRatio(double ratio, long currentTimeMs) {
     if (maxRecordSizeBytes != VeniceWriter.UNLIMITED_MAX_RECORD_SIZE) {
-      hostLevelIngestionStats.recordAssembledRecordSizeRatio((double) size / maxRecordSizeBytes, currentTimeMs);
+      hostLevelIngestionStats.recordAssembledRecordSizeRatio(ratio, currentTimeMs);
     }
   }
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -284,7 +284,6 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
             .setChunkingEnabled(isChunked)
             .setRmdChunkingEnabled(version.isRmdChunkingEnabled())
             .setPartitionCount(storeVersionPartitionCount)
-            // .setMaxRecordSizeBytes(store.getMaxRecordSizeBytes()) // TODO: allow when nearline jobs are enforced
             .build();
     this.veniceWriter = Lazy.of(() -> veniceWriterFactory.createVeniceWriter(writerOptions));
     this.maxRecordSizeBytes = (store.getMaxRecordSizeBytes() < 0) // TODO: move to VeniceWriter when nearline supported
@@ -1903,9 +1902,9 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
 
   @Override
   protected final void recordAssembledRecordSizeRatio(long size, long currentTimeMs) {
-    final double sizeRatio =
-        (maxRecordSizeBytes == VeniceWriter.UNLIMITED_MAX_RECORD_SIZE) ? 0 : (double) size / maxRecordSizeBytes;
-    hostLevelIngestionStats.recordAssembledRecordSizeRatio(sizeRatio, currentTimeMs);
+    if (maxRecordSizeBytes != VeniceWriter.UNLIMITED_MAX_RECORD_SIZE) {
+      hostLevelIngestionStats.recordAssembledRecordSizeRatio((double) size / maxRecordSizeBytes, currentTimeMs);
+    }
   }
 
   private void recordRegionHybridConsumptionStats(

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -2429,7 +2429,9 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
     hostLevelIngestionStats.recordChecksumVerificationFailure();
   }
 
-  protected abstract void recordAssembledRecordSizeRatio(long recordSize, long currentTimeMs);
+  protected abstract void recordAssembledRecordSizeRatio(double ratio, long currentTimeMs);
+
+  protected abstract double calculateAssembledRecordSizeRatio(long recordSize);
 
   public abstract long getBatchReplicationLag();
 
@@ -3243,7 +3245,8 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
             ByteBuffer rmdPayload = put.getReplicationMetadataPayload();
             boolean isValueManifest = rmdPayload != null && rmdPayload.equals(VeniceWriter.EMPTY_BYTE_BUFFER);
             if (isValueManifest) {
-              recordAssembledRecordSizeRatio(keyLen + chunkedValueManifest.getSize(), currentTimeMs);
+              double ratio = calculateAssembledRecordSizeRatio(keyLen + chunkedValueManifest.getSize());
+              recordAssembledRecordSizeRatio(ratio, currentTimeMs);
               hostLevelIngestionStats.recordAssembledValueSize(chunkedValueManifest.getSize(), currentTimeMs);
             } else { // the manifest pertains to a chunked rmd
               hostLevelIngestionStats.recordAssembledRmdSize(chunkedValueManifest.getSize(), currentTimeMs);

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -179,6 +179,9 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
   private static final ExecutorService SHUTDOWN_EXECUTOR_FOR_DVC =
       Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors() * 2);
 
+  protected static final ChunkedValueManifestSerializer CHUNKED_VALUE_MANIFEST_SERIALIZER =
+      new ChunkedValueManifestSerializer(true);
+
   /** storage destination for consumption */
   protected final StorageEngineRepository storageEngineRepository;
   protected final AbstractStorageEngine storageEngine;
@@ -324,7 +327,6 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
   protected final StorageEngineBackedCompressorFactory compressorFactory;
   protected final Lazy<VeniceCompressor> compressor;
   protected final boolean isChunked;
-  protected final ChunkedValueManifestSerializer manifestSerializer;
   protected final PubSubTopicRepository pubSubTopicRepository;
   private final String[] msgForLagMeasurement;
   private final Runnable runnableForKillIngestionTasksForNonCurrentVersions;
@@ -483,7 +485,6 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
     this.compressorFactory = builder.getCompressorFactory();
     this.compressor = Lazy.of(() -> compressorFactory.getCompressor(compressionStrategy, kafkaVersionTopic));
     this.isChunked = version.isChunkingEnabled();
-    this.manifestSerializer = new ChunkedValueManifestSerializer(true);
     this.msgForLagMeasurement = new String[partitionCount];
     for (int i = 0; i < this.msgForLagMeasurement.length; i++) {
       this.msgForLagMeasurement[i] = kafkaVersionTopic + "_" + i;
@@ -2428,6 +2429,10 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
     hostLevelIngestionStats.recordChecksumVerificationFailure();
   }
 
+  protected void recordAssembledRecordSizeRatio(long recordSize, long currentTimeMs) {
+    // no op
+  }
+
   public abstract long getBatchReplicationLag();
 
   public abstract long getLeaderOffsetLag();
@@ -3236,10 +3241,11 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
         if (metricsEnabled && recordLevelMetricEnabled.get()
             && put.getSchemaId() == AvroProtocolDefinition.CHUNKED_VALUE_MANIFEST.getCurrentProtocolVersion()) {
           try {
-            ChunkedValueManifest chunkedValueManifest = manifestSerializer.deserialize(
+            ChunkedValueManifest chunkedValueManifest = CHUNKED_VALUE_MANIFEST_SERIALIZER.deserialize(
                 ByteUtils.extractByteArray(put.getPutValue()), // must be done before recordTransformer changes putValue
                 AvroProtocolDefinition.CHUNKED_VALUE_MANIFEST.getCurrentProtocolVersion());
             hostLevelIngestionStats.recordAssembledValueSize(chunkedValueManifest.getSize(), currentTimeMs);
+            recordAssembledRecordSizeRatio(keyLen + chunkedValueManifest.getSize(), currentTimeMs); // TODO: RMD?
           } catch (VeniceException | IllegalArgumentException | AvroRuntimeException e) {
             LOGGER.error("Failed to deserialize ChunkedValueManifest to record assembled value size", e);
           }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -3243,8 +3243,8 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
             ByteBuffer rmdPayload = put.getReplicationMetadataPayload();
             boolean isValueManifest = rmdPayload != null && rmdPayload.equals(VeniceWriter.EMPTY_BYTE_BUFFER);
             if (isValueManifest) {
-              hostLevelIngestionStats.recordAssembledValueSize(chunkedValueManifest.getSize(), currentTimeMs);
               recordAssembledRecordSizeRatio(keyLen + chunkedValueManifest.getSize(), currentTimeMs);
+              hostLevelIngestionStats.recordAssembledValueSize(chunkedValueManifest.getSize(), currentTimeMs);
             } else { // the manifest pertains to a chunked rmd
               hostLevelIngestionStats.recordAssembledRmdSize(chunkedValueManifest.getSize(), currentTimeMs);
             }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -2442,10 +2442,11 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
    */
   protected void recordAssembledRecordSize(int keyLen, ByteBuffer valueBytes, ByteBuffer rmdBytes, long currentTimeMs) {
     try {
-      if (ByteUtils.getIntHeaderFromByteBuffer(valueBytes) != CHUNK_MANIFEST_SCHEMA_ID) {
-        LOGGER.error("Unable to deserialize putValue into a ChunkedValueManifest due to incorrect integer header");
-        return;
-      }
+      // TODO: Check with Jialin on this
+      // if (ByteUtils.getIntHeaderFromByteBuffer(valueBytes) != CHUNK_MANIFEST_SCHEMA_ID) {
+      // LOGGER.error("Unable to deserialize putValue into a ChunkedValueManifest due to incorrect integer header");
+      // return;
+      // }
 
       byte[] valueByteArray = ByteUtils.extractByteArray(valueBytes);
       ChunkedValueManifest valueManifest = manifestSerializer.deserialize(valueByteArray, CHUNK_MANIFEST_SCHEMA_ID);

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -3244,15 +3244,15 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
                 AvroProtocolDefinition.CHUNKED_VALUE_MANIFEST.getCurrentProtocolVersion());
             ByteBuffer rmdPayload = put.getReplicationMetadataPayload();
             boolean isValueManifest = rmdPayload != null && rmdPayload.equals(VeniceWriter.EMPTY_BYTE_BUFFER);
-            if (isValueManifest) {
-              double ratio = calculateAssembledRecordSizeRatio(keyLen + chunkedValueManifest.getSize());
-              recordAssembledRecordSizeRatio(ratio, currentTimeMs);
-              hostLevelIngestionStats.recordAssembledValueSize(chunkedValueManifest.getSize(), currentTimeMs);
+            if (isValueManifest) { // the manifest pertains to a chunked value
+              int recordSize = keyLen + chunkedValueManifest.getSize();
+              recordAssembledRecordSizeRatio(calculateAssembledRecordSizeRatio(recordSize), currentTimeMs);
+              hostLevelIngestionStats.recordAssembledRecordSize(recordSize, currentTimeMs);
             } else { // the manifest pertains to a chunked rmd
               hostLevelIngestionStats.recordAssembledRmdSize(chunkedValueManifest.getSize(), currentTimeMs);
             }
           } catch (VeniceException | IllegalArgumentException | AvroRuntimeException e) {
-            LOGGER.error("Failed to deserialize ChunkedValueManifest to record assembled value size", e);
+            LOGGER.error("Failed to deserialize ChunkedValueManifest to record the assembled record / RMD size", e);
           }
         }
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/HostLevelIngestionStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/HostLevelIngestionStats.java
@@ -32,6 +32,7 @@ import java.util.Map;
  * (3) Per store and total: The stat is registered for each store on this host and the total number for this host.
  */
 public class HostLevelIngestionStats extends AbstractVeniceStats {
+  public static final String ASSEMBLED_RECORD_SIZE_RATIO = "assembled_record_size_ratio";
   public static final String ASSEMBLED_RECORD_VALUE_SIZE_IN_BYTES = "assembled_record_value_size_in_bytes";
 
   // The aggregated bytes ingested rate for the entire host
@@ -50,6 +51,7 @@ public class HostLevelIngestionStats extends AbstractVeniceStats {
   private final Sensor keySizeSensor;
   private final Sensor valueSizeSensor;
   private final Sensor assembledValueSizeSensor;
+  private final Sensor assembledRecordSizeRatioSensor;
   private final Sensor unexpectedMessageSensor;
   private final Sensor inconsistentStoreMetadataSensor;
   private final Sensor ingestionFailureSensor;
@@ -278,13 +280,9 @@ public class HostLevelIngestionStats extends AbstractVeniceStats {
         new Max(),
         TehutiUtils.getPercentileStat(getName() + AbstractVeniceStats.DELIMITER + valueSizeSensorName));
 
-    this.assembledValueSizeSensor = registerSensor(
-        ASSEMBLED_RECORD_VALUE_SIZE_IN_BYTES,
-        new Avg(),
-        new Min(),
-        new Max(),
-        TehutiUtils
-            .getPercentileStat(getName() + AbstractVeniceStats.DELIMITER + ASSEMBLED_RECORD_VALUE_SIZE_IN_BYTES));
+    this.assembledValueSizeSensor = registerSensor(ASSEMBLED_RECORD_VALUE_SIZE_IN_BYTES, avgAndMax());
+
+    this.assembledRecordSizeRatioSensor = registerSensor(ASSEMBLED_RECORD_SIZE_RATIO, avgAndMax());
 
     String viewTimerSensorName = "total_view_writer_latency";
     this.viewProducerLatencySensor = registerPerStoreAndTotalSensor(
@@ -471,6 +469,10 @@ public class HostLevelIngestionStats extends AbstractVeniceStats {
 
   public void recordAssembledValueSize(long bytes, long currentTimeMs) {
     assembledValueSizeSensor.record(bytes, currentTimeMs);
+  }
+
+  public void recordAssembledRecordSizeRatio(double ratio, long currentTimeMs) {
+    assembledRecordSizeRatioSensor.record(ratio, currentTimeMs);
   }
 
   public void recordIngestionFailure() {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/HostLevelIngestionStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/HostLevelIngestionStats.java
@@ -34,7 +34,7 @@ import java.util.Map;
 public class HostLevelIngestionStats extends AbstractVeniceStats {
   public static final String ASSEMBLED_RECORD_SIZE_RATIO = "assembled_record_size_ratio";
   public static final String ASSEMBLED_RECORD_SIZE_IN_BYTES = "assembled_record_size_in_bytes";
-  public static final String ASSEMBLED_RECORD_RMD_SIZE_IN_BYTES = "assembled_record_rmd_size_in_bytes";
+  public static final String ASSEMBLED_RMD_SIZE_IN_BYTES = "assembled_rmd_size_in_bytes";
 
   // The aggregated bytes ingested rate for the entire host
   private final LongAdderRateGauge totalBytesConsumedRate;
@@ -286,7 +286,7 @@ public class HostLevelIngestionStats extends AbstractVeniceStats {
 
     this.assembledRecordSizeRatioSensor = registerSensor(ASSEMBLED_RECORD_SIZE_RATIO, new Max());
 
-    this.assembledRmdSizeSensor = registerSensor(ASSEMBLED_RECORD_RMD_SIZE_IN_BYTES, avgAndMax());
+    this.assembledRmdSizeSensor = registerSensor(ASSEMBLED_RMD_SIZE_IN_BYTES, avgAndMax());
 
     String viewTimerSensorName = "total_view_writer_latency";
     this.viewProducerLatencySensor = registerPerStoreAndTotalSensor(

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/HostLevelIngestionStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/HostLevelIngestionStats.java
@@ -33,6 +33,7 @@ import java.util.Map;
  */
 public class HostLevelIngestionStats extends AbstractVeniceStats {
   public static final String ASSEMBLED_RECORD_SIZE_RATIO = "assembled_record_size_ratio";
+  public static final String ASSEMBLED_RECORD_RMD_SIZE_IN_BYTES = "assembled_record_rmd_size_in_bytes";
   public static final String ASSEMBLED_RECORD_VALUE_SIZE_IN_BYTES = "assembled_record_value_size_in_bytes";
 
   // The aggregated bytes ingested rate for the entire host
@@ -51,6 +52,7 @@ public class HostLevelIngestionStats extends AbstractVeniceStats {
   private final Sensor keySizeSensor;
   private final Sensor valueSizeSensor;
   private final Sensor assembledValueSizeSensor;
+  private final Sensor assembledRmdSizeSensor;
   private final Sensor assembledRecordSizeRatioSensor;
   private final Sensor unexpectedMessageSensor;
   private final Sensor inconsistentStoreMetadataSensor;
@@ -282,6 +284,8 @@ public class HostLevelIngestionStats extends AbstractVeniceStats {
 
     this.assembledValueSizeSensor = registerSensor(ASSEMBLED_RECORD_VALUE_SIZE_IN_BYTES, avgAndMax());
 
+    this.assembledRmdSizeSensor = registerSensor(ASSEMBLED_RECORD_RMD_SIZE_IN_BYTES, avgAndMax());
+
     this.assembledRecordSizeRatioSensor = registerSensor(ASSEMBLED_RECORD_SIZE_RATIO, new Max());
 
     String viewTimerSensorName = "total_view_writer_latency";
@@ -469,6 +473,10 @@ public class HostLevelIngestionStats extends AbstractVeniceStats {
 
   public void recordAssembledValueSize(long bytes, long currentTimeMs) {
     assembledValueSizeSensor.record(bytes, currentTimeMs);
+  }
+
+  public void recordAssembledRmdSize(long bytes, long currentTimeMs) {
+    assembledRmdSizeSensor.record(bytes, currentTimeMs);
   }
 
   public void recordAssembledRecordSizeRatio(double ratio, long currentTimeMs) {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/HostLevelIngestionStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/HostLevelIngestionStats.java
@@ -282,7 +282,7 @@ public class HostLevelIngestionStats extends AbstractVeniceStats {
 
     this.assembledValueSizeSensor = registerSensor(ASSEMBLED_RECORD_VALUE_SIZE_IN_BYTES, avgAndMax());
 
-    this.assembledRecordSizeRatioSensor = registerSensor(ASSEMBLED_RECORD_SIZE_RATIO, avgAndMax());
+    this.assembledRecordSizeRatioSensor = registerSensor(ASSEMBLED_RECORD_SIZE_RATIO, new Max());
 
     String viewTimerSensorName = "total_view_writer_latency";
     this.viewProducerLatencySensor = registerPerStoreAndTotalSensor(

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/HostLevelIngestionStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/HostLevelIngestionStats.java
@@ -33,8 +33,8 @@ import java.util.Map;
  */
 public class HostLevelIngestionStats extends AbstractVeniceStats {
   public static final String ASSEMBLED_RECORD_SIZE_RATIO = "assembled_record_size_ratio";
+  public static final String ASSEMBLED_RECORD_SIZE_IN_BYTES = "assembled_record_size_in_bytes";
   public static final String ASSEMBLED_RECORD_RMD_SIZE_IN_BYTES = "assembled_record_rmd_size_in_bytes";
-  public static final String ASSEMBLED_RECORD_VALUE_SIZE_IN_BYTES = "assembled_record_value_size_in_bytes";
 
   // The aggregated bytes ingested rate for the entire host
   private final LongAdderRateGauge totalBytesConsumedRate;
@@ -51,9 +51,9 @@ public class HostLevelIngestionStats extends AbstractVeniceStats {
   private final Sensor consumerRecordsQueuePutLatencySensor;
   private final Sensor keySizeSensor;
   private final Sensor valueSizeSensor;
-  private final Sensor assembledValueSizeSensor;
-  private final Sensor assembledRmdSizeSensor;
+  private final Sensor assembledRecordSizeSensor;
   private final Sensor assembledRecordSizeRatioSensor;
+  private final Sensor assembledRmdSizeSensor;
   private final Sensor unexpectedMessageSensor;
   private final Sensor inconsistentStoreMetadataSensor;
   private final Sensor ingestionFailureSensor;
@@ -282,11 +282,11 @@ public class HostLevelIngestionStats extends AbstractVeniceStats {
         new Max(),
         TehutiUtils.getPercentileStat(getName() + AbstractVeniceStats.DELIMITER + valueSizeSensorName));
 
-    this.assembledValueSizeSensor = registerSensor(ASSEMBLED_RECORD_VALUE_SIZE_IN_BYTES, avgAndMax());
-
-    this.assembledRmdSizeSensor = registerSensor(ASSEMBLED_RECORD_RMD_SIZE_IN_BYTES, avgAndMax());
+    this.assembledRecordSizeSensor = registerSensor(ASSEMBLED_RECORD_SIZE_IN_BYTES, avgAndMax());
 
     this.assembledRecordSizeRatioSensor = registerSensor(ASSEMBLED_RECORD_SIZE_RATIO, new Max());
+
+    this.assembledRmdSizeSensor = registerSensor(ASSEMBLED_RECORD_RMD_SIZE_IN_BYTES, avgAndMax());
 
     String viewTimerSensorName = "total_view_writer_latency";
     this.viewProducerLatencySensor = registerPerStoreAndTotalSensor(
@@ -471,16 +471,16 @@ public class HostLevelIngestionStats extends AbstractVeniceStats {
     valueSizeSensor.record(bytes, currentTimeMs);
   }
 
-  public void recordAssembledValueSize(long bytes, long currentTimeMs) {
-    assembledValueSizeSensor.record(bytes, currentTimeMs);
-  }
-
-  public void recordAssembledRmdSize(long bytes, long currentTimeMs) {
-    assembledRmdSizeSensor.record(bytes, currentTimeMs);
+  public void recordAssembledRecordSize(long bytes, long currentTimeMs) {
+    assembledRecordSizeSensor.record(bytes, currentTimeMs);
   }
 
   public void recordAssembledRecordSizeRatio(double ratio, long currentTimeMs) {
     assembledRecordSizeRatioSensor.record(ratio, currentTimeMs);
+  }
+
+  public void recordAssembledRmdSize(long bytes, long currentTimeMs) {
+    assembledRmdSizeSensor.record(bytes, currentTimeMs);
   }
 
   public void recordIngestionFailure() {

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTaskTest.java
@@ -81,7 +81,6 @@ import com.linkedin.venice.storage.protocol.ChunkId;
 import com.linkedin.venice.storage.protocol.ChunkedKeySuffix;
 import com.linkedin.venice.storage.protocol.ChunkedValueManifest;
 import com.linkedin.venice.utils.ByteUtils;
-import com.linkedin.venice.utils.ChunkingTestUtils;
 import com.linkedin.venice.utils.SystemTime;
 import com.linkedin.venice.utils.VeniceProperties;
 import com.linkedin.venice.utils.lazy.Lazy;
@@ -345,8 +344,8 @@ public class ActiveActiveStoreIngestionTaskTest {
     for (int i = 0; i < 50000; i++) {
       stringBuilder.append("abcdefghabcdefghabcdefghabcdefgh");
     }
-    String valueString = stringBuilder.toString();
-    ByteBuffer updatedValueBytes = ChunkingTestUtils.prependSchemaId(valueString.getBytes(), 1);
+    ByteBuffer valueBytes = ByteBuffer.wrap(stringBuilder.toString().getBytes());
+    ByteBuffer updatedValueBytes = ByteUtils.prependIntHeaderToByteBuffer(valueBytes, 1);
     ByteBuffer updatedRmdBytes = ByteBuffer.wrap(new byte[] { 0xa, 0xb });
     PubSubMessage<KafkaKey, KafkaMessageEnvelope, Long> consumerRecord = mock(PubSubMessage.class);
     when(consumerRecord.getOffset()).thenReturn(100L);
@@ -514,11 +513,11 @@ public class ActiveActiveStoreIngestionTaskTest {
     chunkedValueManifest.size = 8;
     chunkedValueManifest.keysWithChunkIdSuffix.add(chunkedKeyWithSuffix1);
     int manifestSchemaId = AvroProtocolDefinition.CHUNKED_VALUE_MANIFEST.getCurrentProtocolVersion();
-    byte[] chunkedManifestBytes = chunkedValueManifestSerializer.serialize(topicName, chunkedValueManifest);
-    chunkedManifestBytes = ChunkingTestUtils.prependSchemaId(chunkedManifestBytes, manifestSchemaId).array();
+    ByteBuffer chunkedManifestBytes = chunkedValueManifestSerializer.serialize(chunkedValueManifest);
+    chunkedManifestBytes = ByteUtils.prependIntHeaderToByteBuffer(chunkedManifestBytes, manifestSchemaId);
     byte[] topLevelKey2 = keyWithChunkingSuffixSerializer.serializeNonChunkedKey(key2);
     byte[] chunkedKey1InKey2 = chunkedKeyWithSuffix1.array();
-    when(storageEngine.getReplicationMetadata(partition, topLevelKey2)).thenReturn(chunkedManifestBytes);
+    when(storageEngine.getReplicationMetadata(partition, topLevelKey2)).thenReturn(chunkedManifestBytes.array());
     when(storageEngine.getReplicationMetadata(partition, chunkedKey1InKey2)).thenReturn(chunkedValue1);
     byte[] result2 = ingestionTask.getRmdWithValueSchemaByteBufferFromStorage(partition, key2, container, 0L);
     Assert.assertNotNull(result2);
@@ -547,12 +546,12 @@ public class ActiveActiveStoreIngestionTaskTest {
     chunkedValueManifest.size = 8 + 12;
     chunkedValueManifest.keysWithChunkIdSuffix.add(chunkedKeyWithSuffix1);
     chunkedValueManifest.keysWithChunkIdSuffix.add(chunkedKeyWithSuffix2);
-    chunkedManifestBytes = chunkedValueManifestSerializer.serialize(topicName, chunkedValueManifest);
-    chunkedManifestBytes = ChunkingTestUtils.prependSchemaId(chunkedManifestBytes, manifestSchemaId).array();
+    chunkedManifestBytes = chunkedValueManifestSerializer.serialize(chunkedValueManifest);
+    chunkedManifestBytes = ByteUtils.prependIntHeaderToByteBuffer(chunkedManifestBytes, manifestSchemaId);
     byte[] topLevelKey3 = keyWithChunkingSuffixSerializer.serializeNonChunkedKey(key3);
     byte[] chunkedKey1InKey3 = chunkedKeyWithSuffix1.array();
     byte[] chunkedKey2InKey3 = chunkedKeyWithSuffix2.array();
-    when(storageEngine.getReplicationMetadata(partition, topLevelKey3)).thenReturn(chunkedManifestBytes);
+    when(storageEngine.getReplicationMetadata(partition, topLevelKey3)).thenReturn(chunkedManifestBytes.array());
     when(storageEngine.getReplicationMetadata(partition, chunkedKey1InKey3)).thenReturn(chunkedValue1);
     when(storageEngine.getReplicationMetadata(partition, chunkedKey2InKey3)).thenReturn(chunkedValue2);
     byte[] result3 = ingestionTask.getRmdWithValueSchemaByteBufferFromStorage(partition, key3, container, 0L);

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
@@ -4547,11 +4547,11 @@ public abstract class StoreIngestionTaskTest {
             put.schemaId = testSchemaId; // set manifest schemaId to testSchemaId to see if metrics are still recorded
             switch (rmdChunkingStatus) {
               case NON_CHUNKED:
-                put.replicationMetadataPayload = ByteBuffer.allocate(rmdSize);
+                put.replicationMetadataPayload = ByteBuffer.allocate(rmdSize + ByteUtils.SIZE_OF_INT);
+                put.replicationMetadataPayload.position(ByteUtils.SIZE_OF_INT); // for getIntHeaderFromByteBuffer()
                 break;
               case CHUNKED:
                 put.replicationMetadataPayload = ChunkingTestUtils.createReplicationMetadataPayload(rmdSize);
-                storeIngestionTaskUnderTest.setRmdChunked(true);
                 break;
               default:
                 put.replicationMetadataPayload = VeniceWriter.EMPTY_BYTE_BUFFER;

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/utils/ByteUtils.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/utils/ByteUtils.java
@@ -279,6 +279,10 @@ public class ByteUtils {
     return originalBuffer.getInt();
   }
 
+  public static ByteBuffer prependIntHeaderToByteBuffer(ByteBuffer originalBuffer, int header) {
+    return prependIntHeaderToByteBuffer(originalBuffer, header, false);
+  }
+
   /**
    * This function will return a ByteBuffer that has the integer prepended as a header from the current position. The
    * position of the buffer will be the same as that of the input.

--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigConstants.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigConstants.java
@@ -1,5 +1,7 @@
 package com.linkedin.venice;
 
+import static com.linkedin.venice.utils.ByteUtils.BYTES_PER_MB;
+
 import java.util.concurrent.TimeUnit;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -12,6 +14,8 @@ public class ConfigConstants {
    */
 
   public static final int UNSPECIFIED_REPLICATION_METADATA_VERSION = -1;
+
+  public static final int DEFAULT_MAX_RECORD_SIZE_BYTES_BACKFILL = 100 * BYTES_PER_MB;
 
   public static final long DEFAULT_PUSH_STATUS_STORE_HEARTBEAT_EXPIRATION_TIME_IN_SECONDS =
       TimeUnit.MINUTES.toSeconds(10);

--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -2117,10 +2117,11 @@ public class ConfigKeys {
       "controller.dangling.topic.occurrence.threshold.for.cleanup";
 
   /**
-   * Controller config for the default value of {@link com.linkedin.venice.writer.VeniceWriter#maxRecordSizeBytes}.
-   * Only used in batch push jobs and partial updates.
+   * Config for the default value which is filled in when the store-level config
+   * {@link com.linkedin.venice.writer.VeniceWriter#maxRecordSizeBytes} is left unset. Used as a controller config for
+   * batch push jobs. Used as a server config for nearline jobs / partial updates.
    */
-  public static final String CONTROLLER_DEFAULT_MAX_RECORD_SIZE_BYTES = "controller.default.max.record.size.bytes";
+  public static final String DEFAULT_MAX_RECORD_SIZE_BYTES = "default.max.record.size.bytes";
 
   /**
    * Percentage of total single get requests that are allowed for retry in decimal. e.g. 0.1 would mean up to 10% of the

--- a/internal/venice-common/src/main/java/com/linkedin/venice/writer/VeniceWriter.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/writer/VeniceWriter.java
@@ -907,7 +907,8 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
      */
     int veniceRecordSize = serializedKey.length + serializedValue.length + replicationMetadataPayloadSize;
     if (isChunkingNeededForRecord(veniceRecordSize)) { // ~1MB default
-      if (isChunkingEnabled && !isRecordTooLarge(veniceRecordSize)) {
+      // RMD size is not checked because it's an internal component, and a user's write should not be failed due to it
+      if (isChunkingEnabled && !isRecordTooLarge(serializedKey.length + serializedValue.length)) {
         return putLargeValue(
             serializedKey,
             serializedValue,

--- a/internal/venice-common/src/main/java/com/linkedin/venice/writer/VeniceWriter.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/writer/VeniceWriter.java
@@ -703,7 +703,6 @@ public class VeniceWriter<K, V, U> extends AbstractVeniceWriter<K, V, U> {
 
     isChunkingFlagInvoked = true;
 
-    // TODO: does a check for size > maxRecordSizeBytes need to be done here?
     int rmdPayloadSize = deleteMetadata == null ? 0 : deleteMetadata.getSerializedSize();
     if (isChunkingNeededForRecord(serializedKey.length + rmdPayloadSize)) {
       throw new RecordTooLargeException(

--- a/internal/venice-common/src/main/java/com/linkedin/venice/writer/VeniceWriterOptions.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/writer/VeniceWriterOptions.java
@@ -26,7 +26,7 @@ public class VeniceWriterOptions {
   private final Integer partitionCount;
   private final boolean chunkingEnabled;
   private final boolean rmdChunkingEnabled;
-  private final Integer maxRecordSizeBytes;
+  private final int maxRecordSizeBytes;
   // Set this field if you want to use different broker address than the local broker address
   private final String brokerAddress;
 
@@ -70,7 +70,7 @@ public class VeniceWriterOptions {
     return rmdChunkingEnabled;
   }
 
-  public Integer getMaxRecordSizeBytes() {
+  public int getMaxRecordSizeBytes() {
     return maxRecordSizeBytes;
   }
 
@@ -109,7 +109,7 @@ public class VeniceWriterOptions {
         .append(rmdChunkingEnabled)
         .append(", ")
         .append("maxRecordSizeBytes:")
-        .append(maxRecordSizeBytes != null ? maxRecordSizeBytes : -1)
+        .append(maxRecordSizeBytes)
         .append("}")
         .toString();
   }
@@ -124,7 +124,7 @@ public class VeniceWriterOptions {
     private Integer partitionCount = null; // default null
     private boolean chunkingEnabled; // default false
     private boolean rmdChunkingEnabled; // default false
-    private Integer maxRecordSizeBytes = null; // default null
+    private int maxRecordSizeBytes = VeniceWriter.UNLIMITED_MAX_RECORD_SIZE; // default -1
     private String brokerAddress = null; // default null
 
     private void addDefaults() {
@@ -142,9 +142,6 @@ public class VeniceWriterOptions {
       }
       if (time == null) {
         time = SystemTime.INSTANCE;
-      }
-      if (maxRecordSizeBytes == null) {
-        maxRecordSizeBytes = VeniceWriter.UNLIMITED_MAX_RECORD_SIZE;
       }
     }
 
@@ -209,7 +206,7 @@ public class VeniceWriterOptions {
       return this;
     }
 
-    public Builder setMaxRecordSizeBytes(Integer maxRecordSizeBytes) {
+    public Builder setMaxRecordSizeBytes(int maxRecordSizeBytes) {
       this.maxRecordSizeBytes = maxRecordSizeBytes;
       return this;
     }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/server/TestAdminSparkServer.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/server/TestAdminSparkServer.java
@@ -95,8 +95,7 @@ public class TestAdminSparkServer extends AbstractTestAdminSparkServer {
     extraProperties.put(
         ConfigKeys.TOPIC_CLEANUP_SLEEP_INTERVAL_BETWEEN_TOPIC_LIST_FETCH_MS,
         Long.toString(TimeUnit.DAYS.toMillis(7)));
-    extraProperties
-        .put(ConfigKeys.CONTROLLER_DEFAULT_MAX_RECORD_SIZE_BYTES, Integer.toString(TEST_MAX_RECORD_SIZE_BYTES));
+    extraProperties.put(ConfigKeys.DEFAULT_MAX_RECORD_SIZE_BYTES, Integer.toString(TEST_MAX_RECORD_SIZE_BYTES));
     extraProperties.put(ConfigKeys.MIN_NUMBER_OF_UNUSED_KAFKA_TOPICS_TO_PRESERVE, Integer.toString(1));
     super.setUp(false, Optional.empty(), extraProperties);
   }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestBatch.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestBatch.java
@@ -953,23 +953,19 @@ public abstract class TestBatch {
         MetricsRepository metricsRepository) throws Exception;
   }
 
-  private List<Double> getPerStoreMetricValues(String storeName, String sensorName) {
-    String metricName = AbstractVeniceStats.getSensorFullName(storeName, sensorName);
-    List<VeniceServerWrapper> veniceServers = veniceCluster.getVeniceServers();
-    return Arrays.asList(
-        MetricsUtils.getMax(metricName + ".Max", veniceServers), // default=Double.MAX_VALUE
-        MetricsUtils.getAvg(metricName + ".Avg", veniceServers)); // default=NaN
-  }
-
   private void validatePerStoreMetricsRange(String storeName, String sensorName, double minValue, double maxValue) {
-    getPerStoreMetricValues(storeName, sensorName).forEach(value -> {
+    String baseMetricName = AbstractVeniceStats.getSensorFullName(storeName, sensorName);
+    List<VeniceServerWrapper> veniceServers = veniceCluster.getVeniceServers();
+    MetricsUtils.getAvgMax(baseMetricName, veniceServers).forEach(value -> {
       Assert.assertTrue(value >= minValue, "Metric value expected >= " + minValue + " actual=" + value);
       Assert.assertTrue(value <= maxValue, "Metric value expected <= " + maxValue + " actual=" + value);
     });
   }
 
   private void assertUnusedPerStoreMetrics(String storeName, String sensorName) {
-    getPerStoreMetricValues(storeName, sensorName).forEach(value -> {
+    String baseMetricName = AbstractVeniceStats.getSensorFullName(storeName, sensorName);
+    List<VeniceServerWrapper> veniceServers = veniceCluster.getVeniceServers();
+    MetricsUtils.getAvgMax(baseMetricName, veniceServers).forEach(value -> {
       Assert.assertTrue(value == Double.MIN_VALUE || value == Double.MAX_VALUE || value.isNaN(), "Needs to be invalid");
     });
   }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestBatch.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestBatch.java
@@ -1,7 +1,7 @@
 package com.linkedin.venice.endToEnd;
 
+import static com.linkedin.davinci.stats.HostLevelIngestionStats.ASSEMBLED_RECORD_SIZE_IN_BYTES;
 import static com.linkedin.davinci.stats.HostLevelIngestionStats.ASSEMBLED_RECORD_SIZE_RATIO;
-import static com.linkedin.davinci.stats.HostLevelIngestionStats.ASSEMBLED_RECORD_VALUE_SIZE_IN_BYTES;
 import static com.linkedin.venice.ConfigKeys.KAFKA_BOOTSTRAP_SERVERS;
 import static com.linkedin.venice.hadoop.VenicePushJobConstants.ALLOW_DUPLICATE_KEY;
 import static com.linkedin.venice.hadoop.VenicePushJobConstants.COMPRESSION_METRIC_COLLECTION_ENABLED;
@@ -631,7 +631,7 @@ public abstract class TestBatch {
         validator);
 
     // Since chunking was not enabled, verify that the assembled record size metrics are not collected
-    assertUnusedPerStoreMetrics(storeName, ASSEMBLED_RECORD_VALUE_SIZE_IN_BYTES);
+    assertUnusedPerStoreMetrics(storeName, ASSEMBLED_RECORD_SIZE_IN_BYTES);
 
     // Re-push with Kafka Input
     testRepush(storeName, validator);
@@ -987,7 +987,7 @@ public abstract class TestBatch {
 
     // Verify that after records are chunked and re-assembled, the original sizes of these records are being recorded
     // to the metrics sensor, and are within the correct size range.
-    validatePerStoreMetricsRange(storeName, ASSEMBLED_RECORD_VALUE_SIZE_IN_BYTES, BYTES_PER_MB, LARGE_VALUE_SIZE);
+    validatePerStoreMetricsRange(storeName, ASSEMBLED_RECORD_SIZE_IN_BYTES, BYTES_PER_MB, LARGE_VALUE_SIZE);
   }
 
   /** Test that values that are too large will fail the push job only when the limit is enforced. */

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestBatch.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestBatch.java
@@ -1004,7 +1004,7 @@ public abstract class TestBatch {
 
       // Add a little wiggle room (1e-3) for generating the test data / record sizes
       final double maxRatio = (double) tooLargeValueSize / maxRecordSizeBytesForTest + 1e-3;
-      validatePerStoreMetricsRange(storeName, ASSEMBLED_RECORD_SIZE_RATIO, 1e-3, maxRatio);
+      validatePerStoreMetricsRange(storeName, ASSEMBLED_RECORD_SIZE_RATIO, 0, maxRatio);
     } catch (VeniceException e) {
       final String limitStr = generateHumanReadableByteCountString(maxRecordSizeBytesForTest);
       Assert.assertTrue(e.getMessage().contains("exceed the maximum record limit of " + limitStr), e.getMessage());

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestBatch.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestBatch.java
@@ -64,7 +64,6 @@ import com.linkedin.venice.controllerapi.VersionCreationResponse;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.hadoop.spark.datawriter.jobs.DataWriterSparkJob;
 import com.linkedin.venice.integration.utils.VeniceClusterWrapper;
-import com.linkedin.venice.integration.utils.VeniceServerWrapper;
 import com.linkedin.venice.meta.BackupStrategy;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.read.RequestType;
@@ -631,7 +630,10 @@ public abstract class TestBatch {
         validator);
 
     // Since chunking was not enabled, verify that the assembled record size metrics are not collected
-    assertUnusedPerStoreMetrics(storeName, ASSEMBLED_RECORD_SIZE_IN_BYTES);
+    String baseMetricName = AbstractVeniceStats.getSensorFullName(storeName, ASSEMBLED_RECORD_SIZE_IN_BYTES);
+    MetricsUtils.getAvgMax(baseMetricName, veniceCluster.getVeniceServers()).forEach(value -> {
+      Assert.assertTrue(value == Double.MIN_VALUE || value == Double.MAX_VALUE || value.isNaN(), "Must be invalid");
+    });
 
     // Re-push with Kafka Input
     testRepush(storeName, validator);
@@ -953,23 +955,6 @@ public abstract class TestBatch {
         MetricsRepository metricsRepository) throws Exception;
   }
 
-  private void validatePerStoreMetricsRange(String storeName, String sensorName, double minValue, double maxValue) {
-    String baseMetricName = AbstractVeniceStats.getSensorFullName(storeName, sensorName);
-    List<VeniceServerWrapper> veniceServers = veniceCluster.getVeniceServers();
-    MetricsUtils.getAvgMax(baseMetricName, veniceServers).forEach(value -> {
-      Assert.assertTrue(value >= minValue, "Metric value expected >= " + minValue + " actual=" + value);
-      Assert.assertTrue(value <= maxValue, "Metric value expected <= " + maxValue + " actual=" + value);
-    });
-  }
-
-  private void assertUnusedPerStoreMetrics(String storeName, String sensorName) {
-    String baseMetricName = AbstractVeniceStats.getSensorFullName(storeName, sensorName);
-    List<VeniceServerWrapper> veniceServers = veniceCluster.getVeniceServers();
-    MetricsUtils.getAvgMax(baseMetricName, veniceServers).forEach(value -> {
-      Assert.assertTrue(value == Double.MIN_VALUE || value == Double.MAX_VALUE || value.isNaN(), "Needs to be invalid");
-    });
-  }
-
   @Test(timeOut = TEST_TIMEOUT)
   public void testLargeValues() throws Exception {
     try {
@@ -983,7 +968,9 @@ public abstract class TestBatch {
 
     // Verify that after records are chunked and re-assembled, the original sizes of these records are being recorded
     // to the metrics sensor, and are within the correct size range.
-    validatePerStoreMetricsRange(storeName, ASSEMBLED_RECORD_SIZE_IN_BYTES, BYTES_PER_MB, LARGE_VALUE_SIZE);
+    String baseMetricName = AbstractVeniceStats.getSensorFullName(storeName, ASSEMBLED_RECORD_SIZE_IN_BYTES);
+    List<Double> assembledRecordSizes = MetricsUtils.getAvgMax(baseMetricName, veniceCluster.getVeniceServers());
+    MetricsUtils.validateMetricRange(assembledRecordSizes, BYTES_PER_MB, LARGE_VALUE_SIZE);
   }
 
   /** Test that values that are too large will fail the push job only when the limit is enforced. */
@@ -1000,7 +987,9 @@ public abstract class TestBatch {
 
       // Add a little wiggle room (1e-3) for generating the test data / record sizes
       final double maxRatio = (double) tooLargeValueSize / maxRecordSizeBytesForTest + 1e-3;
-      validatePerStoreMetricsRange(storeName, ASSEMBLED_RECORD_SIZE_RATIO, 0, maxRatio);
+      String baseMetricName = AbstractVeniceStats.getSensorFullName(storeName, ASSEMBLED_RECORD_SIZE_RATIO);
+      List<Double> assembledRecordSizeRatios = MetricsUtils.getAvgMax(baseMetricName, veniceCluster.getVeniceServers());
+      MetricsUtils.validateMetricRange(assembledRecordSizeRatios, 0, maxRatio);
     } catch (VeniceException e) {
       final String limitStr = generateHumanReadableByteCountString(maxRecordSizeBytesForTest);
       Assert.assertTrue(e.getMessage().contains("exceed the maximum record limit of " + limitStr), e.getMessage());

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestPartialUpdateWithActiveActiveReplication.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestPartialUpdateWithActiveActiveReplication.java
@@ -77,9 +77,7 @@ public class TestPartialUpdateWithActiveActiveReplication {
   public static final String NULLABLE_MAP_FIELD = "nullableMapField";
 
   private static final Map<String, Integer> MAP_FIELD_DEFAULT_VALUE = Collections.emptyMap();
-  private static final Map<String, Integer> NULLABLE_MAP_FIELD_DEFAULT_VALUE = null;
   private static final List<Integer> LIST_FIELD_DEFAULT_VALUE = Collections.emptyList();
-  private static final List<Integer> NULLABLE_LIST_FIELD_DEFAULT_VALUE = null;
 
   private static final String REGULAR_FIELD_DEFAULT_VALUE = "default_venice";
 

--- a/internal/venice-test-common/src/main/java/com/linkedin/venice/tehuti/MetricsUtils.java
+++ b/internal/venice-test-common/src/main/java/com/linkedin/venice/tehuti/MetricsUtils.java
@@ -39,6 +39,14 @@ public class MetricsUtils {
         getMax(baseMetricName + ".Max", metricsAwareWrapperList));
   }
 
+  public static void validateMetricRange(List<Double> metricValues, double min, double max) throws Exception {
+    for (double value: metricValues) {
+      if (value < min || value > max) {
+        throw new Exception(String.format("Metric value %f is not in range [%f, %f]", value, min, max));
+      }
+    }
+  }
+
   public static double getMetricValue(
       String metricName,
       List<? extends MetricsAware> metricsAwareWrapperList,

--- a/internal/venice-test-common/src/main/java/com/linkedin/venice/tehuti/MetricsUtils.java
+++ b/internal/venice-test-common/src/main/java/com/linkedin/venice/tehuti/MetricsUtils.java
@@ -2,6 +2,7 @@ package com.linkedin.venice.tehuti;
 
 import io.tehuti.Metric;
 import io.tehuti.metrics.MetricsRepository;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -30,6 +31,12 @@ public class MetricsUtils {
       int previousCount = count.getAndIncrement();
       return (left * previousCount + right) / (previousCount + 1);
     }, 0.0));
+  }
+
+  public static List<Double> getAvgMax(String baseMetricName, List<? extends MetricsAware> metricsAwareWrapperList) {
+    return Arrays.asList(
+        getAvg(baseMetricName + ".Avg", metricsAwareWrapperList),
+        getMax(baseMetricName + ".Max", metricsAwareWrapperList));
   }
 
   public static double getMetricValue(

--- a/internal/venice-test-common/src/main/java/com/linkedin/venice/utils/ChunkingTestUtils.java
+++ b/internal/venice-test-common/src/main/java/com/linkedin/venice/utils/ChunkingTestUtils.java
@@ -119,14 +119,25 @@ public final class ChunkingTestUtils {
     manifest.schemaId = AvroProtocolDefinition.CHUNKED_VALUE_MANIFEST.getCurrentProtocolVersion();
     manifest.size = numberOfChunks * CHUNK_LENGTH;
     manifest.keysWithChunkIdSuffix.add(ByteBuffer.wrap(firstMessage.getKey().getKey()));
-    byte[] valueBytes = chunkedValueManifestSerializer.serialize(manifest).array();
+    byte[] putValueBytes = chunkedValueManifestSerializer.serialize(manifest).array();
 
     Put put = new Put();
     put.schemaId = AvroProtocolDefinition.CHUNKED_VALUE_MANIFEST.getCurrentProtocolVersion();
-    put.putValue = prependSchemaId(valueBytes, put.schemaId);
+    put.putValue = prependSchemaId(putValueBytes, put.schemaId);
     put.replicationMetadataPayload = VeniceWriter.EMPTY_BYTE_BUFFER;
     messageEnvelope.payloadUnion = put;
     return new ImmutablePubSubMessage<>(kafkaKey, messageEnvelope, pubSubTopicPartition, newOffset, 0, 20);
+  }
+
+  public static ByteBuffer createReplicationMetadataPayload(int size) {
+    ChunkedValueManifestSerializer chunkedRmdManifestSerializer = new ChunkedValueManifestSerializer(true);
+    ChunkedValueManifest chunkedRmdManifest = new ChunkedValueManifest();
+    chunkedRmdManifest.keysWithChunkIdSuffix = new ArrayList<>(1);
+    ;
+    chunkedRmdManifest.schemaId = AvroProtocolDefinition.CHUNKED_VALUE_MANIFEST.getCurrentProtocolVersion();
+    chunkedRmdManifest.size = size;
+    byte[] putValueBytes = chunkedRmdManifestSerializer.serialize(chunkedRmdManifest).array();
+    return prependSchemaId(putValueBytes, AvroProtocolDefinition.CHUNKED_VALUE_MANIFEST.getCurrentProtocolVersion());
   }
 
   public static PubSubMessage<KafkaKey, KafkaMessageEnvelope, Long> createDeleteRecord(

--- a/internal/venice-test-common/src/main/java/com/linkedin/venice/utils/ChunkingTestUtils.java
+++ b/internal/venice-test-common/src/main/java/com/linkedin/venice/utils/ChunkingTestUtils.java
@@ -56,12 +56,6 @@ public final class ChunkingTestUtils {
     return chunkedKeySuffix;
   }
 
-  public static ByteBuffer prependSchemaId(byte[] valueBytes, int schemaId) {
-    ByteBuffer prependedValueBytes = ByteUtils.enlargeByteBufferForIntHeader(ByteBuffer.wrap(valueBytes));
-    prependedValueBytes.putInt(0, schemaId);
-    return prependedValueBytes;
-  }
-
   public static KafkaMessageEnvelope createKafkaMessageEnvelope(
       MessageType messageType,
       int segmentNumber,
@@ -93,8 +87,8 @@ public final class ChunkingTestUtils {
 
     Put put = new Put();
     put.schemaId = AvroProtocolDefinition.CHUNK.getCurrentProtocolVersion();
-    byte[] valueBytes = createChunkBytes(chunkIndex * CHUNK_LENGTH, CHUNK_LENGTH);
-    put.putValue = prependSchemaId(valueBytes, put.schemaId);
+    ByteBuffer valueBytes = ByteBuffer.wrap(createChunkBytes(chunkIndex * CHUNK_LENGTH, CHUNK_LENGTH));
+    put.putValue = ByteUtils.prependIntHeaderToByteBuffer(valueBytes, put.schemaId);
     put.replicationMetadataPayload = VeniceWriter.EMPTY_BYTE_BUFFER;
     messageEnvelope.payloadUnion = put;
     return new ImmutablePubSubMessage<>(kafkaKey, messageEnvelope, pubSubTopicPartition, newOffset, 0, 20);
@@ -119,11 +113,11 @@ public final class ChunkingTestUtils {
     manifest.schemaId = AvroProtocolDefinition.CHUNKED_VALUE_MANIFEST.getCurrentProtocolVersion();
     manifest.size = numberOfChunks * CHUNK_LENGTH;
     manifest.keysWithChunkIdSuffix.add(ByteBuffer.wrap(firstMessage.getKey().getKey()));
-    byte[] putValueBytes = chunkedValueManifestSerializer.serialize(manifest).array();
+    ByteBuffer putValueBytes = chunkedValueManifestSerializer.serialize(manifest);
 
     Put put = new Put();
     put.schemaId = AvroProtocolDefinition.CHUNKED_VALUE_MANIFEST.getCurrentProtocolVersion();
-    put.putValue = prependSchemaId(putValueBytes, put.schemaId);
+    put.putValue = ByteUtils.prependIntHeaderToByteBuffer(putValueBytes, put.schemaId);
     put.replicationMetadataPayload = VeniceWriter.EMPTY_BYTE_BUFFER;
     messageEnvelope.payloadUnion = put;
     return new ImmutablePubSubMessage<>(kafkaKey, messageEnvelope, pubSubTopicPartition, newOffset, 0, 20);
@@ -133,11 +127,10 @@ public final class ChunkingTestUtils {
     ChunkedValueManifestSerializer chunkedRmdManifestSerializer = new ChunkedValueManifestSerializer(true);
     ChunkedValueManifest chunkedRmdManifest = new ChunkedValueManifest();
     chunkedRmdManifest.keysWithChunkIdSuffix = new ArrayList<>(1);
-    ;
     chunkedRmdManifest.schemaId = AvroProtocolDefinition.CHUNKED_VALUE_MANIFEST.getCurrentProtocolVersion();
     chunkedRmdManifest.size = size;
-    byte[] putValueBytes = chunkedRmdManifestSerializer.serialize(chunkedRmdManifest).array();
-    return prependSchemaId(putValueBytes, AvroProtocolDefinition.CHUNKED_VALUE_MANIFEST.getCurrentProtocolVersion());
+    ByteBuffer putValueBytes = chunkedRmdManifestSerializer.serialize(chunkedRmdManifest);
+    return ByteUtils.prependIntHeaderToByteBuffer(putValueBytes, chunkedRmdManifest.schemaId);
   }
 
   public static PubSubMessage<KafkaKey, KafkaMessageEnvelope, Long> createDeleteRecord(

--- a/internal/venice-test-common/src/main/java/com/linkedin/venice/utils/ChunkingTestUtils.java
+++ b/internal/venice-test-common/src/main/java/com/linkedin/venice/utils/ChunkingTestUtils.java
@@ -19,6 +19,7 @@ import com.linkedin.venice.serialization.avro.ChunkedValueManifestSerializer;
 import com.linkedin.venice.storage.protocol.ChunkId;
 import com.linkedin.venice.storage.protocol.ChunkedKeySuffix;
 import com.linkedin.venice.storage.protocol.ChunkedValueManifest;
+import com.linkedin.venice.writer.VeniceWriter;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 
@@ -94,7 +95,7 @@ public final class ChunkingTestUtils {
     put.schemaId = AvroProtocolDefinition.CHUNK.getCurrentProtocolVersion();
     byte[] valueBytes = createChunkBytes(chunkIndex * CHUNK_LENGTH, CHUNK_LENGTH);
     put.putValue = prependSchemaId(valueBytes, put.schemaId);
-    put.replicationMetadataPayload = ByteBuffer.allocate(10);
+    put.replicationMetadataPayload = VeniceWriter.EMPTY_BYTE_BUFFER;
     messageEnvelope.payloadUnion = put;
     return new ImmutablePubSubMessage<>(kafkaKey, messageEnvelope, pubSubTopicPartition, newOffset, 0, 20);
   }
@@ -123,7 +124,7 @@ public final class ChunkingTestUtils {
     Put put = new Put();
     put.schemaId = AvroProtocolDefinition.CHUNKED_VALUE_MANIFEST.getCurrentProtocolVersion();
     put.putValue = prependSchemaId(valueBytes, put.schemaId);
-    put.replicationMetadataPayload = ByteBuffer.allocate(10);
+    put.replicationMetadataPayload = VeniceWriter.EMPTY_BYTE_BUFFER;
     messageEnvelope.payloadUnion = put;
     return new ImmutablePubSubMessage<>(kafkaKey, messageEnvelope, pubSubTopicPartition, newOffset, 0, 20);
   }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerClusterConfig.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerClusterConfig.java
@@ -37,7 +37,6 @@ import static com.linkedin.venice.ConfigKeys.CONTROLLER_CLUSTER_REPLICA;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_CLUSTER_ZK_ADDRESSS;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_DANGLING_TOPIC_CLEAN_UP_INTERVAL_SECOND;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_DANGLING_TOPIC_OCCURRENCE_THRESHOLD_FOR_CLEANUP;
-import static com.linkedin.venice.ConfigKeys.CONTROLLER_DEFAULT_MAX_RECORD_SIZE_BYTES;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_DEFAULT_READ_QUOTA_PER_ROUTER;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_DISABLED_REPLICA_ENABLER_INTERVAL_MS;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_DISABLED_ROUTES;
@@ -76,6 +75,7 @@ import static com.linkedin.venice.ConfigKeys.DAVINCI_PUSH_STATUS_SCAN_MAX_OFFLIN
 import static com.linkedin.venice.ConfigKeys.DAVINCI_PUSH_STATUS_SCAN_NO_REPORT_RETRY_MAX_ATTEMPTS;
 import static com.linkedin.venice.ConfigKeys.DAVINCI_PUSH_STATUS_SCAN_THREAD_NUMBER;
 import static com.linkedin.venice.ConfigKeys.DEFAULT_MAX_NUMBER_OF_PARTITIONS;
+import static com.linkedin.venice.ConfigKeys.DEFAULT_MAX_RECORD_SIZE_BYTES;
 import static com.linkedin.venice.ConfigKeys.DEFAULT_NUMBER_OF_PARTITION;
 import static com.linkedin.venice.ConfigKeys.DEFAULT_NUMBER_OF_PARTITION_FOR_HYBRID;
 import static com.linkedin.venice.ConfigKeys.DEFAULT_OFFLINE_PUSH_STRATEGY;
@@ -614,7 +614,7 @@ public class VeniceControllerClusterConfig {
         props.getBoolean(CONTROLLER_DISABLE_PARENT_REQUEST_TOPIC_FOR_STREAM_PUSHES, false);
     this.defaultReadQuotaPerRouter =
         props.getInt(CONTROLLER_DEFAULT_READ_QUOTA_PER_ROUTER, DEFAULT_PER_ROUTER_READ_QUOTA);
-    this.defaultMaxRecordSizeBytes = props.getInt(CONTROLLER_DEFAULT_MAX_RECORD_SIZE_BYTES, 100 * BYTES_PER_MB);
+    this.defaultMaxRecordSizeBytes = props.getInt(DEFAULT_MAX_RECORD_SIZE_BYTES, 100 * BYTES_PER_MB);
     if (defaultMaxRecordSizeBytes < BYTES_PER_MB) {
       throw new VeniceException(
           "Default max record size must be at least " + generateHumanReadableByteCountString(BYTES_PER_MB));

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerClusterConfig.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerClusterConfig.java
@@ -1,6 +1,7 @@
 package com.linkedin.venice.controller;
 
 import static com.linkedin.venice.CommonConfigKeys.SSL_FACTORY_CLASS_NAME;
+import static com.linkedin.venice.ConfigConstants.DEFAULT_MAX_RECORD_SIZE_BYTES_BACKFILL;
 import static com.linkedin.venice.ConfigConstants.DEFAULT_PUSH_STATUS_STORE_HEARTBEAT_EXPIRATION_TIME_IN_SECONDS;
 import static com.linkedin.venice.ConfigKeys.ACTIVE_ACTIVE_REAL_TIME_SOURCE_FABRIC_LIST;
 import static com.linkedin.venice.ConfigKeys.ADMIN_CHECK_READ_METHOD_FOR_KAFKA;
@@ -614,7 +615,8 @@ public class VeniceControllerClusterConfig {
         props.getBoolean(CONTROLLER_DISABLE_PARENT_REQUEST_TOPIC_FOR_STREAM_PUSHES, false);
     this.defaultReadQuotaPerRouter =
         props.getInt(CONTROLLER_DEFAULT_READ_QUOTA_PER_ROUTER, DEFAULT_PER_ROUTER_READ_QUOTA);
-    this.defaultMaxRecordSizeBytes = props.getInt(DEFAULT_MAX_RECORD_SIZE_BYTES, 100 * BYTES_PER_MB);
+    this.defaultMaxRecordSizeBytes =
+        props.getInt(DEFAULT_MAX_RECORD_SIZE_BYTES, DEFAULT_MAX_RECORD_SIZE_BYTES_BACKFILL);
     if (defaultMaxRecordSizeBytes < BYTES_PER_MB) {
       throw new VeniceException(
           "Default max record size must be at least " + generateHumanReadableByteCountString(BYTES_PER_MB));


### PR DESCRIPTION
## Summary

Added a metric to alert customers when they are nearing the record size limit by providing the percentage of the record limit reached.

### Changes
1. **[Metric]** Added the metric `assembled_record_size_ratio` which is a ratio of the record size (for records that need chunking, similar to #1009) divided by the `maxRecordSizeBytes` record size limit.
2. **[Metric]** Replaced the metric `assembled_record_value_size_in_bytes` with `assembled_record_size_in_bytes` to pair with `assembled_record_size_ratio`, so we have both metrics that are measuring record size.
3. **[Functional]** Stopped counting RMD size towards the `maxRecordSizeBytes` limit (added in #1052), because it's an internal component and a user's write operation should not be failed because of it.
4. **[Config]** Renamed the controller config `controller.default.max.record.size.bytes` to just `default.max.record.size.bytes`, which will be shared between server and controller.
5. **[Metric]** Added the metric `assembled_rmd_size_in_bytes` (similar to #1009) to track and monitor the RMD size as it contributes to overall record size.
6. **[Functional]** Added field `isRmdChunked` to `StoreIngestionTask` in order to distinguish between chunked and non-chunked RMD payloads.
7. **[Unit Test]** Extended `testAssembledValueSizeSensor()` in `StoreIngestionTaskTest` to test the values of `assembled_record_size_ratio` and `assembled_rmd_size_in_bytes`.
8. **[Integration Test]** Modified `testStoreWithTooLargeValues()` in `TestBatch` to verify that the metric is being populated with the right values.
9. **[Integration Test]** Added a check that the `assembled_rmd_size_in_bytes` metric is being populated in `testActiveActivePartialUpdateWithCompression()` within `PartialUpdateTest`.
10. **[Test]** Minor test util changes in `MetricsUtils` and `ChunkingTestUtils`.

## How was this PR tested?
GHCI

## Does this PR introduce any user-facing changes?
- [X] No. You can skip the rest of this section.