### PR TITLE
Fix flaky test of `testEnablePartialUpdateOnActiveActiveStore` due to no retry on verifying logic.

### DIFF
--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/PartialUpdateTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/PartialUpdateTest.java
@@ -1175,7 +1175,8 @@ public class PartialUpdateTest {
 
   }
 
-  @Test(timeOut = TEST_TIMEOUT_MS)
+  // TODO: remove invocation # before merging this change.
+  @Test(timeOut = TEST_TIMEOUT_MS, invocationCount = 10)
   public void testEnablePartialUpdateOnActiveActiveStore() {
     final String storeName = Utils.getUniqueString("testRepushWithDeleteRecord");
     String parentControllerUrl = parentController.getControllerUrl();
@@ -1212,16 +1213,18 @@ public class PartialUpdateTest {
           parentControllerClient,
           30,
           TimeUnit.SECONDS);
-      verifyConsumerThreadPoolFor(
-          storeVersionTopicV1,
-          new PubSubTopicPartitionImpl(realTimeTopic, 0),
-          ConsumerPoolType.CURRENT_VERSION_NON_AA_WC_LEADER_POOL,
-          1);
-      verifyConsumerThreadPoolFor(
-          storeVersionTopicV1,
-          new PubSubTopicPartitionImpl(storeVersionTopicV1, 0),
-          ConsumerPoolType.CURRENT_VERSION_NON_AA_WC_LEADER_POOL,
-          1);
+      TestUtils.waitForNonDeterministicAssertion(ASSERTION_TIMEOUT_MS, TimeUnit.MILLISECONDS, true, () -> {
+        verifyConsumerThreadPoolFor(
+            storeVersionTopicV1,
+            new PubSubTopicPartitionImpl(realTimeTopic, 0),
+            ConsumerPoolType.CURRENT_VERSION_NON_AA_WC_LEADER_POOL,
+            1);
+        verifyConsumerThreadPoolFor(
+            storeVersionTopicV1,
+            new PubSubTopicPartitionImpl(storeVersionTopicV1, 0),
+            ConsumerPoolType.CURRENT_VERSION_NON_AA_WC_LEADER_POOL,
+            1);
+      });
       // Enable write-compute for v1:
       // leader: CURRENT_VERSION_NON_AAWC_LEADER => CURRENT_VERSION_AAWC_LEADER
       // follower: CURRENT_VERSION_NON_AAWC_LEADER
@@ -1283,29 +1286,31 @@ public class PartialUpdateTest {
           parentControllerClient,
           30,
           TimeUnit.SECONDS);
-      // Version 1 has active-active and write compute disabled, so each server host will ingest from local data center
-      // for leader.
-      verifyConsumerThreadPoolFor(
-          storeVersionTopicV1,
-          new PubSubTopicPartitionImpl(realTimeTopic, 0),
-          ConsumerPoolType.NON_CURRENT_VERSION_NON_AA_WC_LEADER_POOL,
-          1);
-      verifyConsumerThreadPoolFor(
-          storeVersionTopicV1,
-          new PubSubTopicPartitionImpl(storeVersionTopicV1, 0),
-          ConsumerPoolType.NON_CURRENT_VERSION_NON_AA_WC_LEADER_POOL,
-          1);
-      // Version 2 has active-active enabled, so each server host will ingest from two data centers for leader.
-      verifyConsumerThreadPoolFor(
-          storeVersionTopicV2,
-          new PubSubTopicPartitionImpl(realTimeTopic, 0),
-          ConsumerPoolType.CURRENT_VERSION_AA_WC_LEADER_POOL,
-          NUMBER_OF_CHILD_DATACENTERS);
-      verifyConsumerThreadPoolFor(
-          storeVersionTopicV2,
-          new PubSubTopicPartitionImpl(storeVersionTopicV2, 0),
-          ConsumerPoolType.CURRENT_VERSION_NON_AA_WC_LEADER_POOL,
-          1);
+      TestUtils.waitForNonDeterministicAssertion(ASSERTION_TIMEOUT_MS, TimeUnit.MILLISECONDS, true, () -> {
+        // Version 1 has active-active and write compute disabled, so each server host will ingest from local data
+        // center for leader.
+        verifyConsumerThreadPoolFor(
+            storeVersionTopicV1,
+            new PubSubTopicPartitionImpl(realTimeTopic, 0),
+            ConsumerPoolType.NON_CURRENT_VERSION_NON_AA_WC_LEADER_POOL,
+            1);
+        verifyConsumerThreadPoolFor(
+            storeVersionTopicV1,
+            new PubSubTopicPartitionImpl(storeVersionTopicV1, 0),
+            ConsumerPoolType.NON_CURRENT_VERSION_NON_AA_WC_LEADER_POOL,
+            1);
+        // Version 2 has active-active enabled, so each server host will ingest from two data centers for leader.
+        verifyConsumerThreadPoolFor(
+            storeVersionTopicV2,
+            new PubSubTopicPartitionImpl(realTimeTopic, 0),
+            ConsumerPoolType.CURRENT_VERSION_AA_WC_LEADER_POOL,
+            NUMBER_OF_CHILD_DATACENTERS);
+        verifyConsumerThreadPoolFor(
+            storeVersionTopicV2,
+            new PubSubTopicPartitionImpl(storeVersionTopicV2, 0),
+            ConsumerPoolType.CURRENT_VERSION_NON_AA_WC_LEADER_POOL,
+            1);
+      });
     }
 
     VeniceClusterWrapper veniceCluster = childDatacenters.get(0).getClusters().get(CLUSTER_NAME);
