### PR TITLE
[fast-client] Replace per-store per-route tracking by per-route tracking

### DIFF
--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/BatchGetRequestContext.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/BatchGetRequestContext.java
@@ -1,5 +1,8 @@
 package com.linkedin.venice.fastclient;
 
+import com.linkedin.venice.read.RequestType;
+
+
 /**
  * Keep track of the progress of a batch get request . This includes tracking
  * all the scatter requests and utilities to gather responses.
@@ -9,5 +12,10 @@ package com.linkedin.venice.fastclient;
 public class BatchGetRequestContext<K, V> extends MultiKeyRequestContext<K, V> {
   public BatchGetRequestContext(int numKeysInRequest, boolean isPartialSuccessAllowed) {
     super(numKeysInRequest, isPartialSuccessAllowed);
+  }
+
+  @Override
+  public RequestType getRequestType() {
+    return RequestType.MULTI_GET_STREAMING;
   }
 }

--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/ComputeRequestContext.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/ComputeRequestContext.java
@@ -1,5 +1,8 @@
 package com.linkedin.venice.fastclient;
 
+import com.linkedin.venice.read.RequestType;
+
+
 /**
  * Keep track of the progress of a compute request . This includes tracking
  * all the scatter requests and utilities to gather responses.
@@ -9,5 +12,10 @@ package com.linkedin.venice.fastclient;
 public class ComputeRequestContext<K, V> extends MultiKeyRequestContext<K, V> {
   public ComputeRequestContext(int numKeysInRequest, boolean isPartialSuccessAllowed) {
     super(numKeysInRequest, isPartialSuccessAllowed);
+  }
+
+  @Override
+  public RequestType getRequestType() {
+    return RequestType.COMPUTE_STREAMING;
   }
 }

--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/DispatchingAvroGenericStoreClient.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/DispatchingAvroGenericStoreClient.java
@@ -195,6 +195,7 @@ public class DispatchingAvroGenericStoreClient<K, V> extends InternalAvroStoreCl
   @Override
   protected CompletableFuture<V> get(GetRequestContext requestContext, K key) throws VeniceClientException {
     verifyMetadataInitialized();
+    requestContext.serverClusterName = metadata.getClusterName();
     requestContext.instanceHealthMonitor = metadata.getInstanceHealthMonitor();
     if (requestContext.requestUri == null) {
       /**
@@ -425,6 +426,7 @@ public class DispatchingAvroGenericStoreClient<K, V> extends InternalAvroStoreCl
 
     long requestId = REQUEST_ID_GENERATOR.getAndIncrement();
 
+    requestContext.serverClusterName = metadata.getClusterName();
     /* Prepare each of the routes needed to query the keys */
     requestContext.instanceHealthMonitor = metadata.getInstanceHealthMonitor();
     int currentVersion = requestContext.currentVersion;

--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/GetRequestContext.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/GetRequestContext.java
@@ -1,5 +1,8 @@
 package com.linkedin.venice.fastclient;
 
