### PR TITLE
[router][venice-thin-client] Add safeguard against invalid schema ID

### DIFF
--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/schema/RouterBackedSchemaReader.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/schema/RouterBackedSchemaReader.java
@@ -324,9 +324,13 @@ public class RouterBackedSchemaReader implements SchemaReader {
         valueSchemaIdSet = fetchAllValueSchemaIdsFromRouter();
       } catch (Exception e) {
         LOGGER.warn(
-            "Caught exception when trying to fetch all value schema IDs from router, will fetch all value schema entries instead.");
+            "Caught exception when trying to fetch all value schema IDs from router, will fetch all value schema entries instead.",
+            e);
         // Fall back to fetch all value schema.
         for (SchemaEntry valueSchemaEntry: fetchAllValueSchemaEntriesFromRouter()) {
+          if (!isValidSchemaEntry(valueSchemaEntry)) {
+            continue;
+          }
           valueSchemaEntryMap.put(valueSchemaEntry.getId(), valueSchemaEntry);
           cacheValueAndCanonicalSchemas(valueSchemaEntry.getSchema(), valueSchemaEntry.getId());
         }
@@ -441,7 +445,7 @@ public class RouterBackedSchemaReader implements SchemaReader {
        * one active value schema.
        */
       synchronized (this) {
-        if (latest != null && !shouldRefreshLatestValueSchemaEntry.get()) {
+        if (latest != null && !shouldRefreshLatestValueSchemaEntry.get() && isValidSchemaEntry(latest)) {
           return latest;
         }
         updateAllValueSchemaEntriesAndLatestValueSchemaEntry(false);
@@ -449,6 +453,9 @@ public class RouterBackedSchemaReader implements SchemaReader {
         latestValueSchemaEntry.set(latestValueSchemaEntry.get());
         latest = latestValueSchemaEntry.get();
       }
+    }
+    if (!isValidSchemaEntry(latest)) {
+      throw new VeniceClientException("Could not find latest value schema for store " + storeName);
     }
     return latest;
   }

--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/schema/RouterBackedSchemaReader.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/schema/RouterBackedSchemaReader.java
@@ -455,7 +455,7 @@ public class RouterBackedSchemaReader implements SchemaReader {
       }
     }
     if (latest == null || !isValidSchemaEntry(latest)) {
-      throw new VeniceClientException("Could not find latest value schema for store " + storeName);
+      throw new VeniceClientException("Failed to get latest value schema for store: " + storeName);
     }
     return latest;
   }

--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/schema/RouterBackedSchemaReader.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/schema/RouterBackedSchemaReader.java
@@ -454,7 +454,7 @@ public class RouterBackedSchemaReader implements SchemaReader {
         latest = latestValueSchemaEntry.get();
       }
     }
