### PR TITLE
[controller] Manual store deletion only can be done by specific user group. 

### DIFF
--- a/internal/venice-common/src/main/java/com/linkedin/venice/acl/AccessController.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/acl/AccessController.java
@@ -49,6 +49,16 @@ public interface AccessController {
   boolean isAllowlistUsers(X509Certificate clientCert, String resource, String method);
 
   /**
+   * Check whether the client is the allowlist admin users for store deletion.
+   *
+   * @param clientCert the X509Certificate submitted by client
+   * @param resource the resource being requested;
+   * @param method the operation (GET, POST, ...) to perform against the resource
+   * @return true if the client is admin
+   */
+  boolean isAllowlistUsersForStoreDeletion(X509Certificate clientCert, String resource, String method);
+
+  /**
    * Get principal Id from client certificate.
    * @param clientCert the X509Certificate submitted by client
    * @return principal Id. (headless account name, service name, LDAP id or group id)

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/AbstractRoute.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/AbstractRoute.java
@@ -151,6 +151,23 @@ public class AbstractRoute {
   }
 
   /**
+   * Check whether the user is within the admin users allowlist.
+   */
+  protected boolean isAllowListUserForStoreDeletion(Request request) {
+    if (!isAclEnabled()) {
+      /**
+       * Grant access if it's not required to check ACL.
+       * {@link accessController} will be empty if ACL is not enabled.
+       */
+      return true;
+    }
+    X509Certificate certificate = getCertificate(request);
+
+    String storeName = request.queryParamOrDefault(NAME, STORE_UNKNOWN);
+    return accessController.get().isAllowlistUsersForStoreDeletion(certificate, storeName, HTTP_GET);
+  }
+
+  /**
    * @return whether SSL is enabled
    */
   protected boolean isSslEnabled() {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/AbstractRoute.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/AbstractRoute.java
@@ -151,7 +151,7 @@ public class AbstractRoute {
   }
 
   /**
-   * Check whether the user is within the admin users allowlist.
+   * Check whether the user is within the admin users allowlist for store deletion.
    */
   protected boolean isAllowListUserForStoreDeletion(Request request) {
     if (!isAclEnabled()) {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/StoresRoutes.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/StoresRoutes.java
@@ -506,7 +506,7 @@ public class StoresRoutes extends AbstractRoute {
     return new VeniceRouteHandler<TrackableControllerResponse>(TrackableControllerResponse.class) {
       @Override
       public void internalHandle(Request request, TrackableControllerResponse veniceResponse) {
-        // Limit to admin tool usage.
+        // This is to limit the manual store deletion from admin tool without https to a specific allow list users.
         if (!isSslEnabled()
             && !checkIsAllowListUser(request, veniceResponse, () -> isAllowListUserForStoreDeletion(request))) {
           return;

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/StoresRoutes.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/StoresRoutes.java
@@ -506,6 +506,12 @@ public class StoresRoutes extends AbstractRoute {
     return new VeniceRouteHandler<TrackableControllerResponse>(TrackableControllerResponse.class) {
       @Override
       public void internalHandle(Request request, TrackableControllerResponse veniceResponse) {
+        // Limit to admin tool usage.
+        if (!isSslEnabled()
+            && !checkIsAllowListUser(request, veniceResponse, () -> isAllowListUserForStoreDeletion(request))) {
+          return;
+        }
+
         // Only allow allowlist users to run this command
         if (!checkIsAllowListUser(request, veniceResponse, () -> isAllowListUser(request))) {
           return;

--- a/services/venice-router/src/test/java/com/linkedin/venice/router/acl/RouterStoreAclHandlerTest.java
+++ b/services/venice-router/src/test/java/com/linkedin/venice/router/acl/RouterStoreAclHandlerTest.java
@@ -246,6 +246,11 @@ public class RouterStoreAclHandlerTest {
     }
 
     @Override
+    public boolean isAllowlistUsersForStoreDeletion(X509Certificate clientCert, String resource, String method) {
+      return isAllowlistUsers(clientCert, resource, method);
+    }
+
+    @Override
     public String getPrincipalId(X509Certificate clientCert) {
       assertNotNull(clientCert, resourceType.toString());
       return "testPrincipalId";

--- a/services/venice-server/src/test/java/com/linkedin/venice/listener/ServerStoreAclHandlerTest.java
+++ b/services/venice-server/src/test/java/com/linkedin/venice/listener/ServerStoreAclHandlerTest.java
@@ -93,6 +93,11 @@ public class ServerStoreAclHandlerTest {
     }
 
     @Override
+    public boolean isAllowlistUsersForStoreDeletion(X509Certificate clientCert, String resource, String method) {
+      return this.isAllowlistUsers(clientCert, resource, method);
+    }
+
+    @Override
     public String getPrincipalId(X509Certificate clientCert) {
       assertNotNull(clientCert, queryAction.toString());
       return "testPrincipalId";


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Summary, imperative, start upper case, don't end with a period
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

This Code change adds a feature allowing manual store deletion from admin tool to a specific user group only. The newly added interface of `isAllowlistUsersForStoreDeletion` for `AccessController` will be used to check if user belong to that specific user group.  

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [*] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.