### PR TITLE
[service][dvc] generate snapshot after endBatchWrite complete

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/DaVinciBackend.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/DaVinciBackend.java
@@ -292,7 +292,7 @@ public class DaVinciBackend implements Closeable {
       }
 
       if (backendConfig.isBlobTransferManagerEnabled()) {
-        blobTransferManager = BlobTransferUtil.getP2PBlobTransferManagerAndStart(
+        blobTransferManager = BlobTransferUtil.getP2PBlobTransferManagerForDVCAndStart(
             configLoader.getVeniceServerConfig().getDvcP2pBlobTransferServerPort(),
             configLoader.getVeniceServerConfig().getDvcP2pBlobTransferClientPort(),
             configLoader.getVeniceServerConfig().getRocksDBPath(),

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/blobtransfer/BlobSnapshotManager.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/blobtransfer/BlobSnapshotManager.java
@@ -161,4 +161,28 @@ public class BlobSnapshotManager {
     return Checkpoint.create(rocksDB);
   }
 
+  /**
+   * util method to create a snapshot for batch only
+   */
+  public static void createSnapshotForBatch(RocksDB rocksDB, String fullPathForPartitionDBSnapshot) {
+    LOGGER.info("Creating snapshot for batch in directory: {}", fullPathForPartitionDBSnapshot);
+
+    if (fullPathForPartitionDBSnapshot == null || fullPathForPartitionDBSnapshot.isEmpty()) {
+      LOGGER.error("Snapshot directory {} is null or empty", fullPathForPartitionDBSnapshot);
+      return;
+    }
+
+    try {
+      LOGGER.info("Start creating snapshots for batch in directory: {}", fullPathForPartitionDBSnapshot);
+
+      Checkpoint checkpoint = Checkpoint.create(rocksDB);
+      checkpoint.createCheckpoint(fullPathForPartitionDBSnapshot);
+
+      LOGGER.info("Finished creating snapshots for batch in directory: {}", fullPathForPartitionDBSnapshot);
+    } catch (RocksDBException e) {
+      throw new VeniceException(
+          "Received exception during RocksDB's snapshot creation in directory " + fullPathForPartitionDBSnapshot,
+          e);
+    }
+  }
 }

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/DefaultIngestionBackend.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/ingestion/DefaultIngestionBackend.java
@@ -80,10 +80,7 @@ public class DefaultIngestionBackend implements IngestionBackend {
           storeVersion,
           partition);
     };
-
-    // TODO: need to differentiate that's DVC or server. Right now, it doesn't tell so both components can create,
-    // though
-    // Only DVC would create blobTransferManager.
+    // TODO: remove hybrid check after blob transfer in hybrid mode is fully supported
     if (!storeAndVersion.getFirst().isBlobTransferEnabled() || storeAndVersion.getFirst().isHybrid()
         || blobTransferManager == null) {
       runnable.run();

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/AbstractStorageEngine.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/AbstractStorageEngine.java
@@ -423,6 +423,15 @@ public abstract class AbstractStorageEngine<Partition extends AbstractStoragePar
     }
   }
 
+  /**
+   * Create snapshot for the given partition
+   * @param storagePartitionConfig
+   */
+  public synchronized void createSnapshot(StoragePartitionConfig storagePartitionConfig) {
+    AbstractStoragePartition partition = getPartitionOrThrow(storagePartitionConfig.getPartitionId());
+    partition.createSnapshot();
+  }
+
   private void executeWithSafeGuard(int partitionId, Runnable runnable) {
     executeWithSafeGuard(partitionId, () -> {
       runnable.run();

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/ReplicationMetadataRocksDBStoragePartition.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/ReplicationMetadataRocksDBStoragePartition.java
@@ -61,8 +61,7 @@ public class ReplicationMetadataRocksDBStoragePartition extends RocksDBStoragePa
           super.getOptions(),
           fullPathForTempSSTFileDir,
           true,
-          rocksDBServerConfig,
-          super.getBlobTransferEnabled());
+          rocksDBServerConfig);
     }
   }
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/RocksDBStoragePartition.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/RocksDBStoragePartition.java
@@ -218,8 +218,7 @@ public class RocksDBStoragePartition extends AbstractStoragePartition {
           options,
           fullPathForTempSSTFileDir,
           false,
-          rocksDBServerConfig,
-          blobTransferEnabled);
+          rocksDBServerConfig);
     }
 
     /**

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/RocksDBStoragePartition.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/store/rocksdb/RocksDBStoragePartition.java
@@ -2,6 +2,7 @@ package com.linkedin.davinci.store.rocksdb;
 
 import static com.linkedin.davinci.store.AbstractStorageEngine.METADATA_PARTITION_ID;
 
+import com.linkedin.davinci.blobtransfer.BlobSnapshotManager;
 import com.linkedin.davinci.callback.BytesStreamingCallback;
 import com.linkedin.davinci.config.VeniceStoreVersionConfig;
 import com.linkedin.davinci.stats.RocksDBMemoryStats;
@@ -484,16 +485,12 @@ public class RocksDBStoragePartition extends AbstractStoragePartition {
      * the last SST file written is finished.
      */
     rocksDBSstFileWriter.ingestSSTFiles(rocksDB, columnFamilyHandleList);
