### PR TITLE
[router] NPE fix for ReadRequestThrottler constructor/listener

### DIFF
--- a/internal/venice-common/src/main/java/com/linkedin/venice/helix/ZkRoutersClusterManager.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/helix/ZkRoutersClusterManager.java
@@ -177,13 +177,6 @@ public class ZkRoutersClusterManager
   }
 
   @Override
-  public void unSubscribeRouterCountChangedEvent(RouterCountChangedListener listener) {
-    synchronized (routerCountListeners) {
-      routerCountListeners.remove(listener);
-    }
-  }
-
-  @Override
   public boolean isThrottlingEnabled() {
     // If router's config could not be found, by default we think the throttling is enabled.
     return routersClusterConfig.isThrottlingEnabled();

--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/RoutersClusterManager.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/RoutersClusterManager.java
@@ -40,11 +40,6 @@ public interface RoutersClusterManager {
 
   Set<Instance> getLiveRouterInstances();
 
-  /**
-   * Stop listening on the router count.
-   */
-  void unSubscribeRouterCountChangedEvent(RouterCountChangedListener listener);
-
   boolean isThrottlingEnabled();
 
   boolean isMaxCapacityProtectionEnabled();


### PR DESCRIPTION
Set the ReadRequestThrottler.storesThrottlers AtomicReference at the definition site, containing an empty map, to fully eliminate NPEs, even if listeners are added before the end of the constructor. Also added a unit test to repro the issue.

Miscellaneous:

- Reduced accesses to the ReadRequestThrottler.storesThrottlers, to make it easier to see whether mutations are within the scope of a lock or not.

- Deleted the RoutersClusterManager::unSubscribeRouterCountChangedEvent function since it is unused.

## How was this PR tested?
New unit test.

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.