### PR TITLE
[fast-client][thin-client] Common headers and metrics logic between thin-client and fast-client

### DIFF
--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/AvroBlackHoleResponseStoreClientImpl.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/AvroBlackHoleResponseStoreClientImpl.java
@@ -7,6 +7,7 @@ import com.linkedin.venice.client.store.streaming.TrackingStreamingCallback;
 import com.linkedin.venice.client.store.transport.TransportClient;
 import com.linkedin.venice.client.store.transport.TransportClientStreamingCallback;
 import com.linkedin.venice.compute.ComputeRequestWrapper;
+import com.linkedin.venice.read.RequestHeadersProvider;
 import com.linkedin.venice.serializer.RecordSerializer;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
@@ -43,11 +44,10 @@ public class AvroBlackHoleResponseStoreClientImpl<K, V> extends AvroGenericStore
 
     byte[] serializedComputeRequest = serializeComputeRequest(computeRequestWrapper, keys);
 
-    Map<String, String> headerMap = COMPUTE_HEADER_MAP_FOR_STREAMING_V3;
-
     getTransportClient().streamPost(
         getComputeRequestPath(),
-        headerMap,
+        RequestHeadersProvider
+            .getStreamingComputeHeaderMap(keys.size(), computeRequestWrapper.getValueSchemaID(), false),
         serializedComputeRequest,
         new BlackHoleStreamingCallback<>(keys.size(), DelegatingTrackingCallback.wrap(callback)),
         keys.size());

--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/streaming/StreamingResponseTracker.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/streaming/StreamingResponseTracker.java
@@ -1,0 +1,50 @@
+package com.linkedin.venice.client.store.streaming;
+
+import com.linkedin.venice.client.stats.ClientStats;
+import com.linkedin.venice.utils.LatencyUtils;
+import java.util.concurrent.atomic.AtomicInteger;
+
+
+/**
+ * This class provides percentile tracking and stats emission for streaming response
+ */
+public class StreamingResponseTracker {
+  private final ClientStats stats;
+  private final int keyCntForP50;
+  private final int keyCntForP90;
+  private final int keyCntForP95;
+  private final int keyCntForP99;
+  private final long startTimeInNS;
+  private final AtomicInteger receivedKeyCnt = new AtomicInteger(0);
+
+  public StreamingResponseTracker(ClientStats stats, int keyCnt, long startTimeInNS) {
+    this.stats = stats;
+    this.keyCntForP50 = keyCnt / 2;
+    this.keyCntForP90 = keyCnt * 9 / 10;
+    this.keyCntForP95 = keyCnt * 95 / 100;
+    this.keyCntForP99 = keyCnt * 99 / 100;
+    this.startTimeInNS = startTimeInNS;
+  }
+
+  public void recordReceived() {
+    int currentKeyCnt = receivedKeyCnt.incrementAndGet();
+    /**
+     * Do not short-circuit because the key cnt for each percentile could be the same if the total key count is small
+     */
+    if (currentKeyCnt == 1) {
+      stats.recordStreamingResponseTimeToReceiveFirstRecord(LatencyUtils.getElapsedTimeFromNSToMS(startTimeInNS));
+    }
+    if (currentKeyCnt == keyCntForP50) {
+      stats.recordStreamingResponseTimeToReceive50PctRecord(LatencyUtils.getElapsedTimeFromNSToMS(startTimeInNS));
+    }
+    if (currentKeyCnt == keyCntForP90) {
+      stats.recordStreamingResponseTimeToReceive90PctRecord(LatencyUtils.getElapsedTimeFromNSToMS(startTimeInNS));
+    }
+    if (currentKeyCnt == keyCntForP95) {
+      stats.recordStreamingResponseTimeToReceive95PctRecord(LatencyUtils.getElapsedTimeFromNSToMS(startTimeInNS));
+    }
+    if (currentKeyCnt == keyCntForP99) {
+      stats.recordStreamingResponseTimeToReceive99PctRecord(LatencyUtils.getElapsedTimeFromNSToMS(startTimeInNS));
+    }
+  }
+}

