### PR TITLE
[server] Use chunk manifest schema id for writer when performing updates to chunked records

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
@@ -475,7 +475,7 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
 
       case UPDATE:
         mergeConflictResult = mergeConflictResolver.update(
-            oldValueByteBufferProvider.get(),
+            oldValueByteBufferProvider,
             rmdWithValueSchemaID,
             ((Update) kafkaValue.payloadUnion).updateValue,
             incomingValueSchemaId,
@@ -484,7 +484,7 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
             sourceOffset,
             kafkaClusterId,
             kafkaClusterId,
-            valueManifestContainer.getManifest());
+            valueManifestContainer);
         getHostLevelIngestionStats()
             .recordIngestionActiveActiveUpdateLatency(LatencyUtils.getElapsedTimeFromNSToMS(beforeDCRTimestampInNs));
         break;

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
@@ -474,9 +474,8 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
         break;
 
       case UPDATE:
-        int oldValueSchemaId = oldValueProvider.get().writerSchemaId();
         mergeConflictResult = mergeConflictResolver.update(
-            oldValueByteBufferProvider,
+            oldValueByteBufferProvider.get(),
             rmdWithValueSchemaID,
             ((Update) kafkaValue.payloadUnion).updateValue,
             incomingValueSchemaId,
@@ -485,7 +484,7 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
             sourceOffset,
             kafkaClusterId,
             kafkaClusterId,
-            oldValueSchemaId);
+            valueManifestContainer.getManifest());
         getHostLevelIngestionStats()
             .recordIngestionActiveActiveUpdateLatency(LatencyUtils.getElapsedTimeFromNSToMS(beforeDCRTimestampInNs));
         break;

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
@@ -474,6 +474,7 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
         break;
 
       case UPDATE:
+        int oldValueSchemaId = oldValueProvider.get().writerSchemaId();
         mergeConflictResult = mergeConflictResolver.update(
             oldValueByteBufferProvider,
             rmdWithValueSchemaID,
@@ -483,7 +484,8 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
             writeTimestamp,
             sourceOffset,
             kafkaClusterId,
-            kafkaClusterId);
+            kafkaClusterId,
+            oldValueSchemaId);
         getHostLevelIngestionStats()
             .recordIngestionActiveActiveUpdateLatency(LatencyUtils.getElapsedTimeFromNSToMS(beforeDCRTimestampInNs));
         break;

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/replication/merge/MergeConflictResolver.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/replication/merge/MergeConflictResolver.java
@@ -37,6 +37,7 @@ import java.util.stream.Collectors;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.commons.lang3.Validate;
+import org.apache.logging.log4j.LogManager;
 
 
 /**
@@ -630,6 +631,7 @@ public class MergeConflictResolver {
          * case, the value must be retrieved from storage engine, and is prepended with schema ID.
          */
         int schemaId = ValueRecord.parseSchemaId(oldValueBytes.array());
+        LogManager.getLogger(MergeConflictResolver.class).info("DEBUGGING: SCHEMA ID: {}", schemaId);
         newValue =
             deserializerCacheForFullValue.get(schemaId, readerValueSchemaEntry.getId()).deserialize(oldValueBytes);
       }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/replication/merge/MergeConflictResolver.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/replication/merge/MergeConflictResolver.java
@@ -625,8 +625,10 @@ public class MergeConflictResolver {
         newValue = AvroSchemaUtils.createGenericRecord(superSetSchemaSchemaEntry.getSchema());
       } else {
         /**
-         * RMD does not exist. This means the value is written in Batch phase and does not have RMD associated, or was
-         * assembled from a chunked value.  We'll rely on the superset schema to deserialize in this case.
+         * RMD does not exist. This means the value is written in Batch phase and does not have RMD associated. Records
+         * should have the schema id in the first few bytes unless they are assembled from a chunked value. In order
+         * to provide coverage for both cases, we just utilize the supersetSchema entry which should be the latest
+         * schema (and therefore should not drop fields after the update).
          */
 
         int schemaId = superSetSchemaSchemaEntry.getId();

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/replication/merge/TestMergeUpdate.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/replication/merge/TestMergeUpdate.java
@@ -11,7 +11,6 @@ import com.linkedin.davinci.replication.RmdWithValueSchemaId;
 import com.linkedin.davinci.utils.IndexedHashMap;
 import com.linkedin.venice.schema.rmd.RmdConstants;
 import com.linkedin.venice.utils.DataProviderUtils;
-import com.linkedin.venice.utils.lazy.Lazy;
 import com.linkedin.venice.writer.update.UpdateBuilderImpl;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
@@ -48,7 +47,7 @@ public class TestMergeUpdate extends TestMergeBase {
 
     long updateTs = isUpdateTsSmallerThanRmdTs ? baselineRmdTs - 1 : baselineRmdTs;
     MergeConflictResult result = mergeConflictResolver.update(
-        Lazy.of(() -> serializeValueRecord(oldValueRecord)),
+        serializeValueRecord(oldValueRecord),
         new RmdWithValueSchemaId(schemaSet.getValueSchemaId(), RMD_VERSION_ID, oldRmdRecord),
         serializeUpdateRecord(partialUpdateRecord),
         schemaSet.getValueSchemaId(),
@@ -57,7 +56,7 @@ public class TestMergeUpdate extends TestMergeBase {
         1L,
         0,
         0,
-        schemaSet.getValueSchemaId());
+        null);
     Assert.assertTrue(result.isUpdateIgnored());
   }
 
@@ -94,7 +93,7 @@ public class TestMergeUpdate extends TestMergeBase {
     long updateTs = isUpdateTsSmallerThanRmdTs ? baselineRmdTs - 1 : baselineRmdTs;
     int updateColoId = isUpdateTsSmallerThanRmdTs ? baselineColoID : baselineColoID - 1;
     MergeConflictResult result = mergeConflictResolver.update(
-        Lazy.of(() -> serializeValueRecord(oldValueRecord)),
+        serializeValueRecord(oldValueRecord),
         new RmdWithValueSchemaId(schemaSet.getValueSchemaId(), RMD_VERSION_ID, oldRmdRecord),
         serializeUpdateRecord(partialUpdateRecord),
         schemaSet.getValueSchemaId(),
@@ -103,7 +102,7 @@ public class TestMergeUpdate extends TestMergeBase {
         1L,
         0,
         updateColoId,
-        schemaSet.getValueSchemaId());
+        null);
     Assert.assertTrue(result.isUpdateIgnored());
   }
 
@@ -155,7 +154,7 @@ public class TestMergeUpdate extends TestMergeBase {
       updateTs -= 1;
     }
     MergeConflictResult result = mergeConflictResolver.update(
-        Lazy.of(() -> serializeValueRecord(oldValueRecord)),
+        serializeValueRecord(oldValueRecord),
         new RmdWithValueSchemaId(schemaSet.getValueSchemaId(), RMD_VERSION_ID, oldRmdRecord),
         serializeUpdateRecord(partialUpdateRecord),
         schemaSet.getValueSchemaId(),
@@ -164,7 +163,7 @@ public class TestMergeUpdate extends TestMergeBase {
         1L,
         0,
         -2,
-        schemaSet.getValueSchemaId());
+        null);
     Assert.assertTrue(result.isUpdateIgnored());
   }
 
