### PR TITLE
[common] Retry controller client request on exceptions

### DIFF
--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerClient.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerClient.java
@@ -713,10 +713,10 @@ public class ControllerClient implements Closeable {
       throw new VeniceException(
           "Querying with retries requires at least one attempt, called with " + totalAttempts + " attempts");
     }
-    int currentAttempt = 1;
-    while (true) {
-      R response = null;
-      Exception exception = null;
+    Exception exception = null;
+    R response = null;
+
+    for (int currentAttempt = 0; currentAttempt < totalAttempts; currentAttempt++) {
       try {
         response = request.apply(client);
       } catch (Exception e) {
@@ -724,8 +724,8 @@ public class ControllerClient implements Closeable {
       }
       // Do not retry if value schema is not found. TODO: Ideally response should not be an error but should return
       // INVALID schema ID in the response.
-      if (exception == null && (!response.isError() || currentAttempt == totalAttempts
-          || valueSchemaNotFoundSchemaResponse(response) || abortRetryCondition.apply(response))) {
+      if (exception == null && (!response.isError() || valueSchemaNotFoundSchemaResponse(response)
+          || abortRetryCondition.apply(response))) {
         return response;
       } else {
         if (exception != null) {
@@ -741,6 +741,11 @@ public class ControllerClient implements Closeable {
         currentAttempt++;
         Utils.sleep(2000);
       }
+    }
+    if (exception != null) {
+      throw new VeniceException("Could not execute query even after " + totalAttempts + " attempts.", exception);
+    } else {
+      return response;
     }
   }
 
@@ -1472,14 +1477,14 @@ public class ControllerClient implements Closeable {
     return makeErrorResponse(message, lastException, responseType, logErrorMessage);
   }
 
-  private <T extends ControllerResponse> T makeErrorResponse(
+  private static <T extends ControllerResponse> T makeErrorResponse(
       String message,
       Exception exception,
       Class<T> responseType) {
     return makeErrorResponse(message, exception, responseType, true);
   }
 
-  private <T extends ControllerResponse> T makeErrorResponse(
+  private static <T extends ControllerResponse> T makeErrorResponse(
       String message,
       Exception exception,
       Class<T> responseType,

--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerClient.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerClient.java
@@ -716,7 +716,7 @@ public class ControllerClient implements Closeable {
     Exception exception = null;
     R response = null;
 
-    for (int currentAttempt = 0; currentAttempt < totalAttempts; currentAttempt++) {
+    for (int currentAttempt = 1; currentAttempt <= totalAttempts; currentAttempt++) {
       try {
         response = request.apply(client);
       } catch (Exception e) {
@@ -738,7 +738,6 @@ public class ControllerClient implements Closeable {
               totalAttempts,
               response.getError());
         }
-        currentAttempt++;
         Utils.sleep(2000);
       }
     }


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Retry controller client request on exceptions
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Today, "ControllerClient#retryableRequest" retries when the controller returns an error response. It doesn't retry when an exception is thrown. We need to handle exceptions as an error condition and retry till the retryAttempt count is reached.

Also it misses to retry VeniceException from `getLeaderControllerUrl`  which could lead to data recovery pushes to fail on a single unsuccessful controller discovery call. 



## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
GHCI
## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.