### PR TITLE
[server] Enforce Record Size Limit on Nearline Jobs / Partial Update

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
@@ -702,7 +702,7 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
    * This function may modify the original record in KME and it is unsafe to use the payload from KME directly after
    * this function.
    *
-   * @param mergeConflictResult         The result of conflict resolution.
+   * @param mergeConflictResult       The result of conflict resolution.
    * @param partitionConsumptionState The {@link PartitionConsumptionState} of the current partition
    * @param key                       The key bytes of the incoming record.
    * @param consumerRecord            The {@link PubSubMessage} for the current record.

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTask.java
@@ -1474,9 +1474,14 @@ public class ActiveActiveStoreIngestionTask extends LeaderFollowerStoreIngestion
         LOGGER.error(errorMessage, partition, kafkaVersionTopic, e);
 
         // TODO: Or should this be pausing for all partitions for a topic? Would this be a performance issue?
-        storageUtilizationManager.pausePartitionForRecordTooLarge(partition, kafkaVersionTopic);
+        // TODO: should an exception be thrown here, or is it safe to proceed?
+        getStorageUtilizationManager().pausePartitionForRecordTooLarge(partition, kafkaVersionTopic);
       }
     };
+  }
+
+  protected StorageUtilizationManager getStorageUtilizationManager() {
+    return storageUtilizationManager;
   }
 
   protected LeaderProducerCallback createProducerCallback(

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -267,9 +267,15 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
         nativeReplicationSourceVersionTopicKafkaURL,
         getVersionTopic());
 
-    int storeMaxRecordSize = store.getMaxRecordSizeBytes();
-    int maxRecordSizeBytes =
-        (storeMaxRecordSize < 0) ? serverConfig.getDefaultMaxRecordSizeBytes() : storeMaxRecordSize;
+    int maxRecordSizeBytes = store.getMaxRecordSizeBytes();
+    if (maxRecordSizeBytes < 0) {
+      LOGGER.warn(
+          "Max record size: {} was set to invalid value for store: {}. using default max record size: {}",
+          maxRecordSizeBytes,
+          store.getName(),
+          serverConfig.getDefaultMaxRecordSizeBytes());
+      maxRecordSizeBytes = serverConfig.getDefaultMaxRecordSizeBytes();
+    }
 
     this.veniceWriterFactory = builder.getVeniceWriterFactory();
     /**

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -3153,6 +3153,7 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
       LeaderProducedRecordContext leaderProducedRecordContext =
           LeaderProducedRecordContext.newPutRecord(kafkaClusterId, consumerRecord.getOffset(), keyBytes, updatedPut);
 
+      // TODO: does the catch RecordTooLargeException need to be in LFSIT too?
       BiConsumer<ChunkAwareCallback, LeaderMetadataWrapper> produceFunction =
           (callback, leaderMetadataWrapper) -> veniceWriter.get()
               .put(

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -1908,7 +1908,7 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
   @Override
   protected final void recordAssembledRecordSizeRatio(double ratio, long currentTimeMs) {
     int maxRecordSizeBytes = veniceWriter.get().getMaxRecordSizeBytes();
-    if (maxRecordSizeBytes != VeniceWriter.UNLIMITED_MAX_RECORD_SIZE) {
+    if (maxRecordSizeBytes != VeniceWriter.UNLIMITED_MAX_RECORD_SIZE && ratio > 0) {
       hostLevelIngestionStats.recordAssembledRecordSizeRatio(ratio, currentTimeMs);
     }
   }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StorageUtilizationManager.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StorageUtilizationManager.java
@@ -203,7 +203,7 @@ public class StorageUtilizationManager implements StoreDataChangedListener {
           this.storeQuotaInBytes,
           store.getStorageQuotaInByte(),
           store.isHybridStoreDiskQuotaEnabled() ? "enabled" : "not enabled");
-      resumeAllPartitionsIfPossible(PausedConsumptionReason.QUOTA_EXCEEDED);
+      resumeAllPartitionsWherePossible(PausedConsumptionReason.QUOTA_EXCEEDED);
     }
 
     int oldMaxRecordSizeBytes = this.maxRecordSizeBytes.get();
@@ -214,9 +214,11 @@ public class StorageUtilizationManager implements StoreDataChangedListener {
           this.storeName,
           oldMaxRecordSizeBytes,
           store.getMaxRecordSizeBytes(),
-          (isRecordLimitIncreased) ? "Resuming consumption on all partitions paused by RecordTooLarge issue." : "");
+          (isRecordLimitIncreased)
+              ? "Attempting to resume consumption on all partitions paused by RecordTooLarge issue."
+              : "");
       if (isRecordLimitIncreased) {
-        resumeAllPartitionsIfPossible(PausedConsumptionReason.RECORD_TOO_LARGE);
+        resumeAllPartitionsWherePossible(PausedConsumptionReason.RECORD_TOO_LARGE);
       }
     }
 
@@ -375,7 +377,7 @@ public class StorageUtilizationManager implements StoreDataChangedListener {
    * any partitions missing from {@link pausedPartitionsForQuotaExceeded} or {@link pausedPartitionsForRecordTooLarge}.
    * In the unlikely case that partition is paused for both reasons, we can't resume it until both reasons are resolved.
    */