@@ -214,7 +213,7 @@ public class TestMergeUpdate extends TestMergeBase {
 
     long updateTs = updateOnActiveElement ? baselineRmdTs : baselineRmdTs - 1;
     MergeConflictResult result = mergeConflictResolver.update(
-        Lazy.of(() -> serializeValueRecord(oldValueRecord)),
+        serializeValueRecord(oldValueRecord),
         new RmdWithValueSchemaId(schemaSet.getValueSchemaId(), RMD_VERSION_ID, oldRmdRecord),
         serializeUpdateRecord(partialUpdateRecord),
         schemaSet.getValueSchemaId(),
@@ -223,7 +222,7 @@ public class TestMergeUpdate extends TestMergeBase {
         1L,
         0,
         -2,
-        schemaSet.getValueSchemaId());
+        null);
     Assert.assertTrue(result.isUpdateIgnored());
   }
 
@@ -254,7 +253,7 @@ public class TestMergeUpdate extends TestMergeBase {
     GenericRecord oldRmdRecord = initiateValueLevelRmdRecord(baselineRmdTs);
     long updateTs = updateTsSmallerThanRmdTs ? baselineRmdTs - 1 : baselineRmdTs;
     MergeConflictResult result = mergeConflictResolver.update(
-        Lazy.of(() -> serializeValueRecord(oldValueRecord)),
+        serializeValueRecord(oldValueRecord),
         new RmdWithValueSchemaId(schemaSet.getValueSchemaId(), RMD_VERSION_ID, oldRmdRecord),
         serializeUpdateRecord(partialUpdateRecord),
         schemaSet.getValueSchemaId(),
@@ -263,7 +262,7 @@ public class TestMergeUpdate extends TestMergeBase {
         1L,
         0,
         -2,
-        schemaSet.getValueSchemaId());
+        null);
     Assert.assertTrue(result.isUpdateIgnored());
   }
 
