### PR TITLE
[fast-client] Make multi-key retry budget enforce at key level in FC

### DIFF
--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/RetriableAvroGenericStoreClient.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/RetriableAvroGenericStoreClient.java
@@ -312,7 +312,7 @@ public class RetriableAvroGenericStoreClient<K, V> extends DelegatingAvroStoreCl
           finalRequestCompletionFuture.completeExceptionally(throwable);
           return;
         }
-        if (throwable != null || multiKeyLongTailRetryManager.isRetryAllowed()) {
+        if (throwable != null || multiKeyLongTailRetryManager.isRetryAllowed(pendingKeysFuture.keySet().size())) {
           Set<K> pendingKeys = Collections.unmodifiableSet(pendingKeysFuture.keySet());
           R retryRequestContext =
               requestContextConstructor.construct(pendingKeys.size(), requestContext.isPartialSuccessAllowed);
@@ -360,7 +360,7 @@ public class RetriableAvroGenericStoreClient<K, V> extends DelegatingAvroStoreCl
             savedException,
             pendingKeysFuture,
             scheduledRetryTask));
-    multiKeyLongTailRetryManager.recordRequest();
+    multiKeyLongTailRetryManager.recordRequests(originalRequestContext.numKeysInRequest);
 
     finalRequestCompletionFuture.whenComplete((ignore, finalException) -> {
       if (!scheduledRetryTask.isDone()) {

--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/RetryManager.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/RetryManager.java
@@ -74,6 +74,12 @@ public class RetryManager {
     }
   }
 
+  public void recordRequests(int requests) {
+    if (retryBudgetEnabled.get()) {
+      requestCount.getAndAdd(requests);
+    }
+  }
+
   public boolean isRetryAllowed() {
     return this.isRetryAllowed(1);
   }


### PR DESCRIPTION
## [fast-client] Make multi-key retry budget enforce at key level in FC
Unlike routers where traffic from many thin-clients are funnelled through a relatively small set of routers, FC can have the following scenario:

1. Many FCs doing low QPS high batch size multi-key workload. e.g. 1-2 QPS with batch size of 500.

2. RetryManager will calculate to have the refill amount to be at least 1 for the token bucket.

3. If the long tail retry threshold for batch get is misconfigured and we are constantly retrying on all keys then we are not really limiting the retries to be 10% of traffic. The KPS will double for 1 QPS, 50% for 2 QPS and so on. The impact could be significant when there are many FCs with low QPS. The excessive retry could be triggered by bad configs or degrading servers. Both were the intended scenario for retry budget.

Enforcing the retry budget at key level for multi-key requests in FC for best attempt to keep retry traffic around 10% (current config) of user traffic.

## How was this PR tested?
Existing unit and integration tests

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.