-  private void resumeAllPartitionsIfPossible(PausedConsumptionReason reason) {
+  private void resumeAllPartitionsWherePossible(PausedConsumptionReason reason) {
     partitionConsumptionStateMap.forEach((partition, pcs) -> {
       String consumingTopic = getConsumingTopic(pcs);
       resumePartitionIfPossible(partition, consumingTopic, reason);

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StorageUtilizationManager.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StorageUtilizationManager.java
@@ -196,24 +196,24 @@ public class StorageUtilizationManager implements StoreDataChangedListener {
     versionIsOnline = isVersionOnline(version);
     if (this.storeQuotaInBytes != store.getStorageQuotaInByte() || !store.isHybridStoreDiskQuotaEnabled()) {
       LOGGER.info(
-          "Store: {} changed, updated quota from {} to {} and store quota is {} enabled, "
+          "Store: {} changed, updated quota from {} to {} and store quota is {}, "
               + "so we reset the store quota and resume all partitions.",
           this.storeName,
           this.storeQuotaInBytes,
           store.getStorageQuotaInByte(),
-          store.isHybridStoreDiskQuotaEnabled() ? "" : "not ");
+          store.isHybridStoreDiskQuotaEnabled() ? "enabled" : "not enabled");
       resumeAllPartitions(PausedConsumptionReason.QUOTA_EXCEEDED);
     }
 
-    final int oldMaxRecordSizeBytes = this.maxRecordSizeBytes.get();
+    int oldMaxRecordSizeBytes = this.maxRecordSizeBytes.get();
     if (this.maxRecordSizeBytes.compareAndSet(oldMaxRecordSizeBytes, store.getMaxRecordSizeBytes())) {
-      final boolean isRecordLimitIncreased = oldMaxRecordSizeBytes < store.getMaxRecordSizeBytes();
+      boolean isRecordLimitIncreased = oldMaxRecordSizeBytes < store.getMaxRecordSizeBytes();
       LOGGER.info(
-          "Store: {} changed, updated max record size from {} to {}{}.",
+          "Store: {} changed, updated max record size from {} to {}. {}",
           this.storeName,
           oldMaxRecordSizeBytes,
           store.getMaxRecordSizeBytes(),
-          (isRecordLimitIncreased) ? ", so we resume all partitions" : "");
+          (isRecordLimitIncreased) ? "Resuming consumption on all partitions paused by RecordTooLarge issue." : "");
       if (isRecordLimitIncreased) {
         resumeAllPartitions(PausedConsumptionReason.RECORD_TOO_LARGE);
       }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StorageUtilizationManager.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StorageUtilizationManager.java
@@ -94,6 +94,7 @@ public class StorageUtilizationManager implements StoreDataChangedListener {
    *              stale when the store config changes. Refreshing the things we need out of the store object
    *              is handled in {@link #handleStoreChanged(Store)}.
    */
+  // TODO: rename class after PR is reviewed because it's no longer just about hybrid quota
   public StorageUtilizationManager(
       AbstractStorageEngine storageEngine,
       Store store,
@@ -131,6 +132,7 @@ public class StorageUtilizationManager implements StoreDataChangedListener {
     versionIsOnline = isVersionOnline(version);
   }
 
+  // TODO: possibly better naming?
   protected enum PausedConsumptionReason {
     QUOTA_EXCEEDED, RECORD_TOO_LARGE
   }
@@ -350,7 +352,7 @@ public class StorageUtilizationManager implements StoreDataChangedListener {
    * After the partition gets paused, consumer.poll() in {@link StoreIngestionTask} won't return any records from this
    * partition without affecting partition subscription
    */
-  private void pausePartition(int partition, String consumingTopic, PausedConsumptionReason reason) {
+  protected void pausePartition(int partition, String consumingTopic, PausedConsumptionReason reason) {
     getPausedPartitionsForReason(reason).add(partition);
     pausePartition.execute(consumingTopic, partition);
   }
@@ -401,6 +403,10 @@ public class StorageUtilizationManager implements StoreDataChangedListener {
       }
     }
     return consumingTopic;
+  }
+
+  protected boolean isPartitionPausedForReason(int partition, PausedConsumptionReason reason) {
+    return getPausedPartitionsForReason(reason).contains(partition);
   }
 
   protected boolean isPartitionPausedForRecordTooLarge(int partition) {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StorageUtilizationManager.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StorageUtilizationManager.java
@@ -16,7 +16,6 @@ import com.linkedin.venice.utils.locks.AutoCloseableLock;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
@@ -56,7 +55,7 @@ public class StorageUtilizationManager implements StoreDataChangedListener {
   private static final Logger LOGGER = LogManager.getLogger(StorageUtilizationManager.class);
   private static final RedundantExceptionFilter REDUNDANT_LOGGING_FILTER = getRedundantExceptionFilter();
 
-  private final ConcurrentMap<Integer, PartitionConsumptionState> partitionConsumptionStateMap;
+  private final Map<Integer, PartitionConsumptionState> partitionConsumptionStateMap; // UnmodifiableMap
   private final AbstractStorageEngine storageEngine;
   private final Function<Integer, StoragePartitionDiskUsage> storagePartitionDiskUsageFunctionConstructor;
   private final String versionTopic;
@@ -100,7 +99,7 @@ public class StorageUtilizationManager implements StoreDataChangedListener {
       Store store,
       String versionTopic,
       int partitionCount,
-      ConcurrentMap<Integer, PartitionConsumptionState> partitionConsumptionStateMap,
+      Map<Integer, PartitionConsumptionState> partitionConsumptionStateMap,
       boolean isHybridQuotaEnabledInServer,
       boolean isServerCalculateQuotaUsageBasedOnPartitionsAssignmentEnabled,
       IngestionNotificationDispatcher ingestionNotificationDispatcher,

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -262,7 +262,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
   protected final SparseConcurrentList<Object> deserializedSchemaIds = new SparseConcurrentList<>();
   protected int idleCounter = 0;
 
-  private final StorageUtilizationManager storageUtilizationManager;
+  protected final StorageUtilizationManager storageUtilizationManager;
 
   protected final AggKafkaConsumerService aggKafkaConsumerService;
 
@@ -470,7 +470,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
         store,
         kafkaVersionTopic,
         partitionCount,
-        Collections.unmodifiableMap(partitionConsumptionStateMap),
+        (ConcurrentMap<Integer, PartitionConsumptionState>) Collections.unmodifiableMap(partitionConsumptionStateMap),
         serverConfig.isHybridQuotaEnabled(),
         serverConfig.isServerCalculateQuotaUsageBasedOnPartitionsAssignmentEnabled(),
         ingestionNotificationDispatcher,
@@ -1282,7 +1282,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
      * are available records, this function needs to check whether we need to resume the consumption when there are
      * paused consumption because of hybrid quota violation.
      */
-    if (storageUtilizationManager.hasPausedPartitionIngestion()) {
+    if (storageUtilizationManager.hasPausedPartitionForQuotaExceeded()) {
       storageUtilizationManager.checkAllPartitionsQuota();
     }
     Thread.sleep(readCycleDelayMs);

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -2445,7 +2445,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
     try {
       byte[] valueByteArray = ByteUtils.extractByteArray(valueBytes);
       ChunkedValueManifest valueManifest = manifestSerializer.deserialize(valueByteArray, CHUNK_MANIFEST_SCHEMA_ID);
-      int recordSize = keyLen + valueManifest.getSize();
+      long recordSize = keyLen + valueManifest.getSize();
       hostLevelIngestionStats.recordAssembledRecordSize(recordSize, currentTimeMs);
       recordAssembledRecordSizeRatio(calculateAssembledRecordSizeRatio(recordSize), currentTimeMs);
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -470,7 +470,7 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
         store,
         kafkaVersionTopic,
         partitionCount,
-        (ConcurrentMap<Integer, PartitionConsumptionState>) Collections.unmodifiableMap(partitionConsumptionStateMap),
+        Collections.unmodifiableMap(partitionConsumptionStateMap),
         serverConfig.isHybridQuotaEnabled(),
         serverConfig.isServerCalculateQuotaUsageBasedOnPartitionsAssignmentEnabled(),
         ingestionNotificationDispatcher,
@@ -3217,13 +3217,13 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
     aggKafkaConsumerService.resetOffsetFor(versionTopic, new PubSubTopicPartitionImpl(topic, partitionId));
   }
 
-  protected void pauseConsumption(String topic, int partitionId) {
+  private void pauseConsumption(String topic, int partitionId) {
     aggKafkaConsumerService.pauseConsumerFor(
         versionTopic,
         new PubSubTopicPartitionImpl(pubSubTopicRepository.getTopic(topic), partitionId));
   }
 
-  protected void resumeConsumption(String topic, int partitionId) {
+  private void resumeConsumption(String topic, int partitionId) {
     aggKafkaConsumerService.resumeConsumerFor(
         versionTopic,
         new PubSubTopicPartitionImpl(pubSubTopicRepository.getTopic(topic), partitionId));

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -3217,13 +3217,13 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
     aggKafkaConsumerService.resetOffsetFor(versionTopic, new PubSubTopicPartitionImpl(topic, partitionId));
   }
 
-  private void pauseConsumption(String topic, int partitionId) {
+  protected void pauseConsumption(String topic, int partitionId) {
     aggKafkaConsumerService.pauseConsumerFor(
         versionTopic,
         new PubSubTopicPartitionImpl(pubSubTopicRepository.getTopic(topic), partitionId));
   }
 
-  private void resumeConsumption(String topic, int partitionId) {
+  protected void resumeConsumption(String topic, int partitionId) {
     aggKafkaConsumerService.resumeConsumerFor(
         versionTopic,
         new PubSubTopicPartitionImpl(pubSubTopicRepository.getTopic(topic), partitionId));

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTaskTest.java
@@ -293,8 +293,9 @@ public class ActiveActiveStoreIngestionTaskTest {
     when(ingestionTask.getKafkaVersionTopic()).thenReturn(testTopic);
     when(ingestionTask.createProducerCallback(any(), any(), any(), anyInt(), anyString(), anyLong()))
         .thenCallRealMethod();
-    when(ingestionTask.getProduceToTopicFunction(any(), any(), any(), any(), any(), anyInt(), anyBoolean()))
-        .thenCallRealMethod();
+    when(
+        ingestionTask.getProduceToTopicFunction(any(), any(), any(), any(), any(), anyInt(), anyString(), anyBoolean()))
+            .thenCallRealMethod();
     when(ingestionTask.getRmdProtocolVersionId()).thenReturn(rmdProtocolVersionID);
     doCallRealMethod().when(ingestionTask)
         .produceToLocalKafka(any(), any(), any(), any(), anyInt(), anyString(), anyInt(), anyLong());
@@ -377,6 +378,7 @@ public class ActiveActiveStoreIngestionTaskTest {
             null,
             null,
             valueSchemaId,
+            testTopic,
             resultReuseInput),
         partition,
         kafkaUrl,

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTaskTest.java
@@ -293,9 +293,8 @@ public class ActiveActiveStoreIngestionTaskTest {
     when(ingestionTask.getKafkaVersionTopic()).thenReturn(testTopic);
     when(ingestionTask.createProducerCallback(any(), any(), any(), anyInt(), anyString(), anyLong()))
         .thenCallRealMethod();
-    when(
-        ingestionTask.getProduceToTopicFunction(any(), any(), any(), any(), any(), anyInt(), anyString(), anyBoolean()))
-            .thenCallRealMethod();
+    when(ingestionTask.getProduceToTopicFunction(any(), any(), any(), any(), any(), anyInt(), anyInt(), anyBoolean()))
+        .thenCallRealMethod();
     when(ingestionTask.getRmdProtocolVersionId()).thenReturn(rmdProtocolVersionID);
     doCallRealMethod().when(ingestionTask)
         .produceToLocalKafka(any(), any(), any(), any(), anyInt(), anyString(), anyInt(), anyLong());
@@ -378,7 +377,7 @@ public class ActiveActiveStoreIngestionTaskTest {
             null,
             null,
             valueSchemaId,
-            testTopic,
+            partition,
             resultReuseInput),
         partition,
         kafkaUrl,

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StorageUtilizationManagerTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StorageUtilizationManagerTest.java
@@ -98,7 +98,7 @@ public class StorageUtilizationManagerTest {
     addUsageToAllPartitions(20);
     verify(ingestionNotificationDispatcher, times(storePartitionCount)).reportQuotaViolated(any());
     for (int i = 1; i <= storePartitionCount; i++) {
-      Assert.assertTrue(quotaEnforcer.isPartitionPausedIngestion(i));
+      Assert.assertTrue(quotaEnforcer.isPartitionPausedForQuotaExceeded(i));
       PartitionConsumptionState partitionConsumptionState = partitionConsumptionStateMap.get(i);
       verify(ingestionNotificationDispatcher).reportQuotaViolated(partitionConsumptionState);
     }
@@ -107,7 +107,7 @@ public class StorageUtilizationManagerTest {
     when(store.isHybridStoreDiskQuotaEnabled()).thenReturn(false);
     quotaEnforcer.handleStoreChanged(store);
     for (int i = 1; i <= storePartitionCount; i++) {
-      Assert.assertFalse(quotaEnforcer.isPartitionPausedIngestion(i));
+      Assert.assertFalse(quotaEnforcer.isPartitionPausedForQuotaExceeded(i));
       // Expect a new round of QuotaNotViolate are reported.
       PartitionConsumptionState partitionConsumptionState = partitionConsumptionStateMap.get(i);
       verify(ingestionNotificationDispatcher, times(2)).reportQuotaNotViolated(partitionConsumptionState);
@@ -131,7 +131,7 @@ public class StorageUtilizationManagerTest {
     setUpOnlineVersion();
     addUsageToAllPartitions(5);
     for (int i = 1; i <= storePartitionCount; i++) {
-      Assert.assertFalse(quotaEnforcer.isPartitionPausedIngestion(i));
+      Assert.assertFalse(quotaEnforcer.isPartitionPausedForQuotaExceeded(i));
     }
   }
 
@@ -143,7 +143,7 @@ public class StorageUtilizationManagerTest {
     addUsageToAllPartitions(10);
     verify(ingestionNotificationDispatcher, times(storePartitionCount)).reportQuotaViolated(any());
     for (int i = 1; i <= storePartitionCount; i++) {
-      Assert.assertTrue(quotaEnforcer.isPartitionPausedIngestion(i));
+      Assert.assertTrue(quotaEnforcer.isPartitionPausedForQuotaExceeded(i));
       PartitionConsumptionState partitionConsumptionState = partitionConsumptionStateMap.get(i);
       verify(ingestionNotificationDispatcher).reportQuotaViolated(partitionConsumptionState);
     }
@@ -151,14 +151,14 @@ public class StorageUtilizationManagerTest {
     // The later same partitions consumptions should be paused too even with size zero
     addUsageToAllPartitions(0);
     for (int i = 1; i <= storePartitionCount; i++) {
-      Assert.assertTrue(quotaEnforcer.isPartitionPausedIngestion(i));
+      Assert.assertTrue(quotaEnforcer.isPartitionPausedForQuotaExceeded(i));
     }
 
     // check after store change and bumping quota, paused partition should be resumed
     when(store.getStorageQuotaInByte()).thenReturn(newStoreQuotaInBytes);
     quotaEnforcer.handleStoreChanged(store);
     for (int i = 1; i <= storePartitionCount; i++) {
-      Assert.assertFalse(quotaEnforcer.isPartitionPausedIngestion(i));
+      Assert.assertFalse(quotaEnforcer.isPartitionPausedForQuotaExceeded(i));
     }
   }
 
@@ -175,7 +175,7 @@ public class StorageUtilizationManagerTest {
     }
     verify(ingestionNotificationDispatcher, times(storePartitionCount)).reportCompleted(any());
     for (int i = 1; i <= storePartitionCount; i++) {
-      Assert.assertTrue(quotaEnforcer.isPartitionPausedIngestion(i));
+      Assert.assertTrue(quotaEnforcer.isPartitionPausedForQuotaExceeded(i));
       verify(ingestionNotificationDispatcher).reportCompleted(argThat(new PartitionNumberMatcher(i)));
     }
   }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/PartialUpdateTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/PartialUpdateTest.java
@@ -1390,8 +1390,7 @@ public class PartialUpdateTest {
     sendStreamingDeleteRecord(veniceProducer, storeName, key1, 10001L);
     sendStreamingRecord(veniceProducer, storeName, key2, updateBuilder.build(), 10001L);
 
-    Properties props =
-        IntegrationTestPushUtils.defaultVPJProps(multiRegionMultiClusterWrapper, "dummyInputPath", storeName);
+    Properties props = defaultVPJProps(multiRegionMultiClusterWrapper, "dummyInputPath", storeName);
     props.setProperty(SOURCE_KAFKA, "true");
     props.setProperty(KAFKA_INPUT_BROKER_URL, veniceCluster.getPubSubBrokerWrapper().getAddress());
     props.setProperty(KAFKA_INPUT_MAX_RECORDS_PER_MAPPER, "5");

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/PartialUpdateTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/PartialUpdateTest.java
@@ -505,8 +505,7 @@ public class PartialUpdateTest {
     String keySchemaStr = recordSchema.getField(DEFAULT_KEY_FIELD_PROP).schema().toString();
     String valueSchemaStr = recordSchema.getField(DEFAULT_VALUE_FIELD_PROP).schema().toString();
     String inputDirPath = "file://" + inputDir.getAbsolutePath();
-    Properties vpjProperties =
-        IntegrationTestPushUtils.defaultVPJProps(multiRegionMultiClusterWrapper, inputDirPath, storeName);
+    Properties vpjProperties = defaultVPJProps(multiRegionMultiClusterWrapper, inputDirPath, storeName);
 
     Schema valueSchema = AvroCompatibilityHelper.parse(valueSchemaStr);
     Schema writeComputeSchema = WriteComputeSchemaConverter.getInstance().convertFromValueRecordSchema(valueSchema);


### PR DESCRIPTION
## Summary

1. **[Functional]** Added a `catch RecordTooLargeException` clause for `VeniceWriter#put()` in `ActiveActiveStoreIngestionTask` for the expected partial update code path. When the exception is caught, consumption will be paused for the partition and a user will need to work with the Venice team to get it resolved by bumping up the size limit `maxRecordSizeBytes`.
2. **[Functional]**  In `StorageUtilizationManager`, added pausing and resuming consumption on partitions for `RecordTooLarge` issues. If the store-level config `maxRecordSizeBytes` is increased, `StorageUtilizationManager` will try to resume consumption for all partitions paused due to `RecordTooLarge`. Partitions must not be paused for either `RecordTooLarge` or `QuotaExceeded` in order to be allowed to resume consumption.
3. **[Config]** Moved `maxRecordSizeBytes` from its temporary position within `LeaderFollowerStoreIngestionTask` into its final position within `VeniceWriter`.
4. **[Unit Test]** Added to existing test `testLeaderCanSendValueChunksIntoDrainer()` in `ActiveActiveStoreIngestionTaskTest` to verify that partitions are paused when a large record is detected.
5. **[Unit Test]** `TestPausePartitionForRecordTooLage()` and `testPartialResumePartitions()` in `StorageUtilizationManagerTest` verifies that partitions are paused and resumed accordingly, even despite the interactions with Hybrid Quota.
6. **[Integration Test]** `testLargeValuesPartialUpdate()` in `PartialUpdateTest` verifies that `RecordTooLargeException` is thrown on the nearline path.

TODO: Add an integration test that covers the interaction between hybrid quota and this

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

Unit tests:
    1. `testLeaderCanSendValueChunksIntoDrainer()` in `ActiveActiveStoreIngestionTaskTest`
    2. `TestPausePartitionForRecordTooLage()` and `testPartialResumePartitions()` in `StorageUtilizationManagerTest`
Integration Tests:
    1. `testLargeValuesPartialUpdate()` in `PartialUpdateTest`

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [X] Yes. Make sure to explain your proposed changes and call out the behavior change.