### PR TITLE
[fc] Fix fast client multiget metrics to use the right context

### DIFF
--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/DispatchingAvroGenericStoreClient.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/DispatchingAvroGenericStoreClient.java
@@ -506,7 +506,7 @@ public class DispatchingAvroGenericStoreClient<K, V> extends InternalAvroStoreCl
         LOGGER.error(errorMessage);
       }
       VeniceClientHttpException clientException = new VeniceClientHttpException(errorMessage, SC_BAD_GATEWAY);
-      requestContext.setPartialResponseException(clientException);
+      requestContext.setPartialResponseExceptionIfNull(clientException);
       CompletableFuture<Integer> placeholderFailedFuture = new CompletableFuture<>();
       placeholderFailedFuture.completeExceptionally(clientException);
       requestCompletionFutures[routeIndex] = placeholderFailedFuture;

--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/DualReadAvroGenericStoreClient.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/DualReadAvroGenericStoreClient.java
@@ -140,12 +140,8 @@ public class DualReadAvroGenericStoreClient<K, V> extends DelegatingAvroStoreCli
   protected CompletableFuture<V> get(GetRequestContext requestContext, K key) throws VeniceClientException {
     /**
      * If a user calls {@link batchGet}, the {@link batchGet} would trigger a dual read on the thin-client and
-     * fast-client. If internally, batch get gets executed through a series of single gets, we shouldn't trigger dual
-     * reads on the internal {@link get} calls.
+     * fast-client.
      */
-    if (requestContext.isTriggeredByBatchGet) {
-      return super.get(requestContext, key);
-    }
     return dualExecute(() -> super.get(requestContext, key), () -> thinClient.get(key), clientStatsForSingleGet);
   }
 

