### PR TITLE
[server][da-vinci] Bug fix: unsorted drainer service metrics failed to register

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreBufferService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreBufferService.java
@@ -80,10 +80,10 @@ public class StoreBufferService extends AbstractStoreBufferService {
     }
     this.isSorted = sorted;
     this.leaderRecordHandler = queueLeaderWrites ? this::queueLeaderRecord : StoreBufferService::processRecord;
-    String metricName = sorted ? "StoreBufferServiceSorted" : "StoreBufferServiceUnsorted";
+    String metricNamePrefix = sorted ? "StoreBufferServiceSorted" : "StoreBufferServiceUnsorted";
     this.storeBufferServiceStats = new StoreBufferServiceStats(
         metricsRepository,
-        metricName,
+        metricNamePrefix,
         this::getTotalMemoryUsage,
         this::getTotalRemainingMemory,
         this::getMaxMemoryUsagePerDrainer,

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreBufferService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreBufferService.java
@@ -80,8 +80,10 @@ public class StoreBufferService extends AbstractStoreBufferService {
     }
     this.isSorted = sorted;
     this.leaderRecordHandler = queueLeaderWrites ? this::queueLeaderRecord : StoreBufferService::processRecord;
+    String metricName = sorted ? "StoreBufferServiceSorted" : "StoreBufferServiceUnsorted";
     this.storeBufferServiceStats = new StoreBufferServiceStats(
         metricsRepository,
+        metricName,
         this::getTotalMemoryUsage,
         this::getTotalRemainingMemory,
         this::getMaxMemoryUsagePerDrainer,

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/StoreBufferServiceStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/StoreBufferServiceStats.java
@@ -20,11 +20,12 @@ public class StoreBufferServiceStats extends AbstractVeniceStats {
 
   public StoreBufferServiceStats(
       MetricsRepository metricsRepository,
+      String metricName,
       LongSupplier totalMemoryUsageSupplier,
       LongSupplier totalRemainingMemorySupplier,
       LongSupplier maxMemoryUsagePerDrainerSupplier,
       LongSupplier minMemoryUsagePerDrainerSupplier) {
-    super(metricsRepository, "StoreBufferService");
+    super(metricsRepository, metricName);
     totalMemoryUsageSensor = registerSensor(
         new AsyncGauge((ignored, ignored2) -> totalMemoryUsageSupplier.getAsLong(), "total_memory_usage"));
     totalRemainingMemorySensor = registerSensor(

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/StoreBufferServiceStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/StoreBufferServiceStats.java
@@ -20,12 +20,12 @@ public class StoreBufferServiceStats extends AbstractVeniceStats {
 
   public StoreBufferServiceStats(
       MetricsRepository metricsRepository,
-      String metricName,
+      String metricNamePrefix,
       LongSupplier totalMemoryUsageSupplier,
       LongSupplier totalRemainingMemorySupplier,
       LongSupplier maxMemoryUsagePerDrainerSupplier,
       LongSupplier minMemoryUsagePerDrainerSupplier) {
-    super(metricsRepository, metricName);
+    super(metricsRepository, metricNamePrefix);
     totalMemoryUsageSensor = registerSensor(
         new AsyncGauge((ignored, ignored2) -> totalMemoryUsageSupplier.getAsLong(), "total_memory_usage"));
     totalRemainingMemorySensor = registerSensor(

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/SeparatedStoreBufferServiceTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/SeparatedStoreBufferServiceTest.java
@@ -29,5 +29,6 @@ public class SeparatedStoreBufferServiceTest {
     Assert.assertNotNull(
         metricsRepo.getSensor(".StoreBufferServiceUnsorted--max_memory_usage_per_writer"),
         "Missing metric from unsorted drainers");
+    separatedStoreBufferService.close();
   }
 }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/SeparatedStoreBufferServiceTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/SeparatedStoreBufferServiceTest.java
@@ -1,0 +1,33 @@
+package com.linkedin.davinci.kafka.consumer;
+
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+import com.linkedin.davinci.config.VeniceServerConfig;
+import io.tehuti.metrics.MetricsRepository;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class SeparatedStoreBufferServiceTest {
+  private final MetricsRepository metricsRepo = new MetricsRepository();
+
+  @Test
+  public void testSeparatedStoreBufferHaveTwoSetsOfMetrics() {
+    VeniceServerConfig serverConfig = mock(VeniceServerConfig.class);
+    doReturn(8).when(serverConfig).getDrainerPoolSizeSortedInput();
+    doReturn(8).when(serverConfig).getDrainerPoolSizeUnsortedInput();
+    doReturn(1000l).when(serverConfig).getStoreWriterBufferNotifyDelta();
+    doReturn(1000l).when(serverConfig).getStoreWriterBufferMemoryCapacity();
+    SeparatedStoreBufferService separatedStoreBufferService =
+        new SeparatedStoreBufferService(serverConfig, metricsRepo);
+    // Verify that metricsRepo has two sets of metrics, example metric:
+    // StoreBufferServiceSorted--max_memory_usage_per_writer and StoreBufferServiceUnsorted--max_memory_usage_per_writer
+    Assert.assertNotNull(
+        metricsRepo.getSensor(".StoreBufferServiceSorted--max_memory_usage_per_writer"),
+        "Missing metric from sorted drainers");
+    Assert.assertNotNull(
+        metricsRepo.getSensor(".StoreBufferServiceUnsorted--max_memory_usage_per_writer"),
+        "Missing metric from unsorted drainers");
+  }
+}


### PR DESCRIPTION
## Summary
Both sorted and unsorted drainer services are using the same metrics name, and sorted drainer service registers metric first; as a result, unsorted drainer service fails to register because it believes the metrics already exist - inside AbstractVeniceStats#registerSensor, it calls HashMap#computeIfAbsent, so whoever comes later with the same name would fail to register.

This PR fixes the bug by using different metric name prefix: StoreBufferServiceSorted
StoreBufferServiceUnsorted

## How was this PR tested?
Added unit test to ensure two sets of metrics are registered.

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.