### PR TITLE
[router][samza] Harden up quota monitor requests

### DIFF
--- a/clients/venice-samza/src/main/java/com/linkedin/venice/pushmonitor/RouterBasedHybridStoreQuotaMonitor.java
+++ b/clients/venice-samza/src/main/java/com/linkedin/venice/pushmonitor/RouterBasedHybridStoreQuotaMonitor.java
@@ -124,6 +124,10 @@ public class RouterBasedHybridStoreQuotaMonitor implements Closeable {
       // Get hybrid store quota status
       CompletableFuture<TransportClientResponse> responseFuture = transportClient.get(requestPath);
       TransportClientResponse response = responseFuture.get(POLL_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+      if (response == null) {
+        LOGGER.error("Router was not able to get hybrid quota status! Received null response!");
+        return;
+      }
       HybridStoreQuotaStatusResponse quotaStatusResponse =
           mapper.readValue(response.getBody(), HybridStoreQuotaStatusResponse.class);
       if (quotaStatusResponse.isError()) {

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/MetaDataHandler.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/MetaDataHandler.java
@@ -670,13 +670,14 @@ public class MetaDataHandler extends SimpleChannelInboundHandler<HttpRequest> {
       throws IOException {
     String storeName = helper.getResourceName();
     checkResourceName(storeName, "/" + TYPE_STREAM_HYBRID_STORE_QUOTA + "/${storeName}");
-    if (!storeConfigRepo.getStoreConfig(storeName).isPresent()) {
+    Store store = storeRepository.getStore(storeName);
+    if (!storeConfigRepo.getStoreConfig(storeName).isPresent() || store == null) {
       byte[] errBody = ("Cannot fetch the hybrid store quota status for store: " + storeName + " because the store: "
           + storeName + " cannot be found").getBytes();
       setupResponseAndFlush(NOT_FOUND, errBody, false, ctx);
       return;
     }
-    String topicName = Version.composeKafkaTopic(storeName, storeRepository.getStore(storeName).getCurrentVersion());
+    String topicName = Version.composeKafkaTopic(storeName, store.getCurrentVersion());
     prepareHybridStoreQuotaStatusResponse(topicName, ctx);
   }
 


### PR DESCRIPTION
## [router][samza] Harden up quota monitor requests
Main fix is that there exists a condition in the router where during a store move, the store will have information in the routers internal store config repository, but it won't have it in the store repository after the store was deleted at the end of the store move.  This would then trigger an exception and 500 error, and would prevent producers from reinitializing their clients. This fix addresses that.

Added tests in the store migration test suite to include a running producer.  Also added some protection in the code against empty responses (which was encountered while running the debugger).

Resolves #XXX

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.