### PR TITLE
[server] Race condition fix for re-subscription of real-time topic partitions.

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ConsumptionTask.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/ConsumptionTask.java
@@ -250,8 +250,8 @@ class ConsumptionTask implements Runnable {
       // Defensive coding. Should never happen except in case of a regression.
       throw new IllegalStateException(
           "It is not allowed to set multiple " + ConsumedDataReceiver.class.getSimpleName() + " instances for the same "
-              + "topic-partition of a given consumer. Previous: " + previousConsumedDataReceiver + ", New: "
-              + consumedDataReceiver);
+              + "topic-partition of a given consumer. Previous: " + previousConsumedDataReceiver.destinationIdentifier()
+              + ", New: " + consumedDataReceiver.destinationIdentifier());
     }
     synchronized (this) {
       notifyAll();

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaConsumerService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaConsumerService.java
@@ -242,15 +242,15 @@ public abstract class KafkaConsumerService extends AbstractKafkaConsumerService 
       synchronized (consumer) {
         consumer.unSubscribe(pubSubTopicPartition);
         removeTopicPartitionFromConsumptionTask(consumer, pubSubTopicPartition);
-        versionTopicToTopicPartitionToConsumer.compute(versionTopic, (k, topicPartitionToConsumerMap) -> {
-          if (topicPartitionToConsumerMap != null) {
-            topicPartitionToConsumerMap.remove(pubSubTopicPartition);
-            return topicPartitionToConsumerMap.isEmpty() ? null : topicPartitionToConsumerMap;
-          } else {
-            return null;
-          }
-        });
       }
+      versionTopicToTopicPartitionToConsumer.compute(versionTopic, (k, topicPartitionToConsumerMap) -> {
+        if (topicPartitionToConsumerMap != null) {
+          topicPartitionToConsumerMap.remove(pubSubTopicPartition);
+          return topicPartitionToConsumerMap.isEmpty() ? null : topicPartitionToConsumerMap;
+        } else {
+          return null;
+        }
+      });
     }
   }
 

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/SharedKafkaConsumer.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/SharedKafkaConsumer.java
@@ -348,4 +348,9 @@ class SharedKafkaConsumer implements PubSubConsumerAdapter {
   public List<PubSubTopicPartitionInfo> partitionsFor(PubSubTopic topic) {
     throw new UnsupportedOperationException("partitionsFor is not supported in SharedKafkaConsumer");
   }
+
+  // Test only
+  public void setNextPollTimeOutSeconds(long seconds) {
+    this.nextPollTimeOutSeconds = seconds;
+  }
 }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/KafkaConsumerServiceDelegatorTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/KafkaConsumerServiceDelegatorTest.java
@@ -1,28 +1,48 @@
 package com.linkedin.davinci.kafka.consumer;
 
+import static com.linkedin.venice.ConfigKeys.KAFKA_BOOTSTRAP_SERVERS;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
 import com.linkedin.davinci.config.VeniceServerConfig;
 import com.linkedin.davinci.ingestion.consumption.ConsumedDataReceiver;
+import com.linkedin.venice.kafka.protocol.KafkaMessageEnvelope;
+import com.linkedin.venice.meta.ReadOnlyStoreRepository;
+import com.linkedin.venice.meta.Version;
+import com.linkedin.venice.pubsub.PubSubConsumerAdapterFactory;
 import com.linkedin.venice.pubsub.PubSubTopicPartitionImpl;
 import com.linkedin.venice.pubsub.PubSubTopicRepository;
+import com.linkedin.venice.pubsub.adapter.kafka.consumer.ApacheKafkaConsumerAdapter;
+import com.linkedin.venice.pubsub.api.PubSubMessageDeserializer;
 import com.linkedin.venice.pubsub.api.PubSubTopic;
 import com.linkedin.venice.pubsub.api.PubSubTopicPartition;
+import com.linkedin.venice.serialization.avro.OptimizedKafkaValueSerializer;
+import com.linkedin.venice.utils.SystemTime;
+import com.linkedin.venice.utils.Utils;
+import com.linkedin.venice.utils.pools.LandFillObjectPool;
+import io.tehuti.metrics.MetricsRepository;
+import io.tehuti.metrics.Sensor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Properties;
 import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
