### PR TITLE
[server] Reuse resource names and URI object during server read request processing.

### DIFF
--- a/internal/venice-common/src/main/java/com/linkedin/venice/blobtransfer/server/P2PFileTransferServerHandler.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/blobtransfer/server/P2PFileTransferServerHandler.java
@@ -18,7 +18,6 @@ import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http.HttpChunkedInput;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpMethod;
-import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponse;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpVersion;
@@ -30,6 +29,7 @@ import io.netty.handler.timeout.IdleStateEvent;
 import java.io.File;
 import java.io.IOException;
 import java.io.RandomAccessFile;
+import java.net.URI;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -83,7 +83,7 @@ public class P2PFileTransferServerHandler extends SimpleChannelInboundHandler<Fu
     final BlobTransferPayload blobTransferRequest;
     final File snapshotDir;
     try {
-      blobTransferRequest = parseBlobTransferPayload(httpRequest);
+      blobTransferRequest = parseBlobTransferPayload(URI.create(httpRequest.uri()));
       snapshotDir = new File(blobTransferRequest.getSnapshotDir());
       if (!snapshotDir.exists() || !snapshotDir.isDirectory()) {
         byte[] errBody = ("Snapshot for " + blobTransferRequest.getFullResourceName() + " doesn't exist").getBytes();
@@ -192,9 +192,8 @@ public class P2PFileTransferServerHandler extends SimpleChannelInboundHandler<Fu
    * @param request
    * @return
    */
-  private BlobTransferPayload parseBlobTransferPayload(HttpRequest request) throws IllegalArgumentException {
+  private BlobTransferPayload parseBlobTransferPayload(URI uri) throws IllegalArgumentException {
     // Parse the request uri to obtain the storeName and partition
-    String uri = request.uri();
     String[] requestParts = RequestHelper.getRequestParts(uri);
     if (requestParts.length == 4) {
       // [0]""/[1]"store"/[2]"version"/[3]"partition"
@@ -204,7 +203,7 @@ public class P2PFileTransferServerHandler extends SimpleChannelInboundHandler<Fu
           Integer.parseInt(requestParts[2]),
           Integer.parseInt(requestParts[3]));
     } else {
-      throw new IllegalArgumentException("Invalid request for fetching blob at " + uri);
+      throw new IllegalArgumentException("Invalid request for fetching blob at " + uri.getPath());
     }
   }
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/request/RequestHelper.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/request/RequestHelper.java
@@ -9,12 +9,11 @@ public class RequestHelper {
    * @param uri
    * @return String array of the request parts
    */
-  public static String[] getRequestParts(String uri) {
+  public static String[] getRequestParts(URI fullUri) {
     /**
      * Sometimes req.uri() gives a full uri (e.g. https://host:port/path) and sometimes it only gives a path.
      * Generating a URI lets us always take just the path, but we need to add on the query string.
      */
-    URI fullUri = URI.create(uri);
     String path = fullUri.getRawPath();
     if (fullUri.getRawQuery() != null) {
       path += "?" + fullUri.getRawQuery();

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/storagenode/StorageNodeReadTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/storagenode/StorageNodeReadTest.java
@@ -340,8 +340,7 @@ public class StorageNodeReadTest {
     StringBuilder sb = new StringBuilder().append("http://")
         .append(serverAddress)
         .append("/")
-        .append(QueryAction.HEALTH.toString().toLowerCase())
-        .append("?f=b64");
+        .append(QueryAction.HEALTH.toString().toLowerCase());
     HttpGet getReq = new HttpGet(sb.toString());
     Future<HttpResponse> future = client.execute(getReq, null);
     return future.get();

--- a/services/venice-server/src/main/java/com/linkedin/venice/listener/RouterRequestHttpHandler.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/listener/RouterRequestHttpHandler.java
@@ -73,7 +73,8 @@ public class RouterRequestHttpHandler extends SimpleChannelInboundHandler<FullHt
   @Override
   protected void channelRead0(ChannelHandlerContext ctx, FullHttpRequest req) throws Exception {
     try {
-      QueryAction action = getQueryActionFromRequest(req);
+      URI uri = URI.create(req.uri());
+      QueryAction action = getQueryActionFromRequest(req, uri);
       statsHandler.setRequestSize(req.content().readableBytes());
       switch (action) {
         case STORAGE: // GET /storage/store/partition/key
@@ -86,7 +87,8 @@ public class RouterRequestHttpHandler extends SimpleChannelInboundHandler<FullHt
             ctx.fireChannelRead(getRouterRequest);
           } else if (requestMethod.equals(HttpMethod.POST)) {
             // Multi-get
-            MultiGetRouterRequestWrapper multiGetRouterReq = MultiGetRouterRequestWrapper.parseMultiGetHttpRequest(req);
+            MultiGetRouterRequestWrapper multiGetRouterReq =
+                MultiGetRouterRequestWrapper.parseMultiGetHttpRequest(req, uri);
             setupRequestTimeout(multiGetRouterReq);
             statsHandler.setRequestInfo(multiGetRouterReq);
             ctx.fireChannelRead(multiGetRouterReq);
@@ -96,7 +98,7 @@ public class RouterRequestHttpHandler extends SimpleChannelInboundHandler<FullHt
           break;
         case COMPUTE: // compute request
           if (req.method().equals(HttpMethod.POST)) {
-            ComputeRouterRequestWrapper computeRouterReq = ComputeRouterRequestWrapper.parseComputeRequest(req);
+            ComputeRouterRequestWrapper computeRouterReq = ComputeRouterRequestWrapper.parseComputeRequest(req, uri);
             setupRequestTimeout(computeRouterReq);
             statsHandler.setRequestInfo(computeRouterReq);
             ctx.fireChannelRead(computeRouterReq);
@@ -115,7 +117,7 @@ public class RouterRequestHttpHandler extends SimpleChannelInboundHandler<FullHt
           ctx.fireChannelRead(dictionaryFetchRequest);
           break;
         case ADMIN:
-          AdminRequest adminRequest = AdminRequest.parseAdminHttpRequest(req);
+          AdminRequest adminRequest = AdminRequest.parseAdminHttpRequest(req, uri);
           statsHandler.setStoreName(adminRequest.getStoreName());
           ctx.fireChannelRead(adminRequest);
           break;
@@ -167,10 +169,10 @@ public class RouterRequestHttpHandler extends SimpleChannelInboundHandler<FullHt
     super.userEventTriggered(ctx, evt);
   }
 
-  static QueryAction getQueryActionFromRequest(HttpRequest req) {
+  static QueryAction getQueryActionFromRequest(HttpRequest req, URI uri) {
     // Sometimes req.uri() gives a full uri (eg https://host:port/path) and sometimes it only gives a path
     // Generating a URI lets us always take just the path.
-    String[] requestParts = URI.create(req.uri()).getPath().split("/");
+    String[] requestParts = uri.getPath().split("/");
     HttpMethod reqMethod = req.method();
     if ((!reqMethod.equals(HttpMethod.GET) && !reqMethod.equals(HttpMethod.POST)) || requestParts.length < 2) {
       String actions =

--- a/services/venice-server/src/main/java/com/linkedin/venice/listener/RouterRequestHttpHandler.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/listener/RouterRequestHttpHandler.java
@@ -81,7 +81,7 @@ public class RouterRequestHttpHandler extends SimpleChannelInboundHandler<FullHt
           HttpMethod requestMethod = req.method();
           if (requestMethod.equals(HttpMethod.GET)) {
             // TODO: evaluate whether we can replace single-get by multi-get
-            GetRouterRequest getRouterRequest = GetRouterRequest.parseGetHttpRequest(req);
+            GetRouterRequest getRouterRequest = GetRouterRequest.parseGetHttpRequest(req, uri);
             setupRequestTimeout(getRouterRequest);
             statsHandler.setRequestInfo(getRouterRequest);
             ctx.fireChannelRead(getRouterRequest);
@@ -112,7 +112,7 @@ public class RouterRequestHttpHandler extends SimpleChannelInboundHandler<FullHt
           ctx.fireChannelRead(healthCheckRequest);
           break;
         case DICTIONARY:
-          DictionaryFetchRequest dictionaryFetchRequest = DictionaryFetchRequest.parseGetHttpRequest(req);
+          DictionaryFetchRequest dictionaryFetchRequest = DictionaryFetchRequest.parseGetHttpRequest(uri);
           statsHandler.setStoreName(dictionaryFetchRequest.getStoreName());
           ctx.fireChannelRead(dictionaryFetchRequest);
           break;
@@ -123,19 +123,19 @@ public class RouterRequestHttpHandler extends SimpleChannelInboundHandler<FullHt
           break;
         case METADATA:
           statsHandler.setMetadataRequest(true);
-          MetadataFetchRequest metadataFetchRequest = MetadataFetchRequest.parseGetHttpRequest(req);
+          MetadataFetchRequest metadataFetchRequest = MetadataFetchRequest.parseGetHttpRequest(uri);
           statsHandler.setStoreName(metadataFetchRequest.getStoreName());
           ctx.fireChannelRead(metadataFetchRequest);
           break;
         case CURRENT_VERSION:
           statsHandler.setMetadataRequest(true);
-          CurrentVersionRequest currentVersionRequest = CurrentVersionRequest.parseGetHttpRequest(req);
+          CurrentVersionRequest currentVersionRequest = CurrentVersionRequest.parseGetHttpRequest(uri);
           statsHandler.setStoreName(currentVersionRequest.getStoreName());
           ctx.fireChannelRead(currentVersionRequest);
           break;
         case TOPIC_PARTITION_INGESTION_CONTEXT:
           TopicPartitionIngestionContextRequest topicPartitionIngestionContextRequest =
-              TopicPartitionIngestionContextRequest.parseGetHttpRequest(req);
+              TopicPartitionIngestionContextRequest.parseGetHttpRequest(uri);
           statsHandler.setStoreName(
               Version.parseStoreFromVersionTopic(topicPartitionIngestionContextRequest.getVersionTopic()));
           ctx.fireChannelRead(topicPartitionIngestionContextRequest);

--- a/services/venice-server/src/main/java/com/linkedin/venice/listener/RouterRequestHttpHandler.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/listener/RouterRequestHttpHandler.java
@@ -100,7 +100,8 @@ public class RouterRequestHttpHandler extends SimpleChannelInboundHandler<FullHt
           break;
         case COMPUTE: // compute request
           if (req.method().equals(HttpMethod.POST)) {
-            ComputeRouterRequestWrapper computeRouterReq = ComputeRouterRequestWrapper.parseComputeRequest(req, uri);
+            ComputeRouterRequestWrapper computeRouterReq =
+                ComputeRouterRequestWrapper.parseComputeRequest(req, requestParts);
             setupRequestTimeout(computeRouterReq);
             statsHandler.setRequestInfo(computeRouterReq);
             ctx.fireChannelRead(computeRouterReq);
@@ -114,7 +115,7 @@ public class RouterRequestHttpHandler extends SimpleChannelInboundHandler<FullHt
           ctx.fireChannelRead(healthCheckRequest);
           break;
         case DICTIONARY:
-          DictionaryFetchRequest dictionaryFetchRequest = DictionaryFetchRequest.parseGetHttpRequest(uri);
+          DictionaryFetchRequest dictionaryFetchRequest = DictionaryFetchRequest.parseGetHttpRequest(uri, requestParts);
           statsHandler.setStoreName(dictionaryFetchRequest.getStoreName());
           ctx.fireChannelRead(dictionaryFetchRequest);
           break;
@@ -125,7 +126,8 @@ public class RouterRequestHttpHandler extends SimpleChannelInboundHandler<FullHt
           break;
         case METADATA:
           statsHandler.setMetadataRequest(true);
-          MetadataFetchRequest metadataFetchRequest = MetadataFetchRequest.parseGetHttpRequest(uri);
+          MetadataFetchRequest metadataFetchRequest =
+              MetadataFetchRequest.parseGetHttpRequest(uri.getPath(), requestParts);
           statsHandler.setStoreName(metadataFetchRequest.getStoreName());
           ctx.fireChannelRead(metadataFetchRequest);
           break;
@@ -137,7 +139,8 @@ public class RouterRequestHttpHandler extends SimpleChannelInboundHandler<FullHt
           break;
         case TOPIC_PARTITION_INGESTION_CONTEXT:
           TopicPartitionIngestionContextRequest topicPartitionIngestionContextRequest =
-              TopicPartitionIngestionContextRequest.parseGetHttpRequest(uri);
+              TopicPartitionIngestionContextRequest
+                  .parseGetHttpRequest(uri.getPath(), RequestHelper.getRequestParts(uri));
           statsHandler.setStoreName(
               Version.parseStoreFromVersionTopic(topicPartitionIngestionContextRequest.getVersionTopic()));
           ctx.fireChannelRead(topicPartitionIngestionContextRequest);

--- a/services/venice-server/src/main/java/com/linkedin/venice/listener/RouterRequestHttpHandler.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/listener/RouterRequestHttpHandler.java
@@ -133,7 +133,8 @@ public class RouterRequestHttpHandler extends SimpleChannelInboundHandler<FullHt
           break;
         case CURRENT_VERSION:
           statsHandler.setMetadataRequest(true);
-          CurrentVersionRequest currentVersionRequest = CurrentVersionRequest.parseGetHttpRequest(uri);
+          CurrentVersionRequest currentVersionRequest =
+              CurrentVersionRequest.parseGetHttpRequest(uri, RequestHelper.getRequestParts(uri));
           statsHandler.setStoreName(currentVersionRequest.getStoreName());
           ctx.fireChannelRead(currentVersionRequest);
           break;

--- a/services/venice-server/src/main/java/com/linkedin/venice/listener/RouterRequestHttpHandler.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/listener/RouterRequestHttpHandler.java
@@ -133,15 +133,13 @@ public class RouterRequestHttpHandler extends SimpleChannelInboundHandler<FullHt
           break;
         case CURRENT_VERSION:
           statsHandler.setMetadataRequest(true);
-          CurrentVersionRequest currentVersionRequest =
-              CurrentVersionRequest.parseGetHttpRequest(uri, RequestHelper.getRequestParts(uri));
+          CurrentVersionRequest currentVersionRequest = CurrentVersionRequest.parseGetHttpRequest(uri, requestParts);
           statsHandler.setStoreName(currentVersionRequest.getStoreName());
           ctx.fireChannelRead(currentVersionRequest);
           break;
         case TOPIC_PARTITION_INGESTION_CONTEXT:
           TopicPartitionIngestionContextRequest topicPartitionIngestionContextRequest =
-              TopicPartitionIngestionContextRequest
-                  .parseGetHttpRequest(uri.getPath(), RequestHelper.getRequestParts(uri));
+              TopicPartitionIngestionContextRequest.parseGetHttpRequest(uri.getPath(), requestParts);
           statsHandler.setStoreName(
               Version.parseStoreFromVersionTopic(topicPartitionIngestionContextRequest.getVersionTopic()));
           ctx.fireChannelRead(topicPartitionIngestionContextRequest);

--- a/services/venice-server/src/main/java/com/linkedin/venice/listener/request/AdminRequest.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/listener/request/AdminRequest.java
@@ -23,8 +23,7 @@ public class AdminRequest {
     this.partition = partition;
   }
 
-  public static AdminRequest parseAdminHttpRequest(HttpRequest request) {
-    URI fullUri = URI.create(request.uri());
+  public static AdminRequest parseAdminHttpRequest(HttpRequest request, URI fullUri) {
     String[] requestParts = fullUri.getRawPath().split("/");
     // [0]""/[1]"action"/[2]"store_version"/[3]"admin_action"/[4](optional)"partition_id"
     if (requestParts.length >= 4 && requestParts.length <= 5) {

--- a/services/venice-server/src/main/java/com/linkedin/venice/listener/request/ComputeRouterRequestWrapper.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/listener/request/ComputeRouterRequestWrapper.java
@@ -41,8 +41,7 @@ public class ComputeRouterRequestWrapper extends MultiKeyRouterRequestWrapper<Co
     }
   }
 
-  public static ComputeRouterRequestWrapper parseComputeRequest(FullHttpRequest httpRequest) {
-    URI fullUri = URI.create(httpRequest.uri());
+  public static ComputeRouterRequestWrapper parseComputeRequest(FullHttpRequest httpRequest, URI fullUri) {
     String path = fullUri.getRawPath();
     String[] requestParts = path.split("/");
     if (requestParts.length != 3) {

--- a/services/venice-server/src/main/java/com/linkedin/venice/listener/request/ComputeRouterRequestWrapper.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/listener/request/ComputeRouterRequestWrapper.java
@@ -12,7 +12,6 @@ import com.linkedin.venice.serializer.FastSerializerDeserializerFactory;
 import com.linkedin.venice.serializer.RecordDeserializer;
 import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http.HttpRequest;
-import java.net.URI;
 import java.util.List;
 import org.apache.avro.io.BinaryDecoder;
 import org.apache.avro.io.OptimizedBinaryDecoderFactory;
@@ -41,12 +40,10 @@ public class ComputeRouterRequestWrapper extends MultiKeyRouterRequestWrapper<Co
     }
   }
 
-  public static ComputeRouterRequestWrapper parseComputeRequest(FullHttpRequest httpRequest, URI fullUri) {
-    String path = fullUri.getRawPath();
-    String[] requestParts = path.split("/");
+  public static ComputeRouterRequestWrapper parseComputeRequest(FullHttpRequest httpRequest, String[] requestParts) {
     if (requestParts.length != 3) {
       // [0]""/[1]"compute"/[2]{$resourceName}
-      throw new VeniceException("Invalid request: " + path);
+      throw new VeniceException("Invalid request: " + httpRequest.uri());
     }
     String resourceName = requestParts[2];
 

--- a/services/venice-server/src/main/java/com/linkedin/venice/listener/request/CurrentVersionRequest.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/listener/request/CurrentVersionRequest.java
@@ -2,7 +2,7 @@ package com.linkedin.venice.listener.request;
 
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.request.RequestHelper;
-import io.netty.handler.codec.http.HttpRequest;
+import java.net.URI;
 
 
 public class CurrentVersionRequest {
@@ -12,8 +12,7 @@ public class CurrentVersionRequest {
     this.storeName = storeName;
   }
 
-  public static CurrentVersionRequest parseGetHttpRequest(HttpRequest request) {
-    String uri = request.uri();
+  public static CurrentVersionRequest parseGetHttpRequest(URI uri) {
     String[] requestParts = RequestHelper.getRequestParts(uri);
 
     if (requestParts.length == 3) {

--- a/services/venice-server/src/main/java/com/linkedin/venice/listener/request/CurrentVersionRequest.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/listener/request/CurrentVersionRequest.java
@@ -1,7 +1,6 @@
 package com.linkedin.venice.listener.request;
 
 import com.linkedin.venice.exceptions.VeniceException;
-import com.linkedin.venice.request.RequestHelper;
 import java.net.URI;
 
 
@@ -12,15 +11,13 @@ public class CurrentVersionRequest {
     this.storeName = storeName;
   }
 
-  public static CurrentVersionRequest parseGetHttpRequest(URI uri) {
-    String[] requestParts = RequestHelper.getRequestParts(uri);
-
+  public static CurrentVersionRequest parseGetHttpRequest(URI uri, String[] requestParts) {
     if (requestParts.length == 3) {
       // [0]""/[1]"action"/[2]"store"
       String storeName = requestParts[2];
       return new CurrentVersionRequest(storeName);
     } else {
-      throw new VeniceException("not a valid request for a METADATA action: " + uri);
+      throw new VeniceException("not a valid request for a METADATA action: " + uri.getPath());
     }
   }
 

--- a/services/venice-server/src/main/java/com/linkedin/venice/listener/request/DictionaryFetchRequest.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/listener/request/DictionaryFetchRequest.java
@@ -2,7 +2,6 @@ package com.linkedin.venice.listener.request;
 
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.meta.Version;
-import com.linkedin.venice.request.RequestHelper;
 import java.net.URI;
 
 
@@ -19,9 +18,7 @@ public class DictionaryFetchRequest {
     this.resourceName = resourceName;
   }
 
-  public static DictionaryFetchRequest parseGetHttpRequest(URI uri) {
-    String[] requestParts = RequestHelper.getRequestParts(uri);
-
+  public static DictionaryFetchRequest parseGetHttpRequest(URI uri, String[] requestParts) {
     if (requestParts.length == 4) {
       // [0]""/[1]"action"/[2]"store"/[3]"version"
       String storeName = requestParts[2];

--- a/services/venice-server/src/main/java/com/linkedin/venice/listener/request/DictionaryFetchRequest.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/listener/request/DictionaryFetchRequest.java
@@ -3,7 +3,7 @@ package com.linkedin.venice.listener.request;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.request.RequestHelper;
-import io.netty.handler.codec.http.HttpRequest;
+import java.net.URI;
 
 
 /**
@@ -19,8 +19,7 @@ public class DictionaryFetchRequest {
     this.resourceName = resourceName;
   }
 
-  public static DictionaryFetchRequest parseGetHttpRequest(HttpRequest request) {
-    String uri = request.uri();
+  public static DictionaryFetchRequest parseGetHttpRequest(URI uri) {
     String[] requestParts = RequestHelper.getRequestParts(uri);
 
     if (requestParts.length == 4) {
@@ -30,7 +29,7 @@ public class DictionaryFetchRequest {
       String topicName = Version.composeKafkaTopic(storeName, storeVersion);
       return new DictionaryFetchRequest(storeName, topicName);
     } else {
-      throw new VeniceException("Not a valid request for a DICTIONARY action: " + uri);
+      throw new VeniceException("Not a valid request for a DICTIONARY action: " + uri.getPath());
     }
   }
 

--- a/services/venice-server/src/main/java/com/linkedin/venice/listener/request/GetRouterRequest.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/listener/request/GetRouterRequest.java
@@ -5,12 +5,10 @@ import com.linkedin.venice.RequestConstants;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.protocols.VeniceClientRequest;
 import com.linkedin.venice.read.RequestType;
-import com.linkedin.venice.request.RequestHelper;
 import com.linkedin.venice.utils.EncodingUtils;
 import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.QueryStringDecoder;
-import java.net.URI;
 import java.nio.charset.StandardCharsets;
 
 
@@ -53,8 +51,7 @@ public class GetRouterRequest extends RouterRequest {
     return 1;
   }
 
-  public static GetRouterRequest parseGetHttpRequest(HttpRequest request, URI uri) {
-    String[] requestParts = RequestHelper.getRequestParts(uri);
+  public static GetRouterRequest parseGetHttpRequest(HttpRequest request, String[] requestParts) {
     if (requestParts.length == 5) {
       // [0]""/[1]"action"/[2]"store"/[3]"partition"/[4]"key"
       String topicName = requestParts[2];
@@ -62,7 +59,7 @@ public class GetRouterRequest extends RouterRequest {
       byte[] keyBytes = getKeyBytesFromUrlKeyString(requestParts[4]);
       return new GetRouterRequest(topicName, partition, keyBytes, request);
     } else {
-      throw new VeniceException("Not a valid request for a STORAGE action: " + uri);
+      throw new VeniceException("Not a valid request for a STORAGE action: " + request.uri());
     }
   }
 

--- a/services/venice-server/src/main/java/com/linkedin/venice/listener/request/GetRouterRequest.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/listener/request/GetRouterRequest.java
@@ -10,6 +10,7 @@ import com.linkedin.venice.utils.EncodingUtils;
 import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.QueryStringDecoder;
+import java.net.URI;
 import java.nio.charset.StandardCharsets;
 
 
@@ -52,8 +53,7 @@ public class GetRouterRequest extends RouterRequest {
     return 1;
   }
 
-  public static GetRouterRequest parseGetHttpRequest(HttpRequest request) {
-    String uri = request.uri();
+  public static GetRouterRequest parseGetHttpRequest(HttpRequest request, URI uri) {
     String[] requestParts = RequestHelper.getRequestParts(uri);
     if (requestParts.length == 5) {
       // [0]""/[1]"action"/[2]"store"/[3]"partition"/[4]"key"

--- a/services/venice-server/src/main/java/com/linkedin/venice/listener/request/MetadataFetchRequest.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/listener/request/MetadataFetchRequest.java
@@ -1,8 +1,6 @@
 package com.linkedin.venice.listener.request;
 
 import com.linkedin.venice.exceptions.VeniceException;
-import com.linkedin.venice.request.RequestHelper;
-import java.net.URI;
 
 
 /**
@@ -16,9 +14,7 @@ public class MetadataFetchRequest {
     this.storeName = storeName;
   }
 
-  public static MetadataFetchRequest parseGetHttpRequest(URI uri) {
-    String[] requestParts = RequestHelper.getRequestParts(uri);
-
+  public static MetadataFetchRequest parseGetHttpRequest(String uri, String[] requestParts) {
     if (requestParts.length == 3) {
       // [0]""/[1]"action"/[2]"store"
       String storeName = requestParts[2];

--- a/services/venice-server/src/main/java/com/linkedin/venice/listener/request/MetadataFetchRequest.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/listener/request/MetadataFetchRequest.java
@@ -2,7 +2,7 @@ package com.linkedin.venice.listener.request;
 
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.request.RequestHelper;
-import io.netty.handler.codec.http.HttpRequest;
+import java.net.URI;
 
 
 /**
@@ -16,8 +16,7 @@ public class MetadataFetchRequest {
     this.storeName = storeName;
   }
 
-  public static MetadataFetchRequest parseGetHttpRequest(HttpRequest request) {
-    String uri = request.uri();
+  public static MetadataFetchRequest parseGetHttpRequest(URI uri) {
     String[] requestParts = RequestHelper.getRequestParts(uri);
 
     if (requestParts.length == 3) {

--- a/services/venice-server/src/main/java/com/linkedin/venice/listener/request/MultiGetRouterRequestWrapper.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/listener/request/MultiGetRouterRequestWrapper.java
@@ -38,8 +38,8 @@ public class MultiGetRouterRequestWrapper extends MultiKeyRouterRequestWrapper<M
 
   public static MultiGetRouterRequestWrapper parseMultiGetHttpRequest(
       FullHttpRequest httpRequest,
-      String[] resourceNames) {
-    if (resourceNames.length != 3) {
+      String[] requestParts) {
+    if (requestParts.length != 3) {
       // [0]""/[1]"storage"/[2]{$resourceName}
       throw new VeniceException("Invalid request: " + httpRequest.uri());
     }
@@ -58,7 +58,7 @@ public class MultiGetRouterRequestWrapper extends MultiKeyRouterRequestWrapper<M
     httpRequest.content().readBytes(content);
     keys = parseKeys(content);
 
-    return new MultiGetRouterRequestWrapper(resourceNames[2], keys, httpRequest);
+    return new MultiGetRouterRequestWrapper(requestParts[2], keys, httpRequest);
   }
 
   public static MultiGetRouterRequestWrapper parseMultiGetGrpcRequest(VeniceClientRequest grpcRequest) {

--- a/services/venice-server/src/main/java/com/linkedin/venice/listener/request/MultiGetRouterRequestWrapper.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/listener/request/MultiGetRouterRequestWrapper.java
@@ -13,6 +13,7 @@ import io.netty.handler.codec.http.HttpRequest;
 import java.net.URI;
 import java.util.List;
 import org.apache.avro.io.OptimizedBinaryDecoderFactory;
+import org.apache.commons.lang.StringUtils;
 
 
 /**
@@ -40,12 +41,12 @@ public class MultiGetRouterRequestWrapper extends MultiKeyRouterRequestWrapper<M
   public static MultiGetRouterRequestWrapper parseMultiGetHttpRequest(FullHttpRequest httpRequest) {
     URI fullUri = URI.create(httpRequest.uri());
     String path = fullUri.getRawPath();
-    String[] requestParts = path.split("/");
-    if (requestParts.length != 3) {
+    int count = StringUtils.countMatches(path, "/");
+    if (count != 2) {
       // [0]""/[1]"storage"/[2]{$resourceName}
       throw new VeniceException("Invalid request: " + path);
     }
-    String resourceName = requestParts[2];
+    String resourceName = path.substring(path.lastIndexOf('/') + 1);
 
     // Validate API version
     String apiVersion = httpRequest.headers().get(HttpConstants.VENICE_API_VERSION);

--- a/services/venice-server/src/main/java/com/linkedin/venice/listener/request/MultiGetRouterRequestWrapper.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/listener/request/MultiGetRouterRequestWrapper.java
@@ -38,8 +38,7 @@ public class MultiGetRouterRequestWrapper extends MultiKeyRouterRequestWrapper<M
     super(resourceName, keys, isRetryRequest, isStreamingRequest);
   }
 
-  public static MultiGetRouterRequestWrapper parseMultiGetHttpRequest(FullHttpRequest httpRequest) {
-    URI fullUri = URI.create(httpRequest.uri());
+  public static MultiGetRouterRequestWrapper parseMultiGetHttpRequest(FullHttpRequest httpRequest, URI fullUri) {
     String path = fullUri.getRawPath();
     int count = StringUtils.countMatches(path, "/");
     if (count != 2) {

--- a/services/venice-server/src/main/java/com/linkedin/venice/listener/request/TopicPartitionIngestionContextRequest.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/listener/request/TopicPartitionIngestionContextRequest.java
@@ -2,7 +2,7 @@ package com.linkedin.venice.listener.request;
 
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.request.RequestHelper;
-import io.netty.handler.codec.http.HttpRequest;
+import java.net.URI;
 
 
 public class TopicPartitionIngestionContextRequest {
@@ -16,8 +16,7 @@ public class TopicPartitionIngestionContextRequest {
     this.partition = partition;
   }
 
-  public static TopicPartitionIngestionContextRequest parseGetHttpRequest(HttpRequest request) {
-    String uri = request.uri();
+  public static TopicPartitionIngestionContextRequest parseGetHttpRequest(URI uri) {
     String[] requestParts = RequestHelper.getRequestParts(uri);
 
     if (requestParts.length == 5) {

--- a/services/venice-server/src/main/java/com/linkedin/venice/listener/request/TopicPartitionIngestionContextRequest.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/listener/request/TopicPartitionIngestionContextRequest.java
@@ -1,8 +1,6 @@
 package com.linkedin.venice.listener.request;
 
 import com.linkedin.venice.exceptions.VeniceException;
-import com.linkedin.venice.request.RequestHelper;
-import java.net.URI;
 
 
 public class TopicPartitionIngestionContextRequest {
@@ -16,9 +14,7 @@ public class TopicPartitionIngestionContextRequest {
     this.partition = partition;
   }
 
-  public static TopicPartitionIngestionContextRequest parseGetHttpRequest(URI uri) {
-    String[] requestParts = RequestHelper.getRequestParts(uri);
-
+  public static TopicPartitionIngestionContextRequest parseGetHttpRequest(String uri, String[] requestParts) {
     if (requestParts.length == 5) {
       // [0]""/[1]"action"/[2]"version topic"/[3]"topic name"/[4]"partition number"
       String versionTopic = requestParts[2];

--- a/services/venice-server/src/test/java/com/linkedin/venice/listener/RouterRequestHttpHandlerTest.java
+++ b/services/venice-server/src/test/java/com/linkedin/venice/listener/RouterRequestHttpHandlerTest.java
@@ -25,6 +25,7 @@ import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpVersion;
+import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.Collections;
@@ -145,7 +146,7 @@ public class RouterRequestHttpHandlerTest {
 
   public void doActionTest(String urlString, HttpMethod method, QueryAction expectedAction) {
     HttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, method, urlString);
-    QueryAction parsedAction = RouterRequestHttpHandler.getQueryActionFromRequest(request);
+    QueryAction parsedAction = RouterRequestHttpHandler.getQueryActionFromRequest(request, URI.create(request.uri()));
     Assert.assertEquals(parsedAction, expectedAction, "parsed wrong query action from string: " + urlString);
   }
 

--- a/services/venice-server/src/test/java/com/linkedin/venice/listener/RouterRequestHttpHandlerTest.java
+++ b/services/venice-server/src/test/java/com/linkedin/venice/listener/RouterRequestHttpHandlerTest.java
@@ -17,6 +17,7 @@ import com.linkedin.venice.listener.response.HttpShortcutResponse;
 import com.linkedin.venice.meta.QueryAction;
 import com.linkedin.venice.protocols.VeniceClientRequest;
 import com.linkedin.venice.protocols.VeniceServerResponse;
+import com.linkedin.venice.request.RequestHelper;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http.DefaultFullHttpRequest;
 import io.netty.handler.codec.http.DefaultHttpHeaders;
@@ -81,7 +82,8 @@ public class RouterRequestHttpHandlerTest {
     Assert.assertEquals(requestObject.getKeyBytes(), expectedKey, "Key from path: " + path + " was parsed incorrectly");
 
     // Test parse method
-    GetRouterRequest getRouterRequest = GetRouterRequest.parseGetHttpRequest(msg, URI.create(msg.uri()));
+    GetRouterRequest getRouterRequest =
+        GetRouterRequest.parseGetHttpRequest(msg, RequestHelper.getRequestParts(URI.create(msg.uri())));
     Assert.assertEquals(
         getRouterRequest.getResourceName(),
         expectedStore,
@@ -146,7 +148,8 @@ public class RouterRequestHttpHandlerTest {
 
   public void doActionTest(String urlString, HttpMethod method, QueryAction expectedAction) {
     HttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, method, urlString);
-    QueryAction parsedAction = RouterRequestHttpHandler.getQueryActionFromRequest(request, URI.create(request.uri()));
+    QueryAction parsedAction = RouterRequestHttpHandler
+        .getQueryActionFromRequest(request, RequestHelper.getRequestParts(URI.create(request.uri())));
     Assert.assertEquals(parsedAction, expectedAction, "parsed wrong query action from string: " + urlString);
   }
 

--- a/services/venice-server/src/test/java/com/linkedin/venice/listener/RouterRequestHttpHandlerTest.java
+++ b/services/venice-server/src/test/java/com/linkedin/venice/listener/RouterRequestHttpHandlerTest.java
@@ -81,7 +81,7 @@ public class RouterRequestHttpHandlerTest {
     Assert.assertEquals(requestObject.getKeyBytes(), expectedKey, "Key from path: " + path + " was parsed incorrectly");
 
     // Test parse method
-    GetRouterRequest getRouterRequest = GetRouterRequest.parseGetHttpRequest(msg);
+    GetRouterRequest getRouterRequest = GetRouterRequest.parseGetHttpRequest(msg, URI.create(msg.uri()));
     Assert.assertEquals(
         getRouterRequest.getResourceName(),
         expectedStore,

--- a/services/venice-server/src/test/java/com/linkedin/venice/listener/StorageReadRequestHandlerTest.java
+++ b/services/venice-server/src/test/java/com/linkedin/venice/listener/StorageReadRequestHandlerTest.java
@@ -229,7 +229,7 @@ public class StorageReadRequestHandlerTest {
     // [0]""/[1]"action"/[2]"store"/[3]"partition"/[4]"key"
     String uri = "/" + TYPE_STORAGE + "/test-topic_v1/" + partition + "/" + keyString;
     HttpRequest httpRequest = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, uri);
-    GetRouterRequest request = GetRouterRequest.parseGetHttpRequest(httpRequest);
+    GetRouterRequest request = GetRouterRequest.parseGetHttpRequest(httpRequest, URI.create(httpRequest.uri()));
 
     StorageReadRequestHandler requestHandler = createStorageReadRequestHandler();
     requestHandler.channelRead(context, request);
@@ -329,7 +329,7 @@ public class StorageReadRequestHandlerTest {
     // [0]""/[1]"action"/[2]"store"/[3]"partition"/[4]"key"
     String uri = "/" + TYPE_STORAGE + "/" + topic + "/" + partition + "/" + keyString;
     HttpRequest httpRequest = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, uri);
-    GetRouterRequest request = GetRouterRequest.parseGetHttpRequest(httpRequest);
+    GetRouterRequest request = GetRouterRequest.parseGetHttpRequest(httpRequest, URI.create(httpRequest.uri()));
 
     byte[] valueBytes = ValueRecord.create(schemaId, valueString.getBytes()).serialize();
     doReturn(valueBytes).when(storageEngine).get(partition, ByteBuffer.wrap(keyString.getBytes()));
@@ -405,7 +405,7 @@ public class StorageReadRequestHandlerTest {
         + topic + "/" + expectedPartitionId;
     HttpRequest httpRequest = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, uri);
     TopicPartitionIngestionContextRequest request =
-        TopicPartitionIngestionContextRequest.parseGetHttpRequest(httpRequest);
+        TopicPartitionIngestionContextRequest.parseGetHttpRequest(URI.create(httpRequest.uri()));
 
     // Mock the TopicPartitionIngestionContextResponse from ingestion task
     TopicPartitionIngestionContextResponse expectedTopicPartitionIngestionContextResponse =
@@ -442,7 +442,7 @@ public class StorageReadRequestHandlerTest {
     // [0]""/[1]"action"/[2]"store"
     String uri = "/" + QueryAction.METADATA.toString().toLowerCase() + "/" + storeName;
     HttpRequest httpRequest = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, uri);
-    MetadataFetchRequest testRequest = MetadataFetchRequest.parseGetHttpRequest(httpRequest);
+    MetadataFetchRequest testRequest = MetadataFetchRequest.parseGetHttpRequest(URI.create(httpRequest.uri()));
 
     // Mock the MetadataResponse from ingestion task
     MetadataResponse expectedMetadataResponse = new MetadataResponse();

--- a/services/venice-server/src/test/java/com/linkedin/venice/listener/StorageReadRequestHandlerTest.java
+++ b/services/venice-server/src/test/java/com/linkedin/venice/listener/StorageReadRequestHandlerTest.java
@@ -100,6 +100,7 @@ import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpVersion;
+import java.net.URI;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -294,7 +295,8 @@ public class StorageReadRequestHandlerTest {
         .set(
             HttpConstants.VENICE_API_VERSION,
             ReadAvroProtocolDefinition.MULTI_GET_ROUTER_REQUEST_V1.getProtocolVersion());
-    MultiGetRouterRequestWrapper request = MultiGetRouterRequestWrapper.parseMultiGetHttpRequest(httpRequest);
+    MultiGetRouterRequestWrapper request =
+        MultiGetRouterRequestWrapper.parseMultiGetHttpRequest(httpRequest, URI.create(httpRequest.uri()));
 
     StorageReadRequestHandler requestHandler = createStorageReadRequestHandler(isParallel, 10);
     requestHandler.channelRead(context, request);
@@ -370,7 +372,7 @@ public class StorageReadRequestHandlerTest {
     String uri =
         "/" + QueryAction.ADMIN.toString().toLowerCase() + "/" + topic + "/" + ServerAdminAction.DUMP_INGESTION_STATE;
     HttpRequest httpRequest = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, uri);
-    AdminRequest request = AdminRequest.parseAdminHttpRequest(httpRequest);
+    AdminRequest request = AdminRequest.parseAdminHttpRequest(httpRequest, URI.create(httpRequest.uri()));
 
     // Mock the AdminResponse from ingestion task
     AdminResponse expectedAdminResponse = new AdminResponse();

--- a/services/venice-server/src/test/java/com/linkedin/venice/listener/StorageReadRequestHandlerTest.java
+++ b/services/venice-server/src/test/java/com/linkedin/venice/listener/StorageReadRequestHandlerTest.java
@@ -77,6 +77,7 @@ import com.linkedin.venice.protocols.VeniceServerResponse;
 import com.linkedin.venice.read.RequestType;
 import com.linkedin.venice.read.protocol.request.router.MultiGetRouterRequestKeyV1;
 import com.linkedin.venice.read.protocol.response.MultiGetResponseRecordV1;
+import com.linkedin.venice.request.RequestHelper;
 import com.linkedin.venice.schema.AvroSchemaParseUtils;
 import com.linkedin.venice.schema.SchemaEntry;
 import com.linkedin.venice.schema.SchemaReader;
@@ -229,7 +230,8 @@ public class StorageReadRequestHandlerTest {
     // [0]""/[1]"action"/[2]"store"/[3]"partition"/[4]"key"
     String uri = "/" + TYPE_STORAGE + "/test-topic_v1/" + partition + "/" + keyString;
     HttpRequest httpRequest = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, uri);
-    GetRouterRequest request = GetRouterRequest.parseGetHttpRequest(httpRequest, URI.create(httpRequest.uri()));
+    GetRouterRequest request =
+        GetRouterRequest.parseGetHttpRequest(httpRequest, RequestHelper.getRequestParts(URI.create(httpRequest.uri())));
 
     StorageReadRequestHandler requestHandler = createStorageReadRequestHandler();
     requestHandler.channelRead(context, request);
@@ -295,8 +297,8 @@ public class StorageReadRequestHandlerTest {
         .set(
             HttpConstants.VENICE_API_VERSION,
             ReadAvroProtocolDefinition.MULTI_GET_ROUTER_REQUEST_V1.getProtocolVersion());
-    MultiGetRouterRequestWrapper request =
-        MultiGetRouterRequestWrapper.parseMultiGetHttpRequest(httpRequest, URI.create(httpRequest.uri()));
+    MultiGetRouterRequestWrapper request = MultiGetRouterRequestWrapper
+        .parseMultiGetHttpRequest(httpRequest, RequestHelper.getRequestParts(URI.create(httpRequest.uri())));
 
     StorageReadRequestHandler requestHandler = createStorageReadRequestHandler(isParallel, 10);
     requestHandler.channelRead(context, request);
@@ -329,7 +331,8 @@ public class StorageReadRequestHandlerTest {
     // [0]""/[1]"action"/[2]"store"/[3]"partition"/[4]"key"
     String uri = "/" + TYPE_STORAGE + "/" + topic + "/" + partition + "/" + keyString;
     HttpRequest httpRequest = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, uri);
-    GetRouterRequest request = GetRouterRequest.parseGetHttpRequest(httpRequest, URI.create(httpRequest.uri()));
+    GetRouterRequest request =
+        GetRouterRequest.parseGetHttpRequest(httpRequest, RequestHelper.getRequestParts(URI.create(httpRequest.uri())));
 
     byte[] valueBytes = ValueRecord.create(schemaId, valueString.getBytes()).serialize();
     doReturn(valueBytes).when(storageEngine).get(partition, ByteBuffer.wrap(keyString.getBytes()));

--- a/services/venice-server/src/test/java/com/linkedin/venice/listener/StorageReadRequestHandlerTest.java
+++ b/services/venice-server/src/test/java/com/linkedin/venice/listener/StorageReadRequestHandlerTest.java
@@ -407,8 +407,8 @@ public class StorageReadRequestHandlerTest {
     String uri = "/" + QueryAction.TOPIC_PARTITION_INGESTION_CONTEXT.toString().toLowerCase() + "/" + topic + "/"
         + topic + "/" + expectedPartitionId;
     HttpRequest httpRequest = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, uri);
-    TopicPartitionIngestionContextRequest request =
-        TopicPartitionIngestionContextRequest.parseGetHttpRequest(URI.create(httpRequest.uri()));
+    TopicPartitionIngestionContextRequest request = TopicPartitionIngestionContextRequest
+        .parseGetHttpRequest(uri, RequestHelper.getRequestParts(URI.create(httpRequest.uri())));
 
     // Mock the TopicPartitionIngestionContextResponse from ingestion task
     TopicPartitionIngestionContextResponse expectedTopicPartitionIngestionContextResponse =
@@ -445,7 +445,8 @@ public class StorageReadRequestHandlerTest {
     // [0]""/[1]"action"/[2]"store"
     String uri = "/" + QueryAction.METADATA.toString().toLowerCase() + "/" + storeName;
     HttpRequest httpRequest = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, uri);
-    MetadataFetchRequest testRequest = MetadataFetchRequest.parseGetHttpRequest(URI.create(httpRequest.uri()));
+    MetadataFetchRequest testRequest =
+        MetadataFetchRequest.parseGetHttpRequest(uri, RequestHelper.getRequestParts(URI.create(httpRequest.uri())));
 
     // Mock the MetadataResponse from ingestion task
     MetadataResponse expectedMetadataResponse = new MetadataResponse();

--- a/services/venice-server/src/test/java/com/linkedin/venice/listener/request/MetadataFetchRequestTest.java
+++ b/services/venice-server/src/test/java/com/linkedin/venice/listener/request/MetadataFetchRequestTest.java
@@ -16,7 +16,7 @@ public class MetadataFetchRequestTest {
     String storeName = "test_store";
     String uri = "/" + QueryAction.METADATA.toString().toLowerCase() + "/" + storeName;
     HttpRequest httpRequest = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, uri);
-    MetadataFetchRequest testRequest = MetadataFetchRequest.parseGetHttpRequest(httpRequest);
+    MetadataFetchRequest testRequest = MetadataFetchRequest.parseGetHttpRequest();
 
     Assert.assertEquals(testRequest.getStoreName(), storeName);
   }
@@ -27,7 +27,7 @@ public class MetadataFetchRequestTest {
     HttpRequest httpRequest = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, uri);
 
     try {
-      MetadataFetchRequest.parseGetHttpRequest(httpRequest);
+      MetadataFetchRequest.parseGetHttpRequest();
       Assert.fail("Venice Exception was not thrown");
     } catch (VeniceException e) {
       Assert.assertEquals(e.getMessage(), "not a valid request for a METADATA action: " + uri);

--- a/services/venice-server/src/test/java/com/linkedin/venice/listener/request/MetadataFetchRequestTest.java
+++ b/services/venice-server/src/test/java/com/linkedin/venice/listener/request/MetadataFetchRequestTest.java
@@ -2,10 +2,7 @@ package com.linkedin.venice.listener.request;
 
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.meta.QueryAction;
-import io.netty.handler.codec.http.DefaultFullHttpRequest;
-import io.netty.handler.codec.http.HttpMethod;
-import io.netty.handler.codec.http.HttpRequest;
-import io.netty.handler.codec.http.HttpVersion;
+import java.net.URI;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -15,8 +12,7 @@ public class MetadataFetchRequestTest {
   public void testParseGetValidHttpRequest() {
     String storeName = "test_store";
     String uri = "/" + QueryAction.METADATA.toString().toLowerCase() + "/" + storeName;
-    HttpRequest httpRequest = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, uri);
-    MetadataFetchRequest testRequest = MetadataFetchRequest.parseGetHttpRequest();
+    MetadataFetchRequest testRequest = MetadataFetchRequest.parseGetHttpRequest(URI.create(uri));
 
     Assert.assertEquals(testRequest.getStoreName(), storeName);
   }
@@ -24,10 +20,9 @@ public class MetadataFetchRequestTest {
   @Test
   public void testParseGetInvalidHttpRequest() {
     String uri = "/" + QueryAction.METADATA.toString().toLowerCase();
-    HttpRequest httpRequest = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, uri);
 
     try {
-      MetadataFetchRequest.parseGetHttpRequest();
+      MetadataFetchRequest.parseGetHttpRequest(URI.create(uri));
       Assert.fail("Venice Exception was not thrown");
     } catch (VeniceException e) {
       Assert.assertEquals(e.getMessage(), "not a valid request for a METADATA action: " + uri);

--- a/services/venice-server/src/test/java/com/linkedin/venice/listener/request/MetadataFetchRequestTest.java
+++ b/services/venice-server/src/test/java/com/linkedin/venice/listener/request/MetadataFetchRequestTest.java
@@ -2,6 +2,7 @@ package com.linkedin.venice.listener.request;
 
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.meta.QueryAction;
+import com.linkedin.venice.request.RequestHelper;
 import java.net.URI;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -12,7 +13,8 @@ public class MetadataFetchRequestTest {
   public void testParseGetValidHttpRequest() {
     String storeName = "test_store";
     String uri = "/" + QueryAction.METADATA.toString().toLowerCase() + "/" + storeName;
-    MetadataFetchRequest testRequest = MetadataFetchRequest.parseGetHttpRequest(URI.create(uri));
+    MetadataFetchRequest testRequest =
+        MetadataFetchRequest.parseGetHttpRequest(uri, RequestHelper.getRequestParts(URI.create(uri)));
 
     Assert.assertEquals(testRequest.getStoreName(), storeName);
   }
@@ -22,7 +24,7 @@ public class MetadataFetchRequestTest {
     String uri = "/" + QueryAction.METADATA.toString().toLowerCase();
 
     try {
-      MetadataFetchRequest.parseGetHttpRequest(URI.create(uri));
+      MetadataFetchRequest.parseGetHttpRequest(uri, RequestHelper.getRequestParts(URI.create(uri)));
       Assert.fail("Venice Exception was not thrown");
     } catch (VeniceException e) {
       Assert.assertEquals(e.getMessage(), "not a valid request for a METADATA action: " + uri);

--- a/services/venice-server/src/test/java/com/linkedin/venice/listener/request/RequestHelperTest.java
+++ b/services/venice-server/src/test/java/com/linkedin/venice/listener/request/RequestHelperTest.java
@@ -1,6 +1,7 @@
 package com.linkedin.venice.listener.request;
 
 import com.linkedin.venice.request.RequestHelper;
+import java.net.URI;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -12,7 +13,7 @@ public class RequestHelperTest {
     String action = "test_query";
     String uri = "/" + action + "/" + storeName;
 
-    String[] requestParts = RequestHelper.getRequestParts(uri);
+    String[] requestParts = RequestHelper.getRequestParts(URI.create(uri));
 
     Assert.assertEquals(requestParts[1], action);
     Assert.assertEquals(requestParts[2], storeName);
@@ -25,7 +26,7 @@ public class RequestHelperTest {
     String query = "key=value";
     String uri = "/" + action + "/" + storeName + "?" + query;
 
-    String[] requestParts = RequestHelper.getRequestParts(uri);
+    String[] requestParts = RequestHelper.getRequestParts(URI.create(uri));
 
     Assert.assertEquals(requestParts[1], action);
     Assert.assertEquals(requestParts[2], storeName + "?" + query);


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

##  Reuse resource names and URI object during server read request processing.
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

During read request processing server calls String::split and creates URI object multiple times in the hot path. This PR tries to reuse those objects as much as possible. 
## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
CI
## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.