### PR TITLE
[server] Add version topic information to topic partition ingestion context.

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ConsumptionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ConsumptionTask.java
@@ -276,10 +276,7 @@ class ConsumptionTask implements Runnable {
   PubSubTopic getDestinationIdentifier(PubSubTopicPartition topicPartition) {
     ConsumedDataReceiver<List<PubSubMessage<KafkaKey, KafkaMessageEnvelope, Long>>> dataReceiver =
         dataReceiverMap.get(topicPartition);
-    if (dataReceiver != null) {
-      return dataReceiver.destinationIdentifier();
-    }
-    return null;
+    return dataReceiver == null ? null : dataReceiver.destinationIdentifier();
   }
 
   Long getLastSuccessfulPollTimestamp(PubSubTopicPartition topicPartition) {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ConsumptionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ConsumptionTask.java
@@ -6,6 +6,7 @@ import com.linkedin.venice.kafka.protocol.KafkaMessageEnvelope;
 import com.linkedin.venice.message.KafkaKey;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.pubsub.api.PubSubMessage;
+import com.linkedin.venice.pubsub.api.PubSubTopic;
 import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
 import com.linkedin.venice.utils.ExceptionUtils;
 import com.linkedin.venice.utils.LatencyUtils;
@@ -270,6 +271,15 @@ class ConsumptionTask implements Runnable {
       return bytesRatePerTopicPartition.get(topicPartition).measure(metricConfig, System.currentTimeMillis());
     }
     return 0.0D;
+  }
+
+  PubSubTopic getDestinationIdentifier(PubSubTopicPartition topicPartition) {
+    ConsumedDataReceiver<List<PubSubMessage<KafkaKey, KafkaMessageEnvelope, Long>>> dataReceiver =
+        dataReceiverMap.get(topicPartition);
+    if (dataReceiver != null) {
+      return dataReceiver.destinationIdentifier();
+    }
+    return null;
   }
 
   Long getLastSuccessfulPollTimestamp(PubSubTopicPartition topicPartition) {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaConsumerService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaConsumerService.java
@@ -493,14 +493,20 @@ public abstract class KafkaConsumerService extends AbstractKafkaConsumerService 
           elapsedTimeSinceLastPollInMs =
               LatencyUtils.getElapsedTimeFromMsToMs(consumptionTask.getLastSuccessfulPollTimestamp());
         }
-        TopicPartitionIngestionInfo topicPartitionIngestionInfo = new TopicPartitionIngestionInfo(
-            latestOffset,
-            offsetLag,
-            msgRate,
-            byteRate,
-            consumerIdx,
-            elapsedTimeSinceLastPollInMs);
-        topicPartitionIngestionInfoMap.put(topicPartition, topicPartitionIngestionInfo);
+        PubSubTopic destinationVersionTopic = consumptionTask.getDestinationIdentifier(pubSubTopicPartition);
+        if (destinationVersionTopic == null) {
+          throw new VeniceException("Destination version topic is null for " + pubSubTopicPartition);
+        } else {
+          TopicPartitionIngestionInfo topicPartitionIngestionInfo = new TopicPartitionIngestionInfo(
+              latestOffset,
+              offsetLag,
+              msgRate,
+              byteRate,
+              consumerIdx,
+              elapsedTimeSinceLastPollInMs,
+              destinationVersionTopic.getName());
+          topicPartitionIngestionInfoMap.put(topicPartition, topicPartitionIngestionInfo);
+        }
       }
     }
     return topicPartitionIngestionInfoMap;

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaConsumerService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaConsumerService.java
@@ -494,19 +494,16 @@ public abstract class KafkaConsumerService extends AbstractKafkaConsumerService 
               LatencyUtils.getElapsedTimeFromMsToMs(consumptionTask.getLastSuccessfulPollTimestamp());
         }
         PubSubTopic destinationVersionTopic = consumptionTask.getDestinationIdentifier(pubSubTopicPartition);
