### PR TITLE
[dvc] Exposed an API to pass an executor to CachingDaVinciClientFactory

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/client/AvroGenericDaVinciClient.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/client/AvroGenericDaVinciClient.java
@@ -73,6 +73,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -135,13 +136,14 @@ public class AvroGenericDaVinciClient<K, V> implements DaVinciClient<K, V>, Avro
   private static final Map<CharSequence, Schema> computeResultSchemaCache = new VeniceConcurrentHashMap<>();
 
   private final AbstractAvroChunkingAdapter<V> chunkingAdapter;
+  private final Executor readChunkExecutorForLargeRequest;
 
   public AvroGenericDaVinciClient(
       DaVinciConfig daVinciConfig,
       ClientConfig clientConfig,
       VeniceProperties backendConfig,
       Optional<Set<String>> managedClients) {
-    this(daVinciConfig, clientConfig, backendConfig, managedClients, null);
+    this(daVinciConfig, clientConfig, backendConfig, managedClients, null, null);
   }
 
   public AvroGenericDaVinciClient(
@@ -149,7 +151,8 @@ public class AvroGenericDaVinciClient<K, V> implements DaVinciClient<K, V>, Avro
       ClientConfig clientConfig,
       VeniceProperties backendConfig,
       Optional<Set<String>> managedClients,
-      ICProvider icProvider) {
+      ICProvider icProvider,
+      Executor readChunkExecutorForLargeRequest) {
     this(
         daVinciConfig,
         clientConfig,
@@ -157,7 +160,8 @@ public class AvroGenericDaVinciClient<K, V> implements DaVinciClient<K, V>, Avro
         managedClients,
         icProvider,
         GenericChunkingAdapter.INSTANCE,
-        () -> {});
+        () -> {},
+        readChunkExecutorForLargeRequest);
   }
 
   protected AvroGenericDaVinciClient(
@@ -167,7 +171,8 @@ public class AvroGenericDaVinciClient<K, V> implements DaVinciClient<K, V>, Avro
       Optional<Set<String>> managedClients,
       ICProvider icProvider,
       AbstractAvroChunkingAdapter<V> chunkingAdapter,
-      Runnable preValidation) {
+      Runnable preValidation,
+      Executor readChunkExecutorForLargeRequest) {
     logger.info("Creating client, storeName={}, daVinciConfig={}", clientConfig.getStoreName(), daVinciConfig);
     this.daVinciConfig = daVinciConfig;
     this.clientConfig = clientConfig;
@@ -175,6 +180,8 @@ public class AvroGenericDaVinciClient<K, V> implements DaVinciClient<K, V>, Avro
     this.managedClients = managedClients;
     this.icProvider = icProvider;
     this.chunkingAdapter = chunkingAdapter;
+    this.readChunkExecutorForLargeRequest =
+        readChunkExecutorForLargeRequest != null ? readChunkExecutorForLargeRequest : READ_CHUNK_EXECUTOR;
     preValidation.run();
   }
 
@@ -343,6 +350,10 @@ public class AvroGenericDaVinciClient<K, V> implements DaVinciClient<K, V>, Avro
     return this.daVinciConfig;
   }
 
