### PR TITLE
[vpj][server] Fix DELETE handling in TTL repush and allow server to auto convert value level TS to field level TS

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/replication/merge/MergeConflictResolver.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/replication/merge/MergeConflictResolver.java
@@ -312,15 +312,14 @@ public class MergeConflictResolver {
       long newValueSourceOffset,
       int newValueSourceBrokerID,
       int newValueSchemaID) {
-    if (!(oldTimestampObject instanceof GenericRecord)) {
-      throw new IllegalStateException(
-          "Per-field RMD timestamp must be a GenericRecord. Got: " + oldTimestampObject + " and store name is: "
-              + storeName);
+
+    if (oldTimestampObject instanceof GenericRecord) {
+      final GenericRecord oldValueFieldTimestampsRecord = (GenericRecord) oldTimestampObject;
+      if (ignoreNewPut(oldValueSchemaID, oldValueFieldTimestampsRecord, newValueSchemaID, putOperationTimestamp)) {
+        return MergeConflictResult.getIgnoredResult();
+      }
     }
-    final GenericRecord oldValueFieldTimestampsRecord = (GenericRecord) oldTimestampObject;
-    if (ignoreNewPut(oldValueSchemaID, oldValueFieldTimestampsRecord, newValueSchemaID, putOperationTimestamp)) {
-      return MergeConflictResult.getIgnoredResult();
-    }
+
     final SchemaEntry mergeResultValueSchemaEntry =
         mergeResultValueSchemaResolver.getMergeResultValueSchema(oldValueSchemaID, newValueSchemaID);
     /**

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/input/kafka/ttl/VeniceChunkedPayloadTTLFilter.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/input/kafka/ttl/VeniceChunkedPayloadTTLFilter.java
@@ -31,7 +31,8 @@ public class VeniceChunkedPayloadTTLFilter extends VeniceRmdTTLFilter<ChunkAssem
 
   @Override
   protected ByteBuffer getValuePayload(ChunkAssembler.ValueBytesAndSchemaId valueBytesAndSchemaId) {
-    return ByteBuffer.wrap(valueBytesAndSchemaId.getBytes());
+    byte[] valueBytes = valueBytesAndSchemaId.getBytes();
+    return valueBytes == null ? null : ByteBuffer.wrap(valueBytes);
   }
 
   @Override

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/input/kafka/ttl/VeniceRmdTTLFilter.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/input/kafka/ttl/VeniceRmdTTLFilter.java
@@ -25,7 +25,6 @@ import java.util.Map;
 import java.util.Objects;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericRecord;
-import org.apache.logging.log4j.LogManager;
 
 
 /**
@@ -58,7 +57,6 @@ public abstract class VeniceRmdTTLFilter<INPUT_VALUE> extends AbstractVeniceFilt
     this.schemaSource = new HDFSSchemaSource(props.getString(VALUE_SCHEMA_DIR), props.getString(RMD_SCHEMA_DIR));
     this.rmdSchemaMap = schemaSource.fetchRmdSchemas();
     this.valueSchemaMap = schemaSource.fetchValueSchemas();
-    LogManager.getLogger(VeniceRmdTTLFilter.class).info("DEBUGGING: {}", rmdSchemaMap);
     this.rmdDeserializerCache = new VeniceConcurrentHashMap<>();
     this.valueDeserializerCache = new VeniceConcurrentHashMap<>();
     this.rmdSerializerCache = new VeniceConcurrentHashMap<>();
@@ -83,7 +81,6 @@ public abstract class VeniceRmdTTLFilter<INPUT_VALUE> extends AbstractVeniceFilt
 
   boolean filterByTTLandMaybeUpdateValue(final INPUT_VALUE value) {
     ByteBuffer rmdPayload = getRmdPayload(value);
-    LogManager.getLogger(VeniceRmdTTLFilter.class).info("DEBUGGING WE ARE HERE");
     if (rmdPayload == null || !rmdPayload.hasRemaining()) {
       throw new IllegalStateException(
           "The record doesn't contain required RMD field. Please check if your store has A/A enabled");
@@ -100,8 +97,6 @@ public abstract class VeniceRmdTTLFilter<INPUT_VALUE> extends AbstractVeniceFilt
       return (long) rmdTimestampObject <= filterTimestamp;
     }
     ByteBuffer valuePayload = getValuePayload(value);
-    LogManager.getLogger(VeniceRmdTTLFilter.class).info("DEBUGGING: {} {}", rmdRecord, valuePayload);
-
     if (valuePayload == null || valuePayload.remaining() == 0) {
       /**
        * We do not need check the field level TS for DELETE. If a field has TS older than TTL, it does not matter as it
@@ -134,7 +129,6 @@ public abstract class VeniceRmdTTLFilter<INPUT_VALUE> extends AbstractVeniceFilt
 
   RecordDeserializer<GenericRecord> generateRmdDeserializer(RmdVersionId rmdVersionId) {
     Schema schema = rmdSchemaMap.get(rmdVersionId);
-    LogManager.getLogger(VeniceRmdTTLFilter.class).info("DEBUGGING: {} {}", schema, rmdVersionId);
     return MapOrderPreservingSerDeFactory.getDeserializer(schema, schema);
   }
 

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/input/kafka/ttl/VeniceRmdTTLFilter.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/input/kafka/ttl/VeniceRmdTTLFilter.java
@@ -96,6 +96,14 @@ public abstract class VeniceRmdTTLFilter<INPUT_VALUE> extends AbstractVeniceFilt
     if (rmdTimestampType.equals(RmdTimestampType.VALUE_LEVEL_TIMESTAMP)) {
       return (long) rmdTimestampObject <= filterTimestamp;
     }
+    ByteBuffer valuePayload = getValuePayload(value);
+    if (valuePayload == null || valuePayload.remaining() == 0) {
+      /**
+       * We do not need check the field level TS for DELETE. If a field has TS older than TTL, it does not matter as it
+       * will still be overwritten by new PUT/UPDATE.
+       */
+      return true;
+    }
     RecordDeserializer<GenericRecord> valueDeserializer =
         valueDeserializerCache.computeIfAbsent(valueSchemaId, this::generateValueDeserializer);
     GenericRecord valueRecord = valueDeserializer.deserialize(getValuePayload(value));

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/input/kafka/ttl/VeniceRmdTTLFilter.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/input/kafka/ttl/VeniceRmdTTLFilter.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import java.util.Objects;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericRecord;
+import org.apache.logging.log4j.LogManager;
 
 
 /**
@@ -57,6 +58,7 @@ public abstract class VeniceRmdTTLFilter<INPUT_VALUE> extends AbstractVeniceFilt
     this.schemaSource = new HDFSSchemaSource(props.getString(VALUE_SCHEMA_DIR), props.getString(RMD_SCHEMA_DIR));
     this.rmdSchemaMap = schemaSource.fetchRmdSchemas();
     this.valueSchemaMap = schemaSource.fetchValueSchemas();
+    LogManager.getLogger(VeniceRmdTTLFilter.class).info("DEBUGGING: {}", rmdSchemaMap);
     this.rmdDeserializerCache = new VeniceConcurrentHashMap<>();
     this.valueDeserializerCache = new VeniceConcurrentHashMap<>();
     this.rmdSerializerCache = new VeniceConcurrentHashMap<>();
@@ -81,6 +83,7 @@ public abstract class VeniceRmdTTLFilter<INPUT_VALUE> extends AbstractVeniceFilt
 
   boolean filterByTTLandMaybeUpdateValue(final INPUT_VALUE value) {
     ByteBuffer rmdPayload = getRmdPayload(value);
+    LogManager.getLogger(VeniceRmdTTLFilter.class).info("DEBUGGING WE ARE HERE");
     if (rmdPayload == null || !rmdPayload.hasRemaining()) {
       throw new IllegalStateException(
           "The record doesn't contain required RMD field. Please check if your store has A/A enabled");
@@ -97,6 +100,8 @@ public abstract class VeniceRmdTTLFilter<INPUT_VALUE> extends AbstractVeniceFilt
       return (long) rmdTimestampObject <= filterTimestamp;
     }
     ByteBuffer valuePayload = getValuePayload(value);
+    LogManager.getLogger(VeniceRmdTTLFilter.class).info("DEBUGGING: {} {}", rmdRecord, valuePayload);
+
     if (valuePayload == null || valuePayload.remaining() == 0) {
       /**
        * We do not need check the field level TS for DELETE. If a field has TS older than TTL, it does not matter as it
@@ -129,6 +134,7 @@ public abstract class VeniceRmdTTLFilter<INPUT_VALUE> extends AbstractVeniceFilt
 
   RecordDeserializer<GenericRecord> generateRmdDeserializer(RmdVersionId rmdVersionId) {
     Schema schema = rmdSchemaMap.get(rmdVersionId);
+    LogManager.getLogger(VeniceRmdTTLFilter.class).info("DEBUGGING: {} {}", schema, rmdVersionId);
     return MapOrderPreservingSerDeFactory.getDeserializer(schema, schema);
   }
 

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/input/kafka/ttl/VeniceRmdTTLFilter.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/input/kafka/ttl/VeniceRmdTTLFilter.java
@@ -102,7 +102,7 @@ public abstract class VeniceRmdTTLFilter<INPUT_VALUE> extends AbstractVeniceFilt
        * We do not need check the field level TS for DELETE. If a field has TS older than TTL, it does not matter as it
        * will still be overwritten by new PUT/UPDATE.
        */
-      return true;
+      return false;
     }
     RecordDeserializer<GenericRecord> valueDeserializer =
         valueDeserializerCache.computeIfAbsent(valueSchemaId, this::generateValueDeserializer);

