### PR TITLE
[test] Added router metadata refresh in DVC tests

### DIFF
--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/DaVinciClientDiskFullTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/DaVinciClientDiskFullTest.java
@@ -219,7 +219,7 @@ public class DaVinciClientDiskFullTest {
 
       // Do a VPJ push
       runVPJ(vpjProperties, 1, controllerClient);
-
+      venice.refreshAllRouterMetaData();
       // Verify some records (note, record 1 have been pushed)
       TestUtils.waitForNonDeterministicAssertion(10, TimeUnit.SECONDS, true, () -> {
         try {

--- a/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/DaVinciClientMemoryLimitTest.java
+++ b/internal/venice-test-common/src/integrationTest/java/com/linkedin/venice/endToEnd/DaVinciClientMemoryLimitTest.java
@@ -167,6 +167,7 @@ public class DaVinciClientMemoryLimitTest {
 
       // Do an VPJ push
       runVPJ(vpjProperties, 1, controllerClient);
+      venice.refreshAllRouterMetaData();
 
       // Verify some records (note, records 1-100 have been pushed)
       TestUtils.waitForNonDeterministicAssertion(10, TimeUnit.SECONDS, true, () -> {


### PR DESCRIPTION
<!--
Add a list of affected components in the PR title in the following format:
[component1]...[componentN] Concise commit message

Valid component tags are: [da-vinci] (or [dvc]), [server], [controller], [router], [samza],
[vpj], [fast-client] (or [fc]), [thin-client] (or [tc]), [changelog] (or [cc]),
[pulsar-sink], [producer], [admin-tool], [test], [build], [doc], [script], [compat]

Example title: [server][da-vinci] Use dedicated thread to persist data to storage engine

Note: PRs with titles not following the format will not be merged
-->

## Added router metadata refresh in DVC memory limiter tests
<!--
Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal.
- Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
 
Reduce flakiness in those tests.

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to explain your proposed changes and call out the behavior change.