-
-    if (blobTransferEnabled) {
-      createSnapshot();
-    }
   }
 
   @Override
   public synchronized void createSnapshot() {
     if (blobTransferEnabled) {
-      rocksDBSstFileWriter.createSnapshot(rocksDB);
+      BlobSnapshotManager.createSnapshotForBatch(rocksDB, fullPathForTempSnapshotFileDir);
     }
   }
 

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/store/rocksdb/RocksDBSstFileWriterTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/store/rocksdb/RocksDBSstFileWriterTest.java
@@ -1,18 +1,8 @@
 package com.linkedin.davinci.store.rocksdb;
 
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.testng.Assert.assertThrows;
-
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.kafka.validation.checksum.CheckSum;
 import com.linkedin.venice.kafka.validation.checksum.CheckSumType;
-import com.linkedin.venice.store.rocksdb.RocksDBUtils;
 import com.linkedin.venice.utils.Utils;
 import com.linkedin.venice.utils.VeniceProperties;
 import java.io.File;
@@ -22,10 +12,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import org.apache.commons.io.FileUtils;
-import org.rocksdb.Checkpoint;
 import org.rocksdb.EnvOptions;
 import org.rocksdb.Options;
-import org.rocksdb.RocksDB;
 import org.rocksdb.RocksDBException;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -36,7 +24,6 @@ public class RocksDBSstFileWriterTest {
   private static final int PARTITION_ID = 0;
   private static final String DB_DIR = Utils.getUniqueTempPath("sstTest");
   private static final boolean IS_RMD = false;
-  private static final boolean IS_BLOB_TRANSFER_ENABLED = false;
   private static final RocksDBServerConfig ROCKS_DB_SERVER_CONFIG = new RocksDBServerConfig(VeniceProperties.empty());
 
   @Test
@@ -51,8 +38,7 @@ public class RocksDBSstFileWriterTest {
           new Options(),
           DB_DIR,
           IS_RMD,
-          ROCKS_DB_SERVER_CONFIG,
-          IS_BLOB_TRANSFER_ENABLED);
+          ROCKS_DB_SERVER_CONFIG);
       Map<String, String> checkpointedInfo = new HashMap<>();
 
       // Expect false as that file is not found
@@ -76,8 +62,7 @@ public class RocksDBSstFileWriterTest {
           new Options(),
           DB_DIR,
           IS_RMD,
-          ROCKS_DB_SERVER_CONFIG,
-          IS_BLOB_TRANSFER_ENABLED);
+          ROCKS_DB_SERVER_CONFIG);
       Map<String, String> checkpointedInfo = new HashMap<>();
 
       // Checkpoint that 1 sst file should be found
@@ -110,8 +95,7 @@ public class RocksDBSstFileWriterTest {
           new Options(),
           DB_DIR,
           IS_RMD,
-          ROCKS_DB_SERVER_CONFIG,
-          IS_BLOB_TRANSFER_ENABLED);
+          ROCKS_DB_SERVER_CONFIG);
       Map<String, String> checkpointedInfo = new HashMap<>();
 
       // Checkpoint that 2 sst file should be found
@@ -138,8 +122,7 @@ public class RocksDBSstFileWriterTest {
           new Options(),
           DB_DIR,
           IS_RMD,
-          ROCKS_DB_SERVER_CONFIG,
-          IS_BLOB_TRANSFER_ENABLED);
+          ROCKS_DB_SERVER_CONFIG);
       Map<String, String> checkpointedInfo = new HashMap<>();
 
       // Checkpoint -1: invalid
@@ -165,8 +148,7 @@ public class RocksDBSstFileWriterTest {
           new Options(),
           DB_DIR,
           IS_RMD,
-          ROCKS_DB_SERVER_CONFIG,
-          IS_BLOB_TRANSFER_ENABLED);
+          ROCKS_DB_SERVER_CONFIG);
       Map<String, String> checkpointedInfo = new HashMap<>();
 
       // Checkpoint that 6 sst file should be found
