### PR TITLE
[vpj] Exclude jackson dependency from HDFS dependency

### DIFF
--- a/clients/venice-push-job/build.gradle
+++ b/clients/venice-push-job/build.gradle
@@ -31,6 +31,7 @@ dependencies {
     // Exclude transitive dependency
     exclude group: 'org.apache.avro'
     exclude group: 'javax.servlet'
+    exclude group: 'com.fasterxml.jackson'
   }
 
   implementation (libraries.apacheSparkAvro) {

--- a/clients/venice-push-job/build.gradle
+++ b/clients/venice-push-job/build.gradle
@@ -31,7 +31,7 @@ dependencies {
     // Exclude transitive dependency
     exclude group: 'org.apache.avro'
     exclude group: 'javax.servlet'
-    exclude group: 'com.fasterxml.jackson'
+    exclude group: 'com.fasterxml.jackson.core'
   }
 
   implementation (libraries.apacheSparkAvro) {

--- a/internal/venice-common/build.gradle
+++ b/internal/venice-common/build.gradle
@@ -35,7 +35,6 @@ dependencies {
   implementation libraries.conscrypt
   implementation libraries.fastUtil
   implementation libraries.httpAsyncClient
-  implementation libraries.jacksonCore
   implementation libraries.jacksonDatabind
   implementation libraries.jacksonAnnotations
   implementation libraries.kafkaClients // TODO: Get rid of Kafka dependency in venice-common


### PR DESCRIPTION
## Summary
Also reverted a7318c1d918af1d0c53214173200f9e1c254cd9c:
[controller][router][server][da-vinci] Pull jacksonCore into venice-common (#1124)


## How was this PR tested?
./gradlew assemble

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.