--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/GetRequestContext.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/GetRequestContext.java
@@ -6,14 +6,12 @@ public class GetRequestContext extends RequestContext {
    * This field is used to store the request uri to the backend.
    */
   String requestUri;
-  RetryContext retryContext;
-  final boolean isTriggeredByBatchGet;
+  RetryContext retryContext; // initialize if needed for retry
 
-  GetRequestContext(boolean isTriggeredByBatchGet) {
+  GetRequestContext() {
     partitionId = -1;
     requestUri = null;
     retryContext = null;
-    this.isTriggeredByBatchGet = isTriggeredByBatchGet;
   }
 
   static class RetryContext {

--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/MultiKeyRequestContext.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/MultiKeyRequestContext.java
@@ -85,6 +85,9 @@ public abstract class MultiKeyRequestContext<K, V> extends RequestContext {
   }
 
   void complete() {
+    if (completed) {
+      return;
+    }
     completed = true;
     // Roll up route stats into overall stats
     long decompressionTimeNS = 0;
@@ -144,8 +147,12 @@ public abstract class MultiKeyRequestContext<K, V> extends RequestContext {
     return Optional.ofNullable(partialResponseException.get());
   }
 
-  void setPartialResponseException(Throwable exception) {
+  void setPartialResponseExceptionIfNull(Throwable exception) {
     this.partialResponseException.compareAndSet(null, exception);
+  }
+
+  void setPartialResponseException(Throwable exception) {
+    this.partialResponseException.set(exception);
   }
 
   /* Utility validation methods */

--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/RetriableAvroGenericStoreClient.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/RetriableAvroGenericStoreClient.java
@@ -183,7 +183,8 @@ public class RetriableAvroGenericStoreClient<K, V> extends DelegatingAvroStoreCl
           timeoutFuture.cancel();
         }
         if (finalFuture.complete(value)) {
-          // original request is faster
+          // original request is faster: Resetting it even though the default is false is to be accurate as
+          // retryWin is set to true in the above block before completing the future, so there can be a race.
           requestContext.retryContext.retryWin = false;
         }
       } else {
@@ -280,8 +281,6 @@ public class RetriableAvroGenericStoreClient<K, V> extends DelegatingAvroStoreCl
       int longTailRetryThresholdInMicroSeconds,
       RequestContextConstructor<K, V, R> requestContextConstructor,
       StreamingRequestExecutor<K, V, R, RESPONSE> streamingRequestExecutor) throws VeniceClientException {
-    R originalRequestContext = requestContextConstructor.construct(keys.size(), requestContext.isPartialSuccessAllowed);
-
     requestContext.retryContext = new MultiKeyRequestContext.RetryContext<K, V>();
 
     /** Track the final completion of the request. It will be completed normally if
@@ -307,8 +306,8 @@ public class RetriableAvroGenericStoreClient<K, V> extends DelegatingAvroStoreCl
       if (!pendingKeysFuture.isEmpty()) {
         Throwable throwable = savedException.get();
         if (isExceptionCausedByTooManyRequests(throwable)) {
-          // Defensive code, do not trigger retry and complete the final request completion future if we encountered
-          // 429.
+          // Defensive code, do not trigger retry and complete the final request completion
+          // future if we encountered 429.
           finalRequestCompletionFuture.completeExceptionally(throwable);
           return;
         }
@@ -320,7 +319,7 @@ public class RetriableAvroGenericStoreClient<K, V> extends DelegatingAvroStoreCl
           requestContext.retryContext.retryRequestContext = retryRequestContext;
           LOGGER.debug("Retrying {} incomplete keys", retryRequestContext.numKeysInRequest);
           // Prepare the retry context and track excluded routes on a per-partition basis
-          retryRequestContext.setRoutesForPartitionMapping(originalRequestContext.getRoutesForPartitionMapping());
+          retryRequestContext.setRoutesForPartitionMapping(requestContext.getRoutesForPartitionMapping());
 
           streamingRequestExecutor.trigger(
               retryRequestContext,
@@ -352,22 +351,21 @@ public class RetriableAvroGenericStoreClient<K, V> extends DelegatingAvroStoreCl
      * all incomplete keys whether due to long tail or errors (e.g. mis-routed) are retried.
      */
     streamingRequestExecutor.trigger(
-        originalRequestContext,
+        requestContext,
         keys,
         getStreamingCallback(
-            originalRequestContext,
+            requestContext,
             finalRequestCompletionFuture,
             savedException,
             pendingKeysFuture,
             scheduledRetryTask));
-    multiKeyLongTailRetryManager.recordRequests(originalRequestContext.numKeysInRequest);
+    multiKeyLongTailRetryManager.recordRequests(requestContext.numKeysInRequest);
 
     finalRequestCompletionFuture.whenComplete((ignore, finalException) -> {
       if (!scheduledRetryTask.isDone()) {
         scheduledRetryTask.cancel();
       }
       requestContext.complete();
-      requestContext.setFanoutSize(originalRequestContext.getFanoutSize());
       if (finalException == null) {
         callback.onCompletion(Optional.empty());
       } else {

--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/StatsAvroGenericStoreClient.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/StatsAvroGenericStoreClient.java
@@ -122,9 +122,6 @@ public class StatsAvroGenericStoreClient<K, V> extends DelegatingAvroStoreClient
       // If partial success is allowed, the previous layers will not complete the future exceptionally. In such cases,
       // we check if the request is completed successfully with partial exceptions - and these are considered unhealthy
       // requests from metrics point of view.
-      /*boolean exceptionReceived = throwable != null || (requestContext instanceof MultiKeyRequestContext
-          && ((MultiKeyRequestContext) requestContext).isCompletedSuccessfullyWithPartialResponse());*/
-
       boolean exceptionReceived = false;
       if (throwable != null) {
         exceptionReceived = true;
@@ -132,7 +129,6 @@ public class StatsAvroGenericStoreClient<K, V> extends DelegatingAvroStoreClient
         // check for partial failures for multi-key requests
         if (requestContext instanceof MultiKeyRequestContext) {
           MultiKeyRequestContext multiKeyRequestContext = (MultiKeyRequestContext) requestContext;
-          // if retry request is completed,
           boolean checkOriginalRequestContext = false;
           if (multiKeyRequestContext.retryContext != null
               && multiKeyRequestContext.retryContext.retryRequestContext != null) {
@@ -145,9 +141,8 @@ public class StatsAvroGenericStoreClient<K, V> extends DelegatingAvroStoreClient
             }
             if (exceptionReceived) {
               // if there is no exception in the retry request, everything passed, but if there is an exception in the
-              // retry request, that might have passed in the original request after the retry started. Rather than
-              // trying to
-              // check the exact key's status, validate using the count of keys completed.
+              // retry request, that failure might have passed in the original request after the retry started. checking
+              // the numKeysCompleted for now.
               int totalKeyCount = multiKeyRequestContext.numKeysInRequest;
               int successKeyCount = multiKeyRequestContext.numKeysCompleted.get()
                   + multiKeyRequestContext.retryContext.retryRequestContext.numKeysCompleted.get();
@@ -167,11 +162,6 @@ public class StatsAvroGenericStoreClient<K, V> extends DelegatingAvroStoreClient
               throwable = (Throwable) multiKeyRequestContext.getPartialResponseException().get();
             }
           }
-          /*if (multiKeyRequestContext.retryContext != null && multiKeyRequestContext.retryContext.retryRequestContext != null) {
-            exceptionReceived = multiKeyRequestContext.retryContext.retryRequestContext.isCompletedSuccessfullyWithPartialResponse();
-          } else {
-            exceptionReceived = multiKeyRequestContext.isCompletedSuccessfullyWithPartialResponse();
-          }*/
         }
       }
       if (exceptionReceived || (latency > TIMEOUT_IN_SECOND * Time.MS_PER_SECOND)) {

--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/StatsAvroGenericStoreClient.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/StatsAvroGenericStoreClient.java
@@ -128,12 +128,14 @@ public class StatsAvroGenericStoreClient<K, V> extends DelegatingAvroStoreClient
       } else {
         // check for partial failures for multi-key requests
         if (requestContext instanceof MultiKeyRequestContext) {
-          throwable = checkBatchGetPartialFailure((MultiKeyRequestContext) requestContext);
-          if (throwable != null) {
+          MultiKeyRequestContext multiKeyRequestContext = (MultiKeyRequestContext) requestContext;
+          if (multiKeyRequestContext.isCompletedSuccessfullyWithPartialResponse()) {
             exceptionReceived = true;
+            throwable = (Throwable) multiKeyRequestContext.getPartialResponseException().get();
           }
         }
       }
+
       if (exceptionReceived || (latency > TIMEOUT_IN_SECOND * Time.MS_PER_SECOND)) {
         clientStats.recordUnhealthyRequest();
         clientStats.recordUnhealthyLatency(latency);

--- a/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/DispatchingAvroGenericStoreClientTest.java
+++ b/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/DispatchingAvroGenericStoreClientTest.java
@@ -533,7 +533,7 @@ public class DispatchingAvroGenericStoreClientTest {
   public void testGet() throws ExecutionException, InterruptedException, IOException {
     try {
       setUpClient();
-      GetRequestContext getRequestContext = new GetRequestContext(false);
+      GetRequestContext getRequestContext = new GetRequestContext();
       GenericRecord value = (GenericRecord) statsAvroGenericStoreClient.get(getRequestContext, "test_key").get();
       assertEquals(value, SINGLE_GET_VALUE_RESPONSE);
       validateSingleGetMetrics(getRequestContext, true);
@@ -547,7 +547,7 @@ public class DispatchingAvroGenericStoreClientTest {
     GetRequestContext getRequestContext = null;
     try {
       setUpClient(true, false, false);
-      getRequestContext = new GetRequestContext(false);
+      getRequestContext = new GetRequestContext();
       statsAvroGenericStoreClient.get(getRequestContext, "test_key").get().toString();
       fail();
     } catch (Exception e) {
@@ -563,7 +563,7 @@ public class DispatchingAvroGenericStoreClientTest {
     GetRequestContext getRequestContext = null;
     try {
       setUpClient(false, false, false, false, 2 * Time.MS_PER_SECOND);
-      getRequestContext = new GetRequestContext(false);
+      getRequestContext = new GetRequestContext();
       statsAvroGenericStoreClient.get(getRequestContext, "test_key").get();
       fail();
     } catch (Exception e) {

--- a/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/RetriableAvroGenericStoreClientTest.java
+++ b/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/RetriableAvroGenericStoreClientTest.java
@@ -84,7 +84,7 @@ public class RetriableAvroGenericStoreClientTest {
   private StatsAvroGenericStoreClient<String, GenericRecord> statsAvroGenericStoreClient;
   private Map<String, ? extends Metric> metrics;
 
-  public static final Object[] FASTCLIENT_REQUEST_TYPES = { RequestType.SINGLE_GET, RequestType.MULTI_GET,
+  private static final Object[] FASTCLIENT_REQUEST_TYPES = { RequestType.SINGLE_GET, RequestType.MULTI_GET,
       RequestType.MULTI_GET_STREAMING, RequestType.COMPUTE, RequestType.COMPUTE_STREAMING };
 
   @DataProvider(name = "FastClient-RequestTypes")

--- a/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/RetriableAvroGenericStoreClientTest.java
+++ b/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/RetriableAvroGenericStoreClientTest.java
@@ -222,6 +222,7 @@ public class RetriableAvroGenericStoreClientTest {
         if (requestCnt == 1) {
           // Mock the original request
           scheduledExecutor.schedule(() -> {
+            requestContext.complete();
             if (originalRequestThrowException) {
               callback.onCompletion(Optional.of(new VeniceClientException("Original request exception")));
             } else if (noReplicaFound) {
@@ -241,6 +242,7 @@ public class RetriableAvroGenericStoreClientTest {
         } else if (requestCnt == 2) {
           // Mock the retry request
           scheduledExecutor.schedule(() -> {
+            requestContext.complete();
             if (retryRequestThrowException) {
               callback.onCompletion(Optional.of(new VeniceClientException("Retry request exception")));
             } else if (noReplicaFound) {
@@ -278,6 +280,7 @@ public class RetriableAvroGenericStoreClientTest {
         if (requestCnt == 1) {
           // Mock the original request
           scheduledExecutor.schedule(() -> {
+            requestContext.complete();
             if (originalRequestThrowException) {
               callback.onCompletion(Optional.of(new VeniceClientException("Original request exception")));
             } else if (noReplicaFound) {
@@ -297,6 +300,7 @@ public class RetriableAvroGenericStoreClientTest {
         } else if (requestCnt == 2) {
           // Mock the retry request
           scheduledExecutor.schedule(() -> {
+            requestContext.complete();
             if (retryRequestThrowException) {
               callback.onCompletion(Optional.of(new VeniceClientException("Retry request exception")));
             } else if (noReplicaFound) {
@@ -495,7 +499,7 @@ public class RetriableAvroGenericStoreClientTest {
     double expectedKeyCount = (batchGet || computeRequest) ? 2.0 : 1.0;
 
     String finalMetricsPrefix = metricsPrefix;
-    TestUtils.waitForNonDeterministicAssertion(5, TimeUnit.SECONDS, () -> {
+    TestUtils.waitForNonDeterministicAssertion(3, TimeUnit.SECONDS, () -> {
       assertTrue(metrics.get(finalMetricsPrefix + "request.OccurrenceRate").value() > 0);
     });
     assertEquals(metrics.get(metricsPrefix + "request_key_count.Max").value(), expectedKeyCount);
@@ -639,7 +643,7 @@ public class RetriableAvroGenericStoreClientTest {
    * Original request latency is higher than retry threshold and slower than the retry request
    */
   @Test(dataProvider = "FastClient-RequestTypes-And-Two-Boolean", timeOut = TEST_TIMEOUT)
-  public void testGetWithTriggeringLongTailRetryAndRetryWins1(
+  public void testGetWithTriggeringLongTailRetryAndRetryWins(
       RequestType requestType,
       boolean keyNotFound,
       boolean noReplicaFound) throws ExecutionException, InterruptedException {

--- a/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/RetriableAvroGenericStoreClientTest.java
+++ b/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/RetriableAvroGenericStoreClientTest.java
@@ -84,10 +84,18 @@ public class RetriableAvroGenericStoreClientTest {
   private StatsAvroGenericStoreClient<String, GenericRecord> statsAvroGenericStoreClient;
   private Map<String, ? extends Metric> metrics;
 
+  public static final Object[] FASTCLIENT_REQUEST_TYPES = { RequestType.SINGLE_GET, RequestType.MULTI_GET,
+      RequestType.MULTI_GET_STREAMING, RequestType.COMPUTE, RequestType.COMPUTE_STREAMING };
+
   @DataProvider(name = "FastClient-RequestTypes")
   public Object[][] fcRequestTypes() {
-    return new Object[][] { { RequestType.SINGLE_GET }, { RequestType.MULTI_GET }, { RequestType.MULTI_GET_STREAMING },
-        { RequestType.COMPUTE }, { RequestType.COMPUTE_STREAMING } };
+    return DataProviderUtils.allPermutationGenerator(FASTCLIENT_REQUEST_TYPES);
+  }
+
+  @DataProvider(name = "FastClient-RequestTypes-And-Two-Boolean")
+  public Object[][] fcRequestTypesAndTwoBoolean() {
+    return DataProviderUtils
+        .allPermutationGenerator(FASTCLIENT_REQUEST_TYPES, DataProviderUtils.BOOLEAN, DataProviderUtils.BOOLEAN);
   }
 
   @BeforeClass
@@ -126,8 +134,7 @@ public class RetriableAvroGenericStoreClientTest {
     projectionResultForKey2.put(VENICE_COMPUTATION_ERROR_MAP_FIELD_NAME, Collections.emptyMap());
     ComputeGenericRecord computeGenericRecordForProjectionKey2 =
         new ComputeGenericRecord(projectionResultForKey2, STORE_VALUE_SCHEMA);
-    COMPUTE_REQUEST_VALUE_RESPONSE
-        .put("test_key_2", new ComputeGenericRecord(computeGenericRecordForProjectionKey2, STORE_VALUE_SCHEMA));
+    COMPUTE_REQUEST_VALUE_RESPONSE.put("test_key_2", computeGenericRecordForProjectionKey2);
 
     COMPUTE_REQUEST_VALUE_RESPONSE_KEY_NOT_FOUND_CASE.put("test_key_2", computeGenericRecordForProjectionKey2);
   }
@@ -148,6 +155,7 @@ public class RetriableAvroGenericStoreClientTest {
       boolean retryRequestThrowException,
       long retryRequestDelayMs,
       boolean keyNotFound,
+      boolean noReplicaFound,
       ClientConfig clientConfig) {
     StoreMetadata mockMetadata = mock(StoreMetadata.class);
     doReturn(STORE_NAME).when(mockMetadata).getStoreName();
@@ -169,12 +177,14 @@ public class RetriableAvroGenericStoreClientTest {
           scheduledExecutor.schedule(() -> {
             if (originalRequestThrowException) {
               originalRequestFuture.completeExceptionally(new VeniceClientException("Original request exception"));
+            } else if (noReplicaFound) {
+              requestContext.noAvailableReplica = true;
+              originalRequestFuture
+                  .completeExceptionally(new VeniceClientException("At least one route did not complete"));
+            } else if (keyNotFound) {
+              originalRequestFuture.complete(null);
             } else {
-              if (keyNotFound) {
-                originalRequestFuture.complete(null);
-              } else {
-                originalRequestFuture.complete(SINGLE_GET_VALUE_RESPONSE);
-              }
+              originalRequestFuture.complete(SINGLE_GET_VALUE_RESPONSE);
             }
           }, originalRequestDelayMs, TimeUnit.MILLISECONDS);
           return originalRequestFuture;
@@ -185,7 +195,11 @@ public class RetriableAvroGenericStoreClientTest {
             if (retryRequestThrowException) {
               retryRequestFuture.completeExceptionally(new VeniceClientException("Retry request exception"));
             } else {
-              if (keyNotFound) {
+              if (noReplicaFound) {
+                requestContext.noAvailableReplica = true;
+                retryRequestFuture
+                    .completeExceptionally(new VeniceClientException("At least one route did not complete"));
+              } else if (keyNotFound) {
                 retryRequestFuture.complete(null);
               } else {
                 retryRequestFuture.complete(SINGLE_GET_VALUE_RESPONSE);
@@ -210,6 +224,9 @@ public class RetriableAvroGenericStoreClientTest {
           scheduledExecutor.schedule(() -> {
             if (originalRequestThrowException) {
               callback.onCompletion(Optional.of(new VeniceClientException("Original request exception")));
+            } else if (noReplicaFound) {
+              requestContext.noAvailableReplica = true;
+              callback.onCompletion(Optional.of(new VeniceClientException("At least one route did not complete")));
             } else {
               BATCH_GET_KEYS.forEach(key -> {
                 if (key.equals("test_key_1") && keyNotFound) {
@@ -226,6 +243,9 @@ public class RetriableAvroGenericStoreClientTest {
           scheduledExecutor.schedule(() -> {
             if (retryRequestThrowException) {
               callback.onCompletion(Optional.of(new VeniceClientException("Retry request exception")));
+            } else if (noReplicaFound) {
+              requestContext.noAvailableReplica = true;
+              callback.onCompletion(Optional.of(new VeniceClientException("At least one route did not complete")));
             } else {
               BATCH_GET_KEYS.forEach(key -> {
                 if (key.equals("test_key_1") && keyNotFound) {
@@ -260,6 +280,9 @@ public class RetriableAvroGenericStoreClientTest {
           scheduledExecutor.schedule(() -> {
             if (originalRequestThrowException) {
               callback.onCompletion(Optional.of(new VeniceClientException("Original request exception")));
+            } else if (noReplicaFound) {
+              requestContext.noAvailableReplica = true;
+              callback.onCompletion(Optional.of(new VeniceClientException("At least one route did not complete")));
             } else {
               COMPUTE_REQUEST_KEYS.forEach(key -> {
                 if (key.equals("test_key_1") && keyNotFound) {
@@ -276,6 +299,9 @@ public class RetriableAvroGenericStoreClientTest {
           scheduledExecutor.schedule(() -> {
             if (retryRequestThrowException) {
               callback.onCompletion(Optional.of(new VeniceClientException("Retry request exception")));
+            } else if (noReplicaFound) {
+              requestContext.noAvailableReplica = true;
+              callback.onCompletion(Optional.of(new VeniceClientException("At least one route did not complete")));
             } else {
               COMPUTE_REQUEST_KEYS.forEach(key -> {
                 if (key.equals("test_key_1") && keyNotFound) {
@@ -310,11 +336,12 @@ public class RetriableAvroGenericStoreClientTest {
       boolean errorRetry,
       boolean longTailRetry,
       boolean retryWin,
-      boolean keyNotFound) throws ExecutionException, InterruptedException {
-    getRequestContext = new GetRequestContext(false);
+      boolean keyNotFound,
+      boolean noReplicaFound) throws ExecutionException, InterruptedException {
+    getRequestContext = new GetRequestContext();
     try {
       GenericRecord value = (GenericRecord) statsAvroGenericStoreClient.get(getRequestContext, "test_key").get();
-      if (bothOriginalAndRetryFails) {
+      if (bothOriginalAndRetryFails || noReplicaFound) {
         fail("An ExecutionException should be thrown here");
       }
       if (keyNotFound) {
@@ -323,26 +350,27 @@ public class RetriableAvroGenericStoreClientTest {
         assertEquals(value, SINGLE_GET_VALUE_RESPONSE);
       }
     } catch (ExecutionException e) {
-      if (!bothOriginalAndRetryFails) {
+      if (!(bothOriginalAndRetryFails || noReplicaFound)) {
         throw e;
       }
     }
 
-    validateMetrics(RequestType.SINGLE_GET, errorRetry, longTailRetry, retryWin);
+    validateMetrics(RequestType.SINGLE_GET, errorRetry, longTailRetry, retryWin, noReplicaFound);
   }
 
   private void testBatchGetAndValidateMetrics(
       boolean bothOriginalAndRetryFails,
       boolean longTailRetry,
       boolean retryWin,
-      boolean keyNotFound) throws ExecutionException, InterruptedException {
+      boolean keyNotFound,
+      boolean noReplicaFound) throws ExecutionException, InterruptedException {
     batchGetRequestContext = new BatchGetRequestContext<>(BATCH_GET_KEYS.size(), false);
     try {
       Map<String, GenericRecord> value =
           (Map<String, GenericRecord>) statsAvroGenericStoreClient.batchGet(batchGetRequestContext, BATCH_GET_KEYS)
               .get();
 
-      if (bothOriginalAndRetryFails) {
+      if (bothOriginalAndRetryFails || noReplicaFound) {
         fail("An ExecutionException should be thrown here");
       }
 
@@ -352,19 +380,20 @@ public class RetriableAvroGenericStoreClientTest {
         assertEquals(value, BATCH_GET_VALUE_RESPONSE);
       }
     } catch (ExecutionException e) {
-      if (!bothOriginalAndRetryFails) {
+      if (!(bothOriginalAndRetryFails || noReplicaFound)) {
         throw e;
       }
     }
 
-    validateMetrics(RequestType.MULTI_GET, false, longTailRetry, retryWin);
+    validateMetrics(RequestType.MULTI_GET, false, longTailRetry, retryWin, noReplicaFound);
   }
 
   private void testStreamingBatchGetAndValidateMetrics(
       boolean bothOriginalAndRetryFails,
       boolean longTailRetry,
       boolean retryWin,
-      boolean keyNotFound) throws ExecutionException, InterruptedException {
+      boolean keyNotFound,
+      boolean noReplicaFound) throws ExecutionException, InterruptedException {
     batchGetRequestContext = new BatchGetRequestContext<>(BATCH_GET_KEYS.size(), true);
     try {
       VeniceResponseMap<String, GenericRecord> value =
@@ -372,7 +401,7 @@ public class RetriableAvroGenericStoreClientTest {
               .streamingBatchGet(batchGetRequestContext, BATCH_GET_KEYS)
               .get();
 
-      if (bothOriginalAndRetryFails) {
+      if (bothOriginalAndRetryFails || noReplicaFound) {
         assertFalse(value.isFullResponse());
         assertTrue(value.isEmpty());
       } else if (keyNotFound) {
@@ -381,19 +410,18 @@ public class RetriableAvroGenericStoreClientTest {
         assertEquals(value, BATCH_GET_VALUE_RESPONSE);
       }
     } catch (ExecutionException e) {
-      if (!bothOriginalAndRetryFails) {
-        throw e;
-      }
+      throw e;
     }
 
-    validateMetrics(RequestType.MULTI_GET_STREAMING, false, longTailRetry, retryWin);
+    validateMetrics(RequestType.MULTI_GET_STREAMING, false, longTailRetry, retryWin, noReplicaFound);
   }
 
   private void testComputeAndValidateMetrics(
       boolean bothOriginalAndRetryFails,
       boolean longTailRetry,
       boolean retryWin,
-      boolean keyNotFound) throws ExecutionException, InterruptedException {
+      boolean keyNotFound,
+      boolean noReplicaFound) throws ExecutionException, InterruptedException {
     try {
       VeniceResponseMap<String, ComputeGenericRecord> value =
           (VeniceResponseMap<String, ComputeGenericRecord>) statsAvroGenericStoreClient.compute()
@@ -401,7 +429,7 @@ public class RetriableAvroGenericStoreClientTest {
               .execute(COMPUTE_REQUEST_KEYS)
               .get();
 
-      if (bothOriginalAndRetryFails) {
+      if (bothOriginalAndRetryFails || noReplicaFound) {
         fail("An ExecutionException should be thrown here");
       }
 
@@ -411,24 +439,25 @@ public class RetriableAvroGenericStoreClientTest {
         assertEquals(value, COMPUTE_REQUEST_VALUE_RESPONSE);
       }
     } catch (ExecutionException e) {
-      if (!bothOriginalAndRetryFails) {
+      if (!(bothOriginalAndRetryFails || noReplicaFound)) {
         throw e;
       }
     }
 
-    validateMetrics(RequestType.COMPUTE_STREAMING, false, longTailRetry, retryWin);
+    validateMetrics(RequestType.COMPUTE_STREAMING, false, longTailRetry, retryWin, noReplicaFound);
   }
 
   private void testStreamingComputeAndValidateMetrics(
       boolean bothOriginalAndRetryFails,
       boolean longTailRetry,
       boolean retryWin,
-      boolean keyNotFound) throws ExecutionException, InterruptedException {
+      boolean keyNotFound,
+      boolean noReplicaFound) throws ExecutionException, InterruptedException {
     try {
       VeniceResponseMap<String, ComputeGenericRecord> value =
           statsAvroGenericStoreClient.compute().project("name").streamingExecute(COMPUTE_REQUEST_KEYS).get();
 
-      if (bothOriginalAndRetryFails) {
+      if (bothOriginalAndRetryFails || noReplicaFound) {
         assertFalse(value.isFullResponse());
         assertTrue(value.isEmpty());
       } else if (keyNotFound) {
@@ -437,12 +466,10 @@ public class RetriableAvroGenericStoreClientTest {
         assertEquals(value, COMPUTE_REQUEST_VALUE_RESPONSE);
       }
     } catch (ExecutionException e) {
-      if (!bothOriginalAndRetryFails) {
-        throw e;
-      }
+      throw e;
     }
 
-    validateMetrics(RequestType.COMPUTE_STREAMING, false, longTailRetry, retryWin);
+    validateMetrics(RequestType.COMPUTE_STREAMING, false, longTailRetry, retryWin, noReplicaFound);
   }
 
   /**
@@ -452,7 +479,12 @@ public class RetriableAvroGenericStoreClientTest {
    * @param longTailRetry request is retried because the original request is taking more time
    * @param retryWin retry request wins
    */
-  private void validateMetrics(RequestType requestType, boolean errorRetry, boolean longTailRetry, boolean retryWin) {
+  private void validateMetrics(
+      RequestType requestType,
+      boolean errorRetry,
+      boolean longTailRetry,
+      boolean retryWin,
+      boolean noReplicaFound) {
     String metricsPrefix = ClientTestUtils.getMetricPrefix(STORE_NAME, requestType);
 
     boolean singleGet = requestType == RequestType.SINGLE_GET;
@@ -460,7 +492,7 @@ public class RetriableAvroGenericStoreClientTest {
     boolean computeRequest = requestType == RequestType.COMPUTE || requestType == RequestType.COMPUTE_STREAMING;
 
     metrics = getStats(clientConfig);
-    double expectedKeyCount = batchGet || computeRequest ? 2.0 : 1.0;
+    double expectedKeyCount = (batchGet || computeRequest) ? 2.0 : 1.0;
 
     String finalMetricsPrefix = metricsPrefix;
     TestUtils.waitForNonDeterministicAssertion(5, TimeUnit.SECONDS, () -> {
@@ -468,10 +500,23 @@ public class RetriableAvroGenericStoreClientTest {
     });
     assertEquals(metrics.get(metricsPrefix + "request_key_count.Max").value(), expectedKeyCount);
 
-    if (errorRetry || longTailRetry) {
+    if (noReplicaFound) {
+      assertTrue(metrics.get(metricsPrefix + "no_available_replica_request_count.OccurrenceRate").value() > 0);
+    } else if (errorRetry || longTailRetry) {
+      assertFalse(metrics.get(metricsPrefix + "no_available_replica_request_count.OccurrenceRate").value() > 0);
+      if (errorRetry) {
+        assertTrue(metrics.get(metricsPrefix + "error_retry_request.OccurrenceRate").value() > 0);
+        assertFalse(metrics.get(metricsPrefix + "long_tail_retry_request.OccurrenceRate").value() > 0);
+      } else {
+        assertFalse(metrics.get(metricsPrefix + "error_retry_request.OccurrenceRate").value() > 0);
+        assertTrue(metrics.get(metricsPrefix + "long_tail_retry_request.OccurrenceRate").value() > 0);
+      }
       assertTrue(metrics.get(metricsPrefix + "retry_request_key_count.Rate").value() > 0);
       assertEquals(metrics.get(metricsPrefix + "retry_request_key_count.Max").value(), expectedKeyCount);
     } else {
+      assertFalse(metrics.get(metricsPrefix + "no_available_replica_request_count.OccurrenceRate").value() > 0);
+      assertFalse(metrics.get(metricsPrefix + "long_tail_retry_request.OccurrenceRate").value() > 0);
+      assertFalse(metrics.get(metricsPrefix + "error_retry_request.OccurrenceRate").value() > 0);
       assertFalse(metrics.get(metricsPrefix + "retry_request_key_count.Rate").value() > 0);
       assertFalse(metrics.get(metricsPrefix + "retry_request_key_count.Max").value() > 0);
     }
@@ -507,23 +552,25 @@ public class RetriableAvroGenericStoreClientTest {
       }
     }
 
-    if (retryWin) {
-      assertTrue(metrics.get(metricsPrefix + "retry_request_win.OccurrenceRate").value() > 0);
-      assertEquals(metrics.get(metricsPrefix + "retry_request_success_key_count.Max").value(), expectedKeyCount);
-      if (batchGet) {
-        assertTrue(batchGetRequestContext.retryContext.retryRequestContext.numKeysCompleted.get() > 0);
-      } else if (singleGet) {
-        assertTrue(getRequestContext.retryContext.retryWin);
-      }
-    } else {
-      assertFalse(metrics.get(metricsPrefix + "retry_request_win.OccurrenceRate").value() > 0);
-      assertFalse(metrics.get(metricsPrefix + "retry_request_success_key_count.Max").value() > 0);
-      if (batchGet) {
-        assertTrue(
-            batchGetRequestContext.retryContext.retryRequestContext == null
-                || batchGetRequestContext.retryContext.retryRequestContext.numKeysCompleted.get() == 0);
-      } else if (singleGet) {
-        assertTrue(getRequestContext.retryContext == null || !getRequestContext.retryContext.retryWin);
+    if (!noReplicaFound) {
+      if (retryWin) {
+        assertTrue(metrics.get(metricsPrefix + "retry_request_win.OccurrenceRate").value() > 0);
+        assertEquals(metrics.get(metricsPrefix + "retry_request_success_key_count.Max").value(), expectedKeyCount);
+        if (batchGet) {
+          assertTrue(batchGetRequestContext.retryContext.retryRequestContext.numKeysCompleted.get() > 0);
+        } else if (singleGet) {
+          assertTrue(getRequestContext.retryContext.retryWin);
+        }
+      } else {
+        assertFalse(metrics.get(metricsPrefix + "retry_request_win.OccurrenceRate").value() > 0);
+        assertFalse(metrics.get(metricsPrefix + "retry_request_success_key_count.Max").value() > 0);
+        if (batchGet) {
+          assertTrue(
+              batchGetRequestContext.retryContext.retryRequestContext == null
+                  || batchGetRequestContext.retryContext.retryRequestContext.numKeysCompleted.get() == 0);
+        } else if (singleGet) {
+          assertTrue(getRequestContext.retryContext == null || !getRequestContext.retryContext.retryWin);
+        }
       }
     }
   }
@@ -543,14 +590,15 @@ public class RetriableAvroGenericStoreClientTest {
             false,
             LONG_TAIL_RETRY_THRESHOLD_IN_MS * 2,
             keyNotFound,
+            false,
             clientConfig),
         clientConfig,
         timeoutProcessor);
     statsAvroGenericStoreClient = new StatsAvroGenericStoreClient(retriableClient, clientConfig);
     if (!batchGet) {
-      testSingleGetAndValidateMetrics(false, false, false, false, keyNotFound);
+      testSingleGetAndValidateMetrics(false, false, false, false, keyNotFound, false);
     } else {
-      testBatchGetAndValidateMetrics(false, false, false, keyNotFound);
+      testBatchGetAndValidateMetrics(false, false, false, keyNotFound, false);
     }
   }
 
@@ -569,29 +617,32 @@ public class RetriableAvroGenericStoreClientTest {
             false,
             LONG_TAIL_RETRY_THRESHOLD_IN_MS * 50,
             false,
+            false,
             clientConfig),
         clientConfig,
         timeoutProcessor);
     statsAvroGenericStoreClient = new StatsAvroGenericStoreClient(retriableClient, clientConfig);
     if (requestType.equals(RequestType.SINGLE_GET)) {
-      testSingleGetAndValidateMetrics(false, false, true, false, false);
+      testSingleGetAndValidateMetrics(false, false, true, false, false, false);
     } else if (requestType.equals(RequestType.MULTI_GET_STREAMING)) {
-      testStreamingBatchGetAndValidateMetrics(false, true, false, false);
+      testStreamingBatchGetAndValidateMetrics(false, true, false, false, false);
     } else if (requestType.equals(RequestType.MULTI_GET)) {
-      testBatchGetAndValidateMetrics(false, true, false, false);
+      testBatchGetAndValidateMetrics(false, true, false, false, false);
     } else if (requestType.equals(RequestType.COMPUTE_STREAMING)) {
-      testStreamingComputeAndValidateMetrics(false, true, false, false);
+      testStreamingComputeAndValidateMetrics(false, true, false, false, false);
     } else if (requestType.equals(RequestType.COMPUTE)) {
-      testComputeAndValidateMetrics(false, true, false, false);
+      testComputeAndValidateMetrics(false, true, false, false, false);
     }
   }
 
   /**
    * Original request latency is higher than retry threshold and slower than the retry request
    */
-  @Test(dataProvider = "Two-True-and-False", dataProviderClass = DataProviderUtils.class, timeOut = TEST_TIMEOUT)
-  public void testGetWithTriggeringLongTailRetryAndRetryWins(boolean batchGet, boolean keyNotFound)
-      throws ExecutionException, InterruptedException {
+  @Test(dataProvider = "FastClient-RequestTypes-And-Two-Boolean", timeOut = TEST_TIMEOUT)
+  public void testGetWithTriggeringLongTailRetryAndRetryWins1(
+      RequestType requestType,
+      boolean keyNotFound,
+      boolean noReplicaFound) throws ExecutionException, InterruptedException {
     clientConfigBuilder.setMetricsRepository(new MetricsRepository());
     clientConfig = clientConfigBuilder.build();
     retriableClient = new RetriableAvroGenericStoreClient<>(
@@ -601,14 +652,21 @@ public class RetriableAvroGenericStoreClientTest {
             false,
             LONG_TAIL_RETRY_THRESHOLD_IN_MS / 2,
             keyNotFound,
+            noReplicaFound,
             clientConfig),
         clientConfig,
         timeoutProcessor);
     statsAvroGenericStoreClient = new StatsAvroGenericStoreClient(retriableClient, clientConfig);
-    if (!batchGet) {
-      testSingleGetAndValidateMetrics(false, false, true, true, keyNotFound);
-    } else {
-      testBatchGetAndValidateMetrics(false, true, true, keyNotFound);
+    if (requestType.equals(RequestType.SINGLE_GET)) {
+      testSingleGetAndValidateMetrics(false, false, true, true, keyNotFound, noReplicaFound);
+    } else if (requestType.equals(RequestType.MULTI_GET_STREAMING)) {
+      testStreamingBatchGetAndValidateMetrics(false, true, true, keyNotFound, noReplicaFound);
+    } else if (requestType.equals(RequestType.MULTI_GET)) {
+      testBatchGetAndValidateMetrics(false, true, true, keyNotFound, noReplicaFound);
+    } else if (requestType.equals(RequestType.COMPUTE_STREAMING)) {
+      testStreamingComputeAndValidateMetrics(false, true, true, keyNotFound, noReplicaFound);
+    } else if (requestType.equals(RequestType.COMPUTE)) {
+      testComputeAndValidateMetrics(false, true, true, keyNotFound, noReplicaFound);
     }
   }
 
@@ -621,20 +679,20 @@ public class RetriableAvroGenericStoreClientTest {
     clientConfigBuilder.setMetricsRepository(new MetricsRepository());
     clientConfig = clientConfigBuilder.build();
     retriableClient = new RetriableAvroGenericStoreClient<>(
-        prepareDispatchingClient(true, 0, false, LONG_TAIL_RETRY_THRESHOLD_IN_MS, false, clientConfig),
+        prepareDispatchingClient(true, 0, false, LONG_TAIL_RETRY_THRESHOLD_IN_MS, false, false, clientConfig),
         clientConfig,
         timeoutProcessor);
     statsAvroGenericStoreClient = new StatsAvroGenericStoreClient(retriableClient, clientConfig);
     if (requestType.equals(RequestType.SINGLE_GET)) {
-      testSingleGetAndValidateMetrics(false, true, false, true, false);
+      testSingleGetAndValidateMetrics(false, true, false, true, false, false);
     } else if (requestType.equals(RequestType.MULTI_GET_STREAMING)) {
-      testStreamingBatchGetAndValidateMetrics(false, true, true, false);
+      testStreamingBatchGetAndValidateMetrics(false, true, true, false, false);
     } else if (requestType.equals(RequestType.MULTI_GET)) {
-      testBatchGetAndValidateMetrics(false, true, true, false);
+      testBatchGetAndValidateMetrics(false, true, true, false, false);
     } else if (requestType.equals(RequestType.COMPUTE_STREAMING)) {
-      testStreamingComputeAndValidateMetrics(false, true, true, false);
+      testStreamingComputeAndValidateMetrics(false, true, true, false, false);
     } else if (requestType.equals(RequestType.COMPUTE)) {
-      testComputeAndValidateMetrics(false, true, true, false);
+      testComputeAndValidateMetrics(false, true, true, false, false);
     }
   }
 
@@ -647,20 +705,20 @@ public class RetriableAvroGenericStoreClientTest {
     clientConfigBuilder.setMetricsRepository(new MetricsRepository());
     clientConfig = clientConfigBuilder.build();
     retriableClient = new RetriableAvroGenericStoreClient<>(
-        prepareDispatchingClient(false, 10 * LONG_TAIL_RETRY_THRESHOLD_IN_MS, true, 0, false, clientConfig),
+        prepareDispatchingClient(false, 10 * LONG_TAIL_RETRY_THRESHOLD_IN_MS, true, 0, false, false, clientConfig),
         clientConfig,
         timeoutProcessor);
     statsAvroGenericStoreClient = new StatsAvroGenericStoreClient(retriableClient, clientConfig);
     if (requestType.equals(RequestType.SINGLE_GET)) {
-      testSingleGetAndValidateMetrics(false, false, true, false, false);
+      testSingleGetAndValidateMetrics(false, false, true, false, false, false);
     } else if (requestType.equals(RequestType.MULTI_GET_STREAMING)) {
-      testStreamingBatchGetAndValidateMetrics(false, true, false, false);
+      testStreamingBatchGetAndValidateMetrics(false, true, false, false, false);
     } else if (requestType.equals(RequestType.MULTI_GET)) {
-      testBatchGetAndValidateMetrics(false, true, false, false);
+      testBatchGetAndValidateMetrics(false, true, false, false, false);
     } else if (requestType.equals(RequestType.COMPUTE_STREAMING)) {
-      testStreamingComputeAndValidateMetrics(false, true, false, false);
+      testStreamingComputeAndValidateMetrics(false, true, false, false, false);
     } else if (requestType.equals(RequestType.COMPUTE)) {
-      testComputeAndValidateMetrics(false, true, false, false);
+      testComputeAndValidateMetrics(false, true, false, false, false);
     }
   }
 
@@ -673,7 +731,7 @@ public class RetriableAvroGenericStoreClientTest {
     clientConfigBuilder.setMetricsRepository(new MetricsRepository());
     clientConfig = clientConfigBuilder.build();
     retriableClient = new RetriableAvroGenericStoreClient<>(
-        prepareDispatchingClient(true, 10 * LONG_TAIL_RETRY_THRESHOLD_IN_MS, true, 0, false, clientConfig),
+        prepareDispatchingClient(true, 10 * LONG_TAIL_RETRY_THRESHOLD_IN_MS, true, 0, false, false, clientConfig),
         clientConfig,
         timeoutProcessor);
     statsAvroGenericStoreClient = new StatsAvroGenericStoreClient(retriableClient, clientConfig);
@@ -684,15 +742,15 @@ public class RetriableAvroGenericStoreClientTest {
      *  Check {@link StatsAvroGenericStoreClient#recordRequestMetrics} for more details.
      */
     if (requestType.equals(RequestType.SINGLE_GET)) {
-      testSingleGetAndValidateMetrics(true, false, true, false, false);
+      testSingleGetAndValidateMetrics(true, false, true, false, false, false);
     } else if (requestType.equals(RequestType.MULTI_GET_STREAMING)) {
-      testStreamingBatchGetAndValidateMetrics(true, true, false, false);
+      testStreamingBatchGetAndValidateMetrics(true, true, false, false, false);
     } else if (requestType.equals(RequestType.MULTI_GET)) {
-      testBatchGetAndValidateMetrics(true, true, false, false);
+      testBatchGetAndValidateMetrics(true, true, false, false, false);
     } else if (requestType.equals(RequestType.COMPUTE_STREAMING)) {
-      testStreamingComputeAndValidateMetrics(true, true, false, false);
+      testStreamingComputeAndValidateMetrics(true, true, false, false, false);
     } else if (requestType.equals(RequestType.COMPUTE)) {
-      testComputeAndValidateMetrics(true, true, false, false);
+      testComputeAndValidateMetrics(true, true, false, false, false);
     }
   }
 
@@ -705,7 +763,7 @@ public class RetriableAvroGenericStoreClientTest {
     clientConfigBuilder.setMetricsRepository(new MetricsRepository());
     clientConfig = clientConfigBuilder.build();
     retriableClient = new RetriableAvroGenericStoreClient<>(
-        prepareDispatchingClient(true, 0, true, 0, false, clientConfig),
+        prepareDispatchingClient(true, 0, true, 0, false, false, clientConfig),
         clientConfig,
         timeoutProcessor);
     statsAvroGenericStoreClient = new StatsAvroGenericStoreClient(retriableClient, clientConfig);
@@ -716,15 +774,15 @@ public class RetriableAvroGenericStoreClientTest {
      *  Check {@link StatsAvroGenericStoreClient#recordRequestMetrics} for more details.
      */
     if (requestType.equals(RequestType.SINGLE_GET)) {
-      testSingleGetAndValidateMetrics(true, true, false, false, false);
+      testSingleGetAndValidateMetrics(true, true, false, false, false, false);
     } else if (requestType.equals(RequestType.MULTI_GET_STREAMING)) {
-      testStreamingBatchGetAndValidateMetrics(true, true, false, false);
+      testStreamingBatchGetAndValidateMetrics(true, true, false, false, false);
     } else if (requestType.equals(RequestType.MULTI_GET)) {
-      testBatchGetAndValidateMetrics(true, true, false, false);
+      testBatchGetAndValidateMetrics(true, true, false, false, false);
     } else if (requestType.equals(RequestType.COMPUTE_STREAMING)) {
-      testStreamingComputeAndValidateMetrics(true, true, false, false);
+      testStreamingComputeAndValidateMetrics(true, true, false, false, false);
     } else if (requestType.equals(RequestType.COMPUTE)) {
-      testComputeAndValidateMetrics(true, true, false, false);
+      testComputeAndValidateMetrics(true, true, false, false, false);
     }
   }
 }


### PR DESCRIPTION
## Summary
1. Fast client multiget created 2 new contexts for the original and the retry request on top of the context passed to it which was used while recording metrics. Fix is to create a new context only for the retry and use the context passed for the original request.
2. Added additional check on the retry request context for partial response failure.
3. removed unused `isTriggeredByBatchGet` for single get

Resolves #XXX

## How was this PR tested?
GH CI

## Does this PR introduce any user-facing changes?
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.