@@ -1363,27 +1368,29 @@ public class PartialUpdateTest {
           30,
           TimeUnit.SECONDS);
     }
-    // Version 2 become backup version.
-    verifyConsumerThreadPoolFor(
-        storeVersionTopicV2,
-        new PubSubTopicPartitionImpl(realTimeTopic, 0),
-        ConsumerPoolType.NON_CURRENT_VERSION_AA_WC_LEADER_POOL,
-        NUMBER_OF_CHILD_DATACENTERS);
-    verifyConsumerThreadPoolFor(
-        storeVersionTopicV2,
-        new PubSubTopicPartitionImpl(storeVersionTopicV2, 0),
-        ConsumerPoolType.NON_CURRENT_VERSION_NON_AA_WC_LEADER_POOL,
-        1);
-    verifyConsumerThreadPoolFor(
-        storeVersionTopicV3,
-        new PubSubTopicPartitionImpl(realTimeTopic, 0),
-        ConsumerPoolType.CURRENT_VERSION_AA_WC_LEADER_POOL,
-        NUMBER_OF_CHILD_DATACENTERS);
-    verifyConsumerThreadPoolFor(
-        storeVersionTopicV3,
-        new PubSubTopicPartitionImpl(storeVersionTopicV3, 0),
-        ConsumerPoolType.CURRENT_VERSION_NON_AA_WC_LEADER_POOL,
-        1);
+    TestUtils.waitForNonDeterministicAssertion(ASSERTION_TIMEOUT_MS, TimeUnit.MILLISECONDS, true, () -> {
+      // Version 2 become backup version.
+      verifyConsumerThreadPoolFor(
+          storeVersionTopicV2,
+          new PubSubTopicPartitionImpl(realTimeTopic, 0),
+          ConsumerPoolType.NON_CURRENT_VERSION_AA_WC_LEADER_POOL,
+          NUMBER_OF_CHILD_DATACENTERS);
+      verifyConsumerThreadPoolFor(
+          storeVersionTopicV2,
+          new PubSubTopicPartitionImpl(storeVersionTopicV2, 0),
+          ConsumerPoolType.NON_CURRENT_VERSION_NON_AA_WC_LEADER_POOL,
+          1);
+      verifyConsumerThreadPoolFor(
+          storeVersionTopicV3,
+          new PubSubTopicPartitionImpl(realTimeTopic, 0),
+          ConsumerPoolType.CURRENT_VERSION_AA_WC_LEADER_POOL,
+          NUMBER_OF_CHILD_DATACENTERS);
+      verifyConsumerThreadPoolFor(
+          storeVersionTopicV3,
+          new PubSubTopicPartitionImpl(storeVersionTopicV3, 0),
+          ConsumerPoolType.CURRENT_VERSION_NON_AA_WC_LEADER_POOL,
+          1);
+    });
     // Need to create a new producer to update partial update config from store response.
     veniceProducer = getSamzaProducer(veniceCluster, storeName, Version.PushType.STREAM);
     UpdateBuilder builder = new UpdateBuilderImpl(partialUpdateSchema);
@@ -1430,16 +1437,17 @@ public class PartialUpdateTest {
             for (Map.Entry<String, Map<String, TopicPartitionIngestionInfo>> entry: topicPartitionIngestionContexts
                 .entrySet()) {
               Map<String, TopicPartitionIngestionInfo> topicPartitionIngestionInfoMap = entry.getValue();
-              Assert.assertTrue(topicPartitionIngestionInfoMap.size() <= 1);
               for (Map.Entry<String, TopicPartitionIngestionInfo> topicPartitionIngestionInfoEntry: topicPartitionIngestionInfoMap
                   .entrySet()) {
                 String topicPartitionStr = topicPartitionIngestionInfoEntry.getKey();
-                TopicPartitionIngestionInfo topicPartitionIngestionInfo = topicPartitionIngestionInfoEntry.getValue();
-                assertEquals(pubSubTopicPartition.toString(), topicPartitionStr);
-                assertTrue(topicPartitionIngestionInfo.getConsumerIdStr().contains(consumerPoolType.getStatSuffix()));
-                regionCount += 1;
+                if (pubSubTopicPartition.toString().equals(topicPartitionStr)) {
+                  TopicPartitionIngestionInfo topicPartitionIngestionInfo = topicPartitionIngestionInfoEntry.getValue();
+                  assertTrue(topicPartitionIngestionInfo.getConsumerIdStr().contains(consumerPoolType.getStatSuffix()));
+                  regionCount += 1;
+                }
               }
             }
+            // To ensure exactly one consumer from specific pool is allocated for each region.
             Assert.assertEquals(regionCount, expectedRegionNum);
           }
         } catch (IOException e) {


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Summary, imperative, start upper case, don't end with a period
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Previously, `testEnablePartialUpdateOnActiveActiveStore` was flaky due to no retry on verifying logic for consumer assignment with a fixed timeout. Besides, it has a wrong assumption:  the consumer we verify will only have one partition assignment. 


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.