### PR TITLE
[doc][script] Automatically verify JDK version in gradle, and specify in docs users need to set their JAVA_HOME

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -799,12 +799,11 @@ allprojects {
   task printAllDependencies(type: DependencyReportTask) {}
 }
 
-def supportedJdkVersions = ["8", "11", "17"]
+def supportedJdkVersions = [JavaVersion.VERSION_1_8, JavaVersion.VERSION_11, JavaVersion.VERSION_17]
 
 task verifyJdkVersion {
-  def currentJdkVersion = System.getProperty('java.version')
-  def currentJdkMajorVersion = currentJdkVersion.startsWith('1.') ? currentJdkVersion.split("\\.")[1] : currentJdkVersion.split("\\.")[0]
-  def isSupported = supportedJdkVersions.any {majorVersion -> currentJdkMajorVersion.equals(majorVersion) }
+  def currentJdkVersion = JavaVersion.current()
+  def isSupported = supportedJdkVersions.any {majorVersion -> currentJdkVersion.equals(majorVersion) }
   if (!isSupported) {
     throw new GradleException("Invalid JDK version: ${currentJdkVersion}. Supported versions: ${supportedJdkVersions.join(', ')}.")
   }

--- a/build.gradle
+++ b/build.gradle
@@ -803,7 +803,7 @@ def supportedJdkVersions = [JavaVersion.VERSION_1_8, JavaVersion.VERSION_11, Jav
 
 task verifyJdkVersion {
   def currentJdkVersion = JavaVersion.current()
-  def isSupported = supportedJdkVersions.any {majorVersion -> currentJdkVersion.equals(majorVersion) }
+  def isSupported = supportedJdkVersions.any {version -> currentJdkVersion.equals(version) }
   if (!isSupported) {
     throw new GradleException("Invalid JDK version: ${currentJdkVersion}. Supported versions: ${supportedJdkVersions.join(', ')}.")
   }

--- a/build.gradle
+++ b/build.gradle
@@ -803,7 +803,7 @@ def supportedJdkVersions = ["8", "11", "17"]
 
 task verifyJdkVersion {
   def currentJdkVersion = System.getProperty('java.version')
-  def currentJdkMajorVersion = currentJdkVersion.split("\\.")[0]
+  def currentJdkMajorVersion = currentJdkVersion.startsWith('1.') ? currentJdkVersion.split("\\.")[1] : currentJdkVersion.split("\\.")[0]
   def isSupported = supportedJdkVersions.any {majorVersion -> currentJdkMajorVersion.equals(majorVersion) }
   if (!isSupported) {
     throw new GradleException("Invalid JDK version: ${currentJdkVersion}. Supported versions: ${supportedJdkVersions.join(', ')}.")

--- a/build.gradle
+++ b/build.gradle
@@ -798,3 +798,20 @@ ext.parseJacocoXml = { filePath ->
 allprojects {
   task printAllDependencies(type: DependencyReportTask) {}
 }
+
+def supportedJdkVersions = ["8", "11", "17"]
+
+task verifyJdkVersion {
+  def currentJdkVersion = System.getProperty('java.version')
+  def currentJdkMajorVersion = currentJdkVersion.split("\\.")[0]
+  def isSupported = supportedJdkVersions.any {majorVersion -> currentJdkMajorVersion.equals(majorVersion) }
+  if (!isSupported) {
+    throw new GradleException("Invalid JDK version: ${currentJdkVersion}. Supported versions: ${supportedJdkVersions.join(', ')}.")
+  }
+  println "JDK version ${currentJdkVersion} is valid."
+}
+
+gradle.taskGraph.whenReady {
+  // Ensure the JDK version is verified before any other tasks
+  verifyJdkVersion
+}

--- a/docs/dev_guide/how_to/workspace_setup.md
+++ b/docs/dev_guide/how_to/workspace_setup.md
@@ -24,6 +24,9 @@ git fetch upstream
 ## Setting up Java
 We use Java 17 for development. You can download it [here](https://www.oracle.com/java/technologies/javase/jdk17-archive-downloads.html).
 
+Make sure to set the `JAVA_HOME` environment variable to the location of your JDK installation.
+How to do this will be dependent on your OS.
+
 ## Setting up the IDE
 We recommend using IntelliJ IDEA for development to take advantage of the debugger, and provide instructions for it.
 However, any IDE of your choice should work.


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Summary, imperative, start upper case, don't end with a period
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

1. When users are on the wrong version, the error message when running gradle tasks can be cryptic. So verifying their JDK version before running other tasks will make it easier for users to debug.
2. The docs mention to download JDK 17, but it doesn't explicitly mention to add it to their JAVA_HOME.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
Tested locally

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [ ] No. You can skip the rest of this section.
- [X] Yes. Make sure to explain your proposed changes and call out the behavior change.

Users will receive an explicit error message when using the incorrect JDK version.