@@ -326,7 +325,7 @@ public class TestMergeUpdate extends TestMergeBase {
     nullableMapTsRecord.put(DELETED_ELEM_TS_FIELD_NAME, Arrays.asList(2L, 3L));
 
     MergeConflictResult result = mergeConflictResolver.update(
-        Lazy.of(() -> serializeValueRecord(oldValueRecord)),
+        serializeValueRecord(oldValueRecord),
         new RmdWithValueSchemaId(schemaSet.getValueSchemaId(), RMD_VERSION_ID, oldRmdRecord),
         serializeUpdateRecord(partialUpdateRecord),
         schemaSet.getValueSchemaId(),
@@ -335,7 +334,7 @@ public class TestMergeUpdate extends TestMergeBase {
         1L,
         0,
         0,
-        schemaSet.getValueSchemaId());
+        null);
 
     GenericRecord updatedValueRecord = deserializeValueRecord(result.getNewValue());
     Assert.assertEquals(
@@ -393,7 +392,7 @@ public class TestMergeUpdate extends TestMergeBase {
             .setNewFieldValue(NULLABLE_STRING_ARRAY_FIELD_NAME, null)
             .build();
     result = mergeConflictResolver.update(
-        Lazy.of(() -> serializeValueRecord(updatedValueRecord)),
+        serializeValueRecord(oldValueRecord),
         new RmdWithValueSchemaId(schemaSet.getValueSchemaId(), RMD_VERSION_ID, updateRmdRecord),
         serializeUpdateRecord(partialUpdateRecord),
         schemaSet.getValueSchemaId(),
@@ -402,7 +401,7 @@ public class TestMergeUpdate extends TestMergeBase {
         1L,
         0,
         0,
-        schemaSet.getValueSchemaId());
+        null);
 
     GenericRecord newUpdatedValueRecord = deserializeValueRecord(result.getNewValue());
     Assert.assertNull(newUpdatedValueRecord.get(NULLABLE_STRING_ARRAY_FIELD_NAME));
@@ -473,7 +472,7 @@ public class TestMergeUpdate extends TestMergeBase {
     mapTsRecord.put(ACTIVE_ELEM_TS_FIELD_NAME, Arrays.asList(2L, 2L, 3L));
 
     MergeConflictResult result = mergeConflictResolver.update(
-        Lazy.of(() -> serializeValueRecord(oldValueRecord)),
+        serializeValueRecord(oldValueRecord),
         new RmdWithValueSchemaId(schemaSet.getValueSchemaId(), RMD_VERSION_ID, oldRmdRecord),
         serializeUpdateRecord(partialUpdateRecord),
         schemaSet.getValueSchemaId(),
@@ -482,7 +481,7 @@ public class TestMergeUpdate extends TestMergeBase {
         1L,
         0,
         0,
-        schemaSet.getValueSchemaId());
+        null);
 
     GenericRecord updatedValueRecord = deserializeValueRecord(result.getNewValue());
     Assert.assertEquals(
@@ -552,7 +551,7 @@ public class TestMergeUpdate extends TestMergeBase {
     listTsRecord.put(DELETED_ELEM_TS_FIELD_NAME, Arrays.asList(2L, 3L, 4L));
 
     MergeConflictResult result = mergeConflictResolver.update(
-        Lazy.of(() -> serializeValueRecord(oldValueRecord)),
+        serializeValueRecord(oldValueRecord),
         new RmdWithValueSchemaId(schemaSet.getValueSchemaId(), RMD_VERSION_ID, oldRmdRecord),
         serializeUpdateRecord(partialUpdateRecord),
         schemaSet.getValueSchemaId(),
@@ -561,7 +560,7 @@ public class TestMergeUpdate extends TestMergeBase {
         1L,
         0,
         0,
-        schemaSet.getValueSchemaId());
+        null);
     GenericRecord updatedValueRecord = deserializeValueRecord(result.getNewValue());
     Assert.assertEquals(updatedValueRecord.get(NULLABLE_STRING_ARRAY_FIELD_NAME), Collections.emptyList());
     IndexedHashMap<Utf8, Utf8> expectedNullableMap = new IndexedHashMap<>();
@@ -758,7 +757,7 @@ public class TestMergeUpdate extends TestMergeBase {
     }
 
     return mergeConflictResolver.update(
-        Lazy.of(() -> oldValueByteBuffer),
+        oldValueByteBuffer,
         oldRmdRecord == null
             ? null
             : new RmdWithValueSchemaId(
@@ -772,7 +771,7 @@ public class TestMergeUpdate extends TestMergeBase {
         1L,
         0,
         0,
-        schemaSet.getValueSchemaId());
+        null);
   }
 
   private void validateNullableCollectionUpdateResult(

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/replication/merge/TestMergeUpdate.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/replication/merge/TestMergeUpdate.java
@@ -56,7 +56,8 @@ public class TestMergeUpdate extends TestMergeBase {
         updateTs,
         1L,
         0,
-        0);
+        0,
+        schemaSet.getValueSchemaId());
     Assert.assertTrue(result.isUpdateIgnored());
   }
 
@@ -101,7 +102,8 @@ public class TestMergeUpdate extends TestMergeBase {
         updateTs,
         1L,
         0,
-        updateColoId);
+        updateColoId,
+        schemaSet.getValueSchemaId());
     Assert.assertTrue(result.isUpdateIgnored());
   }
 
@@ -161,7 +163,8 @@ public class TestMergeUpdate extends TestMergeBase {
         updateTs,
         1L,
         0,
-        -2);
+        -2,
+        schemaSet.getValueSchemaId());
     Assert.assertTrue(result.isUpdateIgnored());
   }
 
@@ -219,7 +222,8 @@ public class TestMergeUpdate extends TestMergeBase {
         updateTs,
         1L,
         0,
-        -2);
+        -2,
+        schemaSet.getValueSchemaId());
     Assert.assertTrue(result.isUpdateIgnored());
   }
 
@@ -258,7 +262,8 @@ public class TestMergeUpdate extends TestMergeBase {
         updateTs,
         1L,
         0,
-        -2);
+        -2,
+        schemaSet.getValueSchemaId());
     Assert.assertTrue(result.isUpdateIgnored());
   }
 
@@ -329,7 +334,8 @@ public class TestMergeUpdate extends TestMergeBase {
         2L,
         1L,
         0,
-        0);
+        0,
+        schemaSet.getValueSchemaId());
 
     GenericRecord updatedValueRecord = deserializeValueRecord(result.getNewValue());
     Assert.assertEquals(
@@ -395,7 +401,8 @@ public class TestMergeUpdate extends TestMergeBase {
         10L,
         1L,
         0,
-        0);
+        0,
+        schemaSet.getValueSchemaId());
 
     GenericRecord newUpdatedValueRecord = deserializeValueRecord(result.getNewValue());
     Assert.assertNull(newUpdatedValueRecord.get(NULLABLE_STRING_ARRAY_FIELD_NAME));
@@ -474,7 +481,8 @@ public class TestMergeUpdate extends TestMergeBase {
         2L,
         1L,
         0,
-        0);
+        0,
+        schemaSet.getValueSchemaId());
 
     GenericRecord updatedValueRecord = deserializeValueRecord(result.getNewValue());
     Assert.assertEquals(
@@ -552,7 +560,8 @@ public class TestMergeUpdate extends TestMergeBase {
         3L,
         1L,
         0,
-        0);
+        0,
+        schemaSet.getValueSchemaId());
     GenericRecord updatedValueRecord = deserializeValueRecord(result.getNewValue());
     Assert.assertEquals(updatedValueRecord.get(NULLABLE_STRING_ARRAY_FIELD_NAME), Collections.emptyList());
     IndexedHashMap<Utf8, Utf8> expectedNullableMap = new IndexedHashMap<>();
