### PR TITLE
[server] Batch report EOIP for incremental push prior to replica ready-to-serve

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/DaVinciBackend.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/DaVinciBackend.java
@@ -109,7 +109,6 @@ public class DaVinciBackend implements Closeable {
   private IngestionBackend ingestionBackend;
   private final AggVersionedStorageEngineStats aggVersionedStorageEngineStats;
   private final boolean useDaVinciSpecificExecutionStatusForError;
-  private final ClientConfig clientConfig;
   private BlobTransferManager<Void> blobTransferManager;
   private final boolean writeBatchingPushStatus;
 
@@ -126,7 +125,6 @@ public class DaVinciBackend implements Closeable {
       useDaVinciSpecificExecutionStatusForError = backendConfig.useDaVinciSpecificExecutionStatusForError();
       writeBatchingPushStatus = backendConfig.getDaVinciPushStatusCheckIntervalInMs() >= 0;
       this.configLoader = configLoader;
-      this.clientConfig = clientConfig;
       metricsRepository = Optional.ofNullable(clientConfig.getMetricsRepository())
           .orElse(TehutiUtils.getMetricsRepository("davinci-client"));
       VeniceMetadataRepositoryBuilder veniceMetadataRepositoryBuilder =

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/DaVinciBackend.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/DaVinciBackend.java
@@ -279,7 +279,6 @@ public class DaVinciBackend implements Closeable {
           null);
 
       ingestionService.start();
-      ingestionService.addIngestionNotifier(ingestionListener);
 
       if (isIsolatedIngestion() && cacheConfig.isPresent()) {
         // TODO: There are 'some' cases where this mix might be ok, (like a batch only store, or with certain TTL
@@ -704,7 +703,11 @@ public class DaVinciBackend implements Closeable {
           versionBackend.completePartition(partitionId);
           versionBackend.maybeReportBatchEOIPStatus(
               partitionId,
-              v -> reportPushStatus(kafkaTopic, partitionId, ExecutionStatus.END_OF_PUSH_RECEIVED, Optional.of(v)));
+              v -> reportPushStatus(
+                  kafkaTopic,
+                  partitionId,
+                  ExecutionStatus.END_OF_INCREMENTAL_PUSH_RECEIVED,
+                  Optional.of(v)));
           versionBackend.tryStopHeartbeat();
           reportPushStatus(kafkaTopic, partitionId, ExecutionStatus.COMPLETED);
         }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/VersionBackend.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/VersionBackend.java
@@ -409,6 +409,11 @@ public class VersionBackend {
           pendingReportIncPushVersionList.size() - MAX_INCREMENTAL_PUSH_ENTRY_NUM,
           pendingReportIncPushVersionList.size());
     }
+    LOGGER.info(
+        "Topic: {}, partition: {} batch reporting EOIP for inc push versions: {}",
+        version.kafkaTopicName(),
+        partition,
+        filteredIncPushVersionList);
     for (String incPushVersion: filteredIncPushVersionList) {
       reportConsumer.accept(incPushVersion);
     }
@@ -426,6 +431,11 @@ public class VersionBackend {
     if (executionStatus.equals(ExecutionStatus.START_OF_INCREMENTAL_PUSH_RECEIVED)) {
       return;
     }
+    LOGGER.info(
+        "Adding incremental push version: {} to pending report list for topic: {}, partition: {}",
+        incrementalPushVersion,
+        version.kafkaTopicName(),
+        partition);
     getPartitionToPendingReportIncrementalPushList().computeIfAbsent(partition, p -> new ArrayList<>())
         .add(incrementalPushVersion);
   }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
@@ -50,6 +50,7 @@ import static com.linkedin.venice.ConfigKeys.PUBSUB_TOPIC_MANAGER_METADATA_FETCH
 import static com.linkedin.venice.ConfigKeys.PUBSUB_TOPIC_MANAGER_METADATA_FETCHER_THREAD_POOL_SIZE;
 import static com.linkedin.venice.ConfigKeys.ROUTER_PRINCIPAL_NAME;
 import static com.linkedin.venice.ConfigKeys.SERVER_AA_WC_LEADER_QUOTA_RECORDS_PER_SECOND;
+import static com.linkedin.venice.ConfigKeys.SERVER_BATCH_REPORT_END_OF_INCREMENTAL_PUSH_STATUS_INTERVAL_SECONDS;
 import static com.linkedin.venice.ConfigKeys.SERVER_BLOCKING_QUEUE_TYPE;
 import static com.linkedin.venice.ConfigKeys.SERVER_CHANNEL_OPTION_WRITE_BUFFER_WATERMARK_HIGH_BYTES;
 import static com.linkedin.venice.ConfigKeys.SERVER_COMPUTE_FAST_AVRO_ENABLED;
@@ -483,6 +484,7 @@ public class VeniceServerConfig extends VeniceClusterConfig {
   private final long metaStoreWriterCloseTimeoutInMS;
   private final int metaStoreWriterCloseConcurrency;
 
+  private final long batchReportEOIPIntervalSecond;
   private final long ingestionHeartbeatIntervalMs;
   private final boolean leaderCompleteStateCheckInFollowerEnabled;
   private final long leaderCompleteStateCheckInFollowerValidIntervalMs;
@@ -795,6 +797,8 @@ public class VeniceServerConfig extends VeniceClusterConfig {
     metaStoreWriterCloseConcurrency = serverProperties.getInt(META_STORE_WRITER_CLOSE_CONCURRENCY, -1);
     ingestionHeartbeatIntervalMs =
         serverProperties.getLong(SERVER_INGESTION_HEARTBEAT_INTERVAL_MS, TimeUnit.MINUTES.toMillis(1));
+    batchReportEOIPIntervalSecond =
+        serverProperties.getInt(SERVER_BATCH_REPORT_END_OF_INCREMENTAL_PUSH_STATUS_INTERVAL_SECONDS, -1);
 
     stuckConsumerRepairEnabled = serverProperties.getBoolean(SERVER_STUCK_CONSUMER_REPAIR_ENABLED, true);
     stuckConsumerRepairIntervalSecond = serverProperties.getInt(SERVER_STUCK_CONSUMER_REPAIR_INTERVAL_SECOND, 60);
@@ -1418,6 +1422,10 @@ public class VeniceServerConfig extends VeniceClusterConfig {
 
   public long getIngestionHeartbeatIntervalMs() {
     return ingestionHeartbeatIntervalMs;
+  }
+
+  public long getBatchReportEOIPIntervalSecond() {
+    return batchReportEOIPIntervalSecond;
   }
 
   public boolean isLeaderCompleteStateCheckInFollowerEnabled() {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
@@ -50,7 +50,7 @@ import static com.linkedin.venice.ConfigKeys.PUBSUB_TOPIC_MANAGER_METADATA_FETCH
 import static com.linkedin.venice.ConfigKeys.PUBSUB_TOPIC_MANAGER_METADATA_FETCHER_THREAD_POOL_SIZE;
 import static com.linkedin.venice.ConfigKeys.ROUTER_PRINCIPAL_NAME;
 import static com.linkedin.venice.ConfigKeys.SERVER_AA_WC_LEADER_QUOTA_RECORDS_PER_SECOND;
-import static com.linkedin.venice.ConfigKeys.SERVER_BATCH_REPORT_END_OF_INCREMENTAL_PUSH_STATUS_INTERVAL_SECONDS;
+import static com.linkedin.venice.ConfigKeys.SERVER_BATCH_REPORT_END_OF_INCREMENTAL_PUSH_STATUS_ENABLED;
 import static com.linkedin.venice.ConfigKeys.SERVER_BLOCKING_QUEUE_TYPE;
 import static com.linkedin.venice.ConfigKeys.SERVER_CHANNEL_OPTION_WRITE_BUFFER_WATERMARK_HIGH_BYTES;
 import static com.linkedin.venice.ConfigKeys.SERVER_COMPUTE_FAST_AVRO_ENABLED;
@@ -484,7 +484,7 @@ public class VeniceServerConfig extends VeniceClusterConfig {
   private final long metaStoreWriterCloseTimeoutInMS;
   private final int metaStoreWriterCloseConcurrency;
 
-  private final long batchReportEOIPIntervalSecond;
+  private final boolean batchReportEOIPEnabled;
   private final long ingestionHeartbeatIntervalMs;
   private final boolean leaderCompleteStateCheckInFollowerEnabled;
   private final long leaderCompleteStateCheckInFollowerValidIntervalMs;
@@ -797,8 +797,8 @@ public class VeniceServerConfig extends VeniceClusterConfig {
     metaStoreWriterCloseConcurrency = serverProperties.getInt(META_STORE_WRITER_CLOSE_CONCURRENCY, -1);
     ingestionHeartbeatIntervalMs =
         serverProperties.getLong(SERVER_INGESTION_HEARTBEAT_INTERVAL_MS, TimeUnit.MINUTES.toMillis(1));
-    batchReportEOIPIntervalSecond =
-        serverProperties.getInt(SERVER_BATCH_REPORT_END_OF_INCREMENTAL_PUSH_STATUS_INTERVAL_SECONDS, -1);
+    batchReportEOIPEnabled =
+        serverProperties.getBoolean(SERVER_BATCH_REPORT_END_OF_INCREMENTAL_PUSH_STATUS_ENABLED, false);
 
     stuckConsumerRepairEnabled = serverProperties.getBoolean(SERVER_STUCK_CONSUMER_REPAIR_ENABLED, true);
     stuckConsumerRepairIntervalSecond = serverProperties.getInt(SERVER_STUCK_CONSUMER_REPAIR_INTERVAL_SECOND, 60);
@@ -1424,8 +1424,8 @@ public class VeniceServerConfig extends VeniceClusterConfig {
     return ingestionHeartbeatIntervalMs;
   }
 
-  public long getBatchReportEOIPIntervalSecond() {
-    return batchReportEOIPIntervalSecond;
+  public boolean getBatchReportEOIPEnabled() {
+    return batchReportEOIPEnabled;
   }
 
   public boolean isLeaderCompleteStateCheckInFollowerEnabled() {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/IngestionNotificationDispatcher.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/IngestionNotificationDispatcher.java
@@ -260,6 +260,17 @@ class IngestionNotificationDispatcher {
             version));
   }
 
+  void reportBatchEndOfIncrementalPushStatus(PartitionConsumptionState pcs) {
+    report(
+        pcs,
+        ExecutionStatus.END_OF_INCREMENTAL_PUSH_RECEIVED,
+        notifier -> notifier.batchEndOfIncrementalPushReceived(
+            topic,
+            pcs.getPartition(),
+            pcs.getLatestProcessedLocalVersionTopicOffset(),
+            pcs.getPendingReportIncPushVersionList()));
+  }
+
   void reportTopicSwitchReceived(PartitionConsumptionState pcs) {
     report(
         pcs,

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/PartitionConsumptionState.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/PartitionConsumptionState.java
@@ -205,7 +205,6 @@ public class PartitionConsumptionState {
   private long lastLeaderCompleteStateUpdateInMs;
 
   private final List<String> pendingReportIncPushVersionList;
-  private long batchReportIncPushTimestamp;
 
   public PartitionConsumptionState(String replicaId, int partition, OffsetRecord offsetRecord, boolean hybrid) {
     this.replicaId = replicaId;
@@ -250,7 +249,6 @@ public class PartitionConsumptionState {
     this.lastVTProduceCallFuture = CompletableFuture.completedFuture(null);
     this.leaderCompleteState = LeaderCompleteState.LEADER_NOT_COMPLETED;
     this.lastLeaderCompleteStateUpdateInMs = 0;
-    this.batchReportIncPushTimestamp = 0;
     this.pendingReportIncPushVersionList = offsetRecord.getPendingReportIncPushVersionList();
   }
 
@@ -852,13 +850,5 @@ public class PartitionConsumptionState {
   public void clearPendingReportIncPushVersionList() {
     pendingReportIncPushVersionList.clear();
     offsetRecord.setPendingReportIncPushVersionList(pendingReportIncPushVersionList);
-  }
-
-  public long getBatchIncPushReportTimestamp() {
-    return batchReportIncPushTimestamp;
-  }
-
-  public void setBatchIncPushReportTimestamp(long updateTimestamp) {
-    batchReportIncPushTimestamp = updateTimestamp;
   }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -2704,15 +2704,10 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
       ControlMessage endOfIncrementalPush,
       PartitionConsumptionState partitionConsumptionState) {
     CharSequence endVersion = ((EndOfIncrementalPush) endOfIncrementalPush.controlMessageUnion).version;
-    LOGGER.info(
-        "DEBUGGING BATCH REPORT ENABLED? {}, PCS completed {}",
-        batchReportIncPushStatusEnabled,
-        partitionConsumptionState.isComplete());
     if (!batchReportIncPushStatusEnabled || partitionConsumptionState.isComplete()) {
       ingestionNotificationDispatcher
           .reportEndOfIncrementalPushReceived(partitionConsumptionState, endVersion.toString());
     } else {
-      // TODO: We will still need to update push status store, for now it is still writing entry by entry.
       LOGGER.info(
           "Adding incremental push: {} to pending batch report list for replica: {}.",
           endVersion.toString(),

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/StoreIngestionTask.java
@@ -2704,12 +2704,19 @@ public abstract class StoreIngestionTask implements Runnable, Closeable {
       ControlMessage endOfIncrementalPush,
       PartitionConsumptionState partitionConsumptionState) {
     CharSequence endVersion = ((EndOfIncrementalPush) endOfIncrementalPush.controlMessageUnion).version;
+    LOGGER.info(
+        "DEBUGGING BATCH REPORT ENABLED? {}, PCS completed {}",
+        batchReportIncPushStatusEnabled,
+        partitionConsumptionState.isComplete());
     if (!batchReportIncPushStatusEnabled || partitionConsumptionState.isComplete()) {
       ingestionNotificationDispatcher
           .reportEndOfIncrementalPushReceived(partitionConsumptionState, endVersion.toString());
     } else {
       // TODO: We will still need to update push status store, for now it is still writing entry by entry.
-      LOGGER.info("Adding incremental push: {} to pending batch report list.", endVersion.toString());
+      LOGGER.info(
+          "Adding incremental push: {} to pending batch report list for replica: {}.",
+          endVersion.toString(),
+          partitionConsumptionState.getReplicaId());
       partitionConsumptionState.addIncPushVersionToPendingReportList(endVersion.toString());
     }
   }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/notifier/PushStatusNotifier.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/notifier/PushStatusNotifier.java
@@ -149,12 +149,8 @@ public class PushStatusNotifier implements VeniceNotifier {
     }
     offLinePushAccessor
         .batchUpdateReplicaIncPushStatus(topic, partitionId, instanceId, offset, filteredIncPushVersionList);
+    // We don't need to report redundant SOIP for these stale inc push versions as they've all received EOIP.
     for (String incPushVersion: filteredIncPushVersionList) {
-      updateIncrementalPushStatusToPushStatusStore(
-          topic,
-          incPushVersion,
-          partitionId,
-          START_OF_INCREMENTAL_PUSH_RECEIVED);
       updateIncrementalPushStatusToPushStatusStore(
           topic,
           incPushVersion,

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/notifier/PushStatusNotifier.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/notifier/PushStatusNotifier.java
@@ -33,7 +33,7 @@ import org.apache.logging.log4j.Logger;
  */
 public class PushStatusNotifier implements VeniceNotifier {
   private static final Logger LOGGER = LogManager.getLogger(PushStatusNotifier.class);
-
+  private static final int MAX_INCREMENTAL_PUSH_ENTRY_NUM = 50;
   private final OfflinePushAccessor offLinePushAccessor;
   private final HelixPartitionStatusAccessor helixPartitionStatusAccessor;
 
@@ -141,8 +141,12 @@ public class PushStatusNotifier implements VeniceNotifier {
      * For system store dual write, this is not perfect but good enough for now to keep a low volume of updates without
      * refactor the key schema.
      */
-    List<String> filteredIncPushVersionList = pendingReportIncPushVersionList
-        .subList(pendingReportIncPushVersionList.size() - 50, pendingReportIncPushVersionList.size());
+    List<String> filteredIncPushVersionList = pendingReportIncPushVersionList;
+    if (pendingReportIncPushVersionList.size() > MAX_INCREMENTAL_PUSH_ENTRY_NUM) {
+      filteredIncPushVersionList = pendingReportIncPushVersionList.subList(
+          pendingReportIncPushVersionList.size() - MAX_INCREMENTAL_PUSH_ENTRY_NUM,
+          pendingReportIncPushVersionList.size());
+    }
     offLinePushAccessor
         .batchUpdateReplicaIncPushStatus(topic, partitionId, instanceId, offset, filteredIncPushVersionList);
     for (String incPushVersion: filteredIncPushVersionList) {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/notifier/VeniceNotifier.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/notifier/VeniceNotifier.java
@@ -2,6 +2,7 @@ package com.linkedin.davinci.notifier;
 
 import com.linkedin.venice.kafka.protocol.enums.ControlMessageType;
 import java.io.Closeable;
+import java.util.List;
 
 
 /**
@@ -85,6 +86,13 @@ public interface VeniceNotifier extends Closeable {
   }
 
   default void endOfIncrementalPushReceived(String kafkaTopic, int partitionId, long offset, String message) {
+  }
+
+  default void batchEndOfIncrementalPushReceived(
+      String kafkaTopic,
+      int partitionId,
+      long offset,
+      List<String> historicalIncPushes) {
   }
 
   default void catchUpVersionTopicOffsetLag(String kafkaTopic, int partitionId) {

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/VersionBackendTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/VersionBackendTest.java
@@ -1,0 +1,76 @@
+package com.linkedin.davinci;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.linkedin.venice.pushmonitor.ExecutionStatus;
+import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class VersionBackendTest {
+  @Test
+  public void testMaybeReportIncrementalPushStatus() {
+    VersionBackend versionBackend = mock(VersionBackend.class);
+    Map<Integer, List<String>> partitionToPendingReportIncrementalPushList = new VeniceConcurrentHashMap<>();
+    Map<Integer, Boolean> partitionToBatchReportEOIPEnabled = new VeniceConcurrentHashMap<>();
+    doReturn(partitionToBatchReportEOIPEnabled).when(versionBackend).getPartitionToBatchReportEOIPEnabled();
+    doReturn(partitionToPendingReportIncrementalPushList).when(versionBackend)
+        .getPartitionToPendingReportIncrementalPushList();
+    doCallRealMethod().when(versionBackend).maybeReportIncrementalPushStatus(anyInt(), anyString(), any(), any());
+    Consumer<String> mockConsumer = mock(Consumer.class);
+
+    versionBackend
+        .maybeReportIncrementalPushStatus(0, "a", ExecutionStatus.START_OF_INCREMENTAL_PUSH_RECEIVED, mockConsumer);
+    verify(mockConsumer, times(1)).accept("a");
+    versionBackend
+        .maybeReportIncrementalPushStatus(0, "a", ExecutionStatus.END_OF_INCREMENTAL_PUSH_RECEIVED, mockConsumer);
+    verify(mockConsumer, times(2)).accept("a");
+
+    partitionToBatchReportEOIPEnabled.put(0, true);
+    versionBackend
+        .maybeReportIncrementalPushStatus(0, "a", ExecutionStatus.START_OF_INCREMENTAL_PUSH_RECEIVED, mockConsumer);
+    verify(mockConsumer, times(2)).accept("a");
+    versionBackend
+        .maybeReportIncrementalPushStatus(0, "a", ExecutionStatus.END_OF_INCREMENTAL_PUSH_RECEIVED, mockConsumer);
+    verify(mockConsumer, times(2)).accept("a");
+    Assert.assertTrue(partitionToPendingReportIncrementalPushList.containsKey(0));
+    Assert.assertEquals(partitionToPendingReportIncrementalPushList.get(0).size(), 1);
+  }
+
+  @Test
+  public void testMaybeReportBatchEOIPStatus() {
+    VersionBackend versionBackend = mock(VersionBackend.class);
+    List<String> incPushList = new ArrayList<>();
+    for (int i = 0; i < 100; i++) {
+      incPushList.add("inc_" + i);
+    }
+    Map<Integer, List<String>> partitionToPendingReportIncrementalPushList = Collections.singletonMap(0, incPushList);
+    Map<Integer, Boolean> partitionToBatchReportEOIPEnabled = new VeniceConcurrentHashMap<>();
+    partitionToBatchReportEOIPEnabled.put(0, true);
+    doReturn(partitionToBatchReportEOIPEnabled).when(versionBackend).getPartitionToBatchReportEOIPEnabled();
+    doReturn(partitionToPendingReportIncrementalPushList).when(versionBackend)
+        .getPartitionToPendingReportIncrementalPushList();
+    doCallRealMethod().when(versionBackend).maybeReportBatchEOIPStatus(anyInt(), any());
+    Consumer<String> mockConsumer = mock(Consumer.class);
+    versionBackend.maybeReportBatchEOIPStatus(0, mockConsumer);
+    verify(mockConsumer, times(50)).accept(anyString());
+    verify(mockConsumer, times(0)).accept("inc_0");
+    verify(mockConsumer, times(0)).accept("inc_49");
+    verify(mockConsumer, times(1)).accept("inc_50");
+    verify(mockConsumer, times(1)).accept("inc_99");
+    Assert.assertFalse(partitionToBatchReportEOIPEnabled.get(0));
+  }
+}

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/VersionBackendTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/VersionBackendTest.java
@@ -9,6 +9,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import com.linkedin.venice.meta.Version;
+import com.linkedin.venice.meta.VersionImpl;
 import com.linkedin.venice.pushmonitor.ExecutionStatus;
 import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
 import java.util.ArrayList;
@@ -29,6 +31,8 @@ public class VersionBackendTest {
     doReturn(partitionToBatchReportEOIPEnabled).when(versionBackend).getPartitionToBatchReportEOIPEnabled();
     doReturn(partitionToPendingReportIncrementalPushList).when(versionBackend)
         .getPartitionToPendingReportIncrementalPushList();
+    Version version = new VersionImpl("test_store", 1, "dummy");
+    doReturn(version).when(versionBackend).getVersion();
     doCallRealMethod().when(versionBackend).maybeReportIncrementalPushStatus(anyInt(), anyString(), any(), any());
     Consumer<String> mockConsumer = mock(Consumer.class);
 
@@ -64,6 +68,8 @@ public class VersionBackendTest {
     doReturn(partitionToPendingReportIncrementalPushList).when(versionBackend)
         .getPartitionToPendingReportIncrementalPushList();
     doCallRealMethod().when(versionBackend).maybeReportBatchEOIPStatus(anyInt(), any());
+    Version version = new VersionImpl("test_store", 1, "dummy");
+    doReturn(version).when(versionBackend).getVersion();
     Consumer<String> mockConsumer = mock(Consumer.class);
     versionBackend.maybeReportBatchEOIPStatus(0, mockConsumer);
     verify(mockConsumer, times(50)).accept(anyString());

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTaskTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/ActiveActiveStoreIngestionTaskTest.java
@@ -97,9 +97,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
-import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicLong;
 import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
@@ -279,25 +277,27 @@ public class ActiveActiveStoreIngestionTaskTest {
   public void testMaybeBatchReportEOIP() {
     ActiveActiveStoreIngestionTask ingestionTask = mock(ActiveActiveStoreIngestionTask.class);
     PartitionConsumptionState pcs = mock(PartitionConsumptionState.class);
-    doCallRealMethod().when(ingestionTask).maybeReportBatchEndOfIncPushStatus(any(), anyLong());
-
-    ingestionTask.maybeReportBatchEndOfIncPushStatus(pcs, -1);
-    Mockito.verify(ingestionTask, Mockito.times(0)).getIngestionNotificationDispatcher();
+    doCallRealMethod().when(ingestionTask).maybeReportBatchEndOfIncPushStatus(any());
 
     when(pcs.getPendingReportIncPushVersionList()).thenReturn(Collections.emptyList());
-    ingestionTask.maybeReportBatchEndOfIncPushStatus(pcs, 10);
+    ingestionTask.maybeReportBatchEndOfIncPushStatus(pcs);
     Mockito.verify(ingestionTask, Mockito.times(0)).getIngestionNotificationDispatcher();
 
     when(pcs.getPendingReportIncPushVersionList()).thenReturn(Collections.singletonList("test"));
     IngestionNotificationDispatcher ingestionNotificationDispatcher = mock(IngestionNotificationDispatcher.class);
     when(ingestionTask.getIngestionNotificationDispatcher()).thenReturn(ingestionNotificationDispatcher);
-    ingestionTask.maybeReportBatchEndOfIncPushStatus(pcs, 10);
+
+    when(pcs.isComplete()).thenReturn(false);
+    ingestionTask.maybeReportBatchEndOfIncPushStatus(pcs);
+    Mockito.verify(ingestionTask, Mockito.times(0)).getIngestionNotificationDispatcher();
+
+    when(pcs.isComplete()).thenReturn(true);
+    ingestionTask.maybeReportBatchEndOfIncPushStatus(pcs);
     Mockito.verify(ingestionTask, Mockito.times(1)).getIngestionNotificationDispatcher();
   }
 
   @Test
-  public void testLeaderCanSendValueChunksIntoDrainer()
-      throws ExecutionException, InterruptedException, TimeoutException {
+  public void testLeaderCanSendValueChunksIntoDrainer() throws InterruptedException {
     String testTopic = "test";
     int valueSchemaId = 1;
     int rmdProtocolVersionID = 1;

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/PartitionConsumptionStateTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/PartitionConsumptionStateTest.java
@@ -1,5 +1,6 @@
 package com.linkedin.davinci.kafka.consumer;
 
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
@@ -15,6 +16,8 @@ import com.linkedin.venice.utils.Utils;
 import com.linkedin.venice.writer.LeaderCompleteState;
 import com.linkedin.venice.writer.WriterChunkingHelper;
 import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
@@ -138,4 +141,20 @@ public class PartitionConsumptionStateTest {
     pcs.setLeaderCompleteState(LeaderCompleteState.LEADER_COMPLETED);
     assertTrue(pcs.isLeaderCompleted());
   }
+
+  @Test
+  public void testAddIncPushVersionToPendingReportList() {
+    List<String> pendingReportIncrementalPush = new ArrayList<>();
+    OffsetRecord offsetRecord = mock(OffsetRecord.class);
+    doReturn(pendingReportIncrementalPush).when(offsetRecord).getPendingReportIncPushVersionList();
+    PartitionConsumptionState pcs = new PartitionConsumptionState(replicaId, 0, offsetRecord, false);
+    pcs.addIncPushVersionToPendingReportList("a");
+    Assert.assertEquals(pcs.getPendingReportIncPushVersionList().size(), 1);
+    for (int i = 0; i < 50; i++) {
+      pcs.addIncPushVersionToPendingReportList("v_" + i);
+    }
+    Assert.assertEquals(pcs.getPendingReportIncPushVersionList().size(), 50);
+    Assert.assertEquals(pcs.getPendingReportIncPushVersionList().get(0), "v_0");
+  }
+
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -724,8 +724,8 @@ public class ConfigKeys {
   public static final String SERVER_INGESTION_ISOLATION_HEARTBEAT_REQUEST_TIMEOUT_SECONDS =
       "server.ingestion.isolation.heartbeat.request.timeout.seconds";
 
-  public static final String SERVER_BATCH_REPORT_END_OF_INCREMENTAL_PUSH_STATUS_INTERVAL_SECONDS =
-      "server.batch.report.end.of.incremental.push.status.interval.seconds";
+  public static final String SERVER_BATCH_REPORT_END_OF_INCREMENTAL_PUSH_STATUS_ENABLED =
+      "server.batch.report.end.of.incremental.push.status.enabled";
 
   /**
    * whether to enable checksum verification in the ingestion path from kafka to database persistency. If enabled it will

--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -724,6 +724,9 @@ public class ConfigKeys {
   public static final String SERVER_INGESTION_ISOLATION_HEARTBEAT_REQUEST_TIMEOUT_SECONDS =
       "server.ingestion.isolation.heartbeat.request.timeout.seconds";
 
+  public static final String SERVER_BATCH_REPORT_END_OF_INCREMENTAL_PUSH_STATUS_INTERVAL_SECONDS =
+      "server.batch.report.end.of.incremental.push.status.interval.seconds";
+
   /**
    * whether to enable checksum verification in the ingestion path from kafka to database persistency. If enabled it will
    * keep a running checksum for all and only PUT kafka data message received in the ingestion task and periodically

--- a/internal/venice-common/src/main/java/com/linkedin/venice/helix/VeniceOfflinePushMonitorAccessor.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/helix/VeniceOfflinePushMonitorAccessor.java
@@ -335,7 +335,7 @@ public class VeniceOfflinePushMonitorAccessor implements OfflinePushAccessor {
       return;
     }
     LOGGER.info(
-        "Start update replica status for topic: {}, partition: {} in cluster: {}.",
+        "Start batch update replica status for topic: {}, partition: {} in cluster: {}.",
         topic,
         partitionId,
         clusterName);

--- a/internal/venice-common/src/main/java/com/linkedin/venice/helix/VeniceOfflinePushMonitorAccessor.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/helix/VeniceOfflinePushMonitorAccessor.java
@@ -349,11 +349,7 @@ public class VeniceOfflinePushMonitorAccessor implements OfflinePushAccessor {
         currentData = new PartitionStatus(partitionId);
       }
 
-      currentData.batchUpdateReplicaIncPushStatus(
-          instanceId,
-          ExecutionStatus.END_OF_INCREMENTAL_PUSH_RECEIVED,
-          incPushBatchStatus,
-          progress);
+      currentData.batchUpdateReplicaIncPushStatus(instanceId, incPushBatchStatus, progress);
       return currentData;
     });
     LOGGER.info(

--- a/internal/venice-common/src/main/java/com/linkedin/venice/helix/VeniceOfflinePushMonitorAccessor.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/helix/VeniceOfflinePushMonitorAccessor.java
@@ -326,11 +326,6 @@ public class VeniceOfflinePushMonitorAccessor implements OfflinePushAccessor {
       String instanceId,
       long progress,
       List<String> incPushBatchStatus) {
-    // If a version was created prior to the deployment of this new push monitor, an exception would be thrown while
-    // upgrading venice server.
-    // Because the server would try to update replica status but there is no ZNode for that replica. So we add a check
-    // here to ignore the update
-    // in case of ZNode missing.
     if (!pushStatusExists(topic)) {
       return;
     }
@@ -340,15 +335,9 @@ public class VeniceOfflinePushMonitorAccessor implements OfflinePushAccessor {
         partitionId,
         clusterName);
     HelixUtils.compareAndUpdate(partitionStatusAccessor, getPartitionStatusPath(topic, partitionId), currentData -> {
-
-      // currentData can be null if the path read out of zk is blank to start with (as current data is read and passed
-      // in)
-      // So first we do a null check. If it's null, we can return a base object and fill the data we're trying to
-      // persist
       if (currentData == null) {
         currentData = new PartitionStatus(partitionId);
       }
-
       currentData.batchUpdateReplicaIncPushStatus(instanceId, incPushBatchStatus, progress);
       return currentData;
     });

--- a/internal/venice-common/src/main/java/com/linkedin/venice/offsets/OffsetRecord.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/offsets/OffsetRecord.java
@@ -13,8 +13,11 @@ import com.linkedin.venice.serialization.avro.InternalAvroSpecificSerializer;
 import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import org.apache.avro.generic.GenericDatumWriter;
 import org.apache.avro.io.ByteBufferToHexFormatJsonEncoder;
@@ -248,6 +251,19 @@ public class OffsetRecord {
 
   public String getLeaderHostId() {
     return (partitionState.leaderHostId != null) ? partitionState.leaderHostId.toString() : null;
+  }
+
+  public List<String> getPendingReportIncPushVersionList() {
+    if (partitionState.pendingReportIncrementalPushVersions == null) {
+      return new ArrayList<>();
+    }
+    return partitionState.pendingReportIncrementalPushVersions.stream()
+        .map(CharSequence::toString)
+        .collect(Collectors.toList());
+  }
+
+  public void setPendingReportIncPushVersionList(List<String> incPushVersionList) {
+    partitionState.pendingReportIncrementalPushVersions = new ArrayList<>(incPushVersionList);
   }
 
   /**

--- a/internal/venice-common/src/main/java/com/linkedin/venice/offsets/OffsetRecord.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/offsets/OffsetRecord.java
@@ -72,6 +72,7 @@ public class OffsetRecord {
     emptyPartitionState.leaderOffset = DEFAULT_UPSTREAM_OFFSET;
     emptyPartitionState.upstreamOffsetMap = new VeniceConcurrentHashMap<>();
     emptyPartitionState.upstreamVersionTopicOffset = DEFAULT_UPSTREAM_OFFSET;
+    emptyPartitionState.pendingReportIncrementalPushVersions = new ArrayList<>();
     return emptyPartitionState;
   }
 

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pushmonitor/OfflinePushAccessor.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pushmonitor/OfflinePushAccessor.java
@@ -69,6 +69,14 @@ public interface OfflinePushAccessor {
       ExecutionStatus status,
       String message);
 
+  default void batchUpdateReplicaIncPushStatus(
+      String kafkaTopic,
+      int partitionId,
+      String instanceId,
+      long progress,
+      List<String> pendingReportIncPushVersionList) {
+  }
+
   /**
    * Subscribe the data change of partition status.
    */

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pushmonitor/PartitionStatus.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pushmonitor/PartitionStatus.java
@@ -47,14 +47,11 @@ public class PartitionStatus implements Comparable<PartitionStatus> {
     replicaStatus.setCurrentProgress(progress);
   }
 
-  public void batchUpdateReplicaIncPushStatus(
-      String instanceId,
-      ExecutionStatus newStatus,
-      List<String> incPushVersionList,
-      long progress) {
+  public void batchUpdateReplicaIncPushStatus(String instanceId, List<String> incPushVersionList, long progress) {
     ReplicaStatus replicaStatus = null;
     for (String incrementalPushVersion: incPushVersionList) {
-      replicaStatus = updateReplicaStatus(instanceId, newStatus, incrementalPushVersion, true);
+      replicaStatus =
+          updateReplicaStatus(instanceId, ExecutionStatus.END_OF_PUSH_RECEIVED, incrementalPushVersion, true);
     }
     if (replicaStatus != null) {
       replicaStatus.setCurrentProgress(progress);

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pushmonitor/PartitionStatus.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pushmonitor/PartitionStatus.java
@@ -50,8 +50,11 @@ public class PartitionStatus implements Comparable<PartitionStatus> {
   public void batchUpdateReplicaIncPushStatus(String instanceId, List<String> incPushVersionList, long progress) {
     ReplicaStatus replicaStatus = null;
     for (String incrementalPushVersion: incPushVersionList) {
-      replicaStatus =
-          updateReplicaStatus(instanceId, ExecutionStatus.END_OF_PUSH_RECEIVED, incrementalPushVersion, true);
+      replicaStatus = updateReplicaStatus(
+          instanceId,
+          ExecutionStatus.END_OF_INCREMENTAL_PUSH_RECEIVED,
+          incrementalPushVersion,
+          true);
     }
     if (replicaStatus != null) {
       replicaStatus.setCurrentProgress(progress);

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pushmonitor/PartitionStatus.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pushmonitor/PartitionStatus.java
@@ -47,6 +47,20 @@ public class PartitionStatus implements Comparable<PartitionStatus> {
     replicaStatus.setCurrentProgress(progress);
   }
 
+  public void batchUpdateReplicaIncPushStatus(
+      String instanceId,
+      ExecutionStatus newStatus,
+      List<String> incPushVersionList,
+      long progress) {
+    ReplicaStatus replicaStatus = null;
+    for (String incrementalPushVersion: incPushVersionList) {
+      replicaStatus = updateReplicaStatus(instanceId, newStatus, incrementalPushVersion, true);
+    }
+    if (replicaStatus != null) {
+      replicaStatus.setCurrentProgress(progress);
+    }
+  }
+
   private ReplicaStatus updateReplicaStatus(
       String instanceId,
       ExecutionStatus newStatus,

--- a/internal/venice-common/src/main/java/com/linkedin/venice/serialization/avro/AvroProtocolDefinition.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/serialization/avro/AvroProtocolDefinition.java
@@ -51,7 +51,7 @@ public enum AvroProtocolDefinition {
    * Used to persist the state of a partition in Storage Nodes, including offset,
    * Data Ingest Validation state, etc.
    */
-  PARTITION_STATE(24, 12, PartitionState.class),
+  PARTITION_STATE(24, 13, PartitionState.class),
 
   /**
    * Used to persist state related to a store-version, including Start of Buffer Replay

--- a/internal/venice-common/src/main/resources/avro/PartitionState/v13/PartitionState.avsc
+++ b/internal/venice-common/src/main/resources/avro/PartitionState/v13/PartitionState.avsc
@@ -1,0 +1,178 @@
+{
+  "name": "PartitionState",
+  "namespace": "com.linkedin.venice.kafka.protocol.state",
+  "doc": "This record holds the state necessary for a consumer to checkpoint its progress when consuming a Venice partition. When provided the state in this record, a consumer should thus be able to resume consuming midway through a stream.",
+  "type": "record",
+  "fields": [
+    {
+      "name": "offset",
+      "doc": "The last Kafka offset consumed successfully in this partition from version topic.",
+      "type": "long"
+    }, {
+      "name": "offsetLag",
+      "doc": "The last Kafka offset lag in this partition for fast online transition in server restart.",
+      "type": "long",
+      "default": -1
+    }, {
+      "name": "endOfPush",
+      "doc": "Whether the EndOfPush control message was consumed in this partition.",
+      "type": "boolean"
+    }, {
+      "name": "lastUpdate",
+      "doc": "The last time this PartitionState was updated. Can be compared against the various messageTimestamp in ProducerPartitionState in order to infer lag time between producers and the consumer maintaining this PartitionState.",
+      "type": "long"
+    }, {
+      "name": "startOfBufferReplayDestinationOffset",
+      "doc": "This is the offset at which the StartOfBufferReplay control message was consumed in the current partition of the destination topic. This is not the same value as the source offsets contained in the StartOfBufferReplay control message itself. The source and destination offsets act together as a synchronization marker. N.B.: null means that the SOBR control message was not received yet.",
+      "type": ["null", "long"],
+      "default": null
+    }, {
+      "name": "databaseInfo",
+      "doc": "A map of string -> string to store database related info, which is necessary to checkpoint",
+      "type": {
+        "type": "map",
+        "values": "string"
+      },
+      "default": {}
+    }, {
+      "name": "incrementalPushInfo",
+      "doc": "metadata of ongoing incremental push in the partition",
+      "type": [
+        "null",
+        {
+          "name": "IncrementalPush",
+          "type": "record",
+          "fields": [
+            {
+              "name": "version",
+              "doc": "The version of current incremental push",
+              "type": "string"
+            }, {
+              "name": "error",
+              "doc": "The first error founded during in`gestion",
+              "type": ["null", "string"],
+              "default": null
+            }
+          ]
+        }
+      ],
+      "default": null
+    }, {
+      "name": "leaderTopic",
+      "type": ["null", "string"],
+      "doc": "The topic that leader is consuming from; for leader, leaderTopic can be different from the version topic; for follower, leaderTopic is the same as version topic.",
+      "default": null
+    }, {
+      "name": "leaderOffset",
+      "type": "long",
+      "doc": "The last Kafka offset consumed successfully in this partition from the leader topic. TODO: remove this field once upstreamOffsetMap is used everywhere.",
+      "default": -1
+    }, {
+      "name": "upstreamOffsetMap",
+      "type": {
+        "type": "map",
+        "values": "long",
+        "java-key-class": "java.lang.String",
+        "avro.java.string": "String"
+      },
+      "doc": "A map of upstream Kafka bootstrap server url -> the last Kafka offset consumed from upstream topic.",
+      "default": {}
+    }, {
+      "name": "upstreamVersionTopicOffset",
+      "type": "long",
+      "doc": "The last upstream version topic offset persisted to disk; if the batch native-replication source is the same as local region, this value will always be -1",
+      "default": -1
+    }, {
+      "name": "leaderGUID",
+      "type": [
+        "null",
+        {
+          "namespace": "com.linkedin.venice.kafka.protocol",
+          "name": "GUID",
+          "type": "fixed",
+          "size": 16
+        }
+      ],
+      "doc": "This field is deprecated since GUID is no longer able to identify the split-brain issue once 'pass-through' mode is enabled in venice writer. The field is superseded by leaderHostId and will be removed in the future ",
+      "default": null
+    }, {
+      "name": "leaderHostId",
+      "type": ["null", "string"],
+      "doc": "An unique identifier (such as host name) that stands for each host. It's used to identify if there is a split-brain happened while the leader(s) re-produce records",
+      "default": null
+    }, {
+      "name": "producerStates",
+      "doc": "A map of producer GUID -> producer state.",
+      "type": {
+        "type": "map",
+        "values": {
+          "name": "ProducerPartitionState",
+          "doc": "A record containing the state pertaining to the data sent by one upstream producer into one partition.",
+          "type": "record",
+          "fields": [
+            {
+              "name": "segmentNumber",
+              "doc": "The current segment number corresponds to the last (highest) segment number for which we have seen a StartOfSegment control message.",
+              "type": "int"
+            }, {
+              "name": "segmentStatus",
+              "doc": "The status of the current segment: 0 => NOT_STARTED, 1 => IN_PROGRESS, 2 => END_OF_INTERMEDIATE_SEGMENT, 3 => END_OF_FINAL_SEGMENT.",
+              "type": "int"
+            }, {
+              "name": "isRegistered",
+              "doc": "Whether the segment is registered. i.e. received Start_Of_Segment to initialize the segment.",
+              "type": "boolean",
+              "default": false
+            }, {
+              "name": "messageSequenceNumber",
+              "doc": "The current message sequence number, within the current segment, which we have seen for this partition/producer pair.",
+              "type": "int"
+            }, {
+              "name": "messageTimestamp",
+              "doc": "The timestamp included in the last message we have seen for this partition/producer pair.",
+              "type": "long"
+            }, {
+              "name": "checksumType",
+              "doc": "The current mapping is the following: 0 => None, 1 => MD5, 2 => Adler32, 3 => CRC32.",
+              "type": "int"
+            }, {
+              "name": "checksumState",
+              "doc": "The value of the checksum computed since the last StartOfSegment ControlMessage.",
+              "type": "bytes"
+            }, {
+              "name": "aggregates",
+              "doc": "The aggregates that have been computed so far since the last StartOfSegment ControlMessage.",
+              "type": {
+                "type": "map",
+                "values": "long"
+              }
+            }, {
+              "name": "debugInfo",
+              "doc": "The debug info received as part of the last StartOfSegment ControlMessage.",
+              "type": {
+                "type": "map",
+                "values": "string"
+              }
+            }
+          ]
+        }
+      }
+    }, {
+      "name": "previousStatuses",
+      "doc": "A map of string -> string which stands for previous PartitionStatus",
+      "type": {
+        "type": "map",
+        "values": "string"
+      },
+      "default": {}
+    }, {
+      "name": "pendingReportIncrementalPushVersions",
+      "doc": "A list of string which stands for incremental push versions which have received EOIP but not yet reported prior to lag caught up, they will be reported in batch",
+      "type": {
+        "type":  "array",
+        "items": "string"
+      },
+      "default": []
+    }
+  ]
+}

--- a/internal/venice-common/src/test/java/com/linkedin/venice/helix/OfflinePushMonitorAccessorTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/helix/OfflinePushMonitorAccessorTest.java
@@ -1,14 +1,19 @@
 package com.linkedin.venice.helix;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.anyInt;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import com.linkedin.venice.pushmonitor.OfflinePushStatus;
+import com.linkedin.venice.pushmonitor.PartitionStatus;
+import java.util.Arrays;
 import java.util.Optional;
 import org.apache.helix.manager.zk.ZkBaseDataAccessor;
+import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -32,5 +37,18 @@ public class OfflinePushMonitorAccessorTest {
         new VeniceOfflinePushMonitorAccessor("cluster0", mockOfflinePushStatusAccessor, mock(ZkBaseDataAccessor.class));
     Optional<Long> ctime = accessor.getOfflinePushStatusCreationTime("test");
     Assert.assertFalse(ctime.isPresent());
+  }
+
+  @Test
+  public void testBatchUpdateEOIP() {
+    ZkBaseDataAccessor<OfflinePushStatus> mockOfflinePushStatusAccessor = mock(ZkBaseDataAccessor.class);
+    ZkBaseDataAccessor<PartitionStatus> mockPartitionStatusAccessor = mock(ZkBaseDataAccessor.class);
+    doReturn(null).when(mockOfflinePushStatusAccessor).getStat(anyString(), anyInt());
+    VeniceOfflinePushMonitorAccessor accessor =
+        new VeniceOfflinePushMonitorAccessor("cluster0", mockOfflinePushStatusAccessor, mockPartitionStatusAccessor);
+    when(mockPartitionStatusAccessor.exists(anyString(), anyInt())).thenReturn(true);
+    when(mockPartitionStatusAccessor.update(anyString(), any(), anyInt())).thenReturn(true);
+    accessor.batchUpdateReplicaIncPushStatus("test_topic", 0, "test_instance_id", 100L, Arrays.asList("a", "b"));
+    Mockito.verify(mockPartitionStatusAccessor, Mockito.times(1)).update(anyString(), any(), anyInt());
   }
 }

--- a/internal/venice-common/src/test/java/com/linkedin/venice/offsets/TestOffsetRecord.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/offsets/TestOffsetRecord.java
@@ -3,6 +3,7 @@ package com.linkedin.venice.offsets;
 import com.linkedin.venice.serialization.avro.AvroProtocolDefinition;
 import com.linkedin.venice.utils.TestUtils;
 import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import org.testng.Assert;
@@ -40,5 +41,12 @@ public class TestOffsetRecord {
     // no upstream found for it so fall back to use the leaderOffset which is 1
     Assert.assertEquals(offsetRecord.getUpstreamOffset(TEST_KAFKA_URL1), 1L);
     Assert.assertEquals(offsetRecord.getUpstreamOffset(TEST_KAFKA_URL2), 2L);
+  }
+
+  @Test
+  public void testBatchUpdateEOIP() {
+    OffsetRecord offsetRecord = TestUtils.getOffsetRecord(100);
+    offsetRecord.setPendingReportIncPushVersionList(Arrays.asList("a", "b", "c"));
+    Assert.assertEquals(offsetRecord.getPendingReportIncPushVersionList(), Arrays.asList("a", "b", "c"));
   }
 }

--- a/internal/venice-common/src/test/java/com/linkedin/venice/pushmonitor/PartitionStatusTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/pushmonitor/PartitionStatusTest.java
@@ -66,11 +66,22 @@ public class PartitionStatusTest {
 
     partitionStatus.batchUpdateReplicaIncPushStatus("testInstance1", Arrays.asList("a", "b", "c"), 100L);
     Assert.assertFalse(partitionStatus.hasFatalDataValidationError());
-    Assert.assertEquals(partitionStatus.getReplicaStatus("testInstance1"), ExecutionStatus.END_OF_PUSH_RECEIVED);
+    Assert.assertEquals(
+        partitionStatus.getReplicaStatus("testInstance1"),
+        ExecutionStatus.END_OF_INCREMENTAL_PUSH_RECEIVED);
     ReplicaStatus replicaStatus = partitionStatus.getReplicaStatuses().iterator().next();
     Assert.assertEquals(replicaStatus.getCurrentProgress(), 100L);
     Assert.assertEquals(replicaStatus.getStatusHistory().get(0).getIncrementalPushVersion(), "a");
+    Assert.assertEquals(
+        replicaStatus.getStatusHistory().get(0).getStatus(),
+        ExecutionStatus.END_OF_INCREMENTAL_PUSH_RECEIVED);
     Assert.assertEquals(replicaStatus.getStatusHistory().get(1).getIncrementalPushVersion(), "b");
+    Assert.assertEquals(
+        replicaStatus.getStatusHistory().get(1).getStatus(),
+        ExecutionStatus.END_OF_INCREMENTAL_PUSH_RECEIVED);
     Assert.assertEquals(replicaStatus.getStatusHistory().get(2).getIncrementalPushVersion(), "c");
+    Assert.assertEquals(
+        replicaStatus.getStatusHistory().get(2).getStatus(),
+        ExecutionStatus.END_OF_INCREMENTAL_PUSH_RECEIVED);
   }
 }

--- a/internal/venice-common/src/test/java/com/linkedin/venice/pushmonitor/PartitionStatusTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/pushmonitor/PartitionStatusTest.java
@@ -4,6 +4,7 @@ import static com.linkedin.venice.utils.Utils.FATAL_DATA_VALIDATION_ERROR;
 import static org.testng.Assert.assertThrows;
 
 import com.linkedin.venice.exceptions.VeniceException;
+import java.util.Arrays;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -56,5 +57,20 @@ public class PartitionStatusTest {
     partitionStatus
         .updateReplicaStatus("testInstance4", ExecutionStatus.ERROR, FATAL_DATA_VALIDATION_ERROR + " for replica", 10);
     Assert.assertTrue(partitionStatus.hasFatalDataValidationError());
+  }
+
+  @Test
+  public void testValidateBatchUpdateEOIP() {
+    PartitionStatus partitionStatus = new PartitionStatus(partitionId);
+    Assert.assertFalse(partitionStatus.hasFatalDataValidationError());
+
+    partitionStatus.batchUpdateReplicaIncPushStatus("testInstance1", Arrays.asList("a", "b", "c"), 100L);
+    Assert.assertFalse(partitionStatus.hasFatalDataValidationError());
+    Assert.assertEquals(partitionStatus.getReplicaStatus("testInstance1"), ExecutionStatus.END_OF_PUSH_RECEIVED);
+    ReplicaStatus replicaStatus = partitionStatus.getReplicaStatuses().iterator().next();
+    Assert.assertEquals(replicaStatus.getCurrentProgress(), 100L);
+    Assert.assertEquals(replicaStatus.getStatusHistory().get(0).getIncrementalPushVersion(), "a");
+    Assert.assertEquals(replicaStatus.getStatusHistory().get(1).getIncrementalPushVersion(), "b");
+    Assert.assertEquals(replicaStatus.getStatusHistory().get(2).getIncrementalPushVersion(), "c");
   }
 }

--- a/internal/venice-common/src/test/java/com/linkedin/venice/schema/TestAvroSchema.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/schema/TestAvroSchema.java
@@ -65,6 +65,7 @@ public class TestAvroSchema {
     ps.upstreamOffsetMap = upstreamOffsetMap;
     ps.producerStates = Collections.emptyMap();
     ps.previousStatuses = Collections.emptyMap();
+    ps.pendingReportIncrementalPushVersions = Collections.emptyList();
 
     AvroSerializer serializer = new AvroSerializer(ps.getSchema());
     byte[] serializedBytes = serializer.serialize(ps);

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestBatchReportIncrementalPush.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestBatchReportIncrementalPush.java
@@ -1,0 +1,193 @@
+package com.linkedin.venice.endToEnd;
+
+import static com.linkedin.venice.hadoop.VenicePushJobConstants.DEFAULT_KEY_FIELD_PROP;
+import static com.linkedin.venice.hadoop.VenicePushJobConstants.ENABLE_WRITE_COMPUTE;
+import static com.linkedin.venice.hadoop.VenicePushJobConstants.INCREMENTAL_PUSH;
+import static com.linkedin.venice.hadoop.VenicePushJobConstants.VENICE_STORE_NAME_PROP;
+import static com.linkedin.venice.utils.TestUtils.assertCommand;
+import static com.linkedin.venice.utils.TestWriteUtils.getTempDataDirectory;
+import static com.linkedin.venice.utils.TestWriteUtils.writeSimpleAvroFileWithStringToPartialUpdateOpRecordSchema;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.linkedin.davinci.kafka.consumer.KafkaConsumerServiceDelegator;
+import com.linkedin.davinci.kafka.consumer.TopicPartitionIngestionInfo;
+import com.linkedin.venice.ConfigKeys;
+import com.linkedin.venice.client.store.AvroGenericStoreClient;
+import com.linkedin.venice.client.store.ClientConfig;
+import com.linkedin.venice.client.store.ClientFactory;
+import com.linkedin.venice.compression.CompressionStrategy;
+import com.linkedin.venice.controllerapi.ControllerClient;
+import com.linkedin.venice.controllerapi.ControllerResponse;
+import com.linkedin.venice.controllerapi.UpdateStoreQueryParams;
+import com.linkedin.venice.controllerapi.VersionCreationResponse;
+import com.linkedin.venice.exceptions.VeniceException;
+import com.linkedin.venice.hadoop.VenicePushJob;
+import com.linkedin.venice.helix.VeniceJsonSerializer;
+import com.linkedin.venice.integration.utils.ServiceFactory;
+import com.linkedin.venice.integration.utils.VeniceClusterWrapper;
+import com.linkedin.venice.integration.utils.VeniceControllerWrapper;
+import com.linkedin.venice.integration.utils.VeniceMultiClusterWrapper;
+import com.linkedin.venice.integration.utils.VeniceTwoLayerMultiRegionMultiClusterWrapper;
+import com.linkedin.venice.meta.Store;
+import com.linkedin.venice.meta.Version;
+import com.linkedin.venice.pubsub.PubSubTopicRepository;
+import com.linkedin.venice.serialization.avro.ChunkedValueManifestSerializer;
+import com.linkedin.venice.utils.IntegrationTestPushUtils;
+import com.linkedin.venice.utils.TestUtils;
+import com.linkedin.venice.utils.TestWriteUtils;
+import com.linkedin.venice.utils.Utils;
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericRecord;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+
+public class TestBatchReportIncrementalPush {
+  private static final int NUMBER_OF_CHILD_DATACENTERS = 2;
+  private static final int NUMBER_OF_CLUSTERS = 1;
+  private static final int TEST_TIMEOUT_MS = 180_000;
+  private static final int ASSERTION_TIMEOUT_MS = 30_000;
+  private static final String CLUSTER_NAME = "venice-cluster0";
+
+  private static final PubSubTopicRepository PUB_SUB_TOPIC_REPOSITORY = new PubSubTopicRepository();
+
+  private static VeniceJsonSerializer<Map<String, Map<String, TopicPartitionIngestionInfo>>> VENICE_JSON_SERIALIZER =
+      new VeniceJsonSerializer<>(new TypeReference<Map<String, Map<String, TopicPartitionIngestionInfo>>>() {
+      });
+
+  private static final ChunkedValueManifestSerializer CHUNKED_VALUE_MANIFEST_SERIALIZER =
+      new ChunkedValueManifestSerializer(false);
+
+  private VeniceTwoLayerMultiRegionMultiClusterWrapper multiRegionMultiClusterWrapper;
+  private VeniceControllerWrapper parentController;
+  private List<VeniceMultiClusterWrapper> childDatacenters;
+
+  @BeforeClass(alwaysRun = true)
+  public void setUp() {
+    Properties serverProperties = new Properties();
+    serverProperties.put(ConfigKeys.SERVER_RESUBSCRIPTION_TRIGGERED_BY_VERSION_INGESTION_CONTEXT_CHANGE_ENABLED, true);
+    serverProperties.put(
+        ConfigKeys.SERVER_CONSUMER_POOL_ALLOCATION_STRATEGY,
+        KafkaConsumerServiceDelegator.ConsumerPoolStrategyType.CURRENT_VERSION_PRIORITIZATION.name());
+    Properties controllerProps = new Properties();
+    controllerProps.put(ConfigKeys.CONTROLLER_AUTO_MATERIALIZE_META_SYSTEM_STORE, false);
+    this.multiRegionMultiClusterWrapper = ServiceFactory.getVeniceTwoLayerMultiRegionMultiClusterWrapper(
+        NUMBER_OF_CHILD_DATACENTERS,
+        NUMBER_OF_CLUSTERS,
+        1,
+        1,
+        2,
+        1,
+        2,
+        Optional.of(controllerProps),
+        Optional.of(controllerProps),
+        Optional.of(serverProperties),
+        false);
+    this.childDatacenters = multiRegionMultiClusterWrapper.getChildRegions();
+    List<VeniceControllerWrapper> parentControllers = multiRegionMultiClusterWrapper.getParentControllers();
+    if (parentControllers.size() != 1) {
+      throw new IllegalStateException("Expect only one parent controller. Got: " + parentControllers.size());
+    }
+    this.parentController = parentControllers.get(0);
+  }
+
+  @AfterClass(alwaysRun = true)
+  public void cleanUp() {
+    Utils.closeQuietlyWithErrorLogged(multiRegionMultiClusterWrapper);
+  }
+
+  @Test(timeOut = TEST_TIMEOUT_MS)
+  public void testBatchReportIncrementalPush() throws IOException {
+    final String storeName = Utils.getUniqueString("inc_push_update_classic_format");
+    String parentControllerUrl = parentController.getControllerUrl();
+    File inputDir = getTempDataDirectory();
+    Schema recordSchema = writeSimpleAvroFileWithStringToPartialUpdateOpRecordSchema(inputDir);
+    String keySchemaStr = recordSchema.getField(DEFAULT_KEY_FIELD_PROP).schema().toString();
+    String inputDirPath = "file://" + inputDir.getAbsolutePath();
+    Properties vpjProperties =
+        IntegrationTestPushUtils.defaultVPJProps(multiRegionMultiClusterWrapper, inputDirPath, storeName);
+    vpjProperties.put(ENABLE_WRITE_COMPUTE, true);
+    vpjProperties.put(INCREMENTAL_PUSH, true);
+
+    try (ControllerClient parentControllerClient = new ControllerClient(CLUSTER_NAME, parentControllerUrl)) {
+      assertCommand(
+          parentControllerClient
+              .createNewStore(storeName, "test_owner", keySchemaStr, TestWriteUtils.NAME_RECORD_V1_SCHEMA.toString()));
+      UpdateStoreQueryParams updateStoreParams =
+          new UpdateStoreQueryParams().setStorageQuotaInByte(Store.UNLIMITED_STORAGE_QUOTA)
+              .setCompressionStrategy(CompressionStrategy.NO_OP)
+              .setWriteComputationEnabled(true)
+              .setChunkingEnabled(true)
+              .setIncrementalPushEnabled(true)
+              .setHybridRewindSeconds(10L)
+              .setHybridOffsetLagThreshold(2L);
+      ControllerResponse updateStoreResponse =
+          parentControllerClient.retryableRequest(5, c -> c.updateStore(storeName, updateStoreParams));
+      assertFalse(updateStoreResponse.isError(), "Update store got error: " + updateStoreResponse.getError());
+
+      VersionCreationResponse response = parentControllerClient.emptyPush(storeName, "test_push_id", 1000);
+      assertEquals(response.getVersion(), 1);
+      assertFalse(response.isError(), "Empty push to parent colo should succeed");
+      TestUtils.waitForNonDeterministicPushCompletion(
+          Version.composeKafkaTopic(storeName, 1),
+          parentControllerClient,
+          30,
+          TimeUnit.SECONDS);
+
+      // VPJ push
+      String childControllerUrl = childDatacenters.get(0).getRandomController().getControllerUrl();
+      try (ControllerClient childControllerClient = new ControllerClient(CLUSTER_NAME, childControllerUrl)) {
+        runVPJ(vpjProperties, 1, childControllerClient);
+      }
+      VeniceClusterWrapper veniceClusterWrapper = childDatacenters.get(0).getClusters().get(CLUSTER_NAME);
+      veniceClusterWrapper.waitVersion(storeName, 1);
+      try (AvroGenericStoreClient<Object, Object> storeReader = ClientFactory.getAndStartGenericAvroClient(
+          ClientConfig.defaultGenericClientConfig(storeName).setVeniceURL(veniceClusterWrapper.getRandomRouterURL()))) {
+        TestUtils.waitForNonDeterministicAssertion(10, TimeUnit.SECONDS, true, () -> {
+          try {
+            for (int i = 1; i < 100; i++) {
+              String key = String.valueOf(i);
+              GenericRecord value = readValue(storeReader, key);
+              assertNotNull(value, "Key " + key + " should not be missing!");
+              assertEquals(value.get("firstName").toString(), "first_name_" + key);
+              assertEquals(value.get("lastName").toString(), "last_name_" + key);
+            }
+          } catch (Exception e) {
+            throw new VeniceException(e);
+          }
+        });
+      }
+    }
+  }
+
+  private void runVPJ(Properties vpjProperties, int expectedVersionNumber, ControllerClient controllerClient) {
+    String jobName = Utils.getUniqueString("write-compute-job-" + expectedVersionNumber);
+    try (VenicePushJob job = new VenicePushJob(jobName, vpjProperties)) {
+      job.run();
+      TestUtils.waitForNonDeterministicCompletion(
+          60,
+          TimeUnit.SECONDS,
+          () -> controllerClient.getStore((String) vpjProperties.get(VENICE_STORE_NAME_PROP))
+              .getStore()
+              .getCurrentVersion() == expectedVersionNumber);
+    }
+  }
+
+  private GenericRecord readValue(AvroGenericStoreClient<Object, Object> storeReader, String key)
+      throws ExecutionException, InterruptedException {
+    return (GenericRecord) storeReader.get(key).get();
+  }
+
+}

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestBatchReportIncrementalPush.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestBatchReportIncrementalPush.java
@@ -1,6 +1,6 @@
 package com.linkedin.venice.endToEnd;
 
-import static com.linkedin.venice.ConfigKeys.SERVER_BATCH_REPORT_END_OF_INCREMENTAL_PUSH_STATUS_INTERVAL_SECONDS;
+import static com.linkedin.venice.ConfigKeys.SERVER_BATCH_REPORT_END_OF_INCREMENTAL_PUSH_STATUS_ENABLED;
 import static com.linkedin.venice.ConfigKeys.SERVER_PROMOTION_TO_LEADER_REPLICA_DELAY_SECONDS;
 import static com.linkedin.venice.hadoop.VenicePushJobConstants.ENABLE_WRITE_COMPUTE;
 import static com.linkedin.venice.hadoop.VenicePushJobConstants.INCREMENTAL_PUSH;
@@ -62,8 +62,7 @@ public class TestBatchReportIncrementalPush {
   public void setUp() {
     Properties serverProperties = new Properties();
     serverProperties.setProperty(SERVER_PROMOTION_TO_LEADER_REPLICA_DELAY_SECONDS, Long.toString(1L));
-    serverProperties
-        .setProperty(SERVER_BATCH_REPORT_END_OF_INCREMENTAL_PUSH_STATUS_INTERVAL_SECONDS, Long.toString(60L));
+    serverProperties.setProperty(SERVER_BATCH_REPORT_END_OF_INCREMENTAL_PUSH_STATUS_ENABLED, Long.toString(60L));
     Properties controllerProps = new Properties();
     controllerProps.put(ConfigKeys.CONTROLLER_AUTO_MATERIALIZE_META_SYSTEM_STORE, false);
     this.multiRegionMultiClusterWrapper = ServiceFactory.getVeniceTwoLayerMultiRegionMultiClusterWrapper(

--- a/internal/venice-test-common/src/main/java/com/linkedin/venice/utils/TestWriteUtils.java
+++ b/internal/venice-test-common/src/main/java/com/linkedin/venice/utils/TestWriteUtils.java
@@ -357,6 +357,13 @@ public class TestWriteUtils {
   }
 
   public static Schema writeSimpleAvroFileWithStringToPartialUpdateOpRecordSchema(File parentDir) throws IOException {
+    return writeSimpleAvroFileWithStringToPartialUpdateOpRecordSchema(parentDir, 1, 100);
+  }
+
+  public static Schema writeSimpleAvroFileWithStringToPartialUpdateOpRecordSchema(
+      File parentDir,
+      int startIndex,
+      int endIndex) throws IOException {
     return writeAvroFile(
         parentDir,
         "string2record.avro",
@@ -364,7 +371,7 @@ public class TestWriteUtils {
         (recordSchema, writer) -> {
           String firstName = "first_name_";
           String lastName = "last_name_";
-          for (int i = 1; i <= 100; ++i) {
+          for (int i = startIndex; i <= endIndex; ++i) {
             GenericRecord keyValueRecord = new GenericData.Record(recordSchema);
             keyValueRecord.put(DEFAULT_KEY_FIELD_PROP, String.valueOf(i)); // Key
             GenericRecord valueRecord =


### PR DESCRIPTION
## [server] Batch report EOIP for incremental push prior to replica ready-to-serve
This PR will try to batch the EOIP messages for historical incremental pushes and batch up them to ZK OfflinePushes Znode prior to replica ready-to-serve.
It is intended to reduce the volume of unnecessary update to ZK nodes.

## How was this PR tested?
Add integration tests and unit tests to cover the functionality.

## Does this PR introduce any user-facing changes?
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.