### PR TITLE
[server] Fail-Fast on Corrupted OffsetRecord 

### DIFF
--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTaskTest.java
@@ -4853,6 +4853,33 @@ public abstract class StoreIngestionTaskTest {
         "If the partition has messages in it, and we consumed some of them, we expect lag to equal the unconsumed message count.");
   }
 
+  /**
+   * When SIT encounters a corrupted {@link OffsetRecord} in {@link StoreIngestionTask#processCommonConsumerAction} and
+   * {@link StorageMetadataService#getLastOffset} throws an exception due to a deserialization error,
+   * {@link StoreIngestionTask#reportError(String, int, Exception)} should be called in order to trigger a Helix
+   * state transition without waiting 24+ hours for the Helix state transition timeout.
+   */
+  @Test
+  public void testProcessConsumerActionsError() throws Exception {
+    runTest(Collections.singleton(PARTITION_FOO), () -> {
+      // This is an actual exception thrown when deserializing a corrupted OffsetRecord
+      String msg = "Received Magic Byte '6' which is not supported by InternalAvroSpecificSerializer. "
+          + "The only supported Magic Byte for this implementation is '24'.";
+      doThrow(new VeniceMessageException(msg)).when(mockStorageMetadataService).getLastOffset(any(), anyInt());
+
+      for (int i = 0; i < StoreIngestionTask.MAX_CONSUMER_ACTION_ATTEMPTS; i++) {
+        try {
+          storeIngestionTaskUnderTest.processConsumerActions(storeAndVersionConfigsUnderTest.store);
+        } catch (InterruptedException e) {
+          throw new RuntimeException(e);
+        }
+      }
+      ArgumentCaptor<VeniceException> captor = ArgumentCaptor.forClass(VeniceException.class);
+      verify(storeIngestionTaskUnderTest, atLeastOnce()).reportError(anyString(), eq(PARTITION_FOO), captor.capture());
+      assertTrue(captor.getValue().getMessage().endsWith(msg));
+    }, AA_OFF);
+  }
+
   private VeniceStoreVersionConfig getDefaultMockVeniceStoreVersionConfig(
       Consumer<VeniceStoreVersionConfig> storeVersionConfigOverride) {
     // mock the store config


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Summary
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

The following sequence of events causes the Helix status to wait 24-48 hours:
1. In the main `StoreIngestionTask` thread, the calls stack is [`run()`](https://github.com/linkedin/venice/blob/c8b95abd90a6c20601fdd79ae15552bd646e1ea8/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java#L1369) -> [`processConsumerActions()`](https://github.com/linkedin/venice/blob/c8b95abd90a6c20601fdd79ae15552bd646e1ea8/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java#L1391) -> [`processConsumerAction()`](https://github.com/linkedin/venice/blob/c8b95abd90a6c20601fdd79ae15552bd646e1ea8/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java#L1644) -> [`processCommonConsumerAction()`](https://github.com/linkedin/venice/blob/c8b95abd90a6c20601fdd79ae15552bd646e1ea8/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/LeaderFollowerStoreIngestionTask.java#L482)
2. The underlying `OffsetRecord` was corrupted, and [`getLastOffset()`](https://github.com/linkedin/venice/blob/c8b95abd90a6c20601fdd79ae15552bd646e1ea8/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java#L1849) throws an `Exception`
3. As a result, the [`partitionConsumptionStateMap`](https://github.com/linkedin/venice/blob/c8b95abd90a6c20601fdd79ae15552bd646e1ea8/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java#L1858) will not be populated
4. In the `catch Throwable` clause, the PCS was never created so [`(pcs) state == null`](https://github.com/linkedin/venice/blob/c8b95abd90a6c20601fdd79ae15552bd646e1ea8/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java#L1671)
5. [`reportError()`](https://github.com/linkedin/venice/blob/c8b95abd90a6c20601fdd79ae15552bd646e1ea8/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java#L1677) never gets called
6. The [`CountDownLatch ingestionCompletionFlag`](https://github.com/linkedin/venice/blob/c8b95abd90a6c20601fdd79ae15552bd646e1ea8/clients/da-vinci-client/src/main/java/com/linkedin/davinci/helix/StateModelIngestionProgressNotifier.java#L95) was never released by [IngestionNotificationDispatcher](https://github.com/linkedin/venice/blob/c8b95abd90a6c20601fdd79ae15552bd646e1ea8/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/IngestionNotificationDispatcher.java#L294), so the `OFFLINE -> STANDBY` transition never occurred

The solution is to consider the case when `state == null`, ensuring that `reportError()` will be called.

### Changes
**[Functional]**: When `state == null` as the PCS was never created, ensure that `reportError()` is called. Otherwise, the Helix state transition will wait 24-48 hours for a signal.
**[Unit Test]**: Added unit test `testProcessConsumerActionsError()` in `StoreIngestionTaskTest`.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

Unit test `testProcessConsumerActionsError()`.

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [X] No. You can skip the rest of this section.