### PR TITLE
[server] Supporting 4 consumer pools for current version and isolation for AA WC leader.

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
@@ -50,6 +50,11 @@ import static com.linkedin.venice.ConfigKeys.SERVER_BLOCKING_QUEUE_TYPE;
 import static com.linkedin.venice.ConfigKeys.SERVER_COMPUTE_FAST_AVRO_ENABLED;
 import static com.linkedin.venice.ConfigKeys.SERVER_COMPUTE_QUEUE_CAPACITY;
 import static com.linkedin.venice.ConfigKeys.SERVER_COMPUTE_THREAD_NUM;
+import static com.linkedin.venice.ConfigKeys.SERVER_CONSUMER_POOL_ALLOCATION_STRATEGY;
+import static com.linkedin.venice.ConfigKeys.SERVER_CONSUMER_POOL_SIZE_FOR_CURRENT_VERSION_AA_WC_LEADER;
+import static com.linkedin.venice.ConfigKeys.SERVER_CONSUMER_POOL_SIZE_FOR_CURRENT_VERSION_NON_AA_WC_LEADER;
+import static com.linkedin.venice.ConfigKeys.SERVER_CONSUMER_POOL_SIZE_FOR_NON_CURRENT_VERSION_AA_WC_LEADER;
+import static com.linkedin.venice.ConfigKeys.SERVER_CONSUMER_POOL_SIZE_FOR_NON_CURRENT_VERSION_NON_AA_WC_LEADER;
 import static com.linkedin.venice.ConfigKeys.SERVER_CONSUMER_POOL_SIZE_PER_KAFKA_CLUSTER;
 import static com.linkedin.venice.ConfigKeys.SERVER_DATABASE_CHECKSUM_VERIFICATION_ENABLED;
 import static com.linkedin.venice.ConfigKeys.SERVER_DATABASE_LOOKUP_QUEUE_CAPACITY;
@@ -143,6 +148,7 @@ import static com.linkedin.venice.pubsub.PubSubConstants.PUBSUB_TOPIC_MANAGER_ME
 
 import com.linkedin.davinci.helix.LeaderFollowerPartitionStateModelFactory;
 import com.linkedin.davinci.kafka.consumer.KafkaConsumerService;
+import com.linkedin.davinci.kafka.consumer.KafkaConsumerServiceDelegator;
 import com.linkedin.davinci.kafka.consumer.RemoteIngestionRepairService;
 import com.linkedin.davinci.store.rocksdb.RocksDBServerConfig;
 import com.linkedin.davinci.validation.KafkaDataIntegrityValidator;
