### PR TITLE
[davinci][test] Global RT DIV improvement (part 1): RT and VT DIV sep…

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/config/VeniceServerConfig.java
@@ -80,6 +80,7 @@ import static com.linkedin.venice.ConfigKeys.SERVER_DISK_HEALTH_CHECK_TIMEOUT_IN
 import static com.linkedin.venice.ConfigKeys.SERVER_ENABLE_LIVE_CONFIG_BASED_KAFKA_THROTTLING;
 import static com.linkedin.venice.ConfigKeys.SERVER_ENABLE_PARALLEL_BATCH_GET;
 import static com.linkedin.venice.ConfigKeys.SERVER_FORKED_PROCESS_JVM_ARGUMENT_LIST;
+import static com.linkedin.venice.ConfigKeys.SERVER_GLOBAL_RT_DIV_ENABLED;
 import static com.linkedin.venice.ConfigKeys.SERVER_HTTP2_HEADER_TABLE_SIZE;
 import static com.linkedin.venice.ConfigKeys.SERVER_HTTP2_INBOUND_ENABLED;
 import static com.linkedin.venice.ConfigKeys.SERVER_HTTP2_INITIAL_WINDOW_SIZE;
@@ -536,6 +537,7 @@ public class VeniceServerConfig extends VeniceClusterConfig {
   private final int nonCurrentVersionAAWCLeaderQuotaRecordsPerSecond;
   private final int nonCurrentVersionNonAAWCLeaderQuotaRecordsPerSecond;
   private final int channelOptionWriteBufferHighBytes;
+  private final boolean isGlobalRtDivEnabled;
 
   public VeniceServerConfig(VeniceProperties serverProperties) throws ConfigurationException {
     this(serverProperties, Collections.emptyMap());
@@ -892,6 +894,7 @@ public class VeniceServerConfig extends VeniceClusterConfig {
     channelOptionWriteBufferHighBytes = (int) serverProperties
         .getSizeInBytes(SERVER_CHANNEL_OPTION_WRITE_BUFFER_WATERMARK_HIGH_BYTES, WriteBufferWaterMark.DEFAULT.high()); // default
                                                                                                                        // 64KB
+    this.isGlobalRtDivEnabled = serverProperties.getBoolean(SERVER_GLOBAL_RT_DIV_ENABLED, true);
     if (channelOptionWriteBufferHighBytes <= 0) {
       throw new VeniceException("Invalid channel option write buffer high bytes: " + channelOptionWriteBufferHighBytes);
     }
@@ -1599,5 +1602,9 @@ public class VeniceServerConfig extends VeniceClusterConfig {
 
   public int getQuotaEnforcementCapacityMultiple() {
     return quotaEnforcementCapacityMultiple;
+  }
+
+  public boolean isGlobalRtDivEnabled() {
+    return isGlobalRtDivEnabled;
   }
 }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/store/rocksdb/RocksDBStorageEngineTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/store/rocksdb/RocksDBStorageEngineTest.java
@@ -9,7 +9,12 @@ import com.linkedin.davinci.stats.AggVersionedStorageEngineStats;
 import com.linkedin.davinci.storage.StorageService;
 import com.linkedin.davinci.store.AbstractStorageEngine;
 import com.linkedin.davinci.store.AbstractStorageEngineTest;
+import com.linkedin.venice.guid.GuidUtils;
+import com.linkedin.venice.kafka.protocol.GUID;
+import com.linkedin.venice.kafka.protocol.state.ProducerPartitionState;
 import com.linkedin.venice.kafka.protocol.state.StoreVersionState;
+import com.linkedin.venice.kafka.validation.SegmentStatus;
+import com.linkedin.venice.kafka.validation.checksum.CheckSumType;
 import com.linkedin.venice.meta.PersistenceType;
 import com.linkedin.venice.meta.ReadOnlyStoreRepository;
 import com.linkedin.venice.meta.Store;
@@ -18,7 +23,10 @@ import com.linkedin.venice.offsets.OffsetRecord;
 import com.linkedin.venice.serialization.avro.AvroProtocolDefinition;
 import com.linkedin.venice.utils.Utils;
 import com.linkedin.venice.utils.VeniceProperties;
+import java.nio.ByteBuffer;
+import java.util.HashMap;
 import java.util.Set;
+import org.apache.avro.util.Utf8;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterMethod;
@@ -117,11 +125,38 @@ public class RocksDBStorageEngineTest extends AbstractStorageEngineTest {
     Assert.assertEquals(testStorageEngine.getType(), PersistenceType.ROCKS_DB);
     RocksDBStorageEngine rocksDBStorageEngine = (RocksDBStorageEngine) testStorageEngine;
     OffsetRecord offsetRecord = new OffsetRecord(AvroProtocolDefinition.PARTITION_STATE.getSerializer());
+
+    int segment = 0;
+    int sequence = 10;
+    ProducerPartitionState ppState = createProducerPartitionState(segment, sequence);
+    GUID guid = new GUID();
+    offsetRecord.setRealtimeTopicProducerState(guid, ppState);
     offsetRecord.setCheckpointLocalVersionTopicOffset(666L);
     rocksDBStorageEngine.putPartitionOffset(PARTITION_ID, offsetRecord);
     Assert.assertEquals(rocksDBStorageEngine.getPartitionOffset(PARTITION_ID).get().getLocalVersionTopicOffset(), 666L);
+    ProducerPartitionState ppStateFromRocksDB =
+        rocksDBStorageEngine.getPartitionOffset(PARTITION_ID).get().getRealTimeProducerState().get(guidToUtf8(guid));
+    Assert.assertEquals(ppStateFromRocksDB.getSegmentNumber(), segment);
+    Assert.assertEquals(ppStateFromRocksDB.getMessageSequenceNumber(), sequence);
     rocksDBStorageEngine.clearPartitionOffset(PARTITION_ID);
     Assert.assertEquals(rocksDBStorageEngine.getPartitionOffset(PARTITION_ID).isPresent(), false);
+  }
+
+  private ProducerPartitionState createProducerPartitionState(int segment, int sequence) {
+    ProducerPartitionState ppState = new ProducerPartitionState();
+    ppState.segmentNumber = segment;
+    ppState.segmentStatus = SegmentStatus.IN_PROGRESS.getValue();
+    ppState.messageSequenceNumber = sequence;
+    ppState.messageTimestamp = System.currentTimeMillis();
+    ppState.checksumType = CheckSumType.NONE.getValue();
+    ppState.checksumState = ByteBuffer.allocate(0);
+    ppState.aggregates = new HashMap<>();
+    ppState.debugInfo = new HashMap<>();
+    return ppState;
+  }
+
+  private CharSequence guidToUtf8(GUID guid) {
+    return new Utf8(GuidUtils.getCharSequenceFromGuid(guid));
   }
 
   @Test

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/validation/KafkaDataIntegrityValidatorTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/validation/KafkaDataIntegrityValidatorTest.java
@@ -81,7 +81,7 @@ public class KafkaDataIntegrityValidatorTest {
         time.getMilliseconds(),
         p0offsetRecord,
         checkSumType);
-    validator.validateMessage(p0g0record0, false, Lazy.FALSE);
+    validator.validateMessage(PartitionTracker.TopicType.VERSION_TOPIC, p0g0record0, false, Lazy.FALSE);
 
     time.sleep(10);
 
@@ -93,20 +93,20 @@ public class KafkaDataIntegrityValidatorTest {
         seqNumberForPartition0Guid1++,
         time.getMilliseconds(),
         p0offsetRecord);
-    validator.validateMessage(p0g0record1, false, Lazy.FALSE);
+    validator.validateMessage(PartitionTracker.TopicType.VERSION_TOPIC, p0g0record1, false, Lazy.FALSE);
 
     assertEquals(validator.getNumberOfTrackedPartitions(), 1);
     assertEquals(validator.getNumberOfTrackedProducerGUIDs(), 1);
 
     // Nothing should be cleared yet
-    validator.updateOffsetRecordForPartition(0, p0offsetRecord);
+    validator.updateOffsetRecordForPartition(PartitionTracker.TopicType.VERSION_TOPIC, 0, p0offsetRecord);
     assertEquals(validator.getNumberOfTrackedPartitions(), 1);
     assertEquals(validator.getNumberOfTrackedProducerGUIDs(), 1);
 
     // Even if we wait some more, the state should still be retained, since the wall-clock time does not matter, only
     // the last consumed time does.
     time.sleep(2 * maxAgeInMs);
-    validator.updateOffsetRecordForPartition(0, p0offsetRecord);
+    validator.updateOffsetRecordForPartition(PartitionTracker.TopicType.VERSION_TOPIC, 0, p0offsetRecord);
     assertEquals(validator.getNumberOfTrackedPartitions(), 1);
     assertEquals(validator.getNumberOfTrackedProducerGUIDs(), 1);
 
@@ -123,12 +123,12 @@ public class KafkaDataIntegrityValidatorTest {
         time.getMilliseconds(),
         p0offsetRecord,
         checkSumType);
-    validator.validateMessage(p0g1record0, false, Lazy.FALSE);
+    validator.validateMessage(PartitionTracker.TopicType.VERSION_TOPIC, p0g1record0, false, Lazy.FALSE);
     assertEquals(validator.getNumberOfTrackedPartitions(), 1);
     assertEquals(validator.getNumberOfTrackedProducerGUIDs(), 2);
 
     // After calling clear, now we should see the update to the internal state...
-    validator.updateOffsetRecordForPartition(0, p0offsetRecord);
+    validator.updateOffsetRecordForPartition(PartitionTracker.TopicType.VERSION_TOPIC, 0, p0offsetRecord);
     assertEquals(validator.getNumberOfTrackedPartitions(), 1);
     assertEquals(validator.getNumberOfTrackedProducerGUIDs(), 1);
 
@@ -140,7 +140,7 @@ public class KafkaDataIntegrityValidatorTest {
         time.getMilliseconds(),
         p1offsetRecord,
         checkSumType);
-    validator.validateMessage(p1g0record0, false, Lazy.FALSE);
+    validator.validateMessage(PartitionTracker.TopicType.VERSION_TOPIC, p1g0record0, false, Lazy.FALSE);
     assertEquals(validator.getNumberOfTrackedPartitions(), 2);
     assertEquals(validator.getNumberOfTrackedProducerGUIDs(), 2);
 
@@ -155,13 +155,13 @@ public class KafkaDataIntegrityValidatorTest {
         p0offsetRecord);
     assertThrows(
         ImproperlyStartedSegmentException.class,
-        () -> validator.validateMessage(p0g0record2, false, Lazy.FALSE));
+        () -> validator.validateMessage(PartitionTracker.TopicType.VERSION_TOPIC, p0g0record2, false, Lazy.FALSE));
     assertEquals(validator.getNumberOfTrackedPartitions(), 2);
     assertEquals(validator.getNumberOfTrackedProducerGUIDs(), 2);
 
     // This is a stable state, so no changes are expected...
-    validator.updateOffsetRecordForPartition(0, p0offsetRecord);
-    validator.updateOffsetRecordForPartition(1, p1offsetRecord);
+    validator.updateOffsetRecordForPartition(PartitionTracker.TopicType.VERSION_TOPIC, 0, p0offsetRecord);
+    validator.updateOffsetRecordForPartition(PartitionTracker.TopicType.VERSION_TOPIC, 1, p1offsetRecord);
     assertEquals(validator.getNumberOfTrackedPartitions(), 2);
     assertEquals(validator.getNumberOfTrackedProducerGUIDs(), 2);
   }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -2238,4 +2238,5 @@ public class ConfigKeys {
 
   public static final String SERVER_CHANNEL_OPTION_WRITE_BUFFER_WATERMARK_HIGH_BYTES =
       "server.channel.option.write.buffer.watermark.high.bytes";
+  public static final String SERVER_GLOBAL_RT_DIV_ENABLED = "server.global.rt.div.enabled";
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/offsets/OffsetRecord.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/offsets/OffsetRecord.java
@@ -69,6 +69,7 @@ public class OffsetRecord {
     emptyPartitionState.leaderOffset = DEFAULT_UPSTREAM_OFFSET;
     emptyPartitionState.upstreamOffsetMap = new VeniceConcurrentHashMap<>();
     emptyPartitionState.upstreamVersionTopicOffset = DEFAULT_UPSTREAM_OFFSET;
+    emptyPartitionState.setRealtimeTopicProducerStates(new VeniceConcurrentHashMap<>());
     return emptyPartitionState;
   }
 
@@ -141,6 +142,18 @@ public class OffsetRecord {
 
   public synchronized Map<CharSequence, ProducerPartitionState> getProducerPartitionStateMap() {
     return this.partitionState.producerStates;
+  }
+
+  public synchronized void setRealtimeTopicProducerState(GUID producerGuid, ProducerPartitionState state) {
+    this.partitionState.getRealtimeTopicProducerStates().put(guidToUtf8(producerGuid), state);
+  }
+
+  public synchronized void removeRealTimeTopicProducerState(GUID producerGuid) {
+    this.partitionState.getRealtimeTopicProducerStates().remove(guidToUtf8(producerGuid));
+  }
+
+  public synchronized Map<CharSequence, ProducerPartitionState> getRealTimeProducerState() {
+    return this.partitionState.getRealtimeTopicProducerStates();
   }
 
   public synchronized ProducerPartitionState getProducerPartitionState(GUID producerGuid) {

--- a/internal/venice-common/src/main/java/com/linkedin/venice/serialization/avro/AvroProtocolDefinition.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/serialization/avro/AvroProtocolDefinition.java
@@ -51,7 +51,7 @@ public enum AvroProtocolDefinition {
    * Used to persist the state of a partition in Storage Nodes, including offset,
    * Data Ingest Validation state, etc.
    */
-  PARTITION_STATE(24, 12, PartitionState.class),
+  PARTITION_STATE(24, 13, PartitionState.class),
 
   /**
    * Used to persist state related to a store-version, including Start of Buffer Replay

--- a/internal/venice-common/src/main/resources/avro/PartitionState/v13/PartitionState.avsc
+++ b/internal/venice-common/src/main/resources/avro/PartitionState/v13/PartitionState.avsc
@@ -1,0 +1,178 @@
+{
+  "name": "PartitionState",
+  "namespace": "com.linkedin.venice.kafka.protocol.state",
+  "doc": "This record holds the state necessary for a consumer to checkpoint its progress when consuming a Venice partition. When provided the state in this record, a consumer should thus be able to resume consuming midway through a stream.",
+  "type": "record",
+  "fields": [
+    {
+      "name": "offset",
+      "doc": "The last Kafka offset consumed successfully in this partition from version topic.",
+      "type": "long"
+    }, {
+      "name": "offsetLag",
+      "doc": "The last Kafka offset lag in this partition for fast online transition in server restart.",
+      "type": "long",
+      "default": -1
+    }, {
+      "name": "endOfPush",
+      "doc": "Whether the EndOfPush control message was consumed in this partition.",
+      "type": "boolean"
+    }, {
+      "name": "lastUpdate",
+      "doc": "The last time this PartitionState was updated. Can be compared against the various messageTimestamp in ProducerPartitionState in order to infer lag time between producers and the consumer maintaining this PartitionState.",
+      "type": "long"
+    }, {
+      "name": "startOfBufferReplayDestinationOffset",
+      "doc": "This is the offset at which the StartOfBufferReplay control message was consumed in the current partition of the destination topic. This is not the same value as the source offsets contained in the StartOfBufferReplay control message itself. The source and destination offsets act together as a synchronization marker. N.B.: null means that the SOBR control message was not received yet.",
+      "type": ["null", "long"],
+      "default": null
+    }, {
+      "name": "databaseInfo",
+      "doc": "A map of string -> string to store database related info, which is necessary to checkpoint",
+      "type": {
+        "type": "map",
+        "values": "string"
+      },
+      "default": {}
+    }, {
+      "name": "incrementalPushInfo",
+      "doc": "metadata of ongoing incremental push in the partition",
+      "type": [
+        "null",
+        {
+          "name": "IncrementalPush",
+          "type": "record",
+          "fields": [
+            {
+              "name": "version",
+              "doc": "The version of current incremental push",
+              "type": "string"
+            }, {
+              "name": "error",
+              "doc": "The first error founded during in`gestion",
+              "type": ["null", "string"],
+              "default": null
+            }
+          ]
+        }
+      ],
+      "default": null
+    }, {
+      "name": "leaderTopic",
+      "type": ["null", "string"],
+      "doc": "The topic that leader is consuming from; for leader, leaderTopic can be different from the version topic; for follower, leaderTopic is the same as version topic.",
+      "default": null
+    }, {
+      "name": "leaderOffset",
+      "type": "long",
+      "doc": "The last Kafka offset consumed successfully in this partition from the leader topic. TODO: remove this field once upstreamOffsetMap is used everywhere.",
+      "default": -1
+    }, {
+      "name": "upstreamOffsetMap",
+      "type": {
+        "type": "map",
+        "values": "long",
+        "java-key-class": "java.lang.String",
+        "avro.java.string": "String"
+      },
+      "doc": "A map of upstream Kafka bootstrap server url -> the last Kafka offset consumed from upstream topic.",
+      "default": {}
+    }, {
+      "name": "upstreamVersionTopicOffset",
+      "type": "long",
+      "doc": "The last upstream version topic offset persisted to disk; if the batch native-replication source is the same as local region, this value will always be -1",
+      "default": -1
+    }, {
+      "name": "leaderGUID",
+      "type": [
+        "null",
+        {
+          "namespace": "com.linkedin.venice.kafka.protocol",
+          "name": "GUID",
+          "type": "fixed",
+          "size": 16
+        }
+      ],
+      "doc": "This field is deprecated since GUID is no longer able to identify the split-brain issue once 'pass-through' mode is enabled in venice writer. The field is superseded by leaderHostId and will be removed in the future ",
+      "default": null
+    }, {
+      "name": "leaderHostId",
+      "type": ["null", "string"],
+      "doc": "An unique identifier (such as host name) that stands for each host. It's used to identify if there is a split-brain happened while the leader(s) re-produce records",
+      "default": null
+    }, {
+      "name": "producerStates",
+      "doc": "A map of producer GUID -> producer state.",
+      "type": {
+        "type": "map",
+        "values": {
+          "name": "ProducerPartitionState",
+          "doc": "A record containing the state pertaining to the data sent by one upstream producer into one partition.",
+          "type": "record",
+          "fields": [
+            {
+              "name": "segmentNumber",
+              "doc": "The current segment number corresponds to the last (highest) segment number for which we have seen a StartOfSegment control message.",
+              "type": "int"
+            }, {
+              "name": "segmentStatus",
+              "doc": "The status of the current segment: 0 => NOT_STARTED, 1 => IN_PROGRESS, 2 => END_OF_INTERMEDIATE_SEGMENT, 3 => END_OF_FINAL_SEGMENT.",
+              "type": "int"
+            }, {
+              "name": "isRegistered",
+              "doc": "Whether the segment is registered. i.e. received Start_Of_Segment to initialize the segment.",
+              "type": "boolean",
+              "default": false
+            }, {
+              "name": "messageSequenceNumber",
+              "doc": "The current message sequence number, within the current segment, which we have seen for this partition/producer pair.",
+              "type": "int"
+            }, {
+              "name": "messageTimestamp",
+              "doc": "The timestamp included in the last message we have seen for this partition/producer pair.",
+              "type": "long"
+            }, {
+              "name": "checksumType",
+              "doc": "The current mapping is the following: 0 => None, 1 => MD5, 2 => Adler32, 3 => CRC32.",
+              "type": "int"
+            }, {
+              "name": "checksumState",
+              "doc": "The value of the checksum computed since the last StartOfSegment ControlMessage.",
+              "type": "bytes"
+            }, {
+              "name": "aggregates",
+              "doc": "The aggregates that have been computed so far since the last StartOfSegment ControlMessage.",
+              "type": {
+                "type": "map",
+                "values": "long"
+              }
+            }, {
+              "name": "debugInfo",
+              "doc": "The debug info received as part of the last StartOfSegment ControlMessage.",
+              "type": {
+                "type": "map",
+                "values": "string"
+              }
+            }
+          ]
+        }
+      }
+    }, {
+      "name": "previousStatuses",
+      "doc": "A map of string -> string which stands for previous PartitionStatus",
+      "type": {
+        "type": "map",
+        "values": "string"
+      },
+      "default": {}
+    }, {
+      "name": "realtimeTopicProducerStates",
+      "doc": "A map of producer GUID -> producer state for real-time data.",
+      "type": {
+        "type": "map",
+        "values": "com.linkedin.venice.kafka.protocol.state.ProducerPartitionState"
+      },
+      "default": {}
+    }
+  ]
+}

--- a/internal/venice-common/src/test/java/com/linkedin/venice/schema/TestAvroSchema.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/schema/TestAvroSchema.java
@@ -65,6 +65,7 @@ public class TestAvroSchema {
     ps.upstreamOffsetMap = upstreamOffsetMap;
     ps.producerStates = Collections.emptyMap();
     ps.previousStatuses = Collections.emptyMap();
+    ps.setRealtimeTopicProducerStates(Collections.emptyMap());
 
     AvroSerializer serializer = new AvroSerializer(ps.getSchema());
     byte[] serializedBytes = serializer.serialize(ps);


### PR DESCRIPTION
…aration

This is the first part of the implementation for global DIV improvement, this PR contains the following:

1. introduce a new flag for the global RT div feature.
2. introduce a new realtimeTopicProducerStates in PartitionState in the local RocksDB checkpoint.
```
     {
      "name": "realtimeTopicProducerStates",
      "doc": "A map of producer GUID -> producer state for real-time data.",
      "type": {
        "type": "map",
        "values": "com.linkedin.venice.kafka.protocol.state.ProducerPartitionState"
      },
      "default": {}
    }
```
3. divide today's PartitionTracker's DIV into two groups VT and RT div, so that each group can be updated separately based on where the records comes from. (When the feature is disabled, only VT DIV is updated).
4. Add a test to verify the read/write of an OffsetRecord with new the new added field.

## How was this PR tested?
CI passed (with feature enabled or disabled)


## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.