+  Executor getReadChunkExecutorForLargeRequest() {
+    return this.readChunkExecutorForLargeRequest;
+  }
+
   CompletableFuture<Map<K, V>> batchGetFromLocalStorage(Iterable<K> keys) {
     // expose underlying getAll functionality.
     Map<K, V> result = new VeniceConcurrentHashMap<>();
@@ -392,8 +403,8 @@ public class AvroGenericDaVinciClient<K, V> implements DaVinciClient<K, V>, Avro
         CompletableFuture[] splitFutures = new CompletableFuture[splits.size()];
         for (int cur = 0; cur < splits.size(); ++cur) {
           List<K> currentSplit = splits.get(cur);
-          splitFutures[cur] =
-              CompletableFuture.runAsync(() -> keyArrayConsumer.accept(currentSplit), READ_CHUNK_EXECUTOR);
+          splitFutures[cur] = CompletableFuture
+              .runAsync(() -> keyArrayConsumer.accept(currentSplit), getReadChunkExecutorForLargeRequest());
         }
         CompletableFuture<Map<K, V>> resultFuture = new CompletableFuture<>();
         CompletableFuture.allOf(splitFutures).whenComplete((ignored, throwable) -> {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/client/AvroGenericDaVinciClient.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/client/AvroGenericDaVinciClient.java
@@ -112,7 +112,7 @@ public class AvroGenericDaVinciClient<K, V> implements DaVinciClient<K, V>, Avro
    * 1. Split the big request into smaller chunks.
    * 2. Execute these chunks concurrently.
    */
-  private static final ExecutorService READ_CHUNK_EXECUTOR = Executors.newFixedThreadPool(
+  public static final ExecutorService READ_CHUNK_EXECUTOR = Executors.newFixedThreadPool(
       Runtime.getRuntime().availableProcessors(),
       new DaemonThreadFactory("DaVinci_Read_Chunk_Executor"));
   public static final int DEFAULT_CHUNK_SPLIT_THRESHOLD = 100;

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/client/AvroSpecificDaVinciClient.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/client/AvroSpecificDaVinciClient.java
@@ -7,6 +7,7 @@ import com.linkedin.venice.service.ICProvider;
 import com.linkedin.venice.utils.VeniceProperties;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.Executor;
 import org.apache.avro.specific.SpecificRecord;
 
 
@@ -16,7 +17,8 @@ public class AvroSpecificDaVinciClient<K, V extends SpecificRecord> extends Avro
       ClientConfig clientConfig,
       VeniceProperties backendConfig,
       Optional<Set<String>> managedClients,
-      ICProvider icProvider) {
+      ICProvider icProvider,
+      Executor readChunkExecutorForLargeRequest) {
     super(
         daVinciConfig,
         clientConfig,
@@ -27,6 +29,7 @@ public class AvroSpecificDaVinciClient<K, V extends SpecificRecord> extends Avro
         () -> {
           Class<V> valueClass = clientConfig.getSpecificValueClass();
           FastSerializerDeserializerFactory.verifyWhetherFastSpecificDeserializerWorks(valueClass);
-        });
+        },
+        readChunkExecutorForLargeRequest);
   }
 }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/client/AvroGenericDaVinciClientTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/client/AvroGenericDaVinciClientTest.java
@@ -1,5 +1,6 @@
 package com.linkedin.davinci.client;
 
+import static com.linkedin.davinci.client.AvroGenericDaVinciClient.READ_CHUNK_EXECUTOR;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.mock;
@@ -10,7 +11,9 @@ import com.linkedin.alpini.base.concurrency.Executors;
 import com.linkedin.davinci.StoreBackend;
 import com.linkedin.davinci.VersionBackend;
 import com.linkedin.davinci.store.rocksdb.RocksDBServerConfig;
+import com.linkedin.venice.client.store.ClientConfig;
 import com.linkedin.venice.serializer.AvroSerializer;
+import com.linkedin.venice.service.ICProvider;
 import com.linkedin.venice.utils.DaemonThreadFactory;
 import com.linkedin.venice.utils.PropertyBuilder;
 import com.linkedin.venice.utils.ReferenceCounted;
@@ -19,6 +22,7 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.concurrent.ExecutionException;
@@ -109,5 +113,29 @@ public class AvroGenericDaVinciClientTest {
     for (int i = 0; i < keyCnt; ++i) {
       assertEquals(resultMap.get(keyPrefix + i), testValue);
     }
+  }
+
+  @Test
+  public void constructorTest() {
+    DaVinciConfig daVinciConfig = new DaVinciConfig();
+    ClientConfig clientConfig = mock(ClientConfig.class);
+    VeniceProperties backendConfig = mock(VeniceProperties.class);
+    ICProvider icProvider = mock(ICProvider.class);
+
+    AvroGenericDaVinciClient daVinciClient =
+        new AvroGenericDaVinciClient(daVinciConfig, clientConfig, backendConfig, Optional.empty(), icProvider, null);
+
+    assertEquals(daVinciClient.getReadChunkExecutorForLargeRequest(), READ_CHUNK_EXECUTOR);
+
+    Executor readChunkExecutor = mock(Executor.class);
+    daVinciClient = new AvroGenericDaVinciClient(
+        daVinciConfig,
+        clientConfig,
+        backendConfig,
+        Optional.empty(),
+        icProvider,
+        readChunkExecutor);
+    assertEquals(daVinciClient.getReadChunkExecutorForLargeRequest(), readChunkExecutor);
+
   }
 }


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Summary, imperative, start upper case, don't end with a period
This PR makes the read chunk executor pluggable.
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->


## How was this PR tested?
CI
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.