### PR TITLE
[dvc] Fixed DVC integration test resource leak

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/DaVinciBackend.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/DaVinciBackend.java
@@ -576,10 +576,6 @@ public class DaVinciBackend implements Closeable {
     return ingestionBackend;
   }
 
-  public boolean compareCacheConfig(Optional<ObjectCacheConfig> config) {
-    return cacheBackend.map(ObjectCacheBackend::getStoreCacheConfig).equals(config);
-  }
-
   public void verifyCacheConfigEquality(@Nullable ObjectCacheConfig newObjectCacheConfig, String storeName) {
     ObjectCacheConfig existingObjectCacheConfig =
         cacheBackend.isPresent() ? cacheBackend.get().getStoreCacheConfig() : null;

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/DaVinciBackend.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/DaVinciBackend.java
@@ -32,6 +32,7 @@ import com.linkedin.davinci.store.cache.backend.ObjectCacheBackend;
 import com.linkedin.davinci.store.cache.backend.ObjectCacheConfig;
 import com.linkedin.venice.blobtransfer.BlobTransferManager;
 import com.linkedin.venice.blobtransfer.BlobTransferUtil;
+import com.linkedin.venice.client.exceptions.VeniceClientException;
 import com.linkedin.venice.client.schema.StoreSchemaFetcher;
 import com.linkedin.venice.client.store.ClientConfig;
 import com.linkedin.venice.client.store.ClientFactory;
@@ -75,6 +76,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
@@ -82,6 +84,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
+import javax.annotation.Nullable;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -575,6 +578,16 @@ public class DaVinciBackend implements Closeable {
 
   public boolean compareCacheConfig(Optional<ObjectCacheConfig> config) {
     return cacheBackend.map(ObjectCacheBackend::getStoreCacheConfig).equals(config);
+  }
+
+  public void verifyCacheConfigEquality(@Nullable ObjectCacheConfig newObjectCacheConfig, String storeName) {
+    ObjectCacheConfig existingObjectCacheConfig =
+        cacheBackend.isPresent() ? cacheBackend.get().getStoreCacheConfig() : null;
+    if (!Objects.equals(existingObjectCacheConfig, newObjectCacheConfig)) {
+      throw new VeniceClientException(
+          "Cache config conflicts with existing backend, storeName=" + storeName + "; existing cache config: "
+              + existingObjectCacheConfig + "; new cache config: " + newObjectCacheConfig);
+    }
   }
 
   final Map<String, VersionBackend> getVersionByTopicMap() {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/client/AvroGenericDaVinciClient.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/client/AvroGenericDaVinciClient.java
@@ -725,8 +725,10 @@ public class AvroGenericDaVinciClient<K, V> implements DaVinciClient<K, V>, Avro
             backend -> {
               // Ensure that existing backend is fully closed before a new one can be created.
               synchronized (AvroGenericDaVinciClient.class) {
+                logger.info("Start of " + this.getClass().getSimpleName() + "'s ref counted deleter closure.");
                 daVinciBackend = null;
                 backend.close();
+                logger.info("End of " + this.getClass().getSimpleName() + "'s ref counted deleter closure.");
               }
             });
       } else if (VeniceSystemStoreType
@@ -766,9 +768,7 @@ public class AvroGenericDaVinciClient<K, V> implements DaVinciClient<K, V>, Avro
         daVinciConfig::getRecordTransformer);
 
     try {
-      if (!getBackend().compareCacheConfig(cacheConfig)) {
-        throw new VeniceClientException("Cache config conflicts with existing backend, storeName=" + getStoreName());
-      }
+      getBackend().verifyCacheConfigEquality(daVinciConfig.getCacheConfig(), getStoreName());
 
       if (daVinciConfig.isCacheEnabled()) {
         cacheBackend = getBackend().getObjectCache();

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/DaVinciClientTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/DaVinciClientTest.java
@@ -1066,19 +1066,19 @@ public class DaVinciClientTest {
     VeniceProperties backendConfig2 = configBuilder.build();
     DaVinciConfig dvcConfig = new DaVinciConfig().setIsolated(true);
 
-    CachingDaVinciClientFactory factory2 = new CachingDaVinciClientFactory(
+    try (CachingDaVinciClientFactory factory2 = new CachingDaVinciClientFactory(
         d2Client,
         VeniceRouterWrapper.CLUSTER_DISCOVERY_D2_SERVICE_NAME,
         new MetricsRepository(),
-        backendConfig2);
-    DaVinciClient<Integer, Object> client2 = factory2.getAndStartGenericAvroClient(storeName, dvcConfig);
-    client2.subscribeAll().get();
+        backendConfig2)) {
+      DaVinciClient<Integer, Object> client2 = factory2.getAndStartGenericAvroClient(storeName, dvcConfig);
+      client2.subscribeAll().get();
 
-    for (int i = 0; i < 3; i++) {
-      String snapshotPath = RocksDBUtils.composeSnapshotDir(dvcPath1 + "/rocksdb", storeName + "_v1", i);
-      Assert.assertTrue(Files.exists(Paths.get(snapshotPath)));
+      for (int i = 0; i < 3; i++) {
+        String snapshotPath = RocksDBUtils.composeSnapshotDir(dvcPath1 + "/rocksdb", storeName + "_v1", i);
+        Assert.assertTrue(Files.exists(Paths.get(snapshotPath)));
+      }
     }
-
   }
 
   private void setupHybridStore(String storeName, Consumer<UpdateStoreQueryParams> paramsConsumer) throws Exception {


### PR DESCRIPTION
There is a resource leak in `DaVinciClientTest::testBlobP2PTransferAmongDVC` which causes subsequent tests to fail. This is occasionally masked by the `test-retry` plugin, though the retry itself is flaky and so it sometimes fails to retry at all. In any case, it is better to not fail in the first place...

Also did some minor tweaks to the main code to make debugging issues easier in the future. This includes extra logging in `DaVinciBackend` and a slightly more precise exception message in `AvroGenericDaVinciClient`.

## How was this PR tested?
Existing tests are deflaked.

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.