@@ -762,7 +771,8 @@ public class TestMergeUpdate extends TestMergeBase {
         timestamp,
         1L,
         0,
-        0);
+        0,
+        schemaSet.getValueSchemaId());
   }
 
   private void validateNullableCollectionUpdateResult(

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/replication/merge/TestMergeUpdate.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/replication/merge/TestMergeUpdate.java
@@ -392,7 +392,7 @@ public class TestMergeUpdate extends TestMergeBase {
             .setNewFieldValue(NULLABLE_STRING_ARRAY_FIELD_NAME, null)
             .build();
     result = mergeConflictResolver.update(
-        serializeValueRecord(oldValueRecord),
+        serializeValueRecord(updatedValueRecord),
         new RmdWithValueSchemaId(schemaSet.getValueSchemaId(), RMD_VERSION_ID, updateRmdRecord),
         serializeUpdateRecord(partialUpdateRecord),
         schemaSet.getValueSchemaId(),

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/replication/merge/TestMergeUpdateWithFieldLevelTimestamp.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/replication/merge/TestMergeUpdateWithFieldLevelTimestamp.java
@@ -107,8 +107,6 @@ public class TestMergeUpdateWithFieldLevelTimestamp extends TestMergeConflictRes
     oldValueRecord.put("age", 30);
     oldValueRecord.put("name", "Kafka");
     oldValueRecord.put("intArray", Arrays.asList(1, 2, 3));
-    ByteBuffer oldValueBytes =
-        ByteBuffer.wrap(MapOrderPreservingSerDeFactory.getSerializer(personSchemaV2).serialize(oldValueRecord));
 
     // Set up Write Compute request.
     Schema writeComputeSchema = WriteComputeSchemaConverter.getInstance().convertFromValueRecordSchema(personSchemaV2);

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/replication/merge/TestMergeUpdateWithFieldLevelTimestamp.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/replication/merge/TestMergeUpdateWithFieldLevelTimestamp.java
@@ -89,7 +89,8 @@ public class TestMergeUpdateWithFieldLevelTimestamp extends TestMergeConflictRes
         valueLevelTimestamp - 1, // Slightly lower than existing timestamp. Thus update should be ignored.
         1,
         1,
-        1);
+        1,
+        incomingValueSchemaId);
     Assert.assertEquals(mergeConflictResult, MergeConflictResult.getIgnoredResult());
     Assert.assertTrue(
         ((List<?>) rmdRecord.get(RmdConstants.REPLICATION_CHECKPOINT_VECTOR_FIELD_NAME)).isEmpty(),
@@ -154,7 +155,8 @@ public class TestMergeUpdateWithFieldLevelTimestamp extends TestMergeConflictRes
         valueLevelTimestamp + 1,
         1,
         1,
-        1);
+        1,
+        incomingValueSchemaId);
 
     GenericRecord updateFieldPartialUpdateRecord2 = AvroSchemaUtils.createGenericRecord(writeComputeSchema);
     updateFieldPartialUpdateRecord2.put("intArray", Arrays.asList(10, 20, 30, 40));
@@ -171,7 +173,8 @@ public class TestMergeUpdateWithFieldLevelTimestamp extends TestMergeConflictRes
         valueLevelTimestamp + 2,
         2,
         0,
-        0);
+        0,
+        incomingValueSchemaId);
 
     // Validate updated replication metadata.
     Assert.assertFalse(mergeConflictResult.isUpdateIgnored());
@@ -276,7 +279,8 @@ public class TestMergeUpdateWithFieldLevelTimestamp extends TestMergeConflictRes
         valueLevelTimestamp + 1, // Slightly higher than existing timestamp. Thus update is NOT ignored.
         1,
         1,
-        newColoID);
+        newColoID,
+        incomingValueSchemaId);
 
     // Validate updated replication metadata.
     Assert.assertNotEquals(mergeConflictResult, MergeConflictResult.getIgnoredResult());

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/replication/merge/TestMergeUpdateWithFieldLevelTimestamp.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/replication/merge/TestMergeUpdateWithFieldLevelTimestamp.java
@@ -17,7 +17,6 @@ import com.linkedin.venice.schema.rmd.RmdConstants;
 import com.linkedin.venice.schema.writecompute.DerivedSchemaEntry;
 import com.linkedin.venice.schema.writecompute.WriteComputeSchemaConverter;
 import com.linkedin.venice.utils.AvroSchemaUtils;
-import com.linkedin.venice.utils.lazy.Lazy;
 import com.linkedin.venice.writer.update.UpdateBuilder;
 import com.linkedin.venice.writer.update.UpdateBuilderImpl;
 import java.nio.ByteBuffer;
@@ -81,7 +80,7 @@ public class TestMergeUpdateWithFieldLevelTimestamp extends TestMergeConflictRes
             new RmdSerDe(stringAnnotatedStoreSchemaCache, RMD_VERSION_ID),
             storeName);
     MergeConflictResult mergeConflictResult = mergeConflictResolver.update(
-        Lazy.of(() -> null),
+        null,
         rmdWithValueSchemaId,
         writeComputeBytes,
         incomingValueSchemaId,
@@ -90,7 +89,7 @@ public class TestMergeUpdateWithFieldLevelTimestamp extends TestMergeConflictRes
         1,
         1,
         1,
-        incomingValueSchemaId);
+        null);
     Assert.assertEquals(mergeConflictResult, MergeConflictResult.getIgnoredResult());
     Assert.assertTrue(
         ((List<?>) rmdRecord.get(RmdConstants.REPLICATION_CHECKPOINT_VECTOR_FIELD_NAME)).isEmpty(),
@@ -147,7 +146,7 @@ public class TestMergeUpdateWithFieldLevelTimestamp extends TestMergeConflictRes
     ByteBuffer writeComputeBytes1 = ByteBuffer.wrap(
         MapOrderPreservingSerDeFactory.getSerializer(writeComputeSchema).serialize(updateFieldPartialUpdateRecord1));
     MergeConflictResult mergeConflictResult = mergeConflictResolver.update(
-        Lazy.of(() -> oldValueBytes),
+        null,
         rmdWithValueSchemaId,
         writeComputeBytes1,
         incomingValueSchemaId,
@@ -156,7 +155,7 @@ public class TestMergeUpdateWithFieldLevelTimestamp extends TestMergeConflictRes
         1,
         1,
         1,
-        incomingValueSchemaId);
+        null);
 
     GenericRecord updateFieldPartialUpdateRecord2 = AvroSchemaUtils.createGenericRecord(writeComputeSchema);
     updateFieldPartialUpdateRecord2.put("intArray", Arrays.asList(10, 20, 30, 40));
