### PR TITLE
[server] SN read quota usage should return NaN for stores with no replicas

### DIFF
--- a/services/venice-server/src/main/java/com/linkedin/venice/stats/ServerQuotaUsageStats.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/stats/ServerQuotaUsageStats.java
@@ -65,7 +65,7 @@ public class ServerQuotaUsageStats extends AbstractVeniceStats {
    */
   private Double getReadQuotaUsageRatio() {
     if (tokenBucket == null) {
-      return -1d;
+      return Double.NaN;
     } else {
       return tokenBucket.getStaleUsageRatio();
     }

--- a/services/venice-server/src/test/java/com/linkedin/venice/stats/AggServerQuotaUsageStatsTest.java
+++ b/services/venice-server/src/test/java/com/linkedin/venice/stats/AggServerQuotaUsageStatsTest.java
@@ -70,10 +70,10 @@ public class AggServerQuotaUsageStatsTest {
     double expectedUsageRatio = 0.5;
     doReturn(expectedUsageRatio).when(mockTokenBucket).getStaleUsageRatio();
 
-    Assert.assertEquals(metricsRepository.getMetric(readQuotaUsageRatioString).value(), -1d);
+    Assert.assertEquals(metricsRepository.getMetric(readQuotaUsageRatioString).value(), Double.NaN);
     aggServerQuotaUsageStats.setStoreTokenBucket(storeName, mockTokenBucket);
     Assert.assertEquals(metricsRepository.getMetric(readQuotaUsageRatioString).value(), expectedUsageRatio);
     aggServerQuotaUsageStats.setStoreTokenBucket(storeName, null);
-    Assert.assertEquals(metricsRepository.getMetric(readQuotaUsageRatioString).value(), -1d);
+    Assert.assertEquals(metricsRepository.getMetric(readQuotaUsageRatioString).value(), Double.NaN);
   }
 }


### PR DESCRIPTION
## Summary, imperative, start upper case, don't end with a period

If a store's partition count is small it's normal and expectd to have some hosts in the cluster to not have any replicas assigned to them. The hosts should emit NaN for the SN read quota usage metric instead of -1. Emitting -1 or 0 will mess up aggregation of metrics used for monitoring.

The NaN should be ignored by aggregators and provide clear signals in case of unexpected null rate limiter.

## How was this PR tested?
Existing unit and integration tests

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.