--- a/clients/venice-thin-client/src/test/java/com/linkedin/venice/client/store/streaming/StreamingResponseTrackerTest.java
+++ b/clients/venice-thin-client/src/test/java/com/linkedin/venice/client/store/streaming/StreamingResponseTrackerTest.java
@@ -1,0 +1,84 @@
+package com.linkedin.venice.client.store.streaming;
+
+import static org.mockito.ArgumentMatchers.anyDouble;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.linkedin.venice.client.stats.ClientStats;
+import org.testng.annotations.Test;
+
+
+public class StreamingResponseTrackerTest {
+  @Test
+  public void testStreamingResponseTracker() {
+    int keyCount = 100;
+    ClientStats mockClientStats = mock(ClientStats.class);
+    long startTimeNs = System.nanoTime();
+    StreamingResponseTracker streamingResponseTracker =
+        new StreamingResponseTracker(mockClientStats, keyCount, startTimeNs);
+    streamingResponseTracker.recordReceived();
+    verifyRecordStreamingResponseTime(mockClientStats, true, false, false, false, false);
+    for (int i = 0; i < 48; i++) {
+      streamingResponseTracker.recordReceived();
+    }
+    verifyRecordStreamingResponseTime(mockClientStats, true, false, false, false, false);
+    streamingResponseTracker.recordReceived();
+    verifyRecordStreamingResponseTime(mockClientStats, true, true, false, false, false);
+    for (int i = 0; i < 48; i++) {
+      streamingResponseTracker.recordReceived();
+    }
+    verifyRecordStreamingResponseTime(mockClientStats, true, true, true, true, false);
+    streamingResponseTracker.recordReceived();
+    verifyRecordStreamingResponseTime(mockClientStats, true, true, true, true, true);
+  }
+
+  @Test
+  public void testStreamingResponseTrackerWithSmallKeyCount() {
+    int keyCount = 2;
+    ClientStats mockClientStats = mock(ClientStats.class);
+    long startTimeNs = System.nanoTime();
+    StreamingResponseTracker streamingResponseTracker =
+        new StreamingResponseTracker(mockClientStats, keyCount, startTimeNs);
+    streamingResponseTracker.recordReceived();
+    // The key count ranges are calculated using integers (floor) so 2*99/100 = 1
+    verifyRecordStreamingResponseTime(mockClientStats, true, true, true, true, true);
+    streamingResponseTracker.recordReceived();
+    verifyRecordStreamingResponseTime(mockClientStats, true, true, true, true, true);
+  }
+
+  private void verifyRecordStreamingResponseTime(
+      ClientStats mockClientStats,
+      boolean ttfr,
+      boolean tt50pr,
+      boolean tt90pr,
+      boolean tt95pr,
+      boolean tt99pr) {
+    if (ttfr) {
+      verify(mockClientStats, times(1)).recordStreamingResponseTimeToReceiveFirstRecord(anyDouble());
+    } else {
+      verify(mockClientStats, never()).recordStreamingResponseTimeToReceiveFirstRecord(anyDouble());
+    }
+    if (tt50pr) {
+      verify(mockClientStats, times(1)).recordStreamingResponseTimeToReceive50PctRecord(anyDouble());
+    } else {
+      verify(mockClientStats, never()).recordStreamingResponseTimeToReceive50PctRecord(anyDouble());
+    }
+    if (tt90pr) {
+      verify(mockClientStats, times(1)).recordStreamingResponseTimeToReceive90PctRecord(anyDouble());
+    } else {
+      verify(mockClientStats, never()).recordStreamingResponseTimeToReceive90PctRecord(anyDouble());
+    }
+    if (tt95pr) {
+      verify(mockClientStats, times(1)).recordStreamingResponseTimeToReceive95PctRecord(anyDouble());
+    } else {
+      verify(mockClientStats, never()).recordStreamingResponseTimeToReceive95PctRecord(anyDouble());
+    }
+    if (tt99pr) {
+      verify(mockClientStats, times(1)).recordStreamingResponseTimeToReceive99PctRecord(anyDouble());
+    } else {
+      verify(mockClientStats, never()).recordStreamingResponseTimeToReceive99PctRecord(anyDouble());
+    }
+  }
+}

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/read/RequestHeadersProvider.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/read/RequestHeadersProvider.java
@@ -1,0 +1,89 @@
+package com.linkedin.venice.read;
+
+import static com.linkedin.venice.HttpConstants.VENICE_CLIENT_COMPUTE;
+import static com.linkedin.venice.HttpConstants.VENICE_COMPUTE_VALUE_SCHEMA_ID;
+import static com.linkedin.venice.HttpConstants.VENICE_KEY_COUNT;
+
+import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelperCommon;
+import com.linkedin.avroutil1.compatibility.AvroVersion;
+import com.linkedin.venice.HttpConstants;
+import com.linkedin.venice.compression.CompressionStrategy;
+import com.linkedin.venice.schema.avro.ReadAvroProtocolDefinition;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+
+/**
+ * Provide the appropriate headers based on the request type for all remote Venice clients. i.e. the thin-client and
+ * the fast-client.
+ */
+public class RequestHeadersProvider {
+  private static final Logger LOGGER = LogManager.getLogger(RequestHeadersProvider.class);
+  private static final Map<String, String> GET_HEADER_MAP = new HashMap<>();
+  private static final Map<String, String> STREAMING_MULTI_GET_HEADER_MAP = new HashMap<>();
+  private static final Map<String, String> STREAMING_COMPUTE_HEADER_MAP_V3 = new HashMap<>();
+
+  static {
+    /**
+     * Hard-code API version of single-get and multi-get to be '1'.
+     * If the header varies request by request, Venice client needs to create a map per request.
+     */
+    GET_HEADER_MAP.put(
+        HttpConstants.VENICE_API_VERSION,
+        Integer.toString(ReadAvroProtocolDefinition.SINGLE_GET_CLIENT_REQUEST_V1.getProtocolVersion()));
+    GET_HEADER_MAP.put(
+        HttpConstants.VENICE_SUPPORTED_COMPRESSION_STRATEGY,
+        Integer.toString(CompressionStrategy.GZIP.getValue()));
+
+    STREAMING_MULTI_GET_HEADER_MAP.put(
+        HttpConstants.VENICE_API_VERSION,
+        Integer.toString(ReadAvroProtocolDefinition.MULTI_GET_CLIENT_REQUEST_V1.getProtocolVersion()));
+
+    /**
+     * COMPUTE_REQUEST_V1 and V2 are deprecated.
+     */
+    STREAMING_COMPUTE_HEADER_MAP_V3.put(
+        HttpConstants.VENICE_API_VERSION,
+        Integer.toString(ReadAvroProtocolDefinition.COMPUTE_REQUEST_V3.getProtocolVersion()));
+    STREAMING_COMPUTE_HEADER_MAP_V3.put(HttpConstants.VENICE_STREAMING, "1");
+
+    AvroVersion version = AvroCompatibilityHelperCommon.getRuntimeAvroVersion();
+    LOGGER.info("Detected: {} on the classpath.", version);
+  }
+
+  public static Map<String, String> getThinClientGetHeaderMap() {
+    return new HashMap<>(GET_HEADER_MAP);
+  }
+
+  public static Map<String, String> getThinClientStreamingBatchGetHeaders(int keyCount) {
+    Map<String, String> headers = getStreamingBatchGetHeaders(keyCount);
+    headers.put(HttpConstants.VENICE_STREAMING, "1");
+    headers.put(
+        HttpConstants.VENICE_SUPPORTED_COMPRESSION_STRATEGY,
+        Integer.toString(CompressionStrategy.GZIP.getValue()));
+    return headers;
+  }
+
+  public static Map<String, String> getStreamingBatchGetHeaders(int keyCount) {
+    Map<String, String> headers = new HashMap<>(STREAMING_MULTI_GET_HEADER_MAP.size() + 1);
+    headers.putAll(STREAMING_MULTI_GET_HEADER_MAP);
+    headers.put(VENICE_KEY_COUNT, Integer.toString(keyCount));
+    return headers;
+  }
+
+  public static Map<String, String> getStreamingComputeHeaderMap(
+      int keyCount,
+      int computeValueSchemaId,
+      boolean isRemoteComputationOnly) {
+    Map<String, String> headers = new HashMap<>(STREAMING_COMPUTE_HEADER_MAP_V3.size() + 3);
+    headers.putAll(STREAMING_COMPUTE_HEADER_MAP_V3);
+    headers.put(VENICE_KEY_COUNT, Integer.toString(keyCount));
+    headers.put(VENICE_COMPUTE_VALUE_SCHEMA_ID, Integer.toString(computeValueSchemaId));
+    if (!isRemoteComputationOnly) {
+      headers.put(VENICE_CLIENT_COMPUTE, "1");
+    }
+    return headers;
+  }
+}

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/read/RequestHeadersProviderTest.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/read/RequestHeadersProviderTest.java
@@ -1,0 +1,60 @@
+package com.linkedin.venice.read;
+
+import static com.linkedin.venice.HttpConstants.VENICE_API_VERSION;
+import static com.linkedin.venice.HttpConstants.VENICE_CLIENT_COMPUTE;
+import static com.linkedin.venice.HttpConstants.VENICE_COMPUTE_VALUE_SCHEMA_ID;
+import static com.linkedin.venice.HttpConstants.VENICE_KEY_COUNT;
+import static com.linkedin.venice.HttpConstants.VENICE_STREAMING;
+import static com.linkedin.venice.HttpConstants.VENICE_SUPPORTED_COMPRESSION_STRATEGY;
+
+import java.util.Map;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class RequestHeadersProviderTest {
+  @Test
+  public void testThinClientSingleGetHeaders() {
+    Map<String, String> headers = RequestHeadersProvider.getThinClientGetHeaderMap();
+    Assert.assertEquals(headers.size(), 2);
+    Assert.assertTrue(headers.containsKey(VENICE_API_VERSION));
+    Assert.assertTrue(headers.containsKey(VENICE_SUPPORTED_COMPRESSION_STRATEGY));
+  }
+
+  @Test
+  public void testThinClientStreamingBatchGetHeaders() {
+    int keyCount = 100;
+    Map<String, String> headers = RequestHeadersProvider.getThinClientStreamingBatchGetHeaders(keyCount);
+    Assert.assertEquals(headers.size(), 4);
+    Assert.assertTrue(headers.containsKey(VENICE_STREAMING));
+    Assert.assertTrue(headers.containsKey(VENICE_SUPPORTED_COMPRESSION_STRATEGY));
+    Assert.assertTrue(headers.containsKey(VENICE_API_VERSION));
+    Assert.assertEquals(headers.get(VENICE_KEY_COUNT), Integer.toString(keyCount));
+  }
+
+  @Test
+  public void testStreamingBatchGetHeaders() {
+    int keyCount = 100;
+    Map<String, String> headers = RequestHeadersProvider.getStreamingBatchGetHeaders(keyCount);
+    Assert.assertEquals(headers.size(), 2);
+    Assert.assertTrue(headers.containsKey(VENICE_API_VERSION));
+    Assert.assertEquals(headers.get(VENICE_KEY_COUNT), Integer.toString(keyCount));
+  }
+
+  @Test
+  public void testStreamingComputeHeaders() {
+    int keyCount = 100;
+    int computeSchemaId = 3;
+    Map<String, String> headers = RequestHeadersProvider.getStreamingComputeHeaderMap(keyCount, computeSchemaId, false);
+    Assert.assertEquals(headers.size(), 5);
+    Assert.assertTrue(headers.containsKey(VENICE_API_VERSION));
+    Assert.assertTrue(headers.containsKey(VENICE_STREAMING));
+    Assert.assertTrue(headers.containsKey(VENICE_CLIENT_COMPUTE));
+    Assert.assertEquals(headers.get(VENICE_KEY_COUNT), Integer.toString(keyCount));
+    Assert.assertEquals(headers.get(VENICE_COMPUTE_VALUE_SCHEMA_ID), Integer.toString(computeSchemaId));
+
+    headers = RequestHeadersProvider.getStreamingComputeHeaderMap(keyCount, computeSchemaId, true);
+    Assert.assertEquals(headers.size(), 4);
+    Assert.assertFalse(headers.containsKey(VENICE_CLIENT_COMPUTE));
+  }
+}


