### PR TITLE
[server][metrics] Add new metric which distinguishes a serving partition from a catching up one

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java
@@ -2096,14 +2096,16 @@ public class LeaderFollowerStoreIngestionTask extends StoreIngestionTask {
           versionNumber,
           partitionConsumptionState.getPartition(),
           serverConfig.getKafkaClusterUrlToAliasMap().get(kafkaUrl),
-          consumerRecord.getValue().producerMetadata.messageTimestamp);
+          consumerRecord.getValue().producerMetadata.messageTimestamp,
+          partitionConsumptionState.isWaitingForReplicationLag());
     } else {
       heartbeatMonitoringService.recordFollowerHeartbeat(
           storeName,
           versionNumber,
           partitionConsumptionState.getPartition(),
           serverConfig.getKafkaClusterUrlToAliasMap().get(kafkaUrl),
-          consumerRecord.getValue().producerMetadata.messageTimestamp);
+          consumerRecord.getValue().producerMetadata.messageTimestamp,
+          partitionConsumptionState.isWaitingForReplicationLag());
     }
   }
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/heartbeat/HeartbeatMonitoringService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/heartbeat/HeartbeatMonitoringService.java
@@ -244,7 +244,7 @@ public class HeartbeatMonitoringService extends AbstractVeniceService {
     recordLags(
         leaderHeartbeatTimeStamps,
         ((storeName, version, region, heartbeatTs, isReadyToServe) -> versionStatsReporter
-            .recordLeaderLag(storeName, version, region, heartbeatTs, isReadyToServe)));
+            .recordLeaderLag(storeName, version, region, heartbeatTs)));
     recordLags(
         followerHeartbeatTimeStamps,
         ((storeName, version, region, heartbeatTs, isReadyToServe) -> versionStatsReporter

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/heartbeat/HeartbeatStat.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/heartbeat/HeartbeatStat.java
@@ -11,8 +11,6 @@ import java.util.Set;
 public class HeartbeatStat {
   Map<String, WritePathLatencySensor> readyToServeLeaderSensors = new VeniceConcurrentHashMap<>();
   Map<String, WritePathLatencySensor> readyToServeFollowerSensors = new VeniceConcurrentHashMap<>();
-
-  Map<String, WritePathLatencySensor> catchingUpLeaderSensors = new VeniceConcurrentHashMap<>();
   Map<String, WritePathLatencySensor> catchingUpFollowerSensors = new VeniceConcurrentHashMap<>();
   WritePathLatencySensor defaultSensor;
 
@@ -27,8 +25,6 @@ public class HeartbeatStat {
           .put(region, new WritePathLatencySensor(localRepository, metricConfig, "leader-" + region));
       readyToServeFollowerSensors
           .put(region, new WritePathLatencySensor(localRepository, metricConfig, "follower-" + region));
-      catchingUpLeaderSensors
-          .put(region, new WritePathLatencySensor(localRepository, metricConfig, "catching-up-leader-" + region));
       catchingUpFollowerSensors
           .put(region, new WritePathLatencySensor(localRepository, metricConfig, "catching-up-follower-" + region));
     }
@@ -48,11 +44,6 @@ public class HeartbeatStat {
     readyToServeFollowerSensors.computeIfAbsent(region, k -> defaultSensor).record(endTime - startTime, endTime);
   }
 
-  public void recordCatchingUpLeaderLag(String region, long startTime) {
-    long endTime = System.currentTimeMillis();
-    catchingUpLeaderSensors.computeIfAbsent(region, k -> defaultSensor).record(endTime - startTime, endTime);
-  }
-
   public void recordCatchingUpFollowerLag(String region, long startTime) {
     long endTime = System.currentTimeMillis();
     catchingUpFollowerSensors.computeIfAbsent(region, k -> defaultSensor).record(endTime - startTime, endTime);
@@ -64,10 +55,6 @@ public class HeartbeatStat {
 
   public WritePathLatencySensor getReadyToServeFollowerLag(String region) {
     return readyToServeFollowerSensors.computeIfAbsent(region, k -> defaultSensor);
-  }
-
-  public WritePathLatencySensor getCatchingUpLeaderLag(String region) {
-    return catchingUpLeaderSensors.computeIfAbsent(region, k -> defaultSensor);
   }
 
   public WritePathLatencySensor getCatchingUpFollowerLag(String region) {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/heartbeat/HeartbeatStat.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/heartbeat/HeartbeatStat.java
@@ -9,8 +9,11 @@ import java.util.Set;
 
 
 public class HeartbeatStat {
-  Map<String, WritePathLatencySensor> leaderSensors = new VeniceConcurrentHashMap<>();
-  Map<String, WritePathLatencySensor> followerSensors = new VeniceConcurrentHashMap<>();
+  Map<String, WritePathLatencySensor> readyToServeLeaderSensors = new VeniceConcurrentHashMap<>();
+  Map<String, WritePathLatencySensor> readyToServeFollowerSensors = new VeniceConcurrentHashMap<>();
+
+  Map<String, WritePathLatencySensor> catchingUpLeaderSensors = new VeniceConcurrentHashMap<>();
+  Map<String, WritePathLatencySensor> catchingUpFollowerSensors = new VeniceConcurrentHashMap<>();
   WritePathLatencySensor defaultSensor;
 
   public HeartbeatStat(MetricConfig metricConfig, Set<String> regions) {
@@ -20,8 +23,14 @@ public class HeartbeatStat {
      */
     MetricsRepository localRepository = new MetricsRepository(metricConfig);
     for (String region: regions) {
-      leaderSensors.put(region, new WritePathLatencySensor(localRepository, metricConfig, "leader-" + region));
-      followerSensors.put(region, new WritePathLatencySensor(localRepository, metricConfig, "follower-" + region));
+      readyToServeLeaderSensors
+          .put(region, new WritePathLatencySensor(localRepository, metricConfig, "leader-" + region));
+      readyToServeFollowerSensors
+          .put(region, new WritePathLatencySensor(localRepository, metricConfig, "follower-" + region));
+      catchingUpLeaderSensors
+          .put(region, new WritePathLatencySensor(localRepository, metricConfig, "catching-up-leader-" + region));
+      catchingUpFollowerSensors
+          .put(region, new WritePathLatencySensor(localRepository, metricConfig, "catching-up-follower-" + region));
     }
     // This is an edge case return that should not happen, but it 'can' happen if a venice server is configured with no
     // local fabric in it's config. This currently isn't illegal, and probably wasn't made to be illegal so as to
@@ -29,21 +38,39 @@ public class HeartbeatStat {
     defaultSensor = new WritePathLatencySensor(localRepository, metricConfig, "default-");
   }
 
-  public void recordLeaderLag(String region, long startTime) {
+  public void recordReadyToServeLeaderLag(String region, long startTime) {
     long endTime = System.currentTimeMillis();
-    leaderSensors.computeIfAbsent(region, k -> defaultSensor).record(endTime - startTime, endTime);
+    readyToServeLeaderSensors.computeIfAbsent(region, k -> defaultSensor).record(endTime - startTime, endTime);
   }
 
-  public void recordFollowerLag(String region, long startTime) {
+  public void recordReadyToServeFollowerLag(String region, long startTime) {
     long endTime = System.currentTimeMillis();
-    followerSensors.computeIfAbsent(region, k -> defaultSensor).record(endTime - startTime, endTime);
+    readyToServeFollowerSensors.computeIfAbsent(region, k -> defaultSensor).record(endTime - startTime, endTime);
   }
 
-  public WritePathLatencySensor getLeaderLag(String region) {
-    return leaderSensors.computeIfAbsent(region, k -> defaultSensor);
+  public void recordCatchingUpLeaderLag(String region, long startTime) {
+    long endTime = System.currentTimeMillis();
+    catchingUpLeaderSensors.computeIfAbsent(region, k -> defaultSensor).record(endTime - startTime, endTime);
   }
 
-  public WritePathLatencySensor getFollowerLag(String region) {
-    return followerSensors.computeIfAbsent(region, k -> defaultSensor);
+  public void recordCatchingUpFollowerLag(String region, long startTime) {
+    long endTime = System.currentTimeMillis();
+    catchingUpFollowerSensors.computeIfAbsent(region, k -> defaultSensor).record(endTime - startTime, endTime);
+  }
+
+  public WritePathLatencySensor getReadyToServeLeaderLag(String region) {
+    return readyToServeLeaderSensors.computeIfAbsent(region, k -> defaultSensor);
+  }
+
+  public WritePathLatencySensor getReadyToServeFollowerLag(String region) {
+    return readyToServeFollowerSensors.computeIfAbsent(region, k -> defaultSensor);
+  }
+
+  public WritePathLatencySensor getCatchingUpLeaderLag(String region) {
+    return catchingUpLeaderSensors.computeIfAbsent(region, k -> defaultSensor);
+  }
+
+  public WritePathLatencySensor getCatchingUpFollowerLag(String region) {
+    return catchingUpFollowerSensors.computeIfAbsent(region, k -> defaultSensor);
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/heartbeat/HeartbeatStatReporter.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/heartbeat/HeartbeatStatReporter.java
@@ -11,6 +11,8 @@ import java.util.Set;
 public class HeartbeatStatReporter extends AbstractVeniceStatsReporter<HeartbeatStat> {
   private static final String LEADER_METRIC_PREFIX = "heartbeat_delay_ms_leader-";
   private static final String FOLLOWER_METRIC_PREFIX = "heartbeat_delay_ms_follower-";
+  private static final String CATCHUP_UP_LEADER_METRIC_PREFIX = "catching_up_heartbeat_delay_ms_leader-";
+  private static final String CATCHUP_UP_FOLLOWER_METRIC_PREFIX = "catching_up_heartbeat_delay_ms_follower-";
   private static final String MAX = "-Max";
   private static final String AVG = "-Avg";
 
@@ -21,7 +23,7 @@ public class HeartbeatStatReporter extends AbstractVeniceStatsReporter<Heartbeat
         if (getStats() == null) {
           return NULL_INGESTION_STATS.code;
         }
-        return getStats().getLeaderLag(region).getMax();
+        return getStats().getReadyToServeLeaderLag(region).getMax();
       }, LEADER_METRIC_PREFIX + region + MAX));
 
       registerSensor(new AsyncGauge((ignored, ignored2) -> {
@@ -29,7 +31,7 @@ public class HeartbeatStatReporter extends AbstractVeniceStatsReporter<Heartbeat
           return NULL_INGESTION_STATS.code;
         }
 
-        return getStats().getFollowerLag(region).getMax();
+        return getStats().getReadyToServeFollowerLag(region).getMax();
       }, FOLLOWER_METRIC_PREFIX + region + MAX));
 
       registerSensor(new AsyncGauge((ignored, ignored2) -> {
@@ -37,7 +39,7 @@ public class HeartbeatStatReporter extends AbstractVeniceStatsReporter<Heartbeat
           return NULL_INGESTION_STATS.code;
         }
 
-        return getStats().getLeaderLag(region).getAvg();
+        return getStats().getReadyToServeLeaderLag(region).getAvg();
       }, LEADER_METRIC_PREFIX + region + AVG));
 
       registerSensor(new AsyncGauge((ignored, ignored2) -> {
@@ -45,8 +47,39 @@ public class HeartbeatStatReporter extends AbstractVeniceStatsReporter<Heartbeat
           return NULL_INGESTION_STATS.code;
         }
 
-        return getStats().getFollowerLag(region).getAvg();
+        return getStats().getReadyToServeFollowerLag(region).getAvg();
       }, FOLLOWER_METRIC_PREFIX + region + AVG));
+
+      registerSensor(new AsyncGauge((ignored, ignored2) -> {
+        if (getStats() == null) {
+          return NULL_INGESTION_STATS.code;
+        }
+        return getStats().getCatchingUpLeaderLag(region).getMax();
+      }, CATCHUP_UP_LEADER_METRIC_PREFIX + region + MAX));
+
+      registerSensor(new AsyncGauge((ignored, ignored2) -> {
+        if (getStats() == null) {
+          return NULL_INGESTION_STATS.code;
+        }
+
+        return getStats().getCatchingUpFollowerLag(region).getMax();
+      }, CATCHUP_UP_FOLLOWER_METRIC_PREFIX + region + MAX));
+
+      registerSensor(new AsyncGauge((ignored, ignored2) -> {
+        if (getStats() == null) {
+          return NULL_INGESTION_STATS.code;
+        }
+
+        return getStats().getCatchingUpLeaderLag(region).getAvg();
+      }, CATCHUP_UP_LEADER_METRIC_PREFIX + region + AVG));
+
+      registerSensor(new AsyncGauge((ignored, ignored2) -> {
+        if (getStats() == null) {
+          return NULL_INGESTION_STATS.code;
+        }
+
+        return getStats().getCatchingUpFollowerLag(region).getAvg();
+      }, CATCHUP_UP_FOLLOWER_METRIC_PREFIX + region + AVG));
     }
   }
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/heartbeat/HeartbeatStatReporter.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/heartbeat/HeartbeatStatReporter.java
@@ -11,7 +11,6 @@ import java.util.Set;
 public class HeartbeatStatReporter extends AbstractVeniceStatsReporter<HeartbeatStat> {
   private static final String LEADER_METRIC_PREFIX = "heartbeat_delay_ms_leader-";
   private static final String FOLLOWER_METRIC_PREFIX = "heartbeat_delay_ms_follower-";
-  private static final String CATCHUP_UP_LEADER_METRIC_PREFIX = "catching_up_heartbeat_delay_ms_leader-";
   private static final String CATCHUP_UP_FOLLOWER_METRIC_PREFIX = "catching_up_heartbeat_delay_ms_follower-";
   private static final String MAX = "-Max";
   private static final String AVG = "-Avg";
@@ -54,24 +53,9 @@ public class HeartbeatStatReporter extends AbstractVeniceStatsReporter<Heartbeat
         if (getStats() == null) {
           return NULL_INGESTION_STATS.code;
         }
-        return getStats().getCatchingUpLeaderLag(region).getMax();
-      }, CATCHUP_UP_LEADER_METRIC_PREFIX + region + MAX));
-
-      registerSensor(new AsyncGauge((ignored, ignored2) -> {
-        if (getStats() == null) {
-          return NULL_INGESTION_STATS.code;
-        }
 
         return getStats().getCatchingUpFollowerLag(region).getMax();
       }, CATCHUP_UP_FOLLOWER_METRIC_PREFIX + region + MAX));
-
-      registerSensor(new AsyncGauge((ignored, ignored2) -> {
-        if (getStats() == null) {
-          return NULL_INGESTION_STATS.code;
-        }
-
-        return getStats().getCatchingUpLeaderLag(region).getAvg();
-      }, CATCHUP_UP_LEADER_METRIC_PREFIX + region + AVG));
 
       registerSensor(new AsyncGauge((ignored, ignored2) -> {
         if (getStats() == null) {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/heartbeat/HeartbeatVersionedStats.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/stats/ingestion/heartbeat/HeartbeatVersionedStats.java
@@ -26,18 +26,8 @@ public class HeartbeatVersionedStats extends AbstractVeniceAggVersionedStats<Hea
     this.followerMonitors = followerMonitors;
   }
 
-  public void recordLeaderLag(String storeName, int version, String region, long heartbeatTs, boolean isReadyToServe) {
-    // If the partition is ready to serve, report it's lage to the main lag metric. Otherwise, report it
-    // to the catch up metric.
-    // The metric which isn't updated is squelched by reporting the currentTime (so as to appear caught up and mute
-    // alerts)
-    if (isReadyToServe) {
-      getStats(storeName, version).recordReadyToServeLeaderLag(region, heartbeatTs);
-      getStats(storeName, version).recordCatchingUpLeaderLag(region, System.currentTimeMillis());
-    } else {
-      getStats(storeName, version).recordReadyToServeLeaderLag(region, System.currentTimeMillis());
-      getStats(storeName, version).recordCatchingUpLeaderLag(region, heartbeatTs);
-    }
+  public void recordLeaderLag(String storeName, int version, String region, long heartbeatTs) {
+    getStats(storeName, version).recordReadyToServeLeaderLag(region, heartbeatTs);
   }
 
   public void recordFollowerLag(
@@ -46,6 +36,10 @@ public class HeartbeatVersionedStats extends AbstractVeniceAggVersionedStats<Hea
       String region,
       long heartbeatTs,
       boolean isReadyToServe) {
+    // If the partition is ready to serve, report it's lage to the main lag metric. Otherwise, report it
+    // to the catch up metric.
+    // The metric which isn't updated is squelched by reporting the currentTime (so as to appear caught up and mute
+    // alerts)
     if (isReadyToServe) {
       getStats(storeName, version).recordReadyToServeFollowerLag(region, heartbeatTs);
       getStats(storeName, version).recordCatchingUpFollowerLag(region, System.currentTimeMillis());

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/ingestion/heartbeat/HeartbeatMonitoringServiceTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/stats/ingestion/heartbeat/HeartbeatMonitoringServiceTest.java
@@ -30,7 +30,7 @@ public class HeartbeatMonitoringServiceTest {
         new HybridStoreConfigImpl(1L, 1L, 1L, DataReplicationPolicy.NON_AGGREGATE, BufferReplayPolicy.REWIND_FROM_SOP);
 
     // Version configs
-    Version backupVersion = new VersionImpl(TEST_STORE, 1, "1"); // Non hybrid version
+    Version backupVersion = new VersionImpl(TEST_STORE, 1, "1"); // Non-hybrid version
     Version currentVersion = new VersionImpl(TEST_STORE, 2, "2"); // hybrid version, active/active
     Version futureVersion = new VersionImpl(TEST_STORE, 3, "3"); // hybrid version, non AA
     currentVersion.setHybridStoreConfig(hybridStoreConfig);
@@ -57,10 +57,10 @@ public class HeartbeatMonitoringServiceTest {
         new HeartbeatMonitoringService(mockMetricsRepository, mockReadOnlyRepository, regions, LOCAL_FABRIC);
 
     // Let's emit some heartbeats that don't exist in the registry yet
-    heartbeatMonitoringService.recordLeaderHeartbeat(TEST_STORE, 1, 0, LOCAL_FABRIC, 1000L);
-    heartbeatMonitoringService.recordFollowerHeartbeat(TEST_STORE, 2, 0, LOCAL_FABRIC, 1000L);
+    heartbeatMonitoringService.recordLeaderHeartbeat(TEST_STORE, 1, 0, LOCAL_FABRIC, 1000L, true);
+    heartbeatMonitoringService.recordFollowerHeartbeat(TEST_STORE, 2, 0, LOCAL_FABRIC, 1000L, true);
     // and throw a null at it too for good measure
-    heartbeatMonitoringService.recordFollowerHeartbeat(TEST_STORE, 2, 0, null, 1000L);
+    heartbeatMonitoringService.recordFollowerHeartbeat(TEST_STORE, 2, 0, null, 1000L, true);
 
     // Since we haven't gotten a signal to handle these heartbeats, we discard them.
     Assert.assertNull(heartbeatMonitoringService.getLeaderHeartbeatTimeStamps().get(TEST_STORE));
@@ -83,28 +83,28 @@ public class HeartbeatMonitoringServiceTest {
 
     // Follower heartbeats
     // local fabric heartbeats
-    heartbeatMonitoringService.recordFollowerHeartbeat(TEST_STORE, 1, 0, LOCAL_FABRIC, 1001L);
-    heartbeatMonitoringService.recordFollowerHeartbeat(TEST_STORE, 2, 0, LOCAL_FABRIC, 1001L);
-    heartbeatMonitoringService.recordFollowerHeartbeat(TEST_STORE, 3, 0, LOCAL_FABRIC, 1001L);
-    heartbeatMonitoringService.recordFollowerHeartbeat(TEST_STORE, 1, 1, LOCAL_FABRIC, 1001L);
-    heartbeatMonitoringService.recordFollowerHeartbeat(TEST_STORE, 2, 1, LOCAL_FABRIC, 1001L);
-    heartbeatMonitoringService.recordFollowerHeartbeat(TEST_STORE, 3, 1, LOCAL_FABRIC, 1001L);
-    heartbeatMonitoringService.recordFollowerHeartbeat(TEST_STORE, 1, 2, LOCAL_FABRIC, 1001L);
-    heartbeatMonitoringService.recordFollowerHeartbeat(TEST_STORE, 2, 2, LOCAL_FABRIC, 1001L);
-    heartbeatMonitoringService.recordFollowerHeartbeat(TEST_STORE, 3, 2, LOCAL_FABRIC, 1001L);
+    heartbeatMonitoringService.recordFollowerHeartbeat(TEST_STORE, 1, 0, LOCAL_FABRIC, 1001L, true);
+    heartbeatMonitoringService.recordFollowerHeartbeat(TEST_STORE, 2, 0, LOCAL_FABRIC, 1001L, true);
+    heartbeatMonitoringService.recordFollowerHeartbeat(TEST_STORE, 3, 0, LOCAL_FABRIC, 1001L, true);
+    heartbeatMonitoringService.recordFollowerHeartbeat(TEST_STORE, 1, 1, LOCAL_FABRIC, 1001L, true);
+    heartbeatMonitoringService.recordFollowerHeartbeat(TEST_STORE, 2, 1, LOCAL_FABRIC, 1001L, true);
+    heartbeatMonitoringService.recordFollowerHeartbeat(TEST_STORE, 3, 1, LOCAL_FABRIC, 1001L, true);
+    heartbeatMonitoringService.recordFollowerHeartbeat(TEST_STORE, 1, 2, LOCAL_FABRIC, 1001L, true);
+    heartbeatMonitoringService.recordFollowerHeartbeat(TEST_STORE, 2, 2, LOCAL_FABRIC, 1001L, true);
+    heartbeatMonitoringService.recordFollowerHeartbeat(TEST_STORE, 3, 2, LOCAL_FABRIC, 1001L, true);
 
     // remote fabric heartbeats
-    heartbeatMonitoringService.recordFollowerHeartbeat(TEST_STORE, 1, 0, REMOTE_FABRIC, 1001L);
-    heartbeatMonitoringService.recordFollowerHeartbeat(TEST_STORE, 2, 0, REMOTE_FABRIC, 1001L);
-    heartbeatMonitoringService.recordFollowerHeartbeat(TEST_STORE, 3, 0, REMOTE_FABRIC, 1001L);
-    heartbeatMonitoringService.recordFollowerHeartbeat(TEST_STORE, 1, 1, REMOTE_FABRIC, 1001L);
-    heartbeatMonitoringService.recordFollowerHeartbeat(TEST_STORE, 2, 1, REMOTE_FABRIC, 1001L);
-    heartbeatMonitoringService.recordFollowerHeartbeat(TEST_STORE, 3, 1, REMOTE_FABRIC, 1001L);
-    heartbeatMonitoringService.recordFollowerHeartbeat(TEST_STORE, 1, 3, REMOTE_FABRIC, 1001L);
+    heartbeatMonitoringService.recordFollowerHeartbeat(TEST_STORE, 1, 0, REMOTE_FABRIC, 1001L, true);
+    heartbeatMonitoringService.recordFollowerHeartbeat(TEST_STORE, 2, 0, REMOTE_FABRIC, 1001L, true);
+    heartbeatMonitoringService.recordFollowerHeartbeat(TEST_STORE, 3, 0, REMOTE_FABRIC, 1001L, true);
+    heartbeatMonitoringService.recordFollowerHeartbeat(TEST_STORE, 1, 1, REMOTE_FABRIC, 1001L, true);
+    heartbeatMonitoringService.recordFollowerHeartbeat(TEST_STORE, 2, 1, REMOTE_FABRIC, 1001L, true);
+    heartbeatMonitoringService.recordFollowerHeartbeat(TEST_STORE, 3, 1, REMOTE_FABRIC, 1001L, true);
+    heartbeatMonitoringService.recordFollowerHeartbeat(TEST_STORE, 1, 3, REMOTE_FABRIC, 1001L, true);
 
     // bogus heartbeats
-    heartbeatMonitoringService.recordLeaderHeartbeat(TEST_STORE, 2, 0, LOCAL_FABRIC, 1002L);
-    heartbeatMonitoringService.recordLeaderHeartbeat(TEST_STORE, 3, 0, LOCAL_FABRIC, 1002L);
+    heartbeatMonitoringService.recordLeaderHeartbeat(TEST_STORE, 2, 0, LOCAL_FABRIC, 1002L, true);
+    heartbeatMonitoringService.recordLeaderHeartbeat(TEST_STORE, 3, 0, LOCAL_FABRIC, 1002L, true);
 
     Assert.assertEquals(heartbeatMonitoringService.getFollowerHeartbeatTimeStamps().size(), 1);
     // We only expect two entries as version 1 is a non-hybrid version
@@ -124,15 +124,17 @@ public class HeartbeatMonitoringServiceTest {
         .get(TEST_STORE)
         .get(futureVersion.getNumber())
         .get(1)
-        .get(LOCAL_FABRIC);
-    Assert.assertTrue(value == 1001L);
+        .get(LOCAL_FABRIC)
+        .getLeft();
+    Assert.assertEquals((long) value, 1001L);
 
     value = heartbeatMonitoringService.getFollowerHeartbeatTimeStamps()
         .get(TEST_STORE)
         .get(futureVersion.getNumber())
         .get(1)
-        .get(REMOTE_FABRIC);
-    Assert.assertTrue(value == 1001L);
+        .get(REMOTE_FABRIC)
+        .getLeft();
+    Assert.assertEquals((long) value, 1001L);
 
     // Leader state transitions
     heartbeatMonitoringService.addLeaderLagMonitor(currentVersion, 1);
@@ -172,9 +174,9 @@ public class HeartbeatMonitoringServiceTest {
     Assert.assertNull(
         heartbeatMonitoringService.getLeaderHeartbeatTimeStamps().get(TEST_STORE).get(backupVersion.getNumber()));
 
-    heartbeatMonitoringService.recordFollowerHeartbeat(TEST_STORE, 1, 1, REMOTE_FABRIC, 1003L);
-    heartbeatMonitoringService.recordFollowerHeartbeat(TEST_STORE, 2, 1, REMOTE_FABRIC, 1003L);
-    heartbeatMonitoringService.recordFollowerHeartbeat(TEST_STORE, 3, 1, REMOTE_FABRIC, 1003L);
+    heartbeatMonitoringService.recordFollowerHeartbeat(TEST_STORE, 1, 1, REMOTE_FABRIC, 1003L, true);
+    heartbeatMonitoringService.recordFollowerHeartbeat(TEST_STORE, 2, 1, REMOTE_FABRIC, 1003L, true);
+    heartbeatMonitoringService.recordFollowerHeartbeat(TEST_STORE, 3, 1, REMOTE_FABRIC, 1003L, true);
 
     // make sure leaders are cleared out
     Assert.assertNull(
@@ -204,14 +206,16 @@ public class HeartbeatMonitoringServiceTest {
         .get(TEST_STORE)
         .get(futureVersion.getNumber())
         .get(1)
-        .get(REMOTE_FABRIC);
-    Assert.assertTrue(value == 1003L);
+        .get(REMOTE_FABRIC)
+        .getLeft();
+    Assert.assertEquals((long) value, 1003L);
     value = heartbeatMonitoringService.getFollowerHeartbeatTimeStamps()
         .get(TEST_STORE)
         .get(currentVersion.getNumber())
         .get(1)
-        .get(REMOTE_FABRIC);
-    Assert.assertTrue(value == 1003L);
+        .get(REMOTE_FABRIC)
+        .getLeft();
+    Assert.assertEquals((long) value, 1003L);
 
     // Drop/Error some
     heartbeatMonitoringService.removeLagMonitor(currentVersion, 0);
@@ -219,9 +223,12 @@ public class HeartbeatMonitoringServiceTest {
     heartbeatMonitoringService.removeLagMonitor(backupVersion, 2);
 
     // Send heartbeats to resources we just dropped
-    heartbeatMonitoringService.recordFollowerHeartbeat(TEST_STORE, backupVersion.getNumber(), 2, LOCAL_FABRIC, 1005L);
-    heartbeatMonitoringService.recordFollowerHeartbeat(TEST_STORE, currentVersion.getNumber(), 0, LOCAL_FABRIC, 1005L);
-    heartbeatMonitoringService.recordFollowerHeartbeat(TEST_STORE, futureVersion.getNumber(), 1, LOCAL_FABRIC, 1005L);
+    heartbeatMonitoringService
+        .recordFollowerHeartbeat(TEST_STORE, backupVersion.getNumber(), 2, LOCAL_FABRIC, 1005L, true);
+    heartbeatMonitoringService
+        .recordFollowerHeartbeat(TEST_STORE, currentVersion.getNumber(), 0, LOCAL_FABRIC, 1005L, true);
+    heartbeatMonitoringService
+        .recordFollowerHeartbeat(TEST_STORE, futureVersion.getNumber(), 1, LOCAL_FABRIC, 1005L, true);
 
     Assert.assertNull(
         heartbeatMonitoringService.getFollowerHeartbeatTimeStamps().get(TEST_STORE).get(backupVersion.getNumber()));


### PR DESCRIPTION
## [server][metrics] Add new metric which distinguishes a serving partition from a catching up one

Additionally mutes the metric of whichever one isn't getting updated

Resolves #XXX

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.