### PR TITLE
[da-vinci] Added a speedup throttler when DaVinci is bootstrapping current versions

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
@@ -7,6 +7,9 @@ import static com.linkedin.venice.ConfigKeys.BLOB_TRANSFER_MANAGER_ENABLED;
 import static com.linkedin.venice.ConfigKeys.DATA_BASE_PATH;
 import static com.linkedin.venice.ConfigKeys.DAVINCI_P2P_BLOB_TRANSFER_CLIENT_PORT;
 import static com.linkedin.venice.ConfigKeys.DAVINCI_P2P_BLOB_TRANSFER_SERVER_PORT;
+import static com.linkedin.venice.ConfigKeys.DA_VINCI_CURRENT_VERSION_BOOTSTRAPPING_QUOTA_BYTES_PER_SECOND;
+import static com.linkedin.venice.ConfigKeys.DA_VINCI_CURRENT_VERSION_BOOTSTRAPPING_QUOTA_RECORDS_PER_SECOND;
+import static com.linkedin.venice.ConfigKeys.DA_VINCI_CURRENT_VERSION_BOOTSTRAPPING_SPEEDUP_ENABLED;
 import static com.linkedin.venice.ConfigKeys.DIV_PRODUCER_STATE_MAX_AGE_MS;
 import static com.linkedin.venice.ConfigKeys.ENABLE_GRPC_READ_SERVER;
 import static com.linkedin.venice.ConfigKeys.ENABLE_SERVER_ALLOW_LIST;