### PR DESCRIPTION
## [fast-client][thin-client] Common headers and metrics logic between thin-client and fast-client

1. Fast-client and thin-client use similar headers when making requests to the router/servers. Abstracted the common logic to a static utility class `RequestHeadersProvider` to ensure optimizations like providing key count in request header for early quota rejection is also available for fast-client (this PR does not include the server change that performs the early quota rejection).

2. Although fast-client's `FastClientStats` extends `com.linkedin.venice.client.stats.ClientStats`, we currently have two similar yet different approaches when it comes to metrics emission. Thin-client emits metrics using `TrackingStreamingCallback` which wraps the user callback, specifically the `StatTrackingStreamingCallback` implementation in `StatTrackingStoreClient` together with implementations of `RecordStreamDecoder`. Fast-client on the other hand record some stats in `RequestContext` and adds a handle stage to the user callback in `StatsAvroGenericStoreClient` to perform the actual metrics emission. Today there is no true streaming between fast-client and server but ideally we could have an `AbstractRecordStreamDecoder` with common logic such as metrics emission so it can be used by fast-client as well so it doesn't try to add its own metric emission handle stage (which had gaps) to the user callback in `StatsAvroGenericStoreClient`.
For now the missing streaming response percentile latency metric is added to fast-client using existing methods by abstracting the common logic to an utility class `StreamingResponseTracker`.


## How was this PR tested?
New and existing unit and integration tests

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.