-        if (destinationVersionTopic == null) {
-          throw new VeniceException("Destination version topic is null for " + pubSubTopicPartition);
-        } else {
-          TopicPartitionIngestionInfo topicPartitionIngestionInfo = new TopicPartitionIngestionInfo(
-              latestOffset,
-              offsetLag,
-              msgRate,
-              byteRate,
-              consumerIdx,
-              elapsedTimeSinceLastPollInMs,
-              destinationVersionTopic.getName());
-          topicPartitionIngestionInfoMap.put(topicPartition, topicPartitionIngestionInfo);
-        }
+        String destinationVersionTopicName = destinationVersionTopic == null ? "" : destinationVersionTopic.getName();
+        TopicPartitionIngestionInfo topicPartitionIngestionInfo = new TopicPartitionIngestionInfo(
+            latestOffset,
+            offsetLag,
+            msgRate,
+            byteRate,
+            consumerIdx,
+            elapsedTimeSinceLastPollInMs,
+            destinationVersionTopicName);
+        topicPartitionIngestionInfoMap.put(topicPartition, topicPartitionIngestionInfo);
       }
     }
     return topicPartitionIngestionInfoMap;

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/TopicPartitionIngestionInfo.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/TopicPartitionIngestionInfo.java
@@ -12,6 +12,8 @@ public class TopicPartitionIngestionInfo {
   private int consumerIdx;
   private long elapsedTimeSinceLastPollInMs;
 
+  private String versionTopicName;
+
   @JsonCreator
   public TopicPartitionIngestionInfo(
       @JsonProperty("latestOffset") long latestOffset,
@@ -19,13 +21,15 @@ public class TopicPartitionIngestionInfo {
       @JsonProperty("msgRate") double msgRate,
       @JsonProperty("byteRate") double byteRate,
       @JsonProperty("consumerIdx") int consumerIdx,
-      @JsonProperty("elapsedTimeSinceLastPollInMs") long elapsedTimeSinceLastPollInMs) {
+      @JsonProperty("elapsedTimeSinceLastPollInMs") long elapsedTimeSinceLastPollInMs,
+      @JsonProperty("versionTopicName") String versionTopicName) {
     this.latestOffset = latestOffset;
     this.offsetLag = offsetLag;
     this.msgRate = msgRate;
     this.byteRate = byteRate;
     this.consumerIdx = consumerIdx;
     this.elapsedTimeSinceLastPollInMs = elapsedTimeSinceLastPollInMs;
+    this.versionTopicName = versionTopicName;
   }
 
   public long getLatestOffset() {
@@ -72,6 +76,14 @@ public class TopicPartitionIngestionInfo {
     this.elapsedTimeSinceLastPollInMs = elapsedTimeSinceLastPollInMs;
   }
 
+  public String getVersionTopicName() {
+    return versionTopicName;
+  }
+
+  public void setVersionTopicName(String versionTopicName) {
+    this.versionTopicName = versionTopicName;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -86,7 +98,8 @@ public class TopicPartitionIngestionInfo {
         && Double.doubleToLongBits(this.msgRate) == Double.doubleToLongBits(topicPartitionIngestionInfo.getMsgRate())
         && Double.doubleToLongBits(this.byteRate) == Double.doubleToLongBits(topicPartitionIngestionInfo.getByteRate())
         && this.consumerIdx == topicPartitionIngestionInfo.getConsumerIdx()
-        && this.elapsedTimeSinceLastPollInMs == topicPartitionIngestionInfo.getElapsedTimeSinceLastPollInMs();
+        && this.elapsedTimeSinceLastPollInMs == topicPartitionIngestionInfo.getElapsedTimeSinceLastPollInMs()
+        && this.versionTopicName.equals(topicPartitionIngestionInfo.getVersionTopicName());
   }
 
   @Override
@@ -97,6 +110,7 @@ public class TopicPartitionIngestionInfo {
     result = 31 * result + Double.hashCode(byteRate);
     result = 31 * result + consumerIdx;
     result = 31 * result + Long.hashCode(elapsedTimeSinceLastPollInMs);
+    result = 31 * result + versionTopicName.hashCode();
     return result;
   }
 }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/TopicPartitionIngestionInfoTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/TopicPartitionIngestionInfoTest.java
@@ -18,10 +18,11 @@ public class TopicPartitionIngestionInfoTest {
 
   @Test
   public void testJsonParse() throws Exception {
-    TopicPartitionIngestionInfo topicPartitionIngestionInfo = new TopicPartitionIngestionInfo(0, 1, 2.0, 4.0, 5, 7);
-    PubSubTopic pubSubTopic = pubSubTopicRepository.getTopic("test_store_v1");
+    PubSubTopic versionTopic = pubSubTopicRepository.getTopic("test_store_v1");
+    TopicPartitionIngestionInfo topicPartitionIngestionInfo =
+        new TopicPartitionIngestionInfo(0, 1, 2.0, 4.0, 5, 7, versionTopic.getName());
     String kafkaUrl = "localhost:1234";
-    PubSubTopicPartition pubSubTopicPartition = new PubSubTopicPartitionImpl(pubSubTopic, 0);
+    PubSubTopicPartition pubSubTopicPartition = new PubSubTopicPartitionImpl(versionTopic, 0);
     Map<String, Map<String, TopicPartitionIngestionInfo>> topicPartitionIngestionContext = new HashMap<>();
     topicPartitionIngestionContext.computeIfAbsent(kafkaUrl, k -> new HashMap<>())
         .put(pubSubTopicPartition.toString(), topicPartitionIngestionInfo);

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/KafkaConsumerServiceTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/KafkaConsumerServiceTest.java
@@ -191,6 +191,9 @@ public class KafkaConsumerServiceTest {
       Assert.assertTrue(topicPartitionIngestionInfoMap.get(topicPartition).getConsumerIdx() == 0);
       Assert.assertTrue(topicPartitionIngestionInfoMap.get(topicPartition).getMsgRate() > 0);
       Assert.assertTrue(topicPartitionIngestionInfoMap.get(topicPartition).getByteRate() > 0);
+      Assert.assertEquals(
+          topicPartitionIngestionInfoMap.get(topicPartition).getVersionTopicName(),
+          topicForStoreName3.getName());
     });
     consumerService.stop();
   }


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->
During ingestion debugging process, version topic information of all topic partitions on one consumer are still very useful. As we need this ingestion speed or last poll time for topic partition of all version topics for debugging slow ingestion issues.  The version topic is the destination of `DataReceiver` inside `ConsumptionTask` for each `PubSubTopicPartition`, so here adding a one method for `ConsumptionTask` to get version topic.


## Summary, imperative, start upper case, don't end with a period
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.
mint build
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Resolves #XXX

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.