### PR TITLE
[server] AAWC should ignore NO_OP new field from update record

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/replication/merge/MergeConflictResolver.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/replication/merge/MergeConflictResolver.java
@@ -766,9 +766,11 @@ public class MergeConflictResolver {
       case PER_FIELD_TIMESTAMP:
         GenericRecord timestampRecord = (GenericRecord) oldTimestampObject;
         for (Schema.Field field: writeComputeRecord.getSchema().getFields()) {
-          if (getFieldOperationType(writeComputeRecord.get(field.pos())) != NO_OP_ON_FIELD
-              && timestampRecord.get(field.name()) == null) {
-            return false; // Write Compute tries to update a non-existing field.
+          if (timestampRecord.get(field.name()) == null) {
+            if (getFieldOperationType(writeComputeRecord.get(field.pos())) == NO_OP_ON_FIELD) {
+              continue; // New field does not perform actual update.
+            }
+            return false; // Partial update tries to update a non-existing field.
           }
           if (isRmdFieldTimestampSmaller(timestampRecord, field.name(), updateOperationTimestamp, false)) {
             return false; // One existing field must be updated.

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/replication/merge/MergeConflictResolver.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/replication/merge/MergeConflictResolver.java
@@ -764,15 +764,15 @@ public class MergeConflictResolver {
         return true; // Write Compute does not try to update any non-existing fields in the old value (schema).
 
       case PER_FIELD_TIMESTAMP:
-        GenericRecord timestampRecord = (GenericRecord) oldTimestampObject;
+        GenericRecord oldTimestampRecord = (GenericRecord) oldTimestampObject;
         for (Schema.Field field: writeComputeRecord.getSchema().getFields()) {
-          if (!timestampRecord.hasField(field.name())) {
+          if (!oldTimestampRecord.hasField(field.name())) {
             if (getFieldOperationType(writeComputeRecord.get(field.pos())) == NO_OP_ON_FIELD) {
               continue; // New field does not perform actual update.
             }
             return false; // Partial update tries to update a non-existing field.
           }
-          if (isRmdFieldTimestampSmaller(timestampRecord, field.name(), updateOperationTimestamp, false)) {
+          if (isRmdFieldTimestampSmaller(oldTimestampRecord, field.name(), updateOperationTimestamp, false)) {
             return false; // One existing field must be updated.
           }
         }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/replication/merge/MergeConflictResolver.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/replication/merge/MergeConflictResolver.java
@@ -766,7 +766,7 @@ public class MergeConflictResolver {
       case PER_FIELD_TIMESTAMP:
         GenericRecord timestampRecord = (GenericRecord) oldTimestampObject;
         for (Schema.Field field: writeComputeRecord.getSchema().getFields()) {
-          if (timestampRecord.get(field.name()) == null) {
+          if (!timestampRecord.hasField(field.name())) {
             if (getFieldOperationType(writeComputeRecord.get(field.pos())) == NO_OP_ON_FIELD) {
               continue; // New field does not perform actual update.
             }

--- a/clients/da-vinci-client/src/test/resources/avro/PersonV3.avsc
+++ b/clients/da-vinci-client/src/test/resources/avro/PersonV3.avsc
@@ -3,6 +3,14 @@
   "type": "record",
   "fields": [
     {
+      "name": "stringMap",
+      "type": {
+        "type": "map",
+        "values": "string"
+      },
+      "default": {}
+    },
+    {
       "name": "nullableListField",
       "type": [
         "null",
@@ -43,14 +51,6 @@
         "items": "string"
       },
       "default": []
-    },
-    {
-      "name": "stringMap",
-      "type": {
-        "type": "map",
-        "values": "string"
-      },
-      "default": {}
     }
   ]
 }


### PR DESCRIPTION
## [server] AAWC should ignore NO_OP new field from update record
If a field from update record is new field but it is NO_OP, we should skip this field, instead of letting it slip into checking TS from old TS record, which will result in exception and halt the ingestion

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.