### PR TITLE
[fast-client] Added fanout size metric for FC to monitor multi-key HAR performance

### DIFF
--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/DispatchingAvroGenericStoreClient.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/DispatchingAvroGenericStoreClient.java
@@ -459,6 +459,7 @@ public class DispatchingAvroGenericStoreClient<K, V> extends InternalAvroStoreCl
       }
     }
 
+    requestContext.setFanoutSize(requestContext.getRoutes().size());
     int numberOfRequestCompletionFutures =
         requestContext.getRoutes().size() + (partitionsWithNoRoutes.isEmpty() ? 0 : 1);
     CompletableFuture<Integer>[] requestCompletionFutures = new CompletableFuture[numberOfRequestCompletionFutures];

--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/MultiKeyRequestContext.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/MultiKeyRequestContext.java
@@ -44,6 +44,8 @@ public abstract class MultiKeyRequestContext<K, V> extends RequestContext {
   final boolean isPartialSuccessAllowed;
   private boolean completed;
 
+  private int fanoutSize;
+
   MultiKeyRequestContext(int numKeysInRequest, boolean isPartialSuccessAllowed) {
     this.routeRequests = new VeniceConcurrentHashMap<>();
     this.firstRequestSentTS = new AtomicLong(-1);
@@ -165,6 +167,14 @@ public abstract class MultiKeyRequestContext<K, V> extends RequestContext {
 
   public void setRoutesForPartitionMapping(Map<Integer, Set<String>> routesForPartition) {
     this.routesForPartition = routesForPartition;
+  }
+
+  public void setFanoutSize(int fanoutSize) {
+    this.fanoutSize = fanoutSize;
+  }
+
+  public int getFanoutSize() {
+    return fanoutSize;
   }
 
   /**

--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/RetriableAvroGenericStoreClient.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/RetriableAvroGenericStoreClient.java
@@ -367,6 +367,7 @@ public class RetriableAvroGenericStoreClient<K, V> extends DelegatingAvroStoreCl
         scheduledRetryTask.cancel();
       }
       requestContext.complete();
+      requestContext.setFanoutSize(originalRequestContext.getFanoutSize());
       if (finalException == null) {
         callback.onCompletion(Optional.empty());
       } else {

--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/StatsAvroGenericStoreClient.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/StatsAvroGenericStoreClient.java
@@ -176,11 +176,13 @@ public class StatsAvroGenericStoreClient<K, V> extends DelegatingAvroStoreClient
       } else if (requestContext instanceof MultiKeyRequestContext) {
         // MultiKeyRequestContext is the superclass for ComputeRequestContext and BatchGetRequestContext
         MultiKeyRequestContext<K, V> multiKeyRequestContext = (MultiKeyRequestContext<K, V>) requestContext;
+        clientStats.recordMultiKeyFanoutSize(multiKeyRequestContext.getFanoutSize());
         if (multiKeyRequestContext.retryContext != null
             && multiKeyRequestContext.retryContext.retryRequestContext != null) {
           clientStats.recordLongTailRetryRequest();
           clientStats
               .recordRetryRequestKeyCount(multiKeyRequestContext.retryContext.retryRequestContext.numKeysInRequest);
+          clientStats.recordMultiKeyFanoutSize(multiKeyRequestContext.retryContext.retryRequestContext.getFanoutSize());
           if (!exceptionReceived) {
             clientStats.recordRetryRequestSuccessKeyCount(
                 multiKeyRequestContext.retryContext.retryRequestContext.numKeysCompleted.get());

--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/StatsAvroGenericStoreClient.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/StatsAvroGenericStoreClient.java
@@ -176,13 +176,13 @@ public class StatsAvroGenericStoreClient<K, V> extends DelegatingAvroStoreClient
       } else if (requestContext instanceof MultiKeyRequestContext) {
         // MultiKeyRequestContext is the superclass for ComputeRequestContext and BatchGetRequestContext
         MultiKeyRequestContext<K, V> multiKeyRequestContext = (MultiKeyRequestContext<K, V>) requestContext;
-        clientStats.recordMultiKeyFanoutSize(multiKeyRequestContext.getFanoutSize());
+        clientStats.recordFanoutSize(multiKeyRequestContext.getFanoutSize());
         if (multiKeyRequestContext.retryContext != null
             && multiKeyRequestContext.retryContext.retryRequestContext != null) {
           clientStats.recordLongTailRetryRequest();
           clientStats
               .recordRetryRequestKeyCount(multiKeyRequestContext.retryContext.retryRequestContext.numKeysInRequest);
-          clientStats.recordMultiKeyFanoutSize(multiKeyRequestContext.retryContext.retryRequestContext.getFanoutSize());
+          clientStats.recordRetryFanoutSize(multiKeyRequestContext.retryContext.retryRequestContext.getFanoutSize());
           if (!exceptionReceived) {
             clientStats.recordRetryRequestSuccessKeyCount(
                 multiKeyRequestContext.retryContext.retryRequestContext.numKeysCompleted.get());

--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/stats/FastClientStats.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/stats/FastClientStats.java
@@ -41,8 +41,8 @@ public class FastClientStats extends com.linkedin.venice.client.stats.ClientStat
   private final Sensor longTailRetryRequestSensor;
   private final Sensor errorRetryRequestSensor;
   private final Sensor retryRequestWinSensor;
-
   private final Sensor metadataStalenessSensor;
+  private final Sensor multiKeyFanoutSizeSensor;
   private long cacheTimeStampInMs = 0;
 
   // Routing stats
@@ -96,6 +96,7 @@ public class FastClientStats extends com.linkedin.venice.client.stats.ClientStat
         return System.currentTimeMillis() - this.cacheTimeStampInMs;
       }
     }, "metadata_staleness_high_watermark_ms"));
+    this.multiKeyFanoutSizeSensor = registerSensor("multi_key_fanout_size", new Avg(), new Max());
   }
 
   public void recordNoAvailableReplicaRequest() {
@@ -174,6 +175,10 @@ public class FastClientStats extends com.linkedin.venice.client.stats.ClientStat
 
   public void updateCacheTimestamp(long cacheTimeStampInMs) {
     this.cacheTimeStampInMs = cacheTimeStampInMs;
+  }
+
+  public void recordMultiKeyFanoutSize(int fanoutSize) {
+    multiKeyFanoutSizeSensor.record(fanoutSize);
   }
 
   /**

--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/stats/FastClientStats.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/stats/FastClientStats.java
@@ -42,7 +42,8 @@ public class FastClientStats extends com.linkedin.venice.client.stats.ClientStat
   private final Sensor errorRetryRequestSensor;
   private final Sensor retryRequestWinSensor;
   private final Sensor metadataStalenessSensor;
-  private final Sensor multiKeyFanoutSizeSensor;
+  private final Sensor fanoutSizeSensor;
+  private final Sensor retryFanoutSizeSensor;
   private long cacheTimeStampInMs = 0;
 
   // Routing stats
@@ -96,7 +97,8 @@ public class FastClientStats extends com.linkedin.venice.client.stats.ClientStat
         return System.currentTimeMillis() - this.cacheTimeStampInMs;
       }
     }, "metadata_staleness_high_watermark_ms"));
-    this.multiKeyFanoutSizeSensor = registerSensor("multi_key_fanout_size", new Avg(), new Max());
+    this.fanoutSizeSensor = registerSensor("fanout_size", new Avg(), new Max());
+    this.retryFanoutSizeSensor = registerSensor("retry_fanout_size", new Avg(), new Max());
   }
 
   public void recordNoAvailableReplicaRequest() {
@@ -177,8 +179,12 @@ public class FastClientStats extends com.linkedin.venice.client.stats.ClientStat
     this.cacheTimeStampInMs = cacheTimeStampInMs;
   }
 
-  public void recordMultiKeyFanoutSize(int fanoutSize) {
-    multiKeyFanoutSizeSensor.record(fanoutSize);
+  public void recordFanoutSize(int fanoutSize) {
+    fanoutSizeSensor.record(fanoutSize);
+  }
+
+  public void recordRetryFanoutSize(int retryFanoutSize) {
+    retryFanoutSizeSensor.record(retryFanoutSize);
   }
 
   /**

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/fastclient/FastClientIndividualFeatureConfigurationTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/fastclient/FastClientIndividualFeatureConfigurationTest.java
@@ -472,8 +472,8 @@ public class FastClientIndividualFeatureConfigurationTest extends AbstractClient
     MetricsRepository clientMetric = new MetricsRepository();
     String metricPrefix = ClientTestUtils.getMetricPrefix(storeName, RequestType.MULTI_GET_STREAMING);
     ;
-    String fanoutSizeAverageMetricName = metricPrefix + "multi_key_fanout_size.Avg";
-    String fanoutSizeMaxMetricName = metricPrefix + "multi_key_fanout_size.Max";
+    String fanoutSizeAverageMetricName = metricPrefix + "fanout_size.Avg";
+    String fanoutSizeMaxMetricName = metricPrefix + "fanout_size.Max";
     AvroGenericStoreClient<String, GenericRecord> genericFastClient =
         getGenericFastClient(clientConfigBuilder, clientMetric, StoreMetadataFetchMode.SERVER_BASED_METADATA);
     Set<String> keys = new HashSet<>();


### PR DESCRIPTION
## Summary
[fast-client] Added fanout size metric for FC to monitor multi-key HAR performance

Added `multi_key_fanout_size` Avg and Max metric so we can monitor FC multi-key request fanout size
for HAR.

## How was this PR tested?
Existing and new integration test

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.