### PR TITLE
[fast-client][router] Fixed one slow start issue

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
@@ -151,6 +151,11 @@ import static com.linkedin.venice.ConfigKeys.SYSTEM_SCHEMA_INITIALIZATION_AT_STA
 import static com.linkedin.venice.ConfigKeys.UNREGISTER_METRIC_FOR_DELETED_STORE_ENABLED;
 import static com.linkedin.venice.ConfigKeys.UNSORTED_INPUT_DRAINER_SIZE;
 import static com.linkedin.venice.ConfigKeys.USE_DA_VINCI_SPECIFIC_EXECUTION_STATUS_FOR_ERROR;
+import static com.linkedin.venice.httpclient5.HttpClient5Utils.H2_HEADER_TABLE_SIZE;
+import static com.linkedin.venice.httpclient5.HttpClient5Utils.H2_INITIAL_WINDOW_SIZE;
+import static com.linkedin.venice.httpclient5.HttpClient5Utils.H2_MAX_CONCURRENT_STREAMS;
+import static com.linkedin.venice.httpclient5.HttpClient5Utils.H2_MAX_FRAME_SIZE;
+import static com.linkedin.venice.httpclient5.HttpClient5Utils.H2_MAX_HEADER_LIST_SIZE;
 import static com.linkedin.venice.pubsub.PubSubConstants.PUBSUB_TOPIC_MANAGER_METADATA_FETCHER_CONSUMER_POOL_SIZE_DEFAULT_VALUE;
 import static com.linkedin.venice.utils.ByteUtils.BYTES_PER_MB;
 import static com.linkedin.venice.utils.ByteUtils.generateHumanReadableByteCountString;
