### PR TITLE
[test] Make some tests in TestAdminSparkServer less flaky

### DIFF
--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/server/AbstractTestAdminSparkServer.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/server/AbstractTestAdminSparkServer.java
@@ -21,7 +21,7 @@ import java.util.concurrent.TimeUnit;
  * A common base class to provide setup and teardown routines to be used in venice AdminSparkServer related test cases.
  */
 public class AbstractTestAdminSparkServer {
-  protected static final int TEST_TIMEOUT = 300 * Time.MS_PER_SECOND;
+  protected static final int TEST_TIMEOUT = 5 * Time.MS_PER_MINUTE;
   protected static final int STORAGE_NODE_COUNT = 1;
 
   protected VeniceTwoLayerMultiRegionMultiClusterWrapper venice;


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Make some tests in TestAdminSparkServer less flaky
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
Some tests of `TestAdminSparkServer` were flaky or incorrect. Fixed them.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
CI

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.