+import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -457,5 +477,122 @@ public class KafkaConsumerServiceDelegatorTest {
     delegator.unSubscribe(
         partitionReplicaIngestionContext.getVersionTopic(),
         partitionReplicaIngestionContext.getPubSubTopicPartition());
+  }
+
+  @Test
+  public void testKafkaConsumerServiceResubscriptionConcurrency() throws Exception {
+    ApacheKafkaConsumerAdapter consumer1 = mock(ApacheKafkaConsumerAdapter.class);
+    when(consumer1.hasAnySubscription()).thenReturn(true);
+
+    PubSubConsumerAdapterFactory factory = mock(PubSubConsumerAdapterFactory.class);
+    when(factory.create(any(), anyBoolean(), any(), any())).thenReturn(consumer1);
+
+    Properties properties = new Properties();
+    String testKafkaUrl = "test_kafka_url";
+    properties.put(KAFKA_BOOTSTRAP_SERVERS, testKafkaUrl);
+    MetricsRepository mockMetricsRepository = mock(MetricsRepository.class);
+    final Sensor mockSensor = mock(Sensor.class);
+    doReturn(mockSensor).when(mockMetricsRepository).sensor(anyString(), any());
+    int consumerNum = 6;
+
+    PubSubMessageDeserializer pubSubDeserializer = new PubSubMessageDeserializer(
+        new OptimizedKafkaValueSerializer(),
+        new LandFillObjectPool<>(KafkaMessageEnvelope::new),
+        new LandFillObjectPool<>(KafkaMessageEnvelope::new));
+    KafkaConsumerService consumerService = new PartitionWiseKafkaConsumerService(
+        ConsumerPoolType.REGULAR_POOL,
+        factory,
+        properties,
+        1000l,
+        consumerNum,
+        mock(IngestionThrottler.class),
+        mock(KafkaClusterBasedRecordThrottler.class),
+        mockMetricsRepository,
+        "test_kafka_cluster_alias",
+        TimeUnit.MINUTES.toMillis(1),
+        mock(TopicExistenceChecker.class),
+        false,
+        pubSubDeserializer,
+        SystemTime.INSTANCE,
+        null,
+        false,
+        mock(ReadOnlyStoreRepository.class),
+        false);
+    String storeName = Utils.getUniqueString("test_consumer_service");
+
+    Function<String, Boolean> isAAWCStoreFunc = vt -> true;
+    KafkaConsumerServiceDelegator.KafkaConsumerServiceBuilder consumerServiceBuilder =
+        (ignored, poolType) -> consumerService;
+    VeniceServerConfig mockConfig = mock(VeniceServerConfig.class);
+    doReturn(false).when(mockConfig).isDedicatedConsumerPoolForAAWCLeaderEnabled();
+    doReturn(true).when(mockConfig).isResubscriptionTriggeredByVersionIngestionContextChangeEnabled();
+    doReturn(KafkaConsumerServiceDelegator.ConsumerPoolStrategyType.CURRENT_VERSION_PRIORITIZATION).when(mockConfig)
+        .getConsumerPoolStrategyType();
+    KafkaConsumerServiceDelegator delegator =
+        new KafkaConsumerServiceDelegator(mockConfig, consumerServiceBuilder, isAAWCStoreFunc);
+    PubSubTopicPartition realTimeTopicPartition =
+        new PubSubTopicPartitionImpl(TOPIC_REPOSITORY.getTopic(Version.composeRealTimeTopic(storeName)), 0);
+
+    CountDownLatch countDownLatch = new CountDownLatch(1);
+    for (int i = 0; i < consumerNum; i++) {
+      PubSubTopic topicV1ForStoreName3 = TOPIC_REPOSITORY.getTopic(Version.composeKafkaTopic(storeName, i));
+      StoreIngestionTask task = mock(StoreIngestionTask.class);
+      when(task.getVersionTopic()).thenReturn(topicV1ForStoreName3);
+      when(task.isHybridMode()).thenReturn(true);
+      PubSubTopic versionTopicV1 = task.getVersionTopic();
+
+      PartitionReplicaIngestionContext partitionReplicaIngestionContext = new PartitionReplicaIngestionContext(
+          versionTopicV1,
+          realTimeTopicPartition,
+          PartitionReplicaIngestionContext.VersionRole.CURRENT,
+          PartitionReplicaIngestionContext.WorkloadType.AA_OR_WRITE_COMPUTE);
+      ConsumedDataReceiver consumedDataReceiver = mock(ConsumedDataReceiver.class);
+      when(consumedDataReceiver.destinationIdentifier()).thenReturn(versionTopicV1);
+      Runnable infiniteSubUnSub = getResubscriptionRunnableFor(
+          delegator,
+          partitionReplicaIngestionContext,
+          consumedDataReceiver,
+          countDownLatch);
+      Thread infiniteSubUnSubThread = new Thread(infiniteSubUnSub, "infiniteResubscribe: " + topicV1ForStoreName3);
+      infiniteSubUnSubThread.start();
+    }
+
+    long currentTime = System.currentTimeMillis();
+    Boolean raceConditionFound = countDownLatch.await(30, TimeUnit.SECONDS);
+    long elapsedTime = System.currentTimeMillis() - currentTime;
+    Assert.assertFalse(
+        raceConditionFound,
+        "Found race condition in KafkaConsumerService with time passed in milliseconds: " + elapsedTime);
+  }
+
+  private Runnable getResubscriptionRunnableFor(
+      KafkaConsumerServiceDelegator consumerServiceDelegator,
+      PartitionReplicaIngestionContext partitionReplicaIngestionContext,
+      ConsumedDataReceiver consumedDataReceiver,
+      CountDownLatch countDownLatch) {
+    PubSubTopic versionTopic = partitionReplicaIngestionContext.getVersionTopic();
+    PubSubTopicPartition pubSubTopicPartition = partitionReplicaIngestionContext.getPubSubTopicPartition();
+    return () -> {
+      try {
+        while (true) {
+          consumerServiceDelegator
+              .startConsumptionIntoDataReceiver(partitionReplicaIngestionContext, 0, consumedDataReceiver);
+          // Avoid wait time here to increase the chance for race condition.
+          consumerServiceDelegator.assignConsumerFor(versionTopic, pubSubTopicPartition).setNextPollTimeOutSeconds(0);
+          int versionNum =
+              Version.parseVersionFromKafkaTopicName(partitionReplicaIngestionContext.getVersionTopic().getName());
+          // Here we did not consider batchUnsubscribe, as it is only for batch-only stores with version topic
+          // partitions.
+          if (versionNum % 2 == 0) {
+            consumerServiceDelegator.unSubscribe(versionTopic, pubSubTopicPartition);
+          } else {
+            consumerServiceDelegator.unsubscribeAll(partitionReplicaIngestionContext.getVersionTopic());
+          }
+        }
+      } catch (Exception e) {
+        e.printStackTrace();
+        countDownLatch.countDown();
+      }
+    };
   }
 }

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/KafkaConsumerServiceDelegatorTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/KafkaConsumerServiceDelegatorTest.java
@@ -481,6 +481,11 @@ public class KafkaConsumerServiceDelegatorTest {
         partitionReplicaIngestionContext.getPubSubTopicPartition());
   }
 
