### PR TITLE
[all] Minor code cleanup in various enums

### DIFF
--- a/docs/dev_guide/how_to/style_guide.md
+++ b/docs/dev_guide/how_to/style_guide.md
@@ -42,6 +42,20 @@ rules and there may be good reasons to deviate from them occasionally. When devi
 explaining why we deviated, whether it was intentional, or due to the need for expediency. This helps future maintainers 
 understand what is actually worth cleaning up and how careful they need to be when doing it.
 
+### Compatibility
+
+We care about compatibility across versions of the software. This is a bidirectional statement. Old clients need to be
+able to talk with new servers, and new clients with old servers as well. It also includes interactions across lifetimes
+of the same process, for example, state persisted by an old version of the server code should be usable by a newer 
+version of the server code, and vice versa. If compatibility is impossible, then we should look for ways to achieve
+correct behavior anyway (e.g. potentially at the cost of efficiency, such as the server needing to throw away and
+regenerate the state).
+
+For enums which are going to be communicated across processes or across lifetimes of the same process, consider using 
+[VeniceEnumValue](http://venicedb.org/javadoc/com/linkedin/venice/utils/VeniceEnumValue.html), [EnumUtils](http://venicedb.org/javadoc/com/linkedin/venice/utils/EnumUtils.html)
+and related unit test classes, which provide a structure to minimize the chance that we mistakenly change the mapping of
+numeric ID -> enum value.
+
 ### JavaDoc
 
 Speaking of comments, we ideally want JavaDoc at the top of all classes. The top of class JavaDoc should indicate the

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/compression/CompressionStrategy.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/compression/CompressionStrategy.java
@@ -1,8 +1,8 @@
 package com.linkedin.venice.compression;
 
-import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.utils.EnumUtils;
 import com.linkedin.venice.utils.VeniceEnumValue;
+import java.util.List;
 
 
 /**
@@ -15,13 +15,14 @@ public enum CompressionStrategy implements VeniceEnumValue {
   private final int value;
   private final boolean compressionEnabled;
 
-  private static final CompressionStrategy[] TYPES_ARRAY = EnumUtils.getEnumValuesArray(CompressionStrategy.class);
+  private static final List<CompressionStrategy> TYPES = EnumUtils.getEnumValuesList(CompressionStrategy.class);
 
   CompressionStrategy(int value, boolean compressionEnabled) {
     this.value = value;
     this.compressionEnabled = compressionEnabled;
   }
 
+  @Override
   public int getValue() {
     return value;
   }
@@ -31,14 +32,10 @@ public enum CompressionStrategy implements VeniceEnumValue {
   }
 
   public static CompressionStrategy valueOf(int value) {
-    try {
-      return TYPES_ARRAY[value];
-    } catch (IndexOutOfBoundsException e) {
-      throw new VeniceException("Invalid compression strategy: " + value);
-    }
+    return EnumUtils.valueOf(TYPES, value, CompressionStrategy.class);
   }
 
   public static int getCompressionStrategyTypesArrayLength() {
-    return TYPES_ARRAY.length;
+    return TYPES.size();
   }
 }

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/compute/protocol/request/enums/ComputeOperationType.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/compute/protocol/request/enums/ComputeOperationType.java
@@ -13,6 +13,7 @@ import com.linkedin.venice.compute.protocol.request.HadamardProduct;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.utils.EnumUtils;
 import com.linkedin.venice.utils.VeniceEnumValue;
+import java.util.List;
 
 
 public enum ComputeOperationType implements VeniceEnumValue {
@@ -21,7 +22,7 @@ public enum ComputeOperationType implements VeniceEnumValue {
 
   private final ReadComputeOperator operator;
   private final int value;
-  private static final ComputeOperationType[] TYPES_ARRAY = EnumUtils.getEnumValuesArray(ComputeOperationType.class);
+  private static final List<ComputeOperationType> TYPES = EnumUtils.getEnumValuesList(ComputeOperationType.class);
 
   ComputeOperationType(int value, ReadComputeOperator operator) {
     this.value = value;
@@ -44,17 +45,14 @@ public enum ComputeOperationType implements VeniceEnumValue {
   }
 
   public static ComputeOperationType valueOf(int value) {
-    try {
-      return TYPES_ARRAY[value];
-    } catch (IndexOutOfBoundsException e) {
-      throw new VeniceException("Invalid compute operation type: " + value);
-    }
+    return EnumUtils.valueOf(TYPES, value, ComputeOperationType.class);
   }
 
   public static ComputeOperationType valueOf(ComputeOperation operation) {
     return valueOf(operation.operationType);
   }
 
+  @Override
   public int getValue() {
     return value;
   }

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/utils/VeniceEnumValue.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/utils/VeniceEnumValue.java
@@ -1,5 +1,18 @@
 package com.linkedin.venice.utils;
 
+/**
+ * N.B.: Although there is no way to force this via Java interfaces, the convention is that all enums implementing this
+ * interface should have static "valueOf" function to return the correct enum value from a given numeric value, i.e.:
+ *
+ * {@snippet id='valueOf':
+ * public static MyEnumType valueOf(int value) {
+ *   return EnumUtils.valueOf(TYPES_ARRAY, value, MyEnumTpe.class);
+ * }
+ * }
+ *
+ * Note that VeniceEnumValueTest makes it easy to test the above, and we should have a subclass of that test for all
+ * implementations of this interface.
+ */
 public interface VeniceEnumValue {
   int getValue();
 }

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/compression/CompressionStrategyTest.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/compression/CompressionStrategyTest.java
@@ -1,0 +1,22 @@
+package com.linkedin.venice.compression;
+
+import com.linkedin.alpini.base.misc.CollectionUtil;
+import com.linkedin.venice.utils.VeniceEnumValueTest;
+import java.util.Map;
+
+
+public class CompressionStrategyTest extends VeniceEnumValueTest<CompressionStrategy> {
+  public CompressionStrategyTest() {
+    super(CompressionStrategy.class);
+  }
+
+  @Override
+  protected Map<Integer, CompressionStrategy> expectedMapping() {
+    return CollectionUtil.<Integer, CompressionStrategy>mapBuilder()
+        .put(0, CompressionStrategy.NO_OP)
+        .put(1, CompressionStrategy.GZIP)
+        .put(2, CompressionStrategy.ZSTD)
+        .put(3, CompressionStrategy.ZSTD_WITH_DICT)
+        .build();
+  }
+}

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/compute/protocol/request/enums/ComputeOperationTypeTest.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/compute/protocol/request/enums/ComputeOperationTypeTest.java
@@ -1,0 +1,22 @@
+package com.linkedin.venice.compute.protocol.request.enums;
+
+import com.linkedin.alpini.base.misc.CollectionUtil;
+import com.linkedin.venice.utils.VeniceEnumValueTest;
+import java.util.Map;
+
+
+public class ComputeOperationTypeTest extends VeniceEnumValueTest<ComputeOperationType> {
+  public ComputeOperationTypeTest() {
+    super(ComputeOperationType.class);
+  }
+
+  @Override
+  protected Map<Integer, ComputeOperationType> expectedMapping() {
+    return CollectionUtil.<Integer, ComputeOperationType>mapBuilder()
+        .put(0, ComputeOperationType.DOT_PRODUCT)
+        .put(1, ComputeOperationType.COSINE_SIMILARITY)
+        .put(2, ComputeOperationType.HADAMARD_PRODUCT)
+        .put(3, ComputeOperationType.COUNT)
+        .build();
+  }
+}

--- a/internal/venice-common/src/main/java/com/linkedin/venice/kafka/protocol/enums/ControlMessageType.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/kafka/protocol/enums/ControlMessageType.java
@@ -13,6 +13,7 @@ import com.linkedin.venice.kafka.protocol.TopicSwitch;
 import com.linkedin.venice.kafka.protocol.VersionSwap;
 import com.linkedin.venice.utils.EnumUtils;
 import com.linkedin.venice.utils.VeniceEnumValue;
+import java.util.List;
 
 
 /**
@@ -28,12 +29,13 @@ public enum ControlMessageType implements VeniceEnumValue {
 
   /** The value is the byte used on the wire format */
   private final int value;
-  private static final ControlMessageType[] TYPES_ARRAY = EnumUtils.getEnumValuesArray(ControlMessageType.class);
+  private static final List<ControlMessageType> TYPES = EnumUtils.getEnumValuesList(ControlMessageType.class);
 
   ControlMessageType(int value) {
     this.value = value;
   }
 
+  @Override
   public int getValue() {
     return value;
   }
@@ -76,11 +78,7 @@ public enum ControlMessageType implements VeniceEnumValue {
   }
 
   public static ControlMessageType valueOf(int value) {
-    try {
-      return TYPES_ARRAY[value];
-    } catch (IndexOutOfBoundsException e) {
-      throw new VeniceMessageException("Invalid control message type: " + value);
-    }
+    return EnumUtils.valueOf(TYPES, value, ControlMessageType.class, VeniceMessageException::new);
   }
 
   public static ControlMessageType valueOf(ControlMessage controlMessage) {

--- a/internal/venice-common/src/main/java/com/linkedin/venice/kafka/protocol/enums/MessageType.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/kafka/protocol/enums/MessageType.java
@@ -9,6 +9,7 @@ import com.linkedin.venice.kafka.protocol.Put;
 import com.linkedin.venice.kafka.protocol.Update;
 import com.linkedin.venice.utils.EnumUtils;
 import com.linkedin.venice.utils.VeniceEnumValue;
+import java.util.List;
 
 
 /**
@@ -22,7 +23,7 @@ public enum MessageType implements VeniceEnumValue {
   PUT(0, Constants.PUT_KEY_HEADER_BYTE), DELETE(1, Constants.PUT_KEY_HEADER_BYTE),
   CONTROL_MESSAGE(2, Constants.CONTROL_MESSAGE_KEY_HEADER_BYTE), UPDATE(3, Constants.UPDATE_KEY_HEADER_BYTE);
 
-  private static final MessageType[] TYPES_ARRAY = EnumUtils.getEnumValuesArray(MessageType.class);
+  private static final List<MessageType> TYPES = EnumUtils.getEnumValuesList(MessageType.class);
 
   private final int value;
   private final byte keyHeaderByte;
@@ -36,6 +37,7 @@ public enum MessageType implements VeniceEnumValue {
    * @return This is the value used in {@link com.linkedin.venice.kafka.protocol.KafkaMessageEnvelope#messageType}
    *         to distinguish message types.
    */
+  @Override
   public int getValue() {
     return value;
   }
@@ -73,11 +75,7 @@ public enum MessageType implements VeniceEnumValue {
   }
 
   public static MessageType valueOf(int value) {
-    try {
-      return TYPES_ARRAY[value];
-    } catch (IndexOutOfBoundsException e) {
-      throw new VeniceMessageException("Invalid message type: " + value);
-    }
+    return EnumUtils.valueOf(TYPES, value, MessageType.class, VeniceMessageException::new);
   }
 
   public static MessageType valueOf(KafkaMessageEnvelope kafkaMessageEnvelope) {

--- a/internal/venice-common/src/main/java/com/linkedin/venice/system/store/MetaStoreDataType.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/system/store/MetaStoreDataType.java
@@ -32,7 +32,7 @@ public enum MetaStoreDataType implements VeniceEnumValue {
   VALUE_SCHEMAS_WRITTEN_PER_STORE_VERSION(6, Arrays.asList(KEY_STRING_STORE_NAME, KEY_STRING_VERSION_NUMBER)),
   HEARTBEAT(7, Collections.singletonList(KEY_STRING_STORE_NAME));
 
-  private static final MetaStoreDataType[] TYPES_ARRAY = EnumUtils.getEnumValuesArray(MetaStoreDataType.class);
+  private static final List<MetaStoreDataType> TYPES = EnumUtils.getEnumValuesList(MetaStoreDataType.class);
 
   private final int value;
   private final List<String> requiredKeys;
@@ -42,16 +42,13 @@ public enum MetaStoreDataType implements VeniceEnumValue {
     this.requiredKeys = requiredKeys;
   }
 
+  @Override
   public int getValue() {
     return value;
   }
 
   public static MetaStoreDataType valueOf(int value) {
-    try {
-      return TYPES_ARRAY[value];
-    } catch (IndexOutOfBoundsException e) {
-      throw new VeniceException("Invalid compression strategy: " + value);
-    }
+    return EnumUtils.valueOf(TYPES, value, MetaStoreDataType.class);
   }
 
   public StoreMetaKey getStoreMetaKey(Map<String, String> params) {

--- a/internal/venice-common/src/main/java/com/linkedin/venice/writer/LeaderCompleteState.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/writer/LeaderCompleteState.java
@@ -1,8 +1,8 @@
 package com.linkedin.venice.writer;
 
-import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.utils.EnumUtils;
 import com.linkedin.venice.utils.VeniceEnumValue;
+import java.util.List;
 
 
 /**
@@ -19,7 +19,7 @@ public enum LeaderCompleteState implements VeniceEnumValue {
   LEADER_COMPLETED(1);
 
   private final int value;
-  private static final LeaderCompleteState[] TYPES_ARRAY = EnumUtils.getEnumValuesArray(LeaderCompleteState.class);
+  private static final List<LeaderCompleteState> TYPES = EnumUtils.getEnumValuesList(LeaderCompleteState.class);
 
   LeaderCompleteState(int value) {
     this.value = value;
@@ -34,11 +34,7 @@ public enum LeaderCompleteState implements VeniceEnumValue {
   }
 
   public static LeaderCompleteState valueOf(int value) {
-    try {
-      return TYPES_ARRAY[value];
-    } catch (IndexOutOfBoundsException e) {
-      throw new VeniceException("Invalid LeaderCompleteState: " + value);
-    }
+    return EnumUtils.valueOf(TYPES, value, LeaderCompleteState.class);
   }
 
   @Override

--- a/internal/venice-common/src/test/java/com/linkedin/venice/kafka/protocol/enums/ControlMessageTypeTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/kafka/protocol/enums/ControlMessageTypeTest.java
@@ -1,30 +1,27 @@
 package com.linkedin.venice.kafka.protocol.enums;
 
-import static com.linkedin.venice.kafka.protocol.enums.ControlMessageType.END_OF_INCREMENTAL_PUSH;
-import static com.linkedin.venice.kafka.protocol.enums.ControlMessageType.END_OF_PUSH;
-import static com.linkedin.venice.kafka.protocol.enums.ControlMessageType.END_OF_SEGMENT;
-import static com.linkedin.venice.kafka.protocol.enums.ControlMessageType.START_OF_INCREMENTAL_PUSH;
-import static com.linkedin.venice.kafka.protocol.enums.ControlMessageType.START_OF_PUSH;
-import static com.linkedin.venice.kafka.protocol.enums.ControlMessageType.START_OF_SEGMENT;
-import static com.linkedin.venice.kafka.protocol.enums.ControlMessageType.TOPIC_SWITCH;
-import static com.linkedin.venice.kafka.protocol.enums.ControlMessageType.VERSION_SWAP;
-
-import org.testng.Assert;
-import org.testng.annotations.Test;
+import com.linkedin.alpini.base.misc.CollectionUtil;
+import com.linkedin.venice.utils.VeniceEnumValueTest;
+import java.util.Map;
 
 
-public class ControlMessageTypeTest {
-  @Test
-  public void test() {
-    String assertionErrorMessage = "The value ID of enums should not be changed, as that is backwards incompatible.";
+public class ControlMessageTypeTest extends VeniceEnumValueTest<ControlMessageType> {
+  public ControlMessageTypeTest() {
+    super(ControlMessageType.class);
+  }
 
-    Assert.assertEquals(ControlMessageType.valueOf(0), START_OF_PUSH, assertionErrorMessage);
-    Assert.assertEquals(ControlMessageType.valueOf(1), END_OF_PUSH, assertionErrorMessage);
-    Assert.assertEquals(ControlMessageType.valueOf(2), START_OF_SEGMENT, assertionErrorMessage);
-    Assert.assertEquals(ControlMessageType.valueOf(3), END_OF_SEGMENT, assertionErrorMessage);
-    Assert.assertEquals(ControlMessageType.valueOf(5), START_OF_INCREMENTAL_PUSH, assertionErrorMessage);
-    Assert.assertEquals(ControlMessageType.valueOf(6), END_OF_INCREMENTAL_PUSH, assertionErrorMessage);
-    Assert.assertEquals(ControlMessageType.valueOf(7), TOPIC_SWITCH, assertionErrorMessage);
-    Assert.assertEquals(ControlMessageType.valueOf(8), VERSION_SWAP, assertionErrorMessage);
+  @Override
+  protected Map<Integer, ControlMessageType> expectedMapping() {
+    return CollectionUtil.<Integer, ControlMessageType>mapBuilder()
+        .put(0, ControlMessageType.START_OF_PUSH)
+        .put(1, ControlMessageType.END_OF_PUSH)
+        .put(2, ControlMessageType.START_OF_SEGMENT)
+        .put(3, ControlMessageType.END_OF_SEGMENT)
+        .put(4, ControlMessageType.START_OF_BUFFER_REPLAY)
+        .put(5, ControlMessageType.START_OF_INCREMENTAL_PUSH)
+        .put(6, ControlMessageType.END_OF_INCREMENTAL_PUSH)
+        .put(7, ControlMessageType.TOPIC_SWITCH)
+        .put(8, ControlMessageType.VERSION_SWAP)
+        .build();
   }
 }

--- a/internal/venice-common/src/test/java/com/linkedin/venice/kafka/protocol/enums/MessageTypeTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/kafka/protocol/enums/MessageTypeTest.java
@@ -1,0 +1,22 @@
+package com.linkedin.venice.kafka.protocol.enums;
+
+import com.linkedin.alpini.base.misc.CollectionUtil;
+import com.linkedin.venice.utils.VeniceEnumValueTest;
+import java.util.Map;
+
+
+public class MessageTypeTest extends VeniceEnumValueTest<MessageType> {
+  public MessageTypeTest() {
+    super(MessageType.class);
+  }
+
+  @Override
+  protected Map<Integer, MessageType> expectedMapping() {
+    return CollectionUtil.<Integer, MessageType>mapBuilder()
+        .put(0, MessageType.PUT)
+        .put(1, MessageType.DELETE)
+        .put(2, MessageType.CONTROL_MESSAGE)
+        .put(3, MessageType.UPDATE)
+        .build();
+  }
+}

--- a/internal/venice-common/src/test/java/com/linkedin/venice/system/store/MetaStoreDataTypeTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/system/store/MetaStoreDataTypeTest.java
@@ -1,0 +1,26 @@
+package com.linkedin.venice.system.store;
+
+import com.linkedin.alpini.base.misc.CollectionUtil;
+import com.linkedin.venice.utils.VeniceEnumValueTest;
+import java.util.Map;
+
+
+public class MetaStoreDataTypeTest extends VeniceEnumValueTest<MetaStoreDataType> {
+  public MetaStoreDataTypeTest() {
+    super(MetaStoreDataType.class);
+  }
+
+  @Override
+  protected Map<Integer, MetaStoreDataType> expectedMapping() {
+    return CollectionUtil.<Integer, MetaStoreDataType>mapBuilder()
+        .put(0, MetaStoreDataType.STORE_PROPERTIES)
+        .put(1, MetaStoreDataType.STORE_KEY_SCHEMAS)
+        .put(2, MetaStoreDataType.STORE_VALUE_SCHEMAS)
+        .put(3, MetaStoreDataType.STORE_REPLICA_STATUSES)
+        .put(4, MetaStoreDataType.STORE_CLUSTER_CONFIG)
+        .put(5, MetaStoreDataType.STORE_VALUE_SCHEMA)
+        .put(6, MetaStoreDataType.VALUE_SCHEMAS_WRITTEN_PER_STORE_VERSION)
+        .put(7, MetaStoreDataType.HEARTBEAT)
+        .build();
+  }
+}

--- a/internal/venice-common/src/test/java/com/linkedin/venice/writer/LeaderCompleteStateTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/writer/LeaderCompleteStateTest.java
@@ -1,0 +1,20 @@
+package com.linkedin.venice.writer;
+
+import com.linkedin.alpini.base.misc.CollectionUtil;
+import com.linkedin.venice.utils.VeniceEnumValueTest;
+import java.util.Map;
+
+
+public class LeaderCompleteStateTest extends VeniceEnumValueTest<LeaderCompleteState> {
+  public LeaderCompleteStateTest() {
+    super(LeaderCompleteState.class);
+  }
+
+  @Override
+  protected Map<Integer, LeaderCompleteState> expectedMapping() {
+    return CollectionUtil.<Integer, LeaderCompleteState>mapBuilder()
+        .put(0, LeaderCompleteState.LEADER_NOT_COMPLETED)
+        .put(1, LeaderCompleteState.LEADER_COMPLETED)
+        .build();
+  }
+}

--- a/internal/venice-test-common/src/main/java/com/linkedin/venice/utils/VeniceEnumValueTest.java
+++ b/internal/venice-test-common/src/main/java/com/linkedin/venice/utils/VeniceEnumValueTest.java
@@ -1,0 +1,114 @@
+package com.linkedin.venice.utils;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotEquals;
+import static org.testng.Assert.assertThrows;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+
+import com.linkedin.venice.exceptions.VeniceException;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.Map;
+import java.util.function.Function;
+import org.testng.annotations.Test;
+
+
+/**
+ * Abstract class which makes it as easy as possible to generically test all the assumptions for enums which implement
+ * the {@link VeniceEnumValue} interface. Subclasses only need to implement the constructor and the abstract function.
+ *
+ * @param <T> the enum class under test
+ */
+@Test
+public abstract class VeniceEnumValueTest<T extends VeniceEnumValue> {
+  private static final int INVALID_NEGATIVE_VALUE = -1;
+  private static final String VALUE_OF_METHOD_NAME = "valueOf";
+  private static final String VALUES_METHOD_NAME = "values";
+  private static final String ASSERTION_ERROR_MESSAGE =
+      "The value ID of enums should not be changed, as that is backwards incompatible.";
+  private final Class<T> enumClass;
+
+  protected VeniceEnumValueTest(Class<T> enumClass) {
+    this.enumClass = enumClass;
+  }
+
+  protected abstract Map<Integer, T> expectedMapping();
+
+  @Test
+  public void test() {
+    int highestValue = INVALID_NEGATIVE_VALUE;
+
+    // Check that there is a valueOf function which respects the expected contract
+    Method valueOfMethod = getPublicStaticFunction(this.enumClass, VALUE_OF_METHOD_NAME, int.class);
+
+    assertTrue(Modifier.isStatic(valueOfMethod.getModifiers()), "The " + VALUE_OF_METHOD_NAME + " should be static!");
+    assertTrue(Modifier.isPublic(valueOfMethod.getModifiers()), "The " + VALUE_OF_METHOD_NAME + " should be public!");
+
+    Function<Integer, T> valueOfFunction = value -> {
+      try {
+        return (T) valueOfMethod.invoke(null, value);
+      } catch (Exception e) {
+        if (e.getClass() == InvocationTargetException.class && e.getCause() instanceof VeniceException) {
+          // Those are expected for invalid values, so we bubble them up.
+          throw (VeniceException) e.getCause();
+        }
+        fail("The " + VALUE_OF_METHOD_NAME + " threw an exception!", e);
+        // N.B.: Although the return statement below is unreachable, since fail will throw, the compiler does not know
+        // that.
+        return null;
+      }
+    };
+
+    Map<Integer, T> expectedMapping = expectedMapping();
+    assertFalse(expectedMapping.isEmpty());
+
+    // Check that all mappings are as expected
+    for (Map.Entry<Integer, T> entry: expectedMapping.entrySet()) {
+      assertEquals(valueOfFunction.apply(entry.getKey()), entry.getValue(), ASSERTION_ERROR_MESSAGE);
+      assertEquals(entry.getValue().getValue(), entry.getKey().intValue(), ASSERTION_ERROR_MESSAGE);
+      highestValue = Math.max(entry.getKey(), highestValue);
+    }
+
+    // Check that out of bound IDs throw exceptions
+    assertNotEquals(highestValue, INVALID_NEGATIVE_VALUE, "There are no values at all in the enum!");
+
+    assertThrows(VeniceException.class, () -> valueOfFunction.apply(INVALID_NEGATIVE_VALUE));
+
+    final int tooHighValue = highestValue + 1;
+    assertThrows(VeniceException.class, () -> valueOfFunction.apply(tooHighValue));
+
+    // Check that no other enum values exist besides those that are expected
+    Method valuesFunction = getPublicStaticFunction(this.enumClass, VALUES_METHOD_NAME, new Class[0]);
+    try {
+      T[] types = (T[]) valuesFunction.invoke(null, new Class[0]);
+      for (T type: types) {
+        assertTrue(
+            expectedMapping.containsKey(type.getValue()),
+            "Class " + this.enumClass.getSimpleName() + " contains an unexpected value: " + type.getValue());
+      }
+    } catch (Exception e) {
+      fail("The " + VALUES_METHOD_NAME + " threw an exception!", e);
+    }
+  }
+
+  private static Method getPublicStaticFunction(Class klass, String functionName, Class... params) {
+    try {
+      Method function = klass.getDeclaredMethod(functionName, params);
+      assertTrue(
+          Modifier.isStatic(function.getModifiers()),
+          "Class " + klass.getSimpleName() + " should have a static " + functionName + " function!");
+      assertTrue(
+          Modifier.isPublic(function.getModifiers()),
+          "Class " + klass.getSimpleName() + " should have a public " + functionName + " function!");
+      return function;
+    } catch (NoSuchMethodException e) {
+      fail("Class " + klass.getSimpleName() + " should have a " + functionName + " method!", e);
+      // N.B.: Although the return statement below is unreachable, since fail will throw, the compiler does not know
+      // that.
+      return null;
+    }
+  }
+}


### PR DESCRIPTION
Added a valueOf function in EnumUtils to reduce code duplication and standardize the error message for badly handled enums.

Also added unit tests for the mappings of all VeniceEnumValue.

## How was this PR tested?
New unit tests.

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.