@@ -710,11 +715,11 @@ public class VeniceServerConfig extends VeniceClusterConfig {
     unsubscribeAfterBatchpushEnabled = serverProperties.getBoolean(SERVER_UNSUB_AFTER_BATCHPUSH, false);
 
     http2InboundEnabled = serverProperties.getBoolean(SERVER_HTTP2_INBOUND_ENABLED, false);
-    http2MaxConcurrentStreams = serverProperties.getInt(SERVER_HTTP2_MAX_CONCURRENT_STREAMS, 100);
-    http2MaxFrameSize = serverProperties.getInt(SERVER_HTTP2_MAX_FRAME_SIZE, 8 * 1024 * 1024);
-    http2InitialWindowSize = serverProperties.getInt(SERVER_HTTP2_INITIAL_WINDOW_SIZE, 8 * 1024 * 1024);
-    http2HeaderTableSize = serverProperties.getInt(SERVER_HTTP2_HEADER_TABLE_SIZE, 4096);
-    http2MaxHeaderListSize = serverProperties.getInt(SERVER_HTTP2_MAX_HEADER_LIST_SIZE, 8192);
+    http2MaxConcurrentStreams = serverProperties.getInt(SERVER_HTTP2_MAX_CONCURRENT_STREAMS, H2_MAX_CONCURRENT_STREAMS);
+    http2MaxFrameSize = serverProperties.getInt(SERVER_HTTP2_MAX_FRAME_SIZE, H2_MAX_FRAME_SIZE);
+    http2InitialWindowSize = serverProperties.getInt(SERVER_HTTP2_INITIAL_WINDOW_SIZE, H2_INITIAL_WINDOW_SIZE);
+    http2HeaderTableSize = serverProperties.getInt(SERVER_HTTP2_HEADER_TABLE_SIZE, H2_HEADER_TABLE_SIZE);
+    http2MaxHeaderListSize = serverProperties.getInt(SERVER_HTTP2_MAX_HEADER_LIST_SIZE, H2_MAX_HEADER_LIST_SIZE);
 
     offsetLagDeltaRelaxFactorForFastOnlineTransitionInRestart =
         serverProperties.getInt(OFFSET_LAG_DELTA_RELAX_FACTOR_FOR_FAST_ONLINE_TRANSITION_IN_RESTART, 2);

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/httpclient5/HttpClient5Utils.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/httpclient5/HttpClient5Utils.java
@@ -34,6 +34,12 @@ import org.apache.hc.core5.util.Timeout;
  * TODO: follow up with the httpclient team to get a proper fix.
  */
 public class HttpClient5Utils {
+  public static final int H2_HEADER_TABLE_SIZE = 4096;
+  public static final int H2_MAX_HEADER_LIST_SIZE = 8092;
+  public static final int H2_MAX_FRAME_SIZE = 8 * 1024 * 1024;
+  public static final int H2_INITIAL_WINDOW_SIZE = 8 * 1024 * 1024;
+  public static final int H2_MAX_CONCURRENT_STREAMS = 100;
+
   public static class HttpClient5Builder {
     private SSLContext sslContext;
     private long requestTimeOutInMilliseconds = TimeUnit.SECONDS.toMillis(1); // 1s by default
@@ -159,11 +165,11 @@ public class HttpClient5Utils {
                  * for medium/large responses.
                  */
                 H2Config.initial()
-                    .setHeaderTableSize(4096)
-                    .setMaxFrameSize(8 * 1024 * 1024)
-                    .setInitialWindowSize(8 * 1024 * 1024)
-                    .setMaxHeaderListSize(8192)
-                    .setMaxConcurrentStreams(100)
+                    .setHeaderTableSize(H2_HEADER_TABLE_SIZE)
+                    .setMaxFrameSize(H2_MAX_FRAME_SIZE)
+                    .setInitialWindowSize(H2_INITIAL_WINDOW_SIZE)
+                    .setMaxHeaderListSize(H2_MAX_HEADER_LIST_SIZE)
+                    .setMaxConcurrentStreams(H2_MAX_CONCURRENT_STREAMS)
                     .build())
             .build();
       }

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/httpclient5/HttpClient5Utils.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/httpclient5/HttpClient5Utils.java
@@ -12,6 +12,7 @@ import org.apache.hc.core5.http.impl.DefaultConnectionReuseStrategy;
 import org.apache.hc.core5.http.nio.ssl.TlsStrategy;
 import org.apache.hc.core5.http.ssl.TLS;
 import org.apache.hc.core5.http2.HttpVersionPolicy;
+import org.apache.hc.core5.http2.config.H2Config;
 import org.apache.hc.core5.reactor.IOReactorConfig;
 import org.apache.hc.core5.util.Timeout;
 
@@ -150,6 +151,20 @@ public class HttpClient5Utils {
             .setIOReactorConfig(ioReactorConfig)
             .setDefaultConnectionConfig(getDefaultConnectionConfig())
             .setDefaultRequestConfig(getDefaultRequestConfig())
+            .setH2Config(
+                /**
+                 * The following settings are important to avoid the slow start issue
+                 * as if we use a small Frame/initial window setting, it will take
+                 * time to ramp them up, which would result in a slow start issue
+                 * for medium/large responses.
+                 */
+                H2Config.initial()
+                    .setHeaderTableSize(4096)
+                    .setMaxFrameSize(8 * 1024 * 1024)
+                    .setInitialWindowSize(8 * 1024 * 1024)
+                    .setMaxHeaderListSize(8192)
+                    .setMaxConcurrentStreams(100)
+                    .build())
             .build();
       }
     }


### PR DESCRIPTION


<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Summary, imperative, start upper case, don't end with a period
During the fast-client experiment, I noticed that
the fast-client will take a quite long time to stablize the latency for medim/large response.
This behavior is reproducible, but the stablization periods vary. After several rounds of experiments, I realized that this can be related to the small Http2 InitialWindow/Frame settings being used by Fast-Client. Even Venice Server is using a large config value, but the handshake will choose the small ones sent by Fast-Client, H2 can automatically adjust the setting, but it will take time and the duration is non-deterministic. So this PR will use a same set of values as Venice Server to avoid this slow start issue.
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->


## How was this PR tested?
CI and manual test.
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.