+import com.linkedin.venice.read.RequestType;
+
+
 public class GetRequestContext extends RequestContext {
   int partitionId;
   /**
@@ -12,6 +15,11 @@ public class GetRequestContext extends RequestContext {
     partitionId = -1;
     requestUri = null;
     retryContext = null;
+  }
+
+  @Override
+  public RequestType getRequestType() {
+    return RequestType.SINGLE_GET;
   }
 
   static class RetryContext {

--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/RequestContext.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/RequestContext.java
@@ -1,6 +1,7 @@
 package com.linkedin.venice.fastclient;
 
 import com.linkedin.venice.fastclient.meta.InstanceHealthMonitor;
+import com.linkedin.venice.read.RequestType;
 import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -10,7 +11,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 /**
  * This class is used to include all the intermediate fields required for the communication between the different tiers.
  */
-public class RequestContext {
+public abstract class RequestContext {
   int currentVersion = -1;
   boolean noAvailableReplica = false;
 
@@ -28,6 +29,10 @@ public class RequestContext {
 
   Map<String, CompletableFuture<Integer>> routeRequestMap = new VeniceConcurrentHashMap<>();
 
+  String serverClusterName;
+
   public RequestContext() {
   }
+
+  public abstract RequestType getRequestType();
 }

--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/StatsAvroGenericStoreClient.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/StatsAvroGenericStoreClient.java
@@ -16,11 +16,13 @@ import com.linkedin.venice.client.store.streaming.StreamingCallback;
 import com.linkedin.venice.client.store.streaming.StreamingResponseTracker;
 import com.linkedin.venice.compute.ComputeRequestWrapper;
 import com.linkedin.venice.fastclient.meta.InstanceHealthMonitor;
+import com.linkedin.venice.fastclient.stats.ClusterRouteStats;
 import com.linkedin.venice.fastclient.stats.ClusterStats;
 import com.linkedin.venice.fastclient.stats.FastClientStats;
 import com.linkedin.venice.read.RequestType;
 import com.linkedin.venice.utils.LatencyUtils;
 import com.linkedin.venice.utils.Time;
+import io.tehuti.metrics.MetricsRepository;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -38,6 +40,8 @@ public class StatsAvroGenericStoreClient<K, V> extends DelegatingAvroStoreClient
   private final FastClientStats clientStatsForStreamingBatchGet;
   private final FastClientStats clientStatsForStreamingCompute;
   private final ClusterStats clusterStats;
+  private final MetricsRepository metricsRepository;
+  private final ClusterRouteStats clusterRouteStats;
 
   public StatsAvroGenericStoreClient(InternalAvroStoreClient<K, V> delegate, ClientConfig clientConfig) {
     super(delegate, clientConfig);
@@ -45,6 +49,8 @@ public class StatsAvroGenericStoreClient<K, V> extends DelegatingAvroStoreClient
     this.clientStatsForStreamingBatchGet = clientConfig.getStats(RequestType.MULTI_GET_STREAMING);
     this.clientStatsForStreamingCompute = clientConfig.getStats(RequestType.COMPUTE_STREAMING);
     this.clusterStats = clientConfig.getClusterStats();
+    this.metricsRepository = clientConfig.getMetricsRepository();
+    this.clusterRouteStats = ClusterRouteStats.get();
   }
 
   @Override
@@ -242,6 +248,11 @@ public class StatsAvroGenericStoreClient<K, V> extends DelegatingAvroStoreClient
       }
       replicaRequestFuture.forEach((instance, future) -> {
         future.whenComplete((status, throwable) -> {
+          ClusterRouteStats.RouteStats routeStats = clusterRouteStats.getRouteStats(
+              metricsRepository,
+              requestContext.serverClusterName,
+              instance,
+              requestContext.getRequestType());
           if (monitor != null) {
             clusterStats.recordPendingRequestCount(instance, monitor.getPendingRequestCounter(instance));
           }
@@ -252,29 +263,28 @@ public class StatsAvroGenericStoreClient<K, V> extends DelegatingAvroStoreClient
                 : SC_SERVICE_UNAVAILABLE;
           }
 
-          clientStats.recordRequest(instance);
-          clientStats
-              .recordResponseWaitingTime(instance, LatencyUtils.getElapsedTimeFromNSToMS(requestSentTimestampNS));
+          routeStats.recordRequest();
+          routeStats.recordResponseWaitingTime(LatencyUtils.getElapsedTimeFromNSToMS(requestSentTimestampNS));
           switch (status) {
             case SC_OK:
             case SC_NOT_FOUND:
-              clientStats.recordHealthyRequest(instance);
+              routeStats.recordHealthyRequest();
               break;
             case SC_TOO_MANY_REQUESTS:
-              clientStats.recordQuotaExceededRequest(instance);
+              routeStats.recordQuotaExceededRequest();
               break;
             case SC_INTERNAL_SERVER_ERROR:
-              clientStats.recordInternalServerErrorRequest(instance);
+              routeStats.recordInternalServerErrorRequest();
               break;
             case SC_GONE:
               /* Check {@link InstanceHealthMonitor#trackHealthBasedOnRequestToInstance} to understand this special http status. */
-              clientStats.recordLeakedRequest(instance);
+              routeStats.recordLeakedRequest();
               break;
             case SC_SERVICE_UNAVAILABLE:
-              clientStats.recordServiceUnavailableRequest(instance);
+              routeStats.recordServiceUnavailableRequest();
               break;
             default:
-              clientStats.recordOtherErrorRequest(instance);
+              routeStats.recordOtherErrorRequest();
           }
         });
       });

--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/StatsAvroGenericStoreClient.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/StatsAvroGenericStoreClient.java
@@ -259,9 +259,6 @@ public class StatsAvroGenericStoreClient<K, V> extends DelegatingAvroStoreClient
               requestContext.serverClusterName,
               instance,
               requestContext.getRequestType());
