### PR TITLE
[server] Add metric to verifying current version prioritization strategy.

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -1305,7 +1305,13 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
             newWorkloadType);
         versionRole = newVersionRole;
         workloadType = newWorkloadType;
-        resubscribeForAllPartitions();
+        try {
+          resubscribeForAllPartitions();
+        } catch (Exception e) {
+          LOGGER.error("Error happened during resubscription when store version ingestion role changed.", e);
+          hostLevelIngestionStats.recordResubscriptionFailure();
+          throw e;
+        }
       }
     }
   }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/AggKafkaConsumerServiceStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/AggKafkaConsumerServiceStats.java
@@ -79,6 +79,10 @@ public class AggKafkaConsumerServiceStats extends AbstractVeniceAggStoreStats<Ka
     totalStats.recordAvgPartitionsPerConsumer(count);
   }
 
+  public void recordTotalSubscribedPartitionsNum(int count) {
+    totalStats.recordSubscribedPartitionsNum(count);
+  }
+
   public void recordTotalOffsetLagIsAbsent() {
     totalStats.recordOffsetLagIsAbsent();
   }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/HostLevelIngestionStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/HostLevelIngestionStats.java
@@ -58,6 +58,8 @@ public class HostLevelIngestionStats extends AbstractVeniceStats {
   private final Sensor inconsistentStoreMetadataSensor;
   private final Sensor ingestionFailureSensor;
 
+  private final Sensor resubscriptionFailureSensor;
+
   private final Sensor viewProducerLatencySensor;
   /**
    * Sensors for emitting if/when we detect DCR violations (such as a backwards timestamp or receding offset vector)
@@ -325,6 +327,12 @@ public class HostLevelIngestionStats extends AbstractVeniceStats {
         () -> totalStats.ingestionFailureSensor,
         new Count());
 
+    this.resubscriptionFailureSensor = registerPerStoreAndTotalSensor(
+        "resubscription_failure",
+        totalStats,
+        () -> totalStats.resubscriptionFailureSensor,
+        new Count());
+
     this.leaderProducerSynchronizeLatencySensor = registerPerStoreAndTotalSensor(
         "leader_producer_synchronize_latency",
         totalStats,
@@ -485,6 +493,10 @@ public class HostLevelIngestionStats extends AbstractVeniceStats {
 
   public void recordIngestionFailure() {
     ingestionFailureSensor.record();
+  }
+
+  public void recordResubscriptionFailure() {
+    resubscriptionFailureSensor.record();
   }
 
   public void recordLeaderProducerSynchronizeLatency(double latency) {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/KafkaConsumerServiceStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/KafkaConsumerServiceStats.java
@@ -37,6 +37,7 @@ public class KafkaConsumerServiceStats extends AbstractVeniceStats {
   private final Sensor maxPartitionsPerConsumer;
   private final Sensor minPartitionsPerConsumer;
   private final Sensor avgPartitionsPerConsumer;
+  private final Sensor subscribedPartitionsNum;
   private final Sensor getOffsetLagIsAbsentSensor;
   private final Sensor getOffsetLagIsPresentSensor;
   private final Sensor getLatestOffsetIsAbsentSensor;
@@ -106,6 +107,7 @@ public class KafkaConsumerServiceStats extends AbstractVeniceStats {
     minPartitionsPerConsumer = registerSensor("min_partitions_per_consumer", new Gauge());
     maxPartitionsPerConsumer = registerSensor("max_partitions_per_consumer", new Gauge());
     avgPartitionsPerConsumer = registerSensor("avg_partitions_per_consumer", new Gauge());
+    subscribedPartitionsNum = registerSensor("subscribed_partitions_num", new Gauge());
 
     Sensor getOffsetLagSensor = registerSensor("getOffsetLag", new OccurrenceRate());
     Sensor[] offsetLagParent = new Sensor[] { getOffsetLagSensor };
@@ -191,5 +193,9 @@ public class KafkaConsumerServiceStats extends AbstractVeniceStats {
 
   public void recordConsumerIdleTime(double time) {
     idleTimeSensor.record(time);
+  }
+
+  public void recordSubscribedPartitionsNum(int count) {
+    subscribedPartitionsNum.record(count);
   }
 }


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Summary, imperative, start upper case, don't end with a period
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

This PR adds 2 metrics:
1) `total_kafka_consumer_service_for_<pub sub region alias>--subscribed_partitions_num`: consumer pool level metric total subscribed topic partitions of all consumers, this could be used to verify specific pool subscription change when a new version push is happened.
2) `<store name>--resubscription_failure`: store level metric to alert on exception throwing during resubscription when ingestion role changed.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.