@@ -165,7 +164,7 @@ public class TestMergeUpdateWithFieldLevelTimestamp extends TestMergeConflictRes
 
     ByteBuffer updatedValueBytes = mergeConflictResult.getNewValue();
     mergeConflictResult = mergeConflictResolver.update(
-        Lazy.of(() -> updatedValueBytes),
+        updatedValueBytes,
         rmdWithValueSchemaId,
         writeComputeBytes2,
         incomingValueSchemaId,
@@ -174,7 +173,7 @@ public class TestMergeUpdateWithFieldLevelTimestamp extends TestMergeConflictRes
         2,
         0,
         0,
-        incomingValueSchemaId);
+        null);
 
     // Validate updated replication metadata.
     Assert.assertFalse(mergeConflictResult.isUpdateIgnored());
@@ -271,7 +270,7 @@ public class TestMergeUpdateWithFieldLevelTimestamp extends TestMergeConflictRes
 
     final int newColoID = 3;
     MergeConflictResult mergeConflictResult = mergeConflictResolver.update(
-        Lazy.of(() -> oldValueBytes),
+        oldValueBytes,
         rmdWithValueSchemaId,
         writeComputeBytes,
         incomingValueSchemaId,
@@ -280,7 +279,7 @@ public class TestMergeUpdateWithFieldLevelTimestamp extends TestMergeConflictRes
         1,
         1,
         newColoID,
-        incomingValueSchemaId);
+        null);
 
     // Validate updated replication metadata.
     Assert.assertNotEquals(mergeConflictResult, MergeConflictResult.getIgnoredResult());

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/replication/merge/TestMergeUpdateWithFieldLevelTimestamp.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/replication/merge/TestMergeUpdateWithFieldLevelTimestamp.java
@@ -145,7 +145,7 @@ public class TestMergeUpdateWithFieldLevelTimestamp extends TestMergeConflictRes
     ByteBuffer writeComputeBytes1 = ByteBuffer.wrap(
         MapOrderPreservingSerDeFactory.getSerializer(writeComputeSchema).serialize(updateFieldPartialUpdateRecord1));
     MergeConflictResult mergeConflictResult = mergeConflictResolver.update(
-        null,
+        Lazy.of(() -> null),
         rmdWithValueSchemaId,
         writeComputeBytes1,
         incomingValueSchemaId,

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/replication/merge/TestMergeUpdateWithFieldLevelTimestamp.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/replication/merge/TestMergeUpdateWithFieldLevelTimestamp.java
@@ -17,6 +17,7 @@ import com.linkedin.venice.schema.rmd.RmdConstants;
 import com.linkedin.venice.schema.writecompute.DerivedSchemaEntry;
 import com.linkedin.venice.schema.writecompute.WriteComputeSchemaConverter;
 import com.linkedin.venice.utils.AvroSchemaUtils;
+import com.linkedin.venice.utils.lazy.Lazy;
 import com.linkedin.venice.writer.update.UpdateBuilder;
 import com.linkedin.venice.writer.update.UpdateBuilderImpl;
 import java.nio.ByteBuffer;
@@ -80,7 +81,7 @@ public class TestMergeUpdateWithFieldLevelTimestamp extends TestMergeConflictRes
             new RmdSerDe(stringAnnotatedStoreSchemaCache, RMD_VERSION_ID),
             storeName);
     MergeConflictResult mergeConflictResult = mergeConflictResolver.update(
-        null,
+        Lazy.of(() -> null),
         rmdWithValueSchemaId,
         writeComputeBytes,
         incomingValueSchemaId,
@@ -162,7 +163,7 @@ public class TestMergeUpdateWithFieldLevelTimestamp extends TestMergeConflictRes
 
     ByteBuffer updatedValueBytes = mergeConflictResult.getNewValue();
     mergeConflictResult = mergeConflictResolver.update(
-        updatedValueBytes,
+        Lazy.of(() -> updatedValueBytes),
         rmdWithValueSchemaId,
         writeComputeBytes2,
         incomingValueSchemaId,
@@ -268,7 +269,7 @@ public class TestMergeUpdateWithFieldLevelTimestamp extends TestMergeConflictRes
 
     final int newColoID = 3;
     MergeConflictResult mergeConflictResult = mergeConflictResolver.update(
-        oldValueBytes,
+        Lazy.of(() -> oldValueBytes),
         rmdWithValueSchemaId,
         writeComputeBytes,
         incomingValueSchemaId,

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/replication/merge/TestMergeUpdateWithValueLevelTimestamp.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/replication/merge/TestMergeUpdateWithValueLevelTimestamp.java
@@ -20,7 +20,6 @@ import com.linkedin.venice.schema.writecompute.DerivedSchemaEntry;
 import com.linkedin.venice.schema.writecompute.WriteComputeSchemaConverter;
 import com.linkedin.venice.serializer.FastSerializerDeserializerFactory;
 import com.linkedin.venice.utils.AvroSchemaUtils;
-import com.linkedin.venice.utils.lazy.Lazy;
 import com.linkedin.venice.writer.update.UpdateBuilder;
 import com.linkedin.venice.writer.update.UpdateBuilderImpl;
 import java.nio.ByteBuffer;
@@ -71,7 +70,7 @@ public class TestMergeUpdateWithValueLevelTimestamp extends TestMergeConflictRes
             new RmdSerDe(stringAnnotatedStoreSchemaCache, RMD_VERSION_ID),
             storeName);
     MergeConflictResult mergeConflictResult = mergeConflictResolver.update(
-        Lazy.of(() -> null),
+        null,
         rmdWithValueSchemaId,
         writeComputeBytes,
         incomingValueSchemaId,
@@ -80,7 +79,7 @@ public class TestMergeUpdateWithValueLevelTimestamp extends TestMergeConflictRes
         1,
         1,
         1,
-        incomingValueSchemaId);
+        null);
     Assert.assertEquals(mergeConflictResult, MergeConflictResult.getIgnoredResult());
     Assert.assertTrue(
         ((List<?>) rmdRecord.get(RmdConstants.REPLICATION_CHECKPOINT_VECTOR_FIELD_NAME)).isEmpty(),
@@ -125,7 +124,7 @@ public class TestMergeUpdateWithValueLevelTimestamp extends TestMergeConflictRes
             new RmdSerDe(stringAnnotatedStoreSchemaCache, RMD_VERSION_ID),
             storeName);
     MergeConflictResult mergeConflictResult = mergeConflictResolver.update(
-        Lazy.of(() -> null),
+        null,
         rmdWithValueSchemaId,
         writeComputeBytes,
         incomingValueSchemaId,
@@ -134,7 +133,7 @@ public class TestMergeUpdateWithValueLevelTimestamp extends TestMergeConflictRes
         1,
         1,
         1,
-        incomingValueSchemaId);
+        null);
     Assert.assertEquals(mergeConflictResult, MergeConflictResult.getIgnoredResult());
     Assert.assertTrue(
         ((List<?>) rmdRecord.get(RmdConstants.REPLICATION_CHECKPOINT_VECTOR_FIELD_NAME)).isEmpty(),
@@ -195,7 +194,7 @@ public class TestMergeUpdateWithValueLevelTimestamp extends TestMergeConflictRes
             new RmdSerDe(stringAnnotatedStoreSchemaCache, RMD_VERSION_ID),
             storeName);
     MergeConflictResult mergeConflictResult = mergeConflictResolver.update(
-        Lazy.of(() -> oldValueBytes),
+        oldValueBytes,
         rmdWithValueSchemaId,
         writeComputeBytes,
         incomingValueSchemaId,
@@ -204,7 +203,7 @@ public class TestMergeUpdateWithValueLevelTimestamp extends TestMergeConflictRes
         1,
         1,
         1,
-        incomingValueSchemaId);
+        null);
 
     // Validate updated replication metadata.
     Assert.assertNotEquals(mergeConflictResult, MergeConflictResult.getIgnoredResult());
