### PR TITLE
[controller] Make setting instance group tags for controller cluster resources configurable

### DIFF
--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -214,6 +214,8 @@ public class ConfigKeys {
   public static final String CONTROLLER_CLUSTER_ZK_ADDRESSS = "controller.cluster.zk.address";
   // Name of the Helix cluster for controllers
   public static final String CONTROLLER_CLUSTER = "controller.cluster.name";
+  // What instance group tag to assign to a cluster resource
+  public static final String CONTROLLER_RESOURCE_INSTANCE_GROUP_TAG = "controller.resource.instance.group.tag";
   // What tags to assign to a controller instance
   public static final String CONTROLLER_INSTANCE_TAG_LIST = "controller.instance.tag.list";
 

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestHAASController.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestHAASController.java
@@ -45,7 +45,7 @@ import org.testng.annotations.Test;
 public class TestHAASController {
   private Properties enableControllerClusterHAASProperties;
   private Properties enableControllerAndStorageClusterHAASProperties;
-  private final String instanceTag = "GENERAL";
+  private final static String instanceTag = "GENERAL";
 
   @BeforeClass
   public void setUp() {

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestHAASController.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestHAASController.java
@@ -45,7 +45,6 @@ import org.testng.annotations.Test;
 public class TestHAASController {
   private Properties enableControllerClusterHAASProperties;
   private Properties enableControllerAndStorageClusterHAASProperties;
-  private final static String instanceTag = "GENERAL";
 
   @BeforeClass
   public void setUp() {

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestHAASController.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/controller/TestHAASController.java
@@ -53,9 +53,6 @@ public class TestHAASController {
     enableControllerClusterHAASProperties.put(ConfigKeys.CONTROLLER_CLUSTER_LEADER_HAAS, String.valueOf(true));
     enableControllerClusterHAASProperties
         .put(ConfigKeys.CONTROLLER_HAAS_SUPER_CLUSTER_NAME, HelixAsAServiceWrapper.HELIX_SUPER_CLUSTER_NAME);
-    enableControllerClusterHAASProperties.put(ConfigKeys.CONTROLLER_RESOURCE_INSTANCE_GROUP_TAG, instanceTag);
-    enableControllerClusterHAASProperties.put(ConfigKeys.CONTROLLER_INSTANCE_TAG_LIST, instanceTag);
-
     enableControllerAndStorageClusterHAASProperties = (Properties) enableControllerClusterHAASProperties.clone();
     enableControllerAndStorageClusterHAASProperties
         .put(ConfigKeys.VENICE_STORAGE_CLUSTER_LEADER_HAAS, String.valueOf(true));
@@ -65,10 +62,15 @@ public class TestHAASController {
   public void testClusterResourceInstanceTag() {
     try (VeniceClusterWrapper venice = ServiceFactory.getVeniceCluster(0, 0, 0, 1);
         HelixAsAServiceWrapper helixAsAServiceWrapper = startAndWaitForHAASToBeAvailable(venice.getZk().getAddress())) {
-      VeniceControllerWrapper controllerWrapper =
-          venice.addVeniceController(enableControllerAndStorageClusterHAASProperties);
-
+      String instanceTag = "GENERAL";
       String controllerClusterName = "venice-controllers";
+
+      Properties clusterProperties = (Properties) enableControllerAndStorageClusterHAASProperties.clone();
+      clusterProperties.put(ConfigKeys.CONTROLLER_RESOURCE_INSTANCE_GROUP_TAG, instanceTag);
+      clusterProperties.put(ConfigKeys.CONTROLLER_INSTANCE_TAG_LIST, instanceTag);
+
+      VeniceControllerWrapper controllerWrapper = venice.addVeniceController(clusterProperties);
+
       HelixAdmin helixAdmin = controllerWrapper.getVeniceHelixAdmin().getHelixAdmin();
       List<String> resources = helixAdmin.getResourcesInClusterWithTag(controllerClusterName, instanceTag);
       assertEquals(resources.size(), 1);

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerClusterConfig.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerClusterConfig.java
@@ -59,6 +59,7 @@ import static com.linkedin.venice.ConfigKeys.CONTROLLER_PARENT_SYSTEM_STORE_HEAR
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_PARENT_SYSTEM_STORE_REPAIR_CHECK_INTERVAL_SECONDS;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_PARENT_SYSTEM_STORE_REPAIR_RETRY_COUNT;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_PARENT_SYSTEM_STORE_REPAIR_SERVICE_ENABLED;
+import static com.linkedin.venice.ConfigKeys.CONTROLLER_RESOURCE_INSTANCE_GROUP_TAG;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_SCHEMA_VALIDATION_ENABLED;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_SSL_ENABLED;
 import static com.linkedin.venice.ConfigKeys.CONTROLLER_STORE_GRAVEYARD_CLEANUP_DELAY_MINUTES;
@@ -224,6 +225,7 @@ public class VeniceControllerClusterConfig {
   // Name of the Helix cluster for controllers
   private final String controllerClusterName;
   private final String controllerClusterZkAddress;
+  private final String controllerResourceInstanceGroupTag;
   private final List<String> controllerInstanceTagList;
   private final boolean multiRegion;
   private final boolean parent;
@@ -637,6 +639,7 @@ public class VeniceControllerClusterConfig {
      */
     this.adminCheckReadMethodForKafka = props.getBoolean(ADMIN_CHECK_READ_METHOD_FOR_KAFKA, true);
     this.controllerClusterName = props.getString(CONTROLLER_CLUSTER, "venice-controllers");
+    this.controllerResourceInstanceGroupTag = props.getString(CONTROLLER_RESOURCE_INSTANCE_GROUP_TAG, "");
     this.controllerInstanceTagList = props.getList(CONTROLLER_INSTANCE_TAG_LIST, Collections.emptyList());
     this.controllerClusterReplica = props.getInt(CONTROLLER_CLUSTER_REPLICA, 3);
     this.controllerClusterZkAddress = props.getString(CONTROLLER_CLUSTER_ZK_ADDRESSS, getZkAddress());
@@ -1162,6 +1165,10 @@ public class VeniceControllerClusterConfig {
 
   public String getControllerClusterName() {
     return controllerClusterName;
+  }
+
+  public String getControllerResourceInstanceGroupTag() {
+    return controllerResourceInstanceGroupTag;
   }
 
   public List<String> getControllerInstanceTagList() {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerMultiClusterConfig.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerMultiClusterConfig.java
@@ -283,6 +283,10 @@ public class VeniceControllerMultiClusterConfig {
     return getCommonConfig().getServiceDiscoveryRegistrationRetryMS();
   }
 
+  public String getControllerResourceInstanceGroupTag() {
+    return getCommonConfig().getControllerResourceInstanceGroupTag();
+  }
+
   public List<String> getControllerInstanceTagList() {
     return getCommonConfig().getControllerInstanceTagList();
   }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerMultiClusterConfig.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerMultiClusterConfig.java
@@ -283,10 +283,6 @@ public class VeniceControllerMultiClusterConfig {
     return getCommonConfig().getServiceDiscoveryRegistrationRetryMS();
   }
 
-  public String getControllerResourceInstanceGroupTag() {
-    return getCommonConfig().getControllerResourceInstanceGroupTag();
-  }
-
   public List<String> getControllerInstanceTagList() {
     return getCommonConfig().getControllerInstanceTagList();
   }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/ZkHelixAdminClient.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/ZkHelixAdminClient.java
@@ -164,12 +164,13 @@ public class ZkHelixAdminClient implements HelixAdminClient {
           LeaderStandbySMD.name,
           IdealState.RebalanceMode.FULL_AUTO.toString(),
           AutoRebalanceStrategy.class.getName());
+      VeniceControllerClusterConfig config = multiClusterConfigs.getControllerConfig(clusterName);
       IdealState idealState = helixAdmin.getResourceIdealState(controllerClusterName, clusterName);
       idealState.setMinActiveReplicas(controllerClusterReplicaCount);
       idealState.setRebalancerClassName(DelayedAutoRebalancer.class.getName());
       idealState.setRebalanceStrategy(CrushRebalanceStrategy.class.getName());
 
-      String instanceGroupTag = multiClusterConfigs.getControllerResourceInstanceGroupTag();
+      String instanceGroupTag = config.getControllerResourceInstanceGroupTag();
       if (!instanceGroupTag.isEmpty()) {
         idealState.setInstanceGroupTag(instanceGroupTag);
       }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/ZkHelixAdminClient.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/ZkHelixAdminClient.java
@@ -168,6 +168,12 @@ public class ZkHelixAdminClient implements HelixAdminClient {
       idealState.setMinActiveReplicas(controllerClusterReplicaCount);
       idealState.setRebalancerClassName(DelayedAutoRebalancer.class.getName());
       idealState.setRebalanceStrategy(CrushRebalanceStrategy.class.getName());
+
+      String instanceGroupTag = multiClusterConfigs.getControllerResourceInstanceGroupTag();
+      if (!instanceGroupTag.isEmpty()) {
+        idealState.setInstanceGroupTag(instanceGroupTag);
+      }
+
       helixAdmin.setResourceIdealState(controllerClusterName, clusterName, idealState);
       helixAdmin.rebalance(controllerClusterName, clusterName, controllerClusterReplicaCount);
     } catch (Exception e) {

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestZkHelixAdminClient.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestZkHelixAdminClient.java
@@ -34,6 +34,6 @@ public class TestZkHelixAdminClient {
     String clusterName = "test-cluster";
     zkHelixAdminClient.addVeniceStorageClusterToControllerCluster(clusterName);
 
-    verify(mockIdealState, times(1)).setInstanceGroupTag("GENERAL");
+    verify(mockIdealState).setInstanceGroupTag("GENERAL");
   }
 }

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestZkHelixAdminClient.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/TestZkHelixAdminClient.java
@@ -1,0 +1,39 @@
+package com.linkedin.venice.controller;
+
+import static org.mockito.Mockito.*;
+
+import java.lang.reflect.Field;
+import org.apache.helix.HelixAdmin;
+import org.apache.helix.model.IdealState;
+import org.testng.annotations.Test;
+
+
+public class TestZkHelixAdminClient {
+  @Test
+  public void testInstanceGroupTag() throws NoSuchFieldException, IllegalAccessException {
+    ZkHelixAdminClient zkHelixAdminClient = mock(ZkHelixAdminClient.class);
+    HelixAdmin mockHelixAdmin = mock(HelixAdmin.class);
+    VeniceControllerMultiClusterConfig mockMultiClusterConfigs = mock(VeniceControllerMultiClusterConfig.class);
+    VeniceControllerClusterConfig mockClusterConfig = mock(VeniceControllerClusterConfig.class);
+    IdealState mockIdealState = mock(IdealState.class);
+
+    when(mockClusterConfig.getControllerResourceInstanceGroupTag()).thenReturn("GENERAL");
+    when(mockMultiClusterConfigs.getControllerConfig(anyString())).thenReturn(mockClusterConfig);
+    when(mockHelixAdmin.getResourceIdealState(any(), any())).thenReturn(mockIdealState);
+
+    doCallRealMethod().when(zkHelixAdminClient).addVeniceStorageClusterToControllerCluster(anyString());
+
+    Field multiClusterConfigsField = ZkHelixAdminClient.class.getDeclaredField("multiClusterConfigs");
+    multiClusterConfigsField.setAccessible(true);
+    multiClusterConfigsField.set(zkHelixAdminClient, mockMultiClusterConfigs);
+
+    Field helixAdminField = ZkHelixAdminClient.class.getDeclaredField("helixAdmin");
+    helixAdminField.setAccessible(true);
+    helixAdminField.set(zkHelixAdminClient, mockHelixAdmin);
+
+    String clusterName = "test-cluster";
+    zkHelixAdminClient.addVeniceStorageClusterToControllerCluster(clusterName);
+
+    verify(mockIdealState, times(1)).setInstanceGroupTag("GENERAL");
+  }
+}


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Summary, imperative, start upper case, don't end with a period
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Make setting instance group tags for controller cluster resources configurable. This is needed to provide cluster resource level isolation.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
Added new tests

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [X] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.