### PR TITLE
[controller] Add support for controller instance tagging

### DIFF
--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -214,8 +214,8 @@ public class ConfigKeys {
   public static final String CONTROLLER_CLUSTER_ZK_ADDRESSS = "controller.cluster.zk.address";
   // Name of the Helix cluster for controllers
   public static final String CONTROLLER_CLUSTER = "controller.cluster.name";
-  // What tag to assign to a controller instance
-  public static final String CONTROLLER_INSTANCE_TAG = "controller.instance.tag";
+  // What tags to assign to a controller instance
+  public static final String CONTROLLER_INSTANCE_TAG_LIST = "controller.instance.tag.list";
 
   /** List of forbidden admin paths */
   public static final String CONTROLLER_DISABLED_ROUTES = "controller.cluster.disabled.routes";

--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -214,6 +214,8 @@ public class ConfigKeys {
   public static final String CONTROLLER_CLUSTER_ZK_ADDRESSS = "controller.cluster.zk.address";
   // Name of the Helix cluster for controllers
   public static final String CONTROLLER_CLUSTER = "controller.cluster.name";
+  // What tag to assign to a controller instance
+  public static final String CONTROLLER_INSTANCE_TAG = "controller.instance.tag";
 
   /** List of forbidden admin paths */
   public static final String CONTROLLER_DISABLED_ROUTES = "controller.cluster.disabled.routes";

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/AbstractTestVeniceHelixAdmin.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/AbstractTestVeniceHelixAdmin.java
@@ -1,19 +1,6 @@
 package com.linkedin.venice.controller;
 
-import static com.linkedin.venice.ConfigKeys.ADMIN_HELIX_MESSAGING_CHANNEL_ENABLED;
-import static com.linkedin.venice.ConfigKeys.CLUSTER_NAME;
-import static com.linkedin.venice.ConfigKeys.CLUSTER_TO_D2;
-import static com.linkedin.venice.ConfigKeys.CLUSTER_TO_SERVER_D2;
-import static com.linkedin.venice.ConfigKeys.CONTROLLER_ADD_VERSION_VIA_ADMIN_PROTOCOL;
-import static com.linkedin.venice.ConfigKeys.CONTROLLER_SSL_ENABLED;
-import static com.linkedin.venice.ConfigKeys.CONTROLLER_SYSTEM_SCHEMA_CLUSTER_NAME;
-import static com.linkedin.venice.ConfigKeys.DEFAULT_MAX_NUMBER_OF_PARTITIONS;
-import static com.linkedin.venice.ConfigKeys.DEFAULT_PARTITION_SIZE;
-import static com.linkedin.venice.ConfigKeys.KAFKA_BOOTSTRAP_SERVERS;
-import static com.linkedin.venice.ConfigKeys.KAFKA_REPLICATION_FACTOR;
-import static com.linkedin.venice.ConfigKeys.PARTICIPANT_MESSAGE_STORE_ENABLED;
-import static com.linkedin.venice.ConfigKeys.UNREGISTER_METRIC_FOR_DELETED_STORE_ENABLED;
-import static com.linkedin.venice.ConfigKeys.ZOOKEEPER_ADDRESS;
+import static com.linkedin.venice.ConfigKeys.*;
 
 import com.linkedin.venice.common.VeniceSystemStoreUtils;
 import com.linkedin.venice.exceptions.VeniceException;
@@ -92,6 +79,7 @@ class AbstractTestVeniceHelixAdmin {
       properties.put(ADMIN_HELIX_MESSAGING_CHANNEL_ENABLED, true);
     }
     properties.put(UNREGISTER_METRIC_FOR_DELETED_STORE_ENABLED, true);
+    properties.put(CONTROLLER_INSTANCE_TAG, "GENERAL");
     controllerProps = new VeniceProperties(properties);
     helixMessageChannelStats = new HelixMessageChannelStats(new MetricsRepository(), clusterName);
     controllerConfig = new VeniceControllerClusterConfig(controllerProps);

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/AbstractTestVeniceHelixAdmin.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/AbstractTestVeniceHelixAdmin.java
@@ -5,7 +5,7 @@ import static com.linkedin.venice.ConfigKeys.CLUSTER_NAME;
 import static com.linkedin.venice.ConfigKeys.CLUSTER_TO_D2;
 import static com.linkedin.venice.ConfigKeys.CLUSTER_TO_SERVER_D2;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_ADD_VERSION_VIA_ADMIN_PROTOCOL;
-import static com.linkedin.venice.ConfigKeys.CONTROLLER_INSTANCE_TAG;
+import static com.linkedin.venice.ConfigKeys.CONTROLLER_INSTANCE_TAG_LIST;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_SSL_ENABLED;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_SYSTEM_SCHEMA_CLUSTER_NAME;
 import static com.linkedin.venice.ConfigKeys.DEFAULT_MAX_NUMBER_OF_PARTITIONS;
@@ -93,7 +93,7 @@ class AbstractTestVeniceHelixAdmin {
       properties.put(ADMIN_HELIX_MESSAGING_CHANNEL_ENABLED, true);
     }
     properties.put(UNREGISTER_METRIC_FOR_DELETED_STORE_ENABLED, true);
-    properties.put(CONTROLLER_INSTANCE_TAG, "GENERAL");
+    properties.put(CONTROLLER_INSTANCE_TAG_LIST, "GENERAL,TEST");
     controllerProps = new VeniceProperties(properties);
     helixMessageChannelStats = new HelixMessageChannelStats(new MetricsRepository(), clusterName);
     controllerConfig = new VeniceControllerClusterConfig(controllerProps);

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/AbstractTestVeniceHelixAdmin.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/AbstractTestVeniceHelixAdmin.java
@@ -1,6 +1,20 @@
 package com.linkedin.venice.controller;
 
-import static com.linkedin.venice.ConfigKeys.*;
+import static com.linkedin.venice.ConfigKeys.ADMIN_HELIX_MESSAGING_CHANNEL_ENABLED;
+import static com.linkedin.venice.ConfigKeys.CLUSTER_NAME;
+import static com.linkedin.venice.ConfigKeys.CLUSTER_TO_D2;
+import static com.linkedin.venice.ConfigKeys.CLUSTER_TO_SERVER_D2;
+import static com.linkedin.venice.ConfigKeys.CONTROLLER_ADD_VERSION_VIA_ADMIN_PROTOCOL;
+import static com.linkedin.venice.ConfigKeys.CONTROLLER_INSTANCE_TAG;
+import static com.linkedin.venice.ConfigKeys.CONTROLLER_SSL_ENABLED;
+import static com.linkedin.venice.ConfigKeys.CONTROLLER_SYSTEM_SCHEMA_CLUSTER_NAME;
+import static com.linkedin.venice.ConfigKeys.DEFAULT_MAX_NUMBER_OF_PARTITIONS;
+import static com.linkedin.venice.ConfigKeys.DEFAULT_PARTITION_SIZE;
+import static com.linkedin.venice.ConfigKeys.KAFKA_BOOTSTRAP_SERVERS;
+import static com.linkedin.venice.ConfigKeys.KAFKA_REPLICATION_FACTOR;
+import static com.linkedin.venice.ConfigKeys.PARTICIPANT_MESSAGE_STORE_ENABLED;
+import static com.linkedin.venice.ConfigKeys.UNREGISTER_METRIC_FOR_DELETED_STORE_ENABLED;
+import static com.linkedin.venice.ConfigKeys.ZOOKEEPER_ADDRESS;
 
 import com.linkedin.venice.common.VeniceSystemStoreUtils;
 import com.linkedin.venice.exceptions.VeniceException;

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestVeniceHelixAdminWithSharedEnvironment.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestVeniceHelixAdminWithSharedEnvironment.java
@@ -2075,7 +2075,6 @@ public class TestVeniceHelixAdminWithSharedEnvironment extends AbstractTestVenic
     List<String> instances =
         newHelixAdmin.getHelixAdmin().getInstancesInClusterWithTag(controllerClusterName, instanceTag);
     Assert.assertEquals(instances.size(), 2);
-    newHelixAdmin.close();
 
     // resume to the original venice admin
     veniceAdmin.initStorageCluster(clusterName);

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestVeniceHelixAdminWithSharedEnvironment.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestVeniceHelixAdminWithSharedEnvironment.java
@@ -2058,30 +2058,12 @@ public class TestVeniceHelixAdminWithSharedEnvironment extends AbstractTestVenic
   public void testInstanceTagging() {
     List<String> instanceTagList = Arrays.asList("GENERAL", "TEST");
     String controllerClusterName = "venice-controllers";
-    int newAdminPort = controllerConfig.getAdminPort() + 1; /* Note: dummy port */
-    PropertyBuilder builder = new PropertyBuilder().put(controllerProps.toProperties()).put("admin.port", newAdminPort);
-
-    VeniceProperties newControllerProps = builder.build();
-    VeniceControllerClusterConfig newConfig = new VeniceControllerClusterConfig(newControllerProps);
-    VeniceHelixAdmin newHelixAdmin = new VeniceHelixAdmin(
-        TestUtils.getMultiClusterConfigFromOneCluster(newConfig),
-        new MetricsRepository(),
-        D2TestUtils.getAndStartD2Client(zkAddress),
-        pubSubTopicRepository,
-        pubSubBrokerWrapper.getPubSubClientsFactory());
-    // Start stand by controller
-    newHelixAdmin.initStorageCluster(clusterName);
 
     for (String instanceTag: instanceTagList) {
       List<String> instances =
-          newHelixAdmin.getHelixAdmin().getInstancesInClusterWithTag(controllerClusterName, instanceTag);
-      Assert.assertEquals(instances.size(), 2);
+          veniceAdmin.getHelixAdmin().getInstancesInClusterWithTag(controllerClusterName, instanceTag);
+      Assert.assertEquals(instances.size(), 1);
     }
-
-    // resume to the original venice admin
-    veniceAdmin.initStorageCluster(clusterName);
-    newHelixAdmin.close();
-    waitUntilIsLeader(veniceAdmin, clusterName, LEADER_CHANGE_TIMEOUT_MS);
   }
 
 }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestVeniceHelixAdminWithSharedEnvironment.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestVeniceHelixAdminWithSharedEnvironment.java
@@ -2063,19 +2063,24 @@ public class TestVeniceHelixAdminWithSharedEnvironment extends AbstractTestVenic
 
     VeniceProperties newControllerProps = builder.build();
     VeniceControllerClusterConfig newConfig = new VeniceControllerClusterConfig(newControllerProps);
-    VeniceHelixAdmin helixAdmin = new VeniceHelixAdmin(
+    VeniceHelixAdmin newHelixAdmin = new VeniceHelixAdmin(
         TestUtils.getMultiClusterConfigFromOneCluster(newConfig),
         new MetricsRepository(),
         D2TestUtils.getAndStartD2Client(zkAddress),
         pubSubTopicRepository,
         pubSubBrokerWrapper.getPubSubClientsFactory());
     // Start stand by controller
-    helixAdmin.initStorageCluster(clusterName);
+    newHelixAdmin.initStorageCluster(clusterName);
 
     List<String> instances =
-        helixAdmin.getHelixAdmin().getInstancesInClusterWithTag(controllerClusterName, instanceTag);
+        newHelixAdmin.getHelixAdmin().getInstancesInClusterWithTag(controllerClusterName, instanceTag);
     Assert.assertEquals(instances.size(), 2);
-    helixAdmin.close();
+    newHelixAdmin.close();
+
+    // resume to the original venice admin
+    veniceAdmin.initStorageCluster(clusterName);
+    newHelixAdmin.close();
+    waitUntilIsLeader(veniceAdmin, clusterName, LEADER_CHANGE_TIMEOUT_MS);
   }
 
 }

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestVeniceHelixAdminWithSharedEnvironment.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestVeniceHelixAdminWithSharedEnvironment.java
@@ -2056,7 +2056,7 @@ public class TestVeniceHelixAdminWithSharedEnvironment extends AbstractTestVenic
 
   @Test
   public void testInstanceTagging() {
-    String instanceTag = "GENERAL";
+    List<String> instanceTagList = Arrays.asList("GENERAL", "TEST");
     String controllerClusterName = "venice-controllers";
     int newAdminPort = controllerConfig.getAdminPort() + 1; /* Note: dummy port */
     PropertyBuilder builder = new PropertyBuilder().put(controllerProps.toProperties()).put("admin.port", newAdminPort);
@@ -2072,9 +2072,11 @@ public class TestVeniceHelixAdminWithSharedEnvironment extends AbstractTestVenic
     // Start stand by controller
     newHelixAdmin.initStorageCluster(clusterName);
 
-    List<String> instances =
-        newHelixAdmin.getHelixAdmin().getInstancesInClusterWithTag(controllerClusterName, instanceTag);
-    Assert.assertEquals(instances.size(), 2);
+    for (String instanceTag: instanceTagList) {
+      List<String> instances =
+          newHelixAdmin.getHelixAdmin().getInstancesInClusterWithTag(controllerClusterName, instanceTag);
+      Assert.assertEquals(instances.size(), 2);
+    }
 
     // resume to the original venice admin
     veniceAdmin.initStorageCluster(clusterName);

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/HelixAdminClient.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/HelixAdminClient.java
@@ -128,4 +128,9 @@ public interface HelixAdminClient {
    * Release resources.
    */
   void close();
+
+  /**
+   * Adds a tag to an instance
+   */
+  void addInstanceTag(String clusterName, String instanceName, String tag);
 }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerClusterConfig.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerClusterConfig.java
@@ -47,6 +47,7 @@ import static com.linkedin.venice.ConfigKeys.CONTROLLER_EARLY_DELETE_BACKUP_ENAB
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_ENABLE_DISABLED_REPLICA_ENABLED;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_ENFORCE_SSL;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_HAAS_SUPER_CLUSTER_NAME;
+import static com.linkedin.venice.ConfigKeys.CONTROLLER_INSTANCE_TAG;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_IN_AZURE_FABRIC;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_JETTY_CONFIG_OVERRIDE_PREFIX;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_MIN_SCHEMA_COUNT_TO_KEEP;
@@ -223,6 +224,7 @@ public class VeniceControllerClusterConfig {
   // Name of the Helix cluster for controllers
   private final String controllerClusterName;
   private final String controllerClusterZkAddress;
+  private final String controllerInstanceTag;
   private final boolean multiRegion;
   private final boolean parent;
   private final ParentControllerRegionState parentControllerRegionState;
@@ -635,6 +637,7 @@ public class VeniceControllerClusterConfig {
      */
     this.adminCheckReadMethodForKafka = props.getBoolean(ADMIN_CHECK_READ_METHOD_FOR_KAFKA, true);
     this.controllerClusterName = props.getString(CONTROLLER_CLUSTER, "venice-controllers");
+    this.controllerInstanceTag = props.getString(CONTROLLER_INSTANCE_TAG, "");
     this.controllerClusterReplica = props.getInt(CONTROLLER_CLUSTER_REPLICA, 3);
     this.controllerClusterZkAddress = props.getString(CONTROLLER_CLUSTER_ZK_ADDRESSS, getZkAddress());
     this.parent = props.getBoolean(CONTROLLER_PARENT_MODE, false);
@@ -1159,6 +1162,10 @@ public class VeniceControllerClusterConfig {
 
   public String getControllerClusterName() {
     return controllerClusterName;
+  }
+
+  public String getControllerInstanceTag() {
+    return controllerInstanceTag;
   }
 
   public String getControllerClusterZkAddress() {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerClusterConfig.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerClusterConfig.java
@@ -47,7 +47,7 @@ import static com.linkedin.venice.ConfigKeys.CONTROLLER_EARLY_DELETE_BACKUP_ENAB
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_ENABLE_DISABLED_REPLICA_ENABLED;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_ENFORCE_SSL;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_HAAS_SUPER_CLUSTER_NAME;
-import static com.linkedin.venice.ConfigKeys.CONTROLLER_INSTANCE_TAG;
+import static com.linkedin.venice.ConfigKeys.CONTROLLER_INSTANCE_TAG_LIST;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_IN_AZURE_FABRIC;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_JETTY_CONFIG_OVERRIDE_PREFIX;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_MIN_SCHEMA_COUNT_TO_KEEP;
@@ -224,7 +224,7 @@ public class VeniceControllerClusterConfig {
   // Name of the Helix cluster for controllers
   private final String controllerClusterName;
   private final String controllerClusterZkAddress;
-  private final String controllerInstanceTag;
+  private final List<String> controllerInstanceTagList;
   private final boolean multiRegion;
   private final boolean parent;
   private final ParentControllerRegionState parentControllerRegionState;
@@ -637,7 +637,7 @@ public class VeniceControllerClusterConfig {
      */
     this.adminCheckReadMethodForKafka = props.getBoolean(ADMIN_CHECK_READ_METHOD_FOR_KAFKA, true);
     this.controllerClusterName = props.getString(CONTROLLER_CLUSTER, "venice-controllers");
-    this.controllerInstanceTag = props.getString(CONTROLLER_INSTANCE_TAG, "");
+    this.controllerInstanceTagList = props.getList(CONTROLLER_INSTANCE_TAG_LIST, new ArrayList<>());
     this.controllerClusterReplica = props.getInt(CONTROLLER_CLUSTER_REPLICA, 3);
     this.controllerClusterZkAddress = props.getString(CONTROLLER_CLUSTER_ZK_ADDRESSS, getZkAddress());
     this.parent = props.getBoolean(CONTROLLER_PARENT_MODE, false);
@@ -1164,8 +1164,8 @@ public class VeniceControllerClusterConfig {
     return controllerClusterName;
   }
 
-  public String getControllerInstanceTag() {
-    return controllerInstanceTag;
+  public List<String> getControllerInstanceTagList() {
+    return controllerInstanceTagList;
   }
 
   public String getControllerClusterZkAddress() {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerClusterConfig.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerClusterConfig.java
@@ -637,7 +637,7 @@ public class VeniceControllerClusterConfig {
      */
     this.adminCheckReadMethodForKafka = props.getBoolean(ADMIN_CHECK_READ_METHOD_FOR_KAFKA, true);
     this.controllerClusterName = props.getString(CONTROLLER_CLUSTER, "venice-controllers");
-    this.controllerInstanceTagList = props.getList(CONTROLLER_INSTANCE_TAG_LIST, new ArrayList<>());
+    this.controllerInstanceTagList = props.getList(CONTROLLER_INSTANCE_TAG_LIST, Collections.emptyList());
     this.controllerClusterReplica = props.getInt(CONTROLLER_CLUSTER_REPLICA, 3);
     this.controllerClusterZkAddress = props.getString(CONTROLLER_CLUSTER_ZK_ADDRESSS, getZkAddress());
     this.parent = props.getBoolean(CONTROLLER_PARENT_MODE, false);

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerMultiClusterConfig.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerMultiClusterConfig.java
@@ -282,4 +282,8 @@ public class VeniceControllerMultiClusterConfig {
   public long getServiceDiscoveryRegistrationRetryMS() {
     return getCommonConfig().getServiceDiscoveryRegistrationRetryMS();
   }
+
+  public List<String> getControllerInstanceTagList() {
+    return getCommonConfig().getControllerInstanceTagList();
+  }
 }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -795,8 +795,7 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
     controllerClusterKeyBuilder = new PropertyKey.Builder(tempManager.getClusterName());
     helixManager = tempManager;
 
-    VeniceControllerClusterConfig controllerConfig = multiClusterConfigs.getCommonConfig();
-    List<String> instanceTagList = controllerConfig.getControllerInstanceTagList();
+    List<String> instanceTagList = multiClusterConfigs.getControllerInstanceTagList();
     for (String instanceTag: instanceTagList) {
       helixAdminClient.addInstanceTag(controllerClusterName, helixManager.getInstanceName(), instanceTag);
     }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -796,8 +796,8 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
     helixManager = tempManager;
 
     VeniceControllerClusterConfig controllerConfig = multiClusterConfigs.getCommonConfig();
-    String instanceTag = controllerConfig.getControllerInstanceTag();
-    if (!instanceTag.isEmpty()) {
+    List<String> instanceTagList = controllerConfig.getControllerInstanceTagList();
+    for (String instanceTag: instanceTagList) {
       helixAdminClient.addInstanceTag(controllerClusterName, helixManager.getInstanceName(), instanceTag);
     }
     LOGGER.info("Connected to controller cluster {} with controller {}", controllerClusterName, controllerName);

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -671,6 +671,9 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
       if (!multiClusterConfigs.getControllerConfig(clusterName).isErrorLeaderReplicaFailOverEnabled()) {
         continue;
       }
+      String instanceTag = commonConfig.getControllerInstanceTag();
+      VeniceControllerClusterConfig test = multiClusterConfigs.getControllerConfig(clusterName);
+
       HelixLiveInstanceMonitor liveInstanceMonitor = new HelixLiveInstanceMonitor(this.zkClient, clusterName);
       DisabledPartitionStats disabledPartitionStats = new DisabledPartitionStats(metricsRepository, clusterName);
       disabledPartitionStatMap.put(clusterName, disabledPartitionStats);
@@ -694,6 +697,18 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
               "Enabling disabled replicas for instances {} took {} ms",
               newInstances.stream().map(Instance::getNodeId).collect(Collectors.joining(",")),
               LatencyUtils.getElapsedTimeFromMsToMs(startTime));
+
+          for (Instance instance: newInstances) {
+            String instanceTag = commonConfig.getControllerInstanceTag();
+            if (!instanceTag.isEmpty()) {
+              helixAdminClient.addInstanceTag(clusterName, instance.getNodeId(), instanceTag);
+              LOGGER.info(
+                  "Added instance tag {} to instance {} in cluster {}",
+                  instanceTag,
+                  instance.getNodeId(),
+                  clusterName);
+            }
+          }
         }
 
         @Override

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceHelixAdmin.java
@@ -671,8 +671,6 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
       if (!multiClusterConfigs.getControllerConfig(clusterName).isErrorLeaderReplicaFailOverEnabled()) {
         continue;
       }
-      String instanceTag = commonConfig.getControllerInstanceTag();
-      VeniceControllerClusterConfig test = multiClusterConfigs.getControllerConfig(clusterName);
 
       HelixLiveInstanceMonitor liveInstanceMonitor = new HelixLiveInstanceMonitor(this.zkClient, clusterName);
       DisabledPartitionStats disabledPartitionStats = new DisabledPartitionStats(metricsRepository, clusterName);
@@ -697,18 +695,6 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
               "Enabling disabled replicas for instances {} took {} ms",
               newInstances.stream().map(Instance::getNodeId).collect(Collectors.joining(",")),
               LatencyUtils.getElapsedTimeFromMsToMs(startTime));
-
-          for (Instance instance: newInstances) {
-            String instanceTag = commonConfig.getControllerInstanceTag();
-            if (!instanceTag.isEmpty()) {
-              helixAdminClient.addInstanceTag(clusterName, instance.getNodeId(), instanceTag);
-              LOGGER.info(
-                  "Added instance tag {} to instance {} in cluster {}",
-                  instanceTag,
-                  instance.getNodeId(),
-                  clusterName);
-            }
-          }
         }
 
         @Override
@@ -808,6 +794,14 @@ public class VeniceHelixAdmin implements Admin, StoreCleaner {
     }
     controllerClusterKeyBuilder = new PropertyKey.Builder(tempManager.getClusterName());
     helixManager = tempManager;
+
+    VeniceControllerClusterConfig controllerConfig = multiClusterConfigs.getCommonConfig();
+    String instanceTag = controllerConfig.getControllerInstanceTag();
+    if (!instanceTag.isEmpty()) {
+      helixAdminClient.addInstanceTag(controllerClusterName, helixManager.getInstanceName(), instanceTag);
+    }
+    LOGGER.info("Connected to controller cluster {} with controller {}", controllerClusterName, controllerName);
+
   }
 
   public ZkClient getZkClient() {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/ZkHelixAdminClient.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/ZkHelixAdminClient.java
@@ -314,4 +314,12 @@ public class ZkHelixAdminClient implements HelixAdminClient {
   public void close() {
     helixAdmin.close();
   }
+
+  /**
+   * @see HelixAdminClient#addInstanceTag(String, String, String)()
+   */
+  @Override
+  public void addInstanceTag(String clusterName, String instanceName, String tag) {
+    helixAdmin.addInstanceTag(clusterName, instanceName, tag);
+  }
 }


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Summary, imperative, start upper case, don't end with a period
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

In order for the controller to be migrated to an ephemeral system like Kubernetes and provide isolation for cluster assignment, the controller needs to be able to dynamically set its instance tag.

This instance tag can be specified in the config by setting `controller.instance.tag.list`

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
Added new tests.

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.