@@ -308,7 +307,7 @@ public class TestMergeUpdateWithValueLevelTimestamp extends TestMergeConflictRes
 
     final int newColoID = 3;
     MergeConflictResult mergeConflictResult = mergeConflictResolver.update(
-        Lazy.of(() -> oldValueBytes),
+        oldValueBytes,
         rmdWithValueSchemaId,
         writeComputeBytes,
         incomingValueSchemaId,
@@ -317,7 +316,7 @@ public class TestMergeUpdateWithValueLevelTimestamp extends TestMergeConflictRes
         1,
         1,
         newColoID,
-        incomingValueSchemaId);
+        null);
 
     // Validate updated replication metadata.
     Assert.assertNotEquals(mergeConflictResult, MergeConflictResult.getIgnoredResult());
@@ -388,7 +387,7 @@ public class TestMergeUpdateWithValueLevelTimestamp extends TestMergeConflictRes
             .serialize(updateFieldRecord));
 
     MergeConflictResult mergeConflictResult2 = mergeConflictResolver.update(
-        Lazy.of(() -> updatedValueBytes),
+        updatedValueBytes,
         rmdWithValueSchemaId,
         writeComputeBytes,
         incomingValueSchemaId,
@@ -397,7 +396,7 @@ public class TestMergeUpdateWithValueLevelTimestamp extends TestMergeConflictRes
         1,
         1,
         newColoID,
-        incomingValueSchemaId);
+        null);
     ByteBuffer updatedValueBytes2 = mergeConflictResult2.getNewValue();
     updatedValueRecord = MapOrderPreservingSerDeFactory.getDeserializer(annotatedSchema, annotatedSchema)
         .deserialize(updatedValueBytes2.array());
@@ -473,7 +472,7 @@ public class TestMergeUpdateWithValueLevelTimestamp extends TestMergeConflictRes
             storeName);
     final int newValueColoID = 3;
     MergeConflictResult mergeConflictResult = mergeConflictResolver.update(
-        Lazy.of(() -> oldValueBytes),
+        oldValueBytes,
         rmdWithValueSchemaId,
         writeComputeBytes,
         incomingValueSchemaId,
@@ -482,7 +481,7 @@ public class TestMergeUpdateWithValueLevelTimestamp extends TestMergeConflictRes
         1,
         1,
         newValueColoID,
-        incomingValueSchemaId);
+        null);
 
     // Validate updated replication metadata.
     Assert.assertNotEquals(mergeConflictResult, MergeConflictResult.getIgnoredResult());
@@ -621,7 +620,7 @@ public class TestMergeUpdateWithValueLevelTimestamp extends TestMergeConflictRes
             storeName);
     final int newValueColoID = 3;
     MergeConflictResult mergeConflictResult = mergeConflictResolver.update(
-        Lazy.of(() -> oldValueBytes),
+        oldValueBytes,
         rmdWithValueSchemaId,
         writeComputeBytes,
         incomingValueSchemaId,
@@ -630,7 +629,7 @@ public class TestMergeUpdateWithValueLevelTimestamp extends TestMergeConflictRes
         1,
         1,
         newValueColoID,
-        incomingValueSchemaId);
+        null);
 
     // Validate updated replication metadata.
     Assert.assertNotEquals(mergeConflictResult, MergeConflictResult.getIgnoredResult());

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/replication/merge/TestMergeUpdateWithValueLevelTimestamp.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/replication/merge/TestMergeUpdateWithValueLevelTimestamp.java
@@ -20,6 +20,7 @@ import com.linkedin.venice.schema.writecompute.DerivedSchemaEntry;
 import com.linkedin.venice.schema.writecompute.WriteComputeSchemaConverter;
 import com.linkedin.venice.serializer.FastSerializerDeserializerFactory;
 import com.linkedin.venice.utils.AvroSchemaUtils;
