### PR TITLE
[server][test] Add integration test for thread pool jumping by enabling/disabling AA or WC.

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
@@ -434,6 +434,7 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
     List<Long> recordTimestampsPreOperation = rmdWithValueSchemaID != null
         ? RmdUtils.extractTimestampFromRmd(rmdWithValueSchemaID.getRmdRecord())
         : Collections.singletonList(0L);
+
     // get the source offset and the id
     long sourceOffset = consumerRecord.getOffset();
     final MergeConflictResult mergeConflictResult;

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ConsumptionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ConsumptionTask.java
@@ -44,6 +44,7 @@ import org.apache.logging.log4j.Logger;
 class ConsumptionTask implements Runnable {
   private final Logger LOGGER;
   private final int taskId;
+  private final String consumptionTaskIdStr;
   private final Map<PubSubTopicPartition, ConsumedDataReceiver<List<PubSubMessage<KafkaKey, KafkaMessageEnvelope, Long>>>> dataReceiverMap =
       new VeniceConcurrentHashMap<>();
   private final long readCycleDelayMs;
@@ -79,7 +80,7 @@ class ConsumptionTask implements Runnable {
   public final static long DEFAULT_TOPIC_PARTITION_NO_POLL_TIMESTAMP = -1L;
 
   public ConsumptionTask(
-      final String kafkaUrl,
+      final String consumerNamePrefix,
       final int taskId,
       final long readCycleDelayMs,
       final Supplier<Map<PubSubTopicPartition, List<PubSubMessage<KafkaKey, KafkaMessageEnvelope, Long>>>> pollFunction,
@@ -87,15 +88,15 @@ class ConsumptionTask implements Runnable {
       final IntConsumer recordsThrottler,
       final AggKafkaConsumerServiceStats aggStats,
       final ConsumerSubscriptionCleaner cleaner) {
-    this.taskId = taskId;
     this.readCycleDelayMs = readCycleDelayMs;
     this.pollFunction = pollFunction;
     this.bandwidthThrottler = bandwidthThrottler;
     this.recordsThrottler = recordsThrottler;
     this.aggStats = aggStats;
     this.cleaner = cleaner;
-    String kafkaUrlForLogger = Utils.getSanitizedStringForLogger(kafkaUrl);
-    this.LOGGER = LogManager.getLogger(getClass().getSimpleName() + "[ " + kafkaUrlForLogger + " - " + taskId + " ]");
+    this.taskId = taskId;
+    this.consumptionTaskIdStr = Utils.getSanitizedStringForLogger(consumerNamePrefix) + " - " + taskId;
+    this.LOGGER = LogManager.getLogger(getClass().getSimpleName() + "[ " + consumptionTaskIdStr + " ]");
   }
 
   @Override
@@ -233,6 +234,10 @@ class ConsumptionTask implements Runnable {
 
   int getTaskId() {
     return taskId;
+  }
+
+  String getTaskIdStr() {
+    return consumptionTaskIdStr;
   }
 
   void setDataReceiver(

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/TopicPartitionIngestionInfo.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/TopicPartitionIngestionInfo.java
@@ -9,7 +9,7 @@ public class TopicPartitionIngestionInfo {
   private long offsetLag;
   private double msgRate;
   private double byteRate;
-  private int consumerIdx;
+  private String consumerIdStr;
   private long elapsedTimeSinceLastPollInMs;
 
   private String versionTopicName;
@@ -20,14 +20,14 @@ public class TopicPartitionIngestionInfo {
       @JsonProperty("offsetLag") long offsetLag,
       @JsonProperty("msgRate") double msgRate,
       @JsonProperty("byteRate") double byteRate,
-      @JsonProperty("consumerIdx") int consumerIdx,
+      @JsonProperty("consumerIdStr") String consumerIdStr,
       @JsonProperty("elapsedTimeSinceLastPollInMs") long elapsedTimeSinceLastPollInMs,
       @JsonProperty("versionTopicName") String versionTopicName) {
     this.latestOffset = latestOffset;
     this.offsetLag = offsetLag;
     this.msgRate = msgRate;
     this.byteRate = byteRate;
-    this.consumerIdx = consumerIdx;
+    this.consumerIdStr = consumerIdStr;
     this.elapsedTimeSinceLastPollInMs = elapsedTimeSinceLastPollInMs;
     this.versionTopicName = versionTopicName;
   }
@@ -60,12 +60,12 @@ public class TopicPartitionIngestionInfo {
     this.byteRate = byteRate;
   }
 
-  public int getConsumerIdx() {
-    return consumerIdx;
+  public String getConsumerIdStr() {
+    return consumerIdStr;
   }
 
-  public void setConsumerIdx(int consumerIdx) {
-    this.consumerIdx = consumerIdx;
+  public void setConsumerIdStr(String consumerIdStr) {
+    this.consumerIdStr = consumerIdStr;
   }
 
   public long getElapsedTimeSinceLastPollInMs() {
@@ -97,7 +97,7 @@ public class TopicPartitionIngestionInfo {
         && this.offsetLag == topicPartitionIngestionInfo.getOffsetLag()
         && Double.doubleToLongBits(this.msgRate) == Double.doubleToLongBits(topicPartitionIngestionInfo.getMsgRate())
         && Double.doubleToLongBits(this.byteRate) == Double.doubleToLongBits(topicPartitionIngestionInfo.getByteRate())
-        && this.consumerIdx == topicPartitionIngestionInfo.getConsumerIdx()
+        && this.consumerIdStr.equals(topicPartitionIngestionInfo.getConsumerIdStr())
         && this.elapsedTimeSinceLastPollInMs == topicPartitionIngestionInfo.getElapsedTimeSinceLastPollInMs()
         && this.versionTopicName.equals(topicPartitionIngestionInfo.getVersionTopicName());
   }
@@ -108,7 +108,7 @@ public class TopicPartitionIngestionInfo {
     result = 31 * result + Long.hashCode(offsetLag);
     result = 31 * result + Double.hashCode(msgRate);
     result = 31 * result + Double.hashCode(byteRate);
-    result = 31 * result + consumerIdx;
+    result = 31 * result + consumerIdStr.hashCode();
     result = 31 * result + Long.hashCode(elapsedTimeSinceLastPollInMs);
     result = 31 * result + versionTopicName.hashCode();
     return result;

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/TopicPartitionIngestionInfoTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/consumer/TopicPartitionIngestionInfoTest.java
@@ -20,7 +20,7 @@ public class TopicPartitionIngestionInfoTest {
   public void testJsonParse() throws Exception {
     PubSubTopic versionTopic = pubSubTopicRepository.getTopic("test_store_v1");
     TopicPartitionIngestionInfo topicPartitionIngestionInfo =
-        new TopicPartitionIngestionInfo(0, 1, 2.0, 4.0, 5, 7, versionTopic.getName());
+        new TopicPartitionIngestionInfo(0, 1, 2.0, 4.0, "consumerIdStr", 7, versionTopic.getName());
     String kafkaUrl = "localhost:1234";
     PubSubTopicPartition pubSubTopicPartition = new PubSubTopicPartitionImpl(versionTopic, 0);
     Map<String, Map<String, TopicPartitionIngestionInfo>> topicPartitionIngestionContext = new HashMap<>();

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/KafkaConsumerServiceTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/KafkaConsumerServiceTest.java
@@ -57,6 +57,7 @@ public class KafkaConsumerServiceTest {
 
   @Test
   public void testTopicWiseGetConsumer() throws Exception {
+    String testKafkaClusterAlias = "test_kafka_cluster_alias";
     ApacheKafkaConsumerAdapter consumer1 = mock(ApacheKafkaConsumerAdapter.class);
     when(consumer1.hasAnySubscription()).thenReturn(true);
 
@@ -93,7 +94,7 @@ public class KafkaConsumerServiceTest {
         mock(IngestionThrottler.class),
         mock(KafkaClusterBasedRecordThrottler.class),
         mockMetricsRepository,
-        "test_kafka_cluster_alias",
+        testKafkaClusterAlias,
         TimeUnit.MINUTES.toMillis(1),
         mock(TopicExistenceChecker.class),
         false,
@@ -152,6 +153,7 @@ public class KafkaConsumerServiceTest {
     when(factory.create(any(), anyBoolean(), any(), any())).thenReturn(consumer1);
 
     Properties properties = new Properties();
+    String testKafkaUrl = "test_kafka_url";
     properties.put(KAFKA_BOOTSTRAP_SERVERS, "test_kafka_url");
     MetricsRepository mockMetricsRepository = mock(MetricsRepository.class);
     final Sensor mockSensor = mock(Sensor.class);
@@ -201,7 +203,8 @@ public class KafkaConsumerServiceTest {
           consumerService.getIngestionInfoFromConsumer(versionTopic, topicPartition);
       Assert.assertEquals(topicPartitionIngestionInfoMap.size(), 1);
       Assert.assertTrue(topicPartitionIngestionInfoMap.containsKey(topicPartition));
-      Assert.assertTrue(topicPartitionIngestionInfoMap.get(topicPartition).getConsumerIdx() == 0);
+      Assert.assertTrue(topicPartitionIngestionInfoMap.get(topicPartition).getConsumerIdStr().contains("0"));
+      Assert.assertTrue(topicPartitionIngestionInfoMap.get(topicPartition).getConsumerIdStr().contains(testKafkaUrl));
       Assert.assertTrue(topicPartitionIngestionInfoMap.get(topicPartition).getMsgRate() > 0);
       Assert.assertTrue(topicPartitionIngestionInfoMap.get(topicPartition).getByteRate() > 0);
       Assert.assertEquals(


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Summary, imperative, start upper case, don't end with a period
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

### `PartialUpdateTest#testEnablePartialUpdateOnActiveActiveStore` change
This PR adds an integration test support for verifying the pool jumping strategy: `KafkaConsumerServiceDelegator.ConsumerPoolStrategyType.CURRENT_VERSION_PRIORITIZATION`, when version role and workload type changed.  

### `ConsumptionTask` change
We also add consumer pool name into the `ConsumptionTask`'s id string, we are able to know the consumer thread comes from a certain pool. This will ensure `TopicPartitionIngestionContext` contains the `ConsumptionTask`'s id string for certain topic partition belonging to a specific version topic. To assert the pool changed or not, we rely on previous debugging method by querying `TopicPartitionIngestionContext` from server host. 




## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [*] No. You can skip the rest of this section.
- [] Yes. Make sure to explain your proposed changes and call out the behavior change.