### PR TITLE
[da-vinci] Open RocksDB after blob transfer is completed

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/DefaultIngestionBackend.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/DefaultIngestionBackend.java
@@ -68,7 +68,11 @@ public class DefaultIngestionBackend implements IngestionBackend {
 
     bootstrapFuture.whenComplete((result, throwable) -> {
       long endTime = System.currentTimeMillis();
-      LOGGER.info("Bootstrapping duration: {} ms", endTime - startTime);
+      LOGGER.info(
+          "Blob Transfer duration for store name: {} version: {}: time: {} ms",
+          storeVersion,
+          storeAndVersion.getSecond().getNumber(),
+          endTime - startTime);
       AbstractStorageEngine storageEngine =
           storageService.openStoreForNewPartition(storeConfig, partition, svsSupplier);
       topicStorageEngineReferenceMap.compute(storeVersion, (key, storageEngineAtomicReference) -> {

--- a/internal/venice-common/src/main/java/com/linkedin/venice/blobtransfer/NettyP2PBlobTransferManager.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/blobtransfer/NettyP2PBlobTransferManager.java
@@ -54,7 +54,6 @@ public class NettyP2PBlobTransferManager implements P2PBlobTransferManager<Void>
         // TODO: add some retry logic or strategy to choose the peers differently in case of failure
         // instanceName comes as a format of <hostName>_<applicationPort>
         String chosenHost = peer.split("_")[0];
-        LOGGER.info("Chosen host: {}", chosenHost);
         inputStream = nettyClient.get(chosenHost, storeName, version, partition);
         return inputStream;
       } catch (Exception e) {

--- a/internal/venice-common/src/main/java/com/linkedin/venice/blobtransfer/NettyP2PBlobTransferManager.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/blobtransfer/NettyP2PBlobTransferManager.java
@@ -54,6 +54,7 @@ public class NettyP2PBlobTransferManager implements P2PBlobTransferManager<Void>
         // TODO: add some retry logic or strategy to choose the peers differently in case of failure
         // instanceName comes as a format of <hostName>_<applicationPort>
         String chosenHost = peer.split("_")[0];
+        LOGGER.info("Chosen host: {}", chosenHost);
         inputStream = nettyClient.get(chosenHost, storeName, version, partition);
         return inputStream;
       } catch (Exception e) {

--- a/internal/venice-common/src/main/java/com/linkedin/venice/blobtransfer/client/P2PFileTransferClientHandler.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/blobtransfer/client/P2PFileTransferClientHandler.java
@@ -86,6 +86,7 @@ public class P2PFileTransferClientHandler extends SimpleChannelInboundHandler<Ht
       // Prepare the file
       Path file = Files.createFile(partitionDir.resolve(fileName));
       outputFileChannel = FileChannel.open(file, StandardOpenOption.WRITE, StandardOpenOption.APPEND);
+
     } else if (msg instanceof HttpContent) {
       HttpContent content = (HttpContent) msg;
       ByteBuf byteBuf = content.content();
@@ -119,7 +120,7 @@ public class P2PFileTransferClientHandler extends SimpleChannelInboundHandler<Ht
 
       if (content instanceof DefaultLastHttpContent) {
         // End of a single file transfer
-        LOGGER.info("A file {} received successfully for {}", fileName, payload.getFullResourceName());
+        LOGGER.debug("A file {} received successfully for {}", fileName, payload.getFullResourceName());
         outputFileChannel.force(true);
 
         // Size validation

--- a/internal/venice-common/src/main/java/com/linkedin/venice/blobtransfer/client/P2PFileTransferClientHandler.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/blobtransfer/client/P2PFileTransferClientHandler.java
@@ -72,9 +72,11 @@ public class P2PFileTransferClientHandler extends SimpleChannelInboundHandler<Ht
 
       // Parse the file name
       this.fileName = getFileNameFromHeader(response);
+
       if (this.fileName == null) {
         throw new VeniceException("No file name specified in the response for " + payload.getFullResourceName());
       }
+      LOGGER.info("Starting blob transfer for file: {}", fileName);
       this.fileContentLength = Long.parseLong(response.headers().get(HttpHeaderNames.CONTENT_LENGTH));
 
       // Create the directory
@@ -117,7 +119,7 @@ public class P2PFileTransferClientHandler extends SimpleChannelInboundHandler<Ht
 
       if (content instanceof DefaultLastHttpContent) {
         // End of a single file transfer
-        LOGGER.debug("A file {} received successfully for {}", fileName, payload.getFullResourceName());
+        LOGGER.info("A file {} received successfully for {}", fileName, payload.getFullResourceName());
         outputFileChannel.force(true);
 
         // Size validation


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Summary, imperative, start upper case, don't end with a period
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

When doing blob transfer the files passed in would have already been somewhat initialized instead of it being a clean file. This fix reorganizes the DefaultIngestionBackend file to ensure that blob transfer will be tried first with a clean file.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
Local build and QEI testing 
## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.