--- a/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/input/kafka/ttl/VeniceRmdTTLFilter.java
+++ b/clients/venice-push-job/src/main/java/com/linkedin/venice/hadoop/input/kafka/ttl/VeniceRmdTTLFilter.java
@@ -99,12 +99,11 @@ public abstract class VeniceRmdTTLFilter<INPUT_VALUE> extends AbstractVeniceFilt
     }
     ByteBuffer valuePayload = getValuePayload(value);
     GenericRecord valueRecord;
-    /**
-     * We do not need check the field level TS for DELETE. If a field has TS older than TTL, it does not matter as it
-     * will still be overwritten by new PUT/UPDATE.
-     */
-
     if (valuePayload == null || valuePayload.remaining() == 0) {
+      /**
+       * If it is a DELETE, then we need to create a default value and pass with old timestamp and perform the TTL delete
+       * operation and check the result.
+       */
       valueRecord = AvroSchemaUtils.createGenericRecord(valueSchemaMap.get(valueSchemaId));
     } else {
       RecordDeserializer<GenericRecord> valueDeserializer =

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/input/kafka/ttl/TestVeniceChunkedPayloadTTLFilter.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/input/kafka/ttl/TestVeniceChunkedPayloadTTLFilter.java
@@ -1,0 +1,200 @@
+package com.linkedin.venice.hadoop.input.kafka.ttl;
+
+import static com.linkedin.venice.hadoop.VenicePushJobConstants.REPUSH_TTL_ENABLE;
+import static com.linkedin.venice.hadoop.VenicePushJobConstants.REPUSH_TTL_POLICY;
+import static com.linkedin.venice.hadoop.VenicePushJobConstants.REPUSH_TTL_START_TIMESTAMP;
+import static com.linkedin.venice.hadoop.VenicePushJobConstants.RMD_SCHEMA_DIR;
+import static com.linkedin.venice.hadoop.VenicePushJobConstants.VALUE_SCHEMA_DIR;
+import static com.linkedin.venice.hadoop.VenicePushJobConstants.VENICE_STORE_NAME_PROP;
+import static com.linkedin.venice.schema.rmd.v1.CollectionRmdTimestamp.PUT_ONLY_PART_LENGTH_FIELD_NAME;
+import static com.linkedin.venice.schema.rmd.v1.CollectionRmdTimestamp.TOP_LEVEL_COLO_ID_FIELD_NAME;
+import static com.linkedin.venice.schema.rmd.v1.CollectionRmdTimestamp.TOP_LEVEL_TS_FIELD_NAME;
+import static com.linkedin.venice.utils.ChunkingTestUtils.createChunkBytes;
+import static com.linkedin.venice.utils.TestWriteUtils.getTempDataDirectory;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.linkedin.davinci.serializer.avro.MapOrderPreservingSerDeFactory;
+import com.linkedin.venice.controllerapi.ControllerClient;
+import com.linkedin.venice.controllerapi.MultiSchemaResponse;
+import com.linkedin.venice.hadoop.input.kafka.avro.KafkaInputMapperValue;
+import com.linkedin.venice.hadoop.input.kafka.avro.MapperValueType;
+import com.linkedin.venice.hadoop.input.kafka.chunk.ChunkAssembler;
+import com.linkedin.venice.hadoop.schema.HDFSSchemaSource;
+import com.linkedin.venice.schema.AvroSchemaParseUtils;
+import com.linkedin.venice.schema.rmd.RmdConstants;
+import com.linkedin.venice.schema.rmd.RmdSchemaGenerator;
+import com.linkedin.venice.serialization.KeyWithChunkingSuffixSerializer;
+import com.linkedin.venice.serialization.avro.ChunkedKeySuffixSerializer;
+import com.linkedin.venice.serializer.FastSerializerDeserializerFactory;
+import com.linkedin.venice.serializer.RecordSerializer;
+import com.linkedin.venice.utils.AvroSchemaUtils;
+import com.linkedin.venice.utils.VeniceProperties;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecord;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+
+public class TestVeniceChunkedPayloadTTLFilter {
+  private final static String TEST_STORE = "test_store";
+  private static final String VALUE_RECORD_SCHEMA_STR =
+      "{\"type\":\"record\"," + "\"name\":\"User\"," + "\"namespace\":\"example.avro\"," + "\"fields\":["
+          + "{\"name\":\"name\",\"type\":\"string\",\"default\":\"venice\"}]}";
+  private static final Schema VALUE_SCHEMA =
+      AvroSchemaParseUtils.parseSchemaFromJSONStrictValidation(VALUE_RECORD_SCHEMA_STR);
+  private static final Schema RMD_SCHEMA = RmdSchemaGenerator.generateMetadataSchema(VALUE_SCHEMA, 1);
+  private VeniceChunkedPayloadTTLFilter filter;
+
+  private final ChunkAssembler chunkAssembler = new ChunkAssembler(true);
+  private static final ChunkedKeySuffixSerializer CHUNKED_KEY_SUFFIX_SERIALIZER = new ChunkedKeySuffixSerializer();
+  private static final RecordSerializer<KafkaInputMapperValue> KAFKA_INPUT_MAPPER_VALUE_AVRO_SPECIFIC_SERIALIZER =
+      FastSerializerDeserializerFactory.getFastAvroGenericSerializer(KafkaInputMapperValue.SCHEMA$);
+
+  @BeforeClass
+  public void setUp() throws IOException {
+    Properties validProps = new Properties();
+    validProps.put(REPUSH_TTL_ENABLE, true);
+    validProps.put(REPUSH_TTL_POLICY, TTLResolutionPolicy.RT_WRITE_ONLY.getValue());
+    validProps.put(REPUSH_TTL_START_TIMESTAMP, 9L);
+    validProps.put(RMD_SCHEMA_DIR, getTempDataDirectory().getAbsolutePath());
+    validProps.put(VALUE_SCHEMA_DIR, getTempDataDirectory().getAbsolutePath());
+    validProps.put(VENICE_STORE_NAME_PROP, TEST_STORE);
+    VeniceProperties valid = new VeniceProperties(validProps);
+    // set up HDFS schema source to write dummy RMD schemas on temp directory
+    setupHDFS(valid);
+
+    this.filter = new VeniceChunkedPayloadTTLFilter(valid);
+  }
+
+  @Test
+  public void testTTLFilterRetainsDeleteWithFieldLevelTs() {
+    List<byte[]> values = new ArrayList<>(1);
+    GenericRecord rmdRecord = createRmdWithFieldLevelTimestamp(RMD_SCHEMA, Collections.singletonMap("name", 10L));
+
+    byte[] rmdBytes = MapOrderPreservingSerDeFactory.getSerializer(RMD_SCHEMA).serialize(rmdRecord);
+    values.add(createRegularValue(null, rmdBytes, 1, 1, MapperValueType.DELETE));
+    Collections.reverse(values); // value wins
+    final byte[] serializedKey = createChunkBytes(0, 5);
+    ChunkAssembler.ValueBytesAndSchemaId assembledValue =
+        chunkAssembler.assembleAndGetValue(serializedKey, values.iterator());
+    Assert.assertFalse(filter.checkAndMaybeFilterValue(assembledValue));
+  }
+
+  @Test
+  public void testTTLFilterHandleValuePayloadOfDelete() {
+    List<byte[]> values = new ArrayList<>(1);
+    byte[] rmdBytes = "dummyString".getBytes();
+    values.add(createRegularValue(null, rmdBytes, 1, 1, MapperValueType.DELETE));
+    Collections.reverse(values); // value wins
+    final byte[] serializedKey = createChunkBytes(0, 5);
+    ChunkAssembler.ValueBytesAndSchemaId assembledValue =
+        chunkAssembler.assembleAndGetValue(serializedKey, values.iterator());
+    VeniceChunkedPayloadTTLFilter veniceChunkedPayloadTTLFilter = mock(VeniceChunkedPayloadTTLFilter.class);
+    when(veniceChunkedPayloadTTLFilter.getValuePayload(assembledValue)).thenCallRealMethod();
+    Assert.assertNull(veniceChunkedPayloadTTLFilter.getValuePayload(assembledValue));
+  }
+
+  private byte[] createRegularValue(
+      byte[] valueBytes,
+      byte[] rmdBytes,
+      int schemaId,
+      int offset,
+      MapperValueType valueType) {
+    KafkaInputMapperValue regularValue = new KafkaInputMapperValue();
+    regularValue.chunkedKeySuffix = ByteBuffer
+        .wrap(CHUNKED_KEY_SUFFIX_SERIALIZER.serialize("", KeyWithChunkingSuffixSerializer.NON_CHUNK_KEY_SUFFIX));
+    regularValue.schemaId = schemaId;
+    regularValue.offset = offset;
+    regularValue.value = valueBytes == null ? ByteBuffer.wrap(new byte[0]) : ByteBuffer.wrap(valueBytes);
+    regularValue.valueType = valueType;
+    regularValue.replicationMetadataPayload =
+        rmdBytes == null ? ByteBuffer.wrap(new byte[0]) : ByteBuffer.wrap(rmdBytes);
+    regularValue.replicationMetadataVersionId = 1;
+    return serialize(regularValue);
+  }
+
+  private byte[] serialize(KafkaInputMapperValue value) {
+    return KAFKA_INPUT_MAPPER_VALUE_AVRO_SPECIFIC_SERIALIZER.serialize(value);
+  }
+
+  private void setupHDFS(VeniceProperties props) throws IOException {
+    ControllerClient client = mock(ControllerClient.class);
+    MultiSchemaResponse rmdResponse = new MultiSchemaResponse();
+    rmdResponse.setSchemas(generateRmdSchemas(1));
+    doReturn(rmdResponse).when(client).getAllReplicationMetadataSchemas(TEST_STORE);
+    MultiSchemaResponse valueResponse = new MultiSchemaResponse();
+    valueResponse.setSchemas(generateValueSchema(1));
+    doReturn(valueResponse).when(client).getAllValueSchema(TEST_STORE);
+    HDFSSchemaSource source =
+        new HDFSSchemaSource(props.getString(VALUE_SCHEMA_DIR), props.getString(RMD_SCHEMA_DIR), TEST_STORE);
+    source.saveSchemasOnDisk(client);
+  }
+
+  private MultiSchemaResponse.Schema[] generateRmdSchemas(int n) {
+    MultiSchemaResponse.Schema[] response = new MultiSchemaResponse.Schema[n];
+    for (int i = 1; i <= n; i++) {
+      MultiSchemaResponse.Schema schema = new MultiSchemaResponse.Schema();
+      schema.setRmdValueSchemaId(i);
+      schema.setDerivedSchemaId(i);
+      schema.setId(i);
+      schema.setSchemaStr(RMD_SCHEMA.toString());
+      response[i - 1] = schema;
+    }
+    return response;
+  }
+
+  private MultiSchemaResponse.Schema[] generateValueSchema(int n) {
+    MultiSchemaResponse.Schema[] response = new MultiSchemaResponse.Schema[n];
+    for (int i = 1; i <= n; i++) {
+      MultiSchemaResponse.Schema schema = new MultiSchemaResponse.Schema();
+      schema.setId(i);
+      schema.setSchemaStr(VALUE_SCHEMA.toString());
+      response[i - 1] = schema;
+    }
+    return response;
+  }
+
+  protected GenericRecord createRmdWithFieldLevelTimestamp(
+      Schema rmdSchema,
+      Map<String, Long> fieldNameToTimestampMap) {
+    return createRmdWithFieldLevelTimestamp(rmdSchema, fieldNameToTimestampMap, Collections.emptyMap());
+  }
+
+  protected GenericRecord createRmdWithFieldLevelTimestamp(
+      Schema rmdSchema,
+      Map<String, Long> fieldNameToTimestampMap,
+      Map<String, Integer> fieldNameToExistingPutPartLengthMap) {
+    final GenericRecord rmdRecord = new GenericData.Record(rmdSchema);
+    final Schema fieldLevelTimestampSchema = rmdSchema.getFields().get(0).schema().getTypes().get(1);
+    GenericRecord fieldTimestampsRecord = new GenericData.Record(fieldLevelTimestampSchema);
+    fieldNameToTimestampMap.forEach((fieldName, fieldTimestamp) -> {
+      Schema.Field field = fieldLevelTimestampSchema.getField(fieldName);
+      if (field.schema().getType().equals(Schema.Type.LONG)) {
+        fieldTimestampsRecord.put(fieldName, fieldTimestamp);
+      } else {
+        GenericRecord collectionFieldTimestampRecord = AvroSchemaUtils.createGenericRecord(field.schema());
+        // Only need to set the top-level field timestamp on collection timestamp record.
+        collectionFieldTimestampRecord.put(TOP_LEVEL_TS_FIELD_NAME, fieldTimestamp);
+        // When a collection field metadata is created, its top-level colo ID is always -1.
+        collectionFieldTimestampRecord.put(TOP_LEVEL_COLO_ID_FIELD_NAME, -1);
+        collectionFieldTimestampRecord
+            .put(PUT_ONLY_PART_LENGTH_FIELD_NAME, fieldNameToExistingPutPartLengthMap.getOrDefault(fieldName, 0));
+        fieldTimestampsRecord.put(field.name(), collectionFieldTimestampRecord);
+      }
+    });
+    rmdRecord.put(RmdConstants.TIMESTAMP_FIELD_NAME, fieldTimestampsRecord);
+    rmdRecord.put(RmdConstants.REPLICATION_CHECKPOINT_VECTOR_FIELD_NAME, new ArrayList<>());
+    return rmdRecord;
+  }
+}

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/input/kafka/ttl/TestVeniceChunkedPayloadTTLFilter.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/input/kafka/ttl/TestVeniceChunkedPayloadTTLFilter.java
@@ -95,7 +95,7 @@ public class TestVeniceChunkedPayloadTTLFilter {
     rmdRecord = createRmdWithFieldLevelTimestamp(RMD_SCHEMA, Collections.singletonMap("name", 9L));
     values = Collections
         .singletonList(createRegularValue(null, rmdSerializer.serialize(rmdRecord), 1, 1, MapperValueType.DELETE));
-    Assert.assertFalse(
+    Assert.assertTrue(
         filter.checkAndMaybeFilterValue(chunkAssembler.assembleAndGetValue(serializedKey, values.iterator())));
 
     // For value level TS, it will filter based on RMD timestamp.

--- a/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/input/kafka/ttl/TestVeniceChunkedPayloadTTLFilter.java
+++ b/clients/venice-push-job/src/test/java/com/linkedin/venice/hadoop/input/kafka/ttl/TestVeniceChunkedPayloadTTLFilter.java
@@ -135,6 +135,29 @@ public class TestVeniceChunkedPayloadTTLFilter {
             MapperValueType.PUT));
     Assert.assertFalse(
         filter.checkAndMaybeFilterValue(chunkAssembler.assembleAndGetValue(serializedKey, values.iterator())));
+
+    rmdRecord = createRmdWithFieldLevelTimestamp(RMD_SCHEMA, Collections.singletonMap("name", 10L));
+    values = Collections.singletonList(
+        createRegularValue(
+            valueSerializer.serialize(valueRecord),
+            rmdSerializer.serialize(rmdRecord),
+            1,
+            1,
+            MapperValueType.PUT));
+    Assert.assertFalse(
+        filter.checkAndMaybeFilterValue(chunkAssembler.assembleAndGetValue(serializedKey, values.iterator())));
+
+    rmdRecord = createRmdWithFieldLevelTimestamp(RMD_SCHEMA, Collections.singletonMap("name", 9L));
+    values = Collections.singletonList(
+        createRegularValue(
+            valueSerializer.serialize(valueRecord),
+            rmdSerializer.serialize(rmdRecord),
+            1,
+            1,
+            MapperValueType.PUT));
+    Assert.assertTrue(
+        filter.checkAndMaybeFilterValue(chunkAssembler.assembleAndGetValue(serializedKey, values.iterator())));
+
   }
 
   @Test


### PR DESCRIPTION
## [vpj][server] Fix DELETE handling in TTL repush and allow server to auto convert value level TS to field level TS
This PR addresses two issues related to AAWC:
(1) SIT does not fail when it tries to merge PUT with existing value level RMD record. This can happen when user enables PartialUpdate for an AA store and performs either a restart or repush.
(2) TTL Repush job does not fail when DELETE is the latest value of a key.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
Add new integration test and modify existing integration test.
Will also try to add new unit test for more coverage.
## Does this PR introduce any user-facing changes?
Now we can perform repush to create a new version or just execute a cluster wise restart to pick up the PU config change (the restart case it not ideal, there should be a future PR to refactor ParitalUpdate config to become a version aware config)
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [x] Yes. Make sure to explain your proposed changes and call out the behavior change.