@@ -199,8 +181,7 @@ public class RocksDBSstFileWriterTest {
           new Options(),
           DB_DIR,
           IS_RMD,
-          ROCKS_DB_SERVER_CONFIG,
-          IS_BLOB_TRANSFER_ENABLED);
+          ROCKS_DB_SERVER_CONFIG);
       Map<String, String> checkpointedInfo = new HashMap<>();
 
       // Checkpoint that 6 sst file should be found
@@ -235,8 +216,7 @@ public class RocksDBSstFileWriterTest {
           new Options(),
           DB_DIR,
           IS_RMD,
-          ROCKS_DB_SERVER_CONFIG,
-          IS_BLOB_TRANSFER_ENABLED);
+          ROCKS_DB_SERVER_CONFIG);
       Map<String, String> checkpointedInfo = new HashMap<>();
 
       // Checkpoint that 6 sst file should be found
@@ -267,8 +247,7 @@ public class RocksDBSstFileWriterTest {
           new Options(),
           DB_DIR,
           IS_RMD,
-          ROCKS_DB_SERVER_CONFIG,
-          IS_BLOB_TRANSFER_ENABLED);
+          ROCKS_DB_SERVER_CONFIG);
       Map<String, String> checkpointedInfo = new HashMap<>();
 
       // Checkpoint that 6 sst file should be found
@@ -290,108 +269,6 @@ public class RocksDBSstFileWriterTest {
   }
 
   @Test
-  public void testCreateSnapshotWithBlobTransferDisabled() throws RocksDBException {
-    RocksDBSstFileWriter rocksDBSstFileWriter = null;
-    try {
-      rocksDBSstFileWriter = spy(
-          new RocksDBSstFileWriter(
-              STORE_NAME,
-              PARTITION_ID,
-              "/db",
-              new EnvOptions(),
-              new Options(),
-              DB_DIR,
-              IS_RMD,
-              ROCKS_DB_SERVER_CONFIG,
-              IS_BLOB_TRANSFER_ENABLED));
-
-      String checkpointPath = RocksDBUtils.composeSnapshotDir("/db", STORE_NAME, PARTITION_ID);
-      RocksDB rocksdb = mock(RocksDB.class);
-      Checkpoint checkpoint = mock(Checkpoint.class);
-
-      doReturn(checkpoint).when(rocksDBSstFileWriter).createCheckpoint(rocksdb);
-      doNothing().when(checkpoint).createCheckpoint(checkpointPath);
-
-      // if blob transfer is disabled in configurations, should not create snapshots
-      rocksDBSstFileWriter.createSnapshot(rocksdb);
-      verify(checkpoint, times(0)).createCheckpoint(checkpointPath);
-
-    } finally {
-      if (rocksDBSstFileWriter != null) {
-        rocksDBSstFileWriter.close();
-      }
-    }
-  }
-
-  @Test
-  public void testCreateSnapshotWithBlobTransferEnabled() throws RocksDBException {
-    RocksDBSstFileWriter rocksDBSstFileWriter = null;
-
-    try {
-      rocksDBSstFileWriter = spy(
-          new RocksDBSstFileWriter(
-              STORE_NAME,
-              PARTITION_ID,
-              "/db",
-              new EnvOptions(),
-              new Options(),
-              DB_DIR,
-              IS_RMD,
-              ROCKS_DB_SERVER_CONFIG,
-              true));
-
-      String checkpointPath = RocksDBUtils.composeSnapshotDir("/db", STORE_NAME, PARTITION_ID);
-      RocksDB rocksdb = mock(RocksDB.class);
-      Checkpoint checkpoint = mock(Checkpoint.class);
-
-      doReturn(checkpoint).when(rocksDBSstFileWriter).createCheckpoint(rocksdb);
-      doNothing().when(checkpoint).createCheckpoint(checkpointPath);
-
-      // if blob transfer is enabled in configurations, should create snapshots
-      rocksDBSstFileWriter.createSnapshot(rocksdb);
-      verify(checkpoint, times(1)).createCheckpoint(checkpointPath);
-
-    } finally {
-      if (rocksDBSstFileWriter != null) {
-        rocksDBSstFileWriter.close();
-      }
-    }
-  }
-
-  @Test
-  public void testCreateSnapshotThrowsVeniceExceptionOnRocksDBException() throws RocksDBException {
-    RocksDBSstFileWriter rocksDBSstFileWriter = null;
-
-    try {
-      rocksDBSstFileWriter = spy(
-          new RocksDBSstFileWriter(
-              STORE_NAME,
-              PARTITION_ID,
-              "/db",
-              new EnvOptions(),
-              new Options(),
-              DB_DIR,
-              IS_RMD,
-              ROCKS_DB_SERVER_CONFIG,
-              true));
-
-      String checkpointPath = RocksDBUtils.composeSnapshotDir("/db", STORE_NAME, PARTITION_ID);
-      RocksDB rocksdb = mock(RocksDB.class);
-      Checkpoint checkpoint = mock(Checkpoint.class);
-
-      doReturn(checkpoint).when(rocksDBSstFileWriter).createCheckpoint(rocksdb);
-      doThrow(new RocksDBException("Test exception")).when(checkpoint).createCheckpoint(checkpointPath);
-
-      RocksDBSstFileWriter finalRocksDBSstFileWriter = rocksDBSstFileWriter;
-      assertThrows(VeniceException.class, () -> finalRocksDBSstFileWriter.createSnapshot(rocksdb));
-    } finally {
-      if (rocksDBSstFileWriter != null) {
-        rocksDBSstFileWriter.close();
-      }
-    }
-  }
-
-  @Test
   public void testSyncWithCorrectChecksum() throws IOException, RocksDBException {
     RocksDBSstFileWriter rocksDBSstFileWriter = null;
     try {
@@ -403,8 +280,7 @@ public class RocksDBSstFileWriterTest {
           new Options(),
           DB_DIR,
           IS_RMD,
-          ROCKS_DB_SERVER_CONFIG,
-          IS_BLOB_TRANSFER_ENABLED);
+          ROCKS_DB_SERVER_CONFIG);
       Map<String, String> checkpointedInfo = new HashMap<>();
 
       // Checkpoint that 1 sst file should be found
@@ -444,8 +320,7 @@ public class RocksDBSstFileWriterTest {
           new Options(),
           DB_DIR,
           IS_RMD,
-          ROCKS_DB_SERVER_CONFIG,
-          IS_BLOB_TRANSFER_ENABLED);
+          ROCKS_DB_SERVER_CONFIG);
       Map<String, String> checkpointedInfo = new HashMap<>();
 
       // Checkpoint that 1 sst file should be found