-    if (!isValidSchemaEntry(latest)) {
+    if (latest == null || !isValidSchemaEntry(latest)) {
       throw new VeniceClientException("Could not find latest value schema for store " + storeName);
     }
     return latest;

--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/AbstractAvroComputeRequestBuilder.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/AbstractAvroComputeRequestBuilder.java
@@ -21,6 +21,7 @@ import com.linkedin.venice.compute.protocol.request.CosineSimilarity;
 import com.linkedin.venice.compute.protocol.request.DotProduct;
 import com.linkedin.venice.compute.protocol.request.HadamardProduct;
 import com.linkedin.venice.compute.protocol.request.enums.ComputeOperationType;
+import com.linkedin.venice.schema.SchemaData;
 import com.linkedin.venice.schema.SchemaReader;
 import com.linkedin.venice.utils.Pair;
 import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
@@ -80,6 +81,9 @@ public abstract class AbstractAvroComputeRequestBuilder<K> implements ComputeReq
 
   public AbstractAvroComputeRequestBuilder(AvroGenericReadComputeStoreClient storeClient, SchemaReader schemaReader) {
     this.latestValueSchemaId = schemaReader.getLatestValueSchemaId();
+    if (latestValueSchemaId == SchemaData.INVALID_VALUE_SCHEMA_ID) {
+      throw new VeniceClientException("Invalid value schema ID: " + latestValueSchemaId);
+    }
     this.latestValueSchema = schemaReader.getValueSchema(latestValueSchemaId);
     if (latestValueSchema.getType() != Schema.Type.RECORD) {
       throw new VeniceClientException("Only value schema with 'RECORD' type is supported");

--- a/clients/venice-thin-client/src/test/java/com/linkedin/venice/client/schema/RouterBackedSchemaReaderTest.java
+++ b/clients/venice-thin-client/src/test/java/com/linkedin/venice/client/schema/RouterBackedSchemaReaderTest.java
@@ -386,7 +386,7 @@ public class RouterBackedSchemaReaderTest {
         0);
 
     try (SchemaReader schemaReader = new RouterBackedSchemaReader(() -> mockClient)) {
-      Assert.assertNull(schemaReader.getLatestValueSchema());
+      Assert.assertThrows(VeniceClientException.class, () -> schemaReader.getLatestValueSchema());
       Mockito.verify(mockClient, Mockito.timeout(TIMEOUT).times(1)).getRaw(Mockito.anyString());
     }
   }

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/MetaDataHandler.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/MetaDataHandler.java
@@ -311,7 +311,7 @@ public class MetaDataHandler extends SimpleChannelInboundHandler<HttpRequest> {
         responseObject.setSuperSetSchemaId(superSetSchemaId);
       }
       Collection<SchemaEntry> valueSchemaEntries = schemaRepo.getValueSchemas(storeName);
-      int schemaNum = valueSchemaEntries.size();
+      int schemaNum = (int) valueSchemaEntries.stream().filter(schemaEntry -> schemaEntry.getId() > 0).count();
       MultiSchemaResponse.Schema[] schemas = new MultiSchemaResponse.Schema[schemaNum];
       int index = 0;
       for (SchemaEntry entry: valueSchemaEntries) {
@@ -321,7 +321,7 @@ public class MetaDataHandler extends SimpleChannelInboundHandler<HttpRequest> {
               "Got an invalid schema id ({}) for store {} in handleValueSchemaLookup; will not include this in the {}.",
               entry.getId(),
               storeName,
-              MultiSchemaIdResponse.class.getSimpleName());
+              responseObject.getClass().getSimpleName());
           continue;
         }
         schemas[index] = new MultiSchemaResponse.Schema();
@@ -398,7 +398,7 @@ public class MetaDataHandler extends SimpleChannelInboundHandler<HttpRequest> {
             "Got an invalid schema id ({}) for store {} in handleValueSchemaIdsLookup; will not include this in the {}.",
             entry.getId(),
             storeName,
-            MultiSchemaIdResponse.class.getSimpleName());
+            responseObject.getClass().getSimpleName());
         continue;
       }
       schemaIdSet.add(entry.getId());

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/MetaDataHandler.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/MetaDataHandler.java
@@ -316,6 +316,14 @@ public class MetaDataHandler extends SimpleChannelInboundHandler<HttpRequest> {
       int index = 0;
       for (SchemaEntry entry: valueSchemaEntries) {
         int schemaId = entry.getId();
+        if (schemaId < 1) {
+          LOGGER.warn(
+              "Got an invalid schema id ({}) for store {} in handleValueSchemaLookup; will not include this in the {}.",
+              entry.getId(),
+              storeName,
+              MultiSchemaIdResponse.class.getSimpleName());
+          continue;
+        }
         schemas[index] = new MultiSchemaResponse.Schema();
         schemas[index].setId(schemaId);
         schemas[index].setSchemaStr(entry.getSchema().toString());
@@ -385,6 +393,14 @@ public class MetaDataHandler extends SimpleChannelInboundHandler<HttpRequest> {
     }
     Set<Integer> schemaIdSet = new HashSet<>();
     for (SchemaEntry entry: schemaRepo.getValueSchemas(storeName)) {
+      if (entry.getId() < 1) {
+        LOGGER.warn(
+            "Got an invalid schema id ({}) for store {} in handleValueSchemaIdsLookup; will not include this in the {}.",
+            entry.getId(),
+            storeName,
+            MultiSchemaIdResponse.class.getSimpleName());
+        continue;
+      }
       schemaIdSet.add(entry.getId());
     }
     responseObject.setSchemaIdSet(schemaIdSet);

--- a/services/venice-router/src/test/java/com/linkedin/venice/router/TestMetaDataHandler.java
+++ b/services/venice-router/src/test/java/com/linkedin/venice/router/TestMetaDataHandler.java
@@ -348,7 +348,10 @@ public class TestMetaDataHandler {
     ReadOnlySchemaRepository schemaRepo = Mockito.mock(ReadOnlySchemaRepository.class);
     SchemaEntry valueSchemaEntry1 = new SchemaEntry(valueSchemaId1, valueSchemaStr1);
     SchemaEntry valueSchemaEntry2 = new SchemaEntry(valueSchemaId2, valueSchemaStr2);
-    Mockito.doReturn(Arrays.asList(valueSchemaEntry1, valueSchemaEntry2)).when(schemaRepo).getValueSchemas(storeName);
+    SchemaEntry valueSchemaEntry3 = new SchemaEntry(-1, valueSchemaStr2);
+    Mockito.doReturn(Arrays.asList(valueSchemaEntry1, valueSchemaEntry2, valueSchemaEntry3))
+        .when(schemaRepo)
+        .getValueSchemas(storeName);
     FullHttpResponse response = passRequestToMetadataHandler(
         "http://myRouterHost:4567/all_value_schema_ids/" + storeName,
         null,
@@ -412,7 +415,8 @@ public class TestMetaDataHandler {
     SchemaEntry valueSchemaEntry1 = new SchemaEntry(valueSchemaId1, valueSchemaStr1);
     SchemaEntry valueSchemaEntry2 = new SchemaEntry(valueSchemaId2, valueSchemaStr2);
     SchemaEntry valueSchemaEntry3 = new SchemaEntry(valueSchemaId3, valueSchemaStr3);
-    Mockito.doReturn(Arrays.asList(valueSchemaEntry1, valueSchemaEntry2, valueSchemaEntry3))
+    SchemaEntry valueSchemaEntry4 = new SchemaEntry(-1, valueSchemaStr3);
+    Mockito.doReturn(Arrays.asList(valueSchemaEntry1, valueSchemaEntry2, valueSchemaEntry3, valueSchemaEntry4))
         .when(schemaRepo)
         .getValueSchemas(storeName);
 


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Add safeguard against invalid schema ID in value schema lookup
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

If schema repo returns invalid schema id, that fails client requests. This PR adds safeguard against such invalid schemas in meta data handler and client side schema reader.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
CI
## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.