+  /**
+   * This test is to simulate multiple threads resubscribing to the same real-time topic partition for different store
+   * versions and verify if the lock will protect the handoff for {@link ConsumptionTask} and {@link ConsumedDataReceiver}
+   * during the re-subscription.
+   */
   @Test
   public void testKafkaConsumerServiceResubscriptionConcurrency() throws Exception {
     ApacheKafkaConsumerAdapter consumer1 = mock(ApacheKafkaConsumerAdapter.class);
@@ -507,7 +512,7 @@ public class KafkaConsumerServiceDelegatorTest {
         factory,
         properties,
         1000l,
-        versionNum + 1,
+        versionNum + 1, // Plus 1 to guarantee the consumer pool size is larger than the # of versions.
         mock(IngestionThrottler.class),
         mock(KafkaClusterBasedRecordThrottler.class),
         mockMetricsRepository,

--- a/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/KafkaConsumerServiceDelegatorTest.java
+++ b/clients/da-vinci-client/src/test/java/com/linkedin/davinci/kafka/consumer/KafkaConsumerServiceDelegatorTest.java
@@ -34,6 +34,7 @@ import io.tehuti.metrics.Sensor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -594,12 +595,14 @@ public class KafkaConsumerServiceDelegatorTest {
           consumerServiceDelegator.assignConsumerFor(versionTopic, pubSubTopicPartition).setNextPollTimeOutSeconds(0);
           int versionNum =
               Version.parseVersionFromKafkaTopicName(partitionReplicaIngestionContext.getVersionTopic().getName());
-          // Here we did not consider batchUnsubscribe, as it is only for batch-only stores with version topic
-          // partitions.
-          if (versionNum % 2 == 0) {
+          if (versionNum % 3 == 0) {
             consumerServiceDelegator.unSubscribe(versionTopic, pubSubTopicPartition);
-          } else {
+          } else if (versionNum % 3 == 1) {
             consumerServiceDelegator.unsubscribeAll(partitionReplicaIngestionContext.getVersionTopic());
+          } else {
+            consumerServiceDelegator.batchUnsubscribe(
+                partitionReplicaIngestionContext.getVersionTopic(),
+                Collections.singleton(partitionReplicaIngestionContext.getPubSubTopicPartition()));
           }
         }
       } catch (Exception e) {


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Summary, imperative, start upper case, don't end with a period
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Recently we introduced re-subscription feature for different store versions. Leader and follower partitions from different version topics will experience re-subscription triggered by store version role change concurrently.  

Problem: 
Two `StoreIngestionTask` threads for different store versions (store version 1 and store version 2) try to do re-subscription (unsub and sub) for the same real-time topic partition concurrently. During re-subscription triggered by one store version, operation of `consumer.unSubscribe` to remove assignment of the topic partition and operation of `consumerToConsumptionTask.get(consumer).removeDataReceiver(pubSubTopicPartition)` are sequentially executed. It is possible that `StoreIngestionTask` thread for store version 2 got the same `ConsumptionTask`, but `DataReceiver` inside `ConsumptionTask` is still from store version 1). As each `ConsumptionTask` will only allow one `DataReceiver` for one particular real-time topic partition, the `DataReceiver` from store version 2 will not be able to be added to this `ConsumptionTask`.

Solution: 
Using `SharedKafkaConsumer` level lock to protect `KafkaConsumcerService` for `unSubscribe`, `SetDataReceiver`, `unSubscribeAll` to guarantee there will one real-time partition from specific store version doing `DataReceiver` related assignment change.  
## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.