### PR TITLE
 [controller] Remove older backup versions after retention period

### DIFF
--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/StoreBackupVersionCleanupService.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/StoreBackupVersionCleanupService.java
@@ -281,8 +281,8 @@ public class StoreBackupVersionCleanupService extends AbstractVeniceService {
     // retention period.
     if (readyToBeRemovedVersions.isEmpty()) {
       for (Version version: versions) {
-        if (version.getNumber() < currentVersion && store.getLatestVersionPromoteToCurrentTimestamp()
-            + defaultBackupVersionRetentionMs < time.getMilliseconds()) {
+        if (version.getNumber() < currentVersion
+            && version.getCreatedTime() + defaultBackupVersionRetentionMs < time.getMilliseconds()) {
           readyToBeRemovedVersions.add(version);
         }
       }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/StoreBackupVersionCleanupService.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/StoreBackupVersionCleanupService.java
@@ -265,28 +265,19 @@ public class StoreBackupVersionCleanupService extends AbstractVeniceService {
       return false;
     }
 
-    // If the current version is from repush, do not delete the version before previous current version,
-    // instead delete the repush source version from which it was repushed as they hold identical data.
-    // During later iteration of this thread, it will delete the older backup after threshold retention time.
+    // This will delete backup versions which satisfy any of the following conditions
+    // 1. If the current version is from repush, delete the repush source backup version
+    // 2. Current version is from a repush, but still a lingering version older than retention period.
+    // 3. Current version is not repush and is older than retention, delete any versions < current version.
     int repushSourceVersion = store.getVersionOrThrow(currentVersion).getRepushSourceVersion();
     List<Version> readyToBeRemovedVersions = versions.stream()
         .filter(
             v -> repushSourceVersion > NON_EXISTING_VERSION
-                ? v.getNumber() == repushSourceVersion
+                ? (v.getNumber() == repushSourceVersion || v.getNumber() < currentVersion
+                    && v.getCreatedTime() + defaultBackupVersionRetentionMs < time.getMilliseconds())
                 : v.getNumber() < currentVersion)
         .collect(Collectors.toList());
 
-    // If there are still leaking versions due to consecutive repushes with some version failing in other fabric,
-    // there could be versions with repushSourceVersion does not match current version, delete them after backup
-    // retention period.
-    if (readyToBeRemovedVersions.isEmpty()) {
-      for (Version version: versions) {
-        if (version.getNumber() < currentVersion
-            && version.getCreatedTime() + defaultBackupVersionRetentionMs < time.getMilliseconds()) {
-          readyToBeRemovedVersions.add(version);
-        }
-      }
-    }
     if (readyToBeRemovedVersions.isEmpty()) {
       return false;
     }


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

##  Remove older backup versions after retention period
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

If there are old lingering version and there are newer repush version in regular cadence, today Venice will not delete the old version as the `getLatestVersionPromoteToCurrentTimestamp` updated and never fall off retention period. This PR fixed that by checking version creation time and delete if its older than retention period.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.