@@ -469,6 +475,12 @@ public class VeniceServerConfig extends VeniceClusterConfig {
   private final int nonExistingTopicIngestionTaskKillThresholdSecond;
   private final int nonExistingTopicCheckRetryIntervalSecond;
   private final boolean dedicatedConsumerPoolForAAWCLeaderEnabled;
+  private final KafkaConsumerServiceDelegator.ConsumerPoolStrategyType consumerPoolStrategyType;
+  private final int consumerPoolSizeForCurrentVersionAAWCLeader;
+  private final int consumerPoolSizeForNonCurrentVersionAAWCLeader;
+  private final int consumerPoolSizeForCurrentVersionNonAAWCLeader;
+  private final int consumerPoolSizeForNonCurrentVersionNonAAWCLeader;
+
   private final int dedicatedConsumerPoolSizeForAAWCLeader;
   private final boolean useDaVinciSpecificExecutionStatusForError;
   private final boolean recordLevelMetricWhenBootstrappingCurrentVersionEnabled;
@@ -779,6 +791,18 @@ public class VeniceServerConfig extends VeniceClusterConfig {
         .getLong(SERVER_LEADER_COMPLETE_STATE_CHECK_IN_FOLLOWER_VALID_INTERVAL_MS, TimeUnit.MINUTES.toMillis(5));
     dedicatedConsumerPoolForAAWCLeaderEnabled =
         serverProperties.getBoolean(SERVER_DEDICATED_CONSUMER_POOL_FOR_AA_WC_LEADER_ENABLED, false);
+    consumerPoolStrategyType = KafkaConsumerServiceDelegator.ConsumerPoolStrategyType.valueOf(
+        serverProperties.getString(
+            SERVER_CONSUMER_POOL_ALLOCATION_STRATEGY,
+            KafkaConsumerServiceDelegator.ConsumerPoolStrategyType.DEFAULT.name()));
+    consumerPoolSizeForCurrentVersionAAWCLeader =
+        serverProperties.getInt(SERVER_CONSUMER_POOL_SIZE_FOR_CURRENT_VERSION_AA_WC_LEADER, 10);
+    consumerPoolSizeForNonCurrentVersionAAWCLeader =
+        serverProperties.getInt(SERVER_CONSUMER_POOL_SIZE_FOR_NON_CURRENT_VERSION_AA_WC_LEADER, 10);
+    consumerPoolSizeForCurrentVersionNonAAWCLeader =
+        serverProperties.getInt(SERVER_CONSUMER_POOL_SIZE_FOR_CURRENT_VERSION_NON_AA_WC_LEADER, 10);
+    consumerPoolSizeForNonCurrentVersionNonAAWCLeader =
+        serverProperties.getInt(SERVER_CONSUMER_POOL_SIZE_FOR_NON_CURRENT_VERSION_NON_AA_WC_LEADER, 10);
     dedicatedConsumerPoolSizeForAAWCLeader =
         serverProperties.getInt(SERVER_DEDICATED_CONSUMER_POOL_SIZE_FOR_AA_WC_LEADER, 5);
     useDaVinciSpecificExecutionStatusForError =
@@ -1382,6 +1406,26 @@ public class VeniceServerConfig extends VeniceClusterConfig {
 
   public int getDedicatedConsumerPoolSizeForAAWCLeader() {
     return dedicatedConsumerPoolSizeForAAWCLeader;
+  }
+
+  public KafkaConsumerServiceDelegator.ConsumerPoolStrategyType getConsumerPoolStrategyType() {
+    return consumerPoolStrategyType;
+  }
+
+  public int getConsumerPoolSizeForCurrentVersionAAWCLeader() {
+    return consumerPoolSizeForCurrentVersionAAWCLeader;
+  }
+
+  public int getConsumerPoolSizeForNonCurrentVersionAAWCLeader() {
+    return consumerPoolSizeForNonCurrentVersionAAWCLeader;
+  }
+
+  public int getConsumerPoolSizeForCurrentVersionNonAAWCLeader() {
+    return consumerPoolSizeForNonCurrentVersionNonAAWCLeader;
+  }
+
+  public int getConsumerPoolSizeForNonCurrentVersionNonAAWCLeader() {
+    return consumerPoolSizeForNonCurrentVersionNonAAWCLeader;
   }
 
   public int getTopicManagerMetadataFetcherConsumerPoolSize() {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaConsumerServiceDelegator.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaConsumerServiceDelegator.java
@@ -342,6 +342,11 @@ public class KafkaConsumerServiceDelegator extends AbstractKafkaConsumerService 
       PartitionReplicaIngestionContext.WorkloadType workloadType = topicPartitionReplicaRole.getWorkloadType();
       PubSubTopicPartition pubSubTopicPartition = topicPartitionReplicaRole.getPubSubTopicPartition();
       PubSubTopic pubSubTopic = pubSubTopicPartition.getPubSubTopic();
+      /**
+       * The logic to assign consumer service is with these 2 dimensions:
+       * 1. If the version role is current.
+       * 2. If the workload type is active-active leader and write-computer leader.
+       */
       if (versionRole.equals(PartitionReplicaIngestionContext.VersionRole.CURRENT)) {
         if (workloadType.equals(PartitionReplicaIngestionContext.WorkloadType.AA_OR_WRITE_COMPUTE)
             && pubSubTopic.isRealTime()) {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -330,7 +330,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
   private final Runnable runnableForKillIngestionTasksForNonCurrentVersions;
   protected final AtomicBoolean recordLevelMetricEnabled;
   protected volatile PartitionReplicaIngestionContext.VersionRole versionRole;
-  protected final PartitionReplicaIngestionContext.WorkloadType workloadType;
+  protected volatile PartitionReplicaIngestionContext.WorkloadType workloadType;
 
   public StoreIngestionTask(
       StoreIngestionTaskFactory.Builder builder,
@@ -1290,9 +1290,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
     PartitionReplicaIngestionContext.WorkloadType newWorkloadType =
         PartitionReplicaIngestionContext.getWorkloadType(versionTopic, store);
     if (serverConfig.isResubscriptionTriggeredByVersionIngestionContextChangeEnabled() && isHybridMode()) {
-      // TODO: Add support workload type change in the future, as enabling write computing during normal hybrid
-      // ingestion could cause workload type change.
-      if (!newVersionRole.equals(versionRole)) {
+      if (!newVersionRole.equals(versionRole) || !newWorkloadType.equals(workloadType)) {
         LOGGER.info(
             "Trigger for version topic: {} due to  Previous: version role: {}, workload type: {} "
                 + "changed to New: version role: {}, workload type: {}",
@@ -1302,6 +1300,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
             newVersionRole,
             newWorkloadType);
         versionRole = newVersionRole;
+        workloadType = newWorkloadType;
         resubscribeForAllPartitions();
       }
     }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/TopicPartitionForIngestion.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/TopicPartitionForIngestion.java
@@ -1,0 +1,51 @@
+package com.linkedin.davinci.kafka.consumer;
+
+import com.linkedin.venice.pubsub.api.PubSubTopic;
+import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
+import java.util.Objects;
+
+
+/**
+ * This class is a wrapper of pair of <Version Topic, Version /Real time topic partition>. As for a unique topic partition
+ * to be ingested, We need both version topic and pub-sub topic partition to identify. For example, the server host may
+ * ingestion same {#linkPubSubTopicType.REALTIME_TOPIC} partition from different {#link PubSubTopicType.VERSION_TOPIC}s,
+ * and we should avoid sharing the same consumer for them.
+ * TODO： Modify the Consumer Service to use this class instead of using version topic and pub-sub topic partition separately.
+ */
+public class TopicPartitionForIngestion {
+  private final PubSubTopic versionTopic;
+  private final PubSubTopicPartition pubSubTopicPartition;
+
+  public TopicPartitionForIngestion(PubSubTopic versionTopic, PubSubTopicPartition pubSubTopicPartition) {
+    this.versionTopic = versionTopic;
+    this.pubSubTopicPartition = pubSubTopicPartition;
+  }
+
+  public PubSubTopic getVersionTopic() {
+    return versionTopic;
+  }
+
+  public PubSubTopicPartition getPubSubTopicPartition() {
+    return pubSubTopicPartition;
+  }
+
+  @Override
+  public final int hashCode() {
+    return Objects.hash(versionTopic, pubSubTopicPartition);
+  }
+
+  @Override
+  public final boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+
+    if (!(obj instanceof TopicPartitionForIngestion)) {
+      return false;
+    }
+
+    final TopicPartitionForIngestion other = (TopicPartitionForIngestion) (obj);
+    return Objects.equals(versionTopic, other.versionTopic)
+        && Objects.equals(pubSubTopicPartition, other.pubSubTopicPartition);
+  }
+}

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionServiceTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionServiceTest.java
@@ -116,6 +116,8 @@ public abstract class KafkaStoreIngestionServiceTest {
     doReturn(0.9d).when(mockVeniceServerConfig).getDiskFullThreshold();
     doReturn(Int2ObjectMaps.emptyMap()).when(mockVeniceServerConfig).getKafkaClusterIdToAliasMap();
     doReturn(Object2IntMaps.emptyMap()).when(mockVeniceServerConfig).getKafkaClusterUrlToIdMap();
+    doReturn(KafkaConsumerServiceDelegator.ConsumerPoolStrategyType.DEFAULT).when(mockVeniceServerConfig)
+        .getConsumerPoolStrategyType();
 
     // Consumer related configs for preparing kafka consumer service.
     doReturn(dummyKafkaUrl).when(mockVeniceServerConfig).getKafkaBootstrapServers();

--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -2101,12 +2101,28 @@ public class ConfigKeys {
    * types strategy supported decided by #ConsumerPoolStrategyType.
    */
   public static final String SERVER_CONSUMER_POOL_ALLOCATION_STRATEGY = "server.consumer.pool.allocation.strategy";
+  /**
+   * Consumer Pool for active-active or write computer leader of current version, the traffic we need to isolate due to
+   * it is more costly than normal leader processing and current version should be allocated more resources to prioritize.
+   */
   public static final String SERVER_CONSUMER_POOL_SIZE_FOR_CURRENT_VERSION_AA_WC_LEADER =
       "server.consumer.pool.size.for.current.version.aa.wc.leader";
+  /**
+   * Consumer Pool for active-active or write computer leader of future or backup version, the traffic we need to isolate
+   * due to it is still more costly than normal leader processing and it has less priority than current version.
+   */
   public static final String SERVER_CONSUMER_POOL_SIZE_FOR_NON_CURRENT_VERSION_AA_WC_LEADER =
       "server.consumer.pool.size.for.non.current.version.aa.wc.leader";
+  /**
+   * Consumer Pool for all followers, non-active-active and non-write compute leader of current version, the traffic
+   * is less costly and but it is current version with high priority.
+   */
   public static final String SERVER_CONSUMER_POOL_SIZE_FOR_CURRENT_VERSION_NON_AA_WC_LEADER =
       "server.consumer.pool.size.for.current.version.non.aa.wc.leader";
+  /**
+   * Consumer Pool for all followers, non-active-active leader and non-write compute leader of backup and future version,
+   * the traffic is less costly and with low priority.
+   */
   public static final String SERVER_CONSUMER_POOL_SIZE_FOR_NON_CURRENT_VERSION_NON_AA_WC_LEADER =
       "server.consumer.pool.size.for.non.current.version.non.aa.wc.leader";
 

--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -2097,7 +2097,8 @@ public class ConfigKeys {
       "server.dedicated.consumer.pool.size.for.aa.wc.leader";
 
   /**
-   * Pool allocation strategy to rely on pool size to prioritize specific traffic.
+   * Consumer Pool allocation strategy to rely on pool size to prioritize specific traffic. There will be 3 different
+   * types strategy supported decided by #ConsumerPoolStrategyType.
    */
   public static final String SERVER_CONSUMER_POOL_ALLOCATION_STRATEGY = "server.consumer.pool.allocation.strategy";
   public static final String SERVER_CONSUMER_POOL_SIZE_FOR_CURRENT_VERSION_AA_WC_LEADER =

--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -2097,6 +2097,19 @@ public class ConfigKeys {
       "server.dedicated.consumer.pool.size.for.aa.wc.leader";
 
   /**
+   * Pool allocation strategy to rely on pool size to prioritize specific traffic.
+   */
+  public static final String SERVER_CONSUMER_POOL_ALLOCATION_STRATEGY = "server.consumer.pool.allocation.strategy";
+  public static final String SERVER_CONSUMER_POOL_SIZE_FOR_CURRENT_VERSION_AA_WC_LEADER =
+      "server.consumer.pool.size.for.current.version.aa.wc.leader";
+  public static final String SERVER_CONSUMER_POOL_SIZE_FOR_NON_CURRENT_VERSION_AA_WC_LEADER =
+      "server.consumer.pool.size.for.non.current.version.aa.wc.leader";
+  public static final String SERVER_CONSUMER_POOL_SIZE_FOR_CURRENT_VERSION_NON_AA_WC_LEADER =
+      "server.consumer.pool.size.for.current.version.non.aa.wc.leader";
+  public static final String SERVER_CONSUMER_POOL_SIZE_FOR_NON_CURRENT_VERSION_NON_AA_WC_LEADER =
+      "server.consumer.pool.size.for.non.current.version.non.aa.wc.leader";
+
+  /**
    * Whether to enable record-level metrics when bootstrapping current version.
    * This feature will be mainly used by DaVinci to speed up bootstrapping.
    */

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestActiveActiveIngestion.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestActiveActiveIngestion.java
@@ -2,7 +2,10 @@ package com.linkedin.venice.endToEnd;
 
 import static com.linkedin.davinci.store.rocksdb.RocksDBServerConfig.ROCKSDB_LEVEL0_COMPACTION_TUNING_FOR_READ_WRITE_LEADER_ENABLED;
 import static com.linkedin.davinci.store.rocksdb.RocksDBServerConfig.ROCKSDB_PLAIN_TABLE_FORMAT_ENABLED;
-import static com.linkedin.venice.ConfigKeys.*;
+import static com.linkedin.venice.ConfigKeys.CHILD_DATA_CENTER_KAFKA_URL_PREFIX;
+import static com.linkedin.venice.ConfigKeys.DEFAULT_MAX_NUMBER_OF_PARTITIONS;
+import static com.linkedin.venice.ConfigKeys.SERVER_CONSUMER_POOL_ALLOCATION_STRATEGY;
+import static com.linkedin.venice.ConfigKeys.SERVER_DEDICATED_DRAINER_FOR_SORTED_INPUT_ENABLED;
 import static com.linkedin.venice.hadoop.VenicePushJobConstants.DEFAULT_KEY_FIELD_PROP;
 import static com.linkedin.venice.hadoop.VenicePushJobConstants.DEFAULT_VALUE_FIELD_PROP;
 import static com.linkedin.venice.hadoop.VenicePushJobConstants.KAFKA_INPUT_BROKER_URL;
@@ -20,6 +23,7 @@ import static com.linkedin.venice.utils.TestUtils.generateInput;
 import static com.linkedin.venice.utils.TestWriteUtils.STRING_SCHEMA;
 import static com.linkedin.venice.utils.TestWriteUtils.getTempDataDirectory;
 
+import com.linkedin.davinci.kafka.consumer.KafkaConsumerServiceDelegator;
 import com.linkedin.venice.ConfigKeys;
 import com.linkedin.venice.client.store.AvroGenericStoreClient;
 import com.linkedin.venice.client.store.ClientConfig;
@@ -107,6 +111,9 @@ public class TestActiveActiveIngestion {
     serverProperties.put(
         CHILD_DATA_CENTER_KAFKA_URL_PREFIX + "." + DEFAULT_PARENT_DATA_CENTER_REGION_NAME,
         "localhost:" + TestUtils.getFreePort());
+    serverProperties.put(
+        SERVER_CONSUMER_POOL_ALLOCATION_STRATEGY,
+        KafkaConsumerServiceDelegator.ConsumerPoolStrategyType.CURRENT_VERSION_PRIORITIZATION.name());
     Properties controllerProps = new Properties();
     controllerProps.put(DEFAULT_MAX_NUMBER_OF_PARTITIONS, 20);
     multiRegionMultiClusterWrapper = ServiceFactory.getVeniceTwoLayerMultiRegionMultiClusterWrapper(

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestHybrid.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestHybrid.java
@@ -4,6 +4,7 @@ import static com.linkedin.davinci.store.rocksdb.RocksDBServerConfig.ROCKSDB_PLA
 import static com.linkedin.venice.ConfigKeys.DEFAULT_MAX_NUMBER_OF_PARTITIONS;
 import static com.linkedin.venice.ConfigKeys.KAFKA_BOOTSTRAP_SERVERS;
 import static com.linkedin.venice.ConfigKeys.PERSISTENCE_TYPE;
+import static com.linkedin.venice.ConfigKeys.SERVER_CONSUMER_POOL_ALLOCATION_STRATEGY;
 import static com.linkedin.venice.ConfigKeys.SERVER_CONSUMER_POOL_SIZE_PER_KAFKA_CLUSTER;
 import static com.linkedin.venice.ConfigKeys.SERVER_DATABASE_CHECKSUM_VERIFICATION_ENABLED;
 import static com.linkedin.venice.ConfigKeys.SERVER_DATABASE_SYNC_BYTES_INTERNAL_FOR_DEFERRED_WRITE_MODE;
@@ -36,6 +37,7 @@ import static org.testng.Assert.assertTrue;
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.luben.zstd.Zstd;
 import com.linkedin.davinci.kafka.consumer.KafkaConsumerService;
+import com.linkedin.davinci.kafka.consumer.KafkaConsumerServiceDelegator;
 import com.linkedin.venice.client.store.AvroGenericStoreClient;
 import com.linkedin.venice.client.store.ClientConfig;
 import com.linkedin.venice.client.store.ClientFactory;
@@ -1703,6 +1705,9 @@ public class TestHybrid {
     serverProperties.setProperty(SSL_TO_KAFKA_LEGACY, "false");
     serverProperties.setProperty(SERVER_CONSUMER_POOL_SIZE_PER_KAFKA_CLUSTER, "3");
     serverProperties.setProperty(SERVER_DEDICATED_DRAINER_FOR_SORTED_INPUT_ENABLED, "true");
+    serverProperties.setProperty(
+        SERVER_CONSUMER_POOL_ALLOCATION_STRATEGY,
+        KafkaConsumerServiceDelegator.ConsumerPoolStrategyType.CURRENT_VERSION_PRIORITIZATION.name());
 
     if (enablePartitionWiseSharedConsumer) {
       serverProperties.setProperty(DEFAULT_MAX_NUMBER_OF_PARTITIONS, "4");

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceServerWrapper.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceServerWrapper.java
@@ -20,7 +20,6 @@ import static com.linkedin.venice.ConfigKeys.PERSISTENCE_TYPE;
 import static com.linkedin.venice.ConfigKeys.PUB_SUB_ADMIN_ADAPTER_FACTORY_CLASS;
 import static com.linkedin.venice.ConfigKeys.PUB_SUB_CONSUMER_ADAPTER_FACTORY_CLASS;
 import static com.linkedin.venice.ConfigKeys.PUB_SUB_PRODUCER_ADAPTER_FACTORY_CLASS;
-import static com.linkedin.venice.ConfigKeys.SERVER_CONSUMER_POOL_ALLOCATION_STRATEGY;
 import static com.linkedin.venice.ConfigKeys.SERVER_DATABASE_CHECKSUM_VERIFICATION_ENABLED;
 import static com.linkedin.venice.ConfigKeys.SERVER_DISK_FULL_THRESHOLD;
 import static com.linkedin.venice.ConfigKeys.SERVER_HTTP2_INBOUND_ENABLED;
@@ -39,7 +38,6 @@ import static com.linkedin.venice.ConfigKeys.SYSTEM_SCHEMA_INITIALIZATION_AT_STA
 import static com.linkedin.venice.meta.PersistenceType.ROCKS_DB;
 
 import com.linkedin.davinci.config.VeniceConfigLoader;
-import com.linkedin.davinci.kafka.consumer.KafkaConsumerServiceDelegator;
 import com.linkedin.venice.client.store.ClientConfig;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.helix.AllowlistAccessor;
@@ -255,10 +253,7 @@ public class VeniceServerWrapper extends ProcessWrapper implements MetricsAware 
               pubSubBrokerWrapper.getPubSubClientsFactory().getAdminAdapterFactory().getClass().getName())
           .put(SERVER_INGESTION_HEARTBEAT_INTERVAL_MS, 5000)
           .put(SERVER_LEADER_COMPLETE_STATE_CHECK_IN_FOLLOWER_VALID_INTERVAL_MS, 5000)
-          .put(SERVER_RESUBSCRIPTION_TRIGGERED_BY_VERSION_INGESTION_CONTEXT_CHANGE_ENABLED, true)
-          .put(
-              SERVER_CONSUMER_POOL_ALLOCATION_STRATEGY,
-              KafkaConsumerServiceDelegator.ConsumerPoolStrategyType.CURRENT_VERSION_PRIORITIZATION.name());
+          .put(SERVER_RESUBSCRIPTION_TRIGGERED_BY_VERSION_INGESTION_CONTEXT_CHANGE_ENABLED, true);
       if (sslToKafka) {
         serverPropsBuilder.put(KAFKA_SECURITY_PROTOCOL, SecurityProtocol.SSL.name);
         serverPropsBuilder.put(KafkaTestUtils.getLocalCommonKafkaSSLConfig(SslUtils.getTlsConfiguration()));

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceServerWrapper.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/integration/utils/VeniceServerWrapper.java
@@ -20,6 +20,7 @@ import static com.linkedin.venice.ConfigKeys.PERSISTENCE_TYPE;
 import static com.linkedin.venice.ConfigKeys.PUB_SUB_ADMIN_ADAPTER_FACTORY_CLASS;
 import static com.linkedin.venice.ConfigKeys.PUB_SUB_CONSUMER_ADAPTER_FACTORY_CLASS;
 import static com.linkedin.venice.ConfigKeys.PUB_SUB_PRODUCER_ADAPTER_FACTORY_CLASS;
+import static com.linkedin.venice.ConfigKeys.SERVER_CONSUMER_POOL_ALLOCATION_STRATEGY;
 import static com.linkedin.venice.ConfigKeys.SERVER_DATABASE_CHECKSUM_VERIFICATION_ENABLED;
 import static com.linkedin.venice.ConfigKeys.SERVER_DISK_FULL_THRESHOLD;
 import static com.linkedin.venice.ConfigKeys.SERVER_HTTP2_INBOUND_ENABLED;
@@ -38,6 +39,7 @@ import static com.linkedin.venice.ConfigKeys.SYSTEM_SCHEMA_INITIALIZATION_AT_STA
 import static com.linkedin.venice.meta.PersistenceType.ROCKS_DB;
 
 import com.linkedin.davinci.config.VeniceConfigLoader;
+import com.linkedin.davinci.kafka.consumer.KafkaConsumerServiceDelegator;
 import com.linkedin.venice.client.store.ClientConfig;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.helix.AllowlistAccessor;
@@ -253,7 +255,10 @@ public class VeniceServerWrapper extends ProcessWrapper implements MetricsAware 
               pubSubBrokerWrapper.getPubSubClientsFactory().getAdminAdapterFactory().getClass().getName())
           .put(SERVER_INGESTION_HEARTBEAT_INTERVAL_MS, 5000)
           .put(SERVER_LEADER_COMPLETE_STATE_CHECK_IN_FOLLOWER_VALID_INTERVAL_MS, 5000)
-          .put(SERVER_RESUBSCRIPTION_TRIGGERED_BY_VERSION_INGESTION_CONTEXT_CHANGE_ENABLED, true);
+          .put(SERVER_RESUBSCRIPTION_TRIGGERED_BY_VERSION_INGESTION_CONTEXT_CHANGE_ENABLED, true)
+          .put(
+              SERVER_CONSUMER_POOL_ALLOCATION_STRATEGY,
+              KafkaConsumerServiceDelegator.ConsumerPoolStrategyType.CURRENT_VERSION_PRIORITIZATION.name());
       if (sslToKafka) {
         serverPropsBuilder.put(KAFKA_SECURITY_PROTOCOL, SecurityProtocol.SSL.name);
         serverPropsBuilder.put(KafkaTestUtils.getLocalCommonKafkaSSLConfig(SslUtils.getTlsConfiguration()));

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/kafka/KafkaConsumptionTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/kafka/KafkaConsumptionTest.java
@@ -12,6 +12,7 @@ import com.linkedin.davinci.kafka.consumer.AggKafkaConsumerService;
 import com.linkedin.davinci.kafka.consumer.IngestionThrottler;
 import com.linkedin.davinci.kafka.consumer.KafkaClusterBasedRecordThrottler;
 import com.linkedin.davinci.kafka.consumer.KafkaConsumerService;
+import com.linkedin.davinci.kafka.consumer.KafkaConsumerServiceDelegator;
 import com.linkedin.davinci.kafka.consumer.PartitionReplicaIngestionContext;
 import com.linkedin.davinci.kafka.consumer.StoreIngestionTask;
 import com.linkedin.davinci.kafka.consumer.StorePartitionDataReceiver;
@@ -158,6 +159,8 @@ public class KafkaConsumptionTest {
     doReturn(2).when(veniceServerConfig).getConsumerPoolSizePerKafkaCluster();
     doReturn(10L).when(veniceServerConfig).getSharedConsumerNonExistingTopicCleanupDelayMS();
     doReturn(true).when(veniceServerConfig).isLiveConfigBasedKafkaThrottlingEnabled();
+    doReturn(KafkaConsumerServiceDelegator.ConsumerPoolStrategyType.DEFAULT).when(veniceServerConfig)
+        .getConsumerPoolStrategyType();
     if (isTopicWiseSharedConsumerAssignmentStrategy) {
       doReturn(KafkaConsumerService.ConsumerAssignmentStrategy.TOPIC_WISE_SHARED_CONSUMER_ASSIGNMENT_STRATEGY)
           .when(veniceServerConfig)


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->
 
This PR is mainly for simplifying the logic of consumer pool assignment logic when subscribing one topic partition through `PartitionReplicaIngestionContext`.  Inside `KafkaConsumerServiceDelegator`, A `ConsumerPoolStrategyType` is defined to specify consumer pool allocation strategy implementation of `ConsumerPoolStrategy`.  
`AggKafkaConsumerService#subscribeConsumerFor` will pass `PartitionReplicaIngestionContext` with `VersionRole` and `WorkloadType` information to let `CurrentVersionConsumerPoolStrategy`  pick up the specific consumer pool.  Each instance of  `KakfaConsumerService` will be built inside `ConsumerPoolStrategy`.  

`CurrentVersionConsumerPoolStrategy` will support for 4 different consumer pools with these 4 configs:

1. `SERVER_CONSUMER_POOL_SIZE_FOR_CURRENT_VERSION_AA_WC_LEADER` 
2. `SERVER_CONSUMER_POOL_SIZE_FOR_NON_CURRENT_VERSION_AA_WC_LEADER`
3. `SERVER_CONSUMER_POOL_SIZE_FOR_CURRENT_VERSION_NON_AA_WC_LEADER`
4. `SERVER_CONSUMER_POOL_SIZE_FOR_NON_CURRENT_VERSION_NON_AA_WC_LEADER`

`DefaultConsumerPoolStrategy` will support 1 pool per region with original default setting.

`AAOrWCLeaderConsumerPoolStrategy` will support for 1 more pool with: `SERVER_DEDICATED_CONSUMER_POOL_SIZE_FOR_AA_WC_LEADER`. Here for config backward-compatibility, we will keep relying on `SERVER_DEDICATED_CONSUMER_POOL_FOR_AA_WC_LEADER_ENABLED` to turn on this feature,  `SERVER_CONSUMER_POOL_ALLOCATION_STRATEGY` is only useful when `SERVER_DEDICATED_CONSUMER_POOL_FOR_AA_WC_LEADER_ENABLED` is turned off.

After we validate the `CurrentVersionConsumerPoolStrategy`, we will try to clean up the configs and rely on `SERVER_CONSUMER_POOL_ALLOCATION_STRATEGY` to switch strategy. 

Besides, this change also enable re-subscritpion based on workload type change.




## Summary, imperative, start upper case, don't end with a period
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Resolves #XXX

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.