+import com.linkedin.venice.utils.lazy.Lazy;
 import com.linkedin.venice.writer.update.UpdateBuilder;
 import com.linkedin.venice.writer.update.UpdateBuilderImpl;
 import java.nio.ByteBuffer;
@@ -194,7 +195,7 @@ public class TestMergeUpdateWithValueLevelTimestamp extends TestMergeConflictRes
             new RmdSerDe(stringAnnotatedStoreSchemaCache, RMD_VERSION_ID),
             storeName);
     MergeConflictResult mergeConflictResult = mergeConflictResolver.update(
-        oldValueBytes,
+        Lazy.of(() -> oldValueBytes),
         rmdWithValueSchemaId,
         writeComputeBytes,
         incomingValueSchemaId,
@@ -307,7 +308,7 @@ public class TestMergeUpdateWithValueLevelTimestamp extends TestMergeConflictRes
 
     final int newColoID = 3;
     MergeConflictResult mergeConflictResult = mergeConflictResolver.update(
-        oldValueBytes,
+        Lazy.of(() -> oldValueBytes),
         rmdWithValueSchemaId,
         writeComputeBytes,
         incomingValueSchemaId,
@@ -387,7 +388,7 @@ public class TestMergeUpdateWithValueLevelTimestamp extends TestMergeConflictRes
             .serialize(updateFieldRecord));
 
     MergeConflictResult mergeConflictResult2 = mergeConflictResolver.update(
-        updatedValueBytes,
+        Lazy.of(() -> updatedValueBytes),
         rmdWithValueSchemaId,
         writeComputeBytes,
         incomingValueSchemaId,
@@ -472,7 +473,7 @@ public class TestMergeUpdateWithValueLevelTimestamp extends TestMergeConflictRes
             storeName);
     final int newValueColoID = 3;
     MergeConflictResult mergeConflictResult = mergeConflictResolver.update(
-        oldValueBytes,
+        Lazy.of(() -> oldValueBytes),
         rmdWithValueSchemaId,
         writeComputeBytes,
         incomingValueSchemaId,
@@ -620,7 +621,7 @@ public class TestMergeUpdateWithValueLevelTimestamp extends TestMergeConflictRes
             storeName);
     final int newValueColoID = 3;
     MergeConflictResult mergeConflictResult = mergeConflictResolver.update(
-        oldValueBytes,
+        Lazy.of(() -> oldValueBytes),
         rmdWithValueSchemaId,
         writeComputeBytes,
         incomingValueSchemaId,

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/replication/merge/TestMergeUpdateWithValueLevelTimestamp.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/replication/merge/TestMergeUpdateWithValueLevelTimestamp.java
@@ -79,7 +79,8 @@ public class TestMergeUpdateWithValueLevelTimestamp extends TestMergeConflictRes
         valueLevelTimestamp - 1, // Slightly lower than existing timestamp. Thus update should be ignored.
         1,
         1,
-        1);
+        1,
+        incomingValueSchemaId);
     Assert.assertEquals(mergeConflictResult, MergeConflictResult.getIgnoredResult());
     Assert.assertTrue(
         ((List<?>) rmdRecord.get(RmdConstants.REPLICATION_CHECKPOINT_VECTOR_FIELD_NAME)).isEmpty(),
@@ -132,7 +133,8 @@ public class TestMergeUpdateWithValueLevelTimestamp extends TestMergeConflictRes
         valueLevelTimestamp - 1, // Slightly lower than existing timestamp. Thus update should be ignored.
         1,
         1,
-        1);
+        1,
+        incomingValueSchemaId);
     Assert.assertEquals(mergeConflictResult, MergeConflictResult.getIgnoredResult());
     Assert.assertTrue(
         ((List<?>) rmdRecord.get(RmdConstants.REPLICATION_CHECKPOINT_VECTOR_FIELD_NAME)).isEmpty(),
@@ -201,7 +203,8 @@ public class TestMergeUpdateWithValueLevelTimestamp extends TestMergeConflictRes
         valueLevelTimestamp + 1, // Slightly higher than existing timestamp. Thus update is NOT ignored.
         1,
         1,
-        1);
+        1,
+        incomingValueSchemaId);
 
     // Validate updated replication metadata.
     Assert.assertNotEquals(mergeConflictResult, MergeConflictResult.getIgnoredResult());
@@ -313,7 +316,8 @@ public class TestMergeUpdateWithValueLevelTimestamp extends TestMergeConflictRes
         valueLevelTimestamp + 1, // Slightly higher than existing timestamp. Thus update is NOT ignored.
         1,
         1,
-        newColoID);
+        newColoID,
+        incomingValueSchemaId);
 
     // Validate updated replication metadata.
     Assert.assertNotEquals(mergeConflictResult, MergeConflictResult.getIgnoredResult());
@@ -392,7 +396,8 @@ public class TestMergeUpdateWithValueLevelTimestamp extends TestMergeConflictRes
         valueLevelTimestamp + 2,
         1,
         1,
-        newColoID);
+        newColoID,
+        incomingValueSchemaId);
     ByteBuffer updatedValueBytes2 = mergeConflictResult2.getNewValue();
     updatedValueRecord = MapOrderPreservingSerDeFactory.getDeserializer(annotatedSchema, annotatedSchema)
         .deserialize(updatedValueBytes2.array());