@@ -485,8 +360,7 @@ public class RocksDBSstFileWriterTest {
           new Options(),
           DB_DIR,
           IS_RMD,
-          ROCKS_DB_SERVER_CONFIG,
-          IS_BLOB_TRANSFER_ENABLED);
+          ROCKS_DB_SERVER_CONFIG);
       Map<String, String> checkpointedInfo = new HashMap<>();
 
       // Checkpoint that 6 sst file should be found

--- a/internal/venice-common/src/main/java/com/linkedin/venice/blobtransfer/BlobTransferUtil.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/blobtransfer/BlobTransferUtil.java
@@ -7,6 +7,8 @@ import com.linkedin.venice.blobtransfer.server.P2PBlobTransferService;
 import com.linkedin.venice.client.store.AbstractAvroStoreClient;
 import com.linkedin.venice.client.store.AvroGenericStoreClientImpl;
 import com.linkedin.venice.client.store.ClientConfig;
+import com.linkedin.venice.helix.HelixCustomizedViewOfflinePushRepository;
+import java.util.concurrent.CompletableFuture;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -15,21 +17,21 @@ public class BlobTransferUtil {
   private static final Logger LOGGER = LogManager.getLogger(BlobTransferUtil.class);
 
   /**
-   * Get a P2P blob transfer manager and start it.
+   * Get a P2P blob transfer manager for DaVinci Client and start it.
    * @param p2pTransferPort, the port used by the P2P transfer service and client
    * @param baseDir, the base directory of the underlying storage
    * @param clientConfig, the client config to start up a transport client
-   * @return
+   * @return the blob transfer manager
    * @throws Exception
    */
-  public static BlobTransferManager<Void> getP2PBlobTransferManagerAndStart(
+  public static BlobTransferManager<Void> getP2PBlobTransferManagerForDVCAndStart(
       int p2pTransferPort,
       String baseDir,
       ClientConfig clientConfig) {
-    return getP2PBlobTransferManagerAndStart(p2pTransferPort, p2pTransferPort, baseDir, clientConfig);
+    return getP2PBlobTransferManagerForDVCAndStart(p2pTransferPort, p2pTransferPort, baseDir, clientConfig);
   }
 
-  public static BlobTransferManager<Void> getP2PBlobTransferManagerAndStart(
+  public static BlobTransferManager<Void> getP2PBlobTransferManagerForDVCAndStart(
       int p2pTransferServerPort,
       int p2pTransferClientPort,
       String baseDir,
@@ -45,7 +47,34 @@ public class BlobTransferUtil {
       return manager;
     } catch (Exception e) {
       // swallow the exception and continue the consumption via pubsub system
-      LOGGER.warn("Failed to start up the P2P blob transfer manager", e);
+      LOGGER.warn("Failed to start up the P2P blob transfer manager for DaVinci Client", e);
+      return null;
+    }
+  }
+
+  /**
+   * Get a P2P blob transfer manager for Service and start it.
+   * @param p2pTransferServerPort the port used by the P2P transfer service
+   * @param p2pTransferClientPort the port used by the P2P transfer client
+   * @param baseDir the base directory of the underlying storage
+   * @param customizedViewFuture the future of the customized view repository
+   * @return the blob transfer manager
+   */
+  public static BlobTransferManager<Void> getP2PBlobTransferManagerForServiceAndStart(
+      int p2pTransferServerPort,
+      int p2pTransferClientPort,
+      String baseDir,
+      CompletableFuture<HelixCustomizedViewOfflinePushRepository> customizedViewFuture) {
+    try {
+      BlobTransferManager<Void> manager = new NettyP2PBlobTransferManager(
+          new P2PBlobTransferService(p2pTransferServerPort, baseDir),
+          new NettyFileTransferClient(p2pTransferClientPort, baseDir),
+          new ServerBlobFinder(customizedViewFuture));
+      manager.start();
+      return manager;
+    } catch (Exception e) {
+      // swallow the exception and continue the consumption via pubsub system
+      LOGGER.warn("Failed to start up the P2P blob transfer manager for service", e);
       return null;
     }
   }

--- a/services/venice-server/src/main/java/com/linkedin/venice/server/VeniceServer.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/server/VeniceServer.java
@@ -21,6 +21,8 @@ import com.linkedin.davinci.storage.StorageMetadataService;
 import com.linkedin.davinci.storage.StorageService;
 import com.linkedin.venice.acl.DynamicAccessController;
 import com.linkedin.venice.acl.StaticAccessController;
+import com.linkedin.venice.blobtransfer.BlobTransferManager;
+import com.linkedin.venice.blobtransfer.BlobTransferUtil;
 import com.linkedin.venice.cleaner.BackupVersionOptimizationService;
 import com.linkedin.venice.cleaner.LeakedResourceCleaner;
 import com.linkedin.venice.cleaner.ResourceReadUsageTracker;
@@ -114,6 +116,7 @@ public class VeniceServer {
   StorageEngineBackedCompressorFactory compressorFactory;
   private HeartbeatMonitoringService heartbeatMonitoringService;
   private ServerReadMetadataRepository serverReadMetadataRepository;
+  private BlobTransferManager<Void> blobTransferManager;
 
   /**
    * @deprecated Use {@link VeniceServer#VeniceServer(VeniceServerContext)} instead.
@@ -440,6 +443,19 @@ public class VeniceServer {
     services.add(listenerService);
 
     /**
+     * Initialize Blob transfer manager for Service
+     */
+    if (serverConfig.isBlobTransferManagerEnabled()) {
+      blobTransferManager = BlobTransferUtil.getP2PBlobTransferManagerForServiceAndStart(
+          serverConfig.getDvcP2pBlobTransferServerPort(),
+          serverConfig.getDvcP2pBlobTransferClientPort(),
+          serverConfig.getRocksDBPath(),
+          customizedViewFuture);
+    } else {
+      blobTransferManager = null;
+    }
+
+    /**
      * Helix participator service should start last since we need to make sure current Storage Node is ready to take
      * read requests if it claims to be available in Helix.
      */
@@ -456,7 +472,8 @@ public class VeniceServer {
         veniceConfigLoader.getVeniceServerConfig().getListenerPort(),
         veniceConfigLoader.getVeniceServerConfig().getListenerHostname(),
         managerFuture,
-        heartbeatMonitoringService);
+        heartbeatMonitoringService,
+        blobTransferManager);
     services.add(helixParticipationService);
 
     // Add kafka consumer service last so when shutdown the server, it will be stopped first to avoid the case


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Create snapshots after end batch write complete
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

1. After a batch write, create a partition snapshot. The snapshot will be under the directory in the "./snapshot" folder for each batch-push version. The subfiles under "./snapshot" will be used for blob transfer.
2. The blob transfer manager are initial for Service, not only DVC.


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
Run integration test at TestBatch. Snapshots are generated.

<img width="1359" alt="Screenshot 2024-09-06 at 1 34 31 PM" src="https://github.com/user-attachments/assets/aece303e-d259-4fb5-b09f-0a52bca66430">

**[WIP]** plain table integration test will be added in next commit. 

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.