@@ -472,6 +475,9 @@ public class VeniceServerConfig extends VeniceClusterConfig {
   private final boolean blobTransferManagerEnabled;
   private final int dvcP2pBlobTransferServerPort;
   private final int dvcP2pBlobTransferClientPort;
+  private final boolean daVinciCurrentVersionBootstrappingSpeedupEnabled;
+  private final long daVinciCurrentVersionBootstrappingQuotaRecordsPerSecond;
+  private final long daVinciCurrentVersionBootstrappingQuotaBytesPerSecond;
 
   public VeniceServerConfig(VeniceProperties serverProperties) throws ConfigurationException {
     this(serverProperties, Collections.emptyMap());
@@ -778,6 +784,12 @@ public class VeniceServerConfig extends VeniceClusterConfig {
     recordLevelMetricWhenBootstrappingCurrentVersionEnabled =
         serverProperties.getBoolean(SERVER_RECORD_LEVEL_METRICS_WHEN_BOOTSTRAPPING_CURRENT_VERSION_ENABLED, true);
     identityParserClassName = serverProperties.getString(IDENTITY_PARSER_CLASS, DefaultIdentityParser.class.getName());
+    daVinciCurrentVersionBootstrappingSpeedupEnabled =
+        serverProperties.getBoolean(DA_VINCI_CURRENT_VERSION_BOOTSTRAPPING_SPEEDUP_ENABLED, false);
+    daVinciCurrentVersionBootstrappingQuotaRecordsPerSecond =
+        serverProperties.getLong(DA_VINCI_CURRENT_VERSION_BOOTSTRAPPING_QUOTA_RECORDS_PER_SECOND, -1);
+    daVinciCurrentVersionBootstrappingQuotaBytesPerSecond =
+        serverProperties.getSizeInBytes(DA_VINCI_CURRENT_VERSION_BOOTSTRAPPING_QUOTA_BYTES_PER_SECOND, -1);
   }
 
   long extractIngestionMemoryLimit(
@@ -1390,5 +1402,17 @@ public class VeniceServerConfig extends VeniceClusterConfig {
 
   public String getRocksDBPath() {
     return getDataBasePath() + File.separator + "rocksdb";
+  }
+
+  public boolean isDaVinciCurrentVersionBootstrappingSpeedupEnabled() {
+    return daVinciCurrentVersionBootstrappingSpeedupEnabled;
+  }
+
+  public long getDaVinciCurrentVersionBootstrappingQuotaRecordsPerSecond() {
+    return daVinciCurrentVersionBootstrappingQuotaRecordsPerSecond;
+  }
+
+  public long getDaVinciCurrentVersionBootstrappingQuotaBytesPerSecond() {
+    return daVinciCurrentVersionBootstrappingQuotaBytesPerSecond;
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/AggKafkaConsumerService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/AggKafkaConsumerService.java
@@ -20,7 +20,6 @@ import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
 import com.linkedin.venice.pubsub.manager.TopicManager;
 import com.linkedin.venice.pubsub.manager.TopicManagerContext.PubSubPropertiesSupplier;
 import com.linkedin.venice.service.AbstractVeniceService;
-import com.linkedin.venice.throttle.EventThrottler;
 import com.linkedin.venice.utils.DaemonThreadFactory;
 import com.linkedin.venice.utils.RedundantExceptionFilter;
 import com.linkedin.venice.utils.SystemTime;
@@ -59,8 +58,7 @@ public class AggKafkaConsumerService extends AbstractVeniceService {
   private final VeniceServerConfig serverConfig;
   private final long readCycleDelayMs;
   private final long sharedConsumerNonExistingTopicCleanupDelayMS;
-  private final EventThrottler bandwidthThrottler;
-  private final EventThrottler recordsThrottler;
+  private final IngestionThrottler ingestionThrottler;
   private final KafkaClusterBasedRecordThrottler kafkaClusterBasedRecordThrottler;
   private final MetricsRepository metricsRepository;
   private final TopicExistenceChecker topicExistenceChecker;
@@ -91,8 +89,7 @@ public class AggKafkaConsumerService extends AbstractVeniceService {
       final PubSubConsumerAdapterFactory consumerFactory,
       final PubSubPropertiesSupplier pubSubPropertiesSupplier,
       final VeniceServerConfig serverConfig,
-      final EventThrottler bandwidthThrottler,
-      final EventThrottler recordsThrottler,
+      final IngestionThrottler ingestionThrottler,
       KafkaClusterBasedRecordThrottler kafkaClusterBasedRecordThrottler,
       final MetricsRepository metricsRepository,
       TopicExistenceChecker topicExistenceChecker,
@@ -104,8 +101,7 @@ public class AggKafkaConsumerService extends AbstractVeniceService {
     this.consumerFactory = consumerFactory;
     this.readCycleDelayMs = serverConfig.getKafkaReadCycleDelayMs();
     this.sharedConsumerNonExistingTopicCleanupDelayMS = serverConfig.getSharedConsumerNonExistingTopicCleanupDelayMS();
-    this.bandwidthThrottler = bandwidthThrottler;
-    this.recordsThrottler = recordsThrottler;
+    this.ingestionThrottler = ingestionThrottler;
     this.kafkaClusterBasedRecordThrottler = kafkaClusterBasedRecordThrottler;
     this.metricsRepository = metricsRepository;
     this.topicExistenceChecker = topicExistenceChecker;
@@ -303,8 +299,7 @@ public class AggKafkaConsumerService extends AbstractVeniceService {
                 consumerProperties,
                 readCycleDelayMs,
                 consumerPoolSize,
-                bandwidthThrottler,
-                recordsThrottler,
+                ingestionThrottler,
                 kafkaClusterBasedRecordThrottler,
                 metricsRepository,
                 kafkaClusterUrlToAliasMap.getOrDefault(url, url) + statsSuffix,

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/IngestionThrottler.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/IngestionThrottler.java
@@ -1,0 +1,151 @@
+package com.linkedin.davinci.kafka.consumer;
+
+import static java.lang.Thread.currentThread;
+
+import com.linkedin.alpini.base.concurrency.Executors;
+import com.linkedin.davinci.config.VeniceServerConfig;
+import com.linkedin.venice.throttle.EventThrottler;
+import com.linkedin.venice.utils.DaemonThreadFactory;
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+
+/**
+ * This throttler has the following functionality:
+ * 1. When running in DaVinci mode, if there are active current version bootstrapping with speedup mode is on, this
+ *    ingestion throttler will switch to speedup throttler.
+ * 2. Otherwise, this class will switch to regular throttler.
+ *
+ * This throttler is supposed to be adaptive throttler to speed up the DaVinci bootstrapping and fall back to the regular
+ * mode when the bootstrapping is done.
+ */
+public class IngestionThrottler implements Closeable {
+  private final Logger LOGGER = LogManager.getLogger(IngestionThrottler.class);
+
+  private final static int CURRENT_VERSION_BOOTSTRAPPING_DEFAULT_CHECK_INTERVAL = 30;
+  private final static TimeUnit CURRENT_VERSION_BOOTSTRAPPING_DEFAULT_CHECK_TIMEUNIT = TimeUnit.SECONDS;
+
+  private final ScheduledExecutorService eventThrottlerUpdateService;
+
+  private volatile EventThrottler finalRecordThrottler;
+  private volatile EventThrottler finalBandwidthThrottler;
+  private boolean isUsingSpeedupThrottler = false;
+
+  public IngestionThrottler(
+      boolean isDaVinciClient,
+      VeniceServerConfig serverConfig,
+      Supplier<Map<String, StoreIngestionTask>> ongoingIngestionTaskMapSupplier) {
+    this(
+        isDaVinciClient,
+        serverConfig,
+        ongoingIngestionTaskMapSupplier,
+        CURRENT_VERSION_BOOTSTRAPPING_DEFAULT_CHECK_INTERVAL,
+        CURRENT_VERSION_BOOTSTRAPPING_DEFAULT_CHECK_TIMEUNIT);
+  }
+
+  public IngestionThrottler(
+      boolean isDaVinciClient,
+      VeniceServerConfig serverConfig,
+      Supplier<Map<String, StoreIngestionTask>> ongoingIngestionTaskMapSupplier,
+      int checkInterval,
+      TimeUnit checkTimeUnit) {
+
+    EventThrottler regularRecordThrottler = new EventThrottler(
+        serverConfig.getKafkaFetchQuotaRecordPerSecond(),
+        serverConfig.getKafkaFetchQuotaTimeWindow(),
+        "kafka_consumption_records_count",
+        false,
+        EventThrottler.BLOCK_STRATEGY);
+    EventThrottler regularBandwidthThrottler = new EventThrottler(
+        serverConfig.getKafkaFetchQuotaBytesPerSecond(),
+        serverConfig.getKafkaFetchQuotaTimeWindow(),
+        "kafka_consumption_bandwidth",
+        false,
+        EventThrottler.BLOCK_STRATEGY);
+
+    if (isDaVinciClient && serverConfig.isDaVinciCurrentVersionBootstrappingSpeedupEnabled()) {
+      EventThrottler speedupRecordThrottler = new EventThrottler(
+          serverConfig.getDaVinciCurrentVersionBootstrappingQuotaRecordsPerSecond(),
+          serverConfig.getKafkaFetchQuotaTimeWindow(),
+          "current_version_speedup_kafka_consumption_records_count",
+          false,
+          EventThrottler.BLOCK_STRATEGY);
+      EventThrottler speedupBandwidthThrottler = new EventThrottler(
+          serverConfig.getDaVinciCurrentVersionBootstrappingQuotaBytesPerSecond(),
+          serverConfig.getKafkaFetchQuotaTimeWindow(),
+          "current_version_speedup_kafka_consumption_bandwidth",
+          false,
+          EventThrottler.BLOCK_STRATEGY);
+      this.eventThrottlerUpdateService =
+          Executors.newSingleThreadScheduledExecutor(new DaemonThreadFactory("Ingestion_Event_Throttler_update"));
+      this.eventThrottlerUpdateService.scheduleAtFixedRate(() -> {
+        Map<String, StoreIngestionTask> ongoingStoreIngestionTaskMap = ongoingIngestionTaskMapSupplier.get();
+        boolean hasCurrentVersionBootstrapping = false;
+        String topicOfCurrentVersionBootstrapping = "";
+        for (Map.Entry<String, StoreIngestionTask> entry: ongoingStoreIngestionTaskMap.entrySet()) {
+          StoreIngestionTask task = entry.getValue();
+          if (task.isCurrentVersion() && !task.hasAllPartitionReportedCompleted()) {
+            hasCurrentVersionBootstrapping = true;
+            topicOfCurrentVersionBootstrapping = entry.getKey();
+            break;
+          }
+        }
+        if (hasCurrentVersionBootstrapping && !isUsingSpeedupThrottler) {
+          LOGGER.info(
+              "Found one current version bootstrapping: {}, will switch to speedup throttler",
+              topicOfCurrentVersionBootstrapping);
+          this.finalRecordThrottler = speedupRecordThrottler;
+          this.finalBandwidthThrottler = speedupBandwidthThrottler;
+          this.isUsingSpeedupThrottler = true;
+        } else if (!hasCurrentVersionBootstrapping && isUsingSpeedupThrottler) {
+          LOGGER.info("There is no active current version bootstrapping, so switch to regular throttler");
+          this.finalRecordThrottler = regularRecordThrottler;
+          this.finalBandwidthThrottler = regularBandwidthThrottler;
+          this.isUsingSpeedupThrottler = false;
+        }
+
+      }, checkInterval, checkInterval, checkTimeUnit);
+      LOGGER.info(
+          "DaVinci current version ingestion speedup mode is enabled, and it will switch to speedup throttler"
+              + " when there is any active current version bootstrapping");
+    } else {
+      this.eventThrottlerUpdateService = null;
+    }
+
+    this.finalRecordThrottler = regularRecordThrottler;
+    this.finalBandwidthThrottler = regularBandwidthThrottler;
+  }
+
+  public void maybeThrottleRecordRate(int count) {
+    finalRecordThrottler.maybeThrottle(count);
+  }
+
+  public void maybeThrottleBandwidth(int totalBytes) {
+    finalBandwidthThrottler.maybeThrottle(totalBytes);
+  }
+
+  public boolean isUsingSpeedupThrottler() {
+    return isUsingSpeedupThrottler;
+  }
+
+  @Override
+  public void close() throws IOException {
+    if (eventThrottlerUpdateService != null) {
+      eventThrottlerUpdateService.shutdownNow();
+      try {
+        if (!eventThrottlerUpdateService.awaitTermination(10, TimeUnit.SECONDS)) {
+          LOGGER.error("Failed to shutdown executor for {}", this.getClass().getSimpleName());
+        }
+      } catch (InterruptedException e) {
+        LOGGER.error("Got interrupted when shutting down the scheduler for {}", this.getClass().getSimpleName());
+        currentThread().interrupt();
+      }
+    }
+  }
+}

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/PartitionWiseKafkaConsumerService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/PartitionWiseKafkaConsumerService.java
@@ -8,7 +8,6 @@ import com.linkedin.venice.pubsub.api.PubSubConsumerAdapter;
 import com.linkedin.venice.pubsub.api.PubSubMessageDeserializer;
 import com.linkedin.venice.pubsub.api.PubSubTopic;
 import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
-import com.linkedin.venice.throttle.EventThrottler;
 import com.linkedin.venice.utils.Time;
 import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
 import io.tehuti.metrics.MetricsRepository;
@@ -45,8 +44,7 @@ public class PartitionWiseKafkaConsumerService extends KafkaConsumerService {
       final Properties consumerProperties,
       final long readCycleDelayMs,
       final int numOfConsumersPerKafkaCluster,
-      final EventThrottler bandwidthThrottler,
-      final EventThrottler recordsThrottler,
+      final IngestionThrottler ingestionThrottler,
       final KafkaClusterBasedRecordThrottler kafkaClusterBasedRecordThrottler,
       final MetricsRepository metricsRepository,
       final String kafkaClusterAlias,
@@ -64,8 +62,7 @@ public class PartitionWiseKafkaConsumerService extends KafkaConsumerService {
         consumerProperties,
         readCycleDelayMs,
         numOfConsumersPerKafkaCluster,
-        bandwidthThrottler,
-        recordsThrottler,
+        ingestionThrottler,
         kafkaClusterBasedRecordThrottler,
         metricsRepository,
         kafkaClusterAlias,

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -4017,4 +4017,18 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
     }
     return topicManagerRepository.getLocalTopicManager().containsTopic(this.versionTopic);
   }
+
+  public boolean isCurrentVersion() {
+    return isCurrentVersion.getAsBoolean();
+  }
+
+  public boolean hasAllPartitionReportedCompleted() {
+    for (Map.Entry<Integer, PartitionConsumptionState> entry: partitionConsumptionStateMap.entrySet()) {
+      if (entry.getValue().isCompletionReported()) {
+        return false;
+      }
+    }
+
+    return true;
+  }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/TopicWiseKafkaConsumerService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/TopicWiseKafkaConsumerService.java
@@ -6,7 +6,6 @@ import com.linkedin.venice.pubsub.PubSubConsumerAdapterFactory;
 import com.linkedin.venice.pubsub.api.PubSubMessageDeserializer;
 import com.linkedin.venice.pubsub.api.PubSubTopic;
 import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
-import com.linkedin.venice.throttle.EventThrottler;
 import com.linkedin.venice.utils.Time;
 import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
 import io.tehuti.metrics.MetricsRepository;
@@ -39,8 +38,7 @@ public class TopicWiseKafkaConsumerService extends KafkaConsumerService {
       final Properties consumerProperties,
       final long readCycleDelayMs,
       final int numOfConsumersPerKafkaCluster,
-      final EventThrottler bandwidthThrottler,
-      final EventThrottler recordsThrottler,
+      final IngestionThrottler ingestionThrottler,
       final KafkaClusterBasedRecordThrottler kafkaClusterBasedRecordThrottler,
       final MetricsRepository metricsRepository,
       final String kafkaClusterAlias,
@@ -58,8 +56,7 @@ public class TopicWiseKafkaConsumerService extends KafkaConsumerService {
         consumerProperties,
         readCycleDelayMs,
         numOfConsumersPerKafkaCluster,
-        bandwidthThrottler,
-        recordsThrottler,
+        ingestionThrottler,
         kafkaClusterBasedRecordThrottler,
         metricsRepository,
         kafkaClusterAlias,

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/AggKafkaConsumerServiceTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/AggKafkaConsumerServiceTest.java
@@ -21,7 +21,6 @@ import com.linkedin.venice.pubsub.api.PubSubTopic;
 import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
 import com.linkedin.venice.pubsub.manager.TopicManager;
 import com.linkedin.venice.pubsub.manager.TopicManagerContext.PubSubPropertiesSupplier;
-import com.linkedin.venice.throttle.EventThrottler;
 import com.linkedin.venice.utils.Utils;
 import io.tehuti.metrics.MetricsRepository;
 import it.unimi.dsi.fastutil.objects.Object2IntMaps;
@@ -36,8 +35,7 @@ public class AggKafkaConsumerServiceTest {
   private PubSubConsumerAdapterFactory consumerFactory;
   private PubSubPropertiesSupplier pubSubPropertiesSupplier;
   private VeniceServerConfig serverConfig;
-  private EventThrottler bandwidthThrottler;
-  private EventThrottler recordsThrottler;
+  private IngestionThrottler ingestionThrottler;
   private KafkaClusterBasedRecordThrottler kafkaClusterBasedRecordThrottler;
   private MetricsRepository metricsRepository;
   private TopicExistenceChecker topicExistenceChecker;
@@ -57,8 +55,7 @@ public class AggKafkaConsumerServiceTest {
     topicPartition = new PubSubTopicPartitionImpl(topic, 0);
     consumerFactory = mock(PubSubConsumerAdapterFactory.class);
     pubSubPropertiesSupplier = mock(PubSubPropertiesSupplier.class);
-    bandwidthThrottler = mock(EventThrottler.class);
-    recordsThrottler = mock(EventThrottler.class);
+    ingestionThrottler = mock(IngestionThrottler.class);
     kafkaClusterBasedRecordThrottler = mock(KafkaClusterBasedRecordThrottler.class);
     metricsRepository = mock(MetricsRepository.class);
     topicExistenceChecker = mock(TopicExistenceChecker.class);
@@ -72,8 +69,7 @@ public class AggKafkaConsumerServiceTest {
         consumerFactory,
         pubSubPropertiesSupplier,
         serverConfig,
-        bandwidthThrottler,
-        recordsThrottler,
+        ingestionThrottler,
         kafkaClusterBasedRecordThrottler,
         metricsRepository,
         topicExistenceChecker,

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/IngestionThrottlerTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/IngestionThrottlerTest.java
@@ -1,0 +1,81 @@
+package com.linkedin.davinci.kafka.consumer;
+
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+import com.linkedin.davinci.config.VeniceServerConfig;
+import com.linkedin.venice.utils.TestUtils;
+import java.io.IOException;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import org.testng.annotations.Test;
+
+
+public class IngestionThrottlerTest {
+  @Test
+  public void throttlerSwitchTest() throws IOException {
+    VeniceServerConfig serverConfig = mock(VeniceServerConfig.class);
+    doReturn(100l).when(serverConfig).getKafkaFetchQuotaRecordPerSecond();
+    doReturn(60l).when(serverConfig).getKafkaFetchQuotaTimeWindow();
+    doReturn(1024l).when(serverConfig).getKafkaFetchQuotaBytesPerSecond();
+    doReturn(true).when(serverConfig).isDaVinciCurrentVersionBootstrappingSpeedupEnabled();
+    doReturn(500l).when(serverConfig).getDaVinciCurrentVersionBootstrappingQuotaRecordsPerSecond();
+    doReturn(10240l).when(serverConfig).getDaVinciCurrentVersionBootstrappingQuotaBytesPerSecond();
+
+    StoreIngestionTask nonCurrentVersionTask = mock(StoreIngestionTask.class);
+    doReturn(false).when(nonCurrentVersionTask).isCurrentVersion();
+    doReturn(false).when(nonCurrentVersionTask).hasAllPartitionReportedCompleted();
+
+    StoreIngestionTask currentVersionBootstrappingTask = mock(StoreIngestionTask.class);
+    doReturn(true).when(currentVersionBootstrappingTask).isCurrentVersion();
+    doReturn(false).when(currentVersionBootstrappingTask).hasAllPartitionReportedCompleted();
+
+    StoreIngestionTask currentVersionCompletedTask = mock(StoreIngestionTask.class);
+    doReturn(true).when(currentVersionCompletedTask).isCurrentVersion();
+    doReturn(true).when(currentVersionCompletedTask).hasAllPartitionReportedCompleted();
+
+    ConcurrentHashMap<String, StoreIngestionTask> tasks = new ConcurrentHashMap<>();
+    tasks.put("non_current_version_task", nonCurrentVersionTask);
+
+    IngestionThrottler throttler = new IngestionThrottler(true, serverConfig, () -> tasks, 10, TimeUnit.MILLISECONDS);
+    TestUtils.waitForNonDeterministicAssertion(3, TimeUnit.SECONDS, () -> {
+      assertFalse(
+          throttler.isUsingSpeedupThrottler(),
+          "Shouldn't use speedup throttler when there is no current version bootstrapping");
+    });
+    // Add one bootstrapping current version.
+    tasks.put("current_version_bootstrapping_task", currentVersionBootstrappingTask);
+    TestUtils.waitForNonDeterministicAssertion(3, TimeUnit.SECONDS, () -> {
+      assertTrue(
+          throttler.isUsingSpeedupThrottler(),
+          "Should use speedup throttler when there is some current version bootstrapping");
+    });
+
+    // Remove the bootstrapping current version and add one completed current version
+    tasks.remove("current_version_bootstrapping_task");
+    tasks.put("current_version_completed_task", currentVersionCompletedTask);
+
+    TestUtils.waitForNonDeterministicAssertion(3, TimeUnit.SECONDS, () -> {
+      assertFalse(
+          throttler.isUsingSpeedupThrottler(),
+          "Shouldn't use speedup throttler when there is no current version bootstrapping");
+    });
+
+    throttler.close();
+
+    tasks.clear();
+    IngestionThrottler throttlerForNonDaVinciClient =
+        new IngestionThrottler(false, serverConfig, () -> tasks, 10, TimeUnit.MILLISECONDS);
+    tasks.put("current_version_bootstrapping_task", currentVersionBootstrappingTask);
+    tasks.put("current_version_completed_task", currentVersionCompletedTask);
+    TestUtils.waitForNonDeterministicAssertion(3, TimeUnit.SECONDS, () -> {
+      assertFalse(
+          throttlerForNonDaVinciClient.isUsingSpeedupThrottler(),
+          "Shouldn't use speedup throttler as DaVinci is disabled");
+    });
+
+    throttlerForNonDaVinciClient.close();
+  }
+}

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/KafkaConsumerServiceTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/KafkaConsumerServiceTest.java
@@ -24,7 +24,6 @@ import com.linkedin.venice.pubsub.api.PubSubMessageDeserializer;
 import com.linkedin.venice.pubsub.api.PubSubTopic;
 import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
 import com.linkedin.venice.serialization.avro.OptimizedKafkaValueSerializer;
-import com.linkedin.venice.throttle.EventThrottler;
 import com.linkedin.venice.utils.SystemTime;
 import com.linkedin.venice.utils.TestUtils;
 import com.linkedin.venice.utils.Utils;
@@ -84,8 +83,7 @@ public class KafkaConsumerServiceTest {
         properties,
         1000l,
         2,
-        mock(EventThrottler.class),
-        mock(EventThrottler.class),
+        mock(IngestionThrottler.class),
         mock(KafkaClusterBasedRecordThrottler.class),
         mockMetricsRepository,
         "test_kafka_cluster_alias",
@@ -201,8 +199,7 @@ public class KafkaConsumerServiceTest {
         properties,
         1000l,
         1,
-        mock(EventThrottler.class),
-        mock(EventThrottler.class),
+        mock(IngestionThrottler.class),
         mock(KafkaClusterBasedRecordThrottler.class),
         mockMetricsRepository,
         "test_kafka_cluster_alias",
@@ -255,8 +252,7 @@ public class KafkaConsumerServiceTest {
         properties,
         1000l,
         2,
-        mock(EventThrottler.class),
-        mock(EventThrottler.class),
+        mock(IngestionThrottler.class),
         mock(KafkaClusterBasedRecordThrottler.class),
         mockMetricsRepository,
         "test_kafka_cluster_alias",
@@ -355,8 +351,7 @@ public class KafkaConsumerServiceTest {
         properties,
         1000l,
         2,
-        mock(EventThrottler.class),
-        mock(EventThrottler.class),
+        mock(IngestionThrottler.class),
         mock(KafkaClusterBasedRecordThrottler.class),
         mockMetricsRepository,
         "test_kafka_cluster_alias",

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
@@ -340,8 +340,7 @@ public abstract class StoreIngestionTaskTest {
   private List<Object[]> mockNotifierError;
   private StorageMetadataService mockStorageMetadataService;
   private AbstractStorageEngine mockAbstractStorageEngine;
-  private EventThrottler mockBandwidthThrottler;
-  private EventThrottler mockRecordsThrottler;
+  private IngestionThrottler mockIngestionThrottler;
   private Map<String, EventThrottler> kafkaUrlToRecordsThrottler;
   private KafkaClusterBasedRecordThrottler kafkaClusterBasedRecordThrottler;
   private ReadOnlySchemaRepository mockSchemaRepo;
@@ -521,8 +520,7 @@ public abstract class StoreIngestionTaskTest {
 
     mockStorageMetadataService = mock(StorageMetadataService.class);
 
-    mockBandwidthThrottler = mock(EventThrottler.class);
-    mockRecordsThrottler = mock(EventThrottler.class);
+    mockIngestionThrottler = mock(IngestionThrottler.class);
     mockSchemaRepo = mock(ReadOnlySchemaRepository.class);
     mockMetadataRepo = mock(ReadOnlyStoreRepository.class);
     mockLocalKafkaConsumer = mock(PubSubConsumerAdapter.class);
@@ -956,8 +954,7 @@ public abstract class StoreIngestionTaskTest {
         localKafkaProps,
         10,
         1,
-        mockBandwidthThrottler,
-        mockRecordsThrottler,
+        mockIngestionThrottler,
         kafkaClusterBasedRecordThrottler,
         mockMetricRepo,
         inMemoryLocalKafkaBroker.getKafkaBootstrapServer(),
@@ -979,8 +976,7 @@ public abstract class StoreIngestionTaskTest {
         remoteKafkaProps,
         10,
         1,
-        mockBandwidthThrottler,
-        mockRecordsThrottler,
+        mockIngestionThrottler,
         kafkaClusterBasedRecordThrottler,
         mockMetricRepo,
         inMemoryLocalKafkaBroker.getKafkaBootstrapServer(),
@@ -995,7 +991,6 @@ public abstract class StoreIngestionTaskTest {
         false);
     remoteKafkaConsumerService.start();
 
-    doReturn(100L).when(mockBandwidthThrottler).getMaxRatePerSecond();
     prepareAggKafkaConsumerServiceMock();
 
     return StoreIngestionTaskFactory.builder()
@@ -1727,8 +1722,8 @@ public abstract class StoreIngestionTaskTest {
 
     runTest(new RandomPollStrategy(1), Utils.setOf(PARTITION_FOO), () -> {}, () -> {
       // START_OF_SEGMENT, START_OF_PUSH, PUT, DELETE
-      verify(mockRecordsThrottler, timeout(TEST_TIMEOUT_MS).times(4)).maybeThrottle(1);
-      verify(mockBandwidthThrottler, timeout(TEST_TIMEOUT_MS).times(4)).maybeThrottle(anyDouble());
+      verify(mockIngestionThrottler, timeout(TEST_TIMEOUT_MS).times(4)).maybeThrottleRecordRate(1);
+      verify(mockIngestionThrottler, timeout(TEST_TIMEOUT_MS).times(4)).maybeThrottleBandwidth(anyInt());
     }, aaConfig, null);
   }
 

--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -77,6 +77,26 @@ public class ConfigKeys {
   public static final String SERVER_KAFKA_FETCH_QUOTA_RECORDS_PER_SECOND =
       "server.kafka.fetch.quota.records.per.second";
 
+  /**
+   * Whether to speed up DaVinci current version bootstrapping or not.
+   */
+  public static final String DA_VINCI_CURRENT_VERSION_BOOTSTRAPPING_SPEEDUP_ENABLED =
+      "da.vinci.current.version.bootstrapping.speedup.enabled";
+
+  /**
+   * When {@link #DA_VINCI_CURRENT_VERSION_BOOTSTRAPPING_SPEEDUP_ENABLED} is true, the following throttler
+   * will be applied when any current version is bootstrapping.
+   */
+  public static final String DA_VINCI_CURRENT_VERSION_BOOTSTRAPPING_QUOTA_RECORDS_PER_SECOND =
+      "da.vinci.current.version.bootstrapping.quota.records.per.second";
+
+  /**
+   * When {@link #DA_VINCI_CURRENT_VERSION_BOOTSTRAPPING_SPEEDUP_ENABLED} is true, the following throttler
+   * will be applied when any current version is bootstrapping.
+   */
+  public static final String DA_VINCI_CURRENT_VERSION_BOOTSTRAPPING_QUOTA_BYTES_PER_SECOND =
+      "da.vinci.current.version.bootstrapping.quota.bytes.per.second";
+
   // Unordered throttlers aren't compatible with Shared Kafka Consumer and have no effect when Shared Consumer is used.
   public static final String KAFKA_FETCH_QUOTA_UNORDERED_BYTES_PER_SECOND =
       "kafka.fetch.quota.unordered.bytes.per.second";

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/DaVinciClientTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/DaVinciClientTest.java
@@ -9,6 +9,7 @@ import static com.linkedin.venice.ConfigKeys.DATA_BASE_PATH;
 import static com.linkedin.venice.ConfigKeys.DAVINCI_P2P_BLOB_TRANSFER_CLIENT_PORT;
 import static com.linkedin.venice.ConfigKeys.DAVINCI_P2P_BLOB_TRANSFER_SERVER_PORT;
 import static com.linkedin.venice.ConfigKeys.DAVINCI_PUSH_STATUS_SCAN_INTERVAL_IN_SECONDS;
+import static com.linkedin.venice.ConfigKeys.DA_VINCI_CURRENT_VERSION_BOOTSTRAPPING_SPEEDUP_ENABLED;
 import static com.linkedin.venice.ConfigKeys.PERSISTENCE_TYPE;
 import static com.linkedin.venice.ConfigKeys.PUSH_STATUS_STORE_ENABLED;
 import static com.linkedin.venice.ConfigKeys.SERVER_CONSUMER_POOL_SIZE_PER_KAFKA_CLUSTER;
@@ -220,6 +221,7 @@ public class DaVinciClientTest {
         .put(CLIENT_SYSTEM_STORE_REPOSITORY_REFRESH_INTERVAL_SECONDS, 1)
         .put(DATA_BASE_PATH, baseDataPath)
         .put(PERSISTENCE_TYPE, ROCKS_DB)
+        .put(DA_VINCI_CURRENT_VERSION_BOOTSTRAPPING_SPEEDUP_ENABLED, true)
         .build();
 
     MetricsRepository metricsRepository = new MetricsRepository();

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/kafka/KafkaConsumptionTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/kafka/KafkaConsumptionTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.mock;
 import com.github.benmanes.caffeine.cache.Cache;
 import com.linkedin.davinci.config.VeniceServerConfig;
 import com.linkedin.davinci.kafka.consumer.AggKafkaConsumerService;
+import com.linkedin.davinci.kafka.consumer.IngestionThrottler;
 import com.linkedin.davinci.kafka.consumer.KafkaClusterBasedRecordThrottler;
 import com.linkedin.davinci.kafka.consumer.KafkaConsumerService;
 import com.linkedin.davinci.kafka.consumer.StoreIngestionTask;
@@ -145,8 +146,7 @@ public class KafkaConsumptionTest {
   public void testLocalAndRemoteConsumption(boolean isTopicWiseSharedConsumerAssignmentStrategy)
       throws ExecutionException, InterruptedException {
     // Prepare Aggregate Kafka Consumer Service.
-    EventThrottler mockBandwidthThrottler = mock(EventThrottler.class);
-    EventThrottler mockRecordsThrottler = mock(EventThrottler.class);
+    IngestionThrottler mockIngestionThrottler = mock(IngestionThrottler.class);
     Map<String, EventThrottler> kafkaUrlToRecordsThrottler = new HashMap<>();
     KafkaClusterBasedRecordThrottler kafkaClusterBasedRecordThrottler =
         new KafkaClusterBasedRecordThrottler(kafkaUrlToRecordsThrottler);
@@ -189,8 +189,7 @@ public class KafkaConsumptionTest {
         pubSubConsumerAdapterFactory,
         k -> VeniceProperties.empty(),
         veniceServerConfig,
-        mockBandwidthThrottler,
-        mockRecordsThrottler,
+        mockIngestionThrottler,
         kafkaClusterBasedRecordThrottler,
         metricsRepository,
         topicExistenceChecker,


### PR DESCRIPTION


<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Summary, imperative, start upper case, don't end with a period
When working with DaVinci customers, we often tune the ingestion params to speed up the bootstrapping, but we don't want to use the same setup at the steady state since the high ingestion throughput would affect the performance of the read path. This PR introduces a way to dynamically switch ingestion throttlers based on the ingestion status.
Essentially, this new feature would switch to the speedup throttler when it detects any current version bootstrapping and otherwise, it will continue to use the regular throttler.
To optimize the bootstrapping perf, we can bump up the following pools together with this feature:
1. Consumer pool.
2. Drainer/writer pool. As the GC issue is mainly triggered by the ingestion speed, we can safely increase the pool size.

New configs:
da.vinci.current.version.bootstrapping.speedup.enabled : default false da.vinci.current.version.bootstrapping.quota.records.per.second : default -1 da.vinci.current.version.bootstrapping.quota.bytes.per.second : default -1
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->


## How was this PR tested?
CI
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.