@@ -476,7 +481,8 @@ public class TestMergeUpdateWithValueLevelTimestamp extends TestMergeConflictRes
         valueLevelTimestamp + 1, // Slightly higher than existing timestamp. Thus update is NOT ignored.
         1,
         1,
-        newValueColoID);
+        newValueColoID,
+        incomingValueSchemaId);
 
     // Validate updated replication metadata.
     Assert.assertNotEquals(mergeConflictResult, MergeConflictResult.getIgnoredResult());
@@ -623,7 +629,8 @@ public class TestMergeUpdateWithValueLevelTimestamp extends TestMergeConflictRes
         valueLevelTimestamp + 1, // Slightly higher than existing timestamp. Thus update is NOT ignored.
         1,
         1,
-        newValueColoID);
+        newValueColoID,
+        incomingValueSchemaId);
 
     // Validate updated replication metadata.
     Assert.assertNotEquals(mergeConflictResult, MergeConflictResult.getIgnoredResult());

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/PartialUpdateTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/PartialUpdateTest.java
@@ -533,7 +533,7 @@ public class PartialUpdateTest {
       veniceClusterWrapper.waitVersion(storeName, 1);
       // Produce partial updates on batch pushed keys
       SystemProducer veniceProducer = getSamzaProducer(veniceClusterWrapper, storeName, Version.PushType.STREAM);
-      for (int i = 1; i < 10; i++) {
+      for (int i = 1; i < 100; i++) {
         GenericRecord partialUpdateRecord =
             new UpdateBuilderImpl(writeComputeSchema).setNewFieldValue("key", "new_name_" + i).build();
         sendStreamingRecord(veniceProducer, storeName, String.valueOf(i), partialUpdateRecord);
@@ -543,7 +543,7 @@ public class PartialUpdateTest {
           ClientConfig.defaultGenericClientConfig(storeName).setVeniceURL(veniceClusterWrapper.getRandomRouterURL()))) {
         TestUtils.waitForNonDeterministicAssertion(10, TimeUnit.SECONDS, true, () -> {
           try {
-            for (int i = 1; i < 10; i++) {
+            for (int i = 1; i < 100; i++) {
               String key = String.valueOf(i);
               GenericRecord value = readValue(storeReader, key);
               assertNotNull(value, "Key " + key + " should not be missing!");

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/PartialUpdateTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/PartialUpdateTest.java
@@ -533,7 +533,7 @@ public class PartialUpdateTest {
       veniceClusterWrapper.waitVersion(storeName, 1);
       // Produce partial updates on batch pushed keys
       SystemProducer veniceProducer = getSamzaProducer(veniceClusterWrapper, storeName, Version.PushType.STREAM);
-      for (int i = 1; i < 100; i++) {
+      for (int i = 1; i < 10; i++) {
         GenericRecord partialUpdateRecord =
             new UpdateBuilderImpl(writeComputeSchema).setNewFieldValue("key", "new_name_" + i).build();
         sendStreamingRecord(veniceProducer, storeName, String.valueOf(i), partialUpdateRecord);
@@ -543,7 +543,7 @@ public class PartialUpdateTest {
           ClientConfig.defaultGenericClientConfig(storeName).setVeniceURL(veniceClusterWrapper.getRandomRouterURL()))) {
         TestUtils.waitForNonDeterministicAssertion(10, TimeUnit.SECONDS, true, () -> {
           try {
-            for (int i = 1; i < 100; i++) {
+            for (int i = 1; i < 10; i++) {
               String key = String.valueOf(i);
               GenericRecord value = readValue(storeReader, key);
               assertNotNull(value, "Key " + key + " should not be missing!");

--- a/internal/venice-test-common/src/main/resources/valueSchema/UserWithFloatArray.avsc
+++ b/internal/venice-test-common/src/main/resources/valueSchema/UserWithFloatArray.avsc
@@ -1,18 +1,22 @@
 {
-  "type" : "record",
-  "name" : "ManyFloats",
-  "namespace" : "example.avro",
-  "fields" : [ {
-    "name" : "key",
-    "type" : "string"
-  }, {
-    "name" : "value",
-    "type" : {
-      "type" : "array",
-      "items" : "float"
+  "type": "record",
+  "name": "ManyFloats",
+  "namespace": "example.avro",
+  "fields": [
+    {
+      "name": "key",
+      "type": "string"
+    },
+    {
+      "name": "value",
+      "type": {
+        "type": "array",
+        "items": "float"
+      }
+    },
+    {
+      "name": "age",
+      "type": "int"
     }
-  }, {
-    "name" : "age",
-    "type" : "int"
-  } ]
+  ]
 }

--- a/internal/venice-test-common/src/main/resources/valueSchema/UserWithStringMap.avsc
+++ b/internal/venice-test-common/src/main/resources/valueSchema/UserWithStringMap.avsc
@@ -1,0 +1,25 @@
+{
+  "type": "record",
+  "name": "ManyStrings",
+  "namespace": "example.avro",
+  "fields": [
+    {
+      "name": "key",
+      "type": "string",
+      "default": "default_name"
+    },
+    {
+      "name": "value",
+      "type": {
+        "type": "map",
+        "values": "string"
+      },
+      "default": {}
+    },
+    {
+      "name": "age",
+      "type": "int",
+      "default": 0
+    }
+  ]
+}


### PR DESCRIPTION
## [server] Use supersetschema id for readerschema when performing updates

There is an edge case when a chunk is assembled from batch push that the result of the assembling doesn't contain the schema id in the first few bytes of the resulting record (there's even a bit of code in the ingestion task today which adds it back later in the processing pipeline).  This means that the old code parsing the schemaid in this case would get a corrupted schema id.  Looking at the code, in this path the reader schema is always the latest superset schema id anyway, and should therefore be safe to utilize for deserialization of the record (no field drops should should occur).  This has the advantage of requiring not much change, though it might be more technically correct to make passing the original schema id more explicit in the code?

Unsure what might be more preferred.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.