### PR TITLE
[server] Fix server side connection tracking and logging

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
@@ -757,7 +757,7 @@ public class VeniceServerConfig extends VeniceClusterConfig {
     divProducerStateMaxAgeMs =
         serverProperties.getLong(DIV_PRODUCER_STATE_MAX_AGE_MS, KafkaDataIntegrityValidator.DISABLED);
     pubSubClientsFactory = new PubSubClientsFactory(serverProperties);
-    routerPrincipalName = serverProperties.getString(ROUTER_PRINCIPAL_NAME, "CN=venice-router");
+    routerPrincipalName = serverProperties.getString(ROUTER_PRINCIPAL_NAME, "venice-router");
     ingestionTaskMaxIdleCount = serverProperties.getInt(SERVER_INGESTION_TASK_MAX_IDLE_COUNT, 10000);
     metaStoreWriterCloseTimeoutInMS = serverProperties.getLong(META_STORE_WRITER_CLOSE_TIMEOUT_MS, 300000L);
     metaStoreWriterCloseConcurrency = serverProperties.getInt(META_STORE_WRITER_CLOSE_CONCURRENCY, -1);

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/notifier/LogNotifier.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/notifier/LogNotifier.java
@@ -73,8 +73,6 @@ public class LogNotifier implements VeniceNotifier {
           "{} for replica: {}{}{}",
           header,
           Utils.getReplicaId(pubSubTopic, partitionId),
-          pubSubTopic,
-          partitionId,
           offset == null ? "" : " offset " + offset,
           (message == null || message.isEmpty()) ? "" : " message " + message);
     } else {

--- a/services/venice-server/src/main/java/com/linkedin/venice/listener/ServerConnectionStatsHandler.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/listener/ServerConnectionStatsHandler.java
@@ -19,7 +19,10 @@ public class ServerConnectionStatsHandler extends ChannelInboundHandlerAdapter {
   }
 
   @Override
-  public void channelRegistered(ChannelHandlerContext ctx) throws Exception {
+  public void channelActive(ChannelHandlerContext ctx) throws Exception {
+    if (ctx.channel().remoteAddress() == null) {
+      return;
+    }
     SslHandler sslHandler = extractSslHandler(ctx);
     if (sslHandler == null) {
       // No ssl enabled, record all connections as client connections
@@ -27,7 +30,7 @@ public class ServerConnectionStatsHandler extends ChannelInboundHandlerAdapter {
       return;
     }
     String principalName = getPrincipal(sslHandler);
-    if (principalName.equals(routerPrincipalName)) {
+    if (principalName != null && principalName.contains(routerPrincipalName)) {
       serverConnectionStats.incrementRouterConnectionCount();
     } else {
       serverConnectionStats.incrementClientConnectionCount();
@@ -35,7 +38,11 @@ public class ServerConnectionStatsHandler extends ChannelInboundHandlerAdapter {
   }
 
   @Override
-  public void channelUnregistered(ChannelHandlerContext ctx) throws Exception {
+  public void channelInactive(ChannelHandlerContext ctx) throws Exception {
+    if (ctx.channel().remoteAddress() == null) {
+      return;
+    }
+
     SslHandler sslHandler = extractSslHandler(ctx);
     if (sslHandler == null) {
       // No ssl enabled, record all connections as client connections
@@ -43,7 +50,7 @@ public class ServerConnectionStatsHandler extends ChannelInboundHandlerAdapter {
       return;
     }
     String principalName = getPrincipal(sslHandler);
-    if (principalName.equals(routerPrincipalName)) {
+    if (principalName != null && principalName.contains(routerPrincipalName)) {
       serverConnectionStats.decrementRouterConnectionCount();
     } else {
       serverConnectionStats.decrementClientConnectionCount();


### PR DESCRIPTION
## Fix server side connection tracking and logging

**Switch to channelActive/channelInactive for Accurate Connection Tracking:**
Replaced the use of channelRegistered/channelUnregistered with
channelActive/channelInactive to improve the tracking of active connections.

**Safety Enhancements:** Added safeguards to ensure connections are only tracked if
they have been correctly marked as active. This prevents multiple
channelActive/channelInactive events from being processed for the same
connection and avoids tracking connections that are marked inactive before ever
being marked as active.

**Router Principal Update:** Updated the router principal name from CN=venice-router
to venice-router and switched to using a substring match instead of equals for
more flexible connection tracking from routers.

**Log Notifier Improvement:** Enhanced log statements within LogNotifier for better
clarity and removed redundant logging to streamline output.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
CI

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.