### PR TITLE
[controller] Superset schema generation should reflect default value updates in new value schema

### DIFF
--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/utils/AvroSchemaUtils.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/utils/AvroSchemaUtils.java
@@ -262,8 +262,7 @@ public class AvroSchemaUtils {
       validateTwoSchemasAreFullyCompatible(tmpSupersetSchema, valueSchema);
       largestSchemaID = Math.max(largestSchemaID, valueSchemaEntry.getId());
       /**
-       * Note that superset schema should be the second parameter. For the reason, please refer to the Javadoc of the
-       * {@link AvroSchemaUtils#generateSuperSetSchema} method.
+       * Current superset schema should be the first parameter, and the incoming value schema is the 2nd parameter.
        */
       tmpSupersetSchema = AvroSupersetSchemaUtils.generateSupersetSchema(tmpSupersetSchema, valueSchema);
     }

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/utils/AvroSchemaUtils.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/utils/AvroSchemaUtils.java
@@ -30,7 +30,6 @@ import org.apache.avro.io.ResolvingDecoder;
 import org.apache.avro.io.parsing.Symbol;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.Validate;
-import org.apache.logging.log4j.LogManager;
 
 
 public class AvroSchemaUtils {
@@ -267,8 +266,6 @@ public class AvroSchemaUtils {
        * {@link AvroSchemaUtils#generateSuperSetSchema} method.
        */
       tmpSupersetSchema = AvroSupersetSchemaUtils.generateSuperSetSchema(valueSchema, tmpSupersetSchema);
-      LogManager.getLogger(AvroSupersetSchemaUtils.class)
-          .info("DEBUGGING GENERATED SUPERSET SCHEMA FOR ID: {}, SCHEMA: {}", i, tmpSupersetSchema.toString(true));
     }
     final Schema supersetSchema = tmpSupersetSchema;
 

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/utils/AvroSchemaUtils.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/utils/AvroSchemaUtils.java
@@ -265,7 +265,7 @@ public class AvroSchemaUtils {
        * Note that superset schema should be the second parameter. For the reason, please refer to the Javadoc of the
        * {@link AvroSchemaUtils#generateSuperSetSchema} method.
        */
-      tmpSupersetSchema = AvroSupersetSchemaUtils.generateSuperSetSchema(valueSchema, tmpSupersetSchema);
+      tmpSupersetSchema = AvroSupersetSchemaUtils.generateSuperSetSchema(tmpSupersetSchema, valueSchema);
     }
     final Schema supersetSchema = tmpSupersetSchema;
 

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/utils/AvroSchemaUtils.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/utils/AvroSchemaUtils.java
@@ -265,7 +265,7 @@ public class AvroSchemaUtils {
        * Note that superset schema should be the second parameter. For the reason, please refer to the Javadoc of the
        * {@link AvroSchemaUtils#generateSuperSetSchema} method.
        */
-      tmpSupersetSchema = AvroSupersetSchemaUtils.generateSuperSetSchema(tmpSupersetSchema, valueSchema);
+      tmpSupersetSchema = AvroSupersetSchemaUtils.generateSupersetSchema(tmpSupersetSchema, valueSchema);
     }
     final Schema supersetSchema = tmpSupersetSchema;
 

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/utils/AvroSchemaUtils.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/utils/AvroSchemaUtils.java
@@ -30,6 +30,7 @@ import org.apache.avro.io.ResolvingDecoder;
 import org.apache.avro.io.parsing.Symbol;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.Validate;
+import org.apache.logging.log4j.LogManager;
 
 
 public class AvroSchemaUtils {
@@ -266,6 +267,8 @@ public class AvroSchemaUtils {
        * {@link AvroSchemaUtils#generateSuperSetSchema} method.
        */
       tmpSupersetSchema = AvroSupersetSchemaUtils.generateSuperSetSchema(valueSchema, tmpSupersetSchema);
+      LogManager.getLogger(AvroSupersetSchemaUtils.class)
+          .info("DEBUGGING GENERATED SUPERSET SCHEMA FOR ID: {}, SCHEMA: {}", i, tmpSupersetSchema.toString(true));
     }
     final Schema supersetSchema = tmpSupersetSchema;
 

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/utils/AvroSupersetSchemaUtils.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/utils/AvroSupersetSchemaUtils.java
@@ -83,7 +83,7 @@ public class AvroSupersetSchemaUtils {
       case MAP:
         return Schema.createMap(generateSuperSetSchema(existingSchema.getValueType(), newSchema.getValueType()));
       case UNION:
-        return unionSchema(existingSchema, newSchema);
+        return unionSchema(newSchema, existingSchema);
       default:
         throw new VeniceException("Super set schema not supported");
     }
@@ -93,8 +93,8 @@ public class AvroSupersetSchemaUtils {
    * Merge union schema from two schema object. The rule is: If a field exist in both new schema and old schema, we should
    * generate the superset schema of these two versions of the same field, with new schema's information taking higher
    * priority.
-   * @param s1 old union schema
-   * @param s2 new union schema
+   * @param s1 new union schema
+   * @param s2 old union schema
    * @return merged schema field
    */
   private static Schema unionSchema(Schema s1, Schema s2) {
@@ -111,7 +111,6 @@ public class AvroSupersetSchemaUtils {
       }
     }
     s2Schema.forEach((k, v) -> combinedSchema.add(v));
-
     return Schema.createUnion(combinedSchema);
   }
 
@@ -159,7 +158,7 @@ public class AvroSupersetSchemaUtils {
 
       FieldBuilder fieldBuilder = deepCopySchemaField(f1);
       if (f2 != null) {
-        fieldBuilder.setSchema(generateSuperSetSchema(f1.schema(), f2.schema()))
+        fieldBuilder.setSchema(generateSuperSetSchema(f2.schema(), f1.schema()))
             .setDoc(f1.doc() != null ? f1.doc() : f2.doc());
       }
       fields.add(fieldBuilder.build());

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/utils/AvroSupersetSchemaUtils.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/utils/AvroSupersetSchemaUtils.java
@@ -9,14 +9,12 @@ import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.schema.AvroSchemaParseUtils;
 import com.linkedin.venice.schema.SchemaData;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 import org.apache.avro.Schema;
 import org.apache.commons.lang.StringUtils;
-import org.apache.logging.log4j.LogManager;
 
 
 public class AvroSupersetSchemaUtils {
@@ -42,14 +40,6 @@ public class AvroSupersetSchemaUtils {
    * @return super-set schema of existingSchema abd newSchema
    */
   public static Schema generateSuperSetSchema(Schema newSchema, Schema oldSchema) {
-    LogManager.getLogger(AvroSupersetSchemaUtils.class)
-        .info(
-            "DEBUGGING: generateSupersetSchema: call stack: {}",
-            Arrays.toString(Thread.currentThread().getStackTrace()));
-    LogManager.getLogger(AvroSupersetSchemaUtils.class)
-        .info("DEBUGGING: generateSupersetSchema: existing: {}", newSchema.toString(true));
-    LogManager.getLogger(AvroSupersetSchemaUtils.class)
-        .info("DEBUGGING: generateSupersetSchema: new: {}", oldSchema.toString(true));
     if (newSchema.getType() != oldSchema.getType()) {
       throw new VeniceException("Incompatible schema");
     }

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/utils/AvroSupersetSchemaUtils.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/utils/AvroSupersetSchemaUtils.java
@@ -102,11 +102,11 @@ public class AvroSupersetSchemaUtils {
     Map<String, Schema> s2Schema = s2.getTypes().stream().collect(Collectors.toMap(Schema::getName, s -> s));
     for (Schema subSchemaInS1: s1.getTypes()) {
       final String fieldName = subSchemaInS1.getName();
-      final Schema subSchemaWithSameNameInS2 = s2Schema.get(fieldName);
-      if (subSchemaWithSameNameInS2 == null) {
+      final Schema subSchemaInS2 = s2Schema.get(fieldName);
+      if (subSchemaInS2 == null) {
         combinedSchema.add(subSchemaInS1);
       } else {
-        combinedSchema.add(generateSuperSetSchema(subSchemaInS1, subSchemaWithSameNameInS2));
+        combinedSchema.add(generateSuperSetSchema(subSchemaInS2, subSchemaInS1));
         s2Schema.remove(fieldName);
       }
     }

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/utils/AvroSupersetSchemaUtils.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/utils/AvroSupersetSchemaUtils.java
@@ -159,7 +159,7 @@ public class AvroSupersetSchemaUtils {
 
       FieldBuilder fieldBuilder = deepCopySchemaField(f1);
       if (f2 != null) {
-        fieldBuilder.setSchema(generateSuperSetSchema(f2.schema(), f1.schema()))
+        fieldBuilder.setSchema(generateSuperSetSchema(f1.schema(), f2.schema()))
             .setDoc(f1.doc() != null ? f1.doc() : f2.doc());
       }
       fields.add(fieldBuilder.build());

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/schema/TestAvroSupersetSchemaUtils.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/schema/TestAvroSupersetSchemaUtils.java
@@ -6,6 +6,7 @@ import static com.linkedin.venice.utils.TestWriteUtils.NAME_RECORD_V3_SCHEMA;
 import static com.linkedin.venice.utils.TestWriteUtils.NAME_RECORD_V4_SCHEMA;
 import static com.linkedin.venice.utils.TestWriteUtils.NAME_RECORD_V5_SCHEMA;
 import static com.linkedin.venice.utils.TestWriteUtils.NAME_RECORD_V6_SCHEMA;
+import static com.linkedin.venice.utils.TestWriteUtils.loadFileAsString;
 
 import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
 import com.linkedin.venice.controllerapi.MultiSchemaResponse;
@@ -36,7 +37,7 @@ public class TestAvroSupersetSchemaUtils {
         AvroSchemaUtils.generateSupersetSchemaFromAllValueSchemas(Arrays.asList(schemaEntry1, schemaEntry2));
 
     final Schema expectedSupersetSchema =
-        AvroSupersetSchemaUtils.generateSuperSetSchema(schemaEntry1.getSchema(), schemaEntry2.getSchema());
+        AvroSupersetSchemaUtils.generateSupersetSchema(schemaEntry1.getSchema(), schemaEntry2.getSchema());
     Assert.assertTrue(
         AvroSchemaUtils.compareSchemaIgnoreFieldOrder(expectedSupersetSchema, supersetSchemaEntry.getSchema()));
     Assert.assertEquals(supersetSchemaEntry.getId(), 2);
@@ -142,7 +143,7 @@ public class TestAvroSupersetSchemaUtils {
 
     Schema newValueSchema = AvroSchemaParseUtils.parseSchemaFromJSONStrictValidation(valueSchemaStr1);
     Schema existingValueSchema = AvroSchemaParseUtils.parseSchemaFromJSONStrictValidation(valueSchemaStr2);
-    Schema newSuperSetSchema = AvroSupersetSchemaUtils.generateSuperSetSchema(existingValueSchema, newValueSchema);
+    Schema newSuperSetSchema = AvroSupersetSchemaUtils.generateSupersetSchema(existingValueSchema, newValueSchema);
     Assert.assertTrue(
         new SchemaEntry(1, valueSchemaStr2)
             .isNewSchemaCompatible(new SchemaEntry(2, newSuperSetSchema), DirectionalSchemaCompatibilityType.FULL));
@@ -161,7 +162,7 @@ public class TestAvroSupersetSchemaUtils {
     Assert.assertNotEquals(s1, s2);
     Assert.assertTrue(AvroSchemaUtils.compareSchemaIgnoreFieldOrder(s1, s2));
 
-    Schema s3 = AvroSupersetSchemaUtils.generateSuperSetSchema(s2, s1);
+    Schema s3 = AvroSupersetSchemaUtils.generateSupersetSchema(s2, s1);
     Assert.assertNotNull(s3);
     Assert.assertNotNull(
         AvroCompatibilityHelper.getSchemaPropAsJsonString(s3.getField("name").schema(), "avro.java.string"));
@@ -177,7 +178,7 @@ public class TestAvroSupersetSchemaUtils {
     Schema s2 = AvroSchemaParseUtils.parseSchemaFromJSONStrictValidation(schemaStr2);
     Assert.assertTrue(AvroSchemaUtils.compareSchemaIgnoreFieldOrder(s1, s2));
 
-    Schema s3 = AvroSupersetSchemaUtils.generateSuperSetSchema(s1, s2);
+    Schema s3 = AvroSupersetSchemaUtils.generateSupersetSchema(s1, s2);
     Assert.assertNotNull(s3);
   }
 
@@ -191,7 +192,7 @@ public class TestAvroSupersetSchemaUtils {
     Schema s1 = AvroSchemaParseUtils.parseSchemaFromJSONStrictValidation(schemaStr1);
     Schema s2 = AvroSchemaParseUtils.parseSchemaFromJSONStrictValidation(schemaStr2);
     Assert.assertFalse(AvroSchemaUtils.compareSchemaIgnoreFieldOrder(s1, s2));
-    Schema s3 = AvroSupersetSchemaUtils.generateSuperSetSchema(s1, s2);
+    Schema s3 = AvroSupersetSchemaUtils.generateSupersetSchema(s1, s2);
     Assert.assertNotNull(s3);
   }
 
@@ -206,7 +207,7 @@ public class TestAvroSupersetSchemaUtils {
     Schema s2 = AvroSchemaParseUtils.parseSchemaFromJSONStrictValidation(schemaStr2);
     Assert.assertFalse(AvroSchemaUtils.compareSchemaIgnoreFieldOrder(s1, s2));
 
-    Schema s3 = AvroSupersetSchemaUtils.generateSuperSetSchema(s1, s2);
+    Schema s3 = AvroSupersetSchemaUtils.generateSupersetSchema(s1, s2);
     Assert.assertNotNull(s3.getField("id1"));
     Assert.assertNotNull(s3.getField("id2"));
   }
@@ -222,7 +223,7 @@ public class TestAvroSupersetSchemaUtils {
     Schema s2 = AvroSchemaParseUtils.parseSchemaFromJSONStrictValidation(schemaStr2);
     Assert.assertFalse(AvroSchemaUtils.compareSchemaIgnoreFieldOrder(s1, s2));
 
-    Schema s3 = AvroSupersetSchemaUtils.generateSuperSetSchema(s1, s2);
+    Schema s3 = AvroSupersetSchemaUtils.generateSupersetSchema(s1, s2);
     Assert.assertNotNull(s3.getField("id1"));
     Assert.assertNotNull(s3.getField("id2"));
   }
@@ -237,7 +238,7 @@ public class TestAvroSupersetSchemaUtils {
     Schema s2 = AvroSchemaParseUtils.parseSchemaFromJSONStrictValidation(schemaStr2);
 
     Assert.assertFalse(AvroSchemaUtils.compareSchemaIgnoreFieldOrder(s1, s2));
-    AvroSupersetSchemaUtils.generateSuperSetSchema(s1, s2);
+    AvroSupersetSchemaUtils.generateSupersetSchema(s1, s2);
   }
 
   @Test
@@ -251,9 +252,25 @@ public class TestAvroSupersetSchemaUtils {
     Schema s2 = AvroSchemaParseUtils.parseSchemaFromJSONStrictValidation(schemaStr2);
     Assert.assertFalse(AvroSchemaUtils.compareSchemaIgnoreFieldOrder(s1, s2));
 
-    Schema s3 = AvroSupersetSchemaUtils.generateSuperSetSchema(s1, s2);
+    Schema s3 = AvroSupersetSchemaUtils.generateSupersetSchema(s1, s2);
     Assert.assertNotNull(s3.getField("company"));
     Assert.assertNotNull(s3.getField("organization"));
+  }
+
+  @Test
+  public void testSchemaMergeUnionWithComplexItemType() {
+    Schema s1 = AvroSchemaParseUtils.parseSchemaFromJSONStrictValidation(loadFileAsString("UnionV1.avsc"));
+    Schema s2 = AvroSchemaParseUtils.parseSchemaFromJSONStrictValidation(loadFileAsString("UnionV2.avsc"));
+    Assert.assertFalse(AvroSchemaUtils.compareSchemaIgnoreFieldOrder(s1, s2));
+    Schema s3 = AvroSupersetSchemaUtils.generateSupersetSchema(s1, s2);
+    Assert.assertNotNull(s3.getField("age"));
+    Assert.assertNotNull(s3.getField("field"));
+    Schema.Field subFieldInS2 = s2.getField("field");
+    Schema.Field subFieldInS3 = s3.getField("field");
+    Assert.assertEquals(subFieldInS3.defaultVal(), subFieldInS2.defaultVal());
+    Schema unionSubFieldInS2 = subFieldInS2.schema().getTypes().get(1);
+    Schema unionSubFieldInS3 = subFieldInS3.schema().getTypes().get(1);
+    Assert.assertEquals(unionSubFieldInS3, unionSubFieldInS2);
   }
 
   @Test
@@ -280,7 +297,7 @@ public class TestAvroSupersetSchemaUtils {
     Schema s2 = AvroSchemaParseUtils.parseSchemaFromJSONStrictValidation(recordSchemaStr2);
     Assert.assertFalse(AvroSchemaUtils.compareSchemaIgnoreFieldOrder(s1, s2));
 
-    Schema s3 = AvroSupersetSchemaUtils.generateSuperSetSchema(s1, s2);
+    Schema s3 = AvroSupersetSchemaUtils.generateSupersetSchema(s1, s2);
     Assert.assertNotNull(s3);
   }
 
@@ -309,7 +326,7 @@ public class TestAvroSupersetSchemaUtils {
     Schema s2 = AvroSchemaParseUtils.parseSchemaFromJSONStrictValidation(schemaStr2);
     Assert.assertTrue(AvroSchemaUtils.compareSchemaIgnoreFieldOrder(s1, s2));
 
-    Schema s3 = AvroSupersetSchemaUtils.generateSuperSetSchema(s1, s2);
+    Schema s3 = AvroSupersetSchemaUtils.generateSupersetSchema(s1, s2);
     Assert.assertNotNull(AvroSchemaUtils.getFieldDefault(s3.getField("salary")));
   }
 
@@ -333,7 +350,7 @@ public class TestAvroSupersetSchemaUtils {
     Schema s2 = AvroSchemaParseUtils.parseSchemaFromJSONStrictValidation(schemaStr2);
 
     Assert.assertFalse(AvroSchemaUtils.compareSchemaIgnoreFieldOrder(s1, s2));
-    AvroSupersetSchemaUtils.generateSuperSetSchema(s1, s2);
+    AvroSupersetSchemaUtils.generateSupersetSchema(s1, s2);
   }
 
   @Test
@@ -425,7 +442,7 @@ public class TestAvroSupersetSchemaUtils {
 
     Schema schema1 = AvroSchemaParseUtils.parseSchemaFromJSONStrictValidation(valueSchemaStr1);
     Schema schema2 = AvroSchemaParseUtils.parseSchemaFromJSONStrictValidation(valueSchemaStr2);
-    Schema supersetSchema = AvroSupersetSchemaUtils.generateSuperSetSchema(schema1, schema2);
+    Schema supersetSchema = AvroSupersetSchemaUtils.generateSupersetSchema(schema1, schema2);
 
     Schema.Field intField = supersetSchema.getField("int_field");
     Schema.Field stringField = supersetSchema.getField("string_field");
@@ -495,7 +512,7 @@ public class TestAvroSupersetSchemaUtils {
     Assert.assertNotEquals(NAME_RECORD_V5_SCHEMA, NAME_RECORD_V6_SCHEMA);
     // Test validation skip comparing props when checking for subset schema.
     Schema supersetSchemaForV5AndV4 =
-        AvroSupersetSchemaUtils.generateSuperSetSchema(NAME_RECORD_V5_SCHEMA, NAME_RECORD_V4_SCHEMA);
+        AvroSupersetSchemaUtils.generateSupersetSchema(NAME_RECORD_V5_SCHEMA, NAME_RECORD_V4_SCHEMA);
     Assert.assertTrue(
         AvroSupersetSchemaUtils.validateSubsetValueSchema(NAME_RECORD_V5_SCHEMA, supersetSchemaForV5AndV4.toString()));
     Assert.assertTrue(

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/schema/TestAvroSupersetSchemaUtils.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/schema/TestAvroSupersetSchemaUtils.java
@@ -425,7 +425,7 @@ public class TestAvroSupersetSchemaUtils {
 
     Schema schema1 = AvroSchemaParseUtils.parseSchemaFromJSONStrictValidation(valueSchemaStr1);
     Schema schema2 = AvroSchemaParseUtils.parseSchemaFromJSONStrictValidation(valueSchemaStr2);
-    Schema supersetSchema = AvroSupersetSchemaUtils.generateSuperSetSchema(schema2, schema1);
+    Schema supersetSchema = AvroSupersetSchemaUtils.generateSuperSetSchema(schema1, schema2);
 
     Schema.Field intField = supersetSchema.getField("int_field");
     Schema.Field stringField = supersetSchema.getField("string_field");

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/schema/TestAvroSupersetSchemaUtils.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/schema/TestAvroSupersetSchemaUtils.java
@@ -425,8 +425,7 @@ public class TestAvroSupersetSchemaUtils {
 
     Schema schema1 = AvroSchemaParseUtils.parseSchemaFromJSONStrictValidation(valueSchemaStr1);
     Schema schema2 = AvroSchemaParseUtils.parseSchemaFromJSONStrictValidation(valueSchemaStr2);
-
-    Schema supersetSchema = AvroSupersetSchemaUtils.generateSuperSetSchema(schema1, schema2);
+    Schema supersetSchema = AvroSupersetSchemaUtils.generateSuperSetSchema(schema2, schema1);
 
     Schema.Field intField = supersetSchema.getField("int_field");
     Schema.Field stringField = supersetSchema.getField("string_field");

--- a/internal/venice-client-common/src/test/java/com/linkedin/venice/schema/TestAvroSupersetSchemaUtils.java
+++ b/internal/venice-client-common/src/test/java/com/linkedin/venice/schema/TestAvroSupersetSchemaUtils.java
@@ -267,7 +267,6 @@ public class TestAvroSupersetSchemaUtils {
     Assert.assertNotNull(s3.getField("field"));
     Schema.Field subFieldInS2 = s2.getField("field");
     Schema.Field subFieldInS3 = s3.getField("field");
-    Assert.assertEquals(subFieldInS3.defaultVal(), subFieldInS2.defaultVal());
     Schema unionSubFieldInS2 = subFieldInS2.schema().getTypes().get(1);
     Schema unionSubFieldInS3 = subFieldInS3.schema().getTypes().get(1);
     Assert.assertEquals(unionSubFieldInS3, unionSubFieldInS2);

--- a/internal/venice-client-common/src/test/resources/UnionV1.avsc
+++ b/internal/venice-client-common/src/test/resources/UnionV1.avsc
@@ -1,0 +1,31 @@
+{
+  "type" : "record",
+  "name" : "User",
+  "namespace" : "example.avro",
+  "fields" : [
+    {
+      "name": "field",
+      "type": [
+        "int",
+        {
+          "type": "record",
+          "name": "subField",
+          "fields": [
+            {
+              "name": "name",
+              "type": "string",
+              "doc": "doc v1",
+              "default": "v1"
+            }
+          ]
+        }
+      ],
+      "default": 10
+    },
+    {
+      "name": "age",
+      "type": "int",
+      "default": 10
+    }
+  ]
+}

--- a/internal/venice-client-common/src/test/resources/UnionV2.avsc
+++ b/internal/venice-client-common/src/test/resources/UnionV2.avsc
@@ -1,0 +1,26 @@
+{
+  "type" : "record",
+  "name" : "User",
+  "namespace" : "example.avro",
+  "fields" : [
+    {
+      "name": "field",
+      "type": [
+        "int",
+        {
+          "type": "record",
+          "name": "subField",
+          "fields": [
+            {
+              "name": "name",
+              "type": "string",
+              "doc": "doc v2",
+              "default": "v2"
+            }
+          ]
+        }
+      ],
+      "default": 20
+    }
+  ]
+}

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestEmptyPush.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/TestEmptyPush.java
@@ -136,7 +136,8 @@ public class TestEmptyPush {
       PubSubTopic storeRealTimeTopic =
           venice.getPubSubTopicRepository().getTopic(Version.composeRealTimeTopic(storeName));
       assertTrue(topicManager.containsTopicAndAllPartitionsAreOnline(storeRealTimeTopic));
-
+      // One time refresh of router metadata.
+      venice.refreshAllRouterMetaData();
       // Start writing some real-time records
       SystemProducer veniceProducer =
           IntegrationTestPushUtils.getSamzaProducer(venice, storeName, Version.PushType.STREAM);

--- a/internal/venice-test-common/src/main/java/com/linkedin/venice/utils/TestWriteUtils.java
+++ b/internal/venice-test-common/src/main/java/com/linkedin/venice/utils/TestWriteUtils.java
@@ -100,6 +100,13 @@ public class TestWriteUtils {
   public static final Schema NAME_RECORD_V6_SCHEMA =
       AvroCompatibilityHelper.parse(loadSchemaFileFromResource("valueSchema/NameV6.avsc"));
 
+  public static final Schema UNION_RECORD_V1_SCHEMA =
+      AvroCompatibilityHelper.parse(loadSchemaFileFromResource("valueSchema/UnionV1.avsc"));
+  public static final Schema UNION_RECORD_V2_SCHEMA =
+      AvroCompatibilityHelper.parse(loadSchemaFileFromResource("valueSchema/UnionV2.avsc"));
+  public static final Schema UNION_RECORD_V3_SCHEMA =
+      AvroCompatibilityHelper.parse(loadSchemaFileFromResource("valueSchema/UnionV3.avsc"));
+
   // ETL Schema
   public static final Schema ETL_KEY_SCHEMA = AvroCompatibilityHelper.parse(loadSchemaFileFromResource("etl/Key.avsc"));
   public static final Schema ETL_VALUE_SCHEMA =

--- a/internal/venice-test-common/src/main/resources/valueSchema/UnionV1.avsc
+++ b/internal/venice-test-common/src/main/resources/valueSchema/UnionV1.avsc
@@ -1,0 +1,15 @@
+{
+  "type" : "record",
+  "name" : "User",
+  "namespace" : "example.avro",
+  "fields" : [
+    {
+      "name": "count",
+      "type": [
+        "int",
+        "null"
+      ],
+      "default": 0
+    }
+  ]
+}

--- a/internal/venice-test-common/src/main/resources/valueSchema/UnionV2.avsc
+++ b/internal/venice-test-common/src/main/resources/valueSchema/UnionV2.avsc
@@ -1,0 +1,15 @@
+{
+  "type" : "record",
+  "name" : "User",
+  "namespace" : "example.avro",
+  "fields" : [
+    {
+      "name": "count",
+      "type": [
+        "null",
+        "int"
+      ],
+      "default": null
+    }
+  ]
+}

--- a/internal/venice-test-common/src/main/resources/valueSchema/UnionV3.avsc
+++ b/internal/venice-test-common/src/main/resources/valueSchema/UnionV3.avsc
@@ -1,0 +1,20 @@
+{
+  "type" : "record",
+  "name" : "User",
+  "namespace" : "example.avro",
+  "fields" : [
+    {
+      "name": "count",
+      "type": [
+        "null",
+        "int"
+      ],
+      "default": null
+    },
+    {
+      "name": "dummyField",
+      "type" : "string",
+      "default" : ""
+    }
+  ]
+}

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
@@ -2738,6 +2738,7 @@ public class VeniceParentHelixAdmin implements Admin {
       AdminOperation message = new AdminOperation();
       message.operationType = AdminMessageType.UPDATE_STORE.getValue();
       message.payloadUnion = setStore;
+      LOGGER.info("DEBUGGING: MESSAGE: {}", message);
       sendAdminMessageAndWaitForConsumed(clusterName, storeName, message);
 
       if (needToGenerateSupersetSchema) {
@@ -3040,6 +3041,7 @@ public class VeniceParentHelixAdmin implements Admin {
     }
 
     if (doUpdateSupersetSchemaID) {
+      LOGGER.info("DEBUGGING PERFORMING UPDATE SUPERSET SCHEMA: {} {}", doUpdateSupersetSchemaID, newValueSchemaId);
       updateStore(clusterName, storeName, new UpdateStoreQueryParams().setLatestSupersetSchemaId(newValueSchemaId));
     }
 
@@ -3077,8 +3079,13 @@ public class VeniceParentHelixAdmin implements Admin {
       final boolean doUpdateSupersetSchemaID;
       if (existingValueSchema != null && (store.isReadComputationEnabled() || store.isWriteComputationEnabled())) {
         SupersetSchemaGenerator supersetSchemaGenerator = getSupersetSchemaGenerator(clusterName);
-        Schema newSuperSetSchema = supersetSchemaGenerator.generateSupersetSchema(existingValueSchema, newValueSchema);
+        Schema newSuperSetSchema = supersetSchemaGenerator.generateSupersetSchema(newValueSchema, existingValueSchema);
         String newSuperSetSchemaStr = newSuperSetSchema.toString();
+        LOGGER.info("DEBUGGING: ADD VALUE SCHEMA. NewSupersetSchema: {}", newSuperSetSchema.toString(true));
+        LOGGER.info("DEBUGGING: ADD VALUE SCHEMA. NewValueSchema: {}", newValueSchema.toString(true));
+        LOGGER.info(
+            "DEBUGGING: ADD VALUE SCHEMA. COMPARE: {}",
+            supersetSchemaGenerator.compareSchema(newSuperSetSchema, newValueSchema));
 
         if (supersetSchemaGenerator.compareSchema(newSuperSetSchema, newValueSchema)) {
           doUpdateSupersetSchemaID = true;
@@ -3125,7 +3132,7 @@ public class VeniceParentHelixAdmin implements Admin {
       } else {
         doUpdateSupersetSchemaID = false;
       }
-
+      LOGGER.info("DEBUGGING: doUpdate: {}", doUpdateSupersetSchemaID);
       SchemaEntry addedSchemaEntry =
           addValueSchemaEntry(clusterName, storeName, newValueSchemaStr, schemaId, doUpdateSupersetSchemaID);
 

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
@@ -2738,7 +2738,6 @@ public class VeniceParentHelixAdmin implements Admin {
       AdminOperation message = new AdminOperation();
       message.operationType = AdminMessageType.UPDATE_STORE.getValue();
       message.payloadUnion = setStore;
-      LOGGER.info("DEBUGGING: MESSAGE: {}", message);
       sendAdminMessageAndWaitForConsumed(clusterName, storeName, message);
 
       if (needToGenerateSupersetSchema) {
@@ -3041,7 +3040,6 @@ public class VeniceParentHelixAdmin implements Admin {
     }
 
     if (doUpdateSupersetSchemaID) {
-      LOGGER.info("DEBUGGING PERFORMING UPDATE SUPERSET SCHEMA: {} {}", doUpdateSupersetSchemaID, newValueSchemaId);
       updateStore(clusterName, storeName, new UpdateStoreQueryParams().setLatestSupersetSchemaId(newValueSchemaId));
     }
 
@@ -3126,7 +3124,6 @@ public class VeniceParentHelixAdmin implements Admin {
       } else {
         doUpdateSupersetSchemaID = false;
       }
-      LOGGER.info("DEBUGGING: doUpdate: {}", doUpdateSupersetSchemaID);
       SchemaEntry addedSchemaEntry =
           addValueSchemaEntry(clusterName, storeName, newValueSchemaStr, schemaId, doUpdateSupersetSchemaID);
 

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceParentHelixAdmin.java
@@ -3079,14 +3079,8 @@ public class VeniceParentHelixAdmin implements Admin {
       final boolean doUpdateSupersetSchemaID;
       if (existingValueSchema != null && (store.isReadComputationEnabled() || store.isWriteComputationEnabled())) {
         SupersetSchemaGenerator supersetSchemaGenerator = getSupersetSchemaGenerator(clusterName);
-        Schema newSuperSetSchema = supersetSchemaGenerator.generateSupersetSchema(newValueSchema, existingValueSchema);
+        Schema newSuperSetSchema = supersetSchemaGenerator.generateSupersetSchema(existingValueSchema, newValueSchema);
         String newSuperSetSchemaStr = newSuperSetSchema.toString();
-        LOGGER.info("DEBUGGING: ADD VALUE SCHEMA. NewSupersetSchema: {}", newSuperSetSchema.toString(true));
-        LOGGER.info("DEBUGGING: ADD VALUE SCHEMA. NewValueSchema: {}", newValueSchema.toString(true));
-        LOGGER.info(
-            "DEBUGGING: ADD VALUE SCHEMA. COMPARE: {}",
-            supersetSchemaGenerator.compareSchema(newSuperSetSchema, newValueSchema));
-
         if (supersetSchemaGenerator.compareSchema(newSuperSetSchema, newValueSchema)) {
           doUpdateSupersetSchemaID = true;
 

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/supersetschema/DefaultSupersetSchemaGenerator.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/supersetschema/DefaultSupersetSchemaGenerator.java
@@ -20,6 +20,6 @@ public class DefaultSupersetSchemaGenerator implements SupersetSchemaGenerator {
 
   @Override
   public Schema generateSupersetSchema(Schema existingSchema, Schema newSchema) {
-    return AvroSupersetSchemaUtils.generateSuperSetSchema(existingSchema, newSchema);
+    return AvroSupersetSchemaUtils.generateSupersetSchema(existingSchema, newSchema);
   }
 }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/supersetschema/DefaultSupersetSchemaGenerator.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/supersetschema/DefaultSupersetSchemaGenerator.java
@@ -20,6 +20,6 @@ public class DefaultSupersetSchemaGenerator implements SupersetSchemaGenerator {
 
   @Override
   public Schema generateSupersetSchema(Schema existingSchema, Schema newSchema) {
-    return AvroSupersetSchemaUtils.generateSuperSetSchema(existingSchema, newSchema);
+    return AvroSupersetSchemaUtils.generateSuperSetSchema(newSchema, existingSchema);
   }
 }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/supersetschema/DefaultSupersetSchemaGenerator.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/supersetschema/DefaultSupersetSchemaGenerator.java
@@ -20,6 +20,6 @@ public class DefaultSupersetSchemaGenerator implements SupersetSchemaGenerator {
 
   @Override
   public Schema generateSupersetSchema(Schema existingSchema, Schema newSchema) {
-    return AvroSupersetSchemaUtils.generateSuperSetSchema(newSchema, existingSchema);
+    return AvroSupersetSchemaUtils.generateSuperSetSchema(existingSchema, newSchema);
   }
 }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/supersetschema/SupersetSchemaGeneratorWithCustomProp.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/supersetschema/SupersetSchemaGeneratorWithCustomProp.java
@@ -76,7 +76,7 @@ public class SupersetSchemaGeneratorWithCustomProp implements SupersetSchemaGene
 
   @Override
   public Schema generateSupersetSchema(Schema existingSchema, Schema newSchema) {
-    Schema supersetSchema = AvroSupersetSchemaUtils.generateSuperSetSchema(existingSchema, newSchema);
+    Schema supersetSchema = AvroSupersetSchemaUtils.generateSupersetSchema(existingSchema, newSchema);
     String customPropInNewSchema = newSchema.getProp(customProp);
     if (customPropInNewSchema != null && supersetSchema.getProp(customProp) == null) {
       Schema newSupersetSchema = AvroSchemaParseUtils.parseSchemaFromJSONLooseValidation(supersetSchema.toString());

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/supersetschema/SupersetSchemaGeneratorWithCustomProp.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/supersetschema/SupersetSchemaGeneratorWithCustomProp.java
@@ -76,7 +76,7 @@ public class SupersetSchemaGeneratorWithCustomProp implements SupersetSchemaGene
 
   @Override
   public Schema generateSupersetSchema(Schema existingSchema, Schema newSchema) {
-    Schema supersetSchema = AvroSupersetSchemaUtils.generateSuperSetSchema(existingSchema, newSchema);
+    Schema supersetSchema = AvroSupersetSchemaUtils.generateSuperSetSchema(newSchema, existingSchema);
     String customPropInNewSchema = newSchema.getProp(customProp);
     if (customPropInNewSchema != null && supersetSchema.getProp(customProp) == null) {
       Schema newSupersetSchema = AvroSchemaParseUtils.parseSchemaFromJSONLooseValidation(supersetSchema.toString());

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/supersetschema/SupersetSchemaGeneratorWithCustomProp.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/supersetschema/SupersetSchemaGeneratorWithCustomProp.java
@@ -76,7 +76,7 @@ public class SupersetSchemaGeneratorWithCustomProp implements SupersetSchemaGene
 
   @Override
   public Schema generateSupersetSchema(Schema existingSchema, Schema newSchema) {
-    Schema supersetSchema = AvroSupersetSchemaUtils.generateSuperSetSchema(newSchema, existingSchema);
+    Schema supersetSchema = AvroSupersetSchemaUtils.generateSuperSetSchema(existingSchema, newSchema);
     String customPropInNewSchema = newSchema.getProp(customProp);
     if (customPropInNewSchema != null && supersetSchema.getProp(customProp) == null) {
       Schema newSupersetSchema = AvroSchemaParseUtils.parseSchemaFromJSONLooseValidation(supersetSchema.toString());

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/systemstore/SystemStoreRepairTask.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/systemstore/SystemStoreRepairTask.java
@@ -224,7 +224,6 @@ public class SystemStoreRepairTask implements Runnable {
       }
 
       long retrievedHeartbeatTimestamp = getHeartbeatFromSystemStore(clusterName, entry.getKey());
-      LOGGER.info("DEBUGGING: {} {} {}", entry.getKey(), entry.getValue(), retrievedHeartbeatTimestamp);
       if (retrievedHeartbeatTimestamp < entry.getValue()) {
         newUnhealthySystemStoreSet.add(entry.getKey());
         if (retrievedHeartbeatTimestamp == -1) {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/util/ParentControllerConfigUpdateUtils.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/util/ParentControllerConfigUpdateUtils.java
@@ -152,6 +152,7 @@ public class ParentControllerConfigUpdateUtils {
       } catch (Exception e) {
         // Allow failure in update schema generation in all schema except the latest value schema
         if (valueSchemaEntry.getId() == maxId) {
+          LOGGER.info("DEBUGGING TO BE GENERATED SCHEMA: {}", valueSchemaEntry.getSchema().toString(true));
           throw new VeniceException(
               "For store " + storeName + " cannot generate update schema for value schema ID :"
                   + valueSchemaEntry.getId() + ", top level field probably missing defaults.",

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/util/ParentControllerConfigUpdateUtils.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/util/ParentControllerConfigUpdateUtils.java
@@ -152,7 +152,6 @@ public class ParentControllerConfigUpdateUtils {
       } catch (Exception e) {
         // Allow failure in update schema generation in all schema except the latest value schema
         if (valueSchemaEntry.getId() == maxId) {
-          LOGGER.info("DEBUGGING TO BE GENERATED SCHEMA: {}", valueSchemaEntry.getSchema().toString(true));
           throw new VeniceException(
               "For store " + storeName + " cannot generate update schema for value schema ID :"
                   + valueSchemaEntry.getId() + ", top level field probably missing defaults.",


### PR DESCRIPTION


<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## [controller] Superset schema generation should reflect default value updates in new value schema
When user updates a field default value, we should reflect it in the changes in superset schema, which is used in read-compute / partial update store. This should apply to all the value type, including union schema. 

## How was this PR tested?
Add a new integration test to validate
## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.