### PR TITLE
[server][router] flush latency/response size metrics in Server and HB metric bug fix in Router

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
@@ -177,6 +177,7 @@ import com.linkedin.venice.utils.Time;
 import com.linkedin.venice.utils.Utils;
 import com.linkedin.venice.utils.VeniceProperties;
 import com.linkedin.venice.utils.concurrent.BlockingQueueType;
+import io.netty.channel.WriteBufferWaterMark;
 import java.io.File;
 import java.nio.file.Paths;
 import java.time.Duration;
@@ -856,8 +857,9 @@ public class VeniceServerConfig extends VeniceClusterConfig {
         serverProperties.getInt(SERVER_NON_CURRENT_VERSION_AA_WC_LEADER_QUOTA_RECORDS_PER_SECOND, -1);
     nonCurrentVersionNonAAWCLeaderQuotaRecordsPerSecond =
         serverProperties.getInt(SERVER_NON_CURRENT_VERSION_NON_AA_WC_LEADER_QUOTA_RECORDS_PER_SECOND, -1);
-    channelOptionWriteBufferHighBytes =
-        (int) serverProperties.getSizeInBytes(SERVER_CHANNEL_OPTION_WRITE_BUFFER_WATERMARK_HIGH_BYTES, 1024l * 1024);
+    channelOptionWriteBufferHighBytes = (int) serverProperties
+        .getSizeInBytes(SERVER_CHANNEL_OPTION_WRITE_BUFFER_WATERMARK_HIGH_BYTES, WriteBufferWaterMark.DEFAULT.high()); // default
+                                                                                                                       // 64KB
     if (channelOptionWriteBufferHighBytes <= 0) {
       throw new VeniceException("Invalid channel option write buffer high bytes: " + channelOptionWriteBufferHighBytes);
     }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
@@ -50,6 +50,7 @@ import static com.linkedin.venice.ConfigKeys.PUBSUB_TOPIC_MANAGER_METADATA_FETCH
 import static com.linkedin.venice.ConfigKeys.ROUTER_PRINCIPAL_NAME;
 import static com.linkedin.venice.ConfigKeys.SERVER_AA_WC_LEADER_QUOTA_RECORDS_PER_SECOND;
 import static com.linkedin.venice.ConfigKeys.SERVER_BLOCKING_QUEUE_TYPE;
+import static com.linkedin.venice.ConfigKeys.SERVER_CHANNEL_OPTION_WRITE_BUFFER_WATERMARK_HIGH_BYTES;
 import static com.linkedin.venice.ConfigKeys.SERVER_COMPUTE_FAST_AVRO_ENABLED;
 import static com.linkedin.venice.ConfigKeys.SERVER_COMPUTE_QUEUE_CAPACITY;
 import static com.linkedin.venice.ConfigKeys.SERVER_COMPUTE_THREAD_NUM;
@@ -512,6 +513,7 @@ public class VeniceServerConfig extends VeniceClusterConfig {
   private final int currentVersionNonAAWCLeaderQuotaRecordsPerSecond;
   private final int nonCurrentVersionAAWCLeaderQuotaRecordsPerSecond;
   private final int nonCurrentVersionNonAAWCLeaderQuotaRecordsPerSecond;
+  private final int channelOptionWriteBufferHighBytes;
 
   public VeniceServerConfig(VeniceProperties serverProperties) throws ConfigurationException {
     this(serverProperties, Collections.emptyMap());
@@ -854,6 +856,11 @@ public class VeniceServerConfig extends VeniceClusterConfig {
         serverProperties.getInt(SERVER_NON_CURRENT_VERSION_AA_WC_LEADER_QUOTA_RECORDS_PER_SECOND, -1);
     nonCurrentVersionNonAAWCLeaderQuotaRecordsPerSecond =
         serverProperties.getInt(SERVER_NON_CURRENT_VERSION_NON_AA_WC_LEADER_QUOTA_RECORDS_PER_SECOND, -1);
+    channelOptionWriteBufferHighBytes =
+        (int) serverProperties.getSizeInBytes(SERVER_CHANNEL_OPTION_WRITE_BUFFER_WATERMARK_HIGH_BYTES, 1024l * 1024);
+    if (channelOptionWriteBufferHighBytes <= 0) {
+      throw new VeniceException("Invalid channel option write buffer high bytes: " + channelOptionWriteBufferHighBytes);
+    }
   }
 
   long extractIngestionMemoryLimit(
@@ -1526,5 +1533,9 @@ public class VeniceServerConfig extends VeniceClusterConfig {
 
   public int getNonCurrentVersionNonAAWCLeaderQuotaRecordsPerSecond() {
     return nonCurrentVersionNonAAWCLeaderQuotaRecordsPerSecond;
+  }
+
+  public int getChannelOptionWriteBufferHighBytes() {
+    return channelOptionWriteBufferHighBytes;
   }
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -2207,4 +2207,7 @@ public class ConfigKeys {
       "server.non.current.version.aa.wc.leader.quota.records.per.second";
   public static final String SERVER_NON_CURRENT_VERSION_NON_AA_WC_LEADER_QUOTA_RECORDS_PER_SECOND =
       "server.non.current.version.non.aa.wc.leader.quota.records.per.second";
+
+  public static final String SERVER_CHANNEL_OPTION_WRITE_BUFFER_WATERMARK_HIGH_BYTES =
+      "server.channel.option.write.buffer.watermark.high.bytes";
 }

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/api/VeniceHostHealth.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/api/VeniceHostHealth.java
@@ -72,8 +72,7 @@ public class VeniceHostHealth implements HostHealthMonitor<Instance> {
    */
   public void setHostAsHealthy(Instance hostname) {
     String identifier = hostname.getNodeId();
-    if (unhealthyHosts.contains(identifier)) {
-      unhealthyHosts.remove(identifier);
+    if (unhealthyHosts.remove(identifier)) {
       LOGGER.info("Marking {} back to healthy host", identifier);
     }
     cleanupUnhealthyHostsBasedOnLiveInstanceMonitor();

--- a/services/venice-router/src/test/java/com/linkedin/venice/router/api/TestVeniceHostHealth.java
+++ b/services/venice-router/src/test/java/com/linkedin/venice/router/api/TestVeniceHostHealth.java
@@ -52,6 +52,10 @@ public class TestVeniceHostHealth {
         "Host should be unhealthy when it is dead.");
     Assert.assertTrue(hostHealth.isHostHealthy(liveInstance, fakePartition), "Host should be healthy when it is alive");
     verify(mockAggHostHealthStats, times(1)).recordUnhealthyHostOfflineInstance(deadInstance.getNodeId());
+
+    // When trying to make a dead instance as unhealthy, the dead instance shouldn't be counted as unhealthy instances.
+    hostHealth.setHostAsUnhealthy(deadInstance);
+    verify(mockAggHostHealthStats, times(1)).recordUnhealthyHostCountCausedByRouterHeartBeat(0);
   }
 
   @Test

--- a/services/venice-server/src/main/java/com/linkedin/venice/listener/ListenerService.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/listener/ListenerService.java
@@ -26,6 +26,7 @@ import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.ServerChannel;
+import io.netty.channel.WriteBufferWaterMark;
 import io.netty.channel.epoll.EpollEventLoopGroup;
 import io.netty.channel.epoll.EpollServerSocketChannel;
 import io.netty.channel.nio.NioEventLoopGroup;
@@ -162,7 +163,14 @@ public class ListenerService extends AbstractVeniceService {
         .option(ChannelOption.SO_BACKLOG, nettyBacklogSize)
         .childOption(ChannelOption.SO_KEEPALIVE, true)
         .option(ChannelOption.SO_REUSEADDR, true)
-        .childOption(ChannelOption.TCP_NODELAY, true);
+        .childOption(ChannelOption.TCP_NODELAY, true)
+        // A higher buffer watermark will allow more data write for a given channel and it would be useful for H2,
+        // as H2 works with a smaller number of connections.
+        .childOption(
+            ChannelOption.WRITE_BUFFER_WATER_MARK,
+            new WriteBufferWaterMark(
+                WriteBufferWaterMark.DEFAULT.low(),
+                serverConfig.getChannelOptionWriteBufferHighBytes()));
 
     if (isGrpcEnabled && grpcServer == null) {
       List<ServerInterceptor> interceptors = channelInitializer.initGrpcInterceptors();

--- a/services/venice-server/src/main/java/com/linkedin/venice/listener/OutboundHttpWrapperHandler.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/listener/OutboundHttpWrapperHandler.java
@@ -62,9 +62,11 @@ public class OutboundHttpWrapperHandler extends ChannelOutboundHandlerAdapter {
         if (obj.isFound()) {
           body = obj.getResponseBody();
           schemaIdHeader = obj.getResponseSchemaIdHeader();
+          statsContext.setResponseSize(body.readableBytes());
         } else {
           body = Unpooled.EMPTY_BUFFER;
           responseStatus = NOT_FOUND;
+          statsContext.setResponseSize(0);
         }
         isStreamingResponse = obj.isStreamingResponse();
         responseRcu = obj.getRCU();

--- a/services/venice-server/src/main/java/com/linkedin/venice/listener/ServerStatsContext.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/listener/ServerStatsContext.java
@@ -88,6 +88,8 @@ public class ServerStatsContext {
   private boolean isComplete;
 
   private boolean isMisroutedStoreVersion = false;
+  private double flushLatency = -1;
+  private int responseSize = -1;
 
   public boolean isNewRequest() {
     return newRequest;
@@ -157,6 +159,8 @@ public class ServerStatsContext {
     isRequestTerminatedEarly = false;
     isComplete = false;
     isMisroutedStoreVersion = false;
+    flushLatency = -1;
+    responseSize = -1;
 
     newRequest = false;
   }
@@ -302,6 +306,14 @@ public class ServerStatsContext {
     return this.startTimeInNS;
   }
 
+  public void setFlushLatency(double latency) {
+    this.flushLatency = latency;
+  }
+
+  public void setResponseSize(int size) {
+    this.responseSize = size;
+  }
+
   public void recordBasicMetrics(ServerHttpRequestStats serverHttpRequestStats) {
     if (serverHttpRequestStats != null) {
       if (databaseLookupLatency >= 0) {
@@ -379,6 +391,12 @@ public class ServerStatsContext {
       }
       if (readComputeOutputSize > 0) {
         serverHttpRequestStats.recordReadComputeEfficiency((double) valueSize / readComputeOutputSize);
+      }
+      if (flushLatency >= 0) {
+        serverHttpRequestStats.recordFlushLatency(flushLatency);
+      }
+      if (responseSize >= 0) {
+        serverHttpRequestStats.recordResponseSize(responseSize);
       }
     }
   }

--- a/services/venice-server/src/main/java/com/linkedin/venice/listener/StatsHandler.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/listener/StatsHandler.java
@@ -180,6 +180,7 @@ public class StatsHandler extends ChannelDuplexHandler {
   @Override
   public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws VeniceException {
     ChannelFuture future = ctx.writeAndFlush(msg);
+    long beforeFlushTimestampNs = System.nanoTime();
     future.addListener((result) -> {
       // reset the StatsHandler for the new request. This is necessary since instances are channel-based
       // and channels are ready for the future requests as soon as the current has been handled.
@@ -199,6 +200,7 @@ public class StatsHandler extends ChannelDuplexHandler {
        * multiple times for a single request
        */
       if (!serverStatsContext.isStatCallBackExecuted()) {
+        serverStatsContext.setFlushLatency(LatencyUtils.getElapsedTimeFromNSToMS(beforeFlushTimestampNs));
         ServerHttpRequestStats serverHttpRequestStats = serverStatsContext.getStoreName() == null
             ? null
             : serverStatsContext.getCurrentStats().getStoreStats(serverStatsContext.getStoreName());

--- a/services/venice-server/src/main/java/com/linkedin/venice/stats/ServerHttpRequestStats.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/stats/ServerHttpRequestStats.java
@@ -58,6 +58,8 @@ public class ServerHttpRequestStats extends AbstractVeniceHttpStats {
   @SuppressWarnings("unused")
   private final Sensor successRequestKeyRatioSensor, successRequestRatioSensor;
   private final Sensor misroutedStoreVersionSensor;
+  private final Sensor flushLatencySensor;
+  private final Sensor responseSizeSensor;
 
   private static final MetricsRepository dummySystemStoreMetricRepo = new MetricsRepository();
 
@@ -314,6 +316,16 @@ public class ServerHttpRequestStats extends AbstractVeniceHttpStats {
         totalStats,
         () -> totalStats.misroutedStoreVersionSensor,
         new OccurrenceRate());
+    flushLatencySensor = registerPerStoreAndTotal(
+        "flush_latency",
+        totalStats,
+        () -> totalStats.flushLatencySensor,
+        TehutiUtils.getPercentileStat(getName(), getFullMetricName("flush_latency")));
+    responseSizeSensor = registerPerStoreAndTotal(
+        "response_size",
+        totalStats,
+        () -> totalStats.responseSizeSensor,
+        TehutiUtils.getPercentileStat(getName(), getFullMetricName("response_size")));
   }
 
   private Sensor registerPerStoreAndTotal(
@@ -441,5 +453,13 @@ public class ServerHttpRequestStats extends AbstractVeniceHttpStats {
 
   public void recordMisroutedStoreVersionRequest() {
     misroutedStoreVersionSensor.record();
+  }
+
+  public void recordFlushLatency(double latency) {
+    flushLatencySensor.record(latency);
+  }
+
+  public void recordResponseSize(int size) {
+    responseSizeSensor.record(size);
   }
 }

--- a/services/venice-server/src/test/java/com/linkedin/venice/listener/ListenerServiceTest.java
+++ b/services/venice-server/src/test/java/com/linkedin/venice/listener/ListenerServiceTest.java
@@ -68,6 +68,7 @@ public class ListenerServiceTest {
     doReturn(false).when(serverConfig).isRestServiceEpollEnabled();
     doReturn(10).when(serverConfig).getNettyWorkerThreadCount();
     doReturn(DefaultIdentityParser.class.getName()).when(serverConfig).getIdentityParserClassName();
+    doReturn(1024 * 1024).when(serverConfig).getChannelOptionWriteBufferHighBytes();
   }
 
   @Test


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Summary, imperative, start upper case, don't end with a period

This PR added a few changes:
1. A new server config to tune the write buffer high watermark and a higher write buffer high watermark will allow writing more data at one time as H2 typically works with a smaller number of connections, and this change will affect HTTP/1.1 connections as well.
2. Flush latency/response size metrics in Server.
3. Fixed an issue in Router unhealthy host tracking during node swap. Essentially, if the node is not alive, Router will remove it from the unhealthy host tracking.

New server config:
server.channel.option.write.buffer.watermark.high.bytes: default 64KB (Netty default)

<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->


## How was this PR tested?
CI
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.