-          if (monitor != null) {
-            clusterStats.recordPendingRequestCount(instance, monitor.getPendingRequestCounter(instance));
-          }
 
           if (throwable != null) {
             status = (throwable instanceof VeniceClientHttpException)

--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/StatsAvroGenericStoreClient.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/StatsAvroGenericStoreClient.java
@@ -250,6 +250,12 @@ public class StatsAvroGenericStoreClient<K, V> extends DelegatingAvroStoreClient
         future.whenComplete((status, throwable) -> {
           ClusterRouteStats.RouteStats routeStats = clusterRouteStats.getRouteStats(
               metricsRepository,
+              /**
+               * There is a race condition during store migration and the cluster name might not match
+               * with the requested instance.
+               * It is fine for tracking purpose as it would only happen for a very short period and
+               * the wrong cluster/instance combination will be deprecated soon because of a short lifetime.
+               */
               requestContext.serverClusterName,
               instance,
               requestContext.getRequestType());

--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/meta/RequestBasedMetadata.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/meta/RequestBasedMetadata.java
@@ -112,7 +112,7 @@ public class RequestBasedMetadata extends AbstractStoreMetadata {
   private volatile boolean isServiceDiscovered;
   private volatile boolean isReady;
   private CountDownLatch isReadyLatch = new CountDownLatch(1);
-  private AtomicReference<String> serverClusterName;
+  private AtomicReference<String> serverClusterName = new AtomicReference<>();
 
   private Set<String> harClusters;
 

--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/meta/RequestBasedMetadata.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/meta/RequestBasedMetadata.java
@@ -112,6 +112,7 @@ public class RequestBasedMetadata extends AbstractStoreMetadata {
   private volatile boolean isServiceDiscovered;
   private volatile boolean isReady;
   private CountDownLatch isReadyLatch = new CountDownLatch(1);
+  private String serverClusterName;
 
   private Set<String> harClusters;
 
@@ -144,6 +145,11 @@ public class RequestBasedMetadata extends AbstractStoreMetadata {
   // For unit tests only
   synchronized void setMetadataResponseSchemaReader(RouterBackedSchemaReader metadataResponseSchemaReader) {
     this.metadataResponseSchemaReader = metadataResponseSchemaReader;
+  }
+
+  @Override
+  public String getClusterName() {
+    return serverClusterName;
   }
 
   @Override
@@ -220,6 +226,7 @@ public class RequestBasedMetadata extends AbstractStoreMetadata {
       d2TransportClient.setServiceName(clusterDiscoveryD2ServiceName);
       String serverD2ServiceName = d2ServiceDiscovery.find(d2TransportClient, storeName, true).getServerD2Service();
       d2TransportClient.setServiceName(serverD2ServiceName);
+      serverClusterName = serverD2ServiceName;
       isServiceDiscovered = true;
       if (harClusters.contains(serverD2ServiceName)) {
         LOGGER.info(

--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/meta/RequestBasedMetadata.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/meta/RequestBasedMetadata.java
@@ -112,7 +112,7 @@ public class RequestBasedMetadata extends AbstractStoreMetadata {
   private volatile boolean isServiceDiscovered;
   private volatile boolean isReady;
   private CountDownLatch isReadyLatch = new CountDownLatch(1);
-  private String serverClusterName;
+  private AtomicReference<String> serverClusterName;
 
   private Set<String> harClusters;
 
@@ -149,7 +149,7 @@ public class RequestBasedMetadata extends AbstractStoreMetadata {
 
   @Override
   public String getClusterName() {
-    return serverClusterName;
+    return serverClusterName.get();
   }
 
   @Override
@@ -226,7 +226,7 @@ public class RequestBasedMetadata extends AbstractStoreMetadata {
       d2TransportClient.setServiceName(clusterDiscoveryD2ServiceName);
       String serverD2ServiceName = d2ServiceDiscovery.find(d2TransportClient, storeName, true).getServerD2Service();
       d2TransportClient.setServiceName(serverD2ServiceName);
-      serverClusterName = serverD2ServiceName;
+      serverClusterName.set(serverD2ServiceName);
       isServiceDiscovered = true;
       if (harClusters.contains(serverD2ServiceName)) {
         LOGGER.info(

--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/meta/StoreMetadata.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/meta/StoreMetadata.java
@@ -18,6 +18,8 @@ import java.util.concurrent.CompletableFuture;
  * to decide the healthiness of each replica.
  */
 public interface StoreMetadata extends SchemaReader {
+  String getClusterName();
+
   String getStoreName();
 
   int getCurrentStoreVersion();

--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/stats/ClusterRouteStats.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/stats/ClusterRouteStats.java
@@ -39,7 +39,7 @@ public class ClusterRouteStats {
       String instanceName = instanceUrl;
       try {
         URL url = new URL(instanceUrl);
-        instanceName = url.getHost() + "_" + url.getPort();
+        instanceName = url.getHost();
       } catch (MalformedURLException e) {
         LOGGER.error("Invalid instance url: {}", instanceUrl);
       }

--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/stats/ClusterRouteStats.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/stats/ClusterRouteStats.java
@@ -1,0 +1,115 @@
+package com.linkedin.venice.fastclient.stats;
+
+import com.linkedin.venice.read.RequestType;
+import com.linkedin.venice.stats.AbstractVeniceHttpStats;
+import com.linkedin.venice.stats.StatsUtils;
+import com.linkedin.venice.stats.TehutiUtils;
+import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
+import io.tehuti.metrics.MetricsRepository;
+import io.tehuti.metrics.Sensor;
+import io.tehuti.metrics.stats.OccurrenceRate;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Map;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+
+public class ClusterRouteStats {
+  private static final Logger LOGGER = LogManager.getLogger(ClusterRouteStats.class);
+
+  private static final ClusterRouteStats DEFAULT = new ClusterRouteStats();
+
+  private final Map<String, RouteStats> perRouteStatMap = new VeniceConcurrentHashMap<>();
+
+  public static ClusterRouteStats get() {
+    return DEFAULT;
+  }
+
+  private ClusterRouteStats() {
+  }
+
+  public RouteStats getRouteStats(
+      MetricsRepository metricsRepository,
+      String clusterName,
+      String instanceUrl,
+      RequestType requestType) {
+    String combinedKey = clusterName + "-" + instanceUrl + "-" + requestType.toString();
+    return perRouteStatMap.computeIfAbsent(combinedKey, ignored -> {
+      String instanceName = instanceUrl;
+      try {
+        URL url = new URL(instanceUrl);
+        instanceName = url.getHost() + "_" + url.getPort();
+      } catch (MalformedURLException e) {
+        LOGGER.error("Invalid instance url: {}", instanceUrl);
+      }
+      return new RouteStats(metricsRepository, clusterName, instanceName, requestType);
+    });
+  }
+
+  /**
+   * Per-route request metrics.
+   */
+  public static class RouteStats extends AbstractVeniceHttpStats {
+    private final Sensor requestCountSensor;
+    private final Sensor responseWaitingTimeSensor;
+    private final Sensor healthyRequestCountSensor;
+    private final Sensor quotaExceededRequestCountSensor;
+    private final Sensor internalServerErrorRequestCountSensor;
+    private final Sensor serviceUnavailableRequestCountSensor;
+    private final Sensor leakedRequestCountSensor;
+    private final Sensor otherErrorRequestCountSensor;
+
+    public RouteStats(
+        MetricsRepository metricsRepository,
+        String clusterName,
+        String instanceName,
+        RequestType requestType) {
+      super(metricsRepository, clusterName + "." + StatsUtils.convertHostnameToMetricName(instanceName), requestType);
+      this.requestCountSensor = registerSensor("request_count", new OccurrenceRate());
+      this.responseWaitingTimeSensor = registerSensor(
+          "response_waiting_time",
+          TehutiUtils.getPercentileStat(getName(), getFullMetricName("response_waiting_time")));
+      this.healthyRequestCountSensor = registerSensor("healthy_request_count", new OccurrenceRate());
+      this.quotaExceededRequestCountSensor = registerSensor("quota_exceeded_request_count", new OccurrenceRate());
+      this.internalServerErrorRequestCountSensor =
+          registerSensor("internal_server_error_request_count", new OccurrenceRate());
+      this.serviceUnavailableRequestCountSensor =
+          registerSensor("service_unavailable_request_count", new OccurrenceRate());
+      this.leakedRequestCountSensor = registerSensor("leaked_request_count", new OccurrenceRate());
+      this.otherErrorRequestCountSensor = registerSensor("other_error_request_count", new OccurrenceRate());
+    }
+
+    public void recordRequest() {
+      requestCountSensor.record();
+    }
+
+    public void recordResponseWaitingTime(double latency) {
+      responseWaitingTimeSensor.record(latency);
+    }
+
+    public void recordHealthyRequest() {
+      healthyRequestCountSensor.record();
+    }
+
+    public void recordQuotaExceededRequest() {
+      quotaExceededRequestCountSensor.record();
+    }
+
+    public void recordInternalServerErrorRequest() {
+      internalServerErrorRequestCountSensor.record();
+    }
+
+    public void recordServiceUnavailableRequest() {
+      serviceUnavailableRequestCountSensor.record();
+    }
+
+    public void recordLeakedRequest() {
+      leakedRequestCountSensor.record();
+    }
+
+    public void recordOtherErrorRequest() {
+      otherErrorRequestCountSensor.record();
+    }
+  }
+}

--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/stats/ClusterStats.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/stats/ClusterStats.java
@@ -1,8 +1,6 @@
 package com.linkedin.venice.fastclient.stats;
 
 import com.linkedin.venice.stats.AbstractVeniceStats;
-import com.linkedin.venice.stats.StatsUtils;
-import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
 import io.tehuti.Metric;
 import io.tehuti.metrics.MetricsRepository;
 import io.tehuti.metrics.Sensor;
@@ -10,11 +8,8 @@ import io.tehuti.metrics.stats.AsyncGauge;
 import io.tehuti.metrics.stats.Avg;
 import io.tehuti.metrics.stats.Max;
 import io.tehuti.metrics.stats.OccurrenceRate;
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -28,7 +23,6 @@ public class ClusterStats extends AbstractVeniceStats {
   private static final Logger LOGGER = LogManager.getLogger(ClusterStats.class);
 
   private final String storeName;
-  private final Map<String, RouteStats> perRouteStats = new VeniceConcurrentHashMap<>();
   private final Sensor blockedInstanceCount;
   private final Sensor unhealthyInstanceCount;
   private final Sensor versionUpdateFailureSensor;
@@ -55,10 +49,6 @@ public class ClusterStats extends AbstractVeniceStats {
     this.unhealthyInstanceCount.record(count);
   }
 
-  public void recordPendingRequestCount(String instance, int count) {
-    getRouteStats(instance).recordPendingRequestCount(count);
-  }
-
   public void updateCurrentVersion(int currentVersion) {
     this.currentVersion = currentVersion;
   }
@@ -74,32 +64,5 @@ public class ClusterStats extends AbstractVeniceStats {
       return (metric != null ? metric.value() : Double.NaN);
     }).collect(Collectors.toList());
     return collect;
-  }
-
-  private RouteStats getRouteStats(String instanceUrl) {
-    return perRouteStats.computeIfAbsent(instanceUrl, k -> {
-      String instanceName = instanceUrl;
-      try {
-        URL url = new URL(instanceUrl);
-        instanceName = url.getHost() + "_" + url.getPort();
-      } catch (MalformedURLException e) {
-        LOGGER.error("Invalid instance url: {}", instanceUrl);
-      }
-      return new RouteStats(getMetricsRepository(), storeName, instanceName);
-    });
-  }
-
-  private static class RouteStats extends AbstractVeniceStats {
-    private final Sensor pendingRequestCounterSensor;
-
-    public RouteStats(MetricsRepository metricsRepository, String storeName, String instanceName) {
-      super(metricsRepository, storeName + "." + StatsUtils.convertHostnameToMetricName(instanceName));
-
-      this.pendingRequestCounterSensor = registerSensor("pending_request_count", new Avg(), new Max());
-    }
-
-    public void recordPendingRequestCount(int count) {
-      pendingRequestCounterSensor.record(count);
-    }
   }
 }

--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/stats/FastClientStats.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/stats/FastClientStats.java
@@ -1,10 +1,7 @@
 package com.linkedin.venice.fastclient.stats;
 
 import com.linkedin.venice.read.RequestType;
-import com.linkedin.venice.stats.AbstractVeniceStats;
-import com.linkedin.venice.stats.StatsUtils;
 import com.linkedin.venice.stats.TehutiUtils;
-import com.linkedin.venice.utils.concurrent.VeniceConcurrentHashMap;
 import io.tehuti.Metric;
 import io.tehuti.metrics.MetricsRepository;
 import io.tehuti.metrics.Sensor;
@@ -13,20 +10,13 @@ import io.tehuti.metrics.stats.Avg;
 import io.tehuti.metrics.stats.Max;
 import io.tehuti.metrics.stats.OccurrenceRate;
 import io.tehuti.metrics.stats.Rate;
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 
 public class FastClientStats extends com.linkedin.venice.client.stats.ClientStats {
-  private static final Logger LOGGER = LogManager.getLogger(FastClientStats.class);
-
   private final String storeName;
 
   private final Sensor noAvailableReplicaRequestCountSensor;
@@ -45,9 +35,6 @@ public class FastClientStats extends com.linkedin.venice.client.stats.ClientStat
   private final Sensor fanoutSizeSensor;
   private final Sensor retryFanoutSizeSensor;
   private long cacheTimeStampInMs = 0;
-
-  // Routing stats
-  private final Map<String, RouteStats> perRouteStats = new VeniceConcurrentHashMap<>();
 
   public static FastClientStats getClientStats(
       MetricsRepository metricsRepository,
@@ -117,52 +104,6 @@ public class FastClientStats extends com.linkedin.venice.client.stats.ClientStat
     dualReadThinClientFastClientLatencyDeltaSensor.record(latencyDelta);
   }
 
-  private RouteStats getRouteStats(String instanceUrl) {
-    return perRouteStats.computeIfAbsent(instanceUrl, k -> {
-      String instanceName = instanceUrl;
-      try {
-        URL url = new URL(instanceUrl);
-        instanceName = url.getHost() + "_" + url.getPort();
-      } catch (MalformedURLException e) {
-        LOGGER.error("Invalid instance url: {}", instanceUrl);
-      }
-      return new RouteStats(getMetricsRepository(), storeName, instanceName);
-    });
-  }
-
-  public void recordRequest(String instance) {
-    getRouteStats(instance).recordRequest();
-  }
-
-  public void recordResponseWaitingTime(String instance, double latency) {
-    getRouteStats(instance).recordResponseWaitingTime(latency);
-  }
-
-  public void recordHealthyRequest(String instance) {
-    getRouteStats(instance).recordHealthyRequest();
-  }
-
-  public void recordQuotaExceededRequest(String instance) {
-    getRouteStats(instance).recordQuotaExceededRequest();
-  }
-
-  public void recordInternalServerErrorRequest(String instance) {
-    getRouteStats(instance).recordInternalServerErrorRequest();
-  }
-
-  public void recordServiceUnavailableRequest(String instance) {
-    getRouteStats(instance).recordServiceUnavailableRequest();
-  }
-
-  public void recordLeakedRequest(String instance) {
-    leakedRequestCountSensor.record();
-    getRouteStats(instance).recordLeakedRequest();
-  }
-
-  public void recordOtherErrorRequest(String instance) {
-    getRouteStats(instance).recordOtherErrorRequest();
-  }
-
   public void recordLongTailRetryRequest() {
     longTailRetryRequestSensor.record();
   }
@@ -218,66 +159,5 @@ public class FastClientStats extends com.linkedin.venice.client.stats.ClientStat
       return (metric != null ? metric.value() : Double.NaN);
     }).collect(Collectors.toList());
     return collect;
-  }
-
-  /**
-   * Per-route request metrics.
-   */
-  private static class RouteStats extends AbstractVeniceStats {
-    private final Sensor requestCountSensor;
-    private final Sensor responseWaitingTimeSensor;
-    private final Sensor healthyRequestCountSensor;
-    private final Sensor quotaExceededRequestCountSensor;
-    private final Sensor internalServerErrorRequestCountSensor;
-    private final Sensor serviceUnavailableRequestCountSensor;
-    private final Sensor leakedRequestCountSensor;
-    private final Sensor otherErrorRequestCountSensor;
-
-    public RouteStats(MetricsRepository metricsRepository, String storeName, String instanceName) {
-      super(metricsRepository, storeName + "." + StatsUtils.convertHostnameToMetricName(instanceName));
-      this.requestCountSensor = registerSensor("request_count", new OccurrenceRate());
-      this.responseWaitingTimeSensor =
-          registerSensor("response_waiting_time", TehutiUtils.getPercentileStat(getName(), "response_waiting_time"));
-      this.healthyRequestCountSensor = registerSensor("healthy_request_count", new OccurrenceRate());
-      this.quotaExceededRequestCountSensor = registerSensor("quota_exceeded_request_count", new OccurrenceRate());
-      this.internalServerErrorRequestCountSensor =
-          registerSensor("internal_server_error_request_count", new OccurrenceRate());
-      this.serviceUnavailableRequestCountSensor =
-          registerSensor("service_unavailable_request_count", new OccurrenceRate());
-      this.leakedRequestCountSensor = registerSensor("leaked_request_count", new OccurrenceRate());
-      this.otherErrorRequestCountSensor = registerSensor("other_error_request_count", new OccurrenceRate());
-    }
-
-    public void recordRequest() {
-      requestCountSensor.record();
-    }
-
-    public void recordResponseWaitingTime(double latency) {
-      responseWaitingTimeSensor.record(latency);
-    }
-
-    public void recordHealthyRequest() {
-      healthyRequestCountSensor.record();
-    }
-
-    public void recordQuotaExceededRequest() {
-      quotaExceededRequestCountSensor.record();
-    }
-
-    public void recordInternalServerErrorRequest() {
-      internalServerErrorRequestCountSensor.record();
-    }
-
-    public void recordServiceUnavailableRequest() {
-      serviceUnavailableRequestCountSensor.record();
-    }
-
-    public void recordLeakedRequest() {
-      leakedRequestCountSensor.record();
-    }
-
-    public void recordOtherErrorRequest() {
-      otherErrorRequestCountSensor.record();
-    }
   }
 }

--- a/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/DispatchingAvroGenericStoreClientTest.java
+++ b/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/DispatchingAvroGenericStoreClientTest.java
@@ -15,7 +15,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
@@ -476,19 +475,6 @@ public class DispatchingAvroGenericStoreClientTest {
 
     if (noAvailableReplicas) {
       assertTrue(metrics.get(metricPrefix + "no_available_replica_request_count.OccurrenceRate").value() > 0);
-      TestUtils.waitForNonDeterministicAssertion(5, TimeUnit.SECONDS, () -> {
-        if (numBlockedReplicas == 2) {
-          // some test cases only have 1 replica having pending and some have 2.
-          assertNotNull(metrics.get(routeMetricsPrefix + "_" + REPLICA1_NAME + "--pending_request_count.Max"));
-          assertEquals(
-              metrics.get(routeMetricsPrefix + "_" + REPLICA1_NAME + "--pending_request_count.Max").value(),
-              1.0);
-        }
-        assertNotNull(metrics.get(routeMetricsPrefix + "_" + REPLICA2_NAME + "--pending_request_count.Max"));
-        assertEquals(
-            metrics.get(routeMetricsPrefix + "_" + REPLICA2_NAME + "--pending_request_count.Max").value(),
-            1.0);
-      });
       assertEquals(metrics.get(routeMetricsPrefix + "--blocked_instance_count.Max").value(), numBlockedReplicas);
       if (batchGet) {
         assertTrue(batchGetRequestContext.noAvailableReplica);

--- a/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/meta/RequestBasedMetadataTestUtils.java
+++ b/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/meta/RequestBasedMetadataTestUtils.java
@@ -54,6 +54,7 @@ public class RequestBasedMetadataTestUtils {
   public static final String NEW_REPLICA_NAME = "host3";
   public static final String KEY_SCHEMA = "\"string\"";
   public static final String VALUE_SCHEMA = "\"string\"";
+  public static final String SERVER_D2_SERVICE = "test-d2-service";
   private static final byte[] DICTIONARY = ZstdWithDictCompressor.buildDictionaryOnSyntheticAvroData();
 
   public static ClientConfig getMockClientConfig(String storeName) {
@@ -192,8 +193,8 @@ public class RequestBasedMetadataTestUtils {
 
   public static D2ServiceDiscovery getMockD2ServiceDiscovery(D2TransportClient d2TransportClient, String storeName) {
     D2ServiceDiscovery d2ServiceDiscovery = mock(D2ServiceDiscovery.class);
-
     D2ServiceDiscoveryResponse d2ServiceDiscoveryResponse = new D2ServiceDiscoveryResponse();
+    d2ServiceDiscoveryResponse.setServerD2Service(SERVER_D2_SERVICE);
 
     doReturn(d2ServiceDiscoveryResponse).when(d2ServiceDiscovery)
         .find(eq(d2TransportClient), eq(storeName), anyBoolean());

--- a/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/utils/TestClientSimulator.java
+++ b/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/utils/TestClientSimulator.java
@@ -555,6 +555,11 @@ public class TestClientSimulator implements Client {
 
     AbstractStoreMetadata metadata = new AbstractStoreMetadata(clientConfig) {
       @Override
+      public String getClusterName() {
+        return "test-cluster";
+      }
+
+      @Override
       public int getCurrentStoreVersion() {
         return 1;
       }


### PR DESCRIPTION
This PR is trying to reduce the total number of metrics emitted by fast-client.
Previously, Fast-Client will have the instance-level tracking for each store, which will create a lot of metrics when the application is using multiple stores, and this code change will only emit tacking metrics (qps, latency) in instance level rather than per store per instance.

This PR also removes the pending request metric, which is per store per route, and we will add back this metric in a separate PR when we improve `InstanceHealthMonitor` to be cluster-level instead of store-level.

<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->


<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->



## How was this PR tested?
CI
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.